### PR TITLE
Desktop Access: Drop Shared Directory Removal

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -1079,7 +1079,7 @@ func (c *Client) handleRDPConnectionActivated(ioChannelID, userChannelID, screen
 			ScreenHeight:  uint32(screenHeight),
 		},
 		ClipboardEnabled:               true,
-		DirectoryRemoveSupported:       true,
+		DirectoryRemoveSupported:       false,
 		HidpiSupported:                 true,
 		MultidirectorySharingSupported: true,
 	}); err != nil {

--- a/web/packages/shared/components/DesktopSession/DesktopSession.test.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.test.tsx
@@ -236,7 +236,7 @@ test('directory sharing menu', async () => {
 
   // Successfully initialize the connection.
   await act(() => transport.emitPngFrameTDPBMessage());
-  await act(() => transport.emitServerCapabilities({ canRemove: true }));
+  await act(() => transport.emitServerCapabilities({ canRemove: false }));
 
   // The menu icon should also be visible
   const shareButton = await screen.findByRole('button', {
@@ -264,20 +264,6 @@ test('directory sharing menu', async () => {
   expect(directories).toHaveLength(2);
   expect(directories[0].name).toEqual(dirName);
   expect(directories[1].name).toEqual(dirName);
-
-  // Clicking the eject button unshares the directory and removes
-  // it from the menu.
-  expect(directories[0].ejectButton).toBeEnabled();
-  await userEvent.click(directories[0].ejectButton);
-
-  // Only one should remain
-  const updatedDirectories = await getSharedDirectoryEntries(shareMenu);
-  expect(updatedDirectories).toHaveLength(1);
-
-  // Server reports that it cannot remove directories
-  // unshare/eject button should be disabled.
-  await act(() => transport.emitServerCapabilities({ canRemove: false }));
-  expect(updatedDirectories[0].ejectButton).toBeDisabled();
 });
 
 async function getSharedDirectoryEntries(menu: HTMLElement) {
@@ -287,9 +273,6 @@ async function getSharedDirectoryEntries(menu: HTMLElement) {
   return entries.map(elem => {
     return {
       name: elem.textContent,
-      ejectButton: within(elem).getByRole('button', {
-        name: /disconnect shared directory/i,
-      }),
     };
   });
 }

--- a/web/packages/shared/components/DesktopSession/DesktopSessionWithSharing.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSessionWithSharing.tsx
@@ -70,8 +70,6 @@ export function DesktopSessionWithSharing(
           screenIsHiDpi={controls.screenIsHiDpi}
           hiDpiSupported={controls.hiDpiSupported}
           sharedDirectories={controls.sharedDirectories}
-          onRemoveSharedDirectory={controls.onRemoveSharedDirectory}
-          canRemoveSharedDirectory={controls.canRemoveSharedDirectory}
           onAddSharedDirectory={controls.onAddSharedDirectory}
           maxSharedDirectories={controls.maxSharedDirectories}
           directorySharingMessage={controls.directorySharingMessage}

--- a/web/packages/shared/components/DesktopSession/DirectoryList.tsx
+++ b/web/packages/shared/components/DesktopSession/DirectoryList.tsx
@@ -17,23 +17,14 @@
  */
 import styled from 'styled-components';
 
-import { Flex, Stack, P3, P2, H3 } from 'design';
-import {
-  ButtonFill,
-  ButtonIntent,
-  ButtonPrimary,
-  ButtonProps,
-  ButtonSecondary,
-} from 'design/Button/Button';
-import { Eject, FolderPlus, Plus } from 'design/Icon';
-import { HoverTooltip } from 'design/Tooltip';
+import { Flex, Stack, P2, H3 } from 'design';
+import { ButtonPrimary, ButtonProps } from 'design/Button/Button';
+import { FolderPlus, Plus } from 'design/Icon';
 import { MenuIcon } from 'shared/components/MenuAction';
 
 interface SharedDirectoriesProps {
   sharedDirectories: DirectoryItem[];
-  onRemoveSharedDirectory: (id: number) => void;
   onAddSharedDirectory: () => void;
-  canRemoveSharedDirectory: boolean;
   canShareDirectories: boolean;
   maxSharedDirectories: number;
   directorySharingMessage: string;
@@ -46,9 +37,7 @@ export interface DirectoryItem {
 
 export function SharedDirectoryList({
   sharedDirectories,
-  onRemoveSharedDirectory,
   onAddSharedDirectory,
-  canRemoveSharedDirectory,
   canShareDirectories,
   maxSharedDirectories,
   directorySharingMessage,
@@ -93,96 +82,22 @@ export function SharedDirectoryList({
           {!!sharedDirectories.length && (
             <DirectoryEntries aria-label="Shared directories">
               {sharedDirectories.map(dir => (
-                <DirectoryEntry
-                  name={dir.name}
-                  id={dir.id}
-                  isRemoveSupported={canRemoveSharedDirectory}
-                  onRemove={onRemoveSharedDirectory}
-                  key={dir.id}
-                />
+                <DirectoryEntry name={dir.name} id={dir.id} key={dir.id} />
               ))}
             </DirectoryEntries>
           )}
-
-          {/* If not supported, explain to the user that removal is not supported for the
-              connected WDS version, but may be supported on new versions. */}
-          <RemovalSupportInformation
-            isRemoveSupported={canRemoveSharedDirectory}
-            directoryCount={sharedDirectories.length}
-          />
         </Stack>
       </Container>
     </MenuIcon>
   );
 }
 
-function DirectoryEntry(props: {
-  name: string;
-  id: number;
-  isRemoveSupported: boolean;
-  onRemove: (id: number) => void;
-}) {
-  let buttonProps: {
-    disabled: boolean;
-    intent: ButtonIntent;
-    fill: ButtonFill;
-  } = {
-    disabled: false,
-    intent: 'primary',
-    fill: 'minimal',
-  };
-  let hoverText = 'Disconnect 1 shared directory';
-  if (!props.isRemoveSupported) {
-    hoverText = `
-      Disconnecting shared directories is not supported by this version of
-      Windows Desktop Service. To enable this feature, contact your Teleport
-      administrator about upgrading the Windows Desktop Service instance(s) in
-      your Teleport cluster.
-      `;
-  }
-
-  if (!props.isRemoveSupported) {
-    buttonProps = {
-      disabled: true,
-      intent: 'neutral',
-      fill: 'filled',
-    };
-  }
-
+function DirectoryEntry(props: { name: string; id: number }) {
   return (
     <DirectoryEntriesItem>
       <P2>{props.name}</P2>
-      <HoverTooltip placement="bottom" tipContent={hoverText}>
-        <Flex flexShrink={0}>
-          <ButtonSecondary
-            aria-label={`Disconnect shared directory ${props.name}`}
-            size="small"
-            compact={true}
-            onClick={() => props.onRemove(props.id)}
-            {...buttonProps}
-          >
-            <Eject size="small" />
-          </ButtonSecondary>
-        </Flex>
-      </HoverTooltip>
     </DirectoryEntriesItem>
   );
-}
-
-function RemovalSupportInformation(props: {
-  isRemoveSupported: boolean;
-  directoryCount: number;
-}) {
-  if (props.isRemoveSupported || props.directoryCount == 0) {
-    return;
-  }
-
-  const copyText =
-    props.directoryCount > 1
-      ? 'Disconnect these shared directories by restarting your session.'
-      : 'Disconnect this shared directory by restarting your session.';
-
-  return <P3 color="text.muted">{copyText}</P3>;
 }
 
 function ShareButton(

--- a/web/packages/shared/components/DesktopSession/TopBar.tsx
+++ b/web/packages/shared/components/DesktopSession/TopBar.tsx
@@ -45,14 +45,12 @@ export default function TopBar(props: Props) {
     alerts,
     sharedDirectories,
     onRemoveAlert,
-    onRemoveSharedDirectory,
     isConnected,
     latency,
     hiDpiEnabled,
     onToggleHiDpi,
     screenIsHiDpi,
     hiDpiSupported,
-    canRemoveSharedDirectory,
     maxSharedDirectories,
     directorySharingMessage,
     multidirectorySharingSupported,
@@ -89,9 +87,7 @@ export default function TopBar(props: Props) {
           {multidirectorySharingSupported ? (
             <SharedDirectoryList
               sharedDirectories={sharedDirectories}
-              onRemoveSharedDirectory={onRemoveSharedDirectory}
               onAddSharedDirectory={onAddSharedDirectory}
-              canRemoveSharedDirectory={canRemoveSharedDirectory}
               canShareDirectories={canShareDirectory}
               maxSharedDirectories={maxSharedDirectories}
               directorySharingMessage={directorySharingMessage}
@@ -163,12 +159,10 @@ type Props = {
   screenIsHiDpi: boolean;
   hiDpiSupported: boolean;
   onRemoveAlert(id: string): void;
-  onRemoveSharedDirectory(directoryId: number);
   latency: {
     client: number;
     server: number;
   };
-  canRemoveSharedDirectory: boolean;
   maxSharedDirectories: number;
   directorySharingMessage: string;
   multidirectorySharingSupported: boolean;


### PR DESCRIPTION
Due to a number of server interoperability issues discovered with directory/device removal, the desktop access team has decided to hold off on releasing this feature. This PR simply removes advertised support for directory removal from the Windows Desktop Service, and removes the "eject" icon from the directory list in the UI. The underlying `TdpClient` implementation will still supports removal, but the UI won't make use of it.

<img width="568" height="310" alt="image" src="https://github.com/user-attachments/assets/fdbb3015-5589-4b09-b951-22789604fad2" />


<!-- Provide a descriptive entry for the changelog of the next release. -->


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local clusters with a Windows desktop resource
### Test Cases
- [x] Connect to the desktop and confirm that the folderplus icon still appears.
- [x] Click the folderplus icon and validate that the "eject" icon is omitted, but names of shared directories are still visible.
- [x] Directory list is cleared upon disconnect and reconnect.
