### PR TITLE
kube: route tsh kubectl through local proxy under hardware keys

### DIFF
--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -834,7 +834,7 @@ func isNetworkError(err error) bool {
 }
 
 func (c *kubeCredentialsCommand) checkLocalProxyRequirement(profile *profile.Profile) error {
-	if profile.RequireKubeLocalProxy() {
+	if profile.RequireKubeLocalProxy() || profile.PrivateKeyPolicy.IsHardwareKeyPolicy() {
 		return trace.BadParameter("Cannot connect Kubernetes clients to Teleport Proxy directly. Please use `tsh proxy kube` or `tsh kubectl` instead.")
 	}
 	return nil

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keypaths"
+	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
@@ -787,4 +788,59 @@ func newKubeSelfSubjectServer(t *testing.T) string {
 	t.Cleanup(func() { srv.Close() })
 
 	return srv.URL
+}
+
+func Test_kubeCredentialsCommand_checkLocalProxyRequirement(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		inputProfile *profile.Profile
+		wantErr      bool
+	}{
+		{
+			name: "no requirement",
+			inputProfile: &profile.Profile{
+				WebProxyAddr:  "example.com:443",
+				KubeProxyAddr: "example.com:3026",
+			},
+			wantErr: false,
+		},
+		{
+			name: "kube local proxy required",
+			inputProfile: &profile.Profile{
+				WebProxyAddr:                  "example.com:443",
+				KubeProxyAddr:                 "example.com:443",
+				TLSRoutingConnUpgradeRequired: true,
+			},
+			wantErr: true,
+		},
+		{
+			// A hardware-key policy can't be serialized for the exec plugin, so
+			// the credentials command must return an actionable error even when
+			// a local proxy would not otherwise be required.
+			name: "hardware key policy",
+			inputProfile: &profile.Profile{
+				WebProxyAddr:     "example.com:443",
+				KubeProxyAddr:    "example.com:3026",
+				PrivateKeyPolicy: keys.PrivateKeyPolicyHardwareKeyTouch,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := &kubeCredentialsCommand{}
+			err := c.checkLocalProxyRequirement(test.inputProfile)
+			if !test.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			// The error must be the actionable one, not the opaque PEM failure.
+			require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
+			require.ErrorContains(t, err, "tsh proxy kube")
+			require.ErrorContains(t, err, "tsh kubectl")
+		})
+	}
 }

--- a/tool/tsh/common/kubectl.go
+++ b/tool/tsh/common/kubectl.go
@@ -496,7 +496,13 @@ func shouldUseKubeLocalProxy(cf *CLIConf, kubectlArgs []string) (*clientcmdapi.C
 	// only a little wasteful to spin up a local proxy it's fine for now, but if
 	// we rework the flow we should add a way to skip the local proxy when using
 	// a relay even if a connection through the control plane would require it
-	if !profile.RequireKubeLocalProxy() {
+	//
+	// A hardware-key policy also requires the local proxy: the exec-plugin
+	// credentials path can't serialize a hardware-backed key, whereas the local
+	// proxy uses it as an in-process signer and hands kubectl a fresh software
+	// key. Without this, `tsh kubectl` falls through to the exec plugin and
+	// fails with "cannot get software key PEM".
+	if !profile.RequireKubeLocalProxy() && !profile.PrivateKeyPolicy.IsHardwareKeyPolicy() {
 		return nil, nil, false
 	}
 

--- a/tool/tsh/common/kubectl_test.go
+++ b/tool/tsh/common/kubectl_test.go
@@ -98,6 +98,23 @@ func Test_maybeStartKubeLocalProxy(t *testing.T) {
 				KubeCluster:     kubeCluster,
 			}},
 		},
+		{
+			// A hardware-key policy can't be served by the exec-plugin
+			// credentials path, so the local proxy must be used even when ALPN
+			// connection upgrade is not required (RequireKubeLocalProxy is false).
+			name: "use local proxy for hardware key policy",
+			inputProfile: &profile.Profile{
+				WebProxyAddr:     "localhost:443",
+				KubeProxyAddr:    "localhost:443",
+				PrivateKeyPolicy: keys.PrivateKeyPolicyHardwareKeyTouch,
+			},
+			inputArgs:      []string{"kubectl", "--kubeconfig", kubeconfigLocation, "version"},
+			wantLocalProxy: true,
+			wantKubeClusters: kubeconfig.LocalProxyClusters{{
+				TeleportCluster: "localhost",
+				KubeCluster:     kubeCluster,
+			}},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## What

Under a hardware-key policy (`hardware_key`, `hardware_key_touch`, …), `tsh kubectl` failed with `cannot get software key PEM for private key of type *hardwarekey.Signer`.

`shouldUseKubeLocalProxy` only started the local proxy when `RequireKubeLocalProxy()` was true (ALPN connection upgrade, e.g. behind an ALB). Hardware-key profiles that didn't need a conn upgrade fell through to the exec-plugin credentials path (`tsh kube credentials`), which can't serialize a hardware-backed key.

It now also starts the local proxy when the profile uses a hardware-key policy (`PrivateKeyPolicy.IsHardwareKeyPolicy()`). The local proxy uses the hardware key as an in-process signer and hands kubectl a freshly generated software key, so `tsh kubectl` works.

Part of #68199.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed `tsh kubectl` failing with "cannot get software key PEM" when hardware key support is enabled.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Kind cluster with `proxy_listener_mode: multiplex` (kube over the web port), role with `require_session_mfa: hardware_key_touch`, YubiKey. Verified before (HEAD~1) vs after.

### Test Cases
- [x] `tsh kubectl get pods` under a hardware-key policy returns pods (before: `cannot get software key PEM`).
