### PR TITLE
Fix copy-paste error in app access test

### DIFF
--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -72,7 +72,7 @@ func TestAppAccess(t *testing.T) {
 
 	streamableHTTPTLSServer := httptest.NewTLSServer(mcpserver.NewStreamableHTTPServer(mcptest.NewServer()))
 	streamableHTTPTLSServerURL := "mcp+" + streamableHTTPTLSServer.URL + "/mcp"
-	t.Cleanup(streamableHTTPServer.Close)
+	t.Cleanup(streamableHTTPTLSServer.Close)
 
 	extraApps := []servicecfg.App{
 		{


### PR DESCRIPTION
We were registering cleanup actions to close the same streamableHTTPServer twice, and never closing streamableHTTPTLSServer.

