### PR TITLE
[scopes] tctl acl command support for scoped access lists

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -397,7 +397,7 @@ Arguments:
 |access-list-name|*no default* (required)|The Access List name.|
 |expires|*no default* (optional)|When the user's access expires (must be in RFC3339). Defaults to the expiration time of the Access List.|
 |reason|*no default* (optional)|The reason the user has been added to the Access List. Defaults to empty.|
-|user|*no default* (required)|The user to add to the Access List.|
+|user|*no default* (required)|The member to add to the Access List.|
 
 ## tctl acl users ls
 
@@ -436,7 +436,7 @@ Arguments:
 |Argument|Default|Description|
 |---|---|---|
 |access-list-name|*no default* (required)|The Access List name.|
-|user|*no default* (required)|The user to remove from the Access List.|
+|user|*no default* (required)|The member to remove from the Access List.|
 
 ## tctl alerts ack
 

--- a/tool/tctl/common/accesslist/accesslist.go
+++ b/tool/tctl/common/accesslist/accesslist.go
@@ -21,18 +21,20 @@ import (
 
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/parse"
 )
 
-func newMember(listName, name, kind string) (*accesslist.AccessListMember, error) {
-	return accesslist.NewAccessListMember(
-		header.Metadata{Name: name},
+func newMember(listName, name scopes.QualifiedName, kind string) (*accesslist.AccessListMember, error) {
+	return accesslist.NewAccessListMemberWithScope(
+		header.Metadata{Name: name.String()},
 		accesslist.AccessListMemberSpec{
-			AccessList:     listName,
-			Name:           name,
+			AccessList:     listName.String(),
+			Name:           name.String(),
 			MembershipKind: kind,
 		},
+		listName.Scope,
 	)
 }
 

--- a/tool/tctl/common/accesslist/command.go
+++ b/tool/tctl/common/accesslist/command.go
@@ -33,14 +33,18 @@ import (
 
 	"github.com/gravitational/teleport"
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/accesslists"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/slices"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 )
@@ -67,9 +71,9 @@ type Command struct {
 	memberKind string
 
 	// Used for managing membership to an access list.
-	userName string
-	expires  string
-	reason   string
+	memberName string
+	expires    string
+	reason     string
 
 	// Used for creating reviews.
 	notes         string
@@ -230,13 +234,13 @@ func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags
 	c.usersAdd = users.Command("add", "Add a user to an Access List.")
 	c.usersAdd.Flag("kind", "Access list member kind.").Default(memberKindUser).EnumVar(&c.memberKind, memberKindUser, memberKindList)
 	c.usersAdd.Arg("access-list-name", "The Access List name.").Required().StringVar(&c.accessListName)
-	c.usersAdd.Arg("user", "The user to add to the Access List.").Required().StringVar(&c.userName)
+	c.usersAdd.Arg("user", "The member to add to the Access List.").Required().StringVar(&c.memberName)
 	c.usersAdd.Arg("expires", "When the user's access expires (must be in RFC3339). Defaults to the expiration time of the Access List.").StringVar(&c.expires)
 	c.usersAdd.Arg("reason", "The reason the user has been added to the Access List. Defaults to empty.").StringVar(&c.reason)
 
 	c.usersRemove = users.Command("rm", "Remove a user from an Access List.")
 	c.usersRemove.Arg("access-list-name", "The Access List name.").Required().StringVar(&c.accessListName)
-	c.usersRemove.Arg("user", "The user to remove from the Access List.").Required().StringVar(&c.userName)
+	c.usersRemove.Arg("user", "The member to remove from the Access List.").Required().StringVar(&c.memberName)
 
 	c.usersList = users.Command("ls", "List users that are members of an Access List.")
 	c.usersList.Arg("access-list-name", "The Access List name.").Required().StringVar(&c.accessListName)
@@ -396,9 +400,53 @@ func (c *Command) List(ctx context.Context, client *authclient.Client) error {
 	return trace.Wrap(c.displayAccessLists(accessLists...))
 }
 
+func parseQualifiedName(name string) (scopes.QualifiedName, error) {
+	// For backward compatibility, an argument is considered a scope-qualified
+	// name only if it:
+	// 1. parses as a qualified name (contains :: somewhere in the middle)
+	// 2. contains /
+	// otherwise it is considered a plain unscoped name. This allows access
+	// lists with names like 'example::list' to continue to be referenced in
+	// CLI commands as unscoped lists, only params like '/example::list' will
+	// be considered scoped.
+	if sqn, err := scopes.ParseQualifiedName(name); err == nil && strings.Contains(name, "/") {
+		return sqn, sqn.StrongValidate()
+	}
+	return scopes.QualifiedName{Name: name}, nil
+}
+
+func (c *Command) accessListScopeQualifiedName() (scopes.QualifiedName, error) {
+	sqn, err := parseQualifiedName(c.accessListName)
+	return sqn, trace.Wrap(err, "validating access list name as a scope-qualified name")
+}
+
+func (c *Command) memberScopeQualifiedName() (scopes.QualifiedName, error) {
+	sqn, err := parseQualifiedName(c.memberName)
+	return sqn, trace.Wrap(err, "validating member name as a scope-qualified name")
+}
+
+func splitQualifiedNames(namesStr string) ([]scopes.QualifiedName, error) {
+	var sqns []scopes.QualifiedName
+	for _, name := range utils.SplitIdentifiers(namesStr) {
+		sqn, err := parseQualifiedName(strings.TrimSpace(name))
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		sqns = append(sqns, sqn)
+	}
+	return sqns, nil
+}
+
 // Get will display information about an access list visible to the user.
 func (c *Command) Get(ctx context.Context, client *authclient.Client) error {
-	accessList, err := client.AccessListClient().GetAccessList(ctx, c.accessListName)
+	aclName, err := c.accessListScopeQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	accessList, err := client.AccessListClient().GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Scope: aclName.Scope,
+		Name:  aclName.Name,
+	}.Build())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -418,7 +466,14 @@ func (c *Command) Summary(ctx context.Context, client *authclient.Client) error 
 	var accessLists []*accesslist.AccessList
 
 	if c.accessListName != "" {
-		accessList, err := client.AccessListClient().GetAccessList(ctx, c.accessListName)
+		aclName, err := c.accessListScopeQualifiedName()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		accessList, err := client.AccessListClient().GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+			Scope: aclName.Scope,
+			Name:  aclName.Name,
+		}.Build())
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -465,19 +520,34 @@ func (c *Command) UsersAdd(ctx context.Context, client *authclient.Client) error
 		}
 	}
 
+	aclName, err := c.accessListScopeQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	memberName, err := c.memberScopeQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	var membershipKind string
 	switch c.memberKind {
 	case memberKindList:
 		membershipKind = accesslist.MembershipKindList
+		if memberName.Scope != "" {
+			membershipKind = accesslist.MembershipKindScopedList
+		}
 	case "", memberKindUser:
+		if memberName.Scope != "" {
+			return trace.BadParameter("user members cannot be scoped, got %q", c.memberName)
+		}
 		membershipKind = accesslist.MembershipKindUser
 	}
 
-	member, err := accesslist.NewAccessListMember(header.Metadata{
-		Name: c.userName,
+	member, err := accesslist.NewAccessListMemberWithScope(header.Metadata{
+		Name: memberName.String(),
 	}, accesslist.AccessListMemberSpec{
-		AccessList: c.accessListName,
-		Name:       c.userName,
+		AccessList: aclName.String(),
+		Name:       memberName.String(),
 		Reason:     c.reason,
 		Expires:    expires,
 
@@ -485,7 +555,7 @@ func (c *Command) UsersAdd(ctx context.Context, client *authclient.Client) error
 		Joined:         time.Now(),
 		AddedBy:        "dummy",
 		MembershipKind: membershipKind,
-	})
+	}, aclName.Scope)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -495,26 +565,43 @@ func (c *Command) UsersAdd(ctx context.Context, client *authclient.Client) error
 		return trace.Wrap(err)
 	}
 
-	fmt.Fprintf(c.Stdout, "successfully added user %s to access list %s", c.userName, c.accessListName)
+	fmt.Fprintf(c.Stdout, "successfully added user %s to access list %s", memberName.String(), aclName.String())
 
 	return nil
 }
 
 // UsersRemove will remove a user to an access list.
 func (c *Command) UsersRemove(ctx context.Context, client *authclient.Client) error {
-	err := client.AccessListClient().DeleteAccessListMember(ctx, c.accessListName, c.userName)
+	aclName, err := c.accessListScopeQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	memberName, err := c.memberScopeQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = client.AccessListClient().DeleteAccessListMemberV2(ctx, accesslistv1.DeleteAccessListMemberRequest_builder{
+		AccessListScope: aclName.Scope,
+		AccessList:      aclName.Name,
+		MemberScope:     memberName.Scope,
+		MemberName:      memberName.Name,
+	}.Build())
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	fmt.Fprintf(c.Stdout, "successfully removed user %s from access list %s\n", c.userName, c.accessListName)
+	fmt.Fprintf(c.Stdout, "successfully removed user %s from access list %s\n", memberName.String(), aclName.String())
 
 	return nil
 }
 
 // UsersList will list the users in an access list.
 func (c *Command) UsersList(ctx context.Context, client *authclient.Client) error {
-	allMembers, err := c.collectAllMembers(ctx, client, c.accessListName)
+	aclName, err := c.accessListScopeQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	allMembers, err := c.collectAllMembers(ctx, client, aclName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -526,7 +613,7 @@ func (c *Command) UsersList(ctx context.Context, client *authclient.Client) erro
 		return trace.Wrap(utils.WriteYAML(c.Stdout, allMembers))
 	case teleport.Text:
 		if len(allMembers) == 0 {
-			fmt.Fprintf(c.Stdout, "No members found for access list %s", c.accessListName)
+			fmt.Fprintf(c.Stdout, "No members found for access list %s", aclName.String())
 			return nil
 		}
 		return trace.Wrap(c.displayAccessListMembersText(ctx, client, allMembers))
@@ -556,22 +643,32 @@ func (c *Command) displayAccessListMembersText(ctx context.Context, client *auth
 }
 
 func formatAccessListMember(ctx context.Context, client *authclient.Client, member *accesslist.AccessListMember) (string, error) {
-	name := member.GetName()
-	if member.Spec.MembershipKind == accesslist.MembershipKindList {
-		list, err := client.AccessListClient().GetAccessList(ctx, name)
+	memberName, err := accesslists.MemberScopeQualifiedName(member)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	if member.IsList() {
+		list, err := client.AccessListClient().GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+			Scope: memberName.Scope,
+			Name:  memberName.Name,
+		}.Build())
 		if err != nil {
 			return "", trace.Wrap(err)
 		}
-		return fmt.Sprintf("%v (%v)", list.Spec.Title, name), nil
+		return fmt.Sprintf("%v (%v)", list.Spec.Title, memberName.String()), nil
 	}
-	return name, nil
+	return memberName.String(), nil
 }
 
 func formatAccessListMemberType(member *accesslist.AccessListMember) string {
-	if member.Spec.MembershipKind == accesslist.MembershipKindList {
+	switch member.Spec.MembershipKind {
+	case accesslist.MembershipKindList:
 		return "Access List"
+	case accesslist.MembershipKindScopedList:
+		return "Scoped Access List"
+	default:
+		return "User"
 	}
-	return "User"
 }
 
 func formatAccessListReason(reason string) string {
@@ -605,30 +702,46 @@ func (c *Command) ReviewsCreate(ctx context.Context, client *authclient.Client) 
 }
 
 func (c *Command) makeReview() (*accesslist.Review, error) {
+	aclName, err := c.accessListScopeQualifiedName()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	var removeMembers []string
-	for _, member := range strings.Split(c.removeMembers, ",") {
-		member = strings.TrimSpace(member)
-		if member != "" {
-			removeMembers = append(removeMembers, member)
+	var removeScopedMembers []string
+	removedMemberNames, err := splitQualifiedNames(c.removeMembers)
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing removed member name")
+	}
+	for _, removedMemberName := range removedMemberNames {
+		if removedMemberName.Scope == "" {
+			removeMembers = append(removeMembers, removedMemberName.String())
+		} else {
+			removeScopedMembers = append(removeScopedMembers, removedMemberName.String())
 		}
 	}
-	return accesslist.NewReview(
+	return accesslist.NewReviewWithScope(
 		header.Metadata{
 			Name: uuid.NewString(),
 		},
 		accesslist.ReviewSpec{
-			AccessList: c.accessListName,
+			AccessList: aclName.String(),
 			Reviewers:  []string{"placeholder"}, // Reviewers is set server-side but API requires it.
 			ReviewDate: time.Now(),              // Review date will be set server-side as well.
 			Notes:      c.notes,
 			Changes: accesslist.ReviewChanges{
-				RemovedMembers: removeMembers,
+				RemovedMembers:       removeMembers,
+				ScopedRemovedMembers: removeScopedMembers,
 			},
-		})
+		},
+		aclName.Scope)
 }
 
 func (c *Command) ReviewsList(ctx context.Context, client *authclient.Client) error {
-	reviews, err := c.collectAllReviews(ctx, client, c.accessListName)
+	aclName, err := c.accessListScopeQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	reviews, err := c.collectAllReviews(ctx, client, aclName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -657,7 +770,7 @@ func (c *Command) displayAccessListReviewsText(reviews []*accesslist.Review) err
 			review.GetName(),
 			strings.Join(review.Spec.Reviewers, ","),
 			review.Spec.ReviewDate.Format(time.DateOnly),
-			strings.Join(review.Spec.Changes.RemovedMembers, ","),
+			strings.Join(append(review.Spec.Changes.RemovedMembers, review.Spec.Changes.ScopedRemovedMembers...), ","),
 			review.Spec.Notes,
 		})
 	}
@@ -682,7 +795,12 @@ func (c *Command) displayAccessLists(accessLists ...*accesslist.AccessList) erro
 func (c *Command) displayAccessListsText(accessLists ...*accesslist.AccessList) error {
 	table := asciitable.MakeTable([]string{"ID", "Title", "Next Audit", "Granted Roles", "Granted Traits"})
 	for _, accessList := range accessLists {
-		grantedRoles := strings.Join(accessList.GetGrants().Roles, ",")
+		var grantedRoles []string
+		grantedRoles = append(grantedRoles, accessList.GetGrants().Roles...)
+		grantedRoles = append(grantedRoles, slices.Map(accessList.GetGrants().ScopedRoles,
+			func(g accesslist.ScopedRoleGrant) string {
+				return g.Role
+			})...)
 		traitStrings := make([]string, 0, len(accessList.GetGrants().Traits))
 		for k, values := range accessList.GetGrants().Traits {
 			traitStrings = append(traitStrings, fmt.Sprintf("%s:{%s}", k, strings.Join(values, ",")))
@@ -690,15 +808,14 @@ func (c *Command) displayAccessListsText(accessLists ...*accesslist.AccessList) 
 
 		grantedTraits := strings.Join(traitStrings, ",")
 		table.AddRow([]string{
-			accessList.GetName(),
+			accesslists.ScopeQualifiedName(accessList).String(),
 			accessList.Spec.Title,
 			accessList.Spec.Audit.NextAuditDate.Format(time.DateOnly),
-			grantedRoles,
+			strings.Join(grantedRoles, ","),
 			grantedTraits,
 		})
 	}
-	_, err := fmt.Fprintln(c.Stdout, table.AsBuffer().String())
-	return trace.Wrap(err)
+	return trace.Wrap(table.WriteTo(c.Stdout))
 }
 
 type accessList struct {
@@ -727,17 +844,20 @@ type accessListMember struct {
 }
 
 type accessListReview struct {
-	ReviewDate     time.Time `json:"review_date"`
-	Reviewers      []string  `json:"reviewers"`
-	Notes          string    `json:"notes,omitempty"`
-	RemovedMembers []string  `json:"removed_members"`
+	ReviewDate           time.Time `json:"review_date"`
+	Reviewers            []string  `json:"reviewers"`
+	Notes                string    `json:"notes,omitempty"`
+	RemovedMembers       []string  `json:"removed_members"`
+	ScopedRemovedMembers []string  `json:"scoped_removed_members"`
 }
 
 // buildAccessListSummary constructs an accessList summary entry for the given
 // access list, including its owners, members, and most recent review.
 func (c *Command) buildAccessListSummary(ctx context.Context, client *authclient.Client, al *accesslist.AccessList) (accessList, error) {
+	aclName := accesslists.ScopeQualifiedName(al)
+
 	entry := accessList{
-		Name:          al.GetName(),
+		Name:          aclName.String(),
 		Title:         al.Spec.Title,
 		Description:   al.Spec.Description,
 		NextAuditDate: al.Spec.Audit.NextAuditDate,
@@ -753,7 +873,7 @@ func (c *Command) buildAccessListSummary(ctx context.Context, client *authclient
 	}
 
 	// Get all members.
-	members, err := c.collectAllMembers(ctx, client, al.GetName())
+	members, err := c.collectAllMembers(ctx, client, aclName.ToScopesQualifiedName())
 	if err != nil {
 		return accessList{}, trace.Wrap(err)
 	}
@@ -774,7 +894,7 @@ func (c *Command) buildAccessListSummary(ctx context.Context, client *authclient
 	}
 
 	// Get the most recent review.
-	reviews, err := c.collectAllReviews(ctx, client, al.GetName())
+	reviews, err := c.collectAllReviews(ctx, client, aclName.ToScopesQualifiedName())
 	if err != nil {
 		return accessList{}, trace.Wrap(err)
 	}
@@ -783,10 +903,11 @@ func (c *Command) buildAccessListSummary(ctx context.Context, client *authclient
 			return reviews[i].Spec.ReviewDate.After(reviews[j].Spec.ReviewDate)
 		})
 		entry.LastReview = &accessListReview{
-			ReviewDate:     reviews[0].Spec.ReviewDate,
-			Reviewers:      reviews[0].Spec.Reviewers,
-			Notes:          reviews[0].Spec.Notes,
-			RemovedMembers: reviews[0].Spec.Changes.RemovedMembers,
+			ReviewDate:           reviews[0].Spec.ReviewDate,
+			Reviewers:            reviews[0].Spec.Reviewers,
+			Notes:                reviews[0].Spec.Notes,
+			RemovedMembers:       reviews[0].Spec.Changes.RemovedMembers,
+			ScopedRemovedMembers: reviews[0].Spec.Changes.ScopedRemovedMembers,
 		}
 	}
 
@@ -794,20 +915,37 @@ func (c *Command) buildAccessListSummary(ctx context.Context, client *authclient
 }
 
 func (c *Command) collectAllLists(ctx context.Context, client *authclient.Client) ([]*accesslist.AccessList, error) {
-	return stream.Collect(clientutils.Resources(ctx,
-		client.AccessListClient().ListAccessLists))
+	return stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessList, string, error) {
+		return client.AccessListClient().ListAccessListsV2(ctx, accesslistv1.ListAccessListsV2Request_builder{
+			PageSize:  int32(pageSize),
+			PageToken: pageToken,
+			ScopeFilter: scopesv1.Filter_builder{
+				Mode: scopesv1.Mode_MODE_ALL,
+			}.Build(),
+		}.Build())
+	}))
 }
 
-func (c *Command) collectAllMembers(ctx context.Context, client *authclient.Client, aclName string) ([]*accesslist.AccessListMember, error) {
+func (c *Command) collectAllMembers(ctx context.Context, client *authclient.Client, aclName scopes.QualifiedName) ([]*accesslist.AccessListMember, error) {
 	return stream.Collect(clientutils.Resources(ctx,
 		func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
-			return client.AccessListClient().ListAccessListMembers(ctx, aclName, pageSize, pageToken)
+			return client.AccessListClient().ListAccessListMembersV2(ctx, accesslistv1.ListAccessListMembersRequest_builder{
+				PageSize:        int32(pageSize),
+				PageToken:       pageToken,
+				AccessListScope: aclName.Scope,
+				AccessList:      aclName.Name,
+			}.Build())
 		}))
 }
 
-func (c *Command) collectAllReviews(ctx context.Context, client *authclient.Client, aclName string) ([]*accesslist.Review, error) {
+func (c *Command) collectAllReviews(ctx context.Context, client *authclient.Client, aclName scopes.QualifiedName) ([]*accesslist.Review, error) {
 	return stream.Collect(clientutils.Resources(ctx,
 		func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.Review, string, error) {
-			return client.AccessListClient().ListAccessListReviews(ctx, aclName, pageSize, pageToken)
+			return client.AccessListClient().ListAccessListReviewsV2(ctx, accesslistv1.ListAccessListReviewsRequest_builder{
+				PageSize:        int32(pageSize),
+				NextToken:       pageToken,
+				AccessListScope: aclName.Scope,
+				AccessList:      aclName.Name,
+			}.Build())
 		}))
 }

--- a/tool/tctl/common/accesslist/create.go
+++ b/tool/tctl/common/accesslist/create.go
@@ -32,7 +32,9 @@ import (
 	"github.com/gravitational/teleport/api/types/accesslist"
 	conv "github.com/gravitational/teleport/api/types/accesslist/convert/v1"
 	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/lib/accesslists"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -47,7 +49,7 @@ func (c *Command) Create(ctx context.Context, client *authclient.Client) error {
 		return trace.Wrap(err)
 	}
 
-	members, err := c.buildMembers(newAccessList.GetName())
+	members, err := c.buildMembers(accesslists.ScopeQualifiedName(newAccessList).ToScopesQualifiedName())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -85,15 +87,23 @@ func (c *Command) validateCreate() error {
 	return nil
 }
 
-func (c *Command) buildOwners() []accesslist.Owner {
+func (c *Command) buildOwners() ([]accesslist.Owner, error) {
 	var owners []accesslist.Owner
 	for _, name := range utils.SplitIdentifiers(c.owners) {
 		owners = append(owners, accesslist.Owner{Name: name, MembershipKind: accesslist.MembershipKindUser})
 	}
-	for _, name := range utils.SplitIdentifiers(c.ownerAccessLists) {
-		owners = append(owners, accesslist.Owner{Name: name, MembershipKind: accesslist.MembershipKindList})
+	ownerNames, err := splitQualifiedNames(c.ownerAccessLists)
+	if err != nil {
+		return nil, trace.BadParameter("parsing owner access list name")
 	}
-	return owners
+	for _, ownerName := range ownerNames {
+		kind := accesslist.MembershipKindList
+		if ownerName.Scope != "" {
+			kind = accesslist.MembershipKindScopedList
+		}
+		owners = append(owners, accesslist.Owner{Name: ownerName.String(), MembershipKind: kind})
+	}
+	return owners, nil
 }
 
 func (c *Command) buildAccessListForCreate() (*accesslist.AccessList, error) {
@@ -105,6 +115,10 @@ func (c *Command) buildAccessListForCreate() (*accesslist.AccessList, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	owners, err := c.buildOwners()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	newAccessList, err := accesslist.NewAccessList(
 		header.Metadata{
@@ -113,7 +127,7 @@ func (c *Command) buildAccessListForCreate() (*accesslist.AccessList, error) {
 		accesslist.Spec{
 			Title:       strings.TrimSpace(c.title),
 			Description: strings.TrimSpace(c.description),
-			Owners:      c.buildOwners(),
+			Owners:      owners,
 			Audit: accesslist.Audit{
 				Recurrence: accesslist.Recurrence{
 					Frequency:  reviewFreq,
@@ -273,17 +287,25 @@ func (c *Command) buildResourceAccessRoles() ([]*types.RoleV6, error) {
 	return roles, nil
 }
 
-func (c *Command) buildMembers(accessListID string) ([]*accesslist.AccessListMember, error) {
+func (c *Command) buildMembers(accessListName scopes.QualifiedName) ([]*accesslist.AccessListMember, error) {
 	var members []*accesslist.AccessListMember
 	for _, name := range utils.SplitIdentifiers(c.members) {
-		m, err := newMember(accessListID, name, accesslist.MembershipKindUser)
+		m, err := newMember(accessListName, scopes.QualifiedName{Name: name}, accesslist.MembershipKindUser)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		members = append(members, m)
 	}
-	for _, name := range utils.SplitIdentifiers(c.memberAccessLists) {
-		m, err := newMember(accessListID, name, accesslist.MembershipKindList)
+	memberListNames, err := splitQualifiedNames(c.memberAccessLists)
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing member access list name")
+	}
+	for _, name := range memberListNames {
+		kind := accesslist.MembershipKindList
+		if name.Scope != "" {
+			kind = accesslist.MembershipKindScopedList
+		}
+		m, err := newMember(accessListName, name, kind)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/tool/tctl/common/accesslist/create_test.go
+++ b/tool/tctl/common/accesslist/create_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/lib/scopes"
 )
 
 func TestValidateCreate(t *testing.T) {
@@ -194,9 +195,9 @@ func TestBuildResourceAccessRoles(t *testing.T) {
 
 func TestBuildMembers(t *testing.T) {
 	const listID = "acl-123"
-	c := Command{members: "apple,banana", memberAccessLists: "some-list"}
+	c := Command{members: "apple,banana", memberAccessLists: "some-list,/scoped::other-list"}
 
-	members, err := c.buildMembers(listID)
+	members, err := c.buildMembers(scopes.QualifiedName{Name: listID})
 	require.NoError(t, err)
 
 	gotKinds := make(map[string]string, len(members))
@@ -206,16 +207,18 @@ func TestBuildMembers(t *testing.T) {
 	}
 
 	require.Equal(t, map[string]string{
-		"apple":     accesslist.MembershipKindUser,
-		"banana":    accesslist.MembershipKindUser,
-		"some-list": accesslist.MembershipKindList,
+		"apple":               accesslist.MembershipKindUser,
+		"banana":              accesslist.MembershipKindUser,
+		"some-list":           accesslist.MembershipKindList,
+		"/scoped::other-list": accesslist.MembershipKindScopedList,
 	}, gotKinds)
 }
 
 func TestBuildOwners(t *testing.T) {
-	c := Command{owners: "apple,banana", ownerAccessLists: "some-list"}
+	c := Command{owners: "apple,banana", ownerAccessLists: "some-list,/scoped::other-list"}
 
-	owners := c.buildOwners()
+	owners, err := c.buildOwners()
+	require.NoError(t, err)
 
 	gotKinds := make(map[string]string, len(owners))
 	for _, o := range owners {
@@ -223,8 +226,9 @@ func TestBuildOwners(t *testing.T) {
 	}
 
 	require.Equal(t, map[string]string{
-		"apple":     accesslist.MembershipKindUser,
-		"banana":    accesslist.MembershipKindUser,
-		"some-list": accesslist.MembershipKindList,
+		"apple":               accesslist.MembershipKindUser,
+		"banana":              accesslist.MembershipKindUser,
+		"some-list":           accesslist.MembershipKindList,
+		"/scoped::other-list": accesslist.MembershipKindScopedList,
 	}, gotKinds)
 }

--- a/tool/tctl/common/accesslist/remove.go
+++ b/tool/tctl/common/accesslist/remove.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -38,12 +39,22 @@ import (
 // from assigning these roles to other users or referencing them in other roles.
 // Deleting a role assigned to other resources will lock a user out of their account.
 func (c *Command) Remove(ctx context.Context, client *authclient.Client) error {
-	al, err := client.AccessListClient().GetAccessList(ctx, c.accessListName)
+	aclName, err := c.accessListScopeQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	al, err := client.AccessListClient().GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Scope: aclName.Scope,
+		Name:  aclName.Name,
+	}.Build())
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	if err := client.AccessListClient().DeleteAccessList(ctx, c.accessListName); err != nil {
+	if err := client.AccessListClient().DeleteAccessListV2(ctx, accesslistv1.DeleteAccessListRequest_builder{
+		Scope: aclName.Scope,
+		Name:  aclName.Name,
+	}.Build()); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -59,7 +70,7 @@ func (c *Command) Remove(ctx context.Context, client *authclient.Client) error {
 		return trace.Wrap(utils.WriteJSON(c.Stdout, resp), "failed to marshal access list delete response")
 	}
 
-	fmt.Fprintf(c.Stdout, "Deleted access list %q\n", c.accessListName)
+	fmt.Fprintf(c.Stdout, "Deleted access list %q\n", aclName.String())
 	c.printRolesToBeDeleted(resp.RolesToDelete)
 	return nil
 }

--- a/tool/tctl/common/accesslist/update.go
+++ b/tool/tctl/common/accesslist/update.go
@@ -30,9 +30,12 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	conv "github.com/gravitational/teleport/api/types/accesslist/convert/v1"
+	"github.com/gravitational/teleport/lib/accesslists"
 	"github.com/gravitational/teleport/lib/accesslists/preset"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/utils"
+	sliceutils "github.com/gravitational/teleport/lib/utils/slices"
 )
 
 // Update handles `tctl acl update`.
@@ -53,7 +56,14 @@ func (c *Command) Update(ctx context.Context, client *authclient.Client) error {
 		return trace.BadParameter("cannot unset title")
 	}
 
-	al, err := client.AccessListClient().GetAccessList(ctx, c.accessListName)
+	aclName, err := c.accessListScopeQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	al, err := client.AccessListClient().GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Scope: aclName.Scope,
+		Name:  aclName.Name,
+	}.Build())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -77,15 +87,15 @@ func (c *Command) Update(ctx context.Context, client *authclient.Client) error {
 	var updatedAccessList *accesslist.AccessList
 	var updatedRoles []string
 	var rolesToDelete []string
-	var removedOwners []string
-	var removedMembers []string
+	var removedOwners []accesslists.NormalizedSQN
+	var removedMembers []accesslists.NormalizedSQN
 
 	switch {
 	case c.anyMemberUpdateFlagSet():
 		// Member-only update: replace the membership list without touching
 		// the access list spec.
 		var updatedMembers []*accesslist.AccessListMember
-		updatedMembers, removedMembers, err = c.buildMembersForUpdate(ctx, client, al.GetName())
+		updatedMembers, removedMembers, err = c.buildMembersForUpdate(ctx, client, aclName)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -101,7 +111,10 @@ func (c *Command) Update(ctx context.Context, client *authclient.Client) error {
 		}
 		if c.ownersSet || c.ownerAccessListsSet {
 			var updatedOwners []accesslist.Owner
-			updatedOwners, removedOwners = c.buildOwnersForUpdate(al)
+			updatedOwners, removedOwners, err = c.buildOwnersForUpdate(al)
+			if err != nil {
+				return trace.Wrap(err)
+			}
 			if len(updatedOwners) == 0 {
 				return trace.BadParameter("an access list must have at least one owner")
 			}
@@ -126,8 +139,8 @@ func (c *Command) Update(ctx context.Context, client *authclient.Client) error {
 		AccessType:            accessType(updatedAccessList.GetAllLabels()[accesslist.AccessListPresetLabel]),
 		UpdatedOrCreatedRoles: updatedRoles,
 		RolesToDelete:         rolesToDelete,
-		OwnersRemoved:         removedOwners,
-		MembersRemoved:        removedMembers,
+		OwnersRemoved:         sliceutils.Map(removedOwners, accesslists.NormalizedSQN.String),
+		MembersRemoved:        sliceutils.Map(removedMembers, accesslists.NormalizedSQN.String),
 	}
 	if c.format == teleport.JSON {
 		return trace.Wrap(utils.WriteJSON(c.Stdout, resp), "failed to marshal access list update response")
@@ -171,19 +184,30 @@ func (c *Command) applySpecFlags(al *accesslist.AccessList) error {
 	return nil
 }
 
-func reconcileOwners(wantUpdate bool, ownersStr string, memberKind string, currOwners map[string]accesslist.Owner) (newOwners []accesslist.Owner, removedOwners []string) {
+func reconcileOwners(wantUpdate bool, ownersStr string, memberKind string, currOwners map[accesslists.NormalizedSQN]accesslist.Owner) (newOwners []accesslist.Owner, removedOwners []accesslists.NormalizedSQN, err error) {
 	if !wantUpdate {
 		// return owners as is.
 		for _, o := range currOwners {
 			newOwners = append(newOwners, o)
 		}
-		return newOwners, nil
+		return newOwners, nil, nil
 	}
 
-	newOwnerLookup := make(map[string]struct{}, len(currOwners))
-	for _, owner := range utils.SplitIdentifiers(ownersStr) {
-		newOwnerLookup[owner] = struct{}{}
-		newOwners = append(newOwners, accesslist.Owner{Name: owner, MembershipKind: memberKind})
+	newOwnerLookup := make(map[accesslists.NormalizedSQN]struct{}, len(currOwners))
+	ownerNames, err := splitQualifiedNames(ownersStr)
+	if err != nil {
+		return nil, nil, trace.Wrap(err, "parsing owner name")
+	}
+	for _, ownerName := range ownerNames {
+		kind := memberKind
+		if ownerName.Scope != "" {
+			if !accesslist.IsMembershipKindList(memberKind) {
+				return nil, nil, trace.BadParameter("user owners cannot be scoped, got %q", ownerName.String())
+			}
+			kind = accesslist.MembershipKindScopedList
+		}
+		newOwnerLookup[accesslists.NormalizeSQN(ownerName)] = struct{}{}
+		newOwners = append(newOwners, accesslist.Owner{Name: ownerName.String(), MembershipKind: kind})
 	}
 
 	for currOwner := range currOwners {
@@ -192,10 +216,10 @@ func reconcileOwners(wantUpdate bool, ownersStr string, memberKind string, currO
 		}
 	}
 
-	return newOwners, removedOwners
+	return newOwners, removedOwners, nil
 }
 
-func reconcileMembers(listName string, wantUpdate bool, membersStr string, memberKind string, currMembers map[string]*accesslist.AccessListMember) (newMembers []*accesslist.AccessListMember, removedMembers []string, err error) {
+func reconcileMembers(listName scopes.QualifiedName, wantUpdate bool, membersStr string, memberKind string, currMembers map[accesslists.NormalizedSQN]*accesslist.AccessListMember) (newMembers []*accesslist.AccessListMember, removedMembers []accesslists.NormalizedSQN, err error) {
 	if !wantUpdate {
 		// return members as is.
 		for _, m := range currMembers {
@@ -204,10 +228,21 @@ func reconcileMembers(listName string, wantUpdate bool, membersStr string, membe
 		return newMembers, nil, nil
 	}
 
-	newMemberLookup := make(map[string]struct{}, len(currMembers))
-	for _, name := range utils.SplitIdentifiers(membersStr) {
-		newMemberLookup[name] = struct{}{}
-		m, err := newMember(listName, name, memberKind)
+	newMemberLookup := make(map[accesslists.NormalizedSQN]struct{}, len(currMembers))
+	memberNames, err := splitQualifiedNames(membersStr)
+	if err != nil {
+		return nil, nil, trace.Wrap(err, "parsing member name")
+	}
+	for _, memberName := range memberNames {
+		kind := memberKind
+		if memberName.Scope != "" {
+			if !accesslist.IsMembershipKindList(memberKind) {
+				return nil, nil, trace.BadParameter("user members cannot be scoped, got %q", memberName.String())
+			}
+			kind = accesslist.MembershipKindScopedList
+		}
+		newMemberLookup[accesslists.NormalizeSQN(memberName)] = struct{}{}
+		m, err := newMember(listName, memberName, kind)
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
@@ -228,19 +263,23 @@ func reconcileMembers(listName string, wantUpdate bool, membersStr string, membe
 // updates only the specified member kinds.
 // E.g.: if only "--member-access-lists" was specified, only member kind "access list" is updated
 // and member kind "user" is still preserved.
-func (c *Command) buildMembersForUpdate(ctx context.Context, client *authclient.Client, listName string) ([]*accesslist.AccessListMember, []string, error) {
+func (c *Command) buildMembersForUpdate(ctx context.Context, client *authclient.Client, listName scopes.QualifiedName) ([]*accesslist.AccessListMember, []accesslists.NormalizedSQN, error) {
 	currentMembers, err := c.collectAllMembers(ctx, client, listName)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
-	currentUsers := make(map[string]*accesslist.AccessListMember)
-	currentLists := make(map[string]*accesslist.AccessListMember)
+	currentUsers := make(map[accesslists.NormalizedSQN]*accesslist.AccessListMember)
+	currentLists := make(map[accesslists.NormalizedSQN]*accesslist.AccessListMember)
 	for _, m := range currentMembers {
-		if m.Spec.MembershipKind == accesslist.MembershipKindList {
-			currentLists[m.Spec.Name] = m
+		memberName, err := accesslists.MemberScopeQualifiedName(m)
+		if err != nil {
+			return nil, nil, trace.Wrap(err, "parsing member name")
+		}
+		if m.IsList() {
+			currentLists[memberName] = m
 		} else {
-			currentUsers[m.Spec.Name] = m
+			currentUsers[memberName] = m
 		}
 	}
 
@@ -261,23 +300,28 @@ func (c *Command) buildMembersForUpdate(ctx context.Context, client *authclient.
 // updates only the specified owner kinds.
 // E.g.: if only "--owner-access-lists" was specified, only owner kind "access list" is updated
 // and owner kind "user" is still preserved.
-func (c *Command) buildOwnersForUpdate(al *accesslist.AccessList) ([]accesslist.Owner, []string) {
-	currentUserOwners := make(map[string]accesslist.Owner)
-	currentListOwners := make(map[string]accesslist.Owner)
+func (c *Command) buildOwnersForUpdate(al *accesslist.AccessList) ([]accesslist.Owner, []accesslists.NormalizedSQN, error) {
+	currentUserOwners := make(map[accesslists.NormalizedSQN]accesslist.Owner)
+	currentListOwners := make(map[accesslists.NormalizedSQN]accesslist.Owner)
 	for _, o := range al.Spec.Owners {
-		if o.MembershipKind == accesslist.MembershipKindList {
-			currentListOwners[o.Name] = o
-		} else {
-			currentUserOwners[o.Name] = o
+		ownerName, err := accesslists.OwnerScopeQualifiedName(o)
+		if err != nil {
+			return nil, nil, trace.Wrap(err, "parsing owner name")
+		}
+		if o.IsMembershipKindList() {
+			currentListOwners[ownerName] = o
+		}
+		if o.IsMembershipKindUser() {
+			currentUserOwners[ownerName] = o
 		}
 	}
 
-	userOwners, userRemoved := reconcileOwners(c.ownersSet, c.owners, accesslist.MembershipKindUser, currentUserOwners)
-	listOwners, listRemoved := reconcileOwners(c.ownerAccessListsSet, c.ownerAccessLists, accesslist.MembershipKindList, currentListOwners)
+	userOwners, userRemoved, userErr := reconcileOwners(c.ownersSet, c.owners, accesslist.MembershipKindUser, currentUserOwners)
+	listOwners, listRemoved, listErr := reconcileOwners(c.ownerAccessListsSet, c.ownerAccessLists, accesslist.MembershipKindList, currentListOwners)
 	newOwners := append(userOwners, listOwners...)
 	removedOwners := append(userRemoved, listRemoved...)
 
-	return newOwners, removedOwners
+	return newOwners, removedOwners, trace.NewAggregate(userErr, listErr)
 }
 
 // updateAccessListWithPreset updates an access list spec/meta and its related access roles.


### PR DESCRIPTION
Part of [RFD 308](https://github.com/gravitational/rfd/pull/22)

This PR adds support for scoped access lists in the `tctl acl` family of commands, namely `ls`, `get`, `summary`, `users`, `reviews`, `rm` and `update`. The new `tctl acl create` command does not yet support creating scoped access lists.

Anywhere an access list name is currently accepted as a CLI param, it will be considered a scope-qualified name of a scoped access list if the string is a strongly-valid scope-qualified name, e.g. `/example/scope::name`.  Per [RFD 0229f](https://github.com/gravitational/rfd/pull/36) scope-qualified names are the standard way to refer to scoped resources on the CLI. Requiring the scope-qualified name to be strongly-valid should make this change completely backward-compatible, since scope-qualified names must begin with `/` which is illegal in resource names and prevented by the backend key sanitizer.

Test coverage requires an enterprise cluster, it is added in https://github.com/gravitational/teleport.e/pull/9123

Parent: https://github.com/gravitational/teleport/pull/68567

Manually tested with the testplan at https://github.com/gravitational/teleport.e/pull/9120