### PR TITLE
Release 18.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 18.9.2 (06/26/26)
+
+* Fixed HTTP application access connections returning repeated 403 errors after certificate renewal. When the certificate behind a long-lived connection expires, the proxy now sends `Connection: close` so the client reestablishes the connection with a renewed certificate instead of reusing a dead one. [#68099](https://github.com/gravitational/teleport/pull/68099)
+* Add "tsh apps logins" command to query available logins for the given cloud application (currently only AWS is supported). [#68052](https://github.com/gravitational/teleport/pull/68052)
+* Fixed cloud-hosted Slack plugin exposing credentials in request URLs. [#68017](https://github.com/gravitational/teleport/pull/68017)
+* Added the Sub CA `tctl auth delete-override` command, a user-friendly alternative over `tctl edit ca_overrides` or `tctl rm ca_overrides`. [#68014](https://github.com/gravitational/teleport/pull/68014)
+* Fixed potential deadlock when reading access list owners from the cache as the cache becomes unhealthy. [#68013](https://github.com/gravitational/teleport/pull/68013)
+* Added the Sub CA `tctl auth create-override` command, a user-friendly alternative over `tctl create ca_override.yaml`. [#67983](https://github.com/gravitational/teleport/pull/67983)
+* Fix MFA prompts to show correct --mfa-mode values for webauthn authenticators. [#67971](https://github.com/gravitational/teleport/pull/67971)
+* Prevent misrouting when multiple apps share the same public address. [#67947](https://github.com/gravitational/teleport/pull/67947)
+* Fix an issue where the WebUI would prompt for MFA multiple times for admin actions (or outright fail for select commands) when `sso` is the only allowed second factor on the cluster. [#67867](https://github.com/gravitational/teleport/pull/67867)
+* Fixed desktop connection failures to Windows 11 / Windows Server 2025 instances. [#67483](https://github.com/gravitational/teleport/pull/67483)
+
+Enterprise:
+
+* Add support for rate limiting in the Teleport SCIM Server.
+* Update `golang.org/x/crypto` to `v0.53.0`.
+* Updated Teleport Entra ID integration to support delta sync.
+* Only process Okta assignments for groups and apps currently being synced.
+* Prevent user-deletion of Access Lists being synced by Okta integration.
+
 ## 18.9.1 (06/19/26)
 
 * Fixed a limitation in Kubernetes Access causing the agent to throttle at 5 exec/second.

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=18.9.2-rc.1
+VERSION=18.9.2
 
 DOCKER_IMAGE ?= teleport
 

--- a/api/version.go
+++ b/api/version.go
@@ -2,10 +2,10 @@
 
 package api
 
-const Version = "18.9.2-rc.1"
+const Version = "18.9.2"
 
 const VersionMajor = 18
 const VersionMinor = 9
 const VersionPatch = 2
-const VersionPreRelease = "rc.1"
+const VersionPreRelease = ""
 const VersionMetadata = ""

--- a/build.assets/macos/tsh/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tsh/tsh.app/Contents/Info.plist
@@ -19,13 +19,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>1.0</string>
+		<string>18.9.2</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>1.0</string>
+		<string>18.9.2</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
@@ -17,13 +17,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>1.0</string>
+		<string>18.9.2</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>1.0</string>
+		<string>18.9.2</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/examples/chart/access/datadog/Chart.yaml
+++ b/examples/chart/access/datadog/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.9.2-rc.1"
+.version: &version "18.9.2"
 
 apiVersion: v2
 name: teleport-plugin-datadog

--- a/examples/chart/access/datadog/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/datadog/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,6 +26,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-datadog
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-datadog-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-datadog-18.9.2
       name: RELEASE-NAME-teleport-plugin-datadog

--- a/examples/chart/access/datadog/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/datadog/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-datadog
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-datadog-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-datadog-18.9.2
       name: RELEASE-NAME-teleport-plugin-datadog
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-datadog
-            app.kubernetes.io/version: 18.9.2-rc.1
-            helm.sh/chart: teleport-plugin-datadog-18.9.2-rc.1
+            app.kubernetes.io/version: 18.9.2
+            helm.sh/chart: teleport-plugin-datadog-18.9.2
         spec:
           containers:
           - command:

--- a/examples/chart/access/discord/Chart.yaml
+++ b/examples/chart/access/discord/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.9.2-rc.1"
+.version: &version "18.9.2"
 
 apiVersion: v2
 name: teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-discord-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-discord-18.9.2
       name: RELEASE-NAME-teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-discord-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-discord-18.9.2
       name: RELEASE-NAME-teleport-plugin-discord
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-discord
-            app.kubernetes.io/version: 18.9.2-rc.1
-            helm.sh/chart: teleport-plugin-discord-18.9.2-rc.1
+            app.kubernetes.io/version: 18.9.2
+            helm.sh/chart: teleport-plugin-discord-18.9.2
         spec:
           containers:
           - command:

--- a/examples/chart/access/email/Chart.yaml
+++ b/examples/chart/access/email/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.9.2-rc.1"
+.version: &version "18.9.2"
 
 apiVersion: v2
 name: teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
@@ -25,8 +25,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-email-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-email-18.9.2
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on):
   1: |
@@ -58,8 +58,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-email-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-email-18.9.2
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, no starttls):
   1: |
@@ -91,8 +91,8 @@ should match the snapshot (smtp on, no starttls):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-email-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-email-18.9.2
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, password file):
   1: |
@@ -124,8 +124,8 @@ should match the snapshot (smtp on, password file):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-email-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-email-18.9.2
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, roleToRecipients set):
   1: |
@@ -160,8 +160,8 @@ should match the snapshot (smtp on, roleToRecipients set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-email-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-email-18.9.2
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, starttls disabled):
   1: |
@@ -193,6 +193,6 @@ should match the snapshot (smtp on, starttls disabled):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-email-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-email-18.9.2
       name: RELEASE-NAME-teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should be possible to override volume name (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-email-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-email-18.9.2
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should be possible to override volume name (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.9.2-rc.1
-            helm.sh/chart: teleport-plugin-email-18.9.2-rc.1
+            app.kubernetes.io/version: 18.9.2
+            helm.sh/chart: teleport-plugin-email-18.9.2
         spec:
           containers:
           - command:
@@ -34,7 +34,7 @@ should be possible to override volume name (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:18.9.2-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:18.9.2
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -75,8 +75,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-email-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-email-18.9.2
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.9.2-rc.1
-            helm.sh/chart: teleport-plugin-email-18.9.2-rc.1
+            app.kubernetes.io/version: 18.9.2
+            helm.sh/chart: teleport-plugin-email-18.9.2
         spec:
           containers:
           - command:
@@ -136,8 +136,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-email-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-email-18.9.2
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -151,8 +151,8 @@ should match the snapshot (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.9.2-rc.1
-            helm.sh/chart: teleport-plugin-email-18.9.2-rc.1
+            app.kubernetes.io/version: 18.9.2
+            helm.sh/chart: teleport-plugin-email-18.9.2
         spec:
           containers:
           - command:
@@ -163,7 +163,7 @@ should match the snapshot (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:18.9.2-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:18.9.2
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -204,8 +204,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-email-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-email-18.9.2
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -219,8 +219,8 @@ should match the snapshot (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.9.2-rc.1
-            helm.sh/chart: teleport-plugin-email-18.9.2-rc.1
+            app.kubernetes.io/version: 18.9.2
+            helm.sh/chart: teleport-plugin-email-18.9.2
         spec:
           containers:
           - command:
@@ -231,7 +231,7 @@ should match the snapshot (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:18.9.2-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:18.9.2
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -272,8 +272,8 @@ should mount external secret (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-email-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-email-18.9.2
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -287,8 +287,8 @@ should mount external secret (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.9.2-rc.1
-            helm.sh/chart: teleport-plugin-email-18.9.2-rc.1
+            app.kubernetes.io/version: 18.9.2
+            helm.sh/chart: teleport-plugin-email-18.9.2
         spec:
           containers:
           - command:
@@ -299,7 +299,7 @@ should mount external secret (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:18.9.2-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:18.9.2
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -340,8 +340,8 @@ should mount external secret (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-email-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-email-18.9.2
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -355,8 +355,8 @@ should mount external secret (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.9.2-rc.1
-            helm.sh/chart: teleport-plugin-email-18.9.2-rc.1
+            app.kubernetes.io/version: 18.9.2
+            helm.sh/chart: teleport-plugin-email-18.9.2
         spec:
           containers:
           - command:
@@ -367,7 +367,7 @@ should mount external secret (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:18.9.2-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:18.9.2
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:

--- a/examples/chart/access/jira/Chart.yaml
+++ b/examples/chart/access/jira/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.9.2-rc.1"
+.version: &version "18.9.2"
 
 apiVersion: v2
 name: teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
@@ -30,6 +30,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-jira-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-jira-18.9.2
       name: RELEASE-NAME-teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-jira-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-jira-18.9.2
       name: RELEASE-NAME-teleport-plugin-jira
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-jira
-            app.kubernetes.io/version: 18.9.2-rc.1
-            helm.sh/chart: teleport-plugin-jira-18.9.2-rc.1
+            app.kubernetes.io/version: 18.9.2
+            helm.sh/chart: teleport-plugin-jira-18.9.2
         spec:
           containers:
           - command:

--- a/examples/chart/access/mattermost/Chart.yaml
+++ b/examples/chart/access/mattermost/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.9.2-rc.1"
+.version: &version "18.9.2"
 
 apiVersion: v2
 name: teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
@@ -22,6 +22,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-mattermost-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-mattermost-18.9.2
       name: RELEASE-NAME-teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-mattermost-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-mattermost-18.9.2
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 18.9.2-rc.1
-            helm.sh/chart: teleport-plugin-mattermost-18.9.2-rc.1
+            app.kubernetes.io/version: 18.9.2
+            helm.sh/chart: teleport-plugin-mattermost-18.9.2
         spec:
           containers:
           - command:
@@ -75,8 +75,8 @@ should mount external secret:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-mattermost-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-mattermost-18.9.2
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should mount external secret:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 18.9.2-rc.1
-            helm.sh/chart: teleport-plugin-mattermost-18.9.2-rc.1
+            app.kubernetes.io/version: 18.9.2
+            helm.sh/chart: teleport-plugin-mattermost-18.9.2
         spec:
           containers:
           - command:
@@ -102,7 +102,7 @@ should mount external secret:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:18.9.2-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:18.9.2
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:
@@ -143,8 +143,8 @@ should override volume name:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-mattermost-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-mattermost-18.9.2
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -158,8 +158,8 @@ should override volume name:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 18.9.2-rc.1
-            helm.sh/chart: teleport-plugin-mattermost-18.9.2-rc.1
+            app.kubernetes.io/version: 18.9.2
+            helm.sh/chart: teleport-plugin-mattermost-18.9.2
         spec:
           containers:
           - command:
@@ -170,7 +170,7 @@ should override volume name:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:18.9.2-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:18.9.2
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:

--- a/examples/chart/access/msteams/Chart.yaml
+++ b/examples/chart/access/msteams/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.9.2-rc.1"
+.version: &version "18.9.2"
 
 apiVersion: v2
 name: teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
@@ -29,6 +29,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-msteams-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-msteams-18.9.2
       name: RELEASE-NAME-teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-msteams-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-msteams-18.9.2
       name: RELEASE-NAME-teleport-plugin-msteams
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-msteams
-            app.kubernetes.io/version: 18.9.2-rc.1
-            helm.sh/chart: teleport-plugin-msteams-18.9.2-rc.1
+            app.kubernetes.io/version: 18.9.2
+            helm.sh/chart: teleport-plugin-msteams-18.9.2
         spec:
           containers:
           - command:

--- a/examples/chart/access/pagerduty/Chart.yaml
+++ b/examples/chart/access/pagerduty/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.9.2-rc.1"
+.version: &version "18.9.2"
 
 apiVersion: v2
 name: teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
@@ -21,6 +21,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-pagerduty-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-pagerduty-18.9.2
       name: RELEASE-NAME-teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-pagerduty-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-pagerduty-18.9.2
       name: RELEASE-NAME-teleport-plugin-pagerduty
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-pagerduty
-            app.kubernetes.io/version: 18.9.2-rc.1
-            helm.sh/chart: teleport-plugin-pagerduty-18.9.2-rc.1
+            app.kubernetes.io/version: 18.9.2
+            helm.sh/chart: teleport-plugin-pagerduty-18.9.2
         spec:
           containers:
           - command:

--- a/examples/chart/access/slack/Chart.yaml
+++ b/examples/chart/access/slack/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.9.2-rc.1"
+.version: &version "18.9.2"
 
 apiVersion: v2
 name: teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-slack-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-slack-18.9.2
       name: RELEASE-NAME-teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-slack-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-slack-18.9.2
       name: RELEASE-NAME-teleport-plugin-slack
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-slack
-            app.kubernetes.io/version: 18.9.2-rc.1
-            helm.sh/chart: teleport-plugin-slack-18.9.2-rc.1
+            app.kubernetes.io/version: 18.9.2
+            helm.sh/chart: teleport-plugin-slack-18.9.2
         spec:
           containers:
           - command:

--- a/examples/chart/event-handler/Chart.yaml
+++ b/examples/chart/event-handler/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.9.2-rc.1"
+.version: &version "18.9.2"
 
 apiVersion: v2
 name: teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/certificate_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/certificate_test.yaml.snap
@@ -7,8 +7,8 @@ should request certificates when certManager enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-event-handler-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-event-handler-18.9.2
       name: RELEASE-NAME-teleport-plugin-event-handler-server
       namespace: NAMESPACE
     spec:
@@ -35,8 +35,8 @@ should request certificates when certManager enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-event-handler-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-event-handler-18.9.2
       name: RELEASE-NAME-teleport-plugin-event-handler-client
       namespace: NAMESPACE
     spec:

--- a/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
@@ -33,6 +33,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-event-handler-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-event-handler-18.9.2
       name: RELEASE-NAME-teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-event-handler-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-event-handler-18.9.2
       name: RELEASE-NAME-teleport-plugin-event-handler
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-event-handler
-            app.kubernetes.io/version: 18.9.2-rc.1
-            helm.sh/chart: teleport-plugin-event-handler-18.9.2-rc.1
+            app.kubernetes.io/version: 18.9.2
+            helm.sh/chart: teleport-plugin-event-handler-18.9.2
         spec:
           containers:
           - args:
@@ -87,7 +87,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: "true"
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/helm-lint-existing-tls-secret-key-name
-      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:18.9.2
       imagePullPolicy: IfNotPresent
       name: teleport-plugin-event-handler
       ports:

--- a/examples/chart/event-handler/tests/__snapshot__/operator_crs_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/operator_crs_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot (tokenSpecOverride set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-event-handler-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-event-handler-18.9.2
       name: RELEASE-NAME-teleport-plugin-event-handler
       namespace: NAMESPACE
     spec:
@@ -28,8 +28,8 @@ should match the snapshot (tokenSpecOverride set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-event-handler-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-event-handler-18.9.2
       name: RELEASE-NAME-teleport-plugin-event-handler
       namespace: NAMESPACE
     spec:
@@ -43,8 +43,8 @@ should match the snapshot (tokenSpecOverride set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-plugin-event-handler-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-plugin-event-handler-18.9.2
       name: RELEASE-NAME-tbot
       namespace: NAMESPACE
     spec:

--- a/examples/chart/tbot-spiffe-daemon-set/Chart.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.9.2-rc.1"
+.version: &version "18.9.2"
 
 name: tbot-spiffe-daemon-set
 apiVersion: v2

--- a/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/daemonset_test.yaml.snap
@@ -21,7 +21,7 @@ should match the snapshot (full):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot-spiffe-daemon-set
-            helm.sh/chart: tbot-spiffe-daemon-set-18.9.2-rc.1
+            helm.sh/chart: tbot-spiffe-daemon-set-18.9.2
         spec:
           containers:
           - args:
@@ -38,7 +38,7 @@ should match the snapshot (full):
                   fieldPath: spec.nodeName
             - name: KUBERNETES_TOKEN_PATH
               value: /var/run/secrets/tokens/join-sa-token
-            image: public.ecr.aws/gravitational/tbot-distroless:18.9.2-rc.1
+            image: public.ecr.aws/gravitational/tbot-distroless:18.9.2
             imagePullPolicy: IfNotPresent
             name: tbot
             securityContext:
@@ -94,7 +94,7 @@ should match the snapshot (simple):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot-spiffe-daemon-set
-            helm.sh/chart: tbot-spiffe-daemon-set-18.9.2-rc.1
+            helm.sh/chart: tbot-spiffe-daemon-set-18.9.2
         spec:
           containers:
           - args:
@@ -110,7 +110,7 @@ should match the snapshot (simple):
                   fieldPath: spec.nodeName
             - name: KUBERNETES_TOKEN_PATH
               value: /var/run/secrets/tokens/join-sa-token
-            image: public.ecr.aws/gravitational/tbot-distroless:18.9.2-rc.1
+            image: public.ecr.aws/gravitational/tbot-distroless:18.9.2
             imagePullPolicy: IfNotPresent
             name: tbot
             securityContext:

--- a/examples/chart/tbot/Chart.yaml
+++ b/examples/chart/tbot/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.9.2-rc.1"
+.version: &version "18.9.2"
 
 name: tbot
 apiVersion: v2

--- a/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
@@ -29,7 +29,7 @@ should match the snapshot (full):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-18.9.2-rc.1
+            helm.sh/chart: tbot-18.9.2
             test-key: test-label-pod
         spec:
           affinity:
@@ -68,7 +68,7 @@ should match the snapshot (full):
               value: "1"
             - name: TEST_ENV
               value: test-value
-            image: public.ecr.aws/gravitational/tbot-distroless:18.9.2-rc.1
+            image: public.ecr.aws/gravitational/tbot-distroless:18.9.2
             imagePullPolicy: Always
             livenessProbe:
               failureThreshold: 6
@@ -167,7 +167,7 @@ should match the snapshot (simple):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-18.9.2-rc.1
+            helm.sh/chart: tbot-18.9.2
         spec:
           containers:
           - args:
@@ -189,7 +189,7 @@ should match the snapshot (simple):
                   fieldPath: spec.nodeName
             - name: KUBERNETES_TOKEN_PATH
               value: /var/run/secrets/tokens/join-sa-token
-            image: public.ecr.aws/gravitational/tbot-distroless:18.9.2-rc.1
+            image: public.ecr.aws/gravitational/tbot-distroless:18.9.2
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.9.2-rc.1"
+.version: &version "18.9.2"
 
 name: teleport-cluster
 apiVersion: v2

--- a/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.9.2-rc.1"
+.version: &version "18.9.2"
 
 name: teleport-operator
 apiVersion: v2

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
@@ -8,8 +8,8 @@ adds operator permissions to ClusterRole:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-cluster-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-cluster-18.9.2
         teleport.dev/majorVersion: "18"
       name: RELEASE-NAME
     rules:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -2040,8 +2040,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-cluster-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-cluster-18.9.2
         teleport.dev/majorVersion: "18"
       name: RELEASE-NAME-auth
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -8,7 +8,7 @@
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -159,7 +159,7 @@ should set nodeSelector when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -277,7 +277,7 @@ should set resources when set in values:
       env:
       - name: GOMEMLIMIT
         value: "3865470567"
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -381,7 +381,7 @@ should set securityContext when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
@@ -567,8 +567,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-cluster-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-cluster-18.9.2
         teleport.dev/majorVersion: "18"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -11,8 +11,8 @@ sets clusterDomain on Deployment Pods:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 18.9.2-rc.1
-        helm.sh/chart: teleport-cluster-18.9.2-rc.1
+        app.kubernetes.io/version: 18.9.2
+        helm.sh/chart: teleport-cluster-18.9.2
         teleport.dev/majorVersion: "18"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE
@@ -26,7 +26,7 @@ sets clusterDomain on Deployment Pods:
       template:
         metadata:
           annotations:
-            checksum/config: 8fb6e65b6aae9f6c31c8429a0592b5138845800500349aff852d499b747dec96
+            checksum/config: 04d2854eb1e47526cd6f2c9fa491589356ff0d17af810aabbf16f9f463fcdbdc
             kubernetes.io/pod: test-annotation
             kubernetes.io/pod-different: 4
           labels:
@@ -34,8 +34,8 @@ sets clusterDomain on Deployment Pods:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-cluster
-            app.kubernetes.io/version: 18.9.2-rc.1
-            helm.sh/chart: teleport-cluster-18.9.2-rc.1
+            app.kubernetes.io/version: 18.9.2
+            helm.sh/chart: teleport-cluster-18.9.2
             teleport.dev/majorVersion: "18"
         spec:
           affinity:
@@ -44,7 +44,7 @@ sets clusterDomain on Deployment Pods:
           containers:
           - args:
             - --diag-addr=0.0.0.0:3000
-            image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
             imagePullPolicy: IfNotPresent
             lifecycle:
               preStop:
@@ -106,7 +106,7 @@ sets clusterDomain on Deployment Pods:
             - wait
             - no-resolve
             - RELEASE-NAME-auth-v17.NAMESPACE.svc.test.com
-            image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
             name: wait-auth-update
           serviceAccountName: RELEASE-NAME-proxy
           terminationGracePeriodSeconds: 60
@@ -155,7 +155,7 @@ should provision initContainer correctly when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       name: wait-auth-update
       resources:
         limits:
@@ -219,7 +219,7 @@ should set nodeSelector when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -281,7 +281,7 @@ should set nodeSelector when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       name: wait-auth-update
     nodeSelector:
       environment: security
@@ -352,7 +352,7 @@ should set resources for wait-auth-update initContainer when set in values:
       env:
       - name: GOMEMLIMIT
         value: "3865470567"
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -421,7 +421,7 @@ should set resources for wait-auth-update initContainer when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       name: wait-auth-update
       resources:
         limits:
@@ -481,7 +481,7 @@ should set resources when set in values:
       env:
       - name: GOMEMLIMIT
         value: "3865470567"
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -550,7 +550,7 @@ should set resources when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       name: wait-auth-update
       resources:
         limits:
@@ -607,7 +607,7 @@ should set securityContext for initContainers when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -676,7 +676,7 @@ should set securityContext for initContainers when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false
@@ -733,7 +733,7 @@ should set securityContext when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -802,7 +802,7 @@ should set securityContext when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.9.2-rc.1"
+.version: &version "18.9.2"
 
 name: teleport-kube-agent
 apiVersion: v2

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -32,7 +32,7 @@ sets Deployment annotations when specified if action is Upgrade:
               value: "true"
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -109,7 +109,7 @@ sets Deployment labels when specified if action is Upgrade:
             value: "true"
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-          image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+          image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -173,7 +173,7 @@ sets Pod annotations when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -237,7 +237,7 @@ sets Pod labels when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -322,7 +322,7 @@ should add emptyDir for data when existingDataVolume is not set if action is Upg
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -387,7 +387,7 @@ should add insecureSkipProxyTLSVerify to args when set in values if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -451,7 +451,7 @@ should correctly configure existingDataVolume when set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -513,7 +513,7 @@ should expose diag port if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -589,7 +589,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -665,7 +665,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -729,7 +729,7 @@ should have one replica when replicaCount is not set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -793,7 +793,7 @@ should mount extraVolumes and extraVolumeMounts if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -862,7 +862,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf an
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -932,7 +932,7 @@ should mount jamfCredentialsSecret.name when role is jamf and action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1004,7 +1004,7 @@ should mount tls.existingCASecretName and set environment when set in values if 
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1078,7 +1078,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: http://username:password@my.proxy.host:3128
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1148,7 +1148,7 @@ should provision initContainer correctly when set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1270,7 +1270,7 @@ should set affinity when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1334,7 +1334,7 @@ should set default serviceAccountName when not set in values if action is Upgrad
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1411,7 +1411,7 @@ should set environment when extraEnv set in values if action is Upgrade:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1539,7 +1539,7 @@ should set imagePullPolicy when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1603,7 +1603,7 @@ should set nodeSelector if set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1669,7 +1669,7 @@ should set not set priorityClassName when not set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1745,7 +1745,7 @@ should set preferred affinity when more than one replica is used if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1809,7 +1809,7 @@ should set priorityClassName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1874,7 +1874,7 @@ should set probeTimeoutSeconds when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1948,7 +1948,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set if
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2012,7 +2012,7 @@ should set resources when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2083,7 +2083,7 @@ should set serviceAccountName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2147,7 +2147,7 @@ should set tolerations when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -25,7 +25,7 @@ should create ServiceAccount for post-delete hook by default:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -108,7 +108,7 @@ should not create ServiceAccount for post-delete hook if serviceAccount.create i
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
             imagePullPolicy: IfNotPresent
             name: post-delete-job
             securityContext:
@@ -138,7 +138,7 @@ should not create ServiceAccount, Role or RoleBinding for post-delete hook if se
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -168,7 +168,7 @@ should set nodeSelector in post-delete hook:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -200,7 +200,7 @@ should set resources in the Job's pod spec if resources is set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       resources:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -18,7 +18,7 @@ sets Pod annotations when specified:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -104,7 +104,7 @@ sets Pod labels when specified:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -214,7 +214,7 @@ sets StatefulSet labels when specified:
               value: RELEASE-NAME
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -332,7 +332,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -418,7 +418,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -524,7 +524,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
               value: RELEASE-NAME
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -620,7 +620,7 @@ should add volumeMount for data volume when using StatefulSet:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -706,7 +706,7 @@ should expose diag port:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -792,7 +792,7 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -892,7 +892,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -990,7 +990,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1076,7 +1076,7 @@ should have one replica when replicaCount is not set:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1162,7 +1162,7 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1250,7 +1250,7 @@ should mount extraVolumes and extraVolumeMounts:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1341,7 +1341,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1435,7 +1435,7 @@ should mount jamfCredentialsSecret.name when role is jamf:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1531,7 +1531,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/helm-lint-existing-tls-secret-key-name
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1629,7 +1629,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: /etc/teleport-tls-ca/helm-lint-existing-tls-secret-key-name
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1723,7 +1723,7 @@ should not add emptyDir for data when using StatefulSet:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1811,7 +1811,7 @@ should provision initContainer correctly when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1955,7 +1955,7 @@ should set affinity when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2041,7 +2041,7 @@ should set default serviceAccountName when not set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2140,7 +2140,7 @@ should set environment when extraEnv set in values:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2312,7 +2312,7 @@ should set imagePullPolicy when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -2398,7 +2398,7 @@ should set nodeSelector if set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2498,7 +2498,7 @@ should set preferred affinity when more than one replica is used:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2584,7 +2584,7 @@ should set probeTimeoutSeconds when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2680,7 +2680,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2768,7 +2768,7 @@ should set resources when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2861,7 +2861,7 @@ should set serviceAccountName when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2947,7 +2947,7 @@ should set storage.requests when set in values and action is an Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -3033,7 +3033,7 @@ should set storage.storageClassName when set in values and action is an Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -3119,7 +3119,7 @@ should set tolerations when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -27,7 +27,7 @@ sets the affinity:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -75,7 +75,7 @@ sets the tolerations:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:18.9.2-rc.1
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:18.9.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-updater/Chart.yaml
+++ b/examples/chart/teleport-kube-updater/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.9.2-rc.1"
+.version: &version "18.9.2"
 
 name: teleport-kube-updater
 apiVersion: v2

--- a/examples/chart/teleport-relay/Chart.yaml
+++ b/examples/chart/teleport-relay/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.9.2-rc.1"
+.version: &version "18.9.2"
 
 name: teleport-relay
 apiVersion: v2


### PR DESCRIPTION
* Fixed HTTP application access connections returning repeated 403 errors after certificate renewal. When the certificate behind a long-lived connection expires, the proxy now sends `Connection: close` so the client reestablishes the connection with a renewed certificate instead of reusing a dead one. [#68099](https://github.com/gravitational/teleport/pull/68099)
* Add "tsh apps logins" command to query available logins for the given cloud application (currently only AWS is supported). [#68052](https://github.com/gravitational/teleport/pull/68052)
* Fixed cloud-hosted Slack plugin exposing credentials in request URLs. [#68017](https://github.com/gravitational/teleport/pull/68017)
* Added the Sub CA `tctl auth delete-override` command, a user-friendly alternative over `tctl edit ca_overrides` or `tctl rm ca_overrides`. [#68014](https://github.com/gravitational/teleport/pull/68014)
* Fixed potential deadlock when reading access list owners from the cache as the cache becomes unhealthy. [#68013](https://github.com/gravitational/teleport/pull/68013)
* Added the Sub CA `tctl auth create-override` command, a user-friendly alternative over `tctl create ca_override.yaml`. [#67983](https://github.com/gravitational/teleport/pull/67983)
* Fix MFA prompts to show correct --mfa-mode values for webauthn authenticators. [#67971](https://github.com/gravitational/teleport/pull/67971)
* Prevent misrouting when multiple apps share the same public address. [#67947](https://github.com/gravitational/teleport/pull/67947)
* Fix an issue where the WebUI would prompt for MFA multiple times for admin actions (or outright fail for select commands) when `sso` is the only allowed second factor on the cluster. [#67867](https://github.com/gravitational/teleport/pull/67867)
* Fixed desktop connection failures to Windows 11 / Windows Server 2025 instances. [#67483](https://github.com/gravitational/teleport/pull/67483)

Enterprise:

* Add support for rate limiting in the Teleport SCIM Server.
* Update `golang.org/x/crypto` to `v0.53.0`.
* Updated Teleport Entra ID integration to support delta sync.
* Only process Okta assignments for groups and apps currently being synced.
* Prevent user-deletion of Access Lists being synced by Okta integration.