### PR TITLE
fix: deflake TestIntegrations/LeafAgentlessConnection

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -45,6 +45,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -9512,9 +9513,10 @@ func startSSHServer(t *testing.T, caPubKeys []ssh.PublicKey, hostKey ssh.Signer)
 
 		conn, channels, reqs, err := ssh.NewServerConn(nConn, &sshCfg)
 		if err != nil {
-			// If the connection does not perform an SSH handshake, then this is just
-			// a readiness probe (raw TCP Dial) from the test.
-			if utils.IsOKNetworkError(err) {
+			// WaitForNodeCount performs a raw TCP preflight dial and closes it without
+			// completing an SSH handshake. Depending on timing, the server can observe
+			// either EOF or ECONNRESET.
+			if utils.IsOKNetworkError(err) || errors.Is(err, syscall.ECONNRESET) {
 				return
 			}
 			assert.NoError(t, err)


### PR DESCRIPTION
Fixes #66559

The fake SSH server in the test tried to ignore errors from preflight dials with `utils.IsOKNetworkError`. This was not catching another class of error that was seen in all the flaky test hits: `read tcp 127.0.0.1:37327->127.0.0.1:43184: read: connection reset by peer`. We can catch this by detecting `syscall.ECONNRESET`.

I could easily reproduce the failure within 20 runs of the test (multiple times locally).
With the fix, it continually passed until hitting the 10 minute default `go test` timeout.