### PR TITLE
Add an ARM Network Client to the Discovery Service

### DIFF
--- a/lib/cloud/azure/client/client.go
+++ b/lib/cloud/azure/client/client.go
@@ -1,0 +1,213 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/cloud/azure"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+const (
+	// maxRetriesAfterRateLimitErrors indicates the maximum number of times to retry a request when the Azure API returns a 429 Too Many Requests response.
+	// The Retry-After header indicates how long to wait before retrying the request.
+	// If the API returns a 429 response 10 times in a row, we stop retrying and return an error to avoid infinite loops in case of persistent rate limiting.
+	maxRetriesAfterRateLimitErrors = 10
+)
+
+// ClientOption configures a Client during construction.
+type ClientOption func(*Client)
+
+// WithHTTPClient sets the HTTP client used for Azure API requests.
+// If httpClient is nil, NewClient uses http.DefaultClient.
+func WithHTTPClient(httpClient utils.HTTPDoClient) ClientOption {
+	return func(c *Client) {
+		c.httpClient = httpClient
+	}
+}
+
+// WithLogger sets the logger used for Azure API requests.
+// If logger is nil, NewClient uses slog.Default().
+func WithLogger(logger *slog.Logger) ClientOption {
+	return func(c *Client) {
+		c.logger = logger
+	}
+}
+
+// WithRetryOnRateLimitErrors configures the client to retry requests when rate limit errors are encountered.
+func WithRetryOnRateLimitErrors() ClientOption {
+	return func(c *Client) {
+		c.retryOnRateLimitErrors = true
+	}
+}
+
+// WithClock sets the clock used to wait between retries.
+// If clock is nil, NewClient uses a real clock.
+func WithClock(clock clockwork.Clock) ClientOption {
+	return func(c *Client) {
+		c.clock = clock
+	}
+}
+
+// NewClient creates a Client for making authenticated requests to the Azure Resource Manager API.
+//
+// tokenProvider must be non-nil and concurrent-safe. It is used to acquire access tokens for authenticating requests to the Azure Resource Manager API.
+func NewClient(tokenProvider azcore.TokenCredential, opts ...ClientOption) (*Client, error) {
+	if tokenProvider == nil {
+		return nil, trace.BadParameter("tokenProvider is required")
+	}
+
+	client := &Client{
+		tokenProvider: tokenProvider,
+	}
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	if client.httpClient == nil {
+		client.httpClient = http.DefaultClient
+	}
+
+	if client.logger == nil {
+		client.logger = slog.Default()
+	}
+
+	if client.clock == nil {
+		client.clock = clockwork.NewRealClock()
+	}
+
+	return client, nil
+}
+
+// Client is a client for making authenticated requests to the Azure Resource Manager API.
+// It is safe for concurrent use by multiple goroutines.
+type Client struct {
+	tokenProvider          azcore.TokenCredential
+	httpClient             utils.HTTPDoClient
+	logger                 *slog.Logger
+	retryOnRateLimitErrors bool
+	clock                  clockwork.Clock
+}
+
+// DoRequest executes the given HTTP request against the Azure Resource Manager
+// API and decodes the JSON response body into a value of type T. If the client
+// is configured with WithRetryOnRateLimitErrors, DoRequest retries the request
+// when the API responds with a rate limit error. DoRequest expects a JSON
+// response body and will error if it doesn't receive one.
+func DoRequest[T any](ctx context.Context, client *Client, request *http.Request) (T, error) {
+	var parsedResponse T
+	var currentRetry int
+	for {
+		// Clone the request because doSingleRequest will read and close the body
+		// and we may need to retry the request if we hit a retryable error.
+		attempt := request.Clone(ctx)
+		if request.GetBody != nil {
+			body, err := request.GetBody()
+			if err != nil {
+				return parsedResponse, trace.Wrap(err, "failed to clone request body")
+			}
+			attempt.Body = body
+		}
+
+		responseBodyBS, err := doSingleRequest(ctx, client, attempt)
+		if err != nil {
+			if rateLimitErr, isRateLimitErr := errors.AsType[*azure.RateLimitError](err); isRateLimitErr && client.retryOnRateLimitErrors {
+				if currentRetry < maxRetriesAfterRateLimitErrors {
+					if err := logAndWaitRetryAfter(ctx, client.clock, client.logger, rateLimitErr); err != nil {
+						return parsedResponse, trace.Wrap(err)
+					}
+					currentRetry++
+					continue
+				}
+				return parsedResponse, trace.NewAggregate(err, trace.BadParameter("exceeded maximum retries (%d) after rate limit errors", maxRetriesAfterRateLimitErrors))
+			}
+
+			return parsedResponse, trace.Wrap(err, "failed to fetch azure api response")
+		}
+
+		if err := json.Unmarshal(responseBodyBS, &parsedResponse); err != nil {
+			// A failed Unmarshal may have partially populated parsedResponse,
+			// so return an explicit zero value alongside the error.
+			var zeroValue T
+			return zeroValue, trace.Wrap(err, "failed to unmarshal azure api response: %s", string(responseBodyBS))
+		}
+		break
+	}
+
+	return parsedResponse, nil
+}
+
+func doSingleRequest(ctx context.Context, client *Client, request *http.Request) ([]byte, error) {
+	const azureManagementScope = "https://management.azure.com/.default"
+
+	token, err := client.tokenProvider.GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: []string{azureManagementScope},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to get token")
+	}
+
+	request.Header.Set("Authorization", "Bearer "+token.Token)
+	request.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.httpClient.Do(request)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to execute azure api request")
+	}
+	defer resp.Body.Close()
+
+	responseBodyBS, err := utils.ReadAtMost(resp.Body, teleport.MaxHTTPResponseSize)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to read response body (status code: %d)", resp.StatusCode)
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		// Rebuild resp.Body after it has been drained by utils.ReadAtMost so
+		// ErrorFromResponse can read it and generate a detailed error message.
+		resp.Body = io.NopCloser(bytes.NewReader(responseBodyBS))
+		return nil, azure.ErrorFromResponse(resp)
+	}
+
+	return responseBodyBS, nil
+}
+
+func logAndWaitRetryAfter(ctx context.Context, clock clockwork.Clock, logger *slog.Logger, err *azure.RateLimitError) error {
+	// Clamp err.RetryAfter to be a min of 0 seconds and a max of 5 minutes.
+	retryAfter := max(0, min(err.RetryAfter, 5*time.Minute))
+
+	logger.DebugContext(ctx, "Received rate limit error, retrying after delay", "error", err.Err, "retry_after", retryAfter, "original_retry_after", err.RetryAfter)
+
+	select {
+	case <-ctx.Done():
+		return trace.NewAggregate(ctx.Err(), trace.BadParameter("canceled while waiting to retry after rate limit error"))
+	case <-clock.After(retryAfter):
+		return nil
+	}
+}

--- a/lib/cloud/azure/client/client_test.go
+++ b/lib/cloud/azure/client/client_test.go
@@ -1,0 +1,488 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package client
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/cloud/azure"
+)
+
+// testPayload is the type DoRequest decodes JSON responses into.
+type testPayload struct {
+	Value string `json:"value"`
+}
+
+// fakeTokenCredential is an azcore.TokenCredential that returns a static token
+// or an error and records how many times it was invoked.
+type fakeTokenCredential struct {
+	token string
+	err   error
+	calls atomic.Int32
+}
+
+func (f *fakeTokenCredential) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	f.calls.Add(1)
+	if f.err != nil {
+		return azcore.AccessToken{}, f.err
+	}
+	return azcore.AccessToken{Token: f.token}, nil
+}
+
+// recordedRequest captures the parts of an outgoing request the tests assert on.
+type recordedRequest struct {
+	method        string
+	url           string
+	authorization string
+	contentType   string
+	body          string
+}
+
+// fakeHTTPClient is a utils.HTTPDoClient that returns responses based on the
+// callers provided respond function. It also records the requests it receives.
+type fakeHTTPClient struct {
+	respond func(attempt int, req *http.Request) (*http.Response, error)
+
+	mu       sync.Mutex
+	requests []recordedRequest
+}
+
+func (f *fakeHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	f.mu.Lock()
+	rec := recordedRequest{
+		method:        req.Method,
+		url:           req.URL.String(),
+		authorization: req.Header.Get("Authorization"),
+		contentType:   req.Header.Get("Content-Type"),
+	}
+	if req.Body != nil {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			f.mu.Unlock()
+			return nil, err
+		}
+		rec.body = string(body)
+	}
+	attempt := len(f.requests)
+	f.requests = append(f.requests, rec)
+	f.mu.Unlock()
+
+	return f.respond(attempt, req)
+}
+
+func (f *fakeHTTPClient) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.requests)
+}
+
+func (f *fakeHTTPClient) recorded() []recordedRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]recordedRequest(nil), f.requests...)
+}
+
+// newResponse builds an *http.Response with the given status, body and headers.
+func newResponse(status int, body string, header http.Header) *http.Response {
+	if header == nil {
+		header = make(http.Header)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     header,
+	}
+}
+
+// rateLimitResponse builds a 429 Too Many Requests response. When
+// retryAfterSeconds is positive, it sets the Retry-After header so the client
+// waits that long before retrying.
+func rateLimitResponse(retryAfterSeconds int) *http.Response {
+	header := make(http.Header)
+	if retryAfterSeconds > 0 {
+		header.Set("Retry-After", strconv.Itoa(retryAfterSeconds))
+	}
+	return newResponse(http.StatusTooManyRequests, `{"error":{"code":"TooManyRequests","message":"slow down"}}`, header)
+}
+
+// newRequest builds a request against the Azure management API. When body is
+// set the request is created with a rewindable body so DoRequest can
+// re-send it on retries. The request's own context is unimportant: DoRequest
+// re-binds the request to its own context argument via request.Clone.
+func newRequest(t *testing.T, body string) *http.Request {
+	t.Helper()
+	var reader io.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		"https://management.azure.com/subscriptions?api-version=2026-01-01", reader)
+	require.NoError(t, err)
+	return req
+}
+
+func TestNewClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil token provider is rejected", func(t *testing.T) {
+		t.Parallel()
+		c, err := NewClient(nil)
+		require.Error(t, err)
+		require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %T: %v", err, err)
+		require.Nil(t, c)
+	})
+
+	t.Run("applies defaults", func(t *testing.T) {
+		t.Parallel()
+		creds := &fakeTokenCredential{}
+		c, err := NewClient(creds)
+		require.NoError(t, err)
+		require.Same(t, creds, c.tokenProvider)
+		require.Same(t, http.DefaultClient, c.httpClient)
+		require.NotNil(t, c.logger)
+		require.NotNil(t, c.clock)
+		require.False(t, c.retryOnRateLimitErrors)
+	})
+
+	t.Run("applies options", func(t *testing.T) {
+		t.Parallel()
+		httpClient := &fakeHTTPClient{}
+		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		clock := clockwork.NewFakeClock()
+
+		c, err := NewClient(&fakeTokenCredential{},
+			WithHTTPClient(httpClient),
+			WithLogger(logger),
+			WithClock(clock),
+			WithRetryOnRateLimitErrors(),
+		)
+		require.NoError(t, err)
+		require.Same(t, httpClient, c.httpClient)
+		require.Same(t, logger, c.logger)
+		require.Same(t, clock, c.clock)
+		require.True(t, c.retryOnRateLimitErrors)
+	})
+}
+
+func TestDoRequest_Success(t *testing.T) {
+	t.Parallel()
+
+	httpClient := &fakeHTTPClient{
+		respond: func(int, *http.Request) (*http.Response, error) {
+			return newResponse(http.StatusOK, `{"value":"hello"}`, nil), nil
+		},
+	}
+	creds := &fakeTokenCredential{token: "abc123"}
+	c, err := NewClient(creds, WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	got, err := DoRequest[testPayload](t.Context(), c, newRequest(t, `{"req":true}`))
+	require.NoError(t, err)
+	require.Equal(t, testPayload{Value: "hello"}, got)
+
+	require.Equal(t, 1, httpClient.callCount())
+	require.EqualValues(t, 1, creds.calls.Load())
+
+	reqs := httpClient.recorded()
+	require.Len(t, reqs, 1)
+	require.Equal(t, "Bearer abc123", reqs[0].authorization, "Authorization header must carry the token")
+	require.Equal(t, "application/json", reqs[0].contentType)
+	require.Equal(t, `{"req":true}`, reqs[0].body, "request body must be forwarded")
+}
+
+func TestDoRequest_TokenError(t *testing.T) {
+	t.Parallel()
+
+	httpClient := &fakeHTTPClient{
+		respond: func(int, *http.Request) (*http.Response, error) {
+			t.Error("HTTP client must not be called when token acquisition fails")
+			return nil, errors.New("unexpected call")
+		},
+	}
+	c, err := NewClient(&fakeTokenCredential{err: errors.New("error")}, WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	_, err = DoRequest[testPayload](t.Context(), c, newRequest(t, ""))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to get token")
+	require.Zero(t, httpClient.callCount())
+}
+
+func TestDoRequest_HTTPClientError(t *testing.T) {
+	t.Parallel()
+
+	httpClient := &fakeHTTPClient{
+		respond: func(int, *http.Request) (*http.Response, error) {
+			return nil, errors.New("connection refused")
+		},
+	}
+	c, err := NewClient(&fakeTokenCredential{token: "token"}, WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	_, err = DoRequest[testPayload](t.Context(), c, newRequest(t, ""))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to execute azure api request")
+	require.ErrorContains(t, err, "connection refused")
+}
+
+func TestDoRequest_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	httpClient := &fakeHTTPClient{
+		respond: func(int, *http.Request) (*http.Response, error) {
+			return newResponse(http.StatusOK, `invalid json`, nil), nil
+		},
+	}
+	c, err := NewClient(&fakeTokenCredential{token: "token"}, WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	got, err := DoRequest[testPayload](t.Context(), c, newRequest(t, ""))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to unmarshal azure api response")
+	// A failed unmarshal must return an explicit zero value.
+	require.Equal(t, testPayload{}, got)
+}
+
+// TestDoRequest_ErrorStatusMapping verifies that error status codes are run
+// through azure.ErrorFromResponse and surfaced as the corresponding trace
+// error type. Only status-based mappings are exercised here: doSingleRequest
+// drains the response body before conversion, so body-dependent sub-codes are
+// out of scope for this layer.
+func TestDoRequest_ErrorStatusMapping(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		status int
+		isType func(error) bool
+	}{
+		{name: "403 maps to AccessDenied", status: http.StatusForbidden, isType: trace.IsAccessDenied},
+		{name: "404 maps to NotFound", status: http.StatusNotFound, isType: trace.IsNotFound},
+		{name: "409 maps to AlreadyExists", status: http.StatusConflict, isType: trace.IsAlreadyExists},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			httpClient := &fakeHTTPClient{
+				respond: func(int, *http.Request) (*http.Response, error) {
+					return newResponse(tc.status, "", nil), nil
+				},
+			}
+			c, err := NewClient(&fakeTokenCredential{token: "token"}, WithHTTPClient(httpClient))
+			require.NoError(t, err)
+
+			_, err = DoRequest[testPayload](t.Context(), c, newRequest(t, ""))
+			require.Error(t, err)
+			require.ErrorContains(t, err, "failed to fetch azure api response")
+			require.True(t, tc.isType(err), "unexpected error type %T: %v", err, err)
+			require.Equal(t, 1, httpClient.callCount(), "error responses must not be retried by default")
+		})
+	}
+}
+
+func TestDoRequest_RateLimitNotRetriedByDefault(t *testing.T) {
+	t.Parallel()
+
+	httpClient := &fakeHTTPClient{
+		respond: func(int, *http.Request) (*http.Response, error) {
+			return rateLimitResponse(5), nil
+		},
+	}
+
+	c, err := NewClient(&fakeTokenCredential{token: "token"}, WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	_, err = DoRequest[testPayload](t.Context(), c, newRequest(t, ""))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to fetch azure api response")
+
+	var rateLimitErr *azure.RateLimitError
+	require.ErrorAs(t, err, &rateLimitErr)
+	require.True(t, trace.IsLimitExceeded(err), "expected LimitExceeded, got %T: %v", err, err)
+
+	require.Equal(t, 1, httpClient.callCount(), "must not retry when retry-on-rate-limit is disabled")
+}
+
+func TestDoRequest_NonRateLimitErrorNotRetried(t *testing.T) {
+	t.Parallel()
+
+	httpClient := &fakeHTTPClient{
+		respond: func(int, *http.Request) (*http.Response, error) {
+			return newResponse(http.StatusNotFound, "", nil), nil
+		},
+	}
+
+	c, err := NewClient(&fakeTokenCredential{token: "token"},
+		WithHTTPClient(httpClient),
+		WithClock(clockwork.NewFakeClock()),
+		WithRetryOnRateLimitErrors(),
+	)
+	require.NoError(t, err)
+
+	_, err = DoRequest[testPayload](t.Context(), c, newRequest(t, ""))
+	require.Error(t, err)
+	require.True(t, trace.IsNotFound(err), "expected NotFound, got %T: %v", err, err)
+	require.Equal(t, 1, httpClient.callCount())
+}
+
+func TestDoRequest_RateLimitRetriesThenSucceeds(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	httpClient := &fakeHTTPClient{
+		respond: func(attempt int, _ *http.Request) (*http.Response, error) {
+			if attempt == 0 {
+				return rateLimitResponse(5), nil
+			}
+			return newResponse(http.StatusOK, `{"value":"ok"}`, nil), nil
+		},
+	}
+	c, err := NewClient(&fakeTokenCredential{token: "token"},
+		WithHTTPClient(httpClient),
+		WithClock(clock),
+		WithRetryOnRateLimitErrors(),
+	)
+	require.NoError(t, err)
+
+	type result struct {
+		payload testPayload
+		err     error
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		payload, err := DoRequest[testPayload](t.Context(), c, newRequest(t, `{"n":1}`))
+		resCh <- result{payload, err}
+	}()
+
+	// First attempt hit the rate limit; the client is now blocked waiting to retry.
+	require.NoError(t, clock.BlockUntilContext(t.Context(), 1))
+	require.Equal(t, 1, httpClient.callCount())
+
+	// Advancing past the Retry-After delay releases the retry, which succeeds.
+	clock.Advance(5 * time.Second)
+
+	select {
+	case res := <-resCh:
+		require.NoError(t, res.err)
+		require.Equal(t, testPayload{Value: "ok"}, res.payload)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for DoRequest to return")
+	}
+
+	require.Equal(t, 2, httpClient.callCount())
+	reqs := httpClient.recorded()
+	require.Len(t, reqs, 2)
+	// The body and Authorization header must be re-sent on the retry.
+	for i, req := range reqs {
+		require.Equal(t, `{"n":1}`, req.body, "attempt %d must re-send the request body", i)
+		require.Equal(t, "Bearer token", req.authorization, "attempt %d must re-send the auth header", i)
+	}
+}
+
+func TestDoRequest_RateLimitExceedsMaxRetries(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	httpClient := &fakeHTTPClient{
+		respond: func(int, *http.Request) (*http.Response, error) {
+			return rateLimitResponse(5), nil
+		},
+	}
+	c, err := NewClient(&fakeTokenCredential{token: "token"},
+		WithHTTPClient(httpClient),
+		WithClock(clock),
+		WithRetryOnRateLimitErrors(),
+	)
+	require.NoError(t, err)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := DoRequest[testPayload](t.Context(), c, newRequest(t, ""))
+		errCh <- err
+	}()
+
+	// Make DoRequest retry until we hit maxRetriesAfterRateLimitErrors
+	for range maxRetriesAfterRateLimitErrors {
+		require.NoError(t, clock.BlockUntilContext(t.Context(), 1))
+		clock.Advance(5 * time.Second)
+	}
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		require.ErrorContains(t, err, "exceeded maximum retries")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for DoRequest to give up")
+	}
+
+	require.Equal(t, maxRetriesAfterRateLimitErrors+1, httpClient.callCount(),
+		"expected one initial attempt plus one attempt per retry")
+}
+
+func TestDoRequest_RateLimitContextCanceledDuringWait(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	httpClient := &fakeHTTPClient{
+		respond: func(int, *http.Request) (*http.Response, error) {
+			return rateLimitResponse(0), nil
+		},
+	}
+	c, err := NewClient(&fakeTokenCredential{token: "token"},
+		WithHTTPClient(httpClient),
+		WithClock(clock),
+		WithRetryOnRateLimitErrors(),
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := DoRequest[testPayload](ctx, c, newRequest(t, ""))
+		errCh <- err
+	}()
+
+	// Wait until the client is blocked in the retry delay, then cancel.
+	require.NoError(t, clock.BlockUntilContext(t.Context(), 1))
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		require.ErrorContains(t, err, "canceled while waiting to retry after rate limit error")
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for DoRequest to observe cancellation")
+	}
+
+	require.Equal(t, 1, httpClient.callCount(), "no further attempts after cancellation")
+}

--- a/lib/cloud/azure/client/client_test.go
+++ b/lib/cloud/azure/client/client_test.go
@@ -177,7 +177,7 @@ func TestNewClient(t *testing.T) {
 	t.Run("applies options", func(t *testing.T) {
 		t.Parallel()
 		httpClient := &fakeHTTPClient{}
-		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		logger := slog.New(slog.DiscardHandler)
 		clock := clockwork.NewFakeClock()
 
 		c, err := NewClient(&fakeTokenCredential{},
@@ -454,7 +454,7 @@ func TestDoRequest_RateLimitContextCanceledDuringWait(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	httpClient := &fakeHTTPClient{
 		respond: func(int, *http.Request) (*http.Response, error) {
-			return rateLimitResponse(0), nil
+			return rateLimitResponse(5), nil
 		},
 	}
 	c, err := NewClient(&fakeTokenCredential{token: "token"},

--- a/lib/cloud/azure/errors.go
+++ b/lib/cloud/azure/errors.go
@@ -22,9 +22,12 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/gravitational/trace"
 )
@@ -58,9 +61,14 @@ func ConvertResponseError(err error) error {
 		case http.StatusNotFound:
 			return trace.NotFound("%s", responseErr)
 		case http.StatusTooManyRequests:
-			// TODO(marco): Extract the Retry-After header or any other indication of when we can retry the request.
-			return trace.LimitExceeded("%s", responseErr)
-
+			var header http.Header
+			if responseErr.RawResponse != nil {
+				header = responseErr.RawResponse.Header
+			}
+			return wrapWithRetryAfterHeader(
+				header,
+				trace.LimitExceeded("%s", responseErr),
+			)
 		case http.StatusBadRequest:
 			// Azure API return BadRequest in multiple scenarios, so we need to inspect the error details to ensure we return the most accurate error type.
 			if errorDetails := apiResponseErr.errorDetails(); errorDetails != nil {
@@ -80,7 +88,7 @@ func ConvertResponseError(err error) error {
 }
 
 func apiErrorFromResponse(responseErr *azcore.ResponseError) *apiResponseError {
-	if responseErr == nil || responseErr.RawResponse == nil {
+	if responseErr == nil || responseErr.RawResponse == nil || responseErr.RawResponse.Body == nil {
 		return nil
 	}
 	body := responseErr.RawResponse.Body
@@ -196,4 +204,69 @@ func (e *VMAgentNotAvailableError) Is(target error) bool {
 // Error returns a message indicating that the virtual machine's agent is not available.
 func (e *VMAgentNotAvailableError) Error() string {
 	return "VM agent is not available"
+}
+
+// ErrorFromResponse converts an HTTP response into an error.
+func ErrorFromResponse(response *http.Response) error {
+	return ConvertResponseError(runtime.NewResponseError(response))
+}
+
+// RateLimitError is returned by Azure API when the server signals a rate or concurrency limit.
+// It wraps a [trace.LimitExceededError] and carries the retry-after duration extracted from the API response.
+type RateLimitError struct {
+	// RetryAfter is the value of the "retry-after" header, or 0 if the header was absent.
+	RetryAfter time.Duration
+	// Err is the underlying LimitExceeded trace error.
+	Err error
+}
+
+// Error returns the underlying error message.
+func (e *RateLimitError) Error() string {
+	return e.Err.Error()
+}
+
+// Unwrap returns the underlying error, allowing errors.Is and errors.As to work with RateLimitError.
+func (e *RateLimitError) Unwrap() error {
+	return e.Err
+}
+
+// wrapWithRetryAfterHeader wraps apiErr in a [*RateLimitError], setting its
+// retry-after value from the supplied header. Callers are responsible for only
+// invoking it with a limit-exceeded error.
+func wrapWithRetryAfterHeader(header http.Header, apiErr error) error {
+	return &RateLimitError{
+		Err:        apiErr,
+		RetryAfter: extractRetryAfterDuration(header),
+	}
+}
+
+// extractRetryAfterDuration extracts the retry-after duration as documented by Azure.
+// When it is not present or cannot be parsed, it returns 0.
+func extractRetryAfterDuration(header http.Header) time.Duration {
+	const (
+		retryAfterHeader              = "Retry-After"
+		xMsUserQuotaResetsAfterHeader = "X-Ms-User-Quota-Resets-After"
+	)
+	// See https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/request-limits-and-throttling#error-code
+	// > When you reach the limit, you receive the HTTP status code 429 Too many requests.
+	// > The response includes a Retry-After value, which specifies the number of seconds your application should wait before sending the next request.
+	retryAfterSeconds, err := strconv.Atoi(header.Get(retryAfterHeader))
+	if err == nil {
+		return time.Duration(retryAfterSeconds) * time.Second
+	}
+
+	// Specifically for Azure Resource Graph, the API can also return the "X-Ms-User-Quota-Resets-After" header.
+	// See https://learn.microsoft.com/en-us/azure/governance/resource-graph/concepts/guidance-for-throttled-requests#understand-throttling-headers
+	// This comes in the following format: X-Ms-User-Quota-Resets-After: 00:00:05
+	timeParts := strings.Split(header.Get(xMsUserQuotaResetsAfterHeader), ":")
+	if len(timeParts) == 3 {
+		hours, err1 := strconv.Atoi(timeParts[0])
+		minutes, err2 := strconv.Atoi(timeParts[1])
+		seconds, err3 := strconv.Atoi(timeParts[2])
+		if err1 == nil && err2 == nil && err3 == nil {
+			return time.Duration(hours)*time.Hour + time.Duration(minutes)*time.Minute + time.Duration(seconds)*time.Second
+		}
+	}
+
+	return 0
 }

--- a/lib/cloud/azure/errors_test.go
+++ b/lib/cloud/azure/errors_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -291,4 +292,47 @@ func TestVMErrorTypes(t *testing.T) {
 	require.ErrorIs(t, vmAgentNotAvailableErr, inner)
 	require.ErrorIs(t, vmAgentNotAvailableErr, &VMAgentNotAvailableError{})
 	require.NotErrorIs(t, vmAgentNotAvailableErr, &VMNotRunningError{})
+}
+
+func TestExtractRetryAfterDuration(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		headers map[string]string
+		want    time.Duration
+	}{
+		{name: "retry-after seconds", headers: map[string]string{"Retry-After": "5"}, want: 5 * time.Second},
+		{name: "retry-after zero", headers: map[string]string{"Retry-After": "0"}, want: 0},
+		{name: "quota resets after hh:mm:ss", headers: map[string]string{"X-Ms-User-Quota-Resets-After": "00:00:05"}, want: 5 * time.Second},
+		{name: "quota resets with hours", headers: map[string]string{"X-Ms-User-Quota-Resets-After": "01:02:03"}, want: time.Hour + 2*time.Minute + 3*time.Second},
+		{
+			name:    "retry-after takes precedence",
+			headers: map[string]string{"Retry-After": "10", "X-Ms-User-Quota-Resets-After": "00:00:05"},
+			want:    10 * time.Second,
+		},
+		{
+			name:    "falls back to quota header when retry-after is unparseable",
+			headers: map[string]string{"Retry-After": "soon", "X-Ms-User-Quota-Resets-After": "00:00:07"},
+			want:    7 * time.Second,
+		},
+		{name: "no headers", headers: nil, want: 0},
+		{name: "quota wrong number of parts", headers: map[string]string{"X-Ms-User-Quota-Resets-After": "00:05"}, want: 0},
+		{name: "quota non-numeric", headers: map[string]string{"X-Ms-User-Quota-Resets-After": "aa:bb:cc"}, want: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := make(http.Header)
+			for k, v := range tc.headers {
+				h.Set(k, v)
+			}
+			httpResponseWithHeaders := &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     h,
+				Body:       http.NoBody,
+			}
+			convertedErr := ErrorFromResponse(httpResponseWithHeaders)
+			errorAsRateLimitErr := &RateLimitError{}
+			require.Error(t, convertedErr)
+			require.True(t, errors.As(convertedErr, &errorAsRateLimitErr), "converted error must be a RateLimitError")
+			require.Equal(t, tc.want, errorAsRateLimitErr.RetryAfter, "unexpected RetryAfter duration")
+		})
+	}
 }

--- a/lib/cloud/azure/errors_test.go
+++ b/lib/cloud/azure/errors_test.go
@@ -331,7 +331,7 @@ func TestExtractRetryAfterDuration(t *testing.T) {
 			convertedErr := ErrorFromResponse(httpResponseWithHeaders)
 			errorAsRateLimitErr := &RateLimitError{}
 			require.Error(t, convertedErr)
-			require.True(t, errors.As(convertedErr, &errorAsRateLimitErr), "converted error must be a RateLimitError")
+			require.ErrorAs(t, convertedErr, &errorAsRateLimitErr, "converted error must be a RateLimitError")
 			require.Equal(t, tc.want, errorAsRateLimitErr.RetryAfter, "unexpected RetryAfter duration")
 		})
 	}

--- a/lib/cloud/azure/network/network_interfaces.go
+++ b/lib/cloud/azure/network/network_interfaces.go
@@ -163,6 +163,10 @@ func (c *interfacesClient) Get(ctx context.Context, resourceID string) (*Interfa
 // Keys are lower-cased VM resource IDs. Azure is not always consistent about
 // the casing of the resource group segment across the compute and network APIs,
 // so look up with strings.ToLower(vm.ID).
+//
+// If there is an error fetching the standalone/flexible NICs, an error is
+// returned. If there is an error fetching uniform VMSS NICs, a warning is
+// logged and the standalone/flexible NICs are returned.
 func (c *interfacesClient) List(ctx context.Context, subscriptionID, resourceGroup string) (map[string][]*Interface, error) {
 	if subscriptionID == "" {
 		return nil, trace.BadParameter("subscription ID is required to list network interfaces")
@@ -175,20 +179,17 @@ func (c *interfacesClient) List(ctx context.Context, subscriptionID, resourceGro
 
 	// Standalone VMs and flexible VMSS instances.
 	regularNICsByVM, flatErr := c.listStandaloneAndFlexibleNICs(ctx, subscriptionID, resourceGroup)
+	if flatErr != nil {
+		// The flat networkInterfaces list is the only source of standalone-VM
+		// and flexible-VMSS NICs. A failure here means that most IP addresses will
+		// be dropped. So surface the error rather than falling back to the (legacy)
+		// uniform VMSS NICs.
+		return nil, trace.Wrap(flatErr)
+	}
 	// Uniform VMSS instances, whose NICs are absent from the flat list above.
 	uniformNICsByVM, uniformErr := c.listUniformVMSSNICs(ctx, subscriptionID, resourceGroup)
 
 	switch {
-	case flatErr != nil && uniformErr != nil:
-		return nil, trace.NewAggregate(flatErr, uniformErr)
-	case flatErr != nil:
-		c.logger.WarnContext(ctx, "failed to list standalone and flexible VMSS network interfaces, continuing with uniform VMSS NICs",
-			"error", flatErr,
-			"subscription_id", subscriptionID,
-			"resource_group", resourceGroup,
-			"found_nics", len(uniformNICsByVM),
-		)
-		return uniformNICsByVM, nil
 	case uniformErr != nil:
 		c.logger.WarnContext(ctx, "failed to list uniform VMSS network interfaces, continuing with standalone and flexible VMSS NICs",
 			"error", uniformErr,

--- a/lib/cloud/azure/network/network_interfaces.go
+++ b/lib/cloud/azure/network/network_interfaces.go
@@ -25,12 +25,14 @@ package network
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"net/url"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/cloud/azure/client"
 )
 
@@ -50,12 +52,10 @@ type Interface struct {
 	ID string
 	// Name is the resource name of the network interface.
 	Name string
-	// PrivateIPs are the private IP addresses across all of the NIC's IP
-	// configurations, in the order Azure returns them.
-	PrivateIPs []string
-	// PrimaryPrivateIP is the private IP address of the NIC's primary IP
-	// configuration. Empty if no configuration is flagged primary.
-	PrimaryPrivateIP string
+	// PrivateIP is the private IP address of the NIC's primary IP
+	// configuration. If no configuration is flagged primary, it is the first
+	// private IP address found. Empty only when the NIC has no private IPs.
+	PrivateIP string
 }
 
 // InterfacesClient retrieves Azure network interfaces.
@@ -70,12 +70,30 @@ type interfacesClient struct {
 	// client is the generic Azure ARM HTTP query client. It handles AAD auth,
 	// response decoding, error conversion, and rate-limit retries for us.
 	client *client.Client
+	logger *slog.Logger
+}
+
+// Option configures an InterfacesClient during construction.
+type Option func(*interfacesClient)
+
+// WithLogger sets the logger used by the client. Defaults to slog.Default().
+func WithLogger(logger *slog.Logger) Option {
+	return func(c *interfacesClient) {
+		c.logger = logger
+	}
 }
 
 // NewInterfacesClient creates a new Azure network interfaces client backed by
 // the given Azure HTTP query client.
-func NewInterfacesClient(c *client.Client) InterfacesClient {
-	return &interfacesClient{client: c}
+func NewInterfacesClient(c *client.Client, opts ...Option) InterfacesClient {
+	nic := &interfacesClient{
+		client: c,
+		logger: slog.Default().With(teleport.ComponentKey, "azure_network_interfaces_client"),
+	}
+	for _, opt := range opts {
+		opt(nic)
+	}
+	return nic
 }
 
 // Get returns the network interface for the given NIC resource ID.
@@ -98,12 +116,20 @@ func (c *interfacesClient) Get(ctx context.Context, resourceID string) (*Interfa
 	query.Set("api-version", interfaceAPIVersion)
 	req.URL.RawQuery = query.Encode()
 
+	c.logger.DebugContext(ctx, "fetching Azure network interface", "resource_id", resourceID)
+
 	raw, err := client.DoRequest[armNetworkInterface](ctx, c.client, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return interfaceFromARM(resourceID, raw), nil
+	nic := interfaceFromARM(resourceID, raw)
+	c.logger.DebugContext(ctx, "fetched Azure network interface",
+		"resource_id", nic.ID,
+		"name", nic.Name,
+		"private_ip", nic.PrivateIP,
+	)
+	return nic, nil
 }
 
 // armNetworkInterface is the minimal subset of the network interface resource.
@@ -129,6 +155,9 @@ type armIPConfigurationProperties struct {
 	Primary bool `json:"primary,omitempty"`
 }
 
+// interfaceFromARM converts an ARM network interface resource into a simplified
+// Interface. If the IP configuration has a primary IP address, that will be
+// used, otherwise the first IP address found will be used.
 func interfaceFromARM(resourceID string, raw *armNetworkInterface) *Interface {
 	nic := &Interface{ID: resourceID}
 	if raw == nil {
@@ -138,14 +167,25 @@ func interfaceFromARM(resourceID string, raw *armNetworkInterface) *Interface {
 	if raw.Properties == nil {
 		return nic
 	}
+	var firstIP string
 	for _, ipConfig := range raw.Properties.IPConfigurations {
 		if ipConfig.Properties == nil || ipConfig.Properties.PrivateIPAddress == "" {
 			continue
 		}
-		nic.PrivateIPs = append(nic.PrivateIPs, ipConfig.Properties.PrivateIPAddress)
+		ip := ipConfig.Properties.PrivateIPAddress
+		// If we've found the primary IP config, return it
 		if ipConfig.Properties.Primary {
-			nic.PrimaryPrivateIP = ipConfig.Properties.PrivateIPAddress
+			nic.PrivateIP = ip
+			return nic
+		}
+		if firstIP == "" {
+			firstIP = ip
 		}
 	}
+	// None of the configurations were marked as primary, return the first found.
+	// This would be a bug if encountered, but we don't want to fail the request
+	// if it occurs.
+	// See https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/virtual-network-network-interface-addresses?tabs=nic-address-portal#primary
+	nic.PrivateIP = firstIP
 	return nic
 }

--- a/lib/cloud/azure/network/network_interfaces.go
+++ b/lib/cloud/azure/network/network_interfaces.go
@@ -25,14 +25,19 @@ package network
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"net/netip"
 	"net/url"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/azure/client"
 )
 
@@ -46,6 +51,17 @@ const armEndpoint = "https://management.azure.com"
 // See https://learn.microsoft.com/en-us/rest/api/virtualnetwork/network-interfaces/get?view=rest-virtualnetwork-2025-05-01&tabs=HTTP
 const interfaceAPIVersion = "2025-05-01"
 
+// maxListPages bounds the number of pages followed when listing network
+// interfaces, as a backstop against a runaway nextLink loop.
+const maxListPages = 1000
+
+// computeAPIVersion is the Microsoft.Compute API version used to enumerate VM
+// Scale Sets, so uniform-orchestration sets (whose instance NICs are not in the
+// flat networkInterfaces list) can be found and queried separately.
+//
+// See https://learn.microsoft.com/en-us/rest/api/compute/virtual-machine-scale-sets/list-all?view=rest-compute-2026-03-02&tabs=HTTP
+const computeAPIVersion = "2026-03-01"
+
 // Interface represents an Azure network interface.
 type Interface struct {
 	// ID is the resource ID of the network interface.
@@ -54,7 +70,9 @@ type Interface struct {
 	Name string
 	// PrivateIP is the private IP address of the NIC's primary IP
 	// configuration. If no configuration is flagged primary, it is the first
-	// private IP address found. Empty only when the NIC has no private IPs.
+	// full private IP address found; CIDR blocks from secondary IP prefix
+	// configurations are skipped. Empty only when the NIC has no usable
+	// private IP.
 	PrivateIP string
 }
 
@@ -64,6 +82,11 @@ type InterfacesClient interface {
 	// resource ID is the fully-qualified ARM ID, e.g.
 	// /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/networkInterfaces/<name>.
 	Get(ctx context.Context, resourceID string) (*Interface, error)
+	// List returns the network interfaces in the subscription, grouped by the
+	// lower-cased resource ID of the VM each NIC is attached to. Pass the
+	// wildcard "*" as the resource group to list the whole subscription. NICs
+	// that are not attached to a VM are omitted.
+	List(ctx context.Context, subscriptionID, resourceGroup string) (map[string][]*Interface, error)
 }
 
 type interfacesClient struct {
@@ -132,16 +155,277 @@ func (c *interfacesClient) Get(ctx context.Context, resourceID string) (*Interfa
 	return nic, nil
 }
 
+// List returns the network interfaces in the subscription, grouped by the
+// resource ID of the virtual machine each NIC is attached to. NICs that are not
+// attached to a virtual machine are omitted. resourceGroup may be a wildcard.
+//
+// Keys are lower-cased VM resource IDs. Azure is not always consistent about
+// the casing of the resource group segment across the compute and network APIs,
+// so look up with strings.ToLower(vm.ID).
+func (c *interfacesClient) List(ctx context.Context, subscriptionID, resourceGroup string) (map[string][]*Interface, error) {
+	if subscriptionID == "" {
+		return nil, trace.BadParameter("subscription ID is required to list network interfaces")
+	}
+
+	c.logger.DebugContext(ctx, "listing Azure network interfaces",
+		"subscription_id", subscriptionID,
+		"resource_group", resourceGroup,
+	)
+
+	// Standalone VMs and flexible VMSS instances.
+	regularNICsByVM, flatErr := c.listStandaloneAndFlexibleNICs(ctx, subscriptionID, resourceGroup)
+	// Uniform VMSS instances, whose NICs are absent from the flat list above.
+	uniformNICsByVM, uniformErr := c.listUniformVMSSNICs(ctx, subscriptionID, resourceGroup)
+
+	switch {
+	case flatErr != nil && uniformErr != nil:
+		return nil, trace.NewAggregate(flatErr, uniformErr)
+	case flatErr != nil:
+		c.logger.WarnContext(ctx, "failed to list standalone and flexible VMSS network interfaces, continuing with uniform VMSS NICs",
+			"error", flatErr,
+			"subscription_id", subscriptionID,
+			"resource_group", resourceGroup,
+			"found_nics", len(uniformNICsByVM),
+		)
+		return uniformNICsByVM, nil
+	case uniformErr != nil:
+		c.logger.WarnContext(ctx, "failed to list uniform VMSS network interfaces, continuing with standalone and flexible VMSS NICs",
+			"error", uniformErr,
+			"subscription_id", subscriptionID,
+			"resource_group", resourceGroup,
+			"found_nics", len(regularNICsByVM),
+		)
+		return regularNICsByVM, nil
+	default:
+		for vmID, nics := range uniformNICsByVM {
+			regularNICsByVM[vmID] = append(regularNICsByVM[vmID], nics...)
+		}
+
+		c.logger.DebugContext(ctx, "listed Azure network interfaces",
+			"subscription_id", subscriptionID,
+			"resource_group", resourceGroup,
+			"found_nics", len(regularNICsByVM),
+		)
+
+		return regularNICsByVM, nil
+	}
+}
+
+// listStandaloneAndFlexibleNICs lists NICs via the regular networkInterfaces API,
+// which returns NICs for standalone VMs and flexible VMSS instances.
+func (c *interfacesClient) listStandaloneAndFlexibleNICs(ctx context.Context, subscriptionID, resourceGroup string) (map[string][]*Interface, error) {
+	first, err := buildURL(
+		scopePath(subscriptionID, resourceGroup, "/providers/Microsoft.Network/networkInterfaces"),
+		interfaceAPIVersion,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	nicsByVM := make(map[string][]*Interface)
+	if err := c.collectNICsByVM(ctx, first, nicsByVM); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return nicsByVM, nil
+}
+
+// listUniformVMSSNICs lists NICs for uniform VM Scale Set instances. Their NICs
+// are absent from the regular networkInterfaces list.
+//
+// Flexible sets are skipped because their instances' NICs are in the regular
+// list. A failure to list a single scale set's NICs is logged and skipped
+// rather than failing the whole call.
+func (c *interfacesClient) listUniformVMSSNICs(
+	ctx context.Context,
+	subscriptionID,
+	resourceGroup string,
+) (map[string][]*Interface, error) {
+	scaleSets, err := c.listUniformScaleSets(ctx, subscriptionID, resourceGroup)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	nicsByVM := make(map[string][]*Interface)
+	for _, scaleSet := range scaleSets {
+		first, err := buildURL(scaleSet.ID+"/networkInterfaces", computeAPIVersion)
+		if err != nil {
+			c.logger.DebugContext(ctx, "skipping VM Scale Set with an unparseable ID", "scale_set_id", scaleSet.ID, "error", err)
+			continue
+		}
+		if err := c.collectNICsByVM(ctx, first, nicsByVM); err != nil {
+			c.logger.WarnContext(ctx, "failed to list network interfaces for VM Scale Set", "scale_set_id", scaleSet.ID, "error", err)
+			continue
+		}
+	}
+	return nicsByVM, nil
+}
+
+// listUniformScaleSets enumerates VM Scale Sets in the scope and returns only
+// those with uniform orchestration. Flexible sets' instances appear in the flat
+// networkInterfaces list and are handled there.
+func (c *interfacesClient) listUniformScaleSets(
+	ctx context.Context,
+	subscriptionID,
+	resourceGroup string,
+) ([]armScaleSet, error) {
+	first, err := buildURL(
+		scopePath(subscriptionID, resourceGroup, "/providers/Microsoft.Compute/virtualMachineScaleSets"),
+		computeAPIVersion,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var uniform []armScaleSet
+	pages := 0
+	for next := first; next != ""; {
+		if pages >= maxListPages {
+			return nil, trace.LimitExceeded("listing Azure VM Scale Sets exceeded the maximum of %d pages", maxListPages)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, next, nil)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		page, err := client.DoRequest[armScaleSetList](ctx, c.client, req)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		pages++
+
+		for _, scaleSet := range page.Value {
+			if scaleSet.isFlexible() {
+				continue
+			}
+			uniform = append(uniform, scaleSet)
+		}
+		next = page.NextLink
+	}
+	return uniform, nil
+}
+
+// collectNICsByVM pages through a network-interfaces list beginning at
+// firstURL, adding each VM-attached NIC to dst keyed by the lower-cased
+// resource ID of the VM it is attached to.
+func (c *interfacesClient) collectNICsByVM(ctx context.Context, firstURL string, dst map[string][]*Interface) error {
+	pages := 0
+	for next := firstURL; next != ""; {
+		if pages >= maxListPages {
+			return trace.LimitExceeded("listing Azure network interfaces exceeded the maximum of %d pages", maxListPages)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, next, nil)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		page, err := client.DoRequest[armNetworkInterfaceList](ctx, c.client, req)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		pages++
+
+		for i := range page.Value {
+			raw := &page.Value[i]
+			vmID := raw.virtualMachineID()
+			if vmID == "" {
+				// NICs not attached to a VM are skipped.
+				continue
+			}
+			key := strings.ToLower(vmID)
+			dst[key] = append(dst[key], interfaceFromARM(raw.ID, raw))
+		}
+		next = page.NextLink
+	}
+	return nil
+}
+
+// buildURL joins the ARM endpoint with path and sets the api-version query.
+func buildURL(path, apiVersion string) (string, error) {
+	endpoint, err := url.JoinPath(armEndpoint, path)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	query := u.Query()
+	query.Set("api-version", apiVersion)
+	u.RawQuery = query.Encode()
+	return u.String(), nil
+}
+
+// scopePath builds a subscription- or resource-group-scoped path with the given
+// provider/type suffix. A wildcard resource group scopes to the whole subscription.
+func scopePath(subscriptionID, resourceGroup, providerPath string) string {
+	path := fmt.Sprintf("/subscriptions/%s", subscriptionID)
+	if resourceGroup != types.Wildcard {
+		path += fmt.Sprintf("/resourceGroups/%s", resourceGroup)
+	}
+	return path + providerPath
+}
+
 // armNetworkInterface is the minimal subset of the network interface resource.
 //
 // See https://learn.microsoft.com/en-us/rest/api/virtualnetwork/network-interfaces/get?view=rest-virtualnetwork-2025-05-01&tabs=HTTP#get-network-interface
 type armNetworkInterface struct {
+	ID         string                         `json:"id,omitempty"`
 	Name       string                         `json:"name,omitempty"`
 	Properties *armNetworkInterfaceProperties `json:"properties,omitempty"`
 }
 
+// virtualMachineID returns the resource ID of the VM this NIC is attached to,
+// or "" if it isn't attached to one.
+func (n *armNetworkInterface) virtualMachineID() string {
+	if n.Properties == nil || n.Properties.VirtualMachine == nil {
+		return ""
+	}
+	return n.Properties.VirtualMachine.ID
+}
+
+// armNetworkInterfaceList is the paged response from the network interfaces
+// list API.
+type armNetworkInterfaceList struct {
+	Value    []armNetworkInterface `json:"value,omitempty"`
+	NextLink string                `json:"nextLink,omitempty"`
+}
+
 type armNetworkInterfaceProperties struct {
 	IPConfigurations []armIPConfiguration `json:"ipConfigurations,omitempty"`
+	// VirtualMachine references the VM the NIC is attached to, if any.
+	VirtualMachine *armSubResource `json:"virtualMachine,omitempty"`
+}
+
+// armSubResource is an ARM reference to another resource by ID.
+type armSubResource struct {
+	ID string `json:"id,omitempty"`
+}
+
+// armScaleSet is the minimal subset of a VM Scale Set resource: enough to find
+// its ID and orchestration mode.
+type armScaleSet struct {
+	ID         string                 `json:"id,omitempty"`
+	Name       string                 `json:"name,omitempty"`
+	Properties *armScaleSetProperties `json:"properties,omitempty"`
+}
+
+type armScaleSetProperties struct {
+	// OrchestrationMode is "Uniform" or "Flexible".
+	OrchestrationMode string `json:"orchestrationMode,omitempty"`
+}
+
+// armScaleSetList is the paged response from the VM Scale Sets list API.
+type armScaleSetList struct {
+	Value    []armScaleSet `json:"value,omitempty"`
+	NextLink string        `json:"nextLink,omitempty"`
+}
+
+// isFlexible reports whether the scale set uses flexible orchestration, whose
+// instances' NICs are returned by the flat networkInterfaces list.
+func (s *armScaleSet) isFlexible() bool {
+	return s.Properties != nil && strings.EqualFold(s.Properties.OrchestrationMode, string(armcompute.OrchestrationModeFlexible))
 }
 
 type armIPConfiguration struct {
@@ -178,14 +462,24 @@ func interfaceFromARM(resourceID string, raw *armNetworkInterface) *Interface {
 			nic.PrivateIP = ip
 			return nic
 		}
-		if firstIP == "" {
+		// We use the first IP found as a fallback if no primary ip config is marked.
+		// The isIPAddress check is to skip secondary IP configs that have a CIDR
+		// block rather than a full IP address.
+		// See https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/virtual-network-private-ip-address-blocks-portal
+		if firstIP == "" && isIPAddress(ip) {
 			firstIP = ip
 		}
 	}
-	// None of the configurations were marked as primary, return the first found.
-	// This would be a bug if encountered, but we don't want to fail the request
-	// if it occurs.
+	// None of the configurations were marked as primary, return the first full IP
+	// found. This would be an Azure misconfiguration if encountered, but we don't
+	// want to fail the request if it occurs.
 	// See https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/virtual-network-network-interface-addresses?tabs=nic-address-portal#primary
 	nic.PrivateIP = firstIP
 	return nic
+}
+
+// isIPAddress reports whether s is an IP address rather than a CIDR block.
+func isIPAddress(s string) bool {
+	_, err := netip.ParseAddr(s)
+	return err == nil
 }

--- a/lib/cloud/azure/network/network_interfaces.go
+++ b/lib/cloud/azure/network/network_interfaces.go
@@ -1,0 +1,151 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Package network provides clients for Azure network resources, built on top of
+// the generic Azure HTTP query client in lib/cloud/azure/client. It avoids the
+// armnetwork SDK package: a VM's private IPs live on its NIC resource, and
+// pulling in armnetwork solely to read privateIPAddress would add a large
+// dependency for a single field.
+package network
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/cloud/azure/client"
+)
+
+// armEndpoint is the Azure Resource Manager endpoint for the public cloud.
+// TODO(gavin): if/when we support AzureChina/AzureGovernment, this needs to be
+// derived from the configured cloud.
+const armEndpoint = "https://management.azure.com"
+
+// interfaceAPIVersion is the API version for Azure Network Interfaces
+//
+// See https://learn.microsoft.com/en-us/rest/api/virtualnetwork/network-interfaces/get?view=rest-virtualnetwork-2025-05-01&tabs=HTTP
+const interfaceAPIVersion = "2025-05-01"
+
+// Interface represents an Azure network interface.
+type Interface struct {
+	// ID is the resource ID of the network interface.
+	ID string
+	// Name is the resource name of the network interface.
+	Name string
+	// PrivateIPs are the private IP addresses across all of the NIC's IP
+	// configurations, in the order Azure returns them.
+	PrivateIPs []string
+	// PrimaryPrivateIP is the private IP address of the NIC's primary IP
+	// configuration. Empty if no configuration is flagged primary.
+	PrimaryPrivateIP string
+}
+
+// InterfacesClient retrieves Azure network interfaces.
+type InterfacesClient interface {
+	// Get returns the network interface for the given NIC resource ID. The
+	// resource ID is the fully-qualified ARM ID, e.g.
+	// /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/networkInterfaces/<name>.
+	Get(ctx context.Context, resourceID string) (*Interface, error)
+}
+
+type interfacesClient struct {
+	// client is the generic Azure ARM HTTP query client. It handles AAD auth,
+	// response decoding, error conversion, and rate-limit retries for us.
+	client *client.Client
+}
+
+// NewInterfacesClient creates a new Azure network interfaces client backed by
+// the given Azure HTTP query client.
+func NewInterfacesClient(c *client.Client) InterfacesClient {
+	return &interfacesClient{client: c}
+}
+
+// Get returns the network interface for the given NIC resource ID.
+func (c *interfacesClient) Get(ctx context.Context, resourceID string) (*Interface, error) {
+	if _, err := arm.ParseResourceID(resourceID); err != nil {
+		return nil, trace.BadParameter("failed to parse network interface resource ID %q: %v", resourceID, err)
+	}
+
+	// Endpoint looks like:
+	// GET https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}
+	endpoint, err := url.JoinPath(armEndpoint, resourceID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	query := req.URL.Query()
+	query.Set("api-version", interfaceAPIVersion)
+	req.URL.RawQuery = query.Encode()
+
+	raw, err := client.DoRequest[armNetworkInterface](ctx, c.client, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return interfaceFromARM(resourceID, raw), nil
+}
+
+// armNetworkInterface is the minimal subset of the network interface resource.
+//
+// See https://learn.microsoft.com/en-us/rest/api/virtualnetwork/network-interfaces/get?view=rest-virtualnetwork-2025-05-01&tabs=HTTP#get-network-interface
+type armNetworkInterface struct {
+	Name       string                         `json:"name,omitempty"`
+	Properties *armNetworkInterfaceProperties `json:"properties,omitempty"`
+}
+
+type armNetworkInterfaceProperties struct {
+	IPConfigurations []armIPConfiguration `json:"ipConfigurations,omitempty"`
+}
+
+type armIPConfiguration struct {
+	Properties *armIPConfigurationProperties `json:"properties,omitempty"`
+}
+
+type armIPConfigurationProperties struct {
+	PrivateIPAddress string `json:"privateIPAddress,omitempty"`
+	// Primary indicates whether this is the NIC's primary IP configuration.
+	// A NIC can have multiple IP configurations.
+	Primary bool `json:"primary,omitempty"`
+}
+
+func interfaceFromARM(resourceID string, raw *armNetworkInterface) *Interface {
+	nic := &Interface{ID: resourceID}
+	if raw == nil {
+		return nic
+	}
+	nic.Name = raw.Name
+	if raw.Properties == nil {
+		return nic
+	}
+	for _, ipConfig := range raw.Properties.IPConfigurations {
+		if ipConfig.Properties == nil || ipConfig.Properties.PrivateIPAddress == "" {
+			continue
+		}
+		nic.PrivateIPs = append(nic.PrivateIPs, ipConfig.Properties.PrivateIPAddress)
+		if ipConfig.Properties.Primary {
+			nic.PrimaryPrivateIP = ipConfig.Properties.PrivateIPAddress
+		}
+	}
+	return nic
+}

--- a/lib/cloud/azure/network/network_interfaces.go
+++ b/lib/cloud/azure/network/network_interfaces.go
@@ -35,6 +35,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
@@ -146,7 +147,7 @@ func (c *interfacesClient) Get(ctx context.Context, resourceID string) (*Interfa
 		return nil, trace.Wrap(err)
 	}
 
-	nic := interfaceFromARM(resourceID, raw)
+	nic := interfaceFromARM(resourceID, &raw)
 	c.logger.DebugContext(ctx, "fetched Azure network interface",
 		"resource_id", nic.ID,
 		"name", nic.Name,
@@ -245,16 +246,33 @@ func (c *interfacesClient) listUniformVMSSNICs(
 		return nil, trace.Wrap(err)
 	}
 
+	nicsByScaleSet := make([]map[string][]*Interface, len(scaleSets))
+	var g errgroup.Group
+	// Limit the number of concurrent scale set NIC list calls to avoid being
+	// throttled by the Azure API. Any throttles are handled by the client.
+	g.SetLimit(10)
+	for i, scaleSet := range scaleSets {
+		g.Go(func() error {
+			first, err := buildURL(scaleSet.ID+"/networkInterfaces", computeAPIVersion)
+			if err != nil {
+				c.logger.DebugContext(ctx, "skipping VM Scale Set with an unparseable ID", "scale_set_id", scaleSet.ID, "error", err)
+				return nil
+			}
+			nicsByScaleSet[i] = make(map[string][]*Interface)
+			if err := c.collectNICsByVM(ctx, first, nicsByScaleSet[i]); err != nil {
+				c.logger.WarnContext(ctx, "failed to list network interfaces for VM Scale Set", "scale_set_id", scaleSet.ID, "error", err)
+				nicsByScaleSet[i] = nil
+			}
+			return nil
+		})
+	}
+	// errors are logged above, not returned
+	_ = g.Wait()
+
 	nicsByVM := make(map[string][]*Interface)
-	for _, scaleSet := range scaleSets {
-		first, err := buildURL(scaleSet.ID+"/networkInterfaces", computeAPIVersion)
-		if err != nil {
-			c.logger.DebugContext(ctx, "skipping VM Scale Set with an unparseable ID", "scale_set_id", scaleSet.ID, "error", err)
-			continue
-		}
-		if err := c.collectNICsByVM(ctx, first, nicsByVM); err != nil {
-			c.logger.WarnContext(ctx, "failed to list network interfaces for VM Scale Set", "scale_set_id", scaleSet.ID, "error", err)
-			continue
+	for _, scaleSetNICs := range nicsByScaleSet {
+		for vmID, vmNICs := range scaleSetNICs {
+			nicsByVM[vmID] = append(nicsByVM[vmID], vmNICs...)
 		}
 	}
 	return nicsByVM, nil

--- a/lib/cloud/azure/network/network_interfaces.go
+++ b/lib/cloud/azure/network/network_interfaces.go
@@ -75,6 +75,9 @@ type Interface struct {
 	// configurations are skipped. Empty only when the NIC has no usable
 	// private IP.
 	PrivateIP string
+	// Primary indicates whether this is the primary network interface on the
+	// VM it is attached to. Azure flags exactly one NIC per VM as primary.
+	Primary bool
 }
 
 // InterfacesClient retrieves Azure network interfaces.
@@ -415,6 +418,9 @@ type armNetworkInterfaceProperties struct {
 	IPConfigurations []armIPConfiguration `json:"ipConfigurations,omitempty"`
 	// VirtualMachine references the VM the NIC is attached to, if any.
 	VirtualMachine *armSubResource `json:"virtualMachine,omitempty"`
+	// Primary indicates whether this is the primary network interface on the
+	// virtual machine it is attached to.
+	Primary bool `json:"primary,omitempty"`
 }
 
 // armSubResource is an ARM reference to another resource by ID.
@@ -470,6 +476,7 @@ func interfaceFromARM(resourceID string, raw *armNetworkInterface) *Interface {
 	if raw.Properties == nil {
 		return nic
 	}
+	nic.Primary = raw.Properties.Primary
 	var firstIP string
 	for _, ipConfig := range raw.Properties.IPConfigurations {
 		if ipConfig.Properties == nil || ipConfig.Properties.PrivateIPAddress == "" {

--- a/lib/cloud/azure/network/network_interfaces_test.go
+++ b/lib/cloud/azure/network/network_interfaces_test.go
@@ -234,12 +234,27 @@ func TestInterfacesClientGet(t *testing.T) {
 		body          string
 		wantName      string
 		wantPrivateIP string
+		wantPrimary   bool
 	}{
 		{
 			name:          "single primary ip config",
 			body:          `{"name":"my-nic","properties":{"ipConfigurations":[{"properties":{"privateIPAddress":"10.0.0.4","primary":true}}]}}`,
 			wantName:      "my-nic",
 			wantPrivateIP: "10.0.0.4",
+		},
+		{
+			name:          "primary network interface",
+			body:          `{"name":"my-nic","properties":{"primary":true,"ipConfigurations":[{"properties":{"privateIPAddress":"10.0.0.4","primary":true}}]}}`,
+			wantName:      "my-nic",
+			wantPrivateIP: "10.0.0.4",
+			wantPrimary:   true,
+		},
+		{
+			name:          "non-primary network interface",
+			body:          `{"name":"my-nic","properties":{"primary":false,"ipConfigurations":[{"properties":{"privateIPAddress":"10.0.0.4","primary":true}}]}}`,
+			wantName:      "my-nic",
+			wantPrivateIP: "10.0.0.4",
+			wantPrimary:   false,
 		},
 		{
 			name:          "multiple ip configs, primary not first",
@@ -294,6 +309,7 @@ func TestInterfacesClientGet(t *testing.T) {
 			require.Equal(t, testNICID, nic.ID)
 			require.Equal(t, test.wantName, nic.Name)
 			require.Equal(t, test.wantPrivateIP, nic.PrivateIP)
+			require.Equal(t, test.wantPrimary, nic.Primary)
 		})
 	}
 }
@@ -353,13 +369,19 @@ const (
 	testVMB = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vmB"
 )
 
-func nicJSON(name, vmID, privateIP string) string {
+// nicJSON builds a NIC list-entry JSON body. primary sets the NIC-level primary
+// flag, i.e. whether this is the primary network interface on the VM.
+func nicJSON(name, vmID, privateIP string, primary bool) string {
 	vm := ""
 	if vmID != "" {
 		vm = `"virtualMachine":{"id":"` + vmID + `"},`
 	}
+	primaryField := ""
+	if primary {
+		primaryField = `"primary":true,`
+	}
 	return `{"id":"/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/` + name + `",` +
-		`"name":"` + name + `","properties":{` + vm +
+		`"name":"` + name + `","properties":{` + vm + primaryField +
 		`"ipConfigurations":[{"properties":{"privateIPAddress":"` + privateIP + `","primary":true}}]}}`
 }
 
@@ -383,8 +405,10 @@ func TestInterfacesClientList(t *testing.T) {
 
 	// Two pages of flat NICs: standalone vmA (one NIC per page, so grouping spans
 	// pages) and vmB, the flexible-VMSS instance, and an orphan NIC to be dropped.
-	flatPage1 := `{"value":[` + nicJSON("nicA1", testVMA, "10.0.0.4") + `,` + nicJSON("orphan", "", "10.0.0.5") + `],"nextLink":"https://management.azure.com/flat-page-2"}`
-	flatPage2 := `{"value":[` + nicJSON("nicA2", testVMA, "10.0.0.7") + `,` + nicJSON("nicB", testVMB, "10.0.0.6") + `,` + nicJSON("flex-nic", flexInstance, "10.0.0.8") + `]}`
+	// vmA's primary NIC is nicA2, on the second page, so grouping must carry the
+	// primary flag across pages.
+	flatPage1 := `{"value":[` + nicJSON("nicA1", testVMA, "10.0.0.4", false) + `,` + nicJSON("orphan", "", "10.0.0.5", false) + `],"nextLink":"https://management.azure.com/flat-page-2"}`
+	flatPage2 := `{"value":[` + nicJSON("nicA2", testVMA, "10.0.0.7", true) + `,` + nicJSON("nicB", testVMB, "10.0.0.6", true) + `,` + nicJSON("flex-nic", flexInstance, "10.0.0.8", true) + `]}`
 
 	var mu sync.Mutex
 	var requestedPaths []string
@@ -398,7 +422,7 @@ func TestInterfacesClientList(t *testing.T) {
 			return jsonResponse(http.StatusOK, flatPage2), nil
 		case strings.Contains(p, "/virtualMachineScaleSets/") && strings.HasSuffix(p, "/networkInterfaces"):
 			if s, ok := setForPath(uniform, p); ok {
-				return jsonResponse(http.StatusOK, `{"value":[`+nicJSON(s.nicName, s.instance, s.privateIP)+`]}`), nil
+				return jsonResponse(http.StatusOK, `{"value":[`+nicJSON(s.nicName, s.instance, s.privateIP, true)+`]}`), nil
 			}
 			return jsonResponse(http.StatusNotFound, `{}`), nil
 		case strings.HasSuffix(p, "/virtualMachineScaleSets"):
@@ -417,10 +441,17 @@ func TestInterfacesClientList(t *testing.T) {
 	// is dropped.
 	require.Len(t, nicsByVM, 3+len(uniform))
 
-	// vmA's two NICs are grouped together, collected across both flat pages.
+	// vmA's two NICs are grouped together, collected across both flat pages, and
+	// only its primary NIC (nicA2) carries the primary flag.
 	vmA := nicsByVM[strings.ToLower(testVMA)]
 	require.Len(t, vmA, 2)
 	require.ElementsMatch(t, []string{"10.0.0.4", "10.0.0.7"}, []string{vmA[0].PrivateIP, vmA[1].PrivateIP})
+	vmAByName := make(map[string]*Interface, len(vmA))
+	for _, nic := range vmA {
+		vmAByName[nic.Name] = nic
+	}
+	require.False(t, vmAByName["nicA1"].Primary, "nicA1 is not vmA's primary NIC")
+	require.True(t, vmAByName["nicA2"].Primary, "nicA2 is vmA's primary NIC")
 
 	// Standalone vmB and the flexible-VMSS instance each have one NIC.
 	require.Equal(t, "10.0.0.6", nicsByVM[strings.ToLower(testVMB)][0].PrivateIP)
@@ -469,7 +500,7 @@ func TestInterfacesClientListFlatError(t *testing.T) {
 					return jsonResponse(test.status, `{"error":{"code":"fail","message":"bye"}}`), nil
 				case strings.Contains(p, "/virtualMachineScaleSets/") && strings.HasSuffix(p, "/networkInterfaces"):
 					if s, ok := setForPath(uniform, p); ok {
-						return jsonResponse(http.StatusOK, `{"value":[`+nicJSON(s.nicName, s.instance, s.privateIP)+`]}`), nil
+						return jsonResponse(http.StatusOK, `{"value":[`+nicJSON(s.nicName, s.instance, s.privateIP, true)+`]}`), nil
 					}
 					return jsonResponse(http.StatusNotFound, `{}`), nil
 				case strings.HasSuffix(p, "/virtualMachineScaleSets"):

--- a/lib/cloud/azure/network/network_interfaces_test.go
+++ b/lib/cloud/azure/network/network_interfaces_test.go
@@ -19,6 +19,7 @@
 package network
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"io"
@@ -118,10 +119,7 @@ func TestInterfacesClientLiveList(t *testing.T) {
 
 	nicClient := NewInterfacesClient(queryClient)
 
-	rg := os.Getenv("AZURE_RESOURCE_GROUP")
-	if rg == "" {
-		rg = types.Wildcard
-	}
+	rg := cmp.Or(os.Getenv("AZURE_RESOURCE_GROUP"), types.Wildcard)
 	nicsByVM, err := nicClient.List(ctx, os.Getenv("AZURE_SUBSCRIPTION_ID"), rg)
 	require.NoError(t, err)
 	require.NotNil(t, nicsByVM)

--- a/lib/cloud/azure/network/network_interfaces_test.go
+++ b/lib/cloud/azure/network/network_interfaces_test.go
@@ -20,11 +20,13 @@ package network
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -62,7 +64,7 @@ func TestInterfacesClientLiveGet(t *testing.T) {
 		t.Skip("Set TELEPORT_TEST_AZURE_NIC_ID to the resource ID of a real Azure network interface.")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -105,7 +107,7 @@ func TestInterfacesClientLiveList(t *testing.T) {
 		t.Skip("Set TELEPORT_TEST_AZURE to run this test against a real Azure subscription.")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
 	defer cancel()
 
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -143,22 +145,23 @@ const testNICID = "/subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.N
 const token = "fake-token"
 
 // fakeDoer is an HTTP doer that returns canned responses and records the request
-// it received, so tests can run without contacting Azure. It returns, in order
-// of precedence: an error if set; whatever respond returns (route by request); a
-// fresh response from repeatBody on every call (for pagination loops); otherwise
-// resp.
+// it received, so tests can run without contacting Azure.
 type fakeDoer struct {
 	resp       *http.Response
 	repeatBody string
 	respond    func(*http.Request) (*http.Response, error)
 	err        error
-	calls      int
-	last       *http.Request
+
+	mu    sync.Mutex
+	calls int
+	last  *http.Request
 }
 
 func (f *fakeDoer) Do(req *http.Request) (*http.Response, error) {
+	f.mu.Lock()
 	f.calls++
 	f.last = req
+	f.mu.Unlock()
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -182,39 +185,43 @@ func jsonResponse(status int, body string) *http.Response {
 	}
 }
 
+// uniformSet is a single uniform VM Scale Set with one instance NIC.
+type uniformSet struct {
+	id, instance, nicName, privateIP string
+}
+
+// uniformScaleSets builds n uniform scale sets and their VM Scale Sets list
+// entries (unwrapped JSON objects, ready to compose into a "value" array).
+func uniformScaleSets(n int) ([]uniformSet, []string) {
+	sets := make([]uniformSet, n)
+	entries := make([]string, n)
+	for i := range sets {
+		name := fmt.Sprintf("uniform-ss-%d", i)
+		id := "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/" + name
+		sets[i] = uniformSet{
+			id:        id,
+			instance:  fmt.Sprintf("%s/virtualMachines/%d", id, i),
+			nicName:   name + "-nic",
+			privateIP: fmt.Sprintf("10.1.0.%d", i+1),
+		}
+		entries[i] = fmt.Sprintf(`{"id":%q,"name":%q,"properties":{"orchestrationMode":"Uniform"}}`, id, name)
+	}
+	return sets, entries
+}
+
+// setForPath returns the scale set that matches the given path, or false if
+// none match.
+func setForPath(sets []uniformSet, path string) (uniformSet, bool) {
+	for _, s := range sets {
+		if strings.HasPrefix(path, s.id+"/") {
+			return s, true
+		}
+	}
+	return uniformSet{}, false
+}
+
 // emptyList is an empty paged list response body.
 const emptyList = `{"value":[]}`
-
-// listRoute routes the requests List makes to canned response bodies: the flat
-// networkInterfaces list, the VM Scale Sets list, and per-scale-set NIC lists
-// (perScaleSetNICs is returned for any of those). pages maps a nextLink path to
-// its body. Empty bodies default to an empty list; unmatched requests 404.
-func listRoute(flatNICs, scaleSets, perScaleSetNICs string, pages map[string]string) func(*http.Request) (*http.Response, error) {
-	if flatNICs == "" {
-		flatNICs = emptyList
-	}
-	if scaleSets == "" {
-		scaleSets = emptyList
-	}
-	if perScaleSetNICs == "" {
-		perScaleSetNICs = emptyList
-	}
-	return func(req *http.Request) (*http.Response, error) {
-		p := req.URL.Path
-		if body, ok := pages[p]; ok {
-			return jsonResponse(http.StatusOK, body), nil
-		}
-		switch {
-		case strings.Contains(p, "/virtualMachineScaleSets/") && strings.HasSuffix(p, "/networkInterfaces"):
-			return jsonResponse(http.StatusOK, perScaleSetNICs), nil
-		case strings.HasSuffix(p, "/virtualMachineScaleSets"):
-			return jsonResponse(http.StatusOK, scaleSets), nil
-		case strings.HasSuffix(p, "/networkInterfaces"):
-			return jsonResponse(http.StatusOK, flatNICs), nil
-		}
-		return jsonResponse(http.StatusNotFound, `{}`), nil
-	}
-}
 
 func newTestClient(t *testing.T, doer *fakeDoer) InterfacesClient {
 	t.Helper()
@@ -287,7 +294,7 @@ func TestInterfacesClientGet(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			doer := &fakeDoer{resp: jsonResponse(http.StatusOK, test.body)}
-			nic, err := newTestClient(t, doer).Get(context.Background(), testNICID)
+			nic, err := newTestClient(t, doer).Get(t.Context(), testNICID)
 			require.NoError(t, err)
 			require.Equal(t, testNICID, nic.ID)
 			require.Equal(t, test.wantName, nic.Name)
@@ -300,7 +307,7 @@ func TestInterfacesClientGetRequest(t *testing.T) {
 	t.Parallel()
 
 	doer := &fakeDoer{resp: jsonResponse(http.StatusOK, `{"name":"my-nic"}`)}
-	_, err := newTestClient(t, doer).Get(context.Background(), testNICID)
+	_, err := newTestClient(t, doer).Get(t.Context(), testNICID)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, doer.calls)
@@ -330,7 +337,7 @@ func TestInterfacesClientGetErrors(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			doer := &fakeDoer{resp: jsonResponse(test.status, `{"error":{"code":"fail","message":"bye"}}`)}
-			_, err := newTestClient(t, doer).Get(context.Background(), testNICID)
+			_, err := newTestClient(t, doer).Get(t.Context(), testNICID)
 			require.Error(t, err)
 			require.True(t, test.assertErr(err), "unexpected error type: %v", err)
 		})
@@ -341,7 +348,7 @@ func TestInterfacesClientGetInvalidResourceID(t *testing.T) {
 	t.Parallel()
 
 	doer := &fakeDoer{resp: jsonResponse(http.StatusOK, `{}`)}
-	_, err := newTestClient(t, doer).Get(context.Background(), "not-a-valid-resource-id")
+	_, err := newTestClient(t, doer).Get(t.Context(), "not-a-valid-resource-id")
 	require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
 	require.Zero(t, doer.calls, "transport must not be called for an invalid resource ID")
 }
@@ -361,63 +368,101 @@ func nicJSON(name, vmID, privateIP string) string {
 		`"ipConfigurations":[{"properties":{"privateIPAddress":"` + privateIP + `","primary":true}}]}}`
 }
 
+// TestInterfacesClientList checks that standalone, flexible-VMSS, and
+// uniform-VMSS NICs are all listed, grouped per VM, with orphan NICs dropped.
 func TestInterfacesClientList(t *testing.T) {
 	t.Parallel()
 
-	// Flat-list page 1 has a NIC for vmA and an orphan NIC (no virtualMachine);
-	// page 2 has a NIC for vmB. The orphan must be omitted from the result.
-	page1 := `{"value":[` + nicJSON("nicA", testVMA, "10.0.0.4") + `,` + nicJSON("orphan", "", "10.0.0.5") + `],"nextLink":"https://management.azure.com/flat-page-2"}`
-	page2 := `{"value":[` + nicJSON("nicB", testVMB, "10.0.0.6") + `]}`
+	const (
+		flexSSID     = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/flex-ss"
+		flexInstance = flexSSID + "/virtualMachines/0"
+	)
 
-	doer := &fakeDoer{respond: listRoute(page1, "", "", map[string]string{"/flat-page-2": page2})}
+	uniform, uniformEntries := uniformScaleSets(3)
 
-	nicsByVM, err := newTestClient(t, doer).List(context.Background(), "sub", "rg")
+	// The VM Scale Sets list enumerates the uniform sets plus a flexible set. The
+	// flexible set's instances are already in the flat list, so it must not be
+	// queried per-set.
+	scaleSets := `{"value":[` + strings.Join(append(uniformEntries,
+		`{"id":"`+flexSSID+`","name":"flex-ss","properties":{"orchestrationMode":"Flexible"}}`), ",") + `]}`
+
+	// Two pages of flat NICs: standalone vmA (one NIC per page, so grouping spans
+	// pages) and vmB, the flexible-VMSS instance, and an orphan NIC to be dropped.
+	flatPage1 := `{"value":[` + nicJSON("nicA1", testVMA, "10.0.0.4") + `,` + nicJSON("orphan", "", "10.0.0.5") + `],"nextLink":"https://management.azure.com/flat-page-2"}`
+	flatPage2 := `{"value":[` + nicJSON("nicA2", testVMA, "10.0.0.7") + `,` + nicJSON("nicB", testVMB, "10.0.0.6") + `,` + nicJSON("flex-nic", flexInstance, "10.0.0.8") + `]}`
+
+	var mu sync.Mutex
+	var requestedPaths []string
+	doer := &fakeDoer{respond: func(req *http.Request) (*http.Response, error) {
+		p := req.URL.Path
+		mu.Lock()
+		requestedPaths = append(requestedPaths, p)
+		mu.Unlock()
+		switch {
+		case p == "/flat-page-2":
+			return jsonResponse(http.StatusOK, flatPage2), nil
+		case strings.Contains(p, "/virtualMachineScaleSets/") && strings.HasSuffix(p, "/networkInterfaces"):
+			if s, ok := setForPath(uniform, p); ok {
+				return jsonResponse(http.StatusOK, `{"value":[`+nicJSON(s.nicName, s.instance, s.privateIP)+`]}`), nil
+			}
+			return jsonResponse(http.StatusNotFound, `{}`), nil
+		case strings.HasSuffix(p, "/virtualMachineScaleSets"):
+			return jsonResponse(http.StatusOK, scaleSets), nil
+		case strings.HasSuffix(p, "/networkInterfaces"):
+			return jsonResponse(http.StatusOK, flatPage1), nil
+		}
+		return jsonResponse(http.StatusNotFound, `{}`), nil
+	}}
+
+	nicsByVM, err := newTestClient(t, doer).List(t.Context(), "sub", "rg")
 	require.NoError(t, err)
 
-	require.Len(t, nicsByVM, 2, "orphan NIC without a VM must be omitted")
+	// VMs with NICs: standalone vmA and vmB and the flexible-VMSS instance (all
+	// from the flat list), plus one instance per uniform scale set. The orphan NIC
+	// is dropped.
+	require.Len(t, nicsByVM, 3+len(uniform))
 
-	a := nicsByVM[strings.ToLower(testVMA)]
-	require.Len(t, a, 1)
-	require.Equal(t, "10.0.0.4", a[0].PrivateIP)
+	// vmA's two NICs are grouped together, collected across both flat pages.
+	vmA := nicsByVM[strings.ToLower(testVMA)]
+	require.Len(t, vmA, 2)
+	require.ElementsMatch(t, []string{"10.0.0.4", "10.0.0.7"}, []string{vmA[0].PrivateIP, vmA[1].PrivateIP})
 
-	b := nicsByVM[strings.ToLower(testVMB)]
-	require.Len(t, b, 1)
-	require.Equal(t, "10.0.0.6", b[0].PrivateIP)
-}
+	// Standalone vmB and the flexible-VMSS instance each have one NIC.
+	require.Equal(t, "10.0.0.6", nicsByVM[strings.ToLower(testVMB)][0].PrivateIP)
+	require.Equal(t, "10.0.0.8", nicsByVM[strings.ToLower(flexInstance)][0].PrivateIP)
 
-func TestInterfacesClientListGroupsMultipleNICs(t *testing.T) {
-	t.Parallel()
+	// Each uniform scale set's instance NIC is fetched per-set and merged in.
+	for _, s := range uniform {
+		nics := nicsByVM[strings.ToLower(s.instance)]
+		require.Len(t, nics, 1, "expected exactly one NIC for %s", s.instance)
+		require.Equal(t, s.privateIP, nics[0].PrivateIP)
+	}
 
-	// A single VM with two attached NICs should collect both.
-	body := `{"value":[` + nicJSON("nic1", testVMA, "10.0.0.4") + `,` + nicJSON("nic2", testVMA, "10.0.0.7") + `]}`
-	doer := &fakeDoer{respond: listRoute(body, "", "", nil)}
-
-	nicsByVM, err := newTestClient(t, doer).List(context.Background(), "sub", "rg")
-	require.NoError(t, err)
-
-	nics := nicsByVM[strings.ToLower(testVMA)]
-	require.Len(t, nics, 2)
-	ips := []string{nics[0].PrivateIP, nics[1].PrivateIP}
-	require.ElementsMatch(t, []string{"10.0.0.4", "10.0.0.7"}, ips)
+	// The flexible scale set shouldn't be requested directly through the Compute
+	// API. Instead it should have been found via the Network API.
+	for _, p := range requestedPaths {
+		require.NotContains(t, p, "flex-ss/networkInterfaces")
+	}
 }
 
 func TestInterfacesClientListMaxPages(t *testing.T) {
 	t.Parallel()
 
 	// Every response points to a next page, which would loop forever without the
-	// page cap. Both the flat-list and scale-set enumerations hit it.
+	// page cap.
 	doer := &fakeDoer{repeatBody: `{"value":[],"nextLink":"https://management.azure.com/next"}`}
 
-	_, err := newTestClient(t, doer).List(context.Background(), "sub", "rg")
+	_, err := newTestClient(t, doer).List(t.Context(), "sub", "rg")
 	require.Error(t, err)
-	require.ErrorContains(t, err, "maximum")
+	require.ErrorIs(t, err, trace.LimitExceeded("listing Azure network interfaces exceeded the maximum of %d pages", maxListPages))
 }
 
 func TestInterfacesClientListRequest(t *testing.T) {
 	t.Parallel()
 
-	// check lists with the given resource group and asserts both the flat NIC
-	// request and the VM Scale Sets request use the expected path and api-version.
+	// check lists with the given resource group and asserts both the Network API
+	// request and the VM Scale Sets Compute API request use the expected path and
+	// api-version.
 	check := func(t *testing.T, resourceGroup, wantNICPath, wantScaleSetPath string) {
 		t.Helper()
 		var reqs []*url.URL
@@ -425,7 +470,7 @@ func TestInterfacesClientListRequest(t *testing.T) {
 			reqs = append(reqs, req.URL)
 			return jsonResponse(http.StatusOK, emptyList), nil
 		}}
-		_, err := newTestClient(t, doer).List(context.Background(), "sub", resourceGroup)
+		_, err := newTestClient(t, doer).List(t.Context(), "sub", resourceGroup)
 		require.NoError(t, err)
 
 		var nicURL, scaleSetURL *url.URL
@@ -438,11 +483,11 @@ func TestInterfacesClientListRequest(t *testing.T) {
 			}
 		}
 
-		require.NotNil(t, nicURL, "expected a flat network interfaces request")
+		require.NotNil(t, nicURL, "expected a network API interfaces request")
 		require.Equal(t, wantNICPath, nicURL.Path)
 		require.Equal(t, interfaceAPIVersion, nicURL.Query().Get("api-version"))
 
-		require.NotNil(t, scaleSetURL, "expected a VM Scale Sets request")
+		require.NotNil(t, scaleSetURL, "expected a compute API request")
 		require.Equal(t, wantScaleSetPath, scaleSetURL.Path)
 		require.Equal(t, computeAPIVersion, scaleSetURL.Query().Get("api-version"))
 	}
@@ -460,51 +505,4 @@ func TestInterfacesClientListRequest(t *testing.T) {
 			"/subscriptions/sub/providers/Microsoft.Network/networkInterfaces",
 			"/subscriptions/sub/providers/Microsoft.Compute/virtualMachineScaleSets")
 	})
-}
-
-func TestInterfacesClientListIncludesUniformVMSS(t *testing.T) {
-	t.Parallel()
-
-	const (
-		uniformSSID     = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/uniform-ss"
-		flexSSID        = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/flex-ss"
-		uniformInstance = uniformSSID + "/virtualMachines/0"
-	)
-
-	flat := `{"value":[` + nicJSON("standalone-nic", testVMA, "10.0.0.4") + `]}`
-	scaleSets := `{"value":[` +
-		`{"id":"` + uniformSSID + `","name":"uniform-ss","properties":{"orchestrationMode":"Uniform"}},` +
-		`{"id":"` + flexSSID + `","name":"flex-ss","properties":{"orchestrationMode":"Flexible"}}` +
-		`]}`
-	uniformNICs := `{"value":[` + nicJSON("uniform-nic", uniformInstance, "10.0.0.5") + `]}`
-
-	var requestedPaths []string
-	doer := &fakeDoer{respond: func(req *http.Request) (*http.Response, error) {
-		p := req.URL.Path
-		requestedPaths = append(requestedPaths, p)
-		switch {
-		case strings.Contains(p, "/virtualMachineScaleSets/") && strings.HasSuffix(p, "/networkInterfaces"):
-			return jsonResponse(http.StatusOK, uniformNICs), nil
-		case strings.HasSuffix(p, "/virtualMachineScaleSets"):
-			return jsonResponse(http.StatusOK, scaleSets), nil
-		case strings.HasSuffix(p, "/networkInterfaces"):
-			return jsonResponse(http.StatusOK, flat), nil
-		}
-		return jsonResponse(http.StatusNotFound, `{}`), nil
-	}}
-
-	nicsByVM, err := newTestClient(t, doer).List(context.Background(), "sub", "rg")
-	require.NoError(t, err)
-
-	// The standalone VM comes from the flat list; the uniform VMSS instance comes
-	// from the per-scale-set list.
-	require.Len(t, nicsByVM, 2)
-	require.Equal(t, "10.0.0.4", nicsByVM[strings.ToLower(testVMA)][0].PrivateIP)
-	require.Equal(t, "10.0.0.5", nicsByVM[strings.ToLower(uniformInstance)][0].PrivateIP)
-
-	// The flexible scale set must NOT be queried for NICs; its instances are
-	// already covered by the flat list.
-	for _, p := range requestedPaths {
-		require.NotContains(t, p, "flex-ss/networkInterfaces")
-	}
 }

--- a/lib/cloud/azure/network/network_interfaces_test.go
+++ b/lib/cloud/azure/network/network_interfaces_test.go
@@ -92,12 +92,14 @@ func TestInterfacesClientLiveGet(t *testing.T) {
 //     `az login`, or set AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET.
 //     The identity needs Microsoft.Network/networkInterfaces/read on the NICs.
 //   - Set AZURE_SUBSCRIPTION_ID to a subscription ID that has at least one NIC.
+//   - Optionally set AZURE_RESOURCE_GROUP to a resource group that has at least one NIC.
 //
 // Run with:
 //
-//	TELEPORT_TEST_AZURE=1 \
-//	AZURE_SUBSCRIPTION_ID=<sub> \
-//	go test ./lib/cloud/azure/network/ -run TestInterfacesClientLiveList -v
+//		TELEPORT_TEST_AZURE=1 \
+//		AZURE_SUBSCRIPTION_ID=<sub> \
+//	  AZURE_RESOURCE_GROUP=<rg> \
+//		go test ./lib/cloud/azure/network/ -run TestInterfacesClientLiveList -v
 func TestInterfacesClientLiveList(t *testing.T) {
 	if os.Getenv("TELEPORT_TEST_AZURE") == "" {
 		t.Skip("Set TELEPORT_TEST_AZURE to run this test against a real Azure subscription.")
@@ -114,7 +116,11 @@ func TestInterfacesClientLiveList(t *testing.T) {
 
 	nicClient := NewInterfacesClient(queryClient)
 
-	nicsByVM, err := nicClient.List(ctx, os.Getenv("AZURE_SUBSCRIPTION_ID"), types.Wildcard)
+	rg := os.Getenv("AZURE_RESOURCE_GROUP")
+	if rg == "" {
+		rg = types.Wildcard
+	}
+	nicsByVM, err := nicClient.List(ctx, os.Getenv("AZURE_SUBSCRIPTION_ID"), rg)
 	require.NoError(t, err)
 	require.NotNil(t, nicsByVM)
 

--- a/lib/cloud/azure/network/network_interfaces_test.go
+++ b/lib/cloud/azure/network/network_interfaces_test.go
@@ -1,0 +1,230 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package network
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/cloud/azure"
+	"github.com/gravitational/teleport/lib/cloud/azure/client"
+)
+
+// TestInterfacesClientLive exercises the network interfaces client against a
+// real Azure subscription. It is skipped unless TELEPORT_TEST_AZURE is set.
+//
+// Prerequisites:
+//   - Authenticate so DefaultAzureCredential can find a credential, e.g. run
+//     `az login`, or set AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET.
+//     The identity needs Microsoft.Network/networkInterfaces/read on the NIC.
+//   - Set TELEPORT_TEST_AZURE_NIC_ID to a NIC resource ID, e.g.
+//     /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/networkInterfaces/<name>
+//
+// Run with:
+//
+//	TELEPORT_TEST_AZURE=1 \
+//	TELEPORT_TEST_AZURE_NIC_ID=/subscriptions/.../networkInterfaces/my-nic \
+//	go test ./lib/cloud/azure/network/ -run TestInterfacesClientLive -v
+func TestInterfacesClientLive(t *testing.T) {
+	if os.Getenv("TELEPORT_TEST_AZURE") == "" {
+		t.Skip("Set TELEPORT_TEST_AZURE to run this test against a real Azure subscription.")
+	}
+	nicID := os.Getenv("TELEPORT_TEST_AZURE_NIC_ID")
+	if nicID == "" {
+		t.Skip("Set TELEPORT_TEST_AZURE_NIC_ID to the resource ID of a real Azure network interface.")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	require.NoError(t, err, "failed to build a default Azure credential; have you run `az login`?")
+
+	queryClient, err := client.NewClient(cred, client.WithRetryOnRateLimitErrors())
+	require.NoError(t, err)
+
+	nicClient := NewInterfacesClient(queryClient)
+
+	nic, err := nicClient.Get(ctx, nicID)
+	require.NoError(t, err)
+	require.NotNil(t, nic)
+
+	t.Logf("NIC %q: private IP=%q", nic.Name, nic.PrivateIP)
+
+	require.Equal(t, nicID, nic.ID)
+	require.NotEmpty(t, nic.PrivateIP, "expected the NIC to have a private IP")
+}
+
+const testNICID = "/subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/my-nic"
+const token = "fake-token"
+
+// fakeDoer is an HTTP doer that returns a canned response and records the
+// request it received, so tests can run without contacting Azure.
+type fakeDoer struct {
+	resp  *http.Response
+	err   error
+	calls int
+	last  *http.Request
+}
+
+func (f *fakeDoer) Do(req *http.Request) (*http.Response, error) {
+	f.calls++
+	f.last = req
+	if f.err != nil {
+		return nil, f.err
+	}
+	f.resp.Request = req
+	return f.resp, nil
+}
+
+func jsonResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+func newTestClient(t *testing.T, doer *fakeDoer) InterfacesClient {
+	t.Helper()
+	cred := azure.NewStaticCredential(azcore.AccessToken{Token: token})
+	queryClient, err := client.NewClient(cred, client.WithHTTPClient(doer))
+	require.NoError(t, err)
+	return NewInterfacesClient(queryClient)
+}
+
+func TestInterfacesClientGet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		body          string
+		wantName      string
+		wantPrivateIP string
+	}{
+		{
+			name:          "single primary ip config",
+			body:          `{"name":"my-nic","properties":{"ipConfigurations":[{"properties":{"privateIPAddress":"10.0.0.4","primary":true}}]}}`,
+			wantName:      "my-nic",
+			wantPrivateIP: "10.0.0.4",
+		},
+		{
+			name:          "multiple ip configs, primary not first",
+			body:          `{"name":"my-nic","properties":{"ipConfigurations":[{"properties":{"privateIPAddress":"10.0.0.5"}},{"properties":{"privateIPAddress":"10.0.0.6","primary":true}}]}}`,
+			wantName:      "my-nic",
+			wantPrivateIP: "10.0.0.6",
+		},
+		{
+			name:          "no primary flagged falls back to the only ip",
+			body:          `{"name":"my-nic","properties":{"ipConfigurations":[{"properties":{"privateIPAddress":"10.0.0.7"}}]}}`,
+			wantName:      "my-nic",
+			wantPrivateIP: "10.0.0.7",
+		},
+		{
+			name:          "no primary flagged falls back to the first ip",
+			body:          `{"name":"my-nic","properties":{"ipConfigurations":[{"properties":{"privateIPAddress":"10.0.0.9"}},{"properties":{"privateIPAddress":"10.0.0.10"}}]}}`,
+			wantName:      "my-nic",
+			wantPrivateIP: "10.0.0.9",
+		},
+		{
+			name:          "empty ip config is skipped",
+			body:          `{"name":"my-nic","properties":{"ipConfigurations":[{"properties":{"privateIPAddress":""}},{"properties":{"privateIPAddress":"10.0.0.8"}}]}}`,
+			wantName:      "my-nic",
+			wantPrivateIP: "10.0.0.8",
+		},
+		{
+			name:          "no properties",
+			body:          `{"name":"my-nic"}`,
+			wantName:      "my-nic",
+			wantPrivateIP: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			doer := &fakeDoer{resp: jsonResponse(http.StatusOK, test.body)}
+			nic, err := newTestClient(t, doer).Get(context.Background(), testNICID)
+			require.NoError(t, err)
+			require.Equal(t, testNICID, nic.ID)
+			require.Equal(t, test.wantName, nic.Name)
+			require.Equal(t, test.wantPrivateIP, nic.PrivateIP)
+		})
+	}
+}
+
+func TestInterfacesClientGetRequest(t *testing.T) {
+	t.Parallel()
+
+	doer := &fakeDoer{resp: jsonResponse(http.StatusOK, `{"name":"my-nic"}`)}
+	_, err := newTestClient(t, doer).Get(context.Background(), testNICID)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, doer.calls)
+	req := doer.last
+	require.NotNil(t, req)
+	require.Equal(t, http.MethodGet, req.Method)
+	require.Equal(t, "management.azure.com", req.URL.Host)
+	require.Equal(t, testNICID, req.URL.Path)
+	require.Equal(t, interfaceAPIVersion, req.URL.Query().Get("api-version"))
+	require.Equal(t, "Bearer "+token, req.Header.Get("Authorization"))
+}
+
+func TestInterfacesClientGetErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		status    int
+		assertErr func(error) bool
+	}{
+		{"not found", http.StatusNotFound, trace.IsNotFound},
+		{"access denied", http.StatusForbidden, trace.IsAccessDenied},
+		{"server error", http.StatusInternalServerError, func(err error) bool { return err != nil }},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			doer := &fakeDoer{resp: jsonResponse(test.status, `{"error":{"code":"fail","message":"bye"}}`)}
+			_, err := newTestClient(t, doer).Get(context.Background(), testNICID)
+			require.Error(t, err)
+			require.True(t, test.assertErr(err), "unexpected error type: %v", err)
+		})
+	}
+}
+
+func TestInterfacesClientGetInvalidResourceID(t *testing.T) {
+	t.Parallel()
+
+	doer := &fakeDoer{resp: jsonResponse(http.StatusOK, `{}`)}
+	_, err := newTestClient(t, doer).Get(context.Background(), "not-a-valid-resource-id")
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
+	require.Zero(t, doer.calls, "transport must not be called for an invalid resource ID")
+}

--- a/lib/cloud/azure/network/network_interfaces_test.go
+++ b/lib/cloud/azure/network/network_interfaces_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -32,6 +33,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/cloud/azure/client"
 )
@@ -50,8 +52,8 @@ import (
 //
 //	TELEPORT_TEST_AZURE=1 \
 //	TELEPORT_TEST_AZURE_NIC_ID=/subscriptions/.../networkInterfaces/my-nic \
-//	go test ./lib/cloud/azure/network/ -run TestInterfacesClientLive -v
-func TestInterfacesClientLive(t *testing.T) {
+//	go test ./lib/cloud/azure/network/ -run TestInterfacesClientLiveGet -v
+func TestInterfacesClientLiveGet(t *testing.T) {
 	if os.Getenv("TELEPORT_TEST_AZURE") == "" {
 		t.Skip("Set TELEPORT_TEST_AZURE to run this test against a real Azure subscription.")
 	}
@@ -81,16 +83,71 @@ func TestInterfacesClientLive(t *testing.T) {
 	require.NotEmpty(t, nic.PrivateIP, "expected the NIC to have a private IP")
 }
 
+// TestInterfacesClientLiveList exercises the network interfaces client against
+// a real Azure subscription, listing all NICs. It is skipped unless
+// TELEPORT_TEST_AZURE is set.
+//
+// Prerequisites:
+//   - Authenticate so DefaultAzureCredential can find a credential, e.g. run
+//     `az login`, or set AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET.
+//     The identity needs Microsoft.Network/networkInterfaces/read on the NICs.
+//   - Set AZURE_SUBSCRIPTION_ID to a subscription ID that has at least one NIC.
+//
+// Run with:
+//
+//	TELEPORT_TEST_AZURE=1 \
+//	AZURE_SUBSCRIPTION_ID=<sub> \
+//	go test ./lib/cloud/azure/network/ -run TestInterfacesClientLiveList -v
+func TestInterfacesClientLiveList(t *testing.T) {
+	if os.Getenv("TELEPORT_TEST_AZURE") == "" {
+		t.Skip("Set TELEPORT_TEST_AZURE to run this test against a real Azure subscription.")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	require.NoError(t, err, "failed to build a default Azure credential; have you run `az login`?")
+
+	queryClient, err := client.NewClient(cred, client.WithRetryOnRateLimitErrors())
+	require.NoError(t, err)
+
+	nicClient := NewInterfacesClient(queryClient)
+
+	nicsByVM, err := nicClient.List(ctx, os.Getenv("AZURE_SUBSCRIPTION_ID"), types.Wildcard)
+	require.NoError(t, err)
+	require.NotNil(t, nicsByVM)
+
+	var uniform, other int
+	for vmID, nics := range nicsByVM {
+		if strings.Contains(strings.ToLower(vmID), "/virtualmachinescalesets/") {
+			uniform++
+		} else {
+			other++
+		}
+		t.Logf("VM %q has %d NIC(s):", vmID, len(nics))
+		for _, nic := range nics {
+			t.Logf("  NIC %q: private IP=%q", nic.Name, nic.PrivateIP)
+		}
+	}
+	t.Logf("nicsByVM: total=%d uniform-VMSS=%d standalone/flexible=%d", len(nicsByVM), uniform, other)
+}
+
 const testNICID = "/subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/my-nic"
 const token = "fake-token"
 
-// fakeDoer is an HTTP doer that returns a canned response and records the
-// request it received, so tests can run without contacting Azure.
+// fakeDoer is an HTTP doer that returns canned responses and records the request
+// it received, so tests can run without contacting Azure. It returns, in order
+// of precedence: an error if set; whatever respond returns (route by request); a
+// fresh response from repeatBody on every call (for pagination loops); otherwise
+// resp.
 type fakeDoer struct {
-	resp  *http.Response
-	err   error
-	calls int
-	last  *http.Request
+	resp       *http.Response
+	repeatBody string
+	respond    func(*http.Request) (*http.Response, error)
+	err        error
+	calls      int
+	last       *http.Request
 }
 
 func (f *fakeDoer) Do(req *http.Request) (*http.Response, error) {
@@ -98,6 +155,14 @@ func (f *fakeDoer) Do(req *http.Request) (*http.Response, error) {
 	f.last = req
 	if f.err != nil {
 		return nil, f.err
+	}
+	if f.respond != nil {
+		return f.respond(req)
+	}
+	if f.repeatBody != "" {
+		resp := jsonResponse(http.StatusOK, f.repeatBody)
+		resp.Request = req
+		return resp, nil
 	}
 	f.resp.Request = req
 	return f.resp, nil
@@ -108,6 +173,40 @@ func jsonResponse(status int, body string) *http.Response {
 		StatusCode: status,
 		Body:       io.NopCloser(strings.NewReader(body)),
 		Header:     make(http.Header),
+	}
+}
+
+// emptyList is an empty paged list response body.
+const emptyList = `{"value":[]}`
+
+// listRoute routes the requests List makes to canned response bodies: the flat
+// networkInterfaces list, the VM Scale Sets list, and per-scale-set NIC lists
+// (perScaleSetNICs is returned for any of those). pages maps a nextLink path to
+// its body. Empty bodies default to an empty list; unmatched requests 404.
+func listRoute(flatNICs, scaleSets, perScaleSetNICs string, pages map[string]string) func(*http.Request) (*http.Response, error) {
+	if flatNICs == "" {
+		flatNICs = emptyList
+	}
+	if scaleSets == "" {
+		scaleSets = emptyList
+	}
+	if perScaleSetNICs == "" {
+		perScaleSetNICs = emptyList
+	}
+	return func(req *http.Request) (*http.Response, error) {
+		p := req.URL.Path
+		if body, ok := pages[p]; ok {
+			return jsonResponse(http.StatusOK, body), nil
+		}
+		switch {
+		case strings.Contains(p, "/virtualMachineScaleSets/") && strings.HasSuffix(p, "/networkInterfaces"):
+			return jsonResponse(http.StatusOK, perScaleSetNICs), nil
+		case strings.HasSuffix(p, "/virtualMachineScaleSets"):
+			return jsonResponse(http.StatusOK, scaleSets), nil
+		case strings.HasSuffix(p, "/networkInterfaces"):
+			return jsonResponse(http.StatusOK, flatNICs), nil
+		}
+		return jsonResponse(http.StatusNotFound, `{}`), nil
 	}
 }
 
@@ -157,6 +256,18 @@ func TestInterfacesClientGet(t *testing.T) {
 			body:          `{"name":"my-nic","properties":{"ipConfigurations":[{"properties":{"privateIPAddress":""}},{"properties":{"privateIPAddress":"10.0.0.8"}}]}}`,
 			wantName:      "my-nic",
 			wantPrivateIP: "10.0.0.8",
+		},
+		{
+			name:          "cidr secondary config is skipped in fallback",
+			body:          `{"name":"my-nic","properties":{"ipConfigurations":[{"properties":{"privateIPAddress":"172.20.2.16/28"}},{"properties":{"privateIPAddress":"10.0.0.9"}}]}}`,
+			wantName:      "my-nic",
+			wantPrivateIP: "10.0.0.9",
+		},
+		{
+			name:          "only a cidr config yields no ip",
+			body:          `{"name":"my-nic","properties":{"ipConfigurations":[{"properties":{"privateIPAddress":"172.20.2.16/28"}}]}}`,
+			wantName:      "my-nic",
+			wantPrivateIP: "",
 		},
 		{
 			name:          "no properties",
@@ -227,4 +338,167 @@ func TestInterfacesClientGetInvalidResourceID(t *testing.T) {
 	_, err := newTestClient(t, doer).Get(context.Background(), "not-a-valid-resource-id")
 	require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
 	require.Zero(t, doer.calls, "transport must not be called for an invalid resource ID")
+}
+
+const (
+	testVMA = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vmA"
+	testVMB = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vmB"
+)
+
+func nicJSON(name, vmID, privateIP string) string {
+	vm := ""
+	if vmID != "" {
+		vm = `"virtualMachine":{"id":"` + vmID + `"},`
+	}
+	return `{"id":"/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/` + name + `",` +
+		`"name":"` + name + `","properties":{` + vm +
+		`"ipConfigurations":[{"properties":{"privateIPAddress":"` + privateIP + `","primary":true}}]}}`
+}
+
+func TestInterfacesClientList(t *testing.T) {
+	t.Parallel()
+
+	// Flat-list page 1 has a NIC for vmA and an orphan NIC (no virtualMachine);
+	// page 2 has a NIC for vmB. The orphan must be omitted from the result.
+	page1 := `{"value":[` + nicJSON("nicA", testVMA, "10.0.0.4") + `,` + nicJSON("orphan", "", "10.0.0.5") + `],"nextLink":"https://management.azure.com/flat-page-2"}`
+	page2 := `{"value":[` + nicJSON("nicB", testVMB, "10.0.0.6") + `]}`
+
+	doer := &fakeDoer{respond: listRoute(page1, "", "", map[string]string{"/flat-page-2": page2})}
+
+	nicsByVM, err := newTestClient(t, doer).List(context.Background(), "sub", "rg")
+	require.NoError(t, err)
+
+	require.Len(t, nicsByVM, 2, "orphan NIC without a VM must be omitted")
+
+	a := nicsByVM[strings.ToLower(testVMA)]
+	require.Len(t, a, 1)
+	require.Equal(t, "10.0.0.4", a[0].PrivateIP)
+
+	b := nicsByVM[strings.ToLower(testVMB)]
+	require.Len(t, b, 1)
+	require.Equal(t, "10.0.0.6", b[0].PrivateIP)
+}
+
+func TestInterfacesClientListGroupsMultipleNICs(t *testing.T) {
+	t.Parallel()
+
+	// A single VM with two attached NICs should collect both.
+	body := `{"value":[` + nicJSON("nic1", testVMA, "10.0.0.4") + `,` + nicJSON("nic2", testVMA, "10.0.0.7") + `]}`
+	doer := &fakeDoer{respond: listRoute(body, "", "", nil)}
+
+	nicsByVM, err := newTestClient(t, doer).List(context.Background(), "sub", "rg")
+	require.NoError(t, err)
+
+	nics := nicsByVM[strings.ToLower(testVMA)]
+	require.Len(t, nics, 2)
+	ips := []string{nics[0].PrivateIP, nics[1].PrivateIP}
+	require.ElementsMatch(t, []string{"10.0.0.4", "10.0.0.7"}, ips)
+}
+
+func TestInterfacesClientListMaxPages(t *testing.T) {
+	t.Parallel()
+
+	// Every response points to a next page, which would loop forever without the
+	// page cap. Both the flat-list and scale-set enumerations hit it.
+	doer := &fakeDoer{repeatBody: `{"value":[],"nextLink":"https://management.azure.com/next"}`}
+
+	_, err := newTestClient(t, doer).List(context.Background(), "sub", "rg")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "maximum")
+}
+
+func TestInterfacesClientListRequest(t *testing.T) {
+	t.Parallel()
+
+	// check lists with the given resource group and asserts both the flat NIC
+	// request and the VM Scale Sets request use the expected path and api-version.
+	check := func(t *testing.T, resourceGroup, wantNICPath, wantScaleSetPath string) {
+		t.Helper()
+		var reqs []*url.URL
+		doer := &fakeDoer{respond: func(req *http.Request) (*http.Response, error) {
+			reqs = append(reqs, req.URL)
+			return jsonResponse(http.StatusOK, emptyList), nil
+		}}
+		_, err := newTestClient(t, doer).List(context.Background(), "sub", resourceGroup)
+		require.NoError(t, err)
+
+		var nicURL, scaleSetURL *url.URL
+		for _, u := range reqs {
+			switch {
+			case strings.HasSuffix(u.Path, "/providers/Microsoft.Network/networkInterfaces"):
+				nicURL = u
+			case strings.HasSuffix(u.Path, "/providers/Microsoft.Compute/virtualMachineScaleSets"):
+				scaleSetURL = u
+			}
+		}
+
+		require.NotNil(t, nicURL, "expected a flat network interfaces request")
+		require.Equal(t, wantNICPath, nicURL.Path)
+		require.Equal(t, interfaceAPIVersion, nicURL.Query().Get("api-version"))
+
+		require.NotNil(t, scaleSetURL, "expected a VM Scale Sets request")
+		require.Equal(t, wantScaleSetPath, scaleSetURL.Path)
+		require.Equal(t, computeAPIVersion, scaleSetURL.Query().Get("api-version"))
+	}
+
+	t.Run("scoped to resource group", func(t *testing.T) {
+		t.Parallel()
+		check(t, "rg",
+			"/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces",
+			"/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets")
+	})
+
+	t.Run("wildcard lists whole subscription", func(t *testing.T) {
+		t.Parallel()
+		check(t, types.Wildcard,
+			"/subscriptions/sub/providers/Microsoft.Network/networkInterfaces",
+			"/subscriptions/sub/providers/Microsoft.Compute/virtualMachineScaleSets")
+	})
+}
+
+func TestInterfacesClientListIncludesUniformVMSS(t *testing.T) {
+	t.Parallel()
+
+	const (
+		uniformSSID     = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/uniform-ss"
+		flexSSID        = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/flex-ss"
+		uniformInstance = uniformSSID + "/virtualMachines/0"
+	)
+
+	flat := `{"value":[` + nicJSON("standalone-nic", testVMA, "10.0.0.4") + `]}`
+	scaleSets := `{"value":[` +
+		`{"id":"` + uniformSSID + `","name":"uniform-ss","properties":{"orchestrationMode":"Uniform"}},` +
+		`{"id":"` + flexSSID + `","name":"flex-ss","properties":{"orchestrationMode":"Flexible"}}` +
+		`]}`
+	uniformNICs := `{"value":[` + nicJSON("uniform-nic", uniformInstance, "10.0.0.5") + `]}`
+
+	var requestedPaths []string
+	doer := &fakeDoer{respond: func(req *http.Request) (*http.Response, error) {
+		p := req.URL.Path
+		requestedPaths = append(requestedPaths, p)
+		switch {
+		case strings.Contains(p, "/virtualMachineScaleSets/") && strings.HasSuffix(p, "/networkInterfaces"):
+			return jsonResponse(http.StatusOK, uniformNICs), nil
+		case strings.HasSuffix(p, "/virtualMachineScaleSets"):
+			return jsonResponse(http.StatusOK, scaleSets), nil
+		case strings.HasSuffix(p, "/networkInterfaces"):
+			return jsonResponse(http.StatusOK, flat), nil
+		}
+		return jsonResponse(http.StatusNotFound, `{}`), nil
+	}}
+
+	nicsByVM, err := newTestClient(t, doer).List(context.Background(), "sub", "rg")
+	require.NoError(t, err)
+
+	// The standalone VM comes from the flat list; the uniform VMSS instance comes
+	// from the per-scale-set list.
+	require.Len(t, nicsByVM, 2)
+	require.Equal(t, "10.0.0.4", nicsByVM[strings.ToLower(testVMA)][0].PrivateIP)
+	require.Equal(t, "10.0.0.5", nicsByVM[strings.ToLower(uniformInstance)][0].PrivateIP)
+
+	// The flexible scale set must NOT be queried for NICs; its instances are
+	// already covered by the flat list.
+	for _, p := range requestedPaths {
+		require.NotContains(t, p, "flex-ss/networkInterfaces")
+	}
 }

--- a/lib/cloud/azure/network/network_interfaces_test.go
+++ b/lib/cloud/azure/network/network_interfaces_test.go
@@ -443,6 +443,52 @@ func TestInterfacesClientList(t *testing.T) {
 	}
 }
 
+// TestInterfacesClientListFlatError checks that a failure to list the flat
+// networkInterfaces API is fatal. We don't want to just return the uniform
+// VMSS NICs because that would silently drop most private IPs.
+func TestInterfacesClientListFlatError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		status    int
+		assertErr func(error) bool
+	}{
+		{"access denied", http.StatusForbidden, trace.IsAccessDenied},
+		{"server error", http.StatusInternalServerError, func(err error) bool { return err != nil }},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			uniform, uniformEntries := uniformScaleSets(1)
+			scaleSets := `{"value":[` + strings.Join(uniformEntries, ",") + `]}`
+
+			doer := &fakeDoer{respond: func(req *http.Request) (*http.Response, error) {
+				p := req.URL.Path
+				switch {
+				case strings.HasSuffix(p, "/providers/Microsoft.Network/networkInterfaces"):
+					return jsonResponse(test.status, `{"error":{"code":"fail","message":"bye"}}`), nil
+				case strings.Contains(p, "/virtualMachineScaleSets/") && strings.HasSuffix(p, "/networkInterfaces"):
+					if s, ok := setForPath(uniform, p); ok {
+						return jsonResponse(http.StatusOK, `{"value":[`+nicJSON(s.nicName, s.instance, s.privateIP)+`]}`), nil
+					}
+					return jsonResponse(http.StatusNotFound, `{}`), nil
+				case strings.HasSuffix(p, "/virtualMachineScaleSets"):
+					return jsonResponse(http.StatusOK, scaleSets), nil
+				}
+				return jsonResponse(http.StatusNotFound, `{}`), nil
+			}}
+
+			nicsByVM, err := newTestClient(t, doer).List(t.Context(), "sub", "rg")
+			require.Error(t, err)
+			require.True(t, test.assertErr(err), "unexpected error type: %v", err)
+			require.Nil(t, nicsByVM, "no NICs should be returned when the flat list fails")
+		})
+	}
+}
+
 func TestInterfacesClientListMaxPages(t *testing.T) {
 	t.Parallel()
 

--- a/lib/cloud/azure/network/network_interfaces_test.go
+++ b/lib/cloud/azure/network/network_interfaces_test.go
@@ -143,12 +143,13 @@ const testNICID = "/subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.N
 const token = "fake-token"
 
 // fakeDoer is an HTTP doer that returns canned responses and records the request
-// it received, so tests can run without contacting Azure.
+// it received, so tests can run without contacting Azure. It builds a fresh
+// response body on every call, so the same doer can serve repeated requests.
 type fakeDoer struct {
-	resp       *http.Response
-	repeatBody string
-	respond    func(*http.Request) (*http.Response, error)
-	err        error
+	status  int
+	body    string
+	respond func(*http.Request) (*http.Response, error)
+	err     error
 
 	mu    sync.Mutex
 	calls int
@@ -166,13 +167,9 @@ func (f *fakeDoer) Do(req *http.Request) (*http.Response, error) {
 	if f.respond != nil {
 		return f.respond(req)
 	}
-	if f.repeatBody != "" {
-		resp := jsonResponse(http.StatusOK, f.repeatBody)
-		resp.Request = req
-		return resp, nil
-	}
-	f.resp.Request = req
-	return f.resp, nil
+	resp := jsonResponse(cmp.Or(f.status, http.StatusOK), f.body)
+	resp.Request = req
+	return resp, nil
 }
 
 func jsonResponse(status int, body string) *http.Response {
@@ -291,7 +288,7 @@ func TestInterfacesClientGet(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			doer := &fakeDoer{resp: jsonResponse(http.StatusOK, test.body)}
+			doer := &fakeDoer{body: test.body}
 			nic, err := newTestClient(t, doer).Get(t.Context(), testNICID)
 			require.NoError(t, err)
 			require.Equal(t, testNICID, nic.ID)
@@ -304,7 +301,7 @@ func TestInterfacesClientGet(t *testing.T) {
 func TestInterfacesClientGetRequest(t *testing.T) {
 	t.Parallel()
 
-	doer := &fakeDoer{resp: jsonResponse(http.StatusOK, `{"name":"my-nic"}`)}
+	doer := &fakeDoer{body: `{"name":"my-nic"}`}
 	_, err := newTestClient(t, doer).Get(t.Context(), testNICID)
 	require.NoError(t, err)
 
@@ -334,7 +331,7 @@ func TestInterfacesClientGetErrors(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			doer := &fakeDoer{resp: jsonResponse(test.status, `{"error":{"code":"fail","message":"bye"}}`)}
+			doer := &fakeDoer{status: test.status, body: `{"error":{"code":"fail","message":"bye"}}`}
 			_, err := newTestClient(t, doer).Get(t.Context(), testNICID)
 			require.Error(t, err)
 			require.True(t, test.assertErr(err), "unexpected error type: %v", err)
@@ -345,7 +342,7 @@ func TestInterfacesClientGetErrors(t *testing.T) {
 func TestInterfacesClientGetInvalidResourceID(t *testing.T) {
 	t.Parallel()
 
-	doer := &fakeDoer{resp: jsonResponse(http.StatusOK, `{}`)}
+	doer := &fakeDoer{body: `{}`}
 	_, err := newTestClient(t, doer).Get(t.Context(), "not-a-valid-resource-id")
 	require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
 	require.Zero(t, doer.calls, "transport must not be called for an invalid resource ID")
@@ -494,7 +491,7 @@ func TestInterfacesClientListMaxPages(t *testing.T) {
 
 	// Every response points to a next page, which would loop forever without the
 	// page cap.
-	doer := &fakeDoer{repeatBody: `{"value":[],"nextLink":"https://management.azure.com/next"}`}
+	doer := &fakeDoer{body: `{"value":[],"nextLink":"https://management.azure.com/next"}`}
 
 	_, err := newTestClient(t, doer).List(t.Context(), "sub", "rg")
 	require.Error(t, err)


### PR DESCRIPTION
This PR adds a client for `GET`ing and `LIST`ing NICs attached to VMs, Flexible VMSS, and Uniform VMSS in Azure for the Discovery Service.

This is in support of discovering Non-AD Windows Desktops in Azure. The branch currently depends on a HTTP Client added in this [PR](https://github.com/gravitational/teleport/pull/67933) that may or may not be merged in to master, if not I'll bring the client in to this PR.

[RFD](https://github.com/gravitational/rfd/pull/17) for this feature. [Tracking issue](https://github.com/gravitational/teleport/issues/68240).

Edit: Apologies for the size of this PR, the PR that this was originally based off was closed. I had to bring the `client.go` and related files in to this PR to keep it functional.

## Manual Test Plan
### Test Environment
Added live tests that exercise the new network interface client
### Test Cases
- [x] The client can GET the details of a specified NIC:
  `TELEPORT_TEST_AZURE=1 TELEPORT_TEST_AZURE_NIC_ID="/subscriptions/[sub-id]/resourceGroups/[rg-id]/providers/Microsoft.Network/networkInterfaces/[vm-id]" go test ./lib/cloud/azure/network/ -run TestInterfacesClientLiveGet -v`
- [x] The client can LIST all NICs in a subscription:
  `TELEPORT_TEST_AZURE=1 AZURE_SUBSCRIPTION_ID="[sub-id]" go test ./lib/cloud/azure/network/ -run TestInterfacesClientLiveList -v`
- [x] The client can LIST all NICs in a resource group:
  `TELEPORT_TEST_AZURE=1 AZURE_SUBSCRIPTION_ID="[sub-id]" AZURE_RESOURCE_GROUP="[rg-id]" go test ./lib/cloud/azure/network/ -run TestInterfacesClientLiveList -v`
