### PR TITLE
Adding `resources` to scoped role kube block

### DIFF
--- a/api/gen/proto/go/teleport/scopes/access/v1/role_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role_protohybrid.pb.go
@@ -988,6 +988,8 @@ type ScopedRoleKube struct {
 	Groups []string `protobuf:"bytes,2,rep,name=groups,proto3" json:"groups,omitempty"`
 	// An optional list of impersonatable kubernetes users this role allows.
 	Users []string `protobuf:"bytes,3,rep,name=users,proto3" json:"users,omitempty"`
+	// The kubernetes resources this role grants access to.
+	Resources []*KubeResource `protobuf:"bytes,4,rep,name=resources,proto3" json:"resources,omitempty"`
 	// Overrides the defaults block idle timeout specifically for kube sessions.
 	// Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
 	// (or global default) applies.
@@ -1046,6 +1048,13 @@ func (x *ScopedRoleKube) GetUsers() []string {
 	return nil
 }
 
+func (x *ScopedRoleKube) GetResources() []*KubeResource {
+	if x != nil {
+		return x.Resources
+	}
+	return nil
+}
+
 func (x *ScopedRoleKube) GetClientIdleTimeout() string {
 	if x != nil {
 		return x.ClientIdleTimeout
@@ -1077,6 +1086,10 @@ func (x *ScopedRoleKube) SetGroups(v []string) {
 
 func (x *ScopedRoleKube) SetUsers(v []string) {
 	x.Users = v
+}
+
+func (x *ScopedRoleKube) SetResources(v []*KubeResource) {
+	x.Resources = v
 }
 
 func (x *ScopedRoleKube) SetClientIdleTimeout(v string) {
@@ -1122,6 +1135,8 @@ type ScopedRoleKube_builder struct {
 	Groups []string
 	// An optional list of impersonatable kubernetes users this role allows.
 	Users []string
+	// The kubernetes resources this role grants access to.
+	Resources []*KubeResource
 	// Overrides the defaults block idle timeout specifically for kube sessions.
 	// Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
 	// (or global default) applies.
@@ -1139,6 +1154,7 @@ func (b0 ScopedRoleKube_builder) Build() *ScopedRoleKube {
 	x.Labels = b.Labels
 	x.Groups = b.Groups
 	x.Users = b.Users
+	x.Resources = b.Resources
 	x.ClientIdleTimeout = b.ClientIdleTimeout
 	x.DisconnectExpiredCert = b.DisconnectExpiredCert
 	x.Lock = b.Lock
@@ -1948,6 +1964,130 @@ func (b0 Lock_builder) Build() *Lock {
 	return m0
 }
 
+// The kube resource identifier.
+type KubeResource struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The kube resource type.
+	Kind string `protobuf:"bytes,1,opt,name=kind,proto3" json:"kind,omitempty"`
+	// The kube resource namespace. It supports wildcards.
+	Namespace string `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	// The kube resource name. It supports wildcards.
+	Name string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
+	// The allowed kube verbs for interacting with the kube resource.
+	Verbs []string `protobuf:"bytes,4,rep,name=verbs,proto3" json:"verbs,omitempty"`
+	// The kube API group of the kube resource. It supports wildcards.
+	ApiGroup      string `protobuf:"bytes,5,opt,name=api_group,json=apiGroup,proto3" json:"api_group,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *KubeResource) Reset() {
+	*x = KubeResource{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *KubeResource) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*KubeResource) ProtoMessage() {}
+
+func (x *KubeResource) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *KubeResource) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *KubeResource) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *KubeResource) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *KubeResource) GetVerbs() []string {
+	if x != nil {
+		return x.Verbs
+	}
+	return nil
+}
+
+func (x *KubeResource) GetApiGroup() string {
+	if x != nil {
+		return x.ApiGroup
+	}
+	return ""
+}
+
+func (x *KubeResource) SetKind(v string) {
+	x.Kind = v
+}
+
+func (x *KubeResource) SetNamespace(v string) {
+	x.Namespace = v
+}
+
+func (x *KubeResource) SetName(v string) {
+	x.Name = v
+}
+
+func (x *KubeResource) SetVerbs(v []string) {
+	x.Verbs = v
+}
+
+func (x *KubeResource) SetApiGroup(v string) {
+	x.ApiGroup = v
+}
+
+type KubeResource_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The kube resource type.
+	Kind string
+	// The kube resource namespace. It supports wildcards.
+	Namespace string
+	// The kube resource name. It supports wildcards.
+	Name string
+	// The allowed kube verbs for interacting with the kube resource.
+	Verbs []string
+	// The kube API group of the kube resource. It supports wildcards.
+	ApiGroup string
+}
+
+func (b0 KubeResource_builder) Build() *KubeResource {
+	m0 := &KubeResource{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Kind = b.Kind
+	x.Namespace = b.Namespace
+	x.Name = b.Name
+	x.Verbs = b.Verbs
+	x.ApiGroup = b.ApiGroup
+	return m0
+}
+
 var File_teleport_scopes_access_v1_role_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
@@ -1997,15 +2137,16 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\r_max_sessionsB\f\n" +
 	"\n" +
 	"_file_copyB\x1a\n" +
-	"\x18_disconnect_expired_cert\"\xbf\x02\n" +
+	"\x18_disconnect_expired_cert\"\xf5\x02\n" +
 	"\x0eScopedRoleKube\x120\n" +
 	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12\x16\n" +
 	"\x06groups\x18\x02 \x03(\tR\x06groups\x12\x14\n" +
-	"\x05users\x18\x03 \x03(\tR\x05users\x12.\n" +
+	"\x05users\x18\x03 \x03(\tR\x05users\x12E\n" +
+	"\tresources\x18\x04 \x03(\v2'.teleport.scopes.access.v1.KubeResourceR\tresources\x12.\n" +
 	"\x13client_idle_timeout\x18\x05 \x01(\tR\x11clientIdleTimeout\x12;\n" +
 	"\x17disconnect_expired_cert\x18\x06 \x01(\bH\x00R\x15disconnectExpiredCert\x88\x01\x01\x123\n" +
 	"\x04lock\x18\a \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x1a\n" +
-	"\x18_disconnect_expired_certJ\x04\b\x04\x10\x05R\tresources\"N\n" +
+	"\x18_disconnect_expired_cert\"N\n" +
 	"\x1aScopedRoleWorkloadIdentity\x120\n" +
 	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\"l\n" +
 	"\rScopedRoleApp\x120\n" +
@@ -2042,9 +2183,15 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x10SessionRecording\x12\x12\n" +
 	"\x04mode\x18\x01 \x01(\tR\x04mode\"\x1a\n" +
 	"\x04Lock\x12\x12\n" +
-	"\x04mode\x18\x01 \x01(\tR\x04modeBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
+	"\x04mode\x18\x01 \x01(\tR\x04mode\"\x87\x01\n" +
+	"\fKubeResource\x12\x12\n" +
+	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x1c\n" +
+	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x12\x12\n" +
+	"\x04name\x18\x03 \x01(\tR\x04name\x12\x14\n" +
+	"\x05verbs\x18\x04 \x03(\tR\x05verbs\x12\x1b\n" +
+	"\tapi_group\x18\x05 \x01(\tR\bapiGroupBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
 
-var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*ScopedRole)(nil),                 // 0: teleport.scopes.access.v1.ScopedRole
 	(*ScopedRoleSpec)(nil),             // 1: teleport.scopes.access.v1.ScopedRoleSpec
@@ -2061,11 +2208,12 @@ var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*EnhancedRecording)(nil),          // 12: teleport.scopes.access.v1.EnhancedRecording
 	(*SessionRecording)(nil),           // 13: teleport.scopes.access.v1.SessionRecording
 	(*Lock)(nil),                       // 14: teleport.scopes.access.v1.Lock
-	(*v1.Metadata)(nil),                // 15: teleport.header.v1.Metadata
-	(*v11.Label)(nil),                  // 16: teleport.label.v1.Label
+	(*KubeResource)(nil),               // 15: teleport.scopes.access.v1.KubeResource
+	(*v1.Metadata)(nil),                // 16: teleport.header.v1.Metadata
+	(*v11.Label)(nil),                  // 17: teleport.label.v1.Label
 }
 var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
-	15, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
+	16, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
 	2,  // 2: teleport.scopes.access.v1.ScopedRoleSpec.defaults:type_name -> teleport.scopes.access.v1.ScopedRoleDefaults
 	7,  // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
@@ -2075,23 +2223,24 @@ var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
 	6,  // 7: teleport.scopes.access.v1.ScopedRoleSpec.app:type_name -> teleport.scopes.access.v1.ScopedRoleApp
 	13, // 8: teleport.scopes.access.v1.ScopedRoleDefaults.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
 	14, // 9: teleport.scopes.access.v1.ScopedRoleDefaults.lock:type_name -> teleport.scopes.access.v1.Lock
-	16, // 10: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
+	17, // 10: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
 	8,  // 11: teleport.scopes.access.v1.ScopedRoleSSH.port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
 	11, // 12: teleport.scopes.access.v1.ScopedRoleSSH.host_user_creation:type_name -> teleport.scopes.access.v1.CreateHostUser
 	12, // 13: teleport.scopes.access.v1.ScopedRoleSSH.enhanced_recording:type_name -> teleport.scopes.access.v1.EnhancedRecording
 	13, // 14: teleport.scopes.access.v1.ScopedRoleSSH.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
 	14, // 15: teleport.scopes.access.v1.ScopedRoleSSH.lock:type_name -> teleport.scopes.access.v1.Lock
-	16, // 16: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
-	14, // 17: teleport.scopes.access.v1.ScopedRoleKube.lock:type_name -> teleport.scopes.access.v1.Lock
-	16, // 18: teleport.scopes.access.v1.ScopedRoleWorkloadIdentity.labels:type_name -> teleport.label.v1.Label
-	16, // 19: teleport.scopes.access.v1.ScopedRoleApp.labels:type_name -> teleport.label.v1.Label
-	9,  // 20: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
-	10, // 21: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
-	22, // [22:22] is the sub-list for method output_type
-	22, // [22:22] is the sub-list for method input_type
-	22, // [22:22] is the sub-list for extension type_name
-	22, // [22:22] is the sub-list for extension extendee
-	0,  // [0:22] is the sub-list for field type_name
+	17, // 16: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
+	15, // 17: teleport.scopes.access.v1.ScopedRoleKube.resources:type_name -> teleport.scopes.access.v1.KubeResource
+	14, // 18: teleport.scopes.access.v1.ScopedRoleKube.lock:type_name -> teleport.scopes.access.v1.Lock
+	17, // 19: teleport.scopes.access.v1.ScopedRoleWorkloadIdentity.labels:type_name -> teleport.label.v1.Label
+	17, // 20: teleport.scopes.access.v1.ScopedRoleApp.labels:type_name -> teleport.label.v1.Label
+	9,  // 21: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
+	10, // 22: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
+	23, // [23:23] is the sub-list for method output_type
+	23, // [23:23] is the sub-list for method input_type
+	23, // [23:23] is the sub-list for extension type_name
+	23, // [23:23] is the sub-list for extension extendee
+	0,  // [0:23] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }
@@ -2111,7 +2260,7 @@ func file_teleport_scopes_access_v1_role_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_access_v1_role_proto_rawDesc), len(file_teleport_scopes_access_v1_role_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   15,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/scopes/access/v1/role_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role_protoopaque.pb.go
@@ -978,6 +978,7 @@ type ScopedRoleKube struct {
 	xxx_hidden_Labels                *[]*v11.Label          `protobuf:"bytes,1,rep,name=labels,proto3"`
 	xxx_hidden_Groups                []string               `protobuf:"bytes,2,rep,name=groups,proto3"`
 	xxx_hidden_Users                 []string               `protobuf:"bytes,3,rep,name=users,proto3"`
+	xxx_hidden_Resources             *[]*KubeResource       `protobuf:"bytes,4,rep,name=resources,proto3"`
 	xxx_hidden_ClientIdleTimeout     string                 `protobuf:"bytes,5,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3"`
 	xxx_hidden_DisconnectExpiredCert bool                   `protobuf:"varint,6,opt,name=disconnect_expired_cert,json=disconnectExpiredCert,proto3,oneof"`
 	xxx_hidden_Lock                  *Lock                  `protobuf:"bytes,7,opt,name=lock,proto3"`
@@ -1035,6 +1036,15 @@ func (x *ScopedRoleKube) GetUsers() []string {
 	return nil
 }
 
+func (x *ScopedRoleKube) GetResources() []*KubeResource {
+	if x != nil {
+		if x.xxx_hidden_Resources != nil {
+			return *x.xxx_hidden_Resources
+		}
+	}
+	return nil
+}
+
 func (x *ScopedRoleKube) GetClientIdleTimeout() string {
 	if x != nil {
 		return x.xxx_hidden_ClientIdleTimeout
@@ -1068,13 +1078,17 @@ func (x *ScopedRoleKube) SetUsers(v []string) {
 	x.xxx_hidden_Users = v
 }
 
+func (x *ScopedRoleKube) SetResources(v []*KubeResource) {
+	x.xxx_hidden_Resources = &v
+}
+
 func (x *ScopedRoleKube) SetClientIdleTimeout(v string) {
 	x.xxx_hidden_ClientIdleTimeout = v
 }
 
 func (x *ScopedRoleKube) SetDisconnectExpiredCert(v bool) {
 	x.xxx_hidden_DisconnectExpiredCert = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 4, 6)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 5, 7)
 }
 
 func (x *ScopedRoleKube) SetLock(v *Lock) {
@@ -1085,7 +1099,7 @@ func (x *ScopedRoleKube) HasDisconnectExpiredCert() bool {
 	if x == nil {
 		return false
 	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 4)
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 5)
 }
 
 func (x *ScopedRoleKube) HasLock() bool {
@@ -1096,7 +1110,7 @@ func (x *ScopedRoleKube) HasLock() bool {
 }
 
 func (x *ScopedRoleKube) ClearDisconnectExpiredCert() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 4)
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 5)
 	x.xxx_hidden_DisconnectExpiredCert = false
 }
 
@@ -1113,6 +1127,8 @@ type ScopedRoleKube_builder struct {
 	Groups []string
 	// An optional list of impersonatable kubernetes users this role allows.
 	Users []string
+	// The kubernetes resources this role grants access to.
+	Resources []*KubeResource
 	// Overrides the defaults block idle timeout specifically for kube sessions.
 	// Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
 	// (or global default) applies.
@@ -1130,9 +1146,10 @@ func (b0 ScopedRoleKube_builder) Build() *ScopedRoleKube {
 	x.xxx_hidden_Labels = &b.Labels
 	x.xxx_hidden_Groups = b.Groups
 	x.xxx_hidden_Users = b.Users
+	x.xxx_hidden_Resources = &b.Resources
 	x.xxx_hidden_ClientIdleTimeout = b.ClientIdleTimeout
 	if b.DisconnectExpiredCert != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 4, 6)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 5, 7)
 		x.xxx_hidden_DisconnectExpiredCert = *b.DisconnectExpiredCert
 	}
 	x.xxx_hidden_Lock = b.Lock
@@ -1956,6 +1973,125 @@ func (b0 Lock_builder) Build() *Lock {
 	return m0
 }
 
+// The kube resource identifier.
+type KubeResource struct {
+	state                protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Kind      string                 `protobuf:"bytes,1,opt,name=kind,proto3"`
+	xxx_hidden_Namespace string                 `protobuf:"bytes,2,opt,name=namespace,proto3"`
+	xxx_hidden_Name      string                 `protobuf:"bytes,3,opt,name=name,proto3"`
+	xxx_hidden_Verbs     []string               `protobuf:"bytes,4,rep,name=verbs,proto3"`
+	xxx_hidden_ApiGroup  string                 `protobuf:"bytes,5,opt,name=api_group,json=apiGroup,proto3"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *KubeResource) Reset() {
+	*x = KubeResource{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *KubeResource) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*KubeResource) ProtoMessage() {}
+
+func (x *KubeResource) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *KubeResource) GetKind() string {
+	if x != nil {
+		return x.xxx_hidden_Kind
+	}
+	return ""
+}
+
+func (x *KubeResource) GetNamespace() string {
+	if x != nil {
+		return x.xxx_hidden_Namespace
+	}
+	return ""
+}
+
+func (x *KubeResource) GetName() string {
+	if x != nil {
+		return x.xxx_hidden_Name
+	}
+	return ""
+}
+
+func (x *KubeResource) GetVerbs() []string {
+	if x != nil {
+		return x.xxx_hidden_Verbs
+	}
+	return nil
+}
+
+func (x *KubeResource) GetApiGroup() string {
+	if x != nil {
+		return x.xxx_hidden_ApiGroup
+	}
+	return ""
+}
+
+func (x *KubeResource) SetKind(v string) {
+	x.xxx_hidden_Kind = v
+}
+
+func (x *KubeResource) SetNamespace(v string) {
+	x.xxx_hidden_Namespace = v
+}
+
+func (x *KubeResource) SetName(v string) {
+	x.xxx_hidden_Name = v
+}
+
+func (x *KubeResource) SetVerbs(v []string) {
+	x.xxx_hidden_Verbs = v
+}
+
+func (x *KubeResource) SetApiGroup(v string) {
+	x.xxx_hidden_ApiGroup = v
+}
+
+type KubeResource_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The kube resource type.
+	Kind string
+	// The kube resource namespace. It supports wildcards.
+	Namespace string
+	// The kube resource name. It supports wildcards.
+	Name string
+	// The allowed kube verbs for interacting with the kube resource.
+	Verbs []string
+	// The kube API group of the kube resource. It supports wildcards.
+	ApiGroup string
+}
+
+func (b0 KubeResource_builder) Build() *KubeResource {
+	m0 := &KubeResource{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Kind = b.Kind
+	x.xxx_hidden_Namespace = b.Namespace
+	x.xxx_hidden_Name = b.Name
+	x.xxx_hidden_Verbs = b.Verbs
+	x.xxx_hidden_ApiGroup = b.ApiGroup
+	return m0
+}
+
 var File_teleport_scopes_access_v1_role_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
@@ -2005,15 +2141,16 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\r_max_sessionsB\f\n" +
 	"\n" +
 	"_file_copyB\x1a\n" +
-	"\x18_disconnect_expired_cert\"\xbf\x02\n" +
+	"\x18_disconnect_expired_cert\"\xf5\x02\n" +
 	"\x0eScopedRoleKube\x120\n" +
 	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12\x16\n" +
 	"\x06groups\x18\x02 \x03(\tR\x06groups\x12\x14\n" +
-	"\x05users\x18\x03 \x03(\tR\x05users\x12.\n" +
+	"\x05users\x18\x03 \x03(\tR\x05users\x12E\n" +
+	"\tresources\x18\x04 \x03(\v2'.teleport.scopes.access.v1.KubeResourceR\tresources\x12.\n" +
 	"\x13client_idle_timeout\x18\x05 \x01(\tR\x11clientIdleTimeout\x12;\n" +
 	"\x17disconnect_expired_cert\x18\x06 \x01(\bH\x00R\x15disconnectExpiredCert\x88\x01\x01\x123\n" +
 	"\x04lock\x18\a \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x1a\n" +
-	"\x18_disconnect_expired_certJ\x04\b\x04\x10\x05R\tresources\"N\n" +
+	"\x18_disconnect_expired_cert\"N\n" +
 	"\x1aScopedRoleWorkloadIdentity\x120\n" +
 	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\"l\n" +
 	"\rScopedRoleApp\x120\n" +
@@ -2050,9 +2187,15 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x10SessionRecording\x12\x12\n" +
 	"\x04mode\x18\x01 \x01(\tR\x04mode\"\x1a\n" +
 	"\x04Lock\x12\x12\n" +
-	"\x04mode\x18\x01 \x01(\tR\x04modeBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
+	"\x04mode\x18\x01 \x01(\tR\x04mode\"\x87\x01\n" +
+	"\fKubeResource\x12\x12\n" +
+	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x1c\n" +
+	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x12\x12\n" +
+	"\x04name\x18\x03 \x01(\tR\x04name\x12\x14\n" +
+	"\x05verbs\x18\x04 \x03(\tR\x05verbs\x12\x1b\n" +
+	"\tapi_group\x18\x05 \x01(\tR\bapiGroupBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
 
-var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*ScopedRole)(nil),                 // 0: teleport.scopes.access.v1.ScopedRole
 	(*ScopedRoleSpec)(nil),             // 1: teleport.scopes.access.v1.ScopedRoleSpec
@@ -2069,11 +2212,12 @@ var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*EnhancedRecording)(nil),          // 12: teleport.scopes.access.v1.EnhancedRecording
 	(*SessionRecording)(nil),           // 13: teleport.scopes.access.v1.SessionRecording
 	(*Lock)(nil),                       // 14: teleport.scopes.access.v1.Lock
-	(*v1.Metadata)(nil),                // 15: teleport.header.v1.Metadata
-	(*v11.Label)(nil),                  // 16: teleport.label.v1.Label
+	(*KubeResource)(nil),               // 15: teleport.scopes.access.v1.KubeResource
+	(*v1.Metadata)(nil),                // 16: teleport.header.v1.Metadata
+	(*v11.Label)(nil),                  // 17: teleport.label.v1.Label
 }
 var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
-	15, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
+	16, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
 	2,  // 2: teleport.scopes.access.v1.ScopedRoleSpec.defaults:type_name -> teleport.scopes.access.v1.ScopedRoleDefaults
 	7,  // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
@@ -2083,23 +2227,24 @@ var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
 	6,  // 7: teleport.scopes.access.v1.ScopedRoleSpec.app:type_name -> teleport.scopes.access.v1.ScopedRoleApp
 	13, // 8: teleport.scopes.access.v1.ScopedRoleDefaults.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
 	14, // 9: teleport.scopes.access.v1.ScopedRoleDefaults.lock:type_name -> teleport.scopes.access.v1.Lock
-	16, // 10: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
+	17, // 10: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
 	8,  // 11: teleport.scopes.access.v1.ScopedRoleSSH.port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
 	11, // 12: teleport.scopes.access.v1.ScopedRoleSSH.host_user_creation:type_name -> teleport.scopes.access.v1.CreateHostUser
 	12, // 13: teleport.scopes.access.v1.ScopedRoleSSH.enhanced_recording:type_name -> teleport.scopes.access.v1.EnhancedRecording
 	13, // 14: teleport.scopes.access.v1.ScopedRoleSSH.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
 	14, // 15: teleport.scopes.access.v1.ScopedRoleSSH.lock:type_name -> teleport.scopes.access.v1.Lock
-	16, // 16: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
-	14, // 17: teleport.scopes.access.v1.ScopedRoleKube.lock:type_name -> teleport.scopes.access.v1.Lock
-	16, // 18: teleport.scopes.access.v1.ScopedRoleWorkloadIdentity.labels:type_name -> teleport.label.v1.Label
-	16, // 19: teleport.scopes.access.v1.ScopedRoleApp.labels:type_name -> teleport.label.v1.Label
-	9,  // 20: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
-	10, // 21: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
-	22, // [22:22] is the sub-list for method output_type
-	22, // [22:22] is the sub-list for method input_type
-	22, // [22:22] is the sub-list for extension type_name
-	22, // [22:22] is the sub-list for extension extendee
-	0,  // [0:22] is the sub-list for field type_name
+	17, // 16: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
+	15, // 17: teleport.scopes.access.v1.ScopedRoleKube.resources:type_name -> teleport.scopes.access.v1.KubeResource
+	14, // 18: teleport.scopes.access.v1.ScopedRoleKube.lock:type_name -> teleport.scopes.access.v1.Lock
+	17, // 19: teleport.scopes.access.v1.ScopedRoleWorkloadIdentity.labels:type_name -> teleport.label.v1.Label
+	17, // 20: teleport.scopes.access.v1.ScopedRoleApp.labels:type_name -> teleport.label.v1.Label
+	9,  // 21: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
+	10, // 22: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
+	23, // [23:23] is the sub-list for method output_type
+	23, // [23:23] is the sub-list for method input_type
+	23, // [23:23] is the sub-list for extension type_name
+	23, // [23:23] is the sub-list for extension extendee
+	0,  // [0:23] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }
@@ -2119,7 +2264,7 @@ func file_teleport_scopes_access_v1_role_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_access_v1_role_proto_rawDesc), len(file_teleport_scopes_access_v1_role_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   15,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -176,8 +176,8 @@ message ScopedRoleKube {
   // An optional list of impersonatable kubernetes users this role allows.
   repeated string users = 3;
 
-  reserved 4; // saving for kube resources
-  reserved "resources"; // saving for kube resources
+  // The kubernetes resources this role grants access to.
+  repeated KubeResource resources = 4;
 
   // Overrides the defaults block idle timeout specifically for kube sessions.
   // Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
@@ -276,4 +276,22 @@ message Lock {
   // Allowed values: strict or best_effort.
   // Defaults to value cluster wide auth preference if not set.
   string mode = 1;
+}
+
+// The kube resource identifier.
+message KubeResource {
+  // The kube resource type.
+  string kind = 1;
+
+  // The kube resource namespace. It supports wildcards.
+  string namespace = 2;
+
+  // The kube resource name. It supports wildcards.
+  string name = 3;
+
+  // The allowed kube verbs for interacting with the kube resource.
+  repeated string verbs = 4;
+
+  // The kube API group of the kube resource. It supports wildcards.
+  string api_group = 5;
 }

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedrolesv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedrolesv1.mdx
@@ -82,6 +82,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |groups|[]string|The list of kubernetes groups this role allows.|
 |labels|[][object](#speckubelabels-items)|The map of kubernetes cluster labels used for RBAC.|
 |lock|[object](#speckubelock)|Lock configures the role's locking behavior for kubernetes sessions.|
+|resources|[][object](#speckuberesources-items)|The kubernetes resources this role grants access to.|
 |users|[]string|An optional list of impersonatable kubernetes users this role allows.|
 
 ### spec.kube.labels items
@@ -96,6 +97,16 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |Field|Type|Description|
 |---|---|---|
 |mode|string|Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.|
+
+### spec.kube.resources items
+
+|Field|Type|Description|
+|---|---|---|
+|api_group|string|The kube API group of the kube resource. It supports wildcards.|
+|kind|string|The kube resource type.|
+|name|string|The kube resource name. It supports wildcards.|
+|namespace|string|The kube resource namespace. It supports wildcards.|
+|verbs|[]string|The allowed kube verbs for interacting with the kube resource.|
 
 ### spec.rules items
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role.mdx
@@ -109,6 +109,7 @@ Optional:
 - `groups` (List of String) The list of kubernetes groups this role allows.
 - `labels` (Attributes List) The map of kubernetes cluster labels used for RBAC. (see [below for nested schema](#nested-schema-for-speckubelabels))
 - `lock` (Attributes) Lock configures the role's locking behavior for kubernetes sessions. (see [below for nested schema](#nested-schema-for-speckubelock))
+- `resources` (Attributes List) The kubernetes resources this role grants access to. (see [below for nested schema](#nested-schema-for-speckuberesources))
 - `users` (List of String) An optional list of impersonatable kubernetes users this role allows.
 
 ### Nested Schema for `spec.kube.labels`
@@ -124,6 +125,17 @@ Optional:
 Optional:
 
 - `mode` (String) Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.
+
+
+### Nested Schema for `spec.kube.resources`
+
+Optional:
+
+- `api_group` (String) The kube API group of the kube resource. It supports wildcards.
+- `kind` (String) The kube resource type.
+- `name` (String) The kube resource name. It supports wildcards.
+- `namespace` (String) The kube resource namespace. It supports wildcards.
+- `verbs` (List of String) The allowed kube verbs for interacting with the kube resource.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role.mdx
@@ -138,6 +138,7 @@ Optional:
 - `groups` (List of String) The list of kubernetes groups this role allows.
 - `labels` (Attributes List) The map of kubernetes cluster labels used for RBAC. (see [below for nested schema](#nested-schema-for-speckubelabels))
 - `lock` (Attributes) Lock configures the role's locking behavior for kubernetes sessions. (see [below for nested schema](#nested-schema-for-speckubelock))
+- `resources` (Attributes List) The kubernetes resources this role grants access to. (see [below for nested schema](#nested-schema-for-speckuberesources))
 - `users` (List of String) An optional list of impersonatable kubernetes users this role allows.
 
 ### Nested Schema for `spec.kube.labels`
@@ -153,6 +154,17 @@ Optional:
 Optional:
 
 - `mode` (String) Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.
+
+
+### Nested Schema for `spec.kube.resources`
+
+Optional:
+
+- `api_group` (String) The kube API group of the kube resource. It supports wildcards.
+- `kind` (String) The kube resource type.
+- `name` (String) The kube resource name. It supports wildcards.
+- `namespace` (String) The kube resource namespace. It supports wildcards.
+- `verbs` (List of String) The allowed kube verbs for interacting with the kube resource.
 
 
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
@@ -170,6 +170,34 @@ spec:
                           to value cluster wide auth preference if not set.'
                         type: string
                     type: object
+                  resources:
+                    description: The kubernetes resources this role grants access
+                      to.
+                    items:
+                      properties:
+                        api_group:
+                          description: The kube API group of the kube resource. It
+                            supports wildcards.
+                          type: string
+                        kind:
+                          description: The kube resource type.
+                          type: string
+                        name:
+                          description: The kube resource name. It supports wildcards.
+                          type: string
+                        namespace:
+                          description: The kube resource namespace. It supports wildcards.
+                          type: string
+                        verbs:
+                          description: The allowed kube verbs for interacting with
+                            the kube resource.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    nullable: true
+                    type: array
                   users:
                     description: An optional list of impersonatable kubernetes users
                       this role allows.

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
@@ -170,6 +170,34 @@ spec:
                           to value cluster wide auth preference if not set.'
                         type: string
                     type: object
+                  resources:
+                    description: The kubernetes resources this role grants access
+                      to.
+                    items:
+                      properties:
+                        api_group:
+                          description: The kube API group of the kube resource. It
+                            supports wildcards.
+                          type: string
+                        kind:
+                          description: The kube resource type.
+                          type: string
+                        name:
+                          description: The kube resource name. It supports wildcards.
+                          type: string
+                        namespace:
+                          description: The kube resource namespace. It supports wildcards.
+                          type: string
+                        verbs:
+                          description: The allowed kube verbs for interacting with
+                            the kube resource.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    nullable: true
+                    type: array
                   users:
                     description: An optional list of impersonatable kubernetes users
                       this role allows.

--- a/integrations/terraform/tfschema/scopes/access/v1/role_terraform.go
+++ b/integrations/terraform/tfschema/scopes/access/v1/role_terraform.go
@@ -218,6 +218,37 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 							Description: "Lock configures the role's locking behavior for kubernetes sessions.",
 							Optional:    true,
 						},
+						"resources": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+								"api_group": {
+									Description: "The kube API group of the kube resource. It supports wildcards.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"kind": {
+									Description: "The kube resource type.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"name": {
+									Description: "The kube resource name. It supports wildcards.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"namespace": {
+									Description: "The kube resource namespace. It supports wildcards.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"verbs": {
+									Description: "The allowed kube verbs for interacting with the kube resource.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+								},
+							}),
+							Description: "The kubernetes resources this role grants access to.",
+							Optional:    true,
+						},
 						"users": {
 							Description: "An optional list of impersonatable kubernetes users this role allows.",
 							Optional:    true,
@@ -1562,6 +1593,130 @@ func CopyScopedRoleFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 																t = string(v.Value)
 															}
 															obj.Users[k] = t
+														}
+													}
+												}
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["resources"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.kube.resources"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.kube.resources", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+											} else {
+												obj.Resources = make([]*github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_access_v1.KubeResource, len(v.Elems))
+												if !v.Null && !v.Unknown {
+													for k, a := range v.Elems {
+														v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														if !ok {
+															diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.kube.resources", "github_com_hashicorp_terraform_plugin_framework_types.Object"})
+														} else {
+															var t *github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_access_v1.KubeResource
+															if !v.Null && !v.Unknown {
+																tf := v
+																t = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_access_v1.KubeResource{}
+																obj := t
+																{
+																	a, ok := tf.Attrs["kind"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedRole.spec.kube.resources.kind"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.kube.resources.kind", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Kind = t
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["namespace"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedRole.spec.kube.resources.namespace"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.kube.resources.namespace", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Namespace = t
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["name"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedRole.spec.kube.resources.name"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.kube.resources.name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Name = t
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["verbs"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedRole.spec.kube.resources.verbs"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.kube.resources.verbs", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+																		} else {
+																			obj.Verbs = make([]string, len(v.Elems))
+																			if !v.Null && !v.Unknown {
+																				for k, a := range v.Elems {
+																					v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																					if !ok {
+																						diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.kube.resources.verbs", "github_com_hashicorp_terraform_plugin_framework_types.String"})
+																					} else {
+																						var t string
+																						if !v.Null && !v.Unknown {
+																							t = string(v.Value)
+																						}
+																						obj.Verbs[k] = t
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["api_group"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedRole.spec.kube.resources.api_group"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.kube.resources.api_group", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.ApiGroup = t
+																		}
+																	}
+																}
+															}
+															obj.Resources[k] = t
 														}
 													}
 												}
@@ -3734,6 +3889,205 @@ func CopyScopedRoleToTerraform(ctx context.Context, obj *github_com_gravitationa
 												}
 												c.Unknown = false
 												tf.Attrs["users"] = c
+											}
+										}
+									}
+									{
+										a, ok := tf.AttrTypes["resources"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.kube.resources"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.kube.resources", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+											} else {
+												c, ok := tf.Attrs["resources"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+												if !ok {
+													c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+														ElemType: o.ElemType,
+														Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Resources)),
+														Null:     true,
+													}
+												} else {
+													if c.Elems == nil {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Resources))
+													}
+												}
+												if obj.Resources != nil {
+													o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+													if len(obj.Resources) != len(c.Elems) {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Resources))
+													}
+													for k, a := range obj.Resources {
+														v, ok := tf.Attrs["resources"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														if !ok {
+															v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+																AttrTypes: o.AttrTypes,
+																Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+															}
+														} else {
+															if v.Attrs == nil {
+																v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+															}
+														}
+														if a == nil {
+															v.Null = true
+														} else {
+															obj := a
+															tf := &v
+															{
+																t, ok := tf.AttrTypes["kind"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedRole.spec.kube.resources.kind"})
+																} else {
+																	v, ok := tf.Attrs["kind"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedRole.spec.kube.resources.kind", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.kube.resources.kind", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Kind) == ""
+																	}
+																	v.Value = string(obj.Kind)
+																	v.Unknown = false
+																	tf.Attrs["kind"] = v
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["namespace"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedRole.spec.kube.resources.namespace"})
+																} else {
+																	v, ok := tf.Attrs["namespace"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedRole.spec.kube.resources.namespace", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.kube.resources.namespace", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Namespace) == ""
+																	}
+																	v.Value = string(obj.Namespace)
+																	v.Unknown = false
+																	tf.Attrs["namespace"] = v
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["name"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedRole.spec.kube.resources.name"})
+																} else {
+																	v, ok := tf.Attrs["name"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedRole.spec.kube.resources.name", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.kube.resources.name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Name) == ""
+																	}
+																	v.Value = string(obj.Name)
+																	v.Unknown = false
+																	tf.Attrs["name"] = v
+																}
+															}
+															{
+																a, ok := tf.AttrTypes["verbs"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedRole.spec.kube.resources.verbs"})
+																} else {
+																	o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+																	if !ok {
+																		diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.kube.resources.verbs", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+																	} else {
+																		c, ok := tf.Attrs["verbs"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+																		if !ok {
+																			c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+																				ElemType: o.ElemType,
+																				Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Verbs)),
+																				Null:     true,
+																			}
+																		} else {
+																			if c.Elems == nil {
+																				c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Verbs))
+																			}
+																		}
+																		if obj.Verbs != nil {
+																			t := o.ElemType
+																			if len(obj.Verbs) != len(c.Elems) {
+																				c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Verbs))
+																			}
+																			for k, a := range obj.Verbs {
+																				v, ok := tf.Attrs["verbs"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																				if !ok {
+																					i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																					if err != nil {
+																						diags.Append(attrWriteGeneralError{"ScopedRole.spec.kube.resources.verbs", err})
+																					}
+																					v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																					if !ok {
+																						diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.kube.resources.verbs", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																					}
+																					v.Null = string(a) == ""
+																				}
+																				v.Value = string(a)
+																				v.Unknown = false
+																				c.Elems[k] = v
+																			}
+																			if len(obj.Verbs) > 0 {
+																				c.Null = false
+																			}
+																		}
+																		c.Unknown = false
+																		tf.Attrs["verbs"] = c
+																	}
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["api_group"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedRole.spec.kube.resources.api_group"})
+																} else {
+																	v, ok := tf.Attrs["api_group"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedRole.spec.kube.resources.api_group", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.kube.resources.api_group", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.ApiGroup) == ""
+																	}
+																	v.Value = string(obj.ApiGroup)
+																	v.Unknown = false
+																	tf.Attrs["api_group"] = v
+																}
+															}
+														}
+														v.Unknown = false
+														c.Elems[k] = v
+													}
+													if len(obj.Resources) > 0 {
+														c.Null = false
+													}
+												}
+												c.Unknown = false
+												tf.Attrs["resources"] = c
 											}
 										}
 									}

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -1657,6 +1657,15 @@ func TestStrongValidateRoleSpecAllFieldsValidated(t *testing.T) {
 			Labels: []*labelv1.Label{
 				labelv1.Label_builder{Name: "env", Values: []string{"prod"}}.Build(),
 			},
+			Resources: []*scopedaccessv1.KubeResource{
+				scopedaccessv1.KubeResource_builder{
+					Kind:      "pods",
+					Namespace: "default",
+					Name:      "*",
+					ApiGroup:  "*",
+					Verbs:     []string{"get"},
+				}.Build(),
+			},
 			ClientIdleTimeout:     "1h",
 			DisconnectExpiredCert: ptr(true),
 			Lock: scopedaccessv1.Lock_builder{


### PR DESCRIPTION
Adds `KubeResource` message and related `resources` field to the scoped kube proto. `KubeResource` is copied without the gogo annotations from `KubernetesResource` in the legacy proto definitions. Validations and compat layer added in follow up PR https://github.com/gravitational/teleport/pull/68273

Related to https://github.com/gravitational/teleport/issues/67205


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
A local teleport cluster with `TELEPORT_UNSTABLE_SCOPES=yes`

### Test Cases
- [x] Scoped roles can still be created (no regressions)
- [x] Scoped roles can be created with `spec.kube.resources` defined
