### PR TITLE
Supporting kube resource RBAC in scoped roles

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1796,8 +1796,9 @@ var KubernetesClusterWideResourceKinds = []string{
 	KindKubeCertificateSigningRequest,
 }
 
-// KubernetesNamespacedResourceKinds is the list of known Kubernetes resource kinds
-// that are namespaced.
+// kubernetesNamespacedResourceKinds is the list of known Kubernetes resource kinds
+// that are namespaced. This map has been duplicated in lib/scopes/access/access.go.
+// Any changes should also be made there.
 //
 // Generated from `kubectl api-resources --namespaced=true -o name --sort-by=name` (kind k8s v1.32.2).
 // The format is "<plural>.<apigroup>".

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -2148,6 +2148,8 @@ func setDefaultKubernetesVerbs(spec *RoleSpecV6) {
 // - Name is not empty
 // - Namespace is not empty
 // - APIGroup is empty for roles <=v7 and not empty for >=v8
+// This function is duplicated for scoped roles in lib/scopes/access/access.go. Any changes to role v8 behavior should
+// also be made there.
 func validateKubeResources(roleVersion string, kubeResources []KubernetesResource) error {
 	for _, kubeResource := range kubeResources {
 		for _, verb := range kubeResource.Verbs {

--- a/integrations/operator/controllers/resources/scopedrole_controller_test.go
+++ b/integrations/operator/controllers/resources/scopedrole_controller_test.go
@@ -28,6 +28,7 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
@@ -136,6 +137,12 @@ func (g *scopedRoleTestingPrimitives) ModifyKubernetesResource(ctx context.Conte
 	}
 	role.Spec.AssignableScopes = []string{"/staging/aa", "/staging/bb"}
 	role.Spec.Ssh = accessv1.ScopedRoleSSH_builder{
+		Labels: []*labelv1.Label{
+			labelv1.Label_builder{
+				Name:   "*",
+				Values: []string{"*"},
+			}.Build(),
+		},
 		HostSudoers: []string{"test"},
 	}.Build()
 	return trace.Wrap(g.setup.K8sClient.Update(ctx, role))

--- a/integrations/terraform/testlib/fixtures/scoped_role_1_update.tf
+++ b/integrations/terraform/testlib/fixtures/scoped_role_1_update.tf
@@ -14,6 +14,10 @@ resource "teleport_scoped_role" "test" {
       verbs     = ["read", "list", "create"]
     }]
     ssh = {
+      labels = [{
+        name   = "*"
+        values = ["*"]
+      }]
       logins = ["root"]
     }
   }

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
@@ -973,6 +974,12 @@ func TestBasicSSHScopedLogin(t *testing.T) {
 	})
 	require.Error(t, err)
 
+	wildcardLabels := []*labelv1.Label{
+		labelv1.Label_builder{
+			Name:   "*",
+			Values: []string{"*"},
+		}.Build(),
+	}
 	// set up some scoped roles
 	scopedRoles := []*scopedaccessv1.ScopedRole{
 		scopedaccessv1.ScopedRole_builder{
@@ -984,6 +991,7 @@ func TestBasicSSHScopedLogin(t *testing.T) {
 			Spec: scopedaccessv1.ScopedRoleSpec_builder{
 				AssignableScopes: []string{"/aa"},
 				Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+					Labels: wildcardLabels,
 					Logins: []string{"login-a"},
 				}.Build(),
 			}.Build(),
@@ -998,6 +1006,7 @@ func TestBasicSSHScopedLogin(t *testing.T) {
 			Spec: scopedaccessv1.ScopedRoleSpec_builder{
 				AssignableScopes: []string{"/aa/bb"},
 				Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+					Labels: wildcardLabels,
 					Logins: []string{"login-b"},
 				}.Build(),
 			}.Build(),
@@ -1012,6 +1021,7 @@ func TestBasicSSHScopedLogin(t *testing.T) {
 			Spec: scopedaccessv1.ScopedRoleSpec_builder{
 				AssignableScopes: []string{"/aa/bb/cc"},
 				Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+					Labels: wildcardLabels,
 					Logins: []string{"login-c"},
 				}.Build(),
 			}.Build(),
@@ -1026,6 +1036,7 @@ func TestBasicSSHScopedLogin(t *testing.T) {
 			Spec: scopedaccessv1.ScopedRoleSpec_builder{
 				AssignableScopes: []string{"/xx"},
 				Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+					Labels: wildcardLabels,
 					Logins: []string{"login-x"},
 				}.Build(),
 			}.Build(),

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -1326,6 +1326,15 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 				Kube: scopedaccessv1.ScopedRoleKube_builder{
 					Users:  []string{"scoped_kube_user"},
 					Groups: []string{"scoped_kube_group"},
+					Resources: []*scopedaccessv1.KubeResource{
+						scopedaccessv1.KubeResource_builder{
+							Kind:      "*",
+							Namespace: "*",
+							Name:      "*",
+							ApiGroup:  "*",
+							Verbs:     []string{"*"},
+						}.Build(),
+					},
 					Labels: []*labelv1.Label{
 						labelv1.Label_builder{
 							Name:   types.Wildcard,
@@ -5918,6 +5927,15 @@ func TestListResources_KindKubernetesCluster(t *testing.T) {
 					Kube: scopedaccessv1.ScopedRoleKube_builder{
 						Users:  []string{"kube_user"},
 						Groups: []string{"kube_group"},
+						Resources: []*scopedaccessv1.KubeResource{
+							scopedaccessv1.KubeResource_builder{
+								Kind:      "*",
+								Namespace: "*",
+								Name:      "*",
+								ApiGroup:  "*",
+								Verbs:     []string{"*"},
+							}.Build(),
+						},
 						Labels: []*labelv1.Label{
 							labelv1.Label_builder{
 								Name:   types.Wildcard,
@@ -13868,6 +13886,15 @@ func TestScopedUserCertGeneration(t *testing.T) {
 				Kube: scopedaccessv1.ScopedRoleKube_builder{
 					Users:  []string{"kube_user"},
 					Groups: []string{"kube_group"},
+					Resources: []*scopedaccessv1.KubeResource{
+						scopedaccessv1.KubeResource_builder{
+							Kind:      "*",
+							Namespace: "*",
+							Name:      "*",
+							ApiGroup:  "*",
+							Verbs:     []string{"*"},
+						}.Build(),
+					},
 					Labels: []*labelv1.Label{
 						labelv1.Label_builder{
 							Name:   types.Wildcard,

--- a/lib/kube/proxy/exec_test.go
+++ b/lib/kube/proxy/exec_test.go
@@ -72,6 +72,27 @@ var (
 	stdinContent             = []byte("stdin_data")
 )
 
+func wildcardResource() []*accessv1.KubeResource {
+	return []*accessv1.KubeResource{
+		accessv1.KubeResource_builder{
+			Kind:      types.Wildcard,
+			Name:      types.Wildcard,
+			Namespace: types.Wildcard,
+			ApiGroup:  types.Wildcard,
+			Verbs:     []string{types.Wildcard},
+		}.Build(),
+	}
+}
+
+func wildcardLabel() []*labelv1.Label {
+	return []*labelv1.Label{
+		labelv1.Label_builder{
+			Name:   types.Wildcard,
+			Values: []string{types.Wildcard},
+		}.Build(),
+	}
+}
+
 func testExecKubeService(t *testing.T, testCtx *TestContext) {
 	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
 	userWithSingleKubeUser, _ := testCtx.CreateUserAndRole(
@@ -118,14 +139,10 @@ func testExecKubeService(t *testing.T, testCtx *TestContext) {
 		accessv1.ScopedRoleSpec_builder{
 			AssignableScopes: []string{scopedTestScope},
 			Kube: accessv1.ScopedRoleKube_builder{
-				Users:  roleKubeUsers,
-				Groups: roleKubeGroups,
-				Labels: []*labelv1.Label{
-					labelv1.Label_builder{
-						Name:   types.Wildcard,
-						Values: []string{types.Wildcard},
-					}.Build(),
-				},
+				Users:     roleKubeUsers,
+				Groups:    roleKubeGroups,
+				Resources: wildcardResource(),
+				Labels:    wildcardLabel(),
 			}.Build(),
 		}.Build())
 
@@ -136,14 +153,10 @@ func testExecKubeService(t *testing.T, testCtx *TestContext) {
 		accessv1.ScopedRoleSpec_builder{
 			AssignableScopes: []string{scopedTestScope},
 			Kube: accessv1.ScopedRoleKube_builder{
-				Users:  append(slices.Clone(roleKubeUsers), "admin"),
-				Groups: roleKubeGroups,
-				Labels: []*labelv1.Label{
-					labelv1.Label_builder{
-						Name:   types.Wildcard,
-						Values: []string{types.Wildcard},
-					}.Build(),
-				},
+				Users:     append(slices.Clone(roleKubeUsers), "admin"),
+				Groups:    roleKubeGroups,
+				Resources: wildcardResource(),
+				Labels:    wildcardLabel(),
 			}.Build(),
 		}.Build(),
 	)
@@ -692,14 +705,10 @@ func TestExecMissingGETPermissionError(t *testing.T) {
 					accessv1.ScopedRoleSpec_builder{
 						AssignableScopes: []string{scopedTestScope},
 						Kube: accessv1.ScopedRoleKube_builder{
-							Users:  roleKubeUsers,
-							Groups: roleKubeGroups,
-							Labels: []*labelv1.Label{
-								labelv1.Label_builder{
-									Name:   types.Wildcard,
-									Values: []string{types.Wildcard},
-								}.Build(),
-							},
+							Users:     roleKubeUsers,
+							Groups:    roleKubeGroups,
+							Resources: wildcardResource(),
+							Labels:    wildcardLabel(),
 						}.Build(),
 					}.Build())
 

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1361,7 +1361,7 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 	// If the user has active Access requests we need to validate that they allow
 	// the kubeResource.
 	// This is required because CheckAccess does not validate the subresource type.
-	// TODO(eriktate/scopes): scoped identities don't support resources or access requests, so we skip
+	// TODO(eriktate/scopes): scoped identities don't support access requests, so we skip
 	// these checks for now.
 	if !isScoped && !actx.metaResource.isList {
 		if rbacResource := actx.metaResource.rbacResource(); rbacResource != nil && len(unscopedCtx.Checker.GetAllowedResourceAccessIDs()) > 0 {

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -60,7 +60,6 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
-	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -1815,9 +1814,8 @@ func newScopedKubeAuthorizer(t *testing.T, cfg scopedKubeAuthorizerConfig) mockA
 		Spec: scopedaccessv1.ScopedRoleSpec_builder{
 			AssignableScopes: []string{scopedTestScope},
 			Kube: scopedaccessv1.ScopedRoleKube_builder{
-				Labels: []*labelv1.Label{
-					labelv1.Label_builder{Name: types.Wildcard, Values: []string{types.Wildcard}}.Build(),
-				},
+				Labels:                wildcardLabel(),
+				Resources:             wildcardResource(),
 				Groups:                cfg.kubeGroups,
 				Users:                 cfg.kubeUsers,
 				Lock:                  lock,

--- a/lib/kube/proxy/resource_rbac_test.go
+++ b/lib/kube/proxy/resource_rbac_test.go
@@ -52,13 +52,14 @@ import (
 	restclientwatch "k8s.io/client-go/rest/watch"
 	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
 	tkm "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
@@ -98,75 +99,88 @@ func TestListPodRBAC(t *testing.T) {
 	// close tests
 	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
 
-	// create a user with full access to kubernetes Pods.
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithFullAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithFullAccess,
-		RoleSpec{
-			Name:       usernameWithFullAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow, []types.KubernetesResource{
-					{
-						Kind:      "pods",
-						Name:      types.Wildcard,
-						Namespace: types.Wildcard,
-						Verbs:     []string{types.Wildcard},
-						APIGroup:  types.Wildcard,
-					},
-				})
+	kubeResourceDefs := map[string][]types.KubernetesResource{
+		usernameWithFullAccess: []types.KubernetesResource{
+			{
+				Kind:      "pods",
+				Name:      types.Wildcard,
+				Namespace: types.Wildcard,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  types.Wildcard,
 			},
 		},
-	)
+		usernameWithNamespaceAccess: []types.KubernetesResource{
+			{
+				Kind:      "pods",
+				Name:      types.Wildcard,
+				Namespace: metav1.NamespaceDefault,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  types.Wildcard,
+			},
+		},
+		usernameWithLimitedAccess: []types.KubernetesResource{
+			{
+				Kind:      "pods",
+				Name:      "nginx-*",
+				Namespace: metav1.NamespaceDefault,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  types.Wildcard,
+			},
+		},
+		usernameWithoutListVerbAccess: []types.KubernetesResource{
+			{
+				Kind:      "pods",
+				Name:      "*",
+				Namespace: metav1.NamespaceDefault,
+				Verbs:     []string{"get"},
+				APIGroup:  types.Wildcard,
+			},
+		},
+	}
 
-	scopedUserWithFullAccess, scopedRoleWithFullAccess := testCtx.CreateUserAndScopedRole(
-		t,
-		"scoped-"+usernameWithFullAccess,
-		scope,
-		accessv1.ScopedRoleSpec_builder{
-			AssignableScopes: []string{scope},
-			Kube: accessv1.ScopedRoleKube_builder{
-				Users:  roleKubeUsers,
-				Groups: roleKubeGroups,
-				Labels: []*labelv1.Label{
-					labelv1.Label_builder{
-						Name:   types.Wildcard,
-						Values: []string{types.Wildcard},
-					}.Build(),
+	scopedAssignments := make([]*accessv1.CreateScopedRoleAssignmentResponse, 0, len(kubeResourceDefs))
+	users := make(map[string]types.User)
+	for username, kubeResources := range kubeResourceDefs {
+		// create unscoped user
+		unscopedUser, _ := testCtx.CreateUserAndRole(
+			testCtx.Context,
+			t,
+			username,
+			RoleSpec{
+				Name:       username,
+				KubeUsers:  roleKubeUsers,
+				KubeGroups: roleKubeGroups,
+				SetupRoleFunc: func(r types.Role) {
+					r.SetKubeResources(types.Allow, kubeResources)
 				},
-			}.Build(),
-		}.Build())
-	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
-
-	// create a user with full access to kubernetes Pods.
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithNamespaceAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithNamespaceAccess,
-		RoleSpec{
-			Name:       usernameWithNamespaceAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow,
-					[]types.KubernetesResource{
-						{
-							Kind:      "pods",
-							Name:      types.Wildcard,
-							Namespace: metav1.NamespaceDefault,
-							Verbs:     []string{types.Wildcard},
-							APIGroup:  types.Wildcard,
-						},
-					})
 			},
-		},
-	)
+		)
+		users[unscopedUser.GetName()] = unscopedUser
 
+		// create scoped user
+		scopedResources := make([]*accessv1.KubeResource, len(kubeResources))
+		for idx, resource := range kubeResources {
+			scopedResources[idx] = toScopedKubeResource(resource)
+		}
+		scopedUser, scopedAssignment := testCtx.CreateUserAndScopedRole(
+			t,
+			scopedUsername(username),
+			scope,
+			accessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{scope},
+				Kube: accessv1.ScopedRoleKube_builder{
+					Users:     roleKubeUsers,
+					Groups:    roleKubeGroups,
+					Labels:    wildcardLabel(),
+					Resources: scopedResources,
+				}.Build(),
+			}.Build())
+		scopedAssignments = append(scopedAssignments, scopedAssignment)
+		users[scopedUser.GetName()] = scopedUser
+	}
+	waitForSRACache(t, testCtx.TLSServer, scopedAssignments...)
+
+	// create a user with traits
 	userWithTraits, _ := testCtx.CreateUserWithTraitsAndRole(
 		testCtx.Context,
 		t,
@@ -192,60 +206,7 @@ func TestListPodRBAC(t *testing.T) {
 			},
 		},
 	)
-
-	// create a moderator user with access to kubernetes
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithLimitedAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithLimitedAccess,
-		RoleSpec{
-			Name:       usernameWithLimitedAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow,
-					[]types.KubernetesResource{
-						{
-							Kind:      "pods",
-							Name:      "nginx-*",
-							Namespace: metav1.NamespaceDefault,
-							Verbs:     []string{types.Wildcard},
-							APIGroup:  types.Wildcard,
-						},
-					},
-				)
-			},
-		},
-	)
-	// create a moderator user with access to kubernetes
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithoutListVerb, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithoutListVerbAccess,
-		RoleSpec{
-			Name:       usernameWithoutListVerbAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow,
-					[]types.KubernetesResource{
-						{
-							Kind:      "pods",
-							Name:      "*",
-							Namespace: metav1.NamespaceDefault,
-							Verbs:     []string{"get"},
-							APIGroup:  types.Wildcard,
-						},
-					},
-				)
-			},
-		},
-	)
-
-	// create a user allowed to access all namespaces except the default namespace.
-	// (kubernetes_user and kubernetes_groups specified)
+	// create a user with deny rules
 	userWithDenyRule, _ := testCtx.CreateUserAndRole(
 		testCtx.Context,
 		t,
@@ -291,11 +252,6 @@ func TestListPodRBAC(t *testing.T) {
 		listPodErr       error
 		getTestPodResult error
 	}
-	scopedOpts := []GenTestKubeClientTLSCertOptions{
-		func(i *tlsca.Identity) {
-			i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
-		},
-	}
 	tests := []struct {
 		name string
 		args args
@@ -304,7 +260,7 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "list default namespace pods for user with full access",
 			args: args{
-				user:      userWithFullAccess,
+				user:      users[usernameWithFullAccess],
 				namespace: metav1.NamespaceDefault,
 			},
 			want: want{
@@ -318,9 +274,9 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "list default namespace pods for scoped user with full access",
 			args: args{
-				user:      scopedUserWithFullAccess,
+				user:      users[scopedUsername(usernameWithFullAccess)],
 				namespace: metav1.NamespaceDefault,
-				opts:      scopedOpts,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithFullAccess), scope),
 			},
 			want: want{
 				listPodsResult: []string{
@@ -333,7 +289,7 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "list pods in every namespace for user with full access",
 			args: args{
-				user:      userWithFullAccess,
+				user:      users[usernameWithFullAccess],
 				namespace: metav1.NamespaceAll,
 			},
 			want: want{
@@ -349,9 +305,9 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "list pods in every namespace for scoped user with full access",
 			args: args{
-				user:      scopedUserWithFullAccess,
+				user:      users[scopedUsername(usernameWithFullAccess)],
 				namespace: metav1.NamespaceAll,
-				opts:      scopedOpts,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithFullAccess), scope),
 			},
 			want: want{
 				listPodsResult: []string{
@@ -366,8 +322,23 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "list default namespace pods for user with default namespace",
 			args: args{
-				user:      userWithNamespaceAccess,
+				user:      users[usernameWithNamespaceAccess],
 				namespace: metav1.NamespaceDefault,
+			},
+			want: want{
+				listPodsResult: []string{
+					"default/nginx-1",
+					"default/nginx-2",
+					"default/test",
+				},
+			},
+		},
+		{
+			name: "list default namespace pods for scoped user with default namespace",
+			args: args{
+				user:      users[scopedUsername(usernameWithNamespaceAccess)],
+				namespace: metav1.NamespaceDefault,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithNamespaceAccess), scope),
 			},
 			want: want{
 				listPodsResult: []string{
@@ -380,8 +351,23 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "list pods in every namespace for user with default namespace",
 			args: args{
-				user:      userWithNamespaceAccess,
+				user:      users[usernameWithNamespaceAccess],
 				namespace: metav1.NamespaceAll,
+			},
+			want: want{
+				listPodsResult: []string{
+					"default/nginx-1",
+					"default/nginx-2",
+					"default/test",
+				},
+			},
+		},
+		{
+			name: "list pods in every namespace for scoped user with default namespace",
+			args: args{
+				user:      users[scopedUsername(usernameWithNamespaceAccess)],
+				namespace: metav1.NamespaceAll,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithNamespaceAccess), scope),
 			},
 			want: want{
 				listPodsResult: []string{
@@ -422,7 +408,7 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "list default namespace pods for user with limited access",
 			args: args{
-				user:      userWithLimitedAccess,
+				user:      users[usernameWithLimitedAccess],
 				namespace: metav1.NamespaceDefault,
 			},
 			want: want{
@@ -434,6 +420,28 @@ func TestListPodRBAC(t *testing.T) {
 					ErrStatus: metav1.Status{
 						Status:  "Failure",
 						Message: "pods \"test\" is forbidden: User \"limited_user\" cannot get resource \"pods\" in API group \"\" in the namespace \"default\"",
+						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
+					},
+				},
+			},
+		},
+		{
+			name: "list default namespace pods for scoped user with limited access",
+			args: args{
+				user:      users[scopedUsername(usernameWithLimitedAccess)],
+				namespace: metav1.NamespaceDefault,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithLimitedAccess), scope),
+			},
+			want: want{
+				listPodsResult: []string{
+					"default/nginx-1",
+					"default/nginx-2",
+				},
+				getTestPodResult: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  "Failure",
+						Message: "pods \"test\" is forbidden: User \"scoped-limited_user\" cannot get resource \"pods\" in API group \"\" in the namespace \"default\"",
 						Code:    403,
 						Reason:  metav1.StatusReasonForbidden,
 					},
@@ -463,7 +471,7 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "list default namespace pods for user with limited access and a resource access request",
 			args: args{
-				user:      userWithNamespaceAccess,
+				user:      users[usernameWithNamespaceAccess],
 				namespace: metav1.NamespaceDefault,
 				opts: []GenTestKubeClientTLSCertOptions{
 					WithResourceAccessRequests(
@@ -497,7 +505,7 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "user with legacy pod access request that no longer fullfills the role requirements",
 			args: args{
-				user:      userWithLimitedAccess,
+				user:      users[usernameWithLimitedAccess],
 				namespace: metav1.NamespaceDefault,
 				opts: []GenTestKubeClientTLSCertOptions{
 					WithResourceAccessRequests(
@@ -535,7 +543,7 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "user with pod access request that no longer fullfills the role requirements",
 			args: args{
-				user:      userWithLimitedAccess,
+				user:      users[usernameWithLimitedAccess],
 				namespace: metav1.NamespaceDefault,
 				opts: []GenTestKubeClientTLSCertOptions{
 					WithResourceAccessRequests(
@@ -573,7 +581,7 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "list default namespace pods for user with limited access",
 			args: args{
-				user:      userWithoutListVerb,
+				user:      users[usernameWithoutListVerbAccess],
 				namespace: metav1.NamespaceDefault,
 			},
 			want: want{
@@ -582,6 +590,25 @@ func TestListPodRBAC(t *testing.T) {
 					ErrStatus: metav1.Status{
 						Status:  "Failure",
 						Message: "pods is forbidden: User \"no_list_user\" cannot list resource \"pods\" in API group \"\" in the namespace \"default\"",
+						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
+					},
+				},
+			},
+		},
+		{
+			name: "list default namespace pods for scoped user with limited access",
+			args: args{
+				user:      users[scopedUsername(usernameWithoutListVerbAccess)],
+				namespace: metav1.NamespaceDefault,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithoutListVerbAccess), scope),
+			},
+			want: want{
+				listPodsResult: []string{},
+				listPodErr: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  "Failure",
+						Message: "pods is forbidden: User \"scoped-no_list_user\" cannot list resource \"pods\" in API group \"\" in the namespace \"default\"",
 						Code:    403,
 						Reason:  metav1.StatusReasonForbidden,
 					},
@@ -1158,110 +1185,80 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 	// close tests
 	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
 
-	// create a user with full access to kubernetes Pods.
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithFullAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithFullAccess,
-		RoleSpec{
-			Name:       usernameWithFullAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow, []types.KubernetesResource{
-					{
-						Kind:      "pods",
-						Name:      types.Wildcard,
-						Namespace: types.Wildcard,
-						Verbs:     []string{types.Wildcard},
-						APIGroup:  types.Wildcard,
-					},
-				})
+	kubeResourceDefs := map[string][]types.KubernetesResource{
+		usernameWithFullAccess: []types.KubernetesResource{
+			{
+				Kind:      "pods",
+				Name:      types.Wildcard,
+				Namespace: types.Wildcard,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  types.Wildcard,
 			},
 		},
-	)
+		usernameWithNamespaceAccess: []types.KubernetesResource{
+			{
+				Kind:      "pods",
+				Name:      types.Wildcard,
+				Namespace: metav1.NamespaceDefault,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  types.Wildcard,
+			},
+		},
+		usernameWithLimitedAccess: []types.KubernetesResource{
+			{
+				Kind:      "pods",
+				Name:      "nginx-*",
+				Namespace: metav1.NamespaceDefault,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  types.Wildcard,
+			},
+		},
+	}
 
-	scopedUserWithFullAccess, scopedRoleWithFullAccess := testCtx.CreateUserAndScopedRole(
-		t,
-		"scoped-"+usernameWithFullAccess,
-		scope,
-		accessv1.ScopedRoleSpec_builder{
-			AssignableScopes: []string{scope},
-			Kube: accessv1.ScopedRoleKube_builder{
-				Users:  roleKubeUsers,
-				Groups: roleKubeGroups,
-				Labels: []*labelv1.Label{
-					labelv1.Label_builder{
-						Name:   types.Wildcard,
-						Values: []string{types.Wildcard},
-					}.Build(),
+	scopedAssignments := make([]*accessv1.CreateScopedRoleAssignmentResponse, 0, len(kubeResourceDefs))
+	users := make(map[string]types.User)
+	for username, kubeResources := range kubeResourceDefs {
+		unscopedUser, _ := testCtx.CreateUserAndRole(
+			testCtx.Context,
+			t,
+			username,
+			RoleSpec{
+				Name:       username,
+				KubeUsers:  roleKubeUsers,
+				KubeGroups: roleKubeGroups,
+				SetupRoleFunc: func(r types.Role) {
+					r.SetKubeResources(types.Allow, kubeResources)
 				},
-			}.Build(),
-		}.Build())
-	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
-
-	// create a user with full access to kubernetes Pods.
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithNamespaceAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithNamespaceAccess,
-		RoleSpec{
-			Name:       usernameWithNamespaceAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow,
-					[]types.KubernetesResource{
-						{
-							Kind:      "pods",
-							Name:      types.Wildcard,
-							Namespace: metav1.NamespaceDefault,
-							Verbs:     []string{types.Wildcard},
-							APIGroup:  types.Wildcard,
-						},
-					})
 			},
-		},
-	)
+		)
+		users[unscopedUser.GetName()] = unscopedUser
 
-	// create a moderator user with access to kubernetes
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithLimitedAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithLimitedAccess,
-		RoleSpec{
-			Name:       usernameWithLimitedAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow,
-					[]types.KubernetesResource{
-						{
-							Kind:      "pods",
-							Name:      "nginx-*",
-							Namespace: metav1.NamespaceDefault,
-							Verbs:     []string{types.Wildcard},
-							APIGroup:  types.Wildcard,
-						},
-					},
-				)
-			},
-		},
-	)
+		scopedResources := make([]*accessv1.KubeResource, len(kubeResources))
+		for idx, resource := range kubeResources {
+			scopedResources[idx] = toScopedKubeResource(resource)
+		}
+		scopedUser, scopedAssignment := testCtx.CreateUserAndScopedRole(
+			t,
+			scopedUsername(username),
+			scope,
+			accessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{scope},
+				Kube: accessv1.ScopedRoleKube_builder{
+					Users:     roleKubeUsers,
+					Groups:    roleKubeGroups,
+					Labels:    wildcardLabel(),
+					Resources: scopedResources,
+				}.Build(),
+			}.Build())
+		scopedAssignments = append(scopedAssignments, scopedAssignment)
+		users[scopedUser.GetName()] = scopedUser
+	}
+	waitForSRACache(t, testCtx.TLSServer, scopedAssignments...)
 
 	type args struct {
 		user      types.User
 		namespace string
 		opts      []GenTestKubeClientTLSCertOptions
-	}
-	scopedOpts := []GenTestKubeClientTLSCertOptions{
-		func(i *tlsca.Identity) {
-			i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
-		},
 	}
 	tests := []struct {
 		name        string
@@ -1272,7 +1269,7 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 		{
 			name: "delete pods in default namespace for user with full access",
 			args: args{
-				user:      userWithFullAccess,
+				user:      users[usernameWithFullAccess],
 				namespace: metav1.NamespaceDefault,
 			},
 
@@ -1285,9 +1282,9 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 		{
 			name: "delete pods in default namespace for scoped user with full access",
 			args: args{
-				user:      scopedUserWithFullAccess,
+				user:      users[scopedUsername(usernameWithFullAccess)],
 				namespace: metav1.NamespaceDefault,
-				opts:      scopedOpts,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithFullAccess), scope),
 			},
 
 			deletedPods: []string{
@@ -1299,8 +1296,21 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 		{
 			name: "delete pods for user limited to default namespace",
 			args: args{
-				user:      userWithNamespaceAccess,
+				user:      users[usernameWithNamespaceAccess],
 				namespace: metav1.NamespaceDefault,
+			},
+			deletedPods: []string{
+				"default/nginx-1",
+				"default/nginx-2",
+				"default/test",
+			},
+		},
+		{
+			name: "delete pods for scoped user limited to default namespace",
+			args: args{
+				user:      users[scopedUsername(usernameWithNamespaceAccess)],
+				namespace: metav1.NamespaceDefault,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithNamespaceAccess), scope),
 			},
 			deletedPods: []string{
 				"default/nginx-1",
@@ -1311,8 +1321,18 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 		{
 			name: "delete pods in dev namespace for user limited to default",
 			args: args{
-				user:      userWithNamespaceAccess,
+				user:      users[usernameWithNamespaceAccess],
 				namespace: "dev",
+			},
+			wantErr:     true,
+			deletedPods: []string{},
+		},
+		{
+			name: "delete pods in dev namespace for scoped user limited to default",
+			args: args{
+				user:      users[scopedUsername(usernameWithNamespaceAccess)],
+				namespace: "dev",
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithNamespaceAccess), scope),
 			},
 			wantErr:     true,
 			deletedPods: []string{},
@@ -1320,8 +1340,21 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 		{
 			name: "delete pods in default namespace for user with limited access",
 			args: args{
-				user:      userWithLimitedAccess,
+				user:      users[usernameWithLimitedAccess],
 				namespace: metav1.NamespaceDefault,
+			},
+
+			deletedPods: []string{
+				"default/nginx-1",
+				"default/nginx-2",
+			},
+		},
+		{
+			name: "delete pods in default namespace for scoped user with limited access",
+			args: args{
+				user:      users[scopedUsername(usernameWithLimitedAccess)],
+				namespace: metav1.NamespaceDefault,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithLimitedAccess), scope),
 			},
 
 			deletedPods: []string{
@@ -1396,112 +1429,80 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 	// close tests
 	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
 
-	// create a user with full access to kubernetes Pods.
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithFullAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithFullAccess,
-		RoleSpec{
-			Name:       usernameWithFullAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow, []types.KubernetesResource{
-					{
-						Kind:      "teleportroles",
-						Name:      types.Wildcard,
-						Namespace: types.Wildcard,
-						Verbs:     []string{types.Wildcard},
-						APIGroup:  "resources.teleport.dev",
-					},
-				})
+	kubeResourceDefs := map[string][]types.KubernetesResource{
+		usernameWithFullAccess: []types.KubernetesResource{
+			{
+				Kind:      "teleportroles",
+				Name:      types.Wildcard,
+				Namespace: types.Wildcard,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  "resources.teleport.dev",
 			},
 		},
-	)
+		usernameWithNamespaceAccess: []types.KubernetesResource{
+			{
+				Kind:      "teleportroles",
+				Name:      types.Wildcard,
+				Namespace: metav1.NamespaceDefault,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  "resources.teleport.dev",
+			},
+		},
+		usernameWithLimitedAccess: []types.KubernetesResource{
+			{
+				Kind:      "teleportroles",
+				Name:      "*-test",
+				Namespace: metav1.NamespaceDefault,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  "resources.teleport.dev",
+			},
+		},
+	}
 
-	// create a scoped user with full access to kubernetes Pods.
-	// (kubernetes_user and kubernetes_groups specified)
-	scopedUserWithFullAccess, scopedRoleWithFullAccess := testCtx.CreateUserAndScopedRole(
-		t,
-		"scoped-"+usernameWithFullAccess,
-		scope,
-		accessv1.ScopedRoleSpec_builder{
-			AssignableScopes: []string{scope},
-			Kube: accessv1.ScopedRoleKube_builder{
-				Users:  roleKubeUsers,
-				Groups: roleKubeGroups,
-				Labels: []*labelv1.Label{
-					labelv1.Label_builder{
-						Name:   types.Wildcard,
-						Values: []string{types.Wildcard},
-					}.Build(),
+	scopedAssignments := make([]*accessv1.CreateScopedRoleAssignmentResponse, 0, len(kubeResourceDefs))
+	users := make(map[string]types.User)
+	for username, kubeResources := range kubeResourceDefs {
+		unscopedUser, _ := testCtx.CreateUserAndRole(
+			testCtx.Context,
+			t,
+			username,
+			RoleSpec{
+				Name:       username,
+				KubeUsers:  roleKubeUsers,
+				KubeGroups: roleKubeGroups,
+				SetupRoleFunc: func(r types.Role) {
+					r.SetKubeResources(types.Allow, kubeResources)
 				},
-			}.Build(),
-		}.Build())
-	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
-
-	// create a user with full access to kubernetes Pods.
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithNamespaceAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithNamespaceAccess,
-		RoleSpec{
-			Name:       usernameWithNamespaceAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow,
-					[]types.KubernetesResource{
-						{
-							Kind:      "teleportroles",
-							Name:      types.Wildcard,
-							Namespace: metav1.NamespaceDefault,
-							Verbs:     []string{types.Wildcard},
-							APIGroup:  "resources.teleport.dev",
-						},
-					})
 			},
-		},
-	)
+		)
+		users[unscopedUser.GetName()] = unscopedUser
 
-	// create a moderator user with access to kubernetes
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithLimitedAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithLimitedAccess,
-		RoleSpec{
-			Name:       usernameWithLimitedAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow,
-					[]types.KubernetesResource{
-						{
-							Kind:      "teleportroles",
-							Name:      "*-test",
-							Namespace: metav1.NamespaceDefault,
-							Verbs:     []string{types.Wildcard},
-							APIGroup:  "resources.teleport.dev",
-						},
-					},
-				)
-			},
-		},
-	)
+		scopedResources := make([]*accessv1.KubeResource, len(kubeResources))
+		for idx, resource := range kubeResources {
+			scopedResources[idx] = toScopedKubeResource(resource)
+		}
+		scopedUser, scopedAssignment := testCtx.CreateUserAndScopedRole(
+			t,
+			scopedUsername(username),
+			scope,
+			accessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{scope},
+				Kube: accessv1.ScopedRoleKube_builder{
+					Users:     roleKubeUsers,
+					Groups:    roleKubeGroups,
+					Labels:    wildcardLabel(),
+					Resources: scopedResources,
+				}.Build(),
+			}.Build())
+		scopedAssignments = append(scopedAssignments, scopedAssignment)
+		users[scopedUser.GetName()] = scopedUser
+	}
+	waitForSRACache(t, testCtx.TLSServer, scopedAssignments...)
 
 	type args struct {
 		user      types.User
 		namespace string
 		opts      []GenTestKubeClientTLSCertOptions
-	}
-	scopedOpts := []GenTestKubeClientTLSCertOptions{
-		func(i *tlsca.Identity) {
-			i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
-		},
 	}
 	tests := []struct {
 		name        string
@@ -1512,7 +1513,7 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 		{
 			name: "delete teleportroles in default namespace for user with full access",
 			args: args{
-				user:      userWithFullAccess,
+				user:      users[usernameWithFullAccess],
 				namespace: metav1.NamespaceDefault,
 			},
 
@@ -1526,9 +1527,9 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 		{
 			name: "delete teleportroles in default namespace for scoped user with full access",
 			args: args{
-				user:      scopedUserWithFullAccess,
+				user:      users[scopedUsername(usernameWithFullAccess)],
 				namespace: metav1.NamespaceDefault,
-				opts:      scopedOpts,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithFullAccess), scope),
 			},
 
 			deletedCRDs: []string{
@@ -1541,8 +1542,22 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 		{
 			name: "delete teleportroles for user limited to default namespace",
 			args: args{
-				user:      userWithNamespaceAccess,
+				user:      users[usernameWithNamespaceAccess],
 				namespace: metav1.NamespaceDefault,
+			},
+			deletedCRDs: []string{
+				"default/telerole-1",
+				"default/telerole-1",
+				"default/telerole-2",
+				"default/telerole-test",
+			},
+		},
+		{
+			name: "delete teleportroles for scoped user limited to default namespace",
+			args: args{
+				user:      users[scopedUsername(usernameWithNamespaceAccess)],
+				namespace: metav1.NamespaceDefault,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithNamespaceAccess), scope),
 			},
 			deletedCRDs: []string{
 				"default/telerole-1",
@@ -1554,8 +1569,18 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 		{
 			name: "delete teleportroles in dev namespace for user limited to default",
 			args: args{
-				user:      userWithNamespaceAccess,
+				user:      users[usernameWithNamespaceAccess],
 				namespace: "dev",
+			},
+			wantErr:     true,
+			deletedCRDs: []string{},
+		},
+		{
+			name: "delete teleportroles in dev namespace for scoped user limited to default",
+			args: args{
+				user:      users[scopedUsername(usernameWithNamespaceAccess)],
+				namespace: "dev",
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithNamespaceAccess), scope),
 			},
 			wantErr:     true,
 			deletedCRDs: []string{},
@@ -1563,8 +1588,20 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 		{
 			name: "delete teleportroles in default namespace for user with limited access",
 			args: args{
-				user:      userWithLimitedAccess,
+				user:      users[usernameWithLimitedAccess],
 				namespace: metav1.NamespaceDefault,
+			},
+
+			deletedCRDs: []string{
+				"default/telerole-test",
+			},
+		},
+		{
+			name: "delete teleportroles in default namespace for scoped user with limited access",
+			args: args{
+				user:      users[scopedUsername(usernameWithLimitedAccess)],
+				namespace: metav1.NamespaceDefault,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithLimitedAccess), scope),
 			},
 
 			deletedCRDs: []string{
@@ -1642,84 +1679,68 @@ func TestListClusterRoleRBAC(t *testing.T) {
 	// close tests
 	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
 
-	// create a user with full access to kubernetes Pods.
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithFullAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithFullAccess,
-		RoleSpec{
-			Name:       usernameWithFullAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow, []types.KubernetesResource{
-					{
-						Kind:     "clusterroles",
-						Name:     types.Wildcard,
-						Verbs:    []string{types.Wildcard},
-						APIGroup: types.Wildcard,
-					},
-				})
+	kubeResourceDefs := map[string][]types.KubernetesResource{
+		usernameWithFullAccess: []types.KubernetesResource{
+			{
+				Kind:     "clusterroles",
+				Name:     types.Wildcard,
+				Verbs:    []string{types.Wildcard},
+				APIGroup: types.Wildcard,
 			},
 		},
-	)
+		usernameWithLimitedAccess: []types.KubernetesResource{
+			{
+				Kind:     "clusterroles",
+				Name:     "cr-nginx-*",
+				Verbs:    []string{types.Wildcard},
+				APIGroup: types.Wildcard,
+			},
+		},
+	}
 
-	// create a scoped user with full access to kubernetes Pods.
-	// (kubernetes_user and kubernetes_groups specified)
-	scopedUserWithFullAccess, scopedRoleWithFullAccess := testCtx.CreateUserAndScopedRole(
-		t,
-		"scoped-"+usernameWithFullAccess,
-		scope,
-		accessv1.ScopedRoleSpec_builder{
-			AssignableScopes: []string{scope},
-			Kube: accessv1.ScopedRoleKube_builder{
-				Users:  roleKubeUsers,
-				Groups: roleKubeGroups,
-				Labels: []*labelv1.Label{
-					labelv1.Label_builder{
-						Name:   types.Wildcard,
-						Values: []string{types.Wildcard},
-					}.Build(),
+	scopedAssignments := make([]*accessv1.CreateScopedRoleAssignmentResponse, 0, len(kubeResourceDefs))
+	users := make(map[string]types.User)
+	for username, kubeResources := range kubeResourceDefs {
+		unscopedUser, _ := testCtx.CreateUserAndRole(
+			testCtx.Context,
+			t,
+			username,
+			RoleSpec{
+				Name:       username,
+				KubeUsers:  roleKubeUsers,
+				KubeGroups: roleKubeGroups,
+				SetupRoleFunc: func(r types.Role) {
+					r.SetKubeResources(types.Allow, kubeResources)
 				},
-			}.Build(),
-		}.Build())
-	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
-
-	// Create a moderator user with access to kubernetes
-	// (kubernetes_user and kubernetes_groups specified).
-	userWithLimitedAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithLimitedAccess,
-		RoleSpec{
-			Name:       usernameWithLimitedAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow,
-					[]types.KubernetesResource{
-						{
-							Kind:     "clusterroles",
-							Name:     "cr-nginx-*",
-							Verbs:    []string{types.Wildcard},
-							APIGroup: types.Wildcard,
-						},
-					},
-				)
 			},
-		},
-	)
+		)
+		users[unscopedUser.GetName()] = unscopedUser
+
+		scopedResources := make([]*accessv1.KubeResource, len(kubeResources))
+		for idx, resource := range kubeResources {
+			scopedResources[idx] = toScopedKubeResource(resource)
+		}
+		scopedUser, scopedAssignment := testCtx.CreateUserAndScopedRole(
+			t,
+			scopedUsername(username),
+			scope,
+			accessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{scope},
+				Kube: accessv1.ScopedRoleKube_builder{
+					Users:     roleKubeUsers,
+					Groups:    roleKubeGroups,
+					Labels:    wildcardLabel(),
+					Resources: scopedResources,
+				}.Build(),
+			}.Build())
+		scopedAssignments = append(scopedAssignments, scopedAssignment)
+		users[scopedUser.GetName()] = scopedUser
+	}
+	waitForSRACache(t, testCtx.TLSServer, scopedAssignments...)
 
 	type args struct {
 		user types.User
 		opts []GenTestKubeClientTLSCertOptions
-	}
-	scopedOpts := []GenTestKubeClientTLSCertOptions{
-		func(i *tlsca.Identity) {
-			i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
-		},
 	}
 	type want struct {
 		listClusterRolesResult []string
@@ -1734,7 +1755,7 @@ func TestListClusterRoleRBAC(t *testing.T) {
 		{
 			name: "list cluster roles for user with full access",
 			args: args{
-				user: userWithFullAccess,
+				user: users[usernameWithFullAccess],
 			},
 			want: want{
 				listClusterRolesResult: []string{
@@ -1747,8 +1768,8 @@ func TestListClusterRoleRBAC(t *testing.T) {
 		{
 			name: "list cluster roles for scoped user with full access",
 			args: args{
-				user: scopedUserWithFullAccess,
-				opts: scopedOpts,
+				user: users[scopedUsername(usernameWithFullAccess)],
+				opts: makeScopedOpts(t, testCtx, scopedUsername(usernameWithFullAccess), scope),
 			},
 			want: want{
 				listClusterRolesResult: []string{
@@ -1761,7 +1782,7 @@ func TestListClusterRoleRBAC(t *testing.T) {
 		{
 			name: "list cluster roles for user with limited access",
 			args: args{
-				user: userWithLimitedAccess,
+				user: users[usernameWithLimitedAccess],
 			},
 			want: want{
 				listClusterRolesResult: []string{
@@ -1778,11 +1799,31 @@ func TestListClusterRoleRBAC(t *testing.T) {
 				},
 			},
 		},
-
+		{
+			name: "list cluster roles for scoped user with limited access",
+			args: args{
+				user: users[scopedUsername(usernameWithLimitedAccess)],
+				opts: makeScopedOpts(t, testCtx, scopedUsername(usernameWithLimitedAccess), scope),
+			},
+			want: want{
+				listClusterRolesResult: []string{
+					"cr-nginx-1",
+					"cr-nginx-2",
+				},
+				getTestResult: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  "Failure",
+						Message: "clusterroles \"cr-test\" is forbidden: User \"scoped-limited_user\" cannot get resource \"clusterroles\" in API group \"rbac.authorization.k8s.io\"",
+						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
+					},
+				},
+			},
+		},
 		{
 			name: "user with cluster role access request that no longer fullfills the role requirements",
 			args: args{
-				user: userWithLimitedAccess,
+				user: users[usernameWithLimitedAccess],
 				opts: []GenTestKubeClientTLSCertOptions{
 					WithResourceAccessRequests(
 						types.ResourceAccessID{
@@ -1877,118 +1918,84 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 
 	kubeScheme, testCtx := newTestKubeCRDMock(t, scope, tkm.WithTeleportRoleCRD)
 
-	// create a user with full access to all namespaces.
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithFullAccess, _ := testCtx.CreateUserAndRoleVersion(
-		testCtx.Context,
-		t,
-		usernameWithFullAccess,
-		types.V8,
-		RoleSpec{
-			Name:       usernameWithFullAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow, []types.KubernetesResource{
-					{
-						Kind:      types.Wildcard,
-						Name:      types.Wildcard,
-						Namespace: types.Wildcard,
-						Verbs:     []string{types.Wildcard},
-						APIGroup:  types.Wildcard,
-					},
-				})
+	kubeResourceDefs := map[string][]types.KubernetesResource{
+		usernameWithFullAccess: []types.KubernetesResource{
+			{
+				Kind:      types.Wildcard,
+				Name:      types.Wildcard,
+				Namespace: types.Wildcard,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  types.Wildcard,
 			},
 		},
-	)
+		usernameWithLimitedAccess: []types.KubernetesResource{
+			{
+				Kind:      types.Wildcard,
+				Name:      types.Wildcard,
+				Namespace: "dev",
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  types.Wildcard,
+			},
+			{
+				Kind:  "namespaces",
+				Name:  "dev",
+				Verbs: []string{types.Wildcard},
+			},
+		},
+		usernameWithSpecificAccess: []types.KubernetesResource{
+			{
+				Kind:      "teleportroles",
+				Name:      types.Wildcard,
+				Namespace: "dev",
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  "resources.teleport.dev",
+			},
+		},
+	}
 
-	// create a scoped user with full access to all namespaces.
-	// (kubernetes_user and kubernetes_groups specified)
-	scopedUserWithFullAccess, scopedRoleWithFullAccess := testCtx.CreateUserAndScopedRole(
-		t,
-		"scoped-"+usernameWithFullAccess,
-		scope,
-		accessv1.ScopedRoleSpec_builder{
-			AssignableScopes: []string{scope},
-			Kube: accessv1.ScopedRoleKube_builder{
-				Users:  roleKubeUsers,
-				Groups: roleKubeGroups,
-				Labels: []*labelv1.Label{
-					labelv1.Label_builder{
-						Name:   types.Wildcard,
-						Values: []string{types.Wildcard},
-					}.Build(),
+	scopedAssignments := make([]*accessv1.CreateScopedRoleAssignmentResponse, 0, len(kubeResourceDefs))
+	users := make(map[string]types.User)
+	for username, kubeResources := range kubeResourceDefs {
+		unscopedUser, _ := testCtx.CreateUserAndRoleVersion(
+			testCtx.Context,
+			t,
+			username,
+			types.V8,
+			RoleSpec{
+				Name:       username,
+				KubeUsers:  roleKubeUsers,
+				KubeGroups: roleKubeGroups,
+				SetupRoleFunc: func(r types.Role) {
+					r.SetKubeResources(types.Allow, kubeResources)
 				},
-			}.Build(),
-		}.Build())
-	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
-
-	// create a user with limited access to kubernetes namespaces.
-	userWithLimitedAccess, _ := testCtx.CreateUserAndRoleVersion(
-		testCtx.Context,
-		t,
-		usernameWithLimitedAccess,
-		types.V8,
-		RoleSpec{
-			Name:       usernameWithLimitedAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow,
-					[]types.KubernetesResource{
-						{
-							Kind:      types.Wildcard,
-							Name:      types.Wildcard,
-							Namespace: "dev",
-							Verbs:     []string{types.Wildcard},
-							APIGroup:  types.Wildcard,
-						},
-						{
-							Kind:  "namespaces",
-							Name:  "dev",
-							Verbs: []string{types.Wildcard},
-						},
-					},
-				)
 			},
-		},
-	)
+		)
+		users[unscopedUser.GetName()] = unscopedUser
 
-	// create a user with limited access to kubernetes namespaces.
-	userWithSpecificAccess, _ := testCtx.CreateUserAndRoleVersion(
-		testCtx.Context,
-		t,
-		usernameWithSpecificAccess,
-		types.V8,
-		RoleSpec{
-			Name:       usernameWithSpecificAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow,
-					[]types.KubernetesResource{
-						{
-							Kind:      "teleportroles",
-							Name:      types.Wildcard,
-							Namespace: "dev",
-							Verbs:     []string{types.Wildcard},
-							APIGroup:  "resources.teleport.dev",
-						},
-					},
-				)
-			},
-		},
-	)
-
+		scopedResources := make([]*accessv1.KubeResource, len(kubeResources))
+		for idx, resource := range kubeResources {
+			scopedResources[idx] = toScopedKubeResource(resource)
+		}
+		scopedUser, scopedAssignment := testCtx.CreateUserAndScopedRole(
+			t,
+			scopedUsername(username),
+			scope,
+			accessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{scope},
+				Kube: accessv1.ScopedRoleKube_builder{
+					Users:     roleKubeUsers,
+					Groups:    roleKubeGroups,
+					Labels:    wildcardLabel(),
+					Resources: scopedResources,
+				}.Build(),
+			}.Build())
+		scopedAssignments = append(scopedAssignments, scopedAssignment)
+		users[scopedUser.GetName()] = scopedUser
+	}
+	waitForSRACache(t, testCtx.TLSServer, scopedAssignments...)
 	type args struct {
 		user types.User
 		opts []GenTestKubeClientTLSCertOptions
-	}
-	scopedOpts := []GenTestKubeClientTLSCertOptions{
-		func(i *tlsca.Identity) {
-			i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
-		},
 	}
 	type want struct {
 		listTeleportRolesResult []string
@@ -2004,7 +2011,7 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "list teleport roles for user with full access",
 			args: args{
-				user: userWithFullAccess,
+				user: users[usernameWithFullAccess],
 			},
 			want: want{
 				listTeleportRolesResult: []string{
@@ -2020,8 +2027,8 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "list teleport roles for scoped user with full access",
 			args: args{
-				user: scopedUserWithFullAccess,
-				opts: scopedOpts,
+				user: users[scopedUsername(usernameWithFullAccess)],
+				opts: makeScopedOpts(t, testCtx, scopedUsername(usernameWithFullAccess), scope),
 			},
 			want: want{
 				listTeleportRolesResult: []string{
@@ -2037,7 +2044,7 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "list teleport roles for user with specific crd access",
 			args: args{
-				user: userWithSpecificAccess,
+				user: users[usernameWithSpecificAccess],
 			},
 			want: want{
 				listTeleportRolesResult: []string{
@@ -2058,9 +2065,33 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 			},
 		},
 		{
+			name: "list teleport roles for scoped user with specific crd access",
+			args: args{
+				user: users[scopedUsername(usernameWithSpecificAccess)],
+				opts: makeScopedOpts(t, testCtx, scopedUsername(usernameWithSpecificAccess), scope),
+			},
+			want: want{
+				listTeleportRolesResult: []string{
+					"dev/telerole-1",
+					"dev/telerole-2",
+				},
+				getTestResult: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status: "Failure",
+						Message: fmt.Sprintf(
+							"teleportroles \"telerole-test\" is forbidden: User %q cannot get resource \"teleportroles\" in API group \"resources.teleport.dev\"",
+							"scoped-"+usernameWithSpecificAccess,
+						),
+						Code:   403,
+						Reason: metav1.StatusReasonForbidden,
+					},
+				},
+			},
+		},
+		{
 			name: "list teleport roles for user with limited access",
 			args: args{
-				user: userWithLimitedAccess,
+				user: users[usernameWithLimitedAccess],
 			},
 			want: want{
 				listTeleportRolesResult: []string{
@@ -2077,11 +2108,31 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 				},
 			},
 		},
-
+		{
+			name: "list teleport roles for scoped user with limited access",
+			args: args{
+				user: users[scopedUsername(usernameWithLimitedAccess)],
+				opts: makeScopedOpts(t, testCtx, scopedUsername(usernameWithLimitedAccess), scope),
+			},
+			want: want{
+				listTeleportRolesResult: []string{
+					"dev/telerole-1",
+					"dev/telerole-2",
+				},
+				getTestResult: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  "Failure",
+						Message: "teleportroles \"telerole-test\" is forbidden: User \"scoped-limited_user\" cannot get resource \"teleportroles\" in API group \"resources.teleport.dev\"",
+						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
+					},
+				},
+			},
+		},
 		{
 			name: "user with namespace access request that no longer fullfills the role requirements",
 			args: args{
-				user: userWithLimitedAccess,
+				user: users[usernameWithLimitedAccess],
 				opts: []GenTestKubeClientTLSCertOptions{
 					WithResourceAccessRequests(
 						types.ResourceAccessID{
@@ -2119,7 +2170,7 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "user with namespace access request that restricts the role requirements",
 			args: args{
-				user: userWithFullAccess,
+				user: users[usernameWithFullAccess],
 				opts: []GenTestKubeClientTLSCertOptions{
 					WithResourceAccessRequests(
 						types.ResourceAccessID{
@@ -2239,9 +2290,10 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 func TestV8JailedNamespaceListRBAC(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
+	const scope = "/test"
+	_, testCtx := newTestKubeCRDMock(t, scope, tkm.WithTeleportRoleCRD)
 
-	newTestUser := newTestUserFactory(t, testCtx, "", types.V8)
+	newTestUser := newTestUserFactoryWithScope(t, testCtx, "", types.V8, scope)
 
 	tests := []struct {
 		name string
@@ -2251,7 +2303,9 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 	}{
 		{
 			name: "full default access",
-			user: newTestUser(nil, nil),
+			// regnerate a factory without scopes because omitting kube resources
+			// is not allowed for scoped roles and newTestUser will fail
+			user: newTestUserFactory(t, testCtx, "", types.V8)(nil, nil),
 			ns:   "default",
 			want: []string{
 				// teleportroles.
@@ -2541,24 +2595,30 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+		// loop to run the test case against scoped and unscoped credentials
+		for _, scoped := range []bool{false, true} {
+			var opts []GenTestKubeClientTLSCertOptions
+			want := tt.want
+			if scoped {
+				opts = makeScopedOpts(t, testCtx, tt.user.GetName(), scope)
+			}
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 
-			// Generate a kube dynClient with user certs for auth.
-			_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), kubeCluster)
+				// Generate a kube dynClient with user certs for auth.
+				_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), kubeCluster, opts...)
+				// List TeleportRoles (namespaced), pods (namespaced), clusterroles (cluster wide) and namespaces (kind of cluster wide).
+				got := []string{}
+				got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("resources.teleport.dev/v6/teleportroles")).Namespace(tt.ns))...)
+				got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("v1/pods")).Namespace(tt.ns))...)
+				got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("rbac.authorization.k8s.io/v1/clusterroles")))...)
+				got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("v1/namespaces")))...)
 
-			// List TeleportRoles (namespaced), pods (namespaced), clusterroles (cluster wide) and namespaces (kind of cluster wide).
-			got := []string{}
-			got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("resources.teleport.dev/v6/teleportroles")).Namespace(tt.ns))...)
-			got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("v1/pods")).Namespace(tt.ns))...)
-			got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("rbac.authorization.k8s.io/v1/clusterroles")))...)
-			got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("v1/namespaces")))...)
-
-			require.Equal(t, tt.want, got)
-		})
+				require.Equal(t, want, got)
+			})
+		}
 	}
 }
-
 func TestV7JailedNamespaceListRBAC(t *testing.T) {
 	t.Parallel()
 
@@ -3147,9 +3207,10 @@ func TestV7V8Match(t *testing.T) {
 func TestNamespaceListRBAC(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
+	const scope = "/test"
+	_, testCtx := newTestKubeCRDMock(t, scope, tkm.WithTeleportRoleCRD)
 
-	newTestUser := newTestUserFactory(t, testCtx, "nslist", types.V8)
+	newTestUser := newTestUserFactoryWithScope(t, testCtx, "nslist", types.V8, scope)
 
 	commonResources := []types.KubernetesResource{
 		{
@@ -3175,9 +3236,10 @@ func TestNamespaceListRBAC(t *testing.T) {
 	}
 
 	tests := []struct {
-		name string
-		user types.User
-		want []string
+		name       string
+		user       types.User
+		want       []string
+		wantScoped []string
 	}{
 		{
 			name: "common resources",
@@ -3339,6 +3401,13 @@ func TestNamespaceListRBAC(t *testing.T) {
 				"test",
 				"prod",
 			},
+			// scoped roles do not support denials
+			wantScoped: []string{
+				"default",
+				"test",
+				"dev",
+				"prod",
+			},
 		},
 		{
 			name: "ns resource deny cluster-wide wildcard",
@@ -3358,6 +3427,12 @@ func TestNamespaceListRBAC(t *testing.T) {
 				},
 			}),
 			want: []string{},
+			wantScoped: []string{
+				"default",
+				"test",
+				"dev",
+				"prod",
+			},
 		},
 		{
 			name: "ns pods deny cluster-wide wildcard",
@@ -3385,6 +3460,13 @@ func TestNamespaceListRBAC(t *testing.T) {
 			// Even though the user has access to pods and still can get pods in all NSs, the list namespace is empty
 			// because of the deny rule.
 			want: []string{},
+			// scoped roles do not support denials
+			wantScoped: []string{
+				"default",
+				"test",
+				"dev",
+				"prod",
+			},
 		},
 		{
 			name: "ns pods deny ns wildcard",
@@ -3410,20 +3492,41 @@ func TestNamespaceListRBAC(t *testing.T) {
 			// Even though the user has access to pods and still can get pods in all NSs, the list namespace is empty
 			// because of the deny rule.
 			want: []string{},
+			// scoped roles do not support denials
+			wantScoped: []string{
+				"default",
+				"test",
+				"dev",
+				"prod",
+			},
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+		// loop to run the test case against scoped and unscoped credentials
+		for _, scoped := range []bool{false, true} {
+			var opts []GenTestKubeClientTLSCertOptions
+			want := tt.want
+			if scoped {
+				opts = makeScopedOpts(t, testCtx, tt.user.GetName(), scope)
+				// we only want to check tt.wantScoped if it was provided, otherwise a nil value means
+				// we should test scoped credentials against the same expectations
+				if tt.wantScoped != nil {
+					want = tt.wantScoped
+				}
+			}
 
-			// Generate a kube dynClient with user certs for auth.
-			_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), kubeCluster)
+			t.Run(fmt.Sprintf("%s scoped=%t", tt.name, scoped), func(t *testing.T) {
+				t.Parallel()
 
-			got := []string{}
-			got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("v1/namespaces")))...)
+				// Generate a kube dynClient with user certs for auth.
+				_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), kubeCluster, opts...)
 
-			require.Equal(t, tt.want, got)
-		})
+				got := []string{}
+				got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("v1/namespaces")))...)
+
+				require.Equal(t, want, got)
+			})
+		}
 	}
 }
 
@@ -3581,12 +3684,13 @@ func TestDenyClusterWideResources(t *testing.T) {
 	}
 }
 
-func TestDeleteNamespace(t *testing.T) {
+func TestDeleteNamespaceDenial(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
+	const scope = "/test"
+	_, testCtx := newTestKubeCRDMock(t, scope, tkm.WithTeleportRoleCRD)
 
-	newTestUser := newTestUserFactory(t, testCtx, "delete-ns", types.V8)
+	newTestUser := newTestUserFactoryWithScope(t, testCtx, "delete-ns", types.V8, scope)
 
 	fullAccess := []types.KubernetesResource{
 		{
@@ -3834,6 +3938,10 @@ func newTestKubeCRDMock(t *testing.T, scope string, opts ...tkm.Option) (*runtim
 }
 
 func newTestUserFactory(t *testing.T, testCtx *TestContext, prefix, roleVersion string) func(allow, deny []types.KubernetesResource) types.User {
+	return newTestUserFactoryWithScope(t, testCtx, prefix, roleVersion, "")
+}
+
+func newTestUserFactoryWithScope(t *testing.T, testCtx *TestContext, prefix, roleVersion, scope string) func(allow, deny []types.KubernetesResource) types.User {
 	count := 0
 	if prefix == "" {
 		prefix = "test"
@@ -3858,6 +3966,69 @@ func newTestUserFactory(t *testing.T, testCtx *TestContext, prefix, roleVersion 
 				},
 			},
 		)
+
+		// don't generate scoped roles if scope wasn't provided
+		if scope == "" {
+			return user
+		}
+
+		// don't generate scoped roles for legacy role kinds
+		if roleVersion != "" && roleVersion != types.V8 {
+			return user
+		}
+
+		// scoped roles are implicit deny and only provide allow rules
+		scopedResources := make([]*accessv1.KubeResource, len(allow))
+		for idx, res := range allow {
+			scopedResources[idx] = toScopedKubeResource(res)
+		}
+		scopedAccess := testCtx.TLSServer.Auth().ScopedAccess()
+		role, err := scopedAccess.CreateScopedRole(t.Context(), accessv1.CreateScopedRoleRequest_builder{
+			Role: accessv1.ScopedRole_builder{
+				Kind:    access.KindScopedRole,
+				Version: types.V1,
+				Metadata: headerv1.Metadata_builder{
+					Name: name,
+				}.Build(),
+				Scope: scope,
+				Spec: accessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{scope},
+					Kube: accessv1.ScopedRoleKube_builder{
+						Users:     roleKubeUsers,
+						Groups:    roleKubeGroups,
+						Labels:    wildcardLabel(),
+						Resources: scopedResources,
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+
+		assignment, err := scopedAccess.CreateScopedRoleAssignment(t.Context(), accessv1.CreateScopedRoleAssignmentRequest_builder{
+			Assignment: accessv1.ScopedRoleAssignment_builder{
+				Kind:    access.KindScopedRoleAssignment,
+				Version: types.V1,
+				SubKind: access.SubKindDynamic,
+				Scope:   scope,
+				Metadata: headerv1.Metadata_builder{
+					Name: uuid.New().String(),
+				}.Build(),
+				Spec: accessv1.ScopedRoleAssignmentSpec_builder{
+					User: name,
+					Assignments: []*accessv1.Assignment{
+						accessv1.Assignment_builder{
+							Role: scopes.QualifiedName{
+								Name:  role.GetRole().GetMetadata().GetName(),
+								Scope: role.GetRole().GetScope(),
+							}.String(),
+							Scope: scope,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		waitForSRACache(t, testCtx.TLSServer, assignment)
 		return user
 	}
 }
@@ -3919,8 +4090,9 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 	teleswagv1 := tkm.NewCRD("swag.teleport.dev", "v1", "teleswags", "TeleportSwag", "TeleportSwagList", true)
 	clusterswagv0 := tkm.NewCRD("resources.teleport.dev", "v0", "clusterswags", "ClusterSwag", "ClusterSwagList", false)
 
+	const scope = "/test"
 	kubeScheme, testCtx := newTestKubeCRDMock(t,
-		"",
+		scope,
 		tkm.WithTeleportRoleCRD,
 		tkm.WithCRD(telerolev8,
 			tkm.NewObject("default", "telerole-1"),
@@ -3939,20 +4111,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		),
 	)
 
-	newUser := func(name string, resources []types.KubernetesResource) types.User {
-		u, _ := testCtx.CreateUserAndRole(
-			testCtx.Context,
-			t,
-			name,
-			RoleSpec{
-				Name:          name,
-				KubeUsers:     roleKubeUsers,
-				KubeGroups:    roleKubeGroups,
-				SetupRoleFunc: func(r types.Role) { r.SetKubeResources(types.Allow, resources) },
-			},
-		)
-		return u
-	}
+	newUser := newTestUserFactoryWithScope(t, testCtx, "crd-rbac", types.V8, scope)
 
 	type args struct {
 		user types.User
@@ -3970,7 +4129,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "list crds on multiple versions",
 			args: args{
-				user: newUser("dev_access_two_versions", []types.KubernetesResource{
+				user: newUser([]types.KubernetesResource{
 					{
 						Kind:      tkm.NewTeleportRoleCRD().GetKindPlural(),
 						Name:      types.Wildcard,
@@ -3985,7 +4144,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  types.Wildcard,
 					},
-				}),
+				}, nil),
 				crds: []*tkm.CRD{tkm.NewTeleportRoleCRD(), telerolev8.Copy()},
 			},
 			want: want{
@@ -4004,7 +4163,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "access to multiple crds listing one without access",
 			args: args{
-				user: newUser("no_swag_access", []types.KubernetesResource{
+				user: newUser([]types.KubernetesResource{
 					{
 						Kind:      tkm.NewTeleportRoleCRD().GetKindPlural(),
 						Name:      types.Wildcard,
@@ -4019,7 +4178,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  types.Wildcard,
 					},
-				}),
+				}, nil),
 				crds: []*tkm.CRD{tkm.NewTeleportRoleCRD(), telerolev8.Copy(), teleswagv1.Copy()},
 			},
 			want: want{
@@ -4040,7 +4199,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "valid kind format",
 			args: args{
-				user: newUser("diff_fmt_ok", []types.KubernetesResource{
+				user: newUser([]types.KubernetesResource{
 					{
 						Kind:      "teleportroles",
 						Name:      types.Wildcard,
@@ -4055,7 +4214,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  "resources.teleport.dev",
 					},
-				}),
+				}, nil),
 				crds: []*tkm.CRD{telerolev8},
 			},
 			want: want{
@@ -4071,7 +4230,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "different invalid kind format",
 			args: args{
-				user: newUser("diff_fmt_ko", []types.KubernetesResource{
+				user: newUser([]types.KubernetesResource{
 					{
 						Kind:      "TeleportRole",
 						Name:      types.Wildcard,
@@ -4135,7 +4294,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  types.Wildcard,
 					},
-				}),
+				}, nil),
 				crds: []*tkm.CRD{telerolev8},
 			},
 			want: want{
@@ -4145,7 +4304,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "cluster wide crd",
 			args: args{
-				user: newUser("cluster_crd_ok", []types.KubernetesResource{
+				user: newUser([]types.KubernetesResource{
 					{
 						Kind:      clusterswagv0.GetKindPlural(),
 						Name:      "clusterswag-*",
@@ -4153,7 +4312,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  types.Wildcard,
 					},
-				}),
+				}, nil),
 				crds: []*tkm.CRD{clusterswagv0},
 			},
 			want: want{
@@ -4169,7 +4328,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "cluster wide crd no access",
 			args: args{
-				user: newUser("cluster_crd_ko", []types.KubernetesResource{
+				user: newUser([]types.KubernetesResource{
 					{
 						Kind:      telerolev8.GetKindPlural(),
 						Name:      types.Wildcard,
@@ -4177,7 +4336,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  types.Wildcard,
 					},
-				}),
+				}, nil),
 				crds: []*tkm.CRD{clusterswagv0},
 			},
 			want: want{
@@ -4187,7 +4346,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "cluster wide crd no acces wildcard",
 			args: args{
-				user: newUser("cluster_crd_ko", []types.KubernetesResource{
+				user: newUser([]types.KubernetesResource{
 					{
 						Kind:      telerolev8.GetKindPlural(),
 						Name:      types.Wildcard,
@@ -4195,7 +4354,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  types.Wildcard,
 					},
-				}),
+				}, nil),
 				crds: []*tkm.CRD{clusterswagv0},
 			},
 			want: want{
@@ -4205,45 +4364,51 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			// Generate a kube client with user certs for auth.
-			_, rest := testCtx.GenTestKubeClientTLSCert(t, tt.args.user.GetName(), kubeCluster)
-
-			client, err := controllerclient.New(rest, controllerclient.Options{
-				Scheme: kubeScheme,
-			})
-			require.NoError(t, err)
-
-			for i, list := range tt.args.crds {
-				list := list.Copy()
-				if err := client.List(context.Background(), list); tt.want.wantListErr[i] {
-					require.Error(t, err)
-					continue
-				} else {
-					require.NoError(t, err)
-				}
-				require.True(t, list.IsList())
-
-				// Iterate over the list of teleport roles and get the namespace and name
-				// of each role in the format <namespace>/<name>.
-				var retList []string
-				require.NoError(
-					t,
-					list.EachListItem(
-						func(itemI runtime.Object) error {
-							item, ok := itemI.(*unstructured.Unstructured)
-							if !ok {
-								return fmt.Errorf("invalid item type %T", itemI)
-							}
-							retList = append(retList, path.Join(item.GetNamespace(), item.GetName()))
-							return nil
-						},
-					),
-				)
-				require.ElementsMatch(t, tt.want.listTeleportRolesResult[i], retList)
+		for _, scoped := range []bool{false, true} {
+			var opts []GenTestKubeClientTLSCertOptions
+			if scoped {
+				opts = makeScopedOpts(t, testCtx, tt.args.user.GetName(), scope)
 			}
-		})
+			t.Run(fmt.Sprintf("%s scoped=%t", tt.name, scoped), func(t *testing.T) {
+				t.Parallel()
+				// Generate a kube client with user certs for auth.
+				_, rest := testCtx.GenTestKubeClientTLSCert(t, tt.args.user.GetName(), kubeCluster, opts...)
+
+				client, err := controllerclient.New(rest, controllerclient.Options{
+					Scheme: kubeScheme,
+				})
+				require.NoError(t, err)
+
+				for i, list := range tt.args.crds {
+					list := list.Copy()
+					if err := client.List(context.Background(), list); tt.want.wantListErr[i] {
+						require.Error(t, err)
+						continue
+					} else {
+						require.NoError(t, err)
+					}
+					require.True(t, list.IsList())
+
+					// Iterate over the list of teleport roles and get the namespace and name
+					// of each role in the format <namespace>/<name>.
+					var retList []string
+					require.NoError(
+						t,
+						list.EachListItem(
+							func(itemI runtime.Object) error {
+								item, ok := itemI.(*unstructured.Unstructured)
+								if !ok {
+									return fmt.Errorf("invalid item type %T", itemI)
+								}
+								retList = append(retList, path.Join(item.GetNamespace(), item.GetName()))
+								return nil
+							},
+						),
+					)
+					require.ElementsMatch(t, tt.want.listTeleportRolesResult[i], retList)
+				}
+			})
+		}
 	}
 }
 
@@ -4259,51 +4424,45 @@ func TestProxySubresourceRBAC(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { kubeMock.Close() })
 
+	const scope = "/test"
 	testCtx := SetupTestContext(
 		context.Background(),
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			Scope:    scope,
+			ScopesFeatures: scopes.Features{
+				Enabled: true,
+			},
 		},
 	)
 	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
 
-	roleSpec := func(name string, resources []types.KubernetesResource) RoleSpec {
-		return RoleSpec{
-			Name:       name,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow, resources)
-			},
-		}
-	}
+	newUser := newTestUserFactoryWithScope(t, testCtx, "subresource-rbac", types.V8, scope)
 
-	podGetUser, _ := testCtx.CreateUserAndRole(testCtx.Context, t, "pod-get",
-		roleSpec("pod-get-role", []types.KubernetesResource{{
-			Kind: "pods", Namespace: types.Wildcard, Name: types.Wildcard,
-			Verbs: []string{"get", "list"}, APIGroup: types.Wildcard,
-		}}))
-	serviceGetUser, _ := testCtx.CreateUserAndRole(testCtx.Context, t, "service-get",
-		roleSpec("service-get-role", []types.KubernetesResource{{
-			Kind: "services", Namespace: types.Wildcard, Name: types.Wildcard,
-			Verbs: []string{"get", "list"}, APIGroup: types.Wildcard,
-		}}))
-	nodeGetUser, _ := testCtx.CreateUserAndRole(testCtx.Context, t, "node-get",
-		roleSpec("node-get-role", []types.KubernetesResource{{
-			Kind: "nodes", Name: types.Wildcard,
-			Verbs: []string{"get", "list"}, APIGroup: types.Wildcard,
-		}}))
+	podGetUser := newUser([]types.KubernetesResource{{
+		Kind: "pods", Namespace: types.Wildcard, Name: types.Wildcard,
+		Verbs: []string{"get", "list"}, APIGroup: types.Wildcard,
+	}}, nil)
+
+	serviceGetUser := newUser([]types.KubernetesResource{{
+		Kind: "services", Namespace: types.Wildcard, Name: types.Wildcard,
+		Verbs: []string{"get", "list"}, APIGroup: types.Wildcard,
+	}}, nil)
+
+	nodeGetUser := newUser([]types.KubernetesResource{{
+		Kind: "nodes", Name: types.Wildcard,
+		Verbs: []string{"get", "list"}, APIGroup: types.Wildcard,
+	}}, nil)
 	// Negative control: configmaps allow rule, no pods/services/nodes match.
-	noMatchUser, _ := testCtx.CreateUserAndRole(testCtx.Context, t, "no-match",
-		roleSpec("no-match-role", []types.KubernetesResource{{
-			Kind: "configmaps", Namespace: types.Wildcard, Name: types.Wildcard,
-			Verbs: []string{"get"}, APIGroup: types.Wildcard,
-		}}))
+	noMatchUser := newUser([]types.KubernetesResource{{
+		Kind: "configmaps", Namespace: types.Wildcard, Name: types.Wildcard,
+		Verbs: []string{"get"}, APIGroup: types.Wildcard,
+	}}, nil)
 
-	sendGet := func(t *testing.T, user types.User, urlPath string) (int, string) {
+	sendGet := func(t *testing.T, user types.User, urlPath string, opts ...GenTestKubeClientTLSCertOptions) (int, string) {
 		t.Helper()
-		_, cfg := testCtx.GenTestKubeClientTLSCert(t, user.GetName(), kubeCluster)
+		_, cfg := testCtx.GenTestKubeClientTLSCert(t, user.GetName(), kubeCluster, opts...)
 		transport, err := rest.TransportFor(cfg)
 		require.NoError(t, err)
 		client := &http.Client{Transport: transport}
@@ -4363,14 +4522,43 @@ func TestProxySubresourceRBAC(t *testing.T) {
 			user:         noMatchUser,
 			urlPath:      "/api/v1/namespaces/default/pods/teleport/proxy/8080",
 			wantCode:     http.StatusForbidden,
-			bodyContains: `User \"no-match\" cannot proxy resource`,
+			bodyContains: fmt.Sprintf("User \\\"%s\\\" cannot proxy resource", noMatchUser.GetName()),
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			code, body := sendGet(t, tt.user, tt.urlPath)
-			require.Equal(t, tt.wantCode, code, "body: %s", body)
-			require.Contains(t, body, tt.bodyContains)
-		})
+		for _, scoped := range []bool{false, true} {
+			var opts []GenTestKubeClientTLSCertOptions
+			if scoped {
+				opts = makeScopedOpts(t, testCtx, tt.user.GetName(), scope)
+			}
+			t.Run(fmt.Sprintf("%s scoped=%t", tt.name, scoped), func(t *testing.T) {
+				code, body := sendGet(t, tt.user, tt.urlPath, opts...)
+				require.Equal(t, tt.wantCode, code, "body: %s", body)
+				require.Contains(t, body, tt.bodyContains)
+			})
+
+		}
 	}
+}
+
+func makeScopedOpts(t *testing.T, testCtx *TestContext, username, scope string) []GenTestKubeClientTLSCertOptions {
+	return []GenTestKubeClientTLSCertOptions{
+		func(i *tlsca.Identity) {
+			i.ScopePin = testCtx.GetScopePinForUser(t, username, scope)
+		},
+	}
+}
+
+func toScopedKubeResource(resource types.KubernetesResource) *accessv1.KubeResource {
+	return accessv1.KubeResource_builder{
+		Kind:      resource.Kind,
+		Name:      resource.Name,
+		Namespace: resource.Namespace,
+		Verbs:     resource.Verbs,
+		ApiGroup:  resource.APIGroup,
+	}.Build()
+}
+
+func scopedUsername(username string) string {
+	return "scoped-" + username
 }

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -18,6 +18,7 @@ package access
 
 import (
 	"iter"
+	"slices"
 	"strings"
 	"time"
 
@@ -215,6 +216,12 @@ func StrongValidateRole(role *scopedaccessv1.ScopedRole) error {
 		return trace.BadParameter("scoped role %q has invalid login %q", role.GetMetadata().GetName(), login)
 	}
 
+	// verify that at least one label entry is defined when SSH block is given - scoped roles are deny by default, so a wildcard entry for
+	// labels must be explicitly provided if the role is meant to grant full access
+	if role.GetSpec().GetSsh() != nil && len(role.GetSpec().GetSsh().GetLabels()) == 0 {
+		return trace.BadParameter("scoped role %q has no spec.ssh.labels defined, please add at least one entry", role.GetMetadata().GetName())
+	}
+
 	// verify that ssh node labels are well-formed
 	for _, label := range role.GetSpec().GetSsh().GetLabels() {
 		// we currently don't support any form of wildcard/regex/substitution in scoped role
@@ -291,45 +298,13 @@ func StrongValidateRole(role *scopedaccessv1.ScopedRole) error {
 		}
 	}
 
-	// verify that lock.Mode is a recognized value for Kube
-	if lock := role.GetSpec().GetKube().GetLock(); lock != nil {
-		if err := validateLock(lock); err != nil {
-			return trace.BadParameter("scoped role %q has invalid kube.lock.mode %q", role.GetMetadata().GetName(), lock.GetMode())
-		}
-	}
-
-	// verify that kube labels are well-formed
-	for _, label := range role.GetSpec().GetKube().GetLabels() {
-		// we currently don't support any form of wildcard/regex/substitution in scoped role
-		// kube labels. we likely will support such things in the future, but its best to disallow
-		// them until that has landed.
-
-		if strings.ContainsAny(label.GetName(), invalidLabelChars) {
-			return trace.BadParameter("scoped role %q has invalid kube label name %q", role.GetMetadata().GetName(), label.GetName())
-		}
-		if value := validateDoesNotContain(label.GetValues(), invalidLabelChars); value != "" {
-			return trace.BadParameter("scoped role %q has invalid kube label value %q for label %q", role.GetMetadata().GetName(), value, label.GetName())
-		}
-	}
-
 	if err := validateAppBlock(role.GetSpec().GetApp()); err != nil {
 		return trace.BadParameter("scoped role %q %s", role.GetMetadata().GetName(), err)
 	}
 
-	// verify that kube groups are well-formed
-	if group := validateDoesNotContain(role.GetSpec().GetKube().GetGroups(), invalidChars); group != "" {
-		// we currently don't support any form of wildcard/regex/substitution in scoped role
-		// kube gruops. we likely will support substitution in the future, but its best to disallow
-		// it until that has landed.
-		return trace.BadParameter("scoped role %q has invalid kube group %q", role.GetMetadata().GetName(), group)
-	}
-
-	// verify that kube users are well-formed
-	if user := validateDoesNotContain(role.GetSpec().GetKube().GetUsers(), invalidChars); user != "" {
-		// we currently don't support any form of wildcard/regex/substitution in scoped role
-		// kube users. we likely will support substitution in the future, but its best to disallow
-		// it until that has landed.
-		return trace.BadParameter("scoped role %q has invalid kube user %q", role.GetMetadata().GetName(), user)
+	// verify that kube block is well-formed
+	if err := validateKubeBlock(role.GetSpec().GetKube()); err != nil {
+		return trace.BadParameter("scoped role %q has %s", role.GetMetadata().GetName(), err)
 	}
 
 	// verify that workload_identity labels are well-formed
@@ -640,6 +615,175 @@ func commonValidateAssignment(assignment *scopedaccessv1.ScopedRoleAssignment) e
 
 	if assignment.GetSpec().GetUser() == "" && assignment.GetSpec().GetBot() == "" {
 		return trace.BadParameter("scoped role assignment %q is missing spec.user or spec.bot", assignment.GetMetadata().GetName())
+	}
+
+	return nil
+}
+
+// getNamespacedResourceAPIGroup maps the list of known Kubernetes resource kinds
+// that are namespaced to their respective API group. It is copied from the kubernetesNamespacesResourceKinds
+// map found in api/types/constants.go to prevent exporting it from the public API. Any changes should also be
+// made in the original.
+//
+// Generated from `kubectl api-resources --namespaced=true -o name --sort-by=name` (kind k8s v1.32.2).
+// The format is "<plural>.<apigroup>".
+//
+// Only used to validate the api_group field.
+// If we have a match, we know we need a namespaced value, if we don't
+// have a match, we don't know we don't. Best effort basis.
+//
+// Key: resource kind, value: api group.
+func getNamespacedResourceAPIGroup(resource string) (string, bool) {
+	switch resource {
+	case "bindings", "services", "serviceaccounts", "secrets", "resourcequotas",
+		"replicationcontrollers", "podtemplates", "pods", "limitranges", "endpoints",
+		"configmaps", "persistentvolumeclaims":
+		return "", true
+	case "controllerrevisions":
+		return "apps", true
+	case "cronjobs":
+		return "batch", true
+	case "csistoragecapacities":
+		return "storage.k8s.io", true
+	case "daemonsets":
+		return "apps", true
+	case "deployments":
+		return "apps", true
+	case "endpointslices":
+		return "discovery.k8s.io", true
+	case "events":
+		return "events.k8s.io", true
+	case "horizontalpodautoscalers":
+		return "autoscaling", true
+	case "ingresses":
+		return "networking.k8s.io", true
+	case "jobs":
+		return "batch", true
+	case "leases":
+		return "coordination.k8s.io", true
+	case "localsubjectaccessreviews":
+		return "authorization.k8s.io", true
+	case "networkpolicies":
+		return "networking.k8s.io", true
+	case "poddisruptionbudgets":
+		return "policy", true
+	case "replicasets":
+		return "apps", true
+	case "rolebindings":
+		return "rbac.authorization.k8s.io", true
+	case "roles":
+		return "rbac.authorization.k8s.io", true
+	case "statefulsets":
+		return "apps", true
+	default:
+		return "", false
+	}
+}
+
+// validateKubeResources validates the following rules for each spec.kube.resources entry:
+// - Kind doesn't map to an API group
+// - Name is not empty
+// - Namespace is not empty
+// - ApiGroup not empty
+// This validator is largely copied from the role v8 case of validateKubeResources found in api/types/role.go.
+// It is ported to support scoped roles and the original should considered as well when making any changes.
+func validateKubeResource(resource *scopedaccessv1.KubeResource) error {
+	// NOTE(eriktate): errors must start with the field name producing the error so the final reported error
+	// renders correctly.
+	// (e.g. `scoped role "/my/scope::my-role" has invalid kube resource: spec.kube.resources[0].kind is required`)
+	for _, verb := range resource.GetVerbs() {
+		if !slices.Contains(types.KubernetesVerbs, verb) && verb != types.Wildcard {
+			return trace.BadParameter("verbs contain invalid or unsupported %q; Supported: %v", verb, types.KubernetesVerbs)
+		}
+		if verb == types.Wildcard && len(resource.GetVerbs()) > 1 {
+			return trace.BadParameter("verbs contain %q which cannot be used with other verbs", verb)
+		}
+	}
+
+	if resource.GetKind() == "" {
+		return trace.BadParameter("kind is required")
+	}
+	// If we have a kind in singular form for a known resource kind, check the api group.
+	if slices.Contains(types.KubernetesResourcesKinds, resource.GetKind()) {
+		// If the api group is a wildcard or matches a legacy group, then it is most definitely a mistake. Reject the role.
+		if resource.GetApiGroup() == types.Wildcard || resource.GetApiGroup() == types.KubernetesResourcesV7KindGroups[resource.GetKind()] {
+			return trace.BadParameter("kind %q is invalid. Please use plural name", resource.GetKind())
+		}
+	}
+	// Only allow empty string for known core resources.
+	if resource.GetApiGroup() == "" {
+		if _, ok := types.KubernetesCoreResourceKinds[resource.GetKind()]; !ok {
+			return trace.BadParameter("api_group is required for resource %q", resource.GetKind())
+		}
+	}
+	// Best effort attempt to validate if the namespace field is needed.
+	if resource.GetNamespace() == "" {
+		if apiGroup, ok := getNamespacedResourceAPIGroup(resource.GetKind()); ok && apiGroup == resource.GetApiGroup() {
+			return trace.BadParameter("namespace must be included for kind %q", resource.GetKind())
+		}
+	}
+
+	return nil
+}
+
+// validateKubeBlock validates the given kube configuration in a scoped role spec.
+func validateKubeBlock(kube *scopedaccessv1.ScopedRoleKube) error {
+	// the kube block is not required for all scoped roles, so nil is
+	// not an error
+	if kube == nil {
+		return nil
+	}
+
+	// verify that lock.Mode is a recognized value for Kube
+	if lock := kube.GetLock(); lock != nil {
+		if err := validateLock(lock); err != nil {
+			return trace.BadParameter("invalid kube.lock.mode %q", lock.GetMode())
+		}
+	}
+
+	// verify that at least one label entry is defined - scoped roles are deny by default, so a wildcard entry for
+	// labels must be explicitly provided if the role is meant to grant full access
+	if len(kube.GetLabels()) == 0 {
+		return trace.BadParameter("no spec.kube.labels defined, please add at least one entry")
+	}
+
+	// verify that kube labels are well-formed
+	for _, label := range kube.GetLabels() {
+		if strings.ContainsAny(label.GetName(), invalidLabelChars) {
+			return trace.BadParameter("invalid kube label name %q", label.GetName())
+		}
+		if value := validateDoesNotContain(label.GetValues(), invalidLabelChars); value != "" {
+			return trace.BadParameter("invalid kube label value %q for label %q", value, label.GetName())
+		}
+	}
+
+	// verify that at least one resource is defined - scoped roles are deny by default, so a wildcard entry for
+	// resources must be explicitly provided when resource-based RBAC is not desired
+	if len(kube.GetResources()) == 0 {
+		return trace.BadParameter("no spec.kube.resources defined, if resource-based RBAC is not required please configure explicit wildcard access")
+	}
+
+	// verify that kube resources are well-formed
+	for idx, resource := range kube.GetResources() {
+		if err := validateKubeResource(resource); err != nil {
+			return trace.BadParameter("invalid kube resource: spec.kube.resources[%d].%s", idx, err)
+		}
+	}
+
+	// verify that kube groups are well-formed
+	if group := validateDoesNotContain(kube.GetGroups(), invalidChars); group != "" {
+		// we currently don't support any form of wildcard/regex/substitution in scoped role
+		// kube groups. we likely will support substitution in the future, but its best to disallow
+		// it until that has landed.
+		return trace.BadParameter("invalid kube group %q", group)
+	}
+
+	// verify that kube users are well-formed
+	if user := validateDoesNotContain(kube.GetUsers(), invalidChars); user != "" {
+		// we currently don't support any form of wildcard/regex/substitution in scoped role
+		// kube users. we likely will support substitution in the future, but its best to disallow
+		// it until that has landed.
+		return trace.BadParameter("invalid kube user %q", user)
 	}
 
 	return nil

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -37,6 +37,21 @@ import (
 func TestValidateRole(t *testing.T) {
 	t.Parallel()
 
+	wildcardKubeResources := []*scopedaccessv1.KubeResource{
+		scopedaccessv1.KubeResource_builder{
+			Kind:      "*",
+			Namespace: "*",
+			Name:      "*",
+			ApiGroup:  "*",
+			Verbs:     []string{"*"},
+		}.Build(),
+	}
+	wildcardLabels := []*labelv1.Label{
+		labelv1.Label_builder{
+			Name:   "*",
+			Values: []string{"*"},
+		}.Build(),
+	}
 	tts := []struct {
 		name     string
 		role     *scopedaccessv1.ScopedRole
@@ -288,6 +303,7 @@ func TestValidateRole(t *testing.T) {
 				Spec: scopedaccessv1.ScopedRoleSpec_builder{
 					AssignableScopes: []string{"/foo"},
 					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Labels:            wildcardLabels,
 						ClientIdleTimeout: "not-a-duration",
 					}.Build(),
 				}.Build(),
@@ -326,6 +342,7 @@ func TestValidateRole(t *testing.T) {
 				Spec: scopedaccessv1.ScopedRoleSpec_builder{
 					AssignableScopes: []string{"/foo"},
 					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Labels: wildcardLabels,
 						HostUserCreation: scopedaccessv1.CreateHostUser_builder{
 							Mode: "invalid-mode",
 						}.Build(),
@@ -347,6 +364,7 @@ func TestValidateRole(t *testing.T) {
 				Spec: scopedaccessv1.ScopedRoleSpec_builder{
 					AssignableScopes: []string{"/foo"},
 					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Labels: wildcardLabels,
 						HostUserCreation: scopedaccessv1.CreateHostUser_builder{
 							Mode: "keep",
 						}.Build(),
@@ -368,6 +386,7 @@ func TestValidateRole(t *testing.T) {
 				Spec: scopedaccessv1.ScopedRoleSpec_builder{
 					AssignableScopes: []string{"/foo"},
 					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Labels:      wildcardLabels,
 						MaxSessions: proto.Int64(-1),
 					}.Build(),
 				}.Build(),
@@ -387,6 +406,7 @@ func TestValidateRole(t *testing.T) {
 				Spec: scopedaccessv1.ScopedRoleSpec_builder{
 					AssignableScopes: []string{"/foo"},
 					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Labels:      wildcardLabels,
 						MaxSessions: proto.Int64(1),
 					}.Build(),
 				}.Build(),
@@ -460,6 +480,7 @@ func TestValidateRole(t *testing.T) {
 				Spec: scopedaccessv1.ScopedRoleSpec_builder{
 					AssignableScopes: []string{"/foo"},
 					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Labels: wildcardLabels,
 						SessionRecording: scopedaccessv1.SessionRecording_builder{
 							Mode: "blah",
 						}.Build(),
@@ -478,10 +499,28 @@ func TestValidateRole(t *testing.T) {
 				Spec: scopedaccessv1.ScopedRoleSpec_builder{
 					AssignableScopes: []string{"/foo"},
 					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Labels: wildcardLabels,
 						Lock: scopedaccessv1.Lock_builder{
 							Mode: "invalid",
 						}.Build(),
 					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "ssh without labels",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Ssh:              scopedaccessv1.ScopedRoleSSH_builder{}.Build(),
 				}.Build(),
 				Version: types.V1,
 			}.Build(),
@@ -497,6 +536,7 @@ func TestValidateRole(t *testing.T) {
 				Spec: scopedaccessv1.ScopedRoleSpec_builder{
 					AssignableScopes: []string{"/foo"},
 					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Labels: wildcardLabels,
 						SessionRecording: scopedaccessv1.SessionRecording_builder{
 							Mode: string(constants.SessionRecordingModeStrict),
 						}.Build(),
@@ -515,6 +555,7 @@ func TestValidateRole(t *testing.T) {
 				Spec: scopedaccessv1.ScopedRoleSpec_builder{
 					AssignableScopes: []string{"/foo"},
 					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Labels: wildcardLabels,
 						Lock: scopedaccessv1.Lock_builder{
 							Mode: string(constants.LockingModeStrict),
 						}.Build(),
@@ -537,6 +578,7 @@ func TestValidateRole(t *testing.T) {
 				Spec: scopedaccessv1.ScopedRoleSpec_builder{
 					AssignableScopes: []string{"/foo"},
 					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Labels: wildcardLabels,
 						Lock: scopedaccessv1.Lock_builder{
 							Mode: "",
 						}.Build(),
@@ -558,6 +600,8 @@ func TestValidateRole(t *testing.T) {
 				Spec: scopedaccessv1.ScopedRoleSpec_builder{
 					AssignableScopes: []string{"/foo"},
 					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Labels:    wildcardLabels,
+						Resources: wildcardKubeResources,
 						Lock: scopedaccessv1.Lock_builder{
 							Mode: "invalid",
 						}.Build(),
@@ -579,6 +623,8 @@ func TestValidateRole(t *testing.T) {
 				Spec: scopedaccessv1.ScopedRoleSpec_builder{
 					AssignableScopes: []string{"/foo"},
 					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Labels:    wildcardLabels,
+						Resources: wildcardKubeResources,
 						Lock: scopedaccessv1.Lock_builder{
 							Mode: string(constants.LockingModeStrict),
 						}.Build(),
@@ -600,6 +646,8 @@ func TestValidateRole(t *testing.T) {
 				Spec: scopedaccessv1.ScopedRoleSpec_builder{
 					AssignableScopes: []string{"/foo"},
 					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Labels:    wildcardLabels,
+						Resources: wildcardKubeResources,
 						Lock: scopedaccessv1.Lock_builder{
 							Mode: "",
 						}.Build(),
@@ -979,6 +1027,288 @@ func TestValidateRole(t *testing.T) {
 						Labels: []*labelv1.Label{
 							labelv1.Label_builder{Name: "env", Values: []string{"pr$od"}}.Build(),
 						},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube without labels",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Resources: wildcardKubeResources,
+						Groups:    []string{"cluster-admin"},
+						Users:     []string{"cluster-user"},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube without resources",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Labels: wildcardLabels,
+						Groups: []string{"cluster-admin"},
+						Users:  []string{"cluster-user"},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube with resource missing kind",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Resources: []*scopedaccessv1.KubeResource{
+							scopedaccessv1.KubeResource_builder{
+								Kind:      "",
+								Name:      "*",
+								Namespace: "*",
+								ApiGroup:  "*",
+								Verbs:     []string{"*"},
+							}.Build(),
+						},
+						Labels: wildcardLabels,
+						Groups: []string{"cluster-admin"},
+						Users:  []string{"cluster-user"},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube with resource setting wildcard api group for singular resource kind",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Resources: []*scopedaccessv1.KubeResource{
+							scopedaccessv1.KubeResource_builder{
+								Kind:      "pod",
+								Name:      "*",
+								Namespace: "*",
+								ApiGroup:  "*",
+								Verbs:     []string{"*"},
+							}.Build(),
+						},
+						Labels: wildcardLabels,
+						Groups: []string{"cluster-admin"},
+						Users:  []string{"cluster-user"},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube with resource setting legacy api group for singular resource kind",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Resources: []*scopedaccessv1.KubeResource{
+							scopedaccessv1.KubeResource_builder{
+								Kind:      types.KindKubeDeployment,
+								Name:      "*",
+								Namespace: "*",
+								ApiGroup:  "apps",
+								Verbs:     []string{"*"},
+							}.Build(),
+						},
+						Labels: wildcardLabels,
+						Groups: []string{"cluster-admin"},
+						Users:  []string{"cluster-user"},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube with resource setting empty api group for non-core resource",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Resources: []*scopedaccessv1.KubeResource{
+							scopedaccessv1.KubeResource_builder{
+								Kind:      "apps",
+								Name:      "*",
+								Namespace: "*",
+								ApiGroup:  "",
+								Verbs:     []string{"*"},
+							}.Build(),
+						},
+						Labels: wildcardLabels,
+						Groups: []string{"cluster-admin"},
+						Users:  []string{"cluster-user"},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube with resource setting empty namespace for namespaced kind/api_group combo",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Resources: []*scopedaccessv1.KubeResource{
+							scopedaccessv1.KubeResource_builder{
+								Kind:      "deployments",
+								Name:      "*",
+								Namespace: "",
+								ApiGroup:  "apps",
+								Verbs:     []string{"*"},
+							}.Build(),
+						},
+						Labels: wildcardLabels,
+						Groups: []string{"cluster-admin"},
+						Users:  []string{"cluster-user"},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube with resource setting wildcard verb with any other verb",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Resources: []*scopedaccessv1.KubeResource{
+							scopedaccessv1.KubeResource_builder{
+								Kind:      "*",
+								Name:      "*",
+								Namespace: "*",
+								ApiGroup:  "*",
+								Verbs:     []string{"*", "get"},
+							}.Build(),
+						},
+						Labels: wildcardLabels,
+						Groups: []string{"cluster-admin"},
+						Users:  []string{"cluster-user"},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube with resource setting unrecognized verb",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Resources: []*scopedaccessv1.KubeResource{
+							scopedaccessv1.KubeResource_builder{
+								Kind:      "*",
+								Name:      "*",
+								Namespace: "*",
+								ApiGroup:  "*",
+								Verbs:     []string{"scopify"},
+							}.Build(),
+						},
+						Labels: wildcardLabels,
+						Groups: []string{"cluster-admin"},
+						Users:  []string{"cluster-user"},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube with resource setting interpolated verb",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Resources: []*scopedaccessv1.KubeResource{
+							scopedaccessv1.KubeResource_builder{
+								Kind:      "*",
+								Name:      "*",
+								Namespace: "*",
+								ApiGroup:  "*",
+								Verbs:     []string{"{{internal.verb}}"},
+							}.Build(),
+						},
+						Labels: wildcardLabels,
+						Groups: []string{"cluster-admin"},
+						Users:  []string{"cluster-user"},
 					}.Build(),
 				}.Build(),
 				Version: types.V1,

--- a/lib/scopes/access/compat.go
+++ b/lib/scopes/access/compat.go
@@ -57,6 +57,19 @@ func applyKubeBlock(src *scopedaccessv1.ScopedRoleKube, dst *types.RoleCondition
 		}
 		dst.KubernetesLabels[label.GetName()] = apiutils.Strings(label.GetValues())
 	}
+
+	for i, resource := range src.GetResources() {
+		if dst.KubernetesResources == nil {
+			dst.KubernetesResources = make([]types.KubernetesResource, len(src.GetResources()))
+		}
+		dst.KubernetesResources[i] = types.KubernetesResource{
+			Kind:      resource.GetKind(),
+			Namespace: resource.GetNamespace(),
+			Name:      resource.GetName(),
+			Verbs:     resource.GetVerbs(),
+			APIGroup:  resource.GetApiGroup(),
+		}
+	}
 }
 
 // applyAppBlock writes/converts the relevant subset of the scoped role's app block into the provided
@@ -129,10 +142,16 @@ func applyRules(src []*scopedaccessv1.ScopedRule, dst *types.RoleConditions) {
 
 // ScopedRoleToRole converts a scoped role to an equivalent classic role. Scoped roles do not implement their
 // own access-control logic for the most part, and instead rely on converting to classic roles for the final
-// step of evaluation. This functiona also accepts the assigned scope as a parameter because we conventionally
+// step of evaluation. This function also accepts the assigned scope as a parameter because we conventionally
 // format converted role names as "<role-name>@<assigned-scope>" to help ensure reasonable error messages from
 // role evaluation logic.
 func ScopedRoleToRole(sr *scopedaccessv1.ScopedRole, assignedScope string) (types.Role, error) {
+	// role conversion applies unwanted wildcards for kube resources when left unassigned, so we
+	// explicitly validate the kube block as a sanity check
+	if err := validateKubeBlock(sr.GetSpec().GetKube()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	var conditions types.RoleConditions
 	applySSHBlock(sr.GetSpec().GetSsh(), &conditions)
 	applyKubeBlock(sr.GetSpec().GetKube(), &conditions)

--- a/lib/scopes/access/compat_test.go
+++ b/lib/scopes/access/compat_test.go
@@ -231,7 +231,23 @@ func baseScopedRole() *scopedaccessv1.ScopedRole {
 		Spec: scopedaccessv1.ScopedRoleSpec_builder{
 			AssignableScopes: []string{"/foo/bar"},
 			Ssh:              &scopedaccessv1.ScopedRoleSSH{},
-			Kube:             &scopedaccessv1.ScopedRoleKube{},
+			Kube: scopedaccessv1.ScopedRoleKube_builder{
+				Labels: []*labelv1.Label{
+					labelv1.Label_builder{
+						Name:   "*",
+						Values: []string{"*"},
+					}.Build(),
+				},
+				Resources: []*scopedaccessv1.KubeResource{
+					scopedaccessv1.KubeResource_builder{
+						Kind:      "*",
+						Namespace: "*",
+						Name:      "*",
+						ApiGroup:  "*",
+						Verbs:     []string{"*"},
+					}.Build(),
+				},
+			}.Build(),
 		}.Build(),
 		Version: types.V1,
 	}.Build()
@@ -379,6 +395,21 @@ func TestKubeDisconnectExpiredCertNotInClassicRole(t *testing.T) {
 	sr := baseScopedRole()
 	sr.GetSpec().SetKube(scopedaccessv1.ScopedRoleKube_builder{
 		DisconnectExpiredCert: ptr(true),
+		Labels: []*labelv1.Label{
+			labelv1.Label_builder{
+				Name:   "*",
+				Values: []string{"*"},
+			}.Build(),
+		},
+		Resources: []*scopedaccessv1.KubeResource{
+			scopedaccessv1.KubeResource_builder{
+				Kind:      types.Wildcard,
+				Namespace: types.Wildcard,
+				Name:      types.Wildcard,
+				ApiGroup:  types.Wildcard,
+				Verbs:     []string{types.Wildcard},
+			}.Build(),
+		},
 	}.Build())
 
 	role, err := ScopedRoleToRole(sr, "/foo/bar")
@@ -451,7 +482,7 @@ func TestKubeConversion(t *testing.T) {
 	}{
 		{
 			name:   "empty conditions",
-			kube:   &scopedaccessv1.ScopedRoleKube{},
+			kube:   nil,
 			expect: types.RoleConditions{},
 		},
 		{
@@ -463,6 +494,15 @@ func TestKubeConversion(t *testing.T) {
 					labelv1.Label_builder{
 						Name:   "team",
 						Values: []string{"red"},
+					}.Build(),
+				},
+				Resources: []*scopedaccessv1.KubeResource{
+					scopedaccessv1.KubeResource_builder{
+						Kind:      types.Wildcard,
+						Namespace: types.Wildcard,
+						Name:      types.Wildcard,
+						ApiGroup:  types.Wildcard,
+						Verbs:     []string{types.Wildcard},
 					}.Build(),
 				},
 			}.Build(),
@@ -490,6 +530,20 @@ func TestKubeConversion(t *testing.T) {
 						Values: []string{"blue"},
 					}.Build(),
 				},
+				Resources: []*scopedaccessv1.KubeResource{
+					scopedaccessv1.KubeResource_builder{
+						Kind:      "pods",
+						Namespace: "default",
+						Name:      "pod-name",
+						Verbs:     []string{"get", "list"},
+						ApiGroup:  "pod-group",
+					}.Build(),
+				},
+				ClientIdleTimeout:     "30m",
+				DisconnectExpiredCert: new(bool),
+				Lock: scopedaccessv1.Lock_builder{
+					Mode: "strict",
+				}.Build(),
 			}.Build(),
 			expect: types.RoleConditions{
 				KubeUsers:  []string{"system:user", "system:admin"},
@@ -498,7 +552,15 @@ func TestKubeConversion(t *testing.T) {
 					"env":  apiutils.Strings{"prod", "staging"},
 					"team": apiutils.Strings{"blue"},
 				},
-				KubernetesResources: wildcardResources,
+				KubernetesResources: []types.KubernetesResource{
+					types.KubernetesResource{
+						Kind:      "pods",
+						Namespace: "default",
+						Name:      "pod-name",
+						Verbs:     []string{"get", "list"},
+						APIGroup:  "pod-group",
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Adds the compat layer for kube resources in scoped roles. Validation for the kube block in scoped roles requires that at least one entry is defined for `spec.kube.resources`. In cases where the intent is to fallback on builtin kube RBAC a wildcard resource must be configured:
```yaml
kind: scoped_token
metadata:
  name: kube-admin
scope: /local/k8s
spec:
  kube:
    groups: [cluster-admin]
    resources:
    - kind: "*"
      name: "*"
      namespace: "*"
      api_group: "*"
      verbs: ["*"]
    labels:
    - name: "*"
      values: ["*"]
```
This is a departure from pervious versions of classic roles that assigned default values to `kube_resources`. Making this into a validation error aligns with scoped role semantics up to this point (implicit deny, explicit allow) while removing ambiguity about whether `kube_resources` should be defined or not.

This also requires `spec.kube.labels` and `spec.ssh.labels` when creating scoped roles and updates automated tests accordingly.

Related to https://github.com/gravitational/teleport/issues/67205

## Manual Test Plan
### Test Environment
A local teleport cluster with `TELEPORT_UNSTABLE_SCOPES=yes` and `TELEPORT_UNSTABLE_AGENT_SCOPE_PIN=yes`
### Test Cases
- [x] Fail to create a scoped role with non-nil `spec.kube` that does not define `resources`
- [x] Fail to create a scoped role with non-nil `spec.kube` that does not define `labels`
- [x] Create a scoped role with valid `spec.kube.resources`
- [x] Access scoped kube cluster using scoped identity with wildcard access
- [x] Access scoped kube cluster using scoped identity with limited access
  - [x] Limit resources by kind
  - [x] Limit resources by name
  - [x] Limit resources by namespace
  - [x] Limit resources by API group
  - [x] Limit actions by verb
- [x] Fail to create a scoped role with non-nil `spec.ssh` that does not define `labels`

