### PR TITLE
access-review[2]: Detailed per-grantor output for `tctl access-review`

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -106,6 +106,7 @@ Flags:
 |`--format`|`text` (one of: `text`, `json`, `yaml`)|Output format. (Values: text, json, yaml)|
 |`--from`|*no default*|Show access activity at or after this time; enables the activity columns. (Examples: 2006-01-02T15:04:05Z07:00, 2006-01-02, 24h, 7d). Default: activity hidden.|
 |`--limit`|`50`|Maximum number of identities to return.|
+|`--[no-]detailed`|`false`|In text output, show each grantor with its individual access level instead of the summary counts.|
 |`--query`|*no default*|SQL SELECT against access_path scoping the identities to review.|
 |`--to`|*no default*|Upper bound for access activity. Defaults to now when --from is set; requires --from.|
 

--- a/tool/tctl/common/accessgraph/access_review_command.go
+++ b/tool/tctl/common/accessgraph/access_review_command.go
@@ -44,11 +44,12 @@ const accessReviewPageSize = 25
 type accessReviewArgs struct {
 	cmd *kingpin.CmdClause
 
-	query  string
-	from   time.Time
-	to     time.Time
-	limit  int
-	format string
+	query    string
+	from     time.Time
+	to       time.Time
+	limit    int
+	detailed bool
+	format   string
 }
 
 func (c *AccessGraphCommand) initAccessReview(app *kingpin.Application) {
@@ -67,6 +68,8 @@ func (c *AccessGraphCommand) initAccessReview(app *kingpin.Application) {
 	cmd.Flag("limit", "Maximum number of identities to return.").
 		Default("50").
 		IntVar(&c.accessReview.limit)
+	cmd.Flag("detailed", "In text output, show each grantor with its individual access level instead of the summary counts.").
+		BoolVar(&c.accessReview.detailed)
 	cmd.Flag("format", "Output format. (Values: text, json, yaml)").
 		Default(teleport.Text).
 		EnumVar(&c.accessReview.format, teleport.Text, teleport.JSON, teleport.YAML)
@@ -123,7 +126,7 @@ func (c *AccessGraphCommand) AccessReview(ctx context.Context, client *accessgra
 	}
 
 	return writeOutput(c.stdout, output, args.format, func(w io.Writer) error {
-		return displayAccessReviewText(w, output, from, to, showActivity)
+		return displayAccessReviewText(w, output, from, to, showActivity, args.detailed)
 	})
 }
 
@@ -345,7 +348,7 @@ func grantorSummary(p grantorCounts) string {
 
 // --- display ----------------------------------------------------------------
 
-func displayAccessReviewText(out io.Writer, output accessReviewOutput, from, to time.Time, showActivity bool) error {
+func displayAccessReviewText(out io.Writer, output accessReviewOutput, from, to time.Time, showActivity, detailed bool) error {
 	if showActivity {
 		if _, err := fmt.Fprintf(out, "Period: %s → %s\n\n", from.Format(time.RFC3339), to.Format(time.RFC3339)); err != nil {
 			return trace.Wrap(err)
@@ -359,7 +362,14 @@ func displayAccessReviewText(out io.Writer, output accessReviewOutput, from, to 
 		return trace.Wrap(writeWarnings(out, output.Warnings))
 	}
 
-	if err := renderAccessReviewSummary(out, output, showActivity); err != nil {
+	render := renderAccessReviewSummary
+	if detailed {
+		render = renderAccessReviewDetailed
+	}
+	if err := render(out, output, showActivity); err != nil {
+		return trace.Wrap(err)
+	}
+	if _, err := fmt.Fprintln(out, "* marks self-expiring access or a temporary grantor"); err != nil {
 		return trace.Wrap(err)
 	}
 	return trace.Wrap(writeWarnings(out, output.Warnings))
@@ -368,7 +378,7 @@ func displayAccessReviewText(out io.Writer, output accessReviewOutput, from, to 
 // renderAccessReviewSummary shows one row per (identity, resource) with the
 // resolved level, the primary grantor, and the grantor path counts.
 func renderAccessReviewSummary(out io.Writer, output accessReviewOutput, showActivity bool) error {
-	headers := []string{"Identity", "Kind", "Resource", "Resource Kind", "Access Level", "Granted By", "Grantor Counts"}
+	headers := []string{"Identity", "Kind", "Resource", "Resource Kind", "Access Level", "Grantor", "Grantor Counts"}
 	if showActivity {
 		headers = append(headers, "Accesses", "Last Access")
 	}
@@ -376,11 +386,7 @@ func renderAccessReviewSummary(out io.Writer, output accessReviewOutput, showAct
 	var rows [][]string
 	for _, ia := range output.Identities {
 		if len(ia.Resources) == 0 {
-			row := []string{cellName(ia.Identity), cellKind(ia.Identity), "", "", "", "", ""}
-			if showActivity {
-				row = append(row, "", "")
-			}
-			rows = append(rows, row)
+			rows = append(rows, padActivity([]string{cellName(ia.Identity), cellKind(ia.Identity), "", "", "", "", ""}, showActivity))
 			continue
 		}
 		for i, ra := range ia.Resources {
@@ -389,23 +395,13 @@ func renderAccessReviewSummary(out io.Writer, output accessReviewOutput, showAct
 				identity, kind = cellName(ia.Identity), cellKind(ia.Identity)
 			}
 
-			level := utils.EscapeControl(ra.Level)
-			if ra.Temporary {
-				level += "*"
-			}
 			granted := ""
 			if g, ok := primaryGrantor(ra); ok {
 				granted = grantorName(g)
 			}
-			row := []string{identity, kind, cellName(ra.Resource), cellKind(ra.Resource), level, granted, grantorSummary(ra.GrantorCounts)}
+			row := []string{identity, kind, cellName(ra.Resource), cellKind(ra.Resource), levelCell(ra), granted, grantorSummary(ra.GrantorCounts)}
 			if showActivity {
-				accesses, last := "0", "never"
-				if ra.Activity != nil {
-					accesses = fmt.Sprintf("%d", ra.Activity.Count)
-					if ra.Activity.LastAccess != nil {
-						last = ra.Activity.LastAccess.Format(time.RFC3339)
-					}
-				}
+				accesses, last := activityCells(ra)
 				row = append(row, accesses, last)
 			}
 			rows = append(rows, row)
@@ -413,6 +409,73 @@ func renderAccessReviewSummary(out io.Writer, output accessReviewOutput, showAct
 	}
 
 	return writeAccessTable(out, headers, rows)
+}
+
+func renderAccessReviewDetailed(out io.Writer, output accessReviewOutput, showActivity bool) error {
+	headers, rows := accessReviewDetailedRows(output, showActivity)
+	return writeAccessTable(out, headers, rows)
+}
+
+// accessReviewDetailedRows builds the detailed table rows, breaking each
+// (identity, resource) pair down by grantor.
+func accessReviewDetailedRows(output accessReviewOutput, showActivity bool) ([]string, [][]string) {
+	headers := []string{"Identity", "Kind", "Resource", "Resource Kind", "Access Level", "Grantor", "Grantor Level"}
+	if showActivity {
+		headers = append(headers, "Accesses", "Last Access")
+	}
+
+	var rows [][]string
+	for _, ia := range output.Identities {
+		identityShown := false
+		identityCells := func() (string, string) {
+			if identityShown {
+				return "", ""
+			}
+			identityShown = true
+			return cellName(ia.Identity), cellKind(ia.Identity)
+		}
+
+		if len(ia.Resources) == 0 {
+			id, kind := identityCells()
+			rows = append(rows, padActivity([]string{id, kind, "", "", "", "", ""}, showActivity))
+			continue
+		}
+		for _, ra := range ia.Resources {
+			id, kind := identityCells()
+
+			// A single grantor shares the resource's row; its activity is
+			// unambiguous. Zero grantors leave the grantor cells blank.
+			if len(ra.Grantors) <= 1 {
+				grantor, grantorLevel := "", ""
+				if len(ra.Grantors) == 1 {
+					g := ra.Grantors[0]
+					grantor, grantorLevel = grantorName(g), utils.EscapeControl(g.Level)
+				}
+				row := []string{id, kind, cellName(ra.Resource), cellKind(ra.Resource), levelCell(ra), grantor, grantorLevel}
+				if showActivity {
+					accesses, last := activityCells(ra)
+					row = append(row, accesses, last)
+				}
+				rows = append(rows, row)
+				continue
+			}
+
+			// Multiple grantors: summary row carries the pair-level activity,
+			// then one indented row per grantor.
+			summary := []string{id, kind, cellName(ra.Resource), cellKind(ra.Resource), levelCell(ra), "", ""}
+			if showActivity {
+				accesses, last := activityCells(ra)
+				summary = append(summary, accesses, last)
+			}
+			rows = append(rows, summary)
+
+			for _, g := range ra.Grantors {
+				rows = append(rows, padActivity([]string{"", "", "", "", "", "↳ " + grantorName(g), utils.EscapeControl(g.Level)}, showActivity))
+			}
+		}
+	}
+
+	return headers, rows
 }
 
 const resourceColumn = "Resource"
@@ -491,4 +554,35 @@ func grantorName(g grantor) string {
 		name += "*"
 	}
 	return name
+}
+
+// levelCell renders the resolved access level, marking self-expiring access.
+func levelCell(ra resourceAccess) string {
+	level := utils.EscapeControl(ra.Level)
+	if ra.Temporary {
+		level += "*"
+	}
+	return level
+}
+
+// activityCells renders the access count and last-access time for a pair,
+// reading absent activity as zero / never.
+func activityCells(ra resourceAccess) (accesses, last string) {
+	if ra.Activity == nil {
+		return "0", "never"
+	}
+	last = "never"
+	if ra.Activity.LastAccess != nil {
+		last = ra.Activity.LastAccess.Format(time.RFC3339)
+	}
+	return fmt.Sprintf("%d", ra.Activity.Count), last
+}
+
+// padActivity keeps rows the same width as the activity headers, so a row
+// built without per-row activity still lines up under the activity columns.
+func padActivity(row []string, showActivity bool) []string {
+	if showActivity {
+		return append(row, "", "")
+	}
+	return row
 }

--- a/tool/tctl/common/accessgraph/access_review_command_test.go
+++ b/tool/tctl/common/accessgraph/access_review_command_test.go
@@ -209,9 +209,9 @@ func TestDisplayAccessReviewText(t *testing.T) {
 		}},
 	}
 
-	t.Run("without window omits activity columns", func(t *testing.T) {
+	t.Run("summary without window omits activity columns", func(t *testing.T) {
 		var buf bytes.Buffer
-		require.NoError(t, displayAccessReviewText(&buf, output, time.Time{}, time.Time{}, false))
+		require.NoError(t, displayAccessReviewText(&buf, output, time.Time{}, time.Time{}, false, false))
 		out := buf.String()
 		require.NotContains(t, out, "Last Access")
 		require.NotContains(t, out, "Accesses")
@@ -224,11 +224,11 @@ func TestDisplayAccessReviewText(t *testing.T) {
 		require.NotContains(t, out, "break-glass", "summary shows only the primary grantor")
 	})
 
-	t.Run("with window shows activity and period", func(t *testing.T) {
+	t.Run("summary with window shows activity and period", func(t *testing.T) {
 		from := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
 		to := time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
 		var buf bytes.Buffer
-		require.NoError(t, displayAccessReviewText(&buf, output, from, to, true))
+		require.NoError(t, displayAccessReviewText(&buf, output, from, to, true, false))
 		out := buf.String()
 		require.Contains(t, out, "Period:")
 		require.Contains(t, out, "Last Access")
@@ -238,7 +238,7 @@ func TestDisplayAccessReviewText(t *testing.T) {
 
 	t.Run("identity cell blanked after first resource row", func(t *testing.T) {
 		var buf bytes.Buffer
-		require.NoError(t, displayAccessReviewText(&buf, output, time.Time{}, time.Time{}, false))
+		require.NoError(t, displayAccessReviewText(&buf, output, time.Time{}, time.Time{}, false, false))
 		// alice@corp must appear exactly once even though she has two resources.
 		require.Equal(t, 1, bytes.Count(buf.Bytes(), []byte("alice@corp")))
 	})
@@ -253,20 +253,30 @@ func TestDisplayAccessReviewText(t *testing.T) {
 			}},
 		}}}
 		var buf bytes.Buffer
-		require.NoError(t, displayAccessReviewText(&buf, o, time.Time{}, time.Time{}, false))
+		require.NoError(t, displayAccessReviewText(&buf, o, time.Time{}, time.Time{}, false, false))
 		require.Contains(t, buf.String(), "break-glass*", "a temporary primary grantor should be marked")
+	})
+
+	t.Run("legend keys the marker in both views", func(t *testing.T) {
+		const legend = "* marks self-expiring access or a temporary grantor"
+		var summary, detailed bytes.Buffer
+		require.NoError(t, displayAccessReviewText(&summary, output, time.Time{}, time.Time{}, false, false))
+		require.NoError(t, displayAccessReviewText(&detailed, output, time.Time{}, time.Time{}, false, true))
+		require.Contains(t, summary.String(), legend)
+		require.Contains(t, detailed.String(), legend)
 	})
 
 	t.Run("empty result", func(t *testing.T) {
 		var buf bytes.Buffer
-		require.NoError(t, displayAccessReviewText(&buf, accessReviewOutput{}, time.Time{}, time.Time{}, false))
+		require.NoError(t, displayAccessReviewText(&buf, accessReviewOutput{}, time.Time{}, time.Time{}, false, false))
 		require.Contains(t, buf.String(), "No access found.")
+		require.NotContains(t, buf.String(), "* marks", "no legend without a table")
 	})
 
 	t.Run("warnings printed", func(t *testing.T) {
 		var buf bytes.Buffer
 		o := accessReviewOutput{Warnings: []string{"activity unavailable: boom"}}
-		require.NoError(t, displayAccessReviewText(&buf, o, time.Time{}, time.Time{}, false))
+		require.NoError(t, displayAccessReviewText(&buf, o, time.Time{}, time.Time{}, false, false))
 		require.Contains(t, buf.String(), "Warning: activity unavailable: boom")
 	})
 }
@@ -276,7 +286,7 @@ func TestDisplayAccessReviewText(t *testing.T) {
 // bounded — so naturally wide columns like Grantor Counts and Last Access are never
 // truncated just because the table has many columns.
 func TestBuildAccessTable(t *testing.T) {
-	headers := []string{"Identity", "Kind", "Resource", "Resource Kind", "Access Level", "Granted By", "Grantor Counts", "Accesses", "Last Access"}
+	headers := []string{"Identity", "Kind", "Resource", "Resource Kind", "Access Level", "Grantor", "Grantor Counts", "Accesses", "Last Access"}
 	rows := [][]string{
 		{"ghassan", "user", "teleport-mcp-demo", "app", "standing", "Local DB ACL", "3 standing, 1 request", "6", "2026-06-05T19:15:32-07:00"},
 	}
@@ -411,6 +421,7 @@ func TestAccessReviewFlags(t *testing.T) {
 		require.Equal(t, "SELECT * FROM access_path", c.accessReview.query)
 		require.Equal(t, 50, c.accessReview.limit)
 		require.Equal(t, teleport.Text, c.accessReview.format)
+		require.False(t, c.accessReview.detailed)
 		require.True(t, c.accessReview.from.IsZero())
 		require.True(t, c.accessReview.to.IsZero())
 	})


### PR DESCRIPTION
Issue: gravitational/access-graph#1933
RFC: gravitational/rfd#40


| #     | PR                          | What it does                          |
| ----- | --------------------------- | ------------------------------------- |
| 1     | `tctl-access-review-part-1` | Core `tctl access-review` command     |
| **2** | **this PR**                 | **Detailed per-grantor output**       |
| 3     | `tctl-access-review-part-3` | `access-review` skill                 |
| 4     | `tctl-access-review-part-4` | Eval for the access-review skill      |

This is the second slice of the access-review stack. Part 1 landed the core command, whose text output collapses each identity→resource pair to a single row: the resolved access level, the primary grantor, and per-level grantor counts. That summary answers "who can reach what" but hides *which* grantors back the access and at what level. This PR adds a `--detailed` view that expands that one row into the full grantor breakdown.

## What changed

- New `--[no-]detailed` flag on `tctl access-review`. In the text view it replaces the summary's "Grantor" (primary) and "Grantor Counts" columns with a per-grantor breakdown: a resource with a single grantor folds it onto the resource row, while a resource with multiple grantors renders a summary row (resolved level and, with a `--from`/`--to` window, the pair-level activity) followed by one indented `↳ grantor` row each, showing that grantor's individual level.
- A `*` legend is now printed under every non-empty table, keying the marker for self-expiring access and temporary grantors.
- Extracted the summary renderer's inline cell-building into shared helpers (`levelCell`, `activityCells`, `padActivity`) now used by both the summary and detailed renderers, and renamed the summary's "Granted By" column to "Grantor" so the two views share a label.

## Why

Reviewing effective access is rarely done at the summary level alone — once a reviewer spots an identity that can reach a sensitive resource, the next question is always *how*: which role, group, or access request grants it, and whether any path is standing versus temporary. The summary view deliberately answers the first-pass "who can reach what" question compactly; this PR gives reviewers the drill-down they need to act on a finding without leaving the CLI for the web UI, which is the whole point of putting access review in `tctl`. It also sets up the access-review skill in part 3, which leans on the per-grantor detail to explain *why* an identity has the access it does.

Changelog: Added a `--detailed` flag to `tctl access-review` that shows each grantor and its individual access level.

### Screenshot 
<img width="1299" height="754" alt="Screenshot 2026-06-30 at 4 17 08 PM" src="https://github.com/user-attachments/assets/a5b76c21-acad-460e-86c1-c3e8d5af74e7" />

## Manual Test Plan

### Test Environment

- Local dev cluster with an access-graph build running gravitational/access-graph#2028.

### Test Cases

- [X] `tctl access-review --query=... --detailed`: a resource with multiple grantors renders a summary row carrying the resolved level, then one indented `↳ grantor` row per grantor with its individual level.
- [X] A resource with a single grantor folds that grantor onto the resource row (no indented row).
- [X] Without `--detailed`, the summary view is unchanged (primary grantor + grantor counts), aside from the "Granted By" → "Grantor" header rename.
- [X] The `*` legend prints under the table; a self-expiring access level and a temporary grantor are both marked with `*`.
- [X] `--detailed` with a `--from`/`--to` window: activity columns sit on the resource summary row, and the per-grantor `↳` rows carry no activity.
- [X] `--detailed --format json` / `--format yaml`: the flag is a no-op (structured output already lists every grantor) and the output stays valid and complete.
- [X] Narrow terminal: the detailed table stays readable and only the Resource column truncates (minor overflow acceptable per the documented heuristic).