### PR TITLE
[v18] Backport generic scope-aware service (#67732, #67682, #68042, #68096)

### DIFF
--- a/lib/scopes/cursor.go
+++ b/lib/scopes/cursor.go
@@ -1,0 +1,110 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package scopes
+
+import (
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// ResourceCursorPrefix prefixes cursors for scoped resources in a
+// logical resource stream.
+//
+// The prefix starts with '~', which is not allowed in backend-safe resource
+// names and sorts after all backend-safe name bytes, preserving historical
+// name-only cursors for unscoped resources while ordering scoped resources
+// after unscoped resources.
+const ResourceCursorPrefix = "~scoped/"
+
+// ResourceCursorScopedStart returns the first cursor in the scoped portion of
+// the logical resource stream.
+func ResourceCursorScopedStart() string {
+	return ResourceCursorPrefix
+}
+
+// IsScopedResourceCursor returns true if cursor is in the scoped portion of the
+// logical resource stream.
+func IsScopedResourceCursor(cursor string) bool {
+	return strings.HasPrefix(cursor, ResourceCursorPrefix)
+}
+
+// MakeResourceCursor returns the cursor for a scoped or unscoped resource in a
+// logical, lexicographically ordered resource stream.
+//
+// Resource cursors are intended for pagination tokens, range bounds, and
+// in-memory cache indexes. They are not backend storage keys and must not be
+// used to construct backend keys.
+//
+// Unscoped resource cursors preserve the historical name-only format:
+//
+//	<name>
+//
+// Scoped resource cursors use a synthetic prefix that cannot appear in
+// backend-safe resource names and sorts after all backend-safe name bytes:
+//
+//	~scoped/<encoded-scope>/<name>
+//
+// The scope component is encoded with EncodeForKey so that scoped cursors
+// preserve scope ordering and can safely use '/' as the cursor separator.
+func MakeResourceCursor(scope, name string) (string, error) {
+	if scope == "" {
+		return name, nil
+	}
+
+	encodedScope, err := EncodeForKey(scope)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return ResourceCursorPrefix + encodedScope + separator + name, nil
+}
+
+// ParseResourceCursor parses a resource cursor produced by [MakeResourceCursor]
+// into its scope and name components.
+//
+// Unscoped cursors are interpreted as historical name-only cursors. Scoped
+// cursors must use the scoped cursor format:
+//
+//	~scoped/<encoded-scope>/<name>
+func ParseResourceCursor(cursor string) (QualifiedName, error) {
+	encodedScopeAndName, ok := strings.CutPrefix(cursor, ResourceCursorPrefix)
+	if !ok {
+		return QualifiedName{Name: cursor}, nil
+	}
+
+	encodedScope, name, ok := strings.Cut(encodedScopeAndName, separator)
+	if !ok {
+		return QualifiedName{}, trace.BadParameter("scoped resource cursor %q missing name separator", cursor)
+	}
+	if encodedScope == "" {
+		return QualifiedName{}, trace.BadParameter("scoped resource cursor %q has empty encoded scope", cursor)
+	}
+	if name == "" {
+		return QualifiedName{}, trace.BadParameter("scoped resource cursor %q has empty name", cursor)
+	}
+	if strings.Contains(name, separator) {
+		return QualifiedName{}, trace.BadParameter("scoped resource cursor %q has invalid name", cursor)
+	}
+
+	scope, err := DecodeFromKey(encodedScope)
+	if err != nil {
+		return QualifiedName{}, trace.Wrap(err)
+	}
+
+	return QualifiedName{Scope: scope, Name: name}, nil
+}

--- a/lib/scopes/cursor_test.go
+++ b/lib/scopes/cursor_test.go
@@ -1,0 +1,113 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package scopes
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceCursor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unscoped", func(t *testing.T) {
+		cursor, err := MakeResourceCursor("", "name")
+		require.NoError(t, err)
+		require.Equal(t, "name", cursor)
+		require.False(t, IsScopedResourceCursor(cursor))
+
+		parsed, err := ParseResourceCursor(cursor)
+		require.NoError(t, err)
+		require.Equal(t, QualifiedName{Name: "name"}, parsed)
+	})
+
+	t.Run("scoped", func(t *testing.T) {
+		cursor, err := MakeResourceCursor("/aa/bb", "name")
+		require.NoError(t, err)
+		require.True(t, IsScopedResourceCursor(cursor))
+		require.Contains(t, cursor, ResourceCursorPrefix)
+
+		parsed, err := ParseResourceCursor(cursor)
+		require.NoError(t, err)
+		require.Equal(t, QualifiedName{Scope: "/aa/bb", Name: "name"}, parsed)
+	})
+
+	t.Run("scoped start", func(t *testing.T) {
+		require.Equal(t, ResourceCursorPrefix, ResourceCursorScopedStart())
+		require.True(t, IsScopedResourceCursor(ResourceCursorScopedStart()))
+	})
+}
+
+func TestParseResourceCursorErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, cursor := range []string{
+		ResourceCursorPrefix,
+		ResourceCursorPrefix + "/name",
+		ResourceCursorPrefix + "++/",
+		ResourceCursorPrefix + "++/nested/name",
+		ResourceCursorPrefix + "invalid/name",
+	} {
+		t.Run(cursor, func(t *testing.T) {
+			_, err := ParseResourceCursor(cursor)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestResourceCursorSort(t *testing.T) {
+	t.Parallel()
+
+	resources := []QualifiedName{
+		{Scope: "/bb", Name: "aaa"},
+		{Scope: "", Name: "zzz"},
+		{Scope: "/aa", Name: "bbb"},
+		{Scope: "/aa/bb", Name: "aaa"},
+		{Scope: "", Name: "aaa"},
+		{Scope: "/aa", Name: "aaa"},
+	}
+
+	cursors := make([]string, 0, len(resources))
+	for _, resource := range resources {
+		cursor, err := MakeResourceCursor(resource.Scope, resource.Name)
+		require.NoError(t, err)
+		cursors = append(cursors, cursor)
+	}
+
+	slices.Sort(cursors)
+
+	var got []QualifiedName
+	for _, cursor := range cursors {
+		resource, err := ParseResourceCursor(cursor)
+		require.NoError(t, err)
+		got = append(got, resource)
+	}
+
+	require.Equal(t, []QualifiedName{
+		// Unscoped cursors preserve historical name-only ordering and sort before
+		// all scoped cursors.
+		{Scope: "", Name: "aaa"},
+		{Scope: "", Name: "zzz"},
+		// Scoped cursors sort by encoded scope, then name within the same scope.
+		{Scope: "/aa", Name: "aaa"},
+		{Scope: "/aa", Name: "bbb"},
+		{Scope: "/aa/bb", Name: "aaa"},
+		{Scope: "/bb", Name: "aaa"},
+	}, got)
+}

--- a/lib/scopes/encoding.go
+++ b/lib/scopes/encoding.go
@@ -1,0 +1,122 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package scopes
+
+import (
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+const (
+	// + sorts before all characters that can appear in a scope (see
+	// segmentRegexp), is allowed in backend keys, and is not the backend key
+	// separator.
+	encodedSeparator       = '+'
+	encodedSeparatorString = string(encodedSeparator)
+)
+
+// EncodeForKey encodes a scope so that it will be valid for use in a single
+// backend key segment, preserving sort order. If given an empty string, it
+// will return a non-empty encoding that sorts before all valid encoded
+// scopes.
+//
+// This implementation is a placeholder to unblock development, it is intended
+// to be replaced with a better implementation.
+func EncodeForKey(scope string) (string, error) {
+	// The empty scope is encoded as a single encoded separator.
+	//
+	// All other scopes are encoded with an extra separator at the beginning so
+	// that the root scope sorts after the empty scope.
+	// They also have an extra separator added at the end to support prefix and
+	// exact matches.
+	if scope == "" {
+		return encodedSeparatorString, nil
+	}
+
+	if err := WeakValidate(scope); err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	// Enforce that the scope does not contain any byte that would sort before
+	// or equal to the encoded separator, which would break sorting.
+	// StrongValidate would prevent this, WeakValidate may not.
+	for _, b := range []byte(scope) {
+		if b <= encodedSeparator {
+			return "", trace.BadParameter("scope contains invalid byte %d which would break sorting", b)
+		}
+	}
+
+	// Enforce that the scope does not contain empty segments, which can also
+	// break sorting of composed keys. For example / and /// could encode to:
+	//
+	//   +++/resource
+	//   +++++/resource
+	//
+	// and the sort order would invert depending on whether the /resource
+	// suffix was present.
+	//
+	// Also enforce that each segment does not start with a byte that would
+	// sort before the backend separator, which could break sorting of composed
+	// keys. For example /a and /a/.b could encode to:
+	//
+	//   ++a+/resource
+	//   ++a+.b+/resource
+	//
+	// and the sort order would be inverted because '.' sorts before '/'
+	// This is only an issue at the first byte of a segment.
+	for segment := range DescendingSegments(scope) {
+		if len(segment) == 0 {
+			return "", trace.BadParameter("scope contains empty segment which would break sorting")
+		}
+		if segment[0] < '/' {
+			return "", trace.BadParameter("scope segment starts with invalid byte %d which would break sorting", segment[0])
+		}
+	}
+
+	// NormalizeForEquality will trim a trailing separator, which may be
+	// necessary for prefix/exact match queries on encoded scopes.
+	encoded := NormalizeForEquality(scope)
+	encoded = strings.ReplaceAll(encoded, separator, encodedSeparatorString)
+
+	encoded = encodedSeparatorString + encoded + encodedSeparatorString
+	return encoded, nil
+}
+
+// DecodeFromKey decodes a scope encoded by EncodeForKey.
+func DecodeFromKey(encodedScope string) (string, error) {
+	if encodedScope == encodedSeparatorString {
+		return "", nil
+	}
+
+	decoded, ok := strings.CutPrefix(encodedScope, encodedSeparatorString)
+	if !ok {
+		return "", trace.BadParameter("encoded scope did not begin with separator")
+	}
+	decoded, ok = strings.CutSuffix(decoded, encodedSeparatorString)
+	if !ok {
+		return "", trace.BadParameter("encoded scope did not end with separator")
+	}
+
+	decoded = strings.ReplaceAll(decoded, encodedSeparatorString, separator)
+
+	if err := WeakValidate(decoded); err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return decoded, nil
+}

--- a/lib/scopes/encoding_test.go
+++ b/lib/scopes/encoding_test.go
@@ -1,0 +1,211 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package scopes
+
+import (
+	"math/rand/v2"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/backend"
+)
+
+// TestEncodeDecode tests that encoded scopes are valid backend keys and than
+// an encode-decode round-trip preserves with scope.
+func TestEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	testCases := []string{
+		"",
+		"/",
+		"/example/basic",
+		"/ops/west/vancouver",
+		"/some/really/long/scope/with/many/segments",
+		"/a/b/c",
+		"/a/b/",
+		"/a",
+	}
+
+	seenEncodings := make(map[string]struct{}, len(testCases))
+
+	for _, tc := range testCases {
+		t.Run(tc, func(t *testing.T) {
+			encoded, err := EncodeForKey(tc)
+			require.NoError(t, err)
+
+			require.NotEmpty(t, encoded)
+
+			require.NotContains(t, seenEncodings, encoded)
+			seenEncodings[encoded] = struct{}{}
+
+			require.True(t, backend.IsKeySafe(backend.NewKey(encoded)))
+
+			decoded, err := DecodeFromKey(encoded)
+			require.NoError(t, err)
+
+			require.Equal(t, NormalizeForEquality(tc), decoded)
+		})
+	}
+}
+
+// TestEncodeForKeyErrors asserts that EncodeForKeys returns an error in expected cases.
+func TestEncodeForKeyErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []string{
+		"//",
+		"/aa//",
+		"/.a",
+		"/aa/.b",
+		"/aa/.b",
+		string([]byte{0, 1, 2, 3}),
+	} {
+		_, err := EncodeForKey(tc)
+		require.Error(t, err, "expected an error encoding %s", tc)
+	}
+}
+
+// TestEncodedSort asserts that a basic string sort over encoded scopes
+// produces the same ordering as sorting real scopes with [Sort].
+func TestEncodedSort(t *testing.T) {
+	t.Parallel()
+
+	const numScopes = 1000
+	var generatedScopes [numScopes]string
+	for i := range numScopes {
+		generatedScopes[i] = generateScope()
+	}
+
+	unencoded := generatedScopes[:]
+	encoded, err := encodeScopes(unencoded)
+	require.NoError(t, err)
+
+	slices.SortFunc(unencoded, Sort)
+	slices.Sort(encoded)
+
+	decoded, err := decodeScopes(encoded)
+	require.NoError(t, err)
+
+	require.Equal(t, unencoded, decoded)
+
+	// Encoded scopes are not only compared as standalone values. They are also
+	// commonly used as a key component before a resource name, e.g.
+	//
+	//	<encoded-scope>/<resource-name>
+	//
+	// Verify that adding this suffix doesn't change the relative ordering of the
+	// encoded scopes.
+	composed := make([]string, 0, len(encoded))
+	for _, encodedScope := range encoded {
+		composed = append(composed, encodedScope+backend.SeparatorString+"resource")
+	}
+	slices.Sort(composed)
+	for i, key := range composed {
+		// Split the composed key back into the encoded scope component so we can
+		// compare the resulting scope order with the canonical scope sort order.
+		encodedScope, _, ok := strings.Cut(key, backend.SeparatorString)
+		require.True(t, ok)
+		decodedScope, err := DecodeFromKey(encodedScope)
+		require.NoError(t, err)
+		require.Equal(t, NormalizeForEquality(unencoded[i]), decodedScope)
+	}
+
+	// [Sort] does not support empty scopes, so generatedScope does not
+	// generate any empty scopes. Manually test that empty encoded scopes sort
+	// to the beginning.
+	const numEmptyScopes = 10
+	encodedEmptyScope, err := EncodeForKey("")
+	require.NoError(t, err)
+	// Add some encoded empty scopes at the end.
+	for range numEmptyScopes {
+		encoded = append(encoded, encodedEmptyScope)
+	}
+	// Make sure they sort to the beginning.
+	slices.Sort(encoded)
+	for i := range numEmptyScopes {
+		require.Equal(t, encodedEmptyScope, encoded[i])
+	}
+}
+
+func generateScope() string {
+	targetLen := 1 + rand.IntN(maxScopeSize)
+	var scope strings.Builder
+	for scope.Len() <= targetLen-2 {
+		scope.WriteString(separator)
+		segmentLen := 1 + rand.IntN(targetLen-scope.Len())
+		scope.WriteString(generateSegment(segmentLen))
+	}
+	if scope.Len() == 0 {
+		return Root
+	}
+	return scope.String()
+}
+
+// generateSegment generates a scope segment considered valid by EncodeForKey,
+// meaning it must be weakly valid and start with a byte that sorts after '/'.
+func generateSegment(segmentLen int) string {
+	const (
+		minStartingByte = '/' + 1
+		minByte         = encodedSeparator + 1
+		maxByte         = 126
+	)
+	b := make([]byte, segmentLen)
+	for i := range segmentLen {
+		if i == 0 {
+			b[i] = randomValidByteInRange(minStartingByte, maxByte)
+		} else {
+			b[i] = randomValidByteInRange(minByte, maxByte)
+		}
+	}
+	return string(b)
+}
+
+func randomValidByteInRange(min, max int) byte {
+	for {
+		candidate := byte(min + rand.IntN(max-min+1))
+		if !strings.ContainsRune(breakingChars, rune(candidate)) {
+			return candidate
+		}
+	}
+}
+
+func encodeScopes(scopes []string) ([]string, error) {
+	encoded := make([]string, len(scopes))
+	for i, scope := range scopes {
+		var err error
+		encoded[i], err = EncodeForKey(scope)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return encoded, nil
+}
+
+func decodeScopes(encodedScopes []string) ([]string, error) {
+	scopes := make([]string, len(encodedScopes))
+	for i, encodedScope := range encodedScopes {
+		var err error
+		scopes[i], err = DecodeFromKey(encodedScope)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return scopes, nil
+}

--- a/lib/scopes/qualified.go
+++ b/lib/scopes/qualified.go
@@ -25,7 +25,7 @@ import (
 )
 
 // QualifiedNameSeparator is the separator between scope and name in a
-// scope-qualified name. This separator must never appear in scope segements.
+// scope-qualified name. This separator must never appear in scope segments.
 const QualifiedNameSeparator = "::"
 
 // QualifiedName pairs a scope with a resource name to uniquely identify a scoped
@@ -35,6 +35,10 @@ const QualifiedNameSeparator = "::"
 // is necessary to fully specify the unique identifier of a scoped resource. Internally,
 // teleport APIs should generally continue to use separate scope and name fields, as
 // should structured logs/events.
+//
+// A QualifiedName may be used in APIs that need to refer to a resource that
+// may be scoped or unscoped. In these cases the Scope field may be empty, and
+// WeakValidate and StrongValidate will return an error.
 type QualifiedName struct {
 	// Scope is the resource's scope path, e.g. "/staging/west".
 	Scope string
@@ -42,8 +46,12 @@ type QualifiedName struct {
 	Name string
 }
 
-// String returns encodes the string representation of the QualifiedName.
+// String returns the string representation of the QualifiedName.
+// If the Scope is empty, the Name is returned verbatim.
 func (q QualifiedName) String() string {
+	if q.Scope == "" {
+		return q.Name
+	}
 	return q.Scope + QualifiedNameSeparator + q.Name
 }
 

--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -252,17 +252,19 @@ func (s *Service[T]) Resources(ctx context.Context, startKey, endKey string) ite
 		return resource, true
 	}
 
-	return stream.TakeWhile(
-		stream.FilterMap(s.backend.Items(ctx, params), mapFn),
-		func(r T) bool {
-			// We promise the consumers of this function that the returned
-			// results an exclusive of the endkey but the underlying Items
-			// method returns us a stream that's inclusive of the end key - so
-			// if the user has provided us an end-key, we manually filter them
-			// out to convert from inclusive to exclusive.
-			return endKey == "" || r.GetName() < endKey
-		},
-	)
+	items := s.backend.Items(ctx, params)
+	if endKey != "" {
+		exclusiveEndKey := s.backendPrefix.AppendKey(backend.KeyFromString(endKey))
+		items = stream.TakeWhile(items, func(item backend.Item) bool {
+			// We promise consumers that the returned results are exclusive of
+			// endKey, but the underlying Items method returns an inclusive end
+			// key. Compare the full backend key so composite relative keys such
+			// as "<prefix>/<name>" are handled correctly.
+			return item.Key.Compare(exclusiveEndKey) < 0
+		})
+	}
+
+	return stream.FilterMap(items, mapFn)
 }
 
 // ListResources returns a paginated list of resources.

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -45,7 +45,12 @@ import (
 // testResource for testing the generic service.
 type testResource struct {
 	types.ResourceHeader
-	Spec testResourceSpec
+	Spec  testResourceSpec
+	Scope string
+}
+
+func (r *testResource) GetScope() string {
+	return r.Scope
 }
 
 func newTestResource(name string) *testResource {

--- a/lib/services/local/generic/resource_adapter.go
+++ b/lib/services/local/generic/resource_adapter.go
@@ -47,3 +47,20 @@ func (w resourceMetadataAdapter[T]) GetMetadata() *headerv1.Metadata {
 func (w resourceMetadataAdapter[T]) GetName() string {
 	return w.resource.GetMetadata().GetName()
 }
+
+// scopedResourceMetadataAdapter extends resourceMetadataAdapter for RFD 153-style
+// resources that additionally carry a scope. For inner types T which implement
+// ScopedResourceMetadata, the adapter implements ScopedResource, making the
+// resource usable with ScopeAwareService.
+type scopedResourceMetadataAdapter[T ScopedResourceMetadata] struct {
+	resourceMetadataAdapter[T]
+}
+
+func newScopedResourceMetadataAdapter[T ScopedResourceMetadata](t T) scopedResourceMetadataAdapter[T] {
+	return scopedResourceMetadataAdapter[T]{newResourceMetadataAdapter(t)}
+}
+
+// GetScope returns the scope of the inner resource. Required for ScopedResource.
+func (w scopedResourceMetadataAdapter[T]) GetScope() string {
+	return w.resource.GetScope()
+}

--- a/lib/services/local/generic/scopeaware.go
+++ b/lib/services/local/generic/scopeaware.go
@@ -1,0 +1,324 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package generic
+
+import (
+	"context"
+	"iter"
+	"strings"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
+)
+
+// ScopedResource is a resource type that has a scope. The scope may be empty
+// on any individual resource of the type, that resource may be referred to as
+// "unscoped" despite the type being scoped.
+type ScopedResource interface {
+	Resource
+	// GetScope returns the scope of the resource.
+	GetScope() string
+}
+
+// ScopeAwareService is a generic service for interacting with namespaced
+// scoped resources in the backend. Scoped resources will be stored in a
+// separate key range from resources with an empty scope, and namespaced by
+// their scope. The ScopeAwareService transparently handles listing all scoped
+// and unscoped resources, as well as creating and querying individual resources
+// from the correct key range.
+type ScopeAwareService[T ScopedResource] struct {
+	// UnscopedService is the underlying service for resources with an empty scope.
+	// Resources will be keyed at <backend_prefix>/<name>
+	UnscopedService *Service[T]
+	// ScopedService is the underlying service for resources with a scope.
+	// Resources will be keyed at <scoped_prefix>/<backend_prefix>/<encoded_scope>/<name>
+	ScopedService *Service[T]
+}
+
+// ScopeAwareServiceConfig holds configuration options for ScopeAwareService.
+type ScopeAwareServiceConfig[T ScopedResource] struct {
+	// Backend used to persist the resource.
+	Backend backend.Backend
+	// ResourceKind is the friendly name of the resource.
+	ResourceKind string
+	// UnscopedBackendPrefix used when constructing the [backend.Item.Key] for unscoped resources.
+	UnscopedBackendPrefix backend.Key
+	// ScopedBackendPrefix used when constructing the [backend.Item.Key] for scoped resources.
+	ScopedBackendPrefix backend.Key
+	// PageLimit
+	PageLimit uint
+	// MarshlFunc converts the resource to bytes for persistence.
+	MarshalFunc MarshalFunc[T]
+	// UnmarshalFunc converts the bytes read from the backend to the resource.
+	UnmarshalFunc UnmarshalFunc[T]
+	// ValidateFunc optionally validates the resource prior to persisting it. Any errors
+	// returned from the validation function will prevent writes to the backend.
+	ValidateFunc func(T) error
+	// RunWhileLockedRetryInterval is the interval to retry the RunWhileLocked function.
+	// If set to 0, the default interval of 250ms will be used.
+	// WARNING: If set to a negative value, the RunWhileLocked function will retry immediately.
+	RunWhileLockedRetryInterval time.Duration
+}
+
+// NewScopeAwareService returns a new scope-aware service.
+func NewScopeAwareService[T ScopedResource](cfg *ScopeAwareServiceConfig[T]) (*ScopeAwareService[T], error) {
+	unscopedService, err := NewService(&ServiceConfig[T]{
+		Backend:                     cfg.Backend,
+		ResourceKind:                cfg.ResourceKind,
+		PageLimit:                   cfg.PageLimit,
+		BackendPrefix:               cfg.UnscopedBackendPrefix,
+		MarshalFunc:                 cfg.MarshalFunc,
+		UnmarshalFunc:               cfg.UnmarshalFunc,
+		ValidateFunc:                cfg.ValidateFunc,
+		RunWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	scopedService, err := NewService(&ServiceConfig[T]{
+		Backend:                     cfg.Backend,
+		ResourceKind:                cfg.ResourceKind,
+		PageLimit:                   cfg.PageLimit,
+		BackendPrefix:               cfg.ScopedBackendPrefix,
+		MarshalFunc:                 cfg.MarshalFunc,
+		UnmarshalFunc:               cfg.UnmarshalFunc,
+		ValidateFunc:                cfg.ValidateFunc,
+		RunWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &ScopeAwareService[T]{
+		UnscopedService: unscopedService,
+		ScopedService:   scopedService,
+	}, nil
+}
+
+// Resources returns a stream of resources within the unified scope-aware range
+// [startKey, endKey). Unscoped resources are ordered before scoped resources.
+//
+// The startKey and endKey values are resource cursors as defined by
+// [scopes.MakeResourceCursor]. An unscoped cursor is the resource name. A scoped
+// cursor uses [scopes.ResourceCursorPrefix] followed by the scoped backend
+// service's relative key. [scopes.ResourceCursorScopedStart] is the boundary
+// between unscoped and scoped resources.
+func (s *ScopeAwareService[T]) Resources(ctx context.Context, startKey, endKey string) iter.Seq2[T, error] {
+	var streams []stream.Stream[T]
+
+	if !scopes.IsScopedResourceCursor(startKey) {
+		unscopedEndKey := endKey
+		if scopes.IsScopedResourceCursor(endKey) {
+			unscopedEndKey = ""
+		}
+		streams = append(streams, s.UnscopedService.Resources(ctx, startKey, unscopedEndKey))
+	}
+
+	if endKey != "" && !scopes.IsScopedResourceCursor(endKey) {
+		return stream.Chain(streams...)
+	}
+	if endKey == scopes.ResourceCursorScopedStart() {
+		return stream.Chain(streams...)
+	}
+
+	scopedStartKey := ""
+	if scopes.IsScopedResourceCursor(startKey) {
+		scopedStartKey = strings.TrimPrefix(startKey, scopes.ResourceCursorPrefix)
+	}
+	scopedEndKey := strings.TrimPrefix(endKey, scopes.ResourceCursorPrefix)
+	streams = append(streams, s.ScopedService.Resources(ctx, scopedStartKey, scopedEndKey))
+
+	return stream.Chain(streams...)
+}
+
+// GetResources returns all unscoped and scoped resources.
+func (s *ScopeAwareService[T]) GetResources(ctx context.Context) ([]T, error) {
+	return stream.Collect(s.Resources(ctx, "", ""))
+}
+
+// ListResources returns a page of resources over the unified scoped
+// and unscoped collection. It always returns all unscoped resources before
+// matching scoped resources.
+func (s *ScopeAwareService[T]) ListResources(ctx context.Context, pageSize int, nextToken string) ([]T, string, error) {
+	return s.ListResourcesWithFilter(ctx, pageSize, nextToken, func(T) bool { return true })
+}
+
+// ListResourcesWithFilter returns a page of matching resources over the
+// unified scoped and unscoped collection. It always returns all matching
+// unscoped resources before matching scoped resources.
+func (s *ScopeAwareService[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, nextToken string, matcher func(T) bool) ([]T, string, error) {
+	if pageSize <= 0 || pageSize > int(s.UnscopedService.pageLimit) {
+		pageSize = int(s.UnscopedService.pageLimit)
+	}
+
+	// Check if the token was scoped, if so the caller has already paged over
+	// all unscoped resources and we should return the next page of scoped
+	// resources.
+	if scopes.IsScopedResourceCursor(nextToken) {
+		nextToken = strings.TrimPrefix(nextToken, scopes.ResourceCursorPrefix)
+		resources, nextToken, err := s.ScopedService.ListResourcesWithFilter(ctx, pageSize, nextToken, matcher)
+		if nextToken != "" {
+			nextToken = scopes.ResourceCursorPrefix + nextToken
+		}
+		return resources, nextToken, trace.Wrap(err)
+	}
+
+	// Fetch the next page of matching unscoped resources.
+	resources, nextToken, err := s.UnscopedService.ListResourcesWithFilter(ctx, pageSize, nextToken, matcher)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	if nextToken != "" {
+		// There are remaining unscoped resources, return this page.
+		return resources, nextToken, nil
+	}
+	if len(resources) >= pageSize {
+		// The page is full but nextToken is empty indicating there are no more
+		// unscoped resources. Return with scopedPageTokenPrefix so the next
+		// page begins with scoped resources.
+		return resources, scopes.ResourceCursorScopedStart(), nil
+	}
+
+	// Reached the end of unscoped resources within pageSize, try to fill in
+	// the page with scoped resources.
+	remainingPageSize := pageSize - len(resources)
+	scopedResources, nextToken, err := s.ScopedService.ListResourcesWithFilter(ctx, remainingPageSize, "", matcher)
+	if nextToken != "" {
+		nextToken = scopes.ResourceCursorPrefix + nextToken
+	}
+	return append(resources, scopedResources...), nextToken, trace.Wrap(err)
+}
+
+// GetResource returns a resource, if it exists, for the given scope-qualified name.
+// If the scope is empty, it returns an unscoped resource from the unscoped key range.
+// If the scope is non-empty, it returns a scoped resource from the scoped key range.
+func (s *ScopeAwareService[T]) GetResource(ctx context.Context, scopedName scopes.QualifiedName) (T, error) {
+	svc, err := s.WithScopePrefix(scopedName.Scope)
+	if err != nil {
+		var nul T
+		return nul, trace.Wrap(err)
+	}
+	return svc.GetResource(ctx, scopedName.Name)
+}
+
+// DeleteResource deletes a resource for the given scope-qualified name.
+// If the scope is empty, it deletes an unscoped resource from the unscoped key range.
+// If the scope is non-empty, it deletes a scoped resource from the scoped key range.
+func (s *ScopeAwareService[T]) DeleteResource(ctx context.Context, scopedName scopes.QualifiedName) error {
+	svc, err := s.WithScopePrefix(scopedName.Scope)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return svc.DeleteResource(ctx, scopedName.Name)
+}
+
+// DeleteAllResources deletes all scoped and unscoped resources.
+func (s *ScopeAwareService[T]) DeleteAllResources(ctx context.Context) error {
+	return trace.NewAggregate(
+		s.UnscopedService.DeleteAllResources(ctx),
+		s.ScopedService.DeleteAllResources(ctx),
+	)
+}
+
+// CreateResource creates the given scoped resource if it doesn't already
+// exist. If the scope is empty, it will be inserted in the unscoped key range,
+// else it will be inserted in the scoped key range.
+func (s *ScopeAwareService[T]) CreateResource(ctx context.Context, resource T) (T, error) {
+	svc, err := s.WithScopePrefix(resource.GetScope())
+	if err != nil {
+		var nul T
+		return nul, trace.Wrap(err)
+	}
+	return svc.CreateResource(ctx, resource)
+}
+
+// UpsertResource upserts the given scoped resource. If the scope is empty, it
+// will be inserted in the unscoped key range, else it will be inserted in the
+// scoped key range.
+func (s *ScopeAwareService[T]) UpsertResource(ctx context.Context, resource T) (T, error) {
+	svc, err := s.WithScopePrefix(resource.GetScope())
+	if err != nil {
+		var nul T
+		return nul, trace.Wrap(err)
+	}
+	return svc.UpsertResource(ctx, resource)
+}
+
+// UpdateResource updates the given scoped resource. If the scope is empty, it
+// will be updated in the unscoped key range, else it will be updated in the
+// scoped key range.
+func (s *ScopeAwareService[T]) UpdateResource(ctx context.Context, resource T) (T, error) {
+	svc, err := s.WithScopePrefix(resource.GetScope())
+	if err != nil {
+		var nul T
+		return nul, trace.Wrap(err)
+	}
+	return svc.UpdateResource(ctx, resource)
+}
+
+// ConditionalUpdateResource updates the given scoped resource if the revision
+// matches. If the scope is empty, it will be updated in the unscoped key
+// range, else it will be updated in the scoped key range.
+func (s *ScopeAwareService[T]) ConditionalUpdateResource(ctx context.Context, resource T) (T, error) {
+	svc, err := s.WithScopePrefix(resource.GetScope())
+	if err != nil {
+		var nul T
+		return nul, trace.Wrap(err)
+	}
+	return svc.ConditionalUpdateResource(ctx, resource)
+}
+
+// WithScopePrefix returns the unscoped service when scope is empty, otherwise
+// returns the scoped service with the encoded scope appended to its backend prefix.
+func (s *ScopeAwareService[T]) WithScopePrefix(scope string) (*Service[T], error) {
+	if scope == "" {
+		return s.UnscopedService, nil
+	}
+	encodedScope, err := scopes.EncodeForKey(scope)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return s.ScopedService.WithPrefix(encodedScope), nil
+}
+
+// WithScopedResourcePrefix returns a [*Service] with a prefix for the given
+// scope-qualified name appended to the backend prefix.
+//
+// If the given scope is empty, it will return the UnscopedService with the
+// given name as an added prefix.
+//
+// If the given scope is non-empty, it will return the ScopedService with the
+// encoded scope and the name as an added prefix.
+//
+// This may be appropriate for dependent resources keyed by a unique scoped
+// resource, i.e. members of a scoped access list.
+func (s *ScopeAwareService[T]) WithScopedResourcePrefix(scopedName scopes.QualifiedName) (*Service[T], error) {
+	if scopedName.Scope == "" {
+		return s.UnscopedService.WithPrefix(scopedName.Name), nil
+	}
+	encodedScope, err := scopes.EncodeForKey(scopedName.Scope)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return s.ScopedService.WithPrefix(encodedScope, scopedName.Name), nil
+}

--- a/lib/services/local/generic/scopeaware.go
+++ b/lib/services/local/generic/scopeaware.go
@@ -43,10 +43,16 @@ type ScopedResource interface {
 // separate key range from resources with an empty scope, and namespaced by
 // their scope. The ScopeAwareService transparently handles listing all scoped
 // and unscoped resources, as well as creating and querying individual resources
-// from the correct key range.
+// from the correct key range. A ScopeAwareService can also be configured to only
+// consume scoped resources. This is useful for situations in which a resource
+// has never had an unscoped variant.
 type ScopeAwareService[T ScopedResource] struct {
+	// scopedOnly indicates that the service will only operate on scoped resources.
+	// The unscoped fallback path will be ignored in all cases.
+	scopedOnly bool
 	// UnscopedService is the underlying service for resources with an empty scope.
-	// Resources will be keyed at <backend_prefix>/<name>
+	// Resources will be keyed at <backend_prefix>/<name>. It will be nil if the
+	// service was configured to be scoped only.
 	UnscopedService *Service[T]
 	// ScopedService is the underlying service for resources with a scope.
 	// Resources will be keyed at <scoped_prefix>/<backend_prefix>/<encoded_scope>/<name>
@@ -55,6 +61,9 @@ type ScopeAwareService[T ScopedResource] struct {
 
 // ScopeAwareServiceConfig holds configuration options for ScopeAwareService.
 type ScopeAwareServiceConfig[T ScopedResource] struct {
+	// ScopedOnly indicates that the service will only operate on scoped resources.
+	// The unscoped fallback path will be ignored in all cases.
+	ScopedOnly bool
 	// Backend used to persist the resource.
 	Backend backend.Backend
 	// ResourceKind is the friendly name of the resource.
@@ -80,11 +89,11 @@ type ScopeAwareServiceConfig[T ScopedResource] struct {
 
 // NewScopeAwareService returns a new scope-aware service.
 func NewScopeAwareService[T ScopedResource](cfg *ScopeAwareServiceConfig[T]) (*ScopeAwareService[T], error) {
-	unscopedService, err := NewService(&ServiceConfig[T]{
+	scopedService, err := NewService(&ServiceConfig[T]{
 		Backend:                     cfg.Backend,
 		ResourceKind:                cfg.ResourceKind,
 		PageLimit:                   cfg.PageLimit,
-		BackendPrefix:               cfg.UnscopedBackendPrefix,
+		BackendPrefix:               cfg.ScopedBackendPrefix,
 		MarshalFunc:                 cfg.MarshalFunc,
 		UnmarshalFunc:               cfg.UnmarshalFunc,
 		ValidateFunc:                cfg.ValidateFunc,
@@ -94,11 +103,18 @@ func NewScopeAwareService[T ScopedResource](cfg *ScopeAwareServiceConfig[T]) (*S
 		return nil, trace.Wrap(err)
 	}
 
-	scopedService, err := NewService(&ServiceConfig[T]{
+	if cfg.ScopedOnly {
+		return &ScopeAwareService[T]{
+			scopedOnly:    true,
+			ScopedService: scopedService,
+		}, nil
+	}
+
+	unscopedService, err := NewService(&ServiceConfig[T]{
 		Backend:                     cfg.Backend,
 		ResourceKind:                cfg.ResourceKind,
 		PageLimit:                   cfg.PageLimit,
-		BackendPrefix:               cfg.ScopedBackendPrefix,
+		BackendPrefix:               cfg.UnscopedBackendPrefix,
 		MarshalFunc:                 cfg.MarshalFunc,
 		UnmarshalFunc:               cfg.UnmarshalFunc,
 		ValidateFunc:                cfg.ValidateFunc,
@@ -123,6 +139,22 @@ func NewScopeAwareService[T ScopedResource](cfg *ScopeAwareServiceConfig[T]) (*S
 // service's relative key. [scopes.ResourceCursorScopedStart] is the boundary
 // between unscoped and scoped resources.
 func (s *ScopeAwareService[T]) Resources(ctx context.Context, startKey, endKey string) iter.Seq2[T, error] {
+	if s.scopedOnly {
+		if endKey != "" && !scopes.IsScopedResourceCursor(endKey) {
+			return stream.Empty[T]()
+		}
+		if endKey == scopes.ResourceCursorScopedStart() {
+			return stream.Empty[T]()
+		}
+
+		scopedStartKey := ""
+		if scopes.IsScopedResourceCursor(startKey) {
+			scopedStartKey = strings.TrimPrefix(startKey, scopes.ResourceCursorPrefix)
+		}
+		scopedEndKey := strings.TrimPrefix(endKey, scopes.ResourceCursorPrefix)
+		return s.ScopedService.Resources(ctx, scopedStartKey, scopedEndKey)
+	}
+
 	var streams []stream.Stream[T]
 
 	if !scopes.IsScopedResourceCursor(startKey) {
@@ -166,14 +198,18 @@ func (s *ScopeAwareService[T]) ListResources(ctx context.Context, pageSize int, 
 // unified scoped and unscoped collection. It always returns all matching
 // unscoped resources before matching scoped resources.
 func (s *ScopeAwareService[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, nextToken string, matcher func(T) bool) ([]T, string, error) {
-	if pageSize <= 0 || pageSize > int(s.UnscopedService.pageLimit) {
-		pageSize = int(s.UnscopedService.pageLimit)
+	if pageSize <= 0 || pageSize > int(s.ScopedService.pageLimit) {
+		pageSize = int(s.ScopedService.pageLimit)
 	}
 
-	// Check if the token was scoped, if so the caller has already paged over
-	// all unscoped resources and we should return the next page of scoped
-	// resources.
-	if scopes.IsScopedResourceCursor(nextToken) {
+	if s.scopedOnly && nextToken != "" && !scopes.IsScopedResourceCursor(nextToken) {
+		return nil, "", trace.BadParameter("scoped-only storage service received invalid pagination token")
+	}
+
+	// If in scoped only mode we don't care about unscoped resources. If the
+	// token was scoped the caller has already paged over all unscoped
+	// resources and we should return the next page of scoped resources.
+	if s.scopedOnly || scopes.IsScopedResourceCursor(nextToken) {
 		nextToken = strings.TrimPrefix(nextToken, scopes.ResourceCursorPrefix)
 		resources, nextToken, err := s.ScopedService.ListResourcesWithFilter(ctx, pageSize, nextToken, matcher)
 		if nextToken != "" {
@@ -232,8 +268,12 @@ func (s *ScopeAwareService[T]) DeleteResource(ctx context.Context, scopedName sc
 	return svc.DeleteResource(ctx, scopedName.Name)
 }
 
-// DeleteAllResources deletes all scoped and unscoped resources.
+// DeleteAllResources deletes all scoped and unscoped resources (if not in scoped only mode).
 func (s *ScopeAwareService[T]) DeleteAllResources(ctx context.Context) error {
+	if s.scopedOnly {
+		return trace.Wrap(s.ScopedService.DeleteAllResources(ctx))
+	}
+
 	return trace.NewAggregate(
 		s.UnscopedService.DeleteAllResources(ctx),
 		s.ScopedService.DeleteAllResources(ctx),
@@ -292,6 +332,9 @@ func (s *ScopeAwareService[T]) ConditionalUpdateResource(ctx context.Context, re
 // returns the scoped service with the encoded scope appended to its backend prefix.
 func (s *ScopeAwareService[T]) WithScopePrefix(scope string) (*Service[T], error) {
 	if scope == "" {
+		if s.scopedOnly {
+			return nil, trace.BadParameter("scoped-only storage service received an empty scope")
+		}
 		return s.UnscopedService, nil
 	}
 	encodedScope, err := scopes.EncodeForKey(scope)
@@ -314,6 +357,9 @@ func (s *ScopeAwareService[T]) WithScopePrefix(scope string) (*Service[T], error
 // resource, i.e. members of a scoped access list.
 func (s *ScopeAwareService[T]) WithScopedResourcePrefix(scopedName scopes.QualifiedName) (*Service[T], error) {
 	if scopedName.Scope == "" {
+		if s.scopedOnly {
+			return nil, trace.BadParameter("scoped-only storage service received an empty scope")
+		}
 		return s.UnscopedService.WithPrefix(scopedName.Name), nil
 	}
 	encodedScope, err := scopes.EncodeForKey(scopedName.Scope)

--- a/lib/services/local/generic/scopeaware_test.go
+++ b/lib/services/local/generic/scopeaware_test.go
@@ -1,0 +1,265 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package generic
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"maps"
+	"strings"
+	"testing"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/scopes"
+)
+
+func newScopedTestResource(sqn scopes.QualifiedName) *testResource {
+	r := newTestResource(sqn.Name)
+	r.Scope = sqn.Scope
+	return r
+}
+
+func TestScopeAwareService(t *testing.T) {
+	memBackend, err := memory.New(memory.Config{
+		Context: t.Context(),
+		Clock:   clockwork.NewFakeClock(),
+	})
+	require.NoError(t, err)
+
+	service, err := NewScopeAwareService(&ScopeAwareServiceConfig[*testResource]{
+		Backend:               memBackend,
+		ResourceKind:          "generic resource",
+		UnscopedBackendPrefix: backend.NewKey("generic_prefix"),
+		ScopedBackendPrefix:   backend.NewKey("scoped", "generic_prefix"),
+		PageLimit:             200,
+		UnmarshalFunc:         unmarshalResource,
+		MarshalFunc:           marshalResource,
+	})
+	require.NoError(t, err)
+
+	var resources []*testResource
+
+	// Create some unscoped resources.
+	const numUnscopedResources = 10
+	for nameIndex := range numUnscopedResources {
+		resources = append(resources, newTestResource(fmt.Sprintf("name%d", nameIndex)))
+	}
+
+	// Add a bunch of scoped resources at various scopes.
+	for baseScopeIndex := range 10 {
+		// Add ten at this base scope.
+		for nameIndex := range 10 {
+			resources = append(resources, newScopedTestResource(scopes.QualifiedName{
+				Scope: fmt.Sprintf("/base%d", baseScopeIndex),
+				Name:  fmt.Sprintf("name%d", nameIndex),
+			}))
+		}
+
+		// Add ten more at each of 10 sub scopes.
+		for subScopeIndex := range 10 {
+			for nameIndex := range 10 {
+				resources = append(resources, newScopedTestResource(scopes.QualifiedName{
+					Scope: fmt.Sprintf("/base%d/sub%d", baseScopeIndex, subScopeIndex),
+					Name:  fmt.Sprintf("name%d", nameIndex),
+				}))
+			}
+		}
+	}
+
+	expectedResourceNames := make(map[scopes.QualifiedName]struct{}, len(resources))
+	for _, resource := range resources {
+		expectedResourceNames[scopes.QualifiedName{
+			Scope: resource.GetScope(),
+			Name:  resource.GetName(),
+		}] = struct{}{}
+	}
+
+	checkExpectedResources := func(t *testing.T, expectedResourceNames map[scopes.QualifiedName]struct{}, resources iter.Seq2[*testResource, error]) {
+		t.Helper()
+
+		expected := maps.Clone(expectedResourceNames)
+
+		for resource, err := range resources {
+			require.NoError(t, err)
+
+			key := scopes.QualifiedName{
+				Scope: resource.GetScope(),
+				Name:  resource.GetName(),
+			}
+
+			assert.Contains(t, expected, key, "found unexpected resource %v", key)
+			delete(expected, key)
+		}
+		assert.Empty(t, expected, "did not find expected resources")
+	}
+
+	expectedResourcesInCursorRange := func(t *testing.T, startKey, endKey string) map[scopes.QualifiedName]struct{} {
+		t.Helper()
+
+		expected := make(map[scopes.QualifiedName]struct{})
+		for _, resource := range resources {
+			cursor, err := scopes.MakeResourceCursor(resource.GetScope(), resource.GetName())
+			require.NoError(t, err)
+			if startKey != "" && cursor < startKey {
+				continue
+			}
+			if endKey != "" && cursor >= endKey {
+				continue
+			}
+			expected[scopes.QualifiedName{Scope: resource.GetScope(), Name: resource.GetName()}] = struct{}{}
+		}
+		return expected
+	}
+
+	// Create all the resources.
+	for _, resource := range resources {
+		_, err := service.CreateResource(t.Context(), resource)
+		require.NoError(t, err)
+	}
+
+	t.Run("Resources", func(t *testing.T) {
+		checkExpectedResources(t, expectedResourceNames, service.Resources(t.Context(), "", ""))
+
+		foundScoped := false
+		for resource, err := range service.Resources(t.Context(), "", "") {
+			require.NoError(t, err)
+			if foundScoped && resource.GetScope() == "" {
+				t.Fatal("found unscoped resource after scoped resource")
+			}
+			foundScoped = foundScoped || resource.GetScope() != ""
+		}
+
+		countResources := func(resources iter.Seq2[*testResource, error]) int {
+			t.Helper()
+			var count int
+			for _, err := range resources {
+				require.NoError(t, err)
+				count++
+			}
+			return count
+		}
+
+		// The scoped start cursor is the boundary between unscoped resources and
+		// scoped resources in the unified logical resource stream.
+		require.Equal(t, numUnscopedResources,
+			countResources(service.Resources(t.Context(), "", scopes.ResourceCursorScopedStart())))
+		require.Equal(t, len(resources)-numUnscopedResources,
+			countResources(service.Resources(t.Context(), scopes.ResourceCursorScopedStart(), "")))
+
+		// Verify a range that starts in unscoped resources and ends in scoped
+		// resources, forcing Resources to concatenate both underlying services.
+		scopedEnd, err := scopes.MakeResourceCursor("/base1", "name0")
+		require.NoError(t, err)
+		checkExpectedResources(t,
+			expectedResourcesInCursorRange(t, "name5", scopedEnd),
+			service.Resources(t.Context(), "name5", scopedEnd),
+		)
+	})
+
+	// Check all resources can be listed, at various page sizes.
+	for _, pageSize := range []int{0, 1, 3, 5, 10, 11, 99, 100, 101} {
+		t.Run(fmt.Sprintf("pageSize=%d", pageSize), func(t *testing.T) {
+			t.Run("unfiltered", func(t *testing.T) {
+				resourceIter := clientutils.ResourcesWithPageSize(t.Context(), service.ListResources, pageSize)
+				checkExpectedResources(t, expectedResourceNames, resourceIter)
+			})
+
+			t.Run("filtered", func(t *testing.T) {
+				iter := clientutils.ResourcesWithPageSize(t.Context(), func(ctx context.Context, pageSize int, nextPageToken string) ([]*testResource, string, error) {
+					return service.ListResourcesWithFilter(ctx, pageSize, nextPageToken, func(resource *testResource) bool {
+						return strings.HasPrefix(resource.GetScope(), "/base7/")
+					})
+				}, pageSize)
+				count := 0
+				for resource, err := range iter {
+					require.NoError(t, err)
+					require.True(t, strings.HasPrefix(resource.GetScope(), "/base7/"))
+					count++
+				}
+				require.Equal(t, 100, count)
+
+			})
+		})
+
+	}
+
+	// Check that unscoped resources sort before scoped resources.
+	foundScoped := false
+	for resource, err := range clientutils.Resources(t.Context(), service.ListResources) {
+		require.NoError(t, err)
+		scope := resource.GetScope()
+		if foundScoped && scope == "" {
+			t.Fatal("found unscoped resource after scoped resource")
+		}
+		foundScoped = foundScoped || scope != ""
+	}
+
+	for resourceName := range expectedResourceNames {
+		// Get should work.
+		resource, err := service.GetResource(t.Context(), resourceName)
+		require.NoError(t, err)
+
+		// Update should work.
+		resource.Spec.PropA = "updated"
+		resource, err = service.UpdateResource(t.Context(), resource)
+		require.NoError(t, err)
+		require.Equal(t, "updated", resource.Spec.PropA)
+
+		// Try ConditionalUpdate with incorrect revision.
+		rev := resource.Metadata.Revision
+		resource.Metadata.Revision = ""
+		_, err = service.ConditionalUpdateResource(t.Context(), resource)
+		require.Error(t, err)
+
+		// ConditionalUpdate with correct revision.
+		resource.Metadata.Revision = rev
+		resource.Spec.PropA = "conditional_updated"
+		resource, err = service.ConditionalUpdateResource(t.Context(), resource)
+		require.NoError(t, err)
+		require.Equal(t, "conditional_updated", resource.Spec.PropA)
+
+		// Delete the resource and Get should fail.
+		err = service.DeleteResource(t.Context(), resourceName)
+		require.NoError(t, err)
+		_, err = service.GetResource(t.Context(), resourceName)
+		require.Error(t, err)
+
+		// Upsert the resource.
+		resource.Spec.PropA = "upserted"
+		resource, err = service.UpsertResource(t.Context(), resource)
+		require.NoError(t, err)
+		require.Equal(t, "upserted", resource.Spec.PropA)
+	}
+
+	// Make sure all the expected resources are still there.
+	resourceIter := clientutils.Resources(t.Context(), service.ListResources)
+	checkExpectedResources(t, expectedResourceNames, resourceIter)
+
+	// Delete all resources and make sure they're gone.
+	err = service.DeleteAllResources(t.Context())
+	require.NoError(t, err)
+	page, _, err := service.ListResources(t.Context(), 1, "")
+	require.NoError(t, err)
+	require.Empty(t, page)
+}

--- a/lib/services/local/generic/scopeaware_test.go
+++ b/lib/services/local/generic/scopeaware_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -262,4 +263,225 @@ func TestScopeAwareService(t *testing.T) {
 	page, _, err := service.ListResources(t.Context(), 1, "")
 	require.NoError(t, err)
 	require.Empty(t, page)
+}
+
+func newScopedOnlyServiceForTest(t *testing.T) *ScopeAwareService[*testResource] {
+	t.Helper()
+
+	memBackend, err := memory.New(memory.Config{
+		Context: t.Context(),
+		Clock:   clockwork.NewFakeClock(),
+	})
+	require.NoError(t, err)
+
+	service, err := NewScopeAwareService(&ScopeAwareServiceConfig[*testResource]{
+		ScopedOnly:          true,
+		Backend:             memBackend,
+		ResourceKind:        "generic resource",
+		ScopedBackendPrefix: backend.NewKey(testScopedTopPrefix, testUnscopedPrefix),
+		PageLimit:           200,
+		MarshalFunc:         marshalResource,
+		UnmarshalFunc:       unmarshalResource,
+	})
+	require.NoError(t, err)
+	return service
+}
+
+func newScopedTestResourceWithBody(sqn scopes.QualifiedName) *testResource {
+	r := newScopedTestResource(sqn)
+	r.Spec.PropA = specDataFor(sqn)
+	return r
+}
+
+func requireTestResourceBody(t *testing.T, want scopes.QualifiedName, got *testResource) {
+	t.Helper()
+	require.Equal(t, want.Name, got.GetName())
+	require.Equal(t, want.Scope, got.GetScope())
+	require.Equal(t, specDataFor(want), got.Spec.PropA)
+}
+
+func scopedNames(resources []*testResource) []scopes.QualifiedName {
+	out := make([]scopes.QualifiedName, 0, len(resources))
+	for _, r := range resources {
+		out = append(out, scopes.QualifiedName{Scope: r.GetScope(), Name: r.GetName()})
+	}
+	return out
+}
+
+func collectScopedStream(t *testing.T, seq iter.Seq2[*testResource, error]) []*testResource {
+	t.Helper()
+	var out []*testResource
+	for r, err := range seq {
+		require.NoError(t, err)
+		out = append(out, r)
+	}
+	return out
+}
+
+func TestScopeAwareService_ScopedOnly(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects empty scope on every operation", func(t *testing.T) {
+		t.Parallel()
+		svc := newScopedOnlyServiceForTest(t)
+		ctx := t.Context()
+		unscoped := scopes.QualifiedName{Name: "foo"}
+
+		_, err := svc.CreateResource(ctx, newScopedTestResource(unscoped))
+		require.True(t, trace.IsBadParameter(err), "create: %v", err)
+
+		_, err = svc.UpsertResource(ctx, newScopedTestResource(unscoped))
+		require.True(t, trace.IsBadParameter(err), "upsert: %v", err)
+
+		_, err = svc.ConditionalUpdateResource(ctx, newScopedTestResource(unscoped))
+		require.True(t, trace.IsBadParameter(err), "update: %v", err)
+
+		_, err = svc.GetResource(ctx, unscoped)
+		require.True(t, trace.IsBadParameter(err), "get: %v", err)
+
+		err = svc.DeleteResource(ctx, unscoped)
+		require.True(t, trace.IsBadParameter(err), "delete: %v", err)
+
+		_, err = svc.WithScopedResourcePrefix(unscoped)
+		require.True(t, trace.IsBadParameter(err), "with scoped resource prefix: %v", err)
+
+		_, err = svc.WithScopePrefix("")
+		require.True(t, trace.IsBadParameter(err), "with scope prefix: %v", err)
+	})
+
+	t.Run("CRUD", func(t *testing.T) {
+		t.Parallel()
+		svc := newScopedOnlyServiceForTest(t)
+		ctx := t.Context()
+		qn := scopes.QualifiedName{Scope: "/security", Name: "foo"}
+
+		created, err := svc.CreateResource(ctx, newScopedTestResourceWithBody(qn))
+		require.NoError(t, err)
+
+		got, err := svc.GetResource(ctx, qn)
+		require.NoError(t, err)
+		requireTestResourceBody(t, qn, got)
+
+		updated := newScopedTestResource(qn)
+		updated.Spec.PropA = "updated!"
+		updated.Metadata.Revision = created.Metadata.Revision
+		updated, err = svc.ConditionalUpdateResource(ctx, updated)
+		require.NoError(t, err)
+		require.NotEqual(t, created.Metadata.Revision, updated.Metadata.Revision)
+
+		got, err = svc.GetResource(ctx, qn)
+		require.NoError(t, err)
+		require.Equal(t, "updated!", got.Spec.PropA)
+
+		_, err = svc.ConditionalUpdateResource(ctx, created)
+		require.True(t, trace.IsCompareFailed(err))
+
+		upserted, err := svc.UpsertResource(ctx, created)
+		require.NoError(t, err)
+		requireTestResourceBody(t, qn, upserted)
+
+		require.NoError(t, svc.DeleteResource(ctx, qn))
+		_, err = svc.GetResource(ctx, qn)
+		require.True(t, trace.IsNotFound(err), "expected not found, got %v", err)
+	})
+
+	t.Run("same name across scopes does not conflict", func(t *testing.T) {
+		t.Parallel()
+		svc := newScopedOnlyServiceForTest(t)
+		ctx := t.Context()
+		a := scopes.QualifiedName{Scope: "/a", Name: "shared"}
+		b := scopes.QualifiedName{Scope: "/b", Name: "shared"}
+		_, err := svc.CreateResource(ctx, newScopedTestResourceWithBody(a))
+		require.NoError(t, err)
+		_, err = svc.CreateResource(ctx, newScopedTestResourceWithBody(b))
+		require.NoError(t, err)
+
+		gotA, err := svc.GetResource(ctx, a)
+		require.NoError(t, err)
+		requireTestResourceBody(t, a, gotA)
+		gotB, err := svc.GetResource(ctx, b)
+		require.NoError(t, err)
+		requireTestResourceBody(t, b, gotB)
+	})
+
+	t.Run("Resources bounded ranges", func(t *testing.T) {
+		t.Parallel()
+		svc := newScopedOnlyServiceForTest(t)
+		ctx := t.Context()
+		resources := []scopes.QualifiedName{
+			{Scope: "/a", Name: "1"},
+			{Scope: "/b", Name: "2"},
+			{Scope: "/c", Name: "3"},
+		}
+		for _, qn := range resources {
+			_, err := svc.CreateResource(ctx, newScopedTestResource(qn))
+			require.NoError(t, err)
+		}
+
+		// A scoped-only service has no unscoped resources, so ranges ending
+		// before the scoped resource range must be empty.
+		require.Empty(t, collectScopedStream(t, svc.Resources(ctx, "", "name5")))
+		require.Empty(t, collectScopedStream(t, svc.Resources(ctx, "", scopes.ResourceCursorScopedStart())))
+
+		start, err := scopes.MakeResourceCursor("/b", "2")
+		require.NoError(t, err)
+		end, err := scopes.MakeResourceCursor("/c", "3")
+		require.NoError(t, err)
+		require.Equal(t,
+			[]scopes.QualifiedName{{Scope: "/b", Name: "2"}},
+			scopedNames(collectScopedStream(t, svc.Resources(ctx, start, end))),
+		)
+	})
+
+	t.Run("ListResourcesWithFilter pagination", func(t *testing.T) {
+		t.Parallel()
+		svc := newScopedOnlyServiceForTest(t)
+		ctx := t.Context()
+		want := []scopes.QualifiedName{
+			{Scope: "/a", Name: "1"},
+			{Scope: "/b", Name: "2"},
+			{Scope: "/c", Name: "3"},
+		}
+		for _, qn := range want {
+			_, err := svc.CreateResource(ctx, newScopedTestResource(qn))
+			require.NoError(t, err)
+		}
+
+		// Single full page.
+		got, next, err := svc.ListResourcesWithFilter(ctx, 100, "", func(*testResource) bool { return true })
+		require.NoError(t, err)
+		require.Empty(t, next)
+		require.Equal(t, want, scopedNames(got))
+
+		// One item per page.
+		var paged []*testResource
+		token := ""
+		for {
+			page, nextToken, err := svc.ListResourcesWithFilter(ctx, 1, token, func(*testResource) bool { return true })
+			require.NoError(t, err)
+			if nextToken != "" {
+				require.True(t, scopes.IsScopedResourceCursor(nextToken))
+			}
+			paged = append(paged, page...)
+			if nextToken == "" {
+				break
+			}
+			token = nextToken
+		}
+		require.Equal(t, want, scopedNames(paged))
+
+		// Default page size.
+		got, _, err = svc.ListResourcesWithFilter(ctx, 0, "", func(*testResource) bool { return true })
+		require.NoError(t, err)
+		require.Len(t, got, 3)
+
+		// A scoped-only service must reject non-empty unscoped tokens. Such a
+		// token could only come from a different service mode and would otherwise
+		// be silently interpreted as a scoped service relative key.
+		_, _, err = svc.ListResourcesWithFilter(ctx, 100, "legacy", func(*testResource) bool { return true })
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+
+		require.NoError(t, svc.DeleteAllResources(ctx))
+		require.Empty(t, collectScopedStream(t, svc.Resources(ctx, "", "")))
+	})
 }

--- a/lib/services/local/generic/scopeaware_wrapper.go
+++ b/lib/services/local/generic/scopeaware_wrapper.go
@@ -45,6 +45,7 @@ type ScopedResourceMetadata interface {
 // wrapper transparently routes reads and writes to the correct range.
 func NewScopeAwareServiceWrapper[T ScopedResourceMetadata](cfg ScopeAwareServiceWrapperConfig[T]) (*ScopeAwareServiceWrapper[T], error) {
 	serviceConfig := &ScopeAwareServiceConfig[scopedResourceMetadataAdapter[T]]{
+		ScopedOnly:            cfg.ScopedOnly,
 		Backend:               cfg.Backend,
 		ResourceKind:          cfg.ResourceKind,
 		PageLimit:             cfg.PageLimit,
@@ -77,6 +78,9 @@ func NewScopeAwareServiceWrapper[T ScopedResourceMetadata](cfg ScopeAwareService
 // ScopeAwareServiceWrapper. It mirrors ScopeAwareServiceConfig but operates on
 // the bare RFD 153 resource type T rather than an adapter.
 type ScopeAwareServiceWrapperConfig[T ScopedResourceMetadata] struct {
+	// ScopedOnly indicates that the service will only operate on scoped resources.
+	// The unscoped fallback path will be ignored in all cases.
+	ScopedOnly bool
 	// Backend used to persist the resource.
 	Backend backend.Backend
 	// ResourceKind is the friendly name of the resource.

--- a/lib/services/local/generic/scopeaware_wrapper.go
+++ b/lib/services/local/generic/scopeaware_wrapper.go
@@ -1,0 +1,214 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package generic
+
+import (
+	"context"
+	"iter"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// ScopedResourceMetadata is an RFD 153-style resource that additionally carries
+// a scope. The scope may be empty on any individual resource, in which case the
+// resource is unscoped (classic behavior).
+type ScopedResourceMetadata interface {
+	types.ResourceMetadata
+	// GetScope returns the scope of the resource. An empty scope indicates the
+	// resource is unscoped.
+	GetScope() string
+}
+
+// NewScopeAwareServiceWrapper returns a new scope-aware generic service wrapper.
+// It is the RFD 153 analog of ScopeAwareService: scoped resources are stored
+// in a separate, scope-namespaced key range from unscoped resources, and the
+// wrapper transparently routes reads and writes to the correct range.
+func NewScopeAwareServiceWrapper[T ScopedResourceMetadata](cfg ScopeAwareServiceWrapperConfig[T]) (*ScopeAwareServiceWrapper[T], error) {
+	serviceConfig := &ScopeAwareServiceConfig[scopedResourceMetadataAdapter[T]]{
+		Backend:               cfg.Backend,
+		ResourceKind:          cfg.ResourceKind,
+		PageLimit:             cfg.PageLimit,
+		UnscopedBackendPrefix: cfg.UnscopedBackendPrefix,
+		ScopedBackendPrefix:   cfg.ScopedBackendPrefix,
+		MarshalFunc: func(w scopedResourceMetadataAdapter[T], opts ...services.MarshalOption) ([]byte, error) {
+			return cfg.MarshalFunc(w.resource, opts...)
+		},
+		UnmarshalFunc: func(bytes []byte, opts ...services.MarshalOption) (scopedResourceMetadataAdapter[T], error) {
+			r, err := cfg.UnmarshalFunc(bytes, opts...)
+			return newScopedResourceMetadataAdapter(r), trace.Wrap(err)
+		},
+		RunWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
+	}
+
+	if cfg.ValidateFunc != nil {
+		serviceConfig.ValidateFunc = func(w scopedResourceMetadataAdapter[T]) error {
+			return cfg.ValidateFunc(w.resource)
+		}
+	}
+
+	service, err := NewScopeAwareService(serviceConfig)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &ScopeAwareServiceWrapper[T]{service: service}, nil
+}
+
+// ScopeAwareServiceWrapperConfig holds configuration options for a
+// ScopeAwareServiceWrapper. It mirrors ScopeAwareServiceConfig but operates on
+// the bare RFD 153 resource type T rather than an adapter.
+type ScopeAwareServiceWrapperConfig[T ScopedResourceMetadata] struct {
+	// Backend used to persist the resource.
+	Backend backend.Backend
+	// ResourceKind is the friendly name of the resource.
+	ResourceKind string
+	// UnscopedBackendPrefix used when constructing the [backend.Item.Key] for unscoped resources.
+	UnscopedBackendPrefix backend.Key
+	// ScopedBackendPrefix used when constructing the [backend.Item.Key] for scoped resources.
+	ScopedBackendPrefix backend.Key
+	// PageLimit is the maximum number of resources returned in a single page.
+	PageLimit uint
+	// MarshalFunc converts the resource to bytes for persistence.
+	MarshalFunc MarshalFunc[T]
+	// UnmarshalFunc converts the bytes read from the backend to the resource.
+	UnmarshalFunc UnmarshalFunc[T]
+	// ValidateFunc optionally validates the resource prior to persisting it. Any errors
+	// returned from the validation function will prevent writes to the backend.
+	ValidateFunc func(T) error
+	// RunWhileLockedRetryInterval is the interval to retry the RunWhileLocked function.
+	// If set to 0, the default interval of 250ms will be used.
+	// WARNING: If set to a negative value, the RunWhileLocked function will retry immediately.
+	RunWhileLockedRetryInterval time.Duration
+}
+
+// ScopeAwareServiceWrapper is an adapter for ScopeAwareService that makes it
+// usable with RFD 153-style resources which implement ScopedResourceMetadata.
+//
+// As with ServiceWrapper, not all methods of the underlying service are
+// exported; additional methods may be exported in the future as needed.
+type ScopeAwareServiceWrapper[T ScopedResourceMetadata] struct {
+	service *ScopeAwareService[scopedResourceMetadataAdapter[T]]
+}
+
+// CreateResource creates the given resource if it doesn't already exist. The
+// resource is stored in the unscoped key range if its scope is empty, else in
+// the scope-namespaced key range.
+func (s *ScopeAwareServiceWrapper[T]) CreateResource(ctx context.Context, resource T) (T, error) {
+	adapter, err := s.service.CreateResource(ctx, newScopedResourceMetadataAdapter(resource))
+	return adapter.resource, trace.Wrap(err)
+}
+
+// UpsertResource upserts the given resource into the key range determined by its scope.
+func (s *ScopeAwareServiceWrapper[T]) UpsertResource(ctx context.Context, resource T) (T, error) {
+	adapter, err := s.service.UpsertResource(ctx, newScopedResourceMetadataAdapter(resource))
+	return adapter.resource, trace.Wrap(err)
+}
+
+// ConditionalUpdateResource updates the given resource if the provided and
+// existing revisions match, in the key range determined by its scope.
+func (s *ScopeAwareServiceWrapper[T]) ConditionalUpdateResource(ctx context.Context, resource T) (T, error) {
+	adapter, err := s.service.ConditionalUpdateResource(ctx, newScopedResourceMetadataAdapter(resource))
+	return adapter.resource, trace.Wrap(err)
+}
+
+// GetResource returns the resource for the given scope-qualified name. An empty
+// scope reads from the unscoped key range.
+func (s *ScopeAwareServiceWrapper[T]) GetResource(ctx context.Context, name scopes.QualifiedName) (T, error) {
+	adapter, err := s.service.GetResource(ctx, name)
+	return adapter.resource, trace.Wrap(err)
+}
+
+// DeleteResource deletes the resource for the given scope-qualified name. An
+// empty scope deletes from the unscoped key range.
+func (s *ScopeAwareServiceWrapper[T]) DeleteResource(ctx context.Context, name scopes.QualifiedName) error {
+	return trace.Wrap(s.service.DeleteResource(ctx, name))
+}
+
+// DeleteAllResources deletes all scoped and unscoped resources.
+func (s *ScopeAwareServiceWrapper[T]) DeleteAllResources(ctx context.Context) error {
+	return trace.Wrap(s.service.DeleteAllResources(ctx))
+}
+
+// ListResources returns a page of resources over the unified scoped and
+// unscoped collection. All unscoped resources are returned before scoped ones.
+func (s *ScopeAwareServiceWrapper[T]) ListResources(ctx context.Context, pageSize int, nextToken string) ([]T, string, error) {
+	return s.ListResourcesWithFilter(ctx, pageSize, nextToken, func(T) bool { return true })
+}
+
+// ListResourcesWithFilter returns a page of matching resources over the unified
+// scoped and unscoped collection. All matching unscoped resources are returned
+// before matching scoped ones.
+func (s *ScopeAwareServiceWrapper[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, nextToken string, matcher func(T) bool) ([]T, string, error) {
+	adapters, next, err := s.service.ListResourcesWithFilter(ctx, pageSize, nextToken, func(w scopedResourceMetadataAdapter[T]) bool {
+		return matcher(w.resource)
+	})
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	out := make([]T, 0, len(adapters))
+	for _, adapter := range adapters {
+		out = append(out, adapter.resource)
+	}
+	return out, next, nil
+}
+
+// Resources returns a stream of resources within the unified scope-aware range
+// [startKey, endKey). Unscoped resources are ordered before scoped resources.
+// The startKey and endKey values are resource cursors as defined by
+// [scopes.MakeResourceCursor].
+//
+// This method may be used to implement RangeFoo.
+func (s *ScopeAwareServiceWrapper[T]) Resources(ctx context.Context, startKey, endKey string) iter.Seq2[T, error] {
+	return func(yield func(T, error) bool) {
+		for adapter, err := range s.service.Resources(ctx, startKey, endKey) {
+			if err != nil {
+				var t T
+				yield(t, err)
+				return
+			}
+			if !yield(adapter.resource, nil) {
+				return
+			}
+		}
+	}
+}
+
+// MakeBackendItem returns a backend.Item for the given resource, keyed within
+// the unscoped or scope-namespaced range according to the resource's scope.
+func (s *ScopeAwareServiceWrapper[T]) MakeBackendItem(resource T) (backend.Item, error) {
+	svc, err := s.service.WithScopePrefix(resource.GetScope())
+	if err != nil {
+		return backend.Item{}, trace.Wrap(err)
+	}
+	return svc.MakeBackendItem(newScopedResourceMetadataAdapter(resource))
+}
+
+// BackendKey returns the backend.Key for the resource with the given
+// scope-qualified name, within the unscoped or scope-namespaced range according
+// to its scope.
+func (s *ScopeAwareServiceWrapper[T]) BackendKey(name scopes.QualifiedName) (backend.Key, error) {
+	svc, err := s.service.WithScopePrefix(name.Scope)
+	if err != nil {
+		return backend.Key{}, trace.Wrap(err)
+	}
+	return svc.resourceKey(name.Name), nil
+}

--- a/lib/services/local/generic/scopeaware_wrapper_test.go
+++ b/lib/services/local/generic/scopeaware_wrapper_test.go
@@ -1,0 +1,599 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package generic
+
+import (
+	"fmt"
+	"iter"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+const (
+	// testUnscopedPrefix is the backend prefix the test wrapper uses for unscoped
+	// resources.
+	testUnscopedPrefix = "generic_prefix"
+	// testScopedTopPrefix is the top-level backend prefix under which the test
+	// wrapper namespaces scoped resources.
+	testScopedTopPrefix = "scoped"
+)
+
+type scopedTestResource153 struct {
+	Metadata *headerv1.Metadata
+	Scope    string
+	Spec     scopedTestResource153Spec
+}
+
+type scopedTestResource153Spec struct {
+	Data string
+}
+
+func (t *scopedTestResource153) GetMetadata() *headerv1.Metadata {
+	return t.Metadata
+}
+
+func (t *scopedTestResource153) GetScope() string {
+	return t.Scope
+}
+
+func specDataFor(sqn scopes.QualifiedName) string {
+	return fmt.Sprintf("spec-data(scope=%q,name=%q)", sqn.Scope, sqn.Name)
+}
+
+func newScopedTestResource153(sqn scopes.QualifiedName) *scopedTestResource153 {
+	tr := &scopedTestResource153{
+		Metadata: headerv1.Metadata_builder{Name: sqn.Name}.Build(),
+		Scope:    sqn.Scope,
+		Spec:     scopedTestResource153Spec{Data: specDataFor(sqn)},
+	}
+	tr.Metadata.SetExpires(timestamppb.New(time.Now().AddDate(0, 0, 3)))
+	return tr
+}
+
+func marshalScopedResource153(resource *scopedTestResource153, opts ...services.MarshalOption) ([]byte, error) {
+	// TODO(strideynet): It feels a little janky utilizing fast marshal rather
+	// than Proto marshal (which is what 99.9% of RFD153 resources are going to
+	// use). Could we add a "foo" resource to `/api` for testing?
+	return utils.FastMarshal(resource)
+}
+
+func unmarshalScopedResource153(data []byte, opts ...services.MarshalOption) (*scopedTestResource153, error) {
+	if len(data) == 0 {
+		return nil, trace.BadParameter("missing resource data")
+	}
+	cfg, err := services.CollectOptions(opts)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var r scopedTestResource153
+	if err := utils.FastUnmarshal(data, &r); err != nil {
+		return nil, trace.BadParameter("%s", err)
+	}
+	if r.Metadata == nil {
+		r.Metadata = &headerv1.Metadata{}
+	}
+	if cfg.Revision != "" {
+		r.Metadata.SetRevision(cfg.Revision)
+	}
+	if !cfg.Expires.IsZero() {
+		r.Metadata.SetExpires(timestamppb.New(cfg.Expires))
+	}
+	return &r, nil
+}
+
+func newScopeAwareWrapperForTest(t *testing.T) *ScopeAwareServiceWrapper[*scopedTestResource153] {
+	t.Helper()
+
+	memBackend, err := memory.New(memory.Config{
+		Context: t.Context(),
+		Clock:   clockwork.NewFakeClock(),
+	})
+	require.NoError(t, err)
+
+	service, err := NewScopeAwareServiceWrapper(ScopeAwareServiceWrapperConfig[*scopedTestResource153]{
+		Backend:               memBackend,
+		ResourceKind:          "scoped_generic_resource",
+		UnscopedBackendPrefix: backend.NewKey(testUnscopedPrefix),
+		ScopedBackendPrefix:   backend.NewKey(testScopedTopPrefix, testUnscopedPrefix),
+		PageLimit:             200,
+		MarshalFunc:           marshalScopedResource153,
+		UnmarshalFunc:         unmarshalScopedResource153,
+	})
+	require.NoError(t, err)
+	return service
+}
+
+func names(resources []*scopedTestResource153) []scopes.QualifiedName {
+	out := make([]scopes.QualifiedName, 0, len(resources))
+	for _, r := range resources {
+		out = append(out, scopes.QualifiedName{Scope: r.GetScope(), Name: r.GetMetadata().GetName()})
+	}
+	return out
+}
+
+func collectStream(t *testing.T, seq iter.Seq2[*scopedTestResource153, error]) []*scopedTestResource153 {
+	t.Helper()
+	var out []*scopedTestResource153
+	for r, err := range seq {
+		require.NoError(t, err)
+		out = append(out, r)
+	}
+	return out
+}
+
+// requireResourceBody asserts the resource read back carries exactly the body we
+// stored for the given scope-qualified name. Because the spec data is never
+// encoded in the backend key, its correct round-trip proves the whole resource
+// body — including its scope — is sourced from the persisted value, and not
+// reconstructed from the storage key.
+func requireResourceBody(t *testing.T, want scopes.QualifiedName, got *scopedTestResource153) {
+	t.Helper()
+	require.Equal(t, want.Name, got.GetMetadata().GetName())
+	require.Equal(t, want.Scope, got.GetScope())
+	require.Equal(t, specDataFor(want), got.Spec.Data)
+}
+
+// TestScopeAwareServiceWrapper_E2E is an end-to-end smoke test that
+// exercises the key behaviors in order.
+func TestScopeAwareServiceWrapper_E2E(t *testing.T) {
+	t.Parallel()
+	svc := newScopeAwareWrapperForTest(t)
+	ctx := t.Context()
+
+	unscoped := scopes.QualifiedName{Name: "foo"}
+	scoped := scopes.QualifiedName{Scope: "/security", Name: "foo"}
+
+	// A scoped and an unscoped resource may share a name; they live in distinct
+	// key ranges.
+	_, err := svc.CreateResource(ctx, newScopedTestResource153(unscoped))
+	require.NoError(t, err)
+	_, err = svc.CreateResource(ctx, newScopedTestResource153(scoped))
+	require.NoError(t, err)
+
+	// Each resolves only under its own scope-qualified name, returning the body
+	// stored for that scope.
+	got, err := svc.GetResource(ctx, unscoped)
+	require.NoError(t, err)
+	requireResourceBody(t, unscoped, got)
+
+	got, err = svc.GetResource(ctx, scoped)
+	require.NoError(t, err)
+	requireResourceBody(t, scoped, got)
+
+	// An unscoped name does not resolve under a scope, and a scoped name does
+	// not resolve as unscoped.
+	_, err = svc.GetResource(ctx, scopes.QualifiedName{Scope: "/other", Name: "foo"})
+	require.True(t, trace.IsNotFound(err), "expected not found, got %v", err)
+
+	// Deleting one leaves the other intact.
+	require.NoError(t, svc.DeleteResource(ctx, unscoped))
+	_, err = svc.GetResource(ctx, unscoped)
+	require.True(t, trace.IsNotFound(err), "expected not found, got %v", err)
+	_, err = svc.GetResource(ctx, scoped)
+	require.NoError(t, err)
+}
+
+func TestScopeAwareServiceWrapper_CreateResource(t *testing.T) {
+	t.Parallel()
+	svc := newScopeAwareWrapperForTest(t)
+	ctx := t.Context()
+
+	t.Run("creates unscoped and scoped resources", func(t *testing.T) {
+		for _, qn := range []scopes.QualifiedName{
+			{Name: "foo"},
+			{Scope: "/security", Name: "foo"},
+		} {
+			created, err := svc.CreateResource(ctx, newScopedTestResource153(qn))
+			require.NoError(t, err)
+			require.NotEmpty(t, created.GetMetadata().GetRevision(), "create must populate a revision")
+
+			got, err := svc.GetResource(ctx, qn)
+			require.NoError(t, err)
+			requireResourceBody(t, qn, got)
+		}
+	})
+
+	t.Run("rejects duplicate within the same scope", func(t *testing.T) {
+		qn := scopes.QualifiedName{Scope: "/eng", Name: "dup"}
+		_, err := svc.CreateResource(ctx, newScopedTestResource153(qn))
+		require.NoError(t, err)
+		_, err = svc.CreateResource(ctx, newScopedTestResource153(qn))
+		require.True(t, trace.IsAlreadyExists(err), "expected AlreadyExists, got %v", err)
+	})
+
+	t.Run("same name in different scopes does not conflict", func(t *testing.T) {
+		a := scopes.QualifiedName{Scope: "/a", Name: "shared"}
+		b := scopes.QualifiedName{Scope: "/b", Name: "shared"}
+		_, err := svc.CreateResource(ctx, newScopedTestResource153(a))
+		require.NoError(t, err)
+		_, err = svc.CreateResource(ctx, newScopedTestResource153(b))
+		require.NoError(t, err)
+
+		gotA, err := svc.GetResource(ctx, a)
+		require.NoError(t, err)
+		requireResourceBody(t, a, gotA)
+		gotB, err := svc.GetResource(ctx, b)
+		require.NoError(t, err)
+		requireResourceBody(t, b, gotB)
+	})
+}
+
+func TestScopeAwareServiceWrapper_UpsertResource(t *testing.T) {
+	t.Parallel()
+	svc := newScopeAwareWrapperForTest(t)
+	ctx := t.Context()
+
+	for _, tc := range []struct {
+		name string
+		qn   scopes.QualifiedName
+	}{
+		{"unscoped", scopes.QualifiedName{Name: "up"}},
+		{"scoped", scopes.QualifiedName{Scope: "/security", Name: "up"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Upsert creates when absent.
+			first := newScopedTestResource153(tc.qn)
+			first.Spec.Data = "first"
+			_, err := svc.UpsertResource(ctx, first)
+			require.NoError(t, err)
+			got, err := svc.GetResource(ctx, tc.qn)
+			require.NoError(t, err)
+			require.Equal(t, "first", got.Spec.Data)
+
+			// Upsert overwrites when present, with no revision and no AlreadyExists.
+			second := newScopedTestResource153(tc.qn)
+			second.Spec.Data = "second"
+			_, err = svc.UpsertResource(ctx, second)
+			require.NoError(t, err)
+			got, err = svc.GetResource(ctx, tc.qn)
+			require.NoError(t, err)
+			require.Equal(t, "second", got.Spec.Data)
+		})
+	}
+
+	t.Run("routes by scope", func(t *testing.T) {
+		// Upserting a scoped resource must not clobber an unscoped one of the
+		// same name.
+		unscoped := scopes.QualifiedName{Name: "router"}
+		scoped := scopes.QualifiedName{Scope: "/eng", Name: "router"}
+
+		u := newScopedTestResource153(unscoped)
+		u.Spec.Data = "unscoped"
+		_, err := svc.UpsertResource(ctx, u)
+		require.NoError(t, err)
+
+		s := newScopedTestResource153(scoped)
+		s.Spec.Data = "scoped"
+		_, err = svc.UpsertResource(ctx, s)
+		require.NoError(t, err)
+
+		gotU, err := svc.GetResource(ctx, unscoped)
+		require.NoError(t, err)
+		require.Equal(t, "unscoped", gotU.Spec.Data)
+		gotS, err := svc.GetResource(ctx, scoped)
+		require.NoError(t, err)
+		require.Equal(t, "scoped", gotS.Spec.Data)
+	})
+}
+
+func TestScopeAwareServiceWrapper_ConditionalUpdateResource(t *testing.T) {
+	t.Parallel()
+	svc := newScopeAwareWrapperForTest(t)
+	ctx := t.Context()
+
+	for _, tc := range []struct {
+		name string
+		qn   scopes.QualifiedName
+	}{
+		{"unscoped", scopes.QualifiedName{Name: "cu"}},
+		{"scoped", scopes.QualifiedName{Scope: "/security", Name: "cu"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			created, err := svc.CreateResource(ctx, newScopedTestResource153(tc.qn))
+			require.NoError(t, err)
+			revBefore := created.GetMetadata().GetRevision()
+
+			// A matching revision updates the body in place and rotates the revision.
+			created.Spec.Data = "updated"
+			updated, err := svc.ConditionalUpdateResource(ctx, created)
+			require.NoError(t, err)
+			require.Equal(t, "updated", updated.Spec.Data)
+			require.NotEqual(t, revBefore, updated.GetMetadata().GetRevision(), "update must rotate the revision")
+
+			got, err := svc.GetResource(ctx, tc.qn)
+			require.NoError(t, err)
+			require.Equal(t, "updated", got.Spec.Data)
+			require.Equal(t, tc.qn.Scope, got.GetScope())
+
+			// A stale revision is rejected and leaves the stored resource untouched.
+			updated.GetMetadata().SetRevision("not-the-right-revision")
+			updated.Spec.Data = "should-not-persist"
+			_, err = svc.ConditionalUpdateResource(ctx, updated)
+			require.True(t, trace.IsCompareFailed(err), "expected CompareFailed, got %v", err)
+
+			got, err = svc.GetResource(ctx, tc.qn)
+			require.NoError(t, err)
+			require.Equal(t, "updated", got.Spec.Data)
+		})
+	}
+
+	t.Run("missing resource errors", func(t *testing.T) {
+		_, err := svc.ConditionalUpdateResource(ctx, newScopedTestResource153(scopes.QualifiedName{Name: "ghost"}))
+		require.Error(t, err)
+	})
+}
+
+func TestScopeAwareServiceWrapper_GetResource(t *testing.T) {
+	t.Parallel()
+	svc := newScopeAwareWrapperForTest(t)
+	ctx := t.Context()
+
+	unscoped := scopes.QualifiedName{Name: "foo"}
+	scoped := scopes.QualifiedName{Scope: "/security/eu", Name: "foo"}
+	scopedOnly := scopes.QualifiedName{Scope: "/security", Name: "sec-only"}
+	for _, qn := range []scopes.QualifiedName{unscoped, scoped, scopedOnly} {
+		_, err := svc.CreateResource(ctx, newScopedTestResource153(qn))
+		require.NoError(t, err)
+	}
+
+	t.Run("unscoped", func(t *testing.T) {
+		got, err := svc.GetResource(ctx, unscoped)
+		require.NoError(t, err)
+		requireResourceBody(t, unscoped, got)
+	})
+
+	t.Run("scoped", func(t *testing.T) {
+		got, err := svc.GetResource(ctx, scoped)
+		require.NoError(t, err)
+		requireResourceBody(t, scoped, got)
+	})
+
+	t.Run("wrong scope is not found", func(t *testing.T) {
+		_, err := svc.GetResource(ctx, scopes.QualifiedName{Scope: "/other", Name: "foo"})
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+	})
+
+	t.Run("scoped resource does not leak into the unscoped range", func(t *testing.T) {
+		_, err := svc.GetResource(ctx, scopes.QualifiedName{Name: "sec-only"})
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+	})
+}
+
+func TestScopeAwareServiceWrapper_DeleteResource(t *testing.T) {
+	t.Parallel()
+	svc := newScopeAwareWrapperForTest(t)
+	ctx := t.Context()
+
+	t.Run("deletes only the addressed scope", func(t *testing.T) {
+		unscoped := scopes.QualifiedName{Name: "foo"}
+		scoped := scopes.QualifiedName{Scope: "/security", Name: "foo"}
+		for _, qn := range []scopes.QualifiedName{unscoped, scoped} {
+			_, err := svc.CreateResource(ctx, newScopedTestResource153(qn))
+			require.NoError(t, err)
+		}
+
+		// Deleting the unscoped resource leaves the scoped one intact.
+		require.NoError(t, svc.DeleteResource(ctx, unscoped))
+		_, err := svc.GetResource(ctx, unscoped)
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+		got, err := svc.GetResource(ctx, scoped)
+		require.NoError(t, err)
+		requireResourceBody(t, scoped, got)
+
+		// And deleting the scoped resource removes it too.
+		require.NoError(t, svc.DeleteResource(ctx, scoped))
+		_, err = svc.GetResource(ctx, scoped)
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+	})
+
+	t.Run("wrong scope does not delete", func(t *testing.T) {
+		qn := scopes.QualifiedName{Scope: "/eng", Name: "keep"}
+		_, err := svc.CreateResource(ctx, newScopedTestResource153(qn))
+		require.NoError(t, err)
+
+		// Deleting under a different scope must not remove it, and is NotFound.
+		err = svc.DeleteResource(ctx, scopes.QualifiedName{Scope: "/other", Name: "keep"})
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+		got, err := svc.GetResource(ctx, qn)
+		require.NoError(t, err)
+		requireResourceBody(t, qn, got)
+	})
+
+	t.Run("missing is not found", func(t *testing.T) {
+		err := svc.DeleteResource(ctx, scopes.QualifiedName{Name: "ghost"})
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+	})
+}
+
+func TestScopeAwareServiceWrapper_DeleteAllResources(t *testing.T) {
+	t.Parallel()
+	svc := newScopeAwareWrapperForTest(t)
+	ctx := t.Context()
+
+	for _, qn := range []scopes.QualifiedName{
+		{Name: "a"},
+		{Name: "b"},
+		{Scope: "/security", Name: "x"},
+		{Scope: "/security/eu", Name: "y"},
+	} {
+		_, err := svc.CreateResource(ctx, newScopedTestResource153(qn))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, svc.DeleteAllResources(ctx))
+
+	// Both the scoped and unscoped ranges are emptied.
+	page, next, err := svc.ListResources(ctx, 100, "")
+	require.NoError(t, err)
+	require.Empty(t, next)
+	require.Empty(t, page)
+}
+
+func TestScopeAwareServiceWrapper_ListResourcesWithFilter(t *testing.T) {
+	t.Parallel()
+	svc := newScopeAwareWrapperForTest(t)
+	ctx := t.Context()
+
+	created := []scopes.QualifiedName{
+		{Name: "keep-a"},
+		{Name: "drop-a"},
+		{Scope: "/security", Name: "keep-b"},
+		{Scope: "/security", Name: "drop-b"},
+		{Scope: "/security/eu", Name: "keep-c"},
+	}
+	for _, qn := range created {
+		_, err := svc.CreateResource(ctx, newScopedTestResource153(qn))
+		require.NoError(t, err)
+	}
+
+	keep := func(r *scopedTestResource153) bool {
+		return strings.HasPrefix(r.GetMetadata().GetName(), "keep-")
+	}
+	// The matcher must apply across both the unscoped and scoped ranges, with
+	// unscoped matches ordered first.
+	want := []scopes.QualifiedName{
+		{Name: "keep-a"},
+		{Scope: "/security", Name: "keep-b"},
+		{Scope: "/security/eu", Name: "keep-c"},
+	}
+
+	t.Run("single page", func(t *testing.T) {
+		got, next, err := svc.ListResourcesWithFilter(ctx, 100, "", keep)
+		require.NoError(t, err)
+		require.Empty(t, next)
+		require.Equal(t, want, names(got))
+	})
+
+	t.Run("paginated preserves filter and order across the boundary", func(t *testing.T) {
+		var paged []*scopedTestResource153
+		token := ""
+		for {
+			page, nextToken, err := svc.ListResourcesWithFilter(ctx, 1, token, keep)
+			require.NoError(t, err)
+			paged = append(paged, page...)
+			if nextToken == "" {
+				break
+			}
+			token = nextToken
+		}
+		require.Equal(t, want, names(paged))
+	})
+}
+
+func TestScopeAwareServiceWrapper_Resources(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		svc := newScopeAwareWrapperForTest(t)
+		require.Empty(t, collectStream(t, svc.Resources(t.Context(), "", "")))
+	})
+
+	t.Run("orders unscoped before scoped and honors the cursor range", func(t *testing.T) {
+		svc := newScopeAwareWrapperForTest(t)
+		ctx := t.Context()
+
+		want := []scopes.QualifiedName{
+			{Name: "a"},
+			{Name: "b"},
+			{Scope: "/security", Name: "x"},
+			{Scope: "/security/eu", Name: "y"},
+		}
+		for _, qn := range want {
+			_, err := svc.CreateResource(ctx, newScopedTestResource153(qn))
+			require.NoError(t, err)
+		}
+
+		// The full range yields everything, unscoped first.
+		require.Equal(t, want, names(collectStream(t, svc.Resources(ctx, "", ""))))
+
+		// The scoped-start cursor is the boundary between the unscoped and scoped
+		// halves of the unified stream.
+		unscopedOnly := collectStream(t, svc.Resources(ctx, "", scopes.ResourceCursorScopedStart()))
+		require.Equal(t, []scopes.QualifiedName{{Name: "a"}, {Name: "b"}}, names(unscopedOnly))
+
+		scopedOnly := collectStream(t, svc.Resources(ctx, scopes.ResourceCursorScopedStart(), ""))
+		require.Equal(t, []scopes.QualifiedName{
+			{Scope: "/security", Name: "x"},
+			{Scope: "/security/eu", Name: "y"},
+		}, names(scopedOnly))
+	})
+}
+
+func TestScopeAwareServiceWrapper_MakeBackendItem(t *testing.T) {
+	t.Parallel()
+	svc := newScopeAwareWrapperForTest(t)
+
+	for _, tc := range []struct {
+		name string
+		qn   scopes.QualifiedName
+	}{
+		{"unscoped", scopes.QualifiedName{Name: "foo"}},
+		{"scoped", scopes.QualifiedName{Scope: "/security", Name: "foo"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			item, err := svc.MakeBackendItem(newScopedTestResource153(tc.qn))
+			require.NoError(t, err)
+
+			// The item is keyed exactly where BackendKey reports.
+			wantKey, err := svc.BackendKey(tc.qn)
+			require.NoError(t, err)
+			require.Equal(t, wantKey.String(), item.Key.String())
+
+			// The stored value is the marshaled body and round-trips.
+			require.NotEmpty(t, item.Value)
+			decoded, err := unmarshalScopedResource153(item.Value)
+			require.NoError(t, err)
+			requireResourceBody(t, tc.qn, decoded)
+		})
+	}
+}
+
+func TestScopeAwareServiceWrapper_BackendKey(t *testing.T) {
+	t.Parallel()
+	svc := newScopeAwareWrapperForTest(t)
+
+	t.Run("unscoped", func(t *testing.T) {
+		key, err := svc.BackendKey(scopes.QualifiedName{Name: "foo"})
+		require.NoError(t, err)
+		require.Equal(t, backend.NewKey(testUnscopedPrefix, "foo").String(), key.String())
+	})
+
+	t.Run("scoped is namespaced by encoded scope", func(t *testing.T) {
+		encodedScope, err := scopes.EncodeForKey("/security")
+		require.NoError(t, err)
+		key, err := svc.BackendKey(scopes.QualifiedName{Scope: "/security", Name: "foo"})
+		require.NoError(t, err)
+		require.Equal(t,
+			backend.NewKey(testScopedTopPrefix, testUnscopedPrefix, encodedScope, "foo").String(),
+			key.String(),
+		)
+	})
+}


### PR DESCRIPTION
Backports #67732
Backports #67682 
Backports #68042 
Backports #68096 

Replaces https://github.com/gravitational/teleport/pull/67984