### PR TITLE
[scopes] tctl resource command support for scoped access lists

### DIFF
--- a/lib/scopes/access/verbs.go
+++ b/lib/scopes/access/verbs.go
@@ -41,6 +41,11 @@ func isAllowedScopedRule(kind string, verb string) bool {
 		return isReadWriteNoSecrets(verb)
 	case types.KindKubernetesCluster:
 		return isReadWriteWithSecrets(verb) || isReadWriteNoSecrets(verb)
+	case types.KindAccessList:
+		// access lists can be read/written, and do not contain a concept of a secret.
+		// permissions for access list members are conferred by permissions for
+		// access list themselves, and/or list ownership.
+		return isReadWriteNoSecrets(verb)
 	default:
 		return false
 	}

--- a/tool/tctl/common/resources/accesslist.go
+++ b/tool/tctl/common/resources/accesslist.go
@@ -25,12 +25,15 @@ import (
 	"github.com/gravitational/trace"
 
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/accesslists"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -50,7 +53,7 @@ func (c *accessListCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Title", "Review Frequency", "Next Audit Date"})
 	for _, al := range c.accessLists {
 		t.AddRow([]string{
-			al.GetName(),
+			accesslists.ScopeQualifiedName(al).String(),
 			al.Spec.Title,
 			al.Spec.Audit.Recurrence.Frequency.String(),
 			al.Spec.Audit.NextAuditDate.Format(time.RFC822),
@@ -62,19 +65,36 @@ func (c *accessListCollection) WriteText(w io.Writer, verbose bool) error {
 
 func accessListHandler() Handler {
 	return Handler{
-		getHandler:    getAccessList,
+		getHandler:    getUnscopedAccessList,
 		createHandler: createAccessList,
-		deleteHandler: deleteAccessList,
+		deleteHandler: deleteUnscopedAccessList,
 		singleton:     false,
 		mfaRequired:   true,
 		description:   "Used to grant roles or traits to users or other lists. Part of Identity Governance.",
 	}
 }
 
-// getAccessList implements `tctl get accesslist/my-list` command.
-func getAccessList(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
-	if ref.Name != "" {
-		resource, err := client.AccessListClient().GetAccessList(ctx, ref.Name)
+func accessListScopedHandler() ScopedHandler {
+	return ScopedHandler{
+		getHandler:    getAccessList,
+		createHandler: createAccessList,
+		deleteHandler: deleteAccessList,
+		mfaRequired:   true,
+		description:   "Used to grant roles or traits to users or other lists. Part of Identity Governance.",
+	}
+}
+
+// getAccessList implements `tctl get accesslist /scope::my-list` command.
+func getAccessList(ctx context.Context, client *authclient.Client, subKind string, sqn *scopes.QualifiedName, opts GetOpts) (Collection, error) {
+	if subKind != "" {
+		return nil, rejectSubKind(types.KindAccessList, subKind)
+	}
+
+	if sqn != nil {
+		resource, err := client.AccessListClient().GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+			Scope: sqn.Scope,
+			Name:  sqn.Name,
+		}.Build())
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -87,12 +107,22 @@ func getAccessList(ctx context.Context, client *authclient.Client, ref services.
 				accesslistv1.ListAccessListsV2Request_builder{
 					PageSize:  int32(size),
 					PageToken: token,
+					ScopeFilter: scopesv1.Filter_builder{
+						Mode: scopesv1.Mode_MODE_ALL,
+					}.Build(),
 				}.Build())
 		}),
 	)
 
 	return &accessListCollection{accessLists: accessLists}, trace.Wrap(err)
+}
 
+// getUnscopedAccessList implements `tctl get accesslist/my-list` command.
+func getUnscopedAccessList(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
+	if ref.Name != "" {
+		return getAccessList(ctx, client, ref.SubKind, &scopes.QualifiedName{Name: ref.Name}, opts)
+	}
+	return getAccessList(ctx, client, ref.SubKind, nil, opts)
 }
 
 // createAccessList implements `tctl create accesslist/my-list` command.
@@ -102,7 +132,10 @@ func createAccessList(ctx context.Context, client *authclient.Client, raw servic
 		return trace.Wrap(err)
 	}
 
-	_, err = client.AccessListClient().GetAccessList(ctx, accessList.GetName())
+	_, err = client.AccessListClient().GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Scope: accessList.GetScope(),
+		Name:  accessList.GetName(),
+	}.Build())
 	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
@@ -121,11 +154,23 @@ func createAccessList(ctx context.Context, client *authclient.Client, raw servic
 
 }
 
-// deleteAccessList implements `tctl rm accesslist/my-list` command.
-func deleteAccessList(ctx context.Context, client *authclient.Client, ref services.Ref) error {
-	if err := client.AccessListClient().DeleteAccessList(ctx, ref.Name); err != nil {
+// deleteAccessList implements `tctl rm accesslist /scope::my-list` command.
+func deleteAccessList(ctx context.Context, client *authclient.Client, subKind string, sqn scopes.QualifiedName) error {
+	if subKind != "" {
+		return rejectSubKind(types.KindAccessList, subKind)
+	}
+
+	if err := client.AccessListClient().DeleteAccessListV2(ctx, accesslistv1.DeleteAccessListRequest_builder{
+		Scope: sqn.Scope,
+		Name:  sqn.Name,
+	}.Build()); err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("Access list %q has been deleted\n", ref.Name)
+	fmt.Printf("Access list %q has been deleted\n", sqn.String())
 	return nil
+}
+
+// deleteAccessList implements `tctl rm accesslist/my-list` command.
+func deleteUnscopedAccessList(ctx context.Context, client *authclient.Client, ref services.Ref) error {
+	return deleteAccessList(ctx, client, ref.SubKind, scopes.QualifiedName{Name: ref.Name})
 }

--- a/tool/tctl/common/resources/scoped_handler.go
+++ b/tool/tctl/common/resources/scoped_handler.go
@@ -39,6 +39,7 @@ func ScopedHandlers() map[string]ScopedHandler {
 		scopedaccess.KindScopedRole:           scopedRoleScopedHandler(),
 		types.KindScopedToken:                 scopedTokenScopedHandler(),
 		scopedaccess.KindScopedRoleAssignment: scopedRoleAssignmentScopedHandler(),
+		types.KindAccessList:                  accessListScopedHandler(),
 	}
 }
 


### PR DESCRIPTION
Part of [RFD 308](https://github.com/gravitational/rfd/pull/22)

This PR adds support for `tctl get access_list /example/scope::examplename` and `tctl rm access_list /example/scope::examplename`.

Test coverage requires an enterprise cluster, it is added in https://github.com/gravitational/teleport.e/pull/9123

Parent: https://github.com/gravitational/teleport/pull/68564
Child: https://github.com/gravitational/teleport/pull/68568

Manually tested with the testplan at https://github.com/gravitational/teleport.e/pull/9120
