### PR TITLE
Update design-system to v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@codemirror/view": "^6.43.4",
     "@floating-ui/react": "^0.27.19",
     "@fontsource/ubuntu": "^5.2.8",
-    "@gravitational/design-system": "https://github.com/gravitational/design-system/releases/download/v0.1.3/design-system.tgz",
+    "@gravitational/design-system": "https://github.com/gravitational/design-system/releases/download/v0.2.0/design-system.tgz",
     "@grpc/grpc-js": "1.14.4",
     "@hookform/resolvers": "^5.4.0",
     "@lezer/highlight": "^1.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       '@gravitational/design-system':
-        specifier: https://github.com/gravitational/design-system/releases/download/v0.1.3/design-system.tgz
-        version: https://github.com/gravitational/design-system/releases/download/v0.1.3/design-system.tgz(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@fontsource/ubuntu@5.2.8)(@tanstack/react-query@5.101.2(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tslib@2.8.1)(zod@4.4.3)
+        specifier: https://github.com/gravitational/design-system/releases/download/v0.2.0/design-system.tgz
+        version: https://github.com/gravitational/design-system/releases/download/v0.2.0/design-system.tgz(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@fontsource/ubuntu@5.2.8)(@tanstack/react-query@5.101.2(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tslib@2.8.1)(zod@4.4.3)
       '@grpc/grpc-js':
         specifier: 1.14.4
         version: 1.14.4
@@ -2207,9 +2207,9 @@ packages:
   '@fontsource/ubuntu@5.2.8':
     resolution: {integrity: sha512-esSJCpgigwWOm4Ug9f7AMozUyBq5Iobea5C9QYsl2OlCb62wZABBUbXahHLdFv5Ru4lJCD9tUX6xEAeLwUTNBg==}
 
-  '@gravitational/design-system@https://github.com/gravitational/design-system/releases/download/v0.1.3/design-system.tgz':
-    resolution: {integrity: sha512-3JCC8uktM8ZFRom6vhg5TH6e8atC/7PSLL49hcQgkNr4ZdFI5LmxnnwMZlyxR/Juj3t1KRxOreT6exDWVZI0uA==, tarball: https://github.com/gravitational/design-system/releases/download/v0.1.3/design-system.tgz}
-    version: 0.1.3
+  '@gravitational/design-system@https://github.com/gravitational/design-system/releases/download/v0.2.0/design-system.tgz':
+    resolution: {integrity: sha512-LPvUKuu8sVRnbi6BBicyvLIF1uC+Kd2H6962hKE9Qhr+DYG2tzRrKuNpXCKoPORn7QEPolqs/Voqh8Ve/0WUkg==, tarball: https://github.com/gravitational/design-system/releases/download/v0.2.0/design-system.tgz}
+    version: 0.2.0
     hasBin: true
     peerDependencies:
       '@emotion/react': '>=11'
@@ -3182,6 +3182,9 @@ packages:
   '@peculiar/webcrypto@1.7.1':
     resolution: {integrity: sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==}
     engines: {node: '>=14.18.0'}
+
+  '@phosphor-icons/core@2.1.1':
+    resolution: {integrity: sha512-v4ARvrip4qBCImOE5rmPUylOEK4iiED9ZyKjcvzuezqMaiRASCHKcRIuvvxL/twvLpkfnEODCOJp5dM4eZilxQ==}
 
   '@phosphor-icons/react@2.1.10':
     resolution: {integrity: sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==}
@@ -9901,7 +9904,7 @@ snapshots:
 
   '@fontsource/ubuntu@5.2.8': {}
 
-  '@gravitational/design-system@https://github.com/gravitational/design-system/releases/download/v0.1.3/design-system.tgz(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@fontsource/ubuntu@5.2.8)(@tanstack/react-query@5.101.2(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tslib@2.8.1)(zod@4.4.3)':
+  '@gravitational/design-system@https://github.com/gravitational/design-system/releases/download/v0.2.0/design-system.tgz(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@fontsource/ubuntu@5.2.8)(@tanstack/react-query@5.101.2(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tslib@2.8.1)(zod@4.4.3)':
     dependencies:
       '@ark-ui/react': 5.37.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@chakra-ui/cli': 3.35.0(@chakra-ui/react@3.35.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
@@ -9909,6 +9912,7 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
       '@fontsource/ubuntu': 5.2.8
       '@hookform/resolvers': 5.4.0(react-hook-form@7.80.0(react@19.2.7))(zod@4.4.3)
+      '@phosphor-icons/core': 2.1.1
       '@phosphor-icons/react': 2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@tanstack/react-table': 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -10875,6 +10879,8 @@ snapshots:
       '@peculiar/utils': 2.0.3
       tslib: 2.8.1
       webcrypto-core: 1.9.2
+
+  '@phosphor-icons/core@2.1.1': {}
 
   '@phosphor-icons/react@2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:


### PR DESCRIPTION
Bumps `@gravitational/design-system` from v0.1.3 to v0.2.0.

## Changelog

### [0.2.0](https://github.com/gravitational/design-system/releases/tag/v0.2.0)

### Minor Changes

* Added indeterminate state support for `ComposedCheckbox` (set `checked="indeterminate"` to render a horizontal bar) and a bold `Minus` icon. ([#144](https://github.com/gravitational/design-system/pull/144))

### Patch Changes

* Fix Chakra type generation on Windows by resolving the generated types path from the package URL before converting it to an OS-specific filesystem path. ([#148](https://github.com/gravitational/design-system/pull/148))

* Add a bunch of icons ([#149](https://github.com/gravitational/design-system/pull/149))
