### PR TITLE
Complete required permissions in the Jira guide

### DIFF
--- a/docs/pages/includes/plugins/rbac-update.mdx
+++ b/docs/pages/includes/plugins/rbac-update.mdx
@@ -17,7 +17,7 @@ spec:
       - resources: ['access_request']
         verbs: ['list', 'read', 'update']
       - resources: ['access_plugin_data']
-        verbs: ['update']
+        verbs: ['list', 'read', 'update']
 ---
 kind: user
 metadata:


### PR DESCRIPTION
In the Jira Access Request plugin guide, the Machine ID tab instructs the user to grant permissions to read and list access plugin data, while the long-lived credential tab does not. Update the guide to make both tabs consistent. Editing the `rbac-update.mdx` partial also makes the expectations of Access Request plugins in general explicit in cases where the user needs access to update access plugin data.