### PR TITLE
[v18] MCP: Remove all non-canonical fields impacting RBAC from tools/call request

### DIFF
--- a/lib/srv/mcp/helpers_test.go
+++ b/lib/srv/mcp/helpers_test.go
@@ -24,6 +24,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"slices"
 	"sync"
@@ -32,7 +34,9 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	mcpclienttransport "github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
 	"github.com/moby/moby/api/types/container"
 	docker "github.com/moby/moby/client"
 	"github.com/stretchr/testify/assert"
@@ -44,6 +48,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -436,4 +441,97 @@ func checkSessionStartHasExternalSessionID() func(*testing.T, *apievents.MCPSess
 		t.Helper()
 		require.NotEmpty(t, sessionStart.SessionID)
 	}
+}
+
+func newAllowAllDenyForbiddenToolRole(t *testing.T, forbiddenTool string) types.Role {
+	t.Helper()
+	role, err := types.NewRole("allow-all-deny-forbidden", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: map[string]apiutils.Strings{
+				types.Wildcard: {types.Wildcard},
+			},
+			MCP: &types.MCPPermissions{
+				Tools: []string{types.Wildcard},
+			},
+		},
+		Deny: types.RoleConditions{
+			MCP: &types.MCPPermissions{
+				Tools: []string{forbiddenTool},
+			},
+		},
+	})
+	require.NoError(t, err)
+	return role
+}
+
+func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role types.Role) (*eventstest.MockRecorderEmitter, *mcpclienttransport.StreamableHTTP) {
+	t.Helper()
+
+	remoteMCPServer := mcpserver.NewStreamableHTTPServer(upstream)
+	remoteHTTPServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		remoteMCPServer.ServeHTTP(w, r)
+	}))
+	t.Cleanup(remoteHTTPServer.Close)
+
+	app, err := types.NewAppV3(
+		types.Metadata{
+			Name:   "test-mcp-server",
+			Labels: map[string]string{"env": "prod"},
+		},
+		types.AppSpecV3{
+			URI: fmt.Sprintf("mcp+%s/mcp", remoteHTTPServer.URL),
+		},
+	)
+	require.NoError(t, err)
+
+	emitter := eventstest.MockRecorderEmitter{}
+	s, err := NewServer(ServerConfig{
+		Emitter:       &emitter,
+		ParentContext: t.Context(),
+		HostID:        "my-host-id",
+		AccessPoint:   fakeAccessPoint{},
+		CipherSuites:  utils.DefaultCipherSuites(),
+		AuthClient:    &mockAuthClient{},
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	t.Cleanup(wg.Wait)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				assert.True(t, utils.IsOKNetworkError(err))
+				return
+			}
+			wg.Go(func() {
+				defer conn.Close()
+				testCtx := setupTestContext(t,
+					withRole(role),
+					withApp(app),
+					withClientConn(conn),
+				)
+				assert.NoError(t, s.HandleSession(t.Context(), testCtx.SessionCtx))
+			})
+		}
+	}()
+
+	mcpClientTransport, err := mcpclienttransport.NewStreamableHTTP("http://" + listener.Addr().String())
+	require.NoError(t, err)
+
+	return &emitter, mcpClientTransport
+}
+
+func testJSONString(t *testing.T, v any) string {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(data)
 }

--- a/lib/srv/mcp/helpers_test.go
+++ b/lib/srv/mcp/helpers_test.go
@@ -23,11 +23,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -443,32 +445,14 @@ func checkSessionStartHasExternalSessionID() func(*testing.T, *apievents.MCPSess
 	}
 }
 
-func newAllowAllDenyForbiddenToolRole(t *testing.T, forbiddenTool string) types.Role {
+func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role types.Role) (_ *testRecorder, _ *mcpclienttransport.StreamableHTTP, proxyURL string) {
 	t.Helper()
-	role, err := types.NewRole("allow-all-deny-forbidden", types.RoleSpecV6{
-		Allow: types.RoleConditions{
-			AppLabels: map[string]apiutils.Strings{
-				types.Wildcard: {types.Wildcard},
-			},
-			MCP: &types.MCPPermissions{
-				Tools: []string{types.Wildcard},
-			},
-		},
-		Deny: types.RoleConditions{
-			MCP: &types.MCPPermissions{
-				Tools: []string{forbiddenTool},
-			},
-		},
-	})
-	require.NoError(t, err)
-	return role
-}
 
-func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role types.Role) (*eventstest.MockRecorderEmitter, *mcpclienttransport.StreamableHTTP) {
-	t.Helper()
+	recorder := newTestRecorders()
 
 	remoteMCPServer := mcpserver.NewStreamableHTTPServer(upstream)
 	remoteHTTPServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recorder.registerHttpRequest(t, r)
 		if r.URL.Path != "/mcp" {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -488,9 +472,8 @@ func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role ty
 	)
 	require.NoError(t, err)
 
-	emitter := eventstest.MockRecorderEmitter{}
 	s, err := NewServer(ServerConfig{
-		Emitter:       &emitter,
+		Emitter:       recorder,
 		ParentContext: t.Context(),
 		HostID:        "my-host-id",
 		AccessPoint:   fakeAccessPoint{},
@@ -523,15 +506,131 @@ func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role ty
 		}
 	}()
 
-	mcpClientTransport, err := mcpclienttransport.NewStreamableHTTP("http://" + listener.Addr().String())
+	proxyURL = "http://" + listener.Addr().String()
+	mcpClientTransport, err := mcpclienttransport.NewStreamableHTTP(proxyURL)
 	require.NoError(t, err)
 
-	return &emitter, mcpClientTransport
+	return recorder, mcpClientTransport, proxyURL
 }
 
-func testJSONString(t *testing.T, v any) string {
+func testSendRAWRequest(t *testing.T, method, url, sessionID string, body string) (response []byte) {
+	t.Helper()
+	ctx := t.Context()
+
+	req, err := http.NewRequestWithContext(ctx, method, url, strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set(mcpclienttransport.HeaderKeySessionID, sessionID)
+
+	resp, err := (&http.Client{Timeout: 5 * time.Second}).Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Contains(t, []int{http.StatusOK, http.StatusAccepted}, resp.StatusCode)
+
+	return respBody
+}
+
+type testRecorder struct {
+	*testHTTPRequestRecorder
+	*eventstest.MockRecorderEmitter
+}
+
+func newTestRecorders() *testRecorder {
+	return &testRecorder{&testHTTPRequestRecorder{}, &eventstest.MockRecorderEmitter{}}
+}
+
+func (r *testRecorder) Reset() {
+	r.testHTTPRequestRecorder.Reset()
+	r.MockRecorderEmitter.Reset()
+}
+
+type testHTTPRequestRecorder struct {
+	mu       sync.RWMutex
+	requests []*http.Request
+}
+
+func (r *testHTTPRequestRecorder) registerHttpRequest(t *testing.T, req *http.Request) {
+	t.Helper()
+
+	data, err := utils.GetAndReplaceRequestBody(req)
+	require.NoError(t, err)
+	req = req.Clone(t.Context())
+	// The requests is now cloned, but it's a shallow clone holding a pointer to the original
+	// body. Let's now set a the cloned body.
+	utils.OverwriteRequestBodyNoDrain(req, data)
+	require.NoError(t, err)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.requests = append(r.requests, req)
+}
+
+func (r *testHTTPRequestRecorder) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.requests = r.requests[:0]
+}
+
+func (r *testHTTPRequestRecorder) HTTPRequests() []*http.Request {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.requests
+}
+
+func testGetRequestPayload(t *testing.T, req *http.Request) []byte {
+	t.Helper()
+	defer req.Body.Close()
+	payload, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	return payload
+}
+
+func testJSON(t *testing.T, v any) []byte {
 	t.Helper()
 	data, err := json.Marshal(v)
 	require.NoError(t, err)
-	return string(data)
+	return data
+}
+
+func requireDeniedToolResponse(t *testing.T, respJSON []byte) {
+	t.Helper()
+	requireRequestResponseError(t, respJSON, mcp.INVALID_PARAMS, "User does not have permissions")
+}
+
+func requireToolNameMissingResponse(t *testing.T, respJSON []byte) {
+	t.Helper()
+	requireRequestResponseError(t, respJSON, mcp.INVALID_REQUEST, errInvalidRequestMissingName.Error())
+}
+
+func requireRequestResponseError(t *testing.T, respJSON []byte, expectedCode int, includedData string) {
+	t.Helper()
+
+	var baseMessage mcputils.BaseJSONRPCMessage
+	err := json.Unmarshal(respJSON, &baseMessage)
+	require.NoError(t, err, string(respJSON))
+
+	// Case everything to string so it's displayed nicely in case of error.
+	require.Empty(t, string(baseMessage.Result), string(respJSON))
+	require.NotEmpty(t, baseMessage.ID)
+	require.NotEmpty(t, string(baseMessage.Error))
+
+	var messageErrorDetails map[string]json.RawMessage
+	err = json.Unmarshal(baseMessage.Error, &messageErrorDetails)
+	require.NoError(t, err)
+
+	require.Contains(t, messageErrorDetails, "code")
+	var code int
+	err = json.Unmarshal(messageErrorDetails["code"], &code)
+	require.NoError(t, err)
+	require.Equal(t, expectedCode, code)
+
+	require.Contains(t, messageErrorDetails, "data")
+	escapedIncludedData, err := json.Marshal(includedData)
+	escapedIncludedData = escapedIncludedData[1 : len(escapedIncludedData)-1]
+	require.NoError(t, err)
+	require.Contains(t, string(messageErrorDetails["data"]), string(escapedIncludedData))
 }

--- a/lib/srv/mcp/http.go
+++ b/lib/srv/mcp/http.go
@@ -227,8 +227,9 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 	switch {
 	case baseMessage.IsRequest():
 		mcpRequest := baseMessage.MakeRequest()
-		if errResp, authErr := t.sessionHandler.processClientRequest(r.Context(), mcpRequest); authErr != nil {
-			return t.handleRequestAuthError(r, mcpRequest, errResp, authErr)
+		if errResp := t.sessionHandler.processClientRequest(r.Context(), mcpRequest); errResp != nil {
+			t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(toError(*errResp)), eventWithHeader(r.Header))
+			return t.handleRequestError(r, *errResp)
 		}
 	case baseMessage.IsNotification():
 		t.sessionHandler.processClientNotification(r.Context(), baseMessage.MakeNotification())
@@ -255,16 +256,14 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 		if mcpRequest.Method == mcputils.MethodInitialize && respErrForAudit == nil {
 			t.appendStartEvent(r.Context(), eventWithHeader(r.Header))
 		}
-		t.emitRequestEvent(r.Context(), mcpRequest, eventWithError(respErrForAudit), eventWithHeader(r.Header))
+		t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(respErrForAudit), eventWithHeader(r.Header))
 	case baseMessage.IsNotification():
 		t.emitNotificationEvent(r.Context(), baseMessage.MakeNotification(), eventWithError(respErrForAudit), eventWithHeader(r.Header))
 	}
 	return resp, trace.Wrap(err)
 }
 
-func (t *streamableHTTPTransport) handleRequestAuthError(r *http.Request, mcpRequest *mcputils.JSONRPCRequest, errResp mcp.JSONRPCMessage, authErr error) (*http.Response, error) {
-	t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(authErr), eventWithHeader(r.Header))
-
+func (t *streamableHTTPTransport) handleRequestError(r *http.Request, errResp mcp.JSONRPCMessage) (*http.Response, error) {
 	errRespAsBody, err := json.Marshal(errResp)
 	if err != nil {
 		// Should not happen. If it does, we are failing the request either way.

--- a/lib/srv/mcp/http.go
+++ b/lib/srv/mcp/http.go
@@ -175,7 +175,7 @@ func (t *streamableHTTPTransport) setExternalSessionID(header http.Header) {
 	}
 }
 
-func (t *streamableHTTPTransport) rewriteRequest(r *http.Request) (*http.Request, error) {
+func (t *streamableHTTPTransport) rewriteAndSendRequest(r *http.Request) (*http.Response, error) {
 	r = r.Clone(r.Context())
 	r.URL.Scheme = t.targetURI.Scheme
 	r.URL.Host = t.targetURI.Host
@@ -191,15 +191,8 @@ func (t *streamableHTTPTransport) rewriteRequest(r *http.Request) (*http.Request
 	if err := t.rewriteHTTPRequestHeaders(r); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return r, nil
-}
 
-func (t *streamableHTTPTransport) rewriteAndSendRequest(r *http.Request) (*http.Response, error) {
-	rCopy, err := t.rewriteRequest(r)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return t.targetTransport.RoundTrip(rCopy)
+	return t.targetTransport.RoundTrip(r)
 }
 
 func (t *streamableHTTPTransport) handleSessionEndRequest(r *http.Request) (*http.Response, error) {
@@ -215,11 +208,21 @@ func (t *streamableHTTPTransport) handleListenSSEStreamRequest(r *http.Request) 
 }
 
 func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Response, error) {
-	var baseMessage mcputils.BaseJSONRPCMessage
-	if reqBody, err := utils.GetAndReplaceRequestBody(r); err != nil {
+	reqBody, err := utils.GetAndReplaceRequestBody(r)
+	if err != nil {
 		t.emitInvalidHTTPRequest(t.parentCtx, r)
 		return nil, trace.BadParameter("invalid request body %v", err)
-	} else if err := json.Unmarshal(reqBody, &baseMessage); err != nil {
+	}
+	reqBody, err = sanitizeRawMCPRequest(reqBody)
+	if err != nil {
+		t.emitInvalidHTTPRequest(t.parentCtx, r)
+		return nil, trace.BadParameter("invalid request body %v", err)
+	}
+	if err := utils.OverwriteRequestBody(r, reqBody); err != nil {
+		return nil, trace.Wrap(err, "overwriting request body with sanitized value")
+	}
+	var baseMessage mcputils.BaseJSONRPCMessage
+	if err := json.Unmarshal(reqBody, &baseMessage); err != nil {
 		t.emitInvalidHTTPRequest(t.parentCtx, r)
 		return nil, trace.BadParameter("invalid request body %v", err)
 	}
@@ -227,7 +230,8 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 	switch {
 	case baseMessage.IsRequest():
 		mcpRequest := baseMessage.MakeRequest()
-		if errResp := t.sessionHandler.processClientRequest(r.Context(), mcpRequest); errResp != nil {
+		errResp := t.sessionHandler.processClientRequest(r.Context(), mcpRequest)
+		if errResp != nil {
 			t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(toError(*errResp)), eventWithHeader(r.Header))
 			return t.handleRequestError(r, *errResp)
 		}
@@ -239,7 +243,7 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 		return nil, trace.BadParameter("not a MCP request or notification")
 	}
 
-	resp, err := t.rewriteAndSendRequest(r)
+	resp, sendReqErr := t.rewriteAndSendRequest(r)
 	// Prefer session ID from server response if present. For example,
 	// "initialize" request does not have an ID but the server response may have
 	// it.
@@ -248,19 +252,19 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 	}
 
 	// Take care of audit events after round trip.
-	respErrForAudit := convertHTTPResponseErrorForAudit(resp, err)
+	auditErr := convertHTTPResponseErrorForAudit(resp, sendReqErr)
 	switch {
 	case baseMessage.IsRequest():
 		mcpRequest := baseMessage.MakeRequest()
 		// Only emit session start if "initialize" succeeded.
-		if mcpRequest.Method == mcputils.MethodInitialize && respErrForAudit == nil {
+		if mcpRequest.Method == mcputils.MethodInitialize && auditErr == nil {
 			t.appendStartEvent(r.Context(), eventWithHeader(r.Header))
 		}
-		t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(respErrForAudit), eventWithHeader(r.Header))
+		t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(auditErr), eventWithHeader(r.Header))
 	case baseMessage.IsNotification():
-		t.emitNotificationEvent(r.Context(), baseMessage.MakeNotification(), eventWithError(respErrForAudit), eventWithHeader(r.Header))
+		t.emitNotificationEvent(r.Context(), baseMessage.MakeNotification(), eventWithError(auditErr), eventWithHeader(r.Header))
 	}
-	return resp, trace.Wrap(err)
+	return resp, trace.Wrap(sendReqErr)
 }
 
 func (t *streamableHTTPTransport) handleRequestError(r *http.Request, errResp mcp.JSONRPCMessage) (*http.Response, error) {

--- a/lib/srv/mcp/http_test.go
+++ b/lib/srv/mcp/http_test.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/utils"
@@ -213,33 +214,48 @@ func Test_handleStreamableHTTP(t *testing.T) {
 	})
 }
 
-// Test_Server_HandleSession_reject_req_missing_name makes sure requests with missing canonical
-// "name" param are rejected.
-func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
+// Test_Server_HandleSession_request_sanitization verifies the forwarded request is stripped of
+// non-canonical fields (e.g. uppercase) which may confuse the upstream server.
+func Test_Server_HandleSession_request_sanitization(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
 
-	const forbiddenTool = "forbidden_tool"
-	const forbiddenToolTextContent = "FORBIDDEN_TOOL_EXECUTED_ON_UPSTREAM"
+	const allowedTool = "allowed_tool"
+	const allowedToolTextContent = "allowed_tool_executed_on_upstream"
+	const deniedTool = "denied_tool"
+	const deniedToolTextContent = "DENIED_TOOL_EXECUTED_ON_UPSTREAM"
 
-	role := newAllowAllDenyForbiddenToolRole(t, forbiddenTool)
+	role, err := types.NewRole("allowed_tool_access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: map[string]apiutils.Strings{
+				types.Wildcard: {types.Wildcard},
+			},
+			MCP: &types.MCPPermissions{
+				Tools: []string{allowedTool},
+			},
+		},
+	})
+	require.NoError(t, err)
 
 	upstream := mcpserver.NewMCPServer("test-server", "1.0.0")
 	upstream.AddTool(
-		mcp.Tool{
-			Name: forbiddenTool,
-		},
+		mcp.Tool{Name: allowedTool},
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{mcp.NewTextContent(forbiddenToolTextContent)},
-			}, nil
+			return &mcp.CallToolResult{Content: []mcp.Content{mcp.NewTextContent(allowedToolTextContent)}}, nil
+		},
+	)
+	upstream.AddTool(
+		mcp.Tool{Name: deniedTool},
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{Content: []mcp.Content{mcp.NewTextContent(deniedToolTextContent)}}, nil
 		},
 	)
 
-	emitter, mcpClientTransport := newStreamableMCPServer(t, upstream, role)
+	recorder, mcpClientTransport, proxyURL := newStreamableMCPServer(t, upstream, role)
 
-	_, err := mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
+	// Initialize message has to be sent first. It isn't a part of the test.
+	_, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
 		JSONRPC: mcp.JSONRPC_VERSION,
 		ID:      mcp.NewRequestId(1),
 		Method:  string(mcp.MethodInitialize),
@@ -254,43 +270,40 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, mcpClientTransport.GetSessionId())
 
-	// Verify it works as expected if the canonical lower-case "name" param is provided.
-	emitter.Reset()
+	// Verify everything works as expected if the canonical lower-case "name" param is
+	// provided and allowed tool is executed.
+	recorder.Reset()
 	resp, err := mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
 		JSONRPC: mcp.JSONRPC_VERSION,
 		ID:      mcp.NewRequestId(2),
 		Method:  string(mcp.MethodToolsCall),
 		Params: map[string]any{
-			"name": forbiddenTool,
+			"name": allowedTool,
 		},
 	})
 	require.NoError(t, err)
-	require.NotNil(t, resp.Error)
-	require.Equal(t, mcp.INVALID_PARAMS, resp.Error.Code)
-	respJSON := testJSONString(t, resp)
-	require.NotContains(t, respJSON, forbiddenToolTextContent)
-	require.Contains(t, respJSON, "User does not have permissions")
+	require.Contains(t, string(resp.Result), allowedToolTextContent)
+	// Verify the request was forwarded.
+	require.Len(t, recorder.requests, 1)
 
-	// Verify that when non-canonical capitalized "Name" param is specified the request is
-	// rejected.
-	emitter.Reset()
+	// Verify everything works as expected if the canonical lower-case "name" param is
+	// provided and denied tool is rejected.
+	recorder.Reset()
 	resp, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
 		JSONRPC: mcp.JSONRPC_VERSION,
-		ID:      mcp.NewRequestId(3),
+		ID:      mcp.NewRequestId(2),
 		Method:  string(mcp.MethodToolsCall),
 		Params: map[string]any{
-			"Name": forbiddenTool,
+			"name": deniedTool,
 		},
 	})
 	require.NoError(t, err)
-	require.NotNil(t, resp.Error)
-	require.Equal(t, mcp.INVALID_REQUEST, resp.Error.Code)
-	respJSON = testJSONString(t, resp)
-	require.NotContains(t, respJSON, forbiddenToolTextContent)
-	require.Contains(t, respJSON, testJSONString(t, errInvalidRequestMissingName.Error()))
+	requireDeniedToolResponse(t, testJSON(t, resp))
+	// Verify the request was not forwarded.
+	require.Empty(t, recorder.requests)
 
-	// Verify that when an empty "name" param is specified the request is rejected.
-	emitter.Reset()
+	// Verify that when an empty "name" param is specified the request is rejected as invalid.
+	recorder.Reset()
 	resp, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
 		JSONRPC: mcp.JSONRPC_VERSION,
 		ID:      mcp.NewRequestId(4),
@@ -300,28 +313,120 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NotNil(t, resp.Error)
-	require.Equal(t, mcp.INVALID_REQUEST, resp.Error.Code)
-	respJSON = testJSONString(t, resp)
-	require.NotContains(t, respJSON, forbiddenToolTextContent)
-	require.Contains(t, respJSON, testJSONString(t, errInvalidRequestMissingName.Error()))
+	requireToolNameMissingResponse(t, testJSON(t, resp))
+	// Verify the request was not forwarded.
+	require.Empty(t, recorder.requests)
 
-	// Verify that correct request is properly unauthorized.
-	emitter.Reset()
+	// Verify that when non-canonical capitalized "Name" param is specified and send through
+	// streamable transport the request is correctly rejected.
+	recorder.Reset()
 	resp, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
 		JSONRPC: mcp.JSONRPC_VERSION,
-		ID:      mcp.NewRequestId(5),
+		ID:      mcp.NewRequestId(3),
 		Method:  string(mcp.MethodToolsCall),
 		Params: map[string]any{
-			"name": forbiddenTool,
+			"Name": allowedTool,
+			"name": deniedTool,
+			"NAME": allowedTool,
 		},
 	})
 	require.NoError(t, err)
-	require.NotNil(t, resp.Error)
-	require.Equal(t, mcp.INVALID_PARAMS, resp.Error.Code)
-	respJSON = testJSONString(t, resp)
-	require.NotContains(t, respJSON, forbiddenToolTextContent)
-	require.Contains(t, respJSON, "User does not have permissions.")
+	requireDeniedToolResponse(t, testJSON(t, resp))
+	// Verify the request was not forwarded.
+	require.Empty(t, recorder.requests)
+
+	// Verify that when non-canonical capitalized "Name" param is specified and send through
+	// HTTP transport the request is correctly rejected.
+	recorder.Reset()
+	proxyRequest := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{%q:%q,%q:%q,%q:%q,%q:%q}}`,
+		"Name", allowedTool,
+		"NaMe", allowedTool,
+		"name", deniedTool,
+		"NAME", allowedTool,
+	)
+	rawResp := testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), proxyRequest)
+	requireDeniedToolResponse(t, rawResp)
+	// Verify the request was not forwarded.
+	require.Empty(t, recorder.requests)
+
+	// Verify that when non-canonical capitalized "Params" field is specified and send through
+	// HTTP transport the request is correctly rejected.
+	recorder.Reset()
+	proxyRequest = fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":8,"method":"tools/call","Params":{%q:%q}}`,
+		"name", deniedTool,
+	)
+	rawResp = testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), proxyRequest)
+	requireToolNameMissingResponse(t, rawResp)
+	// Verify the request was not forwarded.
+	require.Empty(t, recorder.requests)
+
+	// Verify that when non-canonical capitalized "Method" field is specified and send through
+	// HTTP transport the request is sanitized before forwarding, resulting in a ping message.
+	recorder.Reset()
+	proxyRequest = fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":9,"method":"ping","Method":"tools/call","params":{%q:%q}}`,
+		"name", deniedTool,
+	)
+	expectedForwardedRequest := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":9,"method":"ping","params":{%q:%q}}`,
+		"name", deniedTool,
+	)
+	rawResp = testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), proxyRequest)
+	require.JSONEq(t, `{"jsonrpc":"2.0","id":9,"result":{}}`, string(rawResp))
+	// Verify the request was forwarded as ping.
+	require.Len(t, recorder.requests, 1)
+	forwardedRequest := string(testGetRequestPayload(t, recorder.requests[0]))
+	require.JSONEq(t, expectedForwardedRequest, forwardedRequest)
+	require.Contains(t, proxyRequest, `"Method"`)
+	require.NotContains(t, forwardedRequest, `"Method"`)
+
+	// Verify that when non-canonical capitalized "ID" field is specified and send through HTTP
+	// transport the request is sanitized before forwarding, resulting in a Notification
+	// message.
+	recorder.Reset()
+	proxyRequest = fmt.Sprintf(
+		`{"jsonrpc":"2.0","ID":8,"method":"tools/call","params":{%q:%q}}`, "name", deniedTool,
+	)
+	expectedForwardedRequest = fmt.Sprintf(
+		`{"jsonrpc":"2.0","method":"tools/call","params":{%q:%q}}`, "name", deniedTool,
+	)
+	rawResp = testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), proxyRequest)
+	require.Empty(t, rawResp) // MCP Notification response.
+	// Verify the forwarded request's confusing fields are pruned.
+	require.Len(t, recorder.requests, 1)
+	forwardedRequest = string(testGetRequestPayload(t, recorder.requests[0]))
+	require.JSONEq(t, expectedForwardedRequest, forwardedRequest)
+	require.Contains(t, proxyRequest, `"ID":8`)
+	require.NotContains(t, forwardedRequest, `"ID":8`)
+
+	// Verify multiple non-canonical fields are stripped from a message send over HTTP before
+	// forwarding.
+	recorder.Reset()
+	proxyRequest = fmt.Sprintf(
+		`{"jsonrpc":"2.0","ID":100,"id":9,"Method":"ping","method":"tools/call","Params":{"a":"b"},"params":{%q:%q,%q:%q,%q:%q,%q:%q}}`,
+		"Name", deniedTool,
+		"NaMe", deniedTool,
+		"name", allowedTool,
+		"NAME", deniedTool,
+	)
+	expectedForwardedRequest = fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{%q:%q}}`,
+		"name", allowedTool,
+	)
+	rawResp = testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), proxyRequest)
+	require.Contains(t, string(rawResp), allowedToolTextContent)
+	// Verify the forwarded request's confusing fields are pruned.
+	require.Len(t, recorder.requests, 1)
+	forwardedRequest = string(testGetRequestPayload(t, recorder.requests[0]))
+	require.JSONEq(t, expectedForwardedRequest, forwardedRequest)
+	require.Contains(t, proxyRequest, `"ID":`)
+	require.NotContains(t, forwardedRequest, `"ID"`)
+	require.Contains(t, proxyRequest, `"Method":`)
+	require.NotContains(t, forwardedRequest, `"Method"`)
+	require.Contains(t, proxyRequest, `"Params":`)
+	require.NotContains(t, forwardedRequest, `"Params"`)
 }
 
 func Test_handleAuthErrHTTP(t *testing.T) {

--- a/lib/srv/mcp/http_test.go
+++ b/lib/srv/mcp/http_test.go
@@ -19,6 +19,7 @@
 package mcp
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -94,8 +95,7 @@ func Test_handleStreamableHTTP(t *testing.T) {
 	var wg sync.WaitGroup
 	t.Cleanup(wg.Wait)
 	listener := listenerutils.NewInMemoryListener()
-	require.NoError(t, err)
-	defer listener.Close()
+	t.Cleanup(func() { _ = listener.Close() })
 	go func() {
 		for {
 			conn, err := listener.Accept()
@@ -211,6 +211,117 @@ func Test_handleStreamableHTTP(t *testing.T) {
 		events := emitter.Events()
 		require.Empty(t, events)
 	})
+}
+
+// Test_Server_HandleSession_reject_req_missing_name makes sure requests with missing canonical
+// "name" param are rejected.
+func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	const forbiddenTool = "forbidden_tool"
+	const forbiddenToolTextContent = "FORBIDDEN_TOOL_EXECUTED_ON_UPSTREAM"
+
+	role := newAllowAllDenyForbiddenToolRole(t, forbiddenTool)
+
+	upstream := mcpserver.NewMCPServer("test-server", "1.0.0")
+	upstream.AddTool(
+		mcp.Tool{
+			Name: forbiddenTool,
+		},
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.NewTextContent(forbiddenToolTextContent)},
+			}, nil
+		},
+	)
+
+	emitter, mcpClientTransport := newStreamableMCPServer(t, upstream, role)
+
+	_, err := mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(1),
+		Method:  string(mcp.MethodInitialize),
+		Params: map[string]any{
+			"protocolVersion": mcp.LATEST_PROTOCOL_VERSION,
+			"clientInfo": map[string]any{
+				"name":    "test-client-transport",
+				"version": "1.0.0",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, mcpClientTransport.GetSessionId())
+
+	// Verify it works as expected if the canonical lower-case "name" param is provided.
+	emitter.Reset()
+	resp, err := mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(2),
+		Method:  string(mcp.MethodToolsCall),
+		Params: map[string]any{
+			"name": forbiddenTool,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Error)
+	require.Equal(t, mcp.INVALID_PARAMS, resp.Error.Code)
+	respJSON := testJSONString(t, resp)
+	require.NotContains(t, respJSON, forbiddenToolTextContent)
+	require.Contains(t, respJSON, "User does not have permissions")
+
+	// Verify that when non-canonical capitalized "Name" param is specified the request is
+	// rejected.
+	emitter.Reset()
+	resp, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(3),
+		Method:  string(mcp.MethodToolsCall),
+		Params: map[string]any{
+			"Name": forbiddenTool,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Error)
+	require.Equal(t, mcp.INVALID_REQUEST, resp.Error.Code)
+	respJSON = testJSONString(t, resp)
+	require.NotContains(t, respJSON, forbiddenToolTextContent)
+	require.Contains(t, respJSON, testJSONString(t, errInvalidRequestMissingName.Error()))
+
+	// Verify that when an empty "name" param is specified the request is rejected.
+	emitter.Reset()
+	resp, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(4),
+		Method:  string(mcp.MethodToolsCall),
+		Params: map[string]any{
+			"name": "",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Error)
+	require.Equal(t, mcp.INVALID_REQUEST, resp.Error.Code)
+	respJSON = testJSONString(t, resp)
+	require.NotContains(t, respJSON, forbiddenToolTextContent)
+	require.Contains(t, respJSON, testJSONString(t, errInvalidRequestMissingName.Error()))
+
+	// Verify that correct request is properly unauthorized.
+	emitter.Reset()
+	resp, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(5),
+		Method:  string(mcp.MethodToolsCall),
+		Params: map[string]any{
+			"name": forbiddenTool,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Error)
+	require.Equal(t, mcp.INVALID_PARAMS, resp.Error.Code)
+	respJSON = testJSONString(t, resp)
+	require.NotContains(t, respJSON, forbiddenToolTextContent)
+	require.Contains(t, respJSON, "User does not have permissions.")
 }
 
 func Test_handleAuthErrHTTP(t *testing.T) {

--- a/lib/srv/mcp/sanitize.go
+++ b/lib/srv/mcp/sanitize.go
@@ -1,0 +1,131 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/utils/mcputils"
+)
+
+// sanitizeMCPRequestParams removes all non-canonical "name" (e.g. "Name") from top-level "params"
+// field of the MCP Request message. This is to prevent vulnerable upstream MCP servers and
+// responding to malformed messages. This is a stripped down version of [sanitizeRawMCPRequest] and
+// prevents the same issue.  For mcputils.JSONRPCRequest the blast radius is reduced because
+// JSONRPCRequest.UnmarshalJSON is case-sensitive cutting out the edge cases like capitalized
+// "method", "id" or "params" field.
+func sanitizeMCPRequestParams(r *mcputils.JSONRPCRequest) {
+	deleteNonCanonicalKey(r.Params, mcputils.ParamsNameKey)
+}
+
+// sanitizeRawMCPRequest is an extended version of [sanitizeMCPRequestParams] which works on raw JSON
+// data. It works for both MCP Requests and Notifications and removes all non-canonical fields and
+// parameters which have a potential of confusing the upstream server. The confusion is possible
+// due to non-compliant implementation. One example is usage of the Go builtin "json" package which
+// is case-insensitive.
+//
+// Currently, it handles following cases:
+//
+//  1. Trying to confuse upstream MCP server with, non-canonical "name" parameter. Without this
+//     sanitization Teleport correctly allows the call allowed_tool, but the upstream server may
+//     incorrectly execute the denied_tool if it incorrectly decodes "name" parameter:
+//
+//     {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"Name":"denied_tool","name":"allowed_tool"}}
+//
+//  2. Trying to confuse upstream MCP server with, non-canonical "params" filed. Without this
+//     sanitization Teleport correctly allows the call of allowed_tool, but the upstream server may
+//     incorrectly execute the denied_tool if it incorrectly decodes "params" field:
+//
+//     {"jsonrpc":"2.0","id":1,"method":"tools/call","Params":{"name":"denied_tool"},"params":{"name":"allowed_tool"}}
+//
+//  3. Trying to confuse upstream MCP server with, non-canonical "method" filed. Without this
+//     sanitization Teleport correctly forwards the ping request, but the upstream server may incorrectly
+//     decode it as a tools/call request and execute the denied_tool.
+//
+//     {"jsonrpc":"2.0","id":1,"method":"ping","Method":"tools/call","params":{"name":"denied_tool"}}
+//
+//  4. Trying to confuse upstream MCP server with, non-canonical "id" filed. Without this
+//     sanitization Teleport correctly interprets the message as a notification (messages without
+//     the "id" field are Requests according to the spec), but the upstream server may incorrectly
+//     decode it as a tools/call request and execute the denied_tool.
+//
+//     {"jsonrpc":"2.0","ID":1,"method":"tools/call","params":{"name":"denied_tool"}}
+//
+// It is implemented in a way that prevents corruptions caused by rounding float-precision number
+// or overflowing very large numbers.
+//
+// NOTE: The provided request, can be modified or replaced like in the builtin append function.
+func sanitizeRawMCPRequest(request []byte) ([]byte, error) {
+	if len(request) == 0 {
+		return request, nil
+	}
+
+	// Use json.RawMessage, to not mess with the content, e.g. introduce floating-point
+	// corruption caused by rounding.
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(request, &m); err != nil {
+		return nil, trace.Wrap(err, "unmarshaling MCP Request into a map")
+	}
+
+	// Delete non-canonical "id", "method", "params" top-level message fields.
+	modifiedM := deleteNonCanonicalKey(m, mcputils.IDKey, mcputils.MethodKey, mcputils.ParamsKey)
+
+	var modifiedParams bool
+	if rawParams := m[mcputils.ParamsKey]; len(rawParams) > 0 {
+		var params map[string]json.RawMessage
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return nil, trace.Wrap(err, "unmarshaling MCP Request params into a map")
+		}
+
+		// Delete non-canonical "name" key from "params" field.
+		modifiedParams = deleteNonCanonicalKey(params, mcputils.ParamsNameKey)
+
+		if modifiedParams {
+			var err error
+			m[mcputils.ParamsKey], err = json.Marshal(params)
+			if err != nil {
+				return nil, trace.Wrap(err, "encoding MCP Request params map back into JSON")
+			}
+		}
+	}
+
+	if modifiedM || modifiedParams {
+		var err error
+		request, err = json.Marshal(m)
+		if err != nil {
+			return nil, trace.Wrap(err, "encoding MCP Request map back into JSON")
+		}
+	}
+	return request, nil
+}
+
+func deleteNonCanonicalKey[V any](m map[string]V, canonicalKey ...string) (modified bool) {
+	for k := range m {
+		for _, ck := range canonicalKey {
+			if strings.EqualFold(k, ck) && k != ck {
+				modified = true
+				delete(m, k)
+			}
+		}
+	}
+	return
+}

--- a/lib/srv/mcp/sanitize_test.go
+++ b/lib/srv/mcp/sanitize_test.go
@@ -1,0 +1,67 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test_sanitizeParamsNameRaw_preserves_number_precision verifies that sanitizing raw MCP requests
+// does not round or otherwise rewrite JSON number tokens.
+func Test_sanitizeParamsNameRaw_preserves_number_precision(t *testing.T) {
+	t.Parallel()
+
+	const preciseFloat = `0.123456789012345678901234567890123456789`
+	const bigNumber = `12345678901234567890123456789012345678901234567890`
+
+	request := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"Name":"force_decoding","name":"test-tool","arguments":{"preciseFloat":` + preciseFloat + `,"bigNumber":` + bigNumber + `}}}`)
+
+	// Verify those values cause errors with naive unmarshaling.
+	var m map[string]any
+	err := json.Unmarshal(request, &m)
+	require.NoError(t, err)
+
+	corrupted, err := json.Marshal(m)
+	require.NoError(t, err)
+	require.NotContains(t, string(corrupted), preciseFloat)
+	require.NotContains(t, string(corrupted), bigNumber)
+
+	// Now verify that sanitization does not corrupt.
+	sanitized, err := sanitizeRawMCPRequest(request)
+	require.NoError(t, err)
+
+	require.Contains(t, string(sanitized), preciseFloat)
+	require.Contains(t, string(sanitized), bigNumber)
+}
+
+func Test_sanitizeRawRequest_returns_same_slice_when_unmodified(t *testing.T) {
+	t.Parallel()
+
+	request := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"test_tool"}}`)
+
+	sanitized, err := sanitizeRawMCPRequest(request)
+	require.NoError(t, err)
+
+	require.Equal(t, request, sanitized)
+	require.Same(t, unsafe.SliceData(request), unsafe.SliceData(sanitized))
+}

--- a/lib/srv/mcp/session.go
+++ b/lib/srv/mcp/session.go
@@ -222,12 +222,13 @@ func (s *sessionHandler) onClientNotification(serverRequestWriter mcputils.Messa
 
 func (s *sessionHandler) onClientRequest(clientResponseWriter, serverRequestWriter mcputils.MessageWriter) mcputils.HandleRequestFunc {
 	return func(ctx context.Context, request *mcputils.JSONRPCRequest) error {
-		msg, authErr := s.processClientRequest(ctx, request)
-		s.emitRequestEvent(ctx, request, eventWithError(authErr))
-		if authErr != nil {
-			return trace.Wrap(clientResponseWriter.WriteMessage(ctx, msg))
+		if errMsg := s.processClientRequest(ctx, request); errMsg != nil {
+			// Respond immediately
+			s.emitRequestEvent(ctx, request, eventWithError(toError(*errMsg)))
+			return trace.Wrap(clientResponseWriter.WriteMessage(ctx, *errMsg))
 		}
-		return trace.Wrap(serverRequestWriter.WriteMessage(ctx, msg))
+		s.emitRequestEvent(ctx, request)
+		return trace.Wrap(serverRequestWriter.WriteMessage(ctx, request))
 	}
 }
 
@@ -248,20 +249,25 @@ func (s *sessionHandler) onServerResponse(clientResponseWriter mcputils.MessageW
 	}
 }
 
-func (s *sessionHandler) processClientRequest(ctx context.Context, req *mcputils.JSONRPCRequest) (mcp.JSONRPCMessage, error) {
+func (s *sessionHandler) processClientRequest(ctx context.Context, req *mcputils.JSONRPCRequest) *mcp.JSONRPCError {
 	messagesFromClient.WithLabelValues(s.transport, "request", reportRequestMethod(req.Method)).Inc()
+
+	switch req.Method {
+	case mcputils.MethodToolsCall:
+		toolName, _ := req.Params.GetName()
+		if toolName == "" {
+			return makeInvalidRequestResponse(req, errInvalidRequestMissingName)
+		}
+		if authErr := s.checkAccessToTool(ctx, toolName); authErr != nil {
+			return makeToolAccessDeniedResponse(req, authErr)
+		}
+	}
 
 	// TODO(greedy52) add checks to ensure that the initialize request is the
 	// first request coming in (with the exception of the ping).
 	s.idTracker.PushRequest(req)
-	switch req.Method {
-	case mcputils.MethodToolsCall:
-		methodName, _ := req.Params.GetName()
-		if authErr := s.checkAccessToTool(ctx, methodName); authErr != nil {
-			return makeToolAccessDeniedResponse(req, authErr), trace.Wrap(authErr)
-		}
-	}
-	return req, nil
+
+	return nil
 }
 
 func (s *sessionHandler) processClientNotification(ctx context.Context, notification *mcputils.JSONRPCNotification) {
@@ -331,11 +337,36 @@ func (s *sessionHandler) rewriteHTTPRequestHeaders(r *http.Request) error {
 	return nil
 }
 
-func makeToolAccessDeniedResponse(msg *mcputils.JSONRPCRequest, authErr error) mcp.JSONRPCMessage {
-	return mcp.NewJSONRPCError(
-		msg.ID,
+var errInvalidRequestMissingName = &trace.BadParameterError{Message: `"name" parameter missing`}
+
+func makeInvalidRequestResponse(req *mcputils.JSONRPCRequest, err error) *mcp.JSONRPCError {
+	r := mcp.NewJSONRPCError(
+		req.ID,
+		mcp.INVALID_REQUEST,
+		"Teleport did not forward an invalid Request object.",
+		err,
+	)
+	return &r
+}
+
+func makeToolAccessDeniedResponse(req *mcputils.JSONRPCRequest, authErr error) *mcp.JSONRPCError {
+	r := mcp.NewJSONRPCError(
+		req.ID,
 		mcp.INVALID_PARAMS,
 		"RBAC is enforced by your Teleport roles. Contact your Teleport Admin for more details.",
 		authErr,
 	)
+	return &r
+}
+
+func toError(e mcp.JSONRPCError) error {
+	// If the data holds an underlying error, replace the message with that, before
+	// constructing the final error. In that case the Message should be a high-level
+	// user-facing error. Otherwise fall back to the original message.
+	if e.Error.Data != nil {
+		if dataErr, ok := e.Error.Data.(error); ok {
+			e.Error.Message = dataErr.Error()
+		}
+	}
+	return e.Error.AsError()
 }

--- a/lib/srv/mcp/session.go
+++ b/lib/srv/mcp/session.go
@@ -222,7 +222,9 @@ func (s *sessionHandler) onClientNotification(serverRequestWriter mcputils.Messa
 
 func (s *sessionHandler) onClientRequest(clientResponseWriter, serverRequestWriter mcputils.MessageWriter) mcputils.HandleRequestFunc {
 	return func(ctx context.Context, request *mcputils.JSONRPCRequest) error {
-		if errMsg := s.processClientRequest(ctx, request); errMsg != nil {
+		sanitizeMCPRequestParams(request)
+		errMsg := s.processClientRequest(ctx, request)
+		if errMsg != nil {
 			// Respond immediately
 			s.emitRequestEvent(ctx, request, eventWithError(toError(*errMsg)))
 			return trace.Wrap(clientResponseWriter.WriteMessage(ctx, *errMsg))
@@ -270,7 +272,7 @@ func (s *sessionHandler) processClientRequest(ctx context.Context, req *mcputils
 	return nil
 }
 
-func (s *sessionHandler) processClientNotification(ctx context.Context, notification *mcputils.JSONRPCNotification) {
+func (s *sessionHandler) processClientNotification(_ context.Context, notification *mcputils.JSONRPCNotification) {
 	messagesFromClient.WithLabelValues(s.transport, "notification", reportNotificationMethod(notification.Method)).Inc()
 }
 

--- a/lib/srv/mcp/session_test.go
+++ b/lib/srv/mcp/session_test.go
@@ -20,6 +20,7 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"sync"
 	"testing"
@@ -161,6 +162,39 @@ func Test_sessionHandler(t *testing.T) {
 					require.Len(t, clientMessages, 1)
 					require.IsType(t, mcp.JSONRPCError{}, clientMessages[0])
 				})
+			}
+
+			for _, allowedTool := range tt.allowedTools {
+				for _, deniedTool := range tt.deniedTools {
+					t.Run(fmt.Sprintf("deny %q tool while allowed tool %q is passed with a non-canonical name param", deniedTool, allowedTool), func(t *testing.T) {
+						clientReq := requestBuilder.makeToolsCallRequest(deniedTool)
+						clientReq.Params["Name"] = allowedTool
+						clientReq.Params["NaMe"] = allowedTool
+						clientReq.Params["NAME"] = allowedTool
+						clientCapture := &captureMessageWriter{}
+						serverCapture := &captureMessageWriter{}
+						require.NoError(t, handler.onClientRequest(clientCapture, serverCapture)(ctx, clientReq))
+
+						event := mockEmitter.LastEvent()
+						require.NotNil(t, event)
+						requestEvent, ok := event.(*apievents.MCPSessionRequest)
+						require.True(t, ok)
+						require.False(t, requestEvent.Success)
+						require.Equal(t, mcputils.MethodToolsCall, requestEvent.Message.Method)
+						// Verify there is only 1 param and it's "name" and
+						// all other non-lower-case name params are removed
+						// from the request.
+						require.Len(t, requestEvent.Message.Params.Fields, 1)
+						require.Equal(t, deniedTool, requestEvent.Message.Params.Fields["name"].GetStringValue(), 1)
+
+						// Server does not receive the client's request. An error is
+						// sent to client.
+						require.Empty(t, serverCapture.messages())
+						clientMessages := clientCapture.messages()
+						require.Len(t, clientMessages, 1)
+						require.IsType(t, mcp.JSONRPCError{}, clientMessages[0])
+					})
+				}
 			}
 
 			t.Run("tools list", func(t *testing.T) {

--- a/lib/srv/mcp/session_test.go
+++ b/lib/srv/mcp/session_test.go
@@ -168,8 +168,8 @@ func Test_sessionHandler(t *testing.T) {
 
 				// First make a request so the handler can track the method by ID.
 				clientReq := requestBuilder.makeToolsListRequest()
-				_, authErr := handler.processClientRequest(ctx, clientReq)
-				require.NoError(t, authErr)
+				respErr := handler.processClientRequest(ctx, clientReq)
+				require.Nil(t, respErr)
 
 				// tools/list does not trigger audit event.
 				require.Nil(t, mockEmitter.LastEvent())

--- a/lib/utils/http.go
+++ b/lib/utils/http.go
@@ -42,8 +42,6 @@ func GetAndReplaceRequestBody(req *http.Request) ([]byte, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	// Replace the drained body with io.NopCloser reader allowing for further request processing by HTTP transport.
 	req.Body = io.NopCloser(bytes.NewReader(payload))
 	return payload, nil
 }
@@ -69,18 +67,28 @@ func GetAndReplaceResponseBody(response *http.Response) ([]byte, error) {
 
 // ReplaceRequestBody drains the old request body and replaces it with a new one.
 func ReplaceRequestBody(req *http.Request, newBody io.ReadCloser) error {
-	if req.Body != nil {
-		defer req.Body.Close()
-		// drain and discard the request body to allow connection reuse.
-		// No need to enforce a max request size, nor rely on callers to do so,
-		// since we do not buffer the entire request body.
-		_, err := io.Copy(io.Discard, req.Body)
-		if err != nil && !errors.Is(err, io.EOF) {
-			return trace.Wrap(err)
-		}
+	if err := drainAndCloseRequestBody(req); err != nil {
+		return trace.Wrap(err)
 	}
 	req.Body = newBody
 	return nil
+}
+
+// OverwriteRequestBody (over)writes the new data into the given request's body. It attempts to to
+// drain close the request body it overwrites.
+func OverwriteRequestBody(req *http.Request, data []byte) error {
+	if err := drainAndCloseRequestBody(req); err != nil {
+		return trace.Wrap(err)
+	}
+	OverwriteRequestBodyNoDrain(req, data)
+	return nil
+}
+
+// OverwriteRequestBodyNoDrain (over)writes the new data into the given request's body. It does not
+// close or drain the request body it overwrites.
+func OverwriteRequestBodyNoDrain(req *http.Request, data []byte) {
+	req.Body = io.NopCloser(bytes.NewReader(data))
+	req.ContentLength = int64(len(data))
 }
 
 // RenameHeader moves all values from the old header key to the new header key.
@@ -123,6 +131,18 @@ func GetSingleHeader(headers http.Header, key string) (string, error) {
 	} else {
 		return values[0], nil
 	}
+}
+
+func drainAndCloseRequestBody(req *http.Request) error {
+	if req.Body != nil {
+		defer req.Body.Close()
+		// drain and discard the request body to allow connection reuse.
+		_, err := io.Copy(io.Discard, req.Body)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
 }
 
 // HTTPDoClient is an interface that defines the Do function of http.Client.

--- a/lib/utils/mcputils/id_tracker.go
+++ b/lib/utils/mcputils/id_tracker.go
@@ -47,14 +47,13 @@ func NewIDTracker(size int) (*IDTracker, error) {
 
 // PushRequest tracks a request. Returns true if the request has been added to
 // cache.
-func (t *IDTracker) PushRequest(msg *JSONRPCRequest) bool {
+func (t *IDTracker) PushRequest(msg *JSONRPCRequest) {
 	if msg == nil || msg.ID.IsNil() || msg.Method == "" {
-		return false
+		return
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.lruCache.Add(msg.ID, msg.Method)
-	return true
 }
 
 // PopByID retrieves the tracked information and remove it from the tracker.

--- a/lib/utils/mcputils/id_tracker_test.go
+++ b/lib/utils/mcputils/id_tracker_test.go
@@ -33,17 +33,17 @@ func TestIDTracker(t *testing.T) {
 	require.Empty(t, tracker.Len())
 
 	t.Run("request missing ID not tracked", func(t *testing.T) {
-		require.False(t, tracker.PushRequest(&JSONRPCRequest{
+		tracker.PushRequest(&JSONRPCRequest{
 			Method: "bad",
-		}))
+		})
 		require.Empty(t, tracker.Len())
 	})
 
 	t.Run("request tracked", func(t *testing.T) {
-		require.True(t, tracker.PushRequest(&JSONRPCRequest{
+		tracker.PushRequest(&JSONRPCRequest{
 			ID:     mcp.NewRequestId(0),
 			Method: MethodToolsList,
-		}))
+		})
 		require.Equal(t, 1, tracker.Len())
 	})
 

--- a/lib/utils/mcputils/protocol.go
+++ b/lib/utils/mcputils/protocol.go
@@ -28,6 +28,13 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 )
 
+const (
+	IDKey         = "id"
+	MethodKey     = "method"
+	ParamsKey     = "params"
+	ParamsNameKey = "name"
+)
+
 // Type definitions from both mcp-go/client/transport or mcp-go are not suitable
 // for our reverse proxy use, thus this file redefines them.
 //
@@ -53,7 +60,7 @@ func (p JSONRPCParams) GetName() (string, bool) {
 	if p == nil {
 		return "", false
 	}
-	name, ok := p["name"].(string)
+	name, ok := p[ParamsNameKey].(string)
 	return name, ok
 }
 


### PR DESCRIPTION
Backport #66989 and #67262 to branch/v18

Changelog: MCP: Forwarded MCP messages are now stripped down from non-canonical fields, e.g. "ID", "Params" or "params.Name". This is to protect to bypassing RBAC check for upstream servers which may incorrectly accept non-canonical JSON-RPC message fields.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan

### Test Environment

- Upstream MCP server printing incoming requests with 3 different transports: streamable-HTTP, SSE, stdio
- Connection to the upstream MCP server is done with `tsh mcp connect $NAME`

### Test Cases

- [x] For streamable-HTTP transport
   - [x] Verify the server responds to a normal initialization flow and tools/list call
   - [x] Verify the server responds to a tools/call for an RBAC-allowed tool
   - [x] Verify the tools/call request is not forwarded to the upstream MCP server for RBAC-denied tool
   - [x] Verify an extra "Name" parameter is removed from the forwarded request
   - [x] Verify an extra "Method" field is removed from the forwarded request
   - [x] Verify an extra "Params" field is removed from the forwarded request
   - [x] Verify an extra "ID" field is removed from the forwarded request
 - [x] Do the same for SSE transport
 - [x] Do the same for stdio transport

