### PR TITLE
docs: Refactor identity export docs for plugins

### DIFF
--- a/docs/pages/identity-governance/access-requests/plugins/discord.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/discord.mdx
@@ -107,7 +107,7 @@ longer-lived identity files with `tctl`:
 (!docs/pages/includes/plugins/tbot-identity.mdx secret="teleport-plugin-discord-identity"!)
 </TabItem>
 <TabItem label="Long-lived identity files">
-(!docs/pages/includes/plugins/identity-export.mdx user="access-plugin" secret="teleport-plugin-discord-identity"!)
+(!docs/pages/includes/plugins/identity-export.mdx plugin="discord" secret="teleport-plugin-discord-identity"!)
 </TabItem>
 </Tabs>
 

--- a/docs/pages/identity-governance/access-requests/plugins/email.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/email.mdx
@@ -112,7 +112,7 @@ longer-lived identity files with `tctl`:
 (!docs/pages/includes/plugins/tbot-identity.mdx secret="teleport-plugin-email-identity"!)
 </TabItem>
 <TabItem label="Long-lived identity files">
-(!docs/pages/includes/plugins/identity-export.mdx user="access-plugin" secret="teleport-plugin-email-identity"!)
+(!docs/pages/includes/plugins/identity-export.mdx plugin="email" secret="teleport-plugin-email-identity"!)
 </TabItem>
 </Tabs>
 

--- a/docs/pages/identity-governance/access-requests/plugins/how-to-build.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/how-to-build.mdx
@@ -197,7 +197,7 @@ longer-lived identity files with `tctl`:
 (!docs/pages/includes/plugins/tbot-identity.mdx secret="teleport-plugin-identity"!)
 </TabItem>
 <TabItem label="Long-lived identity files">
-(!docs/pages/includes/plugins/identity-export.mdx user="access-plugin" secret="teleport-plugin-identity"!)
+(!docs/pages/includes/plugins/identity-export.mdx plugin="demo-plugin" secret="teleport-plugin-identity"!)
 </TabItem>
 </Tabs>
 

--- a/docs/pages/identity-governance/access-requests/plugins/jira.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/jira.mdx
@@ -166,7 +166,7 @@ longer-lived identity files with `tctl`:
 (!docs/pages/includes/plugins/tbot-identity.mdx secret="teleport-plugin-jira-identity"!)
 </TabItem>
 <TabItem label="Long-lived identity files">
-(!docs/pages/includes/plugins/identity-export.mdx user="access-plugin-update" secret="teleport-plugin-jira-identity"!)
+(!docs/pages/includes/plugins/identity-export.mdx plugin="jira" user="access-plugin-update" secret="teleport-plugin-jira-identity"!)
 </TabItem>
 </Tabs>
 

--- a/docs/pages/identity-governance/access-requests/plugins/mattermost.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/mattermost.mdx
@@ -90,7 +90,7 @@ longer-lived identity files with `tctl`:
 (!docs/pages/includes/plugins/tbot-identity.mdx secret="teleport-plugin-mattermost-identity"!)
 </TabItem>
 <TabItem label="Long-lived identity files">
-(!docs/pages/includes/plugins/identity-export.mdx user="access-plugin" secret="teleport-plugin-mattermost-identity"!)
+(!docs/pages/includes/plugins/identity-export.mdx plugin="mattermost" secret="teleport-plugin-mattermost-identity"!)
 </TabItem>
 </Tabs>
 

--- a/docs/pages/identity-governance/access-requests/plugins/msteams.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/msteams.mdx
@@ -90,7 +90,7 @@ longer-lived identity files with `tctl`:
 (!docs/pages/includes/plugins/tbot-identity.mdx secret="teleport-plugin-msteams-identity"!)
 </TabItem>
 <TabItem label="Long-lived identity files">
-(!docs/pages/includes/plugins/identity-export.mdx user="access-plugin" secret="teleport-plugin-msteams-identity"!)
+(!docs/pages/includes/plugins/identity-export.mdx plugin="msteams" secret="teleport-plugin-msteams-identity"!)
 </TabItem>
 </Tabs>
 

--- a/docs/pages/identity-governance/access-requests/plugins/pagerduty.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/pagerduty.mdx
@@ -388,7 +388,7 @@ longer-lived identity files with `tctl`:
 (!docs/pages/includes/plugins/tbot-identity.mdx secret="teleport-plugin-pagerduty-identity"!)
 </TabItem>
 <TabItem label="Long-lived identity files">
-(!docs/pages/includes/plugins/identity-export.mdx user="access-plugin" secret="teleport-plugin-pagerduty-identity"!)
+(!docs/pages/includes/plugins/identity-export.mdx plugin="pagerduty" secret="teleport-plugin-pagerduty-identity"!)
 </TabItem>
 </Tabs>
 

--- a/docs/pages/identity-governance/access-requests/plugins/slack.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/slack.mdx
@@ -112,7 +112,7 @@ longer-lived identity files with `tctl`:
 (!docs/pages/includes/plugins/tbot-identity.mdx secret="teleport-plugin-slack-identity"!)
 </TabItem>
 <TabItem label="Long-lived identity files">
-(!docs/pages/includes/plugins/identity-export.mdx user="access-plugin" secret="teleport-plugin-slack-identity"!)
+(!docs/pages/includes/plugins/identity-export.mdx plugin="slack" secret="teleport-plugin-slack-identity"!)
 </TabItem>
 </Tabs>
 

--- a/docs/pages/includes/plugins/identity-export.mdx
+++ b/docs/pages/includes/plugins/identity-export.mdx
@@ -1,4 +1,4 @@
-{{ client="plugin" secret="plugin-identity" }}
+{{ user="access-plugin" secret="plugin-identity" }}
 
 Like all Teleport users, `{{ user }}` needs signed credentials in order to
 connect to your Teleport cluster. You will use the `tctl auth sign` command to
@@ -12,11 +12,11 @@ directory:
 $ tctl auth sign --user={{ user }} --out=identity
 ```
 
-The {{ client }} connects to the Teleport Auth Service's gRPC endpoint over TLS.
+The plugin connects to the Teleport Auth Service's gRPC endpoint over TLS.
 
 The identity file, `identity`, includes both TLS and SSH credentials. The
-{{ client }} uses the SSH credentials to connect to the Proxy Service, which
-establishes a reverse tunnel connection to the Auth Service. The {{ client }}
+plugin uses the SSH credentials to connect to the Proxy Service, which
+establishes a reverse tunnel connection to the Auth Service. The plugin
 uses this reverse tunnel, along with your TLS credentials, to connect to the
 Auth Service's gRPC endpoint.
 
@@ -41,15 +41,15 @@ Auth Service's gRPC endpoint.
 
 </details>
 
-If you are running the {{ client }} on a Linux server, create a data directory
-to hold certificate files for the {{ client }}:
+If you are running the plugin on a Linux server, create a data directory
+to hold certificate files for the plugin:
 
 ```code
-$ sudo mkdir -p /var/lib/teleport/plugins/api-credentials
-$ sudo mv identity /var/lib/teleport/plugins/api-credentials
+$ sudo mkdir -p /var/lib/teleport/plugins/{{ plugin }}
+$ sudo mv identity /var/lib/teleport/plugins/{{ plugin }}
 ```
 
-If you are running the {{ client }} on Kubernetes, create a Kubernetes secret
+If you are running the plugin on Kubernetes, create a Kubernetes secret
 that contains the Teleport identity file:
 
 ```code

--- a/docs/pages/zero-trust-access/export-audit-events/event-handler-setup.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/event-handler-setup.mdx
@@ -129,7 +129,7 @@ longer-lived identity files with `tctl`:
 (!docs/pages/includes/plugins/tbot-identity.mdx secret="teleport-event-handler-identity"!)
 </TabItem>
 <TabItem label="Long-lived identity files">
-(!docs/pages/includes/plugins/identity-export.mdx user="teleport-event-handler" secret="teleport-event-handler-identity"!)
+(!docs/pages/includes/plugins/identity-export.mdx user="teleport-event-handler" plugin="event-handler" secret="teleport-event-handler-identity"!)
 </TabItem>
 </Tabs>
 


### PR DESCRIPTION
Modifies `"/var/lib/teleport/plugins/api-credentials"` path in the identity export command to a plugin-specific path.

This matches config comments which generally refer to the identity file as eg.
`"/var/lib/teleport/plugins/slack/identity"`

Also removed an unused partial parameter `{{ client="plugin" }}`