### PR TITLE
[scopes] backend support for scoped access list reviews

### DIFF
--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -313,7 +313,7 @@ type Requires struct {
 
 // IsEmpty returns true when no roles or traits are set
 func (r *Requires) IsEmpty() bool {
-	return len(r.Roles) == 0 && len(r.Traits) == 0
+	return r == nil || (len(r.Roles) == 0 && len(r.Traits) == 0)
 }
 
 // Clone returns a deep copy of the [Requires]

--- a/lib/accesslists/scopequalifiedname.go
+++ b/lib/accesslists/scopequalifiedname.go
@@ -148,3 +148,40 @@ func ParentListOf(member *accesslist.AccessListMember) (NormalizedSQN, error) {
 	}
 	return ParseScopeQualifiedName(member.Spec.AccessList)
 }
+
+// ReviewedList returns the scope-qualified name of the access list reviewed by
+// the given review.
+func ReviewedList(review *accesslist.Review) (NormalizedSQN, error) {
+	if review.Scope == "" {
+		return NormalizedSQN{
+			Name: review.Spec.AccessList,
+		}, nil
+	}
+	listName, err := ParseScopeQualifiedName(review.Spec.AccessList)
+	if err != nil {
+		return NormalizedSQN{}, trace.Wrap(err)
+	}
+	if review.Scope != listName.Scope {
+		return NormalizedSQN{}, trace.BadParameter("access list review scope %q does not match the scope of the reviewed list %q", review.Scope, listName.Scope)
+	}
+	return listName, nil
+}
+
+// AllRemovedMembers returns the scope-qualified names of all members removed
+// by this access list review.
+func AllRemovedMembers(review *accesslist.Review) ([]NormalizedSQN, error) {
+	removedMembers := make([]NormalizedSQN, 0, len(review.Spec.Changes.RemovedMembers)+len(review.Spec.Changes.ScopedRemovedMembers))
+	for _, removedMember := range review.Spec.Changes.RemovedMembers {
+		removedMembers = append(removedMembers, NormalizedSQN{
+			Name: removedMember,
+		})
+	}
+	for _, scopedRemovedMember := range review.Spec.Changes.ScopedRemovedMembers {
+		sqn, err := ParseScopeQualifiedName(scopedRemovedMember)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		removedMembers = append(removedMembers, sqn)
+	}
+	return removedMembers, nil
+}

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -63,6 +63,10 @@ const (
 	accessListMemberPrefix      = "access_list_member"
 	accessListMemberMaxPageSize = 200
 
+	// Access list reviews are stored under one of the following key ranges,
+	// depending on the scope of the reviewed list:
+	// - /access_list_review/<list-name>/<review-id>                             (for unscoped lists)
+	// - /scoped/access_list_review/<encoded-list-scope>/<list-name>/<review-id> (for scoped lists)
 	accessListReviewPrefix      = "access_list_review"
 	accessListReviewMaxPageSize = 200
 
@@ -93,7 +97,7 @@ type AccessListService struct {
 	scopesFeatures scopes.Features
 	service        *generic.ScopeAwareService[*accesslist.AccessList]
 	memberService  *generic.ScopeAwareService[*accesslist.AccessListMember]
-	reviewService  *generic.Service[*accesslist.Review]
+	reviewService  *generic.ScopeAwareService[*accesslist.Review]
 }
 
 type accessListAndMembersGetter struct {
@@ -344,11 +348,12 @@ func NewAccessListServiceV2(cfg AccessListServiceConfig) (*AccessListService, er
 		return nil, trace.Wrap(err)
 	}
 
-	reviewService, err := generic.NewService(&generic.ServiceConfig[*accesslist.Review]{
+	reviewService, err := generic.NewScopeAwareService(&generic.ScopeAwareServiceConfig[*accesslist.Review]{
 		Backend:                     cfg.Backend,
 		PageLimit:                   accessListReviewMaxPageSize,
 		ResourceKind:                types.KindAccessListReview,
-		BackendPrefix:               backend.NewKey(accessListReviewPrefix),
+		UnscopedBackendPrefix:       backend.NewKey(accessListReviewPrefix),
+		ScopedBackendPrefix:         backend.NewKey(scopedPrefix, accessListReviewPrefix),
 		MarshalFunc:                 services.MarshalAccessListReview,
 		UnmarshalFunc:               services.UnmarshalAccessListReview,
 		RunWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
@@ -1423,12 +1428,29 @@ func (a *AccessListService) AccessRequestPromote(_ context.Context, _ *accesslis
 
 // ListAccessListReviews will list access list reviews for a particular access list.
 func (a *AccessListService) ListAccessListReviews(ctx context.Context, accessList string, pageSize int, pageToken string) (reviews []*accesslist.Review, nextToken string, err error) {
-	_, err = a.GetAccessList(ctx, accessList)
+	return a.ListAccessListReviewsV2(ctx, accesslistv1.ListAccessListReviewsRequest_builder{
+		AccessList: accessList,
+		PageSize:   int32(pageSize),
+		NextToken:  pageToken,
+	}.Build())
+}
+
+func (a *AccessListService) ListAccessListReviewsV2(ctx context.Context, req *accesslistv1.ListAccessListReviewsRequest) (reviews []*accesslist.Review, nextToken string, err error) {
+	listName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	_, err = a.getAccessList(ctx, listName)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 
-	reviews, nextToken, err = a.reviewService.WithPrefix(accessList).ListResources(ctx, pageSize, pageToken)
+	reviewService, err := a.reviewService.WithScopedResourcePrefix(listName.ToScopesQualifiedName())
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	reviews, nextToken, err = reviewService.ListResources(ctx, int(req.GetPageSize()), req.GetNextToken())
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -1437,7 +1459,8 @@ func (a *AccessListService) ListAccessListReviews(ctx context.Context, accessLis
 
 // ListAllAccessListReviews will list access list reviews for all access lists.
 func (a *AccessListService) ListAllAccessListReviews(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.Review, string, error) {
-	reviews, next, err := a.reviewService.ListResourcesReturnNextResource(ctx, pageSize, pageToken)
+	// TODO(nklaassen): support listing reviews of scoped access lists.
+	reviews, next, err := a.reviewService.UnscopedService.ListResourcesReturnNextResource(ctx, pageSize, pageToken)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -1450,13 +1473,8 @@ func (a *AccessListService) ListAllAccessListReviews(ctx context.Context, pageSi
 
 // CreateAccessListReview will create a new review for an access list.
 func (a *AccessListService) CreateAccessListReview(ctx context.Context, review *accesslist.Review) (*accesslist.Review, time.Time, error) {
-	if review.Scope != "" {
-		// TODO(nklaassen): support scoped access list reviews.
-		return nil, time.Time{}, trace.BadParameter("scoped access list reviews are not yet supported")
-	}
-
 	reviewName := uuid.New().String()
-	createdReview, err := accesslist.NewReview(header.Metadata{
+	createdReview, err := accesslist.NewReviewWithScope(header.Metadata{
 		Name:        reviewName,
 		Labels:      review.GetAllLabels(),
 		Description: review.Metadata.Description,
@@ -1467,21 +1485,44 @@ func (a *AccessListService) CreateAccessListReview(ctx context.Context, review *
 		ReviewDate: review.Spec.ReviewDate,
 		Notes:      review.Spec.Notes,
 		Changes:    review.Spec.Changes,
-	})
+	}, review.Scope)
 	if err != nil {
 		return nil, time.Time{}, trace.Wrap(err)
 	}
 
+	reviewedListName, err := accesslists.ReviewedList(review)
+	if err != nil {
+		return nil, time.Time{}, trace.Wrap(err)
+	}
+	reviewService, err := a.reviewService.WithScopedResourcePrefix(reviewedListName.ToScopesQualifiedName())
+	if err != nil {
+		return nil, time.Time{}, trace.Wrap(err)
+	}
+	allRemovedMembers, err := accesslists.AllRemovedMembers(review)
+	if err != nil {
+		return nil, time.Time{}, trace.Wrap(err)
+	}
+	if review.Scope != "" && !review.Spec.Changes.MembershipRequirementsChanged.IsEmpty() {
+		return nil, time.Time{}, trace.BadParameter("scoped access lists cannot contain membership requirements")
+	}
+	if review.Scope == "" && len(review.Spec.Changes.ScopedRemovedMembers) > 0 {
+		return nil, time.Time{}, trace.BadParameter("unscoped access lists cannot have scoped members")
+	}
+
 	var nextAuditDate time.Time
 
-	err = a.service.RunWhileLocked(ctx, lockName(review.Spec.AccessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		accessList, err := a.GetAccessList(ctx, review.Spec.AccessList)
+	lockName, err := scopeAwareLockName(reviewedListName)
+	if err != nil {
+		return nil, time.Time{}, trace.Wrap(err)
+	}
+	err = a.service.RunWhileLocked(ctx, lockName, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		accessList, err := a.getAccessList(ctx, reviewedListName)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 
 		if !accessList.IsReviewable() {
-			return trace.BadParameter("access_list %q is not reviewable", accessList.GetName())
+			return trace.BadParameter("access_list %q is not reviewable", reviewedListName.String())
 		}
 
 		if createdReview.Spec.Changes.MembershipRequirementsChanged != nil {
@@ -1508,7 +1549,7 @@ func (a *AccessListService) CreateAccessListReview(ctx context.Context, review *
 			}
 		}
 
-		createdReview, err = a.reviewService.WithPrefix(review.Spec.AccessList).CreateResource(ctx, createdReview)
+		createdReview, err = reviewService.CreateResource(ctx, createdReview)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1519,22 +1560,23 @@ func (a *AccessListService) CreateAccessListReview(ctx context.Context, review *
 		}
 		accessList.Spec.Audit.NextAuditDate = nextAuditDate
 
-		// TODO(nklaassen): support scoped access list reviews.
-		reviewedListName := accesslists.NormalizedSQN{Name: review.Spec.AccessList}
-
-		for _, removedMember := range review.Spec.Changes.RemovedMembers {
-			_, err := a.memberService.UnscopedService.WithPrefix(review.Spec.AccessList).GetResource(ctx, removedMember)
+		for _, removedMember := range allRemovedMembers {
+			memberService, err := a.memberServiceForNamedMember(reviewedListName, removedMember)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			_, err = memberService.get(ctx)
 			if err != nil && !trace.IsNotFound(err) {
 				return trace.Wrap(err)
 			}
 			isAccessListMember := err == nil
 
 			if isAccessListMember {
-				if err := a.updateAccessListMemberOf(ctx, reviewedListName, accesslists.NormalizedSQN{Name: removedMember}, false); err != nil {
+				if err := a.updateAccessListMemberOf(ctx, reviewedListName, removedMember, false); err != nil {
 					return trace.Wrap(err)
 				}
 			}
-			if err := a.memberService.UnscopedService.WithPrefix(review.Spec.AccessList).DeleteResource(ctx, removedMember); err != nil {
+			if err := memberService.delete(ctx); err != nil {
 				return trace.Wrap(err)
 			}
 		}
@@ -1592,11 +1634,27 @@ func accessListRequiresEqual(a, b accesslist.Requires) bool {
 
 // DeleteAccessListReview will delete an access list review from the backend.
 func (a *AccessListService) DeleteAccessListReview(ctx context.Context, accessListName, reviewName string) error {
-	_, err := a.GetAccessList(ctx, accessListName)
+	return a.DeleteAccessListReviewV2(ctx, accesslistv1.DeleteAccessListReviewRequest_builder{
+		AccessListName: accessListName,
+		ReviewName:     reviewName,
+	}.Build())
+}
+
+// DeleteAccessListReviewV2 will delete an access list review from the backend.
+func (a *AccessListService) DeleteAccessListReviewV2(ctx context.Context, req *accesslistv1.DeleteAccessListReviewRequest) error {
+	accessListName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessListName(),
+	})
+	_, err := a.getAccessList(ctx, accessListName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return trace.Wrap(a.reviewService.WithPrefix(accessListName).DeleteResource(ctx, reviewName))
+	reviewService, err := a.reviewService.WithScopedResourcePrefix(accessListName.ToScopesQualifiedName())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(reviewService.DeleteResource(ctx, req.GetReviewName()))
 }
 
 // DeleteAllAccessListReviews will delete all access list reviews from all access lists.

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -1838,6 +1838,156 @@ func TestAccessListReviewCRUD(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestAccessListReviewCRUDScoped(t *testing.T) {
+	ctx := t.Context()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service := newAccessListService(t, mem, modulestest.EnterpriseModules())
+
+	// Create an access list with 2 members, the review will remove the members.
+	listName := scopes.QualifiedName{Scope: "/eng/platform", Name: "reviewed"}
+	unscopedMemberName := scopes.QualifiedName{Name: "alice"}
+	scopedMemberName := scopes.QualifiedName{Scope: "/eng", Name: "team"}
+
+	accessList, err := service.UpsertAccessList(ctx, newScopedAccessList(t, listName, clock))
+	require.NoError(t, err)
+	_, err = service.UpsertAccessList(ctx, newScopedAccessList(t, scopedMemberName, clock))
+	require.NoError(t, err)
+
+	unscopedMember := newScopedAccessListMember(t, listName, unscopedMemberName, withMembershipKind(accesslist.MembershipKindUser))
+	scopedMember := newScopedAccessListMember(t, listName, scopedMemberName, withMembershipKind(accesslist.MembershipKindScopedList))
+	_, returnedMembers, err := service.UpsertAccessListWithMembers(ctx, accessList, []*accesslist.AccessListMember{unscopedMember, scopedMember})
+	require.NoError(t, err)
+	require.Len(t, returnedMembers, 2)
+
+	// Create a review.
+	review, err := accesslist.NewReviewWithScope(header.Metadata{Name: "ignored-by-create"}, accesslist.ReviewSpec{
+		AccessList: listName.String(),
+		Reviewers:  []string{"user1"},
+		ReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+		Changes: accesslist.ReviewChanges{
+			// Remove both the scoped and unscoped members.
+			RemovedMembers:         []string{unscopedMemberName.Name},
+			ScopedRemovedMembers:   []string{scopedMemberName.String()},
+			ReviewFrequencyChanged: accesslist.ThreeMonths,
+		},
+	}, listName.Scope)
+	require.NoError(t, err)
+
+	createdReview, nextAuditDate, err := service.CreateAccessListReview(ctx, review)
+	require.NoError(t, err)
+	require.NotEmpty(t, createdReview.GetName())
+	require.Equal(t, listName.Scope, createdReview.Scope)
+	require.Equal(t, listName.String(), createdReview.Spec.AccessList)
+	updatedAccessList, err := service.GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Scope: listName.Scope,
+		Name:  listName.Name,
+	}.Build())
+	require.NoError(t, err)
+	require.Equal(t, updatedAccessList.Spec.Audit.NextAuditDate, nextAuditDate)
+	require.Equal(t, accesslist.ThreeMonths, updatedAccessList.Spec.Audit.Recurrence.Frequency)
+
+	// Assert that both the members were actually removed.
+	_, err = service.GetAccessListMemberV2(ctx, accesslistv1.GetAccessListMemberRequest_builder{
+		AccessListScope: listName.Scope,
+		AccessList:      listName.Name,
+		MemberName:      unscopedMemberName.Name,
+	}.Build())
+	require.True(t, trace.IsNotFound(err), "expected not found error, got %v", err)
+	_, err = service.GetAccessListMemberV2(ctx, accesslistv1.GetAccessListMemberRequest_builder{
+		AccessListScope: listName.Scope,
+		AccessList:      listName.Name,
+		MemberScope:     scopedMemberName.Scope,
+		MemberName:      scopedMemberName.Name,
+	}.Build())
+	require.True(t, trace.IsNotFound(err), "expected not found error, got %v", err)
+
+	// Make sure the review can be listed.
+	reviews, nextToken, err := service.ListAccessListReviewsV2(ctx, accesslistv1.ListAccessListReviewsRequest_builder{
+		AccessListScope: listName.Scope,
+		AccessList:      listName.Name,
+		PageSize:        1,
+	}.Build())
+	require.NoError(t, err)
+	require.Empty(t, nextToken)
+	require.Len(t, reviews, 1)
+	require.Equal(t, createdReview.GetName(), reviews[0].GetName())
+	require.Equal(t, listName.Scope, reviews[0].Scope)
+
+	// Legacy ListAccessListReviews is unscoped, if there is an unscoped access
+	// list with a colliding name, listing its reviews should return nothing.
+	_, err = service.UpsertAccessList(ctx, newAccessList(t, listName.Name, clock))
+	require.NoError(t, err)
+	reviews, nextToken, err = service.ListAccessListReviews(ctx, listName.Name, 1, "")
+	require.NoError(t, err)
+	require.Empty(t, nextToken)
+	require.Empty(t, reviews)
+
+	// Delete the review and assert that it's not longer listed.
+	err = service.DeleteAccessListReviewV2(ctx, accesslistv1.DeleteAccessListReviewRequest_builder{
+		AccessListScope: listName.Scope,
+		AccessListName:  listName.Name,
+		ReviewName:      createdReview.GetName(),
+	}.Build())
+	require.NoError(t, err)
+
+	reviews, _, err = service.ListAccessListReviewsV2(ctx, accesslistv1.ListAccessListReviewsRequest_builder{
+		AccessListScope: listName.Scope,
+		AccessList:      listName.Name,
+	}.Build())
+	require.NoError(t, err)
+	require.Empty(t, reviews)
+}
+
+func TestCreateAccessListReviewScopedValidation(t *testing.T) {
+	ctx := t.Context()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service := newAccessListService(t, mem, modulestest.EnterpriseModules())
+	listName := scopes.QualifiedName{Scope: "/eng", Name: "reviewed"}
+	_, err = service.UpsertAccessList(ctx, newScopedAccessList(t, listName, clock))
+	require.NoError(t, err)
+
+	newReview := func(t *testing.T) *accesslist.Review {
+		t.Helper()
+		review, err := accesslist.NewReviewWithScope(header.Metadata{Name: "review"}, accesslist.ReviewSpec{
+			AccessList: listName.String(),
+			Reviewers:  []string{"user1"},
+			ReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+		}, listName.Scope)
+		require.NoError(t, err)
+		return review
+	}
+
+	t.Run("review scope must match access list scope", func(t *testing.T) {
+		review := newReview(t)
+		review.Scope = "/ops"
+
+		_, _, err := service.CreateAccessListReview(ctx, review)
+		require.ErrorContains(t, err, `access list review scope "/ops" does not match the scope of the reviewed list "/eng"`)
+	})
+
+	t.Run("membership requirements are rejected", func(t *testing.T) {
+		review := newReview(t)
+		review.Spec.Changes.MembershipRequirementsChanged = &accesslist.Requires{Roles: []string{"role"}}
+
+		_, _, err := service.CreateAccessListReview(ctx, review)
+		require.ErrorContains(t, err, "scoped access lists cannot contain membership requirements")
+	})
+}
+
 func Test_CreateAccessListReview_NestedListMemberRemoval(t *testing.T) {
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()


### PR DESCRIPTION
Part of [RFD 308](https://github.com/gravitational/rfd/pull/22)

This PR adds backend support for reviews of scoped access lists. Reviews of scoped lists are not yet included in ListAllAccessListReviews, nor are they cached, nor does the API layer accept them yet, that is coming in later PRs.

Parent: https://github.com/gravitational/teleport/pull/68179
Child: https://github.com/gravitational/teleport/pull/68478

## Manual Test Plan
### Test Environment

Cluster running this branch.

### Test Cases
The API layer does not support scopes yet, try an unscoped list review as a regression test

- [x] Create an unscoped Access List with a recurring audit schedule.
- [x] Add a user to the Access List and verify that the user appears in its membership.
- [x] Submit a review without changes and verify that:
  - the review completes successfully;
  - the next audit date is updated;
  - the review appears in the Access List's review history.
- [x] Submit another review that removes the user and verify that:
  - the user is removed from the Access List;
  - the removal appears in the review history.
