### PR TITLE
[v18] Desktop Access: Support Shared Directory Removal (Backend only)

### DIFF
--- a/api/gen/proto/go/teleport/desktop/v1/tdpb.pb.go
+++ b/api/gen/proto/go/teleport/desktop/v1/tdpb.pb.go
@@ -326,9 +326,10 @@ func (b0 ClientHello_builder) Build() *ClientHello {
 
 // Sent by server in response to a 'Client Hello'. Advertises server capabilities.
 type ServerHello struct {
-	state            protoimpl.MessageState `protogen:"hybrid.v1"`
-	ActivationSpec   *ConnectionActivated   `protobuf:"bytes,1,opt,name=activation_spec,json=activationSpec,proto3" json:"activation_spec,omitempty"`
-	ClipboardEnabled bool                   `protobuf:"varint,2,opt,name=clipboard_enabled,json=clipboardEnabled,proto3" json:"clipboard_enabled,omitempty"`
+	state                    protoimpl.MessageState `protogen:"hybrid.v1"`
+	ActivationSpec           *ConnectionActivated   `protobuf:"bytes,1,opt,name=activation_spec,json=activationSpec,proto3" json:"activation_spec,omitempty"`
+	ClipboardEnabled         bool                   `protobuf:"varint,2,opt,name=clipboard_enabled,json=clipboardEnabled,proto3" json:"clipboard_enabled,omitempty"`
+	DirectoryRemoveSupported bool                   `protobuf:"varint,3,opt,name=directory_remove_supported,json=directoryRemoveSupported,proto3" json:"directory_remove_supported,omitempty"`
 	// Field number 5 matches master. v18 doesn't use fields 3 and 4
 	// (directory_remove_supported and sessions on master).
 	HidpiSupported bool `protobuf:"varint,5,opt,name=hidpi_supported,json=hidpiSupported,proto3" json:"hidpi_supported,omitempty"`
@@ -375,6 +376,13 @@ func (x *ServerHello) GetClipboardEnabled() bool {
 	return false
 }
 
+func (x *ServerHello) GetDirectoryRemoveSupported() bool {
+	if x != nil {
+		return x.DirectoryRemoveSupported
+	}
+	return false
+}
+
 func (x *ServerHello) GetHidpiSupported() bool {
 	if x != nil {
 		return x.HidpiSupported
@@ -388,6 +396,10 @@ func (x *ServerHello) SetActivationSpec(v *ConnectionActivated) {
 
 func (x *ServerHello) SetClipboardEnabled(v bool) {
 	x.ClipboardEnabled = v
+}
+
+func (x *ServerHello) SetDirectoryRemoveSupported(v bool) {
+	x.DirectoryRemoveSupported = v
 }
 
 func (x *ServerHello) SetHidpiSupported(v bool) {
@@ -408,8 +420,9 @@ func (x *ServerHello) ClearActivationSpec() {
 type ServerHello_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	ActivationSpec   *ConnectionActivated
-	ClipboardEnabled bool
+	ActivationSpec           *ConnectionActivated
+	ClipboardEnabled         bool
+	DirectoryRemoveSupported bool
 	// Field number 5 matches master. v18 doesn't use fields 3 and 4
 	// (directory_remove_supported and sessions on master).
 	HidpiSupported bool
@@ -421,6 +434,7 @@ func (b0 ServerHello_builder) Build() *ServerHello {
 	_, _ = b, x
 	x.ActivationSpec = b.ActivationSpec
 	x.ClipboardEnabled = b.ClipboardEnabled
+	x.DirectoryRemoveSupported = b.DirectoryRemoveSupported
 	x.HidpiSupported = b.HidpiSupported
 	return m0
 }
@@ -1643,6 +1657,64 @@ func (b0 SharedDirectoryAnnounce_builder) Build() *SharedDirectoryAnnounce {
 	return m0
 }
 
+// Sent by client to remove a previously announced shared directory.
+type SharedDirectoryRemove struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	DirectoryId   uint32                 `protobuf:"varint,1,opt,name=directory_id,json=directoryId,proto3" json:"directory_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SharedDirectoryRemove) Reset() {
+	*x = SharedDirectoryRemove{}
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SharedDirectoryRemove) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SharedDirectoryRemove) ProtoMessage() {}
+
+func (x *SharedDirectoryRemove) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *SharedDirectoryRemove) GetDirectoryId() uint32 {
+	if x != nil {
+		return x.DirectoryId
+	}
+	return 0
+}
+
+func (x *SharedDirectoryRemove) SetDirectoryId(v uint32) {
+	x.DirectoryId = v
+}
+
+type SharedDirectoryRemove_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	DirectoryId uint32
+}
+
+func (b0 SharedDirectoryRemove_builder) Build() *SharedDirectoryRemove {
+	m0 := &SharedDirectoryRemove{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.DirectoryId = b.DirectoryId
+	return m0
+}
+
 // Sent by server to acknowledge a new shared directory.
 type SharedDirectoryAcknowledge struct {
 	state         protoimpl.MessageState `protogen:"hybrid.v1"`
@@ -1654,7 +1726,7 @@ type SharedDirectoryAcknowledge struct {
 
 func (x *SharedDirectoryAcknowledge) Reset() {
 	*x = SharedDirectoryAcknowledge{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[17]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1666,7 +1738,7 @@ func (x *SharedDirectoryAcknowledge) String() string {
 func (*SharedDirectoryAcknowledge) ProtoMessage() {}
 
 func (x *SharedDirectoryAcknowledge) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[17]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1740,7 +1812,7 @@ type SharedDirectoryRequest struct {
 
 func (x *SharedDirectoryRequest) Reset() {
 	*x = SharedDirectoryRequest{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[18]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1752,7 +1824,7 @@ func (x *SharedDirectoryRequest) String() string {
 func (*SharedDirectoryRequest) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[18]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2143,7 +2215,7 @@ func (b0 SharedDirectoryRequest_builder) Build() *SharedDirectoryRequest {
 type case_SharedDirectoryRequest_Operation protoreflect.FieldNumber
 
 func (x case_SharedDirectoryRequest_Operation) String() string {
-	md := file_teleport_desktop_v1_tdpb_proto_msgTypes[18].Descriptor()
+	md := file_teleport_desktop_v1_tdpb_proto_msgTypes[19].Descriptor()
 	if x == 0 {
 		return "not set"
 	}
@@ -2228,7 +2300,7 @@ type SharedDirectoryResponse struct {
 
 func (x *SharedDirectoryResponse) Reset() {
 	*x = SharedDirectoryResponse{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[19]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2240,7 +2312,7 @@ func (x *SharedDirectoryResponse) String() string {
 func (*SharedDirectoryResponse) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[19]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2632,7 +2704,7 @@ func (b0 SharedDirectoryResponse_builder) Build() *SharedDirectoryResponse {
 type case_SharedDirectoryResponse_Operation protoreflect.FieldNumber
 
 func (x case_SharedDirectoryResponse_Operation) String() string {
-	md := file_teleport_desktop_v1_tdpb_proto_msgTypes[19].Descriptor()
+	md := file_teleport_desktop_v1_tdpb_proto_msgTypes[20].Descriptor()
 	if x == 0 {
 		return "not set"
 	}
@@ -2705,7 +2777,7 @@ type FileSystemObject struct {
 
 func (x *FileSystemObject) Reset() {
 	*x = FileSystemObject{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[20]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2717,7 +2789,7 @@ func (x *FileSystemObject) String() string {
 func (*FileSystemObject) ProtoMessage() {}
 
 func (x *FileSystemObject) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[20]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2817,7 +2889,7 @@ type LatencyStats struct {
 
 func (x *LatencyStats) Reset() {
 	*x = LatencyStats{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[21]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2829,7 +2901,7 @@ func (x *LatencyStats) String() string {
 func (*LatencyStats) ProtoMessage() {}
 
 func (x *LatencyStats) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[21]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2889,7 +2961,7 @@ type Ping struct {
 
 func (x *Ping) Reset() {
 	*x = Ping{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[22]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2901,7 +2973,7 @@ func (x *Ping) String() string {
 func (*Ping) ProtoMessage() {}
 
 func (x *Ping) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[22]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2966,6 +3038,7 @@ type Envelope struct {
 	//	*Envelope_SharedDirectoryResponse
 	//	*Envelope_LatencyStats
 	//	*Envelope_Ping
+	//	*Envelope_SharedDirectoryRemove
 	Payload       isEnvelope_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -2973,7 +3046,7 @@ type Envelope struct {
 
 func (x *Envelope) Reset() {
 	*x = Envelope{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[23]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2985,7 +3058,7 @@ func (x *Envelope) String() string {
 func (*Envelope) ProtoMessage() {}
 
 func (x *Envelope) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[23]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3183,6 +3256,15 @@ func (x *Envelope) GetPing() *Ping {
 	return nil
 }
 
+func (x *Envelope) GetSharedDirectoryRemove() *SharedDirectoryRemove {
+	if x != nil {
+		if x, ok := x.Payload.(*Envelope_SharedDirectoryRemove); ok {
+			return x.SharedDirectoryRemove
+		}
+	}
+	return nil
+}
+
 func (x *Envelope) SetClientHello(v *ClientHello) {
 	if v == nil {
 		x.Payload = nil
@@ -3341,6 +3423,14 @@ func (x *Envelope) SetPing(v *Ping) {
 		return
 	}
 	x.Payload = &Envelope_Ping{v}
+}
+
+func (x *Envelope) SetSharedDirectoryRemove(v *SharedDirectoryRemove) {
+	if v == nil {
+		x.Payload = nil
+		return
+	}
+	x.Payload = &Envelope_SharedDirectoryRemove{v}
 }
 
 func (x *Envelope) HasPayload() bool {
@@ -3510,6 +3600,14 @@ func (x *Envelope) HasPing() bool {
 	return ok
 }
 
+func (x *Envelope) HasSharedDirectoryRemove() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.Payload.(*Envelope_SharedDirectoryRemove)
+	return ok
+}
+
 func (x *Envelope) ClearPayload() {
 	x.Payload = nil
 }
@@ -3634,6 +3732,12 @@ func (x *Envelope) ClearPing() {
 	}
 }
 
+func (x *Envelope) ClearSharedDirectoryRemove() {
+	if _, ok := x.Payload.(*Envelope_SharedDirectoryRemove); ok {
+		x.Payload = nil
+	}
+}
+
 const Envelope_Payload_not_set_case case_Envelope_Payload = 0
 const Envelope_ClientHello_case case_Envelope_Payload = 1
 const Envelope_ServerHello_case case_Envelope_Payload = 2
@@ -3655,6 +3759,7 @@ const Envelope_SharedDirectoryRequest_case case_Envelope_Payload = 17
 const Envelope_SharedDirectoryResponse_case case_Envelope_Payload = 18
 const Envelope_LatencyStats_case case_Envelope_Payload = 19
 const Envelope_Ping_case case_Envelope_Payload = 20
+const Envelope_SharedDirectoryRemove_case case_Envelope_Payload = 21
 
 func (x *Envelope) WhichPayload() case_Envelope_Payload {
 	if x == nil {
@@ -3701,6 +3806,8 @@ func (x *Envelope) WhichPayload() case_Envelope_Payload {
 		return Envelope_LatencyStats_case
 	case *Envelope_Ping:
 		return Envelope_Ping_case
+	case *Envelope_SharedDirectoryRemove:
+		return Envelope_SharedDirectoryRemove_case
 	default:
 		return Envelope_Payload_not_set_case
 	}
@@ -3730,6 +3837,7 @@ type Envelope_builder struct {
 	SharedDirectoryResponse    *SharedDirectoryResponse
 	LatencyStats               *LatencyStats
 	Ping                       *Ping
+	SharedDirectoryRemove      *SharedDirectoryRemove
 	// -- end of Payload
 }
 
@@ -3797,13 +3905,16 @@ func (b0 Envelope_builder) Build() *Envelope {
 	if b.Ping != nil {
 		x.Payload = &Envelope_Ping{b.Ping}
 	}
+	if b.SharedDirectoryRemove != nil {
+		x.Payload = &Envelope_SharedDirectoryRemove{b.SharedDirectoryRemove}
+	}
 	return m0
 }
 
 type case_Envelope_Payload protoreflect.FieldNumber
 
 func (x case_Envelope_Payload) String() string {
-	md := file_teleport_desktop_v1_tdpb_proto_msgTypes[23].Descriptor()
+	md := file_teleport_desktop_v1_tdpb_proto_msgTypes[24].Descriptor()
 	if x == 0 {
 		return "not set"
 	}
@@ -3894,6 +4005,10 @@ type Envelope_Ping struct {
 	Ping *Ping `protobuf:"bytes,20,opt,name=ping,proto3,oneof"`
 }
 
+type Envelope_SharedDirectoryRemove struct {
+	SharedDirectoryRemove *SharedDirectoryRemove `protobuf:"bytes,21,opt,name=shared_directory_remove,json=sharedDirectoryRemove,proto3,oneof"`
+}
+
 func (*Envelope_ClientHello) isEnvelope_Payload() {}
 
 func (*Envelope_ServerHello) isEnvelope_Payload() {}
@@ -3934,6 +4049,8 @@ func (*Envelope_LatencyStats) isEnvelope_Payload() {}
 
 func (*Envelope_Ping) isEnvelope_Payload() {}
 
+func (*Envelope_SharedDirectoryRemove) isEnvelope_Payload() {}
+
 // Info request.
 type SharedDirectoryRequest_Info struct {
 	state         protoimpl.MessageState `protogen:"hybrid.v1"`
@@ -3944,7 +4061,7 @@ type SharedDirectoryRequest_Info struct {
 
 func (x *SharedDirectoryRequest_Info) Reset() {
 	*x = SharedDirectoryRequest_Info{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[24]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3956,7 +4073,7 @@ func (x *SharedDirectoryRequest_Info) String() string {
 func (*SharedDirectoryRequest_Info) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Info) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[24]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4003,7 +4120,7 @@ type SharedDirectoryRequest_Create struct {
 
 func (x *SharedDirectoryRequest_Create) Reset() {
 	*x = SharedDirectoryRequest_Create{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[25]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4015,7 +4132,7 @@ func (x *SharedDirectoryRequest_Create) String() string {
 func (*SharedDirectoryRequest_Create) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Create) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[25]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4074,7 +4191,7 @@ type SharedDirectoryRequest_Delete struct {
 
 func (x *SharedDirectoryRequest_Delete) Reset() {
 	*x = SharedDirectoryRequest_Delete{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[26]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4086,7 +4203,7 @@ func (x *SharedDirectoryRequest_Delete) String() string {
 func (*SharedDirectoryRequest_Delete) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Delete) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[26]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4132,7 +4249,7 @@ type SharedDirectoryRequest_List struct {
 
 func (x *SharedDirectoryRequest_List) Reset() {
 	*x = SharedDirectoryRequest_List{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[27]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4144,7 +4261,7 @@ func (x *SharedDirectoryRequest_List) String() string {
 func (*SharedDirectoryRequest_List) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_List) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[27]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4192,7 +4309,7 @@ type SharedDirectoryRequest_Read struct {
 
 func (x *SharedDirectoryRequest_Read) Reset() {
 	*x = SharedDirectoryRequest_Read{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[28]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4204,7 +4321,7 @@ func (x *SharedDirectoryRequest_Read) String() string {
 func (*SharedDirectoryRequest_Read) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Read) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[28]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4278,7 +4395,7 @@ type SharedDirectoryRequest_Write struct {
 
 func (x *SharedDirectoryRequest_Write) Reset() {
 	*x = SharedDirectoryRequest_Write{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[29]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4290,7 +4407,7 @@ func (x *SharedDirectoryRequest_Write) String() string {
 func (*SharedDirectoryRequest_Write) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Write) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[29]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4366,7 +4483,7 @@ type SharedDirectoryRequest_Move struct {
 
 func (x *SharedDirectoryRequest_Move) Reset() {
 	*x = SharedDirectoryRequest_Move{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[30]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4378,7 +4495,7 @@ func (x *SharedDirectoryRequest_Move) String() string {
 func (*SharedDirectoryRequest_Move) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Move) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[30]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4438,7 +4555,7 @@ type SharedDirectoryRequest_Truncate struct {
 
 func (x *SharedDirectoryRequest_Truncate) Reset() {
 	*x = SharedDirectoryRequest_Truncate{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[31]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4450,7 +4567,7 @@ func (x *SharedDirectoryRequest_Truncate) String() string {
 func (*SharedDirectoryRequest_Truncate) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Truncate) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[31]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4509,7 +4626,7 @@ type SharedDirectoryResponse_Info struct {
 
 func (x *SharedDirectoryResponse_Info) Reset() {
 	*x = SharedDirectoryResponse_Info{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[32]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4521,7 +4638,7 @@ func (x *SharedDirectoryResponse_Info) String() string {
 func (*SharedDirectoryResponse_Info) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Info) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[32]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4578,7 +4695,7 @@ type SharedDirectoryResponse_Create struct {
 
 func (x *SharedDirectoryResponse_Create) Reset() {
 	*x = SharedDirectoryResponse_Create{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[33]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4590,7 +4707,7 @@ func (x *SharedDirectoryResponse_Create) String() string {
 func (*SharedDirectoryResponse_Create) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Create) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[33]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4646,7 +4763,7 @@ type SharedDirectoryResponse_Delete struct {
 
 func (x *SharedDirectoryResponse_Delete) Reset() {
 	*x = SharedDirectoryResponse_Delete{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[34]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4658,7 +4775,7 @@ func (x *SharedDirectoryResponse_Delete) String() string {
 func (*SharedDirectoryResponse_Delete) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Delete) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[34]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4691,7 +4808,7 @@ type SharedDirectoryResponse_List struct {
 
 func (x *SharedDirectoryResponse_List) Reset() {
 	*x = SharedDirectoryResponse_List{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[35]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4703,7 +4820,7 @@ func (x *SharedDirectoryResponse_List) String() string {
 func (*SharedDirectoryResponse_List) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_List) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[35]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4749,7 +4866,7 @@ type SharedDirectoryResponse_Read struct {
 
 func (x *SharedDirectoryResponse_Read) Reset() {
 	*x = SharedDirectoryResponse_Read{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[36]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4761,7 +4878,7 @@ func (x *SharedDirectoryResponse_Read) String() string {
 func (*SharedDirectoryResponse_Read) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Read) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[36]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4810,7 +4927,7 @@ type SharedDirectoryResponse_Write struct {
 
 func (x *SharedDirectoryResponse_Write) Reset() {
 	*x = SharedDirectoryResponse_Write{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[37]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4822,7 +4939,7 @@ func (x *SharedDirectoryResponse_Write) String() string {
 func (*SharedDirectoryResponse_Write) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Write) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[37]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4867,7 +4984,7 @@ type SharedDirectoryResponse_Move struct {
 
 func (x *SharedDirectoryResponse_Move) Reset() {
 	*x = SharedDirectoryResponse_Move{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[38]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4879,7 +4996,7 @@ func (x *SharedDirectoryResponse_Move) String() string {
 func (*SharedDirectoryResponse_Move) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Move) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[38]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4911,7 +5028,7 @@ type SharedDirectoryResponse_Truncate struct {
 
 func (x *SharedDirectoryResponse_Truncate) Reset() {
 	*x = SharedDirectoryResponse_Truncate{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[39]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4923,7 +5040,7 @@ func (x *SharedDirectoryResponse_Truncate) String() string {
 func (*SharedDirectoryResponse_Truncate) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Truncate) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[39]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4955,10 +5072,11 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\busername\x18\x01 \x01(\tR\busername\x12F\n" +
 	"\vscreen_spec\x18\x02 \x01(\v2%.teleport.desktop.v1.ClientScreenSpecR\n" +
 	"screenSpec\x12'\n" +
-	"\x0fkeyboard_layout\x18\x03 \x01(\rR\x0ekeyboardLayout\"\xb6\x01\n" +
+	"\x0fkeyboard_layout\x18\x03 \x01(\rR\x0ekeyboardLayout\"\xf4\x01\n" +
 	"\vServerHello\x12Q\n" +
 	"\x0factivation_spec\x18\x01 \x01(\v2(.teleport.desktop.v1.ConnectionActivatedR\x0eactivationSpec\x12+\n" +
-	"\x11clipboard_enabled\x18\x02 \x01(\bR\x10clipboardEnabled\x12'\n" +
+	"\x11clipboard_enabled\x18\x02 \x01(\bR\x10clipboardEnabled\x12<\n" +
+	"\x1adirectory_remove_supported\x18\x03 \x01(\bR\x18directoryRemoveSupported\x12'\n" +
 	"\x0fhidpi_supported\x18\x05 \x01(\bR\x0ehidpiSupported\"_\n" +
 	"\tRectangle\x12\x12\n" +
 	"\x04left\x18\x01 \x01(\rR\x04left\x12\x10\n" +
@@ -5012,7 +5130,9 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\x17authentication_response\x18\x04 \x01(\v2%.teleport.mfa.v1.AuthenticateResponseR\x16authenticationResponse\"P\n" +
 	"\x17SharedDirectoryAnnounce\x12!\n" +
 	"\fdirectory_id\x18\x01 \x01(\rR\vdirectoryId\x12\x12\n" +
-	"\x04name\x18\x02 \x01(\tR\x04name\"^\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\":\n" +
+	"\x15SharedDirectoryRemove\x12!\n" +
+	"\fdirectory_id\x18\x01 \x01(\rR\vdirectoryId\"^\n" +
 	"\x1aSharedDirectoryAcknowledge\x12!\n" +
 	"\fdirectory_id\x18\x01 \x01(\rR\vdirectoryId\x12\x1d\n" +
 	"\n" +
@@ -5091,7 +5211,7 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\x11client_latency_ms\x18\x01 \x01(\rR\x0fclientLatencyMs\x12*\n" +
 	"\x11server_latency_ms\x18\x02 \x01(\rR\x0fserverLatencyMs\"\x1a\n" +
 	"\x04Ping\x12\x12\n" +
-	"\x04uuid\x18\x01 \x01(\fR\x04uuid\"\x8b\f\n" +
+	"\x04uuid\x18\x01 \x01(\fR\x04uuid\"\xf1\f\n" +
 	"\bEnvelope\x12E\n" +
 	"\fclient_hello\x18\x01 \x01(\v2 .teleport.desktop.v1.ClientHelloH\x00R\vclientHello\x12E\n" +
 	"\fserver_hello\x18\x02 \x01(\v2 .teleport.desktop.v1.ServerHelloH\x00R\vserverHello\x12<\n" +
@@ -5115,7 +5235,8 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\x18shared_directory_request\x18\x11 \x01(\v2+.teleport.desktop.v1.SharedDirectoryRequestH\x00R\x16sharedDirectoryRequest\x12j\n" +
 	"\x19shared_directory_response\x18\x12 \x01(\v2,.teleport.desktop.v1.SharedDirectoryResponseH\x00R\x17sharedDirectoryResponse\x12H\n" +
 	"\rlatency_stats\x18\x13 \x01(\v2!.teleport.desktop.v1.LatencyStatsH\x00R\flatencyStats\x12/\n" +
-	"\x04ping\x18\x14 \x01(\v2\x19.teleport.desktop.v1.PingH\x00R\x04pingB\t\n" +
+	"\x04ping\x18\x14 \x01(\v2\x19.teleport.desktop.v1.PingH\x00R\x04ping\x12d\n" +
+	"\x17shared_directory_remove\x18\x15 \x01(\v2*.teleport.desktop.v1.SharedDirectoryRemoveH\x00R\x15sharedDirectoryRemoveB\t\n" +
 	"\apayload*\x8b\x01\n" +
 	"\x0fMouseButtonType\x12!\n" +
 	"\x1dMOUSE_BUTTON_TYPE_UNSPECIFIED\x10\x00\x12\x1a\n" +
@@ -5137,7 +5258,7 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\fMFA_TYPE_U2F\x10\x02BOZMgithub.com/gravitational/teleport/api/gen/proto/go/teleport/desktop/v1;tdpbv1b\x06proto3"
 
 var file_teleport_desktop_v1_tdpb_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_teleport_desktop_v1_tdpb_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
+var file_teleport_desktop_v1_tdpb_proto_msgTypes = make([]protoimpl.MessageInfo, 41)
 var file_teleport_desktop_v1_tdpb_proto_goTypes = []any{
 	(MouseButtonType)(0),                     // 0: teleport.desktop.v1.MouseButtonType
 	(AlertSeverity)(0),                       // 1: teleport.desktop.v1.AlertSeverity
@@ -5160,31 +5281,32 @@ var file_teleport_desktop_v1_tdpb_proto_goTypes = []any{
 	(*ClipboardData)(nil),                    // 18: teleport.desktop.v1.ClipboardData
 	(*MFA)(nil),                              // 19: teleport.desktop.v1.MFA
 	(*SharedDirectoryAnnounce)(nil),          // 20: teleport.desktop.v1.SharedDirectoryAnnounce
-	(*SharedDirectoryAcknowledge)(nil),       // 21: teleport.desktop.v1.SharedDirectoryAcknowledge
-	(*SharedDirectoryRequest)(nil),           // 22: teleport.desktop.v1.SharedDirectoryRequest
-	(*SharedDirectoryResponse)(nil),          // 23: teleport.desktop.v1.SharedDirectoryResponse
-	(*FileSystemObject)(nil),                 // 24: teleport.desktop.v1.FileSystemObject
-	(*LatencyStats)(nil),                     // 25: teleport.desktop.v1.LatencyStats
-	(*Ping)(nil),                             // 26: teleport.desktop.v1.Ping
-	(*Envelope)(nil),                         // 27: teleport.desktop.v1.Envelope
-	(*SharedDirectoryRequest_Info)(nil),      // 28: teleport.desktop.v1.SharedDirectoryRequest.Info
-	(*SharedDirectoryRequest_Create)(nil),    // 29: teleport.desktop.v1.SharedDirectoryRequest.Create
-	(*SharedDirectoryRequest_Delete)(nil),    // 30: teleport.desktop.v1.SharedDirectoryRequest.Delete
-	(*SharedDirectoryRequest_List)(nil),      // 31: teleport.desktop.v1.SharedDirectoryRequest.List
-	(*SharedDirectoryRequest_Read)(nil),      // 32: teleport.desktop.v1.SharedDirectoryRequest.Read
-	(*SharedDirectoryRequest_Write)(nil),     // 33: teleport.desktop.v1.SharedDirectoryRequest.Write
-	(*SharedDirectoryRequest_Move)(nil),      // 34: teleport.desktop.v1.SharedDirectoryRequest.Move
-	(*SharedDirectoryRequest_Truncate)(nil),  // 35: teleport.desktop.v1.SharedDirectoryRequest.Truncate
-	(*SharedDirectoryResponse_Info)(nil),     // 36: teleport.desktop.v1.SharedDirectoryResponse.Info
-	(*SharedDirectoryResponse_Create)(nil),   // 37: teleport.desktop.v1.SharedDirectoryResponse.Create
-	(*SharedDirectoryResponse_Delete)(nil),   // 38: teleport.desktop.v1.SharedDirectoryResponse.Delete
-	(*SharedDirectoryResponse_List)(nil),     // 39: teleport.desktop.v1.SharedDirectoryResponse.List
-	(*SharedDirectoryResponse_Read)(nil),     // 40: teleport.desktop.v1.SharedDirectoryResponse.Read
-	(*SharedDirectoryResponse_Write)(nil),    // 41: teleport.desktop.v1.SharedDirectoryResponse.Write
-	(*SharedDirectoryResponse_Move)(nil),     // 42: teleport.desktop.v1.SharedDirectoryResponse.Move
-	(*SharedDirectoryResponse_Truncate)(nil), // 43: teleport.desktop.v1.SharedDirectoryResponse.Truncate
-	(*v1.AuthenticateChallenge)(nil),         // 44: teleport.mfa.v1.AuthenticateChallenge
-	(*v1.AuthenticateResponse)(nil),          // 45: teleport.mfa.v1.AuthenticateResponse
+	(*SharedDirectoryRemove)(nil),            // 21: teleport.desktop.v1.SharedDirectoryRemove
+	(*SharedDirectoryAcknowledge)(nil),       // 22: teleport.desktop.v1.SharedDirectoryAcknowledge
+	(*SharedDirectoryRequest)(nil),           // 23: teleport.desktop.v1.SharedDirectoryRequest
+	(*SharedDirectoryResponse)(nil),          // 24: teleport.desktop.v1.SharedDirectoryResponse
+	(*FileSystemObject)(nil),                 // 25: teleport.desktop.v1.FileSystemObject
+	(*LatencyStats)(nil),                     // 26: teleport.desktop.v1.LatencyStats
+	(*Ping)(nil),                             // 27: teleport.desktop.v1.Ping
+	(*Envelope)(nil),                         // 28: teleport.desktop.v1.Envelope
+	(*SharedDirectoryRequest_Info)(nil),      // 29: teleport.desktop.v1.SharedDirectoryRequest.Info
+	(*SharedDirectoryRequest_Create)(nil),    // 30: teleport.desktop.v1.SharedDirectoryRequest.Create
+	(*SharedDirectoryRequest_Delete)(nil),    // 31: teleport.desktop.v1.SharedDirectoryRequest.Delete
+	(*SharedDirectoryRequest_List)(nil),      // 32: teleport.desktop.v1.SharedDirectoryRequest.List
+	(*SharedDirectoryRequest_Read)(nil),      // 33: teleport.desktop.v1.SharedDirectoryRequest.Read
+	(*SharedDirectoryRequest_Write)(nil),     // 34: teleport.desktop.v1.SharedDirectoryRequest.Write
+	(*SharedDirectoryRequest_Move)(nil),      // 35: teleport.desktop.v1.SharedDirectoryRequest.Move
+	(*SharedDirectoryRequest_Truncate)(nil),  // 36: teleport.desktop.v1.SharedDirectoryRequest.Truncate
+	(*SharedDirectoryResponse_Info)(nil),     // 37: teleport.desktop.v1.SharedDirectoryResponse.Info
+	(*SharedDirectoryResponse_Create)(nil),   // 38: teleport.desktop.v1.SharedDirectoryResponse.Create
+	(*SharedDirectoryResponse_Delete)(nil),   // 39: teleport.desktop.v1.SharedDirectoryResponse.Delete
+	(*SharedDirectoryResponse_List)(nil),     // 40: teleport.desktop.v1.SharedDirectoryResponse.List
+	(*SharedDirectoryResponse_Read)(nil),     // 41: teleport.desktop.v1.SharedDirectoryResponse.Read
+	(*SharedDirectoryResponse_Write)(nil),    // 42: teleport.desktop.v1.SharedDirectoryResponse.Write
+	(*SharedDirectoryResponse_Move)(nil),     // 43: teleport.desktop.v1.SharedDirectoryResponse.Move
+	(*SharedDirectoryResponse_Truncate)(nil), // 44: teleport.desktop.v1.SharedDirectoryResponse.Truncate
+	(*v1.AuthenticateChallenge)(nil),         // 45: teleport.mfa.v1.AuthenticateChallenge
+	(*v1.AuthenticateResponse)(nil),          // 46: teleport.mfa.v1.AuthenticateResponse
 }
 var file_teleport_desktop_v1_tdpb_proto_depIdxs = []int32{
 	15, // 0: teleport.desktop.v1.ClientHello.screen_spec:type_name -> teleport.desktop.v1.ClientScreenSpec
@@ -5194,24 +5316,24 @@ var file_teleport_desktop_v1_tdpb_proto_depIdxs = []int32{
 	1,  // 4: teleport.desktop.v1.Alert.severity:type_name -> teleport.desktop.v1.AlertSeverity
 	2,  // 5: teleport.desktop.v1.MouseWheel.axis:type_name -> teleport.desktop.v1.MouseWheelAxis
 	3,  // 6: teleport.desktop.v1.MFA.type:type_name -> teleport.desktop.v1.MFAType
-	44, // 7: teleport.desktop.v1.MFA.challenge:type_name -> teleport.mfa.v1.AuthenticateChallenge
-	45, // 8: teleport.desktop.v1.MFA.authentication_response:type_name -> teleport.mfa.v1.AuthenticateResponse
-	28, // 9: teleport.desktop.v1.SharedDirectoryRequest.info:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Info
-	29, // 10: teleport.desktop.v1.SharedDirectoryRequest.create:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Create
-	30, // 11: teleport.desktop.v1.SharedDirectoryRequest.delete:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Delete
-	31, // 12: teleport.desktop.v1.SharedDirectoryRequest.list:type_name -> teleport.desktop.v1.SharedDirectoryRequest.List
-	32, // 13: teleport.desktop.v1.SharedDirectoryRequest.read:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Read
-	33, // 14: teleport.desktop.v1.SharedDirectoryRequest.write:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Write
-	34, // 15: teleport.desktop.v1.SharedDirectoryRequest.move:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Move
-	35, // 16: teleport.desktop.v1.SharedDirectoryRequest.truncate:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Truncate
-	36, // 17: teleport.desktop.v1.SharedDirectoryResponse.info:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Info
-	37, // 18: teleport.desktop.v1.SharedDirectoryResponse.create:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Create
-	38, // 19: teleport.desktop.v1.SharedDirectoryResponse.delete:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Delete
-	39, // 20: teleport.desktop.v1.SharedDirectoryResponse.list:type_name -> teleport.desktop.v1.SharedDirectoryResponse.List
-	40, // 21: teleport.desktop.v1.SharedDirectoryResponse.read:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Read
-	41, // 22: teleport.desktop.v1.SharedDirectoryResponse.write:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Write
-	42, // 23: teleport.desktop.v1.SharedDirectoryResponse.move:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Move
-	43, // 24: teleport.desktop.v1.SharedDirectoryResponse.truncate:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Truncate
+	45, // 7: teleport.desktop.v1.MFA.challenge:type_name -> teleport.mfa.v1.AuthenticateChallenge
+	46, // 8: teleport.desktop.v1.MFA.authentication_response:type_name -> teleport.mfa.v1.AuthenticateResponse
+	29, // 9: teleport.desktop.v1.SharedDirectoryRequest.info:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Info
+	30, // 10: teleport.desktop.v1.SharedDirectoryRequest.create:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Create
+	31, // 11: teleport.desktop.v1.SharedDirectoryRequest.delete:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Delete
+	32, // 12: teleport.desktop.v1.SharedDirectoryRequest.list:type_name -> teleport.desktop.v1.SharedDirectoryRequest.List
+	33, // 13: teleport.desktop.v1.SharedDirectoryRequest.read:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Read
+	34, // 14: teleport.desktop.v1.SharedDirectoryRequest.write:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Write
+	35, // 15: teleport.desktop.v1.SharedDirectoryRequest.move:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Move
+	36, // 16: teleport.desktop.v1.SharedDirectoryRequest.truncate:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Truncate
+	37, // 17: teleport.desktop.v1.SharedDirectoryResponse.info:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Info
+	38, // 18: teleport.desktop.v1.SharedDirectoryResponse.create:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Create
+	39, // 19: teleport.desktop.v1.SharedDirectoryResponse.delete:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Delete
+	40, // 20: teleport.desktop.v1.SharedDirectoryResponse.list:type_name -> teleport.desktop.v1.SharedDirectoryResponse.List
+	41, // 21: teleport.desktop.v1.SharedDirectoryResponse.read:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Read
+	42, // 22: teleport.desktop.v1.SharedDirectoryResponse.write:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Write
+	43, // 23: teleport.desktop.v1.SharedDirectoryResponse.move:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Move
+	44, // 24: teleport.desktop.v1.SharedDirectoryResponse.truncate:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Truncate
 	4,  // 25: teleport.desktop.v1.Envelope.client_hello:type_name -> teleport.desktop.v1.ClientHello
 	5,  // 26: teleport.desktop.v1.Envelope.server_hello:type_name -> teleport.desktop.v1.ServerHello
 	7,  // 27: teleport.desktop.v1.Envelope.png_frame:type_name -> teleport.desktop.v1.PNGFrame
@@ -5227,19 +5349,20 @@ var file_teleport_desktop_v1_tdpb_proto_depIdxs = []int32{
 	18, // 37: teleport.desktop.v1.Envelope.clipboard_data:type_name -> teleport.desktop.v1.ClipboardData
 	19, // 38: teleport.desktop.v1.Envelope.mfa:type_name -> teleport.desktop.v1.MFA
 	20, // 39: teleport.desktop.v1.Envelope.shared_directory_announce:type_name -> teleport.desktop.v1.SharedDirectoryAnnounce
-	21, // 40: teleport.desktop.v1.Envelope.shared_directory_acknowledge:type_name -> teleport.desktop.v1.SharedDirectoryAcknowledge
-	22, // 41: teleport.desktop.v1.Envelope.shared_directory_request:type_name -> teleport.desktop.v1.SharedDirectoryRequest
-	23, // 42: teleport.desktop.v1.Envelope.shared_directory_response:type_name -> teleport.desktop.v1.SharedDirectoryResponse
-	25, // 43: teleport.desktop.v1.Envelope.latency_stats:type_name -> teleport.desktop.v1.LatencyStats
-	26, // 44: teleport.desktop.v1.Envelope.ping:type_name -> teleport.desktop.v1.Ping
-	24, // 45: teleport.desktop.v1.SharedDirectoryResponse.Info.fso:type_name -> teleport.desktop.v1.FileSystemObject
-	24, // 46: teleport.desktop.v1.SharedDirectoryResponse.Create.fso:type_name -> teleport.desktop.v1.FileSystemObject
-	24, // 47: teleport.desktop.v1.SharedDirectoryResponse.List.fso_list:type_name -> teleport.desktop.v1.FileSystemObject
-	48, // [48:48] is the sub-list for method output_type
-	48, // [48:48] is the sub-list for method input_type
-	48, // [48:48] is the sub-list for extension type_name
-	48, // [48:48] is the sub-list for extension extendee
-	0,  // [0:48] is the sub-list for field type_name
+	22, // 40: teleport.desktop.v1.Envelope.shared_directory_acknowledge:type_name -> teleport.desktop.v1.SharedDirectoryAcknowledge
+	23, // 41: teleport.desktop.v1.Envelope.shared_directory_request:type_name -> teleport.desktop.v1.SharedDirectoryRequest
+	24, // 42: teleport.desktop.v1.Envelope.shared_directory_response:type_name -> teleport.desktop.v1.SharedDirectoryResponse
+	26, // 43: teleport.desktop.v1.Envelope.latency_stats:type_name -> teleport.desktop.v1.LatencyStats
+	27, // 44: teleport.desktop.v1.Envelope.ping:type_name -> teleport.desktop.v1.Ping
+	21, // 45: teleport.desktop.v1.Envelope.shared_directory_remove:type_name -> teleport.desktop.v1.SharedDirectoryRemove
+	25, // 46: teleport.desktop.v1.SharedDirectoryResponse.Info.fso:type_name -> teleport.desktop.v1.FileSystemObject
+	25, // 47: teleport.desktop.v1.SharedDirectoryResponse.Create.fso:type_name -> teleport.desktop.v1.FileSystemObject
+	25, // 48: teleport.desktop.v1.SharedDirectoryResponse.List.fso_list:type_name -> teleport.desktop.v1.FileSystemObject
+	49, // [49:49] is the sub-list for method output_type
+	49, // [49:49] is the sub-list for method input_type
+	49, // [49:49] is the sub-list for extension type_name
+	49, // [49:49] is the sub-list for extension extendee
+	0,  // [0:49] is the sub-list for field type_name
 }
 
 func init() { file_teleport_desktop_v1_tdpb_proto_init() }
@@ -5247,7 +5370,7 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 	if File_teleport_desktop_v1_tdpb_proto != nil {
 		return
 	}
-	file_teleport_desktop_v1_tdpb_proto_msgTypes[18].OneofWrappers = []any{
+	file_teleport_desktop_v1_tdpb_proto_msgTypes[19].OneofWrappers = []any{
 		(*SharedDirectoryRequest_Info_)(nil),
 		(*SharedDirectoryRequest_Create_)(nil),
 		(*SharedDirectoryRequest_Delete_)(nil),
@@ -5257,7 +5380,7 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 		(*SharedDirectoryRequest_Move_)(nil),
 		(*SharedDirectoryRequest_Truncate_)(nil),
 	}
-	file_teleport_desktop_v1_tdpb_proto_msgTypes[19].OneofWrappers = []any{
+	file_teleport_desktop_v1_tdpb_proto_msgTypes[20].OneofWrappers = []any{
 		(*SharedDirectoryResponse_Info_)(nil),
 		(*SharedDirectoryResponse_Create_)(nil),
 		(*SharedDirectoryResponse_Delete_)(nil),
@@ -5267,7 +5390,7 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 		(*SharedDirectoryResponse_Move_)(nil),
 		(*SharedDirectoryResponse_Truncate_)(nil),
 	}
-	file_teleport_desktop_v1_tdpb_proto_msgTypes[23].OneofWrappers = []any{
+	file_teleport_desktop_v1_tdpb_proto_msgTypes[24].OneofWrappers = []any{
 		(*Envelope_ClientHello)(nil),
 		(*Envelope_ServerHello)(nil),
 		(*Envelope_PngFrame)(nil),
@@ -5288,6 +5411,7 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 		(*Envelope_SharedDirectoryResponse)(nil),
 		(*Envelope_LatencyStats)(nil),
 		(*Envelope_Ping)(nil),
+		(*Envelope_SharedDirectoryRemove)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -5295,7 +5419,7 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_desktop_v1_tdpb_proto_rawDesc), len(file_teleport_desktop_v1_tdpb_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   40,
+			NumMessages:   41,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/desktop/v1/tdpb_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/desktop/v1/tdpb_protoopaque.pb.go
@@ -326,12 +326,13 @@ func (b0 ClientHello_builder) Build() *ClientHello {
 
 // Sent by server in response to a 'Client Hello'. Advertises server capabilities.
 type ServerHello struct {
-	state                       protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_ActivationSpec   *ConnectionActivated   `protobuf:"bytes,1,opt,name=activation_spec,json=activationSpec,proto3"`
-	xxx_hidden_ClipboardEnabled bool                   `protobuf:"varint,2,opt,name=clipboard_enabled,json=clipboardEnabled,proto3"`
-	xxx_hidden_HidpiSupported   bool                   `protobuf:"varint,5,opt,name=hidpi_supported,json=hidpiSupported,proto3"`
-	unknownFields               protoimpl.UnknownFields
-	sizeCache                   protoimpl.SizeCache
+	state                               protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_ActivationSpec           *ConnectionActivated   `protobuf:"bytes,1,opt,name=activation_spec,json=activationSpec,proto3"`
+	xxx_hidden_ClipboardEnabled         bool                   `protobuf:"varint,2,opt,name=clipboard_enabled,json=clipboardEnabled,proto3"`
+	xxx_hidden_DirectoryRemoveSupported bool                   `protobuf:"varint,3,opt,name=directory_remove_supported,json=directoryRemoveSupported,proto3"`
+	xxx_hidden_HidpiSupported           bool                   `protobuf:"varint,5,opt,name=hidpi_supported,json=hidpiSupported,proto3"`
+	unknownFields                       protoimpl.UnknownFields
+	sizeCache                           protoimpl.SizeCache
 }
 
 func (x *ServerHello) Reset() {
@@ -373,6 +374,13 @@ func (x *ServerHello) GetClipboardEnabled() bool {
 	return false
 }
 
+func (x *ServerHello) GetDirectoryRemoveSupported() bool {
+	if x != nil {
+		return x.xxx_hidden_DirectoryRemoveSupported
+	}
+	return false
+}
+
 func (x *ServerHello) GetHidpiSupported() bool {
 	if x != nil {
 		return x.xxx_hidden_HidpiSupported
@@ -386,6 +394,10 @@ func (x *ServerHello) SetActivationSpec(v *ConnectionActivated) {
 
 func (x *ServerHello) SetClipboardEnabled(v bool) {
 	x.xxx_hidden_ClipboardEnabled = v
+}
+
+func (x *ServerHello) SetDirectoryRemoveSupported(v bool) {
+	x.xxx_hidden_DirectoryRemoveSupported = v
 }
 
 func (x *ServerHello) SetHidpiSupported(v bool) {
@@ -406,8 +418,9 @@ func (x *ServerHello) ClearActivationSpec() {
 type ServerHello_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	ActivationSpec   *ConnectionActivated
-	ClipboardEnabled bool
+	ActivationSpec           *ConnectionActivated
+	ClipboardEnabled         bool
+	DirectoryRemoveSupported bool
 	// Field number 5 matches master. v18 doesn't use fields 3 and 4
 	// (directory_remove_supported and sessions on master).
 	HidpiSupported bool
@@ -419,6 +432,7 @@ func (b0 ServerHello_builder) Build() *ServerHello {
 	_, _ = b, x
 	x.xxx_hidden_ActivationSpec = b.ActivationSpec
 	x.xxx_hidden_ClipboardEnabled = b.ClipboardEnabled
+	x.xxx_hidden_DirectoryRemoveSupported = b.DirectoryRemoveSupported
 	x.xxx_hidden_HidpiSupported = b.HidpiSupported
 	return m0
 }
@@ -1640,6 +1654,64 @@ func (b0 SharedDirectoryAnnounce_builder) Build() *SharedDirectoryAnnounce {
 	return m0
 }
 
+// Sent by client to remove a previously announced shared directory.
+type SharedDirectoryRemove struct {
+	state                  protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_DirectoryId uint32                 `protobuf:"varint,1,opt,name=directory_id,json=directoryId,proto3"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *SharedDirectoryRemove) Reset() {
+	*x = SharedDirectoryRemove{}
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SharedDirectoryRemove) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SharedDirectoryRemove) ProtoMessage() {}
+
+func (x *SharedDirectoryRemove) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *SharedDirectoryRemove) GetDirectoryId() uint32 {
+	if x != nil {
+		return x.xxx_hidden_DirectoryId
+	}
+	return 0
+}
+
+func (x *SharedDirectoryRemove) SetDirectoryId(v uint32) {
+	x.xxx_hidden_DirectoryId = v
+}
+
+type SharedDirectoryRemove_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	DirectoryId uint32
+}
+
+func (b0 SharedDirectoryRemove_builder) Build() *SharedDirectoryRemove {
+	m0 := &SharedDirectoryRemove{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_DirectoryId = b.DirectoryId
+	return m0
+}
+
 // Sent by server to acknowledge a new shared directory.
 type SharedDirectoryAcknowledge struct {
 	state                  protoimpl.MessageState `protogen:"opaque.v1"`
@@ -1651,7 +1723,7 @@ type SharedDirectoryAcknowledge struct {
 
 func (x *SharedDirectoryAcknowledge) Reset() {
 	*x = SharedDirectoryAcknowledge{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[17]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1663,7 +1735,7 @@ func (x *SharedDirectoryAcknowledge) String() string {
 func (*SharedDirectoryAcknowledge) ProtoMessage() {}
 
 func (x *SharedDirectoryAcknowledge) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[17]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1724,7 +1796,7 @@ type SharedDirectoryRequest struct {
 
 func (x *SharedDirectoryRequest) Reset() {
 	*x = SharedDirectoryRequest{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[18]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1736,7 +1808,7 @@ func (x *SharedDirectoryRequest) String() string {
 func (*SharedDirectoryRequest) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[18]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2120,7 +2192,7 @@ func (b0 SharedDirectoryRequest_builder) Build() *SharedDirectoryRequest {
 type case_SharedDirectoryRequest_Operation protoreflect.FieldNumber
 
 func (x case_SharedDirectoryRequest_Operation) String() string {
-	md := file_teleport_desktop_v1_tdpb_proto_msgTypes[18].Descriptor()
+	md := file_teleport_desktop_v1_tdpb_proto_msgTypes[19].Descriptor()
 	if x == 0 {
 		return "not set"
 	}
@@ -2191,7 +2263,7 @@ type SharedDirectoryResponse struct {
 
 func (x *SharedDirectoryResponse) Reset() {
 	*x = SharedDirectoryResponse{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[19]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2203,7 +2275,7 @@ func (x *SharedDirectoryResponse) String() string {
 func (*SharedDirectoryResponse) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[19]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2588,7 +2660,7 @@ func (b0 SharedDirectoryResponse_builder) Build() *SharedDirectoryResponse {
 type case_SharedDirectoryResponse_Operation protoreflect.FieldNumber
 
 func (x case_SharedDirectoryResponse_Operation) String() string {
-	md := file_teleport_desktop_v1_tdpb_proto_msgTypes[19].Descriptor()
+	md := file_teleport_desktop_v1_tdpb_proto_msgTypes[20].Descriptor()
 	if x == 0 {
 		return "not set"
 	}
@@ -2661,7 +2733,7 @@ type FileSystemObject struct {
 
 func (x *FileSystemObject) Reset() {
 	*x = FileSystemObject{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[20]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2673,7 +2745,7 @@ func (x *FileSystemObject) String() string {
 func (*FileSystemObject) ProtoMessage() {}
 
 func (x *FileSystemObject) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[20]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2773,7 +2845,7 @@ type LatencyStats struct {
 
 func (x *LatencyStats) Reset() {
 	*x = LatencyStats{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[21]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2785,7 +2857,7 @@ func (x *LatencyStats) String() string {
 func (*LatencyStats) ProtoMessage() {}
 
 func (x *LatencyStats) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[21]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2844,7 +2916,7 @@ type Ping struct {
 
 func (x *Ping) Reset() {
 	*x = Ping{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[22]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2856,7 +2928,7 @@ func (x *Ping) String() string {
 func (*Ping) ProtoMessage() {}
 
 func (x *Ping) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[22]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2906,7 +2978,7 @@ type Envelope struct {
 
 func (x *Envelope) Reset() {
 	*x = Envelope{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[23]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2918,7 +2990,7 @@ func (x *Envelope) String() string {
 func (*Envelope) ProtoMessage() {}
 
 func (x *Envelope) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[23]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3109,6 +3181,15 @@ func (x *Envelope) GetPing() *Ping {
 	return nil
 }
 
+func (x *Envelope) GetSharedDirectoryRemove() *SharedDirectoryRemove {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Payload.(*envelope_SharedDirectoryRemove); ok {
+			return x.SharedDirectoryRemove
+		}
+	}
+	return nil
+}
+
 func (x *Envelope) SetClientHello(v *ClientHello) {
 	if v == nil {
 		x.xxx_hidden_Payload = nil
@@ -3267,6 +3348,14 @@ func (x *Envelope) SetPing(v *Ping) {
 		return
 	}
 	x.xxx_hidden_Payload = &envelope_Ping{v}
+}
+
+func (x *Envelope) SetSharedDirectoryRemove(v *SharedDirectoryRemove) {
+	if v == nil {
+		x.xxx_hidden_Payload = nil
+		return
+	}
+	x.xxx_hidden_Payload = &envelope_SharedDirectoryRemove{v}
 }
 
 func (x *Envelope) HasPayload() bool {
@@ -3436,6 +3525,14 @@ func (x *Envelope) HasPing() bool {
 	return ok
 }
 
+func (x *Envelope) HasSharedDirectoryRemove() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Payload.(*envelope_SharedDirectoryRemove)
+	return ok
+}
+
 func (x *Envelope) ClearPayload() {
 	x.xxx_hidden_Payload = nil
 }
@@ -3560,6 +3657,12 @@ func (x *Envelope) ClearPing() {
 	}
 }
 
+func (x *Envelope) ClearSharedDirectoryRemove() {
+	if _, ok := x.xxx_hidden_Payload.(*envelope_SharedDirectoryRemove); ok {
+		x.xxx_hidden_Payload = nil
+	}
+}
+
 const Envelope_Payload_not_set_case case_Envelope_Payload = 0
 const Envelope_ClientHello_case case_Envelope_Payload = 1
 const Envelope_ServerHello_case case_Envelope_Payload = 2
@@ -3581,6 +3684,7 @@ const Envelope_SharedDirectoryRequest_case case_Envelope_Payload = 17
 const Envelope_SharedDirectoryResponse_case case_Envelope_Payload = 18
 const Envelope_LatencyStats_case case_Envelope_Payload = 19
 const Envelope_Ping_case case_Envelope_Payload = 20
+const Envelope_SharedDirectoryRemove_case case_Envelope_Payload = 21
 
 func (x *Envelope) WhichPayload() case_Envelope_Payload {
 	if x == nil {
@@ -3627,6 +3731,8 @@ func (x *Envelope) WhichPayload() case_Envelope_Payload {
 		return Envelope_LatencyStats_case
 	case *envelope_Ping:
 		return Envelope_Ping_case
+	case *envelope_SharedDirectoryRemove:
+		return Envelope_SharedDirectoryRemove_case
 	default:
 		return Envelope_Payload_not_set_case
 	}
@@ -3656,6 +3762,7 @@ type Envelope_builder struct {
 	SharedDirectoryResponse    *SharedDirectoryResponse
 	LatencyStats               *LatencyStats
 	Ping                       *Ping
+	SharedDirectoryRemove      *SharedDirectoryRemove
 	// -- end of xxx_hidden_Payload
 }
 
@@ -3723,13 +3830,16 @@ func (b0 Envelope_builder) Build() *Envelope {
 	if b.Ping != nil {
 		x.xxx_hidden_Payload = &envelope_Ping{b.Ping}
 	}
+	if b.SharedDirectoryRemove != nil {
+		x.xxx_hidden_Payload = &envelope_SharedDirectoryRemove{b.SharedDirectoryRemove}
+	}
 	return m0
 }
 
 type case_Envelope_Payload protoreflect.FieldNumber
 
 func (x case_Envelope_Payload) String() string {
-	md := file_teleport_desktop_v1_tdpb_proto_msgTypes[23].Descriptor()
+	md := file_teleport_desktop_v1_tdpb_proto_msgTypes[24].Descriptor()
 	if x == 0 {
 		return "not set"
 	}
@@ -3820,6 +3930,10 @@ type envelope_Ping struct {
 	Ping *Ping `protobuf:"bytes,20,opt,name=ping,proto3,oneof"`
 }
 
+type envelope_SharedDirectoryRemove struct {
+	SharedDirectoryRemove *SharedDirectoryRemove `protobuf:"bytes,21,opt,name=shared_directory_remove,json=sharedDirectoryRemove,proto3,oneof"`
+}
+
 func (*envelope_ClientHello) isEnvelope_Payload() {}
 
 func (*envelope_ServerHello) isEnvelope_Payload() {}
@@ -3860,6 +3974,8 @@ func (*envelope_LatencyStats) isEnvelope_Payload() {}
 
 func (*envelope_Ping) isEnvelope_Payload() {}
 
+func (*envelope_SharedDirectoryRemove) isEnvelope_Payload() {}
+
 // Info request.
 type SharedDirectoryRequest_Info struct {
 	state           protoimpl.MessageState `protogen:"opaque.v1"`
@@ -3870,7 +3986,7 @@ type SharedDirectoryRequest_Info struct {
 
 func (x *SharedDirectoryRequest_Info) Reset() {
 	*x = SharedDirectoryRequest_Info{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[24]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3882,7 +3998,7 @@ func (x *SharedDirectoryRequest_Info) String() string {
 func (*SharedDirectoryRequest_Info) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Info) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[24]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3929,7 +4045,7 @@ type SharedDirectoryRequest_Create struct {
 
 func (x *SharedDirectoryRequest_Create) Reset() {
 	*x = SharedDirectoryRequest_Create{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[25]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3941,7 +4057,7 @@ func (x *SharedDirectoryRequest_Create) String() string {
 func (*SharedDirectoryRequest_Create) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Create) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[25]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4000,7 +4116,7 @@ type SharedDirectoryRequest_Delete struct {
 
 func (x *SharedDirectoryRequest_Delete) Reset() {
 	*x = SharedDirectoryRequest_Delete{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[26]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4012,7 +4128,7 @@ func (x *SharedDirectoryRequest_Delete) String() string {
 func (*SharedDirectoryRequest_Delete) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Delete) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[26]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4058,7 +4174,7 @@ type SharedDirectoryRequest_List struct {
 
 func (x *SharedDirectoryRequest_List) Reset() {
 	*x = SharedDirectoryRequest_List{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[27]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4070,7 +4186,7 @@ func (x *SharedDirectoryRequest_List) String() string {
 func (*SharedDirectoryRequest_List) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_List) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[27]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4118,7 +4234,7 @@ type SharedDirectoryRequest_Read struct {
 
 func (x *SharedDirectoryRequest_Read) Reset() {
 	*x = SharedDirectoryRequest_Read{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[28]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4130,7 +4246,7 @@ func (x *SharedDirectoryRequest_Read) String() string {
 func (*SharedDirectoryRequest_Read) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Read) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[28]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4204,7 +4320,7 @@ type SharedDirectoryRequest_Write struct {
 
 func (x *SharedDirectoryRequest_Write) Reset() {
 	*x = SharedDirectoryRequest_Write{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[29]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4216,7 +4332,7 @@ func (x *SharedDirectoryRequest_Write) String() string {
 func (*SharedDirectoryRequest_Write) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Write) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[29]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4292,7 +4408,7 @@ type SharedDirectoryRequest_Move struct {
 
 func (x *SharedDirectoryRequest_Move) Reset() {
 	*x = SharedDirectoryRequest_Move{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[30]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4304,7 +4420,7 @@ func (x *SharedDirectoryRequest_Move) String() string {
 func (*SharedDirectoryRequest_Move) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Move) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[30]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4364,7 +4480,7 @@ type SharedDirectoryRequest_Truncate struct {
 
 func (x *SharedDirectoryRequest_Truncate) Reset() {
 	*x = SharedDirectoryRequest_Truncate{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[31]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4376,7 +4492,7 @@ func (x *SharedDirectoryRequest_Truncate) String() string {
 func (*SharedDirectoryRequest_Truncate) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Truncate) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[31]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4435,7 +4551,7 @@ type SharedDirectoryResponse_Info struct {
 
 func (x *SharedDirectoryResponse_Info) Reset() {
 	*x = SharedDirectoryResponse_Info{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[32]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4447,7 +4563,7 @@ func (x *SharedDirectoryResponse_Info) String() string {
 func (*SharedDirectoryResponse_Info) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Info) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[32]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4504,7 +4620,7 @@ type SharedDirectoryResponse_Create struct {
 
 func (x *SharedDirectoryResponse_Create) Reset() {
 	*x = SharedDirectoryResponse_Create{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[33]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4516,7 +4632,7 @@ func (x *SharedDirectoryResponse_Create) String() string {
 func (*SharedDirectoryResponse_Create) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Create) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[33]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4572,7 +4688,7 @@ type SharedDirectoryResponse_Delete struct {
 
 func (x *SharedDirectoryResponse_Delete) Reset() {
 	*x = SharedDirectoryResponse_Delete{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[34]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4584,7 +4700,7 @@ func (x *SharedDirectoryResponse_Delete) String() string {
 func (*SharedDirectoryResponse_Delete) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Delete) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[34]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4617,7 +4733,7 @@ type SharedDirectoryResponse_List struct {
 
 func (x *SharedDirectoryResponse_List) Reset() {
 	*x = SharedDirectoryResponse_List{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[35]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4629,7 +4745,7 @@ func (x *SharedDirectoryResponse_List) String() string {
 func (*SharedDirectoryResponse_List) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_List) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[35]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4677,7 +4793,7 @@ type SharedDirectoryResponse_Read struct {
 
 func (x *SharedDirectoryResponse_Read) Reset() {
 	*x = SharedDirectoryResponse_Read{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[36]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4689,7 +4805,7 @@ func (x *SharedDirectoryResponse_Read) String() string {
 func (*SharedDirectoryResponse_Read) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Read) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[36]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4738,7 +4854,7 @@ type SharedDirectoryResponse_Write struct {
 
 func (x *SharedDirectoryResponse_Write) Reset() {
 	*x = SharedDirectoryResponse_Write{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[37]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4750,7 +4866,7 @@ func (x *SharedDirectoryResponse_Write) String() string {
 func (*SharedDirectoryResponse_Write) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Write) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[37]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4795,7 +4911,7 @@ type SharedDirectoryResponse_Move struct {
 
 func (x *SharedDirectoryResponse_Move) Reset() {
 	*x = SharedDirectoryResponse_Move{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[38]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4807,7 +4923,7 @@ func (x *SharedDirectoryResponse_Move) String() string {
 func (*SharedDirectoryResponse_Move) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Move) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[38]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4839,7 +4955,7 @@ type SharedDirectoryResponse_Truncate struct {
 
 func (x *SharedDirectoryResponse_Truncate) Reset() {
 	*x = SharedDirectoryResponse_Truncate{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[39]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4851,7 +4967,7 @@ func (x *SharedDirectoryResponse_Truncate) String() string {
 func (*SharedDirectoryResponse_Truncate) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Truncate) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[39]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4883,10 +4999,11 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\busername\x18\x01 \x01(\tR\busername\x12F\n" +
 	"\vscreen_spec\x18\x02 \x01(\v2%.teleport.desktop.v1.ClientScreenSpecR\n" +
 	"screenSpec\x12'\n" +
-	"\x0fkeyboard_layout\x18\x03 \x01(\rR\x0ekeyboardLayout\"\xb6\x01\n" +
+	"\x0fkeyboard_layout\x18\x03 \x01(\rR\x0ekeyboardLayout\"\xf4\x01\n" +
 	"\vServerHello\x12Q\n" +
 	"\x0factivation_spec\x18\x01 \x01(\v2(.teleport.desktop.v1.ConnectionActivatedR\x0eactivationSpec\x12+\n" +
-	"\x11clipboard_enabled\x18\x02 \x01(\bR\x10clipboardEnabled\x12'\n" +
+	"\x11clipboard_enabled\x18\x02 \x01(\bR\x10clipboardEnabled\x12<\n" +
+	"\x1adirectory_remove_supported\x18\x03 \x01(\bR\x18directoryRemoveSupported\x12'\n" +
 	"\x0fhidpi_supported\x18\x05 \x01(\bR\x0ehidpiSupported\"_\n" +
 	"\tRectangle\x12\x12\n" +
 	"\x04left\x18\x01 \x01(\rR\x04left\x12\x10\n" +
@@ -4940,7 +5057,9 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\x17authentication_response\x18\x04 \x01(\v2%.teleport.mfa.v1.AuthenticateResponseR\x16authenticationResponse\"P\n" +
 	"\x17SharedDirectoryAnnounce\x12!\n" +
 	"\fdirectory_id\x18\x01 \x01(\rR\vdirectoryId\x12\x12\n" +
-	"\x04name\x18\x02 \x01(\tR\x04name\"^\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\":\n" +
+	"\x15SharedDirectoryRemove\x12!\n" +
+	"\fdirectory_id\x18\x01 \x01(\rR\vdirectoryId\"^\n" +
 	"\x1aSharedDirectoryAcknowledge\x12!\n" +
 	"\fdirectory_id\x18\x01 \x01(\rR\vdirectoryId\x12\x1d\n" +
 	"\n" +
@@ -5019,7 +5138,7 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\x11client_latency_ms\x18\x01 \x01(\rR\x0fclientLatencyMs\x12*\n" +
 	"\x11server_latency_ms\x18\x02 \x01(\rR\x0fserverLatencyMs\"\x1a\n" +
 	"\x04Ping\x12\x12\n" +
-	"\x04uuid\x18\x01 \x01(\fR\x04uuid\"\x8b\f\n" +
+	"\x04uuid\x18\x01 \x01(\fR\x04uuid\"\xf1\f\n" +
 	"\bEnvelope\x12E\n" +
 	"\fclient_hello\x18\x01 \x01(\v2 .teleport.desktop.v1.ClientHelloH\x00R\vclientHello\x12E\n" +
 	"\fserver_hello\x18\x02 \x01(\v2 .teleport.desktop.v1.ServerHelloH\x00R\vserverHello\x12<\n" +
@@ -5043,7 +5162,8 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\x18shared_directory_request\x18\x11 \x01(\v2+.teleport.desktop.v1.SharedDirectoryRequestH\x00R\x16sharedDirectoryRequest\x12j\n" +
 	"\x19shared_directory_response\x18\x12 \x01(\v2,.teleport.desktop.v1.SharedDirectoryResponseH\x00R\x17sharedDirectoryResponse\x12H\n" +
 	"\rlatency_stats\x18\x13 \x01(\v2!.teleport.desktop.v1.LatencyStatsH\x00R\flatencyStats\x12/\n" +
-	"\x04ping\x18\x14 \x01(\v2\x19.teleport.desktop.v1.PingH\x00R\x04pingB\t\n" +
+	"\x04ping\x18\x14 \x01(\v2\x19.teleport.desktop.v1.PingH\x00R\x04ping\x12d\n" +
+	"\x17shared_directory_remove\x18\x15 \x01(\v2*.teleport.desktop.v1.SharedDirectoryRemoveH\x00R\x15sharedDirectoryRemoveB\t\n" +
 	"\apayload*\x8b\x01\n" +
 	"\x0fMouseButtonType\x12!\n" +
 	"\x1dMOUSE_BUTTON_TYPE_UNSPECIFIED\x10\x00\x12\x1a\n" +
@@ -5065,7 +5185,7 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\fMFA_TYPE_U2F\x10\x02BOZMgithub.com/gravitational/teleport/api/gen/proto/go/teleport/desktop/v1;tdpbv1b\x06proto3"
 
 var file_teleport_desktop_v1_tdpb_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_teleport_desktop_v1_tdpb_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
+var file_teleport_desktop_v1_tdpb_proto_msgTypes = make([]protoimpl.MessageInfo, 41)
 var file_teleport_desktop_v1_tdpb_proto_goTypes = []any{
 	(MouseButtonType)(0),                     // 0: teleport.desktop.v1.MouseButtonType
 	(AlertSeverity)(0),                       // 1: teleport.desktop.v1.AlertSeverity
@@ -5088,31 +5208,32 @@ var file_teleport_desktop_v1_tdpb_proto_goTypes = []any{
 	(*ClipboardData)(nil),                    // 18: teleport.desktop.v1.ClipboardData
 	(*MFA)(nil),                              // 19: teleport.desktop.v1.MFA
 	(*SharedDirectoryAnnounce)(nil),          // 20: teleport.desktop.v1.SharedDirectoryAnnounce
-	(*SharedDirectoryAcknowledge)(nil),       // 21: teleport.desktop.v1.SharedDirectoryAcknowledge
-	(*SharedDirectoryRequest)(nil),           // 22: teleport.desktop.v1.SharedDirectoryRequest
-	(*SharedDirectoryResponse)(nil),          // 23: teleport.desktop.v1.SharedDirectoryResponse
-	(*FileSystemObject)(nil),                 // 24: teleport.desktop.v1.FileSystemObject
-	(*LatencyStats)(nil),                     // 25: teleport.desktop.v1.LatencyStats
-	(*Ping)(nil),                             // 26: teleport.desktop.v1.Ping
-	(*Envelope)(nil),                         // 27: teleport.desktop.v1.Envelope
-	(*SharedDirectoryRequest_Info)(nil),      // 28: teleport.desktop.v1.SharedDirectoryRequest.Info
-	(*SharedDirectoryRequest_Create)(nil),    // 29: teleport.desktop.v1.SharedDirectoryRequest.Create
-	(*SharedDirectoryRequest_Delete)(nil),    // 30: teleport.desktop.v1.SharedDirectoryRequest.Delete
-	(*SharedDirectoryRequest_List)(nil),      // 31: teleport.desktop.v1.SharedDirectoryRequest.List
-	(*SharedDirectoryRequest_Read)(nil),      // 32: teleport.desktop.v1.SharedDirectoryRequest.Read
-	(*SharedDirectoryRequest_Write)(nil),     // 33: teleport.desktop.v1.SharedDirectoryRequest.Write
-	(*SharedDirectoryRequest_Move)(nil),      // 34: teleport.desktop.v1.SharedDirectoryRequest.Move
-	(*SharedDirectoryRequest_Truncate)(nil),  // 35: teleport.desktop.v1.SharedDirectoryRequest.Truncate
-	(*SharedDirectoryResponse_Info)(nil),     // 36: teleport.desktop.v1.SharedDirectoryResponse.Info
-	(*SharedDirectoryResponse_Create)(nil),   // 37: teleport.desktop.v1.SharedDirectoryResponse.Create
-	(*SharedDirectoryResponse_Delete)(nil),   // 38: teleport.desktop.v1.SharedDirectoryResponse.Delete
-	(*SharedDirectoryResponse_List)(nil),     // 39: teleport.desktop.v1.SharedDirectoryResponse.List
-	(*SharedDirectoryResponse_Read)(nil),     // 40: teleport.desktop.v1.SharedDirectoryResponse.Read
-	(*SharedDirectoryResponse_Write)(nil),    // 41: teleport.desktop.v1.SharedDirectoryResponse.Write
-	(*SharedDirectoryResponse_Move)(nil),     // 42: teleport.desktop.v1.SharedDirectoryResponse.Move
-	(*SharedDirectoryResponse_Truncate)(nil), // 43: teleport.desktop.v1.SharedDirectoryResponse.Truncate
-	(*v1.AuthenticateChallenge)(nil),         // 44: teleport.mfa.v1.AuthenticateChallenge
-	(*v1.AuthenticateResponse)(nil),          // 45: teleport.mfa.v1.AuthenticateResponse
+	(*SharedDirectoryRemove)(nil),            // 21: teleport.desktop.v1.SharedDirectoryRemove
+	(*SharedDirectoryAcknowledge)(nil),       // 22: teleport.desktop.v1.SharedDirectoryAcknowledge
+	(*SharedDirectoryRequest)(nil),           // 23: teleport.desktop.v1.SharedDirectoryRequest
+	(*SharedDirectoryResponse)(nil),          // 24: teleport.desktop.v1.SharedDirectoryResponse
+	(*FileSystemObject)(nil),                 // 25: teleport.desktop.v1.FileSystemObject
+	(*LatencyStats)(nil),                     // 26: teleport.desktop.v1.LatencyStats
+	(*Ping)(nil),                             // 27: teleport.desktop.v1.Ping
+	(*Envelope)(nil),                         // 28: teleport.desktop.v1.Envelope
+	(*SharedDirectoryRequest_Info)(nil),      // 29: teleport.desktop.v1.SharedDirectoryRequest.Info
+	(*SharedDirectoryRequest_Create)(nil),    // 30: teleport.desktop.v1.SharedDirectoryRequest.Create
+	(*SharedDirectoryRequest_Delete)(nil),    // 31: teleport.desktop.v1.SharedDirectoryRequest.Delete
+	(*SharedDirectoryRequest_List)(nil),      // 32: teleport.desktop.v1.SharedDirectoryRequest.List
+	(*SharedDirectoryRequest_Read)(nil),      // 33: teleport.desktop.v1.SharedDirectoryRequest.Read
+	(*SharedDirectoryRequest_Write)(nil),     // 34: teleport.desktop.v1.SharedDirectoryRequest.Write
+	(*SharedDirectoryRequest_Move)(nil),      // 35: teleport.desktop.v1.SharedDirectoryRequest.Move
+	(*SharedDirectoryRequest_Truncate)(nil),  // 36: teleport.desktop.v1.SharedDirectoryRequest.Truncate
+	(*SharedDirectoryResponse_Info)(nil),     // 37: teleport.desktop.v1.SharedDirectoryResponse.Info
+	(*SharedDirectoryResponse_Create)(nil),   // 38: teleport.desktop.v1.SharedDirectoryResponse.Create
+	(*SharedDirectoryResponse_Delete)(nil),   // 39: teleport.desktop.v1.SharedDirectoryResponse.Delete
+	(*SharedDirectoryResponse_List)(nil),     // 40: teleport.desktop.v1.SharedDirectoryResponse.List
+	(*SharedDirectoryResponse_Read)(nil),     // 41: teleport.desktop.v1.SharedDirectoryResponse.Read
+	(*SharedDirectoryResponse_Write)(nil),    // 42: teleport.desktop.v1.SharedDirectoryResponse.Write
+	(*SharedDirectoryResponse_Move)(nil),     // 43: teleport.desktop.v1.SharedDirectoryResponse.Move
+	(*SharedDirectoryResponse_Truncate)(nil), // 44: teleport.desktop.v1.SharedDirectoryResponse.Truncate
+	(*v1.AuthenticateChallenge)(nil),         // 45: teleport.mfa.v1.AuthenticateChallenge
+	(*v1.AuthenticateResponse)(nil),          // 46: teleport.mfa.v1.AuthenticateResponse
 }
 var file_teleport_desktop_v1_tdpb_proto_depIdxs = []int32{
 	15, // 0: teleport.desktop.v1.ClientHello.screen_spec:type_name -> teleport.desktop.v1.ClientScreenSpec
@@ -5122,24 +5243,24 @@ var file_teleport_desktop_v1_tdpb_proto_depIdxs = []int32{
 	1,  // 4: teleport.desktop.v1.Alert.severity:type_name -> teleport.desktop.v1.AlertSeverity
 	2,  // 5: teleport.desktop.v1.MouseWheel.axis:type_name -> teleport.desktop.v1.MouseWheelAxis
 	3,  // 6: teleport.desktop.v1.MFA.type:type_name -> teleport.desktop.v1.MFAType
-	44, // 7: teleport.desktop.v1.MFA.challenge:type_name -> teleport.mfa.v1.AuthenticateChallenge
-	45, // 8: teleport.desktop.v1.MFA.authentication_response:type_name -> teleport.mfa.v1.AuthenticateResponse
-	28, // 9: teleport.desktop.v1.SharedDirectoryRequest.info:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Info
-	29, // 10: teleport.desktop.v1.SharedDirectoryRequest.create:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Create
-	30, // 11: teleport.desktop.v1.SharedDirectoryRequest.delete:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Delete
-	31, // 12: teleport.desktop.v1.SharedDirectoryRequest.list:type_name -> teleport.desktop.v1.SharedDirectoryRequest.List
-	32, // 13: teleport.desktop.v1.SharedDirectoryRequest.read:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Read
-	33, // 14: teleport.desktop.v1.SharedDirectoryRequest.write:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Write
-	34, // 15: teleport.desktop.v1.SharedDirectoryRequest.move:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Move
-	35, // 16: teleport.desktop.v1.SharedDirectoryRequest.truncate:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Truncate
-	36, // 17: teleport.desktop.v1.SharedDirectoryResponse.info:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Info
-	37, // 18: teleport.desktop.v1.SharedDirectoryResponse.create:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Create
-	38, // 19: teleport.desktop.v1.SharedDirectoryResponse.delete:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Delete
-	39, // 20: teleport.desktop.v1.SharedDirectoryResponse.list:type_name -> teleport.desktop.v1.SharedDirectoryResponse.List
-	40, // 21: teleport.desktop.v1.SharedDirectoryResponse.read:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Read
-	41, // 22: teleport.desktop.v1.SharedDirectoryResponse.write:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Write
-	42, // 23: teleport.desktop.v1.SharedDirectoryResponse.move:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Move
-	43, // 24: teleport.desktop.v1.SharedDirectoryResponse.truncate:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Truncate
+	45, // 7: teleport.desktop.v1.MFA.challenge:type_name -> teleport.mfa.v1.AuthenticateChallenge
+	46, // 8: teleport.desktop.v1.MFA.authentication_response:type_name -> teleport.mfa.v1.AuthenticateResponse
+	29, // 9: teleport.desktop.v1.SharedDirectoryRequest.info:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Info
+	30, // 10: teleport.desktop.v1.SharedDirectoryRequest.create:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Create
+	31, // 11: teleport.desktop.v1.SharedDirectoryRequest.delete:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Delete
+	32, // 12: teleport.desktop.v1.SharedDirectoryRequest.list:type_name -> teleport.desktop.v1.SharedDirectoryRequest.List
+	33, // 13: teleport.desktop.v1.SharedDirectoryRequest.read:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Read
+	34, // 14: teleport.desktop.v1.SharedDirectoryRequest.write:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Write
+	35, // 15: teleport.desktop.v1.SharedDirectoryRequest.move:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Move
+	36, // 16: teleport.desktop.v1.SharedDirectoryRequest.truncate:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Truncate
+	37, // 17: teleport.desktop.v1.SharedDirectoryResponse.info:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Info
+	38, // 18: teleport.desktop.v1.SharedDirectoryResponse.create:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Create
+	39, // 19: teleport.desktop.v1.SharedDirectoryResponse.delete:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Delete
+	40, // 20: teleport.desktop.v1.SharedDirectoryResponse.list:type_name -> teleport.desktop.v1.SharedDirectoryResponse.List
+	41, // 21: teleport.desktop.v1.SharedDirectoryResponse.read:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Read
+	42, // 22: teleport.desktop.v1.SharedDirectoryResponse.write:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Write
+	43, // 23: teleport.desktop.v1.SharedDirectoryResponse.move:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Move
+	44, // 24: teleport.desktop.v1.SharedDirectoryResponse.truncate:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Truncate
 	4,  // 25: teleport.desktop.v1.Envelope.client_hello:type_name -> teleport.desktop.v1.ClientHello
 	5,  // 26: teleport.desktop.v1.Envelope.server_hello:type_name -> teleport.desktop.v1.ServerHello
 	7,  // 27: teleport.desktop.v1.Envelope.png_frame:type_name -> teleport.desktop.v1.PNGFrame
@@ -5155,19 +5276,20 @@ var file_teleport_desktop_v1_tdpb_proto_depIdxs = []int32{
 	18, // 37: teleport.desktop.v1.Envelope.clipboard_data:type_name -> teleport.desktop.v1.ClipboardData
 	19, // 38: teleport.desktop.v1.Envelope.mfa:type_name -> teleport.desktop.v1.MFA
 	20, // 39: teleport.desktop.v1.Envelope.shared_directory_announce:type_name -> teleport.desktop.v1.SharedDirectoryAnnounce
-	21, // 40: teleport.desktop.v1.Envelope.shared_directory_acknowledge:type_name -> teleport.desktop.v1.SharedDirectoryAcknowledge
-	22, // 41: teleport.desktop.v1.Envelope.shared_directory_request:type_name -> teleport.desktop.v1.SharedDirectoryRequest
-	23, // 42: teleport.desktop.v1.Envelope.shared_directory_response:type_name -> teleport.desktop.v1.SharedDirectoryResponse
-	25, // 43: teleport.desktop.v1.Envelope.latency_stats:type_name -> teleport.desktop.v1.LatencyStats
-	26, // 44: teleport.desktop.v1.Envelope.ping:type_name -> teleport.desktop.v1.Ping
-	24, // 45: teleport.desktop.v1.SharedDirectoryResponse.Info.fso:type_name -> teleport.desktop.v1.FileSystemObject
-	24, // 46: teleport.desktop.v1.SharedDirectoryResponse.Create.fso:type_name -> teleport.desktop.v1.FileSystemObject
-	24, // 47: teleport.desktop.v1.SharedDirectoryResponse.List.fso_list:type_name -> teleport.desktop.v1.FileSystemObject
-	48, // [48:48] is the sub-list for method output_type
-	48, // [48:48] is the sub-list for method input_type
-	48, // [48:48] is the sub-list for extension type_name
-	48, // [48:48] is the sub-list for extension extendee
-	0,  // [0:48] is the sub-list for field type_name
+	22, // 40: teleport.desktop.v1.Envelope.shared_directory_acknowledge:type_name -> teleport.desktop.v1.SharedDirectoryAcknowledge
+	23, // 41: teleport.desktop.v1.Envelope.shared_directory_request:type_name -> teleport.desktop.v1.SharedDirectoryRequest
+	24, // 42: teleport.desktop.v1.Envelope.shared_directory_response:type_name -> teleport.desktop.v1.SharedDirectoryResponse
+	26, // 43: teleport.desktop.v1.Envelope.latency_stats:type_name -> teleport.desktop.v1.LatencyStats
+	27, // 44: teleport.desktop.v1.Envelope.ping:type_name -> teleport.desktop.v1.Ping
+	21, // 45: teleport.desktop.v1.Envelope.shared_directory_remove:type_name -> teleport.desktop.v1.SharedDirectoryRemove
+	25, // 46: teleport.desktop.v1.SharedDirectoryResponse.Info.fso:type_name -> teleport.desktop.v1.FileSystemObject
+	25, // 47: teleport.desktop.v1.SharedDirectoryResponse.Create.fso:type_name -> teleport.desktop.v1.FileSystemObject
+	25, // 48: teleport.desktop.v1.SharedDirectoryResponse.List.fso_list:type_name -> teleport.desktop.v1.FileSystemObject
+	49, // [49:49] is the sub-list for method output_type
+	49, // [49:49] is the sub-list for method input_type
+	49, // [49:49] is the sub-list for extension type_name
+	49, // [49:49] is the sub-list for extension extendee
+	0,  // [0:49] is the sub-list for field type_name
 }
 
 func init() { file_teleport_desktop_v1_tdpb_proto_init() }
@@ -5175,7 +5297,7 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 	if File_teleport_desktop_v1_tdpb_proto != nil {
 		return
 	}
-	file_teleport_desktop_v1_tdpb_proto_msgTypes[18].OneofWrappers = []any{
+	file_teleport_desktop_v1_tdpb_proto_msgTypes[19].OneofWrappers = []any{
 		(*sharedDirectoryRequest_Info_)(nil),
 		(*sharedDirectoryRequest_Create_)(nil),
 		(*sharedDirectoryRequest_Delete_)(nil),
@@ -5185,7 +5307,7 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 		(*sharedDirectoryRequest_Move_)(nil),
 		(*sharedDirectoryRequest_Truncate_)(nil),
 	}
-	file_teleport_desktop_v1_tdpb_proto_msgTypes[19].OneofWrappers = []any{
+	file_teleport_desktop_v1_tdpb_proto_msgTypes[20].OneofWrappers = []any{
 		(*sharedDirectoryResponse_Info_)(nil),
 		(*sharedDirectoryResponse_Create_)(nil),
 		(*sharedDirectoryResponse_Delete_)(nil),
@@ -5195,7 +5317,7 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 		(*sharedDirectoryResponse_Move_)(nil),
 		(*sharedDirectoryResponse_Truncate_)(nil),
 	}
-	file_teleport_desktop_v1_tdpb_proto_msgTypes[23].OneofWrappers = []any{
+	file_teleport_desktop_v1_tdpb_proto_msgTypes[24].OneofWrappers = []any{
 		(*envelope_ClientHello)(nil),
 		(*envelope_ServerHello)(nil),
 		(*envelope_PngFrame)(nil),
@@ -5216,6 +5338,7 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 		(*envelope_SharedDirectoryResponse)(nil),
 		(*envelope_LatencyStats)(nil),
 		(*envelope_Ping)(nil),
+		(*envelope_SharedDirectoryRemove)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -5223,7 +5346,7 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_desktop_v1_tdpb_proto_rawDesc), len(file_teleport_desktop_v1_tdpb_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   40,
+			NumMessages:   41,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/desktop/v1/tdpb.proto
+++ b/api/proto/teleport/desktop/v1/tdpb.proto
@@ -36,6 +36,7 @@ message ClientHello {
 message ServerHello {
   ConnectionActivated activation_spec = 1;
   bool clipboard_enabled = 2;
+  bool directory_remove_supported = 3;
   // Field number 5 matches master. v18 doesn't use fields 3 and 4
   // (directory_remove_supported and sessions on master).
   bool hidpi_supported = 5;
@@ -173,6 +174,11 @@ message MFA {
 message SharedDirectoryAnnounce {
   uint32 directory_id = 1;
   string name = 2;
+}
+
+// Sent by client to remove a previously announced shared directory.
+message SharedDirectoryRemove {
+  uint32 directory_id = 1;
 }
 
 // Sent by server to acknowledge a new shared directory.
@@ -348,5 +354,6 @@ message Envelope {
     SharedDirectoryResponse shared_directory_response = 18;
     LatencyStats latency_stats = 19;
     Ping ping = 20;
+    SharedDirectoryRemove shared_directory_remove = 21;
   }
 }

--- a/gen/proto/ts/teleport/desktop/v1/tdpb_pb.ts
+++ b/gen/proto/ts/teleport/desktop/v1/tdpb_pb.ts
@@ -66,6 +66,10 @@ export interface ServerHello {
      */
     clipboardEnabled: boolean;
     /**
+     * @generated from protobuf field: bool directory_remove_supported = 3;
+     */
+    directoryRemoveSupported: boolean;
+    /**
      * Field number 5 matches master. v18 doesn't use fields 3 and 4
      * (directory_remove_supported and sessions on master).
      *
@@ -330,6 +334,17 @@ export interface SharedDirectoryAnnounce {
      * @generated from protobuf field: string name = 2;
      */
     name: string;
+}
+/**
+ * Sent by client to remove a previously announced shared directory.
+ *
+ * @generated from protobuf message teleport.desktop.v1.SharedDirectoryRemove
+ */
+export interface SharedDirectoryRemove {
+    /**
+     * @generated from protobuf field: uint32 directory_id = 1;
+     */
+    directoryId: number;
 }
 /**
  * Sent by server to acknowledge a new shared directory.
@@ -866,6 +881,12 @@ export interface Envelope {
          */
         ping: Ping;
     } | {
+        oneofKind: "sharedDirectoryRemove";
+        /**
+         * @generated from protobuf field: teleport.desktop.v1.SharedDirectoryRemove shared_directory_remove = 21;
+         */
+        sharedDirectoryRemove: SharedDirectoryRemove;
+    } | {
         oneofKind: undefined;
     };
 }
@@ -1021,12 +1042,14 @@ class ServerHello$Type extends MessageType<ServerHello> {
         super("teleport.desktop.v1.ServerHello", [
             { no: 1, name: "activation_spec", kind: "message", T: () => ConnectionActivated },
             { no: 2, name: "clipboard_enabled", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 3, name: "directory_remove_supported", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
             { no: 5, name: "hidpi_supported", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
     create(value?: PartialMessage<ServerHello>): ServerHello {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.clipboardEnabled = false;
+        message.directoryRemoveSupported = false;
         message.hidpiSupported = false;
         if (value !== undefined)
             reflectionMergePartial<ServerHello>(this, message, value);
@@ -1042,6 +1065,9 @@ class ServerHello$Type extends MessageType<ServerHello> {
                     break;
                 case /* bool clipboard_enabled */ 2:
                     message.clipboardEnabled = reader.bool();
+                    break;
+                case /* bool directory_remove_supported */ 3:
+                    message.directoryRemoveSupported = reader.bool();
                     break;
                 case /* bool hidpi_supported */ 5:
                     message.hidpiSupported = reader.bool();
@@ -1064,6 +1090,9 @@ class ServerHello$Type extends MessageType<ServerHello> {
         /* bool clipboard_enabled = 2; */
         if (message.clipboardEnabled !== false)
             writer.tag(2, WireType.Varint).bool(message.clipboardEnabled);
+        /* bool directory_remove_supported = 3; */
+        if (message.directoryRemoveSupported !== false)
+            writer.tag(3, WireType.Varint).bool(message.directoryRemoveSupported);
         /* bool hidpi_supported = 5; */
         if (message.hidpiSupported !== false)
             writer.tag(5, WireType.Varint).bool(message.hidpiSupported);
@@ -1947,6 +1976,53 @@ class SharedDirectoryAnnounce$Type extends MessageType<SharedDirectoryAnnounce> 
  * @generated MessageType for protobuf message teleport.desktop.v1.SharedDirectoryAnnounce
  */
 export const SharedDirectoryAnnounce = new SharedDirectoryAnnounce$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class SharedDirectoryRemove$Type extends MessageType<SharedDirectoryRemove> {
+    constructor() {
+        super("teleport.desktop.v1.SharedDirectoryRemove", [
+            { no: 1, name: "directory_id", kind: "scalar", T: 13 /*ScalarType.UINT32*/ }
+        ]);
+    }
+    create(value?: PartialMessage<SharedDirectoryRemove>): SharedDirectoryRemove {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.directoryId = 0;
+        if (value !== undefined)
+            reflectionMergePartial<SharedDirectoryRemove>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SharedDirectoryRemove): SharedDirectoryRemove {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* uint32 directory_id */ 1:
+                    message.directoryId = reader.uint32();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: SharedDirectoryRemove, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* uint32 directory_id = 1; */
+        if (message.directoryId !== 0)
+            writer.tag(1, WireType.Varint).uint32(message.directoryId);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.desktop.v1.SharedDirectoryRemove
+ */
+export const SharedDirectoryRemove = new SharedDirectoryRemove$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class SharedDirectoryAcknowledge$Type extends MessageType<SharedDirectoryAcknowledge> {
     constructor() {
@@ -3218,7 +3294,8 @@ class Envelope$Type extends MessageType<Envelope> {
             { no: 17, name: "shared_directory_request", kind: "message", oneof: "payload", T: () => SharedDirectoryRequest },
             { no: 18, name: "shared_directory_response", kind: "message", oneof: "payload", T: () => SharedDirectoryResponse },
             { no: 19, name: "latency_stats", kind: "message", oneof: "payload", T: () => LatencyStats },
-            { no: 20, name: "ping", kind: "message", oneof: "payload", T: () => Ping }
+            { no: 20, name: "ping", kind: "message", oneof: "payload", T: () => Ping },
+            { no: 21, name: "shared_directory_remove", kind: "message", oneof: "payload", T: () => SharedDirectoryRemove }
         ]);
     }
     create(value?: PartialMessage<Envelope>): Envelope {
@@ -3353,6 +3430,12 @@ class Envelope$Type extends MessageType<Envelope> {
                         ping: Ping.internalBinaryRead(reader, reader.uint32(), options, (message.payload as any).ping)
                     };
                     break;
+                case /* teleport.desktop.v1.SharedDirectoryRemove shared_directory_remove */ 21:
+                    message.payload = {
+                        oneofKind: "sharedDirectoryRemove",
+                        sharedDirectoryRemove: SharedDirectoryRemove.internalBinaryRead(reader, reader.uint32(), options, (message.payload as any).sharedDirectoryRemove)
+                    };
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -3425,6 +3508,9 @@ class Envelope$Type extends MessageType<Envelope> {
         /* teleport.desktop.v1.Ping ping = 20; */
         if (message.payload.oneofKind === "ping")
             Ping.internalBinaryWrite(message.payload.ping, writer.tag(20, WireType.LengthDelimited).fork(), options).join();
+        /* teleport.desktop.v1.SharedDirectoryRemove shared_directory_remove = 21; */
+        if (message.payload.oneofKind === "sharedDirectoryRemove")
+            SharedDirectoryRemove.internalBinaryWrite(message.payload.sharedDirectoryRemove, writer.tag(21, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -578,7 +578,7 @@ func (c *Client) startInputStreaming(stopCh chan struct{}) error {
 		// file transfer.
 		switch msg.(type) {
 		case *tdpb.KeyboardButton, *tdpb.MouseMove, *tdpb.MouseButton, *tdpb.MouseWheel,
-			*tdpb.SharedDirectoryAnnounce, *tdpb.SharedDirectoryResponse:
+			*tdpb.SharedDirectoryAnnounce, *tdpb.SharedDirectoryRemove, *tdpb.SharedDirectoryResponse:
 
 			c.UpdateClientActivity()
 		}
@@ -733,6 +733,14 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 				name:         driveName,
 			}); errCode != C.ErrCodeSuccess {
 				return trace.Errorf("SharedDirectoryAnnounce: failed with %v", errCode)
+			}
+		}
+	case *tdpb.SharedDirectoryRemove:
+		if c.cfg.AllowDirectorySharing {
+			if errCode := C.client_handle_tdp_sd_remove(C.uintptr_t(c.handle), C.CGOSharedDirectoryRemove{
+				directory_id: C.uint32_t(m.DirectoryId),
+			}); errCode != C.ErrCodeSuccess {
+				return trace.Errorf("SharedDirectoryRemove: failed with %v", errCode)
 			}
 		}
 	case *tdpb.SharedDirectoryResponse:
@@ -1059,8 +1067,9 @@ func (c *Client) handleRDPConnectionActivated(ioChannelID, userChannelID, screen
 			ScreenWidth:   uint32(screenWidth),
 			ScreenHeight:  uint32(screenHeight),
 		},
-		ClipboardEnabled: true,
-		HidpiSupported:   true,
+		ClipboardEnabled:         true,
+		HidpiSupported:           true,
+		DirectoryRemoveSupported: true,
 	}); err != nil {
 		c.cfg.Logger.ErrorContext(context.Background(), "failed handling connection initialization", "error", err)
 		return C.ErrCodeFailure

--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -52,7 +52,7 @@ use ironrdp_pdu::rdp::client_info::{PerformanceFlags, TimezoneInfo};
 use ironrdp_pdu::PduError;
 use ironrdp_pdu::PduResult;
 use ironrdp_pdu::{encode_err, pdu_other_err};
-use ironrdp_rdpdr::pdu::efs::ClientDeviceListAnnounce;
+use ironrdp_rdpdr::pdu::efs::{ClientDeviceListAnnounce, ClientDeviceListRemove};
 use ironrdp_rdpdr::pdu::RdpdrPdu;
 use ironrdp_rdpdr::Rdpdr;
 use ironrdp_rdpsnd::client::{NoopRdpsndBackend, Rdpsnd};
@@ -61,7 +61,7 @@ use ironrdp_session::SessionErrorKind::Reason;
 use ironrdp_session::{reason_err, SessionError, SessionResult};
 use ironrdp_svc::{SvcMessage, SvcProcessor, SvcProcessorMessages};
 use ironrdp_tokio::{single_sequence_step_read, Framed, FramedWrite, TokioStream};
-use log::{debug, error};
+use log::{debug, error, warn};
 use rand::{Rng, TryRngCore};
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
@@ -477,6 +477,10 @@ impl Client {
                     Client::handle_tdp_sd_announce(&mut write_stream, x224_processor.clone(), sda)
                         .await?;
                 }
+                ClientFunction::HandleTdpSdRemove(sdr) => {
+                    Client::handle_tdp_sd_remove(&mut write_stream, x224_processor.clone(), sdr)
+                        .await?;
+                }
                 ClientFunction::HandleTdpSdInfoResponse(res) => {
                     Client::handle_tdp_sd_info_response(x224_processor.clone(), res).await?;
                 }
@@ -831,6 +835,32 @@ impl Client {
         Ok(())
     }
 
+    async fn handle_tdp_sd_remove(
+        write_stream: &mut RdpWriteStream,
+        x224_processor: Arc<Mutex<x224::Processor>>,
+        sdr: tdp::SharedDirectoryRemove,
+    ) -> ClientResult<()> {
+        debug!("received tdp: {:?}", sdr);
+        let pdu = Self::remove_drive(x224_processor.clone(), sdr.directory_id).await;
+
+        match pdu {
+            Ok(remove) => {
+                Self::write_rdpdr(
+                    write_stream,
+                    x224_processor,
+                    RdpdrPdu::ClientDeviceListRemove(remove),
+                )
+                .await?;
+                Ok(())
+            }
+            Err(ClientError::UnknownDevice(id)) => {
+                warn!("attempted to remove unknown device id: {:?}", id);
+                Ok(())
+            }
+            Err(other) => Err(other),
+        }
+    }
+
     async fn handle_tdp_sd_info_response(
         x224_processor: Arc<Mutex<x224::Processor>>,
         res: tdp::SharedDirectoryInfoResponse,
@@ -952,6 +982,21 @@ impl Client {
             let rdpdr = Self::get_svc_processor_mut::<Rdpdr>(&mut x224_processor)?;
             let pdu = rdpdr.add_drive(sda.directory_id, sda.name);
             Ok(pdu)
+        })
+        .await?
+    }
+
+    async fn remove_drive(
+        x224_processor: Arc<Mutex<x224::Processor>>,
+        device_id: u32,
+    ) -> ClientResult<ClientDeviceListRemove> {
+        task::spawn_blocking(move || {
+            let mut x224_processor = Self::x224_lock(&x224_processor)?;
+            let rdpdr = Self::get_svc_processor_mut::<Rdpdr>(&mut x224_processor)?;
+            if let Some(pdu) = rdpdr.remove_device(device_id) {
+                return Ok(pdu);
+            }
+            Err(ClientError::UnknownDevice(device_id))
         })
         .await?
     }
@@ -1092,6 +1137,8 @@ enum ClientFunction {
     WriteScreenResize(u32, u32, u32),
     /// Corresponds to [`Client::handle_tdp_sd_announce`]
     HandleTdpSdAnnounce(tdp::SharedDirectoryAnnounce),
+    /// Corresponds to [`Client::handle_tdp_sd_remove`]
+    HandleTdpSdRemove(tdp::SharedDirectoryRemove),
     /// Corresponds to [`Client::handle_tdp_sd_info_response`]
     HandleTdpSdInfoResponse(tdp::SharedDirectoryInfoResponse),
     /// Corresponds to [`Client::handle_tdp_sd_create_response`]
@@ -1186,6 +1233,10 @@ impl ClientHandle {
 
     pub fn handle_tdp_sd_announce(&self, sda: tdp::SharedDirectoryAnnounce) -> ClientResult<()> {
         self.blocking_send(ClientFunction::HandleTdpSdAnnounce(sda))
+    }
+
+    pub fn handle_tdp_sd_remove(&self, sda: tdp::SharedDirectoryRemove) -> ClientResult<()> {
+        self.blocking_send(ClientFunction::HandleTdpSdRemove(sda))
     }
 
     pub async fn handle_tdp_sd_announce_async(
@@ -1500,6 +1551,7 @@ pub enum ClientError {
     JoinError(JoinError),
     InternalError(String),
     UnknownAddress,
+    UnknownDevice(u32),
     UrlError(url::ParseError),
     #[cfg(feature = "fips")]
     ErrorStack(ErrorStack),
@@ -1541,6 +1593,7 @@ impl Display for ClientError {
             ClientError::EncodeError(e) => Display::fmt(e, f),
             ClientError::PduError(e) => Display::fmt(e, f),
             ClientError::UrlError(e) => Display::fmt(e, f),
+            ClientError::UnknownDevice(e) => Display::fmt(e, f),
             #[cfg(feature = "fips")]
             ClientError::ErrorStack(e) => Display::fmt(e, f),
             #[cfg(feature = "fips")]

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -34,8 +34,8 @@ use rdpdr::path::UnixPath;
 use rdpdr::tdp::{
     FileSystemObject, FileType, SharedDirectoryAcknowledge, SharedDirectoryCreateResponse,
     SharedDirectoryDeleteResponse, SharedDirectoryInfoResponse, SharedDirectoryListResponse,
-    SharedDirectoryMoveResponse, SharedDirectoryReadResponse, SharedDirectoryTruncateResponse,
-    SharedDirectoryWriteResponse, TdpErrCode,
+    SharedDirectoryMoveResponse, SharedDirectoryReadResponse, SharedDirectoryRemove,
+    SharedDirectoryTruncateResponse, SharedDirectoryWriteResponse, TdpErrCode,
 };
 use std::ffi::CString;
 use std::fmt::Debug;
@@ -254,6 +254,26 @@ pub unsafe extern "C" fn client_handle_tdp_sd_announce(
         cgo_handle,
         "client_handle_tdp_sd_announce",
         move |client_handle| client_handle.handle_tdp_sd_announce(sd_announce),
+    )
+}
+
+/// client_handle_tdp_sd_remove removes a drive that has been redirected over RDP
+///
+///
+/// # Safety
+///
+/// `cgo_handle` must be a valid handle.
+///
+#[no_mangle]
+pub unsafe extern "C" fn client_handle_tdp_sd_remove(
+    cgo_handle: CgoHandle,
+    sd_remove: CGOSharedDirectoryRemove,
+) -> CGOErrCode {
+    let sd_remove = SharedDirectoryRemove::from(sd_remove);
+    handle_operation(
+        cgo_handle,
+        "client_handle_tdp_sd_remove",
+        move |client_handle| client_handle.handle_tdp_sd_remove(sd_remove),
     )
 }
 
@@ -603,6 +623,11 @@ pub struct CGOSharedDirectoryAnnounce {
 }
 
 pub type CGOSharedDirectoryAcknowledge = SharedDirectoryAcknowledge;
+
+#[repr(C)]
+pub struct CGOSharedDirectoryRemove {
+    pub directory_id: u32,
+}
 
 #[repr(C)]
 pub struct CGOSharedDirectoryInfoRequest {

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/tdp.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/tdp.rs
@@ -21,7 +21,7 @@ use crate::{
     CGOSharedDirectoryAnnounce, CGOSharedDirectoryCreateRequest, CGOSharedDirectoryCreateResponse,
     CGOSharedDirectoryDeleteRequest, CGOSharedDirectoryInfoRequest, CGOSharedDirectoryInfoResponse,
     CGOSharedDirectoryListRequest, CGOSharedDirectoryListResponse, CGOSharedDirectoryMoveRequest,
-    CGOSharedDirectoryReadRequest, CGOSharedDirectoryReadResponse,
+    CGOSharedDirectoryReadRequest, CGOSharedDirectoryReadResponse, CGOSharedDirectoryRemove,
     CGOSharedDirectoryTruncateRequest, CGOSharedDirectoryWriteRequest,
 };
 
@@ -53,6 +53,21 @@ impl From<CGOSharedDirectoryAnnounce> for SharedDirectoryAnnounce {
                 directory_id: cgo.directory_id,
                 name: from_c_string(cgo.name),
             }
+        }
+    }
+}
+
+/// SharedDirectoryAnnounce is sent by the TDP client to the server
+/// to announce a new directory to be shared over TDP.
+#[derive(Debug)]
+pub struct SharedDirectoryRemove {
+    pub directory_id: u32,
+}
+
+impl From<CGOSharedDirectoryRemove> for SharedDirectoryRemove {
+    fn from(cgo: CGOSharedDirectoryRemove) -> SharedDirectoryRemove {
+        SharedDirectoryRemove {
+            directory_id: cgo.directory_id,
         }
     }
 }

--- a/lib/srv/desktop/tdp/protocol/tdpb/tdpb.go
+++ b/lib/srv/desktop/tdp/protocol/tdpb/tdpb.go
@@ -282,6 +282,20 @@ func (s *SharedDirectoryAnnounce) Encode() ([]byte, error) {
 
 func (*SharedDirectoryAnnounce) validate() error { return nil }
 
+// SharedDirectoryRemove is sent by the client to stop sharing a directory.
+type SharedDirectoryRemove tdpbv1.SharedDirectoryRemove
+
+// Encode encodes a SharedDirectoryAnnounce message.
+func (s *SharedDirectoryRemove) Encode() ([]byte, error) {
+	return marshalWithHeader(&tdpbv1.Envelope{
+		Payload: &tdpbv1.Envelope_SharedDirectoryRemove{
+			SharedDirectoryRemove: (*tdpbv1.SharedDirectoryRemove)(s),
+		},
+	})
+}
+
+func (*SharedDirectoryRemove) validate() error { return nil }
+
 // SharedDirectoryAcknowledge is sent by the server to acknowledge a
 // new shared directory.
 type SharedDirectoryAcknowledge tdpbv1.SharedDirectoryAcknowledge
@@ -571,6 +585,8 @@ func messageFromEnvelope(e *tdpbv1.Envelope) validatableMessage {
 		return (*LatencyStats)(m.LatencyStats)
 	case *tdpbv1.Envelope_Ping:
 		return (*Ping)(m.Ping)
+	case *tdpbv1.Envelope_SharedDirectoryRemove:
+		return (*SharedDirectoryRemove)(m.SharedDirectoryRemove)
 	default:
 		return nil
 	}

--- a/lib/srv/desktop/tdp/protocol/tdpb/translate.go
+++ b/lib/srv/desktop/tdp/protocol/tdpb/translate.go
@@ -385,6 +385,8 @@ func TranslateToModern(msg tdp.Message) ([]tdp.Message, error) {
 			},
 			// Assume all legacy TDP servers support clipboard sharing
 			ClipboardEnabled: true,
+			// No data to map, default to false
+			DirectoryRemoveSupported: false,
 		}}, nil
 	case legacy.SyncKeys:
 		return []tdp.Message{&SyncKeys{


### PR DESCRIPTION
Backport #65101

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local Cluster
### Test Cases
Regression tests only since this feature is not yet implemented in the client.
- [x] Desktop session starts without error
- [x] Clicking "Share a Directory" in the action menu creates a shared directory visible in Windows Explorer
- [x] Typical file operations succeed within the shared directory
