### PR TITLE
auth: add license expiry Prometheus metric

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -241,6 +241,14 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		cfg.Modules = modules.GetModules()
 	}
 
+	// Report the Unix timestamp at which the enterprise license will expire.
+	// The auth server holds the license, so the value is read directly from
+	// modules. It is the zero value (reported as 0) for builds without an
+	// expiring license.
+	if expiry := cfg.Modules.LicenseExpiry(); !expiry.IsZero() {
+		licenseExpiryMetric.Set(float64(expiry.Unix()))
+	}
+
 	if cfg.VersionStorage == nil {
 		return nil, trace.BadParameter("version storage is not set")
 	}
@@ -1263,6 +1271,14 @@ var (
 		},
 	)
 
+	licenseExpiryMetric = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: teleport.MetricNamespace,
+			Name:      teleport.MetricLicenseExpiry,
+			Help:      "Expiry timestamp of the Teleport Enterprise license; 0 if not applicable.",
+		},
+	)
+
 	prometheusCollectors = []prometheus.Collector{
 		generateRequestsCount, generateThrottledRequestsCount,
 		generateRequestsCurrent, generateRequestsLatencies, UserLoginCount, userLoginCountPerClient, heartbeatsMissedByAuth,
@@ -1273,6 +1289,7 @@ var (
 		userCertificatesGeneratedMetric,
 		roleCount,
 		botInstancesMetric,
+		licenseExpiryMetric,
 	}
 )
 

--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -81,6 +81,8 @@ var (
 	ErrDeleteRoleAccessList = errDeleteRoleAccessList
 
 	CreateAuditStreamAcceptedTotalMetric = createAuditStreamAcceptedTotalMetric
+
+	LicenseExpiryMetric = licenseExpiryMetric
 )
 
 func ServerWithModules(mt *modulestest.Modules) *Server {

--- a/lib/modules/modulestest/modules.go
+++ b/lib/modules/modulestest/modules.go
@@ -86,6 +86,8 @@ type Modules struct {
 	// during tests when hardware key support is enabled. This
 	// attestation data is shared by all logins when set.
 	MockAttestationData *keys.AttestationData
+	// TestLicenseExpiry is returned from the LicenseExpiry function.
+	TestLicenseExpiry time.Time
 
 	GenerateAccessRequestPromotionsFn         func(ctx context.Context, accessListGetter modules.AccessResourcesGetter, accessReq types.AccessRequest) (*types.AccessRequestAllowedPromotions, error)
 	GenerateAccessRequestSuggestedReviewersFn func(ctx context.Context, accessListGetter modules.AccessResourcesGetter, accessReq types.AccessRequest) ([]string, error)
@@ -168,7 +170,7 @@ func (m *Modules) IsOSSBuild() bool {
 
 // LicenseExpiry implements modules.Modules.
 func (m *Modules) LicenseExpiry() time.Time {
-	return time.Time{}
+	return m.TestLicenseExpiry
 }
 
 // PrintVersion implements modules.Modules.

--- a/metrics.go
+++ b/metrics.go
@@ -301,6 +301,11 @@ const (
 	// MetricResourceKubernetes is a Kubernetes cluster resource metric.
 	MetricResourceKubernetes = "kubernetes"
 
+	// MetricLicenseExpiry is Unix timestamp at which the Teleport
+	// Enterprise license will expire. It is 0 when no expiring license
+	// applies (for example OSS/Community builds).
+	MetricLicenseExpiry = "license_expiry_timestamp_seconds"
+
 	// TagRange is a tag specifying backend requests
 	TagRange = "range"
 


### PR DESCRIPTION
<!-- Provide a descriptive entry for the changelog of the next release. -->

### Changelog:
Expose the Teleport Enterprise license expiry as a gauge, teleport_license_expiry_timestamp_seconds, reporting the expiry as a Unix timestamp in seconds (0 when no expiring license applies). The value is read from modules.LicenseExpiry() and registered alongside the other cluster-wide auth gauges in NewServer.

<!-- Include manual testing efforts to verify the change. -->
### Testing note
`make test` fails on recent MacOS not finding the Rust `wasm32-unknown-unknown` target even when it's installed. 
See build: ["make test" does not work on unmodified tree on MacOS](https://github.com/gravitational/teleport/issues/68265)

<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] Run with Enterprise, ensure license shows timestamp correctly
- [ ] Run with OSS, ensure license shows `0`
