### PR TITLE
Encode Bot Scope into TLS/SSH identity

### DIFF
--- a/api/gen/proto/go/teleport/decision/v1alpha1/ssh_identity.pb.go
+++ b/api/gen/proto/go/teleport/decision/v1alpha1/ssh_identity.pb.go
@@ -321,7 +321,10 @@ type SSHIdentity struct {
 	HeadlessAuthenticationId string `protobuf:"bytes,40,opt,name=headless_authentication_id,json=headlessAuthenticationId,proto3" json:"headless_authentication_id,omitempty"`
 	// Beam this SSH identity is associated with, derived from the delegation
 	// session's beam ID label.
-	BeamId        string `protobuf:"bytes,41,opt,name=beam_id,json=beamId,proto3" json:"beam_id,omitempty"`
+	BeamId string `protobuf:"bytes,41,opt,name=beam_id,json=beamId,proto3" json:"beam_id,omitempty"`
+	// BotScope is the scope of the Machine ID bot this identity was issued to,
+	// if any. Empty for unscoped bots and non-bot identities.
+	BotScope      string `protobuf:"bytes,42,opt,name=bot_scope,json=botScope,proto3" json:"bot_scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -638,6 +641,13 @@ func (x *SSHIdentity) GetBeamId() string {
 	return ""
 }
 
+func (x *SSHIdentity) GetBotScope() string {
+	if x != nil {
+		return x.BotScope
+	}
+	return ""
+}
+
 func (x *SSHIdentity) SetValidAfter(v uint64) {
 	x.ValidAfter = v
 }
@@ -802,6 +812,10 @@ func (x *SSHIdentity) SetBeamId(v string) {
 	x.BeamId = v
 }
 
+func (x *SSHIdentity) SetBotScope(v string) {
+	x.BotScope = v
+}
+
 func (x *SSHIdentity) HasPreviousIdentityExpires() bool {
 	if x == nil {
 		return false
@@ -938,6 +952,9 @@ type SSHIdentity_builder struct {
 	// Beam this SSH identity is associated with, derived from the delegation
 	// session's beam ID label.
 	BeamId string
+	// BotScope is the scope of the Machine ID bot this identity was issued to,
+	// if any. Empty for unscoped bots and non-bot identities.
+	BotScope string
 }
 
 func (b0 SSHIdentity_builder) Build() *SSHIdentity {
@@ -985,6 +1002,7 @@ func (b0 SSHIdentity_builder) Build() *SSHIdentity {
 	x.DelegationSessionId = b.DelegationSessionId
 	x.HeadlessAuthenticationId = b.HeadlessAuthenticationId
 	x.BeamId = b.BeamId
+	x.BotScope = b.BotScope
 	return m0
 }
 
@@ -1112,7 +1130,7 @@ const file_teleport_decision_v1alpha1_ssh_identity_proto_rawDesc = "" +
 	"-teleport/decision/v1alpha1/ssh_identity.proto\x12\x1ateleport.decision.v1alpha1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a-teleport/decision/v1alpha1/tls_identity.proto\x1a%teleport/legacy/types/resources.proto\x1a\x1fteleport/scopes/v1/scopes.proto\x1a\x1dteleport/trait/v1/trait.proto\"X\n" +
 	"\fSSHAuthority\x12!\n" +
 	"\fcluster_name\x18\x01 \x01(\tR\vclusterName\x12%\n" +
-	"\x0eauthority_type\x18\x02 \x01(\tR\rauthorityType\"\xa5\x0e\n" +
+	"\x0eauthority_type\x18\x02 \x01(\tR\rauthorityType\"\xc2\x0e\n" +
 	"\vSSHIdentity\x12\x1f\n" +
 	"\vvalid_after\x18\x01 \x01(\x04R\n" +
 	"validAfter\x12!\n" +
@@ -1163,7 +1181,8 @@ const file_teleport_decision_v1alpha1_ssh_identity_proto_rawDesc = "" +
 	"\x14immutable_label_hash\x18& \x01(\tR\x12immutableLabelHash\x122\n" +
 	"\x15delegation_session_id\x18' \x01(\tR\x13delegationSessionId\x12<\n" +
 	"\x1aheadless_authentication_id\x18( \x01(\tR\x18headlessAuthenticationId\x12\x17\n" +
-	"\abeam_id\x18) \x01(\tR\x06beamId\"\xbf\x01\n" +
+	"\abeam_id\x18) \x01(\tR\x06beamId\x12\x1b\n" +
+	"\tbot_scope\x18* \x01(\tR\bbotScope\"\xbf\x01\n" +
 	"\rCertExtension\x12A\n" +
 	"\x04type\x18\x01 \x01(\x0e2-.teleport.decision.v1alpha1.CertExtensionTypeR\x04type\x12A\n" +
 	"\x04mode\x18\x02 \x01(\x0e2-.teleport.decision.v1alpha1.CertExtensionModeR\x04mode\x12\x12\n" +

--- a/api/gen/proto/go/teleport/decision/v1alpha1/ssh_identity_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/decision/v1alpha1/ssh_identity_protoopaque.pb.go
@@ -250,6 +250,7 @@ type SSHIdentity struct {
 	xxx_hidden_DelegationSessionId      string                     `protobuf:"bytes,39,opt,name=delegation_session_id,json=delegationSessionId,proto3"`
 	xxx_hidden_HeadlessAuthenticationId string                     `protobuf:"bytes,40,opt,name=headless_authentication_id,json=headlessAuthenticationId,proto3"`
 	xxx_hidden_BeamId                   string                     `protobuf:"bytes,41,opt,name=beam_id,json=beamId,proto3"`
+	xxx_hidden_BotScope                 string                     `protobuf:"bytes,42,opt,name=bot_scope,json=botScope,proto3"`
 	unknownFields                       protoimpl.UnknownFields
 	sizeCache                           protoimpl.SizeCache
 }
@@ -574,6 +575,13 @@ func (x *SSHIdentity) GetBeamId() string {
 	return ""
 }
 
+func (x *SSHIdentity) GetBotScope() string {
+	if x != nil {
+		return x.xxx_hidden_BotScope
+	}
+	return ""
+}
+
 func (x *SSHIdentity) SetValidAfter(v uint64) {
 	x.xxx_hidden_ValidAfter = v
 }
@@ -738,6 +746,10 @@ func (x *SSHIdentity) SetBeamId(v string) {
 	x.xxx_hidden_BeamId = v
 }
 
+func (x *SSHIdentity) SetBotScope(v string) {
+	x.xxx_hidden_BotScope = v
+}
+
 func (x *SSHIdentity) HasPreviousIdentityExpires() bool {
 	if x == nil {
 		return false
@@ -874,6 +886,9 @@ type SSHIdentity_builder struct {
 	// Beam this SSH identity is associated with, derived from the delegation
 	// session's beam ID label.
 	BeamId string
+	// BotScope is the scope of the Machine ID bot this identity was issued to,
+	// if any. Empty for unscoped bots and non-bot identities.
+	BotScope string
 }
 
 func (b0 SSHIdentity_builder) Build() *SSHIdentity {
@@ -921,6 +936,7 @@ func (b0 SSHIdentity_builder) Build() *SSHIdentity {
 	x.xxx_hidden_DelegationSessionId = b.DelegationSessionId
 	x.xxx_hidden_HeadlessAuthenticationId = b.HeadlessAuthenticationId
 	x.xxx_hidden_BeamId = b.BeamId
+	x.xxx_hidden_BotScope = b.BotScope
 	return m0
 }
 
@@ -1040,7 +1056,7 @@ const file_teleport_decision_v1alpha1_ssh_identity_proto_rawDesc = "" +
 	"-teleport/decision/v1alpha1/ssh_identity.proto\x12\x1ateleport.decision.v1alpha1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a-teleport/decision/v1alpha1/tls_identity.proto\x1a%teleport/legacy/types/resources.proto\x1a\x1fteleport/scopes/v1/scopes.proto\x1a\x1dteleport/trait/v1/trait.proto\"X\n" +
 	"\fSSHAuthority\x12!\n" +
 	"\fcluster_name\x18\x01 \x01(\tR\vclusterName\x12%\n" +
-	"\x0eauthority_type\x18\x02 \x01(\tR\rauthorityType\"\xa5\x0e\n" +
+	"\x0eauthority_type\x18\x02 \x01(\tR\rauthorityType\"\xc2\x0e\n" +
 	"\vSSHIdentity\x12\x1f\n" +
 	"\vvalid_after\x18\x01 \x01(\x04R\n" +
 	"validAfter\x12!\n" +
@@ -1091,7 +1107,8 @@ const file_teleport_decision_v1alpha1_ssh_identity_proto_rawDesc = "" +
 	"\x14immutable_label_hash\x18& \x01(\tR\x12immutableLabelHash\x122\n" +
 	"\x15delegation_session_id\x18' \x01(\tR\x13delegationSessionId\x12<\n" +
 	"\x1aheadless_authentication_id\x18( \x01(\tR\x18headlessAuthenticationId\x12\x17\n" +
-	"\abeam_id\x18) \x01(\tR\x06beamId\"\xbf\x01\n" +
+	"\abeam_id\x18) \x01(\tR\x06beamId\x12\x1b\n" +
+	"\tbot_scope\x18* \x01(\tR\bbotScope\"\xbf\x01\n" +
 	"\rCertExtension\x12A\n" +
 	"\x04type\x18\x01 \x01(\x0e2-.teleport.decision.v1alpha1.CertExtensionTypeR\x04type\x12A\n" +
 	"\x04mode\x18\x02 \x01(\x0e2-.teleport.decision.v1alpha1.CertExtensionModeR\x04mode\x12\x12\n" +

--- a/api/gen/proto/go/teleport/decision/v1alpha1/tls_identity.pb.go
+++ b/api/gen/proto/go/teleport/decision/v1alpha1/tls_identity.pb.go
@@ -153,7 +153,10 @@ type TLSIdentity struct {
 	DelegationSessionId string `protobuf:"bytes,39,opt,name=delegation_session_id,json=delegationSessionId,proto3" json:"delegation_session_id,omitempty"`
 	// Beam this TLS identity is associated with, derived from the delegation
 	// session's beam ID label.
-	BeamId        string `protobuf:"bytes,40,opt,name=beam_id,json=beamId,proto3" json:"beam_id,omitempty"`
+	BeamId string `protobuf:"bytes,40,opt,name=beam_id,json=beamId,proto3" json:"beam_id,omitempty"`
+	// BotScope is the scope of the Machine ID bot this identity was issued to,
+	// if any. Empty for unscoped bots and non-bot identities.
+	BotScope      string `protobuf:"bytes,41,opt,name=bot_scope,json=botScope,proto3" json:"bot_scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -463,6 +466,13 @@ func (x *TLSIdentity) GetBeamId() string {
 	return ""
 }
 
+func (x *TLSIdentity) GetBotScope() string {
+	if x != nil {
+		return x.BotScope
+	}
+	return ""
+}
+
 func (x *TLSIdentity) SetUsername(v string) {
 	x.Username = v
 }
@@ -621,6 +631,10 @@ func (x *TLSIdentity) SetDelegationSessionId(v string) {
 
 func (x *TLSIdentity) SetBeamId(v string) {
 	x.BeamId = v
+}
+
+func (x *TLSIdentity) SetBotScope(v string) {
+	x.BotScope = v
 }
 
 func (x *TLSIdentity) HasExpires() bool {
@@ -802,6 +816,9 @@ type TLSIdentity_builder struct {
 	// Beam this TLS identity is associated with, derived from the delegation
 	// session's beam ID label.
 	BeamId string
+	// BotScope is the scope of the Machine ID bot this identity was issued to,
+	// if any. Empty for unscoped bots and non-bot identities.
+	BotScope string
 }
 
 func (b0 TLSIdentity_builder) Build() *TLSIdentity {
@@ -848,6 +865,7 @@ func (b0 TLSIdentity_builder) Build() *TLSIdentity {
 	x.AllowedResourceAccessIds = b.AllowedResourceAccessIds
 	x.DelegationSessionId = b.DelegationSessionId
 	x.BeamId = b.BeamId
+	x.BotScope = b.BotScope
 	return m0
 }
 
@@ -1430,7 +1448,7 @@ var File_teleport_decision_v1alpha1_tls_identity_proto protoreflect.FileDescript
 
 const file_teleport_decision_v1alpha1_tls_identity_proto_rawDesc = "" +
 	"\n" +
-	"-teleport/decision/v1alpha1/tls_identity.proto\x12\x1ateleport.decision.v1alpha1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a%teleport/legacy/types/resources.proto\x1a\x1fteleport/scopes/v1/scopes.proto\x1a\x1dteleport/trait/v1/trait.proto\"\xb0\x0e\n" +
+	"-teleport/decision/v1alpha1/tls_identity.proto\x12\x1ateleport.decision.v1alpha1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a%teleport/legacy/types/resources.proto\x1a\x1fteleport/scopes/v1/scopes.proto\x1a\x1dteleport/trait/v1/trait.proto\"\xcd\x0e\n" +
 	"\vTLSIdentity\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\"\n" +
 	"\fimpersonator\x18\x02 \x01(\tR\fimpersonator\x12\x16\n" +
@@ -1478,7 +1496,8 @@ const file_teleport_decision_v1alpha1_tls_identity_proto_rawDesc = "" +
 	"\tscope_pin\x18% \x01(\v2\x17.teleport.scopes.v1.PinR\bscopePin\x12V\n" +
 	"\x1ballowed_resource_access_ids\x18& \x03(\v2\x17.types.ResourceAccessIDR\x18allowedResourceAccessIds\x122\n" +
 	"\x15delegation_session_id\x18' \x01(\tR\x13delegationSessionId\x12\x17\n" +
-	"\abeam_id\x18( \x01(\tR\x06beamId\"\xfb\x02\n" +
+	"\abeam_id\x18( \x01(\tR\x06beamId\x12\x1b\n" +
+	"\tbot_scope\x18) \x01(\tR\bbotScope\"\xfb\x02\n" +
 	"\n" +
 	"RouteToApp\x12\x1d\n" +
 	"\n" +

--- a/api/gen/proto/go/teleport/decision/v1alpha1/tls_identity_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/decision/v1alpha1/tls_identity_protoopaque.pb.go
@@ -84,6 +84,7 @@ type TLSIdentity struct {
 	xxx_hidden_AllowedResourceAccessIds *[]*types.ResourceAccessID `protobuf:"bytes,38,rep,name=allowed_resource_access_ids,json=allowedResourceAccessIds,proto3"`
 	xxx_hidden_DelegationSessionId      string                     `protobuf:"bytes,39,opt,name=delegation_session_id,json=delegationSessionId,proto3"`
 	xxx_hidden_BeamId                   string                     `protobuf:"bytes,40,opt,name=beam_id,json=beamId,proto3"`
+	xxx_hidden_BotScope                 string                     `protobuf:"bytes,41,opt,name=bot_scope,json=botScope,proto3"`
 	unknownFields                       protoimpl.UnknownFields
 	sizeCache                           protoimpl.SizeCache
 }
@@ -399,6 +400,13 @@ func (x *TLSIdentity) GetBeamId() string {
 	return ""
 }
 
+func (x *TLSIdentity) GetBotScope() string {
+	if x != nil {
+		return x.xxx_hidden_BotScope
+	}
+	return ""
+}
+
 func (x *TLSIdentity) SetUsername(v string) {
 	x.xxx_hidden_Username = v
 }
@@ -557,6 +565,10 @@ func (x *TLSIdentity) SetDelegationSessionId(v string) {
 
 func (x *TLSIdentity) SetBeamId(v string) {
 	x.xxx_hidden_BeamId = v
+}
+
+func (x *TLSIdentity) SetBotScope(v string) {
+	x.xxx_hidden_BotScope = v
 }
 
 func (x *TLSIdentity) HasExpires() bool {
@@ -738,6 +750,9 @@ type TLSIdentity_builder struct {
 	// Beam this TLS identity is associated with, derived from the delegation
 	// session's beam ID label.
 	BeamId string
+	// BotScope is the scope of the Machine ID bot this identity was issued to,
+	// if any. Empty for unscoped bots and non-bot identities.
+	BotScope string
 }
 
 func (b0 TLSIdentity_builder) Build() *TLSIdentity {
@@ -784,6 +799,7 @@ func (b0 TLSIdentity_builder) Build() *TLSIdentity {
 	x.xxx_hidden_AllowedResourceAccessIds = &b.AllowedResourceAccessIds
 	x.xxx_hidden_DelegationSessionId = b.DelegationSessionId
 	x.xxx_hidden_BeamId = b.BeamId
+	x.xxx_hidden_BotScope = b.BotScope
 	return m0
 }
 
@@ -1321,7 +1337,7 @@ var File_teleport_decision_v1alpha1_tls_identity_proto protoreflect.FileDescript
 
 const file_teleport_decision_v1alpha1_tls_identity_proto_rawDesc = "" +
 	"\n" +
-	"-teleport/decision/v1alpha1/tls_identity.proto\x12\x1ateleport.decision.v1alpha1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a%teleport/legacy/types/resources.proto\x1a\x1fteleport/scopes/v1/scopes.proto\x1a\x1dteleport/trait/v1/trait.proto\"\xb0\x0e\n" +
+	"-teleport/decision/v1alpha1/tls_identity.proto\x12\x1ateleport.decision.v1alpha1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a%teleport/legacy/types/resources.proto\x1a\x1fteleport/scopes/v1/scopes.proto\x1a\x1dteleport/trait/v1/trait.proto\"\xcd\x0e\n" +
 	"\vTLSIdentity\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\"\n" +
 	"\fimpersonator\x18\x02 \x01(\tR\fimpersonator\x12\x16\n" +
@@ -1369,7 +1385,8 @@ const file_teleport_decision_v1alpha1_tls_identity_proto_rawDesc = "" +
 	"\tscope_pin\x18% \x01(\v2\x17.teleport.scopes.v1.PinR\bscopePin\x12V\n" +
 	"\x1ballowed_resource_access_ids\x18& \x03(\v2\x17.types.ResourceAccessIDR\x18allowedResourceAccessIds\x122\n" +
 	"\x15delegation_session_id\x18' \x01(\tR\x13delegationSessionId\x12\x17\n" +
-	"\abeam_id\x18( \x01(\tR\x06beamId\"\xfb\x02\n" +
+	"\abeam_id\x18( \x01(\tR\x06beamId\x12\x1b\n" +
+	"\tbot_scope\x18) \x01(\tR\bbotScope\"\xfb\x02\n" +
 	"\n" +
 	"RouteToApp\x12\x1d\n" +
 	"\n" +

--- a/api/proto/teleport/decision/v1alpha1/ssh_identity.proto
+++ b/api/proto/teleport/decision/v1alpha1/ssh_identity.proto
@@ -190,6 +190,10 @@ message SSHIdentity {
   // Beam this SSH identity is associated with, derived from the delegation
   // session's beam ID label.
   string beam_id = 41;
+
+  // BotScope is the scope of the Machine ID bot this identity was issued to,
+  // if any. Empty for unscoped bots and non-bot identities.
+  string bot_scope = 42;
 }
 
 // CertExtensionMode specifies the type of extension to use in the cert. This type

--- a/api/proto/teleport/decision/v1alpha1/tls_identity.proto
+++ b/api/proto/teleport/decision/v1alpha1/tls_identity.proto
@@ -175,6 +175,10 @@ message TLSIdentity {
   // Beam this TLS identity is associated with, derived from the delegation
   // session's beam ID label.
   string beam_id = 40;
+
+  // BotScope is the scope of the Machine ID bot this identity was issued to,
+  // if any. Empty for unscoped bots and non-bot identities.
+  string bot_scope = 41;
 }
 
 // RouteToApp holds routing information for applications.

--- a/constants.go
+++ b/constants.go
@@ -544,6 +544,9 @@ const (
 	// Machine ID bot instance, if any. This identifier is persisted through
 	// certificate renewals.
 	CertExtensionBotInstanceID = "bot-instance-id@goteleport.com"
+	// CertExtensionBotScope indicates the scope of the Machine ID bot this
+	// certificate was issued to, if any.
+	CertExtensionBotScope = "bot-scope@goteleport.com"
 	// CertExtensionJoinToken is the name of the join token used to join this
 	// bot, if any.
 	CertExtensionJoinToken = "join-token@goteleport.com"

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3033,6 +3033,7 @@ func (a *Server) GenerateUserTestCertsWithContext(ctx context.Context, req Gener
 	if botName, isBot := userState.GetLabel(types.BotLabel); isBot {
 		certReq.BotName = botName
 		certReq.BotInstanceID = uuid.NewString()
+		certReq.BotScope, _ = userState.GetLabel(types.BotScopeLabel)
 	}
 
 	certs, err := a.GenerateUserCerts(ctx, certReq)
@@ -3902,6 +3903,7 @@ func generateCert(ctx context.Context, a *Server, req cert.Request, caType types
 				Generation:               req.Generation,
 				BotName:                  req.BotName,
 				BotInstanceID:            req.BotInstanceID,
+				BotScope:                 req.BotScope,
 				DelegationSessionID:      req.DelegationSessionID,
 				BeamID:                   req.BeamID,
 				JoinToken:                req.JoinToken,
@@ -4049,6 +4051,7 @@ func generateCert(ctx context.Context, a *Server, req cert.Request, caType types
 		Generation:               req.Generation,
 		BotName:                  req.BotName,
 		BotInstanceID:            req.BotInstanceID,
+		BotScope:                 req.BotScope,
 		BotInternal:              req.BotInternal,
 		DelegationSessionID:      req.DelegationSessionID,
 		BeamID:                   req.BeamID,

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3871,6 +3871,17 @@ func getBotName(user services.UserState) string {
 	return ""
 }
 
+// getBotScope returns the scope of the bot embedded in the user metadata, if
+// any. For unscoped bots and non-bot users, returns "".
+func getBotScope(user services.UserState) string {
+	scope, ok := user.GetLabel(types.BotScopeLabel)
+	if ok {
+		return scope
+	}
+
+	return ""
+}
+
 func (a *ScopedServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserCertsRequest, opts ...certRequestOption) (*proto.Certs, error) {
 	// Device trust: authorize device before issuing certificates.
 	readOnlyAuthPref, err := a.authServer.GetReadOnlyAuthPreference(ctx)
@@ -4239,7 +4250,8 @@ func (a *ScopedServerWithRoles) generateUserCerts(ctx context.Context, req proto
 			AppURI:            req.RouteToApp.URI,
 			AppTargetPort:     int(req.RouteToApp.TargetPort),
 
-			BotName: getBotName(user),
+			BotName:  getBotName(user),
+			BotScope: getBotScope(user),
 			// Always pass through a bot instance ID if available. Legacy bots
 			// joining without an instance ID may have one generated when
 			// `updateBotInstance()` is called below, and this (empty) value will be
@@ -4314,6 +4326,7 @@ func (a *ScopedServerWithRoles) generateUserCerts(ctx context.Context, req proto
 		ActiveRequests:         req.AccessRequests,
 		ConnectionDiagnosticID: req.ConnectionDiagnosticID,
 		BotName:                getBotName(user),
+		BotScope:               getBotScope(user),
 
 		// Always pass through a bot instance ID if available. Legacy bots
 		// joining without an instance ID may have one generated when

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -1167,8 +1167,8 @@ func TestBot(botName string, botInternal bool) TestIdentity {
 			Username: userName,
 			Identity: tlsca.Identity{
 				Username: userName,
-				// GenerateUserTestCertsWithContext will inject BotName and
-				// BotInstanceID.
+				// GenerateUserTestCertsWithContext will inject BotName,
+				// BotInstanceID and BotScope.
 				BotInternal: botInternal,
 			},
 		},
@@ -1183,8 +1183,8 @@ func TestScopedBot(botName string, scope string, botInternal bool) TestIdentity 
 			Username: userName,
 			Identity: tlsca.Identity{
 				Username: userName,
-				// GenerateUserTestCertsWithContext will inject BotName and
-				// BotInstanceID.
+				// GenerateUserTestCertsWithContext will inject BotName,
+				// BotInstanceID and BotScope.
 				BotInternal: botInternal,
 			},
 		},

--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -611,6 +611,7 @@ func (a *Server) generateInitialBotCerts(
 		IncludeHostCA:  true,
 		LoginIP:        loginIP,
 		BotName:        botName,
+		BotScope:       botScope,
 		BotInternal:    true,
 		JoinAttributes: joinAttrs,
 	}

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -1510,6 +1510,7 @@ func TestRegisterBotWithScopedKubernetesToken(t *testing.T) {
 	require.Equal(t, "/test", ident.ScopePin.GetScope())
 	require.True(t, ident.BotInternal)
 	require.Equal(t, "example-token", ident.JoinToken)
+	require.Equal(t, "/test", ident.BotScope)
 
 	botClient := authClientForRegisterResult(t, ctx, addr, result)
 

--- a/lib/auth/delegation/delegationv1/generate_certs.go
+++ b/lib/auth/delegation/delegationv1/generate_certs.go
@@ -247,6 +247,7 @@ func (s *SessionService) generateCertificates(
 
 		BotName:             callerIdentity.BotName,
 		BotInstanceID:       callerIdentity.BotInstanceID,
+		BotScope:            callerIdentity.BotScope,
 		DelegationSessionID: session.GetMetadata().GetName(),
 	}
 
@@ -298,6 +299,7 @@ func (s *SessionService) generateCertificates(
 			AppTargetPort: certReq.AppTargetPort,
 			BotName:       callerIdentity.BotName,
 			BotInstanceID: certReq.BotInstanceID,
+			BotScope:      callerIdentity.BotScope,
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/auth/internal/cert/request.go
+++ b/lib/auth/internal/cert/request.go
@@ -154,6 +154,9 @@ type Request struct {
 	// BotInstanceID is the unique identifier of the bot instance associated
 	// with this cert, if any.
 	BotInstanceID string
+	// BotScope is the scope of the bot requesting this cert, if any. Empty for
+	// unscoped bots and non-bot identities.
+	BotScope string
 	// BotInternal is a flag that indicates an identity is specifically a bot
 	// internal identity, rather than output certificates intended for direct
 	// consumption by users or user-facing bot services.

--- a/lib/auth/internal/session/request.go
+++ b/lib/auth/internal/session/request.go
@@ -124,4 +124,6 @@ type NewAppSessionRequest struct {
 	BotName string
 	// BotInstanceID is the ID of the bot instance that is creating this session.
 	BotInstanceID string
+	// BotScope is the scope of the bot that is creating this session, if any.
+	BotScope string
 }

--- a/lib/auth/issuance/v1/service.go
+++ b/lib/auth/issuance/v1/service.go
@@ -219,6 +219,7 @@ func (s *Service) IssueScopedBotCerts(
 		LoginIP:        currentIdentity.LoginIP,
 		BotName:        currentIdentity.BotName,
 		BotInstanceID:  currentIdentity.BotInstanceID,
+		BotScope:       currentIdentity.BotScope,
 		JoinToken:      currentIdentity.JoinToken,
 	}
 

--- a/lib/auth/issuance/v1/service.go
+++ b/lib/auth/issuance/v1/service.go
@@ -219,8 +219,11 @@ func (s *Service) IssueScopedBotCerts(
 		LoginIP:        currentIdentity.LoginIP,
 		BotName:        currentIdentity.BotName,
 		BotInstanceID:  currentIdentity.BotInstanceID,
-		BotScope:       currentIdentity.BotScope,
-		JoinToken:      currentIdentity.JoinToken,
+		// Derived from the bot user's label rather than copied from the
+		// current identity so that certs issued before the BotScope cert field
+		// existed still produce correctly-attributed output certs.
+		BotScope:  botScope,
+		JoinToken: currentIdentity.JoinToken,
 	}
 
 	// nb(strideynet): One day, we'll want to pull more of the logic around

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -550,6 +550,7 @@ func (a *Server) CreateAppSessionFromReq(ctx context.Context, req NewAppSessionR
 		// Pass along bot details to ensure audit logs are correct.
 		BotName:             req.BotName,
 		BotInstanceID:       req.BotInstanceID,
+		BotScope:            req.BotScope,
 		DelegationSessionID: req.DelegationSessionID,
 		BeamID:              req.BeamID,
 	})

--- a/lib/decision/ssh_identity.go
+++ b/lib/decision/ssh_identity.go
@@ -58,6 +58,7 @@ func SSHIdentityToSSHCA(id *decisionpb.SSHIdentity) *sshca.Identity {
 		Generation:              id.GetGeneration(),
 		BotName:                 id.GetBotName(),
 		BotInstanceID:           id.GetBotInstanceId(),
+		BotScope:                id.GetBotScope(),
 		JoinToken:               id.GetJoinToken(),
 		//nolint:staticcheck // TODO(kiosion): deprecated, to be removed in v21
 		AllowedResourceIDs:       resourceIDsToTypes(id.GetAllowedResourceIds()),
@@ -109,6 +110,7 @@ func SSHIdentityFromSSHCA(id *sshca.Identity) *decisionpb.SSHIdentity {
 		Generation:              id.Generation,
 		BotName:                 id.BotName,
 		BotInstanceId:           id.BotInstanceID,
+		BotScope:                id.BotScope,
 		//nolint:staticcheck // TODO(kiosion): deprecated, to be removed in v21
 		AllowedResourceIds:       resourceIDsFromTypes(id.AllowedResourceIDs),
 		AllowedResourceAccessIds: resourceAccessIDValuesToPointers(id.AllowedResourceAccessIDs),

--- a/lib/decision/ssh_identity_test.go
+++ b/lib/decision/ssh_identity_test.go
@@ -80,6 +80,7 @@ func TestSSHIdentityConversion(t *testing.T) {
 		Generation:    3,
 		BotName:       "bot",
 		BotInstanceID: "instance",
+		BotScope:      "/foo",
 		JoinToken:     "join-token",
 		//nolint:staticcheck // TODO(kiosion): deprecated, to be removed in v21
 		AllowedResourceIDs: []types.ResourceID{{

--- a/lib/decision/tls_identity.go
+++ b/lib/decision/tls_identity.go
@@ -72,6 +72,7 @@ func TLSIdentityToTLSCA(id *decisionpb.TLSIdentity) *tlsca.Identity {
 		Generation:              id.GetGeneration(),
 		BotName:                 id.GetBotName(),
 		BotInstanceID:           id.GetBotInstanceId(),
+		BotScope:                id.GetBotScope(),
 		JoinToken:               id.GetJoinToken(),
 		//nolint:staticcheck // TODO(kiosion): deprecated, to be removed in v21
 		AllowedResourceIDs:       resourceIDsToTypes(id.GetAllowedResourceIds()),
@@ -125,6 +126,7 @@ func TLSIdentityFromTLSCA(id *tlsca.Identity) *decisionpb.TLSIdentity {
 		Generation:              id.Generation,
 		BotName:                 id.BotName,
 		BotInstanceId:           id.BotInstanceID,
+		BotScope:                id.BotScope,
 		JoinToken:               id.JoinToken,
 		//nolint:staticcheck // TODO(kiosion): deprecated, to be removed in v21
 		AllowedResourceIds:       resourceIDsFromTypes(id.AllowedResourceIDs),

--- a/lib/decision/tls_identity_test.go
+++ b/lib/decision/tls_identity_test.go
@@ -105,6 +105,7 @@ func TestTLSIdentity_roundtrip(t *testing.T) {
 		Generation:              112,
 		BotName:                 "bot-name",
 		BotInstanceId:           "bot-instance-id",
+		BotScope:                "/foo",
 		AllowedResourceIds: []*decisionpb.ResourceId{
 			decisionpb.ResourceId_builder{
 				ClusterName:     "cluster1",

--- a/lib/sshca/identity.go
+++ b/lib/sshca/identity.go
@@ -124,6 +124,9 @@ type Identity struct {
 	// BotInstanceID is the unique identifier for the bot instance, if this is a
 	// Machine ID bot. It is empty for human users.
 	BotInstanceID string
+	// BotScope is the scope of the Machine ID bot this identity was issued to,
+	// if any. Empty for unscoped bots and human users.
+	BotScope string
 	// JoinToken is the name of the join token used by the bot to join, if any.
 	JoinToken string
 	// AllowedResourceIDs lists the resources the user should be able to access.
@@ -281,6 +284,9 @@ func (i *Identity) Encode(certFormat string) (*ssh.Certificate, error) {
 	}
 	if i.BotInstanceID != "" {
 		cert.Permissions.Extensions[teleport.CertExtensionBotInstanceID] = i.BotInstanceID
+	}
+	if i.BotScope != "" {
+		cert.Permissions.Extensions[teleport.CertExtensionBotScope] = i.BotScope
 	}
 	if i.JoinToken != "" {
 		cert.Permissions.Extensions[teleport.CertExtensionJoinToken] = i.JoinToken
@@ -542,6 +548,7 @@ func DecodeIdentity(cert *ssh.Certificate) (*Identity, error) {
 
 	ident.BotName = takeValue(teleport.CertExtensionBotName)
 	ident.BotInstanceID = takeValue(teleport.CertExtensionBotInstanceID)
+	ident.BotScope = takeValue(teleport.CertExtensionBotScope)
 	ident.JoinToken = takeValue(teleport.CertExtensionJoinToken)
 
 	var (

--- a/lib/sshca/identity_test.go
+++ b/lib/sshca/identity_test.go
@@ -84,6 +84,7 @@ func TestIdentityConversion(t *testing.T) {
 		Generation:    3,
 		BotName:       "bot",
 		BotInstanceID: "instance",
+		BotScope:      "/foo",
 		JoinToken:     "join-token",
 		AllowedResourceAccessIDs: []types.ResourceAccessID{{
 			Id: types.ResourceID{

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -202,6 +202,9 @@ type Identity struct {
 	// BotInstanceID is a unique identifier for Machine ID bots that is
 	// persisted through renewals.
 	BotInstanceID string
+	// BotScope is the scope of the Machine ID bot this identity was issued to,
+	// if any. Empty for unscoped bots and non-bot identities.
+	BotScope string
 	// BotInternal is a flag that indicates an identity is specifically a bot
 	// internal identity, rather than output certificates intended for direct
 	// consumption by users or user-facing bot services.
@@ -675,6 +678,10 @@ var (
 	// the Beam this certificate was created for.
 	BeamIDASN1ExtensionOID = asn1.ObjectIdentifier{1, 3, 9999, 2, 32}
 
+	// BotScopeASN1ExtensionOID is an extension OID that encodes the scope of
+	// the Machine ID bot the certificate was issued to, if any.
+	BotScopeASN1ExtensionOID = asn1.ObjectIdentifier{1, 3, 9999, 2, 33}
+
 	// CAClusterNameExtensionOID records the cluster name in a Teleport CA
 	// certificate.
 	//
@@ -1003,6 +1010,14 @@ func (id *Identity) Subject() (pkix.Name, error) {
 			pkix.AttributeTypeAndValue{
 				Type:  BotInstanceASN1ExtensionOID,
 				Value: id.BotInstanceID,
+			})
+	}
+
+	if id.BotScope != "" {
+		subject.ExtraNames = append(subject.ExtraNames,
+			pkix.AttributeTypeAndValue{
+				Type:  BotScopeASN1ExtensionOID,
+				Value: id.BotScope,
 			})
 	}
 
@@ -1409,6 +1424,11 @@ func FromSubject(subject pkix.Name, expires time.Time) (*Identity, error) {
 			val, ok := attr.Value.(string)
 			if ok {
 				id.BotInstanceID = val
+			}
+		case attr.Type.Equal(BotScopeASN1ExtensionOID):
+			val, ok := attr.Value.(string)
+			if ok {
+				id.BotScope = val
 			}
 		case attr.Type.Equal(BotInternalASN1ExtensionOID):
 			val, ok := attr.Value.(string)

--- a/lib/tlsca/ca_test.go
+++ b/lib/tlsca/ca_test.go
@@ -219,6 +219,7 @@ func TestJoinAttributes(t *testing.T) {
 		Groups:        []string{"bot-bernard"},
 		BotName:       "bernard",
 		BotInstanceID: "1234-5678",
+		BotScope:      "/foo",
 		BotInternal:   true,
 		Expires:       expires,
 		JoinAttributes: workloadidentityv1pb.JoinAttrs_builder{


### PR DESCRIPTION
As part of introducing scope namespacing of Bots and Bot Instances, we need an explicit way to determine the Scope of a Bot at authorization time when it calls various RPCs (i.e heartbeating). Whilst we can infer the Bot's scope from the scope pin, if we ever loosen the requirement that the scope pin == bot scope, then this inference will break.

Unblocks https://github.com/gravitational/teleport/pull/68326.

This PR introduces a new certificate field which encodes the Bot's scope for this purpose. Existing scoped Bots will pick up this field as they renew/rejoin.

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

- [x] Smoke: Join and renew unscoped Bot, ensure functions correctly.
- [x] Join and renew scoped Bot, ensure internal certificate and output certificate include BotScope attribute.