### PR TITLE
Refactor LLM requests recorder into a dedicated package

### DIFF
--- a/lib/srv/app/llm/anthropic/recorder.go
+++ b/lib/srv/app/llm/anthropic/recorder.go
@@ -17,255 +17,50 @@
 package anthropic
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"log/slog"
-	"mime"
 	"net/http"
-	"sync"
-	"sync/atomic"
 
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/lib/httplib/sse"
 	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+	llmrecorder "github.com/gravitational/teleport/lib/srv/app/llm/recorder"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-// ResponseRecorder is the Anthropic's response modifier and recorder.
-type ResponseRecorder struct {
-	http.ResponseWriter
-	flusher http.Flusher
-
-	log          *slog.Logger
-	status       int
-	written      int
-	containsErr  bool
-	err          error
-	responseType func() string
-	closed       atomic.Bool
-
-	// usage-related fields
-	inputTokensCount  int
-	outputTokensCount int
-
-	// used for non-streaming requests.
-	writer io.Writer
-	buf    *bytes.Buffer
-
-	// used for streaming requests.
-	startSSEOnce sync.Once
-	streamDoneCh chan struct{}
-	sseWriter    io.WriteCloser
-
-	// This values is guarded as atomic values since `Flush` calls may happen
-	// from different goroutines.
-	skipFlush atomic.Bool
+// NewResponseRecorder creates a new Anthropic response recorder.
+func NewResponseRecorder(log *slog.Logger, w http.ResponseWriter) (*llmrecorder.ResponseRecorder, error) {
+	return llmrecorder.NewResponseRecorder(log, w, Endpoint{})
 }
 
-// NewResponseRecorder creates a new response recorder.
-func NewResponseRecorder(log *slog.Logger, w http.ResponseWriter) (*ResponseRecorder, error) {
-	f, ok := w.(http.Flusher)
-	if !ok {
-		return nil, trace.BadParameter("response writer must be flusher")
-	}
-	r := &ResponseRecorder{
-		ResponseWriter: w,
-		// Defaults to 200, this matches the [http.ResponseWriter] expectation when
-		// [WriteHeader] is not called.
-		status:  http.StatusOK,
-		flusher: f,
-		log:     log,
-		buf:     new(bytes.Buffer),
-	}
-	r.writer = io.MultiWriter(w, r.buf)
-	r.responseType = sync.OnceValue(func() string {
-		mediaType, _, err := mime.ParseMediaType(w.Header().Get("Content-Type"))
-		if err != nil {
-			// No need to log the error here, the caller of this function will
-			// do the proper handling of this case (including logs).
-			return ""
-		}
-		return mediaType
-	})
-	return r, nil
+// Endpoint implements [llmrecorder.Endpoint] for the Anthropic messages API.
+type Endpoint struct{}
+
+// ParseError implements [llmrecorder.Endpoint]. The Anthropic API presents
+// errors in the body, so the status code is ignored.
+func (Endpoint) ParseError(_ int, body []byte) (*llmerrors.ProviderError, error) {
+	return parseProviderError(body)
 }
 
-// WriteHeader implements [http.ResponseWriter].
-func (r *ResponseRecorder) WriteHeader(status int) {
-	// In case of errors or response type not JSON, we delete the original
-	// Content-Length because we might rewrite the result contents, changing the
-	// total length.
-	contentType := r.responseType()
-	if status != http.StatusOK || contentType != "application/json" {
-		r.Header().Del("Content-Length")
-	}
-
-	// When the result is an unsupported content-type we set as error
-	// here since it might not contain a body (resulting in no [Write] calls).
-	//
-	// In addition, we "force" an error status code. This is done to keep the
-	// API contract where errors return only when status code is not 200.
-	if contentType != "application/json" && contentType != "text/event-stream" {
-		status = http.StatusInternalServerError
-		r.log.ErrorContext(context.Background(), "unsupported response content-type", "content_type", contentType)
-		r.err = llmerrors.NewProviderError(llmerrors.ErrBadResponse, "unsupported %q response type", contentType)
-	}
-	if status != http.StatusOK {
-		r.containsErr = true
-	}
-	r.status = status
-	r.ResponseWriter.WriteHeader(status)
+// MarshalError implements [llmrecorder.Endpoint].
+func (Endpoint) MarshalError(err error) []byte {
+	return marshalError(newErrorMessage(err))
 }
 
-// Writer implements [http.ResponseWriter].
-func (r *ResponseRecorder) Write(data []byte) (int, error) {
-	if r.status != http.StatusOK {
-		// Necessary because [WriteHeader] might not have been called before
-		// [Write].
-		r.containsErr = true
-		return r.writeError(data)
-	}
-
-	contentType := r.responseType()
-	switch contentType {
-	case "application/json":
-		n, err := r.writer.Write(data)
-		r.written += n
-		return n, trace.Wrap(err)
-	case "text/event-stream":
-		return r.writeStream(data)
-	default:
-		// This handling exists because callers are not guaranteed to call
-		// [WriteHeader]. So we must mimic the behavior here in case it wasn't
-		// called before.
-		//
-		// Note that at this point, we cannot change the status code returned,
-		// but we'll still return an error object here.
-		if !r.containsErr {
-			r.log.ErrorContext(context.Background(), "unsupported response content-type", "content_type", contentType)
-			r.err = llmerrors.NewProviderError(llmerrors.ErrBadResponse, "unsupported %q response type", contentType)
-			r.containsErr = true
-		}
-		return len(data), nil
-	}
-}
-
-// Flush implements [http.Flusher].
-func (r *ResponseRecorder) Flush() {
-	if r.skipFlush.Load() {
-		return
-	}
-
-	if r.flusher != nil {
-		r.flusher.Flush()
-	}
-}
-
-// Written is the number of bytes written in the downstream connection.
-//
-// Must be called after [Close].
-func (r *ResponseRecorder) Written() int {
-	return r.written
-}
-
-// Err is the error encountered while processing/forwarding the response.
-//
-// Must be called after [Close].
-func (r *ResponseRecorder) Err() error {
-	return r.err
-}
-
-// InputTokensCount is the number of input tokens that were used on the request.
-//
-// Must be called after [Close].
-func (r *ResponseRecorder) InputTokensCount() int {
-	return r.inputTokensCount
-}
-
-// OutputTokensCount is the number of output tokens generated by the request.
-//
-// Must be called after [Close].
-func (r *ResponseRecorder) OutputTokensCount() int {
-	return r.outputTokensCount
-}
-
-// Close implements [io.Closer]. Errors returned are only related to the
-// recorder teardown. For processing errors, callers must retrieve errors using
-// [Err].
-//
-// Must be called once.
-func (r *ResponseRecorder) Close() error {
-	if r.closed.Swap(true) {
-		return nil
-	}
-
-	// In case the response contains an error, this is the place where we write
-	// it back to the upstream.
-	if r.containsErr {
-		// Error might already be defined, so we can skip parsing it.
-		if r.err == nil {
-			var err error
-			r.err, err = parseProviderError(r.buf.Bytes())
-			// Failure here could indicate that the message is incomplete or
-			// that it is malformed.
-			if err != nil {
-				r.log.WarnContext(context.Background(), "unable to parse the provider error message", "error", err)
-				r.err = llmerrors.NewProviderError(llmerrors.ErrBadResponse, "invalid JSON response")
-			}
-		}
-
-		encodedErr := marshalError(newErrorMessage(r.err))
-		r.written += len(encodedErr)
-		if _, err := r.ResponseWriter.Write(encodedErr); err != nil {
-			r.log.WarnContext(context.Background(), "unable to write error message to downstream", "error", err)
-		}
-	}
-
-	if r.sseWriter != nil {
-		err := r.sseWriter.Close()
-		<-r.streamDoneCh
-		return trace.Wrap(err)
-	}
-
-	// When request contains error, it won't contain usage information, so we
-	// can skip it.
-	if r.containsErr {
-		return nil
-	}
-
-	// Non-streaming requests we must try to extract result metrics at the end.
+// ParseUsage implements [llmrecorder.Endpoint].
+func (Endpoint) ParseUsage(body []byte) (int, int, error) {
 	var result messagesAPIResult
-	err := utils.FastUnmarshal(r.buf.Bytes(), &result)
-	if err != nil {
-		r.log.WarnContext(context.Background(), "unable to parse messages result", "error", err)
-		r.err = llmerrors.NewProviderError(llmerrors.ErrBadResponse, "invalid JSON response")
-		return nil
+	if err := utils.FastUnmarshal(body, &result); err != nil {
+		return 0, 0, trace.Wrap(err)
 	}
-
-	r.inputTokensCount = result.Usage.InputTokens
-	r.outputTokensCount = result.Usage.OutputTokens
-	return nil
+	return result.Usage.InputTokens, result.Usage.OutputTokens, nil
 }
 
-func (r *ResponseRecorder) writeStream(data []byte) (int, error) {
-	// first write should initialize the pipe and start the read events
-	// goroutine.
-	r.startSSEOnce.Do(func() {
-		pr, pw := io.Pipe()
-		r.sseWriter = pw
-		r.streamDoneCh = make(chan struct{})
-		r.skipFlush.Store(true)
-		go func() {
-			defer close(r.streamDoneCh)
-			w := &writeFlusher{writer: r.ResponseWriter, flushFunc: r.flusher.Flush}
-			r.inputTokensCount, r.outputTokensCount, r.err = processSSEEvents(context.Background(), r.log, pr, w)
-			r.written = w.written
-		}()
-	})
-
-	return r.sseWriter.Write(data)
+// ProcessSSE implements [llmrecorder.Endpoint].
+func (Endpoint) ProcessSSE(ctx context.Context, log *slog.Logger, r io.ReadCloser, w io.Writer) (int, int, error) {
+	return processSSEEvents(ctx, log, r, w)
 }
 
 func processSSEEvents(ctx context.Context, log *slog.Logger, r io.ReadCloser, w io.Writer) (int, int, error) {
@@ -330,34 +125,4 @@ func processSSEEvents(ctx context.Context, log *slog.Logger, r io.ReadCloser, w 
 	}
 
 	return inputTokensCount, outputTokensCount, nil
-}
-
-func (r *ResponseRecorder) writeError(data []byte) (int, error) {
-	// Collect the error, but do not immediately forward it as we might need
-	// to perform modifications to it.
-	n, err := r.buf.Write(data)
-	if err != nil {
-		return 0, trace.Wrap(err)
-	}
-
-	// We might not write the error data as is, but we should return the
-	// original written value for writter that double check the total amount of
-	// data written.
-	return n, nil
-}
-
-type writeFlusher struct {
-	written   int
-	writer    io.Writer
-	flushFunc func()
-}
-
-func (w *writeFlusher) Write(data []byte) (int, error) {
-	n, err := w.writer.Write(data)
-	if err != nil {
-		return 0, trace.Wrap(err)
-	}
-	w.written += n
-	w.flushFunc()
-	return n, nil
 }

--- a/lib/srv/app/llm/anthropic/recorder_test.go
+++ b/lib/srv/app/llm/anthropic/recorder_test.go
@@ -17,418 +17,199 @@
 package anthropic
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
-	"net/http/httptest"
-	"slices"
-	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/lib/httplib/sse"
-	"github.com/gravitational/teleport/lib/itertools/stream"
 	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+	llmtesting "github.com/gravitational/teleport/lib/srv/app/llm/testing"
 )
 
-func TestHandleNonStreaming(t *testing.T) {
-	expectStatus := func(statusCode int) require.ValueAssertionFunc {
-		return func(tt require.TestingT, i1 any, i2 ...any) {
-			require.Equal(tt, statusCode, i1, i2...)
-		}
-	}
+// successStream is a valid messages API SSE stream. Input tokens are reported
+// on message_start and output tokens on message_delta.
+var successStream = strings.Join([]string{
+	"event: message_start\n" + `data: {"type":"message_start","message":{"id":"msg_123","type":"message","content":[],"usage":{"input_tokens":15}}}`,
+	"event: content_block_start\n" + `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"Hello"}}`,
+	"event: message_delta\n" + `data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":15,"output_tokens":60}}`,
+	"event: message_stop",
+}, "\n\n")
 
-	expectContentLength := func(length int) require.ValueAssertionFunc {
-		return func(tt require.TestingT, i1 any, i2 ...any) {
-			contentLength, err := strconv.Atoi(i1.(string))
-			require.NoError(tt, err, "expected content length to not be empty")
-			require.Equal(tt, length, contentLength, i2...)
-		}
-	}
-
-	const successResponse = `{"id":"msg_123","type":"message","content":[{"type":"text","text":"Hello"}],"usage":{"input_tokens":15, "output_tokens": 20}}`
+// TestParseProviderError covers the Anthropic error type to Teleport error
+// mapping.
+func TestParseProviderError(t *testing.T) {
+	t.Parallel()
 
 	for name, tc := range map[string]struct {
-		providerStatusCode           int
-		providerBody                 string
-		providerContentType          string
-		expectedDownstreamBody       require.ValueAssertionFunc
-		expectedDownstreamStatusCode require.ValueAssertionFunc
-		expectedContentLength        require.ValueAssertionFunc
-		expectedRecorder             require.ValueAssertionFunc
+		body        string
+		expectedErr error
 	}{
-		"success": {
-			providerStatusCode:  http.StatusOK,
-			providerBody:        successResponse,
-			providerContentType: "application/json",
-			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
-				body, _ := i1.(string)
-				// Expect unmodified response.
-				require.Equal(tt, successResponse, body, i2...)
-			},
-			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
-			// Expect content length equal to the original message.
-			expectedContentLength: expectContentLength(len(successResponse)),
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.Equal(tt, len(successResponse), rec.Written())
-				require.Equal(tt, 15, rec.InputTokensCount(), i2...)
-				require.Equal(tt, 20, rec.OutputTokensCount(), i2...)
-				require.NoError(tt, rec.Err(), i2...)
-			},
-		},
-		"non-json response": {
-			providerStatusCode:  http.StatusOK,
-			providerBody:        "Non-JSON result",
-			providerContentType: "text/html",
-			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
-				body, _ := i1.(string)
-				var apiErr errorEnvelope
-				require.NoError(tt, json.Unmarshal([]byte(body), &apiErr), "expected message to be in JSON format")
-				require.Contains(tt, apiErr.Error.Message, llmerrors.ErrBadResponse.Error(), "expected error response to include Teleport message")
-				require.Contains(tt, apiErr.Error.Message, `unsupported "text/html" response type`, "expected error response to include the unsupported content-type detail")
-			},
-			expectedDownstreamStatusCode: expectStatus(http.StatusInternalServerError),
-			// In case of errors, we always expect empty Content-Length.
-			expectedContentLength: require.Empty,
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.NotEmpty(tt, rec.Written(), i2...)
-				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
-			},
-		},
-		"api invalid request includes original message": {
-			providerStatusCode:  http.StatusBadRequest,
-			providerBody:        `{"error":{"type":"invalid_request_error","message":"invalid model"}}`,
-			providerContentType: "application/json",
-			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
-				body, _ := i1.(string)
-				var apiErr errorEnvelope
-				require.NoError(tt, json.Unmarshal([]byte(body), &apiErr), "expected message to be in JSON format")
-				require.Contains(tt, apiErr.Error.Message, "invalid model", "expected error response to include original message")
-				require.Contains(tt, apiErr.Error.Message, llmerrors.ErrBadRequest.Error(), "expected error response to include Teleport message")
-			},
-			expectedDownstreamStatusCode: expectStatus(http.StatusBadRequest),
-			// In case of errors, we always expect empty Content-Length.
-			expectedContentLength: require.Empty,
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.NotEmpty(tt, rec.Written(), i2...)
-				require.Equal(tt, 0, rec.OutputTokensCount(), i2...)
-				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadRequest, i2...)
-			},
-		},
-		"auth error 401 rewrites message": {
-			providerStatusCode:  http.StatusUnauthorized,
-			providerBody:        `{"error":{"type":"authentication_error","message":"original provider secret"}}`,
-			providerContentType: "application/json",
-			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
-				body, _ := i1.(string)
-				var apiErr errorEnvelope
-				require.NoError(tt, json.Unmarshal([]byte(body), &apiErr), "expected message to be in JSON format")
-				require.NotContains(tt, body, "original provider secret", "expected error response to NOT include original message")
-				require.Contains(tt, apiErr.Error.Message, llmerrors.ErrUnauthorized.Error(), "expected error response to include Teleport message")
-			},
-			expectedDownstreamStatusCode: expectStatus(http.StatusUnauthorized),
-			// In case of errors, we always expect empty Content-Length.
-			expectedContentLength: require.Empty,
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.NotEmpty(tt, rec.Written(), i2...)
-				require.ErrorIs(tt, rec.Err(), llmerrors.ErrUnauthorized, i2...)
-			},
-		},
-		"empty success response": {
-			providerStatusCode:           http.StatusOK,
-			providerBody:                 "",
-			providerContentType:          "application/json",
-			expectedDownstreamBody:       require.Empty,
-			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
-			expectedContentLength:        expectContentLength(0),
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.Empty(tt, rec.Written(), i2...)
-				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
-			},
-		},
-		"empty error response": {
-			providerStatusCode:  http.StatusUnauthorized,
-			providerBody:        "",
-			providerContentType: "application/json",
-			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
-				body, _ := i1.(string)
-				var apiErr errorEnvelope
-				require.NoError(tt, json.Unmarshal([]byte(body), &apiErr), "expected message to be in JSON format")
-				require.Contains(tt, apiErr.Error.Message, llmerrors.ErrBadResponse.Error(), "expected error response to include Teleport message")
-				require.Contains(tt, apiErr.Error.Message, "invalid JSON response", "expected error response to include the unparseable-body detail")
-			},
-			expectedDownstreamStatusCode: expectStatus(http.StatusUnauthorized),
-			expectedContentLength:        require.Empty,
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.NotEmpty(tt, rec.Written(), i2...)
-				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+		"timeout":         {`{"error":{"type":"timeout_error","message":"slow"}}`, llmerrors.ErrTimeout},
+		"invalid request": {`{"error":{"type":"invalid_request_error","message":"bad"}}`, llmerrors.ErrBadRequest},
+		"authentication":  {`{"error":{"type":"authentication_error","message":"nope"}}`, llmerrors.ErrUnauthorized},
+		"permission":      {`{"error":{"type":"permission_error","message":"nope"}}`, llmerrors.ErrUnauthorized},
+		"rate limit":      {`{"error":{"type":"rate_limit_error","message":"slow down"}}`, llmerrors.ErrRejected},
+		"overloaded":      {`{"error":{"type":"overloaded_error","message":"busy"}}`, llmerrors.ErrRejected},
+		"billing":         {`{"error":{"type":"billing_error","message":"pay"}}`, llmerrors.ErrRejected},
+		"not found":       {`{"error":{"type":"not_found_error","message":"missing"}}`, llmerrors.ErrUnsupported},
+		"unknown type":    {`{"error":{"type":"some_new_error","message":"?"}}`, llmerrors.ErrUnknown},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			apiErr, err := parseProviderError([]byte(tc.body))
+			require.NoError(t, err)
+			require.ErrorIs(t, apiErr, tc.expectedErr)
+		})
+	}
+
+	t.Run("malformed body returns parse error", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseProviderError([]byte(`{"error":`))
+		require.Error(t, err)
+	})
+}
+
+// TestNewErrorMessage covers the Teleport error to Anthropic error type
+// mapping.
+func TestNewErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		err          error
+		expectedType string
+	}{
+		"timeout":      {llmerrors.ErrTimeout, errorTypeTimeoutError},
+		"canceled":     {llmerrors.ErrCanceled, errorTypeTimeoutError},
+		"bad request":  {llmerrors.ErrBadRequest, errorTypeInvalidRequestError},
+		"unauthorized": {llmerrors.ErrUnauthorized, errorTypeAuthenticationError},
+		"rejected":     {llmerrors.ErrRejected, errorTypeRateLimitError},
+		"unsupported":  {llmerrors.ErrUnsupported, errorTypeNotFoundError},
+		"unknown":      {llmerrors.ErrUnknown, errorTypeAPIError},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			msg := newErrorMessage(tc.err)
+			require.Equal(t, tc.expectedType, msg.Error.Type)
+			require.Contains(t, msg.Error.Message, tc.err.Error())
+		})
+	}
+
+	require.Nil(t, newErrorMessage(nil))
+}
+
+// TestEndpointParseUsage covers extraction of token usage from a non-streaming
+// messages API response.
+func TestEndpointParseUsage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		in, out, err := Endpoint{}.ParseUsage([]byte(`{"usage":{"input_tokens":15,"output_tokens":20}}`))
+		require.NoError(t, err)
+		require.Equal(t, 15, in)
+		require.Equal(t, 20, out)
+	})
+
+	t.Run("malformed body", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := Endpoint{}.ParseUsage([]byte(`{"usage":`))
+		require.Error(t, err)
+	})
+}
+
+// TestProcessSSEEvents covers the messages API SSE processing.
+func TestProcessSSEEvents(t *testing.T) {
+	t.Parallel()
+
+	log := slog.New(slog.DiscardHandler)
+
+	for name, tc := range map[string]struct {
+		stream              string
+		expectedInputTokens int
+		expectedOutput      int
+		expectedErr         require.ErrorAssertionFunc
+		expectedDownstream  func(t *testing.T, body string)
+	}{
+		"success extracts usage and forwards events": {
+			stream:              successStream,
+			expectedInputTokens: 15,
+			expectedOutput:      60,
+			expectedErr:         require.NoError,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Equal(t, successStream+"\n\n", body)
 			},
 		},
-		"broken response": {
-			providerStatusCode:  http.StatusOK,
-			providerBody:        `{"id":"msg_123","type":"message","content"`,
-			providerContentType: "application/json",
-			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
-				body, _ := i1.(string)
-				// Expect unmodified response.
-				require.Equal(tt, `{"id":"msg_123","type":"message","content"`, body, i2...)
+		"error event surfaces provider error": {
+			stream: "event: error\n" + `data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`,
+			expectedErr: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorIs(tt, err, llmerrors.ErrRejected, i...)
 			},
-			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
-			// Here, the original message is not parsed as error, and will be
-			// forwarded as is to downstream.
-			expectedContentLength: expectContentLength(42),
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.Equal(tt, 42, rec.Written(), i2...)
-				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Contains(t, body, "Overloaded")
+				require.Contains(t, body, llmerrors.ErrRejected.Error())
 			},
 		},
-		"no write header success": {
-			// WriteHeader is not called.
-			providerStatusCode:  0,
-			providerBody:        successResponse,
-			providerContentType: "application/json",
-			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
-				body, _ := i1.(string)
-				// Expect unmodified response.
-				require.Equal(tt, successResponse, body, i2...)
+		"invalid error event surfaces bad response": {
+			stream: "event: error\n" + `data: {"type":"error","error":`,
+			expectedErr: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorIs(tt, err, llmerrors.ErrBadResponse, i...)
 			},
-			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
-			expectedContentLength:        expectContentLength(len(successResponse)),
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.Equal(tt, len(successResponse), rec.Written(), i2...)
-				require.Equal(tt, 15, rec.InputTokensCount(), i2...)
-				require.Equal(tt, 20, rec.OutputTokensCount(), i2...)
-				require.NoError(tt, rec.Err(), i2...)
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Contains(t, body, llmerrors.ErrBadResponse.Error())
 			},
 		},
-		"no write header unsupported content-type": {
-			// WriteHeader is not called.
-			providerStatusCode:  0,
-			providerBody:        "Non-JSON result",
-			providerContentType: "text/html",
-			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
-				body, _ := i1.(string)
-				var apiErr errorEnvelope
-				require.NoError(tt, json.Unmarshal([]byte(body), &apiErr), "expected message to be in JSON format")
-				require.Contains(tt, apiErr.Error.Message, llmerrors.ErrBadResponse.Error(), "expected error response to include Teleport message")
-				require.Contains(tt, apiErr.Error.Message, `unsupported "text/html" response type`, "expected error response to include the unsupported content-type detail")
-			},
-			// Without WriteHeader the recorder cannot force a 500 status nor
-			// strip the original Content-Length, so the status stays 200.
-			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
-			expectedContentLength:        expectContentLength(len("Non-JSON result")),
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.NotEmpty(tt, rec.Written(), i2...)
-				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+		"malformed message_start is skipped": {
+			stream:      "event: message_start\n" + `data: {"type":"message_start","message":`,
+			expectedErr: require.NoError,
+			expectedDownstream: func(t *testing.T, body string) {
+				// The malformed event is dropped (continue), so nothing is
+				// forwarded downstream.
+				require.Empty(t, body)
 			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// This scenario covers when the provider responses returns all
-			// at once (single write). This is less realistic for large
-			// responses.
-			t.Run("single write", func(t *testing.T) {
-				w := httptest.NewRecorder()
-				rec, err := NewResponseRecorder(slog.Default(), w)
-				require.NoError(t, err)
-
-				rec.Header().Add("Content-Type", tc.providerContentType)
-				rec.Header().Add("Content-Length", strconv.Itoa(len(tc.providerBody)))
-				// A status code of 0 simulates a caller that never calls
-				// WriteHeader, exercising the default 200 status path.
-				if tc.providerStatusCode != 0 {
-					rec.WriteHeader(tc.providerStatusCode)
-				}
-				if len(tc.providerBody) > 0 {
-					_, err = io.WriteString(rec, tc.providerBody)
-					require.NoError(t, err)
-				}
-
-				require.NoError(t, rec.Close())
-
-				resp := w.Result()
-				body, err := io.ReadAll(resp.Body)
-				require.NoError(t, err)
-				tc.expectedRecorder(t, rec)
-				tc.expectedDownstreamStatusCode(t, resp.StatusCode)
-				tc.expectedContentLength(t, w.Header().Get("Content-Length"))
-				tc.expectedDownstreamBody(t, string(body))
-			})
-			// This scenario covers when the provider responses returns in
-			// multiple writes. This is more realistic considering larger
-			// responses and network conditions.
-			t.Run("multi write", func(t *testing.T) {
-				w := httptest.NewRecorder()
-				rec, err := NewResponseRecorder(slog.Default(), w)
-				require.NoError(t, err)
-
-				rec.Header().Add("Content-Type", tc.providerContentType)
-				rec.Header().Add("Content-Length", strconv.Itoa(len(tc.providerBody)))
-				// A status code of 0 simulates a caller that never calls
-				// WriteHeader, exercising the default 200 status path.
-				if tc.providerStatusCode != 0 {
-					rec.WriteHeader(tc.providerStatusCode)
-				}
-				for chunk := range slices.Chunk([]byte(tc.providerBody), 1) {
-					_, err = rec.Write(chunk)
-					require.NoError(t, err)
-				}
-
-				require.NoError(t, rec.Close())
-
-				resp := w.Result()
-				body, err := io.ReadAll(resp.Body)
-				require.NoError(t, err)
-				tc.expectedRecorder(t, rec)
-				tc.expectedDownstreamStatusCode(t, resp.StatusCode)
-				tc.expectedContentLength(t, w.Header().Get("Content-Length"))
-				tc.expectedDownstreamBody(t, string(body))
-			})
+			var out strings.Builder
+			in, out2, err := processSSEEvents(
+				context.Background(),
+				log,
+				io.NopCloser(strings.NewReader(tc.stream)),
+				&out,
+			)
+			tc.expectedErr(t, err)
+			require.Equal(t, tc.expectedInputTokens, in)
+			require.Equal(t, tc.expectedOutput, out2)
+			tc.expectedDownstream(t, out.String())
 		})
 	}
 }
 
-func TestHandleStreaming(t *testing.T) {
-	expectStatus := func(statusCode int) require.ValueAssertionFunc {
-		return func(tt require.TestingT, i1 any, i2 ...any) {
-			require.Equal(tt, statusCode, i1, i2...)
-		}
-	}
+// TestProcessSSEEventsWriteFailure covers the error-event branch when the
+// downstream write fails: the recorder must still surface the semantic error.
+func TestProcessSSEEventsWriteFailure(t *testing.T) {
+	t.Parallel()
 
-	successStream := strings.Join([]string{
-		"event: message_start\n" + `data: {"type": "message_start", "message":{"id":"msg_123","type":"message","content":[],"usage":{"input_tokens":15}}}`,
-		"event: content_block_start\n" + `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
-		"event: content_block_start\n" + `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"Hello"}}`,
-		"event: content_block_start\n" + `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"World"}}`,
-		"event: content_block_stop\n" + `data: {"type":"content_block_stop","index":0}`,
-		"event: message_delta\n" + `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":15,"output_tokens":60}}`,
-		"event: message_stop",
-	}, "\n\n")
+	log := slog.New(slog.DiscardHandler)
 
-	for name, tc := range map[string]struct {
-		providerResp                 func(w http.ResponseWriter)
-		expectedDownstreamBody       require.ValueAssertionFunc
-		expectedDownstreamStatusCode require.ValueAssertionFunc
-		expectedRecorder             require.ValueAssertionFunc
-	}{
-		"success": {
-			providerResp: func(w http.ResponseWriter) {
-				w.Header().Add("Content-Type", "text/event-stream")
-				w.WriteHeader(http.StatusOK)
-				io.WriteString(w, successStream)
-			},
-			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
-				body, _ := i1.(string)
-				// Expect unmodified response.
-				require.Equal(tt, successStream+"\n\n", body, i2...)
-			},
-			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				// events length + last event line break.
-				require.Equal(tt, len(successStream)+2, rec.Written())
-				require.Equal(tt, 15, rec.InputTokensCount(), i2...)
-				require.Equal(tt, 60, rec.OutputTokensCount(), i2...)
-				require.NoError(tt, rec.Err())
-			},
-		},
-		"with error": {
-			providerResp: func(w http.ResponseWriter) {
-				w.Header().Add("Content-Type", "text/event-stream")
-				w.WriteHeader(http.StatusOK)
-				io.WriteString(w, "event: error\n"+`data: {"type": "error", "error": {"type": "overloaded_error", "message": "Overloaded"}}`)
-			},
-			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
-				body, _ := i1.(string)
-				evt := readSSEOneEvent(tt, body)
-				var apiErr errorEnvelope
-				require.Equal(t, "error", evt.Event)
-				require.NoError(tt, json.Unmarshal(evt.Data, &apiErr), "expected message to be in JSON format")
-				require.Contains(tt, body, "Overloaded", "expected error response to include original message")
-				require.Contains(tt, body, llmerrors.ErrRejected.Error(), "expected error response to include Teleport message")
-			},
-			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.Equal(tt, 198, rec.Written())
-				require.ErrorIs(tt, rec.Err(), llmerrors.ErrRejected)
-			},
-		},
-		"empty stream": {
-			providerResp: func(w http.ResponseWriter) {
-				w.Header().Add("Content-Type", "text/event-stream")
-				w.WriteHeader(http.StatusOK)
-			},
-			expectedDownstreamBody:       require.Empty,
-			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.Empty(tt, rec.Written())
-			},
-		},
-		"broken stream": {
-			providerResp: func(w http.ResponseWriter) {
-				w.Header().Add("Content-Type", "text/event-stream")
-				w.WriteHeader(http.StatusOK)
-				// Broken JSON response.
-				io.WriteString(w, "event: message_start\n"+`data: {"type": "message_start", "message":{"id":"msg_123","type":"message","content":`)
-			},
-			expectedDownstreamBody:       require.Empty,
-			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.Empty(tt, rec.Written())
-			},
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			w := httptest.NewRecorder()
-			rec, err := NewResponseRecorder(slog.Default(), w)
-			require.NoError(t, err)
-			tc.providerResp(rec)
-			require.NoError(t, rec.Close())
-
-			resp := w.Result()
-			body, err := io.ReadAll(resp.Body)
-			require.NoError(t, err)
-			tc.expectedRecorder(t, rec)
-			tc.expectedDownstreamStatusCode(t, resp.StatusCode)
-			tc.expectedDownstreamBody(t, string(body))
-		})
-	}
-}
-
-// TestHandleStreamingErrorEventWriteFailure covers the error-event branch of
-// processSSEEvents when the downstream write fails: the client connection is
-// broken, but the recorder must still surface the semantic error via Err().
-func TestHandleStreamingErrorEventWriteFailure(t *testing.T) {
 	for name, tc := range map[string]struct {
 		stream      string
 		expectedErr require.ErrorAssertionFunc
 	}{
 		"write error surfaces provider error": {
-			stream: "event: error\n" + `data: {"type": "error", "error": {"type": "overloaded_error", "message": "Overloaded"}}`,
+			stream: "event: error\n" + `data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`,
 			expectedErr: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorIs(tt, err, llmerrors.ErrRejected, i...)
 			},
 		},
 		"invalid error event surfaces bad response": {
-			stream: "event: error\n" + `data: {"type": "error", "error":`,
+			stream: "event: error\n" + `data: {"type":"error","error":`,
 			expectedErr: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorIs(tt, err, llmerrors.ErrBadResponse, i...)
 			},
@@ -437,50 +218,17 @@ func TestHandleStreamingErrorEventWriteFailure(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			w := &failingResponseWriter{header: http.Header{}}
-			w.header.Set("Content-Type", "text/event-stream")
-
-			rec, err := NewResponseRecorder(slog.Default(), w)
-			require.NoError(t, err)
-
-			rec.WriteHeader(http.StatusOK)
-			_, err = io.WriteString(rec, tc.stream)
-			require.NoError(t, err)
-			// Close waits on the streaming goroutine, so Err() is populated.
-			require.NoError(t, rec.Close())
-			tc.expectedErr(t, rec.Err())
+			w := llmtesting.NewFailingResponseWriter("text/event-stream")
+			_, _, err := processSSEEvents(
+				context.Background(),
+				log,
+				io.NopCloser(strings.NewReader(tc.stream)),
+				w,
+			)
+			tc.expectedErr(t, err)
 		})
 	}
 }
-
-func readSSEOneEvent(t require.TestingT, str string) sse.Event {
-	events, err := stream.Collect(sse.ReadEvents(strings.NewReader(str)))
-	require.NoError(t, err)
-	require.Len(t, events, 1)
-	return events[0]
-}
-
-// discardResponseWriter is a minimal [http.ResponseWriter] + [http.Flusher]
-// that discards all writes.
-type discardResponseWriter struct {
-	header http.Header
-}
-
-func (w *discardResponseWriter) Header() http.Header         { return w.header }
-func (w *discardResponseWriter) Write(p []byte) (int, error) { return len(p), nil }
-func (w *discardResponseWriter) WriteHeader(int)             {}
-func (w *discardResponseWriter) Flush()                      {}
-
-// failingResponseWriter is a minimal [http.ResponseWriter] + [http.Flusher]
-// whose Write always fails, simulating a broken downstream connection.
-type failingResponseWriter struct {
-	header http.Header
-}
-
-func (w *failingResponseWriter) Header() http.Header       { return w.header }
-func (w *failingResponseWriter) Write([]byte) (int, error) { return 0, io.ErrClosedPipe }
-func (w *failingResponseWriter) WriteHeader(int)           {}
-func (w *failingResponseWriter) Flush()                    {}
 
 // buildResponseBody returns a valid non-streaming messages API response whose
 // total size is roughly fillerBytes.
@@ -522,8 +270,7 @@ func BenchmarkResponseRecorderJSON(b *testing.B) {
 			b.ReportAllocs()
 
 			for b.Loop() {
-				w := &discardResponseWriter{header: http.Header{}}
-				w.header.Set("Content-Type", "application/json")
+				w := llmtesting.NewDiscardResponseWriter("application/json")
 				rec, err := NewResponseRecorder(log, w)
 				require.NoError(b, err)
 				rec.WriteHeader(http.StatusOK)
@@ -535,8 +282,7 @@ func BenchmarkResponseRecorderJSON(b *testing.B) {
 	}
 }
 
-// BenchmarkResponseRecorderStreamChunked mirrors BenchmarkResponseRecorderStream
-// but issues one Write per SSE event.
+// BenchmarkResponseRecorderStream issues one Write per SSE event.
 //
 //	go test ./lib/srv/app/llm/anthropic/ -run '^$' -bench BenchmarkResponseRecorderStream -benchmem
 func BenchmarkResponseRecorderStream(b *testing.B) {
@@ -559,8 +305,7 @@ func BenchmarkResponseRecorderStream(b *testing.B) {
 			b.ReportAllocs()
 
 			for b.Loop() {
-				w := &discardResponseWriter{header: http.Header{}}
-				w.header.Set("Content-Type", "text/event-stream")
+				w := llmtesting.NewDiscardResponseWriter("text/event-stream")
 				rec, err := NewResponseRecorder(log, w)
 				require.NoError(b, err)
 				rec.WriteHeader(http.StatusOK)

--- a/lib/srv/app/llm/recorder/recorder.go
+++ b/lib/srv/app/llm/recorder/recorder.go
@@ -39,16 +39,29 @@ import (
 // Endpoint supplies the provider-specific behavior needed by a
 // [ResponseRecorder].
 type Endpoint interface {
+	EndpointNonStreaming
+	EndpointStreaming
+
+	// MarshalError encodes err into the provider's on-the-wire error format. It
+	// must always return a valid payload, even when err cannot be marshaled.
+	MarshalError(err error) (body []byte)
+}
+
+// EndpointNonStreaming contains the endpoint functions used for non streaming
+// requests.
+type EndpointNonStreaming interface {
 	// ParseError parses a non-streaming error response body into a provider
 	// error. statusCode is the HTTP status of the response. The second return
 	// value is non-nil only when the body itself could not be parsed.
 	ParseError(statusCode int, body []byte) (providerError *llmerrors.ProviderError, err error)
-	// MarshalError encodes err into the provider's on-the-wire error format. It
-	// must always return a valid payload, even when err cannot be marshaled.
-	MarshalError(err error) (body []byte)
 	// ParseUsage extracts the input/output token usage from a non-streaming
 	// success response body.
 	ParseUsage(body []byte) (inputTokens int, outputTokens int, err error)
+}
+
+// EndpointNonStreaming contains the endpoint functions used for streaming
+// requests.
+type EndpointStreaming interface {
 	// ProcessSSE reads SSE events from reader, forwarding them to writer while
 	// recording token usage.
 	ProcessSSE(ctx context.Context, log *slog.Logger, reader io.ReadCloser, writer io.Writer) (inputTokens int, outputTokens int, err error)

--- a/lib/srv/app/llm/recorder/recorder.go
+++ b/lib/srv/app/llm/recorder/recorder.go
@@ -1,0 +1,323 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package recorder provides a provider-agnostic LLM response recorder. The
+// recorder modifies and records the upstream provider response while forwarding
+// it downstream, tracking the bytes written, the token usage and any provider
+// error. All provider-specific behavior is supplied through the [Endpoint]
+// interface.
+package recorder
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"mime"
+	"net/http"
+	"sync"
+	"sync/atomic"
+
+	"github.com/gravitational/trace"
+
+	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+)
+
+// Endpoint supplies the provider-specific behavior needed by a
+// [ResponseRecorder].
+type Endpoint interface {
+	// ParseError parses a non-streaming error response body into a provider
+	// error. statusCode is the HTTP status of the response. The second return
+	// value is non-nil only when the body itself could not be parsed.
+	ParseError(statusCode int, body []byte) (providerError *llmerrors.ProviderError, err error)
+	// MarshalError encodes err into the provider's on-the-wire error format. It
+	// must always return a valid payload, even when err cannot be marshaled.
+	MarshalError(err error) (body []byte)
+	// ParseUsage extracts the input/output token usage from a non-streaming
+	// success response body.
+	ParseUsage(body []byte) (inputTokens int, outputTokens int, err error)
+	// ProcessSSE reads SSE events from reader, forwarding them to writer while
+	// recording token usage.
+	ProcessSSE(ctx context.Context, log *slog.Logger, reader io.ReadCloser, writer io.Writer) (inputTokens int, outputTokens int, err error)
+}
+
+// ResponseRecorder is the provider-agnostic response modifier and recorder.
+type ResponseRecorder struct {
+	http.ResponseWriter
+	flusher  http.Flusher
+	endpoint Endpoint
+
+	log          *slog.Logger
+	status       int
+	written      int
+	containsErr  bool
+	err          error
+	responseType func() string
+	closed       atomic.Bool
+
+	// usage-related fields
+	inputTokensCount  int
+	outputTokensCount int
+
+	// used for non-streaming requests.
+	writer io.Writer
+	buf    *bytes.Buffer
+
+	// used for streaming requests.
+	startSSEOnce sync.Once
+	streamDoneCh chan struct{}
+	sseWriter    io.WriteCloser
+
+	// This values is guarded as atomic values since `Flush` calls may happen
+	// from different goroutines.
+	skipFlush atomic.Bool
+}
+
+// NewResponseRecorder creates a new response recorder backed by the given
+// endpoint.
+func NewResponseRecorder(log *slog.Logger, w http.ResponseWriter, endpoint Endpoint) (*ResponseRecorder, error) {
+	f, ok := w.(http.Flusher)
+	if !ok {
+		return nil, trace.BadParameter("response writer must be flusher")
+	}
+	r := &ResponseRecorder{
+		ResponseWriter: w,
+		endpoint:       endpoint,
+		// Defaults to 200, this matches the [http.ResponseWriter] expectation when
+		// [WriteHeader] is not called.
+		status:  http.StatusOK,
+		flusher: f,
+		log:     log,
+		buf:     new(bytes.Buffer),
+	}
+	r.writer = io.MultiWriter(w, r.buf)
+	r.responseType = sync.OnceValue(func() string {
+		mediaType, _, err := mime.ParseMediaType(w.Header().Get("Content-Type"))
+		if err != nil {
+			// No need to log the error here, the caller of this function will
+			// do the proper handling of this case (including logs).
+			return ""
+		}
+		return mediaType
+	})
+	return r, nil
+}
+
+// WriteHeader implements [http.ResponseWriter].
+func (r *ResponseRecorder) WriteHeader(status int) {
+	// In case of errors or response type not JSON, we delete the original
+	// Content-Length because we might rewrite the result contents, changing the
+	// total length.
+	contentType := r.responseType()
+	if status != http.StatusOK || contentType != "application/json" {
+		r.Header().Del("Content-Length")
+	}
+
+	// When the result is an unsupported content-type we set as error
+	// here since it might not contain a body (resulting in no [Write] calls).
+	//
+	// In addition, we "force" an error status code. This is done to keep the
+	// API contract where errors return only when status code is not 200.
+	if contentType != "application/json" && contentType != "text/event-stream" {
+		status = http.StatusInternalServerError
+		r.log.ErrorContext(context.Background(), "unsupported response content-type", "content_type", contentType)
+		r.err = llmerrors.NewProviderError(llmerrors.ErrBadResponse, "unsupported %q response type", contentType)
+	}
+	if status != http.StatusOK {
+		r.containsErr = true
+	}
+	r.status = status
+	r.ResponseWriter.WriteHeader(status)
+}
+
+// Write implements [http.ResponseWriter].
+func (r *ResponseRecorder) Write(data []byte) (int, error) {
+	if r.status != http.StatusOK {
+		// Necessary because [WriteHeader] might not have been called before
+		// [Write].
+		r.containsErr = true
+		return r.writeError(data)
+	}
+
+	contentType := r.responseType()
+	switch contentType {
+	case "application/json":
+		n, err := r.writer.Write(data)
+		r.written += n
+		return n, trace.Wrap(err)
+	case "text/event-stream":
+		return r.writeStream(data)
+	default:
+		// This handling exists because callers are not guaranteed to call
+		// [WriteHeader]. So we must mimic the behavior here in case it wasn't
+		// called before.
+		//
+		// Note that at this point, we cannot change the status code returned,
+		// but we'll still return an error object here.
+		if !r.containsErr {
+			r.log.ErrorContext(context.Background(), "unsupported response content-type", "content_type", contentType)
+			r.err = llmerrors.NewProviderError(llmerrors.ErrBadResponse, "unsupported %q response type", contentType)
+			r.containsErr = true
+		}
+		return len(data), nil
+	}
+}
+
+// Flush implements [http.Flusher].
+func (r *ResponseRecorder) Flush() {
+	if r.skipFlush.Load() {
+		return
+	}
+
+	if r.flusher != nil {
+		r.flusher.Flush()
+	}
+}
+
+// Written is the number of bytes written in the downstream connection.
+//
+// Must be called after [ResponseRecorder.Close].
+func (r *ResponseRecorder) Written() int {
+	return r.written
+}
+
+// Err is the error encountered while processing/forwarding the response.
+//
+// Must be called after [ResponseRecorder.Close].
+func (r *ResponseRecorder) Err() error {
+	return r.err
+}
+
+// InputTokensCount is the number of input tokens that were used on the request.
+//
+// Must be called after [ResponseRecorder.Close].
+func (r *ResponseRecorder) InputTokensCount() int {
+	return r.inputTokensCount
+}
+
+// OutputTokensCount is the number of output tokens generated by the request.
+//
+// Must be called after [ResponseRecorder.Close].
+func (r *ResponseRecorder) OutputTokensCount() int {
+	return r.outputTokensCount
+}
+
+// Close implements [io.Closer]. Errors returned are only related to the
+// recorder teardown. For processing errors, callers must retrieve errors using
+// [ResponseRecorder.Err].
+//
+// Must be called once.
+func (r *ResponseRecorder) Close() error {
+	if r.closed.Swap(true) {
+		return nil
+	}
+
+	// In case the response contains an error, this is the place where we write
+	// it back to the upstream.
+	if r.containsErr {
+		// Error might already be defined, so we can skip parsing it.
+		if r.err == nil {
+			apiErr, err := r.endpoint.ParseError(r.status, r.buf.Bytes())
+			// Failure here could indicate that the message is incomplete or
+			// that it is malformed.
+			if err != nil {
+				r.log.WarnContext(context.Background(), "unable to parse the provider error message", "error", err)
+				r.err = llmerrors.NewProviderError(llmerrors.ErrBadResponse, "invalid JSON response")
+			} else if apiErr != nil {
+				r.err = apiErr
+			}
+		}
+
+		encodedErr := r.endpoint.MarshalError(r.err)
+		r.written += len(encodedErr)
+		if _, err := r.ResponseWriter.Write(encodedErr); err != nil {
+			r.log.WarnContext(context.Background(), "unable to write error message to downstream", "error", err)
+		}
+	}
+
+	if r.sseWriter != nil {
+		err := r.sseWriter.Close()
+		<-r.streamDoneCh
+		return trace.Wrap(err)
+	}
+
+	// When request contains error, it won't contain usage information, so we
+	// can skip it.
+	if r.containsErr {
+		return nil
+	}
+
+	// Non-streaming requests we must try to extract result metrics at the end.
+	inputTokens, outputTokens, err := r.endpoint.ParseUsage(r.buf.Bytes())
+	if err != nil {
+		r.log.WarnContext(context.Background(), "unable to parse messages result", "error", err)
+		r.err = llmerrors.NewProviderError(llmerrors.ErrBadResponse, "invalid JSON response")
+		return nil
+	}
+
+	r.inputTokensCount = inputTokens
+	r.outputTokensCount = outputTokens
+	return nil
+}
+
+func (r *ResponseRecorder) writeStream(data []byte) (int, error) {
+	// first write should initialize the pipe and start the read events
+	// goroutine.
+	r.startSSEOnce.Do(func() {
+		pr, pw := io.Pipe()
+		r.sseWriter = pw
+		r.streamDoneCh = make(chan struct{})
+		r.skipFlush.Store(true)
+		go func() {
+			defer close(r.streamDoneCh)
+			w := &writeFlusher{writer: r.ResponseWriter, flushFunc: r.flusher.Flush}
+			r.inputTokensCount, r.outputTokensCount, r.err = r.endpoint.ProcessSSE(context.Background(), r.log, pr, w)
+			r.written = w.written
+		}()
+	})
+
+	return r.sseWriter.Write(data)
+}
+
+func (r *ResponseRecorder) writeError(data []byte) (int, error) {
+	// Collect the error, but do not immediately forward it as we might need
+	// to perform modifications to it.
+	n, err := r.buf.Write(data)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+
+	// We might not write the error data as is, but we should return the
+	// original written value for writter that double check the total amount of
+	// data written.
+	return n, nil
+}
+
+type writeFlusher struct {
+	written   int
+	writer    io.Writer
+	flushFunc func()
+}
+
+func (w *writeFlusher) Write(data []byte) (int, error) {
+	n, err := w.writer.Write(data)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+	w.written += n
+	w.flushFunc()
+	return n, nil
+}

--- a/lib/srv/app/llm/recorder/recorder_test.go
+++ b/lib/srv/app/llm/recorder/recorder_test.go
@@ -1,0 +1,420 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package recorder_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+	"github.com/gravitational/teleport/lib/srv/app/llm/recorder"
+	llmtesting "github.com/gravitational/teleport/lib/srv/app/llm/testing"
+)
+
+// TestNonStreaming exercises the provider-agnostic non-streaming
+// (application/json) recorder pipeline against a stub endpoint.
+func TestNonStreaming(t *testing.T) {
+	t.Parallel()
+
+	const successResponse = `{"In":15,"Out":20}`
+
+	for name, tc := range map[string]struct {
+		providerStatusCode           int
+		providerBody                 string
+		providerContentType          string
+		expectedDownstreamBody       require.ValueAssertionFunc
+		expectedDownstreamStatusCode require.ValueAssertionFunc
+		expectedContentLength        require.ValueAssertionFunc
+		expectedRecorder             require.ValueAssertionFunc
+	}{
+		"success forwards body and records usage": {
+			providerStatusCode:  http.StatusOK,
+			providerBody:        successResponse,
+			providerContentType: "application/json",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.Equal(tt, successResponse, i1.(string), i2...)
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
+			expectedContentLength:        expectContentLength(len(successResponse)),
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec := i1.(*recorder.ResponseRecorder)
+				require.Equal(tt, len(successResponse), rec.Written())
+				require.Equal(tt, 15, rec.InputTokensCount(), i2...)
+				require.Equal(tt, 20, rec.OutputTokensCount(), i2...)
+				require.NoError(tt, rec.Err(), i2...)
+			},
+		},
+		"unsupported content-type forces error": {
+			providerStatusCode:  http.StatusOK,
+			providerBody:        "Non-JSON result",
+			providerContentType: "text/html",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				body := i1.(string)
+				require.Contains(tt, body, llmerrors.ErrBadResponse.Error(), "expected Teleport message")
+				require.Contains(tt, body, "text/html", "expected unsupported content-type detail")
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusInternalServerError),
+			expectedContentLength:        require.Empty,
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec := i1.(*recorder.ResponseRecorder)
+				require.NotEmpty(tt, rec.Written(), i2...)
+				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+			},
+		},
+		"error status is parsed by endpoint": {
+			providerStatusCode:  http.StatusUnauthorized,
+			providerBody:        `{"error":"boom"}`,
+			providerContentType: "application/json",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				body := i1.(string)
+				require.Contains(tt, body, "stub provider error", "expected endpoint-provided detail")
+				require.Contains(tt, body, llmerrors.ErrUnauthorized.Error(), "expected mapped Teleport message")
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusUnauthorized),
+			expectedContentLength:        require.Empty,
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec := i1.(*recorder.ResponseRecorder)
+				require.NotEmpty(tt, rec.Written(), i2...)
+				require.Equal(tt, 0, rec.OutputTokensCount(), i2...)
+				require.ErrorIs(tt, rec.Err(), llmerrors.ErrUnauthorized, i2...)
+			},
+		},
+		"empty success body is bad response": {
+			providerStatusCode:           http.StatusOK,
+			providerBody:                 "",
+			providerContentType:          "application/json",
+			expectedDownstreamBody:       require.Empty,
+			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
+			expectedContentLength:        expectContentLength(0),
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec := i1.(*recorder.ResponseRecorder)
+				require.Empty(tt, rec.Written(), i2...)
+				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+			},
+		},
+		"empty error body falls back to bad response": {
+			providerStatusCode:  http.StatusUnauthorized,
+			providerBody:        "",
+			providerContentType: "application/json",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.Contains(tt, i1.(string), llmerrors.ErrBadResponse.Error(), "expected fallback Teleport message")
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusUnauthorized),
+			expectedContentLength:        require.Empty,
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec := i1.(*recorder.ResponseRecorder)
+				require.NotEmpty(tt, rec.Written(), i2...)
+				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+			},
+		},
+		"unparseable success body forwarded as-is": {
+			providerStatusCode:  http.StatusOK,
+			providerBody:        `{"In":`,
+			providerContentType: "application/json",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.Equal(tt, `{"In":`, i1.(string), i2...)
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
+			expectedContentLength:        expectContentLength(len(`{"In":`)),
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec := i1.(*recorder.ResponseRecorder)
+				require.Equal(tt, len(`{"In":`), rec.Written(), i2...)
+				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+			},
+		},
+		"no write header success uses default 200": {
+			// WriteHeader is not called.
+			providerStatusCode:  0,
+			providerBody:        successResponse,
+			providerContentType: "application/json",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.Equal(tt, successResponse, i1.(string), i2...)
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
+			expectedContentLength:        expectContentLength(len(successResponse)),
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec := i1.(*recorder.ResponseRecorder)
+				require.Equal(tt, len(successResponse), rec.Written(), i2...)
+				require.Equal(tt, 15, rec.InputTokensCount(), i2...)
+				require.Equal(tt, 20, rec.OutputTokensCount(), i2...)
+				require.NoError(tt, rec.Err(), i2...)
+			},
+		},
+		"no write header unsupported content-type": {
+			// WriteHeader is not called.
+			providerStatusCode:  0,
+			providerBody:        "Non-JSON result",
+			providerContentType: "text/html",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				body := i1.(string)
+				require.Contains(tt, body, llmerrors.ErrBadResponse.Error(), "expected Teleport message")
+				require.Contains(tt, body, "text/html", "expected unsupported content-type detail")
+			},
+			// Without WriteHeader the recorder cannot force a 500 status nor
+			// strip the original Content-Length, so the status stays 200.
+			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
+			expectedContentLength:        expectContentLength(len("Non-JSON result")),
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec := i1.(*recorder.ResponseRecorder)
+				require.NotEmpty(tt, rec.Written(), i2...)
+				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			run := func(t *testing.T, write func(rec *recorder.ResponseRecorder)) {
+				w := httptest.NewRecorder()
+				rec, err := recorder.NewResponseRecorder(slog.Default(), w, newFakeEndpoint())
+				require.NoError(t, err)
+
+				rec.Header().Add("Content-Type", tc.providerContentType)
+				rec.Header().Add("Content-Length", strconv.Itoa(len(tc.providerBody)))
+				// A status code of 0 simulates a caller that never calls
+				// WriteHeader, exercising the default 200 status path.
+				if tc.providerStatusCode != 0 {
+					rec.WriteHeader(tc.providerStatusCode)
+				}
+				write(rec)
+
+				require.NoError(t, rec.Close())
+
+				resp := w.Result()
+				body, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+				tc.expectedRecorder(t, rec)
+				tc.expectedDownstreamStatusCode(t, resp.StatusCode)
+				tc.expectedContentLength(t, w.Header().Get("Content-Length"))
+				tc.expectedDownstreamBody(t, string(body))
+			}
+
+			// Provider responses can arrive all at once (single write) or
+			// across multiple writes (more realistic for large responses).
+			t.Run("single write", func(t *testing.T) {
+				run(t, func(rec *recorder.ResponseRecorder) {
+					if len(tc.providerBody) > 0 {
+						_, err := io.WriteString(rec, tc.providerBody)
+						require.NoError(t, err)
+					}
+				})
+			})
+			t.Run("multi write", func(t *testing.T) {
+				run(t, func(rec *recorder.ResponseRecorder) {
+					for chunk := range slices.Chunk([]byte(tc.providerBody), 1) {
+						_, err := rec.Write(chunk)
+						require.NoError(t, err)
+					}
+				})
+			})
+		})
+	}
+}
+
+// TestStreaming exercises the provider-agnostic streaming (text/event-stream)
+// recorder pipeline: the recorder hands the stream to the endpoint's ProcessSSE
+// and records the bytes written, usage and error it reports.
+func TestStreaming(t *testing.T) {
+	t.Parallel()
+
+	const stream = "event: message\n" + `data: {"hello":"world"}` + "\n\n"
+
+	t.Run("success records usage and forwards stream", func(t *testing.T) {
+		t.Parallel()
+
+		w := httptest.NewRecorder()
+		rec, err := recorder.NewResponseRecorder(slog.Default(), w, newFakeEndpoint())
+		require.NoError(t, err)
+
+		rec.Header().Add("Content-Type", "text/event-stream")
+		rec.WriteHeader(http.StatusOK)
+		_, err = io.WriteString(rec, stream)
+		require.NoError(t, err)
+		require.NoError(t, rec.Close())
+
+		resp := w.Result()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, stream, string(body))
+		require.Equal(t, len(stream), rec.Written())
+		require.Equal(t, 15, rec.InputTokensCount())
+		require.Equal(t, 60, rec.OutputTokensCount())
+		require.NoError(t, rec.Err())
+	})
+
+	t.Run("processor error surfaces via Err", func(t *testing.T) {
+		t.Parallel()
+
+		ep := newFakeEndpoint()
+		ep.processSSE = func(_ context.Context, _ *slog.Logger, r io.ReadCloser, _ io.Writer) (int, int, error) {
+			defer r.Close()
+			_, _ = io.ReadAll(r)
+			return 0, 0, llmerrors.ErrRejected
+		}
+
+		w := httptest.NewRecorder()
+		rec, err := recorder.NewResponseRecorder(slog.Default(), w, ep)
+		require.NoError(t, err)
+
+		rec.Header().Add("Content-Type", "text/event-stream")
+		rec.WriteHeader(http.StatusOK)
+		_, err = io.WriteString(rec, stream)
+		require.NoError(t, err)
+		require.NoError(t, rec.Close())
+
+		require.ErrorIs(t, rec.Err(), llmerrors.ErrRejected)
+	})
+
+	t.Run("empty stream writes nothing", func(t *testing.T) {
+		t.Parallel()
+
+		w := httptest.NewRecorder()
+		rec, err := recorder.NewResponseRecorder(slog.Default(), w, newFakeEndpoint())
+		require.NoError(t, err)
+
+		rec.Header().Add("Content-Type", "text/event-stream")
+		rec.WriteHeader(http.StatusOK)
+		// No body written, so the SSE processing goroutine never starts.
+		require.NoError(t, rec.Close())
+
+		require.Empty(t, rec.Written())
+	})
+}
+
+// TestDownstreamWriteFailure ensures the recorder still surfaces the semantic
+// error via Err() when writing to a broken downstream connection.
+func TestDownstreamWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-streaming error write", func(t *testing.T) {
+		t.Parallel()
+
+		w := llmtesting.NewFailingResponseWriter("application/json")
+		rec, err := recorder.NewResponseRecorder(slog.Default(), w, newFakeEndpoint())
+		require.NoError(t, err)
+
+		rec.WriteHeader(http.StatusUnauthorized)
+		// Empty error body drives the ParseError fallback.
+		require.NoError(t, rec.Close())
+		require.ErrorIs(t, rec.Err(), llmerrors.ErrBadResponse)
+	})
+
+	t.Run("streaming processor error", func(t *testing.T) {
+		t.Parallel()
+
+		ep := newFakeEndpoint()
+		ep.processSSE = func(_ context.Context, _ *slog.Logger, r io.ReadCloser, w io.Writer) (int, int, error) {
+			defer r.Close()
+			_, _ = io.ReadAll(r)
+			// The provider error must be preserved even when the downstream
+			// write fails.
+			_, _ = w.Write([]byte("ignored"))
+			return 0, 0, llmerrors.ErrRejected
+		}
+
+		w := llmtesting.NewFailingResponseWriter("text/event-stream")
+		rec, err := recorder.NewResponseRecorder(slog.Default(), w, ep)
+		require.NoError(t, err)
+
+		rec.WriteHeader(http.StatusOK)
+		_, err = io.WriteString(rec, "event: message\ndata: {}\n\n")
+		require.NoError(t, err)
+		// Close waits on the streaming goroutine, so Err() is populated.
+		require.NoError(t, rec.Close())
+		require.ErrorIs(t, rec.Err(), llmerrors.ErrRejected)
+	})
+}
+
+// fakeEndpoint is a configurable [recorder.Endpoint] stub used to exercise the
+// provider-agnostic recorder pipeline in isolation.
+type fakeEndpoint struct {
+	parseError   func(int, []byte) (*llmerrors.ProviderError, error)
+	marshalError func(error) []byte
+	parseUsage   func([]byte) (int, int, error)
+	processSSE   func(context.Context, *slog.Logger, io.ReadCloser, io.Writer) (int, int, error)
+}
+
+func (e fakeEndpoint) ParseError(status int, body []byte) (*llmerrors.ProviderError, error) {
+	return e.parseError(status, body)
+}
+
+func (e fakeEndpoint) MarshalError(err error) []byte { return e.marshalError(err) }
+
+func (e fakeEndpoint) ParseUsage(body []byte) (int, int, error) {
+	return e.parseUsage(body)
+}
+
+func (e fakeEndpoint) ProcessSSE(ctx context.Context, log *slog.Logger, r io.ReadCloser, w io.Writer) (int, int, error) {
+	return e.processSSE(ctx, log, r, w)
+}
+
+func newFakeEndpoint() fakeEndpoint {
+	return fakeEndpoint{
+		parseError: func(_ int, body []byte) (*llmerrors.ProviderError, error) {
+			if len(body) == 0 {
+				return nil, errors.New("empty error body")
+			}
+			return llmerrors.NewProviderError(llmerrors.ErrUnauthorized, "stub provider error"), nil
+		},
+		marshalError: func(err error) []byte {
+			return fmt.Appendf(nil, `{"message":%q}`, err.Error())
+		},
+		parseUsage: func(body []byte) (int, int, error) {
+			var u struct{ In, Out int }
+			if err := json.Unmarshal(body, &u); err != nil {
+				return 0, 0, err
+			}
+			return u.In, u.Out, nil
+		},
+		processSSE: func(_ context.Context, _ *slog.Logger, r io.ReadCloser, w io.Writer) (int, int, error) {
+			defer r.Close()
+			data, err := io.ReadAll(r)
+			if err != nil {
+				return 0, 0, err
+			}
+			if _, err := w.Write(data); err != nil {
+				return 0, 0, err
+			}
+			return 15, 60, nil
+		},
+	}
+}
+
+func expectStatus(statusCode int) require.ValueAssertionFunc {
+	return func(tt require.TestingT, i1 any, i2 ...any) {
+		require.Equal(tt, statusCode, i1, i2...)
+	}
+}
+
+func expectContentLength(length int) require.ValueAssertionFunc {
+	return func(tt require.TestingT, i1 any, i2 ...any) {
+		contentLength, err := strconv.Atoi(i1.(string))
+		require.NoError(tt, err, "expected content length to not be empty")
+		require.Equal(tt, length, contentLength, i2...)
+	}
+}

--- a/lib/srv/app/llm/testing/testing.go
+++ b/lib/srv/app/llm/testing/testing.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/stretchr/testify/require"
+	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/lib/httplib/sse"
 	"github.com/gravitational/teleport/lib/itertools/stream"
@@ -71,9 +71,13 @@ func (w *FailingResponseWriter) Flush()                    {}
 
 // ReadSSEOneEvent parses str and asserts it contains exactly one SSE event,
 // which it returns.
-func ReadSSEOneEvent(t require.TestingT, str string) sse.Event {
+func ReadSSEOneEvent(str string) (sse.Event, error) {
 	events, err := stream.Collect(sse.ReadEvents(strings.NewReader(str)))
-	require.NoError(t, err)
-	require.Len(t, events, 1)
-	return events[0]
+	if err != nil {
+		return sse.Event{}, trace.Wrap(err)
+	}
+	if len(events) != 1 {
+		return sse.Event{}, trace.BadParameter("must contain exactly one SSE event")
+	}
+	return events[0], nil
 }

--- a/lib/srv/app/llm/testing/testing.go
+++ b/lib/srv/app/llm/testing/testing.go
@@ -1,0 +1,79 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package testing
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/httplib/sse"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+)
+
+// DiscardResponseWriter is a minimal [http.ResponseWriter] + [http.Flusher]
+// that discards all writes.
+type DiscardResponseWriter struct {
+	header http.Header
+}
+
+// NewDiscardResponseWriter creates a [DiscardResponseWriter] with the given
+// Content-Type header set (when non-empty).
+func NewDiscardResponseWriter(contentType string) *DiscardResponseWriter {
+	h := http.Header{}
+	if contentType != "" {
+		h.Set("Content-Type", contentType)
+	}
+	return &DiscardResponseWriter{header: h}
+}
+
+func (w *DiscardResponseWriter) Header() http.Header         { return w.header }
+func (w *DiscardResponseWriter) Write(p []byte) (int, error) { return len(p), nil }
+func (w *DiscardResponseWriter) WriteHeader(int)             {}
+func (w *DiscardResponseWriter) Flush()                      {}
+
+// FailingResponseWriter is a minimal [http.ResponseWriter] + [http.Flusher]
+// whose Write always fails, simulating a broken downstream connection.
+type FailingResponseWriter struct {
+	header http.Header
+}
+
+// NewFailingResponseWriter creates a [FailingResponseWriter] with the given
+// Content-Type header set (when non-empty).
+func NewFailingResponseWriter(contentType string) *FailingResponseWriter {
+	h := http.Header{}
+	if contentType != "" {
+		h.Set("Content-Type", contentType)
+	}
+	return &FailingResponseWriter{header: h}
+}
+
+func (w *FailingResponseWriter) Header() http.Header       { return w.header }
+func (w *FailingResponseWriter) Write([]byte) (int, error) { return 0, io.ErrClosedPipe }
+func (w *FailingResponseWriter) WriteHeader(int)           {}
+func (w *FailingResponseWriter) Flush()                    {}
+
+// ReadSSEOneEvent parses str and asserts it contains exactly one SSE event,
+// which it returns.
+func ReadSSEOneEvent(t require.TestingT, str string) sse.Event {
+	events, err := stream.Collect(sse.ReadEvents(strings.NewReader(str)))
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	return events[0]
+}


### PR DESCRIPTION
> [!NOTE]
> No behavior changes, and test coverage remains the same.

This PR refactors the Anthropic endpoint recorder into a dedicated shared package, leaving only Anthropic-specific logic in the `anthropic` package.

The motivation for this was that the OpenAI endpoint recorder is largely a copy of the Anthropic recorder without this refactor. So with this refactor, we avoid code duplication and make it easier to improve the recorder and fix bugs.


## Manual Test Plan
### Test Environment

Local cluster with dedicated app service instance.

### Test Cases
- [x] Access using `curl` and `claude` (provider: `anthropic`) 
  - [x] Mapped model.
  - [x] Streaming requests.
  - [x] Fallback model.
  - [x] Invalid messages/errors returned are from Teleport.
  - [x] Audit events are included in the app session recording. `tsh play -f json <chunk-id>`
  - [x] Prometheus metrics generated.
