### PR TITLE
[v18] Add page_type and outcome statements to 44 guides

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/reference.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/reference.mdx
@@ -6,12 +6,15 @@ tags:
  - reference
  - zero-trust
  - infrastructure-identity
+page_type: reference
 ---
 
 Kubernetes Application Discovery involves the Teleport Discovery Service,
-Teleport Application Service, and annotations on Kubernetes services. This guide
-shows you how to configure each of these to manage Kubernetes Application
-Discovery in your Kubernetes cluster.
+Teleport Application Service, and annotations on Kubernetes services. 
+
+This page lists the Teleport configuration options and Kubernetes annotations
+that you can use to configure Kubernetes Application Discovery in your
+Kubernetes cluster.
 
 ## Configuring Teleport Agent Helm chart
 

--- a/docs/pages/enroll-resources/desktop-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/desktop-access/getting-started.mdx
@@ -7,10 +7,11 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
-This guide demonstrates how to configure Teleport to provide secure, passwordless access
-to Microsoft Windows desktops for local Windows users.
+In this guide, you will configure Teleport to provide secure, passwordless
+access to Microsoft Windows desktops for local Windows users.
 
 Passwordless access for local users is limited to 5 desktops in Teleport Community Edition.
 

--- a/docs/pages/enroll-resources/desktop-access/introduction.mdx
+++ b/docs/pages/enroll-resources/desktop-access/introduction.mdx
@@ -7,6 +7,7 @@ tags:
  - conceptual
  - zero-trust
  - privileged-access
+page_type: conceptual
 ---
 
 You can configure Teleport to provide secure, passwordless access to Microsoft

--- a/docs/pages/enroll-resources/desktop-access/reference/user-creation.mdx
+++ b/docs/pages/enroll-resources/desktop-access/reference/user-creation.mdx
@@ -5,10 +5,14 @@ tags:
  - conceptual
  - zero-trust
  - infrastructure-identity
+page_type: conceptual
 ---
 
 Teleport's Desktop Service can be configured to automatically create local
 Windows users upon login.
+
+This page describes the configuration options for automatic user creation on
+Teleport-protected Windows desktops.
 
 ## Configuration
 

--- a/docs/pages/enroll-resources/mcp-access/integration-guides/aws-bedrock-gateway.mdx
+++ b/docs/pages/enroll-resources/mcp-access/integration-guides/aws-bedrock-gateway.mdx
@@ -6,6 +6,7 @@ tags:
 - how-to
 - mcp
 - zero-trust
+page_type: how-to
 ---
 
 (!docs/pages/includes/mcp-access/integration-intro.mdx serviceName="Amazon Bedrock AgentCore Gateway" !)

--- a/docs/pages/enroll-resources/mcp-access/integration-guides/github.mdx
+++ b/docs/pages/enroll-resources/mcp-access/integration-guides/github.mdx
@@ -6,6 +6,7 @@ tags:
 - how-to
 - mcp
 - zero-trust
+page_type: how-to
 ---
 
 (!docs/pages/includes/mcp-access/integration-intro.mdx serviceName="GitHub" !)

--- a/docs/pages/enroll-resources/mcp-access/integration-guides/notion.mdx
+++ b/docs/pages/enroll-resources/mcp-access/integration-guides/notion.mdx
@@ -6,6 +6,7 @@ tags:
 - how-to
 - mcp
 - zero-trust
+page_type: how-to
 ---
 
 (!docs/pages/includes/mcp-access/integration-intro.mdx serviceName="Notion" !)

--- a/docs/pages/enroll-resources/mcp-access/rbac.mdx
+++ b/docs/pages/enroll-resources/mcp-access/rbac.mdx
@@ -7,6 +7,7 @@ tags:
 - conceptual
 - mcp
 - zero-trust
+page_type: conceptual
 ---
 
 <Callout
@@ -22,6 +23,9 @@ tags:
 
 You can use Teleport's role-based access control (RBAC) system to set up
 granular permissions for authenticating to MCP servers connected to Teleport.
+This page describes the available Teleport role options for configuring MCP
+access controls, including template variables you can use in MCP-related role
+options.
 
 ## Role configuration
 

--- a/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
@@ -6,7 +6,6 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
-page_type: how-to
 ---
 
 Teleport's SSH Service can be configured to automatically create local Unix users

--- a/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
@@ -6,11 +6,12 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
-In this guide, we will show you how to configure the OpenSSH server `sshd` to
-join a Teleport cluster. Existing fleets of OpenSSH servers can be configured to
-accept SSH certificates dynamically issued by a Teleport CA.
+In this guide, you will configure the OpenSSH server `sshd` to join a Teleport
+cluster. Existing fleets of OpenSSH servers can be configured to accept SSH
+certificates dynamically issued by a Teleport CA.
 
 Using Teleport and OpenSSH has the advantage of getting you up
 and running, but in the long run, we would recommend replacing `sshd` with `teleport`.

--- a/docs/pages/identity-governance/integrations/okta/okta.mdx
+++ b/docs/pages/identity-governance/integrations/okta/okta.mdx
@@ -8,6 +8,7 @@ tags:
  - identity-governance
  - privileged-access
 enterprise: Identity Governance
+page_type: how-to
 ---
 
 The Teleport Okta integration can import and grant access to resources from an
@@ -16,7 +17,7 @@ provision user accounts based Okta users, Okta applications can be accessed
 through Teleport's application access UI, and access to these applications along
 with user groups can be managed by Teleport's RBAC along with Access Requests.
 
-This guide shows you how to set up the Teleport Okta integration.
+In this guide, you will set up the Teleport Okta integration.
 
 ## How it works
 

--- a/docs/pages/installation/self-hosted/helm-deployments/aws.mdx
+++ b/docs/pages/installation/self-hosted/helm-deployments/aws.mdx
@@ -6,9 +6,10 @@ tags:
  - how-to
  - platform-wide
  - aws
+page_type: how-to
 ---
 
-In this guide, we'll use Teleport Helm charts to set up a high-availability
+In this guide, you will use Teleport Helm charts to set up a high-availability
 Teleport cluster that runs on AWS EKS.
 
 (!docs/pages/includes/cloud/call-to-action.mdx!)

--- a/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
+++ b/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
@@ -5,10 +5,11 @@ description: Cloud security, availability, and networking details.
 tags:
  - conceptual
  - platform-wide
+page_type: conceptual
 ---
 
-This guide describes architectural features of Teleport Enterprise (Cloud). In
-general, Teleport Enterprise (Cloud) includes managed deployments of the
+This page describes the architectural features of Teleport Enterprise (Cloud).
+In general, Teleport Enterprise (Cloud) includes managed deployments of the
 Teleport Auth Service and Teleport Proxy Service. Read on for information about
 topics like High Availability, deployment regions, and data retention.
 

--- a/docs/pages/reference/helm-reference/teleport-operator.mdx
+++ b/docs/pages/reference/helm-reference/teleport-operator.mdx
@@ -6,6 +6,7 @@ tags:
  - infrastructure-as-code
  - reference
  - zero-trust
+page_type: reference
 ---
 
 The `teleport-operator` Helm chart deploys the Teleport Kubernetes Operator.
@@ -13,6 +14,9 @@ When deployed via the chart, the operator can join Teleport clusters living in
 Kubernetes or remote ones (such as Teleport Cloud).
 See the [Kubernetes Operator for remote Teleport clusters guide](../../configuration/teleport-operator/teleport-operator-standalone.mdx)
 for more details.
+
+This page lists the values you can configure in the `teleport-operator` Helm
+chart.
 
 You can
 [browse the source on GitHub](https://github.com/gravitational/teleport/tree/branch/v(=teleport.major_version=)/examples/chart/teleport-cluster/charts/teleport-operator).

--- a/docs/pages/reference/machine-workload-identity/workload-identity/attributes.mdx
+++ b/docs/pages/reference/machine-workload-identity/workload-identity/attributes.mdx
@@ -6,6 +6,7 @@ tags:
  - reference
  - mwi
  - infrastructure-identity
+page_type: reference
 ---
 
 Attributes are features of an identity which you can use with the
@@ -15,6 +16,9 @@ and template values.
 These attributes come from a variety of sources, such as workload attestations
 performed by `tbot` or the attestation performed by the control plane when
 `tbot` joins.
+
+This page lists the attributes that Workload Identity supports, categorized by
+source.
 
 ## Join attributes
 

--- a/docs/pages/zero-trust-access/authentication/authentication.mdx
+++ b/docs/pages/zero-trust-access/authentication/authentication.mdx
@@ -3,6 +3,7 @@ title: Authentication and Session Joining
 description: Provides information on configuring the way users authenticate to your Teleport cluster or join an existing session.
 sidebar_position: 3
 template: "no-toc"
+page_type: landing
 tags:
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/authentication/browser-mfa.mdx
+++ b/docs/pages/zero-trust-access/authentication/browser-mfa.mdx
@@ -5,6 +5,7 @@ tags:
  - how-to
  - zero-trust
  - privileged-access
+page_type: how-to
 ---
 
 Browser MFA enables users of `tsh`, `tctl`, and Teleport Connect to complete
@@ -27,6 +28,9 @@ $ tsh mfa add --mfa-mode=browser
 # Edit a Teleport resource
 $ tctl edit --mfa-mode=browser cluster_auth_preference
 ```
+
+In this guide, you will enable browser MFA on your Teleport cluster and use a
+browser to authenticate your user to Teleport.
 
 ## How it works
 

--- a/docs/pages/zero-trust-access/authentication/hardware-key-support.mdx
+++ b/docs/pages/zero-trust-access/authentication/hardware-key-support.mdx
@@ -6,10 +6,11 @@ tags:
  - zero-trust
  - privileged-access
 enterprise: Hardware key support
+page_type: how-to
 ---
 
-This guide explains how to configure Teleport authentication using
-hardware-based private keys.
+In this guide, you will configure Teleport authentication using hardware-based
+private keys.
 
 ## How it works
 

--- a/docs/pages/zero-trust-access/authentication/headless.mdx
+++ b/docs/pages/zero-trust-access/authentication/headless.mdx
@@ -5,6 +5,7 @@ tags:
  - how-to
  - zero-trust
  - privileged-access
+page_type: how-to
 ---
 
 Headless Authentication provides a secure way to authenticate with Teleport on
@@ -27,6 +28,9 @@ For example:
 
   In the future, Headless Authentication will be extended to other `tsh` commands.
 </Admonition>
+
+In this guide, you will enable headless authentication on your cluster and go
+through a headless authentication flow.
 
 ## How it works
 

--- a/docs/pages/zero-trust-access/authentication/impersonation.mdx
+++ b/docs/pages/zero-trust-access/authentication/impersonation.mdx
@@ -5,6 +5,7 @@ description: How to issue short-lived certs on behalf of Teleport users using im
 tags:
  - how-to
  - zero-trust
+page_type: how-to
 ---
 
 Sometimes users need to create short-lived certificates for non-interactive
@@ -12,8 +13,8 @@ users, for example, CI/CD systems. Your programs interacting with Teleport may
 need to create their own authentication as well. Teleport's impersonation allows
 users and robots to create short-lived certs for other users and roles.
 
-Let's explore how interactive user Alice can create credentials for a
-non-interactive CI/CD user Jenkins and a security scanner.
+In this guide, you will set up Teleport so user Alice can create credentials for
+a non-interactive CI/CD user Jenkins and a security scanner.
 
 ## How it works
 

--- a/docs/pages/zero-trust-access/authentication/passwordless.mdx
+++ b/docs/pages/zero-trust-access/authentication/passwordless.mdx
@@ -2,6 +2,7 @@
 title: "Passwordless"
 description: Learn how to use passwordless authentication with Teleport.
 videoBanner: GA37qqB6Lmk
+page_type: how-to
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/zero-trust-access/device-trust/device-trust.mdx
+++ b/docs/pages/zero-trust-access/device-trust/device-trust.mdx
@@ -2,6 +2,7 @@
 title: Device Trust
 description: Teleport Device Trust Concepts
 template: "no-toc"
+page_type: landing
 videoBanner: gBQyj_X1LVw
 sidebar_position: 4
 tags:

--- a/docs/pages/zero-trust-access/device-trust/guide.mdx
+++ b/docs/pages/zero-trust-access/device-trust/guide.mdx
@@ -8,6 +8,7 @@ tags:
  - zero-trust
  - resiliency
 enterprise: Device Trust
+page_type: how-to
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/zero-trust-access/export-audit-events/event-handler-setup.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/event-handler-setup.mdx
@@ -9,9 +9,10 @@ tags:
  - audit
  - mwi
  - infrastructure-identity
+page_type: how-to
 ---
 
-In this guide, we will set up the Teleport Event Handler plugin with credentials
+In this guide, you will set up the Teleport Event Handler plugin with credentials
 to authenticate to the Teleport Auth Service and access the events API.
 
 ## How it works

--- a/docs/pages/zero-trust-access/management/management.mdx
+++ b/docs/pages/zero-trust-access/management/management.mdx
@@ -2,6 +2,7 @@
 title: Cluster Management
 description: "Guides for performing day-two operations on your Teleport cluster."
 template: "no-toc"
+page_type: landing
 tags:
  - platform-wide
 ---

--- a/docs/pages/zero-trust-access/rbac-get-started/users.mdx
+++ b/docs/pages/zero-trust-access/rbac-get-started/users.mdx
@@ -1,6 +1,7 @@
 ---
 title: Local Users
 description: Learn how to manage local users in Teleport. Local users are stored on the Auth Service instead of a third-party identity provider.
+page_type: how-to
 tags:
  - conceptual
  - zero-trust

--- a/docs/pages/zero-trust-access/sso/integrate-idp/adfs.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/adfs.mdx
@@ -8,11 +8,12 @@ tags:
  - zero-trust
  - privileged-access
 enterprise: Enterprise SSO
+page_type: how-to
 ---
 
-This guide will explain how to configure Active Directory Federation Services
-([ADFS](https://en.wikipedia.org/wiki/Active_Directory_Federation_Services)) to be
-a single sign-on (SSO) provider to issue login credentials to specific groups
+In this guide, you will configure Active Directory Federation Services
+([ADFS](https://en.wikipedia.org/wiki/Active_Directory_Federation_Services)) to
+be a single sign-on (SSO) provider to issue login credentials to specific groups
 of users. When used in combination with role based access control (RBAC), it
 allows Teleport administrators to define policies like:
 

--- a/docs/pages/zero-trust-access/sso/integrate-idp/entra-id-oidc.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/entra-id-oidc.mdx
@@ -8,12 +8,14 @@ tags:
  - privileged-access
  - azure
 enterprise: Enterprise SSO
+page_type: how-to
 ---
 
-This guide shows how to configure Microsoft Entra ID (formerly Azure AD) as an
+In this guide, you will configure Microsoft Entra ID (formerly Azure AD) as an
 OIDC identity provider for Teleport. With this configuration, users can access
 Teleport by authenticating with Entra ID, and be granted with permissions to
-access or manage resource in Teleport based on their group membership in Entra ID.
+access or manage resource in Teleport based on their group membership in Entra
+ID.
 
 A SAML-based Entra ID IdP configuration version is available in this [guide](entra-id.mdx).
 

--- a/docs/pages/zero-trust-access/sso/integrate-idp/entra-id.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/entra-id.mdx
@@ -9,9 +9,10 @@ tags:
  - privileged-access
  - azure
 enterprise: Enterprise SSO
+page_type: how-to
 ---
 
-This guide will cover how to configure Microsoft Entra ID (formerly Azure AD) as
+In this guide, you will configure Microsoft Entra ID (formerly Azure AD) as
 a SAML identity provider to issue credentials to specific groups of users with 
 a SAML Authentication Connector. When used in combination with role-based access 
 control (RBAC), it allows Teleport administrators to define policies like:

--- a/docs/pages/zero-trust-access/sso/integrate-idp/github-sso.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/github-sso.mdx
@@ -8,9 +8,10 @@ tags:
  - how-to
  - zero-trust
  - privileged-access
+page_type: how-to
 ---
 
-This guide explains how to set up GitHub Single Sign On (SSO) so you can
+In this guide, you will set up GitHub Single Sign On (SSO) so you can
 automatically map teams in your GitHub organization to users and roles in
 Teleport.
 

--- a/docs/pages/zero-trust-access/sso/integrate-idp/gitlab.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/gitlab.mdx
@@ -8,12 +8,12 @@ tags:
  - zero-trust
  - privileged-access
 enterprise: Enterprise SSO
+page_type: how-to
 ---
 
-This guide will cover how to configure [GitLab](https://www.gitlab.com/) to issue
+In this guide, you will configure [GitLab](https://www.gitlab.com/) to issue
 credentials to specific groups of users. When used in combination with role
-based access control (RBAC), it allows administrators to define policies
-like:
+based access control (RBAC), it allows administrators to define policies like:
 
 - Only members of the "DBA" group can access PostgreSQL databases.
 - Only members of "ProductionKubernetes" can access production Kubernetes clusters

--- a/docs/pages/zero-trust-access/sso/integrate-idp/google-workspace.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/google-workspace.mdx
@@ -10,12 +10,14 @@ tags:
  - privileged-access
  - google-cloud
 enterprise: Enterprise SSO
+page_type: how-to
 ---
 
-This guide explains how to configure [Google Workspace](https://workspace.google.com/)
-to be a single sign-on (SSO) provider that issues Teleport credentials to specific
-groups of users. When you use Google Workspace in combination with Teleport role-based
-access control (RBAC), you can define policies like the following:
+In this guide, you will configure [Google
+Workspace](https://workspace.google.com/) to be a single sign-on (SSO) provider
+that issues Teleport credentials to specific groups of users. When you use
+Google Workspace in combination with Teleport role-based access control (RBAC),
+you can define policies like the following:
 
 - Only members of the "DBA" Google group can connect to PostgreSQL databases.
 - Developers must never use SSH to access production servers.

--- a/docs/pages/zero-trust-access/sso/integrate-idp/integrate-idp.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/integrate-idp.mdx
@@ -2,6 +2,7 @@
 title: Integrate your Identity Provider with Teleport
 sidebar_label: Integrate your Provider
 description: Configure user authentication to Teleport through your identity provider.
+page_type: landing
 ---
 
 import Resources from "@site/src/components/Pages/Homepage/Resources";

--- a/docs/pages/zero-trust-access/sso/integrate-idp/keycloak.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/keycloak.mdx
@@ -8,12 +8,13 @@ tags:
  - zero-trust
  - privileged-access
 enterprise: Enterprise SSO
+page_type: how-to
 ---
 
-This guide explains how to configure Keycloak to issue
-credentials to specific groups of users with a SAML authentication connector.
-When used in combination with role-based access control (RBAC), it allows Teleport
-administrators to define policies like:
+In this guide, you will configure Keycloak to issue credentials to specific
+groups of users with a SAML authentication connector.  When used in combination
+with role-based access control (RBAC), it allows Teleport administrators to
+define policies like:
 
 - Only members of the "DBA" group can connect to PostgreSQL databases.
 - Developers must never SSH into production servers.

--- a/docs/pages/zero-trust-access/sso/integrate-idp/oidc.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/oidc.mdx
@@ -8,12 +8,13 @@ tags:
  - zero-trust
  - privileged-access
 enterprise: Enterprise SSO
+page_type: how-to
 ---
 
-This guide will explain how to configure an SSO provider using [OpenID
+In this guide, you will configure an SSO provider using [OpenID
 Connect](http://openid.net/connect/) (also known as OIDC) to issue Teleport
-credentials to specific groups of users. When used in combination with role-based
-access control (RBAC), OIDC allows Teleport administrators to define
+credentials to specific groups of users. When used in combination with
+role-based access control (RBAC), OIDC allows Teleport administrators to define
 policies like:
 
 - Only members of the "DBA" group can connect to PostgreSQL databases.

--- a/docs/pages/zero-trust-access/sso/integrate-idp/okta.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/okta.mdx
@@ -7,12 +7,13 @@ tags:
  - how-to
  - zero-trust
  - privileged-access
+page_type: how-to
 ---
 
-This guide covers how to configure [Okta](https://www.okta.com/) to provide
+In this guide, you will configure [Okta](https://www.okta.com/) to provide
 single sign on (SSO) identities to Teleport Enterprise and Teleport Enterprise
-Cloud. When used in combination with role-based access control (RBAC), this allows
-Teleport administrators to define policies like:
+Cloud. When used in combination with role-based access control (RBAC), this
+allows Teleport administrators to define policies like:
 
 - Only members of the "DBA" group can access PostgreSQL databases.
 - Developers must never SSH into production servers.

--- a/docs/pages/zero-trust-access/sso/integrate-idp/one-login.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/one-login.mdx
@@ -8,15 +8,16 @@ tags:
  - zero-trust
  - privileged-access
 enterprise: Enterprise SSO
+page_type: how-to
 ---
 
 import SquareIcon from "@version/docs/img/sso/onelogin/teleport.png"
 import RectangleIcon from "@version/docs/img/sso/onelogin/teleportlogo@2x.png"
 
-This guide will explain how to configure [OneLogin](https://www.onelogin.com/)
-to issue Teleport credentials to specific groups of users. When used in
-combination with role based access control (RBAC) it allows SSH administrators
-to define policies like:
+In this guide, you will configure [OneLogin](https://www.onelogin.com/) to issue
+Teleport credentials to specific groups of users. When used in combination with
+role based access control (RBAC) it allows SSH administrators to define policies
+like:
 
 - Only members of "DBA" group can connect to PostgreSQL databases.
 - Developers must never SSH into production servers.

--- a/docs/pages/zero-trust-access/sso/login-rules/guide.mdx
+++ b/docs/pages/zero-trust-access/sso/login-rules/guide.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - privileged-access
+page_type: how-to
 ---
 
 Login Rules define logic that transforms the external traits of a user who signs
@@ -15,8 +16,8 @@ in user traits without requiring changes in their IdP configuration. This is
 particularly useful if the team that manages an organization's identity provider
 (IdP) is separate from the team that manages Teleport.
 
-This guide walks you through the process of writing, testing, and adding the
-first Login Rule to your Teleport cluster. 
+In this guide, you will write, test, and create the first Login Rule in your
+Teleport cluster. 
 
 ## How it works
 

--- a/docs/pages/zero-trust-access/sso/login-rules/login-rules.mdx
+++ b/docs/pages/zero-trust-access/sso/login-rules/login-rules.mdx
@@ -4,15 +4,19 @@ description: Transform User Traits with Login Rules
 template: "no-toc"
 tags:
  - sso
- - how-to
+ - conceptual
  - zero-trust
  - privileged-access
+page_type: conceptual
 ---
 
 When users log in to your Teleport cluster with a configured SSO provider,
 **Login Rules** can transform the traits provided by your IdP to meet your needs
 for configuring access within Teleport.
 Login Rules are a feature of Teleport Enterprise.
+
+This page describes the key concepts surrounding Login Rules and provides
+answers to frequently asked questions.
 
 Some use cases for Login Rules are:
 

--- a/docs/pages/zero-trust-access/sso/multiple-providers.mdx
+++ b/docs/pages/zero-trust-access/sso/multiple-providers.mdx
@@ -3,14 +3,15 @@ title: Working with Multiple Identity Providers
 sidebar_label: Multiple Identity Providers
 sidebar_position: 2
 description: Provides guidance on integrating Teleport with multiple identity providers.
+page_type: conceptual
 ---
 
 Teleport allows you to create and manage multiple authentication connectors, so
 you can centralize authentication and access controls in your organization's
 infrastructure even if your organization uses several identity providers.
 
-This guide explains how you can work with multiple identity providers in
-Teleport.
+This page describes the options Teleport provides for managing multiple
+identity providers in Teleport.
 
 ## Managing authentication connector resources
 

--- a/docs/pages/zero-trust-access/sso/saml-cert-rotation.mdx
+++ b/docs/pages/zero-trust-access/sso/saml-cert-rotation.mdx
@@ -7,6 +7,7 @@ tags:
  - sso
  - how-to
 enterprise: Enterprise SSO
+page_type: conceptual
 ---
 
 SAML signing certificates are used by the identity provider to sign SAML assertions, 
@@ -14,6 +15,11 @@ and Teleport verifies the signature to authenticate users. Certificates have a f
 validity period, after which they expire, and SSO will no longer work. The default lifetime
 for these certificates is set by the identity provider, for example Entra ID (3 years)
 or Okta (10 years).
+
+This page describes the features Teleport provides for rotating SAML signing
+certificates.
+
+## Expiration alerts
 
 When a signing certificate is expiring or expired, Teleport raises a cluster alert with
 details about the certificate that needs to be rotated.

--- a/docs/pages/zero-trust-access/sso/sso-for-mfa.mdx
+++ b/docs/pages/zero-trust-access/sso/sso-for-mfa.mdx
@@ -2,12 +2,13 @@
 title: Configuring SSO for MFA Checks
 sidebar_label: SSO For MFA Checks
 description: Explains how to set up an authentication connector to delegate multi-factor authentication to your identity provider.
+page_type: how-to
 ---
 
 Teleport administrators can configure Teleport to delegate multi-factor
 authentication checks to a single sign-on provider as an alternative to
-registering MFA devices directly with the Teleport cluster. This guide explains
-how to configure SSO for MFA checks.  
+registering MFA devices directly with the Teleport cluster. In this guide, you
+will configure SSO for MFA checks in your cluster.
 
 SSO for MFA checks allows Teleport users to use MFA devices and custom flows
 configured in the SSO provider to carry out privileged actions in Teleport, such

--- a/docs/pages/zero-trust-access/sso/sso.mdx
+++ b/docs/pages/zero-trust-access/sso/sso.mdx
@@ -8,6 +8,7 @@ tags:
  - conceptual
  - zero-trust
  - privileged-access
+page_type: conceptual
 ---
 
 Users can log in to Teleport through your organization's single sign-on (SSO)
@@ -15,7 +16,7 @@ provider. You can centralize the way your infrastructure authenticates,
 authorizes, and audits users who want to access it, while also keeping your
 organization's existing processes for managing users.
 
-This guide explains key concepts related to Teleport single sign-on
+This page describes the key concepts related to Teleport single sign-on
 integrations.
 
 <Admonition type="tip">


### PR DESCRIPTION
Backports #68050

We are standardizing docs guides to add a `page_type` frontmatter field, with values for how-to guides, references, etc. We can then use this field to apply linting rules that ensure each guide type follows type-specific docs site conventions. The first convention is that each docs page must have an outcome statement, the structure of which depends on the guide's type. Human and AI agent readers can determine from the outcome statement whether to continue reading the guide or not.

This change assigns the page_type frontmatter field to 44 guides in the enroll-resources section of the docs. Where an outcome statement is missing or incorrect, this change adds or corrects it.
- 4 landing pages: added `page_type: landing`, with no outcome statement required
- 8 guides with entirely new outcome statements
- 8 already-compliant guides: intro paragraphs already matched the required pattern, so this added `page_type` only
- 24 phrasing fixes: a sentence in the introduction mostly matched the expected pattern, but required a one-word phrasing change