### PR TITLE
[v18] Remove github.com/santhosh-tekuri/jsonschema/v6

### DIFF
--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -219,7 +219,6 @@ require (
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/russellhaering/gosaml2 v0.11.0 // indirect
 	github.com/russellhaering/goxmldsig v1.6.0 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/scim2/filter-parser/v2 v2.2.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.10.0 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect

--- a/e_imports.go
+++ b/e_imports.go
@@ -129,7 +129,6 @@ import (
 	_ "github.com/russellhaering/gosaml2"
 	_ "github.com/russellhaering/gosaml2/types"
 	_ "github.com/russellhaering/goxmldsig"
-	_ "github.com/santhosh-tekuri/jsonschema/v6"
 	_ "github.com/scim2/filter-parser/v2"
 	_ "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	_ "github.com/sigstore/sigstore-go/pkg/bundle"

--- a/go.mod
+++ b/go.mod
@@ -209,7 +209,7 @@ require (
 	github.com/redis/go-redis/v9 v9.17.2 // replaced
 	github.com/russellhaering/gosaml2 v0.11.0
 	github.com/russellhaering/goxmldsig v1.6.0
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/schollz/progressbar/v3 v3.18.0
 	github.com/scim2/filter-parser/v2 v2.2.0
 	github.com/shirou/gopsutil/v4 v4.26.3


### PR DESCRIPTION
This is my bad, I pre-emptively added https://github.com/gravitational/teleport/pull/68187 to the v18 desktop summaries backport as it and https://github.com/gravitational/teleport.e/pull/8969 were needed to not have structured output broken for bedrock models that do not support the structured output API. I was a bit hasty and didn't think moving it to being a direct dependency would be an issue.

This reverts the addition, as we'll move to hand rolling the schema validation instead.