### PR TITLE
[v18] docs: Add helm chart reference links for access plugin guides

### DIFF
--- a/docs/pages/identity-governance/access-requests/plugins/discord.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/discord.mdx
@@ -412,3 +412,6 @@ $ sudo systemctl start teleport-discord
     Requests](../resource-requests.mdx) and [Role Access
     Requests](../role-requests.mdx) so you can get the most out
     of your Access Request plugins.
+- To see all of the options you can set in the values file for the
+`teleport-plugin-discord` Helm chart, consult our [Helm chart reference
+guide](../../../reference/helm-reference/teleport-plugin-discord.mdx).

--- a/docs/pages/identity-governance/access-requests/plugins/email.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/email.mdx
@@ -530,4 +530,8 @@ $ sudo systemctl start teleport-email
 
 (!docs/pages/includes/plugins/access-plugin-troubleshooting.mdx!)
 
+## Next steps
 
+- To see all of the options you can set in the values file for the
+`teleport-plugin-email` Helm chart, consult our [Helm chart reference
+guide](../../../reference/helm-reference/teleport-plugin-email.mdx).

--- a/docs/pages/identity-governance/access-requests/plugins/jira.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/jira.mdx
@@ -455,3 +455,8 @@ $ sudo systemctl start teleport-jira
 
 (!docs/pages/includes/plugins/access-plugin-troubleshooting.mdx!)
 
+## Next steps
+
+- To see all of the options you can set in the values file for the
+`teleport-plugin-jira` Helm chart, consult our [Helm chart reference
+guide](../../../reference/helm-reference/teleport-plugin-jira.mdx).

--- a/docs/pages/identity-governance/access-requests/plugins/mattermost.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/mattermost.mdx
@@ -384,4 +384,8 @@ $ sudo systemctl start teleport-mattermost
 
 (!docs/pages/includes/plugins/access-plugin-troubleshooting.mdx!)
 
+## Next steps
 
+- To see all of the options you can set in the values file for the
+`teleport-plugin-mattermost` Helm chart, consult our [Helm chart reference
+guide](../../../reference/helm-reference/teleport-plugin-mattermost.mdx).

--- a/docs/pages/identity-governance/access-requests/plugins/msteams.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/msteams.mdx
@@ -586,3 +586,6 @@ $ sudo systemctl start teleport-msteams
     Requests](../resource-requests.mdx) and [Role Access
     Requests](../role-requests.mdx) so you can get the most out
     of your Access Request plugins.
+- To see all of the options you can set in the values file for the
+`teleport-plugin-msteams` Helm chart, consult our [Helm chart reference
+guide](../../../reference/helm-reference/teleport-plugin-msteams.mdx).

--- a/docs/pages/identity-governance/access-requests/plugins/opsgenie.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/opsgenie.mdx
@@ -132,5 +132,3 @@ Request Reviewed` in the Teleport Web UI.
 ## Troubleshooting
 
 (!docs/pages/includes/plugins/access-plugin-troubleshooting.mdx!)
-
-

--- a/docs/pages/identity-governance/access-requests/plugins/pagerduty.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/pagerduty.mdx
@@ -639,4 +639,8 @@ $ sudo systemctl start teleport-pagerduty
 
 (!docs/pages/includes/plugins/access-plugin-troubleshooting.mdx!)
 
+## Next steps
 
+To see all of the options you can set in the values file for the
+`teleport-plugin-pagerduty` Helm chart, consult our [Helm chart reference
+guide](../../../reference/helm-reference/teleport-plugin-pagerduty.mdx).

--- a/docs/pages/identity-governance/access-requests/plugins/servicenow.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/servicenow.mdx
@@ -113,5 +113,3 @@ ServiceNow user currently on-call in that rotation and approve the Access Reques
 ## Troubleshooting
 
 (!docs/pages/includes/plugins/access-plugin-troubleshooting.mdx!)
-
-

--- a/docs/pages/identity-governance/access-requests/plugins/slack.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/slack.mdx
@@ -437,3 +437,6 @@ $ sudo systemctl start teleport-slack
     Requests](../resource-requests.mdx) and [Role Access
     Requests](../role-requests.mdx) so you can get the most out
     of your Access Request plugins.
+- To see all of the options you can set in the values file for the
+`teleport-plugin-slack` Helm chart, consult our [Helm chart reference
+guide](../../../reference/helm-reference/teleport-plugin-slack.mdx).


### PR DESCRIPTION
Backport #68127 to branch/v18