### PR TITLE
Add in-band MFA desktop protos and Go bindings.

### DIFF
--- a/api/gen/proto/go/teleport/desktop/v1/tdpb.pb.go
+++ b/api/gen/proto/go/teleport/desktop/v1/tdpb.pb.go
@@ -3175,6 +3175,431 @@ func (b0 Ping_builder) Build() *Ping {
 	return m0
 }
 
+// Sent by the server to request authentication from the client before session establishment.
+type AuthPrompt struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// Types that are valid to be assigned to Prompt:
+	//
+	//	*AuthPrompt_MfaPrompt
+	Prompt        isAuthPrompt_Prompt `protobuf_oneof:"prompt"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AuthPrompt) Reset() {
+	*x = AuthPrompt{}
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AuthPrompt) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AuthPrompt) ProtoMessage() {}
+
+func (x *AuthPrompt) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *AuthPrompt) GetPrompt() isAuthPrompt_Prompt {
+	if x != nil {
+		return x.Prompt
+	}
+	return nil
+}
+
+func (x *AuthPrompt) GetMfaPrompt() *MFAPrompt {
+	if x != nil {
+		if x, ok := x.Prompt.(*AuthPrompt_MfaPrompt); ok {
+			return x.MfaPrompt
+		}
+	}
+	return nil
+}
+
+func (x *AuthPrompt) SetMfaPrompt(v *MFAPrompt) {
+	if v == nil {
+		x.Prompt = nil
+		return
+	}
+	x.Prompt = &AuthPrompt_MfaPrompt{v}
+}
+
+func (x *AuthPrompt) HasPrompt() bool {
+	if x == nil {
+		return false
+	}
+	return x.Prompt != nil
+}
+
+func (x *AuthPrompt) HasMfaPrompt() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.Prompt.(*AuthPrompt_MfaPrompt)
+	return ok
+}
+
+func (x *AuthPrompt) ClearPrompt() {
+	x.Prompt = nil
+}
+
+func (x *AuthPrompt) ClearMfaPrompt() {
+	if _, ok := x.Prompt.(*AuthPrompt_MfaPrompt); ok {
+		x.Prompt = nil
+	}
+}
+
+const AuthPrompt_Prompt_not_set_case case_AuthPrompt_Prompt = 0
+const AuthPrompt_MfaPrompt_case case_AuthPrompt_Prompt = 1
+
+func (x *AuthPrompt) WhichPrompt() case_AuthPrompt_Prompt {
+	if x == nil {
+		return AuthPrompt_Prompt_not_set_case
+	}
+	switch x.Prompt.(type) {
+	case *AuthPrompt_MfaPrompt:
+		return AuthPrompt_MfaPrompt_case
+	default:
+		return AuthPrompt_Prompt_not_set_case
+	}
+}
+
+type AuthPrompt_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Fields of oneof Prompt:
+	MfaPrompt *MFAPrompt
+	// -- end of Prompt
+}
+
+func (b0 AuthPrompt_builder) Build() *AuthPrompt {
+	m0 := &AuthPrompt{}
+	b, x := &b0, m0
+	_, _ = b, x
+	if b.MfaPrompt != nil {
+		x.Prompt = &AuthPrompt_MfaPrompt{b.MfaPrompt}
+	}
+	return m0
+}
+
+type case_AuthPrompt_Prompt protoreflect.FieldNumber
+
+func (x case_AuthPrompt_Prompt) String() string {
+	md := file_teleport_desktop_v1_tdpb_proto_msgTypes[26].Descriptor()
+	if x == 0 {
+		return "not set"
+	}
+	return protoimpl.X.MessageFieldStringOf(md, protoreflect.FieldNumber(x))
+}
+
+type isAuthPrompt_Prompt interface {
+	isAuthPrompt_Prompt()
+}
+
+type AuthPrompt_MfaPrompt struct {
+	MfaPrompt *MFAPrompt `protobuf:"bytes,1,opt,name=mfa_prompt,json=mfaPrompt,proto3,oneof"`
+}
+
+func (*AuthPrompt_MfaPrompt) isAuthPrompt_Prompt() {}
+
+// Indicates MFA is required for the session. The client performs the MFA ceremony and responds with
+// MFAPromptResponse.
+type MFAPrompt struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MFAPrompt) Reset() {
+	*x = MFAPrompt{}
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MFAPrompt) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MFAPrompt) ProtoMessage() {}
+
+func (x *MFAPrompt) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type MFAPrompt_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 MFAPrompt_builder) Build() *MFAPrompt {
+	m0 := &MFAPrompt{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
+// Client response to an AuthPrompt containing MFAPrompt.
+type MFAPromptResponse struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// Types that are valid to be assigned to Response:
+	//
+	//	*MFAPromptResponse_Reference
+	Response      isMFAPromptResponse_Response `protobuf_oneof:"response"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MFAPromptResponse) Reset() {
+	*x = MFAPromptResponse{}
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MFAPromptResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MFAPromptResponse) ProtoMessage() {}
+
+func (x *MFAPromptResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *MFAPromptResponse) GetResponse() isMFAPromptResponse_Response {
+	if x != nil {
+		return x.Response
+	}
+	return nil
+}
+
+func (x *MFAPromptResponse) GetReference() *MFAPromptResponseReference {
+	if x != nil {
+		if x, ok := x.Response.(*MFAPromptResponse_Reference); ok {
+			return x.Reference
+		}
+	}
+	return nil
+}
+
+func (x *MFAPromptResponse) SetReference(v *MFAPromptResponseReference) {
+	if v == nil {
+		x.Response = nil
+		return
+	}
+	x.Response = &MFAPromptResponse_Reference{v}
+}
+
+func (x *MFAPromptResponse) HasResponse() bool {
+	if x == nil {
+		return false
+	}
+	return x.Response != nil
+}
+
+func (x *MFAPromptResponse) HasReference() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.Response.(*MFAPromptResponse_Reference)
+	return ok
+}
+
+func (x *MFAPromptResponse) ClearResponse() {
+	x.Response = nil
+}
+
+func (x *MFAPromptResponse) ClearReference() {
+	if _, ok := x.Response.(*MFAPromptResponse_Reference); ok {
+		x.Response = nil
+	}
+}
+
+const MFAPromptResponse_Response_not_set_case case_MFAPromptResponse_Response = 0
+const MFAPromptResponse_Reference_case case_MFAPromptResponse_Response = 1
+
+func (x *MFAPromptResponse) WhichResponse() case_MFAPromptResponse_Response {
+	if x == nil {
+		return MFAPromptResponse_Response_not_set_case
+	}
+	switch x.Response.(type) {
+	case *MFAPromptResponse_Reference:
+		return MFAPromptResponse_Reference_case
+	default:
+		return MFAPromptResponse_Response_not_set_case
+	}
+}
+
+type MFAPromptResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Fields of oneof Response:
+	Reference *MFAPromptResponseReference
+	// -- end of Response
+}
+
+func (b0 MFAPromptResponse_builder) Build() *MFAPromptResponse {
+	m0 := &MFAPromptResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	if b.Reference != nil {
+		x.Response = &MFAPromptResponse_Reference{b.Reference}
+	}
+	return m0
+}
+
+type case_MFAPromptResponse_Response protoreflect.FieldNumber
+
+func (x case_MFAPromptResponse_Response) String() string {
+	md := file_teleport_desktop_v1_tdpb_proto_msgTypes[28].Descriptor()
+	if x == 0 {
+		return "not set"
+	}
+	return protoimpl.X.MessageFieldStringOf(md, protoreflect.FieldNumber(x))
+}
+
+type isMFAPromptResponse_Response interface {
+	isMFAPromptResponse_Response()
+}
+
+type MFAPromptResponse_Reference struct {
+	Reference *MFAPromptResponseReference `protobuf:"bytes,1,opt,name=reference,proto3,oneof"`
+}
+
+func (*MFAPromptResponse_Reference) isMFAPromptResponse_Response() {}
+
+// Instructs the server to verify the MFA challenge with the MFA service.
+type MFAPromptResponseReference struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The name of the MFA challenge created by the client.
+	ChallengeName string `protobuf:"bytes,1,opt,name=challenge_name,json=challengeName,proto3" json:"challenge_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MFAPromptResponseReference) Reset() {
+	*x = MFAPromptResponseReference{}
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MFAPromptResponseReference) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MFAPromptResponseReference) ProtoMessage() {}
+
+func (x *MFAPromptResponseReference) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *MFAPromptResponseReference) GetChallengeName() string {
+	if x != nil {
+		return x.ChallengeName
+	}
+	return ""
+}
+
+func (x *MFAPromptResponseReference) SetChallengeName(v string) {
+	x.ChallengeName = v
+}
+
+type MFAPromptResponseReference_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The name of the MFA challenge created by the client.
+	ChallengeName string
+}
+
+func (b0 MFAPromptResponseReference_builder) Build() *MFAPromptResponseReference {
+	m0 := &MFAPromptResponseReference{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.ChallengeName = b.ChallengeName
+	return m0
+}
+
+// Sent by the server to indicate the session backend is being established and no additional authentication is required.
+type SessionEstablishing struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SessionEstablishing) Reset() {
+	*x = SessionEstablishing{}
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SessionEstablishing) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SessionEstablishing) ProtoMessage() {}
+
+func (x *SessionEstablishing) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type SessionEstablishing_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 SessionEstablishing_builder) Build() *SessionEstablishing {
+	m0 := &SessionEstablishing{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
 // Envelope wraps all messages that are allowed to be sent on the wire.
 type Envelope struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
@@ -3202,6 +3627,9 @@ type Envelope struct {
 	//	*Envelope_Ping
 	//	*Envelope_SharedDirectoryRemove
 	//	*Envelope_SessionSelection
+	//	*Envelope_AuthPrompt
+	//	*Envelope_MfaPromptResponse
+	//	*Envelope_SessionEstablishing
 	Payload       isEnvelope_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -3209,7 +3637,7 @@ type Envelope struct {
 
 func (x *Envelope) Reset() {
 	*x = Envelope{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[26]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3221,7 +3649,7 @@ func (x *Envelope) String() string {
 func (*Envelope) ProtoMessage() {}
 
 func (x *Envelope) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[26]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3437,6 +3865,33 @@ func (x *Envelope) GetSessionSelection() *SessionSelection {
 	return nil
 }
 
+func (x *Envelope) GetAuthPrompt() *AuthPrompt {
+	if x != nil {
+		if x, ok := x.Payload.(*Envelope_AuthPrompt); ok {
+			return x.AuthPrompt
+		}
+	}
+	return nil
+}
+
+func (x *Envelope) GetMfaPromptResponse() *MFAPromptResponse {
+	if x != nil {
+		if x, ok := x.Payload.(*Envelope_MfaPromptResponse); ok {
+			return x.MfaPromptResponse
+		}
+	}
+	return nil
+}
+
+func (x *Envelope) GetSessionEstablishing() *SessionEstablishing {
+	if x != nil {
+		if x, ok := x.Payload.(*Envelope_SessionEstablishing); ok {
+			return x.SessionEstablishing
+		}
+	}
+	return nil
+}
+
 func (x *Envelope) SetClientHello(v *ClientHello) {
 	if v == nil {
 		x.Payload = nil
@@ -3611,6 +4066,30 @@ func (x *Envelope) SetSessionSelection(v *SessionSelection) {
 		return
 	}
 	x.Payload = &Envelope_SessionSelection{v}
+}
+
+func (x *Envelope) SetAuthPrompt(v *AuthPrompt) {
+	if v == nil {
+		x.Payload = nil
+		return
+	}
+	x.Payload = &Envelope_AuthPrompt{v}
+}
+
+func (x *Envelope) SetMfaPromptResponse(v *MFAPromptResponse) {
+	if v == nil {
+		x.Payload = nil
+		return
+	}
+	x.Payload = &Envelope_MfaPromptResponse{v}
+}
+
+func (x *Envelope) SetSessionEstablishing(v *SessionEstablishing) {
+	if v == nil {
+		x.Payload = nil
+		return
+	}
+	x.Payload = &Envelope_SessionEstablishing{v}
 }
 
 func (x *Envelope) HasPayload() bool {
@@ -3796,6 +4275,30 @@ func (x *Envelope) HasSessionSelection() bool {
 	return ok
 }
 
+func (x *Envelope) HasAuthPrompt() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.Payload.(*Envelope_AuthPrompt)
+	return ok
+}
+
+func (x *Envelope) HasMfaPromptResponse() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.Payload.(*Envelope_MfaPromptResponse)
+	return ok
+}
+
+func (x *Envelope) HasSessionEstablishing() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.Payload.(*Envelope_SessionEstablishing)
+	return ok
+}
+
 func (x *Envelope) ClearPayload() {
 	x.Payload = nil
 }
@@ -3932,6 +4435,24 @@ func (x *Envelope) ClearSessionSelection() {
 	}
 }
 
+func (x *Envelope) ClearAuthPrompt() {
+	if _, ok := x.Payload.(*Envelope_AuthPrompt); ok {
+		x.Payload = nil
+	}
+}
+
+func (x *Envelope) ClearMfaPromptResponse() {
+	if _, ok := x.Payload.(*Envelope_MfaPromptResponse); ok {
+		x.Payload = nil
+	}
+}
+
+func (x *Envelope) ClearSessionEstablishing() {
+	if _, ok := x.Payload.(*Envelope_SessionEstablishing); ok {
+		x.Payload = nil
+	}
+}
+
 const Envelope_Payload_not_set_case case_Envelope_Payload = 0
 const Envelope_ClientHello_case case_Envelope_Payload = 1
 const Envelope_ServerHello_case case_Envelope_Payload = 2
@@ -3955,6 +4476,9 @@ const Envelope_LatencyStats_case case_Envelope_Payload = 19
 const Envelope_Ping_case case_Envelope_Payload = 20
 const Envelope_SharedDirectoryRemove_case case_Envelope_Payload = 21
 const Envelope_SessionSelection_case case_Envelope_Payload = 22
+const Envelope_AuthPrompt_case case_Envelope_Payload = 23
+const Envelope_MfaPromptResponse_case case_Envelope_Payload = 24
+const Envelope_SessionEstablishing_case case_Envelope_Payload = 25
 
 func (x *Envelope) WhichPayload() case_Envelope_Payload {
 	if x == nil {
@@ -4005,6 +4529,12 @@ func (x *Envelope) WhichPayload() case_Envelope_Payload {
 		return Envelope_SharedDirectoryRemove_case
 	case *Envelope_SessionSelection:
 		return Envelope_SessionSelection_case
+	case *Envelope_AuthPrompt:
+		return Envelope_AuthPrompt_case
+	case *Envelope_MfaPromptResponse:
+		return Envelope_MfaPromptResponse_case
+	case *Envelope_SessionEstablishing:
+		return Envelope_SessionEstablishing_case
 	default:
 		return Envelope_Payload_not_set_case
 	}
@@ -4036,6 +4566,9 @@ type Envelope_builder struct {
 	Ping                       *Ping
 	SharedDirectoryRemove      *SharedDirectoryRemove
 	SessionSelection           *SessionSelection
+	AuthPrompt                 *AuthPrompt
+	MfaPromptResponse          *MFAPromptResponse
+	SessionEstablishing        *SessionEstablishing
 	// -- end of Payload
 }
 
@@ -4109,13 +4642,22 @@ func (b0 Envelope_builder) Build() *Envelope {
 	if b.SessionSelection != nil {
 		x.Payload = &Envelope_SessionSelection{b.SessionSelection}
 	}
+	if b.AuthPrompt != nil {
+		x.Payload = &Envelope_AuthPrompt{b.AuthPrompt}
+	}
+	if b.MfaPromptResponse != nil {
+		x.Payload = &Envelope_MfaPromptResponse{b.MfaPromptResponse}
+	}
+	if b.SessionEstablishing != nil {
+		x.Payload = &Envelope_SessionEstablishing{b.SessionEstablishing}
+	}
 	return m0
 }
 
 type case_Envelope_Payload protoreflect.FieldNumber
 
 func (x case_Envelope_Payload) String() string {
-	md := file_teleport_desktop_v1_tdpb_proto_msgTypes[26].Descriptor()
+	md := file_teleport_desktop_v1_tdpb_proto_msgTypes[31].Descriptor()
 	if x == 0 {
 		return "not set"
 	}
@@ -4214,6 +4756,18 @@ type Envelope_SessionSelection struct {
 	SessionSelection *SessionSelection `protobuf:"bytes,22,opt,name=session_selection,json=sessionSelection,proto3,oneof"`
 }
 
+type Envelope_AuthPrompt struct {
+	AuthPrompt *AuthPrompt `protobuf:"bytes,23,opt,name=auth_prompt,json=authPrompt,proto3,oneof"`
+}
+
+type Envelope_MfaPromptResponse struct {
+	MfaPromptResponse *MFAPromptResponse `protobuf:"bytes,24,opt,name=mfa_prompt_response,json=mfaPromptResponse,proto3,oneof"`
+}
+
+type Envelope_SessionEstablishing struct {
+	SessionEstablishing *SessionEstablishing `protobuf:"bytes,25,opt,name=session_establishing,json=sessionEstablishing,proto3,oneof"`
+}
+
 func (*Envelope_ClientHello) isEnvelope_Payload() {}
 
 func (*Envelope_ServerHello) isEnvelope_Payload() {}
@@ -4258,6 +4812,12 @@ func (*Envelope_SharedDirectoryRemove) isEnvelope_Payload() {}
 
 func (*Envelope_SessionSelection) isEnvelope_Payload() {}
 
+func (*Envelope_AuthPrompt) isEnvelope_Payload() {}
+
+func (*Envelope_MfaPromptResponse) isEnvelope_Payload() {}
+
+func (*Envelope_SessionEstablishing) isEnvelope_Payload() {}
+
 // Info request.
 type SharedDirectoryRequest_Info struct {
 	state         protoimpl.MessageState `protogen:"hybrid.v1"`
@@ -4268,7 +4828,7 @@ type SharedDirectoryRequest_Info struct {
 
 func (x *SharedDirectoryRequest_Info) Reset() {
 	*x = SharedDirectoryRequest_Info{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[27]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4280,7 +4840,7 @@ func (x *SharedDirectoryRequest_Info) String() string {
 func (*SharedDirectoryRequest_Info) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Info) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[27]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4327,7 +4887,7 @@ type SharedDirectoryRequest_Create struct {
 
 func (x *SharedDirectoryRequest_Create) Reset() {
 	*x = SharedDirectoryRequest_Create{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[28]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4339,7 +4899,7 @@ func (x *SharedDirectoryRequest_Create) String() string {
 func (*SharedDirectoryRequest_Create) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Create) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[28]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4398,7 +4958,7 @@ type SharedDirectoryRequest_Delete struct {
 
 func (x *SharedDirectoryRequest_Delete) Reset() {
 	*x = SharedDirectoryRequest_Delete{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[29]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4410,7 +4970,7 @@ func (x *SharedDirectoryRequest_Delete) String() string {
 func (*SharedDirectoryRequest_Delete) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Delete) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[29]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4456,7 +5016,7 @@ type SharedDirectoryRequest_List struct {
 
 func (x *SharedDirectoryRequest_List) Reset() {
 	*x = SharedDirectoryRequest_List{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[30]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4468,7 +5028,7 @@ func (x *SharedDirectoryRequest_List) String() string {
 func (*SharedDirectoryRequest_List) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_List) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[30]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4516,7 +5076,7 @@ type SharedDirectoryRequest_Read struct {
 
 func (x *SharedDirectoryRequest_Read) Reset() {
 	*x = SharedDirectoryRequest_Read{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[31]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4528,7 +5088,7 @@ func (x *SharedDirectoryRequest_Read) String() string {
 func (*SharedDirectoryRequest_Read) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Read) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[31]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4602,7 +5162,7 @@ type SharedDirectoryRequest_Write struct {
 
 func (x *SharedDirectoryRequest_Write) Reset() {
 	*x = SharedDirectoryRequest_Write{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[32]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4614,7 +5174,7 @@ func (x *SharedDirectoryRequest_Write) String() string {
 func (*SharedDirectoryRequest_Write) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Write) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[32]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4690,7 +5250,7 @@ type SharedDirectoryRequest_Move struct {
 
 func (x *SharedDirectoryRequest_Move) Reset() {
 	*x = SharedDirectoryRequest_Move{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[33]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4702,7 +5262,7 @@ func (x *SharedDirectoryRequest_Move) String() string {
 func (*SharedDirectoryRequest_Move) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Move) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[33]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4762,7 +5322,7 @@ type SharedDirectoryRequest_Truncate struct {
 
 func (x *SharedDirectoryRequest_Truncate) Reset() {
 	*x = SharedDirectoryRequest_Truncate{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[34]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4774,7 +5334,7 @@ func (x *SharedDirectoryRequest_Truncate) String() string {
 func (*SharedDirectoryRequest_Truncate) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Truncate) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[34]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4833,7 +5393,7 @@ type SharedDirectoryResponse_Info struct {
 
 func (x *SharedDirectoryResponse_Info) Reset() {
 	*x = SharedDirectoryResponse_Info{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[35]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4845,7 +5405,7 @@ func (x *SharedDirectoryResponse_Info) String() string {
 func (*SharedDirectoryResponse_Info) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Info) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[35]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4902,7 +5462,7 @@ type SharedDirectoryResponse_Create struct {
 
 func (x *SharedDirectoryResponse_Create) Reset() {
 	*x = SharedDirectoryResponse_Create{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[36]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4914,7 +5474,7 @@ func (x *SharedDirectoryResponse_Create) String() string {
 func (*SharedDirectoryResponse_Create) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Create) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[36]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4970,7 +5530,7 @@ type SharedDirectoryResponse_Delete struct {
 
 func (x *SharedDirectoryResponse_Delete) Reset() {
 	*x = SharedDirectoryResponse_Delete{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[37]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4982,7 +5542,7 @@ func (x *SharedDirectoryResponse_Delete) String() string {
 func (*SharedDirectoryResponse_Delete) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Delete) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[37]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5015,7 +5575,7 @@ type SharedDirectoryResponse_List struct {
 
 func (x *SharedDirectoryResponse_List) Reset() {
 	*x = SharedDirectoryResponse_List{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[38]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5027,7 +5587,7 @@ func (x *SharedDirectoryResponse_List) String() string {
 func (*SharedDirectoryResponse_List) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_List) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[38]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5073,7 +5633,7 @@ type SharedDirectoryResponse_Read struct {
 
 func (x *SharedDirectoryResponse_Read) Reset() {
 	*x = SharedDirectoryResponse_Read{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[39]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5085,7 +5645,7 @@ func (x *SharedDirectoryResponse_Read) String() string {
 func (*SharedDirectoryResponse_Read) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Read) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[39]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5134,7 +5694,7 @@ type SharedDirectoryResponse_Write struct {
 
 func (x *SharedDirectoryResponse_Write) Reset() {
 	*x = SharedDirectoryResponse_Write{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[40]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5146,7 +5706,7 @@ func (x *SharedDirectoryResponse_Write) String() string {
 func (*SharedDirectoryResponse_Write) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Write) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[40]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5191,7 +5751,7 @@ type SharedDirectoryResponse_Move struct {
 
 func (x *SharedDirectoryResponse_Move) Reset() {
 	*x = SharedDirectoryResponse_Move{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[41]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5203,7 +5763,7 @@ func (x *SharedDirectoryResponse_Move) String() string {
 func (*SharedDirectoryResponse_Move) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Move) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[41]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5235,7 +5795,7 @@ type SharedDirectoryResponse_Truncate struct {
 
 func (x *SharedDirectoryResponse_Truncate) Reset() {
 	*x = SharedDirectoryResponse_Truncate{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[42]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5247,7 +5807,7 @@ func (x *SharedDirectoryResponse_Truncate) String() string {
 func (*SharedDirectoryResponse_Truncate) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Truncate) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[42]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5425,7 +5985,20 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\x11client_latency_ms\x18\x01 \x01(\rR\x0fclientLatencyMs\x12*\n" +
 	"\x11server_latency_ms\x18\x02 \x01(\rR\x0fserverLatencyMs\"\x1a\n" +
 	"\x04Ping\x12\x12\n" +
-	"\x04uuid\x18\x01 \x01(\fR\x04uuid\"\xc7\r\n" +
+	"\x04uuid\x18\x01 \x01(\fR\x04uuid\"W\n" +
+	"\n" +
+	"AuthPrompt\x12?\n" +
+	"\n" +
+	"mfa_prompt\x18\x01 \x01(\v2\x1e.teleport.desktop.v1.MFAPromptH\x00R\tmfaPromptB\b\n" +
+	"\x06prompt\"\v\n" +
+	"\tMFAPrompt\"p\n" +
+	"\x11MFAPromptResponse\x12O\n" +
+	"\treference\x18\x01 \x01(\v2/.teleport.desktop.v1.MFAPromptResponseReferenceH\x00R\treferenceB\n" +
+	"\n" +
+	"\bresponse\"C\n" +
+	"\x1aMFAPromptResponseReference\x12%\n" +
+	"\x0echallenge_name\x18\x01 \x01(\tR\rchallengeName\"\x15\n" +
+	"\x13SessionEstablishing\"\xc4\x0f\n" +
 	"\bEnvelope\x12E\n" +
 	"\fclient_hello\x18\x01 \x01(\v2 .teleport.desktop.v1.ClientHelloH\x00R\vclientHello\x12E\n" +
 	"\fserver_hello\x18\x02 \x01(\v2 .teleport.desktop.v1.ServerHelloH\x00R\vserverHello\x12<\n" +
@@ -5451,7 +6024,11 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\rlatency_stats\x18\x13 \x01(\v2!.teleport.desktop.v1.LatencyStatsH\x00R\flatencyStats\x12/\n" +
 	"\x04ping\x18\x14 \x01(\v2\x19.teleport.desktop.v1.PingH\x00R\x04ping\x12d\n" +
 	"\x17shared_directory_remove\x18\x15 \x01(\v2*.teleport.desktop.v1.SharedDirectoryRemoveH\x00R\x15sharedDirectoryRemove\x12T\n" +
-	"\x11session_selection\x18\x16 \x01(\v2%.teleport.desktop.v1.SessionSelectionH\x00R\x10sessionSelectionB\t\n" +
+	"\x11session_selection\x18\x16 \x01(\v2%.teleport.desktop.v1.SessionSelectionH\x00R\x10sessionSelection\x12B\n" +
+	"\vauth_prompt\x18\x17 \x01(\v2\x1f.teleport.desktop.v1.AuthPromptH\x00R\n" +
+	"authPrompt\x12X\n" +
+	"\x13mfa_prompt_response\x18\x18 \x01(\v2&.teleport.desktop.v1.MFAPromptResponseH\x00R\x11mfaPromptResponse\x12]\n" +
+	"\x14session_establishing\x18\x19 \x01(\v2(.teleport.desktop.v1.SessionEstablishingH\x00R\x13sessionEstablishingB\t\n" +
 	"\apayload*\x8b\x01\n" +
 	"\x0fMouseButtonType\x12!\n" +
 	"\x1dMOUSE_BUTTON_TYPE_UNSPECIFIED\x10\x00\x12\x1a\n" +
@@ -5473,7 +6050,7 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\fMFA_TYPE_U2F\x10\x02BOZMgithub.com/gravitational/teleport/api/gen/proto/go/teleport/desktop/v1;tdpbv1b\x06proto3"
 
 var file_teleport_desktop_v1_tdpb_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_teleport_desktop_v1_tdpb_proto_msgTypes = make([]protoimpl.MessageInfo, 43)
+var file_teleport_desktop_v1_tdpb_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
 var file_teleport_desktop_v1_tdpb_proto_goTypes = []any{
 	(MouseButtonType)(0),                     // 0: teleport.desktop.v1.MouseButtonType
 	(AlertSeverity)(0),                       // 1: teleport.desktop.v1.AlertSeverity
@@ -5505,25 +6082,30 @@ var file_teleport_desktop_v1_tdpb_proto_goTypes = []any{
 	(*FileSystemObject)(nil),                 // 27: teleport.desktop.v1.FileSystemObject
 	(*LatencyStats)(nil),                     // 28: teleport.desktop.v1.LatencyStats
 	(*Ping)(nil),                             // 29: teleport.desktop.v1.Ping
-	(*Envelope)(nil),                         // 30: teleport.desktop.v1.Envelope
-	(*SharedDirectoryRequest_Info)(nil),      // 31: teleport.desktop.v1.SharedDirectoryRequest.Info
-	(*SharedDirectoryRequest_Create)(nil),    // 32: teleport.desktop.v1.SharedDirectoryRequest.Create
-	(*SharedDirectoryRequest_Delete)(nil),    // 33: teleport.desktop.v1.SharedDirectoryRequest.Delete
-	(*SharedDirectoryRequest_List)(nil),      // 34: teleport.desktop.v1.SharedDirectoryRequest.List
-	(*SharedDirectoryRequest_Read)(nil),      // 35: teleport.desktop.v1.SharedDirectoryRequest.Read
-	(*SharedDirectoryRequest_Write)(nil),     // 36: teleport.desktop.v1.SharedDirectoryRequest.Write
-	(*SharedDirectoryRequest_Move)(nil),      // 37: teleport.desktop.v1.SharedDirectoryRequest.Move
-	(*SharedDirectoryRequest_Truncate)(nil),  // 38: teleport.desktop.v1.SharedDirectoryRequest.Truncate
-	(*SharedDirectoryResponse_Info)(nil),     // 39: teleport.desktop.v1.SharedDirectoryResponse.Info
-	(*SharedDirectoryResponse_Create)(nil),   // 40: teleport.desktop.v1.SharedDirectoryResponse.Create
-	(*SharedDirectoryResponse_Delete)(nil),   // 41: teleport.desktop.v1.SharedDirectoryResponse.Delete
-	(*SharedDirectoryResponse_List)(nil),     // 42: teleport.desktop.v1.SharedDirectoryResponse.List
-	(*SharedDirectoryResponse_Read)(nil),     // 43: teleport.desktop.v1.SharedDirectoryResponse.Read
-	(*SharedDirectoryResponse_Write)(nil),    // 44: teleport.desktop.v1.SharedDirectoryResponse.Write
-	(*SharedDirectoryResponse_Move)(nil),     // 45: teleport.desktop.v1.SharedDirectoryResponse.Move
-	(*SharedDirectoryResponse_Truncate)(nil), // 46: teleport.desktop.v1.SharedDirectoryResponse.Truncate
-	(*v1.AuthenticateChallenge)(nil),         // 47: teleport.mfa.v1.AuthenticateChallenge
-	(*v1.AuthenticateResponse)(nil),          // 48: teleport.mfa.v1.AuthenticateResponse
+	(*AuthPrompt)(nil),                       // 30: teleport.desktop.v1.AuthPrompt
+	(*MFAPrompt)(nil),                        // 31: teleport.desktop.v1.MFAPrompt
+	(*MFAPromptResponse)(nil),                // 32: teleport.desktop.v1.MFAPromptResponse
+	(*MFAPromptResponseReference)(nil),       // 33: teleport.desktop.v1.MFAPromptResponseReference
+	(*SessionEstablishing)(nil),              // 34: teleport.desktop.v1.SessionEstablishing
+	(*Envelope)(nil),                         // 35: teleport.desktop.v1.Envelope
+	(*SharedDirectoryRequest_Info)(nil),      // 36: teleport.desktop.v1.SharedDirectoryRequest.Info
+	(*SharedDirectoryRequest_Create)(nil),    // 37: teleport.desktop.v1.SharedDirectoryRequest.Create
+	(*SharedDirectoryRequest_Delete)(nil),    // 38: teleport.desktop.v1.SharedDirectoryRequest.Delete
+	(*SharedDirectoryRequest_List)(nil),      // 39: teleport.desktop.v1.SharedDirectoryRequest.List
+	(*SharedDirectoryRequest_Read)(nil),      // 40: teleport.desktop.v1.SharedDirectoryRequest.Read
+	(*SharedDirectoryRequest_Write)(nil),     // 41: teleport.desktop.v1.SharedDirectoryRequest.Write
+	(*SharedDirectoryRequest_Move)(nil),      // 42: teleport.desktop.v1.SharedDirectoryRequest.Move
+	(*SharedDirectoryRequest_Truncate)(nil),  // 43: teleport.desktop.v1.SharedDirectoryRequest.Truncate
+	(*SharedDirectoryResponse_Info)(nil),     // 44: teleport.desktop.v1.SharedDirectoryResponse.Info
+	(*SharedDirectoryResponse_Create)(nil),   // 45: teleport.desktop.v1.SharedDirectoryResponse.Create
+	(*SharedDirectoryResponse_Delete)(nil),   // 46: teleport.desktop.v1.SharedDirectoryResponse.Delete
+	(*SharedDirectoryResponse_List)(nil),     // 47: teleport.desktop.v1.SharedDirectoryResponse.List
+	(*SharedDirectoryResponse_Read)(nil),     // 48: teleport.desktop.v1.SharedDirectoryResponse.Read
+	(*SharedDirectoryResponse_Write)(nil),    // 49: teleport.desktop.v1.SharedDirectoryResponse.Write
+	(*SharedDirectoryResponse_Move)(nil),     // 50: teleport.desktop.v1.SharedDirectoryResponse.Move
+	(*SharedDirectoryResponse_Truncate)(nil), // 51: teleport.desktop.v1.SharedDirectoryResponse.Truncate
+	(*v1.AuthenticateChallenge)(nil),         // 52: teleport.mfa.v1.AuthenticateChallenge
+	(*v1.AuthenticateResponse)(nil),          // 53: teleport.mfa.v1.AuthenticateResponse
 }
 var file_teleport_desktop_v1_tdpb_proto_depIdxs = []int32{
 	17, // 0: teleport.desktop.v1.ClientHello.screen_spec:type_name -> teleport.desktop.v1.ClientScreenSpec
@@ -5535,54 +6117,59 @@ var file_teleport_desktop_v1_tdpb_proto_depIdxs = []int32{
 	1,  // 6: teleport.desktop.v1.Alert.severity:type_name -> teleport.desktop.v1.AlertSeverity
 	2,  // 7: teleport.desktop.v1.MouseWheel.axis:type_name -> teleport.desktop.v1.MouseWheelAxis
 	3,  // 8: teleport.desktop.v1.MFA.type:type_name -> teleport.desktop.v1.MFAType
-	47, // 9: teleport.desktop.v1.MFA.challenge:type_name -> teleport.mfa.v1.AuthenticateChallenge
-	48, // 10: teleport.desktop.v1.MFA.authentication_response:type_name -> teleport.mfa.v1.AuthenticateResponse
-	31, // 11: teleport.desktop.v1.SharedDirectoryRequest.info:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Info
-	32, // 12: teleport.desktop.v1.SharedDirectoryRequest.create:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Create
-	33, // 13: teleport.desktop.v1.SharedDirectoryRequest.delete:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Delete
-	34, // 14: teleport.desktop.v1.SharedDirectoryRequest.list:type_name -> teleport.desktop.v1.SharedDirectoryRequest.List
-	35, // 15: teleport.desktop.v1.SharedDirectoryRequest.read:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Read
-	36, // 16: teleport.desktop.v1.SharedDirectoryRequest.write:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Write
-	37, // 17: teleport.desktop.v1.SharedDirectoryRequest.move:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Move
-	38, // 18: teleport.desktop.v1.SharedDirectoryRequest.truncate:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Truncate
-	39, // 19: teleport.desktop.v1.SharedDirectoryResponse.info:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Info
-	40, // 20: teleport.desktop.v1.SharedDirectoryResponse.create:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Create
-	41, // 21: teleport.desktop.v1.SharedDirectoryResponse.delete:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Delete
-	42, // 22: teleport.desktop.v1.SharedDirectoryResponse.list:type_name -> teleport.desktop.v1.SharedDirectoryResponse.List
-	43, // 23: teleport.desktop.v1.SharedDirectoryResponse.read:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Read
-	44, // 24: teleport.desktop.v1.SharedDirectoryResponse.write:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Write
-	45, // 25: teleport.desktop.v1.SharedDirectoryResponse.move:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Move
-	46, // 26: teleport.desktop.v1.SharedDirectoryResponse.truncate:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Truncate
-	4,  // 27: teleport.desktop.v1.Envelope.client_hello:type_name -> teleport.desktop.v1.ClientHello
-	5,  // 28: teleport.desktop.v1.Envelope.server_hello:type_name -> teleport.desktop.v1.ServerHello
-	9,  // 29: teleport.desktop.v1.Envelope.png_frame:type_name -> teleport.desktop.v1.PNGFrame
-	10, // 30: teleport.desktop.v1.Envelope.fast_path_pdu:type_name -> teleport.desktop.v1.FastPathPDU
-	11, // 31: teleport.desktop.v1.Envelope.rdp_response_pdu:type_name -> teleport.desktop.v1.RDPResponsePDU
-	13, // 32: teleport.desktop.v1.Envelope.sync_keys:type_name -> teleport.desktop.v1.SyncKeys
-	14, // 33: teleport.desktop.v1.Envelope.mouse_move:type_name -> teleport.desktop.v1.MouseMove
-	15, // 34: teleport.desktop.v1.Envelope.mouse_button:type_name -> teleport.desktop.v1.MouseButton
-	16, // 35: teleport.desktop.v1.Envelope.keyboard_button:type_name -> teleport.desktop.v1.KeyboardButton
-	17, // 36: teleport.desktop.v1.Envelope.client_screen_spec:type_name -> teleport.desktop.v1.ClientScreenSpec
-	18, // 37: teleport.desktop.v1.Envelope.alert:type_name -> teleport.desktop.v1.Alert
-	19, // 38: teleport.desktop.v1.Envelope.mouse_wheel:type_name -> teleport.desktop.v1.MouseWheel
-	20, // 39: teleport.desktop.v1.Envelope.clipboard_data:type_name -> teleport.desktop.v1.ClipboardData
-	21, // 40: teleport.desktop.v1.Envelope.mfa:type_name -> teleport.desktop.v1.MFA
-	22, // 41: teleport.desktop.v1.Envelope.shared_directory_announce:type_name -> teleport.desktop.v1.SharedDirectoryAnnounce
-	24, // 42: teleport.desktop.v1.Envelope.shared_directory_acknowledge:type_name -> teleport.desktop.v1.SharedDirectoryAcknowledge
-	25, // 43: teleport.desktop.v1.Envelope.shared_directory_request:type_name -> teleport.desktop.v1.SharedDirectoryRequest
-	26, // 44: teleport.desktop.v1.Envelope.shared_directory_response:type_name -> teleport.desktop.v1.SharedDirectoryResponse
-	28, // 45: teleport.desktop.v1.Envelope.latency_stats:type_name -> teleport.desktop.v1.LatencyStats
-	29, // 46: teleport.desktop.v1.Envelope.ping:type_name -> teleport.desktop.v1.Ping
-	23, // 47: teleport.desktop.v1.Envelope.shared_directory_remove:type_name -> teleport.desktop.v1.SharedDirectoryRemove
-	7,  // 48: teleport.desktop.v1.Envelope.session_selection:type_name -> teleport.desktop.v1.SessionSelection
-	27, // 49: teleport.desktop.v1.SharedDirectoryResponse.Info.fso:type_name -> teleport.desktop.v1.FileSystemObject
-	27, // 50: teleport.desktop.v1.SharedDirectoryResponse.Create.fso:type_name -> teleport.desktop.v1.FileSystemObject
-	27, // 51: teleport.desktop.v1.SharedDirectoryResponse.List.fso_list:type_name -> teleport.desktop.v1.FileSystemObject
-	52, // [52:52] is the sub-list for method output_type
-	52, // [52:52] is the sub-list for method input_type
-	52, // [52:52] is the sub-list for extension type_name
-	52, // [52:52] is the sub-list for extension extendee
-	0,  // [0:52] is the sub-list for field type_name
+	52, // 9: teleport.desktop.v1.MFA.challenge:type_name -> teleport.mfa.v1.AuthenticateChallenge
+	53, // 10: teleport.desktop.v1.MFA.authentication_response:type_name -> teleport.mfa.v1.AuthenticateResponse
+	36, // 11: teleport.desktop.v1.SharedDirectoryRequest.info:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Info
+	37, // 12: teleport.desktop.v1.SharedDirectoryRequest.create:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Create
+	38, // 13: teleport.desktop.v1.SharedDirectoryRequest.delete:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Delete
+	39, // 14: teleport.desktop.v1.SharedDirectoryRequest.list:type_name -> teleport.desktop.v1.SharedDirectoryRequest.List
+	40, // 15: teleport.desktop.v1.SharedDirectoryRequest.read:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Read
+	41, // 16: teleport.desktop.v1.SharedDirectoryRequest.write:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Write
+	42, // 17: teleport.desktop.v1.SharedDirectoryRequest.move:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Move
+	43, // 18: teleport.desktop.v1.SharedDirectoryRequest.truncate:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Truncate
+	44, // 19: teleport.desktop.v1.SharedDirectoryResponse.info:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Info
+	45, // 20: teleport.desktop.v1.SharedDirectoryResponse.create:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Create
+	46, // 21: teleport.desktop.v1.SharedDirectoryResponse.delete:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Delete
+	47, // 22: teleport.desktop.v1.SharedDirectoryResponse.list:type_name -> teleport.desktop.v1.SharedDirectoryResponse.List
+	48, // 23: teleport.desktop.v1.SharedDirectoryResponse.read:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Read
+	49, // 24: teleport.desktop.v1.SharedDirectoryResponse.write:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Write
+	50, // 25: teleport.desktop.v1.SharedDirectoryResponse.move:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Move
+	51, // 26: teleport.desktop.v1.SharedDirectoryResponse.truncate:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Truncate
+	31, // 27: teleport.desktop.v1.AuthPrompt.mfa_prompt:type_name -> teleport.desktop.v1.MFAPrompt
+	33, // 28: teleport.desktop.v1.MFAPromptResponse.reference:type_name -> teleport.desktop.v1.MFAPromptResponseReference
+	4,  // 29: teleport.desktop.v1.Envelope.client_hello:type_name -> teleport.desktop.v1.ClientHello
+	5,  // 30: teleport.desktop.v1.Envelope.server_hello:type_name -> teleport.desktop.v1.ServerHello
+	9,  // 31: teleport.desktop.v1.Envelope.png_frame:type_name -> teleport.desktop.v1.PNGFrame
+	10, // 32: teleport.desktop.v1.Envelope.fast_path_pdu:type_name -> teleport.desktop.v1.FastPathPDU
+	11, // 33: teleport.desktop.v1.Envelope.rdp_response_pdu:type_name -> teleport.desktop.v1.RDPResponsePDU
+	13, // 34: teleport.desktop.v1.Envelope.sync_keys:type_name -> teleport.desktop.v1.SyncKeys
+	14, // 35: teleport.desktop.v1.Envelope.mouse_move:type_name -> teleport.desktop.v1.MouseMove
+	15, // 36: teleport.desktop.v1.Envelope.mouse_button:type_name -> teleport.desktop.v1.MouseButton
+	16, // 37: teleport.desktop.v1.Envelope.keyboard_button:type_name -> teleport.desktop.v1.KeyboardButton
+	17, // 38: teleport.desktop.v1.Envelope.client_screen_spec:type_name -> teleport.desktop.v1.ClientScreenSpec
+	18, // 39: teleport.desktop.v1.Envelope.alert:type_name -> teleport.desktop.v1.Alert
+	19, // 40: teleport.desktop.v1.Envelope.mouse_wheel:type_name -> teleport.desktop.v1.MouseWheel
+	20, // 41: teleport.desktop.v1.Envelope.clipboard_data:type_name -> teleport.desktop.v1.ClipboardData
+	21, // 42: teleport.desktop.v1.Envelope.mfa:type_name -> teleport.desktop.v1.MFA
+	22, // 43: teleport.desktop.v1.Envelope.shared_directory_announce:type_name -> teleport.desktop.v1.SharedDirectoryAnnounce
+	24, // 44: teleport.desktop.v1.Envelope.shared_directory_acknowledge:type_name -> teleport.desktop.v1.SharedDirectoryAcknowledge
+	25, // 45: teleport.desktop.v1.Envelope.shared_directory_request:type_name -> teleport.desktop.v1.SharedDirectoryRequest
+	26, // 46: teleport.desktop.v1.Envelope.shared_directory_response:type_name -> teleport.desktop.v1.SharedDirectoryResponse
+	28, // 47: teleport.desktop.v1.Envelope.latency_stats:type_name -> teleport.desktop.v1.LatencyStats
+	29, // 48: teleport.desktop.v1.Envelope.ping:type_name -> teleport.desktop.v1.Ping
+	23, // 49: teleport.desktop.v1.Envelope.shared_directory_remove:type_name -> teleport.desktop.v1.SharedDirectoryRemove
+	7,  // 50: teleport.desktop.v1.Envelope.session_selection:type_name -> teleport.desktop.v1.SessionSelection
+	30, // 51: teleport.desktop.v1.Envelope.auth_prompt:type_name -> teleport.desktop.v1.AuthPrompt
+	32, // 52: teleport.desktop.v1.Envelope.mfa_prompt_response:type_name -> teleport.desktop.v1.MFAPromptResponse
+	34, // 53: teleport.desktop.v1.Envelope.session_establishing:type_name -> teleport.desktop.v1.SessionEstablishing
+	27, // 54: teleport.desktop.v1.SharedDirectoryResponse.Info.fso:type_name -> teleport.desktop.v1.FileSystemObject
+	27, // 55: teleport.desktop.v1.SharedDirectoryResponse.Create.fso:type_name -> teleport.desktop.v1.FileSystemObject
+	27, // 56: teleport.desktop.v1.SharedDirectoryResponse.List.fso_list:type_name -> teleport.desktop.v1.FileSystemObject
+	57, // [57:57] is the sub-list for method output_type
+	57, // [57:57] is the sub-list for method input_type
+	57, // [57:57] is the sub-list for extension type_name
+	57, // [57:57] is the sub-list for extension extendee
+	0,  // [0:57] is the sub-list for field type_name
 }
 
 func init() { file_teleport_desktop_v1_tdpb_proto_init() }
@@ -5611,6 +6198,12 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 		(*SharedDirectoryResponse_Truncate_)(nil),
 	}
 	file_teleport_desktop_v1_tdpb_proto_msgTypes[26].OneofWrappers = []any{
+		(*AuthPrompt_MfaPrompt)(nil),
+	}
+	file_teleport_desktop_v1_tdpb_proto_msgTypes[28].OneofWrappers = []any{
+		(*MFAPromptResponse_Reference)(nil),
+	}
+	file_teleport_desktop_v1_tdpb_proto_msgTypes[31].OneofWrappers = []any{
 		(*Envelope_ClientHello)(nil),
 		(*Envelope_ServerHello)(nil),
 		(*Envelope_PngFrame)(nil),
@@ -5633,6 +6226,9 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 		(*Envelope_Ping)(nil),
 		(*Envelope_SharedDirectoryRemove)(nil),
 		(*Envelope_SessionSelection)(nil),
+		(*Envelope_AuthPrompt)(nil),
+		(*Envelope_MfaPromptResponse)(nil),
+		(*Envelope_SessionEstablishing)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -5640,7 +6236,7 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_desktop_v1_tdpb_proto_rawDesc), len(file_teleport_desktop_v1_tdpb_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   43,
+			NumMessages:   48,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/desktop/v1/tdpb_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/desktop/v1/tdpb_protoopaque.pb.go
@@ -3134,6 +3134,410 @@ func (b0 Ping_builder) Build() *Ping {
 	return m0
 }
 
+// Sent by the server to request authentication from the client before session establishment.
+type AuthPrompt struct {
+	state             protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Prompt isAuthPrompt_Prompt    `protobuf_oneof:"prompt"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *AuthPrompt) Reset() {
+	*x = AuthPrompt{}
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AuthPrompt) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AuthPrompt) ProtoMessage() {}
+
+func (x *AuthPrompt) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *AuthPrompt) GetMfaPrompt() *MFAPrompt {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Prompt.(*authPrompt_MfaPrompt); ok {
+			return x.MfaPrompt
+		}
+	}
+	return nil
+}
+
+func (x *AuthPrompt) SetMfaPrompt(v *MFAPrompt) {
+	if v == nil {
+		x.xxx_hidden_Prompt = nil
+		return
+	}
+	x.xxx_hidden_Prompt = &authPrompt_MfaPrompt{v}
+}
+
+func (x *AuthPrompt) HasPrompt() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Prompt != nil
+}
+
+func (x *AuthPrompt) HasMfaPrompt() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Prompt.(*authPrompt_MfaPrompt)
+	return ok
+}
+
+func (x *AuthPrompt) ClearPrompt() {
+	x.xxx_hidden_Prompt = nil
+}
+
+func (x *AuthPrompt) ClearMfaPrompt() {
+	if _, ok := x.xxx_hidden_Prompt.(*authPrompt_MfaPrompt); ok {
+		x.xxx_hidden_Prompt = nil
+	}
+}
+
+const AuthPrompt_Prompt_not_set_case case_AuthPrompt_Prompt = 0
+const AuthPrompt_MfaPrompt_case case_AuthPrompt_Prompt = 1
+
+func (x *AuthPrompt) WhichPrompt() case_AuthPrompt_Prompt {
+	if x == nil {
+		return AuthPrompt_Prompt_not_set_case
+	}
+	switch x.xxx_hidden_Prompt.(type) {
+	case *authPrompt_MfaPrompt:
+		return AuthPrompt_MfaPrompt_case
+	default:
+		return AuthPrompt_Prompt_not_set_case
+	}
+}
+
+type AuthPrompt_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Fields of oneof xxx_hidden_Prompt:
+	MfaPrompt *MFAPrompt
+	// -- end of xxx_hidden_Prompt
+}
+
+func (b0 AuthPrompt_builder) Build() *AuthPrompt {
+	m0 := &AuthPrompt{}
+	b, x := &b0, m0
+	_, _ = b, x
+	if b.MfaPrompt != nil {
+		x.xxx_hidden_Prompt = &authPrompt_MfaPrompt{b.MfaPrompt}
+	}
+	return m0
+}
+
+type case_AuthPrompt_Prompt protoreflect.FieldNumber
+
+func (x case_AuthPrompt_Prompt) String() string {
+	md := file_teleport_desktop_v1_tdpb_proto_msgTypes[26].Descriptor()
+	if x == 0 {
+		return "not set"
+	}
+	return protoimpl.X.MessageFieldStringOf(md, protoreflect.FieldNumber(x))
+}
+
+type isAuthPrompt_Prompt interface {
+	isAuthPrompt_Prompt()
+}
+
+type authPrompt_MfaPrompt struct {
+	MfaPrompt *MFAPrompt `protobuf:"bytes,1,opt,name=mfa_prompt,json=mfaPrompt,proto3,oneof"`
+}
+
+func (*authPrompt_MfaPrompt) isAuthPrompt_Prompt() {}
+
+// Indicates MFA is required for the session. The client performs the MFA ceremony and responds with
+// MFAPromptResponse.
+type MFAPrompt struct {
+	state         protoimpl.MessageState `protogen:"opaque.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MFAPrompt) Reset() {
+	*x = MFAPrompt{}
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MFAPrompt) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MFAPrompt) ProtoMessage() {}
+
+func (x *MFAPrompt) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type MFAPrompt_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 MFAPrompt_builder) Build() *MFAPrompt {
+	m0 := &MFAPrompt{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
+// Client response to an AuthPrompt containing MFAPrompt.
+type MFAPromptResponse struct {
+	state               protoimpl.MessageState       `protogen:"opaque.v1"`
+	xxx_hidden_Response isMFAPromptResponse_Response `protobuf_oneof:"response"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *MFAPromptResponse) Reset() {
+	*x = MFAPromptResponse{}
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MFAPromptResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MFAPromptResponse) ProtoMessage() {}
+
+func (x *MFAPromptResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *MFAPromptResponse) GetReference() *MFAPromptResponseReference {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Response.(*mFAPromptResponse_Reference); ok {
+			return x.Reference
+		}
+	}
+	return nil
+}
+
+func (x *MFAPromptResponse) SetReference(v *MFAPromptResponseReference) {
+	if v == nil {
+		x.xxx_hidden_Response = nil
+		return
+	}
+	x.xxx_hidden_Response = &mFAPromptResponse_Reference{v}
+}
+
+func (x *MFAPromptResponse) HasResponse() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Response != nil
+}
+
+func (x *MFAPromptResponse) HasReference() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Response.(*mFAPromptResponse_Reference)
+	return ok
+}
+
+func (x *MFAPromptResponse) ClearResponse() {
+	x.xxx_hidden_Response = nil
+}
+
+func (x *MFAPromptResponse) ClearReference() {
+	if _, ok := x.xxx_hidden_Response.(*mFAPromptResponse_Reference); ok {
+		x.xxx_hidden_Response = nil
+	}
+}
+
+const MFAPromptResponse_Response_not_set_case case_MFAPromptResponse_Response = 0
+const MFAPromptResponse_Reference_case case_MFAPromptResponse_Response = 1
+
+func (x *MFAPromptResponse) WhichResponse() case_MFAPromptResponse_Response {
+	if x == nil {
+		return MFAPromptResponse_Response_not_set_case
+	}
+	switch x.xxx_hidden_Response.(type) {
+	case *mFAPromptResponse_Reference:
+		return MFAPromptResponse_Reference_case
+	default:
+		return MFAPromptResponse_Response_not_set_case
+	}
+}
+
+type MFAPromptResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Fields of oneof xxx_hidden_Response:
+	Reference *MFAPromptResponseReference
+	// -- end of xxx_hidden_Response
+}
+
+func (b0 MFAPromptResponse_builder) Build() *MFAPromptResponse {
+	m0 := &MFAPromptResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	if b.Reference != nil {
+		x.xxx_hidden_Response = &mFAPromptResponse_Reference{b.Reference}
+	}
+	return m0
+}
+
+type case_MFAPromptResponse_Response protoreflect.FieldNumber
+
+func (x case_MFAPromptResponse_Response) String() string {
+	md := file_teleport_desktop_v1_tdpb_proto_msgTypes[28].Descriptor()
+	if x == 0 {
+		return "not set"
+	}
+	return protoimpl.X.MessageFieldStringOf(md, protoreflect.FieldNumber(x))
+}
+
+type isMFAPromptResponse_Response interface {
+	isMFAPromptResponse_Response()
+}
+
+type mFAPromptResponse_Reference struct {
+	Reference *MFAPromptResponseReference `protobuf:"bytes,1,opt,name=reference,proto3,oneof"`
+}
+
+func (*mFAPromptResponse_Reference) isMFAPromptResponse_Response() {}
+
+// Instructs the server to verify the MFA challenge with the MFA service.
+type MFAPromptResponseReference struct {
+	state                    protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_ChallengeName string                 `protobuf:"bytes,1,opt,name=challenge_name,json=challengeName,proto3"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
+}
+
+func (x *MFAPromptResponseReference) Reset() {
+	*x = MFAPromptResponseReference{}
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MFAPromptResponseReference) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MFAPromptResponseReference) ProtoMessage() {}
+
+func (x *MFAPromptResponseReference) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *MFAPromptResponseReference) GetChallengeName() string {
+	if x != nil {
+		return x.xxx_hidden_ChallengeName
+	}
+	return ""
+}
+
+func (x *MFAPromptResponseReference) SetChallengeName(v string) {
+	x.xxx_hidden_ChallengeName = v
+}
+
+type MFAPromptResponseReference_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The name of the MFA challenge created by the client.
+	ChallengeName string
+}
+
+func (b0 MFAPromptResponseReference_builder) Build() *MFAPromptResponseReference {
+	m0 := &MFAPromptResponseReference{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_ChallengeName = b.ChallengeName
+	return m0
+}
+
+// Sent by the server to indicate the session backend is being established and no additional authentication is required.
+type SessionEstablishing struct {
+	state         protoimpl.MessageState `protogen:"opaque.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SessionEstablishing) Reset() {
+	*x = SessionEstablishing{}
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SessionEstablishing) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SessionEstablishing) ProtoMessage() {}
+
+func (x *SessionEstablishing) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type SessionEstablishing_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 SessionEstablishing_builder) Build() *SessionEstablishing {
+	m0 := &SessionEstablishing{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
 // Envelope wraps all messages that are allowed to be sent on the wire.
 type Envelope struct {
 	state              protoimpl.MessageState `protogen:"opaque.v1"`
@@ -3144,7 +3548,7 @@ type Envelope struct {
 
 func (x *Envelope) Reset() {
 	*x = Envelope{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[26]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3156,7 +3560,7 @@ func (x *Envelope) String() string {
 func (*Envelope) ProtoMessage() {}
 
 func (x *Envelope) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[26]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3365,6 +3769,33 @@ func (x *Envelope) GetSessionSelection() *SessionSelection {
 	return nil
 }
 
+func (x *Envelope) GetAuthPrompt() *AuthPrompt {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Payload.(*envelope_AuthPrompt); ok {
+			return x.AuthPrompt
+		}
+	}
+	return nil
+}
+
+func (x *Envelope) GetMfaPromptResponse() *MFAPromptResponse {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Payload.(*envelope_MfaPromptResponse); ok {
+			return x.MfaPromptResponse
+		}
+	}
+	return nil
+}
+
+func (x *Envelope) GetSessionEstablishing() *SessionEstablishing {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Payload.(*envelope_SessionEstablishing); ok {
+			return x.SessionEstablishing
+		}
+	}
+	return nil
+}
+
 func (x *Envelope) SetClientHello(v *ClientHello) {
 	if v == nil {
 		x.xxx_hidden_Payload = nil
@@ -3539,6 +3970,30 @@ func (x *Envelope) SetSessionSelection(v *SessionSelection) {
 		return
 	}
 	x.xxx_hidden_Payload = &envelope_SessionSelection{v}
+}
+
+func (x *Envelope) SetAuthPrompt(v *AuthPrompt) {
+	if v == nil {
+		x.xxx_hidden_Payload = nil
+		return
+	}
+	x.xxx_hidden_Payload = &envelope_AuthPrompt{v}
+}
+
+func (x *Envelope) SetMfaPromptResponse(v *MFAPromptResponse) {
+	if v == nil {
+		x.xxx_hidden_Payload = nil
+		return
+	}
+	x.xxx_hidden_Payload = &envelope_MfaPromptResponse{v}
+}
+
+func (x *Envelope) SetSessionEstablishing(v *SessionEstablishing) {
+	if v == nil {
+		x.xxx_hidden_Payload = nil
+		return
+	}
+	x.xxx_hidden_Payload = &envelope_SessionEstablishing{v}
 }
 
 func (x *Envelope) HasPayload() bool {
@@ -3724,6 +4179,30 @@ func (x *Envelope) HasSessionSelection() bool {
 	return ok
 }
 
+func (x *Envelope) HasAuthPrompt() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Payload.(*envelope_AuthPrompt)
+	return ok
+}
+
+func (x *Envelope) HasMfaPromptResponse() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Payload.(*envelope_MfaPromptResponse)
+	return ok
+}
+
+func (x *Envelope) HasSessionEstablishing() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Payload.(*envelope_SessionEstablishing)
+	return ok
+}
+
 func (x *Envelope) ClearPayload() {
 	x.xxx_hidden_Payload = nil
 }
@@ -3860,6 +4339,24 @@ func (x *Envelope) ClearSessionSelection() {
 	}
 }
 
+func (x *Envelope) ClearAuthPrompt() {
+	if _, ok := x.xxx_hidden_Payload.(*envelope_AuthPrompt); ok {
+		x.xxx_hidden_Payload = nil
+	}
+}
+
+func (x *Envelope) ClearMfaPromptResponse() {
+	if _, ok := x.xxx_hidden_Payload.(*envelope_MfaPromptResponse); ok {
+		x.xxx_hidden_Payload = nil
+	}
+}
+
+func (x *Envelope) ClearSessionEstablishing() {
+	if _, ok := x.xxx_hidden_Payload.(*envelope_SessionEstablishing); ok {
+		x.xxx_hidden_Payload = nil
+	}
+}
+
 const Envelope_Payload_not_set_case case_Envelope_Payload = 0
 const Envelope_ClientHello_case case_Envelope_Payload = 1
 const Envelope_ServerHello_case case_Envelope_Payload = 2
@@ -3883,6 +4380,9 @@ const Envelope_LatencyStats_case case_Envelope_Payload = 19
 const Envelope_Ping_case case_Envelope_Payload = 20
 const Envelope_SharedDirectoryRemove_case case_Envelope_Payload = 21
 const Envelope_SessionSelection_case case_Envelope_Payload = 22
+const Envelope_AuthPrompt_case case_Envelope_Payload = 23
+const Envelope_MfaPromptResponse_case case_Envelope_Payload = 24
+const Envelope_SessionEstablishing_case case_Envelope_Payload = 25
 
 func (x *Envelope) WhichPayload() case_Envelope_Payload {
 	if x == nil {
@@ -3933,6 +4433,12 @@ func (x *Envelope) WhichPayload() case_Envelope_Payload {
 		return Envelope_SharedDirectoryRemove_case
 	case *envelope_SessionSelection:
 		return Envelope_SessionSelection_case
+	case *envelope_AuthPrompt:
+		return Envelope_AuthPrompt_case
+	case *envelope_MfaPromptResponse:
+		return Envelope_MfaPromptResponse_case
+	case *envelope_SessionEstablishing:
+		return Envelope_SessionEstablishing_case
 	default:
 		return Envelope_Payload_not_set_case
 	}
@@ -3964,6 +4470,9 @@ type Envelope_builder struct {
 	Ping                       *Ping
 	SharedDirectoryRemove      *SharedDirectoryRemove
 	SessionSelection           *SessionSelection
+	AuthPrompt                 *AuthPrompt
+	MfaPromptResponse          *MFAPromptResponse
+	SessionEstablishing        *SessionEstablishing
 	// -- end of xxx_hidden_Payload
 }
 
@@ -4037,13 +4546,22 @@ func (b0 Envelope_builder) Build() *Envelope {
 	if b.SessionSelection != nil {
 		x.xxx_hidden_Payload = &envelope_SessionSelection{b.SessionSelection}
 	}
+	if b.AuthPrompt != nil {
+		x.xxx_hidden_Payload = &envelope_AuthPrompt{b.AuthPrompt}
+	}
+	if b.MfaPromptResponse != nil {
+		x.xxx_hidden_Payload = &envelope_MfaPromptResponse{b.MfaPromptResponse}
+	}
+	if b.SessionEstablishing != nil {
+		x.xxx_hidden_Payload = &envelope_SessionEstablishing{b.SessionEstablishing}
+	}
 	return m0
 }
 
 type case_Envelope_Payload protoreflect.FieldNumber
 
 func (x case_Envelope_Payload) String() string {
-	md := file_teleport_desktop_v1_tdpb_proto_msgTypes[26].Descriptor()
+	md := file_teleport_desktop_v1_tdpb_proto_msgTypes[31].Descriptor()
 	if x == 0 {
 		return "not set"
 	}
@@ -4142,6 +4660,18 @@ type envelope_SessionSelection struct {
 	SessionSelection *SessionSelection `protobuf:"bytes,22,opt,name=session_selection,json=sessionSelection,proto3,oneof"`
 }
 
+type envelope_AuthPrompt struct {
+	AuthPrompt *AuthPrompt `protobuf:"bytes,23,opt,name=auth_prompt,json=authPrompt,proto3,oneof"`
+}
+
+type envelope_MfaPromptResponse struct {
+	MfaPromptResponse *MFAPromptResponse `protobuf:"bytes,24,opt,name=mfa_prompt_response,json=mfaPromptResponse,proto3,oneof"`
+}
+
+type envelope_SessionEstablishing struct {
+	SessionEstablishing *SessionEstablishing `protobuf:"bytes,25,opt,name=session_establishing,json=sessionEstablishing,proto3,oneof"`
+}
+
 func (*envelope_ClientHello) isEnvelope_Payload() {}
 
 func (*envelope_ServerHello) isEnvelope_Payload() {}
@@ -4186,6 +4716,12 @@ func (*envelope_SharedDirectoryRemove) isEnvelope_Payload() {}
 
 func (*envelope_SessionSelection) isEnvelope_Payload() {}
 
+func (*envelope_AuthPrompt) isEnvelope_Payload() {}
+
+func (*envelope_MfaPromptResponse) isEnvelope_Payload() {}
+
+func (*envelope_SessionEstablishing) isEnvelope_Payload() {}
+
 // Info request.
 type SharedDirectoryRequest_Info struct {
 	state           protoimpl.MessageState `protogen:"opaque.v1"`
@@ -4196,7 +4732,7 @@ type SharedDirectoryRequest_Info struct {
 
 func (x *SharedDirectoryRequest_Info) Reset() {
 	*x = SharedDirectoryRequest_Info{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[27]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4208,7 +4744,7 @@ func (x *SharedDirectoryRequest_Info) String() string {
 func (*SharedDirectoryRequest_Info) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Info) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[27]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4255,7 +4791,7 @@ type SharedDirectoryRequest_Create struct {
 
 func (x *SharedDirectoryRequest_Create) Reset() {
 	*x = SharedDirectoryRequest_Create{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[28]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4267,7 +4803,7 @@ func (x *SharedDirectoryRequest_Create) String() string {
 func (*SharedDirectoryRequest_Create) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Create) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[28]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4326,7 +4862,7 @@ type SharedDirectoryRequest_Delete struct {
 
 func (x *SharedDirectoryRequest_Delete) Reset() {
 	*x = SharedDirectoryRequest_Delete{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[29]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4338,7 +4874,7 @@ func (x *SharedDirectoryRequest_Delete) String() string {
 func (*SharedDirectoryRequest_Delete) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Delete) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[29]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4384,7 +4920,7 @@ type SharedDirectoryRequest_List struct {
 
 func (x *SharedDirectoryRequest_List) Reset() {
 	*x = SharedDirectoryRequest_List{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[30]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4396,7 +4932,7 @@ func (x *SharedDirectoryRequest_List) String() string {
 func (*SharedDirectoryRequest_List) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_List) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[30]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4444,7 +4980,7 @@ type SharedDirectoryRequest_Read struct {
 
 func (x *SharedDirectoryRequest_Read) Reset() {
 	*x = SharedDirectoryRequest_Read{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[31]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4456,7 +4992,7 @@ func (x *SharedDirectoryRequest_Read) String() string {
 func (*SharedDirectoryRequest_Read) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Read) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[31]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4530,7 +5066,7 @@ type SharedDirectoryRequest_Write struct {
 
 func (x *SharedDirectoryRequest_Write) Reset() {
 	*x = SharedDirectoryRequest_Write{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[32]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4542,7 +5078,7 @@ func (x *SharedDirectoryRequest_Write) String() string {
 func (*SharedDirectoryRequest_Write) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Write) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[32]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4618,7 +5154,7 @@ type SharedDirectoryRequest_Move struct {
 
 func (x *SharedDirectoryRequest_Move) Reset() {
 	*x = SharedDirectoryRequest_Move{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[33]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4630,7 +5166,7 @@ func (x *SharedDirectoryRequest_Move) String() string {
 func (*SharedDirectoryRequest_Move) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Move) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[33]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4690,7 +5226,7 @@ type SharedDirectoryRequest_Truncate struct {
 
 func (x *SharedDirectoryRequest_Truncate) Reset() {
 	*x = SharedDirectoryRequest_Truncate{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[34]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4702,7 +5238,7 @@ func (x *SharedDirectoryRequest_Truncate) String() string {
 func (*SharedDirectoryRequest_Truncate) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Truncate) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[34]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4761,7 +5297,7 @@ type SharedDirectoryResponse_Info struct {
 
 func (x *SharedDirectoryResponse_Info) Reset() {
 	*x = SharedDirectoryResponse_Info{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[35]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4773,7 +5309,7 @@ func (x *SharedDirectoryResponse_Info) String() string {
 func (*SharedDirectoryResponse_Info) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Info) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[35]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4830,7 +5366,7 @@ type SharedDirectoryResponse_Create struct {
 
 func (x *SharedDirectoryResponse_Create) Reset() {
 	*x = SharedDirectoryResponse_Create{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[36]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4842,7 +5378,7 @@ func (x *SharedDirectoryResponse_Create) String() string {
 func (*SharedDirectoryResponse_Create) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Create) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[36]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4898,7 +5434,7 @@ type SharedDirectoryResponse_Delete struct {
 
 func (x *SharedDirectoryResponse_Delete) Reset() {
 	*x = SharedDirectoryResponse_Delete{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[37]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4910,7 +5446,7 @@ func (x *SharedDirectoryResponse_Delete) String() string {
 func (*SharedDirectoryResponse_Delete) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Delete) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[37]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4943,7 +5479,7 @@ type SharedDirectoryResponse_List struct {
 
 func (x *SharedDirectoryResponse_List) Reset() {
 	*x = SharedDirectoryResponse_List{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[38]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4955,7 +5491,7 @@ func (x *SharedDirectoryResponse_List) String() string {
 func (*SharedDirectoryResponse_List) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_List) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[38]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5003,7 +5539,7 @@ type SharedDirectoryResponse_Read struct {
 
 func (x *SharedDirectoryResponse_Read) Reset() {
 	*x = SharedDirectoryResponse_Read{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[39]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5015,7 +5551,7 @@ func (x *SharedDirectoryResponse_Read) String() string {
 func (*SharedDirectoryResponse_Read) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Read) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[39]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5064,7 +5600,7 @@ type SharedDirectoryResponse_Write struct {
 
 func (x *SharedDirectoryResponse_Write) Reset() {
 	*x = SharedDirectoryResponse_Write{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[40]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5076,7 +5612,7 @@ func (x *SharedDirectoryResponse_Write) String() string {
 func (*SharedDirectoryResponse_Write) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Write) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[40]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5121,7 +5657,7 @@ type SharedDirectoryResponse_Move struct {
 
 func (x *SharedDirectoryResponse_Move) Reset() {
 	*x = SharedDirectoryResponse_Move{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[41]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5133,7 +5669,7 @@ func (x *SharedDirectoryResponse_Move) String() string {
 func (*SharedDirectoryResponse_Move) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Move) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[41]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5165,7 +5701,7 @@ type SharedDirectoryResponse_Truncate struct {
 
 func (x *SharedDirectoryResponse_Truncate) Reset() {
 	*x = SharedDirectoryResponse_Truncate{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[42]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5177,7 +5713,7 @@ func (x *SharedDirectoryResponse_Truncate) String() string {
 func (*SharedDirectoryResponse_Truncate) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Truncate) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[42]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5355,7 +5891,20 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\x11client_latency_ms\x18\x01 \x01(\rR\x0fclientLatencyMs\x12*\n" +
 	"\x11server_latency_ms\x18\x02 \x01(\rR\x0fserverLatencyMs\"\x1a\n" +
 	"\x04Ping\x12\x12\n" +
-	"\x04uuid\x18\x01 \x01(\fR\x04uuid\"\xc7\r\n" +
+	"\x04uuid\x18\x01 \x01(\fR\x04uuid\"W\n" +
+	"\n" +
+	"AuthPrompt\x12?\n" +
+	"\n" +
+	"mfa_prompt\x18\x01 \x01(\v2\x1e.teleport.desktop.v1.MFAPromptH\x00R\tmfaPromptB\b\n" +
+	"\x06prompt\"\v\n" +
+	"\tMFAPrompt\"p\n" +
+	"\x11MFAPromptResponse\x12O\n" +
+	"\treference\x18\x01 \x01(\v2/.teleport.desktop.v1.MFAPromptResponseReferenceH\x00R\treferenceB\n" +
+	"\n" +
+	"\bresponse\"C\n" +
+	"\x1aMFAPromptResponseReference\x12%\n" +
+	"\x0echallenge_name\x18\x01 \x01(\tR\rchallengeName\"\x15\n" +
+	"\x13SessionEstablishing\"\xc4\x0f\n" +
 	"\bEnvelope\x12E\n" +
 	"\fclient_hello\x18\x01 \x01(\v2 .teleport.desktop.v1.ClientHelloH\x00R\vclientHello\x12E\n" +
 	"\fserver_hello\x18\x02 \x01(\v2 .teleport.desktop.v1.ServerHelloH\x00R\vserverHello\x12<\n" +
@@ -5381,7 +5930,11 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\rlatency_stats\x18\x13 \x01(\v2!.teleport.desktop.v1.LatencyStatsH\x00R\flatencyStats\x12/\n" +
 	"\x04ping\x18\x14 \x01(\v2\x19.teleport.desktop.v1.PingH\x00R\x04ping\x12d\n" +
 	"\x17shared_directory_remove\x18\x15 \x01(\v2*.teleport.desktop.v1.SharedDirectoryRemoveH\x00R\x15sharedDirectoryRemove\x12T\n" +
-	"\x11session_selection\x18\x16 \x01(\v2%.teleport.desktop.v1.SessionSelectionH\x00R\x10sessionSelectionB\t\n" +
+	"\x11session_selection\x18\x16 \x01(\v2%.teleport.desktop.v1.SessionSelectionH\x00R\x10sessionSelection\x12B\n" +
+	"\vauth_prompt\x18\x17 \x01(\v2\x1f.teleport.desktop.v1.AuthPromptH\x00R\n" +
+	"authPrompt\x12X\n" +
+	"\x13mfa_prompt_response\x18\x18 \x01(\v2&.teleport.desktop.v1.MFAPromptResponseH\x00R\x11mfaPromptResponse\x12]\n" +
+	"\x14session_establishing\x18\x19 \x01(\v2(.teleport.desktop.v1.SessionEstablishingH\x00R\x13sessionEstablishingB\t\n" +
 	"\apayload*\x8b\x01\n" +
 	"\x0fMouseButtonType\x12!\n" +
 	"\x1dMOUSE_BUTTON_TYPE_UNSPECIFIED\x10\x00\x12\x1a\n" +
@@ -5403,7 +5956,7 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\fMFA_TYPE_U2F\x10\x02BOZMgithub.com/gravitational/teleport/api/gen/proto/go/teleport/desktop/v1;tdpbv1b\x06proto3"
 
 var file_teleport_desktop_v1_tdpb_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_teleport_desktop_v1_tdpb_proto_msgTypes = make([]protoimpl.MessageInfo, 43)
+var file_teleport_desktop_v1_tdpb_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
 var file_teleport_desktop_v1_tdpb_proto_goTypes = []any{
 	(MouseButtonType)(0),                     // 0: teleport.desktop.v1.MouseButtonType
 	(AlertSeverity)(0),                       // 1: teleport.desktop.v1.AlertSeverity
@@ -5435,25 +5988,30 @@ var file_teleport_desktop_v1_tdpb_proto_goTypes = []any{
 	(*FileSystemObject)(nil),                 // 27: teleport.desktop.v1.FileSystemObject
 	(*LatencyStats)(nil),                     // 28: teleport.desktop.v1.LatencyStats
 	(*Ping)(nil),                             // 29: teleport.desktop.v1.Ping
-	(*Envelope)(nil),                         // 30: teleport.desktop.v1.Envelope
-	(*SharedDirectoryRequest_Info)(nil),      // 31: teleport.desktop.v1.SharedDirectoryRequest.Info
-	(*SharedDirectoryRequest_Create)(nil),    // 32: teleport.desktop.v1.SharedDirectoryRequest.Create
-	(*SharedDirectoryRequest_Delete)(nil),    // 33: teleport.desktop.v1.SharedDirectoryRequest.Delete
-	(*SharedDirectoryRequest_List)(nil),      // 34: teleport.desktop.v1.SharedDirectoryRequest.List
-	(*SharedDirectoryRequest_Read)(nil),      // 35: teleport.desktop.v1.SharedDirectoryRequest.Read
-	(*SharedDirectoryRequest_Write)(nil),     // 36: teleport.desktop.v1.SharedDirectoryRequest.Write
-	(*SharedDirectoryRequest_Move)(nil),      // 37: teleport.desktop.v1.SharedDirectoryRequest.Move
-	(*SharedDirectoryRequest_Truncate)(nil),  // 38: teleport.desktop.v1.SharedDirectoryRequest.Truncate
-	(*SharedDirectoryResponse_Info)(nil),     // 39: teleport.desktop.v1.SharedDirectoryResponse.Info
-	(*SharedDirectoryResponse_Create)(nil),   // 40: teleport.desktop.v1.SharedDirectoryResponse.Create
-	(*SharedDirectoryResponse_Delete)(nil),   // 41: teleport.desktop.v1.SharedDirectoryResponse.Delete
-	(*SharedDirectoryResponse_List)(nil),     // 42: teleport.desktop.v1.SharedDirectoryResponse.List
-	(*SharedDirectoryResponse_Read)(nil),     // 43: teleport.desktop.v1.SharedDirectoryResponse.Read
-	(*SharedDirectoryResponse_Write)(nil),    // 44: teleport.desktop.v1.SharedDirectoryResponse.Write
-	(*SharedDirectoryResponse_Move)(nil),     // 45: teleport.desktop.v1.SharedDirectoryResponse.Move
-	(*SharedDirectoryResponse_Truncate)(nil), // 46: teleport.desktop.v1.SharedDirectoryResponse.Truncate
-	(*v1.AuthenticateChallenge)(nil),         // 47: teleport.mfa.v1.AuthenticateChallenge
-	(*v1.AuthenticateResponse)(nil),          // 48: teleport.mfa.v1.AuthenticateResponse
+	(*AuthPrompt)(nil),                       // 30: teleport.desktop.v1.AuthPrompt
+	(*MFAPrompt)(nil),                        // 31: teleport.desktop.v1.MFAPrompt
+	(*MFAPromptResponse)(nil),                // 32: teleport.desktop.v1.MFAPromptResponse
+	(*MFAPromptResponseReference)(nil),       // 33: teleport.desktop.v1.MFAPromptResponseReference
+	(*SessionEstablishing)(nil),              // 34: teleport.desktop.v1.SessionEstablishing
+	(*Envelope)(nil),                         // 35: teleport.desktop.v1.Envelope
+	(*SharedDirectoryRequest_Info)(nil),      // 36: teleport.desktop.v1.SharedDirectoryRequest.Info
+	(*SharedDirectoryRequest_Create)(nil),    // 37: teleport.desktop.v1.SharedDirectoryRequest.Create
+	(*SharedDirectoryRequest_Delete)(nil),    // 38: teleport.desktop.v1.SharedDirectoryRequest.Delete
+	(*SharedDirectoryRequest_List)(nil),      // 39: teleport.desktop.v1.SharedDirectoryRequest.List
+	(*SharedDirectoryRequest_Read)(nil),      // 40: teleport.desktop.v1.SharedDirectoryRequest.Read
+	(*SharedDirectoryRequest_Write)(nil),     // 41: teleport.desktop.v1.SharedDirectoryRequest.Write
+	(*SharedDirectoryRequest_Move)(nil),      // 42: teleport.desktop.v1.SharedDirectoryRequest.Move
+	(*SharedDirectoryRequest_Truncate)(nil),  // 43: teleport.desktop.v1.SharedDirectoryRequest.Truncate
+	(*SharedDirectoryResponse_Info)(nil),     // 44: teleport.desktop.v1.SharedDirectoryResponse.Info
+	(*SharedDirectoryResponse_Create)(nil),   // 45: teleport.desktop.v1.SharedDirectoryResponse.Create
+	(*SharedDirectoryResponse_Delete)(nil),   // 46: teleport.desktop.v1.SharedDirectoryResponse.Delete
+	(*SharedDirectoryResponse_List)(nil),     // 47: teleport.desktop.v1.SharedDirectoryResponse.List
+	(*SharedDirectoryResponse_Read)(nil),     // 48: teleport.desktop.v1.SharedDirectoryResponse.Read
+	(*SharedDirectoryResponse_Write)(nil),    // 49: teleport.desktop.v1.SharedDirectoryResponse.Write
+	(*SharedDirectoryResponse_Move)(nil),     // 50: teleport.desktop.v1.SharedDirectoryResponse.Move
+	(*SharedDirectoryResponse_Truncate)(nil), // 51: teleport.desktop.v1.SharedDirectoryResponse.Truncate
+	(*v1.AuthenticateChallenge)(nil),         // 52: teleport.mfa.v1.AuthenticateChallenge
+	(*v1.AuthenticateResponse)(nil),          // 53: teleport.mfa.v1.AuthenticateResponse
 }
 var file_teleport_desktop_v1_tdpb_proto_depIdxs = []int32{
 	17, // 0: teleport.desktop.v1.ClientHello.screen_spec:type_name -> teleport.desktop.v1.ClientScreenSpec
@@ -5465,54 +6023,59 @@ var file_teleport_desktop_v1_tdpb_proto_depIdxs = []int32{
 	1,  // 6: teleport.desktop.v1.Alert.severity:type_name -> teleport.desktop.v1.AlertSeverity
 	2,  // 7: teleport.desktop.v1.MouseWheel.axis:type_name -> teleport.desktop.v1.MouseWheelAxis
 	3,  // 8: teleport.desktop.v1.MFA.type:type_name -> teleport.desktop.v1.MFAType
-	47, // 9: teleport.desktop.v1.MFA.challenge:type_name -> teleport.mfa.v1.AuthenticateChallenge
-	48, // 10: teleport.desktop.v1.MFA.authentication_response:type_name -> teleport.mfa.v1.AuthenticateResponse
-	31, // 11: teleport.desktop.v1.SharedDirectoryRequest.info:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Info
-	32, // 12: teleport.desktop.v1.SharedDirectoryRequest.create:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Create
-	33, // 13: teleport.desktop.v1.SharedDirectoryRequest.delete:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Delete
-	34, // 14: teleport.desktop.v1.SharedDirectoryRequest.list:type_name -> teleport.desktop.v1.SharedDirectoryRequest.List
-	35, // 15: teleport.desktop.v1.SharedDirectoryRequest.read:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Read
-	36, // 16: teleport.desktop.v1.SharedDirectoryRequest.write:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Write
-	37, // 17: teleport.desktop.v1.SharedDirectoryRequest.move:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Move
-	38, // 18: teleport.desktop.v1.SharedDirectoryRequest.truncate:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Truncate
-	39, // 19: teleport.desktop.v1.SharedDirectoryResponse.info:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Info
-	40, // 20: teleport.desktop.v1.SharedDirectoryResponse.create:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Create
-	41, // 21: teleport.desktop.v1.SharedDirectoryResponse.delete:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Delete
-	42, // 22: teleport.desktop.v1.SharedDirectoryResponse.list:type_name -> teleport.desktop.v1.SharedDirectoryResponse.List
-	43, // 23: teleport.desktop.v1.SharedDirectoryResponse.read:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Read
-	44, // 24: teleport.desktop.v1.SharedDirectoryResponse.write:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Write
-	45, // 25: teleport.desktop.v1.SharedDirectoryResponse.move:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Move
-	46, // 26: teleport.desktop.v1.SharedDirectoryResponse.truncate:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Truncate
-	4,  // 27: teleport.desktop.v1.Envelope.client_hello:type_name -> teleport.desktop.v1.ClientHello
-	5,  // 28: teleport.desktop.v1.Envelope.server_hello:type_name -> teleport.desktop.v1.ServerHello
-	9,  // 29: teleport.desktop.v1.Envelope.png_frame:type_name -> teleport.desktop.v1.PNGFrame
-	10, // 30: teleport.desktop.v1.Envelope.fast_path_pdu:type_name -> teleport.desktop.v1.FastPathPDU
-	11, // 31: teleport.desktop.v1.Envelope.rdp_response_pdu:type_name -> teleport.desktop.v1.RDPResponsePDU
-	13, // 32: teleport.desktop.v1.Envelope.sync_keys:type_name -> teleport.desktop.v1.SyncKeys
-	14, // 33: teleport.desktop.v1.Envelope.mouse_move:type_name -> teleport.desktop.v1.MouseMove
-	15, // 34: teleport.desktop.v1.Envelope.mouse_button:type_name -> teleport.desktop.v1.MouseButton
-	16, // 35: teleport.desktop.v1.Envelope.keyboard_button:type_name -> teleport.desktop.v1.KeyboardButton
-	17, // 36: teleport.desktop.v1.Envelope.client_screen_spec:type_name -> teleport.desktop.v1.ClientScreenSpec
-	18, // 37: teleport.desktop.v1.Envelope.alert:type_name -> teleport.desktop.v1.Alert
-	19, // 38: teleport.desktop.v1.Envelope.mouse_wheel:type_name -> teleport.desktop.v1.MouseWheel
-	20, // 39: teleport.desktop.v1.Envelope.clipboard_data:type_name -> teleport.desktop.v1.ClipboardData
-	21, // 40: teleport.desktop.v1.Envelope.mfa:type_name -> teleport.desktop.v1.MFA
-	22, // 41: teleport.desktop.v1.Envelope.shared_directory_announce:type_name -> teleport.desktop.v1.SharedDirectoryAnnounce
-	24, // 42: teleport.desktop.v1.Envelope.shared_directory_acknowledge:type_name -> teleport.desktop.v1.SharedDirectoryAcknowledge
-	25, // 43: teleport.desktop.v1.Envelope.shared_directory_request:type_name -> teleport.desktop.v1.SharedDirectoryRequest
-	26, // 44: teleport.desktop.v1.Envelope.shared_directory_response:type_name -> teleport.desktop.v1.SharedDirectoryResponse
-	28, // 45: teleport.desktop.v1.Envelope.latency_stats:type_name -> teleport.desktop.v1.LatencyStats
-	29, // 46: teleport.desktop.v1.Envelope.ping:type_name -> teleport.desktop.v1.Ping
-	23, // 47: teleport.desktop.v1.Envelope.shared_directory_remove:type_name -> teleport.desktop.v1.SharedDirectoryRemove
-	7,  // 48: teleport.desktop.v1.Envelope.session_selection:type_name -> teleport.desktop.v1.SessionSelection
-	27, // 49: teleport.desktop.v1.SharedDirectoryResponse.Info.fso:type_name -> teleport.desktop.v1.FileSystemObject
-	27, // 50: teleport.desktop.v1.SharedDirectoryResponse.Create.fso:type_name -> teleport.desktop.v1.FileSystemObject
-	27, // 51: teleport.desktop.v1.SharedDirectoryResponse.List.fso_list:type_name -> teleport.desktop.v1.FileSystemObject
-	52, // [52:52] is the sub-list for method output_type
-	52, // [52:52] is the sub-list for method input_type
-	52, // [52:52] is the sub-list for extension type_name
-	52, // [52:52] is the sub-list for extension extendee
-	0,  // [0:52] is the sub-list for field type_name
+	52, // 9: teleport.desktop.v1.MFA.challenge:type_name -> teleport.mfa.v1.AuthenticateChallenge
+	53, // 10: teleport.desktop.v1.MFA.authentication_response:type_name -> teleport.mfa.v1.AuthenticateResponse
+	36, // 11: teleport.desktop.v1.SharedDirectoryRequest.info:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Info
+	37, // 12: teleport.desktop.v1.SharedDirectoryRequest.create:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Create
+	38, // 13: teleport.desktop.v1.SharedDirectoryRequest.delete:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Delete
+	39, // 14: teleport.desktop.v1.SharedDirectoryRequest.list:type_name -> teleport.desktop.v1.SharedDirectoryRequest.List
+	40, // 15: teleport.desktop.v1.SharedDirectoryRequest.read:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Read
+	41, // 16: teleport.desktop.v1.SharedDirectoryRequest.write:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Write
+	42, // 17: teleport.desktop.v1.SharedDirectoryRequest.move:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Move
+	43, // 18: teleport.desktop.v1.SharedDirectoryRequest.truncate:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Truncate
+	44, // 19: teleport.desktop.v1.SharedDirectoryResponse.info:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Info
+	45, // 20: teleport.desktop.v1.SharedDirectoryResponse.create:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Create
+	46, // 21: teleport.desktop.v1.SharedDirectoryResponse.delete:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Delete
+	47, // 22: teleport.desktop.v1.SharedDirectoryResponse.list:type_name -> teleport.desktop.v1.SharedDirectoryResponse.List
+	48, // 23: teleport.desktop.v1.SharedDirectoryResponse.read:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Read
+	49, // 24: teleport.desktop.v1.SharedDirectoryResponse.write:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Write
+	50, // 25: teleport.desktop.v1.SharedDirectoryResponse.move:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Move
+	51, // 26: teleport.desktop.v1.SharedDirectoryResponse.truncate:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Truncate
+	31, // 27: teleport.desktop.v1.AuthPrompt.mfa_prompt:type_name -> teleport.desktop.v1.MFAPrompt
+	33, // 28: teleport.desktop.v1.MFAPromptResponse.reference:type_name -> teleport.desktop.v1.MFAPromptResponseReference
+	4,  // 29: teleport.desktop.v1.Envelope.client_hello:type_name -> teleport.desktop.v1.ClientHello
+	5,  // 30: teleport.desktop.v1.Envelope.server_hello:type_name -> teleport.desktop.v1.ServerHello
+	9,  // 31: teleport.desktop.v1.Envelope.png_frame:type_name -> teleport.desktop.v1.PNGFrame
+	10, // 32: teleport.desktop.v1.Envelope.fast_path_pdu:type_name -> teleport.desktop.v1.FastPathPDU
+	11, // 33: teleport.desktop.v1.Envelope.rdp_response_pdu:type_name -> teleport.desktop.v1.RDPResponsePDU
+	13, // 34: teleport.desktop.v1.Envelope.sync_keys:type_name -> teleport.desktop.v1.SyncKeys
+	14, // 35: teleport.desktop.v1.Envelope.mouse_move:type_name -> teleport.desktop.v1.MouseMove
+	15, // 36: teleport.desktop.v1.Envelope.mouse_button:type_name -> teleport.desktop.v1.MouseButton
+	16, // 37: teleport.desktop.v1.Envelope.keyboard_button:type_name -> teleport.desktop.v1.KeyboardButton
+	17, // 38: teleport.desktop.v1.Envelope.client_screen_spec:type_name -> teleport.desktop.v1.ClientScreenSpec
+	18, // 39: teleport.desktop.v1.Envelope.alert:type_name -> teleport.desktop.v1.Alert
+	19, // 40: teleport.desktop.v1.Envelope.mouse_wheel:type_name -> teleport.desktop.v1.MouseWheel
+	20, // 41: teleport.desktop.v1.Envelope.clipboard_data:type_name -> teleport.desktop.v1.ClipboardData
+	21, // 42: teleport.desktop.v1.Envelope.mfa:type_name -> teleport.desktop.v1.MFA
+	22, // 43: teleport.desktop.v1.Envelope.shared_directory_announce:type_name -> teleport.desktop.v1.SharedDirectoryAnnounce
+	24, // 44: teleport.desktop.v1.Envelope.shared_directory_acknowledge:type_name -> teleport.desktop.v1.SharedDirectoryAcknowledge
+	25, // 45: teleport.desktop.v1.Envelope.shared_directory_request:type_name -> teleport.desktop.v1.SharedDirectoryRequest
+	26, // 46: teleport.desktop.v1.Envelope.shared_directory_response:type_name -> teleport.desktop.v1.SharedDirectoryResponse
+	28, // 47: teleport.desktop.v1.Envelope.latency_stats:type_name -> teleport.desktop.v1.LatencyStats
+	29, // 48: teleport.desktop.v1.Envelope.ping:type_name -> teleport.desktop.v1.Ping
+	23, // 49: teleport.desktop.v1.Envelope.shared_directory_remove:type_name -> teleport.desktop.v1.SharedDirectoryRemove
+	7,  // 50: teleport.desktop.v1.Envelope.session_selection:type_name -> teleport.desktop.v1.SessionSelection
+	30, // 51: teleport.desktop.v1.Envelope.auth_prompt:type_name -> teleport.desktop.v1.AuthPrompt
+	32, // 52: teleport.desktop.v1.Envelope.mfa_prompt_response:type_name -> teleport.desktop.v1.MFAPromptResponse
+	34, // 53: teleport.desktop.v1.Envelope.session_establishing:type_name -> teleport.desktop.v1.SessionEstablishing
+	27, // 54: teleport.desktop.v1.SharedDirectoryResponse.Info.fso:type_name -> teleport.desktop.v1.FileSystemObject
+	27, // 55: teleport.desktop.v1.SharedDirectoryResponse.Create.fso:type_name -> teleport.desktop.v1.FileSystemObject
+	27, // 56: teleport.desktop.v1.SharedDirectoryResponse.List.fso_list:type_name -> teleport.desktop.v1.FileSystemObject
+	57, // [57:57] is the sub-list for method output_type
+	57, // [57:57] is the sub-list for method input_type
+	57, // [57:57] is the sub-list for extension type_name
+	57, // [57:57] is the sub-list for extension extendee
+	0,  // [0:57] is the sub-list for field type_name
 }
 
 func init() { file_teleport_desktop_v1_tdpb_proto_init() }
@@ -5541,6 +6104,12 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 		(*sharedDirectoryResponse_Truncate_)(nil),
 	}
 	file_teleport_desktop_v1_tdpb_proto_msgTypes[26].OneofWrappers = []any{
+		(*authPrompt_MfaPrompt)(nil),
+	}
+	file_teleport_desktop_v1_tdpb_proto_msgTypes[28].OneofWrappers = []any{
+		(*mFAPromptResponse_Reference)(nil),
+	}
+	file_teleport_desktop_v1_tdpb_proto_msgTypes[31].OneofWrappers = []any{
 		(*envelope_ClientHello)(nil),
 		(*envelope_ServerHello)(nil),
 		(*envelope_PngFrame)(nil),
@@ -5563,6 +6132,9 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 		(*envelope_Ping)(nil),
 		(*envelope_SharedDirectoryRemove)(nil),
 		(*envelope_SessionSelection)(nil),
+		(*envelope_AuthPrompt)(nil),
+		(*envelope_MfaPromptResponse)(nil),
+		(*envelope_SessionEstablishing)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -5570,7 +6142,7 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_desktop_v1_tdpb_proto_rawDesc), len(file_teleport_desktop_v1_tdpb_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   43,
+			NumMessages:   48,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/mfa/v2/validated_challenge.pb.go
+++ b/api/gen/proto/go/teleport/mfa/v2/validated_challenge.pb.go
@@ -335,11 +335,27 @@ func (x *SessionIdentifyingPayload) GetSshSessionId() []byte {
 	return nil
 }
 
+func (x *SessionIdentifyingPayload) GetTlsSessionId() []byte {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Payload.(*sessionIdentifyingPayload_TlsSessionId); ok {
+			return x.TlsSessionId
+		}
+	}
+	return nil
+}
+
 func (x *SessionIdentifyingPayload) SetSshSessionId(v []byte) {
 	if v == nil {
 		v = []byte{}
 	}
 	x.xxx_hidden_Payload = &sessionIdentifyingPayload_SshSessionId{v}
+}
+
+func (x *SessionIdentifyingPayload) SetTlsSessionId(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.xxx_hidden_Payload = &sessionIdentifyingPayload_TlsSessionId{v}
 }
 
 func (x *SessionIdentifyingPayload) HasPayload() bool {
@@ -357,6 +373,14 @@ func (x *SessionIdentifyingPayload) HasSshSessionId() bool {
 	return ok
 }
 
+func (x *SessionIdentifyingPayload) HasTlsSessionId() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Payload.(*sessionIdentifyingPayload_TlsSessionId)
+	return ok
+}
+
 func (x *SessionIdentifyingPayload) ClearPayload() {
 	x.xxx_hidden_Payload = nil
 }
@@ -367,8 +391,15 @@ func (x *SessionIdentifyingPayload) ClearSshSessionId() {
 	}
 }
 
+func (x *SessionIdentifyingPayload) ClearTlsSessionId() {
+	if _, ok := x.xxx_hidden_Payload.(*sessionIdentifyingPayload_TlsSessionId); ok {
+		x.xxx_hidden_Payload = nil
+	}
+}
+
 const SessionIdentifyingPayload_Payload_not_set_case case_SessionIdentifyingPayload_Payload = 0
 const SessionIdentifyingPayload_SshSessionId_case case_SessionIdentifyingPayload_Payload = 1
+const SessionIdentifyingPayload_TlsSessionId_case case_SessionIdentifyingPayload_Payload = 2
 
 func (x *SessionIdentifyingPayload) WhichPayload() case_SessionIdentifyingPayload_Payload {
 	if x == nil {
@@ -377,6 +408,8 @@ func (x *SessionIdentifyingPayload) WhichPayload() case_SessionIdentifyingPayloa
 	switch x.xxx_hidden_Payload.(type) {
 	case *sessionIdentifyingPayload_SshSessionId:
 		return SessionIdentifyingPayload_SshSessionId_case
+	case *sessionIdentifyingPayload_TlsSessionId:
+		return SessionIdentifyingPayload_TlsSessionId_case
 	default:
 		return SessionIdentifyingPayload_Payload_not_set_case
 	}
@@ -389,6 +422,9 @@ type SessionIdentifyingPayload_builder struct {
 	// SSH session hash computed from session state. For example, in Go this is the value from
 	// crypto/ssh#ConnMetadata.SessionID().
 	SshSessionId []byte
+	// TLS session hash derived from the TLS connection using RFC 5705 exportable keying material. For example, in Go
+	// this is the value from crypto/tls#ConnectionState.ExportKeyingMaterial().
+	TlsSessionId []byte
 	// -- end of xxx_hidden_Payload
 }
 
@@ -398,6 +434,9 @@ func (b0 SessionIdentifyingPayload_builder) Build() *SessionIdentifyingPayload {
 	_, _ = b, x
 	if b.SshSessionId != nil {
 		x.xxx_hidden_Payload = &sessionIdentifyingPayload_SshSessionId{b.SshSessionId}
+	}
+	if b.TlsSessionId != nil {
+		x.xxx_hidden_Payload = &sessionIdentifyingPayload_TlsSessionId{b.TlsSessionId}
 	}
 	return m0
 }
@@ -422,7 +461,15 @@ type sessionIdentifyingPayload_SshSessionId struct {
 	SshSessionId []byte `protobuf:"bytes,1,opt,name=ssh_session_id,json=sshSessionId,proto3,oneof"`
 }
 
+type sessionIdentifyingPayload_TlsSessionId struct {
+	// TLS session hash derived from the TLS connection using RFC 5705 exportable keying material. For example, in Go
+	// this is the value from crypto/tls#ConnectionState.ExportKeyingMaterial().
+	TlsSessionId []byte `protobuf:"bytes,2,opt,name=tls_session_id,json=tlsSessionId,proto3,oneof"`
+}
+
 func (*sessionIdentifyingPayload_SshSessionId) isSessionIdentifyingPayload_Payload() {}
+
+func (*sessionIdentifyingPayload_TlsSessionId) isSessionIdentifyingPayload_Payload() {}
 
 var File_teleport_mfa_v2_validated_challenge_proto protoreflect.FileDescriptor
 
@@ -439,9 +486,10 @@ const file_teleport_mfa_v2_validated_challenge_proto_rawDesc = "" +
 	"\apayload\x18\x01 \x01(\v2*.teleport.mfa.v2.SessionIdentifyingPayloadR\apayload\x12%\n" +
 	"\x0esource_cluster\x18\x02 \x01(\tR\rsourceCluster\x12%\n" +
 	"\x0etarget_cluster\x18\x03 \x01(\tR\rtargetCluster\x12\x1a\n" +
-	"\busername\x18\x04 \x01(\tR\busername\"N\n" +
+	"\busername\x18\x04 \x01(\tR\busername\"v\n" +
 	"\x19SessionIdentifyingPayload\x12&\n" +
-	"\x0essh_session_id\x18\x01 \x01(\fH\x00R\fsshSessionIdB\t\n" +
+	"\x0essh_session_id\x18\x01 \x01(\fH\x00R\fsshSessionId\x12&\n" +
+	"\x0etls_session_id\x18\x02 \x01(\fH\x00R\ftlsSessionIdB\t\n" +
 	"\apayloadBJZHgithub.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v2;mfav2b\x06proto3"
 
 var file_teleport_mfa_v2_validated_challenge_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
@@ -469,6 +517,7 @@ func file_teleport_mfa_v2_validated_challenge_proto_init() {
 	}
 	file_teleport_mfa_v2_validated_challenge_proto_msgTypes[2].OneofWrappers = []any{
 		(*sessionIdentifyingPayload_SshSessionId)(nil),
+		(*sessionIdentifyingPayload_TlsSessionId)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/api/proto/teleport/desktop/v1/tdpb.proto
+++ b/api/proto/teleport/desktop/v1/tdpb.proto
@@ -338,6 +338,33 @@ message Ping {
   bytes uuid = 1;
 }
 
+// Sent by the server to request authentication from the client before session establishment.
+message AuthPrompt {
+  oneof prompt {
+    MFAPrompt mfa_prompt = 1;
+  }
+}
+
+// Indicates MFA is required for the session. The client performs the MFA ceremony and responds with
+// MFAPromptResponse.
+message MFAPrompt {}
+
+// Client response to an AuthPrompt containing MFAPrompt.
+message MFAPromptResponse {
+  oneof response {
+    MFAPromptResponseReference reference = 1;
+  }
+}
+
+// Instructs the server to verify the MFA challenge with the MFA service.
+message MFAPromptResponseReference {
+  // The name of the MFA challenge created by the client.
+  string challenge_name = 1;
+}
+
+// Sent by the server to indicate the session backend is being established and no additional authentication is required.
+message SessionEstablishing {}
+
 // Envelope wraps all messages that are allowed to be sent on the wire.
 message Envelope {
   oneof payload {
@@ -363,5 +390,8 @@ message Envelope {
     Ping ping = 20;
     SharedDirectoryRemove shared_directory_remove = 21;
     SessionSelection session_selection = 22;
+    AuthPrompt auth_prompt = 23;
+    MFAPromptResponse mfa_prompt_response = 24;
+    SessionEstablishing session_establishing = 25;
   }
 }

--- a/api/proto/teleport/mfa/v2/validated_challenge.proto
+++ b/api/proto/teleport/mfa/v2/validated_challenge.proto
@@ -54,5 +54,8 @@ message SessionIdentifyingPayload {
     // SSH session hash computed from session state. For example, in Go this is the value from
     // crypto/ssh#ConnMetadata.SessionID().
     bytes ssh_session_id = 1;
+    // TLS session hash derived from the TLS connection using RFC 5705 exportable keying material. For example, in Go
+    // this is the value from crypto/tls#ConnectionState.ExportKeyingMaterial().
+    bytes tls_session_id = 2;
   }
 }

--- a/gen/proto/ts/teleport/desktop/v1/tdpb_pb.ts
+++ b/gen/proto/ts/teleport/desktop/v1/tdpb_pb.ts
@@ -780,6 +780,72 @@ export interface Ping {
     uuid: Uint8Array;
 }
 /**
+ * Sent by the server to request authentication from the client before session establishment.
+ *
+ * @generated from protobuf message teleport.desktop.v1.AuthPrompt
+ */
+export interface AuthPrompt {
+    /**
+     * @generated from protobuf oneof: prompt
+     */
+    prompt: {
+        oneofKind: "mfaPrompt";
+        /**
+         * @generated from protobuf field: teleport.desktop.v1.MFAPrompt mfa_prompt = 1;
+         */
+        mfaPrompt: MFAPrompt;
+    } | {
+        oneofKind: undefined;
+    };
+}
+/**
+ * Indicates MFA is required for the session. The client performs the MFA ceremony and responds with
+ * MFAPromptResponse.
+ *
+ * @generated from protobuf message teleport.desktop.v1.MFAPrompt
+ */
+export interface MFAPrompt {
+}
+/**
+ * Client response to an AuthPrompt containing MFAPrompt.
+ *
+ * @generated from protobuf message teleport.desktop.v1.MFAPromptResponse
+ */
+export interface MFAPromptResponse {
+    /**
+     * @generated from protobuf oneof: response
+     */
+    response: {
+        oneofKind: "reference";
+        /**
+         * @generated from protobuf field: teleport.desktop.v1.MFAPromptResponseReference reference = 1;
+         */
+        reference: MFAPromptResponseReference;
+    } | {
+        oneofKind: undefined;
+    };
+}
+/**
+ * Instructs the server to verify the MFA challenge with the MFA service.
+ *
+ * @generated from protobuf message teleport.desktop.v1.MFAPromptResponseReference
+ */
+export interface MFAPromptResponseReference {
+    /**
+     * The name of the MFA challenge created by the client.
+     *
+     * @generated from protobuf field: string challenge_name = 1;
+     */
+    challengeName: string;
+}
+/**
+ * Sent by the server to indicate the session backend is being established and no additional authentication is required.
+ *
+ * @generated from protobuf message teleport.desktop.v1.SessionEstablishing
+ */
+export interface SessionEstablishing {
+}
+/**
  * Envelope wraps all messages that are allowed to be sent on the wire.
  *
  * @generated from protobuf message teleport.desktop.v1.Envelope
@@ -920,6 +986,24 @@ export interface Envelope {
          * @generated from protobuf field: teleport.desktop.v1.SessionSelection session_selection = 22;
          */
         sessionSelection: SessionSelection;
+    } | {
+        oneofKind: "authPrompt";
+        /**
+         * @generated from protobuf field: teleport.desktop.v1.AuthPrompt auth_prompt = 23;
+         */
+        authPrompt: AuthPrompt;
+    } | {
+        oneofKind: "mfaPromptResponse";
+        /**
+         * @generated from protobuf field: teleport.desktop.v1.MFAPromptResponse mfa_prompt_response = 24;
+         */
+        mfaPromptResponse: MFAPromptResponse;
+    } | {
+        oneofKind: "sessionEstablishing";
+        /**
+         * @generated from protobuf field: teleport.desktop.v1.SessionEstablishing session_establishing = 25;
+         */
+        sessionEstablishing: SessionEstablishing;
     } | {
         oneofKind: undefined;
     };
@@ -3423,6 +3507,203 @@ class Ping$Type extends MessageType<Ping> {
  */
 export const Ping = new Ping$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class AuthPrompt$Type extends MessageType<AuthPrompt> {
+    constructor() {
+        super("teleport.desktop.v1.AuthPrompt", [
+            { no: 1, name: "mfa_prompt", kind: "message", oneof: "prompt", T: () => MFAPrompt }
+        ]);
+    }
+    create(value?: PartialMessage<AuthPrompt>): AuthPrompt {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.prompt = { oneofKind: undefined };
+        if (value !== undefined)
+            reflectionMergePartial<AuthPrompt>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: AuthPrompt): AuthPrompt {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* teleport.desktop.v1.MFAPrompt mfa_prompt */ 1:
+                    message.prompt = {
+                        oneofKind: "mfaPrompt",
+                        mfaPrompt: MFAPrompt.internalBinaryRead(reader, reader.uint32(), options, (message.prompt as any).mfaPrompt)
+                    };
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: AuthPrompt, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* teleport.desktop.v1.MFAPrompt mfa_prompt = 1; */
+        if (message.prompt.oneofKind === "mfaPrompt")
+            MFAPrompt.internalBinaryWrite(message.prompt.mfaPrompt, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.desktop.v1.AuthPrompt
+ */
+export const AuthPrompt = new AuthPrompt$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class MFAPrompt$Type extends MessageType<MFAPrompt> {
+    constructor() {
+        super("teleport.desktop.v1.MFAPrompt", []);
+    }
+    create(value?: PartialMessage<MFAPrompt>): MFAPrompt {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<MFAPrompt>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: MFAPrompt): MFAPrompt {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: MFAPrompt, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.desktop.v1.MFAPrompt
+ */
+export const MFAPrompt = new MFAPrompt$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class MFAPromptResponse$Type extends MessageType<MFAPromptResponse> {
+    constructor() {
+        super("teleport.desktop.v1.MFAPromptResponse", [
+            { no: 1, name: "reference", kind: "message", oneof: "response", T: () => MFAPromptResponseReference }
+        ]);
+    }
+    create(value?: PartialMessage<MFAPromptResponse>): MFAPromptResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.response = { oneofKind: undefined };
+        if (value !== undefined)
+            reflectionMergePartial<MFAPromptResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: MFAPromptResponse): MFAPromptResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* teleport.desktop.v1.MFAPromptResponseReference reference */ 1:
+                    message.response = {
+                        oneofKind: "reference",
+                        reference: MFAPromptResponseReference.internalBinaryRead(reader, reader.uint32(), options, (message.response as any).reference)
+                    };
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: MFAPromptResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* teleport.desktop.v1.MFAPromptResponseReference reference = 1; */
+        if (message.response.oneofKind === "reference")
+            MFAPromptResponseReference.internalBinaryWrite(message.response.reference, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.desktop.v1.MFAPromptResponse
+ */
+export const MFAPromptResponse = new MFAPromptResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class MFAPromptResponseReference$Type extends MessageType<MFAPromptResponseReference> {
+    constructor() {
+        super("teleport.desktop.v1.MFAPromptResponseReference", [
+            { no: 1, name: "challenge_name", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<MFAPromptResponseReference>): MFAPromptResponseReference {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.challengeName = "";
+        if (value !== undefined)
+            reflectionMergePartial<MFAPromptResponseReference>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: MFAPromptResponseReference): MFAPromptResponseReference {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string challenge_name */ 1:
+                    message.challengeName = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: MFAPromptResponseReference, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string challenge_name = 1; */
+        if (message.challengeName !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.challengeName);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.desktop.v1.MFAPromptResponseReference
+ */
+export const MFAPromptResponseReference = new MFAPromptResponseReference$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class SessionEstablishing$Type extends MessageType<SessionEstablishing> {
+    constructor() {
+        super("teleport.desktop.v1.SessionEstablishing", []);
+    }
+    create(value?: PartialMessage<SessionEstablishing>): SessionEstablishing {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<SessionEstablishing>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SessionEstablishing): SessionEstablishing {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: SessionEstablishing, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.desktop.v1.SessionEstablishing
+ */
+export const SessionEstablishing = new SessionEstablishing$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class Envelope$Type extends MessageType<Envelope> {
     constructor() {
         super("teleport.desktop.v1.Envelope", [
@@ -3447,7 +3728,10 @@ class Envelope$Type extends MessageType<Envelope> {
             { no: 19, name: "latency_stats", kind: "message", oneof: "payload", T: () => LatencyStats },
             { no: 20, name: "ping", kind: "message", oneof: "payload", T: () => Ping },
             { no: 21, name: "shared_directory_remove", kind: "message", oneof: "payload", T: () => SharedDirectoryRemove },
-            { no: 22, name: "session_selection", kind: "message", oneof: "payload", T: () => SessionSelection }
+            { no: 22, name: "session_selection", kind: "message", oneof: "payload", T: () => SessionSelection },
+            { no: 23, name: "auth_prompt", kind: "message", oneof: "payload", T: () => AuthPrompt },
+            { no: 24, name: "mfa_prompt_response", kind: "message", oneof: "payload", T: () => MFAPromptResponse },
+            { no: 25, name: "session_establishing", kind: "message", oneof: "payload", T: () => SessionEstablishing }
         ]);
     }
     create(value?: PartialMessage<Envelope>): Envelope {
@@ -3594,6 +3878,24 @@ class Envelope$Type extends MessageType<Envelope> {
                         sessionSelection: SessionSelection.internalBinaryRead(reader, reader.uint32(), options, (message.payload as any).sessionSelection)
                     };
                     break;
+                case /* teleport.desktop.v1.AuthPrompt auth_prompt */ 23:
+                    message.payload = {
+                        oneofKind: "authPrompt",
+                        authPrompt: AuthPrompt.internalBinaryRead(reader, reader.uint32(), options, (message.payload as any).authPrompt)
+                    };
+                    break;
+                case /* teleport.desktop.v1.MFAPromptResponse mfa_prompt_response */ 24:
+                    message.payload = {
+                        oneofKind: "mfaPromptResponse",
+                        mfaPromptResponse: MFAPromptResponse.internalBinaryRead(reader, reader.uint32(), options, (message.payload as any).mfaPromptResponse)
+                    };
+                    break;
+                case /* teleport.desktop.v1.SessionEstablishing session_establishing */ 25:
+                    message.payload = {
+                        oneofKind: "sessionEstablishing",
+                        sessionEstablishing: SessionEstablishing.internalBinaryRead(reader, reader.uint32(), options, (message.payload as any).sessionEstablishing)
+                    };
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -3672,6 +3974,15 @@ class Envelope$Type extends MessageType<Envelope> {
         /* teleport.desktop.v1.SessionSelection session_selection = 22; */
         if (message.payload.oneofKind === "sessionSelection")
             SessionSelection.internalBinaryWrite(message.payload.sessionSelection, writer.tag(22, WireType.LengthDelimited).fork(), options).join();
+        /* teleport.desktop.v1.AuthPrompt auth_prompt = 23; */
+        if (message.payload.oneofKind === "authPrompt")
+            AuthPrompt.internalBinaryWrite(message.payload.authPrompt, writer.tag(23, WireType.LengthDelimited).fork(), options).join();
+        /* teleport.desktop.v1.MFAPromptResponse mfa_prompt_response = 24; */
+        if (message.payload.oneofKind === "mfaPromptResponse")
+            MFAPromptResponse.internalBinaryWrite(message.payload.mfaPromptResponse, writer.tag(24, WireType.LengthDelimited).fork(), options).join();
+        /* teleport.desktop.v1.SessionEstablishing session_establishing = 25; */
+        if (message.payload.oneofKind === "sessionEstablishing")
+            SessionEstablishing.internalBinaryWrite(message.payload.sessionEstablishing, writer.tag(25, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);


### PR DESCRIPTION
Part of the implementation of [RFD 0314](https://github.com/gravitational/rfd/blob/52ee5c7c406410c776cc0214e2a1dcfd2f4362a3/rfd/0314-in-band-mfa-desktop.md#proto-specification).

Adds the new proto messages and changes to existing messages with docs.