### PR TITLE
[v17] autoupdate: Create slices with zero length for appending

### DIFF
--- a/lib/autoupdate/rollout/client.go
+++ b/lib/autoupdate/rollout/client.go
@@ -90,7 +90,7 @@ func getAllValidReports(ctx context.Context, clt Client, now time.Time) ([]*auto
 		return nil, trace.Wrap(err, "getting all reports")
 	}
 
-	validReports := make([]*autoupdatepb.AutoUpdateAgentReport, len(allReports))
+	validReports := make([]*autoupdatepb.AutoUpdateAgentReport, 0, len(allReports))
 	for _, report := range allReports {
 		if now.Sub(report.GetSpec().GetTimestamp().AsTime()) <= constants.AutoUpdateAgentReportPeriod {
 			validReports = append(validReports, report)

--- a/lib/autoupdate/rollout/transitions.go
+++ b/lib/autoupdate/rollout/transitions.go
@@ -65,7 +65,7 @@ func TriggerGroups(rollout *autoupdatev1pb.AutoUpdateAgentRollout, reports []*au
 	}
 
 	// filter out expired reports
-	validReports := make([]*autoupdatev1pb.AutoUpdateAgentReport, len(reports))
+	validReports := make([]*autoupdatev1pb.AutoUpdateAgentReport, 0, len(reports))
 	for _, report := range reports {
 		if now.Sub(report.GetSpec().GetTimestamp().AsTime()) <= constants.AutoUpdateAgentReportPeriod {
 			validReports = append(validReports, report)


### PR DESCRIPTION
Create slices of zero length when appending to them, rather than a
length equal to the capacity. The intent was to create a slice pre-sized
before adding elements, but because the length was not set to zero, and
instead set to the capacity, the resulting slices had an initial content
of nil pointers, which then grew with the real data for the slice. The
nil pointers did not cause any issues as protobuf getters were used to
access fields which is safe on nil pointers.

This is a minor quality improvement. Correctness was already satisfied.

Backport: https://github.com/gravitational/teleport/pull/68229