### PR TITLE
[v18] Add missing `type` modifier to `FilterMap` re-export

### DIFF
--- a/web/packages/shared/components/ListFilters/index.ts
+++ b/web/packages/shared/components/ListFilters/index.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { FilterMap, ListFilters } from './ListFilters';
+import { type FilterMap, ListFilters } from './ListFilters';
 import { applyFilters } from './utilities';
 
 export { ListFilters, type FilterMap, applyFilters };


### PR DESCRIPTION
Backport #68076 to branch/v18

## Manual Test Plan
### Test Environment

My laptop.

### Test Cases
- [x] `pnpm test` doesn't return a warning about `FilterMap`.