### PR TITLE
Add delegation to user login state

### DIFF
--- a/api/gen/proto/go/teleport/userloginstate/v1/userloginstate_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/userloginstate/v1/userloginstate_protohybrid.pb.go
@@ -23,6 +23,7 @@
 package userloginstatev1
 
 import (
+	v12 "github.com/gravitational/teleport/api/gen/proto/go/teleport/delegation/v1"
 	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	v11 "github.com/gravitational/teleport/api/gen/proto/go/teleport/trait/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
@@ -185,8 +186,13 @@ type Spec struct {
 	// access_list_traits are traits granted to this user by the Access Lists membership/ownership.
 	// Basically, [access_list_traits] = [traits] - [original_traits].
 	AccessListTraits []*v11.Trait `protobuf:"bytes,9,rep,name=access_list_traits,json=accessListTraits,proto3" json:"access_list_traits,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// delegation represents the relationship between the user and the identity
+	// who delegated their access to the them. This field is not ephemeral, but
+	// is stored on the user login state to avoid needing to read the user record
+	// separately when generating certificates.
+	Delegation    *v12.Delegation `protobuf:"bytes,10,opt,name=delegation,proto3" json:"delegation,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Spec) Reset() {
@@ -277,6 +283,13 @@ func (x *Spec) GetAccessListTraits() []*v11.Trait {
 	return nil
 }
 
+func (x *Spec) GetDelegation() *v12.Delegation {
+	if x != nil {
+		return x.Delegation
+	}
+	return nil
+}
+
 func (x *Spec) SetRoles(v []string) {
 	x.Roles = v
 }
@@ -313,6 +326,10 @@ func (x *Spec) SetAccessListTraits(v []*v11.Trait) {
 	x.AccessListTraits = v
 }
 
+func (x *Spec) SetDelegation(v *v12.Delegation) {
+	x.Delegation = v
+}
+
 func (x *Spec) HasGitHubIdentity() bool {
 	if x == nil {
 		return false
@@ -320,8 +337,19 @@ func (x *Spec) HasGitHubIdentity() bool {
 	return x.GitHubIdentity != nil
 }
 
+func (x *Spec) HasDelegation() bool {
+	if x == nil {
+		return false
+	}
+	return x.Delegation != nil
+}
+
 func (x *Spec) ClearGitHubIdentity() {
 	x.GitHubIdentity = nil
+}
+
+func (x *Spec) ClearDelegation() {
+	x.Delegation = nil
 }
 
 type Spec_builder struct {
@@ -373,6 +401,11 @@ type Spec_builder struct {
 	// access_list_traits are traits granted to this user by the Access Lists membership/ownership.
 	// Basically, [access_list_traits] = [traits] - [original_traits].
 	AccessListTraits []*v11.Trait
+	// delegation represents the relationship between the user and the identity
+	// who delegated their access to the them. This field is not ephemeral, but
+	// is stored on the user login state to avoid needing to read the user record
+	// separately when generating certificates.
+	Delegation *v12.Delegation
 }
 
 func (b0 Spec_builder) Build() *Spec {
@@ -388,6 +421,7 @@ func (b0 Spec_builder) Build() *Spec {
 	x.SamlIdentities = b.SamlIdentities
 	x.AccessListRoles = b.AccessListRoles
 	x.AccessListTraits = b.AccessListTraits
+	x.Delegation = b.Delegation
 	return m0
 }
 
@@ -521,10 +555,10 @@ var File_teleport_userloginstate_v1_userloginstate_proto protoreflect.FileDescri
 
 const file_teleport_userloginstate_v1_userloginstate_proto_rawDesc = "" +
 	"\n" +
-	"/teleport/userloginstate/v1/userloginstate.proto\x12\x1ateleport.userloginstate.v1\x1a'teleport/header/v1/resourceheader.proto\x1a\x1dteleport/trait/v1/trait.proto\"\x82\x01\n" +
+	"/teleport/userloginstate/v1/userloginstate.proto\x12\x1ateleport.userloginstate.v1\x1a'teleport/delegation/v1/delegation.proto\x1a'teleport/header/v1/resourceheader.proto\x1a\x1dteleport/trait/v1/trait.proto\"\x82\x01\n" +
 	"\x0eUserLoginState\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x124\n" +
-	"\x04spec\x18\x02 \x01(\v2 .teleport.userloginstate.v1.SpecR\x04spec\"\xf8\x03\n" +
+	"\x04spec\x18\x02 \x01(\v2 .teleport.userloginstate.v1.SpecR\x04spec\"\xbc\x04\n" +
 	"\x04Spec\x12\x14\n" +
 	"\x05roles\x18\x01 \x03(\tR\x05roles\x120\n" +
 	"\x06traits\x18\x02 \x03(\v2\x18.teleport.trait.v1.TraitR\x06traits\x12\x1b\n" +
@@ -534,7 +568,11 @@ const file_teleport_userloginstate_v1_userloginstate_proto_rawDesc = "" +
 	"\x10git_hub_identity\x18\x06 \x01(\v2,.teleport.userloginstate.v1.ExternalIdentityR\x0egitHubIdentity\x12U\n" +
 	"\x0fsaml_identities\x18\a \x03(\v2,.teleport.userloginstate.v1.ExternalIdentityR\x0esamlIdentities\x12*\n" +
 	"\x11access_list_roles\x18\b \x03(\tR\x0faccessListRoles\x12F\n" +
-	"\x12access_list_traits\x18\t \x03(\v2\x18.teleport.trait.v1.TraitR\x10accessListTraits\"\xd0\x01\n" +
+	"\x12access_list_traits\x18\t \x03(\v2\x18.teleport.trait.v1.TraitR\x10accessListTraits\x12B\n" +
+	"\n" +
+	"delegation\x18\n" +
+	" \x01(\v2\".teleport.delegation.v1.DelegationR\n" +
+	"delegation\"\xd0\x01\n" +
 	"\x10ExternalIdentity\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x1a\n" +
 	"\busername\x18\x02 \x01(\tR\busername\x12!\n" +
@@ -549,6 +587,7 @@ var file_teleport_userloginstate_v1_userloginstate_proto_goTypes = []any{
 	(*ExternalIdentity)(nil),  // 2: teleport.userloginstate.v1.ExternalIdentity
 	(*v1.ResourceHeader)(nil), // 3: teleport.header.v1.ResourceHeader
 	(*v11.Trait)(nil),         // 4: teleport.trait.v1.Trait
+	(*v12.Delegation)(nil),    // 5: teleport.delegation.v1.Delegation
 }
 var file_teleport_userloginstate_v1_userloginstate_proto_depIdxs = []int32{
 	3, // 0: teleport.userloginstate.v1.UserLoginState.header:type_name -> teleport.header.v1.ResourceHeader
@@ -558,12 +597,13 @@ var file_teleport_userloginstate_v1_userloginstate_proto_depIdxs = []int32{
 	2, // 4: teleport.userloginstate.v1.Spec.git_hub_identity:type_name -> teleport.userloginstate.v1.ExternalIdentity
 	2, // 5: teleport.userloginstate.v1.Spec.saml_identities:type_name -> teleport.userloginstate.v1.ExternalIdentity
 	4, // 6: teleport.userloginstate.v1.Spec.access_list_traits:type_name -> teleport.trait.v1.Trait
-	4, // 7: teleport.userloginstate.v1.ExternalIdentity.granted_traits:type_name -> teleport.trait.v1.Trait
-	8, // [8:8] is the sub-list for method output_type
-	8, // [8:8] is the sub-list for method input_type
-	8, // [8:8] is the sub-list for extension type_name
-	8, // [8:8] is the sub-list for extension extendee
-	0, // [0:8] is the sub-list for field type_name
+	5, // 7: teleport.userloginstate.v1.Spec.delegation:type_name -> teleport.delegation.v1.Delegation
+	4, // 8: teleport.userloginstate.v1.ExternalIdentity.granted_traits:type_name -> teleport.trait.v1.Trait
+	9, // [9:9] is the sub-list for method output_type
+	9, // [9:9] is the sub-list for method input_type
+	9, // [9:9] is the sub-list for extension type_name
+	9, // [9:9] is the sub-list for extension extendee
+	0, // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_teleport_userloginstate_v1_userloginstate_proto_init() }

--- a/api/gen/proto/go/teleport/userloginstate/v1/userloginstate_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/userloginstate/v1/userloginstate_protoopaque.pb.go
@@ -23,6 +23,7 @@
 package userloginstatev1
 
 import (
+	v12 "github.com/gravitational/teleport/api/gen/proto/go/teleport/delegation/v1"
 	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	v11 "github.com/gravitational/teleport/api/gen/proto/go/teleport/trait/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
@@ -146,6 +147,7 @@ type Spec struct {
 	xxx_hidden_SamlIdentities   *[]*ExternalIdentity   `protobuf:"bytes,7,rep,name=saml_identities,json=samlIdentities,proto3"`
 	xxx_hidden_AccessListRoles  []string               `protobuf:"bytes,8,rep,name=access_list_roles,json=accessListRoles,proto3"`
 	xxx_hidden_AccessListTraits *[]*v11.Trait          `protobuf:"bytes,9,rep,name=access_list_traits,json=accessListTraits,proto3"`
+	xxx_hidden_Delegation       *v12.Delegation        `protobuf:"bytes,10,opt,name=delegation,proto3"`
 	unknownFields               protoimpl.UnknownFields
 	sizeCache                   protoimpl.SizeCache
 }
@@ -246,6 +248,13 @@ func (x *Spec) GetAccessListTraits() []*v11.Trait {
 	return nil
 }
 
+func (x *Spec) GetDelegation() *v12.Delegation {
+	if x != nil {
+		return x.xxx_hidden_Delegation
+	}
+	return nil
+}
+
 func (x *Spec) SetRoles(v []string) {
 	x.xxx_hidden_Roles = v
 }
@@ -282,6 +291,10 @@ func (x *Spec) SetAccessListTraits(v []*v11.Trait) {
 	x.xxx_hidden_AccessListTraits = &v
 }
 
+func (x *Spec) SetDelegation(v *v12.Delegation) {
+	x.xxx_hidden_Delegation = v
+}
+
 func (x *Spec) HasGitHubIdentity() bool {
 	if x == nil {
 		return false
@@ -289,8 +302,19 @@ func (x *Spec) HasGitHubIdentity() bool {
 	return x.xxx_hidden_GitHubIdentity != nil
 }
 
+func (x *Spec) HasDelegation() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Delegation != nil
+}
+
 func (x *Spec) ClearGitHubIdentity() {
 	x.xxx_hidden_GitHubIdentity = nil
+}
+
+func (x *Spec) ClearDelegation() {
+	x.xxx_hidden_Delegation = nil
 }
 
 type Spec_builder struct {
@@ -342,6 +366,11 @@ type Spec_builder struct {
 	// access_list_traits are traits granted to this user by the Access Lists membership/ownership.
 	// Basically, [access_list_traits] = [traits] - [original_traits].
 	AccessListTraits []*v11.Trait
+	// delegation represents the relationship between the user and the identity
+	// who delegated their access to the them. This field is not ephemeral, but
+	// is stored on the user login state to avoid needing to read the user record
+	// separately when generating certificates.
+	Delegation *v12.Delegation
 }
 
 func (b0 Spec_builder) Build() *Spec {
@@ -357,6 +386,7 @@ func (b0 Spec_builder) Build() *Spec {
 	x.xxx_hidden_SamlIdentities = &b.SamlIdentities
 	x.xxx_hidden_AccessListRoles = b.AccessListRoles
 	x.xxx_hidden_AccessListTraits = &b.AccessListTraits
+	x.xxx_hidden_Delegation = b.Delegation
 	return m0
 }
 
@@ -486,10 +516,10 @@ var File_teleport_userloginstate_v1_userloginstate_proto protoreflect.FileDescri
 
 const file_teleport_userloginstate_v1_userloginstate_proto_rawDesc = "" +
 	"\n" +
-	"/teleport/userloginstate/v1/userloginstate.proto\x12\x1ateleport.userloginstate.v1\x1a'teleport/header/v1/resourceheader.proto\x1a\x1dteleport/trait/v1/trait.proto\"\x82\x01\n" +
+	"/teleport/userloginstate/v1/userloginstate.proto\x12\x1ateleport.userloginstate.v1\x1a'teleport/delegation/v1/delegation.proto\x1a'teleport/header/v1/resourceheader.proto\x1a\x1dteleport/trait/v1/trait.proto\"\x82\x01\n" +
 	"\x0eUserLoginState\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x124\n" +
-	"\x04spec\x18\x02 \x01(\v2 .teleport.userloginstate.v1.SpecR\x04spec\"\xf8\x03\n" +
+	"\x04spec\x18\x02 \x01(\v2 .teleport.userloginstate.v1.SpecR\x04spec\"\xbc\x04\n" +
 	"\x04Spec\x12\x14\n" +
 	"\x05roles\x18\x01 \x03(\tR\x05roles\x120\n" +
 	"\x06traits\x18\x02 \x03(\v2\x18.teleport.trait.v1.TraitR\x06traits\x12\x1b\n" +
@@ -499,7 +529,11 @@ const file_teleport_userloginstate_v1_userloginstate_proto_rawDesc = "" +
 	"\x10git_hub_identity\x18\x06 \x01(\v2,.teleport.userloginstate.v1.ExternalIdentityR\x0egitHubIdentity\x12U\n" +
 	"\x0fsaml_identities\x18\a \x03(\v2,.teleport.userloginstate.v1.ExternalIdentityR\x0esamlIdentities\x12*\n" +
 	"\x11access_list_roles\x18\b \x03(\tR\x0faccessListRoles\x12F\n" +
-	"\x12access_list_traits\x18\t \x03(\v2\x18.teleport.trait.v1.TraitR\x10accessListTraits\"\xd0\x01\n" +
+	"\x12access_list_traits\x18\t \x03(\v2\x18.teleport.trait.v1.TraitR\x10accessListTraits\x12B\n" +
+	"\n" +
+	"delegation\x18\n" +
+	" \x01(\v2\".teleport.delegation.v1.DelegationR\n" +
+	"delegation\"\xd0\x01\n" +
 	"\x10ExternalIdentity\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x1a\n" +
 	"\busername\x18\x02 \x01(\tR\busername\x12!\n" +
@@ -514,6 +548,7 @@ var file_teleport_userloginstate_v1_userloginstate_proto_goTypes = []any{
 	(*ExternalIdentity)(nil),  // 2: teleport.userloginstate.v1.ExternalIdentity
 	(*v1.ResourceHeader)(nil), // 3: teleport.header.v1.ResourceHeader
 	(*v11.Trait)(nil),         // 4: teleport.trait.v1.Trait
+	(*v12.Delegation)(nil),    // 5: teleport.delegation.v1.Delegation
 }
 var file_teleport_userloginstate_v1_userloginstate_proto_depIdxs = []int32{
 	3, // 0: teleport.userloginstate.v1.UserLoginState.header:type_name -> teleport.header.v1.ResourceHeader
@@ -523,12 +558,13 @@ var file_teleport_userloginstate_v1_userloginstate_proto_depIdxs = []int32{
 	2, // 4: teleport.userloginstate.v1.Spec.git_hub_identity:type_name -> teleport.userloginstate.v1.ExternalIdentity
 	2, // 5: teleport.userloginstate.v1.Spec.saml_identities:type_name -> teleport.userloginstate.v1.ExternalIdentity
 	4, // 6: teleport.userloginstate.v1.Spec.access_list_traits:type_name -> teleport.trait.v1.Trait
-	4, // 7: teleport.userloginstate.v1.ExternalIdentity.granted_traits:type_name -> teleport.trait.v1.Trait
-	8, // [8:8] is the sub-list for method output_type
-	8, // [8:8] is the sub-list for method input_type
-	8, // [8:8] is the sub-list for extension type_name
-	8, // [8:8] is the sub-list for extension extendee
-	0, // [0:8] is the sub-list for field type_name
+	5, // 7: teleport.userloginstate.v1.Spec.delegation:type_name -> teleport.delegation.v1.Delegation
+	4, // 8: teleport.userloginstate.v1.ExternalIdentity.granted_traits:type_name -> teleport.trait.v1.Trait
+	9, // [9:9] is the sub-list for method output_type
+	9, // [9:9] is the sub-list for method input_type
+	9, // [9:9] is the sub-list for extension type_name
+	9, // [9:9] is the sub-list for extension extendee
+	0, // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_teleport_userloginstate_v1_userloginstate_proto_init() }

--- a/api/proto/teleport/userloginstate/v1/userloginstate.proto
+++ b/api/proto/teleport/userloginstate/v1/userloginstate.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package teleport.userloginstate.v1;
 
+import "teleport/delegation/v1/delegation.proto";
 import "teleport/header/v1/resourceheader.proto";
 import "teleport/trait/v1/trait.proto";
 
@@ -86,6 +87,12 @@ message Spec {
   // access_list_traits are traits granted to this user by the Access Lists membership/ownership.
   // Basically, [access_list_traits] = [traits] - [original_traits].
   repeated teleport.trait.v1.Trait access_list_traits = 9;
+
+  // delegation represents the relationship between the user and the identity
+  // who delegated their access to the them. This field is not ephemeral, but
+  // is stored on the user login state to avoid needing to read the user record
+  // separately when generating certificates.
+  teleport.delegation.v1.Delegation delegation = 10;
 }
 
 // ExternalIdentity defines an external identity attached to this user state.

--- a/api/types/userloginstate/convert/v1/user_login_state.go
+++ b/api/types/userloginstate/convert/v1/user_login_state.go
@@ -42,6 +42,7 @@ func FromProto(msg *userloginstatev1.UserLoginState) (*userloginstate.UserLoginS
 		UserType:         types.UserType(msg.GetSpec().GetUserType()),
 		GitHubIdentity:   externalIdentityFromProto(msg.GetSpec().GetGitHubIdentity()),
 		SAMLIdentities:   externalIdentitiesFromProto(msg.GetSpec().GetSamlIdentities()),
+		Delegation:       types.DelegationToLegacy(msg.GetSpec().GetDelegation()),
 	})
 
 	return uls, trace.Wrap(err)
@@ -61,6 +62,7 @@ func ToProto(uls *userloginstate.UserLoginState) *userloginstatev1.UserLoginStat
 			UserType:         string(uls.Spec.UserType),
 			GitHubIdentity:   externalIdentityToProto(uls.Spec.GitHubIdentity),
 			SamlIdentities:   externalIdentitiesToProto(uls.Spec.SAMLIdentities),
+			Delegation:       types.DelegationFromLegacy(uls.Spec.Delegation),
 		},
 	}
 }

--- a/api/types/userloginstate/derived.gen.go
+++ b/api/types/userloginstate/derived.gen.go
@@ -3,6 +3,7 @@
 package userloginstate
 
 import (
+	types "github.com/gravitational/teleport/api/types"
 	header "github.com/gravitational/teleport/api/types/header"
 	"time"
 )
@@ -51,7 +52,8 @@ func deriveTeleportEqual_(this, that *Spec) bool {
 			deriveTeleportEqual_3(this.AccessListTraits, that.AccessListTraits) &&
 			this.UserType == that.UserType &&
 			deriveTeleportEqual_4(this.GitHubIdentity, that.GitHubIdentity) &&
-			deriveTeleportEqual_5(this.SAMLIdentities, that.SAMLIdentities)
+			deriveTeleportEqual_5(this.SAMLIdentities, that.SAMLIdentities) &&
+			deriveTeleportEqual_6(this.Delegation, that.Delegation)
 }
 
 // deriveDeepCopy recursively copies the contents of src into dst.
@@ -165,6 +167,12 @@ func deriveDeepCopy_(dst, src *Spec) {
 		}
 		deriveDeepCopy_4(dst.SAMLIdentities, src.SAMLIdentities)
 	}
+	if src.Delegation == nil {
+		dst.Delegation = nil
+	} else {
+		dst.Delegation = new(types.Delegation)
+		deriveDeepCopy_5(dst.Delegation, src.Delegation)
+	}
 }
 
 // deriveTeleportEqual_1 returns whether this and that are equal.
@@ -173,7 +181,7 @@ func deriveTeleportEqual_1(this, that *header.Metadata) bool {
 		this != nil && that != nil &&
 			this.Name == that.Name &&
 			this.Description == that.Description &&
-			deriveTeleportEqual_6(this.Labels, that.Labels) &&
+			deriveTeleportEqual_7(this.Labels, that.Labels) &&
 			this.Expires.Equal(that.Expires)
 }
 
@@ -240,19 +248,28 @@ func deriveTeleportEqual_5(this, that []ExternalIdentity) bool {
 	return true
 }
 
+// deriveTeleportEqual_6 returns whether this and that are equal.
+func deriveTeleportEqual_6(this, that *types.Delegation) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			deriveTeleportEqual_8(this.User, that.User) &&
+			deriveTeleportEqual_9(this.Bot, that.Bot) &&
+			deriveTeleportEqual_6(this.Previous, that.Previous)
+}
+
 // deriveDeepCopy_1 recursively copies the contents of src into dst.
 func deriveDeepCopy_1(dst, src *header.Metadata) {
 	dst.Name = src.Name
 	dst.Description = src.Description
 	if src.Labels != nil {
 		dst.Labels = make(map[string]string, len(src.Labels))
-		deriveDeepCopy_5(dst.Labels, src.Labels)
+		deriveDeepCopy_6(dst.Labels, src.Labels)
 	} else {
 		dst.Labels = nil
 	}
 	func() {
 		field := new(time.Time)
-		deriveDeepCopy_6(field, &src.Expires)
+		deriveDeepCopy_7(field, &src.Expires)
 		dst.Expires = *field
 	}()
 	dst.Revision = src.Revision
@@ -327,8 +344,50 @@ func deriveDeepCopy_4(dst, src []ExternalIdentity) {
 	}
 }
 
-// deriveTeleportEqual_6 returns whether this and that are equal.
-func deriveTeleportEqual_6(this, that map[string]string) bool {
+// deriveDeepCopy_5 recursively copies the contents of src into dst.
+func deriveDeepCopy_5(dst, src *types.Delegation) {
+	if src.User == nil {
+		dst.User = nil
+	} else {
+		dst.User = new(types.UserDelegator)
+		deriveDeepCopy_8(dst.User, src.User)
+	}
+	if src.Bot == nil {
+		dst.Bot = nil
+	} else {
+		dst.Bot = new(types.BotDelegator)
+		deriveDeepCopy_9(dst.Bot, src.Bot)
+	}
+	if src.Previous == nil {
+		dst.Previous = nil
+	} else {
+		dst.Previous = new(types.Delegation)
+		deriveDeepCopy_5(dst.Previous, src.Previous)
+	}
+	dst.XXX_NoUnkeyedLiteral = src.XXX_NoUnkeyedLiteral
+	if src.XXX_unrecognized == nil {
+		dst.XXX_unrecognized = nil
+	} else {
+		if dst.XXX_unrecognized != nil {
+			if len(src.XXX_unrecognized) > len(dst.XXX_unrecognized) {
+				if cap(dst.XXX_unrecognized) >= len(src.XXX_unrecognized) {
+					dst.XXX_unrecognized = (dst.XXX_unrecognized)[:len(src.XXX_unrecognized)]
+				} else {
+					dst.XXX_unrecognized = make([]byte, len(src.XXX_unrecognized))
+				}
+			} else if len(src.XXX_unrecognized) < len(dst.XXX_unrecognized) {
+				dst.XXX_unrecognized = (dst.XXX_unrecognized)[:len(src.XXX_unrecognized)]
+			}
+		} else {
+			dst.XXX_unrecognized = make([]byte, len(src.XXX_unrecognized))
+		}
+		copy(dst.XXX_unrecognized, src.XXX_unrecognized)
+	}
+	dst.XXX_sizecache = src.XXX_sizecache
+}
+
+// deriveTeleportEqual_7 returns whether this and that are equal.
+func deriveTeleportEqual_7(this, that map[string]string) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -347,14 +406,80 @@ func deriveTeleportEqual_6(this, that map[string]string) bool {
 	return true
 }
 
-// deriveDeepCopy_5 recursively copies the contents of src into dst.
-func deriveDeepCopy_5(dst, src map[string]string) {
+// deriveTeleportEqual_8 returns whether this and that are equal.
+func deriveTeleportEqual_8(this, that *types.UserDelegator) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.Username == that.Username
+}
+
+// deriveTeleportEqual_9 returns whether this and that are equal.
+func deriveTeleportEqual_9(this, that *types.BotDelegator) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.Name == that.Name &&
+			this.Scope == that.Scope
+}
+
+// deriveDeepCopy_6 recursively copies the contents of src into dst.
+func deriveDeepCopy_6(dst, src map[string]string) {
 	for src_key, src_value := range src {
 		dst[src_key] = src_value
 	}
 }
 
-// deriveDeepCopy_6 recursively copies the contents of src into dst.
-func deriveDeepCopy_6(dst, src *time.Time) {
+// deriveDeepCopy_7 recursively copies the contents of src into dst.
+func deriveDeepCopy_7(dst, src *time.Time) {
 	*dst = *src
+}
+
+// deriveDeepCopy_8 recursively copies the contents of src into dst.
+func deriveDeepCopy_8(dst, src *types.UserDelegator) {
+	dst.Username = src.Username
+	dst.XXX_NoUnkeyedLiteral = src.XXX_NoUnkeyedLiteral
+	if src.XXX_unrecognized == nil {
+		dst.XXX_unrecognized = nil
+	} else {
+		if dst.XXX_unrecognized != nil {
+			if len(src.XXX_unrecognized) > len(dst.XXX_unrecognized) {
+				if cap(dst.XXX_unrecognized) >= len(src.XXX_unrecognized) {
+					dst.XXX_unrecognized = (dst.XXX_unrecognized)[:len(src.XXX_unrecognized)]
+				} else {
+					dst.XXX_unrecognized = make([]byte, len(src.XXX_unrecognized))
+				}
+			} else if len(src.XXX_unrecognized) < len(dst.XXX_unrecognized) {
+				dst.XXX_unrecognized = (dst.XXX_unrecognized)[:len(src.XXX_unrecognized)]
+			}
+		} else {
+			dst.XXX_unrecognized = make([]byte, len(src.XXX_unrecognized))
+		}
+		copy(dst.XXX_unrecognized, src.XXX_unrecognized)
+	}
+	dst.XXX_sizecache = src.XXX_sizecache
+}
+
+// deriveDeepCopy_9 recursively copies the contents of src into dst.
+func deriveDeepCopy_9(dst, src *types.BotDelegator) {
+	dst.Name = src.Name
+	dst.Scope = src.Scope
+	dst.XXX_NoUnkeyedLiteral = src.XXX_NoUnkeyedLiteral
+	if src.XXX_unrecognized == nil {
+		dst.XXX_unrecognized = nil
+	} else {
+		if dst.XXX_unrecognized != nil {
+			if len(src.XXX_unrecognized) > len(dst.XXX_unrecognized) {
+				if cap(dst.XXX_unrecognized) >= len(src.XXX_unrecognized) {
+					dst.XXX_unrecognized = (dst.XXX_unrecognized)[:len(src.XXX_unrecognized)]
+				} else {
+					dst.XXX_unrecognized = make([]byte, len(src.XXX_unrecognized))
+				}
+			} else if len(src.XXX_unrecognized) < len(dst.XXX_unrecognized) {
+				dst.XXX_unrecognized = (dst.XXX_unrecognized)[:len(src.XXX_unrecognized)]
+			}
+		} else {
+			dst.XXX_unrecognized = make([]byte, len(src.XXX_unrecognized))
+		}
+		copy(dst.XXX_unrecognized, src.XXX_unrecognized)
+	}
+	dst.XXX_sizecache = src.XXX_sizecache
 }

--- a/api/types/userloginstate/user_login_state.go
+++ b/api/types/userloginstate/user_login_state.go
@@ -19,6 +19,7 @@ package userloginstate
 import (
 	"github.com/gravitational/trace"
 
+	delegationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/delegation/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/header/convert/legacy"
@@ -94,6 +95,12 @@ type Spec struct {
 	//
 	// TODO(kopiczko) v19: consider proceeding with the STAGE 2 described above.
 	SAMLIdentities []ExternalIdentity `json:"saml_identities,omitempty" yaml:"saml_identities"`
+
+	// Delegation represents the relationship between the user and the identity
+	// who delegated their access to the them. This field is not ephemeral, but
+	// is stored on the user login state to avoid needing to read the user record
+	// separately when generating certificates.
+	Delegation *types.Delegation `json:"delegation,omitempty" yaml:"delegation"`
 }
 
 // ExternalIdentity defines an external identity attached to this user state.
@@ -239,4 +246,9 @@ func (u *UserLoginState) SetGithubIdentities(identities []types.ExternalIdentity
 			Username: identities[0].Username,
 		}
 	}
+}
+
+// GetDelegator returns the head of the user's delegation chain.
+func (u *UserLoginState) GetDelegation() *delegationv1.Delegation {
+	return types.DelegationFromLegacy(u.Spec.Delegation)
 }

--- a/lib/auth/userloginstate/generator.go
+++ b/lib/auth/userloginstate/generator.go
@@ -195,6 +195,7 @@ func (g *Generator) generate(ctx context.Context, user types.User, ulsService se
 			UserType:       user.GetUserType(),
 			GitHubIdentity: githubIdentity,
 			SAMLIdentities: samlIdentities,
+			Delegation:     types.DelegationToLegacy(user.GetDelegation()),
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
+	delegationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/delegation/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
@@ -1676,6 +1677,9 @@ type UserState interface {
 	GetGithubIdentities() []types.ExternalIdentity
 	// SetGithubIdentities sets the list of connected GitHub identities
 	SetGithubIdentities(identities []types.ExternalIdentity)
+
+	// GetDelegator returns the head of the user's delegation chain.
+	GetDelegation() *delegationv1.Delegation
 }
 
 // AccessInfoFromUserState return a new AccessInfo populated from the roles and


### PR DESCRIPTION
Based on https://github.com/gravitational/teleport/pull/68545

Propagate the user's delegation into the `UserLoginState` so it is available when generating certificates without needing to separately read the user record.

- [RFD 0329: Delegation V2](https://github.com/gravitational/rfd/pull/66)
- [Identity Delegation: Phase 1](https://github.com/gravitational/core/issues/536)
