### PR TITLE
Move accesslist preset builder from enterprise

### DIFF
--- a/lib/accesslists/preset/builder.go
+++ b/lib/accesslists/preset/builder.go
@@ -1,0 +1,480 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package preset
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+)
+
+const (
+	// AccessListPresetRoleInfix is the infix used in the names of roles
+	// auto-created for a preset-backed access list. The full role name
+	// format is "{prefix}-{AccessListPresetRoleInfix}-{accessListUUID}".
+	AccessListPresetRoleInfix = "acl-preset"
+
+	// RoleRequesterPrefix describes a role that allows to make access requests
+	// to some resources.
+	RoleRequesterPrefix = "requester"
+	// RoleReviewerPrefix describes a role that allows reviewing access requests.
+	RoleReviewerPrefix = "reviewer"
+
+	// RoleDesc indicating that resources was created by internal flow and should not be manage by users.
+	RoleDesc = "Role created by Teleport. Do not edit."
+)
+
+// PresetType defines the type of access list preset.
+type PresetType string
+
+// LongTermPresetType grants members access roles directly.
+// Owners receive the reviewer role.
+const LongTermPresetType PresetType = "long-term"
+
+// ShortTermPresetType grants members a requester role for on-demand access.
+// Members receive the requester role to request access, owners receive the reviewer role.
+const ShortTermPresetType PresetType = "short-term"
+
+// AccessListRolesBuilderConfig contains the configuration for building
+// access list and roles. The config is validated during builder creation.
+type AccessListRolesBuilderConfig struct {
+	// PresetName is the name of the preset access list.
+	PresetName string
+	// AccessListSpec is the access list specification to build from.
+	AccessListSpec *accesslist.AccessList
+	// PresetType determines the grant behavior (long-term or short-term).
+	PresetType PresetType
+	// AccessRoles are the roles that will be granted based on the preset type.
+	AccessRoles []types.Role
+
+	// SkipRoleDescriptions when true, omits adding role descriptions
+	SkipRoleDescriptions bool
+	// ManagedByIAC when not empty, adds a label to roles and access list that
+	// the resource is being managed by a IAC tool (e.g. terraform)
+	ManagedByIAC string
+}
+
+// CheckAndSetDefaults validates the config and sets default values.
+// It ensures that the access list name, preset name, and preset type are valid.
+//
+// Note: this function is not called by NewPresetAccessListRolesBuilderForTerraform.
+func (c *AccessListRolesBuilderConfig) CheckAndSetDefaults() error {
+	if c.AccessListSpec == nil {
+		return trace.BadParameter("access list is required")
+	}
+	if err := c.validateAccessListName(); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := c.validatePreset(); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// validatePreset validates the preset type in the config.
+func (c *AccessListRolesBuilderConfig) validatePreset() error {
+	if c.PresetType != LongTermPresetType && c.PresetType != ShortTermPresetType {
+		return trace.BadParameter("preset type is required")
+	}
+	return nil
+}
+
+// validateAccessListName validates the access list name in the config
+// and ensures name matches if both are provided.
+func (c *AccessListRolesBuilderConfig) validateAccessListName() error {
+	aclName := c.AccessListSpec.GetName()
+	if aclName == "" {
+		return trace.BadParameter("access list name is required")
+	}
+	if c.PresetName != "" && c.PresetName != aclName {
+		return trace.BadParameter("access list name is invalid")
+	}
+	return nil
+}
+
+// AccessListRolesBuilder is a standalone builder that constructs access lists
+// and roles in-memory WITHOUT any backend operations.
+// It is completely decoupled from persistence and can be used independently.
+type AccessListRolesBuilder struct {
+	cfg AccessListRolesBuilderConfig
+}
+
+type RolesBuildResult struct {
+	// ReviewerRole allows reviewing access requests for the access roles.
+	ReviewerRole types.Role
+	// RequesterRole allows requesting access to the access roles.
+	RequesterRole types.Role
+	// AccessRoles are the roles that grant actual permissions (e.g., app access, database access).
+	AccessRoles []types.Role
+}
+
+type AccessListBuildResult struct {
+	// AccessList is the constructed access list with grants configured based on preset type.
+	AccessList *accesslist.AccessList
+	// RolesToBeDeleted are role names that should be deleted (removed from previous access list configuration).
+	RolesToBeDeleted []string
+}
+
+// BuildResult contains all constructed objects (access list + roles).
+type BuildResult struct {
+	RolesBuildResult
+	AccessListBuildResult
+}
+
+// NewPresetAccessListRolesBuilder creates a new standalone builder
+// that constructs access list and roles in-memory (no backend operations).
+// The config is validated during builder creation.
+func NewPresetAccessListRolesBuilder(cfg AccessListRolesBuilderConfig) (*AccessListRolesBuilder, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &AccessListRolesBuilder{cfg: cfg}, nil
+}
+
+// NewPresetAccessListRolesBuilderForTerraform is similar to NewPresetAccessListRolesBuilder but allows for more
+// flexible validation rules to accommodate Terraform's workflow where certain resources (e.g access list) may
+// not exist yet.
+//
+// Note: this constructor does not call CheckAndSetDefaults.
+func NewPresetAccessListRolesBuilderForTerraform(cfg AccessListRolesBuilderConfig) (*AccessListRolesBuilder, error) {
+	if err := cfg.validatePreset(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if cfg.AccessListSpec != nil {
+		if err := cfg.validateAccessListName(); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	cfg.ManagedByIAC = types.IACToolTerraform
+	cfg.SkipRoleDescriptions = true
+	return &AccessListRolesBuilder{cfg: cfg}, nil
+}
+
+func collectRolesName(roles []types.Role) []string {
+	out := make([]string, 0, len(roles))
+	for _, role := range roles {
+		out = append(out, role.GetName())
+	}
+	return out
+}
+
+// Build constructs the access list and all roles in-memory.
+// It creates the access list, reviewer role, requester role, and access roles
+// based on the preset type. Returns BuildResult with all constructed objects.
+func (b *AccessListRolesBuilder) Build() (*BuildResult, error) {
+	builtRoles, err := b.BuildRoles()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	builtAccessList, err := b.BuildAccessList(builtRoles)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &BuildResult{
+		RolesBuildResult:      *builtRoles,
+		AccessListBuildResult: *builtAccessList,
+	}, nil
+}
+
+// BuildRoles only constructs the roles: access roles, reviewer role, and requester role.
+// Reviewer and requester roles are still constructed even if access roles are not provided.
+func (b *AccessListRolesBuilder) BuildRoles() (*RolesBuildResult, error) {
+	accessRoles, err := b.constructAccessRoles()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	accessRoleNames := collectRolesName(accessRoles)
+	reviewerRole, err := b.constructReviewerRole(accessRoleNames)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	requesterRole, err := b.constructRequesterRole(accessRoleNames)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &RolesBuildResult{
+		AccessRoles:   accessRoles,
+		ReviewerRole:  reviewerRole,
+		RequesterRole: requesterRole,
+	}, nil
+}
+
+// BuildAccessList only constructs the access list with the appropriate grants based on preset type.
+// If builtRoles is nil, access list grants will be empty.
+func (b *AccessListRolesBuilder) BuildAccessList(builtRoles *RolesBuildResult) (*AccessListBuildResult, error) {
+	if b.cfg.AccessListSpec == nil {
+		return nil, trace.BadParameter("access list spec is required to build access list")
+	}
+
+	reviewerRoleName := ""
+	requesterRoleName := ""
+	accessRoleNames := []string{}
+	if builtRoles != nil {
+		if builtRoles.ReviewerRole != nil {
+			reviewerRoleName = builtRoles.ReviewerRole.GetName()
+		}
+		if builtRoles.RequesterRole != nil {
+			requesterRoleName = builtRoles.RequesterRole.GetName()
+		}
+		accessRoleNames = collectRolesName(builtRoles.AccessRoles)
+	}
+
+	accessList, err := b.constructAccessList(reviewerRoleName, requesterRoleName, accessRoleNames)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Compute roles to be deleted by comparing old and new access lists
+	rolesToBeDeleted := b.computeRolesToBeDeleted(b.cfg.AccessListSpec, accessList)
+
+	return &AccessListBuildResult{
+		AccessList:       accessList,
+		RolesToBeDeleted: rolesToBeDeleted,
+	}, nil
+}
+
+// constructAccessRoles constructs the access roles from the provided role specs
+//
+// Note: This function modifies the input roles in cfg.AccessRoles
+// (renames them and adds labels). Callers should not reuse these role objects.
+func (b *AccessListRolesBuilder) constructAccessRoles() ([]types.Role, error) {
+	roles := make([]types.Role, 0, len(b.cfg.AccessRoles))
+	for _, roleSpec := range b.cfg.AccessRoles {
+		role := b.prepareAccessRole(roleSpec)
+		roles = append(roles, role)
+	}
+	return roles, nil
+}
+
+// prepareAccessRole clones and configures a role for the preset access list.
+// It ensures the role has the correct preset name (without double-suffixing),
+// labels, and description.
+func (b *AccessListRolesBuilder) prepareAccessRole(roleSpec types.Role) types.Role {
+	role := roleSpec.Clone()
+
+	labels := map[string]string{
+		accesslist.AccessListPresetLabel: b.cfg.PresetName,
+	}
+	if b.cfg.ManagedByIAC != "" {
+		labels[types.IACToolLabel] = b.cfg.ManagedByIAC
+	}
+
+	if _, ok := role.GetLabel(accesslist.AccessListPresetLabel); !ok {
+		role.SetName(b.generateRoleName(roleSpec.GetName()))
+		role.SetStaticLabels(labels)
+	} else if b.cfg.ManagedByIAC != "" {
+		existing := role.GetStaticLabels()
+		if existing == nil {
+			existing = map[string]string{}
+		}
+		existing[types.IACToolLabel] = b.cfg.ManagedByIAC
+		role.SetStaticLabels(existing)
+	}
+	if !b.cfg.SkipRoleDescriptions {
+		setRoleDesc(role, RoleDesc)
+	}
+
+	return role
+}
+
+// constructReviewerRole constructs the reviewer role that allows reviewing access requests
+func (b *AccessListRolesBuilder) constructReviewerRole(accessRoleNames []string) (types.Role, error) {
+	spec := types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			ReviewRequests: &types.AccessReviewConditions{
+				PreviewAsRoles: accessRoleNames,
+				Roles:          accessRoleNames,
+			},
+		},
+	}
+	labels := map[string]string{
+		accesslist.AccessListPresetLabel: b.cfg.PresetName,
+	}
+	if b.cfg.ManagedByIAC != "" {
+		labels[types.IACToolLabel] = b.cfg.ManagedByIAC
+	}
+
+	role, err := types.NewRole(b.generateRoleName(RoleReviewerPrefix), spec)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !b.cfg.SkipRoleDescriptions {
+		setRoleDesc(role, RoleDesc)
+	}
+	role.SetStaticLabels(labels)
+	return role, nil
+}
+
+// constructRequesterRole constructs the requester role that allows requesting access
+func (b *AccessListRolesBuilder) constructRequesterRole(accessRoleNames []string) (types.Role, error) {
+	roleName := b.generateRoleName(RoleRequesterPrefix)
+
+	spec := types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Request: &types.AccessRequestConditions{
+				SearchAsRoles: accessRoleNames,
+			},
+		},
+	}
+	labels := map[string]string{
+		accesslist.AccessListPresetLabel: b.cfg.PresetName,
+	}
+	if b.cfg.ManagedByIAC != "" {
+		labels[types.IACToolLabel] = b.cfg.ManagedByIAC
+	}
+
+	role, err := types.NewRole(roleName, spec)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if !b.cfg.SkipRoleDescriptions {
+		setRoleDesc(role, RoleDesc)
+	}
+	role.SetStaticLabels(labels)
+	return role, nil
+}
+
+func setRoleDesc(r types.Role, desc string) {
+	meta := r.GetMetadata()
+	meta.Description = desc
+	r.SetMetadata(meta)
+}
+
+// constructAccessList constructs the access list with the appropriate grants based on preset type
+func (b *AccessListRolesBuilder) constructAccessList(reviewerRoleName, requesterRoleName string, accessRoleNames []string) (*accesslist.AccessList, error) {
+	labels := map[string]string{
+		accesslist.AccessListPresetLabel: string(b.cfg.PresetType),
+	}
+
+	presetRoles := []string{}
+	if reviewerRoleName != "" {
+		presetRoles = append(presetRoles, reviewerRoleName)
+	}
+	if requesterRoleName != "" {
+		presetRoles = append(presetRoles, requesterRoleName)
+	}
+	presetRoles = append(presetRoles, accessRoleNames...)
+
+	if len(presetRoles) > 0 {
+		labels[accesslist.AccessListPresetRolesLabel] = strings.Join(presetRoles, ",")
+	}
+
+	if b.cfg.ManagedByIAC != "" {
+		labels[types.IACToolLabel] = b.cfg.ManagedByIAC
+	}
+
+	al, err := accesslist.NewAccessList(b.cfg.AccessListSpec.Metadata, b.cfg.AccessListSpec.Spec)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	al.Metadata.Name = b.cfg.PresetName
+	al.Metadata.Labels = labels
+
+	// Apply grants based on preset type
+	switch b.cfg.PresetType {
+	case LongTermPresetType:
+		memberGrants := accesslist.Grants{}
+		ownerGrants := accesslist.Grants{}
+
+		// long-term: Members get access roles directly, owners get reviewer role
+		if len(accessRoleNames) > 0 {
+			memberGrants = accesslist.Grants{
+				Roles: accessRoleNames,
+			}
+		}
+		if reviewerRoleName != "" {
+			ownerGrants = accesslist.Grants{
+				Roles: []string{reviewerRoleName},
+			}
+		}
+
+		al.Spec.Grants = memberGrants
+		al.Spec.OwnerGrants = ownerGrants
+
+	case ShortTermPresetType:
+		memberGrants := accesslist.Grants{}
+		ownerGrants := accesslist.Grants{}
+
+		// Short-term: Members get requester role, owners get reviewer role
+		if requesterRoleName != "" {
+			memberGrants = accesslist.Grants{
+				Roles: []string{requesterRoleName},
+			}
+		}
+		if reviewerRoleName != "" {
+			ownerGrants = accesslist.Grants{
+				Roles: []string{reviewerRoleName},
+			}
+		}
+
+		al.Spec.Grants = memberGrants
+		al.Spec.OwnerGrants = ownerGrants
+
+	default:
+		return nil, trace.BadParameter("unknown preset type %v", b.cfg.PresetType)
+	}
+
+	return al, nil
+}
+
+// computeRolesToBeDeleted identifies roles that were in the previous access list
+// but are not in the new configuration and should be deleted.
+func (b *AccessListRolesBuilder) computeRolesToBeDeleted(old, new *accesslist.AccessList) []string {
+	return b.findRolesToDelete(old.PresetRoleNames(), new.PresetRoleNames())
+}
+
+// findRolesToDelete compares old roles with new roles and returns
+// a list of roles that should be deleted.
+func (b *AccessListRolesBuilder) findRolesToDelete(existingRoles, newRoleNames []string) []string {
+	newRoleSet := make(map[string]struct{}, len(newRoleNames))
+	for _, name := range newRoleNames {
+		newRoleSet[name] = struct{}{}
+	}
+
+	var rolesToDelete []string
+	for _, existingRole := range existingRoles {
+		if _, exists := newRoleSet[existingRole]; !exists {
+			rolesToDelete = append(rolesToDelete, existingRole)
+		}
+	}
+	return rolesToDelete
+}
+
+func (b *AccessListRolesBuilder) generateRoleName(prefix string) string {
+	return RoleName(prefix, b.cfg.PresetName)
+}
+
+// GetAllRoles returns access, access request, reviewer roles.
+func (r BuildResult) GetAllRoles() []types.Role {
+	return append([]types.Role{r.ReviewerRole, r.RequesterRole}, r.AccessRoles...)
+}
+
+// RoleName generates a role name for preset access list roles.
+// The format is: {prefix}-acl-preset-{accessListName}.
+// For example: "reviewer-acl-preset-my-access-list".
+func RoleName(prefix, accessListName string) string {
+	return fmt.Sprintf("%s-%s-%s", prefix, AccessListPresetRoleInfix, accessListName)
+}

--- a/lib/accesslists/preset/builder_test.go
+++ b/lib/accesslists/preset/builder_test.go
@@ -1,0 +1,580 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package preset_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/lib/accesslists/preset"
+)
+
+func TestPresetAccessListRolesBuilder(t *testing.T) {
+	type check func(t *testing.T, result *preset.BuildResult)
+
+	accessListName := "test-access-list"
+	appRoleName := "app-access-acl-preset-test-access-list"
+	dbRoleName := "db-access-acl-preset-test-access-list"
+	reviewerRoleName := "reviewer-acl-preset-test-access-list"
+	requesterRoleName := "requester-acl-preset-test-access-list"
+
+	appRole, err := types.NewRole("app-access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: types.Labels{"env": []string{"production"}},
+		},
+	})
+	require.NoError(t, err)
+
+	dbRole, err := types.NewRole("db-access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			DatabaseLabels: types.Labels{"env": []string{"production"}},
+		},
+	})
+	require.NoError(t, err)
+
+	al, err := accesslist.NewAccessList(
+		header.Metadata{Name: accessListName},
+		accesslist.Spec{Title: "Test Access List"},
+	)
+	require.NoError(t, err)
+
+	checkAccessListMetadata := func(presetTypeLabel string) check {
+		return func(t *testing.T, result *preset.BuildResult) {
+			require.Equal(t, accessListName, result.AccessList.GetName())
+			require.Equal(t, presetTypeLabel, result.AccessList.GetMetadata().Labels[accesslist.AccessListPresetLabel])
+			require.Equal(t, "Test Access List", result.AccessList.Spec.Title)
+		}
+	}
+
+	checkAccessListGrants := func(memberRoles, ownerRoles []string) check {
+		return func(t *testing.T, result *preset.BuildResult) {
+			require.ElementsMatch(t, memberRoles, result.AccessList.Spec.Grants.Roles)
+			require.Equal(t, ownerRoles, result.AccessList.Spec.OwnerGrants.Roles)
+		}
+	}
+
+	checkAccessRole := func(index int, name string, appLabels, dbLabels types.Labels) check {
+		return func(t *testing.T, result *preset.BuildResult) {
+			require.Greater(t, len(result.AccessRoles), index, "role index out of bounds")
+
+			role := result.AccessRoles[index]
+			require.Equal(t, name, role.GetName())
+			require.Equal(t, accessListName, role.GetMetadata().Labels[accesslist.AccessListPresetLabel])
+			require.Equal(t, preset.RoleDesc, role.GetMetadata().Description)
+
+			// Check app labels if specified
+			if appLabels != nil {
+				require.Equal(t, appLabels, role.GetAppLabels(types.Allow))
+			}
+
+			// Check database labels if specified
+			if dbLabels != nil {
+				require.Equal(t, dbLabels, role.GetDatabaseLabels(types.Allow))
+			}
+		}
+	}
+
+	checkReviewerRoleCanReviewRoles := func(roles []string) check {
+		return func(t *testing.T, result *preset.BuildResult) {
+			require.Equal(t, reviewerRoleName, result.ReviewerRole.GetName())
+			require.Equal(t, accessListName, result.ReviewerRole.GetMetadata().Labels[accesslist.AccessListPresetLabel])
+			require.Equal(t, preset.RoleDesc, result.ReviewerRole.GetMetadata().Description)
+
+			reviewCond := result.ReviewerRole.GetAccessReviewConditions(types.Allow)
+			require.ElementsMatch(t, roles, reviewCond.Roles)
+			require.ElementsMatch(t, roles, reviewCond.PreviewAsRoles)
+		}
+	}
+
+	checkRequesterRoleCanSearchAsRoles := func(roles []string) check {
+		return func(t *testing.T, result *preset.BuildResult) {
+			require.Equal(t, requesterRoleName, result.RequesterRole.GetName())
+			require.Equal(t, accessListName, result.RequesterRole.GetMetadata().Labels[accesslist.AccessListPresetLabel])
+			require.Equal(t, preset.RoleDesc, result.RequesterRole.GetMetadata().Description)
+
+			requestCond := result.RequesterRole.GetAccessRequestConditions(types.Allow)
+			require.ElementsMatch(t, roles, requestCond.SearchAsRoles)
+		}
+	}
+
+	checkNoRolesToDelete := func() check {
+		return func(t *testing.T, result *preset.BuildResult) {
+			require.Nil(t, result.RolesToBeDeleted)
+		}
+	}
+
+	tests := []struct {
+		name       string
+		presetType preset.PresetType
+		checks     []check
+	}{
+		{
+			name:       "LongTerm",
+			presetType: preset.LongTermPresetType,
+			checks: []check{
+				checkAccessListMetadata("long-term"),
+				checkAccessListGrants(
+					[]string{appRoleName, dbRoleName}, // Members get access roles directly
+					[]string{reviewerRoleName},        // Owners get reviewer role
+				),
+				checkAccessRole(0, appRoleName, types.Labels{"env": []string{"production"}}, nil),
+				checkAccessRole(1, dbRoleName, nil, types.Labels{"env": []string{"production"}}),
+				checkReviewerRoleCanReviewRoles([]string{appRoleName, dbRoleName}),
+				checkRequesterRoleCanSearchAsRoles([]string{appRoleName, dbRoleName}),
+				checkNoRolesToDelete(),
+			},
+		},
+		{
+			name:       "ShortTerm",
+			presetType: preset.ShortTermPresetType,
+			checks: []check{
+				checkAccessListMetadata("short-term"),
+				checkAccessListGrants(
+					[]string{requesterRoleName}, // Members get requester role (to request access)
+					[]string{reviewerRoleName},  // Owners get reviewer role
+				),
+				checkAccessRole(0, appRoleName, types.Labels{"env": []string{"production"}}, nil),
+				checkAccessRole(1, dbRoleName, nil, types.Labels{"env": []string{"production"}}),
+				checkReviewerRoleCanReviewRoles([]string{appRoleName, dbRoleName}),
+				checkRequesterRoleCanSearchAsRoles([]string{appRoleName, dbRoleName}),
+				checkNoRolesToDelete(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder, err := preset.NewPresetAccessListRolesBuilder(preset.AccessListRolesBuilderConfig{
+				PresetName:     accessListName,
+				PresetType:     tt.presetType,
+				AccessRoles:    []types.Role{appRole, dbRole},
+				AccessListSpec: al,
+			})
+			require.NoError(t, err)
+
+			result, err := builder.Build()
+			require.NoError(t, err)
+
+			for _, check := range tt.checks {
+				check(t, result)
+			}
+		})
+	}
+
+	t.Run("nil builtRoles leaves grants empty", func(t *testing.T) {
+		builder, err := preset.NewPresetAccessListRolesBuilder(preset.AccessListRolesBuilderConfig{
+			PresetName:     accessListName,
+			PresetType:     preset.LongTermPresetType,
+			AccessRoles:    []types.Role{appRole},
+			AccessListSpec: al,
+		})
+		require.NoError(t, err)
+
+		result, err := builder.BuildAccessList(nil)
+		require.NoError(t, err)
+
+		require.Empty(t, result.AccessList.Spec.Grants.Roles)
+		require.Empty(t, result.AccessList.Spec.OwnerGrants.Roles)
+		require.NotContains(t, result.AccessList.GetStaticLabels(), accesslist.AccessListPresetRolesLabel)
+	})
+
+	t.Run("nil access list spec returns error", func(t *testing.T) {
+		_, err := preset.NewPresetAccessListRolesBuilder(preset.AccessListRolesBuilderConfig{
+			PresetName: accessListName,
+			PresetType: preset.LongTermPresetType,
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("preset name mismatch", func(t *testing.T) {
+		otherAccessList, err := accesslist.NewAccessList(
+			header.Metadata{Name: "different-name"},
+			accesslist.Spec{Title: "Other Access List"},
+		)
+		require.NoError(t, err)
+		_, err = preset.NewPresetAccessListRolesBuilder(preset.AccessListRolesBuilderConfig{
+			PresetName:     accessListName,
+			PresetType:     preset.LongTermPresetType,
+			AccessListSpec: otherAccessList,
+		})
+		require.ErrorContains(t, err, "access list name is invalid")
+	})
+}
+
+func TestPresetAccessListRolesBuilder_RolesToBeDeleted(t *testing.T) {
+	accessListName := "test-access-list"
+
+	existingAL, err := accesslist.NewAccessList(
+		header.Metadata{
+			Name: accessListName,
+		},
+		accesslist.Spec{
+			Title:       "Test Access List",
+			Description: "Test description",
+			Grants: accesslist.Grants{
+				Roles: []string{
+					"old-role-1-acl-preset-test-access-list",
+					"old-role-2-acl-preset-test-access-list",
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	newRole, err := types.NewRole("new-role", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: types.Labels{"env": []string{"production"}},
+		},
+	})
+	require.NoError(t, err)
+
+	builder, err := preset.NewPresetAccessListRolesBuilder(preset.AccessListRolesBuilderConfig{
+		PresetName:     accessListName,
+		PresetType:     preset.LongTermPresetType,
+		AccessRoles:    []types.Role{newRole},
+		AccessListSpec: existingAL,
+	})
+	require.NoError(t, err)
+
+	result, err := builder.Build()
+	require.NoError(t, err)
+
+	require.Len(t, result.AccessRoles, 1)
+	require.Equal(t, "new-role-acl-preset-test-access-list", result.AccessRoles[0].GetName())
+}
+
+func TestPresetAccessListRolesBuilderForTerraform(t *testing.T) {
+	accessListName := "test-access-list"
+	accessRole1Name := "accessRole1-acl-preset-test-access-list"
+	accessRole2Name := "accessRole2-acl-preset-test-access-list"
+	reviewerRoleName := "reviewer-acl-preset-test-access-list"
+	requesterRoleName := "requester-acl-preset-test-access-list"
+
+	rolesLabelValue := strings.Join([]string{reviewerRoleName, requesterRoleName, accessRole1Name, accessRole2Name}, ",")
+
+	accessList, err := accesslist.NewAccessList(
+		header.Metadata{Name: accessListName},
+		accesslist.Spec{Title: "Test Access List"},
+	)
+	require.NoError(t, err)
+
+	accessRole1, err := types.NewRole("accessRole1", types.RoleSpecV6{})
+	require.NoError(t, err)
+
+	accessRole2, err := types.NewRole("accessRole2", types.RoleSpecV6{})
+	require.NoError(t, err)
+
+	checkCommonLabelsAndRoles := func(result *preset.BuildResult) {
+		require.Equal(t, []string{reviewerRoleName}, result.AccessList.Spec.OwnerGrants.Roles)
+
+		staticLabels := result.AccessList.GetStaticLabels()
+		require.Len(t, result.AccessRoles, 2)
+		require.Equal(t, types.IACToolTerraform, staticLabels[types.IACToolLabel])
+		require.Equal(t, rolesLabelValue, staticLabels[accesslist.AccessListPresetRolesLabel])
+
+		require.Len(t, result.GetAllRoles(), 4) // 2 access roles + reviewer + requester
+		for _, role := range result.GetAllRoles() {
+			labels := role.GetStaticLabels()
+			require.Equal(t, types.IACToolTerraform, labels[types.IACToolLabel], "role %s missing terraform label", role.GetName())
+			require.Equal(t, accessListName, labels[accesslist.AccessListPresetLabel], "role %s missing access list preset label", role.GetName())
+			require.Empty(t, role.GetMetadata().Description, "role %s should have no description", role.GetName())
+		}
+	}
+
+	tests := []struct {
+		name        string
+		presetType  preset.PresetType
+		accessList  *accesslist.AccessList
+		accessRoles []types.Role
+		validate    func(t *testing.T, result *preset.BuildResult)
+	}{
+		{
+			name:        "long term build",
+			presetType:  preset.LongTermPresetType,
+			accessList:  accessList,
+			accessRoles: []types.Role{accessRole1, accessRole2},
+			validate: func(t *testing.T, result *preset.BuildResult) {
+				checkCommonLabelsAndRoles(result)
+				require.Equal(t, string(preset.LongTermPresetType), result.AccessList.GetMetadata().Labels[accesslist.AccessListPresetLabel])
+				require.ElementsMatch(t, []string{accessRole1Name, accessRole2Name}, result.AccessList.Spec.Grants.Roles)
+			},
+		},
+		{
+			name:        "short term build",
+			presetType:  preset.ShortTermPresetType,
+			accessList:  accessList,
+			accessRoles: []types.Role{accessRole1, accessRole2},
+			validate: func(t *testing.T, result *preset.BuildResult) {
+				checkCommonLabelsAndRoles(result)
+				require.Equal(t, string(preset.ShortTermPresetType), result.AccessList.GetMetadata().Labels[accesslist.AccessListPresetLabel])
+				require.ElementsMatch(t, []string{requesterRoleName}, result.AccessList.Spec.Grants.Roles)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			builder, err := preset.NewPresetAccessListRolesBuilderForTerraform(preset.AccessListRolesBuilderConfig{
+				PresetName:     accessListName,
+				PresetType:     tc.presetType,
+				AccessRoles:    tc.accessRoles,
+				AccessListSpec: tc.accessList,
+			})
+			require.NoError(t, err)
+
+			result, err := builder.Build()
+			require.NoError(t, err)
+
+			tc.validate(t, result)
+		})
+	}
+
+	t.Run("nil builtRoles leaves grants empty", func(t *testing.T) {
+		builder, err := preset.NewPresetAccessListRolesBuilderForTerraform(preset.AccessListRolesBuilderConfig{
+			PresetName:     accessListName,
+			PresetType:     preset.ShortTermPresetType,
+			AccessListSpec: accessList,
+		})
+		require.NoError(t, err)
+
+		builtRoles, err := builder.BuildRoles()
+		require.NoError(t, err)
+		require.Empty(t, builtRoles.AccessRoles)
+
+		builtAl, err := builder.BuildAccessList(nil)
+		require.NoError(t, err)
+		require.NotNil(t, builtAl.AccessList)
+		require.Empty(t, builtAl.AccessList.Spec.Grants.Roles)
+		require.Empty(t, builtAl.AccessList.Spec.OwnerGrants.Roles)
+		require.NotContains(t, builtAl.AccessList.GetStaticLabels(), accesslist.AccessListPresetRolesLabel)
+	})
+
+	t.Run("invalid preset type", func(t *testing.T) {
+		_, err := preset.NewPresetAccessListRolesBuilderForTerraform(preset.AccessListRolesBuilderConfig{
+			PresetName:     accessListName,
+			PresetType:     "unknown",
+			AccessListSpec: accessList,
+		})
+		require.ErrorContains(t, err, "preset type is required")
+	})
+
+	t.Run("preset name mismatch", func(t *testing.T) {
+		otherAccessList, err := accesslist.NewAccessList(
+			header.Metadata{Name: "different-name"},
+			accesslist.Spec{Title: "Other Access List"},
+		)
+		require.NoError(t, err)
+		_, err = preset.NewPresetAccessListRolesBuilderForTerraform(preset.AccessListRolesBuilderConfig{
+			PresetName:     accessListName,
+			PresetType:     preset.LongTermPresetType,
+			AccessListSpec: otherAccessList,
+		})
+		require.ErrorContains(t, err, "access list name is invalid")
+	})
+}
+
+func TestPresetAccessListRolesBuilder_Added(t *testing.T) {
+	accessListName := "test-access-list"
+
+	al, err := accesslist.NewAccessList(
+		header.Metadata{Name: accessListName},
+		accesslist.Spec{Title: "Test Access List"},
+	)
+	require.NoError(t, err)
+
+	devRole, err := types.NewRole("dev", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: types.Labels{"env": []string{"dev"}},
+		},
+	})
+	require.NoError(t, err)
+
+	prodRole, err := types.NewRole("prod", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: types.Labels{"env": []string{"prod"}},
+		},
+	})
+	require.NoError(t, err)
+
+	builder, err := preset.NewPresetAccessListRolesBuilder(preset.AccessListRolesBuilderConfig{
+		PresetName:     accessListName,
+		PresetType:     preset.LongTermPresetType,
+		AccessRoles:    []types.Role{devRole},
+		AccessListSpec: al,
+	})
+	require.NoError(t, err)
+
+	result, err := builder.Build()
+	require.NoError(t, err)
+
+	require.NotNil(t, result.AccessList)
+	require.Empty(t, result.RolesToBeDeleted)
+	require.Len(t, result.AccessRoles, 1)
+	require.Equal(t, result.AccessRoles[0].GetName(), preset.RoleName(devRole.GetName(), accessListName))
+
+	builder, err = preset.NewPresetAccessListRolesBuilder(preset.AccessListRolesBuilderConfig{
+		PresetName:     accessListName,
+		PresetType:     preset.ShortTermPresetType,
+		AccessRoles:    []types.Role{result.AccessRoles[0], prodRole},
+		AccessListSpec: result.AccessList,
+	})
+	require.NoError(t, err)
+
+	result, err = builder.Build()
+	require.NoError(t, err)
+
+	require.NotNil(t, result.AccessList)
+	require.Empty(t, result.RolesToBeDeleted)
+	require.Len(t, result.AccessRoles, 2)
+	require.Equal(t, result.AccessRoles[0].GetName(), preset.RoleName(devRole.GetName(), accessListName))
+	require.Equal(t, result.AccessRoles[1].GetName(), preset.RoleName(prodRole.GetName(), accessListName))
+
+	builder, err = preset.NewPresetAccessListRolesBuilder(preset.AccessListRolesBuilderConfig{
+		PresetName:     accessListName,
+		PresetType:     preset.ShortTermPresetType,
+		AccessRoles:    []types.Role{result.AccessRoles[0]},
+		AccessListSpec: result.AccessList,
+	})
+	require.NoError(t, err)
+
+	result, err = builder.Build()
+	require.NoError(t, err)
+
+	require.NotNil(t, result.AccessList)
+	require.Len(t, result.RolesToBeDeleted, 1)
+	require.Equal(t, result.AccessRoles[0].GetName(), preset.RoleName(devRole.GetName(), accessListName))
+}
+
+func TestPresetAccessListRolesBuilder_PreservesExistingRoleLabels(t *testing.T) {
+	accessListName := "test-access-list"
+
+	al, err := accesslist.NewAccessList(
+		header.Metadata{Name: accessListName},
+		accesslist.Spec{Title: "Test Access List"},
+	)
+	require.NoError(t, err)
+
+	existingRole, err := types.NewRole(
+		preset.RoleName("app-access", accessListName),
+		types.RoleSpecV6{
+			Allow: types.RoleConditions{
+				AppLabels: types.Labels{"env": []string{"production"}},
+			},
+		},
+	)
+	require.NoError(t, err)
+	existingRole.SetStaticLabels(map[string]string{
+		accesslist.AccessListPresetLabel: accessListName,
+		"owner":                          "team-foo",
+		"env":                            "dev",
+	})
+
+	t.Run("non-IAC update preserves all existing labels", func(t *testing.T) {
+		builder, err := preset.NewPresetAccessListRolesBuilder(preset.AccessListRolesBuilderConfig{
+			PresetName:     accessListName,
+			PresetType:     preset.LongTermPresetType,
+			AccessRoles:    []types.Role{existingRole.Clone()},
+			AccessListSpec: al,
+		})
+		require.NoError(t, err)
+
+		result, err := builder.Build()
+		require.NoError(t, err)
+
+		require.Len(t, result.AccessRoles, 1)
+		labels := result.AccessRoles[0].GetStaticLabels()
+		require.Equal(t, accessListName, labels[accesslist.AccessListPresetLabel])
+		require.Equal(t, "team-foo", labels["owner"])
+		require.Equal(t, "dev", labels["env"])
+	})
+
+	t.Run("IAC update preserves unrelated labels and adds IAC label", func(t *testing.T) {
+		builder, err := preset.NewPresetAccessListRolesBuilderForTerraform(preset.AccessListRolesBuilderConfig{
+			PresetName:     accessListName,
+			PresetType:     preset.LongTermPresetType,
+			AccessRoles:    []types.Role{existingRole.Clone()},
+			AccessListSpec: al,
+		})
+		require.NoError(t, err)
+
+		result, err := builder.Build()
+		require.NoError(t, err)
+
+		require.Len(t, result.AccessRoles, 1)
+		labels := result.AccessRoles[0].GetStaticLabels()
+		require.Equal(t, accessListName, labels[accesslist.AccessListPresetLabel])
+		require.Equal(t, types.IACToolTerraform, labels[types.IACToolLabel])
+		require.Equal(t, "team-foo", labels["owner"])
+		require.Equal(t, "dev", labels["env"])
+	})
+}
+
+func TestNewPresetAccessListRolesBuilder_Validation(t *testing.T) {
+	accessListName := "test-access-list"
+
+	al, err := accesslist.NewAccessList(
+		header.Metadata{Name: accessListName},
+		accesslist.Spec{Title: "Test Access List"},
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		cfg     preset.AccessListRolesBuilderConfig
+		wantErr string
+	}{
+		{
+			name: "nil access list spec",
+			cfg: preset.AccessListRolesBuilderConfig{
+				PresetName:     accessListName,
+				PresetType:     preset.LongTermPresetType,
+				AccessListSpec: nil,
+			},
+			wantErr: "access list is required",
+		},
+		{
+			name: "invalid preset type",
+			cfg: preset.AccessListRolesBuilderConfig{
+				PresetName:     accessListName,
+				PresetType:     "unknown",
+				AccessListSpec: al,
+			},
+			wantErr: "preset type is required",
+		},
+		{
+			name: "preset name mismatch",
+			cfg: preset.AccessListRolesBuilderConfig{
+				PresetName:     "different-name",
+				PresetType:     preset.LongTermPresetType,
+				AccessListSpec: al,
+			},
+			wantErr: "access list name is invalid",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := preset.NewPresetAccessListRolesBuilder(tc.cfg)
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}

--- a/tool/tctl/common/accesslist/preset.go
+++ b/tool/tctl/common/accesslist/preset.go
@@ -22,8 +22,8 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/common"
+	"github.com/gravitational/teleport/lib/accesslists/preset"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -73,11 +73,11 @@ func buildRole(roleName string, allow types.RoleConditions) (*types.RoleV6, erro
 }
 
 // accessType maps the backend value into the user facing accessType value.
-func accessType(preset string) string {
-	switch preset {
-	case string(accesslist.LongTermPresetType):
+func accessType(presetType string) string {
+	switch presetType {
+	case string(preset.LongTermPresetType):
 		return accessTypeLongTerm
-	case string(accesslist.ShortTermPresetType):
+	case string(preset.ShortTermPresetType):
 		return accessTypeShortTerm
 	}
 	return ""

--- a/tool/tctl/common/accesslist/update.go
+++ b/tool/tctl/common/accesslist/update.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	conv "github.com/gravitational/teleport/api/types/accesslist/convert/v1"
+	"github.com/gravitational/teleport/lib/accesslists/preset"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/parse"
@@ -510,7 +511,7 @@ func (c *Command) printUpdateText(r UpdateJSONResponse) {
 // - not attached + updates requested: return a fresh role with updates applied
 // - not attached + no updates: return nil
 func resolveAccessRole(ctx context.Context, client *authclient.Client, al *accesslist.AccessList, prefix string, applyUpdates applyAccessFlagsToRole) (*types.RoleV6, error) {
-	roleName := accesslist.RoleName(prefix, al.GetName())
+	roleName := preset.RoleName(prefix, al.GetName())
 	role, err := getAccessRoleByName(ctx, client, roleName)
 	if err != nil && !trace.IsNotFound(err) {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
This PR moves the [e/builder.go](https://github.com/gravitational/teleport.e/blob/fdc915a6416c9fedf96a567194e4900f21c409ba/lib/accesslist/preset/builder.go) and its test file into open source (just copy and pasta). The file is just about constructing role and access list resources and nothing in it requires enterprise only code. 

This move was necessary to allow reusing this builder in `tctl` (to support terraform generation). The other alternative, which allowed this file to remain in enterprise, was to create a RPC endpoint that returned terraform text but I thought that was too much.

I'll do some e2e testing once i remove the `builder.go` from enterprise. The files created in this PR is not used yet (other than consts)

part of https://github.com/gravitational/teleport.e/issues/8271 

