### PR TITLE
MCP: Fix http test case

### DIFF
--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -58,7 +58,7 @@ import (
 // It allows to make the entire cluster set up once, instead of per test,
 // which speeds things up significantly.
 func TestAppAccess(t *testing.T) {
-	sseServer := httptest.NewTLSServer(mcpserver.NewSSEServer(mcptest.NewServer()))
+	sseServer := httptest.NewServer(mcpserver.NewSSEServer(mcptest.NewServer()))
 	sseServerURL := "mcp+sse+" + sseServer.URL + "/sse"
 	t.Cleanup(sseServer.Close)
 


### PR DESCRIPTION
It was a copy/paste error.

The TLS case is defined below:

```
sseTLSServer := httptest.NewTLSServer(mcpserver.NewSSEServer(mcptest.NewServer()))
```

## Backports

- https://github.com/gravitational/teleport/pull/68058