### PR TITLE
[v18] [Docs] Add docs for `web_terminal_clipboard_mode` role option

### DIFF
--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -28,6 +28,11 @@ spec:
     # ssh_file_copy controls whether file copying (SCP/SFTP) is allowed.
     # Defaults to true.
     ssh_file_copy: false
+    # web_terminal_clipboard_mode controls whether users can copy text from
+    # an SSH session to the clipboard in the Web UI terminal. Options are 'unrestricted'
+    # (the default) and 'no-copy'. If any of the user's roles is set to 'no-copy',
+    # copying is disabled. Available in Teleport v18.9.0 and newer.
+    web_terminal_clipboard_mode: no-copy
     # client_idle_timeout determines if SSH sessions to cluster nodes are
     # forcefully terminated after no activity from a client (idle client).
     # it overrides the global cluster setting. examples: '30m', '1h' or '1h30m'

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -58,6 +58,7 @@ user:
 | `forward_agent` | Allow SSH agent forwarding | Logical "OR" i.e. if any role allows agent forwarding, it's allowed |
 | `ssh_port_forwarding` | Allow TCP port forwarding | Logical "AND" i.e. if any role denies port forwarding, it's denied |
 | `ssh_file_copy` | Allow SCP/SFTP | Logical "AND" i.e. if all roles allows file copying, it's allowed |
+| `web_terminal_clipboard_mode` | Whether users can copy text from an SSH session to the clipboard in the Web UI terminal (`unrestricted` or `no-copy`) | If any of the user's role's is set to `no-copy`, copying is restricted. |
 | `client_idle_timeout` | Forcefully terminate active sessions after an idle interval | The shortest timeout value wins, i.e. the most restrictive value is selected |
 | `disconnect_expired_cert` | Forcefully terminate active sessions when a client certificate expires | Logical "OR" i.e. evaluates to "yes" if at least one role requires session termination |
 | `max_sessions` | Total number of session channels which can be established across a single SSH connection via Teleport | The lowest value takes precedence. |


### PR DESCRIPTION
Backport #67902 to branch/v18

Only difference from the `master` PR is that we mentioned 18.9.0+ here.