### PR TITLE
iOS: Revise EnrollDeviceView

### DIFF
--- a/mobile/Verify/Core/EnrollClient.swift
+++ b/mobile/Verify/Core/EnrollClient.swift
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see http://www.gnu.org/licenses/
 
+import Dependencies
 import DependenciesMacros
 import Enroll
 import Foundation
@@ -33,6 +34,7 @@ public enum EnrollClientError: Error, Sendable {
 	case clientCreationFailed
 }
 
+
 extension EnrollClient {
 	public static let liveValue = EnrollClient(
 		requestEnrollmentToken: { hostName, port, pairingToken in
@@ -51,3 +53,4 @@ extension EnrollClient {
 		},
 	)
 }
+

--- a/mobile/Verify/Verify.xcodeproj/xcshareddata/xcschemes/Verify.xcscheme
+++ b/mobile/Verify/Verify.xcodeproj/xcshareddata/xcschemes/Verify.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2650"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0C94C8512FA232E600C13C9A"
+               BuildableName = "Verify.app"
+               BlueprintName = "Verify"
+               ReferencedContainer = "container:Verify.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      queueDebuggingEnableBacktraceRecording = "Yes">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0C94C8512FA232E600C13C9A"
+            BuildableName = "Verify.app"
+            BlueprintName = "Verify"
+            ReferencedContainer = "container:Verify.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0C94C8512FA232E600C13C9A"
+            BuildableName = "Verify.app"
+            BlueprintName = "Verify"
+            ReferencedContainer = "container:Verify.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/mobile/Verify/Verify/App Lifecycle/Dependencies.swift
+++ b/mobile/Verify/Verify/App Lifecycle/Dependencies.swift
@@ -1,0 +1,24 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/
+
+import Core
+import Dependencies
+import DependenciesMacros
+
+extension DependencyValues {
+	@DependencyEntry(liveValue: EnrollClient.liveValue)
+	nonisolated var enrollClient = EnrollClient()
+}

--- a/mobile/Verify/Verify/App Lifecycle/LandingView.swift
+++ b/mobile/Verify/Verify/App Lifecycle/LandingView.swift
@@ -30,6 +30,8 @@ struct LandingView: View {
 					.frame(maxWidth: .infinity, maxHeight: 44, alignment: .leading)
 				ScrollView {
 					VStack(spacing: .large) {
+						Icon(systemName: "viewfinder")
+							.padding(.top, .xlarge)
 						titleBlock
 						instructionSteps
 						scanQRCodeButton
@@ -71,7 +73,6 @@ extension LandingView {
 		VStack(spacing: .small) {
 			Text("Scan QR code")
 				.font(.title)
-				.padding(.top, .xlarge)
 			Text("Enroll this device for your cluster by scanning the QR code in your web browser")
 				.font(.callout)
 				.multilineTextAlignment(.center)
@@ -104,10 +105,10 @@ extension LandingView {
 			viewModel.userTappedOnScanQRCode()
 		} label: {
 			Text("Scan QR Code")
-				.padding(.vertical, .xsmall)
 				.frame(maxWidth: .infinity)
 		}
-		.buttonStyle(.borderedProminent)
+		.buttonStyle(.primary)
+		.controlSize(.large)
 	}
 
 	private func instructionStep(stepNumber: UInt, @ViewBuilder label: () -> some View) -> some View {

--- a/mobile/Verify/Verify/App Lifecycle/LandingView.swift
+++ b/mobile/Verify/Verify/App Lifecycle/LandingView.swift
@@ -41,7 +41,7 @@ struct LandingView: View {
 
 			// MARK: Navigation
 
-			.navigationDestination(item: $viewModel.destination.deviceEnrollment) { deviceEnrollmentViewModel in
+			.navigationDestination(item: $viewModel.destination.enrollDevice) { deviceEnrollmentViewModel in
 				EnrollDeviceView(viewModel: deviceEnrollmentViewModel)
 			}
 			.sheet(item: $viewModel.destination.cameraScanner, id: \.presentationID) { enrollCameraScannerViewModel in

--- a/mobile/Verify/Verify/App Lifecycle/LandingViewModel.swift
+++ b/mobile/Verify/Verify/App Lifecycle/LandingViewModel.swift
@@ -19,11 +19,12 @@ import SwiftNavigation
 
 @Observable @MainActor
 final class LandingViewModel {
+	// swiftformat:sort
 	@CasePathable
 	enum Destination {
-		case deviceEnrollment(EnrollDeviceViewModel)
-		case deepLinkParsingAlert(errorMessage: String)
 		case cameraScanner(EnrollCameraScannerViewModel)
+		case deepLinkParsingAlert(errorMessage: String)
+		case enrollDevice(EnrollDeviceViewModel)
 	}
 
 	var destination: Destination? = nil
@@ -42,7 +43,7 @@ extension LandingViewModel {
 
 extension LandingViewModel {
 	func navigateToDeviceEnrollment(with deepLink: EnrollMobileDeviceDeepLink) {
-		destination = .deviceEnrollment(EnrollDeviceViewModel(deepLink: deepLink, delegate: self))
+		destination = .enrollDevice(EnrollDeviceViewModel(deepLink: deepLink, delegate: self))
 	}
 
 	func showParserError(errorMessage: String) {
@@ -66,6 +67,6 @@ extension LandingViewModel: EnrollCameraScannerViewModel.Delegate {
 		didReceiveEnrollMobileDeviceDeepLink deepLink: EnrollMobileDeviceDeepLink,
 	) {
 		sensoryFeedbackTrigger.toggle()
-		destination = .deviceEnrollment(EnrollDeviceViewModel(deepLink: deepLink, delegate: self))
+		destination = .enrollDevice(EnrollDeviceViewModel(deepLink: deepLink, delegate: self))
 	}
 }

--- a/mobile/Verify/Verify/Components/Icon.swift
+++ b/mobile/Verify/Verify/Components/Icon.swift
@@ -1,0 +1,104 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/
+
+import SwiftUI
+
+/// A general-purpose SF-symbol based icon boxed into a rounded rect.
+struct Icon: View {
+	// MARK: Initializer
+
+	let systemName: String
+	var iconScale: CGFloat
+	var foreground: AnyShapeStyle
+	var fillStyle: AnyShapeStyle
+	var strokeStyle: AnyShapeStyle
+	var maxWidth: CGFloat? = nil
+
+	/// Initializes a standard-looking SF Symbol-based icon with various configurations.
+	/// - Parameters:
+	///   - systemName: The name of the SF Symbol
+	///   - iconScale: The scale of the icon relative to its bounding box
+	///   - foreground: The foreground style to use for the icon
+	///   - fillStyle: The fill to use for the enclosing rounded rectangle
+	///   - strokeStyle: The stroke to apply to the rounded rectangle. For no stroke, supply `.clear`.
+	///   - maxWidth: The width (and therefore height) of the bounding box of the icon. Supply `nil` to allow the icon
+	/// to grow to fill its space.
+	init(
+		systemName: String,
+		iconScale: CGFloat = 0.45,
+		foreground: some ShapeStyle = .foreground,
+		fillStyle: some ShapeStyle = .background,
+		strokeStyle: some ShapeStyle = .separator,
+		maxWidth: CGFloat? = .xlarge * 2,
+	) {
+		self.systemName = systemName
+		self.iconScale = iconScale
+		self.foreground = AnyShapeStyle(foreground)
+		self.fillStyle = AnyShapeStyle(fillStyle)
+		self.strokeStyle = AnyShapeStyle(strokeStyle)
+		self.maxWidth = maxWidth
+	}
+
+	// MARK: State
+
+	@State
+	private var size: CGSize = .zero
+
+	// MARK: UI Helpers
+
+	private var imageWidth: CGFloat {
+		size.width * iconScale
+	}
+
+	private var imageHeight: CGFloat {
+		size.height * iconScale
+	}
+
+	// MARK: Body
+
+	var body: some View {
+		RoundedRectangle(cornerRadius: .medium)
+			.fill(fillStyle)
+			.strokeBorder(strokeStyle, lineWidth: 1)
+			.aspectRatio(1, contentMode: .fit)
+			.overlay {
+				Image(systemName: systemName)
+					.resizable()
+					.aspectRatio(contentMode: .fill)
+					.foregroundStyle(foreground)
+					.frame(maxWidth: imageWidth, maxHeight: imageHeight)
+			}
+			.onGeometryChange(for: CGSize.self) { geometry in
+				geometry.size
+			} action: { size in
+				self.size = size
+			}
+			.frame(maxWidth: maxWidth)
+	}
+}
+
+#Preview("Basic Icon") {
+	Icon(systemName: "viewfinder")
+}
+
+#Preview("App Tinted Icon") {
+	Icon(
+		systemName: "gearshape.fill",
+		foreground: .tint,
+		fillStyle: .tint.opacity(0.5),
+		strokeStyle: .clear,
+	)
+}

--- a/mobile/Verify/Verify/Design/Color.xcassets/Button/Contents.json
+++ b/mobile/Verify/Verify/Design/Color.xcassets/Button/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/mobile/Verify/Verify/Design/Color.xcassets/Button/primaryBackground.colorset/Contents.json
+++ b/mobile/Verify/Verify/Design/Color.xcassets/Button/primaryBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.788",
+          "green" : "0.184",
+          "red" : "0.318"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.522",
+          "red" : "0.624"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/mobile/Verify/Verify/Design/Color.xcassets/Button/primaryBackgroundPressed.colorset/Contents.json
+++ b/mobile/Verify/Verify/Design/Color.xcassets/Button/primaryBackgroundPressed.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.475",
+          "green" : "0.110",
+          "red" : "0.192"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.714",
+          "red" : "0.773"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/mobile/Verify/Verify/Design/Color.xcassets/Button/primayForeground.colorset/Contents.json
+++ b/mobile/Verify/Verify/Design/Color.xcassets/Button/primayForeground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/mobile/Verify/Verify/Design/Color.xcassets/Contents.json
+++ b/mobile/Verify/Verify/Design/Color.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/mobile/Verify/Verify/Design/PrimaryButtonStyle.swift
+++ b/mobile/Verify/Verify/Design/PrimaryButtonStyle.swift
@@ -1,0 +1,35 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/
+
+import Foundation
+import SwiftUI
+
+struct PrimaryButtonStyle: PrimitiveButtonStyle {
+	func makeBody(configuration: Configuration) -> some View {
+		Button(action: configuration.trigger) {
+			configuration.label
+				.foregroundStyle(Color.Button.primayForeground)
+		}
+		.buttonStyle(.borderedProminent)
+		.tint(Color.Button.primaryBackground)
+	}
+}
+
+extension PrimitiveButtonStyle where Self == PrimaryButtonStyle {
+	static var primary: PrimaryButtonStyle {
+		PrimaryButtonStyle()
+	}
+}

--- a/mobile/Verify/Verify/Enrollment/EnrollDeviceView.swift
+++ b/mobile/Verify/Verify/Enrollment/EnrollDeviceView.swift
@@ -15,8 +15,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import SwiftUI
+import SwiftUINavigation
 
 struct EnrollDeviceView: View {
+	@Bindable
 	var viewModel: EnrollDeviceViewModel
 
 	var body: some View {
@@ -42,23 +44,10 @@ struct EnrollDeviceView: View {
 
 		// MARK: Navigation
 
-		.sheet(
-			isPresented: Binding(
-				get: {
-					switch viewModel.loadingState {
-						case .idle: false
-						default: true
-					}
-				},
-				set: { if !$0 { viewModel.loadingState = .idle } },
-			),
-		) {
-			EnrollRequestStatusView(
-				attempt: viewModel.loadingState,
-				onDismiss: { viewModel.loadingState = .idle },
-			)
-			.presentationDetents([.medium])
-			.interactiveDismissDisabled(viewModel.loadingState.isLoading)
+		.navigationDestination(item: $viewModel.destination.loadingSheet) {
+			EnrollRequestStatusView(attempt: viewModel.loadingState, onDismiss: {})
+				.presentationDetents([.medium])
+				.interactiveDismissDisabled(viewModel.loadingState.isLoading)
 		}
 	}
 }
@@ -71,13 +60,8 @@ extension EnrollDeviceView {
 		Text("Enroll Your Device")
 			.font(.title2)
 			.fontWeight(.semibold)
-		Text(
-			"""
-			To finish enrolling this device, approve the request from \
-			your account settings on another device.
-			""",
-		)
-		.foregroundStyle(.secondary)
+		Text("To finish enrolling this device, approve the request from your account settings on another device.")
+			.foregroundStyle(.secondary)
 	}
 
 	var requestNowButton: some View {

--- a/mobile/Verify/Verify/Enrollment/EnrollDeviceView.swift
+++ b/mobile/Verify/Verify/Enrollment/EnrollDeviceView.swift
@@ -103,3 +103,15 @@ struct EnrollDeviceView: View {
 		}
 	}
 }
+
+#Preview {
+	EnrollDeviceView(
+		viewModel: EnrollDeviceViewModel(
+			deepLink: EnrollMobileDeviceDeepLink(
+				hostname: "localhost",
+				port: 1234,
+				enrollPairingToken: "pairing-token",
+			),
+		),
+	)
+}

--- a/mobile/Verify/Verify/Enrollment/EnrollDeviceView.swift
+++ b/mobile/Verify/Verify/Enrollment/EnrollDeviceView.swift
@@ -27,57 +27,21 @@ struct EnrollDeviceView: View {
 						.frame(maxWidth: 80)
 						.padding(.bottom, .small)
 						.padding(.top, .xxlarge)
-					Text("Enroll Your Device")
-						.font(.title2)
-						.fontWeight(.semibold)
-					Text(
-						"""
-						To finish enrolling this device, approve the request from \
-						your account settings on another device.
-						""",
-					)
-					.foregroundStyle(.secondary)
+					titleBlock
 				}
 				.multilineTextAlignment(.center)
 				.frame(maxHeight: .infinity, alignment: .center)
 			}
 			.scrollBounceBehavior(.basedOnSize)
-			Button {
-				Task { await viewModel.requestEnrollToken() }
-			} label: {
-				Group {
-					if viewModel.attempt.isLoading {
-						Label(
-							"Request in progress",
-							systemImage: "progress.indicator",
-						)
-						.labelStyle(.iconOnly)
-						.symbolEffect(
-							.variableColor.iterative,
-							options: .repeat(.continuous),
-							isActive: true,
-						)
-					} else {
-						Text("Request Now")
-					}
-				}
-				.frame(maxWidth: .infinity)
-			}
-			.buttonStyle(.primary)
-			.controlSize(.large)
-			.animation(.easeInOut, value: viewModel.attempt.isLoading)
-			.disabled(viewModel.attempt.isLoading)
-
-			Button(role: .cancel, action: viewModel.userTappedCancel) {
-				Text("Cancel").frame(maxWidth: .infinity)
-			}
-			.buttonStyle(.bordered)
-			.controlSize(.large)
-			.disabled(viewModel.attempt.isLoading)
+			requestNowButton
+			cancelButton
 		}
 		.padding()
 		.frame(maxWidth: .infinity, maxHeight: .infinity)
 		.background(Color(.systemGroupedBackground))
+
+		// MARK: Navigation
+
 		.sheet(
 			isPresented: Binding(
 				get: {
@@ -96,6 +60,61 @@ struct EnrollDeviceView: View {
 			.presentationDetents([.medium])
 			.interactiveDismissDisabled(viewModel.attempt.isLoading)
 		}
+	}
+}
+
+// MARK: - Subviews
+
+extension EnrollDeviceView {
+	@ViewBuilder
+	var titleBlock: some View {
+		Text("Enroll Your Device")
+			.font(.title2)
+			.fontWeight(.semibold)
+		Text(
+			"""
+			To finish enrolling this device, approve the request from \
+			your account settings on another device.
+			""",
+		)
+		.foregroundStyle(.secondary)
+	}
+
+	var requestNowButton: some View {
+		Button {
+			Task { await viewModel.requestEnrollToken() }
+		} label: {
+			Group {
+				if viewModel.attempt.isLoading {
+					Label(
+						"Request in progress",
+						systemImage: "progress.indicator",
+					)
+					.labelStyle(.iconOnly)
+					.symbolEffect(
+						.variableColor.iterative,
+						options: .repeat(.continuous),
+						isActive: true,
+					)
+				} else {
+					Text("Request Now")
+				}
+			}
+			.frame(maxWidth: .infinity)
+		}
+		.buttonStyle(.primary)
+		.controlSize(.large)
+		.animation(.easeInOut, value: viewModel.attempt.isLoading)
+		.disabled(viewModel.attempt.isLoading)
+	}
+
+	var cancelButton: some View {
+		Button(role: .cancel, action: viewModel.userTappedCancel) {
+			Text("Cancel").frame(maxWidth: .infinity)
+		}
+		.buttonStyle(.bordered)
+		.controlSize(.large)
+		.disabled(viewModel.attempt.isLoading)
 	}
 }
 

--- a/mobile/Verify/Verify/Enrollment/EnrollDeviceView.swift
+++ b/mobile/Verify/Verify/Enrollment/EnrollDeviceView.swift
@@ -20,65 +20,60 @@ struct EnrollDeviceView: View {
 	var viewModel: EnrollDeviceViewModel
 
 	var body: some View {
-		VStack(spacing: 16) {
-			Spacer()
-			Image(systemName: "ipad.and.iphone")
-				.font(.system(size: 37))
-				.foregroundStyle(.primary)
-				.frame(width: 75, height: 75)
-				.background(
-					RoundedRectangle(cornerRadius: 16)
-						.fill(Color(.systemBackground)),
-				)
-				.overlay(
-					RoundedRectangle(cornerRadius: 16)
-						.strokeBorder(Color(.separator), lineWidth: 1),
-				)
-			VStack(spacing: 8) {
-				Text("Enroll Your Device")
-					.font(.title2)
-					.fontWeight(.semibold)
-				Text(
-					"To finish enrolling this device, approve the request from your account settings on another device.",
-				)
+		VStack(spacing: .medium) {
+			ScrollView {
+				VStack(spacing: .small) {
+					Icon(systemName: "ipad.and.iphone")
+						.frame(maxWidth: 80)
+						.padding(.bottom, .small)
+						.padding(.top, .xxlarge)
+					Text("Enroll Your Device")
+						.font(.title2)
+						.fontWeight(.semibold)
+					Text(
+						"""
+						To finish enrolling this device, approve the request from \
+						your account settings on another device.
+						""",
+					)
+					.foregroundStyle(.secondary)
+				}
 				.multilineTextAlignment(.center)
-				.foregroundStyle(.secondary)
+				.frame(maxHeight: .infinity, alignment: .center)
 			}
-			Spacer()
-			VStack(spacing: 16) {
-				Button {
-					Task { await viewModel.requestEnrollToken() }
-				} label: {
-					Group {
-						if viewModel.attempt.isLoading {
-							Label(
-								"Request in progress",
-								systemImage: "progress.indicator",
-							)
-							.labelStyle(.iconOnly)
-							.symbolEffect(
-								.variableColor.iterative,
-								options: .repeat(.continuous),
-								isActive: true,
-							)
-						} else {
-							Text("Request Now")
-						}
+			.scrollBounceBehavior(.basedOnSize)
+			Button {
+				Task { await viewModel.requestEnrollToken() }
+			} label: {
+				Group {
+					if viewModel.attempt.isLoading {
+						Label(
+							"Request in progress",
+							systemImage: "progress.indicator",
+						)
+						.labelStyle(.iconOnly)
+						.symbolEffect(
+							.variableColor.iterative,
+							options: .repeat(.continuous),
+							isActive: true,
+						)
+					} else {
+						Text("Request Now")
 					}
-					.frame(maxWidth: .infinity)
 				}
-				.buttonStyle(.borderedProminent)
-				.controlSize(.large)
-				.animation(.easeInOut, value: viewModel.attempt.isLoading)
-				.disabled(viewModel.attempt.isLoading)
-
-				Button(role: .cancel, action: viewModel.userTappedCancel) {
-					Text("Cancel").frame(maxWidth: .infinity)
-				}
-				.buttonStyle(.bordered)
-				.controlSize(.large)
-				.disabled(viewModel.attempt.isLoading)
+				.frame(maxWidth: .infinity)
 			}
+			.buttonStyle(.primary)
+			.controlSize(.large)
+			.animation(.easeInOut, value: viewModel.attempt.isLoading)
+			.disabled(viewModel.attempt.isLoading)
+
+			Button(role: .cancel, action: viewModel.userTappedCancel) {
+				Text("Cancel").frame(maxWidth: .infinity)
+			}
+			.buttonStyle(.bordered)
+			.controlSize(.large)
+			.disabled(viewModel.attempt.isLoading)
 		}
 		.padding()
 		.frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/mobile/Verify/Verify/Enrollment/EnrollDeviceView.swift
+++ b/mobile/Verify/Verify/Enrollment/EnrollDeviceView.swift
@@ -45,20 +45,20 @@ struct EnrollDeviceView: View {
 		.sheet(
 			isPresented: Binding(
 				get: {
-					switch viewModel.attempt {
+					switch viewModel.loadingState {
 						case .idle: false
 						default: true
 					}
 				},
-				set: { if !$0 { viewModel.attempt = .idle } },
+				set: { if !$0 { viewModel.loadingState = .idle } },
 			),
 		) {
 			EnrollRequestStatusView(
-				attempt: viewModel.attempt,
-				onDismiss: { viewModel.attempt = .idle },
+				attempt: viewModel.loadingState,
+				onDismiss: { viewModel.loadingState = .idle },
 			)
 			.presentationDetents([.medium])
-			.interactiveDismissDisabled(viewModel.attempt.isLoading)
+			.interactiveDismissDisabled(viewModel.loadingState.isLoading)
 		}
 	}
 }
@@ -85,7 +85,7 @@ extension EnrollDeviceView {
 			Task { await viewModel.requestEnrollToken() }
 		} label: {
 			Group {
-				if viewModel.attempt.isLoading {
+				if viewModel.loadingState.isLoading {
 					Label(
 						"Request in progress",
 						systemImage: "progress.indicator",
@@ -104,8 +104,8 @@ extension EnrollDeviceView {
 		}
 		.buttonStyle(.primary)
 		.controlSize(.large)
-		.animation(.easeInOut, value: viewModel.attempt.isLoading)
-		.disabled(viewModel.attempt.isLoading)
+		.animation(.easeInOut, value: viewModel.loadingState.isLoading)
+		.disabled(viewModel.loadingState.isLoading)
 	}
 
 	var cancelButton: some View {
@@ -114,7 +114,7 @@ extension EnrollDeviceView {
 		}
 		.buttonStyle(.bordered)
 		.controlSize(.large)
-		.disabled(viewModel.attempt.isLoading)
+		.disabled(viewModel.loadingState.isLoading)
 	}
 }
 

--- a/mobile/Verify/Verify/Enrollment/EnrollDeviceViewModel.swift
+++ b/mobile/Verify/Verify/Enrollment/EnrollDeviceViewModel.swift
@@ -20,7 +20,7 @@ import Observation
 @Observable
 @MainActor
 class EnrollDeviceViewModel {
-	var attempt: LoadingState<String> = .idle
+	var loadingState: LoadingState<String> = .idle
 	private let deepLink: EnrollMobileDeviceDeepLink
 	private let enrollClient: EnrollClient
 
@@ -37,7 +37,7 @@ class EnrollDeviceViewModel {
 	}
 
 	func requestEnrollToken() async {
-		attempt = .loading
+		loadingState = .loading
 		let defaultHTTPSPort = 443
 		do {
 			let token = try await enrollClient.requestEnrollmentToken(
@@ -45,9 +45,9 @@ class EnrollDeviceViewModel {
 				port: deepLink.port ?? defaultHTTPSPort,
 				pairingToken: deepLink.enrollPairingToken,
 			)
-			attempt = .success(token)
+			loadingState = .success(token)
 		} catch {
-			attempt = .failure(error)
+			loadingState = .failure(error)
 		}
 	}
 }

--- a/mobile/Verify/Verify/Enrollment/EnrollDeviceViewModel.swift
+++ b/mobile/Verify/Verify/Enrollment/EnrollDeviceViewModel.swift
@@ -15,37 +15,57 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import Core
+import Dependencies
 import Observation
+import SwiftNavigation
 
 @Observable
 @MainActor
 class EnrollDeviceViewModel {
+	// swiftformat:sort
+	@CasePathable
+	enum Destination {
+		case loadingSheet
+	}
+
+	var destination: Destination? = nil
 	var loadingState: LoadingState<String> = .idle
 	private let deepLink: EnrollMobileDeviceDeepLink
-	private let enrollClient: EnrollClient
+
+	@ObservationIgnored
+	@Dependency(\.enrollClient)
+	private var enrollClient: EnrollClient
 
 	weak var delegate: (any Delegate)? = nil
 
 	init(
 		deepLink: EnrollMobileDeviceDeepLink,
-		enrollClient: EnrollClient = .liveValue,
 		delegate: (any Delegate)? = nil,
 	) {
 		self.deepLink = deepLink
-		self.enrollClient = enrollClient
 		self.delegate = delegate
 	}
 
 	func requestEnrollToken() async {
 		loadingState = .loading
+		destination = .loadingSheet
 		let defaultHTTPSPort = 443
 		do {
-			let token = try await enrollClient.requestEnrollmentToken(
-				hostName: deepLink.hostname,
-				port: deepLink.port ?? defaultHTTPSPort,
-				pairingToken: deepLink.enrollPairingToken,
-			)
-			loadingState = .success(token)
+			/*
+			 TODO: Implement the call to requestEnrollmentToken
+			 Right now, the backend doesn't have all the behavior we need to test enrollment token request end-to-end
+			 so we just simulate the behavior for now with a small delay.
+
+			 let token = try await enrollClient.requestEnrollmentToken(
+			 	hostName: deepLink.hostname,
+			 	port: deepLink.port ?? defaultHTTPSPort,
+			 	pairingToken: deepLink.enrollPairingToken,
+			 )
+			  */
+
+			try await Task.sleep(for: .seconds(1))
+			loadingState = .success("fake-token-\(defaultHTTPSPort)")
+			destination = nil
 		} catch {
 			loadingState = .failure(error)
 		}


### PR DESCRIPTION
This PR consists of a few different things to get EnrollDeviceView production-ready. These include:

- Structural refactoring to support accessibility features (like dynamic type) and readability.
- Adding a new `Icon` type for the standard "image in a rounded rect" motif we've used a couple times now.
- Use `@Dependency` to depend on `EnrollClient` rather than injecting it directly through a static accessor.
