### PR TITLE
Teleport discovery skill - Reinstate the human description intro for automated docs generation

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -79,10 +79,10 @@ Example invocations:
 
 ### teleport-discovery
 
-Enroll cloud resources (AWS EC2 instances, AWS EKS clusters, and Azure VMs) into
-Teleport using Auto-Discovery. Provides a guided workflow to generate a Terraform
-configuration to create an OIDC integration. Use for checking status of the
-Discovery Service or troubleshooting resource enrollment.
+Connect Teleport to your cloud to automatically discover and enroll your resources. Use Terraform
+to create an OIDC integration in your cloud provider and configure the Teleport
+Discovery Service. Troubleshoot any issues getting your resources enrolled. Supports AWS EC2
+instances, AWS EKS clusters, and Azure VMS.
 
 Example invocations:
 

--- a/skills/teleport-discovery/SKILL.md
+++ b/skills/teleport-discovery/SKILL.md
@@ -33,6 +33,11 @@ allowed-tools:
 
 # Teleport Auto-Discovery
 
+Connect Teleport to your cloud to automatically discover and enroll your resources. Use Terraform
+to create an OIDC integration in your cloud provider and configure the Teleport
+Discovery Service. Troubleshoot any issues getting your resources enrolled. Supports AWS EC2
+instances, AWS EKS clusters, and Azure VMS.
+
 ## Communicating
 
 Open with one or two sentences stating which procedures will run and what each produces or


### PR DESCRIPTION
The intro human description was removed during a dedupe optimization in #68029 

This intro is going to be grabbed by a docs generation tool, so it needs to be present. It appears to be harmless to the skill performance and looks like better UX.

## Manual Test Plan
### Test Environment
Local Opus 4.8
### Test Cases
- [x] Ran skill to check for side effects. Claude does output a starting blurb regardless, and it does change to use this statement. Look good anyway.
