### PR TITLE
[scopes] materialize assignments for scoped access lists

### DIFF
--- a/lib/accesslists/scopedcollection.go
+++ b/lib/accesslists/scopedcollection.go
@@ -1,0 +1,272 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package accesslists
+
+import (
+	"context"
+	"slices"
+	"strconv"
+
+	"github.com/gravitational/trace"
+
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/lib/scopes"
+)
+
+// ScopedCollection represents a complete batch of access list and members from
+// one source (e.g. entraID or okta). It is a clone of [Collection] that
+// supports inclusion of scoped access lists and nested scoped access list
+// members.
+//
+// All access lists and members in the batch are expected to be created/updated
+// together as a snapshot of a final complete state of the access lists and
+// their member hierarchy.
+//
+// For instance, imagine an access list import from EntraID directory where the
+// access list can't be modified outside EntraID and teleport only fetches the
+// complete state of access lists and members from EntraID.
+// This is useful to validate nested hierarchy on the fly and preset the
+// reference updates (Status.MemberOf and Status.OwnerOf) before starting the
+// actual creation/update process in the backend.
+// Relationships with access lists outside the ScopedCollection is not possible
+// because the collection source is aware only of the access lists and members
+// they contain.
+type ScopedCollection struct {
+	// MembersByAccessList maps access list names to their members
+	MembersByAccessList map[NormalizedSQN][]*accesslist.AccessListMember
+	// AccessListsByName is an internal map for fast lookup by name
+	AccessListsByName map[NormalizedSQN]*accesslist.AccessList
+}
+
+// Validate validates all access lists and members in the batch.
+func (b *ScopedCollection) Validate(ctx context.Context) error {
+	for aclName, accessList := range b.AccessListsByName {
+		if err := accessList.CheckAndSetDefaults(); err != nil {
+			return trace.Wrap(err)
+		}
+		if ScopeQualifiedName(accessList) != aclName {
+			return trace.BadParameter("AccessListsByName key %s does not match actual access list name %s",
+				aclName.String(), ScopeQualifiedName(accessList))
+		}
+	}
+	for aclName, members := range b.MembersByAccessList {
+		if _, ok := b.AccessListsByName[aclName]; !ok {
+			return trace.BadParameter("MembersByAccessList key %s has no corresponding list in AccessListsByName", aclName.String())
+		}
+		for _, member := range members {
+			if err := member.CheckAndSetDefaults(); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+	}
+	for _, accessList := range b.AccessListsByName {
+		members := b.MembersByAccessList[ScopeQualifiedName(accessList)]
+		if err := ValidateAccessListWithMembers(ctx, nil, accessList, members, b); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	if err := b.RefUpdates(); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// AddAccessList adds an access list and its members to the batch.
+func (b *ScopedCollection) AddAccessList(accessList *accesslist.AccessList, members []*accesslist.AccessListMember) error {
+	if accessList == nil {
+		return trace.BadParameter("access list is nil")
+	}
+	if b.MembersByAccessList == nil {
+		b.MembersByAccessList = make(map[NormalizedSQN][]*accesslist.AccessListMember)
+	}
+	if b.AccessListsByName == nil {
+		b.AccessListsByName = make(map[NormalizedSQN]*accesslist.AccessList)
+	}
+	b.MembersByAccessList[ScopeQualifiedName(accessList)] = members
+	b.AccessListsByName[ScopeQualifiedName(accessList)] = accessList
+
+	if accessList.Status.MemberOf == nil {
+		accessList.Status.MemberOf = []string{}
+	}
+	if accessList.Status.OwnerOf == nil {
+		accessList.Status.OwnerOf = []string{}
+	}
+	return nil
+}
+
+// GetAccessList retrieves an access list from the batch by name.
+// Implements accesslists.AccessListAndMembersGetter interface.
+func (b *ScopedCollection) GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error) {
+	al, exists := b.AccessListsByName[NormalizedSQN{Name: name}]
+	if !exists {
+		return nil, trace.NotFound("access list %q not found in batch", name)
+	}
+	return al, nil
+}
+
+// GetAccessListV2 retrieves an access list from the batch by scoped name.
+// Implements accesslists.AccessListAndMembersGetter interface.
+func (b *ScopedCollection) GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error) {
+	listName := NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetScope(),
+		Name:  req.GetName(),
+	})
+	al, exists := b.AccessListsByName[listName]
+	if !exists {
+		return nil, trace.NotFound("access list %q not found in batch", listName.String())
+	}
+	return al, nil
+}
+
+// ListAccessListMembers retrieves members for an access list from the batch.
+// Implements accesslists.AccessListAndMembersGetter interface.
+func (b *ScopedCollection) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+	return b.ListAccessListMembersV2(ctx, accesslistv1.ListAccessListMembersRequest_builder{
+		AccessList: accessListName,
+		PageSize:   int32(pageSize),
+		PageToken:  pageToken,
+	}.Build())
+}
+
+// ListAccessListMembersV2 retrieves members for an access list from the batch.
+func (b *ScopedCollection) ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) ([]*accesslist.AccessListMember, string, error) {
+	listName := NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	members, exists := b.MembersByAccessList[listName]
+	if !exists {
+		return nil, "", trace.NotFound("access list %q not found in batch", listName.String())
+	}
+
+	// Handle pagination
+	startIdx := 0
+	if req.GetPageToken() != "" {
+		idx, err := strconv.Atoi(req.GetPageToken())
+		if err != nil {
+			return nil, "", trace.BadParameter("invalid page token: %v", err)
+		}
+		startIdx = idx
+	}
+
+	// If startIdx is beyond the members slice, return empty result
+	if startIdx >= len(members) {
+		return []*accesslist.AccessListMember{}, "", nil
+	}
+
+	// Calculate end index based on pageSize
+	endIdx := len(members)
+	if req.GetPageSize() > 0 {
+		endIdx = min(startIdx+int(req.GetPageSize()), len(members))
+	}
+
+	// Slice members for this page
+	pageMembers := members[startIdx:endIdx]
+
+	// Generate next page token if there are more members
+	nextToken := ""
+	if endIdx < len(members) {
+		nextToken = strconv.Itoa(endIdx)
+	}
+
+	return pageMembers, nextToken, nil
+}
+
+// GetAccessListMember retrieves a specific member from an access list in the batch.
+// Implements accesslists.AccessListAndMembersGetter interface.
+func (b *ScopedCollection) GetAccessListMember(ctx context.Context, accessListName, memberName string) (*accesslist.AccessListMember, error) {
+	return b.GetAccessListMemberV2(ctx, accesslistv1.GetAccessListMemberRequest_builder{
+		AccessList: accessListName,
+		MemberName: memberName,
+	}.Build())
+}
+
+// GetAccessListMemberV2 retrieves a specific member from an access list in the batch.
+func (b *ScopedCollection) GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error) {
+	listName := NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	memberName := NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetMemberScope(),
+		Name:  req.GetMemberName(),
+	})
+	members, exists := b.MembersByAccessList[listName]
+	if !exists {
+		return nil, trace.NotFound("access list %q not found in batch", listName.String())
+	}
+	for _, member := range members {
+		thisMemberName, err := MemberScopeQualifiedName(member)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if thisMemberName == memberName {
+			return member, nil
+		}
+	}
+	return nil, trace.NotFound("member %q not found in access list %q", memberName.String(), listName.String())
+}
+
+// RefUpdates calculates and applies reference updates (Status.MemberOf and Status.OwnerOf)
+// based on the nested access list relationships in the collection.
+func (b *ScopedCollection) RefUpdates() error {
+	for name, accessList := range b.AccessListsByName {
+		for _, owner := range accessList.Spec.Owners {
+			if !owner.IsMembershipKindList() {
+				continue
+			}
+			ownerName, err := OwnerScopeQualifiedName(owner)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if targetList, exists := b.AccessListsByName[ownerName]; exists {
+				target := &targetList.Status.OwnerOf
+				if name.Scope != "" {
+					target = &targetList.Status.ScopedOwnerOf
+				}
+				if slices.Contains(*target, name.String()) {
+					continue
+				}
+				*target = append(*target, name.String())
+			}
+		}
+	}
+
+	for accessListName, members := range b.MembersByAccessList {
+		for _, member := range members {
+			if !member.IsList() {
+				continue
+			}
+			memberName, err := MemberScopeQualifiedName(member)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if targetList, exists := b.AccessListsByName[memberName]; exists {
+				target := &targetList.Status.MemberOf
+				if accessListName.Scope != "" {
+					target = &targetList.Status.ScopedMemberOf
+				}
+				if slices.Contains(*target, accessListName.String()) {
+					continue
+				}
+				*target = append(*target, accessListName.String())
+			}
+		}
+	}
+	return nil
+}

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -1442,15 +1442,23 @@ type Cache interface {
 	ListAccessListsV2(context.Context, *accesslistv1.ListAccessListsV2Request) ([]*accesslist.AccessList, string, error)
 	// GetAccessList returns the specified access list resource.
 	GetAccessList(context.Context, string) (*accesslist.AccessList, error)
+	// GetAccessListV2 returns the specified access list resource.
+	GetAccessListV2(context.Context, *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error)
 
 	// CountAccessListMembers will count all access list members.
 	CountAccessListMembers(ctx context.Context, accessListName string) (users uint32, lists uint32, err error)
 	// ListAccessListMembers returns a paginated list of all access list members.
 	ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
+	// ListAccessListMembersV2 returns a paginated list of all access list members.
+	ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error)
 	// ListAllAccessListMembers returns a paginated list of all members of all access lists.
 	ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
+	// ListAllAccessListMembersV2 returns a paginated list of all members of all access lists.
+	ListAllAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAllAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error)
 	// GetAccessListMember returns the specified access list member resource.
 	GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error)
+	// GetAccessListMemberV2 returns the specified access list member resource.
+	GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error)
 
 	// GetAccessListOwners returns a list of owners for a particular access list.
 	GetAccessListOwners(ctx context.Context, accessList string) ([]*accesslist.Owner, error)

--- a/lib/scopes/cache/access/access.go
+++ b/lib/scopes/cache/access/access.go
@@ -325,13 +325,11 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry retryutils.Retry) error
 	// watcher which watches backend events. It is used for driving changes to
 	// scoped role assignments materialized from access lists and their
 	// memberships.
-	// TODO(nklaassen): remove scope filter when materializer supports scoped lists.
-	unscoped := types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build())
 	aclWatcher, err := c.cfg.AccessListEvents.NewWatcher(ctx, types.Watch{
 		Name: "scoped-access-cache-acl-watcher",
 		Kinds: []types.WatchKind{
-			{Kind: types.KindAccessList, ScopeFilter: unscoped},
-			{Kind: types.KindAccessListMember, ScopeFilter: unscoped},
+			{Kind: types.KindAccessList},
+			{Kind: types.KindAccessListMember},
 		},
 	})
 	if err != nil {

--- a/lib/scopes/cache/access/materializer.go
+++ b/lib/scopes/cache/access/materializer.go
@@ -17,10 +17,10 @@
 package access
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/binary"
 	"iter"
 	"log/slog"
 	"maps"
@@ -32,12 +32,14 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/gravitational/teleport"
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/accesslists"
 	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/utils/set"
@@ -62,12 +64,12 @@ const (
 
 // AccessListReader provides the upstream source of access list and member resources.
 type AccessListReader interface {
-	ListAccessLists(context.Context, int, string) ([]*accesslist.AccessList, string, error)
-	GetAccessList(ctx context.Context, accessListName string) (*accesslist.AccessList, error)
+	ListAccessListsV2(context.Context, *accesslistv1.ListAccessListsV2Request) ([]*accesslist.AccessList, string, error)
+	GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error)
 
-	ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
-	ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
-	GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error)
+	ListAllAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAllAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error)
+	ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error)
+	GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error)
 }
 
 // AssignmentStore is the interface the materializer uses to persist
@@ -79,10 +81,53 @@ type AssignmentStore interface {
 
 // listAccessListMembers is a helper for calling clientutils.Resources to range
 // over all members of [listName].
-func listAccessListMembers(aclReader AccessListReader, listName string) func(context.Context, int, string) ([]*accesslist.AccessListMember, string, error) {
+func listAccessListMembers(aclReader AccessListReader, listName accesslists.NormalizedSQN) func(context.Context, int, string) ([]*accesslist.AccessListMember, string, error) {
 	return func(ctx context.Context, pageSize int, cursor string) ([]*accesslist.AccessListMember, string, error) {
-		return aclReader.ListAccessListMembers(ctx, listName, pageSize, cursor)
+		return aclReader.ListAccessListMembersV2(ctx, accesslistv1.ListAccessListMembersRequest_builder{
+			AccessListScope: listName.Scope,
+			AccessList:      listName.Name,
+			PageSize:        int32(pageSize),
+			PageToken:       cursor,
+		}.Build())
 	}
+}
+
+// listAllAccessListMembers is a helper for calling clientutils.Resources to range
+// over all access list members.
+func listAllAccessListMembers(aclReader AccessListReader) func(context.Context, int, string) ([]*accesslist.AccessListMember, string, error) {
+	return func(ctx context.Context, pageSize int, cursor string) ([]*accesslist.AccessListMember, string, error) {
+		return aclReader.ListAllAccessListMembersV2(ctx, accesslistv1.ListAllAccessListMembersRequest_builder{
+			PageSize:  int32(pageSize),
+			PageToken: cursor,
+		}.Build())
+	}
+}
+
+// listAccessLists is a helper for calling clientutils.Resources to range
+// over all access lists.
+func listAccessLists(aclReader AccessListReader) func(context.Context, int, string) ([]*accesslist.AccessList, string, error) {
+	return func(ctx context.Context, pageSize int, cursor string) ([]*accesslist.AccessList, string, error) {
+		return aclReader.ListAccessListsV2(ctx, accesslistv1.ListAccessListsV2Request_builder{
+			PageSize:  int32(pageSize),
+			PageToken: cursor,
+		}.Build())
+	}
+}
+
+func getAccessList(ctx context.Context, aclReader AccessListReader, listName accesslists.NormalizedSQN) (*accesslist.AccessList, error) {
+	return aclReader.GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Scope: listName.Scope,
+		Name:  listName.Name,
+	}.Build())
+}
+
+func getAccessListMember(ctx context.Context, aclReader AccessListReader, listName, memberName accesslists.NormalizedSQN) (*accesslist.AccessListMember, error) {
+	return aclReader.GetAccessListMemberV2(ctx, accesslistv1.GetAccessListMemberRequest_builder{
+		AccessListScope: listName.Scope,
+		AccessList:      listName.Name,
+		MemberScope:     memberName.Scope,
+		MemberName:      memberName.Name,
+	}.Build())
 }
 
 // Materializer is responsible for "materializing" scoped role assignments into
@@ -146,17 +191,42 @@ type Materializer struct {
 type MaterializedAssignmentKey struct {
 	// User is the name of the user the assignment is materialized for.
 	User string
-	// List is the name of the access list the assignment is materialized for.
-	List string
+	// ListName is the name of the access list the assignment is materialized for.
+	ListName string
+	// ListScope is the normalized scope of the access list the assignment is materialized for.
+	ListScope string
+}
+
+func newMaterializedAssignmentKey(list *accesslist.AccessList, userName string) MaterializedAssignmentKey {
+	return MaterializedAssignmentKey{
+		User:      userName,
+		ListName:  list.GetName(),
+		ListScope: scopes.NormalizeForEquality(list.GetScope()),
+	}
 }
 
 // AssignmentName returns the canonical name for the materialized scoped role assignment.
 func (k MaterializedAssignmentKey) AssignmentName() string {
 	h := sha256.New224()
-	binary.Write(h, binary.LittleEndian, uint16(len(k.User)))
 	h.Write([]byte(k.User))
-	h.Write([]byte(k.List))
+	h.Write([]byte{0})
+	h.Write([]byte(k.ListName))
+	h.Write([]byte{0})
+	h.Write([]byte(k.ListScope))
 	return "acl-" + base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+}
+
+func (k MaterializedAssignmentKey) assignmentScope() string {
+	return cmp.Or(k.ListScope, scopes.Root)
+}
+
+// listSQN returns the scope-qualified name of the access list the asignment
+// was materialized for.
+func (k MaterializedAssignmentKey) listSQN() accesslists.NormalizedSQN {
+	return accesslists.NormalizedSQN{
+		Name:  k.ListName,
+		Scope: k.ListScope,
+	}
 }
 
 // NewMaterializer returns a new scoped role assignment materializer.
@@ -193,12 +263,20 @@ func (m *Materializer) Init(ctx context.Context) (err error) {
 	// can react to member expiration.
 	now := time.Now()
 	nextExpiry := now.Add(century)
-	for member, err := range clientutils.Resources(ctx, m.aclReader.ListAllAccessListMembers) {
+	for member, err := range clientutils.Resources(ctx, listAllAccessListMembers(m.aclReader)) {
 		if err != nil {
 			return trace.Wrap(err, "reading access list members")
 		}
-		if member.Spec.MembershipKind == accesslist.MembershipKindList {
-			m.ancestorCache.addMembership(member.Spec.AccessList, member.GetName())
+		if member.IsList() {
+			memberSQN, err := accesslists.MemberScopeQualifiedName(member)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			parentSQN, err := accesslists.ParentListOf(member)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			m.ancestorCache.addMembership(parentSQN, memberSQN)
 		}
 		if member.Spec.Expires.After(now) && member.Spec.Expires.Before(nextExpiry) {
 			nextExpiry = member.Spec.Expires
@@ -206,21 +284,27 @@ func (m *Materializer) Init(ctx context.Context) (err error) {
 	}
 	m.reportFutureMemberExpiry(ctx, nextExpiry)
 
-	for list, err := range clientutils.Resources(ctx, m.aclReader.ListAccessLists) {
+	for list, err := range clientutils.Resources(ctx, listAccessLists(m.aclReader)) {
 		if err != nil {
 			return trace.Wrap(err, "reading access lists")
 		}
+		listSQN := accesslists.ScopeQualifiedName(list)
 		for _, owner := range list.Spec.Owners {
-			if owner.MembershipKind == accesslist.MembershipKindList {
-				m.ancestorCache.addOwnership(owner.Name, list.GetName())
+			if !owner.IsMembershipKindList() {
+				continue
 			}
+			ownerSQN, err := accesslists.OwnerScopeQualifiedName(owner)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			m.ancestorCache.addOwnership(ownerSQN, listSQN)
 		}
 	}
 
 	// We iterate the access lists again separately so that the ancestor cache
 	// is fully initialized before it may be referenced in
 	// m.initAccessListMembers.
-	for list, err := range clientutils.Resources(ctx, m.aclReader.ListAccessLists) {
+	for list, err := range clientutils.Resources(ctx, listAccessLists(m.aclReader)) {
 		if err != nil {
 			return trace.Wrap(err, "reading access lists")
 		}
@@ -252,14 +336,34 @@ func (m *Materializer) ProcessEvent(ctx context.Context, event types.Event) (err
 	case types.OpDelete:
 		switch event.Resource.GetKind() {
 		case types.KindAccessList:
-			m.handleAccessListDelete(ctx, event.Resource.GetName())
+			if list, ok := event.Resource.(*accesslist.AccessList); ok {
+				m.handleAccessListDelete(ctx, accesslists.ScopeQualifiedName(list))
+				return nil
+			}
+			m.handleAccessListDelete(ctx, accesslists.NormalizedSQN{Name: event.Resource.GetName()})
 		case types.KindAccessListMember:
+			if member, ok := event.Resource.(*accesslist.AccessListMember); ok {
+				listName, err := accesslists.ParentListOf(member)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				memberName, err := accesslists.MemberScopeQualifiedName(member)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				if memberName.Scope == "" {
+					m.handleAccessListMemberDelete(ctx, listName, memberName.Name)
+				} else {
+					m.handleListMemberDelete(ctx, listName, memberName)
+				}
+				return nil
+			}
 			listName := event.Resource.GetMetadata().Description
 			if listName == "" {
 				// This is a bug, return a hard failure.
 				return trace.Errorf("missing access list name in access list member delete event description")
 			}
-			m.handleAccessListMemberDelete(ctx, listName, event.Resource.GetName())
+			m.handleAccessListMemberDelete(ctx, accesslists.NormalizedSQN{Name: listName}, event.Resource.GetName())
 		}
 	}
 	return nil
@@ -269,7 +373,7 @@ func (m *Materializer) handleAccessListMemberPut(ctx context.Context, member *ac
 	if member.IsUser() {
 		m.handleUserMemberPut(ctx, member)
 	}
-	if member.Spec.MembershipKind == accesslist.MembershipKindList {
+	if member.IsList() {
 		m.handleListMemberPut(ctx, member)
 	}
 }
@@ -280,15 +384,19 @@ func (m *Materializer) handleAccessListMemberPut(ctx context.Context, member *ac
 // If the member resource is expired, it re-checks all materialized assignments
 // for the user in case they were granted via this membership.
 func (m *Materializer) handleUserMemberPut(ctx context.Context, member *accesslist.AccessListMember) {
-	listName := member.Spec.AccessList
 	userName := member.GetName()
+	listName, err := accesslists.ParentListOf(member)
+	if err != nil {
+		m.logger.WarnContext(ctx, "Access list member is invalid, unable to parse parent list", "error", err)
+		return
+	}
 
-	if m.ancestorCache.children.Get(listName).Contains(userName) {
+	if m.ancestorCache.children.Get(listName).Contains(accesslists.NormalizedSQN{Name: userName}) {
 		// Due to presence in the ancestor cache, this access list member must
 		// have been observed with membership kind list before, and now has
 		// membership kind user. Process a list member delete first, and then
 		// carry on to handle the user member put.
-		m.handleListMemberDelete(ctx, listName, userName)
+		m.handleListMemberDelete(ctx, listName, accesslists.NormalizedSQN{Name: userName})
 	}
 
 	if member.IsExpired(time.Now()) {
@@ -297,7 +405,7 @@ func (m *Materializer) handleUserMemberPut(ctx context.Context, member *accessli
 	}
 	m.reportFutureMemberExpiry(ctx, member.Spec.Expires)
 
-	list, err := m.aclReader.GetAccessList(ctx, listName)
+	list, err := getAccessList(ctx, m.aclReader, listName)
 	if err != nil {
 		m.logger.InfoContext(ctx, "Failed to get access list while handling member put",
 			"error", err,
@@ -322,7 +430,7 @@ func (m *Materializer) handleUserMemberPut(ctx context.Context, member *accessli
 			"list", list.GetName())
 	}
 
-	ancestors, validationErrors := m.collectAncestors(ctx, list.GetName())
+	ancestors, validationErrors := m.collectAncestors(ctx, listName)
 	for _, validationError := range validationErrors {
 		m.logger.InfoContext(ctx, "Error while validating access list ancestors, some scoped role assignments may not be materialized",
 			"error", validationError)
@@ -338,7 +446,7 @@ func (m *Materializer) handleUserMemberPut(ctx context.Context, member *accessli
 			m.logger.WarnContext(ctx, "Failed to materialize assignment",
 				"error", err,
 				"user", userName,
-				"list", ancestor.list.GetName())
+				"list", accesslists.ScopeQualifiedName(ancestor.list))
 		}
 	}
 }
@@ -351,12 +459,23 @@ func (m *Materializer) handleUserMemberPut(ctx context.Context, member *accessli
 // If the member resource is expired, it re-checks all materialized assignments
 // for the parent list and all of its ancestors, in case they were granted via this membership.
 func (m *Materializer) handleListMemberPut(ctx context.Context, member *accesslist.AccessListMember) {
-	parentListName, memberListName := member.Spec.AccessList, member.Spec.Name
+	parentListName, err := accesslists.ParentListOf(member)
+	if err != nil {
+		m.logger.WarnContext(ctx, "Access list member is invalid, unable to parse parent list", "error", err)
+		return
+	}
+	memberListName, err := accesslists.MemberScopeQualifiedName(member)
+	if err != nil {
+		m.logger.WarnContext(ctx, "Access list member is invalid, unable to parse member name", "error", err)
+		return
+	}
 
-	// It's possible this member resource used to have membership kind user and
-	// was updated to have membership kind list, so we must clear anything
-	// related to a previous user membership.
-	m.handleUserMemberDeleteOrExpired(ctx, parentListName, memberListName)
+	// If unscoped it's possible this member resource used to have membership
+	// kind user and was updated to have membership kind list, so we must clear
+	// anything related to a previous user membership.
+	if memberListName.Scope == "" {
+		m.handleUserMemberDeleteOrExpired(ctx, parentListName, memberListName.Name)
+	}
 
 	m.ancestorCache.addMembership(parentListName, memberListName)
 
@@ -369,7 +488,7 @@ func (m *Materializer) handleListMemberPut(ctx context.Context, member *accessli
 	// Every user that is a nested member of memberList may have just become a
 	// member of parentList and all lists it is a nested member of. They also
 	// may have become an owner of every list parentList is an owner of.
-	parentList, err := m.aclReader.GetAccessList(ctx, parentListName)
+	parentList, err := getAccessList(ctx, m.aclReader, parentListName)
 	if err != nil {
 		m.logger.InfoContext(ctx, "Failed to get access list while handling list member put, some scoped role assignments may not be materialized",
 			"error", err,
@@ -378,7 +497,7 @@ func (m *Materializer) handleListMemberPut(ctx context.Context, member *accessli
 		m.scheduleMissedMembersRepair(ctx)
 		return
 	}
-	memberList, err := m.aclReader.GetAccessList(ctx, memberListName)
+	memberList, err := getAccessList(ctx, m.aclReader, memberListName)
 	if err != nil {
 		m.logger.InfoContext(ctx, "Failed to get access list while handling list member put, some scoped role assignments may not be materialized",
 			"error", err,
@@ -440,22 +559,22 @@ func (m *Materializer) handleListMemberPut(ctx context.Context, member *accessli
 	}
 }
 
-func (m *Materializer) handleAccessListMemberDelete(ctx context.Context, listName, memberName string) {
+func (m *Materializer) handleAccessListMemberDelete(ctx context.Context, listName accesslists.NormalizedSQN, memberName string) {
 	// We don't get enough info from the event to know if the deleted member
 	// was a user or a list. Luckily member names are unique, so we know that
 	// if this membership is present in the ancestor cache as a list, then this
 	// member was last observed as a list. If it is not present in the ancestor
 	// cache, then it was last observed as a user (or not observed at all) and
 	// we handle it as a user member delete.
-	if m.ancestorCache.children.Get(listName).Contains(memberName) {
-		m.handleListMemberDelete(ctx, listName, memberName)
+	if m.ancestorCache.children.Get(listName).Contains(accesslists.NormalizedSQN{Name: memberName}) {
+		m.handleListMemberDelete(ctx, listName, accesslists.NormalizedSQN{Name: memberName})
 		return
 	}
 	m.handleUserMemberDeleteOrExpired(ctx, listName, memberName)
 }
 
 // handleListMemberDelete handles delete events for nested access list memberships.
-func (m *Materializer) handleListMemberDelete(ctx context.Context, parentListName, memberListName string) {
+func (m *Materializer) handleListMemberDelete(ctx context.Context, parentListName, memberListName accesslists.NormalizedSQN) {
 	// First and foremost, always keep the ancestor cache up to date with all
 	// direct list->list memberships.
 	m.ancestorCache.removeMembership(parentListName, memberListName)
@@ -470,7 +589,7 @@ func (m *Materializer) handleListMemberDelete(ctx context.Context, parentListNam
 // no longer be valid members or owners of the parent list or any of its
 // ancestors. At risk of being overly pessimistic, we re-check every
 // materialized assignment for the parent list and all of its ancestors.
-func (m *Materializer) handleListMemberExpired(ctx context.Context, parentListName string) {
+func (m *Materializer) handleListMemberExpired(ctx context.Context, parentListName accesslists.NormalizedSQN) {
 	// We must iterate all ancestors without relying on paging through
 	// collections in the cache to make sure we don't miss any assignments that
 	// need to be invalidated due to a paging error or any other transient
@@ -480,8 +599,8 @@ func (m *Materializer) handleListMemberExpired(ctx context.Context, parentListNa
 
 	// Iterate all currently materialized assignments.
 	for key := range m.materializedAssignments {
-		_, isAncestor := ancestors[key.List]
-		if key.List != parentListName && !isAncestor {
+		_, isAncestor := ancestors[key.listSQN()]
+		if key.listSQN() != parentListName && !isAncestor {
 			// We don't need to validate any assignments that are not for the
 			// parent list or any of its ancestors.
 			continue
@@ -502,7 +621,7 @@ func (m *Materializer) handleListMemberExpired(ctx context.Context, parentListNa
 // It's possible they are no longer a valid member of the parent list or any of
 // its ancestors. We need to re-check all current materialized assignments for
 // this user in the initial list or any of its ancestors.
-func (m *Materializer) handleUserMemberDeleteOrExpired(ctx context.Context, parentListName, userName string) {
+func (m *Materializer) handleUserMemberDeleteOrExpired(ctx context.Context, parentListName accesslists.NormalizedSQN, userName string) {
 	// We must iterate all ancestors without relying on paging through
 	// collections in the cache to make sure we don't miss any assignments that
 	// need to be invalidated due to a paging error or any other transient
@@ -510,8 +629,8 @@ func (m *Materializer) handleUserMemberDeleteOrExpired(ctx context.Context, pare
 	// memberships and ownerships, which is sufficient.
 	ancestors := m.collectAncestorListsWithoutValidation(parentListName)
 	for key := range m.materializedAssignmentsForUser(userName) {
-		_, isAncestor := ancestors[key.List]
-		if key.List != parentListName && !isAncestor {
+		_, isAncestor := ancestors[key.listSQN()]
+		if key.listSQN() != parentListName && !isAncestor {
 			// We don't need to validate any assignments that are not for the
 			// parent list or any of its ancestors.
 			continue
@@ -543,19 +662,27 @@ func (m *Materializer) handleUserMemberDeleteOrExpired(ctx context.Context, pare
 // If the list has any scoped owner grants and any owner lists were added,
 // materialize an assignment for them.
 func (m *Materializer) handleAccessListPut(ctx context.Context, list *accesslist.AccessList) {
+	listName := accesslists.ScopeQualifiedName(list)
+
 	// Update any owner list edges in the ancestor cache.
-	m.ancestorCache.clearOwnersOf(list.GetName())
+	m.ancestorCache.clearOwnersOf(listName)
 	for _, owner := range list.Spec.Owners {
-		if owner.MembershipKind != accesslist.MembershipKindList {
+		if !owner.IsMembershipKindList() {
 			continue
 		}
-		m.ancestorCache.addOwnership(owner.Name, list.GetName())
+		ownerName, err := accesslists.OwnerScopeQualifiedName(owner)
+		if err != nil {
+			m.logger.WarnContext(ctx, "Failed to parse owner name, ownership will not be considered",
+				"error", err, "name", owner.Name)
+			continue
+		}
+		m.ancestorCache.addOwnership(ownerName, listName)
 	}
 
 	// Re-check all extant assignments for this list in case any grants were added
 	// or removed or ownership status changed.
 	hasScopedGrants := hasMemberGrants(list) || hasOwnerGrants(list)
-	for key := range m.materializedAssignmentsForList(list.GetName()) {
+	for key := range m.materializedAssignmentsForList(listName) {
 		if hasScopedGrants {
 			// The list has some grants we should re-check. This may delete
 			// assignments as necessary.
@@ -580,7 +707,7 @@ func (m *Materializer) handleAccessListPut(ctx context.Context, list *accesslist
 	// is not possible for an access list update to invalidate membership in
 	// any other lists.
 	if hasMembershipRequires(list) {
-		ancestors := m.collectAncestorListsWithoutValidation(list.GetName())
+		ancestors := m.collectAncestorListsWithoutValidation(listName)
 		for ancestorListName := range ancestors {
 			for key := range m.materializedAssignmentsForList(ancestorListName) {
 				if err := m.recheckAssignment(ctx, key); err != nil {
@@ -611,7 +738,7 @@ func (m *Materializer) initAccessListMembers(ctx context.Context, list *accessli
 		return
 	}
 
-	ancestors, validationErrors := m.collectAncestors(ctx, list.GetName())
+	ancestors, validationErrors := m.collectAncestors(ctx, accesslists.ScopeQualifiedName(list))
 	for _, validationError := range validationErrors {
 		m.logger.InfoContext(ctx, "Error while validating access list ancestors, some scoped role assignments may not be materialized",
 			"error", validationError)
@@ -673,11 +800,12 @@ func (m *Materializer) initAccessListOwners(ctx context.Context, list *accesslis
 		// There is nothing to materialize for owners of this list.
 		return
 	}
+	listName := accesslists.ScopeQualifiedName(list)
 
 	// Keep track of users and lists that have already been seen across member
 	// iterations to avoid duplicating work if the same user or list is a
 	// member of multiple owner lists.
-	seenLists := set.New[string]()
+	seenLists := set.New[accesslists.NormalizedSQN]()
 	seenUsers := set.New[string]()
 
 	for _, owner := range list.Spec.Owners {
@@ -689,16 +817,22 @@ func (m *Materializer) initAccessListOwners(ctx context.Context, list *accesslis
 				m.logger.WarnContext(ctx, "Failed to materialize assignment",
 					"error", err,
 					"user", owner.Name,
-					"list", list.GetName())
+					"list", listName)
 			}
 			continue
 		}
 
-		if owner.MembershipKind != accesslist.MembershipKindList {
+		if !owner.IsMembershipKindList() {
 			continue
 		}
 
-		ownerList, err := m.aclReader.GetAccessList(ctx, owner.Name)
+		ownerName, err := accesslists.OwnerScopeQualifiedName(owner)
+		if err != nil {
+			m.logger.InfoContext(ctx, "Owner is invalid, failed to parse name",
+				"error", err, "name", owner.Name)
+			return
+		}
+		ownerList, err := getAccessList(ctx, m.aclReader, ownerName)
 		if err != nil {
 			m.logger.InfoContext(ctx, "Failed to get owner list, some scoped role assignments may not be materialized for owners",
 				"error", err)
@@ -713,7 +847,7 @@ func (m *Materializer) initAccessListOwners(ctx context.Context, list *accesslis
 			if err != nil {
 				m.logger.WarnContext(ctx, "Error while walking members of access list, some scoped role assignments may not be materialized",
 					"error", err,
-					"list", list.GetName())
+					"list", listName)
 				m.scheduleMissedMembersRepair(ctx)
 				// walkUserMembersRecursive may yield errors from walking members of any
 				// member lists, but it may not be done, so continue the loop.
@@ -723,7 +857,7 @@ func (m *Materializer) initAccessListOwners(ctx context.Context, list *accesslis
 				m.logger.WarnContext(ctx, "Failed to materialize assignment",
 					"error", err,
 					"user", member.GetName(),
-					"list", list.GetName())
+					"list", listName)
 			}
 		}
 	}
@@ -734,7 +868,7 @@ func (m *Materializer) initAccessListOwners(ctx context.Context, list *accesslis
 // another list (the access list service attempts to prevent it), but to be
 // defensive we re-check assignments for all ancestors anyway in case a
 // membership path through this list has been broken.
-func (m *Materializer) handleAccessListDelete(ctx context.Context, listName string) {
+func (m *Materializer) handleAccessListDelete(ctx context.Context, listName accesslists.NormalizedSQN) {
 	// First of all, keep the ancestor cache up to date with respect to owners.
 	// Access lists are the source of truth for direct owner relationships.
 	// While the deletion of the access list may invalidate a direct membership
@@ -752,8 +886,8 @@ func (m *Materializer) handleAccessListDelete(ctx context.Context, listName stri
 
 	// Iterate all currently materialized assignments.
 	for key := range m.materializedAssignments {
-		_, isAncestor := ancestors[key.List]
-		if key.List != listName && !isAncestor {
+		_, isAncestor := ancestors[key.listSQN()]
+		if key.listSQN() != listName && !isAncestor {
 			// We don't need to validate any assignments that are not for the
 			// deleted list or any of its ancestors.
 			continue
@@ -800,10 +934,7 @@ func (m *Materializer) updateRelationshipAndMaterialize(
 	relation ancestorRelation,
 	userName string,
 ) error {
-	currentRelation := m.materializedAssignments[MaterializedAssignmentKey{
-		List: list.GetName(),
-		User: userName,
-	}]
+	currentRelation := m.materializedAssignments[newMaterializedAssignmentKey(list, userName)]
 	relation.isMember = relation.isMember || currentRelation.isMember
 	relation.isOwner = relation.isOwner || currentRelation.isOwner
 	return m.materializeAssignment(ctx, list, relation, userName)
@@ -820,10 +951,7 @@ func (m *Materializer) materializeAssignment(
 	relation ancestorRelation,
 	userName string,
 ) error {
-	key := MaterializedAssignmentKey{
-		User: userName,
-		List: list.GetName(),
-	}
+	key := newMaterializedAssignmentKey(list, userName)
 
 	if (!relation.isMember || !hasMemberGrants(list)) && (!relation.isOwner || !hasOwnerGrants(list)) {
 		// This access list does not grant any scoped roles to this user,
@@ -836,7 +964,7 @@ func (m *Materializer) materializeAssignment(
 		Kind:    scopedaccess.KindScopedRoleAssignment,
 		SubKind: scopedaccess.SubKindMaterialized,
 		Version: types.V1,
-		Scope:   scopes.Root,
+		Scope:   key.assignmentScope(),
 		Metadata: headerv1.Metadata_builder{
 			Name: key.AssignmentName(),
 		}.Build(),
@@ -846,7 +974,7 @@ func (m *Materializer) materializeAssignment(
 		Status: scopedaccessv1.ScopedRoleAssignmentStatus_builder{
 			Origin: scopedaccessv1.ScopedRoleAssignmentStatus_Origin_builder{
 				CreatorKind: scopedaccess.CreatorKindAccessList,
-				CreatorName: list.GetName(),
+				CreatorName: key.listSQN().String(),
 			}.Build(),
 		}.Build(),
 	}.Build()
@@ -870,7 +998,7 @@ func (m *Materializer) materializeAssignment(
 
 	m.logger.DebugContext(ctx, "Materializing scoped role assignment",
 		"user", key.User,
-		"list", key.List)
+		"list", key.listSQN().String())
 	if err := m.assignmentStore.Put(assignment); err != nil {
 		return trace.Wrap(err, "putting materialized assignment into cache")
 	}
@@ -883,9 +1011,10 @@ func (m *Materializer) deleteMaterializedAssignment(ctx context.Context, key Mat
 	if _, ok := m.materializedAssignments[key]; ok {
 		m.logger.DebugContext(ctx, "Deleting materialized scoped role assignment",
 			"user", key.User,
-			"list", key.List)
+			"list", key.listSQN().String(),
+		)
 		m.assignmentStore.Delete(scopes.QualifiedName{
-			Scope: scopes.Root,
+			Scope: key.assignmentScope(),
 			Name:  key.AssignmentName(),
 		}, scopedaccess.SubKindMaterialized)
 		delete(m.materializedAssignments, key)
@@ -899,9 +1028,9 @@ func (m *Materializer) syncMaterializedAssignmentsMetric() {
 }
 
 func (m *Materializer) recheckAssignment(ctx context.Context, key MaterializedAssignmentKey) error {
-	list, err := m.aclReader.GetAccessList(ctx, key.List)
+	list, err := getAccessList(ctx, m.aclReader, key.listSQN())
 	if err != nil {
-		return trace.Wrap(err, "getting access list %v", key.List)
+		return trace.Wrap(err, "getting access list %v", key.listSQN().String())
 	}
 
 	relation := ancestorRelation{
@@ -934,10 +1063,15 @@ func (m *Materializer) checkNestedOwnership(ctx context.Context, list *accesslis
 
 	// Then check if user is a member or nested member of any owner lists.
 	for _, owner := range list.Spec.Owners {
-		if owner.MembershipKind != accesslist.MembershipKindList {
+		if !owner.IsMembershipKindList() {
 			continue
 		}
-		ownerList, err := m.aclReader.GetAccessList(ctx, owner.Name)
+		ownerName, err := accesslists.OwnerScopeQualifiedName(owner)
+		if err != nil {
+			// Must assume any membership is invalid if the owner name can't be parsed
+			continue
+		}
+		ownerList, err := getAccessList(ctx, m.aclReader, ownerName)
 		if err != nil {
 			// Must assume any membership is invalid if we can't fetch the access list.
 			continue
@@ -951,14 +1085,15 @@ func (m *Materializer) checkNestedOwnership(ctx context.Context, list *accesslis
 }
 
 func (m *Materializer) checkNestedMembership(ctx context.Context, list *accesslist.AccessList, userName string) bool {
-	seen := set.New[string]()
+	seen := set.New[accesslists.NormalizedSQN]()
 
 	var checkNestedMembershipRecursive func(*accesslist.AccessList) bool
 	checkNestedMembershipRecursive = func(list *accesslist.AccessList) bool {
-		if seen.Contains(list.GetName()) {
+		listName := accesslists.ScopeQualifiedName(list)
+		if seen.Contains(listName) {
 			return false
 		}
-		seen.Add(list.GetName())
+		seen.Add(listName)
 
 		if hasMembershipRequires(list) {
 			// Memberships can not be valid, for the purposes of granting scoped
@@ -967,7 +1102,7 @@ func (m *Materializer) checkNestedMembership(ctx context.Context, list *accessli
 		}
 
 		// Check if the user is a non-expired direct member of this list.
-		member, err := m.aclReader.GetAccessListMember(ctx, list.GetName(), userName)
+		member, err := getAccessListMember(ctx, m.aclReader, listName, accesslists.NormalizedSQN{Name: userName})
 		if err == nil {
 			if member.IsUser() && !member.IsExpired(time.Now()) {
 				// This user is a valid member.
@@ -976,14 +1111,14 @@ func (m *Materializer) checkNestedMembership(ctx context.Context, list *accessli
 		}
 
 		// Recursively check if the user is a valid member of any child lists.
-		for childListName := range m.ancestorCache.children.Get(list.GetName()).Items() {
-			listMember, err := m.aclReader.GetAccessListMember(ctx, list.GetName(), childListName)
+		for childListName := range m.ancestorCache.children.Get(listName).Items() {
+			listMember, err := getAccessListMember(ctx, m.aclReader, listName, childListName)
 			if err != nil || listMember.IsExpired(time.Now()) {
 				// Couldn't fetch child list member or its membership is
 				// expired, don't walk this membership path.
 				continue
 			}
-			childList, err := m.aclReader.GetAccessList(ctx, childListName)
+			childList, err := getAccessList(ctx, m.aclReader, childListName)
 			if err != nil {
 				// Must assume any membership is invalid if we can't fetch the access list.
 				continue
@@ -1000,10 +1135,10 @@ func (m *Materializer) checkNestedMembership(ctx context.Context, list *accessli
 	return checkNestedMembershipRecursive(list)
 }
 
-func (m *Materializer) materializedAssignmentsForList(listName string) iter.Seq2[MaterializedAssignmentKey, ancestorRelation] {
+func (m *Materializer) materializedAssignmentsForList(listName accesslists.NormalizedSQN) iter.Seq2[MaterializedAssignmentKey, ancestorRelation] {
 	return func(yield func(MaterializedAssignmentKey, ancestorRelation) bool) {
 		for key, relation := range m.materializedAssignments {
-			if key.List != listName {
+			if key.listSQN() != listName {
 				continue
 			}
 			if !yield(key, relation) {
@@ -1037,7 +1172,7 @@ func (m *Materializer) materializedAssignmentsForUser(userName string) iter.Seq2
 // It will yield any errors encountered while fetching list or member resources
 // but may continue iterating over other lists/members.
 func (m *Materializer) walkUserMembers(ctx context.Context, list *accesslist.AccessList) iter.Seq2[*accesslist.AccessListMember, error] {
-	seenLists := set.New[string]()
+	seenLists := set.New[accesslists.NormalizedSQN]()
 	seenUsers := set.New[string]()
 	return m.walkUserMembersRecursive(ctx, list, seenLists, seenUsers)
 }
@@ -1060,16 +1195,17 @@ func (m *Materializer) walkUserMembers(ctx context.Context, list *accesslist.Acc
 //
 // It will yield any errors encountered while fetching list or member resources
 // but may continue iterating over other lists/members.
-func (m *Materializer) walkUserMembersRecursive(ctx context.Context, list *accesslist.AccessList, seenLists set.Set[string], seenUsers set.Set[string]) iter.Seq2[*accesslist.AccessListMember, error] {
+func (m *Materializer) walkUserMembersRecursive(ctx context.Context, list *accesslist.AccessList, seenLists set.Set[accesslists.NormalizedSQN], seenUsers set.Set[string]) iter.Seq2[*accesslist.AccessListMember, error] {
 	return func(yield func(*accesslist.AccessListMember, error) bool) {
-		seenLists.Add(list.GetName())
+		listName := accesslists.ScopeQualifiedName(list)
+		seenLists.Add(listName)
 		if hasMembershipRequires(list) {
 			// membership requires are not supported in lists that transitively
 			// grant scoped roles, do not walk members of this list.
 			return
 		}
 
-		for member, err := range clientutils.Resources(ctx, listAccessListMembers(m.aclReader, list.GetName())) {
+		for member, err := range clientutils.Resources(ctx, listAccessListMembers(m.aclReader, listName)) {
 			if err != nil {
 				if !yield(nil, trace.Wrap(err)) {
 					return
@@ -1094,20 +1230,26 @@ func (m *Materializer) walkUserMembersRecursive(ctx context.Context, list *acces
 				}
 			}
 
-			if member.Spec.MembershipKind != accesslist.MembershipKindList {
-				// Currently members can only be users or lists, may need to
-				// handle bots in the future.
+			if !member.IsList() {
+				continue
+			}
+
+			memberListName, err := accesslists.MemberScopeQualifiedName(member)
+			if err != nil {
+				if !yield(nil, trace.Wrap(err)) {
+					return
+				}
 				continue
 			}
 
 			// Don't walk through this list if has already been seen.
-			if seenLists.Contains(member.GetName()) {
+			if seenLists.Contains(memberListName) {
 				continue
 			}
 
 			// Fetch the member list resource so the recursive call can check
 			// if it has any membership requires.
-			memberList, err := m.aclReader.GetAccessList(ctx, member.GetName())
+			memberList, err := getAccessList(ctx, m.aclReader, memberListName)
 			if err != nil {
 				// Yield the error so the caller can handle it how it wants,
 				// but continue iterating other nested members.
@@ -1123,96 +1265,96 @@ func (m *Materializer) walkUserMembersRecursive(ctx context.Context, list *acces
 	}
 }
 
-type mapStringSet struct {
-	m map[string]set.Set[string]
+type mapNormalizedSQNSet struct {
+	m map[accesslists.NormalizedSQN]set.Set[accesslists.NormalizedSQN]
 }
 
-func newMapStringSet() mapStringSet {
-	return mapStringSet{
-		m: make(map[string]set.Set[string]),
+func newMapNormalizedSQNSet() mapNormalizedSQNSet {
+	return mapNormalizedSQNSet{
+		m: make(map[accesslists.NormalizedSQN]set.Set[accesslists.NormalizedSQN]),
 	}
 }
 
 // readOnlySet implements a read-only view of a set.Set[string] that only
 // contains methods guaranteed to work even if the underlying map is nil.
 type readOnlySet struct {
-	s set.Set[string]
+	s set.Set[accesslists.NormalizedSQN]
 }
 
 // Contains implements a membership test for the readOnlySet.
-func (s readOnlySet) Contains(key string) bool {
+func (s readOnlySet) Contains(key accesslists.NormalizedSQN) bool {
 	return s.s.Contains(key)
 }
 
 // Items returns an iterator over all items in the set.
-func (s readOnlySet) Items() iter.Seq[string] {
+func (s readOnlySet) Items() iter.Seq[accesslists.NormalizedSQN] {
 	return maps.Keys(s.s)
 }
 
 // Get returns a read-only view of the set for the given key, it does not
 // allocate a set if the key is not present.
-func (m *mapStringSet) Get(key string) readOnlySet {
+func (m *mapNormalizedSQNSet) Get(key accesslists.NormalizedSQN) readOnlySet {
 	return readOnlySet{m.m[key]}
 }
 
 // Ensure returns a set for the given key, creating an empty set if one is not
-// currently present. Prefer [mapStringSet.Get] if the retuned set does not
+// currently present. Prefer [mapNormalizedSQNSet.Get] if the returned set does not
 // need to be mutated.
-func (m *mapStringSet) Ensure(key string) set.Set[string] {
+func (m *mapNormalizedSQNSet) Ensure(key accesslists.NormalizedSQN) set.Set[accesslists.NormalizedSQN] {
 	if s, ok := m.m[key]; ok {
 		return s
 	}
-	s := set.New[string]()
+	s := set.New[accesslists.NormalizedSQN]()
 	m.m[key] = s
 	return s
 }
 
 type ancestorCache struct {
-	parents  mapStringSet
-	children mapStringSet
-	ownedBy  mapStringSet
-	ownersOf mapStringSet
+	parents  mapNormalizedSQNSet
+	children mapNormalizedSQNSet
+	ownedBy  mapNormalizedSQNSet
+	ownersOf mapNormalizedSQNSet
 }
 
 func newAncestorCache() *ancestorCache {
 	return &ancestorCache{
-		parents:  newMapStringSet(),
-		children: newMapStringSet(),
-		ownedBy:  newMapStringSet(),
-		ownersOf: newMapStringSet(),
+		parents:  newMapNormalizedSQNSet(),
+		children: newMapNormalizedSQNSet(),
+		ownedBy:  newMapNormalizedSQNSet(),
+		ownersOf: newMapNormalizedSQNSet(),
 	}
 }
 
-func (c *ancestorCache) addMembership(parent, member string) {
+func (c *ancestorCache) addMembership(parent, member accesslists.NormalizedSQN) {
 	c.parents.Ensure(member).Add(parent)
 	c.children.Ensure(parent).Add(member)
 }
 
-func (c *ancestorCache) removeMembership(parent, member string) {
+func (c *ancestorCache) removeMembership(parent, member accesslists.NormalizedSQN) {
 	c.parents.Ensure(member).Remove(parent)
 	c.children.Ensure(parent).Remove(member)
 }
 
-func (c *ancestorCache) addOwnership(owner, owned string) {
+func (c *ancestorCache) addOwnership(owner, owned accesslists.NormalizedSQN) {
 	c.ownedBy.Ensure(owner).Add(owned)
 	c.ownersOf.Ensure(owned).Add(owner)
 }
 
-func (c *ancestorCache) removeOwnership(owner, owned string) {
+func (c *ancestorCache) removeOwnership(owner, owned accesslists.NormalizedSQN) {
 	c.ownedBy.Ensure(owner).Remove(owned)
 	c.ownersOf.Ensure(owned).Remove(owner)
 }
 
-func (c *ancestorCache) clearOwnersOf(owned string) {
+func (c *ancestorCache) clearOwnersOf(owned accesslists.NormalizedSQN) {
 	for owner := range c.ownersOf.Get(owned).Items() {
 		c.removeOwnership(owner, owned)
 	}
 }
 
 type collectAncestorListsParams struct {
-	startListName      string
-	validateMembership func(parentListName, memberListName string) bool
-	validateOwnership  func(ownerListName, ownedListName string) bool
+	startListName      accesslists.NormalizedSQN
+	validateMembership func(parentListName, memberListName accesslists.NormalizedSQN) bool
+	validateOwnership  func(ownerListName, ownedListName accesslists.NormalizedSQN) bool
 }
 
 type ancestorRelation struct {
@@ -1224,23 +1366,23 @@ type ancestorRelation struct {
 // list, that is all lists where the given list is a (nested) member or owner.
 // This may be useful for calculating all related lists that may require an
 // assignment to be materialized for members of the starting list.
-func (c *ancestorCache) collectAncestorLists(params collectAncestorListsParams) map[string]ancestorRelation {
-	result := make(map[string]ancestorRelation)
-	markOwned := func(ownedListName string) {
+func (c *ancestorCache) collectAncestorLists(params collectAncestorListsParams) map[accesslists.NormalizedSQN]ancestorRelation {
+	result := make(map[accesslists.NormalizedSQN]ancestorRelation)
+	markOwned := func(ownedListName accesslists.NormalizedSQN) {
 		curr := result[ownedListName]
 		curr.isOwner = true
 		result[ownedListName] = curr
 	}
-	markMember := func(parentListName string) {
+	markMember := func(parentListName accesslists.NormalizedSQN) {
 		curr := result[parentListName]
 		curr.isMember = true
 		result[parentListName] = curr
 	}
 
-	seen := set.New[string]()
+	seen := set.New[accesslists.NormalizedSQN]()
 
-	var collectAncestorsRecursive func(currListName string)
-	collectAncestorsRecursive = func(currListName string) {
+	var collectAncestorsRecursive func(currListName accesslists.NormalizedSQN)
+	collectAncestorsRecursive = func(currListName accesslists.NormalizedSQN) {
 		if seen.Contains(currListName) {
 			return
 		}
@@ -1282,11 +1424,11 @@ func (c *ancestorCache) collectAncestorLists(params collectAncestorListsParams) 
 // This is useful when handling membership deletions, which requires
 // pessimistic validation of every possible already-materialized assignment
 // that may need to be invalidated.
-func (m *Materializer) collectAncestorListsWithoutValidation(startListName string) map[string]ancestorRelation {
+func (m *Materializer) collectAncestorListsWithoutValidation(startListName accesslists.NormalizedSQN) map[accesslists.NormalizedSQN]ancestorRelation {
 	return m.ancestorCache.collectAncestorLists(collectAncestorListsParams{
 		startListName:      startListName,
-		validateMembership: func(string, string) bool { return true },
-		validateOwnership:  func(string, string) bool { return true },
+		validateMembership: func(accesslists.NormalizedSQN, accesslists.NormalizedSQN) bool { return true },
+		validateOwnership:  func(accesslists.NormalizedSQN, accesslists.NormalizedSQN) bool { return true },
 	})
 }
 
@@ -1313,15 +1455,23 @@ type ancestor struct {
 // contain any ownership requires.
 //
 // Finally, any lists that do not contain any effective scoped role grants are
-// filted out. It is safe to materialize an assignment for all returned lists
+// filtered out. It is safe to materialize an assignment for all returned lists
 // without any further validation.
-func (m *Materializer) collectAncestors(ctx context.Context, startListName string) ([]ancestor, []error) {
+func (m *Materializer) collectAncestors(ctx context.Context, startListName accesslists.NormalizedSQN) ([]ancestor, []error) {
 	var validationErrors []error
-	fetchedLists := make(map[string]*accesslist.AccessList)
+	fetchedLists := make(map[accesslists.NormalizedSQN]*accesslist.AccessList)
 	ancestorRelations := m.ancestorCache.collectAncestorLists(collectAncestorListsParams{
 		startListName: startListName,
-		validateMembership: func(parentListName, memberListName string) bool {
-			memberResource, err := m.aclReader.GetAccessListMember(ctx, parentListName, memberListName)
+		validateMembership: func(parentListName, memberListName accesslists.NormalizedSQN) bool {
+			if memberListName.Scope != "" && !scopes.PolicyResourceScope(parentListName.Scope).CanDependOnStateFromPolicyResourceAtScope(memberListName.Scope) {
+				return false
+			}
+			memberResource, err := m.aclReader.GetAccessListMemberV2(ctx, accesslistv1.GetAccessListMemberRequest_builder{
+				AccessList:      parentListName.Name,
+				AccessListScope: parentListName.Scope,
+				MemberName:      memberListName.Name,
+				MemberScope:     memberListName.Scope,
+			}.Build())
 			if err != nil {
 				validationErrors = append(validationErrors,
 					trace.Wrap(err, "getting access list member %q in list %q", memberListName, parentListName))
@@ -1332,7 +1482,7 @@ func (m *Materializer) collectAncestors(ctx context.Context, startListName strin
 				// expected but should not be followed.
 				return false
 			}
-			parentList, err := m.aclReader.GetAccessList(ctx, parentListName)
+			parentList, err := getAccessList(ctx, m.aclReader, parentListName)
 			if err != nil {
 				validationErrors = append(validationErrors,
 					trace.Wrap(err, "getting access list %q", parentListName))
@@ -1348,8 +1498,11 @@ func (m *Materializer) collectAncestors(ctx context.Context, startListName strin
 			}
 			return true
 		},
-		validateOwnership: func(parentListName, ownedListName string) bool {
-			ownedList, err := m.aclReader.GetAccessList(ctx, ownedListName)
+		validateOwnership: func(ownerListName, ownedListName accesslists.NormalizedSQN) bool {
+			if ownerListName.Scope != "" && !scopes.PolicyResourceScope(ownedListName.Scope).CanDependOnStateFromPolicyResourceAtScope(ownerListName.Scope) {
+				return false
+			}
+			ownedList, err := getAccessList(ctx, m.aclReader, ownedListName)
 			if err != nil {
 				validationErrors = append(validationErrors,
 					trace.Wrap(err, "getting access list %q", ownedListName))
@@ -1529,7 +1682,7 @@ func (m *Materializer) repairExpiredMembers(ctx context.Context) {
 
 // collectExpiredMembers collects all expired access list members by parent
 // list, and returns the earliest seen future expiry.
-func (m *Materializer) collectExpiredMembers(ctx context.Context) (expiredMembersOf map[string]expiredMembers, nextExpiry time.Time) {
+func (m *Materializer) collectExpiredMembers(ctx context.Context) (expiredMembersOf map[accesslists.NormalizedSQN]expiredMembers, nextExpiry time.Time) {
 	// Use a consistent time for "now" so that this will report all members
 	// expired before this time, and schedule another repair for any members
 	// expiring after this time.
@@ -1538,11 +1691,11 @@ func (m *Materializer) collectExpiredMembers(ctx context.Context) (expiredMember
 	// Keep track of the nearest seen member expiry time that's in the future.
 	nextExpiry = now.Add(century)
 
-	expiredMembersOf = make(map[string]expiredMembers)
+	expiredMembersOf = make(map[accesslists.NormalizedSQN]expiredMembers)
 	expiredCount := 0
 
 	// Iterate all access list members to find any that are expired.
-	for member, err := range clientutils.Resources(ctx, m.aclReader.ListAllAccessListMembers) {
+	for member, err := range clientutils.Resources(ctx, listAllAccessListMembers(m.aclReader)) {
 		if err != nil {
 			// Failed to iterate all access list member resources, we may have
 			// missed an expired member or one that will be expiring soon.
@@ -1568,10 +1721,19 @@ func (m *Materializer) collectExpiredMembers(ctx context.Context) (expiredMember
 			"membership_kind", member.Spec.MembershipKind,
 			"expired", member.Spec.Expires)
 
+		parentList, err := accesslists.ParentListOf(member)
+		if err != nil {
+			m.logger.DebugContext(ctx, "Failed to parse parent list of expired member resource",
+				"list", member.Spec.AccessList,
+				"member", member.GetName(),
+				"membership_kind", member.Spec.MembershipKind,
+				"expired", member.Spec.Expires)
+		}
+
 		// Collect the expired membership.
-		knownExpiredMembers := expiredMembersOf[member.Spec.AccessList]
+		knownExpiredMembers := expiredMembersOf[parentList]
 		knownExpiredMembers.insert(member)
-		expiredMembersOf[member.Spec.AccessList] = knownExpiredMembers
+		expiredMembersOf[parentList] = knownExpiredMembers
 		expiredCount++
 	}
 	oteltrace.SpanFromContext(ctx).SetAttributes(attribute.Int("members.expired", expiredCount))
@@ -1581,8 +1743,8 @@ func (m *Materializer) collectExpiredMembers(ctx context.Context) (expiredMember
 
 // affectedAssignmentsForExpiredMembers returns an iterator of all current
 // materialized assignments that may be affected by an expired membership.
-func (m *Materializer) affectedAssignmentsForExpiredMembers(expiredMembersOf map[string]expiredMembers) iter.Seq[MaterializedAssignmentKey] {
-	assignmentFilters := make(map[string]assignmentFilter)
+func (m *Materializer) affectedAssignmentsForExpiredMembers(expiredMembersOf map[accesslists.NormalizedSQN]expiredMembers) iter.Seq[MaterializedAssignmentKey] {
+	assignmentFilters := make(map[accesslists.NormalizedSQN]assignmentFilter)
 	for parentListName, knownExpiredMembers := range expiredMembersOf {
 		currFilter := assignmentFilters[parentListName]
 		currFilter.merge(assignmentFilter{
@@ -1615,7 +1777,7 @@ func (m *Materializer) affectedAssignmentsForExpiredMembers(expiredMembersOf map
 
 	return func(yield func(MaterializedAssignmentKey) bool) {
 		for key := range m.materializedAssignments {
-			if !assignmentFilters[key.List].match(key.User) {
+			if !assignmentFilters[key.listSQN()].match(key.User) {
 				continue
 			}
 			if !yield(key) {
@@ -1631,7 +1793,7 @@ type expiredMembers struct {
 }
 
 func (m *expiredMembers) insert(member *accesslist.AccessListMember) {
-	m.hasExpiredListMember = m.hasExpiredListMember || member.Spec.MembershipKind == accesslist.MembershipKindList
+	m.hasExpiredListMember = m.hasExpiredListMember || member.IsList()
 	if m.hasExpiredListMember {
 		// users set is unneeded if there is an expired list member.
 		m.users = nil
@@ -1681,7 +1843,7 @@ func (m *Materializer) repairMissedMembers(ctx context.Context) {
 	// Iterate all access lists to additively materialize assignments for all
 	// their members and owners.
 	repairedLists := 0
-	for list, err := range clientutils.Resources(ctx, m.aclReader.ListAccessLists) {
+	for list, err := range clientutils.Resources(ctx, listAccessLists(m.aclReader)) {
 		if err != nil {
 			m.logger.InfoContext(ctx, "Missed membership repair failed to read all access lists, scheduling another repair",
 				"error", err)

--- a/lib/scopes/cache/access/materializer.go
+++ b/lib/scopes/cache/access/materializer.go
@@ -216,7 +216,10 @@ func (k MaterializedAssignmentKey) AssignmentName() string {
 	return "acl-" + base64.RawURLEncoding.EncodeToString(h.Sum(nil))
 }
 
-func (k MaterializedAssignmentKey) assignmentScope() string {
+// AssignmentScope returns the scope of the materialized assignment. For
+// assignments materialized for an unscoped access list, this will be the root
+// scope. Otherwise, it will be the scope of the access list.
+func (k MaterializedAssignmentKey) AssignmentScope() string {
 	return cmp.Or(k.ListScope, scopes.Root)
 }
 
@@ -964,7 +967,7 @@ func (m *Materializer) materializeAssignment(
 		Kind:    scopedaccess.KindScopedRoleAssignment,
 		SubKind: scopedaccess.SubKindMaterialized,
 		Version: types.V1,
-		Scope:   key.assignmentScope(),
+		Scope:   key.AssignmentScope(),
 		Metadata: headerv1.Metadata_builder{
 			Name: key.AssignmentName(),
 		}.Build(),
@@ -1014,7 +1017,7 @@ func (m *Materializer) deleteMaterializedAssignment(ctx context.Context, key Mat
 			"list", key.listSQN().String(),
 		)
 		m.assignmentStore.Delete(scopes.QualifiedName{
-			Scope: key.assignmentScope(),
+			Scope: key.AssignmentScope(),
 			Name:  key.AssignmentName(),
 		}, scopedaccess.SubKindMaterialized)
 		delete(m.materializedAssignments, key)

--- a/lib/scopes/cache/access/materializer_test.go
+++ b/lib/scopes/cache/access/materializer_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -40,6 +41,7 @@ import (
 	cachepkg "github.com/gravitational/teleport/lib/cache"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/observability/tracing"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/cache/access"
 	"github.com/gravitational/teleport/lib/scopes/cache/assignments"
@@ -55,7 +57,7 @@ func TestMain(m *testing.M) {
 
 type materializerTestcase struct {
 	// An initial collection of access lists and members for the test case.
-	collection accesslists.Collection
+	collection accesslists.ScopedCollection
 	// Expected assignments after cache init (and materialization).
 	expectedAssignments []*scopedaccessv1.ScopedRoleAssignment
 	// Optional extra mutation steps the test may run.
@@ -70,6 +72,20 @@ type materializerTestcaseStep struct {
 type materializerTestcaseState struct {
 	aclService         *local.AccessListService
 	breakableACLReader *breakableAccessListReader
+}
+
+func scopedCollection(collection accesslists.Collection) accesslists.ScopedCollection {
+	scopedCollection := accesslists.ScopedCollection{
+		AccessListsByName:   make(map[accesslists.NormalizedSQN]*accesslist.AccessList, len(collection.AccessListsByName)),
+		MembersByAccessList: make(map[accesslists.NormalizedSQN][]*accesslist.AccessListMember, len(collection.MembersByAccessList)),
+	}
+	for name, accessList := range collection.AccessListsByName {
+		scopedCollection.AccessListsByName[accesslists.NormalizedSQN{Name: name}] = accessList
+	}
+	for name, members := range collection.MembersByAccessList {
+		scopedCollection.MembersByAccessList[accesslists.NormalizedSQN{Name: name}] = members
+	}
+	return scopedCollection
 }
 
 func runMaterializerTestcase(t *testing.T, tc materializerTestcase) {
@@ -93,7 +109,7 @@ func runMaterializerTestcase(t *testing.T, tc materializerTestcase) {
 	require.NoError(t, err)
 
 	// Insert the access lists and members into the backend.
-	require.NoError(t, aclService.InsertAccessListCollection(t.Context(), &tc.collection))
+	require.NoError(t, aclService.InsertScopedAccessListCollection(t.Context(), &tc.collection))
 
 	// Create the access lists cache.
 	aclCache, err := cachepkg.New(cachepkg.Config{
@@ -168,7 +184,7 @@ func runMaterializerTestcase(t *testing.T, tc materializerTestcase) {
 func TestMaterializerSimpleChain(t *testing.T) {
 	t.Parallel()
 	runMaterializerTestcase(t, materializerTestcase{
-		collection: accesslists.Collection{
+		collection: scopedCollection(accesslists.Collection{
 			AccessListsByName: map[string]*accesslist.AccessList{
 				"grandparent": newAccessList(t, "grandparent", withMemberGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/aa/bb/cc",
@@ -194,7 +210,7 @@ func TestMaterializerSimpleChain(t *testing.T) {
 					newAccessListMember(t, "base", "tester", accesslist.MembershipKindUser),
 				},
 			},
-		},
+		}),
 		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 			expectedScopedRoleAssignment("tester", "base", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::baserole",
@@ -212,10 +228,69 @@ func TestMaterializerSimpleChain(t *testing.T) {
 	})
 }
 
+func TestMaterializerScopedAccessListDirectMember(t *testing.T) {
+	t.Parallel()
+
+	listName := accesslists.NormalizedSQN{Scope: "/eng", Name: "granted"}
+	runMaterializerTestcase(t, materializerTestcase{
+		collection: accesslists.ScopedCollection{
+			AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+				listName: newScopedAccessList(t, listName, withMemberGrants([]accesslist.ScopedRoleGrant{{
+					Scope: "/eng/team",
+					Role:  "/::engrole",
+				}})),
+			},
+			MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+				listName: {
+					newScopedAccessListMember(t, listName, accesslists.NormalizedSQN{Name: "tester"}, accesslist.MembershipKindUser),
+				},
+			},
+		},
+		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+			expectedScopedScopedRoleAssignment("tester", listName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				Role:  "/::engrole",
+				Scope: "/eng/team",
+			}.Build()}),
+		},
+	})
+}
+
+func TestMaterializerScopedAccessListMember(t *testing.T) {
+	t.Parallel()
+
+	parentName := accesslists.NormalizedSQN{Scope: "/eng/team", Name: "parent"}
+	childName := accesslists.NormalizedSQN{Scope: "/eng", Name: "child"}
+	runMaterializerTestcase(t, materializerTestcase{
+		collection: accesslists.ScopedCollection{
+			AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+				parentName: newScopedAccessList(t, parentName, withMemberGrants([]accesslist.ScopedRoleGrant{{
+					Scope: "/eng/team",
+					Role:  "/::parentrole",
+				}})),
+				childName: newScopedAccessList(t, childName),
+			},
+			MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+				parentName: {
+					newScopedAccessListMember(t, parentName, childName, accesslist.MembershipKindScopedList),
+				},
+				childName: {
+					newScopedAccessListMember(t, childName, accesslists.NormalizedSQN{Name: "tester"}, accesslist.MembershipKindUser),
+				},
+			},
+		},
+		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+			expectedScopedScopedRoleAssignment("tester", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				Role:  "/::parentrole",
+				Scope: "/eng/team",
+			}.Build()}),
+		},
+	})
+}
+
 func TestMaterializerDoubleListMembership(t *testing.T) {
 	t.Parallel()
 	runMaterializerTestcase(t, materializerTestcase{
-		collection: accesslists.Collection{
+		collection: scopedCollection(accesslists.Collection{
 			AccessListsByName: map[string]*accesslist.AccessList{
 				"parent": newAccessList(t, "parent", withMemberGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/parentscope",
@@ -239,7 +314,7 @@ func TestMaterializerDoubleListMembership(t *testing.T) {
 					newAccessListMember(t, "memberListB", "testerC", accesslist.MembershipKindUser),
 				},
 			},
-		},
+		}),
 		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 			// All users should be direct or nested members of the parent role,
 			// expect exactly one materialized assignment each.
@@ -266,7 +341,7 @@ func TestMaterializerDoubleListMembership(t *testing.T) {
 func TestMaterializerDoubleListParents(t *testing.T) {
 	t.Parallel()
 	runMaterializerTestcase(t, materializerTestcase{
-		collection: accesslists.Collection{
+		collection: scopedCollection(accesslists.Collection{
 			AccessListsByName: map[string]*accesslist.AccessList{
 				"parentA": newAccessList(t, "parentA", withMemberGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/aa",
@@ -289,7 +364,7 @@ func TestMaterializerDoubleListParents(t *testing.T) {
 					newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser),
 				},
 			},
-		},
+		}),
 		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 			// User should be a nested member of both parents and get an assignment for each.
 			expectedScopedRoleAssignment("tester", "parentA", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
@@ -307,7 +382,7 @@ func TestMaterializerDoubleListParents(t *testing.T) {
 func TestMaterializerDirectOwner(t *testing.T) {
 	t.Parallel()
 	runMaterializerTestcase(t, materializerTestcase{
-		collection: accesslists.Collection{
+		collection: scopedCollection(accesslists.Collection{
 			AccessListsByName: map[string]*accesslist.AccessList{
 				"testlist": newAccessList(t, "testlist", withOwnerGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/aa",
@@ -320,7 +395,7 @@ func TestMaterializerDirectOwner(t *testing.T) {
 			MembersByAccessList: map[string][]*accesslist.AccessListMember{
 				"testlist": {},
 			},
-		},
+		}),
 		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 			// The user is simply a direct owner of the access list and an
 			// assignment is expected.
@@ -336,7 +411,7 @@ func TestMaterializerUserMemberPutPreservesExistingOwnerGrant(t *testing.T) {
 	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: accesslists.Collection{
+			collection: scopedCollection(accesslists.Collection{
 				AccessListsByName: map[string]*accesslist.AccessList{
 					"granted": newAccessList(t, "granted",
 						withMemberGrants([]accesslist.ScopedRoleGrant{{
@@ -360,7 +435,7 @@ func TestMaterializerUserMemberPutPreservesExistingOwnerGrant(t *testing.T) {
 					},
 					"child": {},
 				},
-			},
+			}),
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 				expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::ownerrole",
@@ -393,7 +468,7 @@ func TestMaterializerListMemberPutPreservesExistingOwnerGrant(t *testing.T) {
 	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: accesslists.Collection{
+			collection: scopedCollection(accesslists.Collection{
 				AccessListsByName: map[string]*accesslist.AccessList{
 					"granted": newAccessList(t, "granted",
 						withMemberGrants([]accesslist.ScopedRoleGrant{{
@@ -421,7 +496,7 @@ func TestMaterializerListMemberPutPreservesExistingOwnerGrant(t *testing.T) {
 						newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser),
 					},
 				},
-			},
+			}),
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 				expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::ownerrole",
@@ -454,7 +529,7 @@ func TestMaterializerAccessListPutPreservesExistingOwnerGrant(t *testing.T) {
 	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: accesslists.Collection{
+			collection: scopedCollection(accesslists.Collection{
 				AccessListsByName: map[string]*accesslist.AccessList{
 					"granted": newAccessList(t, "granted",
 						withMemberGrants([]accesslist.ScopedRoleGrant{{
@@ -482,7 +557,7 @@ func TestMaterializerAccessListPutPreservesExistingOwnerGrant(t *testing.T) {
 						newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser),
 					},
 				},
-			},
+			}),
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 				// tests is initially ownly an owner of the granted list.
 				expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
@@ -517,7 +592,7 @@ func TestMaterializerOwnerRequirements(t *testing.T) {
 	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: accesslists.Collection{
+			collection: scopedCollection(accesslists.Collection{
 				AccessListsByName: map[string]*accesslist.AccessList{
 					// Ownership requirements in the owner list should not block
 					// _members_ of the owner list from receiving owner grants
@@ -537,7 +612,7 @@ func TestMaterializerOwnerRequirements(t *testing.T) {
 						newAccessListMember(t, "owners", "tester", accesslist.MembershipKindUser),
 					},
 				},
-			},
+			}),
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 				// tester is a valid member of list "owners". All valid members of
 				// list "owners" are valid _owners_ of list "granted", so the
@@ -580,7 +655,7 @@ func TestMaterializerOwnerRequirements(t *testing.T) {
 func TestMaterializerOwnerChain(t *testing.T) {
 	t.Parallel()
 	runMaterializerTestcase(t, materializerTestcase{
-		collection: accesslists.Collection{
+		collection: scopedCollection(accesslists.Collection{
 			AccessListsByName: map[string]*accesslist.AccessList{
 				"grandparent": newAccessList(t, "grandparent", withOwnerGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/aa/bb/cc",
@@ -617,7 +692,7 @@ func TestMaterializerOwnerChain(t *testing.T) {
 					newAccessListMember(t, "base", "basemember", accesslist.MembershipKindUser),
 				},
 			},
-		},
+		}),
 		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 			// baseowner is a direct owner of base list. Ownership is not inherited.
 			expectedScopedRoleAssignment("baseowner", "base", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
@@ -647,7 +722,7 @@ func TestMaterializerAccessListPutWithMembershipRequirements(t *testing.T) {
 	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: accesslists.Collection{
+			collection: scopedCollection(accesslists.Collection{
 				AccessListsByName: map[string]*accesslist.AccessList{
 					"top": newAccessList(t, "top", withMemberGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/aa",
@@ -663,7 +738,7 @@ func TestMaterializerAccessListPutWithMembershipRequirements(t *testing.T) {
 						newAccessListMember(t, "middle", "tester", accesslist.MembershipKindUser),
 					},
 				},
-			},
+			}),
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 				expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::toprole",
@@ -688,7 +763,7 @@ func TestMaterializerAccessListMemberKindUpdateInvalidatesPriorKind(t *testing.T
 	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: accesslists.Collection{
+			collection: scopedCollection(accesslists.Collection{
 				AccessListsByName: map[string]*accesslist.AccessList{
 					"parent": newAccessList(t, "parent", withMemberGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/aa",
@@ -704,7 +779,7 @@ func TestMaterializerAccessListMemberKindUpdateInvalidatesPriorKind(t *testing.T
 						newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser),
 					},
 				},
-			},
+			}),
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 				// Initially tester is a member of list child which is a member
 				// of list parent, resulting in a materialized assignment for
@@ -782,7 +857,7 @@ func TestMaterializerDiamond(t *testing.T) {
 	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: accesslists.Collection{
+			collection: scopedCollection(accesslists.Collection{
 				AccessListsByName: map[string]*accesslist.AccessList{
 					"top": newAccessList(t, "top", withMemberGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/aa",
@@ -807,7 +882,7 @@ func TestMaterializerDiamond(t *testing.T) {
 						newAccessListMember(t, "bottom", "tester", accesslist.MembershipKindUser),
 					},
 				},
-			},
+			}),
 			// Initially the user is a valid member of the top list by 2 paths.
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 				expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
@@ -867,7 +942,7 @@ func TestMaterializerCascadingMemberExpiries(t *testing.T) {
 		testStart := time.Now()
 
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: accesslists.Collection{
+			collection: scopedCollection(accesslists.Collection{
 				AccessListsByName: map[string]*accesslist.AccessList{
 					"testlist": newAccessList(t, "testlist", withMemberGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/test",
@@ -881,7 +956,7 @@ func TestMaterializerCascadingMemberExpiries(t *testing.T) {
 						newAccessListMember(t, "testlist", "charlie", accesslist.MembershipKindUser, withExpires(testStart.Add(3*time.Minute))),
 					},
 				},
-			},
+			}),
 			// Initially all users are valid members of testlist.
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 				expectedScopedRoleAssignment("alice", "testlist", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
@@ -945,7 +1020,7 @@ func TestMaterializerRepairFailedReads(t *testing.T) {
 	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: accesslists.Collection{
+			collection: scopedCollection(accesslists.Collection{
 				AccessListsByName: map[string]*accesslist.AccessList{
 					"parent": newAccessList(t, "parent", withMemberGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/test/parent",
@@ -960,7 +1035,7 @@ func TestMaterializerRepairFailedReads(t *testing.T) {
 					"parent": {},
 					"child":  {},
 				},
-			},
+			}),
 			// Initially there are no members and therefore no assignments.
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{},
 			steps: []materializerTestcaseStep{
@@ -1052,7 +1127,7 @@ func TestMaterializerDiamondExpiry(t *testing.T) {
 		rightExpires := testStart.Add(3 * time.Hour)
 
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: accesslists.Collection{
+			collection: scopedCollection(accesslists.Collection{
 				AccessListsByName: map[string]*accesslist.AccessList{
 					"top": newAccessList(t, "top", withMemberGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/aa",
@@ -1077,7 +1152,7 @@ func TestMaterializerDiamondExpiry(t *testing.T) {
 						newAccessListMember(t, "bottom", "tester", accesslist.MembershipKindUser),
 					},
 				},
-			},
+			}),
 			// Initially the user is a valid member of the top list by 2 paths.
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 				expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
@@ -1193,7 +1268,7 @@ func BenchmarkMaterializerInit(b *testing.B) {
 			t1 := time.Now()
 
 			// Insert the access lists and members into the backend.
-			require.NoError(b, aclService.InsertAccessListCollection(b.Context(), collection))
+			require.NoError(b, aclService.InsertScopedAccessListCollection(b.Context(), collection))
 
 			t2 := time.Now()
 
@@ -1254,8 +1329,9 @@ initializing acl cache: %v`, t1.Sub(t0), t2.Sub(t1), t3.Sub(t2))
 						continue
 					}
 					key := access.MaterializedAssignmentKey{
-						List: listName,
-						User: member.GetName(),
+						ListName:  listName.Name,
+						ListScope: listName.Scope,
+						User:      member.GetName(),
 					}
 					_, err := assignmentCache.GetScopedRoleAssignment(b.Context(), scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
 						Name:    key.AssignmentName(),
@@ -1269,8 +1345,8 @@ initializing acl cache: %v`, t1.Sub(t0), t2.Sub(t1), t3.Sub(t2))
 	}
 }
 
-func createBenchmarkCollection(b require.TestingT, listCount, membersPerList, nestingDepth int) *accesslists.Collection {
-	var collection accesslists.Collection
+func createBenchmarkCollection(b require.TestingT, listCount, membersPerList, nestingDepth int) *accesslists.ScopedCollection {
+	var collection accesslists.ScopedCollection
 
 	grants := []accesslist.ScopedRoleGrant{{
 		Role:  "/::testrole",
@@ -1369,6 +1445,23 @@ func newAccessList(t require.TestingT, name string, opts ...aclOption) *accessli
 	return list
 }
 
+func newScopedAccessList(t require.TestingT, name accesslists.NormalizedSQN, opts ...aclOption) *accesslist.AccessList {
+	list, err := accesslist.NewAccessListWithScope(header.Metadata{
+		Name: name.Name,
+	}, accesslist.Spec{
+		Title: name.String(),
+		Owners: []accesslist.Owner{{
+			Name:           "testowner",
+			MembershipKind: accesslist.MembershipKindUser,
+		}},
+	}, name.Scope)
+	require.NoError(t, err)
+	for _, opt := range opts {
+		opt(list)
+	}
+	return list
+}
+
 type memberOption func(*accesslist.AccessListMember)
 
 func withExpires(expires time.Time) memberOption {
@@ -1394,10 +1487,54 @@ func newAccessListMember(t require.TestingT, parent, member, membershipKind stri
 	return memberResource
 }
 
+func newScopedAccessListMember(t require.TestingT, parent, member accesslists.NormalizedSQN, membershipKind string, opts ...memberOption) *accesslist.AccessListMember {
+	memberResource, err := accesslist.NewAccessListMemberWithScope(header.Metadata{
+		Name: member.String(),
+	}, accesslist.AccessListMemberSpec{
+		AccessList:     parent.String(),
+		Name:           member.String(),
+		MembershipKind: membershipKind,
+		Joined:         time.Now(),
+		AddedBy:        "testowner",
+	}, parent.Scope)
+	require.NoError(t, err)
+	for _, opt := range opts {
+		opt(memberResource)
+	}
+	return memberResource
+}
+
+func expectedScopedScopedRoleAssignment(userName string, listName accesslists.NormalizedSQN, assignments []*scopedaccessv1.Assignment) *scopedaccessv1.ScopedRoleAssignment {
+	key := access.MaterializedAssignmentKey{
+		User:      userName,
+		ListName:  listName.Name,
+		ListScope: listName.Scope,
+	}
+	return scopedaccessv1.ScopedRoleAssignment_builder{
+		Kind:    scopedaccess.KindScopedRoleAssignment,
+		SubKind: scopedaccess.SubKindMaterialized,
+		Version: types.V1,
+		Metadata: headerv1.Metadata_builder{
+			Name: key.AssignmentName(),
+		}.Build(),
+		Scope: listName.Scope,
+		Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+			User:        userName,
+			Assignments: assignments,
+		}.Build(),
+		Status: scopedaccessv1.ScopedRoleAssignmentStatus_builder{
+			Origin: scopedaccessv1.ScopedRoleAssignmentStatus_Origin_builder{
+				CreatorKind: scopedaccess.CreatorKindAccessList,
+				CreatorName: listName.String(),
+			}.Build(),
+		}.Build(),
+	}.Build()
+}
+
 func expectedScopedRoleAssignment(userName, listName string, assignments []*scopedaccessv1.Assignment) *scopedaccessv1.ScopedRoleAssignment {
 	key := access.MaterializedAssignmentKey{
-		User: userName,
-		List: listName,
+		User:     userName,
+		ListName: listName,
 	}
 	return scopedaccessv1.ScopedRoleAssignment_builder{
 		Kind:    scopedaccess.KindScopedRoleAssignment,
@@ -1438,37 +1575,30 @@ func (b *breakableAccessListReader) err() error {
 	return fmt.Errorf("access list reader is broken")
 }
 
-func (b *breakableAccessListReader) ListAccessLists(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessList, string, error) {
+func (b *breakableAccessListReader) ListAccessListsV2(ctx context.Context, req *accesslistv1.ListAccessListsV2Request) ([]*accesslist.AccessList, string, error) {
 	if b.broken.Load() {
 		return nil, "", b.err()
 	}
-	return b.AccessListReader.ListAccessLists(ctx, pageSize, pageToken)
+	return b.AccessListReader.ListAccessListsV2(ctx, req)
 }
 
-func (b *breakableAccessListReader) GetAccessList(ctx context.Context, accessListName string) (*accesslist.AccessList, error) {
+func (b *breakableAccessListReader) GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error) {
 	if b.broken.Load() {
 		return nil, b.err()
 	}
-	return b.AccessListReader.GetAccessList(ctx, accessListName)
+	return b.AccessListReader.GetAccessListV2(ctx, req)
 }
 
-func (b *breakableAccessListReader) ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+func (b *breakableAccessListReader) ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) ([]*accesslist.AccessListMember, string, error) {
 	if b.broken.Load() {
 		return nil, "", b.err()
 	}
-	return b.AccessListReader.ListAllAccessListMembers(ctx, pageSize, pageToken)
+	return b.AccessListReader.ListAccessListMembersV2(ctx, req)
 }
 
-func (b *breakableAccessListReader) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
-	if b.broken.Load() {
-		return nil, "", b.err()
-	}
-	return b.AccessListReader.ListAccessListMembers(ctx, accessListName, pageSize, pageToken)
-}
-
-func (b *breakableAccessListReader) GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error) {
+func (b *breakableAccessListReader) GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error) {
 	if b.broken.Load() {
 		return nil, b.err()
 	}
-	return b.AccessListReader.GetAccessListMember(ctx, accessList, memberName)
+	return b.AccessListReader.GetAccessListMemberV2(ctx, req)
 }

--- a/lib/scopes/cache/access/materializer_test.go
+++ b/lib/scopes/cache/access/materializer_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -74,20 +75,6 @@ type materializerTestcaseState struct {
 	breakableACLReader *breakableAccessListReader
 }
 
-func scopedCollection(collection accesslists.Collection) accesslists.ScopedCollection {
-	scopedCollection := accesslists.ScopedCollection{
-		AccessListsByName:   make(map[accesslists.NormalizedSQN]*accesslist.AccessList, len(collection.AccessListsByName)),
-		MembersByAccessList: make(map[accesslists.NormalizedSQN][]*accesslist.AccessListMember, len(collection.MembersByAccessList)),
-	}
-	for name, accessList := range collection.AccessListsByName {
-		scopedCollection.AccessListsByName[accesslists.NormalizedSQN{Name: name}] = accessList
-	}
-	for name, members := range collection.MembersByAccessList {
-		scopedCollection.MembersByAccessList[accesslists.NormalizedSQN{Name: name}] = members
-	}
-	return scopedCollection
-}
-
 func runMaterializerTestcase(t *testing.T, tc materializerTestcase) {
 	// Setup prequisites for the cache
 	backend, err := memory.New(memory.Config{
@@ -109,7 +96,8 @@ func runMaterializerTestcase(t *testing.T, tc materializerTestcase) {
 	require.NoError(t, err)
 
 	// Insert the access lists and members into the backend.
-	require.NoError(t, aclService.InsertScopedAccessListCollection(t.Context(), &tc.collection))
+	err = aclService.InsertScopedAccessListCollection(t.Context(), &tc.collection)
+	require.NoError(t, err, trace.DebugReport(err))
 
 	// Create the access lists cache.
 	aclCache, err := cachepkg.New(cachepkg.Config{
@@ -183,154 +171,179 @@ func runMaterializerTestcase(t *testing.T, tc materializerTestcase) {
 
 func TestMaterializerSimpleChain(t *testing.T) {
 	t.Parallel()
-	runMaterializerTestcase(t, materializerTestcase{
-		collection: scopedCollection(accesslists.Collection{
-			AccessListsByName: map[string]*accesslist.AccessList{
-				"grandparent": newAccessList(t, "grandparent", withMemberGrants([]accesslist.ScopedRoleGrant{{
-					Scope: "/aa/bb/cc",
-					Role:  "/::grandparentrole",
-				}})),
-				"parent": newAccessList(t, "parent", withMemberGrants([]accesslist.ScopedRoleGrant{{
-					Scope: "/aa/bb",
-					Role:  "/::parentrole",
-				}})),
-				"base": newAccessList(t, "base", withMemberGrants([]accesslist.ScopedRoleGrant{{
-					Scope: "/aa",
+	t.Run("unscoped", func(t *testing.T) {
+		grandparentName := accesslists.NormalizedSQN{Name: "grandparent"}
+		parentName := accesslists.NormalizedSQN{Name: "parent"}
+		baseName := accesslists.NormalizedSQN{Name: "base"}
+		testMaterializerSimpleChain(t, grandparentName, parentName, baseName)
+	})
+	t.Run("scoped", func(t *testing.T) {
+		grandparentName := accesslists.NormalizedSQN{
+			Scope: "/aa/bb/cc",
+			Name:  "grandparent",
+		}
+		parentName := accesslists.NormalizedSQN{
+			Scope: "/aa/bb",
+			Name:  "parent",
+		}
+		baseName := accesslists.NormalizedSQN{
+			Scope: "/aa",
+			Name:  "base",
+		}
+		testMaterializerSimpleChain(t, grandparentName, parentName, baseName)
+	})
+}
+
+func testMaterializerSimpleChain(t *testing.T, grandparentName, parentName, baseName accesslists.NormalizedSQN) {
+	synctest.Test(t, func(t *testing.T) {
+		runMaterializerTestcase(t, materializerTestcase{
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+					grandparentName: newAccessList(t, grandparentName, withMemberGrants([]accesslist.ScopedRoleGrant{{
+						Role:  "/::grandparentrole",
+						Scope: "/aa/bb/cc",
+					}})),
+					parentName: newAccessList(t, parentName, withMemberGrants([]accesslist.ScopedRoleGrant{{
+						Role:  "/::parentrole",
+						Scope: "/aa/bb",
+					}})),
+					baseName: newAccessList(t, baseName, withMemberGrants([]accesslist.ScopedRoleGrant{{
+						Role:  "/::baserole",
+						Scope: "/aa",
+					}})),
+				},
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					grandparentName: {
+						newAccessListMember(t, grandparentName, parentName),
+					},
+					parentName: {
+						newAccessListMember(t, parentName, baseName),
+					},
+					baseName: {
+						newUserMember(t, baseName, "tester"),
+					},
+				},
+			},
+			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+				expectedScopedRoleAssignment("tester", baseName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::baserole",
-				}})),
-			},
-			MembersByAccessList: map[string][]*accesslist.AccessListMember{
-				"grandparent": {
-					newAccessListMember(t, "grandparent", "parent", accesslist.MembershipKindList),
-				},
-				"parent": {
-					newAccessListMember(t, "parent", "base", accesslist.MembershipKindList),
-				},
-				"base": {
-					newAccessListMember(t, "base", "tester", accesslist.MembershipKindUser),
-				},
-			},
-		}),
-		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-			expectedScopedRoleAssignment("tester", "base", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
-				Role:  "/::baserole",
-				Scope: "/aa",
-			}.Build()}),
-			expectedScopedRoleAssignment("tester", "parent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
-				Role:  "/::parentrole",
-				Scope: "/aa/bb",
-			}.Build()}),
-			expectedScopedRoleAssignment("tester", "grandparent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
-				Role:  "/::grandparentrole",
-				Scope: "/aa/bb/cc",
-			}.Build()}),
-		},
-	})
-}
-
-func TestMaterializerScopedAccessListDirectMember(t *testing.T) {
-	t.Parallel()
-
-	listName := accesslists.NormalizedSQN{Scope: "/eng", Name: "granted"}
-	runMaterializerTestcase(t, materializerTestcase{
-		collection: accesslists.ScopedCollection{
-			AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
-				listName: newScopedAccessList(t, listName, withMemberGrants([]accesslist.ScopedRoleGrant{{
-					Scope: "/eng/team",
-					Role:  "/::engrole",
-				}})),
-			},
-			MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
-				listName: {
-					newScopedAccessListMember(t, listName, accesslists.NormalizedSQN{Name: "tester"}, accesslist.MembershipKindUser),
-				},
-			},
-		},
-		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-			expectedScopedScopedRoleAssignment("tester", listName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
-				Role:  "/::engrole",
-				Scope: "/eng/team",
-			}.Build()}),
-		},
-	})
-}
-
-func TestMaterializerScopedAccessListMember(t *testing.T) {
-	t.Parallel()
-
-	parentName := accesslists.NormalizedSQN{Scope: "/eng/team", Name: "parent"}
-	childName := accesslists.NormalizedSQN{Scope: "/eng", Name: "child"}
-	runMaterializerTestcase(t, materializerTestcase{
-		collection: accesslists.ScopedCollection{
-			AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
-				parentName: newScopedAccessList(t, parentName, withMemberGrants([]accesslist.ScopedRoleGrant{{
-					Scope: "/eng/team",
+					Scope: "/aa",
+				}.Build()}),
+				expectedScopedRoleAssignment("tester", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::parentrole",
-				}})),
-				childName: newScopedAccessList(t, childName),
+					Scope: "/aa/bb",
+				}.Build()}),
+				expectedScopedRoleAssignment("tester", grandparentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+					Role:  "/::grandparentrole",
+					Scope: "/aa/bb/cc",
+				}.Build()}),
 			},
-			MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
-				parentName: {
-					newScopedAccessListMember(t, parentName, childName, accesslist.MembershipKindScopedList),
+			steps: []materializerTestcaseStep{
+				// Delete each membership in the chain one by one, the materialized assignments should be deleted.
+				{
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
+						require.NoError(t, state.aclService.DeleteAccessListMemberV2(t.Context(), accesslistv1.DeleteAccessListMemberRequest_builder{
+							AccessList:      grandparentName.Name,
+							AccessListScope: grandparentName.Scope,
+							MemberName:      parentName.Name,
+							MemberScope:     parentName.Scope,
+						}.Build()))
+					},
+					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+						expectedScopedRoleAssignment("tester", baseName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+							Role:  "/::baserole",
+							Scope: "/aa",
+						}.Build()}),
+						expectedScopedRoleAssignment("tester", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+							Role:  "/::parentrole",
+							Scope: "/aa/bb",
+						}.Build()}),
+					},
 				},
-				childName: {
-					newScopedAccessListMember(t, childName, accesslists.NormalizedSQN{Name: "tester"}, accesslist.MembershipKindUser),
+				{
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
+						require.NoError(t, state.aclService.DeleteAccessListMemberV2(t.Context(), accesslistv1.DeleteAccessListMemberRequest_builder{
+							AccessList:      parentName.Name,
+							AccessListScope: parentName.Scope,
+							MemberName:      baseName.Name,
+							MemberScope:     baseName.Scope,
+						}.Build()))
+					},
+					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+						expectedScopedRoleAssignment("tester", baseName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+							Role:  "/::baserole",
+							Scope: "/aa",
+						}.Build()}),
+					},
+				},
+				{
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
+						require.NoError(t, state.aclService.DeleteAccessListMemberV2(t.Context(), accesslistv1.DeleteAccessListMemberRequest_builder{
+							AccessList:      baseName.Name,
+							AccessListScope: baseName.Scope,
+							MemberName:      "tester",
+						}.Build()))
+					},
+					expectedAssignments: nil,
 				},
 			},
-		},
-		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-			expectedScopedScopedRoleAssignment("tester", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
-				Role:  "/::parentrole",
-				Scope: "/eng/team",
-			}.Build()}),
-		},
+		})
 	})
 }
 
 func TestMaterializerDoubleListMembership(t *testing.T) {
 	t.Parallel()
+	parentName := accesslists.NormalizedSQN{
+		Scope: "/parentscope",
+		Name:  "parent",
+	}
+	memberListAName := accesslists.NormalizedSQN{
+		Scope: "/parentscope",
+		Name:  "member-list-a",
+	}
+	memberListBName := accesslists.NormalizedSQN{Name: "memberListB"}
 	runMaterializerTestcase(t, materializerTestcase{
-		collection: scopedCollection(accesslists.Collection{
-			AccessListsByName: map[string]*accesslist.AccessList{
-				"parent": newAccessList(t, "parent", withMemberGrants([]accesslist.ScopedRoleGrant{{
+		collection: accesslists.ScopedCollection{
+			AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+				parentName: newAccessList(t, parentName, withMemberGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/parentscope",
 					Role:  "/::parentrole",
 				}})),
-				"memberListA": newAccessList(t, "memberListA"),
-				"memberListB": newAccessList(t, "memberListB"),
+				memberListAName: newAccessList(t, memberListAName),
+				memberListBName: newAccessList(t, memberListBName),
 			},
-			MembersByAccessList: map[string][]*accesslist.AccessListMember{
-				"parent": {
-					newAccessListMember(t, "parent", "memberListA", accesslist.MembershipKindList),
-					newAccessListMember(t, "parent", "memberListB", accesslist.MembershipKindList),
-					newAccessListMember(t, "parent", "testerD", accesslist.MembershipKindUser),
+			MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+				parentName: {
+					newAccessListMember(t, parentName, memberListAName),
+					newAccessListMember(t, parentName, memberListBName),
+					newUserMember(t, parentName, "testerD"),
 				},
-				"memberListA": {
-					newAccessListMember(t, "memberListA", "testerA", accesslist.MembershipKindUser),
-					newAccessListMember(t, "memberListA", "testerC", accesslist.MembershipKindUser),
+				memberListAName: {
+					newUserMember(t, memberListAName, "testerA"),
+					newUserMember(t, memberListAName, "testerC"),
 				},
-				"memberListB": {
-					newAccessListMember(t, "memberListB", "testerB", accesslist.MembershipKindUser),
-					newAccessListMember(t, "memberListB", "testerC", accesslist.MembershipKindUser),
+				memberListBName: {
+					newUserMember(t, memberListBName, "testerB"),
+					newUserMember(t, memberListBName, "testerC"),
 				},
 			},
-		}),
+		},
 		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 			// All users should be direct or nested members of the parent role,
 			// expect exactly one materialized assignment each.
-			expectedScopedRoleAssignment("testerA", "parent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("testerA", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::parentrole",
 				Scope: "/parentscope",
 			}.Build()}),
-			expectedScopedRoleAssignment("testerB", "parent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("testerB", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::parentrole",
 				Scope: "/parentscope",
 			}.Build()}),
-			expectedScopedRoleAssignment("testerC", "parent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("testerC", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::parentrole",
 				Scope: "/parentscope",
 			}.Build()}),
-			expectedScopedRoleAssignment("testerD", "parent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("testerD", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::parentrole",
 				Scope: "/parentscope",
 			}.Build()}),
@@ -340,38 +353,41 @@ func TestMaterializerDoubleListMembership(t *testing.T) {
 
 func TestMaterializerDoubleListParents(t *testing.T) {
 	t.Parallel()
+	parentAName := accesslists.NormalizedSQN{Scope: "/aa", Name: "parent-a"}
+	parentBName := accesslists.NormalizedSQN{Scope: "/bb", Name: "parent-b"}
+	childName := accesslists.NormalizedSQN{Scope: "/", Name: "child"}
 	runMaterializerTestcase(t, materializerTestcase{
-		collection: scopedCollection(accesslists.Collection{
-			AccessListsByName: map[string]*accesslist.AccessList{
-				"parentA": newAccessList(t, "parentA", withMemberGrants([]accesslist.ScopedRoleGrant{{
+		collection: accesslists.ScopedCollection{
+			AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+				parentAName: newAccessList(t, parentAName, withMemberGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/aa",
 					Role:  "/::rolea",
 				}})),
-				"parentB": newAccessList(t, "parentB", withMemberGrants([]accesslist.ScopedRoleGrant{{
+				parentBName: newAccessList(t, parentBName, withMemberGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/bb",
 					Role:  "/::roleb",
 				}})),
-				"child": newAccessList(t, "child"),
+				childName: newAccessList(t, childName),
 			},
-			MembersByAccessList: map[string][]*accesslist.AccessListMember{
-				"parentA": {
-					newAccessListMember(t, "parentA", "child", accesslist.MembershipKindList),
+			MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+				parentAName: {
+					newAccessListMember(t, parentAName, childName),
 				},
-				"parentB": {
-					newAccessListMember(t, "parentB", "child", accesslist.MembershipKindList),
+				parentBName: {
+					newAccessListMember(t, parentBName, childName),
 				},
-				"child": {
-					newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser),
+				childName: {
+					newUserMember(t, childName, "tester"),
 				},
 			},
-		}),
+		},
 		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 			// User should be a nested member of both parents and get an assignment for each.
-			expectedScopedRoleAssignment("tester", "parentA", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("tester", parentAName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::rolea",
 				Scope: "/aa",
 			}.Build()}),
-			expectedScopedRoleAssignment("tester", "parentB", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("tester", parentBName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::roleb",
 				Scope: "/bb",
 			}.Build()}),
@@ -381,10 +397,11 @@ func TestMaterializerDoubleListParents(t *testing.T) {
 
 func TestMaterializerDirectOwner(t *testing.T) {
 	t.Parallel()
+	listName := accesslists.NormalizedSQN{Scope: "/aa", Name: "testlist"}
 	runMaterializerTestcase(t, materializerTestcase{
-		collection: scopedCollection(accesslists.Collection{
-			AccessListsByName: map[string]*accesslist.AccessList{
-				"testlist": newAccessList(t, "testlist", withOwnerGrants([]accesslist.ScopedRoleGrant{{
+		collection: accesslists.ScopedCollection{
+			AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+				listName: newAccessList(t, listName, withOwnerGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/aa",
 					Role:  "/::testrole",
 				}}), withOwners([]accesslist.Owner{{
@@ -392,14 +409,14 @@ func TestMaterializerDirectOwner(t *testing.T) {
 					MembershipKind: accesslist.MembershipKindUser,
 				}})),
 			},
-			MembersByAccessList: map[string][]*accesslist.AccessListMember{
-				"testlist": {},
+			MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+				listName: {},
 			},
-		}),
+		},
 		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 			// The user is simply a direct owner of the access list and an
 			// assignment is expected.
-			expectedScopedRoleAssignment("tester", "testlist", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("tester", listName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::testrole",
 				Scope: "/aa",
 			}.Build()}),
@@ -409,11 +426,13 @@ func TestMaterializerDirectOwner(t *testing.T) {
 
 func TestMaterializerUserMemberPutPreservesExistingOwnerGrant(t *testing.T) {
 	t.Parallel()
+	grantedName := accesslists.NormalizedSQN{Scope: "/", Name: "granted"}
+	childName := accesslists.NormalizedSQN{Scope: "/", Name: "child"}
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: scopedCollection(accesslists.Collection{
-				AccessListsByName: map[string]*accesslist.AccessList{
-					"granted": newAccessList(t, "granted",
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+					grantedName: newAccessList(t, grantedName,
 						withMemberGrants([]accesslist.ScopedRoleGrant{{
 							Scope: "/member",
 							Role:  "/::memberrole",
@@ -427,31 +446,30 @@ func TestMaterializerUserMemberPutPreservesExistingOwnerGrant(t *testing.T) {
 							MembershipKind: accesslist.MembershipKindUser,
 						}}),
 					),
-					"child": newAccessList(t, "child"),
+					childName: newAccessList(t, childName),
 				},
-				MembersByAccessList: map[string][]*accesslist.AccessListMember{
-					"granted": {
-						newAccessListMember(t, "granted", "child", accesslist.MembershipKindList),
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					grantedName: {
+						newAccessListMember(t, grantedName, childName),
 					},
-					"child": {},
+					childName: {},
 				},
-			}),
+			},
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-				expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("tester", grantedName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::ownerrole",
 					Scope: "/owner",
 				}.Build()}),
 			},
 			steps: []materializerTestcaseStep{{
 				mutateState: func(t *testing.T, state *materializerTestcaseState) {
-					_, err := state.aclService.UpsertAccessListMember(t.Context(),
-						newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser))
+					_, err := state.aclService.UpsertAccessListMember(t.Context(), newUserMember(t, childName, "tester"))
 					require.NoError(t, err)
 				},
 				expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 					// tester is now both a direct owner of granted and a nested member via child,
 					// so the materialized assignment must include both grants.
-					expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+					expectedScopedRoleAssignment("tester", grantedName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 						Role:  "/::memberrole",
 						Scope: "/member",
 					}.Build(), scopedaccessv1.Assignment_builder{
@@ -466,11 +484,14 @@ func TestMaterializerUserMemberPutPreservesExistingOwnerGrant(t *testing.T) {
 
 func TestMaterializerListMemberPutPreservesExistingOwnerGrant(t *testing.T) {
 	t.Parallel()
+	grantedName := accesslists.NormalizedSQN{Scope: "/", Name: "granted"}
+	parentName := accesslists.NormalizedSQN{Scope: "/", Name: "parent"}
+	childName := accesslists.NormalizedSQN{Scope: "/", Name: "child"}
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: scopedCollection(accesslists.Collection{
-				AccessListsByName: map[string]*accesslist.AccessList{
-					"granted": newAccessList(t, "granted",
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+					grantedName: newAccessList(t, grantedName,
 						withMemberGrants([]accesslist.ScopedRoleGrant{{
 							Scope: "/member",
 							Role:  "/::memberrole",
@@ -484,21 +505,21 @@ func TestMaterializerListMemberPutPreservesExistingOwnerGrant(t *testing.T) {
 							MembershipKind: accesslist.MembershipKindUser,
 						}}),
 					),
-					"parent": newAccessList(t, "parent"),
-					"child":  newAccessList(t, "child"),
+					parentName: newAccessList(t, parentName),
+					childName:  newAccessList(t, childName),
 				},
-				MembersByAccessList: map[string][]*accesslist.AccessListMember{
-					"granted": {
-						newAccessListMember(t, "granted", "parent", accesslist.MembershipKindList),
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					grantedName: {
+						newAccessListMember(t, grantedName, parentName),
 					},
-					"parent": {},
-					"child": {
-						newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser),
+					parentName: {},
+					childName: {
+						newUserMember(t, childName, "tester"),
 					},
 				},
-			}),
+			},
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-				expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("tester", grantedName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::ownerrole",
 					Scope: "/owner",
 				}.Build()}),
@@ -506,13 +527,13 @@ func TestMaterializerListMemberPutPreservesExistingOwnerGrant(t *testing.T) {
 			steps: []materializerTestcaseStep{{
 				mutateState: func(t *testing.T, state *materializerTestcaseState) {
 					_, err := state.aclService.UpsertAccessListMember(t.Context(),
-						newAccessListMember(t, "parent", "child", accesslist.MembershipKindList))
+						newAccessListMember(t, parentName, childName))
 					require.NoError(t, err)
 				},
 				expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 					// tester is now both a direct owner of granted and a nested member via
 					// parent->child, so the materialized assignment must include both grants.
-					expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+					expectedScopedRoleAssignment("tester", grantedName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 						Role:  "/::memberrole",
 						Scope: "/member",
 					}.Build(), scopedaccessv1.Assignment_builder{
@@ -527,11 +548,13 @@ func TestMaterializerListMemberPutPreservesExistingOwnerGrant(t *testing.T) {
 
 func TestMaterializerAccessListPutPreservesExistingOwnerGrant(t *testing.T) {
 	t.Parallel()
+	grantedName := accesslists.NormalizedSQN{Scope: "/", Name: "granted"}
+	childName := accesslists.NormalizedSQN{Name: "child"}
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: scopedCollection(accesslists.Collection{
-				AccessListsByName: map[string]*accesslist.AccessList{
-					"granted": newAccessList(t, "granted",
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+					grantedName: newAccessList(t, grantedName,
 						withMemberGrants([]accesslist.ScopedRoleGrant{{
 							Scope: "/member",
 							Role:  "/::memberrole",
@@ -547,20 +570,20 @@ func TestMaterializerAccessListPutPreservesExistingOwnerGrant(t *testing.T) {
 					),
 					// child list starts with membership requirements, so any
 					// memberships are initially invalid.
-					"child": newAccessList(t, "child", withMembershipRequires()),
+					childName: newAccessList(t, childName, withMembershipRequires()),
 				},
-				MembersByAccessList: map[string][]*accesslist.AccessListMember{
-					"granted": {
-						newAccessListMember(t, "granted", "child", accesslist.MembershipKindList),
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					grantedName: {
+						newAccessListMember(t, grantedName, childName),
 					},
-					"child": {
-						newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser),
+					childName: {
+						newUserMember(t, childName, "tester"),
 					},
 				},
-			}),
+			},
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 				// tests is initially ownly an owner of the granted list.
-				expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("tester", grantedName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::ownerrole",
 					Scope: "/owner",
 				}.Build()}),
@@ -569,13 +592,13 @@ func TestMaterializerAccessListPutPreservesExistingOwnerGrant(t *testing.T) {
 				mutateState: func(t *testing.T, state *materializerTestcaseState) {
 					// remove the membership requirements so that tester
 					// becomes a legitimate member of child and granted lists.
-					_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, "child"))
+					_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, childName))
 					require.NoError(t, err)
 				},
 				expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 					// as tests is now a member and owner of granted, make sure
 					// the materialiazed assignment includes both grants.
-					expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+					expectedScopedRoleAssignment("tester", grantedName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 						Role:  "/::memberrole",
 						Scope: "/member",
 					}.Build(), scopedaccessv1.Assignment_builder{
@@ -590,34 +613,37 @@ func TestMaterializerAccessListPutPreservesExistingOwnerGrant(t *testing.T) {
 
 func TestMaterializerOwnerRequirements(t *testing.T) {
 	t.Parallel()
+	grantedName := accesslists.NormalizedSQN{Scope: "/aa", Name: "granted"}
+	ownersName := accesslists.NormalizedSQN{Name: "owners"}
+	nestedName := accesslists.NormalizedSQN{Name: "nested"}
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: scopedCollection(accesslists.Collection{
-				AccessListsByName: map[string]*accesslist.AccessList{
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
 					// Ownership requirements in the owner list should not block
 					// _members_ of the owner list from receiving owner grants
 					// present in the granted list.
-					"granted": newAccessList(t, "granted", withOwnerGrants([]accesslist.ScopedRoleGrant{{
+					grantedName: newAccessList(t, grantedName, withOwnerGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/aa",
 						Role:  "/::ownerrole",
 					}}), withOwners([]accesslist.Owner{{
 						Name:           "owners",
 						MembershipKind: accesslist.MembershipKindList,
 					}})),
-					"owners": newAccessList(t, "owners", withOwnershipRequires()),
+					ownersName: newAccessList(t, ownersName, withOwnershipRequires()),
 				},
-				MembersByAccessList: map[string][]*accesslist.AccessListMember{
-					"granted": {},
-					"owners": {
-						newAccessListMember(t, "owners", "tester", accesslist.MembershipKindUser),
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					grantedName: {},
+					ownersName: {
+						newUserMember(t, ownersName, "tester"),
 					},
 				},
-			}),
+			},
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 				// tester is a valid member of list "owners". All valid members of
 				// list "owners" are valid _owners_ of list "granted", so the
 				// assignment should be materialized.
-				expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("tester", grantedName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::ownerrole",
 					Scope: "/aa",
 				}.Build()}),
@@ -625,24 +651,24 @@ func TestMaterializerOwnerRequirements(t *testing.T) {
 			steps: []materializerTestcaseStep{{
 				mutateState: func(t *testing.T, state *materializerTestcaseState) {
 					// Add a nested list as a member of the owners list.
-					_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, "nested"))
+					_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, nestedName))
 					require.NoError(t, err)
 					_, err = state.aclService.UpsertAccessListMember(t.Context(),
-						newAccessListMember(t, "owners", "nested", accesslist.MembershipKindList))
+						newAccessListMember(t, ownersName, nestedName))
 					require.NoError(t, err)
 					// Add a user as a member of the nested list.
 					_, err = state.aclService.UpsertAccessListMember(t.Context(),
-						newAccessListMember(t, "nested", "nested_tester", accesslist.MembershipKindUser))
+						newUserMember(t, nestedName, "nested_tester"))
 					require.NoError(t, err)
 				},
 				expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 					// The nested user is also a valid member of the owners list so
 					// should also have an assignment materialized.
-					expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+					expectedScopedRoleAssignment("tester", grantedName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 						Role:  "/::ownerrole",
 						Scope: "/aa",
 					}.Build()}),
-					expectedScopedRoleAssignment("nested_tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+					expectedScopedRoleAssignment("nested_tester", grantedName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 						Role:  "/::ownerrole",
 						Scope: "/aa",
 					}.Build()}),
@@ -654,24 +680,27 @@ func TestMaterializerOwnerRequirements(t *testing.T) {
 
 func TestMaterializerOwnerChain(t *testing.T) {
 	t.Parallel()
+	grandParentName := accesslists.NormalizedSQN{Scope: "/aa/bb/cc", Name: "grandparent"}
+	parentName := accesslists.NormalizedSQN{Scope: "/aa/bb", Name: "parent"}
+	baseName := accesslists.NormalizedSQN{Scope: "/aa", Name: "base"}
 	runMaterializerTestcase(t, materializerTestcase{
-		collection: scopedCollection(accesslists.Collection{
-			AccessListsByName: map[string]*accesslist.AccessList{
-				"grandparent": newAccessList(t, "grandparent", withOwnerGrants([]accesslist.ScopedRoleGrant{{
+		collection: accesslists.ScopedCollection{
+			AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+				grandParentName: newAccessList(t, grandParentName, withOwnerGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/aa/bb/cc",
 					Role:  "/::grandparentownerrole",
 				}}), withOwners([]accesslist.Owner{{
-					Name:           "parent",
-					MembershipKind: accesslist.MembershipKindList,
+					Name:           parentName.String(),
+					MembershipKind: accesslist.MembershipKindScopedList,
 				}})),
-				"parent": newAccessList(t, "parent", withOwnerGrants([]accesslist.ScopedRoleGrant{{
+				parentName: newAccessList(t, parentName, withOwnerGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/aa/bb",
 					Role:  "/::parentownerrole",
 				}}), withOwners([]accesslist.Owner{{
-					Name:           "base",
-					MembershipKind: accesslist.MembershipKindList,
+					Name:           baseName.String(),
+					MembershipKind: accesslist.MembershipKindScopedList,
 				}})),
-				"base": newAccessList(t, "base", withOwnerGrants([]accesslist.ScopedRoleGrant{{
+				baseName: newAccessList(t, baseName, withOwnerGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/aa",
 					Role:  "/::baseownerrole",
 				}}), withOwners([]accesslist.Owner{{
@@ -679,38 +708,38 @@ func TestMaterializerOwnerChain(t *testing.T) {
 					MembershipKind: accesslist.MembershipKindUser,
 				}})),
 			},
-			MembersByAccessList: map[string][]*accesslist.AccessListMember{
-				"grandparent": {
-					newAccessListMember(t, "grandparent", "parent", accesslist.MembershipKindList),
-					newAccessListMember(t, "grandparent", "grandparentmember", accesslist.MembershipKindUser),
+			MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+				grandParentName: {
+					newAccessListMember(t, grandParentName, parentName),
+					newUserMember(t, grandParentName, "grandparentmember"),
 				},
-				"parent": {
-					newAccessListMember(t, "parent", "base", accesslist.MembershipKindList),
-					newAccessListMember(t, "parent", "parentmember", accesslist.MembershipKindUser),
+				parentName: {
+					newAccessListMember(t, parentName, baseName),
+					newUserMember(t, parentName, "parentmember"),
 				},
-				"base": {
-					newAccessListMember(t, "base", "basemember", accesslist.MembershipKindUser),
+				baseName: {
+					newUserMember(t, baseName, "basemember"),
 				},
 			},
-		}),
+		},
 		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 			// baseowner is a direct owner of base list. Ownership is not inherited.
-			expectedScopedRoleAssignment("baseowner", "base", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("baseowner", baseName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::baseownerrole",
 				Scope: "/aa",
 			}.Build()}),
 			// basemember is a member of base list, base list is an owner of parent list.
-			expectedScopedRoleAssignment("basemember", "parent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("basemember", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::parentownerrole",
 				Scope: "/aa/bb",
 			}.Build()}),
 			// basemember is a nested member of parent list, parent list is an owner of grandparent list.
-			expectedScopedRoleAssignment("basemember", "grandparent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("basemember", grandParentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::grandparentownerrole",
 				Scope: "/aa/bb/cc",
 			}.Build()}),
 			// parentmember is a member of parent list, parent list is an owner of grandparent list.
-			expectedScopedRoleAssignment("parentmember", "grandparent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("parentmember", grandParentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::grandparentownerrole",
 				Scope: "/aa/bb/cc",
 			}.Build()}),
@@ -720,27 +749,29 @@ func TestMaterializerOwnerChain(t *testing.T) {
 
 func TestMaterializerAccessListPutWithMembershipRequirements(t *testing.T) {
 	t.Parallel()
+	topName := accesslists.NormalizedSQN{Scope: "/aa", Name: "top"}
+	middleName := accesslists.NormalizedSQN{Name: "middle"}
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: scopedCollection(accesslists.Collection{
-				AccessListsByName: map[string]*accesslist.AccessList{
-					"top": newAccessList(t, "top", withMemberGrants([]accesslist.ScopedRoleGrant{{
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+					topName: newAccessList(t, topName, withMemberGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/aa",
 						Role:  "/::toprole",
 					}})),
-					"middle": newAccessList(t, "middle"),
+					middleName: newAccessList(t, middleName),
 				},
-				MembersByAccessList: map[string][]*accesslist.AccessListMember{
-					"top": {
-						newAccessListMember(t, "top", "middle", accesslist.MembershipKindList),
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					topName: {
+						newAccessListMember(t, topName, middleName),
 					},
-					"middle": {
-						newAccessListMember(t, "middle", "tester", accesslist.MembershipKindUser),
+					middleName: {
+						newUserMember(t, middleName, "tester"),
 					},
 				},
-			}),
+			},
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-				expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("tester", topName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::toprole",
 					Scope: "/aa",
 				}.Build()}),
@@ -750,7 +781,7 @@ func TestMaterializerAccessListPutWithMembershipRequirements(t *testing.T) {
 				// assignment for the top list should be deleted as the
 				// membership path is broken.
 				mutateState: func(t *testing.T, state *materializerTestcaseState) {
-					_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, "middle", withMembershipRequires()))
+					_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, middleName, withMembershipRequires()))
 					require.NoError(t, err)
 				},
 				expectedAssignments: nil,
@@ -761,30 +792,32 @@ func TestMaterializerAccessListPutWithMembershipRequirements(t *testing.T) {
 
 func TestMaterializerAccessListMemberKindUpdateInvalidatesPriorKind(t *testing.T) {
 	t.Parallel()
+	parentName := accesslists.NormalizedSQN{Scope: "/aa", Name: "parent"}
+	childName := accesslists.NormalizedSQN{Name: "child"}
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: scopedCollection(accesslists.Collection{
-				AccessListsByName: map[string]*accesslist.AccessList{
-					"parent": newAccessList(t, "parent", withMemberGrants([]accesslist.ScopedRoleGrant{{
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+					parentName: newAccessList(t, parentName, withMemberGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/aa",
 						Role:  "/::parentrole",
 					}})),
-					"child": newAccessList(t, "child"),
+					childName: newAccessList(t, childName),
 				},
-				MembersByAccessList: map[string][]*accesslist.AccessListMember{
-					"parent": {
-						newAccessListMember(t, "parent", "child", accesslist.MembershipKindList),
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					parentName: {
+						newAccessListMember(t, parentName, childName),
 					},
-					"child": {
-						newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser),
+					childName: {
+						newUserMember(t, childName, "tester"),
 					},
 				},
-			}),
+			},
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 				// Initially tester is a member of list child which is a member
 				// of list parent, resulting in a materialized assignment for
 				// tester in parent.
-				expectedScopedRoleAssignment("tester", "parent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("tester", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::parentrole",
 					Scope: "/aa",
 				}.Build()}),
@@ -793,7 +826,11 @@ func TestMaterializerAccessListMemberKindUpdateInvalidatesPriorKind(t *testing.T
 				{
 					// Update the member resource in place to change the membership kind from list to user.
 					mutateState: func(t *testing.T, state *materializerTestcaseState) {
-						member, err := state.aclService.GetAccessListMember(t.Context(), "parent", "child")
+						member, err := state.aclService.GetAccessListMemberV2(t.Context(), accesslistv1.GetAccessListMemberRequest_builder{
+							AccessListScope: parentName.Scope,
+							AccessList:      parentName.Name,
+							MemberName:      childName.Name,
+						}.Build())
 						require.NoError(t, err)
 
 						member.Spec.MembershipKind = accesslist.MembershipKindUser
@@ -806,7 +843,7 @@ func TestMaterializerAccessListMemberKindUpdateInvalidatesPriorKind(t *testing.T
 					// member because the path through the list named child is
 					// now broken.
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-						expectedScopedRoleAssignment("child", "parent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("child", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::parentrole",
 							Scope: "/aa",
 						}.Build()}),
@@ -817,7 +854,11 @@ func TestMaterializerAccessListMemberKindUpdateInvalidatesPriorKind(t *testing.T
 					// back to a list, and the original assignment should be
 					// restored.
 					mutateState: func(t *testing.T, state *materializerTestcaseState) {
-						member, err := state.aclService.GetAccessListMember(t.Context(), "parent", "child")
+						member, err := state.aclService.GetAccessListMemberV2(t.Context(), accesslistv1.GetAccessListMemberRequest_builder{
+							AccessListScope: parentName.Scope,
+							AccessList:      parentName.Name,
+							MemberName:      childName.Name,
+						}.Build())
 						require.NoError(t, err)
 
 						member.Spec.MembershipKind = accesslist.MembershipKindList
@@ -826,7 +867,7 @@ func TestMaterializerAccessListMemberKindUpdateInvalidatesPriorKind(t *testing.T
 						require.Equal(t, accesslist.MembershipKindList, updatedMember.Spec.MembershipKind)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-						expectedScopedRoleAssignment("tester", "parent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("tester", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::parentrole",
 							Scope: "/aa",
 						}.Build()}),
@@ -855,37 +896,41 @@ func TestMaterializerDiamond(t *testing.T) {
 	//        v
 	//      tester
 	t.Parallel()
+	topName := accesslists.NormalizedSQN{Scope: "/aa", Name: "top"}
+	leftName := accesslists.NormalizedSQN{Name: "left"}
+	rightName := accesslists.NormalizedSQN{Scope: "/aa", Name: "right"}
+	bottomName := accesslists.NormalizedSQN{Name: "bottom"}
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: scopedCollection(accesslists.Collection{
-				AccessListsByName: map[string]*accesslist.AccessList{
-					"top": newAccessList(t, "top", withMemberGrants([]accesslist.ScopedRoleGrant{{
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+					topName: newAccessList(t, topName, withMemberGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/aa",
 						Role:  "/::toprole",
 					}})),
-					"left":   newAccessList(t, "left"),
-					"right":  newAccessList(t, "right"),
-					"bottom": newAccessList(t, "bottom"),
+					leftName:   newAccessList(t, leftName),
+					rightName:  newAccessList(t, rightName),
+					bottomName: newAccessList(t, bottomName),
 				},
-				MembersByAccessList: map[string][]*accesslist.AccessListMember{
-					"top": {
-						newAccessListMember(t, "top", "left", accesslist.MembershipKindList),
-						newAccessListMember(t, "top", "right", accesslist.MembershipKindList),
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					topName: {
+						newAccessListMember(t, topName, leftName),
+						newAccessListMember(t, topName, rightName),
 					},
-					"left": {
-						newAccessListMember(t, "left", "bottom", accesslist.MembershipKindList),
+					leftName: {
+						newAccessListMember(t, leftName, bottomName),
 					},
-					"right": {
-						newAccessListMember(t, "right", "bottom", accesslist.MembershipKindList),
+					rightName: {
+						newAccessListMember(t, rightName, bottomName),
 					},
-					"bottom": {
-						newAccessListMember(t, "bottom", "tester", accesslist.MembershipKindUser),
+					bottomName: {
+						newUserMember(t, bottomName, "tester"),
 					},
 				},
-			}),
+			},
 			// Initially the user is a valid member of the top list by 2 paths.
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-				expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("tester", topName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::toprole",
 					Scope: "/aa",
 				}.Build()}),
@@ -896,11 +941,11 @@ func TestMaterializerDiamond(t *testing.T) {
 					// should stay via the right list.
 					mutateState: func(t *testing.T, state *materializerTestcaseState) {
 						// Upsert the access list to remove the membership requires.
-						_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, "left", withMembershipRequires()))
+						_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, leftName, withMembershipRequires()))
 						require.NoError(t, err)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-						expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("tester", topName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::toprole",
 							Scope: "/aa",
 						}.Build()}),
@@ -910,7 +955,12 @@ func TestMaterializerDiamond(t *testing.T) {
 					// Delete the membership path on the right, the assignment
 					// should be deleted as there is no more path.
 					mutateState: func(t *testing.T, state *materializerTestcaseState) {
-						err := state.aclService.DeleteAccessListMember(t.Context(), "top", "right")
+						err := state.aclService.DeleteAccessListMemberV2(t.Context(), accesslistv1.DeleteAccessListMemberRequest_builder{
+							AccessListScope: topName.Scope,
+							AccessList:      topName.Name,
+							MemberScope:     rightName.Scope,
+							MemberName:      rightName.Name,
+						}.Build())
 						require.NoError(t, err)
 					},
 					expectedAssignments: nil,
@@ -920,11 +970,11 @@ func TestMaterializerDiamond(t *testing.T) {
 					// should come back.
 					mutateState: func(t *testing.T, state *materializerTestcaseState) {
 						// Upsert the access list to remove the membership requires.
-						_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, "left"))
+						_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, leftName))
 						require.NoError(t, err)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-						expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("tester", topName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::toprole",
 							Scope: "/aa",
 						}.Build()}),
@@ -937,37 +987,38 @@ func TestMaterializerDiamond(t *testing.T) {
 
 func TestMaterializerCascadingMemberExpiries(t *testing.T) {
 	t.Parallel()
+	listName := accesslists.NormalizedSQN{Scope: "/test", Name: "testlist"}
 	synctest.Test(t, func(t *testing.T) {
 
 		testStart := time.Now()
 
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: scopedCollection(accesslists.Collection{
-				AccessListsByName: map[string]*accesslist.AccessList{
-					"testlist": newAccessList(t, "testlist", withMemberGrants([]accesslist.ScopedRoleGrant{{
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+					listName: newAccessList(t, listName, withMemberGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/test",
 						Role:  "/::testrole",
 					}})),
 				},
-				MembersByAccessList: map[string][]*accesslist.AccessListMember{
-					"testlist": {
-						newAccessListMember(t, "testlist", "alice", accesslist.MembershipKindUser, withExpires(testStart.Add(time.Minute))),
-						newAccessListMember(t, "testlist", "bob", accesslist.MembershipKindUser, withExpires(testStart.Add(2*time.Minute))),
-						newAccessListMember(t, "testlist", "charlie", accesslist.MembershipKindUser, withExpires(testStart.Add(3*time.Minute))),
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					listName: {
+						newUserMember(t, listName, "alice", withExpires(testStart.Add(time.Minute))),
+						newUserMember(t, listName, "bob", withExpires(testStart.Add(2*time.Minute))),
+						newUserMember(t, listName, "charlie", withExpires(testStart.Add(3*time.Minute))),
 					},
 				},
-			}),
+			},
 			// Initially all users are valid members of testlist.
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-				expectedScopedRoleAssignment("alice", "testlist", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("alice", listName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::testrole",
 					Scope: "/test",
 				}.Build()}),
-				expectedScopedRoleAssignment("bob", "testlist", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("bob", listName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::testrole",
 					Scope: "/test",
 				}.Build()}),
-				expectedScopedRoleAssignment("charlie", "testlist", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("charlie", listName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::testrole",
 					Scope: "/test",
 				}.Build()}),
@@ -980,11 +1031,11 @@ func TestMaterializerCascadingMemberExpiries(t *testing.T) {
 						time.Sleep(time.Minute)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-						expectedScopedRoleAssignment("bob", "testlist", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("bob", listName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::testrole",
 							Scope: "/test",
 						}.Build()}),
-						expectedScopedRoleAssignment("charlie", "testlist", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("charlie", listName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::testrole",
 							Scope: "/test",
 						}.Build()}),
@@ -997,7 +1048,7 @@ func TestMaterializerCascadingMemberExpiries(t *testing.T) {
 						time.Sleep(time.Minute)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-						expectedScopedRoleAssignment("charlie", "testlist", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("charlie", listName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::testrole",
 							Scope: "/test",
 						}.Build()}),
@@ -1018,24 +1069,26 @@ func TestMaterializerCascadingMemberExpiries(t *testing.T) {
 
 func TestMaterializerRepairFailedReads(t *testing.T) {
 	t.Parallel()
+	parentName := accesslists.NormalizedSQN{Scope: "/test", Name: "parent"}
+	childName := accesslists.NormalizedSQN{Scope: "/test", Name: "child"}
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: scopedCollection(accesslists.Collection{
-				AccessListsByName: map[string]*accesslist.AccessList{
-					"parent": newAccessList(t, "parent", withMemberGrants([]accesslist.ScopedRoleGrant{{
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+					parentName: newAccessList(t, parentName, withMemberGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/test/parent",
 						Role:  "/::testrole",
 					}})),
-					"child": newAccessList(t, "child", withMemberGrants([]accesslist.ScopedRoleGrant{{
+					childName: newAccessList(t, childName, withMemberGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/test/child",
 						Role:  "/::testrole",
 					}})),
 				},
-				MembersByAccessList: map[string][]*accesslist.AccessListMember{
-					"parent": {},
-					"child":  {},
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					parentName: {},
+					childName:  {},
 				},
-			}),
+			},
 			// Initially there are no members and therefore no assignments.
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{},
 			steps: []materializerTestcaseStep{
@@ -1045,7 +1098,7 @@ func TestMaterializerRepairFailedReads(t *testing.T) {
 						// with the access list reader broken, the assignment
 						// cannot be validated and should not be materialized.
 						state.breakableACLReader.Break()
-						state.aclService.UpsertAccessListMember(t.Context(), newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser))
+						state.aclService.UpsertAccessListMember(t.Context(), newUserMember(t, childName, "tester"))
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{},
 				},
@@ -1057,7 +1110,7 @@ func TestMaterializerRepairFailedReads(t *testing.T) {
 						time.Sleep(access.MissedMembersRepairBackoff)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-						expectedScopedRoleAssignment("tester", "child", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("tester", childName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::testrole",
 							Scope: "/test/child",
 						}.Build()}),
@@ -1068,7 +1121,7 @@ func TestMaterializerRepairFailedReads(t *testing.T) {
 						// Break the access list reader again and add the child
 						// list as a member of parent list.
 						state.breakableACLReader.Break()
-						state.aclService.UpsertAccessListMember(t.Context(), newAccessListMember(t, "parent", "child", accesslist.MembershipKindList))
+						state.aclService.UpsertAccessListMember(t.Context(), newAccessListMember(t, parentName, childName))
 					},
 					// The access list service will update the child list with
 					// a Status.MemberOf reference. While handling the access
@@ -1087,11 +1140,11 @@ func TestMaterializerRepairFailedReads(t *testing.T) {
 						time.Sleep(access.MissedMembersRepairBackoff)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-						expectedScopedRoleAssignment("tester", "child", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("tester", childName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::testrole",
 							Scope: "/test/child",
 						}.Build()}),
-						expectedScopedRoleAssignment("tester", "parent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("tester", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::testrole",
 							Scope: "/test/parent",
 						}.Build()}),
@@ -1120,6 +1173,10 @@ func TestMaterializerDiamondExpiry(t *testing.T) {
 	//        v
 	//      tester
 	t.Parallel()
+	topName := accesslists.NormalizedSQN{Scope: "/aa", Name: "top"}
+	leftName := accesslists.NormalizedSQN{Scope: "/aa", Name: "left"}
+	rightName := accesslists.NormalizedSQN{Scope: "/aa", Name: "right"}
+	bottomName := accesslists.NormalizedSQN{Scope: "/aa", Name: "bottom"}
 	synctest.Test(t, func(t *testing.T) {
 
 		testStart := time.Now()
@@ -1127,35 +1184,35 @@ func TestMaterializerDiamondExpiry(t *testing.T) {
 		rightExpires := testStart.Add(3 * time.Hour)
 
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: scopedCollection(accesslists.Collection{
-				AccessListsByName: map[string]*accesslist.AccessList{
-					"top": newAccessList(t, "top", withMemberGrants([]accesslist.ScopedRoleGrant{{
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+					topName: newAccessList(t, topName, withMemberGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/aa",
 						Role:  "/::toprole",
 					}})),
-					"left":   newAccessList(t, "left"),
-					"right":  newAccessList(t, "right"),
-					"bottom": newAccessList(t, "bottom"),
+					leftName:   newAccessList(t, leftName),
+					rightName:  newAccessList(t, rightName),
+					bottomName: newAccessList(t, bottomName),
 				},
-				MembersByAccessList: map[string][]*accesslist.AccessListMember{
-					"top": {
-						newAccessListMember(t, "top", "left", accesslist.MembershipKindList, withExpires(leftExpires)),
-						newAccessListMember(t, "top", "right", accesslist.MembershipKindList, withExpires(rightExpires)),
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					topName: {
+						newAccessListMember(t, topName, leftName, withExpires(leftExpires)),
+						newAccessListMember(t, topName, rightName, withExpires(rightExpires)),
 					},
-					"left": {
-						newAccessListMember(t, "left", "bottom", accesslist.MembershipKindList),
+					leftName: {
+						newAccessListMember(t, leftName, bottomName),
 					},
-					"right": {
-						newAccessListMember(t, "right", "bottom", accesslist.MembershipKindList),
+					rightName: {
+						newAccessListMember(t, rightName, bottomName),
 					},
-					"bottom": {
-						newAccessListMember(t, "bottom", "tester", accesslist.MembershipKindUser),
+					bottomName: {
+						newUserMember(t, bottomName, "tester"),
 					},
 				},
-			}),
+			},
 			// Initially the user is a valid member of the top list by 2 paths.
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-				expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("tester", topName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::toprole",
 					Scope: "/aa",
 				}.Build()}),
@@ -1169,7 +1226,7 @@ func TestMaterializerDiamondExpiry(t *testing.T) {
 						time.Sleep(time.Minute)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-						expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("tester", topName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::toprole",
 							Scope: "/aa",
 						}.Build()}),
@@ -1187,12 +1244,12 @@ func TestMaterializerDiamondExpiry(t *testing.T) {
 				{
 					// Upsert the left membership with a future expiry, the assignment should come back.
 					mutateState: func(t *testing.T, state *materializerTestcaseState) {
-						member := newAccessListMember(t, "top", "left", accesslist.MembershipKindList, withExpires(time.Now().Add(time.Minute)))
+						member := newAccessListMember(t, topName, leftName, withExpires(time.Now().Add(time.Minute)))
 						_, err := state.aclService.UpsertAccessListMember(t.Context(), member)
 						require.NoError(t, err)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-						expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("tester", topName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::toprole",
 							Scope: "/aa",
 						}.Build()}),
@@ -1233,16 +1290,16 @@ func BenchmarkMaterializerInit(b *testing.B) {
 		},
 		// These cases are theoretically realistic for very large clusters, but pretty slow to run in CI.
 		// {
-		//  // benchmarked this case at 6.2 seconds for a materializer init,
-		//  // vs 3.4 seconds for the baseline case that just copies the
-		//  // assignments with no logic. It materializes 2 million assignments.
+		// 	// benchmarked this case at 6.2 seconds for a materializer init,
+		// 	// vs 3.4 seconds for the baseline case that just copies the
+		// 	// assignments with no logic. It materializes 2 million assignments.
 		// 	listCount:      100,
 		// 	membersPerList: 20000,
 		// },
 		// {
-		//  // benchmarked this case at 26.6 seconds for a materializer init,
-		//  // vs 14.7 seconds for the baseline case that just copies the
-		//  // assignments with no logic. It materializes 5 million assignments.
+		// 	// benchmarked this case at 26.6 seconds for a materializer init,
+		// 	// vs 14.7 seconds for the baseline case that just copies the
+		// 	// assignments with no logic. It materializes 5 million assignments.
 		// 	listCount:      25000,
 		// 	membersPerList: 200,
 		// },
@@ -1258,6 +1315,9 @@ func BenchmarkMaterializerInit(b *testing.B) {
 			aclService, err := local.NewAccessListServiceV2(local.AccessListServiceConfig{
 				Backend: backend,
 				Modules: modulestest.EnterpriseModules(),
+				ScopesFeatures: scopes.Features{
+					Enabled: true,
+				},
 			})
 			require.NoError(b, err)
 
@@ -1355,7 +1415,7 @@ func createBenchmarkCollection(b require.TestingT, listCount, membersPerList, ne
 	listIndex := 0
 	memberIndex := 0
 	for range listCount {
-		listName := fmt.Sprintf("list-%d", listIndex)
+		listName := accesslists.NormalizedSQN{Name: fmt.Sprintf("list-%d", listIndex)}
 		listIndex++
 
 		list := newAccessList(b, listName, withMemberGrants(grants))
@@ -1365,7 +1425,7 @@ func createBenchmarkCollection(b require.TestingT, listCount, membersPerList, ne
 			memberName := fmt.Sprintf("user-%d", listIndex*membersPerList+memberIndex)
 			memberIndex++
 
-			members[i] = newAccessListMember(b, listName, memberName, accesslist.MembershipKindUser)
+			members[i] = newUserMember(b, listName, memberName)
 		}
 
 		require.NoError(b, collection.AddAccessList(list, members))
@@ -1378,17 +1438,17 @@ func createBenchmarkCollection(b require.TestingT, listCount, membersPerList, ne
 		ancestorListCount = ancestorListCount / 2
 
 		for range ancestorListCount {
-			listName := fmt.Sprintf("list-%d", listIndex)
+			listName := accesslists.NormalizedSQN{Name: fmt.Sprintf("list-%d", listIndex)}
 			listIndex++
 
 			list := newAccessList(b, listName, withMemberGrants(grants))
 
 			members := make([]*accesslist.AccessListMember, 2)
 			for i := range 2 {
-				childListName := fmt.Sprintf("list-%d", childListIndex)
+				childListName := accesslists.NormalizedSQN{Name: fmt.Sprintf("list-%d", childListIndex)}
 				childListIndex++
 
-				members[i] = newAccessListMember(b, listName, childListName, accesslist.MembershipKindList)
+				members[i] = newAccessListMember(b, listName, childListName)
 			}
 
 			require.NoError(b, collection.AddAccessList(list, members))
@@ -1428,24 +1488,7 @@ func withOwnershipRequires() aclOption {
 	}
 }
 
-func newAccessList(t require.TestingT, name string, opts ...aclOption) *accesslist.AccessList {
-	list, err := accesslist.NewAccessList(header.Metadata{
-		Name: name,
-	}, accesslist.Spec{
-		Title: name,
-		Owners: []accesslist.Owner{{
-			Name:           "testowner",
-			MembershipKind: accesslist.MembershipKindUser,
-		}},
-	})
-	require.NoError(t, err)
-	for _, opt := range opts {
-		opt(list)
-	}
-	return list
-}
-
-func newScopedAccessList(t require.TestingT, name accesslists.NormalizedSQN, opts ...aclOption) *accesslist.AccessList {
+func newAccessList(t require.TestingT, name accesslists.NormalizedSQN, opts ...aclOption) *accesslist.AccessList {
 	list, err := accesslist.NewAccessListWithScope(header.Metadata{
 		Name: name.Name,
 	}, accesslist.Spec{
@@ -1470,24 +1513,17 @@ func withExpires(expires time.Time) memberOption {
 	}
 }
 
-func newAccessListMember(t require.TestingT, parent, member, membershipKind string, opts ...memberOption) *accesslist.AccessListMember {
-	memberResource, err := accesslist.NewAccessListMember(header.Metadata{
-		Name: member,
-	}, accesslist.AccessListMemberSpec{
-		AccessList:     parent,
-		Name:           member,
-		MembershipKind: membershipKind,
-		Joined:         time.Now(),
-		AddedBy:        "testowner",
-	})
-	require.NoError(t, err)
-	for _, opt := range opts {
-		opt(memberResource)
+func withMembershipKind(kind string) memberOption {
+	return func(member *accesslist.AccessListMember) {
+		member.Spec.MembershipKind = kind
 	}
-	return memberResource
 }
 
-func newScopedAccessListMember(t require.TestingT, parent, member accesslists.NormalizedSQN, membershipKind string, opts ...memberOption) *accesslist.AccessListMember {
+func newAccessListMember(t require.TestingT, parent, member accesslists.NormalizedSQN, opts ...memberOption) *accesslist.AccessListMember {
+	membershipKind := accesslist.MembershipKindList
+	if member.Scope != "" {
+		membershipKind = accesslist.MembershipKindScopedList
+	}
 	memberResource, err := accesslist.NewAccessListMemberWithScope(header.Metadata{
 		Name: member.String(),
 	}, accesslist.AccessListMemberSpec{
@@ -1504,7 +1540,11 @@ func newScopedAccessListMember(t require.TestingT, parent, member accesslists.No
 	return memberResource
 }
 
-func expectedScopedScopedRoleAssignment(userName string, listName accesslists.NormalizedSQN, assignments []*scopedaccessv1.Assignment) *scopedaccessv1.ScopedRoleAssignment {
+func newUserMember(t require.TestingT, parent accesslists.NormalizedSQN, userName string, opts ...memberOption) *accesslist.AccessListMember {
+	return newAccessListMember(t, parent, accesslists.NormalizedSQN{Name: userName}, append(opts, withMembershipKind(accesslist.MembershipKindUser))...)
+}
+
+func expectedScopedRoleAssignment(userName string, listName accesslists.NormalizedSQN, assignments []*scopedaccessv1.Assignment) *scopedaccessv1.ScopedRoleAssignment {
 	key := access.MaterializedAssignmentKey{
 		User:      userName,
 		ListName:  listName.Name,
@@ -1517,7 +1557,7 @@ func expectedScopedScopedRoleAssignment(userName string, listName accesslists.No
 		Metadata: headerv1.Metadata_builder{
 			Name: key.AssignmentName(),
 		}.Build(),
-		Scope: listName.Scope,
+		Scope: key.AssignmentScope(),
 		Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
 			User:        userName,
 			Assignments: assignments,
@@ -1526,32 +1566,6 @@ func expectedScopedScopedRoleAssignment(userName string, listName accesslists.No
 			Origin: scopedaccessv1.ScopedRoleAssignmentStatus_Origin_builder{
 				CreatorKind: scopedaccess.CreatorKindAccessList,
 				CreatorName: listName.String(),
-			}.Build(),
-		}.Build(),
-	}.Build()
-}
-
-func expectedScopedRoleAssignment(userName, listName string, assignments []*scopedaccessv1.Assignment) *scopedaccessv1.ScopedRoleAssignment {
-	key := access.MaterializedAssignmentKey{
-		User:     userName,
-		ListName: listName,
-	}
-	return scopedaccessv1.ScopedRoleAssignment_builder{
-		Kind:    scopedaccess.KindScopedRoleAssignment,
-		SubKind: scopedaccess.SubKindMaterialized,
-		Version: types.V1,
-		Metadata: headerv1.Metadata_builder{
-			Name: key.AssignmentName(),
-		}.Build(),
-		Scope: "/",
-		Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-			User:        userName,
-			Assignments: assignments,
-		}.Build(),
-		Status: scopedaccessv1.ScopedRoleAssignmentStatus_builder{
-			Origin: scopedaccessv1.ScopedRoleAssignmentStatus_Origin_builder{
-				CreatorKind: scopedaccess.CreatorKindAccessList,
-				CreatorName: listName,
 			}.Build(),
 		}.Build(),
 	}.Build()

--- a/lib/scopes/cache/access/materializer_test.go
+++ b/lib/scopes/cache/access/materializer_test.go
@@ -86,6 +86,9 @@ func runMaterializerTestcase(t *testing.T, tc materializerTestcase) {
 	aclService, err := local.NewAccessListServiceV2(local.AccessListServiceConfig{
 		Backend: backend,
 		Modules: modulestest.EnterpriseModules(),
+		ScopesFeatures: scopes.Features{
+			Enabled: true,
+		},
 	})
 	require.NoError(t, err)
 

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -1779,7 +1779,7 @@ func (a *AccessListService) insertMembersAndUpdateNestedRelationships(ctx contex
 }
 
 func (a *AccessListService) insertMembers(ctx context.Context, acl accesslists.NormalizedSQN, members []*accesslist.AccessListMember) error {
-	items, err := a.membersToBackendItems(acl, members)
+	items, err := stream.Collect(a.membersToBackendItems(acl, members))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1794,24 +1794,30 @@ func (a *AccessListService) insertMembers(ctx context.Context, acl accesslists.N
 	return nil
 }
 
-func (a *AccessListService) membersToBackendItems(acl accesslists.NormalizedSQN, members []*accesslist.AccessListMember) ([]backend.Item, error) {
-	out := make([]backend.Item, 0, len(members))
-	for _, member := range members {
-		memberName, err := accesslists.MemberScopeQualifiedName(member)
-		if err != nil {
-			return nil, trace.Wrap(err)
+func (a *AccessListService) membersToBackendItems(acl accesslists.NormalizedSQN, members []*accesslist.AccessListMember) iter.Seq2[backend.Item, error] {
+	return func(yield func(backend.Item, error) bool) {
+		for _, member := range members {
+			memberName, err := accesslists.MemberScopeQualifiedName(member)
+			if err != nil {
+				yield(backend.Item{}, trace.Wrap(err))
+				return
+			}
+			memberService, err := a.memberServiceForNamedMember(acl, memberName)
+			if err != nil {
+				yield(backend.Item{}, trace.Wrap(err))
+				return
+			}
+			item, err := memberService.makeBackendItem(member)
+			if err != nil {
+				yield(backend.Item{}, trace.Wrap(err))
+				return
+			}
+			if !yield(item, nil) {
+				return
+			}
 		}
-		memberService, err := a.memberServiceForNamedMember(acl, memberName)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		item, err := memberService.makeBackendItem(member)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		out = append(out, item)
+
 	}
-	return out, nil
 }
 
 func (a *AccessListService) updatedMembersNestedRelationships(ctx context.Context, acl accesslists.NormalizedSQN, members []*accesslist.AccessListMember) error {
@@ -2048,7 +2054,6 @@ func (a *AccessListService) collectionToBackendItemsIter(collection *accesslists
 				yield(backend.Item{}, trace.NotFound("access list %q not found", aclName))
 				return
 			}
-			// TODO(nklaassen): support collections of scoped access lists.
 			for _, member := range members {
 				item, err := a.memberService.UnscopedService.WithPrefix(member.Spec.AccessList).MakeBackendItem(member)
 				if err != nil {
@@ -2059,8 +2064,94 @@ func (a *AccessListService) collectionToBackendItemsIter(collection *accesslists
 					return
 				}
 			}
-			// TODO(nklaassen): support collections of scoped access lists.
 			item, err := a.service.UnscopedService.MakeBackendItem(acl)
+			if err != nil {
+				yield(backend.Item{}, trace.Wrap(err))
+				return
+			}
+			if !yield(item, nil) {
+				return
+			}
+		}
+	}
+}
+
+// InsertScopedAccessListCollection inserts a complete collection of access lists and their members from a single
+// upstream source (e.g. EntraID) using a batch operation for improved performance.
+//
+// This method is designed for bulk import scenarios where an entire access list collection needs to be
+// synchronized from an external source. All access lists and members in the collection are
+// inserted using chunked batch operations, minimizing memory allocation while still reducing
+// the number of write operations. Due to the batch nature of this operation (access list hierarchy
+// is known upfront), we can avoid per-access-list locking and global locks to improve performance.
+//
+// Important: This method assumes the collection is self-contained. Access lists in the collection
+// cannot reference access lists outside the collection as members or owners. This is intentional for
+// collections representing a complete snapshot from a single upstream source.
+// The function should be used only once during initial import where
+// we are sure that Teleport doesn't have any pre-existing access lists from the upstream and the
+// internal relation between upstream access lists and internal access lists doesn't exist yet.
+//
+// Operation can fail due to backend shutdown. In that case, if partial state was created,
+// use UpsertAccessListWithMembers/DeleteAccessListMember to reconcile to the desired state.
+func (a *AccessListService) InsertScopedAccessListCollection(ctx context.Context, collection *accesslists.ScopedCollection) error {
+	if err := a.scopesFeatures.AssertEnabled(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := collection.Validate(ctx); err != nil {
+		return trace.Wrap(err)
+	}
+	// Collect backend items in chunks of 800 items each to avoid high memory consumption
+	// from constructing a large slice of all backend items at once. PutBatch will then
+	// leverage its own internal chunking to write items to the backend in smaller batches.
+	// TODO(smallinsky) align the chunk size with the one used in backend.PutBatch
+	for chunk, err := range stream.Chunks(a.scopedCollectionToBackendItemsIter(collection), 800) {
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if _, err := backend.PutBatch(ctx, a.backend, chunk); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}
+
+// scopedCollectionToBackendItemsIter converts access list collection to an iterator of backend items.
+// The iterator yields access list members first, followed by their parent access list.
+func (a *AccessListService) scopedCollectionToBackendItemsIter(collection *accesslists.ScopedCollection) iter.Seq2[backend.Item, error] {
+	return func(yield func(backend.Item, error) bool) {
+		seenLists := make(map[accesslists.NormalizedSQN]struct{}, len(collection.MembersByAccessList))
+		for aclName, members := range collection.MembersByAccessList {
+			acl, ok := collection.AccessListsByName[aclName]
+			if !ok {
+				yield(backend.Item{}, trace.NotFound("access list %q not found", aclName))
+				return
+			}
+			for item, err := range a.membersToBackendItems(aclName, members) {
+				if err != nil {
+					yield(backend.Item{}, err)
+					return
+				}
+				if !yield(item, nil) {
+					return
+				}
+			}
+			item, err := a.service.MakeBackendItem(acl)
+			if err != nil {
+				yield(backend.Item{}, trace.Wrap(err))
+				return
+			}
+			if !yield(item, nil) {
+				return
+			}
+			seenLists[aclName] = struct{}{}
+		}
+		for aclName, acl := range collection.AccessListsByName {
+			if _, ok := seenLists[aclName]; ok {
+				continue
+			}
+			item, err := a.service.MakeBackendItem(acl)
 			if err != nil {
 				yield(backend.Item{}, trace.Wrap(err))
 				return

--- a/lib/services/local/generic/scopeaware.go
+++ b/lib/services/local/generic/scopeaware.go
@@ -333,6 +333,15 @@ func (s *ScopeAwareService[T]) ConditionalUpdateResource(ctx context.Context, re
 	return svc.ConditionalUpdateResource(ctx, resource)
 }
 
+// MakeBackendItem will check and make the backend item.
+func (s *ScopeAwareService[T]) MakeBackendItem(resource T) (backend.Item, error) {
+	svc, err := s.WithScopePrefix(resource.GetScope())
+	if err != nil {
+		return backend.Item{}, trace.Wrap(err)
+	}
+	return svc.MakeBackendItem(resource)
+}
+
 // WithScopePrefix returns the unscoped service when scope is empty, otherwise
 // returns the scoped service with the encoded scope appended to its backend prefix.
 func (s *ScopeAwareService[T]) WithScopePrefix(scope string) (*Service[T], error) {


### PR DESCRIPTION
Part of [RFD 308](https://github.com/gravitational/rfd/pull/22)

This PR updates the scoped role assignment materializer to consider scoped access lists and materialize scoped role assignments with the appropriate scope.

Parent: https://github.com/gravitational/teleport/pull/68479

## Manual Test Plan
### Test Environment

Cluster running this branch with TELEPORT_UNSTABLE_SCOPES=yes

### Test Cases
- [x] regression test: unscoped access lists granting scoped roles still materialize scoped role assignments at the root scope
