### PR TITLE
Update ironrdp to 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22c0c90bbe8d4f77c3ca9ddabe41a1f8382d6fc1f7cea89459d0f320371f972"
+checksum = "da8c919c118108f144adecad74b425b804ad075580d605d9b33c2d6d1c62a2f8"
 dependencies = [
  "aead",
  "aes",
@@ -597,9 +597,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -697,12 +697,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.6"
+version = "5.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+checksum = "c906a87e53a36ff795d72e06e8162a83c5436e3ea89e942a9cb9fc083f0a384f"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto",
@@ -839,34 +839,33 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.17"
+version = "0.17.0-rc.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4bf51f0534ed6e59a0f2f26272b64ba55c470133f8424c2adfd1c4d59d9988"
+checksum = "b7c72d1455753a703ad4b90ed2a759f2bc4562024a303176439cf6e593b5ade4"
 dependencies = [
  "der 0.8.0",
  "digest 0.11.3",
  "elliptic-curve",
  "rfc6979",
- "signature 3.0.0-rc.10",
+ "signature 3.0.0",
  "spki 0.8.0",
  "zeroize",
 ]
 
 [[package]]
 name = "ed25519"
-version = "3.0.0-rc.4"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e914c7c52decb085cea910552e24c63ac019e3ab8bf001ff736da9a9d9d890"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "pkcs8 0.11.0-rc.11",
- "signature 3.0.0-rc.10",
+ "signature 3.0.0",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.6"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053618a4c3d3bc24f188aa660ae75a46eeab74ef07fb415c61431e5e7cd4749b"
+checksum = "1685663e23882cd8517dcbcb1c23a6ebff4433c22dfb681d760219b62cd1b849"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -878,22 +877,21 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.31"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b148a81cede8f4023248f980cffdf7611c46f2add469c6980e815b7c5b764ba5"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "crypto-common 0.2.2",
  "digest 0.11.3",
+ "ff",
+ "group",
  "hkdf",
  "hybrid-array",
- "once_cell",
  "pem-rfc7468 1.0.0",
- "pkcs8 0.11.0-rc.11",
+ "pkcs8 0.11.0",
  "rand_core 0.10.1",
- "rustcrypto-ff",
- "rustcrypto-group",
  "sec1",
  "subtle",
  "zeroize",
@@ -958,11 +956,11 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
-version = "0.14.0-pre.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d42dd26f5790eda47c1a2158ea4120e32c35ddc9a7743c98a292accc01b54ef3"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
 dependencies = [
- "rand_core 0.9.5",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -1217,12 +1215,12 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
-version = "0.14.0-pre.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff6a0b2dd4b981b1ae9e3e6830ab146771f3660d31d57bafd9018805a91b0f1"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
 dependencies = [
  "ff",
- "rand_core 0.9.5",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -1353,9 +1351,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "subtle",
  "typenum",
@@ -1581,8 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-async"
-version = "0.9.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=7dd4db0f6234da95f8d003bea406fbe74e238b03#7dd4db0f6234da95f8d003bea406fbe74e238b03"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea12d80384007fe321eb6b36c9225be9559c655fd581458a6a1386c1774d729"
 dependencies = [
  "bytes",
  "ironrdp-connector",
@@ -1594,12 +1593,14 @@ dependencies = [
 [[package]]
 name = "ironrdp-bulk"
 version = "0.1.1"
-source = "git+https://github.com/Devolutions/IronRDP?rev=7dd4db0f6234da95f8d003bea406fbe74e238b03#7dd4db0f6234da95f8d003bea406fbe74e238b03"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e548d9fd162558a5a8aaed72e528556ce88e77773634e3722b8d01d6f170388"
 
 [[package]]
 name = "ironrdp-cliprdr"
-version = "0.6.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=7dd4db0f6234da95f8d003bea406fbe74e238b03#7dd4db0f6234da95f8d003bea406fbe74e238b03"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb9050999a1e032f4313788ac5a6d06e897a4f672f1de2ed98683001fc1abf56"
 dependencies = [
  "bitflags 2.13.0",
  "ironrdp-core",
@@ -1610,8 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-connector"
-version = "0.9.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=7dd4db0f6234da95f8d003bea406fbe74e238b03#7dd4db0f6234da95f8d003bea406fbe74e238b03"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5898b3f1fcaca0f9b923b1463e158aeb64dfdec4ac361b7c086492466ff341c"
 dependencies = [
  "ironrdp-core",
  "ironrdp-error",
@@ -1628,16 +1630,18 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-core"
-version = "0.2.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=7dd4db0f6234da95f8d003bea406fbe74e238b03#7dd4db0f6234da95f8d003bea406fbe74e238b03"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0875b98275068b88652e49ba2e0a1150a1390aad69d26c942c8c59e8ec918e"
 dependencies = [
  "ironrdp-error",
 ]
 
 [[package]]
 name = "ironrdp-displaycontrol"
-version = "0.6.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=7dd4db0f6234da95f8d003bea406fbe74e238b03#7dd4db0f6234da95f8d003bea406fbe74e238b03"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74a111a6fd25abbe51b6a15276fe980c6b9eee50a1421224b0c3f45848d45bcf"
 dependencies = [
  "ironrdp-core",
  "ironrdp-dvc",
@@ -1648,8 +1652,9 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-dvc"
-version = "0.6.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=7dd4db0f6234da95f8d003bea406fbe74e238b03#7dd4db0f6234da95f8d003bea406fbe74e238b03"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a5de64988ddabf96928e2f042e1772a5f7201f0001ea99012129c73a105fc52"
 dependencies = [
  "ironrdp-core",
  "ironrdp-pdu",
@@ -1660,12 +1665,14 @@ dependencies = [
 [[package]]
 name = "ironrdp-error"
 version = "0.2.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=7dd4db0f6234da95f8d003bea406fbe74e238b03#7dd4db0f6234da95f8d003bea406fbe74e238b03"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd344ce9518ab83f6f7568ca4f1bc6dc8c55bd2da04cb5ee7b3e8740d5041734"
 
 [[package]]
 name = "ironrdp-graphics"
-version = "0.8.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=7dd4db0f6234da95f8d003bea406fbe74e238b03#7dd4db0f6234da95f8d003bea406fbe74e238b03"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7493e426b6a8104cd497e518ba7781a9c7fc9a5f58a9cc0c1111e6d66f63bcc"
 dependencies = [
  "bit_field",
  "bitflags 2.13.0",
@@ -1680,8 +1687,9 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-pdu"
-version = "0.8.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=7dd4db0f6234da95f8d003bea406fbe74e238b03#7dd4db0f6234da95f8d003bea406fbe74e238b03"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccd1179a4d106df1930347701388b5c79bc3725fa7dab4438d57db0d9d19347"
 dependencies = [
  "bit_field",
  "bitflags 2.13.0",
@@ -1702,8 +1710,9 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-rdpdr"
-version = "0.6.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=7dd4db0f6234da95f8d003bea406fbe74e238b03#7dd4db0f6234da95f8d003bea406fbe74e238b03"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece9e67ccf992eb8ce5ec0416d3950e2e199d4b1e2523f91af192205279fc970"
 dependencies = [
  "bitflags 2.13.0",
  "ironrdp-core",
@@ -1715,8 +1724,9 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-rdpsnd"
-version = "0.8.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=7dd4db0f6234da95f8d003bea406fbe74e238b03#7dd4db0f6234da95f8d003bea406fbe74e238b03"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1a4f7092ae8fdc0a2f61be8e100277dc6f4ad51b85455dc9e8157979993ea2"
 dependencies = [
  "bitflags 2.13.0",
  "ironrdp-core",
@@ -1727,11 +1737,11 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-session"
-version = "0.9.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=7dd4db0f6234da95f8d003bea406fbe74e238b03#7dd4db0f6234da95f8d003bea406fbe74e238b03"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1a5a20c24d8ebf47477f9f513201aeb894e7c7f779ea633ece65e42a9f0652"
 dependencies = [
  "ironrdp-bulk",
- "ironrdp-connector",
  "ironrdp-core",
  "ironrdp-displaycontrol",
  "ironrdp-dvc",
@@ -1746,8 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-svc"
-version = "0.7.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=7dd4db0f6234da95f8d003bea406fbe74e238b03#7dd4db0f6234da95f8d003bea406fbe74e238b03"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24c36b82ab0f7fef2668fb7004008a0f3c100a3d9a7b18bd4495a71aba55b796"
 dependencies = [
  "bitflags 2.13.0",
  "ironrdp-core",
@@ -1756,8 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-tls"
-version = "0.2.1"
-source = "git+https://github.com/Devolutions/IronRDP?rev=7dd4db0f6234da95f8d003bea406fbe74e238b03#7dd4db0f6234da95f8d003bea406fbe74e238b03"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5f0bb732e33159834f06a687f5415dae1a82c71c123c1c3a3689d41ed47645"
 dependencies = [
  "tokio",
  "tokio-rustls",
@@ -1766,8 +1778,9 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-tokio"
-version = "0.9.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=7dd4db0f6234da95f8d003bea406fbe74e238b03#7dd4db0f6234da95f8d003bea406fbe74e238b03"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7692ac83a98e4b3ac01405e311bbbd5a33683447032986ed92a4a44d46ad6344"
 dependencies = [
  "ironrdp-async",
  "tokio",
@@ -2149,9 +2162,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b97e3bf0465157ae90975ff52dbeb1362ba618924878c9f74c25baa27a65f9a"
+checksum = "c855a8d2ffd346aa03122626f22e96e3aa75e3bfe64e6bf6cb82f71821ed6ae7"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -2162,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437f30ebcb1e16ff48acead5f08bd69fbcdbc82421687bb48af5c315a0bfab03"
+checksum = "62941b68907ddf996ac20f0debf700c236ccc3d874637731a93c631129ca042f"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -2176,9 +2189,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9fd792bab86ecf6249561752fb5a413511f999887107dd054bbda5143743d7"
+checksum = "0dd6f2fe6e76c8d5e8828e92aafa463777d1e72e70b78acc724214757e92479a"
 dependencies = [
  "base16ct",
  "ecdsa",
@@ -2213,9 +2226,9 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.13.0-rc.10"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f24f3eb2f4471b1730d59e4b730b747939960a8c7eb0c33c5a9076f2d3dddea"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
  "digest 0.11.3",
  "hmac",
@@ -2253,11 +2266,10 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "picky"
-version = "7.0.0-rc.23"
+version = "7.0.0-rc.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8b243c0a8e59483c7b0f746aed1c1719245692a92e9a35693f9edb88a0b712"
+checksum = "c1ae9cd78eb1d61be4790713d28368cf71c844218fcd91542768805423f02666"
 dependencies = [
- "aead",
  "aes",
  "aes-gcm",
  "aes-kw",
@@ -2270,11 +2282,7 @@ dependencies = [
  "des",
  "digest 0.11.3",
  "ecdsa",
- "ed25519",
  "ed25519-dalek",
- "elliptic-curve",
- "ff",
- "group",
  "hex",
  "hmac",
  "http",
@@ -2288,14 +2296,11 @@ dependencies = [
  "picky-asn1-der",
  "picky-asn1-x509",
  "pkcs1 0.8.0-rc.4",
- "pkcs8 0.11.0-rc.11",
- "primefield",
  "primeorder",
  "rand 0.10.1",
  "rand_core 0.10.1",
  "rc2",
- "rfc6979",
- "rsa 0.10.0-rc.17",
+ "rsa 0.10.0-rc.18",
  "rustcrypto-ff",
  "rustcrypto-ff_derive",
  "rustcrypto-group",
@@ -2304,7 +2309,6 @@ dependencies = [
  "sha1 0.11.0",
  "sha2",
  "sha3",
- "signature 3.0.0-rc.10",
  "thiserror",
  "x25519-dalek",
  "zeroize",
@@ -2352,9 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "picky-krb"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43602452fdea9ee3fa4141a918c3659bc43d0277143e4ee06be89e26c22e8676"
+checksum = "2d188f3192356068dbdba54bddbca6fd0f7a09565d3861eeb8efe1ab77ae8e97"
 dependencies = [
  "aes",
  "block-padding",
@@ -2423,9 +2427,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.11"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der 0.8.0",
  "spki 0.8.0",
@@ -2508,25 +2512,28 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.9"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b52e6ee42db392378a95622b463c9740631171d1efce43fa445a569c1600cb6"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
 dependencies = [
  "crypto-bigint",
  "crypto-common 0.2.2",
+ "ff",
  "rand_core 0.10.1",
- "rustcrypto-ff",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0556580e42c19833f5d232aca11a7687a503ee41f937b54f5ae1d50fc2a6a36a"
+checksum = "4e56e6d67fdf5744e9e245ae571450fe584b91f5af261d0e40163b618e53a1f6"
 dependencies = [
  "elliptic-curve",
+ "once_cell",
+ "primefield",
+ "serdect",
 ]
 
 [[package]]
@@ -2832,12 +2839,12 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0-rc.5"
+version = "0.6.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a3127ee32baec36af75b4107082d9bd823501ec14a4e016be4b6b37faa74ae"
+checksum = "9935425142ac6e252364413291d96c8bc9898d0876a801824c7af4eae397b689"
 dependencies = [
+ "ctutils",
  "hmac",
- "subtle",
 ]
 
 [[package]]
@@ -2876,18 +2883,18 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.10.0-rc.17"
+version = "0.10.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ed3e93fc7e473e464b9726f4759659e72bc8665e4b8ea227547024f416d905"
+checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
 dependencies = [
  "const-oid 0.10.2",
  "crypto-bigint",
  "crypto-primes",
  "digest 0.11.3",
  "pkcs1 0.8.0-rc.4",
- "pkcs8 0.11.0-rc.11",
+ "pkcs8 0.11.0",
  "rand_core 0.10.1",
- "signature 3.0.0-rc.10",
+ "signature 3.0.0",
  "spki 0.8.0",
  "zeroize",
 ]
@@ -3213,12 +3220,13 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
 dependencies = [
  "digest 0.11.3",
  "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -3264,9 +3272,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.10"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
  "digest 0.11.3",
  "rand_core 0.10.1",
@@ -3330,10 +3338,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "sspi"
-version = "0.21.0"
+name = "sponge-cursor"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db83308ba07f6c54141f7e34a167353f81250fe8ccab87e90c323f4390b0fb0"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
+
+[[package]]
+name = "sspi"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15294fb005e36e0b0871d8fc0a4f6aac19f9f5440baee229a9a2b2d7de5ed484"
 dependencies = [
  "async-dnssd",
  "async-recursion",
@@ -3346,10 +3360,8 @@ dependencies = [
  "cryptoki",
  "curve25519-dalek",
  "ed25519-dalek",
- "ff",
  "futures",
  "getrandom 0.3.4",
- "group",
  "hmac",
  "md-5 0.11.0",
  "md4",
@@ -3365,14 +3377,12 @@ dependencies = [
  "picky-asn1-x509",
  "picky-krb",
  "pkcs1 0.8.0-rc.4",
- "pkcs8 0.11.0-rc.11",
  "portpicker",
- "primefield",
  "primeorder",
  "rand 0.10.1",
  "rand_core 0.10.1",
  "reqwest 0.12.28",
- "rsa 0.10.0-rc.17",
+ "rsa 0.10.0-rc.18",
  "rustcrypto-ff",
  "rustcrypto-ff_derive",
  "rustcrypto-group",
@@ -3381,7 +3391,6 @@ dependencies = [
  "serde",
  "sha1 0.11.0",
  "sha2",
- "signature 3.0.0-rc.10",
  "time",
  "tokio",
  "tracing",
@@ -4250,9 +4259,9 @@ checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "winscard"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1210bde4c851460210856b10dbbbad824f9e1e635794f44cf2ce552972521e44"
+checksum = "12dafb3c1468d0a3f5440e21e51614b53d1fdc62c9f82cc861c447906d09c69a"
 dependencies = [
  "bitflags 2.13.0",
  "crypto-bigint",
@@ -4263,7 +4272,7 @@ dependencies = [
  "num-traits",
  "picky",
  "picky-asn1-x509",
- "rsa 0.10.0-rc.17",
+ "rsa 0.10.0-rc.18",
  "sha1 0.11.0",
  "time",
  "tracing",
@@ -4382,9 +4391,9 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "3.0.0-pre.6"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d5d6ff67acd3945b933e592bfa7143db4fcbb2f871754b6b9fbd7847fc5aea"
+checksum = "eee64e8620caa64914d669b1f68f858aaff54e2d0f9ad3b30a613b58a1baa83e"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,18 +21,16 @@ lto = "thin"
 [workspace.dependencies]
 # Note: To use a local IronRDP repository as a crate (for example, ironrdp-cliprdr), define the dependency as follows:
 # ironrdp-cliprdr = { path = "/path/to/local/IronRDP/crates/ironrdp-cliprdr" }
-ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP", rev = "7dd4db0f6234da95f8d003bea406fbe74e238b03" }
-ironrdp-connector = { git = "https://github.com/Devolutions/IronRDP", rev = "7dd4db0f6234da95f8d003bea406fbe74e238b03" }
-ironrdp-core = { git = "https://github.com/Devolutions/IronRDP", rev = "7dd4db0f6234da95f8d003bea406fbe74e238b03" }
-ironrdp-displaycontrol = { git = "https://github.com/Devolutions/IronRDP", rev = "7dd4db0f6234da95f8d003bea406fbe74e238b03" }
-ironrdp-dvc = { git = "https://github.com/Devolutions/IronRDP", rev = "7dd4db0f6234da95f8d003bea406fbe74e238b03" }
-ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP", rev = "7dd4db0f6234da95f8d003bea406fbe74e238b03" }
-ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP", rev = "7dd4db0f6234da95f8d003bea406fbe74e238b03" }
-ironrdp-rdpdr = { git = "https://github.com/Devolutions/IronRDP", rev = "7dd4db0f6234da95f8d003bea406fbe74e238b03" }
-ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP", rev = "7dd4db0f6234da95f8d003bea406fbe74e238b03" }
-ironrdp-session = { git = "https://github.com/Devolutions/IronRDP", rev = "7dd4db0f6234da95f8d003bea406fbe74e238b03" }
-ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP", rev = "7dd4db0f6234da95f8d003bea406fbe74e238b03" }
-ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "7dd4db0f6234da95f8d003bea406fbe74e238b03", features = [
-    "rustls",
-] }
-ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "7dd4db0f6234da95f8d003bea406fbe74e238b03" }
+ironrdp-cliprdr = "0.7"
+ironrdp-connector = "0.10"
+ironrdp-core = "0.2"
+ironrdp-displaycontrol = "0.8"
+ironrdp-dvc = "0.8"
+ironrdp-graphics = "0.9"
+ironrdp-pdu = "0.9"
+ironrdp-rdpdr = "0.7"
+ironrdp-rdpsnd = "0.9"
+ironrdp-session = "0.11"
+ironrdp-svc = "0.8"
+ironrdp-tls = { version = "0.2", features = ["rustls"] }
+ironrdp-tokio = "0.10"

--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -26,7 +26,9 @@ use crate::{
 use boring::error::ErrorStack;
 use bytes::BytesMut;
 use ironrdp_cliprdr::{Cliprdr, CliprdrClient, CliprdrSvcMessages};
-use ironrdp_connector::connection_activation::ConnectionActivationState;
+use ironrdp_connector::connection_activation::{
+    ConnectionActivationFactory, ConnectionActivationState,
+};
 use ironrdp_connector::credssp::KerberosConfig;
 use ironrdp_connector::{
     Config, ConnectorError, ConnectorErrorKind, Credentials, DesktopSize, SmartCardIdentity,
@@ -102,6 +104,7 @@ pub struct Client {
     function_receiver: Option<FunctionReceiver>,
     x224_processor: Arc<Mutex<x224::Processor>>,
     pending_resize: Arc<Mutex<PendingResize>>,
+    activation_factory: ConnectionActivationFactory,
 }
 
 /// A global, static tokio runtime for use by `Client`.
@@ -269,8 +272,8 @@ impl Client {
             connection_result.static_channels,
             connection_result.user_channel_id,
             connection_result.io_channel_id,
+            connection_result.message_channel_id,
             connection_result.share_id,
-            connection_result.connection_activation,
         )));
 
         Ok(Self {
@@ -281,6 +284,7 @@ impl Client {
             function_receiver,
             x224_processor,
             pending_resize,
+            activation_factory: connection_result.activation_factory,
         })
     }
 
@@ -323,6 +327,7 @@ impl Client {
             read_stream,
             self.x224_processor.clone(),
             self.client_handle.clone(),
+            self.activation_factory.clone(),
         );
 
         let write_loop_handle = Client::run_write_loop(
@@ -349,6 +354,7 @@ impl Client {
         mut read_stream: RdpReadStream,
         x224_processor: Arc<Mutex<x224::Processor>>,
         write_requester: ClientHandle,
+        activation_factory: ConnectionActivationFactory,
     ) -> ClientResult<Option<DisconnectDescription>> {
         loop {
             let (action, mut frame) = read_stream.read_pdu().await?;
@@ -377,15 +383,16 @@ impl Client {
                             ProcessorOutput::Disconnect(reason) => {
                                 return Ok(Some(reason));
                             }
-                            ProcessorOutput::DeactivateAll(mut sequence) => {
+                            ProcessorOutput::DeactivateAll => {
                                 // Execute the Deactivation-Reactivation Sequence:
                                 // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/dfc234ce-481a-4674-9a5d-2a7bafb14432
                                 debug!("Received Server Deactivate All PDU, executing Deactivation-Reactivation Sequence");
+                                let mut sequence = activation_factory.create();
                                 let mut buf = WriteBuf::new();
                                 loop {
                                     let written = single_sequence_step_read(
                                         &mut read_stream,
-                                        sequence.as_mut(),
+                                        &mut sequence,
                                         &mut buf,
                                     )
                                     .await?;
@@ -397,8 +404,6 @@ impl Client {
                                     }
 
                                     if let ConnectionActivationState::Finalized {
-                                        io_channel_id,
-                                        user_channel_id,
                                         desktop_size,
                                         ..
                                     } = sequence.connection_activation_state()
@@ -408,8 +413,8 @@ impl Client {
                                         // connection result in [`Self::connect`].
                                         Self::send_connection_activated(
                                             cgo_handle,
-                                            io_channel_id,
-                                            user_channel_id,
+                                            activation_factory.io_channel_id(),
+                                            activation_factory.user_channel_id(),
                                             desktop_size,
                                         )
                                         .await?;


### PR DESCRIPTION
This update includes some internal re-organization that drops some dependencies and prunes the overall dependency tree.

Also take this opportunity to start referencing the version by semver intead of commit SHA. In the past, the commits we need weren't always available in releases, and we've been using SHA ever since.

## Manual Test Plan

### Test Environment

Local cluster. Windows Sever 2019 (non-AD) host.

### Test Cases
- [x] RDP sessions work (web UI).
- [x] RDP sessions work (Connect).
- [x] Session recordings play back.
