### PR TITLE
docs: Add event handler reference links to "Export Audit Events" guides

### DIFF
--- a/docs/pages/reference/deployment/monitoring/event-handler.mdx
+++ b/docs/pages/reference/deployment/monitoring/event-handler.mdx
@@ -18,6 +18,10 @@ event to Fluentd over mTLS, and persists the ID of each successfully sent event
 to local storage. If the plugin crashes or restarts, it resumes from the last
 confirmed event. By default, the plugin polls for new events every 10 seconds.
 
+To learn more about exporting Teleport audit events with the Event Handler,
+see the [Audit Event Export guides
+](../../../zero-trust-access/export-audit-events/export-audit-events.mdx).
+
 ## Configuration methods
 
 The Event Handler plugin accepts configuration from three sources:
@@ -212,6 +216,4 @@ See the following related topics:
 
 - [Teleport audit event reference](../../audit-events.mdx)
 - [Fluentd Documentation](https://docs.fluentd.org/)
-- [Exporting Teleport audit events with the Event Handler
-](../../../zero-trust-access/export-audit-events/export-audit-events.mdx)
 - [Teleport audit log architecture](../../deployment/monitoring/audit.mdx)

--- a/docs/pages/reference/deployment/monitoring/event-handler.mdx
+++ b/docs/pages/reference/deployment/monitoring/event-handler.mdx
@@ -7,8 +7,10 @@ keywords:
   - event handler
   - audit log
   - Fluentd
+tags:
+  - reference
+  - audit
 ---
-
 
 The **Event Handler** plugin exports Teleport audit events to a Fluentd
 service. The plugin retrieves events in configurable batches, forwards each
@@ -210,5 +212,6 @@ See the following related topics:
 
 - [Teleport audit event reference](../../audit-events.mdx)
 - [Fluentd Documentation](https://docs.fluentd.org/)
-- [Teleport plugin integrations](../../../identity-governance/access-requests/plugins/plugins.mdx)
+- [Exporting Teleport audit events with the Event Handler
+](../../../zero-trust-access/export-audit-events/export-audit-events.mdx)
 - [Teleport audit log architecture](../../deployment/monitoring/audit.mdx)

--- a/docs/pages/zero-trust-access/export-audit-events/datadog.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/datadog.mdx
@@ -160,7 +160,7 @@ Teleport Cluster, ensure that:
 file](https://github.com/DataDog/fluent-plugin-datadog/blob/master/README.md)
 to learn how to customize the log format entering Datadog.
 - To see all of the options you can set for the Teleport Event Handler binary,
-consult our [binary reference
+consult our [reference
 guide](../../reference/deployment/monitoring/event-handler.mdx).
 - To see all of the options you can set in the values file for the
 `teleport-plugin-event-handler` Helm chart, consult our [Helm chart reference

--- a/docs/pages/zero-trust-access/export-audit-events/datadog.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/datadog.mdx
@@ -159,6 +159,9 @@ Teleport Cluster, ensure that:
 - Review the Fluentd output plugin for Datadog [README
 file](https://github.com/DataDog/fluent-plugin-datadog/blob/master/README.md)
 to learn how to customize the log format entering Datadog.
+- To see all of the options you can set for the Teleport Event Handler binary,
+consult our [binary reference
+guide](../../reference/deployment/monitoring/event-handler.mdx).
 - To see all of the options you can set in the values file for the
-`teleport-plugin-event-handler` Helm chart, consult our [reference
+`teleport-plugin-event-handler` Helm chart, consult our [Helm chart reference
 guide](../../reference/helm-reference/teleport-plugin-event-handler.mdx).

--- a/docs/pages/zero-trust-access/export-audit-events/elastic-stack.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/elastic-stack.mdx
@@ -405,6 +405,9 @@ alerts.
 
 ## Further reading
 
-To see all of the options you can set in the values file for the
-`teleport-plugin-event-handler` Helm chart, consult our [reference
+- To see all of the options you can set for the Teleport Event Handler binary,
+consult our [binary reference
+guide](../../reference/deployment/monitoring/event-handler.mdx).
+- To see all of the options you can set in the values configuration file for the
+`teleport-plugin-event-handler` Helm chart, consult our [Helm chart reference
 guide](../../reference/helm-reference/teleport-plugin-event-handler.mdx).

--- a/docs/pages/zero-trust-access/export-audit-events/elastic-stack.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/elastic-stack.mdx
@@ -406,7 +406,7 @@ alerts.
 ## Further reading
 
 - To see all of the options you can set for the Teleport Event Handler binary,
-consult our [binary reference
+consult our [reference
 guide](../../reference/deployment/monitoring/event-handler.mdx).
 - To see all of the options you can set in the values configuration file for the
 `teleport-plugin-event-handler` Helm chart, consult our [Helm chart reference

--- a/docs/pages/zero-trust-access/export-audit-events/fluentd.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/fluentd.mdx
@@ -151,7 +151,7 @@ Teleport Cluster, ensure that:
 - See instructions to configure dedicated integrations in the navigation sidebar
 under [Audit Event Export](./export-audit-events.mdx).
 - To see all of the options you can set for the Teleport Event Handler binary,
-consult our [binary reference
+consult our [reference
 guide](../../reference/deployment/monitoring/event-handler.mdx).
 - To see all of the options you can set in the values file for the
 `teleport-plugin-event-handler` Helm chart, consult our [Helm chart reference

--- a/docs/pages/zero-trust-access/export-audit-events/fluentd.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/fluentd.mdx
@@ -150,6 +150,9 @@ Teleport Cluster, ensure that:
 
 - See instructions to configure dedicated integrations in the navigation sidebar
 under [Audit Event Export](./export-audit-events.mdx).
+- To see all of the options you can set for the Teleport Event Handler binary,
+consult our [binary reference
+guide](../../reference/deployment/monitoring/event-handler.mdx).
 - To see all of the options you can set in the values file for the
-`teleport-plugin-event-handler` Helm chart, consult our [reference
+`teleport-plugin-event-handler` Helm chart, consult our [Helm chart reference
 guide](../../reference/helm-reference/teleport-plugin-event-handler.mdx).

--- a/docs/pages/zero-trust-access/export-audit-events/panther.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/panther.mdx
@@ -208,7 +208,7 @@ Teleport Cluster, ensure that:
 
 - Learn more about the [Panther Detections, Alerts and Notifications](https://panther.com/integrations/logs/teleport/).
 - To see all of the options you can set for the Teleport Event Handler binary,
-consult our [binary reference
+consult our [reference
 guide](../../reference/deployment/monitoring/event-handler.mdx).
 - To see all of the options you can set in the values file for the
 `teleport-plugin-event-handler` Helm chart, consult our [Helm chart reference

--- a/docs/pages/zero-trust-access/export-audit-events/panther.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/panther.mdx
@@ -207,6 +207,9 @@ Teleport Cluster, ensure that:
 ## Next steps
 
 - Learn more about the [Panther Detections, Alerts and Notifications](https://panther.com/integrations/logs/teleport/).
+- To see all of the options you can set for the Teleport Event Handler binary,
+consult our [binary reference
+guide](../../reference/deployment/monitoring/event-handler.mdx).
 - To see all of the options you can set in the values file for the
-`teleport-plugin-event-handler` Helm chart, consult our [reference
+`teleport-plugin-event-handler` Helm chart, consult our [Helm chart reference
 guide](../../reference/helm-reference/teleport-plugin-event-handler.mdx).

--- a/docs/pages/zero-trust-access/export-audit-events/splunk.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/splunk.mdx
@@ -223,9 +223,12 @@ Teleport Cluster, ensure that:
 
 ## Next steps
 
-Now that you are exporting your audit logs to Splunk, consult our [audit log
+- Now that you are exporting your audit logs to Splunk, consult our [audit log
 reference](../../reference/deployment/monitoring/audit.mdx) so you can plan visualizations
 and alerts.
+- To see all of the options you can set for the Teleport Event Handler binary,
+consult our [binary reference
+guide](../../reference/deployment/monitoring/event-handler.mdx).
 - To see all of the options you can set in the values file for the
-`teleport-plugin-event-handler` Helm chart, consult our [reference
+`teleport-plugin-event-handler` Helm chart, consult our [Helm chart reference
 guide](../../reference/helm-reference/teleport-plugin-event-handler.mdx).

--- a/docs/pages/zero-trust-access/export-audit-events/splunk.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/splunk.mdx
@@ -227,7 +227,7 @@ Teleport Cluster, ensure that:
 reference](../../reference/deployment/monitoring/audit.mdx) so you can plan visualizations
 and alerts.
 - To see all of the options you can set for the Teleport Event Handler binary,
-consult our [binary reference
+consult our [reference
 guide](../../reference/deployment/monitoring/event-handler.mdx).
 - To see all of the options you can set in the values file for the
 `teleport-plugin-event-handler` Helm chart, consult our [Helm chart reference


### PR DESCRIPTION
Also point the event handler reference's link to the "Export Audit Events" docs instead of access plugins' docs.