### PR TITLE
[v17] Honor wildcard kube RBAC verb regardless of position

### DIFF
--- a/lib/kube/proxy/self_subject_reviews.go
+++ b/lib/kube/proxy/self_subject_reviews.go
@@ -331,8 +331,8 @@ func (m *kubernetesResourceMatcher) Match(role types.Role, condition types.RoleC
 }
 
 // isVerbAllowed returns true if the verb is allowed in the resource.
-// If the resource has a wildcard verb, it matches all verbs, otherwise
-// the resource must have the verb we're looking for.
+// A wildcard verb anywhere in the list matches all verbs, otherwise the verb
+// must appear in the list explicitly.
 func isVerbAllowed(allowedVerbs []string, verb string) bool {
-	return len(allowedVerbs) != 0 && (allowedVerbs[0] == types.Wildcard || slices.Contains(allowedVerbs, verb))
+	return len(allowedVerbs) != 0 && (slices.Contains(allowedVerbs, types.Wildcard) || slices.Contains(allowedVerbs, verb))
 }

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -531,11 +531,8 @@ func ApplyTraits(r types.Role, traits map[string][]string) (types.Role, error) {
 				names = []string{""}
 			}
 			verbs := applyValueTraitsSlice(rec.Verbs, traits, "kubernetes resource verb")
-			// Trait expansion happens after role validation (which rejects a
-			// wildcard verb mixed with other verbs), so a trait value can
-			// reintroduce that combination here. A wildcard subsumes all other
-			// verbs, so normalize to just the wildcard to keep the stored shape
-			// consistent with validation and the matcher semantics.
+			// A trait can reintroduce a wildcard alongside other verbs after
+			// validation has run, so collapse to just the wildcard.
 			if slices.Contains(verbs, types.Wildcard) {
 				verbs = []string{types.Wildcard}
 			}

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -531,6 +531,14 @@ func ApplyTraits(r types.Role, traits map[string][]string) (types.Role, error) {
 				names = []string{""}
 			}
 			verbs := applyValueTraitsSlice(rec.Verbs, traits, "kubernetes resource verb")
+			// Trait expansion happens after role validation (which rejects a
+			// wildcard verb mixed with other verbs), so a trait value can
+			// reintroduce that combination here. A wildcard subsumes all other
+			// verbs, so normalize to just the wildcard to keep the stored shape
+			// consistent with validation and the matcher semantics.
+			if slices.Contains(verbs, types.Wildcard) {
+				verbs = []string{types.Wildcard}
+			}
 			for _, namespace := range namespaces {
 				for _, name := range names {
 					out = append(out, types.KubernetesResource{

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -2968,6 +2968,36 @@ func TestCheckRuleSorting(t *testing.T) {
 	}
 }
 
+// A trait that expands to a wildcard mixed with other verbs is normalized to
+// just the wildcard, since role validation can't catch this post-expansion.
+func TestApplyTraits_NormalizesWildcardKubeVerbAfterExpansion(t *testing.T) {
+	role, err := types.NewRole("kube-verb-tmpl", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesResources: []types.KubernetesResource{{
+				Kind: types.KindKubeSecret, Namespace: types.Wildcard, Name: types.Wildcard,
+				Verbs: []string{types.Wildcard},
+			}},
+		},
+		Deny: types.RoleConditions{
+			KubernetesResources: []types.KubernetesResource{{
+				Kind: types.KindKubeSecret, Namespace: "prod", Name: types.Wildcard,
+				Verbs: []string{"{{external.kube_verbs}}"},
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	out, err := ApplyTraits(role, map[string][]string{
+		"kube_verbs": {types.KubeVerbCreate, types.KubeVerbUpdate, types.KubeVerbDelete, types.Wildcard},
+	})
+	require.NoError(t, err)
+
+	denied := out.GetKubeResources(types.Deny)
+	require.Len(t, denied, 1)
+	require.Equal(t, []string{types.Wildcard}, denied[0].Verbs)
+}
+
 func TestApplyTraits(t *testing.T) {
 	type rule struct {
 		inLogins                []string

--- a/lib/utils/replace.go
+++ b/lib/utils/replace.go
@@ -148,7 +148,7 @@ func KubeResourceMatchesRegexWithVerbsCollector(input types.KubernetesResource, 
 			continue
 		}
 		matchedAny = true
-		if len(resource.Verbs) > 0 && resource.Verbs[0] == types.Wildcard {
+		if slices.Contains(resource.Verbs, types.Wildcard) {
 			return true, []string{types.Wildcard}, nil
 		}
 		for _, verb := range resource.Verbs {
@@ -346,10 +346,10 @@ func KubeResourceCouldMatchRules(input types.KubernetesResource, resources []typ
 }
 
 // isVerbAllowed returns true if the verb is allowed in the resource.
-// If the resource has a wildcard verb, it matches all verbs, otherwise
-// the resource must have the verb we're looking for.
+// A wildcard verb anywhere in the list matches all verbs, otherwise the verb
+// must appear in the list explicitly.
 func isVerbAllowed(allowedVerbs []string, verb string) bool {
-	return len(allowedVerbs) != 0 && (allowedVerbs[0] == types.Wildcard || slices.Contains(allowedVerbs, verb))
+	return len(allowedVerbs) != 0 && (slices.Contains(allowedVerbs, types.Wildcard) || slices.Contains(allowedVerbs, verb))
 }
 
 // SliceMatchesRegex checks if input matches any of the expressions. The

--- a/lib/utils/replace_test.go
+++ b/lib/utils/replace_test.go
@@ -158,6 +158,22 @@ func TestRegexMatchesAny(t *testing.T) {
 	}
 }
 
+func TestKubeResourceMatchesRegexWithVerbsCollector_WildcardPosition(t *testing.T) {
+	input := types.KubernetesResource{Kind: "pods", Namespace: "default", Name: "podname"}
+	// A wildcard verb anywhere in the list collapses to the wildcard set.
+	for _, verbs := range [][]string{
+		{types.Wildcard, types.KubeVerbGet},
+		{types.KubeVerbGet, types.KubeVerbList, types.Wildcard},
+	} {
+		matched, gotVerbs, err := KubeResourceMatchesRegexWithVerbsCollector(input, []types.KubernetesResource{
+			{Kind: "pods", Namespace: "default", Name: "podname", Verbs: verbs},
+		})
+		require.NoError(t, err)
+		require.True(t, matched)
+		require.Equal(t, []string{types.Wildcard}, gotVerbs)
+	}
+}
+
 func TestKubeResourceMatchesRegex(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -356,6 +372,46 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 			assert:  require.NoError,
 			action:  types.Allow,
 			matches: false,
+		},
+		{
+			name: "deny matches with wildcard verb in non-first position",
+			input: types.KubernetesResource{
+				Kind:      "secrets",
+				Namespace: "default",
+				Name:      "any-secret",
+				Verbs:     []string{types.KubeVerbGet},
+			},
+			resources: []types.KubernetesResource{
+				{
+					Kind:      "secrets",
+					Namespace: types.Wildcard,
+					Name:      types.Wildcard,
+					Verbs:     []string{types.KubeVerbCreate, types.KubeVerbUpdate, types.KubeVerbDelete, types.Wildcard},
+				},
+			},
+			assert:  require.NoError,
+			action:  types.Deny,
+			matches: true,
+		},
+		{
+			name: "allow matches with wildcard verb in non-first position",
+			input: types.KubernetesResource{
+				Kind:      "pods",
+				Namespace: "default",
+				Name:      "podname",
+				Verbs:     []string{types.KubeVerbWatch},
+			},
+			resources: []types.KubernetesResource{
+				{
+					Kind:      "pods",
+					Namespace: "default",
+					Name:      "podname",
+					Verbs:     []string{types.KubeVerbGet, types.KubeVerbList, types.Wildcard},
+				},
+			},
+			assert:  require.NoError,
+			action:  types.Allow,
+			matches: true,
 		},
 		{
 			name: "input matches last resource",


### PR DESCRIPTION
Backport of #67598 to `branch/v17`.

Changelog: Kubernetes resource RBAC now honors a wildcard (`*`) verb regardless of its position in the `verbs` list, including when introduced via trait templating.
