### PR TITLE
iOS: Update bundle identifier

### DIFF
--- a/mobile/Verify/Verify.xcodeproj/project.pbxproj
+++ b/mobile/Verify/Verify.xcodeproj/project.pbxproj
@@ -573,7 +573,7 @@
 				);
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = com.gravitational.Verify;
+				PRODUCT_BUNDLE_IDENTIFIER = com.gravitational.teleport.Verify;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -622,7 +622,7 @@
 				);
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = com.gravitational.Verify;
+				PRODUCT_BUNDLE_IDENTIFIER = com.gravitational.teleport.Verify;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";


### PR DESCRIPTION
Xcode was having trouble generating a provisioning profile for our previous bundle id (`com.gravitational.Verify`) so this PR updates it to one that Xcode is happy with. This works out anyway because as [Maja pointed out previously](https://github.com/gravitational/teleport/pull/67939#discussion_r3443734092) we have other bundle IDs that are more in line with this format (`com.gravitational.teleport.*`).
