### PR TITLE
kube: detect kubectl bypassing the local proxy in tsh proxy kube --exec

### DIFF
--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -835,6 +835,15 @@ func isNetworkError(err error) bool {
 
 func (c *kubeCredentialsCommand) checkLocalProxyRequirement(profile *profile.Profile) error {
 	if profile.RequireKubeLocalProxy() || profile.PrivateKeyPolicy.IsHardwareKeyPolicy() {
+		// If we're inside an active `tsh proxy kube --exec` shell.
+		// Reaching this exec plugin means a Kubernetes client bypassed the local proxy,
+		// typically because KUBECONFIG was overridden (e.g. by a shell startup file).
+		// Point the user at the fix instead of the generic message.
+		if sessionKubeconfig := os.Getenv(kubeLocalProxyEnvVar); sessionKubeconfig != "" {
+			return trace.BadParameter(`this Kubernetes client invoked "tsh kube credentials" from inside an active "tsh proxy kube" session, bypassing the local proxy.
+Your KUBECONFIG no longer points at the session config, usually because a shell startup file or another tool overrode it.
+Run 'export KUBECONFIG=%s' to use the local proxy, or check your shell configuration.`, sessionKubeconfig)
+		}
 		return trace.BadParameter("Cannot connect Kubernetes clients to Teleport Proxy directly. Please use `tsh proxy kube` or `tsh kubectl` instead.")
 	}
 	return nil

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -48,6 +48,10 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+// kubeLocalProxyEnvVar marks a shell started by `tsh proxy kube --exec` as a
+// live local-proxy session. Its value is the KUBECONFIG path the session set.
+const kubeLocalProxyEnvVar = "TELEPORT_KUBE_LOCAL_PROXY"
+
 type proxyKubeCommand struct {
 	*kingpin.CmdClause
 	kubeClusters        []string

--- a/tool/tsh/common/kube_proxy_darwin.go
+++ b/tool/tsh/common/kube_proxy_darwin.go
@@ -52,7 +52,12 @@ func reexecToShell(ctx context.Context, kubeconfigData []byte, command string, a
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	// Set KUBECONFIG in the environment. Even if it was already set, we override it.
-	cmd.Env = append(os.Environ(), fmt.Sprintf("%s=%s", teleport.EnvKubeConfig, f.Name()))
+	// Also mark the shell as a live local-proxy session so `tsh kube credentials`
+	// can detect a Kubernetes client that bypasses the local proxy.
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("%s=%s", teleport.EnvKubeConfig, f.Name()),
+		fmt.Sprintf("%s=%s", kubeLocalProxyEnvVar, f.Name()),
+	)
 
 	if err := cmd.Start(); err != nil {
 		return trace.Wrap(err)

--- a/tool/tsh/common/kube_proxy_linux.go
+++ b/tool/tsh/common/kube_proxy_linux.go
@@ -84,7 +84,12 @@ func reexecToShell(ctx context.Context, kubeconfigData []byte, command string, a
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	// Set KUBECONFIG in the environment. Even if it was already set, we override it.
-	cmd.Env = append(os.Environ(), fmt.Sprintf("%s=%s", teleport.EnvKubeConfig, "/proc/self/fd/3"))
+	// Also mark the shell as a live local-proxy session so `tsh kube credentials`
+	// can detect a Kubernetes client that bypasses the local proxy.
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("%s=%s", teleport.EnvKubeConfig, "/proc/self/fd/3"),
+		fmt.Sprintf("%s=%s", kubeLocalProxyEnvVar, "/proc/self/fd/3"),
+	)
 	// Pass the file descriptor to the child process as an extra file
 	// descriptor. It will be available as fd 3 in "/proc/self/fd/3".
 	cmd.ExtraFiles = []*os.File{f}

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -844,3 +844,32 @@ func Test_kubeCredentialsCommand_checkLocalProxyRequirement(t *testing.T) {
 		})
 	}
 }
+
+// Test_kubeCredentialsCommand_checkLocalProxyRequirement_inLocalProxyShell
+// covers the case where credentials are requested from inside an active
+// `tsh proxy kube --exec` shell (kubeLocalProxyEnvVar set).
+func Test_kubeCredentialsCommand_checkLocalProxyRequirement_inLocalProxyShell(t *testing.T) {
+	const sessionKubeconfig = "/tmp/proxy-kubeconfig-123"
+	t.Setenv(kubeLocalProxyEnvVar, sessionKubeconfig)
+	c := &kubeCredentialsCommand{}
+
+	t.Run("hardware key -> session-specific error", func(t *testing.T) {
+		err := c.checkLocalProxyRequirement(&profile.Profile{
+			PrivateKeyPolicy: keys.PrivateKeyPolicyHardwareKeyTouch,
+		})
+		require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
+		require.ErrorContains(t, err, "tsh proxy kube")
+		// The error points the user at the session's kubeconfig path.
+		require.ErrorContains(t, err, sessionKubeconfig)
+	})
+
+	t.Run("software key -> no error even inside a session", func(t *testing.T) {
+		// A software key can be served by the exec plugin, so being inside a
+		// local proxy shell must not break it (no regression).
+		err := c.checkLocalProxyRequirement(&profile.Profile{
+			WebProxyAddr:  "example.com:443",
+			KubeProxyAddr: "example.com:3026",
+		})
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
`tsh proxy kube --exec` marks its shell with `TELEPORT_KUBE_LOCAL_PROXY`.
If `tsh kube credentials` runs inside that shell,
a client bypassed the local proxy (KUBECONFIG was overridden),
so it returns an actionable error instead of `cannot get software key PEM`.

Follow-up to #68199.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Improved the error `tsh kube credentials` returns when a Kubernetes client bypasses the `tsh proxy kube` local proxy due to an overridden KUBECONFIG.

## Manual Test Plan
### Test Environment

Kind cluster, multiplex mode, `require_session_mfa: hardware_key_touch`, YubiKey.

### Test Cases
- [x] Inside `tsh proxy kube --exec` with KUBECONFIG shadowed, `kubectl get pods` returns the actionable error (before: `cannot get software key PEM`).
- [x] Without overriding `KUBECONFIG` (using the config `--exec` generated), `kubectl get pods` still works through the local proxy; the detector does not false-fire on the normal flow.
