### PR TITLE
Fix VNet freezing up by closing system agent in client cache

### DIFF
--- a/lib/client/clientcache/clientcache.go
+++ b/lib/client/clientcache/clientcache.go
@@ -44,10 +44,34 @@ type Cache struct {
 
 type clientWithMetadata struct {
 	client *client.ClusterClient
+	// tc is the TeleportClient the cached client was built from. The cache owns
+	// it and must close it on eviction to release the connection it holds to the
+	// system SSH agent.
+	tc *client.TeleportClient
 	// tlsCert is the certificate that was loaded when the client was created.
 	tlsCert []byte
 	// getProfile reads the fresh profile for the client from disk.
 	getProfile func() (profile, error)
+}
+
+// close releases the cached client and the TeleportClient it was built from.
+func (c *clientWithMetadata) close() error {
+	return trace.NewAggregate(c.client.Close(), closeClientAgent(c.tc))
+}
+
+// closeClientAgent closes the connection tc holds to the system SSH agent, if
+// any. It is separate from [client.ClusterClient.Close] because a ClusterClient
+// does not own its TeleportClient's agent – only the code that built the
+// TeleportClient may close it.
+func closeClientAgent(tc *client.TeleportClient) error {
+	if tc == nil {
+		return nil
+	}
+	localAgent := tc.LocalAgent()
+	if localAgent == nil {
+		return nil
+	}
+	return trace.Wrap(localAgent.Close())
 }
 
 type profile interface {
@@ -153,17 +177,22 @@ func (c *Cache) Get(ctx context.Context, profileName, leafClusterName string) (*
 			newClient = clt
 			return nil
 		}); err != nil {
-			return nil, trace.Wrap(err)
+			// tc never made it into the cache, so nothing else will close its
+			// connection to the system SSH agent. This path is hit on every poll
+			// while certs are expired, so failing to close here leaks a
+			// connection each time until the agent stops responding.
+			return nil, trace.NewAggregate(err, closeClientAgent(tc))
 		}
 
 		keyRing, err := tc.LocalAgent().GetCoreKeyRing()
 		if err != nil {
-			return nil, trace.Wrap(err)
+			return nil, trace.NewAggregate(err, newClient.Close(), closeClientAgent(tc))
 		}
 
 		// Save the client in the cache, so we don't have to build a new connection next time.
 		c.addToCache(k, &clientWithMetadata{
 			client:  newClient,
+			tc:      tc,
 			tlsCert: keyRing.TLSCert,
 			getProfile: func() (profile, error) {
 				return tc.GetProfile(tc.WebProxyAddr)
@@ -208,7 +237,7 @@ func (c *Cache) ClearStaleClientsForRoot(profileName string) error {
 		} else if !stale {
 			continue
 		}
-		if err = clt.client.Close(); err != nil {
+		if err = clt.close(); err != nil {
 			errors = append(errors, err)
 		}
 		deleted = append(deleted, k.String())
@@ -230,7 +259,7 @@ func (c *Cache) Clear() error {
 
 	var errors []error
 	for _, clt := range c.clients {
-		if err := clt.client.Close(); err != nil {
+		if err := clt.close(); err != nil {
 			errors = append(errors, err)
 		}
 	}

--- a/lib/client/clientcache/clientcache_test.go
+++ b/lib/client/clientcache/clientcache_test.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -288,6 +289,67 @@ func TestGetClosesSystemAgentConnection(t *testing.T) {
 			assert.Zero(t, conns.open.Load())
 		}, 5*time.Second, 10*time.Millisecond,
 			"Clear must close the system agent connections of cached clients")
+	})
+
+	t.Run("evicting a client while it is in use is race-free", func(t *testing.T) {
+		startFakeSystemAgent(t)
+
+		// Capture the TeleportClient the cache builds so the test can drive the
+		// same LocalKeyAgent the cached client shares while the cache closes it.
+		var built atomic.Pointer[client.TeleportClient]
+		capturingNewClientFunc := func(ctx context.Context, profileName, leafClusterName string) (*client.TeleportClient, error) {
+			tc, err := newClientFunc(ctx, profileName, leafClusterName)
+			if err == nil {
+				built.Store(tc)
+			}
+			return tc, err
+		}
+
+		cache, err := New(Config{
+			NewClientFunc: capturingNewClientFunc,
+			RetryWithReloginFunc: func(ctx context.Context, tc *client.TeleportClient, fn func() error, opts ...client.RetryWithReloginOption) error {
+				return fn()
+			},
+			Logger: slog.New(slog.DiscardHandler),
+		})
+		require.NoError(t, err)
+
+		_, err = cache.Get(t.Context(), "root", "")
+		require.NoError(t, err)
+		tc := built.Load()
+		require.NotNil(t, tc)
+
+		// UnloadKeys reads the system agent connection that Clear closes, and
+		// both act on the same LocalKeyAgent because the cache shares one client
+		// with its callers. Have several goroutines read it continuously across
+		// the eviction: each signals once it is already looping, so the read and
+		// Clear's close of systemAgent are provably concurrent and -race reports
+		// any unsynchronized access on the shared agent.
+		const readers = 8
+		var ready, done sync.WaitGroup
+		ready.Add(readers)
+		done.Add(readers)
+		stop := make(chan struct{})
+		for range readers {
+			go func() {
+				defer done.Done()
+				_ = tc.LocalAgent().UnloadKeys()
+				ready.Done()
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+						_ = tc.LocalAgent().UnloadKeys()
+					}
+				}
+			}()
+		}
+
+		ready.Wait()
+		require.NoError(t, cache.Clear())
+		close(stop)
+		done.Wait()
 	})
 }
 

--- a/lib/client/clientcache/clientcache_test.go
+++ b/lib/client/clientcache/clientcache_test.go
@@ -20,13 +20,21 @@ import (
 	"context"
 	"crypto/x509/pkix"
 	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
 
+	"github.com/gravitational/teleport"
 	apiprofile "github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
@@ -185,4 +193,146 @@ func makeCerts(privateKey *keys.PrivateKey) ([]byte, []byte, error) {
 	})
 
 	return tlsCert, sshCert, trace.Wrap(err)
+}
+
+// TestGetClosesSystemAgentConnection verifies that the cache closes the
+// connection each built client opens to the system SSH agent, both when the
+// build fails and when a cached client is evicted. Leaking these connections
+// (as happened while VNet rebuilt clients on a loop with expired certs)
+// eventually exhausts the system agent and wedges every caller on an
+// unresponsive agent.List.
+func TestGetClosesSystemAgentConnection(t *testing.T) {
+	privateKey, err := keys.ParsePrivateKey(fixtures.PEMBytes["rsa"])
+	require.NoError(t, err)
+	tlsCert, sshCert, err := makeCerts(privateKey)
+	require.NoError(t, err)
+
+	keyRing := client.NewKeyRing(privateKey, privateKey)
+	keyRing.KeyRingIndex = client.KeyRingIndex{
+		ProxyHost:   "localhost",
+		Username:    "testuser",
+		ClusterName: "root",
+	}
+	keyRing.Cert = sshCert
+	keyRing.TLSCert = tlsCert
+
+	profile := &apiprofile.Profile{
+		WebProxyAddr: keyRing.ProxyHost,
+		Username:     keyRing.Username,
+		SiteName:     keyRing.ClusterName,
+	}
+	clientStore := client.NewFSClientStore(t.TempDir())
+	require.NoError(t, clientStore.SaveProfile(profile, true))
+	require.NoError(t, clientStore.AddKeyRing(keyRing))
+
+	// AddKeysToAgentYes makes each built client open a connection to the system
+	// agent advertised by SSH_AUTH_SOCK.
+	newClientFunc := func(ctx context.Context, profileName, leafClusterName string) (*client.TeleportClient, error) {
+		config := &client.Config{
+			ClientStore:    clientStore,
+			SSHProxyAddr:   "localhost:3080",
+			WebProxyAddr:   "localhost:3080",
+			Username:       "testuser",
+			Tracer:         tracing.NoopProvider().Tracer("test"),
+			SiteName:       "root",
+			AddKeysToAgent: client.AddKeysToAgentYes,
+		}
+		if leafClusterName != "" {
+			config.SiteName = leafClusterName
+		}
+		return client.NewClient(config)
+	}
+
+	t.Run("connection is closed when building the client fails", func(t *testing.T) {
+		conns := startFakeSystemAgent(t)
+		cache, err := New(Config{
+			NewClientFunc: newClientFunc,
+			// Fail the build after the TeleportClient (and its system agent
+			// connection) has been created, as happens with expired certs.
+			RetryWithReloginFunc: func(ctx context.Context, tc *client.TeleportClient, fn func() error, opts ...client.RetryWithReloginOption) error {
+				return trace.AccessDenied("cluster unreachable")
+			},
+			Logger: slog.New(slog.DiscardHandler),
+		})
+		require.NoError(t, err)
+
+		_, err = cache.Get(t.Context(), "root", "")
+		require.Error(t, err)
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			// The failed build opened a connection to the system agent, and the
+			// cache must have closed it again.
+			assert.Positive(t, conns.opened.Load(), "the failed build should have opened a system agent connection")
+			assert.Zero(t, conns.open.Load(), "the system agent connection of a client the cache fails to build must be closed")
+		}, 5*time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("connection is closed when the cache is cleared", func(t *testing.T) {
+		conns := startFakeSystemAgent(t)
+		cache, err := New(Config{
+			NewClientFunc: newClientFunc,
+			RetryWithReloginFunc: func(ctx context.Context, tc *client.TeleportClient, fn func() error, opts ...client.RetryWithReloginOption) error {
+				return fn()
+			},
+			Logger: slog.New(slog.DiscardHandler),
+		})
+		require.NoError(t, err)
+
+		_, err = cache.Get(t.Context(), "root", "")
+		require.NoError(t, err)
+		require.Positive(t, conns.open.Load(), "building the client should have opened a system agent connection")
+
+		require.NoError(t, cache.Clear())
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			assert.Zero(t, conns.open.Load())
+		}, 5*time.Second, 10*time.Millisecond,
+			"Clear must close the system agent connections of cached clients")
+	})
+}
+
+// systemAgentConns counts connections made to a fake system SSH agent: open is
+// the number currently established, opened the number ever established.
+type systemAgentConns struct {
+	open   atomic.Int64
+	opened atomic.Int64
+}
+
+// startFakeSystemAgent starts an SSH agent on a unix socket, points
+// SSH_AUTH_SOCK at it, and returns counters over the client connections it
+// receives so a test can assert those connections get closed.
+func startFakeSystemAgent(t *testing.T) *systemAgentConns {
+	t.Helper()
+
+	// Use a short temp dir rather than t.TempDir: the latter embeds the (long)
+	// test name in the path, and unix socket paths are capped at 104 chars on
+	// macOS.
+	socketDir, err := os.MkdirTemp("", "teleport-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(socketDir) })
+
+	socketPath := filepath.Join(socketDir, "agent.sock")
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { listener.Close() })
+	t.Setenv(teleport.SSHAuthSock, socketPath)
+
+	conns := &systemAgentConns{}
+	keyring := agent.NewKeyring()
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			conns.open.Add(1)
+			conns.opened.Add(1)
+			go func() {
+				defer conns.open.Add(-1)
+				// ServeAgent returns once the client closes the connection.
+				_ = agent.ServeAgent(keyring, conn)
+			}()
+		}
+	}()
+	return conns
 }

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -29,6 +29,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
@@ -55,6 +56,11 @@ type LocalKeyAgent struct {
 	// clientStore is the local storage backend for the client.
 	clientStore *Store
 
+	// systemAgentMu guards systemAgent. Close closes and clears systemAgent
+	// while other goroutines that share this agent – e.g. through a client
+	// handed out by clientcache – may still read it, so all access must be
+	// synchronized.
+	systemAgentMu sync.Mutex
 	// systemAgent is the system ssh agent
 	systemAgent sshagent.Client
 
@@ -174,12 +180,24 @@ the --add-keys-to-agent=yes flag.`)
 // processes that build many agents (such as tshd) must call Close when an agent
 // is no longer needed to avoid exhausting the system agent with connections.
 func (a *LocalKeyAgent) Close() error {
+	a.systemAgentMu.Lock()
+	defer a.systemAgentMu.Unlock()
 	if a.systemAgent == nil {
 		return nil
 	}
 	err := a.systemAgent.Close()
 	a.systemAgent = nil
 	return trace.Wrap(err)
+}
+
+// getSystemAgent returns the connection to the system SSH agent, or nil if
+// there is none (never configured, or already released by [LocalKeyAgent.Close]).
+// Callers read the connection under the lock and then use the returned value, so
+// they never touch the systemAgent field concurrently with Close.
+func (a *LocalKeyAgent) getSystemAgent() sshagent.Client {
+	a.systemAgentMu.Lock()
+	defer a.systemAgentMu.Unlock()
+	return a.systemAgent
 }
 
 // UpdateProxyHost changes the proxy host that the local agent operates on.
@@ -232,9 +250,9 @@ func (a *LocalKeyAgent) LoadKeyRing(keyRing KeyRing) error {
 
 	a.log.InfoContext(context.Background(), "Loading SSH key", "user", a.username, "cluster", keyRing.ClusterName)
 	agents := []agent.ExtendedAgent{a.ExtendedAgent}
-	if a.systemAgent != nil {
+	if systemAgent := a.getSystemAgent(); systemAgent != nil {
 		if canAddToSystemAgent(agentKey) {
-			agents = append(agents, a.systemAgent)
+			agents = append(agents, systemAgent)
 		} else {
 			a.log.InfoContext(context.Background(), "Skipping adding key to SSH system agent for non-standard key type",
 				"key_type", logutils.TypeAttr(agentKey.PrivateKey),
@@ -277,8 +295,8 @@ func (a *LocalKeyAgent) LoadKeyRing(keyRing KeyRing) error {
 // teleport ssh agent and the system agent.
 func (a *LocalKeyAgent) UnloadKeyRing(keyRing KeyRingIndex) error {
 	agents := []agent.Agent{a.ExtendedAgent}
-	if a.systemAgent != nil {
-		agents = append(agents, a.systemAgent)
+	if systemAgent := a.getSystemAgent(); systemAgent != nil {
+		agents = append(agents, systemAgent)
 	}
 
 	// iterate over all agents we have and unload keys matching the given key
@@ -306,8 +324,8 @@ func (a *LocalKeyAgent) UnloadKeyRing(keyRing KeyRingIndex) error {
 // the system agent.
 func (a *LocalKeyAgent) UnloadKeys() error {
 	agents := []agent.ExtendedAgent{a.ExtendedAgent}
-	if a.systemAgent != nil {
-		agents = append(agents, a.systemAgent)
+	if systemAgent := a.getSystemAgent(); systemAgent != nil {
+		agents = append(agents, systemAgent)
 	}
 
 	// iterate over all agents we have and unload keys
@@ -688,8 +706,8 @@ func (a *LocalKeyAgent) Signers() ([]ssh.Signer, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if a.systemAgent != nil {
-		sshAgentSigners, err := a.systemAgent.Signers()
+	if systemAgent := a.getSystemAgent(); systemAgent != nil {
+		sshAgentSigners, err := systemAgent.Signers()
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -56,7 +56,7 @@ type LocalKeyAgent struct {
 	clientStore *Store
 
 	// systemAgent is the system ssh agent
-	systemAgent agent.ExtendedAgent
+	systemAgent sshagent.Client
 
 	// noHosts is a in-memory map used in tests to track which hosts a user has
 	// manually (via keyboard input) refused connecting to.
@@ -166,6 +166,20 @@ the --add-keys-to-agent=yes flag.`)
 		}
 	}
 	return a, nil
+}
+
+// Close releases resources held by the local agent. In particular it closes the
+// connection to the system SSH agent, which is opened in [NewLocalAgent] and
+// would otherwise stay open for the lifetime of the process. Long-running
+// processes that build many agents (such as tshd) must call Close when an agent
+// is no longer needed to avoid exhausting the system agent with connections.
+func (a *LocalKeyAgent) Close() error {
+	if a.systemAgent == nil {
+		return nil
+	}
+	err := a.systemAgent.Close()
+	a.systemAgent = nil
+	return trace.Wrap(err)
 }
 
 // UpdateProxyHost changes the proxy host that the local agent operates on.


### PR DESCRIPTION
I managed to verify that the fix works and the code looks fine. I didn't have time to address the two todo items below.

## TODO

- [ ] Investigate `lib/teleterm/clusters.Storage.fromProfile` paths which Claude flagged as exhibiting a similar problem ([creating a `TeleportClient`](https://github.com/gravitational/teleport/blob/200175c92322d1ddec4d3e8a99ffe892f2d599b7/lib/teleterm/clusters/storage.go#L234) and newer cleaning up that system agent connection).
- [ ] Do we need `TeleportClient.Close` or is it too much of a mess to add it? (It's probably too much of a mess to add it tbh)

## Claude's bug report

<details><summary>Details</summary>

# Teleport Connect (tshd) freezes: leaked system SSH-agent connections wedge VNet behind an un-cancellable `agent.List()`

## Summary

While VNet is running, Teleport Connect's VNet features (diagnostics, service info,
recent connections) stop responding and never recover. The tshd process must be
killed.

The root cause is a **connection leak against the system SSH agent**: every
Teleport client build opens a new connection to `SSH_AUTH_SOCK` that is never
closed. VNet rebuilds clients in a tight loop, so connections accumulate into
the hundreds. Once the system agent stops servicing new connections, the
un-cancellable `agent.List()` call made during key loading blocks forever, and
that stuck call cascades through singleflight and a VNet service mutex until every
VNet RPC is wedged.

This is not a general `LoadKeyRing`/`UnloadKeyRing` bug — it only manifests in a
long-running process (tshd) that builds clients repeatedly (VNet), which is why
short-lived `tsh` CLI invocations never hit it.

## Impact

- Teleport Connect's VNet panel/diagnostics hang indefinitely; the daemon must be
  force-killed.
- Reproduced on **two separate machines with two different agents** (1Password SSH
  agent and the standard macOS `ssh-agent`), confirming the trigger is
  Teleport/VNet, not a specific agent implementation.
- Aggravated by expired certificates (see "Aggravating factor" below).

## Environment

- Component: `tshd` (Teleport Connect daemon), VNet running.
- Observed: 2026-07-08, from `tshd.log`.
- Platforms: macOS (arm64). Agents: 1Password SSH agent; macOS `ssh-agent`.

## Root cause

### 1. Every client build leaks a system-agent connection

`NewLocalAgent` opens a fresh connection to the system agent and stores it, but
nothing ever closes it:

- `lib/client/keyagent.go:153` — `sshagent.NewSystemAgentClient()` dials
  `SSH_AUTH_SOCK` (`lib/sshagent/clientconn_unix.go:32`) and the connection is
  stored in `a.systemAgent`.
- `LocalKeyAgent` has **no `Close` method**, and nothing in `clientcache`,
  `lib/teleterm`, or `TeleportClient.Close` closes `systemAgent`. A
  `sshagent.(*client).Close` exists (`lib/sshagent/client.go:84`) but is never
  called for the system agent.

So each `TeleportClient` built via `daemon.(*Service).NewClusterClient` leaks one
open agent connection for the lifetime of the process.

### 2. VNet drives client builds in a loop, so the leak grows fast

- `sshConfigurator.runConfigurationLoop` rebuilds clients every 30s
  (`lib/vnet/opensshconfig.go:50`, `:181`, `:199`).
- `vnet.(*Service).RunDiagnostics` and `GetServiceInfo` also build clients on
  demand.
- Each build calls `LoadKeyRingForCluster` → `LoadKeyRing` → `UnloadKeyRing`,
  which calls `agent.List()` on the freshly-opened system-agent connection
  (`lib/client/keyagent.go:200` → `:215` → `:273`).

### 3. The system agent stops answering; `agent.List()` blocks forever

The `x/crypto/ssh/agent` client calls take no context and have no timeout. Once
the agent stops servicing new connections (both 1Password and macOS agents are
effectively serial / limited-capacity servers), the socket is still accepted and
the request write still succeeds, but no response is ever written — so `List()`
blocks indefinitely in the pipeline read loop.

### 4. The stuck call cascades into a full VNet freeze

1. The stuck `List()` is running as the **singleflight leader** inside
   `clientcache.(*Cache).Get`, so all other callers for that cluster client block
   on `singleflight WaitGroup.Wait`.
2. One of those blocked callers is a **critical** VNet background task — the SSH
   config loop (`opensshconfig.go:199` → `getCachedClient`) registered via
   `ProcessManager.AddCriticalBackgroundTask` — so it never returns.
3. `vnet.(*Service).Stop` takes `s.mu` and calls `stopLocked` →
   `ProcessManager.Wait` → `errgroup.Wait` (`lib/teleterm/vnet/service.go:232`,
   `:235`, `:488`), which never returns because that critical task is stuck.
   **`Stop` therefore holds `s.mu` forever.**
4. Every VNet RPC that grabs `s.mu` now deadlocks — e.g. `RunDiagnostics` parks at
   `s.mu.Lock()` (`lib/teleterm/vnet/service.go:280`).

## Evidence (from the goroutine dump, `SIGQUIT` at 14:21:57)

### Connection leak: 248 open agent connections

Of **361 total goroutines**, **248 are `ssh/agent.(*pipeline).readLoop`** — one
per open, never-closed system-agent connection. A healthy tsh/tshd should have
0–2.

Age distribution of these read-loop goroutines (from their `[IO wait, N minutes]`
states) shows a steady burst ~30–37 min before the crash (~35 connections/min),
then accumulation stops ~30 min ago — exactly when the agent stopped responding:

```
  51 [IO wait, 37 minutes]
  41 [IO wait, 36 minutes]
  24 [IO wait, 35 minutes]
  24 [IO wait, 34 minutes]
  23 [IO wait, 33 minutes]
  25 [IO wait, 32 minutes]
  49 [IO wait, 31 minutes]
  12 [IO wait, 30 minutes]
   3 [IO wait]
```

### The stuck `agent.List()` (singleflight leader), blocked 30 min

```
goroutine 1916 [chan receive, 30 minutes]:
  ssh/agent.(*pipeline).call            client.go:1084   ← blocked, no timeout
  ssh/agent.(*client).List              client.go:454
  lib/client.(*LocalKeyAgent).UnloadKeyRing  keyagent.go:273
  lib/client.(*LocalKeyAgent).LoadKeyRing    keyagent.go:215
  lib/client.(*LocalKeyAgent).LoadKeyRingForCluster  keyagent.go:200
  lib/client.(*TeleportClient).LoadKeyForCluster     api.go:1402
  ... clusters.(*Storage).fromProfile ... daemon.(*Service).NewClusterClient
  clientcache.(*Cache).Get.func1        clientcache.go:142   ← singleflight leader
  singleflight.(*Group).Do              singleflight.go:113
  clientcache.(*Cache).Get              clientcache.go:136
  daemon.(*Service).GetCachedClient     daemon.go:1274
  vnet.(*clientApplication).getCachedClient  service.go:564
  vnet.(*UnifiedClusterConfigProvider).GetUnifiedClusterConfig
  vnet.(*Service).GetServiceInfo        service.go:255
```

### The agent socket read loop, blocked 31 min (agent never replied)

```
goroutine 1723 [IO wait, 31 minutes]:
  net.(*conn).Read ... io.ReadFull        (reading 4-byte response header)
  ssh/agent.(*pipeline).readLoop          client.go:988
```

### A critical VNet task blocked behind the same singleflight

```
goroutine (critical background task) [sync.WaitGroup.Wait]:
  singleflight.(*Group).Do              singleflight.go:99   ← waiting on leader above
  clientcache.(*Cache).Get              clientcache.go:136
  daemon.(*Service).GetCachedClient     daemon.go:1274
  vnet.(*clientApplication).getCachedClient  service.go:564
  vnet.(*sshConfigurator).updateSSHConfiguration  opensshconfig.go:199
  vnet.(*sshConfigurator).runConfigurationLoop    opensshconfig.go:182
  vnet.RunUserProcess.func1             user_process.go:165
  vnet.RunUserProcess.(*ProcessManager).AddCriticalBackgroundTask.func2  process_manager.go:58
  errgroup.(*Group).Go.func1
```

### `Stop` holding `s.mu` while waiting for that task

```
goroutine 3755 [sync.WaitGroup.Wait]:
  errgroup.(*Group).Wait
  vnet.(*ProcessManager).Wait           process_manager.go:70
  vnet.(*UserProcess).Wait              user_process.go:199
  vnet.(*Service).stopLocked            service.go:488
  vnet.(*Service).Stop                  service.go:235   (holds s.mu; Lock at :232)
```

### The presenting deadlock: `RunDiagnostics` blocked on `s.mu`

```
goroutine 3781 [sync.Mutex.Lock]:
  sync.(*Mutex).Lock
  vnet.(*Service).RunDiagnostics        service.go:280   ← s.mu.Lock(), blocked forever
```

(The only goroutine in the entire dump blocked on a mutex.)

## Aggravating factor: expired certificates

The log is full of `ssh: cert has expired` errors from
`clientcache.(*Cache).Get` → `ConnectToCluster` → `generateClientConfig`. Because
`ConnectToCluster` fails, the client is **never cached**, so every VNet poll
builds a brand-new `LocalKeyAgent` — one more leaked connection and one more
`agent.List()` call each time. This is what drives the leak rate to ~35/min.
Expired certs are not required to trigger the bug, but they accelerate it sharply.

## Why this hasn't been seen before

`tsh` CLI is short-lived: it opens a couple of agent connections and the process
exits, so the OS reaps them and the leak never matters. Only a long-running tshd
with VNet's polling loops accumulates hundreds of open connections and crosses the
agent's capacity threshold.

This is also why it surfaced only recently. The leak itself is old — clients have
dialed the system agent for a long time. What was missing was a driver that rebuilds
clients on a loop while the process sits idle. That arrived with VNet SSH's
OpenSSH-config writer (#55239, 2025-06): `sshConfigurator.runConfigurationLoop` polls
`GetCachedClient` for every profile every 30s regardless of active connections
(`opensshconfig.go:181`, `:199`).

Note that this loop is **not** gated on whether the user has "configured SSH
clients". It is registered unconditionally whenever the VNet user process starts
(`user_process.go:152`); it is the code that *writes* `vnet_ssh_config` in the first
place. The "Configure SSH clients" action only adds an `Include` line to the user's
`~/.ssh/config` so the `ssh` binary actually uses that file
(`OpenSSHConfigIncludesVNetSSHConfig`, `service.go:246`) — it does not start or stop
the loop. So any Connect running VNet on a build with this feature (mid-2025 onward)
drives the leak; expired certs (above) are what turn the slow drip into the ~35/min
flood that crosses the agent's capacity threshold.

## Suggested fixes

Two independent defects; **either** fix alone prevents the freeze, but both are
worth addressing:

1. **Stop leaking the connection (root cause).** Give `LocalKeyAgent` a `Close`
   that closes `systemAgent` (`sshagent.(*client).Close` already exists), and call
   it when the owning `TeleportClient` is discarded — including the error paths
   where the client is never cached (expired certs). This is the VNet-specific
   root cause.

   Note — **closing the agent must be synchronized.** The `TeleportClient` cached
   by `clientcache` is shared: `Get` hands the same `*ClusterClient` (and its
   `LocalKeyAgent`) to concurrent callers, while `Clear` / `ClearStaleClientsForRoot`
   close it on eviction. A `Close` that simply does `a.systemAgent = nil` therefore
   races the unguarded reads of `systemAgent` in `LoadKeyRing` / `UnloadKeyRing` /
   `UnloadKeys` / `Signers` (`keyagent.go:215`, `:273`, `:678`) — a real data race
   (`go test -race` flags it; a torn interface read can crash tshd). Before this
   change `systemAgent` was written once at construction and only read afterward,
   so all concurrent access was read/read and safe; the nil-out is a *new* write
   the fix itself introduces. Guard `systemAgent` with a mutex taken in `Close`
   **and** every reader — grabbing the handle under the lock and releasing it
   before the agent round-trip, so a wedged agent (this very bug) can't block
   `Close` too — or otherwise ensure the agent is closed only once no borrowed
   client can still use it.

2. **Bound the agent calls.** The `x/crypto/ssh/agent` calls in `UnloadKeyRing` /
   `LoadKeyRing` / `Signers` (`lib/client/keyagent.go:273`, `:215`, `:678`) have no
   deadline; a wedged or slow agent blocks the caller forever. Add a timeout so a
   misbehaving agent degrades gracefully instead of hanging.

Additionally worth considering:

3. **Don't hold `s.mu` across `ProcessManager.Wait()` in `vnet.(*Service).Stop`**
   (`service.go:232`). Even with the above fixed, holding the service mutex across
   a potentially long shutdown wedges every other VNet RPC. `RunDiagnostics`
   already captures state and releases `s.mu` before doing network I/O
   (`service.go:285-288`) for this exact reason; `Stop` should follow the same
   pattern.


</details> 

## Claude's input on not adding `TeleportClient.Close`

<details><summary>Details</summary>

❯ Explain to me the decision behind adding closeClientAgent. My first instinct  
  would be to add a Close method to TeleportClient, so I wonder why you went    
  with this solution.                                                           

● Good question, and honestly your instinct is a reasonable one — this was close
  to a toss-up and I picked the more conservative option. Let me lay out the
  actual tradeoff rather than pretend closeClientAgent is obviously right.

  What I was trying to avoid with TeleportClient.Close():

  1. It adds a lifecycle contract to a huge, shared type that doesn't have one 
  today. TeleportClient has no Close() now, and it's constructed at a very large
  number of call sites across tsh and lib/teleterm, almost none of which close
  anything — they rely on process exit. Introducing tc.Close() implicitly tells
  every one of those sites "there's now something to clean up," and invites
  people to sprinkle defer tc.Close() in places where the tc (and its
  localAgent) is still in use. That's exactly the footgun the existing comment
  at api.go:1293 warns about ("there's no mutex guarding this or localAgent"). A
  tc can outlive any single operation and get reused for multiple
  ConnectToCluster calls.
  2. It would be a partial/misleading Close. tc is also the factory whose real
  network resources (ProxyClient, AuthClient) live on the ClusterClient, not on
  tc itself. A tc.Close() that only closes the system-agent connection reads
  like it closes "the client," but wouldn't touch those. So either it's
  misleadingly named, or it grows to try to close things it doesn't cleanly own.
  3. The leak is really an ownership bug in one place. clientcache is the
  component that builds tc values in a loop and is responsible for tearing them
  down. Keeping the teardown there — where the ownership is — felt more honest
  than spreading a new concern into the shared type to fix what's fundamentally
  a localized problem. LocalKeyAgent (which genuinely owns the connection) did
  get a real Close(); closeClientAgent is just a nil-guarded adapter that
  reaches it through the client.

  Where your instinct is genuinely better:

  - It's more idiomatic and discoverable — a Go type that owns a connection
  should have a Close(), and closeClientAgent reaching through
  tc.LocalAgent().Close() is a bit of a "reach into internals" smell.
  - The "partial Close" objection is weaker than it sounds: tc itself doesn't
  hold other long-lived closeable resources directly (config, localAgent, and a
  channel), so a tc.Close() that closes localAgent is arguably complete for what
  tc owns.

  So the real axis is: blast radius on a shared type vs. idiomatic 
  discoverability. I optimized for the former because this is sensitive shared
  code and the leak fix only needs the cache to behave. If you'd rather have the
  idiomatic TeleportClient.Close() — and you know the tsh call sites and their
  expectations far better than I do — I think that's a defensible call, and I'm
  happy to switch: it'd be tc.Close() delegating to localAgent.Close(), with the
  cache calling tc.Close() instead of the helper. Want me to make that change?


</details> 

## Claude report about `Storage.fromProfile` exhibiting a similar problem

<details><summary>Details</summary>

  - [medium] The leak the commit describes still persists on the main tshd path.
  Storage.addCluster/fromProfile (clusters/storage.go:164/234) build
  TeleportClients that open a system-agent connection (default
  AddKeysToAgent=auto) and are never Closed — and these flow through
  ResolveCluster* on essentially every RPC. Your new Close() doc comment says
  "processes that build many agents (such as tshd) must call Close," yet Close
  is wired only into clientcache eviction. Pre-existing, but a completeness gap
  against the commit's own stated goal.
  - [low] Upstream error-path leak. Get correctly doesn't close tc on
  NewClientFunc error (the teleterm resolver returns (nil, err)), but
  fromProfile/GetByURI (storage.go) can return a live client alongside an error
  and drop it without closing the agent. Pre-existing, different file.


</details> 