### PR TITLE
[v17] Enforce connection limits on the ALPN proxy listener

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4446,6 +4446,11 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		return trace.Wrap(err)
 	}
 
+	alpnLimiter, err := limiter.NewLimiter(cfg.Proxy.Limiter)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	// make a caching auth client for the auth server:
 	accessPoint, err := process.newLocalCacheForProxy(conn.Client, []string{teleport.ComponentProxy})
 	if err != nil {
@@ -5668,6 +5673,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			Listener:          listeners.alpn,
 			ClusterName:       clusterName,
 			AccessPoint:       accessPoint,
+			Limiter:           alpnLimiter,
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -5695,6 +5701,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				Listener:          listeners.reverseTunnelALPN,
 				ClusterName:       clusterName,
 				AccessPoint:       accessPoint,
+				Limiter:           reverseTunnelLimiter,
 			})
 			if err != nil {
 				return trace.Wrap(err)

--- a/lib/srv/alpnproxy/helpers_test.go
+++ b/lib/srv/alpnproxy/helpers_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -53,6 +54,7 @@ type Suite struct {
 	authServer     *authtest.AuthServer
 	tlsServer      *authtest.TLSServer
 	accessPoint    *authclient.Client
+	limiter        *limiter.Limiter
 }
 
 func NewSuite(t *testing.T) *Suite {
@@ -90,6 +92,11 @@ func NewSuite(t *testing.T) *Suite {
 
 	router := NewRouter()
 
+	// An empty limiter config applies no limits; tests exercising connection
+	// limits override this field before starting the proxy.
+	connLimiter, err := limiter.NewLimiter(limiter.Config{})
+	require.NoError(t, err)
+
 	return &Suite{
 		tlsServer:      tlsServer,
 		authServer:     authServer,
@@ -97,6 +104,7 @@ func NewSuite(t *testing.T) *Suite {
 		ca:             ca,
 		serverListener: l,
 		router:         router,
+		limiter:        connLimiter,
 	}
 }
 
@@ -129,6 +137,7 @@ func (s *Suite) CreateProxyServer(t *testing.T) *Proxy {
 		AccessPoint:       s.accessPoint,
 		IdentityTLSConfig: tlsConfig,
 		ClusterName:       "root",
+		Limiter:           s.limiter,
 	}
 
 	svr, err := New(proxyConfig)

--- a/lib/srv/alpnproxy/proxy.go
+++ b/lib/srv/alpnproxy/proxy.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/srv/db/dbutils"
@@ -74,6 +75,9 @@ type ProxyConfig struct {
 	ClusterName string
 	// PingInterval defines the ping interval for ping-wrapped connections.
 	PingInterval time.Duration
+	// Limiter applies a per-client-IP limit on the number of simultaneous connections
+	// accepted from the Listener.
+	Limiter *limiter.Limiter
 }
 
 // NewRouter creates a ALPN new router.
@@ -259,6 +263,14 @@ func (c *ProxyConfig) CheckAndSetDefaults() error {
 	if c.Listener == nil {
 		return trace.BadParameter("listener missing")
 	}
+	if c.Limiter == nil {
+		return trace.BadParameter("limiter missing")
+	}
+	listener, err := c.Limiter.WrapListener(c.Listener)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	c.Listener = listener
 	if c.Log == nil {
 		c.Log = logrus.WithField(teleport.ComponentKey, "alpn:proxy")
 	}
@@ -305,6 +317,7 @@ func New(cfg ProxyConfig) (*Proxy, error) {
 		proxyConnectionsTotal,
 		proxyActiveConnections,
 		proxyConnectionErrorsTotal,
+		proxyConnectionLimitExceededTotal,
 	); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -333,6 +346,11 @@ func (p *Proxy) Serve(ctx context.Context) error {
 	for {
 		clientConn, err := p.cfg.Listener.Accept()
 		if err != nil {
+			if trace.IsLimitExceeded(err) {
+				proxyConnectionLimitExceededTotal.Inc()
+				p.log.WithError(err).Warn("Connection limit exceeded, rejecting connection. Adjust the limit with the connection_limits.max_connections config field.")
+				continue
+			}
 			if utils.IsOKNetworkError(err) || trace.IsConnectionProblem(err) || ctx.Err() != nil {
 				return nil
 			}
@@ -761,5 +779,13 @@ var (
 			Help:      "Number of connection handler errors encountered by TLS routing proxy server.",
 		},
 		[]string{"alpn", "source"},
+	)
+	proxyConnectionLimitExceededTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: teleport.MetricNamespace,
+			Subsystem: "alpn_proxy",
+			Name:      "connection_limit_exceeded_total",
+			Help:      "Number of connections rejected by TLS routing proxy server due to exceeded connection limits.",
+		},
 	)
 )

--- a/lib/srv/alpnproxy/proxy_test.go
+++ b/lib/srv/alpnproxy/proxy_test.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/utils/pingconn"
+	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/srv/db/dbutils"
@@ -351,6 +352,79 @@ func TestProxyHTTPConnection(t *testing.T) {
 		},
 	}
 
+	mustSuccessfullyCallHTTPSServer(t, suite.GetServerAddress(), client)
+}
+
+// TestProxyConnectionLimiting verifies that the ALPN proxy enforces the
+// configured per-client connection limit, keeps accepting connections after
+// rejecting an over-limit one, and releases limiter slots on connection close.
+func TestProxyConnectionLimiting(t *testing.T) {
+	t.Parallel()
+
+	const maxConnections = 2
+
+	suite := NewSuite(t)
+	connLimiter, err := limiter.NewLimiter(limiter.Config{MaxConnections: maxConnections})
+	require.NoError(t, err)
+	suite.limiter = connLimiter
+
+	l := mustCreateLocalListener(t)
+	lw := NewMuxListenerWrapper(l, suite.serverListener)
+	mustStartHTTPServer(t, lw)
+
+	suite.router = NewRouter()
+	suite.router.Add(HandlerDecs{
+		MatchFunc: MatchByProtocol(common.ProtocolHTTP2, common.ProtocolHTTP),
+		Handler:   lw.HandleConnection,
+	})
+	suite.Start(t)
+
+	// The limiter tracks connections by client IP, which for this test is the
+	// same loopback address the server listens on.
+	clientIP, _, err := net.SplitHostPort(suite.GetServerAddress())
+	require.NoError(t, err)
+
+	// Occupy all limiter slots with connections that stall before sending a
+	// TLS hello, like the attack the limiter defends against.
+	heldConns := make([]net.Conn, 0, maxConnections)
+	for range maxConnections {
+		conn, err := net.Dial("tcp", suite.GetServerAddress())
+		require.NoError(t, err)
+		t.Cleanup(func() { conn.Close() })
+		heldConns = append(heldConns, conn)
+	}
+	require.Eventually(t, func() bool {
+		count, err := connLimiter.GetNumConnection(clientIP)
+		return err == nil && count == maxConnections
+	}, 5*time.Second, 10*time.Millisecond, "expected held connections to occupy all limiter slots")
+
+	// The next connection exceeds the limit: the proxy must close it right
+	// away instead of waiting out the TLS handshake read deadline.
+	rejected, err := net.Dial("tcp", suite.GetServerAddress())
+	require.NoError(t, err)
+	t.Cleanup(func() { rejected.Close() })
+	require.NoError(t, rejected.SetReadDeadline(time.Now().Add(5*time.Second)))
+	_, err = rejected.Read(make([]byte, 1))
+	require.ErrorIs(t, err, io.EOF, "expected over-limit connection to be closed by the proxy")
+
+	// Closing a held connection must release its limiter slot.
+	require.NoError(t, heldConns[0].Close())
+	require.Eventually(t, func() bool {
+		count, err := connLimiter.GetNumConnection(clientIP)
+		return err == nil && count == maxConnections-1
+	}, 5*time.Second, 10*time.Millisecond, "expected closed connection to release its limiter slot")
+
+	// A request through the freed slot must succeed, proving the accept loop
+	// survived the over-limit rejection above.
+	client := http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				ServerName: "localhost",
+				RootCAs:    suite.GetCertPool(),
+			},
+			DisableKeepAlives: true,
+		},
+	}
 	mustSuccessfullyCallHTTPSServer(t, suite.GetServerAddress(), client)
 }
 


### PR DESCRIPTION
Backport of #67686 to `branch/v17`.

Changelog: The Teleport proxy now enforces the configured connection limit (`connection_limits.max_connections`) on its multiplexed TLS routing (ALPN) listener.