### PR TITLE
Enforce a max limit on the proxy jump address

### DIFF
--- a/lib/utils/fuzz_test.go
+++ b/lib/utils/fuzz_test.go
@@ -31,6 +31,9 @@ func FuzzParseProxyJump(f *testing.F) {
 	f.Add("@:,")
 	f.Add("user@host:port,bob@host:port")
 
+	// oss-fuzz reproducer: https://issues.oss-fuzz.com/issues/523269348
+	f.Add(strings.Repeat("0", 1<<16) + "]::" + strings.Repeat("0", 1<<16) + "[")
+
 	f.Fuzz(func(t *testing.T, in string) {
 		require.NotPanics(t, func() {
 			ParseProxyJump(in)

--- a/lib/utils/proxyjump.go
+++ b/lib/utils/proxyjump.go
@@ -30,6 +30,9 @@ var reProxyJump = regexp.MustCompile(
 	`(?:(?P<username>[^\:]+)@)?(?P<hostport>[^\@]+)`,
 )
 
+// maxProxyJumpLen is the maximum accepted length of a proxy jump string.
+const maxProxyJumpLen = 4096
+
 // JumpHost is a target jump host
 type JumpHost struct {
 	// Username to login as
@@ -42,6 +45,9 @@ type JumpHost struct {
 func ParseProxyJump(in string) ([]JumpHost, error) {
 	if in == "" {
 		return nil, trace.BadParameter("missing proxyjump")
+	}
+	if len(in) > maxProxyJumpLen {
+		return nil, trace.BadParameter("proxyjump too long: %d bytes (max %d)", len(in), maxProxyJumpLen)
 	}
 	parts := strings.Split(in, ",")
 	out := make([]JumpHost, 0, len(parts))

--- a/lib/utils/proxyjump_test.go
+++ b/lib/utils/proxyjump_test.go
@@ -20,8 +20,10 @@ package utils
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,4 +71,17 @@ func TestProxyJumpParsing(t *testing.T) {
 			require.Equal(t, tc.out, re)
 		})
 	}
+}
+
+func TestProxyJumpLengthLimit(t *testing.T) {
+	t.Parallel()
+
+	atLimit := strings.Repeat("0", maxProxyJumpLen)
+	_, err := ParseProxyJump(atLimit)
+	require.NoError(t, err)
+
+	overLimit := strings.Repeat("0", maxProxyJumpLen+1)
+	_, err = ParseProxyJump(overLimit)
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %T", err)
 }


### PR DESCRIPTION
oss-fuzz observed a 60s timeout in fuzz_parse_proxy_jump. There haven't been any recent changes to this code, but the reproducer inputs from the fuzzer is a very large (> 500K) input, so I suspect running a regex on such a large input in the shared infra that the fuzzer runs on was enough to trigger the timeout.