### PR TITLE
SAML: Sanitize connector creation errors

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -2162,10 +2162,7 @@ func (c *Client) GetSAMLConnector(ctx context.Context, name string, withSecrets 
 
 // GetSAMLConnectorWithValidationOptions returns a SAML connector by name.
 func (c *Client) GetSAMLConnectorWithValidationOptions(ctx context.Context, name string, withSecrets bool, opts ...types.SAMLConnectorValidationOption) (types.SAMLConnector, error) {
-	var options types.SAMLConnectorValidationOptions
-	for _, opt := range opts {
-		opt(&options)
-	}
+	options := types.NewSAMLConnectorValidationOptions(opts)
 
 	if name == "" {
 		return nil, trace.BadParameter("cannot get SAML Connector, missing name")
@@ -2193,10 +2190,7 @@ func (c *Client) GetSAMLConnectors(ctx context.Context, withSecrets bool) ([]typ
 //
 // Deprecated: Use [Client.ListSAMLConnectorsWithOptions] instead.
 func (c *Client) GetSAMLConnectorsWithValidationOptions(ctx context.Context, withSecrets bool, opts ...types.SAMLConnectorValidationOption) ([]types.SAMLConnector, error) {
-	var options types.SAMLConnectorValidationOptions
-	for _, opt := range opts {
-		opt(&options)
-	}
+	options := types.NewSAMLConnectorValidationOptions(opts)
 
 	req := &types.ResourcesWithSecretsRequest{
 		WithSecrets:                withSecrets,
@@ -2217,10 +2211,7 @@ func (c *Client) GetSAMLConnectorsWithValidationOptions(ctx context.Context, wit
 // ListSAMLConnectorsWithOptions returns a page of valid registered SAML connectors.
 // withSecrets adds or removes client secret from return results.
 func (c *Client) ListSAMLConnectorsWithOptions(ctx context.Context, limit int, start string, withSecrets bool, opts ...types.SAMLConnectorValidationOption) ([]types.SAMLConnector, string, error) {
-	var options types.SAMLConnectorValidationOptions
-	for _, opt := range opts {
-		opt(&options)
-	}
+	options := types.NewSAMLConnectorValidationOptions(opts)
 
 	resp, err := c.grpc.ListSAMLConnectors(ctx, &proto.ListSAMLConnectorsRequest{
 		PageSize:     int32(limit),

--- a/api/types/saml.go
+++ b/api/types/saml.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"encoding/json"
+	"net/http"
 	"slices"
 	"strings"
 	"time"
@@ -784,6 +785,18 @@ type SAMLConnectorValidationOptions struct {
 	// endpoints like /webapi/ping which must not hang or fail.
 	NoFollowURLs bool
 	WithSecrets  bool
+	// HTTPClient used to fetch entity descriptor during the validation.
+	HTTPClient *http.Client
+}
+
+func NewSAMLConnectorValidationOptions(opts []SAMLConnectorValidationOption) SAMLConnectorValidationOptions {
+	options := SAMLConnectorValidationOptions{
+		HTTPClient: http.DefaultClient,
+	}
+	for _, o := range opts {
+		o(&options)
+	}
+	return options
 }
 
 // SAMLConnectorValidationOption is an option for validation of SAML connectors.
@@ -802,5 +815,13 @@ func SAMLConnectorValidationFollowURLs(follow bool) SAMLConnectorValidationOptio
 func SAMLConnectorValidationWithSecrets(withSecrets bool) SAMLConnectorValidationOption {
 	return func(opts *SAMLConnectorValidationOptions) {
 		opts.WithSecrets = withSecrets
+	}
+}
+
+// SAMLConnectorValidationHTTPClient sets HTTP client used to fetch entity descriptor during the
+// validation.
+func SAMLConnectorValidationHTTPClient(httpClient *http.Client) SAMLConnectorValidationOption {
+	return func(opts *SAMLConnectorValidationOptions) {
+		opts.HTTPClient = httpClient
 	}
 }

--- a/api/types/saml.go
+++ b/api/types/saml.go
@@ -785,14 +785,12 @@ type SAMLConnectorValidationOptions struct {
 	// endpoints like /webapi/ping which must not hang or fail.
 	NoFollowURLs bool
 	WithSecrets  bool
-	// HTTPClient used to fetch entity descriptor during the validation.
-	HTTPClient *http.Client
+	// Transport used to fetch entity descriptor during the validation.
+	Transport http.RoundTripper
 }
 
 func NewSAMLConnectorValidationOptions(opts []SAMLConnectorValidationOption) SAMLConnectorValidationOptions {
-	options := SAMLConnectorValidationOptions{
-		HTTPClient: http.DefaultClient,
-	}
+	options := SAMLConnectorValidationOptions{}
 	for _, o := range opts {
 		o(&options)
 	}
@@ -818,10 +816,10 @@ func SAMLConnectorValidationWithSecrets(withSecrets bool) SAMLConnectorValidatio
 	}
 }
 
-// SAMLConnectorValidationHTTPClient sets HTTP client used to fetch entity descriptor during the
-// validation.
-func SAMLConnectorValidationHTTPClient(httpClient *http.Client) SAMLConnectorValidationOption {
+// SAMLConnectorValidationHTTPTransport sets HTTP transport used to fetch entity descriptor during
+// the validation.
+func SAMLConnectorValidationHTTPTransport(transport http.RoundTripper) SAMLConnectorValidationOption {
 	return func(opts *SAMLConnectorValidationOptions) {
-		opts.HTTPClient = httpClient
+		opts.Transport = transport
 	}
 }

--- a/api/types/saml.go
+++ b/api/types/saml.go
@@ -789,6 +789,7 @@ type SAMLConnectorValidationOptions struct {
 	Transport http.RoundTripper
 }
 
+// NewSAMLConnectorValidationOptions creates SAMLConnectorValidationOptions from provided options.
 func NewSAMLConnectorValidationOptions(opts []SAMLConnectorValidationOption) SAMLConnectorValidationOptions {
 	options := SAMLConnectorValidationOptions{}
 	for _, o := range opts {

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1561,7 +1561,7 @@ func TestSAMLCreateConnectorErrorSanitization(t *testing.T) {
 
 	samlConnector, err := types.NewSAMLConnector("fetch-entity-descriptor-url-errors", types.SAMLConnectorSpecV2{
 		AssertionConsumerService: "https://teleport.example.com/v1/webapi/saml/acs",
-		EntityDescriptorURL:      server.URL + "/metadata?token=secret",
+		EntityDescriptorURL:      server.URL + "/test_metadata",
 		AttributesToRoles: []types.AttributeMapping{
 			{Name: "groups", Value: "admin", Roles: []string{role.GetName()}},
 		},

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -28,6 +28,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"sort"
 	"strings"
@@ -1533,6 +1535,43 @@ func TestOIDCConnector(t *testing.T) {
 		require.IsType(t, &apievents.OIDCConnectorDelete{}, s.mockEmitter.LastEvent())
 		require.Equal(t, events.OIDCConnectorDeletedEvent, s.mockEmitter.LastEvent().GetType())
 	})
+}
+
+func TestSAMLCreateConnectorErrorSanitization(t *testing.T) {
+	t.Parallel()
+
+	s := newAuthSuite(t)
+	t.Cleanup(func() { _ = s.a.Close() })
+
+	ctx := t.Context()
+
+	role, err := types.NewRole("dummy", types.RoleSpecV6{})
+	require.NoError(t, err)
+	role, err = s.a.CreateRole(ctx, role)
+	require.NoError(t, err)
+
+	const slowPath = "/slow"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == slowPath {
+			time.Sleep(1 * time.Hour)
+		}
+		http.Error(w, "upstream response should not be exposed", http.StatusForbidden)
+	}))
+	t.Cleanup(server.Close)
+
+	samlConnector, err := types.NewSAMLConnector("fetch-entity-descriptor-url-errors", types.SAMLConnectorSpecV2{
+		AssertionConsumerService: "https://teleport.example.com/v1/webapi/saml/acs",
+		EntityDescriptorURL:      server.URL + "/metadata?token=secret",
+		AttributesToRoles: []types.AttributeMapping{
+			{Name: "groups", Value: "admin", Roles: []string{role.GetName()}},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = s.a.CreateSAMLConnector(ctx, samlConnector)
+	require.ErrorIs(t, err, services.ErrFailedToFetchEntityDescriptor)
+	// Make sure the error doesn't leak any extra info about the download failure.
+	require.Equal(t, services.ErrFailedToFetchEntityDescriptor.Error(), err.Error())
 }
 
 func TestSAMLConnector(t *testing.T) {

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1540,6 +1540,19 @@ func TestOIDCConnector(t *testing.T) {
 func TestSAMLCreateConnectorErrorSanitization(t *testing.T) {
 	t.Parallel()
 
+	const loginEntityDescriptor = `
+		<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://login.idp.test/metadata">
+			<IDPSSODescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+				<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://login.idp.test/sso/saml"></SingleSignOnService>
+			</IDPSSODescriptor>
+		</EntityDescriptor>`
+	const mfaEntityDescriptor = `
+		<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://mfa.idp.test/metadata">
+			<IDPSSODescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+				<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://mfa.idp.test/sso/saml"></SingleSignOnService>
+			</IDPSSODescriptor>
+		</EntityDescriptor>`
+
 	s := newAuthSuite(t)
 	t.Cleanup(func() { _ = s.a.Close() })
 
@@ -1550,18 +1563,24 @@ func TestSAMLCreateConnectorErrorSanitization(t *testing.T) {
 	role, err = s.a.CreateRole(ctx, role)
 	require.NoError(t, err)
 
-	const slowPath = "/slow"
+	const loginMetadataPath = "/test_metadata_login"
+	const mfaMetadataPath = "/test_metadata_mfa"
+	const badMetadtaPath = "/test_metadata_bad"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == slowPath {
-			time.Sleep(1 * time.Hour)
+		switch r.URL.Path {
+		case loginMetadataPath:
+			w.Write([]byte(loginEntityDescriptor))
+		case mfaMetadataPath:
+			w.Write([]byte(mfaEntityDescriptor))
+		default:
+			http.Error(w, "upstream response should not be exposed", http.StatusForbidden)
 		}
-		http.Error(w, "upstream response should not be exposed", http.StatusForbidden)
 	}))
 	t.Cleanup(server.Close)
 
 	samlConnector, err := types.NewSAMLConnector("fetch-entity-descriptor-url-errors", types.SAMLConnectorSpecV2{
 		AssertionConsumerService: "https://teleport.example.com/v1/webapi/saml/acs",
-		EntityDescriptorURL:      server.URL + "/test_metadata",
+		EntityDescriptorURL:      server.URL + badMetadtaPath,
 		AttributesToRoles: []types.AttributeMapping{
 			{Name: "groups", Value: "admin", Roles: []string{role.GetName()}},
 		},
@@ -1572,6 +1591,29 @@ func TestSAMLCreateConnectorErrorSanitization(t *testing.T) {
 	require.ErrorIs(t, err, services.ErrFailedToFetchEntityDescriptor)
 	// Make sure the error doesn't leak any extra info about the download failure.
 	require.Equal(t, services.ErrFailedToFetchEntityDescriptor.Error(), err.Error())
+
+	// Let's create a valid connector to check updates.
+	samlConnector.SetEntityDescriptorURL(server.URL + loginMetadataPath)
+	createdSAMLConnector, err := s.a.CreateSAMLConnector(ctx, samlConnector)
+	require.NoError(t, err)
+
+	// Now let's check MFA entity descriptor fetching errors sanitization.
+	createdSAMLConnector.SetMFASettings(&types.SAMLConnectorMFASettings{
+		Enabled:             true,
+		EntityDescriptorUrl: server.URL + badMetadtaPath,
+	})
+	_, err = s.a.UpdateSAMLConnector(ctx, createdSAMLConnector)
+	require.ErrorIs(t, err, services.ErrFailedToFetchEntityDescriptor)
+	// Make sure the error doesn't leak any extra info about the download failure.
+	require.Equal(t, services.ErrFailedToFetchEntityDescriptor.Error(), err.Error())
+
+	// Verify it passes when URLs are OK.
+	createdSAMLConnector.SetMFASettings(&types.SAMLConnectorMFASettings{
+		Enabled:             true,
+		EntityDescriptorUrl: server.URL + mfaMetadataPath,
+	})
+	_, err = s.a.UpdateSAMLConnector(ctx, createdSAMLConnector)
+	require.NoError(t, err)
 }
 
 func TestSAMLConnector(t *testing.T) {

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1588,9 +1588,9 @@ func TestSAMLCreateConnectorErrorSanitization(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = s.a.CreateSAMLConnector(ctx, samlConnector)
-	require.ErrorIs(t, err, services.ErrFailedToFetchEntityDescriptor)
+	require.ErrorIs(t, err, services.ErrFailedToFetchOrParseEntityDescriptor)
 	// Make sure the error doesn't leak any extra info about the download failure.
-	require.Equal(t, services.ErrFailedToFetchEntityDescriptor.Error(), err.Error())
+	require.Equal(t, services.ErrFailedToFetchOrParseEntityDescriptor.Error(), err.Error())
 
 	// Let's create a valid connector to check updates.
 	samlConnector.SetEntityDescriptorURL(server.URL + loginMetadataPath)
@@ -1603,9 +1603,9 @@ func TestSAMLCreateConnectorErrorSanitization(t *testing.T) {
 		EntityDescriptorUrl: server.URL + badMetadtaPath,
 	})
 	_, err = s.a.UpdateSAMLConnector(ctx, createdSAMLConnector)
-	require.ErrorIs(t, err, services.ErrFailedToFetchEntityDescriptor)
+	require.ErrorIs(t, err, services.ErrFailedToFetchOrParseEntityDescriptor)
 	// Make sure the error doesn't leak any extra info about the download failure.
-	require.Equal(t, services.ErrFailedToFetchEntityDescriptor.Error(), err.Error())
+	require.Equal(t, services.ErrFailedToFetchOrParseEntityDescriptor.Error(), err.Error())
 
 	// Verify it passes when URLs are OK.
 	createdSAMLConnector.SetMFASettings(&types.SAMLConnectorMFASettings{

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1565,7 +1565,7 @@ func TestSAMLCreateConnectorErrorSanitization(t *testing.T) {
 
 	const loginMetadataPath = "/test_metadata_login"
 	const mfaMetadataPath = "/test_metadata_mfa"
-	const badMetadtaPath = "/test_metadata_bad"
+	const badMetadataPath = "/test_metadata_bad"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case loginMetadataPath:
@@ -1580,7 +1580,7 @@ func TestSAMLCreateConnectorErrorSanitization(t *testing.T) {
 
 	samlConnector, err := types.NewSAMLConnector("fetch-entity-descriptor-url-errors", types.SAMLConnectorSpecV2{
 		AssertionConsumerService: "https://teleport.example.com/v1/webapi/saml/acs",
-		EntityDescriptorURL:      server.URL + badMetadtaPath,
+		EntityDescriptorURL:      server.URL + badMetadataPath,
 		AttributesToRoles: []types.AttributeMapping{
 			{Name: "groups", Value: "admin", Roles: []string{role.GetName()}},
 		},
@@ -1600,7 +1600,7 @@ func TestSAMLCreateConnectorErrorSanitization(t *testing.T) {
 	// Now let's check MFA entity descriptor fetching errors sanitization.
 	createdSAMLConnector.SetMFASettings(&types.SAMLConnectorMFASettings{
 		Enabled:             true,
-		EntityDescriptorUrl: server.URL + badMetadtaPath,
+		EntityDescriptorUrl: server.URL + badMetadataPath,
 	})
 	_, err = s.a.UpdateSAMLConnector(ctx, createdSAMLConnector)
 	require.ErrorIs(t, err, services.ErrFailedToFetchOrParseEntityDescriptor)

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -44,10 +44,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-// ErrFailedToFetchEntityDescriptor is returned on any error while downloading SAML entity
-// descriptor in entity_descriptor_url is set during the connector validation.
-var ErrFailedToFetchEntityDescriptor = &trace.BadParameterError{Message: "failed to fetch entity descriptor"}
-
 type SAMLConnectorGetter interface {
 	GetSAMLConnector(ctx context.Context, id string, withSecrets bool) (types.SAMLConnector, error)
 	GetSAMLConnectorWithValidationOptions(ctx context.Context, id string, withSecrets bool, opts ...types.SAMLConnectorValidationOption) (types.SAMLConnector, error)
@@ -61,6 +57,10 @@ const (
 	// ErrMsgHowToFixMissingOAuthCreds is the error message displayed when validation of the OAuth credentials for secret refill fails.
 	ErrMsgHowToFixMissingOAuthCreds = "You must specify the OAuth credentials (obtain the existing one with `tctl get saml --with-secrets`)."
 )
+
+// ErrFailedToFetchEntityDescriptor is returned on any error while downloading SAML entity
+// descriptor in entity_descriptor_url is set during the connector validation.
+var ErrFailedToFetchEntityDescriptor = &trace.BadParameterError{Message: "failed to fetch entity descriptor"}
 
 // ValidateSAMLConnector validates the SAMLConnector and sets default values.
 // If a remote to fetch roles is specified, roles will be validated to exist.
@@ -287,7 +287,7 @@ func getEntityDescriptor(ctx context.Context, params getEntityDescriptorParams) 
 
 	entityDescriptor := &samltypes.EntityDescriptor{}
 	if err := xml.Unmarshal([]byte(rawEntityDescriptor), entityDescriptor); err != nil {
-		return "", nil, trace.Wrap(err, "failed to parse entity_descriptor XML")
+		return "", nil, trace.BadParameter("failed to parse entity_descriptor XML: %s", err)
 	}
 	return rawEntityDescriptor, entityDescriptor, nil
 }

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -24,6 +24,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/xml"
+	"errors"
 	"log/slog"
 	"net/http"
 	"slices"
@@ -253,13 +254,26 @@ func getEntityDescriptor(ctx context.Context, params getEntityDescriptorParams) 
 	}()
 
 	if url != "" && !params.Options.NoFollowURLs {
+		httpClient := &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				if len(via) != 0 && strings.EqualFold(via[len(via)-1].URL.Scheme, "https") && !strings.EqualFold(req.URL.Scheme, "https") {
+					return errors.New("connection downgrade not allowed for URL: " + req.URL.String())
+				}
+				if len(via) >= 10 {
+					return errors.New("stopped after 10 redirects")
+				}
+				return nil
+			},
+			Transport: params.Options.Transport,
+		}
+
 		ctx, cancel := context.WithTimeout(ctx, defaults.DefaultIOTimeout)
 		defer cancel()
 		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 		if err != nil {
 			return "", nil, trace.Wrap(err)
 		}
-		resp, err := params.Options.HTTPClient.Do(req)
+		resp, err := httpClient.Do(req)
 		if err != nil {
 			return "", nil, trace.Wrap(err)
 		}

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -59,9 +59,9 @@ const (
 	ErrMsgHowToFixMissingOAuthCreds = "You must specify the OAuth credentials (obtain the existing one with `tctl get saml --with-secrets`)."
 )
 
-// ErrFailedToFetchEntityDescriptor is returned on any error while downloading SAML entity
-// descriptor in entity_descriptor_url is set during the connector validation.
-var ErrFailedToFetchEntityDescriptor = &trace.BadParameterError{Message: "failed to fetch entity descriptor"}
+// ErrFailedToFetchOrParseEntityDescriptor is returned on any error while downloading and parsing
+// SAML entity descriptor if entity_descriptor_url is set during the connector validation.
+var ErrFailedToFetchOrParseEntityDescriptor = &trace.BadParameterError{Message: "failed to fetch or parse entity descriptor"}
 
 // ValidateSAMLConnector validates the SAMLConnector and sets default values.
 // If a remote to fetch roles is specified, roles will be validated to exist.
@@ -250,7 +250,7 @@ func getEntityDescriptor(ctx context.Context, params getEntityDescriptorParams) 
 		} else {
 			log.ErrorContext(ctx, "Failed to fetch or parse SAML entity descriptor", "error", err)
 		}
-		err = trace.Wrap(ErrFailedToFetchEntityDescriptor)
+		err = trace.Wrap(ErrFailedToFetchOrParseEntityDescriptor)
 	}()
 
 	if url != "" && !params.Options.NoFollowURLs {

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -226,7 +226,7 @@ func getEntityDescriptor(ctx context.Context, params getEntityDescriptorParams) 
 	if params.MFA {
 		mfa := connector.GetMFASettings()
 		if mfa == nil {
-			return "", nil, trace.BadParameter("MFA set and MFA settings missing in the connector")
+			return "", nil, trace.BadParameter("MFA set and MFA settings missing in the connector (this is a bug)")
 		}
 		rawEntityDescriptor, url = mfa.EntityDescriptor, mfa.EntityDescriptorUrl
 	}

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -44,6 +44,10 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+// ErrFailedToFetchEntityDescriptor is returned on any error while downloading SAML entity
+// descriptor in entity_descriptor_url is set during the connector validation.
+var ErrFailedToFetchEntityDescriptor = &trace.BadParameterError{Message: "failed to fetch entity descriptor"}
+
 type SAMLConnectorGetter interface {
 	GetSAMLConnector(ctx context.Context, id string, withSecrets bool) (types.SAMLConnector, error)
 	GetSAMLConnectorWithValidationOptions(ctx context.Context, id string, withSecrets bool, opts ...types.SAMLConnectorValidationOption) (types.SAMLConnector, error)
@@ -61,10 +65,9 @@ const (
 // ValidateSAMLConnector validates the SAMLConnector and sets default values.
 // If a remote to fetch roles is specified, roles will be validated to exist.
 func ValidateSAMLConnector(sc types.SAMLConnector, rg RoleGetter, opts ...types.SAMLConnectorValidationOption) error {
-	var options types.SAMLConnectorValidationOptions
-	for _, opt := range opts {
-		opt(&options)
-	}
+	ctx := context.TODO()
+	options := types.NewSAMLConnectorValidationOptions(opts)
+	log := slog.With(teleport.ComponentKey, teleport.ComponentSAML, "saml_connector", sc.GetName())
 
 	// WARNING: this validation runs on the read and write paths, which means it
 	// is NOT safe to add new validations here that could invalidate existing
@@ -86,66 +89,25 @@ func ValidateSAMLConnector(sc types.SAMLConnector, rg RoleGetter, opts ...types.
 		}
 	}
 
-	getEntityDescriptorFromURL := func(url string) (string, error) {
-		ctx, cancel := context.WithTimeout(context.TODO(), defaults.DefaultIOTimeout)
-		defer cancel()
-		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-		if err != nil {
-			return "", trace.Wrap(err)
-		}
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			return "", trace.WrapWithMessage(err, "unable to fetch entity descriptor from %v for SAML connector %v", url, sc.GetName())
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return "", trace.BadParameter("status code %v when fetching from %v for SAML connector %v", resp.StatusCode, url, sc.GetName())
-		}
-		body, err := utils.ReadAtMost(resp.Body, teleport.MaxHTTPResponseSize)
-		if err != nil {
-			return "", trace.Wrap(err)
-		}
-		return string(body), nil
+	rawEntityDescriptor, entityDescriptor, err := getEntityDescriptor(ctx, getEntityDescriptorParams{
+		Log:       log,
+		MFA:       false,
+		Connector: sc,
+		Options:   options,
+	})
+	if err != nil {
+		return trace.Wrap(err)
 	}
+	sc.SetEntityDescriptor(rawEntityDescriptor)
 
-	getEntityDescriptorMetadata := func(ed string) (*samltypes.EntityDescriptor, error) {
-		metadata := &samltypes.EntityDescriptor{}
-		if err := xml.Unmarshal([]byte(ed), metadata); err != nil {
-			return nil, trace.Wrap(err, "failed to parse entity_descriptor")
-		}
-		return metadata, nil
-	}
-
-	// Validate standard settings.
-	if url := sc.GetEntityDescriptorURL(); url != "" && !options.NoFollowURLs {
-		entityDescriptor, err := getEntityDescriptorFromURL(url)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		sc.SetEntityDescriptor(entityDescriptor)
-		slog.DebugContext(context.Background(), " Successfully fetched entity descriptor for connector",
-			teleport.ComponentKey, teleport.ComponentSAML,
-			"entity_descriptor_url", url,
-			"connector", sc.GetName(),
-		)
-	}
-
-	if ed := sc.GetEntityDescriptor(); ed != "" {
-		md, err := getEntityDescriptorMetadata(ed)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		sc.SetIssuer(md.EntityID)
-		if md.IDPSSODescriptor != nil && len(md.IDPSSODescriptor.SingleSignOnServices) > 0 {
-			metadataSsoUrl := md.IDPSSODescriptor.SingleSignOnServices[0].Location
+	if ed := entityDescriptor; ed != nil {
+		sc.SetIssuer(ed.EntityID)
+		if ed.IDPSSODescriptor != nil && len(ed.IDPSSODescriptor.SingleSignOnServices) > 0 {
+			metadataSsoUrl := ed.IDPSSODescriptor.SingleSignOnServices[0].Location
 			if sc.GetSSO() != "" && sc.GetSSO() != metadataSsoUrl {
-				slog.WarnContext(
-					context.Background(),
+				log.WarnContext(ctx,
 					"Connector has set SSO URL, but it does not match the one found in IDP metadata. Overwriting with the IDP metadata SSO URL.",
-					"connector_name", sc.GetName(), "connector_sso_url", sc.GetSSO(), "idp_metadata_sso_url", metadataSsoUrl,
+					"connector_sso_url", sc.GetSSO(), "idp_metadata_sso_url", metadataSsoUrl,
 				)
 			}
 			sc.SetSSO(metadataSsoUrl)
@@ -187,7 +149,7 @@ func ValidateSAMLConnector(sc types.SAMLConnector, rg RoleGetter, opts ...types.
 					// Role is a template so we cannot check for existence of that literal name.
 					continue
 				}
-				_, err := rg.GetRole(context.Background(), role)
+				_, err := rg.GetRole(ctx, role)
 				switch {
 				case trace.IsNotFound(err):
 					return trace.BadParameter("role %q specified in attributes_to_roles not found", role)
@@ -207,33 +169,32 @@ func ValidateSAMLConnector(sc types.SAMLConnector, rg RoleGetter, opts ...types.
 
 	// Validate MFA settings.
 	if mfa := sc.GetMFASettings(); mfa != nil {
+		var mfaEntityDescriptor *samltypes.EntityDescriptor
 		if mfa.EntityDescriptorUrl != "" {
-			switch {
-			case mfa.EntityDescriptorUrl == sc.GetEntityDescriptorURL():
+			if mfa.EntityDescriptorUrl == sc.GetEntityDescriptorURL() {
 				// we got the entity descriptor above, skip the redundant round trip.
 				mfa.EntityDescriptor = sc.GetEntityDescriptor()
-			case !options.NoFollowURLs:
-				entityDescriptor, err := getEntityDescriptorFromURL(mfa.EntityDescriptorUrl)
+			} else {
+				mfa.EntityDescriptor, mfaEntityDescriptor, err = getEntityDescriptor(ctx, getEntityDescriptorParams{
+					Log:       log,
+					MFA:       true,
+					Connector: sc,
+					Options:   options,
+				})
 				if err != nil {
 					return trace.Wrap(err)
 				}
-				mfa.EntityDescriptor = entityDescriptor
 			}
 		}
-		if mfa.EntityDescriptor != "" {
-			md, err := getEntityDescriptorMetadata(mfa.EntityDescriptor)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-
-			mfa.Issuer = md.EntityID
-			if md.IDPSSODescriptor != nil && len(md.IDPSSODescriptor.SingleSignOnServices) > 0 {
-				mfa.Sso = md.IDPSSODescriptor.SingleSignOnServices[0].Location
+		if ed := mfaEntityDescriptor; ed != nil {
+			mfa.Issuer = ed.EntityID
+			if ed.IDPSSODescriptor != nil && len(ed.IDPSSODescriptor.SingleSignOnServices) > 0 {
+				mfa.Sso = ed.IDPSSODescriptor.SingleSignOnServices[0].Location
 			}
 		}
 		if preferredRequestBinding == types.SAMLRequestHTTPPostBinding {
-			slog.WarnContext(context.Background(), "SSO MFA does not support http-post binding request and will use the default http-redirect binding request",
-				teleport.ComponentKey, teleport.ComponentSAML,
+			log.WarnContext(ctx,
+				"SSO MFA does not support http-post binding request and will use the default http-redirect binding request",
 				"preferred_request_binding", preferredRequestBinding,
 			)
 		}
@@ -244,14 +205,91 @@ func ValidateSAMLConnector(sc types.SAMLConnector, rg RoleGetter, opts ...types.
 	// a valid authentication mechanism must be available. Proposed solution is to inject the
 	// token provider and ensure a valid azcore.TokenCredential can be resolved.
 
-	slog.DebugContext(context.Background(), "connector validated",
-		teleport.ComponentKey, teleport.ComponentSAML,
+	log.DebugContext(ctx, "Connector validated",
 		"sso", sc.GetSSO(),
 		"issuer", sc.GetIssuer(),
 		"acs", sc.GetAssertionConsumerService(),
 	)
-
 	return nil
+}
+
+type getEntityDescriptorParams struct {
+	Log       *slog.Logger
+	MFA       bool
+	Connector types.SAMLConnector
+	Options   types.SAMLConnectorValidationOptions
+}
+
+func getEntityDescriptor(ctx context.Context, params getEntityDescriptorParams) (raw string, _ *samltypes.EntityDescriptor, err error) {
+	connector := params.Connector
+	rawEntityDescriptor, url := connector.GetEntityDescriptor(), connector.GetEntityDescriptorURL()
+	if params.MFA {
+		mfa := connector.GetMFASettings()
+		if mfa == nil {
+			return "", nil, trace.BadParameter("MFA set and MFA settings missing in the connector")
+		}
+		rawEntityDescriptor, url = mfa.EntityDescriptor, mfa.EntityDescriptorUrl
+	}
+
+	log := params.Log
+	switch {
+	case params.MFA && url != "":
+		log = log.With("mfa_entity_descriptor_url", url)
+	case url != "":
+		log = log.With("entity_descriptor_url", url)
+	}
+
+	// Sanitize the error message to mitigate potential SSRF attacks attempted by SAML admins.
+	defer func() {
+		if url == "" || params.Options.NoFollowURLs || err == nil {
+			return
+		}
+		if params.MFA {
+			log.ErrorContext(ctx, "Failed to fetch or parse SAML MFA entity descriptor", "error", err)
+		} else {
+			log.ErrorContext(ctx, "Failed to fetch or parse SAML entity descriptor", "error", err)
+		}
+		err = trace.Wrap(ErrFailedToFetchEntityDescriptor)
+	}()
+
+	if url != "" && !params.Options.NoFollowURLs {
+		ctx, cancel := context.WithTimeout(ctx, defaults.DefaultIOTimeout)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+		if err != nil {
+			return "", nil, trace.Wrap(err)
+		}
+		resp, err := params.Options.HTTPClient.Do(req)
+		if err != nil {
+			return "", nil, trace.Wrap(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return "", nil, trace.Errorf("unexpected status code %d", resp.StatusCode)
+		}
+		body, err := utils.ReadAtMost(resp.Body, teleport.MaxHTTPResponseSize)
+		if err != nil {
+			return "", nil, trace.Wrap(err)
+		}
+
+		rawEntityDescriptor = string(body)
+		if params.MFA {
+			log.DebugContext(ctx, "Successfully fetched MFA entity descriptor for connector")
+		} else {
+			log.DebugContext(ctx, "Successfully fetched entity descriptor for connector")
+		}
+	}
+
+	if rawEntityDescriptor == "" {
+		return "", nil, nil
+	}
+
+	entityDescriptor := &samltypes.EntityDescriptor{}
+	if err := xml.Unmarshal([]byte(rawEntityDescriptor), entityDescriptor); err != nil {
+		return "", nil, trace.Wrap(err, "failed to parse entity_descriptor XML")
+	}
+	return rawEntityDescriptor, entityDescriptor, nil
 }
 
 // GetAttributeNames returns a list of claim names from the claim values

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -177,7 +177,8 @@ func ValidateSAMLConnector(sc types.SAMLConnector, rg RoleGetter, opts ...types.
 			mfaEntityDescriptor = entityDescriptor
 		}
 		if mfaEntityDescriptor == nil {
-			mfa.EntityDescriptor, mfaEntityDescriptor, err = getEntityDescriptor(ctx, getEntityDescriptorParams{
+			var rawMFAEntityDescriptor string
+			rawMFAEntityDescriptor, mfaEntityDescriptor, err = getEntityDescriptor(ctx, getEntityDescriptorParams{
 				Log:       log,
 				MFA:       true,
 				Connector: sc,
@@ -186,6 +187,7 @@ func ValidateSAMLConnector(sc types.SAMLConnector, rg RoleGetter, opts ...types.
 			if err != nil {
 				return trace.Wrap(err)
 			}
+			mfa.EntityDescriptor = rawMFAEntityDescriptor
 		}
 		if ed := mfaEntityDescriptor; ed != nil {
 			mfa.Issuer = ed.EntityID

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -170,20 +170,20 @@ func ValidateSAMLConnector(sc types.SAMLConnector, rg RoleGetter, opts ...types.
 	// Validate MFA settings.
 	if mfa := sc.GetMFASettings(); mfa != nil {
 		var mfaEntityDescriptor *samltypes.EntityDescriptor
-		if mfa.EntityDescriptorUrl != "" {
-			if mfa.EntityDescriptorUrl == sc.GetEntityDescriptorURL() {
-				// we got the entity descriptor above, skip the redundant round trip.
-				mfa.EntityDescriptor = sc.GetEntityDescriptor()
-			} else {
-				mfa.EntityDescriptor, mfaEntityDescriptor, err = getEntityDescriptor(ctx, getEntityDescriptorParams{
-					Log:       log,
-					MFA:       true,
-					Connector: sc,
-					Options:   options,
-				})
-				if err != nil {
-					return trace.Wrap(err)
-				}
+		if mfa.EntityDescriptorUrl != "" && mfa.EntityDescriptorUrl == sc.GetEntityDescriptorURL() {
+			// we got the entity descriptor above, skip the redundant round trip.
+			mfa.EntityDescriptor = rawEntityDescriptor
+			mfaEntityDescriptor = entityDescriptor
+		}
+		if mfaEntityDescriptor == nil {
+			mfa.EntityDescriptor, mfaEntityDescriptor, err = getEntityDescriptor(ctx, getEntityDescriptorParams{
+				Log:       log,
+				MFA:       true,
+				Connector: sc,
+				Options:   options,
+			})
+			if err != nil {
+				return trace.Wrap(err)
 			}
 		}
 		if ed := mfaEntityDescriptor; ed != nil {

--- a/lib/services/saml_test.go
+++ b/lib/services/saml_test.go
@@ -21,18 +21,23 @@ package services
 import (
 	"context"
 	"crypto/x509/pkix"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/listener"
 )
 
 func TestParseFromMetadata(t *testing.T) {
@@ -419,5 +424,151 @@ func Test_ValidateSAMLConnector(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, tc.expectedSsoUrl, connector.GetSSO())
+	}
+}
+
+func Test_ValidateSAMLConnector_error_sanitization(t *testing.T) {
+	t.Parallel()
+
+	const role = "existing-test-role"
+
+	for _, tc := range []struct {
+		name                   string
+		spec                   types.SAMLConnectorSpecV2
+		setEntityDescriptorURL func(types.SAMLConnector, string)
+		getEntityDescriptor    func(types.SAMLConnector) string
+	}{
+		{
+			name: "root entity descriptor URL",
+			spec: types.SAMLConnectorSpecV2{
+				AssertionConsumerService: "https://teleport.example.com/v1/webapi/saml/acs",
+				EntityDescriptorURL:      "https://to-be-changed.test",
+				AttributesToRoles: []types.AttributeMapping{
+					{Name: "groups", Value: "admin", Roles: []string{role}},
+				},
+			},
+			setEntityDescriptorURL: func(connector types.SAMLConnector, url string) {
+				connector.SetEntityDescriptorURL(url)
+			},
+			getEntityDescriptor: func(connector types.SAMLConnector) string {
+				return connector.GetEntityDescriptor()
+			},
+		},
+		{
+			name: "MFA entity descriptor URL",
+			spec: types.SAMLConnectorSpecV2{
+				AssertionConsumerService: "https://teleport.example.com/v1/webapi/saml/acs",
+				Issuer:                   "https://idp.example.com",
+				SSO:                      "https://idp.example.com/sso",
+				AttributesToRoles: []types.AttributeMapping{
+					{Name: "groups", Value: "admin", Roles: []string{role}},
+				},
+				MFASettings: &types.SAMLConnectorMFASettings{
+					Enabled:             true,
+					EntityDescriptorUrl: "https://to-be-changed.test",
+				},
+			},
+			setEntityDescriptorURL: func(connector types.SAMLConnector, url string) {
+				connector.GetMFASettings().EntityDescriptorUrl = url
+			},
+			getEntityDescriptor: func(connector types.SAMLConnector) string {
+				return connector.GetMFASettings().EntityDescriptor
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx := t.Context()
+
+				const happyPath = "/happy"
+				const slowPath = "/slow"
+				const entityDescriptor = `<?xml version="1.0" encoding="UTF-8"?>
+					<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://idp.example.com">
+						<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+							<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.example.com/sso"></SingleSignOnService>
+						</IDPSSODescriptor>
+					</EntityDescriptor>`
+
+				handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == happyPath {
+						w.Write([]byte(entityDescriptor))
+						return
+					}
+					if r.URL.Path == slowPath {
+						time.Sleep(1 * time.Hour)
+					}
+					http.Error(w, "upstream response should not be exposed", http.StatusForbidden)
+				})
+
+				listener := listener.NewInMemoryListener()
+				server := httptest.NewUnstartedServer(handler)
+				server.Listener = listener
+				server.Start()
+				t.Cleanup(server.Close)
+
+				samlConnector, err := types.NewSAMLConnector("fetch-entity-descriptor-url-errors", tc.spec)
+				require.NoError(t, err)
+
+				testOpts := []types.SAMLConnectorValidationOption{
+					types.SAMLConnectorValidationHTTPClient(listener.MakeHTTPClient()),
+				}
+
+				// Create a roleSet with <nil> role values as ValidateSAMLConnector only checks if the role
+				// in the connector role mapping exists.
+				var roleGetter = roleSet{role: nil}
+
+				// There are quite a few things to leak in the error message:
+				// 1. The HTTP response content.
+				// 2. The HTTP response code.
+				// 3. The descriptor URL and the path (token=secret in particular)
+				tc.setEntityDescriptorURL(samlConnector, server.URL+"/metadata?token=secret")
+
+				err = ValidateSAMLConnector(samlConnector, roleGetter, testOpts...)
+				require.ErrorIs(t, err, ErrFailedToFetchEntityDescriptor)
+				// Make sure the error doesn't leak any extra info about the download failure.
+				require.Equal(t, ErrFailedToFetchEntityDescriptor.Error(), err.Error())
+
+				// Verify that it also doesn't leak any message specific to timeout.
+				tc.setEntityDescriptorURL(samlConnector, server.URL+slowPath)
+
+				errCh := make(chan error, 1)
+				go func() {
+					err := ValidateSAMLConnector(samlConnector, roleGetter, testOpts...)
+					select {
+					case errCh <- err:
+					case <-ctx.Done():
+					}
+				}()
+
+				time.Sleep(apidefaults.DefaultIOTimeout - 1*time.Nanosecond)
+				synctest.Wait()
+				select {
+				case err := <-errCh:
+					t.Fatalf("expected validation to be blocking on fetching the entity descriptor, but it returned error: %v", err)
+				default:
+				}
+
+				time.Sleep(1 * time.Nanosecond)
+				synctest.Wait()
+				select {
+				case err := <-errCh:
+					require.ErrorIs(t, err, ErrFailedToFetchEntityDescriptor)
+					// Make sure the error doesn't leak any extra info about the timeout.
+					require.Equal(t, ErrFailedToFetchEntityDescriptor.Error(), err.Error())
+				default:
+					t.Fatal("expected ValidateSAMLConnector to already timeout")
+				}
+
+				// To unblock the slow entity server.
+				time.Sleep(2 * time.Hour)
+				synctest.Wait()
+
+				// Verify the happy path.
+				tc.setEntityDescriptorURL(samlConnector, server.URL+happyPath)
+				err = ValidateSAMLConnector(samlConnector, roleGetter, testOpts...)
+				require.NoError(t, err)
+				require.Equal(t, entityDescriptor, tc.getEntityDescriptor(samlConnector))
+			})
+		})
 	}
 }

--- a/lib/services/saml_test.go
+++ b/lib/services/saml_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -556,7 +557,7 @@ func Test_ValidateSAMLConnector_error_sanitization(t *testing.T) {
 				require.NoError(t, err)
 
 				testOpts := []types.SAMLConnectorValidationOption{
-					types.SAMLConnectorValidationHTTPClient(listener.MakeHTTPClient()),
+					types.SAMLConnectorValidationHTTPTransport(listener.MakeHTTPClient().Transport),
 				}
 
 				// Create a roleSet with <nil> role values as ValidateSAMLConnector only checks if the role
@@ -615,6 +616,68 @@ func Test_ValidateSAMLConnector_error_sanitization(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, entityDescriptor, tc.getEntityDescriptor(samlConnector))
 			})
+		})
+	}
+}
+
+func Test_ValidateSAMLConnector_blocksHTTPSRedirectDowngrade(t *testing.T) {
+	t.Parallel()
+
+	const role = "existing-test-role"
+
+	var downgradedRequestsCnt atomic.Int64
+	downgradedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downgradedRequestsCnt.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(downgradedServer.Close)
+
+	redirectingServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, downgradedServer.URL, http.StatusFound)
+	}))
+	t.Cleanup(redirectingServer.Close)
+
+	for _, tc := range []struct {
+		name string
+		spec types.SAMLConnectorSpecV2
+	}{
+		{
+			name: "root entity descriptor URL",
+			spec: types.SAMLConnectorSpecV2{
+				AssertionConsumerService: "https://teleport.example.com/v1/webapi/saml/acs",
+				EntityDescriptorURL:      redirectingServer.URL,
+				AttributesToRoles: []types.AttributeMapping{
+					{Name: "groups", Value: "admin", Roles: []string{role}},
+				},
+			},
+		},
+		{
+			name: "MFA entity descriptor URL",
+			spec: types.SAMLConnectorSpecV2{
+				AssertionConsumerService: "https://teleport.example.com/v1/webapi/saml/acs",
+				Issuer:                   "https://idp.example.com",
+				SSO:                      "https://idp.example.com/sso",
+				AttributesToRoles: []types.AttributeMapping{
+					{Name: "groups", Value: "admin", Roles: []string{role}},
+				},
+				MFASettings: &types.SAMLConnectorMFASettings{
+					Enabled:             true,
+					EntityDescriptorUrl: redirectingServer.URL,
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			samlConnector, err := types.NewSAMLConnector("redirect-downgrade", tc.spec)
+			require.NoError(t, err)
+
+			err = ValidateSAMLConnector(samlConnector, roleSet{role: nil},
+				types.SAMLConnectorValidationHTTPTransport(redirectingServer.Client().Transport),
+			)
+			require.ErrorIs(t, err, ErrFailedToFetchEntityDescriptor)
+			// Make sure there is no any extra information in the error.
+			require.Equal(t, ErrFailedToFetchEntityDescriptor.Error(), err.Error())
+			require.Zero(t, downgradedRequestsCnt.Load())
 		})
 	}
 }

--- a/lib/services/saml_test.go
+++ b/lib/services/saml_test.go
@@ -427,6 +427,52 @@ func Test_ValidateSAMLConnector(t *testing.T) {
 	}
 }
 
+func Test_ValidateSAMLConnector_populatesLoginAndMFASettingsFromEntityDescriptor(t *testing.T) {
+	t.Parallel()
+
+	const role = "test_role"
+	const loginEntityDescriptor = `
+		<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://login.idp.test/metadata">
+			<IDPSSODescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+				<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://login.idp.test/sso/saml"></SingleSignOnService>
+			</IDPSSODescriptor>
+		</EntityDescriptor>`
+	const mfaEntityDescriptor = `
+		<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://mfa.idp.test/metadata">
+			<IDPSSODescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+				<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://mfa.idp.test/sso/saml"></SingleSignOnService>
+			</IDPSSODescriptor>
+		</EntityDescriptor>`
+
+	connector, err := types.NewSAMLConnector("test-connector", types.SAMLConnectorSpecV2{
+		AssertionConsumerService: "https://idp.test/acs",
+		EntityDescriptor:         loginEntityDescriptor,
+		AttributesToRoles: []types.AttributeMapping{
+			{Name: "groups", Value: "Everyone", Roles: []string{role}},
+		},
+		MFASettings: &types.SAMLConnectorMFASettings{
+			Enabled:          true,
+			EntityDescriptor: mfaEntityDescriptor,
+		},
+	})
+	require.NoError(t, err)
+
+	require.Empty(t, connector.GetIssuer())
+	require.Empty(t, connector.GetSSO())
+	require.Empty(t, connector.GetMFASettings().Issuer)
+	require.Empty(t, connector.GetMFASettings().Sso)
+
+	// Create a roleSet with <nil> role values as ValidateSAMLConnector only checks if the role
+	// in the connector role mapping exists.
+	err = ValidateSAMLConnector(connector, roleSet{role: nil})
+	require.NoError(t, err)
+
+	require.Equal(t, "https://login.idp.test/metadata", connector.GetIssuer())
+	require.Equal(t, "https://login.idp.test/sso/saml", connector.GetSSO())
+	require.Equal(t, "https://mfa.idp.test/metadata", connector.GetMFASettings().Issuer)
+	require.Equal(t, "https://mfa.idp.test/sso/saml", connector.GetMFASettings().Sso)
+}
+
 func Test_ValidateSAMLConnector_error_sanitization(t *testing.T) {
 	t.Parallel()
 

--- a/lib/services/saml_test.go
+++ b/lib/services/saml_test.go
@@ -571,9 +571,9 @@ func Test_ValidateSAMLConnector_error_sanitization(t *testing.T) {
 				tc.setEntityDescriptorURL(samlConnector, server.URL+"/test_metadata")
 
 				err = ValidateSAMLConnector(samlConnector, roleGetter, testOpts...)
-				require.ErrorIs(t, err, ErrFailedToFetchEntityDescriptor)
+				require.ErrorIs(t, err, ErrFailedToFetchOrParseEntityDescriptor)
 				// Make sure the error doesn't leak any extra info about the download failure.
-				require.Equal(t, ErrFailedToFetchEntityDescriptor.Error(), err.Error())
+				require.Equal(t, ErrFailedToFetchOrParseEntityDescriptor.Error(), err.Error())
 
 				// Verify that it also doesn't leak any message specific to timeout.
 				tc.setEntityDescriptorURL(samlConnector, server.URL+slowPath)
@@ -599,9 +599,9 @@ func Test_ValidateSAMLConnector_error_sanitization(t *testing.T) {
 				synctest.Wait()
 				select {
 				case err := <-errCh:
-					require.ErrorIs(t, err, ErrFailedToFetchEntityDescriptor)
+					require.ErrorIs(t, err, ErrFailedToFetchOrParseEntityDescriptor)
 					// Make sure the error doesn't leak any extra info about the timeout.
-					require.Equal(t, ErrFailedToFetchEntityDescriptor.Error(), err.Error())
+					require.Equal(t, ErrFailedToFetchOrParseEntityDescriptor.Error(), err.Error())
 				default:
 					t.Fatal("expected ValidateSAMLConnector to already timeout")
 				}
@@ -674,9 +674,9 @@ func Test_ValidateSAMLConnector_blocksHTTPSRedirectDowngrade(t *testing.T) {
 			err = ValidateSAMLConnector(samlConnector, roleSet{role: nil},
 				types.SAMLConnectorValidationHTTPTransport(redirectingServer.Client().Transport),
 			)
-			require.ErrorIs(t, err, ErrFailedToFetchEntityDescriptor)
+			require.ErrorIs(t, err, ErrFailedToFetchOrParseEntityDescriptor)
 			// Make sure there is no any extra information in the error.
-			require.Equal(t, ErrFailedToFetchEntityDescriptor.Error(), err.Error())
+			require.Equal(t, ErrFailedToFetchOrParseEntityDescriptor.Error(), err.Error())
 			require.Zero(t, downgradedRequestsCnt.Load())
 		})
 	}

--- a/lib/services/saml_test.go
+++ b/lib/services/saml_test.go
@@ -566,8 +566,8 @@ func Test_ValidateSAMLConnector_error_sanitization(t *testing.T) {
 				// There are quite a few things to leak in the error message:
 				// 1. The HTTP response content.
 				// 2. The HTTP response code.
-				// 3. The descriptor URL and the path (token=secret in particular)
-				tc.setEntityDescriptorURL(samlConnector, server.URL+"/metadata?token=secret")
+				// 3. The descriptor URL and the path.
+				tc.setEntityDescriptorURL(samlConnector, server.URL+"/test_metadata")
 
 				err = ValidateSAMLConnector(samlConnector, roleGetter, testOpts...)
 				require.ErrorIs(t, err, ErrFailedToFetchEntityDescriptor)

--- a/tool/tctl/common/resources/saml_connector.go
+++ b/tool/tctl/common/resources/saml_connector.go
@@ -94,7 +94,7 @@ func createSAMLConnector(ctx context.Context, client *authclient.Client, raw ser
 	// Create services.SAMLConnector from raw YAML to extract the connector name.
 	conn, err := services.UnmarshalSAMLConnector(raw.Raw, services.DisallowUnknown())
 	if err != nil {
-		if errors.Is(err, services.ErrFailedToFetchEntityDescriptor) {
+		if errors.Is(err, services.ErrFailedToFetchOrParseEntityDescriptor) {
 			return trace.BadParameter("%s (re-run with --debug for more details)", err)
 		}
 		return trace.Wrap(err)
@@ -128,7 +128,7 @@ func createSAMLConnector(ctx context.Context, client *authclient.Client, raw ser
 func updateSAMLConnector(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
 	conn, err := services.UnmarshalSAMLConnector(raw.Raw, services.DisallowUnknown())
 	if err != nil {
-		if errors.Is(err, services.ErrFailedToFetchEntityDescriptor) {
+		if errors.Is(err, services.ErrFailedToFetchOrParseEntityDescriptor) {
 			return trace.BadParameter("%s (re-run with --debug for more details)", err)
 		}
 		return trace.Wrap(err)

--- a/tool/tctl/common/resources/saml_connector.go
+++ b/tool/tctl/common/resources/saml_connector.go
@@ -20,6 +20,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -93,6 +94,9 @@ func createSAMLConnector(ctx context.Context, client *authclient.Client, raw ser
 	// Create services.SAMLConnector from raw YAML to extract the connector name.
 	conn, err := services.UnmarshalSAMLConnector(raw.Raw, services.DisallowUnknown())
 	if err != nil {
+		if errors.Is(err, services.ErrFailedToFetchEntityDescriptor) {
+			return trace.BadParameter("%s (re-run with --debug for more details)", err)
+		}
 		return trace.Wrap(err)
 	}
 

--- a/tool/tctl/common/resources/saml_connector.go
+++ b/tool/tctl/common/resources/saml_connector.go
@@ -128,6 +128,9 @@ func createSAMLConnector(ctx context.Context, client *authclient.Client, raw ser
 func updateSAMLConnector(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
 	conn, err := services.UnmarshalSAMLConnector(raw.Raw, services.DisallowUnknown())
 	if err != nil {
+		if errors.Is(err, services.ErrFailedToFetchEntityDescriptor) {
+			return trace.BadParameter("%s (re-run with --debug for more details)", err)
+		}
 		return trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Changelog: Sanitized SAML connector creation errors to prevent potential SSRF attacks by malicious administrators.

## Backports

- https://github.com/gravitational/teleport/pull/68837

## Manual Test Plan

### Test Environment

#### Compile a custom `tctl` allowing to bypass the local connector validation

In tool/tctl/common/resources/saml_connector.go, change `func createSAMLConnector`:

```diff
-	conn, err := services.UnmarshalSAMLConnector(raw.Raw, services.DisallowUnknown())
-	if err != nil {
-		if errors.Is(err, services.ErrorFailedToFetchEntityDescriptor) {
-			return trace.BadParameter("%s (re-run with --debug for more details)", err)
-		}
-		return trace.Wrap(err)
-	}

+	var connV2 types.SAMLConnectorV2
+	var conn types.SAMLConnector = &connV2
+	if err := utils.FastUnmarshal(raw.Raw, &connV2); err != nil {
+		return trace.Wrap(err)
+	}
```

#### Prepare http server with handlers

```go
const (
	HTTPServerEndpointNotXML            = "/not-xml"
	HTTPServerEndpointCode502           = "/code-502"
	HTTPServerEndpointRedirect          = "/redirect"
	HTTPServerEndpointRedirectInternal  = "/redirect-internal"
	HTTPServerEndpointRedirectDowngrade = "/redirect-downgrade"
	HTTPServerEndpointSlow              = "/slow"
	HTTPServerEndpointHugeBody          = "/huge-body"
)

func _httpServerHandlerNotXML(w http.ResponseWriter, r *http.Request) {
	w.Header().Set("Content-Type", "application/json")
	w.WriteHeader(http.StatusOK)
	fmt.Fprintf(w, `{"not":"xml","but":"json"}`)
}

func _httpServerHandlerCode502(w http.ResponseWriter, r *http.Request) {
	w.WriteHeader(http.StatusBadGateway)
	fmt.Fprintf(w, `I'm about to respond with 502, hihihi.`)
}

func _httpServerHandlerRedirectToSelf(w http.ResponseWriter, r *http.Request) {
	http.Redirect(w, r, "https://"+HTTPServerAddr+HTTPServerEndpointRedirect, http.StatusMovedPermanently)
}

func _httpServerHandlerRedirectInternal(w http.ResponseWriter, r *http.Request) {
	http.Redirect(w, r, "https://169.254.169.254/latest/meta-data/iam/security-credentials/", http.StatusFound)
}

func _httpServerHandlerRedirectDowngrade(w http.ResponseWriter, r *http.Request) {
	http.Redirect(w, r, "http://plan.http.test", http.StatusMovedPermanently)
}

func _httpServerHandlerSlow(w http.ResponseWriter, r *http.Request) {
	select {
	case <-time.After(35 * time.Second):
	case <-r.Context().Done():
	}
}

func _httpServerHandlerHugeBody(w http.ResponseWriter, r *http.Request) {
	w.Header().Set("Content-Type", "application/xml")
	w.WriteHeader(http.StatusOK)
	chunk := bytes.Repeat([]byte("A"), 1024*1024) // 1 MiB
	for range 16 {                                // 16 MiB total
		if _, err := w.Write(chunk); err != nil {
			return
		}
	}
}
```

#### Example SAML connector definition

```yaml
# saml_connector.yaml
kind: saml
metadata:
    name: loopback-502
spec:
    acs: https://teleport.test:3080/v1/webapi/saml/acs/okta
    attributes_to_roles:
        - name: groups
          roles:
            - requester
          value: Everyone
    audience: https://teleport.test:3080/v1/webapi/saml/acs/okta
    display: Loopback (502 response code)
    service_provider_issuer: https://teleport.test:3080/v1/webapi/saml/acs/okta
    entity_descriptor_url: http://127.0.0.1:9000/code-502 # change this part (and eventually name+display)
version: v2

```

### Test Cases

- [x] Verify a correctly defined Okta connector allows SSO login.
- [x] Verify a correctly defined Entra connector allows SSO login.
- [x] For each handler run (note --debug flag): `tctl --debug create -f saml_connector.yaml` and verify there is only a generic error on the client side, and full error log on the server side:
  - [x] `entity_descriptor_url` is set to the each handler's endpoint:
    - [x] /not-xml
    - [x] /code-502
    - [x] /redirect
    - [x] /redirect-internal
    - [x] /redirect-downgrade
    - [x] /slow
    - [x] /huge-body
  - [x] `entity_descriptor_url` is set to `https://i-don-know-you-dns.test` (unkown domain)
  - [x] `entity_descriptor_url` is set to `http://127.0.0.1:1011` (closed local port)
  - [x] `entity_descriptor_url` is set to `http://169.254.169.254/latest/meta-data/iam/security-credentials/` (AWS metadata URL)
  - [x] `entity_descriptor_url` not set and `entity_descriptor` set to a malformed XML: expect an error propagated to `tctl`
- [x] Verify the same for MFA settings. Set `spec.entity_descriptor` and `spec.mfa.enabled: true` and `spec.mfa.entity_descriptor_url`, and then:
  - [x] Check descriptor is downloaded and set in the `spec.mfa.entity_descriptor`
  - [x] Check one of the bad scenarios, e.g. "/not-xml" (no reason to go through all of them as it uses the same download func)
  - [x] `mfa.entity_descriptor_url` not set and `mfa.entity_descriptor` set to a malformed XML: expect an error propagated to `tctl`
  - [x] Verify update form connector without MFA to connector with MFA and entity_descriptor_url set.
- [x] Update `entity_descriptor_url` to /code-502 with `tctl edit saml/saml_hardening_test" and verify there is only a generic error on the client side, and full error log on the server side
- [x] Update `mfa.entity_descriptor_url` to /code-502 with `tctl edit saml/saml_hardening_test" and verify there is only a generic error on the client side, and full error log on the server side

Example `tctl` output:

```
tctl --auth-server=teleport.test:3080 --debug create saml_connector.yaml

2026-07-03T18:48:46.197+01:00 DEBU  Debug logging has been enabled config/global.go:86
2026-07-03T18:48:46.197+01:00 DEBU  no config file, loading auth config via extension config/global.go:142
2026-07-03T18:48:46.201+01:00 DEBU  Found profile proxy:https://local1.gopawel.com:3080 user:admin config/profile.go:75
2026-07-03T18:48:46.202+01:00 DEBU  Auth client connecting auth_servers:[{Addr:local1.gopawel.com:3080 AddrNetwork:tcp Path:} {Addr:local1.gopawel.com:3080 AddrNetwork:tcp Path:}] authclient/authclient.go:63
2026-07-03T18:48:46.211+01:00 DEBU  Attempting request to Proxy web api method:GET host:local1.gopawel.com:3080 path:/webapi/find webclient/webclient.go:154
2026-07-03T18:48:46.229+01:00 DEBU  ALPN connection upgrade test complete address:local1.gopawel.com:3080 upgrade_required:false client/alpn_conn_upgrade.go:98
2026-07-03T18:48:46.229+01:00 DEBU [HTTP:PROX] No proxy set in environment, returning direct dialer proxy/proxy.go:184

ERROR REPORT:
Original Error: *interceptors.RemoteError failed to fetch entity descriptor
Stack Trace:
        /gh/gravitational/teleport.saml_hardening/api/client/client.go:2264 github.com/gravitational/teleport/api/client.(*Client).UpsertSAMLConnector
        /gh/gravitational/teleport.saml_hardening/tool/tctl/common/resources/saml_connector.go:127 github.com/gravitational/teleport/tool/tctl/common/resources.createSAMLConnector
        /gh/gravitational/teleport.saml_hardening/tool/tctl/common/resources/resource.go:166 github.com/gravitational/teleport/tool/tctl/common/resources.(*Handler).Create
        /gh/gravitational/teleport.saml_hardening/tool/tctl/common/resource_command.go:407 github.com/gravitational/teleport/tool/tctl/common.(*ResourceCommand).Create
        /gh/gravitational/teleport.saml_hardening/tool/tctl/common/resource_command.go:203 github.com/gravitational/teleport/tool/tctl/common.(*ResourceCommand).TryRun
        /gh/gravitational/teleport.saml_hardening/tool/tctl/common/tctl.go:195 github.com/gravitational/teleport/tool/tctl/common.TryRun
        /gh/gravitational/teleport.saml_hardening/tool/tctl/common/tctl.go:81 github.com/gravitational/teleport/tool/tctl/common.Run
        /gh/gravitational/teleport.saml_hardening/tool/tctl/main.go:33 main.main
        /opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/proc.go:290 runtime.main
        /opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/asm_arm64.s:1447 runtime.goexit
User Message: failed to fetch entity descriptor
```

Corresponding `auth` logs:

```
2026-07-03T18:48:46.326+01:00 ERRO [SAML]      Failed to fetch or parse SAML MFA entity descriptor saml_connector:loopback-closed-port mfa_entity_descriptor_url:http://127.0.0.1:1011 error:[
ERROR REPORT:
Original Error: *url.Error Get &#34;http://127.0.0.1:1011&#34;: dial tcp 127.0.0.1:1011: connect: connection refused
Stack Trace:
        /gh/gravitational/teleport.saml_hardening/lib/services/saml.go:265 github.com/gravitational/teleport/lib/services.getEntityDescriptor
        /gh/gravitational/teleport.saml_hardening/lib/services/saml.go:179 github.com/gravitational/teleport/lib/services.ValidateSAMLConnector
        /gh/gravitational/teleport.saml_hardening/lib/auth/saml.go:66 github.com/gravitational/teleport/lib/auth.(*Server).UpsertSAMLConnector
        /gh/gravitational/teleport.saml_hardening/lib/auth/auth_with_roles.go:4789 github.com/gravitational/teleport/lib/auth.(*ServerWithRoles).UpsertSAMLConnector
        /gh/gravitational/teleport.saml_hardening/lib/auth/grpcserver.go:3277 github.com/gravitational/teleport/lib/auth.(*GRPCServer).UpsertSAMLConnectorV2
        /gh/gravitational/teleport.saml_hardening/api/client/proto/authservice_grpc.pb.go:7965 github.com/gravitational/teleport/api/client/proto._AuthService_UpsertSAMLConnectorV2_Handler.func1
        /gh/gravitational/teleport.saml_hardening/lib/auth/middleware.go:590 github.com/gravitational/teleport/lib/auth.(*Middleware).withAuthenticatedUserUnaryInterceptor
        /go/pkg/mod/google.golang.org/grpc@v1.81.1/server.go:1243 google.golang.org/grpc.getChainUnaryHandler.func1
        /gh/gravitational/teleport.saml_hardening/lib/auth/middleware.go:417 github.com/gravitational/teleport/lib/auth.(*Middleware).rateLimitUnaryInterceptor.func1
        /go/pkg/mod/google.golang.org/grpc@v1.81.1/server.go:1243 google.golang.org/grpc.getChainUnaryHandler.func1
        /gh/gravitational/teleport.saml_hardening/api/metadata/metadata.go:76 github.com/gravitational/teleport/api/metadata.UnaryServerInterceptor
        /go/pkg/mod/google.golang.org/grpc@v1.81.1/server.go:1243 google.golang.org/grpc.getChainUnaryHandler.func1
        /gh/gravitational/teleport.saml_hardening/api/utils/grpc/interceptors/errors.go:77 github.com/gravitational/teleport/api/utils/grpc/interceptors.GRPCServerUnaryErrorInterceptor
        /go/pkg/mod/google.golang.org/grpc@v1.81.1/server.go:1243 google.golang.org/grpc.getChainUnaryHandler.func1
        /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.3.3/interceptors/server.go:22 github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors.UnaryServerInterceptor.func1
        /go/pkg/mod/google.golang.org/grpc@v1.81.1/server.go:1234 google.golang.org/grpc.chainUnaryInterceptors.func1
        /gh/gravitational/teleport.saml_hardening/api/client/proto/authservice_grpc.pb.go:7967 github.com/gravitational/teleport/api/client/proto._AuthService_UpsertSAMLConnectorV2_Handler
        /go/pkg/mod/google.golang.org/grpc@v1.81.1/server.go:1430 google.golang.org/grpc.(*Server).processUnaryRPC
        /go/pkg/mod/google.golang.org/grpc@v1.81.1/server.go:1856 google.golang.org/grpc.(*Server).handleStream
        /go/pkg/mod/google.golang.org/grpc@v1.81.1/server.go:1065 google.golang.org/grpc.(*Server).serveStreams.func2.1
        /opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/asm_arm64.s:1447 runtime.goexit
User Message: Get &#34;http://127.0.0.1:1011&#34;: dial tcp 127.0.0.1:1011: connect: connection refused] services/saml.go:249
```


