### PR TITLE
access-review[1]: Add core logic for `tctl access-review` command

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -82,6 +82,26 @@ Flags:
 |`--source`|*no default* (any of (repeatable): `AWS`, `Entra`, `Gitlab`, `Okta`, `TELEPORT`)|Filter by source (repeatable; each is OR'd). Combine axes with --filter.|
 |`--type`|*no default* (any of (repeatable): `aws_ec2`, `aws_eks`, `aws_rds`, `aws_s3`, `aws_user`, `entra_user`, `gitlab_project`, `gitlab_user`, `okta_application`, `okta_user`, `teleport_application`, `teleport_bot`, `teleport_database`, `teleport_desktop`, `teleport_kubernetes`, `teleport_node`, `teleport_user`)|Filter by origin type (repeatable; each is OR'd). Combine axes with --filter.|
 
+## tctl access-review
+
+Review which identities can access which resources.
+
+Usage:
+
+```code
+$ tctl access-review --query=QUERY [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--format`|`text` (one of: `text`, `json`, `yaml`)|Output format. (Values: text, json, yaml)|
+|`--from`|*no default*|Show access activity at or after this time; enables the activity columns. (Examples: 2006-01-02T15:04:05Z07:00, 2006-01-02, 24h, 7d). Default: activity hidden.|
+|`--limit`|`50`|Maximum number of identities to return.|
+|`--query`|*no default*|SQL SELECT against access_path scoping the identities to review.|
+|`--to`|*no default*|Upper bound for access activity. Defaults to now when --from is set; requires --from.|
+
 ## tctl acl get
 
 Get detailed information for an Access List.

--- a/lib/accessgraph/apiclient/client.gen.go
+++ b/lib/accessgraph/apiclient/client.gen.go
@@ -76,6 +76,54 @@ func (e AlertStatus) Valid() bool {
 	}
 }
 
+// Defines values for IdentityAccessDecisionLevel.
+const (
+	IdentityAccessDecisionLevelDenied      IdentityAccessDecisionLevel = "denied"
+	IdentityAccessDecisionLevelImpersonate IdentityAccessDecisionLevel = "impersonate"
+	IdentityAccessDecisionLevelRequest     IdentityAccessDecisionLevel = "request"
+	IdentityAccessDecisionLevelStanding    IdentityAccessDecisionLevel = "standing"
+)
+
+// Valid indicates whether the value is a known member of the IdentityAccessDecisionLevel enum.
+func (e IdentityAccessDecisionLevel) Valid() bool {
+	switch e {
+	case IdentityAccessDecisionLevelDenied:
+		return true
+	case IdentityAccessDecisionLevelImpersonate:
+		return true
+	case IdentityAccessDecisionLevelRequest:
+		return true
+	case IdentityAccessDecisionLevelStanding:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for IdentityAccessGrantorLevel.
+const (
+	IdentityAccessGrantorLevelDenied      IdentityAccessGrantorLevel = "denied"
+	IdentityAccessGrantorLevelImpersonate IdentityAccessGrantorLevel = "impersonate"
+	IdentityAccessGrantorLevelRequest     IdentityAccessGrantorLevel = "request"
+	IdentityAccessGrantorLevelStanding    IdentityAccessGrantorLevel = "standing"
+)
+
+// Valid indicates whether the value is a known member of the IdentityAccessGrantorLevel enum.
+func (e IdentityAccessGrantorLevel) Valid() bool {
+	switch e {
+	case IdentityAccessGrantorLevelDenied:
+		return true
+	case IdentityAccessGrantorLevelImpersonate:
+		return true
+	case IdentityAccessGrantorLevelRequest:
+		return true
+	case IdentityAccessGrantorLevelStanding:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for SecurityAlertSeverity.
 const (
 	Critical SecurityAlertSeverity = "critical"
@@ -240,6 +288,95 @@ type GetLogsStatsResponse struct {
 // Graph defines model for Graph.
 type Graph = externalRef0.Graph
 
+// IdentityAccessActivity Observed access activity for this (identity, resource) pair over the request's activity window, aggregated server-side from session-start audit events. Present only when the window (`start_time` + `end_time`) was supplied and the activity lookup succeeded, and only for pairs with at least one access in the window — a pair with no events leaves `activity` absent (the client reads that as zero).
+type IdentityAccessActivity struct {
+	// Count Number of access (session-start) events for this pair in the window; always at least 1 when present.
+	Count int64 `json:"count"`
+
+	// LastAccess Timestamp of the most recent access in the window.
+	LastAccess *time.Time `json:"last_access,omitempty"`
+}
+
+// IdentityAccessDecision defines model for IdentityAccessDecision.
+type IdentityAccessDecision struct {
+	// Activity Observed access activity for this (identity, resource) pair over the request's activity window, aggregated server-side from session-start audit events. Present only when the window (`start_time` + `end_time`) was supplied and the activity lookup succeeded, and only for pairs with at least one access in the window — a pair with no events leaves `activity` absent (the client reads that as zero).
+	Activity *IdentityAccessActivity `json:"activity,omitempty"`
+
+	// GrantorCounts Counts of grantors backing this (identity, resource) pair, split by level. Denied grantors appear in `grantors` but aren't counted here — these counts describe how access *is* granted, and a deny is the absence of a grant.
+	GrantorCounts IdentityAccessGrantorCounts `json:"grantor_counts"`
+	Grantors      []IdentityAccessGrantor     `json:"grantors"`
+
+	// Level Resolved access level for this identity, in priority order `denied > standing > impersonate > request`. `denied` overrides the others when a deny path applies; `impersonate` means the access is only reachable by impersonating another identity (no approval, just a certificate minted as the target); the grantor and path counts still describe how access would otherwise be reached. `temporary` is a within-level qualifier on this value, not a level of its own.
+	Level IdentityAccessDecisionLevel `json:"level"`
+
+	// Temporary True when the resolved access is self-expiring — every grantor at the winning `level` was created by an access request (see the grantor node's own `temporary`). If any permanent grantor reaches the resource at that level, a non-expiring path exists and this is omitted. Read it alongside `level` ("standing, but temporary"). Omitted when false.
+	Temporary *bool `json:"temporary,omitempty"`
+}
+
+// IdentityAccessDecisionLevel Resolved access level for this identity, in priority order `denied > standing > impersonate > request`. `denied` overrides the others when a deny path applies; `impersonate` means the access is only reachable by impersonating another identity (no approval, just a certificate minted as the target); the grantor and path counts still describe how access would otherwise be reached. `temporary` is a within-level qualifier on this value, not a level of its own.
+type IdentityAccessDecisionLevel string
+
+// IdentityAccessGrantor A grantor backing (or denying) this (identity, resource) access. Only the per-access fields live here; the grantor's shared node fields (name, kind, source, origin, …) are resolved by `id` against the response `nodes` list.
+type IdentityAccessGrantor struct {
+	// Id Node id of the grantor; resolve it against the response `nodes` list.
+	Id uuid.UUID `json:"id"`
+
+	// Level This grantor's strongest contribution to the access: `denied` if any path through it crosses a deny, `standing` if a clean path exists, `impersonate` if it is only reachable by impersonating another identity, or `request` if every path is gated by a request.
+	Level IdentityAccessGrantorLevel `json:"level"`
+}
+
+// IdentityAccessGrantorLevel This grantor's strongest contribution to the access: `denied` if any path through it crosses a deny, `standing` if a clean path exists, `impersonate` if it is only reachable by impersonating another identity, or `request` if every path is gated by a request.
+type IdentityAccessGrantorLevel string
+
+// IdentityAccessGrantorCounts Counts of grantors backing this (identity, resource) pair, split by level. Denied grantors appear in `grantors` but aren't counted here — these counts describe how access *is* granted, and a deny is the absence of a grant.
+type IdentityAccessGrantorCounts struct {
+	Impersonate int `json:"impersonate"`
+	Request     int `json:"request"`
+	Standing    int `json:"standing"`
+}
+
+// IdentityAccessNode defines model for IdentityAccessNode.
+type IdentityAccessNode struct {
+	// Alias Optional human-readable alias; UIs should prefer this over `name` when present.
+	Alias   *string               `json:"alias,omitempty"`
+	Id      uuid.UUID             `json:"id"`
+	Kind    externalRef0.NodeKind `json:"kind"`
+	Name    string                `json:"name"`
+	Origin  *string               `json:"origin,omitempty"`
+	Source  *string               `json:"source,omitempty"`
+	SubKind *string               `json:"sub_kind,omitempty"`
+
+	// Temporary True when this node is a grantor created by an access request (e.g. an approved request that granted a role for a window) rather than a standing membership. Access through it still resolves at the grantor's `level`, but it will expire on its own, so reviewers should treat it differently from permanent access. A concrete expiry timestamp is future work (the graph carries only this boolean today). Omitted for permanent nodes.
+	Temporary *bool `json:"temporary,omitempty"`
+}
+
+// IdentityAccessResource defines model for IdentityAccessResource.
+type IdentityAccessResource struct {
+	AccessInfo IdentityAccessDecision `json:"access_info"`
+
+	// Resource Node id of the resource; resolve it against the response `nodes` list.
+	Resource uuid.UUID `json:"resource"`
+}
+
+// IdentityAccessResponse defines model for IdentityAccessResponse.
+type IdentityAccessResponse struct {
+	Data []IdentityAccessRow `json:"data"`
+
+	// IacError Set when the per-pair activity lookup failed or was unavailable (e.g. the Identity Activity Center is not configured, or the audit query errored). User-displayable and non-blocking: because activity comes from a different backend than the graph classification, a failure there is isolated to this one field — `data` still carries the full set of access decisions and only the per-pair `activity` is missing.
+	IacError   *string `json:"iac_error,omitempty"`
+	NextCursor *string `json:"next_cursor,omitempty"`
+
+	// Nodes Deduplicated identity, resource, and grantor nodes referenced by `data`. Clients build a lookup map keyed by `id` and resolve each row's `identity` / `resource` / grantor `id` against it. Scoped to nodes referenced by the current page.
+	Nodes []IdentityAccessNode `json:"nodes"`
+}
+
+// IdentityAccessRow defines model for IdentityAccessRow.
+type IdentityAccessRow struct {
+	// Identity Node id of the identity; resolve it against the response `nodes` list.
+	Identity  uuid.UUID                `json:"identity"`
+	Resources []IdentityAccessResource `json:"resources"`
+}
+
 // IdentitySummary defines model for IdentitySummary.
 type IdentitySummary struct {
 	Data       []IdentitySummaryItem `json:"data"`
@@ -363,6 +500,24 @@ type SecurityAlert struct {
 
 // SecurityAlertSeverity Severity level of the alert
 type SecurityAlertSeverity string
+
+// ListIdentityAccessParams defines parameters for ListIdentityAccess.
+type ListIdentityAccessParams struct {
+	// Query SQL SELECT against `access_path`. WHERE/LIMIT scope the seed identity set.
+	Query string `form:"query" json:"query"`
+
+	// Limit Maximum number of identities to return per page.
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Iterator Opaque cursor returned in `next_cursor` of a prior response.
+	Iterator *string `form:"iterator,omitempty" json:"iterator,omitempty"`
+
+	// StartTime Start of the activity window (RFC 3339). Must be paired with `end_time` to enable per-pair activity.
+	StartTime *time.Time `form:"start_time,omitempty" json:"start_time,omitempty"`
+
+	// EndTime End of the activity window (RFC 3339). Must be paired with `start_time` to enable per-pair activity.
+	EndTime *time.Time `form:"end_time,omitempty" json:"end_time,omitempty"`
+}
 
 // ListAlertStatsV1Params defines parameters for ListAlertStatsV1.
 type ListAlertStatsV1Params struct {
@@ -574,6 +729,9 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 
 // The interface specification for the client above.
 type ClientInterface interface {
+	// ListIdentityAccess request
+	ListIdentityAccess(ctx context.Context, params *ListIdentityAccessParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetAccountAliases request
 	GetAccountAliases(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -646,6 +804,18 @@ type ClientInterface interface {
 	GetRoleTesterAccessPathsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	GetRoleTesterAccessPaths(ctx context.Context, body GetRoleTesterAccessPathsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+}
+
+func (c *Client) ListIdentityAccess(ctx context.Context, params *ListIdentityAccessParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListIdentityAccessRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
 }
 
 func (c *Client) GetAccountAliases(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -958,6 +1128,60 @@ func (c *Client) GetRoleTesterAccessPaths(ctx context.Context, body GetRoleTeste
 		return nil, err
 	}
 	return c.Client.Do(req)
+}
+
+// NewListIdentityAccessRequest generates requests for ListIdentityAccess
+func NewListIdentityAccessRequest(server string, params *ListIdentityAccessParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/graph/access/v1")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+		queryValues.Add("query", string(params.Query))
+
+		if params.Limit != nil {
+			queryValues.Add("limit", strconv.Itoa(*params.Limit))
+
+		}
+
+		if params.Iterator != nil {
+			queryValues.Add("iterator", string(*params.Iterator))
+
+		}
+
+		if params.StartTime != nil {
+			queryValues.Add("start_time", (*params.StartTime).Format(time.RFC3339Nano))
+
+		}
+
+		if params.EndTime != nil {
+			queryValues.Add("end_time", (*params.EndTime).Format(time.RFC3339Nano))
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
 }
 
 // NewGetAccountAliasesRequest generates requests for GetAccountAliases
@@ -1851,6 +2075,9 @@ func WithBaseURL(baseURL string) ClientOption {
 
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
+	// ListIdentityAccessWithResponse request
+	ListIdentityAccessWithResponse(ctx context.Context, params *ListIdentityAccessParams, reqEditors ...RequestEditorFn) (*ListIdentityAccessResponse, error)
+
 	// GetAccountAliasesWithResponse request
 	GetAccountAliasesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetAccountAliasesResponse, error)
 
@@ -1923,6 +2150,34 @@ type ClientWithResponsesInterface interface {
 	GetRoleTesterAccessPathsWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*GetRoleTesterAccessPathsResponse, error)
 
 	GetRoleTesterAccessPathsWithResponse(ctx context.Context, body GetRoleTesterAccessPathsJSONRequestBody, reqEditors ...RequestEditorFn) (*GetRoleTesterAccessPathsResponse, error)
+}
+
+type ListIdentityAccessResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *IdentityAccessResponse
+	JSON400      *BadRequest
+}
+
+// Status returns HTTPResponse.Status
+func (r ListIdentityAccessResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListIdentityAccessResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// Bytes is a convenience method to retrieve the raw bytes from the HTTP response
+func (r ListIdentityAccessResponse) Bytes() []byte {
+	return r.Body
 }
 
 type GetAccountAliasesResponse struct {
@@ -2528,6 +2783,15 @@ func (r GetRoleTesterAccessPathsResponse) Bytes() []byte {
 	return r.Body
 }
 
+// ListIdentityAccessWithResponse request returning *ListIdentityAccessResponse
+func (c *ClientWithResponses) ListIdentityAccessWithResponse(ctx context.Context, params *ListIdentityAccessParams, reqEditors ...RequestEditorFn) (*ListIdentityAccessResponse, error) {
+	rsp, err := c.ListIdentityAccess(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListIdentityAccessResponse(rsp)
+}
+
 // GetAccountAliasesWithResponse request returning *GetAccountAliasesResponse
 func (c *ClientWithResponses) GetAccountAliasesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetAccountAliasesResponse, error) {
 	rsp, err := c.GetAccountAliases(ctx, reqEditors...)
@@ -2755,6 +3019,39 @@ func (c *ClientWithResponses) GetRoleTesterAccessPathsWithResponse(ctx context.C
 		return nil, err
 	}
 	return ParseGetRoleTesterAccessPathsResponse(rsp)
+}
+
+// ParseListIdentityAccessResponse parses an HTTP response from a ListIdentityAccessWithResponse call
+func ParseListIdentityAccessResponse(rsp *http.Response) (*ListIdentityAccessResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListIdentityAccessResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest IdentityAccessResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	}
+
+	return response, nil
 }
 
 // ParseGetAccountAliasesResponse parses an HTTP response from a GetAccountAliasesWithResponse call

--- a/lib/accessgraph/apiclient/client.gen.go
+++ b/lib/accessgraph/apiclient/client.gen.go
@@ -304,7 +304,9 @@ type IdentityAccessDecision struct {
 
 	// GrantorCounts Counts of grantors backing this (identity, resource) pair, split by level. Denied grantors appear in `grantors` but aren't counted here — these counts describe how access *is* granted, and a deny is the absence of a grant.
 	GrantorCounts IdentityAccessGrantorCounts `json:"grantor_counts"`
-	Grantors      []IdentityAccessGrantor     `json:"grantors"`
+
+	// Grantors Grantors backing (or denying) this access, in a stable order callers can rely on: by `level` priority `denied > standing > impersonate > request`, then permanent before temporary, then by name, then by `id`. The first element is the strongest-priority grantor.
+	Grantors []IdentityAccessGrantor `json:"grantors"`
 
 	// Level Resolved access level for this identity, in priority order `denied > standing > impersonate > request`. `denied` overrides the others when a deny path applies; `impersonate` means the access is only reachable by impersonating another identity (no approval, just a certificate minted as the target); the grantor and path counts still describe how access would otherwise be reached. `temporary` is a within-level qualifier on this value, not a level of its own.
 	Level IdentityAccessDecisionLevel `json:"level"`

--- a/tool/tctl/common/accessgraph/access_review_command.go
+++ b/tool/tctl/common/accessgraph/access_review_command.go
@@ -1,0 +1,499 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accessgraph
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// accessReviewPageSize is the per-request identity page size used to paginate
+// the access endpoint. 25 balances latency against round-trips on the current
+// (non-CTE) backend pagination.
+const accessReviewPageSize = 25
+
+type accessReviewArgs struct {
+	cmd *kingpin.CmdClause
+
+	query  string
+	from   time.Time
+	to     time.Time
+	limit  int
+	format string
+}
+
+func (c *AccessGraphCommand) initAccessReview(app *kingpin.Application) {
+	cmd := app.Command("access-review", "Review which identities can access which resources.")
+
+	// TODO: add structured convenience filters (e.g. --user, --acl, --role)
+	// that build the query for the user. They will complement --query, which
+	// stays as the power-user filter.
+	cmd.Flag("query", "SQL SELECT against access_path scoping the identities to review.").
+		Required().
+		StringVar(&c.accessReview.query)
+	cmd.Flag("from", fmt.Sprintf("Show access activity at or after this time; enables the activity columns. (Examples: %s, %s, 24h, 7d). Default: activity hidden.", time.RFC3339, time.DateOnly)).
+		SetValue(timeValue{target: &c.accessReview.from})
+	cmd.Flag("to", "Upper bound for access activity. Defaults to now when --from is set; requires --from.").
+		SetValue(timeValue{target: &c.accessReview.to})
+	cmd.Flag("limit", "Maximum number of identities to return.").
+		Default("50").
+		IntVar(&c.accessReview.limit)
+	cmd.Flag("format", "Output format. (Values: text, json, yaml)").
+		Default(teleport.Text).
+		EnumVar(&c.accessReview.format, teleport.Text, teleport.JSON, teleport.YAML)
+
+	c.accessReview.cmd = cmd
+}
+
+// AccessReview executes `tctl access-review`.
+func (c *AccessGraphCommand) AccessReview(ctx context.Context, client *accessgraph.ClientWithResponses) error {
+	args := &c.accessReview
+
+	// Always bounded: no 0/unlimited sentinel.
+	if args.limit < 1 {
+		return trace.BadParameter("--limit must be at least 1")
+	}
+
+	from, to := args.from, args.to
+	showActivity := !from.IsZero() || !to.IsZero()
+	if !to.IsZero() && from.IsZero() {
+		return trace.BadParameter("--to requires --from")
+	}
+	if !from.IsZero() && to.IsZero() {
+		to = time.Now()
+	}
+	if showActivity {
+		if err := validateTimeWindow(from, to); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	params := accessgraph.ListIdentityAccessParams{Query: args.query}
+	if showActivity {
+		fromUTC, toUTC := from.UTC(), to.UTC()
+		params.StartTime = &fromUTC
+		params.EndTime = &toUTC
+	}
+
+	resp, truncated, err := fetchIdentityAccess(ctx, client, params, args.limit)
+	if err != nil {
+		// A bare 404 means the endpoint isn't routed here; a 404 with a body is a
+		// real API error and surfaces verbatim below.
+		if trace.IsNotFound(err) {
+			return trace.Wrap(err, "access-review is unavailable on this cluster. This usually means Identity Security is not enabled, or that the access-review endpoint is not yet available on this cluster.")
+		}
+		return trace.Wrap(err)
+	}
+
+	output := buildAccessReviewOutput(resp)
+	if resp.IacError != nil && *resp.IacError != "" {
+		output.Warnings = append(output.Warnings, fmt.Sprintf("activity unavailable: %s", utils.EscapeControl(*resp.IacError)))
+	}
+	if truncated {
+		output.Warnings = append(output.Warnings, fmt.Sprintf("results truncated at %d identities; narrow --query for the full set", args.limit))
+	}
+
+	return writeOutput(c.stdout, output, args.format, func(w io.Writer) error {
+		return displayAccessReviewText(w, output, from, to, showActivity)
+	})
+}
+
+// fetchIdentityAccess paginates the access endpoint up to maxResults identities,
+// merging each page's rows and deduplicated nodes into a single response.
+// truncated is true if more identities remained.
+func fetchIdentityAccess(
+	ctx context.Context,
+	client *accessgraph.ClientWithResponses,
+	params accessgraph.ListIdentityAccessParams,
+	maxResults int,
+) (*accessgraph.IdentityAccessResponse, bool, error) {
+	pageSize := min(accessReviewPageSize, maxResults)
+	params.Limit = &pageSize
+	slog.DebugContext(ctx, "access review query", "query", params.Query, "max_results", maxResults, "page_size", pageSize)
+
+	var (
+		cursor    *string
+		rows      []accessgraph.IdentityAccessRow
+		iacErr    *string
+		truncated bool
+		pages     int
+	)
+	nodesByID := make(map[uuid.UUID]accessgraph.IdentityAccessNode)
+
+	for {
+		params.Iterator = cursor
+		resp, err := doRequest(client.ListIdentityAccessWithResponse(ctx, &params))
+		if err != nil {
+			return nil, false, trace.Wrap(err)
+		}
+		if resp.JSON200 == nil {
+			return nil, false, trace.Errorf("received nil json response from Access Graph API")
+		}
+
+		// Guard against a non-advancing cursor that would otherwise loop forever.
+		if cursor != nil && resp.JSON200.NextCursor != nil && *resp.JSON200.NextCursor == *cursor {
+			slog.DebugContext(ctx, "Access Graph cursor did not advance; stopping pagination", "cursor", *cursor)
+			truncated = true
+			break
+		}
+
+		pages++
+		slog.DebugContext(ctx, "access review page fetched", "page", pages, "page_size", len(resp.JSON200.Data))
+		for _, n := range resp.JSON200.Nodes {
+			nodesByID[n.Id] = n
+		}
+		rows = append(rows, resp.JSON200.Data...)
+		// Keep the last non-empty error; empty/nil pages don't clobber it.
+		if resp.JSON200.IacError != nil && *resp.JSON200.IacError != "" {
+			iacErr = resp.JSON200.IacError
+		}
+
+		if len(rows) >= maxResults {
+			truncated = len(rows) > maxResults || resp.JSON200.NextCursor != nil
+			rows = rows[:maxResults]
+			break
+		}
+		if resp.JSON200.NextCursor == nil {
+			break
+		}
+		cursor = resp.JSON200.NextCursor
+	}
+
+	nodes := make([]accessgraph.IdentityAccessNode, 0, len(nodesByID))
+	for _, n := range nodesByID {
+		nodes = append(nodes, n)
+	}
+	slog.DebugContext(ctx, "access review fetch complete", "pages", pages, "identities", len(rows), "nodes", len(nodes), "truncated", truncated)
+	return &accessgraph.IdentityAccessResponse{Data: rows, Nodes: nodes, IacError: iacErr}, truncated, nil
+}
+
+// indexNodesByID maps nodes by id for resolveNode lookups.
+func indexNodesByID(nodes []accessgraph.IdentityAccessNode) map[uuid.UUID]accessgraph.IdentityAccessNode {
+	byID := make(map[uuid.UUID]accessgraph.IdentityAccessNode, len(nodes))
+	for _, n := range nodes {
+		byID[n.Id] = n
+	}
+	return byID
+}
+
+// --- output types -----------------------------------------------------------
+
+// accessReviewOutput is the materialized review payload. Node references in the
+// raw API response are resolved to full Node values here.
+type accessReviewOutput struct {
+	Identities []identityAccess `json:"identities" yaml:"identities"`
+	Warnings   []string         `json:"warnings,omitempty" yaml:"warnings,omitempty"`
+}
+
+type identityAccess struct {
+	Identity  node             `json:"identity" yaml:"identity"`
+	Resources []resourceAccess `json:"resources" yaml:"resources"`
+}
+
+type resourceAccess struct {
+	Resource      node          `json:"resource" yaml:"resource"`
+	Level         string        `json:"level" yaml:"level"`
+	Temporary     bool          `json:"temporary,omitempty" yaml:"temporary,omitempty"`
+	GrantorCounts grantorCounts `json:"grantor_counts" yaml:"grantor_counts"`
+	Grantors      []grantor     `json:"grantors" yaml:"grantors"`
+	Activity      *activity     `json:"activity,omitempty" yaml:"activity,omitempty"`
+}
+
+type grantor struct {
+	Node  node   `json:"node" yaml:"node"`
+	Level string `json:"level" yaml:"level"`
+}
+
+type node struct {
+	ID        string `json:"id" yaml:"id"`
+	Name      string `json:"name" yaml:"name"`
+	Alias     string `json:"alias,omitempty" yaml:"alias,omitempty"`
+	Kind      string `json:"kind" yaml:"kind"`
+	SubKind   string `json:"sub_kind,omitempty" yaml:"sub_kind,omitempty"`
+	Source    string `json:"source,omitempty" yaml:"source,omitempty"`
+	Origin    string `json:"origin,omitempty" yaml:"origin,omitempty"`
+	Temporary bool   `json:"temporary,omitempty" yaml:"temporary,omitempty"`
+}
+
+type grantorCounts struct {
+	Standing    int `json:"standing" yaml:"standing"`
+	Impersonate int `json:"impersonate" yaml:"impersonate"`
+	Request     int `json:"request" yaml:"request"`
+}
+
+type activity struct {
+	Count      int64      `json:"count" yaml:"count"`
+	LastAccess *time.Time `json:"last_access,omitempty" yaml:"last_access,omitempty"`
+}
+
+// --- restructuring ----------------------------------------------------------
+
+// buildAccessReviewOutput resolves the identity-centric API response into the
+// materialized output, looking up every identity/resource/grantor id against
+// the response node list.
+func buildAccessReviewOutput(resp *accessgraph.IdentityAccessResponse) accessReviewOutput {
+	nodesByID := indexNodesByID(resp.Nodes)
+
+	out := accessReviewOutput{Identities: make([]identityAccess, 0, len(resp.Data))}
+	for _, row := range resp.Data {
+		ia := identityAccess{
+			Identity:  resolveNode(nodesByID, row.Identity),
+			Resources: make([]resourceAccess, 0, len(row.Resources)),
+		}
+		for _, r := range row.Resources {
+			info := r.AccessInfo
+			ra := resourceAccess{
+				Resource: resolveNode(nodesByID, r.Resource),
+				Level:    string(info.Level),
+				GrantorCounts: grantorCounts{
+					Standing:    info.GrantorCounts.Standing,
+					Impersonate: info.GrantorCounts.Impersonate,
+					Request:     info.GrantorCounts.Request,
+				},
+				Grantors: make([]grantor, 0, len(info.Grantors)),
+			}
+			if info.Temporary != nil {
+				ra.Temporary = *info.Temporary
+			}
+			for _, g := range info.Grantors {
+				grantor := grantor{Node: resolveNode(nodesByID, g.Id), Level: string(g.Level)}
+				ra.Grantors = append(ra.Grantors, grantor)
+			}
+			if info.Activity != nil {
+				ra.Activity = &activity{Count: info.Activity.Count, LastAccess: info.Activity.LastAccess}
+			}
+			ia.Resources = append(ia.Resources, ra)
+		}
+		out.Identities = append(out.Identities, ia)
+	}
+	return out
+}
+
+// resolveNode looks up id in nodesByID. A referenced id missing from the node
+// list yields a Node carrying only the id rather than failing the review.
+func resolveNode(nodesByID map[uuid.UUID]accessgraph.IdentityAccessNode, id uuid.UUID) node {
+	n, ok := nodesByID[id]
+	if !ok {
+		return node{ID: id.String()}
+	}
+	node := node{
+		ID:      n.Id.String(),
+		Name:    n.Name,
+		Kind:    string(n.Kind),
+		Alias:   strPtrToStr(n.Alias),
+		SubKind: strPtrToStr(n.SubKind),
+		Source:  strPtrToStr(n.Source),
+		Origin:  strPtrToStr(n.Origin),
+	}
+	if n.Temporary != nil {
+		node.Temporary = *n.Temporary
+	}
+	return node
+}
+
+// primaryGrantor returns the grantor that backs the access at its resolved
+// level (the first match), falling back to the first grantor of any level.
+func primaryGrantor(ra resourceAccess) (grantor, bool) {
+	for _, g := range ra.Grantors {
+		if g.Level == ra.Level {
+			return g, true
+		}
+	}
+	if len(ra.Grantors) > 0 {
+		return ra.Grantors[0], true
+	}
+	return grantor{}, false
+}
+
+func grantorSummary(p grantorCounts) string {
+	var parts []string
+	if p.Standing > 0 {
+		parts = append(parts, fmt.Sprintf("%d standing", p.Standing))
+	}
+	if p.Impersonate > 0 {
+		parts = append(parts, fmt.Sprintf("%d impersonate", p.Impersonate))
+	}
+	if p.Request > 0 {
+		parts = append(parts, fmt.Sprintf("%d request", p.Request))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// --- display ----------------------------------------------------------------
+
+func displayAccessReviewText(out io.Writer, output accessReviewOutput, from, to time.Time, showActivity bool) error {
+	if showActivity {
+		if _, err := fmt.Fprintf(out, "Period: %s → %s\n\n", from.Format(time.RFC3339), to.Format(time.RFC3339)); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	if len(output.Identities) == 0 {
+		if _, err := fmt.Fprintln(out, "No access found."); err != nil {
+			return trace.Wrap(err)
+		}
+		return trace.Wrap(writeWarnings(out, output.Warnings))
+	}
+
+	if err := renderAccessReviewSummary(out, output, showActivity); err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(writeWarnings(out, output.Warnings))
+}
+
+// renderAccessReviewSummary shows one row per (identity, resource) with the
+// resolved level, the primary grantor, and the grantor path counts.
+func renderAccessReviewSummary(out io.Writer, output accessReviewOutput, showActivity bool) error {
+	headers := []string{"Identity", "Kind", "Resource", "Resource Kind", "Access Level", "Granted By", "Grantor Counts"}
+	if showActivity {
+		headers = append(headers, "Accesses", "Last Access")
+	}
+
+	var rows [][]string
+	for _, ia := range output.Identities {
+		if len(ia.Resources) == 0 {
+			row := []string{cellName(ia.Identity), cellKind(ia.Identity), "", "", "", "", ""}
+			if showActivity {
+				row = append(row, "", "")
+			}
+			rows = append(rows, row)
+			continue
+		}
+		for i, ra := range ia.Resources {
+			identity, kind := "", ""
+			if i == 0 {
+				identity, kind = cellName(ia.Identity), cellKind(ia.Identity)
+			}
+
+			level := utils.EscapeControl(ra.Level)
+			if ra.Temporary {
+				level += "*"
+			}
+			granted := ""
+			if g, ok := primaryGrantor(ra); ok {
+				granted = grantorName(g)
+			}
+			row := []string{identity, kind, cellName(ra.Resource), cellKind(ra.Resource), level, granted, grantorSummary(ra.GrantorCounts)}
+			if showActivity {
+				accesses, last := "0", "never"
+				if ra.Activity != nil {
+					accesses = fmt.Sprintf("%d", ra.Activity.Count)
+					if ra.Activity.LastAccess != nil {
+						last = ra.Activity.LastAccess.Format(time.RFC3339)
+					}
+				}
+				row = append(row, accesses, last)
+			}
+			rows = append(rows, row)
+		}
+	}
+
+	return writeAccessTable(out, headers, rows)
+}
+
+const resourceColumn = "Resource"
+
+const resourceColumnFloor = 16
+
+func writeAccessTable(out io.Writer, headers []string, rows [][]string) error {
+	table := buildAccessTable(headers, rows, terminalWidth(out))
+	_, err := fmt.Fprintln(out, table.String())
+	return trace.Wrap(err)
+}
+
+// buildAccessTable caps only the Resource column to the space the others leave,
+// so wide columns are never clipped just to fit the table width. The cap ignores
+// the "..." asciitable appends on truncation, so a clipped Resource can overflow
+// width by a few columns; the terminal wraps it.
+func buildAccessTable(headers []string, rows [][]string, width int) asciitable.Table {
+	used := 0
+	for i, h := range headers {
+		if h == resourceColumn {
+			continue
+		}
+		colWidth := len(h)
+		for _, row := range rows {
+			if i < len(row) && len(row[i]) > colWidth {
+				colWidth = len(row[i])
+			}
+		}
+		used += colWidth + 1 // +1 for tabwriter's column padding
+	}
+
+	t := asciitable.MakeTable([]string{})
+	for _, h := range headers {
+		col := asciitable.Column{Title: h}
+		if h == resourceColumn {
+			col.MaxCellLength = max(width-used, resourceColumnFloor)
+		}
+		t.AddColumn(col)
+	}
+	for _, row := range rows {
+		t.AddRow(row)
+	}
+	return t
+}
+
+func writeWarnings(out io.Writer, warnings []string) error {
+	for _, w := range warnings {
+		if _, err := fmt.Fprintln(out, warningStyle.Render("Warning: "+w)); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}
+
+// cellName renders a node's display label (alias, else name, else id), escaped.
+func cellName(n node) string {
+	name := n.Name
+	if n.Alias != "" {
+		name = n.Alias
+	}
+	if name == "" {
+		name = n.ID
+	}
+	return utils.EscapeControl(name)
+}
+
+// cellKind renders a node's sub-kind (e.g. user, bot, ssh).
+func cellKind(n node) string {
+	return utils.EscapeControl(n.SubKind)
+}
+
+// grantorName renders a grantor's display label, marking temporary grantors.
+func grantorName(g grantor) string {
+	name := cellName(g.Node)
+	if g.Node.Temporary {
+		name += "*"
+	}
+	return name
+}

--- a/tool/tctl/common/accessgraph/access_review_command.go
+++ b/tool/tctl/common/accessgraph/access_review_command.go
@@ -320,18 +320,13 @@ func resolveNode(nodesByID map[uuid.UUID]accessgraph.IdentityAccessNode, id uuid
 	return node
 }
 
-// primaryGrantor returns the grantor that backs the access at its resolved
-// level (the first match), falling back to the first grantor of any level.
+// primaryGrantor returns the primary grantor for the access. The backend lists
+// grantors primary-first, so index 0 is authoritative.
 func primaryGrantor(ra resourceAccess) (grantor, bool) {
-	for _, g := range ra.Grantors {
-		if g.Level == ra.Level {
-			return g, true
-		}
+	if len(ra.Grantors) == 0 {
+		return grantor{}, false
 	}
-	if len(ra.Grantors) > 0 {
-		return ra.Grantors[0], true
-	}
-	return grantor{}, false
+	return ra.Grantors[0], true
 }
 
 func grantorSummary(p grantorCounts) string {

--- a/tool/tctl/common/accessgraph/access_review_command_test.go
+++ b/tool/tctl/common/accessgraph/access_review_command_test.go
@@ -96,13 +96,14 @@ func TestBuildAccessReviewOutput(t *testing.T) {
 		require.Equal(t, &lastAccess, ra.Activity.LastAccess)
 	})
 
-	t.Run("primary grantor matches resolved level", func(t *testing.T) {
+	t.Run("primary grantor is the first grantor", func(t *testing.T) {
 		out := buildAccessReviewOutput(resp)
-		// Grantors are listed request-first, but the resolved level is standing.
+		// The backend lists the primary grantor first, so index 0 is primary
+		// regardless of the resolved level.
 		g, ok := primaryGrantor(out.Identities[0].Resources[0])
 		require.True(t, ok)
-		require.Equal(t, "admins", g.Node.Name)
-		require.False(t, g.Node.Temporary)
+		require.Equal(t, "oncall", g.Node.Name)
+		require.True(t, g.Node.Temporary)
 	})
 
 	t.Run("grantor temporary propagates from node", func(t *testing.T) {
@@ -150,15 +151,9 @@ func TestPrimaryGrantor(t *testing.T) {
 		return grantor{Node: node{Name: name}, Level: level}
 	}
 
-	t.Run("matches resolved level", func(t *testing.T) {
+	t.Run("returns the first grantor", func(t *testing.T) {
+		// The primary is index 0 even when a later grantor matches the level.
 		ra := resourceAccess{Level: "standing", Grantors: []grantor{g("req", "request"), g("std", "standing")}}
-		got, ok := primaryGrantor(ra)
-		require.True(t, ok)
-		require.Equal(t, "std", got.Node.Name)
-	})
-
-	t.Run("falls back to first when no level match", func(t *testing.T) {
-		ra := resourceAccess{Level: "denied", Grantors: []grantor{g("req", "request")}}
 		got, ok := primaryGrantor(ra)
 		require.True(t, ok)
 		require.Equal(t, "req", got.Node.Name)

--- a/tool/tctl/common/accessgraph/access_review_command_test.go
+++ b/tool/tctl/common/accessgraph/access_review_command_test.go
@@ -40,8 +40,6 @@ import (
 // identityAccessPath pins the AG path so a generated-client drift fails the test.
 const identityAccessPath = accessGraphAPIPath + "graph/access/v1"
 
-func ptr[T any](v T) *T { return &v }
-
 func TestBuildAccessReviewOutput(t *testing.T) {
 	idID := uuid.New()
 	resID := uuid.New()
@@ -50,10 +48,10 @@ func TestBuildAccessReviewOutput(t *testing.T) {
 	lastAccess := time.Date(2026, 6, 12, 9, 0, 0, 0, time.UTC)
 
 	nodes := []accessgraph.IdentityAccessNode{
-		{Id: idID, Name: "alice@corp", Kind: "identity", SubKind: ptr("user")},
-		{Id: resID, Name: "prod-db", Kind: "resource", SubKind: ptr("db"), Alias: ptr("Production DB")},
-		{Id: grStanding, Name: "admins", Kind: "identity_group", SubKind: ptr("role")},
-		{Id: grRequest, Name: "oncall", Kind: "identity_group", SubKind: ptr("access_request"), Temporary: ptr(true)},
+		{Id: idID, Name: "alice@corp", Kind: "identity", SubKind: new("user")},
+		{Id: resID, Name: "prod-db", Kind: "resource", SubKind: new("db"), Alias: new("Production DB")},
+		{Id: grStanding, Name: "admins", Kind: "identity_group", SubKind: new("role")},
+		{Id: grRequest, Name: "oncall", Kind: "identity_group", SubKind: new("access_request"), Temporary: new(true)},
 	}
 	resp := &accessgraph.IdentityAccessResponse{
 		Nodes: nodes,
@@ -63,7 +61,7 @@ func TestBuildAccessReviewOutput(t *testing.T) {
 				Resource: resID,
 				AccessInfo: accessgraph.IdentityAccessDecision{
 					Level:         accessgraph.IdentityAccessDecisionLevelStanding,
-					Temporary:     ptr(true),
+					Temporary:     new(true),
 					GrantorCounts: accessgraph.IdentityAccessGrantorCounts{Standing: 1, Request: 1},
 					Grantors: []accessgraph.IdentityAccessGrantor{
 						{Id: grRequest, Level: accessgraph.IdentityAccessGrantorLevelRequest},
@@ -349,8 +347,8 @@ func TestFetchIdentityAccess(t *testing.T) {
 	t.Run("walks the cursor across pages and dedups nodes", func(t *testing.T) {
 		shared := accessgraph.IdentityAccessNode{Id: uuid.New(), Name: "shared", Kind: "identity"}
 		h, iters := accessPageHandler(t, []accessgraph.IdentityAccessResponse{
-			{Data: []accessgraph.IdentityAccessRow{row()}, Nodes: []accessgraph.IdentityAccessNode{shared}, NextCursor: ptr("c1")},
-			{Data: []accessgraph.IdentityAccessRow{row()}, Nodes: []accessgraph.IdentityAccessNode{shared}, NextCursor: ptr("c2")},
+			{Data: []accessgraph.IdentityAccessRow{row()}, Nodes: []accessgraph.IdentityAccessNode{shared}, NextCursor: new("c1")},
+			{Data: []accessgraph.IdentityAccessRow{row()}, Nodes: []accessgraph.IdentityAccessNode{shared}, NextCursor: new("c2")},
 			{Data: []accessgraph.IdentityAccessRow{row()}},
 		})
 		c := newAccessGraphTestClient(t, h)
@@ -364,7 +362,7 @@ func TestFetchIdentityAccess(t *testing.T) {
 
 	t.Run("truncates at maxResults", func(t *testing.T) {
 		h, _ := accessPageHandler(t, []accessgraph.IdentityAccessResponse{
-			{Data: []accessgraph.IdentityAccessRow{row(), row(), row()}, NextCursor: ptr("more")},
+			{Data: []accessgraph.IdentityAccessRow{row(), row(), row()}, NextCursor: new("more")},
 		})
 		c := newAccessGraphTestClient(t, h)
 		resp, truncated, err := fetchIdentityAccess(context.Background(), c, baseParams, 2)
@@ -375,8 +373,8 @@ func TestFetchIdentityAccess(t *testing.T) {
 
 	t.Run("non-advancing cursor stops pagination", func(t *testing.T) {
 		h, _ := accessPageHandler(t, []accessgraph.IdentityAccessResponse{
-			{Data: []accessgraph.IdentityAccessRow{row()}, NextCursor: ptr("stuck")},
-			{Data: []accessgraph.IdentityAccessRow{row()}, NextCursor: ptr("stuck")},
+			{Data: []accessgraph.IdentityAccessRow{row()}, NextCursor: new("stuck")},
+			{Data: []accessgraph.IdentityAccessRow{row()}, NextCursor: new("stuck")},
 		})
 		c := newAccessGraphTestClient(t, h)
 		resp, truncated, err := fetchIdentityAccess(context.Background(), c, baseParams, 100)
@@ -387,7 +385,7 @@ func TestFetchIdentityAccess(t *testing.T) {
 
 	t.Run("iac_error propagated", func(t *testing.T) {
 		h, _ := accessPageHandler(t, []accessgraph.IdentityAccessResponse{
-			{Data: []accessgraph.IdentityAccessRow{row()}, IacError: ptr("activity center down")},
+			{Data: []accessgraph.IdentityAccessRow{row()}, IacError: new("activity center down")},
 		})
 		c := newAccessGraphTestClient(t, h)
 		resp, _, err := fetchIdentityAccess(context.Background(), c, baseParams, 100)
@@ -486,14 +484,14 @@ func TestAccessReviewSurfacesWarnings(t *testing.T) {
 		args := base
 		args.limit = 1
 		out := run(t, []accessgraph.IdentityAccessResponse{
-			{Data: []accessgraph.IdentityAccessRow{{Identity: uuid.New()}, {Identity: uuid.New()}}, NextCursor: ptr("more")},
+			{Data: []accessgraph.IdentityAccessRow{{Identity: uuid.New()}, {Identity: uuid.New()}}, NextCursor: new("more")},
 		}, args)
 		require.Contains(t, out, "truncated at 1 identities")
 	})
 
 	t.Run("iac_error warning", func(t *testing.T) {
 		out := run(t, []accessgraph.IdentityAccessResponse{
-			{Data: []accessgraph.IdentityAccessRow{{Identity: uuid.New()}}, IacError: ptr("activity center down")},
+			{Data: []accessgraph.IdentityAccessRow{{Identity: uuid.New()}}, IacError: new("activity center down")},
 		}, base)
 		require.Contains(t, out, "activity unavailable: activity center down")
 	})

--- a/tool/tctl/common/accessgraph/access_review_command_test.go
+++ b/tool/tctl/common/accessgraph/access_review_command_test.go
@@ -1,0 +1,505 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accessgraph
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
+)
+
+// identityAccessPath pins the AG path so a generated-client drift fails the test.
+const identityAccessPath = accessGraphAPIPath + "graph/access/v1"
+
+func ptr[T any](v T) *T { return &v }
+
+func TestBuildAccessReviewOutput(t *testing.T) {
+	idID := uuid.New()
+	resID := uuid.New()
+	grStanding := uuid.New()
+	grRequest := uuid.New()
+	lastAccess := time.Date(2026, 6, 12, 9, 0, 0, 0, time.UTC)
+
+	nodes := []accessgraph.IdentityAccessNode{
+		{Id: idID, Name: "alice@corp", Kind: "identity", SubKind: ptr("user")},
+		{Id: resID, Name: "prod-db", Kind: "resource", SubKind: ptr("db"), Alias: ptr("Production DB")},
+		{Id: grStanding, Name: "admins", Kind: "identity_group", SubKind: ptr("role")},
+		{Id: grRequest, Name: "oncall", Kind: "identity_group", SubKind: ptr("access_request"), Temporary: ptr(true)},
+	}
+	resp := &accessgraph.IdentityAccessResponse{
+		Nodes: nodes,
+		Data: []accessgraph.IdentityAccessRow{{
+			Identity: idID,
+			Resources: []accessgraph.IdentityAccessResource{{
+				Resource: resID,
+				AccessInfo: accessgraph.IdentityAccessDecision{
+					Level:         accessgraph.IdentityAccessDecisionLevelStanding,
+					Temporary:     ptr(true),
+					GrantorCounts: accessgraph.IdentityAccessGrantorCounts{Standing: 1, Request: 1},
+					Grantors: []accessgraph.IdentityAccessGrantor{
+						{Id: grRequest, Level: accessgraph.IdentityAccessGrantorLevelRequest},
+						{Id: grStanding, Level: accessgraph.IdentityAccessGrantorLevelStanding},
+					},
+					Activity: &accessgraph.IdentityAccessActivity{Count: 14, LastAccess: &lastAccess},
+				},
+			}},
+		}},
+	}
+
+	t.Run("resolves nodes and access info", func(t *testing.T) {
+		out := buildAccessReviewOutput(resp)
+		require.Len(t, out.Identities, 1)
+
+		ia := out.Identities[0]
+		require.Equal(t, "alice@corp", ia.Identity.Name)
+		require.Equal(t, "user", ia.Identity.SubKind)
+		require.Len(t, ia.Resources, 1)
+
+		ra := ia.Resources[0]
+		require.Equal(t, "prod-db", ra.Resource.Name)
+		require.Equal(t, "Production DB", ra.Resource.Alias)
+		require.Equal(t, "standing", ra.Level)
+		require.True(t, ra.Temporary)
+		require.Equal(t, grantorCounts{Standing: 1, Request: 1}, ra.GrantorCounts)
+		require.Len(t, ra.Grantors, 2)
+		require.NotNil(t, ra.Activity)
+		require.EqualValues(t, 14, ra.Activity.Count)
+		require.Equal(t, &lastAccess, ra.Activity.LastAccess)
+	})
+
+	t.Run("primary grantor matches resolved level", func(t *testing.T) {
+		out := buildAccessReviewOutput(resp)
+		// Grantors are listed request-first, but the resolved level is standing.
+		g, ok := primaryGrantor(out.Identities[0].Resources[0])
+		require.True(t, ok)
+		require.Equal(t, "admins", g.Node.Name)
+		require.False(t, g.Node.Temporary)
+	})
+
+	t.Run("grantor temporary propagates from node", func(t *testing.T) {
+		out := buildAccessReviewOutput(resp)
+		grantors := out.Identities[0].Resources[0].Grantors
+		require.Equal(t, "oncall", grantors[0].Node.Name)
+		require.True(t, grantors[0].Node.Temporary)
+	})
+
+	t.Run("missing node tolerated", func(t *testing.T) {
+		orphan := uuid.New()
+		r := &accessgraph.IdentityAccessResponse{
+			Nodes: nil,
+			Data: []accessgraph.IdentityAccessRow{{
+				Identity: orphan,
+				Resources: []accessgraph.IdentityAccessResource{{
+					Resource:   orphan,
+					AccessInfo: accessgraph.IdentityAccessDecision{Level: accessgraph.IdentityAccessDecisionLevelStanding},
+				}},
+			}},
+		}
+		out := buildAccessReviewOutput(r)
+		require.Equal(t, orphan.String(), out.Identities[0].Identity.ID)
+		require.Empty(t, out.Identities[0].Identity.Name)
+	})
+
+	t.Run("activity absent when not provided", func(t *testing.T) {
+		r := &accessgraph.IdentityAccessResponse{
+			Nodes: nodes,
+			Data: []accessgraph.IdentityAccessRow{{
+				Identity: idID,
+				Resources: []accessgraph.IdentityAccessResource{{
+					Resource:   resID,
+					AccessInfo: accessgraph.IdentityAccessDecision{Level: accessgraph.IdentityAccessDecisionLevelStanding},
+				}},
+			}},
+		}
+		out := buildAccessReviewOutput(r)
+		require.Nil(t, out.Identities[0].Resources[0].Activity)
+	})
+}
+
+func TestPrimaryGrantor(t *testing.T) {
+	g := func(name, level string) grantor {
+		return grantor{Node: node{Name: name}, Level: level}
+	}
+
+	t.Run("matches resolved level", func(t *testing.T) {
+		ra := resourceAccess{Level: "standing", Grantors: []grantor{g("req", "request"), g("std", "standing")}}
+		got, ok := primaryGrantor(ra)
+		require.True(t, ok)
+		require.Equal(t, "std", got.Node.Name)
+	})
+
+	t.Run("falls back to first when no level match", func(t *testing.T) {
+		ra := resourceAccess{Level: "denied", Grantors: []grantor{g("req", "request")}}
+		got, ok := primaryGrantor(ra)
+		require.True(t, ok)
+		require.Equal(t, "req", got.Node.Name)
+	})
+
+	t.Run("none when no grantors", func(t *testing.T) {
+		_, ok := primaryGrantor(resourceAccess{Level: "standing"})
+		require.False(t, ok)
+	})
+}
+
+func TestGrantorSummary(t *testing.T) {
+	cases := []struct {
+		name string
+		in   grantorCounts
+		want string
+	}{
+		{"empty", grantorCounts{}, ""},
+		{"standing only", grantorCounts{Standing: 2}, "2 standing"},
+		{"impersonate only", grantorCounts{Impersonate: 1}, "1 impersonate"},
+		{"mixed in fixed order", grantorCounts{Standing: 1, Impersonate: 2, Request: 3}, "1 standing, 2 impersonate, 3 request"},
+		{"zero levels omitted", grantorCounts{Standing: 1, Request: 1}, "1 standing, 1 request"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, grantorSummary(tc.in))
+		})
+	}
+}
+
+func TestDisplayAccessReviewText(t *testing.T) {
+	last := time.Date(2026, 6, 12, 9, 0, 0, 0, time.UTC)
+	output := accessReviewOutput{
+		Identities: []identityAccess{{
+			Identity: node{ID: "i1", Name: "alice@corp", SubKind: "user"},
+			Resources: []resourceAccess{
+				{
+					Resource:      node{Name: "prod-db", SubKind: "db"},
+					Level:         "standing",
+					GrantorCounts: grantorCounts{Standing: 1, Request: 1},
+					Grantors: []grantor{
+						{Node: node{Name: "admins"}, Level: "standing"},
+						{Node: node{Name: "break-glass", Temporary: true}, Level: "request"},
+					},
+					Activity: &activity{Count: 14, LastAccess: &last},
+				},
+				{
+					Resource:      node{Name: "prod-web", SubKind: "app"},
+					Level:         "request",
+					Temporary:     true,
+					GrantorCounts: grantorCounts{Request: 1},
+					Grantors:      []grantor{{Node: node{Name: "oncall"}, Level: "request"}},
+				},
+			},
+		}},
+	}
+
+	t.Run("without window omits activity columns", func(t *testing.T) {
+		var buf bytes.Buffer
+		require.NoError(t, displayAccessReviewText(&buf, output, time.Time{}, time.Time{}, false))
+		out := buf.String()
+		require.NotContains(t, out, "Last Access")
+		require.NotContains(t, out, "Accesses")
+		require.NotContains(t, out, "Period:")
+		require.Contains(t, out, "alice@corp")
+		require.Contains(t, out, "request*", "temporary access should be marked")
+		require.Contains(t, out, "Resource Kind")
+		require.Contains(t, out, "db")
+		require.Contains(t, out, "app")
+		require.NotContains(t, out, "break-glass", "summary shows only the primary grantor")
+	})
+
+	t.Run("with window shows activity and period", func(t *testing.T) {
+		from := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+		to := time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
+		var buf bytes.Buffer
+		require.NoError(t, displayAccessReviewText(&buf, output, from, to, true))
+		out := buf.String()
+		require.Contains(t, out, "Period:")
+		require.Contains(t, out, "Last Access")
+		require.Contains(t, out, "14")
+		require.Contains(t, out, "never", "resource without activity shows never")
+	})
+
+	t.Run("identity cell blanked after first resource row", func(t *testing.T) {
+		var buf bytes.Buffer
+		require.NoError(t, displayAccessReviewText(&buf, output, time.Time{}, time.Time{}, false))
+		// alice@corp must appear exactly once even though she has two resources.
+		require.Equal(t, 1, bytes.Count(buf.Bytes(), []byte("alice@corp")))
+	})
+
+	t.Run("temporary primary grantor is marked", func(t *testing.T) {
+		o := accessReviewOutput{Identities: []identityAccess{{
+			Identity: node{Name: "bob@corp", SubKind: "user"},
+			Resources: []resourceAccess{{
+				Resource: node{Name: "vault", SubKind: "db"},
+				Level:    "request",
+				Grantors: []grantor{{Node: node{Name: "break-glass", Temporary: true}, Level: "request"}},
+			}},
+		}}}
+		var buf bytes.Buffer
+		require.NoError(t, displayAccessReviewText(&buf, o, time.Time{}, time.Time{}, false))
+		require.Contains(t, buf.String(), "break-glass*", "a temporary primary grantor should be marked")
+	})
+
+	t.Run("empty result", func(t *testing.T) {
+		var buf bytes.Buffer
+		require.NoError(t, displayAccessReviewText(&buf, accessReviewOutput{}, time.Time{}, time.Time{}, false))
+		require.Contains(t, buf.String(), "No access found.")
+	})
+
+	t.Run("warnings printed", func(t *testing.T) {
+		var buf bytes.Buffer
+		o := accessReviewOutput{Warnings: []string{"activity unavailable: boom"}}
+		require.NoError(t, displayAccessReviewText(&buf, o, time.Time{}, time.Time{}, false))
+		require.Contains(t, buf.String(), "Warning: activity unavailable: boom")
+	})
+}
+
+// TestBuildAccessTable pins the layout policy: every column renders in full
+// when the table fits the terminal, and only the Resource column is ever
+// bounded — so naturally wide columns like Grantor Counts and Last Access are never
+// truncated just because the table has many columns.
+func TestBuildAccessTable(t *testing.T) {
+	headers := []string{"Identity", "Kind", "Resource", "Resource Kind", "Access Level", "Granted By", "Grantor Counts", "Accesses", "Last Access"}
+	rows := [][]string{
+		{"ghassan", "user", "teleport-mcp-demo", "app", "standing", "Local DB ACL", "3 standing, 1 request", "6", "2026-06-05T19:15:32-07:00"},
+	}
+
+	t.Run("wide terminal renders every column in full", func(t *testing.T) {
+		table := buildAccessTable(headers, rows, 200)
+		out := table.String()
+		require.NotContains(t, out, "...", "nothing should truncate when the table fits the terminal")
+		require.Contains(t, out, "3 standing, 1 request")
+		require.Contains(t, out, "2026-06-05T19:15:32-07:00")
+		require.Contains(t, out, "teleport-mcp-demo")
+	})
+
+	t.Run("narrow terminal bounds only the Resource column", func(t *testing.T) {
+		longResource := strings.Repeat("x", 80)
+		narrowRows := [][]string{
+			{"ghassan", "user", longResource, "app", "standing", "Local DB ACL", "3 standing, 1 request", "6", "2026-06-05T19:15:32-07:00"},
+		}
+		table := buildAccessTable(headers, narrowRows, 60)
+		out := table.String()
+		// The wide non-resource columns stay intact even on a narrow terminal...
+		require.Contains(t, out, "3 standing, 1 request")
+		require.Contains(t, out, "2026-06-05T19:15:32-07:00")
+		// ...while the oversized Resource name is the only thing truncated.
+		require.NotContains(t, out, longResource, "an oversized resource name should be bounded")
+		require.Contains(t, out, "...")
+	})
+}
+
+// accessPageHandler serves the configured response pages in order, recording
+// the iterator the client sent on each call.
+func accessPageHandler(t *testing.T, pages []accessgraph.IdentityAccessResponse) (http.Handler, *[]string) {
+	t.Helper()
+	var (
+		calls     atomic.Int64
+		iterators []string
+	)
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idx := int(calls.Add(1) - 1)
+		require.Equal(t, identityAccessPath, r.URL.Path, "generated client drifted from the AG access path")
+		iterators = append(iterators, r.URL.Query().Get("iterator"))
+		require.Less(t, idx, len(pages), "client requested more pages than configured")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(pages[idx]))
+	})
+	return h, &iterators
+}
+
+func TestFetchIdentityAccess(t *testing.T) {
+	row := func() accessgraph.IdentityAccessRow {
+		return accessgraph.IdentityAccessRow{Identity: uuid.New()}
+	}
+	baseParams := accessgraph.ListIdentityAccessParams{Query: "SELECT * FROM access_path"}
+
+	t.Run("single page, no cursor", func(t *testing.T) {
+		h, iters := accessPageHandler(t, []accessgraph.IdentityAccessResponse{
+			{Data: []accessgraph.IdentityAccessRow{row()}},
+		})
+		c := newAccessGraphTestClient(t, h)
+		resp, truncated, err := fetchIdentityAccess(context.Background(), c, baseParams, 100)
+		require.NoError(t, err)
+		require.False(t, truncated)
+		require.Len(t, resp.Data, 1)
+		require.Equal(t, []string{""}, *iters, "first call must omit the iterator")
+	})
+
+	t.Run("walks the cursor across pages and dedups nodes", func(t *testing.T) {
+		shared := accessgraph.IdentityAccessNode{Id: uuid.New(), Name: "shared", Kind: "identity"}
+		h, iters := accessPageHandler(t, []accessgraph.IdentityAccessResponse{
+			{Data: []accessgraph.IdentityAccessRow{row()}, Nodes: []accessgraph.IdentityAccessNode{shared}, NextCursor: ptr("c1")},
+			{Data: []accessgraph.IdentityAccessRow{row()}, Nodes: []accessgraph.IdentityAccessNode{shared}, NextCursor: ptr("c2")},
+			{Data: []accessgraph.IdentityAccessRow{row()}},
+		})
+		c := newAccessGraphTestClient(t, h)
+		resp, truncated, err := fetchIdentityAccess(context.Background(), c, baseParams, 100)
+		require.NoError(t, err)
+		require.False(t, truncated)
+		require.Len(t, resp.Data, 3)
+		require.Len(t, resp.Nodes, 1, "shared node must be deduplicated")
+		require.Equal(t, []string{"", "c1", "c2"}, *iters)
+	})
+
+	t.Run("truncates at maxResults", func(t *testing.T) {
+		h, _ := accessPageHandler(t, []accessgraph.IdentityAccessResponse{
+			{Data: []accessgraph.IdentityAccessRow{row(), row(), row()}, NextCursor: ptr("more")},
+		})
+		c := newAccessGraphTestClient(t, h)
+		resp, truncated, err := fetchIdentityAccess(context.Background(), c, baseParams, 2)
+		require.NoError(t, err)
+		require.True(t, truncated)
+		require.Len(t, resp.Data, 2)
+	})
+
+	t.Run("non-advancing cursor stops pagination", func(t *testing.T) {
+		h, _ := accessPageHandler(t, []accessgraph.IdentityAccessResponse{
+			{Data: []accessgraph.IdentityAccessRow{row()}, NextCursor: ptr("stuck")},
+			{Data: []accessgraph.IdentityAccessRow{row()}, NextCursor: ptr("stuck")},
+		})
+		c := newAccessGraphTestClient(t, h)
+		resp, truncated, err := fetchIdentityAccess(context.Background(), c, baseParams, 100)
+		require.NoError(t, err)
+		require.True(t, truncated)
+		require.Len(t, resp.Data, 1)
+	})
+
+	t.Run("iac_error propagated", func(t *testing.T) {
+		h, _ := accessPageHandler(t, []accessgraph.IdentityAccessResponse{
+			{Data: []accessgraph.IdentityAccessRow{row()}, IacError: ptr("activity center down")},
+		})
+		c := newAccessGraphTestClient(t, h)
+		resp, _, err := fetchIdentityAccess(context.Background(), c, baseParams, 100)
+		require.NoError(t, err)
+		require.NotNil(t, resp.IacError)
+		require.Equal(t, "activity center down", *resp.IacError)
+	})
+}
+
+func TestAccessReviewFlags(t *testing.T) {
+	newApp := func() (*kingpin.Application, *AccessGraphCommand) {
+		app := kingpin.New("tctl", "")
+		app.Terminate(nil)
+		c := &AccessGraphCommand{}
+		c.initAccessReview(app)
+		return app, c
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		app, c := newApp()
+		_, err := app.Parse([]string{"access-review", "--query", "SELECT * FROM access_path"})
+		require.NoError(t, err)
+		require.Equal(t, "SELECT * FROM access_path", c.accessReview.query)
+		require.Equal(t, 50, c.accessReview.limit)
+		require.Equal(t, teleport.Text, c.accessReview.format)
+		require.True(t, c.accessReview.from.IsZero())
+		require.True(t, c.accessReview.to.IsZero())
+	})
+
+	t.Run("query required", func(t *testing.T) {
+		app, _ := newApp()
+		_, err := app.Parse([]string{"access-review"})
+		require.Error(t, err)
+	})
+}
+
+func TestAccessReviewValidation(t *testing.T) {
+	// Returns an empty page so the happy path renders "No access found." without
+	// the validation cases ever reaching the network.
+	h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[],"nodes":[]}`))
+	})
+	client := newAccessGraphTestClient(t, h)
+
+	run := func(args accessReviewArgs) (string, error) {
+		var buf bytes.Buffer
+		c := &AccessGraphCommand{stdout: &buf, accessReview: args}
+		err := c.AccessReview(context.Background(), client)
+		return buf.String(), err
+	}
+	base := accessReviewArgs{query: "SELECT * FROM access_path", limit: 50, format: teleport.Text}
+
+	t.Run("limit below range", func(t *testing.T) {
+		args := base
+		args.limit = 0
+		_, err := run(args)
+		require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
+	})
+
+	t.Run("--to without --from", func(t *testing.T) {
+		args := base
+		args.to = time.Now()
+		_, err := run(args)
+		require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
+	})
+
+	t.Run("--from in the future is rejected", func(t *testing.T) {
+		args := base
+		args.from = time.Now().Add(time.Hour)
+		_, err := run(args)
+		require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
+	})
+
+	t.Run("valid no-window review renders", func(t *testing.T) {
+		out, err := run(base)
+		require.NoError(t, err)
+		require.Contains(t, out, "No access found.")
+	})
+}
+
+func TestAccessReviewSurfacesWarnings(t *testing.T) {
+	run := func(t *testing.T, pages []accessgraph.IdentityAccessResponse, args accessReviewArgs) string {
+		t.Helper()
+		h, _ := accessPageHandler(t, pages)
+		client := newAccessGraphTestClient(t, h)
+		var buf bytes.Buffer
+		c := &AccessGraphCommand{stdout: &buf, accessReview: args}
+		require.NoError(t, c.AccessReview(context.Background(), client))
+		return buf.String()
+	}
+	base := accessReviewArgs{query: "SELECT * FROM access_path", limit: 50, format: teleport.Text}
+
+	t.Run("truncation warning", func(t *testing.T) {
+		args := base
+		args.limit = 1
+		out := run(t, []accessgraph.IdentityAccessResponse{
+			{Data: []accessgraph.IdentityAccessRow{{Identity: uuid.New()}, {Identity: uuid.New()}}, NextCursor: ptr("more")},
+		}, args)
+		require.Contains(t, out, "truncated at 1 identities")
+	})
+
+	t.Run("iac_error warning", func(t *testing.T) {
+		out := run(t, []accessgraph.IdentityAccessResponse{
+			{Data: []accessgraph.IdentityAccessRow{{Identity: uuid.New()}}, IacError: ptr("activity center down")},
+		}, base)
+		require.Contains(t, out, "activity unavailable: activity center down")
+	})
+}

--- a/tool/tctl/common/accessgraph/command.go
+++ b/tool/tctl/common/accessgraph/command.go
@@ -43,6 +43,7 @@ type AccessGraphCommand struct {
 	detections    detectionsArgs
 	investigate   investigateArgs
 	accessChanges accessChangesArgs
+	accessReview  accessReviewArgs
 }
 
 // Initialize allows AccessGraphCommand to plug itself into the CLI parser.
@@ -57,6 +58,7 @@ func (c *AccessGraphCommand) Initialize(app *kingpin.Application, cliFlags *tctl
 	c.initDetections(app)
 	c.initInvestigate(app)
 	c.initAccessChanges(app)
+	c.initAccessReview(app)
 }
 
 // TryRun takes the CLI command as an argument and executes it.
@@ -80,6 +82,8 @@ func (c *AccessGraphCommand) TryRun(ctx context.Context, cmd string, clientFunc 
 		commandFunc = c.AccessChangesList
 	case c.accessChanges.get.cmd.FullCommand():
 		commandFunc = c.AccessChangesGet
+	case c.accessReview.cmd.FullCommand():
+		commandFunc = c.AccessReview
 	default:
 		return false, nil
 	}

--- a/tool/tctl/common/accessgraph/detections_command_test.go
+++ b/tool/tctl/common/accessgraph/detections_command_test.go
@@ -530,14 +530,13 @@ func TestDetectionsGet(t *testing.T) {
 }
 
 func TestDisplayDetectionTextAffectedEntity(t *testing.T) {
-	strPtr := func(s string) *string { return &s }
 
 	cases := []struct {
 		name     string
 		entName  *string
 		wantLine string // empty = no Affected line
 	}{
-		{"name set", strPtr("alice@example.com"), "Affected Entity:   alice@example.com"},
+		{"name set", new("alice@example.com"), "Affected Entity:   alice@example.com"},
 		{"name nil", nil, ""},
 	}
 	for _, tc := range cases {

--- a/tool/tctl/common/accessgraph/investigate_command.go
+++ b/tool/tctl/common/accessgraph/investigate_command.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -30,7 +29,6 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 	"golang.org/x/sync/errgroup"
-	"golang.org/x/term"
 
 	"github.com/gravitational/teleport"
 	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
@@ -516,7 +514,7 @@ func displayFacetsText(out io.Writer, facets []logsFacet, allFacets bool) error 
 		return trace.Wrap(err)
 	}
 
-	width := facetWrapWidth(out)
+	width := terminalWidth(out)
 	if _, err := fmt.Fprintln(out, "Facets:"); err != nil {
 		return trace.Wrap(err)
 	}
@@ -575,19 +573,6 @@ func displayFacetsText(out io.Writer, facets []logsFacet, allFacets bool) error 
 	}
 	_, err := fmt.Fprintln(out)
 	return trace.Wrap(err)
-}
-
-// facetWrapWidth returns the column count to wrap facet values at.
-func facetWrapWidth(out io.Writer) int {
-	f, ok := out.(*os.File)
-	if !ok {
-		return 80
-	}
-	width, _, err := term.GetSize(int(f.Fd()))
-	if err != nil || width <= 0 {
-		return 80
-	}
-	return width
 }
 
 // writeWrappedList prints "prefix" followed by items joined with ", ",

--- a/tool/tctl/common/accessgraph/utils.go
+++ b/tool/tctl/common/accessgraph/utils.go
@@ -23,11 +23,13 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/gravitational/trace"
+	"golang.org/x/term"
 
 	"github.com/gravitational/teleport"
 	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
@@ -35,6 +37,23 @@ import (
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/utils"
 )
+
+// defaultTerminalWidth is the column count assumed when detection fails
+const defaultTerminalWidth = 80
+
+// terminalWidth returns the width of the terminal associated with out,
+// or a default if it cannot be determined.
+func terminalWidth(out io.Writer) int {
+	f, ok := out.(*os.File)
+	if !ok {
+		return defaultTerminalWidth
+	}
+	width, _, err := term.GetSize(int(f.Fd()))
+	if err != nil || width <= 0 {
+		return defaultTerminalWidth
+	}
+	return width
+}
 
 type timeValue struct {
 	target *time.Time


### PR DESCRIPTION

Issue: gravitational/access-graph#1933
RFC: gravitational/rfd#40

| #     | PR                          | What it does                          |
| ----- | --------------------------- | ------------------------------------- |
| **1** | **this PR**                 | **Core `tctl access-review` command** |
| 2     | `tctl-access-review-part-2` | Detailed per-grantor output           |
| 3     | `tctl-access-review-part-3` | `access-review` skill                 |
| 4     | `tctl-access-review-part-4` | Eval for the access-review skill      |

This is the first slice of the access-review feature — the core command.

Adds `tctl access-review`, which lists which identities can reach which resources over the new Access Graph `GET /graph/access/v1` endpoint. Each row resolves to a single effective access level (`denied > standing > impersonate > request`), with grantor counts, the primary grantor, and optional access-activity columns when a `--from`/`--to` window is given. The command paginates the endpoint, dedups nodes across pages, and renders a width-aware text table (or JSON/YAML).

## What changed

- New `tctl access-review` command: flag wiring + validation, pagination, API→view resolution, and a width-aware table layout.
- Extracted a shared `terminalWidth` helper into `utils.go` and switched `investigate` to use it.
- Regenerated the Access Graph API client (`ListIdentityAccess`) and the `tctl` CLI reference docs.

## Why

Identity Security needs a CLI surface for reviewing effective access — "who can reach what, and who granted it" — without going through the web UI. This PR lands the foundational command so later stack parts can build per-grantor detail output, an access-review skill, and its eval on top.

We land `--query` first because it matches the SQL-style queries users already write in the web UI and against the graph, it's the most flexible filter we can offer, and it lets us learn how people actually slice access data before we commit to more streamlined, purpose-built reviews (by user, resource, ACL, or role, etc...).

Changelog: Added `tctl access-review` command to list identity access to resources via the Access Graph.

## Screenshot
<img width="1316" height="505" alt="Screenshot 2026-06-30 at 4 18 49 PM" src="https://github.com/user-attachments/assets/908f7f57-d9a0-4e47-b2e5-600bd3bf8a75" />

## Manual Test Plan

### Test Environment

- Local dev cluster with access-graph build running gravitational/access-graph#2028
- For 404, running main branch of gravitational/access-graph

### Test Cases

- [X] `tctl access-review --query=...` returns identity→resource rows with resolved access level, grantor counts, and primary grantor against a live Access Graph cluster.
- [X] `--from`/`--to` window adds the access-activity columns; omitting the window hides those columns.
- [X] A result set spanning multiple pages paginates and dedups nodes correctly (no duplicate rows).
- [X] `--format json` and `--format yaml` emit valid, complete output.
- [X] Narrow terminal: the table stays readable and only the Resource column truncates (minor overflow acceptable per the documented heuristic).
- [X] Bare 404 (endpoint not routed) shows the friendly "unavailable on this cluster" hint; a 404 with a body surfaces the API error verbatim.
- [X] `--debug` emits the pagination debug logs (query, per-page, completion).
