### PR TITLE
Add linux/darwin to pnpm supported architectures

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,3 +58,11 @@ minimumReleaseAgeExclude:
   - '@gravitational/swc-plugin-styled-components'
 # The pnpm team releases new versions pretty often, and we don't need to stay at the freshest version at all times.
 updateNotifier: false
+supportedArchitectures:
+  os:
+  - darwin
+  - linux
+  - current
+  cpu:
+  - arm64
+  - current

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,6 +59,8 @@ minimumReleaseAgeExclude:
 # The pnpm team releases new versions pretty often, and we don't need to stay at the freshest version at all times.
 updateNotifier: false
 supportedArchitectures:
+# We explicitly set darwin and arm64 (macOS) and `current` here, so if `pnpm install` is ran inside a VM that is neither
+# darwin or arm64, we don't lose the correct architecture bindings.
   os:
   - darwin
   - linux


### PR DESCRIPTION
When running Claude in a VM, it fails with stuff like `tsgo` because the linux binaries are not installed. This adds linux to the supported architectures in `pnpm-workspace.yaml` (and darwin, and `current` just in case it's ran elsewhere) as well as defining `arm64` as the CPU (macOS silicon) and `current` in case it's ran in x64

## Manual Test Plan
### Test Environment
Local

### Test Cases
- [x] `pnpm install` installs Darwin and Linux bindings for TypeScript
- [x] `pnpm type-check` works on macOS
- [x] `pnpm type-check` works inside a linux container
