### PR TITLE
[scopes] cache scoped access lists, members, reviews

### DIFF
--- a/api/client/accesslist/accesslist.go
+++ b/api/client/accesslist/accesslist.go
@@ -119,15 +119,20 @@ func (c *Client) ListAccessListsV2(ctx context.Context, req *accesslistv1.ListAc
 
 // GetAccessList returns the specified access list resource.
 func (c *Client) GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error) {
-	resp, err := c.grpcClient.GetAccessList(ctx, &accesslistv1.GetAccessListRequest{
+	return c.GetAccessListV2(ctx, &accesslistv1.GetAccessListRequest{
 		Name: name,
 	})
+}
+
+// GetAccessListV2 returns the specified access list resource.
+func (c *Client) GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error) {
+	resp, err := c.grpcClient.GetAccessList(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	accessList, err := fromAccessListProto(resp)
-	return accessList, trace.Wrap(err)
+	return accessList, err
 }
 
 // GetAccessListsToReview returns access lists that the user needs to review.
@@ -196,9 +201,14 @@ func (c *Client) DeleteAccessList(ctx context.Context, name string) error {
 
 // CountAccessListMembers will count all access list members.
 func (c *Client) CountAccessListMembers(ctx context.Context, accessListName string) (users uint32, lists uint32, err error) {
-	resp, err := c.grpcClient.CountAccessListMembers(ctx, &accesslistv1.CountAccessListMembersRequest{
+	return c.CountAccessListMembersV2(ctx, &accesslistv1.CountAccessListMembersRequest{
 		AccessListName: accessListName,
 	})
+}
+
+// CountAccessListMembersV2 will count all access list members.
+func (c *Client) CountAccessListMembersV2(ctx context.Context, req *accesslistv1.CountAccessListMembersRequest) (users uint32, lists uint32, err error) {
+	resp, err := c.grpcClient.CountAccessListMembers(ctx, req)
 	if err != nil {
 		return 0, 0, trace.Wrap(err)
 	}
@@ -208,11 +218,16 @@ func (c *Client) CountAccessListMembers(ctx context.Context, accessListName stri
 
 // ListAccessListMembers returns a paginated list of all access list members for an access list.
 func (c *Client) ListAccessListMembers(ctx context.Context, accessList string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error) {
-	resp, err := c.grpcClient.ListAccessListMembers(ctx, &accesslistv1.ListAccessListMembersRequest{
+	return c.ListAccessListMembersV2(ctx, &accesslistv1.ListAccessListMembersRequest{
 		PageSize:   int32(pageSize),
 		PageToken:  pageToken,
 		AccessList: accessList,
 	})
+}
+
+// ListAccessListMembersV2 returns a paginated list of all access list members for an access list.
+func (c *Client) ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error) {
+	resp, err := c.grpcClient.ListAccessListMembers(ctx, req)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -231,10 +246,15 @@ func (c *Client) ListAccessListMembers(ctx context.Context, accessList string, p
 
 // ListAllAccessListMembers returns a paginated list of all access list members for all access lists.
 func (c *Client) ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error) {
-	resp, err := c.grpcClient.ListAllAccessListMembers(ctx, &accesslistv1.ListAllAccessListMembersRequest{
+	return c.ListAllAccessListMembersV2(ctx, &accesslistv1.ListAllAccessListMembersRequest{
 		PageSize:  int32(pageSize),
 		PageToken: pageToken,
 	})
+}
+
+// ListAllAccessListMembersV2 returns a paginated list of all access list members for all access lists.
+func (c *Client) ListAllAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAllAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error) {
+	resp, err := c.grpcClient.ListAllAccessListMembers(ctx, req)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -253,10 +273,15 @@ func (c *Client) ListAllAccessListMembers(ctx context.Context, pageSize int, pag
 
 // GetAccessListMember returns the specified access list member resource.
 func (c *Client) GetAccessListMember(ctx context.Context, accessList, memberName string) (*accesslist.AccessListMember, error) {
-	resp, err := c.grpcClient.GetAccessListMember(ctx, &accesslistv1.GetAccessListMemberRequest{
+	return c.GetAccessListMemberV2(ctx, &accesslistv1.GetAccessListMemberRequest{
 		AccessList: accessList,
 		MemberName: memberName,
 	})
+}
+
+// GetAccessListMemberV2 returns the specified access list member resource.
+func (c *Client) GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error) {
+	resp, err := c.grpcClient.GetAccessListMember(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -284,9 +309,16 @@ func (c *Client) GetStaticAccessListMember(ctx context.Context, accessList, memb
 //
 // Returned Owners are not validated for ownership requirements – use `IsAccessListOwner` for validation.
 func (c *Client) GetAccessListOwners(ctx context.Context, accessListName string) ([]*accesslist.Owner, error) {
-	resp, err := c.grpcClient.GetAccessListOwners(ctx, &accesslistv1.GetAccessListOwnersRequest{
+	return c.GetAccessListOwnersV2(ctx, &accesslistv1.GetAccessListOwnersRequest{
 		AccessList: accessListName,
 	})
+}
+
+// GetAccessListOwnersV2 returns a list of all owners in an Access List, including those inherited from nested Access Lists.
+//
+// Returned Owners are not validated for ownership requirements – use `IsAccessListOwner` for validation.
+func (c *Client) GetAccessListOwnersV2(ctx context.Context, req *accesslistv1.GetAccessListOwnersRequest) ([]*accesslist.Owner, error) {
+	resp, err := c.grpcClient.GetAccessListOwners(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -402,11 +434,16 @@ func (c *Client) AccessRequestPromote(ctx context.Context, req *accesslistv1.Acc
 
 // ListAccessListReviews will list access list reviews for a particular access list.
 func (c *Client) ListAccessListReviews(ctx context.Context, accessList string, pageSize int, pageToken string) (reviews []*accesslist.Review, nextToken string, err error) {
-	resp, err := c.grpcClient.ListAccessListReviews(ctx, &accesslistv1.ListAccessListReviewsRequest{
+	return c.ListAccessListReviewsV2(ctx, &accesslistv1.ListAccessListReviewsRequest{
 		AccessList: accessList,
 		PageSize:   int32(pageSize),
 		NextToken:  pageToken,
 	})
+}
+
+// ListAccessListReviewsV2 will list access list reviews for a particular access list.
+func (c *Client) ListAccessListReviewsV2(ctx context.Context, req *accesslistv1.ListAccessListReviewsRequest) (reviews []*accesslist.Review, nextToken string, err error) {
+	resp, err := c.grpcClient.ListAccessListReviews(ctx, req)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -425,10 +462,15 @@ func (c *Client) ListAccessListReviews(ctx context.Context, accessList string, p
 
 // ListAllAccessListReviews will list access list reviews for all access lists. Only to be used by the cache.
 func (c *Client) ListAllAccessListReviews(ctx context.Context, pageSize int, pageToken string) (reviews []*accesslist.Review, nextToken string, err error) {
-	resp, err := c.grpcClient.ListAllAccessListReviews(ctx, &accesslistv1.ListAllAccessListReviewsRequest{
+	return c.ListAllAccessListReviewsV2(ctx, &accesslistv1.ListAllAccessListReviewsRequest{
 		PageSize:  int32(pageSize),
 		NextToken: pageToken,
 	})
+}
+
+// ListAllAccessListReviewsV2 will list access list reviews for all access lists. Only to be used by the cache.
+func (c *Client) ListAllAccessListReviewsV2(ctx context.Context, req *accesslistv1.ListAllAccessListReviewsRequest) (reviews []*accesslist.Review, nextToken string, err error) {
+	resp, err := c.grpcClient.ListAllAccessListReviews(ctx, req)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1326,7 +1326,11 @@ func (a *ServerWithRoles) hasWatchPermissionForKind(
 // resources is only meaningful for these kinds.
 func supportedScopedWatchKind(kind string) bool {
 	switch kind {
-	case scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment:
+	case types.KindAccessList,
+		types.KindAccessListMember,
+		types.KindAccessListReview,
+		scopedaccess.KindScopedRole,
+		scopedaccess.KindScopedRoleAssignment:
 		return true
 	default:
 		return false

--- a/lib/cache/access_list.go
+++ b/lib/cache/access_list.go
@@ -20,15 +20,18 @@ import (
 	"context"
 
 	"github.com/gravitational/trace"
+	"rsc.io/ordered"
 
 	"github.com/gravitational/teleport/api/defaults"
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/accesslists"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils/sortcache"
 )
@@ -45,6 +48,10 @@ func newAccessListCollection(upstream services.AccessLists, w types.WatchKind) (
 	if upstream == nil {
 		return nil, trace.BadParameter("missing parameter AccessLists")
 	}
+	scopeFilter := w.ScopeFilter.ToProto()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	return &collection[*accesslist.AccessList, accessListIndex]{
 		store: newStore(
@@ -59,9 +66,18 @@ func newAccessListCollection(upstream services.AccessLists, w types.WatchKind) (
 				accessListAuditNextDateIndex: services.AccessListAuditDateIndexKey,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*accesslist.AccessList, error) {
-			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListAccessLists))
+			out, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessList, string, error) {
+				return upstream.ListAccessListsV2(ctx, accesslistv1.ListAccessListsV2Request_builder{
+					PageSize:    int32(pageSize),
+					PageToken:   pageToken,
+					ScopeFilter: scopeFilter,
+				}.Build())
+			}))
 			return out, trace.Wrap(err)
 		},
+		// Note: scoped access list refs are never sent in a ResourceHeader, they
+		// use *accesslist.AccessList for delete events, so this transform will
+		// not apply to scoped access lists.
 		headerTransform: func(hdr *types.ResourceHeader) *accesslist.AccessList {
 			return &accesslist.AccessList{
 				ResourceHeader: header.ResourceHeader{
@@ -77,7 +93,7 @@ func newAccessListCollection(upstream services.AccessLists, w types.WatchKind) (
 	}, nil
 }
 
-// GetAccessLists returns a list of all access lists.
+// GetAccessLists returns a list of all unscoped access lists.
 func (c *Cache) GetAccessLists(ctx context.Context) ([]*accesslist.AccessList, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetAccessLists")
 	defer span.End()
@@ -94,7 +110,7 @@ func (c *Cache) GetAccessLists(ctx context.Context) ([]*accesslist.AccessList, e
 	}
 
 	out := make([]*accesslist.AccessList, 0, rg.store.len())
-	for n := range rg.store.resources(accessListNameIndex, "", "") {
+	for n := range rg.store.resources(accessListNameIndex, "", scopes.ResourceCursorScopedStart()) {
 		out = append(out, n.Clone())
 	}
 	return out, nil
@@ -104,6 +120,11 @@ func (c *Cache) GetAccessLists(ctx context.Context) ([]*accesslist.AccessList, e
 func (c *Cache) ListAccessListsV2(ctx context.Context, req *accesslistv1.ListAccessListsV2Request) ([]*accesslist.AccessList, string, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/ListAccessListsV2")
 	defer span.End()
+
+	scopeFilter := req.GetScopeFilter()
+	if err := scopes.ValidateFilter(req.GetScopeFilter()); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
 
 	index := accessListNameIndex
 
@@ -133,7 +154,7 @@ func (c *Cache) ListAccessListsV2(ctx context.Context, req *accesslistv1.ListAcc
 			return c.Config.AccessLists.ListAccessListsV2(ctx, req)
 		},
 		filter: func(al *accesslist.AccessList) bool {
-			return services.MatchAccessList(al, req.GetFilter())
+			return services.MatchAccessList(al, req.GetFilter()) && scopes.MatchScope(scopeFilter, al.GetScope())
 		},
 		nextToken: func(al *accesslist.AccessList) string {
 			// ignore error because CreateAccessListNextKey only errors
@@ -161,13 +182,20 @@ func (c *Cache) ListAccessLists(ctx context.Context, pageSize int, pageToken str
 			return t.GetMetadata().Name
 		},
 	}
-	out, next, err := lister.list(ctx, pageSize, pageToken)
+	out, next, err := lister.listRange(ctx, pageSize, pageToken, scopes.ResourceCursorScopedStart())
 	return out, next, trace.Wrap(err)
 }
 
 // GetAccessList returns the specified access list resource.
 func (c *Cache) GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/GetAccessList")
+	return c.GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Name: name,
+	}.Build())
+}
+
+// GetAccessListV2 returns the specified access list resource.
+func (c *Cache) GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetAccessListV2")
 	defer span.End()
 
 	var upstreamRead bool
@@ -177,14 +205,17 @@ func (c *Cache) GetAccessList(ctx context.Context, name string) (*accesslist.Acc
 		index:      accessListNameIndex,
 		upstreamGet: func(ctx context.Context, s string) (*accesslist.AccessList, error) {
 			upstreamRead = true
-			return c.Config.AccessLists.GetAccessList(ctx, s)
+			return c.Config.AccessLists.GetAccessListV2(ctx, req)
 		},
 	}
-	out, err := getter.get(ctx, name)
+	out, err := getter.get(ctx, accessListCursor(scopes.QualifiedName{
+		Scope: req.GetScope(),
+		Name:  req.GetName(),
+	}))
 	if trace.IsNotFound(err) && !upstreamRead {
 		// fallback is sane because method is never used
 		// in construction of derivative caches.
-		if item, err := c.Config.AccessLists.GetAccessList(ctx, name); err == nil {
+		if item, err := c.Config.AccessLists.GetAccessListV2(ctx, req); err == nil {
 			return item, nil
 		}
 	}
@@ -199,12 +230,48 @@ const (
 )
 
 func accessListMemberNameIndexKey(r *accesslist.AccessListMember) string {
-	return r.Spec.AccessList + "/" + r.GetName()
+	if r.GetScope() == "" {
+		return r.Spec.AccessList + "/" + r.GetName()
+	}
+	listSQN, listErr := accesslists.ParentListOf(r)
+	memberSQN, memberErr := accesslists.MemberScopeQualifiedName(r)
+	if listErr != nil || memberErr != nil {
+		return "~invalid/" + base32Encode(string(ordered.Encode(r.Spec.AccessList, r.GetName())))
+	}
+	return namedAccessListMemberNameIndexKey(listSQN.ToScopesQualifiedName(), memberSQN.ToScopesQualifiedName())
+}
+
+func namedAccessListMemberNameIndexKey(listName, memberName scopes.QualifiedName) string {
+	return scopes.MakeNestedResourceCursor(listName, memberName)
+}
+
+func accessListCursor(listName scopes.QualifiedName) string {
+	return scopes.MakeResourceCursor(listName.Scope, listName.Name)
+}
+
+func accessListMemberKindIndexKey(r *accesslist.AccessListMember) string {
+	if r.GetScope() == "" {
+		return r.Spec.AccessList + "/" + r.Spec.MembershipKind + "/" + r.GetName()
+	}
+
+	listSQN, listErr := scopes.ParseQualifiedName(r.Spec.AccessList)
+	memberSQN, memberErr := accesslists.MemberScopeQualifiedName(r)
+	if listErr != nil || memberErr != nil {
+		return "~invalid/" + base32Encode(string(ordered.Encode(r.Spec.AccessList, r.Spec.MembershipKind, r.GetName())))
+	}
+
+	listCursor := scopes.MakeResourceCursor(listSQN.Scope, listSQN.Name)
+	encodedMemberScope := scopes.EncodeForResourceCursor(memberSQN.Scope)
+	return listCursor + "/" + r.Spec.MembershipKind + "/" + encodedMemberScope + "/" + memberSQN.Name
 }
 
 func newAccessListMemberCollection(upstream services.AccessLists, w types.WatchKind) (*collection[*accesslist.AccessListMember, accessListMemberIndex], error) {
 	if upstream == nil {
 		return nil, trace.BadParameter("missing parameter AccessLists")
+	}
+	scopeFilter := w.ScopeFilter.ToProto()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	return &collection[*accesslist.AccessListMember, accessListMemberIndex]{
@@ -212,17 +279,22 @@ func newAccessListMemberCollection(upstream services.AccessLists, w types.WatchK
 			types.KindAccessListMember,
 			(*accesslist.AccessListMember).Clone,
 			map[accessListMemberIndex]func(*accesslist.AccessListMember) string{
-				accessListMemberNameIndex: func(r *accesslist.AccessListMember) string {
-					return accessListMemberNameIndexKey(r)
-				},
-				accessListMemberKindIndex: func(r *accesslist.AccessListMember) string {
-					return r.Spec.AccessList + "/" + r.Spec.MembershipKind + "/" + r.GetName()
-				},
+				accessListMemberNameIndex: accessListMemberNameIndexKey,
+				accessListMemberKindIndex: accessListMemberKindIndexKey,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*accesslist.AccessListMember, error) {
-			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListAllAccessListMembers))
+			out, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+				return upstream.ListAllAccessListMembersV2(ctx, accesslistv1.ListAllAccessListMembersRequest_builder{
+					PageSize:    int32(pageSize),
+					PageToken:   pageToken,
+					ScopeFilter: scopeFilter,
+				}.Build())
+			}))
 			return out, trace.Wrap(err)
 		},
+		// Note: scoped member refs are never sent in a ResourceHeader, they
+		// use *accesslist.AccessListMember for delete events, so this
+		// transform will not apply to scoped members.
 		headerTransform: func(hdr *types.ResourceHeader) *accesslist.AccessListMember {
 			return &accesslist.AccessListMember{
 				ResourceHeader: header.ResourceHeader{
@@ -243,7 +315,14 @@ func newAccessListMemberCollection(upstream services.AccessLists, w types.WatchK
 
 // CountAccessListMembers will count all access list members.
 func (c *Cache) CountAccessListMembers(ctx context.Context, accessListName string) (uint32, uint32, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/CountAccessListMembers")
+	return c.CountAccessListMembersV2(ctx, accesslistv1.CountAccessListMembersRequest_builder{
+		AccessListName: accessListName,
+	}.Build())
+}
+
+// CountAccessListMembersV2 will count all access list members.
+func (c *Cache) CountAccessListMembersV2(ctx context.Context, req *accesslistv1.CountAccessListMembersRequest) (uint32, uint32, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/CountAccessListMembersV2")
 	defer span.End()
 
 	rg, err := acquireReadGuard(c, c.collections.accessListMembers)
@@ -253,23 +332,40 @@ func (c *Cache) CountAccessListMembers(ctx context.Context, accessListName strin
 	defer rg.Release()
 
 	if !rg.ReadCache() {
-		count, listCount, err := c.Config.AccessLists.CountAccessListMembers(ctx, accessListName)
+		count, listCount, err := c.Config.AccessLists.CountAccessListMembersV2(ctx, req)
 		return count, listCount, trace.Wrap(err)
 	}
 
-	startUserKey := accessListName + "/" + accesslist.MembershipKindUser + "/"
+	listCursor := accessListCursor(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessListName(),
+	})
+
+	startUserKey := listCursor + "/" + accesslist.MembershipKindUser + "/"
 	endUserKey := sortcache.NextKey(startUserKey)
 	userCount := uint32(rg.store.count(accessListMemberKindIndex, startUserKey, endUserKey))
 
-	startListKey := accessListName + "/" + accesslist.MembershipKindList + "/"
+	startListKey := listCursor + "/" + accesslist.MembershipKindList + "/"
 	endListKey := sortcache.NextKey(startListKey)
 	listCount := uint32(rg.store.count(accessListMemberKindIndex, startListKey, endListKey))
+	startScopedListKey := listCursor + "/" + accesslist.MembershipKindScopedList + "/"
+	endScopedListKey := sortcache.NextKey(startScopedListKey)
+	listCount += uint32(rg.store.count(accessListMemberKindIndex, startScopedListKey, endScopedListKey))
 
 	return userCount, listCount, nil
 }
 
 // ListAccessListMembers returns a paginated list of all access list members.
 func (c *Cache) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error) {
+	return c.ListAccessListMembersV2(ctx, accesslistv1.ListAccessListMembersRequest_builder{
+		AccessList: accessListName,
+		PageSize:   int32(pageSize),
+		PageToken:  pageToken,
+	}.Build())
+}
+
+// ListAccessListMembersV2 returns a paginated list of all access list members.
+func (c *Cache) ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/ListAccessListMembers")
 	defer span.End()
 
@@ -280,21 +376,27 @@ func (c *Cache) ListAccessListMembers(ctx context.Context, accessListName string
 	defer rg.Release()
 
 	if !rg.ReadCache() {
-		out, next, err := c.Config.AccessLists.ListAccessListMembers(ctx, accessListName, pageSize, pageToken)
+		out, next, err := c.Config.AccessLists.ListAccessListMembersV2(ctx, req)
 		return out, next, trace.Wrap(err)
 	}
 
-	return listAccessListMembers(rg.store, accessListName, pageSize, pageToken)
+	return listAccessListMembers(rg.store, req)
 }
 
-func listAccessListMembers(store *store[*accesslist.AccessListMember, accessListMemberIndex], accessListName string, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+func listAccessListMembers(store *store[*accesslist.AccessListMember, accessListMemberIndex], req *accesslistv1.ListAccessListMembersRequest) ([]*accesslist.AccessListMember, string, error) {
+	listCursor := accessListCursor(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+
 	// The ending "/" is very important here, otherwise we can start listing members of access
 	// lists which names are prefixed with this access list name. E.g. we'd list members of
 	// "dev-suffix" for list "dev".
-	start := accessListName + "/"
-	current := start + pageToken
+	start := listCursor + "/"
+	current := start + req.GetPageToken()
 	end := sortcache.NextKey(start)
 
+	pageSize := int(req.GetPageSize())
 	if pageSize <= 0 {
 		pageSize = defaults.DefaultChunkSize
 	}
@@ -302,7 +404,8 @@ func listAccessListMembers(store *store[*accesslist.AccessListMember, accessList
 	var out []*accesslist.AccessListMember
 	for member := range store.resources(accessListMemberNameIndex, current, end) {
 		if len(out) == pageSize {
-			return out, member.GetName(), nil
+			key := accessListMemberNameIndexKey(member)
+			return out, key[len(start):], nil
 		}
 
 		out = append(out, member.Clone())
@@ -313,25 +416,55 @@ func listAccessListMembers(store *store[*accesslist.AccessListMember, accessList
 
 // ListAllAccessListMembers returns a paginated list of all access list members for all access lists.
 func (c *Cache) ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/ListAllAccessListMembers")
+	return c.ListAllAccessListMembersV2(ctx, accesslistv1.ListAllAccessListMembersRequest_builder{
+		PageSize:  int32(pageSize),
+		PageToken: pageToken,
+		ScopeFilter: scopesv1.Filter_builder{
+			Mode: scopesv1.Mode_MODE_UNSCOPED,
+		}.Build(),
+	}.Build())
+
+}
+
+// ListAllAccessListMembersV2 returns a paginated list of all access list members for all access lists.
+func (c *Cache) ListAllAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAllAccessListMembersRequest) ([]*accesslist.AccessListMember, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListAllAccessListMembersV2")
 	defer span.End()
+
+	scopeFilter := req.GetScopeFilter()
+	if err := scopes.ValidateFilter(req.GetScopeFilter()); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
 
 	lister := genericLister[*accesslist.AccessListMember, accessListMemberIndex]{
 		cache:           c,
 		collection:      c.collections.accessListMembers,
 		index:           accessListMemberNameIndex,
 		defaultPageSize: 200,
-		upstreamList:    c.Config.AccessLists.ListAllAccessListMembers,
+		upstreamList: func(ctx context.Context, _ int, _ string) ([]*accesslist.AccessListMember, string, error) {
+			return c.Config.AccessLists.ListAllAccessListMembersV2(ctx, req)
+		},
 		nextToken: func(t *accesslist.AccessListMember) string {
 			return accessListMemberNameIndexKey(t)
 		},
+		filter: func(member *accesslist.AccessListMember) bool {
+			return scopes.MatchScope(scopeFilter, member.GetScope())
+		},
 	}
-	out, next, err := lister.list(ctx, pageSize, pageToken)
+	out, next, err := lister.list(ctx, int(req.GetPageSize()), req.GetPageToken())
 	return out, next, trace.Wrap(err)
 }
 
 // GetAccessListMember returns the specified access list member resource.
 func (c *Cache) GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error) {
+	return c.GetAccessListMemberV2(ctx, accesslistv1.GetAccessListMemberRequest_builder{
+		AccessList: accessList,
+		MemberName: memberName,
+	}.Build())
+}
+
+// GetAccessListMemberV2 returns the specified access list member resource.
+func (c *Cache) GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetAccessListMember")
 	defer span.End()
 
@@ -342,11 +475,21 @@ func (c *Cache) GetAccessListMember(ctx context.Context, accessList string, memb
 	defer rg.Release()
 
 	if !rg.ReadCache() {
-		out, err := c.Config.AccessLists.GetAccessListMember(ctx, accessList, memberName)
+		out, err := c.Config.AccessLists.GetAccessListMemberV2(ctx, req)
 		return out, trace.Wrap(err)
 	}
 
-	member, err := rg.store.get(accessListMemberNameIndex, accessList+"/"+memberName)
+	listName := scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	}
+	memberName := scopes.QualifiedName{
+		Scope: req.GetMemberScope(),
+		Name:  req.GetMemberName(),
+	}
+	key := namedAccessListMemberNameIndexKey(listName, memberName)
+
+	member, err := rg.store.get(accessListMemberNameIndex, key)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -359,15 +502,33 @@ type accessListMembersListerStore struct {
 
 // ListAccessListMembers implements [accesslists.AccessListMembersLister].
 func (l accessListMembersListerStore) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error) {
-	return listAccessListMembers(l.store, accessListName, pageSize, pageToken)
+	return listAccessListMembers(l.store, accesslistv1.ListAccessListMembersRequest_builder{
+		AccessList: accessListName,
+		PageSize:   int32(pageSize),
+		PageToken:  pageToken,
+	}.Build())
+}
+
+func (l accessListMembersListerStore) ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error) {
+	return listAccessListMembers(l.store, req)
 }
 
 // GetAccessListOwners returns the owners of the specified access list, including those inherited.
 func (c *Cache) GetAccessListOwners(ctx context.Context, accessListName string) ([]*accesslist.Owner, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/GetAccessListOwners")
+	return c.GetAccessListOwnersV2(ctx, accesslistv1.GetAccessListOwnersRequest_builder{
+		AccessList: accessListName,
+	}.Build())
+}
+
+// GetAccessListOwnersV2 returns the owners of the specified access list, including those inherited.
+func (c *Cache) GetAccessListOwnersV2(ctx context.Context, req *accesslistv1.GetAccessListOwnersRequest) ([]*accesslist.Owner, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetAccessListOwnersV2")
 	defer span.End()
 
-	accessList, err := c.GetAccessList(ctx, accessListName)
+	accessList, err := c.GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -389,9 +550,27 @@ type accessListReviewIndex string
 
 const accessListReviewNameIndex = "name"
 
+func accessListReviewNameIndexKey(r *accesslist.Review) string {
+	if r.GetScope() == "" {
+		return r.Spec.AccessList + "/" + r.GetName()
+	}
+
+	listSQN, err := accesslists.ReviewedList(r)
+	if err != nil {
+		return "~invalid/" + base32Encode(string(ordered.Encode(r.Spec.AccessList, r.GetName())))
+	}
+
+	listCursor := accessListCursor(listSQN.ToScopesQualifiedName())
+	return listCursor + "/" + r.GetName()
+}
+
 func newAccessListReviewCollection(upstream services.AccessLists, w types.WatchKind) (*collection[*accesslist.Review, accessListReviewIndex], error) {
 	if upstream == nil {
 		return nil, trace.BadParameter("missing parameter AccessLists")
+	}
+	scopeFilter := w.ScopeFilter.ToProto()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	return &collection[*accesslist.Review, accessListReviewIndex]{
@@ -399,14 +578,21 @@ func newAccessListReviewCollection(upstream services.AccessLists, w types.WatchK
 			types.KindAccessListReview,
 			(*accesslist.Review).Clone,
 			map[accessListReviewIndex]func(*accesslist.Review) string{
-				accessListReviewNameIndex: func(r *accesslist.Review) string {
-					return r.Spec.AccessList + "/" + r.GetName()
-				},
+				accessListReviewNameIndex: accessListReviewNameIndexKey,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*accesslist.Review, error) {
-			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListAllAccessListReviews))
+			out, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.Review, string, error) {
+				return upstream.ListAllAccessListReviewsV2(ctx, accesslistv1.ListAllAccessListReviewsRequest_builder{
+					PageSize:    int32(pageSize),
+					NextToken:   pageToken,
+					ScopeFilter: scopeFilter,
+				}.Build())
+			}))
 			return out, trace.Wrap(err)
 		},
+		// Note: scoped review refs are never sent in a ResourceHeader, they
+		// use *accesslist.Review for delete events, so this transform will not apply
+		// to scoped reviews.
 		headerTransform: func(hdr *types.ResourceHeader) *accesslist.Review {
 			return &accesslist.Review{
 				ResourceHeader: header.ResourceHeader{
@@ -427,6 +613,15 @@ func newAccessListReviewCollection(upstream services.AccessLists, w types.WatchK
 
 // ListAccessListReviews will list access list reviews for a particular access list.
 func (c *Cache) ListAccessListReviews(ctx context.Context, accessList string, pageSize int, pageToken string) ([]*accesslist.Review, string, error) {
+	return c.ListAccessListReviewsV2(ctx, accesslistv1.ListAccessListReviewsRequest_builder{
+		AccessList: accessList,
+		PageSize:   int32(pageSize),
+		NextToken:  pageToken,
+	}.Build())
+}
+
+// ListAccessListReviewsV2 will list access list reviews for a particular access list.
+func (c *Cache) ListAccessListReviewsV2(ctx context.Context, req *accesslistv1.ListAccessListReviewsRequest) ([]*accesslist.Review, string, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/ListAccessListReviews")
 	defer span.End()
 
@@ -435,21 +630,26 @@ func (c *Cache) ListAccessListReviews(ctx context.Context, accessList string, pa
 		collection:      c.collections.accessListReviews,
 		index:           accessListReviewNameIndex,
 		defaultPageSize: 200,
-		upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.Review, string, error) {
-			reviews, next, err := c.AccessLists.ListAccessListReviews(ctx, accessList, pageSize, pageToken)
-			return reviews, next, trace.Wrap(err)
+		upstreamList: func(ctx context.Context, _ int, _ string) ([]*accesslist.Review, string, error) {
+			return c.AccessLists.ListAccessListReviewsV2(ctx, req)
 		},
 		nextToken: func(t *accesslist.Review) string {
 			return t.GetName()
 		},
 	}
 
-	start := accessList + "/"
+	listCursor := accessListCursor(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+
+	start := listCursor + "/"
 	end := sortcache.NextKey(start)
+	pageToken := req.GetNextToken()
 	if pageToken != "" {
 		start += pageToken
 	}
 
-	out, next, err := lister.listRange(ctx, pageSize, start, end)
+	out, next, err := lister.listRange(ctx, int(req.GetPageSize()), start, end)
 	return out, next, trace.Wrap(err)
 }

--- a/lib/cache/access_list_test.go
+++ b/lib/cache/access_list_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -36,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/accesslists"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 )
 
@@ -638,4 +640,259 @@ func makeMembers(t *testing.T, alName string, count int) []*accesslist.AccessLis
 		members = append(members, newAccessListMember(t, alName, fmt.Sprintf("member-%d", i)))
 	}
 	return members
+}
+
+func TestScopedAccessListsCache(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		p := newTestPack(t, ForAuth)
+		t.Cleanup(p.Close)
+
+		// Create some scoped and unscoped lists in the backend.
+		listNames := []accesslists.NormalizedSQN{
+			{Name: "test1"},
+			{Name: "test2"},
+			{Name: "test3"},
+			{Scope: "/scope1", Name: "test1"},
+			{Scope: "/scope1", Name: "test2"},
+			{Scope: "/scope2", Name: "test3"},
+		}
+		for _, listName := range listNames {
+			list, err := accesslist.NewAccessListWithScope(
+				header.Metadata{
+					Name: listName.Name,
+				},
+				accesslist.Spec{
+					Title:  "test list",
+					Owners: []accesslist.Owner{{Name: "ownername"}},
+				},
+				listName.Scope,
+			)
+			require.NoError(t, err)
+
+			_, err = p.accessLists.UpsertAccessList(t.Context(), list)
+			require.NoError(t, err)
+		}
+
+		collectListNames := func() []accesslists.NormalizedSQN {
+			collectedNames := make([]accesslists.NormalizedSQN, 0, len(listNames))
+			for list, err := range clientutils.Resources(t.Context(), func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessList, string, error) {
+				return p.cache.ListAccessListsV2(t.Context(), accesslistv1.ListAccessListsV2Request_builder{
+					PageSize:  int32(pageSize),
+					PageToken: pageToken,
+				}.Build())
+			}) {
+				require.NoError(t, err)
+				collectedNames = append(collectedNames, accesslists.ScopeQualifiedName(list))
+			}
+			return collectedNames
+		}
+
+		// Assert the cache sees all the created lists, after backend events propagate.
+		synctest.Wait()
+		require.Equal(t, listNames, collectListNames())
+
+		// Delete each list one by one, the cache view should agree.
+		for len(listNames) > 0 {
+			err := p.accessLists.DeleteAccessListV2(t.Context(), accesslistv1.DeleteAccessListRequest_builder{
+				Scope: listNames[0].Scope,
+				Name:  listNames[0].Name,
+			}.Build())
+			require.NoError(t, err)
+
+			synctest.Wait()
+			listNames = listNames[1:]
+			require.Equal(t, listNames, collectListNames())
+		}
+	})
+}
+
+func TestScopedAccessListMembersCache(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		p := newTestPack(t, ForAuth)
+		t.Cleanup(p.Close)
+
+		// Create user and scoped-list members under scoped and unscoped lists.
+		type memberRef struct {
+			parent accesslists.NormalizedSQN
+			member accesslists.NormalizedSQN
+		}
+		memberRefs := []memberRef{
+			{parent: accesslists.NormalizedSQN{Name: "test1"}, member: accesslists.NormalizedSQN{Name: "member"}},
+			{parent: accesslists.NormalizedSQN{Name: "test2"}, member: accesslists.NormalizedSQN{Name: "member"}},
+			{parent: accesslists.NormalizedSQN{Name: "test3"}, member: accesslists.NormalizedSQN{Name: "member"}},
+			{parent: accesslists.NormalizedSQN{Scope: "/scope1", Name: "test1"}, member: accesslists.NormalizedSQN{Name: "member"}},
+			{parent: accesslists.NormalizedSQN{Scope: "/scope1", Name: "test2"}, member: accesslists.NormalizedSQN{Scope: "/scope1", Name: "nested2"}},
+			{parent: accesslists.NormalizedSQN{Scope: "/scope2", Name: "test3"}, member: accesslists.NormalizedSQN{Scope: "/scope2", Name: "nested3"}},
+		}
+		for _, ref := range memberRefs {
+			list, err := accesslist.NewAccessListWithScope(
+				header.Metadata{Name: ref.parent.Name},
+				accesslist.Spec{
+					Title:  "test list",
+					Owners: []accesslist.Owner{{Name: "ownername"}},
+				},
+				ref.parent.Scope,
+			)
+			require.NoError(t, err)
+			_, err = p.accessLists.UpsertAccessList(t.Context(), list)
+			require.NoError(t, err)
+
+			membershipKind := accesslist.MembershipKindUser
+			if ref.member.Scope != "" {
+				membershipKind = accesslist.MembershipKindScopedList
+				nestedList, err := accesslist.NewAccessListWithScope(
+					header.Metadata{Name: ref.member.Name},
+					accesslist.Spec{
+						Title:  "nested test list",
+						Owners: []accesslist.Owner{{Name: "ownername"}},
+					},
+					ref.member.Scope,
+				)
+				require.NoError(t, err)
+				_, err = p.accessLists.UpsertAccessList(t.Context(), nestedList)
+				require.NoError(t, err)
+			}
+
+			member, err := accesslist.NewAccessListMemberWithScope(
+				header.Metadata{Name: ref.member.String()},
+				accesslist.AccessListMemberSpec{
+					AccessList:     ref.parent.String(),
+					Name:           ref.member.String(),
+					Joined:         time.Now(),
+					Expires:        time.Now().Add(24 * time.Hour),
+					Reason:         "a reason",
+					AddedBy:        "dummy",
+					MembershipKind: membershipKind,
+				},
+				ref.parent.Scope,
+			)
+			require.NoError(t, err)
+			_, err = p.accessLists.UpsertAccessListMember(t.Context(), member)
+			require.NoError(t, err)
+		}
+
+		collectMemberRefs := func() []memberRef {
+			refs := make([]memberRef, 0, len(memberRefs))
+			for member, err := range clientutils.Resources(t.Context(), func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+				return p.cache.ListAllAccessListMembersV2(ctx, accesslistv1.ListAllAccessListMembersRequest_builder{
+					PageSize:  int32(pageSize),
+					PageToken: pageToken,
+				}.Build())
+			}) {
+				require.NoError(t, err)
+				parentListName, err := accesslists.ParentListOf(member)
+				require.NoError(t, err)
+				memberName, err := accesslists.MemberScopeQualifiedName(member)
+				require.NoError(t, err)
+				refs = append(refs, memberRef{parent: parentListName, member: memberName})
+			}
+			return refs
+		}
+
+		// Assert the cache sees all the created members, after backend events propagate.
+		synctest.Wait()
+		require.Equal(t, memberRefs, collectMemberRefs())
+
+		// Delete each member one by one, the cache view should agree.
+		for len(memberRefs) > 0 {
+			err := p.accessLists.DeleteAccessListMemberV2(t.Context(), accesslistv1.DeleteAccessListMemberRequest_builder{
+				AccessListScope: memberRefs[0].parent.Scope,
+				AccessList:      memberRefs[0].parent.Name,
+				MemberScope:     memberRefs[0].member.Scope,
+				MemberName:      memberRefs[0].member.Name,
+			}.Build())
+			require.NoError(t, err)
+
+			synctest.Wait()
+			memberRefs = memberRefs[1:]
+			require.Equal(t, memberRefs, collectMemberRefs())
+		}
+	})
+}
+
+func TestScopedAccessListReviewsCache(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		p := newTestPack(t, ForAuth)
+		t.Cleanup(p.Close)
+
+		type reviewRef struct {
+			parent accesslists.NormalizedSQN
+			review string
+		}
+		reviewRefs := []reviewRef{
+			{parent: accesslists.NormalizedSQN{Name: "test1"}},
+			{parent: accesslists.NormalizedSQN{Name: "test2"}},
+			{parent: accesslists.NormalizedSQN{Name: "test3"}},
+			{parent: accesslists.NormalizedSQN{Scope: "/scope1", Name: "test1"}},
+			{parent: accesslists.NormalizedSQN{Scope: "/scope1", Name: "test2"}},
+			{parent: accesslists.NormalizedSQN{Scope: "/scope2", Name: "test3"}},
+		}
+		for i, ref := range reviewRefs {
+			list, err := accesslist.NewAccessListWithScope(
+				header.Metadata{Name: ref.parent.Name},
+				accesslist.Spec{
+					Title:  "test list",
+					Owners: []accesslist.Owner{{Name: "ownername"}},
+				},
+				ref.parent.Scope,
+			)
+			require.NoError(t, err)
+			_, err = p.accessLists.UpsertAccessList(t.Context(), list)
+			require.NoError(t, err)
+
+			review, err := accesslist.NewReviewWithScope(
+				header.Metadata{Name: "ignored-by-create"},
+				accesslist.ReviewSpec{
+					AccessList: ref.parent.String(),
+					Reviewers:  []string{"reviewer"},
+					ReviewDate: time.Now(),
+				},
+				ref.parent.Scope,
+			)
+			require.NoError(t, err)
+			createdReview, _, err := p.accessLists.CreateAccessListReview(t.Context(), review)
+			require.NoError(t, err)
+			reviewRefs[i].review = createdReview.GetName()
+		}
+
+		collectReviewRefs := func() []reviewRef {
+			refs := make([]reviewRef, 0, len(reviewRefs))
+			for _, ref := range reviewRefs {
+				for review, err := range clientutils.Resources(t.Context(), func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.Review, string, error) {
+					return p.cache.ListAccessListReviewsV2(ctx, accesslistv1.ListAccessListReviewsRequest_builder{
+						AccessListScope: ref.parent.Scope,
+						AccessList:      ref.parent.Name,
+						PageSize:        int32(pageSize),
+						NextToken:       pageToken,
+					}.Build())
+				}) {
+					require.NoError(t, err)
+					parent, err := accesslists.ReviewedList(review)
+					require.NoError(t, err)
+					refs = append(refs, reviewRef{parent: parent, review: review.GetName()})
+				}
+			}
+			return refs
+		}
+
+		// Assert the cache sees all the created reviews, after backend events propagate.
+		synctest.Wait()
+		require.Equal(t, reviewRefs, collectReviewRefs())
+
+		// Delete each review one by one, the cache view should agree.
+		for i, ref := range reviewRefs {
+			err := p.accessLists.DeleteAccessListReviewV2(t.Context(), accesslistv1.DeleteAccessListReviewRequest_builder{
+				AccessListScope: ref.parent.Scope,
+				AccessListName:  ref.parent.Name,
+				ReviewName:      ref.review,
+			}.Build())
+			require.NoError(t, err)
+
+			synctest.Wait()
+			require.Equal(t, reviewRefs[i+1:], collectReviewRefs())
+		}
+	})
 }

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -138,10 +138,6 @@ func makeAllKnownCAsFilter() types.CertAuthorityFilter {
 func ForAuth(cfg Config) Config {
 	cfg.target = "auth"
 	cfg.EnableRelativeExpiry = true
-	// Explicitly filter to only unscoped resources for scope-aware kinds with
-	// scoped events but no cache support yet.
-	// TODO(nklaassen): delete when scoped access lists have cache support.
-	unscoped := types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build())
 	cfg.Watches = []types.WatchKind{
 		{Kind: types.KindCertAuthority, LoadSecrets: true},
 		{Kind: types.KindCertAuthorityOverride},
@@ -197,9 +193,9 @@ func ForAuth(cfg Config) Config {
 		{Kind: types.KindAuditQuery},
 		{Kind: types.KindSecurityReport},
 		{Kind: types.KindSecurityReportState},
-		{Kind: types.KindAccessList, ScopeFilter: unscoped},
-		{Kind: types.KindAccessListMember, ScopeFilter: unscoped},
-		{Kind: types.KindAccessListReview, ScopeFilter: unscoped},
+		{Kind: types.KindAccessList},
+		{Kind: types.KindAccessListMember},
+		{Kind: types.KindAccessListReview},
 		{Kind: types.KindKubeWaitingContainer},
 		{Kind: types.KindNotification},
 		{Kind: types.KindGlobalNotification},

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -89,6 +89,7 @@ import (
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -437,6 +438,9 @@ func newPackWithoutCache(dir string, opts ...packOption) (*testPack, error) {
 	accessListsSvc, err := local.NewAccessListServiceV2(local.AccessListServiceConfig{
 		Backend: p.backend,
 		Modules: modulestest.EnterpriseModules(),
+		ScopesFeatures: scopes.Features{
+			Enabled: true,
+		},
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/scopes/cursor.go
+++ b/lib/scopes/cursor.go
@@ -18,6 +18,7 @@ package scopes
 
 import (
 	"encoding/hex"
+	"slices"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -69,20 +70,83 @@ func IsScopedResourceCursor(cursor string) bool {
 // degraded cursor that is deterministic, unique per scope and name, sorts after
 // all valid cursors, and fails [ParseResourceCursor].
 func MakeResourceCursor(scope, name string) string {
-	if scope == "" {
-		return name
+	return MakeNestedResourceCursor(QualifiedName{
+		Scope: scope,
+		Name:  name,
+	})
+}
+
+// MakeNestedResourceCursor returns the cursor for a scoped or unscoped nested
+// resource in a logical, lexicographically ordered range of nested resources.
+// The motivating example is scoped access list members, where members are
+// keyed under their parent list.
+//
+// Resource cursors are intended for pagination tokens, range bounds, and
+// in-memory cache indexes. They are not backend storage keys and must not be
+// used to construct backend keys.
+//
+// If all provided scopes are empty, all names will simply be joined with the
+// separator, to maintain compatibility with existing unscoped resource cursors
+// and avoid wastefully encoding multiple empty scopes:
+//
+//	<root-name>[/<descendent-name>]...
+//
+// Scoped resource cursors use a synthetic prefix that cannot appear in
+// backend-safe resource names and sorts after all backend-safe name bytes.
+//
+//	~scoped/<encoded-root-scope>/<root-name>[/<encoded-descendent-scope>/<descendent-name>]...
+//
+// Each scope component is encoded with [EncodeForKey] so that scoped cursors
+// preserve scope ordering and can safely use '/' as the cursor separator.
+//
+// MakeNestedResourceCursor is infallible so that it can back key derivation with no
+// error path (in-memory cache indexes, pagination cursors). A scope that
+// cannot be encoded (which is only possible for invalid stored data) yields a
+// degraded cursor that is deterministic, unique per scope and name, sorts after
+// all valid cursors, and fails [ParseResourceCursor].
+func MakeNestedResourceCursor(root QualifiedName, descendents ...QualifiedName) string {
+	hasNonEmptyScope := root.Scope != "" || slices.ContainsFunc(descendents, func(descendent QualifiedName) bool {
+		return descendent.Scope != ""
+	})
+	if !hasNonEmptyScope {
+		var sb strings.Builder
+		sb.WriteString(root.Name)
+		for _, descendent := range descendents {
+			sb.WriteString(separator)
+			sb.WriteString(descendent.Name)
+		}
+		return sb.String()
 	}
 
-	encodedScope, err := EncodeForKey(scope)
+	var sb strings.Builder
+	sb.WriteString(ResourceCursorPrefix)
+	sb.WriteString(EncodeForResourceCursor(root.Scope))
+	sb.WriteString(separator)
+	sb.WriteString(root.Name)
+	for _, descendent := range descendents {
+		sb.WriteString(separator)
+		sb.WriteString(EncodeForResourceCursor(descendent.Scope))
+		sb.WriteString(separator)
+		sb.WriteString(descendent.Name)
+	}
+	return sb.String()
+}
+
+// EncodeForResourceCursor is infallible so that it can back key derivation with no
+// error path (in-memory cache indexes, pagination cursors). A scope that
+// cannot be encoded (which is only possible for invalid stored data) yields a
+// degraded cursor that is deterministic, unique per scope and name, sorts after
+// all valid cursors, and fails [ParseResourceCursor].
+func EncodeForResourceCursor(scope string) string {
+	encoded, err := EncodeForKey(scope)
 	if err != nil {
 		// '~' cannot appear in a valid scope encoding (which starts with '+'),
 		// so degraded cursors never collide with valid cursors and sort after
 		// them. The scope is hex-encoded so the cursor's scope component is a
 		// single path segment regardless of the scope's contents.
-		encodedScope = "~invalid+" + hex.EncodeToString([]byte(scope))
+		return "~invalid+" + hex.EncodeToString([]byte(scope))
 	}
-
-	return ResourceCursorPrefix + encodedScope + separator + name
+	return encoded
 }
 
 // ParseResourceCursor parses a resource cursor produced by [MakeResourceCursor]

--- a/lib/scopes/cursor_test.go
+++ b/lib/scopes/cursor_test.go
@@ -17,10 +17,13 @@
 package scopes
 
 import (
+	"math/rand/v2"
 	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	sliceutils "github.com/gravitational/teleport/lib/utils/slices"
 )
 
 func TestResourceCursor(t *testing.T) {
@@ -128,4 +131,116 @@ func TestResourceCursorSort(t *testing.T) {
 		{Scope: "/aa/bb", Name: "aaa"},
 		{Scope: "/bb", Name: "aaa"},
 	}, got)
+}
+
+func TestNestedResourceCursor(t *testing.T) {
+	for _, tc := range []struct {
+		desc        string
+		root        QualifiedName
+		descendents []QualifiedName
+		expected    string
+	}{
+		{
+			desc: "empty",
+		},
+		{
+			desc:     "unscoped",
+			root:     QualifiedName{Name: "test"},
+			expected: "test",
+		},
+		{
+			desc: "unscoped nested",
+			root: QualifiedName{Name: "test"},
+			descendents: []QualifiedName{
+				{Name: "nested"},
+			},
+			expected: "test/nested",
+		},
+		{
+			desc: "unscoped double nested",
+			root: QualifiedName{Name: "test"},
+			descendents: []QualifiedName{
+				{Name: "nested"},
+				{Name: "doublenested"},
+			},
+			expected: "test/nested/doublenested",
+		},
+		{
+			desc:     "scoped",
+			root:     QualifiedName{Scope: "/aa", Name: "test"},
+			expected: ResourceCursorPrefix + EncodeForResourceCursor("/aa") + separator + "test",
+		},
+		{
+			desc: "scoped nested",
+			root: QualifiedName{Scope: "/aa", Name: "test"},
+			descendents: []QualifiedName{
+				{Scope: "/", Name: "nested"},
+			},
+			expected: ResourceCursorPrefix + EncodeForResourceCursor("/aa") + separator + "test" +
+				separator + EncodeForResourceCursor("/") + separator + "nested",
+		},
+		{
+			desc: "scoped double nested",
+			root: QualifiedName{Scope: "/aa", Name: "test"},
+			descendents: []QualifiedName{
+				{Scope: "/", Name: "nested"},
+				{Scope: "/", Name: "doublenested"},
+			},
+			expected: ResourceCursorPrefix + EncodeForResourceCursor("/aa") + separator + "test" +
+				separator + EncodeForResourceCursor("/") + separator + "nested" +
+				separator + EncodeForResourceCursor("/") + separator + "doublenested",
+		},
+		{
+			desc:        "mixed scopes",
+			root:        QualifiedName{Scope: "/aa", Name: "test"},
+			descendents: []QualifiedName{{Name: "nested"}},
+			expected: ResourceCursorPrefix + EncodeForResourceCursor("/aa") + separator + "test" +
+				separator + EncodeForResourceCursor("") + separator + "nested",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.expected, MakeNestedResourceCursor(tc.root, tc.descendents...))
+		})
+	}
+}
+
+func TestNestedResourceCursorSort(t *testing.T) {
+	sorted := [][]QualifiedName{
+		{{Name: "a"}},
+		{{Name: "a"}, {Name: "a"}},
+		{{Name: "a"}, {Name: "b"}},
+
+		{{Name: "b"}},
+		{{Name: "b"}, {Name: "a"}},
+		{{Name: "b"}, {Name: "b"}},
+		{{Name: "b"}, {Name: "b"}, {Name: "a"}},
+
+		{{Scope: "/aa", Name: "a"}},
+		{{Scope: "/aa", Name: "a"}, {Scope: "/bb", Name: "a"}},
+		{{Scope: "/aa", Name: "a"}, {Scope: "/bb", Name: "b"}},
+		{{Scope: "/aa", Name: "a"}, {Scope: "/bb", Name: "b"}, {Scope: "/cc/dd", Name: "a"}},
+		{{Scope: "/aa", Name: "a"}, {Scope: "/cc", Name: "a"}},
+		{{Scope: "/aa", Name: "b"}},
+
+		{{Scope: "/zz/aa", Name: "z"}},
+		{{Scope: "/zz/aa/bb", Name: "z"}},
+		{{Scope: "/zz/aa/cc", Name: "z"}},
+		{{Scope: "/zz/bb", Name: "z"}},
+		{{Scope: "/zz/cc", Name: "z"}},
+
+		{{Scope: "bad scope 1"}},
+		{{Scope: "bad scope 2"}},
+	}
+	expectSortedCursors := sliceutils.Map(sorted, func(names []QualifiedName) string {
+		return MakeNestedResourceCursor(names[0], names[1:]...)
+	})
+
+	shuffledCursors := slices.Clone(expectSortedCursors)
+	rand.Shuffle(len(shuffledCursors), func(i, j int) {
+		shuffledCursors[i], shuffledCursors[j] = shuffledCursors[j], shuffledCursors[i]
+	})
+
+	// Assert that a string sort gets us back to the expected sorted order.
+	slices.Sort(shuffledCursors)
+	require.Equal(t, expectSortedCursors, shuffledCursors)
 }

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -33,6 +33,7 @@ import (
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/lib/accesslists"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -48,8 +49,6 @@ type AccessListsGetter interface {
 	ListAccessLists(context.Context, int, string) ([]*accesslist.AccessList, string, error)
 	// ListAccessListsV2 returns a filtered and sorted paginated list of access lists.
 	ListAccessListsV2(context.Context, *accesslistv1.ListAccessListsV2Request) ([]*accesslist.AccessList, string, error)
-	// GetAccessList returns the specified access list resource.
-	GetAccessList(context.Context, string) (*accesslist.AccessList, error)
 	// GetAccessListsToReview returns access lists that the user needs to review.
 	GetAccessListsToReview(context.Context) ([]*accesslist.AccessList, error)
 	// GetInheritedGrants returns grants inherited by access list accessListID from parent access lists.
@@ -181,8 +180,12 @@ func (ImplicitAccessListError) Error() string {
 type AccessListMemberGetter interface {
 	// GetAccessListMember returns the specified access list member resource.
 	GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error)
+	// GetAccessListMemberV2 returns the specified access list member resource.
+	GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error)
 	// GetAccessList returns the specified access list resource.
 	GetAccessList(context.Context, string) (*accesslist.AccessList, error)
+	// GetAccessListV2 returns the specified access list resource.
+	GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error)
 	// GetAccessLists returns a list of all access lists.
 	GetAccessLists(context.Context) ([]*accesslist.AccessList, error)
 }
@@ -193,13 +196,20 @@ type AccessListMembersGetter interface {
 
 	// CountAccessListMembers will count all access list members.
 	CountAccessListMembers(ctx context.Context, accessListName string) (membersCount uint32, listCount uint32, err error)
+	// CountAccessListMembersV2 will count all access list members.
+	CountAccessListMembersV2(ctx context.Context, req *accesslistv1.CountAccessListMembersRequest) (membersCount uint32, listCount uint32, err error)
 	// ListAccessListMembers returns a paginated list of all access list members.
 	ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
+	// ListAccessListMembersV2 returns a paginated list of all access list members.
+	ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error)
 	// ListAllAccessListMembers returns a paginated list of all access list members for all access lists.
 	ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
-	GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error)
+	// ListAllAccessListMembers returns a paginated list of all access list members for all access lists.
+	ListAllAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAllAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error)
 	// GetAccessListOwners returns a list of all owners in an Access List, including those inherited from nested Access Lists.
 	GetAccessListOwners(ctx context.Context, accessList string) ([]*accesslist.Owner, error)
+	// GetAccessListOwnersV2 returns a list of all owners in an Access List, including those inherited from nested Access Lists.
+	GetAccessListOwnersV2(ctx context.Context, req *accesslistv1.GetAccessListOwnersRequest) ([]*accesslist.Owner, error)
 }
 
 // AccessListMembers defines an interface for managing AccessListMembers.
@@ -264,9 +274,13 @@ func UnmarshalAccessListMember(data []byte, opts ...MarshalOption) (*accesslist.
 type AccessListReviews interface {
 	// ListAccessListReviews will list access list reviews for a particular access list.
 	ListAccessListReviews(ctx context.Context, accessList string, pageSize int, pageToken string) (reviews []*accesslist.Review, nextToken string, err error)
+	// ListAccessListReviewsV2 will list access list reviews for a particular access list.
+	ListAccessListReviewsV2(ctx context.Context, req *accesslistv1.ListAccessListReviewsRequest) (reviews []*accesslist.Review, nextToken string, err error)
 
-	// ListAllAccessListReviews will list access list reviews for all access lists. Only to be used by the cache.
+	// ListAllAccessListReviews will list access list reviews for all unscoped access lists. Only to be used by the cache.
 	ListAllAccessListReviews(ctx context.Context, pageSize int, pageToken string) (reviews []*accesslist.Review, nextToken string, err error)
+	// ListAllAccessListReviewsV2 will list access list reviews for all access lists. Only to be used by the cache.
+	ListAllAccessListReviewsV2(ctx context.Context, req *accesslistv1.ListAllAccessListReviewsRequest) (reviews []*accesslist.Review, nextToken string, err error)
 
 	// CreateAccessListReview will create a new review for an access list.
 	CreateAccessListReview(ctx context.Context, review *accesslist.Review) (updatedReview *accesslist.Review, nextReviewDate time.Time, err error)
@@ -335,7 +349,7 @@ func CreateAccessListNextKey(al *accesslist.AccessList, indexName string) (strin
 
 // AccessListNameIndexKey returns the resource name returned from GetName().
 func AccessListNameIndexKey(al *accesslist.AccessList) string {
-	return al.GetName()
+	return scopes.MakeResourceCursor(al.GetScope(), al.GetName())
 }
 
 // AccessListAuditDateIndexKey returns the DateOnly formatted next audit date
@@ -346,9 +360,9 @@ func AccessListAuditDateIndexKey(al *accesslist.AccessList) string {
 		// appear at the end when sorted. Otherwise we would compare against
 		// `0001-01-01 00:00:00` which would sort first, but actually means
 		// the access list is not eligible for review.
-		return "z/" + al.GetName()
+		return "z/" + AccessListNameIndexKey(al)
 	}
-	return al.Spec.Audit.NextAuditDate.Format(time.DateOnly) + "/" + al.GetName()
+	return al.Spec.Audit.NextAuditDate.Format(time.DateOnly) + "/" + AccessListNameIndexKey(al)
 }
 
 // AccessListTitleIndexKey returns the access list title base32hex encoded
@@ -356,7 +370,7 @@ func AccessListAuditDateIndexKey(al *accesslist.AccessList) string {
 func AccessListTitleIndexKey(al *accesslist.AccessList) string {
 	title := cases.Fold().String(al.Spec.Title)
 	title = base32.HexEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte(title))
-	return title + "/" + al.GetName()
+	return title + "/" + AccessListNameIndexKey(al)
 }
 
 // MatchAccessList returns true if the access list matches the given filter criteria.


### PR DESCRIPTION
Part of [RFD 308](https://github.com/gravitational/rfd/pull/22)

This PR adds scoped access lists, and their members and reviews, to the cache.

Parent: https://github.com/gravitational/teleport/pull/68696
Children: https://github.com/gravitational/teleport/pull/68480 https://github.com/gravitational/teleport/pull/68564

Manually tested with the testplan at https://github.com/gravitational/teleport.e/pull/9120
