### PR TITLE
Add OpenAI Responses API handler

### DIFF
--- a/lib/srv/app/llm/anthropic/anthropic.go
+++ b/lib/srv/app/llm/anthropic/anthropic.go
@@ -189,7 +189,7 @@ func marshalError(apiErr *errorEnvelope) []byte {
 	enc, err := utils.FastMarshal(apiErr)
 	if err != nil {
 		return []byte(
-			`{"type": "error", "error": {"type": "api_error", "message": "` + llmerrors.ErrUnknown.Error() + `"}}`,
+			`{"type": "error", "error": {"type": "api_error", "message": ` + llmerrors.MarshalMessage(llmerrors.ErrUnknown) + `}}`,
 		)
 	}
 	return enc

--- a/lib/srv/app/llm/anthropic/anthropic.go
+++ b/lib/srv/app/llm/anthropic/anthropic.go
@@ -37,7 +37,7 @@ import (
 
 // NewRequest creates a new provider request based on the downstream request,
 // and inference endpoint configuration.
-func NewRequest(cfg *llmrequest.Config) (*http.Request, *RequestInfo, error) {
+func NewRequest(cfg *llmrequest.Config) (*http.Request, llmrequest.RequestInfo, error) {
 	var (
 		info            = &RequestInfo{}
 		providerPath    string

--- a/lib/srv/app/llm/errors/errors.go
+++ b/lib/srv/app/llm/errors/errors.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
 )
 
@@ -93,4 +94,20 @@ func StatusCodeFromErr(err error) int {
 	default:
 		return trace.ErrorToCode(err)
 	}
+}
+
+// MarshalMessage marshals an error into JSON format. This function might return
+// empty.
+//
+// Callers can safely interpolate the result of this function with JSON strings.
+func MarshalMessage(err error) string {
+	if err == nil {
+		return `""`
+	}
+
+	if enc, err := utils.FastMarshal(err.Error()); err == nil {
+		return string(enc)
+	}
+
+	return `""`
 }

--- a/lib/srv/app/llm/errors/errors.go
+++ b/lib/srv/app/llm/errors/errors.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 var (

--- a/lib/srv/app/llm/errors/errors_test.go
+++ b/lib/srv/app/llm/errors/errors_test.go
@@ -20,8 +20,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 func TestMarshalMessage(t *testing.T) {
@@ -40,8 +41,8 @@ func TestMarshalMessage(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			res := MarshalMessage(tc.in)
-			require.True(t, strings.HasPrefix(res, "\""), "expected result to include surounding \"")
-			require.True(t, strings.HasSuffix(res, "\""), "expected result to include surounding \"")
+			require.True(t, strings.HasPrefix(res, "\""), "expected result to include surrounding \"")
+			require.True(t, strings.HasSuffix(res, "\""), "expected result to include surrounding \"")
 
 			var decRes string
 			require.NoError(t, utils.FastUnmarshal([]byte(res), &decRes))

--- a/lib/srv/app/llm/errors/errors_test.go
+++ b/lib/srv/app/llm/errors/errors_test.go
@@ -1,0 +1,51 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package errors
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalMessage(t *testing.T) {
+	for name, tc := range map[string]struct {
+		in       error
+		expected string
+	}{
+		"error message": {
+			in:       ErrUnknown,
+			expected: ErrUnknown.Error(),
+		},
+		"nil error": {
+			in:       nil,
+			expected: "",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			res := MarshalMessage(tc.in)
+			require.True(t, strings.HasPrefix(res, "\""), "expected result to include surounding \"")
+			require.True(t, strings.HasSuffix(res, "\""), "expected result to include surounding \"")
+
+			var decRes string
+			require.NoError(t, utils.FastUnmarshal([]byte(res), &decRes))
+			require.Equal(t, tc.expected, decRes)
+		})
+	}
+}

--- a/lib/srv/app/llm/handler.go
+++ b/lib/srv/app/llm/handler.go
@@ -48,9 +48,9 @@ type Handler struct {
 	metrics      *llmMetrics
 
 	anthropicProviderURL *url.URL
-	anthropicApiKey      string
+	anthropicAPIKey      string
 	openAIProviderURL    *url.URL
-	openAIApiKey         string
+	openAIAPIKey         string
 }
 
 // HandlerConfig configures dependencies for the LLM proxy handler.
@@ -108,8 +108,8 @@ func NewHandler(ctx context.Context, cfg HandlerConfig) (*Handler, error) {
 		metrics:      m,
 		// Not much validation can be applied here since some providers might
 		// not require an actual API key.
-		anthropicApiKey: os.Getenv(anthropicApiKeyEnvVarName),
-		openAIApiKey:    os.Getenv(openAIApiKeyEnvVarName),
+		anthropicAPIKey: os.Getenv(anthropicAPIKeyEnvVarName),
+		openAIAPIKey:    os.Getenv(openAIAPIKeyEnvVarName),
 	}
 
 	// It ok to leave this value as `nil`, the value receivers must implement a
@@ -172,7 +172,7 @@ func (h *Handler) serveHTTP(w http.ResponseWriter, r *http.Request) error {
 					DownstreamRequest: r,
 					ProviderURL:       h.anthropicProviderURL,
 					GetAPIKeyFunc: func() string {
-						return h.anthropicApiKey
+						return h.anthropicAPIKey
 					},
 					SignBedrockRequest: h.signBedrockRequest,
 				})
@@ -191,7 +191,7 @@ func (h *Handler) serveHTTP(w http.ResponseWriter, r *http.Request) error {
 					DownstreamRequest: r,
 					ProviderURL:       h.openAIProviderURL,
 					GetAPIKeyFunc: func() string {
-						return h.openAIApiKey
+						return h.openAIAPIKey
 					},
 				})
 			},
@@ -372,15 +372,15 @@ const (
 	//
 	// https://code.claude.com/docs/en/env-vars#variables
 	anthropicAddressEnvVarName = "ANTHROPIC_BASE_URL"
-	// anthropicApiKeyEnvVarName is the Anthropic's default environment variable
+	// anthropicAPIKeyEnvVarName is the Anthropic's default environment variable
 	// used to set API keys.
 	//
 	// https://code.claude.com/docs/en/env-vars#variables
-	anthropicApiKeyEnvVarName = "ANTHROPIC_API_KEY"
+	anthropicAPIKeyEnvVarName = "ANTHROPIC_API_KEY"
 	// openAIAddressEnvVarName is the OpenAI's environment variable used to set
 	// base API address.
 	openAIAddressEnvVarName = "OPENAI_BASE_URL"
-	// openAIApiKeyEnvVarName is the OpenAI's environment variable used to
+	// openAIAPIKeyEnvVarName is the OpenAI's environment variable used to
 	// set API keys.
-	openAIApiKeyEnvVarName = "OPENAI_API_KEY"
+	openAIAPIKeyEnvVarName = "OPENAI_API_KEY"
 )

--- a/lib/srv/app/llm/handler.go
+++ b/lib/srv/app/llm/handler.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/app/llm/anthropic"
 	"github.com/gravitational/teleport/lib/srv/app/llm/bedrock"
 	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+	"github.com/gravitational/teleport/lib/srv/app/llm/openai"
 	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
 )
 
@@ -48,6 +49,8 @@ type Handler struct {
 
 	anthropicProviderURL *url.URL
 	anthropicApiKey      string
+	openAIProviderURL    *url.URL
+	openAIApiKey         string
 }
 
 // HandlerConfig configures dependencies for the LLM proxy handler.
@@ -106,6 +109,7 @@ func NewHandler(ctx context.Context, cfg HandlerConfig) (*Handler, error) {
 		// Not much validation can be applied here since some providers might
 		// not require an actual API key.
 		anthropicApiKey: os.Getenv(anthropicApiKeyEnvVarName),
+		openAIApiKey:    os.Getenv(openAIApiKeyEnvVarName),
 	}
 
 	// It ok to leave this value as `nil`, the value receivers must implement a
@@ -113,6 +117,14 @@ func NewHandler(ctx context.Context, cfg HandlerConfig) (*Handler, error) {
 	if rawAnthropicURL := os.Getenv(anthropicAddressEnvVarName); rawAnthropicURL != "" {
 		var err error
 		h.anthropicProviderURL, err = url.Parse(rawAnthropicURL)
+		if err != nil {
+			// Hard failure.
+			return nil, trace.Wrap(err)
+		}
+	}
+	if rawOpenAIURL := os.Getenv(openAIAddressEnvVarName); rawOpenAIURL != "" {
+		var err error
+		h.openAIProviderURL, err = url.Parse(rawOpenAIURL)
 		if err != nil {
 			// Hard failure.
 			return nil, trace.Wrap(err)
@@ -152,7 +164,7 @@ func (h *Handler) serveHTTP(w http.ResponseWriter, r *http.Request) error {
 	case types.LLMFormatAnthropic:
 		h.handleRequest(
 			sessionCtx, w, r,
-			func(app types.Application, r *http.Request) (*http.Request, RequestInfo, error) {
+			func(app types.Application, r *http.Request) (*http.Request, llmrequest.RequestInfo, error) {
 				return anthropic.NewRequest(&llmrequest.Config{
 					App:               app,
 					DownstreamRequest: r,
@@ -163,10 +175,28 @@ func (h *Handler) serveHTTP(w http.ResponseWriter, r *http.Request) error {
 					SignBedrockRequest: h.signBedrockRequest,
 				})
 			},
-			func(l *slog.Logger, w http.ResponseWriter) (UpstreamRecorder, error) {
+			func(l *slog.Logger, _ llmrequest.RequestInfo, w http.ResponseWriter) (UpstreamRecorder, error) {
 				return anthropic.NewResponseRecorder(l, w)
 			},
 			anthropic.WriteError,
+		)
+	case types.LLMFormatOpenAI:
+		h.handleRequest(
+			sessionCtx, w, r,
+			func(app types.Application, r *http.Request) (*http.Request, llmrequest.RequestInfo, error) {
+				return openai.NewRequest(&llmrequest.Config{
+					App:               app,
+					DownstreamRequest: r,
+					ProviderURL:       h.openAIProviderURL,
+					GetAPIKeyFunc: func() string {
+						return h.openAIApiKey
+					},
+				})
+			},
+			func(l *slog.Logger, info llmrequest.RequestInfo, w http.ResponseWriter) (UpstreamRecorder, error) {
+				return openai.NewResponseRecorder(l, info, w)
+			},
+			openai.WriteError,
 		)
 	default:
 		return trace.NotImplemented("llm format %q not supported", llm.Format)
@@ -187,24 +217,12 @@ func (h *Handler) signBedrockRequest(ctx context.Context, app types.Application,
 // WriteErrorFunc is function used to write an error into the downstream request.
 type WriteErrorFunc func(http.ResponseWriter, error) error
 
-// RequestInfo interface that contains the request information.
-type RequestInfo interface {
-	// RequestedModel returns the requested model name.
-	RequestedModel() string
-	// ProviderModel returns the model name sent to the provider.
-	ProviderModel() string
-	// IsStream indicates if the request uses streaming.
-	IsStream() bool
-	// RequestSize contains the total request size in bytes.
-	RequestSize() int
-}
-
 // NewUpstreamRequestFunc function used to create a new upstream request.
-type NewUpstreamRequestFunc func(app types.Application, r *http.Request) (*http.Request, RequestInfo, error)
+type NewUpstreamRequestFunc func(app types.Application, r *http.Request) (*http.Request, llmrequest.RequestInfo, error)
 
 // NewUpstreamRecoderFunc function used to initialize a upstream response
 // recorder.
-type NewUpstreamRecoderFunc func(*slog.Logger, http.ResponseWriter) (UpstreamRecorder, error)
+type NewUpstreamRecoderFunc func(*slog.Logger, llmrequest.RequestInfo, http.ResponseWriter) (UpstreamRecorder, error)
 
 // UpstreamRecorder records upstream results.
 type UpstreamRecorder interface {
@@ -242,7 +260,7 @@ func (h *Handler) handleRequest(
 
 	var (
 		err  error
-		info RequestInfo
+		info llmrequest.RequestInfo
 		rec  UpstreamRecorder
 	)
 
@@ -272,7 +290,7 @@ func (h *Handler) handleRequest(
 		return
 	}
 
-	rec, err = newRecorderFunc(log, w)
+	rec, err = newRecorderFunc(log, info, w)
 	if err != nil {
 		log.ErrorContext(r.Context(), "failed to initialize recorder", "error", err)
 		// This is considered an "internal" error. For downstream connections,
@@ -357,4 +375,10 @@ const (
 	//
 	// https://code.claude.com/docs/en/env-vars#variables
 	anthropicApiKeyEnvVarName = "ANTHROPIC_API_KEY"
+	// openAIAddressEnvVarName is the OpenAI's environment variable used to set
+	// base API address.
+	openAIAddressEnvVarName = "OPENAI_BASE_URL"
+	// openAIApiKeyEnvVarName is the OpenAI's environment variable used to
+	// set API keys.
+	openAIApiKeyEnvVarName = "OPENAI_API_KEY"
 )

--- a/lib/srv/app/llm/handler.go
+++ b/lib/srv/app/llm/handler.go
@@ -121,6 +121,7 @@ func NewHandler(ctx context.Context, cfg HandlerConfig) (*Handler, error) {
 			// Hard failure.
 			return nil, trace.Wrap(err)
 		}
+		h.cfg.Log.InfoContext(ctx, "using anthropic provider address from environment", "host", h.anthropicProviderURL.Host)
 	}
 	if rawOpenAIURL := os.Getenv(openAIAddressEnvVarName); rawOpenAIURL != "" {
 		var err error
@@ -129,6 +130,7 @@ func NewHandler(ctx context.Context, cfg HandlerConfig) (*Handler, error) {
 			// Hard failure.
 			return nil, trace.Wrap(err)
 		}
+		h.cfg.Log.InfoContext(ctx, "using openai provider address from environment", "host", h.openAIProviderURL.Host)
 	}
 
 	return h, nil

--- a/lib/srv/app/llm/handler_test.go
+++ b/lib/srv/app/llm/handler_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv/app/common"
+	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
 )
 
 // TestHandleRequest covers `handleRequest` function which is responsible for
@@ -60,7 +61,7 @@ func TestHandleRequest(t *testing.T) {
 	}{
 		"success request": {
 			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
-				return func(_ types.Application, _ *http.Request) (*http.Request, RequestInfo, error) {
+				return func(_ types.Application, _ *http.Request) (*http.Request, llmrequest.RequestInfo, error) {
 					req, err := http.NewRequest(http.MethodPost, s.URL, nil)
 					if err != nil {
 						return nil, nil, trace.Wrap(err)
@@ -95,7 +96,7 @@ func TestHandleRequest(t *testing.T) {
 		},
 		"new request error": {
 			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
-				return func(_ types.Application, _ *http.Request) (*http.Request, RequestInfo, error) {
+				return func(_ types.Application, _ *http.Request) (*http.Request, llmrequest.RequestInfo, error) {
 					return nil, nil, trace.BadParameter("invalid request")
 				}
 			},
@@ -117,7 +118,7 @@ func TestHandleRequest(t *testing.T) {
 		},
 		"new request error with partial info": {
 			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
-				return func(_ types.Application, _ *http.Request) (*http.Request, RequestInfo, error) {
+				return func(_ types.Application, _ *http.Request) (*http.Request, llmrequest.RequestInfo, error) {
 					return nil, &mockRequestInfo{
 						requestedModel: "requested",
 						providerModel:  "provider",
@@ -142,7 +143,7 @@ func TestHandleRequest(t *testing.T) {
 		},
 		"successful request with recorder error": {
 			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
-				return func(_ types.Application, _ *http.Request) (*http.Request, RequestInfo, error) {
+				return func(_ types.Application, _ *http.Request) (*http.Request, llmrequest.RequestInfo, error) {
 					req, err := http.NewRequest(http.MethodPost, s.URL, nil)
 					if err != nil {
 						return nil, nil, trace.Wrap(err)
@@ -176,7 +177,7 @@ func TestHandleRequest(t *testing.T) {
 		// This case covers scenarios where upstream is not reachable.
 		"upstream forward error": {
 			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
-				return func(_ types.Application, _ *http.Request) (*http.Request, RequestInfo, error) {
+				return func(_ types.Application, _ *http.Request) (*http.Request, llmrequest.RequestInfo, error) {
 					req, err := http.NewRequest(http.MethodPost, s.URL, nil)
 					if err != nil {
 						return nil, nil, trace.Wrap(err)
@@ -249,7 +250,7 @@ func TestHandleRequest(t *testing.T) {
 				w,
 				req,
 				tc.newRequestFunc(w, mockServer),
-				func(_ *slog.Logger, w http.ResponseWriter) (UpstreamRecorder, error) {
+				func(_ *slog.Logger, _ llmrequest.RequestInfo, w http.ResponseWriter) (UpstreamRecorder, error) {
 					rec := &mockUpstreamRecorder{ResponseWriter: w}
 					tc.modifyRecorderFunc(rec)
 					return rec, nil
@@ -299,7 +300,7 @@ func (m *mockUpstreamRecorder) Written() int {
 }
 
 type mockRequestInfo struct {
-	RequestInfo
+	llmrequest.RequestInfo
 
 	requestedModel string
 	providerModel  string

--- a/lib/srv/app/llm/openai/errors.go
+++ b/lib/srv/app/llm/openai/errors.go
@@ -20,9 +20,10 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/gravitational/trace"
+
 	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/trace"
 )
 
 // WriteError writes an error in OpenAI format.
@@ -48,7 +49,7 @@ func marshalResponsesErrorEvent(evt *responsesErrorSSEEvent) []byte {
 	enc, err := utils.FastMarshal(evt)
 	if err != nil {
 		return []byte(
-			// Ignore SequecenNumber to avoid having to deal with number
+			// Ignore SequenceNumber to avoid having to deal with number
 			// conversions in this failure scenario.
 			`{"type": "error", "message": "` + llmerrors.ErrUnknown.Error() + `"}`,
 		)
@@ -62,7 +63,7 @@ func marshalResponsesFailedError(evt *responsesFailedSSEEvent) []byte {
 	enc, err := utils.FastMarshal(evt)
 	if err != nil {
 		return []byte(
-			// Ignore SequecenNumber to avoid having to deal with number
+			// Ignore SequenceNumber to avoid having to deal with number
 			// conversions in this failure scenario.
 			`{"type": "` + responsesFailedEventName + `", "response": {"type": "server_error", "message": "` + llmerrors.ErrUnknown.Error() + `"}}`,
 		)

--- a/lib/srv/app/llm/openai/errors.go
+++ b/lib/srv/app/llm/openai/errors.go
@@ -90,7 +90,7 @@ func newResponsesFailedError(seqNumber int, err error) *responsesFailedSSEEvent 
 		Type:           responsesFailedEventName,
 		SequenceNumber: seqNumber,
 		// `responses.failed` contents needed is only the `error` key.
-		// Instead of definining a dedicated struct for this we reuse the
+		// Instead of defining a dedicated struct for this we reuse the
 		// `errorEvenlope`, but since the response doesn't have the `type` field
 		// we must not define here (and cannot use the `newErrorEnvelope`
 		// function).

--- a/lib/srv/app/llm/openai/errors.go
+++ b/lib/srv/app/llm/openai/errors.go
@@ -38,7 +38,7 @@ func marshalError(apiErr *errorEnvelope) []byte {
 	enc, err := utils.FastMarshal(apiErr)
 	if err != nil {
 		return []byte(
-			`{"error": {"type": "server_error", "message": "` + llmerrors.ErrUnknown.Error() + `"}}`,
+			`{"error": {"type": "server_error", "message": ` + llmerrors.MarshalMessage(llmerrors.ErrUnknown) + `}}`,
 		)
 	}
 	return enc
@@ -51,7 +51,7 @@ func marshalResponsesErrorEvent(evt *responsesErrorSSEEvent) []byte {
 		return []byte(
 			// Ignore SequenceNumber to avoid having to deal with number
 			// conversions in this failure scenario.
-			`{"type": "error", "message": "` + llmerrors.ErrUnknown.Error() + `"}`,
+			`{"type": "error", "message": ` + llmerrors.MarshalMessage(llmerrors.ErrUnknown) + `}`,
 		)
 	}
 	return enc
@@ -65,7 +65,7 @@ func marshalResponsesFailedError(evt *responsesFailedSSEEvent) []byte {
 		return []byte(
 			// Ignore SequenceNumber to avoid having to deal with number
 			// conversions in this failure scenario.
-			`{"type": "` + responsesFailedEventName + `", "response": {"type": "server_error", "message": "` + llmerrors.ErrUnknown.Error() + `"}}`,
+			`{"type": "` + responsesFailedEventName + `", "response": {"type": "server_error", "message": ` + llmerrors.MarshalMessage(llmerrors.ErrUnknown) + `}}`,
 		)
 	}
 	return enc
@@ -89,6 +89,11 @@ func newResponsesFailedError(seqNumber int, err error) *responsesFailedSSEEvent 
 	return &responsesFailedSSEEvent{
 		Type:           responsesFailedEventName,
 		SequenceNumber: seqNumber,
+		// `responses.failed` contents needed is only the `error` key.
+		// Instead of definining a dedicated struct for this we reuse the
+		// `errorEvenlope`, but since the response doesn't have the `type` field
+		// we must not define here (and cannot use the `newErrorEnvelope`
+		// function).
 		Response: errorEnvelope{
 			Error: newErrorMessage(err),
 		},

--- a/lib/srv/app/llm/openai/errors.go
+++ b/lib/srv/app/llm/openai/errors.go
@@ -1,0 +1,162 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package openai
+
+import (
+	"errors"
+	"net/http"
+
+	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
+)
+
+// WriteError writes an error in OpenAI format.
+func WriteError(w http.ResponseWriter, err error) error {
+	w.WriteHeader(llmerrors.StatusCodeFromErr(err))
+	_, werr := w.Write(marshalError(newErrorEnvelope(err)))
+	return trace.Wrap(werr)
+}
+
+// marshalError marshals an error into OpenAI format.
+func marshalError(apiErr *errorEnvelope) []byte {
+	enc, err := utils.FastMarshal(apiErr)
+	if err != nil {
+		return []byte(
+			`{"error": {"type": "server_error", "message": "` + llmerrors.ErrUnknown.Error() + `"}}`,
+		)
+	}
+	return enc
+}
+
+// marshalResponsesErrorEvent marshals an OpenAI error message.
+func marshalResponsesErrorEvent(evt *responsesErrorSSEEvent) []byte {
+	enc, err := utils.FastMarshal(evt)
+	if err != nil {
+		return []byte(
+			// Ignore SequecenNumber to avoid having to deal with number
+			// conversions in this failure scenario.
+			`{"type": "error", "message": "` + llmerrors.ErrUnknown.Error() + `"}`,
+		)
+	}
+	return enc
+}
+
+// marshalResponsesFailedError marshals an OpenAI `response.failed` error
+// message.
+func marshalResponsesFailedError(evt *responsesFailedSSEEvent) []byte {
+	enc, err := utils.FastMarshal(evt)
+	if err != nil {
+		return []byte(
+			// Ignore SequecenNumber to avoid having to deal with number
+			// conversions in this failure scenario.
+			`{"type": "` + responsesFailedEventName + `", "response": {"type": "server_error", "message": "` + llmerrors.ErrUnknown.Error() + `"}}`,
+		)
+	}
+	return enc
+}
+
+// newErrorEnvelope creates a new error envelope.
+func newErrorEnvelope(err error) *errorEnvelope {
+	if err == nil {
+		return nil
+	}
+
+	return &errorEnvelope{
+		Type:  "error",
+		Error: newErrorMessage(err),
+	}
+}
+
+// newResponsesFailedError creates a new error in the `response.failed` event
+// format.
+func newResponsesFailedError(seqNumber int, err error) *responsesFailedSSEEvent {
+	return &responsesFailedSSEEvent{
+		Type:           responsesFailedEventName,
+		SequenceNumber: seqNumber,
+		Response: errorEnvelope{
+			Error: newErrorMessage(err),
+		},
+	}
+}
+
+// newErrorMessage creates a new error message.
+func newErrorMessage(err error) errorMessage {
+	msg := errorMessage{
+		Type:    errorTypeServerError,
+		Message: err.Error(),
+	}
+	switch {
+	case errors.Is(err, llmerrors.ErrRejected):
+		msg.Type = errorTypeRateLimitExceeded
+	case errors.Is(err, llmerrors.ErrBadRequest),
+		errors.Is(err, llmerrors.ErrUnauthorized),
+		errors.Is(err, llmerrors.ErrUnsupported),
+		trace.IsBadParameter(err),
+		trace.IsNotFound(err):
+		msg.Type = errorTypeInvalidRequest
+	}
+
+	return msg
+}
+
+// parseProviderError parses errors that come from OpenAI API.
+func parseProviderError(statusCode int, body []byte) (*llmerrors.ProviderError, error) {
+	var r errorEnvelope
+	if err := utils.FastUnmarshal(body, &r); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Prefer setting the LLM error on status code since it provides more
+	// granularity.
+	//
+	// https://developers.openai.com/api/docs/guides/error-codes#api-errors
+	switch statusCode {
+	case http.StatusBadRequest:
+		return llmerrors.NewProviderError(llmerrors.ErrBadRequest, r.Error.Message), nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return llmerrors.NewProviderError(llmerrors.ErrUnauthorized, ""), nil
+	case http.StatusTooManyRequests, http.StatusServiceUnavailable:
+		return llmerrors.NewProviderError(llmerrors.ErrRejected, r.Error.Message), nil
+	}
+
+	switch r.Error.Type {
+	case errorTypeInvalidRequest:
+		return llmerrors.NewProviderError(llmerrors.ErrBadRequest, r.Error.Message), nil
+	case errorTypeRateLimitExceeded:
+		return llmerrors.NewProviderError(llmerrors.ErrRejected, r.Error.Message), nil
+	default:
+		return llmerrors.NewProviderError(llmerrors.ErrUnknown, r.Error.Message), nil
+	}
+}
+
+type errorMessage struct {
+	Type    string `json:"type,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// errorEnvelope wraps the error message from OpenAI's API.
+type errorEnvelope struct {
+	Type  string       `json:"type,omitempty"`
+	Error errorMessage `json:"error"`
+}
+
+const (
+	errorTypeServerError       = "server_error"
+	errorTypeRateLimitExceeded = "rate_limit_exceeded"
+	errorTypeInvalidRequest    = "invalid_request_error"
+)

--- a/lib/srv/app/llm/openai/openai.go
+++ b/lib/srv/app/llm/openai/openai.go
@@ -1,0 +1,142 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package openai
+
+import (
+	"bytes"
+	"cmp"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/srv/app/llm/models"
+	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// NewRequest creates a new provider request based on the downstream request,
+// and inference endpoint configuration.
+func NewRequest(cfg *llmrequest.Config) (*http.Request, llmrequest.RequestInfo, error) {
+	var (
+		info            = &RequestInfo{}
+		providerPath    string
+		providerMethod  string
+		providerHeaders = http.Header{}
+		req             apiRequest
+	)
+
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, info, trace.Wrap(err)
+	}
+
+	// Default URL address.
+	//
+	// https://developers.openai.com/api/reference/overview
+	cfg.ProviderURL = cmp.Or(cfg.ProviderURL, &url.URL{
+		Scheme: "https",
+		Host:   "api.openai.com",
+		Path:   "/v1",
+	})
+
+	llm := cfg.App.GetLLM()
+	// TODO(gabrielcorado): add support for bedrock provider.
+	switch llm.Provider {
+	case types.LLMProviderOpenAI:
+		switch strings.TrimPrefix(cfg.DownstreamRequest.URL.Path, "/v1") {
+		// https://developers.openai.com/api/reference/resources/responses/methods/create
+		case "/responses":
+			if cfg.DownstreamRequest.Method != http.MethodPost {
+				// We're ok with returning 404 back to clients instead 405 status.
+				return nil, info, trace.NotFound("responses API supports only POST requests")
+			}
+
+			// Currently, websocket mode is not supported.
+			//
+			// https://developers.openai.com/api/docs/guides/websocket-mode
+			if slices.Contains(cfg.DownstreamRequest.Header.Values(constants.WebAPIConnUpgradeHeader), constants.WebAPIConnUpgradeTypeWebSocket) {
+				return nil, info, trace.NotFound("websocket mode is not supported")
+			}
+
+			info.endpointType = endpointTypeResponses
+			providerPath = "/responses"
+			providerMethod = http.MethodPost
+			req = &responsesAPIRequest{}
+		default:
+			return nil, info, trace.NotFound("unsupported endpoint")
+		}
+
+		// OpenAI API requires only `Authorization` header carrying the API key.
+		//
+		// https://developers.openai.com/api/reference/overview#authentication
+		providerHeaders.Set("Authorization", "Bearer "+cfg.GetAPIKeyFunc())
+		providerHeaders.Set("content-type", "application/json")
+	default:
+		return nil, info, trace.NotImplemented("provider %q is not supported", llm.Provider)
+	}
+
+	body, err := utils.ReadAtMost(cfg.DownstreamRequest.Body, teleport.MaxHTTPRequestSize)
+	if err != nil {
+		return nil, info, trace.Wrap(err)
+	}
+	defer cfg.DownstreamRequest.Body.Close()
+
+	if err := utils.FastUnmarshal(body, &req); err != nil {
+		return nil, info, trace.BadParameter("unable to parse request body")
+	}
+
+	if err := req.Validate(); err != nil {
+		return nil, info, trace.Wrap(err)
+	}
+
+	info.requestedModel = req.GetModel()
+	info.stream = req.GetStream()
+
+	providerModel, found := models.ConvertName(llm.Models, llm.FallbackModel, req.GetModel())
+	if !found {
+		return nil, info, trace.BadParameter("requested model %q is not supported", req.GetModel())
+	}
+	info.providerModel = providerModel
+	req.SetModel(providerModel)
+	req.EnableReportUsage()
+
+	providerBody, err := utils.FastMarshal(req)
+	if err != nil {
+		return nil, info, trace.ConnectionProblem(err, "failed to generate provider request")
+	}
+	info.requestSize = len(providerBody)
+
+	// Since we're doing a complete rewrite of the downstream request, it is
+	// easier to use a "fresh" request, and copy what is used from downstream
+	// request.
+	providerReq, err := http.NewRequestWithContext(
+		cfg.DownstreamRequest.Context(), // Keep original context so cancelation propagates.
+		providerMethod,
+		cfg.ProviderURL.JoinPath(providerPath).String(),
+		bytes.NewBuffer(providerBody),
+	)
+	if err != nil {
+		return nil, info, trace.Wrap(err)
+	}
+	providerReq.Header = providerHeaders
+	return providerReq, info, nil
+}

--- a/lib/srv/app/llm/openai/openai.go
+++ b/lib/srv/app/llm/openai/openai.go
@@ -21,13 +21,12 @@ import (
 	"cmp"
 	"net/http"
 	"net/url"
-	"slices"
 	"strings"
 
-	"github.com/gravitational/teleport"
+	"github.com/gorilla/websocket"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/srv/app/llm/models"
 	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
@@ -73,7 +72,7 @@ func NewRequest(cfg *llmrequest.Config) (*http.Request, llmrequest.RequestInfo, 
 			// Currently, websocket mode is not supported.
 			//
 			// https://developers.openai.com/api/docs/guides/websocket-mode
-			if slices.Contains(cfg.DownstreamRequest.Header.Values(constants.WebAPIConnUpgradeHeader), constants.WebAPIConnUpgradeTypeWebSocket) {
+			if websocket.IsWebSocketUpgrade(cfg.DownstreamRequest) {
 				return nil, info, trace.NotFound("websocket mode is not supported")
 			}
 
@@ -89,7 +88,7 @@ func NewRequest(cfg *llmrequest.Config) (*http.Request, llmrequest.RequestInfo, 
 		//
 		// https://developers.openai.com/api/reference/overview#authentication
 		providerHeaders.Set("Authorization", "Bearer "+cfg.GetAPIKeyFunc())
-		providerHeaders.Set("content-type", "application/json")
+		providerHeaders.Set("Content-Type", "application/json")
 	default:
 		return nil, info, trace.NotImplemented("provider %q is not supported", llm.Provider)
 	}
@@ -102,6 +101,14 @@ func NewRequest(cfg *llmrequest.Config) (*http.Request, llmrequest.RequestInfo, 
 
 	if err := utils.FastUnmarshal(body, &req); err != nil {
 		return nil, info, trace.BadParameter("unable to parse request body")
+	}
+
+	// Clients can send `null` JSON values, and since we're decoding into an
+	// interface (which can hold a `nil` reference), decoding `null` into the
+	// interface causes it to be `nil`. This condition guards against this case
+	// avoiding a nil pointer exception.
+	if req == nil {
+		return nil, info, trace.BadParameter("invalid request body")
 	}
 
 	if err := req.Validate(); err != nil {

--- a/lib/srv/app/llm/openai/openai_test.go
+++ b/lib/srv/app/llm/openai/openai_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
 )
@@ -240,7 +239,8 @@ func TestNewRequest(t *testing.T) {
 					"/responses",
 					strings.NewReader(`{"model":"gpt-5","input":"Hello"}`),
 				)
-				r.Header.Set(constants.WebAPIConnUpgradeHeader, constants.WebAPIConnUpgradeTypeWebSocket)
+				r.Header.Set("Connection", "upgrade")
+				r.Header.Set("Upgrade", "websocket")
 				return r
 			},
 			expectedError:   require.Error,
@@ -257,6 +257,23 @@ func TestNewRequest(t *testing.T) {
 					http.MethodPost,
 					"/responses",
 					strings.NewReader(`{"model":"gpt-5","input":"Hello", "background": true}`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"null requests is rejected": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`null`),
 				)
 				return r
 			},

--- a/lib/srv/app/llm/openai/openai_test.go
+++ b/lib/srv/app/llm/openai/openai_test.go
@@ -264,6 +264,23 @@ func TestNewRequest(t *testing.T) {
 			expectedRequest: require.Nil,
 			expectedInfo:    require.NotNil,
 		},
+		"responses store requests is not supported": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`{"model":"gpt-5","input":"Hello", "store": true}`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
 		"null requests is rejected": {
 			app: newApp(t, &types.LLM{
 				Format:   types.LLMFormatOpenAI,

--- a/lib/srv/app/llm/openai/openai_test.go
+++ b/lib/srv/app/llm/openai/openai_test.go
@@ -1,0 +1,349 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package openai
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/types"
+	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
+)
+
+func TestNewRequest(t *testing.T) {
+	apiKey := "random-api-key"
+
+	for name, tc := range map[string]struct {
+		app             types.Application
+		request         func() *http.Request
+		expectedError   require.ErrorAssertionFunc
+		expectedRequest require.ValueAssertionFunc
+		expectedInfo    require.ValueAssertionFunc
+	}{
+		"successful responses": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`{"model":"gpt-5","input":"Hello"}`),
+				)
+				return r
+			},
+			expectedError: require.NoError,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				require.Equal(tt, "/v1/responses", req.URL.Path)
+				require.Equal(tt, http.MethodPost, req.Method)
+				require.Equal(tt, "Bearer "+apiKey, req.Header.Get("Authorization"))
+				require.NotEmpty(tt, req.Header.Get("content-type"))
+			},
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Equal(tt, "gpt-5", info.RequestedModel())
+				require.Equal(tt, "gpt-5", info.ProviderModel())
+			},
+		},
+		"includes single /v1 prefix": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/v1/responses",
+					strings.NewReader(`{"model":"gpt-5","input":"Hello"}`),
+				)
+				return r
+			},
+			expectedError: require.NoError,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				require.Equal(tt, "/v1/responses", req.URL.Path)
+			},
+			expectedInfo: require.NotNil,
+		},
+		"convert model name": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+				Models: []*types.LLM_Model{
+					{ProviderName: "gpt-5", Name: "gpt-4o"},
+				},
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`{"model":"gpt-4o","input":"Hello"}`),
+				)
+				return r
+			},
+			expectedError: require.NoError,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				body, err := io.ReadAll(req.Body)
+				require.NoError(tt, err)
+				require.Contains(tt, string(body), "gpt-5")
+			},
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Equal(tt, "gpt-4o", info.RequestedModel())
+				require.Equal(tt, "gpt-5", info.ProviderModel())
+			},
+		},
+		"fallback model name": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+				Models: []*types.LLM_Model{
+					{ProviderName: "gpt-5", Name: "gpt-4o"},
+				},
+				FallbackModel: "gpt-4o",
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`{"model":"gpt-4o-mini","input":"Hello"}`),
+				)
+				return r
+			},
+			expectedError: require.NoError,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				body, err := io.ReadAll(req.Body)
+				require.NoError(tt, err)
+				require.Contains(tt, string(body), "gpt-5")
+			},
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Equal(tt, "gpt-4o-mini", info.RequestedModel())
+				require.Equal(tt, "gpt-5", info.ProviderModel())
+			},
+		},
+		"unsupported model name": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+				Models: []*types.LLM_Model{
+					{ProviderName: "gpt-5", Name: "gpt-4o"},
+				},
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`{"model":"gpt-4o-mini","input":"Hello"}`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Equal(tt, "gpt-4o-mini", info.RequestedModel())
+				require.Empty(tt, info.ProviderModel())
+			},
+		},
+		"request exceeds max size": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(
+						`{"model":"gpt-5","input":"`+strings.Repeat("a", teleport.MaxHTTPRequestSize)+`"}`,
+					),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Empty(tt, info.RequestedModel())
+				require.Empty(tt, info.ProviderModel())
+			},
+		},
+		"unsupported endpoint": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/embeddings",
+					strings.NewReader(`{"model":"gpt-5","input":"Hello"}`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"unsupported method on responses": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodGet,
+					"/responses",
+					nil,
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"websocket mode is not supported": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`{"model":"gpt-5","input":"Hello"}`),
+				)
+				r.Header.Set(constants.WebAPIConnUpgradeHeader, constants.WebAPIConnUpgradeTypeWebSocket)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"responses background requests is not supported": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`{"model":"gpt-5","input":"Hello", "background": true}`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			req, info, err := NewRequest(&llmrequest.Config{
+				App:               tc.app,
+				DownstreamRequest: tc.request(),
+				GetAPIKeyFunc: func() string {
+					return apiKey
+				},
+			})
+			tc.expectedError(t, err)
+			tc.expectedRequest(t, req)
+			tc.expectedInfo(t, info)
+		})
+	}
+}
+
+func newApp(t *testing.T, llm *types.LLM, appAWS *types.AppAWS) types.Application {
+	app, err := types.NewAppV3(types.Metadata{Name: "llm-app"}, types.AppSpecV3{
+		LLM: llm,
+		AWS: appAWS,
+	})
+	require.NoError(t, err)
+	return app
+}
+
+// buildRequestBody returns a valid responses API request body whose total size
+// is roughly fillerBytes.
+func buildRequestBody(fillerBytes int) []byte {
+	content := strings.Repeat("A", fillerBytes)
+	return fmt.Appendf(nil,
+		`{"model":"gpt-4o","max_output_tokens":1024,"stream":false,"input":%q}`,
+		content,
+	)
+}
+
+// BenchmarkNewRequest tracks the cost of the downstream request "parsing" and
+// generation of the provider request, across different body sizes.
+//
+//	go test ./lib/srv/app/llm/openai/ -run '^$' -bench BenchmarkNewRequest -benchmem
+func BenchmarkNewRequest(b *testing.B) {
+	// Maps the requested model to a provider model so the conversion path
+	// (the common case in production) is exercised.
+	app, err := types.NewAppV3(types.Metadata{Name: "benchmark-app"}, types.AppSpecV3{
+		LLM: &types.LLM{
+			Provider: types.LLMProviderOpenAI,
+			Format:   types.LLMFormatOpenAI,
+			Models: []*types.LLM_Model{
+				{ProviderName: "gpt-5", Name: "gpt-4o"},
+			},
+		},
+	})
+	require.NoError(b, err)
+
+	for _, bc := range []struct {
+		name string
+		body []byte
+	}{
+		{"small_chat", buildRequestBody(16)},
+		{"medium_32KB", buildRequestBody(32 * 1024)},
+		{"large_1MB", buildRequestBody(1024 * 1024)},
+		{"xlarge_8MB", buildRequestBody(8 * 1024 * 1024)},
+	} {
+		b.Run(bc.name, func(b *testing.B) {
+			// Reuse a single request and only reset the body each iteration.
+			r, err := http.NewRequest(http.MethodPost, "/responses", nil)
+			require.NoError(b, err)
+
+			b.SetBytes(int64(len(bc.body)))
+			b.ReportAllocs()
+
+			for b.Loop() {
+				r.Body = io.NopCloser(bytes.NewReader(bc.body))
+				if _, _, err := NewRequest(&llmrequest.Config{
+					App:               app,
+					DownstreamRequest: r,
+					GetAPIKeyFunc:     func() string { return "" },
+				}); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/lib/srv/app/llm/openai/recorder.go
+++ b/lib/srv/app/llm/openai/recorder.go
@@ -1,0 +1,210 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package openai
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/httplib/sse"
+	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+	llmrecorder "github.com/gravitational/teleport/lib/srv/app/llm/recorder"
+	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// NewResponseRecorder creates a new OpenAI response recorder.
+func NewResponseRecorder(log *slog.Logger, info llmrequest.RequestInfo, w http.ResponseWriter) (*llmrecorder.ResponseRecorder, error) {
+	oaiInfo, ok := info.(*RequestInfo)
+	if !ok {
+		return nil, trace.BadParameter("expected openai.RequestInfo but got %T", info)
+	}
+
+	return llmrecorder.NewResponseRecorder(log, w, Endpoint{
+		endpointType: oaiInfo.endpointType,
+	})
+}
+
+// Endpoint implements [llmrecorder.Endpoint] for the OpenAI API.
+type Endpoint struct {
+	endpointType endpointType
+}
+
+// MarshalError implements [recorder.Endpoint].
+func (e Endpoint) MarshalError(err error) (body []byte) {
+	return marshalError(newErrorEnvelope(err))
+}
+
+// ParseError implements [recorder.Endpoint].
+func (e Endpoint) ParseError(statusCode int, body []byte) (providerError *llmerrors.ProviderError, err error) {
+	return parseProviderError(statusCode, body)
+}
+
+// ParseUsage implements [recorder.Endpoint].
+func (e Endpoint) ParseUsage(body []byte) (inputTokens int, outputTokens int, err error) {
+	switch e.endpointType {
+	case endpointTypeResponses:
+		var result responsesAPIUsage
+		if err := utils.FastUnmarshal(body, &result); err != nil {
+			return 0, 0, trace.Wrap(err)
+		}
+		return result.Usage.InputTokens, result.Usage.OutputTokens, nil
+	default:
+		return 0, 0, trace.BadParameter("endpoint type not supported")
+	}
+}
+
+// ProcessSSE implements [recorder.Endpoint].
+func (e Endpoint) ProcessSSE(ctx context.Context, log *slog.Logger, reader io.ReadCloser, writer io.Writer) (inputTokens int, outputTokens int, err error) {
+	switch e.endpointType {
+	case endpointTypeResponses:
+		return processResponsesSSEEvents(ctx, log, reader, writer)
+	default:
+		return 0, 0, trace.BadParameter("endpoint type not supported")
+	}
+}
+
+// processResponsesSSEEvents processes responses API streaming (SSE) events.
+//
+// Usage information is read only from the terminal `response.completed` and
+// `response.incomplete` events.
+//
+// This means that if the request is canceled before any of those "final events"
+// arrives, we cannot track the usage of the request. This is a known limitation
+// and will be addressed in the future when we introduce token budgeting.
+//
+// For error events, OpenAI specifies `response.failed` and `error` events.
+// There isn't much information about what we can expect from both, so we treat
+// them the same way for now.
+//
+// Other events don't contain relevant information for the recorder, so we
+// forward them as is.
+func processResponsesSSEEvents(ctx context.Context, log *slog.Logger, r io.ReadCloser, w io.Writer) (int, int, error) {
+	defer r.Close()
+
+	var (
+		done              bool
+		inputTokensCount  int
+		outputTokensCount int
+	)
+	for event, err := range sse.ReadEvents(r) {
+		if err != nil {
+			return inputTokensCount, outputTokensCount, trace.Wrap(err)
+		}
+
+		switch event.Event {
+		case responsesFailedEventName:
+			var streamEventPayload responsesFailedSSEEvent
+			if err := utils.FastUnmarshal(event.Data, &streamEventPayload); err != nil {
+				log.ErrorContext(ctx, "failed to parse error event", "error", err)
+				if _, err := sse.WriteEvent(w, sse.Event{
+					Event: responsesFailedEventName,
+					Data:  marshalResponsesFailedError(newResponsesFailedError(0 /* seqNumber */, llmerrors.ErrBadResponse)),
+				}); err != nil {
+					// Preserve the provider response for recorder Err().
+					// Downstream delivery failure is a secondary transport
+					// condition here.
+					log.ErrorContext(ctx, "failed to write error event", "error", err)
+				}
+				return inputTokensCount, outputTokensCount, llmerrors.ErrBadResponse
+			}
+
+			apiErr := llmerrors.NewProviderError(llmerrors.ErrUnknown, streamEventPayload.Response.Error.Message)
+			if _, err := sse.WriteEvent(w, sse.Event{
+				Event: responsesFailedEventName,
+				Data:  marshalResponsesFailedError(newResponsesFailedError(streamEventPayload.SequenceNumber, apiErr)),
+			}); err != nil {
+				// Preserve the provider error for recorder Err(). A failed
+				// downstream write here often means the client canceled or
+				// timed out after the provider had already rejected the
+				// request.
+				log.ErrorContext(ctx, "failed to write error event", "error", err)
+			}
+			return inputTokensCount, outputTokensCount, apiErr
+		case responsesErrorEventName:
+			var streamEventPayload responsesErrorSSEEvent
+			if err := utils.FastUnmarshal(event.Data, &streamEventPayload); err != nil {
+				log.ErrorContext(ctx, "failed to parse error event", "error", err)
+				if _, err := sse.WriteEvent(w, sse.Event{
+					Event: responsesErrorEventName,
+					// We use error message directly since we don't need specific
+					// error type set (it must always default to the event name).
+					Data: marshalResponsesErrorEvent(&responsesErrorSSEEvent{Type: responsesErrorEventName, Message: llmerrors.ErrBadResponse.Error()}),
+				}); err != nil {
+					// Preserve the provider response for recorder Err().
+					// Downstream delivery failure is a secondary transport
+					// condition here.
+					log.ErrorContext(ctx, "failed to write error event", "error", err)
+				}
+				return inputTokensCount, outputTokensCount, llmerrors.ErrBadResponse
+			}
+
+			apiErr := llmerrors.NewProviderError(llmerrors.ErrUnknown, streamEventPayload.Message)
+			if _, err := sse.WriteEvent(w, sse.Event{
+				Event: responsesErrorEventName,
+				Data: marshalResponsesErrorEvent(&responsesErrorSSEEvent{
+					Type:           responsesErrorEventName,
+					Message:        apiErr.Error(),
+					SequenceNumber: streamEventPayload.SequenceNumber,
+				}),
+			}); err != nil {
+				// Preserve the provider error for recorder Err(). A failed
+				// downstream write here often means the client canceled or
+				// timed out after the provider had already rejected the
+				// request.
+				log.ErrorContext(ctx, "failed to write error event", "error", err)
+			}
+			return inputTokensCount, outputTokensCount, apiErr
+		case responsesCompletedEventName, responsesIncompleteEventName:
+			var streamEventPayload responsesSSEEventWithUsage
+			if err := utils.FastUnmarshal(event.Data, &streamEventPayload); err != nil {
+				log.ErrorContext(ctx, "failed to parse response.completed event", "error", err)
+				return 0, 0, llmerrors.ErrBadResponse
+			}
+			inputTokensCount = streamEventPayload.Response.Usage.InputTokens
+			outputTokensCount = streamEventPayload.Response.Usage.OutputTokens
+			done = true
+		}
+
+		if _, err := sse.WriteEvent(w, event); err != nil {
+			return inputTokensCount, outputTokensCount, trace.Wrap(err)
+		}
+	}
+
+	// This would mean the stream did not work correctly (due to missing final
+	// event).
+	if !done {
+		return 0, 0, llmerrors.NewProviderError(llmerrors.ErrBadResponse, "provider did not send final event")
+	}
+
+	return inputTokensCount, outputTokensCount, nil
+}
+
+const (
+	// responsesFailedEventName is the SSE event of a failed response.
+	responsesFailedEventName = "response.failed"
+	// responsesCompletedEventName is the SSE event of a completed response.
+	responsesCompletedEventName = "response.completed"
+	// responsesIncompleteEventName is the SSE event of a incomplete response.
+	responsesIncompleteEventName = "response.incomplete"
+	// responsesErrorEventName is the SSE event of an error.
+	responsesErrorEventName = "error"
+)

--- a/lib/srv/app/llm/openai/recorder.go
+++ b/lib/srv/app/llm/openai/recorder.go
@@ -49,7 +49,7 @@ type Endpoint struct {
 }
 
 // MarshalError implements [recorder.Endpoint].
-func (e Endpoint) MarshalError(err error) (body []byte) {
+func (e Endpoint) MarshalError(err error) []byte {
 	return marshalError(newErrorEnvelope(err))
 }
 

--- a/lib/srv/app/llm/openai/recorder_test.go
+++ b/lib/srv/app/llm/openai/recorder_test.go
@@ -1,0 +1,384 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package openai
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+	llmtesting "github.com/gravitational/teleport/lib/srv/app/llm/testing"
+)
+
+// responsesSuccessStream is a valid responses API SSE stream. Usage is only
+// reported on the terminal response.completed event.
+var responsesSuccessStream = strings.Join([]string{
+	"event: response.created\n" + `data: {"type":"response.created","response":{"id":"resp_123","object":"response"},"sequence_number":0}`,
+	"event: response.output_text.delta\n" + `data: {"type":"response.output_text.delta","delta":"Hello","sequence_number":1}`,
+	"event: response.output_text.delta\n" + `data: {"type":"response.output_text.delta","delta":"World","sequence_number":2}`,
+	"event: response.completed\n" + `data: {"type":"response.completed","response":{"usage":{"input_tokens":15,"output_tokens":60,"total_tokens":75}},"sequence_number":3}`,
+}, "\n\n")
+
+// responsesIncompleteStream matches the documented incomplete response shape.
+var responsesIncompleteStream = "event: response.incomplete\n" +
+	`data: {"type":"response.incomplete","response":{"status":"incomplete","incomplete_details":{"reason":"max_tokens"},"usage":{"input_tokens":15,"output_tokens":60,"total_tokens":75},"sequence_number":1}}`
+
+// TestParseProviderError covers the OpenAI status-code to Teleport error
+// mapping.
+func TestParseProviderError(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		statusCode  int
+		body        string
+		expectedErr error
+	}{
+		"bad request":         {http.StatusBadRequest, `{"error":{"type":"invalid_request_error","message":"bad"}}`, llmerrors.ErrBadRequest},
+		"unauthorized":        {http.StatusUnauthorized, `{"error":{"type":"authentication_error","message":"nope"}}`, llmerrors.ErrUnauthorized},
+		"forbidden":           {http.StatusForbidden, `{"error":{"type":"permission_error","message":"nope"}}`, llmerrors.ErrUnauthorized},
+		"rate limit":          {http.StatusTooManyRequests, `{"error":{"type":"rate_limit_exceeded","message":"slow down"}}`, llmerrors.ErrRejected},
+		"service unavailable": {http.StatusServiceUnavailable, `{"error":{"type":"server_error","message":"busy"}}`, llmerrors.ErrRejected},
+		"unknown status":      {http.StatusInternalServerError, `{"error":{"type":"server_error","message":"?"}}`, llmerrors.ErrUnknown},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			apiErr, err := parseProviderError(tc.statusCode, []byte(tc.body))
+			require.NoError(t, err)
+			require.ErrorIs(t, apiErr, tc.expectedErr)
+		})
+	}
+
+	t.Run("malformed body returns parse error", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseProviderError(http.StatusBadRequest, []byte(`{"error":`))
+		require.Error(t, err)
+	})
+}
+
+// TestNewErrorMessage covers the Teleport error to OpenAI error type mapping.
+func TestNewErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		err          error
+		expectedType string
+	}{
+		"bad request":  {llmerrors.ErrBadRequest, errorTypeInvalidRequest},
+		"unauthorized": {llmerrors.ErrUnauthorized, errorTypeInvalidRequest},
+		"unsupported":  {llmerrors.ErrUnsupported, errorTypeInvalidRequest},
+		"rejected":     {llmerrors.ErrRejected, errorTypeRateLimitExceeded},
+		"timeout":      {llmerrors.ErrTimeout, errorTypeServerError},
+		"unknown":      {llmerrors.ErrUnknown, errorTypeServerError},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			msg := newErrorEnvelope(tc.err)
+			require.Equal(t, tc.expectedType, msg.Error.Type)
+			require.Contains(t, msg.Error.Message, tc.err.Error())
+		})
+	}
+
+	require.Nil(t, newErrorEnvelope(nil))
+}
+
+func TestEndpointParseUsage(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		endpointType         endpointType
+		body                 string
+		expectedInputTokens  int
+		expectedOutputTokens int
+		expectedErr          require.ErrorAssertionFunc
+	}{
+		"responses success": {
+			endpointType:         endpointTypeResponses,
+			body:                 `{"usage":{"input_tokens":15,"output_tokens":20,"total_tokens":35}}`,
+			expectedInputTokens:  15,
+			expectedOutputTokens: 20,
+			expectedErr:          require.NoError,
+		},
+		"responses malformed body": {
+			endpointType: endpointTypeResponses,
+			body:         `{"usage":`,
+			expectedErr:  require.Error,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			in, out, err := Endpoint{endpointType: tc.endpointType}.ParseUsage([]byte(tc.body))
+			tc.expectedErr(t, err)
+			require.Equal(t, tc.expectedInputTokens, in)
+			require.Equal(t, tc.expectedOutputTokens, out)
+		})
+	}
+}
+
+func TestEndpointProcessSSE(t *testing.T) {
+	t.Parallel()
+
+	log := slog.New(slog.DiscardHandler)
+
+	for name, tc := range map[string]struct {
+		endpointType        endpointType
+		stream              string
+		expectedInputTokens int
+		expectedOutput      int
+		expectedErr         require.ErrorAssertionFunc
+		expectedDownstream  func(t *testing.T, body string)
+	}{
+		"responses success extracts usage and forwards events": {
+			endpointType:        endpointTypeResponses,
+			stream:              responsesSuccessStream,
+			expectedInputTokens: 15,
+			expectedOutput:      60,
+			expectedErr:         require.NoError,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Equal(t, responsesSuccessStream+"\n\n", body)
+			},
+		},
+		"responses missing end event forwards events and reports error": {
+			endpointType: endpointTypeResponses,
+			stream: strings.Join([]string{
+				"event: response.created\n" + `data: {"type":"response.created","response":{"id":"resp_123","object":"response"},"sequence_number":0}`,
+				"event: response.output_text.delta\n" + `data: {"type":"response.output_text.delta","delta":"Hello","sequence_number":1}`,
+			}, "\n\n"),
+			expectedErr: require.Error,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.NotEmpty(t, body)
+			},
+		},
+		"responses incomplete event extracts usage and forwards events": {
+			endpointType:        endpointTypeResponses,
+			stream:              responsesIncompleteStream,
+			expectedInputTokens: 15,
+			expectedOutput:      60,
+			expectedErr:         require.NoError,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Equal(t, responsesIncompleteStream+"\n\n", body)
+			},
+		},
+		"responses response.failed surfaces provider error": {
+			endpointType: endpointTypeResponses,
+			stream:       "event: response.failed\n" + `data: {"type":"response.failed","response":{"error":{"type":"server_error","message":"the model failed"}},"sequence_number":5}`,
+			expectedErr:  require.Error,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Equal(
+					t,
+					"event: response.failed\n"+`data: {"type":"response.failed","response":{"error":{"type":"server_error","message":"`+llmerrors.ErrUnknown.Error()+`: the model failed"}},"sequence_number":5}`+"\n\n",
+					body,
+					"expected the exact same SSE event shape with Teleport error, but got a different result",
+				)
+			},
+		},
+		"responses error surfaces provider error": {
+			endpointType: endpointTypeResponses,
+			stream:       "event: error\n" + `data: {"type":"error","message":"the model failed","sequence_number":5}`,
+			expectedErr:  require.Error,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Equal(
+					t,
+					"event: error\n"+`data: {"type":"error","message":"`+llmerrors.ErrUnknown.Error()+`: the model failed","sequence_number":5}`+"\n\n",
+					body,
+					"expected the exact same SSE event shape with Teleport error, but got a different result",
+				)
+			},
+		},
+		"responses invalid response.failed surfaces bad response": {
+			endpointType: endpointTypeResponses,
+			stream:       "event: response.failed\n" + `data: {"type":"response.failed","response":`,
+			expectedErr: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorIs(tt, err, llmerrors.ErrBadResponse, i...)
+			},
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Contains(t, body, llmerrors.ErrBadResponse.Error())
+			},
+		},
+		"responses malformed completed event surfaces bad response": {
+			endpointType: endpointTypeResponses,
+			stream:       "event: response.completed\n" + `data: {"type":"response.completed","response":`,
+			expectedErr:  require.Error,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Empty(t, body)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var out strings.Builder
+			in, out2, err := Endpoint{endpointType: tc.endpointType}.ProcessSSE(
+				context.Background(),
+				log,
+				io.NopCloser(strings.NewReader(tc.stream)),
+				&out,
+			)
+			tc.expectedErr(t, err)
+			require.Equal(t, tc.expectedInputTokens, in)
+			require.Equal(t, tc.expectedOutput, out2)
+			tc.expectedDownstream(t, out.String())
+		})
+	}
+}
+
+// TestEndpointProcessSSEWriteFailure covers the error-event branch when the
+// downstream write fails: the recorder must still surface the semantic error.
+func TestEndpointProcessSSEWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	log := slog.New(slog.DiscardHandler)
+
+	for name, tc := range map[string]struct {
+		endpointType endpointType
+		stream       string
+		expectedErr  require.ErrorAssertionFunc
+	}{
+		"responses.failed event error surfaces to downstream": {
+			endpointType: endpointTypeResponses,
+			stream:       "event: response.failed\n" + `data: {"type":"response.failed","response":{"error":{"type":"server_error","message":"the model failed"}}}`,
+			expectedErr: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorContains(tt, err, "the model failed")
+			},
+		},
+		"responses.failed error event surfaces to downstream as bad response": {
+			endpointType: endpointTypeResponses,
+			stream:       "event: response.failed\n" + `data: {"type":"response.failed","response":`,
+			expectedErr: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorIs(tt, err, llmerrors.ErrBadResponse, i...)
+			},
+		},
+		"responses error event surfaces to downstream": {
+			endpointType: endpointTypeResponses,
+			stream:       "event: error\n" + `data: {"type":"server_error","message":"the model failed"}`,
+			expectedErr: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorContains(tt, err, "the model failed")
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			w := llmtesting.NewFailingResponseWriter("text/event-stream")
+			_, _, err := Endpoint{endpointType: tc.endpointType}.ProcessSSE(
+				context.Background(),
+				log,
+				io.NopCloser(strings.NewReader(tc.stream)),
+				w,
+			)
+			tc.expectedErr(t, err)
+		})
+	}
+}
+
+// buildResponsesBody returns a valid non-streaming responses API response whose
+// total size is roughly fillerBytes.
+func buildResponsesBody(fillerBytes int) []byte {
+	text := strings.Repeat("A", fillerBytes)
+	return fmt.Appendf(nil,
+		`{"id":"resp_123","object":"response","output":[{"type":"message","content":[{"type":"output_text","text":%q}]}],"usage":{"input_tokens":15,"output_tokens":20,"total_tokens":35}}`,
+		text,
+	)
+}
+
+// buildResponsesStreamEvents returns valid responses API SSE events.
+func buildResponsesStreamEvents(numEvents int) [][]byte {
+	events := make([][]byte, 0, numEvents+2)
+	events = append(events, []byte("event: response.created\n"+`data: {"type":"response.created","response":{"id":"resp_123","object":"response"}}`+"\n\n"))
+	for range numEvents {
+		events = append(events, []byte("event: response.output_text.delta\n"+`data: {"type":"response.output_text.delta","delta":"Hello world"}`+"\n\n"))
+	}
+	events = append(events, []byte("event: response.completed\n"+`data: {"type":"response.completed","response":{"usage":{"input_tokens":15,"output_tokens":60,"total_tokens":75}}}`+"\n\n"))
+	return events
+}
+
+// BenchmarkResponseRecorderJSON tracks the non-streaming path for each API
+// endpoint format.
+//
+//	go test ./lib/srv/app/llm/openai/ -run '^$' -bench BenchmarkResponseRecorderJSON -benchmem
+func BenchmarkResponseRecorderJSON(b *testing.B) {
+	log := slog.New(slog.DiscardHandler)
+	for _, bc := range []struct {
+		name string
+		ep   endpointType
+		body []byte
+	}{
+		{"responses/small", endpointTypeResponses, buildResponsesBody(16)},
+		{"responses/medium_32KB", endpointTypeResponses, buildResponsesBody(32 * 1024)},
+		{"responses/large_1MB", endpointTypeResponses, buildResponsesBody(1024 * 1024)},
+	} {
+		b.Run(bc.name, func(b *testing.B) {
+			b.SetBytes(int64(len(bc.body)))
+			b.ReportAllocs()
+
+			for b.Loop() {
+				w := llmtesting.NewDiscardResponseWriter("application/json")
+				rec, err := NewResponseRecorder(log, &RequestInfo{endpointType: bc.ep}, w)
+				require.NoError(b, err)
+				rec.WriteHeader(http.StatusOK)
+				_, err = rec.Write(bc.body)
+				require.NoError(b, err)
+				require.NoError(b, rec.Close())
+			}
+		})
+	}
+}
+
+// BenchmarkResponseRecorderStream issues one Write per SSE event for each API
+// endpoint format.
+//
+//	go test ./lib/srv/app/llm/openai/ -run '^$' -bench BenchmarkResponseRecorderStream -benchmem
+func BenchmarkResponseRecorderStream(b *testing.B) {
+	log := slog.New(slog.DiscardHandler)
+	for _, bc := range []struct {
+		name   string
+		ep     endpointType
+		events [][]byte
+	}{
+		{"responses/32_events", endpointTypeResponses, buildResponsesStreamEvents(32)},
+		{"responses/256_events", endpointTypeResponses, buildResponsesStreamEvents(256)},
+		{"responses/1024_events", endpointTypeResponses, buildResponsesStreamEvents(1024)},
+	} {
+		var total int
+		for _, e := range bc.events {
+			total += len(e)
+		}
+		b.Run(bc.name, func(b *testing.B) {
+			b.SetBytes(int64(total))
+			b.ReportAllocs()
+
+			for b.Loop() {
+				w := llmtesting.NewDiscardResponseWriter("text/event-stream")
+				rec, err := NewResponseRecorder(log, &RequestInfo{endpointType: bc.ep}, w)
+				require.NoError(b, err)
+				rec.WriteHeader(http.StatusOK)
+				for _, e := range bc.events {
+					_, err := rec.Write(e)
+					require.NoError(b, err)
+				}
+				// Close waits for the SSE-processing goroutine to drain.
+				require.NoError(b, rec.Close())
+			}
+		})
+	}
+}

--- a/lib/srv/app/llm/openai/types.go
+++ b/lib/srv/app/llm/openai/types.go
@@ -32,8 +32,7 @@ import (
 type endpointType string
 
 const (
-	endpointTypeResponses       endpointType = "responses"
-	endpointTypeChatCompletions endpointType = "chat_completions"
+	endpointTypeResponses endpointType = "responses"
 )
 
 // RequestInfo contains the request information.
@@ -113,8 +112,10 @@ func (r responsesAPIRequest) MarshalJSON() ([]byte, error) {
 	if err := marshalField(final, "model", r.Model); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := marshalField(final, "stream", r.Stream); err != nil {
-		return nil, trace.Wrap(err)
+	if r.Stream {
+		if err := marshalField(final, "stream", r.Stream); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	// [Background] is expected to always be set `false`, so no need to marshal
 	// it.

--- a/lib/srv/app/llm/openai/types.go
+++ b/lib/srv/app/llm/openai/types.go
@@ -1,0 +1,180 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package openai
+
+import (
+	"encoding/json"
+	"maps"
+	"strings"
+
+	"github.com/gravitational/trace"
+	jsoniter "github.com/json-iterator/go"
+
+	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// endpointType is the OpenAI API endpoint format.
+type endpointType string
+
+const (
+	endpointTypeResponses       endpointType = "responses"
+	endpointTypeChatCompletions endpointType = "chat_completions"
+)
+
+// RequestInfo contains the request information.
+type RequestInfo struct {
+	requestedModel string
+	providerModel  string
+	stream         bool
+	requestSize    int
+	endpointType   endpointType
+}
+
+func (r *RequestInfo) RequestedModel() string { return r.requestedModel }
+func (r *RequestInfo) ProviderModel() string  { return r.providerModel }
+func (r *RequestInfo) IsStream() bool         { return r.stream }
+func (r *RequestInfo) RequestSize() int       { return r.requestSize }
+
+type apiRequest interface {
+	GetModel() string
+	SetModel(string)
+	GetStream() bool
+	EnableReportUsage()
+	Validate() error
+}
+
+// responsesAPIRequest contains part of the fields from responses API request
+// body.
+//
+// https://developers.openai.com/api/reference/resources/responses/methods/create
+type responsesAPIRequest struct {
+	Model      string `json:"model"`
+	Stream     bool   `json:"stream"`
+	Background bool   `json:"background"`
+
+	raw map[string]json.RawMessage `json:"-"`
+}
+
+// Nothing to do, usage is always reported on responses API.
+func (r *responsesAPIRequest) EnableReportUsage()    {}
+func (r *responsesAPIRequest) GetModel() string      { return r.Model }
+func (r *responsesAPIRequest) GetStream() bool       { return r.Stream }
+func (r *responsesAPIRequest) SetModel(model string) { r.Model = model }
+func (r *responsesAPIRequest) Validate() error {
+	if r.Background {
+		return llmerrors.NewProviderError(llmerrors.ErrUnsupported, "background responses not supported")
+	}
+
+	return nil
+}
+
+func (r *responsesAPIRequest) UnmarshalJSON(data []byte) error {
+	type Alias responsesAPIRequest
+	aux := &struct{ *Alias }{Alias: (*Alias)(r)}
+	if err := caseSensitiveJSONConfig.Unmarshal(data, aux); err != nil {
+		return trace.Wrap(err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := utils.FastUnmarshal(data, &raw); err != nil {
+		return trace.Wrap(err)
+	}
+
+	for key := range raw {
+		switch strings.ToLower(key) {
+		case "model", "stream", "background":
+			delete(raw, key)
+		default:
+		}
+	}
+
+	r.raw = raw
+	return nil
+}
+
+func (r responsesAPIRequest) MarshalJSON() ([]byte, error) {
+	final := make(map[string]json.RawMessage, len(r.raw)+2) // Current len + taken fields.
+	maps.Copy(final, r.raw)
+	if err := marshalField(final, "model", r.Model); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := marshalField(final, "stream", r.Stream); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// [Background] is expected to always be set `false`, so no need to marshal
+	// it.
+	res, err := utils.FastMarshal(final)
+	return res, trace.Wrap(err)
+}
+
+func marshalField(raw map[string]json.RawMessage, fieldName string, value any) error {
+	field, err := json.Marshal(value)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	raw[fieldName] = field
+	return nil
+}
+
+// responsesAPIUsage contains part of the fields from responses API response
+// body.
+//
+// https://developers.openai.com/api/reference/resources/responses/methods/create#(resource)%20responses%20%3E%20(model)%20response%20%3E%20(schema)
+type responsesAPIUsage struct {
+	Usage struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+	} `json:"usage"`
+}
+
+// responsesSSEEventWithUsage contains part of responses SSE event that contains
+// `usage` information.
+type responsesSSEEventWithUsage struct {
+	Response responsesAPIUsage `json:"response"`
+}
+
+// responsesFailedSSEEvent contains part of the fields from responses API
+// `response.failed` SSE event.
+//
+// https://developers.openai.com/api/reference/resources/responses/streaming-events#response.failed
+type responsesFailedSSEEvent struct {
+	Type           string        `json:"type"`
+	Response       errorEnvelope `json:"response"`
+	SequenceNumber int           `json:"sequence_number"`
+}
+
+// responsesErrorSSEEvent contains part of the fields from responses API `error`
+// SSE event.
+//
+// https://developers.openai.com/api/reference/resources/responses/streaming-events#error
+type responsesErrorSSEEvent struct {
+	Type           string `json:"type"`
+	Message        string `json:"message"`
+	SequenceNumber int    `json:"sequence_number"`
+}
+
+// caseSensitiveJSONConfig is used to decode JSON messages. The config is
+// based on jsoniter.ConfigCompatibleWithStandardLibrary with the addition of
+// CaseSensitive enabled.
+// TODO(gabrielcorado): Migrate to encoding/json/v2 once it's out of experimentation.
+var caseSensitiveJSONConfig = jsoniter.Config{
+	EscapeHTML:             true,
+	SortMapKeys:            true,
+	ValidateJsonRawMessage: true,
+	CaseSensitive:          true,
+}.Froze()

--- a/lib/srv/app/llm/openai/types.go
+++ b/lib/srv/app/llm/openai/types.go
@@ -65,6 +65,7 @@ type responsesAPIRequest struct {
 	Model      string `json:"model"`
 	Stream     bool   `json:"stream"`
 	Background bool   `json:"background"`
+	Store      bool   `json:"store"`
 
 	raw map[string]json.RawMessage `json:"-"`
 }
@@ -77,6 +78,9 @@ func (r *responsesAPIRequest) SetModel(model string) { r.Model = model }
 func (r *responsesAPIRequest) Validate() error {
 	if r.Background {
 		return llmerrors.NewProviderError(llmerrors.ErrUnsupported, "background responses not supported")
+	}
+	if r.Store {
+		return llmerrors.NewProviderError(llmerrors.ErrUnsupported, "storing responses not supported")
 	}
 
 	return nil
@@ -117,8 +121,8 @@ func (r responsesAPIRequest) MarshalJSON() ([]byte, error) {
 			return nil, trace.Wrap(err)
 		}
 	}
-	// [Background] is expected to always be set `false`, so no need to marshal
-	// it.
+	// [Background] and [Store] are expected to always be set `false`, so no
+	// need to marshal it.
 	res, err := utils.FastMarshal(final)
 	return res, trace.Wrap(err)
 }

--- a/lib/srv/app/llm/openai/types_test.go
+++ b/lib/srv/app/llm/openai/types_test.go
@@ -1,0 +1,252 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package openai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func TestParseResponsesRequest(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input       string
+		expectError require.ErrorAssertionFunc
+		expectValue require.ValueAssertionFunc
+	}{
+		"valid json with fields": {
+			input:       `{"model": "gpt-5", "stream": true, "max_output_tokens": 1024, "input":"Hello"}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(responsesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Equal(tt, "gpt-5", req.Model, i2...)
+				require.True(tt, req.Stream, i2...)
+				require.Contains(tt, req.raw, "input")
+			},
+		},
+		"valid json missing fields": {
+			input:       `{"input":"Hello"}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(responsesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Empty(tt, req.Model, i2...)
+				require.False(tt, req.Stream, i2...)
+				require.Contains(tt, req.raw, "input")
+			},
+		},
+		"model duplicates": {
+			input:       `{"model":"gpt-5","model":"gpt-5-mini","MODEL":"gpt-4o","max_output_tokens":1024,"stream":true,"input":"Hello"}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(responsesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Equal(tt, "gpt-5-mini", req.Model, i2...)
+				require.Contains(tt, req.raw, "input")
+			},
+		},
+		"model duplicates different casing": {
+			input:       `{"model":"gpt-5","MODEL":"gpt-4o","max_output_tokens":1024,"stream":true,"input":"Hello"}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(responsesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Equal(tt, "gpt-5", req.Model, i2...)
+				require.Contains(tt, req.raw, "input")
+			},
+		},
+		"stream duplicates": {
+			input:       `{"model":"gpt-5","stream":true,"stream":false,"input":"Hello"}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(responsesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.False(tt, req.Stream, i2...)
+				require.Contains(tt, req.raw, "input")
+			},
+		},
+		"stream duplicates different casing": {
+			input:       `{"model":"gpt-5","stream":true,"STREAM":false,"input":"Hello"}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(responsesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.True(tt, req.Stream, i2...)
+				require.Contains(tt, req.raw, "input")
+			},
+		},
+		"max output tokens duplicates": {
+			input:       `{"model":"gpt-5","max_output_tokens":1024,"max_output_tokens":5555,"stream":true,"input":"Hello"}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(responsesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Contains(tt, req.raw, "input")
+			},
+		},
+		"max output tokens duplicates different casing": {
+			input:       `{"model":"gpt-5","max_output_tokens":1024,"MAX_OUTPUT_TOKENS":9999,"stream":true,"input":"Hello"}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(responsesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Contains(tt, req.raw, "input")
+			},
+		},
+		"fields in uppercase": {
+			input:       `{"MODEL":"gpt-5","MAX_OUTPUT_TOKENS":1024,"STREAM":true,"input":"Hello"}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(responsesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Empty(tt, req.Model, i2...)
+				require.False(tt, req.Stream, i2...)
+				require.Contains(tt, req.raw, "input")
+			},
+		},
+		"stream invalid format": {
+			input:       `{"model":"gpt-5","stream":"yes","input":"Hello"}`,
+			expectError: require.Error,
+			expectValue: require.NotEmpty,
+		},
+		"duplicated other fields no error": {
+			input:       `{"model": "gpt-5", "stream": true, "max_output_tokens": 1024, "input":"Hello", "reasoning": {"effort": "low"}, "reasoning": {"effort": "high"}}`,
+			expectError: require.NoError,
+			expectValue: require.NotEmpty,
+		},
+		"invalid json": {
+			input:       `{random}`,
+			expectError: require.Error,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(responsesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Empty(tt, req.Model, i2...)
+				require.False(tt, req.Stream, i2...)
+				require.Empty(tt, req.raw, i2...)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var r responsesAPIRequest
+			tc.expectError(t, utils.FastUnmarshal([]byte(tc.input), &r))
+			tc.expectValue(t, r)
+		})
+	}
+}
+
+func TestEncodeResponsesRequest(t *testing.T) {
+	// For this test we use the value generated from a raw responses API request,
+	// so effectively we're also testing the parsing/decoding part as well.
+
+	for name, tc := range map[string]struct {
+		input         string
+		modifyRequest func(*responsesAPIRequest)
+		output        string
+		expectError   require.ErrorAssertionFunc
+		expectValue   require.ValueAssertionFunc
+	}{
+		"unmodified fields": {
+			input:         `{"model": "gpt-5", "stream": true, "max_output_tokens": 1024, "input":"Hello"}`,
+			modifyRequest: func(r *responsesAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "gpt-5", "stream": true, "max_output_tokens": 1024, "input":"Hello"}`, resp)
+			},
+		},
+		"modified fields": {
+			input: `{"model": "gpt-5", "stream": true, "max_output_tokens": 1024, "input":"Hello"}`,
+			modifyRequest: func(r *responsesAPIRequest) {
+				r.Model = "gpt-5-mini"
+				r.Stream = false
+			},
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "gpt-5-mini", "stream": false, "max_output_tokens": 1024, "input":"Hello"}`, resp)
+			},
+		},
+		"set model via SetModel": {
+			input: `{"model": "gpt-5", "stream": true, "max_output_tokens": 1024, "input":"Hello"}`,
+			modifyRequest: func(r *responsesAPIRequest) {
+				r.SetModel("gpt-4o")
+			},
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "gpt-4o", "stream": true, "max_output_tokens": 1024, "input":"Hello"}`, resp)
+			},
+		},
+		"duplicate fields": {
+			input:         `{"model": "gpt-5", "model": "gpt-5-mini", "stream": true, "stream": false, "max_output_tokens": 1024, "max_output_tokens": 5555, "input":"Hello"}`,
+			modifyRequest: func(r *responsesAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "gpt-5-mini", "stream": false, "max_output_tokens": 5555, "input":"Hello"}`, resp)
+			},
+		},
+		"duplicate fields different casing": {
+			input:         `{"model": "gpt-5", "MODEL": "gpt-5-mini", "stream": true, "STREAM": false, "input":"Hello"}`,
+			modifyRequest: func(r *responsesAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				// Expect values from lowercase keys.
+				require.JSONEq(tt, `{"model": "gpt-5", "stream": true, "input":"Hello"}`, resp)
+			},
+		},
+		"full uppercase keys": {
+			input:         `{"MODEL": "gpt-5", "STREAM": true, "input":"Hello"}`,
+			modifyRequest: func(r *responsesAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "", "stream": false, "input":"Hello"}`, resp)
+			},
+		},
+		"valid json missing fields": {
+			input:         `{"input":"Hello"}`,
+			modifyRequest: func(r *responsesAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "", "stream": false, "input":"Hello"}`, resp)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var r responsesAPIRequest
+			require.NoError(t, utils.FastUnmarshal([]byte(tc.input), &r))
+			tc.modifyRequest(&r)
+
+			res, err := utils.FastMarshal(r)
+			tc.expectError(t, err)
+			tc.expectValue(t, string(res))
+		})
+	}
+}

--- a/lib/srv/app/llm/openai/types_test.go
+++ b/lib/srv/app/llm/openai/types_test.go
@@ -182,7 +182,7 @@ func TestEncodeResponsesRequest(t *testing.T) {
 			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
 				resp, ok := i1.(string)
 				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
-				require.JSONEq(tt, `{"model": "gpt-5-mini", "stream": false, "max_output_tokens": 1024, "input":"Hello"}`, resp)
+				require.JSONEq(tt, `{"model": "gpt-5-mini", "max_output_tokens": 1024, "input":"Hello"}`, resp)
 			},
 		},
 		"set model via SetModel": {
@@ -204,7 +204,7 @@ func TestEncodeResponsesRequest(t *testing.T) {
 			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
 				resp, ok := i1.(string)
 				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
-				require.JSONEq(tt, `{"model": "gpt-5-mini", "stream": false, "max_output_tokens": 5555, "input":"Hello"}`, resp)
+				require.JSONEq(tt, `{"model": "gpt-5-mini", "max_output_tokens": 5555, "input":"Hello"}`, resp)
 			},
 		},
 		"duplicate fields different casing": {
@@ -225,7 +225,7 @@ func TestEncodeResponsesRequest(t *testing.T) {
 			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
 				resp, ok := i1.(string)
 				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
-				require.JSONEq(tt, `{"model": "", "stream": false, "input":"Hello"}`, resp)
+				require.JSONEq(tt, `{"model": "", "input":"Hello"}`, resp)
 			},
 		},
 		"valid json missing fields": {
@@ -235,7 +235,7 @@ func TestEncodeResponsesRequest(t *testing.T) {
 			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
 				resp, ok := i1.(string)
 				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
-				require.JSONEq(tt, `{"model": "", "stream": false, "input":"Hello"}`, resp)
+				require.JSONEq(tt, `{"model": "", "input":"Hello"}`, resp)
 			},
 		},
 	} {

--- a/lib/srv/app/llm/request/request.go
+++ b/lib/srv/app/llm/request/request.go
@@ -68,3 +68,15 @@ func (c *Config) CheckAndSetDefaults() error {
 
 	return nil
 }
+
+// RequestInfo interface that contains the request information.
+type RequestInfo interface {
+	// RequestedModel returns the requested model name.
+	RequestedModel() string
+	// ProviderModel returns the model name sent to the provider.
+	ProviderModel() string
+	// IsStream indicates if the request uses streaming.
+	IsStream() bool
+	// RequestSize contains the total request size in bytes.
+	RequestSize() int
+}


### PR DESCRIPTION
Related to [RFD 0038e - LLM Access](https://github.com/gravitational/teleport.e/blob/rfd/0038e-llm-access/rfd/0038e-llm-access.md).

Adds an [OpenAI Responses API](https://developers.openai.com/api/reference/responses/overview) handler, allowing access to OpenAI-powered LLMs.

The `Recorder` and `NewRequest` are very close to the Anthropic structure.

> [!NOTE]
> This PR doesn't cover the chat completions API and the AWS Bedrock provider. Those two were removed from this PR to make it easier to review. They will be done in follow-up PRs.

## Manual Test Plan
### Test Environment

Local cluster with dedicated app service instance.

### Test Cases
- [x] Access using `curl` and `codex`
  - [x] Mapped model.
  - [x] Streaming requests.
  - [x] Fallback model.
  - [x] Invalid messages/errors returned are from Teleport.
  - [x] Audit events are included in the app session recording. `tsh play -f json <chunk-id>`
  - [x] Prometheus metrics generated.
- [x] Chat completions requests are rejected
- [x] Bedrock provider apps fail 100% of requests (return "provider is not supported" error)
