### PR TITLE
[v18] Encode Bot Scope into TLS/SSH identity (#68385)

### DIFF
--- a/api/gen/proto/go/teleport/decision/v1alpha1/ssh_identity.pb.go
+++ b/api/gen/proto/go/teleport/decision/v1alpha1/ssh_identity.pb.go
@@ -316,8 +316,11 @@ type SSHIdentity struct {
 	ImmutableLabelHash string `protobuf:"bytes,38,opt,name=immutable_label_hash,json=immutableLabelHash,proto3" json:"immutable_label_hash,omitempty"`
 	// Delegation session this SSH identity is associated with.
 	DelegationSessionId string `protobuf:"bytes,39,opt,name=delegation_session_id,json=delegationSessionId,proto3" json:"delegation_session_id,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// BotScope is the scope of the Machine ID bot this identity was issued to,
+	// if any. Empty for unscoped bots and non-bot identities.
+	BotScope      string `protobuf:"bytes,42,opt,name=bot_scope,json=botScope,proto3" json:"bot_scope,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *SSHIdentity) Reset() {
@@ -618,6 +621,13 @@ func (x *SSHIdentity) GetDelegationSessionId() string {
 	return ""
 }
 
+func (x *SSHIdentity) GetBotScope() string {
+	if x != nil {
+		return x.BotScope
+	}
+	return ""
+}
+
 func (x *SSHIdentity) SetValidAfter(v uint64) {
 	x.ValidAfter = v
 }
@@ -774,6 +784,10 @@ func (x *SSHIdentity) SetDelegationSessionId(v string) {
 	x.DelegationSessionId = v
 }
 
+func (x *SSHIdentity) SetBotScope(v string) {
+	x.BotScope = v
+}
+
 func (x *SSHIdentity) HasPreviousIdentityExpires() bool {
 	if x == nil {
 		return false
@@ -904,6 +918,9 @@ type SSHIdentity_builder struct {
 	ImmutableLabelHash string
 	// Delegation session this SSH identity is associated with.
 	DelegationSessionId string
+	// BotScope is the scope of the Machine ID bot this identity was issued to,
+	// if any. Empty for unscoped bots and non-bot identities.
+	BotScope string
 }
 
 func (b0 SSHIdentity_builder) Build() *SSHIdentity {
@@ -949,6 +966,7 @@ func (b0 SSHIdentity_builder) Build() *SSHIdentity {
 	x.AllowedResourceAccessIds = b.AllowedResourceAccessIds
 	x.ImmutableLabelHash = b.ImmutableLabelHash
 	x.DelegationSessionId = b.DelegationSessionId
+	x.BotScope = b.BotScope
 	return m0
 }
 
@@ -1076,7 +1094,7 @@ const file_teleport_decision_v1alpha1_ssh_identity_proto_rawDesc = "" +
 	"-teleport/decision/v1alpha1/ssh_identity.proto\x12\x1ateleport.decision.v1alpha1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a-teleport/decision/v1alpha1/tls_identity.proto\x1a%teleport/legacy/types/resources.proto\x1a\x1fteleport/scopes/v1/scopes.proto\x1a\x1dteleport/trait/v1/trait.proto\"X\n" +
 	"\fSSHAuthority\x12!\n" +
 	"\fcluster_name\x18\x01 \x01(\tR\vclusterName\x12%\n" +
-	"\x0eauthority_type\x18\x02 \x01(\tR\rauthorityType\"\xce\r\n" +
+	"\x0eauthority_type\x18\x02 \x01(\tR\rauthorityType\"\xeb\r\n" +
 	"\vSSHIdentity\x12\x1f\n" +
 	"\vvalid_after\x18\x01 \x01(\x04R\n" +
 	"validAfter\x12!\n" +
@@ -1125,7 +1143,8 @@ const file_teleport_decision_v1alpha1_ssh_identity_proto_rawDesc = "" +
 	"agentScope\x12V\n" +
 	"\x1ballowed_resource_access_ids\x18% \x03(\v2\x17.types.ResourceAccessIDR\x18allowedResourceAccessIds\x120\n" +
 	"\x14immutable_label_hash\x18& \x01(\tR\x12immutableLabelHash\x122\n" +
-	"\x15delegation_session_id\x18' \x01(\tR\x13delegationSessionId\"\xbf\x01\n" +
+	"\x15delegation_session_id\x18' \x01(\tR\x13delegationSessionId\x12\x1b\n" +
+	"\tbot_scope\x18* \x01(\tR\bbotScope\"\xbf\x01\n" +
 	"\rCertExtension\x12A\n" +
 	"\x04type\x18\x01 \x01(\x0e2-.teleport.decision.v1alpha1.CertExtensionTypeR\x04type\x12A\n" +
 	"\x04mode\x18\x02 \x01(\x0e2-.teleport.decision.v1alpha1.CertExtensionModeR\x04mode\x12\x12\n" +

--- a/api/gen/proto/go/teleport/decision/v1alpha1/ssh_identity_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/decision/v1alpha1/ssh_identity_protoopaque.pb.go
@@ -248,6 +248,7 @@ type SSHIdentity struct {
 	xxx_hidden_AllowedResourceAccessIds *[]*types.ResourceAccessID `protobuf:"bytes,37,rep,name=allowed_resource_access_ids,json=allowedResourceAccessIds,proto3"`
 	xxx_hidden_ImmutableLabelHash       string                     `protobuf:"bytes,38,opt,name=immutable_label_hash,json=immutableLabelHash,proto3"`
 	xxx_hidden_DelegationSessionId      string                     `protobuf:"bytes,39,opt,name=delegation_session_id,json=delegationSessionId,proto3"`
+	xxx_hidden_BotScope                 string                     `protobuf:"bytes,42,opt,name=bot_scope,json=botScope,proto3"`
 	unknownFields                       protoimpl.UnknownFields
 	sizeCache                           protoimpl.SizeCache
 }
@@ -558,6 +559,13 @@ func (x *SSHIdentity) GetDelegationSessionId() string {
 	return ""
 }
 
+func (x *SSHIdentity) GetBotScope() string {
+	if x != nil {
+		return x.xxx_hidden_BotScope
+	}
+	return ""
+}
+
 func (x *SSHIdentity) SetValidAfter(v uint64) {
 	x.xxx_hidden_ValidAfter = v
 }
@@ -714,6 +722,10 @@ func (x *SSHIdentity) SetDelegationSessionId(v string) {
 	x.xxx_hidden_DelegationSessionId = v
 }
 
+func (x *SSHIdentity) SetBotScope(v string) {
+	x.xxx_hidden_BotScope = v
+}
+
 func (x *SSHIdentity) HasPreviousIdentityExpires() bool {
 	if x == nil {
 		return false
@@ -844,6 +856,9 @@ type SSHIdentity_builder struct {
 	ImmutableLabelHash string
 	// Delegation session this SSH identity is associated with.
 	DelegationSessionId string
+	// BotScope is the scope of the Machine ID bot this identity was issued to,
+	// if any. Empty for unscoped bots and non-bot identities.
+	BotScope string
 }
 
 func (b0 SSHIdentity_builder) Build() *SSHIdentity {
@@ -889,6 +904,7 @@ func (b0 SSHIdentity_builder) Build() *SSHIdentity {
 	x.xxx_hidden_AllowedResourceAccessIds = &b.AllowedResourceAccessIds
 	x.xxx_hidden_ImmutableLabelHash = b.ImmutableLabelHash
 	x.xxx_hidden_DelegationSessionId = b.DelegationSessionId
+	x.xxx_hidden_BotScope = b.BotScope
 	return m0
 }
 
@@ -1008,7 +1024,7 @@ const file_teleport_decision_v1alpha1_ssh_identity_proto_rawDesc = "" +
 	"-teleport/decision/v1alpha1/ssh_identity.proto\x12\x1ateleport.decision.v1alpha1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a-teleport/decision/v1alpha1/tls_identity.proto\x1a%teleport/legacy/types/resources.proto\x1a\x1fteleport/scopes/v1/scopes.proto\x1a\x1dteleport/trait/v1/trait.proto\"X\n" +
 	"\fSSHAuthority\x12!\n" +
 	"\fcluster_name\x18\x01 \x01(\tR\vclusterName\x12%\n" +
-	"\x0eauthority_type\x18\x02 \x01(\tR\rauthorityType\"\xce\r\n" +
+	"\x0eauthority_type\x18\x02 \x01(\tR\rauthorityType\"\xeb\r\n" +
 	"\vSSHIdentity\x12\x1f\n" +
 	"\vvalid_after\x18\x01 \x01(\x04R\n" +
 	"validAfter\x12!\n" +
@@ -1057,7 +1073,8 @@ const file_teleport_decision_v1alpha1_ssh_identity_proto_rawDesc = "" +
 	"agentScope\x12V\n" +
 	"\x1ballowed_resource_access_ids\x18% \x03(\v2\x17.types.ResourceAccessIDR\x18allowedResourceAccessIds\x120\n" +
 	"\x14immutable_label_hash\x18& \x01(\tR\x12immutableLabelHash\x122\n" +
-	"\x15delegation_session_id\x18' \x01(\tR\x13delegationSessionId\"\xbf\x01\n" +
+	"\x15delegation_session_id\x18' \x01(\tR\x13delegationSessionId\x12\x1b\n" +
+	"\tbot_scope\x18* \x01(\tR\bbotScope\"\xbf\x01\n" +
 	"\rCertExtension\x12A\n" +
 	"\x04type\x18\x01 \x01(\x0e2-.teleport.decision.v1alpha1.CertExtensionTypeR\x04type\x12A\n" +
 	"\x04mode\x18\x02 \x01(\x0e2-.teleport.decision.v1alpha1.CertExtensionModeR\x04mode\x12\x12\n" +

--- a/api/gen/proto/go/teleport/decision/v1alpha1/tls_identity.pb.go
+++ b/api/gen/proto/go/teleport/decision/v1alpha1/tls_identity.pb.go
@@ -151,8 +151,11 @@ type TLSIdentity struct {
 	AllowedResourceAccessIds []*types.ResourceAccessID `protobuf:"bytes,38,rep,name=allowed_resource_access_ids,json=allowedResourceAccessIds,proto3" json:"allowed_resource_access_ids,omitempty"`
 	// Delegation session this TLS identity is associated with.
 	DelegationSessionId string `protobuf:"bytes,39,opt,name=delegation_session_id,json=delegationSessionId,proto3" json:"delegation_session_id,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// BotScope is the scope of the Machine ID bot this identity was issued to,
+	// if any. Empty for unscoped bots and non-bot identities.
+	BotScope      string `protobuf:"bytes,41,opt,name=bot_scope,json=botScope,proto3" json:"bot_scope,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TLSIdentity) Reset() {
@@ -453,6 +456,13 @@ func (x *TLSIdentity) GetDelegationSessionId() string {
 	return ""
 }
 
+func (x *TLSIdentity) GetBotScope() string {
+	if x != nil {
+		return x.BotScope
+	}
+	return ""
+}
+
 func (x *TLSIdentity) SetUsername(v string) {
 	x.Username = v
 }
@@ -607,6 +617,10 @@ func (x *TLSIdentity) SetAllowedResourceAccessIds(v []*types.ResourceAccessID) {
 
 func (x *TLSIdentity) SetDelegationSessionId(v string) {
 	x.DelegationSessionId = v
+}
+
+func (x *TLSIdentity) SetBotScope(v string) {
+	x.BotScope = v
 }
 
 func (x *TLSIdentity) HasExpires() bool {
@@ -785,6 +799,9 @@ type TLSIdentity_builder struct {
 	AllowedResourceAccessIds []*types.ResourceAccessID
 	// Delegation session this TLS identity is associated with.
 	DelegationSessionId string
+	// BotScope is the scope of the Machine ID bot this identity was issued to,
+	// if any. Empty for unscoped bots and non-bot identities.
+	BotScope string
 }
 
 func (b0 TLSIdentity_builder) Build() *TLSIdentity {
@@ -830,6 +847,7 @@ func (b0 TLSIdentity_builder) Build() *TLSIdentity {
 	x.ScopePin = b.ScopePin
 	x.AllowedResourceAccessIds = b.AllowedResourceAccessIds
 	x.DelegationSessionId = b.DelegationSessionId
+	x.BotScope = b.BotScope
 	return m0
 }
 
@@ -1412,7 +1430,7 @@ var File_teleport_decision_v1alpha1_tls_identity_proto protoreflect.FileDescript
 
 const file_teleport_decision_v1alpha1_tls_identity_proto_rawDesc = "" +
 	"\n" +
-	"-teleport/decision/v1alpha1/tls_identity.proto\x12\x1ateleport.decision.v1alpha1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a%teleport/legacy/types/resources.proto\x1a\x1fteleport/scopes/v1/scopes.proto\x1a\x1dteleport/trait/v1/trait.proto\"\x97\x0e\n" +
+	"-teleport/decision/v1alpha1/tls_identity.proto\x12\x1ateleport.decision.v1alpha1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a%teleport/legacy/types/resources.proto\x1a\x1fteleport/scopes/v1/scopes.proto\x1a\x1dteleport/trait/v1/trait.proto\"\xb4\x0e\n" +
 	"\vTLSIdentity\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\"\n" +
 	"\fimpersonator\x18\x02 \x01(\tR\fimpersonator\x12\x16\n" +
@@ -1459,7 +1477,8 @@ const file_teleport_decision_v1alpha1_tls_identity_proto_rawDesc = "" +
 	"join_token\x18$ \x01(\tR\tjoinToken\x124\n" +
 	"\tscope_pin\x18% \x01(\v2\x17.teleport.scopes.v1.PinR\bscopePin\x12V\n" +
 	"\x1ballowed_resource_access_ids\x18& \x03(\v2\x17.types.ResourceAccessIDR\x18allowedResourceAccessIds\x122\n" +
-	"\x15delegation_session_id\x18' \x01(\tR\x13delegationSessionId\"\xfb\x02\n" +
+	"\x15delegation_session_id\x18' \x01(\tR\x13delegationSessionId\x12\x1b\n" +
+	"\tbot_scope\x18) \x01(\tR\bbotScope\"\xfb\x02\n" +
 	"\n" +
 	"RouteToApp\x12\x1d\n" +
 	"\n" +

--- a/api/gen/proto/go/teleport/decision/v1alpha1/tls_identity_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/decision/v1alpha1/tls_identity_protoopaque.pb.go
@@ -83,6 +83,7 @@ type TLSIdentity struct {
 	xxx_hidden_ScopePin                 *v11.Pin                   `protobuf:"bytes,37,opt,name=scope_pin,json=scopePin,proto3"`
 	xxx_hidden_AllowedResourceAccessIds *[]*types.ResourceAccessID `protobuf:"bytes,38,rep,name=allowed_resource_access_ids,json=allowedResourceAccessIds,proto3"`
 	xxx_hidden_DelegationSessionId      string                     `protobuf:"bytes,39,opt,name=delegation_session_id,json=delegationSessionId,proto3"`
+	xxx_hidden_BotScope                 string                     `protobuf:"bytes,41,opt,name=bot_scope,json=botScope,proto3"`
 	unknownFields                       protoimpl.UnknownFields
 	sizeCache                           protoimpl.SizeCache
 }
@@ -391,6 +392,13 @@ func (x *TLSIdentity) GetDelegationSessionId() string {
 	return ""
 }
 
+func (x *TLSIdentity) GetBotScope() string {
+	if x != nil {
+		return x.xxx_hidden_BotScope
+	}
+	return ""
+}
+
 func (x *TLSIdentity) SetUsername(v string) {
 	x.xxx_hidden_Username = v
 }
@@ -545,6 +553,10 @@ func (x *TLSIdentity) SetAllowedResourceAccessIds(v []*types.ResourceAccessID) {
 
 func (x *TLSIdentity) SetDelegationSessionId(v string) {
 	x.xxx_hidden_DelegationSessionId = v
+}
+
+func (x *TLSIdentity) SetBotScope(v string) {
+	x.xxx_hidden_BotScope = v
 }
 
 func (x *TLSIdentity) HasExpires() bool {
@@ -723,6 +735,9 @@ type TLSIdentity_builder struct {
 	AllowedResourceAccessIds []*types.ResourceAccessID
 	// Delegation session this TLS identity is associated with.
 	DelegationSessionId string
+	// BotScope is the scope of the Machine ID bot this identity was issued to,
+	// if any. Empty for unscoped bots and non-bot identities.
+	BotScope string
 }
 
 func (b0 TLSIdentity_builder) Build() *TLSIdentity {
@@ -768,6 +783,7 @@ func (b0 TLSIdentity_builder) Build() *TLSIdentity {
 	x.xxx_hidden_ScopePin = b.ScopePin
 	x.xxx_hidden_AllowedResourceAccessIds = &b.AllowedResourceAccessIds
 	x.xxx_hidden_DelegationSessionId = b.DelegationSessionId
+	x.xxx_hidden_BotScope = b.BotScope
 	return m0
 }
 
@@ -1305,7 +1321,7 @@ var File_teleport_decision_v1alpha1_tls_identity_proto protoreflect.FileDescript
 
 const file_teleport_decision_v1alpha1_tls_identity_proto_rawDesc = "" +
 	"\n" +
-	"-teleport/decision/v1alpha1/tls_identity.proto\x12\x1ateleport.decision.v1alpha1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a%teleport/legacy/types/resources.proto\x1a\x1fteleport/scopes/v1/scopes.proto\x1a\x1dteleport/trait/v1/trait.proto\"\x97\x0e\n" +
+	"-teleport/decision/v1alpha1/tls_identity.proto\x12\x1ateleport.decision.v1alpha1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a%teleport/legacy/types/resources.proto\x1a\x1fteleport/scopes/v1/scopes.proto\x1a\x1dteleport/trait/v1/trait.proto\"\xb4\x0e\n" +
 	"\vTLSIdentity\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\"\n" +
 	"\fimpersonator\x18\x02 \x01(\tR\fimpersonator\x12\x16\n" +
@@ -1352,7 +1368,8 @@ const file_teleport_decision_v1alpha1_tls_identity_proto_rawDesc = "" +
 	"join_token\x18$ \x01(\tR\tjoinToken\x124\n" +
 	"\tscope_pin\x18% \x01(\v2\x17.teleport.scopes.v1.PinR\bscopePin\x12V\n" +
 	"\x1ballowed_resource_access_ids\x18& \x03(\v2\x17.types.ResourceAccessIDR\x18allowedResourceAccessIds\x122\n" +
-	"\x15delegation_session_id\x18' \x01(\tR\x13delegationSessionId\"\xfb\x02\n" +
+	"\x15delegation_session_id\x18' \x01(\tR\x13delegationSessionId\x12\x1b\n" +
+	"\tbot_scope\x18) \x01(\tR\bbotScope\"\xfb\x02\n" +
 	"\n" +
 	"RouteToApp\x12\x1d\n" +
 	"\n" +

--- a/api/proto/teleport/decision/v1alpha1/ssh_identity.proto
+++ b/api/proto/teleport/decision/v1alpha1/ssh_identity.proto
@@ -182,6 +182,10 @@ message SSHIdentity {
 
   // Delegation session this SSH identity is associated with.
   string delegation_session_id = 39;
+
+  // BotScope is the scope of the Machine ID bot this identity was issued to,
+  // if any. Empty for unscoped bots and non-bot identities.
+  string bot_scope = 42;
 }
 
 // CertExtensionMode specifies the type of extension to use in the cert. This type

--- a/api/proto/teleport/decision/v1alpha1/tls_identity.proto
+++ b/api/proto/teleport/decision/v1alpha1/tls_identity.proto
@@ -171,6 +171,10 @@ message TLSIdentity {
 
   // Delegation session this TLS identity is associated with.
   string delegation_session_id = 39;
+
+  // BotScope is the scope of the Machine ID bot this identity was issued to,
+  // if any. Empty for unscoped bots and non-bot identities.
+  string bot_scope = 41;
 }
 
 // RouteToApp holds routing information for applications.

--- a/constants.go
+++ b/constants.go
@@ -541,6 +541,9 @@ const (
 	// Machine ID bot instance, if any. This identifier is persisted through
 	// certificate renewals.
 	CertExtensionBotInstanceID = "bot-instance-id@goteleport.com"
+	// CertExtensionBotScope indicates the scope of the Machine ID bot this
+	// certificate was issued to, if any.
+	CertExtensionBotScope = "bot-scope@goteleport.com"
 	// CertExtensionJoinToken is the name of the join token used to join this
 	// bot, if any.
 	CertExtensionJoinToken = "join-token@goteleport.com"

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3067,6 +3067,7 @@ func (a *Server) GenerateUserTestCertsWithContext(ctx context.Context, req Gener
 	if botName, isBot := userState.GetLabel(types.BotLabel); isBot {
 		certReq.BotName = botName
 		certReq.BotInstanceID = uuid.NewString()
+		certReq.BotScope, _ = userState.GetLabel(types.BotScopeLabel)
 	}
 
 	certs, err := a.GenerateUserCerts(ctx, certReq)
@@ -3936,6 +3937,7 @@ func generateCert(ctx context.Context, a *Server, req cert.Request, caType types
 				Generation:               req.Generation,
 				BotName:                  req.BotName,
 				BotInstanceID:            req.BotInstanceID,
+				BotScope:                 req.BotScope,
 				DelegationSessionID:      req.DelegationSessionID,
 				JoinToken:                req.JoinToken,
 				CertificateExtensions:    certificateExtensions,
@@ -4080,6 +4082,7 @@ func generateCert(ctx context.Context, a *Server, req cert.Request, caType types
 		Generation:               req.Generation,
 		BotName:                  req.BotName,
 		BotInstanceID:            req.BotInstanceID,
+		BotScope:                 req.BotScope,
 		BotInternal:              req.BotInternal,
 		DelegationSessionID:      req.DelegationSessionID,
 		JoinToken:                req.JoinToken,

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3827,6 +3827,17 @@ func getBotName(user services.UserState) string {
 	return ""
 }
 
+// getBotScope returns the scope of the bot embedded in the user metadata, if
+// any. For unscoped bots and non-bot users, returns "".
+func getBotScope(user services.UserState) string {
+	scope, ok := user.GetLabel(types.BotScopeLabel)
+	if ok {
+		return scope
+	}
+
+	return ""
+}
+
 func (a *ScopedServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserCertsRequest, opts ...certRequestOption) (*proto.Certs, error) {
 	// Device trust: authorize device before issuing certificates.
 	readOnlyAuthPref, err := a.authServer.GetReadOnlyAuthPreference(ctx)
@@ -4160,7 +4171,8 @@ func (a *ScopedServerWithRoles) generateUserCerts(ctx context.Context, req proto
 			AppURI:            req.RouteToApp.URI,
 			AppTargetPort:     int(req.RouteToApp.TargetPort),
 
-			BotName: getBotName(user),
+			BotName:  getBotName(user),
+			BotScope: getBotScope(user),
 			// Always pass through a bot instance ID if available. Legacy bots
 			// joining without an instance ID may have one generated when
 			// `updateBotInstance()` is called below, and this (empty) value will be
@@ -4216,6 +4228,7 @@ func (a *ScopedServerWithRoles) generateUserCerts(ctx context.Context, req proto
 		ActiveRequests:         req.AccessRequests,
 		ConnectionDiagnosticID: req.ConnectionDiagnosticID,
 		BotName:                getBotName(user),
+		BotScope:               getBotScope(user),
 
 		// Always pass through a bot instance ID if available. Legacy bots
 		// joining without an instance ID may have one generated when

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -1153,8 +1153,8 @@ func TestBot(botName string, botInternal bool) TestIdentity {
 			Username: userName,
 			Identity: tlsca.Identity{
 				Username: userName,
-				// GenerateUserTestCertsWithContext will inject BotName and
-				// BotInstanceID.
+				// GenerateUserTestCertsWithContext will inject BotName,
+				// BotInstanceID and BotScope.
 				BotInternal: botInternal,
 			},
 		},
@@ -1169,8 +1169,8 @@ func TestScopedBot(botName string, scope string, botInternal bool) TestIdentity 
 			Username: userName,
 			Identity: tlsca.Identity{
 				Username: userName,
-				// GenerateUserTestCertsWithContext will inject BotName and
-				// BotInstanceID.
+				// GenerateUserTestCertsWithContext will inject BotName,
+				// BotInstanceID and BotScope.
 				BotInternal: botInternal,
 			},
 		},

--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -611,6 +611,7 @@ func (a *Server) generateInitialBotCerts(
 		IncludeHostCA:  true,
 		LoginIP:        loginIP,
 		BotName:        botName,
+		BotScope:       botScope,
 		BotInternal:    true,
 		JoinAttributes: joinAttrs,
 	}

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -1513,6 +1513,7 @@ func TestRegisterBotWithScopedKubernetesToken(t *testing.T) {
 	require.Equal(t, "/test", ident.ScopePin.GetScope())
 	require.True(t, ident.BotInternal)
 	require.Equal(t, "example-token", ident.JoinToken)
+	require.Equal(t, "/test", ident.BotScope)
 
 	botClient := authClientForRegisterResult(t, ctx, addr, result)
 

--- a/lib/auth/delegation/delegationv1/generate_certs.go
+++ b/lib/auth/delegation/delegationv1/generate_certs.go
@@ -247,6 +247,7 @@ func (s *SessionService) generateCertificates(
 
 		BotName:             callerIdentity.BotName,
 		BotInstanceID:       callerIdentity.BotInstanceID,
+		BotScope:            callerIdentity.BotScope,
 		DelegationSessionID: session.GetMetadata().GetName(),
 	}
 
@@ -291,6 +292,7 @@ func (s *SessionService) generateCertificates(
 			AppTargetPort: certReq.AppTargetPort,
 			BotName:       callerIdentity.BotName,
 			BotInstanceID: certReq.BotInstanceID,
+			BotScope:      callerIdentity.BotScope,
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/auth/internal/cert/request.go
+++ b/lib/auth/internal/cert/request.go
@@ -154,6 +154,9 @@ type Request struct {
 	// BotInstanceID is the unique identifier of the bot instance associated
 	// with this cert, if any.
 	BotInstanceID string
+	// BotScope is the scope of the bot requesting this cert, if any. Empty for
+	// unscoped bots and non-bot identities.
+	BotScope string
 	// BotInternal is a flag that indicates an identity is specifically a bot
 	// internal identity, rather than output certificates intended for direct
 	// consumption by users or user-facing bot services.

--- a/lib/auth/internal/session/request.go
+++ b/lib/auth/internal/session/request.go
@@ -117,4 +117,6 @@ type NewAppSessionRequest struct {
 	BotName string
 	// BotInstanceID is the ID of the bot instance that is creating this session.
 	BotInstanceID string
+	// BotScope is the scope of the bot that is creating this session, if any.
+	BotScope string
 }

--- a/lib/auth/issuance/v1/service.go
+++ b/lib/auth/issuance/v1/service.go
@@ -219,7 +219,11 @@ func (s *Service) IssueScopedBotCerts(
 		LoginIP:        currentIdentity.LoginIP,
 		BotName:        currentIdentity.BotName,
 		BotInstanceID:  currentIdentity.BotInstanceID,
-		JoinToken:      currentIdentity.JoinToken,
+		// Derived from the bot user's label rather than copied from the
+		// current identity so that certs issued before the BotScope cert field
+		// existed still produce correctly-attributed output certs.
+		BotScope:  botScope,
+		JoinToken: currentIdentity.JoinToken,
 	}
 
 	// nb(strideynet): One day, we'll want to pull more of the logic around

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -516,6 +516,7 @@ func (a *Server) CreateAppSessionFromReq(ctx context.Context, req NewAppSessionR
 		// Pass along bot details to ensure audit logs are correct.
 		BotName:             req.BotName,
 		BotInstanceID:       req.BotInstanceID,
+		BotScope:            req.BotScope,
 		DelegationSessionID: req.DelegationSessionID,
 	})
 	if err != nil {

--- a/lib/decision/ssh_identity.go
+++ b/lib/decision/ssh_identity.go
@@ -58,6 +58,7 @@ func SSHIdentityToSSHCA(id *decisionpb.SSHIdentity) *sshca.Identity {
 		Generation:              id.Generation,
 		BotName:                 id.BotName,
 		BotInstanceID:           id.BotInstanceId,
+		BotScope:                id.GetBotScope(),
 		JoinToken:               id.JoinToken,
 		//nolint:staticcheck // TODO(kiosion): deprecated, to be removed in v21
 		AllowedResourceIDs:       resourceIDsToTypes(id.AllowedResourceIds),
@@ -107,6 +108,7 @@ func SSHIdentityFromSSHCA(id *sshca.Identity) *decisionpb.SSHIdentity {
 		Generation:              id.Generation,
 		BotName:                 id.BotName,
 		BotInstanceId:           id.BotInstanceID,
+		BotScope:                id.BotScope,
 		//nolint:staticcheck // TODO(kiosion): deprecated, to be removed in v21
 		AllowedResourceIds:       resourceIDsFromTypes(id.AllowedResourceIDs),
 		AllowedResourceAccessIds: resourceAccessIDValuesToPointers(id.AllowedResourceAccessIDs),

--- a/lib/decision/ssh_identity_test.go
+++ b/lib/decision/ssh_identity_test.go
@@ -80,6 +80,7 @@ func TestSSHIdentityConversion(t *testing.T) {
 		Generation:    3,
 		BotName:       "bot",
 		BotInstanceID: "instance",
+		BotScope:      "/foo",
 		JoinToken:     "join-token",
 		//nolint:staticcheck // TODO(kiosion): deprecated, to be removed in v21
 		AllowedResourceIDs: []types.ResourceID{{

--- a/lib/decision/tls_identity.go
+++ b/lib/decision/tls_identity.go
@@ -72,6 +72,7 @@ func TLSIdentityToTLSCA(id *decisionpb.TLSIdentity) *tlsca.Identity {
 		Generation:              id.Generation,
 		BotName:                 id.BotName,
 		BotInstanceID:           id.BotInstanceId,
+		BotScope:                id.BotScope,
 		JoinToken:               id.JoinToken,
 		//nolint:staticcheck // TODO(kiosion): deprecated, to be removed in v21
 		AllowedResourceIDs:       resourceIDsToTypes(id.AllowedResourceIds),
@@ -124,6 +125,7 @@ func TLSIdentityFromTLSCA(id *tlsca.Identity) *decisionpb.TLSIdentity {
 		Generation:              id.Generation,
 		BotName:                 id.BotName,
 		BotInstanceId:           id.BotInstanceID,
+		BotScope:                id.BotScope,
 		JoinToken:               id.JoinToken,
 		//nolint:staticcheck // TODO(kiosion): deprecated, to be removed in v21
 		AllowedResourceIds:       resourceIDsFromTypes(id.AllowedResourceIDs),

--- a/lib/decision/tls_identity_test.go
+++ b/lib/decision/tls_identity_test.go
@@ -105,6 +105,7 @@ func TestTLSIdentity_roundtrip(t *testing.T) {
 		Generation:              112,
 		BotName:                 "bot-name",
 		BotInstanceId:           "bot-instance-id",
+		BotScope:                "/foo",
 		AllowedResourceIds: []*decisionpb.ResourceId{
 			{
 				ClusterName:     "cluster1",

--- a/lib/sshca/identity.go
+++ b/lib/sshca/identity.go
@@ -124,6 +124,9 @@ type Identity struct {
 	// BotInstanceID is the unique identifier for the bot instance, if this is a
 	// Machine ID bot. It is empty for human users.
 	BotInstanceID string
+	// BotScope is the scope of the Machine ID bot this identity was issued to,
+	// if any. Empty for unscoped bots and human users.
+	BotScope string
 	// JoinToken is the name of the join token used by the bot to join, if any.
 	JoinToken string
 	// AllowedResourceIDs lists the resources the user should be able to access.
@@ -275,6 +278,9 @@ func (i *Identity) Encode(certFormat string) (*ssh.Certificate, error) {
 	}
 	if i.BotInstanceID != "" {
 		cert.Permissions.Extensions[teleport.CertExtensionBotInstanceID] = i.BotInstanceID
+	}
+	if i.BotScope != "" {
+		cert.Permissions.Extensions[teleport.CertExtensionBotScope] = i.BotScope
 	}
 	if i.JoinToken != "" {
 		cert.Permissions.Extensions[teleport.CertExtensionJoinToken] = i.JoinToken
@@ -525,6 +531,7 @@ func DecodeIdentity(cert *ssh.Certificate) (*Identity, error) {
 
 	ident.BotName = takeValue(teleport.CertExtensionBotName)
 	ident.BotInstanceID = takeValue(teleport.CertExtensionBotInstanceID)
+	ident.BotScope = takeValue(teleport.CertExtensionBotScope)
 	ident.JoinToken = takeValue(teleport.CertExtensionJoinToken)
 
 	var (

--- a/lib/sshca/identity_test.go
+++ b/lib/sshca/identity_test.go
@@ -83,6 +83,7 @@ func TestIdentityConversion(t *testing.T) {
 		Generation:    3,
 		BotName:       "bot",
 		BotInstanceID: "instance",
+		BotScope:      "/foo",
 		JoinToken:     "join-token",
 		AllowedResourceAccessIDs: []types.ResourceAccessID{{
 			Id: types.ResourceID{

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -202,6 +202,9 @@ type Identity struct {
 	// BotInstanceID is a unique identifier for Machine ID bots that is
 	// persisted through renewals.
 	BotInstanceID string
+	// BotScope is the scope of the Machine ID bot this identity was issued to,
+	// if any. Empty for unscoped bots and non-bot identities.
+	BotScope string
 	// BotInternal is a flag that indicates an identity is specifically a bot
 	// internal identity, rather than output certificates intended for direct
 	// consumption by users or user-facing bot services.
@@ -661,6 +664,10 @@ var (
 	// encoding the agent's pinned scope and system roles.
 	AgentScopePinASN1ExtensionOID = asn1.ObjectIdentifier{1, 3, 9999, 2, 31}
 
+	// BotScopeASN1ExtensionOID is an extension OID that encodes the scope of
+	// the Machine ID bot the certificate was issued to, if any.
+	BotScopeASN1ExtensionOID = asn1.ObjectIdentifier{1, 3, 9999, 2, 33}
+
 	// CAClusterNameExtensionOID records the cluster name in a Teleport CA
 	// certificate.
 	//
@@ -989,6 +996,14 @@ func (id *Identity) Subject() (pkix.Name, error) {
 			pkix.AttributeTypeAndValue{
 				Type:  BotInstanceASN1ExtensionOID,
 				Value: id.BotInstanceID,
+			})
+	}
+
+	if id.BotScope != "" {
+		subject.ExtraNames = append(subject.ExtraNames,
+			pkix.AttributeTypeAndValue{
+				Type:  BotScopeASN1ExtensionOID,
+				Value: id.BotScope,
 			})
 	}
 
@@ -1379,6 +1394,11 @@ func FromSubject(subject pkix.Name, expires time.Time) (*Identity, error) {
 			val, ok := attr.Value.(string)
 			if ok {
 				id.BotInstanceID = val
+			}
+		case attr.Type.Equal(BotScopeASN1ExtensionOID):
+			val, ok := attr.Value.(string)
+			if ok {
+				id.BotScope = val
 			}
 		case attr.Type.Equal(BotInternalASN1ExtensionOID):
 			val, ok := attr.Value.(string)

--- a/lib/tlsca/ca_test.go
+++ b/lib/tlsca/ca_test.go
@@ -220,6 +220,7 @@ func TestJoinAttributes(t *testing.T) {
 		Groups:        []string{"bot-bernard"},
 		BotName:       "bernard",
 		BotInstanceID: "1234-5678",
+		BotScope:      "/foo",
 		BotInternal:   true,
 		Expires:       expires,
 		JoinAttributes: &workloadidentityv1pb.JoinAttrs{


### PR DESCRIPTION
Backports #68385

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

- [x] Smoke: Join and renew unscoped Bot, ensure functions correctly.
- [x] Join and renew scoped Bot, ensure internal certificate and output certificate include BotScope attribute.