### PR TITLE
tctl acl update: add safety against silent role field or list grant overwrite

### DIFF
--- a/tool/tctl/common/accesslist/compare.go
+++ b/tool/tctl/common/accesslist/compare.go
@@ -1,0 +1,118 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package accesslist
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+)
+
+// topLevelRoleConditionMismatches walks each field of the "got" and "want"
+// conditions, compares value and returns a list of mismatched values as
+// JSON field names.
+//
+// This function treats nils and empty values as equivalent eg:
+//
+//	nil == []string{} or nil == &types.AccessRequestConditions{}
+//
+// However, since only the top level fields are traversed, nested empty objects
+// are considered mismatches eg:
+//
+//	 &types.AccessRequestConditions{
+//		Reason: &types.AccessRequestConditionsReason{},
+//	 }
+//
+// This was a trade off accepted to keep this function simple.
+//
+// DeepEqual is used where element ordering will matter. But there are assumptions
+// made when using this func:
+//   - for deny conditions, ANY non-empty deny field is unsupported
+//   - for allow conditions, the supported fields from "got" is copied into "want" so
+//     ordering will be the same
+func topLevelRoleConditionMismatches(want types.RoleConditions, got types.RoleConditions) []string {
+	gotValue := reflect.ValueOf(got)
+	wantValue := reflect.ValueOf(want)
+	gotType := gotValue.Type()
+
+	var mismatches []string
+	for i := 0; i < gotValue.NumField(); i++ {
+		gotTypeField := gotType.Field(i)
+
+		// Ignore protobuf fields ("got" roles are grpc fetched)
+		if strings.HasPrefix(gotTypeField.Name, "XXX_") {
+			continue
+		}
+
+		gotField := gotValue.Field(i)
+		wantField := wantValue.Field(i)
+		if isEmptyField(gotField) && isEmptyField(wantField) {
+			continue
+		}
+
+		if reflect.DeepEqual(gotField.Interface(), wantField.Interface()) {
+			continue
+		}
+
+		mismatches = append(mismatches, jsonFieldName(gotTypeField))
+	}
+
+	return mismatches
+}
+
+func nonEmptyGrantFields(got accesslist.Grants) []string {
+	gotValue := reflect.ValueOf(got)
+	gotType := gotValue.Type()
+
+	mismatches := []string{}
+	for i := 0; i < gotValue.NumField(); i++ {
+		field := gotType.Field(i)
+		gotField := gotValue.Field(i)
+
+		// Role field is checked outside of this func for better
+		// error message handling, so it's skipped here.
+		if field.Name == "Roles" {
+			continue
+		}
+		if !isEmptyField(gotField) {
+			mismatches = append(mismatches, jsonFieldName(field))
+		}
+	}
+
+	return mismatches
+}
+
+func isEmptyField(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Slice, reflect.Map:
+		return v.Len() == 0
+	case reflect.Pointer:
+		return v.IsNil() || v.Elem().IsZero()
+	default:
+		return v.IsZero()
+	}
+}
+
+func jsonFieldName(field reflect.StructField) string {
+	name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+	if name == "" || name == "-" {
+		return field.Name
+	}
+	return name
+}

--- a/tool/tctl/common/accesslist/update.go
+++ b/tool/tctl/common/accesslist/update.go
@@ -18,8 +18,8 @@ package accesslist
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -41,10 +41,7 @@ import (
 )
 
 // Safeguard against older role versions that may have unsupported fields.
-const minimumRoleVersion = types.V8
-
-const editingResourceAccessErrStartText = "the role Teleport created for this list has fields this command doesn't manage."
-const editingResourceAccessErrLastText = "to either apply this resource-access change directly, or clear the role's spec and retry."
+const minimumRoleVersion = 8
 
 // Update handles `tctl acl update`.
 func (c *Command) Update(ctx context.Context, client *authclient.Client) error {
@@ -464,64 +461,85 @@ func getAccessRoleByName(ctx context.Context, client *authclient.Client, roleNam
 	return roleV6, nil
 }
 
+func roleDenyMismatchError(roleName string) error {
+	return trace.BadParameter("the role Teleport created for this list has deny fields not supported by this update.\n"+
+		"Use `tctl edit role/%s` to clear `spec.deny`, then retry; or edit the role directly.",
+		roleName)
+}
+
+func roleAllowMismatchError(roleName string, unsupportedFields []string) error {
+	return trace.BadParameter("the role Teleport created for this list has allow fields not supported by this update: %s.\n"+
+		"Use `tctl edit role/%s` to clear those fields or `spec`, then retry; or edit the role directly.",
+		strings.Join(unsupportedFields, ", "), roleName)
+}
+
+func unknownRoleGrants(unknownRoles []string, accessListID string, field string) error {
+	return trace.BadParameter(
+		"resource access changes cannot be applied; this list grants roles this command doesn't update: %s.\n"+
+			"Use `tctl edit access_list/%s` to remove those roles from %q field, then retry; or edit the access list directly.",
+		strings.Join(unknownRoles, ", "), accessListID, field,
+	)
+}
+
+func unsupportedGrantFields(unsupportedFields []string, accessListID string, field string) error {
+	return trace.BadParameter(
+		"resource access changes cannot be applied; this list has grant fields not supported by this update: %s.\n"+
+			"Use `tctl edit access_list/%s` to clear those fields from %q, then retry; or edit the access list directly.",
+		strings.Join(unsupportedFields, ", "), accessListID, field,
+	)
+}
+
 // rejectUnknownGrants returns an error if an unknown role exists in the
-// access list preset label or in the member/owner grant roles. Also rejects
-// if any grant fields other than "roles" were defined. This helps in avoiding
-// silent dropping of unsupported fields when updating.
+// member/owner grant roles. Also rejects if any grant fields other than
+// "roles" were defined. This helps in avoiding silent dropping of
+// unsupported fields when updating.
 func rejectUnknownGrants(al *accesslist.AccessList) error {
 	reviewerRole := accesslist.RoleName(preset.RoleReviewerPrefix, al.GetName())
 	requesterRole := accesslist.RoleName(preset.RoleRequesterPrefix, al.GetName())
 	standardRole := accesslist.RoleName(standardRolePrefixName, al.GetName())
 	awsicRole := accesslist.RoleName(awsicRolePrefixName, al.GetName())
 
-	knownRoles := map[string]struct{}{
-		reviewerRole: {}, requesterRole: {}, standardRole: {}, awsicRole: {},
-	}
-
-	hasUnknownRole := func(roles []string) bool {
-		for _, name := range roles {
-			if _, ok := knownRoles[name]; !ok {
-				return true
+	unknownRoles := func(validRoles []string, gotRoles []string) []string {
+		unknownRoles := []string{}
+		for _, roleName := range gotRoles {
+			if !slices.Contains(validRoles, roleName) {
+				unknownRoles = append(unknownRoles, roleName)
 			}
 		}
-		return false
+		return unknownRoles
 	}
 
 	var validMemberRoles []string
 	var validOwnerRoles []string
 
-	assignedPresetRoles := al.PresetRoleNames()
 	switch al.GetAllLabels()[accesslist.AccessListPresetLabel] {
 	case string(accesslist.ShortTermPresetType):
 		validMemberRoles = []string{requesterRole}
 		validOwnerRoles = []string{reviewerRole}
 
 	case string(accesslist.LongTermPresetType):
-		if slices.Contains(assignedPresetRoles, standardRole) {
-			validMemberRoles = append(validMemberRoles, standardRole)
-		}
-		if slices.Contains(assignedPresetRoles, awsicRole) {
-			validMemberRoles = append(validMemberRoles, awsicRole)
-		}
+		validMemberRoles = []string{standardRole, awsicRole}
 		validOwnerRoles = []string{reviewerRole}
 	}
 
-	validGrants := accesslist.Grants{
-		Roles: validMemberRoles,
+	// Fail if unknown roles exists in any grants.
+	unknownMemberRoles := unknownRoles(validMemberRoles, al.Spec.Grants.Roles)
+	if len(unknownMemberRoles) > 0 {
+		return unknownRoleGrants(unknownMemberRoles, al.GetName(), "spec.grants.roles")
 	}
-	validOwnerGrants := accesslist.Grants{
-		Roles: validOwnerRoles,
+	unknownOwnerRoles := unknownRoles(validOwnerRoles, al.Spec.OwnerGrants.Roles)
+	if len(unknownOwnerRoles) > 0 {
+		return unknownRoleGrants(unknownOwnerRoles, al.GetName(), "spec.owner_grants.roles")
 	}
 
-	unsupported := hasUnknownRole(assignedPresetRoles) ||
-		!reflect.DeepEqual(al.Spec.Grants, validGrants) ||
-		!reflect.DeepEqual(al.Spec.OwnerGrants, validOwnerGrants)
-
-	if unsupported {
-		return trace.BadParameter(
-			"resource-access changes cannot be applied; this list has grants this command doesn't manage.\nUse `tctl edit access_list/%s` to clear (reset) them and retry, or edit the role directly with `tctl edit role/<role-name>`",
-			al.GetName(),
-		)
+	// Fail if any other fields (other than roles) are defined.
+	grantMismatches := nonEmptyGrantFields(al.Spec.Grants)
+	if len(grantMismatches) > 0 {
+		return unsupportedGrantFields(grantMismatches, al.GetName(), "spec.grants")
+	}
+	ownerGrantMismatches := nonEmptyGrantFields(al.Spec.OwnerGrants)
+	if len(ownerGrantMismatches) > 0 {
+		return unsupportedGrantFields(ownerGrantMismatches, al.GetName(), "spec.owner_grants")
 	}
 	return nil
 }
@@ -542,28 +560,25 @@ func getEmptyRoleV6(roleName, roleVersion string) (*types.RoleV6, error) {
 
 // validateAWSICRoleSpec returns an error if any deny fields got set or if any other allow fields
 // other than ones allowed are set.
-func validateAWSICRoleSpec(roleName string, emptyRoleV6WithDefaults *types.RoleV6, gotAllow types.RoleConditions, gotDeny types.RoleConditions) error {
-	err := trace.BadParameter(
-		"%s\nUse `tctl edit role/%s` %s",
-		editingResourceAccessErrStartText, roleName, editingResourceAccessErrLastText,
-	)
-
-	if !reflect.DeepEqual(gotDeny, emptyRoleV6WithDefaults.Spec.Deny) {
-		return err
+func validateAWSICRoleSpec(roleName string, wantWithDefaults *types.RoleV6, gotAllow types.RoleConditions, gotDeny types.RoleConditions) error {
+	denyMismatches := topLevelRoleConditionMismatches(wantWithDefaults.Spec.Deny, gotDeny)
+	if len(denyMismatches) > 0 {
+		return roleDenyMismatchError(roleName)
 	}
 
 	// Empty allow is valid.
-	if reflect.DeepEqual(gotAllow, emptyRoleV6WithDefaults.Spec.Allow) {
+	allowMismatches := topLevelRoleConditionMismatches(wantWithDefaults.Spec.Allow, gotAllow)
+	if len(allowMismatches) == 0 {
 		return nil
 	}
 
-	validAllow := emptyRoleV6WithDefaults.Spec.Allow
+	validAllow := wantWithDefaults.Spec.Allow
 	// Set allowed fields:
 	validAllow.AppLabels = awsIcAppLabel
 	validAllow.AccountAssignments = gotAllow.AccountAssignments
-
-	if !reflect.DeepEqual(gotAllow, validAllow) {
-		return err
+	allowMismatches = topLevelRoleConditionMismatches(validAllow, gotAllow)
+	if len(allowMismatches) > 0 {
+		return roleAllowMismatchError(roleName, allowMismatches)
 	}
 
 	return nil
@@ -571,8 +586,8 @@ func validateAWSICRoleSpec(roleName string, emptyRoleV6WithDefaults *types.RoleV
 
 // validateStandardRoleSpec returns an error if any deny fields got set or if any other allow fields
 // other than ones allowed are set.
-func validateStandardRoleSpec(roleName string, emptyRoleV6WithDefaults *types.RoleV6, gotAllow types.RoleConditions, gotDeny types.RoleConditions) error {
-	validAllow := emptyRoleV6WithDefaults.Spec.Allow
+func validateStandardRoleSpec(roleName string, wantWithDefaults *types.RoleV6, gotAllow types.RoleConditions, gotDeny types.RoleConditions) error {
+	validAllow := wantWithDefaults.Spec.Allow
 	// Set allowed fields:
 	validAllow.NodeLabels = gotAllow.NodeLabels
 	validAllow.Logins = gotAllow.Logins
@@ -592,45 +607,58 @@ func validateStandardRoleSpec(roleName string, emptyRoleV6WithDefaults *types.Ro
 	validAllow.WindowsDesktopLogins = gotAllow.WindowsDesktopLogins
 	validAllow.GitHubPermissions = gotAllow.GitHubPermissions
 
-	if !reflect.DeepEqual(gotDeny, emptyRoleV6WithDefaults.Spec.Deny) || !reflect.DeepEqual(gotAllow, validAllow) {
+	denyMismatches := topLevelRoleConditionMismatches(wantWithDefaults.Spec.Deny, gotDeny)
+	if len(denyMismatches) > 0 {
+		return roleDenyMismatchError(roleName)
+	}
+
+	allowMismatches := topLevelRoleConditionMismatches(validAllow, gotAllow)
+	if len(allowMismatches) > 0 {
+		return roleAllowMismatchError(roleName, allowMismatches)
+	}
+
+	return nil
+}
+
+func supportsRoleVersion(gotVersion string, roleName string) error {
+	roleVersionNumber := func(version string) (int, error) {
+		return strconv.Atoi(strings.TrimPrefix(version, "v"))
+	}
+
+	gotVersionNum, err := roleVersionNumber(gotVersion)
+	if err != nil && !errors.Is(err, strconv.ErrRange) {
 		return trace.BadParameter(
-			"%s\nUse `tctl edit role/%s` %s",
-			editingResourceAccessErrStartText, roleName, editingResourceAccessErrLastText,
+			"resource access changes cannot be applied; role is using an unsupported version %q.\nUse `tctl edit role/%s` to upgrade its version, or edit the role directly.",
+			gotVersion, roleName,
+		)
+	}
+	if gotVersionNum < minimumRoleVersion {
+		return trace.BadParameter(
+			"resource access changes cannot be applied; role is using an unsupported version %q.\nUse `tctl edit role/%s` to upgrade its version, or edit the role directly.",
+			gotVersion, roleName,
+		)
+	}
+
+	defaultVersionNum, err := roleVersionNumber(types.DefaultRoleVersion)
+	if err != nil || gotVersionNum > defaultVersionNum {
+		return trace.BadParameter(
+			"resource access changes cannot be applied; role %q is using an unsupported version %q.\nUpgrade your tctl binary.",
+			roleName, gotVersion,
 		)
 	}
 
 	return nil
 }
 
-func meetsMinRoleVersion(version string) bool {
-	gotVersion, err := strconv.Atoi(strings.TrimPrefix(version, "v"))
-	if err != nil {
-		return false
-	}
-	minVersion, err := strconv.Atoi(strings.TrimPrefix(minimumRoleVersion, "v"))
-	if err != nil {
-		return false
-	}
-	return gotVersion >= minVersion
-}
-
 func validateQueriedRole(prefix string, roleName, roleVersion string, allow, deny types.RoleConditions) error {
 	// Rare: the role predates this feature's minimum version requirement, or
 	// was manually edited to an older version.
-	if !meetsMinRoleVersion(roleVersion) {
-		return trace.BadParameter(
-			"resource-access changes cannot be applied; role is using an unsupported version %q.\nUse `tctl edit role/%s` to upgrade its version, or edit the role directly.",
-			roleVersion, roleName,
-		)
+	if err := supportsRoleVersion(roleVersion, roleName); err != nil {
+		return trace.Wrap(err)
 	}
 	emptyRoleV6WithDefaults, err := getEmptyRoleV6(roleName, roleVersion)
 	if err != nil {
-		// Error is most likely due to a higher role version that this client doesn't recognize.
-		// Requires user to upgrade the tctl binary.
-		return trace.BadParameter(
-			"resource-access changes cannot be applied; role %q is using an unsupported version %q.\nUpgrade your tctl binary.",
-			roleName, roleVersion,
-		)
+		return trace.Wrap(err)
 	}
 	switch prefix {
 	case standardRolePrefixName:

--- a/tool/tctl/common/accesslist/update.go
+++ b/tool/tctl/common/accesslist/update.go
@@ -19,7 +19,9 @@ package accesslist
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -37,6 +39,12 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 	sliceutils "github.com/gravitational/teleport/lib/utils/slices"
 )
+
+// Safeguard against older role versions that may have unsupported fields.
+const minimumRoleVersion = types.V8
+
+const editingResourceAccessErrStartText = "the role Teleport created for this list has fields this command doesn't manage."
+const editingResourceAccessErrLastText = "to either apply this resource-access change directly, or clear the role's spec and retry."
 
 // Update handles `tctl acl update`.
 func (c *Command) Update(ctx context.Context, client *authclient.Client) error {
@@ -326,6 +334,10 @@ func (c *Command) buildOwnersForUpdate(al *accesslist.AccessList) ([]accesslist.
 
 // updateAccessListWithPreset updates an access list spec/meta and its related access roles.
 func (c *Command) updateAccessListWithPreset(ctx context.Context, client *authclient.Client, al *accesslist.AccessList) (*accesslist.AccessList, []string, []string, error) {
+	if err := rejectUnknownGrants(al); err != nil {
+		return nil, nil, nil, trace.Wrap(err)
+	}
+
 	var updatedAccessRoles []*types.RoleV6
 	if !c.removeAccess {
 		var standardRoleUpdateFn applyAccessFlagsToRole
@@ -419,8 +431,17 @@ func resolveAccessRole(ctx context.Context, client *authclient.Client, al *acces
 	}
 
 	if !isAttachedToList {
+		// New role, nothing to validate.
 		role, err = buildRole(prefix, types.RoleConditions{})
 		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	} else {
+		// Existing role, validate that unsupported role fields were not set.
+		// This will happen if a user manually edited the role outside of the editor/command
+		// built for access lists using preset (access-type).
+		// This helps in avoiding unintentional/silent overwrites or dropping of fields (role/grants).
+		if err := validateQueriedRole(prefix, roleName, role.GetVersion(), role.Spec.Allow, role.Spec.Deny); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -441,6 +462,183 @@ func getAccessRoleByName(ctx context.Context, client *authclient.Client, roleNam
 		return nil, trace.BadParameter("role %q has unexpected type %T", roleName, role)
 	}
 	return roleV6, nil
+}
+
+// rejectUnknownGrants returns an error if an unknown role exists in the
+// access list preset label or in the member/owner grant roles. Also rejects
+// if any grant fields other than "roles" were defined. This helps in avoiding
+// silent dropping of unsupported fields when updating.
+func rejectUnknownGrants(al *accesslist.AccessList) error {
+	reviewerRole := accesslist.RoleName(preset.RoleReviewerPrefix, al.GetName())
+	requesterRole := accesslist.RoleName(preset.RoleRequesterPrefix, al.GetName())
+	standardRole := accesslist.RoleName(standardRolePrefixName, al.GetName())
+	awsicRole := accesslist.RoleName(awsicRolePrefixName, al.GetName())
+
+	knownRoles := map[string]struct{}{
+		reviewerRole: {}, requesterRole: {}, standardRole: {}, awsicRole: {},
+	}
+
+	hasUnknownRole := func(roles []string) bool {
+		for _, name := range roles {
+			if _, ok := knownRoles[name]; !ok {
+				return true
+			}
+		}
+		return false
+	}
+
+	var validMemberRoles []string
+	var validOwnerRoles []string
+
+	assignedPresetRoles := al.PresetRoleNames()
+	switch al.GetAllLabels()[accesslist.AccessListPresetLabel] {
+	case string(accesslist.ShortTermPresetType):
+		validMemberRoles = []string{requesterRole}
+		validOwnerRoles = []string{reviewerRole}
+
+	case string(accesslist.LongTermPresetType):
+		if slices.Contains(assignedPresetRoles, standardRole) {
+			validMemberRoles = append(validMemberRoles, standardRole)
+		}
+		if slices.Contains(assignedPresetRoles, awsicRole) {
+			validMemberRoles = append(validMemberRoles, awsicRole)
+		}
+		validOwnerRoles = []string{reviewerRole}
+	}
+
+	validGrants := accesslist.Grants{
+		Roles: validMemberRoles,
+	}
+	validOwnerGrants := accesslist.Grants{
+		Roles: validOwnerRoles,
+	}
+
+	unsupported := hasUnknownRole(assignedPresetRoles) ||
+		!reflect.DeepEqual(al.Spec.Grants, validGrants) ||
+		!reflect.DeepEqual(al.Spec.OwnerGrants, validOwnerGrants)
+
+	if unsupported {
+		return trace.BadParameter(
+			"resource-access changes cannot be applied; this list has grants this command doesn't manage.\nUse `tctl edit access_list/%s` to clear (reset) them and retry, or edit the role directly with `tctl edit role/<role-name>`",
+			al.GetName(),
+		)
+	}
+	return nil
+}
+
+// getEmptyRoleV6 returns an empty role with defaults set.
+func getEmptyRoleV6(roleName, roleVersion string) (*types.RoleV6, error) {
+	emptyRoleWithDefaults, err := types.NewRoleWithVersion(roleName, roleVersion, types.RoleSpecV6{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	roleV6WithDefaults, ok := emptyRoleWithDefaults.(*types.RoleV6)
+	if !ok {
+		return nil, trace.BadParameter("role %q has unexpected type %T", roleName, emptyRoleWithDefaults)
+	}
+
+	return roleV6WithDefaults, nil
+}
+
+// validateAWSICRoleSpec returns an error if any deny fields got set or if any other allow fields
+// other than ones allowed are set.
+func validateAWSICRoleSpec(roleName string, emptyRoleV6WithDefaults *types.RoleV6, gotAllow types.RoleConditions, gotDeny types.RoleConditions) error {
+	err := trace.BadParameter(
+		"%s\nUse `tctl edit role/%s` %s",
+		editingResourceAccessErrStartText, roleName, editingResourceAccessErrLastText,
+	)
+
+	if !reflect.DeepEqual(gotDeny, emptyRoleV6WithDefaults.Spec.Deny) {
+		return err
+	}
+
+	// Empty allow is valid.
+	if reflect.DeepEqual(gotAllow, emptyRoleV6WithDefaults.Spec.Allow) {
+		return nil
+	}
+
+	validAllow := emptyRoleV6WithDefaults.Spec.Allow
+	// Set allowed fields:
+	validAllow.AppLabels = awsIcAppLabel
+	validAllow.AccountAssignments = gotAllow.AccountAssignments
+
+	if !reflect.DeepEqual(gotAllow, validAllow) {
+		return err
+	}
+
+	return nil
+}
+
+// validateStandardRoleSpec returns an error if any deny fields got set or if any other allow fields
+// other than ones allowed are set.
+func validateStandardRoleSpec(roleName string, emptyRoleV6WithDefaults *types.RoleV6, gotAllow types.RoleConditions, gotDeny types.RoleConditions) error {
+	validAllow := emptyRoleV6WithDefaults.Spec.Allow
+	// Set allowed fields:
+	validAllow.NodeLabels = gotAllow.NodeLabels
+	validAllow.Logins = gotAllow.Logins
+	validAllow.DatabaseLabels = gotAllow.DatabaseLabels
+	validAllow.DatabaseUsers = gotAllow.DatabaseUsers
+	validAllow.DatabaseNames = gotAllow.DatabaseNames
+	validAllow.KubernetesLabels = gotAllow.KubernetesLabels
+	validAllow.KubeUsers = gotAllow.KubeUsers
+	validAllow.KubeGroups = gotAllow.KubeGroups
+	validAllow.KubernetesResources = gotAllow.KubernetesResources
+	validAllow.AppLabels = gotAllow.AppLabels
+	validAllow.AWSRoleARNs = gotAllow.AWSRoleARNs
+	validAllow.AzureIdentities = gotAllow.AzureIdentities
+	validAllow.GCPServiceAccounts = gotAllow.GCPServiceAccounts
+	validAllow.MCP = gotAllow.MCP
+	validAllow.WindowsDesktopLabels = gotAllow.WindowsDesktopLabels
+	validAllow.WindowsDesktopLogins = gotAllow.WindowsDesktopLogins
+	validAllow.GitHubPermissions = gotAllow.GitHubPermissions
+
+	if !reflect.DeepEqual(gotDeny, emptyRoleV6WithDefaults.Spec.Deny) || !reflect.DeepEqual(gotAllow, validAllow) {
+		return trace.BadParameter(
+			"%s\nUse `tctl edit role/%s` %s",
+			editingResourceAccessErrStartText, roleName, editingResourceAccessErrLastText,
+		)
+	}
+
+	return nil
+}
+
+func meetsMinRoleVersion(version string) bool {
+	gotVersion, err := strconv.Atoi(strings.TrimPrefix(version, "v"))
+	if err != nil {
+		return false
+	}
+	minVersion, err := strconv.Atoi(strings.TrimPrefix(minimumRoleVersion, "v"))
+	if err != nil {
+		return false
+	}
+	return gotVersion >= minVersion
+}
+
+func validateQueriedRole(prefix string, roleName, roleVersion string, allow, deny types.RoleConditions) error {
+	// Rare: the role predates this feature's minimum version requirement, or
+	// was manually edited to an older version.
+	if !meetsMinRoleVersion(roleVersion) {
+		return trace.BadParameter(
+			"resource-access changes cannot be applied; role is using an unsupported version %q.\nUse `tctl edit role/%s` to upgrade its version, or edit the role directly.",
+			roleVersion, roleName,
+		)
+	}
+	emptyRoleV6WithDefaults, err := getEmptyRoleV6(roleName, roleVersion)
+	if err != nil {
+		// Error is most likely due to a higher role version that this client doesn't recognize.
+		// Requires user to upgrade the tctl binary.
+		return trace.BadParameter(
+			"resource-access changes cannot be applied; role %q is using an unsupported version %q.\nUpgrade your tctl binary.",
+			roleName, roleVersion,
+		)
+	}
+	switch prefix {
+	case standardRolePrefixName:
+		return validateStandardRoleSpec(roleName, emptyRoleV6WithDefaults, allow, deny)
+	case awsicRolePrefixName:
+		return validateAWSICRoleSpec(roleName, emptyRoleV6WithDefaults, allow, deny)
+	}
+	return nil
 }
 
 // UpdateJSONResponse is the structured response for `tctl acl update

--- a/tool/tctl/common/accesslist/update_test.go
+++ b/tool/tctl/common/accesslist/update_test.go
@@ -17,11 +17,16 @@
 package accesslist
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/trait"
+	"github.com/gravitational/teleport/lib/accesslists/preset"
 )
 
 func TestApplySpecFlags(t *testing.T) {
@@ -123,4 +128,337 @@ func TestApplySpecFlags(t *testing.T) {
 			tt.assert(t, al)
 		})
 	}
+}
+
+func TestValidateStandardRoleSpec(t *testing.T) {
+	emptyRole, err := getEmptyRoleV6("some-role-name", types.V8)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		allow   types.RoleConditions
+		deny    types.RoleConditions
+		wantErr bool
+	}{
+		{
+			name:  "valid empty role conditions",
+			allow: emptyRole.Spec.Allow,
+			deny:  emptyRole.Spec.Deny,
+		},
+		{
+			name: "all valid allow fields",
+			allow: func() types.RoleConditions {
+				allow := emptyRole.Spec.Allow
+				allow.NodeLabels = types.Labels{"node": {"label"}}
+				allow.Logins = []string{"nodelogins"}
+				allow.DatabaseLabels = types.Labels{"db": {"label"}}
+				allow.DatabaseUsers = []string{"dbuser"}
+				allow.DatabaseNames = []string{"dbname"}
+				allow.KubernetesLabels = types.Labels{"kube": {"label"}}
+				allow.KubeUsers = []string{"kubeuser"}
+				allow.KubeGroups = []string{"kubegroup"}
+				allow.KubernetesResources = []types.KubernetesResource{{Kind: "pods", Namespace: "*", Name: "*"}}
+				allow.AppLabels = types.Labels{"app": {"label"}}
+				allow.AWSRoleARNs = []string{"arn:aws:iam::123456789012:role/example"}
+				allow.AzureIdentities = []string{"azureidentity"}
+				allow.GCPServiceAccounts = []string{"gcpserviceaccts"}
+				allow.MCP = &types.MCPPermissions{Tools: []string{"mcptools"}}
+				allow.WindowsDesktopLabels = types.Labels{"windows": {"labels"}}
+				allow.WindowsDesktopLogins = []string{"windowslogins"}
+				allow.GitHubPermissions = []types.GitHubPermission{{Organizations: []string{"githuborg"}}}
+				return allow
+			}(),
+			deny: emptyRole.Spec.Deny,
+		},
+		{
+			name: "invalid field",
+			allow: func() types.RoleConditions {
+				allow := emptyRole.Spec.Allow
+				allow.NodeLabelsExpression = `labels["env"] == "testing"`
+				return allow
+			}(),
+			deny:    emptyRole.Spec.Deny,
+			wantErr: true,
+		},
+		{
+			name:  "invalid deny",
+			allow: emptyRole.Spec.Allow,
+			deny: func() types.RoleConditions {
+				deny := emptyRole.Spec.Deny
+				deny.Logins = []string{"root"}
+				return deny
+			}(),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateStandardRoleSpec("some-role-name", emptyRole, tt.allow, tt.deny)
+			if tt.wantErr {
+				require.True(t, trace.IsBadParameter(err))
+				require.Contains(t, err.Error(), "fields this command doesn't manage")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateAWSICRoleSpec(t *testing.T) {
+	emptyRole, err := getEmptyRoleV6("some-role-name", types.V8)
+	require.NoError(t, err)
+
+	accountAssignments := []types.IdentityCenterAccountAssignment{
+		{Account: "1234", PermissionSet: "arn:aws:sso:::permissionSet/test"},
+	}
+	validAllow := func() types.RoleConditions {
+		allow := emptyRole.Spec.Allow
+		allow.AppLabels = awsIcAppLabel
+		allow.AccountAssignments = accountAssignments
+		return allow
+	}()
+
+	tests := []struct {
+		name    string
+		allow   types.RoleConditions
+		deny    types.RoleConditions
+		wantErr bool
+	}{
+		{
+			name:  "valid fields",
+			allow: validAllow,
+			deny:  emptyRole.Spec.Deny,
+		},
+		{
+			name: "valid label only",
+			allow: func() types.RoleConditions {
+				allow := emptyRole.Spec.Allow
+				allow.AppLabels = awsIcAppLabel
+				return allow
+			}(),
+			deny: emptyRole.Spec.Deny,
+		},
+		{
+			name:  "valid empty allow",
+			allow: emptyRole.Spec.Allow,
+			deny:  emptyRole.Spec.Deny,
+		},
+		{
+			name: "invalid label (hard coded by tctl)",
+			allow: func() types.RoleConditions {
+				allow := emptyRole.Spec.Allow
+				allow.AppLabels = types.Labels{
+					types.OriginLabel: []string{"aws-identity-center"},
+					"offending":       []string{"label"},
+				}
+				return allow
+			}(),
+			deny:    emptyRole.Spec.Deny,
+			wantErr: true,
+		},
+		{
+			name: "invalid field",
+			allow: func() types.RoleConditions {
+				allow := validAllow
+				allow.NodeLabels = types.Labels{"offending": {"field"}}
+				return allow
+			}(),
+			deny:    emptyRole.Spec.Deny,
+			wantErr: true,
+		},
+		{
+			name:    "invalid deny",
+			allow:   emptyRole.Spec.Allow,
+			deny:    validAllow,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAWSICRoleSpec("some-role-name", emptyRole, tt.allow, tt.deny)
+			if tt.wantErr {
+				require.True(t, trace.IsBadParameter(err))
+				require.Contains(t, err.Error(), "fields this command doesn't manage")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateQueriedRole(t *testing.T) {
+	roleName := "some-role-name"
+	emptyRole, err := getEmptyRoleV6(roleName, types.V8)
+	require.NoError(t, err)
+
+	validAWSICAllow := func() types.RoleConditions {
+		allow := emptyRole.Spec.Allow
+		allow.AppLabels = awsIcAppLabel
+		allow.AccountAssignments = []types.IdentityCenterAccountAssignment{
+			{Account: "1234", PermissionSet: "arn:aws:sso:::permissionSet/test"},
+		}
+		return allow
+	}()
+
+	validStandardAllow := func() types.RoleConditions {
+		allow := emptyRole.Spec.Allow
+		allow.NodeLabels = types.Labels{"env": {"testing"}}
+		return allow
+	}()
+
+	tests := []struct {
+		name            string
+		presetPrefix    string
+		roleVersion     string
+		allow           types.RoleConditions
+		wantErrContains string
+	}{
+		{
+			name:         "valid standard validator",
+			presetPrefix: standardRolePrefixName,
+			allow:        validStandardAllow,
+		},
+		{
+			name:            "valid standard validator fails when given awsic spec",
+			presetPrefix:    standardRolePrefixName,
+			allow:           validAWSICAllow,
+			wantErrContains: "fields this command doesn't manage",
+		},
+		{
+			name:         "valid awsic validator",
+			presetPrefix: awsicRolePrefixName,
+			allow:        validAWSICAllow,
+		},
+		{
+			name:            "valid awsic validator fails when given standard spec",
+			presetPrefix:    awsicRolePrefixName,
+			allow:           validStandardAllow,
+			wantErrContains: "fields this command doesn't manage",
+		},
+		{
+			name:         "do nothing if prefix is not handled",
+			presetPrefix: "some-unknown-preset-prefix",
+			allow:        types.RoleConditions{ClusterLabels: types.Labels{"env": {"testing"}}},
+		},
+		{
+			name:            "invalid role version",
+			presetPrefix:    standardRolePrefixName,
+			roleVersion:     types.V7,
+			wantErrContains: "unsupported version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			roleVersion := types.V8
+			if tt.roleVersion != "" {
+				roleVersion = tt.roleVersion
+			}
+			deny := emptyRole.Spec.Deny
+			err := validateQueriedRole(tt.presetPrefix, roleName, roleVersion, tt.allow, deny)
+			if tt.wantErrContains != "" {
+				require.True(t, trace.IsBadParameter(err))
+				require.Contains(t, err.Error(), tt.wantErrContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRejectUnknownRoles(t *testing.T) {
+	tests := []struct {
+		name             string
+		updateAccessList func(al *accesslist.AccessList)
+		wantErr          bool
+	}{
+		{
+			name: "valid empty request",
+		},
+		{
+			name:    "unknown role in preset label",
+			wantErr: true,
+			updateAccessList: func(al *accesslist.AccessList) {
+				al.Metadata.Labels[accesslist.AccessListPresetRolesLabel] += ",custom-role"
+			},
+		},
+		{
+			name:    "unknown role in member grant",
+			wantErr: true,
+			updateAccessList: func(al *accesslist.AccessList) {
+				al.Spec.Grants.Roles = append(al.Spec.Grants.Roles, "custom-role")
+			},
+		},
+		{
+			name:    "unknown role in owner grant",
+			wantErr: true,
+			updateAccessList: func(al *accesslist.AccessList) {
+				al.Spec.OwnerGrants.Roles = append(al.Spec.Grants.Roles, "custom-role")
+			},
+		},
+		{
+			name:    "invalid member trait field defined",
+			wantErr: true,
+			updateAccessList: func(al *accesslist.AccessList) {
+				al.Spec.Grants.Traits = trait.Traits{"offending": []string{"field"}}
+			},
+		},
+		{
+			name:    "invalid owner trait field defined",
+			wantErr: true,
+			updateAccessList: func(al *accesslist.AccessList) {
+				al.Spec.OwnerGrants.Traits = trait.Traits{"offending": []string{"field"}}
+			},
+		},
+		{
+			name:    "invalid member scoped role field defined",
+			wantErr: true,
+			updateAccessList: func(al *accesslist.AccessList) {
+				al.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role", Scope: "/"}}
+			},
+		},
+		{
+			name:    "invalid owner scoped role field defined",
+			wantErr: true,
+			updateAccessList: func(al *accesslist.AccessList) {
+				al.Spec.OwnerGrants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role", Scope: "/"}}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			newAl := newPresetAccessListLongTerm("some-al-name")
+			if tt.updateAccessList != nil {
+				tt.updateAccessList(newAl)
+			}
+
+			err := rejectUnknownGrants(newAl)
+			if tt.wantErr {
+				require.True(t, trace.IsBadParameter(err))
+				require.Contains(t, err.Error(), "grants this command doesn't manage")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func newPresetAccessListLongTerm(name string) *accesslist.AccessList {
+	reviewerRole := accesslist.RoleName(preset.RoleReviewerPrefix, name)
+	requesterRole := accesslist.RoleName(preset.RoleRequesterPrefix, name)
+	standardRole := accesslist.RoleName(standardRolePrefixName, name)
+	awsicRole := accesslist.RoleName(awsicRolePrefixName, name)
+
+	al := &accesslist.AccessList{}
+	al.Metadata.Name = name
+	al.Metadata.Labels = map[string]string{
+		accesslist.AccessListPresetLabel:      string(accesslist.LongTermPresetType),
+		accesslist.AccessListPresetRolesLabel: strings.Join([]string{reviewerRole, requesterRole, standardRole, awsicRole}, ","),
+	}
+	al.Spec.Grants = accesslist.Grants{Roles: []string{standardRole, awsicRole}}
+	al.Spec.OwnerGrants = accesslist.Grants{Roles: []string{reviewerRole}}
+	return al
 }

--- a/tool/tctl/common/accesslist/update_test.go
+++ b/tool/tctl/common/accesslist/update_test.go
@@ -135,10 +135,11 @@ func TestValidateStandardRoleSpec(t *testing.T) {
 	require.NoError(t, err)
 
 	tests := []struct {
-		name    string
-		allow   types.RoleConditions
-		deny    types.RoleConditions
-		wantErr bool
+		name                     string
+		allow                    types.RoleConditions
+		deny                     types.RoleConditions
+		wantErrContains          string
+		wantUnmanagedAllowFields []string
 	}{
 		{
 			name:  "valid empty role conditions",
@@ -171,14 +172,31 @@ func TestValidateStandardRoleSpec(t *testing.T) {
 			deny: emptyRole.Spec.Deny,
 		},
 		{
-			name: "invalid field",
+			name: "single invalid field",
 			allow: func() types.RoleConditions {
 				allow := emptyRole.Spec.Allow
 				allow.NodeLabelsExpression = `labels["env"] == "testing"`
 				return allow
 			}(),
-			deny:    emptyRole.Spec.Deny,
-			wantErr: true,
+			deny:            emptyRole.Spec.Deny,
+			wantErrContains: "allow fields not supported by this update: node_labels_expression",
+		},
+		{
+			name: "multiple invalid fields",
+			allow: func() types.RoleConditions {
+				allow := emptyRole.Spec.Allow
+				allow.AppLabelsExpression = `labels["env"] == "test"`
+				allow.NodeLabelsExpression = `labels["env"] == "test"`
+				allow.Request = &types.AccessRequestConditions{
+					Reason: &types.AccessRequestConditionsReason{},
+				}
+				allow.DatabaseServiceLabels = types.Labels{"env": []string{"test"}}
+				// This is considered "empty" and should not be part of the wantUnmanagedAllowFields
+				allow.ReviewRequests = &types.AccessReviewConditions{}
+				return allow
+			}(),
+			deny:                     emptyRole.Spec.Deny,
+			wantUnmanagedAllowFields: []string{"request", "db_service_labels", "node_labels_expression", "app_labels_expression"},
 		},
 		{
 			name:  "invalid deny",
@@ -188,17 +206,23 @@ func TestValidateStandardRoleSpec(t *testing.T) {
 				deny.Logins = []string{"root"}
 				return deny
 			}(),
-			wantErr: true,
+			wantErrContains: "deny fields not supported by this update",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateStandardRoleSpec("some-role-name", emptyRole, tt.allow, tt.deny)
-			if tt.wantErr {
+			switch {
+			case len(tt.wantUnmanagedAllowFields) > 0:
 				require.True(t, trace.IsBadParameter(err))
-				require.Contains(t, err.Error(), "fields this command doesn't manage")
-			} else {
+				for _, field := range tt.wantUnmanagedAllowFields {
+					require.Contains(t, err.Error(), field)
+				}
+			case tt.wantErrContains != "":
+				require.True(t, trace.IsBadParameter(err))
+				require.Contains(t, err.Error(), tt.wantErrContains)
+			default:
 				require.NoError(t, err)
 			}
 		})
@@ -220,10 +244,10 @@ func TestValidateAWSICRoleSpec(t *testing.T) {
 	}()
 
 	tests := []struct {
-		name    string
-		allow   types.RoleConditions
-		deny    types.RoleConditions
-		wantErr bool
+		name            string
+		allow           types.RoleConditions
+		deny            types.RoleConditions
+		wantErrContains string
 	}{
 		{
 			name:  "valid fields",
@@ -254,8 +278,8 @@ func TestValidateAWSICRoleSpec(t *testing.T) {
 				}
 				return allow
 			}(),
-			deny:    emptyRole.Spec.Deny,
-			wantErr: true,
+			deny:            emptyRole.Spec.Deny,
+			wantErrContains: "allow fields not supported by this update: app_labels",
 		},
 		{
 			name: "invalid field",
@@ -264,23 +288,23 @@ func TestValidateAWSICRoleSpec(t *testing.T) {
 				allow.NodeLabels = types.Labels{"offending": {"field"}}
 				return allow
 			}(),
-			deny:    emptyRole.Spec.Deny,
-			wantErr: true,
+			deny:            emptyRole.Spec.Deny,
+			wantErrContains: "allow fields not supported by this update: node_labels",
 		},
 		{
-			name:    "invalid deny",
-			allow:   emptyRole.Spec.Allow,
-			deny:    validAllow,
-			wantErr: true,
+			name:            "invalid deny",
+			allow:           emptyRole.Spec.Allow,
+			deny:            validAllow,
+			wantErrContains: "deny fields not supported by this update",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateAWSICRoleSpec("some-role-name", emptyRole, tt.allow, tt.deny)
-			if tt.wantErr {
+			if tt.wantErrContains != "" {
 				require.True(t, trace.IsBadParameter(err))
-				require.Contains(t, err.Error(), "fields this command doesn't manage")
+				require.Contains(t, err.Error(), tt.wantErrContains)
 			} else {
 				require.NoError(t, err)
 			}
@@ -309,11 +333,12 @@ func TestValidateQueriedRole(t *testing.T) {
 	}()
 
 	tests := []struct {
-		name            string
-		presetPrefix    string
-		roleVersion     string
-		allow           types.RoleConditions
-		wantErrContains string
+		name                     string
+		presetPrefix             string
+		roleVersion              string
+		allow                    types.RoleConditions
+		wantErrContains          string
+		wantUnmanagedAllowFields []string
 	}{
 		{
 			name:         "valid standard validator",
@@ -321,10 +346,10 @@ func TestValidateQueriedRole(t *testing.T) {
 			allow:        validStandardAllow,
 		},
 		{
-			name:            "valid standard validator fails when given awsic spec",
-			presetPrefix:    standardRolePrefixName,
-			allow:           validAWSICAllow,
-			wantErrContains: "fields this command doesn't manage",
+			name:                     "valid standard validator fails when given awsic spec",
+			presetPrefix:             standardRolePrefixName,
+			allow:                    validAWSICAllow,
+			wantUnmanagedAllowFields: []string{"account_assignments"},
 		},
 		{
 			name:         "valid awsic validator",
@@ -332,10 +357,10 @@ func TestValidateQueriedRole(t *testing.T) {
 			allow:        validAWSICAllow,
 		},
 		{
-			name:            "valid awsic validator fails when given standard spec",
-			presetPrefix:    awsicRolePrefixName,
-			allow:           validStandardAllow,
-			wantErrContains: "fields this command doesn't manage",
+			name:                     "valid awsic validator fails when given standard spec",
+			presetPrefix:             awsicRolePrefixName,
+			allow:                    validStandardAllow,
+			wantUnmanagedAllowFields: []string{"node_labels", "app_labels"},
 		},
 		{
 			name:         "do nothing if prefix is not handled",
@@ -358,10 +383,16 @@ func TestValidateQueriedRole(t *testing.T) {
 			}
 			deny := emptyRole.Spec.Deny
 			err := validateQueriedRole(tt.presetPrefix, roleName, roleVersion, tt.allow, deny)
-			if tt.wantErrContains != "" {
+			switch {
+			case len(tt.wantUnmanagedAllowFields) > 0:
+				require.True(t, trace.IsBadParameter(err))
+				for _, field := range tt.wantUnmanagedAllowFields {
+					require.Contains(t, err.Error(), field)
+				}
+			case tt.wantErrContains != "":
 				require.True(t, trace.IsBadParameter(err))
 				require.Contains(t, err.Error(), tt.wantErrContains)
-			} else {
+			default:
 				require.NoError(t, err)
 			}
 		})
@@ -370,61 +401,72 @@ func TestValidateQueriedRole(t *testing.T) {
 
 func TestRejectUnknownRoles(t *testing.T) {
 	tests := []struct {
-		name             string
-		updateAccessList func(al *accesslist.AccessList)
-		wantErr          bool
+		name               string
+		updateAccessList   func(al *accesslist.AccessList)
+		wantErrContains    string
+		wantErrContainsAll []string
 	}{
 		{
 			name: "valid empty request",
 		},
 		{
-			name:    "unknown role in preset label",
-			wantErr: true,
+			name: "valid empty grant fields",
 			updateAccessList: func(al *accesslist.AccessList) {
-				al.Metadata.Labels[accesslist.AccessListPresetRolesLabel] += ",custom-role"
+				al.Spec.Grants.Traits = trait.Traits{}
+				al.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{}
+				al.Spec.OwnerGrants.Traits = trait.Traits{}
+				al.Spec.OwnerGrants.ScopedRoles = []accesslist.ScopedRoleGrant{}
 			},
 		},
 		{
-			name:    "unknown role in member grant",
-			wantErr: true,
+			name: "unknown role in member grant",
 			updateAccessList: func(al *accesslist.AccessList) {
-				al.Spec.Grants.Roles = append(al.Spec.Grants.Roles, "custom-role")
+				al.Spec.Grants.Roles = append(al.Spec.Grants.Roles, "custom-role", "custom-role2")
 			},
+			wantErrContains: "grants roles this command doesn't update: custom-role, custom-role2",
 		},
 		{
-			name:    "unknown role in owner grant",
-			wantErr: true,
+			name: "unknown role in owner grant",
 			updateAccessList: func(al *accesslist.AccessList) {
-				al.Spec.OwnerGrants.Roles = append(al.Spec.Grants.Roles, "custom-role")
+				al.Spec.OwnerGrants.Roles = append(al.Spec.OwnerGrants.Roles, "custom-role", "custom-role2")
 			},
+			wantErrContains: "grants roles this command doesn't update: custom-role, custom-role2",
 		},
 		{
-			name:    "invalid member trait field defined",
-			wantErr: true,
+			name: "invalid member trait field defined",
 			updateAccessList: func(al *accesslist.AccessList) {
 				al.Spec.Grants.Traits = trait.Traits{"offending": []string{"field"}}
 			},
+			wantErrContains: "grant fields not supported by this update: traits",
 		},
 		{
-			name:    "invalid owner trait field defined",
-			wantErr: true,
+			name: "invalid owner trait field defined",
 			updateAccessList: func(al *accesslist.AccessList) {
 				al.Spec.OwnerGrants.Traits = trait.Traits{"offending": []string{"field"}}
 			},
+			wantErrContains: "grant fields not supported by this update: traits",
 		},
 		{
-			name:    "invalid member scoped role field defined",
-			wantErr: true,
+			name: "invalid member scoped role field defined",
 			updateAccessList: func(al *accesslist.AccessList) {
 				al.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role", Scope: "/"}}
 			},
+			wantErrContains: "grant fields not supported by this update: scoped_roles",
 		},
 		{
-			name:    "invalid owner scoped role field defined",
-			wantErr: true,
+			name: "invalid owner scoped role field defined",
 			updateAccessList: func(al *accesslist.AccessList) {
 				al.Spec.OwnerGrants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role", Scope: "/"}}
 			},
+			wantErrContains: "grant fields not supported by this update: scoped_roles",
+		},
+		{
+			name: "multiple invalid fields",
+			updateAccessList: func(al *accesslist.AccessList) {
+				al.Spec.Grants.Traits = trait.Traits{"offending": []string{"field"}}
+				al.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role", Scope: "/"}}
+			},
+			wantErrContainsAll: []string{"traits", "scoped_roles"},
 		},
 	}
 
@@ -436,9 +478,64 @@ func TestRejectUnknownRoles(t *testing.T) {
 			}
 
 			err := rejectUnknownGrants(newAl)
-			if tt.wantErr {
+			switch {
+			case len(tt.wantErrContainsAll) > 0:
 				require.True(t, trace.IsBadParameter(err))
-				require.Contains(t, err.Error(), "grants this command doesn't manage")
+				for _, want := range tt.wantErrContainsAll {
+					require.Contains(t, err.Error(), want)
+				}
+			case tt.wantErrContains != "":
+				require.True(t, trace.IsBadParameter(err))
+				require.Contains(t, err.Error(), tt.wantErrContains)
+			default:
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSupportsRoleVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		gotVersion      string
+		wantErrContains string
+	}{
+		{
+			name:       "minimum supported version",
+			gotVersion: "v8",
+		},
+		{
+			name:       "default version",
+			gotVersion: types.DefaultRoleVersion,
+		},
+		{
+			name:            "below minimum version",
+			gotVersion:      "v7",
+			wantErrContains: "unsupported version",
+		},
+		{
+			name:            "above default version",
+			gotVersion:      "v9999999999999999999",
+			wantErrContains: "Upgrade your tctl binary",
+		},
+		{
+			name:            "malformed version",
+			gotVersion:      "not-a-version",
+			wantErrContains: "unsupported version",
+		},
+		{
+			name:            "empty version",
+			gotVersion:      "",
+			wantErrContains: "unsupported version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := supportsRoleVersion(tt.gotVersion, "some-role-name")
+			if tt.wantErrContains != "" {
+				require.True(t, trace.IsBadParameter(err))
+				require.Contains(t, err.Error(), tt.wantErrContains)
 			} else {
 				require.NoError(t, err)
 			}


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/8271 

This PR errors editing access list with a preset (`--access-type`) through the `tctl acl update` command if it detects anomalies like: list grants and role fields that are not supported by the command. This prevents unintended changes like silent overwriting of fields or list grants. 

Example outputs:

when the role that was auto created for this list, contains fields not supported by the command (editing standard role):
```bash
$ tctl acl update ABCD  --logins=root --node-labels=env=prod

ERROR: the role Teleport created for this list has allow fields not supported by this update: request, db_service_labels.
Use `tctl edit role/access-standard-acl-preset-ABCD` to clear those fields or `spec`, then retry; or edit the role directly.
```

when the role that was auto created for this list, contains fields not supported by the command (editing awsic role)
```bash
$ tctl acl update ABCD --aws-ic-assignments=testing    
        
ERROR: the role Teleport created for this list has allow fields not supported by this update: logins, node_labels.
Use `tctl edit role/access-awsic-acl-preset-ABCD` to clear those fields or `spec`, then retry; or edit the role directly.
```

when the access list `grants` (members or owners) field contains roles that were not created by teleport, or traits or other fields are defined:
```bash
$ tctl acl update ABCD --aws-ic-assignments=testing
ERROR: resource-access changes cannot be applied; this list grants roles this command doesn't update: some-custom-role.
Use `tctl edit access_list/ABCD` to remove those roles from "spec.grants.roles" field, then retry; or edit the access list directly.
```

when using a unsupported verion
```bash
$ tctl acl update ABCD --logins=root
ERROR: resource-access changes cannot be applied; role is using an unsupported version "v7".
Use `tctl edit role/access-standard-acl-preset-ABCD` to upgrade its version, or edit the role directly.
```

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

cloud staging

### Test Cases
run `tctl acl update XXX` for the following cases:
- [x] when member `grants.roles` contain custom roles
- [x] when member trait is set
- [x] when owner `ownerGrants.roles` contain custom roles
- [x] when owner trait is set
- [x] when a role created by teleport contains fields unsupported by command (e.g.: `spec.allow.cluster_labels`)
- [x] when a role created by teleport is using a unsupported role version (v7) 
