### PR TITLE
Support MCP protocol discovery for Kubernetes app services

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/reference.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/reference.mdx
@@ -97,6 +97,19 @@ heuristics will be used to try to determine protocol of an exposed port.
 If all heuristics didn't work, the port will be skipped. For app to be imported with `tcp` protocol, the
 service should have explicit annotation `teleport.dev/protocol: "tcp"`
 
+To import a service as an MCP server, set the annotation to the URI scheme of
+the transport the MCP server uses:
+
+- `teleport.dev/protocol: "mcp+http"` or `teleport.dev/protocol: "mcp+https"`
+  for the Streamable HTTP transport.
+- `teleport.dev/protocol: "mcp+sse+http"` or `teleport.dev/protocol: "mcp+sse+https"`
+  for the HTTP with SSE transport.
+
+Combine the annotation with `teleport.dev/path` to set the request path of the
+MCP endpoint (for example `/mcp` or `/sse`). MCP servers using the stdio
+transport cannot be discovered from Kubernetes services, since they require a
+command to launch the server.
+
 ### `teleport.dev/port`
 
 Controls preferred port for the Kubernetes service, only this one will be used even if service

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -190,7 +190,14 @@ func (f *KubeAppFetcher) Get(ctx context.Context) (types.ResourcesWithLabels, er
 			portProtocols := map[v1.ServicePort]string{}
 			for _, port := range ports {
 				switch protocolAnnotation {
-				case protoHTTPS, protoHTTP, protoTCP:
+				// MCP servers using the Streamable HTTP or SSE transport are
+				// registered as MCP apps based on their URI scheme, so the
+				// annotation value is passed through as the URI scheme.
+				// mcp+stdio is intentionally excluded: it requires a command,
+				// which a Kubernetes Service cannot provide.
+				case protoHTTPS, protoHTTP, protoTCP,
+					types.SchemeMCPHTTP, types.SchemeMCPHTTPS,
+					types.SchemeMCPSSEHTTP, types.SchemeMCPSSEHTTPS:
 					portProtocols[port] = protocolAnnotation
 				default:
 					if p := autoProtocolDetection(service, port, f.ProtocolChecker); p != protoTCP {

--- a/lib/srv/discovery/fetchers/kube_services_test.go
+++ b/lib/srv/discovery/fetchers/kube_services_test.go
@@ -79,6 +79,19 @@ func TestKubeAppFetcher_Get(t *testing.T) {
 				{Port: 42, Name: "custom", Protocol: corev1.ProtocolTCP},
 				{Port: 43, Name: "custom-udp", Protocol: corev1.ProtocolUDP},
 			}),
+		newMockService("service6", "ns4", "", map[string]string{"test-label4": "testval4"}, map[string]string{
+			types.DiscoveryProtocolLabel: types.SchemeMCPHTTP,
+		},
+			[]corev1.ServicePort{
+				{Port: 8080, Name: "custom", Protocol: corev1.ProtocolTCP},
+			}),
+		newMockService("service7", "ns4", "", map[string]string{"test-label4": "testval4"}, map[string]string{
+			types.DiscoveryProtocolLabel: types.SchemeMCPSSEHTTPS,
+			types.DiscoveryPathLabel:     "/sse",
+		},
+			[]corev1.ServicePort{
+				{Port: 443, Name: "custom", Protocol: corev1.ProtocolTCP},
+			}),
 	}
 
 	apps := map[string]*types.AppV3{
@@ -173,6 +186,42 @@ func TestKubeAppFetcher_Get(t *testing.T) {
 				URI: "tcp://service5.ns3.svc.cluster.local:42",
 			},
 		},
+		"service6.app1": {
+			Kind:    "app",
+			SubKind: types.SubKindMCP,
+			Version: "v3",
+			Metadata: types.Metadata{
+				Name:        "service6-ns4-test-cluster",
+				Namespace:   "default",
+				Description: "Discovered application in Kubernetes cluster \"test-cluster\"",
+				Labels: map[string]string{
+					"test-label4":                "testval4",
+					types.KubernetesClusterLabel: "test-cluster",
+					types.AppSubKindLabel:        types.SubKindMCP,
+				},
+			},
+			Spec: types.AppSpecV3{
+				URI: "mcp+http://service6.ns4.svc.cluster.local:8080",
+			},
+		},
+		"service7.app1": {
+			Kind:    "app",
+			SubKind: types.SubKindMCP,
+			Version: "v3",
+			Metadata: types.Metadata{
+				Name:        "service7-ns4-test-cluster",
+				Namespace:   "default",
+				Description: "Discovered application in Kubernetes cluster \"test-cluster\"",
+				Labels: map[string]string{
+					"test-label4":                "testval4",
+					types.KubernetesClusterLabel: "test-cluster",
+					types.AppSubKindLabel:        types.SubKindMCP,
+				},
+			},
+			Spec: types.AppSpecV3{
+				URI: "mcp+sse+https://service7.ns4.svc.cluster.local:443/sse",
+			},
+		},
 	}
 
 	tests := []struct {
@@ -265,6 +314,13 @@ func TestKubeAppFetcher_Get(t *testing.T) {
 			matcherNamespaces: []string{"ns3"},
 			matcherLabels:     types.Labels{"test-label3": []string{"testval3"}},
 			expected:          types.Apps{apps["service5.app1"]},
+		},
+		{
+			desc:              "Service with MCP Streamable HTTP protocol annotation",
+			services:          mockServices,
+			matcherNamespaces: []string{"ns4"},
+			matcherLabels:     types.Labels{"test-label4": []string{"testval4"}},
+			expected:          types.Apps{apps["service6.app1"], apps["service7.app1"]},
 		},
 		{
 			desc:              "Matching service with protocol checker",


### PR DESCRIPTION
<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed Kubernetes app discovery not registering Services annotated with an MCP protocol (`mcp+http`, `mcp+https`, `mcp+sse+http`, `mcp+sse+https`) as MCP apps.

Fixes #68345


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Ran the real `KubeAppFetcher.Get` path against fixture Services (`teleport.dev/protocol` set to each MCP scheme, plus a plain-HTTP control and the invalid `mcp+sse` value from the issue), asserting the resulting `sub_kind`/`protocol`/`uri`. Verified before/after by reverting the fetcher change and confirming the bug reproduces.

### Test Cases
- [x] `mcp+http` Service → app with `sub_kind: mcp`, uri `mcp+http://...:8080/mcp`
- [x] `mcp+sse+https` Service → app with `sub_kind: mcp`, uri `mcp+sse+https://...:443/sse`
- [x] Plain-HTTP Service (no annotation) → unchanged web app (`sub_kind` empty, `http://`)
- [x] Invalid `mcp+sse` value → not misclassified (falls through, skipped)
- [x] Without the fix, MCP-annotated Services regress to plain web apps (`http://`/`https://`, `sub_kind` empty)
