### PR TITLE
[v18] Adjust ScopedRoleAssignment to refer to scoped Bot using SQN (#67728)

### DIFF
--- a/api/gen/proto/go/teleport/scopes/access/v1/assignment.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/assignment.pb.go
@@ -233,17 +233,17 @@ func (b0 ScopedRoleAssignment_builder) Build() *ScopedRoleAssignment {
 type ScopedRoleAssignmentSpec struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// User is the user to whom all contained assignments apply.
-	// Mutually exclusive with `bot_name`.
+	// Mutually exclusive with `bot`.
 	User string `protobuf:"bytes,1,opt,name=user,proto3" json:"user,omitempty"`
 	// Assignments is a list of individual role @ scope assignments.
 	Assignments []*Assignment `protobuf:"bytes,2,rep,name=assignments,proto3" json:"assignments,omitempty"`
-	// Name of the Bot to whom all contained assignments apply.
+	// The Bot to whom all contained assignments apply, as a scope-qualified name
+	// of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot").
 	// Mutually exclusive with `user`.
-	BotName string `protobuf:"bytes,3,opt,name=bot_name,json=botName,proto3" json:"bot_name,omitempty"`
-	// Scope of the Bot to whom all contained assignments apply.
-	// Required if `bot_name` is set.
-	// If specified, assignment scopes must be equal or descendent of this scope.
-	BotScope      string `protobuf:"bytes,4,opt,name=bot_scope,json=botScope,proto3" json:"bot_scope,omitempty"`
+	//
+	// When specified, assignment scopes must be equal or descendent of the scope
+	// indicated by this field.
+	Bot           string `protobuf:"bytes,5,opt,name=bot,proto3" json:"bot,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -287,16 +287,9 @@ func (x *ScopedRoleAssignmentSpec) GetAssignments() []*Assignment {
 	return nil
 }
 
-func (x *ScopedRoleAssignmentSpec) GetBotName() string {
+func (x *ScopedRoleAssignmentSpec) GetBot() string {
 	if x != nil {
-		return x.BotName
-	}
-	return ""
-}
-
-func (x *ScopedRoleAssignmentSpec) GetBotScope() string {
-	if x != nil {
-		return x.BotScope
+		return x.Bot
 	}
 	return ""
 }
@@ -309,29 +302,25 @@ func (x *ScopedRoleAssignmentSpec) SetAssignments(v []*Assignment) {
 	x.Assignments = v
 }
 
-func (x *ScopedRoleAssignmentSpec) SetBotName(v string) {
-	x.BotName = v
-}
-
-func (x *ScopedRoleAssignmentSpec) SetBotScope(v string) {
-	x.BotScope = v
+func (x *ScopedRoleAssignmentSpec) SetBot(v string) {
+	x.Bot = v
 }
 
 type ScopedRoleAssignmentSpec_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
 	// User is the user to whom all contained assignments apply.
-	// Mutually exclusive with `bot_name`.
+	// Mutually exclusive with `bot`.
 	User string
 	// Assignments is a list of individual role @ scope assignments.
 	Assignments []*Assignment
-	// Name of the Bot to whom all contained assignments apply.
+	// The Bot to whom all contained assignments apply, as a scope-qualified name
+	// of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot").
 	// Mutually exclusive with `user`.
-	BotName string
-	// Scope of the Bot to whom all contained assignments apply.
-	// Required if `bot_name` is set.
-	// If specified, assignment scopes must be equal or descendent of this scope.
-	BotScope string
+	//
+	// When specified, assignment scopes must be equal or descendent of the scope
+	// indicated by this field.
+	Bot string
 }
 
 func (b0 ScopedRoleAssignmentSpec_builder) Build() *ScopedRoleAssignmentSpec {
@@ -340,8 +329,7 @@ func (b0 ScopedRoleAssignmentSpec_builder) Build() *ScopedRoleAssignmentSpec {
 	_, _ = b, x
 	x.User = b.User
 	x.Assignments = b.Assignments
-	x.BotName = b.BotName
-	x.BotScope = b.BotScope
+	x.Bot = b.Bot
 	return m0
 }
 
@@ -582,12 +570,11 @@ const file_teleport_scopes_access_v1_assignment_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12G\n" +
 	"\x04spec\x18\x06 \x01(\v23.teleport.scopes.access.v1.ScopedRoleAssignmentSpecR\x04spec\x12M\n" +
-	"\x06status\x18\a \x01(\v25.teleport.scopes.access.v1.ScopedRoleAssignmentStatusR\x06status\"\xaf\x01\n" +
+	"\x06status\x18\a \x01(\v25.teleport.scopes.access.v1.ScopedRoleAssignmentStatusR\x06status\"\xaa\x01\n" +
 	"\x18ScopedRoleAssignmentSpec\x12\x12\n" +
 	"\x04user\x18\x01 \x01(\tR\x04user\x12G\n" +
-	"\vassignments\x18\x02 \x03(\v2%.teleport.scopes.access.v1.AssignmentR\vassignments\x12\x19\n" +
-	"\bbot_name\x18\x03 \x01(\tR\abotName\x12\x1b\n" +
-	"\tbot_scope\x18\x04 \x01(\tR\bbotScope\"6\n" +
+	"\vassignments\x18\x02 \x03(\v2%.teleport.scopes.access.v1.AssignmentR\vassignments\x12\x10\n" +
+	"\x03bot\x18\x05 \x01(\tR\x03botJ\x04\b\x03\x10\x04J\x04\b\x04\x10\x05R\bbot_nameR\tbot_scope\"6\n" +
 	"\n" +
 	"Assignment\x12\x12\n" +
 	"\x04role\x18\x01 \x01(\tR\x04role\x12\x14\n" +

--- a/api/gen/proto/go/teleport/scopes/access/v1/assignment_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/assignment_protoopaque.pb.go
@@ -227,8 +227,7 @@ type ScopedRoleAssignmentSpec struct {
 	state                  protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_User        string                 `protobuf:"bytes,1,opt,name=user,proto3"`
 	xxx_hidden_Assignments *[]*Assignment         `protobuf:"bytes,2,rep,name=assignments,proto3"`
-	xxx_hidden_BotName     string                 `protobuf:"bytes,3,opt,name=bot_name,json=botName,proto3"`
-	xxx_hidden_BotScope    string                 `protobuf:"bytes,4,opt,name=bot_scope,json=botScope,proto3"`
+	xxx_hidden_Bot         string                 `protobuf:"bytes,5,opt,name=bot,proto3"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
@@ -274,16 +273,9 @@ func (x *ScopedRoleAssignmentSpec) GetAssignments() []*Assignment {
 	return nil
 }
 
-func (x *ScopedRoleAssignmentSpec) GetBotName() string {
+func (x *ScopedRoleAssignmentSpec) GetBot() string {
 	if x != nil {
-		return x.xxx_hidden_BotName
-	}
-	return ""
-}
-
-func (x *ScopedRoleAssignmentSpec) GetBotScope() string {
-	if x != nil {
-		return x.xxx_hidden_BotScope
+		return x.xxx_hidden_Bot
 	}
 	return ""
 }
@@ -296,29 +288,25 @@ func (x *ScopedRoleAssignmentSpec) SetAssignments(v []*Assignment) {
 	x.xxx_hidden_Assignments = &v
 }
 
-func (x *ScopedRoleAssignmentSpec) SetBotName(v string) {
-	x.xxx_hidden_BotName = v
-}
-
-func (x *ScopedRoleAssignmentSpec) SetBotScope(v string) {
-	x.xxx_hidden_BotScope = v
+func (x *ScopedRoleAssignmentSpec) SetBot(v string) {
+	x.xxx_hidden_Bot = v
 }
 
 type ScopedRoleAssignmentSpec_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
 	// User is the user to whom all contained assignments apply.
-	// Mutually exclusive with `bot_name`.
+	// Mutually exclusive with `bot`.
 	User string
 	// Assignments is a list of individual role @ scope assignments.
 	Assignments []*Assignment
-	// Name of the Bot to whom all contained assignments apply.
+	// The Bot to whom all contained assignments apply, as a scope-qualified name
+	// of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot").
 	// Mutually exclusive with `user`.
-	BotName string
-	// Scope of the Bot to whom all contained assignments apply.
-	// Required if `bot_name` is set.
-	// If specified, assignment scopes must be equal or descendent of this scope.
-	BotScope string
+	//
+	// When specified, assignment scopes must be equal or descendent of the scope
+	// indicated by this field.
+	Bot string
 }
 
 func (b0 ScopedRoleAssignmentSpec_builder) Build() *ScopedRoleAssignmentSpec {
@@ -327,8 +315,7 @@ func (b0 ScopedRoleAssignmentSpec_builder) Build() *ScopedRoleAssignmentSpec {
 	_, _ = b, x
 	x.xxx_hidden_User = b.User
 	x.xxx_hidden_Assignments = &b.Assignments
-	x.xxx_hidden_BotName = b.BotName
-	x.xxx_hidden_BotScope = b.BotScope
+	x.xxx_hidden_Bot = b.Bot
 	return m0
 }
 
@@ -563,12 +550,11 @@ const file_teleport_scopes_access_v1_assignment_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12G\n" +
 	"\x04spec\x18\x06 \x01(\v23.teleport.scopes.access.v1.ScopedRoleAssignmentSpecR\x04spec\x12M\n" +
-	"\x06status\x18\a \x01(\v25.teleport.scopes.access.v1.ScopedRoleAssignmentStatusR\x06status\"\xaf\x01\n" +
+	"\x06status\x18\a \x01(\v25.teleport.scopes.access.v1.ScopedRoleAssignmentStatusR\x06status\"\xaa\x01\n" +
 	"\x18ScopedRoleAssignmentSpec\x12\x12\n" +
 	"\x04user\x18\x01 \x01(\tR\x04user\x12G\n" +
-	"\vassignments\x18\x02 \x03(\v2%.teleport.scopes.access.v1.AssignmentR\vassignments\x12\x19\n" +
-	"\bbot_name\x18\x03 \x01(\tR\abotName\x12\x1b\n" +
-	"\tbot_scope\x18\x04 \x01(\tR\bbotScope\"6\n" +
+	"\vassignments\x18\x02 \x03(\v2%.teleport.scopes.access.v1.AssignmentR\vassignments\x12\x10\n" +
+	"\x03bot\x18\x05 \x01(\tR\x03botJ\x04\b\x03\x10\x04J\x04\b\x04\x10\x05R\bbot_nameR\tbot_scope\"6\n" +
 	"\n" +
 	"Assignment\x12\x12\n" +
 	"\x04role\x18\x01 \x01(\tR\x04role\x12\x14\n" +

--- a/api/proto/teleport/scopes/access/v1/assignment.proto
+++ b/api/proto/teleport/scopes/access/v1/assignment.proto
@@ -50,20 +50,22 @@ message ScopedRoleAssignment {
 // ScopedRoleAssignmentSpec is the specification of a scoped role assignment.
 message ScopedRoleAssignmentSpec {
   // User is the user to whom all contained assignments apply.
-  // Mutually exclusive with `bot_name`.
+  // Mutually exclusive with `bot`.
   string user = 1;
 
   // Assignments is a list of individual role @ scope assignments.
   repeated Assignment assignments = 2;
 
-  // Name of the Bot to whom all contained assignments apply.
-  // Mutually exclusive with `user`.
-  string bot_name = 3;
+  reserved 3, 4;
+  reserved "bot_name", "bot_scope";
 
-  // Scope of the Bot to whom all contained assignments apply.
-  // Required if `bot_name` is set.
-  // If specified, assignment scopes must be equal or descendent of this scope.
-  string bot_scope = 4;
+  // The Bot to whom all contained assignments apply, as a scope-qualified name
+  // of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot").
+  // Mutually exclusive with `user`.
+  //
+  // When specified, assignment scopes must be equal or descendent of the scope
+  // indicated by this field.
+  string bot = 5;
 }
 
 // Assignment is a role/scope pair that defines an individual assignment.

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedroleassignmentsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedroleassignmentsv1.mdx
@@ -27,9 +27,8 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |Field|Type|Description|
 |---|---|---|
 |assignments|[][object](#specassignments-items)|Assignments is a list of individual role @ scope assignments.|
-|bot_name|string|Name of the Bot to whom all contained assignments apply. Mutually exclusive with `user`.|
-|bot_scope|string|Scope of the Bot to whom all contained assignments apply. Required if `bot_name` is set. If specified, assignment scopes must be equal or descendent of this scope.|
-|user|string|User is the user to whom all contained assignments apply. Mutually exclusive with `bot_name`.|
+|bot|string|The Bot to whom all contained assignments apply, as a scope-qualified name of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot"). Mutually exclusive with `user`.  When specified, assignment scopes must be equal or descendent of the scope indicated by this field.|
+|user|string|User is the user to whom all contained assignments apply. Mutually exclusive with `bot`.|
 
 ### spec.assignments items
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role_assignment.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role_assignment.mdx
@@ -46,9 +46,8 @@ Required:
 
 Optional:
 
-- `bot_name` (String) Name of the Bot to whom all contained assignments apply. Mutually exclusive with `user`.
-- `bot_scope` (String) Scope of the Bot to whom all contained assignments apply. Required if `bot_name` is set. If specified, assignment scopes must be equal or descendent of this scope.
-- `user` (String) User is the user to whom all contained assignments apply. Mutually exclusive with `bot_name`.
+- `bot` (String) The Bot to whom all contained assignments apply, as a scope-qualified name of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot"). Mutually exclusive with `user`.  When specified, assignment scopes must be equal or descendent of the scope indicated by this field.
+- `user` (String) User is the user to whom all contained assignments apply. Mutually exclusive with `bot`.
 
 ### Nested Schema for `spec.assignments`
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role_assignment.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role_assignment.mdx
@@ -89,9 +89,8 @@ Required:
 
 Optional:
 
-- `bot_name` (String) Name of the Bot to whom all contained assignments apply. Mutually exclusive with `user`.
-- `bot_scope` (String) Scope of the Bot to whom all contained assignments apply. Required if `bot_name` is set. If specified, assignment scopes must be equal or descendent of this scope.
-- `user` (String) User is the user to whom all contained assignments apply. Mutually exclusive with `bot_name`.
+- `bot` (String) The Bot to whom all contained assignments apply, as a scope-qualified name of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot"). Mutually exclusive with `user`.  When specified, assignment scopes must be equal or descendent of the scope indicated by this field.
+- `user` (String) User is the user to whom all contained assignments apply. Mutually exclusive with `bot`.
 
 ### Nested Schema for `spec.assignments`
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedroleassignmentsv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedroleassignmentsv1.yaml
@@ -59,18 +59,15 @@ spec:
                   type: object
                 nullable: true
                 type: array
-              bot_name:
-                description: Name of the Bot to whom all contained assignments apply.
-                  Mutually exclusive with `user`.
-                type: string
-              bot_scope:
-                description: Scope of the Bot to whom all contained assignments apply.
-                  Required if `bot_name` is set. If specified, assignment scopes must
-                  be equal or descendent of this scope.
+              bot:
+                description: The Bot to whom all contained assignments apply, as a
+                  scope-qualified name of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot").
+                  Mutually exclusive with `user`.  When specified, assignment scopes
+                  must be equal or descendent of the scope indicated by this field.
                 type: string
               user:
                 description: User is the user to whom all contained assignments apply.
-                  Mutually exclusive with `bot_name`.
+                  Mutually exclusive with `bot`.
                 type: string
             type: object
           status:

--- a/integrations/lib/embeddedtbot/bot_test.go
+++ b/integrations/lib/embeddedtbot/bot_test.go
@@ -195,4 +195,3 @@ func createBotUser(
 	user.SetTraits(traits)
 	return user, nil
 }
-

--- a/integrations/lib/embeddedtbot/bot_test.go
+++ b/integrations/lib/embeddedtbot/bot_test.go
@@ -195,3 +195,4 @@ func createBotUser(
 	user.SetTraits(traits)
 	return user, nil
 }
+

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedroleassignmentsv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedroleassignmentsv1.yaml
@@ -59,18 +59,15 @@ spec:
                   type: object
                 nullable: true
                 type: array
-              bot_name:
-                description: Name of the Bot to whom all contained assignments apply.
-                  Mutually exclusive with `user`.
-                type: string
-              bot_scope:
-                description: Scope of the Bot to whom all contained assignments apply.
-                  Required if `bot_name` is set. If specified, assignment scopes must
-                  be equal or descendent of this scope.
+              bot:
+                description: The Bot to whom all contained assignments apply, as a
+                  scope-qualified name of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot").
+                  Mutually exclusive with `user`.  When specified, assignment scopes
+                  must be equal or descendent of the scope indicated by this field.
                 type: string
               user:
                 description: User is the user to whom all contained assignments apply.
-                  Mutually exclusive with `bot_name`.
+                  Mutually exclusive with `bot`.
                 type: string
             type: object
           status:

--- a/integrations/terraform/tfschema/scopes/access/assignment/v1/assignment_terraform.go
+++ b/integrations/terraform/tfschema/scopes/access/assignment/v1/assignment_terraform.go
@@ -123,18 +123,13 @@ func GenSchemaScopedRoleAssignment(ctx context.Context) (github_com_hashicorp_te
 					Description: "Assignments is a list of individual role @ scope assignments.",
 					Required:    true,
 				},
-				"bot_name": {
-					Description: "Name of the Bot to whom all contained assignments apply. Mutually exclusive with `user`.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
-				"bot_scope": {
-					Description: "Scope of the Bot to whom all contained assignments apply. Required if `bot_name` is set. If specified, assignment scopes must be equal or descendent of this scope.",
+				"bot": {
+					Description: "The Bot to whom all contained assignments apply, as a scope-qualified name of the form `<scope>::<bot-name>` (e.g. \"/staging/west::mybot\"). Mutually exclusive with `user`.  When specified, assignment scopes must be equal or descendent of the scope indicated by this field.",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"user": {
-					Description: "User is the user to whom all contained assignments apply. Mutually exclusive with `bot_name`.",
+					Description: "User is the user to whom all contained assignments apply. Mutually exclusive with `bot`.",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
@@ -441,36 +436,19 @@ func CopyScopedRoleAssignmentFromTerraform(_ context.Context, tf github_com_hash
 						}
 					}
 					{
-						a, ok := tf.Attrs["bot_name"]
+						a, ok := tf.Attrs["bot"]
 						if !ok {
-							diags.Append(attrReadMissingDiag{"ScopedRoleAssignment.spec.bot_name"})
+							diags.Append(attrReadMissingDiag{"ScopedRoleAssignment.spec.bot"})
 						} else {
 							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"ScopedRoleAssignment.spec.bot_name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+								diags.Append(attrReadConversionFailureDiag{"ScopedRoleAssignment.spec.bot", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 							} else {
 								var t string
 								if !v.Null && !v.Unknown {
 									t = string(v.Value)
 								}
-								obj.BotName = t
-							}
-						}
-					}
-					{
-						a, ok := tf.Attrs["bot_scope"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"ScopedRoleAssignment.spec.bot_scope"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"ScopedRoleAssignment.spec.bot_scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.BotScope = t
+								obj.Bot = t
 							}
 						}
 					}
@@ -907,47 +885,25 @@ func CopyScopedRoleAssignmentToTerraform(ctx context.Context, obj *github_com_gr
 						}
 					}
 					{
-						t, ok := tf.AttrTypes["bot_name"]
+						t, ok := tf.AttrTypes["bot"]
 						if !ok {
-							diags.Append(attrWriteMissingDiag{"ScopedRoleAssignment.spec.bot_name"})
+							diags.Append(attrWriteMissingDiag{"ScopedRoleAssignment.spec.bot"})
 						} else {
-							v, ok := tf.Attrs["bot_name"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+							v, ok := tf.Attrs["bot"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
-									diags.Append(attrWriteGeneralError{"ScopedRoleAssignment.spec.bot_name", err})
+									diags.Append(attrWriteGeneralError{"ScopedRoleAssignment.spec.bot", err})
 								}
 								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
 								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"ScopedRoleAssignment.spec.bot_name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+									diags.Append(attrWriteConversionFailureDiag{"ScopedRoleAssignment.spec.bot", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 								}
-								v.Null = string(obj.BotName) == ""
+								v.Null = string(obj.Bot) == ""
 							}
-							v.Value = string(obj.BotName)
+							v.Value = string(obj.Bot)
 							v.Unknown = false
-							tf.Attrs["bot_name"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["bot_scope"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"ScopedRoleAssignment.spec.bot_scope"})
-						} else {
-							v, ok := tf.Attrs["bot_scope"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"ScopedRoleAssignment.spec.bot_scope", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"ScopedRoleAssignment.spec.bot_scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.BotScope) == ""
-							}
-							v.Value = string(obj.BotScope)
-							v.Unknown = false
-							tf.Attrs["bot_scope"] = v
+							tf.Attrs["bot"] = v
 						}
 					}
 				}

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -1418,8 +1418,7 @@ func createScopedBot(t *testing.T, srv *authtest.TLSServer, adminClient *authcli
 			SubKind: scopedaccess.SubKindDynamic,
 			Scope:   "/test",
 			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
-				BotName:  "test-scoped",
-				BotScope: "/test",
+				Bot: scopes.QualifiedName{Scope: "/test", Name: "test-scoped"}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					{Role: "scoped-example", Scope: "/test"},
 				},

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -6954,8 +6954,7 @@ func TestGenerateUserCertsScopedBot(t *testing.T) {
 						},
 						Scope: c.scope,
 						Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
-							BotName:  bot.GetMetadata().GetName(),
-							BotScope: c.scope,
+							Bot: scopes.QualifiedName{Scope: c.scope, Name: bot.GetMetadata().GetName()}.String(),
 							Assignments: []*scopedaccessv1.Assignment{
 								{Role: roleResp.GetRole().GetMetadata().GetName(), Scope: c.scope},
 							},

--- a/lib/auth/issuance/v1/service_test.go
+++ b/lib/auth/issuance/v1/service_test.go
@@ -134,8 +134,7 @@ func TestIssueScopedBotCerts(t *testing.T) {
 			},
 			Scope: botScope,
 			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
-				BotName:  bot.Metadata.Name,
-				BotScope: botScope,
+				Bot: scopes.QualifiedName{Scope: botScope, Name: bot.GetMetadata().GetName()}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					{Role: "bot-role", Scope: botScope},
 				},
@@ -365,8 +364,7 @@ func TestIssueScopedBotCerts_Unauthorized(t *testing.T) {
 			},
 			Scope: testScope,
 			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
-				BotName:  scopedBot.Metadata.Name,
-				BotScope: testScope,
+				Bot: scopes.QualifiedName{Scope: testScope, Name: scopedBot.GetMetadata().GetName()}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					{Role: "test-role", Scope: testScope},
 				},

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -3625,8 +3625,7 @@ func TestBotInstanceService_SubmitHeartbeat(t *testing.T) {
 				SubKind: scopedaccess.SubKindDynamic,
 				Scope:   "/scopes",
 				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
-					BotName:  botName,
-					BotScope: "/scopes/test",
+					Bot: scopes.QualifiedName{Scope: "/scopes/test", Name: botName}.String(),
 					Assignments: []*scopedaccessv1.Assignment{
 						{Role: scopedRole.Role.Metadata.Name, Scope: "/scopes/test"},
 					},

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -1870,8 +1870,7 @@ func createScopedBot(t *testing.T, srv *authtest.TLSServer, adminClient *authcli
 			SubKind: scopedaccess.SubKindDynamic,
 			Scope:   "/test",
 			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
-				BotName:  "test-scoped",
-				BotScope: "/test",
+				Bot: scopes.QualifiedName{Scope: "/test", Name: "test-scoped"}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					{Role: "scoped-example", Scope: "/test"},
 				},

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -480,23 +480,21 @@ func StrongValidateAssignment(assignment *scopedaccessv1.ScopedRoleAssignment) e
 		return trace.BadParameter("scoped role assignment %q contains too many sub-assignments (max %d)", assignment.GetMetadata().GetName(), MaxRolesPerAssignment)
 	}
 
-	// Assigning to Bot is mutually exclusive with assigning to User. When
-	// assigning to Bot, we also want to ensure Bot's scope is specified.
-	botSet := assignment.GetSpec().GetBotName() != ""
-	botScope := assignment.GetSpec().GetBotScope()
-	if botSet && assignment.GetSpec().GetUser() != "" {
-		return trace.BadParameter("scoped role assignment %q cannot have both spec.bot_name and spec.user set", assignment.GetMetadata().GetName())
-	}
-	if botSet && botScope == "" {
-		return trace.BadParameter("scoped role assignment %q with spec.bot_name set must also have spec.bot_scope set", assignment.GetMetadata().GetName())
-	}
-	if !botSet && botScope != "" {
-		return trace.BadParameter("scoped role assignment %q with spec.bot_scope set must also have spec.bot_name set", assignment.GetMetadata().GetName())
-	}
+	// Assigning to Bot is mutually exclusive with assigning to User.
+	botSet := assignment.GetSpec().GetBot() != ""
+	var botScope string
 	if botSet {
-		if err := scopes.StrongValidate(botScope); err != nil {
-			return trace.BadParameter("scoped role assignment %q has invalid spec.bot_scope: %v", assignment.GetMetadata().GetName(), err)
+		if assignment.GetSpec().GetUser() != "" {
+			return trace.BadParameter("scoped role assignment %q cannot have both spec.bot and spec.user set", assignment.GetMetadata().GetName())
 		}
+		bot, err := scopes.ParseQualifiedName(assignment.GetSpec().GetBot())
+		if err != nil {
+			return trace.BadParameter("scoped role assignment %q has invalid spec.bot: %v", assignment.GetMetadata().GetName(), err)
+		}
+		if err := bot.StrongValidate(); err != nil {
+			return trace.BadParameter("scoped role assignment %q has invalid spec.bot: %v", assignment.GetMetadata().GetName(), err)
+		}
+		botScope = bot.Scope
 	}
 
 	for i, subAssignment := range assignment.GetSpec().GetAssignments() {
@@ -531,7 +529,7 @@ func StrongValidateAssignment(assignment *scopedaccessv1.ScopedRoleAssignment) e
 					assignment.GetMetadata().GetName(),
 					i,
 					subAssignment.GetScope(),
-					assignment.GetSpec().GetBotScope(),
+					botScope,
 				)
 			}
 		}
@@ -565,8 +563,8 @@ func commonValidateAssignment(assignment *scopedaccessv1.ScopedRoleAssignment) e
 		return trace.BadParameter("scoped role assignment %q is missing scope", assignment.GetMetadata().GetName())
 	}
 
-	if assignment.GetSpec().GetUser() == "" && assignment.GetSpec().GetBotName() == "" {
-		return trace.BadParameter("scoped role assignment %q is missing spec.user or spec.bot_name", assignment.GetMetadata().GetName())
+	if assignment.GetSpec().GetUser() == "" && assignment.GetSpec().GetBot() == "" {
+		return trace.BadParameter("scoped role assignment %q is missing spec.user or spec.bot", assignment.GetMetadata().GetName())
 	}
 
 	return nil

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -1047,8 +1047,7 @@ func TestValidateAsssignment(t *testing.T) {
 				},
 				Scope: "/",
 				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
-					BotName:  "mybot",
-					BotScope: "/foo/bar",
+					Bot: "/foo/bar::mybot",
 					Assignments: []*scopedaccessv1.Assignment{
 						{
 							Role:  "test",
@@ -1062,98 +1061,95 @@ func TestValidateAsssignment(t *testing.T) {
 			weakOk:   true,
 		},
 		{
-			name: "bot_name and user both set",
-			assignment: &scopedaccessv1.ScopedRoleAssignment{
+			name: "bot and user both set",
+			assignment: scopedaccessv1.ScopedRoleAssignment_builder{
 				Kind:    KindScopedRoleAssignment,
 				SubKind: SubKindDynamic,
 				Metadata: &headerv1.Metadata{
 					Name: uuid.New().String(),
 				},
 				Scope: "/",
-				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
-					User:     "alice",
-					BotName:  "mybot",
-					BotScope: "/foo/bar",
+				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+					User: "alice",
+					Bot:  "/foo/bar::mybot",
 					Assignments: []*scopedaccessv1.Assignment{
 						{
 							Role:  "test",
 							Scope: "/foo",
 						},
 					},
-				},
+				}.Build(),
 				Version: types.V1,
-			},
+			}.Build(),
 			strongOk: false,
 			weakOk:   true,
 		},
 		{
-			name: "bot_name without bot_scope",
-			assignment: &scopedaccessv1.ScopedRoleAssignment{
+			name: "bot missing scope qualification",
+			assignment: scopedaccessv1.ScopedRoleAssignment_builder{
 				Kind:    KindScopedRoleAssignment,
 				SubKind: SubKindDynamic,
 				Metadata: &headerv1.Metadata{
 					Name: uuid.New().String(),
 				},
 				Scope: "/",
-				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
-					BotName: "mybot",
+				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+					Bot: "mybot",
 					Assignments: []*scopedaccessv1.Assignment{
 						{
 							Role:  "test",
 							Scope: "/foo",
 						},
 					},
-				},
+				}.Build(),
 				Version: types.V1,
-			},
+			}.Build(),
 			strongOk: false,
 			weakOk:   true,
 		},
 		{
-			name: "bot_scope without bot_name",
-			assignment: &scopedaccessv1.ScopedRoleAssignment{
+			name: "bot with empty name component",
+			assignment: scopedaccessv1.ScopedRoleAssignment_builder{
 				Kind:    KindScopedRoleAssignment,
 				SubKind: SubKindDynamic,
 				Metadata: &headerv1.Metadata{
 					Name: uuid.New().String(),
 				},
 				Scope: "/",
-				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
-					User:     "alice",
-					BotScope: "/foo/bar",
+				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+					Bot: "/foo/bar::",
 					Assignments: []*scopedaccessv1.Assignment{
 						{
 							Role:  "test",
 							Scope: "/foo",
 						},
 					},
-				},
+				}.Build(),
 				Version: types.V1,
-			},
+			}.Build(),
 			strongOk: false,
 			weakOk:   true,
 		},
 		{
-			name: "invalid bot_scope",
-			assignment: &scopedaccessv1.ScopedRoleAssignment{
+			name: "invalid bot scope",
+			assignment: scopedaccessv1.ScopedRoleAssignment_builder{
 				Kind:    KindScopedRoleAssignment,
 				SubKind: SubKindDynamic,
 				Metadata: &headerv1.Metadata{
 					Name: uuid.New().String(),
 				},
 				Scope: "/",
-				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
-					BotName:  "mybot",
-					BotScope: "not-a-scope",
+				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+					Bot: "not-a-scope::mybot",
 					Assignments: []*scopedaccessv1.Assignment{
 						{
 							Role:  "test",
 							Scope: "/foo",
 						},
 					},
-				},
+				}.Build(),
 				Version: types.V1,
-			},
+			}.Build(),
 			strongOk: false,
 			weakOk:   true,
 		},
@@ -1166,9 +1162,8 @@ func TestValidateAsssignment(t *testing.T) {
 					Name: uuid.New().String(),
 				},
 				Scope: "/",
-				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
-					BotName:  "mybot",
-					BotScope: "/foo/bar",
+				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+					Bot: "/foo/bar::mybot",
 					Assignments: []*scopedaccessv1.Assignment{
 						// Valid
 						{
@@ -1181,7 +1176,7 @@ func TestValidateAsssignment(t *testing.T) {
 							Scope: "/foo/baz",
 						},
 					},
-				},
+				}.Build(),
 				Version: types.V1,
 			},
 			strongOk: false,

--- a/lib/scopes/cache/assignments/pinning.go
+++ b/lib/scopes/cache/assignments/pinning.go
@@ -199,12 +199,11 @@ func (c *AssignmentCache) PopulatePinnedAssignmentsForBot(
 	var lastErr error
 
 	// all non-orthogonal assignments for this bot *may* assign roles relevant to this pin
-	assignments := c.cache.AllNonOrthogonalResources(pin.Scope, c.cache.WithFilter(func(assignment *scopedaccessv1.ScopedRoleAssignment) bool {
-		matchesBotName := assignment.GetSpec().GetBotName() == botName
-		// ignore assignments where actual bot scope mismatches bot scope
-		// specified in SRA. this mitigates name reuse attacks across scopes.
-		matchesBotScope := assignment.GetSpec().GetBotScope() == botScope
-		return matchesBotName && matchesBotScope
+	wantBot := scopes.QualifiedName{Scope: botScope, Name: botName}.String()
+	assignments := c.cache.AllNonOrthogonalResources(pin.GetScope(), c.cache.WithFilter(func(assignment *scopedaccessv1.ScopedRoleAssignment) bool {
+		// match on the full scope-qualified name. comparing the scope component
+		// as well as the name mitigates name reuse attacks across scopes.
+		return assignment.GetSpec().GetBot() == wantBot
 	}))
 
 	// iterate over all potentially relevant assignments and populate the assignment tree

--- a/lib/scopes/cache/assignments/pinning_test.go
+++ b/lib/scopes/cache/assignments/pinning_test.go
@@ -31,6 +31,7 @@ import (
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/pinning"
 )
@@ -389,16 +390,15 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 				Name: "bernard-01",
 			},
 			Scope: bernardScope,
-			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
-				BotName:  "bernard",
-				BotScope: bernardScope,
+			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+				Bot: scopes.QualifiedName{Scope: bernardScope, Name: "bernard"}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					{
 						Role:  "role-01",
 						Scope: bernardScope,
 					},
 				},
-			},
+			}.Build(),
 			Version: types.V1,
 		},
 		// Assignment to child-scope of main scope
@@ -409,16 +409,15 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 				Name: "bernard-02",
 			},
 			Scope: bernardScope,
-			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
-				BotName:  "bernard",
-				BotScope: bernardScope,
+			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+				Bot: scopes.QualifiedName{Scope: bernardScope, Name: "bernard"}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					{
 						Role:  "role-02",
 						Scope: bernardScope + "/child",
 					},
 				},
-			},
+			}.Build(),
 			Version: types.V1,
 		},
 		// SRA in parent scope, assigning to bot scope.
@@ -429,16 +428,15 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 				Name: "bernard-03",
 			},
 			Scope: "/",
-			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
-				BotName:  "bernard",
-				BotScope: bernardScope,
+			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+				Bot: scopes.QualifiedName{Scope: bernardScope, Name: "bernard"}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					{
 						Role:  "role-03",
 						Scope: bernardScope,
 					},
 				},
-			},
+			}.Build(),
 			Version: types.V1,
 		},
 		// SRA in parent scope, assigning to bot's child scope
@@ -449,38 +447,36 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 				Name: "bernard-04",
 			},
 			Scope: "/",
-			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
-				BotName:  "bernard",
-				BotScope: bernardScope,
+			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+				Bot: scopes.QualifiedName{Scope: bernardScope, Name: "bernard"}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					{
 						Role:  "role-04",
 						Scope: bernardScope + "/child",
 					},
 				},
-			},
+			}.Build(),
 			Version: types.V1,
 		},
-		// `bot_scope` mismatches bot's actual scope - this should be ignored.
-		{
+		// Scope component of `bot` mismatches bot's actual scope - this should be ignored.
+		scopedaccessv1.ScopedRoleAssignment_builder{
 			Kind:    scopedaccess.KindScopedRoleAssignment,
 			SubKind: scopedaccess.SubKindDynamic,
 			Metadata: &headerpb.Metadata{
 				Name: "bernard-invalid-01",
 			},
 			Scope: bernardScope,
-			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
-				BotName:  "bernard",
-				BotScope: "/mismatched",
+			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+				Bot: scopes.QualifiedName{Scope: "/mismatched", Name: "bernard"}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					{
 						Role:  "bernard-invalid-01",
 						Scope: bernardScope,
 					},
 				},
-			},
+			}.Build(),
 			Version: types.V1,
-		},
+		}.Build(),
 		// SRA above bot scope ignored.
 		// nb: we may eventually loosen this to behave more like users.
 		{
@@ -490,16 +486,15 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 				Name: "bernard-invalid-02",
 			},
 			Scope: "/",
-			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
-				BotName:  "bernard",
-				BotScope: bernardScope,
+			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+				Bot: scopes.QualifiedName{Scope: bernardScope, Name: "bernard"}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					{
 						Role:  "bernard-invalid-02",
 						Scope: "/",
 					},
 				},
-			},
+			}.Build(),
 			Version: types.V1,
 		},
 	}

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -1525,8 +1525,7 @@ func TestScopedBotSSH(t *testing.T) {
 			},
 			Scope: scopeName,
 			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
-				BotName:  botName,
-				BotScope: scopeName,
+				Bot: scopes.QualifiedName{Scope: scopeName, Name: botName}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					{Role: scopedRoleName, Scope: scopeName},
 				},


### PR DESCRIPTION
Backport #67728

Breaking change - Scoped Role Assignments created prior to this change targetting Bots will become invalid.

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

- [x] E2E Smoke test: Create Scoped Bot, SR, SRA, ST, join and access scoped SSH resource.
