### PR TITLE
chore: fix azure terraform module lint error

### DIFF
--- a/integrations/terraform-modules/teleport/discovery/azure/main.tf
+++ b/integrations/terraform-modules/teleport/discovery/azure/main.tf
@@ -1,7 +1,6 @@
 locals {
-  create                = var.create
-  azure_subscription_id = one(data.azurerm_client_config.this[*].subscription_id)
-  azure_tenant_id       = one(data.azurerm_client_config.this[*].tenant_id)
+  create          = var.create
+  azure_tenant_id = one(data.azurerm_client_config.this[*].tenant_id)
   apply_azure_tags = merge(var.apply_azure_tags, {
     "TeleportCluster"     = local.teleport_cluster_name
     "TeleportIntegration" = local.teleport_integration_name
@@ -10,10 +9,10 @@ locals {
   apply_teleport_resource_labels = merge(var.apply_teleport_resource_labels, {
     "teleport.dev/iac-tool" = "terraform",
   })
-  apply_teleport_management_group_label = var.azure_management_group_id != null ? {
+  apply_teleport_management_group_labels = var.azure_management_group_id != null ? {
     "teleport.dev/azure-management-group-id" = var.azure_management_group_id
   } : {}
-  apply_teleport_integration_labels = merge(local.apply_teleport_resource_label, local.apply_teleport_management_group_labels, {
+  apply_teleport_integration_labels = merge(local.apply_teleport_resource_labels, local.apply_teleport_management_group_labels, {
     "teleport.dev/azure-managed-identity-region"         = var.azure_managed_identity_location
     "teleport.dev/azure-managed-identity-resource-group" = var.azure_resource_group_name
   })

--- a/integrations/terraform-modules/teleport/discovery/azure/teleport_discovery_config.tf
+++ b/integrations/terraform-modules/teleport/discovery/azure/teleport_discovery_config.tf
@@ -29,8 +29,7 @@ locals {
     )
   ]
 
-  azure_matcher_types   = distinct(flatten([for matcher in local.azure_matchers : matcher.types]))
-  azure_matcher_regions = distinct(flatten([for matcher in local.azure_matchers : matcher.regions]))
+  azure_matcher_types = distinct(flatten([for matcher in local.azure_matchers : matcher.types]))
   azure_matcher_subscriptions = (
     local.has_wildcard_subscription_matcher
     ? ["*"]


### PR DESCRIPTION
Issue: https://github.com/gravitational/teleport/issues/60822

- Fix typo in `teleport-azure-discovery` terraform module
- Resolve linter warnings from `make check` for unused locals

https://github.com/gravitational/teleport/pull/67215

will include in v18 backport PR: https://github.com/gravitational/teleport/pull/68392

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

cloud

### Test Cases
- [x] Configure discovery w/ Management Group Scope, wildcard subscription matcher
- [x] ensure discovery config has management group label 
