### PR TITLE
Compute `ComponentFeatures` for "agent-less" OpenSSH nodes

### DIFF
--- a/lib/componentfeatures/utils.go
+++ b/lib/componentfeatures/utils.go
@@ -215,6 +215,11 @@ type versionedComponent interface {
 // instead of read from their spec field:
 //   - AppServer with integration set (served directly by Proxy, not an
 //     app agent; see lib/web/app/transport.go).
+//   - OpenSSH nodes (registered backend records with no Teleport SSH
+//     agent; see types.Server.IsOpenSSHNode).
+//
+// See RFD 230 (TODO(kiosion): link the agentless section once raised) for the
+// rationale behind computing features from only type for certain resources.
 //
 // Agent-backed resources use the field from spec set by presence heartbeat,
 // with version-gating applied to strip premature advertisements from servers <18.7.6.
@@ -224,6 +229,10 @@ func GetEffectiveServerFeatures(component versionedComponent) *componentfeatures
 	// Agentless app servers: no heartbeat, compute from app type.
 	if appServer, ok := component.(types.AppServer); ok && appServer.GetApp().GetIntegration() != "" {
 		return ForAppServer(appServer)
+	}
+	// Agentless OpenSSH nodes: no heartbeat, compute from node type.
+	if node, ok := component.(types.Server); ok && node.IsOpenSSHNode() {
+		return ForSSHServer()
 	}
 	// Agent-backed: read stored field with version-gating.
 	f := component.GetComponentFeatures()

--- a/lib/componentfeatures/utils_test.go
+++ b/lib/componentfeatures/utils_test.go
@@ -407,6 +407,26 @@ func TestGetEffectiveServerFeatures(t *testing.T) {
 		result := GetEffectiveServerFeatures(srv)
 		require.Nil(t, result)
 	})
+
+	t.Run("agentless OpenSSH node computes features from type", func(t *testing.T) {
+		node, err := types.NewNode("openssh-node", types.SubKindOpenSSHNode, types.ServerSpecV2{
+			Addr:     "1.2.3.4:22",
+			Hostname: "openssh-host",
+		}, nil)
+		require.NoError(t, err)
+		// No heartbeat ever sets ComponentFeatures on an agentless node.
+		require.Nil(t, node.GetComponentFeatures())
+		result := GetEffectiveServerFeatures(node)
+		require.ElementsMatch(t, New(rcv1).GetFeatures(), result.GetFeatures())
+	})
+	t.Run("agent-backed SSH node uses features from presence heartbeat", func(t *testing.T) {
+		node, err := types.NewServer("ssh-node", types.KindNode, types.ServerSpecV2{Version: "18.7.6"})
+		require.NoError(t, err)
+		node.SetComponentFeatures(New(rcv1))
+		require.False(t, node.IsOpenSSHNode())
+		result := GetEffectiveServerFeatures(node)
+		require.ElementsMatch(t, New(rcv1).GetFeatures(), result.GetFeatures())
+	})
 }
 
 type fakeAuthProxyServersLister struct {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3581,7 +3581,7 @@ func (h *Handler) clusterUnifiedResourcesGet(w http.ResponseWriter, request *htt
 					return nil, trace.Wrap(err)
 				}
 
-				nodeComponentFeatures := componentfeatures.Intersect(r.GetComponentFeatures(), clusterAuthProxyServerFeatures)
+				nodeComponentFeatures := componentfeatures.Intersect(componentfeatures.GetEffectiveServerFeatures(r), clusterAuthProxyServerFeatures)
 				unifiedResources = append(unifiedResources, ui.MakeServer(r, ui.MakeServerConfig{
 					ClusterName:       cluster.GetName(),
 					Logins:            principals.Logins,


### PR DESCRIPTION
## Context
Proxy intersects a resource's features with the cluster's Auth and Proxy features and exposes the result as `supportedFeatureIds` to clients. Agent-served resources carry that advertisement on their heartbeat, while OpenSSH nodes are "agent-less". Discovery registers them as backend records through the authorized node API and they're not heartbeated in the same way. Their stored `ComponentFeatures` field is therefore always empty currently.

This PR routes the node case through the shared derive-at-read accessor instead of relying on the raw field:
- `GetEffectiveServerFeatures` has an additional agentless-node case: a server which `IsOpenSSHNode` derives its eligibility from the resource type alone, since the node has no binary of its own.
- The node branch of `clusterUnifiedResourcesGet` reads features through `GetEffectiveServerFeatures` rather than the raw field. 

## Manual Test Plan
### Test Environment
- Single-node cluster (Auth, Proxy) built from this branch, with one registered OpenSSH node, and one regular Teleport SSH agent node
- Requester role whose `search_as_roles` grants additional logins on both

### Test Cases
- [ ] OpenSSH node offers the flow: verify the unified resources response carries `RESOURCE_CONSTRAINTS_V1` in `supportedFeatureIds` for the OpenSSH node and the Web UI shows the granted/requestable login dropdown; create a request constrained to one login, approve, assume, and verify SSH succeeds with that login and is denied with another granted-but-unrequested one.
- [x] Agent-served node is unaffected: the Teleport SSH agent's node still advertises via its heartbeat and shows the dropdown.
- [x] Version gate on the node path: a node record whose `TeleportVersion` is below 18.7.6 with a hand-set `component_features` does not surface `RESOURCE_CONSTRAINTS_V1` in the listing.
