### PR TITLE
Azure Server Discovery: check VM and Guest Agent when running command

### DIFF
--- a/lib/cloud/azure/vm.go
+++ b/lib/cloud/azure/vm.go
@@ -20,6 +20,7 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"time"
@@ -460,6 +461,9 @@ type RunCommandClient interface {
 type runCommandClient struct {
 	virtualMachineRunCommandsAPI *armcompute.VirtualMachineRunCommandsClient
 	scaleSetVMRunCommandsAPI     *armcompute.VirtualMachineScaleSetVMRunCommandsClient
+	virtualMachineAPI            virtualMachinesLister
+	scaleSetVMsAPI               scaleSetVMsLister
+	logger                       *slog.Logger
 }
 
 // NewRunCommandClient creates a new Azure Run Command client by subscription
@@ -475,9 +479,24 @@ func NewRunCommandClient(subscription string, cred azcore.TokenCredential, optio
 		return nil, trace.Wrap(err)
 	}
 
+	virtualMachineAPI, err := armcompute.NewVirtualMachinesClient(subscription, cred, options)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	scaleSetVMsAPI, err := armcompute.NewVirtualMachineScaleSetVMsClient(subscription, cred, options)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	logger := slog.With(teleport.ComponentKey, "azure_run_command_client")
+
 	return &runCommandClient{
 		virtualMachineRunCommandsAPI: runCommandAPI,
 		scaleSetVMRunCommandsAPI:     scaleSetVMRunCommandsAPI,
+		virtualMachineAPI:            virtualMachineAPI,
+		scaleSetVMsAPI:               scaleSetVMsAPI,
+		logger:                       logger,
 	}, nil
 }
 
@@ -487,9 +506,6 @@ const runCommandName = "teleport-install"
 // Run runs Teleport installation command on a virtual machine.
 func (c *runCommandClient) Run(ctx context.Context, req RunCommandRequest) (*RunCommandResult, error) {
 	runCommandTimeout := getRunCommandTimeout()
-	// pad the timeout so we can still attempt to collect output if it times out
-	ctx, cancel := context.WithTimeout(ctx, runCommandTimeout+time.Minute)
-	defer cancel()
 
 	runCommand := armcompute.VirtualMachineRunCommand{
 		Location: to.Ptr(req.Region),
@@ -509,19 +525,19 @@ func (c *runCommandClient) Run(ctx context.Context, req RunCommandRequest) (*Run
 		},
 	}
 
-	var runCommandProperties *armcompute.VirtualMachineRunCommandProperties
-	var err error
-
-	if req.isUniformVMSS() {
-		runCommandProperties, err = c.uniformScaleSetVirtualMachineRunCommand(ctx, req, runCommand)
-		if err != nil {
-			return nil, trace.Wrap(err)
+	runCommandProperties, err := c.runCommandInVM(ctx, req, runCommand, runCommandTimeout)
+	if err != nil {
+		// If the runCommandInVM returns a context.DeadlineExceeded error (by default, 6m in that call), there's two likely causes:
+		// - script is executing but is taking too long (eg, teleport download from CDN is slow)
+		// - script is not executing because the VM Agent is down
+		// Azure does not provide a way to understand whether the script execution actually started or not.
+		// Instead of raising the context.DeadlineExceeded error, we will check the agent status and, if the agent is down, return a more specific error.
+		if errors.Is(err, context.DeadlineExceeded) {
+			if err := c.checkVMStatus(ctx, req); err != nil {
+				return nil, trace.Wrap(err)
+			}
 		}
-	} else {
-		runCommandProperties, err = c.regularVirtualMachineRunCommand(ctx, req, runCommand)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
+		return nil, trace.Wrap(err)
 	}
 
 	commandResult, err := commandResultFromInstanceView(runCommandProperties)
@@ -530,6 +546,19 @@ func (c *runCommandClient) Run(ctx context.Context, req RunCommandRequest) (*Run
 	}
 
 	return commandResult, nil
+}
+
+func (c *runCommandClient) runCommandInVM(ctx context.Context, req RunCommandRequest, runCommand armcompute.VirtualMachineRunCommand, runCommandTimeout time.Duration) (*armcompute.VirtualMachineRunCommandProperties, error) {
+	// pad the timeout so we can still attempt to collect output if it times out
+	ctx, cancel := context.WithTimeout(ctx, runCommandTimeout+time.Minute)
+	defer cancel()
+
+	switch {
+	case req.isUniformVMSS():
+		return c.uniformScaleSetVirtualMachineRunCommand(ctx, req, runCommand)
+	default:
+		return c.regularVirtualMachineRunCommand(ctx, req, runCommand)
+	}
 }
 
 func (c *runCommandClient) regularVirtualMachineRunCommand(ctx context.Context, req RunCommandRequest, runCommand armcompute.VirtualMachineRunCommand) (*armcompute.VirtualMachineRunCommandProperties, error) {
@@ -576,6 +605,127 @@ func (c *runCommandClient) uniformScaleSetVirtualMachineRunCommand(ctx context.C
 	}
 
 	return resp.Properties, nil
+}
+
+func (c *runCommandClient) checkVMStatus(ctx context.Context, req RunCommandRequest) error {
+	var vmStatus *vmStatus
+	var err error
+
+	logger := c.logger.With("resource_group", req.ResourceGroup, "region", req.Region, "vm_name", req.VMName)
+
+	if req.isUniformVMSS() {
+		logger = logger.With("uniform_scale_set_name", req.UniformScaleSetName, "uniform_scale_set_vm_instance_id", req.UniformScaleSetVMInstanceID)
+		vmStatus, err = c.vmssVMStatus(ctx, req)
+	} else {
+		vmStatus, err = c.regularVMStatus(ctx, req)
+	}
+	if err != nil {
+		logger.DebugContext(ctx, "failed to check if VM power status and agent state, continuing with run command", "error", err)
+		return nil
+	}
+
+	switch {
+	case vmStatus.VMIsRunning && vmStatus.AgentIsReady:
+		return nil
+
+	case !vmStatus.VMIsRunning:
+		return NewVMNotRunningError(nil)
+
+	case !vmStatus.AgentIsReady:
+		return NewVMAgentNotAvailableError(nil)
+	}
+
+	return nil
+}
+
+type vmStatus struct {
+	VMIsRunning  bool
+	AgentIsReady bool
+}
+
+func (c *runCommandClient) regularVMStatus(ctx context.Context, req RunCommandRequest) (*vmStatus, error) {
+	getVMResp, err := c.virtualMachineAPI.Get(ctx, req.ResourceGroup, req.VMName, &armcompute.VirtualMachinesClientGetOptions{
+		Expand: new(armcompute.InstanceViewTypesInstanceView),
+	})
+	if err != nil {
+		return nil, trace.Wrap(ConvertResponseError(err))
+	}
+
+	if getVMResp.Properties != nil && getVMResp.Properties.InstanceView != nil {
+		instanceView := getVMResp.Properties.InstanceView
+		return checkStatus(instanceView.VMAgent, instanceView.Statuses)
+	}
+
+	return nil, trace.BadParameter("failed to get vm agent status")
+}
+
+func (c *runCommandClient) vmssVMStatus(ctx context.Context, req RunCommandRequest) (*vmStatus, error) {
+	getVMResp, err := c.scaleSetVMsAPI.Get(ctx, req.ResourceGroup, req.UniformScaleSetName, req.UniformScaleSetVMInstanceID, &armcompute.VirtualMachineScaleSetVMsClientGetOptions{
+		Expand: new(armcompute.InstanceViewTypesInstanceView),
+	})
+	if err != nil {
+		return nil, trace.Wrap(ConvertResponseError(err))
+	}
+
+	if getVMResp.Properties != nil && getVMResp.Properties.InstanceView != nil {
+		instanceView := getVMResp.Properties.InstanceView
+		return checkStatus(instanceView.VMAgent, instanceView.Statuses)
+	}
+
+	return nil, trace.BadParameter("failed to get vm agent status")
+}
+
+func checkStatus(vmAgent *armcompute.VirtualMachineAgentInstanceView, powerStatuses []*armcompute.InstanceViewStatus) (*vmStatus, error) {
+	vmIsRunning, err := isVMRunning(powerStatuses)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	vmAgentReady, err := isVMAgentReady(vmAgent)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &vmStatus{
+		VMIsRunning:  vmIsRunning,
+		AgentIsReady: vmAgentReady,
+	}, nil
+}
+
+func isVMAgentReady(vmAgent *armcompute.VirtualMachineAgentInstanceView) (bool, error) {
+	const (
+		// Azure does not have documentation around possible status codes for the VM Agent, but in practice we have observed the following:
+		// - code:ProvisioningState/succeeded   display_status:Ready     message:GuestAgent is running and processing the extensions. OR Guest Agent is running
+		// - code:ProvisioningState/Unavailable display_status:Not Ready message:VM Agent is unresponsive.
+		provisioningStateSucceeded   = "ProvisioningState/succeeded"
+		provisioningStateUnavailable = "ProvisioningState/Unavailable"
+	)
+	if vmAgent != nil {
+		for _, status := range vmAgent.Statuses {
+			if StringVal(status.Code) == provisioningStateSucceeded {
+				return true, nil
+			}
+			if StringVal(status.Code) == provisioningStateUnavailable {
+				return false, nil
+			}
+		}
+	}
+	return false, trace.BadParameter("failed to get vm agent status")
+}
+
+func isVMRunning(statuses []*armcompute.InstanceViewStatus) (bool, error) {
+	const (
+		powerStateRunning = "PowerState/running"
+		powerStateStopped = "PowerState/stopped"
+	)
+	for _, status := range statuses {
+		if StringVal(status.Code) == powerStateRunning {
+			return true, nil
+		}
+		if StringVal(status.Code) == powerStateStopped {
+			return false, nil
+		}
+	}
+	return false, trace.BadParameter("failed to get vm running status")
 }
 
 func commandResultFromInstanceView(properties *armcompute.VirtualMachineRunCommandProperties) (*RunCommandResult, error) {

--- a/lib/cloud/azure/vm_test.go
+++ b/lib/cloud/azure/vm_test.go
@@ -21,14 +21,23 @@ package azure
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
+	"testing/synctest"
+	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 const (
@@ -40,6 +49,160 @@ const (
 	vmssResourceID   = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1"
 	vmssVMResourceID = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0"
 )
+
+const (
+	testPowerStateRunning            = "PowerState/running"
+	testPowerStateStopped            = "PowerState/stopped"
+	testProvisioningStateSucceeded   = "ProvisioningState/succeeded"
+	testProvisioningStateUnavailable = "ProvisioningState/Unavailable"
+)
+
+func testVMAgent(code string) *armcompute.VirtualMachineAgentInstanceView {
+	return &armcompute.VirtualMachineAgentInstanceView{
+		Statuses: []*armcompute.InstanceViewStatus{{Code: to.Ptr(code)}},
+	}
+}
+
+func testPowerStatus(code string) []*armcompute.InstanceViewStatus {
+	return []*armcompute.InstanceViewStatus{{Code: to.Ptr(code)}}
+}
+
+func testRegularVMWithInstanceView(agent *armcompute.VirtualMachineAgentInstanceView, statuses []*armcompute.InstanceViewStatus) armcompute.VirtualMachine {
+	return armcompute.VirtualMachine{
+		Properties: &armcompute.VirtualMachineProperties{
+			InstanceView: &armcompute.VirtualMachineInstanceView{
+				VMAgent:  agent,
+				Statuses: statuses,
+			},
+		},
+	}
+}
+
+func testScaleSetVMWithInstanceView(agent *armcompute.VirtualMachineAgentInstanceView, statuses []*armcompute.InstanceViewStatus) armcompute.VirtualMachineScaleSetVM {
+	return armcompute.VirtualMachineScaleSetVM{
+		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+				VMAgent:  agent,
+				Statuses: statuses,
+			},
+		},
+	}
+}
+
+type fakeTokenCredential struct{}
+
+func (fakeTokenCredential) GetToken(context.Context, policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{
+		Token:     "fake-token",
+		ExpiresOn: time.Now().Add(time.Hour),
+	}, nil
+}
+
+type fakeAzureRunCommandTransport struct {
+	runCommandInProgress bool
+
+	runCommandGetBody string
+	vmStatusCode      int
+	vmStatusBody      string
+	vmssStatusCode    int
+	vmssStatusBody    string
+
+	runCommandPutCalls   int
+	runCommandGetCalls   int
+	vmStatusCalls        int
+	vmssStatusCalls      int
+	getCommandResultCall int
+	putPaths             []string
+	putRequestBody       string
+}
+
+func newFakeAzureRunCommandTransport() *fakeAzureRunCommandTransport {
+	return &fakeAzureRunCommandTransport{
+		runCommandGetBody: testRunCommandResultBody(string(armcompute.ExecutionStateSucceeded), 0, "install ok", ""),
+		vmStatusCode:      http.StatusOK,
+		vmStatusBody:      testVMInstanceViewBody(testProvisioningStateSucceeded, testPowerStateRunning),
+		vmssStatusCode:    http.StatusOK,
+		vmssStatusBody:    testVMInstanceViewBody(testProvisioningStateSucceeded, testPowerStateRunning),
+	}
+}
+
+func (t *fakeAzureRunCommandTransport) Do(req *http.Request) (*http.Response, error) {
+	path := req.URL.Path
+	switch {
+	case req.Method == http.MethodPut && strings.Contains(path, "/runCommands/"+runCommandName):
+		t.runCommandPutCalls++
+		t.putPaths = append(t.putPaths, path)
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		t.putRequestBody = string(body)
+		if t.runCommandInProgress {
+			return testHTTPResponse(req, http.StatusCreated, `{"properties":{"provisioningState":"Creating"}}`, map[string]string{
+				"Azure-AsyncOperation": "https://management.azure.com/poll",
+			}), nil
+		}
+		return testHTTPResponse(req, http.StatusOK, `{}`, nil), nil
+
+	case req.Method == http.MethodGet && path == "/poll":
+		t.getCommandResultCall++
+		return testHTTPResponse(req, http.StatusOK, `{"status":"InProgress"}`, nil), nil
+
+	case req.Method == http.MethodGet && strings.Contains(path, "/runCommands/"+runCommandName):
+		t.runCommandGetCalls++
+		return testHTTPResponse(req, http.StatusOK, t.runCommandGetBody, nil), nil
+
+	case req.Method == http.MethodGet && strings.Contains(path, "/virtualMachineScaleSets/") && strings.Contains(path, "/virtualMachines/"):
+		t.vmssStatusCalls++
+		return testHTTPResponse(req, t.vmssStatusCode, t.vmssStatusBody, nil), nil
+
+	case req.Method == http.MethodGet && strings.Contains(path, "/virtualMachines/"):
+		t.vmStatusCalls++
+		return testHTTPResponse(req, t.vmStatusCode, t.vmStatusBody, nil), nil
+	}
+
+	return testHTTPResponse(req, http.StatusNotFound, `{"error":{"code":"NotFound","message":"unexpected request"}}`, nil), nil
+}
+
+func testHTTPResponse(req *http.Request, statusCode int, body string, headers map[string]string) *http.Response {
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+	for key, value := range headers {
+		header.Set(key, value)
+	}
+	return &http.Response{
+		StatusCode: statusCode,
+		Status:     fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}
+}
+
+func testRunCommandResultBody(state string, exitCode int32, stdout, stderr string) string {
+	return fmt.Sprintf(`{"properties":{"instanceView":{"executionState":%q,"exitCode":%d,"output":%q,"error":%q}}}`, state, exitCode, stdout, stderr)
+}
+
+func testVMInstanceViewBody(agentCode, powerCode string) string {
+	return fmt.Sprintf(`{"properties":{"instanceView":{"vmAgent":{"statuses":[{"code":%q}]},"statuses":[{"code":%q}]}}}`, agentCode, powerCode)
+}
+
+func newTestRunCommandClient(t *testing.T, transport *fakeAzureRunCommandTransport) *runCommandClient {
+	t.Helper()
+
+	client, err := NewRunCommandClient(testSubID, fakeTokenCredential{}, &arm.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Transport: transport,
+		},
+	})
+	require.NoError(t, err)
+	runCommandClient, ok := client.(*runCommandClient)
+	require.True(t, ok, "got %T", client)
+	return runCommandClient
+}
 
 func TestGetVirtualMachine(t *testing.T) {
 	ctx := context.Background()
@@ -626,6 +789,219 @@ func TestRunCommandRequestIsUniformVMSS(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			require.Equal(t, tc.want, tc.req.isUniformVMSS())
+		})
+	}
+}
+
+func TestRunCommandClientRun(t *testing.T) {
+	t.Parallel()
+
+	t.Run("regular VM returns command result", func(t *testing.T) {
+		transport := newFakeAzureRunCommandTransport()
+		client := newTestRunCommandClient(t, transport)
+
+		result, err := client.Run(t.Context(), RunCommandRequest{
+			Region:        "eastus",
+			ResourceGroup: "rg1",
+			VMName:        "vm1",
+			Script:        "echo ok",
+		})
+		require.NoError(t, err)
+		require.Equal(t, &RunCommandResult{
+			ExecutionState: string(armcompute.ExecutionStateSucceeded),
+			ExitCode:       0,
+			StdOut:         "install ok",
+			StdErr:         "",
+		}, result)
+
+		require.Equal(t, 1, transport.runCommandPutCalls)
+		require.Equal(t, 1, transport.runCommandGetCalls)
+		require.Len(t, transport.putPaths, 1)
+		require.Contains(t, transport.putPaths[0], "/virtualMachines/vm1/runCommands/"+runCommandName)
+		require.Contains(t, transport.putRequestBody, `"location":"eastus"`)
+		require.Contains(t, transport.putRequestBody, `"asyncExecution":false`)
+		require.Contains(t, transport.putRequestBody, `"script":"echo ok"`)
+	})
+
+	t.Run("regular VM timeout returns VM not running error when status says stopped", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			transport := newFakeAzureRunCommandTransport()
+			transport.runCommandInProgress = true
+			transport.vmStatusBody = testVMInstanceViewBody(testProvisioningStateSucceeded, testPowerStateStopped)
+			client := newTestRunCommandClient(t, transport)
+
+			result, err := client.Run(t.Context(), RunCommandRequest{
+				Region:        "eastus",
+				ResourceGroup: "rg1",
+				VMName:        "vm1",
+				Script:        "echo ok",
+			})
+			require.Nil(t, result)
+			require.ErrorIs(t, err, &VMNotRunningError{}, "got %T: %v", err, err)
+			require.NotErrorIs(t, err, context.DeadlineExceeded, "got %T: %v", err, err)
+			require.Equal(t, 1, transport.runCommandPutCalls)
+			require.Zero(t, transport.runCommandGetCalls)
+			require.Equal(t, 1, transport.vmStatusCalls)
+			require.NotZero(t, transport.getCommandResultCall)
+		})
+	})
+
+	t.Run("regular VM timeout returns VM agent error when agent is unavailable", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			transport := newFakeAzureRunCommandTransport()
+			transport.runCommandInProgress = true
+			transport.vmStatusBody = testVMInstanceViewBody(testProvisioningStateUnavailable, testPowerStateRunning)
+			client := newTestRunCommandClient(t, transport)
+
+			result, err := client.Run(t.Context(), RunCommandRequest{
+				Region:        "eastus",
+				ResourceGroup: "rg1",
+				VMName:        "vm1",
+				Script:        "echo ok",
+			})
+			require.Nil(t, result)
+			require.ErrorIs(t, err, &VMAgentNotAvailableError{}, "got %T: %v", err, err)
+			require.NotErrorIs(t, err, context.DeadlineExceeded, "got %T: %v", err, err)
+			require.Equal(t, 1, transport.vmStatusCalls)
+		})
+	})
+
+	t.Run("regular VM timeout keeps original error when status cannot be fetched", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			transport := newFakeAzureRunCommandTransport()
+			transport.runCommandInProgress = true
+			transport.vmStatusCode = http.StatusForbidden
+			transport.vmStatusBody = `{"error":{"code":"AuthorizationFailed","message":"missing read permission"}}`
+			client := newTestRunCommandClient(t, transport)
+
+			result, err := client.Run(t.Context(), RunCommandRequest{
+				Region:        "eastus",
+				ResourceGroup: "rg1",
+				VMName:        "vm1",
+				Script:        "echo ok",
+			})
+			require.Nil(t, result)
+			require.ErrorIs(t, err, context.DeadlineExceeded, "got %T: %v", err, err)
+			require.NotErrorIs(t, err, &VMNotRunningError{}, "got %T: %v", err, err)
+			require.NotErrorIs(t, err, &VMAgentNotAvailableError{}, "got %T: %v", err, err)
+			require.Equal(t, 1, transport.vmStatusCalls)
+		})
+	})
+
+	t.Run("uniform VMSS timeout returns VM not running error when status says stopped", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			transport := newFakeAzureRunCommandTransport()
+			transport.runCommandInProgress = true
+			transport.vmssStatusBody = testVMInstanceViewBody(testProvisioningStateSucceeded, testPowerStateStopped)
+			client := newTestRunCommandClient(t, transport)
+
+			result, err := client.Run(t.Context(), RunCommandRequest{
+				Region:                      "eastus",
+				ResourceGroup:               "rg1",
+				VMName:                      "vmss1_0",
+				UniformScaleSetName:         "vmss1",
+				UniformScaleSetVMInstanceID: "0",
+				Script:                      "echo ok",
+			})
+			require.Nil(t, result)
+			require.ErrorIs(t, err, &VMNotRunningError{}, "got %T: %v", err, err)
+			require.NotErrorIs(t, err, context.DeadlineExceeded, "got %T: %v", err, err)
+			require.Equal(t, 1, transport.runCommandPutCalls)
+			require.Zero(t, transport.runCommandGetCalls)
+			require.Equal(t, 1, transport.vmssStatusCalls)
+			require.Len(t, transport.putPaths, 1)
+			require.Contains(t, transport.putPaths[0], "/virtualMachineScaleSets/vmss1/virtualMachines/0/runCommands/"+runCommandName)
+		})
+	})
+}
+
+func TestRunCommandClientCheckVMStatus(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc            string
+		req             RunCommandRequest
+		vmAPI           *ARMComputeMock
+		scaleSetVMsAPI  *ARMScaleSetVMsMock
+		requireErr      require.ErrorAssertionFunc
+		requireErrIs    error
+		requireNotErrIs error
+	}{
+		{
+			desc: "regular VM running with ready agent",
+			req:  RunCommandRequest{ResourceGroup: "rg1", VMName: "vm1"},
+			vmAPI: &ARMComputeMock{
+				GetResult: testRegularVMWithInstanceView(testVMAgent(testProvisioningStateSucceeded), testPowerStatus(testPowerStateRunning)),
+			},
+			requireErr: require.NoError,
+		},
+		{
+			desc: "regular VM stopped returns VM not running error",
+			req:  RunCommandRequest{ResourceGroup: "rg1", VMName: "vm1"},
+			vmAPI: &ARMComputeMock{
+				GetResult: testRegularVMWithInstanceView(testVMAgent(testProvisioningStateSucceeded), testPowerStatus(testPowerStateStopped)),
+			},
+			requireErr:      require.Error,
+			requireErrIs:    &VMNotRunningError{},
+			requireNotErrIs: &VMAgentNotAvailableError{},
+		},
+		{
+			desc: "regular VM running with unavailable agent returns VM agent error",
+			req:  RunCommandRequest{ResourceGroup: "rg1", VMName: "vm1"},
+			vmAPI: &ARMComputeMock{
+				GetResult: testRegularVMWithInstanceView(testVMAgent(testProvisioningStateUnavailable), testPowerStatus(testPowerStateRunning)),
+			},
+			requireErr:      require.Error,
+			requireErrIs:    &VMAgentNotAvailableError{},
+			requireNotErrIs: &VMNotRunningError{},
+		},
+		{
+			desc: "status fetch errors do not block run command",
+			req:  RunCommandRequest{ResourceGroup: "rg1", VMName: "vm1"},
+			vmAPI: &ARMComputeMock{
+				GetErr: trace.AccessDenied("missing read permission"),
+			},
+			requireErr: require.NoError,
+		},
+		{
+			desc: "missing instance view does not block run command",
+			req:  RunCommandRequest{ResourceGroup: "rg1", VMName: "vm1"},
+			vmAPI: &ARMComputeMock{
+				GetResult: armcompute.VirtualMachine{},
+			},
+			requireErr: require.NoError,
+		},
+		{
+			desc: "uniform VMSS stopped returns VM not running error",
+			req: RunCommandRequest{
+				ResourceGroup:               "rg1",
+				VMName:                      "vmss1_0",
+				UniformScaleSetName:         "vmss1",
+				UniformScaleSetVMInstanceID: "0",
+			},
+			scaleSetVMsAPI: &ARMScaleSetVMsMock{
+				GetResult: testScaleSetVMWithInstanceView(testVMAgent(testProvisioningStateSucceeded), testPowerStatus(testPowerStateStopped)),
+			},
+			requireErr:      require.Error,
+			requireErrIs:    &VMNotRunningError{},
+			requireNotErrIs: &VMAgentNotAvailableError{},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			client := &runCommandClient{
+				virtualMachineAPI: tc.vmAPI,
+				scaleSetVMsAPI:    tc.scaleSetVMsAPI,
+				logger:            logtest.NewLogger(),
+			}
+
+			err := client.checkVMStatus(t.Context(), tc.req)
+			tc.requireErr(t, err)
+			if tc.requireErrIs != nil {
+				require.ErrorIs(t, err, tc.requireErrIs, "got %T: %v", err, err)
+			}
+			if tc.requireNotErrIs != nil {
+				require.NotErrorIs(t, err, tc.requireNotErrIs, "got %T: %v", err, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
When doing Azure Server Discovery, teleport tries to run the installation script in the target Azure VMs.

After calling Azure API to run a command, Discovery service polls every 30 seconds for the command's result.
If it doesn't report any result for 5 minutes, we surface that error to the user.

Azure does not give us a way to understand where the script execution is stuck, but when that happens, it usually means one of:
- the script is just taking too long to execute (eg, it might have a slow network path to download teleport from the CDN)
- the VM Agent in the instance is not healthy

This PR changes the Discovery Service so that we check the VM Agent status.
This way we can provide users with the reason why we were not able to install teleport.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Added a new specific error when Azure Server Discovery fails to enroll an instance because the VM Agent is not healthy. 


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases
- [x] Test with VM with un-healthy agent
- [x] Test with working VM


### Demo

<img width="689" height="623" alt="image" src="https://github.com/user-attachments/assets/4a2cf5ff-dcde-4a8b-aef8-4288bc7d7079" />

<details>
<summary>tctl get user_tasks </summary>

```yaml
kind: user_task
metadata:
  expires: "2026-07-01T18:00:59.233833Z"
  name: 1eb21574-1fd2-5811-8824-60922ef42307
  revision: 543496e6-4583-456a-aec4-48e532252454
spec:
  discover_azure_vm:
    instances:
      b028783e-9e98-4da4-ad95-17168a903021:
        attempts: 1
        discovery_config: teleport-dev
        discovery_group: aws-prod
        last_attempt_time: "2026-07-01T17:50:59.221160Z"
        name: MarcoLinuxAgentNotRunning
        resource_id: /subscriptions/060a97ea-3a57-4218-9be5-dba3f19ff2b5/resourceGroups/marco-discover/providers/Microsoft.Compute/virtualMachines/MarcoLinuxAgentNotRunning
        retry_after_time: "2026-07-01T18:00:40.159245065Z"
        sync_time: "2026-07-01T17:50:59.221160Z"
        vm_id: b028783e-9e98-4da4-ad95-17168a903021
    region: westeurope
    resource_group: marco-discover
    subscription_id: 060a97ea-3a57-4218-9be5-dba3f19ff2b5
  integration: ambient-credentials
  issue_type: azure-vm-agent-not-available
  state: OPEN
  task_type: discover-azure-vm
status:
  last_state_change: "2026-07-01T17:50:59.243988Z"
version: v1
```

</details