### PR TITLE
Cleanup event-handler and fluentd template configs

### DIFF
--- a/docs/pages/includes/plugins/event-handler-operator-helm-config.mdx
+++ b/docs/pages/includes/plugins/event-handler-operator-helm-config.mdx
@@ -37,9 +37,9 @@ tbot:
 
 fluentd:
   url: "https://fluentd.fluentd.svc.cluster.local/events.log"
-  sessionUrl: "https://fluentd.fluentd.svc.cluster.local/session.log"
+  sessionUrl: "https://fluentd.fluentd.svc.cluster.local/session"
   certificate:
-    secretName: "teleport-event-handler-client-tls"
+    secretName: "teleport-plugin-event-handler-client-tls"
     caPath: "ca.crt"
     certPath: "client.crt"
     keyPath: "client.key"

--- a/docs/pages/includes/plugins/finish-event-handler-config.mdx
+++ b/docs/pages/includes/plugins/finish-event-handler-config.mdx
@@ -38,7 +38,7 @@ skip-session-types = []
 ca = <Var name="/home/bob/event-handler" />/ca.crt
 cert = <Var name="/home/bob/event-handler" />/client.crt
 key = <Var name="/home/bob/event-handler" />/client.key
-url = "https://fluentd.example.com:8888/test.log"
+url = "https://fluentd.example.com:8888/events.log"
 # The Event Handler appends `.<session-id>.log` to `session-url` when sending
 # session recording events. For example, if `session-url` is
 # `https://fluentd.example.com:8888/session`, the actual requests are sent to
@@ -88,7 +88,7 @@ eventHandler:
 
 teleport:
   address: <Var name="teleport.example.com:443" />
-  identitySecretName: teleport-event-handler-identity
+  identitySecretName: teleport-plugin-event-handler-identity
   identitySecretPath: identity
 
 fluentd:
@@ -99,9 +99,9 @@ fluentd:
   # paths like `/session.<session-id>.log`. Ensure that your log collector's
   # tag matching or routing rules account for this suffix (e.g., use `session.*`
   # as a match pattern in Fluentd or Fluent Bit).
-  sessionUrl: "https://fluentd.fluentd.svc.cluster.local/session.log"
+  sessionUrl: "https://fluentd.fluentd.svc.cluster.local/session"
   certificate:
-    secretName: "teleport-event-handler-client-tls"
+    secretName: "teleport-plugin-event-handler-client-tls"
     caPath: "ca.crt"
     certPath: "client.crt"
     keyPath: "client.key"

--- a/docs/pages/includes/plugins/finish-event-handler-fields.mdx
+++ b/docs/pages/includes/plugins/finish-event-handler-fields.mdx
@@ -48,7 +48,7 @@ instructions above, this will be `identity`.
 
 `certificate.secretName`: Include the name of the Kubernetes secret containing the
 Fluentd client credentials. If you have followed the instructions above,
-this will be `teleport-event-handler-client-tls`.
+this will be `teleport-plugin-event-handler-client-tls`.
 
 `certificate.caPath`: Include the path to the CA certificate inside the secret.
 
@@ -81,7 +81,7 @@ or Teleport Enterprise Cloud account: <Var name="teleport.example.com:443" />
 
 `certificate.secretName`: Include the name of the Kubernetes secret containing the
 Fluentd client credentials. If you have followed the instructions above,
-this will be `teleport-event-handler-client-tls`.
+this will be `teleport-plugin-event-handler-client-tls`.
 
 `certificate.caPath`: Include the path to the CA certificate inside the secret.
 

--- a/docs/pages/reference/deployment/monitoring/event-handler.mdx
+++ b/docs/pages/reference/deployment/monitoring/event-handler.mdx
@@ -30,7 +30,7 @@ The Event Handler plugin accepts configuration from three sources:
 - Environment variables prefixed with `FDFWD_`.
 - A TOML configuration file specified with the `--config` flag.
 
-```code
+```toml
 storage = "./storage" # Plugin will save its state here
 timeout = "10s"
 batch = 20
@@ -39,7 +39,7 @@ batch = 20
 ca = "/home/bob/event-handler/ca.crt"
 cert = "/home/bob/event-handler/client.crt"
 key = "/home/bob/event-handler/client.key"
-url = "https://fluentd.example.com:8888/test.log"
+url = "https://fluentd.example.com:8888/events.log"
 # The Event Handler appends `.<session-id>.log` to `session-url` when sending
 # session recording events. For example, if `session-url` is
 # `https://fluentd.example.com:8888/session`, the actual requests are sent to
@@ -118,7 +118,7 @@ failed authentication attempts.
 For example, to lock a user after `5` failed attempts within `1m` for `30m`,
 set:
 
-```code
+```toml
 lock-enabled = true
 lock-failed-attempts-count = 5
 lock-period = "1m"
@@ -173,20 +173,20 @@ extendedKeyUsage     = critical,OCSPSigning
 ### Generate a certificate authority
 
 ```code
-openssl genrsa -out ca.key 4096
-chmod 444 ca.key
-openssl req -config ssl.conf -key ca.key -new -x509 -days 7300 \
+$ openssl genrsa -out ca.key 4096
+$ chmod 444 ca.key
+$ openssl req -config ssl.conf -key ca.key -new -x509 -days 7300 \
   -sha256 -extensions v3_ca -subj "/CN=ca" -out ca.crt
 ```
 
 ### Generate a server certificate
 
 ```code
-openssl genrsa -aes256 -out server.key 4096
-chmod 444 server.key
-openssl req -config ssl.conf -subj "/CN=server" -key server.key \
+$ openssl genrsa -aes256 -out server.key 4096
+$ chmod 444 server.key
+$ openssl req -config ssl.conf -subj "/CN=server" -key server.key \
   -new -out server.csr
-openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key \
+$ openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key \
   -CAcreateserial -days 365 -out server.crt -extfile ssl.conf \
   -extensions server_cert
 ```
@@ -194,11 +194,11 @@ openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key \
 ### Generate a client certificate
 
 ```code
-openssl genrsa -out client.key 4096
-chmod 444 client.key
-openssl req -config ssl.conf -subj "/CN=client" -key client.key \
+$ openssl genrsa -out client.key 4096
+$ chmod 444 client.key
+$ openssl req -config ssl.conf -subj "/CN=client" -key client.key \
   -new -out client.csr
-openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key \
+$ openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key \
   -CAcreateserial -days 365 -out client.crt -extfile ssl.conf \
   -extensions client_cert
 ```

--- a/docs/pages/zero-trust-access/export-audit-events/datadog.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/datadog.mdx
@@ -88,7 +88,7 @@ We will modify the `fluent.conf` file generated in the prerequisite setup guide.
 1. Copy the API key and use it to add a new `<match>` block to `fluent.conf`:
 
    ```ini
-   <match test.log>
+   <match events.log>
    
      @type datadog
      @id awesome_agent

--- a/docs/pages/zero-trust-access/export-audit-events/event-handler-setup-operator.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/event-handler-setup-operator.mdx
@@ -91,7 +91,7 @@ client credentials available as a secret. Use the following command to create
 that secret in Kubernetes:
 
 ```code
-$ kubectl create secret generic teleport-event-handler-client-tls --from-file=ca.crt=ca.crt,client.crt=client.crt,client.key=client.key
+$ kubectl create secret generic teleport-plugin-event-handler-client-tls --from-file=ca.crt=ca.crt,client.crt=client.crt,client.key=client.key
 ```
 
 This will pack the content of `ca.crt`, `client.crt`, and `client.key` into the

--- a/docs/pages/zero-trust-access/export-audit-events/event-handler-setup.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/event-handler-setup.mdx
@@ -73,7 +73,7 @@ client credentials available as a secret. Use the following command to create
 that secret in Kubernetes:
 
 ```code
-$ kubectl create secret generic teleport-event-handler-client-tls --from-file=ca.crt=ca.crt,client.crt=client.crt,client.key=client.key
+$ kubectl create secret generic teleport-plugin-event-handler-client-tls --from-file=ca.crt=ca.crt,client.crt=client.crt,client.key=client.key
 ```
 
 This will pack the content of `ca.crt`, `client.crt`, and `client.key` into the
@@ -126,10 +126,10 @@ longer-lived identity files with `tctl`:
 
 <Tabs>
 <TabItem label="Machine & Workload Identity">
-(!docs/pages/includes/plugins/tbot-identity.mdx secret="teleport-event-handler-identity"!)
+(!docs/pages/includes/plugins/tbot-identity.mdx secret="teleport-plugin-event-handler-identity"!)
 </TabItem>
 <TabItem label="Long-lived identity files">
-(!docs/pages/includes/plugins/identity-export.mdx user="teleport-event-handler" plugin="event-handler" secret="teleport-event-handler-identity"!)
+(!docs/pages/includes/plugins/identity-export.mdx user="teleport-event-handler" plugin="event-handler" secret="teleport-plugin-event-handler-identity"!)
 </TabItem>
 </Tabs>
 

--- a/docs/pages/zero-trust-access/export-audit-events/fluentd.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/fluentd.mdx
@@ -100,8 +100,8 @@ your Fluentd instance to accept events using TLS and print them:
     </buffer>
 </source>
 
-# Events sent to test.log will be dumped to STDOUT.
-<match test.log>
+# Events sent to events.log will be dumped to STDOUT.
+<match events.log>
   @type stdout
 </match>
 ```

--- a/docs/pages/zero-trust-access/export-audit-events/panther.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/panther.mdx
@@ -123,14 +123,14 @@ Add the <filter> and <match> sections to the file.
   </buffer>
 </source>
 -->
-<filter test.log>
+<filter events.log>
   @type record_transformer
   enable_ruby true
   <record>
     time ${time.utc.strftime("%Y-%m-%dT%H:%M:%SZ")}
   </record>
 </filter>
-<match test.log>
+<match events.log>
   @type s3
   aws_key_id  REPLACE_aws_access_key
   aws_sec_key  REPLACE_aws_secret_access_key

--- a/docs/pages/zero-trust-access/export-audit-events/splunk.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/splunk.mdx
@@ -141,10 +141,10 @@ your `fluent.conf` file as follows:
    For more information on Splunk HEC URIs, see [Splunk HTTP Event Collector
    ](https://help.splunk.com/en/splunk-enterprise/get-started/get-data-in/10.2/get-data-with-http-event-collector/set-up-and-use-http-event-collector-in-splunk-web#send-data-to-http-event-collector-on-splunk-cloud-platform-0).
 
-1. Edit the `<match test.log>` section with the following section.
+1. Edit the `<match events.log>` section with the following section.
 
    ```xml
-    <match test.log>
+    <match events.log>
       @type http
       endpoint <Var name="splunk-endpoint" />
       headers {"Authorization": "Splunk <Var name="TOKEN" />"}

--- a/integrations/event-handler/tpl/fluent.conf.tpl
+++ b/integrations/event-handler/tpl/fluent.conf.tpl
@@ -36,7 +36,7 @@
     </buffer>
 </source>
 
-<match test.log>
+<match events.log>
   @type stdout
 </match>
 

--- a/integrations/event-handler/tpl/teleport-event-handler.toml.tpl
+++ b/integrations/event-handler/tpl/teleport-event-handler.toml.tpl
@@ -6,7 +6,7 @@ batch = 20
 ca = "{{index .CaCertPath}}"
 cert = "{{index .ClientCertPath}}"
 key = "{{index .ClientKeyPath}}"
-url = "https://localhost:8888/test.log"
+url = "https://localhost:8888/events.log"
 # Note: .<session-id>.log is appended to session-url for each session recording.
 # Ensure your log collector's tag matching accounts for this (e.g., session.* in Fluentd/Fluent Bit).
 session-url = "https://localhost:8888/session"

--- a/integrations/event-handler/tpl/teleport-plugin-event-handler-values.yaml.tpl
+++ b/integrations/event-handler/tpl/teleport-plugin-event-handler-values.yaml.tpl
@@ -5,14 +5,14 @@ eventHandler:
 
 teleport:
   address: "{{.Addr}}"
-  identitySecretName: teleport-event-handler-identity
+  identitySecretName: teleport-plugin-event-handler-identity
   identitySecretPath: identity
 
 fluentd:
   url: "https://fluentd.fluentd.svc.cluster.local/events.log"
-  sessionUrl: "https://fluentd.fluentd.svc.cluster.local/session.log"
+  sessionUrl: "https://fluentd.fluentd.svc.cluster.local/session"
   certificate:
-    secretName: "teleport-event-handler-client-tls"
+    secretName: "teleport-plugin-event-handler-client-tls"
     caPath: "ca.crt"
     certPath: "client.crt"
     keyPath: "client.key"


### PR DESCRIPTION
This PR aims to fix up inconsistencies in event handler template config files generated from `teleport-event-handler configure` command. This only affects initial event handler setup for new users and not existing plugin instances. Docs also updated to be consistent.

Changelog: Improved `teleport-event-handler configure` command with more accurate boilerplate config files

## Changes

`teleport-event-handler` binary and fluentd config:
- Modified audit events endpoint for better clarity: `/test.log` -> `/events.log` (matches helm chart)

`teleport-plugin-event-handler` helm chart:
- Modified session events endpoint to properly match against fluentd matchers: `/session.log` -> `/session`
- Modified config's secret names to match the chart name (other access plugins already follow this convention):
     - `teleport-event-handler-identity` -> `teleport-plugin-event-handler-identity`
     - `teleport-event-handler-client-tls` -> `teleport-plugin-event-handler-client-tls`

Docs:
- Reflect above changes

## Manual Test Plan
### Test Environment

Teleport Cloud and local Event Handler plugin (binary & helm chart)

### Test Cases
- [x] Verify new setup of event handler + fluentd forwarder configs behaves normally
     - [x] executable/docker
     - [x] helm chart