### PR TITLE
Fix some docs papercuts that hindered an agent

### DIFF
--- a/docs/pages/enroll-resources/mcp-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/mcp-access/getting-started.mdx
@@ -41,6 +41,7 @@ activity.
 (!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport (v18.1.0 or higher)"!)
 - A host, e.g., an EC2 instance, where you will run the Teleport Applications
   Service.
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Configure the Teleport Application Service
 

--- a/docs/pages/enroll-resources/server-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/server-access/getting-started.mdx
@@ -151,10 +151,13 @@ configuration:
 ### Access the Web UI
 
 Run the following command to create a local user that can access the Teleport
-Web UI:
+Web UI and SSH into Teleport-protected servers. Replace 
+<Var name="root,ubuntu,ec2-user" /> with a comma-separated list of logins you
+know to exist on your target server, since this command grants the user
+permissions to SSH into Teleport-protected servers as those logins:
 
 ```code
-$ tctl users add myuser --roles=editor,access --logins=root,ubuntu,ec2-user
+$ tctl users add myuser --roles=editor,access --logins=<Var name="root,ubuntu,ec2-user" />
 ```
 
 This will generate an initial login link where you can create a password and set
@@ -273,7 +276,7 @@ which are used for establishing SSH connections:
 
 ```code
 # Use tsh to ssh into a server
-$ tsh ssh root@ip-172-31-41-144
+$ tsh ssh <Var name="root" />@ip-172-31-41-144
 ```
 
 Now, they can:
@@ -293,7 +296,7 @@ into a server using a third-party tool. Compare the two equivalent commands:
   <TabItem label="tsh">
 
     ```code
-    $ tsh ssh root@ip-172-31-41-144
+    $ tsh ssh <Var name="root" />@ip-172-31-41-144
     ```
 
   </TabItem>
@@ -304,7 +307,7 @@ into a server using a third-party tool. Compare the two equivalent commands:
 
     ```code
     $ tsh config > ssh_config_teleport
-    $ ssh -F ssh_config_teleport root@ip-172-31-41-144.example.teleport.sh
+    $ ssh -F ssh_config_teleport <Var name="root" />@ip-172-31-41-144.example.teleport.sh
     ```
 
   </TabItem>
@@ -358,11 +361,12 @@ that label since it remains unchanged.
 
 `myuser` can also execute commands on all servers that share a label, vastly
 simplifying repeated operations. For example, the following command will execute
-the `ls` command on each server and display the results in your terminal:
+the `ls` command on each server and display the results in your terminal.
+Replace <Var name="root" /> with a login that exists on the server:
 
 ```code
 # Run the ls command on all servers with a label
-$ tsh ssh root@env=example ls
+$ tsh ssh <Var name="root" />@env=example ls
 ```
 
 ## Optional: Harden your server

--- a/docs/pages/get-started/deploy-community.mdx
+++ b/docs/pages/get-started/deploy-community.mdx
@@ -59,10 +59,11 @@ requirements for your platform:
 <Tabs>
 <TabItem label="Remote virtual machine">
 
-- A Linux host with only port `443` open to ingress traffic. You must be able to
-  install and run software on the host. Either configure access to the host via
-  SSH for the initial setup (and open an SSH port in addition to port `443`) or
-  enter the commands in this guide into an Amazon EC2 [user data
+- A Linux host with only port `443` open to ingress traffic, and no existing
+  Teleport installation. You must be able to install and run software on the
+  host. Either configure access to the host via SSH for the initial setup (and
+  open an SSH port in addition to port `443`) or enter the commands in this
+  guide into an Amazon EC2 [user data
   script](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html),
   Google Compute Engine [startup
   script](https://cloud.google.com/compute/docs/instances/startup-scripts), or

--- a/docs/pages/identity-governance/locking.mdx
+++ b/docs/pages/identity-governance/locking.mdx
@@ -48,6 +48,43 @@ to prevent various operations, e.g., preventing access from a locked user.
 
 - (!docs/pages/includes/tctl.mdx!)
 
+- Your user must have permissions to manage Teleport lock resources. The preset
+  `editor` role has these permissions, though we recommend defining more
+  granular roles for security.
+
+  <details>
+  <summary>Grant permissions to your user</summary>
+
+    To grant your user permissions to manage locks:
+    
+    1. Define a role with the following permissions (this one is called
+       `locksmith`):
+    
+       ```yaml
+       kind: role
+       version: v5
+       metadata:
+         name: locksmith
+       spec:
+         allow:
+           rules:
+             - resources: [lock]
+               verbs: [list, create, read, update, delete]
+       ```
+    
+    1. Create the role:
+    
+       ```code
+       $ tctl create -f locksmith.yaml
+       # role 'locksmith' has been created
+       ```
+    
+       (!docs/pages/includes/create-role-using-web.mdx!)
+    
+    1. (!docs/pages/includes/add-role-to-user.mdx role="locksmith"!)
+
+  </details>
+
 ## Step 1/2. Create a lock
 
 You can create a new lock with the `tctl lock` command. Specify the lock target
@@ -127,43 +164,6 @@ with one of the following options:
   </TabItem>
 </Tabs>
 
-<details>
-<summary>Troubleshooting: failed to create a lock?</summary>
-
-If your user is missing a lock permission, you will get an error when creating
-a lock:
-
-```txt
-ERROR: access denied to perform action "create" on "lock"
-```
-
-Define a role `locksmith`:
-
-```yaml
-kind: role
-version: v5
-metadata:
-  name: locksmith
-spec:
-  allow:
-    rules:
-      - resources: [lock]
-        verbs: [list, create, read, update, delete]
-```
-
-Create the role:
-
-```code
-$ tctl create -f locksmith.yaml
-# role 'locksmith' has been created
-```
-
-(!docs/pages/includes/create-role-using-web.mdx!)
-
-(!docs/pages/includes/add-role-to-user.mdx role="locksmith"!)
-
-</details>
-
 With a lock in force, all established connections involving the lock's target
 get terminated while any new requests are rejected.
 
@@ -221,7 +221,11 @@ $ tctl rm locks/24679348-baff-4987-a2cd-e820ab7f9d2b
 lock "24679348-baff-4987-a2cd-e820ab7f9d2b" has been deleted
 ```
 
-Deleting a lock will allow new sessions or host connections.
+The change may take a moment to take effect as Teleport services that implement
+lock watchers need to pick up on it.
+
+Once the deletion has taken effect, your cluster will allow new sessions or host
+connections.
 
 ## Next steps: Locking modes
 


### PR DESCRIPTION
An LLM agent attempting to follow docs guides encountered the following small issues. This changes applies fixes.

- **deploy-community.mdx:** `teleport configure` exits with an error when a configuration file already exists. Require a fresh Linux host so `teleport configure` doesn't attempt to overwrite an existing config file.
- **server-access/getting-started.mdx:** The guide gives the user a role that can access logins that don't exist on the protected server. Tell the user to replace the list of logins with ones that exist on the target server when running `tctl users add`.
- **identity-governance/locking.mdx:** The guide includes RBAC instructions for managing locks only after having the user attempt to create a lock. Make sure the user has permissions to manage locks before the instructions to create one. Also explain that lock deletion takes some time to take effect, since the agent expected this to be immediate.
- **mcp-access/getting-started:** The agent couldn't follow the guide without `tctl`, so add the `tctl` prerequisite.
