### PR TITLE
Add WithCanonicalFields option to accesslist.EqualAccessLists

### DIFF
--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -706,8 +706,9 @@ func (a *AccessList) setInitialAuditDate(clock clockwork.Clock) (err error) {
 type EqualAccessListsOption func(*equalAccessListsConfig)
 
 type equalAccessListsConfig struct {
-	skipClone     bool
-	resetFieldsFn func(*AccessList)
+	skipClone      bool
+	resetFieldsFn  func(*AccessList)
+	canonicalizeFn func(*AccessList)
 }
 
 // WithSkipClone configures EqualAccessLists to skip cloning
@@ -772,6 +773,24 @@ func WithIgnoreOktaUserManagedFields() EqualAccessListsOption {
 	}
 }
 
+// WithCanonicalFields configures EqualAccessLists to canonicalize slice fields
+// within the Spec to ensure a consistent order and remove duplicates before
+// comparison. This prevents false negatives in equality checks where slices
+// might have different orders or contain duplicates.
+//
+// The following fields are canonicalized: Grants (roles/traits/scopedRoles),
+// OwnerGrants (roles/traits/scopedRoles), MembershipRequires (roles/traits),
+// and OwnershipRequires (roles/traits).
+//
+// Note: This option reorders and de-duplicates the listed slice fields. As with
+// [WithIgnoreEphemeralFields], the input Access Lists are cloned (unless
+// [WithSkipClone] is also used) to avoid modifying the originals.
+func WithCanonicalFields() EqualAccessListsOption {
+	return func(c *equalAccessListsConfig) {
+		c.canonicalizeFn = canonicalizeAccessList
+	}
+}
+
 // EqualAccessLists compares two access lists for semantic equality.
 //
 // By default, this function performs a standard equality check. Use WithIgnoreEphemeralFields()
@@ -796,6 +815,11 @@ func EqualAccessLists(a, b *AccessList, opts ...EqualAccessListsOption) bool {
 		cfg.resetFieldsFn(b)
 	}
 
+	if cfg.canonicalizeFn != nil {
+		cfg.canonicalizeFn(a)
+		cfg.canonicalizeFn(b)
+	}
+
 	return deriveTeleportEqualAccessList(a, b)
 }
 
@@ -810,4 +834,46 @@ func resetEphemeralFieldsAccessList(a *AccessList) {
 	for i := range a.Spec.Owners {
 		a.Spec.Owners[i].IneligibleStatus = ""
 	}
+}
+
+func canonicalizeAccessList(a *AccessList) {
+	if a == nil {
+		return
+	}
+
+	canonicalizeGrants(&a.Spec.Grants)
+	canonicalizeGrants(&a.Spec.OwnerGrants)
+	canonicalizeRequires(&a.Spec.MembershipRequires)
+	canonicalizeRequires(&a.Spec.OwnershipRequires)
+}
+
+func canonicalizeGrants(g *Grants) {
+	if g == nil {
+		return
+	}
+
+	slices.Sort(g.Roles)
+	g.Roles = slices.Compact(g.Roles)
+
+	trait.Merge(g.Traits, nil)
+
+	slices.SortFunc(g.ScopedRoles, func(a, b ScopedRoleGrant) int {
+		if a.Role == b.Role {
+			return strings.Compare(a.Scope, b.Scope)
+		}
+		return strings.Compare(a.Role, b.Role)
+	})
+
+	g.ScopedRoles = slices.Compact(g.ScopedRoles)
+}
+
+func canonicalizeRequires(r *Requires) {
+	if r == nil {
+		return
+	}
+
+	slices.Sort(r.Roles)
+	r.Roles = slices.Compact(r.Roles)
+
+	trait.Merge(r.Traits, nil)
 }

--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -780,7 +780,7 @@ func WithIgnoreOktaUserManagedFields() EqualAccessListsOption {
 //
 // The following fields are canonicalized: Grants (roles/traits/scopedRoles),
 // OwnerGrants (roles/traits/scopedRoles), MembershipRequires (roles/traits),
-// and OwnershipRequires (roles/traits).
+// OwnershipRequires (roles/traits) and Owners.
 //
 // Note: This option reorders and de-duplicates the listed slice fields. As with
 // [WithIgnoreEphemeralFields], the input Access Lists are cloned (unless
@@ -841,10 +841,45 @@ func canonicalizeAccessList(a *AccessList) {
 		return
 	}
 
+	canonicalizeOwners(&a.Spec.Owners)
 	canonicalizeGrants(&a.Spec.Grants)
 	canonicalizeGrants(&a.Spec.OwnerGrants)
 	canonicalizeRequires(&a.Spec.MembershipRequires)
 	canonicalizeRequires(&a.Spec.OwnershipRequires)
+}
+
+// canonicalize the owner of an access list.
+// NOTE: Please to not use this function outside of the canonicalize flow. If
+// similar functionality is needed elsewhere, please consider using derive based
+// functions instead.
+func canonicalizeOwner(a, b Owner) int {
+	if a.Name != b.Name {
+		return strings.Compare(a.Name, b.Name)
+	}
+	if a.MembershipKind != b.MembershipKind {
+		return strings.Compare(a.MembershipKind, b.MembershipKind)
+	}
+	if a.Description != b.Description {
+		return strings.Compare(a.Description, b.Description)
+	}
+	if a.Title != b.Title {
+		return strings.Compare(a.Title, b.Title)
+	}
+
+	// If WithIgnoreEphemeralFields is used - the fields will be reset and equal.
+	return strings.Compare(a.IneligibleStatus, b.IneligibleStatus)
+}
+
+func canonicalizeOwners(o *[]Owner) {
+	slices.SortFunc(*o, canonicalizeOwner)
+
+	*o = slices.CompactFunc(*o, func(a, b Owner) bool {
+		return canonicalizeOwner(a, b) == 0
+	})
+
+	if len(*o) == 0 {
+		*o = nil
+	}
 }
 
 func canonicalizeGrants(g *Grants) {
@@ -854,8 +889,14 @@ func canonicalizeGrants(g *Grants) {
 
 	slices.Sort(g.Roles)
 	g.Roles = slices.Compact(g.Roles)
+	if len(g.Roles) == 0 {
+		g.Roles = nil
+	}
 
 	trait.Merge(g.Traits, nil)
+	if len(g.Traits) == 0 {
+		g.Traits = nil
+	}
 
 	slices.SortFunc(g.ScopedRoles, func(a, b ScopedRoleGrant) int {
 		if a.Role == b.Role {
@@ -865,6 +906,9 @@ func canonicalizeGrants(g *Grants) {
 	})
 
 	g.ScopedRoles = slices.Compact(g.ScopedRoles)
+	if len(g.ScopedRoles) == 0 {
+		g.ScopedRoles = nil
+	}
 }
 
 func canonicalizeRequires(r *Requires) {
@@ -874,6 +918,12 @@ func canonicalizeRequires(r *Requires) {
 
 	slices.Sort(r.Roles)
 	r.Roles = slices.Compact(r.Roles)
+	if len(r.Roles) == 0 {
+		r.Roles = nil
+	}
 
 	trait.Merge(r.Traits, nil)
+	if len(r.Traits) == 0 {
+		r.Traits = nil
+	}
 }

--- a/api/types/accesslist/accesslist_test.go
+++ b/api/types/accesslist/accesslist_test.go
@@ -858,3 +858,226 @@ func TestEqualIgnoreOktaUserManagedFields(t *testing.T) {
 		require.False(t, EqualAccessLists(al2, al1, WithIgnoreOktaUserManagedFields()))
 	})
 }
+
+func TestEqualWithCanonicalFields(t *testing.T) {
+	t.Parallel()
+
+	baseSpec := Spec{
+		Title: "Test Access List",
+	}
+
+	newAL := func(t *testing.T, name string, spec Spec) *AccessList {
+		al, err := NewAccessList(header.Metadata{Name: name}, spec)
+		require.NoError(t, err)
+		return al
+	}
+
+	tests := []struct {
+		name               string
+		setup              func(spec1, spec2 *Spec)
+		wantCanonicalEqual bool
+	}{
+		{
+			name: "Reordered Grants.Roles equal with WithCanonicalFields()",
+			setup: func(spec1, spec2 *Spec) {
+				spec1.Grants.Roles = []string{"role-b", "role-a"}
+				spec2.Grants.Roles = []string{"role-a", "role-b"}
+			},
+			wantCanonicalEqual: true,
+		},
+		{
+			name: "Reordered OwnerGrants.Roles equal with WithCanonicalFields()",
+			setup: func(spec1, spec2 *Spec) {
+				spec1.OwnerGrants.Roles = []string{"role-b", "role-a"}
+				spec2.OwnerGrants.Roles = []string{"role-a", "role-b"}
+			},
+			wantCanonicalEqual: true,
+		},
+		{
+			name: "Reordered MembershipRequires.Roles equal",
+			setup: func(spec1, spec2 *Spec) {
+				spec1.MembershipRequires.Roles = []string{"role-b", "role-a"}
+				spec2.MembershipRequires.Roles = []string{"role-a", "role-b"}
+			},
+			wantCanonicalEqual: true,
+		},
+		{
+			name: "Reordered OwnershipRequires.Roles equal",
+			setup: func(spec1, spec2 *Spec) {
+				spec1.OwnershipRequires.Roles = []string{"role-b", "role-a"}
+				spec2.OwnershipRequires.Roles = []string{"role-a", "role-b"}
+			},
+			wantCanonicalEqual: true,
+		},
+		{
+			name: "Duplicates compare equal to unique sets",
+			setup: func(spec1, spec2 *Spec) {
+				spec1.Grants.Roles = []string{"role-a", "role-b", "role-a"}
+				spec2.Grants.Roles = []string{"role-a", "role-b"}
+			},
+			wantCanonicalEqual: true,
+		},
+		{
+			name: "Trait value order/dups compare equal",
+			setup: func(spec1, spec2 *Spec) {
+				spec1.Grants.Traits = map[string][]string{
+					"trait1": {"value-b", "value-a", "value-b"},
+				}
+				spec2.Grants.Traits = map[string][]string{
+					"trait1": {"value-a", "value-b"},
+				}
+			},
+			wantCanonicalEqual: true,
+		},
+		{
+			name: "Reordered and duplicate ScopedRoles compare equal",
+			setup: func(spec1, spec2 *Spec) {
+				spec1.Grants.ScopedRoles = []ScopedRoleGrant{
+					{Role: "scoped2", Scope: "scopeB"},
+					{Role: "scoped1", Scope: "scopeA"},
+					{Role: "scoped2", Scope: "scopeB"},
+				}
+				spec2.Grants.ScopedRoles = []ScopedRoleGrant{
+					{Role: "scoped1", Scope: "scopeA"},
+					{Role: "scoped2", Scope: "scopeB"},
+				}
+			},
+			wantCanonicalEqual: true,
+		},
+		{
+			name: "Different values still compare unequal",
+			setup: func(spec1, spec2 *Spec) {
+				spec1.Grants.Roles = []string{"role-a", "role-b"}
+				spec2.Grants.Roles = []string{"role-a", "role-c"}
+			},
+		},
+		{
+			name: "Different trait values still compare unequal",
+			setup: func(spec1, spec2 *Spec) {
+				spec1.Grants.Traits = map[string][]string{
+					"trait1": {"value-a", "value-b"},
+				}
+				spec2.Grants.Traits = map[string][]string{
+					"trait1": {"value-a", "value-c"},
+				}
+			},
+		},
+		{
+			name: "Different ScopedRoles still compare unequal",
+			setup: func(spec1, spec2 *Spec) {
+				spec1.Grants.ScopedRoles = []ScopedRoleGrant{
+					{Role: "scoped1", Scope: "scopeA"},
+					{Role: "scoped2", Scope: "scopeB"},
+				}
+				spec2.Grants.ScopedRoles = []ScopedRoleGrant{
+					{Role: "scoped1", Scope: "scopeA"},
+					{Role: "scoped2", Scope: "scopeC"},
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec1 := baseSpec
+			spec2 := baseSpec
+			tt.setup(&spec1, &spec2)
+
+			al1 := newAL(t, "test", spec1)
+			al2 := newAL(t, "test", spec2)
+
+			require.False(t, EqualAccessLists(al1, al2))
+			require.Equal(t, tt.wantCanonicalEqual, EqualAccessLists(al1, al2, WithCanonicalFields()))
+		})
+	}
+
+	t.Run("default behavior does not mutate originals", func(t *testing.T) {
+		spec1 := baseSpec
+		spec1.Grants = Grants{
+			Roles: []string{"role-b", "role-a"},
+			Traits: map[string][]string{
+				"trait1": {"value-b", "value-a"},
+				"trait2": {"value-a", "value-b"},
+			},
+			ScopedRoles: []ScopedRoleGrant{
+				{Role: "scoped2", Scope: "scopeB"},
+				{Role: "scoped1", Scope: "scopeA"},
+			},
+		}
+		spec1.OwnerGrants = Grants{
+			Roles: []string{"role-b", "role-a"},
+			Traits: map[string][]string{
+				"trait1": {"value-b", "value-a"},
+				"trait2": {"value-a", "value-b"},
+			},
+			ScopedRoles: []ScopedRoleGrant{
+				{Role: "scoped2", Scope: "scopeB"},
+				{Role: "scoped1", Scope: "scopeA"},
+			},
+		}
+		spec1.MembershipRequires = Requires{
+			Roles: []string{"role-b", "role-a"},
+			Traits: map[string][]string{
+				"trait1": {"value-b", "value-a"},
+				"trait2": {"value-a", "value-b"},
+			},
+		}
+		spec1.OwnershipRequires = Requires{
+			Roles: []string{"role-b", "role-a"},
+			Traits: map[string][]string{
+				"trait1": {"value-b", "value-a"},
+				"trait2": {"value-a", "value-b"},
+			},
+		}
+
+		spec2 := baseSpec
+		spec2.Grants = Grants{
+			Roles: []string{"role-a", "role-b"},
+			Traits: map[string][]string{
+				"trait1": {"value-a", "value-b"},
+				"trait2": {"value-b", "value-a"},
+			},
+			ScopedRoles: []ScopedRoleGrant{
+				{Role: "scoped1", Scope: "scopeA"},
+				{Role: "scoped2", Scope: "scopeB"},
+			},
+		}
+		spec2.OwnerGrants = Grants{
+			Roles: []string{"role-a", "role-b"},
+			Traits: map[string][]string{
+				"trait1": {"value-a", "value-b"},
+				"trait2": {"value-b", "value-a"},
+			},
+			ScopedRoles: []ScopedRoleGrant{
+				{Role: "scoped1", Scope: "scopeA"},
+				{Role: "scoped2", Scope: "scopeB"},
+			},
+		}
+		spec2.MembershipRequires = Requires{
+			Roles: []string{"role-a", "role-b"},
+			Traits: map[string][]string{
+				"trait1": {"value-a", "value-b"},
+				"trait2": {"value-b", "value-a"},
+			},
+		}
+		spec2.OwnershipRequires = Requires{
+			Roles: []string{"role-a", "role-b"},
+			Traits: map[string][]string{
+				"trait1": {"value-a", "value-b"},
+				"trait2": {"value-b", "value-a"},
+			},
+		}
+
+		al1Original := newAL(t, "test", spec1)
+		al2Original := newAL(t, "test", spec2)
+
+		al1Clone := al1Original.Clone()
+		al2Clone := al2Original.Clone()
+
+		eq := EqualAccessLists(al1Clone, al2Clone, WithCanonicalFields())
+		require.True(t, eq)
+
+		require.Equal(t, al1Clone, al1Original)
+		require.Equal(t, al2Clone, al2Original)
+	})
+}

--- a/api/types/accesslist/accesslist_test.go
+++ b/api/types/accesslist/accesslist_test.go
@@ -975,6 +975,68 @@ func TestEqualWithCanonicalFields(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "Empty lists compare equal to nil lists",
+			setup: func(spec1, spec2 *Spec) {
+				spec1.Owners = []Owner{}
+				spec2.Owners = nil
+
+				spec1.Grants.Roles = []string{}
+				spec2.Grants.Roles = nil
+				spec1.Grants.Traits = map[string][]string{}
+				spec2.Grants.Traits = nil
+				spec1.Grants.ScopedRoles = []ScopedRoleGrant{}
+				spec2.Grants.ScopedRoles = nil
+
+				spec1.OwnerGrants.Roles = []string{}
+				spec2.OwnerGrants.Roles = nil
+				spec1.OwnerGrants.Traits = map[string][]string{}
+				spec2.OwnerGrants.Traits = nil
+				spec1.OwnerGrants.ScopedRoles = []ScopedRoleGrant{}
+				spec2.OwnerGrants.ScopedRoles = nil
+
+				spec1.MembershipRequires.Roles = []string{}
+				spec2.MembershipRequires.Roles = nil
+				spec1.MembershipRequires.Traits = map[string][]string{}
+				spec2.MembershipRequires.Traits = nil
+
+				spec1.OwnershipRequires.Roles = []string{}
+				spec2.OwnershipRequires.Roles = nil
+				spec1.OwnershipRequires.Traits = map[string][]string{}
+				spec2.OwnershipRequires.Traits = nil
+			},
+			wantCanonicalEqual: true,
+		},
+		{
+			name: "Reordered owners equal",
+			setup: func(spec1, spec2 *Spec) {
+				spec1.Owners = []Owner{
+					{Name: "owner-b", MembershipKind: MembershipKindUser, Description: "b"},
+					{Name: "owner-a", MembershipKind: MembershipKindUser, Description: "a"},
+				}
+				spec2.Owners = []Owner{
+					{Name: "owner-a", MembershipKind: MembershipKindUser, Description: "a"},
+					{Name: "owner-b", MembershipKind: MembershipKindUser, Description: "b"},
+				}
+			},
+			wantCanonicalEqual: true,
+		},
+		{
+			name: "Duplicate owners compare equal to unique owners",
+			setup: func(spec1, spec2 *Spec) {
+				owner := Owner{Name: "owner-a", MembershipKind: MembershipKindUser, Description: "a"}
+				spec1.Owners = []Owner{owner, owner}
+				spec2.Owners = []Owner{owner}
+			},
+			wantCanonicalEqual: true,
+		},
+		{
+			name: "Different owner name still compares unequal",
+			setup: func(spec1, spec2 *Spec) {
+				spec1.Owners = []Owner{{Name: "owner-a", MembershipKind: MembershipKindUser}}
+				spec2.Owners = []Owner{{Name: "owner-b", MembershipKind: MembershipKindUser}}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -986,7 +1048,6 @@ func TestEqualWithCanonicalFields(t *testing.T) {
 			al1 := newAL(t, "test", spec1)
 			al2 := newAL(t, "test", spec2)
 
-			require.False(t, EqualAccessLists(al1, al2))
 			require.Equal(t, tt.wantCanonicalEqual, EqualAccessLists(al1, al2, WithCanonicalFields()))
 		})
 	}


### PR DESCRIPTION
Issue: https://github.com/gravitational/teleport/issues/53662

This is a dependency for solving the https://github.com/gravitational/teleport/issues/53662 issue.


## What
This change adds an option for EqualAccessLists to canonicalise the fields, which will allow avoiding false positives when determining if the access list was changed or not (eg. order of owner grants changed).

`WithCanonicalFields` option configures `EqualAccessLists` to canonicalise slice fields within the Spec to ensure a consistent order and remove duplicates before comparison. This prevents false negatives in equality checks where slices might have different orders or contain duplicates.

The following fields are canonicalised: Grants (roles/traits/scopedRoles), OwnerGrants (roles/traits/scopedRoles), MembershipRequires (roles/traits), and OwnershipRequires (roles/traits).

## Why
As per https://github.com/gravitational/teleport/issues/53662, adding roles to list owners permissions granted out of order breaks owners permissions. Canonicalising the field will allow ignore order and duplicates and thus avoid false positive decisions that the AccessList was changed, when in fact it was not.

**NOTE:** This change only adds the facility to canonicalise the fields in the access list, which will be enabled in a separate PR. 

## Background
This was initially solved in the following PRs, but since the master has gone far away now, I decided to redo.
- https://github.com/gravitational/teleport/pull/56007

I attempted changing the equality function in the `accesslist.EqualAccessLists` approach first but then switched to canonicalisation instead, which seems to be working better and arguably easier to reason about.

## Manual Test Plan
- [x] See manual test plan section in the https://github.com/gravitational/teleport.e/pull/9063 where the functionality is activated.

### Test Environment
- See test environment section in the https://github.com/gravitational/teleport.e/pull/9063 where the functionality is activated.

### Test Cases
- [x] Reordered Grants.Roles equal with WithCanonicalFields().
- [x] Reordered OwnerGrants.Roles equal with WithCanonicalFields().
- [x] Reordered MembershipRequires.Roles equal.
- [x] Reordered OwnershipRequires.Roles equal.
- [x] Duplicates compare equal to unique sets.
- [x] Different values still compare unequal.
- [x] Trait value order/dups compare equal. 

Issue: https://github.com/gravitational/customer-sensitive-requests/issues/658
PR to activate this: https://github.com/gravitational/teleport.e/pull/9063