### PR TITLE
[v18] backport scope pinned openssh support

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -259,7 +259,6 @@ type upsertServerRawReq struct {
 
 // presenceForAPIServer is a subset of [services.Presence].
 type presenceForAPIServer interface {
-	UpsertNode(ctx context.Context, s types.Server) (*types.KeepAlive, error)
 	UpsertAuthServer(ctx context.Context, s types.Server) error
 	UpsertProxy(ctx context.Context, s types.Server) error
 }
@@ -272,8 +271,6 @@ func (s *APIServer) upsertServer(auth presenceForAPIServer, role types.SystemRol
 	}
 	var kind string
 	switch role {
-	case types.RoleNode:
-		kind = types.KindNode
 	case types.RoleAuth:
 		kind = types.KindAuthServer
 	case types.RoleProxy:
@@ -281,6 +278,12 @@ func (s *APIServer) upsertServer(auth presenceForAPIServer, role types.SystemRol
 	default:
 		return nil, trace.BadParameter("upsertServer with unknown role: %q", role)
 	}
+	// UnmarshalServer forces s.Kind = kind, ignoring the Kind in the payload.
+	// This is retained for backwards compatibility: prior to v19, proxy
+	// heartbeats sent the resource with Kind=KindNode over the wire (see
+	// https://github.com/gravitational/teleport/issues/66997). v19+ proxies
+	// send the correct kind; the override remains so older proxies in mixed
+	// clusters continue to work.
 	server, err := services.UnmarshalServer(req.Server, kind)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -291,18 +294,8 @@ func (s *APIServer) upsertServer(auth presenceForAPIServer, role types.SystemRol
 	if req.TTL != 0 {
 		server.SetExpiry(s.Now().UTC().Add(req.TTL))
 	}
+
 	switch role {
-	case types.RoleNode:
-		namespace := p.ByName("namespace")
-		if !types.IsValidNamespace(namespace) {
-			return nil, trace.BadParameter("invalid namespace %q", namespace)
-		}
-		server.SetNamespace(namespace)
-		handle, err := auth.UpsertNode(r.Context(), server)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return handle, nil
 	case types.RoleAuth:
 		if err := auth.UpsertAuthServer(r.Context(), server); err != nil {
 			return nil, trace.Wrap(err)
@@ -329,7 +322,9 @@ func (s *APIServer) keepAliveNode(auth *ServerWithRoles, w http.ResponseWriter, 
 	return message("ok"), nil
 }
 
-// upsertProxy is called by remote SSH nodes when they ping back into the auth service
+// upsertProxy registers a proxy server heartbeat sent via the legacy HTTP endpoint.
+//
+// TODO(noah): move to httpMigratedHandler in v20.0.0
 func (s *APIServer) upsertProxy(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	return s.upsertServer(auth, types.RoleProxy, r, p)
 }

--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -19,130 +19,14 @@
 package auth_test
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/julienschmidt/httprouter"
 	"github.com/stretchr/testify/require"
 
-	apidefaults "github.com/gravitational/teleport/api/defaults"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
-	"github.com/gravitational/teleport/lib/services"
 )
-
-func TestUpsertServer(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	const remoteAddr = "request-remote-addr"
-
-	tests := []struct {
-		desc       string
-		role       types.SystemRole
-		reqServer  types.Server
-		wantServer types.Server
-		assertErr  require.ErrorAssertionFunc
-	}{
-		{
-			desc: "node",
-			reqServer: &types.ServerV2{
-				Metadata: types.Metadata{Name: "test-server", Namespace: apidefaults.Namespace},
-				Version:  types.V2,
-				Kind:     types.KindNode,
-			},
-			role: types.RoleNode,
-			wantServer: &types.ServerV2{
-				Metadata: types.Metadata{Name: "test-server", Namespace: apidefaults.Namespace},
-				Version:  types.V2,
-				Kind:     types.KindNode,
-			},
-			assertErr: require.NoError,
-		},
-		{
-			desc: "proxy",
-			reqServer: &types.ServerV2{
-				Metadata: types.Metadata{Name: "test-server", Namespace: apidefaults.Namespace},
-				Version:  types.V2,
-				Kind:     types.KindProxy,
-			},
-			role: types.RoleProxy,
-			wantServer: &types.ServerV2{
-				Metadata: types.Metadata{Name: "test-server", Namespace: apidefaults.Namespace},
-				Version:  types.V2,
-				Kind:     types.KindProxy,
-			},
-			assertErr: require.NoError,
-		},
-		{
-			desc: "auth",
-			reqServer: &types.ServerV2{
-				Metadata: types.Metadata{Name: "test-server", Namespace: apidefaults.Namespace},
-				Version:  types.V2,
-				Kind:     types.KindAuthServer,
-			},
-			role: types.RoleAuth,
-			wantServer: &types.ServerV2{
-				Metadata: types.Metadata{Name: "test-server", Namespace: apidefaults.Namespace},
-				Version:  types.V2,
-				Kind:     types.KindAuthServer,
-			},
-			assertErr: require.NoError,
-		},
-		{
-			desc: "unknown",
-			reqServer: &types.ServerV2{
-				Metadata: types.Metadata{Name: "test-server", Namespace: apidefaults.Namespace},
-				Version:  types.V2,
-				Kind:     types.KindNode,
-			},
-			role:      types.SystemRole("unknown"),
-			assertErr: require.Error,
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-			// Set up backend to upsert servers into.
-			s := newTestServices(t)
-
-			// Create a fake HTTP request.
-			inSrv, err := services.MarshalServer(tt.reqServer)
-			require.NoError(t, err)
-			body, err := json.Marshal(auth.UpsertServerRawReq{Server: inSrv})
-			require.NoError(t, err)
-			req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(body))
-			req.RemoteAddr = remoteAddr
-			req.Header.Add("Content-Type", "application/json")
-
-			_, err = auth.UpsertServer(new(auth.APIServer), s, tt.role, req, httprouter.Params{httprouter.Param{Key: "namespace", Value: apidefaults.Namespace}})
-			tt.assertErr(t, err)
-			if err != nil {
-				return
-			}
-
-			// Fetch all servers from the backend, there should only be 1.
-			var allServers []types.Server
-			addServers := func(servers []types.Server, err error) {
-				require.NoError(t, err)
-				allServers = append(allServers, servers...)
-			}
-			//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
-			addServers(s.GetAuthServers())
-			addServers(s.GetNodes(ctx, apidefaults.Namespace))
-			//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
-			addServers(s.GetProxies())
-			require.Empty(t, cmp.Diff(allServers, []types.Server{tt.wantServer}, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
-		})
-	}
-}
 
 // TestTokensRegisterReturnsTooOldError verifies that the re-added /tokens/register
 // route returns an explicit "too old" error rather than a 404, so that outdated

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1130,30 +1130,27 @@ func (a *ServerWithRoles) ClearAlertAcks(ctx context.Context, req proto.ClearAle
 	return a.authServer.ClearAlertAcks(ctx, req)
 }
 
-func (a *ServerWithRoles) UpsertNode(ctx context.Context, s types.Server) (*types.KeepAlive, error) {
+func (a *ScopedServerWithRoles) UpsertNode(ctx context.Context, s types.Server) (*types.KeepAlive, error) {
+	ruleCtx := a.scopedContext.RuleContext()
 	// Note: UpsertNode doesn't allow any namespaces but "default".
-	if err := a.authorizeAction(types.KindNode, types.VerbCreate, types.VerbUpdate); err != nil {
+	// The Decision API only checks on the default namespace.
+	if err := a.scopedContext.CheckerContext.Decision(ctx, s.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		return checker.CheckAccessToRules(&ruleCtx, types.KindNode, types.VerbCreate, types.VerbUpdate)
+	}); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	agentScope := a.context.Identity.GetIdentity().GetAgentScope()
+	agentScope := a.scopedContext.Identity.GetIdentity().GetAgentScope()
 	if nodeScope := s.GetScope(); agentScope != "" {
 		if nodeScope != agentScope {
 			return nil, trace.AccessDenied("node scope %q does not match agent identity scope %q", nodeScope, agentScope)
 		}
+	}
 
-		if a.hasBuiltinRole(types.RoleNode) {
-			clusterName, err := a.GetDomainName(ctx)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			callerID, err := ExtractHostID(a.context.User.GetName(), clusterName)
-			if err != nil {
-				return nil, trace.AccessDenied("access denied")
-			}
-			if s.GetName() != callerID {
-				return nil, trace.AccessDenied("node ID %q does not match agent identity ID %q", s.GetName(), callerID)
-			}
+	if a.hasBuiltinRole(types.RoleNode) {
+		callerID, _ := getBuiltinServerID(a.scopedContext.Identity)
+		if s.GetName() != callerID {
+			return nil, trace.AccessDenied("node ID %q does not match agent identity ID %q", s.GetName(), callerID)
 		}
 	}
 

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -61,6 +61,7 @@ import (
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	userpreferencesv1 "github.com/gravitational/teleport/api/gen/proto/go/userpreferences/v1"
 	"github.com/gravitational/teleport/api/metadata"
@@ -8802,6 +8803,80 @@ func newScopePinnedTestServerForHost(t *testing.T, srv *authtest.AuthServer, hos
 	return authWithRole
 }
 
+func newScopedTestServerWithUnscopedUser(t *testing.T, srv *authtest.AuthServer, username string, allowRules []types.Rule) *auth.ScopedServerWithRoles {
+	t.Helper()
+	ctx := t.Context()
+
+	user, role, err := authtest.CreateUserAndRole(srv.AuthServer, username, nil, allowRules)
+	require.NoError(t, err)
+
+	authCtx, err := srv.Authorizer.Authorize(authz.ContextWithUser(ctx, authtest.TestUserWithRoles(user.GetName(), []string{role.GetName()}).I))
+	require.NoError(t, err)
+
+	scoped := auth.NewServerWithRoles(srv.AuthServer, srv.AuditLog, *authCtx).ScopedServerWithRoles()
+	t.Cleanup(func() { scoped.Close() })
+	return scoped
+}
+
+func newScopePinnedTestServerWithScopedUser(t *testing.T, srv *authtest.AuthServer, username, scope string, rules []*scopedaccessv1.ScopedRule) *auth.ScopedServerWithRoles {
+	t.Helper()
+	ctx := t.Context()
+
+	_, err := authtest.CreateUser(ctx, srv.AuthServer, username)
+	require.NoError(t, err)
+
+	scopedAccess := srv.AuthServer.ScopedAccess()
+	roleName := username + "-role"
+	_, err = scopedAccess.CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+		Role: scopedaccessv1.ScopedRole_builder{
+			Kind:     scopedaccess.KindScopedRole,
+			Version:  types.V1,
+			Metadata: headerv1.Metadata_builder{Name: roleName}.Build(),
+			Scope:    scope,
+			Spec: scopedaccessv1.ScopedRoleSpec_builder{
+				Rules:            rules,
+				AssignableScopes: []string{scope},
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	_, err = scopedAccess.CreateScopedRoleAssignment(ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
+		Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
+			Kind:     scopedaccess.KindScopedRoleAssignment,
+			SubKind:  scopedaccess.SubKindDynamic,
+			Version:  types.V1,
+			Metadata: headerv1.Metadata_builder{Name: uuid.NewString()}.Build(),
+			Scope:    scope,
+			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+				User: username,
+				Assignments: []*scopedaccessv1.Assignment{
+					scopedaccessv1.Assignment_builder{Role: roleName, Scope: scope}.Build(),
+				},
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	pin := scopesv1.Pin_builder{Kind: scopesv1.PinKind_PIN_KIND_USER, Scope: scope}.Build()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		err := srv.AuthServer.ScopedAccessCache.PopulatePinnedAssignmentsForUser(ctx, username, pin)
+		assert.NoError(c, err)
+		assert.NotNil(c, pin.GetAssignmentTree())
+	}, 10*time.Second, 100*time.Millisecond)
+
+	identity := authz.LocalUser{
+		Username: username,
+		Identity: tlsca.Identity{Username: username, ScopePin: pin},
+	}
+	scopedCtx, err := srv.ScopedAuthorizer.AuthorizeScoped(authz.ContextWithUser(ctx, identity))
+	require.NoError(t, err)
+
+	authWithRole := auth.NewScopedServerWithRoles(srv.AuthServer, srv.AuditLog, scopedCtx)
+	t.Cleanup(func() { authWithRole.Close() })
+	return authWithRole
+}
+
 func TestGenerateHostCertsScoped(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -8847,9 +8922,15 @@ func TestGenerateHostCertsScoped(t *testing.T) {
 
 func TestUpsertNode(t *testing.T) {
 	t.Parallel()
-	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	authsrv, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir: t.TempDir(),
+		ScopesFeatures: scopes.Features{
+			Enabled:         true,
+			AgentPinEnabled: true,
+		},
+	})
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	t.Cleanup(func() { require.NoError(t, authsrv.Close()) })
 
 	const nodeName = "test1"
 	const otherID = "test2"
@@ -8872,44 +8953,91 @@ func TestUpsertNode(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		callerScope string
-		nodeName    string
-		nodeScope   string
-		shouldErr   bool
+		name      string
+		server    *auth.ScopedServerWithRoles
+		nodeName  string
+		nodeScope string
+		shouldErr bool
 	}{
 		{
-			name:        "unscoped - bypasses node ID check",
-			callerScope: "",
-			nodeName:    otherID,
-			nodeScope:   "",
+			name:     "unscoped node - own node allowed",
+			server:   newScopedTestServerForHost(t, authsrv, nodeName, "", types.RoleNode).ScopedServerWithRoles(),
+			nodeName: nodeName,
 		},
 		{
-			name:        "scoped - matching ID and scope allowed",
-			callerScope: "/staging",
-			nodeName:    nodeName,
-			nodeScope:   "/staging",
+			// Node agents may only upsert their own node resource, scoped or not.
+			name:      "unscoped node - mismatched ID denied",
+			server:    newScopedTestServerForHost(t, authsrv, nodeName, "", types.RoleNode).ScopedServerWithRoles(),
+			nodeName:  otherID,
+			shouldErr: true,
 		},
 		{
-			name:        "scoped - matching ID but mismatched scope denied",
-			callerScope: "/staging",
-			nodeName:    nodeName,
-			nodeScope:   "/prod",
-			shouldErr:   true,
+			name:      "agent scope - matching ID and scope allowed",
+			server:    newScopedTestServerForHost(t, authsrv, nodeName, "/staging", types.RoleNode).ScopedServerWithRoles(),
+			nodeName:  nodeName,
+			nodeScope: "/staging",
 		},
 		{
-			name:        "scoped - matching scope but mismatched ID denied",
-			callerScope: "/staging",
-			nodeName:    otherID,
-			nodeScope:   "/staging",
-			shouldErr:   true,
+			name:      "agent scope - mismatched scope denied",
+			server:    newScopedTestServerForHost(t, authsrv, nodeName, "/staging", types.RoleNode).ScopedServerWithRoles(),
+			nodeName:  nodeName,
+			nodeScope: "/prod",
+			shouldErr: true,
+		},
+		{
+			name:      "agent scope - mismatched ID denied",
+			server:    newScopedTestServerForHost(t, authsrv, nodeName, "/staging", types.RoleNode).ScopedServerWithRoles(),
+			nodeName:  otherID,
+			nodeScope: "/staging",
+			shouldErr: true,
+		},
+		{
+			name:      "agent pin - matching ID and scope allowed",
+			server:    newScopePinnedTestServerForHost(t, authsrv, nodeName, "/staging", types.RoleNode),
+			nodeName:  nodeName,
+			nodeScope: "/staging",
+		},
+		{
+			name:      "agent pin - node scope orthogonal to pinned scope denied",
+			server:    newScopePinnedTestServerForHost(t, authsrv, nodeName, "/staging", types.RoleNode),
+			nodeName:  nodeName,
+			nodeScope: "/prod",
+			shouldErr: true,
+		},
+		{
+			name:      "agent pin - mismatched ID denied",
+			server:    newScopePinnedTestServerForHost(t, authsrv, nodeName, "/staging", types.RoleNode),
+			nodeName:  otherID,
+			nodeScope: "/staging",
+			shouldErr: true,
+		},
+		{
+			name: "unscoped user with node rules allowed",
+			server: newScopedTestServerWithUnscopedUser(t, authsrv, "node-admin",
+				[]types.Rule{types.NewRule(types.KindNode, []string{types.VerbCreate, types.VerbUpdate})}),
+			nodeName: otherID,
+		},
+		{
+			name:      "unscoped user without node rules denied",
+			server:    newScopedTestServerWithUnscopedUser(t, authsrv, "plain-user", nil),
+			nodeName:  otherID,
+			shouldErr: true,
+		},
+		{
+			// Scoped roles cannot be created with node write permissions, so a scoped
+			// user never holds node:create/update and Decision should fail. Change this in the future
+			// if we ever let scoped users permissions for nodes.
+			name:      "scoped user denied",
+			server:    newScopePinnedTestServerWithScopedUser(t, authsrv, "scoped-user", "/staging", nil),
+			nodeName:  otherID,
+			nodeScope: "/staging",
+			shouldErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			srv := newScopedTestServerForHost(t, as, nodeName, tt.callerScope, types.RoleNode)
-			_, err := srv.UpsertNode(t.Context(), makeNode(t, tt.nodeName, tt.nodeScope))
+			_, err := tt.server.UpsertNode(t.Context(), makeNode(t, tt.nodeName, tt.nodeScope))
 			if tt.shouldErr {
 				require.Error(t, err)
 				require.True(t, trace.IsAccessDenied(err))

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -1293,6 +1293,7 @@ func TestScopePinnedHost(clusterName, hostID, scope string, roles ...types.Syste
 			ServerFQDN:  serverFQDN,
 			ScopePin:    pin,
 			Identity: tlsca.Identity{
+				Username: serverFQDN,
 				ScopePin: pin,
 			},
 		},

--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
-	"github.com/julienschmidt/httprouter"
 	"google.golang.org/grpc/credentials"
 
 	"github.com/gravitational/teleport/api/client"
@@ -255,12 +254,6 @@ func EncodeProquint(x uint16) string {
 
 func EmitSSOLoginFailureEvent(ctx context.Context, emitter apievents.Emitter, method string, err error, testFlow bool) {
 	emitSSOLoginFailureEvent(ctx, emitter, method, err, testFlow)
-}
-
-type UpsertServerRawReq = upsertServerRawReq
-
-func UpsertServer(srv *APIServer, auth presenceForAPIServer, role types.SystemRole, r *http.Request, p httprouter.Params) (any, error) {
-	return srv.upsertServer(auth, role, r, p)
 }
 
 func NewServerWithRoles(srv *Server, alog events.AuditLogSessionStreamer, authzContext authz.Context) *ServerWithRoles {

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -3848,7 +3848,7 @@ func (g *GRPCServer) GetNode(ctx context.Context, req *types.ResourceInNamespace
 
 // UpsertNode upserts a node.
 func (g *GRPCServer) UpsertNode(ctx context.Context, node *types.ServerV2) (*types.KeepAlive, error) {
-	auth, err := g.authenticate(ctx)
+	auth, err := g.scopedAuthenticate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -3862,7 +3862,7 @@ func (g *GRPCServer) UpsertNode(ctx context.Context, node *types.ServerV2) (*typ
 	}
 	node.SetAddr(utils.ReplaceLocalhost(node.GetAddr(), p.Addr.String()))
 
-	keepAlive, err := auth.ServerWithRoles.UpsertNode(ctx, node)
+	keepAlive, err := auth.UpsertNode(ctx, node)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -26,7 +26,6 @@ import (
 	"encoding/base32"
 	"encoding/pem"
 	"errors"
-	"fmt"
 	"net"
 	"net/url"
 	"os"
@@ -4282,12 +4281,12 @@ func TestEventsNodePresence(t *testing.T) {
 
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
-
+	nodeName := "node1." + testSrv.ClusterName()
 	node := &types.ServerV2{
 		Kind:    types.KindNode,
 		Version: types.V2,
 		Metadata: types.Metadata{
-			Name:      "node1",
+			Name:      nodeName,
 			Namespace: apidefaults.Namespace,
 		},
 		Spec: types.ServerSpecV2{
@@ -4298,7 +4297,7 @@ func TestEventsNodePresence(t *testing.T) {
 	clt, err := testSrv.NewClient(authtest.TestIdentity{
 		I: authz.BuiltinRole{
 			Role:     types.RoleNode,
-			Username: fmt.Sprintf("%v.%v", node.Metadata.Name, testSrv.ClusterName()),
+			Username: nodeName,
 		},
 	})
 	require.NoError(t, err)

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -2669,7 +2669,9 @@ func TestParseSubsystemRequest(t *testing.T) {
 		require.NoError(t, reverseTunnelServer.Start())
 		t.Cleanup(func() { _ = reverseTunnelServer.Close() })
 
-		nodeClient, _ := newNodeClient(t, f.testSrv)
+		nodeClient, nodeID := newNodeClient(t, f.testSrv)
+
+		agentlessSrv.Metadata.Name = nodeID // overwrite the nodeID
 
 		_, err = nodeClient.UpsertNode(ctx, &agentlessSrv)
 		require.NoError(t, err)


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/68351

UpsertAuthServer looks to be still in use, so I've only deleted the `UpsertNode`


<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: 


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster, docker open ssh nodes

### Test Cases
With Agent pins enabled
- [x] OpenSSH nodes can be registered
- [x] Scoped and unscoped users can access the open ssh node
- [x] Scoped users cannot access orthogonal scopes

With Agent pins disabled
- [x] OpenSSH nodes can be registered
- [x] Scoped and unscoped users can access the open ssh node
- [x] Scoped users cannot access orthogonal scopes
