### PR TITLE
Show User Display Name in the Top-Bar User Menu

### DIFF
--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -57,6 +57,10 @@ type UserContext struct {
 	AuthType authType `json:"authType"`
 	// Name is this user name.
 	Name string `json:"userName"`
+	// DisplayPrimary is a display name when distinct from the username. May be empty.
+	DisplayPrimary string `json:"displayPrimary"`
+	// DisplaySecondary is extra context when distinct from the username. May be empty.
+	DisplaySecondary string `json:"displaySecondary"`
 	// ACL contains user access control list.
 	ACL services.UserACL `json:"userAcl"`
 	// Cluster contains cluster detail for this user's context.
@@ -114,11 +118,15 @@ func NewUserContext(user types.User, userRoles services.RoleSet, features proto.
 		authType = authSSO
 	}
 
+	display := user.GetDisplay()
+
 	return &UserContext{
-		Name:           user.GetName(),
-		ACL:            acl,
-		AuthType:       authType,
-		AccessStrategy: accessStrategy,
-		PasswordSate:   user.GetPasswordState(),
+		Name:             user.GetName(),
+		DisplayPrimary:   display.Primary,
+		DisplaySecondary: display.Secondary,
+		ACL:              acl,
+		AuthType:         authType,
+		AccessStrategy:   accessStrategy,
+		PasswordSate:     user.GetPasswordState(),
 	}, nil
 }

--- a/lib/web/ui/usercontext_test.go
+++ b/lib/web/ui/usercontext_test.go
@@ -112,3 +112,32 @@ func TestNewUserContextCloud(t *testing.T) {
 		Prompt: "",
 	}))
 }
+
+func TestNewUserContextDisplayValues(t *testing.T) {
+	t.Parallel()
+
+	role := &types.RoleV6{}
+	role.SetNamespaces(types.Allow, []string{apidefaults.Namespace})
+	roleSet := []types.Role{role}
+
+	t.Run("populated from traits", func(t *testing.T) {
+		t.Parallel()
+
+		user := &types.UserV2{
+			Metadata: types.Metadata{
+				Name: "alice",
+			},
+			Spec: types.UserSpecV2{
+				Traits: map[string][]string{
+					"displayName": {"Alice Anderson"},
+					"email":       {"alice@example.com"},
+				},
+			},
+		}
+
+		userContext, err := NewUserContext(user, roleSet, proto.Features{}, true, false)
+		require.NoError(t, err)
+		require.Equal(t, "Alice Anderson", userContext.DisplayPrimary)
+		require.Equal(t, "alice@example.com", userContext.DisplaySecondary)
+	})
+}

--- a/lib/web/ui/usercontext_test.go
+++ b/lib/web/ui/usercontext_test.go
@@ -116,10 +116,6 @@ func TestNewUserContextCloud(t *testing.T) {
 func TestNewUserContextDisplayValues(t *testing.T) {
 	t.Parallel()
 
-	role := &types.RoleV6{}
-	role.SetNamespaces(types.Allow, []string{apidefaults.Namespace})
-	roleSet := []types.Role{role}
-
 	t.Run("populated from traits", func(t *testing.T) {
 		t.Parallel()
 
@@ -135,7 +131,7 @@ func TestNewUserContextDisplayValues(t *testing.T) {
 			},
 		}
 
-		userContext, err := NewUserContext(user, roleSet, proto.Features{}, true, false)
+		userContext, err := NewUserContext(user, nil, proto.Features{}, true, false)
 		require.NoError(t, err)
 		require.Equal(t, "Alice Anderson", userContext.DisplayPrimary)
 		require.Equal(t, "alice@example.com", userContext.DisplaySecondary)

--- a/web/packages/teleport/src/Main/fixtures/index.ts
+++ b/web/packages/teleport/src/Main/fixtures/index.ts
@@ -22,6 +22,8 @@ import makeUserContext from 'teleport/services/user/makeUserContext';
 export const userContext = makeUserContext({
   authType: 'sso',
   userName: 'Sam',
+  displayPrimary: '',
+  displaySecondary: '',
   accessCapabilities: {
     suggestedReviewers: ['george_washington@gmail.com', 'chad'],
     requestableRoles: ['dev-a', 'dev-b', 'dev-c', 'dev-d'],

--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -30,14 +30,12 @@ import { useFeatures } from 'teleport/FeaturesContext';
 import { useLayout } from 'teleport/Main/LayoutContext';
 import { zIndexMap } from 'teleport/Navigation/zIndexMap';
 import { Notifications } from 'teleport/Notifications';
-import useTeleport from 'teleport/useTeleport';
 
 export function TopBar({
   CustomLogo,
 }: {
   CustomLogo?: () => React.ReactElement;
 }) {
-  const ctx = useTeleport();
   const location = useLocation();
   const features = useFeatures();
   const { currentWidth } = useLayout();
@@ -63,7 +61,7 @@ export function TopBar({
       {!feature?.logoOnlyTopbar && (
         <Flex height="100%" alignItems="center">
           <Notifications iconSize={iconSize} />
-          <UserMenuNav username={ctx.storeUser.state.username} />
+          <UserMenuNav />
         </Flex>
       )}
     </TopBarContainer>

--- a/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.story.tsx
+++ b/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.story.tsx
@@ -18,8 +18,6 @@
 
 import { MemoryRouter } from 'react-router';
 
-import * as Icons from 'design/Icon';
-
 import { getOSSFeatures } from 'teleport/features';
 import { FeaturesContextProvider } from 'teleport/FeaturesContext';
 import { makeUserContext } from 'teleport/services/user';
@@ -30,13 +28,56 @@ import { UserMenuNav } from './UserMenuNav';
 
 export default {
   title: 'Teleport/UserMenuNav',
-  args: { userContext: true },
 };
 
-export function Loaded() {
+export function UsernameOnly() {
+  return renderUserMenuNav({
+    userName: 'george',
+    displayPrimary: '',
+    displaySecondary: '',
+  });
+}
+
+export function DisplayName() {
+  return renderUserMenuNav({
+    userName: '123456',
+    displayPrimary: 'Jane Garcia',
+    displaySecondary: 'jane@example.com',
+  });
+}
+
+export function SecondaryOnly() {
+  return renderUserMenuNav({
+    userName: 'casey',
+    displayPrimary: '',
+    displaySecondary: 'casey@example.com',
+  });
+}
+
+export function LongName() {
+  return renderUserMenuNav({
+    userName: 'long-canonical-username-used-for-display-testing@example.com',
+    displayPrimary:
+      'Josephine Alexandra Montgomery-Smith With A Very Long Display Name',
+    displaySecondary: '',
+  });
+}
+
+function renderUserMenuNav({
+  userName,
+  displayPrimary,
+  displaySecondary,
+}: {
+  userName: string;
+  displayPrimary: string;
+  displaySecondary: string;
+}) {
   const ctx = new TeleportContext();
 
   ctx.storeUser.state = makeUserContext({
+    userName,
+    displayPrimary,
+    displaySecondary,
     cluster: {
       name: 'test-cluster',
       lastConnected: Date.now(),
@@ -47,27 +88,9 @@ export function Loaded() {
     <MemoryRouter>
       <TeleportContextProvider ctx={ctx}>
         <FeaturesContextProvider value={getOSSFeatures()}>
-          <UserMenuNav {...props} />
+          <UserMenuNav />
         </FeaturesContextProvider>
       </TeleportContextProvider>
     </MemoryRouter>
   );
 }
-
-const props = {
-  navItems: [
-    {
-      title: 'Nav Item 1',
-      Icon: Icons.Apple,
-      getLink: () => 'test',
-    },
-    {
-      title: 'Nav Item 2',
-      Icon: Icons.Cloud,
-      getLink: () => 'test2',
-    },
-  ],
-  iconSize: 24,
-  username: 'george',
-  logout: () => null,
-};

--- a/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.test.tsx
+++ b/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.test.tsx
@@ -47,10 +47,8 @@ describe('navigation items rendering', () => {
     async ({ path, menuName }) => {
       render(path);
 
-      // Click on dropdown menu.
-      fireEvent.click(await screen.findByText(/llama/i));
+      fireEvent.click(screen.getByRole('button', { name: 'User Menu' }));
 
-      // Only one checkmark should be rendered at a time.
       const targetEl = screen.getByText(menuName);
 
       expect(targetEl).toBeInTheDocument();
@@ -59,10 +57,53 @@ describe('navigation items rendering', () => {
   );
 });
 
-function render(path: string) {
+describe('user identity rendering', () => {
+  test('shows display primary over username and suppresses secondary', () => {
+    render('/', {
+      userName: '123456',
+      displayPrimary: 'Jane Garcia',
+      displaySecondary: 'jane@example.com',
+    });
+
+    expect(screen.getByText('Jane Garcia')).toBeInTheDocument();
+    expect(screen.getByText('123456')).toBeInTheDocument();
+    expect(screen.queryByText('jane@example.com')).not.toBeInTheDocument();
+    expect(screen.getByText('J')).toBeInTheDocument();
+  });
+
+  test('shows username over secondary when primary is absent', () => {
+    render('/', {
+      userName: 'casey',
+      displaySecondary: 'casey@example.com',
+    });
+
+    expect(screen.getByText('casey')).toBeInTheDocument();
+    expect(screen.getByText('casey@example.com')).toBeInTheDocument();
+    expect(screen.getByText('C')).toBeInTheDocument();
+  });
+
+  test('shows username only when display values are absent', () => {
+    render('/', { userName: 'llama' });
+
+    expect(screen.getAllByText('llama')).toHaveLength(1);
+    expect(screen.getByText('L')).toBeInTheDocument();
+  });
+});
+
+type UserContextOverrides = Partial<{
+  userName: string;
+  displayPrimary: string;
+  displaySecondary: string;
+}>;
+
+function render(path: string, userContext: UserContextOverrides = {}) {
   const ctx = new TeleportContext();
 
   ctx.storeUser.state = makeUserContext({
+    userName: 'llama',
+    displayPrimary: '',
+    displaySecondary: '',
+    ...userContext,
     cluster: {
       name: 'test-cluster',
       lastConnected: Date.now(),
@@ -73,7 +114,7 @@ function render(path: string) {
     <MemoryRouter initialEntries={[path]}>
       <TeleportContextProvider ctx={ctx}>
         <FeaturesContextProvider value={getOSSFeatures()}>
-          <UserMenuNav username="llama" />
+          <UserMenuNav />
         </FeaturesContextProvider>
       </TeleportContextProvider>
     </MemoryRouter>

--- a/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.tsx
+++ b/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.tsx
@@ -19,9 +19,10 @@
 import { useRef, useState } from 'react';
 import styled, { useTheme } from 'styled-components';
 
-import { Box, Text } from 'design';
+import { Box } from 'design';
 import { ChevronDown, Logout as LogoutIcon, Moon, Sun } from 'design/Icon';
 import { Theme } from 'gen-proto-ts/teleport/userpreferences/v1/theme_pb';
+import { UserDisplayName } from 'shared/components/UserDisplayName';
 import { useRefClickOutside } from 'shared/hooks/useRefClickOutside';
 
 import { useTeleport } from 'teleport';
@@ -41,10 +42,6 @@ import session from 'teleport/services/websession';
 import { getCurrentTheme, getNextTheme } from 'teleport/ThemeProvider';
 import { DeviceTrustStatus } from 'teleport/TopBar/DeviceTrustStatus';
 import { useUser } from 'teleport/User/UserContext';
-
-interface UserMenuNavProps {
-  username: string;
-}
 
 const USER_MENU_DROPDOWN_ID = 'tb-user-menu';
 
@@ -71,10 +68,7 @@ const UserInfo = styled.div`
   outline: none;
 `;
 
-const Username = styled(Text)`
-  color: ${props => props.theme.colors.text.main};
-  font-size: 14px;
-  font-weight: 400;
+const CornerUserDisplay = styled(UserDisplayName)`
   display: none;
   @media screen and (min-width: ${p => p.theme.breakpoints.large}) {
     display: inline-flex;
@@ -117,7 +111,7 @@ const Arrow = styled.div<{ open?: boolean }>`
   }
 `;
 
-export function UserMenuNav({ username }: UserMenuNavProps) {
+export function UserMenuNav() {
   const [open, setOpen] = useState(false);
   const theme = useTheme();
 
@@ -127,6 +121,8 @@ export function UserMenuNav({ username }: UserMenuNavProps) {
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const ctx = useTeleport();
+  const username = ctx.storeUser.state.username;
+  const { displayPrimary, displaySecondary } = ctx.storeUser.state;
   const clusterId = ctx.storeUser.getClusterId();
   const features = useFeatures();
   const currentTheme = getCurrentTheme(preferences.theme);
@@ -137,8 +133,9 @@ export function UserMenuNav({ username }: UserMenuNavProps) {
     setOpen(false);
   };
 
-  const initial =
-    username && username.length ? username.trim().charAt(0).toUpperCase() : '';
+  const initial = (displayPrimary.trim() || username.trim())
+    .charAt(0)
+    .toUpperCase();
 
   const topMenuItems = features.filter(
     feature => Boolean(feature.topMenuItem) && feature.category === undefined
@@ -197,7 +194,13 @@ export function UserMenuNav({ username }: UserMenuNavProps) {
       >
         <StyledAvatar>{initial}</StyledAvatar>
 
-        <Username>{username}</Username>
+        <CornerUserDisplay
+          username={username}
+          primaryText={displayPrimary}
+          // Suppress secondary text if primary is present to avoid cluttering the corner space.
+          secondaryText={displayPrimary ? undefined : displaySecondary}
+          layout="stacked"
+        />
         <Box ml={3}>
           <DeviceTrustStatus iconOnly />
         </Box>

--- a/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.tsx
+++ b/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.tsx
@@ -135,7 +135,7 @@ export function UserMenuNav() {
     setOpen(false);
   };
 
-  const initial = (displayPrimary.trim() || username.trim())
+  const initial = (displayPrimary?.trim() || username.trim())
     .charAt(0)
     .toUpperCase();
 

--- a/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.tsx
+++ b/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.tsx
@@ -73,6 +73,9 @@ const CornerUserDisplay = styled(UserDisplayName)`
   @media screen and (min-width: ${p => p.theme.breakpoints.large}) {
     display: inline-flex;
   }
+  span {
+    line-height: 1.2;
+  }
 `;
 
 const StyledAvatar = styled.div`
@@ -121,8 +124,7 @@ export function UserMenuNav() {
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const ctx = useTeleport();
-  const username = ctx.storeUser.state.username;
-  const { displayPrimary, displaySecondary } = ctx.storeUser.state;
+  const { displayPrimary, displaySecondary, username } = ctx.storeUser.state;
   const clusterId = ctx.storeUser.getClusterId();
   const features = useFeatures();
   const currentTheme = getCurrentTheme(preferences.theme);

--- a/web/packages/teleport/src/mocks/contexts.ts
+++ b/web/packages/teleport/src/mocks/contexts.ts
@@ -104,6 +104,8 @@ export function getAcl(cfg?: { noAccess: boolean }) {
 export const baseContext = {
   authType: 'local',
   userName: 'llama',
+  displayPrimary: '',
+  displaySecondary: '',
   accessCapabilities: {
     suggestedReviewers: ['george_washington@gmail.com', 'alpha'],
     requestableRoles: ['dev-a', 'dev-b', 'dev-c', 'dev-d'],

--- a/web/packages/teleport/src/services/user/makeUserContext.ts
+++ b/web/packages/teleport/src/services/user/makeUserContext.ts
@@ -36,6 +36,8 @@ export default function makeUserContext(json: any): UserContext {
 
   return {
     username,
+    displayPrimary: json.displayPrimary,
+    displaySecondary: json.displaySecondary,
     authType,
     acl,
     cluster,

--- a/web/packages/teleport/src/services/user/types.ts
+++ b/web/packages/teleport/src/services/user/types.ts
@@ -38,6 +38,10 @@ export interface UserContext {
   authType: AuthType;
   acl: Acl;
   username: string;
+  /** Human-readable name resolved server-side, empty if not distinct from username. */
+  displayPrimary: string;
+  /** Supporting context resolved server-side, usually email. */
+  displaySecondary: string;
   cluster: Cluster;
   accessStrategy: AccessStrategy;
   accessCapabilities: AccessCapabilities;

--- a/web/packages/teleport/src/services/user/user.test.ts
+++ b/web/packages/teleport/src/services/user/user.test.ts
@@ -27,6 +27,8 @@ test('undefined values in context response gives proper default values', async (
   const mockContext = {
     authType: 'local',
     userName: 'foo',
+    displayPrimary: 'Foo User',
+    displaySecondary: 'foo@example.com',
     cluster: {
       name: 'aws',
       lastConnected: new Date('2020-09-26T17:30:23.512876876Z'),
@@ -395,6 +397,8 @@ test('undefined values in context response gives proper default values', async (
 
   expect(response).toEqual({
     username: 'foo',
+    displayPrimary: 'Foo User',
+    displaySecondary: 'foo@example.com',
     authType: 'local',
     acl,
     cluster: {


### PR DESCRIPTION
This PR contributes to [#66993](https://github.com/gravitational/teleport/issues/66993)  by showing the session user's display name in the top-right user menu. When a display primary exists, the corner renders it stacked above the username, and the avatar initial derives from the display primary. Username-only users render exactly as today. 

The following changes were made:

- **Backend (`ui.UserContext`):** Added `displayPrimary`/`displaySecondary` to the `/webapi/sites/:site/context` response, populated from `user.GetDisplay()` in `NewUserContext`. 

- **Web UI (`UserMenuNav`):** The corner now renders the shared `UserDisplayName` component in `stacked` layout: display primary on top with the username below, or username with the secondary below when only a secondary exists. 

## Screenshot

<img width="394" height="261" alt="Screenshot 2026-07-06 at 9 46 57 PM" src="https://github.com/user-attachments/assets/9beab3f3-2b6c-4239-b5aa-f867f5134ffa" />


## Manual Test Plan
### Test Environment

- A local cluster

### Test Cases

- [x] Verify the user display renders primary + username correctly
   1. Make sure your logged-in user has the `displayName` trait set.
   2. Refresh the page to verify the top-right user display has 2 lines of display values: the value from the `displayName` trait on top and the username on the 2nd line.

- [x] Verify the user display renders username + secondary correctly
   1. Make sure your logged-in user has the `email` trait set (with the previously set `displayName` trait removed).
   2. Refresh the page to verify the top-right user display has 2 lines of display values: the username on the 1st line and the value from the `email` trait on the 2nd line.


changelog: The Web UI top bar now shows the user's display name above the username in the user menu when one is available