### PR TITLE
fix: update stale member_of refs on membership kind change

### DIFF
--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -918,6 +918,16 @@ func (a *AccessListService) UpsertAccessListMember(ctx context.Context, member *
 			return trace.Wrap(err)
 		}
 
+		// Remove stale member_of refs if the membership kind has changed.
+		// Switching between MembershipKindList and MembershipKindScopedList is
+		// impossible, by definition scoped lists have a non-empty scope, which
+		// would mean the member resource would have a different name and key.
+		if existingMember != nil && existingMember.IsList() && !member.IsList() {
+			if err := a.updateAccessListMemberOf(ctx, parentListName, memberName, false); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+
 		if member.IsList() {
 			if err := a.updateAccessListMemberOf(ctx, parentListName, memberName, true); err != nil {
 				return trace.Wrap(err)
@@ -976,6 +986,13 @@ func (a *AccessListService) UpdateAccessListMember(ctx context.Context, member *
 			updated, err = memberService.conditionalUpdateResource(ctx, member)
 			if err != nil {
 				return trace.Wrap(err)
+			}
+
+			// Remove stale member_of refs if the membership kind has changed.
+			if existingMember != nil && existingMember.IsList() && !member.IsList() {
+				if err := a.updateAccessListMemberOf(ctx, parentListName, memberName, false); err != nil {
+					return trace.Wrap(err)
+				}
 			}
 
 			if member.IsList() {
@@ -1237,6 +1254,13 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 					}
 
 					existingMember.SetRevision(upserted.GetRevision())
+				}
+
+				// Update the status member_of ref if membership kind has changed.
+				if existingMember.IsList() != newMember.IsList() {
+					if err := a.updateAccessListMemberOf(ctx, accessListName, existingMemberName, newMember.IsList()); err != nil {
+						return trace.Wrap(err)
+					}
 				}
 			}
 

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -2724,6 +2724,179 @@ func TestAccessListService_Status_MemberOf(t *testing.T) {
 		requireStatusMemberOf(t, service, nestedAccessList.GetName(), []string{accessList.GetName()})
 	})
 
+	// Assert that when a member's kind changes from a list to a user, stale
+	// member_of refs on the previous member list are removed.
+	t.Run("status member_of and scoped_member_of fixed on kind change", func(t *testing.T) {
+		// Set up a child list with a scoped and unscoped parent list.
+		suffix := uuid.NewString()[:8]
+		scopedParentListName := scopes.QualifiedName{Scope: "/eng/platform", Name: "acl-" + suffix}
+		unscopedParentListName := scopes.QualifiedName{Name: "acl-" + suffix}
+		scopedChildName := scopes.QualifiedName{Scope: "/eng/platform", Name: "child-" + suffix}
+		unscopedChildName := scopes.QualifiedName{Name: "child-" + suffix}
+
+		for _, tc := range []struct {
+			desc                   string
+			parentListName         scopes.QualifiedName
+			childListName          scopes.QualifiedName
+			initialMembershipKind  string
+			targetMembershipKind   string
+			requireKindChangeError require.ErrorAssertionFunc
+			requireMemberOf        func(t *testing.T)
+			requireNotMemberOf     func(t *testing.T)
+		}{
+			{
+				desc:                  "scoped parent, unscoped child",
+				parentListName:        scopedParentListName,
+				childListName:         unscopedChildName,
+				initialMembershipKind: accesslist.MembershipKindList,
+				targetMembershipKind:  accesslist.MembershipKindUser,
+				requireMemberOf: func(t *testing.T) {
+					requireStatusScopedMemberOf(t, service, unscopedChildName, []string{scopedParentListName.String()})
+				},
+				requireNotMemberOf: func(t *testing.T) {
+					requireStatusScopedMemberOf(t, service, unscopedChildName, []string{})
+				},
+			},
+			{
+				desc:                  "unscoped parent, unscoped child",
+				parentListName:        unscopedParentListName,
+				childListName:         unscopedChildName,
+				initialMembershipKind: accesslist.MembershipKindList,
+				targetMembershipKind:  accesslist.MembershipKindUser,
+				requireMemberOf: func(t *testing.T) {
+					requireStatusMemberOfV2(t, service, unscopedChildName, []string{unscopedParentListName.Name})
+				},
+				requireNotMemberOf: func(t *testing.T) {
+					requireStatusMemberOfV2(t, service, unscopedChildName, []string{})
+				},
+			},
+			{
+				desc:                  "scoped parent, scoped child",
+				parentListName:        scopedParentListName,
+				childListName:         scopedChildName,
+				initialMembershipKind: accesslist.MembershipKindScopedList,
+				targetMembershipKind:  accesslist.MembershipKindUser,
+				requireKindChangeError: func(t require.TestingT, err error, msg ...any) {
+					// The user name will be invalid if trying to change a scoped list member to a user.
+					require.ErrorAs(t, err, new(*trace.BadParameterError), msg...)
+				},
+				requireMemberOf: func(t *testing.T) {
+					requireStatusScopedMemberOf(t, service, scopedChildName, []string{scopedParentListName.String()})
+				},
+			},
+			{
+				desc:                  "scoped parent, scoped child, changed to unscoped child",
+				parentListName:        scopedParentListName,
+				childListName:         scopedChildName,
+				initialMembershipKind: accesslist.MembershipKindScopedList,
+				targetMembershipKind:  accesslist.MembershipKindList,
+				requireKindChangeError: func(t require.TestingT, err error, msg ...any) {
+					// The member key will change if trying to change a scoped
+					// list member to an unscoped list member, and the member
+					// will not be found.
+					require.ErrorAs(t, err, new(*trace.NotFoundError), msg...)
+				},
+				requireMemberOf: func(t *testing.T) {
+					requireStatusScopedMemberOf(t, service, scopedChildName, []string{scopedParentListName.String()})
+				},
+			},
+			{
+				desc:                  "scoped parent, unscoped child, changed to scoped child",
+				parentListName:        scopedParentListName,
+				childListName:         unscopedChildName,
+				initialMembershipKind: accesslist.MembershipKindList,
+				targetMembershipKind:  accesslist.MembershipKindScopedList,
+				requireKindChangeError: func(t require.TestingT, err error, msg ...any) {
+					// The member name will be invalid if trying to change an
+					// unscoped list member to a scoped list member.
+					require.ErrorAs(t, err, new(*trace.BadParameterError), msg...)
+				},
+				requireMemberOf: func(t *testing.T) {
+					requireStatusScopedMemberOf(t, service, unscopedChildName, []string{scopedParentListName.String()})
+				},
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				parentList, err := service.UpsertAccessList(ctx, newScopedAccessList(t, tc.parentListName, clock))
+				require.NoError(t, err)
+				_, err = service.UpsertAccessList(ctx, newScopedAccessList(t, tc.childListName, clock))
+				require.NoError(t, err)
+
+				for _, ttc := range []struct {
+					desc                 string
+					changeMembershipKind func(member *accesslist.AccessListMember, kind string) (*accesslist.AccessListMember, error)
+				}{
+					{
+						desc: "UpdateAccessListMember",
+						changeMembershipKind: func(member *accesslist.AccessListMember, kind string) (*accesslist.AccessListMember, error) {
+							member.Spec.MembershipKind = kind
+							return service.UpdateAccessListMember(ctx, member)
+						},
+					},
+					{
+						desc: "UpsertAccessListMember",
+						changeMembershipKind: func(member *accesslist.AccessListMember, kind string) (*accesslist.AccessListMember, error) {
+							member.Spec.MembershipKind = kind
+							return service.UpsertAccessListMember(ctx, member)
+						},
+					},
+					{
+						desc: "UpsertAccessListWithMembers",
+						changeMembershipKind: func(member *accesslist.AccessListMember, kind string) (*accesslist.AccessListMember, error) {
+							member.Spec.MembershipKind = kind
+							_, newMembers, err := service.UpsertAccessListWithMembers(ctx, parentList, []*accesslist.AccessListMember{member})
+							if err != nil {
+								return nil, err
+							}
+							return newMembers[0], nil
+						},
+					},
+					{
+						desc: "UpdateAccessListAndOverwriteMembers",
+						changeMembershipKind: func(member *accesslist.AccessListMember, kind string) (*accesslist.AccessListMember, error) {
+							member.Spec.MembershipKind = kind
+							_, newMembers, err := service.UpdateAccessListAndOverwriteMembers(ctx, parentList, []*accesslist.AccessListMember{member})
+							if err != nil {
+								return nil, err
+							}
+							return newMembers[0], nil
+						},
+					},
+				} {
+					t.Run(ttc.desc, func(t *testing.T) {
+						member, err := service.UpsertAccessListMember(ctx, newScopedAccessListMember(t,
+							tc.parentListName,
+							tc.childListName,
+							withMembershipKind(tc.initialMembershipKind),
+						))
+						require.NoError(t, err)
+
+						// Initially the child list status should reference the parent list.
+						tc.requireMemberOf(t)
+
+						// Change the membership kind to invalidate the initial membership.
+						member, err = ttc.changeMembershipKind(member, tc.targetMembershipKind)
+						if tc.requireKindChangeError != nil {
+							tc.requireKindChangeError(t, err)
+							return
+						}
+						require.NoError(t, err)
+
+						// The child list status should no longer reference the parent list.
+						tc.requireNotMemberOf(t)
+
+						// Make the child list a member again.
+						_, err = ttc.changeMembershipKind(member, tc.initialMembershipKind)
+						require.NoError(t, err)
+
+						// The child list status should reference the parent list again.
+						tc.requireMemberOf(t)
+					})
+				}
+			})
+		}
+	})
+
 	t.Run("scoped parent updates scoped_member_of for scoped and unscoped child lists", func(t *testing.T) {
 		suffix := uuid.NewString()[:8]
 		parentName := scopes.QualifiedName{Scope: "/eng/platform", Name: "acl-" + suffix}


### PR DESCRIPTION
This PR updates the access list membership status reconciliation paths to remove the stale `status.member_of` or `status.scoped_member_of` value from the former member list if an existing member resource has its membership kind changed from list to user.

Resolves this PR comment: https://github.com/gravitational/teleport/pull/68095#discussion_r3475078274

Parent: https://github.com/gravitational/teleport/pull/68095
Child: https://github.com/gravitational/teleport/pull/68477

## Manual Test Plan
### Test Environment

Cluster running this branch

### Test Cases
- [x] create two access lists
- [x] make one list a member of the other list
- [x] update the member resource to change the membership kind from list to user
- [x] observe that the status.member_of on the former member list no longer contains the parent list name
