### PR TITLE
Remove unused comment in access-plugin helm charts

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.access-datadog.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-datadog.mdx
@@ -295,7 +295,6 @@ put on the `Pod` resources created by the chart.
 
 `annotations.secret` contains the Kubernetes annotations
 put on the `Secret` resource created by the chart.
-This has no effect when `joinTokenSecret.create` is `false`.
 
 ## `image`
 

--- a/docs/pages/includes/helm-reference/zz_generated.access-discord.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-discord.mdx
@@ -260,7 +260,6 @@ put on the `Pod` resources created by the chart.
 
 `annotations.secret` contains the Kubernetes annotations
 put on the `Secret` resource created by the chart.
-This has no effect when `joinTokenSecret.create` is `false`.
 
 ## `image`
 

--- a/docs/pages/includes/helm-reference/zz_generated.access-email.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-email.mdx
@@ -380,7 +380,6 @@ put on the `Pod` resources created by the chart.
 
 `annotations.secret` contains the Kubernetes annotations
 put on the `Secret` resource created by the chart.
-This has no effect when `joinTokenSecret.create` is `false`.
 
 ## `image`
 

--- a/docs/pages/includes/helm-reference/zz_generated.access-jira.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-jira.mdx
@@ -328,7 +328,6 @@ put on the `Pod` resources created by the chart.
 
 `annotations.secret` contains the Kubernetes annotations
 put on the `Secret` resource created by the chart.
-This has no effect when `joinTokenSecret.create` is `false`.
 
 ### `annotations.service`
 

--- a/docs/pages/includes/helm-reference/zz_generated.access-mattermost.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-mattermost.mdx
@@ -256,7 +256,6 @@ put on the `Pod` resources created by the chart.
 
 `annotations.secret` contains the Kubernetes annotations
 put on the `Secret` resource created by the chart.
-This has no effect when `joinTokenSecret.create` is `false`.
 
 ## `image`
 

--- a/docs/pages/includes/helm-reference/zz_generated.access-msteams.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-msteams.mdx
@@ -292,7 +292,6 @@ put on the `Pod` resources created by the chart.
 
 `annotations.secret` contains the Kubernetes annotations
 put on the `Secret` resource created by the chart.
-This has no effect when `joinTokenSecret.create` is `false`.
 
 ## `image`
 

--- a/docs/pages/includes/helm-reference/zz_generated.access-pagerduty.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-pagerduty.mdx
@@ -248,7 +248,6 @@ put on the `Pod` resources created by the chart.
 
 `annotations.secret` contains the Kubernetes annotations
 put on the `Secret` resource created by the chart.
-This has no effect when `joinTokenSecret.create` is `false`.
 
 ## `image`
 

--- a/docs/pages/includes/helm-reference/zz_generated.access-slack.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-slack.mdx
@@ -349,7 +349,6 @@ put on the `Pod` resources created by the chart.
 
 `annotations.secret` contains the Kubernetes annotations
 put on the `Secret` resource created by the chart.
-This has no effect when `joinTokenSecret.create` is `false`.
 
 ## `image`
 

--- a/examples/chart/access/datadog/values.yaml
+++ b/examples/chart/access/datadog/values.yaml
@@ -162,7 +162,6 @@ annotations:
   pod: {}
   # annotations.secret(object) -- contains the Kubernetes annotations
   # put on the `Secret` resource created by the chart.
-  # This has no effect when `joinTokenSecret.create` is `false`.
   secret: {}
 
 #

--- a/examples/chart/access/discord/values.yaml
+++ b/examples/chart/access/discord/values.yaml
@@ -158,7 +158,6 @@ annotations:
   pod: {}
   # annotations.secret(object) -- contains the Kubernetes annotations
   # put on the `Secret` resource created by the chart.
-  # This has no effect when `joinTokenSecret.create` is `false`.
   secret: {}
 
 #

--- a/examples/chart/access/email/values.yaml
+++ b/examples/chart/access/email/values.yaml
@@ -204,7 +204,6 @@ annotations:
   pod: {}
   # annotations.secret(object) -- contains the Kubernetes annotations
   # put on the `Secret` resource created by the chart.
-  # This has no effect when `joinTokenSecret.create` is `false`.
   secret: {}
 
 #

--- a/examples/chart/access/jira/values.yaml
+++ b/examples/chart/access/jira/values.yaml
@@ -182,7 +182,6 @@ annotations:
   pod: {}
   # annotations.secret(object) -- contains the Kubernetes annotations
   # put on the `Secret` resource created by the chart.
-  # This has no effect when `joinTokenSecret.create` is `false`.
   secret: {}
   # annotations.service(object) -- contains the Kubernetes annotations
   # put on the `Service` resource created by the chart.

--- a/examples/chart/access/mattermost/values.yaml
+++ b/examples/chart/access/mattermost/values.yaml
@@ -148,7 +148,6 @@ annotations:
   pod: {}
   # annotations.secret(object) -- contains the Kubernetes annotations
   # put on the `Secret` resource created by the chart.
-  # This has no effect when `joinTokenSecret.create` is `false`.
   secret: {}
 
 #

--- a/examples/chart/access/msteams/values.yaml
+++ b/examples/chart/access/msteams/values.yaml
@@ -172,7 +172,6 @@ annotations:
   pod: {}
   # annotations.secret(object) -- contains the Kubernetes annotations
   # put on the `Secret` resource created by the chart.
-  # This has no effect when `joinTokenSecret.create` is `false`.
   secret: {}
 
 #

--- a/examples/chart/access/pagerduty/values.yaml
+++ b/examples/chart/access/pagerduty/values.yaml
@@ -145,7 +145,6 @@ annotations:
   pod: {}
   # annotations.secret(object) -- contains the Kubernetes annotations
   # put on the `Secret` resource created by the chart.
-  # This has no effect when `joinTokenSecret.create` is `false`.
   secret: {}
 
 #

--- a/examples/chart/access/slack/values.yaml
+++ b/examples/chart/access/slack/values.yaml
@@ -210,7 +210,6 @@ annotations:
   pod: {}
   # annotations.secret(object) -- contains the Kubernetes annotations
   # put on the `Secret` resource created by the chart.
-  # This has no effect when `joinTokenSecret.create` is `false`.
   secret: {}
 
 #


### PR DESCRIPTION
The field `joinTokenSecret.create` only exists for `teleport-kube-agent` Helm chart.

For brevity we can simply remove this comment even if secrets (eg. api tokens) are not created by the `access-plugin` charts.