### PR TITLE
Edit MongoDB Atlas trust policy instructions

### DIFF
--- a/docs/pages/enroll-resources/database-access/enrollment/managed/mongodb-atlas.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/managed/mongodb-atlas.mdx
@@ -193,32 +193,40 @@ You must provide the Teleport Database Service access to AWS credentials.
 
 ### Create a MongoDB IAM role
 
-Navigate to the [AWS IAM console](https://console.aws.amazon.com/iam/). In the
-navigation pane, choose **Roles** and then choose **Create role**. Next, select
-the "Custom trust policy" type. Edit the trust policy to allow the Teleport
-Database service IAM role to assume this role so that the Teleport can fetch the
-necessary credentials to authenticate to MongoDB:
+1. Navigate to the [AWS IAM console](https://console.aws.amazon.com/iam/). 
 
-```json
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "Statement1",
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "arn:aws:iam::111111111111:role/teleport-database-access",
-                "Service": "ec2.amazonaws.com"
-            },
-            "Action": "sts:AssumeRole"
-        }
-    ]
-}
-```
+1. In the navigation pane, choose **Roles** and then choose **Create role**.
+   
+1. Select the "Custom trust policy" type. 
 
-Your role won’t require any permission, so you can leave it empty on the
-**Add Permissions** step. Then, choose a name for it and create it. In this
-guide, we will use the name `teleport-access`.
+1. Edit the trust policy to allow the Teleport Database Service IAM role to
+   assume this role so that the Teleport Database Service can fetch the
+   necessary credentials to authenticate to MongoDB. Assign 
+   <Var name="arn:aws:iam::111111111111:role/teleport-database-access" /> to the
+   ARN of the role used by the Teleport Database Service.
+
+   ```json
+   {
+       "Version": "2012-10-17",
+       "Statement": [
+           {
+               "Sid": "Statement1",
+               "Effect": "Allow",
+               "Principal": {
+                   "AWS": "<Var name="arn:aws:iam::111111111111:role/teleport-database-access" />",
+                   "Service": "ec2.amazonaws.com"
+               },
+               "Action": "sts:AssumeRole"
+           }
+       ]
+   }
+   ```
+
+   Your role won’t require any permission, so you can leave it empty on the
+   **Add Permissions** step.
+
+1. Choose a name for it and create it. In this guide, we will use the name
+   `teleport-access`.
 
 ### Create a MongoDB User
 


### PR DESCRIPTION
Closes #67517

Edit the instructions in the MongoDB Atlas how-to guide for adding a trust policy to the MongoDB user's IAM role. In the current instructions, users miss that they need to edit the principal to match the name of the role used by the Teleport Database Service. This change makes the need to edit the principal explicit by (a) breaking the text into numbered steps to better highlight each operation and (b) adding a step to change the principal.