### PR TITLE
Let scope pinned agents read ancestor scoped role

### DIFF
--- a/lib/auth/scopes/access/service.go
+++ b/lib/auth/scopes/access/service.go
@@ -106,7 +106,7 @@ func (s *Server) CreateScopedRole(ctx context.Context, req *scopedaccessv1.Creat
 		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbCreate)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to create scoped roles in the requested scope",
-			"user", authzContext.User.GetName(),
+			"user", authzContext.DisplayName(),
 			"scope", req.GetRole().GetScope())
 		return nil, trace.Wrap(err)
 	}
@@ -158,7 +158,7 @@ func (s *Server) CreateScopedRoleAssignment(ctx context.Context, req *scopedacce
 		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbCreate)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to create scoped role assignments in the requested scope",
-			"user", authzContext.User.GetName(),
+			"user", authzContext.DisplayName(),
 			"scope", req.GetAssignment().GetScope())
 		return nil, trace.Wrap(err)
 	}
@@ -205,7 +205,7 @@ func (s *Server) DeleteScopedRole(ctx context.Context, req *scopedaccessv1.Delet
 		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbDelete)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to delete scoped roles in the requested scope",
-			"user", authzContext.User.GetName(),
+			"user", authzContext.DisplayName(),
 			"scope", grsp.GetRole().GetScope(),
 			"role", req.GetName(),
 			"error", err,
@@ -260,7 +260,7 @@ func (s *Server) DeleteScopedRoleAssignment(ctx context.Context, req *scopedacce
 		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbDelete)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to delete scoped role assignments in the requested scope",
-			"user", authzContext.User.GetName(),
+			"user", authzContext.DisplayName(),
 			"scope", grsp.GetAssignment().GetScope(),
 			"assignment", req.GetName(),
 			"error", err,
@@ -297,12 +297,21 @@ func (s *Server) GetScopedRole(ctx context.Context, req *scopedaccessv1.GetScope
 		return nil, trace.Wrap(err)
 	}
 
-	// evaluate the access to the role based on its scope
-	if err := authzContext.CheckerContext.Decision(ctx, preAuthzRsp.GetRole().GetScope(), func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbReadNoSecrets)
-	}); err != nil {
+	// Evaluate access to the role based on its scope. Only agents are allowed to read ancestor scopes.
+	if authz.ScopedIsLocalOrRemoteService(authzContext) {
+		err = authzContext.CheckerContext.RiskyAuthorizeUnpinnedReadWithScope(
+			ctx,
+			services.UnpinnedReadScopedRole,
+			&ruleCtx,
+			preAuthzRsp.GetRole().GetScope())
+	} else {
+		err = authzContext.CheckerContext.Decision(ctx, preAuthzRsp.GetRole().GetScope(), func(checker *services.ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbReadNoSecrets)
+		})
+	}
+	if err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to read scoped role",
-			"user", authzContext.User.GetName(),
+			"user", authzContext.DisplayName(),
 			"scope", preAuthzRsp.GetRole().GetScope(),
 			"role", req.GetName(),
 			"error", err,
@@ -344,7 +353,7 @@ func (s *Server) GetScopedRoleAssignment(ctx context.Context, req *scopedaccessv
 		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbReadNoSecrets)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to read scoped role assignment",
-			"user", authzContext.User.GetName(),
+			"user", authzContext.DisplayName(),
 			"scope", preAuthzRsp.GetAssignment().GetScope(),
 			"assignment", req.GetName(),
 			"error", err,
@@ -454,7 +463,7 @@ func (s *Server) UpdateScopedRole(ctx context.Context, req *scopedaccessv1.Updat
 		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbUpdate)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to update scoped roles in the requested scope",
-			"user", authzContext.User.GetName(),
+			"user", authzContext.DisplayName(),
 			"scope", req.GetRole().GetScope())
 		return nil, trace.Wrap(err)
 	}
@@ -483,7 +492,7 @@ func (s *Server) UpdateScopedRoleAssignment(ctx context.Context, req *scopedacce
 		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbUpdate)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to update scoped role assignments in the requested scope",
-			"user", authzContext.User.GetName(),
+			"user", authzContext.DisplayName(),
 			"scope", req.GetAssignment().GetScope())
 		return nil, trace.Wrap(err)
 	}
@@ -515,7 +524,7 @@ func (s *Server) UpsertScopedRole(ctx context.Context, req *scopedaccessv1.Upser
 		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbCreate, types.VerbUpdate)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to upsert scoped roles in the requested scope",
-			"user", authzContext.User.GetName(),
+			"user", authzContext.DisplayName(),
 			"scope", req.GetRole().GetScope())
 		return nil, trace.Wrap(err)
 	}
@@ -540,7 +549,7 @@ func (s *Server) UpsertScopedRoleAssignment(ctx context.Context, req *scopedacce
 		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbCreate, types.VerbUpdate)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to upsert scoped role assignments in the requested scope",
-			"user", authzContext.User.GetName(),
+			"user", authzContext.DisplayName(),
 			"scope", req.GetAssignment().GetScope())
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/scopes/access/service_test.go
+++ b/lib/auth/scopes/access/service_test.go
@@ -120,6 +120,94 @@ func newServerForIdentity(t *testing.T, bk *backendPack, accessInfo *services.Ac
 	return srv
 }
 
+// newServerForAgent builds a server whose scoped context is a scoped agent.
+func newServerForAgent(t *testing.T, bk *backendPack, pin *scopesv1.Pin) *Server {
+	t.Helper()
+
+	roleSet, err := services.RoleSetFromSpec("test-agent-role", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Rules: []types.Rule{types.NewRule(types.Wildcard, services.RW())},
+		},
+	})
+	require.NoError(t, err)
+
+	roleName := pin.GetSystemRoles().GetPrimary()
+	checker := services.NewAccessCheckerWithRoleSet(&services.AccessInfo{}, testClusterName, roleSet)
+	checkerCtx, err := services.NewScopedAccessCheckerContextForAgentPin(pin, map[string]*services.ScopedAccessChecker{
+		roleName: services.NewScopedAccessCheckerForSystemRole(roleName, checker),
+	})
+	require.NoError(t, err)
+
+	authorizer := &fakeSplitAuthorizer{
+		ctx: &authz.ScopedContext{
+			User:           &types.UserV2{Metadata: types.Metadata{Name: "agent"}},
+			Identity:       authz.ScopedBuiltinRole{ScopePin: pin},
+			CheckerContext: checkerCtx,
+		},
+	}
+
+	srv, err := New(Config{
+		ScopedAuthorizer: authorizer,
+		Reader:           bk.cache,
+		Writer:           bk.service,
+		BackendReader:    bk.service,
+		ScopesFeatures:   scopes.Features{Enabled: true},
+	})
+	require.NoError(t, err)
+
+	return srv
+}
+
+// TestGetScopedRoleAgentReadsAncestorScope verifies that a scoped agent can read a
+// scoped role at an ancestor of its pinned scope.
+func TestGetScopedRoleAgentReadsAncestorScope(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	bk := newBackendPack(t)
+	defer bk.Close()
+
+	// A role at /staging, an ancestor of the agent's pin (/staging/west).
+	_, err := bk.service.CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+		Role: scopedaccessv1.ScopedRole_builder{
+			Kind:     scopedaccess.KindScopedRole,
+			Metadata: headerv1.Metadata_builder{Name: "staging-admin"}.Build(),
+			Scope:    "/staging",
+			Spec: scopedaccessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{"/staging"},
+				Rules: []*scopedaccessv1.ScopedRule{
+					scopedaccessv1.ScopedRule_builder{
+						Resources: []string{scopedaccess.KindScopedRole},
+						Verbs:     []string{types.VerbReadNoSecrets},
+					}.Build(),
+				},
+			}.Build(),
+			Version: types.V1,
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	waitForRoleCondition(t, bk.cache, func(roles []*scopedaccessv1.ScopedRole) bool {
+		return len(roles) == 1
+	})
+
+	// Agent pinned to /staging/west — a descendant of the role's /staging scope.
+	srv := newServerForAgent(t, bk, scopesv1.Pin_builder{
+		Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+		Scope: "/staging/west",
+		SystemRoles: scopesv1.SystemRoles_builder{
+			Primary: string(types.RoleApp),
+		}.Build(),
+	}.Build())
+
+	rrsp, err := srv.GetScopedRole(ctx, scopedaccessv1.GetScopedRoleRequest_builder{
+		Name: "staging-admin",
+	}.Build())
+	require.NoError(t, err)
+	require.Equal(t, "staging-admin", rrsp.GetRole().GetMetadata().GetName())
+	require.Equal(t, "/staging", rrsp.GetRole().GetScope())
+}
+
 type backendPack struct {
 	backend        backend.Backend
 	service        *local.ScopedAccessService

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -2125,12 +2125,7 @@ func IsLocalOrRemoteUser(authContext Context) bool {
 
 // IsLocalOrRemoteService checks if the identity is either a local or remote service.
 func IsLocalOrRemoteService(authContext Context) bool {
-	switch authContext.UnmappedIdentity.(type) {
-	case BuiltinRole, RemoteBuiltinRole:
-		return true
-	default:
-		return false
-	}
+	return isLocalOrRemoteService(authContext.UnmappedIdentity)
 }
 
 // IsCurrentUser checks if the identity is a local user matching the given username
@@ -2142,6 +2137,30 @@ func IsCurrentUser(authContext Context, username string) bool {
 func ScopedIsCurrentUser(scopedContext *ScopedContext, username string) bool {
 	_, isLocal := scopedContext.Identity.(LocalUser)
 	return isLocal && scopedContext.User.GetName() == username
+}
+
+// ScopedIsLocalOrRemoteService checks if the scoped identity is either a local or
+// remote service, for scoped or unscoped agents alike. This is the
+// scoped aware counterpart to [IsLocalOrRemoteService].
+// RemoteBuiltinRoles continue to be only available for unscoped identities.
+func ScopedIsLocalOrRemoteService(scopedContext *ScopedContext) bool {
+	if scopedContext == nil {
+		return false
+	}
+
+	if scopedContext.unscopedContext != nil {
+		return isLocalOrRemoteService(scopedContext.unscopedContext.UnmappedIdentity)
+	}
+	return isLocalOrRemoteService(scopedContext.Identity)
+}
+
+func isLocalOrRemoteService(identity IdentityGetter) bool {
+	switch identity.(type) {
+	case BuiltinRole, RemoteBuiltinRole, ScopedBuiltinRole:
+		return true
+	default:
+		return false
+	}
 }
 
 // IsRemoteUser checks if the identity is a remote user.

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -1795,6 +1795,104 @@ func TestScopedContextLockTargets(t *testing.T) {
 	})
 }
 
+func TestScopedContextDisplayName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		scopedCtx *authz.ScopedContext
+		want      string
+	}{
+		{
+			name: "user identity uses the user name",
+			scopedCtx: &authz.ScopedContext{
+				User:     &types.UserV2{Metadata: types.Metadata{Name: "alice"}},
+				Identity: authz.LocalUser{Identity: tlsca.Identity{Username: "alice-identity"}},
+			},
+			want: "alice",
+		},
+		{
+			name: "agent identity falls back to the identity username",
+			scopedCtx: &authz.ScopedContext{
+				Identity: authz.ScopedBuiltinRole{Identity: tlsca.Identity{Username: "alice-identity"}},
+			},
+			want: "alice-identity",
+		},
+		{
+			name:      "empty when neither user nor identity is set",
+			scopedCtx: &authz.ScopedContext{},
+			want:      "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.scopedCtx.DisplayName())
+		})
+	}
+}
+
+func TestScopedIsLocalOrRemoteService(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		want      bool
+		scopedCtx *authz.ScopedContext
+	}{
+		{name: "builtin role (unscoped agent)",
+			want:      true,
+			scopedCtx: &authz.ScopedContext{Identity: authz.BuiltinRole{}},
+		},
+		{
+			name:      "remote builtin role",
+			want:      true,
+			scopedCtx: &authz.ScopedContext{Identity: authz.RemoteBuiltinRole{}},
+		},
+		{
+			name:      "scoped builtin role",
+			want:      true,
+			scopedCtx: &authz.ScopedContext{Identity: authz.ScopedBuiltinRole{}},
+		},
+		{
+			name:      "local user",
+			want:      false,
+			scopedCtx: &authz.ScopedContext{Identity: authz.LocalUser{}},
+		},
+		{
+			name:      "remote user",
+			want:      false,
+			scopedCtx: &authz.ScopedContext{Identity: authz.RemoteUser{}},
+		},
+		{
+			name:      "unauthenticated",
+			want:      false,
+			scopedCtx: &authz.ScopedContext{Identity: authz.UnauthenticatedRole{}},
+		},
+		// Unscoped-wrapped contexts (unscopedContext != nil) delegate to
+		// IsLocalOrRemoteService rather than hitting the identity switch.
+		{
+			name:      "unscoped-wrapped builtin role",
+			want:      true,
+			scopedCtx: authz.ScopedContextFromUnscopedContext(&authz.Context{UnmappedIdentity: authz.BuiltinRole{}}),
+		},
+		{
+			name:      "unscoped-wrapped remote builtin role",
+			want:      true,
+			scopedCtx: authz.ScopedContextFromUnscopedContext(&authz.Context{UnmappedIdentity: authz.RemoteBuiltinRole{}}),
+		},
+		{
+			name:      "unscoped-wrapped local user",
+			want:      false,
+			scopedCtx: authz.ScopedContextFromUnscopedContext(&authz.Context{UnmappedIdentity: authz.LocalUser{}}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, authz.ScopedIsLocalOrRemoteService(tt.scopedCtx))
+		})
+	}
+}
+
 // brokenScopedRoleReader is a minimal ScopedRoleReader for use in tests that need a non-nil reader
 // but aren't expected to actually need any scoped roles.
 type brokenScopedRoleReader struct{}

--- a/lib/authz/scoped.go
+++ b/lib/authz/scoped.go
@@ -292,3 +292,17 @@ func (s *ScopedContext) LockTargets() []types.LockTarget {
 	}
 	return lockTargets
 }
+
+// DisplayName returns a display name for the calling identity.
+// authzContext.User is nil for non-user (agent/builtin) identities, so fall back to
+// the identity's username.
+// TODO (williamo/scopes) - consider implementing slog.LogValuer if we end up only needing this for logging.
+func (s *ScopedContext) DisplayName() string {
+	if s.User != nil {
+		return s.User.GetName()
+	}
+	if s.Identity != nil {
+		return s.Identity.GetIdentity().Username
+	}
+	return ""
+}

--- a/lib/services/scoped_access_checker_context.go
+++ b/lib/services/scoped_access_checker_context.go
@@ -30,6 +30,7 @@ import (
 	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -222,8 +223,14 @@ func (c *ScopedAccessCheckerContext) checkersForResourceScope(ctx context.Contex
 		// particular role. For example, if a user has a scoped role assigned at /foo which grants access to all ssh
 		// nodes, but they are pinned to scope /foo/bar, even if a role at /foo permits access, the pin restricts
 		// access to only resources subject to /foo/bar.
-		if enforcePin && !pinning.PinAppliesToResourceScope(c.pin, scope) {
-			yield(nil, trace.AccessDenied("scope pin %q does not apply to resource scope %q", c.pin.GetScope(), scope))
+		if enforcePin {
+			if !pinning.PinAppliesToResourceScope(c.pin, scope) {
+				yield(nil, trace.AccessDenied("scope pin %q does not apply to resource scope %q", c.pin.GetScope(), scope))
+				return
+			}
+		} else if !pinning.PinCompatibleWithPolicyScope(c.pin, scope) {
+			// Unpinned reads should still not allow orthogonal reads.
+			yield(nil, trace.AccessDenied("scope pin %q is orthogonal to resource scope %q", c.pin.GetScope(), scope))
 			return
 		}
 
@@ -426,6 +433,25 @@ func (c *ScopedAccessCheckerContext) RiskyAuthorizeUnpinnedRead(
 	)
 }
 
+// RiskyAuthorizeUnpinnedReadWithScope extends [RiskyAuthorizeUnpinnedRead].
+// It authorizes a read-only access check that bypasses
+// enforcement of the identity's pinned scope, but ensures that the
+// resource scope is related to the identity's pinned scope.
+// This must only be used for specific APIs that make an exception to pinning exclusion rules (e.g.
+// allowing read operations for resources at a parent scope). To avoid misuse,
+// a specific [UnpinnedReadAuthorization] must be provided that will encode the
+// effective scope of the access check and the allowed verbs. The scope provided
+// must not be empty, and will be used to determine the enforcement.
+func (c *ScopedAccessCheckerContext) RiskyAuthorizeUnpinnedReadWithScope(
+	ctx context.Context,
+	authz UnpinnedReadAuthorization,
+	ruleCtx RuleContext,
+	resourceScope string,
+) error {
+	authz.resourceScope = resourceScope
+	return c.RiskyAuthorizeUnpinnedRead(ctx, authz, ruleCtx)
+}
+
 // UnpinnedReadAuthorization is a special authorization to complete an unscoped
 // read-only access check. This is meant to be used for access checks on
 // typically cluster-wide resources that need to be readable by identities with
@@ -532,6 +558,14 @@ var (
 	UnpinnedReadSessionRecordingConfig = UnpinnedReadAuthorization{
 		resourceScope: scopes.Root,
 		kind:          types.KindSessionRecordingConfig,
+		verbs:         []string{types.VerbRead},
+	}
+
+	// UnpinnedReadScopedRole is a special authorization to complete an
+	// unscoped access check to read a scoped role.
+	UnpinnedReadScopedRole = UnpinnedReadAuthorization{
+		resourceScope: scopes.Root,
+		kind:          scopedaccess.KindScopedRole,
 		verbs:         []string{types.VerbRead},
 	}
 )

--- a/lib/services/scoped_access_checker_context_test.go
+++ b/lib/services/scoped_access_checker_context_test.go
@@ -61,6 +61,60 @@ func TestScopedAccessCheckerContextRiskyAuthorizeUnpinnedRead(t *testing.T) {
 	require.ErrorAs(t, err, new(*trace.BadParameterError))
 }
 
+// TestRiskyAuthorizeUnpinnedReadWithScope verifies that the per-call resourceScope
+// overrides the authorization's scope and is used to determine the resulting access decision.
+func TestRiskyAuthorizeUnpinnedReadWithScope(t *testing.T) {
+	t.Parallel()
+
+	const pinScope = "/test/scope"
+	pin := scopesv1.Pin_builder{
+		Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+		Scope: pinScope,
+		SystemRoles: scopesv1.SystemRoles_builder{
+			Primary: types.RoleNode.String(),
+		}.Build(),
+	}.Build()
+	checkerCtx := newAgentPinCheckerContext(t, pin)
+
+	tests := []struct {
+		name          string
+		resourceScope string
+		wantErr       string
+	}{
+		{
+			name:          "override to pin scope is allowed",
+			resourceScope: pinScope,
+		},
+		{
+			name:          "override to descendant scope is allowed",
+			resourceScope: pinScope + "/child",
+		},
+		{
+			name:          "override to ancestor (root) scope is allowed",
+			resourceScope: scopes.Root,
+		},
+		{
+			name:          "override to orthogonal scope is denied",
+			resourceScope: "/other",
+			wantErr:       "scope pin \"/test/scope\" is orthogonal to resource scope \"/other\"",
+		},
+		{
+			name:          "override to empty scope is rejected",
+			resourceScope: "",
+			wantErr:       "scope is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkerCtx.RiskyAuthorizeUnpinnedReadWithScope(t.Context(), UnpinnedReadScopedRole, &Context{}, tt.resourceScope)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 type emptyScopedRoleReader struct{}
 
 func (emptyScopedRoleReader) GetScopedRole(context.Context, *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {


### PR DESCRIPTION
The introduction of agent pins broke access from ancestor scoped for ssh/k8s. The agent is not allowed to read ancestor scopes with the `Decision` API enforcing pins.

This pr alters  `checkersForResourceScope` such that when pinning isn't enforced, it should still only be able to check ancestor scopes.

It introduces a new `RiskyAuthorizeUnpinnedReadWithScope` where you still need to define a UnpinnedReadAuthorization, but will allow to override the scope from the default "/" root behavior. 

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster, k3d kube env, docker ssh agents

### Test Cases
- [x] Agent pin ssh and k8s works (tested on erik's branch)
- [x] Unscoped access is unchanged
- [x] Scoped non agent pin access still works
