### PR TITLE
[v18] Remove references to `roles` config in `tbot` from documentation

### DIFF
--- a/docs/pages/includes/machine-id/common-output-config.yaml
+++ b/docs/pages/includes/machine-id/common-output-config.yaml
@@ -8,13 +8,6 @@
 destination:
   type: directory
   path: /opt/machine-id
-# roles specifies the roles that should be included in the certificates generated
-# by the output. These roles must be roles that the bot has been granted
-# permission to impersonate.
-#
-# if no roles are specified, all roles the bot is allowed to impersonate are used.
-roles:
-  - editor
 
 # credential_ttl and renewal_interval override the credential TTL and renewal
 # interval for this specific output, so that you can make its certificates valid

--- a/docs/pages/machine-workload-identity/troubleshooting.mdx
+++ b/docs/pages/machine-workload-identity/troubleshooting.mdx
@@ -295,16 +295,6 @@ Edit the role, then save and close the file to apply your changes.
 
 (!docs/pages/includes/create-role-using-web.mdx!)
 
-<Admonition type="note">
-By default, output services (like `/opt/machine-id`) are granted all roles provided
-to the bot via `tctl bots add --roles=...`, but it's possible to grant only a
-subset of these roles using the `roles: ...` parameter in `tbot.yaml`.
-
-If permissions are unexpectedly missing, ensure `tbot.yaml` requests your
-database role, either by relying on default behavior or adding the role to the
-`roles: ...` list.
-</Admonition>
-
 Once fixed, restart or reload the `tbot` clients for the updated role to take
 effect.
 

--- a/docs/pages/reference/machine-workload-identity/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/configuration.mdx
@@ -209,8 +209,8 @@ services:
 ## Output Services
 
 Output services define what actions `tbot` should take when it runs. They
-describe the format of the certificates to be generated, the roles used to
-generate the certificates, and the destination where they should be written.
+describe the format of the certificates to be generated and the destination
+where they should be written.
 
 There are multiple types of output. Select the one that is most appropriate for
 your intended use-case.
@@ -405,7 +405,6 @@ selectors:
       env: dev
 
 # The following configuration fields are available across most output types.
-# Note that `roles` are not supported for this output type.
 
 destination:
   type: directory
@@ -583,7 +582,7 @@ cluster_resources: true
 cluster_name_template: "{{.KubeName}}"
 
 # The following configuration fields are available across most output types.
-# Note that `roles` and `destination` are not supported for this output type.
+# Note that `destination` is not supported for this output type.
 
 # credential_ttl and renewal_interval override the credential TTL and renewal
 # interval for this specific output, so that you can make its certificates valid


### PR DESCRIPTION
Backport #68347 to branch/v18