### PR TITLE
typical: Add function combinators

### DIFF
--- a/lib/services/label/label_expressions_test.go
+++ b/lib/services/label/label_expressions_test.go
@@ -95,7 +95,7 @@ func TestLabelExpressions(t *testing.T) {
 				"env": "staging",
 			},
 			expectParseError: []string{
-				"parsing first argument to (contains)",
+				"parsing first argument to function (contains)",
 				"expected type []string",
 			},
 		},

--- a/lib/utils/typical/example_test.go
+++ b/lib/utils/typical/example_test.go
@@ -94,6 +94,6 @@ func Example() {
 	// true
 	// false
 	// parse error: parsing expression
-	// 	parsing second argument to (contains)
+	// 	parsing second argument to function (contains)
 	// 		expected type string, got value (false) with type (bool)
 }

--- a/lib/utils/typical/parser.go
+++ b/lib/utils/typical/parser.go
@@ -91,7 +91,8 @@ type ParserSpec[TEnv any] struct {
 type Variable any
 
 // Function holds the definition of a function. It is expected to be the result
-// of calling one of (Unary|Binary|Ternary)(Variadic)?Function.
+// of calling one of the function constructors in this package, such as
+// [UnaryFunction] or [BinaryVariadicFunctionWithEnv].
 type Function interface {
 	buildExpression(name string, args ...any) (any, error)
 }
@@ -434,6 +435,36 @@ func (d dynamicVariable[TEnv, TVar]) Evaluate(env TEnv) (TVar, error) {
 	return result, trace.Wrap(err)
 }
 
+type nullaryFunction[TEnv, TResult any] struct {
+	impl func() (TResult, error)
+}
+
+// NullaryFunction returns a definition for a function that is called without
+// arguments.
+func NullaryFunction[TEnv, TResult any](impl func() (TResult, error)) Function {
+	return nullaryFunction[TEnv, TResult]{impl}
+}
+
+func (f nullaryFunction[TEnv, TResult]) buildExpression(name string, args ...any) (any, error) {
+	if len(args) != 0 {
+		return nil, trace.BadParameter("function (%s) accepts 0 arguments, given %d", name, len(args))
+	}
+	return nullaryFuncExpr[TEnv, TResult]{
+		name: name,
+		impl: f.impl,
+	}, nil
+}
+
+type nullaryFuncExpr[TEnv, TResult any] struct {
+	name string
+	impl func() (TResult, error)
+}
+
+func (e nullaryFuncExpr[TEnv, TResult]) Evaluate(_ TEnv) (TResult, error) {
+	res, err := e.impl()
+	return res, trace.Wrap(err, "evaluating function (%s)", e.name)
+}
+
 type unaryFunction[TEnv, TArg, TResult any] struct {
 	impl func(TArg) (TResult, error)
 }
@@ -450,7 +481,7 @@ func (f unaryFunction[TEnv, TArg, TResult]) buildExpression(name string, args ..
 	}
 	argExpr, err := coerce[TEnv, TArg](args[0])
 	if err != nil {
-		return nil, trace.Wrap(err, "parsing argument to (%s)", name)
+		return nil, trace.Wrap(err, "parsing argument to function (%s)", name)
 	}
 	return unaryFuncExpr[TEnv, TArg, TResult]{
 		name:    name,
@@ -493,7 +524,7 @@ func (f unaryFunctionWithEnv[TEnv, TArg, TResult]) buildExpression(name string, 
 	}
 	argExpr, err := coerce[TEnv, TArg](args[0])
 	if err != nil {
-		return nil, trace.Wrap(err, "parsing argument to (%s)", name)
+		return nil, trace.Wrap(err, "parsing argument to function (%s)", name)
 	}
 	return unaryFuncWithEnvExpr[TEnv, TArg, TResult]{
 		name:    name,
@@ -534,11 +565,11 @@ func (f binaryFunction[TEnv, TArg1, TArg2, TResult]) buildExpression(name string
 	}
 	arg1Expr, err := coerce[TEnv, TArg1](args[0])
 	if err != nil {
-		return nil, trace.Wrap(err, "parsing first argument to (%s)", name)
+		return nil, trace.Wrap(err, "parsing first argument to function (%s)", name)
 	}
 	arg2Expr, err := coerce[TEnv, TArg2](args[1])
 	if err != nil {
-		return nil, trace.Wrap(err, "parsing second argument to (%s)", name)
+		return nil, trace.Wrap(err, "parsing second argument to function (%s)", name)
 	}
 	return binaryFuncExpr[TEnv, TArg1, TArg2, TResult]{
 		name:     name,
@@ -588,15 +619,15 @@ func (f ternaryFunction[TEnv, TArg1, TArg2, TArg3, TResult]) buildExpression(nam
 	}
 	arg1Expr, err := coerce[TEnv, TArg1](args[0])
 	if err != nil {
-		return nil, trace.Wrap(err, "parsing first argument to (%s)", name)
+		return nil, trace.Wrap(err, "parsing first argument to function (%s)", name)
 	}
 	arg2Expr, err := coerce[TEnv, TArg2](args[1])
 	if err != nil {
-		return nil, trace.Wrap(err, "parsing second argument to (%s)", name)
+		return nil, trace.Wrap(err, "parsing second argument to function (%s)", name)
 	}
 	arg3Expr, err := coerce[TEnv, TArg3](args[2])
 	if err != nil {
-		return nil, trace.Wrap(err, "parsing third argument to (%s)", name)
+		return nil, trace.Wrap(err, "parsing third argument to function (%s)", name)
 	}
 	return ternaryFuncExpr[TEnv, TArg1, TArg2, TArg3, TResult]{
 		name:     name,
@@ -630,6 +661,72 @@ func (e ternaryFuncExpr[TEnv, TArg1, TArg2, TArg3, TResult]) Evaluate(env TEnv) 
 		return nul, trace.Wrap(err, "evaluating third argument to function (%s)", e.name)
 	}
 	res, err := e.impl(arg1, arg2, arg3)
+	if err != nil {
+		return nul, trace.Wrap(err, "evaluating function (%s)", e.name)
+	}
+	return res, nil
+}
+
+type ternaryFunctionWithEnv[TEnv, TArg1, TArg2, TArg3, TResult any] struct {
+	impl func(TEnv, TArg1, TArg2, TArg3) (TResult, error)
+}
+
+// TernaryFunctionWithEnv returns a definition for a function that can be called
+// with three arguments. The arguments may be literals or subexpressions. The
+// [impl] will be called with the evaluation env as the first argument, followed
+// by the actual arguments passed in the expression.
+func TernaryFunctionWithEnv[TEnv, TArg1, TArg2, TArg3, TResult any](impl func(TEnv, TArg1, TArg2, TArg3) (TResult, error)) Function {
+	return ternaryFunctionWithEnv[TEnv, TArg1, TArg2, TArg3, TResult]{impl}
+}
+
+func (f ternaryFunctionWithEnv[TEnv, TArg1, TArg2, TArg3, TResult]) buildExpression(name string, args ...any) (any, error) {
+	if len(args) != 3 {
+		return nil, trace.BadParameter("function (%s) accepts 3 arguments, given %d", name, len(args))
+	}
+	arg1Expr, err := coerce[TEnv, TArg1](args[0])
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing first argument to function (%s)", name)
+	}
+	arg2Expr, err := coerce[TEnv, TArg2](args[1])
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing second argument to function (%s)", name)
+	}
+	arg3Expr, err := coerce[TEnv, TArg3](args[2])
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing third argument to function (%s)", name)
+	}
+	return ternaryFuncWithEnvExpr[TEnv, TArg1, TArg2, TArg3, TResult]{
+		name:     name,
+		impl:     f.impl,
+		arg1Expr: arg1Expr,
+		arg2Expr: arg2Expr,
+		arg3Expr: arg3Expr,
+	}, nil
+}
+
+type ternaryFuncWithEnvExpr[TEnv, TArg1, TArg2, TArg3, TResult any] struct {
+	name     string
+	impl     func(TEnv, TArg1, TArg2, TArg3) (TResult, error)
+	arg1Expr Expression[TEnv, TArg1]
+	arg2Expr Expression[TEnv, TArg2]
+	arg3Expr Expression[TEnv, TArg3]
+}
+
+func (e ternaryFuncWithEnvExpr[TEnv, TArg1, TArg2, TArg3, TResult]) Evaluate(env TEnv) (TResult, error) {
+	var nul TResult
+	arg1, err := e.arg1Expr.Evaluate(env)
+	if err != nil {
+		return nul, trace.Wrap(err, "evaluating first argument to function (%s)", e.name)
+	}
+	arg2, err := e.arg2Expr.Evaluate(env)
+	if err != nil {
+		return nul, trace.Wrap(err, "evaluating second argument to function (%s)", e.name)
+	}
+	arg3, err := e.arg3Expr.Evaluate(env)
+	if err != nil {
+		return nul, trace.Wrap(err, "evaluating third argument to function (%s)", e.name)
+	}
+	res, err := e.impl(env, arg1, arg2, arg3)
 	if err != nil {
 		return nul, trace.Wrap(err, "evaluating function (%s)", e.name)
 	}
@@ -749,7 +846,7 @@ func BinaryVariadicFunction[TEnv, TArg1, TVarArgs, TResult any](impl func(TArg1,
 
 func (f binaryVariadicFunction[TEnv, TArg1, TVarArgs, TResult]) buildExpression(name string, args ...any) (any, error) {
 	if len(args) == 0 {
-		return nil, trace.BadParameter("function (%s) accepts 1 or more argument, given %d", name, len(args))
+		return nil, trace.BadParameter("function (%s) accepts 1 or more arguments, given %d", name, len(args))
 	}
 	arg1Expr, err := coerce[TEnv, TArg1](args[0])
 	if err != nil {
@@ -794,6 +891,71 @@ func (e binaryVariadicFuncExpr[TEnv, TArg1, TVarArgs, TResult]) Evaluate(env TEn
 		varArgs[i] = arg
 	}
 	res, err := e.impl(arg1, varArgs...)
+	if err != nil {
+		return nul, trace.Wrap(err, "evaluating function (%s)", e.name)
+	}
+	return res, nil
+}
+
+type binaryVariadicFunctionWithEnv[TEnv, TArg1, TVarArgs, TResult any] struct {
+	impl func(TEnv, TArg1, ...TVarArgs) (TResult, error)
+}
+
+// BinaryVariadicFunctionWithEnv returns a definition for a function that can
+// be called with one or more arguments. The arguments may be literals or
+// subexpressions. The [impl] will be called with the evaluation env as the
+// first argument, followed by the actual arguments passed in the expression.
+func BinaryVariadicFunctionWithEnv[TEnv, TArg1, TVarArgs, TResult any](impl func(TEnv, TArg1, ...TVarArgs) (TResult, error)) Function {
+	return binaryVariadicFunctionWithEnv[TEnv, TArg1, TVarArgs, TResult]{impl}
+}
+
+func (f binaryVariadicFunctionWithEnv[TEnv, TArg1, TVarArgs, TResult]) buildExpression(name string, args ...any) (any, error) {
+	if len(args) == 0 {
+		return nil, trace.BadParameter("function (%s) accepts 1 or more arguments, given %d", name, len(args))
+	}
+	arg1Expr, err := coerce[TEnv, TArg1](args[0])
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing first argument to function (%s)", name)
+	}
+	args = args[1:]
+	varArgExprs := make([]Expression[TEnv, TVarArgs], len(args))
+	for i, arg := range args {
+		argExpr, err := coerce[TEnv, TVarArgs](arg)
+		if err != nil {
+			return nil, trace.Wrap(err, "parsing argument %d to function (%s)", i+2, name)
+		}
+		varArgExprs[i] = argExpr
+	}
+	return binaryVariadicFuncWithEnvExpr[TEnv, TArg1, TVarArgs, TResult]{
+		name:        name,
+		impl:        f.impl,
+		arg1Expr:    arg1Expr,
+		varArgExprs: varArgExprs,
+	}, nil
+}
+
+type binaryVariadicFuncWithEnvExpr[TEnv, TArg1, TVarArgs, TResult any] struct {
+	name        string
+	impl        func(TEnv, TArg1, ...TVarArgs) (TResult, error)
+	arg1Expr    Expression[TEnv, TArg1]
+	varArgExprs []Expression[TEnv, TVarArgs]
+}
+
+func (e binaryVariadicFuncWithEnvExpr[TEnv, TArg1, TVarArgs, TResult]) Evaluate(env TEnv) (TResult, error) {
+	var nul TResult
+	arg1, err := e.arg1Expr.Evaluate(env)
+	if err != nil {
+		return nul, trace.Wrap(err, "evaluating first argument to function (%s)", e.name)
+	}
+	varArgs := make([]TVarArgs, len(e.varArgExprs))
+	for i, argExpr := range e.varArgExprs {
+		arg, err := argExpr.Evaluate(env)
+		if err != nil {
+			return nul, trace.Wrap(err, "evaluating argument %d to function (%s)", i+2, e.name)
+		}
+		varArgs[i] = arg
+	}
+	res, err := e.impl(env, arg1, varArgs...)
 	if err != nil {
 		return nul, trace.Wrap(err, "evaluating function (%s)", e.name)
 	}

--- a/lib/utils/typical/parser_test.go
+++ b/lib/utils/typical/parser_test.go
@@ -104,6 +104,30 @@ func TestParser(t *testing.T) {
 				}
 				return matchingLabels, nil
 			}),
+			"cluster": typical.NullaryFunction[env](func() (string, error) {
+				return "default-cluster", nil
+			}),
+			"nullary_error": typical.NullaryFunction[env](func() (string, error) {
+				return "", errors.New("nullary error")
+			}),
+			"path": typical.TernaryFunctionWithEnv(func(e env, a, b, c string) (string, error) {
+				return e.labels["env"] + "/" + a + "/" + b + "/" + c, nil
+			}),
+			"ternary_error": typical.TernaryFunctionWithEnv(func(e env, a, b, c string) (string, error) {
+				return "", errors.New("ternary error")
+			}),
+			"all_have_label_prefix": typical.BinaryVariadicFunctionWithEnv(func(e env, key string, vals ...string) (bool, error) {
+				prefix := e.labels[key]
+				for _, v := range vals {
+					if !strings.HasPrefix(v, prefix) {
+						return false, nil
+					}
+				}
+				return true, nil
+			}),
+			"variadic_error": typical.BinaryVariadicFunctionWithEnv(func(e env, key string, vals ...string) (bool, error) {
+				return false, errors.New("variadic error")
+			}),
 		},
 		Methods: map[string]typical.Function{
 			"add_trait_values": typical.TernaryVariadicFunction[env](func(m map[string][]string, key string, values ...string) (map[string][]string, error) {
@@ -168,7 +192,7 @@ func TestParser(t *testing.T) {
 			desc: "unary function wrong type",
 			expr: `not("true")`,
 			expectParseError: []string{
-				"parsing argument to (not)",
+				"parsing argument to function (not)",
 				"expected type bool, got value (true) with type (string)",
 			},
 		},
@@ -271,7 +295,7 @@ func TestParser(t *testing.T) {
 			desc: "argument is expression returning wrong type",
 			expr: `contains(traits, "root")`,
 			expectParseError: []string{
-				"parsing first argument to (contains)",
+				"parsing first argument to function (contains)",
 				"expected type []string, got expression returning type (map[string][]string)",
 			},
 		},
@@ -356,7 +380,7 @@ func TestParser(t *testing.T) {
 			desc: "unary func with env wrong type",
 			expr: `contains_all(labels_matching(traits["username"]), "staging", "dev")`,
 			expectParseError: []string{
-				"parsing argument to (labels_matching)",
+				"parsing argument to function (labels_matching)",
 				"expected type string, got expression returning type ([]string)",
 			},
 		},
@@ -464,6 +488,116 @@ func TestParser(t *testing.T) {
 			expr: `traits != traits`,
 			expectParseError: []string{
 				"operator (!=) not supported for type: map[string][]string",
+			},
+		},
+		{
+			desc:        "nullary function",
+			expr:        `cluster() == "default-cluster"`,
+			expectMatch: true,
+		},
+		{
+			desc: "nullary function with argument",
+			expr: `cluster("x") == "default-cluster"`,
+			expectParseError: []string{
+				"function (cluster) accepts 0 arguments, given 1",
+			},
+		},
+		{
+			desc: "nullary function evaluation error",
+			expr: `nullary_error() == "x"`,
+			expectEvaluationError: []string{
+				"evaluating function (nullary_error)",
+				"nullary error",
+			},
+		},
+		{
+			desc:        "ternary function with env",
+			expr:        `path("a", "b", "c") == "staging/a/b/c"`,
+			expectMatch: true,
+		},
+		{
+			desc: "ternary function wrong argument count",
+			expr: `path("a", "b") == "x"`,
+			expectParseError: []string{
+				"function (path) accepts 3 arguments, given 2",
+			},
+		},
+		{
+			desc: "ternary function wrong argument type",
+			expr: `path("a", "b", true) == "x"`,
+			expectParseError: []string{
+				"parsing third argument to function (path)",
+				"expected type string, got value (true) with type (bool)",
+			},
+		},
+		{
+			desc: "ternary function argument evaluation error",
+			expr: `path(nullary_error(), "b", "c") == "x"`,
+			expectEvaluationError: []string{
+				"evaluating first argument to function (path)",
+				"nullary error",
+			},
+		},
+		{
+			desc: "ternary function implementation error",
+			expr: `ternary_error("a", "b", "c") == "x"`,
+			expectEvaluationError: []string{
+				"evaluating function (ternary_error)",
+				"ternary error",
+			},
+		},
+		{
+			desc:        "binary variadic function with env all match",
+			expr:        `all_have_label_prefix("team", "dev", "developer")`,
+			expectMatch: true,
+		},
+		{
+			desc:        "binary variadic function with env one mismatch",
+			expr:        `all_have_label_prefix("team", "dev", "ops")`,
+			expectMatch: false,
+		},
+		{
+			desc:        "binary variadic function with only the fixed argument",
+			expr:        `all_have_label_prefix("team")`,
+			expectMatch: true,
+		},
+		{
+			desc: "binary variadic function no arguments",
+			expr: `all_have_label_prefix()`,
+			expectParseError: []string{
+				"function (all_have_label_prefix) accepts 1 or more arguments, given 0",
+			},
+		},
+		{
+			desc: "binary variadic function wrong first argument type",
+			expr: `all_have_label_prefix(true, "x")`,
+			expectParseError: []string{
+				"parsing first argument to function (all_have_label_prefix)",
+				"expected type string, got value (true) with type (bool)",
+			},
+		},
+		{
+			desc: "binary variadic function wrong variadic argument type",
+			expr: `all_have_label_prefix("team", true)`,
+			expectParseError: []string{
+				"parsing argument 2 to function (all_have_label_prefix)",
+				"expected type string, got value (true) with type (bool)",
+			},
+		},
+		{
+			desc: "binary variadic function variadic evaluation error",
+			expr: `all_have_label_prefix("team", nullary_error())`,
+			expectEvaluationError: []string{
+				"evaluating argument 2 to function (all_have_label_prefix)",
+				"nullary error",
+			},
+		},
+		{
+			desc: "binary variadic function implementation error",
+			expr: `variadic_error("team", "v")`,
+			expectEvaluationError: []string{
+				"evaluating function (variadic_error)",
+				"variadic error",
 			},
 		},
 	} {


### PR DESCRIPTION
Add three parser-combinator definitions to the `typical` expression language:

- `NullaryFunction` defines functions that take no arguments
  (zero-argument counterpart of the existing `UnaryFunction`).
- `TernaryFunctionWithEnv` defines three-argument functions that receive the evaluation env
  (env variant of the existing `TernaryFunction`).
- `BinaryVariadicFunctionWithEnv` defines variadic functions with one fixed argument that also receive the env
  (env variant of the existing `BinaryVariadicFunction`).

The fine-grained app access predicate language ([RFD 0303](https://github.com/gravitational/rfd/blob/master/rfd/0303-policy-based-app-access.md)) needs these forms. For wider context see the more complete work on the sketch branch [`julia/app/policy-matcher-sketch`](https://github.com/gravitational/teleport/tree/julia/app/policy-matcher-sketch).

Concrete callers on the sketch branch, all in [`predicate.go`](https://github.com/gravitational/teleport/blob/julia/app/policy-matcher-sketch/lib/srv/app/resourcematcher/predicate.go):

- `NullaryFunction` → `greedy()`, `slash()` (grammar constants, no args).
- `TernaryFunctionWithEnv` → `allow_code(...)`, `deny_hint(...)` (mutate env to record the allow decision or deny hint, return the wrapped bool).
- `BinaryVariadicFunctionWithEnv` → `path.match(root, opts...)` (reads path tokens from env, writes captured vars back).

The parser-combinator definitions have no callers on this branch, so there is nothing to exercise on a live cluster or in manual tests.

Related-RFD: https://github.com/gravitational/rfd/blob/master/rfd/0303-policy-based-app-access.md
