### PR TITLE
Refactor agentpool to track active agent wait group in the store

### DIFF
--- a/lib/reversetunnel/agent_store.go
+++ b/lib/reversetunnel/agent_store.go
@@ -19,18 +19,27 @@
 package reversetunnel
 
 import (
+	"sort"
 	"sync"
+	"time"
 )
 
 // agentStore handles adding and removing agents from an in memory store.
 type agentStore struct {
-	agents []Agent
+	agents map[Agent]agentStoreMeta
 	mu     sync.RWMutex
+	wg     sync.WaitGroup
+}
+
+type agentStoreMeta struct {
+	addedAt time.Time
 }
 
 // newAgentStore creates a new agentStore instance.
 func newAgentStore() *agentStore {
-	return &agentStore{}
+	return &agentStore{
+		agents: make(map[Agent]agentStoreMeta),
+	}
 }
 
 // len returns the number of agents in the store.
@@ -44,41 +53,86 @@ func (s *agentStore) len() int {
 func (s *agentStore) add(agent Agent) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.agents = append(s.agents, agent)
+
+	if _, ok := s.agents[agent]; ok {
+		return
+	}
+
+	s.wg.Add(1)
+	s.agents[agent] = agentStoreMeta{
+		addedAt: time.Now(),
+	}
 }
 
 // unsafeRemove removes an agent. Warning this is not threadsafe.
 func (s *agentStore) unsafeRemove(agent Agent) bool {
-	for i := range s.agents {
-		if s.agents[i] != agent {
-			continue
-		}
-		s.agents = append(s.agents[:i], s.agents[i+1:]...)
-		return true
+	if _, ok := s.agents[agent]; !ok {
+		return false
 	}
 
-	return false
+	delete(s.agents, agent)
+	return true
 }
 
 // remove removes the given agent from the store.
 func (s *agentStore) remove(agent Agent) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.unsafeRemove(agent)
+
+	if !s.unsafeRemove(agent) {
+		return false
+	}
+
+	s.wg.Done()
+	return true
 }
 
-// proxyIDs returns a list of proxy ids that each agent is connected to ordered
-// from newest to oldest connected proxy id.
+// wait blocks until all agents have been removed from the store.
+func (s *agentStore) wait() {
+	if s == nil {
+		return
+	}
+	s.wg.Wait()
+}
+
+// proxyIDs returns a list of proxy ids that each agent is connected to.
 func (s *agentStore) proxyIDs() []string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	ids := make([]string, 0, len(s.agents))
 
-	// New agents are always appended to the store so reversing the list
-	// orders the ids from newest to oldest.
-	for i := len(s.agents) - 1; i >= 0; i-- {
-		if id, ok := s.agents[i].GetProxyID(); ok {
+	for agent := range s.agents {
+		if id, ok := agent.GetProxyID(); ok {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// proxyIDsByJoinTime returns a list of proxy ids ordered from newest to oldest
+// connected proxy id.
+func (s *agentStore) proxyIDsByJoinTime() []string {
+	s.mu.RLock()
+	agents := make([]struct {
+		agent Agent
+		entry agentStoreMeta
+	}, 0, len(s.agents))
+	for agent, entry := range s.agents {
+		agents = append(agents, struct {
+			agent Agent
+			entry agentStoreMeta
+		}{agent: agent, entry: entry})
+	}
+	s.mu.RUnlock()
+
+	sort.Slice(agents, func(i, j int) bool {
+		return agents[i].entry.addedAt.After(agents[j].entry.addedAt)
+	})
+
+	ids := make([]string, 0, len(agents))
+	for _, agent := range agents {
+		if id, ok := agent.agent.GetProxyID(); ok {
 			ids = append(ids, id)
 		}
 	}
@@ -86,9 +140,9 @@ func (s *agentStore) proxyIDs() []string {
 }
 
 func (s *agentStore) getByProxyID(proxyID string) (Agent, bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	for _, agent := range s.agents {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for agent := range s.agents {
 		if id, ok := agent.GetProxyID(); ok && id == proxyID {
 			return agent, true
 		}

--- a/lib/reversetunnel/agent_store_test.go
+++ b/lib/reversetunnel/agent_store_test.go
@@ -21,6 +21,7 @@ package reversetunnel
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -60,6 +61,48 @@ func TestAgentStoreRace(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestAgentStoreDuplicateAgents(t *testing.T) {
+	store := newAgentStore()
+	agent := &testStoreAgent{proxyID: "proxy-1"}
+
+	store.add(agent)
+	store.add(agent)
+
+	require.Equal(t, 1, store.len())
+	require.Equal(t, []string{"proxy-1"}, store.proxyIDs())
+
+	require.True(t, store.remove(agent))
+	require.False(t, store.remove(agent))
+	require.Zero(t, store.len())
+
+	waitDone := make(chan struct{})
+	go func() {
+		store.wait()
+		close(waitDone)
+	}()
+
+	select {
+	case <-waitDone:
+	case <-time.After(time.Second):
+		t.Fatal("agent store did not drain")
+	}
+}
+
+func TestAgentStoreProxyIDsNewestFirst(t *testing.T) {
+	oldest := &testStoreAgent{proxyID: "proxy-1"}
+	newest := &testStoreAgent{proxyID: "proxy-2"}
+	middle := &testStoreAgent{proxyID: "proxy-3"}
+	store := &agentStore{
+		agents: map[Agent]agentStoreMeta{
+			oldest: {addedAt: time.Unix(1, 0)},
+			newest: {addedAt: time.Unix(3, 0)},
+			middle: {addedAt: time.Unix(2, 0)},
+		},
+	}
+
+	require.Equal(t, []string{"proxy-2", "proxy-3", "proxy-1"}, store.proxyIDsByJoinTime())
 }
 
 func TestAgentStoreGetByProxyID(t *testing.T) {

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -91,7 +91,7 @@ type AgentPool struct {
 	// newAgentFunc is used during testing to mock new agents.
 	newAgentFunc newAgentFunc
 
-	// wg waits for the pool and all agents to complete.
+	// wg waits for the pool loop to complete.
 	wg     sync.WaitGroup
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -248,7 +248,7 @@ func (p *AgentPool) updateConnectedProxies() {
 		return
 	}
 
-	proxies := p.active.proxyIDs()
+	proxies := p.active.proxyIDsByJoinTime()
 	p.logger.DebugContext(p.ctx, "Updating connected proxies", "proxies", proxies)
 	p.AgentPoolConfig.ConnectedProxyGetter.setProxyIDs(proxies)
 }
@@ -278,8 +278,7 @@ func (p *AgentPool) Start() error {
 // run connects agents until the agent pool context is done.
 func (p *AgentPool) run() error {
 	for {
-		agent, err := p.connectAgent(p.ctx, p.events)
-		if err != nil {
+		if _, err := p.connectAgent(p.ctx, p.events); err != nil {
 			if p.ctx.Err() != nil {
 				return nil
 			}
@@ -294,33 +293,17 @@ func (p *AgentPool) run() error {
 
 			p.logger.Log(p.ctx, level, "Failed to establish reverse tunnel", "error", err)
 		} else {
-			p.addActiveAgent(p.ctx, agent)
+			p.lastConnectivityChange = p.Clock.Now()
+			p.updateConnectedProxies()
 		}
 
-		err = p.waitForBackoff(p.ctx, p.events)
+		err := p.waitForBackoff(p.ctx, p.events)
 		if p.ctx.Err() != nil {
 			return nil
 		} else if err != nil {
 			p.logger.DebugContext(p.ctx, "Failed to wait for backoff", "error", err)
 		}
 	}
-}
-
-// addActiveAgent registers a successfully started agent with the pool.
-func (p *AgentPool) addActiveAgent(ctx context.Context, agent Agent) {
-	p.wg.Add(1)
-	p.active.add(agent)
-	p.lastConnectivityChange = p.Clock.Now()
-
-	if agent.GetState() == AgentClosed {
-		// The agent can close after Start succeeds but before run registers it.
-		// If the AgentClosed callback already ran, it could not remove the agent
-		// from the active set, so reconcile the state after registration.
-		p.handleEvent(ctx, agent)
-		return
-	}
-
-	p.updateConnectedProxies()
 }
 
 // connectAgent connects a new agent and processes any agent events blocking until a
@@ -438,7 +421,7 @@ func (p *AgentPool) tryDisconnect(ctx context.Context) {
 		return
 	}
 
-	proxyIDs := p.active.proxyIDs()
+	proxyIDs := p.active.proxyIDsByJoinTime()
 	snapshot := p.tracker.Snapshot()
 	if snapshot.ConnectionCount == 0 {
 		return
@@ -534,10 +517,9 @@ func (p *AgentPool) handleEvent(ctx context.Context, agent Agent) {
 	case AgentConnecting:
 		return
 	case AgentConnected:
+		p.active.add(agent)
 	case AgentClosed:
-		if ok := p.active.remove(agent); ok {
-			p.wg.Done()
-		}
+		p.active.remove(agent)
 	}
 	p.updateConnectedProxies()
 	p.logger.DebugContext(ctx, "Processed agent event", "active_agent_count", p.active.len())
@@ -633,7 +615,9 @@ func (p *AgentPool) Wait() {
 	}
 
 	<-p.ctx.Done()
+	// The run loop has to exit before we can wait for the agents to close.
 	p.wg.Wait()
+	p.active.wait()
 }
 
 // Stop stops the pool and waits for all resources to be released.
@@ -642,7 +626,9 @@ func (p *AgentPool) Stop() {
 		return
 	}
 	p.cancel()
+	// The run loop has to exit before we can wait for the agents to close.
 	p.wg.Wait()
+	p.active.wait()
 }
 
 // getVersion gets the connected auth server version.

--- a/lib/reversetunnel/agentpool_test.go
+++ b/lib/reversetunnel/agentpool_test.go
@@ -132,15 +132,29 @@ func setupTestAgentPool(t *testing.T) (*AgentPool, *mockClient) {
 	)
 	pool.newAgentFunc = func(ctx context.Context, tracker *track.Tracker, l *track.Lease) (Agent, error) {
 		agent := &mockAgent{}
+		var (
+			stateMu sync.Mutex
+			state   = AgentInitial
+		)
+		agent.mockGetState = func() AgentState {
+			stateMu.Lock()
+			defer stateMu.Unlock()
+			return state
+		}
 		agent.mockStart = func(ctx context.Context) error {
+			stateMu.Lock()
+			state = AgentConnected
+			stateMu.Unlock()
+			callback := pool.getStateCallback(agent)
+			go callback(AgentConnected)
 			return nil
 		}
 
 		go func() {
 			<-pool.ctx.Done()
-			agent.mockGetState = func() AgentState {
-				return AgentClosed
-			}
+			stateMu.Lock()
+			state = AgentClosed
+			stateMu.Unlock()
 			callback := pool.getStateCallback(agent)
 			callback(AgentClosed)
 		}()


### PR DESCRIPTION
This keeps the waitgroup increments/decrements close and avoids race conditions between adding the agent and incrementing the group if the agent happens to disconnect.

It also now relies on the agent events rather than both run loop and events. Modified the mock agent to also be event driven to match production.