### PR TITLE
Skip flaky firefox e2e test

### DIFF
--- a/e2e/tests/web/unauthenticated/login.spec.ts
+++ b/e2e/tests/web/unauthenticated/login.spec.ts
@@ -21,10 +21,12 @@ import { test } from '@gravitational/e2e/helpers/test';
 
 test.use({ user: { roles: ['access', 'editor'] } });
 
-// TODO(ryan): figure out a fix for firefox flakiness
-test.skip('verify that a user can log in with username, password, and webauthn', async ({
+test('verify that a user can log in with username, password, and webauthn', async ({
   page,
   username,
+  browserName,
 }) => {
+  // TODO(ryan): figure out a fix for firefox flakiness
+  test.skip(browserName === 'firefox', 'flaky on firefox');
   await login(page, username);
 });

--- a/e2e/tests/web/unauthenticated/login.spec.ts
+++ b/e2e/tests/web/unauthenticated/login.spec.ts
@@ -21,7 +21,8 @@ import { test } from '@gravitational/e2e/helpers/test';
 
 test.use({ user: { roles: ['access', 'editor'] } });
 
-test('verify that a user can log in with username, password, and webauthn', async ({
+// TODO(ryan): figure out a fix for firefox flakiness
+test.skip('verify that a user can log in with username, password, and webauthn', async ({
   page,
   username,
 }) => {


### PR DESCRIPTION
I can't figure out why this is failing only sometimes in firefox, so skip it for now