### PR TITLE
[v18] Remove unused CertAuthorityOverride event codes

### DIFF
--- a/lib/events/codes.go
+++ b/lib/events/codes.go
@@ -893,15 +893,6 @@ const (
 	CertAuthOverrideUpsertCode = "TCO03I"
 	// CertAuthOverrideDeleteCode is the cert_auth_override delete event code.
 	CertAuthOverrideDeleteCode = "TCO04I"
-	// CertAuthOverrideCertificatesAddCode is the event code for specialized
-	// AddCertificateOverride operation.
-	CertAuthOverrideCertificatesAddCode = "TCO05I"
-	// CertAuthOverrideCertificatesUpdateCode is the event code for specialized
-	// UpdateCertificateOverride operation.
-	CertAuthOverrideCertificatesUpdateCode = "TCO06I"
-	// CertAuthOverrideCertificatesRemoveCode is the event code for specialized
-	// RemoveCertificateOverride operation.
-	CertAuthOverrideCertificatesRemoveCode = "TCO07I"
 
 	// UnknownCode is used when an event of unknown type is encountered.
 	UnknownCode = apievents.UnknownCode

--- a/lib/events/events_test.go
+++ b/lib/events/events_test.go
@@ -1254,9 +1254,6 @@ func TestEventCodesInWebTypes(t *testing.T) {
 		"WID004I":     true, // WorkloadIdentityX509RevocationCreateCode
 		"WID005I":     true, // WorkloadIdentityX509RevocationUpdateCode
 		"WID006I":     true, // WorkloadIdentityX509RevocationDeleteCode
-		"TCO05I":      true, // CertAuthOverrideCertificatesAddCode
-		"TCO06I":      true, // CertAuthOverrideCertificatesUpdateCode
-		"TCO07I":      true, // CertAuthOverrideCertificatesRemoveCode
 	}
 
 	codesFile, err := os.ReadFile("codes.go")


### PR DESCRIPTION
Backport #68319 to branch/v18.

https://github.com/gravitational/teleport.e/issues/7675