### PR TITLE
Remove unused CertAuthorityOverride event codes

### DIFF
--- a/lib/events/codes.go
+++ b/lib/events/codes.go
@@ -945,15 +945,6 @@ const (
 	CertAuthOverrideUpsertCode = "TCO03I"
 	// CertAuthOverrideDeleteCode is the cert_auth_override delete event code.
 	CertAuthOverrideDeleteCode = "TCO04I"
-	// CertAuthOverrideCertificatesAddCode is the event code for specialized
-	// AddCertificateOverride operation.
-	CertAuthOverrideCertificatesAddCode = "TCO05I"
-	// CertAuthOverrideCertificatesUpdateCode is the event code for specialized
-	// UpdateCertificateOverride operation.
-	CertAuthOverrideCertificatesUpdateCode = "TCO06I"
-	// CertAuthOverrideCertificatesRemoveCode is the event code for specialized
-	// RemoveCertificateOverride operation.
-	CertAuthOverrideCertificatesRemoveCode = "TCO07I"
 
 	// BeamsConfigCreateCode is the Beams config create event code.
 	BeamsConfigCreateCode = "TBEAM001I"

--- a/lib/events/events_test.go
+++ b/lib/events/events_test.go
@@ -1262,9 +1262,6 @@ func TestEventCodesInWebTypes(t *testing.T) {
 		"WID004I":     true, // WorkloadIdentityX509RevocationCreateCode
 		"WID005I":     true, // WorkloadIdentityX509RevocationUpdateCode
 		"WID006I":     true, // WorkloadIdentityX509RevocationDeleteCode
-		"TCO05I":      true, // CertAuthOverrideCertificatesAddCode
-		"TCO06I":      true, // CertAuthOverrideCertificatesUpdateCode
-		"TCO07I":      true, // CertAuthOverrideCertificatesRemoveCode
 	}
 
 	codesFile, err := os.ReadFile("codes.go")


### PR DESCRIPTION
Remove unused event codes. These were superseded, during implementation, by CertAuthOverrideCreateCode, CertAuthOverrideUpdateCode and CertAuthOverrideDeleteCode (as appropriate).

No behavioral changes (dead code removal only).

https://github.com/gravitational/teleport.e/issues/7675