### PR TITLE
Record Sub CA prometheus metrics

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -181,6 +181,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/regular"
 	"github.com/gravitational/teleport/lib/srv/transport/transportv1"
 	"github.com/gravitational/teleport/lib/sshutils"
+	"github.com/gravitational/teleport/lib/subca"
 	"github.com/gravitational/teleport/lib/system"
 	"github.com/gravitational/teleport/lib/tlsca"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
@@ -3085,6 +3086,11 @@ func (process *TeleportProcess) initAuthService() error {
 		}
 		logger.InfoContext(process.ExitContext(), "Exited.")
 	})
+
+	if err := subca.RegisterMetrics(process.metricsRegistry); err != nil {
+		return trace.Wrap(err)
+	}
+
 	return nil
 }
 

--- a/lib/subca/ca_override_resolver.go
+++ b/lib/subca/ca_override_resolver.go
@@ -18,7 +18,9 @@ package subca
 
 import (
 	"context"
+	"strconv"
 	"sync"
+	"time"
 
 	"github.com/gravitational/trace"
 
@@ -81,10 +83,17 @@ func LoadCAOverrideResolver(
 	caGetter CAOverrideGetter,
 	isEnterpriseBuild bool,
 	id types.CertAuthorityOverrideID,
-) (*CAOverrideResolver, error) {
+) (_ *CAOverrideResolver, err error) {
 	if !isEnterpriseBuild {
 		return &CAOverrideResolver{}, nil
 	}
+
+	start := time.Now()
+	defer func() {
+		overrideReadHist.
+			WithLabelValues(id.CAType, resultFromError(err)).
+			Observe(time.Since(start).Seconds())
+	}()
 
 	parsed, isNotFound, err := getParsedCAOverride(ctx, caGetter, id)
 	if isNotFound {
@@ -163,10 +172,19 @@ func (res *CalculateOverrideResult) ToClientOverrideDetailsProto() *proto.CAOver
 //
 // Useful to determine current/active CA certificates. For more details on each
 // override, use [CAOverrideResolver.CalculateOverride].
-func (c *CAOverrideResolver) ApplyOverrides(certPEMs [][]byte) ([][]byte, error) {
+func (c *CAOverrideResolver) ApplyOverrides(certPEMs [][]byte) (_ [][]byte, err error) {
 	if !c.overridesActive {
 		return certPEMs, nil
 	}
+
+	start := time.Now()
+	defer func() {
+		caType := c.parsed.CAOverride.GetSubKind()
+		numCerts := strconv.Itoa(len(certPEMs))
+		overrideApplyHist.
+			WithLabelValues(caType, numCerts, resultFromError(err)).
+			Observe(time.Since(start).Seconds())
+	}()
 
 	overridePEMs := make([][]byte, len(certPEMs))
 	for i, certPEM := range certPEMs {
@@ -185,13 +203,22 @@ func (c *CAOverrideResolver) ApplyOverrides(certPEMs [][]byte) ([][]byte, error)
 // Returns a result with the CA certificate and chain to be used, with either
 // the input certificate or the one acquired from an active, matching CA
 // certificate override.
-func (c *CAOverrideResolver) CalculateOverride(caCert Certificate) (*CalculateOverrideResult, error) {
+func (c *CAOverrideResolver) CalculateOverride(caCert Certificate) (_ *CalculateOverrideResult, err error) {
 	switch {
 	case len(caCert.PEM) == 0:
 		return nil, trace.BadParameter("caCert required")
 	case !c.overridesActive:
 		return &CalculateOverrideResult{CACertificate: caCert}, nil
 	}
+
+	start := time.Now()
+	defer func() {
+		caType := c.parsed.CAOverride.GetSubKind()
+		const numCerts = "1"
+		overrideApplyHist.
+			WithLabelValues(caType, numCerts, resultFromError(err)).
+			Observe(time.Since(start).Seconds())
+	}()
 
 	const skipCAChain = false
 	return c.calculateOverride(caCert, skipCAChain)

--- a/lib/subca/ca_override_resolver_test.go
+++ b/lib/subca/ca_override_resolver_test.go
@@ -17,10 +17,15 @@
 package subca_test
 
 import (
+	"bytes"
 	"crypto/x509"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/common/expfmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -609,4 +614,112 @@ func TestCAOverrideResolver_CalculateOverride(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCAOverrideResolver_metrics(t *testing.T) {
+	// Don't t.Parallel, metrics are global.
+
+	const (
+		readMetricName  = "teleport_ca_override_read_seconds"
+		applyMetricName = "teleport_ca_override_apply_seconds"
+	)
+
+	subca.OverrideReadHist.Reset()
+	subca.OverrideApplyHist.Reset()
+
+	const caType = types.WindowsCA
+	env := subcaenv.New(t, subcaenv.EnvParams{
+		CATypesToCreate: []types.CertAuthType{
+			caType,
+		},
+	})
+	clusterName := env.ClusterName
+	subCA := env.SubCA
+
+	// Read CA so we have a potential overridden cert.
+	const loadKeys = false
+	ca, err := env.Trust.GetCertAuthority(t.Context(), types.CertAuthID{
+		Type:       caType,
+		DomainName: env.ClusterName,
+	}, loadKeys)
+	require.NoError(t, err)
+	caCertPEM := ca.GetActiveKeys().TLS[0].Cert
+
+	_, unrelatedCertPEM, err := tlscatest.GenerateSelfSignedCA(tlscatest.GenerateCAConfig{
+		ClusterName: clusterName,
+	})
+	require.NoError(t, err)
+
+	// runOverrides runs the Load, Apply and Calculate functions so we can
+	// assert their effects on the metrics.
+	runOverrides := func(t *testing.T) {
+		t.Helper()
+
+		const isEnterprise = true
+		r, err := subca.LoadCAOverrideResolver(t.Context(), subCA, isEnterprise, types.CertAuthorityOverrideID{
+			ClusterName: clusterName,
+			CAType:      string(caType),
+		})
+		require.NoError(t, err)
+		// 2 certs so it creates a distinct metric count.
+		_, err = r.ApplyOverrides([][]byte{caCertPEM, unrelatedCertPEM})
+		require.NoError(t, err)
+		_, err = r.CalculateOverride(subca.Certificate{PEM: caCertPEM})
+		require.NoError(t, err)
+	}
+
+	t.Run("no overrides", func(t *testing.T) {
+		runOverrides(t)
+
+		collectAndCompareCount(t, subca.OverrideReadHist, readMetricName, `
+teleport_ca_override_read_seconds_count{ca_type="windows",result="success"} 1
+`)
+		// No applies recorded.
+		collectAndCompareCount(t, subca.OverrideApplyHist, applyMetricName, ``)
+	})
+
+	t.Run("active overrides", func(t *testing.T) {
+		// Create an active override.
+		caOverride := env.NewOverrideForCAType(t, caType)
+		for _, co := range caOverride.GetSpec().GetCertificateOverrides() {
+			co.SetDisabled(false)
+		}
+		_, err = subCA.CreateCertAuthorityOverride(t.Context(), caOverride)
+		require.NoError(t, err)
+
+		runOverrides(t)
+
+		// +1 read
+		collectAndCompareCount(t, subca.OverrideReadHist, readMetricName, `
+teleport_ca_override_read_seconds_count{ca_type="windows",result="success"} 2
+`)
+		// +2 applies: count=1 (CalculateOverride) and count=2 (ApplyOverrides).
+		collectAndCompareCount(t, subca.OverrideApplyHist, applyMetricName, `
+teleport_ca_override_apply_seconds_count{ca_type="windows",num_certificates="1",result="success"} 1
+teleport_ca_override_apply_seconds_count{ca_type="windows",num_certificates="2",result="success"} 1
+`)
+	})
+}
+
+func collectAndCompareCount(t *testing.T, col prometheus.Collector, metricName, want string) {
+	t.Helper()
+
+	val, err := testutil.CollectAndFormat(col, expfmt.TypeTextPlain, metricName)
+	require.NoError(t, err)
+
+	countName := []byte(metricName + "_count")
+
+	var buf strings.Builder
+	buf.WriteRune('\n') // start with a newline to mimic usual prometheus asserts
+	for line := range bytes.Lines(val) {
+		if bytes.HasPrefix(line, countName) {
+			buf.Write(line)
+		}
+	}
+	if buf.Len() == 1 {
+		buf.Reset() // Only \n present, so the output is empty.
+	}
+
+	got := buf.String()
+	assert.Empty(t, cmp.Diff(want, got))
 }

--- a/lib/subca/export_test.go
+++ b/lib/subca/export_test.go
@@ -1,0 +1,20 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package subca
+
+var OverrideReadHist = overrideReadHist
+var OverrideApplyHist = overrideApplyHist

--- a/lib/subca/metrics.go
+++ b/lib/subca/metrics.go
@@ -1,0 +1,58 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package subca
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/observability/metrics"
+)
+
+const metricSubsystem = "ca"
+
+var (
+	overrideReadHist = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: teleport.MetricNamespace,
+		Subsystem: metricSubsystem,
+		Name:      "override_read_seconds",
+		Help:      "Measures the impact of reading and parsing CA overrides",
+		Buckets:   prometheus.DefBuckets,
+	}, []string{"ca_type", "result"})
+
+	overrideApplyHist = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: teleport.MetricNamespace,
+		Subsystem: metricSubsystem,
+		Name:      "override_apply_seconds",
+		Help:      "Measures the impact of applying certificate overrides to CA certificates",
+		Buckets:   prometheus.DefBuckets,
+	}, []string{"ca_type", "num_certificates", "result"})
+)
+
+func init() {
+	metrics.RegisterPrometheusCollectors(
+		overrideReadHist,
+		overrideApplyHist,
+	)
+}
+
+func resultFromError(err error) string {
+	if err == nil {
+		return "success"
+	}
+	return "error"
+}

--- a/lib/subca/metrics.go
+++ b/lib/subca/metrics.go
@@ -17,6 +17,7 @@
 package subca
 
 import (
+	"github.com/gravitational/trace"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/gravitational/teleport"
@@ -43,11 +44,12 @@ var (
 	}, []string{"ca_type", "num_certificates", "result"})
 )
 
-func init() {
-	metrics.RegisterPrometheusCollectors(
+// RegisterMetrics registers subca prometheus metrics.
+func RegisterMetrics(registerer prometheus.Registerer) error {
+	return trace.Wrap(metrics.RegisterCollectors(registerer,
 		overrideReadHist,
 		overrideApplyHist,
-	)
+	))
 }
 
 func resultFromError(err error) string {


### PR DESCRIPTION
Add metrics to track CA override impact in serving.

Namely:
* teleport_ca_override_read_seconds: time to load and parse CA overrides.
* teleport_ca_override_apply_seconds: time to apply overrides to certificates.

This differs a bit from the [RFD design][1], as the implementation ended up having two distinct stages, so we cannot simply measure applies. This is because multiple applies may happen from a single load (for example, in certain DB access flows).

https://github.com/gravitational/teleport.e/issues/7675

[1]: https://github.com/gravitational/teleport/blob/master/rfd/0237-sub-ca-support.md#observability