### PR TITLE
[v18] Fix checkSCPAllowed() whitespace parsing

### DIFF
--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -284,7 +284,7 @@ func (e *localExec) transformSecureCopy() error {
 func checkSCPAllowed(scx *ServerContext, command string) (bool, error) {
 	// split up command by space to grab the first word. if we don't have anything
 	// it's an interactive shell the user requested and not scp, return
-	args := strings.Split(command, " ")
+	args := strings.Fields(command)
 	if len(args) == 0 {
 		return false, nil
 	}

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 
+	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/modules"
@@ -142,4 +143,49 @@ func newExecServerContext(t *testing.T, srv Server) *ServerContext {
 	t.Cleanup(func() { require.NoError(t, scx.session.term.Close()) })
 
 	return scx
+}
+
+func TestCheckSCPAllowed(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		command string
+		assert  require.BoolAssertionFunc
+	}{
+		{
+			name:    "scp command",
+			command: "scp foo bar",
+			assert:  require.True,
+		},
+		{
+			name:    "other command",
+			command: "some other command",
+			assert:  require.False,
+		},
+		{
+			name:    "no command",
+			command: "",
+			assert:  require.False,
+		},
+		{
+			name:    "scp command with whitespace",
+			command: "\tscp foo bar",
+			assert:  require.True,
+		},
+		{
+			name:    "other bash commands aren't affected",
+			command: "echo $((1+1))",
+			assert:  require.False,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scx := newTestServerContext(t, nil, nil, nil)
+			scx.AllowFileCopying = true
+			scx.Identity.AccessPermit = decisionpb.SSHAccessPermit_builder{SshFileCopy: true}.Build()
+			ok, err := checkSCPAllowed(scx, tc.command)
+			require.NoError(t, err)
+			tc.assert(t, ok)
+		})
+	}
 }


### PR DESCRIPTION
Backport #67526 to branch/v18

Changelog: Fixed file copying permissions not recognizing scp commands when surrounded by non-space whitespace

## Manual Test Plan
### Test Environment

Local cluster with a user and a note. File copying must be disabled either in the user's role or the ssh_service config.

### Test Cases
- [x] Verify that running `echo -n 'C0644 8 foo.txt\nabcdefgh\0' | tsh ssh node " scp -t $PWD/foo.txt"` does *not* create the file `foo.txt` in the current directory.
- [x] Verify that running a non-scp exec command succeeds (test something weird like `tsh ssh node echo $((1+1))`)
