### PR TITLE
Add github.com/santhosh-tekuri/jsonschema/v6 to e_imports

### DIFF
--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -221,6 +221,7 @@ require (
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/russellhaering/gosaml2 v0.11.0 // indirect
 	github.com/russellhaering/goxmldsig v1.6.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/scim2/filter-parser/v2 v2.2.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.10.0 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect

--- a/e2e/runner/go.mod
+++ b/e2e/runner/go.mod
@@ -218,6 +218,7 @@ require (
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/russellhaering/gosaml2 v0.11.0 // indirect
 	github.com/russellhaering/goxmldsig v1.6.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/scim2/filter-parser/v2 v2.2.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.10.0 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect

--- a/e_imports.go
+++ b/e_imports.go
@@ -131,6 +131,7 @@ import (
 	_ "github.com/russellhaering/gosaml2"
 	_ "github.com/russellhaering/gosaml2/types"
 	_ "github.com/russellhaering/goxmldsig"
+	_ "github.com/santhosh-tekuri/jsonschema/v6"
 	_ "github.com/scim2/filter-parser/v2"
 	_ "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	_ "github.com/sigstore/sigstore-go/pkg/bundle"

--- a/go.mod
+++ b/go.mod
@@ -210,6 +210,7 @@ require (
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/russellhaering/gosaml2 v0.11.0
 	github.com/russellhaering/goxmldsig v1.6.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/schollz/progressbar/v3 v3.18.0
 	github.com/scim2/filter-parser/v2 v2.2.0
 	github.com/shirou/gopsutil/v4 v4.26.3
@@ -544,7 +545,6 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46 // indirect
 	github.com/sahilm/fuzzy v0.1.1 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/sassoftware/relic v7.2.1+incompatible // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.10.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect


### PR DESCRIPTION
Needed for https://github.com/gravitational/teleport.e/pull/8969 as `github.com/santhosh-tekuri/jsonschema/v6` becomes a direct dependency

After we get a response from Bedrock via the non-official structured output path (for models such as Opus 4.7/4.8 and others that do not support it), we need to verify that the schema returned matches the schema we sent. If we didn't validate this, getting back `{}` from the LLM would succeed. Verifying the response against the exact schema provided gives us resiliency without having to do awkward manual checking of the response shape that changes every time the schema does.

`santhosh-tekuri/jsonschema` seems to be the most stable and mature option for validating JSON schema in go. Alternatives are `google/jsonschema-go` (which is also currently an indirect dependency, but is pre-1.0 and [warns things may change between releases](https://pkg.go.dev/github.com/google/jsonschema-go/jsonschema#hdr-Controlling_behavior_changes)), `kaptinlin/jsonschema` is also a possibility but isn't in the go dependency graph already. 

Alternatives without a library - hand-rolled validation code that matches the schema, which would have to deal with nested objects and arrays. I'd like to avoid this to remove chance of error and churn. Keeping the validation in the schema means we only have things defined in a single place.