### PR TITLE
Add support for Scoped Users to access Scoped Apps

### DIFF
--- a/api/gen/proto/go/teleport/scopes/access/v1/role_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role_protohybrid.pb.go
@@ -435,15 +435,20 @@ type ScopedRoleDefaults struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// ClientIdleTimeout sets the default idle timeout for access sessions across all protocols
 	// that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h").
+	// The cluster-wide default is used only when neither this nor the protocol's equivalent
+	// control is set.
 	ClientIdleTimeout string `protobuf:"bytes,1,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3" json:"client_idle_timeout,omitempty"`
 	// SessionRecording configures the session recording strategy for all protocols that don't
-	// explicitly set their session recording mode.
+	// explicitly set their session recording mode. If neither this nor the protocol's equivalent control
+	// is set, best_effort is used.
 	SessionRecording *SessionRecording `protobuf:"bytes,2,opt,name=session_recording,json=sessionRecording,proto3" json:"session_recording,omitempty"`
-	// DisconnectExpiredCert defines the default behavior of all protocols when certs expire for a session.
-	// If unset, cluster wide defaults are used.
+	// DisconnectExpiredCert defines the default behavior of all protocols when certs expire for
+	// a session. The cluster-wide default is used only when neither this nor the protocol's
+	// equivalent control is set.
 	DisconnectExpiredCert *bool `protobuf:"varint,3,opt,name=disconnect_expired_cert,json=disconnectExpiredCert,proto3,oneof" json:"disconnect_expired_cert,omitempty"`
 	// Lock specifies the default locking mode for access sessions across all protocols that
-	// do not specify their own value. If unset, cluster wide defaults are used.
+	// do not specify their own value. The cluster-wide default is used only when neither this
+	// nor the protocol's equivalent control is set.
 	Lock          *Lock `protobuf:"bytes,4,opt,name=lock,proto3" json:"lock,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -556,15 +561,20 @@ type ScopedRoleDefaults_builder struct {
 
 	// ClientIdleTimeout sets the default idle timeout for access sessions across all protocols
 	// that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h").
+	// The cluster-wide default is used only when neither this nor the protocol's equivalent
+	// control is set.
 	ClientIdleTimeout string
 	// SessionRecording configures the session recording strategy for all protocols that don't
-	// explicitly set their session recording mode.
+	// explicitly set their session recording mode. If neither this nor the protocol's equivalent control
+	// is set, best_effort is used.
 	SessionRecording *SessionRecording
-	// DisconnectExpiredCert defines the default behavior of all protocols when certs expire for a session.
-	// If unset, cluster wide defaults are used.
+	// DisconnectExpiredCert defines the default behavior of all protocols when certs expire for
+	// a session. The cluster-wide default is used only when neither this nor the protocol's
+	// equivalent control is set.
 	DisconnectExpiredCert *bool
 	// Lock specifies the default locking mode for access sessions across all protocols that
-	// do not specify their own value. If unset, cluster wide defaults are used.
+	// do not specify their own value. The cluster-wide default is used only when neither this
+	// nor the protocol's equivalent control is set.
 	Lock *Lock
 }
 
@@ -617,9 +627,10 @@ type ScopedRoleSSH struct {
 	SessionRecording *SessionRecording `protobuf:"bytes,13,opt,name=session_recording,json=sessionRecording,proto3" json:"session_recording,omitempty"`
 	// DisconnectExpiredCert controls whether SSH sessions are disconnected when the
 	// user certificate expires.
-	// Defaults to value cluster wide auth preference if not set.
+	// If empty, the defaults block value (or global default) applies.
 	DisconnectExpiredCert *bool `protobuf:"varint,14,opt,name=disconnect_expired_cert,json=disconnectExpiredCert,proto3,oneof" json:"disconnect_expired_cert,omitempty"`
 	// Lock configures the role's locking behavior for SSH sessions.
+	// If empty, the defaults block value (or global default) applies.
 	Lock          *Lock `protobuf:"bytes,15,opt,name=lock,proto3" json:"lock,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -948,9 +959,10 @@ type ScopedRoleSSH_builder struct {
 	SessionRecording *SessionRecording
 	// DisconnectExpiredCert controls whether SSH sessions are disconnected when the
 	// user certificate expires.
-	// Defaults to value cluster wide auth preference if not set.
+	// If empty, the defaults block value (or global default) applies.
 	DisconnectExpiredCert *bool
 	// Lock configures the role's locking behavior for SSH sessions.
+	// If empty, the defaults block value (or global default) applies.
 	Lock *Lock
 }
 
@@ -995,8 +1007,10 @@ type ScopedRoleKube struct {
 	// (or global default) applies.
 	ClientIdleTimeout string `protobuf:"bytes,5,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3" json:"client_idle_timeout,omitempty"`
 	// DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires.
+	// If empty, the defaults block value (or global default) applies.
 	DisconnectExpiredCert *bool `protobuf:"varint,6,opt,name=disconnect_expired_cert,json=disconnectExpiredCert,proto3,oneof" json:"disconnect_expired_cert,omitempty"`
 	// Lock configures the role's locking behavior for kubernetes sessions.
+	// If empty, the defaults block value (or global default) applies.
 	Lock          *Lock `protobuf:"bytes,7,opt,name=lock,proto3" json:"lock,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1142,8 +1156,10 @@ type ScopedRoleKube_builder struct {
 	// (or global default) applies.
 	ClientIdleTimeout string
 	// DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires.
+	// If empty, the defaults block value (or global default) applies.
 	DisconnectExpiredCert *bool
 	// Lock configures the role's locking behavior for kubernetes sessions.
+	// If empty, the defaults block value (or global default) applies.
 	Lock *Lock
 }
 
@@ -1241,8 +1257,18 @@ type ScopedRoleApp struct {
 	// LabelExpression is an optional predicate expression evaluated against an
 	// application's labels.
 	LabelExpression string `protobuf:"bytes,2,opt,name=label_expression,json=labelExpression,proto3" json:"label_expression,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// Overrides the defaults block idle timeout specifically for app sessions.
+	// Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
+	// (or global default) applies.
+	ClientIdleTimeout string `protobuf:"bytes,3,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3" json:"client_idle_timeout,omitempty"`
+	// DisconnectExpiredCert controls whether App sessions are disconnected when the user certificate expires.
+	// If empty, the defaults block value (or global default) applies.
+	DisconnectExpiredCert *bool `protobuf:"varint,4,opt,name=disconnect_expired_cert,json=disconnectExpiredCert,proto3,oneof" json:"disconnect_expired_cert,omitempty"`
+	// Lock configures the role's locking behavior for app sessions.
+	// If empty, the defaults block value (or global default) applies.
+	Lock          *Lock `protobuf:"bytes,5,opt,name=lock,proto3" json:"lock,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ScopedRoleApp) Reset() {
@@ -1284,12 +1310,67 @@ func (x *ScopedRoleApp) GetLabelExpression() string {
 	return ""
 }
 
+func (x *ScopedRoleApp) GetClientIdleTimeout() string {
+	if x != nil {
+		return x.ClientIdleTimeout
+	}
+	return ""
+}
+
+func (x *ScopedRoleApp) GetDisconnectExpiredCert() bool {
+	if x != nil && x.DisconnectExpiredCert != nil {
+		return *x.DisconnectExpiredCert
+	}
+	return false
+}
+
+func (x *ScopedRoleApp) GetLock() *Lock {
+	if x != nil {
+		return x.Lock
+	}
+	return nil
+}
+
 func (x *ScopedRoleApp) SetLabels(v []*v11.Label) {
 	x.Labels = v
 }
 
 func (x *ScopedRoleApp) SetLabelExpression(v string) {
 	x.LabelExpression = v
+}
+
+func (x *ScopedRoleApp) SetClientIdleTimeout(v string) {
+	x.ClientIdleTimeout = v
+}
+
+func (x *ScopedRoleApp) SetDisconnectExpiredCert(v bool) {
+	x.DisconnectExpiredCert = &v
+}
+
+func (x *ScopedRoleApp) SetLock(v *Lock) {
+	x.Lock = v
+}
+
+func (x *ScopedRoleApp) HasDisconnectExpiredCert() bool {
+	if x == nil {
+		return false
+	}
+	return x.DisconnectExpiredCert != nil
+}
+
+func (x *ScopedRoleApp) HasLock() bool {
+	if x == nil {
+		return false
+	}
+	return x.Lock != nil
+}
+
+func (x *ScopedRoleApp) ClearDisconnectExpiredCert() {
+	x.DisconnectExpiredCert = nil
+}
+
+func (x *ScopedRoleApp) ClearLock() {
+	x.Lock = nil
 }
 
 type ScopedRoleApp_builder struct {
@@ -1300,6 +1381,16 @@ type ScopedRoleApp_builder struct {
 	// LabelExpression is an optional predicate expression evaluated against an
 	// application's labels.
 	LabelExpression string
+	// Overrides the defaults block idle timeout specifically for app sessions.
+	// Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
+	// (or global default) applies.
+	ClientIdleTimeout string
+	// DisconnectExpiredCert controls whether App sessions are disconnected when the user certificate expires.
+	// If empty, the defaults block value (or global default) applies.
+	DisconnectExpiredCert *bool
+	// Lock configures the role's locking behavior for app sessions.
+	// If empty, the defaults block value (or global default) applies.
+	Lock *Lock
 }
 
 func (b0 ScopedRoleApp_builder) Build() *ScopedRoleApp {
@@ -1308,6 +1399,9 @@ func (b0 ScopedRoleApp_builder) Build() *ScopedRoleApp {
 	_, _ = b, x
 	x.Labels = b.Labels
 	x.LabelExpression = b.LabelExpression
+	x.ClientIdleTimeout = b.ClientIdleTimeout
+	x.DisconnectExpiredCert = b.DisconnectExpiredCert
+	x.Lock = b.Lock
 	return m0
 }
 
@@ -2148,10 +2242,14 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x04lock\x18\a \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x1a\n" +
 	"\x18_disconnect_expired_cert\"N\n" +
 	"\x1aScopedRoleWorkloadIdentity\x120\n" +
-	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\"l\n" +
+	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\"\xaa\x02\n" +
 	"\rScopedRoleApp\x120\n" +
 	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12)\n" +
-	"\x10label_expression\x18\x02 \x01(\tR\x0flabelExpression\"@\n" +
+	"\x10label_expression\x18\x02 \x01(\tR\x0flabelExpression\x12.\n" +
+	"\x13client_idle_timeout\x18\x03 \x01(\tR\x11clientIdleTimeout\x12;\n" +
+	"\x17disconnect_expired_cert\x18\x04 \x01(\bH\x00R\x15disconnectExpiredCert\x88\x01\x01\x123\n" +
+	"\x04lock\x18\x05 \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x1a\n" +
+	"\x18_disconnect_expired_cert\"@\n" +
 	"\n" +
 	"ScopedRule\x12\x1c\n" +
 	"\tresources\x18\x01 \x03(\tR\tresources\x12\x14\n" +
@@ -2234,13 +2332,14 @@ var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
 	14, // 18: teleport.scopes.access.v1.ScopedRoleKube.lock:type_name -> teleport.scopes.access.v1.Lock
 	17, // 19: teleport.scopes.access.v1.ScopedRoleWorkloadIdentity.labels:type_name -> teleport.label.v1.Label
 	17, // 20: teleport.scopes.access.v1.ScopedRoleApp.labels:type_name -> teleport.label.v1.Label
-	9,  // 21: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
-	10, // 22: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
-	23, // [23:23] is the sub-list for method output_type
-	23, // [23:23] is the sub-list for method input_type
-	23, // [23:23] is the sub-list for extension type_name
-	23, // [23:23] is the sub-list for extension extendee
-	0,  // [0:23] is the sub-list for field type_name
+	14, // 21: teleport.scopes.access.v1.ScopedRoleApp.lock:type_name -> teleport.scopes.access.v1.Lock
+	9,  // 22: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
+	10, // 23: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
+	24, // [24:24] is the sub-list for method output_type
+	24, // [24:24] is the sub-list for method input_type
+	24, // [24:24] is the sub-list for extension type_name
+	24, // [24:24] is the sub-list for extension extendee
+	0,  // [0:24] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }
@@ -2251,6 +2350,7 @@ func file_teleport_scopes_access_v1_role_proto_init() {
 	file_teleport_scopes_access_v1_role_proto_msgTypes[2].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[3].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[4].OneofWrappers = []any{}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[6].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[9].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[10].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[12].OneofWrappers = []any{}

--- a/api/gen/proto/go/teleport/scopes/access/v1/role_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role_protoopaque.pb.go
@@ -538,15 +538,20 @@ type ScopedRoleDefaults_builder struct {
 
 	// ClientIdleTimeout sets the default idle timeout for access sessions across all protocols
 	// that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h").
+	// The cluster-wide default is used only when neither this nor the protocol's equivalent
+	// control is set.
 	ClientIdleTimeout string
 	// SessionRecording configures the session recording strategy for all protocols that don't
-	// explicitly set their session recording mode.
+	// explicitly set their session recording mode. If neither this nor the protocol's equivalent control
+	// is set, best_effort is used.
 	SessionRecording *SessionRecording
-	// DisconnectExpiredCert defines the default behavior of all protocols when certs expire for a session.
-	// If unset, cluster wide defaults are used.
+	// DisconnectExpiredCert defines the default behavior of all protocols when certs expire for
+	// a session. The cluster-wide default is used only when neither this nor the protocol's
+	// equivalent control is set.
 	DisconnectExpiredCert *bool
 	// Lock specifies the default locking mode for access sessions across all protocols that
-	// do not specify their own value. If unset, cluster wide defaults are used.
+	// do not specify their own value. The cluster-wide default is used only when neither this
+	// nor the protocol's equivalent control is set.
 	Lock *Lock
 }
 
@@ -926,9 +931,10 @@ type ScopedRoleSSH_builder struct {
 	SessionRecording *SessionRecording
 	// DisconnectExpiredCert controls whether SSH sessions are disconnected when the
 	// user certificate expires.
-	// Defaults to value cluster wide auth preference if not set.
+	// If empty, the defaults block value (or global default) applies.
 	DisconnectExpiredCert *bool
 	// Lock configures the role's locking behavior for SSH sessions.
+	// If empty, the defaults block value (or global default) applies.
 	Lock *Lock
 }
 
@@ -1134,8 +1140,10 @@ type ScopedRoleKube_builder struct {
 	// (or global default) applies.
 	ClientIdleTimeout string
 	// DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires.
+	// If empty, the defaults block value (or global default) applies.
 	DisconnectExpiredCert *bool
 	// Lock configures the role's locking behavior for kubernetes sessions.
+	// If empty, the defaults block value (or global default) applies.
 	Lock *Lock
 }
 
@@ -1227,11 +1235,16 @@ func (b0 ScopedRoleWorkloadIdentity_builder) Build() *ScopedRoleWorkloadIdentity
 
 // ScopedRoleApp groups all scoped role fields relevant to application access.
 type ScopedRoleApp struct {
-	state                      protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Labels          *[]*v11.Label          `protobuf:"bytes,1,rep,name=labels,proto3"`
-	xxx_hidden_LabelExpression string                 `protobuf:"bytes,2,opt,name=label_expression,json=labelExpression,proto3"`
-	unknownFields              protoimpl.UnknownFields
-	sizeCache                  protoimpl.SizeCache
+	state                            protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Labels                *[]*v11.Label          `protobuf:"bytes,1,rep,name=labels,proto3"`
+	xxx_hidden_LabelExpression       string                 `protobuf:"bytes,2,opt,name=label_expression,json=labelExpression,proto3"`
+	xxx_hidden_ClientIdleTimeout     string                 `protobuf:"bytes,3,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3"`
+	xxx_hidden_DisconnectExpiredCert bool                   `protobuf:"varint,4,opt,name=disconnect_expired_cert,json=disconnectExpiredCert,proto3,oneof"`
+	xxx_hidden_Lock                  *Lock                  `protobuf:"bytes,5,opt,name=lock,proto3"`
+	XXX_raceDetectHookData           protoimpl.RaceDetectHookData
+	XXX_presence                     [1]uint32
+	unknownFields                    protoimpl.UnknownFields
+	sizeCache                        protoimpl.SizeCache
 }
 
 func (x *ScopedRoleApp) Reset() {
@@ -1275,12 +1288,69 @@ func (x *ScopedRoleApp) GetLabelExpression() string {
 	return ""
 }
 
+func (x *ScopedRoleApp) GetClientIdleTimeout() string {
+	if x != nil {
+		return x.xxx_hidden_ClientIdleTimeout
+	}
+	return ""
+}
+
+func (x *ScopedRoleApp) GetDisconnectExpiredCert() bool {
+	if x != nil {
+		return x.xxx_hidden_DisconnectExpiredCert
+	}
+	return false
+}
+
+func (x *ScopedRoleApp) GetLock() *Lock {
+	if x != nil {
+		return x.xxx_hidden_Lock
+	}
+	return nil
+}
+
 func (x *ScopedRoleApp) SetLabels(v []*v11.Label) {
 	x.xxx_hidden_Labels = &v
 }
 
 func (x *ScopedRoleApp) SetLabelExpression(v string) {
 	x.xxx_hidden_LabelExpression = v
+}
+
+func (x *ScopedRoleApp) SetClientIdleTimeout(v string) {
+	x.xxx_hidden_ClientIdleTimeout = v
+}
+
+func (x *ScopedRoleApp) SetDisconnectExpiredCert(v bool) {
+	x.xxx_hidden_DisconnectExpiredCert = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 3, 5)
+}
+
+func (x *ScopedRoleApp) SetLock(v *Lock) {
+	x.xxx_hidden_Lock = v
+}
+
+func (x *ScopedRoleApp) HasDisconnectExpiredCert() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 3)
+}
+
+func (x *ScopedRoleApp) HasLock() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Lock != nil
+}
+
+func (x *ScopedRoleApp) ClearDisconnectExpiredCert() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 3)
+	x.xxx_hidden_DisconnectExpiredCert = false
+}
+
+func (x *ScopedRoleApp) ClearLock() {
+	x.xxx_hidden_Lock = nil
 }
 
 type ScopedRoleApp_builder struct {
@@ -1291,6 +1361,16 @@ type ScopedRoleApp_builder struct {
 	// LabelExpression is an optional predicate expression evaluated against an
 	// application's labels.
 	LabelExpression string
+	// Overrides the defaults block idle timeout specifically for app sessions.
+	// Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
+	// (or global default) applies.
+	ClientIdleTimeout string
+	// DisconnectExpiredCert controls whether App sessions are disconnected when the user certificate expires.
+	// If empty, the defaults block value (or global default) applies.
+	DisconnectExpiredCert *bool
+	// Lock configures the role's locking behavior for app sessions.
+	// If empty, the defaults block value (or global default) applies.
+	Lock *Lock
 }
 
 func (b0 ScopedRoleApp_builder) Build() *ScopedRoleApp {
@@ -1299,6 +1379,12 @@ func (b0 ScopedRoleApp_builder) Build() *ScopedRoleApp {
 	_, _ = b, x
 	x.xxx_hidden_Labels = &b.Labels
 	x.xxx_hidden_LabelExpression = b.LabelExpression
+	x.xxx_hidden_ClientIdleTimeout = b.ClientIdleTimeout
+	if b.DisconnectExpiredCert != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 3, 5)
+		x.xxx_hidden_DisconnectExpiredCert = *b.DisconnectExpiredCert
+	}
+	x.xxx_hidden_Lock = b.Lock
 	return m0
 }
 
@@ -2152,10 +2238,14 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x04lock\x18\a \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x1a\n" +
 	"\x18_disconnect_expired_cert\"N\n" +
 	"\x1aScopedRoleWorkloadIdentity\x120\n" +
-	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\"l\n" +
+	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\"\xaa\x02\n" +
 	"\rScopedRoleApp\x120\n" +
 	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12)\n" +
-	"\x10label_expression\x18\x02 \x01(\tR\x0flabelExpression\"@\n" +
+	"\x10label_expression\x18\x02 \x01(\tR\x0flabelExpression\x12.\n" +
+	"\x13client_idle_timeout\x18\x03 \x01(\tR\x11clientIdleTimeout\x12;\n" +
+	"\x17disconnect_expired_cert\x18\x04 \x01(\bH\x00R\x15disconnectExpiredCert\x88\x01\x01\x123\n" +
+	"\x04lock\x18\x05 \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x1a\n" +
+	"\x18_disconnect_expired_cert\"@\n" +
 	"\n" +
 	"ScopedRule\x12\x1c\n" +
 	"\tresources\x18\x01 \x03(\tR\tresources\x12\x14\n" +
@@ -2238,13 +2328,14 @@ var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
 	14, // 18: teleport.scopes.access.v1.ScopedRoleKube.lock:type_name -> teleport.scopes.access.v1.Lock
 	17, // 19: teleport.scopes.access.v1.ScopedRoleWorkloadIdentity.labels:type_name -> teleport.label.v1.Label
 	17, // 20: teleport.scopes.access.v1.ScopedRoleApp.labels:type_name -> teleport.label.v1.Label
-	9,  // 21: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
-	10, // 22: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
-	23, // [23:23] is the sub-list for method output_type
-	23, // [23:23] is the sub-list for method input_type
-	23, // [23:23] is the sub-list for extension type_name
-	23, // [23:23] is the sub-list for extension extendee
-	0,  // [0:23] is the sub-list for field type_name
+	14, // 21: teleport.scopes.access.v1.ScopedRoleApp.lock:type_name -> teleport.scopes.access.v1.Lock
+	9,  // 22: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
+	10, // 23: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
+	24, // [24:24] is the sub-list for method output_type
+	24, // [24:24] is the sub-list for method input_type
+	24, // [24:24] is the sub-list for extension type_name
+	24, // [24:24] is the sub-list for extension extendee
+	0,  // [0:24] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }
@@ -2255,6 +2346,7 @@ func file_teleport_scopes_access_v1_role_proto_init() {
 	file_teleport_scopes_access_v1_role_proto_msgTypes[2].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[3].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[4].OneofWrappers = []any{}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[6].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[9].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[10].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[12].OneofWrappers = []any{}

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -91,18 +91,23 @@ message ScopedRoleSpec {
 message ScopedRoleDefaults {
   // ClientIdleTimeout sets the default idle timeout for access sessions across all protocols
   // that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h").
+  // The cluster-wide default is used only when neither this nor the protocol's equivalent
+  // control is set.
   string client_idle_timeout = 1;
 
   // SessionRecording configures the session recording strategy for all protocols that don't
-  // explicitly set their session recording mode.
+  // explicitly set their session recording mode. If neither this nor the protocol's equivalent control
+  // is set, best_effort is used.
   SessionRecording session_recording = 2;
 
-  // DisconnectExpiredCert defines the default behavior of all protocols when certs expire for a session.
-  // If unset, cluster wide defaults are used.
+  // DisconnectExpiredCert defines the default behavior of all protocols when certs expire for
+  // a session. The cluster-wide default is used only when neither this nor the protocol's
+  // equivalent control is set.
   optional bool disconnect_expired_cert = 3;
 
   // Lock specifies the default locking mode for access sessions across all protocols that
-  // do not specify their own value. If unset, cluster wide defaults are used.
+  // do not specify their own value. The cluster-wide default is used only when neither this
+  // nor the protocol's equivalent control is set.
   Lock lock = 4;
 }
 
@@ -154,10 +159,11 @@ message ScopedRoleSSH {
 
   // DisconnectExpiredCert controls whether SSH sessions are disconnected when the
   // user certificate expires.
-  // Defaults to value cluster wide auth preference if not set.
+  // If empty, the defaults block value (or global default) applies.
   optional bool disconnect_expired_cert = 14;
 
   // Lock configures the role's locking behavior for SSH sessions.
+  // If empty, the defaults block value (or global default) applies.
   Lock lock = 15;
 }
 
@@ -185,9 +191,11 @@ message ScopedRoleKube {
   string client_idle_timeout = 5;
 
   // DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires.
+  // If empty, the defaults block value (or global default) applies.
   optional bool disconnect_expired_cert = 6;
 
   // Lock configures the role's locking behavior for kubernetes sessions.
+  // If empty, the defaults block value (or global default) applies.
   Lock lock = 7;
 }
 
@@ -213,6 +221,19 @@ message ScopedRoleApp {
   // LabelExpression is an optional predicate expression evaluated against an
   // application's labels.
   string label_expression = 2;
+
+  // Overrides the defaults block idle timeout specifically for app sessions.
+  // Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
+  // (or global default) applies.
+  string client_idle_timeout = 3;
+
+  // DisconnectExpiredCert controls whether App sessions are disconnected when the user certificate expires.
+  // If empty, the defaults block value (or global default) applies.
+  optional bool disconnect_expired_cert = 4;
+
+  // Lock configures the role's locking behavior for app sessions.
+  // If empty, the defaults block value (or global default) applies.
+  Lock lock = 5;
 }
 
 // ScopedRule maps resources to verbs. This is the underlying type used to describe

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedrolesv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedrolesv1.mdx
@@ -42,8 +42,11 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 |Field|Type|Description|
 |---|---|---|
+|client_idle_timeout|string|Overrides the defaults block idle timeout specifically for app sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.|
+|disconnect_expired_cert|boolean|DisconnectExpiredCert controls whether App sessions are disconnected when the user certificate expires. If empty, the defaults block value (or global default) applies.|
 |label_expression|string|LabelExpression is an optional predicate expression evaluated against an application's labels.|
 |labels|[][object](#specapplabels-items)|The set of application labels used for RBAC.|
+|lock|[object](#specapplock)|Lock configures the role's locking behavior for app sessions. If empty, the defaults block value (or global default) applies.|
 
 ### spec.app.labels items
 
@@ -52,14 +55,20 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |name|string|The name of the label.|
 |values|[]string|The values associated with the label.|
 
+### spec.app.lock
+
+|Field|Type|Description|
+|---|---|---|
+|mode|string|Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.|
+
 ### spec.defaults
 
 |Field|Type|Description|
 |---|---|---|
-|client_idle_timeout|string|ClientIdleTimeout sets the default idle timeout for access sessions across all protocols that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h").|
-|disconnect_expired_cert|boolean|DisconnectExpiredCert defines the default behavior of all protocols when certs expire for a session. If unset, cluster wide defaults are used.|
-|lock|[object](#specdefaultslock)|Lock specifies the default locking mode for access sessions across all protocols that do not specify their own value. If unset, cluster wide defaults are used.|
-|session_recording|[object](#specdefaultssession_recording)|SessionRecording configures the session recording strategy for all protocols that don't explicitly set their session recording mode.|
+|client_idle_timeout|string|ClientIdleTimeout sets the default idle timeout for access sessions across all protocols that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h"). The cluster-wide default is used only when neither this nor the protocol's equivalent control is set.|
+|disconnect_expired_cert|boolean|DisconnectExpiredCert defines the default behavior of all protocols when certs expire for a session. The cluster-wide default is used only when neither this nor the protocol's equivalent control is set.|
+|lock|[object](#specdefaultslock)|Lock specifies the default locking mode for access sessions across all protocols that do not specify their own value. The cluster-wide default is used only when neither this nor the protocol's equivalent control is set.|
+|session_recording|[object](#specdefaultssession_recording)|SessionRecording configures the session recording strategy for all protocols that don't explicitly set their session recording mode. If neither this nor the protocol's equivalent control is set, best_effort is used.|
 
 ### spec.defaults.lock
 
@@ -78,10 +87,10 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |Field|Type|Description|
 |---|---|---|
 |client_idle_timeout|string|Overrides the defaults block idle timeout specifically for kube sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.|
-|disconnect_expired_cert|boolean|DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires.|
+|disconnect_expired_cert|boolean|DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires. If empty, the defaults block value (or global default) applies.|
 |groups|[]string|The list of kubernetes groups this role allows.|
 |labels|[][object](#speckubelabels-items)|The map of kubernetes cluster labels used for RBAC.|
-|lock|[object](#speckubelock)|Lock configures the role's locking behavior for kubernetes sessions.|
+|lock|[object](#speckubelock)|Lock configures the role's locking behavior for kubernetes sessions. If empty, the defaults block value (or global default) applies.|
 |resources|[][object](#speckuberesources-items)|The kubernetes resources this role grants access to.|
 |users|[]string|An optional list of impersonatable kubernetes users this role allows.|
 
@@ -120,14 +129,14 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |Field|Type|Description|
 |---|---|---|
 |client_idle_timeout|string|ClientIdleTimeout overrides the defaults block idle timeout specifically for SSH sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.|
-|disconnect_expired_cert|boolean|DisconnectExpiredCert controls whether SSH sessions are disconnected when the user certificate expires. Defaults to value cluster wide auth preference if not set.|
+|disconnect_expired_cert|boolean|DisconnectExpiredCert controls whether SSH sessions are disconnected when the user certificate expires. If empty, the defaults block value (or global default) applies.|
 |enhanced_recording|[object](#specsshenhanced_recording)|EnhancedRecording is the set of BPF events to record for enhanced session recording.|
 |file_copy|boolean|FileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to allowing the user to download and upload files by default.|
 |forward_agent|boolean|ForwardAgent enables SSH agent forwarding.|
 |host_sudoers|[]string|Sudoers is a list of entries to include in a users sudoer file|
 |host_user_creation|[object](#specsshhost_user_creation)|HostUserCreation configures the creation of host users.|
 |labels|[][object](#specsshlabels-items)|Labels is the set of node labels used to dynamically select which nodes this role applies to.|
-|lock|[object](#specsshlock)|Lock configures the role's locking behavior for SSH sessions.|
+|lock|[object](#specsshlock)|Lock configures the role's locking behavior for SSH sessions. If empty, the defaults block value (or global default) applies.|
 |logins|[]string|Logins is the list of OS logins this role permits on matching nodes.|
 |max_sessions|integer|MaxSessions defines the maximum number of concurrent sessions per connection.|
 |permit_x11_forwarding|boolean|PermitX11Forwarding, when true, authorizes use of X11 forwarding over SSH sessions. If not set, X11 forwarding is not permitted.|

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role.mdx
@@ -64,8 +64,11 @@ Optional:
 
 Optional:
 
+- `client_idle_timeout` (String) Overrides the defaults block idle timeout specifically for app sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.
+- `disconnect_expired_cert` (Boolean) DisconnectExpiredCert controls whether App sessions are disconnected when the user certificate expires. If empty, the defaults block value (or global default) applies.
 - `label_expression` (String) LabelExpression is an optional predicate expression evaluated against an application's labels.
 - `labels` (Attributes List) The set of application labels used for RBAC. (see [below for nested schema](#nested-schema-for-specapplabels))
+- `lock` (Attributes) Lock configures the role's locking behavior for app sessions. If empty, the defaults block value (or global default) applies. (see [below for nested schema](#nested-schema-for-specapplock))
 
 ### Nested Schema for `spec.app.labels`
 
@@ -75,15 +78,22 @@ Optional:
 - `values` (List of String) The values associated with the label.
 
 
+### Nested Schema for `spec.app.lock`
+
+Optional:
+
+- `mode` (String) Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.
+
+
 
 ### Nested Schema for `spec.defaults`
 
 Optional:
 
-- `client_idle_timeout` (String) ClientIdleTimeout sets the default idle timeout for access sessions across all protocols that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h").
-- `disconnect_expired_cert` (Boolean) DisconnectExpiredCert defines the default behavior of all protocols when certs expire for a session. If unset, cluster wide defaults are used.
-- `lock` (Attributes) Lock specifies the default locking mode for access sessions across all protocols that do not specify their own value. If unset, cluster wide defaults are used. (see [below for nested schema](#nested-schema-for-specdefaultslock))
-- `session_recording` (Attributes) SessionRecording configures the session recording strategy for all protocols that don't explicitly set their session recording mode. (see [below for nested schema](#nested-schema-for-specdefaultssession_recording))
+- `client_idle_timeout` (String) ClientIdleTimeout sets the default idle timeout for access sessions across all protocols that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h"). The cluster-wide default is used only when neither this nor the protocol's equivalent control is set.
+- `disconnect_expired_cert` (Boolean) DisconnectExpiredCert defines the default behavior of all protocols when certs expire for a session. The cluster-wide default is used only when neither this nor the protocol's equivalent control is set.
+- `lock` (Attributes) Lock specifies the default locking mode for access sessions across all protocols that do not specify their own value. The cluster-wide default is used only when neither this nor the protocol's equivalent control is set. (see [below for nested schema](#nested-schema-for-specdefaultslock))
+- `session_recording` (Attributes) SessionRecording configures the session recording strategy for all protocols that don't explicitly set their session recording mode. If neither this nor the protocol's equivalent control is set, best_effort is used. (see [below for nested schema](#nested-schema-for-specdefaultssession_recording))
 
 ### Nested Schema for `spec.defaults.lock`
 
@@ -105,10 +115,10 @@ Optional:
 Optional:
 
 - `client_idle_timeout` (String) Overrides the defaults block idle timeout specifically for kube sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.
-- `disconnect_expired_cert` (Boolean) DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires.
+- `disconnect_expired_cert` (Boolean) DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires. If empty, the defaults block value (or global default) applies.
 - `groups` (List of String) The list of kubernetes groups this role allows.
 - `labels` (Attributes List) The map of kubernetes cluster labels used for RBAC. (see [below for nested schema](#nested-schema-for-speckubelabels))
-- `lock` (Attributes) Lock configures the role's locking behavior for kubernetes sessions. (see [below for nested schema](#nested-schema-for-speckubelock))
+- `lock` (Attributes) Lock configures the role's locking behavior for kubernetes sessions. If empty, the defaults block value (or global default) applies. (see [below for nested schema](#nested-schema-for-speckubelock))
 - `resources` (Attributes List) The kubernetes resources this role grants access to. (see [below for nested schema](#nested-schema-for-speckuberesources))
 - `users` (List of String) An optional list of impersonatable kubernetes users this role allows.
 
@@ -152,14 +162,14 @@ Optional:
 Optional:
 
 - `client_idle_timeout` (String) ClientIdleTimeout overrides the defaults block idle timeout specifically for SSH sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.
-- `disconnect_expired_cert` (Boolean) DisconnectExpiredCert controls whether SSH sessions are disconnected when the user certificate expires. Defaults to value cluster wide auth preference if not set.
+- `disconnect_expired_cert` (Boolean) DisconnectExpiredCert controls whether SSH sessions are disconnected when the user certificate expires. If empty, the defaults block value (or global default) applies.
 - `enhanced_recording` (Attributes) EnhancedRecording is the set of BPF events to record for enhanced session recording. (see [below for nested schema](#nested-schema-for-specsshenhanced_recording))
 - `file_copy` (Boolean) FileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to allowing the user to download and upload files by default.
 - `forward_agent` (Boolean) ForwardAgent enables SSH agent forwarding.
 - `host_sudoers` (List of String) Sudoers is a list of entries to include in a users sudoer file
 - `host_user_creation` (Attributes) HostUserCreation configures the creation of host users. (see [below for nested schema](#nested-schema-for-specsshhost_user_creation))
 - `labels` (Attributes List) Labels is the set of node labels used to dynamically select which nodes this role applies to. (see [below for nested schema](#nested-schema-for-specsshlabels))
-- `lock` (Attributes) Lock configures the role's locking behavior for SSH sessions. (see [below for nested schema](#nested-schema-for-specsshlock))
+- `lock` (Attributes) Lock configures the role's locking behavior for SSH sessions. If empty, the defaults block value (or global default) applies. (see [below for nested schema](#nested-schema-for-specsshlock))
 - `logins` (List of String) Logins is the list of OS logins this role permits on matching nodes.
 - `max_sessions` (Number) MaxSessions defines the maximum number of concurrent sessions per connection.
 - `permit_x11_forwarding` (Boolean) PermitX11Forwarding, when true, authorizes use of X11 forwarding over SSH sessions. If not set, X11 forwarding is not permitted.

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role.mdx
@@ -93,8 +93,11 @@ Optional:
 
 Optional:
 
+- `client_idle_timeout` (String) Overrides the defaults block idle timeout specifically for app sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.
+- `disconnect_expired_cert` (Boolean) DisconnectExpiredCert controls whether App sessions are disconnected when the user certificate expires. If empty, the defaults block value (or global default) applies.
 - `label_expression` (String) LabelExpression is an optional predicate expression evaluated against an application's labels.
 - `labels` (Attributes List) The set of application labels used for RBAC. (see [below for nested schema](#nested-schema-for-specapplabels))
+- `lock` (Attributes) Lock configures the role's locking behavior for app sessions. If empty, the defaults block value (or global default) applies. (see [below for nested schema](#nested-schema-for-specapplock))
 
 ### Nested Schema for `spec.app.labels`
 
@@ -104,15 +107,22 @@ Optional:
 - `values` (List of String) The values associated with the label.
 
 
+### Nested Schema for `spec.app.lock`
+
+Optional:
+
+- `mode` (String) Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.
+
+
 
 ### Nested Schema for `spec.defaults`
 
 Optional:
 
-- `client_idle_timeout` (String) ClientIdleTimeout sets the default idle timeout for access sessions across all protocols that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h").
-- `disconnect_expired_cert` (Boolean) DisconnectExpiredCert defines the default behavior of all protocols when certs expire for a session. If unset, cluster wide defaults are used.
-- `lock` (Attributes) Lock specifies the default locking mode for access sessions across all protocols that do not specify their own value. If unset, cluster wide defaults are used. (see [below for nested schema](#nested-schema-for-specdefaultslock))
-- `session_recording` (Attributes) SessionRecording configures the session recording strategy for all protocols that don't explicitly set their session recording mode. (see [below for nested schema](#nested-schema-for-specdefaultssession_recording))
+- `client_idle_timeout` (String) ClientIdleTimeout sets the default idle timeout for access sessions across all protocols that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h"). The cluster-wide default is used only when neither this nor the protocol's equivalent control is set.
+- `disconnect_expired_cert` (Boolean) DisconnectExpiredCert defines the default behavior of all protocols when certs expire for a session. The cluster-wide default is used only when neither this nor the protocol's equivalent control is set.
+- `lock` (Attributes) Lock specifies the default locking mode for access sessions across all protocols that do not specify their own value. The cluster-wide default is used only when neither this nor the protocol's equivalent control is set. (see [below for nested schema](#nested-schema-for-specdefaultslock))
+- `session_recording` (Attributes) SessionRecording configures the session recording strategy for all protocols that don't explicitly set their session recording mode. If neither this nor the protocol's equivalent control is set, best_effort is used. (see [below for nested schema](#nested-schema-for-specdefaultssession_recording))
 
 ### Nested Schema for `spec.defaults.lock`
 
@@ -134,10 +144,10 @@ Optional:
 Optional:
 
 - `client_idle_timeout` (String) Overrides the defaults block idle timeout specifically for kube sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.
-- `disconnect_expired_cert` (Boolean) DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires.
+- `disconnect_expired_cert` (Boolean) DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires. If empty, the defaults block value (or global default) applies.
 - `groups` (List of String) The list of kubernetes groups this role allows.
 - `labels` (Attributes List) The map of kubernetes cluster labels used for RBAC. (see [below for nested schema](#nested-schema-for-speckubelabels))
-- `lock` (Attributes) Lock configures the role's locking behavior for kubernetes sessions. (see [below for nested schema](#nested-schema-for-speckubelock))
+- `lock` (Attributes) Lock configures the role's locking behavior for kubernetes sessions. If empty, the defaults block value (or global default) applies. (see [below for nested schema](#nested-schema-for-speckubelock))
 - `resources` (Attributes List) The kubernetes resources this role grants access to. (see [below for nested schema](#nested-schema-for-speckuberesources))
 - `users` (List of String) An optional list of impersonatable kubernetes users this role allows.
 
@@ -181,14 +191,14 @@ Optional:
 Optional:
 
 - `client_idle_timeout` (String) ClientIdleTimeout overrides the defaults block idle timeout specifically for SSH sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.
-- `disconnect_expired_cert` (Boolean) DisconnectExpiredCert controls whether SSH sessions are disconnected when the user certificate expires. Defaults to value cluster wide auth preference if not set.
+- `disconnect_expired_cert` (Boolean) DisconnectExpiredCert controls whether SSH sessions are disconnected when the user certificate expires. If empty, the defaults block value (or global default) applies.
 - `enhanced_recording` (Attributes) EnhancedRecording is the set of BPF events to record for enhanced session recording. (see [below for nested schema](#nested-schema-for-specsshenhanced_recording))
 - `file_copy` (Boolean) FileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to allowing the user to download and upload files by default.
 - `forward_agent` (Boolean) ForwardAgent enables SSH agent forwarding.
 - `host_sudoers` (List of String) Sudoers is a list of entries to include in a users sudoer file
 - `host_user_creation` (Attributes) HostUserCreation configures the creation of host users. (see [below for nested schema](#nested-schema-for-specsshhost_user_creation))
 - `labels` (Attributes List) Labels is the set of node labels used to dynamically select which nodes this role applies to. (see [below for nested schema](#nested-schema-for-specsshlabels))
-- `lock` (Attributes) Lock configures the role's locking behavior for SSH sessions. (see [below for nested schema](#nested-schema-for-specsshlock))
+- `lock` (Attributes) Lock configures the role's locking behavior for SSH sessions. If empty, the defaults block value (or global default) applies. (see [below for nested schema](#nested-schema-for-specsshlock))
 - `logins` (List of String) Logins is the list of OS logins this role permits on matching nodes.
 - `max_sessions` (Number) MaxSessions defines the maximum number of concurrent sessions per connection.
 - `permit_x11_forwarding` (Boolean) PermitX11Forwarding, when true, authorizes use of X11 forwarding over SSH sessions. If not set, X11 forwarding is not permitted.

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
@@ -56,6 +56,17 @@ spec:
                 description: The App Access specific configuration for a scoped role.
                 nullable: true
                 properties:
+                  client_idle_timeout:
+                    description: Overrides the defaults block idle timeout specifically
+                      for app sessions. Must be a valid Go duration string (e.g. "30m",
+                      "1h"). If empty, the defaults block value (or global default)
+                      applies.
+                    type: string
+                  disconnect_expired_cert:
+                    description: DisconnectExpiredCert controls whether App sessions
+                      are disconnected when the user certificate expires. If empty,
+                      the defaults block value (or global default) applies.
+                    type: boolean
                   label_expression:
                     description: LabelExpression is an optional predicate expression
                       evaluated against an application's labels.
@@ -76,6 +87,17 @@ spec:
                       type: object
                     nullable: true
                     type: array
+                  lock:
+                    description: Lock configures the role's locking behavior for app
+                      sessions. If empty, the defaults block value (or global default)
+                      applies.
+                    nullable: true
+                    properties:
+                      mode:
+                        description: 'Allowed values: strict or best_effort. Defaults
+                          to value cluster wide auth preference if not set.'
+                        type: string
+                    type: object
                 type: object
               assignable_scopes:
                 description: AssignableScopes is a list of scopes to which this role
@@ -95,16 +117,20 @@ spec:
                     description: ClientIdleTimeout sets the default idle timeout for
                       access sessions across all protocols that do not specify their
                       own value. Must be a valid Go duration string (e.g. "30m", "1h").
+                      The cluster-wide default is used only when neither this nor
+                      the protocol's equivalent control is set.
                     type: string
                   disconnect_expired_cert:
                     description: DisconnectExpiredCert defines the default behavior
-                      of all protocols when certs expire for a session. If unset,
-                      cluster wide defaults are used.
+                      of all protocols when certs expire for a session. The cluster-wide
+                      default is used only when neither this nor the protocol's equivalent
+                      control is set.
                     type: boolean
                   lock:
                     description: Lock specifies the default locking mode for access
                       sessions across all protocols that do not specify their own
-                      value. If unset, cluster wide defaults are used.
+                      value. The cluster-wide default is used only when neither this
+                      nor the protocol's equivalent control is set.
                     nullable: true
                     properties:
                       mode:
@@ -115,7 +141,8 @@ spec:
                   session_recording:
                     description: SessionRecording configures the session recording
                       strategy for all protocols that don't explicitly set their session
-                      recording mode.
+                      recording mode. If neither this nor the protocol's equivalent
+                      control is set, best_effort is used.
                     nullable: true
                     properties:
                       mode:
@@ -136,7 +163,8 @@ spec:
                     type: string
                   disconnect_expired_cert:
                     description: DisconnectExpiredCert controls whether Kube sessions
-                      are disconnected when the user certificate expires.
+                      are disconnected when the user certificate expires. If empty,
+                      the defaults block value (or global default) applies.
                     type: boolean
                   groups:
                     description: The list of kubernetes groups this role allows.
@@ -162,7 +190,8 @@ spec:
                     type: array
                   lock:
                     description: Lock configures the role's locking behavior for kubernetes
-                      sessions.
+                      sessions. If empty, the defaults block value (or global default)
+                      applies.
                     nullable: true
                     properties:
                       mode:
@@ -240,8 +269,8 @@ spec:
                     type: string
                   disconnect_expired_cert:
                     description: DisconnectExpiredCert controls whether SSH sessions
-                      are disconnected when the user certificate expires. Defaults
-                      to value cluster wide auth preference if not set.
+                      are disconnected when the user certificate expires. If empty,
+                      the defaults block value (or global default) applies.
                     type: boolean
                   enhanced_recording:
                     description: EnhancedRecording is the set of BPF events to record
@@ -311,7 +340,8 @@ spec:
                     type: array
                   lock:
                     description: Lock configures the role's locking behavior for SSH
-                      sessions.
+                      sessions. If empty, the defaults block value (or global default)
+                      applies.
                     nullable: true
                     properties:
                       mode:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
@@ -56,6 +56,17 @@ spec:
                 description: The App Access specific configuration for a scoped role.
                 nullable: true
                 properties:
+                  client_idle_timeout:
+                    description: Overrides the defaults block idle timeout specifically
+                      for app sessions. Must be a valid Go duration string (e.g. "30m",
+                      "1h"). If empty, the defaults block value (or global default)
+                      applies.
+                    type: string
+                  disconnect_expired_cert:
+                    description: DisconnectExpiredCert controls whether App sessions
+                      are disconnected when the user certificate expires. If empty,
+                      the defaults block value (or global default) applies.
+                    type: boolean
                   label_expression:
                     description: LabelExpression is an optional predicate expression
                       evaluated against an application's labels.
@@ -76,6 +87,17 @@ spec:
                       type: object
                     nullable: true
                     type: array
+                  lock:
+                    description: Lock configures the role's locking behavior for app
+                      sessions. If empty, the defaults block value (or global default)
+                      applies.
+                    nullable: true
+                    properties:
+                      mode:
+                        description: 'Allowed values: strict or best_effort. Defaults
+                          to value cluster wide auth preference if not set.'
+                        type: string
+                    type: object
                 type: object
               assignable_scopes:
                 description: AssignableScopes is a list of scopes to which this role
@@ -95,16 +117,20 @@ spec:
                     description: ClientIdleTimeout sets the default idle timeout for
                       access sessions across all protocols that do not specify their
                       own value. Must be a valid Go duration string (e.g. "30m", "1h").
+                      The cluster-wide default is used only when neither this nor
+                      the protocol's equivalent control is set.
                     type: string
                   disconnect_expired_cert:
                     description: DisconnectExpiredCert defines the default behavior
-                      of all protocols when certs expire for a session. If unset,
-                      cluster wide defaults are used.
+                      of all protocols when certs expire for a session. The cluster-wide
+                      default is used only when neither this nor the protocol's equivalent
+                      control is set.
                     type: boolean
                   lock:
                     description: Lock specifies the default locking mode for access
                       sessions across all protocols that do not specify their own
-                      value. If unset, cluster wide defaults are used.
+                      value. The cluster-wide default is used only when neither this
+                      nor the protocol's equivalent control is set.
                     nullable: true
                     properties:
                       mode:
@@ -115,7 +141,8 @@ spec:
                   session_recording:
                     description: SessionRecording configures the session recording
                       strategy for all protocols that don't explicitly set their session
-                      recording mode.
+                      recording mode. If neither this nor the protocol's equivalent
+                      control is set, best_effort is used.
                     nullable: true
                     properties:
                       mode:
@@ -136,7 +163,8 @@ spec:
                     type: string
                   disconnect_expired_cert:
                     description: DisconnectExpiredCert controls whether Kube sessions
-                      are disconnected when the user certificate expires.
+                      are disconnected when the user certificate expires. If empty,
+                      the defaults block value (or global default) applies.
                     type: boolean
                   groups:
                     description: The list of kubernetes groups this role allows.
@@ -162,7 +190,8 @@ spec:
                     type: array
                   lock:
                     description: Lock configures the role's locking behavior for kubernetes
-                      sessions.
+                      sessions. If empty, the defaults block value (or global default)
+                      applies.
                     nullable: true
                     properties:
                       mode:
@@ -240,8 +269,8 @@ spec:
                     type: string
                   disconnect_expired_cert:
                     description: DisconnectExpiredCert controls whether SSH sessions
-                      are disconnected when the user certificate expires. Defaults
-                      to value cluster wide auth preference if not set.
+                      are disconnected when the user certificate expires. If empty,
+                      the defaults block value (or global default) applies.
                     type: boolean
                   enhanced_recording:
                     description: EnhancedRecording is the set of BPF events to record
@@ -311,7 +340,8 @@ spec:
                     type: array
                   lock:
                     description: Lock configures the role's locking behavior for SSH
-                      sessions.
+                      sessions. If empty, the defaults block value (or global default)
+                      applies.
                     nullable: true
                     properties:
                       mode:

--- a/integrations/terraform/tfschema/scopes/access/v1/role_terraform.go
+++ b/integrations/terraform/tfschema/scopes/access/v1/role_terraform.go
@@ -112,6 +112,16 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				"app": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+						"client_idle_timeout": {
+							Description: "Overrides the defaults block idle timeout specifically for app sessions. Must be a valid Go duration string (e.g. \"30m\", \"1h\"). If empty, the defaults block value (or global default) applies.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"disconnect_expired_cert": {
+							Description: "DisconnectExpiredCert controls whether App sessions are disconnected when the user certificate expires. If empty, the defaults block value (or global default) applies.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
+						},
 						"label_expression": {
 							Description: "LabelExpression is an optional predicate expression evaluated against an application's labels.",
 							Optional:    true,
@@ -133,6 +143,15 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 							Description: "The set of application labels used for RBAC.",
 							Optional:    true,
 						},
+						"lock": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"mode": {
+								Description: "Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.",
+								Optional:    true,
+								Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+							}}),
+							Description: "Lock configures the role's locking behavior for app sessions. If empty, the defaults block value (or global default) applies.",
+							Optional:    true,
+						},
 					}),
 					Description: "The App Access specific configuration for a scoped role.",
 					Optional:    true,
@@ -145,12 +164,12 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 				"defaults": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						"client_idle_timeout": {
-							Description: "ClientIdleTimeout sets the default idle timeout for access sessions across all protocols that do not specify their own value. Must be a valid Go duration string (e.g. \"30m\", \"1h\").",
+							Description: "ClientIdleTimeout sets the default idle timeout for access sessions across all protocols that do not specify their own value. Must be a valid Go duration string (e.g. \"30m\", \"1h\"). The cluster-wide default is used only when neither this nor the protocol's equivalent control is set.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 						"disconnect_expired_cert": {
-							Description: "DisconnectExpiredCert defines the default behavior of all protocols when certs expire for a session. If unset, cluster wide defaults are used.",
+							Description: "DisconnectExpiredCert defines the default behavior of all protocols when certs expire for a session. The cluster-wide default is used only when neither this nor the protocol's equivalent control is set.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
 						},
@@ -160,7 +179,7 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 								Optional:    true,
 								Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 							}}),
-							Description: "Lock specifies the default locking mode for access sessions across all protocols that do not specify their own value. If unset, cluster wide defaults are used.",
+							Description: "Lock specifies the default locking mode for access sessions across all protocols that do not specify their own value. The cluster-wide default is used only when neither this nor the protocol's equivalent control is set.",
 							Optional:    true,
 						},
 						"session_recording": {
@@ -169,7 +188,7 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 								Optional:    true,
 								Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 							}}),
-							Description: "SessionRecording configures the session recording strategy for all protocols that don't explicitly set their session recording mode.",
+							Description: "SessionRecording configures the session recording strategy for all protocols that don't explicitly set their session recording mode. If neither this nor the protocol's equivalent control is set, best_effort is used.",
 							Optional:    true,
 						},
 					}),
@@ -184,7 +203,7 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 						"disconnect_expired_cert": {
-							Description: "DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires.",
+							Description: "DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires. If empty, the defaults block value (or global default) applies.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
 						},
@@ -215,7 +234,7 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 								Optional:    true,
 								Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 							}}),
-							Description: "Lock configures the role's locking behavior for kubernetes sessions.",
+							Description: "Lock configures the role's locking behavior for kubernetes sessions. If empty, the defaults block value (or global default) applies.",
 							Optional:    true,
 						},
 						"resources": {
@@ -282,7 +301,7 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 						"disconnect_expired_cert": {
-							Description: "DisconnectExpiredCert controls whether SSH sessions are disconnected when the user certificate expires. Defaults to value cluster wide auth preference if not set.",
+							Description: "DisconnectExpiredCert controls whether SSH sessions are disconnected when the user certificate expires. If empty, the defaults block value (or global default) applies.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
 						},
@@ -365,7 +384,7 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 								Optional:    true,
 								Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 							}}),
-							Description: "Lock configures the role's locking behavior for SSH sessions.",
+							Description: "Lock configures the role's locking behavior for SSH sessions. If empty, the defaults block value (or global default) applies.",
 							Optional:    true,
 						},
 						"logins": {
@@ -1989,6 +2008,76 @@ func CopyScopedRoleFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 													t = string(v.Value)
 												}
 												obj.LabelExpression = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["client_idle_timeout"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.app.client_idle_timeout"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.app.client_idle_timeout", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.ClientIdleTimeout = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["disconnect_expired_cert"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.app.disconnect_expired_cert"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.app.disconnect_expired_cert", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+											} else {
+												var t *bool
+												if !v.Null && !v.Unknown {
+													c := bool(v.Value)
+													t = &c
+												}
+												obj.DisconnectExpiredCert = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["lock"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.app.lock"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.app.lock", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+											} else {
+												obj.Lock = nil
+												if !v.Null && !v.Unknown {
+													tf := v
+													obj.Lock = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_access_v1.Lock{}
+													obj := obj.Lock
+													{
+														a, ok := tf.Attrs["mode"]
+														if !ok {
+															diags.Append(attrReadMissingDiag{"ScopedRole.spec.app.lock.mode"})
+														} else {
+															v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.app.lock.mode", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+															} else {
+																var t string
+																if !v.Null && !v.Unknown {
+																	t = string(v.Value)
+																}
+																obj.Mode = t
+															}
+														}
+													}
+												}
 											}
 										}
 									}
@@ -4543,6 +4632,108 @@ func CopyScopedRoleToTerraform(ctx context.Context, obj *github_com_gravitationa
 											v.Value = string(obj.LabelExpression)
 											v.Unknown = false
 											tf.Attrs["label_expression"] = v
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["client_idle_timeout"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.app.client_idle_timeout"})
+										} else {
+											v, ok := tf.Attrs["client_idle_timeout"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ScopedRole.spec.app.client_idle_timeout", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.app.client_idle_timeout", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.ClientIdleTimeout) == ""
+											}
+											v.Value = string(obj.ClientIdleTimeout)
+											v.Unknown = false
+											tf.Attrs["client_idle_timeout"] = v
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["disconnect_expired_cert"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.app.disconnect_expired_cert"})
+										} else {
+											v, ok := tf.Attrs["disconnect_expired_cert"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ScopedRole.spec.app.disconnect_expired_cert", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.app.disconnect_expired_cert", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+												}
+											}
+											if obj.DisconnectExpiredCert == nil {
+												v.Null = true
+											} else {
+												v.Null = false
+												v.Value = bool(*obj.DisconnectExpiredCert)
+											}
+											v.Unknown = false
+											tf.Attrs["disconnect_expired_cert"] = v
+										}
+									}
+									{
+										a, ok := tf.AttrTypes["lock"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.app.lock"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.app.lock", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+											} else {
+												v, ok := tf.Attrs["lock"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+												if !ok {
+													v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+														AttrTypes: o.AttrTypes,
+														Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+													}
+												} else {
+													if v.Attrs == nil {
+														v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+													}
+												}
+												if obj.Lock == nil {
+													v.Null = true
+												} else {
+													obj := obj.Lock
+													tf := &v
+													{
+														t, ok := tf.AttrTypes["mode"]
+														if !ok {
+															diags.Append(attrWriteMissingDiag{"ScopedRole.spec.app.lock.mode"})
+														} else {
+															v, ok := tf.Attrs["mode"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																if err != nil {
+																	diags.Append(attrWriteGeneralError{"ScopedRole.spec.app.lock.mode", err})
+																}
+																v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																if !ok {
+																	diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.app.lock.mode", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																}
+																v.Null = string(obj.Mode) == ""
+															}
+															v.Value = string(obj.Mode)
+															v.Unknown = false
+															tf.Attrs["mode"] = v
+														}
+													}
+												}
+												v.Unknown = false
+												tf.Attrs["lock"] = v
+											}
 										}
 									}
 								}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2184,7 +2184,7 @@ func (a *ServerWithRoles) ResolveSSHTarget(ctx context.Context, req *proto.Resol
 	return &proto.ResolveSSHTargetResponse{Server: bestServer}, nil
 }
 
-// ListResources is the scoped equivalent of [ServerWithRoles.ListResources]. Only kube_server and
+// ListResources is the scoped equivalent of [ServerWithRoles.ListResources]. Only kube_server, app_server, and
 // kube_cluster resource types are currently supported for scoped identities. Advanced features like
 // search_as_roles, preview_as_roles, and login inclusion are not yet available for scoped identities.
 func (a *ScopedServerWithRoles) ListResources(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
@@ -2196,8 +2196,11 @@ func (a *ScopedServerWithRoles) ListResources(ctx context.Context, req proto.Lis
 		return nil, trace.AccessDenied("search_as_roles is not supported for scoped identities")
 	case req.UsePreviewAsRoles:
 		return nil, trace.AccessDenied("preview_as_roles is not supported for scoped identities")
-	case req.IncludeLogins:
-		return nil, trace.AccessDenied("include_logins is not supported for scoped identities")
+	case req.IncludeLogins && req.ResourceType != types.KindAppServer:
+		// include_logins is only used for AWS console apps and is otherwise unsupported for
+		// scoped identities. It will be left empty for now so that we can still list normal apps.
+		// Reject it for every other resource kind.
+		return nil, trace.AccessDenied("include_logins is not supported for scoped identities for resource %q", req.ResourceType)
 	}
 
 	switch req.ResourceType {
@@ -2207,42 +2210,7 @@ func (a *ScopedServerWithRoles) ListResources(ctx context.Context, req proto.Lis
 	}
 
 	if req.RequiresFakePagination() {
-		if req.ResourceType != types.KindKubernetesCluster {
-			// Kube clusters always use fake pagination but we don't have a need to support other kinds while using
-			// scoped credentials at this time. We explicitly disallow other kinds to avoid any potential for calling
-			// listResourcesWithSort with a kind that does not properly support scoped access.
-			return nil, trace.BadParameter("scoped resource kind %q does not support fake pagination", req.ResourceType)
-		}
-		if err := req.CheckAndSetDefaults(); err != nil {
-			return nil, trace.Wrap(err)
-		}
-		kubeServers, err := a.GetKubernetesServers(ctx)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		var clusters []types.KubeCluster
-		for _, svc := range kubeServers {
-			clusters = append(clusters, svc.GetCluster())
-		}
-		sortedClusters := types.KubeClusters(clusters)
-		if err := sortedClusters.SortByCustom(req.SortBy); err != nil {
-			return nil, trace.Wrap(err)
-		}
-		params := local.FakePaginateParams{
-			ResourceType:   req.ResourceType,
-			Limit:          req.Limit,
-			Labels:         req.Labels,
-			SearchKeywords: req.SearchKeywords,
-			StartKey:       req.StartKey,
-		}
-		if req.PredicateExpression != "" {
-			expression, err := services.NewResourceExpression(req.PredicateExpression)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			params.PredicateExpression = expression
-		}
-		return local.FakePaginate(sortedClusters.AsResources(), params)
+		return a.listResourcesWithSort(ctx, req)
 	}
 
 	if err := req.CheckAndSetDefaults(); err != nil {
@@ -2624,7 +2592,7 @@ func (a *ServerWithRoles) listResourcesWithSort(ctx context.Context, req proto.L
 		resources = servers.AsResources()
 
 	case types.KindAppServer:
-		appservers, err := a.GetApplicationServers(ctx, req.Namespace)
+		appservers, err := a.ScopedServerWithRoles().GetApplicationServers(ctx, req.Namespace)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -2788,6 +2756,64 @@ func (a *ServerWithRoles) listResourcesWithSort(ctx context.Context, req proto.L
 	}
 
 	return resp, nil
+}
+
+// listResourcesWithSort is the scoped equivalent of [ServerWithRoles.listResourcesWithSort].
+// It only supports listing apps servers (not apps) and kube clusters (not kube servers)
+// at this point and will need to be updated to reach feature parity with the Unscoped version.
+// This function only supports listing with fake pagination.
+func (a *ScopedServerWithRoles) listResourcesWithSort(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var resources []types.ResourceWithLabels
+	switch req.ResourceType {
+	case types.KindKubernetesCluster:
+		kubeServers, err := a.GetKubernetesServers(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		var clusters []types.KubeCluster
+		for _, svc := range kubeServers {
+			clusters = append(clusters, svc.GetCluster())
+		}
+		sortedClusters := types.KubeClusters(clusters)
+		if err := sortedClusters.SortByCustom(req.SortBy); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		resources = sortedClusters.AsResources()
+	case types.KindAppServer:
+		appServers, err := a.GetApplicationServers(ctx, req.Namespace)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		sortedServers := types.AppServers(appServers)
+		if err := sortedServers.SortByCustom(req.SortBy); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		resources = sortedServers.AsResources()
+	default:
+		// We explicitly disallow other kinds to avoid any potential for calling
+		// FakePaginate with a kind that does not properly support scoped access.
+		return nil, trace.BadParameter("scoped resource kind %q does not support fake pagination", req.ResourceType)
+	}
+
+	params := local.FakePaginateParams{
+		ResourceType:   req.ResourceType,
+		Limit:          req.Limit,
+		Labels:         req.Labels,
+		SearchKeywords: req.SearchKeywords,
+		StartKey:       req.StartKey,
+	}
+	if req.PredicateExpression != "" {
+		expression, err := services.NewResourceExpression(req.PredicateExpression)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		params.PredicateExpression = expression
+	}
+	return local.FakePaginate(resources, params)
 }
 
 // Deprecated: Prefer paginated variant [ListAuthServers].
@@ -3841,14 +3867,8 @@ func (a *ServerWithRoles) GenerateUserCerts(ctx context.Context, req proto.UserC
 }
 
 // GenerateUserCerts generates users certificates. Scoped identities are currently limited to
-// generating kubernetes certificates.
+// generating kubernetes and app certificates.
 func (a *ScopedServerWithRoles) GenerateUserCerts(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
-	if _, isUnscoped := a.UnscopedServerWithRoles(); !isUnscoped {
-		// Scoped identities may only generate Kubernetes certificates.
-		if req.Usage != proto.UserCertsRequest_Kubernetes || req.KubernetesCluster == "" {
-			return nil, trace.Wrap(services.ErrScopedIdentity, "generating scoped user cert for non-kubernetes usage")
-		}
-	}
 	identity := a.scopedContext.Identity.GetIdentity()
 	return a.generateUserCerts(ctx, req, certRequestDeviceExtensions(identity.DeviceExtensions))
 }
@@ -3919,12 +3939,23 @@ func (a *ScopedServerWithRoles) generateUserCerts(ctx context.Context, req proto
 		isScoped = false
 		unscopedSWR, _ = a.UnscopedServerWithRoles()
 	}
-	isKubeCert := req.Usage == proto.UserCertsRequest_Kubernetes && req.KubernetesCluster != ""
-	if isScoped && !isKubeCert {
-		// TODO (eriktate/scopes): Remove this restriction once we have more thorough support for scopes with other usages.
-		// For now this is out of an abundance of caution to prevent scoped identities from generating user certs for
-		// usages that have not been fully thought through or tested yet.
-		return nil, trace.Wrap(services.ErrScopedIdentity, "generating scoped user cert for non-kubernetes usage")
+
+	if isScoped {
+		isKubeCert := req.Usage == proto.UserCertsRequest_Kubernetes && req.KubernetesCluster != ""
+		isAppCert := req.Usage == proto.UserCertsRequest_App
+		if !isKubeCert && !isAppCert {
+			// TODO (eriktate/scopes): Remove this restriction once we have more thorough support for scopes with other usages.
+			// For now this is out of an abundance of caution to prevent scoped identities from generating user certs for
+			// usages that have not been fully thought through or tested yet.
+			return nil, trace.Wrap(services.ErrScopedIdentity, "generating scoped user cert for unsupported usage %q", req.Usage)
+		}
+
+		// Scoped identities cannot access cloud apps (AWS console / AWS Roles Anywhere, Azure, GCP).
+		// TODO(williamo/scopes): add support for this.
+		if req.RequesterName == proto.UserCertsRequest_TSH_APP_AWS_CREDENTIALPROCESS ||
+			req.RouteToApp.AWSRoleARN != "" || req.RouteToApp.AzureIdentity != "" || req.RouteToApp.GCPServiceAccount != "" {
+			return nil, trace.Wrap(services.ErrScopedIdentity, "generating scoped user cert for cloud app access")
+		}
 	}
 
 	hasAdminRole := !isScoped && authz.HasBuiltinRole(*unscopedCtx, string(types.RoleAdmin))
@@ -4213,9 +4244,6 @@ func (a *ScopedServerWithRoles) generateUserCerts(ctx context.Context, req proto
 	var appSessionID string
 	var webSessionID string
 	if req.RouteToApp.Name != "" {
-		if isScoped {
-			return nil, trace.Wrap(services.ErrScopedIdentity, "creating app session")
-		}
 		// Create a new app session using the same cert request. The user certs
 		// generated below will be linked to this session by the session ID.
 		ws, err := a.authServer.CreateAppSessionFromReq(ctx, sessionreq.NewAppSessionRequest{
@@ -4252,6 +4280,9 @@ func (a *ScopedServerWithRoles) generateUserCerts(ctx context.Context, req proto
 			AppName:           req.RouteToApp.Name,
 			AppURI:            req.RouteToApp.URI,
 			AppTargetPort:     int(req.RouteToApp.TargetPort),
+			// Propagate the caller's identity so CreateAppSessionFromReq can build a scoped
+			// access checker context when the caller is scope-pinned.
+			Identity: a.scopedContext.Identity.GetIdentity(),
 
 			BotName:  getBotName(user),
 			BotScope: getBotScope(user),
@@ -6423,28 +6454,6 @@ func (a *ServerWithRoles) checkAccessToApp(app types.Application) error {
 		services.AccessState{MFAVerified: true})
 }
 
-// GetApplicationServers returns all registered application servers.
-func (a *ServerWithRoles) GetApplicationServers(ctx context.Context, namespace string) ([]types.AppServer, error) {
-	if err := a.actionNamespace(namespace, types.KindAppServer, types.VerbList, types.VerbRead); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	servers, err := a.authServer.GetApplicationServers(ctx, namespace)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	// Filter out apps the caller doesn't have access to.
-	var filtered []types.AppServer
-	for _, server := range servers {
-		err := a.checkAccessToApp(server.GetApp())
-		if err != nil && !trace.IsAccessDenied(err) {
-			return nil, trace.Wrap(err)
-		} else if err == nil {
-			filtered = append(filtered, server)
-		}
-	}
-	return filtered, nil
-}
-
 // UpsertApplicationServer registers an application server.
 func (a *ServerWithRoles) UpsertApplicationServer(ctx context.Context, server types.AppServer) (*types.KeepAlive, error) {
 	if err := a.actionNamespace(server.GetNamespace(), types.KindAppServer, types.VerbCreate, types.VerbUpdate); err != nil {
@@ -6861,6 +6870,39 @@ func (a *ScopedServerWithRoles) GetKubernetesServers(ctx context.Context) ([]typ
 	var filtered []types.KubeServer
 	for _, server := range servers {
 		err := a.checkAccessToKubeClusterWithVerbs(ctx, server.GetCluster(), types.VerbList, types.VerbRead)
+		if err != nil && !trace.IsAccessDenied(err) {
+			return nil, trace.Wrap(err)
+		} else if err == nil {
+			filtered = append(filtered, server)
+		}
+	}
+
+	return filtered, nil
+}
+
+// GetApplicationServers returns all registered application servers
+// that the calling identity has permissions to view.
+func (a *ScopedServerWithRoles) GetApplicationServers(ctx context.Context, namespace string) ([]types.AppServer, error) {
+	servers, err := a.authServer.GetApplicationServers(ctx, namespace)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	ruleCtx := a.scopedContext.RuleContext()
+
+	var filtered []types.AppServer
+	for _, server := range servers {
+		// Identity Center account apps are currently not supported for scoped applications.
+		// TODO (williamo/scopes) - potentially look into adding account_assignments into scoped roles.
+		if server.GetScope() != "" && server.GetApp().GetSubKind() == types.KindIdentityCenterAccount {
+			continue
+		}
+
+		err := a.scopedContext.CheckerContext.Decision(ctx, server.GetScope(), func(checker *services.ScopedAccessChecker) error {
+			if err := checker.CheckAccessToRules(&ruleCtx, types.KindAppServer, types.VerbRead, types.VerbList); err != nil {
+				return trace.Wrap(err)
+			}
+			return checker.App().CanAccessApp(server.GetApp())
+		})
 		if err != nil && !trace.IsAccessDenied(err) {
 			return nil, trace.Wrap(err)
 		} else if err == nil {

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -6107,7 +6107,7 @@ func TestListResources_ScopedApps(t *testing.T) {
 	const childScope = "/test/child"
 	const otherScope = "/other"
 
-	createAppServer := func(t *testing.T, name, scope string, labels map[string]string) {
+	createAppServer := func(t *testing.T, name, scope, subkind string, labels map[string]string) {
 		t.Helper()
 		app, err := types.NewAppV3(types.Metadata{
 			Name:   name,
@@ -6116,21 +6116,28 @@ func TestListResources_ScopedApps(t *testing.T) {
 			types.AppSpecV3{URI: "http://localhost:8080"},
 			scope)
 		require.NoError(t, err)
+		if subkind != "" {
+			app.SubKind = subkind
+		}
 		if scope != "" {
 			app.Spec.PublicAddr = scopedapp.ScopedAppPublicAddr(scope, name, "proxy.example.com")
 		}
 		server, err := types.NewAppServerV3FromApp(app, name+"-host", name+"-hostid")
+		if subkind != "" {
+			server.SubKind = subkind
+		}
 		require.NoError(t, err)
 		_, err = srv.Auth().UpsertApplicationServer(ctx, server)
 		require.NoError(t, err)
 	}
 
 	// Create apps in various scopes with differing labels
-	createAppServer(t, "prod-app", scope, map[string]string{"env": "prod"})
-	createAppServer(t, "dev-app", scope, map[string]string{"env": "dev"})
-	createAppServer(t, "dev-child-app", childScope, map[string]string{"env": "dev"})
-	createAppServer(t, "other-scope-app", otherScope, map[string]string{"env": "prod"})
-	createAppServer(t, "unscoped-app", "", map[string]string{"env": "prod"})
+	createAppServer(t, "prod-app", scope, "", map[string]string{"env": "prod"})
+	createAppServer(t, "dev-app", scope, "", map[string]string{"env": "dev"})
+	createAppServer(t, "dev-child-app", childScope, "", map[string]string{"env": "dev"})
+	createAppServer(t, "other-scope-app", otherScope, "", map[string]string{"env": "prod"})
+	createAppServer(t, "unscoped-app", "", "", map[string]string{"env": "prod"})
+	createAppServer(t, "ic-app", scope, types.KindIdentityCenterAccount, map[string]string{"env": "dev"})
 
 	appLabels := func(env string) *scopedaccessv1.ScopedRoleApp {
 		return scopedaccessv1.ScopedRoleApp_builder{
@@ -6159,54 +6166,97 @@ func TestListResources_ScopedApps(t *testing.T) {
 		name             string
 		server           *auth.ScopedServerWithRoles
 		appNamesExpected []string
+		req              proto.ListResourcesRequest
 	}{
 		{
 			name:             "prod labels in scope " + scope,
 			server:           scopedAppUser("test-prod-label", scope, appLabels("prod")),
 			appNamesExpected: []string{"prod-app"},
+			req: proto.ListResourcesRequest{
+				ResourceType: types.KindAppServer,
+				Limit:        10,
+			},
 		},
 		{
 			name:             "dev label in " + scope,
 			server:           scopedAppUser("test-dev-label", scope, appLabels("dev")),
 			appNamesExpected: []string{"dev-app", "dev-child-app"},
+			req: proto.ListResourcesRequest{
+				ResourceType: types.KindAppServer,
+				Limit:        10,
+			},
 		},
 		{
 			name:             "dev label expression in " + scope,
 			server:           scopedAppUser("test-dev-expression", scope, appLabelExpression(`contains(labels["env"], "dev")`)),
 			appNamesExpected: []string{"dev-app", "dev-child-app"},
+			req: proto.ListResourcesRequest{
+				ResourceType: types.KindAppServer,
+				Limit:        10,
+			},
 		},
 		{
 			name:             "label expression in " + scope,
 			server:           scopedAppUser("test-prod-expression", scope, appLabelExpression(`contains(labels["env"], "prod")`)),
 			appNamesExpected: []string{"prod-app"},
+			req: proto.ListResourcesRequest{
+				ResourceType: types.KindAppServer,
+				Limit:        10,
+			},
 		},
 		{
 			name:             "label expression in " + childScope,
 			server:           scopedAppUser("test-child-prod-expr", childScope, appLabelExpression(`contains(labels["env"], "prod")`)),
 			appNamesExpected: []string{},
+			req: proto.ListResourcesRequest{
+				ResourceType: types.KindAppServer,
+				Limit:        10,
+			},
 		},
 		{
 			name:             "label expression in " + otherScope,
 			server:           scopedAppUser("other-prod-expression", otherScope, appLabelExpression(`contains(labels["env"], "prod")`)),
 			appNamesExpected: []string{"other-scope-app"},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			res, err := tc.server.ListResources(ctx, proto.ListResourcesRequest{
+			req: proto.ListResourcesRequest{
 				ResourceType: types.KindAppServer,
 				Limit:        10,
-			})
+			},
+		},
+		{
+			name:             "fake pagination path returns apps",
+			server:           scopedAppUser("test-fake-pagination", scope, appLabels("prod")),
+			appNamesExpected: []string{"prod-app"},
+			req: proto.ListResourcesRequest{
+				ResourceType:   types.KindAppServer,
+				Limit:          10,
+				SortBy:         types.SortBy{Field: types.ResourceMetadataName},
+				NeedTotalCount: true,
+				IncludeLogins:  true,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := tc.server.ListResources(ctx, tc.req)
 			require.NoError(t, err)
 
 			var names []string
 			for _, r := range res.Resources {
 				names = append(names, r.GetName())
 				require.NotEqual(t, "unscoped-app", r.GetName())
+				// Identity Center account apps must never appear in scoped
+				// listings, even when their labels match the role.
+				require.NotEqual(t, "ic-app", r.GetName())
 			}
 
 			require.ElementsMatch(t, tc.appNamesExpected, names)
+
+			if tc.req.SortBy.Field != "" {
+				require.True(t, slices.IsSorted(names))
+			}
+			if tc.req.NeedTotalCount {
+				require.Equal(t, len(tc.appNamesExpected), res.TotalCount)
+			}
 		})
 	}
 }
@@ -13727,6 +13777,7 @@ func TestScopedUserCertGeneration(t *testing.T) {
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
 				entitlements.Policy: {Enabled: true},
 				entitlements.K8s:    {Enabled: true},
+				entitlements.App:    {Enabled: true},
 			},
 		},
 	}), withClock(clock))
@@ -13749,6 +13800,14 @@ func TestScopedUserCertGeneration(t *testing.T) {
 				Kube: scopedaccessv1.ScopedRoleKube_builder{
 					Users:  []string{"kube_user"},
 					Groups: []string{"kube_group"},
+					Labels: []*labelv1.Label{
+						labelv1.Label_builder{
+							Name:   types.Wildcard,
+							Values: []string{types.Wildcard},
+						}.Build(),
+					},
+				}.Build(),
+				App: scopedaccessv1.ScopedRoleApp_builder{
 					Labels: []*labelv1.Label{
 						labelv1.Label_builder{
 							Name:   types.Wildcard,
@@ -13790,6 +13849,20 @@ func TestScopedUserCertGeneration(t *testing.T) {
 	require.NoError(t, err)
 
 	createKubeServer(t, srv.Auth(), []string{"kube-cluster"}, "kube-host", scope)
+
+	scopedApp, err := types.NewAppV3(types.Metadata{
+		Name:   "test-app",
+		Labels: map[string]string{"env": "test"},
+	}, types.AppSpecV3{URI: "http://localhost:8080"})
+	require.NoError(t, err)
+	scopedApp.Scope = scope
+	scopedApp.Spec.PublicAddr = scopedapp.ScopedAppPublicAddr(scope, "test-app", "proxy.example.com")
+	scopedAppServer, err := types.NewAppServerV3FromApp(scopedApp, "test-app-host", "test-app-hostid")
+	require.NoError(t, err)
+	scopedAppServer.Scope = scope
+	_, err = srv.Auth().UpsertApplicationServer(ctx, scopedAppServer)
+	require.NoError(t, err)
+
 	tts := []struct {
 		name       string
 		req        proto.UserCertsRequest
@@ -13867,25 +13940,52 @@ func TestScopedUserCertGeneration(t *testing.T) {
 		{
 			name: "app session creation",
 			req: proto.UserCertsRequest{
-				SSHPublicKey:      sshPubKey,
-				TLSPublicKey:      tlsPubKey,
-				Username:          username,
-				Usage:             proto.UserCertsRequest_Kubernetes,
-				KubernetesCluster: "kube-cluster",
-				Expires:           time.Now().Add(time.Hour),
+				SSHPublicKey:  sshPubKey,
+				TLSPublicKey:  tlsPubKey,
+				Username:      username,
+				Usage:         proto.UserCertsRequest_App,
+				RequesterName: proto.UserCertsRequest_TSH_APP_LOCAL_PROXY,
+				Expires:       time.Now().Add(time.Hour),
 				RouteToApp: proto.RouteToApp{
-					Name: "app-name",
+					Name:        "test-app",
+					PublicAddr:  scopedApp.GetPublicAddr(),
+					ClusterName: srv.ClusterName(),
+				},
+			},
+			assertCert: func(t *testing.T, cert *x509.Certificate) {
+				identity, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
+				require.NoError(t, err)
+				require.Equal(t, "test-app", identity.RouteToApp.Name)
+				require.Equal(t, scopedApp.GetPublicAddr(), identity.RouteToApp.PublicAddr)
+				// An app session is created and linked to the certificate.
+				require.NotEmpty(t, identity.RouteToApp.SessionID)
+			},
+		},
+		{
+			name: "app with AWS role ARN is rejected",
+			req: proto.UserCertsRequest{
+				SSHPublicKey:  sshPubKey,
+				TLSPublicKey:  tlsPubKey,
+				Username:      username,
+				Usage:         proto.UserCertsRequest_App,
+				RequesterName: proto.UserCertsRequest_TSH_APP_LOCAL_PROXY,
+				Expires:       time.Now().Add(time.Hour),
+				RouteToApp: proto.RouteToApp{
+					Name:        "test-app",
+					PublicAddr:  scopedApp.GetPublicAddr(),
+					ClusterName: srv.ClusterName(),
+					AWSRoleARN:  "arn:aws:iam::123456789012:role/example",
 				},
 			},
 			assertErr: func(t *testing.T, err error) {
 				require.Error(t, err)
 				require.True(t, trace.IsAccessDenied(err), "expected AccessDeniedError")
-				require.ErrorContains(t, err, "creating app session")
 				require.ErrorContains(t, err, "scoped identities not supported")
+				require.ErrorContains(t, err, "generating scoped user cert for cloud app access")
 			},
 		},
 		{
-			name: "for non-kube usage",
+			name: "for non-kube non-app usage",
 			req: proto.UserCertsRequest{
 				SSHPublicKey: sshPubKey,
 				TLSPublicKey: tlsPubKey,
@@ -13896,7 +13996,7 @@ func TestScopedUserCertGeneration(t *testing.T) {
 				require.Error(t, err)
 				require.True(t, trace.IsAccessDenied(err), "expected AccessDeniedError")
 				require.ErrorContains(t, err, "scoped identities not supported")
-				require.ErrorContains(t, err, "generating scoped user cert for non-kubernetes usage")
+				require.ErrorContains(t, err, "generating scoped user cert for unsupported usage \"All\"")
 			},
 		},
 		{
@@ -13917,7 +14017,7 @@ func TestScopedUserCertGeneration(t *testing.T) {
 				require.ErrorContains(t, err, "scoped identities not supported")
 				// TODO (eriktate/scopes): remove the nonKubeErr check if/when we stop restricting usages for scoped
 				// user cert gen
-				nonKubeErr := strings.Contains(err.Error(), "generating scoped user cert for non-kubernetes usage")
+				nonKubeErr := strings.Contains(err.Error(), "generating scoped user cert for unsupported usage \"AccessGraphAPI\"")
 				accessGraphErr := strings.Contains(err.Error(), "access graph is not permitted")
 				require.True(t, nonKubeErr || accessGraphErr, "expected error due to unsupported scoped certificate usage or unsupported scoped access graph usage")
 			},

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -687,6 +687,10 @@ type AppsAccessPoint interface {
 	// ReadAppsAccessPoint provides methods to read data
 	ReadAppsAccessPoint
 
+	// ScopedRoleReader returns a read-only scoped role client. Used by the app service to
+	// authorize scope-pinned identities accessing applications.
+	ScopedRoleReader() services.ScopedRoleReader
+
 	// accessPoint provides common access point functionality
 	accessPoint
 }
@@ -1752,6 +1756,12 @@ func NewAppsWrapper(base AppsAccessPoint, cache ReadAppsAccessPoint) AppsAccessP
 		accessPoint:         base,
 		ReadAppsAccessPoint: cache,
 	}
+}
+
+func (w *AppsWrapper) ScopedRoleReader() services.ScopedRoleReader {
+	// TODO(fspmarshall/scopes): implement caching for scoped roles
+	// on app agents.
+	return w.NoCache.ScopedRoleReader()
 }
 
 // Close closes all associated resources

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -475,18 +475,35 @@ func (a *Server) CreateAppSessionFromReq(ctx context.Context, req NewAppSessionR
 		return nil, trace.Wrap(err)
 	}
 
-	checker, err := services.NewAccessChecker(&services.AccessInfo{
-		Username: req.User,
-		Roles:    req.Roles,
-		Traits:   req.Traits,
-		// Propagate AllowedResourceAccessIDs from the req, so AccessChecker
-		// doesn't fall back to role-based checks alone if resource-level restrictions
-		// are present on caller's identity.
-		AllowedResourceAccessIDs: req.NewWebSessionRequest.RequestedResourceAccessIDs,
-		DelegationSessionID:      req.DelegationSessionID,
-	}, clusterName.GetClusterName(), a)
-	if err != nil {
-		return nil, trace.Wrap(err)
+	var checkerContext *services.ScopedAccessCheckerContext
+	if req.Identity.ScopePin != nil {
+		if req.DelegationSessionID != "" {
+			return nil, trace.AccessDenied("scoped identities do not support delegation session ID")
+		}
+		if len(req.RequestedResourceAccessIDs) != 0 {
+			return nil, trace.AccessDenied("scoped identities do not support requested resource access IDs")
+		}
+
+		accessInfo := services.ScopePinnedAccessInfoFromUserState(user, req.Identity.ScopePin)
+		checkerContext, err = services.NewScopedAccessCheckerContext(ctx, accessInfo, clusterName.GetClusterName(), a.ScopedAccessCache)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	} else {
+		checker, err := services.NewAccessChecker(&services.AccessInfo{
+			Username: req.User,
+			Roles:    req.Roles,
+			Traits:   req.Traits,
+			// Propagate AllowedResourceAccessIDs from the req, so AccessChecker
+			// doesn't fall back to role-based checks alone if resource-level restrictions
+			// are present on caller's identity.
+			AllowedResourceAccessIDs: req.NewWebSessionRequest.RequestedResourceAccessIDs,
+			DelegationSessionID:      req.DelegationSessionID,
+		}, clusterName.GetClusterName(), a)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		checkerContext = services.NewScopedAccessCheckerContextFromUnscoped(checker)
 	}
 
 	sessionID := req.SuggestedSessionID
@@ -529,7 +546,7 @@ func (a *Server) CreateAppSessionFromReq(ctx context.Context, req NewAppSessionR
 		User:           user,
 		LoginIP:        req.LoginIP,
 		TLSPublicKey:   tlsPublicKey,
-		CheckerContext: services.NewScopedAccessCheckerContextFromUnscoped(checker), // TODO(fspmarshall/scopes): add scoping support to newAppSession.
+		CheckerContext: checkerContext,
 		TTL:            req.SessionTTL,
 		Traits:         req.Traits,
 		ActiveRequests: req.AccessRequests,

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -27,6 +27,7 @@ import (
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/services/label"
 )
 
 const (
@@ -59,6 +60,11 @@ const (
 	// unlike MaxRolesPerAssignment, this is a fairly arbitrary limit and there isn't a strong reason to keep it low other than
 	// to avoid excess resource size and to keep our options open for the future.
 	maxAssignableScopes = 16
+
+	// invalidChars are the special characters that should not be allowed in certain keys or values.
+	invalidChars = "{}^$*"
+	// invalidLabelChars are the special characters that should not be allowed in label keys or values.
+	invalidLabelChars = "{}^$"
 )
 
 // RoleIsAssignableToScopeOfEffect checks if the given role is assignable to the given scope of effect. For example,
@@ -201,8 +207,6 @@ func StrongValidateRole(role *scopedaccessv1.ScopedRole) error {
 		}
 	}
 
-	const invalidChars = "{}^$*"
-	const invalidLabelChars = "{}^$"
 	// verify that ssh logins are well-formed
 	if login := validateDoesNotContain(role.GetSpec().GetSsh().GetLogins(), invalidChars); login != "" {
 		// we currently don't support any form of wildcard/regex/substitution in scoped role
@@ -280,7 +284,6 @@ func StrongValidateRole(role *scopedaccessv1.ScopedRole) error {
 			return trace.BadParameter("scoped role %q has invalid defaults.lock.mode %q", role.GetMetadata().GetName(), lock.GetMode())
 		}
 	}
-
 	// verify that lock.Mode is a recognized value for SSH
 	if lock := role.GetSpec().GetSsh().GetLock(); lock != nil {
 		if err := validateLock(lock); err != nil {
@@ -298,7 +301,7 @@ func StrongValidateRole(role *scopedaccessv1.ScopedRole) error {
 	// verify that kube labels are well-formed
 	for _, label := range role.GetSpec().GetKube().GetLabels() {
 		// we currently don't support any form of wildcard/regex/substitution in scoped role
-		// node labels. we likely will support such things in the future, but its best to disallow
+		// kube labels. we likely will support such things in the future, but its best to disallow
 		// them until that has landed.
 
 		if strings.ContainsAny(label.GetName(), invalidLabelChars) {
@@ -307,6 +310,10 @@ func StrongValidateRole(role *scopedaccessv1.ScopedRole) error {
 		if value := validateDoesNotContain(label.GetValues(), invalidLabelChars); value != "" {
 			return trace.BadParameter("scoped role %q has invalid kube label value %q for label %q", role.GetMetadata().GetName(), value, label.GetName())
 		}
+	}
+
+	if err := validateAppBlock(role.GetSpec().GetApp()); err != nil {
+		return trace.BadParameter("scoped role %q %s", role.GetMetadata().GetName(), err)
 	}
 
 	// verify that kube groups are well-formed
@@ -357,6 +364,51 @@ func validateDoesNotContain(values []string, invalidSet string) string {
 	}
 
 	return ""
+}
+
+func validateAppBlock(app *scopedaccessv1.ScopedRoleApp) error {
+	if app == nil {
+		return nil
+	}
+
+	labels := app.GetLabels()
+	if len(labels) == 0 && app.GetLabelExpression() == "" {
+		return trace.BadParameter("must define at least one app.labels entry or app.label expressions")
+	}
+
+	if expr := app.GetLabelExpression(); expr != "" {
+		if _, err := label.ParseExpression(expr); err != nil {
+			return trace.BadParameter("has invalid app.label_expression: %v", err)
+		}
+	}
+
+	// verify that app labels are well formed
+	for _, label := range labels {
+		// we currently don't support any form of wildcard/regex/substitution in scoped role
+		// app labels. we likely will support such things in the future, but its best to disallow
+		// them until that has landed.
+
+		if strings.ContainsAny(label.GetName(), invalidLabelChars) {
+			return trace.BadParameter("has invalid app label name %q", label.GetName())
+		}
+		if value := validateDoesNotContain(label.GetValues(), invalidLabelChars); value != "" {
+			return trace.BadParameter("has invalid app label value %q for label %q", value, label.GetName())
+		}
+	}
+
+	// verify that lock.Mode is a recognized value for App
+	if lock := app.GetLock(); lock != nil {
+		if err := validateLock(lock); err != nil {
+			return trace.BadParameter("has invalid app.lock.mode %q", lock.GetMode())
+		}
+	}
+
+	if s := app.GetClientIdleTimeout(); s != "" {
+		if _, err := time.ParseDuration(s); err != nil {
+			return trace.BadParameter("has invalid app.client_idle_timeout %q: %v", s, err)
+		}
+	}
+	return nil
 }
 
 func validateLock(lock *scopedaccessv1.Lock) error {

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -674,6 +674,205 @@ func TestValidateRole(t *testing.T) {
 			weakOk:   true,
 		},
 		{
+			name: "app block without labels or label_expression",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					App: scopedaccessv1.ScopedRoleApp_builder{
+						Lock: scopedaccessv1.Lock_builder{
+							Mode: string(constants.LockingModeStrict),
+						}.Build(),
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "app block with invalid labels",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					App: scopedaccessv1.ScopedRoleApp_builder{
+						Labels: []*labelv1.Label{
+							labelv1.Label_builder{
+								Name:   "{}",
+								Values: []string{"{}"},
+							}.Build(),
+						},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "app block with labels only",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					App: scopedaccessv1.ScopedRoleApp_builder{
+						Labels: []*labelv1.Label{
+							labelv1.Label_builder{
+								Name:   "env",
+								Values: []string{"staging"},
+							}.Build(),
+						},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name: "app block with invalid label expression",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					App: scopedaccessv1.ScopedRoleApp_builder{
+						LabelExpression: `labels["env"] ==`,
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "valid App.lock.mode",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					App: scopedaccessv1.ScopedRoleApp_builder{
+						LabelExpression: `labels["env"] == "staging"`,
+						Lock: scopedaccessv1.Lock_builder{
+							Mode: string(constants.LockingModeStrict),
+						}.Build(),
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name: "empty App.lock.mode",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					App: scopedaccessv1.ScopedRoleApp_builder{
+						LabelExpression: `labels["env"] == "staging"`,
+						Lock: scopedaccessv1.Lock_builder{
+							Mode: "",
+						}.Build(),
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name: "invalid App.lock.mode",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					App: scopedaccessv1.ScopedRoleApp_builder{
+						Labels: []*labelv1.Label{
+							labelv1.Label_builder{
+								Name:   "test",
+								Values: []string{"test"},
+							}.Build(),
+						},
+						Lock: scopedaccessv1.Lock_builder{
+							Mode: "invalid",
+						}.Build(),
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "invalid app.client_idle_timeout",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					App: scopedaccessv1.ScopedRoleApp_builder{
+						LabelExpression:   `labels["env"] == "staging"`,
+						ClientIdleTimeout: "not-a-duration",
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "valid app.client_idle_timeout",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					App: scopedaccessv1.ScopedRoleApp_builder{
+						LabelExpression:   `labels["env"] == "staging"`,
+						ClientIdleTimeout: "1h",
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
 			name: "valid workload_identity rule",
 			role: scopedaccessv1.ScopedRole_builder{
 				Kind: KindScopedRole,
@@ -1681,7 +1880,12 @@ func TestStrongValidateRoleSpecAllFieldsValidated(t *testing.T) {
 			Labels: []*labelv1.Label{
 				labelv1.Label_builder{Name: "env", Values: []string{"prod"}}.Build(),
 			},
-			LabelExpression: `contains(labels["env"], "prod")`,
+			LabelExpression:       `contains(labels["env"], "prod")`,
+			ClientIdleTimeout:     "1h",
+			DisconnectExpiredCert: ptr(true),
+			Lock: scopedaccessv1.Lock_builder{
+				Mode: "strict",
+			}.Build(),
 		}.Build(),
 	}.Build()
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -5621,13 +5621,14 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			return trace.Wrap(err)
 		}
 
-		authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
-			ClusterName:    cn.GetClusterName(),
-			AccessPoint:    accessPoint,
-			LockWatcher:    lockWatcher,
-			Logger:         process.logger,
-			PermitCaching:  process.Config.CachePolicy.Enabled,
-			ScopesFeatures: process.scopesFeatures,
+		scopedAuthorizer, err := authz.NewScopedAuthorizer(authz.AuthorizerOpts{
+			ClusterName:      cn.GetClusterName(),
+			AccessPoint:      accessPoint,
+			ScopedRoleReader: accessPoint.ScopedRoleReader(),
+			LockWatcher:      lockWatcher,
+			Logger:           process.logger,
+			PermitCaching:    process.Config.CachePolicy.Enabled,
+			ScopesFeatures:   process.scopesFeatures,
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -5651,7 +5652,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			Clock:             process.Clock,
 			DataDir:           cfg.DataDir,
 			Emitter:           asyncEmitter,
-			Authorizer:        authorizer,
+			Authorizer:        scopedAuthorizer,
 			HostID:            conn.HostUUID(),
 			AuthClient:        conn.Client,
 			AccessPoint:       accessPoint,
@@ -7049,12 +7050,14 @@ func (process *TeleportProcess) initApps() {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
-			ClusterName:    clusterName,
-			AccessPoint:    accessPoint,
-			LockWatcher:    lockWatcher,
-			Logger:         process.logger.With(teleport.ComponentKey, component),
-			ScopesFeatures: process.scopesFeatures,
+
+		scopedAuthorizer, err := authz.NewScopedAuthorizer(authz.AuthorizerOpts{
+			ClusterName:      clusterName,
+			AccessPoint:      accessPoint,
+			ScopedRoleReader: accessPoint.ScopedRoleReader(),
+			LockWatcher:      lockWatcher,
+			Logger:           process.logger.With(teleport.ComponentKey, component),
+			ScopesFeatures:   process.scopesFeatures,
 			DeviceAuthorization: authz.DeviceAuthorizationOpts{
 				// Ignore the global device_trust.mode toggle, but allow role-based
 				// settings to be applied.
@@ -7102,7 +7105,7 @@ func (process *TeleportProcess) initApps() {
 			DataDir:           process.Config.DataDir,
 			AuthClient:        conn.Client,
 			AccessPoint:       accessPoint,
-			Authorizer:        authorizer,
+			Authorizer:        scopedAuthorizer,
 			TLSConfig:         tlsConfig,
 			CipherSuites:      process.Config.CipherSuites,
 			HostID:            conn.HostUUID(),

--- a/lib/services/app_access_checker.go
+++ b/lib/services/app_access_checker.go
@@ -19,6 +19,11 @@
 package services
 
 import (
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -45,4 +50,34 @@ func (c *AppAccessChecker) CanAccessApp(target types.Application) error {
 		return c.checker.unscopedChecker.CheckAccess(target, AccessState{MFAVerified: true})
 	}
 	return c.checker.scopedCompatChecker.CheckAccess(target, AccessState{MFAVerified: true})
+}
+
+// AdjustClientIdleTimeout determines the app client idle timeout to apply.
+func (c *AppAccessChecker) AdjustClientIdleTimeout(timeout time.Duration) (time.Duration, error) {
+	if !c.checker.isScoped() {
+		return c.checker.unscopedChecker.AdjustClientIdleTimeout(timeout), nil
+	}
+	return c.checker.adjustScopedClientIdleTimeout(c.checker.role.GetSpec().GetApp().GetClientIdleTimeout(), timeout)
+}
+
+// AdjustDisconnectExpiredCert adjusts whether to disconnect on certificate expiry.
+func (c *AppAccessChecker) AdjustDisconnectExpiredCert(disconnect bool) bool {
+	if !c.checker.isScoped() {
+		return c.checker.unscopedChecker.AdjustDisconnectExpiredCert(disconnect)
+	}
+	app := c.checker.role.GetSpec().GetApp()
+	var disconnectExpiredCert *bool
+	if app != nil {
+		disconnectExpiredCert = proto.ValueOrNil(app.HasDisconnectExpiredCert(), app.GetDisconnectExpiredCert)
+	}
+	return c.checker.adjustScopedDisconnectExpiredCert(disconnectExpiredCert, disconnect)
+}
+
+// LockingMode returns the App lock enforcement mode to apply.
+func (c *AppAccessChecker) LockingMode(defaultMode constants.LockingMode) constants.LockingMode {
+	if !c.checker.isScoped() {
+		return c.checker.unscopedChecker.LockingMode(defaultMode)
+	}
+
+	return c.checker.scopedLockingMode(c.checker.role.GetSpec().GetApp().GetLock(), defaultMode)
 }

--- a/lib/services/app_access_checker_test.go
+++ b/lib/services/app_access_checker_test.go
@@ -1,0 +1,317 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/constants"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+)
+
+// TestAppAccessCheckerAdjustClientIdleTimeout verifies the idle timeout selection logic:
+// <protocol>.client_idle_timeout takes precedence over defaults.client_idle_timeout, either value
+// is only applied when it is more restrictive than the supplied global default, and invalid
+// or empty values defer to the global default.
+func TestAppAccessCheckerAdjustClientIdleTimeout(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name          string
+		spec          *scopedaccessv1.ScopedRoleSpec
+		globalTimeout time.Duration
+		expect        time.Duration
+		expectErr     bool
+	}{
+		{
+			name:          "no timeout set defers to global",
+			spec:          &scopedaccessv1.ScopedRoleSpec{},
+			globalTimeout: 30 * time.Minute,
+			expect:        30 * time.Minute,
+		},
+		{
+			name: "app timeout more restrictive than global",
+			spec: scopedaccessv1.ScopedRoleSpec_builder{
+				App: scopedaccessv1.ScopedRoleApp_builder{
+					ClientIdleTimeout: "10m",
+				}.Build(),
+			}.Build(),
+			globalTimeout: 30 * time.Minute,
+			expect:        10 * time.Minute,
+		},
+		{
+			name: "app timeout less restrictive than global is ignored",
+			spec: scopedaccessv1.ScopedRoleSpec_builder{
+				App: scopedaccessv1.ScopedRoleApp_builder{
+					ClientIdleTimeout: "2h",
+				}.Build(),
+			}.Build(),
+			globalTimeout: 30 * time.Minute,
+			expect:        30 * time.Minute,
+		},
+		{
+			name: "defaults timeout used when app timeout absent",
+			spec: scopedaccessv1.ScopedRoleSpec_builder{
+				Defaults: scopedaccessv1.ScopedRoleDefaults_builder{
+					ClientIdleTimeout: "15m",
+				}.Build(),
+			}.Build(),
+			globalTimeout: 30 * time.Minute,
+			expect:        15 * time.Minute,
+		},
+		{
+			name: "app timeout overrides defaults timeout",
+			spec: scopedaccessv1.ScopedRoleSpec_builder{
+				Defaults: scopedaccessv1.ScopedRoleDefaults_builder{
+					ClientIdleTimeout: "5m",
+				}.Build(),
+				App: scopedaccessv1.ScopedRoleApp_builder{
+					ClientIdleTimeout: "20m",
+				}.Build(),
+			}.Build(),
+			globalTimeout: 30 * time.Minute,
+			// app (20m) overrides defaults (5m), and 20m < 30m so 20m wins
+			expect: 20 * time.Minute,
+		},
+		{
+			name: "app timeout overrides defaults even when defaults is more restrictive",
+			spec: scopedaccessv1.ScopedRoleSpec_builder{
+				Defaults: scopedaccessv1.ScopedRoleDefaults_builder{
+					ClientIdleTimeout: "5m",
+				}.Build(),
+				App: scopedaccessv1.ScopedRoleApp_builder{
+					// App block explicitly overrides defaults with a less restrictive value;
+					// the App block takes precedence, and since 25m < 30m global it still applies.
+					ClientIdleTimeout: "25m",
+				}.Build(),
+			}.Build(),
+			globalTimeout: 30 * time.Minute,
+			expect:        25 * time.Minute,
+		},
+		{
+			name: "role timeout applied when global is unlimited (zero)",
+			spec: scopedaccessv1.ScopedRoleSpec_builder{
+				App: scopedaccessv1.ScopedRoleApp_builder{
+					ClientIdleTimeout: "1h",
+				}.Build(),
+			}.Build(),
+			globalTimeout: 0, // zero means no global limit
+			expect:        time.Hour,
+		},
+		{
+			name: "empty app timeout defers to global",
+			spec: scopedaccessv1.ScopedRoleSpec_builder{
+				App: scopedaccessv1.ScopedRoleApp_builder{
+					ClientIdleTimeout: "",
+				}.Build(),
+			}.Build(),
+			globalTimeout: 30 * time.Minute,
+			expect:        30 * time.Minute,
+		},
+		{
+			name: "invalid duration string returns error",
+			spec: scopedaccessv1.ScopedRoleSpec_builder{
+				App: scopedaccessv1.ScopedRoleApp_builder{
+					ClientIdleTimeout: "not-a-duration",
+				}.Build(),
+			}.Build(),
+			globalTimeout: 30 * time.Minute,
+			expectErr:     true,
+		},
+		{
+			name: "zero duration string defers to global",
+			spec: scopedaccessv1.ScopedRoleSpec_builder{
+				App: scopedaccessv1.ScopedRoleApp_builder{
+					ClientIdleTimeout: "0s",
+				}.Build(),
+			}.Build(),
+			globalTimeout: 30 * time.Minute,
+			expect:        30 * time.Minute,
+		},
+		{
+			name: "various valid duration formats",
+			spec: scopedaccessv1.ScopedRoleSpec_builder{
+				App: scopedaccessv1.ScopedRoleApp_builder{
+					ClientIdleTimeout: "1h30m",
+				}.Build(),
+			}.Build(),
+			globalTimeout: 3 * time.Hour,
+			expect:        time.Hour + 30*time.Minute,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).App()
+			got, err := checker.AdjustClientIdleTimeout(tt.globalTimeout)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, got)
+		})
+	}
+}
+
+func TestAppAccessCheckerAdjustDisconnectExpiredCert(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name       string
+		spec       *scopedaccessv1.ScopedRoleSpec
+		defaultVal bool
+		expect     bool
+	}{
+		{
+			name: "unset defers to default false",
+			spec: scopedaccessv1.ScopedRoleSpec_builder{
+				App: &scopedaccessv1.ScopedRoleApp{},
+			}.Build(),
+			defaultVal: false,
+			expect:     false,
+		},
+		{
+			name: "unset defers to default true",
+			spec: scopedaccessv1.ScopedRoleSpec_builder{
+				App: &scopedaccessv1.ScopedRoleApp{},
+			}.Build(),
+			defaultVal: true,
+			expect:     true,
+		},
+		{
+			name: "explicit true overrides default false",
+			spec: scopedaccessv1.ScopedRoleSpec_builder{
+				App: scopedaccessv1.ScopedRoleApp_builder{
+					DisconnectExpiredCert: ptr(true),
+				}.Build(),
+			}.Build(),
+			defaultVal: false,
+			expect:     true,
+		},
+		{
+			name: "explicit false overrides default true",
+			spec: scopedaccessv1.ScopedRoleSpec_builder{
+				App: scopedaccessv1.ScopedRoleApp_builder{
+					DisconnectExpiredCert: ptr(false),
+				}.Build(),
+			}.Build(),
+			defaultVal: true,
+			expect:     false,
+		},
+		{
+			name: "unset app block defaults to default block",
+			spec: scopedaccessv1.ScopedRoleSpec_builder{
+				Defaults: scopedaccessv1.ScopedRoleDefaults_builder{
+					DisconnectExpiredCert: ptr(false),
+				}.Build(),
+				App: &scopedaccessv1.ScopedRoleApp{},
+			}.Build(),
+			defaultVal: true,
+			expect:     false,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).App()
+			require.Equal(t, tt.expect, checker.AdjustDisconnectExpiredCert(tt.defaultVal))
+		})
+	}
+}
+
+func TestAppAccessCheckerLockingMode(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name        string
+		spec        *scopedaccessv1.ScopedRoleSpec
+		defaultMode constants.LockingMode
+		expect      constants.LockingMode
+	}{
+		{
+			name: "unset defers to default",
+			spec: scopedaccessv1.ScopedRoleSpec_builder{
+				App: &scopedaccessv1.ScopedRoleApp{},
+			}.Build(),
+			defaultMode: constants.LockingModeBestEffort,
+			expect:      constants.LockingModeBestEffort,
+		},
+		{
+			name: "strict from role",
+			spec: scopedaccessv1.ScopedRoleSpec_builder{
+				App: scopedaccessv1.ScopedRoleApp_builder{
+					Lock: scopedaccessv1.Lock_builder{
+						Mode: string(constants.LockingModeStrict),
+					}.Build(),
+				}.Build(),
+			}.Build(),
+			defaultMode: constants.LockingModeBestEffort,
+			expect:      constants.LockingModeStrict,
+		},
+		{
+			name: "best effort from role",
+			spec: scopedaccessv1.ScopedRoleSpec_builder{
+				App: scopedaccessv1.ScopedRoleApp_builder{
+					Lock: scopedaccessv1.Lock_builder{
+						Mode: string(constants.LockingModeBestEffort),
+					}.Build(),
+				}.Build(),
+			}.Build(),
+			defaultMode: constants.LockingModeStrict,
+			expect:      constants.LockingModeBestEffort,
+		},
+		{
+			name: "invalid value falls back to default",
+			spec: scopedaccessv1.ScopedRoleSpec_builder{
+				App: scopedaccessv1.ScopedRoleApp_builder{
+					Lock: scopedaccessv1.Lock_builder{
+						Mode: "invalid",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+			defaultMode: constants.LockingModeStrict,
+			expect:      constants.LockingModeStrict,
+		},
+		{
+			name: "empty mode falls back to default",
+			spec: scopedaccessv1.ScopedRoleSpec_builder{
+				App: scopedaccessv1.ScopedRoleApp_builder{
+
+					Lock: &scopedaccessv1.Lock{},
+				}.Build(),
+			}.Build(),
+			defaultMode: constants.LockingModeStrict,
+			expect:      constants.LockingModeStrict,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).App()
+			require.Equal(t, tt.expect, checker.LockingMode(tt.defaultMode))
+		})
+	}
+}

--- a/lib/services/health_check_config.go
+++ b/lib/services/health_check_config.go
@@ -28,6 +28,7 @@ import (
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services/label"
 )
 
 // HealthCheckConfigReader defines methods for reading health check config
@@ -79,7 +80,7 @@ func ValidateHealthCheckConfig(s *healthcheckconfigv1.HealthCheckConfig) error {
 		}
 	}
 	if expr := s.GetSpec().GetMatch().GetDbLabelsExpression(); len(expr) > 0 {
-		if _, err := parseLabelExpression(expr); err != nil {
+		if _, err := label.ParseExpression(expr); err != nil {
 			return trace.BadParameter("invalid spec.db_labels_expression: %v", err)
 		}
 	}
@@ -90,7 +91,7 @@ func ValidateHealthCheckConfig(s *healthcheckconfigv1.HealthCheckConfig) error {
 		}
 	}
 	if expr := s.GetSpec().GetMatch().GetKubernetesLabelsExpression(); len(expr) > 0 {
-		if _, err := parseLabelExpression(expr); err != nil {
+		if _, err := label.ParseExpression(expr); err != nil {
 			return trace.BadParameter("invalid spec.kubernetes_labels_expression: %v", err)
 		}
 	}

--- a/lib/services/label/label.go
+++ b/lib/services/label/label.go
@@ -1,0 +1,36 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package label
+
+// LabelGetter allows retrieving a particular label by name or retreiving all
+// labels at once. Prefer to use GetLabel when possible to avoid unnecessary
+// copies.
+type LabelGetter interface {
+	GetLabel(key string) (value string, ok bool)
+	GetAllLabels() map[string]string
+}
+
+type MapLabelGetter map[string]string
+
+func (m MapLabelGetter) GetLabel(key string) (value string, ok bool) {
+	v, ok := m[key]
+	return v, ok
+}
+
+func (m MapLabelGetter) GetAllLabels() map[string]string {
+	return map[string]string(m)
+}

--- a/lib/services/label/label_expressions.go
+++ b/lib/services/label/label_expressions.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package services
+package label
 
 import (
 	"slices"
@@ -30,26 +30,27 @@ import (
 	"github.com/gravitational/teleport/lib/utils/typical"
 )
 
-type labelExpression typical.Expression[labelExpressionEnv, bool]
+type Expression typical.Expression[ExpressionEnv, bool]
 
-type labelExpressionEnv struct {
-	resourceLabelGetter LabelGetter
-	username            string
-	userTraits          map[string][]string
+type ExpressionEnv struct {
+	ResourceLabelGetter LabelGetter
+	Username            string
+	UserTraits          map[string][]string
 }
 
 var labelExpressionParser = mustNewLabelExpressionParser()
 
-func parseLabelExpression(expr string) (labelExpression, error) {
+// ParseExpression checks that the given label expression string is
+// valid and returns a [labelExpression].
+func ParseExpression(expr string) (Expression, error) {
 	parsedExpr, err := labelExpressionParser.Parse(expr)
 	if err != nil {
 		return nil, trace.Wrap(err, "parsing label expression")
 	}
 	return parsedExpr, nil
-
 }
 
-func mustNewLabelExpressionParser() *typical.CachedParser[labelExpressionEnv, bool] {
+func mustNewLabelExpressionParser() *typical.CachedParser[ExpressionEnv, bool] {
 	parser, err := newLabelExpressionParser()
 	if err != nil {
 		panic(trace.Wrap(err, "failed to create label expression parser (this is a bug)"))
@@ -57,39 +58,39 @@ func mustNewLabelExpressionParser() *typical.CachedParser[labelExpressionEnv, bo
 	return parser
 }
 
-func newLabelExpressionParser() (*typical.CachedParser[labelExpressionEnv, bool], error) {
-	parser, err := typical.NewCachedParser[labelExpressionEnv, bool](typical.ParserSpec[labelExpressionEnv]{
+func newLabelExpressionParser() (*typical.CachedParser[ExpressionEnv, bool], error) {
+	parser, err := typical.NewCachedParser[ExpressionEnv, bool](typical.ParserSpec[ExpressionEnv]{
 		Variables: map[string]typical.Variable{
 			"user.metadata.name": typical.DynamicVariable(
-				func(env labelExpressionEnv) (string, error) {
-					if env.username == "" {
+				func(env ExpressionEnv) (string, error) {
+					if env.Username == "" {
 						return "", trace.NotFound("user.metadata.name is not available in this context")
 					}
-					return env.username, nil
+					return env.Username, nil
 				}),
 			"user.spec.traits": typical.DynamicVariable(
-				func(env labelExpressionEnv) (map[string][]string, error) {
-					return env.userTraits, nil
+				func(env ExpressionEnv) (map[string][]string, error) {
+					return env.UserTraits, nil
 				}),
 			"labels": typical.DynamicMapFunction(
-				func(env labelExpressionEnv, key string) (string, error) {
-					label, _ := env.resourceLabelGetter.GetLabel(key)
+				func(env ExpressionEnv, key string) (string, error) {
+					label, _ := env.ResourceLabelGetter.GetLabel(key)
 					return label, nil
 				}),
 		},
 		Functions: map[string]typical.Function{
-			"set": typical.UnaryVariadicFunction[labelExpressionEnv](
+			"set": typical.UnaryVariadicFunction[ExpressionEnv](
 				func(args ...string) ([]string, error) {
 					return args, nil
 				}),
 			"labels_matching": typical.UnaryFunctionWithEnv(labelsMatching),
-			"contains": typical.BinaryFunction[labelExpressionEnv](
+			"contains": typical.BinaryFunction[ExpressionEnv](
 				func(list []string, item string) (bool, error) {
 					return slices.Contains(list, item), nil
 				}),
-			"contains_any": typical.BinaryFunction[labelExpressionEnv](containsAny),
-			"contains_all": typical.BinaryFunction[labelExpressionEnv](containsAll),
-			"regexp.match": typical.BinaryFunction[labelExpressionEnv](
+			"contains_any": typical.BinaryFunction[ExpressionEnv](containsAny),
+			"contains_all": typical.BinaryFunction[ExpressionEnv](containsAll),
+			"regexp.match": typical.BinaryFunction[ExpressionEnv](
 				func(list []string, re string) (bool, error) {
 					match, err := utils.RegexMatchesAny(list, re)
 					if err != nil {
@@ -99,9 +100,9 @@ func newLabelExpressionParser() (*typical.CachedParser[labelExpressionEnv, bool]
 				}),
 			// Use regexp.replace and email.local from lib/utils/parse to get behavior identical
 			// to role templates.
-			"regexp.replace": typical.TernaryFunction[labelExpressionEnv](parse.RegexpReplace),
-			"email.local":    typical.UnaryFunction[labelExpressionEnv](parse.EmailLocal),
-			"strings.upper": typical.UnaryFunction[labelExpressionEnv](
+			"regexp.replace": typical.TernaryFunction[ExpressionEnv](parse.RegexpReplace),
+			"email.local":    typical.UnaryFunction[ExpressionEnv](parse.EmailLocal),
+			"strings.upper": typical.UnaryFunction[ExpressionEnv](
 				func(list []string) ([]string, error) {
 					out := make([]string, len(list))
 					for i, s := range list {
@@ -109,7 +110,7 @@ func newLabelExpressionParser() (*typical.CachedParser[labelExpressionEnv, bool]
 					}
 					return out, nil
 				}),
-			"strings.lower": typical.UnaryFunction[labelExpressionEnv](
+			"strings.lower": typical.UnaryFunction[ExpressionEnv](
 				func(list []string) ([]string, error) {
 					out := make([]string, len(list))
 					for i, s := range list {
@@ -125,8 +126,8 @@ func newLabelExpressionParser() (*typical.CachedParser[labelExpressionEnv, bool]
 // labelsMatching returns the aggregate of all label values for all keys that
 // match keyExpr. It supports globs or full regular expressions and must find
 // a complete match for the key.
-func labelsMatching(env labelExpressionEnv, keyExpr string) ([]string, error) {
-	allLabels := env.resourceLabelGetter.GetAllLabels()
+func labelsMatching(env ExpressionEnv, keyExpr string) ([]string, error) {
+	allLabels := env.ResourceLabelGetter.GetAllLabels()
 	var matchingLabelValues []string
 	for key, value := range allLabels {
 		match, err := utils.MatchString(key, keyExpr)

--- a/lib/services/label/label_expressions_test.go
+++ b/lib/services/label/label_expressions_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package services
+package label
 
 import (
 	"testing"
@@ -329,7 +329,7 @@ func TestLabelExpressions(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			parsedExpr, err := parseLabelExpression(tc.expr)
+			parsedExpr, err := ParseExpression(tc.expr)
 			for _, msg := range tc.expectParseError {
 				assert.ErrorContains(t, err, msg, "parse error doesn't include expected message")
 			}
@@ -338,10 +338,10 @@ func TestLabelExpressions(t *testing.T) {
 			}
 			require.NoError(t, err, trace.DebugReport(err))
 
-			env := labelExpressionEnv{
-				resourceLabelGetter: mapLabelGetter(tc.resourceLabels),
-				username:            "alice",
-				userTraits:          tc.userTraits,
+			env := ExpressionEnv{
+				ResourceLabelGetter: MapLabelGetter(tc.resourceLabels),
+				Username:            "alice",
+				UserTraits:          tc.userTraits,
 			}
 
 			match, err := parsedExpr.Evaluate(env)

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -50,6 +50,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
+	"github.com/gravitational/teleport/lib/services/label"
 	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -378,7 +379,7 @@ func validateRoleExpressions(r types.Role) error {
 				}
 			}
 			if len(labelMatchers.Expression) > 0 {
-				if _, err := parseLabelExpression(labelMatchers.Expression); err != nil {
+				if _, err := label.ParseExpression(labelMatchers.Expression); err != nil {
 					errs = append(errs, trace.BadParameter("parsing %s.%s_expression: %v", condition.name, labels.name, err))
 				}
 			}
@@ -1410,26 +1411,7 @@ func MatchDatabaseUser(selectors []string, user string, matchWildcard, caseFold 
 // MatchLabels matches selector against target. Empty selector matches
 // nothing, wildcard matches everything.
 func MatchLabels(selector types.Labels, target map[string]string) (bool, string, error) {
-	return MatchLabelGetter(selector, mapLabelGetter(target))
-}
-
-// LabelGetter allows retrieving a particular label by name or retreiving all
-// labels at once. Prefer to use GetLabel when possible to avoid unnecessary
-// copies.
-type LabelGetter interface {
-	GetLabel(key string) (value string, ok bool)
-	GetAllLabels() map[string]string
-}
-
-type mapLabelGetter map[string]string
-
-func (m mapLabelGetter) GetLabel(key string) (value string, ok bool) {
-	v, ok := m[key]
-	return v, ok
-}
-
-func (m mapLabelGetter) GetAllLabels() map[string]string {
-	return map[string]string(m)
+	return MatchLabelGetter(selector, label.MapLabelGetter(target))
 }
 
 // MatchLabelGetter matches selector against labelGetter. Empty selector matches
@@ -1437,7 +1419,7 @@ func (m mapLabelGetter) GetAllLabels() map[string]string {
 //
 // Keep in sync with front-end implementation;
 //   - web/packages/teleport/src/Bots/Add/Shared/kubernetes.ts:34
-func MatchLabelGetter(selector types.Labels, labelGetter LabelGetter) (bool, string, error) {
+func MatchLabelGetter(selector types.Labels, labelGetter label.LabelGetter) (bool, string, error) {
 	// Empty selector matches nothing.
 	if len(selector) == 0 {
 		return false, "no match, empty selector", nil
@@ -2928,7 +2910,7 @@ func (l *kubernetesClusterLabelMatcher) Match(role types.Role, typ types.RoleCon
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
-	ok, _, err := CheckLabelsMatch(typ, labelMatchers, l.username, l.userTraits, mapLabelGetter(l.clusterLabels), false)
+	ok, _, err := CheckLabelsMatch(typ, labelMatchers, l.username, l.userTraits, label.MapLabelGetter(l.clusterLabels), false)
 	return ok, trace.Wrap(err)
 }
 
@@ -3275,7 +3257,7 @@ func CheckLabelsMatch(
 	labelMatchers types.LabelMatchers,
 	username string,
 	userTraits wrappers.Traits,
-	resource LabelGetter,
+	resource label.LabelGetter,
 	debug bool,
 ) (bool, string, error) {
 	if labelMatchers.Empty() {
@@ -3324,15 +3306,15 @@ func CheckLabelsMatch(
 	return labelsUnsetOrMatch && expressionUnsetOrMatch, message, nil
 }
 
-func matchLabelExpression(labelExpression string, resource LabelGetter, username string, userTraits wrappers.Traits) (bool, string, error) {
-	parsedExpr, err := parseLabelExpression(labelExpression)
+func matchLabelExpression(labelExpression string, resource label.LabelGetter, username string, userTraits wrappers.Traits) (bool, string, error) {
+	parsedExpr, err := label.ParseExpression(labelExpression)
 	if err != nil {
 		return false, "", trace.Wrap(err)
 	}
-	match, err := parsedExpr.Evaluate(labelExpressionEnv{
-		resourceLabelGetter: resource,
-		username:            username,
-		userTraits:          userTraits,
+	match, err := parsedExpr.Evaluate(label.ExpressionEnv{
+		ResourceLabelGetter: resource,
+		Username:            username,
+		UserTraits:          userTraits,
 	})
 	if err != nil {
 		return false, "", trace.Wrap(err, "evaluating label expression %q", labelExpression)

--- a/lib/services/scoped_access_checker_context.go
+++ b/lib/services/scoped_access_checker_context.go
@@ -347,6 +347,10 @@ func (c *ScopedAccessCheckerContext) CheckMaybeHasAccessToRules(ctx RuleContext,
 // Decision calls fn against each checker in the resource scope evaluation order until one of three
 // conditions is met: (1) fn succeeds, (2) fn returns an explicitly denied error, or (3) all checkers
 // have been exhausted (implicit deny).
+//
+// Unscoped contexts resolve to exactly one checker, an error returned in this case is unmodified in order to
+// surface special unscoped requirements like trusted device or session MFA that only an unscoped checker can produce
+// right now.
 func (c *ScopedAccessCheckerContext) Decision(ctx context.Context, scope string, fn func(*ScopedAccessChecker) error) error {
 	return c.decision(c.CheckersForResourceScope(ctx, scope), fn)
 }
@@ -360,6 +364,12 @@ func (c *ScopedAccessCheckerContext) decision(checkers stream.Stream[*ScopedAcce
 		switch {
 		case err == nil:
 			return nil
+		case !c.isScoped():
+			// This surfaces requirements like trusted device and session MFA
+			// that only the unscoped checker can produce right now.
+			// Rather than masking them into an explicit deny,
+			// return errors here that unscoped checkers return.
+			return trace.Wrap(err)
 		case IsAccessExplicitlyDenied(err):
 			return trace.Wrap(err)
 		default:

--- a/lib/services/statichostuser.go
+++ b/lib/services/statichostuser.go
@@ -25,6 +25,7 @@ import (
 
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services/label"
 )
 
 // StaticHostUserService manages host users that should be created on SSH nodes.
@@ -75,7 +76,7 @@ func ValidateStaticHostUser(u *userprovisioningpb.StaticHostUser) error {
 			}
 		}
 		if len(matcher.GetNodeLabelsExpression()) > 0 {
-			if _, err := parseLabelExpression(matcher.GetNodeLabelsExpression()); err != nil {
+			if _, err := label.ParseExpression(matcher.GetNodeLabelsExpression()); err != nil {
 				return trace.BadParameter("parsing node labels expression: %v", err)
 			}
 		}

--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -66,7 +66,7 @@ import (
 // ConnMonitor monitors authorized connections and terminates them when
 // session controls dictate so.
 type ConnMonitor interface {
-	MonitorConn(ctx context.Context, authzCtx *authz.Context, conn net.Conn) (context.Context, net.Conn, error)
+	MonitorConnScoped(ctx context.Context, scopedCtx *srv.ScopedSessionContext, conn net.Conn) (context.Context, net.Conn, error)
 }
 
 // ConnectionsHandlerConfig is the configuration for a ConnectionsHandler.
@@ -81,7 +81,7 @@ type ConnectionsHandlerConfig struct {
 	Emitter events.Emitter
 
 	// Authorizer is used to authorize requests.
-	Authorizer authz.Authorizer
+	Authorizer authz.ScopedAuthorizer
 
 	// HostID is the id of the host where this application agent is running.
 	HostID string
@@ -476,12 +476,12 @@ func (c *ConnectionsHandler) Close(ctx context.Context) []error {
 func (c *ConnectionsHandler) serveHTTP(w http.ResponseWriter, r *http.Request) error {
 	// Extract the identity and application being requested from the certificate
 	// and check if the caller has access.
-	authCtx, app, err := c.authorizeContext(r.Context())
+	sessionCtx, app, err := c.authorizeContext(r.Context())
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	identity := authCtx.Identity.GetIdentity()
+	identity := sessionCtx.Context.Identity.GetIdentity()
 	switch {
 	case app.IsAWSConsole():
 		// Requests from AWS applications are signed by AWS Signature Version 4
@@ -561,8 +561,9 @@ func (c *ConnectionsHandler) serveAWSWebConsole(w http.ResponseWriter, r *http.R
 }
 
 // authorizeContext will check if the context carries identity information and
-// runs authorization checks on it.
-func (c *ConnectionsHandler) authorizeContext(ctx context.Context) (*authz.Context, types.Application, error) {
+// runs authorization checks on it. On success it returns the scoped context
+// bundled with the session controls of the role that granted access.
+func (c *ConnectionsHandler) authorizeContext(ctx context.Context) (*srv.ScopedSessionContext, types.Application, error) {
 	// Only allow local and remote identities to proxy to an application.
 	userType, err := authz.UserFromContext(ctx)
 	if err != nil {
@@ -575,8 +576,7 @@ func (c *ConnectionsHandler) authorizeContext(ctx context.Context) (*authz.Conte
 		return nil, nil, trace.BadParameter("invalid identity: %T", userType)
 	}
 
-	// Extract authorizing context and identity of the user from the request.
-	authContext, err := c.cfg.Authorizer.Authorize(ctx)
+	authContext, err := c.cfg.Authorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -588,10 +588,6 @@ func (c *ConnectionsHandler) authorizeContext(ctx context.Context) (*authz.Conte
 		identity.RouteToApp.Name,
 		identity.RouteToApp.PublicAddr,
 	)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	authPref, err := c.cfg.AccessPoint.GetAuthPreference(ctx)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -621,11 +617,25 @@ func (c *ConnectionsHandler) authorizeContext(ctx context.Context) (*authz.Conte
 		})
 	}
 
-	state := authContext.GetAccessState(authPref)
-	switch err := authContext.Checker.CheckAccess(
-		app,
-		state,
-		matchers...); {
+	state, err := authContext.CheckerContext.AccessStateFromTLSIdentity(ctx, &identity, c.cfg.AccessPoint)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	// Identity Center account apps are currently not supported for scoped applications.
+	// TODO (williamo/scopes) - potentially look into adding account_assignments into scoped roles.
+	if _, isUnscoped := authContext.UnscopedContext(); !isUnscoped && app.GetSubKind() == types.KindIdentityCenterAccount {
+		return nil, nil, trace.AccessDenied("identity center account apps are not supported for scoped identities")
+	}
+
+	var sessionControls srv.ScopedSessionControls
+	switch err := authContext.CheckerContext.Decision(ctx, app.GetScope(), func(check *services.ScopedAccessChecker) error {
+		if err := check.App().CheckAccessToApp(app, state, matchers...); err != nil {
+			return trace.Wrap(err)
+		}
+		sessionControls = check.App()
+		return nil
+	}); {
 	case errors.Is(err, services.ErrTrustedDeviceRequired) || errors.Is(err, services.ErrSessionMFARequired):
 		// When access is denied due to trusted device or session MFA requirements, these specific errors
 		// are returned directly to provide clarity to the client about the additional authentication steps needed.
@@ -639,7 +649,10 @@ func (c *ConnectionsHandler) authorizeContext(ctx context.Context) (*authz.Conte
 		return nil, nil, utils.OpaqueAccessDenied(err)
 	}
 
-	return authContext, app, nil
+	return &srv.ScopedSessionContext{
+		Context:         authContext,
+		SessionControls: sessionControls,
+	}, app, nil
 }
 
 func (c *ConnectionsHandler) handleConnection(ctx context.Context, cancel context.CancelCauseFunc, conn net.Conn) (func(), error) {
@@ -679,7 +692,7 @@ func (c *ConnectionsHandler) handleConnection(ctx context.Context, cancel contex
 
 	ctx = authz.ContextWithUser(ctx, user)
 	ctx = authz.ContextWithClientSrcAddr(ctx, conn.RemoteAddr())
-	authCtx, _, err := c.authorizeContext(ctx)
+	sessionCtx, _, err := c.authorizeContext(ctx)
 
 	// The behavior here is a little hard to track. To be clear here, if authorization fails
 	// the following will occur:
@@ -702,8 +715,7 @@ func (c *ConnectionsHandler) handleConnection(ctx context.Context, cancel contex
 			c.setConnAuth(tlsConn, err)
 		}
 	} else {
-		// Monitor the connection an update the context.
-		ctx, _, err = c.cfg.ConnectionMonitor.MonitorConn(ctx, authCtx, tc)
+		ctx, _, err = c.cfg.ConnectionMonitor.MonitorConnScoped(ctx, sessionCtx, tc)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -720,13 +732,18 @@ func (c *ConnectionsHandler) handleConnection(ctx context.Context, cancel contex
 	// blocks on waitConn.Wait() until the HTTP server closes the conn.
 	switch {
 	case app.IsTCP():
-		identity := authCtx.Identity.GetIdentity()
+		identity := sessionCtx.Context.Identity.GetIdentity()
 		return nil, trace.Wrap(c.handleTCPApp(ctx, tlsConn, &identity, app))
 
 	case app.IsMCP():
+		// TODO (williamo/scopes): change this to a scoped context when we support MCP.
+		unscopedAuthCtx, ok := sessionCtx.Context.UnscopedContext()
+		if !ok {
+			return nil, trace.AccessDenied("MCP application access is not supported for scoped identities")
+		}
 		sessionCtx := mcp.SessionCtx{
 			ClientConn: tlsConn,
-			AuthCtx:    authCtx,
+			AuthCtx:    unscopedAuthCtx,
 			App:        app,
 		}
 		return nil, trace.Wrap(c.mcpServer.HandleSession(ctx, &sessionCtx))

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -73,6 +73,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/srv/app/common"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
@@ -173,7 +174,7 @@ type suiteConfig struct {
 
 type fakeConnMonitor struct{}
 
-func (f fakeConnMonitor) MonitorConn(ctx context.Context, authzCtx *authz.Context, conn net.Conn) (context.Context, net.Conn, error) {
+func (f fakeConnMonitor) MonitorConnScoped(ctx context.Context, scopedCtx *srv.ScopedSessionContext, conn net.Conn) (context.Context, net.Conn, error) {
 	return ctx, conn, nil
 }
 
@@ -365,10 +366,11 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 		},
 	})
 	require.NoError(t, err)
-	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
-		ClusterName: "cluster-name",
-		AccessPoint: s.authClient,
-		LockWatcher: s.lockWatcher,
+	authorizer, err := authz.NewScopedAuthorizer(authz.AuthorizerOpts{
+		ClusterName:      "cluster-name",
+		AccessPoint:      s.authClient,
+		ScopedRoleReader: s.authClient.ScopedRoleReader(),
+		LockWatcher:      s.lockWatcher,
 	})
 	require.NoError(t, err)
 

--- a/lib/srv/monitor.go
+++ b/lib/srv/monitor.go
@@ -164,12 +164,101 @@ func (c *ConnectionMonitor) MonitorConn(ctx context.Context, authzCtx *authz.Con
 
 	identity := authzCtx.Identity.GetIdentity()
 	checker := authzCtx.Checker
+	return c.monitorConn(ctx, monitorParams{
+		lockTargets:           authzCtx.LockTargets(),
+		lockingMode:           checker.LockingMode(authPref.GetLockingMode()),
+		disconnectExpiredCert: authzCtx.GetDisconnectCertExpiry(authPref),
+		clientIdleTimeout:     checker.AdjustClientIdleTimeout(netConfig.GetClientIdleTimeout()),
+		teleportUser:          identity.Username,
+		originClusterName:     identity.OriginClusterName,
+		idleTimeoutMessage:    netConfig.GetClientIdleTimeoutMessage(),
+	}, conn)
+}
 
-	idleTimeout := checker.AdjustClientIdleTimeout(netConfig.GetClientIdleTimeout())
+// ScopedSessionControls exposes the per-protocol session controls (idle
+// timeout, disconnect on cert expiry, locking mode) of the role that granted
+// access for a connection.
+type ScopedSessionControls interface {
+	AdjustClientIdleTimeout(time.Duration) (time.Duration, error)
+	AdjustDisconnectExpiredCert(bool) bool
+	LockingMode(constants.LockingMode) constants.LockingMode
+}
 
+// ScopedSessionContext bundles a scoped authorization context with the session
+// controls produced by the access decision that authorized the connection.
+type ScopedSessionContext struct {
+	// Context is the scoped authorization context of the caller.
+	Context *authz.ScopedContext
+	// SessionControls are the per-protocol session controls of the role that
+	// granted access.
+	SessionControls ScopedSessionControls
+}
+
+// MonitorConnScoped is the scoped-identity variant of [ConnectionMonitor.MonitorConn].
+func (c *ConnectionMonitor) MonitorConnScoped(ctx context.Context, sessionCtx *ScopedSessionContext, conn net.Conn) (context.Context, net.Conn, error) {
+	if sessionCtx == nil {
+		return ctx, conn, trace.BadParameter("missing session control context for scoped connection monitoring")
+	}
+	if sessionCtx.Context == nil {
+		return ctx, conn, trace.BadParameter("missing scoped auth context inside the session control context for scoped connection monitoring")
+	}
+	if sessionCtx.SessionControls == nil {
+		return ctx, conn, trace.BadParameter("missing session controls inside the session control context for scoped connection monitoring")
+	}
+
+	controls := sessionCtx.SessionControls
+
+	authPref, err := c.cfg.AccessPoint.GetAuthPreference(ctx)
+	if err != nil {
+		return ctx, conn, trace.Wrap(err)
+	}
+	netConfig, err := c.cfg.AccessPoint.GetClusterNetworkingConfig(ctx)
+	if err != nil {
+		return ctx, conn, trace.Wrap(err)
+	}
+
+	idleTimeout, err := controls.AdjustClientIdleTimeout(netConfig.GetClientIdleTimeout())
+	if err != nil {
+		return ctx, conn, trace.Wrap(err)
+	}
+
+	var disconnectExpiredCert time.Time
+	if controls.AdjustDisconnectExpiredCert(authPref.GetDisconnectExpiredCert()) {
+		disconnectExpiredCert = sessionCtx.Context.GetDisconnectCertExpiryTime()
+	}
+
+	identity := sessionCtx.Context.Identity.GetIdentity()
+	return c.monitorConn(ctx, monitorParams{
+		lockTargets:           sessionCtx.Context.LockTargets(),
+		lockingMode:           controls.LockingMode(authPref.GetLockingMode()),
+		disconnectExpiredCert: disconnectExpiredCert,
+		clientIdleTimeout:     idleTimeout,
+		teleportUser:          identity.Username,
+		originClusterName:     identity.OriginClusterName,
+		idleTimeoutMessage:    netConfig.GetClientIdleTimeoutMessage(),
+	}, conn)
+}
+
+// monitorParams holds the per-connection session-control values resolved from a scoped
+// or unscoped identity, used to configure connection monitoring.
+type monitorParams struct {
+	lockTargets           []types.LockTarget
+	lockingMode           constants.LockingMode
+	disconnectExpiredCert time.Time
+	clientIdleTimeout     time.Duration
+	teleportUser          string
+	originClusterName     string
+	idleTimeoutMessage    string
+}
+
+// monitorConn wraps conn in a tracking connection and starts monitoring it with the
+// provided per-connection session controls. When the client connection is closed the
+// monitor goroutine exits.
+func (c *ConnectionMonitor) monitorConn(ctx context.Context, params monitorParams, conn net.Conn) (context.Context, net.Conn, error) {
 	tconn, ok := getTrackingReadConn(conn)
 	if !ok {
 		tctx, cancel := context.WithCancelCause(ctx)
+		var err error
 		tconn, err = NewTrackingReadConn(TrackingReadConnConfig{
 			Conn:    conn,
 			Clock:   c.cfg.Clock,
@@ -181,24 +270,23 @@ func (c *ConnectionMonitor) MonitorConn(ctx context.Context, authzCtx *authz.Con
 		}
 	}
 
-	// Start monitoring client connection. When client connection is closed the monitor goroutine exits.
 	if err := StartMonitor(MonitorConfig{
 		LockWatcher:           c.cfg.LockWatcher,
-		LockTargets:           authzCtx.LockTargets(),
-		LockingMode:           authzCtx.Checker.LockingMode(authPref.GetLockingMode()),
-		DisconnectExpiredCert: authzCtx.GetDisconnectCertExpiry(authPref),
-		ClientIdleTimeout:     idleTimeout,
+		LockTargets:           params.lockTargets,
+		LockingMode:           params.lockingMode,
+		DisconnectExpiredCert: params.disconnectExpiredCert,
+		ClientIdleTimeout:     params.clientIdleTimeout,
 		Conn:                  tconn,
 		Tracker:               tconn,
 		Context:               ctx,
 		Clock:                 c.cfg.Clock,
 		ServerID:              c.cfg.ServerID,
-		TeleportUser:          identity.Username,
-		UserOriginClusterName: identity.OriginClusterName,
+		TeleportUser:          params.teleportUser,
+		UserOriginClusterName: params.originClusterName,
 		Emitter:               c.cfg.Emitter,
 		EmitterContext:        c.cfg.EmitterContext,
 		Logger:                c.cfg.Logger,
-		IdleTimeoutMessage:    netConfig.GetClientIdleTimeoutMessage(),
+		IdleTimeoutMessage:    params.idleTimeoutMessage,
 		MonitorCloseChannel:   c.cfg.MonitorCloseChannel,
 	}); err != nil {
 		return ctx, conn, trace.Wrap(err)

--- a/lib/srv/monitor_test.go
+++ b/lib/srv/monitor_test.go
@@ -24,10 +24,12 @@ import (
 	"net"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/constants"
@@ -402,6 +404,272 @@ func TestTrackingReadConn(t *testing.T) {
 		require.NoError(t, tc.Close())
 		require.ErrorIs(t, context.Cause(ctx), io.EOF)
 	})
+}
+
+// mockScopedControls implements [ScopedSessionControls] for MonitorConnScoped tests.
+type mockScopedControls struct {
+	idleTimeout       time.Duration
+	disconnectExpired bool
+	lockingMode       constants.LockingMode
+}
+
+func (m mockScopedControls) AdjustClientIdleTimeout(ttl time.Duration) (time.Duration, error) {
+	if m.idleTimeout != 0 {
+		return m.idleTimeout, nil
+	}
+	return ttl, nil
+}
+
+func (m mockScopedControls) AdjustDisconnectExpiredCert(disconnect bool) bool {
+	return m.disconnectExpired || disconnect
+}
+
+func (m mockScopedControls) LockingMode(defaultMode constants.LockingMode) constants.LockingMode {
+	return m.lockingMode
+}
+
+func TestMonitorScoped(t *testing.T) {
+	t.Parallel()
+
+	newAuthServer := func(t *testing.T) *authtest.AuthServer {
+		srv, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+			Dir:   t.TempDir(),
+			Clock: clockwork.NewFakeClock(),
+		})
+		require.NoError(t, err)
+		return srv
+	}
+
+	t.Run("scoped connection terminated when a matching lock is created", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
+			srv := newAuthServer(t)
+			defer func() { require.NoError(t, srv.Close()) }()
+
+			scopedCtx := &authz.ScopedContext{
+				Identity: authz.LocalUser{
+					Username: "scoped-user",
+					Identity: tlsca.Identity{Username: "scoped-user"},
+				},
+			}
+			emitter := eventstest.NewChannelEmitter(1)
+			lock, err := types.NewLock("test-lock", types.LockSpecV2{Target: types.LockTarget{User: "scoped-user"}})
+			require.NoError(t, err)
+			conn := &mockTrackingConn{closedC: make(chan struct{})}
+			monitor, err := NewConnectionMonitor(ConnectionMonitorConfig{
+				AccessPoint:    srv.AuthServer,
+				Emitter:        emitter,
+				EmitterContext: ctx,
+				Clock:          srv.Clock(),
+				Logger:         logtest.NewLogger(),
+				LockWatcher:    srv.LockWatcher,
+				ServerID:       "test",
+			})
+			require.NoError(t, err)
+			monitorCtx, _, err := monitor.MonitorConnScoped(ctx, &ScopedSessionContext{
+				Context:         scopedCtx,
+				SessionControls: mockScopedControls{},
+			}, conn)
+			require.NoError(t, err)
+			require.NoError(t, monitorCtx.Err())
+
+			// Create a lock targeting the scoped user after the connection is established.
+			require.NoError(t, srv.AuthServer.UpsertLock(ctx, lock))
+			synctest.Wait()
+
+			select {
+			case <-conn.closedC:
+			default:
+				t.Fatal("connection is still open")
+			}
+			require.Error(t, monitorCtx.Err())
+			cause := context.Cause(monitorCtx)
+			require.True(t, trace.IsAccessDenied(cause))
+			require.Equal(t, services.LockInForceAccessDenied(lock).Error(), (<-emitter.C()).(*apievents.ClientDisconnect).Reason)
+		})
+	})
+
+	t.Run("scoped client idle timeout is enforced", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
+			srv := newAuthServer(t)
+			defer func() { require.NoError(t, srv.Close()) }()
+
+			idleCtx := &authz.ScopedContext{
+				Identity: authz.LocalUser{
+					Username: "idle-user",
+					Identity: tlsca.Identity{Username: "idle-user"},
+				},
+			}
+			conn := &mockTrackingConn{closedC: make(chan struct{})}
+			m, err := NewConnectionMonitor(ConnectionMonitorConfig{
+				AccessPoint:    srv.AuthServer,
+				Emitter:        eventstest.NewChannelEmitter(1),
+				EmitterContext: ctx,
+				Clock:          clockwork.NewRealClock(),
+				Logger:         logtest.NewLogger(),
+				LockWatcher:    srv.LockWatcher,
+				ServerID:       "test",
+			})
+			require.NoError(t, err)
+
+			_, _, err = m.MonitorConnScoped(ctx, &ScopedSessionContext{
+				Context:         idleCtx,
+				SessionControls: mockScopedControls{idleTimeout: time.Minute},
+			}, conn)
+			require.NoError(t, err)
+
+			time.Sleep(2 * time.Minute)
+			synctest.Wait()
+			select {
+			case <-conn.closedC:
+			default:
+				t.Fatal("connection is still open after the idle timeout")
+			}
+		})
+	})
+
+	t.Run("scoped disconnect_expired_cert is enforced at cert expiry", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
+			srv := newAuthServer(t)
+			defer func() { require.NoError(t, srv.Close()) }()
+
+			clock := clockwork.NewRealClock()
+			expiredCtx := &authz.ScopedContext{
+				Identity: authz.LocalUser{
+					Username: "expiry-user",
+					Identity: tlsca.Identity{Username: "expiry-user", Expires: clock.Now().Add(-time.Second)},
+				},
+			}
+			conn := &mockTrackingConn{closedC: make(chan struct{})}
+			m, err := NewConnectionMonitor(ConnectionMonitorConfig{
+				AccessPoint:    srv.AuthServer,
+				Emitter:        eventstest.NewChannelEmitter(1),
+				EmitterContext: ctx,
+				Clock:          clock,
+				Logger:         logtest.NewLogger(),
+				LockWatcher:    srv.LockWatcher,
+				ServerID:       "test",
+			})
+			require.NoError(t, err)
+
+			_, _, err = m.MonitorConnScoped(ctx, &ScopedSessionContext{
+				Context:         expiredCtx,
+				SessionControls: mockScopedControls{disconnectExpired: true},
+			}, conn)
+			require.NoError(t, err)
+
+			synctest.Wait()
+			select {
+			case <-conn.closedC:
+			default:
+				t.Fatal("connection is still open after certificate expiry")
+			}
+		})
+	})
+
+	staleLockCases := []struct {
+		name        string
+		lockingMode constants.LockingMode
+		// assertStale runs after the lock watcher has been forced into a stale state.
+		assertStale func(t *testing.T, conn *mockTrackingConn, emitter *eventstest.ChannelEmitter)
+	}{
+		{
+			name:        "best-effort locking keeps the scoped connection open on a stale lock view",
+			lockingMode: constants.LockingModeBestEffort,
+			assertStale: func(t *testing.T, conn *mockTrackingConn, emitter *eventstest.ChannelEmitter) {
+				// Under best-effort locking the connection must remain open despite the stale view.
+				select {
+				case <-conn.closedC:
+					t.Fatal("connection closed under best-effort locking with a stale lock view")
+				case <-time.After(2 * time.Second):
+				}
+			},
+		},
+		{
+			name:        "strict locking stops the scoped connection on a stale lock view",
+			lockingMode: constants.LockingModeStrict,
+			assertStale: func(t *testing.T, conn *mockTrackingConn, emitter *eventstest.ChannelEmitter) {
+				// Under strict locking the connection must be terminated on the stale view.
+				select {
+				case <-conn.closedC:
+				case <-time.After(15 * time.Second):
+					t.Fatal("Timeout waiting for connection close.")
+				}
+				require.Equal(t, services.StrictLockingModeAccessDenied.Error(), (<-emitter.C()).(*apievents.ClientDisconnect).Reason)
+			},
+		},
+	}
+
+	for _, tc := range staleLockCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			srv := newAuthServer(t)
+			t.Cleanup(func() { require.NoError(t, srv.Close()) })
+
+			emitter := eventstest.NewChannelEmitter(1)
+			authCtx := &authz.ScopedContext{
+				Identity: authz.LocalUser{
+					Username: "stale-lock-user",
+					Identity: tlsca.Identity{Username: "stale-lock-user"},
+				},
+			}
+			conn := &mockTrackingConn{closedC: make(chan struct{})}
+			m, err := NewConnectionMonitor(ConnectionMonitorConfig{
+				AccessPoint:    srv.AuthServer,
+				Emitter:        emitter,
+				EmitterContext: ctx,
+				Clock:          srv.Clock(),
+				Logger:         logtest.NewLogger(),
+				LockWatcher:    srv.LockWatcher,
+				ServerID:       "test",
+			})
+			require.NoError(t, err)
+
+			_, _, err = m.MonitorConnScoped(ctx, &ScopedSessionContext{
+				Context:         authCtx,
+				SessionControls: mockScopedControls{lockingMode: tc.lockingMode},
+			}, conn)
+			require.NoError(t, err)
+			select {
+			case <-conn.closedC:
+				t.Fatal("Connection is already closed.")
+			default:
+			}
+
+			// Force the lock watcher into a stale state (mirrors TestMonitorStaleLocks).
+			select {
+			case <-srv.LockWatcher.LoopC:
+			case <-time.After(15 * time.Second):
+				t.Fatal("Timeout waiting for LockWatcher loop check.")
+			}
+			// ensure ResetC is drained
+			select {
+			case <-srv.LockWatcher.ResetC:
+			default:
+			}
+			go srv.Backend.CloseWatchers()
+			// wait for reset
+			select {
+			case <-srv.LockWatcher.ResetC:
+			case <-time.After(15 * time.Second):
+				t.Fatal("Timeout waiting for LockWatcher reset.")
+			}
+
+			// StaleC is listened by multiple goroutines, so we close it to ensure they are all
+			// unblocked and the stale state is detected.
+			// synctest is not applicable here because closing srv.LockWatcher.StaleC
+			// causes its resource watch loop to retry continuously, preventing
+			// synctest.Wait from returning.
+			close(srv.LockWatcher.StaleC)
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.True(c, srv.LockWatcher.IsStale())
+			}, 15*time.Second, 100*time.Millisecond, "Timeout waiting for LockWatcher to be stale.")
+
+			tc.assertStale(t, conn, emitter)
+		})
+	}
 }
 
 type mockChecker struct {


### PR DESCRIPTION
This PR lets scoped users run tsh app login and tsh proxy app for scoped applications by propagating required scoped access checkers/authorizers in the app access path

Added `Lock`, `Client Idle Timeout`, and `Disconnect Expired Cert` role options to the app block.



<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Allow for scoped users to run `tsh proxy app` and `tsh app login`


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster, docker apps

### Test Cases
- [x] Scoped Users can run tctl login to scoped apps (http and tcp)
- [x] Scoped Users can't run tctl login to orthogonally scoped apps or unscoped apps (http and tcp)
- [x] TSH Proxy works for scoped users 
- [x] Vnet access for scoped apps and scoped users 
- [x] Ensure app sessions are terminated when  client idle timeout is set
- [x] Ensure app sessions are terminated when disconnect expired cert is set
- [x] Ensure app sessions are terminated or persisted depending on the lock mode set
