### PR TITLE
Fix slow makefile with GNU make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1938,6 +1938,8 @@ ensure-llvm-macos:
 	fi
 
 else
+WASM_CC = $(CC)
+WASM_AR = $(AR)
 ensure-llvm-macos:
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1922,10 +1922,15 @@ ensure-wasm-deps: ensure-llvm-macos rustup-toolchain-warning ensure-wasm-bindgen
 .PHONY: ensure-llvm-macos
 ifeq ("$(OS)-$(ARCH)","darwin-arm64")
 BREW_DIR = $(shell brew --prefix)
+unexport BREW_DIR
 LLVM_PREFIX = $(shell brew list | grep llvm | head -n 1)
+unexport LLVM_PREFIX
 LLVM_DIR = $(shell brew --prefix $(LLVM_PREFIX))
+unexport LLVM_DIR
 CC = $(LLVM_DIR)/bin/clang
+unexport CC
 AR = $(LLVM_DIR)/bin/llvm-ar
+unexport AR
 ensure-llvm-macos:
 	@if [[ "${BREW_DIR}" = "${LLVM_DIR}" ]]; then \
 		echo "llvm is required, please run 'brew install llvm' and add '/opt/homebrew/opt/llvm/bin' at the start of PATH variable"; \
@@ -1940,6 +1945,7 @@ WASM_BINDGEN_VERSION = $(shell awk ' \
   $$1 == "name" && $$3 == "\"wasm-bindgen\"" { in_pkg=1; next } \
   in_pkg && $$1 == "version" { gsub(/"/, "", $$3); print $$3; exit } \
 ' Cargo.lock)
+unexport WASM_BINDGEN_VERSION
 
 # Opt-in isolation (WASM_BINDGEN_ISOLATE=1): install and run the wasm-bindgen CLI
 # from a per-version path under target/ rather than the shared ~/.cargo/bin. 
@@ -1956,6 +1962,7 @@ print-wasm-bindgen-version:
 	@echo $(WASM_BINDGEN_VERSION)
 
 RUST_TOOLCHAIN_VERSION = $(shell awk '$$1 == "channel" && $$2 == "=" { gsub(/"/, "", $$3); print $$3 }' rust-toolchain.toml )
+unexport RUST_TOOLCHAIN_VERSION
 
 .PHONY: print-rust-toolchain-version
 print-rust-toolchain-version:

--- a/Makefile
+++ b/Makefile
@@ -1938,8 +1938,8 @@ ensure-llvm-macos:
 	fi
 
 else
-WASM_CC = $(CC)
-WASM_AR = $(AR)
+WASM_CC = clang
+WASM_AR = llvm-ar
 ensure-llvm-macos:
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -568,7 +568,7 @@ build-ironrdp-wasm:
 	@echo "Skipping ironrdp WASM build (IRONRDP_SKIP_BUILD=1)"
 else
 build-ironrdp-wasm: ensure-wasm-deps
-	RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo build --package ironrdp --lib --target $(CARGO_WASM_TARGET) --release
+	RUSTFLAGS='--cfg getrandom_backend="wasm_js"' CC="$(WASM_CC)" AR="$(WASM_AR)" cargo build --package ironrdp --lib --target $(CARGO_WASM_TARGET) --release
 	wasm-opt target/$(CARGO_WASM_TARGET)/release/ironrdp.wasm -o target/$(CARGO_WASM_TARGET)/release/ironrdp.wasm -O
 	$(WASM_BINDGEN) target/$(CARGO_WASM_TARGET)/release/ironrdp.wasm --out-dir $(ironrdp)/pkg --typescript --target web
 	printenv ironrdp_package_json > $(ironrdp)/pkg/package.json
@@ -1927,10 +1927,10 @@ LLVM_PREFIX = $(shell brew list | grep llvm | head -n 1)
 unexport LLVM_PREFIX
 LLVM_DIR = $(shell brew --prefix $(LLVM_PREFIX))
 unexport LLVM_DIR
-CC = $(LLVM_DIR)/bin/clang
-unexport CC
-AR = $(LLVM_DIR)/bin/llvm-ar
-unexport AR
+WASM_CC = $(LLVM_DIR)/bin/clang
+unexport WASM_CC
+WASM_AR = $(LLVM_DIR)/bin/llvm-ar
+unexport WASM_AR
 ensure-llvm-macos:
 	@if [[ "${BREW_DIR}" = "${LLVM_DIR}" ]]; then \
 		echo "llvm is required, please run 'brew install llvm' and add '/opt/homebrew/opt/llvm/bin' at the start of PATH variable"; \
@@ -1973,7 +1973,7 @@ ensure-wasm-bindgen: INSTALLED_VERSION = $(word 2,$(shell $(WASM_BINDGEN) --vers
 ensure-wasm-bindgen:
 	@: $(or $(NEED_VERSION),$(error Unknown wasm-bindgen version. Is it in Cargo.lock?))
 	$(if $(filter-out $(INSTALLED_VERSION),$(NEED_VERSION)),\
-		cargo install wasm-bindgen-cli --force --locked --version "$(NEED_VERSION)" $(WASM_BINDGEN_INSTALL_FLAGS), \
+		CC="$(WASM_CC)" AR="$(WASM_AR)" cargo install wasm-bindgen-cli --force --locked --version "$(NEED_VERSION)" $(WASM_BINDGEN_INSTALL_FLAGS), \
 		@echo wasm-bindgen-cli up-to-date: $(INSTALLED_VERSION) \
 	)
 endif
@@ -1981,7 +1981,7 @@ endif
 .PHONY: ensure-wasm-opt
 ensure-wasm-opt: WASM_OPT_VERSION := $(shell $(MAKE) --no-print-directory -C build.assets print-wasm-opt-version)
 ensure-wasm-opt:
-	cargo install --locked wasm-opt@$(WASM_OPT_VERSION)
+	CC="$(WASM_CC)" AR="$(WASM_AR)" cargo install --locked wasm-opt@$(WASM_OPT_VERSION)
 
 .PHONY: build-ui
 build-ui: ensure-js-deps ensure-wasm-deps

--- a/common.mk
+++ b/common.mk
@@ -25,6 +25,7 @@ BPF_MESSAGE := without-BPF-support
 # will it require cross-compilation? We need to know this (especially for ARM) so we
 # can set the cross-compiler path (and possibly feature flags) correctly.
 IS_NATIVE_BUILD ?= $(filter $(ARCH),$(shell go env GOARCH))
+unexport IS_NATIVE_BUILD
 IS_CROSS_COMPILE_BB = $(filter $(BUILDBOX_MODE),cross)
 
 # Only build with BPF for linux/amd64 and linux/arm64.


### PR DESCRIPTION
Since the Linux Desktop PR, make commands have been taking a few minutes instead of a few seconds.
This also broke the CD pipeline and linux builds in general.


This is caused by:
- us exporting every variable
- exported variables being evaluated every time another process starts
- the new variables spinning up a shell to obtain their value
- the CC variable being overwritten for the whole Makefile, changing the compiler for every other target

A single `make` target caused thousands of `brew` invocations. I don't know why all vars are exported but I'm confident things will break if I unexport them, so I only unexported the expensive variables.

CC was used somewhere else so I introduced the unexported WASM_CC.

## Manual Test Plan
### Test Environment

- CD
- buildbox

### Test Cases
- [ ] Cut a dev build: https://github.com/gravitational/teleport.e/actions/runs/29115763350
- [x] make full full-ent
- [x] make ensure-webassets passes in the linux buildbox