### PR TITLE
Fix Openssh Access When Agent Pin is Enabled

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -19,7 +19,6 @@
 package auth
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -256,34 +255,21 @@ type upsertServerRawReq struct {
 	TTL    time.Duration   `json:"ttl"`
 }
 
-// presenceForAPIServer is a subset of [services.Presence].
-type presenceForAPIServer interface {
-	UpsertNode(ctx context.Context, s types.Server) (*types.KeepAlive, error)
-	UpsertProxyServer(ctx context.Context, s types.Server) (types.Server, error)
-}
-
-// upsertServer is a common utility function
-func (s *APIServer) upsertServer(auth presenceForAPIServer, role types.SystemRole, r *http.Request, p httprouter.Params) (any, error) {
+// upsertProxy registers a proxy server heartbeat sent via the legacy HTTP endpoint.
+//
+// TODO(noah): move to httpMigratedHandler in v20.0.0
+func (s *APIServer) upsertProxy(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (any, error) {
 	var req upsertServerRawReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	var kind string
-	switch role {
-	case types.RoleNode:
-		kind = types.KindNode
-	case types.RoleProxy:
-		kind = types.KindProxy
-	default:
-		return nil, trace.BadParameter("upsertServer with unknown role: %q", role)
-	}
-	// UnmarshalServer forces s.Kind = kind, ignoring the Kind in the payload.
+	// UnmarshalServer forces s.Kind = KindProxy, ignoring the Kind in the payload.
 	// This is retained for backwards compatibility: prior to v19, proxy
 	// heartbeats sent the resource with Kind=KindNode over the wire (see
 	// https://github.com/gravitational/teleport/issues/66997). v19+ proxies
 	// send the correct kind; the override remains so older proxies in mixed
 	// clusters continue to work.
-	server, err := services.UnmarshalServer(req.Server, kind)
+	server, err := services.UnmarshalServer(req.Server, types.KindProxy)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -293,33 +279,10 @@ func (s *APIServer) upsertServer(auth presenceForAPIServer, role types.SystemRol
 	if req.TTL != 0 {
 		server.SetExpiry(s.Now().UTC().Add(req.TTL))
 	}
-	switch role {
-	case types.RoleNode:
-		namespace := p.ByName("namespace")
-		if !types.IsValidNamespace(namespace) {
-			return nil, trace.BadParameter("invalid namespace %q", namespace)
-		}
-		server.SetNamespace(namespace)
-		handle, err := auth.UpsertNode(r.Context(), server)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return handle, nil
-	case types.RoleProxy:
-		if _, err := auth.UpsertProxyServer(r.Context(), server); err != nil {
-			return nil, trace.Wrap(err)
-		}
-	default:
-		return nil, trace.BadParameter("unknown server role %q", role)
+	if _, err := auth.UpsertProxyServer(r.Context(), server); err != nil {
+		return nil, trace.Wrap(err)
 	}
 	return message("ok"), nil
-}
-
-// upsertProxy is called by remote SSH nodes when they ping back into the auth service
-//
-// TODO(noah): move to httpMigratedHandler in v20.0.0
-func (s *APIServer) upsertProxy(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (any, error) {
-	return s.upsertServer(auth, types.RoleProxy, r, p)
 }
 
 // getProxies returns registered proxies

--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -19,131 +19,14 @@
 package auth_test
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/julienschmidt/httprouter"
 	"github.com/stretchr/testify/require"
 
-	apidefaults "github.com/gravitational/teleport/api/defaults"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
-	"github.com/gravitational/teleport/lib/services"
 )
-
-// TODO(noah): In a separate PR soon, nuke this test. We cover this elsewhere
-// much better. This test awkwardly skips some important layers.
-func TestUpsertServer(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	const remoteAddr = "request-remote-addr"
-
-	tests := []struct {
-		desc       string
-		role       types.SystemRole
-		reqServer  types.Server
-		wantServer types.Server
-		assertErr  require.ErrorAssertionFunc
-	}{
-		{
-			desc: "node",
-			reqServer: &types.ServerV2{
-				Metadata: types.Metadata{Name: "test-server", Namespace: apidefaults.Namespace},
-				Version:  types.V2,
-				Kind:     types.KindNode,
-			},
-			role: types.RoleNode,
-			wantServer: &types.ServerV2{
-				Metadata: types.Metadata{Name: "test-server", Namespace: apidefaults.Namespace},
-				Version:  types.V2,
-				Kind:     types.KindNode,
-			},
-			assertErr: require.NoError,
-		},
-		{
-			desc: "proxy",
-			reqServer: &types.ServerV2{
-				Metadata: types.Metadata{Name: "test-server", Namespace: apidefaults.Namespace},
-				Version:  types.V2,
-				Kind:     types.KindProxy,
-			},
-			role: types.RoleProxy,
-			wantServer: &types.ServerV2{
-				Metadata: types.Metadata{Name: "test-server", Namespace: apidefaults.Namespace},
-				Version:  types.V2,
-				Kind:     types.KindProxy,
-			},
-			assertErr: require.NoError,
-		},
-		{
-			desc: "auth",
-			reqServer: &types.ServerV2{
-				Metadata: types.Metadata{Name: "test-server", Namespace: apidefaults.Namespace},
-				Version:  types.V2,
-				Kind:     types.KindAuthServer,
-			},
-			role: types.RoleAuth,
-			wantServer: &types.ServerV2{
-				Metadata: types.Metadata{Name: "test-server", Namespace: apidefaults.Namespace},
-				Version:  types.V2,
-				Kind:     types.KindAuthServer,
-			},
-			assertErr: require.Error,
-		},
-		{
-			desc: "unknown",
-			reqServer: &types.ServerV2{
-				Metadata: types.Metadata{Name: "test-server", Namespace: apidefaults.Namespace},
-				Version:  types.V2,
-				Kind:     types.KindNode,
-			},
-			role:      types.SystemRole("unknown"),
-			assertErr: require.Error,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-			// Set up backend to upsert servers into.
-			s := newTestServices(t)
-
-			// Create a fake HTTP request.
-			inSrv, err := services.MarshalServer(tt.reqServer)
-			require.NoError(t, err)
-			body, err := json.Marshal(auth.UpsertServerRawReq{Server: inSrv})
-			require.NoError(t, err)
-			req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(body))
-			req.RemoteAddr = remoteAddr
-			req.Header.Add("Content-Type", "application/json")
-
-			_, err = auth.UpsertServer(new(auth.APIServer), s, tt.role, req, httprouter.Params{httprouter.Param{Key: "namespace", Value: apidefaults.Namespace}})
-			tt.assertErr(t, err)
-			if err != nil {
-				return
-			}
-
-			// Fetch all servers from the backend, there should only be 1.
-			var allServers []types.Server
-			addServers := func(servers []types.Server, err error) {
-				require.NoError(t, err)
-				allServers = append(allServers, servers...)
-			}
-			//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
-			addServers(s.GetAuthServers())
-			addServers(s.GetNodes(ctx, apidefaults.Namespace))
-			//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
-			addServers(s.GetProxies())
-			require.Empty(t, cmp.Diff(allServers, []types.Server{tt.wantServer}, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
-		})
-	}
-}
 
 // TestTokensRegisterReturnsTooOldError verifies that the re-added /tokens/register
 // route returns an explicit "too old" error rather than a 404, so that outdated

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1119,30 +1119,27 @@ func (a *ServerWithRoles) ClearAlertAcks(ctx context.Context, req proto.ClearAle
 	return a.authServer.ClearAlertAcks(ctx, req)
 }
 
-func (a *ServerWithRoles) UpsertNode(ctx context.Context, s types.Server) (*types.KeepAlive, error) {
+func (a *ScopedServerWithRoles) UpsertNode(ctx context.Context, s types.Server) (*types.KeepAlive, error) {
+	ruleCtx := a.scopedContext.RuleContext()
 	// Note: UpsertNode doesn't allow any namespaces but "default".
-	if err := a.authorizeAction(types.KindNode, types.VerbCreate, types.VerbUpdate); err != nil {
+	// The Decision API only checks on the default namespace.
+	if err := a.scopedContext.CheckerContext.Decision(ctx, s.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		return checker.CheckAccessToRules(&ruleCtx, types.KindNode, types.VerbCreate, types.VerbUpdate)
+	}); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	agentScope := a.context.Identity.GetIdentity().GetAgentScope()
+	agentScope := a.scopedContext.Identity.GetIdentity().GetAgentScope()
 	if nodeScope := s.GetScope(); agentScope != "" {
 		if nodeScope != agentScope {
 			return nil, trace.AccessDenied("node scope %q does not match agent identity scope %q", nodeScope, agentScope)
 		}
+	}
 
-		if a.hasBuiltinRole(types.RoleNode) {
-			clusterName, err := a.GetDomainName(ctx)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			callerID, err := ExtractHostID(a.context.User.GetName(), clusterName)
-			if err != nil {
-				return nil, trace.AccessDenied("access denied")
-			}
-			if s.GetName() != callerID {
-				return nil, trace.AccessDenied("node ID %q does not match agent identity ID %q", s.GetName(), callerID)
-			}
+	if a.hasBuiltinRole(types.RoleNode) {
+		callerID, _ := getLocalServerID(a.scopedContext.Identity)
+		if s.GetName() != callerID {
+			return nil, trace.AccessDenied("node ID %q does not match agent identity ID %q", s.GetName(), callerID)
 		}
 	}
 

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -9230,9 +9230,15 @@ func TestGenerateHostCertsScoped(t *testing.T) {
 
 func TestUpsertNode(t *testing.T) {
 	t.Parallel()
-	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	authsrv, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir: t.TempDir(),
+		ScopesFeatures: scopes.Features{
+			Enabled:         true,
+			AgentPinEnabled: true,
+		},
+	})
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	t.Cleanup(func() { require.NoError(t, authsrv.Close()) })
 
 	const nodeName = "test1"
 	const otherID = "test2"
@@ -9255,44 +9261,91 @@ func TestUpsertNode(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		callerScope string
-		nodeName    string
-		nodeScope   string
-		shouldErr   bool
+		name      string
+		server    *auth.ScopedServerWithRoles
+		nodeName  string
+		nodeScope string
+		shouldErr bool
 	}{
 		{
-			name:        "unscoped - bypasses node ID check",
-			callerScope: "",
-			nodeName:    otherID,
-			nodeScope:   "",
+			name:     "unscoped node - own node allowed",
+			server:   newScopedTestServerForHost(t, authsrv, nodeName, "", types.RoleNode).ScopedServerWithRoles(),
+			nodeName: nodeName,
 		},
 		{
-			name:        "scoped - matching ID and scope allowed",
-			callerScope: "/staging",
-			nodeName:    nodeName,
-			nodeScope:   "/staging",
+			// Node agents may only upsert their own node resource, scoped or not.
+			name:      "unscoped node - mismatched ID denied",
+			server:    newScopedTestServerForHost(t, authsrv, nodeName, "", types.RoleNode).ScopedServerWithRoles(),
+			nodeName:  otherID,
+			shouldErr: true,
 		},
 		{
-			name:        "scoped - matching ID but mismatched scope denied",
-			callerScope: "/staging",
-			nodeName:    nodeName,
-			nodeScope:   "/prod",
-			shouldErr:   true,
+			name:      "agent scope - matching ID and scope allowed",
+			server:    newScopedTestServerForHost(t, authsrv, nodeName, "/staging", types.RoleNode).ScopedServerWithRoles(),
+			nodeName:  nodeName,
+			nodeScope: "/staging",
 		},
 		{
-			name:        "scoped - matching scope but mismatched ID denied",
-			callerScope: "/staging",
-			nodeName:    otherID,
-			nodeScope:   "/staging",
-			shouldErr:   true,
+			name:      "agent scope - mismatched scope denied",
+			server:    newScopedTestServerForHost(t, authsrv, nodeName, "/staging", types.RoleNode).ScopedServerWithRoles(),
+			nodeName:  nodeName,
+			nodeScope: "/prod",
+			shouldErr: true,
+		},
+		{
+			name:      "agent scope - mismatched ID denied",
+			server:    newScopedTestServerForHost(t, authsrv, nodeName, "/staging", types.RoleNode).ScopedServerWithRoles(),
+			nodeName:  otherID,
+			nodeScope: "/staging",
+			shouldErr: true,
+		},
+		{
+			name:      "agent pin - matching ID and scope allowed",
+			server:    newScopePinnedTestServerForHost(t, authsrv, nodeName, "/staging", types.RoleNode),
+			nodeName:  nodeName,
+			nodeScope: "/staging",
+		},
+		{
+			name:      "agent pin - node scope orthogonal to pinned scope denied",
+			server:    newScopePinnedTestServerForHost(t, authsrv, nodeName, "/staging", types.RoleNode),
+			nodeName:  nodeName,
+			nodeScope: "/prod",
+			shouldErr: true,
+		},
+		{
+			name:      "agent pin - mismatched ID denied",
+			server:    newScopePinnedTestServerForHost(t, authsrv, nodeName, "/staging", types.RoleNode),
+			nodeName:  otherID,
+			nodeScope: "/staging",
+			shouldErr: true,
+		},
+		{
+			name: "unscoped user with node rules allowed",
+			server: newScopedTestServerWithUnscopedUser(t, authsrv, "node-admin",
+				[]types.Rule{types.NewRule(types.KindNode, []string{types.VerbCreate, types.VerbUpdate})}),
+			nodeName: otherID,
+		},
+		{
+			name:      "unscoped user without node rules denied",
+			server:    newScopedTestServerWithUnscopedUser(t, authsrv, "plain-user", nil),
+			nodeName:  otherID,
+			shouldErr: true,
+		},
+		{
+			// Scoped roles cannot be created with node write permissions, so a scoped
+			// user never holds node:create/update and Decision should fail. Change this in the future
+			// if we ever let scoped users permissions for nodes.
+			name:      "scoped user denied",
+			server:    newScopePinnedTestServerWithScopedUser(t, authsrv, "scoped-user", "/staging", nil),
+			nodeName:  otherID,
+			nodeScope: "/staging",
+			shouldErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			srv := newScopedTestServerForHost(t, as, nodeName, tt.callerScope, types.RoleNode)
-			_, err := srv.UpsertNode(t.Context(), makeNode(t, tt.nodeName, tt.nodeScope))
+			_, err := tt.server.UpsertNode(t.Context(), makeNode(t, tt.nodeName, tt.nodeScope))
 			if tt.shouldErr {
 				require.Error(t, err)
 				require.True(t, trace.IsAccessDenied(err))

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -1307,6 +1307,7 @@ func TestScopePinnedHost(clusterName, hostID, scope string, roles ...types.Syste
 			ServerFQDN:  serverFQDN,
 			ScopePin:    pin,
 			Identity: tlsca.Identity{
+				Username: serverFQDN,
 				ScopePin: pin,
 			},
 		},

--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
-	"github.com/julienschmidt/httprouter"
 	"google.golang.org/grpc/credentials"
 
 	"github.com/gravitational/teleport/api/client"
@@ -262,12 +261,6 @@ func EncodeProquint(x uint16) string {
 
 func EmitSSOLoginFailureEvent(ctx context.Context, emitter apievents.Emitter, method string, err error, testFlow bool) {
 	emitSSOLoginFailureEvent(ctx, emitter, method, err, testFlow)
-}
-
-type UpsertServerRawReq = upsertServerRawReq
-
-func UpsertServer(srv *APIServer, auth presenceForAPIServer, role types.SystemRole, r *http.Request, p httprouter.Params) (any, error) {
-	return srv.upsertServer(auth, role, r, p)
 }
 
 func NewServerWithRoles(srv *Server, alog events.AuditLogSessionStreamer, authzContext authz.Context) *ServerWithRoles {

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -3845,7 +3845,7 @@ func (g *GRPCServer) GetNode(ctx context.Context, req *types.ResourceInNamespace
 
 // UpsertNode upserts a node.
 func (g *GRPCServer) UpsertNode(ctx context.Context, node *types.ServerV2) (*types.KeepAlive, error) {
-	auth, err := g.authenticate(ctx)
+	auth, err := g.scopedAuthenticate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -3859,7 +3859,7 @@ func (g *GRPCServer) UpsertNode(ctx context.Context, node *types.ServerV2) (*typ
 	}
 	node.SetAddr(utils.ReplaceLocalhost(node.GetAddr(), p.Addr.String()))
 
-	keepAlive, err := auth.ServerWithRoles.UpsertNode(ctx, node)
+	keepAlive, err := auth.UpsertNode(ctx, node)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -4540,12 +4540,12 @@ func TestEventsNodePresence(t *testing.T) {
 
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
-
+	nodeName := "node1." + testSrv.ClusterName()
 	node := &types.ServerV2{
 		Kind:    types.KindNode,
 		Version: types.V2,
 		Metadata: types.Metadata{
-			Name:      "node1",
+			Name:      nodeName,
 			Namespace: apidefaults.Namespace,
 		},
 		Spec: types.ServerSpecV2{
@@ -4556,7 +4556,7 @@ func TestEventsNodePresence(t *testing.T) {
 	clt, err := testSrv.NewClient(authtest.TestIdentity{
 		I: authz.BuiltinRole{
 			Role:     types.RoleNode,
-			Username: fmt.Sprintf("%v.%v", node.Metadata.Name, testSrv.ClusterName()),
+			Username: nodeName,
 		},
 	})
 	require.NoError(t, err)

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -2898,7 +2898,9 @@ func TestParseSubsystemRequest(t *testing.T) {
 		require.NoError(t, reverseTunnelServer.Start())
 		t.Cleanup(func() { _ = reverseTunnelServer.Close() })
 
-		nodeClient, _ := newNodeClient(t, f.testSrv)
+		nodeClient, nodeID := newNodeClient(t, f.testSrv)
+
+		agentlessSrv.Metadata.Name = nodeID // overwrite the nodeID
 
 		_, err = nodeClient.UpsertNode(ctx, &agentlessSrv)
 		require.NoError(t, err)


### PR DESCRIPTION
With Agent pins enabled, we need to port over `UpsertNode`  to being scope aware so that scoped openssh access works again. 



The apiserver needed to be changed because `ServerWithRoles` no longer implemented `UpsertNode`. `apiserver.upsertServer` takes in a `presenceForAPIServer` interface that required `UpsertNode` - but since it was only being called by `upsertProxy`, I opted to delete the UpsertNode requirement and clean up that function to only upsert proxy servers instead of also upserting nodes. 

Additionally, extracting the callerID matching should address https://github.com/gravitational/pressure-washing/issues/438#issuecomment-4784947907. 



<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: 


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local cluster - docker based openssh nodes

### Test Cases
With Agent pins enabled
- [x] OpenSSH nodes can be registered
- [x] Scoped and unscoped users can access the open ssh node
- [x] Scoped users cannot access orthogonal scopes

With Agent pins disabled
- [x] OpenSSH nodes can be registered
- [x] Scoped and unscoped users can access the open ssh node
- [x] Scoped users cannot access orthogonal scopes
