### PR TITLE
EC2 auto-discovery: emit IAM permission errors as UserTasks V2

### DIFF
--- a/api/types/usertasks/object.go
+++ b/api/types/usertasks/object.go
@@ -399,13 +399,16 @@ func validateDiscoverEC2TaskType(ut *usertasksv1.UserTask) error {
 
 	// Permission issues occur before instance discovery (org/account level),
 	// so account ID, region, and instance list may all be empty.
-	if isPermissionIssueType(ut.GetSpec().GetIssueType()) {
+	if IsPermissionIssueType(ut.GetSpec().GetIssueType()) {
 		return validateDiscoverEC2PermissionIssue(ut)
 	}
 	return validateDiscoverEC2InstallationIssue(ut)
 }
 
-func isPermissionIssueType(issueType string) bool {
+// IsPermissionIssueType reports whether the given issue type represents an
+// IAM permission error (account-level or org-level). Permission issues have
+// relaxed validation: they may have empty account ID, region, and instances.
+func IsPermissionIssueType(issueType string) bool {
 	switch issueType {
 	case AutoDiscoverEC2IssuePermAccountDenied,
 		AutoDiscoverEC2IssuePermOrgDenied:

--- a/lib/cloud/aws/regions/regions.go
+++ b/lib/cloud/aws/regions/regions.go
@@ -53,11 +53,7 @@ func ListEnabledRegions(ctx context.Context, listerGetter ListerGetter, opts ...
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			convertedErr := libcloudaws.ConvertRequestFailureError(err)
-			if trace.IsAccessDenied(convertedErr) {
-				return nil, trace.BadParameter("Missing account:ListRegions permission in IAM Role, which is required to iterate over all regions. " +
-					"Add this permission to the IAM Role, or enumerate the regions explicitly.")
-			}
-			return nil, convertedErr
+			return nil, trace.Wrap(convertedErr)
 		}
 
 		for _, region := range page.Regions {

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -663,6 +663,7 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 		server.WithTriggerFetchC[*server.EC2Instances](s.newDiscoveryConfigChangedSub()),
 		server.WithPreFetchHookFn(s.ec2WatcherIterationStarted),
 		server.WithClock[*server.EC2Instances](s.clock),
+		server.WithFetchErrorHookFn[*server.EC2Instances](s.handleEC2WatcherError),
 		server.WithPerInstanceHookFn(func(instanceGroups []*server.EC2Instances) {
 			for _, group := range instanceGroups {
 				s.awsEC2ResourcesStatus.incrementFound(awsResourceGroup{
@@ -711,6 +712,40 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 	s.kubeFetchers = append(s.kubeFetchers, kubeFetchers...)
 
 	return nil
+}
+
+func (s *Server) handleEC2WatcherError(err error) bool {
+	permissionErrors := server.EC2IAMPermissionErrors(err)
+	if len(permissionErrors) == 0 {
+		return false
+	}
+
+	for _, permErr := range permissionErrors {
+		if permErr == nil {
+			continue
+		}
+		s.Log.WarnContext(s.ctx, "IAM permission error during EC2 discovery",
+			"issue_type", permErr.IssueType,
+			"integration", permErr.Integration,
+			"account_id", permErr.AccountID,
+			"region", permErr.Region,
+			"discovery_config", permErr.DiscoveryConfigName,
+			"error", permErr.Err,
+		)
+
+		s.awsEC2Tasks.addFailedPermissionEnrollment(
+			awsEC2TaskKey{
+				// Intentionally do not include DiscoveryConfigName in the task key. Permission errors are
+				// account/region scoped and usually shared by all discovery configs using the same credentials.
+				accountID:   permErr.AccountID,
+				integration: permErr.Integration,
+				issueType:   permErr.IssueType,
+				region:      permErr.Region,
+			},
+		)
+	}
+
+	return true
 }
 
 func (s *Server) ec2WatcherIterationStarted(fetchers []server.Fetcher[*server.EC2Instances]) {

--- a/lib/srv/discovery/fetchers/eks.go
+++ b/lib/srv/discovery/fetchers/eks.go
@@ -216,6 +216,10 @@ func (f *eksFetcher) Get(ctx context.Context) (types.ResourcesWithLabels, error)
 	if f.Matcher.IsRegionWildcard() {
 		enabled, err := awsregions.ListEnabledRegions(ctx, f.RegionsListerGetter, matcherCredentialOpts(f.Matcher)...)
 		if err != nil {
+			if trace.IsAccessDenied(err) {
+				return nil, trace.BadParameter("Missing account:ListRegions permission in IAM Role, which is required to iterate over all regions. " +
+					"Add this permission to the IAM Role, or enumerate the regions explicitly.")
+			}
 			return nil, trace.Wrap(err)
 		}
 		regions = enabled

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -431,7 +431,14 @@ type awsEC2Tasks struct {
 	issuesSyncQueue map[awsEC2TaskKey]struct{}
 }
 
-// awsEC2TaskKey identifies a UserTask group.
+// awsEC2TaskKey identifies a unique UserTask group for EC2
+// discovery errors.
+//
+// Note: DiscoveryConfigName is intentionally excluded from the
+// key. EC2 permission and execution issues are account and
+// region scoped, so failures from multiple discovery configs
+// sharing the same credentials or installation parameters
+// deduplicate into a single UserTask.
 type awsEC2TaskKey struct {
 	integration     string
 	issueType       string
@@ -451,10 +458,13 @@ func (d *awsEC2Tasks) reset() {
 	d.issuesSyncQueue = make(map[awsEC2TaskKey]struct{})
 }
 
-// addFailedEnrollment adds an enrollment failure of a given instance.
+// addFailedEnrollment records an EC2 enrollment failure.
+//
+// Instance may be nil for failures that occur before any instance metadata is
+// known.
 func (d *awsEC2Tasks) addFailedEnrollment(g awsEC2TaskKey, instance *usertasksv1.DiscoverEC2Instance) {
-	// Only failures associated with an Integration are reported.
-	// There's no major blocking for showing non-integration User Tasks, but this keeps scope smaller.
+	// Only failures with non-empty Integration are reported. UserTask validation
+	// requires an Integration, so ambient-credential failures are intentionally skipped.
 	if g.integration == "" {
 		return
 	}
@@ -476,12 +486,20 @@ func (d *awsEC2Tasks) addFailedEnrollment(g awsEC2TaskKey, instance *usertasksv1
 			InstallerScript: g.installerScript,
 		}.Build()
 	}
-	d.instancesIssues[g].GetInstances()[instance.GetInstanceId()] = instance
+	if instance != nil {
+		d.instancesIssues[g].GetInstances()[instance.GetInstanceId()] = instance
+	}
 
 	if d.issuesSyncQueue == nil {
 		d.issuesSyncQueue = make(map[awsEC2TaskKey]struct{})
 	}
 	d.issuesSyncQueue[g] = struct{}{}
+}
+
+// addFailedPermissionEnrollment records an EC2 permission failure
+// with no associated instance data.
+func (d *awsEC2Tasks) addFailedPermissionEnrollment(g awsEC2TaskKey) {
+	d.addFailedEnrollment(g, nil)
 }
 
 // awsEKSTasks contains the Discover EKS User Tasks that must be reported to the user.
@@ -667,10 +685,6 @@ func (s *taskUpdater) acquireSemaphoreForUserTask(userTaskName string) (releaseF
 //
 // All of this flow is protected by a lock to ensure there's no race between this and other DiscoveryServices.
 func (s *taskUpdater) mergeUpsertDiscoverEC2Task(taskGroup awsEC2TaskKey, failedInstances *usertasksv1.DiscoverEC2) error {
-	if len(failedInstances.GetInstances()) == 0 {
-		return nil
-	}
-
 	userTaskName := usertasks.TaskNameForDiscoverEC2(usertasks.TaskNameForDiscoverEC2Parts{
 		Integration:     taskGroup.integration,
 		IssueType:       taskGroup.issueType,

--- a/lib/srv/discovery/status_test.go
+++ b/lib/srv/discovery/status_test.go
@@ -339,6 +339,162 @@ func newTaskUpdater(t *testing.T, existingTasks ...*usertasksv1.UserTask) (*task
 	return manager, ap
 }
 
+func TestAWSEC2Tasks_AddFailedEnrollment(t *testing.T) {
+	t.Parallel()
+
+	permissionKey := awsEC2TaskKey{
+		integration: "my-int",
+		issueType:   usertasks.AutoDiscoverEC2IssuePermAccountDenied,
+		accountID:   "123456789012",
+		region:      "us-east-1",
+	}
+	installKey := awsEC2TaskKey{
+		integration: "my-int",
+		issueType:   usertasks.AutoDiscoverEC2IssueSSMInvocationFailure,
+		accountID:   "123456789012",
+		region:      "us-east-1",
+	}
+
+	tests := []struct {
+		name     string
+		mutate   func(tasks *awsEC2Tasks)
+		expected map[awsEC2TaskKey]*usertasksv1.DiscoverEC2
+		queued   map[awsEC2TaskKey]struct{}
+	}{
+		{
+			name: "empty integration is ignored",
+			mutate: func(tasks *awsEC2Tasks) {
+				tasks.addFailedPermissionEnrollment(awsEC2TaskKey{
+					issueType: usertasks.AutoDiscoverEC2IssuePermAccountDenied,
+					accountID: "123456789012",
+					region:    "us-east-1",
+				})
+			},
+		},
+		{
+			name: "non permission issue with nil instance is queued",
+			mutate: func(tasks *awsEC2Tasks) {
+				tasks.addFailedEnrollment(installKey, nil)
+			},
+			expected: map[awsEC2TaskKey]*usertasksv1.DiscoverEC2{
+				installKey: usertasksv1.DiscoverEC2_builder{
+					AccountId: installKey.accountID,
+					Region:    installKey.region,
+					Instances: map[string]*usertasksv1.DiscoverEC2Instance{},
+				}.Build(),
+			},
+			queued: map[awsEC2TaskKey]struct{}{
+				installKey: {},
+			},
+		},
+		{
+			name: "permission issue with nil instance is queued",
+			mutate: func(tasks *awsEC2Tasks) {
+				tasks.addFailedPermissionEnrollment(permissionKey)
+			},
+			expected: map[awsEC2TaskKey]*usertasksv1.DiscoverEC2{
+				permissionKey: usertasksv1.DiscoverEC2_builder{
+					AccountId: permissionKey.accountID,
+					Region:    permissionKey.region,
+					Instances: map[string]*usertasksv1.DiscoverEC2Instance{},
+				}.Build(),
+			},
+			queued: map[awsEC2TaskKey]struct{}{
+				permissionKey: {},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tasks := &awsEC2Tasks{}
+			tt.mutate(tasks)
+			require.Empty(t, cmp.Diff(tt.expected, tasks.instancesIssues, protocmp.Transform()))
+			require.Equal(t, tt.queued, tasks.issuesSyncQueue)
+		})
+	}
+}
+
+func TestMergeUpsertDiscoverEC2Task(t *testing.T) {
+	t.Parallel()
+
+	permissionKey := awsEC2TaskKey{
+		integration: "my-int",
+		issueType:   usertasks.AutoDiscoverEC2IssuePermAccountDenied,
+		accountID:   "123456789012",
+		region:      "us-east-1",
+	}
+	installKey := awsEC2TaskKey{
+		integration: "my-int",
+		issueType:   usertasks.AutoDiscoverEC2IssueSSMInvocationFailure,
+		accountID:   "123456789012",
+		region:      "us-east-1",
+	}
+
+	emptyEC2Data := func(key awsEC2TaskKey) *usertasksv1.DiscoverEC2 {
+		return usertasksv1.DiscoverEC2_builder{
+			AccountId:       key.accountID,
+			Region:          key.region,
+			SsmDocument:     key.ssmDocument,
+			InstallerScript: key.installerScript,
+			Instances:       map[string]*usertasksv1.DiscoverEC2Instance{},
+		}.Build()
+	}
+	existingPermissionTask := func(t *testing.T) *usertasksv1.UserTask {
+		task, err := usertasks.NewDiscoverEC2UserTask(
+			usertasksv1.UserTaskSpec_builder{
+				Integration: permissionKey.integration,
+				TaskType:    usertasks.TaskTypeDiscoverEC2,
+				IssueType:   permissionKey.issueType,
+				State:       usertasks.TaskStateOpen,
+				DiscoverEc2: usertasksv1.DiscoverEC2_builder{
+					AccountId: permissionKey.accountID,
+					Region:    permissionKey.region,
+					Instances: map[string]*usertasksv1.DiscoverEC2Instance{},
+				}.Build(),
+			}.Build(),
+		)
+		require.NoError(t, err)
+		return task
+	}
+
+	t.Run("permission issue with empty instances is upserted", func(t *testing.T) {
+		s, ap := newTaskUpdater(t)
+
+		require.NoError(t, s.mergeUpsertDiscoverEC2Task(permissionKey, emptyEC2Data(permissionKey)))
+
+		require.Len(t, ap.tasks, 1)
+		taskName := usertasks.TaskNameForDiscoverEC2(usertasks.TaskNameForDiscoverEC2Parts{
+			Integration: permissionKey.integration,
+			IssueType:   permissionKey.issueType,
+			AccountID:   permissionKey.accountID,
+			Region:      permissionKey.region,
+		})
+		upsertedTask, err := ap.GetUserTask(s.ctx, taskName)
+		require.NoError(t, err)
+		require.Empty(t, upsertedTask.GetSpec().GetDiscoverEc2().GetInstances())
+	})
+
+	t.Run("non permission issue with empty instances returns validation error", func(t *testing.T) {
+		s, ap := newTaskUpdater(t)
+
+		err := s.mergeUpsertDiscoverEC2Task(installKey, emptyEC2Data(installKey))
+		require.ErrorContains(t, err, "at least one instance is required")
+		require.Empty(t, ap.tasks)
+	})
+
+	t.Run("permission issue updates existing task with empty instances", func(t *testing.T) {
+		existingTask := existingPermissionTask(t)
+		s, ap := newTaskUpdater(t, existingTask)
+
+		require.NoError(t, s.mergeUpsertDiscoverEC2Task(permissionKey, emptyEC2Data(permissionKey)))
+
+		upsertedTask, err := ap.GetUserTask(s.ctx, existingTask.GetMetadata().GetName())
+		require.NoError(t, err)
+		require.Empty(t, upsertedTask.GetSpec().GetDiscoverEc2().GetInstances())
+	})
+}
+
 func TestAzureVMTasks_AddFailedEnrollment(t *testing.T) {
 	t.Parallel()
 

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -32,6 +32,7 @@ import (
 
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/usertasks"
 	libcloudaws "github.com/gravitational/teleport/lib/cloud/aws"
 	awsregions "github.com/gravitational/teleport/lib/cloud/aws/regions"
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
@@ -226,6 +227,40 @@ func MatchersToEC2InstanceFetchers(ctx context.Context, matcherParams MatcherToE
 		ret = append(ret, fetcher)
 	}
 	return ret, nil
+}
+
+func (f *ec2InstanceFetcher) permissionErrorOrWarn(ctx context.Context, err error, region, assumeRoleARN string) error {
+	if len(EC2IAMPermissionErrors(err)) > 0 {
+		return trace.Wrap(err)
+	}
+
+	logAttrs := []any{
+		"assume_role_arn", assumeRoleARN,
+		"error", err,
+	}
+	if region != "" {
+		logAttrs = append(logAttrs, "region", region)
+	}
+
+	f.Logger.WarnContext(ctx, "Failed to discover EC2 instances", logAttrs...)
+	return nil
+}
+
+func (f *ec2InstanceFetcher) wrapEC2DiscoveryPermissionError(err error, issueType, assumeRoleARN, region string) error {
+	convertedErr := libcloudaws.ConvertRequestFailureError(err)
+	if !isEC2DiscoveryPermissionError(convertedErr) {
+		return trace.Wrap(convertedErr)
+	}
+
+	accountID := accountIDFromRoleARN(assumeRoleARN)
+	return trace.Wrap(&EC2IAMPermissionError{
+		Integration:         f.Matcher.Integration,
+		Region:              region,
+		IssueType:           issueType,
+		DiscoveryConfigName: f.DiscoveryConfigName,
+		AccountID:           accountID,
+		Err:                 convertedErr,
+	})
 }
 
 type ec2FetcherConfig struct {
@@ -460,6 +495,24 @@ func chunkInstances(instancesByRegion map[string]EC2Instances) []*EC2Instances {
 	return instColl
 }
 
+type matcherRegionsParams struct {
+	awsOpts       []awsconfig.OptionsFn
+	assumeRoleARN string
+}
+
+func (f *ec2InstanceFetcher) matcherRegions(ctx context.Context, params matcherRegionsParams) ([]string, error) {
+	if !f.Matcher.IsRegionWildcard() {
+		return f.Matcher.Regions, nil
+	}
+
+	regions, err := awsregions.ListEnabledRegions(ctx, f.RegionsListerGetter, params.awsOpts...)
+	if err != nil {
+		return nil, f.wrapEC2DiscoveryPermissionError(err, usertasks.AutoDiscoverEC2IssuePermAccountDenied, params.assumeRoleARN, "")
+	}
+
+	return regions, nil
+}
+
 func (f *ec2InstanceFetcher) fetchAccountIDsUnderOrganization(ctx context.Context) ([]string, error) {
 	awsOpts := []awsconfig.OptionsFn{
 		awsconfig.WithCredentialsMaybeIntegration(awsconfig.IntegrationMetadata{Name: f.Matcher.Integration}),
@@ -476,7 +529,7 @@ func (f *ec2InstanceFetcher) fetchAccountIDsUnderOrganization(ctx context.Contex
 
 	orgsClient, err := f.AWSOrganizationsGetter(ctx, awsOpts...)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, f.wrapEC2DiscoveryPermissionError(err, usertasks.AutoDiscoverEC2IssuePermOrgDenied, f.Matcher.AssumeRole.RoleARN, "")
 	}
 
 	accountIDs, err := organizations.MatchingAccounts(ctx, f.Logger, orgsClient, organizations.MatchingAccountsFilter{
@@ -485,13 +538,7 @@ func (f *ec2InstanceFetcher) fetchAccountIDsUnderOrganization(ctx context.Contex
 		OrganizationID: organizationID,
 	})
 	if err != nil {
-		convertedErr := libcloudaws.ConvertRequestFailureError(err)
-		if trace.IsAccessDenied(convertedErr) {
-			// TODO(marco): create UserTask to alert users about missing permissions.
-			return nil, trace.BadParameter("discovering instances under an organization requires the following permissions: [%s], add those to the IAM Role used by the Discovery Service", strings.Join(organizations.RequiredAPIs(), ", "))
-		}
-
-		return nil, trace.Wrap(convertedErr)
+		return nil, f.wrapEC2DiscoveryPermissionError(err, usertasks.AutoDiscoverEC2IssuePermOrgDenied, f.Matcher.AssumeRole.RoleARN, "")
 	}
 
 	return accountIDs, nil
@@ -557,6 +604,7 @@ func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([
 
 	f.cachedInstances.clear()
 	var allInstances []*EC2Instances
+	var permissionErrors []error
 
 	accountRolesToAssume, err := f.allAssumeRoles(ctx)
 	if err != nil {
@@ -569,16 +617,15 @@ func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([
 			awsconfig.WithAssumeRole(assumeRole.RoleARN, assumeRole.ExternalID),
 		}
 
-		regions := f.Matcher.Regions
-		if f.Matcher.IsRegionWildcard() {
-			regions, err = awsregions.ListEnabledRegions(ctx, f.RegionsListerGetter, awsOpts...)
-			if err != nil {
-				f.Logger.WarnContext(ctx, "Failed to get regions for EC2 discovery",
-					"assume_role_arn", assumeRole.RoleARN,
-					"error", err,
-				)
-				continue
-			}
+		regions, err := f.matcherRegions(ctx, matcherRegionsParams{
+			awsOpts:       awsOpts,
+			assumeRoleARN: assumeRole.RoleARN,
+		})
+		if err != nil {
+			permissionErrors = append(permissionErrors,
+				f.permissionErrorOrWarn(ctx, err, "", assumeRole.RoleARN),
+			)
+			continue
 		}
 
 		for _, region := range regions {
@@ -590,10 +637,8 @@ func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([
 				ssmRunParams: ssmRunParams,
 			})
 			if err != nil {
-				f.Logger.WarnContext(ctx, "Failed to get instances for EC2 discovery",
-					"region", region,
-					"assume_role_arn", assumeRole.RoleARN,
-					"error", err,
+				permissionErrors = append(permissionErrors,
+					f.permissionErrorOrWarn(ctx, err, region, assumeRole.RoleARN),
 				)
 				continue
 			}
@@ -602,11 +647,15 @@ func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([
 		}
 	}
 
+	permissionErr := trace.NewAggregate(permissionErrors...)
 	if len(allInstances) == 0 {
+		if permissionErr != nil {
+			return nil, trace.Wrap(permissionErr)
+		}
 		return nil, trace.NotFound("no ec2 instances found")
 	}
 
-	return allInstances, nil
+	return allInstances, trace.Wrap(permissionErr)
 }
 
 type getInstancesInRegionParams struct {
@@ -621,7 +670,7 @@ type getInstancesInRegionParams struct {
 func (f *ec2InstanceFetcher) getInstancesInRegion(ctx context.Context, params getInstancesInRegionParams) ([]*EC2Instances, error) {
 	ec2Client, err := f.EC2ClientGetter(ctx, params.region, params.awsOpts...)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, f.wrapEC2DiscoveryPermissionError(err, usertasks.AutoDiscoverEC2IssuePermAccountDenied, params.assumeRole.RoleARN, params.region)
 	}
 
 	var instances []*EC2Instances
@@ -633,7 +682,7 @@ func (f *ec2InstanceFetcher) getInstancesInRegion(ctx context.Context, params ge
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			return nil, libcloudaws.ConvertRequestFailureError(err)
+			return nil, f.wrapEC2DiscoveryPermissionError(err, usertasks.AutoDiscoverEC2IssuePermAccountDenied, params.assumeRole.RoleARN, params.region)
 		}
 
 		pageInstancesPerOwnerID := make(map[string][]ec2types.Instance)

--- a/lib/srv/server/ec2_watcher_test.go
+++ b/lib/srv/server/ec2_watcher_test.go
@@ -32,12 +32,14 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
 	organizationtypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/usertasks"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	liborganizations "github.com/gravitational/teleport/lib/utils/aws/organizations"
@@ -45,10 +47,15 @@ import (
 )
 
 type mockEC2Client struct {
-	output *ec2.DescribeInstancesOutput
+	output        *ec2.DescribeInstancesOutput
+	responseError error
 }
 
 func (m *mockEC2Client) DescribeInstances(ctx context.Context, input *ec2.DescribeInstancesInput, opts ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	if m.responseError != nil {
+		return nil, m.responseError
+	}
+
 	var output ec2.DescribeInstancesOutput
 	for _, res := range m.output.Reservations {
 		var instances []ec2types.Instance
@@ -82,6 +89,7 @@ type mockOrganizationsClient struct {
 	organizationID string
 	rootOUID       string
 	ouItems        map[string]ouItem
+	responseError  error
 }
 
 type ouItem struct {
@@ -91,6 +99,9 @@ type ouItem struct {
 }
 
 func (m *mockOrganizationsClient) ListChildren(ctx context.Context, input *organizations.ListChildrenInput, opts ...func(*organizations.Options)) (*organizations.ListChildrenOutput, error) {
+	if m.responseError != nil {
+		return nil, m.responseError
+	}
 	if input.ChildType != organizationtypes.ChildTypeOrganizationalUnit {
 		return nil, trace.NotImplemented("unexpected call to organizations.ListChildren, with ChildType != OU")
 	}
@@ -113,6 +124,9 @@ func (m *mockOrganizationsClient) ListChildren(ctx context.Context, input *organ
 }
 
 func (m *mockOrganizationsClient) ListRoots(ctx context.Context, input *organizations.ListRootsInput, opts ...func(*organizations.Options)) (*organizations.ListRootsOutput, error) {
+	if m.responseError != nil {
+		return nil, m.responseError
+	}
 	rootARN := fmt.Sprintf("arn:aws:organizations::0000000000:root/%s/%s", m.organizationID, m.rootOUID)
 	return &organizations.ListRootsOutput{
 		Roots: []organizationtypes.Root{
@@ -125,6 +139,9 @@ func (m *mockOrganizationsClient) ListRoots(ctx context.Context, input *organiza
 }
 
 func (m *mockOrganizationsClient) ListAccountsForParent(ctx context.Context, input *organizations.ListAccountsForParentInput, opts ...func(*organizations.Options)) (*organizations.ListAccountsForParentOutput, error) {
+	if m.responseError != nil {
+		return nil, m.responseError
+	}
 	ouItem, ok := m.ouItems[*input.ParentId]
 	if !ok {
 		return nil, trace.NotFound("OU %s does not exist", *input.ParentId)
@@ -472,18 +489,21 @@ func TestEC2Watcher(t *testing.T) {
 		},
 	}
 
-	for _, instances := range expectedInstances {
+	var gotInstances []*EC2Instances
+	for len(gotInstances) < len(expectedInstances) {
 		select {
-		case result := <-watcher.InstancesC:
-			require.Equal(t, instances, result)
+		case instances := <-watcher.InstancesC:
+			require.NotNil(t, instances)
+			gotInstances = append(gotInstances, instances)
 		case <-t.Context().Done():
 			require.Fail(t, "context canceled")
 		}
 	}
+	require.ElementsMatch(t, expectedInstances, gotInstances)
 
 	select {
-	case inst := <-watcher.InstancesC:
-		require.Fail(t, "unexpected instance: %v", inst)
+	case result := <-watcher.InstancesC:
+		require.Fail(t, "unexpected result: %v", result)
 	default:
 	}
 }
@@ -571,8 +591,9 @@ func TestEC2WatcherMergesReservationInstances(t *testing.T) {
 		}
 
 		select {
-		case result := <-watcher.InstancesC:
-			require.Equal(t, expectedInstances, result)
+		case instances := <-watcher.InstancesC:
+			require.NotNil(t, instances)
+			require.Equal(t, expectedInstances, instances)
 		case <-t.Context().Done():
 			require.Fail(t, "context canceled")
 		}
@@ -605,8 +626,8 @@ func TestEC2WatcherMergesReservationInstances(t *testing.T) {
 		var gotInstances []*EC2Instances
 
 		synctest.Test(t, func(t *testing.T) {
-			watcher := NewWatcher(t.Context(), logtest.NewLogger(), WithPerInstanceHookFn(func(groups []*EC2Instances) {
-				gotInstances = append(gotInstances, groups...)
+			watcher := NewWatcher(t.Context(), logtest.NewLogger(), WithPerInstanceHookFn(func(results []*EC2Instances) {
+				gotInstances = append(gotInstances, results...)
 			}))
 			watcher.SetFetchers(noDiscoveryConfig, fetchers)
 			go watcher.Run()
@@ -630,6 +651,398 @@ func TestEC2WatcherMergesReservationInstances(t *testing.T) {
 
 		require.ElementsMatch(t, expectedInstances, gotInstances)
 	})
+}
+
+func TestEC2WatcherOrganizationAccessDeniedReturnsPermissionError(t *testing.T) {
+	t.Parallel()
+
+	const (
+		discoveryConfigName = "dc-org"
+		integrationName     = "aws-integration"
+		organizationID      = "o-abcdefghij"
+		roleARN             = "arn:aws:iam::123456789012:role/OrganizationReader"
+	)
+
+	matchers := []types.AWSMatcher{
+		{
+			Params: &types.InstallerParams{
+				InstallTeleport: true,
+			},
+			Types:       []string{"ec2"},
+			Regions:     []string{"us-west-2"},
+			Tags:        map[string]utils.Strings{"teleport": {"yes"}},
+			Integration: integrationName,
+			SSM:         &types.AWSSSM{},
+			AssumeRole: &types.AssumeRole{
+				RoleARN:  roleARN,
+				RoleName: "OrganizationReader",
+			},
+			Organization: &types.AWSOrganizationMatcher{
+				OrganizationID: organizationID,
+				OrganizationalUnits: &types.AWSOrganizationUnitsMatcher{
+					Include: []string{types.Wildcard},
+				},
+			},
+		},
+	}
+
+	fetchers, err := MatchersToEC2InstanceFetchers(t.Context(), MatcherToEC2FetcherParams{
+		Matchers: matchers,
+		PublicProxyAddrGetter: func(ctx context.Context) (string, error) {
+			return "proxy.example.com:3080", nil
+		},
+		EC2ClientGetter: func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+			return nil, errors.New("EC2 client getter must not be called when org listing fails")
+		},
+		AWSOrganizationsGetter: func(ctx context.Context, opts ...awsconfig.OptionsFn) (liborganizations.OrganizationsClient, error) {
+			return &mockOrganizationsClient{
+				responseError: trace.AccessDenied("organizations denied"),
+			}, nil
+		},
+		DiscoveryConfigName: discoveryConfigName,
+	})
+	require.NoError(t, err)
+	require.Len(t, fetchers, 1)
+
+	results, err := fetchers[0].GetInstances(t.Context(), false)
+	require.Error(t, err)
+	require.Empty(t, results)
+
+	permissionErrors := EC2IAMPermissionErrors(err)
+	require.Len(t, permissionErrors, 1)
+
+	permErr := permissionErrors[0]
+	require.Equal(t, integrationName, permErr.Integration)
+	require.Equal(t, usertasks.AutoDiscoverEC2IssuePermOrgDenied, permErr.IssueType)
+	require.Equal(t, discoveryConfigName, permErr.DiscoveryConfigName)
+	require.Equal(t, "123456789012", permErr.AccountID)
+	require.Empty(t, permErr.Region)
+	require.True(t, trace.IsAccessDenied(permErr.Err))
+}
+
+func TestEC2WatcherOrganizationClientCreationPermissionErrorReturnsPermissionError(t *testing.T) {
+	t.Parallel()
+
+	const (
+		discoveryConfigName = "dc-org-client"
+		integrationName     = "aws-integration"
+		organizationID      = "o-abcdefghij"
+		roleARN             = "arn:aws:iam::123456789012:role/OrganizationReader"
+	)
+
+	for _, tt := range []struct {
+		name     string
+		err      error
+		checkErr func(*testing.T, error)
+	}{
+		{
+			name: "access denied",
+			err:  trace.AccessDenied("organizations client denied"),
+			checkErr: func(t *testing.T, err error) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name: "invalid identity token",
+			err: fmt.Errorf("failed to retrieve credentials: %w", &ststypes.InvalidIdentityTokenException{
+				Message: aws.String("No OpenIDConnect provider found"),
+			}),
+			checkErr: func(t *testing.T, err error) {
+				require.ErrorAs(t, err, new(*ststypes.InvalidIdentityTokenException))
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			matchers := []types.AWSMatcher{
+				{
+					Params: &types.InstallerParams{
+						InstallTeleport: true,
+					},
+					Types:       []string{"ec2"},
+					Regions:     []string{"us-west-2"},
+					Tags:        map[string]utils.Strings{"teleport": {"yes"}},
+					Integration: integrationName,
+					SSM:         &types.AWSSSM{},
+					AssumeRole: &types.AssumeRole{
+						RoleARN:  roleARN,
+						RoleName: "OrganizationReader",
+					},
+					Organization: &types.AWSOrganizationMatcher{
+						OrganizationID: organizationID,
+						OrganizationalUnits: &types.AWSOrganizationUnitsMatcher{
+							Include: []string{types.Wildcard},
+						},
+					},
+				},
+			}
+
+			fetchers, err := MatchersToEC2InstanceFetchers(t.Context(), MatcherToEC2FetcherParams{
+				Matchers: matchers,
+				PublicProxyAddrGetter: func(ctx context.Context) (string, error) {
+					return "proxy.example.com:3080", nil
+				},
+				EC2ClientGetter: func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+					return nil, errors.New("EC2 client getter must not be called when org client creation fails")
+				},
+				AWSOrganizationsGetter: func(ctx context.Context, opts ...awsconfig.OptionsFn) (liborganizations.OrganizationsClient, error) {
+					return nil, tt.err
+				},
+				DiscoveryConfigName: discoveryConfigName,
+			})
+			require.NoError(t, err)
+			require.Len(t, fetchers, 1)
+
+			results, err := fetchers[0].GetInstances(t.Context(), false)
+			require.Error(t, err)
+			require.Empty(t, results)
+
+			permissionErrors := EC2IAMPermissionErrors(err)
+			require.Len(t, permissionErrors, 1)
+
+			permErr := permissionErrors[0]
+			require.Equal(t, integrationName, permErr.Integration)
+			require.Equal(t, usertasks.AutoDiscoverEC2IssuePermOrgDenied, permErr.IssueType)
+			require.Equal(t, discoveryConfigName, permErr.DiscoveryConfigName)
+			require.Equal(t, "123456789012", permErr.AccountID)
+			require.Empty(t, permErr.Region)
+			tt.checkErr(t, permErr.Err)
+		})
+	}
+}
+
+func TestEC2WatcherListRegionsAccessDeniedReturnsPermissionError(t *testing.T) {
+	t.Parallel()
+
+	const (
+		discoveryConfigName = "dc-regions"
+		integrationName     = "aws-integration"
+		roleARN             = "arn:aws:iam::123456789012:role/Discovery"
+	)
+
+	matchers := []types.AWSMatcher{
+		{
+			Params: &types.InstallerParams{
+				InstallTeleport: true,
+			},
+			Types:       []string{"ec2"},
+			Regions:     []string{types.Wildcard},
+			Tags:        map[string]utils.Strings{"teleport": {"yes"}},
+			Integration: integrationName,
+			SSM:         &types.AWSSSM{},
+			AssumeRole: &types.AssumeRole{
+				RoleARN: roleARN,
+			},
+		},
+	}
+
+	fetchers, err := MatchersToEC2InstanceFetchers(t.Context(), MatcherToEC2FetcherParams{
+		Matchers: matchers,
+		PublicProxyAddrGetter: func(ctx context.Context) (string, error) {
+			return "proxy.example.com:3080", nil
+		},
+		EC2ClientGetter: func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+			return nil, errors.New("EC2 client getter must not be called when region listing fails")
+		},
+		RegionsListerGetter: func(ctx context.Context, opts ...awsconfig.OptionsFn) (account.ListRegionsAPIClient, error) {
+			return &mockAWSAccountClient{
+				responseError: trace.AccessDenied("account regions denied"),
+			}, nil
+		},
+		DiscoveryConfigName: discoveryConfigName,
+	})
+	require.NoError(t, err)
+	require.Len(t, fetchers, 1)
+
+	results, err := fetchers[0].GetInstances(t.Context(), false)
+	require.Error(t, err)
+	require.Empty(t, results)
+
+	permissionErrors := EC2IAMPermissionErrors(err)
+	require.Len(t, permissionErrors, 1)
+
+	permErr := permissionErrors[0]
+	require.Equal(t, integrationName, permErr.Integration)
+	require.Equal(t, usertasks.AutoDiscoverEC2IssuePermAccountDenied, permErr.IssueType)
+	require.Equal(t, discoveryConfigName, permErr.DiscoveryConfigName)
+	require.Equal(t, "123456789012", permErr.AccountID)
+	require.Empty(t, permErr.Region)
+	require.True(t, trace.IsAccessDenied(permErr.Err))
+}
+
+func TestEC2WatcherDescribeInstancesAccessDeniedReturnsPermissionErrorAndPartialResults(t *testing.T) {
+	t.Parallel()
+
+	const (
+		discoveryConfigName = "dc-describe"
+		integrationName     = "aws-integration"
+		roleARN             = "arn:aws:iam::123456789012:role/Discovery"
+	)
+
+	matchers := []types.AWSMatcher{
+		{
+			Params: &types.InstallerParams{
+				InstallTeleport: true,
+			},
+			Types:       []string{"ec2"},
+			Regions:     []string{"us-west-2", "us-east-1"},
+			Tags:        map[string]utils.Strings{"teleport": {"yes"}},
+			Integration: integrationName,
+			SSM:         &types.AWSSSM{},
+			AssumeRole: &types.AssumeRole{
+				RoleARN: roleARN,
+			},
+		},
+	}
+
+	discoveredInstance := ec2types.Instance{
+		InstanceId: aws.String("instance-present"),
+		Tags: []ec2types.Tag{
+			{
+				Key:   aws.String("teleport"),
+				Value: aws.String("yes"),
+			},
+		},
+		State: &ec2types.InstanceState{
+			Name: ec2types.InstanceStateNameRunning,
+		},
+	}
+
+	fetchers, err := MatchersToEC2InstanceFetchers(t.Context(), MatcherToEC2FetcherParams{
+		Matchers: matchers,
+		PublicProxyAddrGetter: func(ctx context.Context) (string, error) {
+			return "proxy.example.com:3080", nil
+		},
+		EC2ClientGetter: func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+			if region == "us-west-2" {
+				return &mockEC2Client{
+					responseError: trace.AccessDenied("describe instances denied"),
+				}, nil
+			}
+			return &mockEC2Client{
+				output: &ec2.DescribeInstancesOutput{
+					Reservations: []ec2types.Reservation{
+						{
+							OwnerId:   aws.String("123456789012"),
+							Instances: []ec2types.Instance{discoveredInstance},
+						},
+					},
+				},
+			}, nil
+		},
+		DiscoveryConfigName: discoveryConfigName,
+	})
+	require.NoError(t, err)
+	require.Len(t, fetchers, 1)
+
+	results, err := fetchers[0].GetInstances(t.Context(), false)
+	require.Error(t, err)
+
+	permissionErrors := EC2IAMPermissionErrors(err)
+	require.Len(t, permissionErrors, 1)
+
+	permErr := permissionErrors[0]
+	require.Equal(t, integrationName, permErr.Integration)
+	require.Equal(t, usertasks.AutoDiscoverEC2IssuePermAccountDenied, permErr.IssueType)
+	require.Equal(t, discoveryConfigName, permErr.DiscoveryConfigName)
+	require.Equal(t, "123456789012", permErr.AccountID)
+	require.Equal(t, "us-west-2", permErr.Region)
+	require.True(t, trace.IsAccessDenied(permErr.Err))
+
+	require.Len(t, results, 1)
+	require.Equal(t, &EC2Instances{
+		AccountID:           "123456789012",
+		Region:              "us-east-1",
+		DocumentName:        "",
+		Instances:           []EC2Instance{toEC2Instance(discoveredInstance)},
+		Parameters:          map[string]string{"token": "", "scriptName": ""},
+		Integration:         integrationName,
+		AssumeRoleARN:       roleARN,
+		DiscoveryConfigName: discoveryConfigName,
+	}, results[0])
+}
+
+func TestEC2WatcherClientCreationPermissionErrorReturnsPermissionError(t *testing.T) {
+	t.Parallel()
+
+	const (
+		discoveryConfigName = "dc-client"
+		integrationName     = "aws-integration"
+		roleARN             = "arn:aws:iam::123456789012:role/Discovery"
+		region              = "us-west-2"
+	)
+
+	for _, tt := range []struct {
+		name     string
+		err      error
+		checkErr func(*testing.T, error)
+	}{
+		{
+			name: "access denied",
+			err:  trace.AccessDenied("ec2 client denied"),
+			checkErr: func(t *testing.T, err error) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name: "invalid identity token",
+			err: fmt.Errorf("failed to retrieve credentials: %w", &ststypes.InvalidIdentityTokenException{
+				Message: aws.String("No OpenIDConnect provider found"),
+			}),
+			checkErr: func(t *testing.T, err error) {
+				require.ErrorAs(t, err, new(*ststypes.InvalidIdentityTokenException))
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			matchers := []types.AWSMatcher{
+				{
+					Params: &types.InstallerParams{
+						InstallTeleport: true,
+					},
+					Types:       []string{"ec2"},
+					Regions:     []string{region},
+					Tags:        map[string]utils.Strings{"teleport": {"yes"}},
+					Integration: integrationName,
+					SSM:         &types.AWSSSM{},
+					AssumeRole: &types.AssumeRole{
+						RoleARN: roleARN,
+					},
+				},
+			}
+
+			fetchers, err := MatchersToEC2InstanceFetchers(t.Context(), MatcherToEC2FetcherParams{
+				Matchers: matchers,
+				PublicProxyAddrGetter: func(ctx context.Context) (string, error) {
+					return "proxy.example.com:3080", nil
+				},
+				EC2ClientGetter: func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+					return nil, tt.err
+				},
+				DiscoveryConfigName: discoveryConfigName,
+			})
+			require.NoError(t, err)
+			require.Len(t, fetchers, 1)
+
+			results, err := fetchers[0].GetInstances(t.Context(), false)
+			require.Error(t, err)
+			require.Empty(t, results)
+
+			permissionErrors := EC2IAMPermissionErrors(err)
+			require.Len(t, permissionErrors, 1)
+
+			permErr := permissionErrors[0]
+			require.Equal(t, integrationName, permErr.Integration)
+			require.Equal(t, usertasks.AutoDiscoverEC2IssuePermAccountDenied, permErr.IssueType)
+			require.Equal(t, discoveryConfigName, permErr.DiscoveryConfigName)
+			require.Equal(t, "123456789012", permErr.AccountID)
+			require.Equal(t, region, permErr.Region)
+			tt.checkErr(t, permErr.Err)
+		})
+	}
 }
 
 func TestEC2WatcherWithMultipleAccounts(t *testing.T) {
@@ -749,7 +1162,7 @@ func TestEC2WatcherWithMultipleAccounts(t *testing.T) {
 
 	go watcher.Run()
 
-	expectedInstances := []EC2Instances{
+	expectedInstances := []*EC2Instances{
 		{
 			Region:        "us-west-2",
 			Instances:     []EC2Instance{toEC2Instance(instance01Account01)},
@@ -764,19 +1177,21 @@ func TestEC2WatcherWithMultipleAccounts(t *testing.T) {
 		},
 	}
 
-	for _, instances := range expectedInstances {
+	var gotInstances []*EC2Instances
+	for len(gotInstances) < len(expectedInstances) {
 		select {
-		case result := <-watcher.InstancesC:
-			require.NotNil(t, result)
-			require.Equal(t, instances, *result)
+		case instances := <-watcher.InstancesC:
+			require.NotNil(t, instances)
+			gotInstances = append(gotInstances, instances)
 		case <-t.Context().Done():
 			require.Fail(t, "context canceled")
 		}
 	}
+	require.ElementsMatch(t, expectedInstances, gotInstances)
 
 	select {
-	case inst := <-watcher.InstancesC:
-		require.Fail(t, "unexpected instance: %v", inst)
+	case result := <-watcher.InstancesC:
+		require.Fail(t, "unexpected result: %v", result)
 	default:
 	}
 }

--- a/lib/srv/server/errors.go
+++ b/lib/srv/server/errors.go
@@ -1,0 +1,111 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package server
+
+import (
+	"errors"
+	"fmt"
+
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"github.com/gravitational/trace"
+
+	utilsaws "github.com/gravitational/teleport/lib/utils/aws"
+)
+
+// EC2IAMPermissionError is a structured IAM permission error from EC2 discovery.
+type EC2IAMPermissionError struct {
+	// Integration is the AWS integration used by discovery.
+	Integration string
+	// AccountID is the AWS account ID associated with the permission error.
+	AccountID string
+	// Region is the AWS region associated with the permission error, if known.
+	Region string
+	// IssueType is the UserTask issue type for the permission error.
+	IssueType string
+	// DiscoveryConfigName is the DiscoveryConfig name that produced the permission error.
+	DiscoveryConfigName string
+	// Err is the underlying AWS or Teleport error.
+	Err error
+}
+
+// Error formats the permission error as a human-readable string, including the
+// integration and region (if set), issue type, account ID, and underlying error.
+func (e *EC2IAMPermissionError) Error() string {
+	integrationPrefix := ""
+	if e.Integration != "" {
+		integrationPrefix = fmt.Sprintf("integration %s: ", e.Integration)
+	}
+
+	if e.Region != "" {
+		return fmt.Sprintf("%sIAM permission error (%s) for account %s in region %s: %v",
+			integrationPrefix, e.IssueType, e.AccountID, e.Region, e.Err)
+	}
+
+	return fmt.Sprintf("%sIAM permission error (%s) for account %s: %v",
+		integrationPrefix, e.IssueType, e.AccountID, e.Err)
+}
+
+// Unwrap returns the underlying error that triggered the permission failure.
+// This is typically an AWS SDK request error.
+func (e *EC2IAMPermissionError) Unwrap() error {
+	return e.Err
+}
+
+// EC2IAMPermissionErrors returns EC2 IAM permission errors found in err.
+func EC2IAMPermissionErrors(err error) []*EC2IAMPermissionError {
+	if err == nil {
+		return nil
+	}
+
+	var aggregate trace.Aggregate
+	if errors.As(err, &aggregate) {
+		var permissionErrors []*EC2IAMPermissionError
+		for _, err := range aggregate.Errors() {
+			permissionErrors = append(permissionErrors, EC2IAMPermissionErrors(err)...)
+		}
+		return permissionErrors
+	}
+
+	var permissionError *EC2IAMPermissionError
+	if errors.As(err, &permissionError) {
+		return []*EC2IAMPermissionError{permissionError}
+	}
+
+	return nil
+}
+
+func isEC2DiscoveryPermissionError(err error) bool {
+	if trace.IsAccessDenied(err) {
+		return true
+	}
+
+	var invalidIdentityTokenErr *ststypes.InvalidIdentityTokenException
+	return errors.As(err, &invalidIdentityTokenErr)
+}
+
+// accountIDFromRoleARN extracts the AWS account ID from a role ARN.
+// It returns "unknown" when the account ID cannot be determined.
+func accountIDFromRoleARN(roleARN string) string {
+	parsed, err := utilsaws.ParseRoleARN(roleARN)
+	if err != nil {
+		return "unknown"
+	}
+
+	return parsed.AccountID
+}

--- a/lib/srv/server/watcher.go
+++ b/lib/srv/server/watcher.go
@@ -92,6 +92,25 @@ func WithPerInstanceHookFn[Instances InstanceGroup](callback func(groups []Insta
 	}
 }
 
+// WithFetchErrorHookFn sets a callback for errors returned by fetchers.
+// The callback returns whether the error was handled and should not be logged by
+// the watcher.
+func WithFetchErrorHookFn[Instances InstanceGroup](callback func(error) bool) Option[Instances] {
+	return func(w *Watcher[Instances]) {
+		if callback == nil {
+			return
+		}
+
+		defaultFetchErrorHookFn := w.fetchErrorHookFn
+		w.fetchErrorHookFn = func(err error) bool {
+			if callback(err) {
+				return true
+			}
+			return defaultFetchErrorHookFn(err)
+		}
+	}
+}
+
 // WithPostFetchHookFn sets an optional callback to be called after the fetch round is finished.
 func WithPostFetchHookFn[Instances InstanceGroup](f func()) Option[Instances] {
 	return func(w *Watcher[Instances]) {
@@ -137,6 +156,7 @@ type Watcher[Instances InstanceGroup] struct {
 	postFetchHookFn    func()
 	triggerFetchHookFn func()
 	perInstanceHookFn  func(instances []Instances)
+	fetchErrorHookFn   func(error) bool
 }
 
 // NewWatcher initializes a new instance of Watcher.
@@ -165,6 +185,13 @@ func NewWatcher[Instances InstanceGroup](ctx context.Context, logger *slog.Logge
 			}
 		}
 	}
+	watcher.fetchErrorHookFn = func(err error) bool {
+		if trace.IsNotFound(err) {
+			return false
+		}
+		watcher.logger.ErrorContext(watcher.ctx, "Failed to fetch instances", "error", err)
+		return false
+	}
 
 	for _, opt := range opts {
 		opt(&watcher)
@@ -187,14 +214,11 @@ func (w *Watcher[Instances]) ReplaceFetchers(replaceMap map[string][]Fetcher[Ins
 	w.fetcherMap.Set(replaceMap)
 }
 
-func (w *Watcher[Instances]) sendInstancesOrLogError(instancesColl []Instances, err error) {
-	if err != nil {
-		if trace.IsNotFound(err) {
-			return
-		}
-		w.logger.ErrorContext(w.ctx, "Failed to fetch instances", "error", err)
+func (w *Watcher[Instances]) handleFetchResult(instancesColl []Instances, err error) {
+	if err != nil && !w.fetchErrorHookFn(err) {
 		return
 	}
+
 	w.logger.DebugContext(w.ctx, "Processing instance groups", "total_groups", len(instancesColl))
 	w.perInstanceHookFn(instancesColl)
 }
@@ -222,7 +246,7 @@ func (w *Watcher[Instances]) fetchAndSubmit() {
 			"current_fetcher", i+1,
 			"total_fetchers", len(fetchers),
 		)
-		w.sendInstancesOrLogError(fetcher.GetInstances(w.ctx, false))
+		w.handleFetchResult(fetcher.GetInstances(w.ctx, false))
 	}
 
 	if w.postFetchHookFn != nil {
@@ -247,7 +271,7 @@ func (w *Watcher[Instances]) Run() {
 			fetchers := slices.Concat(slices.Collect(maps.Values(cloned))...)
 
 			for _, fetcher := range fetchers {
-				w.sendInstancesOrLogError(fetcher.GetMatchingInstances(w.ctx, insts, true))
+				w.handleFetchResult(fetcher.GetMatchingInstances(w.ctx, insts, true))
 			}
 
 		case <-pollTimer.Chan():

--- a/lib/srv/server/watcher_test.go
+++ b/lib/srv/server/watcher_test.go
@@ -47,7 +47,7 @@ type mockFetcher struct {
 
 func (m *mockFetcher) GetInstances(ctx context.Context, rotation bool) ([]mockInstance, error) {
 	if m.err != nil {
-		return nil, m.err
+		return m.instances, m.err
 	}
 	return m.instances, nil
 }
@@ -69,6 +69,41 @@ func (m *mockFetcher) LogValue() slog.Value {
 		slog.Any("instances", m.instances),
 		slog.Any("error", m.err),
 	)
+}
+
+type captureLogHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *captureLogHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (h *captureLogHandler) Handle(_ context.Context, record slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, record.Clone())
+	return nil
+}
+
+func (h *captureLogHandler) WithAttrs([]slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *captureLogHandler) WithGroup(string) slog.Handler {
+	return h
+}
+
+func (h *captureLogHandler) hasMessage(message string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, record := range h.records {
+		if record.Message == message {
+			return true
+		}
+	}
+	return false
 }
 
 func TestWatcherFetchAndSubmit(t *testing.T) {
@@ -115,6 +150,18 @@ func TestWatcherFetchAndSubmit(t *testing.T) {
 				},
 			},
 			expectedIDs: []string{"good"},
+		},
+		{
+			name: "fetcher with unhandled error does not send instances",
+			fetchers: map[string][]Fetcher[mockInstance]{
+				"dc1": {
+					&mockFetcher{
+						instances: []mockInstance{{ID: "bad"}},
+						err:       trace.BadParameter("fail"),
+					},
+				},
+			},
+			expectedIDs: nil,
 		},
 		{
 			name: "fetcher with NotFound error silent",
@@ -167,6 +214,66 @@ func TestWatcherFetchAndSubmit(t *testing.T) {
 			assert.ElementsMatch(t, tt.expectedIDs, ids)
 		})
 	}
+}
+
+func TestWatcherFetchErrorHookHandlesPartialResults(t *testing.T) {
+	t.Parallel()
+
+	fetchErr := trace.BadParameter("partial failure")
+	var gotErr error
+	var gotInstances []mockInstance
+
+	w := NewWatcher[mockInstance](t.Context(), logtest.NewLogger(),
+		WithFetchErrorHookFn[mockInstance](func(err error) bool {
+			gotErr = err
+			return true
+		}),
+		WithPerInstanceHookFn[mockInstance](func(instances []mockInstance) {
+			gotInstances = append(gotInstances, instances...)
+		}),
+	)
+	w.SetFetchers("dc1", []Fetcher[mockInstance]{
+		&mockFetcher{
+			instances: []mockInstance{{ID: "partial"}},
+			err:       fetchErr,
+		},
+	})
+
+	w.fetchAndSubmit()
+
+	assert.Equal(t, fetchErr, gotErr)
+	assert.Equal(t, []mockInstance{{ID: "partial"}}, gotInstances)
+}
+
+func TestWatcherFetchErrorHookFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+
+	fetchErr := trace.BadParameter("failure")
+	var gotErr error
+	var gotInstances []mockInstance
+	logHandler := &captureLogHandler{}
+
+	w := NewWatcher[mockInstance](t.Context(), slog.New(logHandler),
+		WithFetchErrorHookFn[mockInstance](func(err error) bool {
+			gotErr = err
+			return false
+		}),
+		WithPerInstanceHookFn[mockInstance](func(instances []mockInstance) {
+			gotInstances = append(gotInstances, instances...)
+		}),
+	)
+	w.SetFetchers("dc1", []Fetcher[mockInstance]{
+		&mockFetcher{
+			instances: []mockInstance{{ID: "partial"}},
+			err:       fetchErr,
+		},
+	})
+
+	w.fetchAndSubmit()
+
+	assert.Equal(t, fetchErr, gotErr)
+	assert.Empty(t, gotInstances)
+	assert.True(t, logHandler.hasMessage("Failed to fetch instances"))
 }
 
 func TestWatcherRunLoop(t *testing.T) {


### PR DESCRIPTION
Fixes #62828

Changelog: Surface EC2 auto-discovery IAM permission errors as UserTasks.

## What this does
  
This PR ports the behavior from #64004 onto the current watcher architecture on master. Instead of adding a `WithPerInstanceTapFn` that observes EC2 instance results before normal forwarding, this version uses the existing `WithPerInstanceHookFn` path. The hook is responsible for handling the full fetch result, so EC2 discovery now returns `EC2DiscoveryResult`, which carries both discovered instance groups and non-fatal IAM permission errors.

For integration-backed EC2 auto-discovery, access-denied errors during discovery are returned as structured results instead of failing the whole watcher result:

- `ec2:DescribeInstances` denied for a region -> `ec2-perm-account-denied` with that region.
- `account:ListRegions` denied for `regions: ["*"]` -> `ec2-perm-account-denied` with no region.
- AWS Organizations listing denied -> `ec2-perm-org-denied` with no region.

Successful regions/accounts continue to be processed, so one denied region can produce a task while accessible regions still discover instances.

Permission failures use the existing Discover EC2 UserTask merge/upsert path. Permission tasks have no instance data, so validation and upsert now allow empty instances for permission issue types and avoid merging stale instance entries into those tasks.

## Relationship to #64004

#64004 implemented the same end-user behavior in the earlier watcher shape. This PR keeps that behavior but adapts it to the V2 architecture:

- Uses `EC2DiscoveryResult` to carry both discovered EC2 instance groups and IAM permission errors.
- Uses `WithPerInstanceHookFn`, replacing the `WithPerInstanceTapFn` approach from #64004 per review feedback.
- Does not add/use `KeyedLimiter`. Permission errors are logged on every poll, and deduplication happens at the UserTask layer through deterministic task names and the existing semaphore-protected merge/upsert path.
- Permission task grouping excludes `DiscoveryConfigName`, so multiple discovery configs using the same credential scope collapse into the same task.

## Manual Test Plan

### Test Environment

Tested against https://mpmonboarding.cloud.gravitational.io/ using a real AWS OIDC integration and live Discovery Service polling against AWS.

### Test Cases

- [x] Happy path: with full permissions, EC2 discovery ran without creating `ec2-perm-*` UserTasks.
- [x] Denied `ec2:DescribeInstances`: created an `ec2-perm-account-denied` task for the denied region; repeated polls kept the synthetic account ID stable.
- [x] Denied `account:ListRegions` with `regions: ["*"]`: created an `ec2-perm-account-denied` task with no region field, validating the relaxed permission-task validation path.
- [x] Organization matcher from a non-delegated-admin member account: AWS blocked Organizations APIs naturally and Teleport created an `ec2-perm-org-denied` task without needing an IAM deny policy.
- [x] Partial regional failure: with two tagged instances in different regions and `DescribeInstances` denied in only one region, the accessible region continued discovering instances while the denied region produced a permission task.
- [x] Unscoped deny across all 24 enumerable regions: let several poll cycles run with per-poll logging and no suppression; two backend Discovery Service replicas independently logged the same failures, and UserTasks deduplicated to exactly 24 tasks, one per region, not 48.
- [x] Recovery/expiry: removed the deny and confirmed all 24 tasks eventually cleared via TTL. Clearing 24 tasks lagged noticeably behind nominal expiry (~12+ minutes) compared with a single task (~9 minutes); noted as an observation, not a blocker.
- [x] Reproduced EC2 client creation credential failure with AWS OIDC integration: temporarily removed the AWS IAM OIDC provider so STS `AssumeRoleWithWebIdentity` failed before `DescribeInstances`; verified Teleport created an `ec2-perm-account-denied` UserTask with the expected integration, synthetic account ID, and explicit region.
- [x] Reproduced AWS Organizations client creation credential failure: created an organization-level EC2 discovery config while the AWS IAM OIDC provider was temporarily missing; verified Teleport created an `ec2-perm-org-denied` UserTask instead of only logging the discovery failure.


## Backport
- [ ] backport/branch/v18
