### PR TITLE
docs: p0 and p1 Agent-blocker findings for database guides

### DIFF
--- a/docs/pages/enroll-resources/database-access/enrollment/aws/rds/mysql-postgres-mariadb.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/rds/mysql-postgres-mariadb.mdx
@@ -26,10 +26,17 @@ page_type: how-to
 
 </Tabs>
 
-<Admonition type="note" title="Supported versions">
+(!docs/pages/includes/database-access/auto-discovery-tip.mdx dbType="RDS" providerType="AWS" !)
 
-The following products are not compatible with Teleport as they don't support
-IAM authentication:
+## Prerequisites
+
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
+<Admonition type="warning" title="Supported versions">
+
+Before you provision a database for this guide, confirm it isn't one of the
+following, since neither supports IAM authentication and Teleport cannot
+connect to them:
 
     - Aurora Serverless v1.
     - RDS MariaDB versions lower than 10.6.
@@ -39,12 +46,6 @@ v2](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverle
 which supports IAM authentication.
 
 </Admonition>
-
-(!docs/pages/includes/database-access/auto-discovery-tip.mdx dbType="RDS" providerType="AWS" !)
-
-## Prerequisites
-
-(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - AWS account with RDS and Aurora databases and permissions to create and attach
   IAM policies.

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/rds/sql-server-ad.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/rds/sql-server-ad.mdx
@@ -39,13 +39,8 @@ Database Service forwards user traffic to the database.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 <Admonition type="tip" title="Time to complete">
-
-This guide involves configuring Active Directory, Kerberos, and a Linux host
-joined to your AD domain in addition to Teleport itself. Completing it end to
-end typically takes 2-4 hours and requires access to an AD administrator
-account. If you don't already have an AD domain and a Windows and Linux
+This guide requires an existing Active Directory domain, a Windows host and a Linux host joined to it, and AD administrator access to configure Kerberos and SPNs. If you don't already have an AD domain and a Windows and Linux
 machine joined to it, budget additional time to set those up first.
-
 </Admonition>
 
 - A SQL Server database with Active Directory authentication enabled.

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/rds/sql-server-ad.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/rds/sql-server-ad.mdx
@@ -38,6 +38,16 @@ Database Service forwards user traffic to the database.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
+<Admonition type="tip" title="Time to complete">
+
+This guide involves configuring Active Directory, Kerberos, and a Linux host
+joined to your AD domain in addition to Teleport itself. Completing it end to
+end typically takes 2-4 hours and requires access to an AD administrator
+account. If you don't already have an AD domain and a Windows and Linux
+machine joined to it, budget additional time to set those up first.
+
+</Admonition>
+
 - A SQL Server database with Active Directory authentication enabled.
 
 - A SQL Server network listener configured with a Certificate using Subject Alternative Names

--- a/docs/pages/includes/database-access/rds-proxy.mdx
+++ b/docs/pages/includes/database-access/rds-proxy.mdx
@@ -111,17 +111,17 @@ example:
             "Effect": "Allow",
             "Action": "secretsmanager:GetSecretValue",
             "Resource": [
-                "arn:aws:secretsmanager:us-west-1:account_id:secret:rdsproxy_alice",
-                "arn:aws:secretsmanager:us-west-1:account_id:secret:rdsproxy_anotheruser"
+                "arn:aws:secretsmanager:region:account_id:secret:rdsproxy_alice",
+                "arn:aws:secretsmanager:region:account_id:secret:rdsproxy_anotheruser"
             ]
         },
         {   
             "Effect": "Allow",
             "Action": "kms:Decrypt",
-            "Resource": "arn:aws:kms:us-west-1:account_id:key/key_id",
+            "Resource": "arn:aws:kms:region:account_id:key/key_id",
             "Condition": {
                 "StringEquals": {
-                    "kms:ViaService": "secretsmanager.us-east-2.amazonaws.com"
+                    "kms:ViaService": "secretsmanager.region.amazonaws.com"
                 }
             }
         }

--- a/docs/pages/includes/database-access/rds-proxy.mdx
+++ b/docs/pages/includes/database-access/rds-proxy.mdx
@@ -100,8 +100,12 @@ $ aws secretsmanager create-secret \
   --secret-string '{"username":"alice","password":"password_for_alice"}'
 ```
 
-Next, create an IAM role with a policy that can access these secrets, for
-example:
+Next, create an IAM role with a policy that can access these secrets. Assign
+<Var name="region"/> to the AWS Region of your secrets, <Var
+name="aws-account-id"/> to your AWS account ID, and <Var name="key-id"/> to
+the ID of the KMS key that encrypts your secrets. If your secrets are
+encrypted with the default AWS managed key (`aws/secretsmanager`), you can
+omit the `kms:Decrypt` statement:
 
 ```json
 {
@@ -111,17 +115,17 @@ example:
             "Effect": "Allow",
             "Action": "secretsmanager:GetSecretValue",
             "Resource": [
-                "arn:aws:secretsmanager:region:account_id:secret:rdsproxy_alice",
-                "arn:aws:secretsmanager:region:account_id:secret:rdsproxy_anotheruser"
+                "arn:aws:secretsmanager:<Var name="region"/>:<Var name="aws-account-id"/>:secret:rdsproxy_alice",
+                "arn:aws:secretsmanager:<Var name="region"/>:<Var name="aws-account-id"/>:secret:rdsproxy_anotheruser"
             ]
         },
-        {   
+        {
             "Effect": "Allow",
             "Action": "kms:Decrypt",
-            "Resource": "arn:aws:kms:region:account_id:key/key_id",
+            "Resource": "arn:aws:kms:<Var name="region"/>:<Var name="aws-account-id"/>:key/<Var name="key-id"/>",
             "Condition": {
                 "StringEquals": {
-                    "kms:ViaService": "secretsmanager.region.amazonaws.com"
+                    "kms:ViaService": "secretsmanager.<Var name="region"/>.amazonaws.com"
                 }
             }
         }
@@ -209,3 +213,4 @@ $ tsh db logout rds-proxy
   and [Setting up AWS Identity and Access Management (IAM)
   policies](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-setup.html)
   for RDS Proxy
+  

--- a/docs/pages/includes/database-access/reference/aws-iam/rds/access-policy.mdx
+++ b/docs/pages/includes/database-access/reference/aws-iam/rds/access-policy.mdx
@@ -42,7 +42,7 @@ The Teleport Database Service uses `rds:ModifyDBInstance` and
 on RDS instances and Aurora clusters, respectively.
 
 <Admonition type="warning" title="Production databases">
-Granting `RDSAutoEnableIAMAuth` allows the Database Service to modify your
+Granting `RDSAutoEnableIAMAuth` allows the Teleport Database Service to modify your
 RDS instance or Aurora cluster configuration directly. Enabling IAM
 authentication does not cause downtime by itself. However, the Database
 Service applies the change immediately, which also applies any other

--- a/docs/pages/includes/database-access/reference/aws-iam/rds/access-policy.mdx
+++ b/docs/pages/includes/database-access/reference/aws-iam/rds/access-policy.mdx
@@ -33,7 +33,7 @@
 | Statement | Purpose |
 | --------- | ------- |
 |`RDSAutoEnableIAMAuth` | Automatically enable IAM auth on RDS instances and Aurora clusters. |
-|`RDSConnect` | Generate an IAM authentication token to connect to a database. |
+|`RDSConnect` | Connect to a database using IAM authentication tokens. | 
 |`RDSFetchMetadata` | Automatically import AWS tags as database labels or find missing information such as the database's AWS region. |
 
 The Teleport Database Service uses `rds:ModifyDBInstance` and
@@ -42,12 +42,13 @@ The Teleport Database Service uses `rds:ModifyDBInstance` and
 on RDS instances and Aurora clusters, respectively.
 
 <Admonition type="warning" title="Production databases">
-Granting `RDSAutoEnableIAMAuth` means the Database Service can modify your
-RDS instance or Aurora cluster configuration directly, which can trigger a
-restart depending on your database engine. If you are attaching this policy
-in a production environment, confirm IAM authentication is already enabled
-on the target database and omit this statement, or apply this change during
-a maintenance window.
+Granting `RDSAutoEnableIAMAuth` allows the Database Service to modify your
+RDS instance or Aurora cluster configuration directly. Enabling IAM
+authentication does not cause downtime by itself. However, the Database
+Service applies the change immediately, which also applies any other
+modifications pending on the database. Before attaching this policy in a 
+production environment, check for pending modifications on your databases,
+or enable IAM authentication yourself and omit the `RDSAutoEnableIAMAuth` statement.
 </Admonition>
 
 You can omit the `RDSAutoEnableIAMAuth` permissions if IAM authentication is

--- a/docs/pages/includes/database-access/reference/aws-iam/rds/access-policy.mdx
+++ b/docs/pages/includes/database-access/reference/aws-iam/rds/access-policy.mdx
@@ -40,6 +40,16 @@ The Teleport Database Service uses `rds:ModifyDBInstance` and
 `rds:ModifyDBCluster` to automatically enable
 [IAM authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html)
 on RDS instances and Aurora clusters, respectively.
+
+<Admonition type="warning" title="Production databases">
+Granting `RDSAutoEnableIAMAuth` means the Database Service can modify your
+RDS instance or Aurora cluster configuration directly, which can trigger a
+restart depending on your database engine. If you are attaching this policy
+in a production environment, confirm IAM authentication is already enabled
+on the target database and omit this statement, or apply this change during
+a maintenance window.
+</Admonition>
+
 You can omit the `RDSAutoEnableIAMAuth` permissions if IAM authentication is
 already enabled on your databases.
 


### PR DESCRIPTION
## Summary

Fixes four documentation issues surfaced in the database access enrollment guide audit, using Claude Code on Beams (2026-07-03). Two of the four live in shared partials, so each fix propagates to multiple guides.

## Changes

- **`includes/database-access/rds-proxy.mdx`** - Fixed a region mismatch in the RDS Proxy IAM policy example (`kms:Decrypt` resource used `us-west-1` while the `kms:ViaService` condition referenced `us-east-2`, breaking decryption if copied as-is). Replaced both with a consistent `region` placeholder to match the existing `account_id` convention. Affects `rds-proxy-mysql`, `rds-proxy-postgres`, and `rds-proxy-sqlserver`.

- **`includes/database-access/reference/aws-iam/rds/access-policy.mdx`** - Added a warning admonition for `RDSAutoEnableIAMAuth`: the Database Service modifies RDS/Aurora configuration directly with `ApplyImmediately: true`. Enabling IAM auth itself causes no downtime, but applying immediately also flushes any pending modifications on the database, which can cause unexpected downtime ([AWS docs](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ModifyInstance.ApplyImmediately.html)). The policy table previously named the permission without flagging this production risk. Also reworded the RDSConnect table entry: rds-db:connect authorizes connections made with IAM auth tokens; token generation is a local signing operation requiring no permission. Affects mysql-postgres-mariadb, aws-cross-account, and the AWS IAM reference page.

- **`enrollment/aws/rds/mysql-postgres-mariadb.mdx`** - Moved the Aurora Serverless v1 / MariaDB <10.6 incompatibility note out of a standalone admonition and into Prerequisites (upgraded from `note` to `warning`), so users see it before provisioning rather than after.

- **`enrollment/aws/rds/sql-server-ad.mdx`** - Added a "Time to complete" note to Prerequisites (2-4 hours, requires AD admin access) to set expectations before users start a guide with a non-trivial AD/Kerberos setup chain.

Verification pass done using Claude with web fetch + a checkout of the repo to compare docs claims against both AWS docs and Teleport code
