### PR TITLE
Fix docs paper cuts found by an agent

### DIFF
--- a/docs/pages/enroll-resources/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/register-clusters/iam-joining.mdx
@@ -79,7 +79,7 @@ $ aws iam create-policy --policy-name <Var name="kube-iam-policy"/> --policy-doc
     "Policy": {
         "PolicyName": "<Var name="kube-iam-policy"/>",
         "PolicyId": "ANPAW2Y2Q2Y2Y2Y2Y2Y2Y",
-        "Arn": "arn:aws:iam::aws:policy/<Var name="kube-iam-policy"/>",
+        "Arn": "arn:aws:iam::123456789012:policy/<Var name="kube-iam-policy"/>",
         "Path": "/",
         "DefaultVersionId": "v1",
         "AttachmentCount": 0,
@@ -98,8 +98,10 @@ using it or you can use the AWS CLI method.
 
 <Tabs>
 <TabItem label="Using eksctl">
-`eksctl` supports automatic creation of new IAM roles and mapping it into the Kubernetes Service
-  Account in the target namespace.
+
+`eksctl` supports automatic creation of new IAM roles and mapping it into the
+Kubernetes Service Account in the target namespace. Make sure to assign
+<Var name="aws-account-id" /> to your AWS account ID:
 
 ```code
 $ eksctl create iamserviceaccount \
@@ -107,7 +109,7 @@ $ eksctl create iamserviceaccount \
     --namespace <Var name="teleport-agent"/> \
     --cluster <Var name="kube-cluster"/> \
     --region <Var name="aws-region"/> \
-    --attach-policy-arn arn:aws:iam::aws:policy/<Var name="kube-iam-policy"/> \
+    --attach-policy-arn arn:aws:iam::<Var name="aws-account-id" />:policy/<Var name="kube-iam-policy"/> \
     --role-name <Var name="kube-iam-role"/> \
     --approve
 ```

--- a/docs/pages/enroll-resources/mcp-access/enrolling-mcp-servers/stdio.mdx
+++ b/docs/pages/enroll-resources/mcp-access/enrolling-mcp-servers/stdio.mdx
@@ -64,7 +64,8 @@ app_service:
       # Args to execute with the command.
       args: ["run", "-i", "--rm", "mcp/everything"]
       # Name of the host user account under which the command will be
-      # executed. Required for stdio-based MCP servers.
+      # executed. Required for stdio-based MCP servers. The user account must
+      # exist on the host before you run the Teleport Application Service.
       run_as_host_user: "docker"
 ```
 

--- a/docs/pages/enroll-resources/server-access/guides/auditd.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/auditd.mdx
@@ -19,7 +19,8 @@ You can configure Teleport's SSH Service to integrate with the Linux Auditing Sy
 
 - A running Teleport Agent instance. See the [getting started guide](../getting-started.mdx) for  how to add an agent to your Teleport cluster. On the agent, `teleport` must be running as a systemd service with root permissions.
 - Linux kernel 2.6.6+ compiled with `CONFIG_AUDIT`. Most Linux distributions have this option enabled by default.
-- `auditctl` to check auditd status (optional).
+- `auditctl` to check auditd status. You must install the `auditd` package to
+  follow the command examples in this guide.
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Check system configuration

--- a/docs/pages/includes/mcp-access/integration-teleport-app-rewrite.mdx
+++ b/docs/pages/includes/mcp-access/integration-teleport-app-rewrite.mdx
@@ -44,7 +44,7 @@ spec:
 
 Create the `app` resource with:
 ```code
-$ tctl create -f app-{{service}}-app.yaml
+$ tctl create -f app-{{service}}-mcp.yaml
 ```
 </TabItem>
 
@@ -55,7 +55,7 @@ with the host running the {{serviceName}} MCP server:
 resource "teleport_app" "grafana" {
   version = "v3"
   metadata = {
-    name = "grafana"
+    name = "{{service}}-mcp"
     labels = {
       "teleport.dev/origin" = "dynamic"
       "env"                 = "dev"


### PR DESCRIPTION
- **mcp-access/integration-teleport-app-rewrite.mdx:** Fix a mismatch between the file path of a tctl manifest and the corresponding `tctl create` command. Use consistent resource names between tab items.
- **stdio.mdx:** Indicate that the `run_as_host_user` login must exist on the system.
- **auditd.mdx:** Make installing auditd a hard requirement for following command examples, rather than indicating that it's optional and then having the first command example be an `auditctl` command, which is confusing.
- **iam-joining.mdx:** Use a custom policy ARN instead of a managed one.