### PR TITLE
Temporarily disable DBSC

### DIFF
--- a/lib/web/app/auth.go
+++ b/lib/web/app/auth.go
@@ -219,11 +219,12 @@ func (h *Handler) completeAppAuthExchange(w http.ResponseWriter, r *http.Request
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
 	setAppSessionCookies(w, ws, 0)
 
+	// TODO (avatus) re-enable dbsc after spec change is in https://github.com/gravitational/teleport/pull/68354
 	// Set DBSC registration header to trigger device-bound session credentials.
 	// The browser will generate a key pair and POST to the registration endpoint.
-	if err := h.setDBSCRegistrationHeader(r.Context(), w, req.CookieValue); err != nil {
-		h.logger.DebugContext(r.Context(), "Failed to set DBSC registration header", "error", err)
-	}
+	// if err := h.setDBSCRegistrationHeader(r.Context(), w, req.CookieValue); err != nil {
+	// 	h.logger.DebugContext(r.Context(), "Failed to set DBSC registration header", "error", err)
+	// }
 
 	requiredApps := strings.Split(req.RequiredApps, ",")
 	if len(requiredApps) <= 1 {

--- a/lib/web/app/dbsc.go
+++ b/lib/web/app/dbsc.go
@@ -38,7 +38,7 @@ import (
 
 const (
 	// secureSessionRegistrationHeader is the header that triggers DBSC registration in the browser.
-	secureSessionRegistrationHeader = "Secure-Session-Registration"
+	secureSessionRegistrationHeader = "Secure-Session-Registration" //nolint:unused // TODO(avatus) re-enable after spec change
 	// secureSessionResponseHeader is the header containing the browser's signed JWT.
 	secureSessionResponseHeader = "Secure-Session-Response"
 	// secureSessionIDHeader is the header containing the session ID for refresh requests.
@@ -265,6 +265,8 @@ func (h *Handler) verifyDBSCChallenge(ctx context.Context, challenge string, ses
 
 // setDBSCRegistrationHeader sets the Secure-Session-Registration header to trigger
 // DBSC registration in the browser.
+//
+//nolint:unused // TODO(avatus) re-enable after spec change
 func (h *Handler) setDBSCRegistrationHeader(ctx context.Context, w http.ResponseWriter, sessionID string) error {
 	challenge, err := h.c.AuthClient.SignDBSCChallenge(ctx, sessionID)
 	if err != nil {


### PR DESCRIPTION
Temporarily disable DBSC for app access while https://github.com/gravitational/teleport/pull/68354 is in review. this is done by simply never sending the dbsc header, so the browser will never initiate the dbsc registration (or refresh)

## Manual Test Plan
### Test Environment
local

### Test Cases
- [x] start a new app session from the web UI. ensure that there is no dbsc session configuration in dev tools -> application -> device bound session credentials 
- [x] ensure sessions last longer than 10 minutes