### PR TITLE
[v18] Add client-side version verification to join flow

### DIFF
--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -102,6 +102,14 @@ type GitlabParams struct {
 	EnvVarName string
 }
 
+// VersionInfo contains version information advertised by a cluster during join.
+type VersionInfo struct {
+	// ServerVersion is the Teleport version advertised by the cluster.
+	ServerVersion string
+	// MinClientVersion is the minimum client version advertised by the cluster.
+	MinClientVersion string
+}
+
 // RegisterParams specifies parameters
 // for first time register operation with auth server
 type RegisterParams struct {
@@ -197,9 +205,10 @@ type RegisterParams struct {
 	// Log is the logger to use for emitting log messages.
 	// If not specified, this defaults to the global logger.
 	Log *slog.Logger
-	// SkipVersionCheck bypasses the client-side minimum version check performed
-	// when joining via a proxy.
-	SkipVersionCheck bool
+	// OnVersionCallback, if non-nil, is invoked during a join after fetching
+	// version information from the cluster. Returning a non-nil error aborts
+	// the join; returning nil allows it to proceed.
+	OnVersionCallback func(ctx context.Context, info VersionInfo) error
 }
 
 func (r *RegisterParams) CheckAndSetDefaults() error {

--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -197,6 +197,9 @@ type RegisterParams struct {
 	// Log is the logger to use for emitting log messages.
 	// If not specified, this defaults to the global logger.
 	Log *slog.Logger
+	// SkipVersionCheck bypasses the client-side minimum version check performed
+	// when joining via a proxy.
+	SkipVersionCheck bool
 }
 
 func (r *RegisterParams) CheckAndSetDefaults() error {

--- a/lib/join/joinclient/join.go
+++ b/lib/join/joinclient/join.go
@@ -22,12 +22,16 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"os"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/client/webclient"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	authjoin "github.com/gravitational/teleport/lib/auth/join"
@@ -45,6 +49,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/spacelift"
 	"github.com/gravitational/teleport/lib/join/terraformcloud"
 	kubetoken "github.com/gravitational/teleport/lib/kube/token"
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/hostid"
 )
 
@@ -166,7 +171,101 @@ func joinNew(ctx context.Context, params JoinParams) (*JoinResult, error) {
 	return nil, trace.NewAggregate(errs...)
 }
 
+// checkClientVersionSupported verifies this client is compatible with the cluster
+// using the proxy's web API. It returns a [ClientTooOldError] when this client
+// is older than the advertised minimum client version, and a [ClientTooNewError]
+// when this client's major version is ahead of the cluster's. It is best-effort
+// and fails open, returning nil when the versions can't be determined. It is
+// bypassed with a warning on incompatibility when [JoinParams.SkipVersionCheck]
+// is set, which is generally set by the --skip-version-check CLI flag.
+func checkClientVersionSupported(ctx context.Context, version string, params JoinParams, proxyAddr string) error {
+	resp, err := webclient.Find(&webclient.Config{
+		Context:   ctx,
+		ProxyAddr: proxyAddr,
+		Insecure:  params.Insecure,
+	})
+	if err != nil {
+		params.Log.WarnContext(ctx,
+			"Could not fetch the cluster's version information from the proxy's web API, skipping version check.",
+			"proxy_addr", proxyAddr,
+			"error", err,
+		)
+		return nil
+	}
+
+	for _, err := range []error{
+		checkClientMeetsMinVersion(version, resp.MinClientVersion),
+		checkClientMeetsMaxVersion(version, resp.ServerVersion),
+	} {
+		if err == nil {
+			continue
+		}
+		// Only a confirmed version mismatch is fatal. Parsing problems fail open so a
+		// malformed version advertised by the proxy can't block joining.
+		if !IsVersionIncompatible(err) {
+			params.Log.WarnContext(ctx,
+				"Could not determine version compatibility with the cluster, skipping check.",
+				"error", err,
+				"min_client_version", resp.MinClientVersion,
+				"server_version", resp.ServerVersion,
+				"client_version", version,
+			)
+			continue
+		}
+		if params.SkipVersionCheck {
+			params.Log.WarnContext(ctx,
+				"This client is not compatible with the cluster's version, ignoring the version check because --skip-version-check is set.",
+				"error", err,
+				"min_client_version", resp.MinClientVersion,
+				"server_version", resp.ServerVersion,
+				"client_version", version,
+			)
+			continue
+		}
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func checkClientMeetsMinVersion(clientVersion, minVersion string) error {
+	if minVersion == "" {
+		return nil
+	}
+	// Stripping the pre-release both validates the advertised minimum and yields a
+	// clean version for the user-facing error message.
+	minWithoutPreRelease, err := utils.VersionWithoutPreRelease(minVersion)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if !utils.MeetsMinVersion(clientVersion, minVersion) {
+		return &ClientTooOldError{ClientVersion: clientVersion, MinVersion: minWithoutPreRelease}
+	}
+	return nil
+}
+
+func checkClientMeetsMaxVersion(clientVersion, serverVersion string) error {
+	if serverVersion == "" {
+		return nil
+	}
+	client, err := semver.NewVersion(clientVersion)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	server, err := semver.NewVersion(serverVersion)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if server.Major < client.Major {
+		return &ClientTooNewError{LocalMajorVersion: client.Major, ClusterMajorVersion: server.Major}
+	}
+	return nil
+}
+
 func joinViaProxy(ctx context.Context, params JoinParams, proxyAddr string) (*JoinResult, error) {
+	if err := checkClientVersionSupported(ctx, teleport.Version, params, proxyAddr); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// Connect to the proxy's insecure gRPC listener (this is regular TLS, the
 	// client is not authenticated because it doesn't have certs yet).
 	conn, err := proxyinsecureclient.NewConnection(ctx,
@@ -592,4 +691,33 @@ func (e *LegacyJoinError) Error() string {
 
 func (e *LegacyJoinError) Unwrap() error {
 	return e.wrapped
+}
+
+// ClientTooOldError indicates this client is older than the cluster's minimum
+// client version.
+type ClientTooOldError struct {
+	ClientVersion string
+	MinVersion    string
+}
+
+func (e *ClientTooOldError) Error() string {
+	return fmt.Sprintf("this client is older than the minimum supported version required by the cluster and will not be able to connect until it is upgraded (client v%s, minimum v%s). To connect anyway pass the --skip-version-check flag.", e.ClientVersion, e.MinVersion)
+}
+
+// ClientTooNewError indicates this client is a newer major version than the cluster.
+type ClientTooNewError struct {
+	LocalMajorVersion   int64
+	ClusterMajorVersion int64
+}
+
+func (e *ClientTooNewError) Error() string {
+	return fmt.Sprintf("this client is running v%d, but the cluster is running v%d and only supports clients on v%d or v%d. To connect anyway pass the --skip-version-check flag.", e.LocalMajorVersion, e.ClusterMajorVersion, e.ClusterMajorVersion, e.ClusterMajorVersion-1)
+}
+
+// IsVersionIncompatible reports whether err indicates this client's version is
+// incompatible with the cluster, either a [ClientTooOldError] or [ClientTooNewError].
+func IsVersionIncompatible(err error) bool {
+	var tooOld *ClientTooOldError
+	var tooNew *ClientTooNewError
+	return errors.As(err, &tooOld) || errors.As(err, &tooNew)
 }

--- a/lib/join/joinclient/join.go
+++ b/lib/join/joinclient/join.go
@@ -22,14 +22,11 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
-	"fmt"
 	"os"
 
-	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/client/webclient"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
@@ -49,7 +46,6 @@ import (
 	"github.com/gravitational/teleport/lib/join/spacelift"
 	"github.com/gravitational/teleport/lib/join/terraformcloud"
 	kubetoken "github.com/gravitational/teleport/lib/kube/token"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/hostid"
 )
 
@@ -58,6 +54,7 @@ type (
 	JoinResult   = authjoin.RegisterResult
 	AzureParams  = authjoin.AzureParams
 	GitlabParams = authjoin.GitlabParams
+	VersionInfo  = authjoin.VersionInfo
 )
 
 // Join is used to join a cluster. A host or bot calls this with the name of a
@@ -171,14 +168,18 @@ func joinNew(ctx context.Context, params JoinParams) (*JoinResult, error) {
 	return nil, trace.NewAggregate(errs...)
 }
 
-// checkClientVersionSupported verifies this client is compatible with the cluster
-// using the proxy's web API. It returns a [ClientTooOldError] when this client
-// is older than the advertised minimum client version, and a [ClientTooNewError]
-// when this client's major version is ahead of the cluster's. It is best-effort
-// and fails open, returning nil when the versions can't be determined. It is
-// bypassed with a warning on incompatibility when [JoinParams.SkipVersionCheck]
-// is set, which is generally set by the --skip-version-check CLI flag.
-func checkClientVersionSupported(ctx context.Context, version string, params JoinParams, proxyAddr string) error {
+// invokeVersionCallback fetches the cluster's version information using the
+// proxy's web API and passes it to the caller's callback, configured via the
+// [JoinParams.OnVersionCallback] field. It is best-effort and fails open if
+// the version information can't be fetched. It exits early, skipping the
+// fetch, if no version callback is configured.
+func invokeVersionCallback(ctx context.Context, params JoinParams, proxyAddr string) error {
+	if params.OnVersionCallback == nil {
+		params.Log.DebugContext(ctx,
+			"No version callback configured, skipping version information fetch.")
+		return nil
+	}
+
 	resp, err := webclient.Find(&webclient.Config{
 		Context:   ctx,
 		ProxyAddr: proxyAddr,
@@ -186,83 +187,21 @@ func checkClientVersionSupported(ctx context.Context, version string, params Joi
 	})
 	if err != nil {
 		params.Log.WarnContext(ctx,
-			"Could not fetch the cluster's version information from the proxy's web API, skipping version check.",
+			"Could not fetch the cluster's version information from the proxy's web API, skipping version callback.",
 			"proxy_addr", proxyAddr,
 			"error", err,
 		)
 		return nil
 	}
 
-	for _, err := range []error{
-		checkClientMeetsMinVersion(version, resp.MinClientVersion),
-		checkClientMeetsMaxVersion(version, resp.ServerVersion),
-	} {
-		if err == nil {
-			continue
-		}
-		// Only a confirmed version mismatch is fatal. Parsing problems fail open so a
-		// malformed version advertised by the proxy can't block joining.
-		if !IsVersionIncompatible(err) {
-			params.Log.WarnContext(ctx,
-				"Could not determine version compatibility with the cluster, skipping check.",
-				"error", err,
-				"min_client_version", resp.MinClientVersion,
-				"server_version", resp.ServerVersion,
-				"client_version", version,
-			)
-			continue
-		}
-		if params.SkipVersionCheck {
-			params.Log.WarnContext(ctx,
-				"This client is not compatible with the cluster's version, ignoring the version check because --skip-version-check is set.",
-				"error", err,
-				"min_client_version", resp.MinClientVersion,
-				"server_version", resp.ServerVersion,
-				"client_version", version,
-			)
-			continue
-		}
-		return trace.Wrap(err)
-	}
-	return nil
-}
-
-func checkClientMeetsMinVersion(clientVersion, minVersion string) error {
-	if minVersion == "" {
-		return nil
-	}
-	// Stripping the pre-release both validates the advertised minimum and yields a
-	// clean version for the user-facing error message.
-	minWithoutPreRelease, err := utils.VersionWithoutPreRelease(minVersion)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if !utils.MeetsMinVersion(clientVersion, minVersion) {
-		return &ClientTooOldError{ClientVersion: clientVersion, MinVersion: minWithoutPreRelease}
-	}
-	return nil
-}
-
-func checkClientMeetsMaxVersion(clientVersion, serverVersion string) error {
-	if serverVersion == "" {
-		return nil
-	}
-	client, err := semver.NewVersion(clientVersion)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	server, err := semver.NewVersion(serverVersion)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if server.Major < client.Major {
-		return &ClientTooNewError{LocalMajorVersion: client.Major, ClusterMajorVersion: server.Major}
-	}
-	return nil
+	return trace.Wrap(params.OnVersionCallback(ctx, VersionInfo{
+		ServerVersion:    resp.ServerVersion,
+		MinClientVersion: resp.MinClientVersion,
+	}))
 }
 
 func joinViaProxy(ctx context.Context, params JoinParams, proxyAddr string) (*JoinResult, error) {
-	if err := checkClientVersionSupported(ctx, teleport.Version, params, proxyAddr); err != nil {
+	if err := invokeVersionCallback(ctx, params, proxyAddr); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -691,33 +630,4 @@ func (e *LegacyJoinError) Error() string {
 
 func (e *LegacyJoinError) Unwrap() error {
 	return e.wrapped
-}
-
-// ClientTooOldError indicates this client is older than the cluster's minimum
-// client version.
-type ClientTooOldError struct {
-	ClientVersion string
-	MinVersion    string
-}
-
-func (e *ClientTooOldError) Error() string {
-	return fmt.Sprintf("this client is older than the minimum supported version required by the cluster and will not be able to connect until it is upgraded (client v%s, minimum v%s). To connect anyway pass the --skip-version-check flag.", e.ClientVersion, e.MinVersion)
-}
-
-// ClientTooNewError indicates this client is a newer major version than the cluster.
-type ClientTooNewError struct {
-	LocalMajorVersion   int64
-	ClusterMajorVersion int64
-}
-
-func (e *ClientTooNewError) Error() string {
-	return fmt.Sprintf("this client is running v%d, but the cluster is running v%d and only supports clients on v%d or v%d. To connect anyway pass the --skip-version-check flag.", e.LocalMajorVersion, e.ClusterMajorVersion, e.ClusterMajorVersion, e.ClusterMajorVersion-1)
-}
-
-// IsVersionIncompatible reports whether err indicates this client's version is
-// incompatible with the cluster, either a [ClientTooOldError] or [ClientTooNewError].
-func IsVersionIncompatible(err error) bool {
-	var tooOld *ClientTooOldError
-	var tooNew *ClientTooNewError
-	return errors.As(err, &tooOld) || errors.As(err, &tooNew)
 }

--- a/lib/join/joinclient/version_test.go
+++ b/lib/join/joinclient/version_test.go
@@ -17,6 +17,7 @@
 package joinclient
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -31,230 +32,47 @@ import (
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
-func requireClientTooOld(t require.TestingT, err error, _ ...any) {
-	var target *ClientTooOldError
-	require.ErrorAs(t, err, &target)
-}
-
-func requireClientTooNew(t require.TestingT, err error, _ ...any) {
-	var target *ClientTooNewError
-	require.ErrorAs(t, err, &target)
-}
-
-func TestCheckClientMeetsMinVersion(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name          string
-		clientVersion string
-		minVersion    string
-		assertErr     require.ErrorAssertionFunc
-	}{
-		{
-			name:          "client too old",
-			clientVersion: "1.0.0",
-			minVersion:    "2.0.0",
-			assertErr:     requireClientTooOld,
-		},
-		{
-			// The pre-release suffix is stripped from the minimum reported in
-			// the error so the user-facing message shows a clean version.
-			name:          "client too old with pre-release minimum",
-			clientVersion: "1.0.0",
-			minVersion:    "2.0.0-aa",
-			assertErr: func(t require.TestingT, err error, _ ...any) {
-				requireClientTooOld(t, err)
-				require.Contains(t, err.Error(), "minimum v2.0.0)")
-			},
-		},
-		{
-			name:          "pre-release client too old for release minimum",
-			clientVersion: "2.0.0-dev",
-			minVersion:    "2.0.0",
-			assertErr:     requireClientTooOld,
-		},
-		{
-			// The proxy advertises "<major>.0.0-aa" so that pre-release builds
-			// of the minimum version are permitted. This case fails if the
-			// comparison ever switches to the stripped minimum (2.0.0-dev is
-			// below 2.0.0 but above 2.0.0-aa).
-			name:          "pre-release client meets pre-release minimum",
-			clientVersion: "2.0.0-dev",
-			minVersion:    "2.0.0-aa",
-			assertErr:     require.NoError,
-		},
-		{
-			name:          "client meets minimum",
-			clientVersion: "2.0.0",
-			minVersion:    "1.0.0",
-			assertErr:     require.NoError,
-		},
-		{
-			name:          "client exactly meets minimum",
-			clientVersion: "1.0.0",
-			minVersion:    "1.0.0",
-			assertErr:     require.NoError,
-		},
-		{
-			name:          "no minimum advertised",
-			clientVersion: "1.0.0",
-			minVersion:    "",
-			assertErr:     require.NoError,
-		},
-		{
-			name:          "malformed minimum returns parse error",
-			clientVersion: "1.0.0",
-			minVersion:    "not-a-version",
-			assertErr: func(t require.TestingT, err error, _ ...any) {
-				require.Error(t, err)
-				var target *ClientTooOldError
-				require.NotErrorAs(t, err, &target)
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			tc.assertErr(t, checkClientMeetsMinVersion(tc.clientVersion, tc.minVersion))
-		})
-	}
-}
-
-func TestCheckClientMeetsMaxVersion(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name          string
-		clientVersion string
-		serverVersion string
-		assertErr     require.ErrorAssertionFunc
-	}{
-		{
-			name:          "client is newer than server",
-			clientVersion: "3.0.0",
-			serverVersion: "2.0.0",
-			assertErr: func(t require.TestingT, err error, _ ...any) {
-				requireClientTooNew(t, err)
-				require.Contains(t, err.Error(), "supports clients on v2 or v1")
-			},
-		},
-		{
-			name:          "client is older than server",
-			clientVersion: "1.0.0",
-			serverVersion: "2.0.0",
-			assertErr:     require.NoError,
-		},
-		{
-			name:          "client and server are the same version",
-			clientVersion: "1.0.0",
-			serverVersion: "1.0.0",
-			assertErr:     require.NoError,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			tc.assertErr(t, checkClientMeetsMaxVersion(tc.clientVersion, tc.serverVersion))
-		})
-	}
-}
-
-func TestCheckClientVersionSupported(t *testing.T) {
+func TestInvokeVersionCallback(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
 		name             string
-		clientVersion    string
 		minClientVersion string
 		serverVersion    string
 		findError        bool
-		skipVersionCheck bool
+		callback         func(t *testing.T, info VersionInfo) error
 		assertErr        require.ErrorAssertionFunc
 	}{
 		{
-			name:             "too old",
-			clientVersion:    "1.0.0",
+			name:             "invokes callback with version info",
 			minClientVersion: "2.0.0",
-			assertErr:        requireClientTooOld,
-		},
-		{
-			name:             "too old but skip version check",
-			clientVersion:    "1.0.0",
-			minClientVersion: "2.0.0",
-			skipVersionCheck: true,
-			assertErr:        require.NoError,
-		},
-		{
-			name:             "meets minimum",
-			clientVersion:    "2.0.0",
-			minClientVersion: "1.0.0",
-			assertErr:        require.NoError,
-		},
-		{
-			name:             "malformed minimum fails open",
-			clientVersion:    "1.0.0",
-			minClientVersion: "not-a-version",
-			assertErr:        require.NoError,
-		},
-		{
-			name:          "client too new",
-			clientVersion: "3.0.0",
-			serverVersion: "2.0.0",
-			assertErr:     requireClientTooNew,
-		},
-		{
-			name:             "client too new but skip version check",
-			clientVersion:    "3.0.0",
 			serverVersion:    "2.0.0",
-			skipVersionCheck: true,
-			assertErr:        require.NoError,
+			callback: func(t *testing.T, info VersionInfo) error {
+				require.Equal(t, VersionInfo{
+					ServerVersion:    "2.0.0",
+					MinClientVersion: "2.0.0",
+				}, info)
+				return nil
+			},
+			assertErr: require.NoError,
 		},
 		{
-			name:          "server same major",
-			clientVersion: "2.5.0",
-			serverVersion: "2.0.0",
-			assertErr:     require.NoError,
-		},
-		{
-			name:          "malformed server version fails open",
-			clientVersion: "3.0.0",
-			serverVersion: "not-a-version",
-			assertErr:     require.NoError,
-		},
-		{
-			// A malformed minimum must not mask a real server-too-old verdict.
-			// The min parse error fails open on its own, but the independent
-			// server check must still be honored.
-			name:             "malformed minimum does not mask client too new",
-			clientVersion:    "3.0.0",
-			minClientVersion: "not-a-version",
+			name:             "callback error aborts",
+			minClientVersion: "2.0.0",
 			serverVersion:    "2.0.0",
-			assertErr:        requireClientTooNew,
+			callback: func(t *testing.T, info VersionInfo) error {
+				return trace.BadParameter("version rejected")
+			},
+			assertErr: require.Error,
 		},
 		{
-			// A client-too-old verdict stands even when the server version is
-			// unparseable. The bad server version fails open and must not
-			// suppress the client check.
-			name:             "client too old with malformed server version",
-			clientVersion:    "1.0.0",
-			minClientVersion: "2.0.0",
-			serverVersion:    "not-a-version",
-			assertErr:        requireClientTooOld,
-		},
-		{
-			name:          "find error fails open",
-			clientVersion: "1.0.0",
-			findError:     true,
-			assertErr:     require.NoError,
-		},
-		{
-			name:             "malformed client version",
-			clientVersion:    "not-a-version",
-			minClientVersion: "2.0.0",
-			serverVersion:    "3.0.0",
-			assertErr:        require.NoError,
+			name:      "find error does not invoke callback",
+			findError: true,
+			callback: func(t *testing.T, info VersionInfo) error {
+				t.Fatal("unexpected version callback invocation")
+				return nil
+			},
+			assertErr: require.NoError,
 		},
 	}
 
@@ -276,25 +94,32 @@ func TestCheckClientVersionSupported(t *testing.T) {
 			t.Cleanup(srv.Close)
 
 			params := JoinParams{
-				Insecure:         true,
-				SkipVersionCheck: tc.skipVersionCheck,
-				Log:              logtest.NewLogger(),
+				Insecure: true,
+				OnVersionCallback: func(ctx context.Context, info VersionInfo) error {
+					return tc.callback(t, info)
+				},
+				Log: logtest.NewLogger(),
 			}
 			addr := strings.TrimPrefix(srv.URL, "https://")
-			tc.assertErr(t, checkClientVersionSupported(t.Context(), tc.clientVersion, params, addr))
+			tc.assertErr(t, invokeVersionCallback(t.Context(), params, addr))
 		})
 	}
 }
 
-// TestClientVersionErrorsAreFatal ensures a confirmed too-old or too-new client
-// error is not misclassified as a connection or not-implemented error. If it
-// were, Join would fall back to the legacy join service (join.go), which has no
-// version check and would discard the original error.
-func TestClientVersionErrorsAreFatal(t *testing.T) {
+// TestInvokeVersionCallbackNoHandler ensures version information is not fetched
+// when no version callback is configured.
+func TestInvokeVersionCallbackNoHandler(t *testing.T) {
 	t.Parallel()
 
-	for _, err := range []error{&ClientTooOldError{}, &ClientTooNewError{}} {
-		assert.False(t, isConnectionError(err), "%T must not be a connection error", err)
-		assert.False(t, trace.IsNotImplemented(err), "%T must not be not-implemented", err)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request to proxy web API: %s", r.URL.Path)
+	}))
+	t.Cleanup(srv.Close)
+
+	params := JoinParams{
+		Insecure: true,
+		Log:      logtest.NewLogger(),
 	}
+	addr := strings.TrimPrefix(srv.URL, "https://")
+	require.NoError(t, invokeVersionCallback(t.Context(), params, addr))
 }

--- a/lib/join/joinclient/version_test.go
+++ b/lib/join/joinclient/version_test.go
@@ -1,0 +1,300 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package joinclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/client/webclient"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+func requireClientTooOld(t require.TestingT, err error, _ ...any) {
+	var target *ClientTooOldError
+	require.ErrorAs(t, err, &target)
+}
+
+func requireClientTooNew(t require.TestingT, err error, _ ...any) {
+	var target *ClientTooNewError
+	require.ErrorAs(t, err, &target)
+}
+
+func TestCheckClientMeetsMinVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		clientVersion string
+		minVersion    string
+		assertErr     require.ErrorAssertionFunc
+	}{
+		{
+			name:          "client too old",
+			clientVersion: "1.0.0",
+			minVersion:    "2.0.0",
+			assertErr:     requireClientTooOld,
+		},
+		{
+			// The pre-release suffix is stripped from the minimum reported in
+			// the error so the user-facing message shows a clean version.
+			name:          "client too old with pre-release minimum",
+			clientVersion: "1.0.0",
+			minVersion:    "2.0.0-aa",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				requireClientTooOld(t, err)
+				require.Contains(t, err.Error(), "minimum v2.0.0)")
+			},
+		},
+		{
+			name:          "pre-release client too old for release minimum",
+			clientVersion: "2.0.0-dev",
+			minVersion:    "2.0.0",
+			assertErr:     requireClientTooOld,
+		},
+		{
+			// The proxy advertises "<major>.0.0-aa" so that pre-release builds
+			// of the minimum version are permitted. This case fails if the
+			// comparison ever switches to the stripped minimum (2.0.0-dev is
+			// below 2.0.0 but above 2.0.0-aa).
+			name:          "pre-release client meets pre-release minimum",
+			clientVersion: "2.0.0-dev",
+			minVersion:    "2.0.0-aa",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "client meets minimum",
+			clientVersion: "2.0.0",
+			minVersion:    "1.0.0",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "client exactly meets minimum",
+			clientVersion: "1.0.0",
+			minVersion:    "1.0.0",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "no minimum advertised",
+			clientVersion: "1.0.0",
+			minVersion:    "",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "malformed minimum returns parse error",
+			clientVersion: "1.0.0",
+			minVersion:    "not-a-version",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				var target *ClientTooOldError
+				require.NotErrorAs(t, err, &target)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.assertErr(t, checkClientMeetsMinVersion(tc.clientVersion, tc.minVersion))
+		})
+	}
+}
+
+func TestCheckClientMeetsMaxVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		clientVersion string
+		serverVersion string
+		assertErr     require.ErrorAssertionFunc
+	}{
+		{
+			name:          "client is newer than server",
+			clientVersion: "3.0.0",
+			serverVersion: "2.0.0",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				requireClientTooNew(t, err)
+				require.Contains(t, err.Error(), "supports clients on v2 or v1")
+			},
+		},
+		{
+			name:          "client is older than server",
+			clientVersion: "1.0.0",
+			serverVersion: "2.0.0",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "client and server are the same version",
+			clientVersion: "1.0.0",
+			serverVersion: "1.0.0",
+			assertErr:     require.NoError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.assertErr(t, checkClientMeetsMaxVersion(tc.clientVersion, tc.serverVersion))
+		})
+	}
+}
+
+func TestCheckClientVersionSupported(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name             string
+		clientVersion    string
+		minClientVersion string
+		serverVersion    string
+		findError        bool
+		skipVersionCheck bool
+		assertErr        require.ErrorAssertionFunc
+	}{
+		{
+			name:             "too old",
+			clientVersion:    "1.0.0",
+			minClientVersion: "2.0.0",
+			assertErr:        requireClientTooOld,
+		},
+		{
+			name:             "too old but skip version check",
+			clientVersion:    "1.0.0",
+			minClientVersion: "2.0.0",
+			skipVersionCheck: true,
+			assertErr:        require.NoError,
+		},
+		{
+			name:             "meets minimum",
+			clientVersion:    "2.0.0",
+			minClientVersion: "1.0.0",
+			assertErr:        require.NoError,
+		},
+		{
+			name:             "malformed minimum fails open",
+			clientVersion:    "1.0.0",
+			minClientVersion: "not-a-version",
+			assertErr:        require.NoError,
+		},
+		{
+			name:          "client too new",
+			clientVersion: "3.0.0",
+			serverVersion: "2.0.0",
+			assertErr:     requireClientTooNew,
+		},
+		{
+			name:             "client too new but skip version check",
+			clientVersion:    "3.0.0",
+			serverVersion:    "2.0.0",
+			skipVersionCheck: true,
+			assertErr:        require.NoError,
+		},
+		{
+			name:          "server same major",
+			clientVersion: "2.5.0",
+			serverVersion: "2.0.0",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "malformed server version fails open",
+			clientVersion: "3.0.0",
+			serverVersion: "not-a-version",
+			assertErr:     require.NoError,
+		},
+		{
+			// A malformed minimum must not mask a real server-too-old verdict.
+			// The min parse error fails open on its own, but the independent
+			// server check must still be honored.
+			name:             "malformed minimum does not mask client too new",
+			clientVersion:    "3.0.0",
+			minClientVersion: "not-a-version",
+			serverVersion:    "2.0.0",
+			assertErr:        requireClientTooNew,
+		},
+		{
+			// A client-too-old verdict stands even when the server version is
+			// unparseable. The bad server version fails open and must not
+			// suppress the client check.
+			name:             "client too old with malformed server version",
+			clientVersion:    "1.0.0",
+			minClientVersion: "2.0.0",
+			serverVersion:    "not-a-version",
+			assertErr:        requireClientTooOld,
+		},
+		{
+			name:          "find error fails open",
+			clientVersion: "1.0.0",
+			findError:     true,
+			assertErr:     require.NoError,
+		},
+		{
+			name:             "malformed client version",
+			clientVersion:    "not-a-version",
+			minClientVersion: "2.0.0",
+			serverVersion:    "3.0.0",
+			assertErr:        require.NoError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.findError {
+					http.Error(w, "unavailable", http.StatusServiceUnavailable)
+					return
+				}
+				assert.Equal(t, "/webapi/find", r.URL.Path)
+				assert.NoError(t, json.NewEncoder(w).Encode(webclient.PingResponse{
+					MinClientVersion: tc.minClientVersion,
+					ServerVersion:    tc.serverVersion,
+				}))
+			}))
+			t.Cleanup(srv.Close)
+
+			params := JoinParams{
+				Insecure:         true,
+				SkipVersionCheck: tc.skipVersionCheck,
+				Log:              logtest.NewLogger(),
+			}
+			addr := strings.TrimPrefix(srv.URL, "https://")
+			tc.assertErr(t, checkClientVersionSupported(t.Context(), tc.clientVersion, params, addr))
+		})
+	}
+}
+
+// TestClientVersionErrorsAreFatal ensures a confirmed too-old or too-new client
+// error is not misclassified as a connection or not-implemented error. If it
+// were, Join would fall back to the legacy join service (join.go), which has no
+// version check and would discard the original error.
+func TestClientVersionErrorsAreFatal(t *testing.T) {
+	t.Parallel()
+
+	for _, err := range []error{&ClientTooOldError{}, &ClientTooNewError{}} {
+		assert.False(t, isConnectionError(err), "%T must not be a connection error", err)
+		assert.False(t, trace.IsNotImplemented(err), "%T must not be not-implemented", err)
+	}
+}

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -97,7 +97,10 @@ func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*
 			return connector, nil
 		} else {
 			switch {
-			case errors.As(connectErr, &invalidVersionErr{}):
+			// Version incompatibilities (the client is too new or too old for
+			// the cluster) are fatal. Retrying is pointless until the client is
+			// up or downgraded, so surface the error and stop reconnecting.
+			case isVersionCompatibilityError(connectErr):
 				return nil, trace.Wrap(connectErr)
 			case strings.Contains(connectErr.Error(), auth.TokenExpiredOrNotFound):
 				process.logger.ErrorContext(process.ExitContext(), "Can not join the cluster, the token is expired or not found. Regenerate the token and try again.")
@@ -135,6 +138,11 @@ type invalidVersionErr struct {
 
 func (i invalidVersionErr) Error() string {
 	return fmt.Sprintf("Teleport instance is too new. This instance is running v%d. The auth server is running v%d and only supports instances on v%d or v%d. To connect anyway pass the --skip-version-check flag.", i.LocalMajorVersion, i.ClusterMajorVersion, i.ClusterMajorVersion, i.ClusterMajorVersion-1)
+}
+
+func isVersionCompatibilityError(err error) bool {
+	return errors.As(err, &invalidVersionErr{}) ||
+		joinclient.IsVersionIncompatible(err)
 }
 
 func (process *TeleportProcess) assertSystemRoles(rolesToAssert []types.SystemRole) (assertionID string, err error) {
@@ -817,6 +825,7 @@ func (process *TeleportProcess) makeJoinParams(
 		CircuitBreakerConfig: breaker.NoopBreakerConfig(),
 		FIPS:                 process.Config.FIPS,
 		Insecure:             lib.IsInsecureDevMode(),
+		SkipVersionCheck:     process.Config.SkipVersionCheck,
 	}
 	if joinParams.JoinMethod == types.JoinMethodAzure {
 		joinParams.AzureParams = joinclient.AzureParams{

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -142,7 +142,7 @@ func (i invalidVersionErr) Error() string {
 
 func isVersionCompatibilityError(err error) bool {
 	return errors.As(err, &invalidVersionErr{}) ||
-		joinclient.IsVersionIncompatible(err)
+		isVersionIncompatible(err)
 }
 
 func (process *TeleportProcess) assertSystemRoles(rolesToAssert []types.SystemRole) (assertionID string, err error) {
@@ -825,7 +825,7 @@ func (process *TeleportProcess) makeJoinParams(
 		CircuitBreakerConfig: breaker.NoopBreakerConfig(),
 		FIPS:                 process.Config.FIPS,
 		Insecure:             lib.IsInsecureDevMode(),
-		SkipVersionCheck:     process.Config.SkipVersionCheck,
+		OnVersionCallback:    process.enforceVersionPolicy,
 	}
 	if joinParams.JoinMethod == types.JoinMethodAzure {
 		joinParams.AzureParams = joinclient.AzureParams{

--- a/lib/service/connect_test.go
+++ b/lib/service/connect_test.go
@@ -90,7 +90,7 @@ func TestTeleportProcessClientVersionCheck(t *testing.T) {
 		t.Cleanup(func() { _ = process.Close() })
 
 		c, err := process.reconnectToAuthService(types.RoleInstance)
-		var tooOld *joinclient.ClientTooOldError
+		var tooOld *clientTooOldError
 		require.ErrorAs(t, err, &tooOld)
 		require.Nil(t, c)
 	})
@@ -107,11 +107,11 @@ func TestTeleportProcessClientVersionCheck(t *testing.T) {
 		// With the check skipped the join fails against the stub with an
 		// ordinary connection error, which reconnectToAuthService treats as
 		// retryable and would loop on forever. Failing with anything other
-		// than ClientTooOldError proves SkipVersionCheck was plumbed through
+		// than clientTooOldError proves SkipVersionCheck was plumbed through
 		// and bypassed the check.
 		c, err := process.connectToAuthService(types.RoleInstance)
 		require.Error(t, err)
-		var tooOld *joinclient.ClientTooOldError
+		var tooOld *clientTooOldError
 		require.NotErrorAs(t, err, &tooOld)
 		require.Nil(t, c)
 	})
@@ -124,7 +124,7 @@ func TestTeleportProcessClientVersionCheck(t *testing.T) {
 		t.Cleanup(func() { _ = process.Close() })
 
 		c, err := process.reconnectToAuthService(types.RoleInstance)
-		var tooNew *joinclient.ClientTooNewError
+		var tooNew *clientTooNewError
 		require.ErrorAs(t, err, &tooNew)
 		require.Nil(t, c)
 	})
@@ -141,11 +141,11 @@ func TestTeleportProcessClientVersionCheck(t *testing.T) {
 		// With the check skipped the join fails against the stub with an
 		// ordinary connection error, which reconnectToAuthService treats as
 		// retryable and would loop on forever. Failing with anything other
-		// than ClientTooNewError proves SkipVersionCheck was plumbed through
+		// than clientTooNewError proves SkipVersionCheck was plumbed through
 		// and bypassed the check.
 		c, err := process.connectToAuthService(types.RoleInstance)
 		require.Error(t, err)
-		var tooNew *joinclient.ClientTooNewError
+		var tooNew *clientTooNewError
 		require.NotErrorAs(t, err, &tooNew)
 		require.Nil(t, c)
 	})

--- a/lib/service/connect_test.go
+++ b/lib/service/connect_test.go
@@ -19,24 +19,137 @@
 package service
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/storage"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
+
+func TestTeleportProcessClientVersionCheck(t *testing.T) {
+	lib.SetInsecureDevMode(true)
+	t.Cleanup(func() { lib.SetInsecureDevMode(false) })
+
+	// The skew is induced from the server side: the stub advertises requirements
+	// the running build can't satisfy, so the client-side check trips against the
+	// real teleport.Version without overriding the local version.
+	tooOldMinVersion := semver.Version{Major: teleport.SemVer().Major + 1}.String()
+	tooNewServerVersion := semver.Version{Major: teleport.SemVer().Major - 1}.String()
+
+	newConfig := func(t *testing.T, minClientVersion, serverVersion string) *servicecfg.Config {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// The skipped-check variant proceeds past the version check and hits
+			// join endpoints this stub doesn't implement before failing.
+			if r.URL.Path != "/webapi/find" {
+				http.NotFound(w, r)
+				return
+			}
+			require.NoError(t, json.NewEncoder(w).Encode(webclient.PingResponse{
+				MinClientVersion: minClientVersion,
+				ServerVersion:    serverVersion,
+			}))
+		}))
+		t.Cleanup(srv.Close)
+
+		cfg := servicecfg.MakeDefaultConfig()
+		cfg.Version = defaults.TeleportConfigVersionV3
+		cfg.ProxyServer = utils.NetAddr{AddrNetwork: "tcp", Addr: strings.TrimPrefix(srv.URL, "https://")}
+		cfg.DataDir = makeTempDir(t)
+		cfg.SetToken("join-token")
+		cfg.Auth.Enabled = false
+		cfg.Proxy.Enabled = false
+		cfg.SSH.Enabled = true
+		return cfg
+	}
+
+	t.Run("client too old stops reconnect retries", func(t *testing.T) {
+		cfg := newConfig(t, tooOldMinVersion, teleport.Version)
+		process, err := NewTeleport(cfg)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = process.Close() })
+
+		c, err := process.reconnectToAuthService(types.RoleInstance)
+		var tooOld *joinclient.ClientTooOldError
+		require.ErrorAs(t, err, &tooOld)
+		require.Nil(t, c)
+	})
+
+	t.Run("client too old with skip version check bypasses the failure", func(t *testing.T) {
+		cfg := newConfig(t, tooOldMinVersion, teleport.Version)
+		cfg.SkipVersionCheck = true
+
+		process, err := NewTeleport(cfg)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = process.Close() })
+
+		// Deliberately call connectToAuthService, not reconnectToAuthService.
+		// With the check skipped the join fails against the stub with an
+		// ordinary connection error, which reconnectToAuthService treats as
+		// retryable and would loop on forever. Failing with anything other
+		// than ClientTooOldError proves SkipVersionCheck was plumbed through
+		// and bypassed the check.
+		c, err := process.connectToAuthService(types.RoleInstance)
+		require.Error(t, err)
+		var tooOld *joinclient.ClientTooOldError
+		require.NotErrorAs(t, err, &tooOld)
+		require.Nil(t, c)
+	})
+
+	t.Run("client too new stops reconnect retries", func(t *testing.T) {
+		cfg := newConfig(t, teleport.MinClientSemVer().String(), tooNewServerVersion)
+
+		process, err := NewTeleport(cfg)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = process.Close() })
+
+		c, err := process.reconnectToAuthService(types.RoleInstance)
+		var tooNew *joinclient.ClientTooNewError
+		require.ErrorAs(t, err, &tooNew)
+		require.Nil(t, c)
+	})
+
+	t.Run("client too new with skip version check bypasses the failure", func(t *testing.T) {
+		cfg := newConfig(t, teleport.MinClientSemVer().String(), tooNewServerVersion)
+		cfg.SkipVersionCheck = true
+
+		process, err := NewTeleport(cfg)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = process.Close() })
+
+		// Deliberately call connectToAuthService, not reconnectToAuthService.
+		// With the check skipped the join fails against the stub with an
+		// ordinary connection error, which reconnectToAuthService treats as
+		// retryable and would loop on forever. Failing with anything other
+		// than ClientTooNewError proves SkipVersionCheck was plumbed through
+		// and bypassed the check.
+		c, err := process.connectToAuthService(types.RoleInstance)
+		require.Error(t, err)
+		var tooNew *joinclient.ClientTooNewError
+		require.NotErrorAs(t, err, &tooNew)
+		require.Nil(t, c)
+	})
+}
 
 func TestMakeJoinParams_BoundKeypair(t *testing.T) {
 	t.Parallel()

--- a/lib/service/versioncompat.go
+++ b/lib/service/versioncompat.go
@@ -1,0 +1,130 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/join/joinclient"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// clientTooOldError indicates this client is older than the cluster's minimum
+// client version.
+type clientTooOldError struct {
+	ClientVersion string
+	MinVersion    string
+}
+
+func (e *clientTooOldError) Error() string {
+	return fmt.Sprintf("Teleport instance is too old. This instance is running v%s. The server requires a minimum version of v%s. To connect anyway pass the --skip-version-check flag.", e.ClientVersion, e.MinVersion)
+}
+
+// clientTooNewError indicates this client is a newer major version than the cluster.
+type clientTooNewError struct {
+	LocalMajorVersion   int64
+	ClusterMajorVersion int64
+}
+
+func (e *clientTooNewError) Error() string {
+	return fmt.Sprintf("Teleport instance is too new. This instance is running v%d. The server is running v%d and only supports instances on v%d or v%d. To connect anyway pass the --skip-version-check flag.", e.LocalMajorVersion, e.ClusterMajorVersion, e.ClusterMajorVersion, e.ClusterMajorVersion-1)
+}
+
+// isVersionIncompatible reports whether err indicates this client's version is
+// incompatible with the cluster, either a [clientTooOldError] or [clientTooNewError].
+func isVersionIncompatible(err error) bool {
+	var tooOld *clientTooOldError
+	var tooNew *clientTooNewError
+	return errors.As(err, &tooOld) || errors.As(err, &tooNew)
+}
+
+// enforceVersionPolicy implements this agent's policy for an incompatible cluster
+// version. Any version incompatibility is fatal unless the --skip-version-check
+// flag is provided. Parse errors fail open so malformed version information
+// advertised by the cluster can't block joining.
+func (process *TeleportProcess) enforceVersionPolicy(ctx context.Context, info joinclient.VersionInfo) error {
+	for _, err := range []error{
+		checkClientMeetsMinVersion(teleport.Version, info.MinClientVersion),
+		checkClientMeetsMaxVersion(teleport.Version, info.ServerVersion),
+	} {
+		if err == nil {
+			continue
+		}
+		if !isVersionIncompatible(err) {
+			process.logger.WarnContext(ctx,
+				"Could not determine version compatibility with the cluster, skipping check.",
+				"error", err,
+				"min_client_version", info.MinClientVersion,
+				"server_version", info.ServerVersion,
+				"instance_version", teleport.Version,
+			)
+			continue
+		}
+		if process.Config.SkipVersionCheck {
+			process.logger.WarnContext(ctx,
+				"Instance version is incompatible with the cluster, continuing anyway because --skip-version-check flag was provided.",
+				"error", err,
+				"min_client_version", info.MinClientVersion,
+				"server_version", info.ServerVersion,
+				"instance_version", teleport.Version,
+			)
+			continue
+		}
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func checkClientMeetsMinVersion(clientVersion, minVersion string) error {
+	if minVersion == "" {
+		return nil
+	}
+	// Stripping the pre-release both validates the advertised minimum and yields a
+	// clean version for the user-facing error message.
+	minWithoutPreRelease, err := utils.VersionWithoutPreRelease(minVersion)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if !utils.MeetsMinVersion(clientVersion, minVersion) {
+		return &clientTooOldError{ClientVersion: clientVersion, MinVersion: minWithoutPreRelease}
+	}
+	return nil
+}
+
+func checkClientMeetsMaxVersion(clientVersion, serverVersion string) error {
+	if serverVersion == "" {
+		return nil
+	}
+	client, err := semver.NewVersion(clientVersion)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	server, err := semver.NewVersion(serverVersion)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if server.Major < client.Major {
+		return &clientTooNewError{LocalMajorVersion: client.Major, ClusterMajorVersion: server.Major}
+	}
+	return nil
+}

--- a/lib/service/versioncompat_test.go
+++ b/lib/service/versioncompat_test.go
@@ -1,0 +1,243 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"testing"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/join/joinclient"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+func requireClientTooOld(t require.TestingT, err error, _ ...any) {
+	var target *clientTooOldError
+	require.ErrorAs(t, err, &target)
+}
+
+func requireClientTooNew(t require.TestingT, err error, _ ...any) {
+	var target *clientTooNewError
+	require.ErrorAs(t, err, &target)
+}
+
+func TestCheckClientMeetsMinVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		clientVersion string
+		minVersion    string
+		assertErr     require.ErrorAssertionFunc
+	}{
+		{
+			name:          "client too old",
+			clientVersion: "1.0.0",
+			minVersion:    "2.0.0",
+			assertErr:     requireClientTooOld,
+		},
+		{
+			// The pre-release suffix is stripped from the minimum reported in
+			// the error so the user-facing message shows a clean version.
+			name:          "client too old with pre-release minimum",
+			clientVersion: "1.0.0",
+			minVersion:    "2.0.0-aa",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				requireClientTooOld(t, err)
+				require.Contains(t, err.Error(), "minimum version of v2.0.0.")
+			},
+		},
+		{
+			name:          "pre-release client too old for release minimum",
+			clientVersion: "2.0.0-dev",
+			minVersion:    "2.0.0",
+			assertErr:     requireClientTooOld,
+		},
+		{
+			// The proxy advertises "<major>.0.0-aa" so that pre-release builds
+			// of the minimum version are permitted. This case fails if the
+			// comparison ever switches to the stripped minimum (2.0.0-dev is
+			// below 2.0.0 but above 2.0.0-aa).
+			name:          "pre-release client meets pre-release minimum",
+			clientVersion: "2.0.0-dev",
+			minVersion:    "2.0.0-aa",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "client meets minimum",
+			clientVersion: "2.0.0",
+			minVersion:    "1.0.0",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "client exactly meets minimum",
+			clientVersion: "1.0.0",
+			minVersion:    "1.0.0",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "no minimum advertised",
+			clientVersion: "1.0.0",
+			minVersion:    "",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "malformed minimum returns parse error",
+			clientVersion: "1.0.0",
+			minVersion:    "not-a-version",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				var target *clientTooOldError
+				require.NotErrorAs(t, err, &target)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.assertErr(t, checkClientMeetsMinVersion(tc.clientVersion, tc.minVersion))
+		})
+	}
+}
+
+func TestCheckClientMeetsMaxVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		clientVersion string
+		serverVersion string
+		assertErr     require.ErrorAssertionFunc
+	}{
+		{
+			name:          "client is newer than server",
+			clientVersion: "3.0.0",
+			serverVersion: "2.0.0",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				requireClientTooNew(t, err)
+				require.Contains(t, err.Error(), "supports instances on v2 or v1")
+			},
+		},
+		{
+			name:          "client is older than server",
+			clientVersion: "1.0.0",
+			serverVersion: "2.0.0",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "client and server are the same version",
+			clientVersion: "1.0.0",
+			serverVersion: "1.0.0",
+			assertErr:     require.NoError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.assertErr(t, checkClientMeetsMaxVersion(tc.clientVersion, tc.serverVersion))
+		})
+	}
+}
+
+func TestEnforceVersionPolicy(t *testing.T) {
+	t.Parallel()
+
+	// The skew is induced from the server side: advertise requirements the
+	// running build can't satisfy, so the check trips against the real
+	// teleport.Version without overriding the local version.
+	tooOldMinVersion := semver.Version{Major: teleport.SemVer().Major + 1}.String()
+	tooNewServerVersion := semver.Version{Major: teleport.SemVer().Major - 1}.String()
+
+	cases := []struct {
+		name             string
+		minClientVersion string
+		serverVersion    string
+		skipVersionCheck bool
+		assertErr        require.ErrorAssertionFunc
+	}{
+		{
+			name:             "compatible",
+			minClientVersion: teleport.MinClientSemVer().String(),
+			serverVersion:    teleport.Version,
+			assertErr:        require.NoError,
+		},
+		{
+			name:             "client too old",
+			minClientVersion: tooOldMinVersion,
+			assertErr:        requireClientTooOld,
+		},
+		{
+			name:          "client too new",
+			serverVersion: tooNewServerVersion,
+			assertErr:     requireClientTooNew,
+		},
+		{
+			name:             "client too old but skip version check",
+			minClientVersion: tooOldMinVersion,
+			skipVersionCheck: true,
+			assertErr:        require.NoError,
+		},
+		{
+			name:             "client too new but skip version check",
+			serverVersion:    tooNewServerVersion,
+			skipVersionCheck: true,
+			assertErr:        require.NoError,
+		},
+		{
+			// The min parse error must fail open without short-circuiting the
+			// loop before the independent server check produces its verdict.
+			name:             "malformed minimum does not mask client too new",
+			minClientVersion: "not-a-version",
+			serverVersion:    tooNewServerVersion,
+			assertErr:        requireClientTooNew,
+		},
+		{
+			// The bad server version fails open and must not suppress the
+			// client-too-old verdict from the min check.
+			name:             "client too old with malformed server version",
+			minClientVersion: tooOldMinVersion,
+			serverVersion:    "not-a-version",
+			assertErr:        requireClientTooOld,
+		},
+		{
+			name:             "both versions malformed fail open",
+			minClientVersion: "not-a-version",
+			serverVersion:    "not-a-version",
+			assertErr:        require.NoError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			process := &TeleportProcess{
+				Config: &servicecfg.Config{SkipVersionCheck: tc.skipVersionCheck},
+				logger: logtest.NewLogger(),
+			}
+			err := process.enforceVersionPolicy(t.Context(), joinclient.VersionInfo{
+				MinClientVersion: tc.minClientVersion,
+				ServerVersion:    tc.serverVersion,
+			})
+			tc.assertErr(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Backport #67627 + #68134 to branch/v18

Both of the aforementioned PRs are being backported together since #68134 includes a fix for inadvertently applying client-side version checks to `tbot` in #67627.

Changelog: Teleport instances now fail fast with a clear and actionable error when joining a cluster with an incompatible version.

Part of #64567

## Manual Test Plan
### Test Environment

The client-side version verification requires an auth + proxy that is a high enough version to render the built `tbot` + Teleport agent "too old". The below tests were run with two builds based on [the current branch](https://github.com/gravitational/teleport/tree/wethreetrees/backport-67627-branch/v18). One with no changes (`v18.9.2`) and the other with the version manually set to `v21.0.0`.

- Cluster running `v21.0.0` (for the too-old/meets-minimum/fail-open cases)
  - `auth_service` and `proxy_service` enabled
  - `TELEPORT_UNSTABLE_ALLOW_OLD_CLIENTS=yes`
- Cluster running `v18.9.2` (for the too-new/tbot cases - clients use the v21 build)
  - same service + env config as above

### Test Cases
- [x] Node using older version refuses to join cluster with a clear "too old" error and stops retrying
- [x] The same too-old node joins successfully when `--skip-version-check` is set and logs a warning
- [x] Node that meets the minimum joins normally
- [x] Node refuses to join cluster with lower major version than itself
- [x] Join proceeds (fails open) when performing a direct-to-auth join from node with older version

### Test Cases (tbot)
- [x] tbot using the older version joins successfully with no client-side "too old" error
- [x] tbot using the too-new version joins successfully
- [x] tbot on current version joins successfully