### PR TITLE
oslog_darwin.go: Add blank line after build constraint

### DIFF
--- a/lib/utils/log/oslog/oslog_darwin.go
+++ b/lib/utils/log/oslog/oslog_darwin.go
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //go:build darwin && !ios
+
 package oslog
 
 // #cgo CFLAGS: -Wall -xobjective-c -fblocks -fobjc-arc -mmacosx-version-min=11.0


### PR DESCRIPTION
Tim tipped me off about golangci-lint flagging this file. It passes on CI because (I assume) CI runs on Linux and it takes build constraints into account so it skips this file.

```
$ golangci-lint run -c .golangci.yml --build-tags='libfido2  piv ' --fast-only
lib/utils/log/oslog/oslog_darwin.go:17:1: File is not properly formatted (gci)
//go:build darwin && !ios
^
e/scripts/loadtest-login/main.go:63:1: File is not properly formatted (goimports)
	"github.com/gravitational/teleport/api/mfa"
^
lib/utils/log/oslog/oslog_darwin.go:17:1: File is not properly formatted (goimports)
//go:build darwin && !ios
^
3 issues:
* gci: 1
* goimports: 2
```


## Manual Test Plan
### Test Environment

My laptop.

### Test Cases
- [x] The file is no longer flagged by golangci-lint.
