### PR TITLE
helm(teleport-kube-agent): add storage.emptyDirSizeLimit value

### DIFF
--- a/examples/chart/teleport-kube-agent/.lint/storage-emptydirsizelimit.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/storage-emptydirsizelimit.yaml
@@ -1,0 +1,5 @@
+authToken: auth-token
+proxyAddr: proxy.example.com:3080
+kubeClusterName: test-kube-cluster-name
+storage:
+  emptyDirSizeLimit: "512Mi"

--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -300,7 +300,12 @@ spec:
       {{- end }}
 {{- if not .Values.storage.enabled }}
       - name: "data"
+        {{- if .Values.storage.emptyDirSizeLimit }}
+        emptyDir:
+          sizeLimit: {{ .Values.storage.emptyDirSizeLimit }}
+        {{- else }}
         emptyDir: {}
+        {{- end }}
 {{- end}}
 {{- if .Values.tls.existingCASecretName }}
       - name: "teleport-tls-ca"

--- a/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
@@ -1096,3 +1096,28 @@ tests:
           content:
             name: "GOMEMLIMIT"
           any: true
+
+  - it: should set sizeLimit on emptyDir when storage.emptyDirSizeLimit is set
+    template: statefulset.yaml
+    values:
+      - ../.lint/storage-emptydirsizelimit.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: "data"
+            emptyDir:
+              sizeLimit: 512Mi
+      - matchSnapshot:
+          path: spec.template.spec.volumes
+
+  - it: should not set sizeLimit on emptyDir when storage.emptyDirSizeLimit is not set
+    template: statefulset.yaml
+    values:
+      - ../.lint/join-params-iam.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: "data"
+            emptyDir: {}

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -804,6 +804,32 @@
             "$id": "#/properties/jamfSecret",
             "type": "string",
             "default": ""
+        },
+        "storage": {
+            "$id": "#/properties/storage",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "$id": "#/properties/storage/properties/enabled",
+                    "type": "boolean",
+                    "default": false
+                },
+                "storageClassName": {
+                    "$id": "#/properties/storage/properties/storageClassName",
+                    "type": "string",
+                    "default": ""
+                },
+                "requests": {
+                    "$id": "#/properties/storage/properties/requests",
+                    "type": "string",
+                    "default": "128Mi"
+                },
+                "emptyDirSizeLimit": {
+                    "$id": "#/properties/storage/properties/emptyDirSizeLimit",
+                    "type": "string",
+                    "default": ""
+                }
+            }
         }
     }
 }

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -894,6 +894,12 @@ storage:
   # storage.requests(string) -- is the size of the persistent volume to create.
   requests: 128Mi
 
+  # storage.emptyDirSizeLimit(string) -- sets a sizeLimit on the emptyDir volume used when
+  # storage.enabled is false. Useful when admission policies (e.g. OPA/Kyverno/CEL) require
+  # all emptyDir volumes to have an explicit size limit. Leave empty for no limit (default).
+  # Example: "512Mi"
+  emptyDirSizeLimit: ""
+
 # adminClusterRoleBinding -- optionally creates a cluster admin role binding.
 # This is useful for granting cluster admin permissions to a Kubernetes Group
 # other than the default `system:masters` group.


### PR DESCRIPTION
Changelog: helm/teleport-kube-agent: add \`storage.emptyDirSizeLimit\` value to allow setting an explicit size limit on the emptyDir data volume.

## Context

Admission controllers (OPA Gatekeeper, Kyverno, CEL) often enforce a policy requiring all \`emptyDir\` volumes to declare a \`sizeLimit\`. Currently, the \`data\` emptyDir rendered by this chart when \`storage.enabled: false\` has no size limit, forcing operators to maintain a policy exemption for the Teleport agent.

## Manual Test Plan

### Test Environment
- Helm 3.x
- \`helm unittest\` (quintush fork)

### Test Cases
- [ ] \`storage.emptyDirSizeLimit\` not set: renders \`emptyDir: {}\` (no change from existing behaviour)
- [ ] \`storage.emptyDirSizeLimit: "512Mi"\`: renders \`emptyDir: { sizeLimit: 512Mi }\`
- [ ] \`storage.enabled: true\`: emptyDir volume is not rendered at all (existing behaviour unchanged)
- [ ] \`helm lint\` passes with new lint file \`.lint/storage-emptydirsizelimit.yaml\`
- [ ] Unit tests pass (\`make lint-helm test-helm\`)

Note: snapshot for the new \`sizeLimit\` test case will be generated on first run of \`make test-helm-update-snapshots\`.