### PR TITLE
gha: Docs Preview - stop using secrets context

### DIFF
--- a/.github/workflows/docs-amplify.yaml
+++ b/.github/workflows/docs-amplify.yaml
@@ -24,21 +24,21 @@ jobs:
         cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
         existing-gh-secrets: "${{ toJSON(secrets) }}"
         existing-gh-variables: "${{ toJSON(vars) }}"
-        # values: |
-        #   AMPLIFY_APP_IDS,variable
-        #   IAM_ROLE,variable
+        values: |
+          AMPLIFY_APP_IDS,variable
+          IAM_ROLE,variable
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v4
       with:
         aws-region: us-west-2
-        role-to-assume: ${{ vars.IAM_ROLE }}
+        role-to-assume: ${{ env.IAM_ROLE }}
 
     - name: Create Amplify preview environment
       uses: gravitational/shared-workflows/tools/amplify-preview@b90d744feb39522329fba9c7764a4fe07d039d29 # tools/amplify-preview/v0.0.3
       id: amplify_preview
       with:
-        app_ids: ${{ vars.AMPLIFY_APP_IDS }}
+        app_ids: ${{ env.AMPLIFY_APP_IDS }}
         create_branches: "true"
         github_token: ${{ secrets.GITHUB_TOKEN }}
         wait: "true"

--- a/.github/workflows/update-docs-webhook.yaml
+++ b/.github/workflows/update-docs-webhook.yaml
@@ -30,11 +30,11 @@ jobs:
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
           existing-gh-secrets: "${{ toJSON(secrets) }}"
           existing-gh-variables: "${{ toJSON(vars) }}"
-          # values: |
-          #   AMPLIFY_DOCS_DEPLOY_HOOK,secret
+          values: |
+            AMPLIFY_DOCS_DEPLOY_HOOK,secret
       - name: Call deployment webhook
         env:
-          WEBHOOK_URL: ${{ secrets.AMPLIFY_DOCS_DEPLOY_HOOK }}
+          WEBHOOK_URL: ${{ env.AMPLIFY_DOCS_DEPLOY_HOOK }}
         run: |
           if curl -X POST --silent --fail --show-error "$WEBHOOK_URL" > /dev/null; then
             echo "Triggered successfully"


### PR DESCRIPTION
Contributes to https://github.com/gravitational/cloud/issues/14222
Follow up from https://github.com/gravitational/teleport/pull/68046

This PR replaces the use of GHA `secrets` context with runtime values loaded to environment variables in the `kvstore` step.

Similar to https://github.com/gravitational/teleport/pull/68450, but the change in that PR doesn't appear to actually use the values for any purpose.