### PR TITLE
[v18] kube: require exec and patch for pods/ephemeralcontainers

### DIFF
--- a/lib/kube/proxy/ephemeralcontainers_verb_test.go
+++ b/lib/kube/proxy/ephemeralcontainers_verb_test.go
@@ -1,0 +1,97 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// TestEphemeralContainersRequiredVerbs asserts the set of kubernetes_resources verbs that gate each pods request.
+// Adding an ephemeral container (PATCH/PUT to pods/{name}/ephemeralcontainers) runs code in the target pod
+// the same way exec does, and also mutates the pod,
+// so it must require both the exec verb and the mutation verb the HTTP method maps to.
+// A plain pod patch and pods/exec must each require only their own single verb,
+// so that neither verb on its own is enough to add an ephemeral container.
+func TestEphemeralContainersRequiredVerbs(t *testing.T) {
+	// Minimal kubeDetails with just the "pods" resource registered for RBAC.
+	// Mirrors what newClusterSchemaBuilder populates from real cluster
+	// discovery for the core/v1 pods resource.
+	kd := &kubeDetails{
+		rbacSupportedTypes: rbacSupportedResources{
+			allowedResourcesKey{apiGroup: "", resourceKind: "pods"}: metav1.APIResource{
+				Name:       "pods",
+				Namespaced: true,
+				Kind:       "Pod",
+			},
+		},
+	}
+
+	verbsFor := func(t *testing.T, method, path string) []string {
+		u, err := url.Parse(path)
+		require.NoError(t, err)
+		mr, err := getResourceFromRequest(&http.Request{Method: method, URL: u}, kd)
+		require.NoError(t, err)
+
+		var verbs []string
+		for _, r := range mr.requiredRBACResources() {
+			verbs = append(verbs, r.Verbs...)
+		}
+		return verbs
+	}
+
+	// Control: pods/exec requires only the exec verb.
+	t.Run("pods/exec requires only exec", func(t *testing.T) {
+		verbs := verbsFor(t, http.MethodPost, "/api/v1/namespaces/default/pods/foo/exec")
+		require.Equal(t, []string{types.KubeVerbExec}, verbs)
+	})
+
+	// Control: a patch to the pod itself (e.g. a label update) requires only
+	// the patch verb. It must not pull in exec, otherwise a label patch and an
+	// ephemeral container would be indistinguishable in RBAC.
+	t.Run("pod patch requires only patch", func(t *testing.T) {
+		verbs := verbsFor(t, http.MethodPatch, "/api/v1/namespaces/default/pods/foo")
+		require.Equal(t, []string{types.KubeVerbPatch}, verbs)
+		require.NotContains(t, verbs, types.KubeVerbExec)
+	})
+
+	t.Run("ephemeralcontainers patch requires exec and patch", func(t *testing.T) {
+		verbs := verbsFor(t, http.MethodPatch,
+			"/api/v1/namespaces/default/pods/foo/ephemeralcontainers")
+		require.Contains(t, verbs, types.KubeVerbExec,
+			"adding an ephemeral container must require the exec verb")
+		require.Contains(t, verbs, types.KubeVerbPatch,
+			"adding an ephemeral container must require the mutation verb")
+	})
+
+	t.Run("ephemeralcontainers put requires exec and update", func(t *testing.T) {
+		verbs := verbsFor(t, http.MethodPut,
+			"/api/v1/namespaces/default/pods/foo/ephemeralcontainers")
+		require.Contains(t, verbs, types.KubeVerbExec,
+			"adding an ephemeral container must require the exec verb")
+		require.Contains(t, verbs, types.KubeVerbUpdate,
+			"adding an ephemeral container must require the mutation verb")
+	})
+}

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1239,8 +1239,15 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 			// results in the intersection of roles that match the "kubernetes_labels" and
 			// roles that allow access to the desired "kubernetes_resource".
 			// If from the intersection results an empty set, the request is denied.
-			roleMatchers = services.RoleMatchers{
-				services.NewKubernetesResourceMatcher(*rbacResource, actx.metaResource.isClusterWideResource()),
+			//
+			// requiredRBACResources returns one tuple per (resource, verb) the request needs.
+			// Most requests need exactly one, adding an ephemeral container needs both exec and the mutation verb.
+			isClusterWideResource := actx.metaResource.isClusterWideResource()
+			required := actx.metaResource.requiredRBACResources()
+			roleMatchers = make(services.RoleMatchers, 0, len(required))
+			for i := range required {
+				roleMatchers = append(roleMatchers,
+					services.NewKubernetesResourceMatcher(required[i], isClusterWideResource))
 			}
 		}
 	}

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -64,6 +64,29 @@ func (mr *metaResource) rbacResource() *types.KubernetesResource {
 	}
 }
 
+// ephemeralContainersResourceKind is the pods subresource used to add an
+// ephemeral container to a running pod (the endpoint `kubectl debug` targets).
+const ephemeralContainersResourceKind = "pods/ephemeralcontainers"
+
+// requiredRBACResources returns the set of Kubernetes resources the caller must be granted to perform this request.
+// Most requests need a single (resource, verb) tuple, the one returned by rbacResource.
+// Adding an ephemeral container runs code in the target pod the same way exec does,
+// and the request also mutates the pod object (it is a patch/update),
+// so it requires both the exec verb and the mutation verb the HTTP method maps to.
+// Returning both keeps either verb on its own from being enough to add an ephemeral container.
+func (mr *metaResource) requiredRBACResources() []types.KubernetesResource {
+	base := mr.rbacResource()
+	if base == nil {
+		return nil
+	}
+	if mr.requestedResource.resourceKind != ephemeralContainersResourceKind {
+		return []types.KubernetesResource{*base}
+	}
+	execResource := *base
+	execResource.Verbs = []string{types.KubeVerbExec}
+	return []types.KubernetesResource{*base, execResource}
+}
+
 // apiResource represents the resource requested by the user.
 type apiResource struct {
 	apiGroup        string


### PR DESCRIPTION
Backport of #67595 to `branch/v18`. Clean cherry-pick.

Changelog: Kubernetes: adding an ephemeral container to a pod (`pods/ephemeralcontainers`) now requires both the `exec` and `patch`/`update` verbs in the same role's `kubernetes_resources`. Previously only `patch`/`update` was required.