### PR TITLE
[v18.10] Suppress IronRDP's decode tracing logs

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -120,6 +120,11 @@ func init() {
 		// TODO(zmb3): remove this after sspi-rs logging is cleaned up
 		rustLogLevel += ",sspi=warn"
 
+		// IronRDP instruments hot-path decode functions (e.g. RemoteFX process_frame) at INFO.
+		// With no tracing subscriber installed, tracing's `log` feature bridges those span
+		// records to env_logger as noisy non-JSON lines, so drop the span-lifecycle target.
+		rustLogLevel += ",tracing::span=off"
+
 		os.Setenv("RUST_LOG", rustLogLevel)
 	}
 


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/68324 to branch/v18.10.0