### PR TITLE
Improve the error message when pin doesn't apply to resource scope

### DIFF
--- a/lib/services/scoped_access_checker_context.go
+++ b/lib/services/scoped_access_checker_context.go
@@ -225,12 +225,18 @@ func (c *ScopedAccessCheckerContext) checkersForResourceScope(ctx context.Contex
 		// access to only resources subject to /foo/bar.
 		if enforcePin {
 			if !pinning.PinAppliesToResourceScope(c.pin, scope) {
-				yield(nil, trace.AccessDenied("scope pin %q does not apply to resource scope %q", c.pin.GetScope(), scope))
+				yield(nil, trace.AccessDenied(
+					"a resource in scope %q can't be manipulated from a session pinned to scope %q",
+					scope, c.pin.GetScope(),
+				))
 				return
 			}
 		} else if !pinning.PinCompatibleWithPolicyScope(c.pin, scope) {
 			// Unpinned reads should still not allow orthogonal reads.
-			yield(nil, trace.AccessDenied("scope pin %q is orthogonal to resource scope %q", c.pin.GetScope(), scope))
+			yield(nil, trace.AccessDenied(
+				"a resource in scope %q can't be manipulated from a session pinned to orthogonal scope %q",
+				scope, c.pin.GetScope(),
+			))
 			return
 		}
 

--- a/lib/services/scoped_access_checker_context_test.go
+++ b/lib/services/scoped_access_checker_context_test.go
@@ -96,7 +96,7 @@ func TestRiskyAuthorizeUnpinnedReadWithScope(t *testing.T) {
 		{
 			name:          "override to orthogonal scope is denied",
 			resourceScope: "/other",
-			wantErr:       "a resource in scope \"other\" can't be manipulated from a session pinned to orthogonal scope \"/test/scope\"",
+			wantErr:       "a resource in scope \"/other\" can't be manipulated from a session pinned to orthogonal scope \"/test/scope\"",
 		},
 		{
 			name:          "override to empty scope is rejected",

--- a/lib/services/scoped_access_checker_context_test.go
+++ b/lib/services/scoped_access_checker_context_test.go
@@ -96,7 +96,7 @@ func TestRiskyAuthorizeUnpinnedReadWithScope(t *testing.T) {
 		{
 			name:          "override to orthogonal scope is denied",
 			resourceScope: "/other",
-			wantErr:       "scope pin \"/test/scope\" is orthogonal to resource scope \"/other\"",
+			wantErr:       "a resource in scope \"other\" can't be manipulated from a session pinned to orthogonal scope \"/test/scope\"",
 		},
 		{
 			name:          "override to empty scope is rejected",


### PR DESCRIPTION
## Manual Test Plan
### Test Environment
Any cluster with scopes enabled.

### Test Cases
- [x] Sign in to scope `a/b` and try to create any resource in scope `a`. This should fail with an updated error message.
- [x] Sign into scope `a` and try to create any resource in scope `a/b`. This should succeed.
