### PR TITLE
[v17] Improve tsh kubectl traces

### DIFF
--- a/tool/tsh/common/kubectl.go
+++ b/tool/tsh/common/kubectl.go
@@ -20,6 +20,8 @@ package common
 
 import (
 	"bufio"
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -34,6 +36,7 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/spf13/cobra"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -45,6 +48,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/observability/tracing"
 	tracehttp "github.com/gravitational/teleport/api/observability/tracing/http"
 	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
@@ -97,20 +101,28 @@ const (
 	// tshKubectlReexecEnvVar is the name of the environment variable used to control if
 	// tsh should re-exec or execute a kubectl command.
 	tshKubectlReexecEnvVar = "TSH_KUBE_REEXEC"
+	tshTraceContextEnvVar  = "TSH_TRACE_CONTEXT"
 )
 
 // runKubectlReexec reexecs itself and copies the `stderr` output into
 // the provided collector.
 // It also sets tshKubectlReexec for the command to prevent
 // an exec loop
-func runKubectlReexec(cf *CLIConf, fullArgs, args []string, collector io.Writer) error {
+func runKubectlReexec(ctx context.Context, cf *CLIConf, fullArgs, args []string, collector io.Writer) error {
 	closeFn, newKubeConfigLocation, err := maybeStartKubeLocalProxy(cf, withKubectlArgs(args))
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	defer closeFn()
 
-	cmdEnv := append(os.Environ(), fmt.Sprintf("%s=yes", tshKubectlReexecEnvVar))
+	cmdEnv := append(os.Environ(), tshKubectlReexecEnvVar+"=yes")
+	if span := oteltrace.SpanFromContext(ctx); span.IsRecording() {
+		if traceCtx := tracing.PropagationContextFromContext(ctx); len(traceCtx) > 0 {
+			if out, err := json.Marshal(traceCtx); err == nil {
+				cmdEnv = append(cmdEnv, tshTraceContextEnvVar+"="+string(out))
+			}
+		}
+	}
 
 	// Update kubeconfig location.
 	if newKubeConfigLocation != "" {
@@ -119,7 +131,7 @@ func runKubectlReexec(cf *CLIConf, fullArgs, args []string, collector io.Writer)
 	}
 
 	// Execute.
-	cmd := exec.Command(cf.executablePath, fullArgs...)
+	cmd := exec.CommandContext(ctx, cf.executablePath, fullArgs...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = io.MultiWriter(os.Stderr, collector)
@@ -129,19 +141,43 @@ func runKubectlReexec(cf *CLIConf, fullArgs, args []string, collector io.Writer)
 
 // wrapConfigFn wraps the rest.Config with a custom RoundTripper if the user
 // wants to sample traces.
-func wrapConfigFn(cf *CLIConf) func(c *rest.Config) *rest.Config {
+func wrapConfigFn(span oteltrace.Span) func(c *rest.Config) *rest.Config {
 	return func(c *rest.Config) *rest.Config {
-		c.Wrap(
-			func(rt http.RoundTripper) http.RoundTripper {
-				if cf.SampleTraces {
-					// If the user wants to sample traces, wrap the transport with a trace
-					// transport.
-					return tracehttp.NewTransport(rt)
-				}
+		c.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+			if !span.IsRecording() {
 				return rt
-			},
+			}
+
+			// Wrap the transport with a transport that injects span context
+			// since kubectl uses context.TODO() for all requests.
+			return &spanContextTripper{span: span, RoundTripper: tracehttp.NewTransport(rt)}
+		},
 		)
 		return c
+	}
+}
+
+// spanContextTripper wraps an [http.RoundTrip] so that tracing context
+// can be injected into any requests made.
+//
+// This is a workaround for kubectl which hardcodes [context.TODO()] instead of
+// using the passed in context. Without this tracing information does not
+// get forwarded in HTTP requests issued to other Teleport components.
+type spanContextTripper struct {
+	span oteltrace.Span
+	http.RoundTripper
+}
+
+func (t *spanContextTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	return t.RoundTripper.RoundTrip(r.WithContext(oteltrace.ContextWithSpan(r.Context(), t.span)))
+}
+
+func (t *spanContextTripper) CloseIdleConnections() {
+	type closeIdler interface {
+		CloseIdleConnections()
+	}
+	if c, ok := t.RoundTripper.(closeIdler); ok {
+		c.CloseIdleConnections()
 	}
 }
 
@@ -150,21 +186,16 @@ func wrapConfigFn(cf *CLIConf) func(c *rest.Config) *rest.Config {
 // because we need to retry kubectl calls and `kubectl` calls os.Exit in multiple
 // paths.
 func runKubectlCode(cf *CLIConf, args []string) {
-	closeTracer := initializeTracing(cf)
-	// If the user opted to not sample traces, cf.TracingProvider is pre-initialized
-	// with a noop provider.
 	ctx, span := cf.TracingProvider.Tracer("kubectl").Start(cf.Context, "kubectl")
-	closeSpanAndTracer := func() {
-		span.End()
-		closeTracer()
-	}
+	defer span.End()
+
 	// These values are the defaults used by kubectl and can be found here:
 	// https://github.com/kubernetes/kubectl/blob/3612c18ed86fc0a2f4467ca355b3e21569fabe0a/pkg/cmd/cmd.go#L94
 	defaultConfigFlags := genericclioptions.NewConfigFlags(true).
 		WithDeprecatedPasswordFlag().
 		WithDiscoveryBurst(300).
 		WithDiscoveryQPS(50.0).
-		WithWrapConfigFn(wrapConfigFn(cf))
+		WithWrapConfigFn(wrapConfigFn(span))
 
 	command := cmd.NewDefaultKubectlCommandWithArgs(
 		cmd.KubectlOptions{
@@ -182,16 +213,15 @@ func runKubectlCode(cf *CLIConf, args []string) {
 
 	// run command until it finishes.
 	if err := cli.RunNoErrOutput(command); err != nil {
-		closeSpanAndTracer()
-		// Pretty-print the error and exit with an error.
+		tracing.EndSpan(span, err)
 		cmdutil.CheckErr(err)
 	}
-
-	closeSpanAndTracer()
-	os.Exit(0)
 }
 
 func runKubectlAndCollectRun(cf *CLIConf, fullArgs, args []string) error {
+	ctx, span := cf.tracer.Start(cf.Context, "kubectl/reexec")
+	defer span.End()
+
 	var (
 		alreadyRequestedAccess bool
 		err                    error
@@ -202,7 +232,7 @@ func runKubectlAndCollectRun(cf *CLIConf, fullArgs, args []string) error {
 		// was rejected in this kubectl call.
 		missingKubeResources := make([]resourceKind, 0, 50)
 		reader, writer := io.Pipe()
-		group, _ := errgroup.WithContext(cf.Context)
+		group, _ := errgroup.WithContext(ctx)
 		group.Go(
 			func() error {
 				// This goroutine scans each line of output emitted to stderr by kubectl
@@ -236,7 +266,7 @@ func runKubectlAndCollectRun(cf *CLIConf, fullArgs, args []string) error {
 			},
 		)
 
-		err := runKubectlReexec(cf, fullArgs, args, writer)
+		err := runKubectlReexec(ctx, cf, fullArgs, args, writer)
 		writer.CloseWithError(io.EOF)
 
 		if scanErr := group.Wait(); scanErr != nil {
@@ -265,6 +295,7 @@ func runKubectlAndCollectRun(cf *CLIConf, fullArgs, args []string) error {
 	}
 	// exit with the kubectl exit code to keep compatibility.
 	if errors.As(err, &exitErr) {
+		tracing.EndSpan(span, exitErr)
 		os.Exit(exitErr.ExitCode())
 	}
 	return nil

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -21,6 +21,7 @@ package common
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -63,6 +64,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/metadata"
+	apitracing "github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -1874,15 +1876,28 @@ func initializeTracing(cf *CLIConf) func() {
 	cf.TracingProvider = tracing.NoopProvider()
 	cf.tracer = cf.TracingProvider.Tracer(teleport.ComponentTSH)
 
-	// flush ensures that the spans are all attempted to be written when tsh exits.
+	// flush ends the root span and ensures that the spans are all attempted to be written when tsh exits.
+	var rootSpan oteltrace.Span
 	flush := func(provider *tracing.Provider) func() {
 		return func() {
+			if rootSpan != nil {
+				rootSpan.End()
+			}
+
 			shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(cf.Context), time.Second)
 			defer cancel()
 			err := provider.Shutdown(shutdownCtx)
 			if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 				log.WithError(err).Debug("failed to shutdown trace provider")
 			}
+		}
+	}
+
+	var propContext apitracing.PropagationContext
+	if traceContext := os.Getenv(tshTraceContextEnvVar); traceContext != "" {
+		logger.DebugContext(cf.Context, "found tracing context in environment", "context", traceContext)
+		if err := json.Unmarshal([]byte(traceContext), &propContext); err == nil {
+			logger.DebugContext(cf.Context, "tracing context was valid", "context", propContext)
 		}
 	}
 
@@ -1893,16 +1908,6 @@ func initializeTracing(cf *CLIConf) func() {
 	const samplingRate = 1.0
 
 	switch {
-	// kubectl is a special case because it is the only command that we re-execute
-	// in order to be able to access the exit code and stdout/stderr of the command
-	// that was run and determine if we should create a new access request from
-	// the output data.
-	// We don't want to enable tracing for the master invocation of tsh kubectl
-	// because the data that we would be tracing would be the tsh kubectl command.
-	// Instead, we want to enable tracing for the re-executed kubectl command and
-	// we do that in the kubectl command handler.
-	case cf.command == "kubectl":
-		return func() {}
 	// The user explicitly asked for traces to be sent to a particular exporter
 	// instead of forwarding them to Auth. Proceed with creating the provider.
 	case cf.SampleTraces && cf.TraceExporter != "":
@@ -1918,6 +1923,7 @@ func initializeTracing(cf *CLIConf) func() {
 
 		cf.TracingProvider = provider
 		cf.tracer = provider.Tracer(teleport.ComponentTSH)
+		cf.Context, rootSpan = cf.tracer.Start(apitracing.WithPropagationContext(cf.Context, propContext), cf.command)
 		return flush(provider)
 	// The login command cannot forward spans to Auth since there is no way to get
 	// an authenticated client to forward with until after the authentication ceremony
@@ -1967,6 +1973,7 @@ func initializeTracing(cf *CLIConf) func() {
 
 	cf.TracingProvider = provider
 	cf.tracer = provider.Tracer(teleport.ComponentTSH)
+	cf.Context, rootSpan = cf.tracer.Start(apitracing.WithPropagationContext(cf.Context, propContext), cf.command)
 	return flush(provider)
 }
 


### PR DESCRIPTION
Attempting to backport https://github.com/gravitational/teleport/pull/63652 / https://github.com/gravitational/teleport/pull/63762 to `v17`.

Currently we're still on v17 but would like to make better use of tracing; without this fix we're unable to link the traces that `tsh` emits with the traces our tooling emits.

Changelog: Improved tracing support via tsh --trace kubectl.