### PR TITLE
Use string.Fields for checkSCPAllowed()

### DIFF
--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -35,7 +35,6 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/mattn/go-shellwords"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
@@ -378,10 +377,7 @@ func (e *localExec) transformSecureCopy() error {
 func checkSCPAllowed(scx *ServerContext, command string) (bool, error) {
 	// split up command by space to grab the first word. if we don't have anything
 	// it's an interactive shell the user requested and not scp, return
-	args, err := shellwords.Parse(command)
-	if err != nil {
-		return false, trace.Wrap(err)
-	}
+	args := strings.Fields(command)
 	if len(args) == 0 {
 		return false, nil
 	}

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -194,6 +194,11 @@ func TestCheckSCPAllowed(t *testing.T) {
 			command: "\tscp foo bar",
 			assert:  require.True,
 		},
+		{
+			name:    "other bash commands aren't affected",
+			command: "echo $((1+1))",
+			assert:  require.False,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Follow-up to #67526. This change updates checkSCPAllowed() to use `strings.Fields()` instead of `shellwords.Parse()`, as the latter can't parse some bash commands (e.g. `echo $((1+1))`) and would block acceptable command invocations.

Changelog: Fixed file copying permission check blocking some valid commands

## Manual Test Plan
### Test Environment

Local cluster with a user. File copying must be disabled either in the user's role or the ssh_service config.

### Test Cases
- [x] Verify that running `echo -n 'C0644 8 foo.txt\nabcdefgh\0' | tsh ssh node " scp -t $PWD/foo.txt"` does *not* create the file `foo.txt` in the current directory.
- [x] Verify that running a non-scp exec command succeeds (test something weird like `tsh ssh node 'echo $((1+1))'`)
