### PR TITLE
[v18] Honor wildcard kube RBAC verb regardless of position

### DIFF
--- a/lib/kube/proxy/fast_matcher_test.go
+++ b/lib/kube/proxy/fast_matcher_test.go
@@ -93,7 +93,7 @@ func TestNewMatcher(t *testing.T) {
 			kind: types.KindKubePod,
 			verb: types.KubeVerbList,
 			allowed: []types.KubernetesResource{
-				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbGet, types.Wildcard}, APIGroup: "*"},
+				{Kind: types.KindKubePod, Namespace: types.Wildcard, Name: types.Wildcard, Verbs: []string{types.KubeVerbGet, types.Wildcard}, APIGroup: types.Wildcard},
 			},
 			wantAllowCount: 1,
 		},

--- a/lib/kube/proxy/fast_matcher_test.go
+++ b/lib/kube/proxy/fast_matcher_test.go
@@ -89,13 +89,13 @@ func TestNewMatcher(t *testing.T) {
 			wantAllowCount: 0,
 		},
 		{
-			name: "wildcard verb only recognized as first element",
+			name: "wildcard verb recognized in non-first position",
 			kind: types.KindKubePod,
 			verb: types.KubeVerbList,
 			allowed: []types.KubernetesResource{
 				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbGet, types.Wildcard}, APIGroup: "*"},
 			},
-			wantAllowCount: 0,
+			wantAllowCount: 1,
 		},
 		{
 			name: "wildcard verb as first element matches any verb",

--- a/lib/kube/proxy/self_subject_reviews.go
+++ b/lib/kube/proxy/self_subject_reviews.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"net/http"
 	"path"
-	"slices"
 
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
@@ -311,7 +310,7 @@ func (m *kubernetesResourceMatcher) Match(role types.Role, condition types.RoleC
 		if !isResourceTheSameKind && !namespaceScopeMatch {
 			continue
 		}
-		if len(m.resource.Verbs) == 1 && !isVerbAllowed(resource.Verbs, m.resource.Verbs[0]) {
+		if len(m.resource.Verbs) == 1 && !utils.IsVerbAllowed(resource.Verbs, m.resource.Verbs[0]) {
 			continue
 		}
 
@@ -354,11 +353,4 @@ func (m *kubernetesResourceMatcher) Match(role types.Role, condition types.RoleC
 	}
 
 	return false, nil
-}
-
-// isVerbAllowed returns true if the verb is allowed in the resource.
-// If the resource has a wildcard verb, it matches all verbs, otherwise
-// the resource must have the verb we're looking for.
-func isVerbAllowed(allowedVerbs []string, verb string) bool {
-	return len(allowedVerbs) != 0 && (allowedVerbs[0] == types.Wildcard || slices.Contains(allowedVerbs, verb))
 }

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -565,11 +565,8 @@ func ApplyTraitsWithContext(r types.Role, ctx RoleTemplateContext) (types.Role, 
 				names = []string{""}
 			}
 			verbs := applyValueTraitsSlice(rec.Verbs, ctx, "kubernetes resource verb")
-			// Trait expansion happens after role validation (which rejects a
-			// wildcard verb mixed with other verbs), so a trait value can
-			// reintroduce that combination here. A wildcard subsumes all other
-			// verbs, so normalize to just the wildcard to keep the stored shape
-			// consistent with validation and the matcher semantics.
+			// A trait can reintroduce a wildcard alongside other verbs after
+			// validation has run, so collapse to just the wildcard.
 			if slices.Contains(verbs, types.Wildcard) {
 				verbs = []string{types.Wildcard}
 			}

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -565,6 +565,14 @@ func ApplyTraitsWithContext(r types.Role, ctx RoleTemplateContext) (types.Role, 
 				names = []string{""}
 			}
 			verbs := applyValueTraitsSlice(rec.Verbs, ctx, "kubernetes resource verb")
+			// Trait expansion happens after role validation (which rejects a
+			// wildcard verb mixed with other verbs), so a trait value can
+			// reintroduce that combination here. A wildcard subsumes all other
+			// verbs, so normalize to just the wildcard to keep the stored shape
+			// consistent with validation and the matcher semantics.
+			if slices.Contains(verbs, types.Wildcard) {
+				verbs = []string{types.Wildcard}
+			}
 			for _, namespace := range namespaces {
 				for _, name := range names {
 					out = append(out, types.KubernetesResource{

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -3054,6 +3054,36 @@ func TestCheckRuleSorting(t *testing.T) {
 	}
 }
 
+// A trait that expands to a wildcard mixed with other verbs is normalized to
+// just the wildcard, since role validation can't catch this post-expansion.
+func TestApplyTraits_NormalizesWildcardKubeVerbAfterExpansion(t *testing.T) {
+	role, err := types.NewRoleWithVersion("kube-verb-tmpl", types.V8, types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesResources: []types.KubernetesResource{{
+				Kind: "secrets", APIGroup: types.Wildcard, Namespace: types.Wildcard, Name: types.Wildcard,
+				Verbs: []string{types.Wildcard},
+			}},
+		},
+		Deny: types.RoleConditions{
+			KubernetesResources: []types.KubernetesResource{{
+				Kind: "secrets", APIGroup: types.Wildcard, Namespace: "prod", Name: types.Wildcard,
+				Verbs: []string{"{{external.kube_verbs}}"},
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	out, err := ApplyTraits(role, map[string][]string{
+		"kube_verbs": {types.KubeVerbCreate, types.KubeVerbUpdate, types.KubeVerbDelete, types.Wildcard},
+	})
+	require.NoError(t, err)
+
+	denied := out.GetKubeResources(types.Deny)
+	require.Len(t, denied, 1)
+	require.Equal(t, []string{types.Wildcard}, denied[0].Verbs)
+}
+
 func TestApplyTraits(t *testing.T) {
 	type rule struct {
 		inLogins                []string

--- a/lib/utils/replace.go
+++ b/lib/utils/replace.go
@@ -148,7 +148,7 @@ func KubeResourceMatchesRegexWithVerbsCollector(input types.KubernetesResource, 
 			continue
 		}
 		matchedAny = true
-		if len(resource.Verbs) > 0 && resource.Verbs[0] == types.Wildcard {
+		if slices.Contains(resource.Verbs, types.Wildcard) {
 			return true, []string{types.Wildcard}, nil
 		}
 		for _, verb := range resource.Verbs {
@@ -358,9 +358,10 @@ func KubeResourceCouldMatchRules(input types.KubernetesResource, isClusterWideRe
 }
 
 // IsVerbAllowed returns true if the verb is allowed in the resource.
-// It short-circuits on a wildcard in position 0, otherwise checks whether the verb appears in the list.
+// A wildcard verb anywhere in the list matches all verbs,
+// otherwise the verb must appear in the list explicitly.
 func IsVerbAllowed(allowedVerbs []string, verb string) bool {
-	return len(allowedVerbs) != 0 && (allowedVerbs[0] == types.Wildcard || slices.Contains(allowedVerbs, verb))
+	return len(allowedVerbs) != 0 && (slices.Contains(allowedVerbs, types.Wildcard) || slices.Contains(allowedVerbs, verb))
 }
 
 // SliceMatchesRegex checks if input matches any of the expressions. The

--- a/lib/utils/replace_test.go
+++ b/lib/utils/replace_test.go
@@ -158,6 +158,22 @@ func TestRegexMatchesAny(t *testing.T) {
 	}
 }
 
+func TestKubeResourceMatchesRegexWithVerbsCollector_WildcardPosition(t *testing.T) {
+	input := types.KubernetesResource{Kind: "pods", Namespace: "default", Name: "podname"}
+	// A wildcard verb anywhere in the list collapses to the wildcard set.
+	for _, verbs := range [][]string{
+		{types.Wildcard, types.KubeVerbGet},
+		{types.KubeVerbGet, types.KubeVerbList, types.Wildcard},
+	} {
+		matched, gotVerbs, err := KubeResourceMatchesRegexWithVerbsCollector(input, []types.KubernetesResource{
+			{Kind: "pods", Namespace: "default", Name: "podname", Verbs: verbs},
+		})
+		require.NoError(t, err)
+		require.True(t, matched)
+		require.Equal(t, []string{types.Wildcard}, gotVerbs)
+	}
+}
+
 func TestKubeResourceMatchesRegex(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -367,6 +383,47 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 			assert:  require.NoError,
 			action:  types.Allow,
 			matches: false,
+		},
+		{
+			name: "deny matches with wildcard verb in non-first position",
+			input: types.KubernetesResource{
+				Kind:      "secrets",
+				Namespace: "default",
+				Name:      "any-secret",
+				Verbs:     []string{types.KubeVerbGet},
+			},
+			resources: []types.KubernetesResource{
+				{
+					Kind:      "secrets",
+					APIGroup:  types.Wildcard,
+					Namespace: types.Wildcard,
+					Name:      types.Wildcard,
+					Verbs:     []string{types.KubeVerbCreate, types.KubeVerbUpdate, types.KubeVerbDelete, types.Wildcard},
+				},
+			},
+			assert:  require.NoError,
+			action:  types.Deny,
+			matches: true,
+		},
+		{
+			name: "allow matches with wildcard verb in non-first position",
+			input: types.KubernetesResource{
+				Kind:      "pods",
+				Namespace: "default",
+				Name:      "podname",
+				Verbs:     []string{types.KubeVerbWatch},
+			},
+			resources: []types.KubernetesResource{
+				{
+					Kind:      "pods",
+					Namespace: "default",
+					Name:      "podname",
+					Verbs:     []string{types.KubeVerbGet, types.KubeVerbList, types.Wildcard},
+				},
+			},
+			assert:  require.NoError,
+			action:  types.Allow,
+			matches: true,
 		},
 		{
 			name: "input matches last resource",


### PR DESCRIPTION
Backport of #67598 to `branch/v18`.

Clean cherry-pick (no conflicts).

Changelog: Kubernetes resource RBAC now honors a wildcard (`*`) verb regardless of its position in the `verbs` list, including when introduced via trait templating.
