### PR TITLE
[v17] gha: include kvstore action in workflows (#68046)

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -13,6 +13,7 @@ on:
 permissions:
   pull-requests: write
   contents: write
+  id-token: write
 
 jobs:
   backport-pull-request:
@@ -20,6 +21,17 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          existing-gh-secrets: "${{ toJSON(secrets) }}"
+          existing-gh-variables: "${{ toJSON(vars) }}"
+          # values: |
+          #   BACKPORT_APP_ID,secret
+          #   BACKPORT_PRIVATE_KEY,secret
       - name: Generate GitHub Token
         id: generate_token
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -25,11 +25,24 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write
 
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport17
 
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          existing-gh-secrets: "${{ toJSON(secrets) }}"
+          existing-gh-variables: "${{ toJSON(vars) }}"
+          # values: |
+          #   REVIEWERS_APP_ID,secret
+          #   REVIEWERS_PRIVATE_KEY,secret
+          #   REVIEWERS,secret
       - name: Checkout base
         uses: actions/checkout@v3 # Cannot upgrade to v4 while this runs in centos:7 due to nodejs GLIBC incompatibility
         with:

--- a/.github/workflows/build-usage-image.yaml
+++ b/.github/workflows/build-usage-image.yaml
@@ -3,12 +3,22 @@ on:
   release:
     types: ["published"]
 permissions:
-  id-token: write
   contents: read
+  id-token: write
 jobs:
   image:
     runs-on: ubuntu-latest
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          existing-gh-secrets: "${{ toJSON(secrets) }}"
+          existing-gh-variables: "${{ toJSON(vars) }}"
+          # values: |
+          #   TELEPORT_USAGE_IAM_ROLE_ARN,secret
       # This step is used to extract the version of the usage script.
       - name: Trim leading v in release
         id: version

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -28,6 +28,7 @@ permissions:
     repository-projects: none
     security-events: none
     statuses: none
+    id-token: write
 
 jobs:
   check-reviews:
@@ -35,6 +36,18 @@ jobs:
     if: ${{ !github.event.pull_request.draft && !startsWith(github.head_ref, 'dependabot/') }}
     runs-on: ubuntu-latest
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          existing-gh-secrets: "${{ toJSON(secrets) }}"
+          existing-gh-variables: "${{ toJSON(vars) }}"
+          # values: |
+          #   REVIEWERS_APP_ID,secret
+          #   REVIEWERS_PRIVATE_KEY,secret
+          #   REVIEWERS,secret
       - name: Generate GitHub Token
         id: generate_token
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -43,8 +43,22 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write
 
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          existing-gh-secrets: "${{ toJSON(secrets) }}"
+          existing-gh-variables: "${{ toJSON(vars) }}"
+          # values: |
+          #   REVIEWERS_APP_ID,secret
+          #   REVIEWERS_PRIVATE_KEY,secret
+          #   REVIEWERS,secret
+
       - name: Check out teleport
         uses: actions/checkout@v4
         with:
@@ -69,7 +83,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: shared-workflows
-          ref: 6f388765b8ce993721502083c74cb9af1fc5658f 
+          ref: 6f388765b8ce993721502083c74cb9af1fc5658f
 
       - name: Install Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
@@ -104,7 +118,7 @@ jobs:
         # To do this, we delete the three submodules we use for building the
         # live docs site and copy a gravitational/teleport clone into the
         # content directory.
-        # 
+        #
         # The docs engine expects a config.json file at the root of the
         # gravitational/docs clone that associates directories with git
         # submodules. By default, these directories represent versioned branches

--- a/.github/workflows/docs-amplify.yaml
+++ b/.github/workflows/docs-amplify.yaml
@@ -5,17 +5,29 @@ on:
       - 'docs/**'
       - .github/workflows/docs-amplify.yaml
   workflow_dispatch:
-  
+
 permissions:
   pull-requests: write
   id-token: write
-  
+
 jobs:
   amplify-preview:
     name: Prepare Amplify preview URL
     runs-on: ubuntu-slim
     environment: docs-amplify
-    steps:    
+    steps:
+    - name: Get runtime values from kvstore
+      id: kvstore
+      uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+      with:
+        cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+        cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+        existing-gh-secrets: "${{ toJSON(secrets) }}"
+        existing-gh-variables: "${{ toJSON(vars) }}"
+        # values: |
+        #   AMPLIFY_APP_IDS,variable
+        #   IAM_ROLE,variable
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
       with:

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: read
       packages: read
+      id-token: write
 
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport17
@@ -44,6 +45,19 @@ jobs:
           - 3379:3379
 
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          existing-gh-secrets: "${{ toJSON(secrets) }}"
+          existing-gh-variables: "${{ toJSON(vars) }}"
+          # values: |
+          #   REVIEWERS_APP_ID,secret
+          #   REVIEWERS_PRIVATE_KEY,secret
+          #   REVIEWERS,secret
+
       - name: Checkout Teleport
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -57,6 +57,18 @@ jobs:
     runs-on: ubuntu-latest
     environment: post-release
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          existing-gh-secrets: "${{ toJSON(secrets) }}"
+          existing-gh-variables: "${{ toJSON(vars) }}"
+          # values: |
+          #   APP_ID,variable
+          #   PRIVATE_KEY,secret
+
       - name: Get Release Branch
         id: get-branch
         env:

--- a/.github/workflows/update-ami-ids.yaml
+++ b/.github/workflows/update-ami-ids.yaml
@@ -28,6 +28,18 @@ jobs:
     environment: post-release
 
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          existing-gh-secrets: "${{ toJSON(secrets) }}"
+          existing-gh-variables: "${{ toJSON(vars) }}"
+          # values: |
+          #   APP_ID,variable
+          #   PRIVATE_KEY,secret
+
       - name: Generate Github token
         id: generate_token
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/update-docs-webhook.yaml
+++ b/.github/workflows/update-docs-webhook.yaml
@@ -11,6 +11,9 @@ on:
       - branch/v*
   workflow_dispatch:
 
+permissions:
+  id-token: write
+
 jobs:
   update-webhook:
     name: Update docs webhook
@@ -19,6 +22,16 @@ jobs:
     strategy:
       fail-fast: false
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          existing-gh-secrets: "${{ toJSON(secrets) }}"
+          existing-gh-variables: "${{ toJSON(vars) }}"
+          # values: |
+          #   AMPLIFY_DOCS_DEPLOY_HOOK,secret
       - name: Call deployment webhook
         env:
           WEBHOOK_URL: ${{ secrets.AMPLIFY_DOCS_DEPLOY_HOOK }}


### PR DESCRIPTION
Contributes to https://github.com/gravitational/cloud/issues/14222

Adds the env-kvstore action from shared-workflows to all jobs that use GHA vars.* or secrets.*. Backporting this to export secrets from jobs that only run on release.

Once we've collected all the values, will raise follow-up PRs:

- Add secrets and variables to SOPS files in kvstore repo.
- Replace references to vars.* and secrets.* in workflows.
- Disable migration

Then we can delete all secret and variable values from GHA for this repo.