### PR TITLE
[v17] cli: Fix bash autocomplete output

### DIFF
--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -429,6 +429,9 @@ func InitCLIParser(appName, appHelp string) (app *kingpin.Application) {
 func InitHiddenCLIParser() (app *kingpin.Application) {
 	app = kingpin.New("", "")
 	app.UsageWriter(io.Discard)
+	// HiddenHelpWriter suppresses flags like --completion-script-bash that override UsageWriter before writing.
+	// This prevents an unnecessary autocomplete from outputting.
+	app.HiddenHelpWriter(io.Discard)
 	app.Terminate(func(i int) {})
 
 	return app


### PR DESCRIPTION
Backport #66821 to branch/v17

## Manual Test Plan
### Test Environment
   Dev environment
### Test Cases
- [x] Confirm `usage: complete` message no longer occurring with `tsh` and `tctl`
- [x] Validate autocomplete working as expected for `tsh` 
- [x] Validate autocomplete working as expected for `tctl` 