### PR TITLE
Desktop Access: Add directoryId awareness to audit handlers

### DIFF
--- a/lib/srv/desktop/audit.go
+++ b/lib/srv/desktop/audit.go
@@ -19,6 +19,7 @@
 package desktop
 
 import (
+	"cmp"
 	"context"
 	"time"
 
@@ -207,7 +208,7 @@ func (d *desktopSessionAuditor) makeClipboardReceive(length int32) *events.Deskt
 // are cached for future audit events. An event is returned only if there was
 // an error.
 func (d *desktopSessionAuditor) onSharedDirectoryAnnounce(m *tdpb.SharedDirectoryAnnounce) *events.DesktopSharedDirectoryStart {
-	err := d.auditCache.SetName(directoryID(m.DirectoryId), directoryName(m.Name))
+	err := d.auditCache.NewDirectory(directoryID(m.DirectoryId), directoryName(m.Name))
 	if err == nil {
 		// no work to do yet, but data is cached for future events
 		return nil
@@ -236,6 +237,11 @@ func (d *desktopSessionAuditor) onSharedDirectoryAnnounce(m *tdpb.SharedDirector
 		DirectoryID:   m.DirectoryId,
 		DesktopName:   d.desktop.GetName(),
 	}
+}
+
+// onSharedDirectoryRemove handles a shared directory removal message.
+func (d *desktopSessionAuditor) onSharedDirectoryRemove(m *tdpb.SharedDirectoryRemove) {
+	d.auditCache.RemoveDirectory(directoryID(m.DirectoryId))
 }
 
 // makeSharedDirectoryStart creates a DesktopSharedDirectoryStart event.
@@ -278,10 +284,9 @@ func (d *desktopSessionAuditor) onSharedDirectoryReadRequest(completion completi
 	path := m.GetPath()
 	offset := m.GetOffset()
 
-	err := d.auditCache.SetReadRequestInfo(completion, readRequestInfo{
-		directoryID: did,
-		path:        path,
-		offset:      offset,
+	err := d.auditCache.SetReadRequestInfo(directory, completion, readRequestInfo{
+		path:   path,
+		offset: offset,
 	})
 	if err == nil {
 		// no work to do yet, but data is cached for future events
@@ -319,31 +324,21 @@ func (d *desktopSessionAuditor) onSharedDirectoryReadRequest(completion completi
 }
 
 // makeSharedDirectoryReadResponse creates a DesktopSharedDirectoryRead audit event.
-func (d *desktopSessionAuditor) makeSharedDirectoryReadResponse(completion completionID, errorCode uint32, m *tdpbv1.SharedDirectoryResponse_Read) *events.DesktopSharedDirectoryRead {
-	var did directoryID
-	var name directoryName
-
+func (d *desktopSessionAuditor) makeSharedDirectoryReadResponse(did directoryID, completion completionID, errorCode uint32, m *tdpbv1.SharedDirectoryResponse_Read) *events.DesktopSharedDirectoryRead {
 	var path string
 	var offset uint64
 
 	code := libevents.DesktopSharedDirectoryReadCode
 
 	// Gather info from the audit cache
-	info, ok := d.auditCache.TakeReadRequestInfo(completion)
+	info, name, ok := d.auditCache.TakeReadRequestInfo(did, completion)
+	name = cmp.Or(name, "unknown")
 	if ok {
-		did = info.directoryID
-		// Only search for the directory name if we retrieved the directory ID from the audit cache.
-		name, ok = d.auditCache.GetName(did)
-		if !ok {
-			code = libevents.DesktopSharedDirectoryReadFailureCode
-			name = "unknown"
-		}
 		path = info.path
 		offset = info.offset
 	} else {
 		code = libevents.DesktopSharedDirectoryReadFailureCode
 		path = "unknown"
-		name = "unknown"
 	}
 
 	if errorCode != legacy.ErrCodeNil {
@@ -381,11 +376,11 @@ func (d *desktopSessionAuditor) onSharedDirectoryWriteRequest(completion complet
 	offset := m.GetOffset()
 
 	err := d.auditCache.SetWriteRequestInfo(
+		directory,
 		completion,
 		writeRequestInfo{
-			directoryID: did,
-			path:        path,
-			offset:      offset,
+			path:   path,
+			offset: offset,
 		})
 	if err == nil {
 		// no work to do yet, but data is cached for future events
@@ -423,8 +418,7 @@ func (d *desktopSessionAuditor) onSharedDirectoryWriteRequest(completion complet
 }
 
 // makeSharedDirectoryWriteResponse creates a DesktopSharedDirectoryWrite audit event.
-func (d *desktopSessionAuditor) makeSharedDirectoryWriteResponse(completion completionID, errorCode uint32, m *tdpbv1.SharedDirectoryResponse_Write) *events.DesktopSharedDirectoryWrite {
-	var did directoryID
+func (d *desktopSessionAuditor) makeSharedDirectoryWriteResponse(did directoryID, completion completionID, errorCode uint32, m *tdpbv1.SharedDirectoryResponse_Write) *events.DesktopSharedDirectoryWrite {
 	var name directoryName
 
 	var path string
@@ -432,21 +426,14 @@ func (d *desktopSessionAuditor) makeSharedDirectoryWriteResponse(completion comp
 
 	code := libevents.DesktopSharedDirectoryWriteCode
 	// Gather info from the audit cache
-	info, ok := d.auditCache.TakeWriteRequestInfo(completion)
+	info, name, ok := d.auditCache.TakeWriteRequestInfo(did, completion)
+	name = cmp.Or(name, "unknown")
 	if ok {
-		did = info.directoryID
-		// Only search for the directory name if we retrieved the directoryID from the audit cache.
-		name, ok = d.auditCache.GetName(did)
-		if !ok {
-			code = libevents.DesktopSharedDirectoryWriteFailureCode
-			name = "unknown"
-		}
 		path = info.path
 		offset = info.offset
 	} else {
 		code = libevents.DesktopSharedDirectoryWriteFailureCode
 		path = "unknown"
-		name = "unknown"
 	}
 
 	if errorCode != legacy.ErrCodeNil {

--- a/lib/srv/desktop/audit_cache.go
+++ b/lib/srv/desktop/audit_cache.go
@@ -29,9 +29,8 @@ type completionID uint32
 type directoryName string
 
 type readRequestInfo struct {
-	directoryID directoryID
-	path        string
-	offset      uint64
+	path   string
+	offset uint64
 }
 
 type writeRequestInfo readRequestInfo
@@ -46,31 +45,45 @@ const maxAuditCacheItems = 2000
 // totalItems returns the total number of items held in the cache.
 // The caller should hold a lock on the cache prior to calling this method.
 func (e *sharedDirectoryAuditCache) totalItems() int {
-	return len(e.nameCache) + len(e.readRequestCache) + len(e.writeRequestCache)
-}
-
-// sharedDirectoryAuditCache is a data structure for caching information
-// from shared directory messages so that it can be used later for
-// creating shared directory audit events.
-type sharedDirectoryAuditCache struct {
-	sync.Mutex
-
-	nameCache         map[directoryID]directoryName
-	readRequestCache  map[completionID]readRequestInfo
-	writeRequestCache map[completionID]writeRequestInfo
+	sum := 0
+	for _, cache := range e.directories {
+		// +1 because a directoryAuditCache with no read/write info
+		// items should still count as at least one entry.
+		sum += cache.totalItems() + 1
+	}
+	return sum
 }
 
 func newSharedDirectoryAuditCache() sharedDirectoryAuditCache {
 	return sharedDirectoryAuditCache{
-		nameCache:         make(map[directoryID]directoryName),
+		directories: make(map[directoryID]directoryAuditCache),
+	}
+}
+
+type sharedDirectoryAuditCache struct {
+	sync.Mutex
+	directories map[directoryID]directoryAuditCache
+}
+
+type directoryAuditCache struct {
+	name              directoryName
+	readRequestCache  map[completionID]readRequestInfo
+	writeRequestCache map[completionID]writeRequestInfo
+}
+
+func (d directoryAuditCache) totalItems() int {
+	return len(d.readRequestCache) + len(d.writeRequestCache)
+}
+
+func newdirectoryAuditCache(name directoryName) directoryAuditCache {
+	return directoryAuditCache{
+		name:              name,
 		readRequestCache:  make(map[completionID]readRequestInfo),
 		writeRequestCache: make(map[completionID]writeRequestInfo),
 	}
 }
 
-// SetName returns a non-nil error if the audit cache entry for sid exceeds its maximum size.
-// It is the responsibility of the caller to terminate the session if a non-nil error is returned.
-func (c *sharedDirectoryAuditCache) SetName(did directoryID, name directoryName) error {
+func (c *sharedDirectoryAuditCache) NewDirectory(did directoryID, name directoryName) error {
 	c.Lock()
 	defer c.Unlock()
 
@@ -78,13 +91,22 @@ func (c *sharedDirectoryAuditCache) SetName(did directoryID, name directoryName)
 		return trace.LimitExceeded("audit cache exceeded maximum size")
 	}
 
-	c.nameCache[did] = name
+	c.directories[did] = newdirectoryAuditCache(name)
 	return nil
+}
+
+func (c *sharedDirectoryAuditCache) RemoveDirectory(did directoryID) bool {
+	c.Lock()
+	defer c.Unlock()
+
+	_, ok := c.directories[did]
+	delete(c.directories, did)
+	return ok
 }
 
 // SetReadRequestInfo returns a non-nil error if the audit cache exceeds its maximum size.
 // It is the responsibility of the caller to terminate the session if a non-nil error is returned.
-func (c *sharedDirectoryAuditCache) SetReadRequestInfo(cid completionID, info readRequestInfo) error {
+func (c *sharedDirectoryAuditCache) SetReadRequestInfo(did directoryID, cid completionID, info readRequestInfo) error {
 	c.Lock()
 	defer c.Unlock()
 
@@ -92,13 +114,17 @@ func (c *sharedDirectoryAuditCache) SetReadRequestInfo(cid completionID, info re
 		return trace.LimitExceeded("audit cache exceeded maximum size")
 	}
 
-	c.readRequestCache[cid] = info
-	return nil
+	if directory, exists := c.directories[did]; exists {
+		directory.readRequestCache[cid] = info
+		return nil
+	}
+
+	return trace.NotFound("no such directory with id %d ", did)
 }
 
 // SetWriteRequestInfo returns a non-nil error if the audit cache exceeds its maximum size.
 // It is the responsibility of the caller to terminate the session if a non-nil error is returned.
-func (c *sharedDirectoryAuditCache) SetWriteRequestInfo(cid completionID, info writeRequestInfo) error {
+func (c *sharedDirectoryAuditCache) SetWriteRequestInfo(did directoryID, cid completionID, info writeRequestInfo) error {
 	c.Lock()
 	defer c.Unlock()
 
@@ -106,40 +132,50 @@ func (c *sharedDirectoryAuditCache) SetWriteRequestInfo(cid completionID, info w
 		return trace.LimitExceeded("audit cache exceeded maximum size")
 	}
 
-	c.writeRequestCache[cid] = info
-	return nil
+	if directory, exists := c.directories[did]; exists {
+		directory.writeRequestCache[cid] = info
+		return nil
+	}
+
+	return trace.NotFound("no such directory with id %d ", did)
 }
 
-func (c *sharedDirectoryAuditCache) GetName(did directoryID) (name directoryName, ok bool) {
+func (c *sharedDirectoryAuditCache) GetName(did directoryID) (directoryName, bool) {
 	c.Lock()
 	defer c.Unlock()
 
-	name, ok = c.nameCache[did]
-	return
+	directory, ok := c.directories[did]
+	return directory.name, ok
 }
 
 // TakeReadRequestInfo gets the readRequestInfo for completion ID cid,
 // removing the readRequestInfo from the cache in the process.
-func (c *sharedDirectoryAuditCache) TakeReadRequestInfo(cid completionID) (info readRequestInfo, ok bool) {
+func (c *sharedDirectoryAuditCache) TakeReadRequestInfo(did directoryID, cid completionID) (info readRequestInfo, name directoryName, ok bool) {
 	c.Lock()
 	defer c.Unlock()
 
-	info, ok = c.readRequestCache[cid]
-	if ok {
-		delete(c.readRequestCache, cid)
+	if directory, exists := c.directories[did]; exists {
+		info, ok = directory.readRequestCache[cid]
+		name = directory.name
+		if ok {
+			delete(directory.readRequestCache, cid)
+		}
 	}
 	return
 }
 
 // TakeWriteRequestInfo gets the writeRequestInfo for completion ID cid,
 // removing the writeRequestInfo from the cache in the process.
-func (c *sharedDirectoryAuditCache) TakeWriteRequestInfo(cid completionID) (info writeRequestInfo, ok bool) {
+func (c *sharedDirectoryAuditCache) TakeWriteRequestInfo(did directoryID, cid completionID) (info writeRequestInfo, name directoryName, ok bool) {
 	c.Lock()
 	defer c.Unlock()
 
-	info, ok = c.writeRequestCache[cid]
-	if ok {
-		delete(c.writeRequestCache, cid)
+	if directory, exists := c.directories[did]; exists {
+		info, ok = directory.writeRequestCache[cid]
+		name = directory.name
+		if ok {
+			delete(directory.writeRequestCache, cid)
+		}
 	}
 	return
 }

--- a/lib/srv/desktop/audit_test.go
+++ b/lib/srv/desktop/audit_test.go
@@ -361,6 +361,12 @@ func TestDesktopSharedDirectoryReadEvent(t *testing.T) {
 			errCode:       legacy.ErrCodeNil,
 			expected: func(baseEvent *events.DesktopSharedDirectoryRead) *events.DesktopSharedDirectoryRead {
 				baseEvent.Metadata.Code = libevents.DesktopSharedDirectoryReadFailureCode
+				// resorts to default values for these
+				baseEvent.DirectoryID = uint32(testDirectoryID)
+				baseEvent.Offset = 0
+
+				// sets "unknown" for these
+				baseEvent.Path = "unknown"
 				baseEvent.DirectoryName = "unknown"
 				return baseEvent
 			},
@@ -375,13 +381,12 @@ func TestDesktopSharedDirectoryReadEvent(t *testing.T) {
 				baseEvent.Metadata.Code = libevents.DesktopSharedDirectoryReadFailureCode
 
 				// resorts to default values for these
-				baseEvent.DirectoryID = 0
+				baseEvent.DirectoryID = uint32(testDirectoryID)
 				baseEvent.Offset = 0
 
 				// sets "unknown" for these
 				baseEvent.Path = "unknown"
-				// we can't retrieve the directory name because we don't have the directoryID
-				baseEvent.DirectoryName = "unknown"
+				baseEvent.DirectoryName = testDirName
 
 				return baseEvent
 			},
@@ -396,7 +401,7 @@ func TestDesktopSharedDirectoryReadEvent(t *testing.T) {
 				baseEvent.Metadata.Code = libevents.DesktopSharedDirectoryReadFailureCode
 
 				// resorts to default values for these
-				baseEvent.DirectoryID = 0
+				baseEvent.DirectoryID = uint32(testDirectoryID)
 				baseEvent.Offset = 0
 
 				// sets "unknown" for these
@@ -428,7 +433,7 @@ func TestDesktopSharedDirectoryReadEvent(t *testing.T) {
 			}
 
 			// SharedDirectoryReadResponse causes the event to be emitted.
-			readEvent := audit.makeSharedDirectoryReadResponse(testCompletionID, test.errCode, tdpbv1.SharedDirectoryResponse_Read_builder{
+			readEvent := audit.makeSharedDirectoryReadResponse(testDirectoryID, testCompletionID, test.errCode, tdpbv1.SharedDirectoryResponse_Read_builder{
 				Data: make([]byte, testLength), // slice contents are irrelevant in this context
 			}.Build())
 
@@ -506,6 +511,12 @@ func TestDesktopSharedDirectoryWriteEvent(t *testing.T) {
 			errCode:       legacy.ErrCodeNil,
 			expected: func(baseEvent *events.DesktopSharedDirectoryWrite) *events.DesktopSharedDirectoryWrite {
 				baseEvent.Metadata.Code = libevents.DesktopSharedDirectoryWriteFailureCode
+				// resorts to default values for these
+				baseEvent.DirectoryID = uint32(testDirectoryID)
+				baseEvent.Offset = 0
+
+				// sets "unknown" for these
+				baseEvent.Path = "unknown"
 				baseEvent.DirectoryName = "unknown"
 				return baseEvent
 			},
@@ -520,13 +531,12 @@ func TestDesktopSharedDirectoryWriteEvent(t *testing.T) {
 				baseEvent.Metadata.Code = libevents.DesktopSharedDirectoryWriteFailureCode
 
 				// resorts to default values for these
-				baseEvent.DirectoryID = 0
+				baseEvent.DirectoryID = uint32(testDirectoryID)
 				baseEvent.Offset = 0
 
 				// sets "unknown" for these
 				baseEvent.Path = "unknown"
-				// we can't retrieve the directory name because we don't have the directoryID
-				baseEvent.DirectoryName = "unknown"
+				baseEvent.DirectoryName = testDirName
 
 				return baseEvent
 			},
@@ -541,7 +551,7 @@ func TestDesktopSharedDirectoryWriteEvent(t *testing.T) {
 				baseEvent.Metadata.Code = libevents.DesktopSharedDirectoryWriteFailureCode
 
 				// resorts to default values for these
-				baseEvent.DirectoryID = 0
+				baseEvent.DirectoryID = uint32(testDirectoryID)
 				baseEvent.Offset = 0
 
 				// sets "unknown" for these
@@ -573,7 +583,7 @@ func TestDesktopSharedDirectoryWriteEvent(t *testing.T) {
 			}
 
 			// SharedDirectoryWriteResponse causes the event to be emitted.
-			writeEvent := audit.makeSharedDirectoryWriteResponse(testCompletionID, test.errCode, tdpbv1.SharedDirectoryResponse_Write_builder{
+			writeEvent := audit.makeSharedDirectoryWriteResponse(testDirectoryID, testCompletionID, test.errCode, tdpbv1.SharedDirectoryResponse_Write_builder{
 				BytesWritten: testLength,
 			}.Build())
 
@@ -611,13 +621,8 @@ func TestDesktopSharedDirectoryWriteEvent(t *testing.T) {
 
 // fillReadRequestCache is a helper function that fills an entry's readRequestCache up with entryMaxItems.
 func fillReadRequestCache(cache *sharedDirectoryAuditCache, did directoryID) {
-	cache.Lock()
-	defer cache.Unlock()
-
 	for i := range maxAuditCacheItems {
-		cache.readRequestCache[completionID(i)] = readRequestInfo{
-			directoryID: did,
-		}
+		cache.SetReadRequestInfo(did, completionID(i), readRequestInfo{})
 	}
 }
 
@@ -627,6 +632,7 @@ func fillReadRequestCache(cache *sharedDirectoryAuditCache, did directoryID) {
 func TestDesktopSharedDirectoryStartEventAuditCacheMax(t *testing.T) {
 	id, audit := setup(testDesktop)
 
+	audit.auditCache.NewDirectory(testDirectoryID, testDirName)
 	// Set the audit cache entry to the maximum allowable size
 	fillReadRequestCache(&audit.auditCache, testDirectoryID)
 
@@ -682,6 +688,7 @@ func TestDesktopSharedDirectoryReadEventAuditCacheMax(t *testing.T) {
 		Name:        testDirName,
 	})
 
+	audit.auditCache.NewDirectory(testDirectoryID, testDirName)
 	// Set the audit cache entry to the maximum allowable size
 	fillReadRequestCache(&audit.auditCache, testDirectoryID)
 
@@ -738,6 +745,7 @@ func TestDesktopSharedDirectoryWriteEventAuditCacheMax(t *testing.T) {
 		Name:        testDirName,
 	})
 
+	audit.auditCache.NewDirectory(testDirectoryID, testDirName)
 	fillReadRequestCache(&audit.auditCache, testDirectoryID)
 
 	writeEvent := audit.onSharedDirectoryWriteRequest(testCompletionID, testDirectoryID, tdpbv1.SharedDirectoryRequest_Write_builder{
@@ -797,9 +805,9 @@ func TestAuditCacheLifecycle(t *testing.T) {
 	name, ok := audit.auditCache.GetName(testDirectoryID)
 	require.True(t, ok)
 	require.Equal(t, directoryName(testDirName), name)
-	_, ok = audit.auditCache.TakeReadRequestInfo(testCompletionID)
+	_, _, ok = audit.auditCache.TakeReadRequestInfo(testDirectoryID, testCompletionID)
 	require.False(t, ok)
-	_, ok = audit.auditCache.TakeWriteRequestInfo(testCompletionID)
+	_, _, ok = audit.auditCache.TakeWriteRequestInfo(testDirectoryID, testCompletionID)
 	require.False(t, ok)
 
 	// A SharedDirectoryReadRequest should add a corresponding entry in the readRequestCache.
@@ -819,26 +827,26 @@ func TestAuditCacheLifecycle(t *testing.T) {
 	require.Equal(t, 3, audit.auditCache.totalItems())
 
 	// Check that the readRequestCache was properly filled out.
-	require.Contains(t, audit.auditCache.readRequestCache, testCompletionID)
+	require.Contains(t, audit.auditCache.directories[testDirectoryID].readRequestCache, testCompletionID)
 
 	// Check that the writeRequestCache was properly filled out.
-	require.Contains(t, audit.auditCache.writeRequestCache, testCompletionID)
+	require.Contains(t, audit.auditCache.directories[testDirectoryID].writeRequestCache, testCompletionID)
 
 	// SharedDirectoryReadResponse should cause the entry in the readRequestCache to be cleaned up.
-	audit.makeSharedDirectoryReadResponse(testCompletionID, legacy.ErrCodeNil, tdpbv1.SharedDirectoryResponse_Read_builder{
+	audit.makeSharedDirectoryReadResponse(testDirectoryID, testCompletionID, legacy.ErrCodeNil, tdpbv1.SharedDirectoryResponse_Read_builder{
 		Data: make([]byte, testLength), // slice contents are irrelevant in this context
 	}.Build())
 	require.Equal(t, 2, audit.auditCache.totalItems())
 
 	// SharedDirectoryWriteResponse should cause the entry in the writeRequestCache to be cleaned up.
-	audit.makeSharedDirectoryWriteResponse(testCompletionID, legacy.ErrCodeNil, tdpbv1.SharedDirectoryResponse_Write_builder{
+	audit.makeSharedDirectoryWriteResponse(testDirectoryID, testCompletionID, legacy.ErrCodeNil, tdpbv1.SharedDirectoryResponse_Write_builder{
 		BytesWritten: testLength,
 	}.Build())
 	require.Equal(t, 1, audit.auditCache.totalItems())
 
 	// Check that the readRequestCache was properly cleaned up.
-	require.NotContains(t, audit.auditCache.readRequestCache, testCompletionID)
+	require.NotContains(t, audit.auditCache.directories[testDirectoryID].readRequestCache, testCompletionID)
 
 	// Check that the writeRequestCache was properly cleaned up.
-	require.NotContains(t, audit.auditCache.writeRequestCache, testCompletionID)
+	require.NotContains(t, audit.auditCache.directories[testDirectoryID].writeRequestCache, testCompletionID)
 }

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -1162,14 +1162,18 @@ func (s *WindowsService) makeTDPReceiveAuditor(
 				s.emit(ctx, errorEvent)
 				return err
 			}
+		case *tdpb.SharedDirectoryRemove:
+			// This doesn't yield an audit event for removal. It just cleans up
+			// the directory entry from the audit cache.
+			audit.onSharedDirectoryRemove(msg)
 		case *tdpb.SharedDirectoryResponse:
 			// shared directory audit events can be noisy, so we use a compactor
 			// to retain and delay them in an attempt to coalesce contiguous events
 			switch op := msg.Operation.(type) {
 			case *tdpbv1.SharedDirectoryResponse_Read_:
-				audit.compactor.handleRead(ctx, audit.makeSharedDirectoryReadResponse(completionID(msg.CompletionId), msg.ErrorCode, op.Read))
+				audit.compactor.handleRead(ctx, audit.makeSharedDirectoryReadResponse(directoryID(msg.DirectoryId), completionID(msg.CompletionId), msg.ErrorCode, op.Read))
 			case *tdpbv1.SharedDirectoryResponse_Write_:
-				audit.compactor.handleWrite(ctx, audit.makeSharedDirectoryWriteResponse(completionID(msg.CompletionId), msg.ErrorCode, op.Write))
+				audit.compactor.handleWrite(ctx, audit.makeSharedDirectoryWriteResponse(directoryID(msg.DirectoryId), completionID(msg.CompletionId), msg.ErrorCode, op.Write))
 			}
 		}
 		return nil


### PR DESCRIPTION
To facilitate multi-directory sharing, the audit cache will need to match shared directory read/write responses by (directoryId, completionId) tuples, rather than just the completionId. This PR updates the audit cache and audit handlers to account for the DirectoryId field of shared directory response messages.

<!-- Provide a descriptive entry for the changelog of the next release. -->


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local cluster with at least one desktop resource
### Test Cases
- [x] Connect and share a directory. Read and write to a file in the directory.
- [x] Validate that the audit log contains a start event with the correct directory name and directoryId: 2
- [x] Validate that the audit log contains a read with the correct directory name, directoryId: 2, path and offset.
- [x] Validate that the audit log contains a write with the correct directory name, directoryId: 2, path and offset