### PR TITLE
[4] events: allow athena to query for activity from specific `beam_id`

### DIFF
--- a/api/types/events/metadata.go
+++ b/api/types/events/metadata.go
@@ -107,3 +107,9 @@ func (m *SessionMetadata) GetSessionID() string {
 func (m *UserMetadata) GetUser() string {
 	return m.User
 }
+
+// GetBeamID returns the identifier of the Beam this action is associated with,
+// if any.
+func (m *UserMetadata) GetBeamID() string {
+	return m.BeamID
+}

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -1329,6 +1329,11 @@ type SearchEventsRequest struct {
 	StartKey string
 	// Search is an optional search query to filter events.
 	Search string
+	// BeamID optionally restricts results to events attributed to the given
+	// beam (matched against the event's user metadata beam_id). This filter is
+	// only supported by the Athena audit backend; other backends return a
+	// trace.NotImplemented error when it is set.
+	BeamID string
 }
 
 type SearchSessionEventsRequest struct {

--- a/lib/events/athena/querier.go
+++ b/lib/events/athena/querier.go
@@ -208,7 +208,7 @@ func (q *querier) SearchEvents(ctx context.Context, req events.SearchEventsReque
 			limit:     req.Limit,
 			order:     req.Order,
 			startKey:  startKeyset,
-			filter:    searchEventsFilter{eventTypes: req.EventTypes, search: req.Search},
+			filter:    searchEventsFilter{eventTypes: req.EventTypes, search: req.Search, beamID: req.BeamID},
 			sessionID: "",
 		})
 		return events, keyset, trace.Wrap(err)
@@ -220,7 +220,7 @@ func (q *querier) SearchEvents(ctx context.Context, req events.SearchEventsReque
 		limit:     req.Limit,
 		order:     req.Order,
 		startKey:  startKeyset,
-		filter:    searchEventsFilter{eventTypes: req.EventTypes, search: req.Search},
+		filter:    searchEventsFilter{eventTypes: req.EventTypes, search: req.Search, beamID: req.BeamID},
 		sessionID: "",
 	})
 	return events, keyset, trace.Wrap(err)
@@ -664,6 +664,9 @@ type searchEventsFilter struct {
 	eventTypes []string
 	search     string
 	condition  utils.FieldsCondition
+	// beamID, when set, restricts results to events whose top-level
+	// event_data beam_id equals it (see prepareQuery).
+	beamID string
 }
 
 type queryBuilder struct {
@@ -746,6 +749,12 @@ func prepareQuery(params searchParams) (query string, execParams []string, err e
 		for term := range strings.FieldsSeq(strings.ToLower(params.filter.search)) {
 			qb.Append(" AND strpos(lower(event_data), ?) > 0", withTicks(term))
 		}
+	}
+
+	if params.filter.beamID != "" {
+		// beam_id is not a dedicated column; it lives at the top level of the
+		// event_data JSON (UserMetadata is inlined into every event).
+		qb.Append(" AND json_extract_scalar(event_data, '$.beam_id') = ?", withTicks(params.filter.beamID))
 	}
 
 	if params.order == types.EventOrderAscending {

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -776,6 +776,9 @@ type legacyCheckpointKey struct {
 //
 // This function may never return more than 1 MiB of event data.
 func (l *Log) SearchEvents(ctx context.Context, req events.SearchEventsRequest) ([]apievents.AuditEvent, string, error) {
+	if req.BeamID != "" {
+		return nil, "", trace.NotImplemented("the dynamodb audit backend does not support the beam ID filter")
+	}
 	values, next, err := l.searchEventsWithFilter(ctx, req.From, req.To, apidefaults.Namespace, req.Limit, req.Order, req.StartKey, searchEventsFilter{eventTypes: req.EventTypes, search: req.Search}, "")
 	if err != nil {
 		return nil, "", trace.Wrap(err)
@@ -788,6 +791,9 @@ func (l *Log) SearchEvents(ctx context.Context, req events.SearchEventsRequest) 
 }
 
 func (l *Log) SearchUnstructuredEvents(ctx context.Context, req events.SearchEventsRequest) ([]*auditlogpb.EventUnstructured, string, error) {
+	if req.BeamID != "" {
+		return nil, "", trace.NotImplemented("the dynamodb audit backend does not support the beam ID filter")
+	}
 	values, next, err := l.searchEventsWithFilter(ctx, req.From, req.To, apidefaults.Namespace, req.Limit, req.Order, req.StartKey, searchEventsFilter{eventTypes: req.EventTypes, search: req.Search}, "")
 	if err != nil {
 		return nil, "", trace.Wrap(err)

--- a/lib/events/filelog.go
+++ b/lib/events/filelog.go
@@ -197,6 +197,9 @@ func (l *FileLog) trimSizeAndMarshal(event apievents.AuditEvent) ([]byte, error)
 //
 // This function may never return more than 1 MiB of event data.
 func (l *FileLog) SearchEvents(ctx context.Context, req SearchEventsRequest) ([]apievents.AuditEvent, string, error) {
+	if req.BeamID != "" {
+		return nil, "", trace.NotImplemented("the file audit backend does not support the beam ID filter")
+	}
 	l.logger.DebugContext(ctx, "SearchEvents", "from", req.From, "to", req.To, "event_type", req.EventTypes, "limit", req.Limit, "search", req.Search)
 	values, next, err := l.searchEventsWithFilter(ctx, req.From, req.To, req.Limit, req.Order, req.StartKey, searchEventsFilter{
 		eventTypes: req.EventTypes,
@@ -214,6 +217,9 @@ func (l *FileLog) SearchEvents(ctx context.Context, req SearchEventsRequest) ([]
 }
 
 func (l *FileLog) SearchUnstructuredEvents(ctx context.Context, req SearchEventsRequest) ([]*auditlogpb.EventUnstructured, string, error) {
+	if req.BeamID != "" {
+		return nil, "", trace.NotImplemented("the file audit backend does not support the beam ID filter")
+	}
 	l.logger.DebugContext(ctx, "SearchUnstructuredEvents", "from", req.From, "to", req.To, "event_type", req.EventTypes, "limit", req.Limit)
 	values, next, err := l.searchEventsWithFilter(ctx, req.From, req.To, req.Limit, req.Order, req.StartKey, searchEventsFilter{eventTypes: req.EventTypes})
 	if err != nil {

--- a/lib/events/firestoreevents/firestoreevents.go
+++ b/lib/events/firestoreevents/firestoreevents.go
@@ -360,6 +360,9 @@ func (l *Log) EmitAuditEvent(ctx context.Context, in apievents.AuditEvent) error
 //
 // This function may never return more than 1 MiB of event data.
 func (l *Log) SearchEvents(ctx context.Context, req events.SearchEventsRequest) ([]apievents.AuditEvent, string, error) {
+	if req.BeamID != "" {
+		return nil, "", trace.NotImplemented("the firestore audit backend does not support the beam ID filter")
+	}
 	values, next, err := l.searchEventsWithFilter(
 		ctx,
 		searchEventsWithFilterParams{
@@ -682,6 +685,9 @@ func (l *Log) getDocIDForEvent() string {
 }
 
 func (l *Log) SearchUnstructuredEvents(ctx context.Context, req events.SearchEventsRequest) ([]*auditlogpb.EventUnstructured, string, error) {
+	if req.BeamID != "" {
+		return nil, "", trace.NotImplemented("the firestore audit backend does not support the beam ID filter")
+	}
 	values, next, err := l.searchEventsWithFilter(
 		ctx,
 		searchEventsWithFilterParams{

--- a/lib/events/pgevents/pgevents.go
+++ b/lib/events/pgevents/pgevents.go
@@ -593,6 +593,9 @@ func (l *Log) searchEvents(
 
 // SearchEvents implements [events.AuditLogger].
 func (l *Log) SearchEvents(ctx context.Context, req events.SearchEventsRequest) ([]apievents.AuditEvent, string, error) {
+	if req.BeamID != "" {
+		return nil, "", trace.NotImplemented("the postgres audit backend does not support the beam ID filter")
+	}
 	var emptyCond *utils.ToFieldsConditionConfig
 	const emptySessionID = ""
 
@@ -610,6 +613,9 @@ func (l *Log) SearchEvents(ctx context.Context, req events.SearchEventsRequest) 
 
 // SearchUnstructuredEvents implements [events.AuditLogger].
 func (l *Log) SearchUnstructuredEvents(ctx context.Context, req events.SearchEventsRequest) ([]*auditlogpb.EventUnstructured, string, error) {
+	if req.BeamID != "" {
+		return nil, "", trace.NotImplemented("the postgres audit backend does not support the beam ID filter")
+	}
 	var emptyCond *utils.ToFieldsConditionConfig
 	const emptySessionID = ""
 


### PR DESCRIPTION
This PR extends audit log search to be able to search events for a specific `beam_id`. Only athena backend will support the search because beams only runs on Teleport cloud - uses athena as backend.




