### PR TITLE
Make helm linting support helm4

### DIFF
--- a/build.assets/tooling/cmd/helm-janitor/version.go
+++ b/build.assets/tooling/cmd/helm-janitor/version.go
@@ -40,7 +40,7 @@ func updateVersion(ctx context.Context, version string, charts []Chart) error {
 	return nil
 }
 
-var versionRegex = regexp.MustCompile(`\.version: .*`)
+var versionRegex = regexp.MustCompile(`(?m)^version:\s+&version\s+.*`)
 
 func updateChartVersion(ctx context.Context, chart Chart, version string) error {
 	version = strings.TrimPrefix(version, "v")
@@ -48,7 +48,7 @@ func updateChartVersion(ctx context.Context, chart Chart, version string) error 
 	if err != nil {
 		return trace.Wrap(trace.ConvertSystemError(err), "reading Chart.yaml")
 	}
-	newChartYaml := versionRegex.ReplaceAll(chartYaml, []byte(fmt.Sprintf(`.version: &version %q`, version)))
+	newChartYaml := versionRegex.ReplaceAll(chartYaml, []byte(fmt.Sprintf(`version: &version %q`, version)))
 	if bytes.Equal(chartYaml, newChartYaml) {
 		fmt.Printf(" ⚠️ Warning: Chart.yaml unchanged: %q\n", chart.Path)
 	}

--- a/build.assets/tooling/cmd/helm-janitor/version_test.go
+++ b/build.assets/tooling/cmd/helm-janitor/version_test.go
@@ -28,10 +28,8 @@ import (
 
 const (
 	testChartYaml = `
-.version: &version "1.2.3"
-
 name: test-chart
-version: *version
+version: &version "1.2.3"
 appVersion: *version
 
 dependencies:
@@ -39,10 +37,8 @@ dependencies:
     version: *version
 `
 	updatedTestChartYaml = `
-.version: &version "1.2.4-foobar"
-
 name: test-chart
-version: *version
+version: &version "1.2.4-foobar"
 appVersion: *version
 
 dependencies:

--- a/examples/chart/access/datadog/Chart.yaml
+++ b/examples/chart/access/datadog/Chart.yaml
@@ -1,10 +1,8 @@
-.version: &version "19.0.0-prealpha.2"
-
 apiVersion: v2
 name: teleport-plugin-datadog
 description: A Helm chart for the Teleport Datadog Incident Management Plugin
 type: application
-version: *version
+version: &version "19.0.0-prealpha.2"
 appVersion: *version
 
 dependencies:

--- a/examples/chart/access/discord/Chart.yaml
+++ b/examples/chart/access/discord/Chart.yaml
@@ -1,10 +1,8 @@
-.version: &version "19.0.0-prealpha.2"
-
 apiVersion: v2
 name: teleport-plugin-discord
 description: A Helm chart for the Teleport Discord Plugin
 type: application
-version: *version
+version: &version "19.0.0-prealpha.2"
 appVersion: *version
 
 dependencies:

--- a/examples/chart/access/email/Chart.yaml
+++ b/examples/chart/access/email/Chart.yaml
@@ -1,10 +1,8 @@
-.version: &version "19.0.0-prealpha.2"
-
 apiVersion: v2
 name: teleport-plugin-email
 description: A Helm chart for the Teleport Email Plugin
 type: application
-version: *version
+version: &version "19.0.0-prealpha.2"
 appVersion: *version
 
 dependencies:

--- a/examples/chart/access/jira/Chart.yaml
+++ b/examples/chart/access/jira/Chart.yaml
@@ -1,10 +1,8 @@
-.version: &version "19.0.0-prealpha.2"
-
 apiVersion: v2
 name: teleport-plugin-jira
 description: A Helm chart for the Teleport Jira Plugin
 type: application
-version: *version
+version: &version "19.0.0-prealpha.2"
 appVersion: *version
 
 dependencies:

--- a/examples/chart/access/mattermost/Chart.yaml
+++ b/examples/chart/access/mattermost/Chart.yaml
@@ -1,10 +1,8 @@
-.version: &version "19.0.0-prealpha.2"
-
 apiVersion: v2
 name: teleport-plugin-mattermost
 description: A Helm chart for the Teleport Mattermost Plugin
 type: application
-version: *version
+version: &version "19.0.0-prealpha.2"
 appVersion: *version
 
 dependencies:

--- a/examples/chart/access/msteams/Chart.yaml
+++ b/examples/chart/access/msteams/Chart.yaml
@@ -1,10 +1,8 @@
-.version: &version "19.0.0-prealpha.2"
-
 apiVersion: v2
 name: teleport-plugin-msteams
 description: A Helm chart for the Teleport MsTeams Plugin
 type: application
-version: *version
+version: &version "19.0.0-prealpha.2"
 appVersion: *version
 
 dependencies:

--- a/examples/chart/access/pagerduty/Chart.yaml
+++ b/examples/chart/access/pagerduty/Chart.yaml
@@ -1,10 +1,8 @@
-.version: &version "19.0.0-prealpha.2"
-
 apiVersion: v2
 name: teleport-plugin-pagerduty
 description: A Helm chart for the Teleport Pagerduty Plugin
 type: application
-version: *version
+version: &version "19.0.0-prealpha.2"
 appVersion: *version
 
 dependencies:

--- a/examples/chart/access/slack/Chart.yaml
+++ b/examples/chart/access/slack/Chart.yaml
@@ -1,10 +1,8 @@
-.version: &version "19.0.0-prealpha.2"
-
 apiVersion: v2
 name: teleport-plugin-slack
 description: A Helm chart for the Teleport Slack Plugin
 type: application
-version: *version
+version: &version "19.0.0-prealpha.2"
 appVersion: *version
 
 dependencies:

--- a/examples/chart/event-handler/Chart.yaml
+++ b/examples/chart/event-handler/Chart.yaml
@@ -1,10 +1,8 @@
-.version: &version "19.0.0-prealpha.2"
-
 apiVersion: v2
 name: teleport-plugin-event-handler
 description: A Helm chart for Teleport Event Handler Plugin
 type: application
-version: *version
+version: &version "19.0.0-prealpha.2"
 appVersion: *version
 
 dependencies:

--- a/examples/chart/lib/teleport-proxy-lib-test/Chart.yaml
+++ b/examples/chart/lib/teleport-proxy-lib-test/Chart.yaml
@@ -1,9 +1,7 @@
-.version: &version "19.0.0-prealpha.2"
-
 apiVersion: v2
 name: teleport-proxy-lib-test
 type: application
-version: *version
+version: &version "19.0.0-prealpha.2"
 appVersion: *version
 description: Test harness for teleport-proxy-lib. Not for installation.
 dependencies:

--- a/examples/chart/lib/teleport-proxy-lib/Chart.yaml
+++ b/examples/chart/lib/teleport-proxy-lib/Chart.yaml
@@ -1,9 +1,7 @@
-.version: &version "19.0.0-prealpha.2"
-
 apiVersion: v2
 name: teleport-proxy-lib
 type: library
-version: *version
+version: &version "19.0.0-prealpha.2"
 appVersion: *version
 description: |
   Library chart containing all the templates to deploy Teleport proxy.

--- a/examples/chart/lib/teleport-util-lib-test/Chart.yaml
+++ b/examples/chart/lib/teleport-util-lib-test/Chart.yaml
@@ -1,10 +1,7 @@
-.version: &version "19.0.0-prealpha.2"
-
-
 apiVersion: v2
 name: teleport-util-lib-test
 type: application
-version: *version
+version: &version "19.0.0-prealpha.2"
 appVersion: *version
 description: Test harness for teleport-util-lib. Not for installation.
 dependencies:

--- a/examples/chart/lib/teleport-util-lib/Chart.yaml
+++ b/examples/chart/lib/teleport-util-lib/Chart.yaml
@@ -1,9 +1,7 @@
-.version: &version "19.0.0-prealpha.2"
-
 apiVersion: v2
 name: teleport-util-lib
 type: library
-version: *version
+version: &version "19.0.0-prealpha.2"
 appVersion: *version
 description: |
   Library chart containing named templates used across multiple charts.

--- a/examples/chart/tbot-spiffe-daemon-set/Chart.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/Chart.yaml
@@ -1,8 +1,6 @@
-.version: &version "19.0.0-prealpha.2"
-
 name: tbot-spiffe-daemon-set
 apiVersion: v2
-version: *version
+version: &version "19.0.0-prealpha.2"
 appVersion: *version
 description: This chart deploys the Machine & Workload Identity agent, `tbot`, into your Kubernetes cluster and configures it for issuing SPIFFE SVIDs to other Kubernetes workloads.
 icon: https://goteleport.com/static/teleport-symbol-bimi.svg

--- a/examples/chart/tbot/Chart.yaml
+++ b/examples/chart/tbot/Chart.yaml
@@ -1,8 +1,6 @@
-.version: &version "19.0.0-prealpha.2"
-
 name: tbot
 apiVersion: v2
-version: *version
+version: &version "19.0.0-prealpha.2"
 appVersion: *version
 description: This chart deploys an instance of the Machine ID agent, TBot, into your Kubernetes cluster. This allows workloads running within Kubernetes to authenticate to your Teleport cluster.
 icon: https://goteleport.com/static/teleport-symbol-bimi.svg

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,8 +1,6 @@
-.version: &version "19.0.0-prealpha.2"
-
 name: teleport-cluster
 apiVersion: v2
-version: *version
+version: &version "19.0.0-prealpha.2"
 appVersion: *version
 description: Teleport is an access platform for your infrastructure
 icon: https://goteleport.com/static/teleport-symbol-bimi.svg

--- a/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
@@ -1,8 +1,6 @@
-.version: &version "19.0.0-prealpha.2"
-
 name: teleport-operator
 apiVersion: v2
-version: *version
+version: &version "19.0.0-prealpha.2"
 appVersion: *version
 description: Teleport Operator provides management of select Teleport resources.
 icon: https://goteleport.com/static/teleport-symbol-bimi.svg

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,8 +1,6 @@
-.version: &version "19.0.0-prealpha.2"
-
 name: teleport-kube-agent
 apiVersion: v2
-version: *version
+version: &version "19.0.0-prealpha.2"
 appVersion: *version
 description: Teleport provides a secure SSH, Kubernetes, database and application remote access solution that doesn't get in the way.
 icon: https://goteleport.com/static/teleport-symbol-bimi.svg

--- a/examples/chart/teleport-kube-updater/Chart.yaml
+++ b/examples/chart/teleport-kube-updater/Chart.yaml
@@ -1,8 +1,6 @@
-.version: &version "19.0.0-prealpha.2"
-
 name: teleport-kube-updater
 apiVersion: v2
-version: *version
+version: &version "19.0.0-prealpha.2"
 appVersion: *version
 type: library
 description: |

--- a/examples/chart/teleport-relay/Chart.yaml
+++ b/examples/chart/teleport-relay/Chart.yaml
@@ -1,8 +1,6 @@
-.version: &version "19.0.0-prealpha.2"
-
 name: teleport-relay
 apiVersion: v2
-version: *version
+version: &version "19.0.0-prealpha.2"
 appVersion: *version
 description: This chart deploys the Teleport Relay service.
 icon: https://goteleport.com/static/teleport-symbol-bimi.svg


### PR DESCRIPTION
# Fix helm linting for Helm 4

Fixes [#68312](https://github.com/gravitational/teleport/issues/68312)

helm4 lint strictly checks Chart.yaml schema, but we used .version to set a yaml
Anchor. This puts the anchor at the standard `version` field instead to allow
linting with either version.

Changelog: Fix helm linting with helm4

## Manual Test Plan

### Test Environment

- MacOS/helm4

### Test Cases

- [x] Make sure it works on helm4

```
$ helm version
version.BuildInfo{Version:"v4.1.0", GitCommit:"4553a0a96e5205595079b6757236cc6f969ed1b9", GitTreeState:"clean", GoVersion:"go1.25.6", KubeClientVersion:"v1.35"}
...

$ make lint-helm
"$( GOWORK=off CGO_ENABLED=0 go -C /Users/adamcarheden/src/github.com/gravitational/teleport/wip/helm4-lint/teleport/build.assets/tooling tool -n helm-janitor )" reference -check
Rendering reference for chart examples/chart/teleport-kube-agent
...
Rendering reference for chart examples/chart/tbot-spiffe-daemon-set
 ✅ All references are up-to-date
"$( GOWORK=off CGO_ENABLED=0 go -C /go/src/github.com/gravitational/teleport/build.assets/tooling tool -n helm-janitor )" lint
Running lint for chart: teleport-cluster
Running lint for chart: teleport-kube-agent
Running lint for chart: teleport-relay
Running lint for chart: teleport-operator
Running lint for chart: access-email
Running lint for chart: access-jira
Running lint for chart: access-mattermost
Running lint for chart: access-msteams
Running lint for chart: access-pagerduty
Running lint for chart: access-slack
Running lint for chart: access-discord
Running lint for chart: access-datadog
Running lint for chart: event-handler
Running lint for chart: tbot
Running lint for chart: tbot-spiffe-daemon-set
Running lint for chart: teleport-util-lib-test
Running lint for chart: teleport-proxy-lib-test
 ✅ Charts successfully linted.
version.BuildInfo{Version:"v3.12.2", GitCommit:"1e210a2c8cc5117d1055bfaa5d40f51bbc2e345e", GitTreeState:"clean", GoVersion:"go1.20.5"}
```

- [x] Make sure it still works on helm3 (github workflows also do this)

```
$ image="ghcr.io/gravitational/teleport-buildbox:teleport19"
$ container_dir="/go/src/github.com/gravitational/teleport"
$ helm_plugins="/home/ci/.local/share/helm/plugins-new"
$ docker run --rm -t \
  -v "$(pwd):${container_dir}:ro" \
  -w "${container_dir}" \
  -e CI=true \
  -e HELM_PLUGINS="${helm_plugins}" \
  "${image}" \
  /bin/bash -c 'helm version && make lint-helm && helm version'

version.BuildInfo{Version:"v3.12.2", GitCommit:"1e210a2c8cc5117d1055bfaa5d40f51bbc2e345e", GitTreeState:"clean", GoVersion:"go1.20.5"}
go: downloading go1.26.4 (linux/arm64)
"$( GOWORK=off CGO_ENABLED=0 go -C /go/src/github.com/gravitational/teleport/build.assets/tooling tool -n helm-janitor )" reference -check
go: downloading github.com/google/go-cmp v0.7.0
...
Rendering reference for chart examples/chart/tbot-spiffe-daemon-set
 ✅ All references are up-to-date
"$( GOWORK=off CGO_ENABLED=0 go -C /Users/adamcarheden/src/github.com/gravitational/teleport/wip/helm4-lint/teleport/build.assets/tooling tool -n helm-janitor )" lint
Running lint for chart: teleport-cluster
Running lint for chart: teleport-kube-agent
Running lint for chart: teleport-relay
Running lint for chart: teleport-operator
Running lint for chart: access-email
Running lint for chart: access-jira
Running lint for chart: access-mattermost
Running lint for chart: access-msteams
Running lint for chart: access-pagerduty
Running lint for chart: access-slack
Running lint for chart: access-discord
Running lint for chart: access-datadog
Running lint for chart: event-handler
Running lint for chart: tbot
Running lint for chart: tbot-spiffe-daemon-set
Running lint for chart: teleport-util-lib-test
Running lint for chart: teleport-proxy-lib-test
 ✅ Charts successfully linted.
```