### PR TITLE
[v17] Fix checkSCPAllowed() whitespace parsing

### DIFF
--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -251,7 +251,7 @@ func (e *localExec) String() string {
 func (e *localExec) transformSecureCopy() error {
 	isSCPCmd, err := checkSCPAllowed(e.Ctx, e.GetCommand())
 	if err != nil {
-		e.Ctx.GetServer().EmitAuditEvent(context.WithoutCancel(e.Ctx.Context), &apievents.SFTP{
+		e.Ctx.GetServer().EmitAuditEvent(context.WithoutCancel(e.Ctx.CancelContext()), &apievents.SFTP{
 			Metadata: apievents.Metadata{
 				Code: events.SFTPDisallowedCode,
 				Type: events.SFTPEvent,
@@ -293,7 +293,7 @@ func (e *localExec) transformSecureCopy() error {
 func checkSCPAllowed(scx *ServerContext, command string) (bool, error) {
 	// split up command by space to grab the first word. if we don't have anything
 	// it's an interactive shell the user requested and not scp, return
-	args := strings.Split(command, " ")
+	args := strings.Fields(command)
 	if len(args) == 0 {
 		return false, nil
 	}

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -159,3 +159,48 @@ func newExecServerContext(t *testing.T, srv Server) *ServerContext {
 
 	return scx
 }
+
+func TestCheckSCPAllowed(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		command string
+		assert  require.BoolAssertionFunc
+	}{
+		{
+			name:    "scp command",
+			command: "scp foo bar",
+			assert:  require.True,
+		},
+		{
+			name:    "other command",
+			command: "some other command",
+			assert:  require.False,
+		},
+		{
+			name:    "no command",
+			command: "",
+			assert:  require.False,
+		},
+		{
+			name:    "scp command with whitespace",
+			command: "\tscp foo bar",
+			assert:  require.True,
+		},
+		{
+			name:    "other bash commands aren't affected",
+			command: "echo $((1+1))",
+			assert:  require.False,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scx := newTestServerContext(t, nil, nil)
+			scx.AllowFileCopying = true
+			scx.Identity.AccessChecker = &fakeAccessChecker{canCopyFiles: true}
+			ok, err := checkSCPAllowed(scx, tc.command)
+			require.NoError(t, err)
+			tc.assert(t, ok)
+		})
+	}
+}

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -1851,8 +1851,9 @@ func (f *fakeServer) Context() context.Context {
 
 type fakeAccessChecker struct {
 	services.AccessChecker
-	err      error
-	hostInfo services.HostUsersInfo
+	err          error
+	hostInfo     services.HostUsersInfo
+	canCopyFiles bool
 }
 
 func (f *fakeAccessChecker) HostSudoers(srv types.Server) ([]string, error) {
@@ -1861,6 +1862,10 @@ func (f *fakeAccessChecker) HostSudoers(srv types.Server) ([]string, error) {
 
 func (f *fakeAccessChecker) HostUsers(srv types.Server) (*services.HostUsersInfo, error) {
 	return &f.hostInfo, f.err
+}
+
+func (f *fakeAccessChecker) CanCopyFiles() bool {
+	return f.canCopyFiles
 }
 
 type fakeUser struct {


### PR DESCRIPTION
Backport #67526 to branch/v17

Backport changes: fixed panic in `transformSecureCopy()` due to using the wrong context, updated test to account for different access check method in v17

Changelog: Fixed file copying permissions not recognizing scp commands when surrounded by non-space whitespace

## Manual Test Plan
### Test Environment

Local cluster with a user and a note. File copying must be disabled either in the user's role or the ssh_service config.

### Test Cases
- [x] Verify that running `echo -n 'C0644 8 foo.txt\nabcdefgh\0' | tsh ssh node " scp -t $PWD/foo.txt"` does *not* create the file `foo.txt` in the current directory.
- [x] Verify that running a non-scp exec command succeeds (test something weird like `tsh ssh node echo $((1+1))`)
