### PR TITLE
[v17] Make spiffe role deny rules greedy

### DIFF
--- a/lib/auth/machineid/machineidv1/workload_identity_service_test.go
+++ b/lib/auth/machineid/machineidv1/workload_identity_service_test.go
@@ -68,10 +68,6 @@ func TestWorkloadIdentityService_SignX509SVIDs(t *testing.T) {
 			SPIFFE: []*types.SPIFFERoleCondition{
 				{
 					Path:    "/alpha/forbidden",
-					DNSSANs: []string{"*"},
-					IPSANs: []string{
-						"0.0.0.0/0",
-					},
 				},
 			},
 		},

--- a/lib/auth/machineid/machineidv1/workload_identity_service_test.go
+++ b/lib/auth/machineid/machineidv1/workload_identity_service_test.go
@@ -67,7 +67,7 @@ func TestWorkloadIdentityService_SignX509SVIDs(t *testing.T) {
 		Deny: types.RoleConditions{
 			SPIFFE: []*types.SPIFFERoleCondition{
 				{
-					Path:    "/alpha/forbidden",
+					Path: "/alpha/forbidden",
 				},
 			},
 		},

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1920,10 +1920,71 @@ func contains[S ~[]E, E any](s S, f func(E) (bool, error)) (bool, error) {
 	return false, nil
 }
 
-// matchSPIFFESVIDConditions compares a slice of SPIFFE Role Conditions against
+// matchSPIFFESVIDDenyConditions compares a slice of SPIFFE Role Conditions against
+// a requested SPIFFE SVID generation. Any field within a condition must match,
+// and any condition in the slice can match for the function to return true.
+func matchSPIFFESVIDDenyConditions(
+	conds []*types.SPIFFERoleCondition,
+	spiffeIDPath string,
+	dnsSANs []string,
+	ipSANs []net.IP,
+) (bool, error) {
+	return contains(conds, func(cond *types.SPIFFERoleCondition) (bool, error) {
+		// Match SPIFFE ID path.
+		isPathMatch, err := utils.MatchString(spiffeIDPath, cond.Path)
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+		if !isPathMatch {
+			return false, nil
+		}
+
+		// if any DNS SAN in the condition matches, we say the DNS SAN part
+		// of the condition matches
+		isDNSMatch := true
+		for _, dnsSANMatcher := range cond.DNSSANs {
+			isDNSMatch, err := contains(dnsSANs, func(reqDNSSAN string) (bool, error) {
+				return utils.MatchString(reqDNSSAN, dnsSANMatcher)
+			})
+			if err != nil {
+				return false, trace.Wrap(err)
+			}
+			if isDNSMatch {
+				break
+			}
+		}
+		if !isDNSMatch {
+			return false, nil
+		}
+
+		// Any IP SAN requested can match one of the IP SAN matchers in the
+		// condition.
+		isIPMatch := true
+		for _, ipSANMatcher := range cond.IPSANs {
+			isIPMatch, err := contains(ipSANs, func(reqIPSAN net.IP) (bool, error) {
+				_, cidr, err := net.ParseCIDR(ipSANMatcher)
+				if err != nil {
+					return false, trace.Wrap(err, "parsing cidr")
+				}
+				return cidr.Contains(reqIPSAN), nil
+			})
+			if err != nil {
+				return false, trace.Wrap(err)
+			}
+			if isIPMatch {
+				break
+			}
+		}
+
+		// all other conditions met
+		return isIPMatch, nil
+	})
+}
+
+// matchSPIFFESVIDAllowConditions compares a slice of SPIFFE Role Conditions against
 // a requested SPIFFE SVID generation. All fields within a condition must match,
 // but any condition in the slice can match for the function to return true.
-func matchSPIFFESVIDConditions(
+func matchSPIFFESVIDAllowConditions(
 	conds []*types.SPIFFERoleCondition,
 	spiffeIDPath string,
 	dnsSANs []string,
@@ -1991,7 +2052,7 @@ func (set RoleSet) CheckSPIFFESVID(spiffeIDPath string, dnsSANs []string, ipSANs
 	// check deny: a single match on a deny rule prohibits generation
 	for _, role := range set {
 		cond := role.GetSPIFFEConditions(types.Deny)
-		matched, err := matchSPIFFESVIDConditions(cond, spiffeIDPath, dnsSANs, ipSANs)
+		matched, err := matchSPIFFESVIDDenyConditions(cond, spiffeIDPath, dnsSANs, ipSANs)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -2003,7 +2064,7 @@ func (set RoleSet) CheckSPIFFESVID(spiffeIDPath string, dnsSANs []string, ipSANs
 	// check allow: if a single condition matches, allow generation
 	for _, role := range set {
 		cond := role.GetSPIFFEConditions(types.Allow)
-		matched, err := matchSPIFFESVIDConditions(cond, spiffeIDPath, dnsSANs, ipSANs)
+		matched, err := matchSPIFFESVIDAllowConditions(cond, spiffeIDPath, dnsSANs, ipSANs)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1943,7 +1943,7 @@ func matchSPIFFESVIDDenyConditions(
 		// of the condition matches
 		isDNSMatch := true
 		for _, dnsSANMatcher := range cond.DNSSANs {
-			isDNSMatch, err := contains(dnsSANs, func(reqDNSSAN string) (bool, error) {
+			isDNSMatch, err = contains(dnsSANs, func(reqDNSSAN string) (bool, error) {
 				return utils.MatchString(reqDNSSAN, dnsSANMatcher)
 			})
 			if err != nil {
@@ -1961,7 +1961,7 @@ func matchSPIFFESVIDDenyConditions(
 		// condition.
 		isIPMatch := true
 		for _, ipSANMatcher := range cond.IPSANs {
-			isIPMatch, err := contains(ipSANs, func(reqIPSAN net.IP) (bool, error) {
+			isIPMatch, err = contains(ipSANs, func(reqIPSAN net.IP) (bool, error) {
 				_, cidr, err := net.ParseCIDR(ipSANMatcher)
 				if err != nil {
 					return false, trace.Wrap(err, "parsing cidr")

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -9628,11 +9628,71 @@ func TestCheckSPIFFESVID(t *testing.T) {
 			requireErr: requireAccessDenied,
 		},
 		{
+			name: "explicit deny - multiple ip sans",
+
+			spiffeIDPath: "/foo/bar",
+			dnsSANs:      []string{},
+			ipSANs: []net.IP{
+				{10, 0, 0, 42},
+				{8, 8, 8, 8},
+			},
+
+			roles: []types.Role{
+				makeRole([]*types.SPIFFERoleCondition{
+					{
+						Path:    "/foo/*",
+						DNSSANs: []string{},
+						IPSANs:  []string{"10.0.0.1/8"},
+					},
+				}, []*types.SPIFFERoleCondition{
+					{
+						Path: "/*",
+						IPSANs: []string{
+							"10.0.0.42/32",
+						},
+					},
+				}),
+			},
+
+			requireErr: requireAccessDenied,
+		},
+		{
 			name: "explicit deny - dns san",
 
 			spiffeIDPath: "/foo/bar",
 			dnsSANs: []string{
 				"foo.example.com",
+			},
+			ipSANs: []net.IP{},
+
+			roles: []types.Role{
+				makeRole([]*types.SPIFFERoleCondition{
+					{
+						Path: "/foo/*",
+						DNSSANs: []string{
+							"*",
+						},
+						IPSANs: []string{},
+					},
+				}, []*types.SPIFFERoleCondition{
+					{
+						Path: "/*",
+						DNSSANs: []string{
+							"foo.example.com",
+						},
+					},
+				}),
+			},
+
+			requireErr: requireAccessDenied,
+		},
+		{
+			name: "explicit deny - multiple dns sans",
+
+			spiffeIDPath: "/foo/bar",
+			dnsSANs: []string{
+				"foo.example.com",
+				"bar.example.com",
 			},
 			ipSANs: []net.IP{},
 

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -9519,6 +9519,34 @@ func TestCheckSPIFFESVID(t *testing.T) {
 			requireErr: require.NoError,
 		},
 		{
+			name: "deny path matches, but dns and ip sans do not",
+
+			spiffeIDPath: "/foo/bar",
+			dnsSANs: []string{
+				"foo.example.com",
+			},
+			ipSANs: []net.IP{
+				{10, 0, 0, 32},
+			},
+
+			roles: []types.Role{
+				makeRole(
+					[]*types.SPIFFERoleCondition{{
+						Path:    "/foo/*",
+						DNSSANs: []string{"*"},
+						IPSANs:  []string{"0.0.0.0/0"},
+					}},
+					[]*types.SPIFFERoleCondition{{
+						Path:    "/foo/bar",
+						DNSSANs: []string{"never.example.com"},
+						IPSANs:  []string{"127.0.0.1/32"},
+					}},
+				),
+			},
+
+			requireErr: require.NoError,
+		},
+		{
 			name: "regex success",
 
 			spiffeIDPath: "/foo/bar",


### PR DESCRIPTION
Backport #67020 to branch/v17

changelog: Fixed a bug where role based deny rules for SPIFFE certificate issuance would not be enforced if multiple IP or DNS SANs were requested and only a subset matched deny rules.

## Manual Test Plan
### Test Environment

Validated the fix against a local cluster running OSS v18 with the fix cherry-picked. Driven by a tbot build with v18.

```yaml
kind: role
version: v7
metadata: { name: spiffe-tester }
spec:
  allow:
    spiffe:
      - { path: "/foo/*", dns_sans: ["*"], ip_sans: ["0.0.0.0/0"] }
  deny:
    spiffe:
      - path: "/*"
        dns_sans: ["foo.example.com"]
        ip_sans: ["10.0.0.42/32"]
```

### Test Cases

Bot requests an SVID at /foo/bar with the following SANs:

| id | DNS SANs | IP SANs | Expected |
| --- | --- | --- | --- |
| 1 | `foo.example.com, bar.example.com` | `10.0.0.42, 8.8.8.8` | denied (one of each DNS and IP matches) |
| 2 | `foo.example.com, bar.example.com` | - | allowed (one DNS matches, but no IP present in request) |
| 3 | `bar.example.com` | `10.0.0.42, 8.8.8.8` | allowed (IPs match, but DNS condition does not) |
| 4 | `bar.example.com` | `8.8.8.8` | allowed (no field matches) |

- [x] Case 1
- [x] Case 2
- [x] Case 3
- [x] Case 4
