### PR TITLE
RFD 299C: Display scoped workload identities correctly in UI

### DIFF
--- a/lib/web/workload_identity.go
+++ b/lib/web/workload_identity.go
@@ -67,6 +67,7 @@ func (h *Handler) listWorkloadIdentities(_ http.ResponseWriter, r *http.Request,
 	uiItems := tslices.Map(result.GetWorkloadIdentities(), func(item *workloadidentityv1.WorkloadIdentity) WorkloadIdentity {
 		uiItem := WorkloadIdentity{
 			Name:       item.GetMetadata().GetName(),
+			Scope:      item.GetScope(),
 			SpiffeID:   item.GetSpec().GetSpiffe().GetId(),
 			SpiffeHint: item.GetSpec().GetSpiffe().GetHint(),
 			Labels:     item.GetMetadata().GetLabels(),
@@ -88,6 +89,7 @@ type ListWorkloadIdentitiesResponse struct {
 
 type WorkloadIdentity struct {
 	Name       string            `json:"name"`
+	Scope      string            `json:"scope,omitempty"`
 	SpiffeID   string            `json:"spiffe_id"`
 	SpiffeHint string            `json:"spiffe_hint"`
 	Labels     map[string]string `json:"labels"`

--- a/lib/web/workload_identity_test.go
+++ b/lib/web/workload_identity_test.go
@@ -73,6 +73,23 @@ func TestListWorkloadIdentities(t *testing.T) {
 	}.Build())
 	require.NoError(t, err)
 
+	scopedName := uuid.New().String()
+
+	_, err = env.server.Auth().CreateWorkloadIdentity(ctx, workloadidentityv1pb.WorkloadIdentity_builder{
+		Kind:    types.KindWorkloadIdentity,
+		Version: types.V1,
+		Metadata: headerv1.Metadata_builder{
+			Name: scopedName,
+		}.Build(),
+		Scope: "/staging",
+		Spec: workloadidentityv1pb.WorkloadIdentitySpec_builder{
+			Spiffe: workloadidentityv1pb.WorkloadIdentitySPIFFE_builder{
+				Id: "/staging/_/svc",
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
 	response, err := pack.clt.Get(ctx, endpoint, url.Values{})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, response.Code(), "unexpected status code")
@@ -80,7 +97,8 @@ func TestListWorkloadIdentities(t *testing.T) {
 	var instances ListWorkloadIdentitiesResponse
 	require.NoError(t, json.Unmarshal(response.Bytes(), &instances), "invalid response received")
 
-	assert.Len(t, instances.Items, 1)
+	assert.Len(t, instances.Items, 2)
+	// Scoped identities sort after unscoped ones in the name-ordered stream.
 	require.Empty(t, cmp.Diff(instances, ListWorkloadIdentitiesResponse{
 		Items: []WorkloadIdentity{
 			{
@@ -91,6 +109,11 @@ func TestListWorkloadIdentities(t *testing.T) {
 					"label-1": "value-1",
 					"label-2": "value-2",
 				},
+			},
+			{
+				Name:     scopedName,
+				Scope:    "/staging",
+				SpiffeID: "/staging/_/svc",
 			},
 		},
 	}))

--- a/web/packages/teleport/src/WorkloadIdentity/List/WorkloadIdentitiesList.tsx
+++ b/web/packages/teleport/src/WorkloadIdentity/List/WorkloadIdentitiesList.tsx
@@ -75,6 +75,11 @@ export function WorkloadIdetitiesList({
           key: 'name',
           headerText: 'Name',
           isSortable: true,
+          // Scoped workload identities are shown as their scope-qualified
+          // name, e.g. /staging::my-identity.
+          render: ({ name, scope }) => (
+            <Cell>{scope ? `${scope}::${name}` : name}</Cell>
+          ),
         },
         {
           key: 'spiffe_id',

--- a/web/packages/teleport/src/WorkloadIdentity/WorkloadIdentities.test.tsx
+++ b/web/packages/teleport/src/WorkloadIdentity/WorkloadIdentities.test.tsx
@@ -163,6 +163,11 @@ describe('WorkloadIdentities', () => {
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
       )
     ).toBeInTheDocument();
+
+    // Scoped workload identities show their scope-qualified name.
+    expect(
+      screen.getByText('/staging::test-workload-identity-4')
+    ).toBeInTheDocument();
   });
 
   it('Allows paging', async () => {

--- a/web/packages/teleport/src/services/workloadIdentity/types.ts
+++ b/web/packages/teleport/src/services/workloadIdentity/types.ts
@@ -23,6 +23,8 @@ export type ListWorkloadIdentitiesResponse = {
 
 export type WorkloadIdentity = {
   name: string;
+  /** scope is empty or omitted for unscoped workload identities. */
+  scope?: string;
   spiffe_id: string | null | undefined;
   labels: Record<string, string> | null | undefined;
   spiffe_hint: string | null | undefined;

--- a/web/packages/teleport/src/test/helpers/workloadIdentities.ts
+++ b/web/packages/teleport/src/test/helpers/workloadIdentities.ts
@@ -48,6 +48,13 @@ export const listWorkloadIdentitiesSuccess = (
         spiffe_hint: '',
         labels: { 'test-label-4': 'test-value-4' },
       },
+      {
+        name: 'test-workload-identity-4',
+        scope: '/staging',
+        spiffe_id: '/staging/_/70b7ee2f-ea48-42e8-b6e1-9c47dec6e295',
+        spiffe_hint: '',
+        labels: {},
+      },
     ],
     next_page_token: 'page-token-1',
   }


### PR DESCRIPTION
Depends on https://github.com/gravitational/teleport/pull/67979

Updates https://github.com/gravitational/teleport/issues/66349

Modifies the Workload Identity list view to show SQNs for scoped Workload Identities.

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases
- [x] Open Workload Identity list view with scoped and unscoped workload identities, ensure rendered correctly.
