### PR TITLE
gha: Bloat Check - stop using secrets context

### DIFF
--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -44,7 +44,7 @@ jobs:
           existing-gh-variables: "${{ toJSON(vars) }}"
           values: |
             REVIEWERS_APP_ID,variable
-            REVIEWERS_APP_PRIVATE_KEY,secret
+            REVIEWERS_PRIVATE_KEY,secret
             REVIEWERS,secret
       - name: Checkout base
         uses: actions/checkout@v6
@@ -74,7 +74,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ env.REVIEWERS_APP_ID }}
-          private-key: ${{ env.REVIEWERS_APP_PRIVATE_KEY }}
+          private-key: ${{ env.REVIEWERS_PRIVATE_KEY }}
 
       - if: ${{ steps.cache-build-restore.outputs.cache-hit != 'true' }}
         name: Build base

--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -42,10 +42,10 @@ jobs:
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
           existing-gh-secrets: "${{ toJSON(secrets) }}"
           existing-gh-variables: "${{ toJSON(vars) }}"
-          # values: |
-          #   REVIEWERS_APP_ID,secret
-          #   REVIEWERS_PRIVATE_KEY,secret
-          #   REVIEWERS,secret
+          values: |
+            REVIEWERS_APP_ID,variable
+            REVIEWERS_APP_PRIVATE_KEY,secret
+            REVIEWERS,secret
       - name: Checkout base
         uses: actions/checkout@v6
         with:
@@ -73,15 +73,15 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.REVIEWERS_APP_ID }}
-          private-key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
+          app-id: ${{ env.REVIEWERS_APP_ID }}
+          private-key: ${{ env.REVIEWERS_APP_PRIVATE_KEY }}
 
       - if: ${{ steps.cache-build-restore.outputs.cache-hit != 'true' }}
         name: Build base
         id: build_base
         run: |
           make WEBASSETS_SKIP_BUILD=1 BUILDDIR=base_build binaries
-          cd .github/shared-workflows/bot && go run main.go -workflow=binary-sizes --artifacts="tbot,tctl,teleport,tsh,teleport-update,fdpass-teleport,sessionhelper" --builddir="../../../base_build" -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}"  > ~/teleport_base_build_stats
+          cd .github/shared-workflows/bot && go run main.go -workflow=binary-sizes --artifacts="tbot,tctl,teleport,tsh,teleport-update,fdpass-teleport,sessionhelper" --builddir="../../../base_build" -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ env.REVIWERS }}"  > ~/teleport_base_build_stats
           echo "base_stats_file=~/teleport_base_build_stats" >> $GITHUB_OUTPUT
           echo "base_stats=$(cat ~/teleport_base_build_stats)" >> $GITHUB_ENV
 
@@ -131,4 +131,4 @@ jobs:
         id: check_branch_bloat
         run: |
           current=$(pwd)/build
-          cd .github/shared-workflows/bot && go run main.go -workflow=bloat --artifacts="tbot,tctl,teleport,tsh,teleport-update,fdpass-teleport,sessionhelper" --base="${base_stats}" --builddir="${current}" -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}" > $GITHUB_STEP_SUMMARY
+          cd .github/shared-workflows/bot && go run main.go -workflow=bloat --artifacts="tbot,tctl,teleport,tsh,teleport-update,fdpass-teleport,sessionhelper" --base="${base_stats}" --builddir="${current}" -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ env.REVIEWERS }}" > $GITHUB_STEP_SUMMARY

--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -81,7 +81,7 @@ jobs:
         id: build_base
         run: |
           make WEBASSETS_SKIP_BUILD=1 BUILDDIR=base_build binaries
-          cd .github/shared-workflows/bot && go run main.go -workflow=binary-sizes --artifacts="tbot,tctl,teleport,tsh,teleport-update,fdpass-teleport,sessionhelper" --builddir="../../../base_build" -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ env.REVIWERS }}"  > ~/teleport_base_build_stats
+          cd .github/shared-workflows/bot && go run main.go -workflow=binary-sizes --artifacts="tbot,tctl,teleport,tsh,teleport-update,fdpass-teleport,sessionhelper" --builddir="../../../base_build" -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ env.REVIEWERS }}"  > ~/teleport_base_build_stats
           echo "base_stats_file=~/teleport_base_build_stats" >> $GITHUB_OUTPUT
           echo "base_stats=$(cat ~/teleport_base_build_stats)" >> $GITHUB_ENV
 


### PR DESCRIPTION
Contributes to https://github.com/gravitational/cloud/issues/14222
Follow up from https://github.com/gravitational/teleport/pull/68046

This PR replaces the use of GHA `secrets` context with runtime values loaded to environment variables in the `kvstore` step.

Trying this out on the "Bloat Check" job first before proceeding to update other jobs.