### PR TITLE
Fix docs issues that hindered an agent in 7 files

### DIFF
--- a/docs/pages/enroll-resources/kubernetes-access/register-clusters/dynamic-registration.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/register-clusters/dynamic-registration.mdx
@@ -294,8 +294,11 @@ file to base64, then indent it and add it to the `kube_cluster.yaml` resource
 definition using the following command:
 
 ```code
-$ printf "    %s" $(cat kubeconfig | base64) >> kube_cluster.yaml
+$ printf "    %s\n" "$(cat kubeconfig | base64 | tr -d '\n')" >> kube_cluster.yaml
 ```
+
+This command also removes any newlines added to the middle of the base64-encoded
+string before writing it to the `kube_cluster` resource definition.
 
 <details>
 <summary>Add labels to your kube_cluster</summary>

--- a/docs/pages/enroll-resources/server-access/guides/auditd.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/auditd.mdx
@@ -17,7 +17,7 @@ You can configure Teleport's SSH Service to integrate with the Linux Auditing Sy
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-- A running Teleport Agent instance. See the [getting started guide](../getting-started.mdx) for  how to add an agent to your Teleport cluster. On the agent, `teleport` must be running as a systemd service with root permissions.
+- A running Teleport SSH Service instance. See the [getting started guide](../getting-started.mdx) for  how to add an agent to your Teleport cluster. On the agent, `teleport` must be running as a systemd service with root permissions.
 - Linux kernel 2.6.6+ compiled with `CONFIG_AUDIT`. Most Linux distributions have this option enabled by default.
 - `auditctl` to check auditd status. You must install the `auditd` package to
   follow the command examples in this guide.
@@ -89,8 +89,9 @@ Otherwise, Teleport won't send any events to auditd due to lack of permissions.
    <Admonition type="warning">
 
      Make sure that the Teleport process has its login UID unset. Otherwise, a
-     session ID won't be set correctly in the emitted events. You can verify
-     this by running the following command:
+     session ID won't be set correctly in the emitted events, since all sessions
+     inherit the login UID of the Teleport process. You can verify this by
+     running the following command:
 
      ```code
      $ cat /proc/$(pidof teleport)/loginuid
@@ -108,19 +109,34 @@ If your system is missing that tool, consult your distribution documentation to 
 
 ### Search by a system user
 
-You can search events when logging in as a system user by using the `-ua` switch.
-You can check the UID of a user by using the `id` command:
+You can search events when logging in as a system user.
 
-```code
-$ id bob
-uid=1000(bob) gid=1000(bob) groups=1000(bob)
-```
+1. List available servers to access:
 
-Then you can use `uid` to search auditd logs:
+  ```code
+  $ tsh ls
+  ```
 
-```code
-$ ausearch -ua 1000 -m USER_LOGIN
-```
+1. Pick a server from the list and SSH into it. Replace 
+   <Var name="myuser" /> with your login name and <Var name="myhost" /> with your
+   server name.
+
+   ```code
+   $ tsh ssh <Var name="myuser" />@<Var name="myhost" />
+   ```
+
+1. On the server, check the UID of a user by using the `id` command:
+
+   ```code
+   $ id <Var name="myuser" />
+   uid=1000(bob) gid=1000(bob) groups=1000(bob)
+   ```
+
+1. On the server, use `uid` to search auditd logs:
+
+   ```code
+   $ ausearch -ua 1000 -m USER_LOGIN
+   ```
 
 ### Search by Teleport user
 
@@ -128,7 +144,7 @@ Events sent to auditd by Teleport are augmented by the `teleportUser` field, whi
 `ausearch` doesn't let you search by custom fields, but you can use `grep` for that:
 
 ```code
-$ ausearch -m USER_LOGIN | grep teleportUser=bob
+$ ausearch -m USER_LOGIN | grep teleportUser=<Var name="myuser" />
 ```
 
 ### Search by session ID

--- a/docs/pages/enroll-resources/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/bpf-session-recording.mdx
@@ -166,26 +166,7 @@ ssh_service:
 
     # Optional: network_buffer_size is optional with default value of 8 pages.
     network_buffer_size: 8
-
-    # Optional: Controls where cgroupv2 hierarchy is mounted. Default value:
-    # /cgroup2.
-    cgroup_path: /cgroup2
-
-    # Optional: Controls the path inside cgroupv2 hierarchy where Teleport
-    # cgroups will be placed. Default value: /teleport
-    root_path: /teleport
 ```
-
-<details>
-<summary>Isolate session system resources</summary>
-
-If you operate multiple Teleport instances on the same system, customize the
-`root_path` configuration to change the base cgroupv2 slice path for session
-system resources. This ensures security isolation between sessions from
-different Teleport instances, allowing you to apply distinct security rules and
-resource controls.
-
-</details>
 
 ### Start Teleport on your Node
 

--- a/docs/pages/get-started/deploy-community.mdx
+++ b/docs/pages/get-started/deploy-community.mdx
@@ -52,9 +52,14 @@ Also, if you want to get a feel for Teleport commands and capabilities without s
 up any infrastructure, take a look at the browser-based [Teleport
 Labs](https://goteleport.com/labs).
 
-As for this guide, you can work through it with either a remote virtual machine (e.g., an Amazon
-EC2 instance) or a local Docker container. Make sure you have met the following
-requirements for your platform:
+You can work through this guide with either a remote virtual machine (e.g., an
+Amazon EC2 instance) or a local Docker container. **We recommend the Amazon EC2
+instance approach** for simplicity. Once you have completed this guide, having a
+dedicated host for your self-hosted Teleport cluster reduces the complexity of
+following other guides in the Teleport documentation.
+
+Make sure you have met the
+following requirements for your platform:
 
 <Tabs>
 <TabItem label="Remote virtual machine">
@@ -70,7 +75,8 @@ requirements for your platform:
   similar.
 
 - **One** of the following:
-  - A registered domain name.
+  - A registered domain name or access to a service like Amazon Route53 that
+    allows you to register domain names.
   - An authoritative DNS nameserver managed by your organization, plus an
     existing certificate authority. If using this approach, ensure that your
     browser is configured to use your organization's nameserver.
@@ -146,6 +152,15 @@ Finally, you will need a multi-factor authenticator app such as
 Authenticator](https://www.google.com/landing/2step/), or
 [1Password](https://support.1password.com/one-time-passwords/).
 
+<Admonition type="danger">
+
+While it is possible to configure the Teleport Auth Service to use a self-signed
+certificate, this adds significant complexity and is not recommended. See
+[Self-Signed Certificates](../installation/self-hosted/self-signed-certs.mdx)
+for how to run a Teleport cluster with self-signed certificates. 
+
+</Admonition>
+
 ## Step 1/3. Set up Teleport on your Linux host
 
 In this step, you will log into your Linux host, download the Teleport binary,
@@ -167,7 +182,11 @@ Generate a configuration file for Teleport using the `teleport configure` comman
 This command requires information about a TLS certificate and private key.
 
 The instructions depend on whether you are running Teleport on the public
-internet, a local container, or a private network:
+internet, a local container, or a private network. Unless you have specific
+security needs, **we recommend using Let's Encrypt on the public internet**.
+This reduces the complexity of following additional guides in the Teleport
+documentation since you do not need to export a certificate authority to all
+infrastructure in your cluster.
 
 <Tabs>
 

--- a/docs/pages/identity-governance/access-requests/plugins/msteams.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/msteams.mdx
@@ -54,7 +54,7 @@ productivity.
 - Either an Azure virtual machine or Kubernetes cluster where you will run the
   Teleport Microsoft Teams plugin.
 
-(!/docs/pages/includes/tctl.mdx!)
+(!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/9. Define RBAC resources
 

--- a/docs/pages/identity-governance/access-requests/plugins/slack.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/slack.mdx
@@ -135,7 +135,7 @@ Here is an example of sending an Access Request via Teleport's Slack plugin:
 
   </details>
 
-(!/docs/pages/includes/tctl.mdx!)
+(!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/7. Define RBAC resources
 

--- a/docs/pages/identity-governance/locking.mdx
+++ b/docs/pages/identity-governance/locking.mdx
@@ -88,47 +88,48 @@ to prevent various operations, e.g., preventing access from a locked user.
 ## Step 1/2. Create a lock
 
 You can create a new lock with the `tctl lock` command. Specify the lock target
-with one of the following options:
+and time to live using the following command, depending on the resource that you
+would like to lock: 
 
 <Tabs>
   <TabItem label="Username">
   ```code
-  $ tctl lock --user=foo@example.com --message="Suspicious activity." --ttl=10h
+  $ tctl lock --user=foo@example.com --message="Suspicious activity." --ttl=24h
   # Created a lock with name "dc7cee9d-fe5e-4534-a90d-db770f0234a1".
   ```
   </TabItem>
   <TabItem label="Role">
   All users with assigned roles matching the target role will be locked.
   ```code
-  $ tctl lock --role=contractor --message="All contractor access is disabled for 10h." --ttl=10h
+  $ tctl lock --role=contractor --message="All contractor access is disabled for 24h." --ttl=24h
   # Created a lock with name "dc7cee9d-fe5e-4534-a90d-db770f0234a1".
   ```
   </TabItem>
   <TabItem label="Trusted device">
   All connections initiated from a device matching the device ID will be locked.
   ```code
-  $ tctl lock --device 9cdfc0ad-64b7-4d9c-9342-50e97f418ba0 --message="Compromised device" --ttl=48h
+  $ tctl lock --device 9cdfc0ad-64b7-4d9c-9342-50e97f418ba0 --message="Compromised device" --ttl=24h
   Created a lock with name "5444970a-39a0-4814-968d-e58b4a8fa686".
   ```
   </TabItem>
   <TabItem label="Multi-factor device">
   All connections initiated with per-session MFA matching the device ID will be locked.
   ```code
-  $ tctl lock --mfa-device=d6c06a18-e147-4232-9dfe-6f83a28d5850 --message="All contractor access is disabled for 10h." --ttl=10h
+  $ tctl lock --mfa-device=d6c06a18-e147-4232-9dfe-6f83a28d5850 --message="All contractor access is disabled for 24h." --ttl=24h
   # Created a lock with name "d6c06a18-e147-4232-9dfe-6f83a28d5850".
   ```
   </TabItem>
   <TabItem label="Agent">
   All connections to the specified agent will be locked and the agent will be excluded from the Teleport cluster.
   ```code
-  $ tctl lock --server-id=363256df-f78a-4d99-803c-bae19da9ede4 --message="The server running the Kubernetes Service and Database Service is under investigation." --ttl=10h
+  $ tctl lock --server-id=363256df-f78a-4d99-803c-bae19da9ede4 --message="The server running the Kubernetes Service and Database Service is under investigation." --ttl=24h
   # Created a lock with name "dc7cee9d-fe5e-4534-a90d-db770f0234a1".
   ```
   </TabItem>
   <TabItem label="Windows Desktop">
   All connections to the specified Windows Desktop will be locked.
   ```code
-  $ tctl lock --windows-desktop=WIN-FMPFM5UF1SS-teleport-example-com --ttl=10h
+  $ tctl lock --windows-desktop=WIN-FMPFM5UF1SS-teleport-example-com --ttl=24h
   # Created a lock with name "dc7cee9d-fe5e-4534-a90d-db770f0234a1".
   ```
   </TabItem>
@@ -146,20 +147,20 @@ with one of the following options:
   For [delegated join methods](../reference/deployment/join-methods.mdx#secret-vs-delegated),
   it's best to target the specific join token the bot is using to join:
   ```code
-  $ tctl lock --join-token=example-token-name
+  $ tctl lock --join-token=example-token-name --ttl=24h
   ```
 
   The join token name cannot be targeted for bots joined using the `token` join
   method, so it's best to use the
   [bot instance ID](../reference/architecture/machine-id-architecture.mdx#bot-instances):
   ```code
-  $ tctl lock --bot-instance-id aabbccdd-1234-5678-0000-3b04d7d03acc
+  $ tctl lock --bot-instance-id aabbccdd-1234-5678-0000-3b04d7d03acc --ttl=24h
   ```
 
   In all cases, you may also target the bot user, which will lock all instances
   of a bot that share the same underlying user:
   ```code
-  $ tctl lock --user bot-example
+  $ tctl lock --user bot-example --ttl=24h
   ```
   </TabItem>
 </Tabs>

--- a/docs/pages/identity-security/session-summaries/session-search.mdx
+++ b/docs/pages/identity-security/session-summaries/session-search.mdx
@@ -61,6 +61,7 @@ the same data handling and provider considerations that apply to
   and summaries.
 - At least one SSH node, Kubernetes cluster, or PostgreSQL database connected to
   Teleport to generate session recordings. 
+- (!docs/pages/includes/tctl.mdx!)
 
 Teleport Enterprise Cloud manages Access Graph and its backing database. For
 self-hosted clusters, follow the [Docker](../access-graph/self-hosted.mdx) or

--- a/docs/pages/identity-security/session-summaries/session-summaries.mdx
+++ b/docs/pages/identity-security/session-summaries/session-summaries.mdx
@@ -104,6 +104,8 @@ Session Recording Summary Player and Timeline
 </TabItem>
 </Tabs>
 
+(!docs/pages/includes/tctl.mdx!)
+
 <Admonition type="tip" title="Teleport Enterprise Cloud Quick Start">
 Teleport Enterprise Cloud tenants include a pre-provisioned inference model
 (`teleport-cloud-default`). You can skip directly to

--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -1,9 +1,11 @@
-To check that you can connect to your Teleport cluster, sign in with `tsh login`, then
-verify that you can run `tctl` commands using your current credentials.
+Check that you can connect to your Teleport cluster and verify that you can run
+`tctl` commands using your current credentials.
 
-For example, run the following command, assigning
-<Var name="teleport.example.com" /> to the domain name of the Teleport Proxy Service
-in your cluster and <Var name="email@example.com" /> to your Teleport username:
+Run the following command, assigning <Var name="teleport.example.com" /> to the
+domain name of the Teleport Proxy Service in your cluster and
+<Var name="email@example.com" /> to your Teleport username. This command
+requires an interactive shell since, by default, it triggers a multi-factor
+authentication prompt:
 
 ```code
 $ tsh login --proxy=<Var name="teleport.example.com" /> --user=<Var name="email@example.com" />
@@ -18,15 +20,21 @@ current credentials to run subsequent `tctl` commands from your workstation.
 If you host your own Teleport cluster, you can also run `tctl` commands on the computer that
 hosts the Teleport Auth Service for full permissions.
 
+If you want credentials for running `tsh` and `tctl` commands in non-interactive
+environments, we recommend that you [set up Machine
+ID](../machine-workload-identity/getting-started.mdx).
+
 <details>
-<summary>Running `tctl` on a Teleport beam</summary>
+<summary>Client authentication in headless environments</summary>
 
 In some environments, for example on a Teleport beam, Teleport authentication
 must take place through a local identity file. On a Teleport beam, the identity
-file is available automatically, and `tctl` reads the file path from the
-`TELEPORT_IDENTITY_FILE` environment variable.
+file is available automatically. `tsh` and `tctl` read the file path from the
+`TELEPORT_IDENTITY_FILE` environment variable. `tsh` and `tctl` commands that
+you run with an identity file do not require authenticating to Teleport
+separately.
 
-When executing `tctl` commands with an identity file, you  must pass the
+When executing `tctl` commands with an identity file, you must pass the
 `--auth-server` flag to provide the Teleport Auth Service address, which is not
 included in the identity file. If you provide the Proxy Service address, `tctl`
 connects to the Proxy Service, which forwards traffic to and from the Teleport
@@ -38,6 +46,13 @@ environment variable:
 
 ```code
 $ tctl status --auth-server=${TELEPORT_PROXY}
+```
+
+For `tsh` commands that read an identity file, you must pass the `--proxy` flag,
+which points `tsh` to the address of the Teleport Proxy Service:
+
+```code
+$ tsh status --proxy=${TELEPORT_PROXY}
 ```
 
 </details>

--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -45,8 +45,14 @@ Check that you can connect to your Teleport cluster and verify that you can run
    $ tsh status --proxy=<Var name="teleport.example.com" />
    ```
 
-   Export the `TELEPORT_IDENTITY_FILE` environment variable and add the
-   `--auth-server` or `--proxy` flags to all subsequent `tctl` and `tsh`
+   Ensure client commands can access your identity file. Replace
+   <Var name="path/to/identity/file" /> with the path to your identity file:
+
+   ```code
+   $ export TELEPORT_IDENTITY_FILE="${TELEPORT_IDENTITY_FILE:-<Var name="path/to/identity/file" />}"
+   ```
+
+   Add the `--auth-server` or `--proxy` flags to all subsequent `tctl` and `tsh`
    commands.
 
 If you can connect to the cluster and run the `tctl status` command, you can use your

--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -19,15 +19,14 @@ Check that you can connect to your Teleport cluster and verify that you can run
    # CA pin   (=presets.ca_pin=)
    ```
 
-   **On non-interactive environments:** In a [Teleport
-   beam](../beams/beams.mdx), CI/CD environment, or similar, make sure the
+   **On non-interactive environments:** If you are running `tsh` and `tctl` as
+   an AI agent, in a CI/CD environment, or similar, make sure the
    `TELEPORT_IDENTITY_FILE` environment variable is assigned to a valid file
-   path. On a beam, this file is available automatically. `tsh` and `tctl` read
-   the file path from the environment variable and do not require a separate
-   authentication step. If there is no identity file available, we recommend
-   that you [set up Machine
-   ID](../machine-workload-identity/getting-started.mdx) to provision one
-   automatically.
+   path with credentials for your cluster. `tsh` and `tctl` read the file path
+   from the environment variable and do not require a separate authentication
+   step. If there is no identity file available, we recommend that you [set up
+   Machine ID](../machine-workload-identity/getting-started.mdx) to provision
+   one automatically.
 
    When executing `tctl` commands with an identity file, you must pass the
    `--auth-server` flag to provide the Teleport Auth Service address, which is
@@ -35,20 +34,20 @@ Check that you can connect to your Teleport cluster and verify that you can run
    address, `tctl` connects to the Proxy Service, which forwards traffic to
    and from the Teleport Auth Service.
 
-   On a beam, you must use the Proxy Service address, as the Auth Service is
-   not exposed to the public internet. You can do so by using the
-   `TELEPORT_PROXY` environment variable:
-
    ```code
-   $ tctl status --auth-server=${TELEPORT_PROXY}
+   $ tctl status --auth-server=<Var name="teleport.example.com" />
    ```
 
    For `tsh` commands that read an identity file, you must pass the `--proxy` flag,
    which points `tsh` to the address of the Teleport Proxy Service:
 
    ```code
-   $ tsh status --proxy=${TELEPORT_PROXY}
+   $ tsh status --proxy=<Var name="teleport.example.com" />
    ```
+
+   Export the `TELEPORT_IDENTITY_FILE` environment variable and add the
+   `--auth-server` or `--proxy` flags to all subsequent `tctl` and `tsh`
+   commands.
 
 If you can connect to the cluster and run the `tctl status` command, you can use your
 current credentials to run subsequent `tctl` commands from your workstation.

--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -32,10 +32,11 @@ Check that you can connect to your Teleport cluster and verify that you can run
    `--auth-server` flag to provide the Teleport Auth Service address, which is
    not included in the identity file. If you provide the Proxy Service
    address, `tctl` connects to the Proxy Service, which forwards traffic to
-   and from the Teleport Auth Service.
+   and from the Teleport Auth Service. Update <Var name="443" /> to `3025` if
+   you are contacting the Auth Service directly with `tctl`:
 
    ```code
-   $ tctl status --auth-server=<Var name="teleport.example.com" />
+   $ tctl status --auth-server=<Var name="teleport.example.com" />:<Var name="443" />
    ```
 
    For `tsh` commands that read an identity file, you must pass the `--proxy` flag,

--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -1,58 +1,57 @@
 Check that you can connect to your Teleport cluster and verify that you can run
-`tctl` commands using your current credentials.
+`tctl` and `tsh` commands using your current credentials.
 
-Run the following command, assigning <Var name="teleport.example.com" /> to the
-domain name of the Teleport Proxy Service in your cluster and
-<Var name="email@example.com" /> to your Teleport username. This command
-requires an interactive shell since, by default, it triggers a multi-factor
-authentication prompt:
+1. Assign <Var name="teleport.example.com" /> to the domain name of the Teleport
+   Proxy Service in your cluster and <Var name="email@example.com" /> to your
+   Teleport username.
 
-```code
-$ tsh login --proxy=<Var name="teleport.example.com" /> --user=<Var name="email@example.com" />
-$ tctl status
-# Cluster  (=teleport.url=)
-# Version  (=teleport.version=)
-# CA pin   (=presets.ca_pin=)
-```
+1. Authenticate to your Teleport cluster. This depends on whether your shell is
+   interactive or not.
+
+   **In an interactive shell:** Run the following command. By default, this
+   triggers a multi-factor authentication prompt:
+
+   ```code
+   $ tsh login --proxy=<Var name="teleport.example.com" /> --user=<Var name="email@example.com" />
+   $ tctl status
+   # Cluster  (=teleport.url=)
+   # Version  (=teleport.version=)
+   # CA pin   (=presets.ca_pin=)
+   ```
+
+   **On non-interactive environments:** In a [Teleport
+   beam](../beams/beams.mdx), CI/CD environment, or similar, make sure the
+   `TELEPORT_IDENTITY_FILE` environment variable is assigned to a valid file
+   path. On a beam, this file is available automatically. `tsh` and `tctl` read
+   the file path from the environment variable and do not require a separate
+   authentication step. If there is no identity file available, we recommend
+   that you [set up Machine
+   ID](../machine-workload-identity/getting-started.mdx) to provision one
+   automatically.
+
+   When executing `tctl` commands with an identity file, you must pass the
+   `--auth-server` flag to provide the Teleport Auth Service address, which is
+   not included in the identity file. If you provide the Proxy Service
+   address, `tctl` connects to the Proxy Service, which forwards traffic to
+   and from the Teleport Auth Service.
+
+   On a beam, you must use the Proxy Service address, as the Auth Service is
+   not exposed to the public internet. You can do so by using the
+   `TELEPORT_PROXY` environment variable:
+
+   ```code
+   $ tctl status --auth-server=${TELEPORT_PROXY}
+   ```
+
+   For `tsh` commands that read an identity file, you must pass the `--proxy` flag,
+   which points `tsh` to the address of the Teleport Proxy Service:
+
+   ```code
+   $ tsh status --proxy=${TELEPORT_PROXY}
+   ```
 
 If you can connect to the cluster and run the `tctl status` command, you can use your
 current credentials to run subsequent `tctl` commands from your workstation.
 If you host your own Teleport cluster, you can also run `tctl` commands on the computer that
 hosts the Teleport Auth Service for full permissions.
 
-If you want credentials for running `tsh` and `tctl` commands in non-interactive
-environments, we recommend that you [set up Machine
-ID](../machine-workload-identity/getting-started.mdx).
-
-<details>
-<summary>Client authentication in headless environments</summary>
-
-In some environments, for example on a Teleport beam, Teleport authentication
-must take place through a local identity file. On a Teleport beam, the identity
-file is available automatically. `tsh` and `tctl` read the file path from the
-`TELEPORT_IDENTITY_FILE` environment variable. `tsh` and `tctl` commands that
-you run with an identity file do not require authenticating to Teleport
-separately.
-
-When executing `tctl` commands with an identity file, you must pass the
-`--auth-server` flag to provide the Teleport Auth Service address, which is not
-included in the identity file. If you provide the Proxy Service address, `tctl`
-connects to the Proxy Service, which forwards traffic to and from the Teleport
-Auth Service.
-
-On a beam, you must use the Proxy Service address, as the Auth Service is not
-exposed to the public internet. You can do so by using the `TELEPORT_PROXY`
-environment variable:
-
-```code
-$ tctl status --auth-server=${TELEPORT_PROXY}
-```
-
-For `tsh` commands that read an identity file, you must pass the `--proxy` flag,
-which points `tsh` to the address of the Teleport Proxy Service:
-
-```code
-$ tsh status --proxy=${TELEPORT_PROXY}
-```
-
-</details>

--- a/docs/pages/machine-workload-identity/getting-started.mdx
+++ b/docs/pages/machine-workload-identity/getting-started.mdx
@@ -62,7 +62,7 @@ or Kubernetes cluster to Teleport. If you haven't done so, refer to the
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!/docs/pages/includes/tctl.mdx!)
+(!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Choose a target resource
 


### PR DESCRIPTION
1. **locking.mdx:** Add consistent TTLs to lock examples. The agent found some friction in that the explanation of TTLs was a little hidden in a details box. Keep the details box, since this is tangential information for the guide, but include consistent TTLs in all examples so this isn't something a user needs to wonder about initially.
2. **auditd.mdx:** Clarify session UID note. Have the reader SSH into a Teleport-protected server before running `ausearch`.
3. **bpf-session-recording.mdx:** remove docs for deprecated fields related to configuring paths. This now happens automatically.
4. **tctl.mdx partial:** Indicate that readers can use Machine Identity for noninteractive use cases
5. **session-summaries.mdx:** Add tctl.mdx to the Prerequisites.
6. **session-search.mdx:** Add tctl.mdx to the Prerequisites.
7. **register-clusters/dynamic-registration.mdx:** Fix `base64` command: strip newlines added due to wrapping.