### PR TITLE
Add pending CSR requests to CertAuthorityOverrideStatus

### DIFF
--- a/api/gen/proto/go/teleport/subca/v1/cert_authority_override.pb.go
+++ b/api/gen/proto/go/teleport/subca/v1/cert_authority_override.pb.go
@@ -24,8 +24,10 @@ package subcav1
 
 import (
 	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	status "google.golang.org/genproto/googleapis/rpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	unsafe "unsafe"
 )
@@ -46,7 +48,7 @@ const (
 // self-signed root).
 //
 // Key material is never impacted by overrides, only certificates can be
-// overriden.
+// overridden.
 //
 // https://github.com/gravitational/teleport/blob/master/rfd/0237-sub-ca-support.md
 type CertAuthorityOverride struct {
@@ -293,9 +295,16 @@ type CertAuthorityOverrideStatus struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// CRLs generated for each certificate override, keyed by normalized/lowercase
 	// public_key_hash.
+	//
+	// CRLs for disabled overrides may be created asynchronously, using
+	// CertAuthorityOverride watchers, if the Auth server performing the writes
+	// lacks access to certain keys.
 	PublicKeyHashToCrl map[string]*CertificateRevocationList `protobuf:"bytes,1,rep,name=public_key_hash_to_crl,json=publicKeyHashToCrl,proto3" json:"public_key_hash_to_crl,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// Pending CSR requests on multi-Auth, multi-HSM scenarios.
+	// Requests are keyed by an opaque request ID.
+	IdToPendingCsrRequest map[string]*PendingCSRRequest `protobuf:"bytes,2,rep,name=id_to_pending_csr_request,json=idToPendingCsrRequest,proto3" json:"id_to_pending_csr_request,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *CertAuthorityOverrideStatus) Reset() {
@@ -330,8 +339,19 @@ func (x *CertAuthorityOverrideStatus) GetPublicKeyHashToCrl() map[string]*Certif
 	return nil
 }
 
+func (x *CertAuthorityOverrideStatus) GetIdToPendingCsrRequest() map[string]*PendingCSRRequest {
+	if x != nil {
+		return x.IdToPendingCsrRequest
+	}
+	return nil
+}
+
 func (x *CertAuthorityOverrideStatus) SetPublicKeyHashToCrl(v map[string]*CertificateRevocationList) {
 	x.PublicKeyHashToCrl = v
+}
+
+func (x *CertAuthorityOverrideStatus) SetIdToPendingCsrRequest(v map[string]*PendingCSRRequest) {
+	x.IdToPendingCsrRequest = v
 }
 
 type CertAuthorityOverrideStatus_builder struct {
@@ -339,7 +359,14 @@ type CertAuthorityOverrideStatus_builder struct {
 
 	// CRLs generated for each certificate override, keyed by normalized/lowercase
 	// public_key_hash.
+	//
+	// CRLs for disabled overrides may be created asynchronously, using
+	// CertAuthorityOverride watchers, if the Auth server performing the writes
+	// lacks access to certain keys.
 	PublicKeyHashToCrl map[string]*CertificateRevocationList
+	// Pending CSR requests on multi-Auth, multi-HSM scenarios.
+	// Requests are keyed by an opaque request ID.
+	IdToPendingCsrRequest map[string]*PendingCSRRequest
 }
 
 func (b0 CertAuthorityOverrideStatus_builder) Build() *CertAuthorityOverrideStatus {
@@ -347,6 +374,270 @@ func (b0 CertAuthorityOverrideStatus_builder) Build() *CertAuthorityOverrideStat
 	b, x := &b0, m0
 	_, _ = b, x
 	x.PublicKeyHashToCrl = b.PublicKeyHashToCrl
+	x.IdToPendingCsrRequest = b.IdToPendingCsrRequest
+	return m0
+}
+
+// A pending CSR request, created as part of a CreateCSR invocation on
+// multi-Auth, multi-HSM clusters.
+//
+// Requests are registered by the requester Auth server (the one processing the
+// CreateCSR call), in multi-HSM scenarios, when certain keys can't be used.
+// Auth servers watch CertAuthorityOverride resources and reply to requests
+// automatically, assigning a CSR and status to the corresponding PendingCSR
+// message. Once all pending CSRs have a terminal result, the RPC resumes.
+//
+// Successful pending requests are automatically cleaned up from status on
+// completion. Failed pending requests obey the normal create_time rules.
+type PendingCSRRequest struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// Create time of the request.
+	// Requests that are older than a certain threshold value may be automatically
+	// cleaned up by the system, regardless of their status.
+	CreateTime *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=create_time,json=createTime,proto3" json:"create_time,omitempty"`
+	// Pending CSRs of the request.
+	// CSRs are created and set by watching Auth servers.
+	Csrs []*PendingCSR `protobuf:"bytes,2,rep,name=csrs,proto3" json:"csrs,omitempty"`
+	// Custom subject for the CSRs.
+	// Optional.
+	CustomSubject *DistinguishedName `protobuf:"bytes,3,opt,name=custom_subject,json=customSubject,proto3" json:"custom_subject,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PendingCSRRequest) Reset() {
+	*x = PendingCSRRequest{}
+	mi := &file_teleport_subca_v1_cert_authority_override_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PendingCSRRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PendingCSRRequest) ProtoMessage() {}
+
+func (x *PendingCSRRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_subca_v1_cert_authority_override_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *PendingCSRRequest) GetCreateTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CreateTime
+	}
+	return nil
+}
+
+func (x *PendingCSRRequest) GetCsrs() []*PendingCSR {
+	if x != nil {
+		return x.Csrs
+	}
+	return nil
+}
+
+func (x *PendingCSRRequest) GetCustomSubject() *DistinguishedName {
+	if x != nil {
+		return x.CustomSubject
+	}
+	return nil
+}
+
+func (x *PendingCSRRequest) SetCreateTime(v *timestamppb.Timestamp) {
+	x.CreateTime = v
+}
+
+func (x *PendingCSRRequest) SetCsrs(v []*PendingCSR) {
+	x.Csrs = v
+}
+
+func (x *PendingCSRRequest) SetCustomSubject(v *DistinguishedName) {
+	x.CustomSubject = v
+}
+
+func (x *PendingCSRRequest) HasCreateTime() bool {
+	if x == nil {
+		return false
+	}
+	return x.CreateTime != nil
+}
+
+func (x *PendingCSRRequest) HasCustomSubject() bool {
+	if x == nil {
+		return false
+	}
+	return x.CustomSubject != nil
+}
+
+func (x *PendingCSRRequest) ClearCreateTime() {
+	x.CreateTime = nil
+}
+
+func (x *PendingCSRRequest) ClearCustomSubject() {
+	x.CustomSubject = nil
+}
+
+type PendingCSRRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Create time of the request.
+	// Requests that are older than a certain threshold value may be automatically
+	// cleaned up by the system, regardless of their status.
+	CreateTime *timestamppb.Timestamp
+	// Pending CSRs of the request.
+	// CSRs are created and set by watching Auth servers.
+	Csrs []*PendingCSR
+	// Custom subject for the CSRs.
+	// Optional.
+	CustomSubject *DistinguishedName
+}
+
+func (b0 PendingCSRRequest_builder) Build() *PendingCSRRequest {
+	m0 := &PendingCSRRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.CreateTime = b.CreateTime
+	x.Csrs = b.Csrs
+	x.CustomSubject = b.CustomSubject
+	return m0
+}
+
+// A pending CSR, to be created as part of a [PendingCSRRequest].
+type PendingCSR struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// Target public key of the CSR.
+	PublicKeyHash *PublicKeyHash `protobuf:"bytes,1,opt,name=public_key_hash,json=publicKeyHash,proto3" json:"public_key_hash,omitempty"`
+	// The CSR itself.
+	// Assigned by the watching Auth server when created. Non-nil if status is OK.
+	Csr *CertificateSigningRequest `protobuf:"bytes,2,opt,name=csr,proto3" json:"csr,omitempty"`
+	// Status of the CSR signing attempt.
+	// Nil means no attempt was recorded. If non-nil, the attempt happened and
+	// won't be retried.
+	Status        *status.Status `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PendingCSR) Reset() {
+	*x = PendingCSR{}
+	mi := &file_teleport_subca_v1_cert_authority_override_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PendingCSR) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PendingCSR) ProtoMessage() {}
+
+func (x *PendingCSR) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_subca_v1_cert_authority_override_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *PendingCSR) GetPublicKeyHash() *PublicKeyHash {
+	if x != nil {
+		return x.PublicKeyHash
+	}
+	return nil
+}
+
+func (x *PendingCSR) GetCsr() *CertificateSigningRequest {
+	if x != nil {
+		return x.Csr
+	}
+	return nil
+}
+
+func (x *PendingCSR) GetStatus() *status.Status {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
+func (x *PendingCSR) SetPublicKeyHash(v *PublicKeyHash) {
+	x.PublicKeyHash = v
+}
+
+func (x *PendingCSR) SetCsr(v *CertificateSigningRequest) {
+	x.Csr = v
+}
+
+func (x *PendingCSR) SetStatus(v *status.Status) {
+	x.Status = v
+}
+
+func (x *PendingCSR) HasPublicKeyHash() bool {
+	if x == nil {
+		return false
+	}
+	return x.PublicKeyHash != nil
+}
+
+func (x *PendingCSR) HasCsr() bool {
+	if x == nil {
+		return false
+	}
+	return x.Csr != nil
+}
+
+func (x *PendingCSR) HasStatus() bool {
+	if x == nil {
+		return false
+	}
+	return x.Status != nil
+}
+
+func (x *PendingCSR) ClearPublicKeyHash() {
+	x.PublicKeyHash = nil
+}
+
+func (x *PendingCSR) ClearCsr() {
+	x.Csr = nil
+}
+
+func (x *PendingCSR) ClearStatus() {
+	x.Status = nil
+}
+
+type PendingCSR_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Target public key of the CSR.
+	PublicKeyHash *PublicKeyHash
+	// The CSR itself.
+	// Assigned by the watching Auth server when created. Non-nil if status is OK.
+	Csr *CertificateSigningRequest
+	// Status of the CSR signing attempt.
+	// Nil means no attempt was recorded. If non-nil, the attempt happened and
+	// won't be retried.
+	Status *status.Status
+}
+
+func (b0 PendingCSR_builder) Build() *PendingCSR {
+	m0 := &PendingCSR{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.PublicKeyHash = b.PublicKeyHash
+	x.Csr = b.Csr
+	x.Status = b.Status
 	return m0
 }
 
@@ -354,7 +645,7 @@ var File_teleport_subca_v1_cert_authority_override_proto protoreflect.FileDescri
 
 const file_teleport_subca_v1_cert_authority_override_proto_rawDesc = "" +
 	"\n" +
-	"/teleport/subca/v1/cert_authority_override.proto\x12\x11teleport.subca.v1\x1a!teleport/header/v1/metadata.proto\x1a,teleport/subca/v1/certificate_override.proto\x1a\x1bteleport/subca/v1/crl.proto\"\xa4\x02\n" +
+	"/teleport/subca/v1/cert_authority_override.proto\x12\x11teleport.subca.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17google/rpc/status.proto\x1a!teleport/header/v1/metadata.proto\x1a,teleport/subca/v1/certificate_override.proto\x1a\x1bteleport/subca/v1/crl.proto\x1a\x1bteleport/subca/v1/csr.proto\x1a*teleport/subca/v1/distinguished_name.proto\x1a'teleport/subca/v1/public_key_hash.proto\"\xa4\x02\n" +
 	"\x15CertAuthorityOverride\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
@@ -363,35 +654,65 @@ const file_teleport_subca_v1_cert_authority_override_proto_rawDesc = "" +
 	"\x04spec\x18\x05 \x01(\v2,.teleport.subca.v1.CertAuthorityOverrideSpecR\x04spec\x12F\n" +
 	"\x06status\x18\a \x01(\v2..teleport.subca.v1.CertAuthorityOverrideStatusR\x06status\"x\n" +
 	"\x19CertAuthorityOverrideSpec\x12[\n" +
-	"\x15certificate_overrides\x18\x01 \x03(\v2&.teleport.subca.v1.CertificateOverrideR\x14certificateOverrides\"\x8e\x02\n" +
+	"\x15certificate_overrides\x18\x01 \x03(\v2&.teleport.subca.v1.CertificateOverrideR\x14certificateOverrides\"\x84\x04\n" +
 	"\x1bCertAuthorityOverrideStatus\x12z\n" +
-	"\x16public_key_hash_to_crl\x18\x01 \x03(\v2F.teleport.subca.v1.CertAuthorityOverrideStatus.PublicKeyHashToCrlEntryR\x12publicKeyHashToCrl\x1as\n" +
+	"\x16public_key_hash_to_crl\x18\x01 \x03(\v2F.teleport.subca.v1.CertAuthorityOverrideStatus.PublicKeyHashToCrlEntryR\x12publicKeyHashToCrl\x12\x83\x01\n" +
+	"\x19id_to_pending_csr_request\x18\x02 \x03(\v2I.teleport.subca.v1.CertAuthorityOverrideStatus.IdToPendingCsrRequestEntryR\x15idToPendingCsrRequest\x1as\n" +
 	"\x17PublicKeyHashToCrlEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12B\n" +
-	"\x05value\x18\x02 \x01(\v2,.teleport.subca.v1.CertificateRevocationListR\x05value:\x028\x01BNZLgithub.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1;subcav1b\x06proto3"
+	"\x05value\x18\x02 \x01(\v2,.teleport.subca.v1.CertificateRevocationListR\x05value:\x028\x01\x1an\n" +
+	"\x1aIdToPendingCsrRequestEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12:\n" +
+	"\x05value\x18\x02 \x01(\v2$.teleport.subca.v1.PendingCSRRequestR\x05value:\x028\x01\"\xd0\x01\n" +
+	"\x11PendingCSRRequest\x12;\n" +
+	"\vcreate_time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"createTime\x121\n" +
+	"\x04csrs\x18\x02 \x03(\v2\x1d.teleport.subca.v1.PendingCSRR\x04csrs\x12K\n" +
+	"\x0ecustom_subject\x18\x03 \x01(\v2$.teleport.subca.v1.DistinguishedNameR\rcustomSubject\"\xc2\x01\n" +
+	"\n" +
+	"PendingCSR\x12H\n" +
+	"\x0fpublic_key_hash\x18\x01 \x01(\v2 .teleport.subca.v1.PublicKeyHashR\rpublicKeyHash\x12>\n" +
+	"\x03csr\x18\x02 \x01(\v2,.teleport.subca.v1.CertificateSigningRequestR\x03csr\x12*\n" +
+	"\x06status\x18\x03 \x01(\v2\x12.google.rpc.StatusR\x06statusBNZLgithub.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1;subcav1b\x06proto3"
 
-var file_teleport_subca_v1_cert_authority_override_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_teleport_subca_v1_cert_authority_override_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_teleport_subca_v1_cert_authority_override_proto_goTypes = []any{
 	(*CertAuthorityOverride)(nil),       // 0: teleport.subca.v1.CertAuthorityOverride
 	(*CertAuthorityOverrideSpec)(nil),   // 1: teleport.subca.v1.CertAuthorityOverrideSpec
 	(*CertAuthorityOverrideStatus)(nil), // 2: teleport.subca.v1.CertAuthorityOverrideStatus
-	nil,                                 // 3: teleport.subca.v1.CertAuthorityOverrideStatus.PublicKeyHashToCrlEntry
-	(*v1.Metadata)(nil),                 // 4: teleport.header.v1.Metadata
-	(*CertificateOverride)(nil),         // 5: teleport.subca.v1.CertificateOverride
-	(*CertificateRevocationList)(nil),   // 6: teleport.subca.v1.CertificateRevocationList
+	(*PendingCSRRequest)(nil),           // 3: teleport.subca.v1.PendingCSRRequest
+	(*PendingCSR)(nil),                  // 4: teleport.subca.v1.PendingCSR
+	nil,                                 // 5: teleport.subca.v1.CertAuthorityOverrideStatus.PublicKeyHashToCrlEntry
+	nil,                                 // 6: teleport.subca.v1.CertAuthorityOverrideStatus.IdToPendingCsrRequestEntry
+	(*v1.Metadata)(nil),                 // 7: teleport.header.v1.Metadata
+	(*CertificateOverride)(nil),         // 8: teleport.subca.v1.CertificateOverride
+	(*timestamppb.Timestamp)(nil),       // 9: google.protobuf.Timestamp
+	(*DistinguishedName)(nil),           // 10: teleport.subca.v1.DistinguishedName
+	(*PublicKeyHash)(nil),               // 11: teleport.subca.v1.PublicKeyHash
+	(*CertificateSigningRequest)(nil),   // 12: teleport.subca.v1.CertificateSigningRequest
+	(*status.Status)(nil),               // 13: google.rpc.Status
+	(*CertificateRevocationList)(nil),   // 14: teleport.subca.v1.CertificateRevocationList
 }
 var file_teleport_subca_v1_cert_authority_override_proto_depIdxs = []int32{
-	4, // 0: teleport.subca.v1.CertAuthorityOverride.metadata:type_name -> teleport.header.v1.Metadata
-	1, // 1: teleport.subca.v1.CertAuthorityOverride.spec:type_name -> teleport.subca.v1.CertAuthorityOverrideSpec
-	2, // 2: teleport.subca.v1.CertAuthorityOverride.status:type_name -> teleport.subca.v1.CertAuthorityOverrideStatus
-	5, // 3: teleport.subca.v1.CertAuthorityOverrideSpec.certificate_overrides:type_name -> teleport.subca.v1.CertificateOverride
-	3, // 4: teleport.subca.v1.CertAuthorityOverrideStatus.public_key_hash_to_crl:type_name -> teleport.subca.v1.CertAuthorityOverrideStatus.PublicKeyHashToCrlEntry
-	6, // 5: teleport.subca.v1.CertAuthorityOverrideStatus.PublicKeyHashToCrlEntry.value:type_name -> teleport.subca.v1.CertificateRevocationList
-	6, // [6:6] is the sub-list for method output_type
-	6, // [6:6] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	7,  // 0: teleport.subca.v1.CertAuthorityOverride.metadata:type_name -> teleport.header.v1.Metadata
+	1,  // 1: teleport.subca.v1.CertAuthorityOverride.spec:type_name -> teleport.subca.v1.CertAuthorityOverrideSpec
+	2,  // 2: teleport.subca.v1.CertAuthorityOverride.status:type_name -> teleport.subca.v1.CertAuthorityOverrideStatus
+	8,  // 3: teleport.subca.v1.CertAuthorityOverrideSpec.certificate_overrides:type_name -> teleport.subca.v1.CertificateOverride
+	5,  // 4: teleport.subca.v1.CertAuthorityOverrideStatus.public_key_hash_to_crl:type_name -> teleport.subca.v1.CertAuthorityOverrideStatus.PublicKeyHashToCrlEntry
+	6,  // 5: teleport.subca.v1.CertAuthorityOverrideStatus.id_to_pending_csr_request:type_name -> teleport.subca.v1.CertAuthorityOverrideStatus.IdToPendingCsrRequestEntry
+	9,  // 6: teleport.subca.v1.PendingCSRRequest.create_time:type_name -> google.protobuf.Timestamp
+	4,  // 7: teleport.subca.v1.PendingCSRRequest.csrs:type_name -> teleport.subca.v1.PendingCSR
+	10, // 8: teleport.subca.v1.PendingCSRRequest.custom_subject:type_name -> teleport.subca.v1.DistinguishedName
+	11, // 9: teleport.subca.v1.PendingCSR.public_key_hash:type_name -> teleport.subca.v1.PublicKeyHash
+	12, // 10: teleport.subca.v1.PendingCSR.csr:type_name -> teleport.subca.v1.CertificateSigningRequest
+	13, // 11: teleport.subca.v1.PendingCSR.status:type_name -> google.rpc.Status
+	14, // 12: teleport.subca.v1.CertAuthorityOverrideStatus.PublicKeyHashToCrlEntry.value:type_name -> teleport.subca.v1.CertificateRevocationList
+	3,  // 13: teleport.subca.v1.CertAuthorityOverrideStatus.IdToPendingCsrRequestEntry.value:type_name -> teleport.subca.v1.PendingCSRRequest
+	14, // [14:14] is the sub-list for method output_type
+	14, // [14:14] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_teleport_subca_v1_cert_authority_override_proto_init() }
@@ -401,13 +722,16 @@ func file_teleport_subca_v1_cert_authority_override_proto_init() {
 	}
 	file_teleport_subca_v1_certificate_override_proto_init()
 	file_teleport_subca_v1_crl_proto_init()
+	file_teleport_subca_v1_csr_proto_init()
+	file_teleport_subca_v1_distinguished_name_proto_init()
+	file_teleport_subca_v1_public_key_hash_proto_init()
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_subca_v1_cert_authority_override_proto_rawDesc), len(file_teleport_subca_v1_cert_authority_override_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/subca/v1/cert_authority_override_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/subca/v1/cert_authority_override_protoopaque.pb.go
@@ -24,8 +24,10 @@ package subcav1
 
 import (
 	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	status "google.golang.org/genproto/googleapis/rpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	unsafe "unsafe"
 )
@@ -46,7 +48,7 @@ const (
 // self-signed root).
 //
 // Key material is never impacted by overrides, only certificates can be
-// overriden.
+// overridden.
 //
 // https://github.com/gravitational/teleport/blob/master/rfd/0237-sub-ca-support.md
 type CertAuthorityOverride struct {
@@ -282,10 +284,11 @@ func (b0 CertAuthorityOverrideSpec_builder) Build() *CertAuthorityOverrideSpec {
 // CertAuthorityOverrideStatus is the dynamic, system-managed state of a
 // CertAuthorityOverride resource.
 type CertAuthorityOverrideStatus struct {
-	state                         protoimpl.MessageState                `protogen:"opaque.v1"`
-	xxx_hidden_PublicKeyHashToCrl map[string]*CertificateRevocationList `protobuf:"bytes,1,rep,name=public_key_hash_to_crl,json=publicKeyHashToCrl,proto3" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields                 protoimpl.UnknownFields
-	sizeCache                     protoimpl.SizeCache
+	state                            protoimpl.MessageState                `protogen:"opaque.v1"`
+	xxx_hidden_PublicKeyHashToCrl    map[string]*CertificateRevocationList `protobuf:"bytes,1,rep,name=public_key_hash_to_crl,json=publicKeyHashToCrl,proto3" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	xxx_hidden_IdToPendingCsrRequest map[string]*PendingCSRRequest         `protobuf:"bytes,2,rep,name=id_to_pending_csr_request,json=idToPendingCsrRequest,proto3" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields                    protoimpl.UnknownFields
+	sizeCache                        protoimpl.SizeCache
 }
 
 func (x *CertAuthorityOverrideStatus) Reset() {
@@ -320,8 +323,19 @@ func (x *CertAuthorityOverrideStatus) GetPublicKeyHashToCrl() map[string]*Certif
 	return nil
 }
 
+func (x *CertAuthorityOverrideStatus) GetIdToPendingCsrRequest() map[string]*PendingCSRRequest {
+	if x != nil {
+		return x.xxx_hidden_IdToPendingCsrRequest
+	}
+	return nil
+}
+
 func (x *CertAuthorityOverrideStatus) SetPublicKeyHashToCrl(v map[string]*CertificateRevocationList) {
 	x.xxx_hidden_PublicKeyHashToCrl = v
+}
+
+func (x *CertAuthorityOverrideStatus) SetIdToPendingCsrRequest(v map[string]*PendingCSRRequest) {
+	x.xxx_hidden_IdToPendingCsrRequest = v
 }
 
 type CertAuthorityOverrideStatus_builder struct {
@@ -329,7 +343,14 @@ type CertAuthorityOverrideStatus_builder struct {
 
 	// CRLs generated for each certificate override, keyed by normalized/lowercase
 	// public_key_hash.
+	//
+	// CRLs for disabled overrides may be created asynchronously, using
+	// CertAuthorityOverride watchers, if the Auth server performing the writes
+	// lacks access to certain keys.
 	PublicKeyHashToCrl map[string]*CertificateRevocationList
+	// Pending CSR requests on multi-Auth, multi-HSM scenarios.
+	// Requests are keyed by an opaque request ID.
+	IdToPendingCsrRequest map[string]*PendingCSRRequest
 }
 
 func (b0 CertAuthorityOverrideStatus_builder) Build() *CertAuthorityOverrideStatus {
@@ -337,6 +358,259 @@ func (b0 CertAuthorityOverrideStatus_builder) Build() *CertAuthorityOverrideStat
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_PublicKeyHashToCrl = b.PublicKeyHashToCrl
+	x.xxx_hidden_IdToPendingCsrRequest = b.IdToPendingCsrRequest
+	return m0
+}
+
+// A pending CSR request, created as part of a CreateCSR invocation on
+// multi-Auth, multi-HSM clusters.
+//
+// Requests are registered by the requester Auth server (the one processing the
+// CreateCSR call), in multi-HSM scenarios, when certain keys can't be used.
+// Auth servers watch CertAuthorityOverride resources and reply to requests
+// automatically, assigning a CSR and status to the corresponding PendingCSR
+// message. Once all pending CSRs have a terminal result, the RPC resumes.
+//
+// Successful pending requests are automatically cleaned up from status on
+// completion. Failed pending requests obey the normal create_time rules.
+type PendingCSRRequest struct {
+	state                    protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_CreateTime    *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=create_time,json=createTime,proto3"`
+	xxx_hidden_Csrs          *[]*PendingCSR         `protobuf:"bytes,2,rep,name=csrs,proto3"`
+	xxx_hidden_CustomSubject *DistinguishedName     `protobuf:"bytes,3,opt,name=custom_subject,json=customSubject,proto3"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
+}
+
+func (x *PendingCSRRequest) Reset() {
+	*x = PendingCSRRequest{}
+	mi := &file_teleport_subca_v1_cert_authority_override_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PendingCSRRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PendingCSRRequest) ProtoMessage() {}
+
+func (x *PendingCSRRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_subca_v1_cert_authority_override_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *PendingCSRRequest) GetCreateTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.xxx_hidden_CreateTime
+	}
+	return nil
+}
+
+func (x *PendingCSRRequest) GetCsrs() []*PendingCSR {
+	if x != nil {
+		if x.xxx_hidden_Csrs != nil {
+			return *x.xxx_hidden_Csrs
+		}
+	}
+	return nil
+}
+
+func (x *PendingCSRRequest) GetCustomSubject() *DistinguishedName {
+	if x != nil {
+		return x.xxx_hidden_CustomSubject
+	}
+	return nil
+}
+
+func (x *PendingCSRRequest) SetCreateTime(v *timestamppb.Timestamp) {
+	x.xxx_hidden_CreateTime = v
+}
+
+func (x *PendingCSRRequest) SetCsrs(v []*PendingCSR) {
+	x.xxx_hidden_Csrs = &v
+}
+
+func (x *PendingCSRRequest) SetCustomSubject(v *DistinguishedName) {
+	x.xxx_hidden_CustomSubject = v
+}
+
+func (x *PendingCSRRequest) HasCreateTime() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_CreateTime != nil
+}
+
+func (x *PendingCSRRequest) HasCustomSubject() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_CustomSubject != nil
+}
+
+func (x *PendingCSRRequest) ClearCreateTime() {
+	x.xxx_hidden_CreateTime = nil
+}
+
+func (x *PendingCSRRequest) ClearCustomSubject() {
+	x.xxx_hidden_CustomSubject = nil
+}
+
+type PendingCSRRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Create time of the request.
+	// Requests that are older than a certain threshold value may be automatically
+	// cleaned up by the system, regardless of their status.
+	CreateTime *timestamppb.Timestamp
+	// Pending CSRs of the request.
+	// CSRs are created and set by watching Auth servers.
+	Csrs []*PendingCSR
+	// Custom subject for the CSRs.
+	// Optional.
+	CustomSubject *DistinguishedName
+}
+
+func (b0 PendingCSRRequest_builder) Build() *PendingCSRRequest {
+	m0 := &PendingCSRRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_CreateTime = b.CreateTime
+	x.xxx_hidden_Csrs = &b.Csrs
+	x.xxx_hidden_CustomSubject = b.CustomSubject
+	return m0
+}
+
+// A pending CSR, to be created as part of a [PendingCSRRequest].
+type PendingCSR struct {
+	state                    protoimpl.MessageState     `protogen:"opaque.v1"`
+	xxx_hidden_PublicKeyHash *PublicKeyHash             `protobuf:"bytes,1,opt,name=public_key_hash,json=publicKeyHash,proto3"`
+	xxx_hidden_Csr           *CertificateSigningRequest `protobuf:"bytes,2,opt,name=csr,proto3"`
+	xxx_hidden_Status        *status.Status             `protobuf:"bytes,3,opt,name=status,proto3"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
+}
+
+func (x *PendingCSR) Reset() {
+	*x = PendingCSR{}
+	mi := &file_teleport_subca_v1_cert_authority_override_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PendingCSR) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PendingCSR) ProtoMessage() {}
+
+func (x *PendingCSR) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_subca_v1_cert_authority_override_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *PendingCSR) GetPublicKeyHash() *PublicKeyHash {
+	if x != nil {
+		return x.xxx_hidden_PublicKeyHash
+	}
+	return nil
+}
+
+func (x *PendingCSR) GetCsr() *CertificateSigningRequest {
+	if x != nil {
+		return x.xxx_hidden_Csr
+	}
+	return nil
+}
+
+func (x *PendingCSR) GetStatus() *status.Status {
+	if x != nil {
+		return x.xxx_hidden_Status
+	}
+	return nil
+}
+
+func (x *PendingCSR) SetPublicKeyHash(v *PublicKeyHash) {
+	x.xxx_hidden_PublicKeyHash = v
+}
+
+func (x *PendingCSR) SetCsr(v *CertificateSigningRequest) {
+	x.xxx_hidden_Csr = v
+}
+
+func (x *PendingCSR) SetStatus(v *status.Status) {
+	x.xxx_hidden_Status = v
+}
+
+func (x *PendingCSR) HasPublicKeyHash() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_PublicKeyHash != nil
+}
+
+func (x *PendingCSR) HasCsr() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Csr != nil
+}
+
+func (x *PendingCSR) HasStatus() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Status != nil
+}
+
+func (x *PendingCSR) ClearPublicKeyHash() {
+	x.xxx_hidden_PublicKeyHash = nil
+}
+
+func (x *PendingCSR) ClearCsr() {
+	x.xxx_hidden_Csr = nil
+}
+
+func (x *PendingCSR) ClearStatus() {
+	x.xxx_hidden_Status = nil
+}
+
+type PendingCSR_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Target public key of the CSR.
+	PublicKeyHash *PublicKeyHash
+	// The CSR itself.
+	// Assigned by the watching Auth server when created. Non-nil if status is OK.
+	Csr *CertificateSigningRequest
+	// Status of the CSR signing attempt.
+	// Nil means no attempt was recorded. If non-nil, the attempt happened and
+	// won't be retried.
+	Status *status.Status
+}
+
+func (b0 PendingCSR_builder) Build() *PendingCSR {
+	m0 := &PendingCSR{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_PublicKeyHash = b.PublicKeyHash
+	x.xxx_hidden_Csr = b.Csr
+	x.xxx_hidden_Status = b.Status
 	return m0
 }
 
@@ -344,7 +618,7 @@ var File_teleport_subca_v1_cert_authority_override_proto protoreflect.FileDescri
 
 const file_teleport_subca_v1_cert_authority_override_proto_rawDesc = "" +
 	"\n" +
-	"/teleport/subca/v1/cert_authority_override.proto\x12\x11teleport.subca.v1\x1a!teleport/header/v1/metadata.proto\x1a,teleport/subca/v1/certificate_override.proto\x1a\x1bteleport/subca/v1/crl.proto\"\xa4\x02\n" +
+	"/teleport/subca/v1/cert_authority_override.proto\x12\x11teleport.subca.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17google/rpc/status.proto\x1a!teleport/header/v1/metadata.proto\x1a,teleport/subca/v1/certificate_override.proto\x1a\x1bteleport/subca/v1/crl.proto\x1a\x1bteleport/subca/v1/csr.proto\x1a*teleport/subca/v1/distinguished_name.proto\x1a'teleport/subca/v1/public_key_hash.proto\"\xa4\x02\n" +
 	"\x15CertAuthorityOverride\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
@@ -353,35 +627,65 @@ const file_teleport_subca_v1_cert_authority_override_proto_rawDesc = "" +
 	"\x04spec\x18\x05 \x01(\v2,.teleport.subca.v1.CertAuthorityOverrideSpecR\x04spec\x12F\n" +
 	"\x06status\x18\a \x01(\v2..teleport.subca.v1.CertAuthorityOverrideStatusR\x06status\"x\n" +
 	"\x19CertAuthorityOverrideSpec\x12[\n" +
-	"\x15certificate_overrides\x18\x01 \x03(\v2&.teleport.subca.v1.CertificateOverrideR\x14certificateOverrides\"\x8e\x02\n" +
+	"\x15certificate_overrides\x18\x01 \x03(\v2&.teleport.subca.v1.CertificateOverrideR\x14certificateOverrides\"\x84\x04\n" +
 	"\x1bCertAuthorityOverrideStatus\x12z\n" +
-	"\x16public_key_hash_to_crl\x18\x01 \x03(\v2F.teleport.subca.v1.CertAuthorityOverrideStatus.PublicKeyHashToCrlEntryR\x12publicKeyHashToCrl\x1as\n" +
+	"\x16public_key_hash_to_crl\x18\x01 \x03(\v2F.teleport.subca.v1.CertAuthorityOverrideStatus.PublicKeyHashToCrlEntryR\x12publicKeyHashToCrl\x12\x83\x01\n" +
+	"\x19id_to_pending_csr_request\x18\x02 \x03(\v2I.teleport.subca.v1.CertAuthorityOverrideStatus.IdToPendingCsrRequestEntryR\x15idToPendingCsrRequest\x1as\n" +
 	"\x17PublicKeyHashToCrlEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12B\n" +
-	"\x05value\x18\x02 \x01(\v2,.teleport.subca.v1.CertificateRevocationListR\x05value:\x028\x01BNZLgithub.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1;subcav1b\x06proto3"
+	"\x05value\x18\x02 \x01(\v2,.teleport.subca.v1.CertificateRevocationListR\x05value:\x028\x01\x1an\n" +
+	"\x1aIdToPendingCsrRequestEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12:\n" +
+	"\x05value\x18\x02 \x01(\v2$.teleport.subca.v1.PendingCSRRequestR\x05value:\x028\x01\"\xd0\x01\n" +
+	"\x11PendingCSRRequest\x12;\n" +
+	"\vcreate_time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"createTime\x121\n" +
+	"\x04csrs\x18\x02 \x03(\v2\x1d.teleport.subca.v1.PendingCSRR\x04csrs\x12K\n" +
+	"\x0ecustom_subject\x18\x03 \x01(\v2$.teleport.subca.v1.DistinguishedNameR\rcustomSubject\"\xc2\x01\n" +
+	"\n" +
+	"PendingCSR\x12H\n" +
+	"\x0fpublic_key_hash\x18\x01 \x01(\v2 .teleport.subca.v1.PublicKeyHashR\rpublicKeyHash\x12>\n" +
+	"\x03csr\x18\x02 \x01(\v2,.teleport.subca.v1.CertificateSigningRequestR\x03csr\x12*\n" +
+	"\x06status\x18\x03 \x01(\v2\x12.google.rpc.StatusR\x06statusBNZLgithub.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1;subcav1b\x06proto3"
 
-var file_teleport_subca_v1_cert_authority_override_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_teleport_subca_v1_cert_authority_override_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_teleport_subca_v1_cert_authority_override_proto_goTypes = []any{
 	(*CertAuthorityOverride)(nil),       // 0: teleport.subca.v1.CertAuthorityOverride
 	(*CertAuthorityOverrideSpec)(nil),   // 1: teleport.subca.v1.CertAuthorityOverrideSpec
 	(*CertAuthorityOverrideStatus)(nil), // 2: teleport.subca.v1.CertAuthorityOverrideStatus
-	nil,                                 // 3: teleport.subca.v1.CertAuthorityOverrideStatus.PublicKeyHashToCrlEntry
-	(*v1.Metadata)(nil),                 // 4: teleport.header.v1.Metadata
-	(*CertificateOverride)(nil),         // 5: teleport.subca.v1.CertificateOverride
-	(*CertificateRevocationList)(nil),   // 6: teleport.subca.v1.CertificateRevocationList
+	(*PendingCSRRequest)(nil),           // 3: teleport.subca.v1.PendingCSRRequest
+	(*PendingCSR)(nil),                  // 4: teleport.subca.v1.PendingCSR
+	nil,                                 // 5: teleport.subca.v1.CertAuthorityOverrideStatus.PublicKeyHashToCrlEntry
+	nil,                                 // 6: teleport.subca.v1.CertAuthorityOverrideStatus.IdToPendingCsrRequestEntry
+	(*v1.Metadata)(nil),                 // 7: teleport.header.v1.Metadata
+	(*CertificateOverride)(nil),         // 8: teleport.subca.v1.CertificateOverride
+	(*timestamppb.Timestamp)(nil),       // 9: google.protobuf.Timestamp
+	(*DistinguishedName)(nil),           // 10: teleport.subca.v1.DistinguishedName
+	(*PublicKeyHash)(nil),               // 11: teleport.subca.v1.PublicKeyHash
+	(*CertificateSigningRequest)(nil),   // 12: teleport.subca.v1.CertificateSigningRequest
+	(*status.Status)(nil),               // 13: google.rpc.Status
+	(*CertificateRevocationList)(nil),   // 14: teleport.subca.v1.CertificateRevocationList
 }
 var file_teleport_subca_v1_cert_authority_override_proto_depIdxs = []int32{
-	4, // 0: teleport.subca.v1.CertAuthorityOverride.metadata:type_name -> teleport.header.v1.Metadata
-	1, // 1: teleport.subca.v1.CertAuthorityOverride.spec:type_name -> teleport.subca.v1.CertAuthorityOverrideSpec
-	2, // 2: teleport.subca.v1.CertAuthorityOverride.status:type_name -> teleport.subca.v1.CertAuthorityOverrideStatus
-	5, // 3: teleport.subca.v1.CertAuthorityOverrideSpec.certificate_overrides:type_name -> teleport.subca.v1.CertificateOverride
-	3, // 4: teleport.subca.v1.CertAuthorityOverrideStatus.public_key_hash_to_crl:type_name -> teleport.subca.v1.CertAuthorityOverrideStatus.PublicKeyHashToCrlEntry
-	6, // 5: teleport.subca.v1.CertAuthorityOverrideStatus.PublicKeyHashToCrlEntry.value:type_name -> teleport.subca.v1.CertificateRevocationList
-	6, // [6:6] is the sub-list for method output_type
-	6, // [6:6] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	7,  // 0: teleport.subca.v1.CertAuthorityOverride.metadata:type_name -> teleport.header.v1.Metadata
+	1,  // 1: teleport.subca.v1.CertAuthorityOverride.spec:type_name -> teleport.subca.v1.CertAuthorityOverrideSpec
+	2,  // 2: teleport.subca.v1.CertAuthorityOverride.status:type_name -> teleport.subca.v1.CertAuthorityOverrideStatus
+	8,  // 3: teleport.subca.v1.CertAuthorityOverrideSpec.certificate_overrides:type_name -> teleport.subca.v1.CertificateOverride
+	5,  // 4: teleport.subca.v1.CertAuthorityOverrideStatus.public_key_hash_to_crl:type_name -> teleport.subca.v1.CertAuthorityOverrideStatus.PublicKeyHashToCrlEntry
+	6,  // 5: teleport.subca.v1.CertAuthorityOverrideStatus.id_to_pending_csr_request:type_name -> teleport.subca.v1.CertAuthorityOverrideStatus.IdToPendingCsrRequestEntry
+	9,  // 6: teleport.subca.v1.PendingCSRRequest.create_time:type_name -> google.protobuf.Timestamp
+	4,  // 7: teleport.subca.v1.PendingCSRRequest.csrs:type_name -> teleport.subca.v1.PendingCSR
+	10, // 8: teleport.subca.v1.PendingCSRRequest.custom_subject:type_name -> teleport.subca.v1.DistinguishedName
+	11, // 9: teleport.subca.v1.PendingCSR.public_key_hash:type_name -> teleport.subca.v1.PublicKeyHash
+	12, // 10: teleport.subca.v1.PendingCSR.csr:type_name -> teleport.subca.v1.CertificateSigningRequest
+	13, // 11: teleport.subca.v1.PendingCSR.status:type_name -> google.rpc.Status
+	14, // 12: teleport.subca.v1.CertAuthorityOverrideStatus.PublicKeyHashToCrlEntry.value:type_name -> teleport.subca.v1.CertificateRevocationList
+	3,  // 13: teleport.subca.v1.CertAuthorityOverrideStatus.IdToPendingCsrRequestEntry.value:type_name -> teleport.subca.v1.PendingCSRRequest
+	14, // [14:14] is the sub-list for method output_type
+	14, // [14:14] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_teleport_subca_v1_cert_authority_override_proto_init() }
@@ -391,13 +695,16 @@ func file_teleport_subca_v1_cert_authority_override_proto_init() {
 	}
 	file_teleport_subca_v1_certificate_override_proto_init()
 	file_teleport_subca_v1_crl_proto_init()
+	file_teleport_subca_v1_csr_proto_init()
+	file_teleport_subca_v1_distinguished_name_proto_init()
+	file_teleport_subca_v1_public_key_hash_proto_init()
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_subca_v1_cert_authority_override_proto_rawDesc), len(file_teleport_subca_v1_cert_authority_override_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/subca/v1/certificate_override.pb.go
+++ b/api/gen/proto/go/teleport/subca/v1/certificate_override.pb.go
@@ -72,6 +72,9 @@ type CertificateOverride struct {
 	// A disabled override may exist for recording purposes, to be enabled later,
 	// or simply to mark a certain public key as not overridden. In the latter
 	// case the certificate may be absent.
+	//
+	// Disabled overrides also allow CRLs to be created asynchronously, using
+	// CertAuthorityOverride watchers.
 	Disabled      bool `protobuf:"varint,4,opt,name=disabled,proto3" json:"disabled,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -177,6 +180,9 @@ type CertificateOverride_builder struct {
 	// A disabled override may exist for recording purposes, to be enabled later,
 	// or simply to mark a certain public key as not overridden. In the latter
 	// case the certificate may be absent.
+	//
+	// Disabled overrides also allow CRLs to be created asynchronously, using
+	// CertAuthorityOverride watchers.
 	Disabled bool
 }
 

--- a/api/gen/proto/go/teleport/subca/v1/certificate_override_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/subca/v1/certificate_override_protoopaque.pb.go
@@ -152,6 +152,9 @@ type CertificateOverride_builder struct {
 	// A disabled override may exist for recording purposes, to be enabled later,
 	// or simply to mark a certain public key as not overridden. In the latter
 	// case the certificate may be absent.
+	//
+	// Disabled overrides also allow CRLs to be created asynchronously, using
+	// CertAuthorityOverride watchers.
 	Disabled bool
 }
 

--- a/api/gen/proto/go/teleport/subca/v1/subca_service.pb.go
+++ b/api/gen/proto/go/teleport/subca/v1/subca_service.pb.go
@@ -54,6 +54,9 @@ type CreateCSRRequest struct {
 	//
 	// Optional. If present the request must target a single certificate.
 	CustomSubject *DistinguishedName `protobuf:"bytes,3,opt,name=custom_subject,json=customSubject,proto3" json:"custom_subject,omitempty"`
+	// If true don't fanout CSR requests of unusable private keys to other Auth
+	// servers.
+	LocalOnly     bool `protobuf:"varint,4,opt,name=local_only,json=localOnly,proto3" json:"local_only,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -104,6 +107,13 @@ func (x *CreateCSRRequest) GetCustomSubject() *DistinguishedName {
 	return nil
 }
 
+func (x *CreateCSRRequest) GetLocalOnly() bool {
+	if x != nil {
+		return x.LocalOnly
+	}
+	return false
+}
+
 func (x *CreateCSRRequest) SetCaType(v string) {
 	x.CaType = v
 }
@@ -114,6 +124,10 @@ func (x *CreateCSRRequest) SetPublicKeyHash(v *PublicKeyHash) {
 
 func (x *CreateCSRRequest) SetCustomSubject(v *DistinguishedName) {
 	x.CustomSubject = v
+}
+
+func (x *CreateCSRRequest) SetLocalOnly(v bool) {
+	x.LocalOnly = v
 }
 
 func (x *CreateCSRRequest) HasPublicKeyHash() bool {
@@ -155,6 +169,9 @@ type CreateCSRRequest_builder struct {
 	//
 	// Optional. If present the request must target a single certificate.
 	CustomSubject *DistinguishedName
+	// If true don't fanout CSR requests of unusable private keys to other Auth
+	// servers.
+	LocalOnly bool
 }
 
 func (b0 CreateCSRRequest_builder) Build() *CreateCSRRequest {
@@ -164,6 +181,7 @@ func (b0 CreateCSRRequest_builder) Build() *CreateCSRRequest {
 	x.CaType = b.CaType
 	x.PublicKeyHash = b.PublicKeyHash
 	x.CustomSubject = b.CustomSubject
+	x.LocalOnly = b.LocalOnly
 	return m0
 }
 
@@ -1692,11 +1710,13 @@ var File_teleport_subca_v1_subca_service_proto protoreflect.FileDescriptor
 
 const file_teleport_subca_v1_subca_service_proto_rawDesc = "" +
 	"\n" +
-	"%teleport/subca/v1/subca_service.proto\x12\x11teleport.subca.v1\x1a google/protobuf/field_mask.proto\x1a/teleport/subca/v1/cert_authority_override.proto\x1a2teleport/subca/v1/cert_authority_override_id.proto\x1a,teleport/subca/v1/certificate_override.proto\x1a/teleport/subca/v1/certificate_override_id.proto\x1a\x1bteleport/subca/v1/csr.proto\x1a*teleport/subca/v1/distinguished_name.proto\x1a'teleport/subca/v1/public_key_hash.proto\"\xc2\x01\n" +
+	"%teleport/subca/v1/subca_service.proto\x12\x11teleport.subca.v1\x1a google/protobuf/field_mask.proto\x1a/teleport/subca/v1/cert_authority_override.proto\x1a2teleport/subca/v1/cert_authority_override_id.proto\x1a,teleport/subca/v1/certificate_override.proto\x1a/teleport/subca/v1/certificate_override_id.proto\x1a\x1bteleport/subca/v1/csr.proto\x1a*teleport/subca/v1/distinguished_name.proto\x1a'teleport/subca/v1/public_key_hash.proto\"\xe1\x01\n" +
 	"\x10CreateCSRRequest\x12\x17\n" +
 	"\aca_type\x18\x01 \x01(\tR\x06caType\x12H\n" +
 	"\x0fpublic_key_hash\x18\x02 \x01(\v2 .teleport.subca.v1.PublicKeyHashR\rpublicKeyHash\x12K\n" +
-	"\x0ecustom_subject\x18\x03 \x01(\v2$.teleport.subca.v1.DistinguishedNameR\rcustomSubject\"U\n" +
+	"\x0ecustom_subject\x18\x03 \x01(\v2$.teleport.subca.v1.DistinguishedNameR\rcustomSubject\x12\x1d\n" +
+	"\n" +
+	"local_only\x18\x04 \x01(\bR\tlocalOnly\"U\n" +
 	"\x11CreateCSRResponse\x12@\n" +
 	"\x04csrs\x18\x01 \x03(\v2,.teleport.subca.v1.CertificateSigningRequestR\x04csrs\"o\n" +
 	"\"CreateCertAuthorityOverrideRequest\x12I\n" +

--- a/api/gen/proto/go/teleport/subca/v1/subca_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/subca/v1/subca_service_grpc.pb.go
@@ -73,11 +73,19 @@ type SubCAServiceClient interface {
 	// CreateCSR creates certificate signing requests for all certificates of the
 	// specified CA, in preparation for the creation of a CertAuthorityOverride.
 	//
-	// On clusters that use HSMs this must be called on every Auth server
-	// instance, so it every private key is covered. Each Auth issues CSRs for all
-	// the private keys it holds.
+	// On clusters where Auth server instances have access to distinct keys
+	// (multi-Auth, multi-HSM), CreateCSR attempts to collect CSRs from all Auth
+	// servers using CertAuthorityOverride watchers (see
+	// CertAuthorityOverrideStatus.id_to_pending_csr_request). Attempts are gated
+	// on a timeout. If too much time passes the RPC returns as many CSRs as it
+	// managed to collect. If necessary, a watcher-based request will create an
+	// empty CertAuthorityOverride resource for the corresponding CA type.
 	//
-	// CreateCSR requires cert_authority_override:read+list permissions.
+	// If local_only is set the request won't fanout to other Auth servers,
+	// instead it will use local keys. In this case, each Auth server must be
+	// contacted independently to create their corresponding CSRs.
+	//
+	// CreateCSR requires cert_authority_override:create+update permissions.
 	CreateCSR(ctx context.Context, in *CreateCSRRequest, opts ...grpc.CallOption) (*CreateCSRResponse, error)
 	// CreateCertAuthorityOverride creates a CertAuthorityOverride resource.
 	//
@@ -98,7 +106,7 @@ type SubCAServiceClient interface {
 	// Added certificate overrides may take effect immediately depending on the
 	// value of CertificateOverride.disabled. See it for reference.
 	UpsertCertAuthorityOverride(ctx context.Context, in *UpsertCertAuthorityOverrideRequest, opts ...grpc.CallOption) (*UpsertCertAuthorityOverrideResponse, error)
-	// AddCertificateOverride adds a single CertiticateOverride to a
+	// AddCertificateOverride adds a single CertificateOverride to a
 	// CertAuthorityOverride resource.
 	//
 	// The CertAuthorityOverride resource may be created as a consequence of this
@@ -107,13 +115,13 @@ type SubCAServiceClient interface {
 	// Added certificate overrides may take effect immediately depending on the
 	// value of CertificateOverride.disabled. See it for reference.
 	AddCertificateOverride(ctx context.Context, in *AddCertificateOverrideRequest, opts ...grpc.CallOption) (*AddCertificateOverrideResponse, error)
-	// UpdateCertificateOverride updates a single CertiticateOverride in a
+	// UpdateCertificateOverride updates a single CertificateOverride in a
 	// CertAuthorityOverride resource.
 	//
 	// Disabling an active override is disallowed. See
 	// UpdateCertificateOverrideRequest.force_immediate_disable.
 	UpdateCertificateOverride(ctx context.Context, in *UpdateCertificateOverrideRequest, opts ...grpc.CallOption) (*UpdateCertificateOverrideResponse, error)
-	// RemoveCertificateOverride removes a single CertiticateOverride inside a
+	// RemoveCertificateOverride removes a single CertificateOverride inside a
 	// CertAuthorityOverride resource.
 	//
 	// If the last CertificateOverride of a CertAuthorityOverride is removed as a
@@ -276,11 +284,19 @@ type SubCAServiceServer interface {
 	// CreateCSR creates certificate signing requests for all certificates of the
 	// specified CA, in preparation for the creation of a CertAuthorityOverride.
 	//
-	// On clusters that use HSMs this must be called on every Auth server
-	// instance, so it every private key is covered. Each Auth issues CSRs for all
-	// the private keys it holds.
+	// On clusters where Auth server instances have access to distinct keys
+	// (multi-Auth, multi-HSM), CreateCSR attempts to collect CSRs from all Auth
+	// servers using CertAuthorityOverride watchers (see
+	// CertAuthorityOverrideStatus.id_to_pending_csr_request). Attempts are gated
+	// on a timeout. If too much time passes the RPC returns as many CSRs as it
+	// managed to collect. If necessary, a watcher-based request will create an
+	// empty CertAuthorityOverride resource for the corresponding CA type.
 	//
-	// CreateCSR requires cert_authority_override:read+list permissions.
+	// If local_only is set the request won't fanout to other Auth servers,
+	// instead it will use local keys. In this case, each Auth server must be
+	// contacted independently to create their corresponding CSRs.
+	//
+	// CreateCSR requires cert_authority_override:create+update permissions.
 	CreateCSR(context.Context, *CreateCSRRequest) (*CreateCSRResponse, error)
 	// CreateCertAuthorityOverride creates a CertAuthorityOverride resource.
 	//
@@ -301,7 +317,7 @@ type SubCAServiceServer interface {
 	// Added certificate overrides may take effect immediately depending on the
 	// value of CertificateOverride.disabled. See it for reference.
 	UpsertCertAuthorityOverride(context.Context, *UpsertCertAuthorityOverrideRequest) (*UpsertCertAuthorityOverrideResponse, error)
-	// AddCertificateOverride adds a single CertiticateOverride to a
+	// AddCertificateOverride adds a single CertificateOverride to a
 	// CertAuthorityOverride resource.
 	//
 	// The CertAuthorityOverride resource may be created as a consequence of this
@@ -310,13 +326,13 @@ type SubCAServiceServer interface {
 	// Added certificate overrides may take effect immediately depending on the
 	// value of CertificateOverride.disabled. See it for reference.
 	AddCertificateOverride(context.Context, *AddCertificateOverrideRequest) (*AddCertificateOverrideResponse, error)
-	// UpdateCertificateOverride updates a single CertiticateOverride in a
+	// UpdateCertificateOverride updates a single CertificateOverride in a
 	// CertAuthorityOverride resource.
 	//
 	// Disabling an active override is disallowed. See
 	// UpdateCertificateOverrideRequest.force_immediate_disable.
 	UpdateCertificateOverride(context.Context, *UpdateCertificateOverrideRequest) (*UpdateCertificateOverrideResponse, error)
-	// RemoveCertificateOverride removes a single CertiticateOverride inside a
+	// RemoveCertificateOverride removes a single CertificateOverride inside a
 	// CertAuthorityOverride resource.
 	//
 	// If the last CertificateOverride of a CertAuthorityOverride is removed as a

--- a/api/gen/proto/go/teleport/subca/v1/subca_service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/subca/v1/subca_service_protoopaque.pb.go
@@ -43,6 +43,7 @@ type CreateCSRRequest struct {
 	xxx_hidden_CaType        string                 `protobuf:"bytes,1,opt,name=ca_type,json=caType,proto3"`
 	xxx_hidden_PublicKeyHash *PublicKeyHash         `protobuf:"bytes,2,opt,name=public_key_hash,json=publicKeyHash,proto3"`
 	xxx_hidden_CustomSubject *DistinguishedName     `protobuf:"bytes,3,opt,name=custom_subject,json=customSubject,proto3"`
+	xxx_hidden_LocalOnly     bool                   `protobuf:"varint,4,opt,name=local_only,json=localOnly,proto3"`
 	unknownFields            protoimpl.UnknownFields
 	sizeCache                protoimpl.SizeCache
 }
@@ -93,6 +94,13 @@ func (x *CreateCSRRequest) GetCustomSubject() *DistinguishedName {
 	return nil
 }
 
+func (x *CreateCSRRequest) GetLocalOnly() bool {
+	if x != nil {
+		return x.xxx_hidden_LocalOnly
+	}
+	return false
+}
+
 func (x *CreateCSRRequest) SetCaType(v string) {
 	x.xxx_hidden_CaType = v
 }
@@ -103,6 +111,10 @@ func (x *CreateCSRRequest) SetPublicKeyHash(v *PublicKeyHash) {
 
 func (x *CreateCSRRequest) SetCustomSubject(v *DistinguishedName) {
 	x.xxx_hidden_CustomSubject = v
+}
+
+func (x *CreateCSRRequest) SetLocalOnly(v bool) {
+	x.xxx_hidden_LocalOnly = v
 }
 
 func (x *CreateCSRRequest) HasPublicKeyHash() bool {
@@ -144,6 +156,9 @@ type CreateCSRRequest_builder struct {
 	//
 	// Optional. If present the request must target a single certificate.
 	CustomSubject *DistinguishedName
+	// If true don't fanout CSR requests of unusable private keys to other Auth
+	// servers.
+	LocalOnly bool
 }
 
 func (b0 CreateCSRRequest_builder) Build() *CreateCSRRequest {
@@ -153,6 +168,7 @@ func (b0 CreateCSRRequest_builder) Build() *CreateCSRRequest {
 	x.xxx_hidden_CaType = b.CaType
 	x.xxx_hidden_PublicKeyHash = b.PublicKeyHash
 	x.xxx_hidden_CustomSubject = b.CustomSubject
+	x.xxx_hidden_LocalOnly = b.LocalOnly
 	return m0
 }
 
@@ -1632,11 +1648,13 @@ var File_teleport_subca_v1_subca_service_proto protoreflect.FileDescriptor
 
 const file_teleport_subca_v1_subca_service_proto_rawDesc = "" +
 	"\n" +
-	"%teleport/subca/v1/subca_service.proto\x12\x11teleport.subca.v1\x1a google/protobuf/field_mask.proto\x1a/teleport/subca/v1/cert_authority_override.proto\x1a2teleport/subca/v1/cert_authority_override_id.proto\x1a,teleport/subca/v1/certificate_override.proto\x1a/teleport/subca/v1/certificate_override_id.proto\x1a\x1bteleport/subca/v1/csr.proto\x1a*teleport/subca/v1/distinguished_name.proto\x1a'teleport/subca/v1/public_key_hash.proto\"\xc2\x01\n" +
+	"%teleport/subca/v1/subca_service.proto\x12\x11teleport.subca.v1\x1a google/protobuf/field_mask.proto\x1a/teleport/subca/v1/cert_authority_override.proto\x1a2teleport/subca/v1/cert_authority_override_id.proto\x1a,teleport/subca/v1/certificate_override.proto\x1a/teleport/subca/v1/certificate_override_id.proto\x1a\x1bteleport/subca/v1/csr.proto\x1a*teleport/subca/v1/distinguished_name.proto\x1a'teleport/subca/v1/public_key_hash.proto\"\xe1\x01\n" +
 	"\x10CreateCSRRequest\x12\x17\n" +
 	"\aca_type\x18\x01 \x01(\tR\x06caType\x12H\n" +
 	"\x0fpublic_key_hash\x18\x02 \x01(\v2 .teleport.subca.v1.PublicKeyHashR\rpublicKeyHash\x12K\n" +
-	"\x0ecustom_subject\x18\x03 \x01(\v2$.teleport.subca.v1.DistinguishedNameR\rcustomSubject\"U\n" +
+	"\x0ecustom_subject\x18\x03 \x01(\v2$.teleport.subca.v1.DistinguishedNameR\rcustomSubject\x12\x1d\n" +
+	"\n" +
+	"local_only\x18\x04 \x01(\bR\tlocalOnly\"U\n" +
 	"\x11CreateCSRResponse\x12@\n" +
 	"\x04csrs\x18\x01 \x03(\v2,.teleport.subca.v1.CertificateSigningRequestR\x04csrs\"o\n" +
 	"\"CreateCertAuthorityOverrideRequest\x12I\n" +

--- a/api/proto/teleport/subca/v1/cert_authority_override.proto
+++ b/api/proto/teleport/subca/v1/cert_authority_override.proto
@@ -68,6 +68,10 @@ message CertAuthorityOverrideSpec {
 message CertAuthorityOverrideStatus {
   // CRLs generated for each certificate override, keyed by normalized/lowercase
   // public_key_hash.
+  //
+  // CRLs for disabled overrides may be created asynchronously, using
+  // CertAuthorityOverride watchers, if the Auth server performing the writes
+  // lacks access to certain keys.
   map<string, CertificateRevocationList> public_key_hash_to_crl = 1;
 
   // Pending CSR requests on multi-Auth, multi-HSM scenarios.

--- a/api/proto/teleport/subca/v1/cert_authority_override.proto
+++ b/api/proto/teleport/subca/v1/cert_authority_override.proto
@@ -16,9 +16,14 @@ syntax = "proto3";
 
 package teleport.subca.v1;
 
+import "google/protobuf/timestamp.proto";
+import "google/rpc/status.proto";
 import "teleport/header/v1/metadata.proto";
 import "teleport/subca/v1/certificate_override.proto";
 import "teleport/subca/v1/crl.proto";
+import "teleport/subca/v1/csr.proto";
+import "teleport/subca/v1/distinguished_name.proto";
+import "teleport/subca/v1/public_key_hash.proto";
 
 option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1;subcav1";
 
@@ -31,7 +36,7 @@ option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport
 // self-signed root).
 //
 // Key material is never impacted by overrides, only certificates can be
-// overriden.
+// overridden.
 //
 // https://github.com/gravitational/teleport/blob/master/rfd/0237-sub-ca-support.md
 message CertAuthorityOverride {
@@ -64,4 +69,47 @@ message CertAuthorityOverrideStatus {
   // CRLs generated for each certificate override, keyed by normalized/lowercase
   // public_key_hash.
   map<string, CertificateRevocationList> public_key_hash_to_crl = 1;
+
+  // Pending CSR requests on multi-Auth, multi-HSM scenarios.
+  // Requests are keyed by an opaque request ID.
+  map<string, PendingCSRRequest> id_to_pending_csr_request = 2;
+}
+
+// A pending CSR request, created as part of a CreateCSR invocation on
+// multi-Auth, multi-HSM clusters.
+//
+// Requests are registered by the requester Auth server (the one processing the
+// CreateCSR call), in multi-HSM scenarios, when certain keys can't be used.
+// Auth servers watch CertAuthorityOverride resources and reply to requests
+// automatically, assigning a CSR and status to the corresponding PendingCSR
+// message. Once all pending CSRs have a terminal result, the RPC resumes.
+//
+// Successful pending requests are automatically cleaned up from status on
+// completion. Failed pending requests obey the normal create_time rules.
+message PendingCSRRequest {
+  // Create time of the request.
+  // Requests that are older than a certain threshold value may be automatically
+  // cleaned up by the system, regardless of their status.
+  google.protobuf.Timestamp create_time = 1;
+
+  // Pending CSRs of the request.
+  // CSRs are created and set by watching Auth servers.
+  repeated PendingCSR csrs = 2;
+
+  // Custom subject for the CSRs.
+  // Optional.
+  DistinguishedName custom_subject = 3;
+}
+
+// A pending CSR, to be created as part of a [PendingCSRRequest].
+message PendingCSR {
+  // Target public key of the CSR.
+  PublicKeyHash public_key_hash = 1;
+  // The CSR itself.
+  // Assigned by the watching Auth server when created. Non-nil if status is OK.
+  CertificateSigningRequest csr = 2;
+  // Status of the CSR signing attempt.
+  // Nil means no attempt was recorded. If non-nil, the attempt happened and
+  // won't be retried.
+  google.rpc.Status status = 3;
 }

--- a/api/proto/teleport/subca/v1/certificate_override.proto
+++ b/api/proto/teleport/subca/v1/certificate_override.proto
@@ -56,5 +56,8 @@ message CertificateOverride {
   // A disabled override may exist for recording purposes, to be enabled later,
   // or simply to mark a certain public key as not overridden. In the latter
   // case the certificate may be absent.
+  //
+  // Disabled overrides also allow CRLs to be created asynchronously, using
+  // CertAuthorityOverride watchers.
   bool disabled = 4;
 }

--- a/api/proto/teleport/subca/v1/subca_service.proto
+++ b/api/proto/teleport/subca/v1/subca_service.proto
@@ -51,11 +51,19 @@ service SubCAService {
   // CreateCSR creates certificate signing requests for all certificates of the
   // specified CA, in preparation for the creation of a CertAuthorityOverride.
   //
-  // On clusters that use HSMs this must be called on every Auth server
-  // instance, so it every private key is covered. Each Auth issues CSRs for all
-  // the private keys it holds.
+  // On clusters where Auth server instances have access to distinct keys
+  // (multi-Auth, multi-HSM), CreateCSR attempts to collect CSRs from all Auth
+  // servers using CertAuthorityOverride watchers (see
+  // CertAuthorityOverrideStatus.id_to_pending_csr_request). Attempts are gated
+  // on a timeout. If too much time passes the RPC returns as many CSRs as it
+  // managed to collect. If necessary, a watcher-based request will create an
+  // empty CertAuthorityOverride resource for the corresponding CA type.
   //
-  // CreateCSR requires cert_authority_override:read+list permissions.
+  // If local_only is set the request won't fanout to other Auth servers,
+  // instead it will use local keys. In this case, each Auth server must be
+  // contacted independently to create their corresponding CSRs.
+  //
+  // CreateCSR requires cert_authority_override:create+update permissions.
   rpc CreateCSR(CreateCSRRequest) returns (CreateCSRResponse);
 
   // CreateCertAuthorityOverride creates a CertAuthorityOverride resource.
@@ -145,6 +153,10 @@ message CreateCSRRequest {
   //
   // Optional. If present the request must target a single certificate.
   DistinguishedName custom_subject = 3;
+
+  // If true don't fanout CSR requests of unusable private keys to other Auth
+  // servers.
+  bool local_only = 4;
 }
 
 // Response for CreateCSR.

--- a/api/proto/teleport/subca/v1/subca_service.proto
+++ b/api/proto/teleport/subca/v1/subca_service.proto
@@ -88,7 +88,7 @@ service SubCAService {
   // value of CertificateOverride.disabled. See it for reference.
   rpc UpsertCertAuthorityOverride(UpsertCertAuthorityOverrideRequest) returns (UpsertCertAuthorityOverrideResponse);
 
-  // AddCertificateOverride adds a single CertiticateOverride to a
+  // AddCertificateOverride adds a single CertificateOverride to a
   // CertAuthorityOverride resource.
   //
   // The CertAuthorityOverride resource may be created as a consequence of this
@@ -98,14 +98,14 @@ service SubCAService {
   // value of CertificateOverride.disabled. See it for reference.
   rpc AddCertificateOverride(AddCertificateOverrideRequest) returns (AddCertificateOverrideResponse);
 
-  // UpdateCertificateOverride updates a single CertiticateOverride in a
+  // UpdateCertificateOverride updates a single CertificateOverride in a
   // CertAuthorityOverride resource.
   //
   // Disabling an active override is disallowed. See
   // UpdateCertificateOverrideRequest.force_immediate_disable.
   rpc UpdateCertificateOverride(UpdateCertificateOverrideRequest) returns (UpdateCertificateOverrideResponse);
 
-  // RemoveCertificateOverride removes a single CertiticateOverride inside a
+  // RemoveCertificateOverride removes a single CertificateOverride inside a
   // CertAuthorityOverride resource.
   //
   // If the last CertificateOverride of a CertAuthorityOverride is removed as a


### PR DESCRIPTION
Add the ability to register "PendingCSRRequests" in CertAuthorityOverrideStatus. This is used in multi-HSM scenarios to request, via the watcher subsystem, that Auth server instances sign CSRs with their (exclusive) private keys.

Complementary to https://github.com/gravitational/teleport.e/pull/9035, as it allows closing the multi-HSM gap on the CreateCSR RPC.

https://github.com/gravitational/teleport.e/issues/7675