### PR TITLE
Make `scopes.MakeResourceCursor` infallible

### DIFF
--- a/lib/scopes/cursor.go
+++ b/lib/scopes/cursor.go
@@ -17,6 +17,7 @@
 package scopes
 
 import (
+	"encoding/hex"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -59,19 +60,29 @@ func IsScopedResourceCursor(cursor string) bool {
 //
 //	~scoped/<encoded-scope>/<name>
 //
-// The scope component is encoded with EncodeForKey so that scoped cursors
+// The scope component is encoded with [EncodeForKey] so that scoped cursors
 // preserve scope ordering and can safely use '/' as the cursor separator.
-func MakeResourceCursor(scope, name string) (string, error) {
+//
+// MakeResourceCursor is infallible so that it can back key derivation with no
+// error path (in-memory cache indexes, pagination cursors). A scope that
+// cannot be encoded (which is only possible for invalid stored data) yields a
+// degraded cursor that is deterministic, unique per scope and name, sorts after
+// all valid cursors, and fails [ParseResourceCursor].
+func MakeResourceCursor(scope, name string) string {
 	if scope == "" {
-		return name, nil
+		return name
 	}
 
 	encodedScope, err := EncodeForKey(scope)
 	if err != nil {
-		return "", trace.Wrap(err)
+		// '~' cannot appear in a valid scope encoding (which starts with '+'),
+		// so degraded cursors never collide with valid cursors and sort after
+		// them. The scope is hex-encoded so the cursor's scope component is a
+		// single path segment regardless of the scope's contents.
+		encodedScope = "~invalid+" + hex.EncodeToString([]byte(scope))
 	}
 
-	return ResourceCursorPrefix + encodedScope + separator + name, nil
+	return ResourceCursorPrefix + encodedScope + separator + name
 }
 
 // ParseResourceCursor parses a resource cursor produced by [MakeResourceCursor]

--- a/lib/scopes/cursor_test.go
+++ b/lib/scopes/cursor_test.go
@@ -27,8 +27,7 @@ func TestResourceCursor(t *testing.T) {
 	t.Parallel()
 
 	t.Run("unscoped", func(t *testing.T) {
-		cursor, err := MakeResourceCursor("", "name")
-		require.NoError(t, err)
+		cursor := MakeResourceCursor("", "name")
 		require.Equal(t, "name", cursor)
 		require.False(t, IsScopedResourceCursor(cursor))
 
@@ -38,8 +37,7 @@ func TestResourceCursor(t *testing.T) {
 	})
 
 	t.Run("scoped", func(t *testing.T) {
-		cursor, err := MakeResourceCursor("/aa/bb", "name")
-		require.NoError(t, err)
+		cursor := MakeResourceCursor("/aa/bb", "name")
 		require.True(t, IsScopedResourceCursor(cursor))
 		require.Contains(t, cursor, ResourceCursorPrefix)
 
@@ -71,6 +69,28 @@ func TestParseResourceCursorErrors(t *testing.T) {
 	}
 }
 
+func TestResourceCursorInvalidScope(t *testing.T) {
+	t.Parallel()
+
+	// A scope that cannot be encoded safely, e.g. read from invalid stored
+	// data. The cursor is degraded but still deterministic and unique.
+	badScope := "/foo bar"
+	cursor := MakeResourceCursor(badScope, "name")
+
+	// Degraded cursors sort after all valid cursors so the affected resource
+	// ranges at the end of the logical resource stream.
+	require.Greater(t, cursor, MakeResourceCursor("", "zzzz"))
+	require.Greater(t, cursor, MakeResourceCursor("/zz/zz", "zzzz"))
+
+	// Unique per scope and name.
+	require.NotEqual(t, cursor, MakeResourceCursor(badScope, "other"))
+	require.NotEqual(t, cursor, MakeResourceCursor("/other bad scope", "name"))
+
+	// Degraded cursors cannot be parsed back into a scope-qualified name.
+	_, err := ParseResourceCursor(cursor)
+	require.Error(t, err)
+}
+
 func TestResourceCursorSort(t *testing.T) {
 	t.Parallel()
 
@@ -85,9 +105,7 @@ func TestResourceCursorSort(t *testing.T) {
 
 	cursors := make([]string, 0, len(resources))
 	for _, resource := range resources {
-		cursor, err := MakeResourceCursor(resource.Scope, resource.Name)
-		require.NoError(t, err)
-		cursors = append(cursors, cursor)
+		cursors = append(cursors, MakeResourceCursor(resource.Scope, resource.Name))
 	}
 
 	slices.Sort(cursors)

--- a/lib/services/local/generic/scopeaware_test.go
+++ b/lib/services/local/generic/scopeaware_test.go
@@ -120,8 +120,7 @@ func TestScopeAwareService(t *testing.T) {
 
 		expected := make(map[scopes.QualifiedName]struct{})
 		for _, resource := range resources {
-			cursor, err := scopes.MakeResourceCursor(resource.GetScope(), resource.GetName())
-			require.NoError(t, err)
+			cursor := scopes.MakeResourceCursor(resource.GetScope(), resource.GetName())
 			if startKey != "" && cursor < startKey {
 				continue
 			}
@@ -170,8 +169,7 @@ func TestScopeAwareService(t *testing.T) {
 
 		// Verify a range that starts in unscoped resources and ends in scoped
 		// resources, forcing Resources to concatenate both underlying services.
-		scopedEnd, err := scopes.MakeResourceCursor("/base1", "name0")
-		require.NoError(t, err)
+		scopedEnd := scopes.MakeResourceCursor("/base1", "name0")
 		checkExpectedResources(t,
 			expectedResourcesInCursorRange(t, "name5", scopedEnd),
 			service.Resources(t.Context(), "name5", scopedEnd),
@@ -423,10 +421,8 @@ func TestScopeAwareService_ScopedOnly(t *testing.T) {
 		require.Empty(t, collectScopedStream(t, svc.Resources(ctx, "", "name5")))
 		require.Empty(t, collectScopedStream(t, svc.Resources(ctx, "", scopes.ResourceCursorScopedStart())))
 
-		start, err := scopes.MakeResourceCursor("/b", "2")
-		require.NoError(t, err)
-		end, err := scopes.MakeResourceCursor("/c", "3")
-		require.NoError(t, err)
+		start := scopes.MakeResourceCursor("/b", "2")
+		end := scopes.MakeResourceCursor("/c", "3")
 		require.Equal(t,
 			[]scopes.QualifiedName{{Scope: "/b", Name: "2"}},
 			scopedNames(collectScopedStream(t, svc.Resources(ctx, start, end))),


### PR DESCRIPTION
We use the resource cursor when determining the key for SortCache/Cache and the index func taken by SortCache does not permit propagation of errors. This left us in an awkward position when integrating scoped resources into the Cache where we had an error from `scopes.MakeResourceCursor` but no way to propagate/handle it.

This PR modifies `scopes.MakeResourceCursor` to be infallible. There is some simple fallback logic here to account for cases where the scope is invalid, however, if callers heed the advice to ensure that the scope has already passed weak validation, this fallback logic will never be invoked.

Not currently depended on by any merged code.