### PR TITLE
Reset Okta assignment target failure count on op change

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -7854,12 +7854,12 @@ message PluginOktaSyncSettings {
   string time_between_assignment_process_loops = 15;
 
   // TargetProcessingBackoffStep controls the step value for linear backoff when reprocessing Okta assignment targets.
-  // A blank string results in the default value being used.
+  // Value is parsed as Go duration string, e.g. 1h15m. A blank string results in the default value being used.
   // For most use cases the default value should NOT be changed.
   string target_processing_backoff_step = 16;
 
   // TargetProcessingBackoffMax controls the max duration for linear backoff when reprocessing Okta assignment targets.
-  // A blank string results in the default value being used.
+  // Value is parsed as Go duration string, e.g. 1h15m. A blank string results in the default value being used.
   // For most use cases the default value should NOT be changed.
   string target_processing_backoff_max = 17;
 }

--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -7854,13 +7854,13 @@ message PluginOktaSyncSettings {
   string time_between_assignment_process_loops = 15;
 
   // TargetProcessingBackoffStep controls the step value for linear backoff when reprocessing Okta assignment targets.
+  // A blank string results in the default value being used.
   // For most use cases the default value should NOT be changed.
-  // A blank string results in the default value of 15m.
   string target_processing_backoff_step = 16;
 
   // TargetProcessingBackoffMax controls the max duration for linear backoff when reprocessing Okta assignment targets.
+  // A blank string results in the default value being used.
   // For most use cases the default value should NOT be changed.
-  // A blank string results in the default value of 24h.
   string target_processing_backoff_max = 17;
 }
 

--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -7854,13 +7854,13 @@ message PluginOktaSyncSettings {
   string time_between_assignment_process_loops = 15;
 
   // TargetProcessingBackoffStep controls the step value for linear backoff when reprocessing Okta assignment targets.
-  // Value is parsed as Go duration string, e.g. 1h15m. A blank string results in the default value being used.
   // For most use cases the default value should NOT be changed.
+  // A blank string results in the default value of 15m.
   string target_processing_backoff_step = 16;
 
   // TargetProcessingBackoffMax controls the max duration for linear backoff when reprocessing Okta assignment targets.
-  // Value is parsed as Go duration string, e.g. 1h15m. A blank string results in the default value being used.
   // For most use cases the default value should NOT be changed.
+  // A blank string results in the default value of 24h.
   string target_processing_backoff_max = 17;
 }
 

--- a/api/types/okta.go
+++ b/api/types/okta.go
@@ -452,6 +452,7 @@ func (o *OktaAssignmentTargetV1) GetStatus() *OktaAssignmentTargetStatus {
 }
 
 // RecordStatus sets the processing outcome, op type, and last processing time.
+// In the case of transitioning between op types, the failure count is reset.
 // In the case of a failed outcome, the failure count is incremented.
 // In the case of a successful outcome, the failure count is reset.
 // If an invalid value is provided for op or outcome, then an error is returned.
@@ -468,7 +469,7 @@ func (o *OktaAssignmentTargetV1) RecordStatus(
 	}
 
 	failureCount := int32(0)
-	if o.Status != nil {
+	if o.Status != nil && constants.OktaAssignmentTargetOp(o.Status.Op) == op {
 		failureCount = o.Status.FailureCount
 	}
 

--- a/api/types/okta_test.go
+++ b/api/types/okta_test.go
@@ -561,6 +561,24 @@ func TestOktaAssignmentStatusRecordStatus(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
+			name:    "failed provision then failed cleanup",
+			op:      constants.OktaAssignmentTargetOpCleanup,
+			outcome: constants.OktaAssignmentTargetOutcomeFailed,
+			initialStatus: &OktaAssignmentTargetStatus{
+				Op:            string(constants.OktaAssignmentTargetOpProvision),
+				Outcome:       string(constants.OktaAssignmentTargetOutcomeFailed),
+				LastProcessed: now,
+				FailureCount:  7,
+			},
+			expectedStatus: &OktaAssignmentTargetStatus{
+				Op:            string(constants.OktaAssignmentTargetOpCleanup),
+				Outcome:       string(constants.OktaAssignmentTargetOutcomeFailed),
+				LastProcessed: next,
+				FailureCount:  1,
+			},
+			assertErr: require.NoError,
+		},
+		{
 			name:    "invalid op",
 			op:      "invalid-op",
 			outcome: constants.OktaAssignmentTargetOutcomeSuccessful,

--- a/api/types/okta_test.go
+++ b/api/types/okta_test.go
@@ -579,6 +579,24 @@ func TestOktaAssignmentStatusRecordStatus(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
+			name:    "failed cleanup then failed provision",
+			op:      constants.OktaAssignmentTargetOpProvision,
+			outcome: constants.OktaAssignmentTargetOutcomeFailed,
+			initialStatus: &OktaAssignmentTargetStatus{
+				Op:            string(constants.OktaAssignmentTargetOpCleanup),
+				Outcome:       string(constants.OktaAssignmentTargetOutcomeFailed),
+				LastProcessed: now,
+				FailureCount:  7,
+			},
+			expectedStatus: &OktaAssignmentTargetStatus{
+				Op:            string(constants.OktaAssignmentTargetOpProvision),
+				Outcome:       string(constants.OktaAssignmentTargetOutcomeFailed),
+				LastProcessed: next,
+				FailureCount:  1,
+			},
+			assertErr: require.NoError,
+		},
+		{
 			name:    "invalid op",
 			op:      "invalid-op",
 			outcome: constants.OktaAssignmentTargetOutcomeSuccessful,


### PR DESCRIPTION
This change resets the Okta assignment target failure count when a failing target transitions to a new operation, e.g. target is cleanup and failed 7 times, then transitions to provision and fails, the count is now 1 (rather than 8). 

No changelog or manual test plan, since no user-facing behaviour impacted. 
