### PR TITLE
[scopes] prep access list interfaces for use from teleport.e

### DIFF
--- a/api/client/accesslist/accesslist.go
+++ b/api/client/accesslist/accesslist.go
@@ -199,6 +199,12 @@ func (c *Client) DeleteAccessList(ctx context.Context, name string) error {
 	return trace.Wrap(err)
 }
 
+// DeleteAccessList removes the specified access list resource.
+func (c *Client) DeleteAccessListV2(ctx context.Context, req *accesslistv1.DeleteAccessListRequest) error {
+	_, err := c.grpcClient.DeleteAccessList(ctx, req)
+	return trace.Wrap(err)
+}
+
 // CountAccessListMembers will count all access list members.
 func (c *Client) CountAccessListMembers(ctx context.Context, accessListName string) (users uint32, lists uint32, err error) {
 	return c.CountAccessListMembersV2(ctx, &accesslistv1.CountAccessListMembersRequest{
@@ -388,11 +394,23 @@ func (c *Client) DeleteAccessListMember(ctx context.Context, accessList, memberN
 	return trace.Wrap(err)
 }
 
+// DeleteAccessListMemberV2 hard deletes the specified access list member resource.
+func (c *Client) DeleteAccessListMemberV2(ctx context.Context, req *accesslistv1.DeleteAccessListMemberRequest) error {
+	_, err := c.grpcClient.DeleteAccessListMember(ctx, req)
+	return trace.Wrap(err)
+}
+
 // DeleteAllAccessListMembersForAccessList hard deletes all access list members for an access list.
 func (c *Client) DeleteAllAccessListMembersForAccessList(ctx context.Context, accessList string) error {
 	_, err := c.grpcClient.DeleteAllAccessListMembersForAccessList(ctx, &accesslistv1.DeleteAllAccessListMembersForAccessListRequest{
 		AccessList: accessList,
 	})
+	return trace.Wrap(err)
+}
+
+// DeleteAllAccessListMembersForAccessListV2 hard deletes all access list members for an access list.
+func (c *Client) DeleteAllAccessListMembersForAccessListV2(ctx context.Context, req *accesslistv1.DeleteAllAccessListMembersForAccessListRequest) error {
+	_, err := c.grpcClient.DeleteAllAccessListMembersForAccessList(ctx, req)
 	return trace.Wrap(err)
 }
 
@@ -505,6 +523,12 @@ func (c *Client) DeleteAccessListReview(ctx context.Context, accessListName, rev
 		AccessListName: accessListName,
 		ReviewName:     reviewName,
 	})
+	return trace.Wrap(err)
+}
+
+// DeleteAccessListReviewV2 will delete an access list review from the backend.
+func (c *Client) DeleteAccessListReviewV2(ctx context.Context, req *accesslistv1.DeleteAccessListReviewRequest) error {
+	_, err := c.grpcClient.DeleteAccessListReview(ctx, req)
 	return trace.Wrap(err)
 }
 

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -1442,15 +1442,25 @@ type Cache interface {
 	ListAccessListsV2(context.Context, *accesslistv1.ListAccessListsV2Request) ([]*accesslist.AccessList, string, error)
 	// GetAccessList returns the specified access list resource.
 	GetAccessList(context.Context, string) (*accesslist.AccessList, error)
+	// GetAccessListV2 returns the specified access list resource.
+	GetAccessListV2(context.Context, *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error)
 
 	// CountAccessListMembers will count all access list members.
 	CountAccessListMembers(ctx context.Context, accessListName string) (users uint32, lists uint32, err error)
+	// CountAccessListMembersV2 will count all access list members.
+	CountAccessListMembersV2(ctx context.Context, req *accesslistv1.CountAccessListMembersRequest) (users uint32, lists uint32, err error)
 	// ListAccessListMembers returns a paginated list of all access list members.
 	ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
+	// ListAccessListMembersV2 returns a paginated list of all access list members.
+	ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error)
 	// ListAllAccessListMembers returns a paginated list of all members of all access lists.
 	ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
+	// ListAllAccessListMembersV2 returns a paginated list of all members of all access lists.
+	ListAllAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAllAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error)
 	// GetAccessListMember returns the specified access list member resource.
 	GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error)
+	// GetAccessListMemberV2 returns the specified access list member resource.
+	GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error)
 
 	// GetAccessListOwners returns a list of owners for a particular access list.
 	GetAccessListOwners(ctx context.Context, accessList string) ([]*accesslist.Owner, error)

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -77,6 +77,8 @@ type AccessLists interface {
 	UpdateAccessList(context.Context, *accesslist.AccessList) (*accesslist.AccessList, error)
 	// DeleteAccessList removes the specified access list resource.
 	DeleteAccessList(context.Context, string) error
+	// DeleteAccessList removes the specified access list resource.
+	DeleteAccessListV2(context.Context, *accesslistv1.DeleteAccessListRequest) error
 
 	// UpsertAccessListWithMembers creates or updates an access list resource and its members.
 	UpsertAccessListWithMembers(context.Context, *accesslist.AccessList, []*accesslist.AccessListMember) (*accesslist.AccessList, []*accesslist.AccessListMember, error)
@@ -96,10 +98,16 @@ type AccessListsInternal interface {
 
 	// CleanupAccessListStatus removes invalid Status.OwnerOf and Status.MemberOf references.
 	CleanupAccessListStatus(ctx context.Context, accessListName string) (*accesslist.AccessList, error)
+	// CleanupAccessListStatusV2 removes invalid Status.(Scoped)OwnerOf and Status.(Scoped)MemberOf references.
+	CleanupAccessListStatusV2(ctx context.Context, accessListName accesslists.NormalizedSQN) (*accesslist.AccessList, error)
 
 	// EnsureNestedAccessListStatuses goes over all nested owners and nested members of the named
 	// access list and ensures nested lists' statuses owner_of/member_of contain the access list name.
 	EnsureNestedAccessListStatuses(ctx context.Context, accessListName string) error
+	// EnsureNestedAccessListStatusesV2 goes over all nested owners and nested members of the named
+	// access list and ensures nested lists' statuses (scoped_)owner_of/(scoped_)member_of contain
+	// the access list name.
+	EnsureNestedAccessListStatusesV2(ctx context.Context, accessListName accesslists.NormalizedSQN) error
 
 	// InsertAccessListCollection inserts a complete collection of access lists and their members from a single
 	// upstream source (e.g. EntraID) using a batch operation for improved performance.
@@ -222,8 +230,12 @@ type AccessListMembers interface {
 	UpdateAccessListMember(ctx context.Context, member *accesslist.AccessListMember) (*accesslist.AccessListMember, error)
 	// DeleteAccessListMember hard deletes the specified access list member resource.
 	DeleteAccessListMember(ctx context.Context, accessList string, memberName string) error
+	// DeleteAccessListMemberV2 hard deletes the specified access list member resource.
+	DeleteAccessListMemberV2(ctx context.Context, req *accesslistv1.DeleteAccessListMemberRequest) error
 	// DeleteAllAccessListMembersForAccessList hard deletes all access list members for an access list.
 	DeleteAllAccessListMembersForAccessList(ctx context.Context, accessList string) error
+	// DeleteAllAccessListMembersForAccessListV2 hard deletes all access list members for an access list.
+	DeleteAllAccessListMembersForAccessListV2(ctx context.Context, req *accesslistv1.DeleteAllAccessListMembersForAccessListRequest) error
 }
 
 // MarshalAccessListMember marshals the access list member resource to JSON.
@@ -287,6 +299,8 @@ type AccessListReviews interface {
 
 	// DeleteAccessListReview will delete an access list review from the backend.
 	DeleteAccessListReview(ctx context.Context, accessListName, reviewName string) error
+	// DeleteAccessListReviewV2 will delete an access list review from the backend.
+	DeleteAccessListReviewV2(ctx context.Context, req *accesslistv1.DeleteAccessListReviewRequest) error
 }
 
 // MarshalAccessListReview marshals the access list review resource to JSON.


### PR DESCRIPTION
This PR adds methods to access list interfaces that are necessary in order for them to be called from the gRPC API layer in teleport.e in https://github.com/gravitational/teleport.e/pull/9120

Parent: https://github.com/gravitational/teleport/pull/68479
Child: https://github.com/gravitational/teleport/pull/68567