### PR TITLE
[v18] azure discovery refactor installer backoff

### DIFF
--- a/api/gen/proto/go/teleport/usertasks/v1/user_tasks.pb.go
+++ b/api/gen/proto/go/teleport/usertasks/v1/user_tasks.pb.go
@@ -1405,7 +1405,11 @@ type DiscoverAzureVMInstance struct {
 	// DiscoveryGroup is the DiscoveryGroup name that originated this task.
 	DiscoveryGroup string `protobuf:"bytes,5,opt,name=discovery_group,json=discoveryGroup,proto3" json:"discovery_group,omitempty"`
 	// SyncTime is the timestamp when the error was produced.
-	SyncTime      *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=sync_time,json=syncTime,proto3" json:"sync_time,omitempty"`
+	SyncTime *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=sync_time,json=syncTime,proto3" json:"sync_time,omitempty"`
+	// FailureCount is the number of installation attempt failures.
+	FailureCount int32 `protobuf:"varint,7,opt,name=failure_count,json=failureCount,proto3" json:"failure_count,omitempty"`
+	// RetryAfter is the timestamp after which the VM installation will be retried.
+	RetryAfter    *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=retry_after,json=retryAfter,proto3" json:"retry_after,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1477,6 +1481,20 @@ func (x *DiscoverAzureVMInstance) GetSyncTime() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *DiscoverAzureVMInstance) GetFailureCount() int32 {
+	if x != nil {
+		return x.FailureCount
+	}
+	return 0
+}
+
+func (x *DiscoverAzureVMInstance) GetRetryAfter() *timestamppb.Timestamp {
+	if x != nil {
+		return x.RetryAfter
+	}
+	return nil
+}
+
 func (x *DiscoverAzureVMInstance) SetVmId(v string) {
 	x.VmId = v
 }
@@ -1501,6 +1519,14 @@ func (x *DiscoverAzureVMInstance) SetSyncTime(v *timestamppb.Timestamp) {
 	x.SyncTime = v
 }
 
+func (x *DiscoverAzureVMInstance) SetFailureCount(v int32) {
+	x.FailureCount = v
+}
+
+func (x *DiscoverAzureVMInstance) SetRetryAfter(v *timestamppb.Timestamp) {
+	x.RetryAfter = v
+}
+
 func (x *DiscoverAzureVMInstance) HasSyncTime() bool {
 	if x == nil {
 		return false
@@ -1508,8 +1534,19 @@ func (x *DiscoverAzureVMInstance) HasSyncTime() bool {
 	return x.SyncTime != nil
 }
 
+func (x *DiscoverAzureVMInstance) HasRetryAfter() bool {
+	if x == nil {
+		return false
+	}
+	return x.RetryAfter != nil
+}
+
 func (x *DiscoverAzureVMInstance) ClearSyncTime() {
 	x.SyncTime = nil
+}
+
+func (x *DiscoverAzureVMInstance) ClearRetryAfter() {
+	x.RetryAfter = nil
 }
 
 type DiscoverAzureVMInstance_builder struct {
@@ -1527,6 +1564,10 @@ type DiscoverAzureVMInstance_builder struct {
 	DiscoveryGroup string
 	// SyncTime is the timestamp when the error was produced.
 	SyncTime *timestamppb.Timestamp
+	// FailureCount is the number of installation attempt failures.
+	FailureCount int32
+	// RetryAfter is the timestamp after which the VM installation will be retried.
+	RetryAfter *timestamppb.Timestamp
 }
 
 func (b0 DiscoverAzureVMInstance_builder) Build() *DiscoverAzureVMInstance {
@@ -1539,6 +1580,8 @@ func (b0 DiscoverAzureVMInstance_builder) Build() *DiscoverAzureVMInstance {
 	x.DiscoveryConfig = b.DiscoveryConfig
 	x.DiscoveryGroup = b.DiscoveryGroup
 	x.SyncTime = b.SyncTime
+	x.FailureCount = b.FailureCount
+	x.RetryAfter = b.RetryAfter
 	return m0
 }
 
@@ -1622,7 +1665,7 @@ const file_teleport_usertasks_v1_user_tasks_proto_rawDesc = "" +
 	"\x06region\x18\x04 \x01(\tR\x06region\x1al\n" +
 	"\x0eInstancesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12D\n" +
-	"\x05value\x18\x02 \x01(\v2..teleport.usertasks.v1.DiscoverAzureVMInstanceR\x05value:\x028\x01\"\xf0\x01\n" +
+	"\x05value\x18\x02 \x01(\v2..teleport.usertasks.v1.DiscoverAzureVMInstanceR\x05value:\x028\x01\"\xd2\x02\n" +
 	"\x17DiscoverAzureVMInstance\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12\x1f\n" +
 	"\vresource_id\x18\x02 \x01(\tR\n" +
@@ -1630,7 +1673,10 @@ const file_teleport_usertasks_v1_user_tasks_proto_rawDesc = "" +
 	"\x04name\x18\x03 \x01(\tR\x04name\x12)\n" +
 	"\x10discovery_config\x18\x04 \x01(\tR\x0fdiscoveryConfig\x12'\n" +
 	"\x0fdiscovery_group\x18\x05 \x01(\tR\x0ediscoveryGroup\x127\n" +
-	"\tsync_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\bsyncTimeBVZTgithub.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1;usertasksv1b\x06proto3"
+	"\tsync_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\bsyncTime\x12#\n" +
+	"\rfailure_count\x18\a \x01(\x05R\ffailureCount\x12;\n" +
+	"\vretry_after\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"retryAfterBVZTgithub.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1;usertasksv1b\x06proto3"
 
 var file_teleport_usertasks_v1_user_tasks_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_teleport_usertasks_v1_user_tasks_proto_goTypes = []any{
@@ -1669,15 +1715,16 @@ var file_teleport_usertasks_v1_user_tasks_proto_depIdxs = []int32{
 	16, // 13: teleport.usertasks.v1.DiscoverRDSDatabase.sync_time:type_name -> google.protobuf.Timestamp
 	14, // 14: teleport.usertasks.v1.DiscoverAzureVM.instances:type_name -> teleport.usertasks.v1.DiscoverAzureVM.InstancesEntry
 	16, // 15: teleport.usertasks.v1.DiscoverAzureVMInstance.sync_time:type_name -> google.protobuf.Timestamp
-	4,  // 16: teleport.usertasks.v1.DiscoverEC2.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverEC2Instance
-	6,  // 17: teleport.usertasks.v1.DiscoverEKS.ClustersEntry.value:type_name -> teleport.usertasks.v1.DiscoverEKSCluster
-	8,  // 18: teleport.usertasks.v1.DiscoverRDS.DatabasesEntry.value:type_name -> teleport.usertasks.v1.DiscoverRDSDatabase
-	10, // 19: teleport.usertasks.v1.DiscoverAzureVM.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverAzureVMInstance
-	20, // [20:20] is the sub-list for method output_type
-	20, // [20:20] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	16, // 16: teleport.usertasks.v1.DiscoverAzureVMInstance.retry_after:type_name -> google.protobuf.Timestamp
+	4,  // 17: teleport.usertasks.v1.DiscoverEC2.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverEC2Instance
+	6,  // 18: teleport.usertasks.v1.DiscoverEKS.ClustersEntry.value:type_name -> teleport.usertasks.v1.DiscoverEKSCluster
+	8,  // 19: teleport.usertasks.v1.DiscoverRDS.DatabasesEntry.value:type_name -> teleport.usertasks.v1.DiscoverRDSDatabase
+	10, // 20: teleport.usertasks.v1.DiscoverAzureVM.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverAzureVMInstance
+	21, // [21:21] is the sub-list for method output_type
+	21, // [21:21] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_teleport_usertasks_v1_user_tasks_proto_init() }

--- a/api/gen/proto/go/teleport/usertasks/v1/user_tasks.pb.go
+++ b/api/gen/proto/go/teleport/usertasks/v1/user_tasks.pb.go
@@ -663,7 +663,7 @@ type DiscoverEC2Instance struct {
 	DiscoveryConfig string `protobuf:"bytes,6,opt,name=discovery_config,json=discoveryConfig,proto3" json:"discovery_config,omitempty"`
 	// DiscoveryGroup is the DiscoveryGroup name that originated this task.
 	DiscoveryGroup string `protobuf:"bytes,7,opt,name=discovery_group,json=discoveryGroup,proto3" json:"discovery_group,omitempty"`
-	// SyncTime is the timestamp when the error was produced.
+	// SyncTime is the timestamp of the latest discovery sync.
 	SyncTime      *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=sync_time,json=syncTime,proto3" json:"sync_time,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -786,7 +786,7 @@ type DiscoverEC2Instance_builder struct {
 	DiscoveryConfig string
 	// DiscoveryGroup is the DiscoveryGroup name that originated this task.
 	DiscoveryGroup string
-	// SyncTime is the timestamp when the error was produced.
+	// SyncTime is the timestamp of the latest discovery sync.
 	SyncTime *timestamppb.Timestamp
 }
 
@@ -920,7 +920,7 @@ type DiscoverEKSCluster struct {
 	DiscoveryConfig string `protobuf:"bytes,2,opt,name=discovery_config,json=discoveryConfig,proto3" json:"discovery_config,omitempty"`
 	// DiscoveryGroup is the DiscoveryGroup name that originated this task.
 	DiscoveryGroup string `protobuf:"bytes,3,opt,name=discovery_group,json=discoveryGroup,proto3" json:"discovery_group,omitempty"`
-	// SyncTime is the timestamp when the error was produced.
+	// SyncTime is the timestamp of the latest discovery sync.
 	SyncTime      *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=sync_time,json=syncTime,proto3" json:"sync_time,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1015,7 +1015,7 @@ type DiscoverEKSCluster_builder struct {
 	DiscoveryConfig string
 	// DiscoveryGroup is the DiscoveryGroup name that originated this task.
 	DiscoveryGroup string
-	// SyncTime is the timestamp when the error was produced.
+	// SyncTime is the timestamp of the latest discovery sync.
 	SyncTime *timestamppb.Timestamp
 }
 
@@ -1142,7 +1142,7 @@ type DiscoverRDSDatabase struct {
 	DiscoveryConfig string `protobuf:"bytes,4,opt,name=discovery_config,json=discoveryConfig,proto3" json:"discovery_config,omitempty"`
 	// DiscoveryGroup is the DiscoveryGroup name that originated this task.
 	DiscoveryGroup string `protobuf:"bytes,5,opt,name=discovery_group,json=discoveryGroup,proto3" json:"discovery_group,omitempty"`
-	// SyncTime is the timestamp when the error was produced.
+	// SyncTime is the timestamp of the latest discovery sync.
 	SyncTime      *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=sync_time,json=syncTime,proto3" json:"sync_time,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1266,7 +1266,7 @@ type DiscoverRDSDatabase_builder struct {
 	DiscoveryConfig string
 	// DiscoveryGroup is the DiscoveryGroup name that originated this task.
 	DiscoveryGroup string
-	// SyncTime is the timestamp when the error was produced.
+	// SyncTime is the timestamp of the latest discovery sync.
 	SyncTime *timestamppb.Timestamp
 }
 
@@ -1404,12 +1404,14 @@ type DiscoverAzureVMInstance struct {
 	DiscoveryConfig string `protobuf:"bytes,4,opt,name=discovery_config,json=discoveryConfig,proto3" json:"discovery_config,omitempty"`
 	// DiscoveryGroup is the DiscoveryGroup name that originated this task.
 	DiscoveryGroup string `protobuf:"bytes,5,opt,name=discovery_group,json=discoveryGroup,proto3" json:"discovery_group,omitempty"`
-	// SyncTime is the timestamp when the error was produced.
+	// SyncTime is the timestamp of the latest discovery sync.
 	SyncTime *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=sync_time,json=syncTime,proto3" json:"sync_time,omitempty"`
-	// FailureCount is the number of installation attempt failures.
-	FailureCount int32 `protobuf:"varint,7,opt,name=failure_count,json=failureCount,proto3" json:"failure_count,omitempty"`
-	// RetryAfter is the timestamp after which the VM installation will be retried.
-	RetryAfter    *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=retry_after,json=retryAfter,proto3" json:"retry_after,omitempty"`
+	// LastAttemptTime is the timestamp of the last installation attempt.
+	LastAttemptTime *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=last_attempt_time,json=lastAttemptTime,proto3" json:"last_attempt_time,omitempty"`
+	// RetryAfterTime is the timestamp after which the VM installation will be retried.
+	RetryAfterTime *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=retry_after_time,json=retryAfterTime,proto3" json:"retry_after_time,omitempty"`
+	// Attempts is the number of installation attempts.
+	Attempts      int32 `protobuf:"varint,9,opt,name=attempts,proto3" json:"attempts,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1481,18 +1483,25 @@ func (x *DiscoverAzureVMInstance) GetSyncTime() *timestamppb.Timestamp {
 	return nil
 }
 
-func (x *DiscoverAzureVMInstance) GetFailureCount() int32 {
+func (x *DiscoverAzureVMInstance) GetLastAttemptTime() *timestamppb.Timestamp {
 	if x != nil {
-		return x.FailureCount
-	}
-	return 0
-}
-
-func (x *DiscoverAzureVMInstance) GetRetryAfter() *timestamppb.Timestamp {
-	if x != nil {
-		return x.RetryAfter
+		return x.LastAttemptTime
 	}
 	return nil
+}
+
+func (x *DiscoverAzureVMInstance) GetRetryAfterTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.RetryAfterTime
+	}
+	return nil
+}
+
+func (x *DiscoverAzureVMInstance) GetAttempts() int32 {
+	if x != nil {
+		return x.Attempts
+	}
+	return 0
 }
 
 func (x *DiscoverAzureVMInstance) SetVmId(v string) {
@@ -1519,12 +1528,16 @@ func (x *DiscoverAzureVMInstance) SetSyncTime(v *timestamppb.Timestamp) {
 	x.SyncTime = v
 }
 
-func (x *DiscoverAzureVMInstance) SetFailureCount(v int32) {
-	x.FailureCount = v
+func (x *DiscoverAzureVMInstance) SetLastAttemptTime(v *timestamppb.Timestamp) {
+	x.LastAttemptTime = v
 }
 
-func (x *DiscoverAzureVMInstance) SetRetryAfter(v *timestamppb.Timestamp) {
-	x.RetryAfter = v
+func (x *DiscoverAzureVMInstance) SetRetryAfterTime(v *timestamppb.Timestamp) {
+	x.RetryAfterTime = v
+}
+
+func (x *DiscoverAzureVMInstance) SetAttempts(v int32) {
+	x.Attempts = v
 }
 
 func (x *DiscoverAzureVMInstance) HasSyncTime() bool {
@@ -1534,19 +1547,30 @@ func (x *DiscoverAzureVMInstance) HasSyncTime() bool {
 	return x.SyncTime != nil
 }
 
-func (x *DiscoverAzureVMInstance) HasRetryAfter() bool {
+func (x *DiscoverAzureVMInstance) HasLastAttemptTime() bool {
 	if x == nil {
 		return false
 	}
-	return x.RetryAfter != nil
+	return x.LastAttemptTime != nil
+}
+
+func (x *DiscoverAzureVMInstance) HasRetryAfterTime() bool {
+	if x == nil {
+		return false
+	}
+	return x.RetryAfterTime != nil
 }
 
 func (x *DiscoverAzureVMInstance) ClearSyncTime() {
 	x.SyncTime = nil
 }
 
-func (x *DiscoverAzureVMInstance) ClearRetryAfter() {
-	x.RetryAfter = nil
+func (x *DiscoverAzureVMInstance) ClearLastAttemptTime() {
+	x.LastAttemptTime = nil
+}
+
+func (x *DiscoverAzureVMInstance) ClearRetryAfterTime() {
+	x.RetryAfterTime = nil
 }
 
 type DiscoverAzureVMInstance_builder struct {
@@ -1562,12 +1586,14 @@ type DiscoverAzureVMInstance_builder struct {
 	DiscoveryConfig string
 	// DiscoveryGroup is the DiscoveryGroup name that originated this task.
 	DiscoveryGroup string
-	// SyncTime is the timestamp when the error was produced.
+	// SyncTime is the timestamp of the latest discovery sync.
 	SyncTime *timestamppb.Timestamp
-	// FailureCount is the number of installation attempt failures.
-	FailureCount int32
-	// RetryAfter is the timestamp after which the VM installation will be retried.
-	RetryAfter *timestamppb.Timestamp
+	// LastAttemptTime is the timestamp of the last installation attempt.
+	LastAttemptTime *timestamppb.Timestamp
+	// RetryAfterTime is the timestamp after which the VM installation will be retried.
+	RetryAfterTime *timestamppb.Timestamp
+	// Attempts is the number of installation attempts.
+	Attempts int32
 }
 
 func (b0 DiscoverAzureVMInstance_builder) Build() *DiscoverAzureVMInstance {
@@ -1580,8 +1606,9 @@ func (b0 DiscoverAzureVMInstance_builder) Build() *DiscoverAzureVMInstance {
 	x.DiscoveryConfig = b.DiscoveryConfig
 	x.DiscoveryGroup = b.DiscoveryGroup
 	x.SyncTime = b.SyncTime
-	x.FailureCount = b.FailureCount
-	x.RetryAfter = b.RetryAfter
+	x.LastAttemptTime = b.LastAttemptTime
+	x.RetryAfterTime = b.RetryAfterTime
+	x.Attempts = b.Attempts
 	return m0
 }
 
@@ -1665,7 +1692,7 @@ const file_teleport_usertasks_v1_user_tasks_proto_rawDesc = "" +
 	"\x06region\x18\x04 \x01(\tR\x06region\x1al\n" +
 	"\x0eInstancesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12D\n" +
-	"\x05value\x18\x02 \x01(\v2..teleport.usertasks.v1.DiscoverAzureVMInstanceR\x05value:\x028\x01\"\xd2\x02\n" +
+	"\x05value\x18\x02 \x01(\v2..teleport.usertasks.v1.DiscoverAzureVMInstanceR\x05value:\x028\x01\"\x9a\x03\n" +
 	"\x17DiscoverAzureVMInstance\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12\x1f\n" +
 	"\vresource_id\x18\x02 \x01(\tR\n" +
@@ -1673,10 +1700,10 @@ const file_teleport_usertasks_v1_user_tasks_proto_rawDesc = "" +
 	"\x04name\x18\x03 \x01(\tR\x04name\x12)\n" +
 	"\x10discovery_config\x18\x04 \x01(\tR\x0fdiscoveryConfig\x12'\n" +
 	"\x0fdiscovery_group\x18\x05 \x01(\tR\x0ediscoveryGroup\x127\n" +
-	"\tsync_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\bsyncTime\x12#\n" +
-	"\rfailure_count\x18\a \x01(\x05R\ffailureCount\x12;\n" +
-	"\vretry_after\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\n" +
-	"retryAfterBVZTgithub.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1;usertasksv1b\x06proto3"
+	"\tsync_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\bsyncTime\x12F\n" +
+	"\x11last_attempt_time\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\x0flastAttemptTime\x12D\n" +
+	"\x10retry_after_time\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\x0eretryAfterTime\x12\x1a\n" +
+	"\battempts\x18\t \x01(\x05R\battemptsBVZTgithub.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1;usertasksv1b\x06proto3"
 
 var file_teleport_usertasks_v1_user_tasks_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_teleport_usertasks_v1_user_tasks_proto_goTypes = []any{
@@ -1715,16 +1742,17 @@ var file_teleport_usertasks_v1_user_tasks_proto_depIdxs = []int32{
 	16, // 13: teleport.usertasks.v1.DiscoverRDSDatabase.sync_time:type_name -> google.protobuf.Timestamp
 	14, // 14: teleport.usertasks.v1.DiscoverAzureVM.instances:type_name -> teleport.usertasks.v1.DiscoverAzureVM.InstancesEntry
 	16, // 15: teleport.usertasks.v1.DiscoverAzureVMInstance.sync_time:type_name -> google.protobuf.Timestamp
-	16, // 16: teleport.usertasks.v1.DiscoverAzureVMInstance.retry_after:type_name -> google.protobuf.Timestamp
-	4,  // 17: teleport.usertasks.v1.DiscoverEC2.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverEC2Instance
-	6,  // 18: teleport.usertasks.v1.DiscoverEKS.ClustersEntry.value:type_name -> teleport.usertasks.v1.DiscoverEKSCluster
-	8,  // 19: teleport.usertasks.v1.DiscoverRDS.DatabasesEntry.value:type_name -> teleport.usertasks.v1.DiscoverRDSDatabase
-	10, // 20: teleport.usertasks.v1.DiscoverAzureVM.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverAzureVMInstance
-	21, // [21:21] is the sub-list for method output_type
-	21, // [21:21] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	16, // 16: teleport.usertasks.v1.DiscoverAzureVMInstance.last_attempt_time:type_name -> google.protobuf.Timestamp
+	16, // 17: teleport.usertasks.v1.DiscoverAzureVMInstance.retry_after_time:type_name -> google.protobuf.Timestamp
+	4,  // 18: teleport.usertasks.v1.DiscoverEC2.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverEC2Instance
+	6,  // 19: teleport.usertasks.v1.DiscoverEKS.ClustersEntry.value:type_name -> teleport.usertasks.v1.DiscoverEKSCluster
+	8,  // 20: teleport.usertasks.v1.DiscoverRDS.DatabasesEntry.value:type_name -> teleport.usertasks.v1.DiscoverRDSDatabase
+	10, // 21: teleport.usertasks.v1.DiscoverAzureVM.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverAzureVMInstance
+	22, // [22:22] is the sub-list for method output_type
+	22, // [22:22] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_teleport_usertasks_v1_user_tasks_proto_init() }

--- a/api/gen/proto/go/teleport/usertasks/v1/user_tasks_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/usertasks/v1/user_tasks_protoopaque.pb.go
@@ -1335,6 +1335,8 @@ type DiscoverAzureVMInstance struct {
 	xxx_hidden_DiscoveryConfig string                 `protobuf:"bytes,4,opt,name=discovery_config,json=discoveryConfig,proto3"`
 	xxx_hidden_DiscoveryGroup  string                 `protobuf:"bytes,5,opt,name=discovery_group,json=discoveryGroup,proto3"`
 	xxx_hidden_SyncTime        *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=sync_time,json=syncTime,proto3"`
+	xxx_hidden_FailureCount    int32                  `protobuf:"varint,7,opt,name=failure_count,json=failureCount,proto3"`
+	xxx_hidden_RetryAfter      *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=retry_after,json=retryAfter,proto3"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache
 }
@@ -1406,6 +1408,20 @@ func (x *DiscoverAzureVMInstance) GetSyncTime() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *DiscoverAzureVMInstance) GetFailureCount() int32 {
+	if x != nil {
+		return x.xxx_hidden_FailureCount
+	}
+	return 0
+}
+
+func (x *DiscoverAzureVMInstance) GetRetryAfter() *timestamppb.Timestamp {
+	if x != nil {
+		return x.xxx_hidden_RetryAfter
+	}
+	return nil
+}
+
 func (x *DiscoverAzureVMInstance) SetVmId(v string) {
 	x.xxx_hidden_VmId = v
 }
@@ -1430,6 +1446,14 @@ func (x *DiscoverAzureVMInstance) SetSyncTime(v *timestamppb.Timestamp) {
 	x.xxx_hidden_SyncTime = v
 }
 
+func (x *DiscoverAzureVMInstance) SetFailureCount(v int32) {
+	x.xxx_hidden_FailureCount = v
+}
+
+func (x *DiscoverAzureVMInstance) SetRetryAfter(v *timestamppb.Timestamp) {
+	x.xxx_hidden_RetryAfter = v
+}
+
 func (x *DiscoverAzureVMInstance) HasSyncTime() bool {
 	if x == nil {
 		return false
@@ -1437,8 +1461,19 @@ func (x *DiscoverAzureVMInstance) HasSyncTime() bool {
 	return x.xxx_hidden_SyncTime != nil
 }
 
+func (x *DiscoverAzureVMInstance) HasRetryAfter() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_RetryAfter != nil
+}
+
 func (x *DiscoverAzureVMInstance) ClearSyncTime() {
 	x.xxx_hidden_SyncTime = nil
+}
+
+func (x *DiscoverAzureVMInstance) ClearRetryAfter() {
+	x.xxx_hidden_RetryAfter = nil
 }
 
 type DiscoverAzureVMInstance_builder struct {
@@ -1456,6 +1491,10 @@ type DiscoverAzureVMInstance_builder struct {
 	DiscoveryGroup string
 	// SyncTime is the timestamp when the error was produced.
 	SyncTime *timestamppb.Timestamp
+	// FailureCount is the number of installation attempt failures.
+	FailureCount int32
+	// RetryAfter is the timestamp after which the VM installation will be retried.
+	RetryAfter *timestamppb.Timestamp
 }
 
 func (b0 DiscoverAzureVMInstance_builder) Build() *DiscoverAzureVMInstance {
@@ -1468,6 +1507,8 @@ func (b0 DiscoverAzureVMInstance_builder) Build() *DiscoverAzureVMInstance {
 	x.xxx_hidden_DiscoveryConfig = b.DiscoveryConfig
 	x.xxx_hidden_DiscoveryGroup = b.DiscoveryGroup
 	x.xxx_hidden_SyncTime = b.SyncTime
+	x.xxx_hidden_FailureCount = b.FailureCount
+	x.xxx_hidden_RetryAfter = b.RetryAfter
 	return m0
 }
 
@@ -1551,7 +1592,7 @@ const file_teleport_usertasks_v1_user_tasks_proto_rawDesc = "" +
 	"\x06region\x18\x04 \x01(\tR\x06region\x1al\n" +
 	"\x0eInstancesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12D\n" +
-	"\x05value\x18\x02 \x01(\v2..teleport.usertasks.v1.DiscoverAzureVMInstanceR\x05value:\x028\x01\"\xf0\x01\n" +
+	"\x05value\x18\x02 \x01(\v2..teleport.usertasks.v1.DiscoverAzureVMInstanceR\x05value:\x028\x01\"\xd2\x02\n" +
 	"\x17DiscoverAzureVMInstance\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12\x1f\n" +
 	"\vresource_id\x18\x02 \x01(\tR\n" +
@@ -1559,7 +1600,10 @@ const file_teleport_usertasks_v1_user_tasks_proto_rawDesc = "" +
 	"\x04name\x18\x03 \x01(\tR\x04name\x12)\n" +
 	"\x10discovery_config\x18\x04 \x01(\tR\x0fdiscoveryConfig\x12'\n" +
 	"\x0fdiscovery_group\x18\x05 \x01(\tR\x0ediscoveryGroup\x127\n" +
-	"\tsync_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\bsyncTimeBVZTgithub.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1;usertasksv1b\x06proto3"
+	"\tsync_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\bsyncTime\x12#\n" +
+	"\rfailure_count\x18\a \x01(\x05R\ffailureCount\x12;\n" +
+	"\vretry_after\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"retryAfterBVZTgithub.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1;usertasksv1b\x06proto3"
 
 var file_teleport_usertasks_v1_user_tasks_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_teleport_usertasks_v1_user_tasks_proto_goTypes = []any{
@@ -1598,15 +1642,16 @@ var file_teleport_usertasks_v1_user_tasks_proto_depIdxs = []int32{
 	16, // 13: teleport.usertasks.v1.DiscoverRDSDatabase.sync_time:type_name -> google.protobuf.Timestamp
 	14, // 14: teleport.usertasks.v1.DiscoverAzureVM.instances:type_name -> teleport.usertasks.v1.DiscoverAzureVM.InstancesEntry
 	16, // 15: teleport.usertasks.v1.DiscoverAzureVMInstance.sync_time:type_name -> google.protobuf.Timestamp
-	4,  // 16: teleport.usertasks.v1.DiscoverEC2.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverEC2Instance
-	6,  // 17: teleport.usertasks.v1.DiscoverEKS.ClustersEntry.value:type_name -> teleport.usertasks.v1.DiscoverEKSCluster
-	8,  // 18: teleport.usertasks.v1.DiscoverRDS.DatabasesEntry.value:type_name -> teleport.usertasks.v1.DiscoverRDSDatabase
-	10, // 19: teleport.usertasks.v1.DiscoverAzureVM.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverAzureVMInstance
-	20, // [20:20] is the sub-list for method output_type
-	20, // [20:20] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	16, // 16: teleport.usertasks.v1.DiscoverAzureVMInstance.retry_after:type_name -> google.protobuf.Timestamp
+	4,  // 17: teleport.usertasks.v1.DiscoverEC2.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverEC2Instance
+	6,  // 18: teleport.usertasks.v1.DiscoverEKS.ClustersEntry.value:type_name -> teleport.usertasks.v1.DiscoverEKSCluster
+	8,  // 19: teleport.usertasks.v1.DiscoverRDS.DatabasesEntry.value:type_name -> teleport.usertasks.v1.DiscoverRDSDatabase
+	10, // 20: teleport.usertasks.v1.DiscoverAzureVM.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverAzureVMInstance
+	21, // [21:21] is the sub-list for method output_type
+	21, // [21:21] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_teleport_usertasks_v1_user_tasks_proto_init() }

--- a/api/gen/proto/go/teleport/usertasks/v1/user_tasks_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/usertasks/v1/user_tasks_protoopaque.pb.go
@@ -747,7 +747,7 @@ type DiscoverEC2Instance_builder struct {
 	DiscoveryConfig string
 	// DiscoveryGroup is the DiscoveryGroup name that originated this task.
 	DiscoveryGroup string
-	// SyncTime is the timestamp when the error was produced.
+	// SyncTime is the timestamp of the latest discovery sync.
 	SyncTime *timestamppb.Timestamp
 }
 
@@ -968,7 +968,7 @@ type DiscoverEKSCluster_builder struct {
 	DiscoveryConfig string
 	// DiscoveryGroup is the DiscoveryGroup name that originated this task.
 	DiscoveryGroup string
-	// SyncTime is the timestamp when the error was produced.
+	// SyncTime is the timestamp of the latest discovery sync.
 	SyncTime *timestamppb.Timestamp
 }
 
@@ -1205,7 +1205,7 @@ type DiscoverRDSDatabase_builder struct {
 	DiscoveryConfig string
 	// DiscoveryGroup is the DiscoveryGroup name that originated this task.
 	DiscoveryGroup string
-	// SyncTime is the timestamp when the error was produced.
+	// SyncTime is the timestamp of the latest discovery sync.
 	SyncTime *timestamppb.Timestamp
 }
 
@@ -1335,8 +1335,9 @@ type DiscoverAzureVMInstance struct {
 	xxx_hidden_DiscoveryConfig string                 `protobuf:"bytes,4,opt,name=discovery_config,json=discoveryConfig,proto3"`
 	xxx_hidden_DiscoveryGroup  string                 `protobuf:"bytes,5,opt,name=discovery_group,json=discoveryGroup,proto3"`
 	xxx_hidden_SyncTime        *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=sync_time,json=syncTime,proto3"`
-	xxx_hidden_FailureCount    int32                  `protobuf:"varint,7,opt,name=failure_count,json=failureCount,proto3"`
-	xxx_hidden_RetryAfter      *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=retry_after,json=retryAfter,proto3"`
+	xxx_hidden_LastAttemptTime *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=last_attempt_time,json=lastAttemptTime,proto3"`
+	xxx_hidden_RetryAfterTime  *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=retry_after_time,json=retryAfterTime,proto3"`
+	xxx_hidden_Attempts        int32                  `protobuf:"varint,9,opt,name=attempts,proto3"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache
 }
@@ -1408,18 +1409,25 @@ func (x *DiscoverAzureVMInstance) GetSyncTime() *timestamppb.Timestamp {
 	return nil
 }
 
-func (x *DiscoverAzureVMInstance) GetFailureCount() int32 {
+func (x *DiscoverAzureVMInstance) GetLastAttemptTime() *timestamppb.Timestamp {
 	if x != nil {
-		return x.xxx_hidden_FailureCount
-	}
-	return 0
-}
-
-func (x *DiscoverAzureVMInstance) GetRetryAfter() *timestamppb.Timestamp {
-	if x != nil {
-		return x.xxx_hidden_RetryAfter
+		return x.xxx_hidden_LastAttemptTime
 	}
 	return nil
+}
+
+func (x *DiscoverAzureVMInstance) GetRetryAfterTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.xxx_hidden_RetryAfterTime
+	}
+	return nil
+}
+
+func (x *DiscoverAzureVMInstance) GetAttempts() int32 {
+	if x != nil {
+		return x.xxx_hidden_Attempts
+	}
+	return 0
 }
 
 func (x *DiscoverAzureVMInstance) SetVmId(v string) {
@@ -1446,12 +1454,16 @@ func (x *DiscoverAzureVMInstance) SetSyncTime(v *timestamppb.Timestamp) {
 	x.xxx_hidden_SyncTime = v
 }
 
-func (x *DiscoverAzureVMInstance) SetFailureCount(v int32) {
-	x.xxx_hidden_FailureCount = v
+func (x *DiscoverAzureVMInstance) SetLastAttemptTime(v *timestamppb.Timestamp) {
+	x.xxx_hidden_LastAttemptTime = v
 }
 
-func (x *DiscoverAzureVMInstance) SetRetryAfter(v *timestamppb.Timestamp) {
-	x.xxx_hidden_RetryAfter = v
+func (x *DiscoverAzureVMInstance) SetRetryAfterTime(v *timestamppb.Timestamp) {
+	x.xxx_hidden_RetryAfterTime = v
+}
+
+func (x *DiscoverAzureVMInstance) SetAttempts(v int32) {
+	x.xxx_hidden_Attempts = v
 }
 
 func (x *DiscoverAzureVMInstance) HasSyncTime() bool {
@@ -1461,19 +1473,30 @@ func (x *DiscoverAzureVMInstance) HasSyncTime() bool {
 	return x.xxx_hidden_SyncTime != nil
 }
 
-func (x *DiscoverAzureVMInstance) HasRetryAfter() bool {
+func (x *DiscoverAzureVMInstance) HasLastAttemptTime() bool {
 	if x == nil {
 		return false
 	}
-	return x.xxx_hidden_RetryAfter != nil
+	return x.xxx_hidden_LastAttemptTime != nil
+}
+
+func (x *DiscoverAzureVMInstance) HasRetryAfterTime() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_RetryAfterTime != nil
 }
 
 func (x *DiscoverAzureVMInstance) ClearSyncTime() {
 	x.xxx_hidden_SyncTime = nil
 }
 
-func (x *DiscoverAzureVMInstance) ClearRetryAfter() {
-	x.xxx_hidden_RetryAfter = nil
+func (x *DiscoverAzureVMInstance) ClearLastAttemptTime() {
+	x.xxx_hidden_LastAttemptTime = nil
+}
+
+func (x *DiscoverAzureVMInstance) ClearRetryAfterTime() {
+	x.xxx_hidden_RetryAfterTime = nil
 }
 
 type DiscoverAzureVMInstance_builder struct {
@@ -1489,12 +1512,14 @@ type DiscoverAzureVMInstance_builder struct {
 	DiscoveryConfig string
 	// DiscoveryGroup is the DiscoveryGroup name that originated this task.
 	DiscoveryGroup string
-	// SyncTime is the timestamp when the error was produced.
+	// SyncTime is the timestamp of the latest discovery sync.
 	SyncTime *timestamppb.Timestamp
-	// FailureCount is the number of installation attempt failures.
-	FailureCount int32
-	// RetryAfter is the timestamp after which the VM installation will be retried.
-	RetryAfter *timestamppb.Timestamp
+	// LastAttemptTime is the timestamp of the last installation attempt.
+	LastAttemptTime *timestamppb.Timestamp
+	// RetryAfterTime is the timestamp after which the VM installation will be retried.
+	RetryAfterTime *timestamppb.Timestamp
+	// Attempts is the number of installation attempts.
+	Attempts int32
 }
 
 func (b0 DiscoverAzureVMInstance_builder) Build() *DiscoverAzureVMInstance {
@@ -1507,8 +1532,9 @@ func (b0 DiscoverAzureVMInstance_builder) Build() *DiscoverAzureVMInstance {
 	x.xxx_hidden_DiscoveryConfig = b.DiscoveryConfig
 	x.xxx_hidden_DiscoveryGroup = b.DiscoveryGroup
 	x.xxx_hidden_SyncTime = b.SyncTime
-	x.xxx_hidden_FailureCount = b.FailureCount
-	x.xxx_hidden_RetryAfter = b.RetryAfter
+	x.xxx_hidden_LastAttemptTime = b.LastAttemptTime
+	x.xxx_hidden_RetryAfterTime = b.RetryAfterTime
+	x.xxx_hidden_Attempts = b.Attempts
 	return m0
 }
 
@@ -1592,7 +1618,7 @@ const file_teleport_usertasks_v1_user_tasks_proto_rawDesc = "" +
 	"\x06region\x18\x04 \x01(\tR\x06region\x1al\n" +
 	"\x0eInstancesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12D\n" +
-	"\x05value\x18\x02 \x01(\v2..teleport.usertasks.v1.DiscoverAzureVMInstanceR\x05value:\x028\x01\"\xd2\x02\n" +
+	"\x05value\x18\x02 \x01(\v2..teleport.usertasks.v1.DiscoverAzureVMInstanceR\x05value:\x028\x01\"\x9a\x03\n" +
 	"\x17DiscoverAzureVMInstance\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12\x1f\n" +
 	"\vresource_id\x18\x02 \x01(\tR\n" +
@@ -1600,10 +1626,10 @@ const file_teleport_usertasks_v1_user_tasks_proto_rawDesc = "" +
 	"\x04name\x18\x03 \x01(\tR\x04name\x12)\n" +
 	"\x10discovery_config\x18\x04 \x01(\tR\x0fdiscoveryConfig\x12'\n" +
 	"\x0fdiscovery_group\x18\x05 \x01(\tR\x0ediscoveryGroup\x127\n" +
-	"\tsync_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\bsyncTime\x12#\n" +
-	"\rfailure_count\x18\a \x01(\x05R\ffailureCount\x12;\n" +
-	"\vretry_after\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\n" +
-	"retryAfterBVZTgithub.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1;usertasksv1b\x06proto3"
+	"\tsync_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\bsyncTime\x12F\n" +
+	"\x11last_attempt_time\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\x0flastAttemptTime\x12D\n" +
+	"\x10retry_after_time\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\x0eretryAfterTime\x12\x1a\n" +
+	"\battempts\x18\t \x01(\x05R\battemptsBVZTgithub.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1;usertasksv1b\x06proto3"
 
 var file_teleport_usertasks_v1_user_tasks_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_teleport_usertasks_v1_user_tasks_proto_goTypes = []any{
@@ -1642,16 +1668,17 @@ var file_teleport_usertasks_v1_user_tasks_proto_depIdxs = []int32{
 	16, // 13: teleport.usertasks.v1.DiscoverRDSDatabase.sync_time:type_name -> google.protobuf.Timestamp
 	14, // 14: teleport.usertasks.v1.DiscoverAzureVM.instances:type_name -> teleport.usertasks.v1.DiscoverAzureVM.InstancesEntry
 	16, // 15: teleport.usertasks.v1.DiscoverAzureVMInstance.sync_time:type_name -> google.protobuf.Timestamp
-	16, // 16: teleport.usertasks.v1.DiscoverAzureVMInstance.retry_after:type_name -> google.protobuf.Timestamp
-	4,  // 17: teleport.usertasks.v1.DiscoverEC2.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverEC2Instance
-	6,  // 18: teleport.usertasks.v1.DiscoverEKS.ClustersEntry.value:type_name -> teleport.usertasks.v1.DiscoverEKSCluster
-	8,  // 19: teleport.usertasks.v1.DiscoverRDS.DatabasesEntry.value:type_name -> teleport.usertasks.v1.DiscoverRDSDatabase
-	10, // 20: teleport.usertasks.v1.DiscoverAzureVM.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverAzureVMInstance
-	21, // [21:21] is the sub-list for method output_type
-	21, // [21:21] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	16, // 16: teleport.usertasks.v1.DiscoverAzureVMInstance.last_attempt_time:type_name -> google.protobuf.Timestamp
+	16, // 17: teleport.usertasks.v1.DiscoverAzureVMInstance.retry_after_time:type_name -> google.protobuf.Timestamp
+	4,  // 18: teleport.usertasks.v1.DiscoverEC2.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverEC2Instance
+	6,  // 19: teleport.usertasks.v1.DiscoverEKS.ClustersEntry.value:type_name -> teleport.usertasks.v1.DiscoverEKSCluster
+	8,  // 20: teleport.usertasks.v1.DiscoverRDS.DatabasesEntry.value:type_name -> teleport.usertasks.v1.DiscoverRDSDatabase
+	10, // 21: teleport.usertasks.v1.DiscoverAzureVM.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverAzureVMInstance
+	22, // [22:22] is the sub-list for method output_type
+	22, // [22:22] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_teleport_usertasks_v1_user_tasks_proto_init() }

--- a/api/proto/teleport/usertasks/v1/user_tasks.proto
+++ b/api/proto/teleport/usertasks/v1/user_tasks.proto
@@ -110,7 +110,7 @@ message DiscoverEC2Instance {
   string discovery_config = 6;
   // DiscoveryGroup is the DiscoveryGroup name that originated this task.
   string discovery_group = 7;
-  // SyncTime is the timestamp when the error was produced.
+  // SyncTime is the timestamp of the latest discovery sync.
   google.protobuf.Timestamp sync_time = 8;
 }
 
@@ -134,7 +134,7 @@ message DiscoverEKSCluster {
   string discovery_config = 2;
   // DiscoveryGroup is the DiscoveryGroup name that originated this task.
   string discovery_group = 3;
-  // SyncTime is the timestamp when the error was produced.
+  // SyncTime is the timestamp of the latest discovery sync.
   google.protobuf.Timestamp sync_time = 4;
 }
 
@@ -165,7 +165,7 @@ message DiscoverRDSDatabase {
   string discovery_config = 4;
   // DiscoveryGroup is the DiscoveryGroup name that originated this task.
   string discovery_group = 5;
-  // SyncTime is the timestamp when the error was produced.
+  // SyncTime is the timestamp of the latest discovery sync.
   google.protobuf.Timestamp sync_time = 6;
 }
 
@@ -193,10 +193,12 @@ message DiscoverAzureVMInstance {
   string discovery_config = 4;
   // DiscoveryGroup is the DiscoveryGroup name that originated this task.
   string discovery_group = 5;
-  // SyncTime is the timestamp when the error was produced.
+  // SyncTime is the timestamp of the latest discovery sync.
   google.protobuf.Timestamp sync_time = 6;
-  // FailureCount is the number of installation attempt failures.
-  int32 failure_count = 7;
-  // RetryAfter is the timestamp after which the VM installation will be retried.
-  google.protobuf.Timestamp retry_after = 8;
+  // LastAttemptTime is the timestamp of the last installation attempt.
+  google.protobuf.Timestamp last_attempt_time = 7;
+  // RetryAfterTime is the timestamp after which the VM installation will be retried.
+  google.protobuf.Timestamp retry_after_time = 8;
+  // Attempts is the number of installation attempts.
+  int32 attempts = 9;
 }

--- a/api/proto/teleport/usertasks/v1/user_tasks.proto
+++ b/api/proto/teleport/usertasks/v1/user_tasks.proto
@@ -195,4 +195,8 @@ message DiscoverAzureVMInstance {
   string discovery_group = 5;
   // SyncTime is the timestamp when the error was produced.
   google.protobuf.Timestamp sync_time = 6;
+  // FailureCount is the number of installation attempt failures.
+  int32 failure_count = 7;
+  // RetryAfter is the timestamp after which the VM installation will be retried.
+  google.protobuf.Timestamp retry_after = 8;
 }

--- a/api/types/discoveryconfig/convert/v1/discoveryconfig_test.go
+++ b/api/types/discoveryconfig/convert/v1/discoveryconfig_test.go
@@ -80,7 +80,7 @@ func newDiscoveryConfig(t *testing.T, name string) *discoveryconfig.DiscoveryCon
 		"my-integration": {
 			IntegrationDiscoveredSummary: &discoveryconfigv1.IntegrationDiscoveredSummary{
 				AwsEc2: &discoveryconfigv1.ResourcesDiscoveredSummary{
-					Found:    3,
+					Found:    4,
 					Enrolled: 2,
 					Failed:   1,
 				},

--- a/api/types/usertasks/object_test.go
+++ b/api/types/usertasks/object_test.go
@@ -939,6 +939,7 @@ func TestNewDiscoverAzureVMUserTask(t *testing.T) {
 	userTaskExpirationTime := time.Now()
 	userTaskExpirationTimestamp := timestamppb.New(userTaskExpirationTime)
 	vmSyncTimestamp := userTaskExpirationTimestamp
+	vmRetryTimestamp := timestamppb.New(time.Now().Add(time.Minute))
 
 	exampleVMID := "/subscriptions/sub-123/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachines/my-vm"
 
@@ -952,6 +953,9 @@ func TestNewDiscoverAzureVMUserTask(t *testing.T) {
 				DiscoveryConfig: "dc01",
 				DiscoveryGroup:  "dg01",
 				SyncTime:        vmSyncTimestamp,
+				LastAttemptTime: timestamppb.New(vmRetryTimestamp.AsTime().Add(-time.Minute)),
+				RetryAfterTime:  vmRetryTimestamp,
+				Attempts:        2,
 			},
 		},
 	}

--- a/api/utils/retryutils/retryv2.go
+++ b/api/utils/retryutils/retryv2.go
@@ -26,7 +26,7 @@ import (
 
 // maxBackoff is an absolute maximum amount of backoff that our backoff helpers will
 // apply. Used as a safety precaution to limit the impact of misconfigured backoffs.
-const maxBackoff = 16 * time.Minute
+const maxBackoff = 3 * time.Hour
 
 // maxAttempts is the peak attempt number we will scale to (used to prevent overflows).
 const maxAttempts = 16

--- a/lib/srv/discovery/backoff.go
+++ b/lib/srv/discovery/backoff.go
@@ -1,0 +1,195 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package discovery
+
+import (
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/lib/cloud/azure"
+	"github.com/gravitational/teleport/lib/srv/server"
+)
+
+const (
+	maxInstallBackoff = 3 * time.Hour
+	minInstallBackoff = time.Minute
+)
+
+type installerBackoffEntry struct {
+	vm *azure.VirtualMachine
+	// issueType is the latest installation issue for this entry.
+	issueType string
+	// attempts is the count of installation attempts for this entry.
+	attempts int32
+	// lastAttemptAt is the time of the last attempt.
+	lastAttemptAt time.Time
+	// retryAfter is the time after which the installation can be retried.
+	retryAfter time.Time
+	// seenInLastScan indicates that the VM was seen in the last discovery scan.
+	// These are the VMs that were discovered and not already enrolled.
+	seenInLastScan bool
+	// retry tracks the attempts and calculates the retry backoff duration.
+	retry retryutils.Retry
+}
+
+// retryable returns true if the entry can be retried.
+func (e *installerBackoffEntry) retryable(t time.Time) bool {
+	return t.After(e.retryAfter)
+}
+
+func (e *installerBackoffEntry) isFailedAttempt() bool {
+	return e.issueType != ""
+}
+
+type installerBackoffKey struct {
+	// resourceID is the path based resource ID Azure, e.g., /subscriptions/<sub-id>/resourceGroups/<rg-id>/providers/Microsoft.Compute/virtualMachines/<vm-name>
+	// It is not necessarily unique.
+	resourceID string
+	// vmID is a VM UUID. In practice this ID is not empty.
+	// In case it is empty, we also include the resource ID.
+	vmID string
+}
+
+func newInstallerBackoffKey(vm *azure.VirtualMachine) installerBackoffKey {
+	return installerBackoffKey{
+		resourceID: vm.ID,
+		vmID:       vm.VMID,
+	}
+}
+
+// installerBackoff tracks VM installation attempts backs the installer off to
+// avoid excessive attempts.
+type installerBackoff struct {
+	retry *retryutils.RetryV2
+
+	mu sync.Mutex
+	// entries is a map of installation attempts, by VM ID.
+	entries map[installerBackoffKey]*installerBackoffEntry
+}
+
+// newInstallerBackoff creates a new [*installerBackoff].
+func newInstallerBackoff(baseDelay time.Duration, jitter retryutils.Jitter) (*installerBackoff, error) {
+	// bound the base delay to [minInstallBackoff, maxInstallBackoff/4]
+	baseDelay = min(
+		max(baseDelay, minInstallBackoff),
+		maxInstallBackoff/4,
+	)
+	retry, err := retryutils.NewRetryV2(retryutils.RetryV2Config{
+		Driver: retryutils.NewExponentialDriver(baseDelay),
+		Max:    maxInstallBackoff,
+		Jitter: jitter,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &installerBackoff{
+		retry:   retry,
+		entries: make(map[installerBackoffKey]*installerBackoffEntry),
+	}, nil
+}
+
+// filter filters out instances that are should be backed off and returns the
+// list of entries that were removed.
+func (b *installerBackoff) filter(instances *server.AzureInstances, t time.Time) []installerBackoffEntry {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	var removed []installerBackoffEntry
+	instances.Instances = slices.DeleteFunc(instances.Instances, func(vm *azure.VirtualMachine) bool {
+		entry := b.addLocked(vm)
+		entry.seenInLastScan = true
+		if entry.retryable(t) {
+			return false
+		}
+		removed = append(removed, *entry)
+		return true
+	})
+	return removed
+}
+
+func (b *installerBackoff) addLocked(vm *azure.VirtualMachine) *installerBackoffEntry {
+	key := newInstallerBackoffKey(vm)
+	entry := b.entries[key]
+	if entry == nil {
+		entry = &installerBackoffEntry{
+			retry: b.retry.Clone(),
+		}
+		b.entries[key] = entry
+	}
+	entry.vm = vm
+	return entry
+}
+
+func (b *installerBackoff) recordAttemptLocked(vm *azure.VirtualMachine, t time.Time) *installerBackoffEntry {
+	entry := b.addLocked(vm)
+	entry.retry.Inc()
+	entry.attempts++
+	entry.lastAttemptAt = t
+	entry.retryAfter = t.Add(entry.retry.Duration())
+	entry.seenInLastScan = true
+	return entry
+}
+
+func (b *installerBackoff) recordSuccessfulAttempt(vm *azure.VirtualMachine, t time.Time) installerBackoffEntry {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	entry := b.recordAttemptLocked(vm, t)
+	entry.issueType = ""
+	return *entry
+}
+
+// recordFailedAttempt records an entry in the backoff for a failed VM
+// installation attempt and returns its backoff entry.
+func (b *installerBackoff) recordFailedAttempt(vm *azure.VirtualMachine, issueType string, t time.Time) installerBackoffEntry {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	entry := b.recordAttemptLocked(vm, t)
+	entry.issueType = issueType
+	return *entry
+}
+
+// expireEntries removes all entries that were not attempted in the last
+// discovery scan for which the backoff period has elapsed.
+// If discovery no longer matches a VM or if the VM is enrolled and will not be
+// attempted again, then that VM must eventually be removed from the backoff to
+// bound memory growth.
+// Undiscovered entries that have not elapsed the retry period are kept around
+// to handle the case where discovery config is updated to match a VM that was
+// failing and should still be backed off.
+func (b *installerBackoff) expireEntries(t time.Time) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for key, entry := range b.entries {
+		if !entry.seenInLastScan && entry.retryable(t) {
+			delete(b.entries, key)
+		} else {
+			entry.seenInLastScan = false
+		}
+	}
+}
+
+// reset clears all backoff entries.
+func (b *installerBackoff) reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.entries = make(map[installerBackoffKey]*installerBackoffEntry)
+}

--- a/lib/srv/discovery/backoff_test.go
+++ b/lib/srv/discovery/backoff_test.go
@@ -1,0 +1,194 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package discovery
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/cloud/azure"
+	"github.com/gravitational/teleport/lib/srv/server"
+)
+
+func TestInstallerBackoffRecordAttempt(t *testing.T) {
+	now := time.Now()
+	baseDelay := time.Minute
+	backoff, err := newInstallerBackoff(baseDelay, nil)
+	require.NoError(t, err)
+	_, vm := backoffTestVM("vm-1")
+
+	entry := backoff.recordFailedAttempt(vm, "first-issue", now)
+	require.Equal(t, int32(1), entry.attempts)
+	require.Equal(t, now, entry.lastAttemptAt)
+	require.Equal(t, "first-issue", entry.issueType)
+	require.Same(t, vm, entry.vm)
+	require.Equal(t, now.Add(baseDelay), entry.retryAfter)
+	require.True(t, entry.seenInLastScan)
+
+	now = now.Add(time.Hour)
+	entry = backoff.recordFailedAttempt(vm, "second-issue", now)
+	require.Equal(t, int32(2), entry.attempts)
+	require.Equal(t, now, entry.lastAttemptAt)
+	require.Equal(t, "second-issue", entry.issueType)
+	require.Same(t, vm, entry.vm)
+	require.Equal(t, now.Add(2*baseDelay), entry.retryAfter)
+	require.True(t, entry.seenInLastScan)
+
+	now = now.Add(time.Hour)
+	entry = backoff.recordSuccessfulAttempt(vm, now)
+	require.Equal(t, int32(3), entry.attempts)
+	require.Equal(t, now, entry.lastAttemptAt)
+	require.Empty(t, entry.issueType)
+	require.Same(t, vm, entry.vm)
+	require.Equal(t, now.Add(4*baseDelay), entry.retryAfter)
+	require.True(t, entry.seenInLastScan)
+
+	backoff.reset()
+	require.Empty(t, backoff.entries)
+}
+
+func TestInstallerBackoffDelayBounds(t *testing.T) {
+	tests := []struct {
+		name      string
+		baseDelay time.Duration
+		attempts  int32
+		wantDelay time.Duration
+	}{
+		{
+			name:      "uses minimum base delay",
+			baseDelay: time.Second,
+			attempts:  1,
+			wantDelay: 1 * time.Minute,
+		},
+		{
+			name:      "uses bounded poll interval based delay",
+			baseDelay: 7 * time.Minute,
+			attempts:  2,
+			wantDelay: 14 * time.Minute,
+		},
+		{
+			name:      "caps delay at maximum",
+			baseDelay: time.Minute,
+			attempts:  10000,
+			wantDelay: maxInstallBackoff,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backoff, err := newInstallerBackoff(tt.baseDelay, nil)
+			require.NoError(t, err)
+			_, vm := backoffTestVM("backed-off")
+			var entry *installerBackoffEntry
+			for range tt.attempts {
+				entry = backoff.recordAttemptLocked(vm, time.Now())
+			}
+			require.Equal(t, tt.attempts, entry.attempts)
+			require.Equal(t, tt.wantDelay, entry.retry.Duration())
+		})
+	}
+}
+
+func TestInstallerBackoffFilter(t *testing.T) {
+	now := time.Now()
+	baseDelay := time.Minute
+	backoff, err := newInstallerBackoff(baseDelay, nil)
+	require.NoError(t, err)
+
+	vm1Key, vm1 := backoffTestVM("backed-off")
+	vm2Key, vm2 := backoffTestVM("retryable")
+	vm3Key, vm3 := backoffTestVM("never-failed")
+
+	backoff.recordFailedAttempt(vm2, "retryable-issue", now)
+	backedOffEntry := backoff.recordFailedAttempt(vm1, "backed-off-issue", now.Add(baseDelay))
+
+	instances := &server.AzureInstances{
+		Instances: []*azure.VirtualMachine{
+			vm1,
+			vm2,
+			vm3,
+		},
+	}
+
+	skipped := backoff.filter(instances, now.Add(2*baseDelay))
+	require.Contains(t, backoff.entries, vm1Key)
+	require.Contains(t, backoff.entries, vm2Key)
+	require.Contains(t, backoff.entries, vm3Key)
+
+	notSkipped := make([]string, 0, len(instances.Instances))
+	for _, vm := range instances.Instances {
+		notSkipped = append(notSkipped, vm.ID)
+	}
+	require.ElementsMatch(t, []string{vm2.ID, vm3.ID}, notSkipped)
+	require.Len(t, skipped, 1)
+	require.Equal(t, backedOffEntry, skipped[0])
+	require.False(t, backoff.entries[vm3Key].isFailedAttempt())
+}
+
+func TestInstallerBackoffExpireEntries(t *testing.T) {
+	now := time.Now()
+	baseDelay := time.Minute
+	backoff, err := newInstallerBackoff(baseDelay, nil)
+	require.NoError(t, err)
+
+	vm1Key, vm1 := backoffTestVM("vm1")
+	vm2Key, vm2 := backoffTestVM("vm2")
+	vm3Key, vm3 := backoffTestVM("vm3")
+
+	backoff.recordFailedAttempt(vm1, "issue", now)
+	backoff.recordFailedAttempt(vm2, "issue", now)
+	backoff.recordFailedAttempt(vm3, "issue", now.Add(-2*baseDelay))
+	backoff.entries[vm3Key].seenInLastScan = false
+	require.Contains(t, backoff.entries, vm1Key)
+	require.Contains(t, backoff.entries, vm2Key)
+	require.Contains(t, backoff.entries, vm3Key)
+	require.True(t, backoff.entries[vm3Key].retryable(now))
+	backoff.expireEntries(now)
+	require.Contains(t, backoff.entries, vm1Key)
+	require.Contains(t, backoff.entries, vm2Key)
+	require.NotContains(t, backoff.entries, vm3Key, "vm3 was not seen in last scan and expired, so it should have been removed")
+	require.False(t, backoff.entries[vm1Key].seenInLastScan)
+	require.False(t, backoff.entries[vm2Key].seenInLastScan)
+
+	now = now.Add(baseDelay + time.Second)
+	instances := &server.AzureInstances{
+		Instances: []*azure.VirtualMachine{vm1},
+	}
+	_ = backoff.filter(instances, now)
+	require.Contains(t, backoff.entries, vm1Key)
+	require.Contains(t, backoff.entries, vm2Key)
+	require.True(t, backoff.entries[vm1Key].seenInLastScan)
+	require.False(t, backoff.entries[vm2Key].seenInLastScan)
+	require.True(t, backoff.entries[vm1Key].retryable(now))
+	require.True(t, backoff.entries[vm2Key].retryable(now))
+
+	backoff.expireEntries(now)
+	require.Contains(t, backoff.entries, vm1Key)
+	require.NotContains(t, backoff.entries, vm2Key, "vm2 was not seen in last scan and expired, so it should have been removed")
+}
+
+func backoffTestVM(name string) (installerBackoffKey, *azure.VirtualMachine) {
+	vm := &azure.VirtualMachine{
+		ID:   "/subscriptions/test/resourceGroups/test/providers/Microsoft.Compute/virtualMachines/" + name,
+		Name: name,
+		VMID: name + "-vmid",
+	}
+	key := newInstallerBackoffKey(vm)
+	return key, vm
+}

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -1540,7 +1540,7 @@ func (s *Server) enrollAzureVirtualMachines(log *slog.Logger, instances *server.
 	}
 
 	var mu sync.Mutex
-	var failedInstances []server.AzureInstallResult
+	var results []server.AzureInstallResult
 
 	req := server.AzureInstallRequest{
 		Instances:       instances.Instances,
@@ -1556,13 +1556,11 @@ func (s *Server) enrollAzureVirtualMachines(log *slog.Logger, instances *server.
 		},
 		OnRunCommandFinished: func(result server.AzureInstallResult) {
 			s.emitAzureInstallEvents(log, instances.Metadata, result)
+			mu.Lock()
+			results = append(results, result)
+			mu.Unlock()
 			if result.Failure() {
 				reporter.report(s.ctx, result)
-
-				// collect the failed instance
-				mu.Lock()
-				failedInstances = append(failedInstances, result)
-				mu.Unlock()
 			}
 		},
 	}
@@ -1572,12 +1570,8 @@ func (s *Server) enrollAzureVirtualMachines(log *slog.Logger, instances *server.
 		return nil, trace.Wrap(err)
 	}
 
-	log.InfoContext(s.ctx, "Finished installation batch",
-		"total_instances", len(instances.Instances),
-		"failures", len(failedInstances))
 	reporter.summary(s.ctx)
-
-	return failedInstances, nil
+	return results, nil
 }
 
 // startAzureServerDiscovery starts the Azure VM discovery.
@@ -1587,12 +1581,17 @@ func (s *Server) startAzureServerDiscovery() {
 		s.Log.ErrorContext(s.ctx, "Failed to initialize nodeWatcher", "error", err)
 		return
 	}
+	backoff, err := newInstallerBackoff(s.PollInterval*2, retryutils.SeventhJitter)
+	if err != nil {
+		s.Log.ErrorContext(s.ctx, "Failed to initialize installer backoff (this is a bug)", "error", err)
+		return
+	}
 
 	var azureWatcher *server.Watcher[*server.AzureInstances]
 
 	// a full refresh is somewhat wasteful, however not overly so due to inexpensive operations involved.
 	// a more selective approach would necessitate deeper refactoring.
-	fullRefresh := func() {
+	refreshFetchers := func() {
 		s.Log.DebugContext(s.ctx, "Refreshing Azure server fetchers")
 		replaceMap := make(map[string][]server.Fetcher[*server.AzureInstances])
 		replaceMap[noDiscoveryConfig] = s.azureServerFetchersFromMatchers(s.Matchers.Azure, noDiscoveryConfig)
@@ -1681,7 +1680,7 @@ func (s *Server) startAzureServerDiscovery() {
 					continue
 				}
 				eg.Go(func() error {
-					status := s.installAzureServers(group, vmTasks, status, sem)
+					status := s.installAzureServers(group, vmTasks, status, backoff, sem)
 					sm.updateConcurrently(key, status)
 					return nil
 				})
@@ -1689,24 +1688,31 @@ func (s *Server) startAzureServerDiscovery() {
 		}),
 		server.WithPostFetchHookFn[*server.AzureInstances](func() {
 			// refresh the fetchers after every iteration to avoid stale config
-			defer fullRefresh()
+			defer refreshFetchers()
 
 			_ = eg.Wait()
-			sm.syncEnded(s.clock.Now())
+			now := s.clock.Now()
+			sm.syncEnded(now)
 			// update statuses of relevant discovery configs.
 			s.azureVMStatus.Store(sm)
 			s.updateDiscoveryConfigStatus(sm.discoveryConfigs()...)
 			// upsert user tasks for failed enrollments.
 			vmTasks.upsertAll(s.taskUpdater())
+			backoff.expireEntries(now)
 		}),
 		server.WithPollInterval[*server.AzureInstances](s.PollInterval),
 		server.WithTriggerFetchC[*server.AzureInstances](s.newDiscoveryConfigChangedSub()),
-		server.WithTriggerFetchHookFn[*server.AzureInstances](fullRefresh),
+		server.WithTriggerFetchHookFn[*server.AzureInstances](func() {
+			refreshFetchers()
+			// users should be able to adjust discovery config to fix issues
+			// without waiting for the backoff entries to expire
+			backoff.reset()
+		}),
 		server.WithClock[*server.AzureInstances](s.clock),
 	)
 
 	// refresh dynamic fetchers once at the beginning.
-	fullRefresh()
+	refreshFetchers()
 
 	s.Log.DebugContext(s.ctx, "Azure VM watcher starting.")
 	go azureWatcher.Run()
@@ -1741,23 +1747,22 @@ func (s *Server) reconcileAzureServers(instances *server.AzureInstances) (discov
 	return status, nil
 }
 
-func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *azureVMTasks, status discoveryGroupStatus, sem *semaphore.Weighted) discoveryGroupStatus {
+func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *azureVMTasks, status discoveryGroupStatus, backoff *installerBackoff, sem *semaphore.Weighted) discoveryGroupStatus {
 	log := s.Log.With("group", instances)
-	if len(instances.Instances) == 0 {
-		log.DebugContext(s.ctx, "No Azure instances remain to enroll, skipping installation")
-		return status
-	}
-
-	addFailedAzureEnrollment := func(vm *azure.VirtualMachine, issueType string) {
+	addFailedAzureEnrollment := func(entry installerBackoffEntry, syncTime time.Time) {
 		// Static matchers don't have a discovery config resource, so skip creating user tasks
 		// because validation requires a discovery config name.
 		if instances.Metadata.DiscoveryConfigName == noDiscoveryConfig {
 			return
 		}
+		if !entry.isFailedAttempt() {
+			// we don't surface user tasks for successful attempts that fail to join for some reason out of our sight
+			return
+		}
 
 		tg := usertasks.TaskGroup{
 			Integration: instances.Metadata.Integration,
-			IssueType:   issueType,
+			IssueType:   entry.issueType,
 		}
 		vmTasks.addFailedEnrollment(
 			tg,
@@ -1767,18 +1772,47 @@ func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *
 				region:         instances.Metadata.Region,
 			},
 			&usertasksv1.DiscoverAzureVMInstance{
-				VmId:            vm.VMID,
-				ResourceId:      vm.ID,
-				Name:            vm.Name,
+				VmId:            entry.vm.VMID,
+				ResourceId:      entry.vm.ID,
+				Name:            entry.vm.Name,
 				DiscoveryConfig: instances.Metadata.DiscoveryConfigName,
 				DiscoveryGroup:  s.DiscoveryGroup,
-				SyncTime:        timestamppb.New(s.clock.Now()),
+				SyncTime:        timestamppb.New(syncTime),
+				LastAttemptTime: timestamppb.New(entry.lastAttemptAt),
+				RetryAfterTime:  timestamppb.New(entry.retryAfter),
+				Attempts:        entry.attempts,
 			},
 		)
 	}
 
+	skipped := backoff.filter(instances, s.clock.Now())
+	if len(skipped) > 0 {
+		log.DebugContext(s.ctx, "Skipping Azure VMs with an active installation backoff",
+			"skipped", len(skipped),
+		)
+		for _, entry := range skipped {
+			if entry.isFailedAttempt() {
+				status.failed++
+			}
+		}
+	}
+	if len(instances.Instances) == 0 {
+		if len(skipped) > 0 {
+			syncTime := s.clock.Now()
+			for _, entry := range skipped {
+				addFailedAzureEnrollment(entry, syncTime)
+			}
+		}
+		log.DebugContext(s.ctx, "No Azure instances remain to enroll, skipping installation")
+		return status
+	}
+
 	log.DebugContext(s.ctx, "Running Teleport installation on virtual machines", "vms", genAzureInstancesLogStr(instances.Instances))
-	failures, err := s.enrollAzureVirtualMachines(log, instances, sem)
+	results, err := s.enrollAzureVirtualMachines(log, instances, sem)
+	syncTime := s.clock.Now()
+	for _, entry := range skipped {
+		addFailedAzureEnrollment(entry, syncTime)
+	}
 	if err != nil {
 		// treat non-nil err as deployment failure affecting all machines.
 		log.WarnContext(s.ctx, "Failed to enroll all discovered Azure VMs", "error", err)
@@ -1786,22 +1820,34 @@ func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *
 
 		issueType := classifyAzureVMEnrollmentError(err)
 		for _, vm := range instances.Instances {
-			addFailedAzureEnrollment(vm, issueType)
+			entry := backoff.recordFailedAttempt(vm, issueType, syncTime)
+			addFailedAzureEnrollment(entry, syncTime)
 		}
 		return status
 	}
 
-	if len(failures) > 0 {
-		log.WarnContext(s.ctx, "Failed to enroll some discovered Azure VMs", "failures", len(failures))
-	}
+	successful, failures := splitInstallResults(results)
+	log.InfoContext(s.ctx, "Finished installation batch",
+		"total_instances", len(results),
+		"failures", len(failures),
+	)
 
 	// count individual failed enrollments.
 	status.failed += len(failures)
-
+	if len(failures) > 0 {
+		log.WarnContext(s.ctx, "Failed to enroll some discovered Azure VMs", "failures", len(failures))
+	}
 	// Record failures as user tasks.
 	for _, result := range failures {
 		// TODO (Tener): check exit codes and create more detailed user tasks.
-		addFailedAzureEnrollment(result.Instance, classifyAzureInstallResultIssue(result))
+		issueType := classifyAzureInstallResultIssue(result)
+		entry := backoff.recordFailedAttempt(result.Instance, issueType, syncTime)
+		addFailedAzureEnrollment(entry, syncTime)
+	}
+
+	// count individual successful (pending) enrollments.
+	for _, result := range successful {
+		backoff.recordSuccessfulAttempt(result.Instance, syncTime)
 	}
 
 	pendingCount := len(instances.Instances) - len(failures)
@@ -1811,7 +1857,9 @@ func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *
 		// Otherwise, we will try to enroll those once again, possibly failing.
 		// There is a gap here: we will ignore join failures as those happen out of our sight.
 		// There is no easy way to close that gap in the current architecture.
-		log.DebugContext(s.ctx, "Installation attempt finished. If the machines have joined the cluster successfully, they will be counted as enrolled during the next iteration.", "pending", pendingCount)
+		log.DebugContext(s.ctx, "Installation attempt finished. If the machines have joined the cluster successfully, they will be counted as enrolled during the next iteration.",
+			"pending", pendingCount,
+		)
 	}
 	return status
 }
@@ -2415,4 +2463,21 @@ func (s *Server) resolveCreateErr(createErr error, discoveryOrigin string, gette
 	}
 
 	return nil
+}
+
+type installResult interface {
+	Failure() bool
+}
+
+// splitInstallResults splits a list of resutls into a list of successful
+// results and a list of failed results.
+func splitInstallResults[T installResult](results []T) (successful []T, failures []T) {
+	for _, r := range results {
+		if r.Failure() {
+			failures = append(failures, r)
+		} else {
+			successful = append(successful, r)
+		}
+	}
+	return successful, failures
 }

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"slices"
 	"strings"
 	"sync"
@@ -1588,15 +1589,25 @@ func (s *Server) startAzureServerDiscovery() {
 	}
 
 	var azureWatcher *server.Watcher[*server.AzureInstances]
+	configChangeCh := s.newDiscoveryConfigChangedSub()
 
 	// a full refresh is somewhat wasteful, however not overly so due to inexpensive operations involved.
 	// a more selective approach would necessitate deeper refactoring.
-	refreshFetchers := func() {
+	refreshFetchers := func(drainConfigNotifications bool) {
 		s.Log.DebugContext(s.ctx, "Refreshing Azure server fetchers")
 		replaceMap := make(map[string][]server.Fetcher[*server.AzureInstances])
 		replaceMap[noDiscoveryConfig] = s.azureServerFetchersFromMatchers(s.Matchers.Azure, noDiscoveryConfig)
 
 		s.dynamicDiscoveryConfigMu.RLock()
+		if drainConfigNotifications {
+			select {
+			// Config change notifications are only sent under a write lock, so
+			// we can be sure that any pending notification is stale after we
+			// acquire the read lock.
+			case <-configChangeCh:
+			default:
+			}
+		}
 		// avoid holding the read lock while converting matchers to fetchers,
 		// in case of API calls, e.g., to expand subscription wildcard.
 		dynamicConfigs := make(map[string][]types.AzureMatcher, len(s.dynamicDiscoveryConfig))
@@ -1688,7 +1699,9 @@ func (s *Server) startAzureServerDiscovery() {
 		}),
 		server.WithPostFetchHookFn[*server.AzureInstances](func() {
 			// refresh the fetchers after every iteration to avoid stale config
-			defer refreshFetchers()
+			// but don't drain the notifications channel in post fetch - if
+			// config changed during the last fetch then we want to fetch again.
+			defer refreshFetchers(false)
 
 			_ = eg.Wait()
 			now := s.clock.Now()
@@ -1701,9 +1714,10 @@ func (s *Server) startAzureServerDiscovery() {
 			backoff.expireEntries(now)
 		}),
 		server.WithPollInterval[*server.AzureInstances](s.PollInterval),
-		server.WithTriggerFetchC[*server.AzureInstances](s.newDiscoveryConfigChangedSub()),
+		server.WithTriggerFetchC[*server.AzureInstances](configChangeCh),
 		server.WithTriggerFetchHookFn[*server.AzureInstances](func() {
-			refreshFetchers()
+			s.Log.DebugContext(s.ctx, "Fetch triggered by discovery config change")
+			refreshFetchers(true)
 			// users should be able to adjust discovery config to fix issues
 			// without waiting for the backoff entries to expire
 			backoff.reset()
@@ -1712,7 +1726,7 @@ func (s *Server) startAzureServerDiscovery() {
 	)
 
 	// refresh dynamic fetchers once at the beginning.
-	refreshFetchers()
+	refreshFetchers(true)
 
 	s.Log.DebugContext(s.ctx, "Azure VM watcher starting.")
 	go azureWatcher.Run()
@@ -2053,7 +2067,6 @@ func (s *Server) Start() error {
 // loadExistingDynamicDiscoveryConfigs loads all the dynamic discovery configs for the current discovery group
 // and setups their matchers.
 func (s *Server) loadExistingDynamicDiscoveryConfigs() error {
-	hasDynamicMatchers := false
 	discoveryConfigsMap := make(map[string]*discoveryconfig.DiscoveryConfig)
 	// Add all existing DiscoveryConfigs as matchers.
 	nextKey := ""
@@ -2073,7 +2086,6 @@ func (s *Server) loadExistingDynamicDiscoveryConfigs() error {
 				continue
 			}
 			discoveryConfigsMap[dc.GetName()] = dc
-			hasDynamicMatchers = true
 		}
 		if respNextKey == "" {
 			break
@@ -2081,14 +2093,7 @@ func (s *Server) loadExistingDynamicDiscoveryConfigs() error {
 		nextKey = respNextKey
 	}
 
-	s.dynamicDiscoveryConfigMu.Lock()
-	s.dynamicDiscoveryConfig = discoveryConfigsMap
-	s.dynamicDiscoveryConfigMu.Unlock()
-
-	if hasDynamicMatchers {
-		s.notifyDiscoveryConfigChanged()
-	}
-
+	s.setDynamicDiscoveryConfigMap(discoveryConfigsMap)
 	return nil
 }
 
@@ -2125,10 +2130,7 @@ func (s *Server) startDynamicWatcherUpdater(ctx context.Context, dynamicMatcherW
 					// If the user updates the DiscoveryGroup to DG2, then DC1 must be removed from the scope of this process.
 					// We blindly delete it, in the worst case, this is a no-op.
 					s.deleteDynamicFetchers(name)
-					s.dynamicDiscoveryConfigMu.Lock()
-					delete(s.dynamicDiscoveryConfig, name)
-					s.dynamicDiscoveryConfigMu.Unlock()
-					s.notifyDiscoveryConfigChanged()
+					s.deleteDynamicDiscoveryConfig(name)
 					continue
 				}
 				s.dynamicDiscoveryConfigMu.RLock()
@@ -2139,16 +2141,14 @@ func (s *Server) startDynamicWatcherUpdater(ctx context.Context, dynamicMatcherW
 				if oldDiscoveryConfig.IsEqual(dc) {
 					continue
 				}
-
 				if err := s.upsertDynamicMatchers(ctx, dc); err != nil {
-					s.Log.WarnContext(ctx, "Failed to update dynamic matchers for discovery config", "discovery_config", dc.GetName(), "error", err)
+					s.Log.WarnContext(ctx, "Failed to update dynamic matchers for discovery config",
+						"discovery_config", dc.GetName(),
+						"error", err,
+					)
 					continue
 				}
-				s.dynamicDiscoveryConfigMu.Lock()
-				s.dynamicDiscoveryConfig[dc.GetName()] = dc
-				s.dynamicDiscoveryConfigMu.Unlock()
-				s.notifyDiscoveryConfigChanged()
-
+				s.updateDynamicDiscoveryConfig(dc)
 			case types.OpDelete:
 				name := event.Resource.GetName()
 				s.dynamicDiscoveryConfigMu.RLock()
@@ -2160,10 +2160,7 @@ func (s *Server) startDynamicWatcherUpdater(ctx context.Context, dynamicMatcherW
 					continue
 				}
 				s.deleteDynamicFetchers(name)
-				s.dynamicDiscoveryConfigMu.Lock()
-				delete(s.dynamicDiscoveryConfig, name)
-				s.dynamicDiscoveryConfigMu.Unlock()
-				s.notifyDiscoveryConfigChanged()
+				s.deleteDynamicDiscoveryConfig(name)
 			default:
 				s.Log.WarnContext(ctx, "Skipping unknown event type %s", "got", event.Type)
 			}
@@ -2171,6 +2168,35 @@ func (s *Server) startDynamicWatcherUpdater(ctx context.Context, dynamicMatcherW
 			return trace.Wrap(dynamicMatcherWatcher.Error())
 		}
 	}
+}
+
+func (s *Server) setDynamicDiscoveryConfigMap(new map[string]*discoveryconfig.DiscoveryConfig) {
+	s.dynamicDiscoveryConfigMu.Lock()
+	defer s.dynamicDiscoveryConfigMu.Unlock()
+	if !isEqualDiscoveryConfigMap(s.dynamicDiscoveryConfig, new) {
+		s.dynamicDiscoveryConfig = new
+		s.notifyDiscoveryConfigChanged()
+	}
+}
+
+func isEqualDiscoveryConfigMap(a, b map[string]*discoveryconfig.DiscoveryConfig) bool {
+	return maps.EqualFunc(a, b, func(aDC, bDC *discoveryconfig.DiscoveryConfig) bool {
+		return aDC.IsEqual(bDC)
+	})
+}
+
+func (s *Server) updateDynamicDiscoveryConfig(dc *discoveryconfig.DiscoveryConfig) {
+	s.dynamicDiscoveryConfigMu.Lock()
+	defer s.dynamicDiscoveryConfigMu.Unlock()
+	s.dynamicDiscoveryConfig[dc.GetName()] = dc
+	s.notifyDiscoveryConfigChanged()
+}
+
+func (s *Server) deleteDynamicDiscoveryConfig(name string) {
+	s.dynamicDiscoveryConfigMu.Lock()
+	defer s.dynamicDiscoveryConfigMu.Unlock()
+	delete(s.dynamicDiscoveryConfig, name)
+	s.notifyDiscoveryConfigChanged()
 }
 
 // newDiscoveryConfigChangedSub creates a new subscription for DiscoveryConfig events.

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -3209,7 +3209,7 @@ const azureInstallErrorPrefix = "bad-install"
 
 type mockAzureRunCommandClient struct {
 	mu           sync.Mutex
-	attemptedVMs map[string]struct{}
+	attemptedVMs map[string]int
 }
 
 func (m *mockAzureRunCommandClient) Run(_ context.Context, req azure.RunCommandRequest) (*azure.RunCommandResult, error) {
@@ -3217,9 +3217,9 @@ func (m *mockAzureRunCommandClient) Run(_ context.Context, req azure.RunCommandR
 	defer m.mu.Unlock()
 
 	if m.attemptedVMs == nil {
-		m.attemptedVMs = make(map[string]struct{})
+		m.attemptedVMs = make(map[string]int)
 	}
-	m.attemptedVMs[req.VMName] = struct{}{}
+	m.attemptedVMs[req.VMName] = m.attemptedVMs[req.VMName] + 1
 
 	if strings.HasPrefix(req.VMName, azureApiErrorPrefix) {
 		const statusCode = 403
@@ -3256,6 +3256,15 @@ func (m *mockAzureRunCommandClient) getAttempted() []string {
 	elems := slices.Sorted(maps.Keys(m.attemptedVMs))
 	m.mu.Unlock()
 	return elems
+}
+
+func (m *mockAzureRunCommandClient) getAttemptCount(vmName string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.attemptedVMs == nil {
+		return 0
+	}
+	return m.attemptedVMs[vmName]
 }
 
 type mockAzureClient struct {
@@ -3405,6 +3414,8 @@ func TestAzureVMDiscovery(t *testing.T) {
 	presentNodeAlt := presentNode.DeepCopy().(*types.ServerV2)
 	presentNodeAlt.Metadata.Labels["teleport.internal/vm-id"] = "alternate-vmid"
 
+	const pollInterval = 5 * time.Minute
+
 	tests := []struct {
 		name                     string
 		presentVMs               []types.Server
@@ -3414,7 +3425,7 @@ func TestAzureVMDiscovery(t *testing.T) {
 		wantInstances            []string
 		wantResources            int
 		expectedIntegrationNames []string
-		userTasksCheck           func(*testing.T, UserTaskLister)
+		checkState               func(*testing.T, UserTaskLister, *mockAzureRunCommandClient)
 	}{
 		{
 			name:           "no nodes present, 2 found",
@@ -3472,7 +3483,7 @@ func TestAzureVMDiscovery(t *testing.T) {
 			wantInstances:   []string{"bad-api0"},
 			wantResources:   0,
 			foundVMS:        makeFaultyVM(true, 1),
-			userTasksCheck: func(t *testing.T, lister UserTaskLister) {
+			checkState: func(t *testing.T, lister UserTaskLister, runClient *mockAzureRunCommandClient) {
 				var tasks []*usertasksv1.UserTask
 				var err error
 				tasks, _, err = lister.ListUserTasks(t.Context(), 200, "", &usertasksv1.ListUserTasksFilters{})
@@ -3498,6 +3509,7 @@ func TestAzureVMDiscovery(t *testing.T) {
 									Name:            "bad-api0",
 									DiscoveryConfig: defaultDiscoveryConfig().GetName(),
 									DiscoveryGroup:  defaultDiscoveryGroup,
+									Attempts:        1,
 								},
 							},
 							SubscriptionId: "testsub",
@@ -3508,11 +3520,70 @@ func TestAzureVMDiscovery(t *testing.T) {
 					Status: nil,
 				}
 
-				require.Empty(t, cmp.Diff(expectedTask, tasks[0],
+				diffTasksOpts := []cmp.Option{
 					protocmp.Transform(),
 					protocmp.IgnoreFields(&headerv1.Metadata{}, "expires", "revision"),
-					protocmp.IgnoreFields(&usertasksv1.DiscoverAzureVMInstance{}, "sync_time"),
-				))
+					protocmp.IgnoreFields(&usertasksv1.DiscoverAzureVMInstance{}, "sync_time", "retry_after_time", "last_attempt_time"),
+				}
+				require.Equal(t, 1, runClient.getAttemptCount("bad-api0"))
+				require.Empty(t, cmp.Diff(expectedTask, tasks[0], diffTasksOpts...))
+				instance := tasks[0].GetSpec().GetDiscoverAzureVm().GetInstances()["bad-api0-vmid"]
+				require.NotNil(t, instance)
+				syncTime1 := instance.GetSyncTime().AsTime()
+				lastAttemptTime1 := instance.GetLastAttemptTime().AsTime()
+				retryAfter1 := instance.GetRetryAfterTime().AsTime()
+				require.NotZero(t, syncTime1)
+				require.NotZero(t, lastAttemptTime1)
+				require.NotZero(t, retryAfter1)
+				require.Equal(t, syncTime1, lastAttemptTime1)
+				require.Greater(t, retryAfter1, lastAttemptTime1)
+				require.Greater(t, retryAfter1, syncTime1)
+
+				time.Sleep(pollInterval + time.Second)
+				synctest.Wait()
+
+				require.Equal(t, 1, runClient.getAttemptCount("bad-api0"), "VM install should not have been reattempted during backoff period")
+				tasks, _, err = lister.ListUserTasks(t.Context(), 200, "", &usertasksv1.ListUserTasksFilters{})
+				require.NoError(t, err)
+				require.Len(t, tasks, 1)
+				require.Empty(t, cmp.Diff(expectedTask, tasks[0], diffTasksOpts...))
+				instance = tasks[0].GetSpec().GetDiscoverAzureVm().GetInstances()["bad-api0-vmid"]
+				require.NotNil(t, instance)
+				syncTime2 := instance.GetSyncTime().AsTime()
+				lastAttemptTime2 := instance.GetLastAttemptTime().AsTime()
+				retryAfter2 := instance.GetRetryAfterTime().AsTime()
+				require.NotZero(t, syncTime2)
+				require.NotZero(t, lastAttemptTime2)
+				require.NotZero(t, retryAfter2)
+				require.Greater(t, retryAfter2, syncTime2)
+				require.Equal(t, lastAttemptTime1, lastAttemptTime2, "last attempt time should not change during backoff period")
+				require.Equal(t, retryAfter1, retryAfter2, "retry time should not change during backoff period")
+				require.Greater(t, syncTime2, syncTime1)
+				require.Greater(t, syncTime2, lastAttemptTime2)
+
+				time.Sleep(pollInterval + time.Second)
+				synctest.Wait()
+
+				require.Equal(t, 2, runClient.getAttemptCount("bad-api0"), "VM install should have been reattempted after backoff period")
+				tasks, _, err = lister.ListUserTasks(t.Context(), 200, "", &usertasksv1.ListUserTasksFilters{})
+				require.NoError(t, err)
+				require.Len(t, tasks, 1)
+				// another attempt (and failure) should happen after backoff period has elapsed
+				expectedTask.GetSpec().GetDiscoverAzureVm().GetInstances()["bad-api0-vmid"].SetAttempts(2)
+				require.Empty(t, cmp.Diff(expectedTask, tasks[0], diffTasksOpts...))
+				instance = tasks[0].GetSpec().GetDiscoverAzureVm().GetInstances()["bad-api0-vmid"]
+				require.NotNil(t, instance)
+				syncTime3 := instance.GetSyncTime().AsTime()
+				lastAttemptTime3 := instance.GetLastAttemptTime().AsTime()
+				retryAfter3 := instance.GetRetryAfterTime().AsTime()
+				require.NotZero(t, syncTime3)
+				require.NotZero(t, lastAttemptTime3)
+				require.NotZero(t, retryAfter3)
+				require.Greater(t, retryAfter3, syncTime3)
+				require.Greater(t, retryAfter3, retryAfter2, "retry time should change after another failed attempt")
+				require.Greater(t, lastAttemptTime3, lastAttemptTime2, "last attempt time should change after another failed attempt")
+				require.Equal(t, lastAttemptTime3, syncTime3)
+				require.Greater(t, syncTime3, syncTime2, "sync time should change after another failed attempt")
 			},
 		},
 		{
@@ -3522,7 +3593,7 @@ func TestAzureVMDiscovery(t *testing.T) {
 			wantInstances:  []string{"bad-api0"},
 			wantResources:  0,
 			foundVMS:       makeFaultyVM(true, 1),
-			userTasksCheck: func(t *testing.T, lister UserTaskLister) {
+			checkState: func(t *testing.T, lister UserTaskLister, _ *mockAzureRunCommandClient) {
 				tasks, _, err := lister.ListUserTasks(t.Context(), 200, "", &usertasksv1.ListUserTasksFilters{})
 				require.NoError(t, err)
 				require.Empty(t, tasks)
@@ -3535,10 +3606,7 @@ func TestAzureVMDiscovery(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			runClient := &mockAzureRunCommandClient{
-				attemptedVMs: make(map[string]struct{}),
-			}
-
+			runClient := &mockAzureRunCommandClient{}
 			initAzureClients := func(opts ...azure.ClientsOption) (azure.Clients, error) {
 				return &azuretest.Clients{
 					AzureVirtualMachines: &mockAzureClient{
@@ -3596,6 +3664,7 @@ func TestAzureVMDiscovery(t *testing.T) {
 					Emitter:          emitter,
 					Log:              logger,
 					DiscoveryGroup:   defaultDiscoveryGroup,
+					PollInterval:     pollInterval,
 				})
 
 				require.NoError(t, err)
@@ -3638,8 +3707,8 @@ func TestAzureVMDiscovery(t *testing.T) {
 				require.ElementsMatch(t, tc.wantInstances, slices.Collect(maps.Keys(seenVMs)))
 
 				// verify user tasks state
-				if tc.userTasksCheck != nil {
-					tc.userTasksCheck(t, tlsServer.Auth())
+				if tc.checkState != nil {
+					tc.checkState(t, tlsServer.Auth(), runClient)
 				}
 
 				// make sure azure client cache has expected entries

--- a/lib/srv/discovery/status_test.go
+++ b/lib/srv/discovery/status_test.go
@@ -241,6 +241,34 @@ func TestMergeUpsertUserTask(t *testing.T) {
 	}
 }
 
+func TestDiscoveryStatusUpdate(t *testing.T) {
+	const (
+		discoveryConfigName = "dc-1"
+		integrationName     = "integration-1"
+	)
+	key := discoveryGroupStatusKey{
+		discoveryConfigName: discoveryConfigName,
+		integration:         integrationName,
+	}
+	statuses := newStatusMap(types.AzureMatcherVM, time.Now())
+	statuses.add(key)
+
+	statuses.updateConcurrently(key, discoveryGroupStatus{
+		found:    4,
+		enrolled: 1,
+		failed:   1,
+	})
+	statuses.updateConcurrently(key, discoveryGroupStatus{
+		found: 1,
+	})
+
+	status := statuses.mergeIntoGlobalStatus(discoveryConfigName, discoveryconfig.Status{})
+	summary := status.IntegrationDiscoveredResources[integrationName].GetAzureVms()
+	require.Equal(t, uint64(5), summary.GetFound())
+	require.Equal(t, uint64(1), summary.GetEnrolled())
+	require.Equal(t, uint64(1), summary.GetFailed())
+}
+
 type mocktaskUpdaterAccessPoint struct {
 	types.Semaphores
 

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -172,6 +172,7 @@ type ResourcesCount struct {
 	Enrolled int `json:"enrolled"`
 	// Failed is the count of resources that were found but failed to be enrolled
 	Failed int `json:"failed"`
+	// TODO(gavin): add Pending count
 }
 
 // ResourceTypeSummary contains the summary of the enrollment rules and found resources by the integration.


### PR DESCRIPTION
Backports #68035 to branch/v18.
- #68035

Changelog: Azure VM discovery will now backoff from retrying failing Azure VM installations with an exponentially increasing backoff period, up to 2 hours.

## Manual Test Plan
### Test Environment
- cloud staging tenant patched to a dev build
- local discovery agent running a dev build
- multiple VMs in multiple subscriptions
- terraform the azure discovery config and integration to discover all VMs

### Test Cases
- [x] verify that failing Azure VMs produce user tasks with a retry_after and failure count
- [x] verify that discovery service logs info when VM installs are skipped due to backoff
- [x] verify that failing Azure VMs are not retried during their backoff period
- [x] verify that failing Azure VMs are retried after their backoff period