### PR TITLE
UpsertDynamicWindowsDesktops RPC

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -3079,6 +3079,10 @@ func (c *Client) GetDynamicWindowsDesktop(ctx context.Context, name string) (typ
 	return c.DynamicDesktopClient().GetDynamicWindowsDesktop(ctx, name)
 }
 
+func (c *Client) UpsertDynamicWindowsDesktops(ctx context.Context, desktops []types.DynamicWindowsDesktop) ([]dynamicwindows.UpsertDynamicWindowsDesktopResult, error) {
+	return c.DynamicDesktopClient().UpsertDynamicWindowsDesktops(ctx, desktops)
+}
+
 // LinuxDesktopClient returns a LinuxDesktop client.
 // Clients connecting to older Teleport versions, still get a LinuxDesktop client
 // when calling this method, but all RPCs will return "unknown service" errors

--- a/api/client/dynamicwindows/dynamicwindows.go
+++ b/api/client/dynamicwindows/dynamicwindows.go
@@ -93,6 +93,52 @@ func (c *Client) UpsertDynamicWindowsDesktop(ctx context.Context, desktop types.
 	}
 }
 
+// UpsertDynamicWindowsDesktopResult is the outcome of upserting a single dynamic
+// Windows desktop as part of a bulk UpsertDynamicWindowsDesktops call.
+type UpsertDynamicWindowsDesktopResult struct {
+	// Name identifies which desktop this result refers to.
+	Name string
+	// Err is the error encountered while upserting the desktop, or nil on success.
+	Err error
+}
+
+// UpsertDynamicWindowsDesktops upserts multiple dynamic Windows desktops in a
+// single request. The returned slice contains one result per desktop, which
+// contains the desktop name and an error that is nil if successfully upserted.
+//
+// At most 1000 desktops may be upserted per request. Exceeding the limit fails
+// the whole request with a BadParameter error.
+func (c *Client) UpsertDynamicWindowsDesktops(ctx context.Context, desktops []types.DynamicWindowsDesktop) ([]UpsertDynamicWindowsDesktopResult, error) {
+	req := make([]*types.DynamicWindowsDesktopV1, 0, len(desktops))
+	for _, desktop := range desktops {
+		d, ok := desktop.(*types.DynamicWindowsDesktopV1)
+		if !ok {
+			return nil, trace.BadParameter("unknown desktop type: %T", desktop)
+		}
+		req = append(req, d)
+	}
+
+	resp, err := c.grpcClient.UpsertDynamicWindowsDesktops(ctx, &dynamicwindows.UpsertDynamicWindowsDesktopsRequest{
+		Desktops: req,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	results := make([]UpsertDynamicWindowsDesktopResult, 0, len(resp.GetResults()))
+	for _, result := range resp.GetResults() {
+		var resultErr error
+		if result.GetError() != "" {
+			resultErr = trace.Errorf("%s", result.GetError())
+		}
+		results = append(results, UpsertDynamicWindowsDesktopResult{
+			Name: result.GetName(),
+			Err:  resultErr,
+		})
+	}
+	return results, nil
+}
+
 func (c *Client) DeleteDynamicWindowsDesktop(ctx context.Context, name string) error {
 	_, err := c.grpcClient.DeleteDynamicWindowsDesktop(ctx, &dynamicwindows.DeleteDynamicWindowsDesktopRequest{
 		Name: name,

--- a/api/gen/proto/go/teleport/dynamicwindows/v1/dynamicwindows_service.pb.go
+++ b/api/gen/proto/go/teleport/dynamicwindows/v1/dynamicwindows_service.pb.go
@@ -467,6 +467,202 @@ func (b0 UpsertDynamicWindowsDesktopRequest_builder) Build() *UpsertDynamicWindo
 	return m0
 }
 
+// UpsertDynamicWindowsDesktopsRequest is used for upserting multiple dynamic Windows desktops.
+type UpsertDynamicWindowsDesktopsRequest struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// desktops to be upserted
+	Desktops      []*types.DynamicWindowsDesktopV1 `protobuf:"bytes,1,rep,name=desktops,proto3" json:"desktops,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpsertDynamicWindowsDesktopsRequest) Reset() {
+	*x = UpsertDynamicWindowsDesktopsRequest{}
+	mi := &file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpsertDynamicWindowsDesktopsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpsertDynamicWindowsDesktopsRequest) ProtoMessage() {}
+
+func (x *UpsertDynamicWindowsDesktopsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *UpsertDynamicWindowsDesktopsRequest) GetDesktops() []*types.DynamicWindowsDesktopV1 {
+	if x != nil {
+		return x.Desktops
+	}
+	return nil
+}
+
+func (x *UpsertDynamicWindowsDesktopsRequest) SetDesktops(v []*types.DynamicWindowsDesktopV1) {
+	x.Desktops = v
+}
+
+type UpsertDynamicWindowsDesktopsRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// desktops to be upserted
+	Desktops []*types.DynamicWindowsDesktopV1
+}
+
+func (b0 UpsertDynamicWindowsDesktopsRequest_builder) Build() *UpsertDynamicWindowsDesktopsRequest {
+	m0 := &UpsertDynamicWindowsDesktopsRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Desktops = b.Desktops
+	return m0
+}
+
+// UpsertDynamicWindowsDesktopsResponse is the response for upserting multiple dynamic Windows desktops.
+type UpsertDynamicWindowsDesktopsResponse struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// results of upserted desktops
+	Results       []*UpsertDynamicWindowsDesktopResult `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpsertDynamicWindowsDesktopsResponse) Reset() {
+	*x = UpsertDynamicWindowsDesktopsResponse{}
+	mi := &file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpsertDynamicWindowsDesktopsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpsertDynamicWindowsDesktopsResponse) ProtoMessage() {}
+
+func (x *UpsertDynamicWindowsDesktopsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *UpsertDynamicWindowsDesktopsResponse) GetResults() []*UpsertDynamicWindowsDesktopResult {
+	if x != nil {
+		return x.Results
+	}
+	return nil
+}
+
+func (x *UpsertDynamicWindowsDesktopsResponse) SetResults(v []*UpsertDynamicWindowsDesktopResult) {
+	x.Results = v
+}
+
+type UpsertDynamicWindowsDesktopsResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// results of upserted desktops
+	Results []*UpsertDynamicWindowsDesktopResult
+}
+
+func (b0 UpsertDynamicWindowsDesktopsResponse_builder) Build() *UpsertDynamicWindowsDesktopsResponse {
+	m0 := &UpsertDynamicWindowsDesktopsResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Results = b.Results
+	return m0
+}
+
+// UpsertDynamicWindowsDesktopResult is the result of upserting a dynamic Windows desktop.
+type UpsertDynamicWindowsDesktopResult struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// name is the name of the dynamic Windows desktop.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// error is the failure message, empty if the upsert was successful.
+	Error         string `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpsertDynamicWindowsDesktopResult) Reset() {
+	*x = UpsertDynamicWindowsDesktopResult{}
+	mi := &file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpsertDynamicWindowsDesktopResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpsertDynamicWindowsDesktopResult) ProtoMessage() {}
+
+func (x *UpsertDynamicWindowsDesktopResult) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *UpsertDynamicWindowsDesktopResult) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *UpsertDynamicWindowsDesktopResult) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+func (x *UpsertDynamicWindowsDesktopResult) SetName(v string) {
+	x.Name = v
+}
+
+func (x *UpsertDynamicWindowsDesktopResult) SetError(v string) {
+	x.Error = v
+}
+
+type UpsertDynamicWindowsDesktopResult_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// name is the name of the dynamic Windows desktop.
+	Name string
+	// error is the failure message, empty if the upsert was successful.
+	Error string
+}
+
+func (b0 UpsertDynamicWindowsDesktopResult_builder) Build() *UpsertDynamicWindowsDesktopResult {
+	m0 := &UpsertDynamicWindowsDesktopResult{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Name = b.Name
+	x.Error = b.Error
+	return m0
+}
+
 // DeleteDynamicWindowsDesktopRequest is a request to delete a Windows desktop host.
 type DeleteDynamicWindowsDesktopRequest struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
@@ -478,7 +674,7 @@ type DeleteDynamicWindowsDesktopRequest struct {
 
 func (x *DeleteDynamicWindowsDesktopRequest) Reset() {
 	*x = DeleteDynamicWindowsDesktopRequest{}
-	mi := &file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes[6]
+	mi := &file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -490,7 +686,7 @@ func (x *DeleteDynamicWindowsDesktopRequest) String() string {
 func (*DeleteDynamicWindowsDesktopRequest) ProtoMessage() {}
 
 func (x *DeleteDynamicWindowsDesktopRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes[6]
+	mi := &file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -546,51 +742,66 @@ const file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_rawDesc = "" 
 	"\"UpdateDynamicWindowsDesktopRequest\x128\n" +
 	"\adesktop\x18\x01 \x01(\v2\x1e.types.DynamicWindowsDesktopV1R\adesktop\"^\n" +
 	"\"UpsertDynamicWindowsDesktopRequest\x128\n" +
-	"\adesktop\x18\x01 \x01(\v2\x1e.types.DynamicWindowsDesktopV1R\adesktop\"8\n" +
+	"\adesktop\x18\x01 \x01(\v2\x1e.types.DynamicWindowsDesktopV1R\adesktop\"a\n" +
+	"#UpsertDynamicWindowsDesktopsRequest\x12:\n" +
+	"\bdesktops\x18\x01 \x03(\v2\x1e.types.DynamicWindowsDesktopV1R\bdesktops\"\x7f\n" +
+	"$UpsertDynamicWindowsDesktopsResponse\x12W\n" +
+	"\aresults\x18\x01 \x03(\v2=.teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopResultR\aresults\"M\n" +
+	"!UpsertDynamicWindowsDesktopResult\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\"8\n" +
 	"\"DeleteDynamicWindowsDesktopRequest\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name2\xa2\x06\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name2\xc6\a\n" +
 	"\x15DynamicWindowsService\x12\x9b\x01\n" +
 	"\x1aListDynamicWindowsDesktops\x12=.teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsRequest\x1a>.teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsResponse\x12w\n" +
 	"\x18GetDynamicWindowsDesktop\x12;.teleport.dynamicwindows.v1.GetDynamicWindowsDesktopRequest\x1a\x1e.types.DynamicWindowsDesktopV1\x12}\n" +
 	"\x1bCreateDynamicWindowsDesktop\x12>.teleport.dynamicwindows.v1.CreateDynamicWindowsDesktopRequest\x1a\x1e.types.DynamicWindowsDesktopV1\x12}\n" +
 	"\x1bUpdateDynamicWindowsDesktop\x12>.teleport.dynamicwindows.v1.UpdateDynamicWindowsDesktopRequest\x1a\x1e.types.DynamicWindowsDesktopV1\x12}\n" +
-	"\x1bUpsertDynamicWindowsDesktop\x12>.teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopRequest\x1a\x1e.types.DynamicWindowsDesktopV1\x12u\n" +
+	"\x1bUpsertDynamicWindowsDesktop\x12>.teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopRequest\x1a\x1e.types.DynamicWindowsDesktopV1\x12\xa1\x01\n" +
+	"\x1cUpsertDynamicWindowsDesktops\x12?.teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopsRequest\x1a@.teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopsResponse\x12u\n" +
 	"\x1bDeleteDynamicWindowsDesktop\x12>.teleport.dynamicwindows.v1.DeleteDynamicWindowsDesktopRequest\x1a\x16.google.protobuf.EmptyB`Z^github.com/gravitational/teleport/api/gen/proto/go/teleport/dynamicwindows/v1;dynamicwindowsv1b\x06proto3"
 
-var file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_goTypes = []any{
-	(*ListDynamicWindowsDesktopsRequest)(nil),  // 0: teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsRequest
-	(*ListDynamicWindowsDesktopsResponse)(nil), // 1: teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsResponse
-	(*GetDynamicWindowsDesktopRequest)(nil),    // 2: teleport.dynamicwindows.v1.GetDynamicWindowsDesktopRequest
-	(*CreateDynamicWindowsDesktopRequest)(nil), // 3: teleport.dynamicwindows.v1.CreateDynamicWindowsDesktopRequest
-	(*UpdateDynamicWindowsDesktopRequest)(nil), // 4: teleport.dynamicwindows.v1.UpdateDynamicWindowsDesktopRequest
-	(*UpsertDynamicWindowsDesktopRequest)(nil), // 5: teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopRequest
-	(*DeleteDynamicWindowsDesktopRequest)(nil), // 6: teleport.dynamicwindows.v1.DeleteDynamicWindowsDesktopRequest
-	(*types.DynamicWindowsDesktopV1)(nil),      // 7: types.DynamicWindowsDesktopV1
-	(*emptypb.Empty)(nil),                      // 8: google.protobuf.Empty
+	(*ListDynamicWindowsDesktopsRequest)(nil),    // 0: teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsRequest
+	(*ListDynamicWindowsDesktopsResponse)(nil),   // 1: teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsResponse
+	(*GetDynamicWindowsDesktopRequest)(nil),      // 2: teleport.dynamicwindows.v1.GetDynamicWindowsDesktopRequest
+	(*CreateDynamicWindowsDesktopRequest)(nil),   // 3: teleport.dynamicwindows.v1.CreateDynamicWindowsDesktopRequest
+	(*UpdateDynamicWindowsDesktopRequest)(nil),   // 4: teleport.dynamicwindows.v1.UpdateDynamicWindowsDesktopRequest
+	(*UpsertDynamicWindowsDesktopRequest)(nil),   // 5: teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopRequest
+	(*UpsertDynamicWindowsDesktopsRequest)(nil),  // 6: teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopsRequest
+	(*UpsertDynamicWindowsDesktopsResponse)(nil), // 7: teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopsResponse
+	(*UpsertDynamicWindowsDesktopResult)(nil),    // 8: teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopResult
+	(*DeleteDynamicWindowsDesktopRequest)(nil),   // 9: teleport.dynamicwindows.v1.DeleteDynamicWindowsDesktopRequest
+	(*types.DynamicWindowsDesktopV1)(nil),        // 10: types.DynamicWindowsDesktopV1
+	(*emptypb.Empty)(nil),                        // 11: google.protobuf.Empty
 }
 var file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_depIdxs = []int32{
-	7,  // 0: teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsResponse.desktops:type_name -> types.DynamicWindowsDesktopV1
-	7,  // 1: teleport.dynamicwindows.v1.CreateDynamicWindowsDesktopRequest.desktop:type_name -> types.DynamicWindowsDesktopV1
-	7,  // 2: teleport.dynamicwindows.v1.UpdateDynamicWindowsDesktopRequest.desktop:type_name -> types.DynamicWindowsDesktopV1
-	7,  // 3: teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopRequest.desktop:type_name -> types.DynamicWindowsDesktopV1
-	0,  // 4: teleport.dynamicwindows.v1.DynamicWindowsService.ListDynamicWindowsDesktops:input_type -> teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsRequest
-	2,  // 5: teleport.dynamicwindows.v1.DynamicWindowsService.GetDynamicWindowsDesktop:input_type -> teleport.dynamicwindows.v1.GetDynamicWindowsDesktopRequest
-	3,  // 6: teleport.dynamicwindows.v1.DynamicWindowsService.CreateDynamicWindowsDesktop:input_type -> teleport.dynamicwindows.v1.CreateDynamicWindowsDesktopRequest
-	4,  // 7: teleport.dynamicwindows.v1.DynamicWindowsService.UpdateDynamicWindowsDesktop:input_type -> teleport.dynamicwindows.v1.UpdateDynamicWindowsDesktopRequest
-	5,  // 8: teleport.dynamicwindows.v1.DynamicWindowsService.UpsertDynamicWindowsDesktop:input_type -> teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopRequest
-	6,  // 9: teleport.dynamicwindows.v1.DynamicWindowsService.DeleteDynamicWindowsDesktop:input_type -> teleport.dynamicwindows.v1.DeleteDynamicWindowsDesktopRequest
-	1,  // 10: teleport.dynamicwindows.v1.DynamicWindowsService.ListDynamicWindowsDesktops:output_type -> teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsResponse
-	7,  // 11: teleport.dynamicwindows.v1.DynamicWindowsService.GetDynamicWindowsDesktop:output_type -> types.DynamicWindowsDesktopV1
-	7,  // 12: teleport.dynamicwindows.v1.DynamicWindowsService.CreateDynamicWindowsDesktop:output_type -> types.DynamicWindowsDesktopV1
-	7,  // 13: teleport.dynamicwindows.v1.DynamicWindowsService.UpdateDynamicWindowsDesktop:output_type -> types.DynamicWindowsDesktopV1
-	7,  // 14: teleport.dynamicwindows.v1.DynamicWindowsService.UpsertDynamicWindowsDesktop:output_type -> types.DynamicWindowsDesktopV1
-	8,  // 15: teleport.dynamicwindows.v1.DynamicWindowsService.DeleteDynamicWindowsDesktop:output_type -> google.protobuf.Empty
-	10, // [10:16] is the sub-list for method output_type
-	4,  // [4:10] is the sub-list for method input_type
-	4,  // [4:4] is the sub-list for extension type_name
-	4,  // [4:4] is the sub-list for extension extendee
-	0,  // [0:4] is the sub-list for field type_name
+	10, // 0: teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsResponse.desktops:type_name -> types.DynamicWindowsDesktopV1
+	10, // 1: teleport.dynamicwindows.v1.CreateDynamicWindowsDesktopRequest.desktop:type_name -> types.DynamicWindowsDesktopV1
+	10, // 2: teleport.dynamicwindows.v1.UpdateDynamicWindowsDesktopRequest.desktop:type_name -> types.DynamicWindowsDesktopV1
+	10, // 3: teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopRequest.desktop:type_name -> types.DynamicWindowsDesktopV1
+	10, // 4: teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopsRequest.desktops:type_name -> types.DynamicWindowsDesktopV1
+	8,  // 5: teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopsResponse.results:type_name -> teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopResult
+	0,  // 6: teleport.dynamicwindows.v1.DynamicWindowsService.ListDynamicWindowsDesktops:input_type -> teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsRequest
+	2,  // 7: teleport.dynamicwindows.v1.DynamicWindowsService.GetDynamicWindowsDesktop:input_type -> teleport.dynamicwindows.v1.GetDynamicWindowsDesktopRequest
+	3,  // 8: teleport.dynamicwindows.v1.DynamicWindowsService.CreateDynamicWindowsDesktop:input_type -> teleport.dynamicwindows.v1.CreateDynamicWindowsDesktopRequest
+	4,  // 9: teleport.dynamicwindows.v1.DynamicWindowsService.UpdateDynamicWindowsDesktop:input_type -> teleport.dynamicwindows.v1.UpdateDynamicWindowsDesktopRequest
+	5,  // 10: teleport.dynamicwindows.v1.DynamicWindowsService.UpsertDynamicWindowsDesktop:input_type -> teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopRequest
+	6,  // 11: teleport.dynamicwindows.v1.DynamicWindowsService.UpsertDynamicWindowsDesktops:input_type -> teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopsRequest
+	9,  // 12: teleport.dynamicwindows.v1.DynamicWindowsService.DeleteDynamicWindowsDesktop:input_type -> teleport.dynamicwindows.v1.DeleteDynamicWindowsDesktopRequest
+	1,  // 13: teleport.dynamicwindows.v1.DynamicWindowsService.ListDynamicWindowsDesktops:output_type -> teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsResponse
+	10, // 14: teleport.dynamicwindows.v1.DynamicWindowsService.GetDynamicWindowsDesktop:output_type -> types.DynamicWindowsDesktopV1
+	10, // 15: teleport.dynamicwindows.v1.DynamicWindowsService.CreateDynamicWindowsDesktop:output_type -> types.DynamicWindowsDesktopV1
+	10, // 16: teleport.dynamicwindows.v1.DynamicWindowsService.UpdateDynamicWindowsDesktop:output_type -> types.DynamicWindowsDesktopV1
+	10, // 17: teleport.dynamicwindows.v1.DynamicWindowsService.UpsertDynamicWindowsDesktop:output_type -> types.DynamicWindowsDesktopV1
+	7,  // 18: teleport.dynamicwindows.v1.DynamicWindowsService.UpsertDynamicWindowsDesktops:output_type -> teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopsResponse
+	11, // 19: teleport.dynamicwindows.v1.DynamicWindowsService.DeleteDynamicWindowsDesktop:output_type -> google.protobuf.Empty
+	13, // [13:20] is the sub-list for method output_type
+	6,  // [6:13] is the sub-list for method input_type
+	6,  // [6:6] is the sub-list for extension type_name
+	6,  // [6:6] is the sub-list for extension extendee
+	0,  // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_init() }
@@ -604,7 +815,7 @@ func file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_rawDesc), len(file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   7,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/dynamicwindows/v1/dynamicwindows_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/dynamicwindows/v1/dynamicwindows_service_grpc.pb.go
@@ -35,12 +35,13 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	DynamicWindowsService_ListDynamicWindowsDesktops_FullMethodName  = "/teleport.dynamicwindows.v1.DynamicWindowsService/ListDynamicWindowsDesktops"
-	DynamicWindowsService_GetDynamicWindowsDesktop_FullMethodName    = "/teleport.dynamicwindows.v1.DynamicWindowsService/GetDynamicWindowsDesktop"
-	DynamicWindowsService_CreateDynamicWindowsDesktop_FullMethodName = "/teleport.dynamicwindows.v1.DynamicWindowsService/CreateDynamicWindowsDesktop"
-	DynamicWindowsService_UpdateDynamicWindowsDesktop_FullMethodName = "/teleport.dynamicwindows.v1.DynamicWindowsService/UpdateDynamicWindowsDesktop"
-	DynamicWindowsService_UpsertDynamicWindowsDesktop_FullMethodName = "/teleport.dynamicwindows.v1.DynamicWindowsService/UpsertDynamicWindowsDesktop"
-	DynamicWindowsService_DeleteDynamicWindowsDesktop_FullMethodName = "/teleport.dynamicwindows.v1.DynamicWindowsService/DeleteDynamicWindowsDesktop"
+	DynamicWindowsService_ListDynamicWindowsDesktops_FullMethodName   = "/teleport.dynamicwindows.v1.DynamicWindowsService/ListDynamicWindowsDesktops"
+	DynamicWindowsService_GetDynamicWindowsDesktop_FullMethodName     = "/teleport.dynamicwindows.v1.DynamicWindowsService/GetDynamicWindowsDesktop"
+	DynamicWindowsService_CreateDynamicWindowsDesktop_FullMethodName  = "/teleport.dynamicwindows.v1.DynamicWindowsService/CreateDynamicWindowsDesktop"
+	DynamicWindowsService_UpdateDynamicWindowsDesktop_FullMethodName  = "/teleport.dynamicwindows.v1.DynamicWindowsService/UpdateDynamicWindowsDesktop"
+	DynamicWindowsService_UpsertDynamicWindowsDesktop_FullMethodName  = "/teleport.dynamicwindows.v1.DynamicWindowsService/UpsertDynamicWindowsDesktop"
+	DynamicWindowsService_UpsertDynamicWindowsDesktops_FullMethodName = "/teleport.dynamicwindows.v1.DynamicWindowsService/UpsertDynamicWindowsDesktops"
+	DynamicWindowsService_DeleteDynamicWindowsDesktop_FullMethodName  = "/teleport.dynamicwindows.v1.DynamicWindowsService/DeleteDynamicWindowsDesktop"
 )
 
 // DynamicWindowsServiceClient is the client API for DynamicWindowsService service.
@@ -59,6 +60,8 @@ type DynamicWindowsServiceClient interface {
 	UpdateDynamicWindowsDesktop(ctx context.Context, in *UpdateDynamicWindowsDesktopRequest, opts ...grpc.CallOption) (*types.DynamicWindowsDesktopV1, error)
 	// UpsertDynamicWindowsDesktop updates an existing dynamic Windows desktop or creates new if it doesn't exist.
 	UpsertDynamicWindowsDesktop(ctx context.Context, in *UpsertDynamicWindowsDesktopRequest, opts ...grpc.CallOption) (*types.DynamicWindowsDesktopV1, error)
+	// UpsertDynamicWindowsDesktops updates existing dynamic Windows desktops or creates new ones if they don't exist.
+	UpsertDynamicWindowsDesktops(ctx context.Context, in *UpsertDynamicWindowsDesktopsRequest, opts ...grpc.CallOption) (*UpsertDynamicWindowsDesktopsResponse, error)
 	// DeleteDynamicWindowsDesktop removes the specified dynamic Windows desktop.
 	DeleteDynamicWindowsDesktop(ctx context.Context, in *DeleteDynamicWindowsDesktopRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
@@ -121,6 +124,16 @@ func (c *dynamicWindowsServiceClient) UpsertDynamicWindowsDesktop(ctx context.Co
 	return out, nil
 }
 
+func (c *dynamicWindowsServiceClient) UpsertDynamicWindowsDesktops(ctx context.Context, in *UpsertDynamicWindowsDesktopsRequest, opts ...grpc.CallOption) (*UpsertDynamicWindowsDesktopsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UpsertDynamicWindowsDesktopsResponse)
+	err := c.cc.Invoke(ctx, DynamicWindowsService_UpsertDynamicWindowsDesktops_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *dynamicWindowsServiceClient) DeleteDynamicWindowsDesktop(ctx context.Context, in *DeleteDynamicWindowsDesktopRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(emptypb.Empty)
@@ -147,6 +160,8 @@ type DynamicWindowsServiceServer interface {
 	UpdateDynamicWindowsDesktop(context.Context, *UpdateDynamicWindowsDesktopRequest) (*types.DynamicWindowsDesktopV1, error)
 	// UpsertDynamicWindowsDesktop updates an existing dynamic Windows desktop or creates new if it doesn't exist.
 	UpsertDynamicWindowsDesktop(context.Context, *UpsertDynamicWindowsDesktopRequest) (*types.DynamicWindowsDesktopV1, error)
+	// UpsertDynamicWindowsDesktops updates existing dynamic Windows desktops or creates new ones if they don't exist.
+	UpsertDynamicWindowsDesktops(context.Context, *UpsertDynamicWindowsDesktopsRequest) (*UpsertDynamicWindowsDesktopsResponse, error)
 	// DeleteDynamicWindowsDesktop removes the specified dynamic Windows desktop.
 	DeleteDynamicWindowsDesktop(context.Context, *DeleteDynamicWindowsDesktopRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedDynamicWindowsServiceServer()
@@ -173,6 +188,9 @@ func (UnimplementedDynamicWindowsServiceServer) UpdateDynamicWindowsDesktop(cont
 }
 func (UnimplementedDynamicWindowsServiceServer) UpsertDynamicWindowsDesktop(context.Context, *UpsertDynamicWindowsDesktopRequest) (*types.DynamicWindowsDesktopV1, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpsertDynamicWindowsDesktop not implemented")
+}
+func (UnimplementedDynamicWindowsServiceServer) UpsertDynamicWindowsDesktops(context.Context, *UpsertDynamicWindowsDesktopsRequest) (*UpsertDynamicWindowsDesktopsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpsertDynamicWindowsDesktops not implemented")
 }
 func (UnimplementedDynamicWindowsServiceServer) DeleteDynamicWindowsDesktop(context.Context, *DeleteDynamicWindowsDesktopRequest) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeleteDynamicWindowsDesktop not implemented")
@@ -288,6 +306,24 @@ func _DynamicWindowsService_UpsertDynamicWindowsDesktop_Handler(srv interface{},
 	return interceptor(ctx, in, info, handler)
 }
 
+func _DynamicWindowsService_UpsertDynamicWindowsDesktops_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpsertDynamicWindowsDesktopsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DynamicWindowsServiceServer).UpsertDynamicWindowsDesktops(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DynamicWindowsService_UpsertDynamicWindowsDesktops_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DynamicWindowsServiceServer).UpsertDynamicWindowsDesktops(ctx, req.(*UpsertDynamicWindowsDesktopsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _DynamicWindowsService_DeleteDynamicWindowsDesktop_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(DeleteDynamicWindowsDesktopRequest)
 	if err := dec(in); err != nil {
@@ -332,6 +368,10 @@ var DynamicWindowsService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "UpsertDynamicWindowsDesktop",
 			Handler:    _DynamicWindowsService_UpsertDynamicWindowsDesktop_Handler,
+		},
+		{
+			MethodName: "UpsertDynamicWindowsDesktops",
+			Handler:    _DynamicWindowsService_UpsertDynamicWindowsDesktops_Handler,
 		},
 		{
 			MethodName: "DeleteDynamicWindowsDesktop",

--- a/api/gen/proto/go/teleport/dynamicwindows/v1/dynamicwindows_service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/dynamicwindows/v1/dynamicwindows_service_protoopaque.pb.go
@@ -459,6 +459,202 @@ func (b0 UpsertDynamicWindowsDesktopRequest_builder) Build() *UpsertDynamicWindo
 	return m0
 }
 
+// UpsertDynamicWindowsDesktopsRequest is used for upserting multiple dynamic Windows desktops.
+type UpsertDynamicWindowsDesktopsRequest struct {
+	state               protoimpl.MessageState            `protogen:"opaque.v1"`
+	xxx_hidden_Desktops *[]*types.DynamicWindowsDesktopV1 `protobuf:"bytes,1,rep,name=desktops,proto3"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *UpsertDynamicWindowsDesktopsRequest) Reset() {
+	*x = UpsertDynamicWindowsDesktopsRequest{}
+	mi := &file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpsertDynamicWindowsDesktopsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpsertDynamicWindowsDesktopsRequest) ProtoMessage() {}
+
+func (x *UpsertDynamicWindowsDesktopsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *UpsertDynamicWindowsDesktopsRequest) GetDesktops() []*types.DynamicWindowsDesktopV1 {
+	if x != nil {
+		if x.xxx_hidden_Desktops != nil {
+			return *x.xxx_hidden_Desktops
+		}
+	}
+	return nil
+}
+
+func (x *UpsertDynamicWindowsDesktopsRequest) SetDesktops(v []*types.DynamicWindowsDesktopV1) {
+	x.xxx_hidden_Desktops = &v
+}
+
+type UpsertDynamicWindowsDesktopsRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// desktops to be upserted
+	Desktops []*types.DynamicWindowsDesktopV1
+}
+
+func (b0 UpsertDynamicWindowsDesktopsRequest_builder) Build() *UpsertDynamicWindowsDesktopsRequest {
+	m0 := &UpsertDynamicWindowsDesktopsRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Desktops = &b.Desktops
+	return m0
+}
+
+// UpsertDynamicWindowsDesktopsResponse is the response for upserting multiple dynamic Windows desktops.
+type UpsertDynamicWindowsDesktopsResponse struct {
+	state              protoimpl.MessageState                `protogen:"opaque.v1"`
+	xxx_hidden_Results *[]*UpsertDynamicWindowsDesktopResult `protobuf:"bytes,1,rep,name=results,proto3"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *UpsertDynamicWindowsDesktopsResponse) Reset() {
+	*x = UpsertDynamicWindowsDesktopsResponse{}
+	mi := &file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpsertDynamicWindowsDesktopsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpsertDynamicWindowsDesktopsResponse) ProtoMessage() {}
+
+func (x *UpsertDynamicWindowsDesktopsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *UpsertDynamicWindowsDesktopsResponse) GetResults() []*UpsertDynamicWindowsDesktopResult {
+	if x != nil {
+		if x.xxx_hidden_Results != nil {
+			return *x.xxx_hidden_Results
+		}
+	}
+	return nil
+}
+
+func (x *UpsertDynamicWindowsDesktopsResponse) SetResults(v []*UpsertDynamicWindowsDesktopResult) {
+	x.xxx_hidden_Results = &v
+}
+
+type UpsertDynamicWindowsDesktopsResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// results of upserted desktops
+	Results []*UpsertDynamicWindowsDesktopResult
+}
+
+func (b0 UpsertDynamicWindowsDesktopsResponse_builder) Build() *UpsertDynamicWindowsDesktopsResponse {
+	m0 := &UpsertDynamicWindowsDesktopsResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Results = &b.Results
+	return m0
+}
+
+// UpsertDynamicWindowsDesktopResult is the result of upserting a dynamic Windows desktop.
+type UpsertDynamicWindowsDesktopResult struct {
+	state            protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Name  string                 `protobuf:"bytes,1,opt,name=name,proto3"`
+	xxx_hidden_Error string                 `protobuf:"bytes,2,opt,name=error,proto3"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *UpsertDynamicWindowsDesktopResult) Reset() {
+	*x = UpsertDynamicWindowsDesktopResult{}
+	mi := &file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpsertDynamicWindowsDesktopResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpsertDynamicWindowsDesktopResult) ProtoMessage() {}
+
+func (x *UpsertDynamicWindowsDesktopResult) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *UpsertDynamicWindowsDesktopResult) GetName() string {
+	if x != nil {
+		return x.xxx_hidden_Name
+	}
+	return ""
+}
+
+func (x *UpsertDynamicWindowsDesktopResult) GetError() string {
+	if x != nil {
+		return x.xxx_hidden_Error
+	}
+	return ""
+}
+
+func (x *UpsertDynamicWindowsDesktopResult) SetName(v string) {
+	x.xxx_hidden_Name = v
+}
+
+func (x *UpsertDynamicWindowsDesktopResult) SetError(v string) {
+	x.xxx_hidden_Error = v
+}
+
+type UpsertDynamicWindowsDesktopResult_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// name is the name of the dynamic Windows desktop.
+	Name string
+	// error is the failure message, empty if the upsert was successful.
+	Error string
+}
+
+func (b0 UpsertDynamicWindowsDesktopResult_builder) Build() *UpsertDynamicWindowsDesktopResult {
+	m0 := &UpsertDynamicWindowsDesktopResult{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Name = b.Name
+	x.xxx_hidden_Error = b.Error
+	return m0
+}
+
 // DeleteDynamicWindowsDesktopRequest is a request to delete a Windows desktop host.
 type DeleteDynamicWindowsDesktopRequest struct {
 	state           protoimpl.MessageState `protogen:"opaque.v1"`
@@ -469,7 +665,7 @@ type DeleteDynamicWindowsDesktopRequest struct {
 
 func (x *DeleteDynamicWindowsDesktopRequest) Reset() {
 	*x = DeleteDynamicWindowsDesktopRequest{}
-	mi := &file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes[6]
+	mi := &file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -481,7 +677,7 @@ func (x *DeleteDynamicWindowsDesktopRequest) String() string {
 func (*DeleteDynamicWindowsDesktopRequest) ProtoMessage() {}
 
 func (x *DeleteDynamicWindowsDesktopRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes[6]
+	mi := &file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -537,51 +733,66 @@ const file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_rawDesc = "" 
 	"\"UpdateDynamicWindowsDesktopRequest\x128\n" +
 	"\adesktop\x18\x01 \x01(\v2\x1e.types.DynamicWindowsDesktopV1R\adesktop\"^\n" +
 	"\"UpsertDynamicWindowsDesktopRequest\x128\n" +
-	"\adesktop\x18\x01 \x01(\v2\x1e.types.DynamicWindowsDesktopV1R\adesktop\"8\n" +
+	"\adesktop\x18\x01 \x01(\v2\x1e.types.DynamicWindowsDesktopV1R\adesktop\"a\n" +
+	"#UpsertDynamicWindowsDesktopsRequest\x12:\n" +
+	"\bdesktops\x18\x01 \x03(\v2\x1e.types.DynamicWindowsDesktopV1R\bdesktops\"\x7f\n" +
+	"$UpsertDynamicWindowsDesktopsResponse\x12W\n" +
+	"\aresults\x18\x01 \x03(\v2=.teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopResultR\aresults\"M\n" +
+	"!UpsertDynamicWindowsDesktopResult\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\"8\n" +
 	"\"DeleteDynamicWindowsDesktopRequest\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name2\xa2\x06\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name2\xc6\a\n" +
 	"\x15DynamicWindowsService\x12\x9b\x01\n" +
 	"\x1aListDynamicWindowsDesktops\x12=.teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsRequest\x1a>.teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsResponse\x12w\n" +
 	"\x18GetDynamicWindowsDesktop\x12;.teleport.dynamicwindows.v1.GetDynamicWindowsDesktopRequest\x1a\x1e.types.DynamicWindowsDesktopV1\x12}\n" +
 	"\x1bCreateDynamicWindowsDesktop\x12>.teleport.dynamicwindows.v1.CreateDynamicWindowsDesktopRequest\x1a\x1e.types.DynamicWindowsDesktopV1\x12}\n" +
 	"\x1bUpdateDynamicWindowsDesktop\x12>.teleport.dynamicwindows.v1.UpdateDynamicWindowsDesktopRequest\x1a\x1e.types.DynamicWindowsDesktopV1\x12}\n" +
-	"\x1bUpsertDynamicWindowsDesktop\x12>.teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopRequest\x1a\x1e.types.DynamicWindowsDesktopV1\x12u\n" +
+	"\x1bUpsertDynamicWindowsDesktop\x12>.teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopRequest\x1a\x1e.types.DynamicWindowsDesktopV1\x12\xa1\x01\n" +
+	"\x1cUpsertDynamicWindowsDesktops\x12?.teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopsRequest\x1a@.teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopsResponse\x12u\n" +
 	"\x1bDeleteDynamicWindowsDesktop\x12>.teleport.dynamicwindows.v1.DeleteDynamicWindowsDesktopRequest\x1a\x16.google.protobuf.EmptyB`Z^github.com/gravitational/teleport/api/gen/proto/go/teleport/dynamicwindows/v1;dynamicwindowsv1b\x06proto3"
 
-var file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_goTypes = []any{
-	(*ListDynamicWindowsDesktopsRequest)(nil),  // 0: teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsRequest
-	(*ListDynamicWindowsDesktopsResponse)(nil), // 1: teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsResponse
-	(*GetDynamicWindowsDesktopRequest)(nil),    // 2: teleport.dynamicwindows.v1.GetDynamicWindowsDesktopRequest
-	(*CreateDynamicWindowsDesktopRequest)(nil), // 3: teleport.dynamicwindows.v1.CreateDynamicWindowsDesktopRequest
-	(*UpdateDynamicWindowsDesktopRequest)(nil), // 4: teleport.dynamicwindows.v1.UpdateDynamicWindowsDesktopRequest
-	(*UpsertDynamicWindowsDesktopRequest)(nil), // 5: teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopRequest
-	(*DeleteDynamicWindowsDesktopRequest)(nil), // 6: teleport.dynamicwindows.v1.DeleteDynamicWindowsDesktopRequest
-	(*types.DynamicWindowsDesktopV1)(nil),      // 7: types.DynamicWindowsDesktopV1
-	(*emptypb.Empty)(nil),                      // 8: google.protobuf.Empty
+	(*ListDynamicWindowsDesktopsRequest)(nil),    // 0: teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsRequest
+	(*ListDynamicWindowsDesktopsResponse)(nil),   // 1: teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsResponse
+	(*GetDynamicWindowsDesktopRequest)(nil),      // 2: teleport.dynamicwindows.v1.GetDynamicWindowsDesktopRequest
+	(*CreateDynamicWindowsDesktopRequest)(nil),   // 3: teleport.dynamicwindows.v1.CreateDynamicWindowsDesktopRequest
+	(*UpdateDynamicWindowsDesktopRequest)(nil),   // 4: teleport.dynamicwindows.v1.UpdateDynamicWindowsDesktopRequest
+	(*UpsertDynamicWindowsDesktopRequest)(nil),   // 5: teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopRequest
+	(*UpsertDynamicWindowsDesktopsRequest)(nil),  // 6: teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopsRequest
+	(*UpsertDynamicWindowsDesktopsResponse)(nil), // 7: teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopsResponse
+	(*UpsertDynamicWindowsDesktopResult)(nil),    // 8: teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopResult
+	(*DeleteDynamicWindowsDesktopRequest)(nil),   // 9: teleport.dynamicwindows.v1.DeleteDynamicWindowsDesktopRequest
+	(*types.DynamicWindowsDesktopV1)(nil),        // 10: types.DynamicWindowsDesktopV1
+	(*emptypb.Empty)(nil),                        // 11: google.protobuf.Empty
 }
 var file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_depIdxs = []int32{
-	7,  // 0: teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsResponse.desktops:type_name -> types.DynamicWindowsDesktopV1
-	7,  // 1: teleport.dynamicwindows.v1.CreateDynamicWindowsDesktopRequest.desktop:type_name -> types.DynamicWindowsDesktopV1
-	7,  // 2: teleport.dynamicwindows.v1.UpdateDynamicWindowsDesktopRequest.desktop:type_name -> types.DynamicWindowsDesktopV1
-	7,  // 3: teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopRequest.desktop:type_name -> types.DynamicWindowsDesktopV1
-	0,  // 4: teleport.dynamicwindows.v1.DynamicWindowsService.ListDynamicWindowsDesktops:input_type -> teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsRequest
-	2,  // 5: teleport.dynamicwindows.v1.DynamicWindowsService.GetDynamicWindowsDesktop:input_type -> teleport.dynamicwindows.v1.GetDynamicWindowsDesktopRequest
-	3,  // 6: teleport.dynamicwindows.v1.DynamicWindowsService.CreateDynamicWindowsDesktop:input_type -> teleport.dynamicwindows.v1.CreateDynamicWindowsDesktopRequest
-	4,  // 7: teleport.dynamicwindows.v1.DynamicWindowsService.UpdateDynamicWindowsDesktop:input_type -> teleport.dynamicwindows.v1.UpdateDynamicWindowsDesktopRequest
-	5,  // 8: teleport.dynamicwindows.v1.DynamicWindowsService.UpsertDynamicWindowsDesktop:input_type -> teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopRequest
-	6,  // 9: teleport.dynamicwindows.v1.DynamicWindowsService.DeleteDynamicWindowsDesktop:input_type -> teleport.dynamicwindows.v1.DeleteDynamicWindowsDesktopRequest
-	1,  // 10: teleport.dynamicwindows.v1.DynamicWindowsService.ListDynamicWindowsDesktops:output_type -> teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsResponse
-	7,  // 11: teleport.dynamicwindows.v1.DynamicWindowsService.GetDynamicWindowsDesktop:output_type -> types.DynamicWindowsDesktopV1
-	7,  // 12: teleport.dynamicwindows.v1.DynamicWindowsService.CreateDynamicWindowsDesktop:output_type -> types.DynamicWindowsDesktopV1
-	7,  // 13: teleport.dynamicwindows.v1.DynamicWindowsService.UpdateDynamicWindowsDesktop:output_type -> types.DynamicWindowsDesktopV1
-	7,  // 14: teleport.dynamicwindows.v1.DynamicWindowsService.UpsertDynamicWindowsDesktop:output_type -> types.DynamicWindowsDesktopV1
-	8,  // 15: teleport.dynamicwindows.v1.DynamicWindowsService.DeleteDynamicWindowsDesktop:output_type -> google.protobuf.Empty
-	10, // [10:16] is the sub-list for method output_type
-	4,  // [4:10] is the sub-list for method input_type
-	4,  // [4:4] is the sub-list for extension type_name
-	4,  // [4:4] is the sub-list for extension extendee
-	0,  // [0:4] is the sub-list for field type_name
+	10, // 0: teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsResponse.desktops:type_name -> types.DynamicWindowsDesktopV1
+	10, // 1: teleport.dynamicwindows.v1.CreateDynamicWindowsDesktopRequest.desktop:type_name -> types.DynamicWindowsDesktopV1
+	10, // 2: teleport.dynamicwindows.v1.UpdateDynamicWindowsDesktopRequest.desktop:type_name -> types.DynamicWindowsDesktopV1
+	10, // 3: teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopRequest.desktop:type_name -> types.DynamicWindowsDesktopV1
+	10, // 4: teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopsRequest.desktops:type_name -> types.DynamicWindowsDesktopV1
+	8,  // 5: teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopsResponse.results:type_name -> teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopResult
+	0,  // 6: teleport.dynamicwindows.v1.DynamicWindowsService.ListDynamicWindowsDesktops:input_type -> teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsRequest
+	2,  // 7: teleport.dynamicwindows.v1.DynamicWindowsService.GetDynamicWindowsDesktop:input_type -> teleport.dynamicwindows.v1.GetDynamicWindowsDesktopRequest
+	3,  // 8: teleport.dynamicwindows.v1.DynamicWindowsService.CreateDynamicWindowsDesktop:input_type -> teleport.dynamicwindows.v1.CreateDynamicWindowsDesktopRequest
+	4,  // 9: teleport.dynamicwindows.v1.DynamicWindowsService.UpdateDynamicWindowsDesktop:input_type -> teleport.dynamicwindows.v1.UpdateDynamicWindowsDesktopRequest
+	5,  // 10: teleport.dynamicwindows.v1.DynamicWindowsService.UpsertDynamicWindowsDesktop:input_type -> teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopRequest
+	6,  // 11: teleport.dynamicwindows.v1.DynamicWindowsService.UpsertDynamicWindowsDesktops:input_type -> teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopsRequest
+	9,  // 12: teleport.dynamicwindows.v1.DynamicWindowsService.DeleteDynamicWindowsDesktop:input_type -> teleport.dynamicwindows.v1.DeleteDynamicWindowsDesktopRequest
+	1,  // 13: teleport.dynamicwindows.v1.DynamicWindowsService.ListDynamicWindowsDesktops:output_type -> teleport.dynamicwindows.v1.ListDynamicWindowsDesktopsResponse
+	10, // 14: teleport.dynamicwindows.v1.DynamicWindowsService.GetDynamicWindowsDesktop:output_type -> types.DynamicWindowsDesktopV1
+	10, // 15: teleport.dynamicwindows.v1.DynamicWindowsService.CreateDynamicWindowsDesktop:output_type -> types.DynamicWindowsDesktopV1
+	10, // 16: teleport.dynamicwindows.v1.DynamicWindowsService.UpdateDynamicWindowsDesktop:output_type -> types.DynamicWindowsDesktopV1
+	10, // 17: teleport.dynamicwindows.v1.DynamicWindowsService.UpsertDynamicWindowsDesktop:output_type -> types.DynamicWindowsDesktopV1
+	7,  // 18: teleport.dynamicwindows.v1.DynamicWindowsService.UpsertDynamicWindowsDesktops:output_type -> teleport.dynamicwindows.v1.UpsertDynamicWindowsDesktopsResponse
+	11, // 19: teleport.dynamicwindows.v1.DynamicWindowsService.DeleteDynamicWindowsDesktop:output_type -> google.protobuf.Empty
+	13, // [13:20] is the sub-list for method output_type
+	6,  // [6:13] is the sub-list for method input_type
+	6,  // [6:6] is the sub-list for extension type_name
+	6,  // [6:6] is the sub-list for extension extendee
+	0,  // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_init() }
@@ -595,7 +806,7 @@ func file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_rawDesc), len(file_teleport_dynamicwindows_v1_dynamicwindows_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   7,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/proto/teleport/dynamicwindows/v1/dynamicwindows_service.proto
+++ b/api/proto/teleport/dynamicwindows/v1/dynamicwindows_service.proto
@@ -33,6 +33,8 @@ service DynamicWindowsService {
   rpc UpdateDynamicWindowsDesktop(UpdateDynamicWindowsDesktopRequest) returns (types.DynamicWindowsDesktopV1);
   // UpsertDynamicWindowsDesktop updates an existing dynamic Windows desktop or creates new if it doesn't exist.
   rpc UpsertDynamicWindowsDesktop(UpsertDynamicWindowsDesktopRequest) returns (types.DynamicWindowsDesktopV1);
+  // UpsertDynamicWindowsDesktops updates existing dynamic Windows desktops or creates new ones if they don't exist.
+  rpc UpsertDynamicWindowsDesktops(UpsertDynamicWindowsDesktopsRequest) returns (UpsertDynamicWindowsDesktopsResponse);
   // DeleteDynamicWindowsDesktop removes the specified dynamic Windows desktop.
   rpc DeleteDynamicWindowsDesktop(DeleteDynamicWindowsDesktopRequest) returns (google.protobuf.Empty);
 }
@@ -77,6 +79,26 @@ message UpdateDynamicWindowsDesktopRequest {
 message UpsertDynamicWindowsDesktopRequest {
   // desktop to be upserted
   types.DynamicWindowsDesktopV1 desktop = 1;
+}
+
+// UpsertDynamicWindowsDesktopsRequest is used for upserting multiple dynamic Windows desktops.
+message UpsertDynamicWindowsDesktopsRequest {
+  // desktops to be upserted
+  repeated types.DynamicWindowsDesktopV1 desktops = 1;
+}
+
+// UpsertDynamicWindowsDesktopsResponse is the response for upserting multiple dynamic Windows desktops.
+message UpsertDynamicWindowsDesktopsResponse {
+  // results of upserted desktops
+  repeated UpsertDynamicWindowsDesktopResult results = 1;
+}
+
+// UpsertDynamicWindowsDesktopResult is the result of upserting a dynamic Windows desktop.
+message UpsertDynamicWindowsDesktopResult {
+  // name is the name of the dynamic Windows desktop.
+  string name = 1;
+  // error is the failure message, empty if the upsert was successful.
+  string error = 2;
 }
 
 // DeleteDynamicWindowsDesktopRequest is a request to delete a Windows desktop host.

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/trace"
 	"google.golang.org/grpc"
 
+	"github.com/gravitational/teleport/api/client/dynamicwindows"
 	"github.com/gravitational/teleport/api/client/gitserver"
 	"github.com/gravitational/teleport/api/client/proto"
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
@@ -1018,6 +1019,9 @@ type DiscoveryAccessPoint interface {
 
 	// UpsertUserTask creates or updates an User Task
 	UpsertUserTask(ctx context.Context, req *usertasksv1.UserTask) (*usertasksv1.UserTask, error)
+
+	// UpsertDynamicWindowsDesktops upserts multiple Windows Desktops.
+	UpsertDynamicWindowsDesktops(ctx context.Context, desktops []types.DynamicWindowsDesktop) ([]dynamicwindows.UpsertDynamicWindowsDesktopResult, error)
 }
 
 // ReadOktaAccessPoint is a read only API interface to be
@@ -1904,6 +1908,10 @@ func (w *DiscoveryWrapper) GetDiscoveryConfig(ctx context.Context, name string) 
 // UpserUserTask creates or updates an User Task.
 func (w *DiscoveryWrapper) UpsertUserTask(ctx context.Context, req *usertasksv1.UserTask) (*usertasksv1.UserTask, error) {
 	return w.NoCache.UpsertUserTask(ctx, req)
+}
+
+func (w *DiscoveryWrapper) UpsertDynamicWindowsDesktops(ctx context.Context, desktops []types.DynamicWindowsDesktop) ([]dynamicwindows.UpsertDynamicWindowsDesktopResult, error) {
+	return w.NoCache.UpsertDynamicWindowsDesktops(ctx, desktops)
 }
 
 // Close closes all associated resources

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -1666,6 +1666,7 @@ type ClientI interface {
 	DynamicDesktopClient() *dynamicwindows.Client
 	GetDynamicWindowsDesktop(ctx context.Context, name string) (types.DynamicWindowsDesktop, error)
 	ListDynamicWindowsDesktops(ctx context.Context, pageSize int, pageToken string) ([]types.DynamicWindowsDesktop, string, error)
+	UpsertDynamicWindowsDesktops(ctx context.Context, desktops []types.DynamicWindowsDesktop) ([]dynamicwindows.UpsertDynamicWindowsDesktopResult, error)
 
 	LinuxDesktopClient() *linuxdesktop.Client
 

--- a/lib/auth/dynamicwindows/dynamicwindowsv1/service.go
+++ b/lib/auth/dynamicwindows/dynamicwindowsv1/service.go
@@ -32,6 +32,12 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 )
 
+// maxDynamicWindowsDesktopsPerUpsert is the maximum number of desktops accepted
+// in a single UpsertDynamicWindowsDesktops request. The caller will need to
+// batch requests. The limit for a gRPC request is 4MB, so this allows for a
+// record size of ~4KB per desktop, which should be more than enough.
+const maxDynamicWindowsDesktopsPerUpsert = 1000
+
 // Service implements the teleport.trust.v1.TrustService RPC service.
 type Service struct {
 	dynamicwindowspb.UnimplementedDynamicWindowsServiceServer
@@ -255,6 +261,70 @@ func (s *Service) UpsertDynamicWindowsDesktop(ctx context.Context, req *dynamicw
 	}
 
 	return updatedDesktop, nil
+}
+
+// UpsertDynamicWindowsDesktops updates existing dynamic Windows desktops or
+// creates new ones if they don't exist. The function will attempt to upsert
+// each desktop in the request and return a list of results. An empty error
+// means a desktop was upserted successfully. Requests must be batched to
+// 1000 desktops or fewer at a time.
+func (s *Service) UpsertDynamicWindowsDesktops(ctx context.Context, req *dynamicwindowspb.UpsertDynamicWindowsDesktopsRequest) (*dynamicwindowspb.UpsertDynamicWindowsDesktopsResponse, error) {
+	auth, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := auth.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := auth.CheckAccessToKind(types.KindDynamicWindowsDesktop, types.VerbCreate, types.VerbUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	desktops := req.GetDesktops()
+	if len(desktops) > maxDynamicWindowsDesktopsPerUpsert {
+		return nil, trace.BadParameter("too many desktops in request: got %d, at most %d are allowed", len(desktops), maxDynamicWindowsDesktopsPerUpsert)
+	}
+
+	results := make([]*dynamicwindowspb.UpsertDynamicWindowsDesktopResult, 0, len(desktops))
+	fail := func(result *dynamicwindowspb.UpsertDynamicWindowsDesktopResult, err error) {
+		result.Error = err.Error()
+		results = append(results, result)
+	}
+
+	for _, desktop := range desktops {
+		result := &dynamicwindowspb.UpsertDynamicWindowsDesktopResult{
+			Name:  desktop.GetName(),
+			Error: "",
+		}
+
+		d, err := s.cache.GetDynamicWindowsDesktop(ctx, desktop.GetName())
+		if !trace.IsNotFound(err) {
+			if err != nil {
+				fail(result, err)
+				continue
+			}
+			if err := checkAccess(auth, d); err != nil {
+				fail(result, err)
+				continue
+			}
+		}
+		if err := checkAccess(auth, desktop); err != nil {
+			fail(result, err)
+			continue
+		}
+		d, err = s.backend.UpsertDynamicWindowsDesktop(ctx, desktop)
+		if err != nil {
+			fail(result, err)
+			continue
+		}
+
+		results = append(results, result)
+	}
+
+	response := &dynamicwindowspb.UpsertDynamicWindowsDesktopsResponse{
+		Results: results,
+	}
+	return response, nil
 }
 
 // DeleteDynamicWindowsDesktop removes the specified dynamic Windows desktop.

--- a/lib/auth/dynamicwindows/dynamicwindowsv1/service.go
+++ b/lib/auth/dynamicwindows/dynamicwindowsv1/service.go
@@ -297,6 +297,13 @@ func (s *Service) UpsertDynamicWindowsDesktops(ctx context.Context, req *dynamic
 			Error: "",
 		}
 
+		// desktop is user supplied and could have a spoofed type, so make sure it
+		// is set to `dynamic_windows_desktop` before calling checkAccess
+		if err := desktop.CheckAndSetDefaults(); err != nil {
+			fail(result, trace.Wrap(err))
+			continue
+		}
+
 		d, err := s.cache.GetDynamicWindowsDesktop(ctx, desktop.GetName())
 		if !trace.IsNotFound(err) {
 			if err != nil {

--- a/lib/auth/dynamicwindows/dynamicwindowsv1/service_test.go
+++ b/lib/auth/dynamicwindows/dynamicwindowsv1/service_test.go
@@ -74,6 +74,46 @@ func TestFailedAccessCheck(t *testing.T) {
 	})
 }
 
+// TestUpsertDynamicWindowsDesktopsFailedAccessCheck covers the failed access
+// check path for the bulk UpsertDynamicWindowsDesktops RPC. Unlike the methods
+// in TestFailedAccessCheck, this RPC performs per-resource access checks and
+// doesn't fail the entire RPC if one fails, so a new test is needed to verify
+// that the per-resource access denials are recorded in the response.
+func TestUpsertDynamicWindowsDesktopsFailedAccessCheck(t *testing.T) {
+	t.Parallel()
+	checker := fakeChecker{
+		allowedVerbs: []string{types.VerbRead, types.VerbList, types.VerbCreate, types.VerbUpdate},
+	}
+	s := newService(t, authz.AdminActionAuthMFAVerified, &checker)
+
+	// Add an existing desktop to test the update path
+	existing, err := types.NewDynamicWindowsDesktopV1("existing", nil, types.DynamicWindowsDesktopSpecV1{Addr: "addr"})
+	require.NoError(t, err)
+	_, err = s.CreateDynamicWindowsDesktop(context.Background(), dynamicwindowsv1.CreateDynamicWindowsDesktopRequest_builder{
+		Desktop: existing,
+	}.Build())
+	require.NoError(t, err)
+
+	// Now deny per-resource access for the upsert.
+	checker.failAccess = true
+
+	created, err := types.NewDynamicWindowsDesktopV1("created", nil, types.DynamicWindowsDesktopSpecV1{Addr: "addr"})
+	require.NoError(t, err)
+
+	resp, err := s.UpsertDynamicWindowsDesktops(context.Background(), dynamicwindowsv1.UpsertDynamicWindowsDesktopsRequest_builder{
+		Desktops: []*types.DynamicWindowsDesktopV1{existing, created},
+	}.Build())
+	// The kind-level access check passes, so the RPC itself succeeds.
+	// The per-desktop denials are recorded on each result instead.
+	require.NoError(t, err)
+
+	results := resp.GetResults()
+	require.Len(t, results, 2)
+	for _, result := range results {
+		require.NotEmpty(t, result.GetError(), "expected access denied recorded for desktop %q", result.GetName())
+	}
+}
+
 func TestServiceAccess(t *testing.T) {
 	t.Parallel()
 
@@ -133,6 +173,15 @@ func TestServiceAccess(t *testing.T) {
 				authz.AdminActionAuthMFAVerified, authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
 			allowedVerbs: []string{types.VerbRead},
+		},
+		{
+			name: "UpsertDynamicWindowsDesktops",
+			allowedStates: []authz.AdminActionAuthState{
+				authz.AdminActionAuthNotRequired,
+				authz.AdminActionAuthMFAVerified,
+				authz.AdminActionAuthMFAVerifiedWithReuse,
+			},
+			allowedVerbs: []string{types.VerbCreate, types.VerbUpdate},
 		},
 	}
 

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1399,6 +1399,7 @@ func unscopedDefinitionForBuiltinRole(clusterName string, recConfig readonly.Ses
 						types.NewRule(types.KindIntegration, append(services.RO(), types.VerbUse)),
 						types.NewRule(types.KindSemaphore, services.RW()),
 						types.NewRule(types.KindUserTask, services.RW()),
+						types.NewRule(types.KindDynamicWindowsDesktop, services.RW()),
 					},
 					// Discovery service should only access kubes/apps/dbs that originated from discovery.
 					KubernetesLabels: types.Labels{types.OriginLabel: []string{types.OriginCloud}},

--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/go-ldap/ldap/v3"
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
@@ -325,6 +326,97 @@ func testDynamicWindowsDiscovery(t *testing.T, client *authclient.Client, auth *
 	desktops, err = client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
 	require.NoError(t, err)
 	require.Empty(t, desktops)
+}
+
+// TestUpsertDynamicWindowsDesktops exercises the bulk UpsertDynamicWindowsDesktops
+// RPC end-to-end through a real gRPC client and auth server. It covers a bulk
+// create, a bulk update, and partial success (one valid desktop alongside an
+// invalid one), verifying that per-desktop failures are reported in the results
+// rather than failing the whole call.
+func TestUpsertDynamicWindowsDesktops(t *testing.T) {
+	t.Parallel()
+
+	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		ClusterName: "test",
+		Dir:         t.TempDir(),
+		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
+
+	tlsServer, err := authServer.NewTestTLSServer(authtest.WithBufconnListener())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
+
+	client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, "test-host-id"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	ctx := t.Context()
+	dynamicWindowsClient := client.DynamicDesktopClient()
+
+	// Bulk create a batch of valid desktops.
+	names := []string{"desktop-1", "desktop-2", "desktop-3"}
+	var desktops []types.DynamicWindowsDesktop
+	for _, name := range names {
+		d, err := types.NewDynamicWindowsDesktopV1(name, nil, types.DynamicWindowsDesktopSpecV1{Addr: "addr"})
+		require.NoError(t, err)
+		desktops = append(desktops, d)
+	}
+
+	results, err := dynamicWindowsClient.UpsertDynamicWindowsDesktops(ctx, desktops)
+	require.NoError(t, err)
+	require.Len(t, results, len(desktops))
+	for _, result := range results {
+		require.NoError(t, result.Err, "desktop %q should have been upserted", result.Name)
+	}
+
+	// Test 1: All desktops should exist after the bulk create.
+	for _, name := range names {
+		_, err := dynamicWindowsClient.GetDynamicWindowsDesktop(ctx, name)
+		require.NoError(t, err, "desktop %q should exist", name)
+	}
+
+	// Test 2: All Addr fields should be updated after a bulk update.
+	for _, d := range desktops {
+		d.(*types.DynamicWindowsDesktopV1).Spec.Addr = "addr2"
+	}
+	results, err = dynamicWindowsClient.UpsertDynamicWindowsDesktops(ctx, desktops)
+	require.NoError(t, err)
+	for _, result := range results {
+		require.NoError(t, result.Err)
+	}
+	updated, err := dynamicWindowsClient.GetDynamicWindowsDesktop(ctx, "desktop-1")
+	require.NoError(t, err)
+	require.Equal(t, "addr2", updated.GetAddr())
+
+	// Test 3: An invalid desktop should not be created and an error should be
+	// returned.
+	valid, err := types.NewDynamicWindowsDesktopV1("desktop-valid", nil, types.DynamicWindowsDesktopSpecV1{Addr: "addr"})
+	require.NoError(t, err)
+	// Manually create an invalid desktop by mising out the Addr field.
+	invalid := &types.DynamicWindowsDesktopV1{
+		ResourceHeader: types.ResourceHeader{
+			Metadata: types.Metadata{Name: "desktop-invalid"},
+		},
+	}
+
+	results, err = dynamicWindowsClient.UpsertDynamicWindowsDesktops(ctx, []types.DynamicWindowsDesktop{valid, invalid})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	errByName := make(map[string]error, len(results))
+	for _, result := range results {
+		errByName[result.Name] = result.Err
+	}
+	require.NoError(t, errByName["desktop-valid"])
+	require.Error(t, errByName["desktop-invalid"])
+
+	// Test that the valid desktop is present and the invalid desktop is not.
+	_, err = dynamicWindowsClient.GetDynamicWindowsDesktop(ctx, "desktop-valid")
+	require.NoError(t, err)
+	_, err = dynamicWindowsClient.GetDynamicWindowsDesktop(ctx, "desktop-invalid")
+	require.True(t, trace.IsNotFound(err), "invalid desktop should not have been created, got err=%v", err)
 }
 
 func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {


### PR DESCRIPTION
This PR adds a new RPC to the Dynamic Windows Desktop service that allows the caller to bulk upsert many desktops at once, rather than one at a time using the existing `UpsertDynamicWindowsDesktop` rpc. This is part of the work to auto discover non-AD desktops for the Discovery service.

This Claude generated sequence diagram gives an overview of how data flows from caller to backend:

```mermaid
sequenceDiagram
    autonumber
    actor Caller as Caller<br/>(Discovery / other service)
    participant Client as DynamicWindows Client<br/>(api/client/dynamicwindows)
    participant Auth as Auth Service<br/>(dynamicwindowsv1.Service)
    participant Authz as Authorizer / Checker
    participant Cache as Cache (read)
    participant Backend as Backend (write)

    Caller->>Client: UpsertDynamicWindowsDesktops(desktops)

    Note over Client: Type-assert each to *DynamicWindowsDesktopV1
    alt any desktop is wrong type
        Client-->>Caller: BadParameter (no RPC sent)
    end

    Client->>Auth: gRPC UpsertDynamicWindowsDesktopsRequest{desktops}
    Note over Client,Auth: gRPC enforces 4 MiB max message size

    Auth->>Authz: Authorize + AuthorizeAdminActionAllowReusedMFA<br/>(no-op for builtin roles)
    Auth->>Authz: CheckAccessToKind(create, update)
    alt not authorized
        Auth-->>Client: AccessDenied (whole call fails)
        Client-->>Caller: error
    end

    alt len(desktops) > 1000
        Auth-->>Client: BadParameter (whole call fails)
        Client-->>Caller: error
    end

    loop for each desktop
        Auth->>Cache: GetDynamicWindowsDesktop(name)
        alt already exists
            Cache-->>Auth: existing desktop
            Auth->>Authz: checkAccess(existing labels)
        else not found
            Cache-->>Auth: NotFound (create path)
        end
        Auth->>Authz: checkAccess(incoming labels)
        alt access denied OR cache error
            Note over Auth: record result.Error, continue
        else allowed
            Auth->>Backend: UpsertDynamicWindowsDesktop(desktop)
            Note over Backend: CheckAndSetDefaults (validate) + write
            alt write/validation fails
                Backend-->>Auth: error
                Note over Auth: record result.Error, continue
            else success
                Backend-->>Auth: stored desktop
                Note over Auth: record success (empty error)
            end
        end
    end

    Auth-->>Client: Response{results[]}<br/>(per-desktop name + error string)
    Note over Client: Convert error string → error<br/>("" = success)
    Client-->>Caller: []UpsertDynamicWindowsDesktopResult{Name, Err}
```

## Manual Test Plan
### Test Environment
There isn't any callers for this code yet, so it is tough to test manually. However, I added a test in `desktop/discovery_test.go` that acts as a client calling the rpc.
### Test Cases
- [x] Desktops can be bulk created
- [x] Desktops can be bulk updated
- [x] Invalid desktops are not created/updated and an error is returned
