### PR TITLE
[v18] Stream the uploaded Azure blob instead of reading the whole payload into memory.

### DIFF
--- a/lib/srv/app/azure/handler.go
+++ b/lib/srv/app/azure/handler.go
@@ -19,7 +19,6 @@
 package azure
 
 import (
-	"bytes"
 	"context"
 	"crypto"
 	"crypto/x509"
@@ -129,9 +128,6 @@ func newAzureHandler(ctx context.Context, config HandlerConfig) (*handler, error
 
 // RoundTrip handles incoming requests and forwards them to the proper API.
 func (s *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	if req.Body != nil {
-		req.Body = utils.MaxBytesReader(w, req.Body, teleport.MaxHTTPRequestSize)
-	}
 	if err := s.serveHTTP(w, req); err != nil {
 		s.formatForwardResponseError(w, req, err)
 		return
@@ -169,6 +165,15 @@ func (s *handler) formatForwardResponseError(rw http.ResponseWriter, r *http.Req
 }
 
 // prepareForwardRequest prepares a request for forwarding, updating headers and target host. Several checks are made along the way.
+//
+// Do not read the request body but pass the reader as is, so that it streams.
+// In Azure there is a threshold (aka max_single_put_size) which changes how the
+// upload is performed. If the blob size is smaller than the threshold, the blob
+// is uploaded in a single request. If however it's bigger than the threshold,
+// it's uploaded in chunks.
+//
+// More details on the subject:
+// https://learn.microsoft.com/en-us/azure/storage/blobs/scalability-targets
 func (s *handler) prepareForwardRequest(r *http.Request, sessionCtx *common.SessionContext) (*http.Request, error) {
 	forwardedHost, err := utils.GetSingleHeader(r.Header, "X-Forwarded-Host")
 	if err != nil {
@@ -177,19 +182,10 @@ func (s *handler) prepareForwardRequest(r *http.Request, sessionCtx *common.Sess
 		return nil, trace.AccessDenied("%q is not an Azure endpoint", forwardedHost)
 	}
 
-	payload, err := utils.GetAndReplaceRequestBody(r)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	reqCopy, err := http.NewRequest(r.Method, r.URL.String(), bytes.NewReader(payload))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
+	reqCopy := r.Clone(r.Context())
 	reqCopy.URL.Scheme = "https"
 	reqCopy.URL.Host = forwardedHost
-	reqCopy.Header = r.Header.Clone()
+	reqCopy.Host = forwardedHost
 
 	err = s.replaceAuthHeaders(r, sessionCtx, reqCopy)
 	if err != nil {

--- a/lib/srv/app/azure/handler_test.go
+++ b/lib/srv/app/azure/handler_test.go
@@ -20,6 +20,13 @@ package azure
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,7 +34,162 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/jwt"
+	"github.com/gravitational/teleport/lib/srv/app/common"
+	"github.com/gravitational/teleport/lib/tlsca"
 )
+
+type streamingTestBody struct {
+	remaining int64
+	started   *atomic.Bool
+	readEarly *atomic.Bool
+}
+
+func (b *streamingTestBody) Read(p []byte) (int, error) {
+	if !b.started.Load() {
+		b.readEarly.Store(true)
+	}
+	if b.remaining == 0 {
+		return 0, io.EOF
+	}
+	if int64(len(p)) > b.remaining {
+		p = p[:b.remaining]
+	}
+	for i := range p {
+		p[i] = 'x'
+	}
+	b.remaining -= int64(len(p))
+	return len(p), nil
+}
+
+func (b *streamingTestBody) Close() error { return nil }
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type noopAudit struct{}
+
+func (noopAudit) OnSessionStart(context.Context, string, *tlsca.Identity, types.Application) error {
+	return nil
+}
+
+func (noopAudit) OnSessionEnd(context.Context, string, *tlsca.Identity, types.Application) error {
+	return nil
+}
+
+func (noopAudit) OnSessionChunk(context.Context, string, string, *tlsca.Identity, types.Application) error {
+	return nil
+}
+
+func (noopAudit) OnRequest(context.Context, *common.SessionContext, *http.Request, uint32, *common.AWSResolvedEndpoint) error {
+	return nil
+}
+
+func (noopAudit) OnDynamoDBRequest(context.Context, *common.SessionContext, *http.Request, uint32, *common.AWSResolvedEndpoint) error {
+	return nil
+}
+
+func (noopAudit) EmitEvent(context.Context, apievents.AuditEvent) error {
+	return nil
+}
+
+func TestForwarder_streamsLargeRequestBody(t *testing.T) {
+	t.Parallel()
+
+	clientKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+
+	clock := clockwork.NewRealClock()
+	jwtKey, err := jwt.New(&jwt.Config{
+		Clock:       clock,
+		PrivateKey:  clientKey,
+		ClusterName: types.TeleportAzureMSIEndpoint,
+	})
+	require.NoError(t, err)
+
+	const resource = "https://storage.azure.com/"
+	token, err := jwtKey.SignAzureToken(jwt.AzureTokenClaims{
+		TenantID: "tenant",
+		Resource: resource,
+	})
+	require.NoError(t, err)
+
+	var roundTripStarted atomic.Bool
+	var readBeforeRoundTrip atomic.Bool
+	wantSize := int64(teleport.MaxHTTPRequestSize + 1)
+
+	hnd, err := newAzureHandler(t.Context(), HandlerConfig{
+		Clock: clock,
+		RoundTripper: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			roundTripStarted.Store(true)
+
+			require.Equal(t, "https", req.URL.Scheme)
+			require.Equal(t, "account.blob.core.windows.net", req.URL.Host)
+			require.Equal(t, "account.blob.core.windows.net", req.Host)
+			require.Equal(t, "Bearer real-azure-token", req.Header.Get("Authorization"))
+
+			n, err := io.Copy(io.Discard, req.Body)
+			require.NoError(t, err)
+			require.Equal(t, wantSize, n)
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("ok")),
+				Header:     make(http.Header),
+			}, nil
+		}),
+		getAccessToken: func(ctx context.Context, managedIdentity string, scope string) (*azcore.AccessToken, error) {
+			if managedIdentity != "azure-identity" {
+				return nil, trace.BadParameter("wrong managed identity %q", managedIdentity)
+			}
+			if scope != resource {
+				return nil, trace.BadParameter("wrong scope %q", scope)
+			}
+			return &azcore.AccessToken{Token: "real-azure-token"}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPut, "https://teleport.local/container/blob", &streamingTestBody{
+		remaining: wantSize,
+		started:   &roundTripStarted,
+		readEarly: &readBeforeRoundTrip,
+	})
+	req.Header.Set("X-Forwarded-Host", "account.blob.core.windows.net")
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.TLS = &tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{{PublicKey: clientKey.Public()}},
+	}
+
+	app, err := types.NewAppV3(types.Metadata{Name: "azure"}, types.AppSpecV3{Cloud: types.CloudAzure})
+	require.NoError(t, err)
+
+	req = common.WithSessionContext(req, &common.SessionContext{
+		Identity: &tlsca.Identity{
+			Username: "alice",
+			RouteToApp: tlsca.RouteToApp{
+				AzureIdentity: "azure-identity",
+			},
+		},
+		App:   app,
+		Audit: noopAudit{},
+	})
+
+	rec := httptest.NewRecorder()
+	hnd.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, roundTripStarted.Load())
+	require.False(t, readBeforeRoundTrip.Load(), "request body was read before forwarding")
+}
 
 func TestForwarder_getToken(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Backport #68491 to branch/v18

addresses: https://github.com/gravitational/teleport/issues/68103

## What
The `tsh az storage blob upload` command fails for files in the ~10 MiB to ~256 MiB range while smaller and much larger files succeeded.

The Azure CLI's upload algorithm chooses between two paths based on file size:

≤ max_single_put_size (default 256 MiB): one Put Blob PUT containing the entire file.
> max_single_put_size: chunked Put Block + Put Block List, where each block is small (default 4 MiB).
A single PUT with a body larger than 10 MiB was rejected by the Teleport app proxy. The reason was on the server side, in [lib/srv/app/azure/handler.go](https://github.com/gravitational/teleport/blob/master/lib/srv/app/azure/handler.go#L133):

this meant every Azure request body had to fit in 10 MiB and be held in memory in full before being forwarded. Any single PUT exceeding 10 MiB will lead to race.LimitExceededError and the read limit is reached

Moreover, the limits have changed in the newer versions of the storage service (2019+):
https://learn.microsoft.com/en-us/azure/storage/blobs/scalability-targets

The newer limits mean that a client is allowed to sent up to 5Gb in a single write operation which makes it completely incompatible with the current Teleport behaviour, which currently buffers the whole request body (with a hard 10mb cap).

## Why

Current flow (feel free to correct if I miss something):
1. Azure CLI sends one HTTP request with a 15 MiB body.
2. Teleport wraps req.Body in MaxBytesReader(..., 10 MiB).
3. Teleport reads the whole request body with io.ReadAll(...) and creates a new clone request with the payload.
4. Teleport forwards the request using `httputil.ReverseProxy`.
5. `http.Transport` starts reading from `req.Body` and writing bytes to Azure.
6. The first 10 MiB can stream successfully.
7. When the transport tries to read byte >10 MiB, MaxBytesReader returns a limit error.
8. The upstream request fails mid-stream, so the upload fails.
9. The ErrLimitExceeded error maps to HTTP 429.

Updated flow in the PR:
1. Azure CLI sends one HTTP request - 10Mb < r.Body < 256Mb
2. Teleport performs shallow clone of the request but leaves the `r.Body` as is.
4. Teleport forwards the request using `httputil.ReverseProxy`.
5. http.Transport starts reading from `req.Body` and writing bytes to Azure, using stdlib `io.Reader`/`io.Writer` workflow with fixed (small) buffer.
6. the whole body is gradually streamed to Azure - success!

### Questions
I understand it's a big change and currently there is no limit for the size of the upload (Azure supports up to `5Gb`per single request with max blob size of `190.7 TiB`).
- Is there a reason why we read the whole request body into memory before cloning the request?
- I've removed the `MaxBytesReader` completely, but in fact I could keep it to restrict the max request size. With the new microsoft scalability targets this means `~5Gb`. We could choose to set it to `~256Mb` to reflect the current implementation of az, but this may mean it will break again with a new version of `az`. So the question is - should I add a limit and what that limit should be?

## Manual Test Plan
- [x] build an Azure console and upload file of different sizes to the blob store. Files of any sizes succeed.

### Test Environment
- Build Azure console using @smallinsky's terraform https://github.com/smallinsky/infra/tree/main/azure-cli-access (the proxy must be publicly accessible - I used Cloudflare tunnel and [this](https://github.com/marcoandredinis/ttunnel/tree/main) for the repro.

### Test Cases
- [x] Azure handler regression test.
    - Sends a request body larger than the old teleport.MaxHTTPRequestSize limit (10Mb < r.Body < 256Mb)
    - Exercises ServeHTTP
    - Verifies host/scheme rewrite and Authorisation replacement.
    - Verifies the body is not read before the fake upstream RoundTrip, proving no pre-forward buffering.