### PR TITLE
[Docs] Add `Identity Security` Cli to the upcoming release 18.11.0

### DIFF
--- a/docs/pages/upcoming-releases.mdx
+++ b/docs/pages/upcoming-releases.mdx
@@ -67,6 +67,12 @@ Teleport will support remote desktop sessions to Linux hosts.
 
 _Delayed from Teleport 18.10.0._
 
+#### Identity Security CLI
+
+Teleport will add commands to `tctl` for querying Identity Security, letting you
+explore identities, resources, and their access relationships from the command
+line.
+
 #### Generic OIDC Join Method
 
 Teleport will include a new generic OIDC join method for bots and agents.


### PR DESCRIPTION
Adds an entry to the 18.11.0 upcoming releases section announcing the Identity Security CLI.

We've been building out the Identity Security CLI ([access-graph#1933](https://github.com/gravitational/access-graph/issues/1933)), holding off on announcing it until most of the planned commands were ready. The last of them, `tctl access-review`, is now in review, so after talking with the team we're targeting a 18.11.0 backport for the feature and documenting it here.

### Commands planned for 18.11.0

These `tctl` commands query Identity Security data (all read-only for this release):

- `tctl investigate` — search Identity Activity Center activity logs, with text output and geo filters ([#67219](https://github.com/gravitational/teleport/pull/67219), [#67220](https://github.com/gravitational/teleport/pull/67220), [#67523](https://github.com/gravitational/teleport/pull/67523))
- `tctl detections ls` / `tctl detections get` — list and fetch Identity Activity Center alerts ([#66885](https://github.com/gravitational/teleport/pull/66885), [#66888](https://github.com/gravitational/teleport/pull/66888))
- `tctl access-changes ls` / `tctl access-changes get` — list and fetch access changes ([#67328](https://github.com/gravitational/teleport/pull/67328), [#67329](https://github.com/gravitational/teleport/pull/67329))
- `tctl access-review` — classify and review access paths *(in review — see stacks below)*

### `tctl access-review` stacks

The final command spans two stacks:

- **teleport:** [#68283](https://github.com/gravitational/teleport/pull/68283), [#68284](https://github.com/gravitational/teleport/pull/68284), [#68285](https://github.com/gravitational/teleport/pull/68285), [#68374](https://github.com/gravitational/teleport/pull/68374)
- **access-graph:** [#2013](https://github.com/gravitational/access-graph/pull/2013)–[#2021](https://github.com/gravitational/access-graph/pull/2021) (backend, merged), plus UI [#2028](https://github.com/gravitational/access-graph/pull/2028) / [#2029](https://github.com/gravitational/access-graph/pull/2029)

Write-based capabilities are planned for later releases and aren't included here.