### PR TITLE
Limit the maximum input length for types.ParseDuration

### DIFF
--- a/api/types/duration.go
+++ b/api/types/duration.go
@@ -151,6 +151,9 @@ func leadingFraction(s string) (x int64, scale float64, rem string) {
 	return x, scale, s[i:]
 }
 
+// maxDurationLen bounds the length of a string accepted by ParseDuration.
+const maxDurationLen = 64
+
 var unitMap = map[string]int64{
 	"ns": int64(time.Nanosecond),
 	"us": int64(time.Microsecond),
@@ -171,6 +174,10 @@ var unitMap = map[string]int64{
 // such as "300ms", "-1.5h" or "2h45m".
 // Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 func ParseDuration(s string) (Duration, error) {
+	if len(s) > maxDurationLen {
+		return 0, trace.BadParameter("invalid duration: string exceeds %d bytes", maxDurationLen)
+	}
+
 	// [-+]?([0-9]*(\.[0-9]*)?[a-z]+)+
 	orig := s
 	var d int64

--- a/api/types/duration_test.go
+++ b/api/types/duration_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package types
 
 import (
+	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -57,4 +59,16 @@ func TestDurationUnmarshal(t *testing.T) {
 			require.Equal(t, testCase.expectedValue, duration)
 		})
 	}
+}
+
+func TestParseDurationRejectsOversizedInput(t *testing.T) {
+	overlong := strings.Repeat("1", maxDurationLen) + "s"
+	_, err := ParseDuration(overlong)
+	require.Error(t, err)
+
+	// The longest legitimate duration string - "2562047h47m16.854775807s"
+	longestValid := time.Duration(math.MaxInt64).String()
+	require.LessOrEqual(t, len(longestValid), maxDurationLen)
+	_, err = ParseDuration(longestValid)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
This addresses some oss-fuzz timeouts due to unrealistically large inputs.

Foregoing the manual test plan - this is a small well defined change, and I won't be backporting it so it will get manual test coverage on our v19 test plan.