### PR TITLE
iOS: Make an event timeline view to communicate longrunning processes

### DIFF
--- a/mobile/Verify/Verify.xcodeproj/project.pbxproj
+++ b/mobile/Verify/Verify.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0C94C8CE2FA35F3D00C13C9A /* libresolv.9.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C94C8CD2FA35ED900C13C9A /* libresolv.9.tbd */; };
+		CD65C8012FF711CE002FB1CD /* IdentifiedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = CD65C8002FF711CE002FB1CD /* IdentifiedCollections */; };
 		CD7999232FE33AE000133048 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD79991B2FE33AE000133048 /* Core.framework */; };
 		CD7999242FE33AE000133048 /* Core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CD79991B2FE33AE000133048 /* Core.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CD79992C2FE33F0600133048 /* libresolv.9.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = CD79992B2FE33EFF00133048 /* libresolv.9.tbd */; };
@@ -95,6 +96,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0C94C8CE2FA35F3D00C13C9A /* libresolv.9.tbd in Frameworks */,
+				CD65C8012FF711CE002FB1CD /* IdentifiedCollections in Frameworks */,
 				CD7999232FE33AE000133048 /* Core.framework in Frameworks */,
 				CD7999D62FE9C9F300133048 /* SwiftUINavigation in Frameworks */,
 			);
@@ -188,6 +190,7 @@
 			name = Verify;
 			packageProductDependencies = (
 				CD7999D52FE9C9F300133048 /* SwiftUINavigation */,
+				CD65C8002FF711CE002FB1CD /* IdentifiedCollections */,
 			);
 			productName = Verify;
 			productReference = 0C94C8522FA232E600C13C9A /* Verify.app */;
@@ -281,6 +284,7 @@
 				CDDEB8752FE1F5F10052BC27 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */,
 				CD7999312FE345D400133048 /* XCRemoteSwiftPackageReference "swift-dependencies" */,
 				CD7999D42FE9C9F300133048 /* XCRemoteSwiftPackageReference "swift-navigation" */,
+				CD65C7FF2FF711CE002FB1CD /* XCRemoteSwiftPackageReference "swift-identified-collections" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 0C94C8532FA232E600C13C9A /* Products */;
@@ -828,6 +832,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		CD65C7FF2FF711CE002FB1CD /* XCRemoteSwiftPackageReference "swift-identified-collections" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pointfreeco/swift-identified-collections";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.1;
+			};
+		};
 		CD7999312FE345D400133048 /* XCRemoteSwiftPackageReference "swift-dependencies" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swift-dependencies";
@@ -855,6 +867,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		CD65C8002FF711CE002FB1CD /* IdentifiedCollections */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CD65C7FF2FF711CE002FB1CD /* XCRemoteSwiftPackageReference "swift-identified-collections" */;
+			productName = IdentifiedCollections;
+		};
 		CD7999282FE33B7E00133048 /* SwiftLintBuildToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = CDDEB8752FE1F5F10052BC27 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */;

--- a/mobile/Verify/Verify.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile/Verify/Verify.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c838215d62b4997f60cd867f02d8cd46eb80a505e276b4e9370658ac42876f0f",
+  "originHash" : "193f793effae36b92d066c08e527277b1a7ef7e9799f2423a3fa5de77f6451bc",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -62,6 +62,15 @@
       "state" : {
         "revision" : "008b012380623976ce2b9c92c5bf2bda8bcf5e55",
         "version" : "1.14.0"
+      }
+    },
+    {
+      "identity" : "swift-identified-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-identified-collections",
+      "state" : {
+        "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
+        "version" : "1.1.1"
       }
     },
     {

--- a/mobile/Verify/Verify/Components/EventStackView.swift
+++ b/mobile/Verify/Verify/Components/EventStackView.swift
@@ -37,6 +37,7 @@ struct EventStackView<ID: Hashable>: View {
 				row(for: event)
 			}
 		}
+		.frame(maxWidth: .infinity, alignment: .leading)
 	}
 
 	private func row(for event: Event) -> some View {

--- a/mobile/Verify/Verify/Components/EventStackView.swift
+++ b/mobile/Verify/Verify/Components/EventStackView.swift
@@ -1,0 +1,112 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/
+
+import Foundation
+import SwiftUI
+
+struct EventStackView<ID: Hashable>: View {
+	struct Event: Identifiable {
+		var id: ID
+		var status: Status
+		var message: String
+	}
+
+	// swiftformat:sort
+	enum Status {
+		case failure
+		case loading
+		case success
+		case warning
+	}
+
+	let events: [Event]
+
+	@ScaledMetric
+	private var barHeight: CGFloat = 14 // hardcode the point size of SwiftUI's body font
+
+	@ScaledMetric
+	private var leadingPadding: CGFloat = .small
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: .xxsmall) {
+			ForEach(events) { event in
+				Label {
+					if event.status == .loading {
+						Text(event.message)
+							.foregroundStyle(Color.Foreground.slightlyMuted)
+							.phaseAnimator([1.0, 0.5]) { content, opacity in
+								content.opacity(opacity)
+							} animation: { _ in
+								.linear(duration: 0.8)
+							}
+					} else {
+						Text(event.message)
+							.foregroundStyle(Color.Foreground.slightlyMuted)
+					}
+				} icon: {
+					icon(for: event.status)
+				}
+				if event.id != events.last?.id {
+					Label {
+						Text("")
+					} icon: {
+						Capsule()
+							.fill(Color.Foreground.muted)
+							.frame(maxWidth: .xxsmall, maxHeight: barHeight)
+							.padding(.leading, leadingPadding)
+					}
+				}
+			}
+		}
+	}
+
+	@ViewBuilder
+	private func icon(for status: Status) -> some View {
+		let image = switch status {
+			case .failure:
+				Image(systemName: "xmark.circle")
+			case .loading:
+				Image(systemName: "circle.dotted")
+			case .success:
+				Image(systemName: "checkmark.circle")
+			case .warning:
+				Image(systemName: "exclamationmark.circle")
+		}
+		let color: Color = switch status {
+			case .failure: .danger
+			case .loading: Color.Foreground.slightlyMuted
+			case .success: .success
+			case .warning: .alert
+		}
+		if status == .loading {
+			image.foregroundStyle(color)
+				.symbolEffect(.rotate)
+		} else {
+			image.foregroundStyle(color)
+		}
+	}
+}
+
+#Preview {
+	EventStackView(events: [
+		.init(id: 1, status: .success, message: "You threw a Pokéball..."),
+		.init(id: 2, status: .failure, message: "Oh no! The Pokémon broke free!"),
+		.init(id: 3, status: .success, message: "You threw another Pokéball..."),
+		.init(id: 4, status: .warning, message: "Shoot! It was so close, too!"),
+		.init(id: 5, status: .success, message: "You threw yet another Pokéball..."),
+		.init(id: 6, status: .loading, message: "*wobble*"),
+	])
+}

--- a/mobile/Verify/Verify/Components/EventStackView.swift
+++ b/mobile/Verify/Verify/Components/EventStackView.swift
@@ -17,7 +17,9 @@
 import Foundation
 import SwiftUI
 
+/// A general-purpose view for showing a sequence of events on a timeline with associated icons.
 struct EventStackView<ID: Hashable>: View {
+	/// A single devent to be displayed inside an EventStackView.
 	struct Event: Identifiable {
 		var id: ID
 		var status: Status
@@ -25,6 +27,7 @@ struct EventStackView<ID: Hashable>: View {
 	}
 
 	// swiftformat:sort
+	/// The status of a particular event, which will determine its icon and UI treatment.
 	enum Status {
 		case failure
 		case loading
@@ -35,42 +38,38 @@ struct EventStackView<ID: Hashable>: View {
 	let events: [Event]
 
 	@ScaledMetric
-	private var barHeight: CGFloat = 14 // hardcode the point size of SwiftUI's body font
+	private var minimumBarHeight: CGFloat = .medium
 
-	@ScaledMetric
-	private var leadingPadding: CGFloat = .small
+	@ScaledMetric(relativeTo: .body)
+	private var barWidth: CGFloat = .xxsmall
 
 	var body: some View {
 		VStack(alignment: .leading, spacing: .xxsmall) {
 			ForEach(events) { event in
-				Label {
-					if event.status == .loading {
-						Text(event.message)
-							.foregroundStyle(Color.Foreground.slightlyMuted)
-							.phaseAnimator([1.0, 0.5]) { content, opacity in
-								content.opacity(opacity)
-							} animation: { _ in
-								.linear(duration: 0.8)
-							}
-					} else {
-						Text(event.message)
-							.foregroundStyle(Color.Foreground.slightlyMuted)
-					}
-				} icon: {
-					icon(for: event.status)
-				}
-				if event.id != events.last?.id {
-					Label {
-						Text("")
-					} icon: {
-						Capsule()
-							.fill(Color.Foreground.muted)
-							.frame(maxWidth: .xxsmall, maxHeight: barHeight)
-							.padding(.leading, leadingPadding)
-					}
-				}
+				row(for: event)
 			}
 		}
+	}
+
+	private func row(for event: Event) -> some View {
+		HStack(alignment: .firstTextBaseline) {
+			VStack(alignment: .center) {
+				icon(for: event.status)
+				if event.id != events.last?.id {
+					Capsule()
+						.fill(Color.Foreground.muted)
+						.frame(maxWidth: barWidth, minHeight: minimumBarHeight)
+				}
+			}
+			label(for: event)
+				.padding(.bottom, .small)
+		}
+		/*
+		 Distilling the accessibilty representation down to just a message does lose _some_ information by not
+		 including the semantics of the icon, but this UI is general purpose enough that including semantic
+		 infomation about the icon may not always be appropriate.
+		 */
+		.accessibilityLabel(event.message)
 	}
 
 	@ViewBuilder
@@ -98,15 +97,38 @@ struct EventStackView<ID: Hashable>: View {
 			image.foregroundStyle(color)
 		}
 	}
+
+	private func label(for event: Event) -> some View {
+		Group {
+			if event.status == .loading {
+				Text(event.message)
+					.phaseAnimator([1.0, 0.5]) { content, opacity in
+						content.opacity(opacity)
+					} animation: { _ in
+						.linear(duration: 0.8)
+					}
+			} else {
+				Text(event.message)
+			}
+		}
+		.foregroundStyle(Color.Foreground.slightlyMuted)
+	}
 }
 
 #Preview {
-	EventStackView(events: [
-		.init(id: 1, status: .success, message: "You threw a Pokéball..."),
-		.init(id: 2, status: .failure, message: "Oh no! The Pokémon broke free!"),
-		.init(id: 3, status: .success, message: "You threw another Pokéball..."),
-		.init(id: 4, status: .warning, message: "Shoot! It was so close, too!"),
-		.init(id: 5, status: .success, message: "You threw yet another Pokéball..."),
-		.init(id: 6, status: .loading, message: "*wobble*"),
-	])
+	ScrollView {
+		EventStackView(events: [
+			.init(id: 1, status: .success, message: "You threw a Pokéball..."),
+			.init(id: 2, status: .failure, message: "Oh no! The Pokémon broke free!"),
+			.init(id: 3, status: .success, message: "You threw another Pokéball..."),
+			.init(
+				id: 4,
+				status: .warning,
+				message: "Shoot! It was so close, too! Some really really long text that will wrap even in small font sizes.",
+			),
+			.init(id: 5, status: .success, message: "You threw yet another Pokéball..."),
+			.init(id: 6, status: .loading, message: "*wobble*"),
+		])
+		.padding(.horizontal)
+	}
 }

--- a/mobile/Verify/Verify/Components/EventStackView.swift
+++ b/mobile/Verify/Verify/Components/EventStackView.swift
@@ -15,27 +15,15 @@
 // along with this program.  If not, see http://www.gnu.org/licenses/
 
 import Foundation
+import IdentifiedCollections
 import SwiftUI
 
 /// A general-purpose view for showing a sequence of events on a timeline with associated icons.
 struct EventStackView<ID: Hashable>: View {
-	/// A single devent to be displayed inside an EventStackView.
-	struct Event: Identifiable {
-		var id: ID
-		var status: Status
-		var message: String
-	}
+	typealias Event = EventStackViewModel<ID>.Event
+	typealias Status = EventStackViewModel<ID>.Status
 
-	// swiftformat:sort
-	/// The status of a particular event, which will determine its icon and UI treatment.
-	enum Status {
-		case failure
-		case loading
-		case success
-		case warning
-	}
-
-	let events: [Event]
+	let viewModel: EventStackViewModel<ID>
 
 	@ScaledMetric
 	private var minimumBarHeight: CGFloat = .medium
@@ -45,7 +33,7 @@ struct EventStackView<ID: Hashable>: View {
 
 	var body: some View {
 		VStack(alignment: .leading, spacing: .xxsmall) {
-			ForEach(events) { event in
+			ForEach(viewModel.events) { event in
 				row(for: event)
 			}
 		}
@@ -55,7 +43,7 @@ struct EventStackView<ID: Hashable>: View {
 		HStack(alignment: .firstTextBaseline) {
 			VStack(alignment: .center) {
 				icon(for: event.status)
-				if event.id != events.last?.id {
+				if event.id != viewModel.events.last?.id {
 					Capsule()
 						.fill(Color.Foreground.muted)
 						.frame(maxWidth: barWidth, minHeight: minimumBarHeight)
@@ -117,18 +105,20 @@ struct EventStackView<ID: Hashable>: View {
 
 #Preview {
 	ScrollView {
-		EventStackView(events: [
-			.init(id: 1, status: .success, message: "You threw a Pokéball..."),
-			.init(id: 2, status: .failure, message: "Oh no! The Pokémon broke free!"),
-			.init(id: 3, status: .success, message: "You threw another Pokéball..."),
-			.init(
-				id: 4,
-				status: .warning,
-				message: "Shoot! It was so close, too! Some really really long text that will wrap even in small font sizes.",
-			),
-			.init(id: 5, status: .success, message: "You threw yet another Pokéball..."),
-			.init(id: 6, status: .loading, message: "*wobble*"),
-		])
+		EventStackView(
+			viewModel: EventStackViewModel(events: [
+				.init(id: 1, status: .success, message: "You threw a Pokéball..."),
+				.init(id: 2, status: .failure, message: "Oh no! The Pokémon broke free!"),
+				.init(id: 3, status: .success, message: "You threw another Pokéball..."),
+				.init(
+					id: 4,
+					status: .warning,
+					message: "Shoot! It was so close, too! Some really really long text that will wrap even in small font sizes.",
+				),
+				.init(id: 5, status: .success, message: "You threw yet another Pokéball..."),
+				.init(id: 6, status: .loading, message: "*wobble*"),
+			]),
+		)
 		.padding(.horizontal)
 	}
 }

--- a/mobile/Verify/Verify/Components/EventStackViewModel.swift
+++ b/mobile/Verify/Verify/Components/EventStackViewModel.swift
@@ -31,7 +31,7 @@ final class EventStackViewModel<ID: Hashable> {
 // MARK: - Event Model
 
 extension EventStackViewModel {
-	/// A single devent to be displayed inside an EventStackView.
+	/// A single event to be displayed inside an EventStackView.
 	struct Event: Identifiable {
 		var id: ID
 		var status: Status

--- a/mobile/Verify/Verify/Components/EventStackViewModel.swift
+++ b/mobile/Verify/Verify/Components/EventStackViewModel.swift
@@ -1,0 +1,80 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/
+
+import Dependencies
+import Foundation
+import IdentifiedCollections
+import Observation
+
+@Observable @MainActor
+final class EventStackViewModel<ID: Hashable> {
+	private(set) var events: IdentifiedArrayOf<Event> = []
+
+	init(events: IdentifiedArrayOf<Event>) {
+		self.events = events
+	}
+}
+
+// MARK: - Event Model
+
+extension EventStackViewModel {
+	/// A single devent to be displayed inside an EventStackView.
+	struct Event: Identifiable {
+		var id: ID
+		var status: Status
+		var message: String
+	}
+
+	// swiftformat:sort
+	/// The status of a particular event, which will determine its icon and UI treatment.
+	enum Status {
+		case failure
+		case loading
+		case success
+		case warning
+	}
+}
+
+// MARK: - Event Manipulation
+
+extension EventStackViewModel {
+	func addEvent(id: ID, message: String, status: Status = .loading) {
+		events.append(Event(id: id, status: status, message: message))
+	}
+
+	func updateEvent(id: ID, status: Status? = nil, message: String? = nil) {
+		guard var event = events[id: id] else { return }
+		if let status {
+			event.status = status
+		}
+		if let message {
+			event.message = message
+		}
+		events[id: id] = event
+	}
+}
+
+extension EventStackViewModel where ID == UUID {
+	/// Creates a new event with a generated UUID, and returns the generated UUID.
+	func addNewEvent(message: String, status: Status = .loading) -> UUID {
+		@Dependency(\.uuid)
+		var uuid
+
+		let newUUID = uuid()
+		addEvent(id: newUUID, message: message, status: status)
+		return newUUID
+	}
+}

--- a/mobile/Verify/Verify/Components/EventStackViewModel.swift
+++ b/mobile/Verify/Verify/Components/EventStackViewModel.swift
@@ -23,7 +23,7 @@ import Observation
 final class EventStackViewModel<ID: Hashable> {
 	private(set) var events: IdentifiedArrayOf<Event> = []
 
-	init(events: IdentifiedArrayOf<Event>) {
+	init(events: IdentifiedArrayOf<Event> = []) {
 		self.events = events
 	}
 }
@@ -55,7 +55,7 @@ extension EventStackViewModel {
 		events.append(Event(id: id, status: status, message: message))
 	}
 
-	func updateEvent(id: ID, status: Status? = nil, message: String? = nil) {
+	func updateEvent(id: ID, message: String? = nil, status: Status? = nil) {
 		guard var event = events[id: id] else { return }
 		if let status {
 			event.status = status
@@ -65,16 +65,8 @@ extension EventStackViewModel {
 		}
 		events[id: id] = event
 	}
-}
 
-extension EventStackViewModel where ID == UUID {
-	/// Creates a new event with a generated UUID, and returns the generated UUID.
-	func addNewEvent(message: String, status: Status = .loading) -> UUID {
-		@Dependency(\.uuid)
-		var uuid
-
-		let newUUID = uuid()
-		addEvent(id: newUUID, message: message, status: status)
-		return newUUID
+	func clearAllEvents() {
+		events = []
 	}
 }

--- a/mobile/Verify/Verify/Enrollment/EnrollDeviceView.swift
+++ b/mobile/Verify/Verify/Enrollment/EnrollDeviceView.swift
@@ -30,6 +30,8 @@ struct EnrollDeviceView: View {
 						.padding(.bottom, .small)
 						.padding(.top, .xxlarge)
 					titleBlock
+					EventStackView(viewModel: viewModel.eventStackViewModel)
+						.padding(.vertical, .medium)
 				}
 				.multilineTextAlignment(.center)
 				.frame(maxHeight: .infinity, alignment: .center)
@@ -41,14 +43,6 @@ struct EnrollDeviceView: View {
 		.padding()
 		.frame(maxWidth: .infinity, maxHeight: .infinity)
 		.background(Color.Background.depth3)
-
-		// MARK: Navigation
-
-		.navigationDestination(item: $viewModel.destination.loadingSheet) {
-			EnrollRequestStatusView(attempt: viewModel.loadingState, onDismiss: {})
-				.presentationDetents([.medium])
-				.interactiveDismissDisabled(viewModel.loadingState.isLoading)
-		}
 	}
 }
 

--- a/mobile/Verify/Verify/Enrollment/EnrollDeviceViewModel.swift
+++ b/mobile/Verify/Verify/Enrollment/EnrollDeviceViewModel.swift
@@ -22,15 +22,9 @@ import SwiftNavigation
 @Observable
 @MainActor
 class EnrollDeviceViewModel {
-	// swiftformat:sort
-	@CasePathable
-	enum Destination {
-		case loadingSheet
-	}
-
-	var destination: Destination? = nil
 	var loadingState: LoadingState<String> = .idle
 	private let deepLink: EnrollMobileDeviceDeepLink
+	let eventStackViewModel = EventStackViewModel<String>()
 
 	@ObservationIgnored
 	@Dependency(\.enrollClient)
@@ -48,7 +42,6 @@ class EnrollDeviceViewModel {
 
 	func requestEnrollToken() async {
 		loadingState = .loading
-		destination = .loadingSheet
 		let defaultHTTPSPort = 443
 		do {
 			/*
@@ -63,9 +56,38 @@ class EnrollDeviceViewModel {
 			 )
 			  */
 
-			try await Task.sleep(for: .seconds(1))
+			// The code that follows in this function is for demonstration purposes only.
+			eventStackViewModel.clearAllEvents()
+			eventStackViewModel.addEvent(id: "initial-request", message: "Requesting enrollment pairing token.")
+			try await Task.sleep(for: .milliseconds(2000))
+			eventStackViewModel.updateEvent(
+				id: "initial-request",
+				message: "Initial request for enrollment pairing token timed out.",
+				status: .failure,
+			)
+			try await Task.sleep(for: .milliseconds(400))
+			eventStackViewModel.addEvent(
+				id: "retry-request",
+				message: "Retrying...",
+			)
+			try await Task.sleep(for: .milliseconds(1000))
+			eventStackViewModel.updateEvent(
+				id: "retry-request",
+				message: "Received enrollment pairing token.",
+				status: .success,
+			)
+			try await Task.sleep(for: .milliseconds(400))
+			eventStackViewModel.addEvent(
+				id: "enrollment-request",
+				message: "Requesting enrollment...",
+			)
+			try await Task.sleep(for: .milliseconds(2000))
+			eventStackViewModel.updateEvent(
+				id: "enrollment-request",
+				message: "Device enrolled!",
+				status: .success
+			)
 			loadingState = .success("fake-token-\(defaultHTTPSPort)")
-			destination = nil
 		} catch {
 			loadingState = .failure(error)
 		}


### PR DESCRIPTION
Both of the main responsibilities of the Verify app involve long-running processes: device enrollment and authentication. Since I finished my design pass a little early, I thought I would construct a clear and delightful way to communicate the various steps of some of these processes.

> [!NOTE]
> The screen recording below is purely for demonstration purposes. Those behaviors have not yet been built, but they're on the way!

https://github.com/user-attachments/assets/8e82a80d-6960-470d-94e5-44ee698454bc

