### PR TITLE
Set up public Device Trust service proxy

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -81,6 +81,7 @@ import (
 	dbobjectimportrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
 	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
 	delegationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/delegation/v1"
+	publicdevicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/public/v1"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	dynamicwindowsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dynamicwindows/v1"
@@ -777,6 +778,12 @@ func (c *Client) setClosed() bool {
 // "not implemented" errors (as per the default gRPC behavior).
 func (c *Client) DevicesClient() devicepb.DeviceTrustServiceClient {
 	return devicepb.NewDeviceTrustServiceClient(c.conn)
+}
+
+// PublicDevicesClient returns a client for the public Device Trust service,
+// using the underlying Auth gRPC connection.
+func (c *Client) PublicDevicesClient() publicdevicepb.DeviceTrustServiceClient {
+	return publicdevicepb.NewDeviceTrustServiceClient(c.conn)
 }
 
 // CreateDeviceResource creates a device using its resource representation.

--- a/lib/devicetrust/grpcproxy/grpcproxy.go
+++ b/lib/devicetrust/grpcproxy/grpcproxy.go
@@ -1,0 +1,67 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package grpcproxy
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/gravitational/trace"
+
+	publicdevicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/public/v1"
+)
+
+// AuthClient is a subset of the full Auth API that must be connected.
+type AuthClient interface {
+	PublicDevicesClient() publicdevicepb.DeviceTrustServiceClient
+}
+
+// ServiceConfig is the configuration for [New].
+type ServiceConfig struct {
+	AuthClient AuthClient
+	Log        *slog.Logger
+}
+
+// New creates a new [Service].
+func New(cfg ServiceConfig) (*Service, error) {
+	if cfg.AuthClient == nil {
+		return nil, trace.BadParameter("missing AuthClient")
+	}
+	if cfg.Log == nil {
+		cfg.Log = slog.Default()
+	}
+
+	return &Service{
+		authClient: cfg.AuthClient,
+		log:        cfg.Log,
+	}, nil
+}
+
+// Service proxies requests from the public service in the Proxy Service to the
+// equivalent service in the Auth Service.
+type Service struct {
+	publicdevicepb.UnimplementedDeviceTrustServiceServer
+	authClient AuthClient
+	log        *slog.Logger
+}
+
+// CreatePairedDeviceEnrollToken forwards the request to the same RPC in the
+// Auth Service.
+func (s *Service) CreatePairedDeviceEnrollToken(ctx context.Context, req *publicdevicepb.CreatePairedDeviceEnrollTokenRequest) (*publicdevicepb.CreatePairedDeviceEnrollTokenResponse, error) {
+	res, err := s.authClient.PublicDevicesClient().CreatePairedDeviceEnrollToken(ctx, req)
+	return res, trace.Wrap(err)
+}

--- a/lib/devicetrust/grpcproxy/grpcproxy_test.go
+++ b/lib/devicetrust/grpcproxy/grpcproxy_test.go
@@ -1,0 +1,154 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package grpcproxy
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	publicdevicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/public/v1"
+	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
+	grpcinterceptors "github.com/gravitational/teleport/api/utils/grpc/interceptors"
+)
+
+func TestService_CreatePairedDeviceEnrollToken(t *testing.T) {
+	t.Parallel()
+
+	t.Run("forwards the request and returns the response", func(t *testing.T) {
+		fake := &fakeAuthService{
+			resp: publicdevicepb.CreatePairedDeviceEnrollTokenResponse_builder{
+				DeviceEnrollToken: devicepb.DeviceEnrollToken_builder{Token: "enroll-token"}.Build(),
+			}.Build(),
+		}
+		client := newProxyClient(t, fake)
+
+		req := publicdevicepb.CreatePairedDeviceEnrollTokenRequest_builder{
+			EnrollPairingToken: "pairing-token",
+			DeviceData: devicepb.DeviceCollectedData_builder{
+				OsType:       devicepb.OSType_OS_TYPE_IOS,
+				SerialNumber: "CXXXXXXXXX01",
+			}.Build(),
+		}.Build()
+
+		resp, err := client.CreatePairedDeviceEnrollToken(t.Context(), req)
+		require.NoError(t, err)
+		assert.Equal(t, "enroll-token", resp.GetDeviceEnrollToken().GetToken())
+
+		assert.Empty(t, cmp.Diff(req, fake.getLastReq(), protocmp.Transform()))
+	})
+
+	t.Run("propagates errors from the auth service", func(t *testing.T) {
+		fake := &fakeAuthService{err: trace.AccessDenied("denied")}
+		client := newProxyClient(t, fake)
+
+		_, err := client.CreatePairedDeviceEnrollToken(t.Context(),
+			publicdevicepb.CreatePairedDeviceEnrollTokenRequest_builder{
+				EnrollPairingToken: "pairing-token",
+			}.Build())
+		assert.ErrorAs(t, err, new(*trace.AccessDeniedError))
+	})
+}
+
+// fakeAuthService stands in for the auth-side public Device Trust service.
+type fakeAuthService struct {
+	publicdevicepb.UnimplementedDeviceTrustServiceServer
+
+	resp *publicdevicepb.CreatePairedDeviceEnrollTokenResponse
+	err  error
+
+	mu      sync.Mutex
+	lastReq *publicdevicepb.CreatePairedDeviceEnrollTokenRequest
+}
+
+func (f *fakeAuthService) CreatePairedDeviceEnrollToken(_ context.Context, req *publicdevicepb.CreatePairedDeviceEnrollTokenRequest) (*publicdevicepb.CreatePairedDeviceEnrollTokenResponse, error) {
+	f.mu.Lock()
+	f.lastReq = req
+	f.mu.Unlock()
+	return f.resp, f.err
+}
+
+func (f *fakeAuthService) getLastReq() *publicdevicepb.CreatePairedDeviceEnrollTokenRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lastReq
+}
+
+// fakeAuthClient adapts a public Device Trust client to the [AuthClient] interface.
+type fakeAuthClient struct {
+	client publicdevicepb.DeviceTrustServiceClient
+}
+
+func (c fakeAuthClient) PublicDevicesClient() publicdevicepb.DeviceTrustServiceClient {
+	return c.client
+}
+
+// newProxyClient stands up the fake auth service, the proxy in front of it, and
+// returns a client connected to the proxy.
+func newProxyClient(t *testing.T, authSvc publicdevicepb.DeviceTrustServiceServer) publicdevicepb.DeviceTrustServiceClient {
+	t.Helper()
+
+	authClient := fakeAuthClient{client: newGRPCClient(t, authSvc)}
+
+	proxy, err := New(ServiceConfig{AuthClient: authClient})
+	require.NoError(t, err)
+
+	return newGRPCClient(t, proxy)
+}
+
+// newGRPCClient serves svc on an in-memory bufconn listener and returns a client
+// dialed over it. bufconn keeps the transport off the real network so tests can
+// run inside a synctest bubble.
+func newGRPCClient(t *testing.T, svc publicdevicepb.DeviceTrustServiceServer) publicdevicepb.DeviceTrustServiceClient {
+	t.Helper()
+
+	lis := bufconn.Listen(1024)
+	server := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(grpcinterceptors.GRPCServerUnaryErrorInterceptor),
+	)
+	publicdevicepb.RegisterDeviceTrustServiceServer(server, svc)
+	go func() {
+		assert.NoError(t, server.Serve(lis))
+	}()
+	t.Cleanup(func() {
+		server.Stop()
+		assert.NoError(t, lis.Close())
+	})
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufconn",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithChainUnaryInterceptor(grpcinterceptors.GRPCClientUnaryErrorInterceptor),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return publicdevicepb.NewDeviceTrustServiceClient(conn)
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -73,6 +73,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	accessgraphsecretsv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessgraph/v1"
+	publicdevicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/public/v1"
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
@@ -128,6 +129,7 @@ import (
 	oracleimds "github.com/gravitational/teleport/lib/cloud/imds/oracle"
 	"github.com/gravitational/teleport/lib/componentfeatures"
 	"github.com/gravitational/teleport/lib/defaults"
+	devicetrustgrpcproxy "github.com/gravitational/teleport/lib/devicetrust/grpcproxy"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/athena"
 	"github.com/gravitational/teleport/lib/events/azsessions"
@@ -7550,8 +7552,16 @@ func (process *TeleportProcess) initPublicGRPCServer(
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
 	accessgraphsecretsv1pb.RegisterSecretsScannerServiceServer(server, accessGraphProxySvc)
+
+	publicDeviceTrustProxySvc, err := devicetrustgrpcproxy.New(devicetrustgrpcproxy.ServiceConfig{
+		AuthClient: conn.Client,
+		Log:        process.logger.With(teleport.ComponentKey, teleport.Component("dtproxy")),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	publicdevicepb.RegisterDeviceTrustServiceServer(server, publicDeviceTrustProxySvc)
 
 	process.RegisterCriticalFunc("proxy.grpc.public", func() error {
 		process.logger.InfoContext(process.ExitContext(), "Starting proxy gRPC server.", "listen_address", listener.Addr())


### PR DESCRIPTION
* Part of https://github.com/gravitational/teleport.e/issues/8259
* Requires https://github.com/gravitational/teleport/pull/68254

This PR adds the Proxy Service side of the public Device Trust. In short, the Proxy Service is going to use its client to proxy the requests to the public Device Trust service running in the Auth Service. Since no user certs are involved, authentication is going to be achieved through different means. See [the "Proxying requests to auth service" section](https://github.com/gravitational/teleport.e/blob/rfd/0032e-device-trust-ios/rfd/0032e-device-trust-ios.md#proxying-requests-to-auth-service) of RFD 32e for more details.

The implementation follows the footsteps of [`lib/secretsscanner/proxy`](https://github.com/gravitational/teleport/blob/1bb4a82ec3c7991c9401cfc4969ccfaa28548822/lib/secretsscanner/proxy/proxy.go) which exposes RPCs authenticated through means other than user certs through the `SecretsScannerService`.

The only RPC available now through https://github.com/gravitational/teleport/pull/68254 is the unary `CreatePairedDeviceEnrollToken`, so the implementation doesn't make use of `lib/utils/grpc.ProxyBidiStream` just yet. Likewise, the tests in `lib/devicetrust/grpcproxy/grpcproxy_test.go` are a little bit of an overkill for now with the whole gRPC service setup, but I didn't want to leave that setup for later since I know that we're going to be adding two streaming RPCs to this service soon.