### PR TITLE
Desktop Access: Fix Directory Sharing with Windows Server 2025

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
@@ -34,7 +34,7 @@ use ironrdp_rdpdr::pdu::efs::{
     DeviceControlRequest, NtStatus, ServerDeviceAnnounceResponse, ServerDriveIoRequest,
 };
 use ironrdp_rdpdr::pdu::esc::{ScardCall, ScardIoCtlCode};
-use ironrdp_rdpdr::pdu::RdpdrPdu;
+use ironrdp_rdpdr::pdu::RdpdrPdu::{self, ClientDeviceListRemove};
 use ironrdp_rdpdr::RdpdrBackend;
 use ironrdp_svc::SvcMessage;
 
@@ -74,6 +74,20 @@ impl RdpdrBackend for TeleportRdpdrBackend {
 
         // Nothing to send back to the server in either case
         Ok(())
+    }
+
+    fn handle_user_logged_on(
+        &mut self,
+        rdpdr: &mut ironrdp_rdpdr::Rdpdr,
+    ) -> PduResult<Vec<SvcMessage>> {
+        // Removing the smart card device after receiving the logged on message
+        // seems to fix an issue with newer RDP servers (Ex. Windows Server 2025)
+        // where the server ignores device announcements shortly after logon.
+        let mut result = vec![];
+        if let Some(rm) = rdpdr.remove_device(1) {
+            result.push(SvcMessage::from(ClientDeviceListRemove(rm)));
+        }
+        Ok(result)
     }
 
     fn handle_scard_call(


### PR DESCRIPTION
This addresses a directory sharing issue when connecting to Windows Server 2025 instances. It seems that in cases where the server initiates a reconnect


<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed an issue that prevented directory sharing from working on Windows Server 2025 in some cases.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
