### PR TITLE
Fix goroutine leak on failed SPDY upgrades

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1802,7 +1802,7 @@ func (f *Forwarder) execNonInteractive(ctx *authContext, req *http.Request, _ ht
 		}
 	}()
 
-	executor, err := f.getExecutor(sess, req)
+	executor, executorCleanup, err := f.getExecutor(sess, req)
 	if err != nil {
 		execEvent.Code = events.ExecFailureCode
 		execEvent.Error, execEvent.ExitCode = exitCode(err)
@@ -1810,6 +1810,7 @@ func (f *Forwarder) execNonInteractive(ctx *authContext, req *http.Request, _ ht
 		f.log.WarnContext(f.ctx, "Failed creating executor", "error", err)
 		return trace.Wrap(err)
 	}
+	defer executorCleanup()
 
 	streamOptions := proxy.options()
 	err = executor.StreamWithContext(req.Context(), streamOptions)
@@ -1985,11 +1986,12 @@ func (f *Forwarder) exec(authCtx *authContext, w http.ResponseWriter, req *http.
 
 // remoteExec forwards an exec request to a remote cluster.
 func (f *Forwarder) remoteExec(req *http.Request, sess *clusterSession, proxy *remoteCommandProxy) error {
-	executor, err := f.getExecutor(sess, req)
+	executor, executorCleanup, err := f.getExecutor(sess, req)
 	if err != nil {
 		f.log.WarnContext(req.Context(), "Failed creating executor", "error", err)
 		return trace.Wrap(err)
 	}
+	defer executorCleanup()
 	streamOptions := proxy.options()
 	err = executor.StreamWithContext(req.Context(), streamOptions)
 	if err != nil {
@@ -2045,10 +2047,11 @@ func (f *Forwarder) portForward(authCtx *authContext, w http.ResponseWriter, req
 		return nil, trace.Wrap(err)
 	}
 
-	dialer, err := f.getPortForwardDialer(sess, req)
+	dialer, dialerCleanup, err := f.getPortForwardDialer(sess, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	defer dialerCleanup()
 
 	auditSent := map[string]bool{} // Set of `addr`. Can be multiple ports on single call. Using bool to simplify the check.
 	var auditSentMu sync.Mutex
@@ -2414,10 +2417,10 @@ func (f *Forwarder) catchAll(authCtx *authContext, w http.ResponseWriter, req *h
 
 // getWebsocketRestConfig builds a [*rest.Config] configuration to be
 // used when upgrading requests via websocket.
-func (f *Forwarder) getWebsocketRestConfig(sess *clusterSession, req *http.Request) (*rest.Config, error) {
+func (f *Forwarder) getWebsocketRestConfig(sess *clusterSession, req *http.Request) (_ *rest.Config, cleanup func(), _ error) {
 	tlsConfig, useImpersonation, err := f.getTLSConfig(sess)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, nil, trace.Wrap(err)
 	}
 
 	upgradeRoundTripper := NewWebsocketRoundTripperWithDialer(roundTripperConfig{
@@ -2435,7 +2438,8 @@ func (f *Forwarder) getWebsocketRestConfig(sess *clusterSession, req *http.Reque
 		var err error
 		rt, err = sess.kubeAPICreds.wrapTransport(rt)
 		if err != nil {
-			return nil, trace.Wrap(err)
+			upgradeRoundTripper.Cleanup()
+			return nil, nil, trace.Wrap(err)
 		}
 	}
 	rt = tracehttp.NewTransport(rt)
@@ -2453,35 +2457,41 @@ func (f *Forwarder) getWebsocketRestConfig(sess *clusterSession, req *http.Reque
 			return rt
 		},
 	}
-	return cfg, nil
+	return cfg, upgradeRoundTripper.Cleanup, nil
 }
 
-func (f *Forwarder) getWebsocketExecutor(sess *clusterSession, req *http.Request) (remotecommand.Executor, error) {
+func (f *Forwarder) getWebsocketExecutor(sess *clusterSession, req *http.Request) (_ remotecommand.Executor, cleanup func(), _ error) {
 	f.log.DebugContext(req.Context(), "Creating websocket remote executor for request",
 		"request_method", req.Method,
 		"request_uri", req.RequestURI,
 	)
-	cfg, err := f.getWebsocketRestConfig(sess, req)
+	cfg, wsCleanup, err := f.getWebsocketRestConfig(sess, req)
 	if err != nil {
-		return nil, trace.Wrap(err, "unable to create websocket executor")
+		return nil, nil, trace.Wrap(err, "unable to create websocket executor")
 	}
-	return remotecommand.NewWebSocketExecutor(cfg, req.Method, req.URL.String())
+	executor, err := remotecommand.NewWebSocketExecutor(cfg, req.Method, req.URL.String())
+	if err != nil {
+		wsCleanup()
+		return nil, nil, trace.Wrap(err, "unable to create websocket executor")
+	}
+	return executor, wsCleanup, nil
 }
 
 func isRelevantWebsocketError(err error) bool {
 	return err != nil && !strings.Contains(err.Error(), "next reader: EOF")
 }
 
-func (f *Forwarder) getExecutor(sess *clusterSession, req *http.Request) (remotecommand.Executor, error) {
-	wsExec, err := f.getWebsocketExecutor(sess, req)
+func (f *Forwarder) getExecutor(sess *clusterSession, req *http.Request) (_ remotecommand.Executor, cleanup func(), _ error) {
+	wsExec, wsCleanup, err := f.getWebsocketExecutor(sess, req)
 	if err != nil {
-		return nil, trace.Wrap(err, "unable to create websocket executor")
+		return nil, nil, trace.Wrap(err, "unable to create websocket executor")
 	}
-	spdyExec, err := f.getSPDYExecutor(sess, req)
+	spdyExec, spdyCleanup, err := f.getSPDYExecutor(sess, req)
 	if err != nil {
-		return nil, trace.Wrap(err, "unable to create spdy executor")
+		wsCleanup()
+		return nil, nil, trace.Wrap(err, "unable to create spdy executor")
 	}
-	return remotecommand.NewFallbackExecutor(
+	executor, err := remotecommand.NewFallbackExecutor(
 		wsExec,
 		spdyExec,
 		func(err error) bool {
@@ -2491,9 +2501,15 @@ func (f *Forwarder) getExecutor(sess *clusterSession, req *http.Request) (remote
 				kubeerrors.IsForbidden(err) ||
 				isTeleportUpgradeFailure(err)
 		})
+	if err != nil {
+		wsCleanup()
+		spdyCleanup()
+		return nil, nil, trace.Wrap(err, "unable to create fallback executor")
+	}
+	return executor, func() { wsCleanup(); spdyCleanup() }, nil
 }
 
-func (f *Forwarder) getSPDYExecutor(sess *clusterSession, req *http.Request) (remotecommand.Executor, error) {
+func (f *Forwarder) getSPDYExecutor(sess *clusterSession, req *http.Request) (_ remotecommand.Executor, cleanup func(), _ error) {
 	f.log.DebugContext(req.Context(), "Creating SPDY remote executor for request",
 		"request_method", req.Method,
 		"request_uri", req.RequestURI,
@@ -2501,7 +2517,7 @@ func (f *Forwarder) getSPDYExecutor(sess *clusterSession, req *http.Request) (re
 
 	tlsConfig, useImpersonation, err := f.getTLSConfig(sess)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, nil, trace.Wrap(err)
 	}
 
 	upgradeRoundTripper := NewSpdyRoundTripperWithDialer(roundTripperConfig{
@@ -2519,23 +2535,31 @@ func (f *Forwarder) getSPDYExecutor(sess *clusterSession, req *http.Request) (re
 		var err error
 		rt, err = sess.kubeAPICreds.wrapTransport(rt)
 		if err != nil {
-			return nil, trace.Wrap(err)
+			upgradeRoundTripper.Cleanup()
+			return nil, nil, trace.Wrap(err)
 		}
 	}
 	rt = tracehttp.NewTransport(rt)
 
-	return remotecommand.NewSPDYExecutorForTransports(rt, upgradeRoundTripper, req.Method, req.URL)
-}
-
-func (f *Forwarder) getPortForwardDialer(sess *clusterSession, req *http.Request) (httpstream.Dialer, error) {
-	wsDialer, err := f.getWebsocketDialer(sess, req)
+	executor, err := remotecommand.NewSPDYExecutorForTransports(rt, upgradeRoundTripper, req.Method, req.URL)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		upgradeRoundTripper.Cleanup()
+		return nil, nil, trace.Wrap(err)
 	}
 
-	spdyDialer, err := f.getSPDYDialer(sess, req)
+	return executor, upgradeRoundTripper.Cleanup, nil
+}
+
+func (f *Forwarder) getPortForwardDialer(sess *clusterSession, req *http.Request) (_ httpstream.Dialer, cleanup func(), _ error) {
+	wsDialer, wsCleanup, err := f.getWebsocketDialer(sess, req)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, nil, trace.Wrap(err)
+	}
+
+	spdyDialer, spdyCleanup, err := f.getSPDYDialer(sess, req)
+	if err != nil {
+		wsCleanup()
+		return nil, nil, trace.Wrap(err)
 	}
 
 	return portforward.NewFallbackDialer(wsDialer, spdyDialer, func(err error) bool {
@@ -2544,17 +2568,17 @@ func (f *Forwarder) getPortForwardDialer(sess *clusterSession, req *http.Request
 			httpstream.IsHTTPSProxyError(err) ||
 			kubeerrors.IsForbidden(err) ||
 			isTeleportUpgradeFailure(err)
-	}), nil
+	}), func() { wsCleanup(); spdyCleanup() }, nil
 }
 
 // getSPDYDialer returns a dialer that can be used to upgrade the connection
 // to SPDY protocol.
 // SPDY is a deprecated protocol, but it is still used by kubectl to manage data streams.
 // The dialer uses an HTTP1.1 connection to upgrade to SPDY.
-func (f *Forwarder) getSPDYDialer(sess *clusterSession, req *http.Request) (httpstream.Dialer, error) {
+func (f *Forwarder) getSPDYDialer(sess *clusterSession, req *http.Request) (_ httpstream.Dialer, cleanup func(), _ error) {
 	tlsConfig, useImpersonation, err := f.getTLSConfig(sess)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, nil, trace.Wrap(err)
 	}
 
 	req = createSPDYRequest(req, PortForwardProtocolV1Name)
@@ -2573,23 +2597,24 @@ func (f *Forwarder) getSPDYDialer(sess *clusterSession, req *http.Request) (http
 		var err error
 		rt, err = sess.kubeAPICreds.wrapTransport(rt)
 		if err != nil {
-			return nil, trace.Wrap(err)
+			upgradeRoundTripper.Cleanup()
+			return nil, nil, trace.Wrap(err)
 		}
 	}
 	client := &http.Client{
 		Transport: tracehttp.NewTransport(rt),
 	}
 
-	return spdy.NewDialer(upgradeRoundTripper, client, req.Method, req.URL), nil
+	return spdy.NewDialer(upgradeRoundTripper, client, req.Method, req.URL), upgradeRoundTripper.Cleanup, nil
 }
 
-func (f *Forwarder) getWebsocketDialer(sess *clusterSession, req *http.Request) (httpstream.Dialer, error) {
-	cfg, err := f.getWebsocketRestConfig(sess, req)
+func (f *Forwarder) getWebsocketDialer(sess *clusterSession, req *http.Request) (_ httpstream.Dialer, cleanup func(), _ error) {
+	cfg, wsCleanup, err := f.getWebsocketRestConfig(sess, req)
 	if err != nil {
-		return nil, trace.Wrap(err, "unable to retrieve *rest.Config for websocket")
+		return nil, nil, trace.Wrap(err, "unable to retrieve *rest.Config for websocket")
 	}
 	dialer, err := portforward.NewSPDYOverWebsocketDialer(req.URL, cfg)
-	return dialer, trace.Wrap(err)
+	return dialer, wsCleanup, trace.Wrap(err)
 }
 
 // createSPDYRequest modifies the passed request to remove

--- a/lib/kube/proxy/roundtrip.go
+++ b/lib/kube/proxy/roundtrip.go
@@ -258,7 +258,14 @@ func (s *SpdyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 func (s *SpdyRoundTripper) NewConnection(resp *http.Response) (httpstream.Connection, error) {
 	connectionHeader := strings.ToLower(resp.Header.Get(httpstream.HeaderConnection))
 	upgradeHeader := strings.ToLower(resp.Header.Get(httpstream.HeaderUpgrade))
-	if (resp.StatusCode != http.StatusSwitchingProtocols) || !strings.Contains(connectionHeader, strings.ToLower(httpstream.HeaderUpgrade)) || !strings.Contains(upgradeHeader, strings.ToLower(streamspdy.HeaderSpdy31)) {
+	if (resp.StatusCode != http.StatusSwitchingProtocols) ||
+		!strings.Contains(connectionHeader, strings.ToLower(httpstream.HeaderUpgrade)) ||
+		!strings.Contains(upgradeHeader, strings.ToLower(streamspdy.HeaderSpdy31)) {
+		// The upgrade was rejected. Close the conn so that we don't leak an
+		// io.Copy goroutine.
+		if s.conn != nil {
+			_ = s.conn.Close()
+		}
 		return nil, trace.Wrap(extractKubeAPIStatusFromReq(resp))
 	}
 

--- a/lib/kube/proxy/roundtrip.go
+++ b/lib/kube/proxy/roundtrip.go
@@ -58,6 +58,20 @@ type SpdyRoundTripper struct {
 	*/
 	// conn is the underlying network connection to the remote server.
 	conn net.Conn
+
+	// cleanups contains objects that should be closed when the roundtripper is
+	// no longer used. [SpdyRoundTripper.Cleanup] should be called to ensure
+	// that.
+	cleanups []io.Closer
+}
+
+// Cleanup ensures that every connection that was opened by this roundtripper is
+// closed.
+func (w *SpdyRoundTripper) Cleanup() {
+	for _, closer := range w.cleanups {
+		_ = closer.Close()
+	}
+	w.cleanups = nil
 }
 
 var (
@@ -237,6 +251,7 @@ func (s *SpdyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 		return nil, err
 	}
 
+	s.cleanups = append(s.cleanups, conn)
 	s.conn = conn
 
 	return resp, nil

--- a/lib/kube/proxy/roundtrip.go
+++ b/lib/kube/proxy/roundtrip.go
@@ -18,7 +18,6 @@ package proxy
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -213,38 +212,28 @@ func (s *SpdyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 		return nil, trace.Wrap(err)
 	}
 
-	var (
-		conn        net.Conn
-		rawResponse []byte
-		err         error
-	)
-
 	// If we're using identity forwarding, we need to add the impersonation
 	// headers to the request before we send the request.
 	if s.useIdentityForwarding {
-		if header, err = internal.IdentityForwardingHeaders(s.ctx, header); err != nil {
+		h, err := internal.IdentityForwardingHeaders(s.ctx, header)
+		if err != nil {
 			return nil, trace.Wrap(err)
 		}
+		header = h
 	}
 
 	clone := utilnet.CloneRequest(req)
 	clone.Header = header
-	conn, err = s.Dial(clone)
+	conn, err := s.Dial(clone)
 	if err != nil {
 		return nil, err
 	}
 
-	responseReader := bufio.NewReader(
-		io.MultiReader(
-			bytes.NewBuffer(rawResponse),
-			conn,
-		),
-	)
+	responseReader := bufio.NewReader(conn)
+
 	resp, err := http.ReadResponse(responseReader, nil)
 	if err != nil {
-		if conn != nil {
-			conn.Close()
-		}
+		conn.Close()
 		return nil, err
 	}
 

--- a/lib/kube/proxy/roundtrip.go
+++ b/lib/kube/proxy/roundtrip.go
@@ -256,16 +256,19 @@ func (s *SpdyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 // NewConnection validates the upgrade response, creating and returning a new
 // httpstream.Connection if there were no errors.
 func (s *SpdyRoundTripper) NewConnection(resp *http.Response) (httpstream.Connection, error) {
+	if s.conn == nil {
+		return nil, trace.Wrap(&upgradeFailureError{
+			Cause: errors.New("unable to upgrade connection: broken roundtripper setup, connection is missing but it should be present (this is a bug)"),
+		})
+	}
 	connectionHeader := strings.ToLower(resp.Header.Get(httpstream.HeaderConnection))
 	upgradeHeader := strings.ToLower(resp.Header.Get(httpstream.HeaderUpgrade))
 	if (resp.StatusCode != http.StatusSwitchingProtocols) ||
 		!strings.Contains(connectionHeader, strings.ToLower(httpstream.HeaderUpgrade)) ||
 		!strings.Contains(upgradeHeader, strings.ToLower(streamspdy.HeaderSpdy31)) {
-		// The upgrade was rejected. Close the conn so that we don't leak an
-		// io.Copy goroutine.
-		if s.conn != nil {
-			_ = s.conn.Close()
-		}
+		// The upgrade was rejected. Close the conn after reading the response
+		// error so that we don't leak an io.Copy goroutine.
+		defer s.conn.Close()
 		return nil, trace.Wrap(extractKubeAPIStatusFromReq(resp))
 	}
 

--- a/lib/kube/proxy/roundtrip_test.go
+++ b/lib/kube/proxy/roundtrip_test.go
@@ -1,0 +1,61 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package proxy
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// closeTrackingConn is a net.Conn that records whether Close was called.
+type closeTrackingConn struct {
+	net.Conn
+	closed atomic.Bool
+}
+
+func (c *closeTrackingConn) Close() error {
+	c.closed.Store(true)
+	return nil
+}
+
+// TestSPDYFailedUpgrade ensures that when a SPDY upgrade request fails
+// (RBAC rejection, pod doesn't exist, etc) the connection is closed.
+func TestSPDYFailedUpgrade(t *testing.T) {
+	conn := &closeTrackingConn{}
+	rt := &SpdyRoundTripper{conn: conn}
+
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Header:     http.Header{},
+		Body: io.NopCloser(strings.NewReader(
+			`{"kind":"Status","apiVersion":"v1","status":"Failure","message":"forbidden","code":403}`,
+		)),
+	}
+
+	upgraded, err := rt.NewConnection(resp)
+	require.Error(t, err, "a non-101 response must be rejected")
+	require.Nil(t, upgraded)
+	require.True(t, conn.closed.Load(), "dialed connection must be closed when the SPDY upgrade is rejected")
+}

--- a/lib/kube/proxy/roundtrip_websocket.go
+++ b/lib/kube/proxy/roundtrip_websocket.go
@@ -20,6 +20,7 @@ package proxy
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 
 	gwebsocket "github.com/gorilla/websocket"
@@ -40,10 +41,23 @@ type WebsocketRoundTripper struct {
 	// conn is the websocket network connection to the remote server.
 	conn *gwebsocket.Conn
 
+	// cleanups contains objects that should be closed when the roundtripper is
+	// no longer used. Cleared by [WebsocketRoundTripper.Cleanup].
+	cleanups []io.Closer
+
 	// onConnected is a hook that happens when connection was successfully established,
 	// can be used to propagate established connection somewhere else - we are using it
 	// to set underlying connection of the native k8s websocket executor.
 	onConnected func(conn *gwebsocket.Conn)
+}
+
+// Cleanup ensures that every connection that was opened by this roundtripper is
+// closed.
+func (w *WebsocketRoundTripper) Cleanup() {
+	for _, closer := range w.cleanups {
+		_ = closer.Close()
+	}
+	w.cleanups = nil
 }
 
 // NewWebsocketRoundTripperWithDialer creates a new WebsocketRoundTripper that will
@@ -103,6 +117,7 @@ func (w *WebsocketRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 		}
 		return nil, &httpstream.UpgradeFailureError{Cause: err}
 	}
+	w.cleanups = append(w.cleanups, wsConn)
 	w.conn = wsConn
 	if w.onConnected != nil {
 		w.onConnected(wsConn)

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -720,13 +720,12 @@ func (s *session) launch(ephemeralContainerStatus *corev1.ContainerStatus) (retu
 		s.log.WarnContext(s.forwarder.ctx, "Failed to set tracker state to running", "error", err)
 	}
 
-	var executor remotecommand.Executor
-
-	executor, err = s.forwarder.getExecutor(s.sess, s.req)
+	executor, executorCleanup, err := s.forwarder.getExecutor(s.sess, s.req)
 	if err != nil {
 		s.log.WarnContext(s.forwarder.ctx, "Failed creating executor", "error", err)
 		return trace.Wrap(err)
 	}
+	defer executorCleanup()
 
 	options := remotecommand.StreamOptions{
 		Stdin:             s.io,


### PR DESCRIPTION
If a SPDY upgrade failed (due to Teleport RBAC or a Kube API error) we would return an error but never close the underlying connection. Depending on the Teleport component and the path of the connection, this can lead to runaway memory consumption.

This PR ensures that the connection is closed if the SPDY upgrade fails, and surfaces a cleanup function from both `lib/kube/proxy.SpdyRoundTripper` and `WebsocketRoundTripper` up to the point where the connection is handled, to limit the blast radius of any future bugs similar to this.

changelog: fixed a resource leak in Kubernetes Access when exec or port forward requests hit certain failure paths during connection establishment when using SPDY

## Manual Test Plan

### Test Environment

`teleport-cluster` and `teleport-kube-agent` charts on AKS with builds off of this PR that forcibly use SPDY and have additional logging.

### Test Cases

- [x] `kubectl exec` works
- [x] `kubectl port-forward` works
- [x] The error case that led to the leak is hittable
  - I wasn't able to replicate this on the Proxy, but it can be triggered very easily on the Kubernetes Service agent by trying to exec into a pod that's being deleted