### PR TITLE
[terraform] preserve unknown values during TF plan

### DIFF
--- a/integrations/terraform/gen/plural_resource.go.tpl
+++ b/integrations/terraform/gen/plural_resource.go.tpl
@@ -947,7 +947,8 @@ func (r resourceTeleport{{.Name}}) ModifyPlan(ctx context.Context, req tfsdk.Mod
 	{{.VarName}} = {{.VarName}}Resource
 {{- end }}
 
-	resp.Diagnostics.Append({{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, {{.VarName}}, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append({{.SchemaPackage}}.Copy{{.TypeName}}ToTerraformPreserveUnknown(ctx, {{.VarName}}, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/gen/plural_resource.go.tpl
+++ b/integrations/terraform/gen/plural_resource.go.tpl
@@ -947,7 +947,7 @@ func (r resourceTeleport{{.Name}}) ModifyPlan(ctx context.Context, req tfsdk.Mod
 	{{.VarName}} = {{.VarName}}Resource
 {{- end }}
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append({{.SchemaPackage}}.Copy{{.TypeName}}ToTerraformPreserveUnknown(ctx, {{.VarName}}, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/gen/singular_resource.go.tpl
+++ b/integrations/terraform/gen/singular_resource.go.tpl
@@ -693,7 +693,8 @@ func (r resourceTeleport{{.Name}}) ModifyPlan(ctx context.Context, req tfsdk.Mod
 	{{.VarName}} = {{.VarName}}Resource
 {{- end }}
 
-	resp.Diagnostics.Append({{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, {{.VarName}}, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append({{.SchemaPackage}}.Copy{{.TypeName}}ToTerraformPreserveUnknown(ctx, {{.VarName}}, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/gen/singular_resource.go.tpl
+++ b/integrations/terraform/gen/singular_resource.go.tpl
@@ -693,7 +693,7 @@ func (r resourceTeleport{{.Name}}) ModifyPlan(ctx context.Context, req tfsdk.Mod
 	{{.VarName}} = {{.VarName}}Resource
 {{- end }}
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append({{.SchemaPackage}}.Copy{{.TypeName}}ToTerraformPreserveUnknown(ctx, {{.VarName}}, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_access_list.go
+++ b/integrations/terraform/provider/resource_teleport_access_list.go
@@ -391,7 +391,7 @@ func (r resourceTeleportAccessList) ModifyPlan(ctx context.Context, req tfsdk.Mo
 
 	accessList = convert.ToProto(accessListResource)
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyAccessListToTerraformPreserveUnknown(ctx, accessList, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_access_list.go
+++ b/integrations/terraform/provider/resource_teleport_access_list.go
@@ -391,7 +391,8 @@ func (r resourceTeleportAccessList) ModifyPlan(ctx context.Context, req tfsdk.Mo
 
 	accessList = convert.ToProto(accessListResource)
 
-	resp.Diagnostics.Append(schemav1.CopyAccessListToTerraform(ctx, accessList, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyAccessListToTerraformPreserveUnknown(ctx, accessList, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_access_list_member.go
+++ b/integrations/terraform/provider/resource_teleport_access_list_member.go
@@ -412,7 +412,8 @@ func (r resourceTeleportMember) ModifyPlan(ctx context.Context, req tfsdk.Modify
 
 	accessListMember = convert.ToMemberProto(accessListMemberResource)
 
-	resp.Diagnostics.Append(schemav1.CopyMemberToTerraform(ctx, accessListMember, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyMemberToTerraformPreserveUnknown(ctx, accessListMember, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_access_list_member.go
+++ b/integrations/terraform/provider/resource_teleport_access_list_member.go
@@ -412,7 +412,7 @@ func (r resourceTeleportMember) ModifyPlan(ctx context.Context, req tfsdk.Modify
 
 	accessListMember = convert.ToMemberProto(accessListMemberResource)
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyMemberToTerraformPreserveUnknown(ctx, accessListMember, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_access_monitoring_rule.go
+++ b/integrations/terraform/provider/resource_teleport_access_monitoring_rule.go
@@ -370,7 +370,7 @@ func (r resourceTeleportAccessMonitoringRule) ModifyPlan(ctx context.Context, re
 
 	accessMonitoringRule = accessMonitoringRuleResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyAccessMonitoringRuleToTerraformPreserveUnknown(ctx, accessMonitoringRule, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_access_monitoring_rule.go
+++ b/integrations/terraform/provider/resource_teleport_access_monitoring_rule.go
@@ -370,7 +370,8 @@ func (r resourceTeleportAccessMonitoringRule) ModifyPlan(ctx context.Context, re
 
 	accessMonitoringRule = accessMonitoringRuleResource
 
-	resp.Diagnostics.Append(schemav1.CopyAccessMonitoringRuleToTerraform(ctx, accessMonitoringRule, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyAccessMonitoringRuleToTerraformPreserveUnknown(ctx, accessMonitoringRule, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_app.go
+++ b/integrations/terraform/provider/resource_teleport_app.go
@@ -390,7 +390,7 @@ func (r resourceTeleportApp) ModifyPlan(ctx context.Context, req tfsdk.ModifyRes
 
 	app = appResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(tfschema.CopyAppV3ToTerraformPreserveUnknown(ctx, app, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_app.go
+++ b/integrations/terraform/provider/resource_teleport_app.go
@@ -390,7 +390,8 @@ func (r resourceTeleportApp) ModifyPlan(ctx context.Context, req tfsdk.ModifyRes
 
 	app = appResource
 
-	resp.Diagnostics.Append(tfschema.CopyAppV3ToTerraform(ctx, app, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(tfschema.CopyAppV3ToTerraformPreserveUnknown(ctx, app, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_app_auth_config.go
+++ b/integrations/terraform/provider/resource_teleport_app_auth_config.go
@@ -370,7 +370,7 @@ func (r resourceTeleportAppAuthConfig) ModifyPlan(ctx context.Context, req tfsdk
 
 	appauthconfig = appauthconfigResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyAppAuthConfigToTerraformPreserveUnknown(ctx, appauthconfig, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_app_auth_config.go
+++ b/integrations/terraform/provider/resource_teleport_app_auth_config.go
@@ -370,7 +370,8 @@ func (r resourceTeleportAppAuthConfig) ModifyPlan(ctx context.Context, req tfsdk
 
 	appauthconfig = appauthconfigResource
 
-	resp.Diagnostics.Append(schemav1.CopyAppAuthConfigToTerraform(ctx, appauthconfig, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyAppAuthConfigToTerraformPreserveUnknown(ctx, appauthconfig, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_auth_preference.go
+++ b/integrations/terraform/provider/resource_teleport_auth_preference.go
@@ -377,7 +377,8 @@ func (r resourceTeleportAuthPreference) ModifyPlan(ctx context.Context, req tfsd
 
 	authPreference = authPreferenceResource
 
-	resp.Diagnostics.Append(tfschema.CopyAuthPreferenceV2ToTerraform(ctx, authPreference, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(tfschema.CopyAuthPreferenceV2ToTerraformPreserveUnknown(ctx, authPreference, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_auth_preference.go
+++ b/integrations/terraform/provider/resource_teleport_auth_preference.go
@@ -377,7 +377,7 @@ func (r resourceTeleportAuthPreference) ModifyPlan(ctx context.Context, req tfsd
 
 	authPreference = authPreferenceResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(tfschema.CopyAuthPreferenceV2ToTerraformPreserveUnknown(ctx, authPreference, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_autoupdate_config.go
+++ b/integrations/terraform/provider/resource_teleport_autoupdate_config.go
@@ -372,7 +372,8 @@ func (r resourceTeleportAutoUpdateConfig) ModifyPlan(ctx context.Context, req tf
 
 	autoUpdateConfig = autoUpdateConfigResource
 
-	resp.Diagnostics.Append(schemav1.CopyAutoUpdateConfigToTerraform(ctx, autoUpdateConfig, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyAutoUpdateConfigToTerraformPreserveUnknown(ctx, autoUpdateConfig, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_autoupdate_config.go
+++ b/integrations/terraform/provider/resource_teleport_autoupdate_config.go
@@ -372,7 +372,7 @@ func (r resourceTeleportAutoUpdateConfig) ModifyPlan(ctx context.Context, req tf
 
 	autoUpdateConfig = autoUpdateConfigResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyAutoUpdateConfigToTerraformPreserveUnknown(ctx, autoUpdateConfig, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_autoupdate_version.go
+++ b/integrations/terraform/provider/resource_teleport_autoupdate_version.go
@@ -372,7 +372,7 @@ func (r resourceTeleportAutoUpdateVersion) ModifyPlan(ctx context.Context, req t
 
 	autoUpdateVersion = autoUpdateVersionResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyAutoUpdateVersionToTerraformPreserveUnknown(ctx, autoUpdateVersion, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_autoupdate_version.go
+++ b/integrations/terraform/provider/resource_teleport_autoupdate_version.go
@@ -372,7 +372,8 @@ func (r resourceTeleportAutoUpdateVersion) ModifyPlan(ctx context.Context, req t
 
 	autoUpdateVersion = autoUpdateVersionResource
 
-	resp.Diagnostics.Append(schemav1.CopyAutoUpdateVersionToTerraform(ctx, autoUpdateVersion, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyAutoUpdateVersionToTerraformPreserveUnknown(ctx, autoUpdateVersion, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_classifier.go
+++ b/integrations/terraform/provider/resource_teleport_classifier.go
@@ -370,7 +370,7 @@ func (r resourceTeleportClassifier) ModifyPlan(ctx context.Context, req tfsdk.Mo
 
 	classifier = classifierResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyClassifierToTerraformPreserveUnknown(ctx, classifier, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_classifier.go
+++ b/integrations/terraform/provider/resource_teleport_classifier.go
@@ -370,7 +370,8 @@ func (r resourceTeleportClassifier) ModifyPlan(ctx context.Context, req tfsdk.Mo
 
 	classifier = classifierResource
 
-	resp.Diagnostics.Append(schemav1.CopyClassifierToTerraform(ctx, classifier, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyClassifierToTerraformPreserveUnknown(ctx, classifier, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_client_ip_restriction.go
+++ b/integrations/terraform/provider/resource_teleport_client_ip_restriction.go
@@ -372,7 +372,8 @@ func (r resourceTeleportClientIPRestriction) ModifyPlan(ctx context.Context, req
 
 	clientIPRestriction = clientIPRestrictionResource
 
-	resp.Diagnostics.Append(schemav1.CopyClientIPRestrictionToTerraform(ctx, clientIPRestriction, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyClientIPRestrictionToTerraformPreserveUnknown(ctx, clientIPRestriction, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_client_ip_restriction.go
+++ b/integrations/terraform/provider/resource_teleport_client_ip_restriction.go
@@ -342,3 +342,47 @@ func (r resourceTeleportClientIPRestriction) ImportState(ctx context.Context, re
 		return
 	}
 }
+
+// ModifyPlan modifies the planned value, normalizing null values.
+func (r resourceTeleportClientIPRestriction) ModifyPlan(ctx context.Context, req tfsdk.ModifyResourcePlanRequest, resp *tfsdk.ModifyResourcePlanResponse) {
+	// If the entire plan is null, the resource is planned for destruction.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// If the state is null, the resource is being created. No need to modify plan.
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	var config types.Object
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	clientIPRestriction := &clientiprestrictionv1.ClientIPRestriction{}
+	resp.Diagnostics.Append(schemav1.CopyClientIPRestrictionFromTerraform(ctx, config, clientIPRestriction)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	clientIPRestrictionResource := clientIPRestriction
+	clientIPRestrictionResource.Kind = apitypes.KindClientIPRestriction
+
+	clientIPRestriction = clientIPRestrictionResource
+
+	resp.Diagnostics.Append(schemav1.CopyClientIPRestrictionToTerraform(ctx, clientIPRestriction, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var plan types.Object
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.Attrs["spec"] = config.Attrs["spec"]
+
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+}

--- a/integrations/terraform/provider/resource_teleport_client_ip_restriction.go
+++ b/integrations/terraform/provider/resource_teleport_client_ip_restriction.go
@@ -372,7 +372,7 @@ func (r resourceTeleportClientIPRestriction) ModifyPlan(ctx context.Context, req
 
 	clientIPRestriction = clientIPRestrictionResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyClientIPRestrictionToTerraformPreserveUnknown(ctx, clientIPRestriction, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_cluster_maintenance_config.go
+++ b/integrations/terraform/provider/resource_teleport_cluster_maintenance_config.go
@@ -384,7 +384,8 @@ func (r resourceTeleportClusterMaintenanceConfig) ModifyPlan(ctx context.Context
 
 	clusterMaintenanceConfig = clusterMaintenanceConfigResource
 
-	resp.Diagnostics.Append(tfschema.CopyClusterMaintenanceConfigV1ToTerraform(ctx, clusterMaintenanceConfig, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(tfschema.CopyClusterMaintenanceConfigV1ToTerraformPreserveUnknown(ctx, clusterMaintenanceConfig, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_cluster_maintenance_config.go
+++ b/integrations/terraform/provider/resource_teleport_cluster_maintenance_config.go
@@ -384,7 +384,7 @@ func (r resourceTeleportClusterMaintenanceConfig) ModifyPlan(ctx context.Context
 
 	clusterMaintenanceConfig = clusterMaintenanceConfigResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(tfschema.CopyClusterMaintenanceConfigV1ToTerraformPreserveUnknown(ctx, clusterMaintenanceConfig, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_cluster_networking_config.go
+++ b/integrations/terraform/provider/resource_teleport_cluster_networking_config.go
@@ -377,7 +377,8 @@ func (r resourceTeleportClusterNetworkingConfig) ModifyPlan(ctx context.Context,
 
 	clusterNetworkingConfig = clusterNetworkingConfigResource
 
-	resp.Diagnostics.Append(tfschema.CopyClusterNetworkingConfigV2ToTerraform(ctx, clusterNetworkingConfig, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(tfschema.CopyClusterNetworkingConfigV2ToTerraformPreserveUnknown(ctx, clusterNetworkingConfig, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_cluster_networking_config.go
+++ b/integrations/terraform/provider/resource_teleport_cluster_networking_config.go
@@ -377,7 +377,7 @@ func (r resourceTeleportClusterNetworkingConfig) ModifyPlan(ctx context.Context,
 
 	clusterNetworkingConfig = clusterNetworkingConfigResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(tfschema.CopyClusterNetworkingConfigV2ToTerraformPreserveUnknown(ctx, clusterNetworkingConfig, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_database.go
+++ b/integrations/terraform/provider/resource_teleport_database.go
@@ -390,7 +390,8 @@ func (r resourceTeleportDatabase) ModifyPlan(ctx context.Context, req tfsdk.Modi
 
 	database = databaseResource
 
-	resp.Diagnostics.Append(tfschema.CopyDatabaseV3ToTerraform(ctx, database, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(tfschema.CopyDatabaseV3ToTerraformPreserveUnknown(ctx, database, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_database.go
+++ b/integrations/terraform/provider/resource_teleport_database.go
@@ -390,7 +390,7 @@ func (r resourceTeleportDatabase) ModifyPlan(ctx context.Context, req tfsdk.Modi
 
 	database = databaseResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(tfschema.CopyDatabaseV3ToTerraformPreserveUnknown(ctx, database, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_db_object_import_rule.go
+++ b/integrations/terraform/provider/resource_teleport_db_object_import_rule.go
@@ -403,7 +403,7 @@ func (r resourceTeleportDatabaseObjectImportRule) ModifyPlan(ctx context.Context
 
 	importRule = importRuleResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyDatabaseObjectImportRuleToTerraformPreserveUnknown(ctx, importRule, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_db_object_import_rule.go
+++ b/integrations/terraform/provider/resource_teleport_db_object_import_rule.go
@@ -403,7 +403,8 @@ func (r resourceTeleportDatabaseObjectImportRule) ModifyPlan(ctx context.Context
 
 	importRule = importRuleResource
 
-	resp.Diagnostics.Append(schemav1.CopyDatabaseObjectImportRuleToTerraform(ctx, importRule, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyDatabaseObjectImportRuleToTerraformPreserveUnknown(ctx, importRule, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_device_trust.go
+++ b/integrations/terraform/provider/resource_teleport_device_trust.go
@@ -370,7 +370,7 @@ func (r resourceTeleportDeviceV1) ModifyPlan(ctx context.Context, req tfsdk.Modi
 
 	trustedDevice = trustedDeviceResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyDeviceV1ToTerraformPreserveUnknown(ctx, trustedDevice, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_device_trust.go
+++ b/integrations/terraform/provider/resource_teleport_device_trust.go
@@ -370,7 +370,8 @@ func (r resourceTeleportDeviceV1) ModifyPlan(ctx context.Context, req tfsdk.Modi
 
 	trustedDevice = trustedDeviceResource
 
-	resp.Diagnostics.Append(schemav1.CopyDeviceV1ToTerraform(ctx, trustedDevice, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyDeviceV1ToTerraformPreserveUnknown(ctx, trustedDevice, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_discovery_config.go
+++ b/integrations/terraform/provider/resource_teleport_discovery_config.go
@@ -381,7 +381,7 @@ func (r resourceTeleportDiscoveryConfig) ModifyPlan(ctx context.Context, req tfs
 
 	discoveryConfig = convert.ToProto(discoveryConfigResource)
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyDiscoveryConfigToTerraformPreserveUnknown(ctx, discoveryConfig, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_discovery_config.go
+++ b/integrations/terraform/provider/resource_teleport_discovery_config.go
@@ -381,7 +381,8 @@ func (r resourceTeleportDiscoveryConfig) ModifyPlan(ctx context.Context, req tfs
 
 	discoveryConfig = convert.ToProto(discoveryConfigResource)
 
-	resp.Diagnostics.Append(schemav1.CopyDiscoveryConfigToTerraform(ctx, discoveryConfig, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyDiscoveryConfigToTerraformPreserveUnknown(ctx, discoveryConfig, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_dynamic_windows_desktop.go
+++ b/integrations/terraform/provider/resource_teleport_dynamic_windows_desktop.go
@@ -390,7 +390,8 @@ func (r resourceTeleportDynamicWindowsDesktop) ModifyPlan(ctx context.Context, r
 
 	desktop = desktopResource
 
-	resp.Diagnostics.Append(tfschema.CopyDynamicWindowsDesktopV1ToTerraform(ctx, desktop, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(tfschema.CopyDynamicWindowsDesktopV1ToTerraformPreserveUnknown(ctx, desktop, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_dynamic_windows_desktop.go
+++ b/integrations/terraform/provider/resource_teleport_dynamic_windows_desktop.go
@@ -390,7 +390,7 @@ func (r resourceTeleportDynamicWindowsDesktop) ModifyPlan(ctx context.Context, r
 
 	desktop = desktopResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(tfschema.CopyDynamicWindowsDesktopV1ToTerraformPreserveUnknown(ctx, desktop, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_github_connector.go
+++ b/integrations/terraform/provider/resource_teleport_github_connector.go
@@ -390,7 +390,8 @@ func (r resourceTeleportGithubConnector) ModifyPlan(ctx context.Context, req tfs
 
 	githubConnector = githubConnectorResource
 
-	resp.Diagnostics.Append(tfschema.CopyGithubConnectorV3ToTerraform(ctx, githubConnector, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(tfschema.CopyGithubConnectorV3ToTerraformPreserveUnknown(ctx, githubConnector, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_github_connector.go
+++ b/integrations/terraform/provider/resource_teleport_github_connector.go
@@ -390,7 +390,7 @@ func (r resourceTeleportGithubConnector) ModifyPlan(ctx context.Context, req tfs
 
 	githubConnector = githubConnectorResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(tfschema.CopyGithubConnectorV3ToTerraformPreserveUnknown(ctx, githubConnector, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_health_check_config.go
+++ b/integrations/terraform/provider/resource_teleport_health_check_config.go
@@ -370,7 +370,8 @@ func (r resourceTeleportHealthCheckConfig) ModifyPlan(ctx context.Context, req t
 
 	healthCheckConfig = healthCheckConfigResource
 
-	resp.Diagnostics.Append(schemav1.CopyHealthCheckConfigToTerraform(ctx, healthCheckConfig, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyHealthCheckConfigToTerraformPreserveUnknown(ctx, healthCheckConfig, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_health_check_config.go
+++ b/integrations/terraform/provider/resource_teleport_health_check_config.go
@@ -370,7 +370,7 @@ func (r resourceTeleportHealthCheckConfig) ModifyPlan(ctx context.Context, req t
 
 	healthCheckConfig = healthCheckConfigResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyHealthCheckConfigToTerraformPreserveUnknown(ctx, healthCheckConfig, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_inference_model.go
+++ b/integrations/terraform/provider/resource_teleport_inference_model.go
@@ -370,7 +370,7 @@ func (r resourceTeleportInferenceModel) ModifyPlan(ctx context.Context, req tfsd
 
 	inferenceModel = inferenceModelResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyInferenceModelToTerraformPreserveUnknown(ctx, inferenceModel, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_inference_model.go
+++ b/integrations/terraform/provider/resource_teleport_inference_model.go
@@ -370,7 +370,8 @@ func (r resourceTeleportInferenceModel) ModifyPlan(ctx context.Context, req tfsd
 
 	inferenceModel = inferenceModelResource
 
-	resp.Diagnostics.Append(schemav1.CopyInferenceModelToTerraform(ctx, inferenceModel, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyInferenceModelToTerraformPreserveUnknown(ctx, inferenceModel, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_inference_policy.go
+++ b/integrations/terraform/provider/resource_teleport_inference_policy.go
@@ -370,7 +370,8 @@ func (r resourceTeleportInferencePolicy) ModifyPlan(ctx context.Context, req tfs
 
 	inferencePolicy = inferencePolicyResource
 
-	resp.Diagnostics.Append(schemav1.CopyInferencePolicyToTerraform(ctx, inferencePolicy, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyInferencePolicyToTerraformPreserveUnknown(ctx, inferencePolicy, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_inference_policy.go
+++ b/integrations/terraform/provider/resource_teleport_inference_policy.go
@@ -370,7 +370,7 @@ func (r resourceTeleportInferencePolicy) ModifyPlan(ctx context.Context, req tfs
 
 	inferencePolicy = inferencePolicyResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyInferencePolicyToTerraformPreserveUnknown(ctx, inferencePolicy, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_inference_secret.go
+++ b/integrations/terraform/provider/resource_teleport_inference_secret.go
@@ -359,7 +359,8 @@ func (r resourceTeleportInferenceSecret) ModifyPlan(ctx context.Context, req tfs
 
 	inferenceSecret = inferenceSecretResource
 
-	resp.Diagnostics.Append(schemav1.CopyInferenceSecretToTerraform(ctx, inferenceSecret, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyInferenceSecretToTerraformPreserveUnknown(ctx, inferenceSecret, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_inference_secret.go
+++ b/integrations/terraform/provider/resource_teleport_inference_secret.go
@@ -359,7 +359,7 @@ func (r resourceTeleportInferenceSecret) ModifyPlan(ctx context.Context, req tfs
 
 	inferenceSecret = inferenceSecretResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyInferenceSecretToTerraformPreserveUnknown(ctx, inferenceSecret, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_installer.go
+++ b/integrations/terraform/provider/resource_teleport_installer.go
@@ -390,7 +390,8 @@ func (r resourceTeleportInstaller) ModifyPlan(ctx context.Context, req tfsdk.Mod
 
 	installer = installerResource
 
-	resp.Diagnostics.Append(tfschema.CopyInstallerV1ToTerraform(ctx, installer, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(tfschema.CopyInstallerV1ToTerraformPreserveUnknown(ctx, installer, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_installer.go
+++ b/integrations/terraform/provider/resource_teleport_installer.go
@@ -390,7 +390,7 @@ func (r resourceTeleportInstaller) ModifyPlan(ctx context.Context, req tfsdk.Mod
 
 	installer = installerResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(tfschema.CopyInstallerV1ToTerraformPreserveUnknown(ctx, installer, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_integration.go
+++ b/integrations/terraform/provider/resource_teleport_integration.go
@@ -390,7 +390,8 @@ func (r resourceTeleportIntegration) ModifyPlan(ctx context.Context, req tfsdk.M
 
 	integration = integrationResource
 
-	resp.Diagnostics.Append(tfschema.CopyIntegrationV1ToTerraform(ctx, integration, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(tfschema.CopyIntegrationV1ToTerraformPreserveUnknown(ctx, integration, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_integration.go
+++ b/integrations/terraform/provider/resource_teleport_integration.go
@@ -390,7 +390,7 @@ func (r resourceTeleportIntegration) ModifyPlan(ctx context.Context, req tfsdk.M
 
 	integration = integrationResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(tfschema.CopyIntegrationV1ToTerraformPreserveUnknown(ctx, integration, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_kube_cluster.go
+++ b/integrations/terraform/provider/resource_teleport_kube_cluster.go
@@ -390,7 +390,8 @@ func (r resourceTeleportKubeCluster) ModifyPlan(ctx context.Context, req tfsdk.M
 
 	kubeCluster = kubeClusterResource
 
-	resp.Diagnostics.Append(tfschema.CopyKubernetesClusterV3ToTerraform(ctx, kubeCluster, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(tfschema.CopyKubernetesClusterV3ToTerraformPreserveUnknown(ctx, kubeCluster, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_kube_cluster.go
+++ b/integrations/terraform/provider/resource_teleport_kube_cluster.go
@@ -390,7 +390,7 @@ func (r resourceTeleportKubeCluster) ModifyPlan(ctx context.Context, req tfsdk.M
 
 	kubeCluster = kubeClusterResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(tfschema.CopyKubernetesClusterV3ToTerraformPreserveUnknown(ctx, kubeCluster, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_lock.go
+++ b/integrations/terraform/provider/resource_teleport_lock.go
@@ -390,7 +390,8 @@ func (r resourceTeleportLock) ModifyPlan(ctx context.Context, req tfsdk.ModifyRe
 
 	lock = lockResource
 
-	resp.Diagnostics.Append(tfschema.CopyLockV2ToTerraform(ctx, lock, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(tfschema.CopyLockV2ToTerraformPreserveUnknown(ctx, lock, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_lock.go
+++ b/integrations/terraform/provider/resource_teleport_lock.go
@@ -390,7 +390,7 @@ func (r resourceTeleportLock) ModifyPlan(ctx context.Context, req tfsdk.ModifyRe
 
 	lock = lockResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(tfschema.CopyLockV2ToTerraformPreserveUnknown(ctx, lock, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_oidc_connector.go
+++ b/integrations/terraform/provider/resource_teleport_oidc_connector.go
@@ -390,7 +390,7 @@ func (r resourceTeleportOIDCConnector) ModifyPlan(ctx context.Context, req tfsdk
 
 	oidcConnector = oidcConnectorResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(tfschema.CopyOIDCConnectorV3ToTerraformPreserveUnknown(ctx, oidcConnector, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_oidc_connector.go
+++ b/integrations/terraform/provider/resource_teleport_oidc_connector.go
@@ -390,7 +390,8 @@ func (r resourceTeleportOIDCConnector) ModifyPlan(ctx context.Context, req tfsdk
 
 	oidcConnector = oidcConnectorResource
 
-	resp.Diagnostics.Append(tfschema.CopyOIDCConnectorV3ToTerraform(ctx, oidcConnector, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(tfschema.CopyOIDCConnectorV3ToTerraformPreserveUnknown(ctx, oidcConnector, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_okta_import_rule.go
+++ b/integrations/terraform/provider/resource_teleport_okta_import_rule.go
@@ -390,7 +390,7 @@ func (r resourceTeleportOktaImportRule) ModifyPlan(ctx context.Context, req tfsd
 
 	oktaImportRule = oktaImportRuleResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(tfschema.CopyOktaImportRuleV1ToTerraformPreserveUnknown(ctx, oktaImportRule, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_okta_import_rule.go
+++ b/integrations/terraform/provider/resource_teleport_okta_import_rule.go
@@ -390,7 +390,8 @@ func (r resourceTeleportOktaImportRule) ModifyPlan(ctx context.Context, req tfsd
 
 	oktaImportRule = oktaImportRuleResource
 
-	resp.Diagnostics.Append(tfschema.CopyOktaImportRuleV1ToTerraform(ctx, oktaImportRule, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(tfschema.CopyOktaImportRuleV1ToTerraformPreserveUnknown(ctx, oktaImportRule, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_provision_token.go
+++ b/integrations/terraform/provider/resource_teleport_provision_token.go
@@ -401,7 +401,7 @@ func (r resourceTeleportProvisionToken) ModifyPlan(ctx context.Context, req tfsd
 
 	provisionToken = provisionTokenResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(token.CopyProvisionTokenV2ToTerraformPreserveUnknown(ctx, provisionToken, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_provision_token.go
+++ b/integrations/terraform/provider/resource_teleport_provision_token.go
@@ -401,7 +401,8 @@ func (r resourceTeleportProvisionToken) ModifyPlan(ctx context.Context, req tfsd
 
 	provisionToken = provisionTokenResource
 
-	resp.Diagnostics.Append(token.CopyProvisionTokenV2ToTerraform(ctx, provisionToken, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(token.CopyProvisionTokenV2ToTerraformPreserveUnknown(ctx, provisionToken, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_retrieval_model.go
+++ b/integrations/terraform/provider/resource_teleport_retrieval_model.go
@@ -372,7 +372,8 @@ func (r resourceTeleportRetrievalModel) ModifyPlan(ctx context.Context, req tfsd
 
 	retrievalModel = retrievalModelResource
 
-	resp.Diagnostics.Append(schemav1.CopyRetrievalModelToTerraform(ctx, retrievalModel, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyRetrievalModelToTerraformPreserveUnknown(ctx, retrievalModel, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_retrieval_model.go
+++ b/integrations/terraform/provider/resource_teleport_retrieval_model.go
@@ -372,7 +372,7 @@ func (r resourceTeleportRetrievalModel) ModifyPlan(ctx context.Context, req tfsd
 
 	retrievalModel = retrievalModelResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyRetrievalModelToTerraformPreserveUnknown(ctx, retrievalModel, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_role.go
+++ b/integrations/terraform/provider/resource_teleport_role.go
@@ -390,7 +390,7 @@ func (r resourceTeleportRole) ModifyPlan(ctx context.Context, req tfsdk.ModifyRe
 
 	role = roleResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(tfschema.CopyRoleV6ToTerraformPreserveUnknown(ctx, role, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_role.go
+++ b/integrations/terraform/provider/resource_teleport_role.go
@@ -390,7 +390,8 @@ func (r resourceTeleportRole) ModifyPlan(ctx context.Context, req tfsdk.ModifyRe
 
 	role = roleResource
 
-	resp.Diagnostics.Append(tfschema.CopyRoleV6ToTerraform(ctx, role, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(tfschema.CopyRoleV6ToTerraformPreserveUnknown(ctx, role, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_saml_connector.go
+++ b/integrations/terraform/provider/resource_teleport_saml_connector.go
@@ -390,7 +390,8 @@ func (r resourceTeleportSAMLConnector) ModifyPlan(ctx context.Context, req tfsdk
 
 	samlConnector = samlConnectorResource
 
-	resp.Diagnostics.Append(tfschema.CopySAMLConnectorV2ToTerraform(ctx, samlConnector, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(tfschema.CopySAMLConnectorV2ToTerraformPreserveUnknown(ctx, samlConnector, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_saml_connector.go
+++ b/integrations/terraform/provider/resource_teleport_saml_connector.go
@@ -390,7 +390,7 @@ func (r resourceTeleportSAMLConnector) ModifyPlan(ctx context.Context, req tfsdk
 
 	samlConnector = samlConnectorResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(tfschema.CopySAMLConnectorV2ToTerraformPreserveUnknown(ctx, samlConnector, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_scoped_role.go
+++ b/integrations/terraform/provider/resource_teleport_scoped_role.go
@@ -403,7 +403,7 @@ func (r resourceTeleportScopedRole) ModifyPlan(ctx context.Context, req tfsdk.Mo
 
 	scopedRole = scopedRoleResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyScopedRoleToTerraformPreserveUnknown(ctx, scopedRole, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_scoped_role.go
+++ b/integrations/terraform/provider/resource_teleport_scoped_role.go
@@ -403,7 +403,8 @@ func (r resourceTeleportScopedRole) ModifyPlan(ctx context.Context, req tfsdk.Mo
 
 	scopedRole = scopedRoleResource
 
-	resp.Diagnostics.Append(schemav1.CopyScopedRoleToTerraform(ctx, scopedRole, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyScopedRoleToTerraformPreserveUnknown(ctx, scopedRole, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_scoped_role_assignment.go
+++ b/integrations/terraform/provider/resource_teleport_scoped_role_assignment.go
@@ -441,7 +441,8 @@ func (r resourceTeleportScopedRoleAssignment) ModifyPlan(ctx context.Context, re
 
 	scopedRoleAssignment = scopedRoleAssignmentResource
 
-	resp.Diagnostics.Append(assignmentschemav1.CopyScopedRoleAssignmentToTerraform(ctx, scopedRoleAssignment, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(assignmentschemav1.CopyScopedRoleAssignmentToTerraformPreserveUnknown(ctx, scopedRoleAssignment, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_scoped_role_assignment.go
+++ b/integrations/terraform/provider/resource_teleport_scoped_role_assignment.go
@@ -441,7 +441,7 @@ func (r resourceTeleportScopedRoleAssignment) ModifyPlan(ctx context.Context, re
 
 	scopedRoleAssignment = scopedRoleAssignmentResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(assignmentschemav1.CopyScopedRoleAssignmentToTerraformPreserveUnknown(ctx, scopedRoleAssignment, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_scoped_token.go
+++ b/integrations/terraform/provider/resource_teleport_scoped_token.go
@@ -370,7 +370,7 @@ func (r resourceTeleportScopedToken) ModifyPlan(ctx context.Context, req tfsdk.M
 
 	scopedToken = scopedTokenResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyScopedTokenToTerraformPreserveUnknown(ctx, scopedToken, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_scoped_token.go
+++ b/integrations/terraform/provider/resource_teleport_scoped_token.go
@@ -370,7 +370,8 @@ func (r resourceTeleportScopedToken) ModifyPlan(ctx context.Context, req tfsdk.M
 
 	scopedToken = scopedTokenResource
 
-	resp.Diagnostics.Append(schemav1.CopyScopedTokenToTerraform(ctx, scopedToken, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyScopedTokenToTerraformPreserveUnknown(ctx, scopedToken, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_server.go
+++ b/integrations/terraform/provider/resource_teleport_server.go
@@ -394,7 +394,8 @@ func (r resourceTeleportServer) ModifyPlan(ctx context.Context, req tfsdk.Modify
 
 	server = serverResource
 
-	resp.Diagnostics.Append(tfschema.CopyServerV2ToTerraform(ctx, server, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(tfschema.CopyServerV2ToTerraformPreserveUnknown(ctx, server, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_server.go
+++ b/integrations/terraform/provider/resource_teleport_server.go
@@ -394,7 +394,7 @@ func (r resourceTeleportServer) ModifyPlan(ctx context.Context, req tfsdk.Modify
 
 	server = serverResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(tfschema.CopyServerV2ToTerraformPreserveUnknown(ctx, server, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_session_recording_config.go
+++ b/integrations/terraform/provider/resource_teleport_session_recording_config.go
@@ -377,7 +377,8 @@ func (r resourceTeleportSessionRecordingConfig) ModifyPlan(ctx context.Context, 
 
 	sessionRecordingConfig = sessionRecordingConfigResource
 
-	resp.Diagnostics.Append(tfschema.CopySessionRecordingConfigV2ToTerraform(ctx, sessionRecordingConfig, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(tfschema.CopySessionRecordingConfigV2ToTerraformPreserveUnknown(ctx, sessionRecordingConfig, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_session_recording_config.go
+++ b/integrations/terraform/provider/resource_teleport_session_recording_config.go
@@ -377,7 +377,7 @@ func (r resourceTeleportSessionRecordingConfig) ModifyPlan(ctx context.Context, 
 
 	sessionRecordingConfig = sessionRecordingConfigResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(tfschema.CopySessionRecordingConfigV2ToTerraformPreserveUnknown(ctx, sessionRecordingConfig, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_static_host_user.go
+++ b/integrations/terraform/provider/resource_teleport_static_host_user.go
@@ -370,7 +370,8 @@ func (r resourceTeleportStaticHostUser) ModifyPlan(ctx context.Context, req tfsd
 
 	staticHostUser = staticHostUserResource
 
-	resp.Diagnostics.Append(schemav1.CopyStaticHostUserToTerraform(ctx, staticHostUser, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyStaticHostUserToTerraformPreserveUnknown(ctx, staticHostUser, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_static_host_user.go
+++ b/integrations/terraform/provider/resource_teleport_static_host_user.go
@@ -370,7 +370,7 @@ func (r resourceTeleportStaticHostUser) ModifyPlan(ctx context.Context, req tfsd
 
 	staticHostUser = staticHostUserResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyStaticHostUserToTerraformPreserveUnknown(ctx, staticHostUser, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_trusted_cluster.go
+++ b/integrations/terraform/provider/resource_teleport_trusted_cluster.go
@@ -390,7 +390,8 @@ func (r resourceTeleportTrustedCluster) ModifyPlan(ctx context.Context, req tfsd
 
 	trustedCluster = trustedClusterResource
 
-	resp.Diagnostics.Append(tfschema.CopyTrustedClusterV2ToTerraform(ctx, trustedCluster, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(tfschema.CopyTrustedClusterV2ToTerraformPreserveUnknown(ctx, trustedCluster, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_trusted_cluster.go
+++ b/integrations/terraform/provider/resource_teleport_trusted_cluster.go
@@ -390,7 +390,7 @@ func (r resourceTeleportTrustedCluster) ModifyPlan(ctx context.Context, req tfsd
 
 	trustedCluster = trustedClusterResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(tfschema.CopyTrustedClusterV2ToTerraformPreserveUnknown(ctx, trustedCluster, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_ui_config.go
+++ b/integrations/terraform/provider/resource_teleport_ui_config.go
@@ -381,7 +381,8 @@ func (r resourceTeleportUIConfig) ModifyPlan(ctx context.Context, req tfsdk.Modi
 
 	uiConfig = uiConfigResource
 
-	resp.Diagnostics.Append(tfschema.CopyUIConfigV1ToTerraform(ctx, uiConfig, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(tfschema.CopyUIConfigV1ToTerraformPreserveUnknown(ctx, uiConfig, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_ui_config.go
+++ b/integrations/terraform/provider/resource_teleport_ui_config.go
@@ -381,7 +381,7 @@ func (r resourceTeleportUIConfig) ModifyPlan(ctx context.Context, req tfsdk.Modi
 
 	uiConfig = uiConfigResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(tfschema.CopyUIConfigV1ToTerraformPreserveUnknown(ctx, uiConfig, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_user.go
+++ b/integrations/terraform/provider/resource_teleport_user.go
@@ -390,7 +390,8 @@ func (r resourceTeleportUser) ModifyPlan(ctx context.Context, req tfsdk.ModifyRe
 
 	user = userResource
 
-	resp.Diagnostics.Append(tfschema.CopyUserV2ToTerraform(ctx, user, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(tfschema.CopyUserV2ToTerraformPreserveUnknown(ctx, user, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_user.go
+++ b/integrations/terraform/provider/resource_teleport_user.go
@@ -390,7 +390,7 @@ func (r resourceTeleportUser) ModifyPlan(ctx context.Context, req tfsdk.ModifyRe
 
 	user = userResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(tfschema.CopyUserV2ToTerraformPreserveUnknown(ctx, user, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_vnet_config.go
+++ b/integrations/terraform/provider/resource_teleport_vnet_config.go
@@ -372,7 +372,7 @@ func (r resourceTeleportVnetConfig) ModifyPlan(ctx context.Context, req tfsdk.Mo
 
 	vnetConfig = vnetConfigResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyVnetConfigToTerraformPreserveUnknown(ctx, vnetConfig, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_vnet_config.go
+++ b/integrations/terraform/provider/resource_teleport_vnet_config.go
@@ -372,7 +372,8 @@ func (r resourceTeleportVnetConfig) ModifyPlan(ctx context.Context, req tfsdk.Mo
 
 	vnetConfig = vnetConfigResource
 
-	resp.Diagnostics.Append(schemav1.CopyVnetConfigToTerraform(ctx, vnetConfig, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyVnetConfigToTerraformPreserveUnknown(ctx, vnetConfig, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_workload_cluster.go
+++ b/integrations/terraform/provider/resource_teleport_workload_cluster.go
@@ -432,7 +432,7 @@ func (r resourceTeleportWorkloadCluster) ModifyPlan(ctx context.Context, req tfs
 
 	workloadcluster = workloadclusterResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyWorkloadClusterToTerraformPreserveUnknown(ctx, workloadcluster, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_workload_cluster.go
+++ b/integrations/terraform/provider/resource_teleport_workload_cluster.go
@@ -432,7 +432,8 @@ func (r resourceTeleportWorkloadCluster) ModifyPlan(ctx context.Context, req tfs
 
 	workloadcluster = workloadclusterResource
 
-	resp.Diagnostics.Append(schemav1.CopyWorkloadClusterToTerraform(ctx, workloadcluster, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyWorkloadClusterToTerraformPreserveUnknown(ctx, workloadcluster, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/provider/resource_teleport_workload_identity.go
+++ b/integrations/terraform/provider/resource_teleport_workload_identity.go
@@ -369,7 +369,7 @@ func (r resourceTeleportWorkloadIdentity) ModifyPlan(ctx context.Context, req tf
 
 	workloadIdentity = workloadIdentityResource
 
-	preserveUnknown := true
+	const preserveUnknown = true
 	resp.Diagnostics.Append(schemav1.CopyWorkloadIdentityToTerraformPreserveUnknown(ctx, workloadIdentity, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/resource_teleport_workload_identity.go
+++ b/integrations/terraform/provider/resource_teleport_workload_identity.go
@@ -369,7 +369,8 @@ func (r resourceTeleportWorkloadIdentity) ModifyPlan(ctx context.Context, req tf
 
 	workloadIdentity = workloadIdentityResource
 
-	resp.Diagnostics.Append(schemav1.CopyWorkloadIdentityToTerraform(ctx, workloadIdentity, &config)...)
+	preserveUnknown := true
+	resp.Diagnostics.Append(schemav1.CopyWorkloadIdentityToTerraformPreserveUnknown(ctx, workloadIdentity, &config, preserveUnknown)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/integrations/terraform/tfschema/clientiprestriction/v1/clientiprestriction_terraform.go
+++ b/integrations/terraform/tfschema/clientiprestriction/v1/clientiprestriction_terraform.go
@@ -60,9 +60,11 @@ func GenSchemaClientIPRestriction(ctx context.Context) (github_com_hashicorp_ter
 		"metadata": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				"description": {
-					Description: "description is object description.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+					Computed:      true,
+					Description:   "description is object description.",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"expires": GenSchemaTimestamp(ctx, github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Description: "expires is a global expiry time header can be set on any resource in the system.",
@@ -70,9 +72,11 @@ func GenSchemaClientIPRestriction(ctx context.Context) (github_com_hashicorp_ter
 					Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
 				}),
 				"labels": {
-					Description: "labels is a set of labels.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+					Computed:      true,
+					Description:   "labels is a set of labels.",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+					Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
 				"name": {
 					Computed:      true,
@@ -96,9 +100,11 @@ func GenSchemaClientIPRestriction(ctx context.Context) (github_com_hashicorp_ter
 		},
 		"spec": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"allowed_cidrs": {
-				Description: "allowed_cidrs is the list of CIDR blocks permitted to connect to the cluster. An empty list disables restrictions and allows all traffic.",
-				Optional:    true,
-				Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+				Computed:      true,
+				Description:   "allowed_cidrs is the list of CIDR blocks permitted to connect to the cluster. An empty list disables restrictions and allows all traffic.",
+				Optional:      true,
+				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+				Type:          github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 			}}),
 			Description: "User-configurable parts of the resource settings.",
 			Optional:    true,
@@ -327,6 +333,12 @@ func CopyClientIPRestrictionFromTerraform(_ context.Context, tf github_com_hashi
 
 // CopyClientIPRestrictionToTerraform copies contents of the source Terraform object into a target struct
 func CopyClientIPRestrictionToTerraform(ctx context.Context, obj *github_com_gravitational_teleport_api_gen_proto_go_teleport_clientiprestriction_v1.ClientIPRestriction, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+	return CopyClientIPRestrictionToTerraformPreserveUnknown(ctx, obj, tf, false)
+}
+
+// CopyClientIPRestrictionToTerraformPreserveUnknown copies contents of the source Terraform object into a target struct.
+// Set preserveUnknown to true to preserve unknown values.
+func CopyClientIPRestrictionToTerraformPreserveUnknown(ctx context.Context, obj *github_com_gravitational_teleport_api_gen_proto_go_teleport_clientiprestriction_v1.ClientIPRestriction, tf *github_com_hashicorp_terraform_plugin_framework_types.Object, preserveUnknown bool) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false
@@ -340,6 +352,9 @@ func CopyClientIPRestrictionToTerraform(ctx context.Context, obj *github_com_gra
 		} else {
 			v, ok := tf.Attrs["kind"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["kind"] != nil {
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"ClientIPRestriction.kind", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"ClientIPRestriction.kind", err})
@@ -348,10 +363,13 @@ func CopyClientIPRestrictionToTerraform(ctx context.Context, obj *github_com_gra
 				if !ok {
 					diags.Append(attrWriteConversionFailureDiag{"ClientIPRestriction.kind", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
-				v.Null = string(obj.Kind) == ""
 			}
+
+			v.Null = false
 			v.Value = string(obj.Kind)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["kind"] = v
 		}
 	}
@@ -362,6 +380,9 @@ func CopyClientIPRestrictionToTerraform(ctx context.Context, obj *github_com_gra
 		} else {
 			v, ok := tf.Attrs["sub_kind"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["sub_kind"] != nil {
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"ClientIPRestriction.sub_kind", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"ClientIPRestriction.sub_kind", err})
@@ -370,10 +391,13 @@ func CopyClientIPRestrictionToTerraform(ctx context.Context, obj *github_com_gra
 				if !ok {
 					diags.Append(attrWriteConversionFailureDiag{"ClientIPRestriction.sub_kind", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
-				v.Null = string(obj.SubKind) == ""
 			}
+
+			v.Null = false
 			v.Value = string(obj.SubKind)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["sub_kind"] = v
 		}
 	}
@@ -384,6 +408,9 @@ func CopyClientIPRestrictionToTerraform(ctx context.Context, obj *github_com_gra
 		} else {
 			v, ok := tf.Attrs["version"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["version"] != nil {
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"ClientIPRestriction.version", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"ClientIPRestriction.version", err})
@@ -392,10 +419,13 @@ func CopyClientIPRestrictionToTerraform(ctx context.Context, obj *github_com_gra
 				if !ok {
 					diags.Append(attrWriteConversionFailureDiag{"ClientIPRestriction.version", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
-				v.Null = string(obj.Version) == ""
 			}
+
+			v.Null = false
 			v.Value = string(obj.Version)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["version"] = v
 		}
 	}
@@ -423,6 +453,7 @@ func CopyClientIPRestrictionToTerraform(ctx context.Context, obj *github_com_gra
 				if obj.Metadata == nil {
 					v.Null = true
 				} else {
+					v.Null = false
 					obj := obj.Metadata
 					tf := &v
 					{
@@ -432,6 +463,9 @@ func CopyClientIPRestrictionToTerraform(ctx context.Context, obj *github_com_gra
 						} else {
 							v, ok := tf.Attrs["name"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
+								if tf.Attrs["name"] != nil {
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"ClientIPRestriction.metadata.name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"ClientIPRestriction.metadata.name", err})
@@ -440,10 +474,13 @@ func CopyClientIPRestrictionToTerraform(ctx context.Context, obj *github_com_gra
 								if !ok {
 									diags.Append(attrWriteConversionFailureDiag{"ClientIPRestriction.metadata.name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 								}
-								v.Null = string(obj.Name) == ""
 							}
+
+							v.Null = false
 							v.Value = string(obj.Name)
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["name"] = v
 						}
 					}
@@ -454,6 +491,9 @@ func CopyClientIPRestrictionToTerraform(ctx context.Context, obj *github_com_gra
 						} else {
 							v, ok := tf.Attrs["namespace"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
+								if tf.Attrs["namespace"] != nil {
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"ClientIPRestriction.metadata.namespace", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"ClientIPRestriction.metadata.namespace", err})
@@ -462,10 +502,13 @@ func CopyClientIPRestrictionToTerraform(ctx context.Context, obj *github_com_gra
 								if !ok {
 									diags.Append(attrWriteConversionFailureDiag{"ClientIPRestriction.metadata.namespace", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 								}
-								v.Null = string(obj.Namespace) == ""
 							}
+
+							v.Null = false
 							v.Value = string(obj.Namespace)
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["namespace"] = v
 						}
 					}
@@ -476,6 +519,9 @@ func CopyClientIPRestrictionToTerraform(ctx context.Context, obj *github_com_gra
 						} else {
 							v, ok := tf.Attrs["description"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
+								if tf.Attrs["description"] != nil {
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"ClientIPRestriction.metadata.description", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"ClientIPRestriction.metadata.description", err})
@@ -484,10 +530,13 @@ func CopyClientIPRestrictionToTerraform(ctx context.Context, obj *github_com_gra
 								if !ok {
 									diags.Append(attrWriteConversionFailureDiag{"ClientIPRestriction.metadata.description", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 								}
-								v.Null = string(obj.Description) == ""
 							}
+
+							v.Null = false
 							v.Value = string(obj.Description)
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["description"] = v
 						}
 					}
@@ -513,11 +562,14 @@ func CopyClientIPRestrictionToTerraform(ctx context.Context, obj *github_com_gra
 										c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Labels))
 									}
 								}
-								if obj.Labels != nil {
+								{
 									t := o.ElemType
 									for k, a := range obj.Labels {
-										v, ok := tf.Attrs["labels"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
+											if c.Elems[k] != nil {
+												diags.Append(attrWriteUnexpectedExistingTypeDiag{"ClientIPRestriction.metadata.labels", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
 												diags.Append(attrWriteGeneralError{"ClientIPRestriction.metadata.labels", err})
@@ -526,17 +578,20 @@ func CopyClientIPRestrictionToTerraform(ctx context.Context, obj *github_com_gra
 											if !ok {
 												diags.Append(attrWriteConversionFailureDiag{"ClientIPRestriction.metadata.labels", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 											}
-											v.Null = false
 										}
+
+										v.Null = false
 										v.Value = string(a)
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										c.Elems[k] = v
 									}
-									if len(obj.Labels) > 0 {
-										c.Null = false
-									}
 								}
-								c.Unknown = false
+								c.Null = false
+								if !preserveUnknown {
+									c.Unknown = false
+								}
 								tf.Attrs["labels"] = c
 							}
 						}
@@ -546,12 +601,14 @@ func CopyClientIPRestrictionToTerraform(ctx context.Context, obj *github_com_gra
 						if !ok {
 							diags.Append(attrWriteMissingDiag{"ClientIPRestriction.metadata.expires"})
 						} else {
-							v := CopyToTimestamp(diags, obj.Expires, t, tf.Attrs["expires"])
+							v := CopyToTimestamp(diags, obj.Expires, t, tf.Attrs["expires"], preserveUnknown)
 							tf.Attrs["expires"] = v
 						}
 					}
 				}
-				v.Unknown = false
+				if !preserveUnknown {
+					v.Unknown = false
+				}
 				tf.Attrs["metadata"] = v
 			}
 		}
@@ -580,6 +637,7 @@ func CopyClientIPRestrictionToTerraform(ctx context.Context, obj *github_com_gra
 				if obj.Spec == nil {
 					v.Null = true
 				} else {
+					v.Null = false
 					obj := obj.Spec
 					tf := &v
 					{
@@ -604,14 +662,19 @@ func CopyClientIPRestrictionToTerraform(ctx context.Context, obj *github_com_gra
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.AllowedCidrs))
 									}
 								}
-								if obj.AllowedCidrs != nil {
+								{
 									t := o.ElemType
 									if len(obj.AllowedCidrs) != len(c.Elems) {
-										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.AllowedCidrs))
+										newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.AllowedCidrs))
+										copy(newElems, c.Elems)
+										c.Elems = newElems
 									}
 									for k, a := range obj.AllowedCidrs {
-										v, ok := tf.Attrs["allowed_cidrs"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
+											if c.Elems[k] != nil {
+												diags.Append(attrWriteUnexpectedExistingTypeDiag{"ClientIPRestriction.spec.allowed_cidrs", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
 												diags.Append(attrWriteGeneralError{"ClientIPRestriction.spec.allowed_cidrs", err})
@@ -620,23 +683,28 @@ func CopyClientIPRestrictionToTerraform(ctx context.Context, obj *github_com_gra
 											if !ok {
 												diags.Append(attrWriteConversionFailureDiag{"ClientIPRestriction.spec.allowed_cidrs", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 											}
-											v.Null = string(a) == ""
 										}
+
+										v.Null = false
 										v.Value = string(a)
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										c.Elems[k] = v
 									}
-									if len(obj.AllowedCidrs) > 0 {
-										c.Null = false
-									}
 								}
-								c.Unknown = false
+								c.Null = false
+								if !preserveUnknown {
+									c.Unknown = false
+								}
 								tf.Attrs["allowed_cidrs"] = c
 							}
 						}
 					}
 				}
-				v.Unknown = false
+				if !preserveUnknown {
+					v.Unknown = false
+				}
 				tf.Attrs["spec"] = v
 			}
 		}
@@ -749,5 +817,28 @@ func (d attrWriteGeneralError) Detail() string {
 }
 
 func (d attrWriteGeneralError) Equal(o github_com_hashicorp_terraform_plugin_framework_diag.Diagnostic) bool {
+	return (d.Severity() == o.Severity()) && (d.Summary() == o.Summary()) && (d.Detail() == o.Detail())
+}
+
+// attrWriteUnexpectedExistingTypeDiag represents diagnostic message when a field is initialized with a value whose go
+// type does not match what we'd expect.
+type attrWriteUnexpectedExistingTypeDiag struct {
+	Path string
+	Type string
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Severity() github_com_hashicorp_terraform_plugin_framework_diag.Severity {
+	return github_com_hashicorp_terraform_plugin_framework_diag.SeverityError
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Summary() string {
+	return "Error writing to Terraform object"
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Detail() string {
+	return fmt.Sprintf("A value for %v is already initialized and its type is not %v", d.Path, d.Type)
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Equal(o github_com_hashicorp_terraform_plugin_framework_diag.Diagnostic) bool {
 	return (d.Severity() == o.Severity()) && (d.Summary() == o.Summary()) && (d.Detail() == o.Detail())
 }

--- a/integrations/terraform/tfschema/custom_types.go
+++ b/integrations/terraform/tfschema/custom_types.go
@@ -72,19 +72,15 @@ func CopyFromBoolOption(diags diag.Diagnostics, tf attr.Value, o **apitypes.Bool
 // CopyToBoolOption converts a Teleport [apitypes.BoolOption] into a Terraform
 // [types.Bool] value. Set `preserveUnknown` to preserve unknown values.
 func CopyToBoolOption(_ diag.Diagnostics, o *apitypes.BoolOption, _ attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
-	unknown := preserveUnknown && v != nil && v.IsUnknown()
+	if preserveUnknown && v != nil && v.IsUnknown() {
+		return types.Bool{Unknown: true}
+	}
 
 	if o == nil {
-		return types.Bool{
-			Null:    true,
-			Unknown: unknown,
-		}
+		return types.Bool{Null: true}
 	}
 
-	return types.Bool{
-		Value:   o.Value,
-		Unknown: unknown,
-	}
+	return types.Bool{Value: o.Value}
 }
 
 func CopyFromLabels(diags diag.Diagnostics, v attr.Value, o *apitypes.Labels) {
@@ -126,10 +122,14 @@ func CopyFromLabels(diags diag.Diagnostics, v attr.Value, o *apitypes.Labels) {
 func CopyToLabels(_ diag.Diagnostics, o apitypes.Labels, t attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
 	typ := t.(types.MapType) // By the convention, t comes type-asserted so there would be no failure
 
-	value, ok := v.(types.Map)
-	if !ok {
-		value = types.Map{ElemType: typ.ElemType}
+	if preserveUnknown && v != nil && v.IsUnknown() {
+		return types.Map{
+			ElemType: typ.ElemType,
+			Unknown:  true,
+		}
 	}
+
+	value, _ := v.(types.Map)
 
 	elems := make(map[string]attr.Value, len(o))
 	for k, labels := range o {
@@ -139,7 +139,6 @@ func CopyToLabels(_ diag.Diagnostics, o apitypes.Labels, t attr.Type, v attr.Val
 	return types.Map{
 		ElemType: typ.ElemType,
 		Elems:    elems,
-		Unknown:  preserveUnknown && value.IsUnknown(),
 	}
 }
 
@@ -182,20 +181,23 @@ func CopyFromTraits(diags diag.Diagnostics, v attr.Value, o *wrappers.Traits) {
 func CopyToTraits(_ diag.Diagnostics, o wrappers.Traits, t attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
 	typ := t.(types.MapType) // By the convention, t comes type-asserted so there would be no failure
 
-	value, ok := v.(types.Map)
-	if !ok {
-		value = types.Map{ElemType: typ.ElemType}
+	if preserveUnknown && v != nil && v.IsUnknown() {
+		return types.Map{
+			ElemType: typ.ElemType,
+			Unknown:  true,
+		}
 	}
 
+	value, _ := v.(types.Map)
+
 	elems := make(map[string]attr.Value, len(o))
-	for k, traits := range o {
-		elems[k] = copyToList(traits, value.Elems[k], preserveUnknown)
+	for k, labels := range o {
+		elems[k] = copyToList(labels, value.Elems[k], preserveUnknown)
 	}
 
 	return types.Map{
 		ElemType: typ.ElemType,
 		Elems:    elems,
-		Unknown:  preserveUnknown && value.IsUnknown(),
 	}
 }
 
@@ -241,27 +243,30 @@ func CopyToStrings(_ diag.Diagnostics, o wrappers.Strings, _ attr.Type, v attr.V
 }
 
 func copyToList(strList []string, v attr.Value, preserveUnknown bool) attr.Value {
-	listVal, ok := v.(types.List)
-	if !ok {
-		listVal = types.List{ElemType: types.StringType}
+	listVal, _ := v.(types.List)
+
+	if preserveUnknown && listVal.IsUnknown() {
+		return types.List{
+			ElemType: types.StringType,
+			Unknown:  true,
+		}
 	}
 
 	elems := make([]attr.Value, len(strList))
 	for i, str := range strList {
-		unknown := preserveUnknown &&
+		if preserveUnknown &&
 			i < len(listVal.Elems) &&
 			listVal.Elems[i] != nil &&
-			listVal.Elems[i].IsUnknown()
-
-		elems[i] = types.String{
-			Value:   str,
-			Unknown: unknown,
+			listVal.Elems[i].IsUnknown() {
+			elems[i] = types.String{Unknown: true}
+			continue
 		}
+
+		elems[i] = types.String{Value: str}
 	}
 
 	return types.List{
 		ElemType: types.StringType,
 		Elems:    elems,
-		Unknown:  preserveUnknown && listVal.IsUnknown(),
 	}
 }

--- a/integrations/terraform/tfschema/custom_types.go
+++ b/integrations/terraform/tfschema/custom_types.go
@@ -69,22 +69,22 @@ func CopyFromBoolOption(diags diag.Diagnostics, tf attr.Value, o **apitypes.Bool
 	*o = &value
 }
 
-func CopyToBoolOption(diags diag.Diagnostics, o *apitypes.BoolOption, t attr.Type, v attr.Value) attr.Value {
-	value, ok := v.(types.Bool)
-	if !ok {
-		value = types.Bool{}
-	}
-	value.Unknown = false
+// CopyToBoolOption converts a Teleport [apitypes.BoolOption] into a Terraform
+// [types.Bool] value. Set `preserveUnknown` to preserve unknown values.
+func CopyToBoolOption(_ diag.Diagnostics, o *apitypes.BoolOption, _ attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
+	unknown := preserveUnknown && v != nil && v.IsUnknown()
 
 	if o == nil {
-		value.Null = true
-		return value
+		return types.Bool{
+			Null:    true,
+			Unknown: unknown,
+		}
 	}
 
-	value.Null = false
-	value.Value = o.Value
-
-	return value
+	return types.Bool{
+		Value:   o.Value,
+		Unknown: unknown,
+	}
 }
 
 func CopyFromLabels(diags diag.Diagnostics, v attr.Value, o *apitypes.Labels) {
@@ -121,7 +121,9 @@ func CopyFromLabels(diags diag.Diagnostics, v attr.Value, o *apitypes.Labels) {
 	}
 }
 
-func CopyToLabels(diags diag.Diagnostics, o apitypes.Labels, t attr.Type, v attr.Value) attr.Value {
+// CopyToLabels converts a Teleport [apitypes.Labels] into a Terraform
+// [types.Map] value. Set `preserveUnknown` to preserve unknown values.
+func CopyToLabels(_ diag.Diagnostics, o apitypes.Labels, t attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
 	typ := t.(types.MapType) // By the convention, t comes type-asserted so there would be no failure
 
 	value, ok := v.(types.Map)
@@ -129,25 +131,16 @@ func CopyToLabels(diags diag.Diagnostics, o apitypes.Labels, t attr.Type, v attr
 		value = types.Map{ElemType: typ.ElemType}
 	}
 
-	value.ElemType = typ.ElemType
-	value.Elems = make(map[string]attr.Value, len(o))
-
-	for k, l := range o {
-		row := types.List{
-			ElemType: types.StringType,
-			Elems:    make([]attr.Value, len(l)),
-		}
-
-		for i, e := range l {
-			row.Elems[i] = types.String{Value: e}
-		}
-
-		value.Elems[k] = row
+	elems := make(map[string]attr.Value, len(o))
+	for k, labels := range o {
+		elems[k] = copyToList(labels, value.Elems[k], preserveUnknown)
 	}
 
-	value.Null = false
-	value.Unknown = false
-	return value
+	return types.Map{
+		ElemType: typ.ElemType,
+		Elems:    elems,
+		Unknown:  preserveUnknown && value.IsUnknown(),
+	}
 }
 
 func CopyFromTraits(diags diag.Diagnostics, v attr.Value, o *wrappers.Traits) {
@@ -184,7 +177,9 @@ func CopyFromTraits(diags diag.Diagnostics, v attr.Value, o *wrappers.Traits) {
 	}
 }
 
-func CopyToTraits(diags diag.Diagnostics, o wrappers.Traits, t attr.Type, v attr.Value) attr.Value {
+// CopyToTraits converts a Teleport [wrappers.Traits] into a Terraform
+// [types.Map] value. Set `preserveUnknown` to preserve unknown values.
+func CopyToTraits(_ diag.Diagnostics, o wrappers.Traits, t attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
 	typ := t.(types.MapType) // By the convention, t comes type-asserted so there would be no failure
 
 	value, ok := v.(types.Map)
@@ -192,25 +187,16 @@ func CopyToTraits(diags diag.Diagnostics, o wrappers.Traits, t attr.Type, v attr
 		value = types.Map{ElemType: typ.ElemType}
 	}
 
-	value.ElemType = typ.ElemType
-	value.Elems = make(map[string]attr.Value, len(o))
-
-	for k, l := range o {
-		row := types.List{
-			ElemType: types.StringType,
-			Elems:    make([]attr.Value, len(l)),
-		}
-
-		for i, e := range l {
-			row.Elems[i] = types.String{Value: e}
-		}
-
-		value.Elems[k] = row
+	elems := make(map[string]attr.Value, len(o))
+	for k, traits := range o {
+		elems[k] = copyToList(traits, value.Elems[k], preserveUnknown)
 	}
 
-	value.Null = false
-	value.Unknown = false
-	return value
+	return types.Map{
+		ElemType: typ.ElemType,
+		Elems:    elems,
+		Unknown:  preserveUnknown && value.IsUnknown(),
+	}
 }
 
 // GenSchemaStrings returns Terraform schema for Strings type
@@ -249,24 +235,33 @@ func CopyFromStrings(diags diag.Diagnostics, v attr.Value, o *wrappers.Strings) 
 }
 
 // CopyFromStrings converts from a Teleport wrappers.Strings into a Terraform List with ElemType of String
-func CopyToStrings(diags diag.Diagnostics, o wrappers.Strings, t attr.Type, v attr.Value) attr.Value {
-	typ := t.(types.ListType) // By the convention, t comes type-asserted so there would be no failure
+// Set `preserveUnknown` to preserve unknown values.
+func CopyToStrings(_ diag.Diagnostics, o wrappers.Strings, _ attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
+	return copyToList(o, v, preserveUnknown)
+}
 
-	value, ok := v.(types.List)
+func copyToList(strList []string, v attr.Value, preserveUnknown bool) attr.Value {
+	listVal, ok := v.(types.List)
 	if !ok {
-		value = types.List{ElemType: typ.ElemType}
+		listVal = types.List{ElemType: types.StringType}
 	}
 
-	value.ElemType = typ.ElemType
-	value.Elems = make([]attr.Value, len(o))
+	elems := make([]attr.Value, len(strList))
+	for i, str := range strList {
+		unknown := preserveUnknown &&
+			i < len(listVal.Elems) &&
+			listVal.Elems[i] != nil &&
+			listVal.Elems[i].IsUnknown()
 
-	for k, l := range o {
-		value.Elems[k] = types.String{
-			Value: l,
+		elems[i] = types.String{
+			Value:   str,
+			Unknown: unknown,
 		}
 	}
 
-	value.Null = false
-	value.Unknown = false
-	return value
+	return types.List{
+		ElemType: types.StringType,
+		Elems:    elems,
+		Unknown:  preserveUnknown && listVal.IsUnknown(),
+	}
 }

--- a/integrations/terraform/tfschema/custom_types_test.go
+++ b/integrations/terraform/tfschema/custom_types_test.go
@@ -122,17 +122,17 @@ func TestCopyToBoolOptionPreserveUnknown(t *testing.T) {
 		{
 			name:     "true",
 			input:    &apitypes.BoolOption{Value: true},
-			expected: types.Bool{Value: true, Unknown: true},
+			expected: types.Bool{Unknown: true},
 		},
 		{
 			name:     "false",
 			input:    &apitypes.BoolOption{Value: false},
-			expected: types.Bool{Value: false, Unknown: true},
+			expected: types.Bool{Unknown: true},
 		},
 		{
 			name:     "null",
 			input:    nil,
-			expected: types.Bool{Null: true, Unknown: true},
+			expected: types.Bool{Unknown: true},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -440,7 +440,7 @@ func TestCopyToLabelsPreserveUnknown(t *testing.T) {
 					"foo": types.List{
 						ElemType: types.StringType,
 						Elems: []attr.Value{
-							types.String{Value: "new", Unknown: true},
+							types.String{Unknown: true},
 						},
 					},
 				},
@@ -455,7 +455,6 @@ func TestCopyToLabelsPreserveUnknown(t *testing.T) {
 			},
 			expected: types.Map{
 				ElemType: labelListType,
-				Elems:    map[string]attr.Value{},
 				Unknown:  true,
 			},
 		},
@@ -467,7 +466,6 @@ func TestCopyToLabelsPreserveUnknown(t *testing.T) {
 			},
 			expected: types.Map{
 				ElemType: labelListType,
-				Elems:    map[string]attr.Value{},
 				Unknown:  true,
 			},
 		},
@@ -606,7 +604,7 @@ func TestCopyToTraitsPreserveUnknown(t *testing.T) {
 					"foo": types.List{
 						ElemType: types.StringType,
 						Elems: []attr.Value{
-							types.String{Value: "new", Unknown: true},
+							types.String{Unknown: true},
 						},
 					},
 				},
@@ -621,7 +619,6 @@ func TestCopyToTraitsPreserveUnknown(t *testing.T) {
 			},
 			expected: types.Map{
 				ElemType: labelListType,
-				Elems:    map[string]attr.Value{},
 				Unknown:  true,
 			},
 		},
@@ -633,7 +630,6 @@ func TestCopyToTraitsPreserveUnknown(t *testing.T) {
 			},
 			expected: types.Map{
 				ElemType: labelListType,
-				Elems:    map[string]attr.Value{},
 				Unknown:  true,
 			},
 		},
@@ -756,7 +752,7 @@ func TestStringsCopyToPreserveUnknown(t *testing.T) {
 			expected: types.List{
 				ElemType: types.StringType,
 				Elems: []attr.Value{
-					types.String{Value: "new", Unknown: true},
+					types.String{Unknown: true},
 				},
 			},
 		},
@@ -769,7 +765,6 @@ func TestStringsCopyToPreserveUnknown(t *testing.T) {
 			},
 			expected: types.List{
 				ElemType: types.StringType,
-				Elems:    []attr.Value{},
 				Unknown:  true,
 			},
 		},
@@ -781,7 +776,6 @@ func TestStringsCopyToPreserveUnknown(t *testing.T) {
 			},
 			expected: types.List{
 				ElemType: types.StringType,
-				Elems:    []attr.Value{},
 				Unknown:  true,
 			},
 		},

--- a/integrations/terraform/tfschema/custom_types_test.go
+++ b/integrations/terraform/tfschema/custom_types_test.go
@@ -104,7 +104,47 @@ func TestCopyToBoolOption(t *testing.T) {
 				Unknown: true,
 			}
 
-			value := CopyToBoolOption(diags, tc.input, terraformType, valueInitial)
+			value := CopyToBoolOption(diags, tc.input, terraformType, valueInitial, false)
+			require.Empty(t, diags)
+			require.Equal(t, tc.expected, value)
+		})
+	}
+}
+
+func TestCopyToBoolOptionPreserveUnknown(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		input    *apitypes.BoolOption
+		expected types.Bool
+	}{
+		{
+			name:     "true",
+			input:    &apitypes.BoolOption{Value: true},
+			expected: types.Bool{Value: true, Unknown: true},
+		},
+		{
+			name:     "false",
+			input:    &apitypes.BoolOption{Value: false},
+			expected: types.Bool{Value: false, Unknown: true},
+		},
+		{
+			name:     "null",
+			input:    nil,
+			expected: types.Bool{Null: true, Unknown: true},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := diag.Diagnostics{}
+			terraformType := types.BoolType
+			valueInitial := types.Bool{
+				Unknown: true,
+			}
+
+			value := CopyToBoolOption(diags, tc.input, terraformType, valueInitial, true)
 			require.Empty(t, diags)
 			require.Equal(t, tc.expected, value)
 		})
@@ -362,9 +402,84 @@ func TestCopyToLabels(t *testing.T) {
 
 			diags := diag.Diagnostics{}
 
-			value := CopyToLabels(diags, tc.input, labelMapType, tc.initial)
+			value := CopyToLabels(diags, tc.input, labelMapType, tc.initial, false)
 			require.Empty(t, diags)
 			requireLabels(t, value, tc.expected)
+		})
+	}
+}
+
+func TestCopyToLabelsPreserveUnknown(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		input    apitypes.Labels
+		initial  attr.Value
+		expected attr.Value
+	}{
+		{
+			name: "element is unknown",
+			input: apitypes.Labels{
+				"foo": utils.Strings{"new"},
+			},
+			initial: types.Map{
+				ElemType: labelListType,
+				Elems: map[string]attr.Value{
+					"foo": types.List{
+						ElemType: types.StringType,
+						Elems: []attr.Value{
+							types.String{Unknown: true},
+						},
+					},
+				},
+			},
+			expected: types.Map{
+				ElemType: labelListType,
+				Elems: map[string]attr.Value{
+					"foo": types.List{
+						ElemType: types.StringType,
+						Elems: []attr.Value{
+							types.String{Value: "new", Unknown: true},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "empty labels",
+			input: apitypes.Labels{},
+			initial: types.Map{
+				ElemType: labelListType,
+				Unknown:  true,
+			},
+			expected: types.Map{
+				ElemType: labelListType,
+				Elems:    map[string]attr.Value{},
+				Unknown:  true,
+			},
+		},
+		{
+			name: "nil labels",
+			initial: types.Map{
+				ElemType: labelListType,
+				Unknown:  true,
+			},
+			expected: types.Map{
+				ElemType: labelListType,
+				Elems:    map[string]attr.Value{},
+				Unknown:  true,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := diag.Diagnostics{}
+
+			value := CopyToLabels(diags, tc.input, labelMapType, tc.initial, true)
+			require.Empty(t, diags)
+			require.Equal(t, tc.expected, value)
 		})
 	}
 }
@@ -453,9 +568,84 @@ func TestCopyToTraits(t *testing.T) {
 
 			diags := diag.Diagnostics{}
 
-			value := CopyToTraits(diags, tc.input, labelMapType, tc.initial)
+			value := CopyToTraits(diags, tc.input, labelMapType, tc.initial, false)
 			require.Empty(t, diags)
 			requireTraits(t, value, tc.expected)
+		})
+	}
+}
+
+func TestCopyToTraitsPreserveUnknown(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		input    wrappers.Traits
+		initial  attr.Value
+		expected attr.Value
+	}{
+		{
+			name: "element is unknown",
+			input: wrappers.Traits{
+				"foo": utils.Strings{"new"},
+			},
+			initial: types.Map{
+				ElemType: labelListType,
+				Elems: map[string]attr.Value{
+					"foo": types.List{
+						ElemType: types.StringType,
+						Elems: []attr.Value{
+							types.String{Unknown: true},
+						},
+					},
+				},
+			},
+			expected: types.Map{
+				ElemType: labelListType,
+				Elems: map[string]attr.Value{
+					"foo": types.List{
+						ElemType: types.StringType,
+						Elems: []attr.Value{
+							types.String{Value: "new", Unknown: true},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "empty labels",
+			input: wrappers.Traits{},
+			initial: types.Map{
+				ElemType: labelListType,
+				Unknown:  true,
+			},
+			expected: types.Map{
+				ElemType: labelListType,
+				Elems:    map[string]attr.Value{},
+				Unknown:  true,
+			},
+		},
+		{
+			name: "nil labels",
+			initial: types.Map{
+				ElemType: labelListType,
+				Unknown:  true,
+			},
+			expected: types.Map{
+				ElemType: labelListType,
+				Elems:    map[string]attr.Value{},
+				Unknown:  true,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := diag.Diagnostics{}
+
+			value := CopyToTraits(diags, tc.input, labelMapType, tc.initial, true)
+			require.Empty(t, diags)
+			require.Equal(t, tc.expected, value)
 		})
 	}
 }
@@ -536,9 +726,74 @@ func TestStringsCopyTo(t *testing.T) {
 
 			diags := diag.Diagnostics{}
 
-			value := CopyToStrings(diags, tc.input, labelListType, tc.initial)
+			value := CopyToStrings(diags, tc.input, labelListType, tc.initial, false)
 			require.Empty(t, diags)
 			requireStrings(t, value, tc.expected)
+		})
+	}
+}
+
+func TestStringsCopyToPreserveUnknown(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		input    wrappers.Strings
+		initial  attr.Value
+		expected attr.Value
+	}{
+		{
+			name: "element is unknown",
+			input: wrappers.Strings{
+				"new",
+			},
+			initial: types.List{
+				ElemType: types.StringType,
+				Elems: []attr.Value{
+					types.String{Unknown: true},
+				},
+			},
+			expected: types.List{
+				ElemType: types.StringType,
+				Elems: []attr.Value{
+					types.String{Value: "new", Unknown: true},
+				},
+			},
+		},
+		{
+			name:  "empty strings",
+			input: wrappers.Strings{},
+			initial: types.List{
+				ElemType: types.StringType,
+				Unknown:  true,
+			},
+			expected: types.List{
+				ElemType: types.StringType,
+				Elems:    []attr.Value{},
+				Unknown:  true,
+			},
+		},
+		{
+			name: "nil strings",
+			initial: types.List{
+				ElemType: types.StringType,
+				Unknown:  true,
+			},
+			expected: types.List{
+				ElemType: types.StringType,
+				Elems:    []attr.Value{},
+				Unknown:  true,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := diag.Diagnostics{}
+
+			value := CopyToStrings(diags, tc.input, labelListType, tc.initial, true)
+			require.Empty(t, diags)
+			require.Equal(t, tc.expected, value)
 		})
 	}
 }

--- a/integrations/terraform/tfschema/resource153/custom_types.go
+++ b/integrations/terraform/tfschema/resource153/custom_types.go
@@ -116,6 +116,7 @@ func CopyToDuration(_ diag.Diagnostics, o *durationpb.Duration, _ attr.Type, v a
 		value = tfschema.DurationValue{}
 	}
 
+	value.Null = false
 	value.Value = o.AsDuration()
 	value.Unknown = false
 	return value

--- a/integrations/terraform/tfschema/resource153/custom_types.go
+++ b/integrations/terraform/tfschema/resource153/custom_types.go
@@ -52,23 +52,26 @@ func CopyFromTimestamp(diags diag.Diagnostics, v attr.Value, o **timestamppb.Tim
 	}
 }
 
-func CopyToTimestamp(diags diag.Diagnostics, o *timestamppb.Timestamp, t attr.Type, v attr.Value) attr.Value {
-	value, ok := v.(tfschema.TimeValue)
-	if !ok {
-		value = tfschema.TimeValue{}
-	}
-	value.Unknown = false
+// CopyToTimestamp converts a Teleport [timestamppb.Timestamp] into a Terraform
+// [tfschema.TimeValue]. Set `preserveUnknown` to preserve unknown values.
+func CopyToTimestamp(_ diag.Diagnostics, o *timestamppb.Timestamp, _ attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
+	unknown := preserveUnknown && v != nil && v.IsUnknown()
+
+	format := time.RFC3339
 
 	if o == nil {
-		value.Null = true
-		return value
+		return tfschema.TimeValue{
+			Null:    true,
+			Format:  format,
+			Unknown: unknown,
+		}
 	}
 
-	value.Value = (*o).AsTime()
-	value.Format = time.RFC3339
-
-	value.Null = false
-	return value
+	return tfschema.TimeValue{
+		Value:   o.AsTime(),
+		Format:  format,
+		Unknown: unknown,
+	}
 }
 
 func GenSchemaDuration(_ context.Context, attr tfsdk.Attribute) tfsdk.Attribute {
@@ -92,21 +95,27 @@ func CopyFromDuration(diags diag.Diagnostics, v attr.Value, o **durationpb.Durat
 	*o = durationpb.New(value.Value)
 }
 
-func CopyToDuration(diags diag.Diagnostics, o *durationpb.Duration, t attr.Type, v attr.Value) attr.Value {
+// CopyToDuration converts a Teleport [durationpb.Duration] into a Terraform
+// [tfschema.DurationValue]. Set `preserveUnknown` to preserve unknown values.
+func CopyToDuration(_ diag.Diagnostics, o *durationpb.Duration, _ attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
+	unknown := preserveUnknown && v != nil && v.IsUnknown()
+
+	if o == nil {
+		return tfschema.DurationValue{
+			Null:    true,
+			Unknown: unknown,
+		}
+	}
+
+	// Note: Prior Terraform attribute value is returned if possible to preserve
+	// the rawValue, which contains the original string value.
 	value, ok := v.(tfschema.DurationValue)
 	if !ok {
 		value = tfschema.DurationValue{}
 	}
-	value.Unknown = false
 
-	if o == nil {
-		value.Null = true
-		return value
-	}
-
-	value.Value = (*o).AsDuration()
-
-	value.Null = false
+	value.Value = o.AsDuration()
+	value.Unknown = unknown
 	return value
 }
 
@@ -118,6 +127,8 @@ func CopyFromLabels(diags diag.Diagnostics, v attr.Value, o *apitypes.Labels) {
 	tfschema.CopyFromLabels(diags, v, o)
 }
 
-func CopyToLabels(diags diag.Diagnostics, o apitypes.Labels, t attr.Type, v attr.Value) attr.Value {
-	return tfschema.CopyToLabels(diags, o, t, v)
+// CopyToLabels converts a Teleport [apitypes.Labels] into a Terraform
+// `types.Map` value. Set `preserveUnknown` to preserve unknown values.
+func CopyToLabels(diags diag.Diagnostics, o apitypes.Labels, t attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
+	return tfschema.CopyToLabels(diags, o, t, v, preserveUnknown)
 }

--- a/integrations/terraform/tfschema/resource153/custom_types.go
+++ b/integrations/terraform/tfschema/resource153/custom_types.go
@@ -55,22 +55,22 @@ func CopyFromTimestamp(diags diag.Diagnostics, v attr.Value, o **timestamppb.Tim
 // CopyToTimestamp converts a Teleport [timestamppb.Timestamp] into a Terraform
 // [tfschema.TimeValue]. Set `preserveUnknown` to preserve unknown values.
 func CopyToTimestamp(_ diag.Diagnostics, o *timestamppb.Timestamp, _ attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
-	unknown := preserveUnknown && v != nil && v.IsUnknown()
+	if preserveUnknown && v != nil && v.IsUnknown() {
+		return tfschema.TimeValue{Unknown: true}
+	}
 
 	format := time.RFC3339
 
 	if o == nil {
 		return tfschema.TimeValue{
-			Null:    true,
-			Format:  format,
-			Unknown: unknown,
+			Null:   true,
+			Format: format,
 		}
 	}
 
 	return tfschema.TimeValue{
-		Value:   o.AsTime(),
-		Format:  format,
-		Unknown: unknown,
+		Value:  o.AsTime(),
+		Format: format,
 	}
 }
 
@@ -98,12 +98,14 @@ func CopyFromDuration(diags diag.Diagnostics, v attr.Value, o **durationpb.Durat
 // CopyToDuration converts a Teleport [durationpb.Duration] into a Terraform
 // [tfschema.DurationValue]. Set `preserveUnknown` to preserve unknown values.
 func CopyToDuration(_ diag.Diagnostics, o *durationpb.Duration, _ attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
-	unknown := preserveUnknown && v != nil && v.IsUnknown()
+
+	if preserveUnknown && v != nil && v.IsUnknown() {
+		return tfschema.DurationValue{Unknown: true}
+	}
 
 	if o == nil {
 		return tfschema.DurationValue{
-			Null:    true,
-			Unknown: unknown,
+			Null: true,
 		}
 	}
 
@@ -115,7 +117,7 @@ func CopyToDuration(_ diag.Diagnostics, o *durationpb.Duration, _ attr.Type, v a
 	}
 
 	value.Value = o.AsDuration()
-	value.Unknown = unknown
+	value.Unknown = false
 	return value
 }
 

--- a/integrations/terraform/tfschema/resource153/custom_types_test.go
+++ b/integrations/terraform/tfschema/resource153/custom_types_test.go
@@ -103,7 +103,52 @@ func TestCopyToTimestamp(t *testing.T) {
 				Format:  time.RFC3339,
 			}
 
-			value := CopyToTimestamp(diags, tc.input, tfschema.UseRFC3339Time(), valueInitial)
+			value := CopyToTimestamp(diags, tc.input, tfschema.UseRFC3339Time(), valueInitial, false)
+			require.Empty(t, diags)
+			require.Equal(t, tc.expected, value)
+		})
+	}
+}
+
+func TestCopyToTimestampPreserveUnknown(t *testing.T) {
+	t.Parallel()
+
+	timestamp := timestamppb.New(time.Date(2026, time.June, 1, 12, 0, 0, 0, time.UTC))
+
+	for _, tc := range []struct {
+		name     string
+		input    *timestamppb.Timestamp
+		expected tfschema.TimeValue
+	}{
+		{
+			name:  "null",
+			input: nil,
+			expected: tfschema.TimeValue{
+				Null:    true,
+				Format:  time.RFC3339,
+				Unknown: true,
+			},
+		},
+		{
+			name:  "non-nil",
+			input: timestamp,
+			expected: tfschema.TimeValue{
+				Value:   timestamp.AsTime(),
+				Format:  time.RFC3339,
+				Unknown: true,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := diag.Diagnostics{}
+			valueInitial := tfschema.TimeValue{
+				Unknown: true,
+				Format:  time.RFC3339,
+			}
+
+			value := CopyToTimestamp(diags, tc.input, tfschema.UseRFC3339Time(), valueInitial, true)
 			require.Empty(t, diags)
 			require.Equal(t, tc.expected, value)
 		})
@@ -180,7 +225,47 @@ func TestCopyToDuration(t *testing.T) {
 				Unknown: true,
 			}
 
-			value := CopyToDuration(diags, tc.input, tfschema.DurationType{}, initialValue)
+			value := CopyToDuration(diags, tc.input, tfschema.DurationType{}, initialValue, false)
+			require.Empty(t, diags)
+			require.Equal(t, tc.expected, value)
+		})
+	}
+}
+
+func TestCopyToDurationPreserveUnknown(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		input    *durationpb.Duration
+		expected tfschema.DurationValue
+	}{
+		{
+			name:  "null",
+			input: nil,
+			expected: tfschema.DurationValue{
+				Null:    true,
+				Unknown: true,
+			},
+		},
+		{
+			name:  "non-nil",
+			input: durationpb.New(time.Minute),
+			expected: tfschema.DurationValue{
+				Value:   time.Minute,
+				Unknown: true,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := diag.Diagnostics{}
+			initialValue := tfschema.DurationValue{
+				Unknown: true,
+			}
+
+			value := CopyToDuration(diags, tc.input, tfschema.DurationType{}, initialValue, true)
 			require.Empty(t, diags)
 			require.Equal(t, tc.expected, value)
 		})

--- a/integrations/terraform/tfschema/resource153/custom_types_test.go
+++ b/integrations/terraform/tfschema/resource153/custom_types_test.go
@@ -121,22 +121,14 @@ func TestCopyToTimestampPreserveUnknown(t *testing.T) {
 		expected tfschema.TimeValue
 	}{
 		{
-			name:  "null",
-			input: nil,
-			expected: tfschema.TimeValue{
-				Null:    true,
-				Format:  time.RFC3339,
-				Unknown: true,
-			},
+			name:     "null",
+			input:    nil,
+			expected: tfschema.TimeValue{Unknown: true},
 		},
 		{
-			name:  "non-nil",
-			input: timestamp,
-			expected: tfschema.TimeValue{
-				Value:   timestamp.AsTime(),
-				Format:  time.RFC3339,
-				Unknown: true,
-			},
+			name:     "non-nil",
+			input:    timestamp,
+			expected: tfschema.TimeValue{Unknown: true},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -241,20 +233,14 @@ func TestCopyToDurationPreserveUnknown(t *testing.T) {
 		expected tfschema.DurationValue
 	}{
 		{
-			name:  "null",
-			input: nil,
-			expected: tfschema.DurationValue{
-				Null:    true,
-				Unknown: true,
-			},
+			name:     "null",
+			input:    nil,
+			expected: tfschema.DurationValue{Unknown: true},
 		},
 		{
-			name:  "non-nil",
-			input: durationpb.New(time.Minute),
-			expected: tfschema.DurationValue{
-				Value:   time.Minute,
-				Unknown: true,
-			},
+			name:     "non-nil",
+			input:    durationpb.New(time.Minute),
+			expected: tfschema.DurationValue{Unknown: true},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/integrations/terraform/tfschema/scopes/access/v1/role_terraform.go
+++ b/integrations/terraform/tfschema/scopes/access/v1/role_terraform.go
@@ -102,25 +102,33 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 				"app": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						"label_expression": {
-							Description: "LabelExpression is an optional predicate expression evaluated against an application's labels.",
-							Optional:    true,
-							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+							Computed:      true,
+							Description:   "LabelExpression is an optional predicate expression evaluated against an application's labels.",
+							Optional:      true,
+							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+							Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 						"labels": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 								"name": {
-									Description: "The name of the label.",
-									Optional:    true,
-									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+									Computed:      true,
+									Description:   "The name of the label.",
+									Optional:      true,
+									PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+									Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 								"values": {
-									Description: "The values associated with the label.",
-									Optional:    true,
-									Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+									Computed:      true,
+									Description:   "The values associated with the label.",
+									Optional:      true,
+									PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+									Type:          github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 								},
 							}),
-							Description: "The set of application labels used for RBAC.",
-							Optional:    true,
+							Computed:      true,
+							Description:   "The set of application labels used for RBAC.",
+							Optional:      true,
+							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 						},
 					}),
 					Description: "The App Access specific configuration for a scoped role.",
@@ -4370,6 +4378,7 @@ func CopyScopedRoleToTerraformPreserveUnknown(ctx context.Context, obj *github_c
 								if obj.App == nil {
 									v.Null = true
 								} else {
+									v.Null = false
 									obj := obj.App
 									tf := &v
 									{
@@ -4394,13 +4403,15 @@ func CopyScopedRoleToTerraformPreserveUnknown(ctx context.Context, obj *github_c
 														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Labels))
 													}
 												}
-												if obj.Labels != nil {
+												{
 													o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 													if len(obj.Labels) != len(c.Elems) {
-														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Labels))
+														newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Labels))
+														copy(newElems, c.Elems)
+														c.Elems = newElems
 													}
 													for k, a := range obj.Labels {
-														v, ok := tf.Attrs["labels"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 														if !ok {
 															v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -4415,6 +4426,7 @@ func CopyScopedRoleToTerraformPreserveUnknown(ctx context.Context, obj *github_c
 														if a == nil {
 															v.Null = true
 														} else {
+															v.Null = false
 															obj := a
 															tf := &v
 															{
@@ -4424,6 +4436,9 @@ func CopyScopedRoleToTerraformPreserveUnknown(ctx context.Context, obj *github_c
 																} else {
 																	v, ok := tf.Attrs["name"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 																	if !ok {
+																		if tf.Attrs["name"] != nil {
+																			diags.Append(attrWriteUnexpectedExistingTypeDiag{"ScopedRole.spec.app.labels.name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
 																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 																		if err != nil {
 																			diags.Append(attrWriteGeneralError{"ScopedRole.spec.app.labels.name", err})
@@ -4432,10 +4447,13 @@ func CopyScopedRoleToTerraformPreserveUnknown(ctx context.Context, obj *github_c
 																		if !ok {
 																			diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.app.labels.name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 																		}
-																		v.Null = string(obj.Name) == ""
 																	}
+
+																	v.Null = false
 																	v.Value = string(obj.Name)
-																	v.Unknown = false
+																	if !preserveUnknown {
+																		v.Unknown = false
+																	}
 																	tf.Attrs["name"] = v
 																}
 															}
@@ -4461,14 +4479,19 @@ func CopyScopedRoleToTerraformPreserveUnknown(ctx context.Context, obj *github_c
 																				c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Values))
 																			}
 																		}
-																		if obj.Values != nil {
+																		{
 																			t := o.ElemType
 																			if len(obj.Values) != len(c.Elems) {
-																				c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Values))
+																				newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Values))
+																				copy(newElems, c.Elems)
+																				c.Elems = newElems
 																			}
 																			for k, a := range obj.Values {
-																				v, ok := tf.Attrs["values"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																				v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 																				if !ok {
+																					if c.Elems[k] != nil {
+																						diags.Append(attrWriteUnexpectedExistingTypeDiag{"ScopedRole.spec.app.labels.values", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																					}
 																					i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 																					if err != nil {
 																						diags.Append(attrWriteGeneralError{"ScopedRole.spec.app.labels.values", err})
@@ -4477,30 +4500,35 @@ func CopyScopedRoleToTerraformPreserveUnknown(ctx context.Context, obj *github_c
 																					if !ok {
 																						diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.app.labels.values", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 																					}
-																					v.Null = string(a) == ""
 																				}
+
+																				v.Null = false
 																				v.Value = string(a)
-																				v.Unknown = false
+																				if !preserveUnknown {
+																					v.Unknown = false
+																				}
 																				c.Elems[k] = v
 																			}
-																			if len(obj.Values) > 0 {
-																				c.Null = false
-																			}
 																		}
-																		c.Unknown = false
+																		c.Null = false
+																		if !preserveUnknown {
+																			c.Unknown = false
+																		}
 																		tf.Attrs["values"] = c
 																	}
 																}
 															}
 														}
-														v.Unknown = false
+														if !preserveUnknown {
+															v.Unknown = false
+														}
 														c.Elems[k] = v
 													}
-													if len(obj.Labels) > 0 {
-														c.Null = false
-													}
 												}
-												c.Unknown = false
+												c.Null = false
+												if !preserveUnknown {
+													c.Unknown = false
+												}
 												tf.Attrs["labels"] = c
 											}
 										}
@@ -4512,6 +4540,9 @@ func CopyScopedRoleToTerraformPreserveUnknown(ctx context.Context, obj *github_c
 										} else {
 											v, ok := tf.Attrs["label_expression"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 											if !ok {
+												if tf.Attrs["label_expression"] != nil {
+													diags.Append(attrWriteUnexpectedExistingTypeDiag{"ScopedRole.spec.app.label_expression", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
 												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 												if err != nil {
 													diags.Append(attrWriteGeneralError{"ScopedRole.spec.app.label_expression", err})
@@ -4520,15 +4551,20 @@ func CopyScopedRoleToTerraformPreserveUnknown(ctx context.Context, obj *github_c
 												if !ok {
 													diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.app.label_expression", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 												}
-												v.Null = string(obj.LabelExpression) == ""
 											}
+
+											v.Null = false
 											v.Value = string(obj.LabelExpression)
-											v.Unknown = false
+											if !preserveUnknown {
+												v.Unknown = false
+											}
 											tf.Attrs["label_expression"] = v
 										}
 									}
 								}
-								v.Unknown = false
+								if !preserveUnknown {
+									v.Unknown = false
+								}
 								tf.Attrs["app"] = v
 							}
 						}

--- a/integrations/terraform/tfschema/summarizer/v1/custom_types.go
+++ b/integrations/terraform/tfschema/summarizer/v1/custom_types.go
@@ -75,24 +75,17 @@ func CopyFromClassifierActionMode(diags diag.Diagnostics, v attr.Value, o *summa
 // CopyToClassifierActionMode converts a ClassifierActionMode enum value into an
 // optional Terraform boolean. Set `preserveUnknown` to preserve unknown values.
 func CopyToClassifierActionMode(_ diag.Diagnostics, o summarizerv1.ClassifierActionMode, _ attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
-	unknown := preserveUnknown && v != nil && v.IsUnknown()
+	if preserveUnknown && v != nil && v.IsUnknown() {
+		return types.Bool{Unknown: true}
+	}
 
 	switch o {
 	case summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_ENABLED:
-		return types.Bool{
-			Value:   true,
-			Unknown: unknown,
-		}
+		return types.Bool{Value: true}
 	case summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_DISABLED:
-		return types.Bool{
-			Value:   false,
-			Unknown: unknown,
-		}
+		return types.Bool{Value: false}
 	default: // CLASSIFIER_ACTION_MODE_UNSPECIFIED
-		return types.Bool{
-			Null:    true,
-			Unknown: unknown,
-		}
+		return types.Bool{Null: true}
 	}
 }
 
@@ -142,23 +135,19 @@ func CopyFromRiskLevel(diags diag.Diagnostics, v attr.Value, o *summarizerv1.Ris
 	*o = level
 }
 
-// CopyToRiskLevel conversts a [summarizerv1.RiskLevel] into a Terraform
+// CopyToRiskLevel converts a [summarizerv1.RiskLevel] into a Terraform
 // [types.String] value. Set `preserveUnknown` to preserve unknown values.
 func CopyToRiskLevel(_ diag.Diagnostics, o summarizerv1.RiskLevel, _ attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
-	unknown := preserveUnknown && v != nil && v.IsUnknown()
+	if preserveUnknown && v != nil && v.IsUnknown() {
+		return types.String{Unknown: true}
+	}
 
 	s, ok := riskLevelToString[o]
 	if !ok { // RISK_LEVEL_UNSPECIFIED
-		return types.String{
-			Null:    true,
-			Unknown: unknown,
-		}
+		return types.String{Null: true}
 	}
 
-	return types.String{
-		Value:   s,
-		Unknown: unknown,
-	}
+	return types.String{Value: s}
 }
 
 const riskLevelAllowed = `must be one of "low", "medium", "high", "critical"`

--- a/integrations/terraform/tfschema/summarizer/v1/custom_types.go
+++ b/integrations/terraform/tfschema/summarizer/v1/custom_types.go
@@ -73,28 +73,27 @@ func CopyFromClassifierActionMode(diags diag.Diagnostics, v attr.Value, o *summa
 }
 
 // CopyToClassifierActionMode converts a ClassifierActionMode enum value into an
-// optional Terraform boolean.
-func CopyToClassifierActionMode(diags diag.Diagnostics, o summarizerv1.ClassifierActionMode, t attr.Type, v attr.Value) attr.Value {
-	value, ok := v.(types.Bool)
-	if !ok {
-		value = types.Bool{}
-	}
+// optional Terraform boolean. Set `preserveUnknown` to preserve unknown values.
+func CopyToClassifierActionMode(_ diag.Diagnostics, o summarizerv1.ClassifierActionMode, _ attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
+	unknown := preserveUnknown && v != nil && v.IsUnknown()
 
 	switch o {
 	case summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_ENABLED:
-		value.Null = false
-		value.Unknown = false
-		value.Value = true
+		return types.Bool{
+			Value:   true,
+			Unknown: unknown,
+		}
 	case summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_DISABLED:
-		value.Null = false
-		value.Unknown = false
-		value.Value = false
+		return types.Bool{
+			Value:   false,
+			Unknown: unknown,
+		}
 	default: // CLASSIFIER_ACTION_MODE_UNSPECIFIED
-		value.Null = true
-		value.Unknown = false
+		return types.Bool{
+			Null:    true,
+			Unknown: unknown,
+		}
 	}
-
-	return value
 }
 
 var riskLevelToString = map[summarizerv1.RiskLevel]string{
@@ -143,24 +142,23 @@ func CopyFromRiskLevel(diags diag.Diagnostics, v attr.Value, o *summarizerv1.Ris
 	*o = level
 }
 
-func CopyToRiskLevel(diags diag.Diagnostics, o summarizerv1.RiskLevel, t attr.Type, v attr.Value) attr.Value {
-	value, ok := v.(types.String)
-	if !ok {
-		value = types.String{}
-	}
+// CopyToRiskLevel conversts a [summarizerv1.RiskLevel] into a Terraform
+// [types.String] value. Set `preserveUnknown` to preserve unknown values.
+func CopyToRiskLevel(_ diag.Diagnostics, o summarizerv1.RiskLevel, _ attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
+	unknown := preserveUnknown && v != nil && v.IsUnknown()
 
 	s, ok := riskLevelToString[o]
 	if !ok { // RISK_LEVEL_UNSPECIFIED
-		value.Null = true
-		value.Unknown = false
-		return value
+		return types.String{
+			Null:    true,
+			Unknown: unknown,
+		}
 	}
 
-	value.Null = false
-	value.Unknown = false
-	value.Value = s
-
-	return value
+	return types.String{
+		Value:   s,
+		Unknown: unknown,
+	}
 }
 
 const riskLevelAllowed = `must be one of "low", "medium", "high", "critical"`

--- a/integrations/terraform/tfschema/summarizer/v1/custom_types_test.go
+++ b/integrations/terraform/tfschema/summarizer/v1/custom_types_test.go
@@ -1,0 +1,211 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package v1
+
+import (
+	"testing"
+
+	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyToClassifierActionMode(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		input    summarizerv1.ClassifierActionMode
+		expected types.Bool
+	}{
+		{
+			name:     "enabled",
+			input:    summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_ENABLED,
+			expected: types.Bool{Value: true},
+		},
+		{
+			name:     "disabled",
+			input:    summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_DISABLED,
+			expected: types.Bool{Value: false},
+		},
+		{
+			name:     "unspecified",
+			input:    summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_UNSPECIFIED,
+			expected: types.Bool{Null: true},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := diag.Diagnostics{}
+			terraformType := types.BoolType
+			valueInitial := types.Bool{
+				Unknown: true,
+			}
+
+			value := CopyToClassifierActionMode(diags, tc.input, terraformType, valueInitial, false)
+			require.Empty(t, diags)
+			require.Equal(t, tc.expected, value)
+		})
+	}
+}
+
+func TestCopyToClassifierActionModePreserveUnknown(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		input    summarizerv1.ClassifierActionMode
+		expected types.Bool
+	}{
+		{
+			name:  "enabled",
+			input: summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_ENABLED,
+			expected: types.Bool{
+				Value:   true,
+				Unknown: true,
+			},
+		},
+		{
+			name:  "disabled",
+			input: summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_DISABLED,
+			expected: types.Bool{
+				Value:   false,
+				Unknown: true,
+			},
+		},
+		{
+			name:  "unspecified",
+			input: summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_UNSPECIFIED,
+			expected: types.Bool{
+				Null:    true,
+				Unknown: true,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := diag.Diagnostics{}
+			terraformType := types.BoolType
+			valueInitial := types.Bool{
+				Unknown: true,
+			}
+
+			value := CopyToClassifierActionMode(diags, tc.input, terraformType, valueInitial, true)
+			require.Empty(t, diags)
+			require.Equal(t, tc.expected, value)
+		})
+	}
+}
+
+func TestCopyToRiskLevel(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		input    summarizerv1.RiskLevel
+		expected types.String
+	}{
+		{
+			name:  "critical",
+			input: summarizerv1.RiskLevel_RISK_LEVEL_CRITICAL,
+			expected: types.String{
+				Value: riskLevelToString[summarizerv1.RiskLevel_RISK_LEVEL_CRITICAL],
+			},
+		},
+		{
+			name:  "low",
+			input: summarizerv1.RiskLevel_RISK_LEVEL_LOW,
+			expected: types.String{
+				Value: riskLevelToString[summarizerv1.RiskLevel_RISK_LEVEL_LOW],
+			},
+		},
+		{
+			name:  "unspecified",
+			input: summarizerv1.RiskLevel_RISK_LEVEL_UNSPECIFIED,
+			expected: types.String{
+				Null: true,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := diag.Diagnostics{}
+			terraformType := types.StringType
+			valueInitial := types.String{
+				Unknown: true,
+			}
+
+			value := CopyToRiskLevel(diags, tc.input, terraformType, valueInitial, false)
+			require.Empty(t, diags)
+			require.Equal(t, tc.expected, value)
+		})
+	}
+}
+
+func TestCopyToRiskLevelPreserveUnknown(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		input    summarizerv1.RiskLevel
+		expected types.String
+	}{
+		{
+			name:  "critical",
+			input: summarizerv1.RiskLevel_RISK_LEVEL_CRITICAL,
+			expected: types.String{
+				Value:   riskLevelToString[summarizerv1.RiskLevel_RISK_LEVEL_CRITICAL],
+				Unknown: true,
+			},
+		},
+		{
+			name:  "low",
+			input: summarizerv1.RiskLevel_RISK_LEVEL_LOW,
+			expected: types.String{
+				Value:   riskLevelToString[summarizerv1.RiskLevel_RISK_LEVEL_LOW],
+				Unknown: true,
+			},
+		},
+		{
+			name:  "unspecified",
+			input: summarizerv1.RiskLevel_RISK_LEVEL_UNSPECIFIED,
+			expected: types.String{
+				Null:    true,
+				Unknown: true,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := diag.Diagnostics{}
+			terraformType := types.StringType
+			valueInitial := types.String{
+				Unknown: true,
+			}
+
+			value := CopyToRiskLevel(diags, tc.input, terraformType, valueInitial, true)
+			require.Empty(t, diags)
+			require.Equal(t, tc.expected, value)
+		})
+	}
+}

--- a/integrations/terraform/tfschema/summarizer/v1/custom_types_test.go
+++ b/integrations/terraform/tfschema/summarizer/v1/custom_types_test.go
@@ -75,28 +75,19 @@ func TestCopyToClassifierActionModePreserveUnknown(t *testing.T) {
 		expected types.Bool
 	}{
 		{
-			name:  "enabled",
-			input: summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_ENABLED,
-			expected: types.Bool{
-				Value:   true,
-				Unknown: true,
-			},
+			name:     "enabled",
+			input:    summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_ENABLED,
+			expected: types.Bool{Unknown: true},
 		},
 		{
-			name:  "disabled",
-			input: summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_DISABLED,
-			expected: types.Bool{
-				Value:   false,
-				Unknown: true,
-			},
+			name:     "disabled",
+			input:    summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_DISABLED,
+			expected: types.Bool{Unknown: true},
 		},
 		{
-			name:  "unspecified",
-			input: summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_UNSPECIFIED,
-			expected: types.Bool{
-				Null:    true,
-				Unknown: true,
-			},
+			name:     "unspecified",
+			input:    summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_UNSPECIFIED,
+			expected: types.Bool{Unknown: true},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -170,28 +161,19 @@ func TestCopyToRiskLevelPreserveUnknown(t *testing.T) {
 		expected types.String
 	}{
 		{
-			name:  "critical",
-			input: summarizerv1.RiskLevel_RISK_LEVEL_CRITICAL,
-			expected: types.String{
-				Value:   riskLevelToString[summarizerv1.RiskLevel_RISK_LEVEL_CRITICAL],
-				Unknown: true,
-			},
+			name:     "critical",
+			input:    summarizerv1.RiskLevel_RISK_LEVEL_CRITICAL,
+			expected: types.String{Unknown: true},
 		},
 		{
-			name:  "low",
-			input: summarizerv1.RiskLevel_RISK_LEVEL_LOW,
-			expected: types.String{
-				Value:   riskLevelToString[summarizerv1.RiskLevel_RISK_LEVEL_LOW],
-				Unknown: true,
-			},
+			name:     "low",
+			input:    summarizerv1.RiskLevel_RISK_LEVEL_LOW,
+			expected: types.String{Unknown: true},
 		},
 		{
-			name:  "unspecified",
-			input: summarizerv1.RiskLevel_RISK_LEVEL_UNSPECIFIED,
-			expected: types.String{
-				Null:    true,
-				Unknown: true,
-			},
+			name:     "unspecified",
+			input:    summarizerv1.RiskLevel_RISK_LEVEL_UNSPECIFIED,
+			expected: types.String{Unknown: true},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/integrations/terraform/tfschema/summarizer/v1/custom_types_test.go
+++ b/integrations/terraform/tfschema/summarizer/v1/custom_types_test.go
@@ -19,11 +19,11 @@ package v1
 import (
 	"testing"
 
-	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
-
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/require"
+
+	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 )
 
 func TestCopyToClassifierActionMode(t *testing.T) {

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -1173,9 +1173,11 @@ func GenSchemaAppV3(ctx context.Context) (github_com_hashicorp_terraform_plugin_
 							Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 						"region": {
-							Description: "Region is a cloud region for the app. This field is set for apps that integrates with AWS applications/APIs.",
-							Optional:    true,
-							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+							Computed:      true,
+							Description:   "Region is a cloud region for the app. This field is set for apps that integrates with AWS applications/APIs.",
+							Optional:      true,
+							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+							Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 						"roles_anywhere_profile": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
@@ -17625,6 +17627,9 @@ func CopyAppV3ToTerraformPreserveUnknown(ctx context.Context, obj *github_com_gr
 										} else {
 											v, ok := tf.Attrs["region"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 											if !ok {
+												if tf.Attrs["region"] != nil {
+													diags.Append(attrWriteUnexpectedExistingTypeDiag{"AppV3.Spec.AWS.region", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
 												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 												if err != nil {
 													diags.Append(attrWriteGeneralError{"AppV3.Spec.AWS.region", err})
@@ -17633,10 +17638,13 @@ func CopyAppV3ToTerraformPreserveUnknown(ctx context.Context, obj *github_com_gr
 												if !ok {
 													diags.Append(attrWriteConversionFailureDiag{"AppV3.Spec.AWS.region", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 												}
-												v.Null = string(obj.Region) == ""
 											}
+
+											v.Null = false
 											v.Value = string(obj.Region)
-											v.Unknown = false
+											if !preserveUnknown {
+												v.Unknown = false
+											}
 											tf.Attrs["region"] = v
 										}
 									}


### PR DESCRIPTION
Supports https://github.com/gravitational/teleport/issues/66912

This PR updates the TF resource templates so that unknown values are preserved during `ModifyPlan`.

Context for why this change is needed is noted in https://github.com/gravitational/protoc-gen-terraform/pull/77. But to re-iterate here:

> While working on upgrading protoc-gen-terraform to v4 within teleport, we implemented a resource-level ModifyPlan function that is responsible for reading TF config values and normalizing null and unknown values to default/zero values accordingly (https://github.com/gravitational/teleport/pull/67294).

> This works fine when the unknown values are expected to be computed by Teleport because CheckAndSetDefaults will be used to set the values that would be expected after apply.

> However, there are other valid apply-time unknown values that can be used that would differ from the expected default values, and in these cases CheckAndSetDefaults would set an incorrect planned value. This could happen if a value is a reference to another unknown value, for example a random.random_integer.

To resolve the issue, the generated `ToTerraform` functions now accept a `preserveUnknown` flag that, when true, preserves unknown values. This PR enables the `preserveUnknown` flag for all of the default `ModifyPlan` functions.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Teleport Cloud staging environment using latest master branch

### Test Cases

Create resources containing the custom Terraform types. Update the attributes using an apply-time unknown value.

- [x] `role.spec.options.desktop_clipboard` (BoolOption)
- [x] `role.spec.allow.node_labels` (Labels)
- [x] `role.spec.allow.request.annotations` (Traits)
- [x] `oidcconnector.spec.redirect_url` (Strings)
- [x] `access_list.header.metadata.expires` (Timestamp)
- [x] `access_list.spec.audit.notification.start` (Duration)
- [x] `classifier.spec.actions.flag_for_review` (ClassifierActionMode)
- [x] `classifier.spec.actions.risk_level_floor` (RiskLevel)

<details>

```hcl
resource "random_id" "rid" {
  byte_length = 8
}

resource "random_integer" "bool" {
  min = 0
  max = 1
}

resource "random_integer" "second" {
  min = 10
  max = 60
}

locals {
  random_bool = random_integer.bool.result == 1
  random_risk_level = random_integer.bool.result == 1 ? "low" : "high"
}


resource "teleport_role" "test" {
  version = "v8"
  metadata = {
    name = "example"
  }

  spec = {
    allow = {
      logins = [random_id.rid.id]
      node_labels = {
        env = [random_id.rid.id]
      }
      request = {
        annotations = {
          test = [random_id.rid.id]
        }
      }
    }

    options = {
      desktop_clipboard = local.random_bool
    }
  }
}

resource "teleport_oidc_connector" "example" {
  version = "v3"
  metadata = {
    name = "example"
  }

  spec = {
    client_id     = "client"
    client_secret = "client_secret"

    claims_to_roles = [{
      claim = "test"
      roles = ["terraform"]
    }]

    redirect_url = ["https://example.com/redirect/${random_id.rid.id}"]
  }
}


resource "teleport_access_list" "example" {
  header = {
    version = "v1"
    metadata = {
      name    = "example"
      expires = "2026-10-11T20:00:${random_integer.second.result}Z"
    }
  }
  spec = {
    description = "Example"
    owners = [
      {
        name        = "owner"
        description = "Example owner"
      }
    ]
    membership_requires = {
      roles = ["membership_role"]
    }
    ownership_requires = {
      roles = ["ownership_role"]
    }
    grants = {
      roles = ["example_role"]
      traits = [{
        key    = "granted_traits"
        values = ["example"]
      }]
    }
    title = "Example title"

    audit = {
      notifications = {
        start = "10m${random_integer.second.result}s"
      }
    }
  }
}

resource "teleport_classifier" "example" {
  version = "v1"
  metadata = {
    name = "example"
  }
  spec = {
    kinds    = ["ssh", "k8s"]
    filter   = "equals(resource.metadata.labels[\"env\"], \"prod\")"
    criteria = "The user ran a potentially destructive command."
    actions = {
      flag_for_review  = local.random_bool
      risk_level_floor = local.random_risk_level
      emit_audit_event = true
    }
  }
}
```

```sh

❯ terraform apply
teleport_classifier.example: Refreshing state... [id=example]
teleport_oidc_connector.example: Refreshing state... [id=example]
teleport_access_list.example: Refreshing state... [id=example]
teleport_role.test: Refreshing state... [id=example]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # teleport_access_list.example will be updated in-place
  ~ resource "teleport_access_list" "example" {
      ~ header = {
          ~ metadata = {
              ~ expires     = "2026-10-11T20:00:00Z" -> (known after apply)
                name        = "example"
                # (3 unchanged attributes hidden)
            }
            # (3 unchanged attributes hidden)
        }
        id     = "example"
      ~ spec   = {
          ~ audit               = {
              ~ notifications = {
                  ~ start = "10m" -> (known after apply)
                }
                # (1 unchanged attribute hidden)
            }
            # (8 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)
    }

  # teleport_classifier.example will be updated in-place
  ~ resource "teleport_classifier" "example" {
        id       = "example"
      ~ spec     = {
          ~ actions  = {
              ~ flag_for_review  = false -> (known after apply)
              ~ risk_level_floor = "low" -> (known after apply)
                # (1 unchanged attribute hidden)
            }
            # (3 unchanged attributes hidden)
        }
        # (4 unchanged attributes hidden)
    }

  # teleport_oidc_connector.example will be updated in-place
  ~ resource "teleport_oidc_connector" "example" {
        id       = "example"
      ~ spec     = {
          ~ redirect_url               = [
              ~ "https://example.com/redirect" -> (known after apply),
            ]
            # (17 unchanged attributes hidden)
        }
        # (4 unchanged attributes hidden)
    }

  # teleport_role.test will be updated in-place
  ~ resource "teleport_role" "test" {
        id       = "example"
      ~ spec     = {
          ~ allow   = {
              ~ logins                              = [
                  ~ "root" -> (known after apply),
                ]
              ~ node_labels                         = {
                  ~ "env" = [
                      ~ "dev" -> (known after apply),
                    ]
                }
              ~ request                             = {
                  ~ annotations          = {
                      ~ "test" = [
                          ~ "test" -> (known after apply),
                        ]
                    }
                    # (7 unchanged attributes hidden)
                }
                # (42 unchanged attributes hidden)
            }
          ~ options = {
              ~ desktop_clipboard              = false -> (known after apply)
                # (27 unchanged attributes hidden)
            }
            # (1 unchanged attribute hidden)
        }
        # (4 unchanged attributes hidden)
    }

Plan: 3 to add, 4 to change, 0 to destroy.
```

</details>