### PR TITLE
kube: fold hardware-key policy into RequireKubeLocalProxy

### DIFF
--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -200,7 +200,13 @@ func (p *Profile) TLSCert() ([]byte, error) {
 // RequireKubeLocalProxy returns true if this profile indicates a local proxy
 // is required for kube access.
 func (p *Profile) RequireKubeLocalProxy() bool {
-	return p.KubeProxyAddr == p.WebProxyAddr && p.TLSRoutingConnUpgradeRequired
+	if p.PrivateKeyPolicy.IsHardwareKeyPolicy() {
+		return true
+	}
+	if p.KubeProxyAddr != p.WebProxyAddr {
+		return false
+	}
+	return p.TLSRoutingConnUpgradeRequired
 }
 
 func certPoolFromProfile(p *Profile) (*x509.CertPool, error) {

--- a/api/profile/profile_test.go
+++ b/api/profile/profile_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/profile"
+	"github.com/gravitational/teleport/api/utils/keys"
 )
 
 // TestProfileBasics verifies basic profile operations such as
@@ -167,6 +168,17 @@ func TestRequireKubeLocalProxy(t *testing.T) {
 				KubeProxyAddr:                 "example.com:443",
 				TLSRoutingEnabled:             true,
 				TLSRoutingConnUpgradeRequired: true,
+			},
+			checkResult: require.True,
+		},
+		{
+			// A hardware-key policy requires the local proxy even without a TLS
+			// routing connection upgrade (the exec-plugin path can't serialize the key).
+			name: "hardware key policy requires local proxy",
+			inputProfile: &profile.Profile{
+				WebProxyAddr:     "example.com:443",
+				KubeProxyAddr:    "example.com:3026",
+				PrivateKeyPolicy: keys.PrivateKeyPolicyHardwareKeyTouch,
 			},
 			checkResult: require.True,
 		},

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -834,7 +834,7 @@ func isNetworkError(err error) bool {
 }
 
 func (c *kubeCredentialsCommand) checkLocalProxyRequirement(profile *profile.Profile) error {
-	if profile.RequireKubeLocalProxy() || profile.PrivateKeyPolicy.IsHardwareKeyPolicy() {
+	if profile.RequireKubeLocalProxy() {
 		// If we're inside an active `tsh proxy kube --exec` shell.
 		// Reaching this exec plugin means a Kubernetes client bypassed the local proxy,
 		// typically because KUBECONFIG was overridden (e.g. by a shell startup file).
@@ -1442,7 +1442,7 @@ func matchClustersByNameOrDiscoveredName(name string, clusters types.KubeCluster
 
 func (c *kubeLoginCommand) printUserMessage(cf *CLIConf, tc *client.TeleportClient, names []string) {
 	if tc.Profile().RequireKubeLocalProxy() {
-		c.printLocalProxyUserMessage(cf, names)
+		c.printLocalProxyUserMessage(cf, names, tc.Profile().PrivateKeyPolicy.IsHardwareKeyPolicy())
 		return
 	}
 
@@ -1460,7 +1460,7 @@ Select a context and try 'kubectl version' to test the connection.
 	}
 }
 
-func (c *kubeLoginCommand) printLocalProxyUserMessage(cf *CLIConf, names []string) {
+func (c *kubeLoginCommand) printLocalProxyUserMessage(cf *CLIConf, names []string, hardwareKey bool) {
 	switch {
 	case c.kubeCluster != "":
 		fmt.Fprintf(cf.Stdout(), `Logged into Kubernetes cluster %q.`, c.kubeCluster)
@@ -1469,6 +1469,22 @@ func (c *kubeLoginCommand) printLocalProxyUserMessage(cf *CLIConf, names []strin
 %v`, strings.Join(names, "\n"))
 	case c.all:
 		fmt.Fprintf(cf.Stdout(), "Logged into all Kubernetes clusters available.")
+	}
+
+	if hardwareKey {
+		fmt.Fprintf(cf.Stdout(), `
+
+This cluster requires a hardware-backed private key, which native Kubernetes
+clients cannot use directly, so Kubernetes access must go through a local proxy.
+
+To access the cluster, use "tsh kubectl" to run the Kubernetes client:
+  tsh kubectl version
+
+Or, start a local proxy with "tsh proxy kube" and use the kubeconfig it provides
+with your native Kubernetes clients:
+  tsh proxy kube -p 8443
+`)
+		return
 	}
 
 	fmt.Fprintf(cf.Stdout(), `

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -1480,9 +1480,9 @@ clients cannot use directly, so Kubernetes access must go through a local proxy.
 To access the cluster, use "tsh kubectl" to run the Kubernetes client:
   tsh kubectl version
 
-Or, start a local proxy with "tsh proxy kube" and use the kubeconfig it provides
-with your native Kubernetes clients:
-  tsh proxy kube -p 8443
+Or start a local proxy and drop into a shell where native Kubernetes clients are
+ready to use, so you can re-run the same command:
+  tsh proxy kube --exec
 `)
 		return
 	}

--- a/tool/tsh/common/kubectl.go
+++ b/tool/tsh/common/kubectl.go
@@ -496,13 +496,7 @@ func shouldUseKubeLocalProxy(cf *CLIConf, kubectlArgs []string) (*clientcmdapi.C
 	// only a little wasteful to spin up a local proxy it's fine for now, but if
 	// we rework the flow we should add a way to skip the local proxy when using
 	// a relay even if a connection through the control plane would require it
-	//
-	// A hardware-key policy also requires the local proxy: the exec-plugin
-	// credentials path can't serialize a hardware-backed key, whereas the local
-	// proxy uses it as an in-process signer and hands kubectl a fresh software
-	// key. Without this, `tsh kubectl` falls through to the exec plugin and
-	// fails with "cannot get software key PEM".
-	if !profile.RequireKubeLocalProxy() && !profile.PrivateKeyPolicy.IsHardwareKeyPolicy() {
+	if !profile.RequireKubeLocalProxy() {
 		return nil, nil, false
 	}
 


### PR DESCRIPTION
`RequireKubeLocalProxy()` now returns true for hardware-key policies (the exec-plugin credentials path can't serialize a hardware-backed key). This unifies the check that `tsh kubectl` and `tsh kube credentials` previously OR'd inline, and lets `tsh kube login` show a hardware-key-specific message instead of the "layer 7 load balancer" one.

Refactor on top of #68512. Stacked; base retargets to master once #68512 merges.

Changelog: Improved the `tsh kube login` message for clusters that require a hardware key.

## Manual Test Plan
### Test Environment

Kind cluster, multiplex mode, `require_session_mfa: hardware_key_touch`, YubiKey.

### Test Cases
- [x] `tsh kube login` on a hardware-key cluster prints the hardware-key local-proxy message (not "Try kubectl version" or the layer-7 text).
- [x] `tsh kubectl get pods` works via the local proxy.