### PR TITLE
Fix event handler session stream leak

### DIFF
--- a/integrations/event-handler/session_events_job.go
+++ b/integrations/event-handler/session_events_job.go
@@ -327,7 +327,11 @@ func (j *SessionEventsJob) restartPausedSessions() error {
 
 // consumeSession ingests session
 func (j *SessionEventsJob) consumeSession(ctx context.Context, s session) (bool, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	url := j.app.Config.FluentdSessionURL + "." + s.ID + ".log"
+
 	chEvt, chErr := j.app.client.StreamUnstructuredSessionEvents(ctx, s.ID, s.Index)
 
 	cursorSyncLimiter := rate.NewLimiter(rate.Every(time.Second), 1)

--- a/integrations/event-handler/session_events_job_test.go
+++ b/integrations/event-handler/session_events_job_test.go
@@ -34,6 +34,7 @@ import (
 // if no events are found.
 func TestConsumeSessionNoEventsFound(t *testing.T) {
 	sessionID := "test"
+	mockClient := &mockClient{}
 	j := NewSessionEventsJob(&App{
 		Config: &StartCmdConfig{},
 		State: &State{
@@ -41,11 +42,14 @@ func TestConsumeSessionNoEventsFound(t *testing.T) {
 				BasePath: t.TempDir(),
 			}),
 		},
-		client: &mockClient{},
+		client: mockClient,
 		log:    slog.Default(),
 	})
 	_, err := j.consumeSession(t.Context(), session{ID: sessionID})
 	require.NoError(t, err)
+
+	require.NotNil(t, mockClient.streamCtx)
+	require.ErrorIs(t, mockClient.streamCtx.Err(), context.Canceled)
 }
 
 // TestIngestSession tests that the ingestSession method returns without error if a malformed
@@ -94,11 +98,13 @@ func TestIngestSession(t *testing.T) {
 
 type mockClient struct {
 	client.Client
+	streamCtx context.Context
 }
 
 // StreamSessionEvents overrides the client.Client method to return a closed channel
 // to ensure that the consumeSession method returns without error if no events are found.
 func (m *mockClient) StreamUnstructuredSessionEvents(ctx context.Context, sessionID string, startIndex int64) (chan *auditlogpb.EventUnstructured, chan error) {
+	m.streamCtx = ctx
 	c := make(chan *auditlogpb.EventUnstructured)
 	e := make(chan error)
 	close(c)


### PR DESCRIPTION
Fixes #68275

Changelog: Fixed bug where event handler leaks session streams causing spiked memory usage in Auth Service

<details><summary>Before (leak)</summary>
<p>

<img width="1822" height="548" alt="Screenshot 2026-07-01 at 12 48 30 PM" src="https://github.com/user-attachments/assets/d89cbfdc-f8a2-4e25-82fc-7ab4a3a13dc1" />

</p>
</details> 

<details><summary>After (no leak)</summary>
<p>

<img width="1446" height="543" alt="Screenshot 2026-07-01 at 1 52 17 PM" src="https://github.com/user-attachments/assets/84f60dcf-f1b0-4311-86a6-8b05ae019874" />

</p>
</details> 

## Manual Test Plan
### Test Environment

Teleport Cloud. Local `teleport-event-handler` with invalid fluentd session URL to trigger `consumeSession` errors.

### Test Cases
- [x] Generate numerous session recordings and verify event handler's `api/client.(*Client).StreamUnstructuredSessionEvents.func1` goroutines don't leak on `consumeSession` early return errors.