### PR TITLE
docs: Add authoring guidance for prerequisites and variable handling

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,10 +1,29 @@
 # AGENTS.md
 
-Guidance for AI agents reviewing documentation PRs in this repo. Docs live in
-`docs/pages/` and are written in MDX. These guidelines apply to changes under
+Guidance for AI agents working with documentation in this repo. Docs live in
+`docs/pages/` and are written in MDX. These guidelines apply to work under
 `docs/`; for code changes, see the repo-root `AGENTS.md`.
 
-## Review guidelines
+This file covers two distinct jobs. Determine which one applies to your
+current task before reading further, and only follow the rules for that
+mode — the two are not interchangeable and some rules conflict by design.
+
+- **Review Mode:** You are reading a documentation PR as a critic. You do
+  not run commands against live infrastructure and you do not edit files;
+  you produce findings. Covered by "Review guidelines" through "Out of
+  scope" below.
+- **Execution Mode:** You are following a guide's numbered steps against
+  real infrastructure, acting as a reader would. You run commands, resolve
+  `<Var>` placeholders, and check prerequisites. Covered by "Resolving
+  variables and placeholders in guides" and "Prerequisites and permission
+  failures" below.
+
+If it's unclear which mode applies, stop and ask rather than guessing —
+the two modes call for opposite behavior around running commands.
+
+## Review Mode
+
+### Review guidelines
 
 - Focus on accuracy, structure, and conventions. Flag issues; do not rewrite.
 - Keep suggestions targeted. Quote the specific line and propose a minimal fix.
@@ -22,7 +41,7 @@ Guidance for AI agents reviewing documentation PRs in this repo. Docs live in
   issues on the original PR; do not defer findings to the backport phase. A
   finding that only surfaces during backport is a review miss.
 
-## Review output
+### Review output
 
 - Group findings by file, in the order files appear in the diff.
 - Label each finding with a severity:
@@ -45,7 +64,7 @@ Example of a well-formed finding:
 > ## Configure the agent
 > ```
 
-## What to check
+### What to check
 
 - **Style and conventions**
   - The conventions themselves (voice, headings, naming, components, page-type
@@ -113,7 +132,7 @@ Example of a well-formed finding:
     not invent or "correct" tag names; flag unfamiliar tags for human
     verification. See the "Frontmatter and tags" section of `AGENTS-STYLE.md`.
 
-## References
+### References
 
 - Documentation conventions (source of truth):
   [`contributing/documentation-style-guide.md`](contributing/documentation-style-guide.md),
@@ -129,9 +148,11 @@ Example of a well-formed finding:
   conventions the linter cannot verify. Do not attempt to build or lint docs
   from this repo.
 
-## Out of scope
+### Out of scope
 
-Do not do the following in a docs review:
+Do not do the following in a docs review. (This list applies to Review Mode
+only — Execution Mode's whole job is running commands against a live
+cluster; see below.)
 
 - Wholesale rewrites on style or tone grounds.
 - Changes to product behavior described in the docs. If the docs appear to
@@ -139,4 +160,94 @@ Do not do the following in a docs review:
 - Auto-resolving MDX includes (`(!...!)` partials) into inline content.
 - Speculation on provider-specific facts (AWS, Azure, GCP, IdP vendors)
   without a source. Flag uncertainty for a human reviewer instead.
-- Verifying commands against live clusters.
+- Verifying commands against live clusters. A reviewer checks a command
+  for correctness by reading it, not by running it.
+
+## Execution Mode
+
+You are following a guide's steps for real, against live infrastructure, to
+confirm it works as written. This means running commands, resolving
+placeholders, and checking your own permissions before acting — the opposite
+posture from Review Mode above.
+
+### Resolving variables and placeholders in guides
+
+Guides contain `<Var name="..." />` placeholders standing in for values such
+as addresses, tokens, and resource names. Never invent or guess a value for
+a placeholder. Resolve each one using the first rule that applies:
+
+1. **Output of a prior step.** If a command earlier in the guide (or one
+   you already ran in this session) produced the value (a join token, a
+   resource ID, an address printed in command output), reuse that exact
+   value. Example: `<Var name="token" />` after a `tctl tokens add` step
+   refers to the token that command printed.
+2. **Discoverable by command.** If the value describes the current cluster
+   or session: proxy address, cluster name, your roles, existing
+   resources - obtain it with a read-only command and parse the output.
+   Useful commands: `tsh status --format=json`, `tctl status`,
+   `tctl get <resource>`. Example: `<Var name="proxy-address" />` comes
+   from `tsh status`.
+3. **Environment.** If a conventional environment variable clearly
+   provides the value (for example `TELEPORT_PROXY`), use it.
+4. **Otherwise, ask the user and stop until they answer.** Values only the
+   user can choose or know, such as names for new resources, endpoints and
+   credentials of external systems, cloud account identifiers cannot be
+   derived. Ask before proceeding. A wrong guess wastes the entire run;
+   asking costs one exchange.
+
+The same placeholder name refers to the same value everywhere on a page:
+once resolved, reuse it; do not re-derive or re-prompt.
+
+If you resolved a value by inference (rules 1–3) and later output
+contradicts it (errors referencing a different address, a resource not
+found) stop and re-confirm the value with the user instead of continuing.
+
+### Explicit sourcing hints override the rules above
+
+Some `<Var>` tags may carry a `source` attribute (in rendered pages,
+`data-agent-source`). When present, it overrides rules 1–4:
+
+- `source="user-supplied"` - ask the user; the value cannot be derived.
+- `source="command:<cli command>"` - run that command and parse its output.
+- `source="env:<VAR_NAME>"` - read that environment variable; ask if unset.
+- `source="computed"` - reuse a value resolved earlier on the same page.
+
+Most guides do not carry these hints; the numbered rules are the default.
+
+### Prerequisites and permission failures
+
+Before executing a guide's numbered steps, verify its Prerequisites
+section. Confirm you are logged in (`tsh status`) and that each listed
+requirement is met; do not assume a prerequisite is satisfied because it
+is probably true.
+
+Not every prerequisite is a login or a role. Some require
+infrastructure, such as a host to enroll, a network path, or an external
+system. Do not assume such a resource exists, and do not substitute the
+machine you are running on for it. Many guides act on a **separate target
+host**, distinct from the workstation where you run `tsh` and `tctl`; that
+host's requirements (operating system, open ports, network access) may
+differ from your own environment. For example, a guide that enrolls a
+Linux server still expects that server to exist even though you run the
+client commands from macOS or Windows. Before starting the steps, identify
+which machine or resource each step acts on, confirm it exists and meets
+the stated requirements, and stop to ask the user if it is missing or the
+guide is ambiguous about which machine is meant. A wrong assumption here
+wastes the entire run; asking costs one exchange.
+
+If any command fails with an authorization error, such as "access denied",
+"permission denied", a missing verb on a resource, or any RBAC error,
+treat it as a privilege gap, not a configuration problem, a product bug,
+or a documentation error. Do not retry with invented workarounds, do not
+skip the step, and never report the step complete. Instead:
+
+1. Identify the role or permission the step requires. Guides usually name
+   required roles (such as `editor`) in their Prerequisites section.
+2. File an Access Request: `tsh request create --roles=<role>`.
+3. Tell the user what you requested and why, and pause the run until the
+   request is approved or denied.
+
+If a prerequisite or `<Var>` carries an explicit `requires` attribute
+(for example `requires="role:editor"`), check your roles against it with
+`tsh status` before attempting the step, and follow the same
+Access Request procedure if you lack the role.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -265,6 +265,39 @@ If you resolved a value by inference (rules 1–3) and later output
 contradicts it (errors referencing a different address, a resource not
 found) stop and re-confirm the value with the user instead of continuing.
 
+### Values that aren't wrapped in `<Var>`
+
+Many guides have not yet been updated to mark every substitutable value
+with `<Var>` (see "Authoring guidance"). Absence of a `<Var>` tag is not a
+signal that a literal value is safe to copy as-is. Before reusing any
+literal value from a guide's text or code fences, ask: **would this value
+be the same for every reader, or does it depend on the reader's own
+account, cluster, or environment?** If it depends on the reader, treat it
+as if it carried `source="user-supplied"` and apply rules 1–4 above,
+even though no `<Var>` tag is present.
+
+Treat the following as reliable signals that an unwrapped literal is a
+stand-in, not a real value:
+
+- Known placeholder domains and hosts: `example.com`, `example.org`,
+  `*.example.teleport.sh`, or any host containing the literal word
+  `example`.
+- Placeholder-shaped identifiers: repeated or sequential digits in an
+  account ID or ARN (`111111111111`, `123456789012`), UUIDs that appear
+  earlier in the same guide as a different example, or resource names
+  that don't match anything you've actually created or queried.
+- Generic human names or roles used as usernames: `joe`, `myuser`,
+  `contractor`, `foo@example.com`, and similar.
+- Names prefixed `my-`/`your-` (`my-kubernetes-cluster`,
+  `your-github-username`), or file paths written as a description rather
+  than a real path (`/path/to/token.file`).
+- Values introduced in prose as "replace X with your own Y" — this is the
+  same instruction a `source="user-supplied"` `<Var>` would carry, just
+  stated in text instead of markup.
+
+When genuinely unsure whether a literal is a placeholder or a fixed value, 
+ask rather than guess; the cost asymmetry is the same as for `<Var>` resolution.
+
 ### Explicit sourcing hints override the rules above
 
 Some `<Var>` tags may carry a `source` attribute (in rendered pages,

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -18,8 +18,61 @@ mode — the two are not interchangeable and some rules conflict by design.
   variables and placeholders in guides" and "Prerequisites and permission
   failures" below.
 
+A third section, "Authoring guidance," is written for the human (or agent)
+drafting a guide, not for a reviewing or executing agent. Review Mode checks
+against it; see "What to check" below.
+
 If it's unclear which mode applies, stop and ask rather than guessing —
 the two modes call for opposite behavior around running commands.
+
+## Authoring guidance
+
+This section is for whoever is writing or editing a guide. Its purpose is
+narrow: guides get followed by AI agents in Execution Mode (an internal
+Beams test run, or a customer's own agent working through the guide against
+their cluster), and two specific failure patterns show up repeatedly when
+guides don't follow it.
+
+**Failure pattern 1: prerequisites get skipped even when they're present.**
+A Prerequisites section written as narrative description ("You'll need
+appropriate permissions to configure this resource") reads fine to a human
+but doesn't give an executing agent anything to check against — it can
+convince itself the description is satisfied without verifying it. To
+prevent this:
+
+- Name the exact role or permission required, not a paraphrase of it (say
+  `editor`, not "appropriate permissions").
+- Where a step depends on a specific role, add a `requires` attribute to
+  the relevant `<Var>` or step (e.g. `requires="role:editor"`) instead of
+  relying on prose alone. Execution Mode is instructed to check `requires`
+  attributes against the agent's own roles before proceeding; prose alone
+  has no equivalent enforcement.
+- If a prerequisite depends on infrastructure the agent can't assume exists
+  (a target host, a network path, an external system), say so explicitly
+  rather than implying the reader's own workstation satisfies it.
+
+**Failure pattern 2: `<Var>` placeholders get filled with the example value
+instead of a real one.** If a `<Var>` shows a plausible-looking default
+(e.g. `teleport.example.com`), an executing agent may treat it as usable
+rather than a placeholder to replace. To prevent this:
+
+- Add `source="user-supplied"` to any `<Var>` whose value cannot be
+  derived from a prior command, a discovery command, or an environment
+  variable — this is what tells an executing agent to stop and ask instead
+  of guessing or reusing the example. See "Resolving variables and
+  placeholders in guides" below for the full rule set this maps to.
+- Avoid giving a user-supplied `<Var>` a `default` that looks like a
+  complete, valid value; if an example is necessary, make it obviously a
+  placeholder (e.g. `<my-cluster-name>`) rather than something that could
+  pass for real.
+- If a value can be derived (proxy address, cluster name, existing role),
+  mark it with `source="command:<...>"` rather than leaving it ambiguous —
+  don't make every `<Var>` "user-supplied" by default, since that pushes
+  unnecessary questions onto a customer running the guide.
+
+A guide that follows both of these should need no other agent-specific
+authoring effort — the burden shifts from every guide re-explaining itself
+to the shared `<Var>` and Prerequisites conventions doing the work.
 
 ## Review Mode
 
@@ -116,6 +169,16 @@ Example of a well-formed finding:
   - Partials/includes are used where shared content exists. Partials live in
     `docs/pages/includes/`; before flagging duplication, confirm a matching
     partial actually exists there.
+  - Prerequisites name the exact role or permission required (not a
+    paraphrase like "appropriate permissions"), per "Authoring guidance"
+    above. Flag vague prerequisite language as a Suggestion.
+  - A `<Var>` whose value can't reasonably be derived (a new resource name,
+    an external credential, anything only the reader would know) carries
+    `source="user-supplied"`. Flag a missing `source` attribute on such a
+    `<Var>` as a Suggestion — without it, an executing agent may reuse the
+    shown example value instead of asking. Don't flag `<Var>` tags for
+    values that are plausibly derivable (proxy address, cluster name);
+    only flag the ones that clearly cannot be.
 - **Cross-references**
   - Links to related docs are present and resolve (correct relative paths, no
     broken anchors).


### PR DESCRIPTION
## Summary

Restructures `docs/AGENTS.md` adds explicit authoring guidance to close two failure patterns observed in a variety of Beams test runs: agents skipping prerequisites and filling `<Var>` placeholders with dummy values instead of asking.

## What changed

- **Split the file into three clearly labeled sections**: Review Mode, Execution Mode, and a new Authoring guidance section. The intro now tells an agent which mode applies before it reads any rules, instead of leading with "reviewing documentation PRs" and only later revealing execution-specific instructions.
- **Added an Authoring guidance section** naming two specific failure patterns from Beams runs and their fixes:
  - Prerequisites written as narrative description don't give an executing agent anything concrete to check. Fix: name the exact role/permission, and use `requires="role:..."` attributes instead of prose alone.
  - `<Var>` placeholders with plausible-looking example values get reused instead of replaced. Fix: mark any non-derivable value with `source="user-supplied"`.
- **Added matching checks to Review Mode's "What to check"** so these aren't just advice (a reviewing agent now flags guides with vague prerequisite language or missing `source` attributes as a Suggestion).

## Why

Multiple agent runs in Claude Code on Beams periodically found the prerequisites either partially or completely skipped. Empty or dummy variables were not acknowledged or queried with the user during the run time. Guidance that lives in `AGENTS.md` will help perfect guides for agentic use by centralizing page-agnostic rules here.
