### PR TITLE
Add page_type and outcome statements to 47 guides

### DIFF
--- a/docs/pages/agentic-identity-framework/agentic-identity-framework.mdx
+++ b/docs/pages/agentic-identity-framework/agentic-identity-framework.mdx
@@ -2,6 +2,7 @@
 title: Teleport Agentic Identity Framework
 template: landing-page
 description: Describes a design and reference implementation for the secure deployment of agents on infrastructure. 
+page_type: landing
 ---
 
 {/* cspell:disable */}

--- a/docs/pages/agentic-identity-framework/secure-agent-environment.mdx
+++ b/docs/pages/agentic-identity-framework/secure-agent-environment.mdx
@@ -4,6 +4,7 @@ description: Provides architectural principles for isolating agentic workloads i
 tags:
   - conceptual
   - ai
+page_type: conceptual
 ---
 
 An AI agent running on a local workstation can read any credentials available to
@@ -23,6 +24,9 @@ is built on Teleport's foundation of authentication using cryptographically
 signed identities with certificate-based access controls. With Beams as an
 extension of Teleport's existing capabilities, security is built into AI
 infrastructure from the bottom up.
+
+This page describes the components of the secure agent environment as
+recommended by Teleport.
 
 ## A multi-layered approach
 

--- a/docs/pages/enroll-resources/auto-discovery/databases/aws.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/databases/aws.mdx
@@ -7,12 +7,13 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
 Teleport can be configured to discover AWS-hosted databases automatically and
 register them with your Teleport cluster.
 
-In this guide, we will show you how to set-up AWS database auto-discovery.
+In this guide, you will set up AWS database auto-discovery.
 
 ## How it works
 

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/get-started.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/get-started.mdx
@@ -6,6 +6,7 @@ tags:
  - get-started
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 Teleport can automatically detect applications running in your Kubernetes
@@ -14,7 +15,7 @@ Kubernetes-hosted infrastructure can configure secure access to any new
 applications they deploy with no need for manual intervention beyond the initial
 setup step.
 
-In this guide, we show you how to enable Kubernetes application auto-discovery.
+In this guide, you will enable Kubernetes application auto-discovery.
 
 ## How it works
 

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/reference.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/reference.mdx
@@ -3,7 +3,7 @@ title: Kubernetes Application Discovery Reference
 sidebar_label: Configuration Reference
 description: This guide is a comprehensive reference of configuration options for automatically enrolling Kubernetes applications with Teleport.
 tags:
- - reference
+ - conceptual
  - zero-trust
  - infrastructure-identity
 page_type: reference

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/gke-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/gke-discovery.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - google-cloud
+page_type: how-to
 ---
 
 The Teleport Discovery Service can automatically register your Google Kubernetes
@@ -15,8 +16,9 @@ you can configure the Teleport Kubernetes Service and Discovery Service once,
 then create GKE clusters without needing to register them with Teleport after
 each creation.
 
-In this guide, we will show you how to get started with Teleport Kubernetes
-Discovery for GKE.
+In this guide, you will get started with Teleport Kubernetes Discovery for GKE
+by configuring the Teleport Discovery Service to register a GKE cluster with
+Teleport.
 
 ## How it works
 

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-organization.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-organization.mdx
@@ -7,9 +7,10 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
-This guide shows how to configure Teleport to automatically enroll EC2 instances from an AWS Organization in your cluster.
+This guide shows you how to configure Teleport to automatically enroll EC2 instances from an AWS Organization in your cluster.
 
 ## How it works
 

--- a/docs/pages/enroll-resources/desktop-access/active-directory.mdx
+++ b/docs/pages/enroll-resources/desktop-access/active-directory.mdx
@@ -7,10 +7,11 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
-This guide demonstrates how to connect an Active Directory domain and how to log
-into a Windows desktop from the connected domain.
+In this guide, you will connect an Active Directory domain to your Teleport
+cluster and log in to a Windows desktop from the connected domain.
 
 You should note that Teleport requires the Kerberos authentication protocol to
 support certificate-based authentication for Active Directory. Because Microsoft

--- a/docs/pages/enroll-resources/desktop-access/reference/audit.mdx
+++ b/docs/pages/enroll-resources/desktop-access/reference/audit.mdx
@@ -6,9 +6,10 @@ tags:
  - reference
  - zero-trust
  - audit
+page_type: reference
 ---
 
-This guide lists the structures and field names of audit events related to
+This page lists the structures and field names of audit events related to
 connecting to remote desktops with Teleport. Use this guide to understand
 desktop-related audit events and configure your log management solutions if you
 are [exporting audit

--- a/docs/pages/enroll-resources/desktop-access/reference/cli.mdx
+++ b/docs/pages/enroll-resources/desktop-access/reference/cli.mdx
@@ -6,10 +6,11 @@ tags:
  - reference
  - zero-trust
  - infrastructure-identity
+page_type: reference
 ---
 
-The following `tctl` commands are used to manage the Teleport Windows Desktop
-Service.
+This page lists the `tctl` commands that you can use to manage the Teleport
+Windows Desktop Service.
 
 - (!docs/pages/includes/tctl.mdx!)
 

--- a/docs/pages/enroll-resources/desktop-access/reference/clipboard.mdx
+++ b/docs/pages/enroll-resources/desktop-access/reference/clipboard.mdx
@@ -5,10 +5,12 @@ tags:
  - conceptual
  - zero-trust
  - infrastructure-identity
+page_type: conceptual
 ---
 
 Teleport supports copying and pasting text between your browser and a remote
-Windows Desktop.
+Windows Desktop. This page describes the clipboard sharing capability and how to
+configure it.
 
 <Admonition type="note">
 This feature requires a Chromium-based browser such as Google Chrome, Brave,

--- a/docs/pages/enroll-resources/desktop-access/reference/configuration.mdx
+++ b/docs/pages/enroll-resources/desktop-access/reference/configuration.mdx
@@ -3,12 +3,14 @@ title: Desktop Access Configuration Reference
 sidebar_label: Configuration
 description: Configuration reference for Teleport desktop access.
 tags:
- - conceptual
+ - reference
  - zero-trust
  - infrastructure-identity
+page_type: reference
 ---
 
-`teleport.yaml` fields related to desktop access:
+This page lists the Teleport configuration fields that you can use to configure
+the Teleport Desktop Service.
 
 ```yaml
 # Main service responsible for desktop access.

--- a/docs/pages/enroll-resources/desktop-access/reference/sessions.mdx
+++ b/docs/pages/enroll-resources/desktop-access/reference/sessions.mdx
@@ -6,9 +6,13 @@ tags:
  - conceptual
  - zero-trust
  - audit
+page_type: conceptual
 ---
 
-Teleport supports recording and playback of desktop sessions.
+Teleport supports recording and playback of desktop sessions. This page
+describes configuration options for session recording and playback, how to
+access recorded sessions for playback, and how Teleport stores session
+recordings.
 
 ## Disabling session recording
 

--- a/docs/pages/enroll-resources/desktop-access/reference/user-creation.mdx
+++ b/docs/pages/enroll-resources/desktop-access/reference/user-creation.mdx
@@ -9,7 +9,9 @@ page_type: conceptual
 ---
 
 Teleport's Desktop Service can be configured to automatically create local
-Windows users upon login.
+Windows users upon login. This page describes the configuration options
+available for managing automatic user creation for Teleport-protected Windows
+desktops.
 
 This page describes the configuration options for automatic user creation on
 Teleport-protected Windows desktops.

--- a/docs/pages/enroll-resources/kubernetes-access/controls.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/controls.mdx
@@ -6,16 +6,13 @@ tags:
  - conceptual
  - zero-trust
  - privileged-access
+page_type: reference
 ---
 
-This guide explains the way the Teleport Kubernetes Service applies role-based
-access controls when a Teleport user interacts with a Kubernetes cluster. The
-Kubernetes Service intercepts requests to a Kubernetes API server and modifies
-each request depending on the user's Teleport roles.
-
-In this guide, we will show you how to configure the fields available in a
-Teleport role to manage access to Kubernetes clusters you have connected to
-Teleport.
+This guide lists the fields that Teleport roles provide for managing access to
+Teleport-protected Kubernetes clusters. The Kubernetes Service intercepts
+requests to a Kubernetes API server and modifies each request depending on the
+user's Teleport roles.
 
 For an example of how to use Teleport roles to manage access to Kubernetes with
 a local `minikube` cluster, see our [RBAC how-to guide](./manage-access.mdx).

--- a/docs/pages/enroll-resources/kubernetes-access/faq.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/faq.mdx
@@ -6,9 +6,10 @@ tags:
  - faq
  - zero-trust
  - infrastructure-identity
+page_type: faq
 ---
 
-This page offers answers to frequently asked questions about Teleport's
+This page provides answers to frequently asked questions about Teleport's
 Kubernetes feature.
 
 ## Can a single `kubernetes_service` serve multiple Kubernetes clusters?

--- a/docs/pages/enroll-resources/kubernetes-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/getting-started.mdx
@@ -7,11 +7,12 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
-This guide demonstrates how to enroll a Kubernetes cluster as a Teleport
-resource by deploying the Teleport Kubernetes Service on the Kubernetes cluster
-you want to protect. 
+In this guide, you will enroll a Kubernetes cluster as a Teleport resource by
+deploying the Teleport Kubernetes Service on the Kubernetes cluster you want to
+protect. 
 
 ## How it works
 

--- a/docs/pages/enroll-resources/kubernetes-access/manage-access.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/manage-access.mdx
@@ -6,14 +6,15 @@ tags:
  - how-to
  - zero-trust
  - privileged-access
+page_type: how-to
 ---
 
 The Teleport Kubernetes Service is a proxy that sits between Kubernetes users
 and one or more Kubernetes clusters.
 
-In this guide, we will use a local Kubernetes cluster to show you how to
-configure Teleport's role-based access control (RBAC) system to manage access to
-Kubernetes clusters, groups, users, and resources.
+In this guide, you will use a local Kubernetes cluster as a demo for configuring
+Teleport's role-based access control (RBAC) system, which lets you manage access
+to Kubernetes clusters, groups, users, and resources.
 
 ## How it works
 

--- a/docs/pages/enroll-resources/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/register-clusters/iam-joining.mdx
@@ -5,10 +5,11 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
-In this guide, we will show you how to register a Kubernetes cluster with
-Teleport by using the agent's IAM identity to automatically join the Teleport cluster.
+In this guide, you will register a Kubernetes cluster with Teleport by using a
+Teleport Agent's IAM identity to automatically join the Teleport cluster.
 
 ## How it works
 

--- a/docs/pages/enroll-resources/mcp-access/dynamic-registration.mdx
+++ b/docs/pages/enroll-resources/mcp-access/dynamic-registration.mdx
@@ -7,6 +7,7 @@ tags:
 - how-to
 - zero-trust
 - mcp
+page_type: conceptual
 ---
 
 <Callout
@@ -28,6 +29,9 @@ The MCP server resources are registered as `app` resources in the Teleport
 backend. Application Service instances periodically query the Teleport Auth
 Service for `app` resources, each of which includes the information that the
 Application Service needs to proxy an application.
+
+This page describes the operations involved in managing MCP server registration
+dynamically.
 
 ## Required permissions
 

--- a/docs/pages/enroll-resources/mcp-access/enrolling-mcp-servers/enrolling-mcp-servers.mdx
+++ b/docs/pages/enroll-resources/mcp-access/enrolling-mcp-servers/enrolling-mcp-servers.mdx
@@ -2,6 +2,7 @@
 title: Protecting MCP Servers
 sidebar_label: Enrollment Guides
 description: Provides guidance on enrolling various kinds of MCP servers with Teleport.
+page_type: landing
 ---
 
 <DocCardList />

--- a/docs/pages/enroll-resources/mcp-access/integration-guides/grafana.mdx
+++ b/docs/pages/enroll-resources/mcp-access/integration-guides/grafana.mdx
@@ -6,6 +6,7 @@ tags:
 - how-to
 - mcp
 - zero-trust
+page_type: how-to
 ---
 
 (!docs/pages/includes/mcp-access/integration-intro.mdx serviceName="Grafana" !)

--- a/docs/pages/enroll-resources/mcp-access/integration-guides/integration-guides.mdx
+++ b/docs/pages/enroll-resources/mcp-access/integration-guides/integration-guides.mdx
@@ -6,8 +6,8 @@ sidebar_position: 6
 tags:
  - mcp
  - zero-trust
+page_type: landing
 ---
-
 
 Guides on how to configure popular services with the credentials and transports
 required to run their MCP servers and connect them through Teleport.

--- a/docs/pages/enroll-resources/mcp-access/integration-guides/vault.mdx
+++ b/docs/pages/enroll-resources/mcp-access/integration-guides/vault.mdx
@@ -6,6 +6,7 @@ tags:
 - how-to
 - mcp
 - zero-trust
+page_type: how-to
 ---
 
 (!docs/pages/includes/mcp-access/integration-intro.mdx serviceName="HashiCorp Vault" !)

--- a/docs/pages/enroll-resources/mcp-access/jwt.mdx
+++ b/docs/pages/enroll-resources/mcp-access/jwt.mdx
@@ -7,6 +7,7 @@ tags:
 - conceptual
 - mcp
 - zero-trust
+page_type: conceptual
 ---
 
 <Callout
@@ -19,6 +20,9 @@ tags:
     href: "../../../agentic-identity-framework",
   }}
 />
+
+This page describes how Teleport manages JWTs and provides troubleshooting
+guidance for JWT-related issues. 
 
 (!docs/pages/includes/application-access/jwt-intro.mdx appType="MCP server" !)
 

--- a/docs/pages/enroll-resources/mcp-access/mcp-access.mdx
+++ b/docs/pages/enroll-resources/mcp-access/mcp-access.mdx
@@ -5,6 +5,7 @@ template: doc-page
 tags:
  - mcp
  - zero-trust
+page_type: landing
 ---
 
 import DocHero from "@site/src/components/Pages/Landing/DocHero";

--- a/docs/pages/enroll-resources/mcp-access/reference.mdx
+++ b/docs/pages/enroll-resources/mcp-access/reference.mdx
@@ -7,9 +7,10 @@ tags:
 - reference
 - zero-trust
 - mcp
+page_type: reference
 ---
 
-This guide describes interfaces and options for interacting with the Teleport
+This guide lists the interfaces and options for interacting with the Teleport
 Application Service for MCP access, including the static configuration file for
 the `teleport` binary, and `tsh mcp` commands.
 

--- a/docs/pages/enroll-resources/mcp-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/mcp-access/troubleshooting.mdx
@@ -7,9 +7,10 @@ tags:
 - conceptual
 - zero-trust
 - mcp
+page_type: troubleshooting
 ---
 
-This section describes common issues that you might encounter in managing access
+This page describes common issues that you might encounter in managing access
 to MCP servers with Teleport and how to work around or resolve them.
 
 ## Disabled MCP server or tools missing from the MCP server

--- a/docs/pages/enroll-resources/server-access/openssh/openssh-agentless.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh-agentless.mdx
@@ -7,12 +7,13 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
-In this guide, we will show you how to configure Teleport in agentless mode and
-have the OpenSSH server `sshd` join a Teleport cluster. Existing fleets of
-OpenSSH servers can be configured to accept SSH certificates dynamically issued
-by a Teleport CA.
+In this guide, you will configure Teleport in agentless mode and have the
+OpenSSH server `sshd` join a Teleport cluster. Existing fleets of OpenSSH
+servers can be configured to accept SSH certificates dynamically issued by a
+Teleport CA.
 
 Using Teleport and OpenSSH has the advantage of getting you up
 and running, but in the long run, we would recommend replacing `sshd` with `teleport`.

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -4,9 +4,10 @@ description: Frequently Asked Questions About Using Teleport
 tags:
   - faq
   - platform-wide
+page_type: faq
 ---
 
-This page includes answers to frequently asked questions about setting up,
+This page provides answers to frequently asked questions about setting up,
 managing, and using Teleport. If you are new to Teleport, read our [Getting
 Started Guide](./get-started/get-started.mdx).
 

--- a/docs/pages/installation/agents/aws-ec2.mdx
+++ b/docs/pages/installation/agents/aws-ec2.mdx
@@ -7,9 +7,10 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
-This guide explains how to use the **EC2 join method** to configure Teleport
+In this guide, you will use the **EC2 join method** to configure Teleport
 processes to join your Teleport cluster without sharing any secrets when they
 are running in AWS.
 

--- a/docs/pages/installation/agents/gcp.mdx
+++ b/docs/pages/installation/agents/gcp.mdx
@@ -7,9 +7,10 @@ tags:
  - zero-trust
  - infrastructure-identity
  - google-cloud
+page_type: how-to
 ---
 
-This guide will explain how to use the **GCP join method** to configure Teleport
+In this guide, you will use the **GCP join method** to configure Teleport
 processes to join your Teleport cluster without sharing any secrets when they
 are running in a GCP VM.
 

--- a/docs/pages/machine-workload-identity/manifesto.mdx
+++ b/docs/pages/machine-workload-identity/manifesto.mdx
@@ -6,7 +6,10 @@ tags:
  - conceptual
  - mwi
  - infrastructure-identity
+page_type: conceptual
 ---
+
+This page describes the motivation behind Machine & Workload Identity.
 
 The world of machine identity is changing. Machines are trusted to complete
 ever more privileged tasks, and these tasks are no longer confined within the

--- a/docs/pages/machine-workload-identity/use-cases/ai-agents-mwi.mdx
+++ b/docs/pages/machine-workload-identity/use-cases/ai-agents-mwi.mdx
@@ -6,11 +6,14 @@ tags:
  - conceptual
  - mwi
  - ai
+page_type: conceptual
 ---
 
 import TextWithMedia from "@site/src/components/Pages/Landing/TextWithMedia";
 
-Teleport enables you to enforce access and privileges for agents.
+Teleport enables you to enforce access and privileges for agents. This page
+describes the capabilities Teleport Machine & Workload Identity provides for
+protecting agentic AI infrastructure. 
 
 Security must be enforced deterministically. AI agents cannot be trusted to follow high-level instructions like "don't delete production". 
 Teleport solves this by issuing each agent its own identity and requiring the agent's actions (for example, database queries) to flow through the Teleport Proxy Service. 

--- a/docs/pages/machine-workload-identity/workload-identity/best-practices.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/best-practices.mdx
@@ -6,10 +6,11 @@ tags:
  - conceptual
  - mwi
  - infrastructure-identity
+page_type: conceptual
 ---
 
-This page covers common questions and best practices for using Teleport's
-Workload Identity feature in production.
+This page describes the best practices for using Teleport's Workload Identity
+feature in production.
 
 ## Structuring SPIFFE IDs
 

--- a/docs/pages/machine-workload-identity/workload-identity/federation.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/federation.mdx
@@ -5,7 +5,11 @@ tags:
  - conceptual
  - mwi
  - infrastructure-identity
+page_type: conceptual
 ---
+
+This page describes the capabilities that Teleport offers for federating
+Workload Identity SPIFFE.
 
 Federation allows a relationship to be established between your Teleport
 Workload Identity trust domain and another trust domain, enabling workloads

--- a/docs/pages/machine-workload-identity/workload-identity/introduction.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/introduction.mdx
@@ -6,6 +6,7 @@ tags:
  - conceptual
  - mwi
  - infrastructure-identity
+page_type: conceptual
 ---
 
 <Callout
@@ -23,6 +24,12 @@ Teleport Workload Identity securely issues short-lived cryptographic identities
 to workloads. It is a flexible foundation for workload identity across your 
 infrastructure, creating a uniform way for your workloads to authenticate 
 regardless of where they are running.
+
+This page describes the use cases and architecture of Workload Identity, along
+with the relationship of Workload Identity to Zero Trust Access in a Teleport
+cluster.
+
+## Use cases
 
 The flexible nature of Teleport Workload Identity enables it to be used for a
 range of purposes, including:

--- a/docs/pages/machine-workload-identity/workload-identity/jwt-svids.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/jwt-svids.mdx
@@ -5,6 +5,7 @@ tags:
  - conceptual
  - mwi
  - infrastructure-identity
+page_type: conceptual
 ---
 
 One type of credential that can be issued by Teleport Workload Identity is a
@@ -12,6 +13,9 @@ JWT SVID. This is a short-lived JSON Web Token (JWT) that contains the identity
 of the workload and is signed by the Teleport Workload Identity CA.
 
 The ability to issue JWT SVIDs has been available since Teleport 16.4.3.
+
+This page describes the claims available in Workload Ident ity JWT SVIDs and
+provides details on OIDC compatibility.
 
 ## Claims
 
@@ -32,7 +36,7 @@ The JWT-SVID can be useful in scenarios where X509-SVIDs are not suitable.
 For example, when the workload needs to authenticate to another workload which
 is behind a TLS-terminating load balancer.
 
-## OIDC Compatibility
+## OIDC compatibility
 
 The JWT SVIDs issued by Teleport Workload Identity are compatible with the
 specification for OIDC ID Tokens. This means that they can be used by workloads

--- a/docs/pages/machine-workload-identity/workload-identity/spiffe.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/spiffe.mdx
@@ -5,10 +5,12 @@ tags:
  - conceptual
  - mwi
  - infrastructure-identity
+page_type: conceptual
 ---
 
 SPIFFE (Secure Production Identity Framework For Everyone) is a set of standards
-for securely identifying workloads.
+for securely identifying workloads. This page describes the fundamental concepts
+behind SPIFFE.
 
 SPIFFE sets out:
 

--- a/docs/pages/migrate-plans.mdx
+++ b/docs/pages/migrate-plans.mdx
@@ -4,9 +4,10 @@ description: Explains how to migrate between Teleport Enterprise (Self-Hosted), 
 tags:
  - how-to
  - platform-wide
+page_type: how-to
 ---
 
-This guide explains how to migrate from Teleport Community Edition, Teleport
+In this guide, you will migrate from Teleport Community Edition, Teleport
 Enterprise (Self-Hosted) and Teleport Enterprise (Cloud) to another Teleport
 plan. 
 

--- a/docs/pages/upgrading/agent-managed-updates-v1.mdx
+++ b/docs/pages/upgrading/agent-managed-updates-v1.mdx
@@ -4,15 +4,13 @@ description: Describes how to set up Managed Updates for Teleport Agents (v1)
 tags:
  - how-to
  - platform-wide
+page_type: how-to
 ---
 
-<Admonition type="warning">
-This document describes Managed Updates for Agents v1, which
-is a legacy system that may be removed in future versions of Teleport.
-
-For Managed Updates v2 instructions, see [Managed Updates for
-Agents (v2)](./agent-managed-updates/agent-managed-updates.mdx).
-</Admonition>
+In this guide, you will enable Managed Updates for Agents v1, which is a legacy
+system that may be removed in future versions of Teleport. For Managed Updates
+v2 instructions, see [Managed Updates for Agents
+(v2)](./agent-managed-updates/agent-managed-updates.mdx).
 
 Managed Updates v1 uses a script called `teleport-upgrade` that is provided by
 the `teleport-ent-updater` package and configured by the `cluster_maintenance_config`

--- a/docs/pages/upgrading/agent-managed-updates/agent-managed-updates.mdx
+++ b/docs/pages/upgrading/agent-managed-updates/agent-managed-updates.mdx
@@ -4,15 +4,15 @@ description: Describes how to set up Managed Updates for Teleport Agents and Bot
 tags:
   - conceptual
   - platform-wide
+page_type: conceptual
 ---
 
-<Admonition type="warning">
-This document describes Managed Updates for Agents and Bots (v2),
-which replaces Managed Updates for Agents (v1).
+This document describes the common operations you can perform with Managed
+Updates for Agents and Bots (v2), which replaces Managed Updates for Agents
+(v1).
 
 For Managed Updates v1 instructions, see
 [Managed Updates for Agents (v1)](../agent-managed-updates-v1.mdx).
-</Admonition>
 
 For Managed Updates, a binary called `teleport-update` is distributed in
 all Teleport packages, alongside the `teleport`, `tbot`, and other binaries.

--- a/docs/pages/upgrading/agent-managed-updates/bootstrap-ec2-agent.mdx
+++ b/docs/pages/upgrading/agent-managed-updates/bootstrap-ec2-agent.mdx
@@ -3,10 +3,12 @@ title: Managed Updates v2 in EC2 Agents
 description: Describes how to set up EC2 instance by cloud-init script and install Teleport with "teleport-update enable"
 tags:
  - how-to
+page_type: how-to
 ---
 
-This guide shows two cloud-init patterns for bringing Linux EC2 instances under Managed Updates v2
-and assigning them to an update group using `teleport-update` by defining the group and proxy address.
+This guide shows you how to use two cloud-init patterns for bringing Linux EC2
+instances under Managed Updates v2 and assigning them to an update group using
+`teleport-update` by defining the group and proxy address.
 
 ## How it works
 

--- a/docs/pages/upgrading/client-tools-managed-updates.mdx
+++ b/docs/pages/upgrading/client-tools-managed-updates.mdx
@@ -4,9 +4,10 @@ description: Explains how to use Teleport client tools (`tsh` and `tctl`) manage
 tags:
  - conceptual
  - platform-wide
+page_type: conceptual
 ---
 
-This documentation explains how to keep Teleport client tools like `tsh` and `tctl` up-to-date.
+This page describes how to keep Teleport client tools like `tsh` and `tctl` up-to-date.
 Updates can be managed by cluster or self-managed, ensuring tools are secure, free from bugs,
 and compatible with your Teleport cluster.
 

--- a/docs/pages/upgrading/cloud-cluster-updates.mdx
+++ b/docs/pages/upgrading/cloud-cluster-updates.mdx
@@ -4,11 +4,16 @@ description: Provides a high-level overview of Teleport cluster updates on Cloud
 tags:
  - conceptual
  - platform-wide
+page_type: conceptual
 ---
 
 On Teleport Enterprise (Cloud) clusters, the Auth Service and Proxy Service are automatically
 kept up to date with patches and minor releases following the release schedule
 described in [Teleport Upcoming Releases](../upcoming-releases.mdx).
+
+This page describes the functionality of Teleport Cloud cluster updates.
+
+## When updates take place
 
 - Major version updates for the cluster typically occur one month after the
 release of a new major version. Minor version updates and patches occur more regularly.

--- a/docs/pages/upgrading/overview.mdx
+++ b/docs/pages/upgrading/overview.mdx
@@ -5,14 +5,15 @@ sidebar_position: 1
 tags:
  - conceptual
  - platform-wide
+page_type: conceptual
 ---
 
 Since Teleport is a distributed system with a number of services that run on
 potentially many hosts, you should take care when upgrading the cluster to
 ensure that all components remain compatible.
 
-This guide provides an overview of how to upgrade the components in your
-Teleport cluster while preserving compatibility.
+This guide describes how to upgrade the components in your Teleport cluster n
+different scenarios while preserving compatibility between them.
 
 ## Component compatibility
 

--- a/docs/pages/upgrading/upgrading.mdx
+++ b/docs/pages/upgrading/upgrading.mdx
@@ -4,6 +4,7 @@ description: Explains how to upgrade Teleport depending on your environment and 
 tags:
  - conceptual
  - platform-wide
+page_type: landing
 ---
 
 The guides in this section show you how to upgrade Teleport to a more recent


### PR DESCRIPTION
We are standardizing docs guides to add a `page_type` frontmatter field, with values for how-to guides, references, etc. We can then use this field to apply linting rules that ensure each guide type follows type-specific docs site conventions. The first convention is that each docs page must have an outcome statement, the structure of which depends on the guide's type. Human and AI agent readers can determine from the outcome statement whether to continue reading the guide or not.

This change assigns the `page_type` frontmatter field to 47 guides.  Where an outcome statement is missing or incorrect, this change adds or corrects it. Changes include:
- Landing pages: added `page_type: landing`, with no outcome statement required
- Guides with entirely new outcome statements
- Already-compliant guides: intro paragraphs already matched the required pattern, so this adds `page_type` only
- Editing outcome statements to use compliant phrasing: a sentence in the introduction mostly matched the expected pattern, but required a small phrasing change