### PR TITLE
Add prereq scope namespacing support for Kube Operator

### DIFF
--- a/integrations/operator/controllers/reconcilers/generic.go
+++ b/integrations/operator/controllers/reconcilers/generic.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
+	"github.com/gravitational/teleport/lib/scopes"
 )
 
 const (
@@ -68,11 +69,42 @@ type Adapter[T Resource] interface {
 	SetResourceLabels(T, map[string]string)
 }
 
+// ScopedResource153 extends [types.Resource153] for Teleport
+// resources that are scoped.
+type ScopedResource153 interface {
+	types.Resource153
+	GetScope() string
+}
+
+type ScopedResource153Adapter[T ScopedResource153] struct {
+	Resource153Adapter[T]
+}
+
+func (a ScopedResource153Adapter[T]) GetResourceScope(res T) string {
+	return res.GetScope()
+}
+
 // KubernetesCR is a Kubernetes CustomResource representing a Teleport Resource.
 type KubernetesCR[T Resource] interface {
 	kclient.Object
 	ToTeleport() T
 	StatusConditions() *[]metav1.Condition
+}
+
+// ResourceKey identifies a Teleport resource. Unscoped resources use an empty
+// scope. Scoped resources are identified by the pair of name and scope.
+type ResourceKey struct {
+	Name  string
+	Scope string
+}
+
+// String produces either the Scope Qualified Name if the resource is
+// scoped, or the resource name if unscoped.
+func (r ResourceKey) String() string {
+	if r.Scope != "" {
+		return scopes.QualifiedName{Scope: r.Scope, Name: r.Name}.String()
+	}
+	return r.Name
 }
 
 // resourceClient is a CRUD client for a specific Teleport Resource.
@@ -81,10 +113,10 @@ type KubernetesCR[T Resource] interface {
 // resourceClient implementations can optionally implement the resourceMutator
 // and resourceMutator interfaces.
 type resourceClient[T Resource] interface {
-	Get(context.Context, string) (T, error)
+	Get(context.Context, ResourceKey) (T, error)
 	Create(context.Context, T) error
 	Update(context.Context, T) error
-	Delete(context.Context, string) error
+	Delete(context.Context, ResourceKey) error
 }
 
 // resourceMutator can be implemented by TeleportResourceClients
@@ -97,6 +129,9 @@ type Config struct {
 	// Scoped represents if the controller reconciles scoped resources.
 	// Scoped controllers always run.
 	// Unscoped controllers don't run when the controller runs in scoped mode.
+	// TODO(hugoShaka): Separate scoped config to distinguish is a resource scoped from
+	// is the operator itself scoped.
+	// Deprecated: Don't rely on this it is overloaded and will be refactored later.
 	Scoped bool
 	// CheckFeatures checks if the reconciler should run against the cluster given its features.
 	// This is used to disable controllers if the cluster doesn't support their resource (e.g.
@@ -162,8 +197,8 @@ func (r resourceReconciler[T, K]) Upsert(ctx context.Context, obj kclient.Object
 	teleportResource := k8sResource.ToTeleport()
 
 	debugLog.Info("Converting resource to teleport")
-	name := r.adapter.GetResourceName(teleportResource)
-	existingResource, err := r.resourceClient.Get(ctx, name)
+	key := r.resourceKey(teleportResource)
+	existingResource, err := r.resourceClient.Get(ctx, key)
 	updateErr = updateStatus(updateStatusConfig{
 		ctx:         ctx,
 		client:      r.kubeClient,
@@ -190,7 +225,7 @@ func (r resourceReconciler[T, K]) Upsert(ctx context.Context, obj kclient.Object
 			return trace.Wrap(updateErr)
 		}
 		if !isOwned {
-			return trace.AlreadyExists("unowned Resource '%s' already exists", name)
+			return trace.AlreadyExists("unowned Resource %q already exists", key)
 		}
 	} else {
 		debugLog.Info("Resource does not exist yet")
@@ -254,11 +289,36 @@ func (r resourceReconciler[T, K]) Upsert(ctx context.Context, obj kclient.Object
 	return trace.NewAggregate(err, updateErr)
 }
 
+func (r resourceReconciler[T, K]) resourceKey(resource T) ResourceKey {
+	key := ResourceKey{Name: r.adapter.GetResourceName(resource)}
+
+	if scopedAdapter, ok := r.adapter.(interface{ GetResourceScope(T) string }); ok {
+		key.Scope = scopedAdapter.GetResourceScope(resource)
+	}
+	return key
+}
+
 // Delete is the resourceReconciler of the ResourceBaseReconciler DeleteExertal
 func (r resourceReconciler[T, K]) Delete(ctx context.Context, obj kclient.Object) error {
+	key := ResourceKey{Name: obj.GetName()}
+	if r.scoped {
+		// Unmarshaling is avoided by pulling the scope directly out of the Object.
+		u, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			return trace.BadParameter("failed to convert Object into Resource object: %T", obj)
+		}
+
+		scope, _, err := unstructured.NestedString(u.Object, "scope")
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		key.Scope = scope
+	}
+
 	// This call catches non-existing resources or subkind mismatch (e.g. openssh nodes)
 	// We can then check that we own the Resource before deleting it.
-	resource, err := r.resourceClient.Get(ctx, obj.GetName())
+	resource, err := r.resourceClient.Get(ctx, key)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -271,7 +331,7 @@ func (r resourceReconciler[T, K]) Delete(ctx context.Context, obj kclient.Object
 	// This GET->check->DELETE dance is race-prone, but it's good enough for what
 	// we want to do. No one should reconcile the same Resource as the operator.
 	// If they do, it's their fault as the Resource was clearly flagged as belonging to us.
-	return r.resourceClient.Delete(ctx, obj.GetName())
+	return r.resourceClient.Delete(ctx, key)
 }
 
 // Reconcile receives an update request and reconcile the Resource,

--- a/integrations/operator/controllers/reconcilers/generic_test.go
+++ b/integrations/operator/controllers/reconcilers/generic_test.go
@@ -58,10 +58,10 @@ type fakeTeleportResourceClient struct {
 }
 
 // Get implements the TeleportResourceClient interface.
-func (f *fakeTeleportResourceClient) Get(_ context.Context, name string) (*fakeTeleportResource, error) {
-	metadata, ok := f.store[name]
+func (f *fakeTeleportResourceClient) Get(_ context.Context, id ResourceKey) (*fakeTeleportResource, error) {
+	metadata, ok := f.store[id.String()]
 	if !ok {
-		return nil, trace.NotFound("%q not found", name)
+		return nil, trace.NotFound("%q not found", id.String())
 	}
 	return newFakeTeleportResource(metadata), nil
 }
@@ -96,12 +96,12 @@ func (f *fakeTeleportResourceClient) Update(_ context.Context, t *fakeTeleportRe
 }
 
 // Delete implements the TeleportResourceClient interface.
-func (f *fakeTeleportResourceClient) Delete(_ context.Context, name string) error {
-	_, ok := f.store[name]
+func (f *fakeTeleportResourceClient) Delete(_ context.Context, id ResourceKey) error {
+	_, ok := f.store[id.String()]
 	if !ok {
-		return trace.NotFound("%q not found", name)
+		return trace.NotFound("%q not found", id.String())
 	}
-	delete(f.store, name)
+	delete(f.store, id.String())
 	return nil
 
 }

--- a/integrations/operator/controllers/reconcilers/resource153.go
+++ b/integrations/operator/controllers/reconcilers/resource153.go
@@ -97,3 +97,37 @@ func NewTeleportResource153Reconciler[T types.Resource153, K KubernetesCR[T]](
 	}
 	return reconciler, nil
 }
+
+// NewTeleportScopedResource153Reconciler instantiates a resourceReconciler for a
+// ScopedResource153 resource.
+func NewTeleportScopedResource153Reconciler[T ScopedResource153, K KubernetesCR[T]](
+	client kclient.Client,
+	resourceClient resourceClient[T],
+	config Config,
+) (controllers.Reconciler, error) {
+	checkFeatures := controllers.AlwaysEnabled
+	if config.CheckFeatures != nil {
+		checkFeatures = config.CheckFeatures
+	}
+
+	gvk, err := gvkFromScheme[K](controllers.Scheme)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	teleportKind := newKubeResource[K]().ToTeleport().GetKind()
+	if teleportKind == "" {
+		return nil, trace.BadParameter("teleport kind is required, this is a bug")
+	}
+
+	reconciler := &resourceReconciler[T, K]{
+		kubeClient:     client,
+		resourceClient: resourceClient,
+		gvk:            gvk,
+		adapter:        ScopedResource153Adapter[T]{},
+		scoped:         true,
+		teleportKind:   teleportKind,
+		checkFeatures:  checkFeatures,
+	}
+	return reconciler, nil
+}

--- a/integrations/operator/controllers/reconcilers/resource153_test.go
+++ b/integrations/operator/controllers/reconcilers/resource153_test.go
@@ -1,0 +1,154 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package reconcilers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/api/types"
+	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
+	"github.com/gravitational/teleport/integrations/operator/controllers"
+	"github.com/gravitational/teleport/lib/scopes/access"
+)
+
+type fakeScopedRoleClient struct {
+	store map[ResourceKey]*accessv1.ScopedRole
+}
+
+func (f *fakeScopedRoleClient) Get(_ context.Context, key ResourceKey) (*accessv1.ScopedRole, error) {
+	role, ok := f.store[key]
+	if !ok {
+		return nil, trace.NotFound("%q not found", key.String())
+	}
+	return role, nil
+}
+
+func (f *fakeScopedRoleClient) Create(_ context.Context, role *accessv1.ScopedRole) error {
+	key := ResourceKey{Name: role.GetMetadata().GetName(), Scope: role.GetScope()}
+	if _, ok := f.store[key]; ok {
+		return trace.AlreadyExists("%q already exists", key.String())
+	}
+	role.GetMetadata().SetRevision(uuid.New().String())
+	f.store[key] = role
+	return nil
+}
+
+func (f *fakeScopedRoleClient) Update(_ context.Context, role *accessv1.ScopedRole) error {
+	key := ResourceKey{Name: role.GetMetadata().GetName(), Scope: role.GetScope()}
+	existing, ok := f.store[key]
+	if !ok {
+		return trace.NotFound("%q not found", key.String())
+	}
+	if existing.GetMetadata().GetRevision() != role.GetMetadata().GetRevision() {
+		return trace.CompareFailed("revision mismatch")
+	}
+	role.GetMetadata().SetRevision(uuid.New().String())
+	f.store[key] = role
+	return nil
+}
+
+func (f *fakeScopedRoleClient) Delete(_ context.Context, key ResourceKey) error {
+	if _, ok := f.store[key]; !ok {
+		return trace.NotFound("%q not found", key.String())
+	}
+	delete(f.store, key)
+	return nil
+}
+
+func TestScopedResource153Reconciler(t *testing.T) {
+	t.Parallel()
+	const (
+		name      = "test-role"
+		namespace = "default"
+		scopeA    = "/team/a"
+		scopeB    = "/team/b"
+	)
+
+	cr := &resourcesv1.TeleportScopedRoleV1{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: resourcesv1.GroupVersion.String(),
+			Kind:       "TeleportScopedRoleV1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Scope: scopeA,
+		Spec:  &resourcesv1.TeleportScopedRoleV1Spec{},
+	}
+
+	scopedRole := accessv1.ScopedRole_builder{
+		Kind:    access.KindScopedRole,
+		Version: types.V1,
+		Metadata: headerv1.Metadata_builder{
+			Name:   name,
+			Labels: map[string]string{types.OriginLabel: types.OriginKubernetes},
+		}.Build(),
+		Scope: scopeB,
+		Spec:  &accessv1.ScopedRoleSpec{},
+	}.Build()
+
+	resourceClient := &fakeScopedRoleClient{store: map[ResourceKey]*accessv1.ScopedRole{{Name: name, Scope: scopeB}: scopedRole}}
+	kubeClient := fake.NewClientBuilder().
+		WithScheme(controllers.Scheme).
+		WithStatusSubresource(&resourcesv1.TeleportScopedRoleV1{}).
+		WithObjects(cr).
+		Build()
+	reconciler, err := NewTeleportScopedResource153Reconciler[*accessv1.ScopedRole, *resourcesv1.TeleportScopedRoleV1](
+		kubeClient,
+		resourceClient,
+		Config{Scoped: true},
+	)
+	require.NoError(t, err)
+
+	req := ctrl.Request{NamespacedName: k8stypes.NamespacedName{Name: name, Namespace: namespace}}
+
+	// First reconciliation adds the deletion finalizer and exits.
+	_, err = reconciler.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+
+	// Second reconciliation performs the Teleport upsert.
+	_, err = reconciler.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+
+	roleA := resourceClient.store[ResourceKey{Name: name, Scope: scopeA}]
+	require.NotNil(t, roleA)
+	require.Equal(t, types.OriginKubernetes, roleA.GetMetadata().GetLabels()[types.OriginLabel])
+	require.NotNil(t, resourceClient.store[ResourceKey{Name: name, Scope: scopeB}])
+
+	err = kubeClient.Delete(t.Context(), cr)
+	require.NoError(t, err)
+
+	_, err = reconciler.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+
+	require.Nil(t, resourceClient.store[ResourceKey{Name: name, Scope: scopeA}])
+	require.NotNil(t, resourceClient.store[ResourceKey{Name: name, Scope: scopeB}])
+}

--- a/integrations/operator/controllers/resources/accesslist_controller.go
+++ b/integrations/operator/controllers/resources/accesslist_controller.go
@@ -35,8 +35,8 @@ type accessListClient struct {
 }
 
 // Get gets the Teleport access_list of a given name
-func (r accessListClient) Get(ctx context.Context, name string) (*accesslist.AccessList, error) {
-	accessList, err := r.teleportClient.AccessListClient().GetAccessList(ctx, name)
+func (r accessListClient) Get(ctx context.Context, key reconcilers.ResourceKey) (*accesslist.AccessList, error) {
+	accessList, err := r.teleportClient.AccessListClient().GetAccessList(ctx, key.Name)
 	return accessList, trace.Wrap(err)
 }
 
@@ -53,8 +53,8 @@ func (r accessListClient) Update(ctx context.Context, accessList *accesslist.Acc
 }
 
 // Delete deletes a Teleport access_list
-func (r accessListClient) Delete(ctx context.Context, name string) error {
-	return trace.Wrap(r.teleportClient.AccessListClient().DeleteAccessList(ctx, name))
+func (r accessListClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
+	return trace.Wrap(r.teleportClient.AccessListClient().DeleteAccessList(ctx, key.Name))
 }
 
 // Mutate propagates fields from the existing AccessList resource

--- a/integrations/operator/controllers/resources/accessmonitoringrulev1_controller.go
+++ b/integrations/operator/controllers/resources/accessmonitoringrulev1_controller.go
@@ -37,9 +37,9 @@ type accessMonitoringRuleClient struct {
 }
 
 // Get gets the Teleport accessMonitoringRule of a given name
-func (l accessMonitoringRuleClient) Get(ctx context.Context, name string) (*accessmonitoringrulesv1pb.AccessMonitoringRule, error) {
+func (l accessMonitoringRuleClient) Get(ctx context.Context, key reconcilers.ResourceKey) (*accessmonitoringrulesv1pb.AccessMonitoringRule, error) {
 	resp, err := l.teleportClient.AccessMonitoringRulesClient().
-		GetAccessMonitoringRule(ctx, name)
+		GetAccessMonitoringRule(ctx, key.Name)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -61,8 +61,8 @@ func (l accessMonitoringRuleClient) Update(ctx context.Context, resource *access
 }
 
 // Delete deletes a Teleport accessMonitoringRule
-func (l accessMonitoringRuleClient) Delete(ctx context.Context, name string) error {
-	return trace.Wrap(l.teleportClient.AccessMonitoringRulesClient().DeleteAccessMonitoringRule(ctx, name))
+func (l accessMonitoringRuleClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
+	return trace.Wrap(l.teleportClient.AccessMonitoringRulesClient().DeleteAccessMonitoringRule(ctx, key.Name))
 }
 
 // NewAccessMonitoringRuleV1Reconciler instantiates a new Kubernetes controller reconciling accessMonitoringRule

--- a/integrations/operator/controllers/resources/appv3_controller.go
+++ b/integrations/operator/controllers/resources/appv3_controller.go
@@ -40,8 +40,8 @@ type appClient struct {
 }
 
 // Get gets the Teleport app of a given name
-func (r appClient) Get(ctx context.Context, name string) (types.Application, error) {
-	app, err := r.teleportClient.GetApp(ctx, name)
+func (r appClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.Application, error) {
+	app, err := r.teleportClient.GetApp(ctx, key.Name)
 	return app, trace.Wrap(err)
 }
 
@@ -56,8 +56,8 @@ func (r appClient) Update(ctx context.Context, app types.Application) error {
 }
 
 // Delete deletes a Teleport app
-func (r appClient) Delete(ctx context.Context, name string) error {
-	return trace.Wrap(r.teleportClient.DeleteApp(ctx, name))
+func (r appClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
+	return trace.Wrap(r.teleportClient.DeleteApp(ctx, key.Name))
 }
 
 // NewAppV3Reconciler instantiates a new Kubernetes controller reconciling app v6 resources

--- a/integrations/operator/controllers/resources/autoupdateconfig_controller.go
+++ b/integrations/operator/controllers/resources/autoupdateconfig_controller.go
@@ -37,7 +37,7 @@ type autoUpdateConfigClient struct {
 }
 
 // Get gets the Teleport autoUpdateConfig of a given name
-func (l autoUpdateConfigClient) Get(ctx context.Context, name string) (*autoupdatev1pb.AutoUpdateConfig, error) {
+func (l autoUpdateConfigClient) Get(ctx context.Context, key reconcilers.ResourceKey) (*autoupdatev1pb.AutoUpdateConfig, error) {
 	resp, err := l.teleportClient.
 		GetAutoUpdateConfig(ctx)
 	if err != nil {
@@ -61,7 +61,7 @@ func (l autoUpdateConfigClient) Update(ctx context.Context, resource *autoupdate
 }
 
 // Delete deletes a Teleport autoUpdateConfig
-func (l autoUpdateConfigClient) Delete(ctx context.Context, name string) error {
+func (l autoUpdateConfigClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
 	return trace.Wrap(l.teleportClient.DeleteAutoUpdateConfig(ctx))
 }
 

--- a/integrations/operator/controllers/resources/autoupdateversion_controller.go
+++ b/integrations/operator/controllers/resources/autoupdateversion_controller.go
@@ -37,7 +37,7 @@ type autoUpdateVersionClient struct {
 }
 
 // Get gets the Teleport autoUpdateVersion of a given name
-func (l autoUpdateVersionClient) Get(ctx context.Context, name string) (*autoupdatev1pb.AutoUpdateVersion, error) {
+func (l autoUpdateVersionClient) Get(ctx context.Context, key reconcilers.ResourceKey) (*autoupdatev1pb.AutoUpdateVersion, error) {
 	resp, err := l.teleportClient.
 		GetAutoUpdateVersion(ctx)
 	if err != nil {
@@ -61,7 +61,7 @@ func (l autoUpdateVersionClient) Update(ctx context.Context, resource *autoupdat
 }
 
 // Delete deletes a Teleport autoUpdateVersion
-func (l autoUpdateVersionClient) Delete(ctx context.Context, name string) error {
+func (l autoUpdateVersionClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
 	return trace.Wrap(l.teleportClient.DeleteAutoUpdateVersion(ctx))
 }
 

--- a/integrations/operator/controllers/resources/botv1_controller.go
+++ b/integrations/operator/controllers/resources/botv1_controller.go
@@ -37,10 +37,10 @@ type botClient struct {
 }
 
 // Get gets the Teleport bot of a given name
-func (l botClient) Get(ctx context.Context, name string) (*machineidv1.Bot, error) {
+func (l botClient) Get(ctx context.Context, key reconcilers.ResourceKey) (*machineidv1.Bot, error) {
 	resp, err := l.teleportClient.
 		BotServiceClient().
-		GetBot(ctx, machineidv1.GetBotRequest_builder{BotName: name}.Build())
+		GetBot(ctx, machineidv1.GetBotRequest_builder{BotName: key.Name}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -64,10 +64,10 @@ func (l botClient) Update(ctx context.Context, resource *machineidv1.Bot) error 
 }
 
 // Delete deletes a Teleport bot
-func (l botClient) Delete(ctx context.Context, name string) error {
+func (l botClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
 	_, err := l.teleportClient.
 		BotServiceClient().
-		DeleteBot(ctx, machineidv1.DeleteBotRequest_builder{BotName: name}.Build())
+		DeleteBot(ctx, machineidv1.DeleteBotRequest_builder{BotName: key.Name}.Build())
 	return trace.Wrap(err)
 }
 

--- a/integrations/operator/controllers/resources/databasev3_controller.go
+++ b/integrations/operator/controllers/resources/databasev3_controller.go
@@ -40,8 +40,8 @@ type databaseClient struct {
 }
 
 // Get gets the Teleport database of a given name
-func (r databaseClient) Get(ctx context.Context, name string) (types.Database, error) {
-	database, err := r.teleportClient.GetDatabase(ctx, name)
+func (r databaseClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.Database, error) {
+	database, err := r.teleportClient.GetDatabase(ctx, key.Name)
 	return database, trace.Wrap(err)
 }
 
@@ -56,8 +56,8 @@ func (r databaseClient) Update(ctx context.Context, database types.Database) err
 }
 
 // Delete deletes a Teleport database
-func (r databaseClient) Delete(ctx context.Context, name string) error {
-	return trace.Wrap(r.teleportClient.DeleteDatabase(ctx, name))
+func (r databaseClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
+	return trace.Wrap(r.teleportClient.DeleteDatabase(ctx, key.Name))
 }
 
 // NewDatabaseV3Reconciler instantiates a new Kubernetes controller reconciling database v6 resources

--- a/integrations/operator/controllers/resources/github_connector_controller.go
+++ b/integrations/operator/controllers/resources/github_connector_controller.go
@@ -39,8 +39,8 @@ type githubConnectorClient struct {
 }
 
 // Get gets the Teleport github_connector of a given name
-func (r githubConnectorClient) Get(ctx context.Context, name string) (types.GithubConnector, error) {
-	github, err := r.teleportClient.GetGithubConnector(ctx, name, false /* with secrets*/)
+func (r githubConnectorClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.GithubConnector, error) {
+	github, err := r.teleportClient.GetGithubConnector(ctx, key.Name, false /* with secrets*/)
 	return github, trace.Wrap(err)
 }
 
@@ -57,8 +57,8 @@ func (r githubConnectorClient) Update(ctx context.Context, github types.GithubCo
 }
 
 // Delete deletes a Teleport github_connector
-func (r githubConnectorClient) Delete(ctx context.Context, name string) error {
-	return trace.Wrap(r.teleportClient.DeleteGithubConnector(ctx, name))
+func (r githubConnectorClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
+	return trace.Wrap(r.teleportClient.DeleteGithubConnector(ctx, key.Name))
 }
 
 func (r githubConnectorClient) Mutate(ctx context.Context, new, _ types.GithubConnector, crKey kclient.ObjectKey) error {

--- a/integrations/operator/controllers/resources/inference_model_controller.go
+++ b/integrations/operator/controllers/resources/inference_model_controller.go
@@ -37,10 +37,10 @@ type inferenceModelClient struct {
 
 // Get gets an inference model with a given name from Teleport.
 func (c inferenceModelClient) Get(
-	ctx context.Context, name string,
+	ctx context.Context, key reconcilers.ResourceKey,
 ) (*summarizerv1.InferenceModel, error) {
 	resp, err := c.teleportClient.SummarizerServiceClient().GetInferenceModel(
-		ctx, summarizerv1.GetInferenceModelRequest_builder{Name: name}.Build(),
+		ctx, summarizerv1.GetInferenceModelRequest_builder{Name: key.Name}.Build(),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -70,9 +70,9 @@ func (c inferenceModelClient) Update(
 }
 
 // Delete deletes an inference model with a given name from Teleport.
-func (c inferenceModelClient) Delete(ctx context.Context, name string) error {
+func (c inferenceModelClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
 	_, err := c.teleportClient.SummarizerServiceClient().DeleteInferenceModel(
-		ctx, summarizerv1.DeleteInferenceModelRequest_builder{Name: name}.Build(),
+		ctx, summarizerv1.DeleteInferenceModelRequest_builder{Name: key.Name}.Build(),
 	)
 	return trace.Wrap(err)
 }

--- a/integrations/operator/controllers/resources/inference_policy_controller.go
+++ b/integrations/operator/controllers/resources/inference_policy_controller.go
@@ -37,10 +37,10 @@ type inferencePolicyClient struct {
 
 // Get gets an inference policy with a given name from Teleport.
 func (c inferencePolicyClient) Get(
-	ctx context.Context, name string,
+	ctx context.Context, key reconcilers.ResourceKey,
 ) (*summarizerv1.InferencePolicy, error) {
 	resp, err := c.teleportClient.SummarizerServiceClient().GetInferencePolicy(
-		ctx, summarizerv1.GetInferencePolicyRequest_builder{Name: name}.Build(),
+		ctx, summarizerv1.GetInferencePolicyRequest_builder{Name: key.Name}.Build(),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -70,9 +70,9 @@ func (c inferencePolicyClient) Update(
 }
 
 // Delete deletes an inference policy with a given name from Teleport.
-func (c inferencePolicyClient) Delete(ctx context.Context, name string) error {
+func (c inferencePolicyClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
 	_, err := c.teleportClient.SummarizerServiceClient().DeleteInferencePolicy(
-		ctx, summarizerv1.DeleteInferencePolicyRequest_builder{Name: name}.Build(),
+		ctx, summarizerv1.DeleteInferencePolicyRequest_builder{Name: key.Name}.Build(),
 	)
 	return trace.Wrap(err)
 }

--- a/integrations/operator/controllers/resources/inference_secret_controller.go
+++ b/integrations/operator/controllers/resources/inference_secret_controller.go
@@ -38,9 +38,9 @@ type inferenceSecretClient struct {
 }
 
 // Get gets an inference secret with a given name from Teleport.
-func (c inferenceSecretClient) Get(ctx context.Context, name string) (*summarizerv1.InferenceSecret, error) {
+func (c inferenceSecretClient) Get(ctx context.Context, key reconcilers.ResourceKey) (*summarizerv1.InferenceSecret, error) {
 	resp, err := c.teleportClient.SummarizerServiceClient().GetInferenceSecret(
-		ctx, summarizerv1.GetInferenceSecretRequest_builder{Name: name}.Build(),
+		ctx, summarizerv1.GetInferenceSecretRequest_builder{Name: key.Name}.Build(),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -66,9 +66,9 @@ func (c inferenceSecretClient) Update(ctx context.Context, secret *summarizerv1.
 }
 
 // Delete deletes an inference secret with a given name from Teleport.
-func (c inferenceSecretClient) Delete(ctx context.Context, name string) error {
+func (c inferenceSecretClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
 	_, err := c.teleportClient.SummarizerServiceClient().DeleteInferenceSecret(
-		ctx, summarizerv1.DeleteInferenceSecretRequest_builder{Name: name}.Build(),
+		ctx, summarizerv1.DeleteInferenceSecretRequest_builder{Name: key.Name}.Build(),
 	)
 	return trace.Wrap(err)
 }

--- a/integrations/operator/controllers/resources/lock_controller.go
+++ b/integrations/operator/controllers/resources/lock_controller.go
@@ -37,8 +37,8 @@ type lockClient struct {
 }
 
 // Get gets the Teleport lock of a given name
-func (r lockClient) Get(ctx context.Context, name string) (types.Lock, error) {
-	lock, err := r.teleportClient.GetLock(ctx, name)
+func (r lockClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.Lock, error) {
+	lock, err := r.teleportClient.GetLock(ctx, key.Name)
 	return lock, trace.Wrap(err)
 }
 
@@ -53,8 +53,8 @@ func (r lockClient) Update(ctx context.Context, lock types.Lock) error {
 }
 
 // Delete deletes a Teleport lock
-func (r lockClient) Delete(ctx context.Context, name string) error {
-	return trace.Wrap(r.teleportClient.DeleteLock(ctx, name))
+func (r lockClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
+	return trace.Wrap(r.teleportClient.DeleteLock(ctx, key.Name))
 }
 
 // Mutate ensures the spec.CreatedAt and spec.CreatedBy properties are persisted

--- a/integrations/operator/controllers/resources/login_rule_controller.go
+++ b/integrations/operator/controllers/resources/login_rule_controller.go
@@ -39,8 +39,8 @@ type loginRuleClient struct {
 }
 
 // Get gets the Teleport login_rule of a given name
-func (l loginRuleClient) Get(ctx context.Context, name string) (*resourcesv1.LoginRuleResource, error) {
-	loginRule, err := l.teleportClient.GetLoginRule(ctx, name)
+func (l loginRuleClient) Get(ctx context.Context, key reconcilers.ResourceKey) (*resourcesv1.LoginRuleResource, error) {
+	loginRule, err := l.teleportClient.GetLoginRule(ctx, key.Name)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -61,8 +61,8 @@ func (l loginRuleClient) Update(ctx context.Context, resource *resourcesv1.Login
 }
 
 // Delete deletes a Teleport login_rule
-func (l loginRuleClient) Delete(ctx context.Context, name string) error {
-	return trace.Wrap(l.teleportClient.DeleteLoginRule(ctx, name))
+func (l loginRuleClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
+	return trace.Wrap(l.teleportClient.DeleteLoginRule(ctx, key.Name))
 }
 
 // NewLoginRuleReconciler instantiates a new Kubernetes controller reconciling login_rule resources

--- a/integrations/operator/controllers/resources/oidc_connector_controller.go
+++ b/integrations/operator/controllers/resources/oidc_connector_controller.go
@@ -42,8 +42,8 @@ type oidcConnectorClient struct {
 }
 
 // Get gets the Teleport oidc_connector of a given name
-func (r oidcConnectorClient) Get(ctx context.Context, name string) (types.OIDCConnector, error) {
-	oidc, err := r.teleportClient.GetOIDCConnector(ctx, name, false /* with secrets*/)
+func (r oidcConnectorClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.OIDCConnector, error) {
+	oidc, err := r.teleportClient.GetOIDCConnector(ctx, key.Name, false /* with secrets*/)
 	return oidc, trace.Wrap(err)
 }
 
@@ -60,8 +60,8 @@ func (r oidcConnectorClient) Update(ctx context.Context, oidc types.OIDCConnecto
 }
 
 // Delete deletes a Teleport oidc_connector
-func (r oidcConnectorClient) Delete(ctx context.Context, name string) error {
-	return trace.Wrap(r.teleportClient.DeleteOIDCConnector(ctx, name))
+func (r oidcConnectorClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
+	return trace.Wrap(r.teleportClient.DeleteOIDCConnector(ctx, key.Name))
 }
 
 func (r oidcConnectorClient) Mutate(ctx context.Context, new, _ types.OIDCConnector, crKey kclient.ObjectKey) error {

--- a/integrations/operator/controllers/resources/okta_import_rule_controller.go
+++ b/integrations/operator/controllers/resources/okta_import_rule_controller.go
@@ -37,8 +37,8 @@ type oktaImportRuleClient struct {
 }
 
 // Get gets the Teleport okta_import_rule of a given name
-func (r oktaImportRuleClient) Get(ctx context.Context, name string) (types.OktaImportRule, error) {
-	importRule, err := r.teleportClient.OktaClient().GetOktaImportRule(ctx, name)
+func (r oktaImportRuleClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.OktaImportRule, error) {
+	importRule, err := r.teleportClient.OktaClient().GetOktaImportRule(ctx, key.Name)
 	return importRule, trace.Wrap(err)
 }
 
@@ -55,8 +55,8 @@ func (r oktaImportRuleClient) Update(ctx context.Context, importRule types.OktaI
 }
 
 // Delete deletes a Teleport okta_import_rule
-func (r oktaImportRuleClient) Delete(ctx context.Context, name string) error {
-	return trace.Wrap(r.teleportClient.OktaClient().DeleteOktaImportRule(ctx, name))
+func (r oktaImportRuleClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
+	return trace.Wrap(r.teleportClient.OktaClient().DeleteOktaImportRule(ctx, key.Name))
 }
 
 // NewOktaImportRuleReconciler instantiates a new Kubernetes controller reconciling okta_import_rule resources

--- a/integrations/operator/controllers/resources/openssheiceserverv2_controller.go
+++ b/integrations/operator/controllers/resources/openssheiceserverv2_controller.go
@@ -39,8 +39,8 @@ type openSSHEICEServerClient struct {
 }
 
 // Get gets the Teleport OpenSSHEICE server of a given name.
-func (r openSSHEICEServerClient) Get(ctx context.Context, name string) (types.Server, error) {
-	server, err := r.teleportClient.GetNode(ctx, defaults.Namespace, name)
+func (r openSSHEICEServerClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.Server, error) {
+	server, err := r.teleportClient.GetNode(ctx, defaults.Namespace, key.Name)
 	if err != nil {
 		return server, trace.Wrap(err)
 	}
@@ -67,8 +67,8 @@ func (r openSSHEICEServerClient) Update(ctx context.Context, server types.Server
 }
 
 // Delete deletes a Teleport OpenSSHEICE server.
-func (r openSSHEICEServerClient) Delete(ctx context.Context, name string) error {
-	return trace.Wrap(r.teleportClient.DeleteNode(ctx, defaults.Namespace, name))
+func (r openSSHEICEServerClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
+	return trace.Wrap(r.teleportClient.DeleteNode(ctx, defaults.Namespace, key.Name))
 }
 
 // NewOpenSSHEICEServerV2Reconciler instantiates a new Kubernetes controller

--- a/integrations/operator/controllers/resources/opensshserverv2_controller.go
+++ b/integrations/operator/controllers/resources/opensshserverv2_controller.go
@@ -39,8 +39,8 @@ type openSSHServerClient struct {
 }
 
 // Get gets the Teleport OpenSSH server of a given name.
-func (r openSSHServerClient) Get(ctx context.Context, name string) (types.Server, error) {
-	server, err := r.teleportClient.GetNode(ctx, defaults.Namespace, name)
+func (r openSSHServerClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.Server, error) {
+	server, err := r.teleportClient.GetNode(ctx, defaults.Namespace, key.Name)
 	if err != nil {
 		return server, trace.Wrap(err)
 	}
@@ -67,8 +67,8 @@ func (r openSSHServerClient) Update(ctx context.Context, server types.Server) er
 }
 
 // Delete deletes a Teleport OpenSSH server.
-func (r openSSHServerClient) Delete(ctx context.Context, name string) error {
-	return trace.Wrap(r.teleportClient.DeleteNode(ctx, defaults.Namespace, name))
+func (r openSSHServerClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
+	return trace.Wrap(r.teleportClient.DeleteNode(ctx, defaults.Namespace, key.Name))
 }
 
 // NewOpenSSHServerV2Reconciler instantiates a new Kubernetes controller

--- a/integrations/operator/controllers/resources/provision_token_controller.go
+++ b/integrations/operator/controllers/resources/provision_token_controller.go
@@ -37,8 +37,8 @@ type provisionTokenClient struct {
 }
 
 // Get gets the Teleport provision token of a given name
-func (r provisionTokenClient) Get(ctx context.Context, name string) (types.ProvisionToken, error) {
-	token, err := r.teleportClient.GetToken(ctx, name)
+func (r provisionTokenClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.ProvisionToken, error) {
+	token, err := r.teleportClient.GetToken(ctx, key.Name)
 	return token, trace.Wrap(err)
 }
 
@@ -53,8 +53,8 @@ func (r provisionTokenClient) Update(ctx context.Context, token types.ProvisionT
 }
 
 // Delete deletes a Teleport provision token
-func (r provisionTokenClient) Delete(ctx context.Context, name string) error {
-	return trace.Wrap(r.teleportClient.DeleteToken(ctx, name))
+func (r provisionTokenClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
+	return trace.Wrap(r.teleportClient.DeleteToken(ctx, key.Name))
 }
 
 // NewProvisionTokenReconciler instantiates a new Kubernetes controller reconciling provision token resources

--- a/integrations/operator/controllers/resources/retrieval_model_controller.go
+++ b/integrations/operator/controllers/resources/retrieval_model_controller.go
@@ -37,8 +37,8 @@ type retrievalModelClient struct {
 	teleportClient *client.Client
 }
 
-// Get gets the Teleport RetrievalModel singleton. The name parameter is ignored.
-func (r retrievalModelClient) Get(ctx context.Context, _ string) (*summarizerv1.RetrievalModel, error) {
+// Get gets the Teleport RetrievalModel singleton. The key parameter is ignored.
+func (r retrievalModelClient) Get(ctx context.Context, _ reconcilers.ResourceKey) (*summarizerv1.RetrievalModel, error) {
 	resp, err := r.teleportClient.SummarizerServiceClient().
 		GetRetrievalModel(ctx, &summarizerv1.GetRetrievalModelRequest{})
 	if err != nil {
@@ -61,8 +61,8 @@ func (r retrievalModelClient) Update(ctx context.Context, resource *summarizerv1
 	return trace.Wrap(err)
 }
 
-// Delete deletes the Teleport RetrievalModel singleton. The name parameter is ignored.
-func (r retrievalModelClient) Delete(ctx context.Context, _ string) error {
+// Delete deletes the Teleport RetrievalModel singleton. The key parameter is ignored.
+func (r retrievalModelClient) Delete(ctx context.Context, _ reconcilers.ResourceKey) error {
 	_, err := r.teleportClient.SummarizerServiceClient().
 		DeleteRetrievalModel(ctx, &summarizerv1.DeleteRetrievalModelRequest{})
 	return trace.Wrap(err)

--- a/integrations/operator/controllers/resources/rolevX_controller.go
+++ b/integrations/operator/controllers/resources/rolevX_controller.go
@@ -41,8 +41,8 @@ type roleClient struct {
 }
 
 // Get gets the Teleport role of a given name
-func (r roleClient) Get(ctx context.Context, name string) (types.Role, error) {
-	role, err := r.teleportClient.GetRole(ctx, name)
+func (r roleClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.Role, error) {
+	role, err := r.teleportClient.GetRole(ctx, key.Name)
 	return role, trace.Wrap(err)
 }
 
@@ -59,8 +59,8 @@ func (r roleClient) Update(ctx context.Context, role types.Role) error {
 }
 
 // Delete deletes a Teleport role
-func (r roleClient) Delete(ctx context.Context, name string) error {
-	return trace.Wrap(r.teleportClient.DeleteRole(ctx, name))
+func (r roleClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
+	return trace.Wrap(r.teleportClient.DeleteRole(ctx, key.Name))
 }
 
 // NewRoleReconciler instantiates a new Kubernetes controller reconciling legacy role v5 resources

--- a/integrations/operator/controllers/resources/saml_connector_controller.go
+++ b/integrations/operator/controllers/resources/saml_connector_controller.go
@@ -40,8 +40,8 @@ type samlConnectorClient struct {
 }
 
 // Get gets the Teleport saml_connector of a given name
-func (r samlConnectorClient) Get(ctx context.Context, name string) (types.SAMLConnector, error) {
-	saml, err := r.teleportClient.GetSAMLConnector(ctx, name, false /* with secrets*/)
+func (r samlConnectorClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.SAMLConnector, error) {
+	saml, err := r.teleportClient.GetSAMLConnector(ctx, key.Name, false /* with secrets*/)
 	return saml, trace.Wrap(err)
 }
 
@@ -58,8 +58,8 @@ func (r samlConnectorClient) Update(ctx context.Context, saml types.SAMLConnecto
 }
 
 // Delete deletes a Teleport saml_connector
-func (r samlConnectorClient) Delete(ctx context.Context, name string) error {
-	return trace.Wrap(r.teleportClient.DeleteSAMLConnector(ctx, name))
+func (r samlConnectorClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
+	return trace.Wrap(r.teleportClient.DeleteSAMLConnector(ctx, key.Name))
 }
 
 // NewSAMLConnectorReconciler instantiates a new Kubernetes controller reconciling saml_connector resources

--- a/integrations/operator/controllers/resources/saml_idp_service_providerv1_controller.go
+++ b/integrations/operator/controllers/resources/saml_idp_service_providerv1_controller.go
@@ -38,8 +38,8 @@ type samlIdPServiceProviderClient struct {
 }
 
 // Get gets the Teleport saml_idp_service_provider of a given name.
-func (r samlIdPServiceProviderClient) Get(ctx context.Context, name string) (types.SAMLIdPServiceProvider, error) {
-	sp, err := r.teleportClient.GetSAMLIdPServiceProvider(ctx, name)
+func (r samlIdPServiceProviderClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.SAMLIdPServiceProvider, error) {
+	sp, err := r.teleportClient.GetSAMLIdPServiceProvider(ctx, key.Name)
 	return sp, trace.Wrap(err)
 }
 
@@ -54,8 +54,8 @@ func (r samlIdPServiceProviderClient) Update(ctx context.Context, sp types.SAMLI
 }
 
 // Delete deletes a Teleport saml_idp_service_provider.
-func (r samlIdPServiceProviderClient) Delete(ctx context.Context, name string) error {
-	return trace.Wrap(r.teleportClient.DeleteSAMLIdPServiceProvider(ctx, name))
+func (r samlIdPServiceProviderClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
+	return trace.Wrap(r.teleportClient.DeleteSAMLIdPServiceProvider(ctx, key.Name))
 }
 
 // NewSAMLIdPServiceProviderV1Reconciler instantiates a new Kubernetes controller

--- a/integrations/operator/controllers/resources/scopedrole_controller.go
+++ b/integrations/operator/controllers/resources/scopedrole_controller.go
@@ -40,16 +40,16 @@ func (s *scopedRoleClient) Create(ctx context.Context, role *accessv1.ScopedRole
 	return trace.Wrap(err)
 }
 
-func (s *scopedRoleClient) Delete(ctx context.Context, name string) error {
+func (s *scopedRoleClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
 	_, err := s.teleportClient.ScopedAccessServiceClient().DeleteScopedRole(ctx, accessv1.DeleteScopedRoleRequest_builder{
-		Name: name,
+		Name: key.String(),
 	}.Build())
 	return trace.Wrap(err)
 }
 
-func (s *scopedRoleClient) Get(ctx context.Context, name string) (*accessv1.ScopedRole, error) {
+func (s *scopedRoleClient) Get(ctx context.Context, key reconcilers.ResourceKey) (*accessv1.ScopedRole, error) {
 	resp, err := s.teleportClient.ScopedAccessServiceClient().GetScopedRole(ctx, accessv1.GetScopedRoleRequest_builder{
-		Name: name,
+		Name: key.String(),
 	}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/integrations/operator/controllers/resources/scopedroleassignment_controller.go
+++ b/integrations/operator/controllers/resources/scopedroleassignment_controller.go
@@ -41,17 +41,17 @@ func (s *scopedRoleAssignmentClient) Create(ctx context.Context, assignment *acc
 	return trace.Wrap(err)
 }
 
-func (s *scopedRoleAssignmentClient) Delete(ctx context.Context, name string) error {
+func (s *scopedRoleAssignmentClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
 	_, err := s.teleportClient.ScopedAccessServiceClient().DeleteScopedRoleAssignment(ctx, accessv1.DeleteScopedRoleAssignmentRequest_builder{
-		Name:    name,
+		Name:    key.String(),
 		SubKind: scopedaccess.SubKindDynamic,
 	}.Build())
 	return trace.Wrap(err)
 }
 
-func (s *scopedRoleAssignmentClient) Get(ctx context.Context, name string) (*accessv1.ScopedRoleAssignment, error) {
+func (s *scopedRoleAssignmentClient) Get(ctx context.Context, key reconcilers.ResourceKey) (*accessv1.ScopedRoleAssignment, error) {
 	resp, err := s.teleportClient.ScopedAccessServiceClient().GetScopedRoleAssignment(ctx, accessv1.GetScopedRoleAssignmentRequest_builder{
-		Name:    name,
+		Name:    key.String(),
 		SubKind: scopedaccess.SubKindDynamic,
 	}.Build())
 	if err != nil {

--- a/integrations/operator/controllers/resources/scopedtoken_controller.go
+++ b/integrations/operator/controllers/resources/scopedtoken_controller.go
@@ -38,12 +38,12 @@ func (s *scopedTokenClient) Create(ctx context.Context, token *tokenv1.ScopedTok
 	return trace.Wrap(err)
 }
 
-func (s *scopedTokenClient) Delete(ctx context.Context, name string) error {
-	return s.teleportClient.DeleteScopedToken(ctx, name)
+func (s *scopedTokenClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
+	return s.teleportClient.DeleteScopedToken(ctx, key.String())
 }
 
-func (s *scopedTokenClient) Get(ctx context.Context, name string) (*tokenv1.ScopedToken, error) {
-	return s.teleportClient.GetScopedToken(ctx, name, false)
+func (s *scopedTokenClient) Get(ctx context.Context, key reconcilers.ResourceKey) (*tokenv1.ScopedToken, error) {
+	return s.teleportClient.GetScopedToken(ctx, key.String(), false)
 }
 
 func (s *scopedTokenClient) Update(ctx context.Context, token *tokenv1.ScopedToken) error {

--- a/integrations/operator/controllers/resources/trusted_cluster_controller.go
+++ b/integrations/operator/controllers/resources/trusted_cluster_controller.go
@@ -40,8 +40,8 @@ type trustedClusterClient struct {
 }
 
 // Get gets the Teleport trusted_cluster of a given name.
-func (r trustedClusterClient) Get(ctx context.Context, name string) (types.TrustedCluster, error) {
-	trustedCluster, err := r.teleportClient.GetTrustedCluster(ctx, name)
+func (r trustedClusterClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.TrustedCluster, error) {
+	trustedCluster, err := r.teleportClient.GetTrustedCluster(ctx, key.Name)
 	return trustedCluster, trace.Wrap(err)
 }
 
@@ -58,8 +58,8 @@ func (r trustedClusterClient) Update(ctx context.Context, trustedCluster types.T
 }
 
 // Delete deletes a Teleport trusted_cluster.
-func (r trustedClusterClient) Delete(ctx context.Context, name string) error {
-	return trace.Wrap(r.teleportClient.DeleteTrustedCluster(ctx, name))
+func (r trustedClusterClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
+	return trace.Wrap(r.teleportClient.DeleteTrustedCluster(ctx, key.Name))
 }
 
 // Mutate mutates a Teleport trusted_cluster.

--- a/integrations/operator/controllers/resources/user_controller.go
+++ b/integrations/operator/controllers/resources/user_controller.go
@@ -37,8 +37,8 @@ type userClient struct {
 }
 
 // Get gets the Teleport user of a given name
-func (r userClient) Get(ctx context.Context, name string) (types.User, error) {
-	user, err := r.teleportClient.GetUser(ctx, name, false /* with secrets*/)
+func (r userClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.User, error) {
+	user, err := r.teleportClient.GetUser(ctx, key.Name, false /* with secrets*/)
 	return user, trace.Wrap(err)
 }
 
@@ -55,8 +55,8 @@ func (r userClient) Update(ctx context.Context, user types.User) error {
 }
 
 // Delete deletes a Teleport user
-func (r userClient) Delete(ctx context.Context, name string) error {
-	return trace.Wrap(r.teleportClient.DeleteUser(ctx, name))
+func (r userClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
+	return trace.Wrap(r.teleportClient.DeleteUser(ctx, key.Name))
 }
 
 // Mutate ensures the spec.createdBy property is persisted

--- a/integrations/operator/controllers/resources/workload_identityv1_controller.go
+++ b/integrations/operator/controllers/resources/workload_identityv1_controller.go
@@ -39,12 +39,12 @@ type workloadIdentityClient struct {
 
 // Get gets the Teleport WorkloadIdentity of a given name
 func (l workloadIdentityClient) Get(
-	ctx context.Context, name string,
+	ctx context.Context, key reconcilers.ResourceKey,
 ) (*workloadidentityv1.WorkloadIdentity, error) {
 	resp, err := l.teleportClient.
 		WorkloadIdentityResourceServiceClient().
 		GetWorkloadIdentity(
-			ctx, workloadidentityv1.GetWorkloadIdentityRequest_builder{Name: name}.Build(),
+			ctx, workloadidentityv1.GetWorkloadIdentityRequest_builder{Name: key.Name}.Build(),
 		)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -83,11 +83,11 @@ func (l workloadIdentityClient) Update(
 }
 
 // Delete deletes a Teleport WorkloadIdentity
-func (l workloadIdentityClient) Delete(ctx context.Context, name string) error {
+func (l workloadIdentityClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
 	_, err := l.teleportClient.
 		WorkloadIdentityResourceServiceClient().
 		DeleteWorkloadIdentity(
-			ctx, workloadidentityv1.DeleteWorkloadIdentityRequest_builder{Name: name}.Build(),
+			ctx, workloadidentityv1.DeleteWorkloadIdentityRequest_builder{Name: key.Name}.Build(),
 		)
 	return trace.Wrap(err)
 }


### PR DESCRIPTION
The Kube Operator APIs were updated to support Get and Delete operations that may operate on a name and a scope. For now there is no support for actually providing or consuming the scope. This simply updates the plumbing so that in a follow up change resources that are scoped will be able to operate.


Note: The operator is still limited in that it cannot have two resources with same names in the same scope in the same Kubernetes namespace. This is something @hugoShaka is aware of and has been exploring how to resolve this. It will be addressed independently in the future.