### PR TITLE
[v18] Support MCP protocol discovery for Kubernetes app services

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/reference.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/reference.mdx
@@ -97,6 +97,19 @@ heuristics will be used to try to determine protocol of an exposed port.
 If all heuristics didn't work, the port will be skipped. For app to be imported with `tcp` protocol, the
 service should have explicit annotation `teleport.dev/protocol: "tcp"`
 
+To import a service as an MCP server, set the annotation to the URI scheme of
+the transport the MCP server uses:
+
+- `teleport.dev/protocol: "mcp+http"` or `teleport.dev/protocol: "mcp+https"`
+  for the Streamable HTTP transport.
+- `teleport.dev/protocol: "mcp+sse+http"` or `teleport.dev/protocol: "mcp+sse+https"`
+  for the HTTP with SSE transport.
+
+Combine the annotation with `teleport.dev/path` to set the request path of the
+MCP endpoint (for example `/mcp` or `/sse`). MCP servers using the stdio
+transport cannot be discovered from Kubernetes services, since they require a
+command to launch the server.
+
 ### `teleport.dev/port`
 
 Controls preferred port for the Kubernetes service, only this one will be used even if service

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -191,7 +191,14 @@ func (f *KubeAppFetcher) Get(ctx context.Context) (types.ResourcesWithLabels, er
 			portProtocols := map[v1.ServicePort]string{}
 			for _, port := range ports {
 				switch protocolAnnotation {
-				case protoHTTPS, protoHTTP, protoTCP:
+				// MCP servers using the Streamable HTTP or SSE transport are
+				// registered as MCP apps based on their URI scheme, so the
+				// annotation value is passed through as the URI scheme.
+				// mcp+stdio is intentionally excluded: it requires a command,
+				// which a Kubernetes Service cannot provide.
+				case protoHTTPS, protoHTTP, protoTCP,
+					types.SchemeMCPHTTP, types.SchemeMCPHTTPS,
+					types.SchemeMCPSSEHTTP, types.SchemeMCPSSEHTTPS:
 					portProtocols[port] = protocolAnnotation
 				default:
 					if p := autoProtocolDetection(service, port, f.ProtocolChecker); p != protoTCP {

--- a/lib/srv/discovery/fetchers/kube_services_test.go
+++ b/lib/srv/discovery/fetchers/kube_services_test.go
@@ -79,6 +79,19 @@ func TestKubeAppFetcher_Get(t *testing.T) {
 				{Port: 42, Name: "custom", Protocol: corev1.ProtocolTCP},
 				{Port: 43, Name: "custom-udp", Protocol: corev1.ProtocolUDP},
 			}),
+		newMockService("service6", "ns4", "", map[string]string{"test-label4": "testval4"}, map[string]string{
+			types.DiscoveryProtocolLabel: types.SchemeMCPHTTP,
+		},
+			[]corev1.ServicePort{
+				{Port: 8080, Name: "custom", Protocol: corev1.ProtocolTCP},
+			}),
+		newMockService("service7", "ns4", "", map[string]string{"test-label4": "testval4"}, map[string]string{
+			types.DiscoveryProtocolLabel: types.SchemeMCPSSEHTTPS,
+			types.DiscoveryPathLabel:     "/sse",
+		},
+			[]corev1.ServicePort{
+				{Port: 443, Name: "custom", Protocol: corev1.ProtocolTCP},
+			}),
 	}
 
 	apps := map[string]*types.AppV3{
@@ -173,6 +186,42 @@ func TestKubeAppFetcher_Get(t *testing.T) {
 				URI: "tcp://service5.ns3.svc.cluster.local:42",
 			},
 		},
+		"service6.app1": {
+			Kind:    "app",
+			SubKind: types.SubKindMCP,
+			Version: "v3",
+			Metadata: types.Metadata{
+				Name:        "service6-ns4-test-cluster",
+				Namespace:   "default",
+				Description: "Discovered application in Kubernetes cluster \"test-cluster\"",
+				Labels: map[string]string{
+					"test-label4":                "testval4",
+					types.KubernetesClusterLabel: "test-cluster",
+					types.AppSubKindLabel:        types.SubKindMCP,
+				},
+			},
+			Spec: types.AppSpecV3{
+				URI: "mcp+http://service6.ns4.svc.cluster.local:8080",
+			},
+		},
+		"service7.app1": {
+			Kind:    "app",
+			SubKind: types.SubKindMCP,
+			Version: "v3",
+			Metadata: types.Metadata{
+				Name:        "service7-ns4-test-cluster",
+				Namespace:   "default",
+				Description: "Discovered application in Kubernetes cluster \"test-cluster\"",
+				Labels: map[string]string{
+					"test-label4":                "testval4",
+					types.KubernetesClusterLabel: "test-cluster",
+					types.AppSubKindLabel:        types.SubKindMCP,
+				},
+			},
+			Spec: types.AppSpecV3{
+				URI: "mcp+sse+https://service7.ns4.svc.cluster.local:443/sse",
+			},
+		},
 	}
 
 	tests := []struct {
@@ -265,6 +314,13 @@ func TestKubeAppFetcher_Get(t *testing.T) {
 			matcherNamespaces: []string{"ns3"},
 			matcherLabels:     types.Labels{"test-label3": []string{"testval3"}},
 			expected:          types.Apps{apps["service5.app1"]},
+		},
+		{
+			desc:              "Service with MCP Streamable HTTP protocol annotation",
+			services:          mockServices,
+			matcherNamespaces: []string{"ns4"},
+			matcherLabels:     types.Labels{"test-label4": []string{"testval4"}},
+			expected:          types.Apps{apps["service6.app1"], apps["service7.app1"]},
 		},
 		{
 			desc:              "Matching service with protocol checker",


### PR DESCRIPTION
Backport #68442 to branch/v18

changelog: Fixed Kubernetes app discovery not registering Services annotated with an MCP protocol (`mcp+http`, `mcp+https`, `mcp+sse+http`, `mcp+sse+https`) as MCP apps.
