### PR TITLE
`tsh app ls` support for scoped users

### DIFF
--- a/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
@@ -230,8 +230,10 @@ type ScopedRoleSpec struct {
 	// WorkloadIdentity specifies controls that govern issuance using
 	// WorkloadIdentity resources.
 	WorkloadIdentity *ScopedRoleWorkloadIdentity `protobuf:"bytes,9,opt,name=workload_identity,json=workloadIdentity,proto3" json:"workload_identity,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// The App Access specific configuration for a scoped role.
+	App           *ScopedRoleApp `protobuf:"bytes,10,opt,name=app,proto3" json:"app,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ScopedRoleSpec) Reset() {
@@ -301,6 +303,13 @@ func (x *ScopedRoleSpec) GetWorkloadIdentity() *ScopedRoleWorkloadIdentity {
 	return nil
 }
 
+func (x *ScopedRoleSpec) GetApp() *ScopedRoleApp {
+	if x != nil {
+		return x.App
+	}
+	return nil
+}
+
 func (x *ScopedRoleSpec) SetAssignableScopes(v []string) {
 	x.AssignableScopes = v
 }
@@ -323,6 +332,10 @@ func (x *ScopedRoleSpec) SetKube(v *ScopedRoleKube) {
 
 func (x *ScopedRoleSpec) SetWorkloadIdentity(v *ScopedRoleWorkloadIdentity) {
 	x.WorkloadIdentity = v
+}
+
+func (x *ScopedRoleSpec) SetApp(v *ScopedRoleApp) {
+	x.App = v
 }
 
 func (x *ScopedRoleSpec) HasDefaults() bool {
@@ -353,6 +366,13 @@ func (x *ScopedRoleSpec) HasWorkloadIdentity() bool {
 	return x.WorkloadIdentity != nil
 }
 
+func (x *ScopedRoleSpec) HasApp() bool {
+	if x == nil {
+		return false
+	}
+	return x.App != nil
+}
+
 func (x *ScopedRoleSpec) ClearDefaults() {
 	x.Defaults = nil
 }
@@ -367,6 +387,10 @@ func (x *ScopedRoleSpec) ClearKube() {
 
 func (x *ScopedRoleSpec) ClearWorkloadIdentity() {
 	x.WorkloadIdentity = nil
+}
+
+func (x *ScopedRoleSpec) ClearApp() {
+	x.App = nil
 }
 
 type ScopedRoleSpec_builder struct {
@@ -387,6 +411,8 @@ type ScopedRoleSpec_builder struct {
 	// WorkloadIdentity specifies controls that govern issuance using
 	// WorkloadIdentity resources.
 	WorkloadIdentity *ScopedRoleWorkloadIdentity
+	// The App Access specific configuration for a scoped role.
+	App *ScopedRoleApp
 }
 
 func (b0 ScopedRoleSpec_builder) Build() *ScopedRoleSpec {
@@ -399,6 +425,7 @@ func (b0 ScopedRoleSpec_builder) Build() *ScopedRoleSpec {
 	x.Ssh = b.Ssh
 	x.Kube = b.Kube
 	x.WorkloadIdentity = b.WorkloadIdentity
+	x.App = b.App
 	return m0
 }
 
@@ -1190,6 +1217,84 @@ func (b0 ScopedRoleWorkloadIdentity_builder) Build() *ScopedRoleWorkloadIdentity
 	return m0
 }
 
+// ScopedRoleApp groups all scoped role fields relevant to application access.
+type ScopedRoleApp struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The set of application labels used for RBAC.
+	Labels []*v11.Label `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels,omitempty"`
+	// LabelExpression is an optional predicate expression evaluated against an
+	// application's labels.
+	LabelExpression string `protobuf:"bytes,2,opt,name=label_expression,json=labelExpression,proto3" json:"label_expression,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ScopedRoleApp) Reset() {
+	*x = ScopedRoleApp{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ScopedRoleApp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ScopedRoleApp) ProtoMessage() {}
+
+func (x *ScopedRoleApp) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ScopedRoleApp) GetLabels() []*v11.Label {
+	if x != nil {
+		return x.Labels
+	}
+	return nil
+}
+
+func (x *ScopedRoleApp) GetLabelExpression() string {
+	if x != nil {
+		return x.LabelExpression
+	}
+	return ""
+}
+
+func (x *ScopedRoleApp) SetLabels(v []*v11.Label) {
+	x.Labels = v
+}
+
+func (x *ScopedRoleApp) SetLabelExpression(v string) {
+	x.LabelExpression = v
+}
+
+type ScopedRoleApp_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The set of application labels used for RBAC.
+	Labels []*v11.Label
+	// LabelExpression is an optional predicate expression evaluated against an
+	// application's labels.
+	LabelExpression string
+}
+
+func (b0 ScopedRoleApp_builder) Build() *ScopedRoleApp {
+	m0 := &ScopedRoleApp{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Labels = b.Labels
+	x.LabelExpression = b.LabelExpression
+	return m0
+}
+
 // ScopedRule maps resources to verbs. This is the underlying type used to describe
 // permissions like 'scoped_role:read' or 'scoped_role_assignment:create'.
 type ScopedRule struct {
@@ -1204,7 +1309,7 @@ type ScopedRule struct {
 
 func (x *ScopedRule) Reset() {
 	*x = ScopedRule{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[6]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1216,7 +1321,7 @@ func (x *ScopedRule) String() string {
 func (*ScopedRule) ProtoMessage() {}
 
 func (x *ScopedRule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[6]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1280,7 +1385,7 @@ type SSHPortForwarding struct {
 
 func (x *SSHPortForwarding) Reset() {
 	*x = SSHPortForwarding{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[7]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1292,7 +1397,7 @@ func (x *SSHPortForwarding) String() string {
 func (*SSHPortForwarding) ProtoMessage() {}
 
 func (x *SSHPortForwarding) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[7]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1375,7 +1480,7 @@ type SSHLocalPortForwarding struct {
 
 func (x *SSHLocalPortForwarding) Reset() {
 	*x = SSHLocalPortForwarding{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[8]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1387,7 +1492,7 @@ func (x *SSHLocalPortForwarding) String() string {
 func (*SSHLocalPortForwarding) ProtoMessage() {}
 
 func (x *SSHLocalPortForwarding) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[8]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1444,7 +1549,7 @@ type SSHRemotePortForwarding struct {
 
 func (x *SSHRemotePortForwarding) Reset() {
 	*x = SSHRemotePortForwarding{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[9]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1456,7 +1561,7 @@ func (x *SSHRemotePortForwarding) String() string {
 func (*SSHRemotePortForwarding) ProtoMessage() {}
 
 func (x *SSHRemotePortForwarding) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[9]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1518,7 +1623,7 @@ type CreateHostUser struct {
 
 func (x *CreateHostUser) Reset() {
 	*x = CreateHostUser{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[10]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1530,7 +1635,7 @@ func (x *CreateHostUser) String() string {
 func (*CreateHostUser) ProtoMessage() {}
 
 func (x *CreateHostUser) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[10]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1610,7 +1715,7 @@ type EnhancedRecording struct {
 
 func (x *EnhancedRecording) Reset() {
 	*x = EnhancedRecording{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[11]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1622,7 +1727,7 @@ func (x *EnhancedRecording) String() string {
 func (*EnhancedRecording) ProtoMessage() {}
 
 func (x *EnhancedRecording) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[11]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1731,7 +1836,7 @@ type SessionRecording struct {
 
 func (x *SessionRecording) Reset() {
 	*x = SessionRecording{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[12]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1743,7 +1848,7 @@ func (x *SessionRecording) String() string {
 func (*SessionRecording) ProtoMessage() {}
 
 func (x *SessionRecording) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[12]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1793,7 +1898,7 @@ type Lock struct {
 
 func (x *Lock) Reset() {
 	*x = Lock{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[13]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1805,7 +1910,7 @@ func (x *Lock) String() string {
 func (*Lock) ProtoMessage() {}
 
 func (x *Lock) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[13]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1855,14 +1960,16 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12=\n" +
-	"\x04spec\x18\x06 \x01(\v2).teleport.scopes.access.v1.ScopedRoleSpecR\x04spec\"\xc0\x03\n" +
+	"\x04spec\x18\x06 \x01(\v2).teleport.scopes.access.v1.ScopedRoleSpecR\x04spec\"\xfc\x03\n" +
 	"\x0eScopedRoleSpec\x12+\n" +
 	"\x11assignable_scopes\x18\x01 \x03(\tR\x10assignableScopes\x12I\n" +
 	"\bdefaults\x18\x05 \x01(\v2-.teleport.scopes.access.v1.ScopedRoleDefaultsR\bdefaults\x12;\n" +
 	"\x05rules\x18\x06 \x03(\v2%.teleport.scopes.access.v1.ScopedRuleR\x05rules\x12:\n" +
 	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03ssh\x12=\n" +
 	"\x04kube\x18\b \x01(\v2).teleport.scopes.access.v1.ScopedRoleKubeR\x04kube\x12b\n" +
-	"\x11workload_identity\x18\t \x01(\v25.teleport.scopes.access.v1.ScopedRoleWorkloadIdentityR\x10workloadIdentityJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"\xac\x02\n" +
+	"\x11workload_identity\x18\t \x01(\v25.teleport.scopes.access.v1.ScopedRoleWorkloadIdentityR\x10workloadIdentity\x12:\n" +
+	"\x03app\x18\n" +
+	" \x01(\v2(.teleport.scopes.access.v1.ScopedRoleAppR\x03appJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"\xac\x02\n" +
 	"\x12ScopedRoleDefaults\x12.\n" +
 	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\x12X\n" +
 	"\x11session_recording\x18\x02 \x01(\v2+.teleport.scopes.access.v1.SessionRecordingR\x10sessionRecording\x12;\n" +
@@ -1900,7 +2007,10 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x04lock\x18\a \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x1a\n" +
 	"\x18_disconnect_expired_certJ\x04\b\x04\x10\x05R\tresources\"N\n" +
 	"\x1aScopedRoleWorkloadIdentity\x120\n" +
-	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\"@\n" +
+	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\"l\n" +
+	"\rScopedRoleApp\x120\n" +
+	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12)\n" +
+	"\x10label_expression\x18\x02 \x01(\tR\x0flabelExpression\"@\n" +
 	"\n" +
 	"ScopedRule\x12\x1c\n" +
 	"\tresources\x18\x01 \x03(\tR\tresources\x12\x14\n" +
@@ -1934,7 +2044,7 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x04Lock\x12\x12\n" +
 	"\x04mode\x18\x01 \x01(\tR\x04modeBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
 
-var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*ScopedRole)(nil),                 // 0: teleport.scopes.access.v1.ScopedRole
 	(*ScopedRoleSpec)(nil),             // 1: teleport.scopes.access.v1.ScopedRoleSpec
@@ -1942,43 +2052,46 @@ var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*ScopedRoleSSH)(nil),              // 3: teleport.scopes.access.v1.ScopedRoleSSH
 	(*ScopedRoleKube)(nil),             // 4: teleport.scopes.access.v1.ScopedRoleKube
 	(*ScopedRoleWorkloadIdentity)(nil), // 5: teleport.scopes.access.v1.ScopedRoleWorkloadIdentity
-	(*ScopedRule)(nil),                 // 6: teleport.scopes.access.v1.ScopedRule
-	(*SSHPortForwarding)(nil),          // 7: teleport.scopes.access.v1.SSHPortForwarding
-	(*SSHLocalPortForwarding)(nil),     // 8: teleport.scopes.access.v1.SSHLocalPortForwarding
-	(*SSHRemotePortForwarding)(nil),    // 9: teleport.scopes.access.v1.SSHRemotePortForwarding
-	(*CreateHostUser)(nil),             // 10: teleport.scopes.access.v1.CreateHostUser
-	(*EnhancedRecording)(nil),          // 11: teleport.scopes.access.v1.EnhancedRecording
-	(*SessionRecording)(nil),           // 12: teleport.scopes.access.v1.SessionRecording
-	(*Lock)(nil),                       // 13: teleport.scopes.access.v1.Lock
-	(*v1.Metadata)(nil),                // 14: teleport.header.v1.Metadata
-	(*v11.Label)(nil),                  // 15: teleport.label.v1.Label
+	(*ScopedRoleApp)(nil),              // 6: teleport.scopes.access.v1.ScopedRoleApp
+	(*ScopedRule)(nil),                 // 7: teleport.scopes.access.v1.ScopedRule
+	(*SSHPortForwarding)(nil),          // 8: teleport.scopes.access.v1.SSHPortForwarding
+	(*SSHLocalPortForwarding)(nil),     // 9: teleport.scopes.access.v1.SSHLocalPortForwarding
+	(*SSHRemotePortForwarding)(nil),    // 10: teleport.scopes.access.v1.SSHRemotePortForwarding
+	(*CreateHostUser)(nil),             // 11: teleport.scopes.access.v1.CreateHostUser
+	(*EnhancedRecording)(nil),          // 12: teleport.scopes.access.v1.EnhancedRecording
+	(*SessionRecording)(nil),           // 13: teleport.scopes.access.v1.SessionRecording
+	(*Lock)(nil),                       // 14: teleport.scopes.access.v1.Lock
+	(*v1.Metadata)(nil),                // 15: teleport.header.v1.Metadata
+	(*v11.Label)(nil),                  // 16: teleport.label.v1.Label
 }
 var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
-	14, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
+	15, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
 	2,  // 2: teleport.scopes.access.v1.ScopedRoleSpec.defaults:type_name -> teleport.scopes.access.v1.ScopedRoleDefaults
-	6,  // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
+	7,  // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
 	3,  // 4: teleport.scopes.access.v1.ScopedRoleSpec.ssh:type_name -> teleport.scopes.access.v1.ScopedRoleSSH
 	4,  // 5: teleport.scopes.access.v1.ScopedRoleSpec.kube:type_name -> teleport.scopes.access.v1.ScopedRoleKube
 	5,  // 6: teleport.scopes.access.v1.ScopedRoleSpec.workload_identity:type_name -> teleport.scopes.access.v1.ScopedRoleWorkloadIdentity
-	12, // 7: teleport.scopes.access.v1.ScopedRoleDefaults.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
-	13, // 8: teleport.scopes.access.v1.ScopedRoleDefaults.lock:type_name -> teleport.scopes.access.v1.Lock
-	15, // 9: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
-	7,  // 10: teleport.scopes.access.v1.ScopedRoleSSH.port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
-	10, // 11: teleport.scopes.access.v1.ScopedRoleSSH.host_user_creation:type_name -> teleport.scopes.access.v1.CreateHostUser
-	11, // 12: teleport.scopes.access.v1.ScopedRoleSSH.enhanced_recording:type_name -> teleport.scopes.access.v1.EnhancedRecording
-	12, // 13: teleport.scopes.access.v1.ScopedRoleSSH.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
-	13, // 14: teleport.scopes.access.v1.ScopedRoleSSH.lock:type_name -> teleport.scopes.access.v1.Lock
-	15, // 15: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
-	13, // 16: teleport.scopes.access.v1.ScopedRoleKube.lock:type_name -> teleport.scopes.access.v1.Lock
-	15, // 17: teleport.scopes.access.v1.ScopedRoleWorkloadIdentity.labels:type_name -> teleport.label.v1.Label
-	8,  // 18: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
-	9,  // 19: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
-	20, // [20:20] is the sub-list for method output_type
-	20, // [20:20] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	6,  // 7: teleport.scopes.access.v1.ScopedRoleSpec.app:type_name -> teleport.scopes.access.v1.ScopedRoleApp
+	13, // 8: teleport.scopes.access.v1.ScopedRoleDefaults.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
+	14, // 9: teleport.scopes.access.v1.ScopedRoleDefaults.lock:type_name -> teleport.scopes.access.v1.Lock
+	16, // 10: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
+	8,  // 11: teleport.scopes.access.v1.ScopedRoleSSH.port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
+	11, // 12: teleport.scopes.access.v1.ScopedRoleSSH.host_user_creation:type_name -> teleport.scopes.access.v1.CreateHostUser
+	12, // 13: teleport.scopes.access.v1.ScopedRoleSSH.enhanced_recording:type_name -> teleport.scopes.access.v1.EnhancedRecording
+	13, // 14: teleport.scopes.access.v1.ScopedRoleSSH.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
+	14, // 15: teleport.scopes.access.v1.ScopedRoleSSH.lock:type_name -> teleport.scopes.access.v1.Lock
+	16, // 16: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
+	14, // 17: teleport.scopes.access.v1.ScopedRoleKube.lock:type_name -> teleport.scopes.access.v1.Lock
+	16, // 18: teleport.scopes.access.v1.ScopedRoleWorkloadIdentity.labels:type_name -> teleport.label.v1.Label
+	16, // 19: teleport.scopes.access.v1.ScopedRoleApp.labels:type_name -> teleport.label.v1.Label
+	9,  // 20: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
+	10, // 21: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
+	22, // [22:22] is the sub-list for method output_type
+	22, // [22:22] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }
@@ -1989,16 +2102,16 @@ func file_teleport_scopes_access_v1_role_proto_init() {
 	file_teleport_scopes_access_v1_role_proto_msgTypes[2].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[3].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[4].OneofWrappers = []any{}
-	file_teleport_scopes_access_v1_role_proto_msgTypes[8].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[9].OneofWrappers = []any{}
-	file_teleport_scopes_access_v1_role_proto_msgTypes[11].OneofWrappers = []any{}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[10].OneofWrappers = []any{}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[12].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_access_v1_role_proto_rawDesc), len(file_teleport_scopes_access_v1_role_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   14,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/scopes/access/v1/role_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role_protoopaque.pb.go
@@ -215,6 +215,7 @@ type ScopedRoleSpec struct {
 	xxx_hidden_Ssh              *ScopedRoleSSH              `protobuf:"bytes,7,opt,name=ssh,proto3"`
 	xxx_hidden_Kube             *ScopedRoleKube             `protobuf:"bytes,8,opt,name=kube,proto3"`
 	xxx_hidden_WorkloadIdentity *ScopedRoleWorkloadIdentity `protobuf:"bytes,9,opt,name=workload_identity,json=workloadIdentity,proto3"`
+	xxx_hidden_App              *ScopedRoleApp              `protobuf:"bytes,10,opt,name=app,proto3"`
 	unknownFields               protoimpl.UnknownFields
 	sizeCache                   protoimpl.SizeCache
 }
@@ -288,6 +289,13 @@ func (x *ScopedRoleSpec) GetWorkloadIdentity() *ScopedRoleWorkloadIdentity {
 	return nil
 }
 
+func (x *ScopedRoleSpec) GetApp() *ScopedRoleApp {
+	if x != nil {
+		return x.xxx_hidden_App
+	}
+	return nil
+}
+
 func (x *ScopedRoleSpec) SetAssignableScopes(v []string) {
 	x.xxx_hidden_AssignableScopes = v
 }
@@ -310,6 +318,10 @@ func (x *ScopedRoleSpec) SetKube(v *ScopedRoleKube) {
 
 func (x *ScopedRoleSpec) SetWorkloadIdentity(v *ScopedRoleWorkloadIdentity) {
 	x.xxx_hidden_WorkloadIdentity = v
+}
+
+func (x *ScopedRoleSpec) SetApp(v *ScopedRoleApp) {
+	x.xxx_hidden_App = v
 }
 
 func (x *ScopedRoleSpec) HasDefaults() bool {
@@ -340,6 +352,13 @@ func (x *ScopedRoleSpec) HasWorkloadIdentity() bool {
 	return x.xxx_hidden_WorkloadIdentity != nil
 }
 
+func (x *ScopedRoleSpec) HasApp() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_App != nil
+}
+
 func (x *ScopedRoleSpec) ClearDefaults() {
 	x.xxx_hidden_Defaults = nil
 }
@@ -354,6 +373,10 @@ func (x *ScopedRoleSpec) ClearKube() {
 
 func (x *ScopedRoleSpec) ClearWorkloadIdentity() {
 	x.xxx_hidden_WorkloadIdentity = nil
+}
+
+func (x *ScopedRoleSpec) ClearApp() {
+	x.xxx_hidden_App = nil
 }
 
 type ScopedRoleSpec_builder struct {
@@ -374,6 +397,8 @@ type ScopedRoleSpec_builder struct {
 	// WorkloadIdentity specifies controls that govern issuance using
 	// WorkloadIdentity resources.
 	WorkloadIdentity *ScopedRoleWorkloadIdentity
+	// The App Access specific configuration for a scoped role.
+	App *ScopedRoleApp
 }
 
 func (b0 ScopedRoleSpec_builder) Build() *ScopedRoleSpec {
@@ -386,6 +411,7 @@ func (b0 ScopedRoleSpec_builder) Build() *ScopedRoleSpec {
 	x.xxx_hidden_Ssh = b.Ssh
 	x.xxx_hidden_Kube = b.Kube
 	x.xxx_hidden_WorkloadIdentity = b.WorkloadIdentity
+	x.xxx_hidden_App = b.App
 	return m0
 }
 
@@ -1182,6 +1208,83 @@ func (b0 ScopedRoleWorkloadIdentity_builder) Build() *ScopedRoleWorkloadIdentity
 	return m0
 }
 
+// ScopedRoleApp groups all scoped role fields relevant to application access.
+type ScopedRoleApp struct {
+	state                      protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Labels          *[]*v11.Label          `protobuf:"bytes,1,rep,name=labels,proto3"`
+	xxx_hidden_LabelExpression string                 `protobuf:"bytes,2,opt,name=label_expression,json=labelExpression,proto3"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
+}
+
+func (x *ScopedRoleApp) Reset() {
+	*x = ScopedRoleApp{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ScopedRoleApp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ScopedRoleApp) ProtoMessage() {}
+
+func (x *ScopedRoleApp) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ScopedRoleApp) GetLabels() []*v11.Label {
+	if x != nil {
+		if x.xxx_hidden_Labels != nil {
+			return *x.xxx_hidden_Labels
+		}
+	}
+	return nil
+}
+
+func (x *ScopedRoleApp) GetLabelExpression() string {
+	if x != nil {
+		return x.xxx_hidden_LabelExpression
+	}
+	return ""
+}
+
+func (x *ScopedRoleApp) SetLabels(v []*v11.Label) {
+	x.xxx_hidden_Labels = &v
+}
+
+func (x *ScopedRoleApp) SetLabelExpression(v string) {
+	x.xxx_hidden_LabelExpression = v
+}
+
+type ScopedRoleApp_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The set of application labels used for RBAC.
+	Labels []*v11.Label
+	// LabelExpression is an optional predicate expression evaluated against an
+	// application's labels.
+	LabelExpression string
+}
+
+func (b0 ScopedRoleApp_builder) Build() *ScopedRoleApp {
+	m0 := &ScopedRoleApp{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Labels = &b.Labels
+	x.xxx_hidden_LabelExpression = b.LabelExpression
+	return m0
+}
+
 // ScopedRule maps resources to verbs. This is the underlying type used to describe
 // permissions like 'scoped_role:read' or 'scoped_role_assignment:create'.
 type ScopedRule struct {
@@ -1194,7 +1297,7 @@ type ScopedRule struct {
 
 func (x *ScopedRule) Reset() {
 	*x = ScopedRule{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[6]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1206,7 +1309,7 @@ func (x *ScopedRule) String() string {
 func (*ScopedRule) ProtoMessage() {}
 
 func (x *ScopedRule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[6]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1268,7 +1371,7 @@ type SSHPortForwarding struct {
 
 func (x *SSHPortForwarding) Reset() {
 	*x = SSHPortForwarding{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[7]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1280,7 +1383,7 @@ func (x *SSHPortForwarding) String() string {
 func (*SSHPortForwarding) ProtoMessage() {}
 
 func (x *SSHPortForwarding) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[7]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1365,7 +1468,7 @@ type SSHLocalPortForwarding struct {
 
 func (x *SSHLocalPortForwarding) Reset() {
 	*x = SSHLocalPortForwarding{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[8]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1377,7 +1480,7 @@ func (x *SSHLocalPortForwarding) String() string {
 func (*SSHLocalPortForwarding) ProtoMessage() {}
 
 func (x *SSHLocalPortForwarding) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[8]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1441,7 +1544,7 @@ type SSHRemotePortForwarding struct {
 
 func (x *SSHRemotePortForwarding) Reset() {
 	*x = SSHRemotePortForwarding{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[9]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1453,7 +1556,7 @@ func (x *SSHRemotePortForwarding) String() string {
 func (*SSHRemotePortForwarding) ProtoMessage() {}
 
 func (x *SSHRemotePortForwarding) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[9]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1517,7 +1620,7 @@ type CreateHostUser struct {
 
 func (x *CreateHostUser) Reset() {
 	*x = CreateHostUser{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[10]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1529,7 +1632,7 @@ func (x *CreateHostUser) String() string {
 func (*CreateHostUser) ProtoMessage() {}
 
 func (x *CreateHostUser) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[10]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1608,7 +1711,7 @@ type EnhancedRecording struct {
 
 func (x *EnhancedRecording) Reset() {
 	*x = EnhancedRecording{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[11]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1620,7 +1723,7 @@ func (x *EnhancedRecording) String() string {
 func (*EnhancedRecording) ProtoMessage() {}
 
 func (x *EnhancedRecording) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[11]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1743,7 +1846,7 @@ type SessionRecording struct {
 
 func (x *SessionRecording) Reset() {
 	*x = SessionRecording{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[12]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1755,7 +1858,7 @@ func (x *SessionRecording) String() string {
 func (*SessionRecording) ProtoMessage() {}
 
 func (x *SessionRecording) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[12]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1803,7 +1906,7 @@ type Lock struct {
 
 func (x *Lock) Reset() {
 	*x = Lock{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[13]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1815,7 +1918,7 @@ func (x *Lock) String() string {
 func (*Lock) ProtoMessage() {}
 
 func (x *Lock) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[13]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1865,14 +1968,16 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12=\n" +
-	"\x04spec\x18\x06 \x01(\v2).teleport.scopes.access.v1.ScopedRoleSpecR\x04spec\"\xc0\x03\n" +
+	"\x04spec\x18\x06 \x01(\v2).teleport.scopes.access.v1.ScopedRoleSpecR\x04spec\"\xfc\x03\n" +
 	"\x0eScopedRoleSpec\x12+\n" +
 	"\x11assignable_scopes\x18\x01 \x03(\tR\x10assignableScopes\x12I\n" +
 	"\bdefaults\x18\x05 \x01(\v2-.teleport.scopes.access.v1.ScopedRoleDefaultsR\bdefaults\x12;\n" +
 	"\x05rules\x18\x06 \x03(\v2%.teleport.scopes.access.v1.ScopedRuleR\x05rules\x12:\n" +
 	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03ssh\x12=\n" +
 	"\x04kube\x18\b \x01(\v2).teleport.scopes.access.v1.ScopedRoleKubeR\x04kube\x12b\n" +
-	"\x11workload_identity\x18\t \x01(\v25.teleport.scopes.access.v1.ScopedRoleWorkloadIdentityR\x10workloadIdentityJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"\xac\x02\n" +
+	"\x11workload_identity\x18\t \x01(\v25.teleport.scopes.access.v1.ScopedRoleWorkloadIdentityR\x10workloadIdentity\x12:\n" +
+	"\x03app\x18\n" +
+	" \x01(\v2(.teleport.scopes.access.v1.ScopedRoleAppR\x03appJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"\xac\x02\n" +
 	"\x12ScopedRoleDefaults\x12.\n" +
 	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\x12X\n" +
 	"\x11session_recording\x18\x02 \x01(\v2+.teleport.scopes.access.v1.SessionRecordingR\x10sessionRecording\x12;\n" +
@@ -1910,7 +2015,10 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x04lock\x18\a \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x1a\n" +
 	"\x18_disconnect_expired_certJ\x04\b\x04\x10\x05R\tresources\"N\n" +
 	"\x1aScopedRoleWorkloadIdentity\x120\n" +
-	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\"@\n" +
+	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\"l\n" +
+	"\rScopedRoleApp\x120\n" +
+	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12)\n" +
+	"\x10label_expression\x18\x02 \x01(\tR\x0flabelExpression\"@\n" +
 	"\n" +
 	"ScopedRule\x12\x1c\n" +
 	"\tresources\x18\x01 \x03(\tR\tresources\x12\x14\n" +
@@ -1944,7 +2052,7 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x04Lock\x12\x12\n" +
 	"\x04mode\x18\x01 \x01(\tR\x04modeBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
 
-var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*ScopedRole)(nil),                 // 0: teleport.scopes.access.v1.ScopedRole
 	(*ScopedRoleSpec)(nil),             // 1: teleport.scopes.access.v1.ScopedRoleSpec
@@ -1952,43 +2060,46 @@ var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*ScopedRoleSSH)(nil),              // 3: teleport.scopes.access.v1.ScopedRoleSSH
 	(*ScopedRoleKube)(nil),             // 4: teleport.scopes.access.v1.ScopedRoleKube
 	(*ScopedRoleWorkloadIdentity)(nil), // 5: teleport.scopes.access.v1.ScopedRoleWorkloadIdentity
-	(*ScopedRule)(nil),                 // 6: teleport.scopes.access.v1.ScopedRule
-	(*SSHPortForwarding)(nil),          // 7: teleport.scopes.access.v1.SSHPortForwarding
-	(*SSHLocalPortForwarding)(nil),     // 8: teleport.scopes.access.v1.SSHLocalPortForwarding
-	(*SSHRemotePortForwarding)(nil),    // 9: teleport.scopes.access.v1.SSHRemotePortForwarding
-	(*CreateHostUser)(nil),             // 10: teleport.scopes.access.v1.CreateHostUser
-	(*EnhancedRecording)(nil),          // 11: teleport.scopes.access.v1.EnhancedRecording
-	(*SessionRecording)(nil),           // 12: teleport.scopes.access.v1.SessionRecording
-	(*Lock)(nil),                       // 13: teleport.scopes.access.v1.Lock
-	(*v1.Metadata)(nil),                // 14: teleport.header.v1.Metadata
-	(*v11.Label)(nil),                  // 15: teleport.label.v1.Label
+	(*ScopedRoleApp)(nil),              // 6: teleport.scopes.access.v1.ScopedRoleApp
+	(*ScopedRule)(nil),                 // 7: teleport.scopes.access.v1.ScopedRule
+	(*SSHPortForwarding)(nil),          // 8: teleport.scopes.access.v1.SSHPortForwarding
+	(*SSHLocalPortForwarding)(nil),     // 9: teleport.scopes.access.v1.SSHLocalPortForwarding
+	(*SSHRemotePortForwarding)(nil),    // 10: teleport.scopes.access.v1.SSHRemotePortForwarding
+	(*CreateHostUser)(nil),             // 11: teleport.scopes.access.v1.CreateHostUser
+	(*EnhancedRecording)(nil),          // 12: teleport.scopes.access.v1.EnhancedRecording
+	(*SessionRecording)(nil),           // 13: teleport.scopes.access.v1.SessionRecording
+	(*Lock)(nil),                       // 14: teleport.scopes.access.v1.Lock
+	(*v1.Metadata)(nil),                // 15: teleport.header.v1.Metadata
+	(*v11.Label)(nil),                  // 16: teleport.label.v1.Label
 }
 var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
-	14, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
+	15, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
 	2,  // 2: teleport.scopes.access.v1.ScopedRoleSpec.defaults:type_name -> teleport.scopes.access.v1.ScopedRoleDefaults
-	6,  // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
+	7,  // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
 	3,  // 4: teleport.scopes.access.v1.ScopedRoleSpec.ssh:type_name -> teleport.scopes.access.v1.ScopedRoleSSH
 	4,  // 5: teleport.scopes.access.v1.ScopedRoleSpec.kube:type_name -> teleport.scopes.access.v1.ScopedRoleKube
 	5,  // 6: teleport.scopes.access.v1.ScopedRoleSpec.workload_identity:type_name -> teleport.scopes.access.v1.ScopedRoleWorkloadIdentity
-	12, // 7: teleport.scopes.access.v1.ScopedRoleDefaults.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
-	13, // 8: teleport.scopes.access.v1.ScopedRoleDefaults.lock:type_name -> teleport.scopes.access.v1.Lock
-	15, // 9: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
-	7,  // 10: teleport.scopes.access.v1.ScopedRoleSSH.port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
-	10, // 11: teleport.scopes.access.v1.ScopedRoleSSH.host_user_creation:type_name -> teleport.scopes.access.v1.CreateHostUser
-	11, // 12: teleport.scopes.access.v1.ScopedRoleSSH.enhanced_recording:type_name -> teleport.scopes.access.v1.EnhancedRecording
-	12, // 13: teleport.scopes.access.v1.ScopedRoleSSH.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
-	13, // 14: teleport.scopes.access.v1.ScopedRoleSSH.lock:type_name -> teleport.scopes.access.v1.Lock
-	15, // 15: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
-	13, // 16: teleport.scopes.access.v1.ScopedRoleKube.lock:type_name -> teleport.scopes.access.v1.Lock
-	15, // 17: teleport.scopes.access.v1.ScopedRoleWorkloadIdentity.labels:type_name -> teleport.label.v1.Label
-	8,  // 18: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
-	9,  // 19: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
-	20, // [20:20] is the sub-list for method output_type
-	20, // [20:20] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	6,  // 7: teleport.scopes.access.v1.ScopedRoleSpec.app:type_name -> teleport.scopes.access.v1.ScopedRoleApp
+	13, // 8: teleport.scopes.access.v1.ScopedRoleDefaults.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
+	14, // 9: teleport.scopes.access.v1.ScopedRoleDefaults.lock:type_name -> teleport.scopes.access.v1.Lock
+	16, // 10: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
+	8,  // 11: teleport.scopes.access.v1.ScopedRoleSSH.port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
+	11, // 12: teleport.scopes.access.v1.ScopedRoleSSH.host_user_creation:type_name -> teleport.scopes.access.v1.CreateHostUser
+	12, // 13: teleport.scopes.access.v1.ScopedRoleSSH.enhanced_recording:type_name -> teleport.scopes.access.v1.EnhancedRecording
+	13, // 14: teleport.scopes.access.v1.ScopedRoleSSH.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
+	14, // 15: teleport.scopes.access.v1.ScopedRoleSSH.lock:type_name -> teleport.scopes.access.v1.Lock
+	16, // 16: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
+	14, // 17: teleport.scopes.access.v1.ScopedRoleKube.lock:type_name -> teleport.scopes.access.v1.Lock
+	16, // 18: teleport.scopes.access.v1.ScopedRoleWorkloadIdentity.labels:type_name -> teleport.label.v1.Label
+	16, // 19: teleport.scopes.access.v1.ScopedRoleApp.labels:type_name -> teleport.label.v1.Label
+	9,  // 20: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
+	10, // 21: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
+	22, // [22:22] is the sub-list for method output_type
+	22, // [22:22] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }
@@ -1999,16 +2110,16 @@ func file_teleport_scopes_access_v1_role_proto_init() {
 	file_teleport_scopes_access_v1_role_proto_msgTypes[2].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[3].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[4].OneofWrappers = []any{}
-	file_teleport_scopes_access_v1_role_proto_msgTypes[8].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[9].OneofWrappers = []any{}
-	file_teleport_scopes_access_v1_role_proto_msgTypes[11].OneofWrappers = []any{}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[10].OneofWrappers = []any{}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[12].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_access_v1_role_proto_rawDesc), len(file_teleport_scopes_access_v1_role_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   14,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -81,6 +81,9 @@ message ScopedRoleSpec {
   // WorkloadIdentity specifies controls that govern issuance using
   // WorkloadIdentity resources.
   ScopedRoleWorkloadIdentity workload_identity = 9;
+
+  // The App Access specific configuration for a scoped role.
+  ScopedRoleApp app = 10;
 }
 
 // ScopedRoleDefaults provides fallback values for controls shared across multiple protocols.
@@ -200,6 +203,16 @@ message ScopedRoleWorkloadIdentity {
   // multi-issue RPC, list) rules for the workload_identity kind in the relevant
   // scope.
   repeated teleport.label.v1.Label labels = 1;
+}
+
+// ScopedRoleApp groups all scoped role fields relevant to application access.
+message ScopedRoleApp {
+  // The set of application labels used for RBAC.
+  repeated teleport.label.v1.Label labels = 1;
+
+  // LabelExpression is an optional predicate expression evaluated against an
+  // application's labels.
+  string label_expression = 2;
 }
 
 // ScopedRule maps resources to verbs. This is the underlying type used to describe

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedrolesv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedrolesv1.mdx
@@ -30,12 +30,27 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 |Field|Type|Description|
 |---|---|---|
+|app|[object](#specapp)|The App Access specific configuration for a scoped role.|
 |assignable_scopes|[]string|AssignableScopes is a list of scopes to which this role can be assigned.|
 |defaults|[object](#specdefaults)|Defaults specifies default values for controls common across multiple protocols. If the same control specified in defaults is also specified in a protocol block, the value in the protocol block takes precedence.|
 |kube|[object](#speckube)|The kubernetes specific configuration for a scoped role.|
 |rules|[][object](#specrules-items)|Rules describes basic resource:verb permissions (e.g. scoped_role:read).|
 |ssh|[object](#specssh)|Ssh specifies controls that govern SSH access.|
 |workload_identity|[object](#specworkload_identity)|WorkloadIdentity specifies controls that govern issuance using WorkloadIdentity resources.|
+
+### spec.app
+
+|Field|Type|Description|
+|---|---|---|
+|label_expression|string|LabelExpression is an optional predicate expression evaluated against an application's labels.|
+|labels|[][object](#specapplabels-items)|The set of application labels used for RBAC.|
+
+### spec.app.labels items
+
+|Field|Type|Description|
+|---|---|---|
+|name|string|The name of the label.|
+|values|[]string|The values associated with the label.|
 
 ### spec.defaults
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role.mdx
@@ -53,11 +53,28 @@ Required:
 
 Optional:
 
+- `app` (Attributes) The App Access specific configuration for a scoped role. (see [below for nested schema](#nested-schema-for-specapp))
 - `defaults` (Attributes) Defaults specifies default values for controls common across multiple protocols. If the same control specified in defaults is also specified in a protocol block, the value in the protocol block takes precedence. (see [below for nested schema](#nested-schema-for-specdefaults))
 - `kube` (Attributes) The kubernetes specific configuration for a scoped role. (see [below for nested schema](#nested-schema-for-speckube))
 - `rules` (Attributes List) Rules describes basic resource:verb permissions (e.g. scoped_role:read). (see [below for nested schema](#nested-schema-for-specrules))
 - `ssh` (Attributes) Ssh specifies controls that govern SSH access. (see [below for nested schema](#nested-schema-for-specssh))
 - `workload_identity` (Attributes) WorkloadIdentity specifies controls that govern issuance using WorkloadIdentity resources. (see [below for nested schema](#nested-schema-for-specworkload_identity))
+
+### Nested Schema for `spec.app`
+
+Optional:
+
+- `label_expression` (String) LabelExpression is an optional predicate expression evaluated against an application's labels.
+- `labels` (Attributes List) The set of application labels used for RBAC. (see [below for nested schema](#nested-schema-for-specapplabels))
+
+### Nested Schema for `spec.app.labels`
+
+Optional:
+
+- `name` (String) The name of the label.
+- `values` (List of String) The values associated with the label.
+
+
 
 ### Nested Schema for `spec.defaults`
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role.mdx
@@ -82,11 +82,28 @@ Required:
 
 Optional:
 
+- `app` (Attributes) The App Access specific configuration for a scoped role. (see [below for nested schema](#nested-schema-for-specapp))
 - `defaults` (Attributes) Defaults specifies default values for controls common across multiple protocols. If the same control specified in defaults is also specified in a protocol block, the value in the protocol block takes precedence. (see [below for nested schema](#nested-schema-for-specdefaults))
 - `kube` (Attributes) The kubernetes specific configuration for a scoped role. (see [below for nested schema](#nested-schema-for-speckube))
 - `rules` (Attributes List) Rules describes basic resource:verb permissions (e.g. scoped_role:read). (see [below for nested schema](#nested-schema-for-specrules))
 - `ssh` (Attributes) Ssh specifies controls that govern SSH access. (see [below for nested schema](#nested-schema-for-specssh))
 - `workload_identity` (Attributes) WorkloadIdentity specifies controls that govern issuance using WorkloadIdentity resources. (see [below for nested schema](#nested-schema-for-specworkload_identity))
+
+### Nested Schema for `spec.app`
+
+Optional:
+
+- `label_expression` (String) LabelExpression is an optional predicate expression evaluated against an application's labels.
+- `labels` (Attributes List) The set of application labels used for RBAC. (see [below for nested schema](#nested-schema-for-specapplabels))
+
+### Nested Schema for `spec.app.labels`
+
+Optional:
+
+- `name` (String) The name of the label.
+- `values` (List of String) The values associated with the label.
+
+
 
 ### Nested Schema for `spec.defaults`
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
@@ -50,6 +50,31 @@ spec:
           spec:
             description: ScopedRole resource definition v1 from Teleport
             properties:
+              app:
+                description: The App Access specific configuration for a scoped role.
+                nullable: true
+                properties:
+                  label_expression:
+                    description: LabelExpression is an optional predicate expression
+                      evaluated against an application's labels.
+                    type: string
+                  labels:
+                    description: The set of application labels used for RBAC.
+                    items:
+                      properties:
+                        name:
+                          description: The name of the label.
+                          type: string
+                        values:
+                          description: The values associated with the label.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    nullable: true
+                    type: array
+                type: object
               assignable_scopes:
                 description: AssignableScopes is a list of scopes to which this role
                   can be assigned.

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
@@ -50,6 +50,31 @@ spec:
           spec:
             description: ScopedRole resource definition v1 from Teleport
             properties:
+              app:
+                description: The App Access specific configuration for a scoped role.
+                nullable: true
+                properties:
+                  label_expression:
+                    description: LabelExpression is an optional predicate expression
+                      evaluated against an application's labels.
+                    type: string
+                  labels:
+                    description: The set of application labels used for RBAC.
+                    items:
+                      properties:
+                        name:
+                          description: The name of the label.
+                          type: string
+                        values:
+                          description: The values associated with the label.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    nullable: true
+                    type: array
+                type: object
               assignable_scopes:
                 description: AssignableScopes is a list of scopes to which this role
                   can be assigned.

--- a/integrations/terraform/tfschema/scopes/access/v1/role_terraform.go
+++ b/integrations/terraform/tfschema/scopes/access/v1/role_terraform.go
@@ -110,6 +110,33 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 		},
 		"spec": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+				"app": {
+					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+						"label_expression": {
+							Description: "LabelExpression is an optional predicate expression evaluated against an application's labels.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"labels": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+								"name": {
+									Description: "The name of the label.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"values": {
+									Description: "The values associated with the label.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+								},
+							}),
+							Description: "The set of application labels used for RBAC.",
+							Optional:    true,
+						},
+					}),
+					Description: "The App Access specific configuration for a scoped role.",
+					Optional:    true,
+				},
 				"assignable_scopes": {
 					Description: "AssignableScopes is a list of scopes to which this role can be assigned.",
 					Required:    true,
@@ -1699,6 +1726,114 @@ func CopyScopedRoleFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 														}
 													}
 												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					{
+						a, ok := tf.Attrs["app"]
+						if !ok {
+							diags.Append(attrReadMissingDiag{"ScopedRole.spec.app"})
+						} else {
+							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+							if !ok {
+								diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.app", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+							} else {
+								obj.App = nil
+								if !v.Null && !v.Unknown {
+									tf := v
+									obj.App = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_access_v1.ScopedRoleApp{}
+									obj := obj.App
+									{
+										a, ok := tf.Attrs["labels"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.app.labels"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.app.labels", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+											} else {
+												obj.Labels = make([]*github_com_gravitational_teleport_api_gen_proto_go_teleport_label_v1.Label, len(v.Elems))
+												if !v.Null && !v.Unknown {
+													for k, a := range v.Elems {
+														v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														if !ok {
+															diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.app.labels", "github_com_hashicorp_terraform_plugin_framework_types.Object"})
+														} else {
+															var t *github_com_gravitational_teleport_api_gen_proto_go_teleport_label_v1.Label
+															if !v.Null && !v.Unknown {
+																tf := v
+																t = &github_com_gravitational_teleport_api_gen_proto_go_teleport_label_v1.Label{}
+																obj := t
+																{
+																	a, ok := tf.Attrs["name"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedRole.spec.app.labels.name"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.app.labels.name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Name = t
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["values"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedRole.spec.app.labels.values"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.app.labels.values", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+																		} else {
+																			obj.Values = make([]string, len(v.Elems))
+																			if !v.Null && !v.Unknown {
+																				for k, a := range v.Elems {
+																					v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																					if !ok {
+																						diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.app.labels.values", "github_com_hashicorp_terraform_plugin_framework_types.String"})
+																					} else {
+																						var t string
+																						if !v.Null && !v.Unknown {
+																							t = string(v.Value)
+																						}
+																						obj.Values[k] = t
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+															obj.Labels[k] = t
+														}
+													}
+												}
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["label_expression"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.app.label_expression"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.app.label_expression", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.LabelExpression = t
 											}
 										}
 									}
@@ -3872,6 +4007,193 @@ func CopyScopedRoleToTerraform(ctx context.Context, obj *github_com_gravitationa
 								}
 								v.Unknown = false
 								tf.Attrs["workload_identity"] = v
+							}
+						}
+					}
+					{
+						a, ok := tf.AttrTypes["app"]
+						if !ok {
+							diags.Append(attrWriteMissingDiag{"ScopedRole.spec.app"})
+						} else {
+							o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+							if !ok {
+								diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.app", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+							} else {
+								v, ok := tf.Attrs["app"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+								if !ok {
+									v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+										AttrTypes: o.AttrTypes,
+										Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+									}
+								} else {
+									if v.Attrs == nil {
+										v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+									}
+								}
+								if obj.App == nil {
+									v.Null = true
+								} else {
+									obj := obj.App
+									tf := &v
+									{
+										a, ok := tf.AttrTypes["labels"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.app.labels"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.app.labels", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+											} else {
+												c, ok := tf.Attrs["labels"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+												if !ok {
+													c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+														ElemType: o.ElemType,
+														Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Labels)),
+														Null:     true,
+													}
+												} else {
+													if c.Elems == nil {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Labels))
+													}
+												}
+												if obj.Labels != nil {
+													o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+													if len(obj.Labels) != len(c.Elems) {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Labels))
+													}
+													for k, a := range obj.Labels {
+														v, ok := tf.Attrs["labels"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														if !ok {
+															v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+																AttrTypes: o.AttrTypes,
+																Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+															}
+														} else {
+															if v.Attrs == nil {
+																v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+															}
+														}
+														if a == nil {
+															v.Null = true
+														} else {
+															obj := a
+															tf := &v
+															{
+																t, ok := tf.AttrTypes["name"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedRole.spec.app.labels.name"})
+																} else {
+																	v, ok := tf.Attrs["name"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedRole.spec.app.labels.name", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.app.labels.name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Name) == ""
+																	}
+																	v.Value = string(obj.Name)
+																	v.Unknown = false
+																	tf.Attrs["name"] = v
+																}
+															}
+															{
+																a, ok := tf.AttrTypes["values"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedRole.spec.app.labels.values"})
+																} else {
+																	o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+																	if !ok {
+																		diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.app.labels.values", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+																	} else {
+																		c, ok := tf.Attrs["values"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+																		if !ok {
+																			c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+																				ElemType: o.ElemType,
+																				Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Values)),
+																				Null:     true,
+																			}
+																		} else {
+																			if c.Elems == nil {
+																				c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Values))
+																			}
+																		}
+																		if obj.Values != nil {
+																			t := o.ElemType
+																			if len(obj.Values) != len(c.Elems) {
+																				c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Values))
+																			}
+																			for k, a := range obj.Values {
+																				v, ok := tf.Attrs["values"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																				if !ok {
+																					i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																					if err != nil {
+																						diags.Append(attrWriteGeneralError{"ScopedRole.spec.app.labels.values", err})
+																					}
+																					v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																					if !ok {
+																						diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.app.labels.values", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																					}
+																					v.Null = string(a) == ""
+																				}
+																				v.Value = string(a)
+																				v.Unknown = false
+																				c.Elems[k] = v
+																			}
+																			if len(obj.Values) > 0 {
+																				c.Null = false
+																			}
+																		}
+																		c.Unknown = false
+																		tf.Attrs["values"] = c
+																	}
+																}
+															}
+														}
+														v.Unknown = false
+														c.Elems[k] = v
+													}
+													if len(obj.Labels) > 0 {
+														c.Null = false
+													}
+												}
+												c.Unknown = false
+												tf.Attrs["labels"] = c
+											}
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["label_expression"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.app.label_expression"})
+										} else {
+											v, ok := tf.Attrs["label_expression"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ScopedRole.spec.app.label_expression", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.app.label_expression", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.LabelExpression) == ""
+											}
+											v.Value = string(obj.LabelExpression)
+											v.Unknown = false
+											tf.Attrs["label_expression"] = v
+										}
+									}
+								}
+								v.Unknown = false
+								tf.Attrs["app"] = v
 							}
 						}
 					}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2201,7 +2201,7 @@ func (a *ScopedServerWithRoles) ListResources(ctx context.Context, req proto.Lis
 	}
 
 	switch req.ResourceType {
-	case types.KindKubeServer, types.KindKubernetesCluster:
+	case types.KindKubeServer, types.KindKubernetesCluster, types.KindAppServer:
 	default:
 		return nil, trace.AccessDenied("resource kind %q not supported for scoped identities", req.ResourceType)
 	}
@@ -2282,13 +2282,23 @@ func (a *ScopedServerWithRoles) ListResources(ctx context.Context, req proto.Lis
 		var err error
 		switch res := resource.(type) {
 		case types.KubeServer:
-			err = a.scopedContext.CheckerContext.Decision(ctx, cmp.Or(res.GetScope(), scopes.Root), func(checker *services.ScopedAccessChecker) error {
+			err = a.scopedContext.CheckerContext.Decision(ctx, res.GetScope(), func(checker *services.ScopedAccessChecker) error {
 				return checker.Kube().CanAccessCluster(res.GetCluster())
 			})
 		case types.KubeCluster:
 			// kube clusters should always land in the fake pagination path, but we defensively ignore
 			// them here as a fallback since they're a supported type to be listed
 			err = trace.AccessDenied("resource type %q does not support pagination", res.GetKind())
+		case types.AppServer:
+			// Identity Center account apps are currently not supported for scoped applications.
+			// TODO (williamo/scopes) - potentially look into adding account_assignments into scoped roles.
+			if res.GetSubKind() == types.KindIdentityCenterAccount {
+				err = trace.AccessDenied("identity center account apps are not supported for scoped identities")
+				break
+			}
+			err = a.scopedContext.CheckerContext.Decision(ctx, res.GetScope(), func(checker *services.ScopedAccessChecker) error {
+				return checker.App().CanAccessApp(res.GetApp())
+			})
 		}
 		if err != nil {
 			if trace.IsAccessDenied(err) {

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -96,6 +96,7 @@ import (
 	"github.com/gravitational/teleport/lib/okta/oktatest"
 	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	scopedapp "github.com/gravitational/teleport/lib/scopes/app"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -5813,7 +5814,7 @@ func TestScopedServerWithRolesGenerateAppToken(t *testing.T) {
 			// A scoped user is currently not allowed to be created with create permissions on jwt tokens.
 			// We pass in a rules here just to check that the decision api will reject the user properly
 			name:      "scoped user is denied",
-			server:    newScopePinnedTestServerWithScopedUser(t, srv, "scoped-user", scope, []*scopedaccessv1.ScopedRule{}),
+			server:    newScopePinnedTestServerWithScopedUser(t, srv, "scoped-user", scope, scopedaccessv1.ScopedRoleSpec_builder{AssignableScopes: []string{scope}}.Build()),
 			reqScope:  scope,
 			expectErr: true,
 		},
@@ -6094,6 +6095,119 @@ func createKubeServer(t *testing.T, s *auth.Server, clusterNames []string, hostI
 
 		_, err = s.UpsertKubernetesServer(context.Background(), kubeServer)
 		require.NoError(t, err)
+	}
+}
+
+func TestListResources_ScopedApps(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	srv := newTestTLSServer(t, withScopesFeatures(scopes.Features{Enabled: true, AgentPinEnabled: true}))
+
+	const scope = "/test"
+	const childScope = "/test/child"
+	const otherScope = "/other"
+
+	createAppServer := func(t *testing.T, name, scope string, labels map[string]string) {
+		t.Helper()
+		app, err := types.NewAppV3(types.Metadata{
+			Name:   name,
+			Labels: labels,
+		},
+			types.AppSpecV3{URI: "http://localhost:8080"},
+			scope)
+		require.NoError(t, err)
+		if scope != "" {
+			app.Spec.PublicAddr = scopedapp.ScopedAppPublicAddr(scope, name, "proxy.example.com")
+		}
+		server, err := types.NewAppServerV3FromApp(app, name+"-host", name+"-hostid")
+		require.NoError(t, err)
+		_, err = srv.Auth().UpsertApplicationServer(ctx, server)
+		require.NoError(t, err)
+	}
+
+	// Create apps in various scopes with differing labels
+	createAppServer(t, "prod-app", scope, map[string]string{"env": "prod"})
+	createAppServer(t, "dev-app", scope, map[string]string{"env": "dev"})
+	createAppServer(t, "dev-child-app", childScope, map[string]string{"env": "dev"})
+	createAppServer(t, "other-scope-app", otherScope, map[string]string{"env": "prod"})
+	createAppServer(t, "unscoped-app", "", map[string]string{"env": "prod"})
+
+	appLabels := func(env string) *scopedaccessv1.ScopedRoleApp {
+		return scopedaccessv1.ScopedRoleApp_builder{
+			Labels: []*labelv1.Label{
+				labelv1.Label_builder{
+					Name:   "env",
+					Values: []string{env},
+				}.Build(),
+			},
+		}.Build()
+	}
+	appLabelExpression := func(expr string) *scopedaccessv1.ScopedRoleApp {
+		return scopedaccessv1.ScopedRoleApp_builder{LabelExpression: expr}.Build()
+	}
+
+	// scopedAppUser creates a scope-pinned user whose scoped role grants the given app block.
+	scopedAppUser := func(username, scope string, app *scopedaccessv1.ScopedRoleApp) *auth.ScopedServerWithRoles {
+		return newScopePinnedTestServerWithScopedUser(t, srv.AuthServer, username, scope,
+			scopedaccessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{scope},
+				App:              app,
+			}.Build())
+	}
+
+	cases := []struct {
+		name             string
+		server           *auth.ScopedServerWithRoles
+		appNamesExpected []string
+	}{
+		{
+			name:             "prod labels in scope " + scope,
+			server:           scopedAppUser("test-prod-label", scope, appLabels("prod")),
+			appNamesExpected: []string{"prod-app"},
+		},
+		{
+			name:             "dev label in " + scope,
+			server:           scopedAppUser("test-dev-label", scope, appLabels("dev")),
+			appNamesExpected: []string{"dev-app", "dev-child-app"},
+		},
+		{
+			name:             "dev label expression in " + scope,
+			server:           scopedAppUser("test-dev-expression", scope, appLabelExpression(`contains(labels["env"], "dev")`)),
+			appNamesExpected: []string{"dev-app", "dev-child-app"},
+		},
+		{
+			name:             "label expression in " + scope,
+			server:           scopedAppUser("test-prod-expression", scope, appLabelExpression(`contains(labels["env"], "prod")`)),
+			appNamesExpected: []string{"prod-app"},
+		},
+		{
+			name:             "label expression in " + childScope,
+			server:           scopedAppUser("test-child-prod-expr", childScope, appLabelExpression(`contains(labels["env"], "prod")`)),
+			appNamesExpected: []string{},
+		},
+		{
+			name:             "label expression in " + otherScope,
+			server:           scopedAppUser("other-prod-expression", otherScope, appLabelExpression(`contains(labels["env"], "prod")`)),
+			appNamesExpected: []string{"other-scope-app"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := tc.server.ListResources(ctx, proto.ListResourcesRequest{
+				ResourceType: types.KindAppServer,
+				Limit:        10,
+			})
+			require.NoError(t, err)
+
+			var names []string
+			for _, r := range res.Resources {
+				names = append(names, r.GetName())
+				require.NotEqual(t, "unscoped-app", r.GetName())
+			}
+
+			require.ElementsMatch(t, tc.appNamesExpected, names)
+		})
 	}
 }
 
@@ -9124,7 +9238,7 @@ func newScopedTestServerWithUnscopedUser(t *testing.T, srv *authtest.AuthServer,
 	return scoped
 }
 
-func newScopePinnedTestServerWithScopedUser(t *testing.T, srv *authtest.AuthServer, username, scope string, rules []*scopedaccessv1.ScopedRule) *auth.ScopedServerWithRoles {
+func newScopePinnedTestServerWithScopedUser(t *testing.T, srv *authtest.AuthServer, username, scope string, spec *scopedaccessv1.ScopedRoleSpec) *auth.ScopedServerWithRoles {
 	t.Helper()
 	ctx := t.Context()
 
@@ -9139,10 +9253,7 @@ func newScopePinnedTestServerWithScopedUser(t *testing.T, srv *authtest.AuthServ
 			Version:  types.V1,
 			Metadata: headerv1.Metadata_builder{Name: roleName}.Build(),
 			Scope:    scope,
-			Spec: scopedaccessv1.ScopedRoleSpec_builder{
-				Rules:            rules,
-				AssignableScopes: []string{scope},
-			}.Build(),
+			Spec:     spec,
 		}.Build(),
 	}.Build())
 	require.NoError(t, err)
@@ -9335,8 +9446,12 @@ func TestUpsertNode(t *testing.T) {
 			// Scoped roles cannot be created with node write permissions, so a scoped
 			// user never holds node:create/update and Decision should fail. Change this in the future
 			// if we ever let scoped users permissions for nodes.
-			name:      "scoped user denied",
-			server:    newScopePinnedTestServerWithScopedUser(t, authsrv, "scoped-user", "/staging", nil),
+			name: "scoped user denied",
+			server: newScopePinnedTestServerWithScopedUser(t, authsrv, "scoped-user", "/staging",
+				scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{
+						"/staging"},
+				}.Build()),
 			nodeName:  otherID,
 			nodeScope: "/staging",
 			shouldErr: true,

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -1668,6 +1668,12 @@ func TestStrongValidateRoleSpecAllFieldsValidated(t *testing.T) {
 				labelv1.Label_builder{Name: "env", Values: []string{"prod"}}.Build(),
 			},
 		}.Build(),
+		App: scopedaccessv1.ScopedRoleApp_builder{
+			Labels: []*labelv1.Label{
+				labelv1.Label_builder{Name: "env", Values: []string{"prod"}}.Build(),
+			},
+			LabelExpression: `contains(labels["env"], "prod")`,
+		}.Build(),
 	}.Build()
 
 	require.True(t, testutils.ExhaustiveNonEmpty(spec),

--- a/lib/scopes/access/compat.go
+++ b/lib/scopes/access/compat.go
@@ -59,6 +59,23 @@ func applyKubeBlock(src *scopedaccessv1.ScopedRoleKube, dst *types.RoleCondition
 	}
 }
 
+// applyAppBlock writes/converts the relevant subset of the scoped role's app block into the provided
+// classic role allow block. This helper only writes fields relevant to initial app access *checks*. We
+// reuse the initial access check logic from classic RBAC when performing access checks for scoped identities.
+// Secondary protocol-level controls such as client idle timeout are not converted, and
+// are pulled directly from the scoped role.
+func applyAppBlock(src *scopedaccessv1.ScopedRoleApp, dst *types.RoleConditions) {
+	for _, label := range src.GetLabels() {
+		if dst.AppLabels == nil {
+			dst.AppLabels = make(types.Labels)
+		}
+		dst.AppLabels[label.GetName()] = apiutils.Strings(label.GetValues())
+	}
+	if expr := src.GetLabelExpression(); expr != "" {
+		dst.AppLabelsExpression = expr
+	}
+}
+
 // applyWorkloadIdentityBlock writes/converts the relevant subset of the scoped role's workload_identity
 // block into the provided classic role allow block. This helper only writes fields relevant to issuance
 // access *checks*. We reuse the initial access check logic from classic RBAC (WorkloadIdentityLabels)
@@ -120,6 +137,7 @@ func ScopedRoleToRole(sr *scopedaccessv1.ScopedRole, assignedScope string) (type
 	applySSHBlock(sr.GetSpec().GetSsh(), &conditions)
 	applyKubeBlock(sr.GetSpec().GetKube(), &conditions)
 	applyWorkloadIdentityBlock(sr.GetSpec().GetWorkloadIdentity(), &conditions)
+	applyAppBlock(sr.GetSpec().GetApp(), &conditions)
 	applyRules(sr.GetSpec().GetRules(), &conditions)
 
 	role, err := types.NewRoleWithVersion(sr.GetMetadata().GetName()+"@"+assignedScope, types.V8, types.RoleSpecV6{

--- a/lib/scopes/access/compat_test.go
+++ b/lib/scopes/access/compat_test.go
@@ -523,3 +523,89 @@ func TestKubeConversion(t *testing.T) {
 		})
 	}
 }
+
+// TestAppConversion verifies that the scoped role app block converts its labels and
+// label_expression into the classic role's AppLabels/AppLabelsExpression conditions.
+func TestAppConversion(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name   string
+		app    *scopedaccessv1.ScopedRoleApp
+		expect types.RoleConditions
+	}{
+		{
+			name:   "empty conditions",
+			app:    &scopedaccessv1.ScopedRoleApp{},
+			expect: types.RoleConditions{},
+		},
+		{
+			name: "labels only",
+			app: scopedaccessv1.ScopedRoleApp_builder{
+				Labels: []*labelv1.Label{
+					labelv1.Label_builder{
+						Name:   "env",
+						Values: []string{"prod", "staging"},
+					}.Build(),
+					labelv1.Label_builder{
+						Name:   "team",
+						Values: []string{"blue"},
+					}.Build(),
+				},
+			}.Build(),
+			expect: types.RoleConditions{
+				AppLabels: types.Labels{
+					"env":  apiutils.Strings{"prod", "staging"},
+					"team": apiutils.Strings{"blue"},
+				},
+			},
+		},
+		{
+			name: "label expression only",
+			app: scopedaccessv1.ScopedRoleApp_builder{
+				LabelExpression: `contains(labels["env"], "prod")`,
+			}.Build(),
+			expect: types.RoleConditions{
+				AppLabelsExpression: `contains(labels["env"], "prod")`,
+			},
+		},
+		{
+			name: "labels and expression",
+			app: scopedaccessv1.ScopedRoleApp_builder{
+				Labels: []*labelv1.Label{
+					labelv1.Label_builder{
+						Name:   "env",
+						Values: []string{"prod"},
+					}.Build(),
+				},
+				LabelExpression: `contains(labels["team"], "blue")`,
+			}.Build(),
+			expect: types.RoleConditions{
+				AppLabels: types.Labels{
+					"env": apiutils.Strings{"prod"},
+				},
+				AppLabelsExpression: `contains(labels["team"], "blue")`,
+			},
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			role, err := ScopedRoleToRole(scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/foo",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					App:              tt.app,
+					AssignableScopes: []string{"/foo/bar"},
+				}.Build(),
+				Version: types.V1,
+			}.Build(), "/foo/bar")
+			require.NoError(t, err)
+			tt.expect.Namespaces = []string{"default"}
+			require.Empty(t, cmp.Diff(tt.expect, role.GetRoleConditions(types.Allow)))
+		})
+	}
+}

--- a/lib/services/app_access_checker.go
+++ b/lib/services/app_access_checker.go
@@ -1,0 +1,48 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package services
+
+import (
+	"github.com/gravitational/teleport/api/types"
+)
+
+// AppAccessChecker provides app-specific access checking, abstracting over scoped and unscoped
+// identities. It is obtained from [ScopedAccessChecker.App] and should not be constructed directly.
+// Methods on this type implement app-specific behavior, branching internally between the scoped and
+// unscoped paths of the underlying [ScopedAccessChecker].
+type AppAccessChecker struct {
+	checker *ScopedAccessChecker
+}
+
+// CheckAccessToApp checks access to an application.
+func (c *AppAccessChecker) CheckAccessToApp(target types.Application, state AccessState, matchers ...RoleMatcher) error {
+	if !c.checker.isScoped() {
+		return c.checker.unscopedChecker.CheckAccess(target, state, matchers...)
+	}
+	return c.checker.scopedCompatChecker.CheckAccess(target, state, matchers...)
+}
+
+// CanAccessApp checks whether read access to the specified application is possible without regard
+// to a specific MFA state. Used for listing/filtering.
+func (c *AppAccessChecker) CanAccessApp(target types.Application) error {
+	if !c.checker.isScoped() {
+		return c.checker.unscopedChecker.CheckAccess(target, AccessState{MFAVerified: true})
+	}
+	return c.checker.scopedCompatChecker.CheckAccess(target, AccessState{MFAVerified: true})
+}

--- a/lib/services/scoped_access_checker.go
+++ b/lib/services/scoped_access_checker.go
@@ -232,6 +232,12 @@ func (c *ScopedAccessChecker) Kube() *KubeAccessChecker {
 	return &KubeAccessChecker{checker: c}
 }
 
+// App returns an app-specific access checker backed by this checker. All app-specific methods
+// live on [AppAccessChecker].
+func (c *ScopedAccessChecker) App() *AppAccessChecker {
+	return &AppAccessChecker{checker: c}
+}
+
 // AccessInfo returns the AccessInfo that this access checker is based on.
 func (c *ScopedAccessChecker) AccessInfo() *AccessInfo {
 	if !c.isScoped() {


### PR DESCRIPTION
This PR adds support for scoped users to be able to run `tsh apps ls`.

The scoped role contains a new app block that users may configure. It currently contains only labels and label expressions.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Scoped users can now run tsh app ls


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster, docker apps, local app agents

### Test Cases
- [x] Scoped Users can list apps within their scope or child scope
- [x] Scoped Users cannot see unscoped apps
- [x] Scoped Users cannot see orthogonal apps
- [x] Unscoped users can see all apps - labels permitting
