### PR TITLE
MWI: Scope Namespace Bot Instances (1/2) - Storage and API

### DIFF
--- a/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_protohybrid.pb.go
@@ -44,7 +44,11 @@ type GetBotInstanceRequest struct {
 	// The name of the bot associated with the instance.
 	BotName string `protobuf:"bytes,1,opt,name=bot_name,json=botName,proto3" json:"bot_name,omitempty"`
 	// The unique identifier of the bot instance to retrieve.
-	InstanceId    string `protobuf:"bytes,2,opt,name=instance_id,json=instanceId,proto3" json:"instance_id,omitempty"`
+	InstanceId string `protobuf:"bytes,2,opt,name=instance_id,json=instanceId,proto3" json:"instance_id,omitempty"`
+	// The scope of the bot associated with the instance. Combined with bot_name
+	// to uniquely identify a scoped bot. Leave empty if the associated bot is
+	// unscoped.
+	BotScope      string `protobuf:"bytes,3,opt,name=bot_scope,json=botScope,proto3" json:"bot_scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -88,12 +92,23 @@ func (x *GetBotInstanceRequest) GetInstanceId() string {
 	return ""
 }
 
+func (x *GetBotInstanceRequest) GetBotScope() string {
+	if x != nil {
+		return x.BotScope
+	}
+	return ""
+}
+
 func (x *GetBotInstanceRequest) SetBotName(v string) {
 	x.BotName = v
 }
 
 func (x *GetBotInstanceRequest) SetInstanceId(v string) {
 	x.InstanceId = v
+}
+
+func (x *GetBotInstanceRequest) SetBotScope(v string) {
+	x.BotScope = v
 }
 
 type GetBotInstanceRequest_builder struct {
@@ -103,6 +118,10 @@ type GetBotInstanceRequest_builder struct {
 	BotName string
 	// The unique identifier of the bot instance to retrieve.
 	InstanceId string
+	// The scope of the bot associated with the instance. Combined with bot_name
+	// to uniquely identify a scoped bot. Leave empty if the associated bot is
+	// unscoped.
+	BotScope string
 }
 
 func (b0 GetBotInstanceRequest_builder) Build() *GetBotInstanceRequest {
@@ -111,6 +130,7 @@ func (b0 GetBotInstanceRequest_builder) Build() *GetBotInstanceRequest {
 	_, _ = b, x
 	x.BotName = b.BotName
 	x.InstanceId = b.InstanceId
+	x.BotScope = b.BotScope
 	return m0
 }
 
@@ -488,7 +508,11 @@ type DeleteBotInstanceRequest struct {
 	// The name of the BotInstance to delete.
 	BotName string `protobuf:"bytes,1,opt,name=bot_name,json=botName,proto3" json:"bot_name,omitempty"`
 	// The unique identifier of the bot instance to delete.
-	InstanceId    string `protobuf:"bytes,2,opt,name=instance_id,json=instanceId,proto3" json:"instance_id,omitempty"`
+	InstanceId string `protobuf:"bytes,2,opt,name=instance_id,json=instanceId,proto3" json:"instance_id,omitempty"`
+	// The scope of the bot associated with the instance. Combined with bot_name
+	// to uniquely identify a scoped bot. Leave empty if the associated bot is
+	// unscoped.
+	BotScope      string `protobuf:"bytes,3,opt,name=bot_scope,json=botScope,proto3" json:"bot_scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -532,12 +556,23 @@ func (x *DeleteBotInstanceRequest) GetInstanceId() string {
 	return ""
 }
 
+func (x *DeleteBotInstanceRequest) GetBotScope() string {
+	if x != nil {
+		return x.BotScope
+	}
+	return ""
+}
+
 func (x *DeleteBotInstanceRequest) SetBotName(v string) {
 	x.BotName = v
 }
 
 func (x *DeleteBotInstanceRequest) SetInstanceId(v string) {
 	x.InstanceId = v
+}
+
+func (x *DeleteBotInstanceRequest) SetBotScope(v string) {
+	x.BotScope = v
 }
 
 type DeleteBotInstanceRequest_builder struct {
@@ -547,6 +582,10 @@ type DeleteBotInstanceRequest_builder struct {
 	BotName string
 	// The unique identifier of the bot instance to delete.
 	InstanceId string
+	// The scope of the bot associated with the instance. Combined with bot_name
+	// to uniquely identify a scoped bot. Leave empty if the associated bot is
+	// unscoped.
+	BotScope string
 }
 
 func (b0 DeleteBotInstanceRequest_builder) Build() *DeleteBotInstanceRequest {
@@ -555,6 +594,7 @@ func (b0 DeleteBotInstanceRequest_builder) Build() *DeleteBotInstanceRequest {
 	_, _ = b, x
 	x.BotName = b.BotName
 	x.InstanceId = b.InstanceId
+	x.BotScope = b.BotScope
 	return m0
 }
 
@@ -699,7 +739,14 @@ type ListBotInstancesV2Request_Filters struct {
 	// match against supported fields.
 	SearchTerm string `protobuf:"bytes,2,opt,name=search_term,json=searchTerm,proto3" json:"search_term,omitempty"`
 	// A Teleport predicate language query used to filter the results.
-	Query         string `protobuf:"bytes,3,opt,name=query,proto3" json:"query,omitempty"`
+	Query string `protobuf:"bytes,3,opt,name=query,proto3" json:"query,omitempty"`
+	// The scope of the bot to list BotInstances for. Only valid alongside a
+	// non-empty bot_name, which it qualifies to uniquely identify a scoped bot
+	// (a scoped bot is identified by the pair (scope, name)); setting bot_scope
+	// without bot_name is an error. An empty bot_scope with a non-empty bot_name
+	// selects the unscoped bot with that name. This is not a standalone scope
+	// filter for listing all of a scope's instances.
+	BotScope      string `protobuf:"bytes,4,opt,name=bot_scope,json=botScope,proto3" json:"bot_scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -750,6 +797,13 @@ func (x *ListBotInstancesV2Request_Filters) GetQuery() string {
 	return ""
 }
 
+func (x *ListBotInstancesV2Request_Filters) GetBotScope() string {
+	if x != nil {
+		return x.BotScope
+	}
+	return ""
+}
+
 func (x *ListBotInstancesV2Request_Filters) SetBotName(v string) {
 	x.BotName = v
 }
@@ -760,6 +814,10 @@ func (x *ListBotInstancesV2Request_Filters) SetSearchTerm(v string) {
 
 func (x *ListBotInstancesV2Request_Filters) SetQuery(v string) {
 	x.Query = v
+}
+
+func (x *ListBotInstancesV2Request_Filters) SetBotScope(v string) {
+	x.BotScope = v
 }
 
 type ListBotInstancesV2Request_Filters_builder struct {
@@ -773,6 +831,13 @@ type ListBotInstancesV2Request_Filters_builder struct {
 	SearchTerm string
 	// A Teleport predicate language query used to filter the results.
 	Query string
+	// The scope of the bot to list BotInstances for. Only valid alongside a
+	// non-empty bot_name, which it qualifies to uniquely identify a scoped bot
+	// (a scoped bot is identified by the pair (scope, name)); setting bot_scope
+	// without bot_name is an error. An empty bot_scope with a non-empty bot_name
+	// selects the unscoped bot with that name. This is not a standalone scope
+	// filter for listing all of a scope's instances.
+	BotScope string
 }
 
 func (b0 ListBotInstancesV2Request_Filters_builder) Build() *ListBotInstancesV2Request_Filters {
@@ -782,6 +847,7 @@ func (b0 ListBotInstancesV2Request_Filters_builder) Build() *ListBotInstancesV2R
 	x.BotName = b.BotName
 	x.SearchTerm = b.SearchTerm
 	x.Query = b.Query
+	x.BotScope = b.BotScope
 	return m0
 }
 
@@ -789,18 +855,19 @@ var File_teleport_machineid_v1_bot_instance_service_proto protoreflect.FileDescr
 
 const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
-	"0teleport/machineid/v1/bot_instance_service.proto\x12\x15teleport.machineid.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\"S\n" +
+	"0teleport/machineid/v1/bot_instance_service.proto\x12\x15teleport.machineid.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\"p\n" +
 	"\x15GetBotInstanceRequest\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vinstance_id\x18\x02 \x01(\tR\n" +
-	"instanceId\"\xce\x01\n" +
+	"instanceId\x12\x1b\n" +
+	"\tbot_scope\x18\x03 \x01(\tR\bbotScope\"\xce\x01\n" +
 	"\x17ListBotInstancesRequest\x12&\n" +
 	"\x0ffilter_bot_name\x18\x01 \x01(\tR\rfilterBotName\x12\x1b\n" +
 	"\tpage_size\x18\x02 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
 	"page_token\x18\x03 \x01(\tR\tpageToken\x12,\n" +
 	"\x12filter_search_term\x18\x04 \x01(\tR\x10filterSearchTerm\x12!\n" +
-	"\x04sort\x18\x05 \x01(\v2\r.types.SortByR\x04sort\"\xc2\x02\n" +
+	"\x04sort\x18\x05 \x01(\v2\r.types.SortByR\x04sort\"\xdf\x02\n" +
 	"\x19ListBotInstancesV2Request\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
@@ -808,19 +875,21 @@ const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
 	"sort_field\x18\x03 \x01(\tR\tsortField\x12\x1b\n" +
 	"\tsort_desc\x18\x04 \x01(\bR\bsortDesc\x12P\n" +
-	"\x06filter\x18\x05 \x01(\v28.teleport.machineid.v1.ListBotInstancesV2Request.FiltersR\x06filter\x1a[\n" +
+	"\x06filter\x18\x05 \x01(\v28.teleport.machineid.v1.ListBotInstancesV2Request.FiltersR\x06filter\x1ax\n" +
 	"\aFilters\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vsearch_term\x18\x02 \x01(\tR\n" +
 	"searchTerm\x12\x14\n" +
-	"\x05query\x18\x03 \x01(\tR\x05query\"\x8b\x01\n" +
+	"\x05query\x18\x03 \x01(\tR\x05query\x12\x1b\n" +
+	"\tbot_scope\x18\x04 \x01(\tR\bbotScope\"\x8b\x01\n" +
 	"\x18ListBotInstancesResponse\x12G\n" +
 	"\rbot_instances\x18\x01 \x03(\v2\".teleport.machineid.v1.BotInstanceR\fbotInstances\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"V\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"s\n" +
 	"\x18DeleteBotInstanceRequest\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vinstance_id\x18\x02 \x01(\tR\n" +
-	"instanceId\"\xc1\x01\n" +
+	"instanceId\x12\x1b\n" +
+	"\tbot_scope\x18\x03 \x01(\tR\bbotScope\"\xc1\x01\n" +
 	"\x16SubmitHeartbeatRequest\x12O\n" +
 	"\theartbeat\x18\x01 \x01(\v21.teleport.machineid.v1.BotInstanceStatusHeartbeatR\theartbeat\x12V\n" +
 	"\x0eservice_health\x18\x02 \x03(\v2/.teleport.machineid.v1.BotInstanceServiceHealthR\rserviceHealth\"\x19\n" +

--- a/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_protoopaque.pb.go
@@ -43,6 +43,7 @@ type GetBotInstanceRequest struct {
 	state                 protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_BotName    string                 `protobuf:"bytes,1,opt,name=bot_name,json=botName,proto3"`
 	xxx_hidden_InstanceId string                 `protobuf:"bytes,2,opt,name=instance_id,json=instanceId,proto3"`
+	xxx_hidden_BotScope   string                 `protobuf:"bytes,3,opt,name=bot_scope,json=botScope,proto3"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -86,12 +87,23 @@ func (x *GetBotInstanceRequest) GetInstanceId() string {
 	return ""
 }
 
+func (x *GetBotInstanceRequest) GetBotScope() string {
+	if x != nil {
+		return x.xxx_hidden_BotScope
+	}
+	return ""
+}
+
 func (x *GetBotInstanceRequest) SetBotName(v string) {
 	x.xxx_hidden_BotName = v
 }
 
 func (x *GetBotInstanceRequest) SetInstanceId(v string) {
 	x.xxx_hidden_InstanceId = v
+}
+
+func (x *GetBotInstanceRequest) SetBotScope(v string) {
+	x.xxx_hidden_BotScope = v
 }
 
 type GetBotInstanceRequest_builder struct {
@@ -101,6 +113,10 @@ type GetBotInstanceRequest_builder struct {
 	BotName string
 	// The unique identifier of the bot instance to retrieve.
 	InstanceId string
+	// The scope of the bot associated with the instance. Combined with bot_name
+	// to uniquely identify a scoped bot. Leave empty if the associated bot is
+	// unscoped.
+	BotScope string
 }
 
 func (b0 GetBotInstanceRequest_builder) Build() *GetBotInstanceRequest {
@@ -109,6 +125,7 @@ func (b0 GetBotInstanceRequest_builder) Build() *GetBotInstanceRequest {
 	_, _ = b, x
 	x.xxx_hidden_BotName = b.BotName
 	x.xxx_hidden_InstanceId = b.InstanceId
+	x.xxx_hidden_BotScope = b.BotScope
 	return m0
 }
 
@@ -467,6 +484,7 @@ type DeleteBotInstanceRequest struct {
 	state                 protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_BotName    string                 `protobuf:"bytes,1,opt,name=bot_name,json=botName,proto3"`
 	xxx_hidden_InstanceId string                 `protobuf:"bytes,2,opt,name=instance_id,json=instanceId,proto3"`
+	xxx_hidden_BotScope   string                 `protobuf:"bytes,3,opt,name=bot_scope,json=botScope,proto3"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -510,12 +528,23 @@ func (x *DeleteBotInstanceRequest) GetInstanceId() string {
 	return ""
 }
 
+func (x *DeleteBotInstanceRequest) GetBotScope() string {
+	if x != nil {
+		return x.xxx_hidden_BotScope
+	}
+	return ""
+}
+
 func (x *DeleteBotInstanceRequest) SetBotName(v string) {
 	x.xxx_hidden_BotName = v
 }
 
 func (x *DeleteBotInstanceRequest) SetInstanceId(v string) {
 	x.xxx_hidden_InstanceId = v
+}
+
+func (x *DeleteBotInstanceRequest) SetBotScope(v string) {
+	x.xxx_hidden_BotScope = v
 }
 
 type DeleteBotInstanceRequest_builder struct {
@@ -525,6 +554,10 @@ type DeleteBotInstanceRequest_builder struct {
 	BotName string
 	// The unique identifier of the bot instance to delete.
 	InstanceId string
+	// The scope of the bot associated with the instance. Combined with bot_name
+	// to uniquely identify a scoped bot. Leave empty if the associated bot is
+	// unscoped.
+	BotScope string
 }
 
 func (b0 DeleteBotInstanceRequest_builder) Build() *DeleteBotInstanceRequest {
@@ -533,6 +566,7 @@ func (b0 DeleteBotInstanceRequest_builder) Build() *DeleteBotInstanceRequest {
 	_, _ = b, x
 	x.xxx_hidden_BotName = b.BotName
 	x.xxx_hidden_InstanceId = b.InstanceId
+	x.xxx_hidden_BotScope = b.BotScope
 	return m0
 }
 
@@ -673,6 +707,7 @@ type ListBotInstancesV2Request_Filters struct {
 	xxx_hidden_BotName    string                 `protobuf:"bytes,1,opt,name=bot_name,json=botName,proto3"`
 	xxx_hidden_SearchTerm string                 `protobuf:"bytes,2,opt,name=search_term,json=searchTerm,proto3"`
 	xxx_hidden_Query      string                 `protobuf:"bytes,3,opt,name=query,proto3"`
+	xxx_hidden_BotScope   string                 `protobuf:"bytes,4,opt,name=bot_scope,json=botScope,proto3"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -723,6 +758,13 @@ func (x *ListBotInstancesV2Request_Filters) GetQuery() string {
 	return ""
 }
 
+func (x *ListBotInstancesV2Request_Filters) GetBotScope() string {
+	if x != nil {
+		return x.xxx_hidden_BotScope
+	}
+	return ""
+}
+
 func (x *ListBotInstancesV2Request_Filters) SetBotName(v string) {
 	x.xxx_hidden_BotName = v
 }
@@ -733,6 +775,10 @@ func (x *ListBotInstancesV2Request_Filters) SetSearchTerm(v string) {
 
 func (x *ListBotInstancesV2Request_Filters) SetQuery(v string) {
 	x.xxx_hidden_Query = v
+}
+
+func (x *ListBotInstancesV2Request_Filters) SetBotScope(v string) {
+	x.xxx_hidden_BotScope = v
 }
 
 type ListBotInstancesV2Request_Filters_builder struct {
@@ -746,6 +792,13 @@ type ListBotInstancesV2Request_Filters_builder struct {
 	SearchTerm string
 	// A Teleport predicate language query used to filter the results.
 	Query string
+	// The scope of the bot to list BotInstances for. Only valid alongside a
+	// non-empty bot_name, which it qualifies to uniquely identify a scoped bot
+	// (a scoped bot is identified by the pair (scope, name)); setting bot_scope
+	// without bot_name is an error. An empty bot_scope with a non-empty bot_name
+	// selects the unscoped bot with that name. This is not a standalone scope
+	// filter for listing all of a scope's instances.
+	BotScope string
 }
 
 func (b0 ListBotInstancesV2Request_Filters_builder) Build() *ListBotInstancesV2Request_Filters {
@@ -755,6 +808,7 @@ func (b0 ListBotInstancesV2Request_Filters_builder) Build() *ListBotInstancesV2R
 	x.xxx_hidden_BotName = b.BotName
 	x.xxx_hidden_SearchTerm = b.SearchTerm
 	x.xxx_hidden_Query = b.Query
+	x.xxx_hidden_BotScope = b.BotScope
 	return m0
 }
 
@@ -762,18 +816,19 @@ var File_teleport_machineid_v1_bot_instance_service_proto protoreflect.FileDescr
 
 const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
-	"0teleport/machineid/v1/bot_instance_service.proto\x12\x15teleport.machineid.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\"S\n" +
+	"0teleport/machineid/v1/bot_instance_service.proto\x12\x15teleport.machineid.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\"p\n" +
 	"\x15GetBotInstanceRequest\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vinstance_id\x18\x02 \x01(\tR\n" +
-	"instanceId\"\xce\x01\n" +
+	"instanceId\x12\x1b\n" +
+	"\tbot_scope\x18\x03 \x01(\tR\bbotScope\"\xce\x01\n" +
 	"\x17ListBotInstancesRequest\x12&\n" +
 	"\x0ffilter_bot_name\x18\x01 \x01(\tR\rfilterBotName\x12\x1b\n" +
 	"\tpage_size\x18\x02 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
 	"page_token\x18\x03 \x01(\tR\tpageToken\x12,\n" +
 	"\x12filter_search_term\x18\x04 \x01(\tR\x10filterSearchTerm\x12!\n" +
-	"\x04sort\x18\x05 \x01(\v2\r.types.SortByR\x04sort\"\xc2\x02\n" +
+	"\x04sort\x18\x05 \x01(\v2\r.types.SortByR\x04sort\"\xdf\x02\n" +
 	"\x19ListBotInstancesV2Request\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
@@ -781,19 +836,21 @@ const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
 	"sort_field\x18\x03 \x01(\tR\tsortField\x12\x1b\n" +
 	"\tsort_desc\x18\x04 \x01(\bR\bsortDesc\x12P\n" +
-	"\x06filter\x18\x05 \x01(\v28.teleport.machineid.v1.ListBotInstancesV2Request.FiltersR\x06filter\x1a[\n" +
+	"\x06filter\x18\x05 \x01(\v28.teleport.machineid.v1.ListBotInstancesV2Request.FiltersR\x06filter\x1ax\n" +
 	"\aFilters\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vsearch_term\x18\x02 \x01(\tR\n" +
 	"searchTerm\x12\x14\n" +
-	"\x05query\x18\x03 \x01(\tR\x05query\"\x8b\x01\n" +
+	"\x05query\x18\x03 \x01(\tR\x05query\x12\x1b\n" +
+	"\tbot_scope\x18\x04 \x01(\tR\bbotScope\"\x8b\x01\n" +
 	"\x18ListBotInstancesResponse\x12G\n" +
 	"\rbot_instances\x18\x01 \x03(\v2\".teleport.machineid.v1.BotInstanceR\fbotInstances\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"V\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"s\n" +
 	"\x18DeleteBotInstanceRequest\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vinstance_id\x18\x02 \x01(\tR\n" +
-	"instanceId\"\xc1\x01\n" +
+	"instanceId\x12\x1b\n" +
+	"\tbot_scope\x18\x03 \x01(\tR\bbotScope\"\xc1\x01\n" +
 	"\x16SubmitHeartbeatRequest\x12O\n" +
 	"\theartbeat\x18\x01 \x01(\v21.teleport.machineid.v1.BotInstanceStatusHeartbeatR\theartbeat\x12V\n" +
 	"\x0eservice_health\x18\x02 \x03(\v2/.teleport.machineid.v1.BotInstanceServiceHealthR\rserviceHealth\"\x19\n" +

--- a/api/proto/teleport/machineid/v1/bot_instance_service.proto
+++ b/api/proto/teleport/machineid/v1/bot_instance_service.proto
@@ -28,6 +28,10 @@ message GetBotInstanceRequest {
   string bot_name = 1;
   // The unique identifier of the bot instance to retrieve.
   string instance_id = 2;
+  // The scope of the bot associated with the instance. Combined with bot_name
+  // to uniquely identify a scoped bot. Leave empty if the associated bot is
+  // unscoped.
+  string bot_scope = 3;
 }
 
 // Request for ListBotInstances.
@@ -80,6 +84,13 @@ message ListBotInstancesV2Request {
     string search_term = 2;
     // A Teleport predicate language query used to filter the results.
     string query = 3;
+    // The scope of the bot to list BotInstances for. Only valid alongside a
+    // non-empty bot_name, which it qualifies to uniquely identify a scoped bot
+    // (a scoped bot is identified by the pair (scope, name)); setting bot_scope
+    // without bot_name is an error. An empty bot_scope with a non-empty bot_name
+    // selects the unscoped bot with that name. This is not a standalone scope
+    // filter for listing all of a scope's instances.
+    string bot_scope = 4;
   }
 }
 
@@ -98,6 +109,10 @@ message DeleteBotInstanceRequest {
   string bot_name = 1;
   // The unique identifier of the bot instance to delete.
   string instance_id = 2;
+  // The scope of the bot associated with the instance. Combined with bot_name
+  // to uniquely identify a scoped bot. Leave empty if the associated bot is
+  // unscoped.
+  string bot_scope = 3;
 }
 
 // The request for SubmitHeartbeat.

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -1556,8 +1556,10 @@ type Cache interface {
 	// ListRelayServers returns a paginated list of relay server heartbeats.
 	ListRelayServers(ctx context.Context, pageSize int, pageToken string) (_ []*presencev1.RelayServer, nextPageToken string, _ error)
 
-	// GetBotInstance returns the specified BotInstance resource.
-	GetBotInstance(ctx context.Context, botName, instanceID string) (*machineidv1.BotInstance, error)
+	// GetBotInstance returns the specified BotInstance resource. A bot is
+	// identified by the request's (bot_scope, bot_name); bot_scope is empty
+	// for instances of unscoped bots.
+	GetBotInstance(ctx context.Context, req *machineidv1.GetBotInstanceRequest) (*machineidv1.BotInstance, error)
 
 	// ListBotInstances returns a page of BotInstance resources.
 	ListBotInstances(ctx context.Context, pageSize int, lastToken string, options *services.ListBotInstancesRequestOptions) ([]*machineidv1.BotInstance, string, error)

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -669,7 +669,7 @@ func InitAuthCache(p AuthCacheParams) error {
 		PrimaryCache:       c,
 		Events:             p.AuthServer.Services,
 		Inventory:          p.AuthServer.Services,
-		BotInstanceBackend: p.AuthServer.Services,
+		BotInstanceBackend: p.AuthServer.Services.BotInstance,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshutils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
@@ -493,32 +494,36 @@ func (a *Server) updateBotInstance(
 		}
 	}
 
-	_, err := a.BotInstance.PatchBotInstance(ctx, scope, botName, botInstanceID, func(bi *machineidv1pb.BotInstance) (*machineidv1pb.BotInstance, error) {
-		if !bi.HasStatus() {
-			bi.SetStatus(&machineidv1pb.BotInstanceStatus{})
-		}
+	_, err := a.BotInstance.PatchBotInstance(ctx, services.PatchBotInstanceOpts{
+		Bot:        scopes.QualifiedName{Scope: scope, Name: botName},
+		InstanceID: botInstanceID,
+		UpdateFn: func(bi *machineidv1pb.BotInstance) (*machineidv1pb.BotInstance, error) {
+			if !bi.HasStatus() {
+				bi.SetStatus(&machineidv1pb.BotInstanceStatus{})
+			}
 
-		// Update the record's expiration timestamp based on the request TTL
-		// plus an expiry margin.
-		bi.GetMetadata().SetExpires(timestamppb.New(a.GetClock().Now().Add(req.TTL + machineidv1.ExpiryMargin)))
+			// Update the record's expiration timestamp based on the request TTL
+			// plus an expiry margin.
+			bi.GetMetadata().SetExpires(timestamppb.New(a.GetClock().Now().Add(req.TTL + machineidv1.ExpiryMargin)))
 
-		// If we're at or above the limit, remove enough of the front elements
-		// to make room for the new one at the end.
-		if len(bi.GetStatus().GetLatestAuthentications()) >= machineidv1.AuthenticationHistoryLimit {
-			toRemove := len(bi.GetStatus().GetLatestAuthentications()) - machineidv1.AuthenticationHistoryLimit + 1
-			bi.GetStatus().SetLatestAuthentications(bi.GetStatus().GetLatestAuthentications()[toRemove:])
-		}
+			// If we're at or above the limit, remove enough of the front elements
+			// to make room for the new one at the end.
+			if len(bi.GetStatus().GetLatestAuthentications()) >= machineidv1.AuthenticationHistoryLimit {
+				toRemove := len(bi.GetStatus().GetLatestAuthentications()) - machineidv1.AuthenticationHistoryLimit + 1
+				bi.GetStatus().SetLatestAuthentications(bi.GetStatus().GetLatestAuthentications()[toRemove:])
+			}
 
-		// An initial auth record should have been added during initial join,
-		// but if not, add it now.
-		if !bi.GetStatus().HasInitialAuthentication() {
-			log.WarnContext(ctx, "bot instance is missing its initial authentication record, a new one will be added")
-			bi.GetStatus().SetInitialAuthentication(authRecord)
-		}
+			// An initial auth record should have been added during initial join,
+			// but if not, add it now.
+			if !bi.GetStatus().HasInitialAuthentication() {
+				log.WarnContext(ctx, "bot instance is missing its initial authentication record, a new one will be added")
+				bi.GetStatus().SetInitialAuthentication(authRecord)
+			}
 
-		bi.GetStatus().SetLatestAuthentications(append(bi.GetStatus().GetLatestAuthentications(), authRecord))
+			bi.GetStatus().SetLatestAuthentications(append(bi.GetStatus().GetLatestAuthentications(), authRecord))
 
-		return bi, nil
+			return bi, nil
+		},
 	})
 
 	return trace.Wrap(err)

--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -329,7 +329,11 @@ func (a *Server) updateBotInstance(
 	var instanceGeneration int32
 	instanceNotFound := false
 	if botInstanceID != "" {
-		existingInstance, err := a.BotInstance.GetBotInstance(ctx, botName, botInstanceID)
+		existingInstance, err := a.BotInstance.GetBotInstance(ctx, machineidv1pb.GetBotInstanceRequest_builder{
+			BotScope:   scope,
+			BotName:    botName,
+			InstanceId: botInstanceID,
+		}.Build())
 		if trace.IsNotFound(err) {
 			instanceNotFound = true
 		} else if err != nil {
@@ -489,7 +493,7 @@ func (a *Server) updateBotInstance(
 		}
 	}
 
-	_, err := a.BotInstance.PatchBotInstance(ctx, botName, botInstanceID, func(bi *machineidv1pb.BotInstance) (*machineidv1pb.BotInstance, error) {
+	_, err := a.BotInstance.PatchBotInstance(ctx, scope, botName, botInstanceID, func(bi *machineidv1pb.BotInstance) (*machineidv1pb.BotInstance, error) {
 		if !bi.HasStatus() {
 			bi.SetStatus(&machineidv1pb.BotInstanceStatus{})
 		}

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -185,7 +185,7 @@ func TestRegisterBotCertificateGenerationCheck(t *testing.T) {
 	// Renew the cert a bunch of times.
 	for i := range 10 {
 		// Ensure the state of the bot instance before renewal is sane.
-		bi, err := srv.Auth().BotInstance.GetBotInstance(ctx, initialIdent.BotName, initialIdent.BotInstanceID)
+		bi, err := srv.Auth().BotInstance.GetBotInstance(ctx, machineidv1pb.GetBotInstanceRequest_builder{BotScope: "", BotName: initialIdent.BotName, InstanceId: initialIdent.BotInstanceID}.Build())
 		require.NoError(t, err)
 
 		// There should always be at least 1 entry as the initial join is
@@ -221,7 +221,7 @@ func TestRegisterBotCertificateGenerationCheck(t *testing.T) {
 		require.Equal(t, uint64(i+2), renewedIdent.Generation)
 
 		// Ensure the bot instance after renewal is sane.
-		bi, err = srv.Auth().BotInstance.GetBotInstance(ctx, initialIdent.BotName, initialIdent.BotInstanceID)
+		bi, err = srv.Auth().BotInstance.GetBotInstance(ctx, machineidv1pb.GetBotInstanceRequest_builder{BotScope: "", BotName: initialIdent.BotName, InstanceId: initialIdent.BotInstanceID}.Build())
 		require.NoError(t, err)
 
 		require.Len(t, bi.GetStatus().GetLatestAuthentications(), min(i+2, machineidv1.AuthenticationHistoryLimit))
@@ -432,7 +432,7 @@ func TestRegisterBotInstance(t *testing.T) {
 	require.NotEmpty(t, ident.BotInstanceID)
 
 	// The instance ID should match a bot instance record.
-	botInstance, err := srv.Auth().BotInstance.GetBotInstance(ctx, ident.BotName, ident.BotInstanceID)
+	botInstance, err := srv.Auth().BotInstance.GetBotInstance(ctx, machineidv1pb.GetBotInstanceRequest_builder{BotScope: "", BotName: ident.BotName, InstanceId: ident.BotInstanceID}.Build())
 	require.NoError(t, err)
 
 	require.Equal(t, ident.BotName, botInstance.GetSpec().GetBotName())

--- a/lib/auth/machineid/machineidv1/bot_instance_service.go
+++ b/lib/auth/machineid/machineidv1/bot_instance_service.go
@@ -33,6 +33,7 @@ import (
 	pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -58,8 +59,10 @@ const (
 
 // BotInstancesCache is the subset of the cached resources that the Service queries.
 type BotInstancesCache interface {
-	// GetBotInstance returns the specified BotInstance resource.
-	GetBotInstance(ctx context.Context, botName, instanceID string) (*pb.BotInstance, error)
+	// GetBotInstance returns the specified BotInstance resource. A bot is
+	// identified by the request's (bot_scope, bot_name); bot_scope is empty
+	// for instances of unscoped bots.
+	GetBotInstance(ctx context.Context, req *pb.GetBotInstanceRequest) (*pb.BotInstance, error)
 
 	// ListBotInstances returns a page of BotInstance resources.
 	ListBotInstances(ctx context.Context, pageSize int, lastToken string, options *services.ListBotInstancesRequestOptions) ([]*pb.BotInstance, string, error)
@@ -129,7 +132,11 @@ func (b *BotInstanceService) DeleteBotInstance(ctx context.Context, req *pb.Dele
 		return nil, trace.Wrap(err)
 	}
 
-	instance, err := b.backend.GetBotInstance(ctx, req.GetBotName(), req.GetInstanceId())
+	instance, err := b.backend.GetBotInstance(ctx, pb.GetBotInstanceRequest_builder{
+		BotScope:   req.GetBotScope(),
+		BotName:    req.GetBotName(),
+		InstanceId: req.GetInstanceId(),
+	}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -137,7 +144,7 @@ func (b *BotInstanceService) DeleteBotInstance(ctx context.Context, req *pb.Dele
 	ruleCtx.Resource153 = instance
 	if err := authCtx.CheckerContext.Decision(
 		ctx,
-		instance.GetScope(),
+		req.GetBotScope(),
 		func(checker *services.ScopedAccessChecker) error {
 			return checker.CheckAccessToRules(
 				&ruleCtx,
@@ -157,9 +164,7 @@ func (b *BotInstanceService) DeleteBotInstance(ctx context.Context, req *pb.Dele
 		}
 	}
 
-	if err := b.backend.DeleteBotInstance(
-		ctx, instance.GetSpec().GetBotName(), instance.GetSpec().GetInstanceId(),
-	); err != nil {
+	if err := b.backend.DeleteBotInstance(ctx, req); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -182,7 +187,7 @@ func (b *BotInstanceService) GetBotInstance(ctx context.Context, req *pb.GetBotI
 		return nil, trace.Wrap(err)
 	}
 
-	res, err := b.cache.GetBotInstance(ctx, req.GetBotName(), req.GetInstanceId())
+	res, err := b.cache.GetBotInstance(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -241,6 +246,21 @@ func (b *BotInstanceService) ListBotInstancesV2(ctx context.Context, req *pb.Lis
 		return nil, trace.Wrap(err)
 	}
 
+	if filterBotScope := req.GetFilter().GetBotScope(); filterBotScope != "" {
+		// bot_scope is only designed to scope-qualify bot_name. If we want to
+		// introduce actual scope-filtering down the line, we'll introduce a
+		// new field with more control (i.e. exact, descendent)
+		if req.GetFilter().GetBotName() == "" {
+			return nil, trace.BadParameter(
+				"bot_scope filter requires bot_name",
+			)
+		}
+
+		if err := scopes.StrongValidate(filterBotScope); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
 	botInstances, nextToken, err := b.cache.ListBotInstances(
 		ctx,
 		int(req.GetPageSize()),
@@ -249,6 +269,7 @@ func (b *BotInstanceService) ListBotInstancesV2(ctx context.Context, req *pb.Lis
 			SortField:        req.GetSortField(),
 			SortDesc:         req.GetSortDesc(),
 			FilterBotName:    req.GetFilter().GetBotName(),
+			FilterBotScope:   req.GetFilter().GetBotScope(),
 			FilterSearchTerm: req.GetFilter().GetSearchTerm(),
 			FilterQuery:      req.GetFilter().GetQuery(),
 			FilterFn: func(botInstance *pb.BotInstance) bool {
@@ -322,6 +343,18 @@ func (b *BotInstanceService) SubmitHeartbeat(ctx context.Context, req *pb.Submit
 		}
 	}
 
+	// A scoped bot's instances are stored namespaced by the bot's scope, which
+	// is encoded into the identity as BotScope. Certificates issued before the
+	// BotScope field existed lack it, so fall back to the scope pin - correct
+	// for those certs because bots are always pinned to their scope of origin.
+	// TODO(strideynet): remove the ScopePin fallback once sufficient time has
+	// passed that all bot certs carry BotScope. It must be removed before bots
+	// can be pinned to a scope other than their scope of origin.
+	botScope := ident.BotScope
+	if botScope == "" && ident.ScopePin != nil {
+		botScope = ident.ScopePin.GetScope()
+	}
+
 	b.logger.DebugContext(
 		ctx,
 		"Received bot instance heartbeat",
@@ -329,7 +362,7 @@ func (b *BotInstanceService) SubmitHeartbeat(ctx context.Context, req *pb.Submit
 		"bot_instance", botInstanceID,
 		"heartbeat", logutils.StringerAttr(req.GetHeartbeat()),
 	)
-	_, err = b.backend.PatchBotInstance(ctx, botName, botInstanceID, func(instance *pb.BotInstance) (*pb.BotInstance, error) {
+	_, err = b.backend.PatchBotInstance(ctx, botScope, botName, botInstanceID, func(instance *pb.BotInstance) (*pb.BotInstance, error) {
 		if !instance.HasStatus() {
 			instance.SetStatus(&pb.BotInstanceStatus{})
 		}

--- a/lib/auth/machineid/machineidv1/bot_instance_service.go
+++ b/lib/auth/machineid/machineidv1/bot_instance_service.go
@@ -144,7 +144,7 @@ func (b *BotInstanceService) DeleteBotInstance(ctx context.Context, req *pb.Dele
 	ruleCtx.Resource153 = instance
 	if err := authCtx.CheckerContext.Decision(
 		ctx,
-		req.GetBotScope(),
+		instance.GetScope(),
 		func(checker *services.ScopedAccessChecker) error {
 			return checker.CheckAccessToRules(
 				&ruleCtx,
@@ -362,29 +362,33 @@ func (b *BotInstanceService) SubmitHeartbeat(ctx context.Context, req *pb.Submit
 		"bot_instance", botInstanceID,
 		"heartbeat", logutils.StringerAttr(req.GetHeartbeat()),
 	)
-	_, err = b.backend.PatchBotInstance(ctx, botScope, botName, botInstanceID, func(instance *pb.BotInstance) (*pb.BotInstance, error) {
-		if !instance.HasStatus() {
-			instance.SetStatus(&pb.BotInstanceStatus{})
-		}
-		// Set initial heartbeat if not set.
-		if !instance.GetStatus().HasInitialHeartbeat() {
-			instance.GetStatus().SetInitialHeartbeat(req.GetHeartbeat())
-		}
-		// If we're at or above the limit, remove enough of the front
-		// elements to make room for the new one at the end.
-		if len(instance.GetStatus().GetLatestHeartbeats()) >= heartbeatHistoryLimit {
-			toRemove := len(instance.GetStatus().GetLatestHeartbeats()) - heartbeatHistoryLimit + 1
-			instance.GetStatus().SetLatestHeartbeats(instance.GetStatus().GetLatestHeartbeats()[toRemove:])
-		}
-		// Append the new heartbeat to the end.
-		instance.GetStatus().SetLatestHeartbeats(append(instance.GetStatus().GetLatestHeartbeats(), req.GetHeartbeat()))
+	_, err = b.backend.PatchBotInstance(ctx, services.PatchBotInstanceOpts{
+		Bot:        scopes.QualifiedName{Scope: botScope, Name: botName},
+		InstanceID: botInstanceID,
+		UpdateFn: func(instance *pb.BotInstance) (*pb.BotInstance, error) {
+			if !instance.HasStatus() {
+				instance.SetStatus(&pb.BotInstanceStatus{})
+			}
+			// Set initial heartbeat if not set.
+			if !instance.GetStatus().HasInitialHeartbeat() {
+				instance.GetStatus().SetInitialHeartbeat(req.GetHeartbeat())
+			}
+			// If we're at or above the limit, remove enough of the front
+			// elements to make room for the new one at the end.
+			if len(instance.GetStatus().GetLatestHeartbeats()) >= heartbeatHistoryLimit {
+				toRemove := len(instance.GetStatus().GetLatestHeartbeats()) - heartbeatHistoryLimit + 1
+				instance.GetStatus().SetLatestHeartbeats(instance.GetStatus().GetLatestHeartbeats()[toRemove:])
+			}
+			// Append the new heartbeat to the end.
+			instance.GetStatus().SetLatestHeartbeats(append(instance.GetStatus().GetLatestHeartbeats(), req.GetHeartbeat()))
 
-		if storeHeartbeatExtras() {
-			// Overwrite the service health.
-			instance.GetStatus().SetServiceHealth(req.GetServiceHealth())
-		}
+			if storeHeartbeatExtras() {
+				// Overwrite the service health.
+				instance.GetStatus().SetServiceHealth(req.GetServiceHealth())
+			}
 
-		return instance, nil
+			return instance, nil
+		},
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "patching bot instance")

--- a/lib/auth/machineid/machineidv1/bot_instance_service_test.go
+++ b/lib/auth/machineid/machineidv1/bot_instance_service_test.go
@@ -454,6 +454,24 @@ func TestBotInstanceServiceSubmitHeartbeat(t *testing.T) {
 			assertErr:     assert.NoError,
 			wantHeartbeat: true,
 		},
+		{
+			// BotScope determines the storage scope even when the identity is
+			// pinned to a different (narrower) scope.
+			name:              "scoped identity with BotScope preferred over pin",
+			createBotInstance: true,
+			req: machineidv1.SubmitHeartbeatRequest_builder{
+				Heartbeat: machineidv1.BotInstanceStatusHeartbeat_builder{Hostname: "llama"}.Build(),
+			}.Build(),
+			identity: tlsca.Identity{
+				BotName:       botName,
+				BotInstanceID: botInstanceID,
+				BotScope:      "/scopes/test",
+				ScopePin:      scopesv1.Pin_builder{Kind: scopesv1.PinKind_PIN_KIND_USER, Scope: "/scopes/test/narrowed"}.Build(),
+				BotInternal:   true,
+			},
+			assertErr:     assert.NoError,
+			wantHeartbeat: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -473,9 +491,17 @@ func TestBotInstanceServiceSubmitHeartbeat(t *testing.T) {
 			})
 			require.NoError(t, err)
 
+			// A scoped bot's instances are stored namespaced by the identity's
+			// BotScope, falling back to the pinned scope for older certs.
+			botScope := tt.identity.BotScope
+			if botScope == "" {
+				botScope = tt.identity.ScopePin.GetScope()
+			}
+
 			if tt.createBotInstance {
 				bi := newBotInstance(botName)
 				bi.GetSpec().SetInstanceId(botInstanceID)
+				bi.SetScope(botScope)
 				_, err := backend.CreateBotInstance(ctx, bi)
 				require.NoError(t, err)
 			}
@@ -483,7 +509,7 @@ func TestBotInstanceServiceSubmitHeartbeat(t *testing.T) {
 			_, err = service.SubmitHeartbeat(ctx, tt.req)
 			tt.assertErr(t, err)
 			if tt.createBotInstance {
-				bi, err := backend.GetBotInstance(ctx, botName, botInstanceID)
+				bi, err := backend.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: botScope, BotName: botName, InstanceId: botInstanceID}.Build())
 				require.NoError(t, err)
 				if tt.wantHeartbeat {
 					assert.Empty(
@@ -557,7 +583,7 @@ func TestBotInstanceServiceSubmitHeartbeat_HeartbeatLimit(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	bi, err = backend.GetBotInstance(ctx, botName, botInstanceID)
+	bi, err = backend.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "", BotName: botName, InstanceId: botInstanceID}.Build())
 	require.NoError(t, err)
 	assert.Len(t, bi.GetStatus().GetLatestHeartbeats(), heartbeatHistoryLimit)
 	assert.Equal(t, "0", bi.GetStatus().GetInitialHeartbeat().GetHostname())

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -3259,6 +3259,7 @@ func TestBotInstanceService_DeleteBotInstance(t *testing.T) {
 			_, err = client.BotInstanceServiceClient().DeleteBotInstance(ctx, machineidv1pb.DeleteBotInstanceRequest_builder{
 				BotName:    tt.instance.GetSpec().GetBotName(),
 				InstanceId: tt.instance.GetSpec().GetInstanceId(),
+				BotScope:   tt.instance.GetScope(),
 			}.Build())
 			tt.assertError(t, err)
 		})
@@ -3386,6 +3387,7 @@ func TestBotInstanceService_GetBotInstance(t *testing.T) {
 			got, err := client.BotInstanceServiceClient().GetBotInstance(ctx, machineidv1pb.GetBotInstanceRequest_builder{
 				BotName:    tt.instance.GetSpec().GetBotName(),
 				InstanceId: tt.instance.GetSpec().GetInstanceId(),
+				BotScope:   tt.instance.GetScope(),
 			}.Build())
 			tt.assertError(t, err)
 			if err == nil {
@@ -3558,6 +3560,52 @@ func TestBotInstanceService_ListBotInstancesV2(t *testing.T) {
 		got := listAll(t, client.BotInstanceServiceClient())
 		require.Empty(t, got)
 	})
+
+	t.Run("scope filter with bot name returns that bot's instances", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
+		require.NoError(t, err)
+
+		want := grantedInstances[0]
+		res, err := client.BotInstanceServiceClient().ListBotInstancesV2(t.Context(), machineidv1pb.ListBotInstancesV2Request_builder{
+			PageSize: 100,
+			Filter: machineidv1pb.ListBotInstancesV2Request_Filters_builder{
+				BotName:  want.GetSpec().GetBotName(),
+				BotScope: "/scopes/granted",
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		require.Len(t, res.GetBotInstances(), 1)
+		require.Equal(t, want.GetSpec().GetInstanceId(), res.GetBotInstances()[0].GetSpec().GetInstanceId())
+	})
+
+	t.Run("scope filter without bot name is rejected", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
+		require.NoError(t, err)
+
+		// bot_scope only qualifies bot_name; it cannot be used as a standalone
+		// scope filter.
+		_, err = client.BotInstanceServiceClient().ListBotInstancesV2(t.Context(), machineidv1pb.ListBotInstancesV2Request_builder{
+			PageSize: 100,
+			Filter: machineidv1pb.ListBotInstancesV2Request_Filters_builder{
+				BotScope: "/scopes/granted",
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
+	})
+
+	t.Run("non-canonical scope filter is rejected", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
+		require.NoError(t, err)
+
+		_, err = client.BotInstanceServiceClient().ListBotInstancesV2(t.Context(), machineidv1pb.ListBotInstancesV2Request_builder{
+			PageSize: 100,
+			Filter: machineidv1pb.ListBotInstancesV2Request_Filters_builder{
+				BotName:  grantedInstances[0].GetSpec().GetBotName(),
+				BotScope: "/scopes/granted/",
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
+	})
 }
 
 func TestBotInstanceService_SubmitHeartbeat(t *testing.T) {
@@ -3677,13 +3725,14 @@ func TestBotInstanceService_SubmitHeartbeat(t *testing.T) {
 		}.Build())
 		require.NoError(t, err)
 
-		got, err := adminClient.BotInstanceServiceClient().GetBotInstance(ctx, machineidv1pb.GetBotInstanceRequest_builder{
-			BotName:    botName,
-			InstanceId: instanceID,
-		}.Build())
-		require.NoError(t, err)
-		require.NotNil(t, got.GetStatus().GetInitialHeartbeat())
-		require.Equal(t, "scoped-host", got.GetStatus().GetInitialHeartbeat().GetHostname())
+		// The heartbeat lands in the backend and replicates to cache-backed
+		// reads through the scoped event watch, so allow for propagation.
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			got, err := srv.Auth().Cache.GetBotInstance(ctx, machineidv1pb.GetBotInstanceRequest_builder{BotScope: "/scopes/test", BotName: botName, InstanceId: instanceID}.Build())
+			require.NoError(t, err)
+			require.NotNil(t, got.GetStatus().GetInitialHeartbeat())
+			require.Equal(t, "scoped-host", got.GetStatus().GetInitialHeartbeat().GetHostname())
+		}, 5*time.Second, 100*time.Millisecond)
 	})
 }
 

--- a/lib/cache/bot_instance.go
+++ b/lib/cache/bot_instance.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1/expression"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils/typical"
 )
@@ -76,8 +77,11 @@ func newBotInstanceCollection(upstream services.BotInstance, w types.WatchKind) 
 	}, nil
 }
 
-// GetBotInstance returns the specified BotInstance resource.
-func (c *Cache) GetBotInstance(ctx context.Context, botName, instanceID string) (*machineidv1.BotInstance, error) {
+// GetBotInstance returns the specified BotInstance resource. A bot is
+// identified by the request's (bot_scope, bot_name): a lookup with the wrong
+// scope misses, just as it would against the backend's scope-namespaced key
+// ranges.
+func (c *Cache) GetBotInstance(ctx context.Context, req *machineidv1.GetBotInstanceRequest) (*machineidv1.BotInstance, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetBotInstance")
 	defer span.End()
 
@@ -86,11 +90,11 @@ func (c *Cache) GetBotInstance(ctx context.Context, botName, instanceID string) 
 		collection: c.collections.botInstances,
 		index:      botInstanceNameIndex,
 		upstreamGet: func(ctx context.Context, _ string) (*machineidv1.BotInstance, error) {
-			return c.Config.BotInstanceService.GetBotInstance(ctx, botName, instanceID)
+			return c.Config.BotInstanceService.GetBotInstance(ctx, req)
 		},
 	}
 
-	out, err := getter.get(ctx, makeBotInstanceNameIndexKey(botName, instanceID))
+	out, err := getter.get(ctx, makeBotInstanceNameIndexKey(req.GetBotScope(), req.GetBotName(), req.GetInstanceId()))
 	return out, trace.Wrap(err)
 }
 
@@ -144,6 +148,16 @@ func (c *Cache) ListBotInstances(ctx context.Context, pageSize int, lastToken st
 			return c.Config.BotInstanceService.ListBotInstances(ctx, limit, start, options)
 		},
 		filter: func(b *machineidv1.BotInstance) bool {
+			// A bot is identified by (scope, name), so any by-bot or by-scope
+			// filter constrains the scope: name without scope means the
+			// unscoped bot. Only the unfiltered listing spans all scopes.
+			// This mirrors the backend's range routing in
+			// local.BotInstanceService.ListBotInstances.
+			if options.GetFilterBotName() != "" || options.GetFilterBotScope() != "" {
+				if b.GetScope() != options.GetFilterBotScope() {
+					return false
+				}
+			}
 			if !services.MatchBotInstance(b, options.GetFilterBotName(), options.GetFilterSearchTerm(), exp) {
 				return false
 			}
@@ -165,13 +179,16 @@ func (c *Cache) ListBotInstances(ctx context.Context, pageSize int, lastToken st
 
 func keyForBotInstanceNameIndex(botInstance *machineidv1.BotInstance) string {
 	return makeBotInstanceNameIndexKey(
+		botInstance.GetScope(),
 		botInstance.GetSpec().GetBotName(),
 		botInstance.GetMetadata().GetName(),
 	)
 }
 
-func makeBotInstanceNameIndexKey(botName string, instanceID string) string {
-	return botName + "/" + instanceID
+// makeBotInstanceNameIndexKey builds the primary index key for a bot
+// instance.
+func makeBotInstanceNameIndexKey(botScope, botName, instanceID string) string {
+	return scopes.MakeResourceCursor(botScope, botName+"/"+instanceID)
 }
 
 func keyForBotInstanceActiveAtIndex(botInstance *machineidv1.BotInstance) string {

--- a/lib/cache/bot_instance.go
+++ b/lib/cache/bot_instance.go
@@ -104,6 +104,13 @@ func (c *Cache) ListBotInstances(ctx context.Context, pageSize int, lastToken st
 	ctx, span := c.Tracer.Start(ctx, "cache/ListBotInstances")
 	defer span.End()
 
+	// A bot is identified by the pair (scope, name), so the scope filter only
+	// ever qualifies the name filter. Listing a whole scope will be a separate
+	// filter with explicit exact/descendant control.
+	if options.GetFilterBotScope() != "" && options.GetFilterBotName() == "" {
+		return nil, "", trace.BadParameter("bot scope filter requires a bot name filter")
+	}
+
 	index := botInstanceNameIndex
 	keyFn := keyForBotInstanceNameIndex
 	isDesc := options.GetSortDesc()
@@ -148,15 +155,13 @@ func (c *Cache) ListBotInstances(ctx context.Context, pageSize int, lastToken st
 			return c.Config.BotInstanceService.ListBotInstances(ctx, limit, start, options)
 		},
 		filter: func(b *machineidv1.BotInstance) bool {
-			// A bot is identified by (scope, name), so any by-bot or by-scope
-			// filter constrains the scope: name without scope means the
-			// unscoped bot. Only the unfiltered listing spans all scopes.
-			// This mirrors the backend's range routing in
+			// A bot is identified by (scope, name), so a by-bot filter also
+			// constrains the scope: a name without a scope means the unscoped
+			// bot. Only the unfiltered listing spans all scopes. This mirrors
+			// the backend's range routing in
 			// local.BotInstanceService.ListBotInstances.
-			if options.GetFilterBotName() != "" || options.GetFilterBotScope() != "" {
-				if b.GetScope() != options.GetFilterBotScope() {
-					return false
-				}
+			if options.GetFilterBotName() != "" && b.GetScope() != options.GetFilterBotScope() {
+				return false
 			}
 			if !services.MatchBotInstance(b, options.GetFilterBotName(), options.GetFilterSearchTerm(), exp) {
 				return false

--- a/lib/cache/bot_instance_test.go
+++ b/lib/cache/bot_instance_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -78,8 +79,12 @@ func TestBotInstanceCache(t *testing.T) {
 					return p.botInstanceService.ListBotInstances(ctx, pageSize, pageToken, nil)
 				},
 				update: func(ctx context.Context, bi *machineidv1.BotInstance) error {
-					_, err := p.botInstanceService.PatchBotInstance(ctx, botScope, "bot-1", bi.GetMetadata().GetName(), func(_ *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
-						return bi, nil
+					_, err := p.botInstanceService.PatchBotInstance(ctx, services.PatchBotInstanceOpts{
+						Bot:        scopes.QualifiedName{Scope: botScope, Name: "bot-1"},
+						InstanceID: bi.GetMetadata().GetName(),
+						UpdateFn: func(_ *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
+							return bi, nil
+						},
 					})
 					return err
 				},
@@ -274,6 +279,17 @@ func TestBotInstanceCacheList(t *testing.T) {
 			},
 			opts: &services.ListBotInstancesRequestOptions{FilterBotName: "web", FilterBotScope: "/prod"},
 			want: []string{"web-p1", "web-p2"},
+		},
+		{
+			// A scope filter only qualifies a bot name, so it is rejected on its
+			// own rather than listing every instance in the scope.
+			name: "scope filter without a bot name filter is rejected",
+			instances: []botInstanceSpec{
+				{botName: "web", id: "web-u"},
+				{scope: "/prod", botName: "web", id: "web-p1"},
+			},
+			opts:    &services.ListBotInstancesRequestOptions{FilterBotScope: "/prod"},
+			wantErr: "bot scope filter requires a bot name filter",
 		},
 		{
 			name: "search term matches across scopes",

--- a/lib/cache/bot_instance_test.go
+++ b/lib/cache/bot_instance_test.go
@@ -18,8 +18,9 @@ package cache
 
 import (
 	"context"
-	"strconv"
+	"fmt"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/uuid"
@@ -30,507 +31,378 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
 )
 
 // TestBotInstanceCache tests that CRUD operations on bot instances resources are
-// replicated from the backend to the cache.
+// replicated from the backend to the cache. Instances of scoped bots live in a
+// scope-namespaced backend range, so create/update/delete events for them must
+// round-trip through the cache's event watcher just like unscoped instances.
 func TestBotInstanceCache(t *testing.T) {
 	t.Parallel()
 
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
+	for _, botScope := range []string{"", "/scopes/test"} {
+		t.Run(fmt.Sprintf("scope=%q", botScope), func(t *testing.T) {
+			t.Parallel()
 
-	testResources153(t, p, testFuncs[*machineidv1.BotInstance]{
-		newResource: func(key string) (*machineidv1.BotInstance, error) {
-			return machineidv1.BotInstance_builder{
+			p := newTestPack(t, ForAuth)
+			t.Cleanup(p.Close)
+
+			testResources153(t, p, testFuncs[*machineidv1.BotInstance]{
+				newResource: func(key string) (*machineidv1.BotInstance, error) {
+					return machineidv1.BotInstance_builder{
+						Kind:     types.KindBotInstance,
+						Version:  types.V1,
+						Scope:    botScope,
+						Metadata: &headerv1.Metadata{},
+						Spec: machineidv1.BotInstanceSpec_builder{
+							BotName:    "bot-1",
+							InstanceId: key,
+						}.Build(),
+						Status: &machineidv1.BotInstanceStatus{},
+					}.Build(), nil
+				},
+				cacheGet: func(ctx context.Context, key string) (*machineidv1.BotInstance, error) {
+					return p.cache.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: botScope, BotName: "bot-1", InstanceId: key}.Build())
+				},
+				cacheList: func(ctx context.Context, pageSize int, pageToken string) ([]*machineidv1.BotInstance, string, error) {
+					return p.cache.ListBotInstances(ctx, pageSize, pageToken, nil)
+				},
+				create: func(ctx context.Context, resource *machineidv1.BotInstance) error {
+					_, err := p.botInstanceService.CreateBotInstance(ctx, resource)
+					return err
+				},
+				list: func(ctx context.Context, pageSize int, pageToken string) ([]*machineidv1.BotInstance, string, error) {
+					return p.botInstanceService.ListBotInstances(ctx, pageSize, pageToken, nil)
+				},
+				update: func(ctx context.Context, bi *machineidv1.BotInstance) error {
+					_, err := p.botInstanceService.PatchBotInstance(ctx, botScope, "bot-1", bi.GetMetadata().GetName(), func(_ *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
+						return bi, nil
+					})
+					return err
+				},
+				delete: func(ctx context.Context, key string) error {
+					return p.botInstanceService.DeleteBotInstance(ctx, machineidv1.DeleteBotInstanceRequest_builder{BotScope: botScope, BotName: "bot-1", InstanceId: key}.Build())
+				},
+				deleteAll: func(ctx context.Context) error {
+					return p.botInstanceService.DeleteAllBotInstances(ctx)
+				},
+			})
+		})
+	}
+}
+
+// TestBotInstanceCacheBackendTokenParity verifies that the cache lister and
+// the backend lister agree on the ordering of the unified scoped+unscoped
+// listing and mint interchangeable page tokens. genericLister falls back to
+// the backend lister with the caller's token verbatim when the cache is
+// unhealthy, so a token minted by one side must resume correctly against the
+// other.
+func TestBotInstanceCacheBackendTokenParity(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+
+		p := newTestPack(t, ForAuth)
+		t.Cleanup(p.Close)
+
+		instances := []struct {
+			botScope string
+			botName  string
+		}{
+			{botScope: "", botName: "bot-a"},
+			{botScope: "", botName: "bot-b"},
+			{botScope: "/bar", botName: "bot-c"},
+			{botScope: "/foo", botName: "bot-d"},
+		}
+		for _, i := range instances {
+			_, err := p.botInstanceService.CreateBotInstance(ctx, machineidv1.BotInstance_builder{
 				Kind:     types.KindBotInstance,
 				Version:  types.V1,
+				Scope:    i.botScope,
 				Metadata: &headerv1.Metadata{},
 				Spec: machineidv1.BotInstanceSpec_builder{
-					BotName:    "bot-1",
-					InstanceId: key,
+					BotName:    i.botName,
+					InstanceId: uuid.New().String(),
 				}.Build(),
 				Status: &machineidv1.BotInstanceStatus{},
-			}.Build(), nil
-		},
-		cacheGet: func(ctx context.Context, key string) (*machineidv1.BotInstance, error) {
-			return p.cache.GetBotInstance(ctx, "bot-1", key)
-		},
-		cacheList: func(ctx context.Context, pageSize int, pageToken string) ([]*machineidv1.BotInstance, string, error) {
-			return p.cache.ListBotInstances(ctx, pageSize, pageToken, nil)
-		},
-		create: func(ctx context.Context, resource *machineidv1.BotInstance) error {
-			_, err := p.botInstanceService.CreateBotInstance(ctx, resource)
-			return err
-		},
-		list: func(ctx context.Context, pageSize int, pageToken string) ([]*machineidv1.BotInstance, string, error) {
-			return p.botInstanceService.ListBotInstances(ctx, pageSize, pageToken, nil)
-		},
-		update: func(ctx context.Context, bi *machineidv1.BotInstance) error {
-			_, err := p.botInstanceService.PatchBotInstance(ctx, "bot-1", bi.GetMetadata().GetName(), func(_ *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
-				return bi, nil
-			})
-			return err
-		},
-		delete: func(ctx context.Context, key string) error {
-			return p.botInstanceService.DeleteBotInstance(ctx, "bot-1", key)
-		},
-		deleteAll: func(ctx context.Context) error {
-			return p.botInstanceService.DeleteAllBotInstances(ctx)
-		},
+			}.Build())
+			require.NoError(t, err)
+		}
+
+		synctest.Wait()
+
+		names := func(instances []*machineidv1.BotInstance) []string {
+			out := make([]string, 0, len(instances))
+			for _, b := range instances {
+				out = append(out, b.GetSpec().GetBotName())
+			}
+			return out
+		}
+
+		// Both listings order unscoped instances first, then scoped grouped by
+		// scope.
+		wantOrder := []string{"bot-a", "bot-b", "bot-c", "bot-d"}
+		fromCache, _, err := p.cache.ListBotInstances(ctx, 0, "", nil)
+		require.NoError(t, err)
+		require.Equal(t, wantOrder, names(fromCache))
+		fromBackend, _, err := p.botInstanceService.ListBotInstances(ctx, 0, "", nil)
+		require.NoError(t, err)
+		require.Equal(t, wantOrder, names(fromBackend))
+
+		// Page tokens are interchangeable whether the next item is unscoped
+		// (pageSize 1) or scoped (pageSize 3).
+		for _, pageSize := range []int{1, 3} {
+			cachePage, cacheToken, err := p.cache.ListBotInstances(ctx, pageSize, "", nil)
+			require.NoError(t, err)
+			require.Equal(t, wantOrder[:pageSize], names(cachePage))
+			backendPage, backendToken, err := p.botInstanceService.ListBotInstances(ctx, pageSize, "", nil)
+			require.NoError(t, err)
+			require.Equal(t, wantOrder[:pageSize], names(backendPage))
+			require.Equal(t, backendToken, cacheToken)
+
+			rest, _, err := p.botInstanceService.ListBotInstances(ctx, 0, cacheToken, nil)
+			require.NoError(t, err)
+			require.Equal(t, wantOrder[pageSize:], names(rest))
+			rest, _, err = p.cache.ListBotInstances(ctx, 0, backendToken, nil)
+			require.NoError(t, err)
+			require.Equal(t, wantOrder[pageSize:], names(rest))
+		}
 	})
 }
 
-// TestBotInstanceCachePaging tests that items from the cache are paginated.
-func TestBotInstanceCachePaging(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	for _, n := range []int{5, 1, 3, 4, 2} {
-		_, err := p.botInstanceService.CreateBotInstance(ctx, machineidv1.BotInstance_builder{
-			Kind:     types.KindBotInstance,
-			Version:  types.V1,
-			Metadata: &headerv1.Metadata{},
-			Spec: machineidv1.BotInstanceSpec_builder{
-				BotName:    "bot-1",
-				InstanceId: "instance-" + strconv.Itoa(n),
-			}.Build(),
-			Status: &machineidv1.BotInstanceStatus{},
-		}.Build())
-		require.NoError(t, err)
-	}
-
-	// Let the cache catch up
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", nil)
-		require.NoError(t, err)
-		require.Len(t, results, 5)
-	}, 10*time.Second, 100*time.Millisecond)
-
-	// page size equal to total items
-	results, nextPageToken, err := p.cache.ListBotInstances(ctx, 0, "", nil)
-	require.NoError(t, err)
-	require.Empty(t, nextPageToken)
-	require.Len(t, results, 5)
-	require.Equal(t, "instance-1", results[0].GetMetadata().GetName())
-	require.Equal(t, "instance-2", results[1].GetMetadata().GetName())
-	require.Equal(t, "instance-3", results[2].GetMetadata().GetName())
-	require.Equal(t, "instance-4", results[3].GetMetadata().GetName())
-	require.Equal(t, "instance-5", results[4].GetMetadata().GetName())
-
-	// page size smaller than total items
-	results, nextPageToken, err = p.cache.ListBotInstances(ctx, 3, "", nil)
-	require.NoError(t, err)
-	require.Equal(t, "bot-1/instance-4", nextPageToken)
-	require.Len(t, results, 3)
-	require.Equal(t, "instance-1", results[0].GetMetadata().GetName())
-	require.Equal(t, "instance-2", results[1].GetMetadata().GetName())
-	require.Equal(t, "instance-3", results[2].GetMetadata().GetName())
-
-	// next page
-	results, nextPageToken, err = p.cache.ListBotInstances(ctx, 3, nextPageToken, nil)
-	require.NoError(t, err)
-	require.Empty(t, nextPageToken)
-	require.Len(t, results, 2)
-	require.Equal(t, "instance-4", results[0].GetMetadata().GetName())
-	require.Equal(t, "instance-5", results[1].GetMetadata().GetName())
+type botInstanceSpec struct {
+	scope, botName, id string
+	hostname, version  string
+	activeAt           int64
 }
 
-// TestBotInstanceCacheBotFilter tests that cache items are filtered by bot name.
-func TestBotInstanceCacheBotFilter(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	for n := range 10 {
-		_, err := p.botInstanceService.CreateBotInstance(ctx, machineidv1.BotInstance_builder{
-			Kind:     types.KindBotInstance,
-			Version:  types.V1,
-			Metadata: &headerv1.Metadata{},
-			Spec: machineidv1.BotInstanceSpec_builder{
-				BotName:    "bot-" + strconv.Itoa(n%2),
-				InstanceId: "instance-" + strconv.Itoa(n),
-			}.Build(),
-			Status: &machineidv1.BotInstanceStatus{},
-		}.Build())
-		require.NoError(t, err)
-	}
-
-	// Let the cache catch up
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", nil)
-		require.NoError(t, err)
-		require.Len(t, results, 10)
-	}, 10*time.Second, 100*time.Millisecond)
-
-	results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		FilterBotName: "bot-1",
-	})
-	require.NoError(t, err)
-	require.Len(t, results, 5)
-
-	for _, b := range results {
-		require.Equal(t, "bot-1", b.GetSpec().GetBotName())
-	}
-}
-
-// TestBotInstanceCacheSearchFilter tests that cache items are filtered by
-// search term.
-func TestBotInstanceCacheSearchFilter(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	for n := range 10 {
-		instance := machineidv1.BotInstance_builder{
-			Kind:     types.KindBotInstance,
-			Version:  types.V1,
-			Metadata: &headerv1.Metadata{},
-			Spec: machineidv1.BotInstanceSpec_builder{
-				BotName:    "bot-1",
-				InstanceId: "instance-" + strconv.Itoa(n+1),
-			}.Build(),
-			Status: machineidv1.BotInstanceStatus_builder{
-				LatestHeartbeats: []*machineidv1.BotInstanceStatusHeartbeat{
-					machineidv1.BotInstanceStatusHeartbeat_builder{
-						Hostname: "host-" + strconv.Itoa(n%2),
-					}.Build(),
-				},
-			}.Build(),
+func buildBotInstance(s botInstanceSpec) *machineidv1.BotInstance {
+	status := &machineidv1.BotInstanceStatus{}
+	if s.hostname != "" || s.version != "" || s.activeAt != 0 {
+		status = machineidv1.BotInstanceStatus_builder{
+			LatestHeartbeats: []*machineidv1.BotInstanceStatusHeartbeat{
+				machineidv1.BotInstanceStatusHeartbeat_builder{
+					Hostname:   s.hostname,
+					Version:    s.version,
+					RecordedAt: &timestamppb.Timestamp{Seconds: s.activeAt},
+				}.Build(),
+			},
 		}.Build()
-
-		_, err := p.botInstanceService.CreateBotInstance(ctx, instance)
-		require.NoError(t, err)
 	}
-
-	// Let the cache catch up
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", nil)
-		require.NoError(t, err)
-		require.Len(t, results, 10)
-	}, 10*time.Second, 100*time.Millisecond)
-
-	results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		FilterSearchTerm: "host-1",
-	})
-	require.NoError(t, err)
-	require.Len(t, results, 5)
+	return machineidv1.BotInstance_builder{
+		Kind:     types.KindBotInstance,
+		Version:  types.V1,
+		Scope:    s.scope,
+		Metadata: &headerv1.Metadata{},
+		Spec: machineidv1.BotInstanceSpec_builder{
+			BotName:    s.botName,
+			InstanceId: s.id,
+		}.Build(),
+		Status: status,
+	}.Build()
 }
 
-// TestBotInstanceCacheQueryFilter tests that cache items are filtered by query.
-func TestBotInstanceCacheQueryFilter(t *testing.T) {
+// TestBotInstanceCacheList exercises Cache.ListBotInstances across filtering and
+// sorting.
+func TestBotInstanceCacheList(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	{
-		_, err := p.botInstanceService.CreateBotInstance(ctx, machineidv1.BotInstance_builder{
-			Kind:     types.KindBotInstance,
-			Version:  types.V1,
-			Metadata: &headerv1.Metadata{},
-			Spec: machineidv1.BotInstanceSpec_builder{
-				BotName:    "bot-1",
-				InstanceId: "00000000-0000-0000-0000-000000000000",
-			}.Build(),
-			Status: machineidv1.BotInstanceStatus_builder{
-				LatestHeartbeats: []*machineidv1.BotInstanceStatusHeartbeat{
-					machineidv1.BotInstanceStatusHeartbeat_builder{
-						Hostname: "host-1",
-					}.Build(),
-				},
-			}.Build(),
-		}.Build())
-		require.NoError(t, err)
+	botInstanceIDs := func(instances []*machineidv1.BotInstance) []string {
+		out := make([]string, 0, len(instances))
+		for _, b := range instances {
+			out = append(out, b.GetSpec().GetInstanceId())
+		}
+		return out
 	}
 
-	{
-		_, err := p.botInstanceService.CreateBotInstance(ctx, machineidv1.BotInstance_builder{
-			Kind:     types.KindBotInstance,
-			Version:  types.V1,
-			Metadata: &headerv1.Metadata{},
-			Spec: machineidv1.BotInstanceSpec_builder{
-				BotName:    "bot-1",
-				InstanceId: uuid.New().String(),
-			}.Build(),
-			Status: machineidv1.BotInstanceStatus_builder{
-				LatestHeartbeats: []*machineidv1.BotInstanceStatusHeartbeat{
-					machineidv1.BotInstanceStatusHeartbeat_builder{
-						Hostname: "host-2",
-					}.Build(),
-				},
-			}.Build(),
-		}.Build())
-		require.NoError(t, err)
+	sortInstances := []botInstanceSpec{
+		{botName: "alpha", id: "i-a", activeAt: 200, version: "2.0.0", hostname: "host-2"},
+		{botName: "beta", id: "i-b", activeAt: 100, version: "2.0.0-rc1", hostname: "host-3"},
+		{scope: "/east", botName: "alpha", id: "i-c", activeAt: 300, version: "1.0.0", hostname: "host-1"},
 	}
 
-	// Let the cache catch up
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", nil)
-		require.NoError(t, err)
-		require.Len(t, results, 2)
-	}, 10*time.Second, 100*time.Millisecond)
-
-	results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		FilterQuery: `status.latest_heartbeat.hostname == "host-1"`,
-	})
-	require.NoError(t, err)
-	require.Len(t, results, 1)
-	require.Equal(t, "00000000-0000-0000-0000-000000000000", results[0].GetSpec().GetInstanceId())
-}
-
-// TestBotInstanceCacheSorting tests that cache items are sorted.
-func TestBotInstanceCacheSorting(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	items := []struct {
-		botName           string
-		instanceId        string
-		recordedAtSeconds int64
-		version           string
-		hostname          string
-	}{
-		{"bot-1", "instance-1", 2, "2.0.0", "hostname-2"},
-		{"bot-1", "instance-3", 1, "2.0.0-rc1", "hostname-3"},
-		{"bot-2", "instance-2", 3, "1.0.0", "hostname-1"},
-	}
-
-	for _, b := range items {
-		instance := machineidv1.BotInstance_builder{
-			Kind:     types.KindBotInstance,
-			Version:  types.V1,
-			Metadata: &headerv1.Metadata{},
-			Spec: machineidv1.BotInstanceSpec_builder{
-				BotName:    b.botName,
-				InstanceId: b.instanceId,
-			}.Build(),
-			Status: machineidv1.BotInstanceStatus_builder{
-				LatestHeartbeats: []*machineidv1.BotInstanceStatusHeartbeat{
-					machineidv1.BotInstanceStatusHeartbeat_builder{
-						RecordedAt: &timestamppb.Timestamp{
-							Seconds: b.recordedAtSeconds,
-						},
-						Version:  b.version,
-						Hostname: b.hostname,
-					}.Build(),
-				},
-			}.Build(),
-		}.Build()
-
-		_, err := p.botInstanceService.CreateBotInstance(ctx, instance)
-		require.NoError(t, err)
-	}
-
-	// Let the cache catch up
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", nil)
-		require.NoError(t, err)
-		require.Len(t, results, 3)
-	}, 10*time.Second, 100*time.Millisecond)
-
-	t.Run("sort ascending by active_at_latest", func(t *testing.T) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-			SortField: "active_at_latest",
-			SortDesc:  false,
-		})
-		require.NoError(t, err)
-		require.Len(t, results, 3)
-		assert.Equal(t, "instance-3", results[0].GetMetadata().GetName())
-		assert.Equal(t, "instance-1", results[1].GetMetadata().GetName())
-		assert.Equal(t, "instance-2", results[2].GetMetadata().GetName())
-	})
-
-	t.Run("sort descending by active_at_latest", func(t *testing.T) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-			SortField: "active_at_latest",
-			SortDesc:  true,
-		})
-		require.NoError(t, err)
-		require.Len(t, results, 3)
-		assert.Equal(t, "instance-2", results[0].GetMetadata().GetName())
-		assert.Equal(t, "instance-1", results[1].GetMetadata().GetName())
-		assert.Equal(t, "instance-3", results[2].GetMetadata().GetName())
-	})
-
-	t.Run("sort ascending by bot_name", func(t *testing.T) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", nil) // empty sort should default to `bot_name:asc`
-		require.NoError(t, err)
-		require.Len(t, results, 3)
-		assert.Equal(t, "instance-1", results[0].GetMetadata().GetName())
-		assert.Equal(t, "instance-3", results[1].GetMetadata().GetName())
-		assert.Equal(t, "instance-2", results[2].GetMetadata().GetName())
-	})
-
-	t.Run("sort descending by bot_name", func(t *testing.T) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-			SortField: "bot_name",
-			SortDesc:  true,
-		})
-		require.NoError(t, err)
-		require.Len(t, results, 3)
-		assert.Equal(t, "instance-2", results[0].GetMetadata().GetName())
-		assert.Equal(t, "instance-3", results[1].GetMetadata().GetName())
-		assert.Equal(t, "instance-1", results[2].GetMetadata().GetName())
-	})
-
-	t.Run("sort ascending by version", func(t *testing.T) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-			SortField: "version_latest",
-			SortDesc:  false,
-		})
-		require.NoError(t, err)
-		require.Len(t, results, 3)
-		assert.Equal(t, "instance-2", results[0].GetMetadata().GetName())
-		assert.Equal(t, "instance-3", results[1].GetMetadata().GetName())
-		assert.Equal(t, "instance-1", results[2].GetMetadata().GetName())
-	})
-
-	t.Run("sort descending by version", func(t *testing.T) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-			SortField: "version_latest",
-			SortDesc:  true,
-		})
-		require.NoError(t, err)
-		require.Len(t, results, 3)
-		assert.Equal(t, "instance-1", results[0].GetMetadata().GetName())
-		assert.Equal(t, "instance-3", results[1].GetMetadata().GetName())
-		assert.Equal(t, "instance-2", results[2].GetMetadata().GetName())
-	})
-
-	t.Run("sort ascending by hostname", func(t *testing.T) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-			SortField: "host_name_latest",
-			SortDesc:  false,
-		})
-		require.NoError(t, err)
-		require.Len(t, results, 3)
-		require.Equal(t, "instance-2", results[0].GetMetadata().GetName())
-		require.Equal(t, "instance-1", results[1].GetMetadata().GetName())
-		require.Equal(t, "instance-3", results[2].GetMetadata().GetName())
-	})
-
-	t.Run("sort descending by hostname", func(t *testing.T) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-			SortField: "host_name_latest",
-			SortDesc:  true,
-		})
-		require.NoError(t, err)
-		require.Len(t, results, 3)
-		require.Equal(t, "instance-3", results[0].GetMetadata().GetName())
-		require.Equal(t, "instance-1", results[1].GetMetadata().GetName())
-		require.Equal(t, "instance-2", results[2].GetMetadata().GetName())
-	})
-
-	t.Run("sort invalid field", func(t *testing.T) {
-		_, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-			SortField: "blah",
-		})
-		require.Error(t, err)
-		assert.ErrorContains(t, err, `unsupported sort "blah" but expected bot_name, active_at_latest, version_latest or host_name_latest`)
-	})
-}
-
-// TestBotInstanceCacheFilterFn tests that FilterFn is applied during cache
-// iteration and that pages are filled correctly even when some items are
-// filtered out.
-func TestBotInstanceCacheFilterFn(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	// Create 10 instances across two bots: bot-0 and bot-1.
-	for n := range 10 {
-		_, err := p.botInstanceService.CreateBotInstance(ctx, machineidv1.BotInstance_builder{
-			Kind:     types.KindBotInstance,
-			Version:  types.V1,
-			Metadata: &headerv1.Metadata{},
-			Spec: machineidv1.BotInstanceSpec_builder{
-				BotName:    "bot-" + strconv.Itoa(n%2),
-				InstanceId: "instance-" + strconv.Itoa(n),
-			}.Build(),
-			Status: &machineidv1.BotInstanceStatus{},
-		}.Build())
-		require.NoError(t, err)
-	}
-
-	// Let the cache catch up
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", nil)
-		require.NoError(t, err)
-		require.Len(t, results, 10)
-	}, 10*time.Second, 100*time.Millisecond)
-
-	// FilterFn that only accepts even-numbered instances.
-	filterFn := func(b *machineidv1.BotInstance) bool {
+	evenFilter := func(b *machineidv1.BotInstance) bool {
 		id := b.GetSpec().GetInstanceId()
-		n := id[len(id)-1]
-		return n == '0' || n == '2' || n == '4' || n == '6' || n == '8'
+		return (id[len(id)-1]-'0')%2 == 0
 	}
 
-	// FilterFn alone: all even instances across both bots.
-	results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		FilterFn: filterFn,
-	})
-	require.NoError(t, err)
-	require.Len(t, results, 5)
-
-	// Pages should be full: request 3 items with a filter that accepts half.
-	results, nextPageToken, err := p.cache.ListBotInstances(ctx, 3, "", &services.ListBotInstancesRequestOptions{
-		FilterFn: filterFn,
-	})
-	require.NoError(t, err)
-	require.Len(t, results, 3)
-	require.NotEmpty(t, nextPageToken)
-
-	// Next page should contain the remaining 2 items.
-	results, nextPageToken, err = p.cache.ListBotInstances(ctx, 3, nextPageToken, &services.ListBotInstancesRequestOptions{
-		FilterFn: filterFn,
-	})
-	require.NoError(t, err)
-	require.Len(t, results, 2)
-	require.Empty(t, nextPageToken)
-
-	// FilterFn composed with FilterBotName: bot-0 has instances 0,2,4,6,8
-	// (even-numbered), all of which pass the FilterFn. bot-1 has instances
-	// 1,3,5,7,9 (odd-numbered), none of which pass the FilterFn.
-	results, _, err = p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		FilterBotName: "bot-0",
-		FilterFn:      filterFn,
-	})
-	require.NoError(t, err)
-	require.Len(t, results, 5)
-	for _, b := range results {
-		require.Equal(t, "bot-0", b.GetSpec().GetBotName())
+	filterFnInstances := []botInstanceSpec{
+		{botName: "bot", id: "i-0"},
+		{botName: "bot", id: "i-1"},
+		{botName: "bot", id: "i-2"},
+		{botName: "bot", id: "i-3"},
+		{scope: "/s", botName: "bot", id: "i-4"},
+		{scope: "/s", botName: "bot", id: "i-5"},
 	}
 
-	// bot-1 instances are all odd-numbered, so FilterFn rejects them all.
-	results, _, err = p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		FilterBotName: "bot-1",
-		FilterFn:      filterFn,
-	})
-	require.NoError(t, err)
-	require.Empty(t, results)
+	tests := []struct {
+		name      string
+		instances []botInstanceSpec
+		opts      *services.ListBotInstancesRequestOptions
+		want      []string
+		wantErr   string
+	}{
+		{
+			name: "no filter spans all scopes, unscoped first",
+			instances: []botInstanceSpec{
+				{botName: "bot-a", id: "u1"},
+				{scope: "/foo", botName: "bot-b", id: "s1"},
+				{botName: "bot-c", id: "u2"},
+			},
+			want: []string{"u1", "u2", "s1"},
+		},
+		{
+			name: "bot name filter matches only the unscoped bot of that name",
+			instances: []botInstanceSpec{
+				{botName: "web", id: "web-a"},
+				{botName: "web", id: "web-b"},
+				{scope: "/prod", botName: "web", id: "web-c"},
+				{botName: "db", id: "db-a"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterBotName: "web"},
+			want: []string{"web-a", "web-b"},
+		},
+		{
+			name: "bot name and scope filter matches the scoped bot",
+			instances: []botInstanceSpec{
+				{botName: "web", id: "web-u"},
+				{scope: "/prod", botName: "web", id: "web-p1"},
+				{scope: "/prod", botName: "web", id: "web-p2"},
+				{scope: "/prod", botName: "api", id: "api-p"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterBotName: "web", FilterBotScope: "/prod"},
+			want: []string{"web-p1", "web-p2"},
+		},
+		{
+			name: "search term matches across scopes",
+			instances: []botInstanceSpec{
+				{botName: "runner", id: "r1", hostname: "host-match"},
+				{scope: "/foo", botName: "runner", id: "r2", hostname: "host-match"},
+				{botName: "runner", id: "r3", hostname: "host-other"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterSearchTerm: "host-match"},
+			want: []string{"r1", "r2"},
+		},
+		{
+			name: "predicate query matches across scopes",
+			instances: []botInstanceSpec{
+				{botName: "q", id: "q1", hostname: "host-1"},
+				{scope: "/foo", botName: "q", id: "q2", hostname: "host-1"},
+				{botName: "q", id: "q3", hostname: "host-2"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterQuery: `status.latest_heartbeat.hostname == "host-1"`},
+			want: []string{"q1", "q2"},
+		},
+		{
+			name:      "sort by bot_name ascending groups unscoped before scoped",
+			instances: sortInstances,
+			opts:      &services.ListBotInstancesRequestOptions{SortField: "bot_name"},
+			want:      []string{"i-a", "i-b", "i-c"},
+		},
+		{
+			name:      "sort by bot_name descending",
+			instances: sortInstances,
+			opts:      &services.ListBotInstancesRequestOptions{SortField: "bot_name", SortDesc: true},
+			want:      []string{"i-c", "i-b", "i-a"},
+		},
+		{
+			name:      "sort by active_at ascending is global across scopes",
+			instances: sortInstances,
+			opts:      &services.ListBotInstancesRequestOptions{SortField: "active_at_latest"},
+			want:      []string{"i-b", "i-a", "i-c"},
+		},
+		{
+			name:      "sort by active_at descending",
+			instances: sortInstances,
+			opts:      &services.ListBotInstancesRequestOptions{SortField: "active_at_latest", SortDesc: true},
+			want:      []string{"i-c", "i-a", "i-b"},
+		},
+		{
+			name:      "sort by version ascending is global across scopes",
+			instances: sortInstances,
+			opts:      &services.ListBotInstancesRequestOptions{SortField: "version_latest"},
+			want:      []string{"i-c", "i-b", "i-a"},
+		},
+		{
+			name:      "sort by version descending",
+			instances: sortInstances,
+			opts:      &services.ListBotInstancesRequestOptions{SortField: "version_latest", SortDesc: true},
+			want:      []string{"i-a", "i-b", "i-c"},
+		},
+		{
+			name:      "sort by host_name ascending is global across scopes",
+			instances: sortInstances,
+			opts:      &services.ListBotInstancesRequestOptions{SortField: "host_name_latest"},
+			want:      []string{"i-c", "i-a", "i-b"},
+		},
+		{
+			name:      "sort by host_name descending",
+			instances: sortInstances,
+			opts:      &services.ListBotInstancesRequestOptions{SortField: "host_name_latest", SortDesc: true},
+			want:      []string{"i-b", "i-a", "i-c"},
+		},
+		{
+			name:      "unsupported sort field is rejected",
+			instances: []botInstanceSpec{{botName: "bot", id: "x1"}},
+			opts:      &services.ListBotInstancesRequestOptions{SortField: "nope"},
+			wantErr:   `unsupported sort "nope"`,
+		},
+		{
+			name:      "filter fn spans scopes",
+			instances: filterFnInstances,
+			opts:      &services.ListBotInstancesRequestOptions{FilterFn: evenFilter},
+			want:      []string{"i-0", "i-2", "i-4"},
+		},
+		{
+			name:      "filter fn combined with bot name filter",
+			instances: filterFnInstances,
+			opts:      &services.ListBotInstancesRequestOptions{FilterBotName: "bot", FilterFn: evenFilter},
+			want:      []string{"i-0", "i-2"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx := t.Context()
+
+				p := newTestPack(t, ForAuth)
+				t.Cleanup(p.Close)
+
+				for _, s := range tc.instances {
+					_, err := p.botInstanceService.CreateBotInstance(ctx, buildBotInstance(s))
+					require.NoError(t, err)
+				}
+
+				synctest.Wait()
+
+				got, _, err := p.cache.ListBotInstances(ctx, 0, "", tc.opts)
+				if tc.wantErr != "" {
+					assert.ErrorContains(t, err, tc.wantErr)
+					return
+				}
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, botInstanceIDs(got))
+
+				// Also assert that pagination produces the same results (in
+				// particular, we're looking for cursor keys not lining up
+				// leading to skipped entries)
+				paged, err := stream.Collect(
+					clientutils.ResourcesWithPageSize(
+						ctx,
+						func(ctx context.Context, pageSize int, token string) ([]*machineidv1.BotInstance, string, error) {
+							return p.cache.ListBotInstances(ctx, pageSize, token, tc.opts)
+						},
+						2,
+					),
+				)
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, botInstanceIDs(paged))
+			})
+		})
+	}
 }
 
 // TestBotInstanceCacheFallback tests that requests fallback to the upstream when the cache is unhealthy.

--- a/lib/cache/inventory/inventory_cache_test.go
+++ b/lib/cache/inventory/inventory_cache_test.go
@@ -1759,7 +1759,7 @@ func (m *mockBotInstanceCache) DeleteBotInstance(ctx context.Context, req *machi
 	return nil
 }
 
-func (m *mockBotInstanceCache) PatchBotInstance(ctx context.Context, botScope, botName, instanceID string, update func(*machineidv1.BotInstance) (*machineidv1.BotInstance, error)) (*machineidv1.BotInstance, error) {
+func (m *mockBotInstanceCache) PatchBotInstance(ctx context.Context, opts services.PatchBotInstanceOpts) (*machineidv1.BotInstance, error) {
 	return nil, nil
 }
 

--- a/lib/cache/inventory/inventory_cache_test.go
+++ b/lib/cache/inventory/inventory_cache_test.go
@@ -1751,15 +1751,15 @@ func (m *mockBotInstanceCache) ListBotInstances(ctx context.Context, pageSize in
 	return m.bots, "", nil
 }
 
-func (m *mockBotInstanceCache) GetBotInstance(ctx context.Context, botName, instanceID string) (*machineidv1.BotInstance, error) {
+func (m *mockBotInstanceCache) GetBotInstance(ctx context.Context, req *machineidv1.GetBotInstanceRequest) (*machineidv1.BotInstance, error) {
 	return nil, nil
 }
 
-func (m *mockBotInstanceCache) DeleteBotInstance(ctx context.Context, botName, instanceID string) error {
+func (m *mockBotInstanceCache) DeleteBotInstance(ctx context.Context, req *machineidv1.DeleteBotInstanceRequest) error {
 	return nil
 }
 
-func (m *mockBotInstanceCache) PatchBotInstance(ctx context.Context, botName, instanceID string, update func(*machineidv1.BotInstance) (*machineidv1.BotInstance, error)) (*machineidv1.BotInstance, error) {
+func (m *mockBotInstanceCache) PatchBotInstance(ctx context.Context, botScope, botName, instanceID string, update func(*machineidv1.BotInstance) (*machineidv1.BotInstance, error)) (*machineidv1.BotInstance, error) {
 	return nil, nil
 }
 

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -1982,8 +1982,11 @@ func TestJoinBoundKeypair_ScopedToken(t *testing.T) {
 	firstInstance, generation := testExtractBotParamsFromCerts(t, joinResult.Certs)
 	require.Equal(t, uint64(1), generation)
 
-	// The BotInstance should have the scope set.
+	// The BotInstance should have the scope set. A bot is identified by
+	// (scope, name), so the read must declare the bot's scope to address the
+	// scoped instance.
 	botInstance, err := adminClient.BotInstanceServiceClient().GetBotInstance(ctx, machineidv1pb.GetBotInstanceRequest_builder{
+		BotScope:   "/test",
 		BotName:    "test-scoped",
 		InstanceId: firstInstance,
 	}.Build())

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2548,7 +2548,7 @@ func (process *TeleportProcess) initAuthService() error {
 				PrimaryCache:       cache,
 				Events:             as.Services,
 				Inventory:          as.Services,
-				BotInstanceBackend: as.Services,
+				BotInstanceBackend: as.Services.BotInstance,
 				Logger:             process.logger.With(teleport.ComponentKey, "inventory.cache"),
 				MetricsRegistry:    process.metricsRegistry.Wrap("inventory_cache"),
 			})

--- a/lib/services/bot_instance.go
+++ b/lib/services/bot_instance.go
@@ -26,6 +26,7 @@ import (
 
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1/expression"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/utils/typical"
 )
 
@@ -58,14 +59,23 @@ type BotInstance interface {
 	// by the request's (bot_scope, bot_name) with the given instance ID.
 	DeleteBotInstance(ctx context.Context, req *machineidv1.DeleteBotInstanceRequest) error
 
-	// PatchBotInstance fetches an existing bot instance by bot scope, bot name
-	// and instance ID, then calls `updateFn` to apply any changes before
-	// persisting the resource.
-	PatchBotInstance(
-		ctx context.Context,
-		botScope, botName, instanceID string,
-		updateFn func(*machineidv1.BotInstance) (*machineidv1.BotInstance, error),
-	) (*machineidv1.BotInstance, error)
+	// PatchBotInstance fetches the existing bot instance identified by the
+	// given options, then calls the options' UpdateFn to apply any changes
+	// before persisting the resource.
+	PatchBotInstance(ctx context.Context, opts PatchBotInstanceOpts) (*machineidv1.BotInstance, error)
+}
+
+// PatchBotInstanceOpts identifies the bot instance to be patched by
+// [BotInstance.PatchBotInstance] and holds the patch to apply to it.
+type PatchBotInstanceOpts struct {
+	// Bot is the scope-qualified name of the bot that owns the instance. The
+	// scope must be empty if the bot is unscoped.
+	Bot scopes.QualifiedName
+	// InstanceID is the ID of the instance to patch.
+	InstanceID string
+	// UpdateFn is applied to the fetched instance to produce the instance to
+	// persist. It may be called more than once if the write is retried.
+	UpdateFn func(*machineidv1.BotInstance) (*machineidv1.BotInstance, error)
 }
 
 // ValidateBotInstance verifies that required fields for a new BotInstance are present
@@ -168,10 +178,12 @@ type ListBotInstancesRequestOptions struct {
 	// The name of the Bot to list BotInstances for. If empty, all BotInstances
 	// will be listed.
 	FilterBotName string
-	// The scope of the Bot to list BotInstances for. Combined with
-	// FilterBotName to identify a scoped bot; leave empty if the bot is
-	// unscoped. If set without FilterBotName, all BotInstances in the scope
-	// will be listed.
+	// The scope of the Bot to list BotInstances for. A bot is identified by the
+	// pair (scope, name), so this only ever qualifies FilterBotName and must be
+	// set alongside it; setting it without FilterBotName is an error. Leave
+	// empty if the bot is unscoped. This is deliberately not a scope filter for
+	// listing every BotInstance in a scope - that will be a separate field with
+	// explicit exact/descendant control.
 	FilterBotScope string
 	// A search term used to filter the results. If non-empty, it's used to
 	// match against supported fields.

--- a/lib/services/bot_instance.go
+++ b/lib/services/bot_instance.go
@@ -36,25 +36,34 @@ import (
 const BotUserPrefix = "bot-"
 
 // BotInstance is an interface for the BotInstance service.
+//
+// Bot instances belong to a bot, and bots are identified by their scope and
+// name: instances of scoped bots are stored in a scope-namespaced key range,
+// separate from instances of unscoped bots. Methods addressing an individual
+// instance take the owning bot's scope, which must be empty if the bot is
+// unscoped.
 type BotInstance interface {
-	// CreateBotInstance
+	// CreateBotInstance creates a new bot instance. It is stored in the key
+	// range determined by the scope set on the instance itself.
 	CreateBotInstance(ctx context.Context, botInstance *machineidv1.BotInstance) (*machineidv1.BotInstance, error)
 
-	// GetBotInstance
-	GetBotInstance(ctx context.Context, botName, instanceID string) (*machineidv1.BotInstance, error)
+	// GetBotInstance returns the bot instance owned by the bot identified by
+	// the request's (bot_scope, bot_name) with the given instance ID.
+	GetBotInstance(ctx context.Context, req *machineidv1.GetBotInstanceRequest) (*machineidv1.BotInstance, error)
 
 	// ListBotInstances
 	ListBotInstances(ctx context.Context, pageSize int, lastToken string, options *ListBotInstancesRequestOptions) ([]*machineidv1.BotInstance, string, error)
 
-	// DeleteBotInstance
-	DeleteBotInstance(ctx context.Context, botName, instanceID string) error
+	// DeleteBotInstance deletes the bot instance owned by the bot identified
+	// by the request's (bot_scope, bot_name) with the given instance ID.
+	DeleteBotInstance(ctx context.Context, req *machineidv1.DeleteBotInstanceRequest) error
 
-	// PatchBotInstance fetches an existing bot instance by bot name and ID,
-	// then calls `updateFn` to apply any changes before persisting the
-	// resource.
+	// PatchBotInstance fetches an existing bot instance by bot scope, bot name
+	// and instance ID, then calls `updateFn` to apply any changes before
+	// persisting the resource.
 	PatchBotInstance(
 		ctx context.Context,
-		botName, instanceID string,
+		botScope, botName, instanceID string,
 		updateFn func(*machineidv1.BotInstance) (*machineidv1.BotInstance, error),
 	) (*machineidv1.BotInstance, error)
 }
@@ -159,6 +168,11 @@ type ListBotInstancesRequestOptions struct {
 	// The name of the Bot to list BotInstances for. If empty, all BotInstances
 	// will be listed.
 	FilterBotName string
+	// The scope of the Bot to list BotInstances for. Combined with
+	// FilterBotName to identify a scoped bot; leave empty if the bot is
+	// unscoped. If set without FilterBotName, all BotInstances in the scope
+	// will be listed.
+	FilterBotScope string
 	// A search term used to filter the results. If non-empty, it's used to
 	// match against supported fields.
 	FilterSearchTerm string
@@ -187,6 +201,13 @@ func (o *ListBotInstancesRequestOptions) GetFilterBotName() string {
 		return ""
 	}
 	return o.FilterBotName
+}
+
+func (o *ListBotInstancesRequestOptions) GetFilterBotScope() string {
+	if o == nil {
+		return ""
+	}
+	return o.FilterBotScope
 }
 
 func (o *ListBotInstancesRequestOptions) GetFilterSearchTerm() string {

--- a/lib/services/local/bot_instance.go
+++ b/lib/services/local/bot_instance.go
@@ -28,32 +28,49 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1/expression"
 	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
 	"github.com/gravitational/teleport/lib/utils/typical"
 )
 
-const (
-	botInstancePrefix = "bot_instance"
-)
+// botInstancePrefix is the backend prefix for bot instances. Instances of
+// scoped bots are namespaced by their bot's scope under the shared
+// scopedPrefix, keyed as
+// scoped/bot_instance/<encoded scope>/<bot name>/<instance id>. Instances
+// of unscoped bots remain keyed as bot_instance/<bot name>/<instance id>.
+const botInstancePrefix = "bot_instance"
+
+// botInstanceUnscopedWatchPrefix returns the backend key range containing
+// instances of unscoped bots.
+func botInstanceUnscopedWatchPrefix() backend.Key {
+	return backend.NewKey(botInstancePrefix)
+}
+
+// botInstanceScopedWatchPrefix returns the backend key range containing
+// instances of scoped bots.
+func botInstanceScopedWatchPrefix() backend.Key {
+	return backend.NewKey(scopedPrefix, botInstancePrefix)
+}
 
 // BotInstanceService exposes backend functionality for storing bot instances.
 type BotInstanceService struct {
-	service *generic.ServiceWrapper[*machineidv1.BotInstance]
+	service *generic.ScopeAwareServiceWrapper[*machineidv1.BotInstance]
 
 	clock clockwork.Clock
 }
 
 // NewBotInstanceService creates a new BotInstanceService with the given backend.
 func NewBotInstanceService(b backend.Backend, clock clockwork.Clock) (*BotInstanceService, error) {
-	service, err := generic.NewServiceWrapper(
-		generic.ServiceConfig[*machineidv1.BotInstance]{
-			Backend:       b,
-			ResourceKind:  types.KindBotInstance,
-			BackendPrefix: backend.NewKey(botInstancePrefix),
-			MarshalFunc:   services.MarshalBotInstance,
-			UnmarshalFunc: services.UnmarshalBotInstance,
-			ValidateFunc:  services.ValidateBotInstance,
+	service, err := generic.NewScopeAwareServiceWrapper(
+		generic.ScopeAwareServiceWrapperConfig[*machineidv1.BotInstance]{
+			Backend:               b,
+			ResourceKind:          types.KindBotInstance,
+			UnscopedBackendPrefix: backend.NewKey(botInstancePrefix),
+			ScopedBackendPrefix:   backend.NewKey(scopedPrefix, botInstancePrefix),
+			MarshalFunc:           services.MarshalBotInstance,
+			UnmarshalFunc:         services.UnmarshalBotInstance,
+			ValidateFunc:          services.ValidateBotInstance,
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -64,7 +81,16 @@ func NewBotInstanceService(b backend.Backend, clock clockwork.Clock) (*BotInstan
 	}, nil
 }
 
-// CreateBotInstance inserts a new BotInstance into the backend.
+// serviceForBot returns a single-range service addressing the instances of the
+// bot identified by (botScope, botName): the bot's sub-range of the scoped key
+// range when botScope is non-empty, else its sub-range of the unscoped range.
+func (b *BotInstanceService) serviceForBot(botScope, botName string) (*generic.ServiceWrapper[*machineidv1.BotInstance], error) {
+	service, err := b.service.WithScopedResourcePrefix(scopes.QualifiedName{Scope: botScope, Name: botName})
+	return service, trace.Wrap(err)
+}
+
+// CreateBotInstance inserts a new BotInstance into the backend. It is stored
+// in the key range determined by the scope set on the instance itself.
 //
 // Note that new BotInstances will have their .Metadata.Name overwritten by the
 // instance UUID.
@@ -78,21 +104,29 @@ func (b *BotInstanceService) CreateBotInstance(ctx context.Context, instance *ma
 
 	instance.GetMetadata().SetName(instance.GetSpec().GetInstanceId())
 
-	serviceWithPrefix := b.service.WithPrefix(instance.GetSpec().GetBotName())
+	serviceWithPrefix, err := b.serviceForBot(instance.GetScope(), instance.GetSpec().GetBotName())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	created, err := serviceWithPrefix.CreateResource(ctx, instance)
 	return created, trace.Wrap(err)
 }
 
-// GetBotInstance retreives a specific bot instance given a bot name and
-// instance ID.
-func (b *BotInstanceService) GetBotInstance(ctx context.Context, botName, instanceID string) (*machineidv1.BotInstance, error) {
-	serviceWithPrefix := b.service.WithPrefix(botName)
-	instance, err := serviceWithPrefix.GetResource(ctx, instanceID)
+// GetBotInstance retreives a specific bot instance given a bot scope, bot name
+// and instance ID. The scope must be empty if the owning bot is unscoped.
+func (b *BotInstanceService) GetBotInstance(ctx context.Context, req *machineidv1.GetBotInstanceRequest) (*machineidv1.BotInstance, error) {
+	serviceWithPrefix, err := b.serviceForBot(req.GetBotScope(), req.GetBotName())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	instance, err := serviceWithPrefix.GetResource(ctx, req.GetInstanceId())
 	return instance, trace.Wrap(err)
 }
 
-// ListBotInstances lists all matching bot instances. A bot name and/or search terms can be optionally provided.
-// If an non-empty bot name is provided, only instances for that bot will be fetched.
+// ListBotInstances lists all matching bot instances. A bot (scope, name) and/or search terms can be optionally provided.
+// If an non-empty bot name is provided, only instances for that bot will be fetched. The bot scope must be
+// provided alongside the name for a scoped bot's instances; with no bot filter, instances for all bots are
+// listed, unscoped bots' instances first.
 // If an non-empty search term is provided, only instances with a value containing the term in supported fields are fetched.
 // Supported search fields include; bot name, instance id, hostname (latest), tbot version (latest), join method (latest).
 // Sorting by bot name in ascending order is supported - an error is returned for any other sort type.
@@ -104,12 +138,26 @@ func (b *BotInstanceService) ListBotInstances(ctx context.Context, pageSize int,
 		return nil, "", trace.CompareFailed("unsupported sort, only ascending order is supported")
 	}
 
-	var service *generic.ServiceWrapper[*machineidv1.BotInstance]
-	if options.GetFilterBotName() == "" {
-		// If botName is empty, return instances for all bots by not using a service prefix
+	// Satisfied by both the scope-aware wrapper (unified listing across the
+	// unscoped and scoped key ranges) and a single-range service routed by the
+	// bot filter.
+	var service interface {
+		ListResources(ctx context.Context, pageSize int, nextToken string) ([]*machineidv1.BotInstance, string, error)
+		ListResourcesWithFilter(ctx context.Context, pageSize int, nextToken string, matcher func(*machineidv1.BotInstance) bool) ([]*machineidv1.BotInstance, string, error)
+	}
+	if options.GetFilterBotName() == "" && options.GetFilterBotScope() == "" {
+		// If no bot filter is set, return instances for all bots across both
+		// the unscoped and scoped key ranges.
 		service = b.service
 	} else {
-		service = b.service.WithPrefix(options.GetFilterBotName())
+		routed, err := b.service.WithScopePrefix(options.GetFilterBotScope())
+		if err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+		if options.GetFilterBotName() != "" {
+			routed = routed.WithPrefix(options.GetFilterBotName())
+		}
+		service = routed
 	}
 
 	var exp typical.Expression[*expression.Environment, bool]
@@ -143,11 +191,15 @@ func (b *BotInstanceService) ListBotInstances(ctx context.Context, pageSize int,
 	return r, nextToken, trace.Wrap(err)
 }
 
-// DeleteBotInstance deletes a specific bot instance matching the given bot name
-// and instance ID.
-func (b *BotInstanceService) DeleteBotInstance(ctx context.Context, botName, instanceID string) error {
-	serviceWithPrefix := b.service.WithPrefix(botName)
-	return trace.Wrap(serviceWithPrefix.DeleteResource(ctx, instanceID))
+// DeleteBotInstance deletes a specific bot instance matching the given bot
+// scope, bot name and instance ID. The scope must be empty if the owning bot
+// is unscoped.
+func (b *BotInstanceService) DeleteBotInstance(ctx context.Context, req *machineidv1.DeleteBotInstanceRequest) error {
+	serviceWithPrefix, err := b.serviceForBot(req.GetBotScope(), req.GetBotName())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(serviceWithPrefix.DeleteResource(ctx, req.GetInstanceId()))
 }
 
 // DeleteAllBotInstances deletes all bot instances for all bots
@@ -156,18 +208,22 @@ func (b *BotInstanceService) DeleteAllBotInstances(ctx context.Context) error {
 }
 
 // PatchBotInstance uses the supplied function to patch the bot instance
-// matching the given (botName, instanceID) key and persists the patched
-// resource. It will make multiple attempts if a `CompareFailed` error is
-// raised, automatically re-applying `updateFn()`.
+// matching the given (botScope, botName, instanceID) key and persists the
+// patched resource. It will make multiple attempts if a `CompareFailed` error
+// is raised, automatically re-applying `updateFn()`.
 func (b *BotInstanceService) PatchBotInstance(
 	ctx context.Context,
-	botName, instanceID string,
+	botScope, botName, instanceID string,
 	updateFn func(*machineidv1.BotInstance) (*machineidv1.BotInstance, error),
 ) (*machineidv1.BotInstance, error) {
 	const iterLimit = 3
 
 	for range iterLimit {
-		existing, err := b.GetBotInstance(ctx, botName, instanceID)
+		existing, err := b.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{
+			BotScope:   botScope,
+			BotName:    botName,
+			InstanceId: instanceID,
+		}.Build())
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -186,9 +242,14 @@ func (b *BotInstanceService) PatchBotInstance(
 			return nil, trace.BadParameter("spec.instance_id: cannot be patched")
 		case updated.GetSpec().GetBotName() != existing.GetSpec().GetBotName():
 			return nil, trace.BadParameter("spec.bot_name: cannot be patched")
+		case updated.GetScope() != existing.GetScope():
+			return nil, trace.BadParameter("scope: cannot be patched")
 		}
 
-		serviceWithPrefix := b.service.WithPrefix(botName)
+		serviceWithPrefix, err := b.serviceForBot(botScope, botName)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 		lease, err := serviceWithPrefix.ConditionalUpdateResource(ctx, updated)
 		if err != nil {
 			if trace.IsCompareFailed(err) {

--- a/lib/services/local/bot_instance.go
+++ b/lib/services/local/bot_instance.go
@@ -125,8 +125,9 @@ func (b *BotInstanceService) GetBotInstance(ctx context.Context, req *machineidv
 
 // ListBotInstances lists all matching bot instances. A bot (scope, name) and/or search terms can be optionally provided.
 // If an non-empty bot name is provided, only instances for that bot will be fetched. The bot scope must be
-// provided alongside the name for a scoped bot's instances; with no bot filter, instances for all bots are
-// listed, unscoped bots' instances first.
+// provided alongside the name for a scoped bot's instances, and only ever qualifies the name - providing a
+// scope without a name is an error rather than a request for every instance in that scope. With no bot filter,
+// instances for all bots are listed, unscoped bots' instances first.
 // If an non-empty search term is provided, only instances with a value containing the term in supported fields are fetched.
 // Supported search fields include; bot name, instance id, hostname (latest), tbot version (latest), join method (latest).
 // Sorting by bot name in ascending order is supported - an error is returned for any other sort type.
@@ -137,6 +138,12 @@ func (b *BotInstanceService) ListBotInstances(ctx context.Context, pageSize int,
 	if options.GetSortDesc() {
 		return nil, "", trace.CompareFailed("unsupported sort, only ascending order is supported")
 	}
+	// A bot is identified by the pair (scope, name), so the scope filter only
+	// ever qualifies the name filter. Listing a whole scope will be a separate
+	// filter with explicit exact/descendant control.
+	if options.GetFilterBotScope() != "" && options.GetFilterBotName() == "" {
+		return nil, "", trace.BadParameter("bot scope filter requires a bot name filter")
+	}
 
 	// Satisfied by both the scope-aware wrapper (unified listing across the
 	// unscoped and scoped key ranges) and a single-range service routed by the
@@ -145,17 +152,16 @@ func (b *BotInstanceService) ListBotInstances(ctx context.Context, pageSize int,
 		ListResources(ctx context.Context, pageSize int, nextToken string) ([]*machineidv1.BotInstance, string, error)
 		ListResourcesWithFilter(ctx context.Context, pageSize int, nextToken string, matcher func(*machineidv1.BotInstance) bool) ([]*machineidv1.BotInstance, string, error)
 	}
-	if options.GetFilterBotName() == "" && options.GetFilterBotScope() == "" {
+	if options.GetFilterBotName() == "" {
 		// If no bot filter is set, return instances for all bots across both
 		// the unscoped and scoped key ranges.
 		service = b.service
 	} else {
-		routed, err := b.service.WithScopePrefix(options.GetFilterBotScope())
+		// The filter identifies exactly one bot, so read only that bot's
+		// sub-range.
+		routed, err := b.serviceForBot(options.GetFilterBotScope(), options.GetFilterBotName())
 		if err != nil {
 			return nil, "", trace.Wrap(err)
-		}
-		if options.GetFilterBotName() != "" {
-			routed = routed.WithPrefix(options.GetFilterBotName())
 		}
 		service = routed
 	}
@@ -207,28 +213,31 @@ func (b *BotInstanceService) DeleteAllBotInstances(ctx context.Context) error {
 	return trace.Wrap(b.service.DeleteAllResources(ctx))
 }
 
-// PatchBotInstance uses the supplied function to patch the bot instance
-// matching the given (botScope, botName, instanceID) key and persists the
-// patched resource. It will make multiple attempts if a `CompareFailed` error
-// is raised, automatically re-applying `updateFn()`.
+// PatchBotInstance uses the options' UpdateFn to patch the bot instance
+// identified by those same options and persists the patched resource. It will
+// make multiple attempts if a `CompareFailed` error is raised, automatically
+// re-applying UpdateFn.
 func (b *BotInstanceService) PatchBotInstance(
 	ctx context.Context,
-	botScope, botName, instanceID string,
-	updateFn func(*machineidv1.BotInstance) (*machineidv1.BotInstance, error),
+	opts services.PatchBotInstanceOpts,
 ) (*machineidv1.BotInstance, error) {
+	if opts.UpdateFn == nil {
+		return nil, trace.BadParameter("opts.UpdateFn is required")
+	}
+
 	const iterLimit = 3
 
 	for range iterLimit {
 		existing, err := b.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{
-			BotScope:   botScope,
-			BotName:    botName,
-			InstanceId: instanceID,
+			BotScope:   opts.Bot.Scope,
+			BotName:    opts.Bot.Name,
+			InstanceId: opts.InstanceID,
 		}.Build())
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		updated, err := updateFn(utils.CloneProtoMsg(existing))
+		updated, err := opts.UpdateFn(utils.CloneProtoMsg(existing))
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -246,7 +255,7 @@ func (b *BotInstanceService) PatchBotInstance(
 			return nil, trace.BadParameter("scope: cannot be patched")
 		}
 
-		serviceWithPrefix, err := b.serviceForBot(botScope, botName)
+		serviceWithPrefix, err := b.serviceForBot(opts.Bot.Scope, opts.Bot.Name)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/services/local/bot_instance_test.go
+++ b/lib/services/local/bot_instance_test.go
@@ -328,9 +328,13 @@ func TestBotInstanceCRUD(t *testing.T) {
 		Hostname: "foo",
 	}.Build()
 
-	patched, err = service.PatchBotInstance(ctx, "", bi.GetSpec().GetBotName(), bi.GetSpec().GetInstanceId(), func(bi *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
-		bi.GetStatus().SetLatestHeartbeats(append([]*machineidv1.BotInstanceStatusHeartbeat{heartbeat}, bi.GetStatus().GetLatestHeartbeats()...))
-		return bi, nil
+	patched, err = service.PatchBotInstance(ctx, services.PatchBotInstanceOpts{
+		Bot:        scopes.QualifiedName{Name: bi.GetSpec().GetBotName()},
+		InstanceID: bi.GetSpec().GetInstanceId(),
+		UpdateFn: func(bi *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
+			bi.GetStatus().SetLatestHeartbeats(append([]*machineidv1.BotInstanceStatusHeartbeat{heartbeat}, bi.GetStatus().GetLatestHeartbeats()...))
+			return bi, nil
+		},
 	})
 	require.NoError(t, err)
 
@@ -395,15 +399,12 @@ func TestBotInstanceList(t *testing.T) {
 		require.Contains(t, scopedAIds, ins.GetSpec().GetInstanceId())
 	}
 
-	// listing scope /foo without a bot name should return all instances in the
-	// scope
-	fooInstances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
+	// a scope filter only qualifies a bot name, so listing scope /foo without a
+	// bot name is rejected rather than listing the whole scope
+	_, _, err = service.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
 		FilterBotScope: "/foo",
 	})
-	require.Len(t, fooInstances, 2)
-	for _, ins := range fooInstances {
-		require.Contains(t, scopedAIds, ins.GetSpec().GetInstanceId())
-	}
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
 
 	allIds := map[string]struct{}{}
 	for i := range aIds {
@@ -477,18 +478,26 @@ func TestBotInstanceScopedCoexistence(t *testing.T) {
 	require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
 
 	// Patching routes by scope, and the scope itself cannot be patched.
-	patched, err := service.PatchBotInstance(ctx, "/foo", "x", foo.GetSpec().GetInstanceId(), func(bi *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
-		bi.GetStatus().SetLatestHeartbeats([]*machineidv1.BotInstanceStatusHeartbeat{
-			machineidv1.BotInstanceStatusHeartbeat_builder{Hostname: "scoped-host"}.Build(),
-		})
-		return bi, nil
+	patched, err := service.PatchBotInstance(ctx, services.PatchBotInstanceOpts{
+		Bot:        scopes.QualifiedName{Scope: "/foo", Name: "x"},
+		InstanceID: foo.GetSpec().GetInstanceId(),
+		UpdateFn: func(bi *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
+			bi.GetStatus().SetLatestHeartbeats([]*machineidv1.BotInstanceStatusHeartbeat{
+				machineidv1.BotInstanceStatusHeartbeat_builder{Hostname: "scoped-host"}.Build(),
+			})
+			return bi, nil
+		},
 	})
 	require.NoError(t, err)
 	require.Equal(t, "/foo", patched.GetScope())
 
-	_, err = service.PatchBotInstance(ctx, "/foo", "x", foo.GetSpec().GetInstanceId(), func(bi *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
-		bi.SetScope("/other")
-		return bi, nil
+	_, err = service.PatchBotInstance(ctx, services.PatchBotInstanceOpts{
+		Bot:        scopes.QualifiedName{Scope: "/foo", Name: "x"},
+		InstanceID: foo.GetSpec().GetInstanceId(),
+		UpdateFn: func(bi *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
+			bi.SetScope("/other")
+			return bi, nil
+		},
 	})
 	require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
 	require.ErrorContains(t, err, "scope: cannot be patched")

--- a/lib/services/local/bot_instance_test.go
+++ b/lib/services/local/bot_instance_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -79,6 +80,13 @@ func withBotInstanceExpiry(expiry time.Time) func(*machineidv1.BotInstance) {
 		}
 
 		bi.GetMetadata().SetExpires(timestamppb.New(expiry))
+	}
+}
+
+// withBotInstanceScope sets the scope of a bot instance to the given value.
+func withBotInstanceScope(scope string) func(*machineidv1.BotInstance) {
+	return func(bi *machineidv1.BotInstance) {
+		bi.SetScope(scope)
 	}
 }
 
@@ -143,13 +151,13 @@ func withBotInstanceHeartbeatHostname(value string) func(*machineidv1.BotInstanc
 }
 
 // createInstances creates new bot instances for the named bot with random UUIDs
-func createInstances(t *testing.T, ctx context.Context, service *BotInstanceService, botName string, count int) map[string]struct{} {
+func createInstances(t *testing.T, ctx context.Context, service *BotInstanceService, botName string, count int, fns ...func(*machineidv1.BotInstance)) map[string]struct{} {
 	t.Helper()
 
 	ids := map[string]struct{}{}
 
 	for range count {
-		bi := newBotInstance(botName)
+		bi := newBotInstance(botName, fns...)
 		_, err := service.CreateBotInstance(ctx, bi)
 		require.NoError(t, err)
 
@@ -274,7 +282,7 @@ func TestBotInstanceInvalidGetters(t *testing.T) {
 	_, err = service.CreateBotInstance(ctx, newBotInstance("example"))
 	require.NoError(t, err)
 
-	_, err = service.GetBotInstance(ctx, "example", "invalid")
+	_, err = service.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "", BotName: "example", InstanceId: "invalid"}.Build())
 	require.True(t, trace.IsNotFound(err))
 }
 
@@ -303,7 +311,7 @@ func TestBotInstanceCRUD(t *testing.T) {
 	require.Equal(t, bi.GetSpec().GetInstanceId(), patched.GetMetadata().GetName())
 
 	// we should be able to retrieve a matching instance
-	bi2, err := service.GetBotInstance(ctx, bi.GetSpec().GetBotName(), bi.GetSpec().GetInstanceId())
+	bi2, err := service.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "", BotName: bi.GetSpec().GetBotName(), InstanceId: bi.GetSpec().GetInstanceId()}.Build())
 	require.NoError(t, err)
 	require.EqualExportedValues(t, patched, bi2)
 	require.Equal(t, bi.GetMetadata().GetName(), bi2.GetMetadata().GetName())
@@ -320,7 +328,7 @@ func TestBotInstanceCRUD(t *testing.T) {
 		Hostname: "foo",
 	}.Build()
 
-	patched, err = service.PatchBotInstance(ctx, bi.GetSpec().GetBotName(), bi.GetSpec().GetInstanceId(), func(bi *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
+	patched, err = service.PatchBotInstance(ctx, "", bi.GetSpec().GetBotName(), bi.GetSpec().GetInstanceId(), func(bi *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
 		bi.GetStatus().SetLatestHeartbeats(append([]*machineidv1.BotInstanceStatusHeartbeat{heartbeat}, bi.GetStatus().GetLatestHeartbeats()...))
 		return bi, nil
 	})
@@ -330,10 +338,10 @@ func TestBotInstanceCRUD(t *testing.T) {
 	require.EqualExportedValues(t, heartbeat, patched.GetStatus().GetLatestHeartbeats()[0])
 
 	// delete the stored instance
-	require.NoError(t, service.DeleteBotInstance(ctx, bi.GetSpec().GetBotName(), bi.GetSpec().GetInstanceId()))
+	require.NoError(t, service.DeleteBotInstance(ctx, machineidv1.DeleteBotInstanceRequest_builder{BotScope: "", BotName: bi.GetSpec().GetBotName(), InstanceId: bi.GetSpec().GetInstanceId()}.Build()))
 
 	// subsequent delete attempts should fail
-	require.Error(t, service.DeleteBotInstance(ctx, bi.GetSpec().GetBotName(), bi.GetSpec().GetInstanceId()))
+	require.Error(t, service.DeleteBotInstance(ctx, machineidv1.DeleteBotInstanceRequest_builder{BotScope: "", BotName: bi.GetSpec().GetBotName(), InstanceId: bi.GetSpec().GetInstanceId()}.Build()))
 }
 
 // TestBotInstanceList verifies list and filtering by bot functionality for bot
@@ -355,8 +363,11 @@ func TestBotInstanceList(t *testing.T) {
 
 	aIds := createInstances(t, ctx, service, "a", 3)
 	bIds := createInstances(t, ctx, service, "b", 4)
+	// "a" is also the name of a scoped bot in /foo; its instances live in the
+	// scoped key range.
+	scopedAIds := createInstances(t, ctx, service, "a", 2, withBotInstanceScope("/foo"))
 
-	// listing "a" should only return known "a" instances
+	// listing "a" should only return known instances of the unscoped bot "a"
 	aInstances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
 		FilterBotName: "a",
 	})
@@ -374,6 +385,26 @@ func TestBotInstanceList(t *testing.T) {
 		require.Contains(t, bIds, ins.GetSpec().GetInstanceId())
 	}
 
+	// listing "a" in scope /foo should only return the scoped bot's instances
+	scopedAInstances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
+		FilterBotName:  "a",
+		FilterBotScope: "/foo",
+	})
+	require.Len(t, scopedAInstances, 2)
+	for _, ins := range scopedAInstances {
+		require.Contains(t, scopedAIds, ins.GetSpec().GetInstanceId())
+	}
+
+	// listing scope /foo without a bot name should return all instances in the
+	// scope
+	fooInstances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
+		FilterBotScope: "/foo",
+	})
+	require.Len(t, fooInstances, 2)
+	for _, ins := range fooInstances {
+		require.Contains(t, scopedAIds, ins.GetSpec().GetInstanceId())
+	}
+
 	allIds := map[string]struct{}{}
 	for i := range aIds {
 		allIds[i] = struct{}{}
@@ -381,15 +412,103 @@ func TestBotInstanceList(t *testing.T) {
 	for i := range bIds {
 		allIds[i] = struct{}{}
 	}
+	for i := range scopedAIds {
+		allIds[i] = struct{}{}
+	}
 
-	// Listing an empty bot name ("") should return all instances.
+	// Listing with no bot filter should return all instances, unscoped and
+	// scoped.
 	allInstances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
 		FilterBotName: "",
 	})
-	require.Len(t, allInstances, 7)
+	require.Len(t, allInstances, 9)
 	for _, ins := range allInstances {
 		require.Contains(t, allIds, ins.GetSpec().GetInstanceId())
 	}
+}
+
+// TestBotInstanceScopedCoexistence verifies that instances of same-named bots
+// in different scopes (and unscoped) are stored disjointly and are only
+// addressable under their own bot's scope.
+func TestBotInstanceScopedCoexistence(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service, err := NewBotInstanceService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
+
+	// Three bots named "x": unscoped, in /foo, and in /bar.
+	unscoped := newBotInstance("x")
+	foo := newBotInstance("x", withBotInstanceScope("/foo"))
+	bar := newBotInstance("x", withBotInstanceScope("/bar"))
+	for _, bi := range []*machineidv1.BotInstance{unscoped, foo, bar} {
+		_, err := service.CreateBotInstance(ctx, bi)
+		require.NoError(t, err)
+	}
+
+	// The scoped instance is stored in the scope-namespaced key range.
+	encodedScope, err := scopes.EncodeForKey("/foo")
+	require.NoError(t, err)
+	_, err = mem.Get(ctx, backend.NewKey(scopedPrefix, botInstancePrefix, encodedScope, "x", foo.GetSpec().GetInstanceId()))
+	require.NoError(t, err)
+
+	// Each instance resolves only under its own bot's scope.
+	got, err := service.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "", BotName: "x", InstanceId: unscoped.GetSpec().GetInstanceId()}.Build())
+	require.NoError(t, err)
+	require.Empty(t, got.GetScope())
+	got, err = service.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "/foo", BotName: "x", InstanceId: foo.GetSpec().GetInstanceId()}.Build())
+	require.NoError(t, err)
+	require.Equal(t, "/foo", got.GetScope())
+
+	// The wrong (or missing) scope does not resolve.
+	_, err = service.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "", BotName: "x", InstanceId: foo.GetSpec().GetInstanceId()}.Build())
+	require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+	_, err = service.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "/bar", BotName: "x", InstanceId: foo.GetSpec().GetInstanceId()}.Build())
+	require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+	_, err = service.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "/foo", BotName: "x", InstanceId: unscoped.GetSpec().GetInstanceId()}.Build())
+	require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+
+	// Patching routes by scope, and the scope itself cannot be patched.
+	patched, err := service.PatchBotInstance(ctx, "/foo", "x", foo.GetSpec().GetInstanceId(), func(bi *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
+		bi.GetStatus().SetLatestHeartbeats([]*machineidv1.BotInstanceStatusHeartbeat{
+			machineidv1.BotInstanceStatusHeartbeat_builder{Hostname: "scoped-host"}.Build(),
+		})
+		return bi, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "/foo", patched.GetScope())
+
+	_, err = service.PatchBotInstance(ctx, "/foo", "x", foo.GetSpec().GetInstanceId(), func(bi *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
+		bi.SetScope("/other")
+		return bi, nil
+	})
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
+	require.ErrorContains(t, err, "scope: cannot be patched")
+
+	// Deleting under the wrong scope does not delete; the right scope deletes
+	// only that bot's instance.
+	err = service.DeleteBotInstance(ctx, machineidv1.DeleteBotInstanceRequest_builder{BotScope: "/bar", BotName: "x", InstanceId: foo.GetSpec().GetInstanceId()}.Build())
+	require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+	require.NoError(t, service.DeleteBotInstance(ctx, machineidv1.DeleteBotInstanceRequest_builder{BotScope: "/foo", BotName: "x", InstanceId: foo.GetSpec().GetInstanceId()}.Build()))
+	_, err = service.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "/foo", BotName: "x", InstanceId: foo.GetSpec().GetInstanceId()}.Build())
+	require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+	_, err = service.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "", BotName: "x", InstanceId: unscoped.GetSpec().GetInstanceId()}.Build())
+	require.NoError(t, err)
+	_, err = service.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "/bar", BotName: "x", InstanceId: bar.GetSpec().GetInstanceId()}.Build())
+	require.NoError(t, err)
+
+	// DeleteAllBotInstances empties both the unscoped and scoped ranges.
+	require.NoError(t, service.DeleteAllBotInstances(ctx))
+	remaining := listInstances(t, ctx, service, nil)
+	require.Empty(t, remaining)
 }
 
 // TestBotInstanceListWithSearchFilter verifies list and filtering with search

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -3243,7 +3243,10 @@ func (p *globalNotificationParser) parse(event backend.Event) (types.Resource, e
 
 func newBotInstanceParser() *botInstanceParser {
 	return &botInstanceParser{
-		baseParser: newBaseParser(backend.NewKey(botInstancePrefix)),
+		baseParser: newBaseParser(
+			botInstanceUnscopedWatchPrefix(),
+			botInstanceScopedWatchPrefix(),
+		),
 	}
 }
 
@@ -3254,23 +3257,22 @@ type botInstanceParser struct {
 func (p *botInstanceParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		parts := event.Item.Key.Components()
-		if len(parts) != 3 {
-			return nil, trace.BadParameter("malformed key for %s event: %s", types.KindBotInstance, event.Item.Key)
+		bot, instanceID, err := botInstanceNameFromKey(event.Item.Key)
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
-
 		botInstance := machineidv1.BotInstance_builder{
 			Kind:    types.KindBotInstance,
 			Version: types.V1,
+			Scope:   bot.Scope,
 			Spec: machineidv1.BotInstanceSpec_builder{
-				BotName:    parts[1],
-				InstanceId: parts[2],
+				BotName:    bot.Name,
+				InstanceId: instanceID,
 			}.Build(),
 			Metadata: headerv1.Metadata_builder{
-				Name: parts[2],
+				Name: instanceID,
 			}.Build(),
 		}.Build()
-
 		return types.Resource153ToLegacy(botInstance), nil
 	case types.OpPut:
 		botInstance, err := services.UnmarshalBotInstance(
@@ -3283,6 +3285,49 @@ func (p *botInstanceParser) parse(event backend.Event) (types.Resource, error) {
 		return types.Resource153ToLegacy(botInstance), nil
 	default:
 		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
+}
+
+// botInstanceNameFromKey parses a bot instance backend key into the qualified
+// name of the owning bot and the instance ID. The scope must be carried on
+// delete events: consumers (e.g. the cache) key their stores by
+// (scope, bot name, instance id).
+func botInstanceNameFromKey(key backend.Key) (scopes.QualifiedName, string, error) {
+	switch {
+	case key.HasPrefix(botInstanceScopedWatchPrefix()):
+		components := key.TrimPrefix(botInstanceScopedWatchPrefix()).Components()
+		if len(components) != 3 {
+			return scopes.QualifiedName{}, "", trace.BadParameter(
+				"expected 3 components, got %d parsing backend key %v",
+				len(components),
+				key.String(),
+			)
+		}
+		encodedScope, botName, instanceID := components[0], components[1], components[2]
+		scope, err := scopes.DecodeFromKey(encodedScope)
+		if err != nil {
+			return scopes.QualifiedName{}, "", trace.Wrap(err)
+		}
+		return scopes.QualifiedName{
+			Scope: scope,
+			Name:  botName,
+		}, instanceID, nil
+	case key.HasPrefix(botInstanceUnscopedWatchPrefix()):
+		components := key.TrimPrefix(botInstanceUnscopedWatchPrefix()).Components()
+		if len(components) != 2 {
+			return scopes.QualifiedName{}, "", trace.BadParameter(
+				"expected 2 components, got %d parsing backend key %v",
+				len(components),
+				key.String(),
+			)
+		}
+		return scopes.QualifiedName{
+			Name: components[0],
+		}, components[1], nil
+	default:
+		return scopes.QualifiedName{}, "", trace.BadParameter(
+			"unexpected prefix parsing backend key %v", key.String(),
+		)
 	}
 }
 

--- a/lib/services/local/generic/scopeaware_wrapper.go
+++ b/lib/services/local/generic/scopeaware_wrapper.go
@@ -71,7 +71,59 @@ func NewScopeAwareServiceWrapper[T ScopedResourceMetadata](cfg ScopeAwareService
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return &ScopeAwareServiceWrapper[T]{service: service}, nil
+
+	// TODO(strideynet): I'm not super keen on the way we instantiate a scoped
+	// and unscoped ServiceWrapper here. We already instantiate a scoped and
+	// unscoped service within ScopeAwareService. It feels pretty awkward that
+	// we then have a bunch of instantiated services floating around and that
+	// each one has to be used very carefully. There's just too many layers of
+	// indirection and it's not particularly cleanly layered.
+	//
+	// I see a few alternatives:
+	//
+	// 1. Re-architect ScopedAwareServiceWrapper to no longer depend on
+	//    ScopeAwareService and instead directly use the scoped and unscoped
+	//    ServiceWrappers. This effectively leaves us with ScopeAwareService
+	//    implemented twice (so a bit of duplication), but removes a layer of
+	//    indirection.
+	// 2. Remove scopedResourceMetadataAdapter and instead add GetScope directly
+	//    to resourceMetadataAdapter. This lets us directly wrap the Service
+	//    returned by ScopeAwareService.WithScopePrefix with a ServiceWrapper?
+	//    It keeps the indirection thru ScopeAwareService but avoids us forking
+	//    and instantiating ServiceWrappers here...
+	// 3. Introduce /another/ wrapper designed to wrap the Service[T] returned
+	//    by ScopeAwareService.WithScopePrefix?
+	newSingleRangeWrapper := func(prefix backend.Key) (*ServiceWrapper[T], error) {
+		return NewServiceWrapper(ServiceConfig[T]{
+			Backend:                     cfg.Backend,
+			ResourceKind:                cfg.ResourceKind,
+			PageLimit:                   cfg.PageLimit,
+			BackendPrefix:               prefix,
+			MarshalFunc:                 cfg.MarshalFunc,
+			UnmarshalFunc:               cfg.UnmarshalFunc,
+			ValidateFunc:                cfg.ValidateFunc,
+			RunWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
+		})
+	}
+
+	scopedWrapper, err := newSingleRangeWrapper(cfg.ScopedBackendPrefix)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var unscopedWrapper *ServiceWrapper[T]
+	if !cfg.ScopedOnly {
+		unscopedWrapper, err = newSingleRangeWrapper(cfg.UnscopedBackendPrefix)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	return &ScopeAwareServiceWrapper[T]{
+		service:         service,
+		unscopedWrapper: unscopedWrapper,
+		scopedWrapper:   scopedWrapper,
+	}, nil
 }
 
 // ScopeAwareServiceWrapperConfig holds configuration options for a
@@ -111,6 +163,50 @@ type ScopeAwareServiceWrapperConfig[T ScopedResourceMetadata] struct {
 // exported; additional methods may be exported in the future as needed.
 type ScopeAwareServiceWrapper[T ScopedResourceMetadata] struct {
 	service *ScopeAwareService[scopedResourceMetadataAdapter[T]]
+
+	// unscopedWrapper and scopedWrapper are single-range ServiceWrapper views
+	// over the same key ranges as service's unscoped and scoped halves. They
+	// exist because WithScopePrefix must return a *ServiceWrapper[T], and
+	// service's inner services are generic over the scoped adapter type rather
+	// than T. unscopedWrapper is nil when the service is scoped-only.
+	unscopedWrapper *ServiceWrapper[T]
+	scopedWrapper   *ServiceWrapper[T]
+}
+
+// WithScopePrefix returns a single-range ServiceWrapper routed by the given
+// scope: the unscoped range when the scope is empty, otherwise the scoped
+// range namespaced by the encoded scope. It is the ServiceWrapper analog of
+// ScopeAwareService.WithScopePrefix, for callers that need to address one
+// scope's key range directly — e.g. to key dependent resources under a
+// sub-prefix via WithPrefix on the returned wrapper.
+func (s *ScopeAwareServiceWrapper[T]) WithScopePrefix(scope string) (*ServiceWrapper[T], error) {
+	if scope == "" {
+		if s.unscopedWrapper == nil {
+			return nil, trace.BadParameter("scoped-only storage service received an empty scope")
+		}
+		return s.unscopedWrapper, nil
+	}
+	encodedScope, err := scopes.EncodeForKey(scope)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return s.scopedWrapper.WithPrefix(encodedScope), nil
+}
+
+// WithScopedResourcePrefix returns a single-range ServiceWrapper with a prefix
+// for the given scope-qualified name appended to the backend prefix: the
+// unscoped range when the scope is empty, otherwise the scoped range
+// namespaced by the encoded scope. It is the ServiceWrapper analog of
+// ScopeAwareService.WithScopedResourcePrefix.
+//
+// This may be appropriate for dependent resources keyed by a unique scoped
+// resource, i.e. the instances of a scoped bot.
+func (s *ScopeAwareServiceWrapper[T]) WithScopedResourcePrefix(scopedName scopes.QualifiedName) (*ServiceWrapper[T], error) {
+	service, err := s.WithScopePrefix(scopedName.Scope)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return service.WithPrefix(scopedName.Name), nil
 }
 
 // CreateResource creates the given resource if it doesn't already exist. The

--- a/lib/services/local/generic/scopeaware_wrapper_test.go
+++ b/lib/services/local/generic/scopeaware_wrapper_test.go
@@ -576,6 +576,182 @@ func TestScopeAwareServiceWrapper_MakeBackendItem(t *testing.T) {
 	}
 }
 
+func TestScopeAwareServiceWrapper_WithScopePrefix(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty scope routes to the unscoped range", func(t *testing.T) {
+		t.Parallel()
+		svc := newScopeAwareWrapperForTest(t)
+		ctx := t.Context()
+
+		qn := scopes.QualifiedName{Name: "foo"}
+		_, err := svc.CreateResource(ctx, newScopedTestResource153(qn))
+		require.NoError(t, err)
+
+		routed, err := svc.WithScopePrefix("")
+		require.NoError(t, err)
+		require.Equal(t,
+			backend.NewKey(testUnscopedPrefix, "foo").String(),
+			routed.BackendKey("foo").String(),
+		)
+
+		got, err := routed.GetResource(ctx, "foo")
+		require.NoError(t, err)
+		requireResourceBody(t, qn, got)
+	})
+
+	t.Run("scope routes to its scoped range", func(t *testing.T) {
+		t.Parallel()
+		svc := newScopeAwareWrapperForTest(t)
+		ctx := t.Context()
+
+		qn := scopes.QualifiedName{Scope: "/security", Name: "foo"}
+		_, err := svc.CreateResource(ctx, newScopedTestResource153(qn))
+		require.NoError(t, err)
+
+		routed, err := svc.WithScopePrefix("/security")
+		require.NoError(t, err)
+		encodedScope, err := scopes.EncodeForKey("/security")
+		require.NoError(t, err)
+		require.Equal(t,
+			backend.NewKey(testScopedTopPrefix, testUnscopedPrefix, encodedScope, "foo").String(),
+			routed.BackendKey("foo").String(),
+		)
+
+		got, err := routed.GetResource(ctx, "foo")
+		require.NoError(t, err)
+		requireResourceBody(t, qn, got)
+
+		// A different scope's routed wrapper does not see it.
+		other, err := svc.WithScopePrefix("/other")
+		require.NoError(t, err)
+		_, err = other.GetResource(ctx, "foo")
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+	})
+
+	t.Run("sub-prefix keys dependent resources under the scope", func(t *testing.T) {
+		t.Parallel()
+		svc := newScopeAwareWrapperForTest(t)
+		ctx := t.Context()
+
+		qn := scopes.QualifiedName{Scope: "/security", Name: "child"}
+		routed, err := svc.WithScopePrefix(qn.Scope)
+		require.NoError(t, err)
+		sub := routed.WithPrefix("parent")
+
+		_, err = sub.CreateResource(ctx, newScopedTestResource153(qn))
+		require.NoError(t, err)
+
+		encodedScope, err := scopes.EncodeForKey(qn.Scope)
+		require.NoError(t, err)
+		require.Equal(t,
+			backend.NewKey(testScopedTopPrefix, testUnscopedPrefix, encodedScope, "parent", "child").String(),
+			sub.BackendKey("child").String(),
+		)
+
+		got, err := sub.GetResource(ctx, "child")
+		require.NoError(t, err)
+		requireResourceBody(t, qn, got)
+
+		// The resource is not addressable at the scope's top level...
+		_, err = svc.GetResource(ctx, qn)
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+
+		// ...but the unified list still ranges over it.
+		page, next, err := svc.ListResources(ctx, 100, "")
+		require.NoError(t, err)
+		require.Empty(t, next)
+		require.Equal(t, []scopes.QualifiedName{qn}, names(page))
+	})
+
+	t.Run("invalid scope errors", func(t *testing.T) {
+		t.Parallel()
+		svc := newScopeAwareWrapperForTest(t)
+		_, err := svc.WithScopePrefix("/not valid")
+		require.Error(t, err)
+	})
+
+	t.Run("scoped-only rejects the empty scope", func(t *testing.T) {
+		t.Parallel()
+		memBackend, err := memory.New(memory.Config{
+			Context: t.Context(),
+			Clock:   clockwork.NewFakeClock(),
+		})
+		require.NoError(t, err)
+		svc, err := NewScopeAwareServiceWrapper(ScopeAwareServiceWrapperConfig[*scopedTestResource153]{
+			ScopedOnly:          true,
+			Backend:             memBackend,
+			ResourceKind:        "scoped_generic_resource",
+			ScopedBackendPrefix: backend.NewKey(testScopedTopPrefix, testUnscopedPrefix),
+			PageLimit:           200,
+			MarshalFunc:         marshalScopedResource153,
+			UnmarshalFunc:       unmarshalScopedResource153,
+		})
+		require.NoError(t, err)
+
+		_, err = svc.WithScopePrefix("")
+		require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
+
+		routed, err := svc.WithScopePrefix("/security")
+		require.NoError(t, err)
+		require.NotNil(t, routed)
+	})
+}
+
+func TestScopeAwareServiceWrapper_WithScopedResourcePrefix(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty scope keys under the unscoped range", func(t *testing.T) {
+		t.Parallel()
+		svc := newScopeAwareWrapperForTest(t)
+
+		routed, err := svc.WithScopedResourcePrefix(scopes.QualifiedName{Name: "parent"})
+		require.NoError(t, err)
+		require.Equal(t,
+			backend.NewKey(testUnscopedPrefix, "parent", "child").String(),
+			routed.BackendKey("child").String(),
+		)
+	})
+
+	t.Run("scope keys under its scoped range", func(t *testing.T) {
+		t.Parallel()
+		svc := newScopeAwareWrapperForTest(t)
+		ctx := t.Context()
+
+		qn := scopes.QualifiedName{Scope: "/security", Name: "child"}
+		routed, err := svc.WithScopedResourcePrefix(scopes.QualifiedName{Scope: qn.Scope, Name: "parent"})
+		require.NoError(t, err)
+
+		encodedScope, err := scopes.EncodeForKey(qn.Scope)
+		require.NoError(t, err)
+		require.Equal(t,
+			backend.NewKey(testScopedTopPrefix, testUnscopedPrefix, encodedScope, "parent", "child").String(),
+			routed.BackendKey("child").String(),
+		)
+
+		_, err = routed.CreateResource(ctx, newScopedTestResource153(qn))
+		require.NoError(t, err)
+		got, err := routed.GetResource(ctx, "child")
+		require.NoError(t, err)
+		requireResourceBody(t, qn, got)
+
+		// Equivalent to routing by scope and adding the name prefix separately.
+		twoStep, err := svc.WithScopePrefix(qn.Scope)
+		require.NoError(t, err)
+		require.Equal(t,
+			twoStep.WithPrefix("parent").BackendKey("child").String(),
+			routed.BackendKey("child").String(),
+		)
+	})
+
+	t.Run("invalid scope errors", func(t *testing.T) {
+		t.Parallel()
+		svc := newScopeAwareWrapperForTest(t)
+		_, err := svc.WithScopedResourcePrefix(scopes.QualifiedName{Scope: "/not valid", Name: "parent"})
+		require.Error(t, err)
+	})
+}
+
 func TestScopeAwareServiceWrapper_BackendKey(t *testing.T) {
 	t.Parallel()
 	svc := newScopeAwareWrapperForTest(t)

--- a/lib/web/machineid_test.go
+++ b/lib/web/machineid_test.go
@@ -883,7 +883,7 @@ func TestListBotInstancesPaging(t *testing.T) {
 
 					// remove instances before next test
 					for n := range tc.numInstances {
-						err = env.server.Auth().DeleteBotInstance(ctx, "bot-1", "instance-"+strconv.Itoa(n))
+						err = env.server.Auth().DeleteBotInstance(ctx, machineidv1.DeleteBotInstanceRequest_builder{BotScope: "", BotName: "bot-1", InstanceId: "instance-" + strconv.Itoa(n)}.Build())
 						require.NoError(t, err)
 					}
 				})
@@ -1130,7 +1130,7 @@ func TestListBotInstancesWithSearchTermFilter(t *testing.T) {
 					assert.Equal(t, "00000000-0000-0000-0000-000000000000", instances.BotInstances[0].InstanceId)
 
 					// remove before next test
-					err = env.server.Auth().DeleteBotInstance(ctx, spec.GetBotName(), spec.GetInstanceId())
+					err = env.server.Auth().DeleteBotInstance(ctx, machineidv1.DeleteBotInstanceRequest_builder{BotScope: "", BotName: spec.GetBotName(), InstanceId: spec.GetInstanceId()}.Build())
 					require.NoError(t, err)
 				})
 			}


### PR DESCRIPTION
Depends on https://github.com/gravitational/teleport/pull/68385

Breaking Change: Only for Scoped bots. Upon upgrading to a version including this change, existing Bot Instances belonging to Scoped Bots will become decoupled. Upon the next renewal of `tbot`, a new Bot Instance will be created. Old Bot Instances will expire out when previously issued certificates expire.

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

- [x] Regression: Run unscoped `tbot` prior to switching this version, ensure unscoped bot instance remains visible via UI and `tctl` after upgrading to these changes. Ensure that on the next renewal, the bot instance remains the same.
- [x] Run `scoped` tbot with Kubernetes join method, ensure Bot Instance is scoped and that the Bot Instance ID remains the same upon consecutive renewals.
- [x] Run `scoped` tbot with Bound Keypair join method, ensure Bot Instance is scoped and that the Bot Instance ID remains the same upon consecutive renewals. Additionally, ensure that recovery behaves as expected.
