### PR TITLE
Add missing test for CheckConditionalAccess.

### DIFF
--- a/lib/services/access_checker_test.go
+++ b/lib/services/access_checker_test.go
@@ -744,7 +744,7 @@ func TestAccessChecker_CheckConditionalAccess_StateMFANever_ReturnsNoMFAPrecondi
 }
 
 // TODO(cthach): Remove in v20.0 when the legacy out-of-band MFA flow is removed.
-func TestAccessChecker_CheckConditionalAccess_StateMFAAlways_MFAVerified_ReturnsNoMFAPrecondition(t *testing.T) {
+func TestAccessChecker_CheckConditionalAccess_MFAVerifiedPreconditions(t *testing.T) {
 	t.Parallel()
 
 	const roleName = "allow-all-nodes"

--- a/lib/services/access_checker_test.go
+++ b/lib/services/access_checker_test.go
@@ -743,6 +743,52 @@ func TestAccessChecker_CheckConditionalAccess_StateMFANever_ReturnsNoMFAPrecondi
 	)
 }
 
+// TODO(cthach): Remove in v20.0 when the legacy out-of-band MFA flow is removed.
+func TestAccessChecker_CheckConditionalAccess_StateMFAAlways_MFAVerified_ReturnsNoMFAPrecondition(t *testing.T) {
+	t.Parallel()
+
+	const roleName = "allow-all-nodes"
+
+	roleSet := NewRoleSet(newRole(func(r *types.RoleV6) {
+		r.SetName(roleName)
+	}))
+
+	accessInfo := &AccessInfo{
+		Roles: []string{roleName},
+	}
+
+	accessChecker := NewAccessCheckerWithRoleSet(accessInfo, "cluster", roleSet)
+
+	srv, err := types.NewServer(
+		"test-server",
+		types.KindNode,
+		types.ServerSpecV2{},
+	)
+	require.NoError(t, err)
+
+	node := &serverStub{Server: srv}
+
+	preconds, err := accessChecker.CheckConditionalAccess(
+		node,
+		AccessState{
+			MFARequired:         MFARequiredAlways, // MFA is always required.
+			MFAVerified:         true,              // MFA has been verified via legacy out-of-band MFA flow.
+			ReturnPreconditions: true,
+		},
+	)
+	require.NoError(t, err)
+	require.False(
+		t,
+		slices.ContainsFunc(
+			preconds,
+			func(p *decisionpb.Precondition) bool {
+				return p.GetKind() == decisionpb.PreconditionKind_PRECONDITION_KIND_IN_BAND_MFA
+			},
+		),
+		"got preconditions: %v, expected PreconditionKind_PRECONDITION_KIND_IN_BAND_MFA to NOT be included", preconds,
+	)
+}
+
 func TestAccessChecker_CheckConditionalAccess_StateMFAAlways_ReturnsMFAPrecondition(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Found test gap while working on [RFD 314](https://github.com/gravitational/teleport/issues/67919).

This test exercises the scenario when a legacy per-session MFA cert is used during the [transition period](https://github.com/gravitational/rfd/blob/main/rfd/0314-in-band-mfa-desktop.md#transition-period) and MFA is required for access. In this case, `CheckConditionalAccess` should NOT return an MFA required precondition.