### PR TITLE
Dedup audit log events in Firestore.

### DIFF
--- a/lib/events/firestoreevents/firestoreevents.go
+++ b/lib/events/firestoreevents/firestoreevents.go
@@ -74,6 +74,18 @@ var (
 			Help: "Number of batch read requests to firestore events",
 		},
 	)
+	writeRequestsDeduped = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "firestore_events_backend_write_deduped",
+			Help: "Number of write requests that were de-duplicated because an identical event already existed.",
+		},
+	)
+	eventIDCollisions = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "firestore_events_backend_event_id_collisions",
+			Help: "Number of distinct audit events that collided with an existing event sharing the same id and were re-inserted under a newly generated id.",
+		},
+	)
 	writeLatencies = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Name: "firestore_events_backend_write_seconds",
@@ -105,6 +117,7 @@ var (
 	prometheusCollectors = []prometheus.Collector{
 		writeRequests, batchWriteRequests, batchReadRequests,
 		writeLatencies, batchWriteLatencies, batchReadLatencies,
+		writeRequestsDeduped, eventIDCollisions,
 	}
 )
 
@@ -341,14 +354,94 @@ func (l *Log) EmitAuditEvent(ctx context.Context, in apievents.AuditEvent) error
 		CreatedAt:      in.GetTime().Unix(),
 		Fields:         string(data),
 	}
+
+	// All audit log events get assigned a UUID by the function
+	// `checkAndSetEventFields`. This happens when EmitAuditEvent is called.
+	// It should not happen, but if for some reason an event ID is missing, then
+	// we will generate an event ID. We want to prioritize durability of events
+	// and ensure that we don't error if a bug caused an event to be missing an
+	// ID.
+	eventID, err := uuid.Parse(in.GetID())
+	if err != nil {
+		eventID = uuid.New()
+		l.logger.InfoContext(ctx,
+			"Audit event does not have a valid UUID. Using a generated doc id, this event will not be de-duplicated if it is re-delivered.",
+			"error", err,
+			"event_id", in.GetID(),
+			"event_type", in.GetType(),
+			"generated_doc_id", eventID,
+		)
+	}
+
 	start := time.Now()
-	_, err = l.svc.Collection(l.CollectionName).Doc(l.getDocIDForEvent()).Create(l.svcContext, event)
+	err = l.insertEvent(ctx, in, eventID, event)
 	writeLatencies.Observe(time.Since(start).Seconds())
 	writeRequests.Inc()
+	return trace.Wrap(err)
+}
+
+func (l *Log) insertEvent(ctx context.Context, in apievents.AuditEvent, docID uuid.UUID, e event) error {
+	inserted, isDuplicate, err := l.tryInsertEvent(docID, e)
 	if err != nil {
-		return firestorebk.ConvertGRPCError(err)
+		return trace.Wrap(err)
 	}
-	return nil
+	if inserted {
+		return nil
+	}
+	if isDuplicate {
+		writeRequestsDeduped.Inc()
+		l.logger.DebugContext(ctx, "Dropped duplicate audit event.",
+			"event_id", docID,
+			"event_type", in.GetType(),
+		)
+		return nil
+	}
+
+	newID := uuid.New()
+	l.logger.WarnContext(ctx,
+		"Audit event collided with a different event sharing the same id. Re-inserting under a new id.",
+		"event_type", in.GetType(),
+		"original_event_id", docID,
+		"new_event_id", newID,
+	)
+	eventIDCollisions.Inc()
+
+	inserted, isDuplicate, err = l.tryInsertEvent(newID, e)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if inserted || isDuplicate {
+		return nil
+	}
+	return trace.AlreadyExists(
+		"audit event id collision persisted after generating a new id (original_event_id %v)",
+		docID,
+	)
+}
+
+func (l *Log) tryInsertEvent(docID uuid.UUID, e event) (inserted, isDuplicate bool, err error) {
+	docRef := l.svc.Collection(l.CollectionName).Doc(docID.String())
+	if _, err := docRef.Create(l.svcContext, e); err != nil {
+		convertedErr := firestorebk.ConvertGRPCError(err)
+		if !trace.IsAlreadyExists(convertedErr) {
+			return false, false, trace.Wrap(convertedErr)
+		}
+	} else {
+		return true, false, nil
+	}
+
+	docSnap, err := docRef.Get(l.svcContext)
+	if err != nil {
+		return false, false, trace.Wrap(firestorebk.ConvertGRPCError(err), "read existing/collided event")
+	}
+
+	var existing event
+	if err := docSnap.DataTo(&existing); err != nil {
+		return false, false, trace.Wrap(firestorebk.ConvertGRPCError(err), "populate existing/collided event")
+	}
+	// TODO(kkloberdanz): We currently do a strict bytes comparison. Should this
+	// be a proper JSON comparison?
+	return false, existing.Fields == e.Fields, nil
 }
 
 // SearchEvents is a flexible way to find events.
@@ -675,10 +768,6 @@ func (l *Log) ensureIndexes(adminSvc *apiv1.FirestoreAdminClient) error {
 func (l *Log) Close() error {
 	l.svcCancel()
 	return l.svc.Close()
-}
-
-func (l *Log) getDocIDForEvent() string {
-	return uuid.New().String()
 }
 
 func (l *Log) SearchUnstructuredEvents(ctx context.Context, req events.SearchEventsRequest) ([]*auditlogpb.EventUnstructured, string, error) {

--- a/lib/events/firestoreevents/firestoreevents_test.go
+++ b/lib/events/firestoreevents/firestoreevents_test.go
@@ -20,15 +20,25 @@ package firestoreevents
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"os"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/firestore"
+	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/types"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/test"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
@@ -141,6 +151,133 @@ func TestFirestoreEvents(t *testing.T) {
 	t.Run("TestPagination", tt.testPagination)
 	t.Run("TestSearchSessionEvensBySessionID", tt.testSearchSessionEvensBySessionID)
 	t.Run("TestSearchEventsBySearchTerm", tt.testSearchEventsBySearchTerm)
+}
+
+func TestEmitAuditEvent_NoLossDeduplication(t *testing.T) {
+	tt := setupFirestoreContext(t)
+	tt.setupTest(t)
+	ctx := t.Context()
+
+	eventTime := tt.suite.Clock.Now().UTC()
+	from := eventTime.Add(-time.Hour)
+	to := eventTime.Add(time.Hour)
+
+	t.Run("IdenticalReDeliveryIsDeduplicated", func(t *testing.T) {
+		id := uuid.NewString()
+		marker := "dedup-alpaca-" + uuid.NewString()
+		ev := makeDedupTestEvent(id, eventTime, marker)
+
+		before := testutil.ToFloat64(writeRequestsDeduped)
+		require.NoError(t, tt.log.EmitAuditEvent(ctx, ev), "first delivery")
+		require.NoError(t, tt.log.EmitAuditEvent(ctx, ev), "at-least-once re-delivery")
+
+		requireStoredMarkerCount(ctx, t, tt.log, from, to, marker, 1)
+		require.InDelta(t, before+1, testutil.ToFloat64(writeRequestsDeduped), 0.0001,
+			"the duplicate delivery should increment the deduped counter exactly once")
+	})
+
+	t.Run("DistinctEventsSharingIDAreBothStored", func(t *testing.T) {
+		id := uuid.NewString()
+		prefix := "collide-" + uuid.NewString() + "-"
+		alice := makeDedupTestEvent(id, eventTime, prefix+"alice")
+		bob := makeDedupTestEvent(id, eventTime, prefix+"bob")
+
+		before := testutil.ToFloat64(eventIDCollisions)
+		require.NoError(t, tt.log.EmitAuditEvent(ctx, alice))
+		require.NoError(t, tt.log.EmitAuditEvent(ctx, bob))
+
+		requireStoredMarkerCount(ctx, t, tt.log, from, to, prefix+"alice", 1)
+		requireStoredMarkerCount(ctx, t, tt.log, from, to, prefix+"bob", 1)
+		require.InDelta(t, before+1, testutil.ToFloat64(eventIDCollisions), 0.0001,
+			"the colliding distinct event should increment the collision counter exactly once")
+	})
+
+	t.Run("ConcurrentDistinctEventsSharingIDAreNotLost", func(t *testing.T) {
+		id := uuid.NewString()
+		prefix := "concurrent-" + uuid.NewString() + "-"
+		const n = 20
+
+		var wg sync.WaitGroup
+		errs := make([]error, n)
+		for i := range n {
+			wg.Go(func() {
+				ev := makeDedupTestEvent(id, eventTime, fmt.Sprintf("%suser-%02d", prefix, i))
+				errs[i] = tt.log.EmitAuditEvent(ctx, ev)
+			})
+		}
+		wg.Wait()
+
+		require.NoError(t, errors.Join(errs...), "one or more audit goroutines errored")
+
+		for i := range n {
+			marker := fmt.Sprintf("%suser-%02d", prefix, i)
+			requireStoredMarkerCount(ctx, t, tt.log, from, to, marker, 1)
+		}
+	})
+}
+
+func makeDedupTestEvent(id string, eventTime time.Time, marker string) *apievents.UserLogin {
+	return &apievents.UserLogin{
+		Method: events.LoginMethodSAML,
+		Status: apievents.Status{Success: true},
+		UserMetadata: apievents.UserMetadata{
+			User:     marker,
+			UserKind: apievents.UserKind_USER_KIND_HUMAN,
+		},
+		Metadata: apievents.Metadata{
+			ID:          id,
+			Type:        events.UserLoginEvent,
+			ClusterName: "mycluster",
+			Time:        eventTime,
+		},
+	}
+}
+
+func requireStoredMarkerCount(ctx context.Context, t *testing.T, log *Log, from, to time.Time, marker string, want int) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		got, err := searchAllEvents(ctx, log, from, to)
+		if !assert.NoError(c, err) {
+			return
+		}
+		assert.Equal(c, want, countMarker(got, marker), "stored count for marker %q", marker)
+	}, 30*time.Second, time.Second)
+}
+
+func searchAllEvents(ctx context.Context, log *Log, from, to time.Time) ([]apievents.AuditEvent, error) {
+	var out []apievents.AuditEvent
+	var checkpoint string
+	for {
+		fetched, next, err := log.SearchEvents(ctx, events.SearchEventsRequest{
+			From:     from,
+			To:       to,
+			Limit:    1000,
+			Order:    types.EventOrderAscending,
+			StartKey: checkpoint,
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, fetched...)
+		checkpoint = next
+		if checkpoint == "" {
+			return out, nil
+		}
+	}
+}
+
+func countMarker(evts []apievents.AuditEvent, marker string) int {
+	var n int
+	for _, e := range evts {
+		data, err := utils.FastMarshal(e)
+		if err != nil {
+			continue
+		}
+		if strings.Contains(string(data), marker) {
+			n++
+		}
+	}
+	return n
 }
 
 func emulatorRunning() bool {


### PR DESCRIPTION
Changelog: De-duplicate audit log events in Firestore.

## Manual Test Plan

### Test Environment

- Firestore emulator (run via Docker)
- Command:
```sh
docker run -d --name firestore-emulator -p 8618:8618 \
  gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators \
  gcloud beta emulators firestore start --host-port=0.0.0.0:8618
go test ./lib/events/firestoreevents/ -run TestEmitAuditEvent_NoLossDeduplication
```
### Test Cases

- [x] **Identical re-delivery is de-duplicated**: The same event emitted twice
  is stored exactly once.
- [x] **Distinct events sharing an event ID are both stored**: The second event
  is re-inserted under a newly generated ID rather than dropped or
  overwritten.
- [x] **No loss under concurrency**: 20 goroutines concurrently emit distinct
  events sharing one event ID. All 20 are stored with none lost or duplicated.