### PR TITLE
docs: Remove `--integration` flag from AWS OIDC guide

### DIFF
--- a/docs/pages/enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx
@@ -152,7 +152,7 @@ integration '<Var name="my-integration"/>' has been created
 To validate the integration without making a mutating AWS change, run:
 
 ```code
-$ tctl integrations test --integration=<Var name="my-integration"/>
+$ tctl integrations test <Var name="my-integration"/>
 ```
 
 If the integration is working, the command returns the AWS account ID and caller ARN from AWS STS `GetCallerIdentity`.


### PR DESCRIPTION
## Summary

The `tctl integrations test` command example added as part of #68086 includes a `--integration` flag instead of using a positional argument. The command was changed to use an argument instead of a flag and updating this docs guide was missed.

Will backport to v18 along with the changes from #68086.