### PR TITLE
kube proxy: fix CPU hot-spin in session terminal-resize handling

### DIFF
--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -25,7 +25,6 @@ import (
 	"log/slog"
 	"net/http"
 	"path"
-	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -236,43 +235,19 @@ type terminalResizeMessage struct {
 
 // multiResizeQueue is a merged queue of multiple terminal size queues.
 type multiResizeQueue struct {
-	queues       map[string]<-chan terminalResizeMessage
-	cases        []reflect.SelectCase
-	callback     func(terminalResizeMessage)
-	mutex        sync.Mutex
-	parentCtx    context.Context
-	reloadCtx    context.Context
-	reloadCancel context.CancelFunc
-	lastSize     *remotecommand.TerminalSize
+	resizes   chan terminalResizeMessage
+	cancels   map[string]context.CancelFunc
+	callback  func(terminalResizeMessage)
+	mutex     sync.Mutex
+	parentCtx context.Context
+	lastSize  *remotecommand.TerminalSize
 }
 
 func newMultiResizeQueue(parentCtx context.Context) *multiResizeQueue {
-	ctx, cancel := context.WithCancel(parentCtx)
 	return &multiResizeQueue{
-		queues:       make(map[string]<-chan terminalResizeMessage),
-		parentCtx:    parentCtx,
-		reloadCtx:    ctx,
-		reloadCancel: cancel,
-	}
-}
-
-func (r *multiResizeQueue) rebuild() {
-	oldCancel := r.reloadCancel
-	defer oldCancel()
-
-	r.reloadCtx, r.reloadCancel = context.WithCancel(r.parentCtx)
-	r.cases = make([]reflect.SelectCase, 1, len(r.queues)+1)
-	r.cases[0] = reflect.SelectCase{
-		Dir:  reflect.SelectRecv,
-		Chan: reflect.ValueOf(r.reloadCtx.Done()),
-	}
-	for _, queue := range r.queues {
-		r.cases = append(r.cases,
-			reflect.SelectCase{
-				Dir:  reflect.SelectRecv,
-				Chan: reflect.ValueOf(queue),
-			},
-		)
+		resizes:   make(chan terminalResizeMessage),
+		cancels:   make(map[string]context.CancelFunc),
+		parentCtx: parentCtx,
 	}
 }
 
@@ -282,48 +257,70 @@ func (r *multiResizeQueue) getLastSize() *remotecommand.TerminalSize {
 	return r.lastSize
 }
 
+// close stops every forwarder. Canceling the parent context has the same effect; this is the explicit teardown path.
 func (r *multiResizeQueue) close() {
-	r.reloadCancel()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	for id, cancel := range r.cancels {
+		cancel()
+		delete(r.cancels, id)
+	}
 }
 
 func (r *multiResizeQueue) add(id string, queue <-chan terminalResizeMessage) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
-	r.queues[id] = queue
-	r.rebuild()
+	ctx, cancel := context.WithCancel(r.parentCtx)
+	r.cancels[id] = cancel
+	go func() {
+		defer func() {
+			r.mutex.Lock()
+			delete(r.cancels, id)
+			r.mutex.Unlock()
+		}()
+		forwardResizes(ctx, queue, r.resizes)
+	}()
 }
 
 func (r *multiResizeQueue) remove(id string) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
-	delete(r.queues, id)
-	r.rebuild()
+	if cancel, ok := r.cancels[id]; ok {
+		cancel()
+		delete(r.cancels, id)
+	}
+}
+
+// forwardResizes drains queue into out until the queue is closed or ctx is canceled (the party is removed or the session ends).
+func forwardResizes(ctx context.Context, queue <-chan terminalResizeMessage, out chan<- terminalResizeMessage) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-queue:
+			if !ok {
+				return
+			}
+			select {
+			case out <- msg:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
 }
 
 func (r *multiResizeQueue) Next() *remotecommand.TerminalSize {
-loop:
-	for {
+	select {
+	// If the parent context is canceled, the session has ended and we return early.
+	case <-r.parentCtx.Done():
+		return nil
+	case msg := <-r.resizes:
+		r.callback(msg)
 		r.mutex.Lock()
-		cases := r.cases
+		r.lastSize = msg.size
 		r.mutex.Unlock()
-		idx, value, ok := reflect.Select(cases)
-		if !ok || idx == 0 {
-			select {
-			// if parent context is canceled, the session has ended and we should
-			// return early. Otherwise, it means that we rebuilt and in that case we should continue.
-			case <-r.parentCtx.Done():
-				return nil
-			default:
-				continue loop
-			}
-		}
-
-		size := value.Interface().(terminalResizeMessage)
-		r.callback(size)
-		r.mutex.Lock()
-		r.lastSize = size.size
-		r.mutex.Unlock()
-		return size.size
+		return msg.size
 	}
 }
 

--- a/lib/kube/proxy/sess_test.go
+++ b/lib/kube/proxy/sess_test.go
@@ -377,3 +377,125 @@ func TestMultiResizeQueueNextEvictsClosedChannel(t *testing.T) {
 		require.Empty(t, q.queues, "closed resize channel was not evicted from the select set")
 	})
 }
+
+// TestMultiResizeQueueDeliversResize verifies a resize sent by a party is
+// returned by Next(), recorded as the last size, and passed to the callback.
+func TestMultiResizeQueueDeliversResize(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		q := newMultiResizeQueue(ctx)
+		var got terminalResizeMessage
+		q.callback = func(m terminalResizeMessage) { got = m }
+
+		require.Nil(t, q.getLastSize())
+
+		ch := make(chan terminalResizeMessage, 1)
+		q.add("party", ch)
+
+		source := uuid.New()
+		size := &remotecommand.TerminalSize{Width: 80, Height: 24}
+		ch <- terminalResizeMessage{size: size, source: source}
+
+		require.Equal(t, size, q.Next())
+		require.Equal(t, size, q.getLastSize())
+		require.Equal(t, size, got.size)
+		require.Equal(t, source, got.source)
+	})
+}
+
+// TestMultiResizeQueueMultipleParties verifies resizes from several parties are
+// all delivered.
+func TestMultiResizeQueueMultipleParties(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		q := newMultiResizeQueue(ctx)
+		q.callback = func(terminalResizeMessage) {}
+
+		chA := make(chan terminalResizeMessage, 1)
+		chB := make(chan terminalResizeMessage, 1)
+		q.add("a", chA)
+		q.add("b", chB)
+
+		sizeA := &remotecommand.TerminalSize{Width: 80, Height: 24}
+		sizeB := &remotecommand.TerminalSize{Width: 120, Height: 40}
+		chA <- terminalResizeMessage{size: sizeA, source: uuid.New()}
+		chB <- terminalResizeMessage{size: sizeB, source: uuid.New()}
+
+		got := []*remotecommand.TerminalSize{q.Next(), q.Next()}
+		require.ElementsMatch(t, []*remotecommand.TerminalSize{sizeA, sizeB}, got)
+	})
+}
+
+// TestMultiResizeQueueDynamicAdd verifies Next() picks up a channel added while
+// it is already blocked waiting.
+func TestMultiResizeQueueDynamicAdd(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		q := newMultiResizeQueue(ctx)
+		q.callback = func(terminalResizeMessage) {}
+
+		// An existing party with no pending resize: Next() blocks on it.
+		q.add("existing", make(chan terminalResizeMessage))
+
+		result := make(chan *remotecommand.TerminalSize, 1)
+		go func() { result <- q.Next() }()
+		synctest.Wait()
+
+		// A second party joins mid-session and sends a resize.
+		ch := make(chan terminalResizeMessage, 1)
+		size := &remotecommand.TerminalSize{Width: 100, Height: 40}
+		ch <- terminalResizeMessage{size: size, source: uuid.New()}
+		q.add("late", ch)
+
+		require.Equal(t, size, <-result)
+	})
+}
+
+// TestMultiResizeQueueRemove verifies a removed party leaves the queue while the
+// remaining parties keep delivering.
+func TestMultiResizeQueueRemove(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		q := newMultiResizeQueue(ctx)
+		q.callback = func(terminalResizeMessage) {}
+
+		chA := make(chan terminalResizeMessage, 1)
+		chB := make(chan terminalResizeMessage, 1)
+		q.add("a", chA)
+		q.add("b", chB)
+		q.remove("a")
+
+		sizeB := &remotecommand.TerminalSize{Width: 120, Height: 40}
+		chB <- terminalResizeMessage{size: sizeB, source: uuid.New()}
+
+		require.Equal(t, sizeB, q.Next())
+	})
+}
+
+// TestMultiResizeQueueCancelReturnsNil verifies Next() returns nil once the
+// parent context is canceled.
+func TestMultiResizeQueueCancelReturnsNil(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		q := newMultiResizeQueue(ctx)
+		q.callback = func(terminalResizeMessage) {}
+		q.add("party", make(chan terminalResizeMessage))
+
+		result := make(chan *remotecommand.TerminalSize, 1)
+		go func() { result <- q.Next() }()
+		synctest.Wait()
+
+		cancel()
+		require.Nil(t, <-result)
+	})
+}

--- a/lib/kube/proxy/sess_test.go
+++ b/lib/kube/proxy/sess_test.go
@@ -29,6 +29,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/uuid"
@@ -351,4 +352,28 @@ func (m *mockSessionTrackerService) CreateSessionTracker(_ context.Context, trac
 
 func (m *mockSessionTrackerService) ListKubernetesWaitingContainers(ctx context.Context, pageSize int, pageToken string) ([]*kubewaitingcontainerpb.KubernetesWaitingContainer, string, error) {
 	return nil, "", nil
+}
+
+// TestMultiResizeQueueNextEvictsClosedChannel is a regression test for the CPU hot-spin in (*multiResizeQueue).Next():
+// a closed party channel must be dropped from the select set, not re-selected forever.
+// See https://github.com/gravitational/teleport/issues/68140.
+func TestMultiResizeQueueNextEvictsClosedChannel(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		q := newMultiResizeQueue(t.Context())
+		q.callback = func(terminalResizeMessage) {}
+
+		// A disconnected party: its resize channel is closed but never removed.
+		closedCh := make(chan terminalResizeMessage)
+		close(closedCh)
+		q.add("disconnected-party", closedCh)
+
+		go q.Next()
+
+		// Hangs on the unfixed code: Next() spins instead of durably blocking.
+		synctest.Wait()
+
+		q.mutex.Lock()
+		defer q.mutex.Unlock()
+		require.Empty(t, q.queues, "closed resize channel was not evicted from the select set")
+	})
 }

--- a/lib/kube/proxy/sess_test.go
+++ b/lib/kube/proxy/sess_test.go
@@ -355,7 +355,7 @@ func (m *mockSessionTrackerService) ListKubernetesWaitingContainers(ctx context.
 }
 
 // TestMultiResizeQueueNextEvictsClosedChannel is a regression test for the CPU hot-spin in (*multiResizeQueue).Next():
-// a closed party channel must be dropped from the select set, not re-selected forever.
+// a closed party channel must be dropped from the select set, not re-selected forever, and must not wedge other parties.
 // See https://github.com/gravitational/teleport/issues/68140.
 func TestMultiResizeQueueNextEvictsClosedChannel(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
@@ -367,13 +367,18 @@ func TestMultiResizeQueueNextEvictsClosedChannel(t *testing.T) {
 		close(closedCh)
 		q.add("disconnected-party", closedCh)
 
-		go q.Next()
+		// A live party's resize must still come through with the dead channel present.
+		live := make(chan terminalResizeMessage, 1)
+		q.add("live-party", live)
+		size := &remotecommand.TerminalSize{Width: 80, Height: 24}
+		live <- terminalResizeMessage{size: size, source: uuid.New()}
+		require.Equal(t, size, q.Next())
 
+		// The closed channel's forwarder cleaned itself up; only the live party remains.
 		synctest.Wait()
-
 		q.mutex.Lock()
 		defer q.mutex.Unlock()
-		require.Empty(t, q.cancels, "forwarder for the closed channel was not cleaned up")
+		require.Len(t, q.cancels, 1)
 	})
 }
 

--- a/lib/kube/proxy/sess_test.go
+++ b/lib/kube/proxy/sess_test.go
@@ -369,12 +369,11 @@ func TestMultiResizeQueueNextEvictsClosedChannel(t *testing.T) {
 
 		go q.Next()
 
-		// Hangs on the unfixed code: Next() spins instead of durably blocking.
 		synctest.Wait()
 
 		q.mutex.Lock()
 		defer q.mutex.Unlock()
-		require.Empty(t, q.queues, "closed resize channel was not evicted from the select set")
+		require.Empty(t, q.cancels, "forwarder for the closed channel was not cleaned up")
 	})
 }
 


### PR DESCRIPTION
Fixes #68140.

`multiResizeQueue` merged participants' terminal-resize channels with `reflect.Select`. When a participant disconnects its channel is closed but may never be removed (observers have no reader; idle sessions never write), and a closed channel is always ready in `reflect.Select`, so `Next()` re-selected it forever and pinned a CPU core.

What I did:
- Wrote a reproduction test case for the hot-spin.
- Locked in the existing behaviour by adding more `multiResizeQueue` test cases.
- Rewrote `multiResizeQueue` to eliminate `reflect` package (`reflect.Select`) usage, using plain goroutines: one forwarder goroutine per participant drains into a single channel that `Next()` consumes. A closed queue just ends its forwarder instead of being re-selected forever.

## Manual Test Plan
### Test Environment

Local `kind` cluster (`teleport-cluster` chart, enterprise binary from `master` + this fix); kube sessions handled by the auth pod. Plus `-race` unit tests.

### Test Cases
- [x] Interactive `kubectl exec`: terminal resizes propagate to the pod.
- [x] Moderated session: a websocket observer joins and syncs to the current terminal size.
- [x] Observer/peer disconnect does not spike CPU on the kube/auth pod (no hot-spin).

Changelog: Fixed high CPU usage in Kubernetes sessions when a participant disconnected
