### PR TITLE
Update the CA override guide with new features and commands

### DIFF
--- a/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
@@ -211,10 +211,26 @@ Enable it:
 $ tctl auth update-override --type=windows --public-key=<Var name="public-key" /> --set-disabled=false
 ```
 
-You can find the public key of the target override by running
-`tctl auth pub-key-hash --cert=cert.pem` or reading it from
-`tctl get ca_overrides/windows`. Alternatively, you may edit directly using
-`tctl edit ca_overrides/windows`.
+You can find the public key of the target override using the `tctl auth
+pub-key-hash` command or reading it from the ca_override itself.
+
+Using `tctl auth pub-key-hash`:
+
+```code
+$ tctl auth pub-key-hash --cert=cert.pem
+```
+
+Using `tctl get`:
+
+```code
+$ tctl get ca_overrides/windows
+```
+
+Alternatively, you may edit directly using:
+
+```code
+$ tctl edit ca_overrides/windows
+```
 
 ### Multi-Auth Service clusters with per-instance HSM keys
 

--- a/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
@@ -140,15 +140,18 @@ See below for CA-specific instructions.
 
 ### db_client
 
+<details>
 Most databases only need to trust the external root CA and intermediate CAs.
 It's not necessary to trust the override CA certificate directly. Those include,
 but are not limited to, MariaDB, MySQL, PostgreSQL, Redis and Oracle.
 
 We recommend checking your database documentation and verifying access after
 applying the CA override in a controlled environment.
+</details>
 
 ### windows
 
+<details>
 Your configuration depends on whether you use
 [AD](../../../enroll-resources/desktop-access/active-directory.mdx#step-37-configure-a-gpo-to-allow-teleport-connections)
 or
@@ -160,6 +163,7 @@ domain, and publish the override CA certificate directly to NTAuth.
 
 Run the following command on a domain-joined Windows host to verify that the
 NTAuth store includes the override CA certificate.
+</details>
 
 ```code
 $ certutil -viewstore -enterprise NTAuth

--- a/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
@@ -114,7 +114,7 @@ $ tctl auth create-override-csr --type=windows
 
 When writing the override resource, make sure the final
 `spec.certificate_overrides` contains one entry for each certificate issued from
-those CSRs. See steps 4 and 4.1.
+those CSRs. See Step 4.
 
 ## Step 2/5. Issue override certificates using your external CA
 

--- a/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
@@ -222,9 +222,9 @@ You can find the public key of the target override by running
 ### Create certificate overrides on multi-Auth, HSM-enabled clusters
 
 In multi-Auth, HSM-enabled clusters, each Auth Service instance may have
-exclusive private keys. In this scenario, make sure all Auth instances are
+exclusive private keys. In this scenario, make sure all Auth Service instances are
 online and healthy, then create your overrides in the disabled state. The Auth
-instances automatically sign CRLs in the background for their respective keys.
+Service instances automatically sign CRLs in the background for their respective keys.
 After a certificate override has a matching CRL it can be enabled.
 
 ```code

--- a/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
@@ -190,37 +190,8 @@ $ certutil -verify -urlfetch .\override.cer
 After issuing certificates and configuring downstream trust, create the
 certificate overrides.
 
-Find your cluster name:
-
 ```code
-$ tctl get cas/windows | yq '.spec.cluster_name'
-mycluster
-```
-
-Prepare the `ca_override_windows.yaml` file, assigning
-<Var name="cluster-name" /> to your cluster name.
-
-Add one entry under `spec.certificate_overrides` for each override certificate.
-Replace the example PEM with your override certificate PEM.
-
-```yaml
-kind: cert_authority_override
-sub_kind: windows
-version: v1
-metadata:
-  name: <Var name="cluster-name" />
-spec:
-  certificate_overrides:
-  - certificate: |-
-      -----BEGIN CERTIFICATE-----
-      (...)
-      -----END CERTIFICATE-----
-```
-
-Create the override:
-
-```code
-$ tctl create ca_override_windows.yaml
+$ tctl auth create-override --type=windows cert.pem
 ```
 
 <Admonition type="tip">
@@ -230,70 +201,41 @@ This is useful for environments with staged rollouts, so overrides may be
 created in a disabled state until downstream services are ready to accept them.
 Set `disabled` to `false` when you are ready to enable the override.
 
-```yaml
-kind: cert_authority_override
-sub_kind: windows
-version: v1
-metadata:
-  name: <Var name="cluster-name" />
-spec:
-  certificate_overrides:
-  - certificate: |-
-      -----BEGIN CERTIFICATE-----
-      (...)
-      -----END CERTIFICATE-----
-    disabled: true
+Create the disabled override:
+
+```code
+$ tctl auth create-override --type=windows cert.pem --disabled
 ```
+
+Enable it:
+
+```code
+$ tctl auth update-override --type=windows --public-key=<Var name="public-key" /> --set-disabled=false
+```
+
+You can find the public key of the target override by running
+`tctl auth pub-key-hash --cert=cert.pem` or reading it from
+`tctl get ca_overrides/windows`. Alternatively, you may edit directly using
+`tctl edit ca_overrides/windows`.
 </Admonition>
 
 ### Create certificate overrides on multi-Auth, HSM-enabled clusters
 
-In multi-Auth, HSM-enabled clusters, each `certificate_override` entry must be
-added by the corresponding Auth Service instance, which is the Auth Service
-instance that has access to the relevant private key.
-
-Start with an empty CA override created by any Auth Service instance:
-
-```yaml
-kind: cert_authority_override
-sub_kind: windows
-version: v1
-metadata:
-  name: <Var name="cluster-name" />
-spec: {}
-```
+In multi-Auth, HSM-enabled clusters, each Auth Service instance may have
+exclusive private keys. In this scenario, make sure all Auth instances are
+online and healthy, then create your overrides in the disabled state. The Auth
+instances automatically sign CRLs in the background for their respective keys.
+After a certificate override has a matching CRL it can be enabled.
 
 ```code
-$ tctl create ca_override_windows.yaml
-```
+# Create the override. Repeat for each certificate override.
+$ tctl auth create-override --disabled --type=windows cert.pem
 
-Then, on each Auth Service instance, edit the CA override with `tctl edit`.
+# Verify that CRLs are present.
+$ tctl get ca_overrides/windows
 
-```code
-# Modify the command below as appropriate.
-$ tsh ssh user@Auth1
-
-$ tctl edit ca_overrides/windows
-```
-
-Add the corresponding `certificate_override` stanza, then save and exit.
-
-```yaml
-kind: cert_authority_override
-sub_kind: windows
-version: v1
-metadata:
-  name: <Var name="cluster-name" />
-spec:
-  certificate_overrides:
-  - certificate: |-
-      -----BEGIN CERTIFICATE-----
-      (...)
-      -----END CERTIFICATE-----
-  - certificate: |-
-      -----BEGIN CERTIFICATE-----
-      (...)
-      -----END CERTIFICATE-----
+# Enable the override. Repeat for each certificate override.
+$ tctl auth update-override --type=windows --public-key=<Var name="public-key" /> --set-disabled=false
 ```
 
 ## Step 5/5. Exercise the CA override

--- a/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
@@ -190,8 +190,10 @@ certificate overrides.
 $ tctl auth create-override --type=windows cert.pem
 ```
 
-<Admonition type="tip">
-You may create a disabled override and enable it later.
+### Disabled overrides
+
+You may create a disabled override and enable it later. A disabled override
+works as if it didn't exist, leaving signing to the self-signed CA certificate.
 
 This is useful for environments with staged rollouts, so overrides may be
 created in a disabled state until downstream services are ready to accept them.
@@ -213,7 +215,6 @@ You can find the public key of the target override by running
 `tctl auth pub-key-hash --cert=cert.pem` or reading it from
 `tctl get ca_overrides/windows`. Alternatively, you may edit directly using
 `tctl edit ca_overrides/windows`.
-</Admonition>
 
 ### Create certificate overrides on multi-Auth, HSM-enabled clusters
 

--- a/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
@@ -140,18 +140,15 @@ See below for CA-specific instructions.
 
 ### db_client
 
-<details>
 Most databases only need to trust the external root CA and intermediate CAs.
 It's not necessary to trust the override CA certificate directly. Those include,
 but are not limited to, MariaDB, MySQL, PostgreSQL, Redis and Oracle.
 
 We recommend checking your database documentation and verifying access after
 applying the CA override in a controlled environment.
-</details>
 
 ### windows
 
-<details>
 Your configuration depends on whether you use
 [AD](../../../enroll-resources/desktop-access/active-directory.mdx#step-37-configure-a-gpo-to-allow-teleport-connections)
 or
@@ -163,7 +160,6 @@ domain, and publish the override CA certificate directly to NTAuth.
 
 Run the following command on a domain-joined Windows host to verify that the
 NTAuth store includes the override CA certificate.
-</details>
 
 ```code
 $ certutil -viewstore -enterprise NTAuth

--- a/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
@@ -88,11 +88,11 @@ You may customize the certificate subject:
 $ tctl auth create-override-csr --type=windows --subject='OU=My Organization Unit,CN=My Windows CA'
 ```
 
-### Prepare CSRs for multi-Auth, HSM-enabled clusters
+### Prepare CSRs for multi-Auth clusters with per-instance HSM keys
 
-In multi-Auth, HSM-enabled clusters, run `tctl` locally against each Auth
-Service instance. Each Auth Service instance generates CSRs for the keys it can
-access.
+In multi-Auth clusters with per-instance HSM keys, run `tctl` locally against
+each Auth Service instance. Each Auth Service instance generates CSRs for the
+keys it can access.
 
 For example:
 
@@ -216,13 +216,14 @@ You can find the public key of the target override by running
 `tctl get ca_overrides/windows`. Alternatively, you may edit directly using
 `tctl edit ca_overrides/windows`.
 
-### Create certificate overrides on multi-Auth, HSM-enabled clusters
+### Create certificate overrides on multi-Auth clusters with per-instance HSM keys
 
-In multi-Auth, HSM-enabled clusters, each Auth Service instance may have
-exclusive private keys. In this scenario, make sure all Auth Service instances are
-online and healthy, then create your overrides in the disabled state. The Auth
-Service instances automatically sign CRLs in the background for their respective keys.
-After a certificate override has a matching CRL it can be enabled.
+In multi-Auth clusters with per-instance HSM keys, each Auth Service instance
+may only be able to access its own private keys. In this scenario, make sure all
+Auth Service instances are online and healthy, then create your overrides in the
+disabled state. The Auth Service instances automatically sign CRLs in the
+background for their respective keys. After a certificate override has a
+matching CRL it can be enabled.
 
 ```code
 # Create the override. Repeat for each certificate override.

--- a/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
@@ -88,11 +88,11 @@ You may customize the certificate subject:
 $ tctl auth create-override-csr --type=windows --subject='OU=My Organization Unit,CN=My Windows CA'
 ```
 
-### Prepare CSRs for multi-Auth clusters with per-instance HSM keys
+### Multi-Auth Service clusters with per-instance HSM keys
 
-In multi-Auth clusters with per-instance HSM keys, run `tctl` locally against
-each Auth Service instance. Each Auth Service instance generates CSRs for the
-keys it can access.
+In clusters with multiple Auth Service instances and a separate HSM key per
+instance, run `tctl` locally against each Auth Service instance. Each Auth
+Service instance generates CSRs for the keys it can access.
 
 For example:
 
@@ -216,14 +216,14 @@ You can find the public key of the target override by running
 `tctl get ca_overrides/windows`. Alternatively, you may edit directly using
 `tctl edit ca_overrides/windows`.
 
-### Create certificate overrides on multi-Auth clusters with per-instance HSM keys
+### Multi-Auth Service clusters with per-instance HSM keys
 
-In multi-Auth clusters with per-instance HSM keys, each Auth Service instance
-may only be able to access its own private keys. In this scenario, make sure all
-Auth Service instances are online and healthy, then create your overrides in the
-disabled state. The Auth Service instances automatically sign CRLs in the
-background for their respective keys. After a certificate override has a
-matching CRL it can be enabled.
+In clusters with multiple Auth Service instances and a separate HSM key per
+instance, each Auth Service instance may only be able to access its own private
+keys. In this scenario, make sure all Auth Service instances are online and
+healthy, then create your overrides in the disabled state. The Auth Service
+instances automatically sign CRLs in the background for their respective keys.
+After a certificate override has a matching CRL it can be enabled.
 
 ```code
 # Create the override. Repeat for each certificate override.

--- a/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
@@ -183,8 +183,8 @@ $ certutil -verify -urlfetch .\override.cer
 
 ## Step 4/5. Create the certificate overrides
 
-After issuing certificates and configuring downstream trust, create the
-certificate overrides.
+After issuing certificates and configuring downstream trust, create a
+certificate override for each certificate:
 
 ```code
 $ tctl auth create-override --type=windows cert.pem


### PR DESCRIPTION
Update guide with `tctl auth create-override`, `tctl auth update-override` and improvements to async CRL creation.

The old instructions still work, they are simply more laborious to use.

https://github.com/gravitational/teleport.e/issues/7675