### PR TITLE
[v18] Add the `tctl auth update-override` command

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -648,6 +648,28 @@ Flags:
 |`--windows-sid`|*no default*|Optional Security Identifier to embed in the certificate. Only used when --format is set to "windows"|
 |`--windows-user`|*no default*|Window user placed on the identity file. Only used when --format is set to "windows"|
 
+## tctl auth update-override
+
+Update a single certificate override in a CA override resource
+
+Usage:
+
+```code
+$ tctl auth update-override --type=TYPE [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--[no-]clear-chain`|`false`|Clears existing CA override trust chain|
+|`--[no-]force`|`false`|If true attempts to force the update. May be used to ignore select state validation or disable live overrides.|
+|`--public-key`|*no default*|Public key hash of the certificate override to be targeted|
+|`--set-cert`|*no default*|CA override certificate file in PEM form|
+|`--set-chain`|*no default*|CA override trust chain files in PEM form|
+|`--set-disabled`|*no default* (one of: `true`, `false`)|If true disables the override, if false enables it|
+|`--type`|*no default*|CA type (db-client, windows)|
+
 ## tctl autoupdate agents mark-done
 
 Marks one or many groups as done updating.

--- a/tool/tctl/common/subca/subca_command.go
+++ b/tool/tctl/common/subca/subca_command.go
@@ -593,21 +593,21 @@ func (c *updateOverrideCommand) Run(
 	}
 	defer closeFn(ctx)
 
-	_, err = authClient.SubCAClient().UpdateCertificateOverride(ctx, &subcav1.UpdateCertificateOverrideRequest{
+	_, err = authClient.SubCAClient().UpdateCertificateOverride(ctx, subcav1.UpdateCertificateOverrideRequest_builder{
 		CaId: subcav1.CertAuthorityOverrideID_builder{
 			CaType: caType,
 		}.Build(),
 		CertificateOverride:   certificateOverride,
 		UpdateMask:            updateMask,
 		ForceImmediateDisable: c.force,
-	})
+	}.Build())
 	if err != nil {
 		return trace.Wrap(err, "update certificate override")
 	}
 	fmt.Fprintf(s.Stdout,
 		"%s/%s: certificate override %s updated\n",
 		types.KindCertAuthorityOverride,
-		caType, certificateOverride.PublicKey,
+		caType, certificateOverride.GetPublicKey(),
 	)
 
 	return nil

--- a/tool/tctl/common/subca/subca_command.go
+++ b/tool/tctl/common/subca/subca_command.go
@@ -25,10 +25,12 @@ import (
 	"io"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -128,6 +130,7 @@ type Command struct {
 
 	createOverrideCSR createOverrideCSRCommand
 	createOverride    createOverrideCommand
+	updateOverride    updateOverrideCommand
 	deleteOverride    deleteOverrideCommand
 	pubKeyHash        pubKeyHashCommand
 }
@@ -187,6 +190,23 @@ func (c *Command) Initialize(
 	c.createOverride.Flag("force", "If true attempts to force creation, ignoring select state validation").
 		BoolVar(&c.createOverride.force)
 
+	c.updateOverride.CmdClause = parent.Command("update-override", "Update a single certificate override in a CA override resource")
+	c.updateOverride.Flag("type", caTypesHelp).
+		Required().
+		StringVar(&c.updateOverride.cliCAType)
+	c.updateOverride.Flag("public-key", "Public key hash of the certificate override to be targeted").
+		StringVar(&c.updateOverride.publicKey)
+	c.updateOverride.Flag("set-cert", "CA override certificate file in PEM form").
+		StringVar(&c.updateOverride.certFile)
+	c.updateOverride.Flag("set-chain", "CA override trust chain files in PEM form").
+		SetValue(&c.updateOverride.chainFiles)
+	c.updateOverride.Flag("clear-chain", "Clears existing CA override trust chain").
+		BoolVar(&c.updateOverride.chainClear)
+	c.updateOverride.Flag("set-disabled", "If true disables the override, if false enables it").
+		EnumVar(&c.updateOverride.disabled, "true", "false")
+	c.updateOverride.Flag("force", "If true attempts to force the update. May be used to ignore select state validation or disable live overrides.").
+		BoolVar(&c.updateOverride.force)
+
 	c.deleteOverride.CmdClause = parent.Command("delete-override", "Delete a single certificate override from a CA override resource")
 	c.deleteOverride.Flag("type", caTypesHelp).
 		Required().
@@ -216,6 +236,7 @@ func (c *Command) TryRun(
 	for _, cmd := range []subCommand{
 		&c.createOverrideCSR,
 		&c.createOverride,
+		&c.updateOverride,
 		&c.deleteOverride,
 		&c.pubKeyHash,
 	} {
@@ -453,7 +474,7 @@ func (c *createOverrideCommand) Run(
 
 	var chain []string
 	for i, chainFile := range c.chainFiles {
-		// Parse the cert so know it's valid, but otherwise we only need the PEM.
+		// Parse the cert so we know it's valid, but otherwise we only need the PEM.
 		chainPEM, _, err := readCertFile(chainFile)
 		if err != nil {
 			return trace.Wrap(err, "chain%d.pem", i)
@@ -483,6 +504,111 @@ func (c *createOverrideCommand) Run(
 		return trace.Wrap(err, "create certificate override")
 	}
 	fmt.Fprintf(s.Stdout, "%s/%s: certificate override %s created\n", types.KindCertAuthorityOverride, caType, pkh)
+
+	return nil
+}
+
+type updateOverrideCommand struct {
+	*kingpin.CmdClause
+
+	cliCAType  string
+	publicKey  string
+	certFile   string
+	chainFiles pemFileList
+	chainClear bool
+	disabled   string
+	force      bool
+}
+
+func (c *updateOverrideCommand) Run(
+	ctx context.Context,
+	clientFunc InitFunc,
+	s *commandState,
+) error {
+	switch {
+	case c.publicKey == "" && c.certFile == "":
+		return trace.BadParameter("--public-key required to choose target certificate override")
+	case len(c.chainFiles) > 0 && c.chainClear:
+		return trace.BadParameter("--set-chain and --clear-chain cannot be set together")
+	}
+
+	caType := cliCATypes.Convert(c.cliCAType)
+
+	var builder subcav1.CertificateOverride_builder
+	var paths []string // paths for FieldMask
+	builder.PublicKey = c.publicKey
+
+	if c.disabled != "" {
+		val, err := strconv.ParseBool(c.disabled)
+		if err != nil {
+			return trace.BadParameter("--disabled: %v", err)
+		}
+		builder.Disabled = val
+		paths = append(paths, "disabled")
+	}
+
+	if c.certFile != "" {
+		certPEM, cert, err := readCertFile(c.certFile)
+		if err != nil {
+			return trace.Wrap(err, "cert.pem")
+		}
+		if builder.PublicKey == "" {
+			builder.PublicKey = subca.HashCertificatePublicKey(cert)
+		}
+		builder.Certificate = string(certPEM)
+		paths = append(paths, "certificate")
+	} else {
+		builder.PublicKey = strings.ToLower(builder.PublicKey)
+	}
+
+	for i, chainFile := range c.chainFiles {
+		// Parse the cert so we know it's valid, but otherwise we only need the PEM.
+		chainPEM, _, err := readCertFile(chainFile)
+		if err != nil {
+			return trace.Wrap(err, "chain%d.pem", i)
+		}
+		builder.Chain = append(builder.Chain, string(chainPEM))
+	}
+	if len(builder.Chain) > 0 || c.chainClear {
+		paths = append(paths, "chain")
+	}
+
+	if len(paths) == 0 {
+		return trace.BadParameter("one of --set-* or --clear-* flags is required to update")
+	}
+
+	// Backfill a normalized "public_key" as part of the update.
+	// There's no harm in doing so.
+	paths = append(paths, "public_key")
+
+	certificateOverride := builder.Build()
+	updateMask, err := fieldmaskpb.New(certificateOverride, paths...)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	authClient, closeFn, err := clientFunc(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer closeFn(ctx)
+
+	_, err = authClient.SubCAClient().UpdateCertificateOverride(ctx, &subcav1.UpdateCertificateOverrideRequest{
+		CaId: subcav1.CertAuthorityOverrideID_builder{
+			CaType: caType,
+		}.Build(),
+		CertificateOverride:   certificateOverride,
+		UpdateMask:            updateMask,
+		ForceImmediateDisable: c.force,
+	})
+	if err != nil {
+		return trace.Wrap(err, "update certificate override")
+	}
+	fmt.Fprintf(s.Stdout,
+		"%s/%s: certificate override %s updated\n",
+		types.KindCertAuthorityOverride,
+		caType, certificateOverride.PublicKey,
+	)
 
 	return nil
 }

--- a/tool/tctl/common/subca/subca_command.go
+++ b/tool/tctl/common/subca/subca_command.go
@@ -558,7 +558,7 @@ func (c *updateOverrideCommand) Run(
 		builder.Certificate = string(certPEM)
 		paths = append(paths, "certificate")
 	} else {
-		builder.PublicKey = strings.ToLower(builder.PublicKey)
+		builder.PublicKey = subca.NormalizePublicKey(builder.PublicKey)
 	}
 
 	for i, chainFile := range c.chainFiles {

--- a/tool/tctl/common/subca/subca_command_test.go
+++ b/tool/tctl/common/subca/subca_command_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -30,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -408,6 +410,168 @@ func TestCommand_CreateOverride(t *testing.T) {
 	}
 }
 
+func TestCommand_UpdateOverride(t *testing.T) {
+	t.Parallel()
+
+	// Write input certificates to files.
+	// Add trailing spaces to some files for testing purposes.
+	tempDir := t.TempDir()
+	certAltFile := filepath.Join(tempDir, "cert-alt.pem")
+	chain0File := filepath.Join(tempDir, "chain0.pem")
+	chain1File := filepath.Join(tempDir, "chain1.pem")
+	require.NoError(t, os.WriteFile(certAltFile, []byte(overrideAltPEM+"  \n\n  "), 0644))
+	require.NoError(t, os.WriteFile(chain0File, []byte(chain0PEM+"  \n\n  "), 0644))
+	require.NoError(t, os.WriteFile(chain1File, []byte(chain1PEM), 0644))
+
+	var certPubKey string
+	{
+		cert, err := tlsutils.ParseCertificatePEM([]byte(overridePEM))
+		require.NoError(t, err)
+		certPubKey = libsubca.HashCertificatePublicKey(cert)
+	}
+
+	caID := subcav1.CertAuthorityOverrideID_builder{
+		CaType: string(types.DatabaseClientCA),
+	}.Build()
+
+	newFieldMask := func(t *testing.T, paths ...string) *fieldmaskpb.FieldMask {
+		m, err := fieldmaskpb.New(&subcav1.CertificateOverride{}, paths...)
+		require.NoError(t, err)
+		return m
+	}
+
+	tests := []struct {
+		name    string
+		flags   []string // flags after "tctl auth update-override"
+		wantReq *subcav1.UpdateCertificateOverrideRequest
+	}{
+		{
+			name: "enable override",
+			flags: []string{
+				"--type", "db-client",
+				"--public-key", certPubKey,
+				"--set-disabled", "false",
+			},
+			wantReq: subcav1.UpdateCertificateOverrideRequest_builder{
+				CaId: caID,
+				CertificateOverride: subcav1.CertificateOverride_builder{
+					PublicKey: certPubKey,
+				}.Build(),
+				UpdateMask: newFieldMask(t, "disabled", "public_key"),
+			}.Build(),
+		},
+		{
+			name: "force disable override",
+			flags: []string{
+				"--type", "db-client",
+				"--public-key", certPubKey,
+				"--set-disabled", "true",
+				"--force",
+			},
+			wantReq: subcav1.UpdateCertificateOverrideRequest_builder{
+				CaId: caID,
+				CertificateOverride: subcav1.CertificateOverride_builder{
+					PublicKey: certPubKey,
+					Disabled:  true,
+				}.Build(),
+				ForceImmediateDisable: true,
+				UpdateMask:            newFieldMask(t, "disabled", "public_key"),
+			}.Build(),
+		},
+		{
+			name: "normalizes public key",
+			flags: []string{
+				"--type", "db-client",
+				"--public-key", strings.ToUpper(certPubKey),
+				"--set-disabled", "false",
+			},
+			wantReq: subcav1.UpdateCertificateOverrideRequest_builder{
+				CaId: caID,
+				CertificateOverride: subcav1.CertificateOverride_builder{
+					PublicKey: certPubKey,
+				}.Build(),
+				UpdateMask: newFieldMask(t, "disabled", "public_key"),
+			}.Build(),
+		},
+		{
+			name: "update certificate",
+			flags: []string{
+				"--type", "db-client",
+				"--set-cert", certAltFile,
+			},
+			wantReq: subcav1.UpdateCertificateOverrideRequest_builder{
+				CaId: caID,
+				CertificateOverride: subcav1.CertificateOverride_builder{
+					PublicKey:   certPubKey,
+					Certificate: overrideAltPEM,
+				}.Build(),
+				UpdateMask: newFieldMask(t, "certificate", "public_key"),
+			}.Build(),
+		},
+		{
+			name: "update certificate and chain",
+			flags: []string{
+				"--type", "db-client",
+				"--set-cert", certAltFile,
+				"--set-chain", chain0File,
+				"--set-chain", chain1File,
+			},
+			wantReq: subcav1.UpdateCertificateOverrideRequest_builder{
+				CaId: caID,
+				CertificateOverride: subcav1.CertificateOverride_builder{
+					PublicKey:   certPubKey,
+					Certificate: overrideAltPEM,
+					Chain: []string{
+						chain0PEM,
+						chain1PEM,
+					},
+				}.Build(),
+				UpdateMask: newFieldMask(t, "certificate", "chain", "public_key"),
+			}.Build(),
+		},
+		{
+			name: "clear chain",
+			flags: []string{
+				"--type", "db-client",
+				"--public-key", certPubKey,
+				"--clear-chain",
+			},
+			wantReq: subcav1.UpdateCertificateOverrideRequest_builder{
+				CaId: caID,
+				CertificateOverride: subcav1.CertificateOverride_builder{
+					PublicKey: certPubKey,
+				}.Build(),
+				UpdateMask: newFieldMask(t, "chain", "public_key"),
+			}.Build(),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			fakeClient := &fakeAuthClient{}
+			clientFunc := func(ctx context.Context) (_ subca.SubCAClientSource, closeFn func(context.Context), _ error) {
+				return fakeClient, func(ctx context.Context) {}, nil
+			}
+
+			env := newCommand(t)
+
+			flags := append([]string{"auth", "update-override"}, test.flags...)
+			selectedCommand, err := env.App.Parse(flags)
+			require.NoError(t, err, "app.Parse()")
+
+			match, err := env.Cmd.TryRun(t.Context(), selectedCommand, clientFunc)
+			assert.True(t, match)
+			require.NoError(t, err, "Command errored")
+
+			// Verify server request.
+			if diff := cmp.Diff(test.wantReq, fakeClient.lastUpdateCertificateRequest, protocmp.Transform()); diff != "" {
+				t.Errorf("UpdateCertificateOverrideRequest mismatch (-want +got)\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestCommand_DeleteOverride(t *testing.T) {
 	t.Parallel()
 
@@ -552,6 +716,27 @@ Q4FKcCFBuhowCgYIKoZIzj0EAwIDSAAwRQIgebCxPjXntz2l3XtVzPYa63ayFwNX
 42EJAwazCrdS26sCIQC5koQINAk8I1+j3y3PmSw27DzTByWtnYtk9PI7xz9blQ==
 -----END CERTIFICATE-----`
 
+	// overrideAltPEM is an alternative CA override certificate.
+	//
+	// subject=O=zarquon2, CN=zarquon2
+	// issuer=O=Llama Corp, OU=Llama CA, CN=Llama Database CA
+	overrideAltPEM = `-----BEGIN CERTIFICATE-----
+MIICmjCCAkCgAwIBAgIUQ5YwT7MX5bPnQ2v9QV33WPG3DeEwCgYIKoZIzj0EAwIw
+RDETMBEGA1UEChMKTGxhbWEgQ29ycDERMA8GA1UECxMITGxhbWEgQ0ExGjAYBgNV
+BAMTEUxsYW1hIERhdGFiYXNlIENBMB4XDTI2MDYxNzIxMzAwMFoXDTMxMDYxNjIx
+MzAwMFowJjERMA8GA1UEChMIemFycXVvbjIxETAPBgNVBAMTCHphcnF1b24yMIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm2wHhbEzHddPlg8RJxyeAArV
+Ku+jMLGWSVjSVH5Pn2301cSe28KC5iaRuYfzf6sdEftElyV7fUdeZ+i07QTWYuMT
+3B8x5J62n/g3R4RQxYY4ivNaISnApO435cPYDvDIpAzZ3qBKRdvXDAsc0/bjiG39
+qIi04V29WRz1IjS/BPWyRP6hoeP6gbtl4Z2YE4y1MwGvl3a0L4wEFvWrhZrhlpKu
+3IzryaE/lqAaE6H4zRGNL7qPUAxxnr4n1YdDN/0BGY7OYOvea9BPseHHzIAXo/v3
+5T1pn7aVhso4pkgb5Jj715LYw7uWlXV3y/f0R4Y2BP73SqkRhRzvMgQL+1DRBQID
+AQABo2MwYTAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4E
+FgQUYsc7XihR9bNRm8UdGZ1dlRZGVUQwHwYDVR0jBBgwFoAUDC1GIwweTul8uBzi
+Q4FKcCFBuhowCgYIKoZIzj0EAwIDSAAwRQIgN9ch2UET9HJGkUt47c/7UCAv9yyh
+fO01mshT7mnA+vICIQCh0ep22NPhvvZ08MpGLKcfuN6umluM3fYuxNPk8GtG5A==
+-----END CERTIFICATE-----`
+
 	// chain0PEM is an external (non-Teleport) intermediate CA.
 	//
 	// subject=O=Llama Corp, OU=Llama CA, CN=Llama Database CA
@@ -593,6 +778,7 @@ type fakeAuthClient struct {
 	csrPEMs                      []string
 	lastCSRRequest               *subcav1.CreateCSRRequest
 	lastAddCertificateRequest    *subcav1.AddCertificateOverrideRequest
+	lastUpdateCertificateRequest *subcav1.UpdateCertificateOverrideRequest
 	lastRemoveCertificateRequest *subcav1.RemoveCertificateOverrideRequest
 }
 
@@ -626,6 +812,15 @@ func (f *fakeAuthClient) AddCertificateOverride(
 ) (*subcav1.AddCertificateOverrideResponse, error) {
 	f.lastAddCertificateRequest = req
 	return &subcav1.AddCertificateOverrideResponse{}, nil
+}
+
+func (f *fakeAuthClient) UpdateCertificateOverride(
+	ctx context.Context,
+	req *subcav1.UpdateCertificateOverrideRequest,
+	opts ...grpc.CallOption,
+) (*subcav1.UpdateCertificateOverrideResponse, error) {
+	f.lastUpdateCertificateRequest = req
+	return &subcav1.UpdateCertificateOverrideResponse{}, nil
 }
 
 func (f *fakeAuthClient) RemoveCertificateOverride(


### PR DESCRIPTION
Backport #68024 to branch/v18

changelog: Added the Sub CA `tctl auth update-override` command, a user-friendly alternative over `tctl create -f` or `tctl edit ca_overrides`

https://github.com/gravitational/teleport.e/issues/7675

## Manual Test Plan
### Test Environment

Local build with https://github.com/gravitational/teleport.e/pull/9036.

### Test Cases
- [x] `tctl auth update-override --type=db-client --public-key=ABCDE... --set-disabled=false` (enable override)
- [x] `tctl auth update-override --type=db-client --set-disabled=true ...` (disable override)
- [x] `tctl auth update-override --type=db-client --set-disabled=true --force ...` (force-disable override)
- [x] `tctl auth update-override --type=db-client --set-cert=cert.pem` (update certificate)
- [x] `tctl auth update-override --type=db-client --set-chain=chain0.pem --set-chain=chain1.pem ...` (update chain)
- [x] `tctl auth update-override --type=db-client --clear-chain ...` (clear chain)