### PR TITLE
[vnet] Reduce allocations by dropping DNS name compression

### DIFF
--- a/lib/vnet/dns/dns.go
+++ b/lib/vnet/dns/dns.go
@@ -401,7 +401,7 @@ func buildAAAAResponse(buf []byte, requestHeader *dnsmessage.Header, question *d
 	return buf, trace.Wrap(err, "serializing DNS response")
 }
 
-func prepDNSResponse(buf []byte, requestHeader *dnsmessage.Header, question *dnsmessage.Question, rcode dnsmessage.RCode) (*dnsmessage.Builder, error) {
+func prepDNSResponse(buf []byte, requestHeader *dnsmessage.Header, question *dnsmessage.Question, rcode dnsmessage.RCode) (dnsmessage.Builder, error) {
 	buf = buf[:0]
 	responseBuilder := dnsmessage.NewBuilder(buf, dnsmessage.Header{
 		ID:            requestHeader.ID,
@@ -409,12 +409,11 @@ func prepDNSResponse(buf []byte, requestHeader *dnsmessage.Header, question *dns
 		Authoritative: true,
 		RCode:         dnsmessage.RCodeSuccess,
 	})
-	responseBuilder.EnableCompression()
 	if err := responseBuilder.StartQuestions(); err != nil {
-		return nil, trace.Wrap(err, "starting questions section of DNS response")
+		return dnsmessage.Builder{}, trace.Wrap(err, "starting questions section of DNS response")
 	}
 	if err := responseBuilder.Question(*question); err != nil {
-		return nil, trace.Wrap(err, "adding question to DNS response")
+		return dnsmessage.Builder{}, trace.Wrap(err, "adding question to DNS response")
 	}
-	return &responseBuilder, nil
+	return responseBuilder, nil
 }

--- a/lib/vnet/dns/dns_bench_test.go
+++ b/lib/vnet/dns/dns_bench_test.go
@@ -39,6 +39,14 @@ func mustBuildQuery(b *testing.B, name string) []byte {
 	return raw
 }
 
+// go test ./lib/vnet/dns -run='^$' -bench=.
+// goos: darwin
+// goarch: arm64
+// pkg: github.com/gravitational/teleport/lib/vnet/dns
+// cpu: Apple M4 Pro
+// BenchmarkDNSParseAndBuildA-14            9789584               112.7 ns/op             0 B/op          0 allocs/op
+// PASS
+// ok      github.com/gravitational/teleport/lib/vnet/dns  1.539s
 func BenchmarkDNSParseAndBuildA(b *testing.B) {
 	query := mustBuildQuery(b, "app.example.com.")
 	respBuf := make([]byte, 0, maxUDPDNSMessageSize)

--- a/lib/vnet/dns/dns_bench_test.go
+++ b/lib/vnet/dns/dns_bench_test.go
@@ -1,0 +1,62 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package dns
+
+import (
+	"testing"
+
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+func mustBuildQuery(b *testing.B, name string) []byte {
+	b.Helper()
+	msg := dnsmessage.Message{
+		Header: dnsmessage.Header{ID: 1234, RecursionDesired: true},
+		Questions: []dnsmessage.Question{{
+			Name:  dnsmessage.MustNewName(name),
+			Type:  dnsmessage.TypeA,
+			Class: dnsmessage.ClassINET,
+		}},
+	}
+	raw, err := msg.Pack()
+	if err != nil {
+		b.Fatalf("packing query: %v", err)
+	}
+	return raw
+}
+
+func BenchmarkDNSParseAndBuildA(b *testing.B) {
+	query := mustBuildQuery(b, "app.example.com.")
+	respBuf := make([]byte, 0, maxUDPDNSMessageSize)
+	addr := [4]byte{100, 64, 0, 2}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		var parser dnsmessage.Parser
+		header, err := parser.Start(query)
+		if err != nil {
+			b.Fatalf("parsing header: %v", err)
+		}
+		question, err := parser.Question()
+		if err != nil {
+			b.Fatalf("parsing question: %v", err)
+		}
+		if _, err := buildAResponse(respBuf, &header, &question, addr); err != nil {
+			b.Fatalf("building response: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
This PR reduces memory allocations in the VNet DNS server by removing `EnableCompression()` from the DNS response builder. DNS name compression requires a per-response allocation that accounts for 3 allocations per query. Also one more allocation was removed by changing the builder from being returned as a reference to being returned as a value.
RFC 1035 makes compression optional for senders, and VNet only resolves short names for apps, databases, SSH nodes, etc., so responses stay well under UDP size limits. Queries forwarded to upstream nameservers bypass the builder and are unaffected.

Benchmark results:
```
goos: darwin
goarch: arm64
pkg: github.com/gravitational/teleport/lib/vnet/dns
cpu: Apple M4 Pro
                     │ before.txt  │             after.txt              │
                     │   sec/op    │   sec/op     vs base               │
DNSParseAndBuildA-14   217.8n ± 1%   114.1n ± 1%  -47.61% (p=0.002 n=6)

                     │ before.txt │            after.txt             │
                     │    B/op    │   B/op    vs base                │
DNSParseAndBuildA-14   336.0 ± 0%   0.0 ± 0%  -100.00% (p=0.002 n=6)

                     │ before.txt │             after.txt              │
                     │ allocs/op  │ allocs/op   vs base                │
DNSParseAndBuildA-14   4.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)

```
