### PR TITLE
`EnrollPairing`: Add get by token & requesting approval

### DIFF
--- a/api/gen/proto/go/teleport/devicetrust/v1/enroll_pairing_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/devicetrust/v1/enroll_pairing_protohybrid.pb.go
@@ -436,11 +436,11 @@ func (b0 EnrollPairingStatus_builder) Build() *EnrollPairingStatus {
 // CreatePairedDeviceEnrollToken.
 type EnrollPairingDevice struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
-	// Device operating system.
+	// Device operating system. Required.
 	OsType OSType `protobuf:"varint,1,opt,name=os_type,json=osType,proto3,enum=teleport.devicetrust.v1.OSType" json:"os_type,omitempty"`
-	// Device serial number.
+	// Device serial number. Required.
 	SerialNumber string `protobuf:"bytes,2,opt,name=serial_number,json=serialNumber,proto3" json:"serial_number,omitempty"`
-	// OS version number, without the leading 'v'.
+	// OS version number, without the leading 'v'. Required.
 	// Example: "13.2.1".
 	OsVersion     string `protobuf:"bytes,3,opt,name=os_version,json=osVersion,proto3" json:"os_version,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -508,11 +508,11 @@ func (x *EnrollPairingDevice) SetOsVersion(v string) {
 type EnrollPairingDevice_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// Device operating system.
+	// Device operating system. Required.
 	OsType OSType
-	// Device serial number.
+	// Device serial number. Required.
 	SerialNumber string
-	// OS version number, without the leading 'v'.
+	// OS version number, without the leading 'v'. Required.
 	// Example: "13.2.1".
 	OsVersion string
 }

--- a/api/gen/proto/go/teleport/devicetrust/v1/enroll_pairing_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/devicetrust/v1/enroll_pairing_protoopaque.pb.go
@@ -496,11 +496,11 @@ func (x *EnrollPairingDevice) SetOsVersion(v string) {
 type EnrollPairingDevice_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// Device operating system.
+	// Device operating system. Required.
 	OsType OSType
-	// Device serial number.
+	// Device serial number. Required.
 	SerialNumber string
-	// OS version number, without the leading 'v'.
+	// OS version number, without the leading 'v'. Required.
 	// Example: "13.2.1".
 	OsVersion string
 }

--- a/api/proto/teleport/devicetrust/v1/enroll_pairing.proto
+++ b/api/proto/teleport/devicetrust/v1/enroll_pairing.proto
@@ -94,13 +94,13 @@ enum EnrollPairingState {
 // os_type and serial_number are also used to gate retries of
 // CreatePairedDeviceEnrollToken.
 message EnrollPairingDevice {
-  // Device operating system.
+  // Device operating system. Required.
   OSType os_type = 1;
 
-  // Device serial number.
+  // Device serial number. Required.
   string serial_number = 2;
 
-  // OS version number, without the leading 'v'.
+  // OS version number, without the leading 'v'. Required.
   // Example: "13.2.1".
   string os_version = 3;
 }

--- a/lib/services/enroll_pairing.go
+++ b/lib/services/enroll_pairing.go
@@ -32,6 +32,17 @@ type EnrollPairing interface {
 	// GetCurrentEnrollPairing returns the EnrollPairing for user.
 	// Returns NotFound if no pairing exists.
 	GetCurrentEnrollPairing(ctx context.Context, user string) (*devicepb.EnrollPairing, error)
+
+	// GetEnrollPairingByToken returns the EnrollPairing whose status token
+	// matches token. Returns NotFound if no pairing matches.
+	GetEnrollPairingByToken(ctx context.Context, token string) (*devicepb.EnrollPairing, error)
+
+	// RequestEnrollPairingApproval transitions the EnrollPairing identified by
+	// token from AWAITING_DEVICE to AWAITING_APPROVAL, persisting device for the
+	// Web UI to display and for retry gating, and returns the updated pairing.
+	// Returns NotFound if no pairing matches token and CompareFailed if the
+	// pairing is no longer awaiting a device.
+	RequestEnrollPairingApproval(ctx context.Context, token string, device *devicepb.EnrollPairingDevice) (*devicepb.EnrollPairing, error)
 }
 
 // MarshalEnrollPairing marshals an EnrollPairing resource to JSON.

--- a/lib/services/local/enroll_pairing.go
+++ b/lib/services/local/enroll_pairing.go
@@ -213,8 +213,9 @@ func (s *EnrollPairingService) RequestEnrollPairingApproval(ctx context.Context,
 		return nil, trace.Wrap(err)
 	}
 
+	const errNotAwaitingDevice = "enroll pairing is not awaiting a device"
 	if pairing.GetStatus().GetState() != devicepb.EnrollPairingState_ENROLL_PAIRING_STATE_AWAITING_DEVICE {
-		return nil, trace.CompareFailed("enroll pairing is not awaiting a device")
+		return nil, trace.CompareFailed(errNotAwaitingDevice)
 	}
 
 	pairing.GetStatus().SetState(devicepb.EnrollPairingState_ENROLL_PAIRING_STATE_AWAITING_APPROVAL)
@@ -223,7 +224,7 @@ func (s *EnrollPairingService) RequestEnrollPairingApproval(ctx context.Context,
 	updated, err := s.service.ConditionalUpdateResource(ctx, pairing)
 	if trace.IsCompareFailed(err) {
 		// Lost the CAS to a concurrent claim — same outcome as the state check above.
-		return nil, trace.CompareFailed("enroll pairing is not awaiting a device")
+		return nil, trace.CompareFailed(errNotAwaitingDevice)
 	}
 	return updated, trace.Wrap(err)
 }

--- a/lib/services/local/enroll_pairing.go
+++ b/lib/services/local/enroll_pairing.go
@@ -24,6 +24,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -245,5 +246,22 @@ func validateEnrollPairing(pairing *devicepb.EnrollPairing) error {
 	if pairing.GetStatus().GetState() == devicepb.EnrollPairingState_ENROLL_PAIRING_STATE_UNSPECIFIED {
 		return trace.BadParameter("enroll pairing status.state is missing")
 	}
+
+	device := pairing.GetStatus().GetDevice()
+
+	if device != nil {
+		if device.GetOsType() == devicepb.OSType_OS_TYPE_UNSPECIFIED {
+			return trace.BadParameter("device.os_type is missing")
+		}
+
+		if strings.TrimSpace(device.GetOsVersion()) == "" {
+			return trace.BadParameter("device.os_version is missing")
+		}
+
+		if strings.TrimSpace(device.GetSerialNumber()) == "" {
+			return trace.BadParameter("device.serial_number is missing")
+		}
+	}
+
 	return nil
 }

--- a/lib/services/local/enroll_pairing.go
+++ b/lib/services/local/enroll_pairing.go
@@ -19,7 +19,10 @@ package local
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -42,6 +45,7 @@ const EnrollPairingExpireDuration = 5 * time.Minute
 // EnrollPairingService implements [services.EnrollPairing] on a [backend.Backend].
 type EnrollPairingService struct {
 	service *generic.ServiceWrapper[*devicepb.EnrollPairing]
+	backend backend.Backend
 	clock   clockwork.Clock
 	log     *slog.Logger
 }
@@ -62,6 +66,7 @@ func NewEnrollPairingService(b backend.Backend) (*EnrollPairingService, error) {
 	return &EnrollPairingService{
 		clock:   b.Clock(),
 		service: service,
+		backend: b,
 		log:     slog.With(teleport.ComponentKey, teleport.Component("enrollpairing")),
 	}, nil
 }
@@ -118,8 +123,40 @@ func (s *EnrollPairingService) CreateEnrollPairing(ctx context.Context, user str
 		s.log.WarnContext(ctx, "Failed to clear expired pairing if any", "error", err)
 	}
 
-	pairing, err := s.service.CreateResource(ctx, pairing)
-	return pairing, trace.Wrap(err)
+	if err := validateEnrollPairing(pairing); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	pairingItem, err := s.service.MakeBackendItem(pairing)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	indexItem := backend.Item{
+		Key:     enrollPairingByTokenKey(token),
+		Value:   []byte(user),
+		Expires: expires,
+	}
+
+	revision, err := s.backend.AtomicWrite(ctx, []backend.ConditionalAction{
+		{
+			Key:       pairingItem.Key,
+			Condition: backend.NotExists(),
+			Action:    backend.Put(pairingItem),
+		},
+		{
+			Key:       enrollPairingByTokenKey(token),
+			Condition: backend.NotExists(),
+			Action:    backend.Put(indexItem),
+		},
+	})
+	if err != nil {
+		if errors.Is(err, backend.ErrConditionFailed) {
+			return nil, trace.AlreadyExists("enroll pairing for user %q already exists", user)
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	pairing.GetMetadata().SetRevision(revision)
+	return pairing, nil
 }
 
 // GetCurrentEnrollPairing returns the EnrollPairing for user, or NotFound if no

--- a/lib/services/local/enroll_pairing.go
+++ b/lib/services/local/enroll_pairing.go
@@ -180,12 +180,12 @@ func (s *EnrollPairingService) GetEnrollPairingByToken(ctx context.Context, toke
 
 	item, err := s.backend.Get(ctx, enrollPairingByTokenKey(token))
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(err, "read by index")
 	}
 
 	pairing, err := s.service.GetResource(ctx, string(item.Value))
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(err, "read enroll pairing")
 	}
 
 	// Verify that the index and the pairing have the same token, in case the

--- a/lib/services/local/enroll_pairing.go
+++ b/lib/services/local/enroll_pairing.go
@@ -170,6 +170,68 @@ func (s *EnrollPairingService) GetCurrentEnrollPairing(ctx context.Context, user
 	return pairing, trace.Wrap(err)
 }
 
+// GetEnrollPairingByToken returns the EnrollPairing whose status token matches
+// token, or NotFound if none matches.
+func (s *EnrollPairingService) GetEnrollPairingByToken(ctx context.Context, token string) (*devicepb.EnrollPairing, error) {
+	if token == "" {
+		return nil, trace.BadParameter("token required")
+	}
+
+	item, err := s.backend.Get(ctx, enrollPairingByTokenKey(token))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	pairing, err := s.service.GetResource(ctx, string(item.Value))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Verify that the index and the pairing have the same token, in case the
+	// pairing was updated between the two Gets.
+	if pairing.GetStatus().GetToken() != token {
+		return nil, trace.NotFound("enroll pairing not found")
+	}
+
+	return pairing, nil
+}
+
+// RequestEnrollPairingApproval transitions the pairing identified by token from
+// AWAITING_DEVICE to AWAITING_APPROVAL, persisting device, and returns the
+// updated pairing.
+func (s *EnrollPairingService) RequestEnrollPairingApproval(ctx context.Context, token string, device *devicepb.EnrollPairingDevice) (*devicepb.EnrollPairing, error) {
+	if token == "" {
+		return nil, trace.BadParameter("token required")
+	}
+	if device == nil {
+		return nil, trace.BadParameter("device required")
+	}
+
+	pairing, err := s.GetEnrollPairingByToken(ctx, token)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if pairing.GetStatus().GetState() != devicepb.EnrollPairingState_ENROLL_PAIRING_STATE_AWAITING_DEVICE {
+		return nil, trace.CompareFailed("enroll pairing is not awaiting a device")
+	}
+
+	pairing.GetStatus().SetState(devicepb.EnrollPairingState_ENROLL_PAIRING_STATE_AWAITING_APPROVAL)
+	pairing.GetStatus().SetDevice(device)
+
+	updated, err := s.service.ConditionalUpdateResource(ctx, pairing)
+	if trace.IsCompareFailed(err) {
+		// Lost the CAS to a concurrent claim — same outcome as the state check above.
+		return nil, trace.CompareFailed("enroll pairing is not awaiting a device")
+	}
+	return updated, trace.Wrap(err)
+}
+
+func enrollPairingByTokenKey(token string) backend.Key {
+	hash := sha256.Sum256([]byte(token))
+	return backend.NewKey("devices", "enroll_pairing_by_token", hex.EncodeToString(hash[:]))
+}
+
 func validateEnrollPairing(pairing *devicepb.EnrollPairing) error {
 	if pairing.GetMetadata().GetName() == "" {
 		return trace.BadParameter("enroll pairing metadata.name is missing")

--- a/lib/services/local/enroll_pairing.go
+++ b/lib/services/local/enroll_pairing.go
@@ -250,9 +250,7 @@ func validateEnrollPairing(pairing *devicepb.EnrollPairing) error {
 		return trace.BadParameter("enroll pairing status.state is missing")
 	}
 
-	device := pairing.GetStatus().GetDevice()
-
-	if device != nil {
+	if device := pairing.GetStatus().GetDevice(); device != nil {
 		if device.GetOsType() == devicepb.OSType_OS_TYPE_UNSPECIFIED {
 			return trace.BadParameter("device.os_type is missing")
 		}

--- a/lib/services/local/enroll_pairing.go
+++ b/lib/services/local/enroll_pairing.go
@@ -144,7 +144,7 @@ func (s *EnrollPairingService) CreateEnrollPairing(ctx context.Context, user str
 			Action:    backend.Put(pairingItem),
 		},
 		{
-			Key:       enrollPairingByTokenKey(token),
+			Key:       indexItem.Key,
 			Condition: backend.NotExists(),
 			Action:    backend.Put(indexItem),
 		},

--- a/lib/services/local/enroll_pairing.go
+++ b/lib/services/local/enroll_pairing.go
@@ -214,6 +214,8 @@ func (s *EnrollPairingService) RequestEnrollPairingApproval(ctx context.Context,
 	}
 
 	const errNotAwaitingDevice = "enroll pairing is not awaiting a device"
+	// TODO(ravicious): Make the call retryable from the same device, as described
+	// in the Interrputibility section of RFD 32e.
 	if pairing.GetStatus().GetState() != devicepb.EnrollPairingState_ENROLL_PAIRING_STATE_AWAITING_DEVICE {
 		return nil, trace.CompareFailed(errNotAwaitingDevice)
 	}

--- a/lib/services/local/enroll_pairing_test.go
+++ b/lib/services/local/enroll_pairing_test.go
@@ -173,11 +173,10 @@ func TestEnrollPairingService_RequestEnrollPairingApproval(t *testing.T) {
 	t.Parallel()
 
 	s := newEnrollPairingService(t)
-	device := devicepb.EnrollPairingDevice_builder{
-		OsType:       devicepb.OSType_OS_TYPE_IOS,
-		SerialNumber: "CXXXXXXXXX01",
-		OsVersion:    "26.3.1",
-	}.Build()
+	existingPairing, err := s.CreateEnrollPairing(t.Context(), "pairing-for-validation-tests")
+	require.NoError(t, err)
+	existingToken := existingPairing.GetStatus().GetToken()
+	device := makeDevice()
 
 	t.Run("transitions to awaiting approval and persists the device", func(t *testing.T) {
 		t.Parallel()
@@ -213,6 +212,13 @@ func TestEnrollPairingService_RequestEnrollPairingApproval(t *testing.T) {
 		assert.ErrorAs(t, err, new(*trace.CompareFailedError))
 	})
 
+	badOSType := makeDevice()
+	badOSType.SetOsType(devicepb.OSType_OS_TYPE_UNSPECIFIED)
+	badOSVersion := makeDevice()
+	badOSVersion.SetOsVersion(" ")
+	badSerialNumber := makeDevice()
+	badSerialNumber.SetSerialNumber(" ")
+
 	tests := []struct {
 		name      string
 		token     string
@@ -238,6 +244,27 @@ func TestEnrollPairingService_RequestEnrollPairingApproval(t *testing.T) {
 			device:    nil,
 			errTarget: new(*trace.BadParameterError),
 		},
+		{
+			name:      "rejects empty device OS type",
+			token:     existingToken,
+			device:    badOSType,
+			errTarget: new(*trace.BadParameterError),
+			errMsg:    "os_type is missing",
+		},
+		{
+			name:      "rejects empty device OS version",
+			token:     existingToken,
+			device:    badOSVersion,
+			errTarget: new(*trace.BadParameterError),
+			errMsg:    "os_version is missing",
+		},
+		{
+			name:      "rejects empty device serial number",
+			token:     existingToken,
+			device:    badSerialNumber,
+			errTarget: new(*trace.BadParameterError),
+			errMsg:    "serial_number is missing",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -249,4 +276,12 @@ func TestEnrollPairingService_RequestEnrollPairingApproval(t *testing.T) {
 			}
 		})
 	}
+}
+
+func makeDevice() *devicepb.EnrollPairingDevice {
+	return devicepb.EnrollPairingDevice_builder{
+		OsType:       devicepb.OSType_OS_TYPE_IOS,
+		SerialNumber: "CXXXXXXXXX01",
+		OsVersion:    "26.3.1",
+	}.Build()
 }

--- a/lib/services/local/enroll_pairing_test.go
+++ b/lib/services/local/enroll_pairing_test.go
@@ -142,3 +142,87 @@ func TestEnrollPairingService_GetCurrentEnrollPairing(t *testing.T) {
 		assert.ErrorAs(t, err, new(*trace.BadParameterError))
 	})
 }
+
+func TestEnrollPairingService_GetEnrollPairingByToken(t *testing.T) {
+	t.Parallel()
+
+	s := newEnrollPairingService(t)
+
+	t.Run("returns the pairing matching the token", func(t *testing.T) {
+		ctx := t.Context()
+		want, err := s.CreateEnrollPairing(ctx, "by-token-ok")
+		require.NoError(t, err)
+
+		got, err := s.GetEnrollPairingByToken(ctx, want.GetStatus().GetToken())
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(want, got, protocmp.Transform()))
+	})
+
+	t.Run("returns NotFound for an unknown token", func(t *testing.T) {
+		_, err := s.GetEnrollPairingByToken(t.Context(), "does-not-exist")
+		assert.ErrorAs(t, err, new(*trace.NotFoundError))
+	})
+
+	t.Run("rejects empty token", func(t *testing.T) {
+		_, err := s.GetEnrollPairingByToken(t.Context(), "")
+		assert.ErrorAs(t, err, new(*trace.BadParameterError))
+	})
+}
+
+func TestEnrollPairingService_RequestEnrollPairingApproval(t *testing.T) {
+	t.Parallel()
+
+	s := newEnrollPairingService(t)
+	device := devicepb.EnrollPairingDevice_builder{
+		OsType:       devicepb.OSType_OS_TYPE_IOS,
+		SerialNumber: "CXXXXXXXXX01",
+		OsVersion:    "26.3.1",
+	}.Build()
+
+	t.Run("transitions to awaiting approval and persists the device", func(t *testing.T) {
+		ctx := t.Context()
+		created, err := s.CreateEnrollPairing(ctx, "approve-ok")
+		require.NoError(t, err)
+		token := created.GetStatus().GetToken()
+
+		updated, err := s.RequestEnrollPairingApproval(ctx, token, device)
+		require.NoError(t, err)
+		assert.Equal(t,
+			devicepb.EnrollPairingState_ENROLL_PAIRING_STATE_AWAITING_APPROVAL,
+			updated.GetStatus().GetState())
+		assert.Empty(t, cmp.Diff(device, updated.GetStatus().GetDevice(), protocmp.Transform()))
+
+		// The transition is persisted and the pairing is still resolvable by token.
+		got, err := s.GetEnrollPairingByToken(ctx, token)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(updated, got, protocmp.Transform()))
+	})
+
+	t.Run("rejects a pairing that is no longer awaiting a device", func(t *testing.T) {
+		ctx := t.Context()
+		created, err := s.CreateEnrollPairing(ctx, "approve-twice")
+		require.NoError(t, err)
+		token := created.GetStatus().GetToken()
+
+		_, err = s.RequestEnrollPairingApproval(ctx, token, device)
+		require.NoError(t, err)
+
+		_, err = s.RequestEnrollPairingApproval(ctx, token, device)
+		assert.ErrorAs(t, err, new(*trace.CompareFailedError))
+	})
+
+	t.Run("returns NotFound for an unknown token", func(t *testing.T) {
+		_, err := s.RequestEnrollPairingApproval(t.Context(), "does-not-exist", device)
+		assert.ErrorAs(t, err, new(*trace.NotFoundError))
+	})
+
+	t.Run("rejects empty token", func(t *testing.T) {
+		_, err := s.RequestEnrollPairingApproval(t.Context(), "", device)
+		assert.ErrorAs(t, err, new(*trace.BadParameterError))
+	})
+
+	t.Run("rejects nil device", func(t *testing.T) {
+		_, err := s.RequestEnrollPairingApproval(t.Context(), "any-token", nil)
+		assert.ErrorAs(t, err, new(*trace.BadParameterError))
+	})
+}

--- a/lib/services/local/enroll_pairing_test.go
+++ b/lib/services/local/enroll_pairing_test.go
@@ -180,6 +180,7 @@ func TestEnrollPairingService_RequestEnrollPairingApproval(t *testing.T) {
 	}.Build()
 
 	t.Run("transitions to awaiting approval and persists the device", func(t *testing.T) {
+		t.Parallel()
 		ctx := t.Context()
 		created, err := s.CreateEnrollPairing(ctx, "approve-ok")
 		require.NoError(t, err)
@@ -199,6 +200,7 @@ func TestEnrollPairingService_RequestEnrollPairingApproval(t *testing.T) {
 	})
 
 	t.Run("rejects a pairing that is no longer awaiting a device", func(t *testing.T) {
+		t.Parallel()
 		ctx := t.Context()
 		created, err := s.CreateEnrollPairing(ctx, "approve-twice")
 		require.NoError(t, err)
@@ -211,18 +213,40 @@ func TestEnrollPairingService_RequestEnrollPairingApproval(t *testing.T) {
 		assert.ErrorAs(t, err, new(*trace.CompareFailedError))
 	})
 
-	t.Run("returns NotFound for an unknown token", func(t *testing.T) {
-		_, err := s.RequestEnrollPairingApproval(t.Context(), "does-not-exist", device)
-		assert.ErrorAs(t, err, new(*trace.NotFoundError))
-	})
-
-	t.Run("rejects empty token", func(t *testing.T) {
-		_, err := s.RequestEnrollPairingApproval(t.Context(), "", device)
-		assert.ErrorAs(t, err, new(*trace.BadParameterError))
-	})
-
-	t.Run("rejects nil device", func(t *testing.T) {
-		_, err := s.RequestEnrollPairingApproval(t.Context(), "any-token", nil)
-		assert.ErrorAs(t, err, new(*trace.BadParameterError))
-	})
+	tests := []struct {
+		name      string
+		token     string
+		device    *devicepb.EnrollPairingDevice
+		errTarget any
+		errMsg    string
+	}{
+		{
+			name:      "returns NotFound for an unknown token",
+			token:     "does-not-exist",
+			device:    device,
+			errTarget: new(*trace.NotFoundError),
+		},
+		{
+			name:      "rejects empty token",
+			token:     "",
+			device:    device,
+			errTarget: new(*trace.BadParameterError),
+		},
+		{
+			name:      "rejects nil device",
+			token:     "any-token",
+			device:    nil,
+			errTarget: new(*trace.BadParameterError),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := s.RequestEnrollPairingApproval(t.Context(), test.token, test.device)
+			assert.ErrorAs(t, err, test.errTarget)
+			if test.errMsg != "" {
+				assert.ErrorContains(t, err, test.errMsg)
+			}
+		})
+	}
 }


### PR DESCRIPTION
* Part of https://github.com/gravitational/teleport.e/issues/8259
* Requires https://github.com/gravitational/teleport/pull/68254

This PR adds two new methods to `EnrollPairingService`:

* `GetEnrollPairingByToken` for getting an enroll pairing by its token (rather than by username that `EnrollPairing` is keyed on).
* `RequestEnrollPairingApproval` for transitioning an `EnrollPairing` from "awaiting device" to its "awaiting approval" state.

Both of those methods will be used in the initial version of the unauthed `CreatePairedDeviceEnrollToken` RPC that's going to be called by the mobile app. In the initial version, the RPC is not going to wait for `EnrollPairing` to get approved, but simply return an error if `EnrollPairing` is not yet approved.

`GetEnrollPairingByToken` requires a new index that resolves a token to a user. I followed the approach used in other services such as `beam.go` where I create a `backend.Item` with a raw string as `Value`. I decided to use `AtomicWrite` so that the index always stays in sync with the actual resource.

`RequestEnrollPairingApproval` implements the first transition from the `awaiting_device` state as described in [the "Interruptibility" section](https://github.com/gravitational/teleport.e/blob/rfd/0032e-device-trust-ios/rfd/0032e-device-trust-ios.md#interruptibility) of RFD 32e.