### PR TITLE
Fix potential race in agentpool

### DIFF
--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -265,15 +265,13 @@ func (p *AgentPool) Start() error {
 		"cluster", p.Cluster,
 	)
 
-	p.wg.Add(1)
-	go func() {
+	p.wg.Go(func() {
 		if err := p.run(); err != nil {
 			p.logger.WarnContext(p.ctx, "Agent pool exited", "error", err)
 		}
 
 		p.cancel()
-		p.wg.Done()
-	}()
+	})
 	return nil
 }
 
@@ -296,10 +294,7 @@ func (p *AgentPool) run() error {
 
 			p.logger.Log(p.ctx, level, "Failed to establish reverse tunnel", "error", err)
 		} else {
-			p.wg.Add(1)
-			p.active.add(agent)
-			p.lastConnectivityChange = p.Clock.Now()
-			p.updateConnectedProxies()
+			p.addActiveAgent(p.ctx, agent)
 		}
 
 		err = p.waitForBackoff(p.ctx, p.events)
@@ -309,6 +304,23 @@ func (p *AgentPool) run() error {
 			p.logger.DebugContext(p.ctx, "Failed to wait for backoff", "error", err)
 		}
 	}
+}
+
+// addActiveAgent registers a successfully started agent with the pool.
+func (p *AgentPool) addActiveAgent(ctx context.Context, agent Agent) {
+	p.wg.Add(1)
+	p.active.add(agent)
+	p.lastConnectivityChange = p.Clock.Now()
+
+	if agent.GetState() == AgentClosed {
+		// The agent can close after Start succeeds but before run registers it.
+		// If the AgentClosed callback already ran, it could not remove the agent
+		// from the active set, so reconcile the state after registration.
+		p.handleEvent(ctx, agent)
+		return
+	}
+
+	p.updateConnectedProxies()
 }
 
 // connectAgent connects a new agent and processes any agent events blocking until a

--- a/lib/reversetunnel/agentpool_test.go
+++ b/lib/reversetunnel/agentpool_test.go
@@ -473,14 +473,38 @@ func TestAgentPoolKeepAliveCountUpdatesAgent(t *testing.T) {
 		require.NoError(t, err)
 		pool.tracker.TrackExpected(track.Proxy{Name: "proxy-1"})
 
+		agentClosedEvents := make(chan AgentState, 1)
+		wrapStateCallback := func(agent Agent) AgentStateCallback {
+			callback := pool.getStateCallback(agent)
+			return func(state AgentState) {
+				if state == AgentClosed {
+					select {
+					case agentClosedEvents <- state:
+					default:
+					}
+				}
+				callback(state)
+			}
+		}
+		drainAgentClosedEvents := func() {
+			for {
+				select {
+				case <-agentClosedEvents:
+				default:
+					return
+				}
+			}
+		}
+
 		agentCount := 0
 		var keepAliveCountMax atomic.Int64 // starting at 0 will default to apidefaults.KeepAliveCountMax
 
 		pool.newAgentFunc = func(ctx context.Context, tracker *track.Tracker, lease *track.Lease) (Agent, error) {
 			agentCount++
+			agentNumber := agentCount
 			// Each agent gets a unique principal so it never collides with a
 			// previously claimed proxy.
-			principal := fmt.Sprintf("proxy-%d", agentCount)
+			principal := fmt.Sprintf("proxy-%d", agentNumber)
 
 			mu.Lock()
 			reqs := currentRequests
@@ -524,7 +548,7 @@ func TestAgentPoolKeepAliveCountUpdatesAgent(t *testing.T) {
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			a.stateCallback = pool.getStateCallback(a)
+			a.stateCallback = wrapStateCallback(a)
 			return a, nil
 		}
 
@@ -536,7 +560,6 @@ func TestAgentPoolKeepAliveCountUpdatesAgent(t *testing.T) {
 		}
 
 		require.NoError(t, pool.Start())
-		defer pool.Stop()
 
 		synctest.Wait()
 
@@ -557,10 +580,22 @@ func TestAgentPoolKeepAliveCountUpdatesAgent(t *testing.T) {
 		close(oldReqs)
 
 		synctest.Wait()
+		drainAgentClosedEvents()
 
 		require.Equal(t, 700*time.Millisecond, <-watchdogTimeouts,
 			"second agent: watchdog timeout should be keepAlive(100ms) * keepAliveCount(7)")
 
+		drainAgentClosedEvents()
 		close(newReqs)
+
+		stopDone := make(chan struct{})
+		go func() {
+			pool.Stop()
+			close(stopDone)
+		}()
+
+		synctest.Wait()
+		require.Equal(t, AgentClosed, <-agentClosedEvents)
+		<-stopDone
 	})
 }


### PR DESCRIPTION
This fix addresses a potential race when a new agent is closed after connection but before being registered in the active set. This should not be possible under normal operation but can happen in a synctest bubble when forcing disconnects for testing purposes.

A guard is added for this condition to ensure the pool can shutdown safely on the very unlikely event this occurs.

This commit also updates the test to check the correct disconnect events are observed. 

Fixes: gravitational/teleport/issues/67734

