### PR TITLE
Add the `--local-only` flag to `tctl auth create-override-csr`

### DIFF
--- a/tool/tctl/common/subca/subca_command.go
+++ b/tool/tctl/common/subca/subca_command.go
@@ -175,6 +175,9 @@ func (c *Command) Initialize(
 	c.createOverrideCSR.
 		Flag("subject", `Customized certificate subject. Example: "O=MyClusterName,OU=MyOrgUnit,CN=MyCommonName"`).
 		StringVar(&c.createOverrideCSR.subject)
+	c.createOverrideCSR.
+		Flag("local-only", "If true only private keys local to the replying Auth server are used.").
+		BoolVar(&c.createOverrideCSR.localOnly)
 
 	c.createOverride.CmdClause = parent.Command("create-override", "Add a single certificate override to a CA override resource")
 	c.createOverride.Flag("type", caTypesHelp).
@@ -272,6 +275,7 @@ type createOverrideCSRCommand struct {
 	out       string // Output path prefix.
 	publicKey string
 	subject   string
+	localOnly bool
 }
 
 func (c *createOverrideCSRCommand) Run(
@@ -317,6 +321,7 @@ func (c *createOverrideCSRCommand) Run(
 		CaType:        caType,
 		PublicKeyHash: pubKey,
 		CustomSubject: customSubject,
+		LocalOnly:     c.localOnly,
 	}.Build())
 	if err != nil {
 		return trace.Wrap(err, "create CSRs")

--- a/tool/tctl/common/subca/subca_command_test.go
+++ b/tool/tctl/common/subca/subca_command_test.go
@@ -152,6 +152,21 @@ func TestCommand_CreateOverrideCSR(t *testing.T) {
 				wantWindows2File: windowsCSRPEM2,
 			},
 		},
+		{
+			name: "local only",
+			flags: []string{
+				"--type", "db-client",
+				"--local-only",
+			},
+			csrPEMs: []string{
+				dbClientCSRPEM,
+			},
+			wantReq: subcav1.CreateCSRRequest_builder{
+				CaType:    string(types.DatabaseClientCA),
+				LocalOnly: true,
+			}.Build(),
+			wantStdout: dbClientCSRPEM + "\n",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Add the `--local-only` flag to `tctl auth create-override-csr`.

This allows users to quickly collect CSRs "local" to the requested Auth server, serving as a fallback to the "old" behavior of create-override-csr.

Follow up from #68352.

https://github.com/gravitational/teleport.e/issues/7675