### PR TITLE
[v18] Unblocking scoped agents

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -601,7 +601,7 @@ func (*APIServer) getNamespace(_ *ServerWithRoles, _ http.ResponseWriter, _ *htt
 }
 
 func (s *APIServer) getClusterName(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	cn, err := auth.GetClusterName(r.Context())
+	cn, err := auth.ScopedServerWithRoles().GetClusterName(r.Context())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -798,13 +798,7 @@ func (a *ScopedServerWithRoles) GenerateHostCerts(ctx context.Context, req *prot
 // checkAdditionalSystemRoles verifies additional system roles in host cert request.
 func (a *ScopedServerWithRoles) checkAdditionalSystemRoles(ctx context.Context, req *proto.HostCertsRequest) error {
 	// ensure requesting cert's primary role is a server role.
-	var isServer bool
-	switch role := a.scopedContext.Identity.(type) {
-	case authz.BuiltinRole:
-		isServer = role.IsServer()
-	case authz.ScopedBuiltinRole:
-		isServer = role.IsServer()
-	}
+	_, isServer := getBuiltinServerID(a.scopedContext.Identity)
 	if !isServer {
 		return trace.AccessDenied("additional system roles can only be claimed by a teleport built-in server")
 	}
@@ -886,10 +880,10 @@ func (a *ServerWithRoles) AssertSystemRole(ctx context.Context, req proto.System
 // RegisterInventoryControlStream handles the upstream half of the control stream handshake, then passes the control stream to
 // the auth server's main control logic. We also return the post-auth hello message back up to the grpcserver layer in order to
 // use it for metrics purposes.
-func (a *ServerWithRoles) RegisterInventoryControlStream(ics client.UpstreamInventoryControlStream) (*proto.UpstreamInventoryHello, error) {
+func (a *ScopedServerWithRoles) RegisterInventoryControlStream(ics client.UpstreamInventoryControlStream) (*proto.UpstreamInventoryHello, error) {
 	// Ensure that caller is a teleport server
-	role, ok := a.context.Identity.(authz.BuiltinRole)
-	if !ok || !role.IsServer() {
+	serverID, isBuiltinServer := getBuiltinServerID(a.scopedContext.Identity)
+	if !isBuiltinServer {
 		return nil, trace.AccessDenied("inventory control streams can only be created by a teleport built-in server")
 	}
 
@@ -910,8 +904,8 @@ func (a *ServerWithRoles) RegisterInventoryControlStream(ics client.UpstreamInve
 	}
 
 	// verify that server is creating stream on behalf of itself.
-	if hello.GetServerID() != role.GetServerID() {
-		return nil, trace.AccessDenied("control streams do not support impersonation (%q -> %q)", role.GetServerID(), hello.GetServerID())
+	if hello.GetServerID() != serverID {
+		return nil, trace.AccessDenied("control streams do not support impersonation (%q -> %q)", serverID, hello.GetServerID())
 	}
 
 	// in order to reduce sensitivity to downgrades/misconfigurations, we simply filter out
@@ -921,7 +915,7 @@ func (a *ServerWithRoles) RegisterInventoryControlStream(ics client.UpstreamInve
 		if !a.hasBuiltinRole(types.SystemRole(service)) {
 			a.authServer.logger.WarnContext(a.CloseContext(), "Omitting unknown or unauthorized service for instance control stream",
 				"omitted_service", service,
-				"instance", role.GetServerID(),
+				"instance", serverID,
 			)
 			continue
 		}
@@ -933,12 +927,12 @@ func (a *ServerWithRoles) RegisterInventoryControlStream(ics client.UpstreamInve
 	// If the hello message's scope is non-empty, we can verify that it matches the authenticated
 	// scope in the identity. Otherwise, in order to support agents unaware of scopes, we fall back
 	// to the authenticated identity's scope.
-	agentScope := a.context.Identity.GetIdentity().GetAgentScope()
-	if hello.Scope != "" && hello.Scope != agentScope {
-		return nil, trace.AccessDenied("provided scope %q does not match agent identity %q", hello.Scope, agentScope)
+	agentScope := a.scopedContext.Identity.GetIdentity().GetAgentScope()
+	if hello.GetScope() != "" && hello.GetScope() != agentScope {
+		return nil, trace.AccessDenied("provided scope %q does not match agent identity %q", hello.GetScope(), agentScope)
 	}
-	hello.Scope = agentScope
-	labelHash := a.context.Identity.GetIdentity().ImmutableLabelHash
+	hello.SetScope(agentScope)
+	labelHash := a.scopedContext.Identity.GetIdentity().ImmutableLabelHash
 	if labels := hello.GetImmutableLabels(); labels != nil || labelHash != "" {
 		if !joining.VerifyImmutableLabelsHash(labels, labelHash) {
 			return nil, trace.AccessDenied("immutable labels do not match their agent identity")
@@ -1276,6 +1270,7 @@ func (a *ScopedServerWithRoles) NewStream(ctx context.Context, watch types.Watch
 	if err := a.authorizeWatchRequest(ctx, &watch); err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	return a.authServer.NewStream(ctx, watch)
 }
 
@@ -1352,7 +1347,12 @@ func (a *ScopedServerWithRoles) authorizeWatchRequest(ctx context.Context, watch
 	if len(validKinds) == 0 {
 		return trace.BadParameter("none of the requested kinds can be watched")
 	}
+
 	watch.Kinds = validKinds
+	if a.hasBuiltinRole(types.RoleNode) {
+		watch.QueueSize = defaults.NodeQueueSize
+	}
+
 	return nil
 }
 
@@ -5800,12 +5800,18 @@ func (a *ServerWithRoles) GetClusterAuditConfig(ctx context.Context) (types.Clus
 }
 
 // GetClusterNetworkingConfig gets cluster networking configuration.
-func (a *ServerWithRoles) GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error) {
-	if err := a.authorizeAction(types.KindClusterNetworkingConfig, types.VerbRead); err != nil {
-		if err2 := a.authorizeAction(types.KindClusterConfig, types.VerbRead); err2 != nil {
+func (a *ScopedServerWithRoles) GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error) {
+	ruleCtx := a.scopedContext.RuleContext()
+	if err := a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadClusterNetworkingConfig, &ruleCtx); err != nil {
+		unscopedCtx, isUnscoped := a.scopedContext.UnscopedContext()
+		if !isUnscoped {
+			return nil, trace.Wrap(err)
+		}
+		if err2 := unscopedCtx.CheckAccessToKind(types.KindClusterConfig, types.VerbRead); err2 != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
+
 	cfg, err := a.authServer.GetReadOnlyClusterNetworkingConfig(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -5928,9 +5934,14 @@ func (a *ServerWithRoles) ResetClusterNetworkingConfig(ctx context.Context) erro
 }
 
 // GetSessionRecordingConfig gets session recording configuration.
-func (a *ServerWithRoles) GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error) {
-	if err := a.authorizeAction(types.KindSessionRecordingConfig, types.VerbRead); err != nil {
-		if err2 := a.authorizeAction(types.KindClusterConfig, types.VerbRead); err2 != nil {
+func (a *ScopedServerWithRoles) GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error) {
+	ruleCtx := a.scopedContext.RuleContext()
+	if err := a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadSessionRecordingConfig, &ruleCtx); err != nil {
+		unscopedCtx, isUnscoped := a.scopedContext.UnscopedContext()
+		if !isUnscoped {
+			return nil, trace.Wrap(err)
+		}
+		if err2 := unscopedCtx.CheckAccessToKind(types.KindClusterConfig, types.VerbRead); err2 != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -8936,4 +8947,17 @@ func checkOktaLockAccess(ctx context.Context, authzCtx *authz.Context, locks ser
 	}
 
 	return okta.CheckAccess(authzCtx, existingLock, verb)
+}
+
+// getBuiltinServerID returns the builtin server ID associated with the identity.
+// If the identity is not a builtin server role, and empty string and false are returned.
+func getBuiltinServerID(identityGetter authz.IdentityGetter) (serverID string, isBuiltinServer bool) {
+	switch role := identityGetter.(type) {
+	case authz.BuiltinRole:
+		return role.GetServerID(), role.IsServer()
+	case authz.ScopedBuiltinRole:
+		return role.GetServerID(), role.IsServer()
+	}
+
+	return "", false
 }

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -5087,16 +5087,17 @@ func (a *ServerWithRoles) ValidateGithubAuthCallback(ctx context.Context, q url.
 }
 
 // EmitAuditEvent emits a single audit event
-func (a *ServerWithRoles) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
+func (a *ScopedServerWithRoles) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
 	ctx = context.WithoutCancel(ctx)
-	if err := a.authorizeAction(types.KindEvent, types.VerbCreate); err != nil {
+	ruleCtx := a.scopedContext.RuleContext()
+	if err := a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedEmitEvent(ctx, &ruleCtx); err != nil {
 		return trace.Wrap(err)
 	}
-	role, ok := a.context.Identity.(authz.BuiltinRole)
-	if !ok || !role.IsServer() {
+	serverID, isServer := getBuiltinServerID(a.scopedContext.Identity)
+	if !isServer {
 		return trace.AccessDenied("this request can be only executed by a teleport built-in server")
 	}
-	err := events.ValidateServerMetadata(event, role.GetServerID(), a.hasBuiltinRole(types.RoleProxy))
+	err := events.ValidateServerMetadata(event, serverID, a.hasBuiltinRole(types.RoleProxy))
 	if err != nil {
 		// TODO: this should be a proper audit event
 		// notifying about access violation
@@ -5105,7 +5106,7 @@ func (a *ServerWithRoles) EmitAuditEvent(ctx context.Context, event apievents.Au
 		a.authServer.logger.WarnContext(ctx, msg,
 			"event_type", event.GetType(),
 			"event_id", event.GetID(),
-			"server_id", role.GetServerID(),
+			"server_id", serverID,
 			"error", err)
 		// this message is sparse on purpose to avoid conveying extra data to an attacker
 		return trace.AccessDenied("failed to validate event metadata")
@@ -5114,12 +5115,13 @@ func (a *ServerWithRoles) EmitAuditEvent(ctx context.Context, event apievents.Au
 }
 
 // CreateAuditStream creates audit event stream
-func (a *ServerWithRoles) CreateAuditStream(ctx context.Context, sid session.ID) (apievents.Stream, error) {
-	if err := a.authorizeAction(types.KindEvent, types.VerbCreate, types.VerbUpdate); err != nil {
+func (a *ScopedServerWithRoles) CreateAuditStream(ctx context.Context, sid session.ID) (apievents.Stream, error) {
+	ruleCtx := a.scopedContext.RuleContext()
+	if err := a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedWriteEvent(ctx, &ruleCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	role, ok := a.context.Identity.(authz.BuiltinRole)
-	if !ok || !role.IsServer() {
+	serverID, isServer := getBuiltinServerID(a.scopedContext.Identity)
+	if !isServer {
 		return nil, trace.AccessDenied("this request can be only executed by a Teleport server")
 	}
 	stream, err := a.authServer.CreateAuditStream(ctx, sid)
@@ -5129,17 +5131,18 @@ func (a *ServerWithRoles) CreateAuditStream(ctx context.Context, sid session.ID)
 	return &streamWithRoles{
 		stream:   stream,
 		a:        a,
-		serverID: role.GetServerID(),
+		serverID: serverID,
 	}, nil
 }
 
 // ResumeAuditStream resumes the stream that has been created
-func (a *ServerWithRoles) ResumeAuditStream(ctx context.Context, sid session.ID, uploadID string) (apievents.Stream, error) {
-	if err := a.authorizeAction(types.KindEvent, types.VerbCreate, types.VerbUpdate); err != nil {
+func (a *ScopedServerWithRoles) ResumeAuditStream(ctx context.Context, sid session.ID, uploadID string) (apievents.Stream, error) {
+	ruleCtx := a.scopedContext.RuleContext()
+	if err := a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedWriteEvent(ctx, &ruleCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	role, ok := a.context.Identity.(authz.BuiltinRole)
-	if !ok || !role.IsServer() {
+	serverID, isServer := getBuiltinServerID(a.scopedContext.Identity)
+	if !isServer {
 		return nil, trace.AccessDenied("this request can be only executed by a Teleport server")
 	}
 	stream, err := a.authServer.ResumeAuditStream(ctx, sid, uploadID)
@@ -5149,12 +5152,12 @@ func (a *ServerWithRoles) ResumeAuditStream(ctx context.Context, sid session.ID,
 	return &streamWithRoles{
 		stream:   stream,
 		a:        a,
-		serverID: role.GetServerID(),
+		serverID: serverID,
 	}, nil
 }
 
 type streamWithRoles struct {
-	a        *ServerWithRoles
+	a        *ScopedServerWithRoles
 	serverID string
 	stream   apievents.Stream
 }
@@ -5509,6 +5512,19 @@ func checkRoleFeatureSupport(role types.Role) error {
 	}
 }
 
+// GetRole returns a role by name, supporting both scoped and unscoped callers.
+func (a *ScopedServerWithRoles) GetRole(ctx context.Context, name string) (types.Role, error) {
+	if unscoped, ok := a.UnscopedServerWithRoles(); ok {
+		return unscoped.GetRole(ctx, name)
+	}
+
+	ruleCtx := a.scopedContext.RuleContext()
+	if err := a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadRole, &ruleCtx); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return a.authServer.GetRole(ctx, name)
+}
+
 // GetRole returns role by name
 func (a *ServerWithRoles) GetRole(ctx context.Context, name string) (types.Role, error) {
 	// Current-user exception: we always allow users to read roles
@@ -5575,8 +5591,9 @@ func (a *ServerWithRoles) DeleteRole(ctx context.Context, name string) error {
 // GetClusterName gets the name of the cluster.
 // TODO(noah): DELETE IN v19.0.0 - when the apiserver getClusterName method is also
 // deleted.
-func (a *ServerWithRoles) GetClusterName(ctx context.Context) (types.ClusterName, error) {
-	if err := a.authorizeAction(types.KindClusterName, types.VerbRead); err != nil {
+func (a *ScopedServerWithRoles) GetClusterName(ctx context.Context) (types.ClusterName, error) {
+	ruleCtx := a.scopedContext.RuleContext()
+	if err := a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadClusterName, &ruleCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.GetClusterName(ctx)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -369,6 +369,42 @@ func (a *ServerWithRoles) hasBuiltinRole(roles ...types.SystemRole) bool {
 	return false
 }
 
+// hasBuiltinRole checks that the attached identity is a builtin role and
+// whether any of the given roles match the role set.
+func (a *ScopedServerWithRoles) hasBuiltinRole(roles ...types.SystemRole) bool {
+	unscopedCtx, isUnscoped := a.scopedContext.UnscopedContext()
+	if isUnscoped {
+		for _, role := range roles {
+			if authz.HasBuiltinRole(*unscopedCtx, string(role)) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// since we check if the underlying SWR is unscoped, and defer to the
+	// unscoped behavior if it is, the only valid role type at this point
+	// will be a [authz.ScopedBuiltinRole].
+	role, isBuiltin := a.scopedContext.Identity.(authz.ScopedBuiltinRole)
+	if !isBuiltin {
+		return false
+	}
+	// for service certs, the additional system roles will be empty so we only check if the
+	// primary role is included in the given roles
+	if primary := types.SystemRole(role.ScopePin.GetSystemRoles().GetPrimary()); primary != types.RoleInstance {
+		return types.SystemRoles(roles).Include(primary)
+	}
+	// for instance certs, we check if there is any overlap between the given roles and the
+	// additional system roles included in the scope pin
+	existingRoles := role.ScopePin.GetSystemRoles().GetAdditional()
+	for _, role := range roles {
+		if slices.Contains(existingRoles, string(role)) {
+			return true
+		}
+	}
+	return false
+}
+
 // HasBuiltinRole checks if the identity is a builtin role with the matching
 // name.
 // Deprecated: use authz.HasBuiltinRole instead.
@@ -703,14 +739,28 @@ func (a *ScopedServerWithRoles) GetClusterCACert(ctx context.Context) (*proto.Ge
 
 // GenerateHostCerts generates new host certificates (signed
 // by the host certificate authority) for a node.
-func (a *ServerWithRoles) GenerateHostCerts(ctx context.Context, req *proto.HostCertsRequest) (*proto.Certs, error) {
+func (a *ScopedServerWithRoles) GenerateHostCerts(ctx context.Context, req *proto.HostCertsRequest) (*proto.Certs, error) {
 	clusterName, err := a.authServer.GetDomainName()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// username is hostID + cluster name, so make sure server requests new keys for itself
-	if a.context.User.GetName() != utils.HostFQDN(req.HostID, clusterName) {
-		return nil, trace.AccessDenied("username mismatch %q and %q", a.context.User.GetName(), utils.HostFQDN(req.HostID, clusterName))
+
+	var existingRoles []string
+	var serverFQDN string
+	switch role := a.scopedContext.Identity.(type) {
+	case authz.ScopedBuiltinRole:
+		serverFQDN = role.ServerFQDN
+		existingRoles = role.ScopePin.GetSystemRoles().GetAdditional()
+	case authz.BuiltinRole:
+		serverFQDN = a.scopedContext.User.GetName()
+		existingRoles = a.scopedContext.User.GetRoles()
+	default:
+		return nil, trace.AccessDenied("cannot generate host cert as non-builtin role")
+	}
+
+	// serverFQDN is hostID + cluster name, so make sure server requests new keys for itself
+	if serverFQDN != utils.HostFQDN(req.HostID, clusterName) {
+		return nil, trace.AccessDenied("server FQDN mismatch %q and %q", serverFQDN, utils.HostFQDN(req.HostID, clusterName))
 	}
 
 	if req.Role == types.RoleInstance {
@@ -723,16 +773,20 @@ func (a *ServerWithRoles) GenerateHostCerts(ctx context.Context, req *proto.Host
 		}
 	}
 
-	existingRoles, err := types.NewTeleportRoles(a.context.User.GetRoles())
+	existingServerRoles, err := types.NewTeleportRoles(existingRoles)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(err, "parsing existing server roles")
 	}
 
 	// prohibit privilege escalations through role changes (except the instance cert exception, handled above).
 	if !a.hasBuiltinRole(req.Role) && req.Role != types.RoleInstance {
-		return nil, trace.AccessDenied("roles do not match: %v and %v", existingRoles, req.Role)
+		return nil, trace.AccessDenied(
+			"roles do not match: %v and %v",
+			existingServerRoles,
+			req.Role,
+		)
 	}
-	identity := a.context.Identity.GetIdentity()
+	identity := a.scopedContext.Identity.GetIdentity()
 	return a.authServer.GenerateHostCerts(ctx, HostCertsParams{
 		Req:                req,
 		AgentScope:         identity.GetAgentScope(),
@@ -742,10 +796,16 @@ func (a *ServerWithRoles) GenerateHostCerts(ctx context.Context, req *proto.Host
 }
 
 // checkAdditionalSystemRoles verifies additional system roles in host cert request.
-func (a *ServerWithRoles) checkAdditionalSystemRoles(ctx context.Context, req *proto.HostCertsRequest) error {
+func (a *ScopedServerWithRoles) checkAdditionalSystemRoles(ctx context.Context, req *proto.HostCertsRequest) error {
 	// ensure requesting cert's primary role is a server role.
-	role, ok := a.context.Identity.(authz.BuiltinRole)
-	if !ok || !role.IsServer() {
+	var isServer bool
+	switch role := a.scopedContext.Identity.(type) {
+	case authz.BuiltinRole:
+		isServer = role.IsServer()
+	case authz.ScopedBuiltinRole:
+		isServer = role.IsServer()
+	}
+	if !isServer {
 		return trace.AccessDenied("additional system roles can only be claimed by a teleport built-in server")
 	}
 
@@ -6701,6 +6761,10 @@ func (a *ServerWithRoles) GenerateAppToken(ctx context.Context, req types.Genera
 }
 
 func (a *ServerWithRoles) Close() error {
+	return a.authServer.Close()
+}
+
+func (a *ScopedServerWithRoles) Close() error {
 	return a.authServer.Close()
 }
 

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -2321,7 +2321,7 @@ func TestClusterNetworkingConfigRBAC(t *testing.T) {
 			s.UpsertClusterNetworkingConfig(ctx, netConfig)
 		},
 		get: func(s *auth.ServerWithRoles) error {
-			_, err := s.GetClusterNetworkingConfig(ctx)
+			_, err := s.ScopedServerWithRoles().GetClusterNetworkingConfig(ctx)
 			return err
 		},
 		set: func(s *auth.ServerWithRoles) error {
@@ -2331,6 +2331,32 @@ func TestClusterNetworkingConfigRBAC(t *testing.T) {
 			return s.ResetClusterNetworkingConfig(ctx)
 		},
 	})
+}
+
+func TestClusterNetworkingConfigScopedRead(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir: t.TempDir(),
+		ScopesFeatures: scopes.Features{
+			Enabled:         true,
+			AgentPinEnabled: true,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+
+	netConfig := types.DefaultClusterNetworkingConfig()
+	_, err = as.AuthServer.UpsertClusterNetworkingConfig(ctx, netConfig)
+	require.NoError(t, err)
+
+	const hostID = "testhost"
+	const scope = "/aa/bb"
+	srv := newScopePinnedTestServerForHost(t, as, hostID, scope, types.RoleNode)
+	nc, err := srv.GetClusterNetworkingConfig(ctx)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(netConfig, nc))
 }
 
 func TestSessionRecordingConfigRBAC(t *testing.T) {
@@ -2347,7 +2373,7 @@ func TestSessionRecordingConfigRBAC(t *testing.T) {
 			s.UpsertSessionRecordingConfig(ctx, recConfig)
 		},
 		get: func(s *auth.ServerWithRoles) error {
-			_, err := s.GetSessionRecordingConfig(ctx)
+			_, err := s.ScopedServerWithRoles().GetSessionRecordingConfig(ctx)
 			return err
 		},
 		set: func(s *auth.ServerWithRoles) error {
@@ -4597,8 +4623,8 @@ func TestKindClusterConfig(t *testing.T) {
 			*authContext,
 		)
 		_, err1 := s.GetClusterAuditConfig(ctx)
-		_, err2 := s.GetClusterNetworkingConfig(ctx)
-		_, err3 := s.GetSessionRecordingConfig(ctx)
+		_, err2 := s.ScopedServerWithRoles().GetClusterNetworkingConfig(ctx)
+		_, err3 := s.ScopedServerWithRoles().GetSessionRecordingConfig(ctx)
 		return []error{err1, err2, err3}
 	}
 
@@ -12891,34 +12917,43 @@ func TestClusterAlertOperations(t *testing.T) {
 }
 
 type inventoryControlStreamHarness struct {
-	server     *auth.ServerWithRoles
+	server     *auth.ScopedServerWithRoles
 	upstream   apiclient.UpstreamInventoryControlStream
 	downstream apiclient.DownstreamInventoryControlStream
 }
 
-func newInventoryControlStreamHarness(t *testing.T, srv *authtest.AuthServer, serverID, scope, labelHash string, role types.SystemRole) inventoryControlStreamHarness {
+func scopedHostWithLabelHash(t *testing.T, clusterName, serverID, scope, labelHash string, role types.SystemRole) authtest.TestIdentity {
 	t.Helper()
 
-	username := serverID + "." + srv.ClusterName
-	identity := authz.BuiltinRole{
-		Role:                  types.RoleInstance,
-		AdditionalSystemRoles: types.SystemRoles{role},
-		Username:              username,
-		ClusterName:           srv.ClusterName,
-		Identity: tlsca.Identity{
-			Username:           username,
-			AgentScope:         scope,
-			ImmutableLabelHash: labelHash,
-		},
-	}
+	ident := authtest.TestScopedHost(clusterName, serverID, scope, role)
+	builtinRole, ok := ident.I.(authz.BuiltinRole)
+	require.True(t, ok, "expected BuiltinRole")
+	builtinRole.Identity.ImmutableLabelHash = labelHash
+	ident.I = builtinRole
+	return ident
+}
 
-	authContext, err := srv.Authorizer.Authorize(authz.ContextWithUser(t.Context(), identity))
+func scopePinnedHostWithLabelHash(t *testing.T, clusterName, serverID, scope, labelHash string, role types.SystemRole) authtest.TestIdentity {
+	t.Helper()
+
+	ident := authtest.TestScopePinnedHost(clusterName, serverID, scope, role)
+	scopedBuiltinRole, ok := ident.I.(authz.ScopedBuiltinRole)
+	require.True(t, ok, "expected ScopedBuiltinRole")
+	scopedBuiltinRole.Identity.ImmutableLabelHash = labelHash
+	ident.I = scopedBuiltinRole
+	return ident
+}
+
+func newInventoryControlStreamHarness(t *testing.T, srv *authtest.AuthServer, ident authtest.TestIdentity) inventoryControlStreamHarness {
+	t.Helper()
+
+	scopedContext, err := srv.ScopedAuthorizer.AuthorizeScoped(authz.ContextWithUser(t.Context(), ident.I))
 	require.NoError(t, err)
 
-	authWithRole := auth.NewServerWithRoles(
+	authWithRole := auth.NewScopedServerWithRoles(
 		srv.AuthServer,
 		srv.AuditLog,
-		*authContext,
+		scopedContext,
 	)
 	upstream, downstream := apiclient.InventoryControlStreamPipe()
 
@@ -12938,69 +12973,102 @@ func TestRegisterInventoryControlStreamScopes(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	srv := newTestTLSServer(t)
+	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
+
+	scopePinnedAuth, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir: t.TempDir(),
+		ScopesFeatures: scopes.Features{
+			Enabled:         true,
+			AgentPinEnabled: true,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
 
 	const serverID = "test-server"
 	const agentScope = "/test/one"
+	const role = types.RoleNode
 
 	cases := []struct {
-		name        string
-		helloScope  string
-		expectScope string
-		expectErr   func(error) bool
+		name       string
+		helloScope string
+		agentScope string
+		expectErr  func(error) bool
 	}{
 		{
-			name:        "empty scope defaults to agent scope",
-			helloScope:  "",
-			expectScope: agentScope,
-			expectErr:   nil,
+			name:       "empty scope defaults to agent scope",
+			helloScope: "",
+			agentScope: agentScope,
+			expectErr:  nil,
 		},
 		{
-			name:        "matching scope accepted",
-			helloScope:  agentScope,
-			expectScope: agentScope,
-			expectErr:   nil,
+			name:       "matching scope accepted",
+			helloScope: agentScope,
+			agentScope: agentScope,
+			expectErr:  nil,
 		},
 		{
 			name:       "mismatched scope denied",
+			helloScope: "/test/two",
+			agentScope: "/test/one",
+			expectErr:  trace.IsAccessDenied,
+		},
+		{
+			name:       "hello scope with empty agent scope denied",
 			helloScope: "/test/two",
 			expectErr:  trace.IsAccessDenied,
 		},
 	}
 
 	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			h := newInventoryControlStreamHarness(t, srv.AuthServer, serverID, agentScope, "", types.RoleNode)
-			type registerResult struct {
-				hello *proto.UpstreamInventoryHello
-				err   error
+		for _, agentScopePin := range []bool{false, true} {
+			if agentScopePin && c.agentScope == "" {
+				// We skip test cases for scope pinned agents with an empty scope because they cannot be
+				// authorized and will fail while building the harness, so the intended behavior we're testing
+				// is never reached
+				continue
 			}
-			resultCh := make(chan registerResult)
-			go func() {
-				hello, err := h.server.RegisterInventoryControlStream(h.upstream)
-				resultCh <- registerResult{hello: hello, err: err}
-			}()
+			t.Run(fmt.Sprintf("%s agentScopePin=%t", c.name, agentScopePin), func(t *testing.T) {
+				as := authServer
+				ident := scopedHostWithLabelHash(t, as.ClusterName, serverID, c.agentScope, "", role)
+				if agentScopePin {
+					as = scopePinnedAuth
+					ident = scopePinnedHostWithLabelHash(t, as.ClusterName, serverID, c.agentScope, "", role)
+				}
+				h := newInventoryControlStreamHarness(t, as, ident)
+				type registerResult struct {
+					hello *proto.UpstreamInventoryHello
+					err   error
+				}
+				resultCh := make(chan registerResult)
+				go func() {
+					hello, err := h.server.RegisterInventoryControlStream(h.upstream)
+					resultCh <- registerResult{hello: hello, err: err}
+				}()
 
-			err := h.downstream.Send(ctx, &proto.UpstreamInventoryHello{
-				ServerID: serverID,
-				Scope:    c.helloScope,
-			})
-			require.NoError(t, err)
+				err := h.downstream.Send(ctx, proto.UpstreamInventoryHello_builder{
+					ServerID: serverID,
+					Scope:    c.helloScope,
+				}.Build())
+				require.NoError(t, err)
 
-			if c.expectErr != nil {
+				if c.expectErr != nil {
+					result := <-resultCh
+					require.True(t, c.expectErr(result.err), "expected error")
+					return
+				}
+
+				msg := <-h.downstream.Recv()
+				require.IsType(t, *new(*proto.DownstreamInventoryHello), msg)
+
 				result := <-resultCh
-				require.True(t, c.expectErr(result.err), "expected error")
-				return
-			}
-
-			msg := <-h.downstream.Recv()
-			require.IsType(t, *new(*proto.DownstreamInventoryHello), msg)
-
-			result := <-resultCh
-			require.NoError(t, result.err)
-			require.NotNil(t, result.hello)
-			require.Equal(t, c.expectScope, result.hello.GetScope())
-		})
+				require.NoError(t, result.err)
+				require.NotNil(t, result.hello)
+				require.Equal(t, c.agentScope, result.hello.GetScope())
+			})
+		}
 	}
 }
 
@@ -13018,8 +13086,9 @@ func TestRegisterInventoryControlStreamImmutableLabels(t *testing.T) {
 	}
 	helloHash := joining.HashImmutableLabels(helloLabels)
 
-	srv := newTestTLSServer(t)
-	t.Cleanup(func() { srv.Close() })
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 
 	cases := []struct {
 		name        string
@@ -13060,7 +13129,8 @@ func TestRegisterInventoryControlStreamImmutableLabels(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			h := newInventoryControlStreamHarness(t, srv.AuthServer, serverID, "", c.identHash, types.RoleNode)
+			ident := scopedHostWithLabelHash(t, as.ClusterName, serverID, "", c.identHash, types.RoleNode)
+			h := newInventoryControlStreamHarness(t, as, ident)
 			type registerResult struct {
 				hello *proto.UpstreamInventoryHello
 				err   error

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -9188,7 +9188,7 @@ func TestLocalServiceRolesHavePermissionsForUploaderService(t *testing.T) {
 					*authContext,
 				)
 
-				err := s.EmitAuditEvent(ctx, &apievents.UserLogin{
+				err := s.ScopedServerWithRoles().EmitAuditEvent(ctx, &apievents.UserLogin{
 					Metadata: apievents.Metadata{
 						Type: events.UserLoginEvent,
 						Code: events.UserLocalLoginFailureCode,
@@ -9206,7 +9206,7 @@ func TestLocalServiceRolesHavePermissionsForUploaderService(t *testing.T) {
 					*authContext,
 				)
 
-				stream, err := s.CreateAuditStream(ctx, session.ID("streamer"))
+				stream, err := s.ScopedServerWithRoles().CreateAuditStream(ctx, session.ID("streamer"))
 				require.NoError(t, err)
 				require.NoError(t, stream.Close(ctx))
 			})
@@ -9218,7 +9218,7 @@ func TestLocalServiceRolesHavePermissionsForUploaderService(t *testing.T) {
 					*authContext,
 				)
 
-				stream, err := s.ResumeAuditStream(ctx, session.ID("streamer"), "upload")
+				stream, err := s.ScopedServerWithRoles().ResumeAuditStream(ctx, session.ID("streamer"), "upload")
 				require.NoError(t, err)
 				require.NoError(t, stream.Close(ctx))
 			})
@@ -13364,4 +13364,80 @@ func TestScopedUserCertGeneration(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestScopePinnedEmitAuditEvent verifies that an agent with a scope pin is able to emit an audit event.
+func TestScopePinnedEmitAuditEvent(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	srv, err := authtest.NewTestServer(authtest.ServerConfig{
+		Auth: authtest.AuthServerConfig{
+			Dir: t.TempDir(),
+			ScopesFeatures: scopes.Features{
+				Enabled:         true,
+				AgentPinEnabled: true,
+			},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { srv.Close() })
+
+	const (
+		hostID   = "test-host"
+		username = "test-user"
+		scope    = "/test"
+	)
+	// setup auth with scope pinned host
+	scopedHostAuth := newScopePinnedTestServerForHost(t, srv.AuthServer, hostID, scope, types.RoleNode)
+
+	// create user to test scope pinned users
+	_, err = authtest.CreateUser(ctx, srv.Auth(), username)
+	require.NoError(t, err)
+	// create a scoped role assigning perms to create events
+	_, err = srv.Auth().ScopedAccess().CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+		Role: scopedaccessv1.ScopedRole_builder{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: username + "-role",
+			}.Build(),
+			Scope: scope,
+			Spec: scopedaccessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{scope},
+				Rules: []*scopedaccessv1.ScopedRule{
+					scopedaccessv1.ScopedRule_builder{
+						Resources: []string{types.KindEvent},
+						Verbs:     []string{types.VerbCreate},
+					}.Build(),
+				},
+			}.Build(),
+		}.Build(),
+	}.Build())
+	// NOTE (etate): if scoped role validation ever permits VerbCreate on KindEvent, then this test either needs to be updated
+	// to assert that EmitAuditEvent still fails for scoped user pins, or EmitAuditEvent needs to be updated to permit
+	// identities with scoped user pins
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err), "expected trace.BadParameterError")
+
+	// ensure that scope pinned agents are able to emit events
+	err = scopedHostAuth.EmitAuditEvent(ctx, &apievents.SessionConnect{
+		Metadata: apievents.Metadata{
+			Type: events.SessionConnectEvent,
+			Code: events.SessionConnectCode,
+		},
+		ServerMetadata: apievents.ServerMetadata{
+			ServerID: hostID,
+		},
+	})
+	require.NoError(t, err)
+
+	// ensure that scope pinned agents are able to create and resume audit streams
+	sessionID := session.ID("streamer")
+	stream, err := scopedHostAuth.CreateAuditStream(ctx, sessionID)
+	require.NoError(t, err)
+	require.NoError(t, stream.Close(ctx))
+
+	stream, err = scopedHostAuth.ResumeAuditStream(ctx, sessionID, "upload")
+	require.NoError(t, err)
+	require.NoError(t, stream.Close(ctx))
 }

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -8753,6 +8753,29 @@ func newScopedTestServerForHost(t *testing.T, srv *authtest.AuthServer, hostID, 
 	return authWithRole
 }
 
+// newScopePinnedTestServerForHost creates a self-cleaning `ScopedServerWithRoles`, configured
+// for a given host. One or more roles must be provided.
+func newScopePinnedTestServerForHost(t *testing.T, srv *authtest.AuthServer, hostID, scope string, roles ...types.SystemRole) *auth.ScopedServerWithRoles {
+	if !srv.ScopesFeatures.AgentPinEnabled {
+		require.FailNow(t, "cannot create server for scope pinned host while agent pinning is disabled")
+		return nil
+	}
+
+	authzContext := authz.ContextWithUser(t.Context(), authtest.TestScopePinnedHost(srv.ClusterName, hostID, scope, roles...).I)
+	ctxIdentity, err := srv.ScopedAuthorizer.AuthorizeScoped(authzContext)
+	require.NoError(t, err)
+
+	authWithRole := auth.NewScopedServerWithRoles(
+		srv.AuthServer,
+		srv.AuditLog,
+		ctxIdentity,
+	)
+
+	t.Cleanup(func() { authWithRole.Close() })
+
+	return authWithRole
+}
+
 func TestGenerateHostCertsScoped(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -8771,7 +8794,7 @@ func TestGenerateHostCertsScoped(t *testing.T) {
 	tlsPubPEM, err := keys.MarshalPublicKey(tlsKey.Public())
 	require.NoError(t, err)
 
-	certs, err := s.GenerateHostCerts(ctx, &proto.HostCertsRequest{
+	certs, err := s.ScopedServerWithRoles().GenerateHostCerts(ctx, &proto.HostCertsRequest{
 		PublicTLSKey: tlsPubPEM,
 		PublicSSHKey: sshPub,
 		HostID:       hostID,
@@ -8910,7 +8933,7 @@ func TestGenerateHostCertsAgentScopePin(t *testing.T) {
 		tlsPubPEM, err := keys.MarshalPublicKey(tlsKey.Public())
 		require.NoError(t, err)
 
-		certs, err := s.GenerateHostCerts(t.Context(), &proto.HostCertsRequest{
+		certs, err := s.ScopedServerWithRoles().GenerateHostCerts(t.Context(), &proto.HostCertsRequest{
 			PublicTLSKey: tlsPubPEM,
 			PublicSSHKey: sshPub,
 			HostID:       hostID,
@@ -8931,12 +8954,33 @@ func TestGenerateHostCertsAgentScopePin(t *testing.T) {
 		tlsPubPEM, err := keys.MarshalPublicKey(tlsKey.Public())
 		require.NoError(t, err)
 
-		certs, err := s.GenerateHostCerts(t.Context(), &proto.HostCertsRequest{
+		certs, err := s.ScopedServerWithRoles().GenerateHostCerts(t.Context(), &proto.HostCertsRequest{
 			PublicTLSKey: tlsPubPEM,
 			PublicSSHKey: sshPub,
 			HostID:       hostID,
 			Role:         types.RoleInstance,
 			SystemRoles:  systemRoles,
+		})
+		require.NoError(t, err)
+		return parseIdents(t, certs)
+	}
+
+	generatePinnedCerts := func(t *testing.T, as *authtest.AuthServer, role types.SystemRole) certIdents {
+		t.Helper()
+		s := newScopePinnedTestServerForHost(t, as, hostID, scope, role)
+
+		_, sshPub, err := testauthority.GenerateKeyPair()
+		require.NoError(t, err)
+		tlsKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+		require.NoError(t, err)
+		tlsPubPEM, err := keys.MarshalPublicKey(tlsKey.Public())
+		require.NoError(t, err)
+
+		certs, err := s.GenerateHostCerts(t.Context(), &proto.HostCertsRequest{
+			PublicTLSKey: tlsPubPEM,
+			PublicSSHKey: sshPub,
+			HostID:       hostID,
+			Role:         role,
 		})
 		require.NoError(t, err)
 		return parseIdents(t, certs)
@@ -9003,6 +9047,21 @@ func TestGenerateHostCertsAgentScopePin(t *testing.T) {
 			for _, role := range systemRoles {
 				require.Contains(t, sshAdditional, role.String())
 			}
+		})
+
+		// verify agent pin created correctly for service certs issued
+		// to an already pinned instance
+		t.Run("agent pin service cert for pinned identity", func(t *testing.T) {
+			idents := generatePinnedCerts(t, as, types.RoleNode)
+			require.Empty(t, idents.tls.Groups)
+			require.Empty(t, idents.tls.AgentScope)
+			require.NotNil(t, idents.tls.ScopePin)
+			require.Equal(t, scope, idents.tls.ScopePin.GetScope())
+			require.Equal(t, types.RoleNode.String(), idents.tls.ScopePin.GetSystemRoles().GetPrimary())
+
+			require.NotNil(t, idents.ssh.ScopePin)
+			require.Equal(t, scope, idents.ssh.ScopePin.GetScope())
+			require.Equal(t, types.RoleNode.String(), idents.ssh.ScopePin.GetSystemRoles().GetPrimary())
 		})
 
 		// verify that scope pins are not set for unscoped agents

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
@@ -1244,6 +1245,32 @@ func TestScopedHost(clusterName, hostID, scope string, roles ...types.SystemRole
 			AdditionalSystemRoles: types.SystemRoles(roles),
 			Identity: tlsca.Identity{
 				AgentScope: scope,
+			},
+		},
+	}
+}
+
+// TestScopePinnedHost returns TestIdentity for a scoped host with an agent pin. One or more roles may be provided;
+// all are included as AdditionalSystemRoles on an instance cert identity.
+func TestScopePinnedHost(clusterName, hostID, scope string, roles ...types.SystemRole) TestIdentity {
+	serverFQDN := hostID
+	if clusterName != "" {
+		serverFQDN = utils.HostFQDN(hostID, clusterName)
+	}
+	pin := &scopesv1.Pin{
+		Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+		Scope: scope,
+		SystemRoles: &scopesv1.SystemRoles{
+			Primary:    string(types.RoleInstance),
+			Additional: types.SystemRoles(roles).StringSlice(),
+		},
+	}
+	return TestIdentity{
+		I: authz.ScopedBuiltinRole{
+			ServerFQDN: serverFQDN,
+			ScopePin:   pin,
+			Identity: tlsca.Identity{
+				ScopePin: pin,
 			},
 		},
 	}

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -774,7 +774,28 @@ func generateCertificate(authServer *auth.Server, identity TestIdentity) ([]byte
 				PublicSSHKey: sshPublicKeyPEM,
 				SystemRoles:  id.AdditionalSystemRoles,
 			},
-			AgentScope: id.Identity.AgentScope,
+			AgentScope: id.Identity.GetAgentScope(),
+		})
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		return certs.TLS, privateKeyPEM, nil
+	case authz.ScopedBuiltinRole:
+		systemRoles, err := types.NewTeleportRoles(id.ScopePin.GetSystemRoles().GetAdditional())
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+
+		certs, err := authServer.GenerateHostCerts(ctx, auth.HostCertsParams{
+			Req: &proto.HostCertsRequest{
+				HostID:       id.ServerFQDN,
+				NodeName:     id.ServerFQDN,
+				Role:         types.SystemRole(id.ScopePin.GetSystemRoles().GetPrimary()),
+				PublicTLSKey: tlsPublicKeyPEM,
+				PublicSSHKey: sshPublicKeyPEM,
+				SystemRoles:  systemRoles,
+			},
+			AgentScope: id.Identity.GetAgentScope(),
 		})
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
@@ -1244,6 +1265,7 @@ func TestScopedHost(clusterName, hostID, scope string, roles ...types.SystemRole
 			Username:              username,
 			AdditionalSystemRoles: types.SystemRoles(roles),
 			Identity: tlsca.Identity{
+				Username:   hostID,
 				AgentScope: scope,
 			},
 		},
@@ -1267,8 +1289,9 @@ func TestScopePinnedHost(clusterName, hostID, scope string, roles ...types.Syste
 	}
 	return TestIdentity{
 		I: authz.ScopedBuiltinRole{
-			ServerFQDN: serverFQDN,
-			ScopePin:   pin,
+			ClusterName: clusterName,
+			ServerFQDN:  serverFQDN,
+			ScopePin:    pin,
 			Identity: tlsca.Identity{
 				ScopePin: pin,
 			},

--- a/lib/auth/client_tls_config_generator.go
+++ b/lib/auth/client_tls_config_generator.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/retryutils"
@@ -92,6 +93,27 @@ type HostAndUserCAPoolInfo struct {
 	CATypes authclient.HostAndUserCAInfo
 }
 
+// findPrimarySystemRole finds the primary role for the identity and validates that it is
+// a system role.
+// It returns the validated role and a bool indicating whether or not the role was found.
+func findPrimarySystemRole(i *tlsca.Identity) (types.SystemRole, bool) {
+	if i.ScopePin.GetKind() == scopesv1.PinKind_PIN_KIND_AGENT {
+		role := types.SystemRole(i.ScopePin.GetSystemRoles().GetPrimary())
+		if err := role.Check(); err != nil {
+			return "", false
+		}
+		return role, true
+	}
+	for _, role := range i.Groups {
+		systemRole := types.SystemRole(role)
+		err := systemRole.Check()
+		if err == nil {
+			return systemRole, true
+		}
+	}
+	return "", false
+}
+
 // verifyPeerCert returns a function that checks that the client peer
 // certificate's cluster name matches the cluster name of the CA
 // that issued it.
@@ -125,11 +147,11 @@ func (p *HostAndUserCAPoolInfo) verifyPeerCert() func([][]byte, [][]*x509.Certif
 		}
 
 		// Ensure the CA that issued this client cert is of the appropriate type
-		systemRole := findPrimarySystemRole(identity.Groups)
-		if systemRole != nil && !ca.IsHostCA {
+		systemRole, found := findPrimarySystemRole(identity)
+		if found && !ca.IsHostCA {
 			slog.WarnContext(context.TODO(), "Client peer certificate has a builtin role but was not issued by a host CA", "role", systemRole.String())
 			return trace.AccessDenied(invalidCertErrMsg)
-		} else if systemRole == nil && !ca.IsUserCA {
+		} else if !found && !ca.IsUserCA {
 			slog.WarnContext(context.TODO(), "Client peer certificate has a local role but was not issued by a user CA")
 			return trace.AccessDenied(invalidCertErrMsg)
 		}

--- a/lib/auth/clusterconfig/clusterconfigv1/service.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service.go
@@ -404,13 +404,18 @@ func GetAdminActionsMFAStatus(oldPref, newPref types.AuthPreference) apievents.A
 
 // GetClusterNetworkingConfig returns the locally cached networking configuration.
 func (s *Service) GetClusterNetworkingConfig(ctx context.Context, _ *clusterconfigpb.GetClusterNetworkingConfigRequest) (*types.ClusterNetworkingConfigV2, error) {
-	authzCtx, err := s.authorizer.Authorize(ctx)
+	authzCtx, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authzCtx.CheckAccessToKind(types.KindClusterNetworkingConfig, types.VerbRead); err != nil {
-		if err2 := authzCtx.CheckAccessToKind(types.KindClusterConfig, types.VerbRead); err2 != nil {
+	ruleCtx := authzCtx.RuleContext()
+	if err := authzCtx.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadClusterNetworkingConfig, &ruleCtx); err != nil {
+		unscopedCtx, isUnscoped := authzCtx.UnscopedContext()
+		if !isUnscoped {
+			return nil, trace.Wrap(err)
+		}
+		if err2 := unscopedCtx.CheckAccessToKind(types.KindClusterConfig, types.VerbRead); err2 != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -710,25 +715,31 @@ func ValidateCloudNetworkConfigUpdate(authzCtx authz.Context, newConfig, oldConf
 
 // GetSessionRecordingConfig returns the locally cached networking configuration.
 func (s *Service) GetSessionRecordingConfig(ctx context.Context, _ *clusterconfigpb.GetSessionRecordingConfigRequest) (*types.SessionRecordingConfigV2, error) {
-	authzCtx, err := s.authorizer.Authorize(ctx)
+	authzCtx, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authzCtx.CheckAccessToKind(types.KindSessionRecordingConfig, types.VerbRead); err != nil {
-		if err2 := authzCtx.CheckAccessToKind(types.KindClusterConfig, types.VerbRead); err2 != nil {
+	ruleCtx := authzCtx.RuleContext()
+	if err := authzCtx.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadSessionRecordingConfig, &ruleCtx); err != nil {
+		unscopedCtx, isUnscoped := authzCtx.UnscopedContext()
+		if !isUnscoped {
+			return nil, trace.Wrap(err)
+		}
+
+		if err2 := unscopedCtx.CheckAccessToKind(types.KindClusterConfig, types.VerbRead); err2 != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
 
-	netConfig, err := s.readOnlyCache.GetReadOnlySessionRecordingConfig(ctx)
+	recConfig, err := s.readOnlyCache.GetReadOnlySessionRecordingConfig(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	cfgV2, ok := netConfig.Clone().(*types.SessionRecordingConfigV2)
+	cfgV2, ok := recConfig.Clone().(*types.SessionRecordingConfigV2)
 	if !ok {
-		return nil, trace.Wrap(trace.BadParameter("unexpected session recording config type %T (expected %T)", netConfig, cfgV2))
+		return nil, trace.Wrap(trace.BadParameter("unexpected session recording config type %T (expected %T)", recConfig, cfgV2))
 	}
 	return cfgV2, nil
 }
@@ -1160,12 +1171,13 @@ func (s *Service) ResetAccessGraphSettings(ctx context.Context, _ *clusterconfig
 }
 
 func (s *Service) GetClusterName(ctx context.Context, _ *clusterconfigpb.GetClusterNameRequest) (*types.ClusterNameV2, error) {
-	authzCtx, err := s.authorizer.Authorize(ctx)
+	authzCtx, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authzCtx.CheckAccessToKind(types.KindClusterName, types.VerbRead); err != nil {
+	ruleCtx := authzCtx.RuleContext()
+	if err := authzCtx.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadClusterName, &ruleCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/clusterconfig/clusterconfigv1/service_test.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/clusterconfig"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -541,6 +542,18 @@ func TestGetClusterNetworkingConfig(t *testing.T) {
 			assertion: func(t *testing.T, err error) {
 				require.NoError(t, err)
 			},
+		}, {
+			name: "authorized for cluster config",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterConfig: {types.VerbRead}},
+					},
+				}, nil
+			}),
+			assertion: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
 		},
 	}
 
@@ -1038,6 +1051,18 @@ func TestGetSessionRecordingConfig(t *testing.T) {
 				return &authz.Context{
 					Checker: fakeChecker{
 						rules: map[string][]string{types.KindSessionRecordingConfig: {types.VerbRead}},
+					},
+				}, nil
+			}),
+			assertion: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		}, {
+			name: "authorized for cluster config",
+			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return &authz.Context{
+					Checker: fakeChecker{
+						rules: map[string][]string{types.KindClusterConfig: {types.VerbRead}},
 					},
 				}, nil
 			}),
@@ -1691,6 +1716,12 @@ type serviceOpt = func(config *envConfig)
 func withAuthorizer(authz authz.Authorizer) serviceOpt {
 	return func(config *envConfig) {
 		config.authorizer = authz
+	}
+}
+
+func withScopedAuthorizer(scopedAuthz authz.ScopedAuthorizer) serviceOpt {
+	return func(config *envConfig) {
+		config.scopedAuthorizer = scopedAuthz
 	}
 }
 
@@ -2413,6 +2444,212 @@ func TestGetClusterName(t *testing.T) {
 			}
 
 			env, err := newTestEnv(withAuthorizer(test.authorizer), withClusterName(defaultCn))
+			require.NoError(t, err, "creating test service")
+
+			cn, err := env.GetClusterName(context.Background(), &clusterconfigpb.GetClusterNameRequest{})
+			test.assertion(t, cn, err)
+		})
+	}
+}
+
+type noopChecker struct {
+	services.AccessChecker
+}
+
+func (noopChecker) CheckAccessToRule(context services.RuleContext, namespace, rule, verb string) error {
+	return errors.New("noop")
+}
+
+func TestScopedGetClusterNetworkingConfig(t *testing.T) {
+	defaultCN, err := types.NewClusterName(types.ClusterNameSpecV2{
+		ClusterName: "my.example.com",
+		ClusterID:   "0000-0000-0000-0000",
+	})
+	require.NoError(t, err, "creating default cluster name")
+
+	defaultCNC := types.DefaultClusterNetworkingConfig()
+
+	const clusterName = "test-cluster"
+	const scope = "/aa/bb"
+	const systemRole = types.RoleNode
+	cases := []struct {
+		name             string
+		scopedAuthorizer scopedAuthorizerFunc
+		testSetup        func(*testing.T)
+		assertion        func(t *testing.T, cnc *types.ClusterNetworkingConfigV2, err error)
+	}{
+		{
+			name: "unauthorized",
+			scopedAuthorizer: scopedAuthorizerFunc(func(ctx context.Context) (*authz.ScopedContext, error) {
+				// we setup a full scoped checker context to make sure that we're evaluating scoped access rules
+				// and determining that VerbRead is not permitted for KindClusterName
+				checkerCtx, err := services.NewScopedAccessCheckerContextForAgentPin(&scopesv1.Pin{
+					Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+					Scope: scope,
+					SystemRoles: &scopesv1.SystemRoles{
+						Primary: string(systemRole),
+					},
+				}, map[string]*services.ScopedAccessChecker{
+					string(systemRole): services.NewScopedAccessCheckerFromUnscoped(noopChecker{}),
+				})
+				if err != nil {
+					return nil, err
+				}
+				return &authz.ScopedContext{
+					CheckerContext: checkerCtx,
+				}, nil
+			}),
+			assertion: func(t *testing.T, cnc *types.ClusterNetworkingConfigV2, err error) {
+				assert.Nil(t, cnc)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent resetting access graph settings", err)
+			},
+		},
+		{
+			name: "success",
+			scopedAuthorizer: scopedAuthorizerFunc(func(ctx context.Context) (*authz.ScopedContext, error) {
+				roleSet, err := authz.RoleSetForBuiltinRoles(clusterName, nil, true, systemRole)
+				if err != nil {
+					return nil, err
+				}
+				checker := services.NewAccessCheckerWithRoleSet(&services.AccessInfo{
+					Roles: []string{string(systemRole)},
+				}, clusterName, roleSet)
+				checkerCtx, err := services.NewScopedAccessCheckerContextForAgentPin(&scopesv1.Pin{
+					Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+					Scope: scope,
+					SystemRoles: &scopesv1.SystemRoles{
+						Primary: string(systemRole),
+					},
+				}, map[string]*services.ScopedAccessChecker{
+					string(systemRole): services.NewScopedAccessCheckerForSystemRole(string(systemRole), checker),
+				})
+				if err != nil {
+					return nil, err
+				}
+				return &authz.ScopedContext{
+					CheckerContext: checkerCtx,
+				}, nil
+			}),
+			assertion: func(t *testing.T, cnc *types.ClusterNetworkingConfigV2, err error) {
+				require.NoError(t, err)
+				require.Empty(t, cmp.Diff(defaultCNC, cnc, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			if test.testSetup != nil {
+				test.testSetup(t)
+			}
+
+			authorizer := authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return nil, errors.New("unscoped authorizer should not be called")
+			})
+
+			env, err := newTestEnv(
+				withAuthorizer(authorizer),
+				withScopedAuthorizer(test.scopedAuthorizer),
+				withClusterName(defaultCN),
+				withDefaultClusterNetworkingConfig(defaultCNC),
+			)
+			require.NoError(t, err, "creating test service")
+
+			cn, err := env.GetClusterNetworkingConfig(context.Background(), &clusterconfigpb.GetClusterNetworkingConfigRequest{})
+			test.assertion(t, cn, err)
+		})
+	}
+}
+
+func TestScopedGetClusterName(t *testing.T) {
+	defaultCN, err := types.NewClusterName(types.ClusterNameSpecV2{
+		ClusterName: "my.example.com",
+		ClusterID:   "0000-0000-0000-0000",
+	})
+	require.NoError(t, err)
+	const scope = "/aa/bb"
+	const systemRole = types.RoleNode
+	cases := []struct {
+		name             string
+		scopedAuthorizer scopedAuthorizerFunc
+		testSetup        func(*testing.T)
+		assertion        func(t *testing.T, cn *types.ClusterNameV2, err error)
+	}{
+		{
+			name: "unauthorized",
+			scopedAuthorizer: scopedAuthorizerFunc(func(ctx context.Context) (*authz.ScopedContext, error) {
+				// we setup a full scoped checker context to make sure that we're evaluating scoped access rules
+				// and determining that VerbRead is not permitted for KindClusterName
+				checkerCtx, err := services.NewScopedAccessCheckerContextForAgentPin(&scopesv1.Pin{
+					Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+					Scope: scope,
+					SystemRoles: &scopesv1.SystemRoles{
+						Primary: string(systemRole),
+					},
+				}, map[string]*services.ScopedAccessChecker{
+					string(systemRole): services.NewScopedAccessCheckerFromUnscoped(noopChecker{}),
+				})
+				if err != nil {
+					return nil, err
+				}
+				return &authz.ScopedContext{
+					CheckerContext: checkerCtx,
+				}, nil
+			}),
+			assertion: func(t *testing.T, cn *types.ClusterNameV2, err error) {
+				assert.Nil(t, cn)
+				require.True(t, trace.IsAccessDenied(err), "got (%v), expected unauthorized user to prevent resetting access graph settings", err)
+			},
+		},
+		{
+			name: "success",
+			scopedAuthorizer: scopedAuthorizerFunc(func(ctx context.Context) (*authz.ScopedContext, error) {
+				roleSet, err := authz.RoleSetForBuiltinRoles(defaultCN.GetClusterName(), nil, true, systemRole)
+				if err != nil {
+					return nil, err
+				}
+				checker := services.NewAccessCheckerWithRoleSet(&services.AccessInfo{
+					Roles: []string{string(systemRole)},
+				}, defaultCN.GetClusterName(), roleSet)
+				checkerCtx, err := services.NewScopedAccessCheckerContextForAgentPin(&scopesv1.Pin{
+					Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+					Scope: scope,
+					SystemRoles: &scopesv1.SystemRoles{
+						Primary: string(systemRole),
+					},
+				}, map[string]*services.ScopedAccessChecker{
+					string(systemRole): services.NewScopedAccessCheckerForSystemRole(string(systemRole), checker),
+				})
+				if err != nil {
+					return nil, err
+				}
+				return &authz.ScopedContext{
+					CheckerContext: checkerCtx,
+				}, nil
+			}),
+			assertion: func(t *testing.T, cn *types.ClusterNameV2, err error) {
+				require.NoError(t, err)
+				require.Equal(t, defaultCN.GetClusterName(), cn.GetClusterName())
+				require.Equal(t, defaultCN.GetClusterID(), cn.GetClusterID())
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			if test.testSetup != nil {
+				test.testSetup(t)
+			}
+
+			authorizer := authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
+				return nil, errors.New("unscoped authorizer should not be called")
+			})
+
+			env, err := newTestEnv(
+				withAuthorizer(authorizer),
+				withScopedAuthorizer(test.scopedAuthorizer),
+				withClusterName(defaultCN),
+			)
 			require.NoError(t, err, "creating test service")
 
 			cn, err := env.GetClusterName(context.Background(), &clusterconfigpb.GetClusterNameRequest{})

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -789,7 +789,7 @@ func (g *GRPCServer) generateUserSingleUseCerts(ctx context.Context, srv *Scoped
 }
 
 func (g *GRPCServer) GenerateHostCerts(ctx context.Context, req *authpb.HostCertsRequest) (*authpb.Certs, error) {
-	auth, err := g.authenticate(ctx)
+	auth, err := g.scopedAuthenticate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -801,7 +801,7 @@ func (g *GRPCServer) GenerateHostCerts(ctx context.Context, req *authpb.HostCert
 	}
 	req.RemoteAddr = p.Addr.String()
 
-	certs, err := auth.ServerWithRoles.GenerateHostCerts(ctx, req)
+	certs, err := auth.GenerateHostCerts(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -277,7 +277,7 @@ func (g *GRPCServer) GetServer() (*grpc.Server, error) {
 
 // EmitAuditEvent emits audit event
 func (g *GRPCServer) EmitAuditEvent(ctx context.Context, req *apievents.OneOf) (*emptypb.Empty, error) {
-	auth, err := g.authenticate(ctx)
+	auth, err := g.scopedAuthenticate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -347,7 +347,7 @@ func (g *GRPCServer) SendKeepAlives(stream authpb.AuthService_SendKeepAlivesServ
 
 // CreateAuditStream creates or resumes audit event stream
 func (g *GRPCServer) CreateAuditStream(stream authpb.AuthService_CreateAuditStreamServer) error {
-	auth, err := g.authenticate(stream.Context())
+	auth, err := g.scopedAuthenticate(stream.Context())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -369,7 +369,7 @@ func (g *GRPCServer) CreateAuditStream(stream authpb.AuthService_CreateAuditStre
 
 	var eventStream apievents.Stream
 	var sessionID session.ID
-	g.logger.DebugContext(stream.Context(), "CreateAuditStream connection", "identity", auth.User.GetName())
+	g.logger.DebugContext(stream.Context(), "CreateAuditStream connection", "identity", auth.scopedContext.DisplayName())
 	streamStart := time.Now()
 	processed := int64(0)
 	counter := 0
@@ -2456,11 +2456,11 @@ func maybeDowngradeRoleSSHPortForwarding(role *types.RoleV6, clientVersion *semv
 
 // GetRole retrieves a role by name.
 func (g *GRPCServer) GetRole(ctx context.Context, req *authpb.GetRoleRequest) (*types.RoleV6, error) {
-	auth, err := g.authenticate(ctx)
+	auth, err := g.scopedAuthenticate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	roleI, err := auth.ServerWithRoles.GetRole(ctx, req.Name)
+	roleI, err := auth.GetRole(ctx, req.Name)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -6113,13 +6113,14 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	)
 
 	usersService, err := usersv1.NewService(usersv1.ServiceConfig{
-		Authorizer: cfg.Authorizer,
-		Cache:      cfg.AuthServer.Cache,
-		Backend:    cfg.AuthServer.Services,
-		Emitter:    cfg.Emitter,
-		Reporter:   cfg.AuthServer.Services.UsageReporter,
-		Clock:      cfg.AuthServer.GetClock(),
-		Logger:     cfg.AuthServer.logger.With(teleport.ComponentKey, "users.service"),
+		Authorizer:       cfg.Authorizer,
+		ScopedAuthorizer: cfg.ScopedAuthorizer,
+		Cache:            cfg.AuthServer.Cache,
+		Backend:          cfg.AuthServer.Services,
+		Emitter:          cfg.Emitter,
+		Reporter:         cfg.AuthServer.Services.UsageReporter,
+		Clock:            cfg.AuthServer.GetClock(),
+		Logger:           cfg.AuthServer.logger.With(teleport.ComponentKey, "users.service"),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -547,7 +547,17 @@ func (g *GRPCServer) WatchEvents(watch *authpb.Watch, stream authpb.AuthService_
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return trace.Wrap(WatchEvents(watch, stream, auth.scopedContext.User.GetName(), auth, modules.GetModules()))
+	var componentName string
+	if auth.scopedContext.User != nil {
+		componentName = auth.scopedContext.User.GetName()
+	} else {
+		var isBuiltinServer bool
+		componentName, isBuiltinServer = getBuiltinServerID(auth.scopedContext.Identity)
+		if !isBuiltinServer {
+			return trace.BadParameter("could not derive component name from auth context")
+		}
+	}
+	return trace.Wrap(WatchEvents(watch, stream, componentName, auth, modules.GetModules()))
 }
 
 // WatchEvent is a stream interface for sending events.
@@ -850,7 +860,7 @@ var icsServiceToMetricName = map[types.SystemRole]string{
 }
 
 func (g *GRPCServer) InventoryControlStream(stream authpb.AuthService_InventoryControlStreamServer) error {
-	auth, err := g.authenticate(stream.Context())
+	auth, err := g.scopedAuthenticate(stream.Context())
 	if err != nil {
 		return trail.ToGRPC(err)
 	}
@@ -3902,11 +3912,11 @@ func (g *GRPCServer) GetClusterAuditConfig(ctx context.Context, _ *emptypb.Empty
 
 // GetClusterNetworkingConfig gets cluster networking configuration.
 func (g *GRPCServer) GetClusterNetworkingConfig(ctx context.Context, _ *emptypb.Empty) (*types.ClusterNetworkingConfigV2, error) {
-	auth, err := g.authenticate(ctx)
+	auth, err := g.scopedAuthenticate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	netConfig, err := auth.ServerWithRoles.GetClusterNetworkingConfig(ctx)
+	netConfig, err := auth.GetClusterNetworkingConfig(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -3944,11 +3954,11 @@ func (g *GRPCServer) ResetClusterNetworkingConfig(ctx context.Context, _ *emptyp
 
 // GetSessionRecordingConfig gets session recording configuration.
 func (g *GRPCServer) GetSessionRecordingConfig(ctx context.Context, _ *emptypb.Empty) (*types.SessionRecordingConfigV2, error) {
-	auth, err := g.authenticate(ctx)
+	auth, err := g.scopedAuthenticate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	recConfig, err := auth.ServerWithRoles.GetSessionRecordingConfig(ctx)
+	recConfig, err := auth.GetSessionRecordingConfig(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -6989,3 +6989,68 @@ func TestGenerateUserCertsScopedBot(t *testing.T) {
 		})
 	}
 }
+
+func TestScopedWatchEvents(t *testing.T) {
+	t.Parallel()
+	ts := newTestTLSServer(t, withScopesFeatures(scopes.Features{Enabled: true, AgentPinEnabled: true}))
+	const (
+		hostID = "test-server"
+		scope  = "/test"
+		role   = types.RoleNode
+	)
+
+	scopedClient, err := ts.NewClient(authtest.TestScopedHost(ts.ClusterName(), "scoped-host", scope, role))
+	require.NoError(t, err)
+	t.Cleanup(func() { scopedClient.Close() })
+
+	scopePinnedClient, err := ts.NewClient(authtest.TestScopePinnedHost(ts.ClusterName(), "scope-pinned-host", scope, role))
+	require.NoError(t, err)
+	t.Cleanup(func() { scopePinnedClient.Close() })
+
+	tt := []struct {
+		name          string
+		client        *authclient.Client
+		kind          string
+		expectFailure bool
+	}{
+		{
+			name:   "scoped host watching allowed kind",
+			client: scopedClient,
+			kind:   types.KindCertAuthority,
+		},
+		{
+			name:          "scoped host watching disallowed kind",
+			client:        scopedClient,
+			kind:          types.KindNode,
+			expectFailure: true,
+		},
+		{
+			name:   "scope pinned host watching allowed kind",
+			client: scopePinnedClient,
+			kind:   types.KindCertAuthority,
+		},
+		{
+			name:          "scope pinned host watching disallowed kind",
+			client:        scopePinnedClient,
+			kind:          types.KindNode,
+			expectFailure: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			w, err := tc.client.NewWatcher(t.Context(), types.Watch{Kinds: []types.WatchKind{
+				{Kind: tc.kind},
+			}})
+			require.NoError(t, err)
+
+			select {
+			case <-w.Done():
+				require.True(t, tc.expectFailure, "expected watcher to fail")
+			case <-w.Events():
+				require.False(t, tc.expectFailure, "expected watcher to succeed")
+				w.Close()
+			}
+		})
+	}
+}

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -737,7 +737,7 @@ func (a *Middleware) GetUser(connState tls.ConnectionState) (authz.IdentityGette
 		// the local auth server can not trust remote servers
 		// to issue certificates with system roles (e.g. Admin),
 		// to get unrestricted access to the local cluster
-		systemRole := findPrimarySystemRole(identity.Groups)
+		systemRole := getPrimarySystemRole(identity.Groups)
 		if systemRole != nil {
 			return authz.RemoteBuiltinRole{
 				Role:        *systemRole,
@@ -756,7 +756,7 @@ func (a *Middleware) GetUser(connState tls.ConnectionState) (authz.IdentityGette
 	// code below expects user or service from local cluster, to distinguish between
 	// interactive users and services (e.g. proxies), the code below
 	// checks for presence of system roles issued in certificate identity
-	systemRole := findPrimarySystemRole(identity.Groups)
+	systemRole := getPrimarySystemRole(identity.Groups)
 	// in case if the system role is present, assume this is a service
 	// agent, e.g. Proxy, connecting to the cluster
 	if systemRole != nil {
@@ -790,7 +790,10 @@ func (a *Middleware) GetUser(connState tls.ConnectionState) (authz.IdentityGette
 	return newLocalUserFromIdentity(*identity), nil
 }
 
-func findPrimarySystemRole(roles []string) *types.SystemRole {
+// getPrimarySystemRole finds the primary role in the given list and validates that it
+// is a system role. This was renamed from findPrimarySystemRole which was updated and
+// moved to ./client_tls_config_generator.go upstream
+func getPrimarySystemRole(roles []string) *types.SystemRole {
 	for _, role := range roles {
 		systemRole := types.SystemRole(role)
 		err := systemRole.Check()
@@ -930,7 +933,7 @@ func (a *Middleware) extractIdentityFromImpersonationHeader(proxyCluster string,
 	}
 
 	switch {
-	case findPrimarySystemRole(impersonatedIdentity.Groups) != nil:
+	case getPrimarySystemRole(impersonatedIdentity.Groups) != nil:
 		// make sure that this user does not have system role
 		// since system roles are not allowed to be impersonated.
 		return nil, trace.AccessDenied("can not impersonate a system role")

--- a/lib/auth/scopes/access/service.go
+++ b/lib/auth/scopes/access/service.go
@@ -106,7 +106,7 @@ func (s *Server) CreateScopedRole(ctx context.Context, req *scopedaccessv1.Creat
 		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbCreate)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to create scoped roles in the requested scope",
-			"user", authzContext.User.GetName(),
+			"user", authzContext.DisplayName(),
 			"scope", req.GetRole().GetScope())
 		return nil, trace.Wrap(err)
 	}
@@ -158,7 +158,7 @@ func (s *Server) CreateScopedRoleAssignment(ctx context.Context, req *scopedacce
 		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbCreate)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to create scoped role assignments in the requested scope",
-			"user", authzContext.User.GetName(),
+			"user", authzContext.DisplayName(),
 			"scope", req.GetAssignment().GetScope())
 		return nil, trace.Wrap(err)
 	}
@@ -205,7 +205,7 @@ func (s *Server) DeleteScopedRole(ctx context.Context, req *scopedaccessv1.Delet
 		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbDelete)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to delete scoped roles in the requested scope",
-			"user", authzContext.User.GetName(),
+			"user", authzContext.DisplayName(),
 			"scope", grsp.GetRole().GetScope(),
 			"role", req.GetName(),
 			"error", err,
@@ -260,7 +260,7 @@ func (s *Server) DeleteScopedRoleAssignment(ctx context.Context, req *scopedacce
 		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbDelete)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to delete scoped role assignments in the requested scope",
-			"user", authzContext.User.GetName(),
+			"user", authzContext.DisplayName(),
 			"scope", grsp.GetAssignment().GetScope(),
 			"assignment", req.GetName(),
 			"error", err,
@@ -297,12 +297,21 @@ func (s *Server) GetScopedRole(ctx context.Context, req *scopedaccessv1.GetScope
 		return nil, trace.Wrap(err)
 	}
 
-	// evaluate the access to the role based on its scope
-	if err := authzContext.CheckerContext.Decision(ctx, preAuthzRsp.GetRole().GetScope(), func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbReadNoSecrets)
-	}); err != nil {
+	// Evaluate access to the role based on its scope. Only agents are allowed to read ancestor scopes.
+	if authz.ScopedIsLocalOrRemoteService(authzContext) {
+		err = authzContext.CheckerContext.RiskyAuthorizeUnpinnedReadWithScope(
+			ctx,
+			services.UnpinnedReadScopedRole,
+			&ruleCtx,
+			preAuthzRsp.GetRole().GetScope())
+	} else {
+		err = authzContext.CheckerContext.Decision(ctx, preAuthzRsp.GetRole().GetScope(), func(checker *services.ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbReadNoSecrets)
+		})
+	}
+	if err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to read scoped role",
-			"user", authzContext.User.GetName(),
+			"user", authzContext.DisplayName(),
 			"scope", preAuthzRsp.GetRole().GetScope(),
 			"role", req.GetName(),
 			"error", err,
@@ -344,7 +353,7 @@ func (s *Server) GetScopedRoleAssignment(ctx context.Context, req *scopedaccessv
 		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbReadNoSecrets)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to read scoped role assignment",
-			"user", authzContext.User.GetName(),
+			"user", authzContext.DisplayName(),
 			"scope", preAuthzRsp.GetAssignment().GetScope(),
 			"assignment", req.GetName(),
 			"error", err,
@@ -454,7 +463,7 @@ func (s *Server) UpdateScopedRole(ctx context.Context, req *scopedaccessv1.Updat
 		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbUpdate)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to update scoped roles in the requested scope",
-			"user", authzContext.User.GetName(),
+			"user", authzContext.DisplayName(),
 			"scope", req.GetRole().GetScope())
 		return nil, trace.Wrap(err)
 	}
@@ -483,7 +492,7 @@ func (s *Server) UpdateScopedRoleAssignment(ctx context.Context, req *scopedacce
 		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbUpdate)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to update scoped role assignments in the requested scope",
-			"user", authzContext.User.GetName(),
+			"user", authzContext.DisplayName(),
 			"scope", req.GetAssignment().GetScope())
 		return nil, trace.Wrap(err)
 	}
@@ -515,7 +524,7 @@ func (s *Server) UpsertScopedRole(ctx context.Context, req *scopedaccessv1.Upser
 		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbCreate, types.VerbUpdate)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to upsert scoped roles in the requested scope",
-			"user", authzContext.User.GetName(),
+			"user", authzContext.DisplayName(),
 			"scope", req.GetRole().GetScope())
 		return nil, trace.Wrap(err)
 	}
@@ -540,7 +549,7 @@ func (s *Server) UpsertScopedRoleAssignment(ctx context.Context, req *scopedacce
 		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbCreate, types.VerbUpdate)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to upsert scoped role assignments in the requested scope",
-			"user", authzContext.User.GetName(),
+			"user", authzContext.DisplayName(),
 			"scope", req.GetAssignment().GetScope())
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/scopes/access/service_test.go
+++ b/lib/auth/scopes/access/service_test.go
@@ -120,6 +120,94 @@ func newServerForIdentity(t *testing.T, bk *backendPack, accessInfo *services.Ac
 	return srv
 }
 
+// newServerForAgent builds a server whose scoped context is a scoped agent.
+func newServerForAgent(t *testing.T, bk *backendPack, pin *scopesv1.Pin) *Server {
+	t.Helper()
+
+	roleSet, err := services.RoleSetFromSpec("test-agent-role", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Rules: []types.Rule{types.NewRule(types.Wildcard, services.RW())},
+		},
+	})
+	require.NoError(t, err)
+
+	roleName := pin.GetSystemRoles().GetPrimary()
+	checker := services.NewAccessCheckerWithRoleSet(&services.AccessInfo{}, testClusterName, roleSet)
+	checkerCtx, err := services.NewScopedAccessCheckerContextForAgentPin(pin, map[string]*services.ScopedAccessChecker{
+		roleName: services.NewScopedAccessCheckerForSystemRole(roleName, checker),
+	})
+	require.NoError(t, err)
+
+	authorizer := &fakeSplitAuthorizer{
+		ctx: &authz.ScopedContext{
+			User:           &types.UserV2{Metadata: types.Metadata{Name: "agent"}},
+			Identity:       authz.ScopedBuiltinRole{ScopePin: pin},
+			CheckerContext: checkerCtx,
+		},
+	}
+
+	srv, err := New(Config{
+		ScopedAuthorizer: authorizer,
+		Reader:           bk.cache,
+		Writer:           bk.service,
+		BackendReader:    bk.service,
+		ScopesFeatures:   scopes.Features{Enabled: true},
+	})
+	require.NoError(t, err)
+
+	return srv
+}
+
+// TestGetScopedRoleAgentReadsAncestorScope verifies that a scoped agent can read a
+// scoped role at an ancestor of its pinned scope.
+func TestGetScopedRoleAgentReadsAncestorScope(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	bk := newBackendPack(t)
+	defer bk.Close()
+
+	// A role at /staging, an ancestor of the agent's pin (/staging/west).
+	_, err := bk.service.CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+		Role: scopedaccessv1.ScopedRole_builder{
+			Kind:     scopedaccess.KindScopedRole,
+			Metadata: headerv1.Metadata_builder{Name: "staging-admin"}.Build(),
+			Scope:    "/staging",
+			Spec: scopedaccessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{"/staging"},
+				Rules: []*scopedaccessv1.ScopedRule{
+					scopedaccessv1.ScopedRule_builder{
+						Resources: []string{scopedaccess.KindScopedRole},
+						Verbs:     []string{types.VerbReadNoSecrets},
+					}.Build(),
+				},
+			}.Build(),
+			Version: types.V1,
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	waitForRoleCondition(t, bk.cache, func(roles []*scopedaccessv1.ScopedRole) bool {
+		return len(roles) == 1
+	})
+
+	// Agent pinned to /staging/west — a descendant of the role's /staging scope.
+	srv := newServerForAgent(t, bk, scopesv1.Pin_builder{
+		Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+		Scope: "/staging/west",
+		SystemRoles: scopesv1.SystemRoles_builder{
+			Primary: string(types.RoleApp),
+		}.Build(),
+	}.Build())
+
+	rrsp, err := srv.GetScopedRole(ctx, scopedaccessv1.GetScopedRoleRequest_builder{
+		Name: "staging-admin",
+	}.Build())
+	require.NoError(t, err)
+	require.Equal(t, "staging-admin", rrsp.GetRole().GetMetadata().GetName())
+	require.Equal(t, "/staging", rrsp.GetRole().GetScope())
+}
+
 type backendPack struct {
 	backend        backend.Backend
 	service        *local.ScopedAccessService

--- a/lib/auth/users/usersv1/service.go
+++ b/lib/auth/users/usersv1/service.go
@@ -67,26 +67,28 @@ type Backend interface {
 // ServiceConfig holds configuration options for
 // the users gRPC service.
 type ServiceConfig struct {
-	Authorizer authz.Authorizer
-	Cache      Cache
-	Backend    Backend
-	Logger     *slog.Logger
-	Emitter    apievents.Emitter
-	Reporter   usagereporter.UsageReporter
-	Clock      clockwork.Clock
+	Authorizer       authz.Authorizer
+	ScopedAuthorizer authz.ScopedAuthorizer
+	Cache            Cache
+	Backend          Backend
+	Logger           *slog.Logger
+	Emitter          apievents.Emitter
+	Reporter         usagereporter.UsageReporter
+	Clock            clockwork.Clock
 }
 
 // Service implements the teleport.users.v1.UsersService RPC service.
 type Service struct {
 	userspb.UnimplementedUsersServiceServer
 
-	authorizer authz.Authorizer
-	cache      Cache
-	backend    Backend
-	logger     *slog.Logger
-	emitter    apievents.Emitter
-	reporter   usagereporter.UsageReporter
-	clock      clockwork.Clock
+	authorizer       authz.Authorizer
+	scopedAuthorizer authz.ScopedAuthorizer
+	cache            Cache
+	backend          Backend
+	logger           *slog.Logger
+	emitter          apievents.Emitter
+	reporter         usagereporter.UsageReporter
+	clock            clockwork.Clock
 }
 
 // NewService returns a new users gRPC service.
@@ -98,6 +100,8 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 		return nil, trace.BadParameter("backend service is required")
 	case cfg.Authorizer == nil:
 		return nil, trace.BadParameter("authorizer is required")
+	case cfg.ScopedAuthorizer == nil:
+		return nil, trace.BadParameter("scoped authorizer is required")
 	case cfg.Emitter == nil:
 		return nil, trace.BadParameter("emitter is required")
 	case cfg.Reporter == nil:
@@ -112,37 +116,53 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	}
 
 	return &Service{
-		logger:     cfg.Logger,
-		authorizer: cfg.Authorizer,
-		cache:      cfg.Cache,
-		backend:    cfg.Backend,
-		emitter:    cfg.Emitter,
-		reporter:   cfg.Reporter,
-		clock:      cfg.Clock,
+		logger:           cfg.Logger,
+		authorizer:       cfg.Authorizer,
+		scopedAuthorizer: cfg.ScopedAuthorizer,
+		cache:            cfg.Cache,
+		backend:          cfg.Backend,
+		emitter:          cfg.Emitter,
+		reporter:         cfg.Reporter,
+		clock:            cfg.Clock,
 	}, nil
 }
 
 // currentUserAction is a special checker that allows certain actions for users
 // even if they are not admins, e.g. update their own passwords,
 // or generate certificates, otherwise it will require admin privileges
-func currentUserAction(authzContext authz.Context, username string) error {
-	if authz.IsLocalUser(authzContext) && username == authzContext.User.GetName() {
+func currentUserAction(scopedCtx *authz.ScopedContext, username string) error {
+	if authz.ScopedIsCurrentUser(scopedCtx, username) {
 		return nil
 	}
-	return authzContext.Checker.CheckAccessToRule(&services.Context{User: authzContext.User},
+
+	unscopedCtx, isUnscoped := scopedCtx.UnscopedContext()
+	if !isUnscoped {
+		return trace.AccessDenied("scoped users can not create other users")
+	}
+
+	if authz.IsCurrentUser(*unscopedCtx, username) {
+		return nil
+	}
+
+	return unscopedCtx.Checker.CheckAccessToRule(&services.Context{User: unscopedCtx.User},
 		apidefaults.Namespace, types.KindUser, types.VerbCreate)
 }
 
-func (s *Service) getCurrentUser(ctx context.Context, authCtx *authz.Context) (*types.UserV2, error) {
+func (s *Service) getCurrentUser(ctx context.Context, scopedCtx *authz.ScopedContext) (*types.UserV2, error) {
+	// scopedCtx.User can be nil in the case of a scopedCtx built on authz.ScopedBuiltinRole
+	if scopedCtx.User == nil {
+		return nil, trace.BadParameter("expected a current authenticated user, identity likely a builtin system role")
+	}
+
 	// check access to roles
-	for _, role := range authCtx.User.GetRoles() {
+	for _, role := range scopedCtx.User.GetRoles() {
 		_, err := s.cache.GetRole(ctx, role)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
 
-	withoutSecrets := authCtx.User.WithoutSecrets()
+	withoutSecrets := scopedCtx.User.WithoutSecrets()
 	user, ok := withoutSecrets.(types.User)
 	if !ok {
 		return nil, trace.BadParameter("expected types.User when fetching current user information, got %T", withoutSecrets)
@@ -157,21 +177,25 @@ func (s *Service) getCurrentUser(ctx context.Context, authCtx *authz.Context) (*
 }
 
 func (s *Service) GetUser(ctx context.Context, req *userspb.GetUserRequest) (*userspb.GetUserResponse, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
+	scopedCtx, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if req.Name == "" && req.CurrentUser {
-		user, err := s.getCurrentUser(ctx, authCtx)
-		return &userspb.GetUserResponse{User: user}, trace.Wrap(err)
+	if req.GetName() == "" && req.GetCurrentUser() {
+		user, err := s.getCurrentUser(ctx, scopedCtx)
+		return userspb.GetUserResponse_builder{User: user}.Build(), trace.Wrap(err)
 	}
 
-	if req.WithSecrets {
+	unscopedCtx, isUnscoped := scopedCtx.UnscopedContext()
+	if req.GetWithSecrets() {
+		if !isUnscoped {
+			return nil, trace.AccessDenied("this request can only be executed by an unscoped admin")
+		}
 		// TODO(fspmarshall): replace admin requirement with VerbReadWithSecrets once we've
 		// migrated to that model.
-		if !authz.HasBuiltinRole(*authCtx, string(types.RoleAdmin)) {
-			err := trace.AccessDenied("user %q requested access to user %q with secrets", authCtx.User.GetName(), req.Name)
+		if !authz.HasBuiltinRole(*unscopedCtx, string(types.RoleAdmin)) {
+			err := trace.AccessDenied("user %q requested access to user %q with secrets", unscopedCtx.User.GetName(), req.GetName())
 			s.logger.WarnContext(ctx, "user does not have permission to read user with secrets", "error", err)
 			if err := s.emitter.EmitAuditEvent(ctx, &apievents.UserLogin{
 				Metadata: apievents.Metadata{
@@ -187,14 +211,14 @@ func (s *Service) GetUser(ctx context.Context, req *userspb.GetUserRequest) (*us
 			}); err != nil {
 				s.logger.WarnContext(ctx, "Failed to emit local login failure event", "error", err)
 			}
-			return nil, trace.AccessDenied("this request can be only executed by an admin")
+			return nil, trace.AccessDenied("this request can only be executed by an admin")
 		}
 	} else {
 		// if secrets are not being accessed, let users always read
 		// their own info.
-		if err := currentUserAction(*authCtx, req.Name); err != nil {
-			// not current user, perform normal permission check.
-			if err := authCtx.CheckAccessToKind(types.KindUser, types.VerbRead); err != nil {
+		if err := currentUserAction(scopedCtx, req.GetName()); err != nil {
+			ruleCtx := scopedCtx.RuleContext()
+			if err := scopedCtx.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadUser, &ruleCtx); err != nil {
 				return nil, trace.Wrap(err)
 			}
 		}

--- a/lib/auth/users/usersv1/service_test.go
+++ b/lib/auth/users/usersv1/service_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -53,6 +54,7 @@ type fakeAuthorizer struct {
 	authorize bool
 
 	authzContext *authz.Context
+	checkerMap   map[string]*services.ScopedAccessChecker
 }
 
 // Authorize implements authz.Authorizer
@@ -75,6 +77,7 @@ func (a fakeAuthorizer) Authorize(ctx context.Context) (*authz.Context, error) {
 				},
 			},
 			Identity:             identity,
+			UnmappedIdentity:     identity,
 			AdminActionAuthState: authz.AdminActionAuthNotRequired,
 		}, nil
 	}
@@ -87,6 +90,13 @@ func (a fakeAuthorizer) Authorize(ctx context.Context) (*authz.Context, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	identity = &authz.LocalUser{
+		Username: "alice",
+		Identity: tlsca.Identity{
+			Groups:   []string{"dev"},
+			Username: "alice",
+		},
+	}
 	return &authz.Context{
 		User: user,
 		Checker: &fakeChecker{
@@ -97,14 +107,34 @@ func (a fakeAuthorizer) Authorize(ctx context.Context) (*authz.Context, error) {
 				},
 			},
 		},
-		Identity: &authz.LocalUser{
-			Username: "alice",
-			Identity: tlsca.Identity{
-				Groups:   []string{"dev"},
-				Username: "alice",
-			},
-		},
+		Identity:             identity,
+		UnmappedIdentity:     identity,
 		AdminActionAuthState: authz.AdminActionAuthNotRequired,
+	}, nil
+}
+
+func (a fakeAuthorizer) AuthorizeScoped(ctx context.Context) (*authz.ScopedContext, error) {
+	identity, err := authz.UserFromContext(ctx)
+	if err != nil || identity.GetIdentity().ScopePin == nil {
+		authCtx, err := a.Authorize(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return authz.ScopedContextFromUnscopedContext(authCtx), nil
+	}
+
+	scopedBuiltin, ok := identity.(authz.ScopedBuiltinRole)
+	if !ok {
+		return nil, trace.AccessDenied("expected scoped builtin role")
+	}
+
+	checkerCtx, err := services.NewScopedAccessCheckerContextForAgentPin(scopedBuiltin.ScopePin, a.checkerMap)
+	if err != nil {
+		return nil, err
+	}
+	return &authz.ScopedContext{
+		Identity:       identity,
+		CheckerContext: checkerCtx,
 	}, nil
 }
 
@@ -150,6 +180,12 @@ func withAuthorizer(authz authz.Authorizer) serviceOpt {
 	}
 }
 
+func withScopedAuthorizer(scopedAuthz authz.ScopedAuthorizer) serviceOpt {
+	return func(config *usersv1.ServiceConfig) {
+		config.ScopedAuthorizer = scopedAuthz
+	}
+}
+
 func withEmitter(emitter apievents.Emitter) serviceOpt {
 	return func(config *usersv1.ServiceConfig) {
 		config.Emitter = emitter
@@ -184,11 +220,12 @@ func newTestEnv(opts ...serviceOpt) (*env, error) {
 	emitter := eventstest.NewChannelEmitter(10)
 
 	cfg := usersv1.ServiceConfig{
-		Authorizer: fakeAuthorizer{authorize: true},
-		Cache:      service,
-		Backend:    service,
-		Emitter:    emitter,
-		Reporter:   usagereporter.DiscardUsageReporter{},
+		Authorizer:       fakeAuthorizer{authorize: true},
+		ScopedAuthorizer: fakeAuthorizer{authorize: true},
+		Cache:            service,
+		Backend:          service,
+		Emitter:          emitter,
+		Reporter:         usagereporter.DiscardUsageReporter{},
 	}
 
 	for _, opt := range opts {
@@ -305,10 +342,12 @@ func TestGetUser(t *testing.T) {
 	}, &types.SessionRecordingConfigV2{})
 	require.NoError(t, err, "creating authorization context")
 
-	env, err := newTestEnv(withAuthorizer(fakeAuthorizer{authzContext: authzContext}))
+	env, err := newTestEnv(
+		withScopedAuthorizer(fakeAuthorizer{authzContext: authzContext}),
+	)
 	require.NoError(t, err, "creating test service")
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	llama, err := types.NewUser("llama")
 	require.NoError(t, err, "creating new user llama")
@@ -616,7 +655,7 @@ func generateUserSecrets(u types.User) error {
 func TestRBAC(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	llama, err := types.NewUser("llama")
 	require.NoError(t, err, "creating new user llama")
@@ -679,11 +718,27 @@ func TestRBAC(t *testing.T) {
 			expectChecks: []check{},
 		},
 		{
-			desc: "get",
+			desc: "get self with explicit access",
 			f: func(t *testing.T, service *usersv1.Service) {
 				resp, err := service.GetUser(ctx, &userspb.GetUserRequest{Name: "llama"})
 				assert.NoError(t, err, "expected RBAC to allow getting user")
 				assert.Empty(t, cmp.Diff(llama, resp.User, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+			},
+			checker: &fakeChecker{
+				rules: []types.Rule{
+					{
+						Resources: []string{types.KindUser},
+					},
+				},
+			},
+			expectChecks: []check{},
+		},
+		{
+			desc: "get other user",
+			f: func(t *testing.T, service *usersv1.Service) {
+				_, err := service.GetUser(ctx, userspb.GetUserRequest_builder{Name: "alice"}.Build())
+				assert.Error(t, err, "expected error getting non-existing user")
+				assert.True(t, trace.IsNotFound(err), "expected trace.NotFoundError")
 			},
 			checker: &fakeChecker{
 				rules: []types.Rule{
@@ -694,8 +749,8 @@ func TestRBAC(t *testing.T) {
 				},
 			},
 			expectChecks: []check{
-				{kind: types.KindUser, verb: types.VerbCreate},
 				{kind: types.KindUser, verb: types.VerbRead},
+				{kind: types.KindUser, verb: types.VerbCreate},
 			},
 		},
 		{
@@ -935,17 +990,22 @@ func TestRBAC(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			env, err := newTestEnv(withAuthorizer(&fakeAuthorizer{authzContext: &authz.Context{
-				User:    llama,
-				Checker: test.checker,
-				Identity: authz.LocalUser{
-					Username: "alice",
-					Identity: tlsca.Identity{
-						Groups: []string{"dev"},
-					},
+			ident := authz.LocalUser{
+				Username: "llama",
+				Identity: tlsca.Identity{
+					Username: "llama",
+					Groups:   []string{"dev"},
 				},
+			}
+
+			authorizer := fakeAuthorizer{authzContext: &authz.Context{
+				User:                 llama,
+				Checker:              test.checker,
+				Identity:             ident,
+				UnmappedIdentity:     ident,
 				AdminActionAuthState: authz.AdminActionAuthNotRequired,
-			}}))
+			}}
+			env, err := newTestEnv(withAuthorizer(authorizer), withScopedAuthorizer(authorizer))
 			require.NoError(t, err, "creating test service")
 
 			// Create the user directly on the backend to bypass RBAC enforced by the test cases.
@@ -957,4 +1017,64 @@ func TestRBAC(t *testing.T) {
 			require.ElementsMatch(t, test.expectChecks, test.checker.checks)
 		})
 	}
+}
+
+func TestScopePinnedAgentGetUser(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	userChecker := &fakeChecker{
+		rules: []types.Rule{
+			{
+				Resources: []string{types.KindUser},
+				Verbs:     []string{types.VerbRead},
+			},
+		},
+	}
+	// Build a fake authorizer with a scoped checker map allowing node system roles access to users but
+	// denying kube system roles. We need both to test access granted and denied
+	authorizer := fakeAuthorizer{
+		checkerMap: map[string]*services.ScopedAccessChecker{
+			string(types.RoleNode): services.NewScopedAccessCheckerForSystemRole(string(types.RoleNode), userChecker),
+			string(types.RoleKube): services.NewScopedAccessCheckerForSystemRole(string(types.RoleKube), &fakeChecker{}),
+		},
+	}
+
+	// build a scoped agent identity
+	pin := scopesv1.Pin_builder{
+		Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+		Scope: "/test",
+		SystemRoles: scopesv1.SystemRoles_builder{
+			Primary: types.RoleNode.String(),
+		}.Build(),
+	}.Build()
+	agent := authz.ScopedBuiltinRole{
+		ServerFQDN: "test-server.local",
+		ScopePin:   pin,
+		Identity: tlsca.Identity{
+			ScopePin: pin,
+		},
+	}
+
+	// configure test env with a scoped authorizer
+	env, err := newTestEnv(withScopedAuthorizer(authorizer))
+	require.NoError(t, err, "creating test service")
+
+	// create test user to try and fetch
+	llama, err := types.NewUser("llama")
+	require.NoError(t, err, "creating new user llama")
+	_, err = env.backend.CreateUser(ctx, llama.(*types.UserV2))
+	require.NoError(t, err, "creating test user")
+
+	// verify we can fetch the user with the node system role
+	res, err := env.Service.GetUser(authz.ContextWithUser(ctx, agent), userspb.GetUserRequest_builder{Name: "llama"}.Build())
+	require.NoError(t, err, "expected no error getting user as scoped agent")
+	assert.Empty(t, cmp.Diff(llama, res.GetUser(), cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+
+	// verify we can't fetch the user with the kube system role
+	pin.GetSystemRoles().SetPrimary(types.RoleKube.String())
+	_, err = env.Service.GetUser(authz.ContextWithUser(ctx, agent), userspb.GetUserRequest_builder{Name: "llama"}.Build())
+	require.Error(t, err, "expected error getting user as scoped agent")
+	require.True(t, trace.IsAccessDenied(err), "expected trace.AccessDeniedError")
 }

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -2122,12 +2122,7 @@ func IsLocalOrRemoteUser(authContext Context) bool {
 
 // IsLocalOrRemoteService checks if the identity is either a local or remote service.
 func IsLocalOrRemoteService(authContext Context) bool {
-	switch authContext.UnmappedIdentity.(type) {
-	case BuiltinRole, RemoteBuiltinRole:
-		return true
-	default:
-		return false
-	}
+	return isLocalOrRemoteService(authContext.UnmappedIdentity)
 }
 
 // IsCurrentUser checks if the identity is a local user matching the given username
@@ -2139,6 +2134,30 @@ func IsCurrentUser(authContext Context, username string) bool {
 func ScopedIsCurrentUser(scopedContext *ScopedContext, username string) bool {
 	_, isLocal := scopedContext.Identity.(LocalUser)
 	return isLocal && scopedContext.User.GetName() == username
+}
+
+// ScopedIsLocalOrRemoteService checks if the scoped identity is either a local or
+// remote service, for scoped or unscoped agents alike. This is the
+// scoped aware counterpart to [IsLocalOrRemoteService].
+// RemoteBuiltinRoles continue to be only available for unscoped identities.
+func ScopedIsLocalOrRemoteService(scopedContext *ScopedContext) bool {
+	if scopedContext == nil {
+		return false
+	}
+
+	if scopedContext.unscopedContext != nil {
+		return isLocalOrRemoteService(scopedContext.unscopedContext.UnmappedIdentity)
+	}
+	return isLocalOrRemoteService(scopedContext.Identity)
+}
+
+func isLocalOrRemoteService(identity IdentityGetter) bool {
+	switch identity.(type) {
+	case BuiltinRole, RemoteBuiltinRole, ScopedBuiltinRole:
+		return true
+	default:
+		return false
+	}
 }
 
 // IsRemoteUser checks if the identity is a remote user.

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1917,6 +1917,13 @@ func (r ScopedBuiltinRole) GetIdentity() tlsca.Identity {
 	return r.Identity
 }
 
+// IsServer returns true if the primary role is either RoleInstance, or one of
+// the local service roles (e.g. node).
+func (r ScopedBuiltinRole) IsServer() bool {
+	role := types.SystemRole(r.ScopePin.GetSystemRoles().GetPrimary())
+	return role == types.RoleInstance || role.IsLocalService()
+}
+
 // RemoteBuiltinRole is the role of the remote (service connecting via trusted cluster link)
 // Teleport service.
 type RemoteBuiltinRole struct {

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -1705,6 +1705,104 @@ func TestScopedContextLockTargets(t *testing.T) {
 	})
 }
 
+func TestScopedContextDisplayName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		scopedCtx *authz.ScopedContext
+		want      string
+	}{
+		{
+			name: "user identity uses the user name",
+			scopedCtx: &authz.ScopedContext{
+				User:     &types.UserV2{Metadata: types.Metadata{Name: "alice"}},
+				Identity: authz.LocalUser{Identity: tlsca.Identity{Username: "alice-identity"}},
+			},
+			want: "alice",
+		},
+		{
+			name: "agent identity falls back to the identity username",
+			scopedCtx: &authz.ScopedContext{
+				Identity: authz.ScopedBuiltinRole{Identity: tlsca.Identity{Username: "alice-identity"}},
+			},
+			want: "alice-identity",
+		},
+		{
+			name:      "empty when neither user nor identity is set",
+			scopedCtx: &authz.ScopedContext{},
+			want:      "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.scopedCtx.DisplayName())
+		})
+	}
+}
+
+func TestScopedIsLocalOrRemoteService(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		want      bool
+		scopedCtx *authz.ScopedContext
+	}{
+		{name: "builtin role (unscoped agent)",
+			want:      true,
+			scopedCtx: &authz.ScopedContext{Identity: authz.BuiltinRole{}},
+		},
+		{
+			name:      "remote builtin role",
+			want:      true,
+			scopedCtx: &authz.ScopedContext{Identity: authz.RemoteBuiltinRole{}},
+		},
+		{
+			name:      "scoped builtin role",
+			want:      true,
+			scopedCtx: &authz.ScopedContext{Identity: authz.ScopedBuiltinRole{}},
+		},
+		{
+			name:      "local user",
+			want:      false,
+			scopedCtx: &authz.ScopedContext{Identity: authz.LocalUser{}},
+		},
+		{
+			name:      "remote user",
+			want:      false,
+			scopedCtx: &authz.ScopedContext{Identity: authz.RemoteUser{}},
+		},
+		{
+			name:      "unauthenticated",
+			want:      false,
+			scopedCtx: &authz.ScopedContext{Identity: authz.UnauthenticatedRole{}},
+		},
+		// Unscoped-wrapped contexts (unscopedContext != nil) delegate to
+		// IsLocalOrRemoteService rather than hitting the identity switch.
+		{
+			name:      "unscoped-wrapped builtin role",
+			want:      true,
+			scopedCtx: authz.ScopedContextFromUnscopedContext(&authz.Context{UnmappedIdentity: authz.BuiltinRole{}}),
+		},
+		{
+			name:      "unscoped-wrapped remote builtin role",
+			want:      true,
+			scopedCtx: authz.ScopedContextFromUnscopedContext(&authz.Context{UnmappedIdentity: authz.RemoteBuiltinRole{}}),
+		},
+		{
+			name:      "unscoped-wrapped local user",
+			want:      false,
+			scopedCtx: authz.ScopedContextFromUnscopedContext(&authz.Context{UnmappedIdentity: authz.LocalUser{}}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, authz.ScopedIsLocalOrRemoteService(tt.scopedCtx))
+		})
+	}
+}
+
 // brokenScopedRoleReader is a minimal ScopedRoleReader for use in tests that need a non-nil reader
 // but aren't expected to actually need any scoped roles.
 type brokenScopedRoleReader struct{}

--- a/lib/authz/scoped.go
+++ b/lib/authz/scoped.go
@@ -292,3 +292,17 @@ func (s *ScopedContext) LockTargets() []types.LockTarget {
 	}
 	return lockTargets
 }
+
+// DisplayName returns a display name for the calling identity.
+// authzContext.User is nil for non-user (agent/builtin) identities, so fall back to
+// the identity's username.
+// TODO (williamo/scopes) - consider implementing slog.LogValuer if we end up only needing this for logging.
+func (s *ScopedContext) DisplayName() string {
+	if s.User != nil {
+		return s.User.GetName()
+	}
+	if s.Identity != nil {
+		return s.Identity.GetIdentity().Username
+	}
+	return ""
+}

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -254,8 +254,13 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := healthCheckManager.Start(process.ExitContext()); err != nil {
-		return trace.Wrap(err)
+
+	// TODO (eriktate): because HealthCheckConfigs do not yet support scopes, the service will never report
+	// healthy when scope pinned. We need to remove this opt-out behavior once HealthCheckConfigs support scopes
+	if conn.Scope() == "" {
+		if err := healthCheckManager.Start(process.ExitContext()); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 
 	var publicAddr string

--- a/lib/services/scoped_access_checker_context.go
+++ b/lib/services/scoped_access_checker_context.go
@@ -452,6 +452,48 @@ func (c *ScopedAccessCheckerContext) RiskyAuthorizeUnpinnedReadWithScope(
 	return c.RiskyAuthorizeUnpinnedRead(ctx, authz, ruleCtx)
 }
 
+// RiskyAuthorizeUnpinnedEmitEvent authorizes a create-only access check that bypasses
+// enforcement of the identity's pinned scope specifically for emitting audit events.
+// It is special-cased to avoid misuse of unpinned writes.
+func (c *ScopedAccessCheckerContext) RiskyAuthorizeUnpinnedEmitEvent(
+	ctx context.Context,
+	ruleCtx RuleContext,
+) error {
+	if pin, ok := c.ScopePin(); ok {
+		if pin.GetKind() != scopesv1.PinKind_PIN_KIND_AGENT {
+			return trace.AccessDenied("unpinned authorization for audit event emission is only supported for agent pins")
+		}
+	}
+
+	return c.decision(
+		c.riskyUnpinnedCheckersForResourceScope(ctx, scopes.Root),
+		func(checker *ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(ruleCtx, types.KindEvent, types.VerbCreate)
+		},
+	)
+}
+
+// RiskyAuthorizeUnpinnedWriteEvent authorizes a write-only access check that bypasses
+// enforcement of the identity's pinned scope specifically for creating and updating audit events.
+// It is special-cased to avoid misuse of unpinned writes.
+func (c *ScopedAccessCheckerContext) RiskyAuthorizeUnpinnedWriteEvent(
+	ctx context.Context,
+	ruleCtx RuleContext,
+) error {
+	if pin, ok := c.ScopePin(); ok {
+		if pin.GetKind() != scopesv1.PinKind_PIN_KIND_AGENT {
+			return trace.AccessDenied("unpinned authorization for audit event emission is only supported for agent pins")
+		}
+	}
+
+	return c.decision(
+		c.riskyUnpinnedCheckersForResourceScope(ctx, scopes.Root),
+		func(checker *ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(ruleCtx, types.KindEvent, types.VerbCreate, types.VerbUpdate)
+		},
+	)
+}
+
 // UnpinnedReadAuthorization is a special authorization to complete an unscoped
 // read-only access check. This is meant to be used for access checks on
 // typically cluster-wide resources that need to be readable by identities with
@@ -560,12 +602,25 @@ var (
 		kind:          types.KindSessionRecordingConfig,
 		verbs:         []string{types.VerbRead},
 	}
-
 	// UnpinnedReadScopedRole is a special authorization to complete an
 	// unscoped access check to read a scoped role.
 	UnpinnedReadScopedRole = UnpinnedReadAuthorization{
 		resourceScope: scopes.Root,
 		kind:          scopedaccess.KindScopedRole,
+		verbs:         []string{types.VerbRead},
+	}
+	// UnpinnedReadUser is a special authorization to complete a unscoped access check
+	// to read a user.
+	UnpinnedReadUser = UnpinnedReadAuthorization{
+		resourceScope: scopes.Root,
+		kind:          types.KindUser,
+		verbs:         []string{types.VerbRead},
+	}
+	// UnpinnedReadRole is a special authorization to complete an unscoped access check
+	// to read a role.
+	UnpinnedReadRole = UnpinnedReadAuthorization{
+		resourceScope: scopes.Root,
+		kind:          types.KindRole,
 		verbs:         []string{types.VerbRead},
 	}
 )

--- a/lib/services/scoped_access_checker_context.go
+++ b/lib/services/scoped_access_checker_context.go
@@ -513,4 +513,25 @@ var (
 		kind:          types.KindSPIFFEFederation,
 		verbs:         []string{types.VerbList, types.VerbRead},
 	}
+	// UnpinnedReadClusterNetworkingConfig is a special authorization to complete an
+	// unscoped access check to read a cluster networking config.
+	UnpinnedReadClusterNetworkingConfig = UnpinnedReadAuthorization{
+		resourceScope: scopes.Root,
+		kind:          types.KindClusterNetworkingConfig,
+		verbs:         []string{types.VerbRead},
+	}
+	// UnpinnedReadClusterName is a special authorization to complete an
+	// unscoped access check to read a cluster name.
+	UnpinnedReadClusterName = UnpinnedReadAuthorization{
+		resourceScope: scopes.Root,
+		kind:          types.KindClusterName,
+		verbs:         []string{types.VerbRead},
+	}
+	// UnpinnedReadSessionRecordingConfig is a special authorization to complete an
+	// unscoped access check to read a cluster session recording config.
+	UnpinnedReadSessionRecordingConfig = UnpinnedReadAuthorization{
+		resourceScope: scopes.Root,
+		kind:          types.KindSessionRecordingConfig,
+		verbs:         []string{types.VerbRead},
+	}
 )

--- a/lib/services/scoped_access_checker_context.go
+++ b/lib/services/scoped_access_checker_context.go
@@ -30,6 +30,7 @@ import (
 	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -222,8 +223,14 @@ func (c *ScopedAccessCheckerContext) checkersForResourceScope(ctx context.Contex
 		// particular role. For example, if a user has a scoped role assigned at /foo which grants access to all ssh
 		// nodes, but they are pinned to scope /foo/bar, even if a role at /foo permits access, the pin restricts
 		// access to only resources subject to /foo/bar.
-		if enforcePin && !pinning.PinAppliesToResourceScope(c.pin, scope) {
-			yield(nil, trace.AccessDenied("scope pin %q does not apply to resource scope %q", c.pin.GetScope(), scope))
+		if enforcePin {
+			if !pinning.PinAppliesToResourceScope(c.pin, scope) {
+				yield(nil, trace.AccessDenied("scope pin %q does not apply to resource scope %q", c.pin.GetScope(), scope))
+				return
+			}
+		} else if !pinning.PinCompatibleWithPolicyScope(c.pin, scope) {
+			// Unpinned reads should still not allow orthogonal reads.
+			yield(nil, trace.AccessDenied("scope pin %q is orthogonal to resource scope %q", c.pin.GetScope(), scope))
 			return
 		}
 
@@ -426,6 +433,25 @@ func (c *ScopedAccessCheckerContext) RiskyAuthorizeUnpinnedRead(
 	)
 }
 
+// RiskyAuthorizeUnpinnedReadWithScope extends [RiskyAuthorizeUnpinnedRead].
+// It authorizes a read-only access check that bypasses
+// enforcement of the identity's pinned scope, but ensures that the
+// resource scope is related to the identity's pinned scope.
+// This must only be used for specific APIs that make an exception to pinning exclusion rules (e.g.
+// allowing read operations for resources at a parent scope). To avoid misuse,
+// a specific [UnpinnedReadAuthorization] must be provided that will encode the
+// effective scope of the access check and the allowed verbs. The scope provided
+// must not be empty, and will be used to determine the enforcement.
+func (c *ScopedAccessCheckerContext) RiskyAuthorizeUnpinnedReadWithScope(
+	ctx context.Context,
+	authz UnpinnedReadAuthorization,
+	ruleCtx RuleContext,
+	resourceScope string,
+) error {
+	authz.resourceScope = resourceScope
+	return c.RiskyAuthorizeUnpinnedRead(ctx, authz, ruleCtx)
+}
+
 // UnpinnedReadAuthorization is a special authorization to complete an unscoped
 // read-only access check. This is meant to be used for access checks on
 // typically cluster-wide resources that need to be readable by identities with
@@ -532,6 +558,14 @@ var (
 	UnpinnedReadSessionRecordingConfig = UnpinnedReadAuthorization{
 		resourceScope: scopes.Root,
 		kind:          types.KindSessionRecordingConfig,
+		verbs:         []string{types.VerbRead},
+	}
+
+	// UnpinnedReadScopedRole is a special authorization to complete an
+	// unscoped access check to read a scoped role.
+	UnpinnedReadScopedRole = UnpinnedReadAuthorization{
+		resourceScope: scopes.Root,
+		kind:          scopedaccess.KindScopedRole,
 		verbs:         []string{types.VerbRead},
 	}
 )

--- a/lib/services/scoped_access_checker_context_test.go
+++ b/lib/services/scoped_access_checker_context_test.go
@@ -61,6 +61,60 @@ func TestScopedAccessCheckerContextRiskyAuthorizeUnpinnedRead(t *testing.T) {
 	require.ErrorAs(t, err, new(*trace.BadParameterError))
 }
 
+// TestRiskyAuthorizeUnpinnedReadWithScope verifies that the per-call resourceScope
+// overrides the authorization's scope and is used to determine the resulting access decision.
+func TestRiskyAuthorizeUnpinnedReadWithScope(t *testing.T) {
+	t.Parallel()
+
+	const pinScope = "/test/scope"
+	pin := scopesv1.Pin_builder{
+		Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+		Scope: pinScope,
+		SystemRoles: scopesv1.SystemRoles_builder{
+			Primary: types.RoleNode.String(),
+		}.Build(),
+	}.Build()
+	checkerCtx := newAgentPinCheckerContext(t, pin)
+
+	tests := []struct {
+		name          string
+		resourceScope string
+		wantErr       string
+	}{
+		{
+			name:          "override to pin scope is allowed",
+			resourceScope: pinScope,
+		},
+		{
+			name:          "override to descendant scope is allowed",
+			resourceScope: pinScope + "/child",
+		},
+		{
+			name:          "override to ancestor (root) scope is allowed",
+			resourceScope: scopes.Root,
+		},
+		{
+			name:          "override to orthogonal scope is denied",
+			resourceScope: "/other",
+			wantErr:       "scope pin \"/test/scope\" is orthogonal to resource scope \"/other\"",
+		},
+		{
+			name:          "override to empty scope is rejected",
+			resourceScope: "",
+			wantErr:       "scope is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkerCtx.RiskyAuthorizeUnpinnedReadWithScope(t.Context(), UnpinnedReadScopedRole, &Context{}, tt.resourceScope)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 type emptyScopedRoleReader struct{}
 
 func (emptyScopedRoleReader) GetScopedRole(context.Context, *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {

--- a/lib/services/scoped_access_checker_context_test.go
+++ b/lib/services/scoped_access_checker_context_test.go
@@ -145,21 +145,22 @@ func newAgentPinCheckerContext(t *testing.T, pin *scopesv1.Pin) *ScopedAccessChe
 	return ctx
 }
 
+// newAgentPin is a test helper that builds a [*scopesv1.Pin] for an agent.
+func newAgentPin(scope string, role types.SystemRole) *scopesv1.Pin {
+	return scopesv1.Pin_builder{
+		Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+		Scope: scope,
+		SystemRoles: scopesv1.SystemRoles_builder{
+			Primary: role.String(),
+		}.Build(),
+	}.Build()
+}
+
 // TestScopedAccessCheckerContextAgentPin covers the agent-pin mode of ScopedAccessCheckerContext.
 func TestScopedAccessCheckerContextAgentPin(t *testing.T) {
 	t.Parallel()
 
 	const pinScope = "/test/scope"
-
-	newAgentPin := func(scope string, role types.SystemRole) *scopesv1.Pin {
-		return &scopesv1.Pin{
-			Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
-			Scope: scope,
-			SystemRoles: &scopesv1.SystemRoles{
-				Primary: role.String(),
-			},
-		}
-	}
 
 	t.Run("constructor rejects nil pin", func(t *testing.T) {
 		t.Parallel()
@@ -257,6 +258,39 @@ func TestScopedAccessCheckerContextAgentPin(t *testing.T) {
 		require.NoError(t, err, "RiskyAuthorizeUnpinnedRead should bypass pin enforcement and succeed")
 	})
 
+	t.Run("RiskyAuthorizeUnpinnedEmitEvent bypasses pin enforcement", func(t *testing.T) {
+		t.Parallel()
+		pin := newAgentPin(pinScope, types.RoleNode)
+		checkerCtx := newAgentPinCheckerContext(t, pin)
+
+		// A normal decision for a root-scoped resource is denied because the identity
+		// is pinned away from root before any checker, including the default implicit
+		// role checker, is evaluated.
+		err := checkerCtx.Decision(t.Context(), scopes.Root, func(checker *ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(&Context{}, types.KindEvent, types.VerbCreate)
+		})
+		require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+
+		err = checkerCtx.RiskyAuthorizeUnpinnedEmitEvent(t.Context(), &Context{})
+		require.NoError(t, err, "RiskyAuthorizeUnpinnedEmitEvent should bypass pin enforcement and succeed")
+	})
+	t.Run("RiskyAuthorizeUnpinnedWriteEvent bypasses pin enforcement", func(t *testing.T) {
+		t.Parallel()
+		pin := newAgentPin(pinScope, types.RoleNode)
+		checkerCtx := newAgentPinCheckerContext(t, pin)
+
+		// A normal decision for a root-scoped resource is denied because the identity
+		// is pinned away from root before any checker, including the default implicit
+		// role checker, is evaluated.
+		err := checkerCtx.Decision(t.Context(), scopes.Root, func(checker *ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(&Context{}, types.KindEvent, types.VerbCreate, types.VerbUpdate)
+		})
+		require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+
+		err = checkerCtx.RiskyAuthorizeUnpinnedWriteEvent(t.Context(), &Context{})
+		require.NoError(t, err, "RiskyAuthorizeUnpinnedWriteEvent should bypass pin enforcement and succeed")
+	})
+
 	t.Run("riskyEnumerateScopedCheckers panics for agent pin context", func(t *testing.T) {
 		t.Parallel()
 		pin := newAgentPin(pinScope, types.RoleNode)
@@ -268,4 +302,36 @@ func TestScopedAccessCheckerContextAgentPin(t *testing.T) {
 			}
 		}, "riskyEnumerateScopedCheckers should panic for agent pin contexts")
 	})
+}
+
+func TestScopedAccessCheckerContextUnpinnedUserEventWrites(t *testing.T) {
+	ctx := t.Context()
+	userCheckerContext, err := NewScopedAccessCheckerContext(ctx, &AccessInfo{
+		Username: "alice",
+		ScopePin: scopesv1.Pin_builder{
+			Kind:  scopesv1.PinKind_PIN_KIND_USER,
+			Scope: "/test/scope",
+		}.Build(),
+	}, "test-cluster", emptyScopedRoleReader{})
+	require.NoError(t, err)
+
+	ruleCtx := &Context{}
+
+	// A normal decision for a root-scoped resource is denied because the identity
+	// is pinned away from root before any checker, including the default implicit
+	// role checker, is evaluated.
+	err = userCheckerContext.Decision(ctx, scopes.Root, func(checker *ScopedAccessChecker) error {
+		return checker.CheckAccessToRules(ruleCtx, types.KindEvent, types.VerbCreate)
+	})
+	require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+
+	// RiskyAuthorizeUnpinnedEmitEvent bypasses pin enforcement but should explicitly fail for scoped
+	// user pins.
+	err = userCheckerContext.RiskyAuthorizeUnpinnedEmitEvent(ctx, ruleCtx)
+	require.ErrorContains(t, err, "unpinned authorization for audit event emission is only supported for agent pins")
+
+	// RiskyAuthorizeUnpinneWriteEvent bypasses pin enforcement but should explicitly fail for scoped
+	// user pins.
+	err = userCheckerContext.RiskyAuthorizeUnpinnedWriteEvent(ctx, ruleCtx)
+	require.ErrorContains(t, err, "unpinned authorization for audit event emission is only supported for agent pins")
 }

--- a/lib/sshca/identity.go
+++ b/lib/sshca/identity.go
@@ -631,3 +631,12 @@ func DecodeIdentity(cert *ssh.Certificate) (*Identity, error) {
 
 	return ident, nil
 }
+
+// GetPrimaryRole returns the primary role for the identity regardless of
+// whether or not it is scope pinned.
+func (i *Identity) GetPrimaryRole() types.SystemRole {
+	if i.ScopePin.GetKind() == scopesv1.PinKind_PIN_KIND_AGENT {
+		return types.SystemRole(i.ScopePin.GetSystemRoles().GetPrimary())
+	}
+	return i.SystemRole
+}

--- a/lib/sshca/sshca.go
+++ b/lib/sshca/sshca.go
@@ -76,7 +76,7 @@ func (r *HostCertificateRequest) Check() error {
 	if r.Identity.ValidAfter != 0 {
 		return trace.BadParameter("ValidAfter should not be set in host cert requests (derived from TTL)")
 	}
-	if err := r.Identity.SystemRole.Check(); err != nil {
+	if err := r.Identity.GetPrimaryRole().Check(); err != nil {
 		return trace.Wrap(err)
 	}
 	if r.Identity.AgentScope != "" {


### PR DESCRIPTION
Backports #67610, #67680, #68133, #67879 to branch/v18


I left comments in the relevant spots, but there were two small changes that diverge slightly from `master` due to other changes that either haven't or can't be backported yet.

I removed the OpenSSH/agentless portion of the test plan because `UpsertNode` needs to be ported before joins can succeed. That can be backported separately once it hits `master` so I don't see any reason to block merging these changes.

## Manual Test Plan
### Test Environment
A local teleport cluster with `TELEPORT_UNTABLE_SCOPES=yes` and `TELEPORT_UNSTABLE_AGENT_SCOPE_PIN=yes` (unless otherwise stated)
### Test Cases
- [x] Can join and generate host certs for unscoped agent
- [x] Can join and generate SSH host certs for scoped agents using `AgentScope` (`TELEPORT_UNSTABLE_AGENT_SCOPE_PIN=no`)
- [x] Can not join scoped kube agent using `AgentScope`, explicit error
- [x] Join unscoped SSH agent
  - [x] Confirm healthy and available though `tsh ls`
  - [x] Confirm new sessions can be created and interacted with.
  - [x] Confirm no unusual error logs after session creation
  - [x] Confirm session replay is available and works
- [x] Join scoped SSH agent
  - [x] Confirm healthy and available through `tsh ls`
  - [x] Confirm new sessions can be created and interacted with
  - [x] Confirm no blocking error logs after session creation
  - [x] Confirm session replay is available and works
- [x] Join unscoped kube agent
  - [x] Confirm healthy and available through `tsh kube ls`
  - [x] Confirm `kubectl` commands are forwarded with the expected results
  - [x] Confirm no unusual error logs
  - [x] Confirm session replay is available and works for web-based execs
- [x] Join scoped kube agent
  - [x] Confirm healthy and available through `tsh kube ls`
  - [x] Confirm `kubectl` commands are forwarded with the expected results
  - [x] Confirm no unusual error logs
  - [x] Confirm session replay is available and works for web-based execs