### PR TITLE
[v18][scopes] backport scoped access lists

### DIFF
--- a/api/client/accesslist/accesslist.go
+++ b/api/client/accesslist/accesslist.go
@@ -184,6 +184,12 @@ func (c *Client) DeleteAccessList(ctx context.Context, name string) error {
 	return trace.Wrap(err)
 }
 
+// DeleteAccessList removes the specified access list resource.
+func (c *Client) DeleteAccessListV2(ctx context.Context, req *accesslistv1.DeleteAccessListRequest) error {
+	_, err := c.grpcClient.DeleteAccessList(ctx, req)
+	return trace.Wrap(err)
+}
+
 // CountAccessListMembers will count all access list members.
 func (c *Client) CountAccessListMembers(ctx context.Context, accessListName string) (users uint32, lists uint32, err error) {
 	return c.CountAccessListMembersV2(ctx, &accesslistv1.CountAccessListMembersRequest{
@@ -373,11 +379,23 @@ func (c *Client) DeleteAccessListMember(ctx context.Context, accessList, memberN
 	return trace.Wrap(err)
 }
 
+// DeleteAccessListMemberV2 hard deletes the specified access list member resource.
+func (c *Client) DeleteAccessListMemberV2(ctx context.Context, req *accesslistv1.DeleteAccessListMemberRequest) error {
+	_, err := c.grpcClient.DeleteAccessListMember(ctx, req)
+	return trace.Wrap(err)
+}
+
 // DeleteAllAccessListMembersForAccessList hard deletes all access list members for an access list.
 func (c *Client) DeleteAllAccessListMembersForAccessList(ctx context.Context, accessList string) error {
 	_, err := c.grpcClient.DeleteAllAccessListMembersForAccessList(ctx, &accesslistv1.DeleteAllAccessListMembersForAccessListRequest{
 		AccessList: accessList,
 	})
+	return trace.Wrap(err)
+}
+
+// DeleteAllAccessListMembersForAccessListV2 hard deletes all access list members for an access list.
+func (c *Client) DeleteAllAccessListMembersForAccessListV2(ctx context.Context, req *accesslistv1.DeleteAllAccessListMembersForAccessListRequest) error {
+	_, err := c.grpcClient.DeleteAllAccessListMembersForAccessList(ctx, req)
 	return trace.Wrap(err)
 }
 
@@ -490,6 +508,12 @@ func (c *Client) DeleteAccessListReview(ctx context.Context, accessListName, rev
 		AccessListName: accessListName,
 		ReviewName:     reviewName,
 	})
+	return trace.Wrap(err)
+}
+
+// DeleteAccessListReviewV2 will delete an access list review from the backend.
+func (c *Client) DeleteAccessListReviewV2(ctx context.Context, req *accesslistv1.DeleteAccessListReviewRequest) error {
+	_, err := c.grpcClient.DeleteAccessListReview(ctx, req)
 	return trace.Wrap(err)
 }
 

--- a/api/client/accesslist/accesslist.go
+++ b/api/client/accesslist/accesslist.go
@@ -104,9 +104,14 @@ func (c *Client) ListAccessListsV2(ctx context.Context, req *accesslistv1.ListAc
 
 // GetAccessList returns the specified access list resource.
 func (c *Client) GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error) {
-	resp, err := c.grpcClient.GetAccessList(ctx, &accesslistv1.GetAccessListRequest{
+	return c.GetAccessListV2(ctx, &accesslistv1.GetAccessListRequest{
 		Name: name,
 	})
+}
+
+// GetAccessListV2 returns the specified access list resource.
+func (c *Client) GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error) {
+	resp, err := c.grpcClient.GetAccessList(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -181,9 +186,14 @@ func (c *Client) DeleteAccessList(ctx context.Context, name string) error {
 
 // CountAccessListMembers will count all access list members.
 func (c *Client) CountAccessListMembers(ctx context.Context, accessListName string) (users uint32, lists uint32, err error) {
-	resp, err := c.grpcClient.CountAccessListMembers(ctx, &accesslistv1.CountAccessListMembersRequest{
+	return c.CountAccessListMembersV2(ctx, &accesslistv1.CountAccessListMembersRequest{
 		AccessListName: accessListName,
 	})
+}
+
+// CountAccessListMembersV2 will count all access list members.
+func (c *Client) CountAccessListMembersV2(ctx context.Context, req *accesslistv1.CountAccessListMembersRequest) (users uint32, lists uint32, err error) {
+	resp, err := c.grpcClient.CountAccessListMembers(ctx, req)
 	if err != nil {
 		return 0, 0, trace.Wrap(err)
 	}
@@ -193,11 +203,16 @@ func (c *Client) CountAccessListMembers(ctx context.Context, accessListName stri
 
 // ListAccessListMembers returns a paginated list of all access list members for an access list.
 func (c *Client) ListAccessListMembers(ctx context.Context, accessList string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error) {
-	resp, err := c.grpcClient.ListAccessListMembers(ctx, &accesslistv1.ListAccessListMembersRequest{
+	return c.ListAccessListMembersV2(ctx, &accesslistv1.ListAccessListMembersRequest{
 		PageSize:   int32(pageSize),
 		PageToken:  pageToken,
 		AccessList: accessList,
 	})
+}
+
+// ListAccessListMembersV2 returns a paginated list of all access list members for an access list.
+func (c *Client) ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error) {
+	resp, err := c.grpcClient.ListAccessListMembers(ctx, req)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -216,10 +231,15 @@ func (c *Client) ListAccessListMembers(ctx context.Context, accessList string, p
 
 // ListAllAccessListMembers returns a paginated list of all access list members for all access lists.
 func (c *Client) ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error) {
-	resp, err := c.grpcClient.ListAllAccessListMembers(ctx, &accesslistv1.ListAllAccessListMembersRequest{
+	return c.ListAllAccessListMembersV2(ctx, &accesslistv1.ListAllAccessListMembersRequest{
 		PageSize:  int32(pageSize),
 		PageToken: pageToken,
 	})
+}
+
+// ListAllAccessListMembersV2 returns a paginated list of all access list members for all access lists.
+func (c *Client) ListAllAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAllAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error) {
+	resp, err := c.grpcClient.ListAllAccessListMembers(ctx, req)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -238,10 +258,15 @@ func (c *Client) ListAllAccessListMembers(ctx context.Context, pageSize int, pag
 
 // GetAccessListMember returns the specified access list member resource.
 func (c *Client) GetAccessListMember(ctx context.Context, accessList, memberName string) (*accesslist.AccessListMember, error) {
-	resp, err := c.grpcClient.GetAccessListMember(ctx, &accesslistv1.GetAccessListMemberRequest{
+	return c.GetAccessListMemberV2(ctx, &accesslistv1.GetAccessListMemberRequest{
 		AccessList: accessList,
 		MemberName: memberName,
 	})
+}
+
+// GetAccessListMemberV2 returns the specified access list member resource.
+func (c *Client) GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error) {
+	resp, err := c.grpcClient.GetAccessListMember(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -269,9 +294,16 @@ func (c *Client) GetStaticAccessListMember(ctx context.Context, accessList, memb
 //
 // Returned Owners are not validated for ownership requirements – use `IsAccessListOwner` for validation.
 func (c *Client) GetAccessListOwners(ctx context.Context, accessListName string) ([]*accesslist.Owner, error) {
-	resp, err := c.grpcClient.GetAccessListOwners(ctx, &accesslistv1.GetAccessListOwnersRequest{
+	return c.GetAccessListOwnersV2(ctx, &accesslistv1.GetAccessListOwnersRequest{
 		AccessList: accessListName,
 	})
+}
+
+// GetAccessListOwnersV2 returns a list of all owners in an Access List, including those inherited from nested Access Lists.
+//
+// Returned Owners are not validated for ownership requirements – use `IsAccessListOwner` for validation.
+func (c *Client) GetAccessListOwnersV2(ctx context.Context, req *accesslistv1.GetAccessListOwnersRequest) ([]*accesslist.Owner, error) {
+	resp, err := c.grpcClient.GetAccessListOwners(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -387,11 +419,16 @@ func (c *Client) AccessRequestPromote(ctx context.Context, req *accesslistv1.Acc
 
 // ListAccessListReviews will list access list reviews for a particular access list.
 func (c *Client) ListAccessListReviews(ctx context.Context, accessList string, pageSize int, pageToken string) (reviews []*accesslist.Review, nextToken string, err error) {
-	resp, err := c.grpcClient.ListAccessListReviews(ctx, &accesslistv1.ListAccessListReviewsRequest{
+	return c.ListAccessListReviewsV2(ctx, &accesslistv1.ListAccessListReviewsRequest{
 		AccessList: accessList,
 		PageSize:   int32(pageSize),
 		NextToken:  pageToken,
 	})
+}
+
+// ListAccessListReviewsV2 will list access list reviews for a particular access list.
+func (c *Client) ListAccessListReviewsV2(ctx context.Context, req *accesslistv1.ListAccessListReviewsRequest) (reviews []*accesslist.Review, nextToken string, err error) {
+	resp, err := c.grpcClient.ListAccessListReviews(ctx, req)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -410,10 +447,15 @@ func (c *Client) ListAccessListReviews(ctx context.Context, accessList string, p
 
 // ListAllAccessListReviews will list access list reviews for all access lists. Only to be used by the cache.
 func (c *Client) ListAllAccessListReviews(ctx context.Context, pageSize int, pageToken string) (reviews []*accesslist.Review, nextToken string, err error) {
-	resp, err := c.grpcClient.ListAllAccessListReviews(ctx, &accesslistv1.ListAllAccessListReviewsRequest{
+	return c.ListAllAccessListReviewsV2(ctx, &accesslistv1.ListAllAccessListReviewsRequest{
 		PageSize:  int32(pageSize),
 		NextToken: pageToken,
 	})
+}
+
+// ListAllAccessListReviewsV2 will list access list reviews for all access lists. Only to be used by the cache.
+func (c *Client) ListAllAccessListReviewsV2(ctx context.Context, req *accesslistv1.ListAllAccessListReviewsRequest) (reviews []*accesslist.Review, nextToken string, err error) {
+	resp, err := c.grpcClient.ListAllAccessListReviews(ctx, req)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}

--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_protohybrid.pb.go
@@ -150,6 +150,8 @@ const (
 	MembershipKind_MEMBERSHIP_KIND_USER MembershipKind = 1
 	// MEMBERSHIP_KIND_LIST represents list members that are nested Access Lists
 	MembershipKind_MEMBERSHIP_KIND_LIST MembershipKind = 2
+	// MEMBERSHIP_KIND_SCOPED_LIST represents list members that are nested scoped Access Lists
+	MembershipKind_MEMBERSHIP_KIND_SCOPED_LIST MembershipKind = 3
 )
 
 // Enum value maps for MembershipKind.
@@ -158,11 +160,13 @@ var (
 		0: "MEMBERSHIP_KIND_UNSPECIFIED",
 		1: "MEMBERSHIP_KIND_USER",
 		2: "MEMBERSHIP_KIND_LIST",
+		3: "MEMBERSHIP_KIND_SCOPED_LIST",
 	}
 	MembershipKind_value = map[string]int32{
 		"MEMBERSHIP_KIND_UNSPECIFIED": 0,
 		"MEMBERSHIP_KIND_USER":        1,
 		"MEMBERSHIP_KIND_LIST":        2,
+		"MEMBERSHIP_KIND_SCOPED_LIST": 3,
 	}
 )
 
@@ -248,8 +252,8 @@ func (x IneligibleStatus) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// AccessListUserAssignmentType describes the type of membership anr/or ownership
-// a user has in an access list.
+// AccessListUserAssignmentType describes the type of membership and/or ownership
+// a user has in an Access List.
 type AccessListUserAssignmentType int32
 
 const (
@@ -307,7 +311,9 @@ type AccessList struct {
 	// spec is the specification for the Access List.
 	Spec *AccessListSpec `protobuf:"bytes,2,opt,name=spec,proto3" json:"spec,omitempty"`
 	// status contains dynamically calculated fields.
-	Status        *AccessListStatus `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`
+	Status *AccessListStatus `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`
+	// scope is the scope of the Access List.
+	Scope         string `protobuf:"bytes,4,opt,name=scope,proto3" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -358,6 +364,13 @@ func (x *AccessList) GetStatus() *AccessListStatus {
 	return nil
 }
 
+func (x *AccessList) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
 func (x *AccessList) SetHeader(v *v1.ResourceHeader) {
 	x.Header = v
 }
@@ -368,6 +381,10 @@ func (x *AccessList) SetSpec(v *AccessListSpec) {
 
 func (x *AccessList) SetStatus(v *AccessListStatus) {
 	x.Status = v
+}
+
+func (x *AccessList) SetScope(v string) {
+	x.Scope = v
 }
 
 func (x *AccessList) HasHeader() bool {
@@ -412,6 +429,8 @@ type AccessList_builder struct {
 	Spec *AccessListSpec
 	// status contains dynamically calculated fields.
 	Status *AccessListStatus
+	// scope is the scope of the Access List.
+	Scope string
 }
 
 func (b0 AccessList_builder) Build() *AccessList {
@@ -421,6 +440,7 @@ func (b0 AccessList_builder) Build() *AccessList {
 	x.Header = b.Header
 	x.Spec = b.Spec
 	x.Status = b.Status
+	x.Scope = b.Scope
 	return m0
 }
 
@@ -686,7 +706,10 @@ func (b0 AccessListSpec_builder) Build() *AccessListSpec {
 // AccessListOwner is an owner of an Access List.
 type AccessListOwner struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
-	// name is the username of the owner.
+	// name is the name of the owner, depending on MembershipKind:
+	// MEMBERSHIP_KIND_USER: the username of the owner.
+	// MEMBERSHIP_KIND_LIST: the name of the owner Access List.
+	// MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the owner Access List.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// description is the plaintext description of the owner and why they are an
 	// owner.
@@ -695,7 +718,7 @@ type AccessListOwner struct {
 	// and if not, describes how they're lacking eligibility.
 	IneligibleStatus IneligibleStatus `protobuf:"varint,3,opt,name=ineligible_status,json=ineligibleStatus,proto3,enum=teleport.accesslist.v1.IneligibleStatus" json:"ineligible_status,omitempty"`
 	// membership_kind describes the type of membership, either
-	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
 	MembershipKind MembershipKind `protobuf:"varint,4,opt,name=membership_kind,json=membershipKind,proto3,enum=teleport.accesslist.v1.MembershipKind" json:"membership_kind,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
@@ -773,7 +796,10 @@ func (x *AccessListOwner) SetMembershipKind(v MembershipKind) {
 type AccessListOwner_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// name is the username of the owner.
+	// name is the name of the owner, depending on MembershipKind:
+	// MEMBERSHIP_KIND_USER: the username of the owner.
+	// MEMBERSHIP_KIND_LIST: the name of the owner Access List.
+	// MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the owner Access List.
 	Name string
 	// description is the plaintext description of the owner and why they are an
 	// owner.
@@ -782,7 +808,7 @@ type AccessListOwner_builder struct {
 	// and if not, describes how they're lacking eligibility.
 	IneligibleStatus IneligibleStatus
 	// membership_kind describes the type of membership, either
-	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
 	MembershipKind MembershipKind
 }
 
@@ -1253,9 +1279,9 @@ func (b0 AccessListGrants_builder) Build() *AccessListGrants {
 // ScopedRoleGrant describes a scoped role granted at a specific scope.
 type ScopedRoleGrant struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
-	// role is the name of the scoped role to be granted.
+	// role is scope-qualified name of the scoped role to be granted.
 	Role string `protobuf:"bytes,1,opt,name=role,proto3" json:"role,omitempty"`
-	// scope is the scope the role will be assigned at. It must be an assignable
+	// scope is the scope the role will be granted at. It must be an assignable
 	// scope of the role.
 	Scope         string `protobuf:"bytes,2,opt,name=scope,proto3" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -1312,9 +1338,9 @@ func (x *ScopedRoleGrant) SetScope(v string) {
 type ScopedRoleGrant_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// role is the name of the scoped role to be granted.
+	// role is scope-qualified name of the scoped role to be granted.
 	Role string
-	// scope is the scope the role will be assigned at. It must be an assignable
+	// scope is the scope the role will be granted at. It must be an assignable
 	// scope of the role.
 	Scope string
 }
@@ -1334,7 +1360,10 @@ type Member struct {
 	// header is the header for the resource.
 	Header *v1.ResourceHeader `protobuf:"bytes,1,opt,name=header,proto3" json:"header,omitempty"`
 	// spec is the specification for the Access List member.
-	Spec          *MemberSpec `protobuf:"bytes,2,opt,name=spec,proto3" json:"spec,omitempty"`
+	Spec *MemberSpec `protobuf:"bytes,2,opt,name=spec,proto3" json:"spec,omitempty"`
+	// scope is the scope of the Access List member, it must be equal to the
+	// scope of the parent Access List.
+	Scope         string `protobuf:"bytes,3,opt,name=scope,proto3" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1378,12 +1407,23 @@ func (x *Member) GetSpec() *MemberSpec {
 	return nil
 }
 
+func (x *Member) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
 func (x *Member) SetHeader(v *v1.ResourceHeader) {
 	x.Header = v
 }
 
 func (x *Member) SetSpec(v *MemberSpec) {
 	x.Spec = v
+}
+
+func (x *Member) SetScope(v string) {
+	x.Scope = v
 }
 
 func (x *Member) HasHeader() bool {
@@ -1415,6 +1455,9 @@ type Member_builder struct {
 	Header *v1.ResourceHeader
 	// spec is the specification for the Access List member.
 	Spec *MemberSpec
+	// scope is the scope of the Access List member, it must be equal to the
+	// scope of the parent Access List.
+	Scope string
 }
 
 func (b0 Member_builder) Build() *Member {
@@ -1423,6 +1466,7 @@ func (b0 Member_builder) Build() *Member {
 	_, _ = b, x
 	x.Header = b.Header
 	x.Spec = b.Spec
+	x.Scope = b.Scope
 	return m0
 }
 
@@ -1431,7 +1475,10 @@ type MemberSpec struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// associated Access List
 	AccessList string `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3" json:"access_list,omitempty"`
-	// name is the name of the member of the Access List.
+	// name is the name of the member of the Access List, depending on MembershipKind:
+	// MEMBERSHIP_KIND_USER: the username of the member.
+	// MEMBERSHIP_KIND_LIST: the name of the member Access List.
+	// MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the member scope Access List.
 	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	// joined is when the user joined the Access List.
 	Joined *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=joined,proto3" json:"joined,omitempty"`
@@ -1445,7 +1492,7 @@ type MemberSpec struct {
 	// and if not, describes how they're lacking eligibility.
 	IneligibleStatus IneligibleStatus `protobuf:"varint,7,opt,name=ineligible_status,json=ineligibleStatus,proto3,enum=teleport.accesslist.v1.IneligibleStatus" json:"ineligible_status,omitempty"`
 	// membership_kind describes the type of membership, either
-	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
 	MembershipKind MembershipKind `protobuf:"varint,9,opt,name=membership_kind,json=membershipKind,proto3,enum=teleport.accesslist.v1.MembershipKind" json:"membership_kind,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
@@ -1591,7 +1638,10 @@ type MemberSpec_builder struct {
 
 	// associated Access List
 	AccessList string
-	// name is the name of the member of the Access List.
+	// name is the name of the member of the Access List, depending on MembershipKind:
+	// MEMBERSHIP_KIND_USER: the username of the member.
+	// MEMBERSHIP_KIND_LIST: the name of the member Access List.
+	// MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the member scope Access List.
 	Name string
 	// joined is when the user joined the Access List.
 	Joined *timestamppb.Timestamp
@@ -1605,7 +1655,7 @@ type MemberSpec_builder struct {
 	// and if not, describes how they're lacking eligibility.
 	IneligibleStatus IneligibleStatus
 	// membership_kind describes the type of membership, either
-	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
 	MembershipKind MembershipKind
 }
 
@@ -1630,7 +1680,10 @@ type Review struct {
 	// header is the header for the resource.
 	Header *v1.ResourceHeader `protobuf:"bytes,1,opt,name=header,proto3" json:"header,omitempty"`
 	// spec is the specification for the Access List review.
-	Spec          *ReviewSpec `protobuf:"bytes,2,opt,name=spec,proto3" json:"spec,omitempty"`
+	Spec *ReviewSpec `protobuf:"bytes,2,opt,name=spec,proto3" json:"spec,omitempty"`
+	// scope is the scope of the Access List review. It must be equal to the
+	// scope of the reviewed Access List.
+	Scope         string `protobuf:"bytes,3,opt,name=scope,proto3" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1674,12 +1727,23 @@ func (x *Review) GetSpec() *ReviewSpec {
 	return nil
 }
 
+func (x *Review) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
 func (x *Review) SetHeader(v *v1.ResourceHeader) {
 	x.Header = v
 }
 
 func (x *Review) SetSpec(v *ReviewSpec) {
 	x.Spec = v
+}
+
+func (x *Review) SetScope(v string) {
+	x.Scope = v
 }
 
 func (x *Review) HasHeader() bool {
@@ -1711,6 +1775,9 @@ type Review_builder struct {
 	Header *v1.ResourceHeader
 	// spec is the specification for the Access List review.
 	Spec *ReviewSpec
+	// scope is the scope of the Access List review. It must be equal to the
+	// scope of the reviewed Access List.
+	Scope string
 }
 
 func (b0 Review_builder) Build() *Review {
@@ -1719,6 +1786,7 @@ func (b0 Review_builder) Build() *Review {
 	_, _ = b, x
 	x.Header = b.Header
 	x.Spec = b.Spec
+	x.Scope = b.Scope
 	return m0
 }
 
@@ -1726,6 +1794,8 @@ func (b0 Review_builder) Build() *Review {
 type ReviewSpec struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// access_list is the name of the Access List that this review is for.
+	// If the review is scoped, this is the scope-qualified name of the reviewed
+	// scoped Access List.
 	AccessList string `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3" json:"access_list,omitempty"`
 	// reviewers are the users who performed the review.
 	Reviewers []string `protobuf:"bytes,2,rep,name=reviewers,proto3" json:"reviewers,omitempty"`
@@ -1846,6 +1916,8 @@ type ReviewSpec_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
 	// access_list is the name of the Access List that this review is for.
+	// If the review is scoped, this is the scope-qualified name of the reviewed
+	// scoped Access List.
 	AccessList string
 	// reviewers are the users who performed the review.
 	Reviewers []string
@@ -1884,8 +1956,11 @@ type ReviewChanges struct {
 	// review_day_of_month_changed is populated if the review day of month has
 	// changed.
 	ReviewDayOfMonthChanged ReviewDayOfMonth `protobuf:"varint,5,opt,name=review_day_of_month_changed,json=reviewDayOfMonthChanged,proto3,enum=teleport.accesslist.v1.ReviewDayOfMonth" json:"review_day_of_month_changed,omitempty"`
-	unknownFields           protoimpl.UnknownFields
-	sizeCache               protoimpl.SizeCache
+	// scoped_removed_members contains the scope-qualified names of members that
+	// were removed as part of this review.
+	ScopedRemovedMembers []string `protobuf:"bytes,6,rep,name=scoped_removed_members,json=scopedRemovedMembers,proto3" json:"scoped_removed_members,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *ReviewChanges) Reset() {
@@ -1941,6 +2016,13 @@ func (x *ReviewChanges) GetReviewDayOfMonthChanged() ReviewDayOfMonth {
 	return ReviewDayOfMonth_REVIEW_DAY_OF_MONTH_UNSPECIFIED
 }
 
+func (x *ReviewChanges) GetScopedRemovedMembers() []string {
+	if x != nil {
+		return x.ScopedRemovedMembers
+	}
+	return nil
+}
+
 func (x *ReviewChanges) SetMembershipRequirementsChanged(v *AccessListRequires) {
 	x.MembershipRequirementsChanged = v
 }
@@ -1955,6 +2037,10 @@ func (x *ReviewChanges) SetReviewFrequencyChanged(v ReviewFrequency) {
 
 func (x *ReviewChanges) SetReviewDayOfMonthChanged(v ReviewDayOfMonth) {
 	x.ReviewDayOfMonthChanged = v
+}
+
+func (x *ReviewChanges) SetScopedRemovedMembers(v []string) {
+	x.ScopedRemovedMembers = v
 }
 
 func (x *ReviewChanges) HasMembershipRequirementsChanged() bool {
@@ -1982,6 +2068,9 @@ type ReviewChanges_builder struct {
 	// review_day_of_month_changed is populated if the review day of month has
 	// changed.
 	ReviewDayOfMonthChanged ReviewDayOfMonth
+	// scoped_removed_members contains the scope-qualified names of members that
+	// were removed as part of this review.
+	ScopedRemovedMembers []string
 }
 
 func (b0 ReviewChanges_builder) Build() *ReviewChanges {
@@ -1992,15 +2081,16 @@ func (b0 ReviewChanges_builder) Build() *ReviewChanges {
 	x.RemovedMembers = b.RemovedMembers
 	x.ReviewFrequencyChanged = b.ReviewFrequencyChanged
 	x.ReviewDayOfMonthChanged = b.ReviewDayOfMonthChanged
+	x.ScopedRemovedMembers = b.ScopedRemovedMembers
 	return m0
 }
 
-// CurrentUserAssignments describes the current user's ownership and membership status in the access list.
+// CurrentUserAssignments describes the current user's ownership and membership status in the Access List.
 type CurrentUserAssignments struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
-	// ownership_type represents the current user's ownership type (explicit, inherited, or none) in the access list.
+	// ownership_type represents the current user's ownership type (explicit, inherited, or none) in the Access List.
 	OwnershipType AccessListUserAssignmentType `protobuf:"varint,1,opt,name=ownership_type,json=ownershipType,proto3,enum=teleport.accesslist.v1.AccessListUserAssignmentType" json:"ownership_type,omitempty"`
-	// membership_type represents the current user's membership type (explicit, inherited, or none) in the access list.
+	// membership_type represents the current user's membership type (explicit, inherited, or none) in the Access List.
 	MembershipType AccessListUserAssignmentType `protobuf:"varint,2,opt,name=membership_type,json=membershipType,proto3,enum=teleport.accesslist.v1.AccessListUserAssignmentType" json:"membership_type,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
@@ -2056,9 +2146,9 @@ func (x *CurrentUserAssignments) SetMembershipType(v AccessListUserAssignmentTyp
 type CurrentUserAssignments_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// ownership_type represents the current user's ownership type (explicit, inherited, or none) in the access list.
+	// ownership_type represents the current user's ownership type (explicit, inherited, or none) in the Access List.
 	OwnershipType AccessListUserAssignmentType
-	// membership_type represents the current user's membership type (explicit, inherited, or none) in the access list.
+	// membership_type represents the current user's membership type (explicit, inherited, or none) in the Access List.
 	MembershipType AccessListUserAssignmentType
 }
 
@@ -2071,12 +2161,12 @@ func (b0 CurrentUserAssignments_builder) Build() *CurrentUserAssignments {
 	return m0
 }
 
-// UserAssignments describes the requested user's ownership and membership assignment types in the access list.
+// UserAssignments describes the requested user's ownership and membership assignment types in the Access List.
 type UserAssignments struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
-	// ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the access list.
+	// ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the Access List.
 	OwnershipType AccessListUserAssignmentType `protobuf:"varint,1,opt,name=ownership_type,json=ownershipType,proto3,enum=teleport.accesslist.v1.AccessListUserAssignmentType" json:"ownership_type,omitempty"`
-	// membership_type represents the requested user's membership type (explicit, inherited, or none) in the access list.
+	// membership_type represents the requested user's membership type (explicit, inherited, or none) in the Access List.
 	MembershipType AccessListUserAssignmentType `protobuf:"varint,2,opt,name=membership_type,json=membershipType,proto3,enum=teleport.accesslist.v1.AccessListUserAssignmentType" json:"membership_type,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
@@ -2132,9 +2222,9 @@ func (x *UserAssignments) SetMembershipType(v AccessListUserAssignmentType) {
 type UserAssignments_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the access list.
+	// ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the Access List.
 	OwnershipType AccessListUserAssignmentType
-	// membership_type represents the requested user's membership type (explicit, inherited, or none) in the access list.
+	// membership_type represents the requested user's membership type (explicit, inherited, or none) in the Access List.
 	MembershipType AccessListUserAssignmentType
 }
 
@@ -2158,12 +2248,18 @@ type AccessListStatus struct {
 	OwnerOf []string `protobuf:"bytes,3,rep,name=owner_of,json=ownerOf,proto3" json:"owner_of,omitempty"`
 	// member_of describes Access Lists where this Access List is an explicit member.
 	MemberOf []string `protobuf:"bytes,4,rep,name=member_of,json=memberOf,proto3" json:"member_of,omitempty"`
-	// current_user_assignments describes the current user's ownership and membership status in the access list.
+	// current_user_assignments describes the current user's ownership and membership status in the Access List.
 	CurrentUserAssignments *CurrentUserAssignments `protobuf:"bytes,5,opt,name=current_user_assignments,json=currentUserAssignments,proto3" json:"current_user_assignments,omitempty"`
-	// user_assignments describes the requested user's ownership and membership assignment types in the access list.
+	// user_assignments describes the requested user's ownership and membership assignment types in the Access List.
 	UserAssignments *UserAssignments `protobuf:"bytes,6,opt,name=user_assignments,json=userAssignments,proto3" json:"user_assignments,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// scoped_owner_of describes scoped Access Lists where this Access List is an explicit owner.
+	// Each item is the scope-qualified name of the owned scoped Access List.
+	ScopedOwnerOf []string `protobuf:"bytes,7,rep,name=scoped_owner_of,json=scopedOwnerOf,proto3" json:"scoped_owner_of,omitempty"`
+	// scoped_member_of describes scoped Access Lists where this Access List is an explicit member.
+	// Each item is the scope-qualified name of the parent scoped Access List.
+	ScopedMemberOf []string `protobuf:"bytes,8,rep,name=scoped_member_of,json=scopedMemberOf,proto3" json:"scoped_member_of,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *AccessListStatus) Reset() {
@@ -2233,6 +2329,20 @@ func (x *AccessListStatus) GetUserAssignments() *UserAssignments {
 	return nil
 }
 
+func (x *AccessListStatus) GetScopedOwnerOf() []string {
+	if x != nil {
+		return x.ScopedOwnerOf
+	}
+	return nil
+}
+
+func (x *AccessListStatus) GetScopedMemberOf() []string {
+	if x != nil {
+		return x.ScopedMemberOf
+	}
+	return nil
+}
+
 func (x *AccessListStatus) SetMemberCount(v uint32) {
 	x.MemberCount = &v
 }
@@ -2255,6 +2365,14 @@ func (x *AccessListStatus) SetCurrentUserAssignments(v *CurrentUserAssignments) 
 
 func (x *AccessListStatus) SetUserAssignments(v *UserAssignments) {
 	x.UserAssignments = v
+}
+
+func (x *AccessListStatus) SetScopedOwnerOf(v []string) {
+	x.ScopedOwnerOf = v
+}
+
+func (x *AccessListStatus) SetScopedMemberOf(v []string) {
+	x.ScopedMemberOf = v
 }
 
 func (x *AccessListStatus) HasMemberCount() bool {
@@ -2312,10 +2430,16 @@ type AccessListStatus_builder struct {
 	OwnerOf []string
 	// member_of describes Access Lists where this Access List is an explicit member.
 	MemberOf []string
-	// current_user_assignments describes the current user's ownership and membership status in the access list.
+	// current_user_assignments describes the current user's ownership and membership status in the Access List.
 	CurrentUserAssignments *CurrentUserAssignments
-	// user_assignments describes the requested user's ownership and membership assignment types in the access list.
+	// user_assignments describes the requested user's ownership and membership assignment types in the Access List.
 	UserAssignments *UserAssignments
+	// scoped_owner_of describes scoped Access Lists where this Access List is an explicit owner.
+	// Each item is the scope-qualified name of the owned scoped Access List.
+	ScopedOwnerOf []string
+	// scoped_member_of describes scoped Access Lists where this Access List is an explicit member.
+	// Each item is the scope-qualified name of the parent scoped Access List.
+	ScopedMemberOf []string
 }
 
 func (b0 AccessListStatus_builder) Build() *AccessListStatus {
@@ -2328,6 +2452,8 @@ func (b0 AccessListStatus_builder) Build() *AccessListStatus {
 	x.MemberOf = b.MemberOf
 	x.CurrentUserAssignments = b.CurrentUserAssignments
 	x.UserAssignments = b.UserAssignments
+	x.ScopedOwnerOf = b.ScopedOwnerOf
+	x.ScopedMemberOf = b.ScopedMemberOf
 	return m0
 }
 
@@ -2335,12 +2461,13 @@ var File_teleport_accesslist_v1_accesslist_proto protoreflect.FileDescriptor
 
 const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\n" +
-	"'teleport/accesslist/v1/accesslist.proto\x12\x16teleport.accesslist.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a'teleport/header/v1/resourceheader.proto\x1a\x1dteleport/trait/v1/trait.proto\"\xc6\x01\n" +
+	"'teleport/accesslist/v1/accesslist.proto\x12\x16teleport.accesslist.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a'teleport/header/v1/resourceheader.proto\x1a\x1dteleport/trait/v1/trait.proto\"\xdc\x01\n" +
 	"\n" +
 	"AccessList\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x12:\n" +
 	"\x04spec\x18\x02 \x01(\v2&.teleport.accesslist.v1.AccessListSpecR\x04spec\x12@\n" +
-	"\x06status\x18\x03 \x01(\v2(.teleport.accesslist.v1.AccessListStatusR\x06status\"\xd5\x04\n" +
+	"\x06status\x18\x03 \x01(\v2(.teleport.accesslist.v1.AccessListStatusR\x06status\x12\x14\n" +
+	"\x05scope\x18\x04 \x01(\tR\x05scope\"\xd5\x04\n" +
 	"\x0eAccessListSpec\x12 \n" +
 	"\vdescription\x18\x01 \x01(\tR\vdescription\x12?\n" +
 	"\x06owners\x18\x02 \x03(\v2'.teleport.accesslist.v1.AccessListOwnerR\x06owners\x12=\n" +
@@ -2381,10 +2508,11 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\fscoped_roles\x18\x03 \x03(\v2'.teleport.accesslist.v1.ScopedRoleGrantR\vscopedRoles\";\n" +
 	"\x0fScopedRoleGrant\x12\x12\n" +
 	"\x04role\x18\x01 \x01(\tR\x04role\x12\x14\n" +
-	"\x05scope\x18\x02 \x01(\tR\x05scope\"|\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"\x92\x01\n" +
 	"\x06Member\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x126\n" +
-	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.MemberSpecR\x04spec\"\x98\x03\n" +
+	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.MemberSpecR\x04spec\x12\x14\n" +
+	"\x05scope\x18\x03 \x01(\tR\x05scope\"\x98\x03\n" +
 	"\n" +
 	"MemberSpec\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
@@ -2396,10 +2524,11 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\badded_by\x18\x06 \x01(\tR\aaddedBy\x12U\n" +
 	"\x11ineligible_status\x18\a \x01(\x0e2(.teleport.accesslist.v1.IneligibleStatusR\x10ineligibleStatus\x12O\n" +
 	"\x0fmembership_kind\x18\t \x01(\x0e2&.teleport.accesslist.v1.MembershipKindR\x0emembershipKindJ\x04\b\b\x10\tR\n" +
-	"membership\"|\n" +
+	"membership\"\x92\x01\n" +
 	"\x06Review\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x126\n" +
-	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.ReviewSpecR\x04spec\"\xdf\x01\n" +
+	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.ReviewSpecR\x04spec\x12\x14\n" +
+	"\x05scope\x18\x03 \x01(\tR\x05scope\"\xdf\x01\n" +
 	"\n" +
 	"ReviewSpec\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
@@ -2408,25 +2537,28 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\vreview_date\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"reviewDate\x12\x14\n" +
 	"\x05notes\x18\x04 \x01(\tR\x05notes\x12?\n" +
-	"\achanges\x18\x05 \x01(\v2%.teleport.accesslist.v1.ReviewChangesR\achanges\"\x90\x03\n" +
+	"\achanges\x18\x05 \x01(\v2%.teleport.accesslist.v1.ReviewChangesR\achanges\"\xc6\x03\n" +
 	"\rReviewChanges\x12r\n" +
 	"\x1fmembership_requirements_changed\x18\x02 \x01(\v2*.teleport.accesslist.v1.AccessListRequiresR\x1dmembershipRequirementsChanged\x12'\n" +
 	"\x0fremoved_members\x18\x03 \x03(\tR\x0eremovedMembers\x12a\n" +
 	"\x18review_frequency_changed\x18\x04 \x01(\x0e2'.teleport.accesslist.v1.ReviewFrequencyR\x16reviewFrequencyChanged\x12f\n" +
-	"\x1breview_day_of_month_changed\x18\x05 \x01(\x0e2(.teleport.accesslist.v1.ReviewDayOfMonthR\x17reviewDayOfMonthChangedJ\x04\b\x01\x10\x02R\x11frequency_changed\"\xd4\x01\n" +
+	"\x1breview_day_of_month_changed\x18\x05 \x01(\x0e2(.teleport.accesslist.v1.ReviewDayOfMonthR\x17reviewDayOfMonthChanged\x124\n" +
+	"\x16scoped_removed_members\x18\x06 \x03(\tR\x14scopedRemovedMembersJ\x04\b\x01\x10\x02R\x11frequency_changed\"\xd4\x01\n" +
 	"\x16CurrentUserAssignments\x12[\n" +
 	"\x0eownership_type\x18\x01 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\rownershipType\x12]\n" +
 	"\x0fmembership_type\x18\x02 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\x0emembershipType\"\xcd\x01\n" +
 	"\x0fUserAssignments\x12[\n" +
 	"\x0eownership_type\x18\x01 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\rownershipType\x12]\n" +
-	"\x0fmembership_type\x18\x02 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\x0emembershipType\"\x88\x03\n" +
+	"\x0fmembership_type\x18\x02 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\x0emembershipType\"\xda\x03\n" +
 	"\x10AccessListStatus\x12&\n" +
 	"\fmember_count\x18\x01 \x01(\rH\x00R\vmemberCount\x88\x01\x01\x12/\n" +
 	"\x11member_list_count\x18\x02 \x01(\rH\x01R\x0fmemberListCount\x88\x01\x01\x12\x19\n" +
 	"\bowner_of\x18\x03 \x03(\tR\aownerOf\x12\x1b\n" +
 	"\tmember_of\x18\x04 \x03(\tR\bmemberOf\x12h\n" +
 	"\x18current_user_assignments\x18\x05 \x01(\v2..teleport.accesslist.v1.CurrentUserAssignmentsR\x16currentUserAssignments\x12R\n" +
-	"\x10user_assignments\x18\x06 \x01(\v2'.teleport.accesslist.v1.UserAssignmentsR\x0fuserAssignmentsB\x0f\n" +
+	"\x10user_assignments\x18\x06 \x01(\v2'.teleport.accesslist.v1.UserAssignmentsR\x0fuserAssignments\x12&\n" +
+	"\x0fscoped_owner_of\x18\a \x03(\tR\rscopedOwnerOf\x12(\n" +
+	"\x10scoped_member_of\x18\b \x03(\tR\x0escopedMemberOfB\x0f\n" +
 	"\r_member_countB\x14\n" +
 	"\x12_member_list_count*\xb6\x01\n" +
 	"\x0fReviewFrequency\x12 \n" +
@@ -2439,11 +2571,12 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\x1fREVIEW_DAY_OF_MONTH_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19REVIEW_DAY_OF_MONTH_FIRST\x10\x01\x12!\n" +
 	"\x1dREVIEW_DAY_OF_MONTH_FIFTEENTH\x10\x0f\x12\x1c\n" +
-	"\x18REVIEW_DAY_OF_MONTH_LAST\x10\x1f*e\n" +
+	"\x18REVIEW_DAY_OF_MONTH_LAST\x10\x1f*\x86\x01\n" +
 	"\x0eMembershipKind\x12\x1f\n" +
 	"\x1bMEMBERSHIP_KIND_UNSPECIFIED\x10\x00\x12\x18\n" +
 	"\x14MEMBERSHIP_KIND_USER\x10\x01\x12\x18\n" +
-	"\x14MEMBERSHIP_KIND_LIST\x10\x02*\xc6\x01\n" +
+	"\x14MEMBERSHIP_KIND_LIST\x10\x02\x12\x1f\n" +
+	"\x1bMEMBERSHIP_KIND_SCOPED_LIST\x10\x03*\xc6\x01\n" +
 	"\x10IneligibleStatus\x12!\n" +
 	"\x1dINELIGIBLE_STATUS_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aINELIGIBLE_STATUS_ELIGIBLE\x10\x01\x12$\n" +

--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_protohybrid.pb.go
@@ -1279,7 +1279,7 @@ func (b0 AccessListGrants_builder) Build() *AccessListGrants {
 // ScopedRoleGrant describes a scoped role granted at a specific scope.
 type ScopedRoleGrant struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
-	// role is scope-qualified name of the scoped role to be granted.
+	// role is the scope-qualified name of the scoped role to be granted.
 	Role string `protobuf:"bytes,1,opt,name=role,proto3" json:"role,omitempty"`
 	// scope is the scope the role will be granted at. It must be an assignable
 	// scope of the role.
@@ -1338,7 +1338,7 @@ func (x *ScopedRoleGrant) SetScope(v string) {
 type ScopedRoleGrant_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// role is scope-qualified name of the scoped role to be granted.
+	// role is the scope-qualified name of the scoped role to be granted.
 	Role string
 	// scope is the scope the role will be granted at. It must be an assignable
 	// scope of the role.

--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_protoopaque.pb.go
@@ -150,6 +150,8 @@ const (
 	MembershipKind_MEMBERSHIP_KIND_USER MembershipKind = 1
 	// MEMBERSHIP_KIND_LIST represents list members that are nested Access Lists
 	MembershipKind_MEMBERSHIP_KIND_LIST MembershipKind = 2
+	// MEMBERSHIP_KIND_SCOPED_LIST represents list members that are nested scoped Access Lists
+	MembershipKind_MEMBERSHIP_KIND_SCOPED_LIST MembershipKind = 3
 )
 
 // Enum value maps for MembershipKind.
@@ -158,11 +160,13 @@ var (
 		0: "MEMBERSHIP_KIND_UNSPECIFIED",
 		1: "MEMBERSHIP_KIND_USER",
 		2: "MEMBERSHIP_KIND_LIST",
+		3: "MEMBERSHIP_KIND_SCOPED_LIST",
 	}
 	MembershipKind_value = map[string]int32{
 		"MEMBERSHIP_KIND_UNSPECIFIED": 0,
 		"MEMBERSHIP_KIND_USER":        1,
 		"MEMBERSHIP_KIND_LIST":        2,
+		"MEMBERSHIP_KIND_SCOPED_LIST": 3,
 	}
 )
 
@@ -248,8 +252,8 @@ func (x IneligibleStatus) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// AccessListUserAssignmentType describes the type of membership anr/or ownership
-// a user has in an access list.
+// AccessListUserAssignmentType describes the type of membership and/or ownership
+// a user has in an Access List.
 type AccessListUserAssignmentType int32
 
 const (
@@ -305,6 +309,7 @@ type AccessList struct {
 	xxx_hidden_Header *v1.ResourceHeader     `protobuf:"bytes,1,opt,name=header,proto3"`
 	xxx_hidden_Spec   *AccessListSpec        `protobuf:"bytes,2,opt,name=spec,proto3"`
 	xxx_hidden_Status *AccessListStatus      `protobuf:"bytes,3,opt,name=status,proto3"`
+	xxx_hidden_Scope  string                 `protobuf:"bytes,4,opt,name=scope,proto3"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -355,6 +360,13 @@ func (x *AccessList) GetStatus() *AccessListStatus {
 	return nil
 }
 
+func (x *AccessList) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
 func (x *AccessList) SetHeader(v *v1.ResourceHeader) {
 	x.xxx_hidden_Header = v
 }
@@ -365,6 +377,10 @@ func (x *AccessList) SetSpec(v *AccessListSpec) {
 
 func (x *AccessList) SetStatus(v *AccessListStatus) {
 	x.xxx_hidden_Status = v
+}
+
+func (x *AccessList) SetScope(v string) {
+	x.xxx_hidden_Scope = v
 }
 
 func (x *AccessList) HasHeader() bool {
@@ -409,6 +425,8 @@ type AccessList_builder struct {
 	Spec *AccessListSpec
 	// status contains dynamically calculated fields.
 	Status *AccessListStatus
+	// scope is the scope of the Access List.
+	Scope string
 }
 
 func (b0 AccessList_builder) Build() *AccessList {
@@ -418,6 +436,7 @@ func (b0 AccessList_builder) Build() *AccessList {
 	x.xxx_hidden_Header = b.Header
 	x.xxx_hidden_Spec = b.Spec
 	x.xxx_hidden_Status = b.Status
+	x.xxx_hidden_Scope = b.Scope
 	return m0
 }
 
@@ -748,7 +767,10 @@ func (x *AccessListOwner) SetMembershipKind(v MembershipKind) {
 type AccessListOwner_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// name is the username of the owner.
+	// name is the name of the owner, depending on MembershipKind:
+	// MEMBERSHIP_KIND_USER: the username of the owner.
+	// MEMBERSHIP_KIND_LIST: the name of the owner Access List.
+	// MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the owner Access List.
 	Name string
 	// description is the plaintext description of the owner and why they are an
 	// owner.
@@ -757,7 +779,7 @@ type AccessListOwner_builder struct {
 	// and if not, describes how they're lacking eligibility.
 	IneligibleStatus IneligibleStatus
 	// membership_kind describes the type of membership, either
-	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
 	MembershipKind MembershipKind
 }
 
@@ -1274,9 +1296,9 @@ func (x *ScopedRoleGrant) SetScope(v string) {
 type ScopedRoleGrant_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// role is the name of the scoped role to be granted.
+	// role is scope-qualified name of the scoped role to be granted.
 	Role string
-	// scope is the scope the role will be assigned at. It must be an assignable
+	// scope is the scope the role will be granted at. It must be an assignable
 	// scope of the role.
 	Scope string
 }
@@ -1295,6 +1317,7 @@ type Member struct {
 	state             protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_Header *v1.ResourceHeader     `protobuf:"bytes,1,opt,name=header,proto3"`
 	xxx_hidden_Spec   *MemberSpec            `protobuf:"bytes,2,opt,name=spec,proto3"`
+	xxx_hidden_Scope  string                 `protobuf:"bytes,3,opt,name=scope,proto3"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -1338,12 +1361,23 @@ func (x *Member) GetSpec() *MemberSpec {
 	return nil
 }
 
+func (x *Member) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
 func (x *Member) SetHeader(v *v1.ResourceHeader) {
 	x.xxx_hidden_Header = v
 }
 
 func (x *Member) SetSpec(v *MemberSpec) {
 	x.xxx_hidden_Spec = v
+}
+
+func (x *Member) SetScope(v string) {
+	x.xxx_hidden_Scope = v
 }
 
 func (x *Member) HasHeader() bool {
@@ -1375,6 +1409,9 @@ type Member_builder struct {
 	Header *v1.ResourceHeader
 	// spec is the specification for the Access List member.
 	Spec *MemberSpec
+	// scope is the scope of the Access List member, it must be equal to the
+	// scope of the parent Access List.
+	Scope string
 }
 
 func (b0 Member_builder) Build() *Member {
@@ -1383,6 +1420,7 @@ func (b0 Member_builder) Build() *Member {
 	_, _ = b, x
 	x.xxx_hidden_Header = b.Header
 	x.xxx_hidden_Spec = b.Spec
+	x.xxx_hidden_Scope = b.Scope
 	return m0
 }
 
@@ -1541,7 +1579,10 @@ type MemberSpec_builder struct {
 
 	// associated Access List
 	AccessList string
-	// name is the name of the member of the Access List.
+	// name is the name of the member of the Access List, depending on MembershipKind:
+	// MEMBERSHIP_KIND_USER: the username of the member.
+	// MEMBERSHIP_KIND_LIST: the name of the member Access List.
+	// MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the member scope Access List.
 	Name string
 	// joined is when the user joined the Access List.
 	Joined *timestamppb.Timestamp
@@ -1555,7 +1596,7 @@ type MemberSpec_builder struct {
 	// and if not, describes how they're lacking eligibility.
 	IneligibleStatus IneligibleStatus
 	// membership_kind describes the type of membership, either
-	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
 	MembershipKind MembershipKind
 }
 
@@ -1579,6 +1620,7 @@ type Review struct {
 	state             protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_Header *v1.ResourceHeader     `protobuf:"bytes,1,opt,name=header,proto3"`
 	xxx_hidden_Spec   *ReviewSpec            `protobuf:"bytes,2,opt,name=spec,proto3"`
+	xxx_hidden_Scope  string                 `protobuf:"bytes,3,opt,name=scope,proto3"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -1622,12 +1664,23 @@ func (x *Review) GetSpec() *ReviewSpec {
 	return nil
 }
 
+func (x *Review) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
 func (x *Review) SetHeader(v *v1.ResourceHeader) {
 	x.xxx_hidden_Header = v
 }
 
 func (x *Review) SetSpec(v *ReviewSpec) {
 	x.xxx_hidden_Spec = v
+}
+
+func (x *Review) SetScope(v string) {
+	x.xxx_hidden_Scope = v
 }
 
 func (x *Review) HasHeader() bool {
@@ -1659,6 +1712,9 @@ type Review_builder struct {
 	Header *v1.ResourceHeader
 	// spec is the specification for the Access List review.
 	Spec *ReviewSpec
+	// scope is the scope of the Access List review. It must be equal to the
+	// scope of the reviewed Access List.
+	Scope string
 }
 
 func (b0 Review_builder) Build() *Review {
@@ -1667,6 +1723,7 @@ func (b0 Review_builder) Build() *Review {
 	_, _ = b, x
 	x.xxx_hidden_Header = b.Header
 	x.xxx_hidden_Spec = b.Spec
+	x.xxx_hidden_Scope = b.Scope
 	return m0
 }
 
@@ -1788,6 +1845,8 @@ type ReviewSpec_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
 	// access_list is the name of the Access List that this review is for.
+	// If the review is scoped, this is the scope-qualified name of the reviewed
+	// scoped Access List.
 	AccessList string
 	// reviewers are the users who performed the review.
 	Reviewers []string
@@ -1819,6 +1878,7 @@ type ReviewChanges struct {
 	xxx_hidden_RemovedMembers                []string               `protobuf:"bytes,3,rep,name=removed_members,json=removedMembers,proto3"`
 	xxx_hidden_ReviewFrequencyChanged        ReviewFrequency        `protobuf:"varint,4,opt,name=review_frequency_changed,json=reviewFrequencyChanged,proto3,enum=teleport.accesslist.v1.ReviewFrequency"`
 	xxx_hidden_ReviewDayOfMonthChanged       ReviewDayOfMonth       `protobuf:"varint,5,opt,name=review_day_of_month_changed,json=reviewDayOfMonthChanged,proto3,enum=teleport.accesslist.v1.ReviewDayOfMonth"`
+	xxx_hidden_ScopedRemovedMembers          []string               `protobuf:"bytes,6,rep,name=scoped_removed_members,json=scopedRemovedMembers,proto3"`
 	unknownFields                            protoimpl.UnknownFields
 	sizeCache                                protoimpl.SizeCache
 }
@@ -1876,6 +1936,13 @@ func (x *ReviewChanges) GetReviewDayOfMonthChanged() ReviewDayOfMonth {
 	return ReviewDayOfMonth_REVIEW_DAY_OF_MONTH_UNSPECIFIED
 }
 
+func (x *ReviewChanges) GetScopedRemovedMembers() []string {
+	if x != nil {
+		return x.xxx_hidden_ScopedRemovedMembers
+	}
+	return nil
+}
+
 func (x *ReviewChanges) SetMembershipRequirementsChanged(v *AccessListRequires) {
 	x.xxx_hidden_MembershipRequirementsChanged = v
 }
@@ -1890,6 +1957,10 @@ func (x *ReviewChanges) SetReviewFrequencyChanged(v ReviewFrequency) {
 
 func (x *ReviewChanges) SetReviewDayOfMonthChanged(v ReviewDayOfMonth) {
 	x.xxx_hidden_ReviewDayOfMonthChanged = v
+}
+
+func (x *ReviewChanges) SetScopedRemovedMembers(v []string) {
+	x.xxx_hidden_ScopedRemovedMembers = v
 }
 
 func (x *ReviewChanges) HasMembershipRequirementsChanged() bool {
@@ -1917,6 +1988,9 @@ type ReviewChanges_builder struct {
 	// review_day_of_month_changed is populated if the review day of month has
 	// changed.
 	ReviewDayOfMonthChanged ReviewDayOfMonth
+	// scoped_removed_members contains the scope-qualified names of members that
+	// were removed as part of this review.
+	ScopedRemovedMembers []string
 }
 
 func (b0 ReviewChanges_builder) Build() *ReviewChanges {
@@ -1927,10 +2001,11 @@ func (b0 ReviewChanges_builder) Build() *ReviewChanges {
 	x.xxx_hidden_RemovedMembers = b.RemovedMembers
 	x.xxx_hidden_ReviewFrequencyChanged = b.ReviewFrequencyChanged
 	x.xxx_hidden_ReviewDayOfMonthChanged = b.ReviewDayOfMonthChanged
+	x.xxx_hidden_ScopedRemovedMembers = b.ScopedRemovedMembers
 	return m0
 }
 
-// CurrentUserAssignments describes the current user's ownership and membership status in the access list.
+// CurrentUserAssignments describes the current user's ownership and membership status in the Access List.
 type CurrentUserAssignments struct {
 	state                     protoimpl.MessageState       `protogen:"opaque.v1"`
 	xxx_hidden_OwnershipType  AccessListUserAssignmentType `protobuf:"varint,1,opt,name=ownership_type,json=ownershipType,proto3,enum=teleport.accesslist.v1.AccessListUserAssignmentType"`
@@ -1989,9 +2064,9 @@ func (x *CurrentUserAssignments) SetMembershipType(v AccessListUserAssignmentTyp
 type CurrentUserAssignments_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// ownership_type represents the current user's ownership type (explicit, inherited, or none) in the access list.
+	// ownership_type represents the current user's ownership type (explicit, inherited, or none) in the Access List.
 	OwnershipType AccessListUserAssignmentType
-	// membership_type represents the current user's membership type (explicit, inherited, or none) in the access list.
+	// membership_type represents the current user's membership type (explicit, inherited, or none) in the Access List.
 	MembershipType AccessListUserAssignmentType
 }
 
@@ -2004,7 +2079,7 @@ func (b0 CurrentUserAssignments_builder) Build() *CurrentUserAssignments {
 	return m0
 }
 
-// UserAssignments describes the requested user's ownership and membership assignment types in the access list.
+// UserAssignments describes the requested user's ownership and membership assignment types in the Access List.
 type UserAssignments struct {
 	state                     protoimpl.MessageState       `protogen:"opaque.v1"`
 	xxx_hidden_OwnershipType  AccessListUserAssignmentType `protobuf:"varint,1,opt,name=ownership_type,json=ownershipType,proto3,enum=teleport.accesslist.v1.AccessListUserAssignmentType"`
@@ -2063,9 +2138,9 @@ func (x *UserAssignments) SetMembershipType(v AccessListUserAssignmentType) {
 type UserAssignments_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the access list.
+	// ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the Access List.
 	OwnershipType AccessListUserAssignmentType
-	// membership_type represents the requested user's membership type (explicit, inherited, or none) in the access list.
+	// membership_type represents the requested user's membership type (explicit, inherited, or none) in the Access List.
 	MembershipType AccessListUserAssignmentType
 }
 
@@ -2087,6 +2162,8 @@ type AccessListStatus struct {
 	xxx_hidden_MemberOf               []string                `protobuf:"bytes,4,rep,name=member_of,json=memberOf,proto3"`
 	xxx_hidden_CurrentUserAssignments *CurrentUserAssignments `protobuf:"bytes,5,opt,name=current_user_assignments,json=currentUserAssignments,proto3"`
 	xxx_hidden_UserAssignments        *UserAssignments        `protobuf:"bytes,6,opt,name=user_assignments,json=userAssignments,proto3"`
+	xxx_hidden_ScopedOwnerOf          []string                `protobuf:"bytes,7,rep,name=scoped_owner_of,json=scopedOwnerOf,proto3"`
+	xxx_hidden_ScopedMemberOf         []string                `protobuf:"bytes,8,rep,name=scoped_member_of,json=scopedMemberOf,proto3"`
 	XXX_raceDetectHookData            protoimpl.RaceDetectHookData
 	XXX_presence                      [1]uint32
 	unknownFields                     protoimpl.UnknownFields
@@ -2160,14 +2237,28 @@ func (x *AccessListStatus) GetUserAssignments() *UserAssignments {
 	return nil
 }
 
+func (x *AccessListStatus) GetScopedOwnerOf() []string {
+	if x != nil {
+		return x.xxx_hidden_ScopedOwnerOf
+	}
+	return nil
+}
+
+func (x *AccessListStatus) GetScopedMemberOf() []string {
+	if x != nil {
+		return x.xxx_hidden_ScopedMemberOf
+	}
+	return nil
+}
+
 func (x *AccessListStatus) SetMemberCount(v uint32) {
 	x.xxx_hidden_MemberCount = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 6)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 8)
 }
 
 func (x *AccessListStatus) SetMemberListCount(v uint32) {
 	x.xxx_hidden_MemberListCount = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 6)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 8)
 }
 
 func (x *AccessListStatus) SetOwnerOf(v []string) {
@@ -2184,6 +2275,14 @@ func (x *AccessListStatus) SetCurrentUserAssignments(v *CurrentUserAssignments) 
 
 func (x *AccessListStatus) SetUserAssignments(v *UserAssignments) {
 	x.xxx_hidden_UserAssignments = v
+}
+
+func (x *AccessListStatus) SetScopedOwnerOf(v []string) {
+	x.xxx_hidden_ScopedOwnerOf = v
+}
+
+func (x *AccessListStatus) SetScopedMemberOf(v []string) {
+	x.xxx_hidden_ScopedMemberOf = v
 }
 
 func (x *AccessListStatus) HasMemberCount() bool {
@@ -2243,10 +2342,16 @@ type AccessListStatus_builder struct {
 	OwnerOf []string
 	// member_of describes Access Lists where this Access List is an explicit member.
 	MemberOf []string
-	// current_user_assignments describes the current user's ownership and membership status in the access list.
+	// current_user_assignments describes the current user's ownership and membership status in the Access List.
 	CurrentUserAssignments *CurrentUserAssignments
-	// user_assignments describes the requested user's ownership and membership assignment types in the access list.
+	// user_assignments describes the requested user's ownership and membership assignment types in the Access List.
 	UserAssignments *UserAssignments
+	// scoped_owner_of describes scoped Access Lists where this Access List is an explicit owner.
+	// Each item is the scope-qualified name of the owned scoped Access List.
+	ScopedOwnerOf []string
+	// scoped_member_of describes scoped Access Lists where this Access List is an explicit member.
+	// Each item is the scope-qualified name of the parent scoped Access List.
+	ScopedMemberOf []string
 }
 
 func (b0 AccessListStatus_builder) Build() *AccessListStatus {
@@ -2254,17 +2359,19 @@ func (b0 AccessListStatus_builder) Build() *AccessListStatus {
 	b, x := &b0, m0
 	_, _ = b, x
 	if b.MemberCount != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 6)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 8)
 		x.xxx_hidden_MemberCount = *b.MemberCount
 	}
 	if b.MemberListCount != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 6)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 8)
 		x.xxx_hidden_MemberListCount = *b.MemberListCount
 	}
 	x.xxx_hidden_OwnerOf = b.OwnerOf
 	x.xxx_hidden_MemberOf = b.MemberOf
 	x.xxx_hidden_CurrentUserAssignments = b.CurrentUserAssignments
 	x.xxx_hidden_UserAssignments = b.UserAssignments
+	x.xxx_hidden_ScopedOwnerOf = b.ScopedOwnerOf
+	x.xxx_hidden_ScopedMemberOf = b.ScopedMemberOf
 	return m0
 }
 
@@ -2272,12 +2379,13 @@ var File_teleport_accesslist_v1_accesslist_proto protoreflect.FileDescriptor
 
 const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\n" +
-	"'teleport/accesslist/v1/accesslist.proto\x12\x16teleport.accesslist.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a'teleport/header/v1/resourceheader.proto\x1a\x1dteleport/trait/v1/trait.proto\"\xc6\x01\n" +
+	"'teleport/accesslist/v1/accesslist.proto\x12\x16teleport.accesslist.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a'teleport/header/v1/resourceheader.proto\x1a\x1dteleport/trait/v1/trait.proto\"\xdc\x01\n" +
 	"\n" +
 	"AccessList\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x12:\n" +
 	"\x04spec\x18\x02 \x01(\v2&.teleport.accesslist.v1.AccessListSpecR\x04spec\x12@\n" +
-	"\x06status\x18\x03 \x01(\v2(.teleport.accesslist.v1.AccessListStatusR\x06status\"\xd5\x04\n" +
+	"\x06status\x18\x03 \x01(\v2(.teleport.accesslist.v1.AccessListStatusR\x06status\x12\x14\n" +
+	"\x05scope\x18\x04 \x01(\tR\x05scope\"\xd5\x04\n" +
 	"\x0eAccessListSpec\x12 \n" +
 	"\vdescription\x18\x01 \x01(\tR\vdescription\x12?\n" +
 	"\x06owners\x18\x02 \x03(\v2'.teleport.accesslist.v1.AccessListOwnerR\x06owners\x12=\n" +
@@ -2318,10 +2426,11 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\fscoped_roles\x18\x03 \x03(\v2'.teleport.accesslist.v1.ScopedRoleGrantR\vscopedRoles\";\n" +
 	"\x0fScopedRoleGrant\x12\x12\n" +
 	"\x04role\x18\x01 \x01(\tR\x04role\x12\x14\n" +
-	"\x05scope\x18\x02 \x01(\tR\x05scope\"|\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"\x92\x01\n" +
 	"\x06Member\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x126\n" +
-	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.MemberSpecR\x04spec\"\x98\x03\n" +
+	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.MemberSpecR\x04spec\x12\x14\n" +
+	"\x05scope\x18\x03 \x01(\tR\x05scope\"\x98\x03\n" +
 	"\n" +
 	"MemberSpec\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
@@ -2333,10 +2442,11 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\badded_by\x18\x06 \x01(\tR\aaddedBy\x12U\n" +
 	"\x11ineligible_status\x18\a \x01(\x0e2(.teleport.accesslist.v1.IneligibleStatusR\x10ineligibleStatus\x12O\n" +
 	"\x0fmembership_kind\x18\t \x01(\x0e2&.teleport.accesslist.v1.MembershipKindR\x0emembershipKindJ\x04\b\b\x10\tR\n" +
-	"membership\"|\n" +
+	"membership\"\x92\x01\n" +
 	"\x06Review\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x126\n" +
-	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.ReviewSpecR\x04spec\"\xdf\x01\n" +
+	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.ReviewSpecR\x04spec\x12\x14\n" +
+	"\x05scope\x18\x03 \x01(\tR\x05scope\"\xdf\x01\n" +
 	"\n" +
 	"ReviewSpec\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
@@ -2345,25 +2455,28 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\vreview_date\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"reviewDate\x12\x14\n" +
 	"\x05notes\x18\x04 \x01(\tR\x05notes\x12?\n" +
-	"\achanges\x18\x05 \x01(\v2%.teleport.accesslist.v1.ReviewChangesR\achanges\"\x90\x03\n" +
+	"\achanges\x18\x05 \x01(\v2%.teleport.accesslist.v1.ReviewChangesR\achanges\"\xc6\x03\n" +
 	"\rReviewChanges\x12r\n" +
 	"\x1fmembership_requirements_changed\x18\x02 \x01(\v2*.teleport.accesslist.v1.AccessListRequiresR\x1dmembershipRequirementsChanged\x12'\n" +
 	"\x0fremoved_members\x18\x03 \x03(\tR\x0eremovedMembers\x12a\n" +
 	"\x18review_frequency_changed\x18\x04 \x01(\x0e2'.teleport.accesslist.v1.ReviewFrequencyR\x16reviewFrequencyChanged\x12f\n" +
-	"\x1breview_day_of_month_changed\x18\x05 \x01(\x0e2(.teleport.accesslist.v1.ReviewDayOfMonthR\x17reviewDayOfMonthChangedJ\x04\b\x01\x10\x02R\x11frequency_changed\"\xd4\x01\n" +
+	"\x1breview_day_of_month_changed\x18\x05 \x01(\x0e2(.teleport.accesslist.v1.ReviewDayOfMonthR\x17reviewDayOfMonthChanged\x124\n" +
+	"\x16scoped_removed_members\x18\x06 \x03(\tR\x14scopedRemovedMembersJ\x04\b\x01\x10\x02R\x11frequency_changed\"\xd4\x01\n" +
 	"\x16CurrentUserAssignments\x12[\n" +
 	"\x0eownership_type\x18\x01 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\rownershipType\x12]\n" +
 	"\x0fmembership_type\x18\x02 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\x0emembershipType\"\xcd\x01\n" +
 	"\x0fUserAssignments\x12[\n" +
 	"\x0eownership_type\x18\x01 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\rownershipType\x12]\n" +
-	"\x0fmembership_type\x18\x02 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\x0emembershipType\"\x88\x03\n" +
+	"\x0fmembership_type\x18\x02 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\x0emembershipType\"\xda\x03\n" +
 	"\x10AccessListStatus\x12&\n" +
 	"\fmember_count\x18\x01 \x01(\rH\x00R\vmemberCount\x88\x01\x01\x12/\n" +
 	"\x11member_list_count\x18\x02 \x01(\rH\x01R\x0fmemberListCount\x88\x01\x01\x12\x19\n" +
 	"\bowner_of\x18\x03 \x03(\tR\aownerOf\x12\x1b\n" +
 	"\tmember_of\x18\x04 \x03(\tR\bmemberOf\x12h\n" +
 	"\x18current_user_assignments\x18\x05 \x01(\v2..teleport.accesslist.v1.CurrentUserAssignmentsR\x16currentUserAssignments\x12R\n" +
-	"\x10user_assignments\x18\x06 \x01(\v2'.teleport.accesslist.v1.UserAssignmentsR\x0fuserAssignmentsB\x0f\n" +
+	"\x10user_assignments\x18\x06 \x01(\v2'.teleport.accesslist.v1.UserAssignmentsR\x0fuserAssignments\x12&\n" +
+	"\x0fscoped_owner_of\x18\a \x03(\tR\rscopedOwnerOf\x12(\n" +
+	"\x10scoped_member_of\x18\b \x03(\tR\x0escopedMemberOfB\x0f\n" +
 	"\r_member_countB\x14\n" +
 	"\x12_member_list_count*\xb6\x01\n" +
 	"\x0fReviewFrequency\x12 \n" +
@@ -2376,11 +2489,12 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\x1fREVIEW_DAY_OF_MONTH_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19REVIEW_DAY_OF_MONTH_FIRST\x10\x01\x12!\n" +
 	"\x1dREVIEW_DAY_OF_MONTH_FIFTEENTH\x10\x0f\x12\x1c\n" +
-	"\x18REVIEW_DAY_OF_MONTH_LAST\x10\x1f*e\n" +
+	"\x18REVIEW_DAY_OF_MONTH_LAST\x10\x1f*\x86\x01\n" +
 	"\x0eMembershipKind\x12\x1f\n" +
 	"\x1bMEMBERSHIP_KIND_UNSPECIFIED\x10\x00\x12\x18\n" +
 	"\x14MEMBERSHIP_KIND_USER\x10\x01\x12\x18\n" +
-	"\x14MEMBERSHIP_KIND_LIST\x10\x02*\xc6\x01\n" +
+	"\x14MEMBERSHIP_KIND_LIST\x10\x02\x12\x1f\n" +
+	"\x1bMEMBERSHIP_KIND_SCOPED_LIST\x10\x03*\xc6\x01\n" +
 	"\x10IneligibleStatus\x12!\n" +
 	"\x1dINELIGIBLE_STATUS_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aINELIGIBLE_STATUS_ELIGIBLE\x10\x01\x12$\n" +

--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_protoopaque.pb.go
@@ -1296,7 +1296,7 @@ func (x *ScopedRoleGrant) SetScope(v string) {
 type ScopedRoleGrant_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// role is scope-qualified name of the scoped role to be granted.
+	// role is the scope-qualified name of the scoped role to be granted.
 	Role string
 	// scope is the scope the role will be granted at. It must be an assignable
 	// scope of the role.

--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_service_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_service_protohybrid.pb.go
@@ -23,6 +23,7 @@
 package accesslistv1
 
 import (
+	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	types "github.com/gravitational/teleport/api/types"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -305,7 +306,11 @@ type ListAccessListsV2Request struct {
 	// sort_by specifies the sort order for the results.
 	SortBy *types.SortBy `protobuf:"bytes,3,opt,name=sort_by,json=sortBy,proto3" json:"sort_by,omitempty"`
 	// filter is a collection of fields to filter access lists.
-	Filter        *AccessListsFilter `protobuf:"bytes,4,opt,name=filter,proto3" json:"filter,omitempty"`
+	Filter *AccessListsFilter `protobuf:"bytes,4,opt,name=filter,proto3" json:"filter,omitempty"`
+	// scope_filter filters access lists by scope. Defaults to one of EXACT or
+	// UNSCOPED depending on whether the caller is a scoped or unscoped identity.
+	// Exhaustive user-facing views (e.g. `tctl get`) should specify mode ALL.
+	ScopeFilter   *v1.Filter `protobuf:"bytes,5,opt,name=scope_filter,json=scopeFilter,proto3" json:"scope_filter,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -363,6 +368,13 @@ func (x *ListAccessListsV2Request) GetFilter() *AccessListsFilter {
 	return nil
 }
 
+func (x *ListAccessListsV2Request) GetScopeFilter() *v1.Filter {
+	if x != nil {
+		return x.ScopeFilter
+	}
+	return nil
+}
+
 func (x *ListAccessListsV2Request) SetPageSize(v int32) {
 	x.PageSize = v
 }
@@ -379,6 +391,10 @@ func (x *ListAccessListsV2Request) SetFilter(v *AccessListsFilter) {
 	x.Filter = v
 }
 
+func (x *ListAccessListsV2Request) SetScopeFilter(v *v1.Filter) {
+	x.ScopeFilter = v
+}
+
 func (x *ListAccessListsV2Request) HasSortBy() bool {
 	if x == nil {
 		return false
@@ -393,12 +409,23 @@ func (x *ListAccessListsV2Request) HasFilter() bool {
 	return x.Filter != nil
 }
 
+func (x *ListAccessListsV2Request) HasScopeFilter() bool {
+	if x == nil {
+		return false
+	}
+	return x.ScopeFilter != nil
+}
+
 func (x *ListAccessListsV2Request) ClearSortBy() {
 	x.SortBy = nil
 }
 
 func (x *ListAccessListsV2Request) ClearFilter() {
 	x.Filter = nil
+}
+
+func (x *ListAccessListsV2Request) ClearScopeFilter() {
+	x.ScopeFilter = nil
 }
 
 type ListAccessListsV2Request_builder struct {
@@ -412,6 +439,10 @@ type ListAccessListsV2Request_builder struct {
 	SortBy *types.SortBy
 	// filter is a collection of fields to filter access lists.
 	Filter *AccessListsFilter
+	// scope_filter filters access lists by scope. Defaults to one of EXACT or
+	// UNSCOPED depending on whether the caller is a scoped or unscoped identity.
+	// Exhaustive user-facing views (e.g. `tctl get`) should specify mode ALL.
+	ScopeFilter *v1.Filter
 }
 
 func (b0 ListAccessListsV2Request_builder) Build() *ListAccessListsV2Request {
@@ -422,6 +453,7 @@ func (b0 ListAccessListsV2Request_builder) Build() *ListAccessListsV2Request {
 	x.PageToken = b.PageToken
 	x.SortBy = b.SortBy
 	x.Filter = b.Filter
+	x.ScopeFilter = b.ScopeFilter
 	return m0
 }
 
@@ -1545,7 +1577,11 @@ type ListAllAccessListMembersRequest struct {
 	// page_size is the size of the page to request.
 	PageSize int32 `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
 	// page_token is the page token.
-	PageToken     string `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	PageToken string `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	// scope_filter filters access list members by their resource scope. Defaults
+	// to one of EXACT or UNSCOPED depending on whether the caller is a scoped or
+	// unscoped identity.
+	ScopeFilter   *v1.Filter `protobuf:"bytes,3,opt,name=scope_filter,json=scopeFilter,proto3" json:"scope_filter,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1589,12 +1625,34 @@ func (x *ListAllAccessListMembersRequest) GetPageToken() string {
 	return ""
 }
 
+func (x *ListAllAccessListMembersRequest) GetScopeFilter() *v1.Filter {
+	if x != nil {
+		return x.ScopeFilter
+	}
+	return nil
+}
+
 func (x *ListAllAccessListMembersRequest) SetPageSize(v int32) {
 	x.PageSize = v
 }
 
 func (x *ListAllAccessListMembersRequest) SetPageToken(v string) {
 	x.PageToken = v
+}
+
+func (x *ListAllAccessListMembersRequest) SetScopeFilter(v *v1.Filter) {
+	x.ScopeFilter = v
+}
+
+func (x *ListAllAccessListMembersRequest) HasScopeFilter() bool {
+	if x == nil {
+		return false
+	}
+	return x.ScopeFilter != nil
+}
+
+func (x *ListAllAccessListMembersRequest) ClearScopeFilter() {
+	x.ScopeFilter = nil
 }
 
 type ListAllAccessListMembersRequest_builder struct {
@@ -1604,6 +1662,10 @@ type ListAllAccessListMembersRequest_builder struct {
 	PageSize int32
 	// page_token is the page token.
 	PageToken string
+	// scope_filter filters access list members by their resource scope. Defaults
+	// to one of EXACT or UNSCOPED depending on whether the caller is a scoped or
+	// unscoped identity.
+	ScopeFilter *v1.Filter
 }
 
 func (b0 ListAllAccessListMembersRequest_builder) Build() *ListAllAccessListMembersRequest {
@@ -1612,6 +1674,7 @@ func (b0 ListAllAccessListMembersRequest_builder) Build() *ListAllAccessListMemb
 	_, _ = b, x
 	x.PageSize = b.PageSize
 	x.PageToken = b.PageToken
+	x.ScopeFilter = b.ScopeFilter
 	return m0
 }
 
@@ -3163,7 +3226,10 @@ type ListAllAccessListReviewsRequest struct {
 	// page_size is the size of the page to request.
 	PageSize int32 `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
 	// next_token is the page token.
-	NextToken     string `protobuf:"bytes,2,opt,name=next_token,json=nextToken,proto3" json:"next_token,omitempty"`
+	NextToken string `protobuf:"bytes,2,opt,name=next_token,json=nextToken,proto3" json:"next_token,omitempty"`
+	// scope_filter filters reviews by scope. Defaults to one of EXACT or
+	// UNSCOPED depending on whether the caller is a scoped or unscoped identity.
+	ScopeFilter   *v1.Filter `protobuf:"bytes,3,opt,name=scope_filter,json=scopeFilter,proto3" json:"scope_filter,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3207,12 +3273,34 @@ func (x *ListAllAccessListReviewsRequest) GetNextToken() string {
 	return ""
 }
 
+func (x *ListAllAccessListReviewsRequest) GetScopeFilter() *v1.Filter {
+	if x != nil {
+		return x.ScopeFilter
+	}
+	return nil
+}
+
 func (x *ListAllAccessListReviewsRequest) SetPageSize(v int32) {
 	x.PageSize = v
 }
 
 func (x *ListAllAccessListReviewsRequest) SetNextToken(v string) {
 	x.NextToken = v
+}
+
+func (x *ListAllAccessListReviewsRequest) SetScopeFilter(v *v1.Filter) {
+	x.ScopeFilter = v
+}
+
+func (x *ListAllAccessListReviewsRequest) HasScopeFilter() bool {
+	if x == nil {
+		return false
+	}
+	return x.ScopeFilter != nil
+}
+
+func (x *ListAllAccessListReviewsRequest) ClearScopeFilter() {
+	x.ScopeFilter = nil
 }
 
 type ListAllAccessListReviewsRequest_builder struct {
@@ -3222,6 +3310,9 @@ type ListAllAccessListReviewsRequest_builder struct {
 	PageSize int32
 	// next_token is the page token.
 	NextToken string
+	// scope_filter filters reviews by scope. Defaults to one of EXACT or
+	// UNSCOPED depending on whether the caller is a scoped or unscoped identity.
+	ScopeFilter *v1.Filter
 }
 
 func (b0 ListAllAccessListReviewsRequest_builder) Build() *ListAllAccessListReviewsRequest {
@@ -3230,6 +3321,7 @@ func (b0 ListAllAccessListReviewsRequest_builder) Build() *ListAllAccessListRevi
 	_, _ = b, x
 	x.PageSize = b.PageSize
 	x.NextToken = b.NextToken
+	x.ScopeFilter = b.ScopeFilter
 	return m0
 }
 
@@ -4426,7 +4518,7 @@ var File_teleport_accesslist_v1_accesslist_service_proto protoreflect.FileDescri
 
 const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"\n" +
-	"/teleport/accesslist/v1/accesslist_service.proto\x12\x16teleport.accesslist.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a'teleport/accesslist/v1/accesslist.proto\x1a!teleport/legacy/types/types.proto\"\x17\n" +
+	"/teleport/accesslist/v1/accesslist_service.proto\x12\x16teleport.accesslist.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a'teleport/accesslist/v1/accesslist.proto\x1a!teleport/legacy/types/types.proto\x1a\x1fteleport/scopes/v1/scopes.proto\"\x17\n" +
 	"\x15GetAccessListsRequest\"_\n" +
 	"\x16GetAccessListsResponse\x12E\n" +
 	"\faccess_lists\x18\x01 \x03(\v2\".teleport.accesslist.v1.AccessListR\vaccessLists\"T\n" +
@@ -4437,13 +4529,14 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"\x17ListAccessListsResponse\x12E\n" +
 	"\faccess_lists\x18\x01 \x03(\v2\".teleport.accesslist.v1.AccessListR\vaccessLists\x12\x1d\n" +
 	"\n" +
-	"next_token\x18\x02 \x01(\tR\tnextToken\"\xc1\x01\n" +
+	"next_token\x18\x02 \x01(\tR\tnextToken\"\x80\x02\n" +
 	"\x18ListAccessListsV2Request\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
 	"page_token\x18\x02 \x01(\tR\tpageToken\x12&\n" +
 	"\asort_by\x18\x03 \x01(\v2\r.types.SortByR\x06sortBy\x12A\n" +
-	"\x06filter\x18\x04 \x01(\v2).teleport.accesslist.v1.AccessListsFilterR\x06filter\"q\n" +
+	"\x06filter\x18\x04 \x01(\v2).teleport.accesslist.v1.AccessListsFilterR\x06filter\x12=\n" +
+	"\fscope_filter\x18\x05 \x01(\v2\x1a.teleport.scopes.v1.FilterR\vscopeFilter\"q\n" +
 	"\x11AccessListsFilter\x12\x16\n" +
 	"\x06search\x18\x01 \x01(\tR\x06search\x12\x16\n" +
 	"\x06owners\x18\x02 \x03(\tR\x06owners\x12\x14\n" +
@@ -4489,11 +4582,12 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"\x11access_list_scope\x18\x04 \x01(\tR\x0faccessListScope\"\x81\x01\n" +
 	"\x1dListAccessListMembersResponse\x128\n" +
 	"\amembers\x18\x01 \x03(\v2\x1e.teleport.accesslist.v1.MemberR\amembers\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"]\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\x9c\x01\n" +
 	"\x1fListAllAccessListMembersRequest\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
-	"page_token\x18\x02 \x01(\tR\tpageToken\"\x84\x01\n" +
+	"page_token\x18\x02 \x01(\tR\tpageToken\x12=\n" +
+	"\fscope_filter\x18\x03 \x01(\v2\x1a.teleport.scopes.v1.FilterR\vscopeFilter\"\x84\x01\n" +
 	" ListAllAccessListMembersResponse\x128\n" +
 	"\amembers\x18\x01 \x03(\v2\x1e.teleport.accesslist.v1.MemberR\amembers\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\xa3\x01\n" +
@@ -4565,11 +4659,12 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"\x1dListAccessListReviewsResponse\x128\n" +
 	"\areviews\x18\x01 \x03(\v2\x1e.teleport.accesslist.v1.ReviewR\areviews\x12\x1d\n" +
 	"\n" +
-	"next_token\x18\x02 \x01(\tR\tnextToken\"]\n" +
+	"next_token\x18\x02 \x01(\tR\tnextToken\"\x9c\x01\n" +
 	"\x1fListAllAccessListReviewsRequest\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
-	"next_token\x18\x02 \x01(\tR\tnextToken\"{\n" +
+	"next_token\x18\x02 \x01(\tR\tnextToken\x12=\n" +
+	"\fscope_filter\x18\x03 \x01(\v2\x1a.teleport.scopes.v1.FilterR\vscopeFilter\"{\n" +
 	" ListAllAccessListReviewsResponse\x128\n" +
 	"\areviews\x18\x01 \x03(\v2\x1e.teleport.accesslist.v1.ReviewR\areviews\x12\x1d\n" +
 	"\n" +
@@ -4719,123 +4814,127 @@ var file_teleport_accesslist_v1_accesslist_service_proto_goTypes = []any{
 	(*UpdateAccessListWithPresetResponse)(nil),             // 54: teleport.accesslist.v1.UpdateAccessListWithPresetResponse
 	(*AccessList)(nil),                                     // 55: teleport.accesslist.v1.AccessList
 	(*types.SortBy)(nil),                                   // 56: types.SortBy
-	(*AccessListGrants)(nil),                               // 57: teleport.accesslist.v1.AccessListGrants
-	(*Member)(nil),                                         // 58: teleport.accesslist.v1.Member
-	(*AccessListOwner)(nil),                                // 59: teleport.accesslist.v1.AccessListOwner
-	(*Review)(nil),                                         // 60: teleport.accesslist.v1.Review
-	(*timestamppb.Timestamp)(nil),                          // 61: google.protobuf.Timestamp
-	(*types.AccessRequestV3)(nil),                          // 62: types.AccessRequestV3
-	(*types.RoleV6)(nil),                                   // 63: types.RoleV6
-	(*emptypb.Empty)(nil),                                  // 64: google.protobuf.Empty
+	(*v1.Filter)(nil),                                      // 57: teleport.scopes.v1.Filter
+	(*AccessListGrants)(nil),                               // 58: teleport.accesslist.v1.AccessListGrants
+	(*Member)(nil),                                         // 59: teleport.accesslist.v1.Member
+	(*AccessListOwner)(nil),                                // 60: teleport.accesslist.v1.AccessListOwner
+	(*Review)(nil),                                         // 61: teleport.accesslist.v1.Review
+	(*timestamppb.Timestamp)(nil),                          // 62: google.protobuf.Timestamp
+	(*types.AccessRequestV3)(nil),                          // 63: types.AccessRequestV3
+	(*types.RoleV6)(nil),                                   // 64: types.RoleV6
+	(*emptypb.Empty)(nil),                                  // 65: google.protobuf.Empty
 }
 var file_teleport_accesslist_v1_accesslist_service_proto_depIdxs = []int32{
 	55, // 0: teleport.accesslist.v1.GetAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
 	55, // 1: teleport.accesslist.v1.ListAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
 	56, // 2: teleport.accesslist.v1.ListAccessListsV2Request.sort_by:type_name -> types.SortBy
 	5,  // 3: teleport.accesslist.v1.ListAccessListsV2Request.filter:type_name -> teleport.accesslist.v1.AccessListsFilter
-	55, // 4: teleport.accesslist.v1.ListAccessListsV2Response.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	57, // 5: teleport.accesslist.v1.GetInheritedGrantsResponse.grants:type_name -> teleport.accesslist.v1.AccessListGrants
-	55, // 6: teleport.accesslist.v1.UpsertAccessListRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
-	55, // 7: teleport.accesslist.v1.UpdateAccessListRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
-	55, // 8: teleport.accesslist.v1.GetAccessListsToReviewResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	58, // 9: teleport.accesslist.v1.ListAccessListMembersResponse.members:type_name -> teleport.accesslist.v1.Member
-	58, // 10: teleport.accesslist.v1.ListAllAccessListMembersResponse.members:type_name -> teleport.accesslist.v1.Member
-	55, // 11: teleport.accesslist.v1.UpsertAccessListWithMembersRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
-	58, // 12: teleport.accesslist.v1.UpsertAccessListWithMembersRequest.members:type_name -> teleport.accesslist.v1.Member
-	55, // 13: teleport.accesslist.v1.UpsertAccessListWithMembersResponse.access_list:type_name -> teleport.accesslist.v1.AccessList
-	58, // 14: teleport.accesslist.v1.UpsertAccessListWithMembersResponse.members:type_name -> teleport.accesslist.v1.Member
-	58, // 15: teleport.accesslist.v1.GetStaticAccessListMemberResponse.member:type_name -> teleport.accesslist.v1.Member
-	59, // 16: teleport.accesslist.v1.GetAccessListOwnersResponse.owners:type_name -> teleport.accesslist.v1.AccessListOwner
-	58, // 17: teleport.accesslist.v1.UpsertAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
-	58, // 18: teleport.accesslist.v1.UpsertStaticAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
-	58, // 19: teleport.accesslist.v1.UpsertStaticAccessListMemberResponse.member:type_name -> teleport.accesslist.v1.Member
-	58, // 20: teleport.accesslist.v1.UpdateAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
-	60, // 21: teleport.accesslist.v1.ListAccessListReviewsResponse.reviews:type_name -> teleport.accesslist.v1.Review
-	60, // 22: teleport.accesslist.v1.ListAllAccessListReviewsResponse.reviews:type_name -> teleport.accesslist.v1.Review
-	60, // 23: teleport.accesslist.v1.CreateAccessListReviewRequest.review:type_name -> teleport.accesslist.v1.Review
-	61, // 24: teleport.accesslist.v1.CreateAccessListReviewResponse.next_audit_date:type_name -> google.protobuf.Timestamp
-	62, // 25: teleport.accesslist.v1.AccessRequestPromoteResponse.access_request:type_name -> types.AccessRequestV3
-	55, // 26: teleport.accesslist.v1.GetSuggestedAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	55, // 27: teleport.accesslist.v1.ListUserAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	55, // 28: teleport.accesslist.v1.CreateAccessListWithPresetRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
-	63, // 29: teleport.accesslist.v1.CreateAccessListWithPresetRequest.roles:type_name -> types.RoleV6
-	55, // 30: teleport.accesslist.v1.CreateAccessListWithPresetResponse.access_list:type_name -> teleport.accesslist.v1.AccessList
-	63, // 31: teleport.accesslist.v1.CreateAccessListWithPresetResponse.roles:type_name -> types.RoleV6
-	55, // 32: teleport.accesslist.v1.UpdateAccessListWithPresetRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
-	63, // 33: teleport.accesslist.v1.UpdateAccessListWithPresetRequest.roles:type_name -> types.RoleV6
-	55, // 34: teleport.accesslist.v1.UpdateAccessListWithPresetResponse.access_list:type_name -> teleport.accesslist.v1.AccessList
-	63, // 35: teleport.accesslist.v1.UpdateAccessListWithPresetResponse.roles:type_name -> types.RoleV6
-	0,  // 36: teleport.accesslist.v1.AccessListService.GetAccessLists:input_type -> teleport.accesslist.v1.GetAccessListsRequest
-	2,  // 37: teleport.accesslist.v1.AccessListService.ListAccessLists:input_type -> teleport.accesslist.v1.ListAccessListsRequest
-	4,  // 38: teleport.accesslist.v1.AccessListService.ListAccessListsV2:input_type -> teleport.accesslist.v1.ListAccessListsV2Request
-	9,  // 39: teleport.accesslist.v1.AccessListService.GetAccessList:input_type -> teleport.accesslist.v1.GetAccessListRequest
-	10, // 40: teleport.accesslist.v1.AccessListService.UpsertAccessList:input_type -> teleport.accesslist.v1.UpsertAccessListRequest
-	11, // 41: teleport.accesslist.v1.AccessListService.UpdateAccessList:input_type -> teleport.accesslist.v1.UpdateAccessListRequest
-	12, // 42: teleport.accesslist.v1.AccessListService.DeleteAccessList:input_type -> teleport.accesslist.v1.DeleteAccessListRequest
-	13, // 43: teleport.accesslist.v1.AccessListService.DeleteAllAccessLists:input_type -> teleport.accesslist.v1.DeleteAllAccessListsRequest
-	14, // 44: teleport.accesslist.v1.AccessListService.GetAccessListsToReview:input_type -> teleport.accesslist.v1.GetAccessListsToReviewRequest
-	16, // 45: teleport.accesslist.v1.AccessListService.CountAccessListMembers:input_type -> teleport.accesslist.v1.CountAccessListMembersRequest
-	18, // 46: teleport.accesslist.v1.AccessListService.ListAccessListMembers:input_type -> teleport.accesslist.v1.ListAccessListMembersRequest
-	20, // 47: teleport.accesslist.v1.AccessListService.ListAllAccessListMembers:input_type -> teleport.accesslist.v1.ListAllAccessListMembersRequest
-	24, // 48: teleport.accesslist.v1.AccessListService.GetAccessListMember:input_type -> teleport.accesslist.v1.GetAccessListMemberRequest
-	25, // 49: teleport.accesslist.v1.AccessListService.GetStaticAccessListMember:input_type -> teleport.accesslist.v1.GetStaticAccessListMemberRequest
-	27, // 50: teleport.accesslist.v1.AccessListService.GetAccessListOwners:input_type -> teleport.accesslist.v1.GetAccessListOwnersRequest
-	29, // 51: teleport.accesslist.v1.AccessListService.UpsertAccessListMember:input_type -> teleport.accesslist.v1.UpsertAccessListMemberRequest
-	30, // 52: teleport.accesslist.v1.AccessListService.UpsertStaticAccessListMember:input_type -> teleport.accesslist.v1.UpsertStaticAccessListMemberRequest
-	32, // 53: teleport.accesslist.v1.AccessListService.UpdateAccessListMember:input_type -> teleport.accesslist.v1.UpdateAccessListMemberRequest
-	33, // 54: teleport.accesslist.v1.AccessListService.DeleteAccessListMember:input_type -> teleport.accesslist.v1.DeleteAccessListMemberRequest
-	34, // 55: teleport.accesslist.v1.AccessListService.DeleteStaticAccessListMember:input_type -> teleport.accesslist.v1.DeleteStaticAccessListMemberRequest
-	36, // 56: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembersForAccessList:input_type -> teleport.accesslist.v1.DeleteAllAccessListMembersForAccessListRequest
-	37, // 57: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembers:input_type -> teleport.accesslist.v1.DeleteAllAccessListMembersRequest
-	22, // 58: teleport.accesslist.v1.AccessListService.UpsertAccessListWithMembers:input_type -> teleport.accesslist.v1.UpsertAccessListWithMembersRequest
-	38, // 59: teleport.accesslist.v1.AccessListService.ListAccessListReviews:input_type -> teleport.accesslist.v1.ListAccessListReviewsRequest
-	40, // 60: teleport.accesslist.v1.AccessListService.ListAllAccessListReviews:input_type -> teleport.accesslist.v1.ListAllAccessListReviewsRequest
-	42, // 61: teleport.accesslist.v1.AccessListService.CreateAccessListReview:input_type -> teleport.accesslist.v1.CreateAccessListReviewRequest
-	44, // 62: teleport.accesslist.v1.AccessListService.DeleteAccessListReview:input_type -> teleport.accesslist.v1.DeleteAccessListReviewRequest
-	45, // 63: teleport.accesslist.v1.AccessListService.AccessRequestPromote:input_type -> teleport.accesslist.v1.AccessRequestPromoteRequest
-	47, // 64: teleport.accesslist.v1.AccessListService.GetSuggestedAccessLists:input_type -> teleport.accesslist.v1.GetSuggestedAccessListsRequest
-	7,  // 65: teleport.accesslist.v1.AccessListService.GetInheritedGrants:input_type -> teleport.accesslist.v1.GetInheritedGrantsRequest
-	49, // 66: teleport.accesslist.v1.AccessListService.ListUserAccessLists:input_type -> teleport.accesslist.v1.ListUserAccessListsRequest
-	51, // 67: teleport.accesslist.v1.AccessListService.CreateAccessListWithPreset:input_type -> teleport.accesslist.v1.CreateAccessListWithPresetRequest
-	53, // 68: teleport.accesslist.v1.AccessListService.UpdateAccessListWithPreset:input_type -> teleport.accesslist.v1.UpdateAccessListWithPresetRequest
-	1,  // 69: teleport.accesslist.v1.AccessListService.GetAccessLists:output_type -> teleport.accesslist.v1.GetAccessListsResponse
-	3,  // 70: teleport.accesslist.v1.AccessListService.ListAccessLists:output_type -> teleport.accesslist.v1.ListAccessListsResponse
-	6,  // 71: teleport.accesslist.v1.AccessListService.ListAccessListsV2:output_type -> teleport.accesslist.v1.ListAccessListsV2Response
-	55, // 72: teleport.accesslist.v1.AccessListService.GetAccessList:output_type -> teleport.accesslist.v1.AccessList
-	55, // 73: teleport.accesslist.v1.AccessListService.UpsertAccessList:output_type -> teleport.accesslist.v1.AccessList
-	55, // 74: teleport.accesslist.v1.AccessListService.UpdateAccessList:output_type -> teleport.accesslist.v1.AccessList
-	64, // 75: teleport.accesslist.v1.AccessListService.DeleteAccessList:output_type -> google.protobuf.Empty
-	64, // 76: teleport.accesslist.v1.AccessListService.DeleteAllAccessLists:output_type -> google.protobuf.Empty
-	15, // 77: teleport.accesslist.v1.AccessListService.GetAccessListsToReview:output_type -> teleport.accesslist.v1.GetAccessListsToReviewResponse
-	17, // 78: teleport.accesslist.v1.AccessListService.CountAccessListMembers:output_type -> teleport.accesslist.v1.CountAccessListMembersResponse
-	19, // 79: teleport.accesslist.v1.AccessListService.ListAccessListMembers:output_type -> teleport.accesslist.v1.ListAccessListMembersResponse
-	21, // 80: teleport.accesslist.v1.AccessListService.ListAllAccessListMembers:output_type -> teleport.accesslist.v1.ListAllAccessListMembersResponse
-	58, // 81: teleport.accesslist.v1.AccessListService.GetAccessListMember:output_type -> teleport.accesslist.v1.Member
-	26, // 82: teleport.accesslist.v1.AccessListService.GetStaticAccessListMember:output_type -> teleport.accesslist.v1.GetStaticAccessListMemberResponse
-	28, // 83: teleport.accesslist.v1.AccessListService.GetAccessListOwners:output_type -> teleport.accesslist.v1.GetAccessListOwnersResponse
-	58, // 84: teleport.accesslist.v1.AccessListService.UpsertAccessListMember:output_type -> teleport.accesslist.v1.Member
-	31, // 85: teleport.accesslist.v1.AccessListService.UpsertStaticAccessListMember:output_type -> teleport.accesslist.v1.UpsertStaticAccessListMemberResponse
-	58, // 86: teleport.accesslist.v1.AccessListService.UpdateAccessListMember:output_type -> teleport.accesslist.v1.Member
-	64, // 87: teleport.accesslist.v1.AccessListService.DeleteAccessListMember:output_type -> google.protobuf.Empty
-	35, // 88: teleport.accesslist.v1.AccessListService.DeleteStaticAccessListMember:output_type -> teleport.accesslist.v1.DeleteStaticAccessListMemberResponse
-	64, // 89: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembersForAccessList:output_type -> google.protobuf.Empty
-	64, // 90: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembers:output_type -> google.protobuf.Empty
-	23, // 91: teleport.accesslist.v1.AccessListService.UpsertAccessListWithMembers:output_type -> teleport.accesslist.v1.UpsertAccessListWithMembersResponse
-	39, // 92: teleport.accesslist.v1.AccessListService.ListAccessListReviews:output_type -> teleport.accesslist.v1.ListAccessListReviewsResponse
-	41, // 93: teleport.accesslist.v1.AccessListService.ListAllAccessListReviews:output_type -> teleport.accesslist.v1.ListAllAccessListReviewsResponse
-	43, // 94: teleport.accesslist.v1.AccessListService.CreateAccessListReview:output_type -> teleport.accesslist.v1.CreateAccessListReviewResponse
-	64, // 95: teleport.accesslist.v1.AccessListService.DeleteAccessListReview:output_type -> google.protobuf.Empty
-	46, // 96: teleport.accesslist.v1.AccessListService.AccessRequestPromote:output_type -> teleport.accesslist.v1.AccessRequestPromoteResponse
-	48, // 97: teleport.accesslist.v1.AccessListService.GetSuggestedAccessLists:output_type -> teleport.accesslist.v1.GetSuggestedAccessListsResponse
-	8,  // 98: teleport.accesslist.v1.AccessListService.GetInheritedGrants:output_type -> teleport.accesslist.v1.GetInheritedGrantsResponse
-	50, // 99: teleport.accesslist.v1.AccessListService.ListUserAccessLists:output_type -> teleport.accesslist.v1.ListUserAccessListsResponse
-	52, // 100: teleport.accesslist.v1.AccessListService.CreateAccessListWithPreset:output_type -> teleport.accesslist.v1.CreateAccessListWithPresetResponse
-	54, // 101: teleport.accesslist.v1.AccessListService.UpdateAccessListWithPreset:output_type -> teleport.accesslist.v1.UpdateAccessListWithPresetResponse
-	69, // [69:102] is the sub-list for method output_type
-	36, // [36:69] is the sub-list for method input_type
-	36, // [36:36] is the sub-list for extension type_name
-	36, // [36:36] is the sub-list for extension extendee
-	0,  // [0:36] is the sub-list for field type_name
+	57, // 4: teleport.accesslist.v1.ListAccessListsV2Request.scope_filter:type_name -> teleport.scopes.v1.Filter
+	55, // 5: teleport.accesslist.v1.ListAccessListsV2Response.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	58, // 6: teleport.accesslist.v1.GetInheritedGrantsResponse.grants:type_name -> teleport.accesslist.v1.AccessListGrants
+	55, // 7: teleport.accesslist.v1.UpsertAccessListRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
+	55, // 8: teleport.accesslist.v1.UpdateAccessListRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
+	55, // 9: teleport.accesslist.v1.GetAccessListsToReviewResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	59, // 10: teleport.accesslist.v1.ListAccessListMembersResponse.members:type_name -> teleport.accesslist.v1.Member
+	57, // 11: teleport.accesslist.v1.ListAllAccessListMembersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
+	59, // 12: teleport.accesslist.v1.ListAllAccessListMembersResponse.members:type_name -> teleport.accesslist.v1.Member
+	55, // 13: teleport.accesslist.v1.UpsertAccessListWithMembersRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
+	59, // 14: teleport.accesslist.v1.UpsertAccessListWithMembersRequest.members:type_name -> teleport.accesslist.v1.Member
+	55, // 15: teleport.accesslist.v1.UpsertAccessListWithMembersResponse.access_list:type_name -> teleport.accesslist.v1.AccessList
+	59, // 16: teleport.accesslist.v1.UpsertAccessListWithMembersResponse.members:type_name -> teleport.accesslist.v1.Member
+	59, // 17: teleport.accesslist.v1.GetStaticAccessListMemberResponse.member:type_name -> teleport.accesslist.v1.Member
+	60, // 18: teleport.accesslist.v1.GetAccessListOwnersResponse.owners:type_name -> teleport.accesslist.v1.AccessListOwner
+	59, // 19: teleport.accesslist.v1.UpsertAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
+	59, // 20: teleport.accesslist.v1.UpsertStaticAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
+	59, // 21: teleport.accesslist.v1.UpsertStaticAccessListMemberResponse.member:type_name -> teleport.accesslist.v1.Member
+	59, // 22: teleport.accesslist.v1.UpdateAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
+	61, // 23: teleport.accesslist.v1.ListAccessListReviewsResponse.reviews:type_name -> teleport.accesslist.v1.Review
+	57, // 24: teleport.accesslist.v1.ListAllAccessListReviewsRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
+	61, // 25: teleport.accesslist.v1.ListAllAccessListReviewsResponse.reviews:type_name -> teleport.accesslist.v1.Review
+	61, // 26: teleport.accesslist.v1.CreateAccessListReviewRequest.review:type_name -> teleport.accesslist.v1.Review
+	62, // 27: teleport.accesslist.v1.CreateAccessListReviewResponse.next_audit_date:type_name -> google.protobuf.Timestamp
+	63, // 28: teleport.accesslist.v1.AccessRequestPromoteResponse.access_request:type_name -> types.AccessRequestV3
+	55, // 29: teleport.accesslist.v1.GetSuggestedAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	55, // 30: teleport.accesslist.v1.ListUserAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	55, // 31: teleport.accesslist.v1.CreateAccessListWithPresetRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
+	64, // 32: teleport.accesslist.v1.CreateAccessListWithPresetRequest.roles:type_name -> types.RoleV6
+	55, // 33: teleport.accesslist.v1.CreateAccessListWithPresetResponse.access_list:type_name -> teleport.accesslist.v1.AccessList
+	64, // 34: teleport.accesslist.v1.CreateAccessListWithPresetResponse.roles:type_name -> types.RoleV6
+	55, // 35: teleport.accesslist.v1.UpdateAccessListWithPresetRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
+	64, // 36: teleport.accesslist.v1.UpdateAccessListWithPresetRequest.roles:type_name -> types.RoleV6
+	55, // 37: teleport.accesslist.v1.UpdateAccessListWithPresetResponse.access_list:type_name -> teleport.accesslist.v1.AccessList
+	64, // 38: teleport.accesslist.v1.UpdateAccessListWithPresetResponse.roles:type_name -> types.RoleV6
+	0,  // 39: teleport.accesslist.v1.AccessListService.GetAccessLists:input_type -> teleport.accesslist.v1.GetAccessListsRequest
+	2,  // 40: teleport.accesslist.v1.AccessListService.ListAccessLists:input_type -> teleport.accesslist.v1.ListAccessListsRequest
+	4,  // 41: teleport.accesslist.v1.AccessListService.ListAccessListsV2:input_type -> teleport.accesslist.v1.ListAccessListsV2Request
+	9,  // 42: teleport.accesslist.v1.AccessListService.GetAccessList:input_type -> teleport.accesslist.v1.GetAccessListRequest
+	10, // 43: teleport.accesslist.v1.AccessListService.UpsertAccessList:input_type -> teleport.accesslist.v1.UpsertAccessListRequest
+	11, // 44: teleport.accesslist.v1.AccessListService.UpdateAccessList:input_type -> teleport.accesslist.v1.UpdateAccessListRequest
+	12, // 45: teleport.accesslist.v1.AccessListService.DeleteAccessList:input_type -> teleport.accesslist.v1.DeleteAccessListRequest
+	13, // 46: teleport.accesslist.v1.AccessListService.DeleteAllAccessLists:input_type -> teleport.accesslist.v1.DeleteAllAccessListsRequest
+	14, // 47: teleport.accesslist.v1.AccessListService.GetAccessListsToReview:input_type -> teleport.accesslist.v1.GetAccessListsToReviewRequest
+	16, // 48: teleport.accesslist.v1.AccessListService.CountAccessListMembers:input_type -> teleport.accesslist.v1.CountAccessListMembersRequest
+	18, // 49: teleport.accesslist.v1.AccessListService.ListAccessListMembers:input_type -> teleport.accesslist.v1.ListAccessListMembersRequest
+	20, // 50: teleport.accesslist.v1.AccessListService.ListAllAccessListMembers:input_type -> teleport.accesslist.v1.ListAllAccessListMembersRequest
+	24, // 51: teleport.accesslist.v1.AccessListService.GetAccessListMember:input_type -> teleport.accesslist.v1.GetAccessListMemberRequest
+	25, // 52: teleport.accesslist.v1.AccessListService.GetStaticAccessListMember:input_type -> teleport.accesslist.v1.GetStaticAccessListMemberRequest
+	27, // 53: teleport.accesslist.v1.AccessListService.GetAccessListOwners:input_type -> teleport.accesslist.v1.GetAccessListOwnersRequest
+	29, // 54: teleport.accesslist.v1.AccessListService.UpsertAccessListMember:input_type -> teleport.accesslist.v1.UpsertAccessListMemberRequest
+	30, // 55: teleport.accesslist.v1.AccessListService.UpsertStaticAccessListMember:input_type -> teleport.accesslist.v1.UpsertStaticAccessListMemberRequest
+	32, // 56: teleport.accesslist.v1.AccessListService.UpdateAccessListMember:input_type -> teleport.accesslist.v1.UpdateAccessListMemberRequest
+	33, // 57: teleport.accesslist.v1.AccessListService.DeleteAccessListMember:input_type -> teleport.accesslist.v1.DeleteAccessListMemberRequest
+	34, // 58: teleport.accesslist.v1.AccessListService.DeleteStaticAccessListMember:input_type -> teleport.accesslist.v1.DeleteStaticAccessListMemberRequest
+	36, // 59: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembersForAccessList:input_type -> teleport.accesslist.v1.DeleteAllAccessListMembersForAccessListRequest
+	37, // 60: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembers:input_type -> teleport.accesslist.v1.DeleteAllAccessListMembersRequest
+	22, // 61: teleport.accesslist.v1.AccessListService.UpsertAccessListWithMembers:input_type -> teleport.accesslist.v1.UpsertAccessListWithMembersRequest
+	38, // 62: teleport.accesslist.v1.AccessListService.ListAccessListReviews:input_type -> teleport.accesslist.v1.ListAccessListReviewsRequest
+	40, // 63: teleport.accesslist.v1.AccessListService.ListAllAccessListReviews:input_type -> teleport.accesslist.v1.ListAllAccessListReviewsRequest
+	42, // 64: teleport.accesslist.v1.AccessListService.CreateAccessListReview:input_type -> teleport.accesslist.v1.CreateAccessListReviewRequest
+	44, // 65: teleport.accesslist.v1.AccessListService.DeleteAccessListReview:input_type -> teleport.accesslist.v1.DeleteAccessListReviewRequest
+	45, // 66: teleport.accesslist.v1.AccessListService.AccessRequestPromote:input_type -> teleport.accesslist.v1.AccessRequestPromoteRequest
+	47, // 67: teleport.accesslist.v1.AccessListService.GetSuggestedAccessLists:input_type -> teleport.accesslist.v1.GetSuggestedAccessListsRequest
+	7,  // 68: teleport.accesslist.v1.AccessListService.GetInheritedGrants:input_type -> teleport.accesslist.v1.GetInheritedGrantsRequest
+	49, // 69: teleport.accesslist.v1.AccessListService.ListUserAccessLists:input_type -> teleport.accesslist.v1.ListUserAccessListsRequest
+	51, // 70: teleport.accesslist.v1.AccessListService.CreateAccessListWithPreset:input_type -> teleport.accesslist.v1.CreateAccessListWithPresetRequest
+	53, // 71: teleport.accesslist.v1.AccessListService.UpdateAccessListWithPreset:input_type -> teleport.accesslist.v1.UpdateAccessListWithPresetRequest
+	1,  // 72: teleport.accesslist.v1.AccessListService.GetAccessLists:output_type -> teleport.accesslist.v1.GetAccessListsResponse
+	3,  // 73: teleport.accesslist.v1.AccessListService.ListAccessLists:output_type -> teleport.accesslist.v1.ListAccessListsResponse
+	6,  // 74: teleport.accesslist.v1.AccessListService.ListAccessListsV2:output_type -> teleport.accesslist.v1.ListAccessListsV2Response
+	55, // 75: teleport.accesslist.v1.AccessListService.GetAccessList:output_type -> teleport.accesslist.v1.AccessList
+	55, // 76: teleport.accesslist.v1.AccessListService.UpsertAccessList:output_type -> teleport.accesslist.v1.AccessList
+	55, // 77: teleport.accesslist.v1.AccessListService.UpdateAccessList:output_type -> teleport.accesslist.v1.AccessList
+	65, // 78: teleport.accesslist.v1.AccessListService.DeleteAccessList:output_type -> google.protobuf.Empty
+	65, // 79: teleport.accesslist.v1.AccessListService.DeleteAllAccessLists:output_type -> google.protobuf.Empty
+	15, // 80: teleport.accesslist.v1.AccessListService.GetAccessListsToReview:output_type -> teleport.accesslist.v1.GetAccessListsToReviewResponse
+	17, // 81: teleport.accesslist.v1.AccessListService.CountAccessListMembers:output_type -> teleport.accesslist.v1.CountAccessListMembersResponse
+	19, // 82: teleport.accesslist.v1.AccessListService.ListAccessListMembers:output_type -> teleport.accesslist.v1.ListAccessListMembersResponse
+	21, // 83: teleport.accesslist.v1.AccessListService.ListAllAccessListMembers:output_type -> teleport.accesslist.v1.ListAllAccessListMembersResponse
+	59, // 84: teleport.accesslist.v1.AccessListService.GetAccessListMember:output_type -> teleport.accesslist.v1.Member
+	26, // 85: teleport.accesslist.v1.AccessListService.GetStaticAccessListMember:output_type -> teleport.accesslist.v1.GetStaticAccessListMemberResponse
+	28, // 86: teleport.accesslist.v1.AccessListService.GetAccessListOwners:output_type -> teleport.accesslist.v1.GetAccessListOwnersResponse
+	59, // 87: teleport.accesslist.v1.AccessListService.UpsertAccessListMember:output_type -> teleport.accesslist.v1.Member
+	31, // 88: teleport.accesslist.v1.AccessListService.UpsertStaticAccessListMember:output_type -> teleport.accesslist.v1.UpsertStaticAccessListMemberResponse
+	59, // 89: teleport.accesslist.v1.AccessListService.UpdateAccessListMember:output_type -> teleport.accesslist.v1.Member
+	65, // 90: teleport.accesslist.v1.AccessListService.DeleteAccessListMember:output_type -> google.protobuf.Empty
+	35, // 91: teleport.accesslist.v1.AccessListService.DeleteStaticAccessListMember:output_type -> teleport.accesslist.v1.DeleteStaticAccessListMemberResponse
+	65, // 92: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembersForAccessList:output_type -> google.protobuf.Empty
+	65, // 93: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembers:output_type -> google.protobuf.Empty
+	23, // 94: teleport.accesslist.v1.AccessListService.UpsertAccessListWithMembers:output_type -> teleport.accesslist.v1.UpsertAccessListWithMembersResponse
+	39, // 95: teleport.accesslist.v1.AccessListService.ListAccessListReviews:output_type -> teleport.accesslist.v1.ListAccessListReviewsResponse
+	41, // 96: teleport.accesslist.v1.AccessListService.ListAllAccessListReviews:output_type -> teleport.accesslist.v1.ListAllAccessListReviewsResponse
+	43, // 97: teleport.accesslist.v1.AccessListService.CreateAccessListReview:output_type -> teleport.accesslist.v1.CreateAccessListReviewResponse
+	65, // 98: teleport.accesslist.v1.AccessListService.DeleteAccessListReview:output_type -> google.protobuf.Empty
+	46, // 99: teleport.accesslist.v1.AccessListService.AccessRequestPromote:output_type -> teleport.accesslist.v1.AccessRequestPromoteResponse
+	48, // 100: teleport.accesslist.v1.AccessListService.GetSuggestedAccessLists:output_type -> teleport.accesslist.v1.GetSuggestedAccessListsResponse
+	8,  // 101: teleport.accesslist.v1.AccessListService.GetInheritedGrants:output_type -> teleport.accesslist.v1.GetInheritedGrantsResponse
+	50, // 102: teleport.accesslist.v1.AccessListService.ListUserAccessLists:output_type -> teleport.accesslist.v1.ListUserAccessListsResponse
+	52, // 103: teleport.accesslist.v1.AccessListService.CreateAccessListWithPreset:output_type -> teleport.accesslist.v1.CreateAccessListWithPresetResponse
+	54, // 104: teleport.accesslist.v1.AccessListService.UpdateAccessListWithPreset:output_type -> teleport.accesslist.v1.UpdateAccessListWithPresetResponse
+	72, // [72:105] is the sub-list for method output_type
+	39, // [39:72] is the sub-list for method input_type
+	39, // [39:39] is the sub-list for extension type_name
+	39, // [39:39] is the sub-list for extension extendee
+	0,  // [0:39] is the sub-list for field type_name
 }
 
 func init() { file_teleport_accesslist_v1_accesslist_service_proto_init() }

--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_service_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_service_protohybrid.pb.go
@@ -613,9 +613,11 @@ func (b0 ListAccessListsV2Response_builder) Build() *ListAccessListsV2Response {
 type GetInheritedGrantsRequest struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// access_list_id is the ID of the access list to retrieve.
-	AccessListId  string `protobuf:"bytes,1,opt,name=access_list_id,json=accessListId,proto3" json:"access_list_id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	AccessListId string `protobuf:"bytes,1,opt,name=access_list_id,json=accessListId,proto3" json:"access_list_id,omitempty"`
+	// access_list_scope is the scope of the access list to retrieve.
+	AccessListScope string `protobuf:"bytes,2,opt,name=access_list_scope,json=accessListScope,proto3" json:"access_list_scope,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *GetInheritedGrantsRequest) Reset() {
@@ -650,8 +652,19 @@ func (x *GetInheritedGrantsRequest) GetAccessListId() string {
 	return ""
 }
 
+func (x *GetInheritedGrantsRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.AccessListScope
+	}
+	return ""
+}
+
 func (x *GetInheritedGrantsRequest) SetAccessListId(v string) {
 	x.AccessListId = v
+}
+
+func (x *GetInheritedGrantsRequest) SetAccessListScope(v string) {
+	x.AccessListScope = v
 }
 
 type GetInheritedGrantsRequest_builder struct {
@@ -659,6 +672,8 @@ type GetInheritedGrantsRequest_builder struct {
 
 	// access_list_id is the ID of the access list to retrieve.
 	AccessListId string
+	// access_list_scope is the scope of the access list to retrieve.
+	AccessListScope string
 }
 
 func (b0 GetInheritedGrantsRequest_builder) Build() *GetInheritedGrantsRequest {
@@ -666,6 +681,7 @@ func (b0 GetInheritedGrantsRequest_builder) Build() *GetInheritedGrantsRequest {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.AccessListId = b.AccessListId
+	x.AccessListScope = b.AccessListScope
 	return m0
 }
 
@@ -744,7 +760,9 @@ func (b0 GetInheritedGrantsResponse_builder) Build() *GetInheritedGrantsResponse
 type GetAccessListRequest struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// name is the name of the access list to retrieve.
-	Name          string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// scope is the scope of the access list to retrieve.
+	Scope         string `protobuf:"bytes,2,opt,name=scope,proto3" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -781,8 +799,19 @@ func (x *GetAccessListRequest) GetName() string {
 	return ""
 }
 
+func (x *GetAccessListRequest) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
 func (x *GetAccessListRequest) SetName(v string) {
 	x.Name = v
+}
+
+func (x *GetAccessListRequest) SetScope(v string) {
+	x.Scope = v
 }
 
 type GetAccessListRequest_builder struct {
@@ -790,6 +819,8 @@ type GetAccessListRequest_builder struct {
 
 	// name is the name of the access list to retrieve.
 	Name string
+	// scope is the scope of the access list to retrieve.
+	Scope string
 }
 
 func (b0 GetAccessListRequest_builder) Build() *GetAccessListRequest {
@@ -797,6 +828,7 @@ func (b0 GetAccessListRequest_builder) Build() *GetAccessListRequest {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.Name = b.Name
+	x.Scope = b.Scope
 	return m0
 }
 
@@ -946,7 +978,9 @@ func (b0 UpdateAccessListRequest_builder) Build() *UpdateAccessListRequest {
 type DeleteAccessListRequest struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// name is the name of the access list to delete.
-	Name          string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// scope is the scope of the access list to delete.
+	Scope         string `protobuf:"bytes,2,opt,name=scope,proto3" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -983,8 +1017,19 @@ func (x *DeleteAccessListRequest) GetName() string {
 	return ""
 }
 
+func (x *DeleteAccessListRequest) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
 func (x *DeleteAccessListRequest) SetName(v string) {
 	x.Name = v
+}
+
+func (x *DeleteAccessListRequest) SetScope(v string) {
+	x.Scope = v
 }
 
 type DeleteAccessListRequest_builder struct {
@@ -992,6 +1037,8 @@ type DeleteAccessListRequest_builder struct {
 
 	// name is the name of the access list to delete.
 	Name string
+	// scope is the scope of the access list to delete.
+	Scope string
 }
 
 func (b0 DeleteAccessListRequest_builder) Build() *DeleteAccessListRequest {
@@ -999,6 +1046,7 @@ func (b0 DeleteAccessListRequest_builder) Build() *DeleteAccessListRequest {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.Name = b.Name
+	x.Scope = b.Scope
 	return m0
 }
 
@@ -1156,8 +1204,10 @@ type CountAccessListMembersRequest struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// access_list_name is the name of the access list to retrieve.
 	AccessListName string `protobuf:"bytes,1,opt,name=access_list_name,json=accessListName,proto3" json:"access_list_name,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// access_list_scope is the scope of the access list to retrieve.
+	AccessListScope string `protobuf:"bytes,2,opt,name=access_list_scope,json=accessListScope,proto3" json:"access_list_scope,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *CountAccessListMembersRequest) Reset() {
@@ -1192,8 +1242,19 @@ func (x *CountAccessListMembersRequest) GetAccessListName() string {
 	return ""
 }
 
+func (x *CountAccessListMembersRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.AccessListScope
+	}
+	return ""
+}
+
 func (x *CountAccessListMembersRequest) SetAccessListName(v string) {
 	x.AccessListName = v
+}
+
+func (x *CountAccessListMembersRequest) SetAccessListScope(v string) {
+	x.AccessListScope = v
 }
 
 type CountAccessListMembersRequest_builder struct {
@@ -1201,6 +1262,8 @@ type CountAccessListMembersRequest_builder struct {
 
 	// access_list_name is the name of the access list to retrieve.
 	AccessListName string
+	// access_list_scope is the scope of the access list to retrieve.
+	AccessListScope string
 }
 
 func (b0 CountAccessListMembersRequest_builder) Build() *CountAccessListMembersRequest {
@@ -1208,6 +1271,7 @@ func (b0 CountAccessListMembersRequest_builder) Build() *CountAccessListMembersR
 	b, x := &b0, m0
 	_, _ = b, x
 	x.AccessListName = b.AccessListName
+	x.AccessListScope = b.AccessListScope
 	return m0
 }
 
@@ -1297,9 +1361,11 @@ type ListAccessListMembersRequest struct {
 	// page_token is the page token.
 	PageToken string `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
 	// access_list is the name of the access list that the member belongs to.
-	AccessList    string `protobuf:"bytes,3,opt,name=access_list,json=accessList,proto3" json:"access_list,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	AccessList string `protobuf:"bytes,3,opt,name=access_list,json=accessList,proto3" json:"access_list,omitempty"`
+	// access_list_scope is the scope of the access list that the member belongs to.
+	AccessListScope string `protobuf:"bytes,4,opt,name=access_list_scope,json=accessListScope,proto3" json:"access_list_scope,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *ListAccessListMembersRequest) Reset() {
@@ -1348,6 +1414,13 @@ func (x *ListAccessListMembersRequest) GetAccessList() string {
 	return ""
 }
 
+func (x *ListAccessListMembersRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.AccessListScope
+	}
+	return ""
+}
+
 func (x *ListAccessListMembersRequest) SetPageSize(v int32) {
 	x.PageSize = v
 }
@@ -1360,6 +1433,10 @@ func (x *ListAccessListMembersRequest) SetAccessList(v string) {
 	x.AccessList = v
 }
 
+func (x *ListAccessListMembersRequest) SetAccessListScope(v string) {
+	x.AccessListScope = v
+}
+
 type ListAccessListMembersRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -1369,6 +1446,8 @@ type ListAccessListMembersRequest_builder struct {
 	PageToken string
 	// access_list is the name of the access list that the member belongs to.
 	AccessList string
+	// access_list_scope is the scope of the access list that the member belongs to.
+	AccessListScope string
 }
 
 func (b0 ListAccessListMembersRequest_builder) Build() *ListAccessListMembersRequest {
@@ -1378,6 +1457,7 @@ func (b0 ListAccessListMembersRequest_builder) Build() *ListAccessListMembersReq
 	x.PageSize = b.PageSize
 	x.PageToken = b.PageToken
 	x.AccessList = b.AccessList
+	x.AccessListScope = b.AccessListScope
 	return m0
 }
 
@@ -1794,7 +1874,11 @@ type GetAccessListMemberRequest struct {
 	// access_list is the name of the access list that the member belongs to.
 	AccessList string `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3" json:"access_list,omitempty"`
 	// member_name is the name of the user that belongs to the access list.
-	MemberName    string `protobuf:"bytes,2,opt,name=member_name,json=memberName,proto3" json:"member_name,omitempty"`
+	MemberName string `protobuf:"bytes,2,opt,name=member_name,json=memberName,proto3" json:"member_name,omitempty"`
+	// access_list_scope is the scope of the access list that the member belongs to.
+	AccessListScope string `protobuf:"bytes,3,opt,name=access_list_scope,json=accessListScope,proto3" json:"access_list_scope,omitempty"`
+	// member_scope is the scope of the member, in case the member is a scoped access list.
+	MemberScope   string `protobuf:"bytes,4,opt,name=member_scope,json=memberScope,proto3" json:"member_scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1838,12 +1922,34 @@ func (x *GetAccessListMemberRequest) GetMemberName() string {
 	return ""
 }
 
+func (x *GetAccessListMemberRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.AccessListScope
+	}
+	return ""
+}
+
+func (x *GetAccessListMemberRequest) GetMemberScope() string {
+	if x != nil {
+		return x.MemberScope
+	}
+	return ""
+}
+
 func (x *GetAccessListMemberRequest) SetAccessList(v string) {
 	x.AccessList = v
 }
 
 func (x *GetAccessListMemberRequest) SetMemberName(v string) {
 	x.MemberName = v
+}
+
+func (x *GetAccessListMemberRequest) SetAccessListScope(v string) {
+	x.AccessListScope = v
+}
+
+func (x *GetAccessListMemberRequest) SetMemberScope(v string) {
+	x.MemberScope = v
 }
 
 type GetAccessListMemberRequest_builder struct {
@@ -1853,6 +1959,10 @@ type GetAccessListMemberRequest_builder struct {
 	AccessList string
 	// member_name is the name of the user that belongs to the access list.
 	MemberName string
+	// access_list_scope is the scope of the access list that the member belongs to.
+	AccessListScope string
+	// member_scope is the scope of the member, in case the member is a scoped access list.
+	MemberScope string
 }
 
 func (b0 GetAccessListMemberRequest_builder) Build() *GetAccessListMemberRequest {
@@ -1861,6 +1971,8 @@ func (b0 GetAccessListMemberRequest_builder) Build() *GetAccessListMemberRequest
 	_, _ = b, x
 	x.AccessList = b.AccessList
 	x.MemberName = b.MemberName
+	x.AccessListScope = b.AccessListScope
+	x.MemberScope = b.MemberScope
 	return m0
 }
 
@@ -1871,7 +1983,11 @@ type GetStaticAccessListMemberRequest struct {
 	// access_list is the name of the access_list that the member belongs to.
 	AccessList string `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3" json:"access_list,omitempty"`
 	// member_name is the name of the user that belongs to the access_list.
-	MemberName    string `protobuf:"bytes,2,opt,name=member_name,json=memberName,proto3" json:"member_name,omitempty"`
+	MemberName string `protobuf:"bytes,2,opt,name=member_name,json=memberName,proto3" json:"member_name,omitempty"`
+	// access_list_scope is the scope of the access list that the member belongs to.
+	AccessListScope string `protobuf:"bytes,3,opt,name=access_list_scope,json=accessListScope,proto3" json:"access_list_scope,omitempty"`
+	// member_scope is the scope of the member, in case the member is a scoped access list.
+	MemberScope   string `protobuf:"bytes,4,opt,name=member_scope,json=memberScope,proto3" json:"member_scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1915,12 +2031,34 @@ func (x *GetStaticAccessListMemberRequest) GetMemberName() string {
 	return ""
 }
 
+func (x *GetStaticAccessListMemberRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.AccessListScope
+	}
+	return ""
+}
+
+func (x *GetStaticAccessListMemberRequest) GetMemberScope() string {
+	if x != nil {
+		return x.MemberScope
+	}
+	return ""
+}
+
 func (x *GetStaticAccessListMemberRequest) SetAccessList(v string) {
 	x.AccessList = v
 }
 
 func (x *GetStaticAccessListMemberRequest) SetMemberName(v string) {
 	x.MemberName = v
+}
+
+func (x *GetStaticAccessListMemberRequest) SetAccessListScope(v string) {
+	x.AccessListScope = v
+}
+
+func (x *GetStaticAccessListMemberRequest) SetMemberScope(v string) {
+	x.MemberScope = v
 }
 
 type GetStaticAccessListMemberRequest_builder struct {
@@ -1930,6 +2068,10 @@ type GetStaticAccessListMemberRequest_builder struct {
 	AccessList string
 	// member_name is the name of the user that belongs to the access_list.
 	MemberName string
+	// access_list_scope is the scope of the access list that the member belongs to.
+	AccessListScope string
+	// member_scope is the scope of the member, in case the member is a scoped access list.
+	MemberScope string
 }
 
 func (b0 GetStaticAccessListMemberRequest_builder) Build() *GetStaticAccessListMemberRequest {
@@ -1938,6 +2080,8 @@ func (b0 GetStaticAccessListMemberRequest_builder) Build() *GetStaticAccessListM
 	_, _ = b, x
 	x.AccessList = b.AccessList
 	x.MemberName = b.MemberName
+	x.AccessListScope = b.AccessListScope
+	x.MemberScope = b.MemberScope
 	return m0
 }
 
@@ -2018,9 +2162,11 @@ func (b0 GetStaticAccessListMemberResponse_builder) Build() *GetStaticAccessList
 type GetAccessListOwnersRequest struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// access_list is the name of the access list.
-	AccessList    string `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3" json:"access_list,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	AccessList string `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3" json:"access_list,omitempty"`
+	// access_list_scope is the scope of the access list.
+	AccessListScope string `protobuf:"bytes,3,opt,name=access_list_scope,json=accessListScope,proto3" json:"access_list_scope,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *GetAccessListOwnersRequest) Reset() {
@@ -2055,8 +2201,19 @@ func (x *GetAccessListOwnersRequest) GetAccessList() string {
 	return ""
 }
 
+func (x *GetAccessListOwnersRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.AccessListScope
+	}
+	return ""
+}
+
 func (x *GetAccessListOwnersRequest) SetAccessList(v string) {
 	x.AccessList = v
+}
+
+func (x *GetAccessListOwnersRequest) SetAccessListScope(v string) {
+	x.AccessListScope = v
 }
 
 type GetAccessListOwnersRequest_builder struct {
@@ -2064,6 +2221,8 @@ type GetAccessListOwnersRequest_builder struct {
 
 	// access_list is the name of the access list.
 	AccessList string
+	// access_list_scope is the scope of the access list.
+	AccessListScope string
 }
 
 func (b0 GetAccessListOwnersRequest_builder) Build() *GetAccessListOwnersRequest {
@@ -2071,6 +2230,7 @@ func (b0 GetAccessListOwnersRequest_builder) Build() *GetAccessListOwnersRequest
 	b, x := &b0, m0
 	_, _ = b, x
 	x.AccessList = b.AccessList
+	x.AccessListScope = b.AccessListScope
 	return m0
 }
 
@@ -2432,7 +2592,11 @@ type DeleteAccessListMemberRequest struct {
 	// access_list is the name of access list.
 	AccessList string `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3" json:"access_list,omitempty"`
 	// member_name is the name of the user to delete.
-	MemberName    string `protobuf:"bytes,3,opt,name=member_name,json=memberName,proto3" json:"member_name,omitempty"`
+	MemberName string `protobuf:"bytes,3,opt,name=member_name,json=memberName,proto3" json:"member_name,omitempty"`
+	// access_list_scope is the scope of the access list that the member belongs to.
+	AccessListScope string `protobuf:"bytes,4,opt,name=access_list_scope,json=accessListScope,proto3" json:"access_list_scope,omitempty"`
+	// member_scope is the scope of the member, in case the member is a scoped access list.
+	MemberScope   string `protobuf:"bytes,5,opt,name=member_scope,json=memberScope,proto3" json:"member_scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2476,12 +2640,34 @@ func (x *DeleteAccessListMemberRequest) GetMemberName() string {
 	return ""
 }
 
+func (x *DeleteAccessListMemberRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.AccessListScope
+	}
+	return ""
+}
+
+func (x *DeleteAccessListMemberRequest) GetMemberScope() string {
+	if x != nil {
+		return x.MemberScope
+	}
+	return ""
+}
+
 func (x *DeleteAccessListMemberRequest) SetAccessList(v string) {
 	x.AccessList = v
 }
 
 func (x *DeleteAccessListMemberRequest) SetMemberName(v string) {
 	x.MemberName = v
+}
+
+func (x *DeleteAccessListMemberRequest) SetAccessListScope(v string) {
+	x.AccessListScope = v
+}
+
+func (x *DeleteAccessListMemberRequest) SetMemberScope(v string) {
+	x.MemberScope = v
 }
 
 type DeleteAccessListMemberRequest_builder struct {
@@ -2491,6 +2677,10 @@ type DeleteAccessListMemberRequest_builder struct {
 	AccessList string
 	// member_name is the name of the user to delete.
 	MemberName string
+	// access_list_scope is the scope of the access list that the member belongs to.
+	AccessListScope string
+	// member_scope is the scope of the member, in case the member is a scoped access list.
+	MemberScope string
 }
 
 func (b0 DeleteAccessListMemberRequest_builder) Build() *DeleteAccessListMemberRequest {
@@ -2499,6 +2689,8 @@ func (b0 DeleteAccessListMemberRequest_builder) Build() *DeleteAccessListMemberR
 	_, _ = b, x
 	x.AccessList = b.AccessList
 	x.MemberName = b.MemberName
+	x.AccessListScope = b.AccessListScope
+	x.MemberScope = b.MemberScope
 	return m0
 }
 
@@ -2509,7 +2701,11 @@ type DeleteStaticAccessListMemberRequest struct {
 	// access_list is the name of access list.
 	AccessList string `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3" json:"access_list,omitempty"`
 	// member_name is the name of the user to delete.
-	MemberName    string `protobuf:"bytes,2,opt,name=member_name,json=memberName,proto3" json:"member_name,omitempty"`
+	MemberName string `protobuf:"bytes,2,opt,name=member_name,json=memberName,proto3" json:"member_name,omitempty"`
+	// access_list_scope is the scope of the access list that the member belongs to.
+	AccessListScope string `protobuf:"bytes,3,opt,name=access_list_scope,json=accessListScope,proto3" json:"access_list_scope,omitempty"`
+	// member_scope is the scope of the member, in case the member is a scoped access list.
+	MemberScope   string `protobuf:"bytes,4,opt,name=member_scope,json=memberScope,proto3" json:"member_scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2553,12 +2749,34 @@ func (x *DeleteStaticAccessListMemberRequest) GetMemberName() string {
 	return ""
 }
 
+func (x *DeleteStaticAccessListMemberRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.AccessListScope
+	}
+	return ""
+}
+
+func (x *DeleteStaticAccessListMemberRequest) GetMemberScope() string {
+	if x != nil {
+		return x.MemberScope
+	}
+	return ""
+}
+
 func (x *DeleteStaticAccessListMemberRequest) SetAccessList(v string) {
 	x.AccessList = v
 }
 
 func (x *DeleteStaticAccessListMemberRequest) SetMemberName(v string) {
 	x.MemberName = v
+}
+
+func (x *DeleteStaticAccessListMemberRequest) SetAccessListScope(v string) {
+	x.AccessListScope = v
+}
+
+func (x *DeleteStaticAccessListMemberRequest) SetMemberScope(v string) {
+	x.MemberScope = v
 }
 
 type DeleteStaticAccessListMemberRequest_builder struct {
@@ -2568,6 +2786,10 @@ type DeleteStaticAccessListMemberRequest_builder struct {
 	AccessList string
 	// member_name is the name of the user to delete.
 	MemberName string
+	// access_list_scope is the scope of the access list that the member belongs to.
+	AccessListScope string
+	// member_scope is the scope of the member, in case the member is a scoped access list.
+	MemberScope string
 }
 
 func (b0 DeleteStaticAccessListMemberRequest_builder) Build() *DeleteStaticAccessListMemberRequest {
@@ -2576,6 +2798,8 @@ func (b0 DeleteStaticAccessListMemberRequest_builder) Build() *DeleteStaticAcces
 	_, _ = b, x
 	x.AccessList = b.AccessList
 	x.MemberName = b.MemberName
+	x.AccessListScope = b.AccessListScope
+	x.MemberScope = b.MemberScope
 	return m0
 }
 
@@ -2629,9 +2853,11 @@ func (b0 DeleteStaticAccessListMemberResponse_builder) Build() *DeleteStaticAcce
 type DeleteAllAccessListMembersForAccessListRequest struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// access_list is the name of access list.
-	AccessList    string `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3" json:"access_list,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	AccessList string `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3" json:"access_list,omitempty"`
+	// access_list_scope is the scope of the access list.
+	AccessListScope string `protobuf:"bytes,2,opt,name=access_list_scope,json=accessListScope,proto3" json:"access_list_scope,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *DeleteAllAccessListMembersForAccessListRequest) Reset() {
@@ -2666,8 +2892,19 @@ func (x *DeleteAllAccessListMembersForAccessListRequest) GetAccessList() string 
 	return ""
 }
 
+func (x *DeleteAllAccessListMembersForAccessListRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.AccessListScope
+	}
+	return ""
+}
+
 func (x *DeleteAllAccessListMembersForAccessListRequest) SetAccessList(v string) {
 	x.AccessList = v
+}
+
+func (x *DeleteAllAccessListMembersForAccessListRequest) SetAccessListScope(v string) {
+	x.AccessListScope = v
 }
 
 type DeleteAllAccessListMembersForAccessListRequest_builder struct {
@@ -2675,6 +2912,8 @@ type DeleteAllAccessListMembersForAccessListRequest_builder struct {
 
 	// access_list is the name of access list.
 	AccessList string
+	// access_list_scope is the scope of the access list.
+	AccessListScope string
 }
 
 func (b0 DeleteAllAccessListMembersForAccessListRequest_builder) Build() *DeleteAllAccessListMembersForAccessListRequest {
@@ -2682,6 +2921,7 @@ func (b0 DeleteAllAccessListMembersForAccessListRequest_builder) Build() *Delete
 	b, x := &b0, m0
 	_, _ = b, x
 	x.AccessList = b.AccessList
+	x.AccessListScope = b.AccessListScope
 	return m0
 }
 
@@ -2739,9 +2979,11 @@ type ListAccessListReviewsRequest struct {
 	// page_size is the size of the page to request.
 	PageSize int32 `protobuf:"varint,2,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
 	// next_token is the page token.
-	NextToken     string `protobuf:"bytes,3,opt,name=next_token,json=nextToken,proto3" json:"next_token,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	NextToken string `protobuf:"bytes,3,opt,name=next_token,json=nextToken,proto3" json:"next_token,omitempty"`
+	// access_list_scope is the scope of the access list.
+	AccessListScope string `protobuf:"bytes,4,opt,name=access_list_scope,json=accessListScope,proto3" json:"access_list_scope,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *ListAccessListReviewsRequest) Reset() {
@@ -2790,6 +3032,13 @@ func (x *ListAccessListReviewsRequest) GetNextToken() string {
 	return ""
 }
 
+func (x *ListAccessListReviewsRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.AccessListScope
+	}
+	return ""
+}
+
 func (x *ListAccessListReviewsRequest) SetAccessList(v string) {
 	x.AccessList = v
 }
@@ -2802,6 +3051,10 @@ func (x *ListAccessListReviewsRequest) SetNextToken(v string) {
 	x.NextToken = v
 }
 
+func (x *ListAccessListReviewsRequest) SetAccessListScope(v string) {
+	x.AccessListScope = v
+}
+
 type ListAccessListReviewsRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -2811,6 +3064,8 @@ type ListAccessListReviewsRequest_builder struct {
 	PageSize int32
 	// next_token is the page token.
 	NextToken string
+	// access_list_scope is the scope of the access list.
+	AccessListScope string
 }
 
 func (b0 ListAccessListReviewsRequest_builder) Build() *ListAccessListReviewsRequest {
@@ -2820,6 +3075,7 @@ func (b0 ListAccessListReviewsRequest_builder) Build() *ListAccessListReviewsReq
 	x.AccessList = b.AccessList
 	x.PageSize = b.PageSize
 	x.NextToken = b.NextToken
+	x.AccessListScope = b.AccessListScope
 	return m0
 }
 
@@ -3222,8 +3478,10 @@ type DeleteAccessListReviewRequest struct {
 	ReviewName string `protobuf:"bytes,1,opt,name=review_name,json=reviewName,proto3" json:"review_name,omitempty"`
 	// access_list_name is the name of the access list to delete the review from.
 	AccessListName string `protobuf:"bytes,2,opt,name=access_list_name,json=accessListName,proto3" json:"access_list_name,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// access_list_scope is the scope of the access list.
+	AccessListScope string `protobuf:"bytes,3,opt,name=access_list_scope,json=accessListScope,proto3" json:"access_list_scope,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *DeleteAccessListReviewRequest) Reset() {
@@ -3265,12 +3523,23 @@ func (x *DeleteAccessListReviewRequest) GetAccessListName() string {
 	return ""
 }
 
+func (x *DeleteAccessListReviewRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.AccessListScope
+	}
+	return ""
+}
+
 func (x *DeleteAccessListReviewRequest) SetReviewName(v string) {
 	x.ReviewName = v
 }
 
 func (x *DeleteAccessListReviewRequest) SetAccessListName(v string) {
 	x.AccessListName = v
+}
+
+func (x *DeleteAccessListReviewRequest) SetAccessListScope(v string) {
+	x.AccessListScope = v
 }
 
 type DeleteAccessListReviewRequest_builder struct {
@@ -3280,6 +3549,8 @@ type DeleteAccessListReviewRequest_builder struct {
 	ReviewName string
 	// access_list_name is the name of the access list to delete the review from.
 	AccessListName string
+	// access_list_scope is the scope of the access list.
+	AccessListScope string
 }
 
 func (b0 DeleteAccessListReviewRequest_builder) Build() *DeleteAccessListReviewRequest {
@@ -3288,6 +3559,7 @@ func (b0 DeleteAccessListReviewRequest_builder) Build() *DeleteAccessListReviewR
 	_, _ = b, x
 	x.ReviewName = b.ReviewName
 	x.AccessListName = b.AccessListName
+	x.AccessListScope = b.AccessListScope
 	return m0
 }
 
@@ -4179,37 +4451,42 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"\x06origin\x18\x04 \x01(\tR\x06origin\"\x8a\x01\n" +
 	"\x19ListAccessListsV2Response\x12E\n" +
 	"\faccess_lists\x18\x01 \x03(\v2\".teleport.accesslist.v1.AccessListR\vaccessLists\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"A\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"m\n" +
 	"\x19GetInheritedGrantsRequest\x12$\n" +
-	"\x0eaccess_list_id\x18\x01 \x01(\tR\faccessListId\"^\n" +
+	"\x0eaccess_list_id\x18\x01 \x01(\tR\faccessListId\x12*\n" +
+	"\x11access_list_scope\x18\x02 \x01(\tR\x0faccessListScope\"^\n" +
 	"\x1aGetInheritedGrantsResponse\x12@\n" +
-	"\x06grants\x18\x01 \x01(\v2(.teleport.accesslist.v1.AccessListGrantsR\x06grants\"*\n" +
+	"\x06grants\x18\x01 \x01(\v2(.teleport.accesslist.v1.AccessListGrantsR\x06grants\"@\n" +
 	"\x14GetAccessListRequest\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\"^\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"^\n" +
 	"\x17UpsertAccessListRequest\x12C\n" +
 	"\vaccess_list\x18\x01 \x01(\v2\".teleport.accesslist.v1.AccessListR\n" +
 	"accessList\"^\n" +
 	"\x17UpdateAccessListRequest\x12C\n" +
 	"\vaccess_list\x18\x01 \x01(\v2\".teleport.accesslist.v1.AccessListR\n" +
-	"accessList\"-\n" +
+	"accessList\"C\n" +
 	"\x17DeleteAccessListRequest\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\"\x1d\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"\x1d\n" +
 	"\x1bDeleteAllAccessListsRequest\"\x1f\n" +
 	"\x1dGetAccessListsToReviewRequest\"g\n" +
 	"\x1eGetAccessListsToReviewResponse\x12E\n" +
-	"\faccess_lists\x18\x01 \x03(\v2\".teleport.accesslist.v1.AccessListR\vaccessLists\"I\n" +
+	"\faccess_lists\x18\x01 \x03(\v2\".teleport.accesslist.v1.AccessListR\vaccessLists\"u\n" +
 	"\x1dCountAccessListMembersRequest\x12(\n" +
-	"\x10access_list_name\x18\x01 \x01(\tR\x0eaccessListName\"U\n" +
+	"\x10access_list_name\x18\x01 \x01(\tR\x0eaccessListName\x12*\n" +
+	"\x11access_list_scope\x18\x02 \x01(\tR\x0faccessListScope\"U\n" +
 	"\x1eCountAccessListMembersResponse\x12\x14\n" +
 	"\x05count\x18\x01 \x01(\rR\x05count\x12\x1d\n" +
 	"\n" +
-	"list_count\x18\x02 \x01(\rR\tlistCount\"{\n" +
+	"list_count\x18\x02 \x01(\rR\tlistCount\"\xa7\x01\n" +
 	"\x1cListAccessListMembersRequest\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
 	"page_token\x18\x02 \x01(\tR\tpageToken\x12\x1f\n" +
 	"\vaccess_list\x18\x03 \x01(\tR\n" +
-	"accessList\"\x81\x01\n" +
+	"accessList\x12*\n" +
+	"\x11access_list_scope\x18\x04 \x01(\tR\x0faccessListScope\"\x81\x01\n" +
 	"\x1dListAccessListMembersResponse\x128\n" +
 	"\amembers\x18\x01 \x03(\v2\x1e.teleport.accesslist.v1.MemberR\amembers\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"]\n" +
@@ -4227,22 +4504,27 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"#UpsertAccessListWithMembersResponse\x12C\n" +
 	"\vaccess_list\x18\x01 \x01(\v2\".teleport.accesslist.v1.AccessListR\n" +
 	"accessList\x128\n" +
-	"\amembers\x18\x02 \x03(\v2\x1e.teleport.accesslist.v1.MemberR\amembers\"^\n" +
+	"\amembers\x18\x02 \x03(\v2\x1e.teleport.accesslist.v1.MemberR\amembers\"\xad\x01\n" +
 	"\x1aGetAccessListMemberRequest\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
 	"accessList\x12\x1f\n" +
 	"\vmember_name\x18\x02 \x01(\tR\n" +
-	"memberName\"d\n" +
+	"memberName\x12*\n" +
+	"\x11access_list_scope\x18\x03 \x01(\tR\x0faccessListScope\x12!\n" +
+	"\fmember_scope\x18\x04 \x01(\tR\vmemberScope\"\xb3\x01\n" +
 	" GetStaticAccessListMemberRequest\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
 	"accessList\x12\x1f\n" +
 	"\vmember_name\x18\x02 \x01(\tR\n" +
-	"memberName\"[\n" +
+	"memberName\x12*\n" +
+	"\x11access_list_scope\x18\x03 \x01(\tR\x0faccessListScope\x12!\n" +
+	"\fmember_scope\x18\x04 \x01(\tR\vmemberScope\"[\n" +
 	"!GetStaticAccessListMemberResponse\x126\n" +
-	"\x06member\x18\x01 \x01(\v2\x1e.teleport.accesslist.v1.MemberR\x06member\"=\n" +
+	"\x06member\x18\x01 \x01(\v2\x1e.teleport.accesslist.v1.MemberR\x06member\"i\n" +
 	"\x1aGetAccessListOwnersRequest\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
-	"accessList\"^\n" +
+	"accessList\x12*\n" +
+	"\x11access_list_scope\x18\x03 \x01(\tR\x0faccessListScope\"^\n" +
 	"\x1bGetAccessListOwnersResponse\x12?\n" +
 	"\x06owners\x18\x01 \x03(\v2'.teleport.accesslist.v1.AccessListOwnerR\x06owners\"\x84\x01\n" +
 	"\x1dUpsertAccessListMemberRequest\x126\n" +
@@ -4252,28 +4534,34 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"$UpsertStaticAccessListMemberResponse\x126\n" +
 	"\x06member\x18\x01 \x01(\v2\x1e.teleport.accesslist.v1.MemberR\x06member\"W\n" +
 	"\x1dUpdateAccessListMemberRequest\x126\n" +
-	"\x06member\x18\x01 \x01(\v2\x1e.teleport.accesslist.v1.MemberR\x06member\"m\n" +
+	"\x06member\x18\x01 \x01(\v2\x1e.teleport.accesslist.v1.MemberR\x06member\"\xbc\x01\n" +
 	"\x1dDeleteAccessListMemberRequest\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
 	"accessList\x12\x1f\n" +
 	"\vmember_name\x18\x03 \x01(\tR\n" +
-	"memberNameJ\x04\b\x02\x10\x03R\x04name\"g\n" +
+	"memberName\x12*\n" +
+	"\x11access_list_scope\x18\x04 \x01(\tR\x0faccessListScope\x12!\n" +
+	"\fmember_scope\x18\x05 \x01(\tR\vmemberScopeJ\x04\b\x02\x10\x03R\x04name\"\xb6\x01\n" +
 	"#DeleteStaticAccessListMemberRequest\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
 	"accessList\x12\x1f\n" +
 	"\vmember_name\x18\x02 \x01(\tR\n" +
-	"memberName\"&\n" +
-	"$DeleteStaticAccessListMemberResponse\"Q\n" +
+	"memberName\x12*\n" +
+	"\x11access_list_scope\x18\x03 \x01(\tR\x0faccessListScope\x12!\n" +
+	"\fmember_scope\x18\x04 \x01(\tR\vmemberScope\"&\n" +
+	"$DeleteStaticAccessListMemberResponse\"}\n" +
 	".DeleteAllAccessListMembersForAccessListRequest\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
-	"accessList\"6\n" +
-	"!DeleteAllAccessListMembersRequestJ\x04\b\x01\x10\x02R\vaccess_list\"{\n" +
+	"accessList\x12*\n" +
+	"\x11access_list_scope\x18\x02 \x01(\tR\x0faccessListScope\"6\n" +
+	"!DeleteAllAccessListMembersRequestJ\x04\b\x01\x10\x02R\vaccess_list\"\xa7\x01\n" +
 	"\x1cListAccessListReviewsRequest\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
 	"accessList\x12\x1b\n" +
 	"\tpage_size\x18\x02 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
-	"next_token\x18\x03 \x01(\tR\tnextToken\"x\n" +
+	"next_token\x18\x03 \x01(\tR\tnextToken\x12*\n" +
+	"\x11access_list_scope\x18\x04 \x01(\tR\x0faccessListScope\"x\n" +
 	"\x1dListAccessListReviewsResponse\x128\n" +
 	"\areviews\x18\x01 \x03(\v2\x1e.teleport.accesslist.v1.ReviewR\areviews\x12\x1d\n" +
 	"\n" +
@@ -4291,11 +4579,12 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"\x1eCreateAccessListReviewResponse\x12\x1f\n" +
 	"\vreview_name\x18\x01 \x01(\tR\n" +
 	"reviewName\x12B\n" +
-	"\x0fnext_audit_date\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\rnextAuditDate\"j\n" +
+	"\x0fnext_audit_date\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\rnextAuditDate\"\x96\x01\n" +
 	"\x1dDeleteAccessListReviewRequest\x12\x1f\n" +
 	"\vreview_name\x18\x01 \x01(\tR\n" +
 	"reviewName\x12(\n" +
-	"\x10access_list_name\x18\x02 \x01(\tR\x0eaccessListName\"~\n" +
+	"\x10access_list_name\x18\x02 \x01(\tR\x0eaccessListName\x12*\n" +
+	"\x11access_list_scope\x18\x03 \x01(\tR\x0faccessListScope\"~\n" +
 	"\x1bAccessRequestPromoteRequest\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12(\n" +

--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_service_protoopaque.pb.go
@@ -602,10 +602,11 @@ func (b0 ListAccessListsV2Response_builder) Build() *ListAccessListsV2Response {
 
 // GetInheritedGrantsRequest is the request for getting inherited grants.
 type GetInheritedGrantsRequest struct {
-	state                   protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_AccessListId string                 `protobuf:"bytes,1,opt,name=access_list_id,json=accessListId,proto3"`
-	unknownFields           protoimpl.UnknownFields
-	sizeCache               protoimpl.SizeCache
+	state                      protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_AccessListId    string                 `protobuf:"bytes,1,opt,name=access_list_id,json=accessListId,proto3"`
+	xxx_hidden_AccessListScope string                 `protobuf:"bytes,2,opt,name=access_list_scope,json=accessListScope,proto3"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *GetInheritedGrantsRequest) Reset() {
@@ -640,8 +641,19 @@ func (x *GetInheritedGrantsRequest) GetAccessListId() string {
 	return ""
 }
 
+func (x *GetInheritedGrantsRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.xxx_hidden_AccessListScope
+	}
+	return ""
+}
+
 func (x *GetInheritedGrantsRequest) SetAccessListId(v string) {
 	x.xxx_hidden_AccessListId = v
+}
+
+func (x *GetInheritedGrantsRequest) SetAccessListScope(v string) {
+	x.xxx_hidden_AccessListScope = v
 }
 
 type GetInheritedGrantsRequest_builder struct {
@@ -649,6 +661,8 @@ type GetInheritedGrantsRequest_builder struct {
 
 	// access_list_id is the ID of the access list to retrieve.
 	AccessListId string
+	// access_list_scope is the scope of the access list to retrieve.
+	AccessListScope string
 }
 
 func (b0 GetInheritedGrantsRequest_builder) Build() *GetInheritedGrantsRequest {
@@ -656,6 +670,7 @@ func (b0 GetInheritedGrantsRequest_builder) Build() *GetInheritedGrantsRequest {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_AccessListId = b.AccessListId
+	x.xxx_hidden_AccessListScope = b.AccessListScope
 	return m0
 }
 
@@ -731,10 +746,11 @@ func (b0 GetInheritedGrantsResponse_builder) Build() *GetInheritedGrantsResponse
 
 // GetAccessListRequest is the request for retrieving an access list.
 type GetAccessListRequest struct {
-	state           protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Name string                 `protobuf:"bytes,1,opt,name=name,proto3"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state            protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Name  string                 `protobuf:"bytes,1,opt,name=name,proto3"`
+	xxx_hidden_Scope string                 `protobuf:"bytes,2,opt,name=scope,proto3"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *GetAccessListRequest) Reset() {
@@ -769,8 +785,19 @@ func (x *GetAccessListRequest) GetName() string {
 	return ""
 }
 
+func (x *GetAccessListRequest) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
 func (x *GetAccessListRequest) SetName(v string) {
 	x.xxx_hidden_Name = v
+}
+
+func (x *GetAccessListRequest) SetScope(v string) {
+	x.xxx_hidden_Scope = v
 }
 
 type GetAccessListRequest_builder struct {
@@ -778,6 +805,8 @@ type GetAccessListRequest_builder struct {
 
 	// name is the name of the access list to retrieve.
 	Name string
+	// scope is the scope of the access list to retrieve.
+	Scope string
 }
 
 func (b0 GetAccessListRequest_builder) Build() *GetAccessListRequest {
@@ -785,6 +814,7 @@ func (b0 GetAccessListRequest_builder) Build() *GetAccessListRequest {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_Name = b.Name
+	x.xxx_hidden_Scope = b.Scope
 	return m0
 }
 
@@ -930,10 +960,11 @@ func (b0 UpdateAccessListRequest_builder) Build() *UpdateAccessListRequest {
 
 // DeleteAccessListRequest is the request for deleting an access list.
 type DeleteAccessListRequest struct {
-	state           protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Name string                 `protobuf:"bytes,1,opt,name=name,proto3"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state            protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Name  string                 `protobuf:"bytes,1,opt,name=name,proto3"`
+	xxx_hidden_Scope string                 `protobuf:"bytes,2,opt,name=scope,proto3"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *DeleteAccessListRequest) Reset() {
@@ -968,8 +999,19 @@ func (x *DeleteAccessListRequest) GetName() string {
 	return ""
 }
 
+func (x *DeleteAccessListRequest) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
 func (x *DeleteAccessListRequest) SetName(v string) {
 	x.xxx_hidden_Name = v
+}
+
+func (x *DeleteAccessListRequest) SetScope(v string) {
+	x.xxx_hidden_Scope = v
 }
 
 type DeleteAccessListRequest_builder struct {
@@ -977,6 +1019,8 @@ type DeleteAccessListRequest_builder struct {
 
 	// name is the name of the access list to delete.
 	Name string
+	// scope is the scope of the access list to delete.
+	Scope string
 }
 
 func (b0 DeleteAccessListRequest_builder) Build() *DeleteAccessListRequest {
@@ -984,6 +1028,7 @@ func (b0 DeleteAccessListRequest_builder) Build() *DeleteAccessListRequest {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_Name = b.Name
+	x.xxx_hidden_Scope = b.Scope
 	return m0
 }
 
@@ -1140,10 +1185,11 @@ func (b0 GetAccessListsToReviewResponse_builder) Build() *GetAccessListsToReview
 // CountAccessListMembersRequest is the request for counting access list
 // members.
 type CountAccessListMembersRequest struct {
-	state                     protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_AccessListName string                 `protobuf:"bytes,1,opt,name=access_list_name,json=accessListName,proto3"`
-	unknownFields             protoimpl.UnknownFields
-	sizeCache                 protoimpl.SizeCache
+	state                      protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_AccessListName  string                 `protobuf:"bytes,1,opt,name=access_list_name,json=accessListName,proto3"`
+	xxx_hidden_AccessListScope string                 `protobuf:"bytes,2,opt,name=access_list_scope,json=accessListScope,proto3"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *CountAccessListMembersRequest) Reset() {
@@ -1178,8 +1224,19 @@ func (x *CountAccessListMembersRequest) GetAccessListName() string {
 	return ""
 }
 
+func (x *CountAccessListMembersRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.xxx_hidden_AccessListScope
+	}
+	return ""
+}
+
 func (x *CountAccessListMembersRequest) SetAccessListName(v string) {
 	x.xxx_hidden_AccessListName = v
+}
+
+func (x *CountAccessListMembersRequest) SetAccessListScope(v string) {
+	x.xxx_hidden_AccessListScope = v
 }
 
 type CountAccessListMembersRequest_builder struct {
@@ -1187,6 +1244,8 @@ type CountAccessListMembersRequest_builder struct {
 
 	// access_list_name is the name of the access list to retrieve.
 	AccessListName string
+	// access_list_scope is the scope of the access list to retrieve.
+	AccessListScope string
 }
 
 func (b0 CountAccessListMembersRequest_builder) Build() *CountAccessListMembersRequest {
@@ -1194,6 +1253,7 @@ func (b0 CountAccessListMembersRequest_builder) Build() *CountAccessListMembersR
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_AccessListName = b.AccessListName
+	x.xxx_hidden_AccessListScope = b.AccessListScope
 	return m0
 }
 
@@ -1275,12 +1335,13 @@ func (b0 CountAccessListMembersResponse_builder) Build() *CountAccessListMembers
 // ListAccessListMembersRequest is the request for getting paginated access list
 // members.
 type ListAccessListMembersRequest struct {
-	state                 protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_PageSize   int32                  `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3"`
-	xxx_hidden_PageToken  string                 `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3"`
-	xxx_hidden_AccessList string                 `protobuf:"bytes,3,opt,name=access_list,json=accessList,proto3"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	state                      protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_PageSize        int32                  `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3"`
+	xxx_hidden_PageToken       string                 `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3"`
+	xxx_hidden_AccessList      string                 `protobuf:"bytes,3,opt,name=access_list,json=accessList,proto3"`
+	xxx_hidden_AccessListScope string                 `protobuf:"bytes,4,opt,name=access_list_scope,json=accessListScope,proto3"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *ListAccessListMembersRequest) Reset() {
@@ -1329,6 +1390,13 @@ func (x *ListAccessListMembersRequest) GetAccessList() string {
 	return ""
 }
 
+func (x *ListAccessListMembersRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.xxx_hidden_AccessListScope
+	}
+	return ""
+}
+
 func (x *ListAccessListMembersRequest) SetPageSize(v int32) {
 	x.xxx_hidden_PageSize = v
 }
@@ -1341,6 +1409,10 @@ func (x *ListAccessListMembersRequest) SetAccessList(v string) {
 	x.xxx_hidden_AccessList = v
 }
 
+func (x *ListAccessListMembersRequest) SetAccessListScope(v string) {
+	x.xxx_hidden_AccessListScope = v
+}
+
 type ListAccessListMembersRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -1350,6 +1422,8 @@ type ListAccessListMembersRequest_builder struct {
 	PageToken string
 	// access_list is the name of the access list that the member belongs to.
 	AccessList string
+	// access_list_scope is the scope of the access list that the member belongs to.
+	AccessListScope string
 }
 
 func (b0 ListAccessListMembersRequest_builder) Build() *ListAccessListMembersRequest {
@@ -1359,6 +1433,7 @@ func (b0 ListAccessListMembersRequest_builder) Build() *ListAccessListMembersReq
 	x.xxx_hidden_PageSize = b.PageSize
 	x.xxx_hidden_PageToken = b.PageToken
 	x.xxx_hidden_AccessList = b.AccessList
+	x.xxx_hidden_AccessListScope = b.AccessListScope
 	return m0
 }
 
@@ -1769,11 +1844,13 @@ func (b0 UpsertAccessListWithMembersResponse_builder) Build() *UpsertAccessListW
 
 // GetAccessListMemberRequest is the request for retrieving an access_list_member.
 type GetAccessListMemberRequest struct {
-	state                 protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_AccessList string                 `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3"`
-	xxx_hidden_MemberName string                 `protobuf:"bytes,2,opt,name=member_name,json=memberName,proto3"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	state                      protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_AccessList      string                 `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3"`
+	xxx_hidden_MemberName      string                 `protobuf:"bytes,2,opt,name=member_name,json=memberName,proto3"`
+	xxx_hidden_AccessListScope string                 `protobuf:"bytes,3,opt,name=access_list_scope,json=accessListScope,proto3"`
+	xxx_hidden_MemberScope     string                 `protobuf:"bytes,4,opt,name=member_scope,json=memberScope,proto3"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *GetAccessListMemberRequest) Reset() {
@@ -1815,12 +1892,34 @@ func (x *GetAccessListMemberRequest) GetMemberName() string {
 	return ""
 }
 
+func (x *GetAccessListMemberRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.xxx_hidden_AccessListScope
+	}
+	return ""
+}
+
+func (x *GetAccessListMemberRequest) GetMemberScope() string {
+	if x != nil {
+		return x.xxx_hidden_MemberScope
+	}
+	return ""
+}
+
 func (x *GetAccessListMemberRequest) SetAccessList(v string) {
 	x.xxx_hidden_AccessList = v
 }
 
 func (x *GetAccessListMemberRequest) SetMemberName(v string) {
 	x.xxx_hidden_MemberName = v
+}
+
+func (x *GetAccessListMemberRequest) SetAccessListScope(v string) {
+	x.xxx_hidden_AccessListScope = v
+}
+
+func (x *GetAccessListMemberRequest) SetMemberScope(v string) {
+	x.xxx_hidden_MemberScope = v
 }
 
 type GetAccessListMemberRequest_builder struct {
@@ -1830,6 +1929,10 @@ type GetAccessListMemberRequest_builder struct {
 	AccessList string
 	// member_name is the name of the user that belongs to the access list.
 	MemberName string
+	// access_list_scope is the scope of the access list that the member belongs to.
+	AccessListScope string
+	// member_scope is the scope of the member, in case the member is a scoped access list.
+	MemberScope string
 }
 
 func (b0 GetAccessListMemberRequest_builder) Build() *GetAccessListMemberRequest {
@@ -1838,17 +1941,21 @@ func (b0 GetAccessListMemberRequest_builder) Build() *GetAccessListMemberRequest
 	_, _ = b, x
 	x.xxx_hidden_AccessList = b.AccessList
 	x.xxx_hidden_MemberName = b.MemberName
+	x.xxx_hidden_AccessListScope = b.AccessListScope
+	x.xxx_hidden_MemberScope = b.MemberScope
 	return m0
 }
 
 // GetStaticAccessListMemberRequest is the request for retrieving an access_list_member of a static
 // type access_list.
 type GetStaticAccessListMemberRequest struct {
-	state                 protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_AccessList string                 `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3"`
-	xxx_hidden_MemberName string                 `protobuf:"bytes,2,opt,name=member_name,json=memberName,proto3"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	state                      protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_AccessList      string                 `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3"`
+	xxx_hidden_MemberName      string                 `protobuf:"bytes,2,opt,name=member_name,json=memberName,proto3"`
+	xxx_hidden_AccessListScope string                 `protobuf:"bytes,3,opt,name=access_list_scope,json=accessListScope,proto3"`
+	xxx_hidden_MemberScope     string                 `protobuf:"bytes,4,opt,name=member_scope,json=memberScope,proto3"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *GetStaticAccessListMemberRequest) Reset() {
@@ -1890,12 +1997,34 @@ func (x *GetStaticAccessListMemberRequest) GetMemberName() string {
 	return ""
 }
 
+func (x *GetStaticAccessListMemberRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.xxx_hidden_AccessListScope
+	}
+	return ""
+}
+
+func (x *GetStaticAccessListMemberRequest) GetMemberScope() string {
+	if x != nil {
+		return x.xxx_hidden_MemberScope
+	}
+	return ""
+}
+
 func (x *GetStaticAccessListMemberRequest) SetAccessList(v string) {
 	x.xxx_hidden_AccessList = v
 }
 
 func (x *GetStaticAccessListMemberRequest) SetMemberName(v string) {
 	x.xxx_hidden_MemberName = v
+}
+
+func (x *GetStaticAccessListMemberRequest) SetAccessListScope(v string) {
+	x.xxx_hidden_AccessListScope = v
+}
+
+func (x *GetStaticAccessListMemberRequest) SetMemberScope(v string) {
+	x.xxx_hidden_MemberScope = v
 }
 
 type GetStaticAccessListMemberRequest_builder struct {
@@ -1905,6 +2034,10 @@ type GetStaticAccessListMemberRequest_builder struct {
 	AccessList string
 	// member_name is the name of the user that belongs to the access_list.
 	MemberName string
+	// access_list_scope is the scope of the access list that the member belongs to.
+	AccessListScope string
+	// member_scope is the scope of the member, in case the member is a scoped access list.
+	MemberScope string
 }
 
 func (b0 GetStaticAccessListMemberRequest_builder) Build() *GetStaticAccessListMemberRequest {
@@ -1913,6 +2046,8 @@ func (b0 GetStaticAccessListMemberRequest_builder) Build() *GetStaticAccessListM
 	_, _ = b, x
 	x.xxx_hidden_AccessList = b.AccessList
 	x.xxx_hidden_MemberName = b.MemberName
+	x.xxx_hidden_AccessListScope = b.AccessListScope
+	x.xxx_hidden_MemberScope = b.MemberScope
 	return m0
 }
 
@@ -1990,10 +2125,11 @@ func (b0 GetStaticAccessListMemberResponse_builder) Build() *GetStaticAccessList
 // GetAccessListOwnersRequest is the request for getting a list of all owners
 // in an Access List, including those inherited from nested Access Lists.
 type GetAccessListOwnersRequest struct {
-	state                 protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_AccessList string                 `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	state                      protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_AccessList      string                 `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3"`
+	xxx_hidden_AccessListScope string                 `protobuf:"bytes,3,opt,name=access_list_scope,json=accessListScope,proto3"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *GetAccessListOwnersRequest) Reset() {
@@ -2028,8 +2164,19 @@ func (x *GetAccessListOwnersRequest) GetAccessList() string {
 	return ""
 }
 
+func (x *GetAccessListOwnersRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.xxx_hidden_AccessListScope
+	}
+	return ""
+}
+
 func (x *GetAccessListOwnersRequest) SetAccessList(v string) {
 	x.xxx_hidden_AccessList = v
+}
+
+func (x *GetAccessListOwnersRequest) SetAccessListScope(v string) {
+	x.xxx_hidden_AccessListScope = v
 }
 
 type GetAccessListOwnersRequest_builder struct {
@@ -2037,6 +2184,8 @@ type GetAccessListOwnersRequest_builder struct {
 
 	// access_list is the name of the access list.
 	AccessList string
+	// access_list_scope is the scope of the access list.
+	AccessListScope string
 }
 
 func (b0 GetAccessListOwnersRequest_builder) Build() *GetAccessListOwnersRequest {
@@ -2044,6 +2193,7 @@ func (b0 GetAccessListOwnersRequest_builder) Build() *GetAccessListOwnersRequest
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_AccessList = b.AccessList
+	x.xxx_hidden_AccessListScope = b.AccessListScope
 	return m0
 }
 
@@ -2397,11 +2547,13 @@ func (b0 UpdateAccessListMemberRequest_builder) Build() *UpdateAccessListMemberR
 // DeleteAccessListMemberRequest is the request for deleting a member from an
 // access list.
 type DeleteAccessListMemberRequest struct {
-	state                 protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_AccessList string                 `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3"`
-	xxx_hidden_MemberName string                 `protobuf:"bytes,3,opt,name=member_name,json=memberName,proto3"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	state                      protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_AccessList      string                 `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3"`
+	xxx_hidden_MemberName      string                 `protobuf:"bytes,3,opt,name=member_name,json=memberName,proto3"`
+	xxx_hidden_AccessListScope string                 `protobuf:"bytes,4,opt,name=access_list_scope,json=accessListScope,proto3"`
+	xxx_hidden_MemberScope     string                 `protobuf:"bytes,5,opt,name=member_scope,json=memberScope,proto3"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *DeleteAccessListMemberRequest) Reset() {
@@ -2443,12 +2595,34 @@ func (x *DeleteAccessListMemberRequest) GetMemberName() string {
 	return ""
 }
 
+func (x *DeleteAccessListMemberRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.xxx_hidden_AccessListScope
+	}
+	return ""
+}
+
+func (x *DeleteAccessListMemberRequest) GetMemberScope() string {
+	if x != nil {
+		return x.xxx_hidden_MemberScope
+	}
+	return ""
+}
+
 func (x *DeleteAccessListMemberRequest) SetAccessList(v string) {
 	x.xxx_hidden_AccessList = v
 }
 
 func (x *DeleteAccessListMemberRequest) SetMemberName(v string) {
 	x.xxx_hidden_MemberName = v
+}
+
+func (x *DeleteAccessListMemberRequest) SetAccessListScope(v string) {
+	x.xxx_hidden_AccessListScope = v
+}
+
+func (x *DeleteAccessListMemberRequest) SetMemberScope(v string) {
+	x.xxx_hidden_MemberScope = v
 }
 
 type DeleteAccessListMemberRequest_builder struct {
@@ -2458,6 +2632,10 @@ type DeleteAccessListMemberRequest_builder struct {
 	AccessList string
 	// member_name is the name of the user to delete.
 	MemberName string
+	// access_list_scope is the scope of the access list that the member belongs to.
+	AccessListScope string
+	// member_scope is the scope of the member, in case the member is a scoped access list.
+	MemberScope string
 }
 
 func (b0 DeleteAccessListMemberRequest_builder) Build() *DeleteAccessListMemberRequest {
@@ -2466,17 +2644,21 @@ func (b0 DeleteAccessListMemberRequest_builder) Build() *DeleteAccessListMemberR
 	_, _ = b, x
 	x.xxx_hidden_AccessList = b.AccessList
 	x.xxx_hidden_MemberName = b.MemberName
+	x.xxx_hidden_AccessListScope = b.AccessListScope
+	x.xxx_hidden_MemberScope = b.MemberScope
 	return m0
 }
 
 // DeleteStaticAccessListMemberRequest is the request for deleting an access_list_member from an
 // access_list of type static.
 type DeleteStaticAccessListMemberRequest struct {
-	state                 protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_AccessList string                 `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3"`
-	xxx_hidden_MemberName string                 `protobuf:"bytes,2,opt,name=member_name,json=memberName,proto3"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	state                      protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_AccessList      string                 `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3"`
+	xxx_hidden_MemberName      string                 `protobuf:"bytes,2,opt,name=member_name,json=memberName,proto3"`
+	xxx_hidden_AccessListScope string                 `protobuf:"bytes,3,opt,name=access_list_scope,json=accessListScope,proto3"`
+	xxx_hidden_MemberScope     string                 `protobuf:"bytes,4,opt,name=member_scope,json=memberScope,proto3"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *DeleteStaticAccessListMemberRequest) Reset() {
@@ -2518,12 +2700,34 @@ func (x *DeleteStaticAccessListMemberRequest) GetMemberName() string {
 	return ""
 }
 
+func (x *DeleteStaticAccessListMemberRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.xxx_hidden_AccessListScope
+	}
+	return ""
+}
+
+func (x *DeleteStaticAccessListMemberRequest) GetMemberScope() string {
+	if x != nil {
+		return x.xxx_hidden_MemberScope
+	}
+	return ""
+}
+
 func (x *DeleteStaticAccessListMemberRequest) SetAccessList(v string) {
 	x.xxx_hidden_AccessList = v
 }
 
 func (x *DeleteStaticAccessListMemberRequest) SetMemberName(v string) {
 	x.xxx_hidden_MemberName = v
+}
+
+func (x *DeleteStaticAccessListMemberRequest) SetAccessListScope(v string) {
+	x.xxx_hidden_AccessListScope = v
+}
+
+func (x *DeleteStaticAccessListMemberRequest) SetMemberScope(v string) {
+	x.xxx_hidden_MemberScope = v
 }
 
 type DeleteStaticAccessListMemberRequest_builder struct {
@@ -2533,6 +2737,10 @@ type DeleteStaticAccessListMemberRequest_builder struct {
 	AccessList string
 	// member_name is the name of the user to delete.
 	MemberName string
+	// access_list_scope is the scope of the access list that the member belongs to.
+	AccessListScope string
+	// member_scope is the scope of the member, in case the member is a scoped access list.
+	MemberScope string
 }
 
 func (b0 DeleteStaticAccessListMemberRequest_builder) Build() *DeleteStaticAccessListMemberRequest {
@@ -2541,6 +2749,8 @@ func (b0 DeleteStaticAccessListMemberRequest_builder) Build() *DeleteStaticAcces
 	_, _ = b, x
 	x.xxx_hidden_AccessList = b.AccessList
 	x.xxx_hidden_MemberName = b.MemberName
+	x.xxx_hidden_AccessListScope = b.AccessListScope
+	x.xxx_hidden_MemberScope = b.MemberScope
 	return m0
 }
 
@@ -2592,10 +2802,11 @@ func (b0 DeleteStaticAccessListMemberResponse_builder) Build() *DeleteStaticAcce
 // DeleteAllAccessListMembersForAccessListRequest is the request for deleting
 // all members from an access list.
 type DeleteAllAccessListMembersForAccessListRequest struct {
-	state                 protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_AccessList string                 `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	state                      protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_AccessList      string                 `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3"`
+	xxx_hidden_AccessListScope string                 `protobuf:"bytes,2,opt,name=access_list_scope,json=accessListScope,proto3"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *DeleteAllAccessListMembersForAccessListRequest) Reset() {
@@ -2630,8 +2841,19 @@ func (x *DeleteAllAccessListMembersForAccessListRequest) GetAccessList() string 
 	return ""
 }
 
+func (x *DeleteAllAccessListMembersForAccessListRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.xxx_hidden_AccessListScope
+	}
+	return ""
+}
+
 func (x *DeleteAllAccessListMembersForAccessListRequest) SetAccessList(v string) {
 	x.xxx_hidden_AccessList = v
+}
+
+func (x *DeleteAllAccessListMembersForAccessListRequest) SetAccessListScope(v string) {
+	x.xxx_hidden_AccessListScope = v
 }
 
 type DeleteAllAccessListMembersForAccessListRequest_builder struct {
@@ -2639,6 +2861,8 @@ type DeleteAllAccessListMembersForAccessListRequest_builder struct {
 
 	// access_list is the name of access list.
 	AccessList string
+	// access_list_scope is the scope of the access list.
+	AccessListScope string
 }
 
 func (b0 DeleteAllAccessListMembersForAccessListRequest_builder) Build() *DeleteAllAccessListMembersForAccessListRequest {
@@ -2646,6 +2870,7 @@ func (b0 DeleteAllAccessListMembersForAccessListRequest_builder) Build() *Delete
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_AccessList = b.AccessList
+	x.xxx_hidden_AccessListScope = b.AccessListScope
 	return m0
 }
 
@@ -2697,12 +2922,13 @@ func (b0 DeleteAllAccessListMembersRequest_builder) Build() *DeleteAllAccessList
 // ListAccessListReviewsRequest is the request for getting paginated access list
 // reviews for a particular access list.
 type ListAccessListReviewsRequest struct {
-	state                 protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_AccessList string                 `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3"`
-	xxx_hidden_PageSize   int32                  `protobuf:"varint,2,opt,name=page_size,json=pageSize,proto3"`
-	xxx_hidden_NextToken  string                 `protobuf:"bytes,3,opt,name=next_token,json=nextToken,proto3"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	state                      protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_AccessList      string                 `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3"`
+	xxx_hidden_PageSize        int32                  `protobuf:"varint,2,opt,name=page_size,json=pageSize,proto3"`
+	xxx_hidden_NextToken       string                 `protobuf:"bytes,3,opt,name=next_token,json=nextToken,proto3"`
+	xxx_hidden_AccessListScope string                 `protobuf:"bytes,4,opt,name=access_list_scope,json=accessListScope,proto3"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *ListAccessListReviewsRequest) Reset() {
@@ -2751,6 +2977,13 @@ func (x *ListAccessListReviewsRequest) GetNextToken() string {
 	return ""
 }
 
+func (x *ListAccessListReviewsRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.xxx_hidden_AccessListScope
+	}
+	return ""
+}
+
 func (x *ListAccessListReviewsRequest) SetAccessList(v string) {
 	x.xxx_hidden_AccessList = v
 }
@@ -2763,6 +2996,10 @@ func (x *ListAccessListReviewsRequest) SetNextToken(v string) {
 	x.xxx_hidden_NextToken = v
 }
 
+func (x *ListAccessListReviewsRequest) SetAccessListScope(v string) {
+	x.xxx_hidden_AccessListScope = v
+}
+
 type ListAccessListReviewsRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -2772,6 +3009,8 @@ type ListAccessListReviewsRequest_builder struct {
 	PageSize int32
 	// next_token is the page token.
 	NextToken string
+	// access_list_scope is the scope of the access list.
+	AccessListScope string
 }
 
 func (b0 ListAccessListReviewsRequest_builder) Build() *ListAccessListReviewsRequest {
@@ -2781,6 +3020,7 @@ func (b0 ListAccessListReviewsRequest_builder) Build() *ListAccessListReviewsReq
 	x.xxx_hidden_AccessList = b.AccessList
 	x.xxx_hidden_PageSize = b.PageSize
 	x.xxx_hidden_NextToken = b.NextToken
+	x.xxx_hidden_AccessListScope = b.AccessListScope
 	return m0
 }
 
@@ -3173,11 +3413,12 @@ func (b0 CreateAccessListReviewResponse_builder) Build() *CreateAccessListReview
 // DeleteAccessListReviewRequest is the request for deleting an access list
 // review.
 type DeleteAccessListReviewRequest struct {
-	state                     protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_ReviewName     string                 `protobuf:"bytes,1,opt,name=review_name,json=reviewName,proto3"`
-	xxx_hidden_AccessListName string                 `protobuf:"bytes,2,opt,name=access_list_name,json=accessListName,proto3"`
-	unknownFields             protoimpl.UnknownFields
-	sizeCache                 protoimpl.SizeCache
+	state                      protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_ReviewName      string                 `protobuf:"bytes,1,opt,name=review_name,json=reviewName,proto3"`
+	xxx_hidden_AccessListName  string                 `protobuf:"bytes,2,opt,name=access_list_name,json=accessListName,proto3"`
+	xxx_hidden_AccessListScope string                 `protobuf:"bytes,3,opt,name=access_list_scope,json=accessListScope,proto3"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *DeleteAccessListReviewRequest) Reset() {
@@ -3219,12 +3460,23 @@ func (x *DeleteAccessListReviewRequest) GetAccessListName() string {
 	return ""
 }
 
+func (x *DeleteAccessListReviewRequest) GetAccessListScope() string {
+	if x != nil {
+		return x.xxx_hidden_AccessListScope
+	}
+	return ""
+}
+
 func (x *DeleteAccessListReviewRequest) SetReviewName(v string) {
 	x.xxx_hidden_ReviewName = v
 }
 
 func (x *DeleteAccessListReviewRequest) SetAccessListName(v string) {
 	x.xxx_hidden_AccessListName = v
+}
+
+func (x *DeleteAccessListReviewRequest) SetAccessListScope(v string) {
+	x.xxx_hidden_AccessListScope = v
 }
 
 type DeleteAccessListReviewRequest_builder struct {
@@ -3234,6 +3486,8 @@ type DeleteAccessListReviewRequest_builder struct {
 	ReviewName string
 	// access_list_name is the name of the access list to delete the review from.
 	AccessListName string
+	// access_list_scope is the scope of the access list.
+	AccessListScope string
 }
 
 func (b0 DeleteAccessListReviewRequest_builder) Build() *DeleteAccessListReviewRequest {
@@ -3242,6 +3496,7 @@ func (b0 DeleteAccessListReviewRequest_builder) Build() *DeleteAccessListReviewR
 	_, _ = b, x
 	x.xxx_hidden_ReviewName = b.ReviewName
 	x.xxx_hidden_AccessListName = b.AccessListName
+	x.xxx_hidden_AccessListScope = b.AccessListScope
 	return m0
 }
 
@@ -4120,37 +4375,42 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"\x06origin\x18\x04 \x01(\tR\x06origin\"\x8a\x01\n" +
 	"\x19ListAccessListsV2Response\x12E\n" +
 	"\faccess_lists\x18\x01 \x03(\v2\".teleport.accesslist.v1.AccessListR\vaccessLists\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"A\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"m\n" +
 	"\x19GetInheritedGrantsRequest\x12$\n" +
-	"\x0eaccess_list_id\x18\x01 \x01(\tR\faccessListId\"^\n" +
+	"\x0eaccess_list_id\x18\x01 \x01(\tR\faccessListId\x12*\n" +
+	"\x11access_list_scope\x18\x02 \x01(\tR\x0faccessListScope\"^\n" +
 	"\x1aGetInheritedGrantsResponse\x12@\n" +
-	"\x06grants\x18\x01 \x01(\v2(.teleport.accesslist.v1.AccessListGrantsR\x06grants\"*\n" +
+	"\x06grants\x18\x01 \x01(\v2(.teleport.accesslist.v1.AccessListGrantsR\x06grants\"@\n" +
 	"\x14GetAccessListRequest\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\"^\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"^\n" +
 	"\x17UpsertAccessListRequest\x12C\n" +
 	"\vaccess_list\x18\x01 \x01(\v2\".teleport.accesslist.v1.AccessListR\n" +
 	"accessList\"^\n" +
 	"\x17UpdateAccessListRequest\x12C\n" +
 	"\vaccess_list\x18\x01 \x01(\v2\".teleport.accesslist.v1.AccessListR\n" +
-	"accessList\"-\n" +
+	"accessList\"C\n" +
 	"\x17DeleteAccessListRequest\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\"\x1d\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"\x1d\n" +
 	"\x1bDeleteAllAccessListsRequest\"\x1f\n" +
 	"\x1dGetAccessListsToReviewRequest\"g\n" +
 	"\x1eGetAccessListsToReviewResponse\x12E\n" +
-	"\faccess_lists\x18\x01 \x03(\v2\".teleport.accesslist.v1.AccessListR\vaccessLists\"I\n" +
+	"\faccess_lists\x18\x01 \x03(\v2\".teleport.accesslist.v1.AccessListR\vaccessLists\"u\n" +
 	"\x1dCountAccessListMembersRequest\x12(\n" +
-	"\x10access_list_name\x18\x01 \x01(\tR\x0eaccessListName\"U\n" +
+	"\x10access_list_name\x18\x01 \x01(\tR\x0eaccessListName\x12*\n" +
+	"\x11access_list_scope\x18\x02 \x01(\tR\x0faccessListScope\"U\n" +
 	"\x1eCountAccessListMembersResponse\x12\x14\n" +
 	"\x05count\x18\x01 \x01(\rR\x05count\x12\x1d\n" +
 	"\n" +
-	"list_count\x18\x02 \x01(\rR\tlistCount\"{\n" +
+	"list_count\x18\x02 \x01(\rR\tlistCount\"\xa7\x01\n" +
 	"\x1cListAccessListMembersRequest\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
 	"page_token\x18\x02 \x01(\tR\tpageToken\x12\x1f\n" +
 	"\vaccess_list\x18\x03 \x01(\tR\n" +
-	"accessList\"\x81\x01\n" +
+	"accessList\x12*\n" +
+	"\x11access_list_scope\x18\x04 \x01(\tR\x0faccessListScope\"\x81\x01\n" +
 	"\x1dListAccessListMembersResponse\x128\n" +
 	"\amembers\x18\x01 \x03(\v2\x1e.teleport.accesslist.v1.MemberR\amembers\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"]\n" +
@@ -4168,22 +4428,27 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"#UpsertAccessListWithMembersResponse\x12C\n" +
 	"\vaccess_list\x18\x01 \x01(\v2\".teleport.accesslist.v1.AccessListR\n" +
 	"accessList\x128\n" +
-	"\amembers\x18\x02 \x03(\v2\x1e.teleport.accesslist.v1.MemberR\amembers\"^\n" +
+	"\amembers\x18\x02 \x03(\v2\x1e.teleport.accesslist.v1.MemberR\amembers\"\xad\x01\n" +
 	"\x1aGetAccessListMemberRequest\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
 	"accessList\x12\x1f\n" +
 	"\vmember_name\x18\x02 \x01(\tR\n" +
-	"memberName\"d\n" +
+	"memberName\x12*\n" +
+	"\x11access_list_scope\x18\x03 \x01(\tR\x0faccessListScope\x12!\n" +
+	"\fmember_scope\x18\x04 \x01(\tR\vmemberScope\"\xb3\x01\n" +
 	" GetStaticAccessListMemberRequest\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
 	"accessList\x12\x1f\n" +
 	"\vmember_name\x18\x02 \x01(\tR\n" +
-	"memberName\"[\n" +
+	"memberName\x12*\n" +
+	"\x11access_list_scope\x18\x03 \x01(\tR\x0faccessListScope\x12!\n" +
+	"\fmember_scope\x18\x04 \x01(\tR\vmemberScope\"[\n" +
 	"!GetStaticAccessListMemberResponse\x126\n" +
-	"\x06member\x18\x01 \x01(\v2\x1e.teleport.accesslist.v1.MemberR\x06member\"=\n" +
+	"\x06member\x18\x01 \x01(\v2\x1e.teleport.accesslist.v1.MemberR\x06member\"i\n" +
 	"\x1aGetAccessListOwnersRequest\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
-	"accessList\"^\n" +
+	"accessList\x12*\n" +
+	"\x11access_list_scope\x18\x03 \x01(\tR\x0faccessListScope\"^\n" +
 	"\x1bGetAccessListOwnersResponse\x12?\n" +
 	"\x06owners\x18\x01 \x03(\v2'.teleport.accesslist.v1.AccessListOwnerR\x06owners\"\x84\x01\n" +
 	"\x1dUpsertAccessListMemberRequest\x126\n" +
@@ -4193,28 +4458,34 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"$UpsertStaticAccessListMemberResponse\x126\n" +
 	"\x06member\x18\x01 \x01(\v2\x1e.teleport.accesslist.v1.MemberR\x06member\"W\n" +
 	"\x1dUpdateAccessListMemberRequest\x126\n" +
-	"\x06member\x18\x01 \x01(\v2\x1e.teleport.accesslist.v1.MemberR\x06member\"m\n" +
+	"\x06member\x18\x01 \x01(\v2\x1e.teleport.accesslist.v1.MemberR\x06member\"\xbc\x01\n" +
 	"\x1dDeleteAccessListMemberRequest\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
 	"accessList\x12\x1f\n" +
 	"\vmember_name\x18\x03 \x01(\tR\n" +
-	"memberNameJ\x04\b\x02\x10\x03R\x04name\"g\n" +
+	"memberName\x12*\n" +
+	"\x11access_list_scope\x18\x04 \x01(\tR\x0faccessListScope\x12!\n" +
+	"\fmember_scope\x18\x05 \x01(\tR\vmemberScopeJ\x04\b\x02\x10\x03R\x04name\"\xb6\x01\n" +
 	"#DeleteStaticAccessListMemberRequest\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
 	"accessList\x12\x1f\n" +
 	"\vmember_name\x18\x02 \x01(\tR\n" +
-	"memberName\"&\n" +
-	"$DeleteStaticAccessListMemberResponse\"Q\n" +
+	"memberName\x12*\n" +
+	"\x11access_list_scope\x18\x03 \x01(\tR\x0faccessListScope\x12!\n" +
+	"\fmember_scope\x18\x04 \x01(\tR\vmemberScope\"&\n" +
+	"$DeleteStaticAccessListMemberResponse\"}\n" +
 	".DeleteAllAccessListMembersForAccessListRequest\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
-	"accessList\"6\n" +
-	"!DeleteAllAccessListMembersRequestJ\x04\b\x01\x10\x02R\vaccess_list\"{\n" +
+	"accessList\x12*\n" +
+	"\x11access_list_scope\x18\x02 \x01(\tR\x0faccessListScope\"6\n" +
+	"!DeleteAllAccessListMembersRequestJ\x04\b\x01\x10\x02R\vaccess_list\"\xa7\x01\n" +
 	"\x1cListAccessListReviewsRequest\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
 	"accessList\x12\x1b\n" +
 	"\tpage_size\x18\x02 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
-	"next_token\x18\x03 \x01(\tR\tnextToken\"x\n" +
+	"next_token\x18\x03 \x01(\tR\tnextToken\x12*\n" +
+	"\x11access_list_scope\x18\x04 \x01(\tR\x0faccessListScope\"x\n" +
 	"\x1dListAccessListReviewsResponse\x128\n" +
 	"\areviews\x18\x01 \x03(\v2\x1e.teleport.accesslist.v1.ReviewR\areviews\x12\x1d\n" +
 	"\n" +
@@ -4232,11 +4503,12 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"\x1eCreateAccessListReviewResponse\x12\x1f\n" +
 	"\vreview_name\x18\x01 \x01(\tR\n" +
 	"reviewName\x12B\n" +
-	"\x0fnext_audit_date\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\rnextAuditDate\"j\n" +
+	"\x0fnext_audit_date\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\rnextAuditDate\"\x96\x01\n" +
 	"\x1dDeleteAccessListReviewRequest\x12\x1f\n" +
 	"\vreview_name\x18\x01 \x01(\tR\n" +
 	"reviewName\x12(\n" +
-	"\x10access_list_name\x18\x02 \x01(\tR\x0eaccessListName\"~\n" +
+	"\x10access_list_name\x18\x02 \x01(\tR\x0eaccessListName\x12*\n" +
+	"\x11access_list_scope\x18\x03 \x01(\tR\x0faccessListScope\"~\n" +
 	"\x1bAccessRequestPromoteRequest\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12(\n" +

--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_service_protoopaque.pb.go
@@ -23,6 +23,7 @@
 package accesslistv1
 
 import (
+	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	types "github.com/gravitational/teleport/api/types"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -296,13 +297,14 @@ func (b0 ListAccessListsResponse_builder) Build() *ListAccessListsResponse {
 
 // ListAccessListsV2Request is the request for getting filtered and sorted paginated access lists.
 type ListAccessListsV2Request struct {
-	state                protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_PageSize  int32                  `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3"`
-	xxx_hidden_PageToken string                 `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3"`
-	xxx_hidden_SortBy    *types.SortBy          `protobuf:"bytes,3,opt,name=sort_by,json=sortBy,proto3"`
-	xxx_hidden_Filter    *AccessListsFilter     `protobuf:"bytes,4,opt,name=filter,proto3"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	state                  protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_PageSize    int32                  `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3"`
+	xxx_hidden_PageToken   string                 `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3"`
+	xxx_hidden_SortBy      *types.SortBy          `protobuf:"bytes,3,opt,name=sort_by,json=sortBy,proto3"`
+	xxx_hidden_Filter      *AccessListsFilter     `protobuf:"bytes,4,opt,name=filter,proto3"`
+	xxx_hidden_ScopeFilter *v1.Filter             `protobuf:"bytes,5,opt,name=scope_filter,json=scopeFilter,proto3"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *ListAccessListsV2Request) Reset() {
@@ -358,6 +360,13 @@ func (x *ListAccessListsV2Request) GetFilter() *AccessListsFilter {
 	return nil
 }
 
+func (x *ListAccessListsV2Request) GetScopeFilter() *v1.Filter {
+	if x != nil {
+		return x.xxx_hidden_ScopeFilter
+	}
+	return nil
+}
+
 func (x *ListAccessListsV2Request) SetPageSize(v int32) {
 	x.xxx_hidden_PageSize = v
 }
@@ -374,6 +383,10 @@ func (x *ListAccessListsV2Request) SetFilter(v *AccessListsFilter) {
 	x.xxx_hidden_Filter = v
 }
 
+func (x *ListAccessListsV2Request) SetScopeFilter(v *v1.Filter) {
+	x.xxx_hidden_ScopeFilter = v
+}
+
 func (x *ListAccessListsV2Request) HasSortBy() bool {
 	if x == nil {
 		return false
@@ -388,12 +401,23 @@ func (x *ListAccessListsV2Request) HasFilter() bool {
 	return x.xxx_hidden_Filter != nil
 }
 
+func (x *ListAccessListsV2Request) HasScopeFilter() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_ScopeFilter != nil
+}
+
 func (x *ListAccessListsV2Request) ClearSortBy() {
 	x.xxx_hidden_SortBy = nil
 }
 
 func (x *ListAccessListsV2Request) ClearFilter() {
 	x.xxx_hidden_Filter = nil
+}
+
+func (x *ListAccessListsV2Request) ClearScopeFilter() {
+	x.xxx_hidden_ScopeFilter = nil
 }
 
 type ListAccessListsV2Request_builder struct {
@@ -407,6 +431,10 @@ type ListAccessListsV2Request_builder struct {
 	SortBy *types.SortBy
 	// filter is a collection of fields to filter access lists.
 	Filter *AccessListsFilter
+	// scope_filter filters access lists by scope. Defaults to one of EXACT or
+	// UNSCOPED depending on whether the caller is a scoped or unscoped identity.
+	// Exhaustive user-facing views (e.g. `tctl get`) should specify mode ALL.
+	ScopeFilter *v1.Filter
 }
 
 func (b0 ListAccessListsV2Request_builder) Build() *ListAccessListsV2Request {
@@ -417,6 +445,7 @@ func (b0 ListAccessListsV2Request_builder) Build() *ListAccessListsV2Request {
 	x.xxx_hidden_PageToken = b.PageToken
 	x.xxx_hidden_SortBy = b.SortBy
 	x.xxx_hidden_Filter = b.Filter
+	x.xxx_hidden_ScopeFilter = b.ScopeFilter
 	return m0
 }
 
@@ -1517,11 +1546,12 @@ func (b0 ListAccessListMembersResponse_builder) Build() *ListAccessListMembersRe
 // ListAllAccessListMembersRequest is the request for getting paginated access
 // list members for all access lists.
 type ListAllAccessListMembersRequest struct {
-	state                protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_PageSize  int32                  `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3"`
-	xxx_hidden_PageToken string                 `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	state                  protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_PageSize    int32                  `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3"`
+	xxx_hidden_PageToken   string                 `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3"`
+	xxx_hidden_ScopeFilter *v1.Filter             `protobuf:"bytes,3,opt,name=scope_filter,json=scopeFilter,proto3"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *ListAllAccessListMembersRequest) Reset() {
@@ -1563,12 +1593,34 @@ func (x *ListAllAccessListMembersRequest) GetPageToken() string {
 	return ""
 }
 
+func (x *ListAllAccessListMembersRequest) GetScopeFilter() *v1.Filter {
+	if x != nil {
+		return x.xxx_hidden_ScopeFilter
+	}
+	return nil
+}
+
 func (x *ListAllAccessListMembersRequest) SetPageSize(v int32) {
 	x.xxx_hidden_PageSize = v
 }
 
 func (x *ListAllAccessListMembersRequest) SetPageToken(v string) {
 	x.xxx_hidden_PageToken = v
+}
+
+func (x *ListAllAccessListMembersRequest) SetScopeFilter(v *v1.Filter) {
+	x.xxx_hidden_ScopeFilter = v
+}
+
+func (x *ListAllAccessListMembersRequest) HasScopeFilter() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_ScopeFilter != nil
+}
+
+func (x *ListAllAccessListMembersRequest) ClearScopeFilter() {
+	x.xxx_hidden_ScopeFilter = nil
 }
 
 type ListAllAccessListMembersRequest_builder struct {
@@ -1578,6 +1630,10 @@ type ListAllAccessListMembersRequest_builder struct {
 	PageSize int32
 	// page_token is the page token.
 	PageToken string
+	// scope_filter filters access list members by their resource scope. Defaults
+	// to one of EXACT or UNSCOPED depending on whether the caller is a scoped or
+	// unscoped identity.
+	ScopeFilter *v1.Filter
 }
 
 func (b0 ListAllAccessListMembersRequest_builder) Build() *ListAllAccessListMembersRequest {
@@ -1586,6 +1642,7 @@ func (b0 ListAllAccessListMembersRequest_builder) Build() *ListAllAccessListMemb
 	_, _ = b, x
 	x.xxx_hidden_PageSize = b.PageSize
 	x.xxx_hidden_PageToken = b.PageToken
+	x.xxx_hidden_ScopeFilter = b.ScopeFilter
 	return m0
 }
 
@@ -3104,11 +3161,12 @@ func (b0 ListAccessListReviewsResponse_builder) Build() *ListAccessListReviewsRe
 // ListAllAccessListReviewsRequest is the request for getting paginated access
 // list reviews for all access lists.
 type ListAllAccessListReviewsRequest struct {
-	state                protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_PageSize  int32                  `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3"`
-	xxx_hidden_NextToken string                 `protobuf:"bytes,2,opt,name=next_token,json=nextToken,proto3"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	state                  protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_PageSize    int32                  `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3"`
+	xxx_hidden_NextToken   string                 `protobuf:"bytes,2,opt,name=next_token,json=nextToken,proto3"`
+	xxx_hidden_ScopeFilter *v1.Filter             `protobuf:"bytes,3,opt,name=scope_filter,json=scopeFilter,proto3"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *ListAllAccessListReviewsRequest) Reset() {
@@ -3150,12 +3208,34 @@ func (x *ListAllAccessListReviewsRequest) GetNextToken() string {
 	return ""
 }
 
+func (x *ListAllAccessListReviewsRequest) GetScopeFilter() *v1.Filter {
+	if x != nil {
+		return x.xxx_hidden_ScopeFilter
+	}
+	return nil
+}
+
 func (x *ListAllAccessListReviewsRequest) SetPageSize(v int32) {
 	x.xxx_hidden_PageSize = v
 }
 
 func (x *ListAllAccessListReviewsRequest) SetNextToken(v string) {
 	x.xxx_hidden_NextToken = v
+}
+
+func (x *ListAllAccessListReviewsRequest) SetScopeFilter(v *v1.Filter) {
+	x.xxx_hidden_ScopeFilter = v
+}
+
+func (x *ListAllAccessListReviewsRequest) HasScopeFilter() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_ScopeFilter != nil
+}
+
+func (x *ListAllAccessListReviewsRequest) ClearScopeFilter() {
+	x.xxx_hidden_ScopeFilter = nil
 }
 
 type ListAllAccessListReviewsRequest_builder struct {
@@ -3165,6 +3245,9 @@ type ListAllAccessListReviewsRequest_builder struct {
 	PageSize int32
 	// next_token is the page token.
 	NextToken string
+	// scope_filter filters reviews by scope. Defaults to one of EXACT or
+	// UNSCOPED depending on whether the caller is a scoped or unscoped identity.
+	ScopeFilter *v1.Filter
 }
 
 func (b0 ListAllAccessListReviewsRequest_builder) Build() *ListAllAccessListReviewsRequest {
@@ -3173,6 +3256,7 @@ func (b0 ListAllAccessListReviewsRequest_builder) Build() *ListAllAccessListRevi
 	_, _ = b, x
 	x.xxx_hidden_PageSize = b.PageSize
 	x.xxx_hidden_NextToken = b.NextToken
+	x.xxx_hidden_ScopeFilter = b.ScopeFilter
 	return m0
 }
 
@@ -4350,7 +4434,7 @@ var File_teleport_accesslist_v1_accesslist_service_proto protoreflect.FileDescri
 
 const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"\n" +
-	"/teleport/accesslist/v1/accesslist_service.proto\x12\x16teleport.accesslist.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a'teleport/accesslist/v1/accesslist.proto\x1a!teleport/legacy/types/types.proto\"\x17\n" +
+	"/teleport/accesslist/v1/accesslist_service.proto\x12\x16teleport.accesslist.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a'teleport/accesslist/v1/accesslist.proto\x1a!teleport/legacy/types/types.proto\x1a\x1fteleport/scopes/v1/scopes.proto\"\x17\n" +
 	"\x15GetAccessListsRequest\"_\n" +
 	"\x16GetAccessListsResponse\x12E\n" +
 	"\faccess_lists\x18\x01 \x03(\v2\".teleport.accesslist.v1.AccessListR\vaccessLists\"T\n" +
@@ -4361,13 +4445,14 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"\x17ListAccessListsResponse\x12E\n" +
 	"\faccess_lists\x18\x01 \x03(\v2\".teleport.accesslist.v1.AccessListR\vaccessLists\x12\x1d\n" +
 	"\n" +
-	"next_token\x18\x02 \x01(\tR\tnextToken\"\xc1\x01\n" +
+	"next_token\x18\x02 \x01(\tR\tnextToken\"\x80\x02\n" +
 	"\x18ListAccessListsV2Request\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
 	"page_token\x18\x02 \x01(\tR\tpageToken\x12&\n" +
 	"\asort_by\x18\x03 \x01(\v2\r.types.SortByR\x06sortBy\x12A\n" +
-	"\x06filter\x18\x04 \x01(\v2).teleport.accesslist.v1.AccessListsFilterR\x06filter\"q\n" +
+	"\x06filter\x18\x04 \x01(\v2).teleport.accesslist.v1.AccessListsFilterR\x06filter\x12=\n" +
+	"\fscope_filter\x18\x05 \x01(\v2\x1a.teleport.scopes.v1.FilterR\vscopeFilter\"q\n" +
 	"\x11AccessListsFilter\x12\x16\n" +
 	"\x06search\x18\x01 \x01(\tR\x06search\x12\x16\n" +
 	"\x06owners\x18\x02 \x03(\tR\x06owners\x12\x14\n" +
@@ -4413,11 +4498,12 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"\x11access_list_scope\x18\x04 \x01(\tR\x0faccessListScope\"\x81\x01\n" +
 	"\x1dListAccessListMembersResponse\x128\n" +
 	"\amembers\x18\x01 \x03(\v2\x1e.teleport.accesslist.v1.MemberR\amembers\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"]\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\x9c\x01\n" +
 	"\x1fListAllAccessListMembersRequest\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
-	"page_token\x18\x02 \x01(\tR\tpageToken\"\x84\x01\n" +
+	"page_token\x18\x02 \x01(\tR\tpageToken\x12=\n" +
+	"\fscope_filter\x18\x03 \x01(\v2\x1a.teleport.scopes.v1.FilterR\vscopeFilter\"\x84\x01\n" +
 	" ListAllAccessListMembersResponse\x128\n" +
 	"\amembers\x18\x01 \x03(\v2\x1e.teleport.accesslist.v1.MemberR\amembers\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\xa3\x01\n" +
@@ -4489,11 +4575,12 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"\x1dListAccessListReviewsResponse\x128\n" +
 	"\areviews\x18\x01 \x03(\v2\x1e.teleport.accesslist.v1.ReviewR\areviews\x12\x1d\n" +
 	"\n" +
-	"next_token\x18\x02 \x01(\tR\tnextToken\"]\n" +
+	"next_token\x18\x02 \x01(\tR\tnextToken\"\x9c\x01\n" +
 	"\x1fListAllAccessListReviewsRequest\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
-	"next_token\x18\x02 \x01(\tR\tnextToken\"{\n" +
+	"next_token\x18\x02 \x01(\tR\tnextToken\x12=\n" +
+	"\fscope_filter\x18\x03 \x01(\v2\x1a.teleport.scopes.v1.FilterR\vscopeFilter\"{\n" +
 	" ListAllAccessListReviewsResponse\x128\n" +
 	"\areviews\x18\x01 \x03(\v2\x1e.teleport.accesslist.v1.ReviewR\areviews\x12\x1d\n" +
 	"\n" +
@@ -4643,123 +4730,127 @@ var file_teleport_accesslist_v1_accesslist_service_proto_goTypes = []any{
 	(*UpdateAccessListWithPresetResponse)(nil),             // 54: teleport.accesslist.v1.UpdateAccessListWithPresetResponse
 	(*AccessList)(nil),                                     // 55: teleport.accesslist.v1.AccessList
 	(*types.SortBy)(nil),                                   // 56: types.SortBy
-	(*AccessListGrants)(nil),                               // 57: teleport.accesslist.v1.AccessListGrants
-	(*Member)(nil),                                         // 58: teleport.accesslist.v1.Member
-	(*AccessListOwner)(nil),                                // 59: teleport.accesslist.v1.AccessListOwner
-	(*Review)(nil),                                         // 60: teleport.accesslist.v1.Review
-	(*timestamppb.Timestamp)(nil),                          // 61: google.protobuf.Timestamp
-	(*types.AccessRequestV3)(nil),                          // 62: types.AccessRequestV3
-	(*types.RoleV6)(nil),                                   // 63: types.RoleV6
-	(*emptypb.Empty)(nil),                                  // 64: google.protobuf.Empty
+	(*v1.Filter)(nil),                                      // 57: teleport.scopes.v1.Filter
+	(*AccessListGrants)(nil),                               // 58: teleport.accesslist.v1.AccessListGrants
+	(*Member)(nil),                                         // 59: teleport.accesslist.v1.Member
+	(*AccessListOwner)(nil),                                // 60: teleport.accesslist.v1.AccessListOwner
+	(*Review)(nil),                                         // 61: teleport.accesslist.v1.Review
+	(*timestamppb.Timestamp)(nil),                          // 62: google.protobuf.Timestamp
+	(*types.AccessRequestV3)(nil),                          // 63: types.AccessRequestV3
+	(*types.RoleV6)(nil),                                   // 64: types.RoleV6
+	(*emptypb.Empty)(nil),                                  // 65: google.protobuf.Empty
 }
 var file_teleport_accesslist_v1_accesslist_service_proto_depIdxs = []int32{
 	55, // 0: teleport.accesslist.v1.GetAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
 	55, // 1: teleport.accesslist.v1.ListAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
 	56, // 2: teleport.accesslist.v1.ListAccessListsV2Request.sort_by:type_name -> types.SortBy
 	5,  // 3: teleport.accesslist.v1.ListAccessListsV2Request.filter:type_name -> teleport.accesslist.v1.AccessListsFilter
-	55, // 4: teleport.accesslist.v1.ListAccessListsV2Response.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	57, // 5: teleport.accesslist.v1.GetInheritedGrantsResponse.grants:type_name -> teleport.accesslist.v1.AccessListGrants
-	55, // 6: teleport.accesslist.v1.UpsertAccessListRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
-	55, // 7: teleport.accesslist.v1.UpdateAccessListRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
-	55, // 8: teleport.accesslist.v1.GetAccessListsToReviewResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	58, // 9: teleport.accesslist.v1.ListAccessListMembersResponse.members:type_name -> teleport.accesslist.v1.Member
-	58, // 10: teleport.accesslist.v1.ListAllAccessListMembersResponse.members:type_name -> teleport.accesslist.v1.Member
-	55, // 11: teleport.accesslist.v1.UpsertAccessListWithMembersRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
-	58, // 12: teleport.accesslist.v1.UpsertAccessListWithMembersRequest.members:type_name -> teleport.accesslist.v1.Member
-	55, // 13: teleport.accesslist.v1.UpsertAccessListWithMembersResponse.access_list:type_name -> teleport.accesslist.v1.AccessList
-	58, // 14: teleport.accesslist.v1.UpsertAccessListWithMembersResponse.members:type_name -> teleport.accesslist.v1.Member
-	58, // 15: teleport.accesslist.v1.GetStaticAccessListMemberResponse.member:type_name -> teleport.accesslist.v1.Member
-	59, // 16: teleport.accesslist.v1.GetAccessListOwnersResponse.owners:type_name -> teleport.accesslist.v1.AccessListOwner
-	58, // 17: teleport.accesslist.v1.UpsertAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
-	58, // 18: teleport.accesslist.v1.UpsertStaticAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
-	58, // 19: teleport.accesslist.v1.UpsertStaticAccessListMemberResponse.member:type_name -> teleport.accesslist.v1.Member
-	58, // 20: teleport.accesslist.v1.UpdateAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
-	60, // 21: teleport.accesslist.v1.ListAccessListReviewsResponse.reviews:type_name -> teleport.accesslist.v1.Review
-	60, // 22: teleport.accesslist.v1.ListAllAccessListReviewsResponse.reviews:type_name -> teleport.accesslist.v1.Review
-	60, // 23: teleport.accesslist.v1.CreateAccessListReviewRequest.review:type_name -> teleport.accesslist.v1.Review
-	61, // 24: teleport.accesslist.v1.CreateAccessListReviewResponse.next_audit_date:type_name -> google.protobuf.Timestamp
-	62, // 25: teleport.accesslist.v1.AccessRequestPromoteResponse.access_request:type_name -> types.AccessRequestV3
-	55, // 26: teleport.accesslist.v1.GetSuggestedAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	55, // 27: teleport.accesslist.v1.ListUserAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	55, // 28: teleport.accesslist.v1.CreateAccessListWithPresetRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
-	63, // 29: teleport.accesslist.v1.CreateAccessListWithPresetRequest.roles:type_name -> types.RoleV6
-	55, // 30: teleport.accesslist.v1.CreateAccessListWithPresetResponse.access_list:type_name -> teleport.accesslist.v1.AccessList
-	63, // 31: teleport.accesslist.v1.CreateAccessListWithPresetResponse.roles:type_name -> types.RoleV6
-	55, // 32: teleport.accesslist.v1.UpdateAccessListWithPresetRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
-	63, // 33: teleport.accesslist.v1.UpdateAccessListWithPresetRequest.roles:type_name -> types.RoleV6
-	55, // 34: teleport.accesslist.v1.UpdateAccessListWithPresetResponse.access_list:type_name -> teleport.accesslist.v1.AccessList
-	63, // 35: teleport.accesslist.v1.UpdateAccessListWithPresetResponse.roles:type_name -> types.RoleV6
-	0,  // 36: teleport.accesslist.v1.AccessListService.GetAccessLists:input_type -> teleport.accesslist.v1.GetAccessListsRequest
-	2,  // 37: teleport.accesslist.v1.AccessListService.ListAccessLists:input_type -> teleport.accesslist.v1.ListAccessListsRequest
-	4,  // 38: teleport.accesslist.v1.AccessListService.ListAccessListsV2:input_type -> teleport.accesslist.v1.ListAccessListsV2Request
-	9,  // 39: teleport.accesslist.v1.AccessListService.GetAccessList:input_type -> teleport.accesslist.v1.GetAccessListRequest
-	10, // 40: teleport.accesslist.v1.AccessListService.UpsertAccessList:input_type -> teleport.accesslist.v1.UpsertAccessListRequest
-	11, // 41: teleport.accesslist.v1.AccessListService.UpdateAccessList:input_type -> teleport.accesslist.v1.UpdateAccessListRequest
-	12, // 42: teleport.accesslist.v1.AccessListService.DeleteAccessList:input_type -> teleport.accesslist.v1.DeleteAccessListRequest
-	13, // 43: teleport.accesslist.v1.AccessListService.DeleteAllAccessLists:input_type -> teleport.accesslist.v1.DeleteAllAccessListsRequest
-	14, // 44: teleport.accesslist.v1.AccessListService.GetAccessListsToReview:input_type -> teleport.accesslist.v1.GetAccessListsToReviewRequest
-	16, // 45: teleport.accesslist.v1.AccessListService.CountAccessListMembers:input_type -> teleport.accesslist.v1.CountAccessListMembersRequest
-	18, // 46: teleport.accesslist.v1.AccessListService.ListAccessListMembers:input_type -> teleport.accesslist.v1.ListAccessListMembersRequest
-	20, // 47: teleport.accesslist.v1.AccessListService.ListAllAccessListMembers:input_type -> teleport.accesslist.v1.ListAllAccessListMembersRequest
-	24, // 48: teleport.accesslist.v1.AccessListService.GetAccessListMember:input_type -> teleport.accesslist.v1.GetAccessListMemberRequest
-	25, // 49: teleport.accesslist.v1.AccessListService.GetStaticAccessListMember:input_type -> teleport.accesslist.v1.GetStaticAccessListMemberRequest
-	27, // 50: teleport.accesslist.v1.AccessListService.GetAccessListOwners:input_type -> teleport.accesslist.v1.GetAccessListOwnersRequest
-	29, // 51: teleport.accesslist.v1.AccessListService.UpsertAccessListMember:input_type -> teleport.accesslist.v1.UpsertAccessListMemberRequest
-	30, // 52: teleport.accesslist.v1.AccessListService.UpsertStaticAccessListMember:input_type -> teleport.accesslist.v1.UpsertStaticAccessListMemberRequest
-	32, // 53: teleport.accesslist.v1.AccessListService.UpdateAccessListMember:input_type -> teleport.accesslist.v1.UpdateAccessListMemberRequest
-	33, // 54: teleport.accesslist.v1.AccessListService.DeleteAccessListMember:input_type -> teleport.accesslist.v1.DeleteAccessListMemberRequest
-	34, // 55: teleport.accesslist.v1.AccessListService.DeleteStaticAccessListMember:input_type -> teleport.accesslist.v1.DeleteStaticAccessListMemberRequest
-	36, // 56: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembersForAccessList:input_type -> teleport.accesslist.v1.DeleteAllAccessListMembersForAccessListRequest
-	37, // 57: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembers:input_type -> teleport.accesslist.v1.DeleteAllAccessListMembersRequest
-	22, // 58: teleport.accesslist.v1.AccessListService.UpsertAccessListWithMembers:input_type -> teleport.accesslist.v1.UpsertAccessListWithMembersRequest
-	38, // 59: teleport.accesslist.v1.AccessListService.ListAccessListReviews:input_type -> teleport.accesslist.v1.ListAccessListReviewsRequest
-	40, // 60: teleport.accesslist.v1.AccessListService.ListAllAccessListReviews:input_type -> teleport.accesslist.v1.ListAllAccessListReviewsRequest
-	42, // 61: teleport.accesslist.v1.AccessListService.CreateAccessListReview:input_type -> teleport.accesslist.v1.CreateAccessListReviewRequest
-	44, // 62: teleport.accesslist.v1.AccessListService.DeleteAccessListReview:input_type -> teleport.accesslist.v1.DeleteAccessListReviewRequest
-	45, // 63: teleport.accesslist.v1.AccessListService.AccessRequestPromote:input_type -> teleport.accesslist.v1.AccessRequestPromoteRequest
-	47, // 64: teleport.accesslist.v1.AccessListService.GetSuggestedAccessLists:input_type -> teleport.accesslist.v1.GetSuggestedAccessListsRequest
-	7,  // 65: teleport.accesslist.v1.AccessListService.GetInheritedGrants:input_type -> teleport.accesslist.v1.GetInheritedGrantsRequest
-	49, // 66: teleport.accesslist.v1.AccessListService.ListUserAccessLists:input_type -> teleport.accesslist.v1.ListUserAccessListsRequest
-	51, // 67: teleport.accesslist.v1.AccessListService.CreateAccessListWithPreset:input_type -> teleport.accesslist.v1.CreateAccessListWithPresetRequest
-	53, // 68: teleport.accesslist.v1.AccessListService.UpdateAccessListWithPreset:input_type -> teleport.accesslist.v1.UpdateAccessListWithPresetRequest
-	1,  // 69: teleport.accesslist.v1.AccessListService.GetAccessLists:output_type -> teleport.accesslist.v1.GetAccessListsResponse
-	3,  // 70: teleport.accesslist.v1.AccessListService.ListAccessLists:output_type -> teleport.accesslist.v1.ListAccessListsResponse
-	6,  // 71: teleport.accesslist.v1.AccessListService.ListAccessListsV2:output_type -> teleport.accesslist.v1.ListAccessListsV2Response
-	55, // 72: teleport.accesslist.v1.AccessListService.GetAccessList:output_type -> teleport.accesslist.v1.AccessList
-	55, // 73: teleport.accesslist.v1.AccessListService.UpsertAccessList:output_type -> teleport.accesslist.v1.AccessList
-	55, // 74: teleport.accesslist.v1.AccessListService.UpdateAccessList:output_type -> teleport.accesslist.v1.AccessList
-	64, // 75: teleport.accesslist.v1.AccessListService.DeleteAccessList:output_type -> google.protobuf.Empty
-	64, // 76: teleport.accesslist.v1.AccessListService.DeleteAllAccessLists:output_type -> google.protobuf.Empty
-	15, // 77: teleport.accesslist.v1.AccessListService.GetAccessListsToReview:output_type -> teleport.accesslist.v1.GetAccessListsToReviewResponse
-	17, // 78: teleport.accesslist.v1.AccessListService.CountAccessListMembers:output_type -> teleport.accesslist.v1.CountAccessListMembersResponse
-	19, // 79: teleport.accesslist.v1.AccessListService.ListAccessListMembers:output_type -> teleport.accesslist.v1.ListAccessListMembersResponse
-	21, // 80: teleport.accesslist.v1.AccessListService.ListAllAccessListMembers:output_type -> teleport.accesslist.v1.ListAllAccessListMembersResponse
-	58, // 81: teleport.accesslist.v1.AccessListService.GetAccessListMember:output_type -> teleport.accesslist.v1.Member
-	26, // 82: teleport.accesslist.v1.AccessListService.GetStaticAccessListMember:output_type -> teleport.accesslist.v1.GetStaticAccessListMemberResponse
-	28, // 83: teleport.accesslist.v1.AccessListService.GetAccessListOwners:output_type -> teleport.accesslist.v1.GetAccessListOwnersResponse
-	58, // 84: teleport.accesslist.v1.AccessListService.UpsertAccessListMember:output_type -> teleport.accesslist.v1.Member
-	31, // 85: teleport.accesslist.v1.AccessListService.UpsertStaticAccessListMember:output_type -> teleport.accesslist.v1.UpsertStaticAccessListMemberResponse
-	58, // 86: teleport.accesslist.v1.AccessListService.UpdateAccessListMember:output_type -> teleport.accesslist.v1.Member
-	64, // 87: teleport.accesslist.v1.AccessListService.DeleteAccessListMember:output_type -> google.protobuf.Empty
-	35, // 88: teleport.accesslist.v1.AccessListService.DeleteStaticAccessListMember:output_type -> teleport.accesslist.v1.DeleteStaticAccessListMemberResponse
-	64, // 89: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembersForAccessList:output_type -> google.protobuf.Empty
-	64, // 90: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembers:output_type -> google.protobuf.Empty
-	23, // 91: teleport.accesslist.v1.AccessListService.UpsertAccessListWithMembers:output_type -> teleport.accesslist.v1.UpsertAccessListWithMembersResponse
-	39, // 92: teleport.accesslist.v1.AccessListService.ListAccessListReviews:output_type -> teleport.accesslist.v1.ListAccessListReviewsResponse
-	41, // 93: teleport.accesslist.v1.AccessListService.ListAllAccessListReviews:output_type -> teleport.accesslist.v1.ListAllAccessListReviewsResponse
-	43, // 94: teleport.accesslist.v1.AccessListService.CreateAccessListReview:output_type -> teleport.accesslist.v1.CreateAccessListReviewResponse
-	64, // 95: teleport.accesslist.v1.AccessListService.DeleteAccessListReview:output_type -> google.protobuf.Empty
-	46, // 96: teleport.accesslist.v1.AccessListService.AccessRequestPromote:output_type -> teleport.accesslist.v1.AccessRequestPromoteResponse
-	48, // 97: teleport.accesslist.v1.AccessListService.GetSuggestedAccessLists:output_type -> teleport.accesslist.v1.GetSuggestedAccessListsResponse
-	8,  // 98: teleport.accesslist.v1.AccessListService.GetInheritedGrants:output_type -> teleport.accesslist.v1.GetInheritedGrantsResponse
-	50, // 99: teleport.accesslist.v1.AccessListService.ListUserAccessLists:output_type -> teleport.accesslist.v1.ListUserAccessListsResponse
-	52, // 100: teleport.accesslist.v1.AccessListService.CreateAccessListWithPreset:output_type -> teleport.accesslist.v1.CreateAccessListWithPresetResponse
-	54, // 101: teleport.accesslist.v1.AccessListService.UpdateAccessListWithPreset:output_type -> teleport.accesslist.v1.UpdateAccessListWithPresetResponse
-	69, // [69:102] is the sub-list for method output_type
-	36, // [36:69] is the sub-list for method input_type
-	36, // [36:36] is the sub-list for extension type_name
-	36, // [36:36] is the sub-list for extension extendee
-	0,  // [0:36] is the sub-list for field type_name
+	57, // 4: teleport.accesslist.v1.ListAccessListsV2Request.scope_filter:type_name -> teleport.scopes.v1.Filter
+	55, // 5: teleport.accesslist.v1.ListAccessListsV2Response.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	58, // 6: teleport.accesslist.v1.GetInheritedGrantsResponse.grants:type_name -> teleport.accesslist.v1.AccessListGrants
+	55, // 7: teleport.accesslist.v1.UpsertAccessListRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
+	55, // 8: teleport.accesslist.v1.UpdateAccessListRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
+	55, // 9: teleport.accesslist.v1.GetAccessListsToReviewResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	59, // 10: teleport.accesslist.v1.ListAccessListMembersResponse.members:type_name -> teleport.accesslist.v1.Member
+	57, // 11: teleport.accesslist.v1.ListAllAccessListMembersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
+	59, // 12: teleport.accesslist.v1.ListAllAccessListMembersResponse.members:type_name -> teleport.accesslist.v1.Member
+	55, // 13: teleport.accesslist.v1.UpsertAccessListWithMembersRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
+	59, // 14: teleport.accesslist.v1.UpsertAccessListWithMembersRequest.members:type_name -> teleport.accesslist.v1.Member
+	55, // 15: teleport.accesslist.v1.UpsertAccessListWithMembersResponse.access_list:type_name -> teleport.accesslist.v1.AccessList
+	59, // 16: teleport.accesslist.v1.UpsertAccessListWithMembersResponse.members:type_name -> teleport.accesslist.v1.Member
+	59, // 17: teleport.accesslist.v1.GetStaticAccessListMemberResponse.member:type_name -> teleport.accesslist.v1.Member
+	60, // 18: teleport.accesslist.v1.GetAccessListOwnersResponse.owners:type_name -> teleport.accesslist.v1.AccessListOwner
+	59, // 19: teleport.accesslist.v1.UpsertAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
+	59, // 20: teleport.accesslist.v1.UpsertStaticAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
+	59, // 21: teleport.accesslist.v1.UpsertStaticAccessListMemberResponse.member:type_name -> teleport.accesslist.v1.Member
+	59, // 22: teleport.accesslist.v1.UpdateAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
+	61, // 23: teleport.accesslist.v1.ListAccessListReviewsResponse.reviews:type_name -> teleport.accesslist.v1.Review
+	57, // 24: teleport.accesslist.v1.ListAllAccessListReviewsRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
+	61, // 25: teleport.accesslist.v1.ListAllAccessListReviewsResponse.reviews:type_name -> teleport.accesslist.v1.Review
+	61, // 26: teleport.accesslist.v1.CreateAccessListReviewRequest.review:type_name -> teleport.accesslist.v1.Review
+	62, // 27: teleport.accesslist.v1.CreateAccessListReviewResponse.next_audit_date:type_name -> google.protobuf.Timestamp
+	63, // 28: teleport.accesslist.v1.AccessRequestPromoteResponse.access_request:type_name -> types.AccessRequestV3
+	55, // 29: teleport.accesslist.v1.GetSuggestedAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	55, // 30: teleport.accesslist.v1.ListUserAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	55, // 31: teleport.accesslist.v1.CreateAccessListWithPresetRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
+	64, // 32: teleport.accesslist.v1.CreateAccessListWithPresetRequest.roles:type_name -> types.RoleV6
+	55, // 33: teleport.accesslist.v1.CreateAccessListWithPresetResponse.access_list:type_name -> teleport.accesslist.v1.AccessList
+	64, // 34: teleport.accesslist.v1.CreateAccessListWithPresetResponse.roles:type_name -> types.RoleV6
+	55, // 35: teleport.accesslist.v1.UpdateAccessListWithPresetRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
+	64, // 36: teleport.accesslist.v1.UpdateAccessListWithPresetRequest.roles:type_name -> types.RoleV6
+	55, // 37: teleport.accesslist.v1.UpdateAccessListWithPresetResponse.access_list:type_name -> teleport.accesslist.v1.AccessList
+	64, // 38: teleport.accesslist.v1.UpdateAccessListWithPresetResponse.roles:type_name -> types.RoleV6
+	0,  // 39: teleport.accesslist.v1.AccessListService.GetAccessLists:input_type -> teleport.accesslist.v1.GetAccessListsRequest
+	2,  // 40: teleport.accesslist.v1.AccessListService.ListAccessLists:input_type -> teleport.accesslist.v1.ListAccessListsRequest
+	4,  // 41: teleport.accesslist.v1.AccessListService.ListAccessListsV2:input_type -> teleport.accesslist.v1.ListAccessListsV2Request
+	9,  // 42: teleport.accesslist.v1.AccessListService.GetAccessList:input_type -> teleport.accesslist.v1.GetAccessListRequest
+	10, // 43: teleport.accesslist.v1.AccessListService.UpsertAccessList:input_type -> teleport.accesslist.v1.UpsertAccessListRequest
+	11, // 44: teleport.accesslist.v1.AccessListService.UpdateAccessList:input_type -> teleport.accesslist.v1.UpdateAccessListRequest
+	12, // 45: teleport.accesslist.v1.AccessListService.DeleteAccessList:input_type -> teleport.accesslist.v1.DeleteAccessListRequest
+	13, // 46: teleport.accesslist.v1.AccessListService.DeleteAllAccessLists:input_type -> teleport.accesslist.v1.DeleteAllAccessListsRequest
+	14, // 47: teleport.accesslist.v1.AccessListService.GetAccessListsToReview:input_type -> teleport.accesslist.v1.GetAccessListsToReviewRequest
+	16, // 48: teleport.accesslist.v1.AccessListService.CountAccessListMembers:input_type -> teleport.accesslist.v1.CountAccessListMembersRequest
+	18, // 49: teleport.accesslist.v1.AccessListService.ListAccessListMembers:input_type -> teleport.accesslist.v1.ListAccessListMembersRequest
+	20, // 50: teleport.accesslist.v1.AccessListService.ListAllAccessListMembers:input_type -> teleport.accesslist.v1.ListAllAccessListMembersRequest
+	24, // 51: teleport.accesslist.v1.AccessListService.GetAccessListMember:input_type -> teleport.accesslist.v1.GetAccessListMemberRequest
+	25, // 52: teleport.accesslist.v1.AccessListService.GetStaticAccessListMember:input_type -> teleport.accesslist.v1.GetStaticAccessListMemberRequest
+	27, // 53: teleport.accesslist.v1.AccessListService.GetAccessListOwners:input_type -> teleport.accesslist.v1.GetAccessListOwnersRequest
+	29, // 54: teleport.accesslist.v1.AccessListService.UpsertAccessListMember:input_type -> teleport.accesslist.v1.UpsertAccessListMemberRequest
+	30, // 55: teleport.accesslist.v1.AccessListService.UpsertStaticAccessListMember:input_type -> teleport.accesslist.v1.UpsertStaticAccessListMemberRequest
+	32, // 56: teleport.accesslist.v1.AccessListService.UpdateAccessListMember:input_type -> teleport.accesslist.v1.UpdateAccessListMemberRequest
+	33, // 57: teleport.accesslist.v1.AccessListService.DeleteAccessListMember:input_type -> teleport.accesslist.v1.DeleteAccessListMemberRequest
+	34, // 58: teleport.accesslist.v1.AccessListService.DeleteStaticAccessListMember:input_type -> teleport.accesslist.v1.DeleteStaticAccessListMemberRequest
+	36, // 59: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembersForAccessList:input_type -> teleport.accesslist.v1.DeleteAllAccessListMembersForAccessListRequest
+	37, // 60: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembers:input_type -> teleport.accesslist.v1.DeleteAllAccessListMembersRequest
+	22, // 61: teleport.accesslist.v1.AccessListService.UpsertAccessListWithMembers:input_type -> teleport.accesslist.v1.UpsertAccessListWithMembersRequest
+	38, // 62: teleport.accesslist.v1.AccessListService.ListAccessListReviews:input_type -> teleport.accesslist.v1.ListAccessListReviewsRequest
+	40, // 63: teleport.accesslist.v1.AccessListService.ListAllAccessListReviews:input_type -> teleport.accesslist.v1.ListAllAccessListReviewsRequest
+	42, // 64: teleport.accesslist.v1.AccessListService.CreateAccessListReview:input_type -> teleport.accesslist.v1.CreateAccessListReviewRequest
+	44, // 65: teleport.accesslist.v1.AccessListService.DeleteAccessListReview:input_type -> teleport.accesslist.v1.DeleteAccessListReviewRequest
+	45, // 66: teleport.accesslist.v1.AccessListService.AccessRequestPromote:input_type -> teleport.accesslist.v1.AccessRequestPromoteRequest
+	47, // 67: teleport.accesslist.v1.AccessListService.GetSuggestedAccessLists:input_type -> teleport.accesslist.v1.GetSuggestedAccessListsRequest
+	7,  // 68: teleport.accesslist.v1.AccessListService.GetInheritedGrants:input_type -> teleport.accesslist.v1.GetInheritedGrantsRequest
+	49, // 69: teleport.accesslist.v1.AccessListService.ListUserAccessLists:input_type -> teleport.accesslist.v1.ListUserAccessListsRequest
+	51, // 70: teleport.accesslist.v1.AccessListService.CreateAccessListWithPreset:input_type -> teleport.accesslist.v1.CreateAccessListWithPresetRequest
+	53, // 71: teleport.accesslist.v1.AccessListService.UpdateAccessListWithPreset:input_type -> teleport.accesslist.v1.UpdateAccessListWithPresetRequest
+	1,  // 72: teleport.accesslist.v1.AccessListService.GetAccessLists:output_type -> teleport.accesslist.v1.GetAccessListsResponse
+	3,  // 73: teleport.accesslist.v1.AccessListService.ListAccessLists:output_type -> teleport.accesslist.v1.ListAccessListsResponse
+	6,  // 74: teleport.accesslist.v1.AccessListService.ListAccessListsV2:output_type -> teleport.accesslist.v1.ListAccessListsV2Response
+	55, // 75: teleport.accesslist.v1.AccessListService.GetAccessList:output_type -> teleport.accesslist.v1.AccessList
+	55, // 76: teleport.accesslist.v1.AccessListService.UpsertAccessList:output_type -> teleport.accesslist.v1.AccessList
+	55, // 77: teleport.accesslist.v1.AccessListService.UpdateAccessList:output_type -> teleport.accesslist.v1.AccessList
+	65, // 78: teleport.accesslist.v1.AccessListService.DeleteAccessList:output_type -> google.protobuf.Empty
+	65, // 79: teleport.accesslist.v1.AccessListService.DeleteAllAccessLists:output_type -> google.protobuf.Empty
+	15, // 80: teleport.accesslist.v1.AccessListService.GetAccessListsToReview:output_type -> teleport.accesslist.v1.GetAccessListsToReviewResponse
+	17, // 81: teleport.accesslist.v1.AccessListService.CountAccessListMembers:output_type -> teleport.accesslist.v1.CountAccessListMembersResponse
+	19, // 82: teleport.accesslist.v1.AccessListService.ListAccessListMembers:output_type -> teleport.accesslist.v1.ListAccessListMembersResponse
+	21, // 83: teleport.accesslist.v1.AccessListService.ListAllAccessListMembers:output_type -> teleport.accesslist.v1.ListAllAccessListMembersResponse
+	59, // 84: teleport.accesslist.v1.AccessListService.GetAccessListMember:output_type -> teleport.accesslist.v1.Member
+	26, // 85: teleport.accesslist.v1.AccessListService.GetStaticAccessListMember:output_type -> teleport.accesslist.v1.GetStaticAccessListMemberResponse
+	28, // 86: teleport.accesslist.v1.AccessListService.GetAccessListOwners:output_type -> teleport.accesslist.v1.GetAccessListOwnersResponse
+	59, // 87: teleport.accesslist.v1.AccessListService.UpsertAccessListMember:output_type -> teleport.accesslist.v1.Member
+	31, // 88: teleport.accesslist.v1.AccessListService.UpsertStaticAccessListMember:output_type -> teleport.accesslist.v1.UpsertStaticAccessListMemberResponse
+	59, // 89: teleport.accesslist.v1.AccessListService.UpdateAccessListMember:output_type -> teleport.accesslist.v1.Member
+	65, // 90: teleport.accesslist.v1.AccessListService.DeleteAccessListMember:output_type -> google.protobuf.Empty
+	35, // 91: teleport.accesslist.v1.AccessListService.DeleteStaticAccessListMember:output_type -> teleport.accesslist.v1.DeleteStaticAccessListMemberResponse
+	65, // 92: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembersForAccessList:output_type -> google.protobuf.Empty
+	65, // 93: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembers:output_type -> google.protobuf.Empty
+	23, // 94: teleport.accesslist.v1.AccessListService.UpsertAccessListWithMembers:output_type -> teleport.accesslist.v1.UpsertAccessListWithMembersResponse
+	39, // 95: teleport.accesslist.v1.AccessListService.ListAccessListReviews:output_type -> teleport.accesslist.v1.ListAccessListReviewsResponse
+	41, // 96: teleport.accesslist.v1.AccessListService.ListAllAccessListReviews:output_type -> teleport.accesslist.v1.ListAllAccessListReviewsResponse
+	43, // 97: teleport.accesslist.v1.AccessListService.CreateAccessListReview:output_type -> teleport.accesslist.v1.CreateAccessListReviewResponse
+	65, // 98: teleport.accesslist.v1.AccessListService.DeleteAccessListReview:output_type -> google.protobuf.Empty
+	46, // 99: teleport.accesslist.v1.AccessListService.AccessRequestPromote:output_type -> teleport.accesslist.v1.AccessRequestPromoteResponse
+	48, // 100: teleport.accesslist.v1.AccessListService.GetSuggestedAccessLists:output_type -> teleport.accesslist.v1.GetSuggestedAccessListsResponse
+	8,  // 101: teleport.accesslist.v1.AccessListService.GetInheritedGrants:output_type -> teleport.accesslist.v1.GetInheritedGrantsResponse
+	50, // 102: teleport.accesslist.v1.AccessListService.ListUserAccessLists:output_type -> teleport.accesslist.v1.ListUserAccessListsResponse
+	52, // 103: teleport.accesslist.v1.AccessListService.CreateAccessListWithPreset:output_type -> teleport.accesslist.v1.CreateAccessListWithPresetResponse
+	54, // 104: teleport.accesslist.v1.AccessListService.UpdateAccessListWithPreset:output_type -> teleport.accesslist.v1.UpdateAccessListWithPresetResponse
+	72, // [72:105] is the sub-list for method output_type
+	39, // [39:72] is the sub-list for method input_type
+	39, // [39:39] is the sub-list for extension type_name
+	39, // [39:39] is the sub-list for extension extendee
+	0,  // [0:39] is the sub-list for field type_name
 }
 
 func init() { file_teleport_accesslist_v1_accesslist_service_proto_init() }

--- a/api/proto/teleport/accesslist/v1/accesslist.proto
+++ b/api/proto/teleport/accesslist/v1/accesslist.proto
@@ -35,6 +35,9 @@ message AccessList {
 
   // status contains dynamically calculated fields.
   AccessListStatus status = 3;
+
+  // scope is the scope of the Access List.
+  string scope = 4;
 }
 
 // AccessListSpec is the specification for an Access List.
@@ -80,7 +83,10 @@ message AccessListSpec {
 
 // AccessListOwner is an owner of an Access List.
 message AccessListOwner {
-  // name is the username of the owner.
+  // name is the name of the owner, depending on MembershipKind:
+  // MEMBERSHIP_KIND_USER: the username of the owner.
+  // MEMBERSHIP_KIND_LIST: the name of the owner Access List.
+  // MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the owner Access List.
   string name = 1;
 
   // description is the plaintext description of the owner and why they are an
@@ -92,7 +98,7 @@ message AccessListOwner {
   IneligibleStatus ineligible_status = 3;
 
   // membership_kind describes the type of membership, either
-  // `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+  // `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
   MembershipKind membership_kind = 4;
 }
 
@@ -174,9 +180,9 @@ message AccessListGrants {
 
 // ScopedRoleGrant describes a scoped role granted at a specific scope.
 message ScopedRoleGrant {
-  // role is the name of the scoped role to be granted.
+  // role is scope-qualified name of the scoped role to be granted.
   string role = 1;
-  // scope is the scope the role will be assigned at. It must be an assignable
+  // scope is the scope the role will be granted at. It must be an assignable
   // scope of the role.
   string scope = 2;
 }
@@ -188,6 +194,10 @@ message Member {
 
   // spec is the specification for the Access List member.
   MemberSpec spec = 2;
+
+  // scope is the scope of the Access List member, it must be equal to the
+  // scope of the parent Access List.
+  string scope = 3;
 }
 
 // MemberSpec is the specification for an Access List member.
@@ -198,7 +208,10 @@ message MemberSpec {
   // associated Access List
   string access_list = 1;
 
-  // name is the name of the member of the Access List.
+  // name is the name of the member of the Access List, depending on MembershipKind:
+  // MEMBERSHIP_KIND_USER: the username of the member.
+  // MEMBERSHIP_KIND_LIST: the name of the member Access List.
+  // MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the member scope Access List.
   string name = 2;
 
   // joined is when the user joined the Access List.
@@ -218,7 +231,7 @@ message MemberSpec {
   IneligibleStatus ineligible_status = 7;
 
   // membership_kind describes the type of membership, either
-  // `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+  // `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
   MembershipKind membership_kind = 9;
 }
 
@@ -231,6 +244,8 @@ enum MembershipKind {
   MEMBERSHIP_KIND_USER = 1;
   // MEMBERSHIP_KIND_LIST represents list members that are nested Access Lists
   MEMBERSHIP_KIND_LIST = 2;
+  // MEMBERSHIP_KIND_SCOPED_LIST represents list members that are nested scoped Access Lists
+  MEMBERSHIP_KIND_SCOPED_LIST = 3;
 }
 
 // IneligibleStatus describes how the user is ineligible.
@@ -258,11 +273,17 @@ message Review {
 
   // spec is the specification for the Access List review.
   ReviewSpec spec = 2;
+
+  // scope is the scope of the Access List review. It must be equal to the
+  // scope of the reviewed Access List.
+  string scope = 3;
 }
 
 // ReviewSpec is the specification for an Access List review.
 message ReviewSpec {
   // access_list is the name of the Access List that this review is for.
+  // If the review is scoped, this is the scope-qualified name of the reviewed
+  // scoped Access List.
   string access_list = 1;
 
   // reviewers are the users who performed the review.
@@ -298,10 +319,14 @@ message ReviewChanges {
   // review_day_of_month_changed is populated if the review day of month has
   // changed.
   ReviewDayOfMonth review_day_of_month_changed = 5;
+
+  // scoped_removed_members contains the scope-qualified names of members that
+  // were removed as part of this review.
+  repeated string scoped_removed_members = 6;
 }
 
-// AccessListUserAssignmentType describes the type of membership anr/or ownership
-// a user has in an access list.
+// AccessListUserAssignmentType describes the type of membership and/or ownership
+// a user has in an Access List.
 enum AccessListUserAssignmentType {
   // ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED means the user is not an explicit nor an inherited member or owner
   ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED = 0;
@@ -311,19 +336,19 @@ enum AccessListUserAssignmentType {
   ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED = 2;
 }
 
-// CurrentUserAssignments describes the current user's ownership and membership status in the access list.
+// CurrentUserAssignments describes the current user's ownership and membership status in the Access List.
 message CurrentUserAssignments {
-  // ownership_type represents the current user's ownership type (explicit, inherited, or none) in the access list.
+  // ownership_type represents the current user's ownership type (explicit, inherited, or none) in the Access List.
   AccessListUserAssignmentType ownership_type = 1;
-  // membership_type represents the current user's membership type (explicit, inherited, or none) in the access list.
+  // membership_type represents the current user's membership type (explicit, inherited, or none) in the Access List.
   AccessListUserAssignmentType membership_type = 2;
 }
 
-// UserAssignments describes the requested user's ownership and membership assignment types in the access list.
+// UserAssignments describes the requested user's ownership and membership assignment types in the Access List.
 message UserAssignments {
-  // ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the access list.
+  // ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the Access List.
   AccessListUserAssignmentType ownership_type = 1;
-  // membership_type represents the requested user's membership type (explicit, inherited, or none) in the access list.
+  // membership_type represents the requested user's membership type (explicit, inherited, or none) in the Access List.
   AccessListUserAssignmentType membership_type = 2;
 }
 
@@ -337,8 +362,14 @@ message AccessListStatus {
   repeated string owner_of = 3;
   // member_of describes Access Lists where this Access List is an explicit member.
   repeated string member_of = 4;
-  // current_user_assignments describes the current user's ownership and membership status in the access list.
+  // current_user_assignments describes the current user's ownership and membership status in the Access List.
   CurrentUserAssignments current_user_assignments = 5;
-  // user_assignments describes the requested user's ownership and membership assignment types in the access list.
+  // user_assignments describes the requested user's ownership and membership assignment types in the Access List.
   UserAssignments user_assignments = 6;
+  // scoped_owner_of describes scoped Access Lists where this Access List is an explicit owner.
+  // Each item is the scope-qualified name of the owned scoped Access List.
+  repeated string scoped_owner_of = 7;
+  // scoped_member_of describes scoped Access Lists where this Access List is an explicit member.
+  // Each item is the scope-qualified name of the parent scoped Access List.
+  repeated string scoped_member_of = 8;
 }

--- a/api/proto/teleport/accesslist/v1/accesslist.proto
+++ b/api/proto/teleport/accesslist/v1/accesslist.proto
@@ -180,7 +180,7 @@ message AccessListGrants {
 
 // ScopedRoleGrant describes a scoped role granted at a specific scope.
 message ScopedRoleGrant {
-  // role is scope-qualified name of the scoped role to be granted.
+  // role is the scope-qualified name of the scoped role to be granted.
   string role = 1;
   // scope is the scope the role will be granted at. It must be an assignable
   // scope of the role.

--- a/api/proto/teleport/accesslist/v1/accesslist_service.proto
+++ b/api/proto/teleport/accesslist/v1/accesslist_service.proto
@@ -184,6 +184,8 @@ message ListAccessListsV2Response {
 message GetInheritedGrantsRequest {
   // access_list_id is the ID of the access list to retrieve.
   string access_list_id = 1;
+  // access_list_scope is the scope of the access list to retrieve.
+  string access_list_scope = 2;
 }
 
 // GetInheritedGrantsResponse is the response for getting inherited grants.
@@ -196,6 +198,8 @@ message GetInheritedGrantsResponse {
 message GetAccessListRequest {
   // name is the name of the access list to retrieve.
   string name = 1;
+  // scope is the scope of the access list to retrieve.
+  string scope = 2;
 }
 
 // UpsertAccessListRequest is the request for upserting an access list.
@@ -214,6 +218,8 @@ message UpdateAccessListRequest {
 message DeleteAccessListRequest {
   // name is the name of the access list to delete.
   string name = 1;
+  // scope is the scope of the access list to delete.
+  string scope = 2;
 }
 
 // DeleteAllAccessListsRequest is the request for deleting all access lists.
@@ -234,6 +240,8 @@ message GetAccessListsToReviewResponse {
 message CountAccessListMembersRequest {
   // access_list_name is the name of the access list to retrieve.
   string access_list_name = 1;
+  // access_list_scope is the scope of the access list to retrieve.
+  string access_list_scope = 2;
 }
 
 // CountAccessListMembersResponse is the response for counting access list
@@ -256,6 +264,8 @@ message ListAccessListMembersRequest {
 
   // access_list is the name of the access list that the member belongs to.
   string access_list = 3;
+  // access_list_scope is the scope of the access list that the member belongs to.
+  string access_list_scope = 4;
 }
 
 // ListAccessListMembersResponse is the response for getting paginated access
@@ -310,6 +320,10 @@ message GetAccessListMemberRequest {
   string access_list = 1;
   // member_name is the name of the user that belongs to the access list.
   string member_name = 2;
+  // access_list_scope is the scope of the access list that the member belongs to.
+  string access_list_scope = 3;
+  // member_scope is the scope of the member, in case the member is a scoped access list.
+  string member_scope = 4;
 }
 
 // GetStaticAccessListMemberRequest is the request for retrieving an access_list_member of a static
@@ -319,6 +333,10 @@ message GetStaticAccessListMemberRequest {
   string access_list = 1;
   // member_name is the name of the user that belongs to the access_list.
   string member_name = 2;
+  // access_list_scope is the scope of the access list that the member belongs to.
+  string access_list_scope = 3;
+  // member_scope is the scope of the member, in case the member is a scoped access list.
+  string member_scope = 4;
 }
 
 // GetStaticAccessListMemberResponse is the response containing the access_list_member of the
@@ -333,6 +351,8 @@ message GetStaticAccessListMemberResponse {
 message GetAccessListOwnersRequest {
   // access_list is the name of the access list.
   string access_list = 1;
+  // access_list_scope is the scope of the access list.
+  string access_list_scope = 3;
 }
 
 // GetAccessListOwnersResponse is the response for getting a list of all
@@ -384,6 +404,10 @@ message DeleteAccessListMemberRequest {
   string access_list = 1;
   // member_name is the name of the user to delete.
   string member_name = 3;
+  // access_list_scope is the scope of the access list that the member belongs to.
+  string access_list_scope = 4;
+  // member_scope is the scope of the member, in case the member is a scoped access list.
+  string member_scope = 5;
 }
 
 // DeleteStaticAccessListMemberRequest is the request for deleting an access_list_member from an
@@ -393,6 +417,10 @@ message DeleteStaticAccessListMemberRequest {
   string access_list = 1;
   // member_name is the name of the user to delete.
   string member_name = 2;
+  // access_list_scope is the scope of the access list that the member belongs to.
+  string access_list_scope = 3;
+  // member_scope is the scope of the member, in case the member is a scoped access list.
+  string member_scope = 4;
 }
 
 // DeleteStaticAccessListMemberResponse is the response of deleting an access_list_member from an
@@ -404,6 +432,8 @@ message DeleteStaticAccessListMemberResponse {}
 message DeleteAllAccessListMembersForAccessListRequest {
   // access_list is the name of access list.
   string access_list = 1;
+  // access_list_scope is the scope of the access list.
+  string access_list_scope = 2;
 }
 
 // DeleteAllAccessListMembersRequest is the request for all access list members
@@ -424,6 +454,9 @@ message ListAccessListReviewsRequest {
 
   // next_token is the page token.
   string next_token = 3;
+
+  // access_list_scope is the scope of the access list.
+  string access_list_scope = 4;
 }
 
 // ListAccessListReviewsResponse is the response for getting paginated access
@@ -481,6 +514,9 @@ message DeleteAccessListReviewRequest {
 
   // access_list_name is the name of the access list to delete the review from.
   string access_list_name = 2;
+
+  // access_list_scope is the scope of the access list.
+  string access_list_scope = 3;
 }
 
 // AccessRequestPromoteRequest is the request for promoting an access request to

--- a/api/proto/teleport/accesslist/v1/accesslist_service.proto
+++ b/api/proto/teleport/accesslist/v1/accesslist_service.proto
@@ -20,6 +20,7 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 import "teleport/accesslist/v1/accesslist.proto";
 import "teleport/legacy/types/types.proto";
+import "teleport/scopes/v1/scopes.proto";
 
 option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1;accesslistv1";
 
@@ -158,6 +159,10 @@ message ListAccessListsV2Request {
   types.SortBy sort_by = 3;
   // filter is a collection of fields to filter access lists.
   AccessListsFilter filter = 4;
+  // scope_filter filters access lists by scope. Defaults to one of EXACT or
+  // UNSCOPED depending on whether the caller is a scoped or unscoped identity.
+  // Exhaustive user-facing views (e.g. `tctl get`) should specify mode ALL.
+  teleport.scopes.v1.Filter scope_filter = 5;
 }
 
 // AccessListsFilter is used to collect filter options for listing access lists.
@@ -285,6 +290,11 @@ message ListAllAccessListMembersRequest {
 
   // page_token is the page token.
   string page_token = 2;
+
+  // scope_filter filters access list members by their resource scope. Defaults
+  // to one of EXACT or UNSCOPED depending on whether the caller is a scoped or
+  // unscoped identity.
+  teleport.scopes.v1.Filter scope_filter = 3;
 }
 
 // ListAllAccessListMembersResponse is the response for getting paginated access
@@ -477,6 +487,10 @@ message ListAllAccessListReviewsRequest {
 
   // next_token is the page token.
   string next_token = 2;
+
+  // scope_filter filters reviews by scope. Defaults to one of EXACT or
+  // UNSCOPED depending on whether the caller is a scoped or unscoped identity.
+  teleport.scopes.v1.Filter scope_filter = 3;
 }
 
 // ListAllAccessListReviewsResponse is the response for getting paginated access

--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -87,6 +87,9 @@ var (
 
 	// MembershipKindList is the list membership kind.
 	MembershipKindList = accesslistv1.MembershipKind_MEMBERSHIP_KIND_LIST.String()
+
+	// MembershipKindScopedList is the scoped list membership kind.
+	MembershipKindScopedList = accesslistv1.MembershipKind_MEMBERSHIP_KIND_SCOPED_LIST.String()
 )
 
 // ReviewDayOfMonth is the day of month the review should be repeated on.
@@ -138,6 +141,9 @@ type AccessList struct {
 
 	// Status contains dynamically calculated fields.
 	Status Status `json:"status" yaml:"status"`
+
+	// Scope is the scope of the access list.
+	Scope string `json:"scope" yaml:"scope"`
 }
 
 // Spec is the specification for an access list.
@@ -214,7 +220,10 @@ func (t Type) Equals(other Type) bool {
 
 // Owner is an owner of an access list.
 type Owner struct {
-	// Name is the username of the owner.
+	// Name is the username of the owner, depending on MembershipKind:
+	// MEMBERSHIP_KIND_USER: the username of the owner.
+	// MEMBERSHIP_KIND_LIST: the name of the owner access list.
+	// MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the owner access list.
 	Name string `json:"name" yaml:"name"`
 
 	// Title is the title of an owner if it is of type MEMBERSHIP_KIND_LIST.
@@ -228,7 +237,7 @@ type Owner struct {
 	IneligibleStatus string `json:"ineligible_status" yaml:"ineligible_status"`
 
 	// MembershipKind describes the kind of ownership,
-	// either "MEMBERSHIP_KIND_USER" or "MEMBERSHIP_KIND_LIST".
+	// either "MEMBERSHIP_KIND_USER" or "MEMBERSHIP_KIND_LIST" or "MEMBERSHIP_KIND_SCOPED_LIST".
 	MembershipKind string `json:"membership_kind" yaml:"membership_kind"`
 }
 
@@ -336,6 +345,13 @@ type Status struct {
 	// MemberOf is a list of Access List UUIDs where this access list is an explicit member.
 	MemberOf []string `json:"member_of" yaml:"member_of"`
 
+	// ScopedOwnerOf is a list of scope-qualified names of scoped access lists
+	// where this access list is an explicit owner.
+	ScopedOwnerOf []string `json:"scoped_owner_of" yaml:"scoped_owner_of"`
+	// ScopedMemberOf is a list of scope-qualified names of scoped access lists
+	// where this access list is an explicit member.
+	ScopedMemberOf []string `json:"scoped_member_of" yaml:"scoped_member_of"`
+
 	// CurrentUserAssignments describes the current user's ownership and membership in the access list.
 	CurrentUserAssignments *CurrentUserAssignments `json:"-" yaml:"-"`
 	// UserAssignments describes the requested user's ownership and membership assignment types in the access list.
@@ -380,9 +396,15 @@ func (u *UserAssignments) IsOwner() bool {
 
 // NewAccessList will create a new access list.
 func NewAccessList(metadata header.Metadata, spec Spec) (*AccessList, error) {
+	return NewAccessListWithScope(metadata, spec, "")
+}
+
+// NewAccessListWithScope will create a new access list with a scope.
+func NewAccessListWithScope(metadata header.Metadata, spec Spec, scope string) (*AccessList, error) {
 	accessList := &AccessList{
 		ResourceHeader: header.ResourceHeaderFromMetadata(metadata),
 		Spec:           spec,
+		Scope:          scope,
 	}
 
 	if err := accessList.CheckAndSetDefaults(); err != nil {
@@ -452,6 +474,11 @@ func (a *AccessList) CheckAndSetDefaults() error {
 	a.Spec.Owners = deduplicatedOwners
 
 	return nil
+}
+
+// GetScope returns the scope of the access list resource.
+func (a *AccessList) GetScope() string {
+	return a.Scope
 }
 
 // GetOwners returns the list of owners from the access list.

--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -242,9 +242,14 @@ type Owner struct {
 }
 
 // IsMembershipKindUser returns true if the owner is of kind user.
-// All types expect "MEMBERSHIP_KIND_LIST" are treated as "MEMBERSHIP_KIND_USER".
+// "" and "MEMBERSHIP_KIND_UNSPECIFIED" are treated as "MEMBERSHIP_KIND_USER".
 func (o *Owner) IsMembershipKindUser() bool {
 	return isMembershipKindUser(o.MembershipKind)
+}
+
+// IsMembershipKindList returns true if the owner is an access list.
+func (o *Owner) IsMembershipKindList() bool {
+	return IsMembershipKindList(o.MembershipKind)
 }
 
 func isMembershipKindUser(membershipKind string) bool {
@@ -253,6 +258,17 @@ func isMembershipKindUser(membershipKind string) bool {
 		return true
 	default:
 		// In case if MembershipKind was extended.
+		return false
+	}
+}
+
+// IsMembershipKindList returns true if the membership kind is
+// MembershipKindList or MembershipKindScopedList.
+func IsMembershipKindList(membershipKind string) bool {
+	switch membershipKind {
+	case MembershipKindList, MembershipKindScopedList:
+		return true
+	default:
 		return false
 	}
 }

--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -313,7 +313,7 @@ type Requires struct {
 
 // IsEmpty returns true when no roles or traits are set
 func (r *Requires) IsEmpty() bool {
-	return len(r.Roles) == 0 && len(r.Traits) == 0
+	return r == nil || (len(r.Roles) == 0 && len(r.Traits) == 0)
 }
 
 // Clone returns a deep copy of the [Requires]

--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -342,7 +342,7 @@ type Grants struct {
 
 // ScopedRoleGrant describes a scoped role granted at a specific scope.
 type ScopedRoleGrant struct {
-	// Role is the name of the scoped role to be granted.
+	// Role is the scope-qualified name of the scoped role to be granted.
 	Role string `json:"role" yaml:"role"`
 	// Scope is the scope the role will be assigned at. It must be an assignable
 	// scope of the role.

--- a/api/types/accesslist/convert/v1/accesslist.go
+++ b/api/types/accesslist/convert/v1/accesslist.go
@@ -52,7 +52,7 @@ func FromProto(msg *accesslistv1.AccessList, opts ...AccessListOption) (*accessl
 		OwnerGrants:        ConvertGrantsFromProto(spec.GetOwnerGrants()),
 	}
 
-	accessList, err := accesslist.NewAccessList(metadata, accessListSpec)
+	accessList, err := accesslist.NewAccessListWithScope(metadata, accessListSpec, msg.Scope)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -76,6 +76,7 @@ func ToProto(accessList *accesslist.AccessList) *accesslistv1.AccessList {
 
 	return &accesslistv1.AccessList{
 		Header: headerv1.ToResourceHeaderProto(accessList.ResourceHeader),
+		Scope:  accessList.Scope,
 		Spec: &accesslistv1.AccessListSpec{
 			Type:               string(accessList.Spec.Type),
 			Title:              accessList.Spec.Title,
@@ -239,6 +240,8 @@ func convertStatusToProto(status *accesslist.Status) *accesslistv1.AccessListSta
 		MemberOf:               status.MemberOf,
 		CurrentUserAssignments: toCurrentUserAssignmentsProto(status.CurrentUserAssignments),
 		UserAssignments:        toUserAssignmentsProto(status.UserAssignments),
+		ScopedOwnerOf:          status.ScopedOwnerOf,
+		ScopedMemberOf:         status.ScopedMemberOf,
 	}
 }
 
@@ -255,6 +258,8 @@ func fromStatusProto(msg *accesslistv1.AccessList) *accesslist.Status {
 		MemberOf:               protoStatus.GetMemberOf(),
 		CurrentUserAssignments: fromCurrentUserAssignmentsProto(protoStatus.GetCurrentUserAssignments()),
 		UserAssignments:        fromUserAssignmentsProto(protoStatus.GetUserAssignments()),
+		ScopedOwnerOf:          protoStatus.GetScopedOwnerOf(),
+		ScopedMemberOf:         protoStatus.GetScopedMemberOf(),
 	}
 }
 

--- a/api/types/accesslist/convert/v1/accesslist_test.go
+++ b/api/types/accesslist/convert/v1/accesslist_test.go
@@ -292,7 +292,11 @@ func newAccessList(t *testing.T, name string) *accesslist.AccessList {
 	require.NoError(t, err)
 
 	accessList.Status = accesslist.Status{
-		MemberCount: &memberCount,
+		MemberCount:    &memberCount,
+		OwnerOf:        []string{"ownerof"},
+		MemberOf:       []string{"memberof"},
+		ScopedOwnerOf:  []string{"scopedownerof"},
+		ScopedMemberOf: []string{"scopedmemberof"},
 	}
 
 	return accessList

--- a/api/types/accesslist/convert/v1/member.go
+++ b/api/types/accesslist/convert/v1/member.go
@@ -37,7 +37,7 @@ func FromMemberProto(msg *accesslistv1.Member, opts ...MemberOption) (*accesslis
 		return nil, trace.BadParameter("spec is missing")
 	}
 
-	member, err := accesslist.NewAccessListMember(headerv1.FromMetadataProto(msg.GetHeader().GetMetadata()), accesslist.AccessListMemberSpec{
+	member, err := accesslist.NewAccessListMemberWithScope(headerv1.FromMetadataProto(msg.GetHeader().GetMetadata()), accesslist.AccessListMemberSpec{
 		AccessList: msg.GetSpec().GetAccessList(),
 		Name:       msg.GetSpec().GetName(),
 		Joined:     utils.TimeFromProto(msg.GetSpec().GetJoined()),
@@ -48,7 +48,7 @@ func FromMemberProto(msg *accesslistv1.Member, opts ...MemberOption) (*accesslis
 		// Must provide as options to set it with the provided value.
 		IneligibleStatus: "",
 		MembershipKind:   msg.Spec.MembershipKind.String(),
-	})
+	}, msg.Scope)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -87,6 +87,7 @@ func ToMemberProto(member *accesslist.AccessListMember) *accesslistv1.Member {
 
 	return &accesslistv1.Member{
 		Header: headerv1.ToResourceHeaderProto(member.ResourceHeader),
+		Scope:  member.Scope,
 		Spec: &accesslistv1.MemberSpec{
 			AccessList:       member.Spec.AccessList,
 			Name:             member.Spec.Name,

--- a/api/types/accesslist/convert/v1/review.go
+++ b/api/types/accesslist/convert/v1/review.go
@@ -54,17 +54,18 @@ func FromReviewProto(msg *accesslistv1.Review) (*accesslist.Review, error) {
 			}
 		}
 		reviewChanges.RemovedMembers = msg.GetSpec().GetChanges().GetRemovedMembers()
+		reviewChanges.ScopedRemovedMembers = msg.GetSpec().GetChanges().GetScopedRemovedMembers()
 		reviewChanges.ReviewFrequencyChanged = accesslist.ReviewFrequency(msg.GetSpec().GetChanges().GetReviewFrequencyChanged())
 		reviewChanges.ReviewDayOfMonthChanged = accesslist.ReviewDayOfMonth(msg.GetSpec().GetChanges().GetReviewDayOfMonthChanged())
 	}
 
-	member, err := accesslist.NewReview(headerv1.FromMetadataProto(msg.GetHeader().GetMetadata()), accesslist.ReviewSpec{
+	member, err := accesslist.NewReviewWithScope(headerv1.FromMetadataProto(msg.GetHeader().GetMetadata()), accesslist.ReviewSpec{
 		AccessList: msg.GetSpec().GetAccessList(),
 		Reviewers:  msg.GetSpec().GetReviewers(),
 		ReviewDate: reviewDate,
 		Notes:      msg.GetSpec().GetNotes(),
 		Changes:    reviewChanges,
-	})
+	}, msg.Scope)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -90,6 +91,13 @@ func ToReviewProto(review *accesslist.Review) *accesslistv1.Review {
 
 		reviewChanges.RemovedMembers = review.Spec.Changes.RemovedMembers
 	}
+	if len(review.Spec.Changes.ScopedRemovedMembers) > 0 {
+		if reviewChanges == nil {
+			reviewChanges = &accesslistv1.ReviewChanges{}
+		}
+
+		reviewChanges.ScopedRemovedMembers = review.Spec.Changes.ScopedRemovedMembers
+	}
 	if review.Spec.Changes.ReviewFrequencyChanged > 0 {
 		if reviewChanges == nil {
 			reviewChanges = &accesslistv1.ReviewChanges{}
@@ -107,6 +115,7 @@ func ToReviewProto(review *accesslist.Review) *accesslistv1.Review {
 
 	return &accesslistv1.Review{
 		Header: headerv1.ToResourceHeaderProto(review.ResourceHeader),
+		Scope:  review.Scope,
 		Spec: &accesslistv1.ReviewSpec{
 			AccessList: review.Spec.AccessList,
 			Reviewers:  review.Spec.Reviewers,

--- a/api/types/accesslist/derived.gen.go
+++ b/api/types/accesslist/derived.gen.go
@@ -12,7 +12,8 @@ func deriveTeleportEqualAccessList(this, that *AccessList) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			deriveTeleportEqual(&this.ResourceHeader, &that.ResourceHeader) &&
-			deriveTeleportEqual_(&this.Spec, &that.Spec)
+			deriveTeleportEqual_(&this.Spec, &that.Spec) &&
+			this.Scope == that.Scope
 }
 
 // deriveDeepCopyAccessList recursively copies the contents of src into dst.
@@ -32,6 +33,7 @@ func deriveDeepCopyAccessList(dst, src *AccessList) {
 		deriveDeepCopy_1(field, &src.Status)
 		dst.Status = *field
 	}()
+	dst.Scope = src.Scope
 }
 
 // deriveDeepCopyAccessListMember recursively copies the contents of src into dst.
@@ -46,6 +48,7 @@ func deriveDeepCopyAccessListMember(dst, src *AccessListMember) {
 		deriveDeepCopy_2(field, &src.Spec)
 		dst.Spec = *field
 	}()
+	dst.Scope = src.Scope
 }
 
 // deriveDeepCopyReview recursively copies the contents of src into dst.
@@ -60,6 +63,7 @@ func deriveDeepCopyReview(dst, src *Review) {
 		deriveDeepCopy_3(field, &src.Spec)
 		dst.Spec = *field
 	}()
+	dst.Scope = src.Scope
 }
 
 // deriveTeleportEqual returns whether this and that are equal.
@@ -198,6 +202,42 @@ func deriveDeepCopy_1(dst, src *Status) {
 			dst.MemberOf = make([]string, len(src.MemberOf))
 		}
 		copy(dst.MemberOf, src.MemberOf)
+	}
+	if src.ScopedOwnerOf == nil {
+		dst.ScopedOwnerOf = nil
+	} else {
+		if dst.ScopedOwnerOf != nil {
+			if len(src.ScopedOwnerOf) > len(dst.ScopedOwnerOf) {
+				if cap(dst.ScopedOwnerOf) >= len(src.ScopedOwnerOf) {
+					dst.ScopedOwnerOf = (dst.ScopedOwnerOf)[:len(src.ScopedOwnerOf)]
+				} else {
+					dst.ScopedOwnerOf = make([]string, len(src.ScopedOwnerOf))
+				}
+			} else if len(src.ScopedOwnerOf) < len(dst.ScopedOwnerOf) {
+				dst.ScopedOwnerOf = (dst.ScopedOwnerOf)[:len(src.ScopedOwnerOf)]
+			}
+		} else {
+			dst.ScopedOwnerOf = make([]string, len(src.ScopedOwnerOf))
+		}
+		copy(dst.ScopedOwnerOf, src.ScopedOwnerOf)
+	}
+	if src.ScopedMemberOf == nil {
+		dst.ScopedMemberOf = nil
+	} else {
+		if dst.ScopedMemberOf != nil {
+			if len(src.ScopedMemberOf) > len(dst.ScopedMemberOf) {
+				if cap(dst.ScopedMemberOf) >= len(src.ScopedMemberOf) {
+					dst.ScopedMemberOf = (dst.ScopedMemberOf)[:len(src.ScopedMemberOf)]
+				} else {
+					dst.ScopedMemberOf = make([]string, len(src.ScopedMemberOf))
+				}
+			} else if len(src.ScopedMemberOf) < len(dst.ScopedMemberOf) {
+				dst.ScopedMemberOf = (dst.ScopedMemberOf)[:len(src.ScopedMemberOf)]
+			}
+		} else {
+			dst.ScopedMemberOf = make([]string, len(src.ScopedMemberOf))
+		}
+		copy(dst.ScopedMemberOf, src.ScopedMemberOf)
 	}
 	if src.CurrentUserAssignments == nil {
 		dst.CurrentUserAssignments = nil
@@ -456,6 +496,24 @@ func deriveDeepCopy_9(dst, src *ReviewChanges) {
 	}
 	dst.ReviewFrequencyChanged = src.ReviewFrequencyChanged
 	dst.ReviewDayOfMonthChanged = src.ReviewDayOfMonthChanged
+	if src.ScopedRemovedMembers == nil {
+		dst.ScopedRemovedMembers = nil
+	} else {
+		if dst.ScopedRemovedMembers != nil {
+			if len(src.ScopedRemovedMembers) > len(dst.ScopedRemovedMembers) {
+				if cap(dst.ScopedRemovedMembers) >= len(src.ScopedRemovedMembers) {
+					dst.ScopedRemovedMembers = (dst.ScopedRemovedMembers)[:len(src.ScopedRemovedMembers)]
+				} else {
+					dst.ScopedRemovedMembers = make([]string, len(src.ScopedRemovedMembers))
+				}
+			} else if len(src.ScopedRemovedMembers) < len(dst.ScopedRemovedMembers) {
+				dst.ScopedRemovedMembers = (dst.ScopedRemovedMembers)[:len(src.ScopedRemovedMembers)]
+			}
+		} else {
+			dst.ScopedRemovedMembers = make([]string, len(src.ScopedRemovedMembers))
+		}
+		copy(dst.ScopedRemovedMembers, src.ScopedRemovedMembers)
+	}
 }
 
 // deriveTeleportEqual_6 returns whether this and that are equal.

--- a/api/types/accesslist/member.go
+++ b/api/types/accesslist/member.go
@@ -37,14 +37,22 @@ type AccessListMember struct {
 
 	// Spec is the specification for the access list member.
 	Spec AccessListMemberSpec `json:"spec" yaml:"spec"`
+
+	// Scope is the scope of the access list member, it must be equal to the
+	// scope of the parent access list.
+	Scope string `json:"scope" yaml:"scope"`
 }
 
 // AccessListMemberSpec describes the specification of a member of an access list.
 type AccessListMemberSpec struct {
 	// AccessList is the name of the associated access list.
+	// If the member is scoped, this is a scope-qualified name.
 	AccessList string `json:"access_list" yaml:"access_list"`
 
-	// Name is the name of the member of the access list.
+	// Name is the name of the member of the access list, depending on MembershipKind:
+	// MEMBERSHIP_KIND_USER: the username of the member.
+	// MEMBERSHIP_KIND_LIST: the name of the member Access List.
+	// MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the member scope Access List.
 	Name string `json:"name" yaml:"name"`
 
 	// TODO (avatus): eventually populate this in the backend/cache.
@@ -69,15 +77,21 @@ type AccessListMemberSpec struct {
 	IneligibleStatus string `json:"ineligible_status" yaml:"ineligible_status"`
 
 	// MembershipKind describes the kind of membership,
-	// either "MEMBERSHIP_KIND_USER" or "MEMBERSHIP_KIND_LIST".
+	// either "MEMBERSHIP_KIND_USER" or "MEMBERSHIP_KIND_LIST" or "MEMBERSHIP_KIND_SCOPED_LIST".
 	MembershipKind string `json:"membership_kind" yaml:"membership_kind"`
 }
 
 // NewAccessListMember will create a new AccessListMember.
 func NewAccessListMember(metadata header.Metadata, spec AccessListMemberSpec) (*AccessListMember, error) {
+	return NewAccessListMemberWithScope(metadata, spec, "")
+}
+
+// NewAccessListMemberWithScope will create a new AccessListMember.
+func NewAccessListMemberWithScope(metadata header.Metadata, spec AccessListMemberSpec, scope string) (*AccessListMember, error) {
 	member := &AccessListMember{
 		ResourceHeader: header.ResourceHeaderFromMetadata(metadata),
 		Spec:           spec,
+		Scope:          scope,
 	}
 
 	if err := member.CheckAndSetDefaults(); err != nil {
@@ -114,6 +128,10 @@ func (a *AccessListMember) GetMetadata() types.Metadata {
 func (a *AccessListMember) IsEqual(other *AccessListMember) bool {
 	return a.Spec.Name == other.Spec.Name &&
 		a.Spec.AccessList == other.Spec.AccessList
+}
+
+func (a *AccessListMember) GetScope() string {
+	return a.Scope
 }
 
 // MatchSearch goes through select field values of a resource

--- a/api/types/accesslist/member.go
+++ b/api/types/accesslist/member.go
@@ -157,7 +157,12 @@ func (a *AccessListMember) IsExpired(t time.Time) bool {
 }
 
 // IsUser returns true if the membership kind is User
-// All types expect "MEMBERSHIP_KIND_LIST" are treated as "MEMBERSHIP_KIND_USER".
+// "" and "MEMBERSHIP_KIND_UNSPECIFIED" are treated as "MEMBERSHIP_KIND_USER".
 func (a *AccessListMember) IsUser() bool {
 	return isMembershipKindUser(a.Spec.MembershipKind)
+}
+
+// IsList returns true if the member is an access list.
+func (a *AccessListMember) IsList() bool {
+	return IsMembershipKindList(a.Spec.MembershipKind)
 }

--- a/api/types/accesslist/review.go
+++ b/api/types/accesslist/review.go
@@ -32,6 +32,10 @@ type Review struct {
 
 	// Spec is the specification for the access list review.
 	Spec ReviewSpec `json:"spec" yaml:"spec"`
+
+	// Scope is the scope of the access list review, must match the scope of
+	// the reviewed access list.
+	Scope string `json:"scope" yaml:"scope"`
 }
 
 const (
@@ -71,12 +75,31 @@ type ReviewChanges struct {
 
 	// ReviewDayOfMonthChanged is populated if the review day of month has changed.
 	ReviewDayOfMonthChanged ReviewDayOfMonth `json:"review_day_of_month_changed" yaml:"review_day_of_month_changed"`
+
+	// ScopedRemovedMembers contains the scope-qualified names of scoped
+	// members that were removed as part of this review.
+	ScopedRemovedMembers []string `json:"scoped_removed_members" yaml:"scoped_removed_members"`
 }
 
 // NewReview will create a new access list review.
 func NewReview(metadata header.Metadata, spec ReviewSpec) (*Review, error) {
 	review := &Review{
 		ResourceHeader: header.ResourceHeaderFromMetadata(metadata),
+		Spec:           spec,
+	}
+
+	if err := review.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return review, nil
+}
+
+// NewReviewWithScope will create a new access list review.
+func NewReviewWithScope(metadata header.Metadata, spec ReviewSpec, scope string) (*Review, error) {
+	review := &Review{
+		ResourceHeader: header.ResourceHeaderFromMetadata(metadata),
+		Scope:          scope,
 		Spec:           spec,
 	}
 
@@ -119,6 +142,10 @@ func (r *Review) CheckAndSetDefaults() error {
 // and should be removed when possible.
 func (r *Review) GetMetadata() types.Metadata {
 	return legacy.FromHeaderMetadata(r.Metadata)
+}
+
+func (r *Review) GetScope() string {
+	return r.Scope
 }
 
 // Clone returns a copy of the review.

--- a/api/types/accesslist/review_test.go
+++ b/api/types/accesslist/review_test.go
@@ -69,7 +69,7 @@ func TestReviewSpecMarshaling(t *testing.T) {
 	require.Equal(t, `{"review_date":"2023-01-01T00:00:00Z","access_list":"access-list","reviewers":["user1","user2"],`+
 		`"notes":"Some notes","changes":{"review_frequency_changed":"6 months","review_day_of_month_changed":"1",`+
 		`"membership_requirements_changed":{"roles":["member1","member2"],"traits":{"trait1":["value1","value2"],"trait2":["value1","value2"]}},`+
-		`"removed_members":["member1","member2"]}}`, string(data))
+		`"removed_members":["member1","member2"],"scoped_removed_members":null}}`, string(data))
 
 	raw := map[string]interface{}{}
 	require.NoError(t, json.Unmarshal(data, &raw))

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -152,7 +152,7 @@ Arguments:
 |access-list-name|*no default* (required)|The Access List name.|
 |expires|*no default* (optional)|When the user's access expires (must be in RFC3339). Defaults to the expiration time of the Access List.|
 |reason|*no default* (optional)|The reason the user has been added to the Access List. Defaults to empty.|
-|user|*no default* (required)|The user to add to the Access List.|
+|user|*no default* (required)|The member to add to the Access List.|
 
 ## tctl acl users ls
 
@@ -191,7 +191,7 @@ Arguments:
 |Argument|Default|Description|
 |---|---|---|
 |access-list-name|*no default* (required)|The Access List name.|
-|user|*no default* (required)|The user to remove from the Access List.|
+|user|*no default* (required)|The member to remove from the Access List.|
 
 ## tctl alerts ack
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
@@ -68,8 +68,8 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 |Field|Type|Description|
 |---|---|---|
-|role|string|role is the name of the scoped role to be granted.|
-|scope|string|scope is the scope the role will be assigned at. It must be an assignable scope of the role.|
+|role|string|role is scope-qualified name of the scoped role to be granted.|
+|scope|string|scope is the scope the role will be granted at. It must be an assignable scope of the role.|
 
 ### spec.grants.traits
 
@@ -104,8 +104,8 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 |Field|Type|Description|
 |---|---|---|
-|role|string|role is the name of the scoped role to be granted.|
-|scope|string|scope is the scope the role will be assigned at. It must be an assignable scope of the role.|
+|role|string|role is scope-qualified name of the scoped role to be granted.|
+|scope|string|scope is the scope the role will be granted at. It must be an assignable scope of the role.|
 
 ### spec.owner_grants.traits
 
@@ -120,8 +120,8 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |---|---|---|
 |description|string|description is the plaintext description of the owner and why they are an owner.|
 |ineligible_status|string or integer|ineligible_status describes if this owner is eligible or not and if not, describes how they're lacking eligibility. Can be either the string or the integer representation of each option.|
-|membership_kind|string or integer|membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`. Can be either the string or the integer representation of each option.|
-|name|string|name is the username of the owner.|
+|membership_kind|string or integer|membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`. Can be either the string or the integer representation of each option.|
+|name|string|name is the name of the owner, depending on MembershipKind: MEMBERSHIP_KIND_USER: the username of the owner. MEMBERSHIP_KIND_LIST: the name of the owner Access List. MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the owner Access List.|
 
 ### spec.ownership_requires
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
@@ -68,7 +68,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 |Field|Type|Description|
 |---|---|---|
-|role|string|role is scope-qualified name of the scoped role to be granted.|
+|role|string|role is the scope-qualified name of the scoped role to be granted.|
 |scope|string|scope is the scope the role will be granted at. It must be an assignable scope of the role.|
 
 ### spec.grants.traits
@@ -104,7 +104,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 |Field|Type|Description|
 |---|---|---|
-|role|string|role is scope-qualified name of the scoped role to be granted.|
+|role|string|role is the scope-qualified name of the scoped role to be granted.|
 |scope|string|scope is the scope the role will be granted at. It must be an assignable scope of the role.|
 
 ### spec.owner_grants.traits

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list.mdx
@@ -20,6 +20,7 @@ Teleport Terraform provider.
 ### Optional
 
 - `header` (Attributes) header is the header for the resource. (see [below for nested schema](#nested-schema-for-header))
+- `scope` (String) scope is the scope of the Access List.
 - `spec` (Attributes) spec is the specification for the Access List. (see [below for nested schema](#nested-schema-for-spec))
 
 ### Nested Schema for `header`
@@ -72,8 +73,8 @@ Optional:
 Optional:
 
 - `description` (String) description is the plaintext description of the owner and why they are an owner.
-- `membership_kind` (Number) membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
-- `name` (String) name is the username of the owner.
+- `membership_kind` (Number) membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
+- `name` (String) name is the name of the owner, depending on MembershipKind: MEMBERSHIP_KIND_USER: the username of the owner. MEMBERSHIP_KIND_LIST: the name of the owner Access List. MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the owner Access List.
 
 
 ### Nested Schema for `spec.audit`
@@ -112,8 +113,8 @@ Optional:
 
 Optional:
 
-- `role` (String) role is the name of the scoped role to be granted.
-- `scope` (String) scope is the scope the role will be assigned at. It must be an assignable scope of the role.
+- `role` (String) role is scope-qualified name of the scoped role to be granted.
+- `scope` (String) scope is the scope the role will be granted at. It must be an assignable scope of the role.
 
 
 ### Nested Schema for `spec.grants.traits`
@@ -153,8 +154,8 @@ Optional:
 
 Optional:
 
-- `role` (String) role is the name of the scoped role to be granted.
-- `scope` (String) scope is the scope the role will be assigned at. It must be an assignable scope of the role.
+- `role` (String) role is scope-qualified name of the scoped role to be granted.
+- `scope` (String) scope is the scope the role will be granted at. It must be an assignable scope of the role.
 
 
 ### Nested Schema for `spec.owner_grants.traits`

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list.mdx
@@ -113,7 +113,7 @@ Optional:
 
 Optional:
 
-- `role` (String) role is scope-qualified name of the scoped role to be granted.
+- `role` (String) role is the scope-qualified name of the scoped role to be granted.
 - `scope` (String) scope is the scope the role will be granted at. It must be an assignable scope of the role.
 
 
@@ -154,7 +154,7 @@ Optional:
 
 Optional:
 
-- `role` (String) role is scope-qualified name of the scoped role to be granted.
+- `role` (String) role is the scope-qualified name of the scoped role to be granted.
 - `scope` (String) scope is the scope the role will be granted at. It must be an assignable scope of the role.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list_member.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list_member.mdx
@@ -20,6 +20,7 @@ Teleport Terraform provider.
 ### Optional
 
 - `header` (Attributes) header is the header for the resource. (see [below for nested schema](#nested-schema-for-header))
+- `scope` (String) scope is the scope of the Access List member, it must be equal to the scope of the parent Access List.
 - `spec` (Attributes) spec is the specification for the Access List member. (see [below for nested schema](#nested-schema-for-spec))
 
 ### Nested Schema for `header`
@@ -55,13 +56,13 @@ Optional:
 Required:
 
 - `access_list` (String) associated Access List
-- `membership_kind` (Number) membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+- `membership_kind` (Number) membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
 
 Optional:
 
 - `added_by` (String) added_by is the user that added this user to the Access List.
 - `expires` (String) expires is when the user's membership to the Access List expires.
 - `joined` (String) joined is when the user joined the Access List.
-- `name` (String) name is the name of the member of the Access List.
+- `name` (String) name is the name of the member of the Access List, depending on MembershipKind: MEMBERSHIP_KIND_USER: the username of the member. MEMBERSHIP_KIND_LIST: the name of the member Access List. MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the member scope Access List.
 - `reason` (String) reason is the reason this user was added to the Access List.
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list.mdx
@@ -63,6 +63,7 @@ resource "teleport_access_list" "crane-operation" {
 ### Optional
 
 - `header` (Attributes) header is the header for the resource. (see [below for nested schema](#nested-schema-for-header))
+- `scope` (String) scope is the scope of the Access List.
 - `spec` (Attributes) spec is the specification for the Access List. (see [below for nested schema](#nested-schema-for-spec))
 
 ### Nested Schema for `header`
@@ -115,8 +116,8 @@ Optional:
 Optional:
 
 - `description` (String) description is the plaintext description of the owner and why they are an owner.
-- `membership_kind` (Number) membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
-- `name` (String) name is the username of the owner.
+- `membership_kind` (Number) membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
+- `name` (String) name is the name of the owner, depending on MembershipKind: MEMBERSHIP_KIND_USER: the username of the owner. MEMBERSHIP_KIND_LIST: the name of the owner Access List. MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the owner Access List.
 
 
 ### Nested Schema for `spec.audit`
@@ -155,8 +156,8 @@ Optional:
 
 Optional:
 
-- `role` (String) role is the name of the scoped role to be granted.
-- `scope` (String) scope is the scope the role will be assigned at. It must be an assignable scope of the role.
+- `role` (String) role is scope-qualified name of the scoped role to be granted.
+- `scope` (String) scope is the scope the role will be granted at. It must be an assignable scope of the role.
 
 
 ### Nested Schema for `spec.grants.traits`
@@ -196,8 +197,8 @@ Optional:
 
 Optional:
 
-- `role` (String) role is the name of the scoped role to be granted.
-- `scope` (String) scope is the scope the role will be assigned at. It must be an assignable scope of the role.
+- `role` (String) role is scope-qualified name of the scoped role to be granted.
+- `scope` (String) scope is the scope the role will be granted at. It must be an assignable scope of the role.
 
 
 ### Nested Schema for `spec.owner_grants.traits`

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list.mdx
@@ -156,7 +156,7 @@ Optional:
 
 Optional:
 
-- `role` (String) role is scope-qualified name of the scoped role to be granted.
+- `role` (String) role is the scope-qualified name of the scoped role to be granted.
 - `scope` (String) scope is the scope the role will be granted at. It must be an assignable scope of the role.
 
 
@@ -197,7 +197,7 @@ Optional:
 
 Optional:
 
-- `role` (String) role is scope-qualified name of the scoped role to be granted.
+- `role` (String) role is the scope-qualified name of the scoped role to be granted.
 - `scope` (String) scope is the scope the role will be granted at. It must be an assignable scope of the role.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list_member.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list_member.mdx
@@ -95,6 +95,7 @@ resource "teleport_access_list_member" "npcs" {
 ### Optional
 
 - `header` (Attributes) header is the header for the resource. (see [below for nested schema](#nested-schema-for-header))
+- `scope` (String) scope is the scope of the Access List member, it must be equal to the scope of the parent Access List.
 - `spec` (Attributes) spec is the specification for the Access List member. (see [below for nested schema](#nested-schema-for-spec))
 
 ### Nested Schema for `header`
@@ -130,12 +131,12 @@ Optional:
 Required:
 
 - `access_list` (String) associated Access List
-- `membership_kind` (Number) membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+- `membership_kind` (Number) membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
 
 Optional:
 
 - `added_by` (String) added_by is the user that added this user to the Access List.
 - `expires` (String) expires is when the user's membership to the Access List expires.
 - `joined` (String) joined is when the user joined the Access List.
-- `name` (String) name is the name of the member of the Access List.
+- `name` (String) name is the name of the member of the Access List, depending on MembershipKind: MEMBERSHIP_KIND_USER: the username of the member. MEMBERSHIP_KIND_LIST: the name of the member Access List. MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the member scope Access List.
 - `reason` (String) reason is the reason this user was added to the Access List.

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accesslists.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accesslists.yaml
@@ -91,10 +91,11 @@ spec:
                     items:
                       properties:
                         role:
-                          description: role is the name of the scoped role to be granted.
+                          description: role is scope-qualified name of the scoped
+                            role to be granted.
                           type: string
                         scope:
-                          description: scope is the scope the role will be assigned
+                          description: scope is the scope the role will be granted
                             at. It must be an assignable scope of the role.
                           type: string
                       type: object
@@ -147,10 +148,11 @@ spec:
                     items:
                       properties:
                         role:
-                          description: role is the name of the scoped role to be granted.
+                          description: role is scope-qualified name of the scoped
+                            role to be granted.
                           type: string
                         scope:
-                          description: scope is the scope the role will be assigned
+                          description: scope is the scope the role will be granted
                             at. It must be an assignable scope of the role.
                           type: string
                       type: object
@@ -178,10 +180,14 @@ spec:
                       x-kubernetes-int-or-string: true
                     membership_kind:
                       description: membership_kind describes the type of membership,
-                        either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+                        either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or
+                        `MEMBERSHIP_KIND_SCOPED_LIST`.
                       x-kubernetes-int-or-string: true
                     name:
-                      description: name is the username of the owner.
+                      description: 'name is the name of the owner, depending on MembershipKind:
+                        MEMBERSHIP_KIND_USER: the username of the owner. MEMBERSHIP_KIND_LIST:
+                        the name of the owner Access List. MEMBERSHIP_KIND_SCOPED_LIST:
+                        the scope-qualified name of the owner Access List.'
                       type: string
                   type: object
                 nullable: true

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accesslists.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accesslists.yaml
@@ -91,7 +91,7 @@ spec:
                     items:
                       properties:
                         role:
-                          description: role is scope-qualified name of the scoped
+                          description: role is the scope-qualified name of the scoped
                             role to be granted.
                           type: string
                         scope:
@@ -148,7 +148,7 @@ spec:
                     items:
                       properties:
                         role:
-                          description: role is scope-qualified name of the scoped
+                          description: role is the scope-qualified name of the scoped
                             role to be granted.
                           type: string
                         scope:

--- a/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
+++ b/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
@@ -57,6 +57,12 @@ export interface AccessList {
      * @generated from protobuf field: teleport.accesslist.v1.AccessListStatus status = 3;
      */
     status?: AccessListStatus;
+    /**
+     * scope is the scope of the Access List.
+     *
+     * @generated from protobuf field: string scope = 4;
+     */
+    scope: string;
 }
 /**
  * AccessListSpec is the specification for an Access List.
@@ -134,7 +140,10 @@ export interface AccessListSpec {
  */
 export interface AccessListOwner {
     /**
-     * name is the username of the owner.
+     * name is the name of the owner, depending on MembershipKind:
+     * MEMBERSHIP_KIND_USER: the username of the owner.
+     * MEMBERSHIP_KIND_LIST: the name of the owner Access List.
+     * MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the owner Access List.
      *
      * @generated from protobuf field: string name = 1;
      */
@@ -155,7 +164,7 @@ export interface AccessListOwner {
     ineligibleStatus: IneligibleStatus;
     /**
      * membership_kind describes the type of membership, either
-     * `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+     * `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
      *
      * @generated from protobuf field: teleport.accesslist.v1.MembershipKind membership_kind = 4;
      */
@@ -277,13 +286,13 @@ export interface AccessListGrants {
  */
 export interface ScopedRoleGrant {
     /**
-     * role is the name of the scoped role to be granted.
+     * role is scope-qualified name of the scoped role to be granted.
      *
      * @generated from protobuf field: string role = 1;
      */
     role: string;
     /**
-     * scope is the scope the role will be assigned at. It must be an assignable
+     * scope is the scope the role will be granted at. It must be an assignable
      * scope of the role.
      *
      * @generated from protobuf field: string scope = 2;
@@ -308,6 +317,13 @@ export interface Member {
      * @generated from protobuf field: teleport.accesslist.v1.MemberSpec spec = 2;
      */
     spec?: MemberSpec;
+    /**
+     * scope is the scope of the Access List member, it must be equal to the
+     * scope of the parent Access List.
+     *
+     * @generated from protobuf field: string scope = 3;
+     */
+    scope: string;
 }
 /**
  * MemberSpec is the specification for an Access List member.
@@ -322,7 +338,10 @@ export interface MemberSpec {
      */
     accessList: string;
     /**
-     * name is the name of the member of the Access List.
+     * name is the name of the member of the Access List, depending on MembershipKind:
+     * MEMBERSHIP_KIND_USER: the username of the member.
+     * MEMBERSHIP_KIND_LIST: the name of the member Access List.
+     * MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the member scope Access List.
      *
      * @generated from protobuf field: string name = 2;
      */
@@ -360,7 +379,7 @@ export interface MemberSpec {
     ineligibleStatus: IneligibleStatus;
     /**
      * membership_kind describes the type of membership, either
-     * `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+     * `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
      *
      * @generated from protobuf field: teleport.accesslist.v1.MembershipKind membership_kind = 9;
      */
@@ -384,6 +403,13 @@ export interface Review {
      * @generated from protobuf field: teleport.accesslist.v1.ReviewSpec spec = 2;
      */
     spec?: ReviewSpec;
+    /**
+     * scope is the scope of the Access List review. It must be equal to the
+     * scope of the reviewed Access List.
+     *
+     * @generated from protobuf field: string scope = 3;
+     */
+    scope: string;
 }
 /**
  * ReviewSpec is the specification for an Access List review.
@@ -393,6 +419,8 @@ export interface Review {
 export interface ReviewSpec {
     /**
      * access_list is the name of the Access List that this review is for.
+     * If the review is scoped, this is the scope-qualified name of the reviewed
+     * scoped Access List.
      *
      * @generated from protobuf field: string access_list = 1;
      */
@@ -456,40 +484,47 @@ export interface ReviewChanges {
      * @generated from protobuf field: teleport.accesslist.v1.ReviewDayOfMonth review_day_of_month_changed = 5;
      */
     reviewDayOfMonthChanged: ReviewDayOfMonth;
+    /**
+     * scoped_removed_members contains the scope-qualified names of members that
+     * were removed as part of this review.
+     *
+     * @generated from protobuf field: repeated string scoped_removed_members = 6;
+     */
+    scopedRemovedMembers: string[];
 }
 /**
- * CurrentUserAssignments describes the current user's ownership and membership status in the access list.
+ * CurrentUserAssignments describes the current user's ownership and membership status in the Access List.
  *
  * @generated from protobuf message teleport.accesslist.v1.CurrentUserAssignments
  */
 export interface CurrentUserAssignments {
     /**
-     * ownership_type represents the current user's ownership type (explicit, inherited, or none) in the access list.
+     * ownership_type represents the current user's ownership type (explicit, inherited, or none) in the Access List.
      *
      * @generated from protobuf field: teleport.accesslist.v1.AccessListUserAssignmentType ownership_type = 1;
      */
     ownershipType: AccessListUserAssignmentType;
     /**
-     * membership_type represents the current user's membership type (explicit, inherited, or none) in the access list.
+     * membership_type represents the current user's membership type (explicit, inherited, or none) in the Access List.
      *
      * @generated from protobuf field: teleport.accesslist.v1.AccessListUserAssignmentType membership_type = 2;
      */
     membershipType: AccessListUserAssignmentType;
 }
 /**
- * UserAssignments describes the requested user's ownership and membership assignment types in the access list.
+ * UserAssignments describes the requested user's ownership and membership assignment types in the Access List.
  *
  * @generated from protobuf message teleport.accesslist.v1.UserAssignments
  */
 export interface UserAssignments {
     /**
-     * ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the access list.
+     * ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the Access List.
      *
      * @generated from protobuf field: teleport.accesslist.v1.AccessListUserAssignmentType ownership_type = 1;
      */
     ownershipType: AccessListUserAssignmentType;
     /**
-     * membership_type represents the requested user's membership type (explicit, inherited, or none) in the access list.
+     * membership_type represents the requested user's membership type (explicit, inherited, or none) in the Access List.
      *
      * @generated from protobuf field: teleport.accesslist.v1.AccessListUserAssignmentType membership_type = 2;
      */
@@ -526,17 +561,31 @@ export interface AccessListStatus {
      */
     memberOf: string[];
     /**
-     * current_user_assignments describes the current user's ownership and membership status in the access list.
+     * current_user_assignments describes the current user's ownership and membership status in the Access List.
      *
      * @generated from protobuf field: teleport.accesslist.v1.CurrentUserAssignments current_user_assignments = 5;
      */
     currentUserAssignments?: CurrentUserAssignments;
     /**
-     * user_assignments describes the requested user's ownership and membership assignment types in the access list.
+     * user_assignments describes the requested user's ownership and membership assignment types in the Access List.
      *
      * @generated from protobuf field: teleport.accesslist.v1.UserAssignments user_assignments = 6;
      */
     userAssignments?: UserAssignments;
+    /**
+     * scoped_owner_of describes scoped Access Lists where this Access List is an explicit owner.
+     * Each item is the scope-qualified name of the owned scoped Access List.
+     *
+     * @generated from protobuf field: repeated string scoped_owner_of = 7;
+     */
+    scopedOwnerOf: string[];
+    /**
+     * scoped_member_of describes scoped Access Lists where this Access List is an explicit member.
+     * Each item is the scope-qualified name of the parent scoped Access List.
+     *
+     * @generated from protobuf field: repeated string scoped_member_of = 8;
+     */
+    scopedMemberOf: string[];
 }
 /**
  * ReviewFrequency is the frequency of reviews.
@@ -612,7 +661,13 @@ export enum MembershipKind {
      *
      * @generated from protobuf enum value: MEMBERSHIP_KIND_LIST = 2;
      */
-    LIST = 2
+    LIST = 2,
+    /**
+     * MEMBERSHIP_KIND_SCOPED_LIST represents list members that are nested scoped Access Lists
+     *
+     * @generated from protobuf enum value: MEMBERSHIP_KIND_SCOPED_LIST = 3;
+     */
+    SCOPED_LIST = 3
 }
 /**
  * IneligibleStatus describes how the user is ineligible.
@@ -656,8 +711,8 @@ export enum IneligibleStatus {
     EXPIRED = 4
 }
 /**
- * AccessListUserAssignmentType describes the type of membership anr/or ownership
- * a user has in an access list.
+ * AccessListUserAssignmentType describes the type of membership and/or ownership
+ * a user has in an Access List.
  *
  * @generated from protobuf enum teleport.accesslist.v1.AccessListUserAssignmentType
  */
@@ -687,11 +742,13 @@ class AccessList$Type extends MessageType<AccessList> {
         super("teleport.accesslist.v1.AccessList", [
             { no: 1, name: "header", kind: "message", T: () => ResourceHeader },
             { no: 2, name: "spec", kind: "message", T: () => AccessListSpec },
-            { no: 3, name: "status", kind: "message", T: () => AccessListStatus }
+            { no: 3, name: "status", kind: "message", T: () => AccessListStatus },
+            { no: 4, name: "scope", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<AccessList>): AccessList {
         const message = globalThis.Object.create((this.messagePrototype!));
+        message.scope = "";
         if (value !== undefined)
             reflectionMergePartial<AccessList>(this, message, value);
         return message;
@@ -709,6 +766,9 @@ class AccessList$Type extends MessageType<AccessList> {
                     break;
                 case /* teleport.accesslist.v1.AccessListStatus status */ 3:
                     message.status = AccessListStatus.internalBinaryRead(reader, reader.uint32(), options, message.status);
+                    break;
+                case /* string scope */ 4:
+                    message.scope = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -731,6 +791,9 @@ class AccessList$Type extends MessageType<AccessList> {
         /* teleport.accesslist.v1.AccessListStatus status = 3; */
         if (message.status)
             AccessListStatus.internalBinaryWrite(message.status, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
+        /* string scope = 4; */
+        if (message.scope !== "")
+            writer.tag(4, WireType.LengthDelimited).string(message.scope);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1257,11 +1320,13 @@ class Member$Type extends MessageType<Member> {
     constructor() {
         super("teleport.accesslist.v1.Member", [
             { no: 1, name: "header", kind: "message", T: () => ResourceHeader },
-            { no: 2, name: "spec", kind: "message", T: () => MemberSpec }
+            { no: 2, name: "spec", kind: "message", T: () => MemberSpec },
+            { no: 3, name: "scope", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<Member>): Member {
         const message = globalThis.Object.create((this.messagePrototype!));
+        message.scope = "";
         if (value !== undefined)
             reflectionMergePartial<Member>(this, message, value);
         return message;
@@ -1276,6 +1341,9 @@ class Member$Type extends MessageType<Member> {
                     break;
                 case /* teleport.accesslist.v1.MemberSpec spec */ 2:
                     message.spec = MemberSpec.internalBinaryRead(reader, reader.uint32(), options, message.spec);
+                    break;
+                case /* string scope */ 3:
+                    message.scope = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1295,6 +1363,9 @@ class Member$Type extends MessageType<Member> {
         /* teleport.accesslist.v1.MemberSpec spec = 2; */
         if (message.spec)
             MemberSpec.internalBinaryWrite(message.spec, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        /* string scope = 3; */
+        if (message.scope !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.scope);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1411,11 +1482,13 @@ class Review$Type extends MessageType<Review> {
     constructor() {
         super("teleport.accesslist.v1.Review", [
             { no: 1, name: "header", kind: "message", T: () => ResourceHeader },
-            { no: 2, name: "spec", kind: "message", T: () => ReviewSpec }
+            { no: 2, name: "spec", kind: "message", T: () => ReviewSpec },
+            { no: 3, name: "scope", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<Review>): Review {
         const message = globalThis.Object.create((this.messagePrototype!));
+        message.scope = "";
         if (value !== undefined)
             reflectionMergePartial<Review>(this, message, value);
         return message;
@@ -1430,6 +1503,9 @@ class Review$Type extends MessageType<Review> {
                     break;
                 case /* teleport.accesslist.v1.ReviewSpec spec */ 2:
                     message.spec = ReviewSpec.internalBinaryRead(reader, reader.uint32(), options, message.spec);
+                    break;
+                case /* string scope */ 3:
+                    message.scope = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1449,6 +1525,9 @@ class Review$Type extends MessageType<Review> {
         /* teleport.accesslist.v1.ReviewSpec spec = 2; */
         if (message.spec)
             ReviewSpec.internalBinaryWrite(message.spec, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        /* string scope = 3; */
+        if (message.scope !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.scope);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1543,7 +1622,8 @@ class ReviewChanges$Type extends MessageType<ReviewChanges> {
             { no: 2, name: "membership_requirements_changed", kind: "message", T: () => AccessListRequires },
             { no: 3, name: "removed_members", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
             { no: 4, name: "review_frequency_changed", kind: "enum", T: () => ["teleport.accesslist.v1.ReviewFrequency", ReviewFrequency, "REVIEW_FREQUENCY_"] },
-            { no: 5, name: "review_day_of_month_changed", kind: "enum", T: () => ["teleport.accesslist.v1.ReviewDayOfMonth", ReviewDayOfMonth, "REVIEW_DAY_OF_MONTH_"] }
+            { no: 5, name: "review_day_of_month_changed", kind: "enum", T: () => ["teleport.accesslist.v1.ReviewDayOfMonth", ReviewDayOfMonth, "REVIEW_DAY_OF_MONTH_"] },
+            { no: 6, name: "scoped_removed_members", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<ReviewChanges>): ReviewChanges {
@@ -1551,6 +1631,7 @@ class ReviewChanges$Type extends MessageType<ReviewChanges> {
         message.removedMembers = [];
         message.reviewFrequencyChanged = 0;
         message.reviewDayOfMonthChanged = 0;
+        message.scopedRemovedMembers = [];
         if (value !== undefined)
             reflectionMergePartial<ReviewChanges>(this, message, value);
         return message;
@@ -1571,6 +1652,9 @@ class ReviewChanges$Type extends MessageType<ReviewChanges> {
                     break;
                 case /* teleport.accesslist.v1.ReviewDayOfMonth review_day_of_month_changed */ 5:
                     message.reviewDayOfMonthChanged = reader.int32();
+                    break;
+                case /* repeated string scoped_removed_members */ 6:
+                    message.scopedRemovedMembers.push(reader.string());
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1596,6 +1680,9 @@ class ReviewChanges$Type extends MessageType<ReviewChanges> {
         /* teleport.accesslist.v1.ReviewDayOfMonth review_day_of_month_changed = 5; */
         if (message.reviewDayOfMonthChanged !== 0)
             writer.tag(5, WireType.Varint).int32(message.reviewDayOfMonthChanged);
+        /* repeated string scoped_removed_members = 6; */
+        for (let i = 0; i < message.scopedRemovedMembers.length; i++)
+            writer.tag(6, WireType.LengthDelimited).string(message.scopedRemovedMembers[i]);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1725,13 +1812,17 @@ class AccessListStatus$Type extends MessageType<AccessListStatus> {
             { no: 3, name: "owner_of", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
             { no: 4, name: "member_of", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
             { no: 5, name: "current_user_assignments", kind: "message", T: () => CurrentUserAssignments },
-            { no: 6, name: "user_assignments", kind: "message", T: () => UserAssignments }
+            { no: 6, name: "user_assignments", kind: "message", T: () => UserAssignments },
+            { no: 7, name: "scoped_owner_of", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
+            { no: 8, name: "scoped_member_of", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<AccessListStatus>): AccessListStatus {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.ownerOf = [];
         message.memberOf = [];
+        message.scopedOwnerOf = [];
+        message.scopedMemberOf = [];
         if (value !== undefined)
             reflectionMergePartial<AccessListStatus>(this, message, value);
         return message;
@@ -1758,6 +1849,12 @@ class AccessListStatus$Type extends MessageType<AccessListStatus> {
                     break;
                 case /* teleport.accesslist.v1.UserAssignments user_assignments */ 6:
                     message.userAssignments = UserAssignments.internalBinaryRead(reader, reader.uint32(), options, message.userAssignments);
+                    break;
+                case /* repeated string scoped_owner_of */ 7:
+                    message.scopedOwnerOf.push(reader.string());
+                    break;
+                case /* repeated string scoped_member_of */ 8:
+                    message.scopedMemberOf.push(reader.string());
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1789,6 +1886,12 @@ class AccessListStatus$Type extends MessageType<AccessListStatus> {
         /* teleport.accesslist.v1.UserAssignments user_assignments = 6; */
         if (message.userAssignments)
             UserAssignments.internalBinaryWrite(message.userAssignments, writer.tag(6, WireType.LengthDelimited).fork(), options).join();
+        /* repeated string scoped_owner_of = 7; */
+        for (let i = 0; i < message.scopedOwnerOf.length; i++)
+            writer.tag(7, WireType.LengthDelimited).string(message.scopedOwnerOf[i]);
+        /* repeated string scoped_member_of = 8; */
+        for (let i = 0; i < message.scopedMemberOf.length; i++)
+            writer.tag(8, WireType.LengthDelimited).string(message.scopedMemberOf[i]);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
+++ b/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
@@ -286,7 +286,7 @@ export interface AccessListGrants {
  */
 export interface ScopedRoleGrant {
     /**
-     * role is scope-qualified name of the scoped role to be granted.
+     * role is the scope-qualified name of the scoped role to be granted.
      *
      * @generated from protobuf field: string role = 1;
      */

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_accesslists.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_accesslists.yaml
@@ -91,10 +91,11 @@ spec:
                     items:
                       properties:
                         role:
-                          description: role is the name of the scoped role to be granted.
+                          description: role is scope-qualified name of the scoped
+                            role to be granted.
                           type: string
                         scope:
-                          description: scope is the scope the role will be assigned
+                          description: scope is the scope the role will be granted
                             at. It must be an assignable scope of the role.
                           type: string
                       type: object
@@ -147,10 +148,11 @@ spec:
                     items:
                       properties:
                         role:
-                          description: role is the name of the scoped role to be granted.
+                          description: role is scope-qualified name of the scoped
+                            role to be granted.
                           type: string
                         scope:
-                          description: scope is the scope the role will be assigned
+                          description: scope is the scope the role will be granted
                             at. It must be an assignable scope of the role.
                           type: string
                       type: object
@@ -178,10 +180,14 @@ spec:
                       x-kubernetes-int-or-string: true
                     membership_kind:
                       description: membership_kind describes the type of membership,
-                        either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+                        either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or
+                        `MEMBERSHIP_KIND_SCOPED_LIST`.
                       x-kubernetes-int-or-string: true
                     name:
-                      description: name is the username of the owner.
+                      description: 'name is the name of the owner, depending on MembershipKind:
+                        MEMBERSHIP_KIND_USER: the username of the owner. MEMBERSHIP_KIND_LIST:
+                        the name of the owner Access List. MEMBERSHIP_KIND_SCOPED_LIST:
+                        the scope-qualified name of the owner Access List.'
                       type: string
                   type: object
                 nullable: true

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_accesslists.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_accesslists.yaml
@@ -91,7 +91,7 @@ spec:
                     items:
                       properties:
                         role:
-                          description: role is scope-qualified name of the scoped
+                          description: role is the scope-qualified name of the scoped
                             role to be granted.
                           type: string
                         scope:
@@ -148,7 +148,7 @@ spec:
                     items:
                       properties:
                         role:
-                          description: role is scope-qualified name of the scoped
+                          description: role is the scope-qualified name of the scoped
                             role to be granted.
                           type: string
                         scope:

--- a/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
+++ b/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
@@ -120,6 +120,11 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 			Required:      false,
 			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
+		"scope": {
+			Description: "scope is the scope of the Access List.",
+			Optional:    true,
+			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+		},
 		"spec": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				"audit": {
@@ -173,12 +178,12 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 						"scoped_roles": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 								"role": {
-									Description: "role is the name of the scoped role to be granted.",
+									Description: "role is scope-qualified name of the scoped role to be granted.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 								"scope": {
-									Description: "scope is the scope the role will be assigned at. It must be an assignable scope of the role.",
+									Description: "scope is the scope the role will be granted at. It must be an assignable scope of the role.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
@@ -243,12 +248,12 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 						"scoped_roles": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 								"role": {
-									Description: "role is the name of the scoped role to be granted.",
+									Description: "role is scope-qualified name of the scoped role to be granted.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 								"scope": {
-									Description: "scope is the scope the role will be assigned at. It must be an assignable scope of the role.",
+									Description: "scope is the scope the role will be granted at. It must be an assignable scope of the role.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
@@ -284,12 +289,12 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 						"membership_kind": {
-							Description: "membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.",
+							Description: "membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
 						},
 						"name": {
-							Description: "name is the username of the owner.",
+							Description: "name is the name of the owner, depending on MembershipKind: MEMBERSHIP_KIND_USER: the username of the owner. MEMBERSHIP_KIND_LIST: the name of the owner Access List. MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the owner Access List.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
@@ -417,6 +422,11 @@ func GenSchemaMember(ctx context.Context) (github_com_hashicorp_terraform_plugin
 			Required:      false,
 			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
+		"scope": {
+			Description: "scope is the scope of the Access List member, it must be equal to the scope of the parent Access List.",
+			Optional:    true,
+			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+		},
 		"spec": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				"access_list": {
@@ -443,14 +453,14 @@ func GenSchemaMember(ctx context.Context) (github_com_hashicorp_terraform_plugin
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 				}),
 				"membership_kind": {
-					Description:   "membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.",
+					Description:   "membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.",
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
 					Required:      true,
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
 				},
 				"name": {
 					Computed:      true,
-					Description:   "name is the name of the member of the Access List.",
+					Description:   "name is the name of the member of the Access List, depending on MembershipKind: MEMBERSHIP_KIND_USER: the username of the member. MEMBERSHIP_KIND_LIST: the name of the member Access List. MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the member scope Access List.",
 					Optional:      true,
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
@@ -1505,6 +1515,23 @@ func CopyAccessListFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 						}
 					}
 				}
+			}
+		}
+	}
+	{
+		a, ok := tf.Attrs["scope"]
+		if !ok {
+			diags.Append(attrReadMissingDiag{"AccessList.scope"})
+		} else {
+			v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+			if !ok {
+				diags.Append(attrReadConversionFailureDiag{"AccessList.scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+			} else {
+				var t string
+				if !v.Null && !v.Unknown {
+					t = string(v.Value)
+				}
+				obj.Scope = t
 			}
 		}
 	}
@@ -3252,6 +3279,28 @@ func CopyAccessListToTerraform(ctx context.Context, obj *github_com_gravitationa
 			}
 		}
 	}
+	{
+		t, ok := tf.AttrTypes["scope"]
+		if !ok {
+			diags.Append(attrWriteMissingDiag{"AccessList.scope"})
+		} else {
+			v, ok := tf.Attrs["scope"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+			if !ok {
+				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+				if err != nil {
+					diags.Append(attrWriteGeneralError{"AccessList.scope", err})
+				}
+				v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+				if !ok {
+					diags.Append(attrWriteConversionFailureDiag{"AccessList.scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+				}
+				v.Null = string(obj.Scope) == ""
+			}
+			v.Value = string(obj.Scope)
+			v.Unknown = false
+			tf.Attrs["scope"] = v
+		}
+	}
 	return diags
 }
 
@@ -3561,6 +3610,23 @@ func CopyMemberFromTerraform(_ context.Context, tf github_com_hashicorp_terrafor
 						}
 					}
 				}
+			}
+		}
+	}
+	{
+		a, ok := tf.Attrs["scope"]
+		if !ok {
+			diags.Append(attrReadMissingDiag{"Member.scope"})
+		} else {
+			v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+			if !ok {
+				diags.Append(attrReadConversionFailureDiag{"Member.scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+			} else {
+				var t string
+				if !v.Null && !v.Unknown {
+					t = string(v.Value)
+				}
+				obj.Scope = t
 			}
 		}
 	}
@@ -4010,6 +4076,28 @@ func CopyMemberToTerraform(ctx context.Context, obj *github_com_gravitational_te
 				v.Unknown = false
 				tf.Attrs["spec"] = v
 			}
+		}
+	}
+	{
+		t, ok := tf.AttrTypes["scope"]
+		if !ok {
+			diags.Append(attrWriteMissingDiag{"Member.scope"})
+		} else {
+			v, ok := tf.Attrs["scope"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+			if !ok {
+				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+				if err != nil {
+					diags.Append(attrWriteGeneralError{"Member.scope", err})
+				}
+				v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+				if !ok {
+					diags.Append(attrWriteConversionFailureDiag{"Member.scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+				}
+				v.Null = string(obj.Scope) == ""
+			}
+			v.Value = string(obj.Scope)
+			v.Unknown = false
+			tf.Attrs["scope"] = v
 		}
 	}
 	return diags

--- a/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
+++ b/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
@@ -178,7 +178,7 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 						"scoped_roles": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 								"role": {
-									Description: "role is scope-qualified name of the scoped role to be granted.",
+									Description: "role is the scope-qualified name of the scoped role to be granted.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
@@ -248,7 +248,7 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 						"scoped_roles": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 								"role": {
-									Description: "role is scope-qualified name of the scoped role to be granted.",
+									Description: "role is the scope-qualified name of the scoped role to be granted.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},

--- a/lib/accesslists/collection.go
+++ b/lib/accesslists/collection.go
@@ -51,11 +51,17 @@ func (b *Collection) Validate(ctx context.Context) error {
 		if err := accessList.CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err)
 		}
+		if accessList.Scope != "" {
+			return trace.BadParameter("collections do not support scoped access lists")
+		}
 	}
 	for _, members := range b.MembersByAccessList {
 		for _, member := range members {
 			if err := member.CheckAndSetDefaults(); err != nil {
 				return trace.Wrap(err)
+			}
+			if member.Scope != "" {
+				return trace.BadParameter("collections do not support scoped access list members")
 			}
 		}
 	}
@@ -158,6 +164,15 @@ func (b *Collection) ListAccessListMembers(ctx context.Context, accessListName s
 	return pageMembers, nextToken, nil
 }
 
+// ListAccessListMembersV2 retrieves members for an access list from the batch.
+func (b *Collection) ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) ([]*accesslist.AccessListMember, string, error) {
+	// TODO(nklaassen): support collections of scoped access lists.
+	if req.GetAccessListScope() != "" {
+		return nil, "", trace.BadParameter("collection does not support scoped access lists")
+	}
+	return b.ListAccessListMembers(ctx, req.GetAccessList(), int(req.GetPageSize()), req.GetPageToken())
+}
+
 // GetAccessListMember retrieves a specific member from an access list in the batch.
 // Implements accesslists.AccessListAndMembersGetter interface.
 func (b *Collection) GetAccessListMember(ctx context.Context, accessListName, memberName string) (*accesslist.AccessListMember, error) {
@@ -171,6 +186,15 @@ func (b *Collection) GetAccessListMember(ctx context.Context, accessListName, me
 		}
 	}
 	return nil, trace.NotFound("member %q not found in access list %q", memberName, accessListName)
+}
+
+// GetAccessListMemberV2 retrieves a specific member from an access list in the batch.
+func (b *Collection) GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error) {
+	// TODO(nklaassen): support collections of scoped access lists.
+	if req.GetAccessListScope() != "" || req.GetMemberScope() != "" {
+		return nil, trace.BadParameter("collection does not support scoped access lists")
+	}
+	return b.GetAccessListMember(ctx, req.GetAccessList(), req.GetMemberName())
 }
 
 // RefUpdates calculates and applies reference updates (Status.MemberOf and Status.OwnerOf)

--- a/lib/accesslists/collection.go
+++ b/lib/accesslists/collection.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	"github.com/gravitational/teleport/api/types/accesslist"
 )
 
@@ -101,6 +102,16 @@ func (b *Collection) GetAccessList(ctx context.Context, name string) (*accesslis
 		return nil, trace.NotFound("access list %q not found in batch", name)
 	}
 	return al, nil
+}
+
+// GetAccessListV2 retrieves an access list from the batch by scoped name.
+// Implements accesslists.AccessListAndMembersGetter interface.
+func (b *Collection) GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error) {
+	// TODO(nklaassen): support collections of scoped access lists.
+	if req.GetScope() != "" {
+		return nil, trace.BadParameter("Collection does not support scoped access lists")
+	}
+	return b.GetAccessList(ctx, req.GetName())
 }
 
 // ListAccessListMembers retrieves members for an access list from the batch.

--- a/lib/accesslists/hierarchy.go
+++ b/lib/accesslists/hierarchy.go
@@ -55,6 +55,36 @@ type AccessListMembersLister interface {
 }
 
 // TODO(nklaassen): delete this when everything used as an
+// [AccessListAndMembersGetter] implements ListAccessListMembersV2.
+func listAccessListMembers(ctx context.Context, g AccessListMembersLister, req *accesslistv1.ListAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error) {
+	type accessListMembersListerV2 interface {
+		ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error)
+	}
+	if g, ok := g.(accessListMembersListerV2); ok {
+		return g.ListAccessListMembersV2(ctx, req)
+	}
+	if req.GetAccessListScope() != "" {
+		return nil, "", trace.BadParameter("can't list members of scoped access list when g does not implement ListAccessListMembersV2")
+	}
+	return g.ListAccessListMembers(ctx, req.GetAccessList(), int(req.GetPageSize()), req.GetPageToken())
+}
+
+// TODO(nklaassen): delete this when everything used as an
+// [AccessListAndMembersGetter] implements GetAccessListMemberV2.
+func getAccessListMember(ctx context.Context, g AccessListAndMembersGetter, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error) {
+	type accessListMemberGetterV2 interface {
+		GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error)
+	}
+	if g, ok := g.(accessListMemberGetterV2); ok {
+		return g.GetAccessListMemberV2(ctx, req)
+	}
+	if req.GetAccessListScope() != "" || req.GetMemberScope() != "" {
+		return nil, trace.BadParameter("cannot get scoped access list members when g does not implement GetAccessListMemberV2")
+	}
+	return g.GetAccessListMember(ctx, req.GetAccessList(), req.GetMemberName())
+}
+
+// TODO(nklaassen): delete this when everything used as an
 // [AccessListAndMembersGetter] implements GetAccessListV2.
 func getAccessList(ctx context.Context, g AccessListAndMembersGetter, accessListName NormalizedSQN) (*accesslist.AccessList, error) {
 	type accessListGetterV2 interface {
@@ -85,28 +115,39 @@ type lockGetter interface {
 // Returned Members are not validated for expiration or other requirements – use IsAccessListMember
 // to validate a Member's membership status.
 func GetMembersFor(ctx context.Context, accessListName string, g AccessListMembersLister) ([]*accesslist.AccessListMember, error) {
-	return getMembersFor(ctx, accessListName, g, make(map[string]struct{}))
+	return getMembersFor(ctx, NormalizedSQN{Name: accessListName}, g, make(map[NormalizedSQN]struct{}))
 }
 
-func getMembersFor(ctx context.Context, accessListName string, g AccessListMembersLister, visited map[string]struct{}) ([]*accesslist.AccessListMember, error) {
+// GetMembersForV2 returns a flattened list of Members for an Access List, including inherited Members.
+//
+// Returned Members are not validated for expiration or other requirements – use IsAccessListMember
+// to validate a Member's membership status.
+func GetMembersForV2(ctx context.Context, accessListName NormalizedSQN, g AccessListMembersLister) ([]*accesslist.AccessListMember, error) {
+	return getMembersFor(ctx, accessListName, g, make(map[NormalizedSQN]struct{}))
+}
+
+func getMembersFor(ctx context.Context, accessListName NormalizedSQN, g AccessListMembersLister, visited map[NormalizedSQN]struct{}) ([]*accesslist.AccessListMember, error) {
 	if _, ok := visited[accessListName]; ok {
 		return nil, nil
 	}
 	visited[accessListName] = struct{}{}
 
-	// TODO(nklaassen): support scoped access list members
-	members, err := fetchMembers(ctx, NormalizedSQN{Name: accessListName}, g)
+	members, err := fetchMembers(ctx, accessListName, g)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	var allMembers []*accesslist.AccessListMember
 	for _, member := range members {
-		if member.Spec.MembershipKind != accesslist.MembershipKindList {
+		if !member.IsList() {
 			allMembers = append(allMembers, member)
 			continue
 		}
-		childMembers, err := getMembersFor(ctx, member.GetName(), g, visited)
+		memberName, err := MemberScopeQualifiedName(member)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		childMembers, err := getMembersFor(ctx, memberName, g, visited)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -118,15 +159,13 @@ func getMembersFor(ctx context.Context, accessListName string, g AccessListMembe
 
 // fetchMembers is a simple helper to fetch all top-level AccessListMembers for an AccessList.
 func fetchMembers(ctx context.Context, accessListName NormalizedSQN, g AccessListMembersLister) ([]*accesslist.AccessListMember, error) {
-	if accessListName.Scope != "" {
-		// Scoped access lists currently cannot have any members
-		// TODO(nklaassen): support scoped access list members.
-		return nil, nil
-	}
 	var allMembers []*accesslist.AccessListMember
-	pageToken := ""
+	req := accesslistv1.ListAccessListMembersRequest_builder{
+		AccessListScope: accessListName.Scope,
+		AccessList:      accessListName.Name,
+	}.Build()
 	for {
-		page, nextToken, err := g.ListAccessListMembers(ctx, accessListName.Name, 0, pageToken)
+		page, nextToken, err := listAccessListMembers(ctx, g, req)
 		if err != nil {
 			// If the AccessList doesn't exist yet, should return an empty list of members
 			if trace.IsNotFound(err) {
@@ -138,7 +177,7 @@ func fetchMembers(ctx context.Context, accessListName NormalizedSQN, g AccessLis
 		if nextToken == "" {
 			break
 		}
-		pageToken = nextToken
+		req.SetPageToken(nextToken)
 	}
 	return allMembers, nil
 }
@@ -187,18 +226,13 @@ func collectOwners(
 
 // collectMembersAsOwners is a helper to collect all nested members of an AccessList and return them cast as Owners.
 func collectMembersAsOwners(ctx context.Context, accessListName NormalizedSQN, g AccessListMembersLister, visited map[NormalizedSQN]struct{}) ([]*accesslist.Owner, error) {
-	// TODO(nklaassen): support scoped access list members.
-	if accessListName.Scope != "" {
-		return nil, nil
-	}
-
 	owners := make([]*accesslist.Owner, 0)
 	if _, ok := visited[accessListName]; ok {
 		return owners, nil
 	}
 	visited[accessListName] = struct{}{}
 
-	listMembers, err := GetMembersFor(ctx, accessListName.Name, g)
+	listMembers, err := GetMembersForV2(ctx, accessListName, g)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -454,7 +488,7 @@ func IsAccessListMember(
 
 	for _, member := range members {
 		// Is user an explicit member?
-		if member.Spec.MembershipKind != accesslist.MembershipKindList && member.GetName() == user.GetName() {
+		if member.IsUser() && member.GetName() == user.GetName() {
 			if !UserMeetsRequirements(user, accessList.Spec.MembershipRequires) {
 				// Avoid non-deterministic behavior in these checks. Rather than returning immediately, continue
 				// through all members to make sure there isn't a valid match later on.
@@ -468,13 +502,17 @@ func IsAccessListMember(
 			return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_EXPLICIT, nil
 		}
 		// Is user an inherited member through any potential member AccessLists?
-		if member.Spec.MembershipKind == accesslist.MembershipKindList {
-			memberAccessList, err := g.GetAccessList(ctx, member.GetName())
+		if member.IsList() {
+			memberName, err := MemberScopeQualifiedName(member)
+			if err != nil {
+				return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, trace.Wrap(err)
+			}
+			memberAccessList, err := getAccessList(ctx, g, memberName)
 			if err != nil {
 				if trace.IsNotFound(err) {
 					continue
 				}
-				return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, trace.Wrap(err, "getting access list %q", member.GetName())
+				return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, trace.Wrap(err, "getting access list %q", memberName.String())
 			}
 			// Since we already verified that the user is not locked, don't provide lockGetter here
 			membershipType, err := IsAccessListMember(ctx, user, memberAccessList, g, nil, clock)
@@ -692,7 +730,11 @@ func (s *Hierarchy) GetHierarchyForUser(ctx context.Context, accessList *accessl
 }
 
 func (s *Hierarchy) validMembership(ctx context.Context, list *accesslist.AccessList, user types.User) (bool, error) {
-	m, err := s.AccessListsService.GetAccessListMember(ctx, list.GetName(), user.GetName())
+	m, err := getAccessListMember(ctx, s.AccessListsService, accesslistv1.GetAccessListMemberRequest_builder{
+		AccessListScope: list.GetScope(),
+		AccessList:      list.GetName(),
+		MemberName:      user.GetName(),
+	}.Build())
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return false, nil
@@ -817,14 +859,15 @@ func collectAncestors(
 	visited[ScopeQualifiedName(accessList)] = struct{}{}
 
 	isDirectMembershipExpired := func(acl, member NormalizedSQN) (bool, error) {
-		// TODO(nklaassen): support scoped access list members.
-		if acl.Scope != "" || member.Scope != "" {
-			return false, trace.BadParameter("scoped access list members are not yet supported")
-		}
 		if !options.validateUserRequirement {
 			return false, nil
 		}
-		m, err := g.GetAccessListMember(ctx, acl.Name, member.Name)
+		m, err := getAccessListMember(ctx, g, accesslistv1.GetAccessListMemberRequest_builder{
+			AccessListScope: acl.Scope,
+			AccessList:      acl.Name,
+			MemberScope:     member.Scope,
+			MemberName:      member.Name,
+		}.Build())
 		if err != nil {
 			return false, trace.Wrap(err)
 		}

--- a/lib/accesslists/hierarchy.go
+++ b/lib/accesslists/hierarchy.go
@@ -54,6 +54,24 @@ type AccessListMembersLister interface {
 	ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
 }
 
+// TODO(nklaassen): delete this when everything used as an
+// [AccessListAndMembersGetter] implements GetAccessListV2.
+func getAccessList(ctx context.Context, g AccessListAndMembersGetter, accessListName NormalizedSQN) (*accesslist.AccessList, error) {
+	type accessListGetterV2 interface {
+		GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error)
+	}
+	if g, ok := g.(accessListGetterV2); ok {
+		return g.GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+			Scope: accessListName.Scope,
+			Name:  accessListName.Name,
+		}.Build())
+	}
+	if accessListName.Scope != "" {
+		return nil, trace.NotFound("access list %v not found", accessListName)
+	}
+	return g.GetAccessList(ctx, accessListName.Name)
+}
+
 // lockGetter is a service that gets locks.
 type lockGetter interface {
 	// GetLocks is here for compatibility with older Teleport versions.
@@ -76,7 +94,8 @@ func getMembersFor(ctx context.Context, accessListName string, g AccessListMembe
 	}
 	visited[accessListName] = struct{}{}
 
-	members, err := fetchMembers(ctx, accessListName, g)
+	// TODO(nklaassen): support scoped access list members
+	members, err := fetchMembers(ctx, NormalizedSQN{Name: accessListName}, g)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -98,11 +117,16 @@ func getMembersFor(ctx context.Context, accessListName string, g AccessListMembe
 }
 
 // fetchMembers is a simple helper to fetch all top-level AccessListMembers for an AccessList.
-func fetchMembers(ctx context.Context, accessListName string, g AccessListMembersLister) ([]*accesslist.AccessListMember, error) {
+func fetchMembers(ctx context.Context, accessListName NormalizedSQN, g AccessListMembersLister) ([]*accesslist.AccessListMember, error) {
+	if accessListName.Scope != "" {
+		// Scoped access lists currently cannot have any members
+		// TODO(nklaassen): support scoped access list members.
+		return nil, nil
+	}
 	var allMembers []*accesslist.AccessListMember
 	pageToken := ""
 	for {
-		page, nextToken, err := g.ListAccessListMembers(ctx, accessListName, 0, pageToken)
+		page, nextToken, err := g.ListAccessListMembers(ctx, accessListName.Name, 0, pageToken)
 		if err != nil {
 			// If the AccessList doesn't exist yet, should return an empty list of members
 			if trace.IsNotFound(err) {
@@ -120,26 +144,41 @@ func fetchMembers(ctx context.Context, accessListName string, g AccessListMember
 }
 
 // collectOwners is a helper to recursively collect all Owners for an Access List, including inherited Owners.
-func collectOwners(ctx context.Context, accessList *accesslist.AccessList, g AccessListMembersLister, owners map[string]*accesslist.Owner, visited map[string]struct{}) error {
-	if _, ok := visited[accessList.GetName()]; ok {
+func collectOwners(
+	ctx context.Context,
+	accessList *accesslist.AccessList,
+	g AccessListMembersLister,
+	owners map[NormalizedSQN]*accesslist.Owner,
+	visited map[NormalizedSQN]struct{},
+) error {
+	if _, ok := visited[ScopeQualifiedName(accessList)]; ok {
 		return nil
 	}
-	visited[accessList.GetName()] = struct{}{}
+	visited[ScopeQualifiedName(accessList)] = struct{}{}
 
 	for _, owner := range accessList.Spec.Owners {
-		if owner.MembershipKind != accesslist.MembershipKindList {
+		ownerName, err := OwnerScopeQualifiedName(owner)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		if owner.IsMembershipKindUser() {
 			// Collect direct owner users
-			owners[owner.Name] = &owner
+			owners[ownerName] = &owner
 			continue
 		}
 
 		// For owner lists, we need to collect their members as owners
-		ownerMembers, err := collectMembersAsOwners(ctx, owner.Name, g, visited)
+		ownerMembers, err := collectMembersAsOwners(ctx, ownerName, g, visited)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 		for _, ownerMember := range ownerMembers {
-			owners[ownerMember.Name] = ownerMember
+			ownerMemberName, err := OwnerScopeQualifiedName(*ownerMember)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			owners[ownerMemberName] = ownerMember
 		}
 	}
 
@@ -147,14 +186,19 @@ func collectOwners(ctx context.Context, accessList *accesslist.AccessList, g Acc
 }
 
 // collectMembersAsOwners is a helper to collect all nested members of an AccessList and return them cast as Owners.
-func collectMembersAsOwners(ctx context.Context, accessListName string, g AccessListMembersLister, visited map[string]struct{}) ([]*accesslist.Owner, error) {
+func collectMembersAsOwners(ctx context.Context, accessListName NormalizedSQN, g AccessListMembersLister, visited map[NormalizedSQN]struct{}) ([]*accesslist.Owner, error) {
+	// TODO(nklaassen): support scoped access list members.
+	if accessListName.Scope != "" {
+		return nil, nil
+	}
+
 	owners := make([]*accesslist.Owner, 0)
 	if _, ok := visited[accessListName]; ok {
 		return owners, nil
 	}
 	visited[accessListName] = struct{}{}
 
-	listMembers, err := GetMembersFor(ctx, accessListName, g)
+	listMembers, err := GetMembersFor(ctx, accessListName.Name, g)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -176,8 +220,8 @@ func collectMembersAsOwners(ctx context.Context, accessListName string, g Access
 // Returned Owners are not validated for expiration or other requirements – use IsAccessListOwner
 // to validate an Owner's ownership status.
 func GetOwnersFor(ctx context.Context, accessList *accesslist.AccessList, g AccessListMembersLister) ([]*accesslist.Owner, error) {
-	ownersMap := make(map[string]*accesslist.Owner)
-	if err := collectOwners(ctx, accessList, g, ownersMap, make(map[string]struct{})); err != nil {
+	ownersMap := make(map[NormalizedSQN]*accesslist.Owner)
+	if err := collectOwners(ctx, accessList, g, ownersMap, make(map[NormalizedSQN]struct{})); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	owners := make([]*accesslist.Owner, 0, len(ownersMap))
@@ -189,8 +233,8 @@ func GetOwnersFor(ctx context.Context, accessList *accesslist.AccessList, g Acce
 
 func maxDepthDownwards(
 	ctx context.Context,
-	currentListName string,
-	seen map[string]struct{},
+	currentListName NormalizedSQN,
+	seen map[NormalizedSQN]struct{},
 	g AccessListAndMembersGetter,
 ) (int, error) {
 	if _, ok := seen[currentListName]; ok {
@@ -205,17 +249,19 @@ func maxDepthDownwards(
 		return 0, trace.Wrap(err)
 	}
 	for _, member := range listMembers {
-		if member.Spec.MembershipKind == accesslist.MembershipKindList {
-			childListName := member.GetName()
-			depth, err := maxDepthDownwards(ctx, childListName, seen, g)
-			if err != nil {
-				return 0, trace.Wrap(err)
-			}
-			depth += 1 // Edge to the child
-			if depth > maxDepth {
-				maxDepth = depth
-			}
+		if !member.IsList() {
+			continue
 		}
+		childListName, err := MemberScopeQualifiedName(member)
+		if err != nil {
+			return 0, trace.Wrap(err)
+		}
+		depth, err := maxDepthDownwards(ctx, childListName, seen, g)
+		if err != nil {
+			return 0, trace.Wrap(err)
+		}
+		depth += 1 // Edge to the child
+		maxDepth = max(maxDepth, depth)
 	}
 
 	delete(seen, currentListName)
@@ -226,19 +272,23 @@ func maxDepthDownwards(
 func maxDepthUpwards(
 	ctx context.Context,
 	currentList *accesslist.AccessList,
-	seen map[string]struct{},
+	seen map[NormalizedSQN]struct{},
 	g AccessListAndMembersGetter,
 ) (int, error) {
-	if _, ok := seen[currentList.GetName()]; ok {
+	if _, ok := seen[ScopeQualifiedName(currentList)]; ok {
 		return 0, nil
 	}
-	seen[currentList.GetName()] = struct{}{}
+	seen[ScopeQualifiedName(currentList)] = struct{}{}
 
 	maxDepth := 0
 
 	// Traverse MemberOf relationships
-	for _, parentListName := range currentList.Status.MemberOf {
-		parentList, err := g.GetAccessList(ctx, parentListName)
+	allParentLists, err := AllParentLists(currentList)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+	for _, parentListName := range allParentLists {
+		parentList, err := getAccessList(ctx, g, parentListName)
 		if err != nil {
 			return 0, trace.Wrap(err) // Treat missing lists as depth 0
 		}
@@ -247,12 +297,10 @@ func maxDepthUpwards(
 			return 0, trace.Wrap(err)
 		}
 		depth += 1 // Edge to the parent
-		if depth > maxDepth {
-			maxDepth = depth
-		}
+		maxDepth = max(maxDepth, depth)
 	}
 
-	delete(seen, currentList.GetName())
+	delete(seen, ScopeQualifiedName(currentList))
 
 	return maxDepth, nil
 }
@@ -315,8 +363,11 @@ func IsAccessListOwner(
 	var ownershipErr error
 
 	for _, owner := range accessList.Spec.Owners {
-		// Is user an explicit owner?
-		if owner.MembershipKind != accesslist.MembershipKindList && owner.Name == user.GetName() {
+		if owner.IsMembershipKindUser() {
+			// Is user an explicit owner?
+			if owner.Name != user.GetName() {
+				continue
+			}
 			if !UserMeetsRequirements(user, accessList.Spec.OwnershipRequires) {
 				// Avoid non-deterministic behavior in these checks. Rather than returning immediately, continue
 				// through all owners to make sure there isn't a valid match later on.
@@ -325,9 +376,13 @@ func IsAccessListOwner(
 			}
 			return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_EXPLICIT, nil
 		}
-		// Is user an inherited owner through any potential owner AccessLists?
-		if owner.MembershipKind == accesslist.MembershipKindList {
-			ownerAccessList, err := g.GetAccessList(ctx, owner.Name)
+		if owner.IsMembershipKindList() {
+			// Is user an inherited owner through any potential owner AccessLists?
+			ownerName, err := OwnerScopeQualifiedName(owner)
+			if err != nil {
+				return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, trace.Wrap(err)
+			}
+			ownerAccessList, err := getAccessList(ctx, g, ownerName)
 			if err != nil {
 				return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, trace.Wrap(err)
 			}
@@ -390,7 +445,7 @@ func IsAccessListMember(
 		}
 	}
 
-	members, err := fetchMembers(ctx, accessList.GetName(), g)
+	members, err := fetchMembers(ctx, ScopeQualifiedName(accessList), g)
 	if err != nil {
 		return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, trace.Wrap(err, "fetching access list %q members", accessList.GetName())
 	}
@@ -504,6 +559,7 @@ type ancestorOptions struct {
 	validateUserRequirement bool
 	clock                   clockwork.Clock
 	user                    types.User
+	ignoreScoped            bool
 }
 
 func (o *ancestorOptions) validate() error {
@@ -529,12 +585,23 @@ func withUserRequirementsCheck(user types.User, clock clockwork.Clock) ancestorO
 	}
 }
 
+func withIgnoreScoped(ignore bool) ancestorOption {
+	return func(opts *ancestorOptions) {
+		opts.ignoreScoped = ignore
+	}
+}
+
 // HierarchyConfig holds dependencies for building access list hierarchies.
 type HierarchyConfig struct {
 	// AccessListService is used to fetch Access Lists and their members.
 	AccessListsService AccessListAndMembersGetter
 	// Getter is used to fetch Access Lists and their members.
 	Clock clockwork.Clock
+	// IgnoreScoped specifies that the hierarchy should ignore scoped access lists and members.
+	// This should be set during user login state generation, where scoped
+	// access lists should have no effect (scoped access list only affect user
+	// login via materialized scoped role assignments).
+	IgnoreScoped bool
 }
 
 // CheckAndSetDefaults validates the config and sets default values.
@@ -570,6 +637,10 @@ func NewHierarchy(cfg HierarchyConfig) (*Hierarchy, error) {
 // lists where the user satisfies membership or ownership requirements.
 // If the user fails to meet the requirements at any point, that branch is excluded.
 func (s *Hierarchy) GetHierarchyForUser(ctx context.Context, accessList *accesslist.AccessList, user types.User) (memberHierarchy, ownerHierarchy []*accesslist.AccessList, err error) {
+	if s.IgnoreScoped && accessList.Scope != "" {
+		return memberHierarchy, ownerHierarchy, nil
+	}
+
 	if s.validDirectOwner(user, accessList) {
 		// User Is direct owner and meet the ownership requirements
 		// Include access list from the owner hierarchy
@@ -593,7 +664,13 @@ func (s *Hierarchy) GetHierarchyForUser(ctx context.Context, accessList *accessl
 	memberHierarchy = append(memberHierarchy, accessList)
 
 	// Fetch ancestors via MemberOf edges while checking user requirements
-	ancestors, err := getAncestors(ctx, accessList, RelationshipKindMember, s.AccessListsService, withUserRequirementsCheck(user, s.Clock))
+	ancestors, err := getAncestors(
+		ctx,
+		accessList,
+		RelationshipKindMember,
+		s.AccessListsService,
+		withUserRequirementsCheck(user, s.Clock),
+		withIgnoreScoped(s.IgnoreScoped))
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -637,8 +714,12 @@ func (s *Hierarchy) validMembership(ctx context.Context, list *accesslist.Access
 func (s *Hierarchy) expandOwnerOf(ctx context.Context, accessList *accesslist.AccessList, ancestors []*accesslist.AccessList, user types.User) ([]*accesslist.AccessList, error) {
 	var out []*accesslist.AccessList
 	processFn := func(al *accesslist.AccessList) error {
-		for _, name := range al.Status.OwnerOf {
-			ownerList, err := s.AccessListsService.GetAccessList(ctx, name)
+		ownedListNames, err := ownedListsForTraversal(al, s.IgnoreScoped)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		for _, name := range ownedListNames {
+			ownerList, err := getAccessList(ctx, s.AccessListsService, name)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -658,6 +739,28 @@ func (s *Hierarchy) expandOwnerOf(ctx context.Context, accessList *accesslist.Ac
 		}
 	}
 	return out, nil
+}
+
+func ownedListsForTraversal(list *accesslist.AccessList, ignoreScoped bool) ([]NormalizedSQN, error) {
+	if !ignoreScoped {
+		return AllOwnedLists(list)
+	}
+	ownedListNames := make([]NormalizedSQN, 0, len(list.Status.OwnerOf))
+	for _, ownedListName := range list.Status.OwnerOf {
+		ownedListNames = append(ownedListNames, NormalizedSQN{Name: ownedListName})
+	}
+	return ownedListNames, nil
+}
+
+func parentListsForTraversal(list *accesslist.AccessList, ignoreScoped bool) ([]NormalizedSQN, error) {
+	if !ignoreScoped {
+		return AllParentLists(list)
+	}
+	parentListNames := make([]NormalizedSQN, 0, len(list.Status.MemberOf))
+	for _, parentListName := range list.Status.MemberOf {
+		parentListNames = append(parentListNames, NormalizedSQN{Name: parentListName})
+	}
+	return parentListNames, nil
 }
 
 func (s *Hierarchy) validDirectOwner(user types.User, acl *accesslist.AccessList) bool {
@@ -684,15 +787,23 @@ func GetAncestorsFor(ctx context.Context, accessList *accesslist.AccessList, kin
 }
 
 func getAncestors(ctx context.Context, accessList *accesslist.AccessList, kind RelationshipKind, g AccessListAndMembersGetter, opts ...ancestorOption) ([]*accesslist.AccessList, trace.Error) {
-	ancestorsMap := make(map[string]*accesslist.AccessList)
-	if err := collectAncestors(ctx, accessList, kind, g, make(map[string]struct{}), ancestorsMap, opts...); err != nil {
+	ancestorsMap := make(map[NormalizedSQN]*accesslist.AccessList)
+	if err := collectAncestors(ctx, accessList, kind, g, make(map[NormalizedSQN]struct{}), ancestorsMap, opts...); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	ancestors := slices.Collect(maps.Values(ancestorsMap))
 	return ancestors, nil
 }
 
-func collectAncestors(ctx context.Context, accessList *accesslist.AccessList, kind RelationshipKind, g AccessListAndMembersGetter, visited map[string]struct{}, ancestors map[string]*accesslist.AccessList, opts ...ancestorOption) error {
+func collectAncestors(
+	ctx context.Context,
+	accessList *accesslist.AccessList,
+	kind RelationshipKind,
+	g AccessListAndMembersGetter,
+	visited map[NormalizedSQN]struct{},
+	ancestors map[NormalizedSQN]*accesslist.AccessList,
+	opts ...ancestorOption,
+) error {
 	options := &ancestorOptions{}
 	for _, opt := range opts {
 		opt(options)
@@ -700,16 +811,20 @@ func collectAncestors(ctx context.Context, accessList *accesslist.AccessList, ki
 	if err := options.validate(); err != nil {
 		return trace.Wrap(err)
 	}
-	if _, ok := visited[accessList.GetName()]; ok {
+	if _, ok := visited[ScopeQualifiedName(accessList)]; ok {
 		return nil
 	}
-	visited[accessList.GetName()] = struct{}{}
+	visited[ScopeQualifiedName(accessList)] = struct{}{}
 
-	isDirectMembershipExpired := func(acl, member string) (bool, error) {
+	isDirectMembershipExpired := func(acl, member NormalizedSQN) (bool, error) {
+		// TODO(nklaassen): support scoped access list members.
+		if acl.Scope != "" || member.Scope != "" {
+			return false, trace.BadParameter("scoped access list members are not yet supported")
+		}
 		if !options.validateUserRequirement {
 			return false, nil
 		}
-		m, err := g.GetAccessListMember(ctx, acl, member)
+		m, err := g.GetAccessListMember(ctx, acl.Name, member.Name)
 		if err != nil {
 			return false, trace.Wrap(err)
 		}
@@ -725,8 +840,12 @@ func collectAncestors(ctx context.Context, accessList *accesslist.AccessList, ki
 
 	if kind == RelationshipKindOwner {
 		// Add parents where this list is an owner to ancestors
-		for _, ownerParent := range accessList.Status.OwnerOf {
-			ownerParentAcl, err := g.GetAccessList(ctx, ownerParent)
+		ownedListNames, err := ownedListsForTraversal(accessList, options.ignoreScoped)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		for _, ownerParent := range ownedListNames {
+			ownerParentAcl, err := getAccessList(ctx, g, ownerParent)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -736,12 +855,16 @@ func collectAncestors(ctx context.Context, accessList *accesslist.AccessList, ki
 			ancestors[ownerParent] = ownerParentAcl
 		}
 	}
-	for _, memberParent := range accessList.Status.MemberOf {
-		memberParentAcl, err := g.GetAccessList(ctx, memberParent)
+	parentListNames, err := parentListsForTraversal(accessList, options.ignoreScoped)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	for _, memberParent := range parentListNames {
+		memberParentAcl, err := getAccessList(ctx, g, memberParent)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		expired, err := isDirectMembershipExpired(memberParent, accessList.GetName())
+		expired, err := isDirectMembershipExpired(memberParent, ScopeQualifiedName(accessList))
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/accesslists/hierarchy_test.go
+++ b/lib/accesslists/hierarchy_test.go
@@ -37,16 +37,18 @@ import (
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/trait"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 )
 
 // Mock implementation of AccessListAndMembersGetter.
 type mockAccessListAndMembersGetter struct {
-	accessLists map[string]*accesslist.AccessList
-	members     map[string][]*accesslist.AccessListMember
+	accessLists map[NormalizedSQN]*accesslist.AccessList
+	members     map[NormalizedSQN][]*accesslist.AccessListMember
 }
 
 func (m *mockAccessListAndMembersGetter) GetAccessListMember(ctx context.Context, accessListName, memberName string) (*accesslist.AccessListMember, error) {
-	member, exists := m.members[accessListName]
+	// TODO(nklaassen): support scoped access list members.
+	member, exists := m.members[NormalizedSQN{Name: accessListName}]
 	if !exists {
 		return nil, trace.NotFound("access list %v member %v not found", accessListName, memberName)
 	}
@@ -59,6 +61,16 @@ func (m *mockAccessListAndMembersGetter) GetAccessListMember(ctx context.Context
 }
 
 func (m *mockAccessListAndMembersGetter) GetAccessList(ctx context.Context, accessListName string) (*accesslist.AccessList, error) {
+	return m.GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Name: accessListName,
+	}.Build())
+}
+
+func (m *mockAccessListAndMembersGetter) GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error) {
+	accessListName := NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetScope(),
+		Name:  req.GetName(),
+	})
 	accessList, exists := m.accessLists[accessListName]
 	if !exists {
 		return nil, trace.NotFound("access list %v not found", accessListName)
@@ -67,11 +79,29 @@ func (m *mockAccessListAndMembersGetter) GetAccessList(ctx context.Context, acce
 }
 
 func (m *mockAccessListAndMembersGetter) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
-	members, exists := m.members[accessListName]
+	// TODO(nklaassen): support scoped access list members.
+	members, exists := m.members[NormalizedSQN{Name: accessListName}]
 	if !exists {
 		return nil, "", nil
 	}
 	return members, "", nil
+}
+
+func mockAccessLists(accessLists ...*accesslist.AccessList) map[NormalizedSQN]*accesslist.AccessList {
+	out := make(map[NormalizedSQN]*accesslist.AccessList, len(accessLists))
+	for _, accessList := range accessLists {
+		out[ScopeQualifiedName(accessList)] = accessList
+	}
+	return out
+}
+
+func mockAccessListMembers(members ...*accesslist.AccessListMember) map[NormalizedSQN][]*accesslist.AccessListMember {
+	out := make(map[NormalizedSQN][]*accesslist.AccessListMember)
+	for _, member := range members {
+		listName := NormalizedSQN{Name: member.Spec.AccessList}
+		out[listName] = append(out[listName], member)
+	}
+	return out
 }
 
 type mockLocksGetter struct {
@@ -166,18 +196,8 @@ func TestAccessListHierarchyIsOwner(t *testing.T) {
 	acl1.Status.OwnerOf = append(acl1.Status.OwnerOf, acl4.GetName())
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members: map[string][]*accesslist.AccessListMember{
-			acl1.GetName(): {acl1m1, acl1m2},
-			acl2.GetName(): {acl2m1},
-			acl3.GetName(): {},
-			acl4.GetName(): {acl4m1},
-		},
-		accessLists: map[string]*accesslist.AccessList{
-			acl1.GetName(): acl1,
-			acl2.GetName(): acl2,
-			acl3.GetName(): acl3,
-			acl4.GetName(): acl4,
-		},
+		members:     mockAccessListMembers(acl1m1, acl1m2, acl2m1, acl4m1),
+		accessLists: mockAccessLists(acl1, acl2, acl3, acl4),
 	}
 
 	// User which does not meet acl1's Membership requirements.
@@ -239,12 +259,8 @@ func TestAccessListIsMember(t *testing.T) {
 		targets: map[string][]types.Lock{},
 	}
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members: map[string][]*accesslist.AccessListMember{
-			acl1.GetName(): {acl1m1},
-		},
-		accessLists: map[string]*accesslist.AccessList{
-			acl1.GetName(): acl1,
-		},
+		members:     mockAccessListMembers(acl1m1),
+		accessLists: mockAccessLists(acl1),
 	}
 
 	stubMember1, err := types.NewUser(member1)
@@ -282,8 +298,8 @@ func TestAccessListIsMember_RequirementsAndExpiry(t *testing.T) {
 	// single user member
 	member := newAccessListMember(t, "acl", "u", accesslist.MembershipKindUser, clock)
 	aclGetter := &mockAccessListAndMembersGetter{
-		accessLists: map[string]*accesslist.AccessList{"acl": acl},
-		members:     map[string][]*accesslist.AccessListMember{"acl": {member}},
+		accessLists: mockAccessLists(acl),
+		members:     mockAccessListMembers(member),
 	}
 
 	u, _ := types.NewUser("u")
@@ -340,16 +356,8 @@ func TestAccessListIsMember_NestedRequirements(t *testing.T) {
 		middleInRoot := newAccessListMember(t, rootList.GetName(), middleList.GetName(), accesslist.MembershipKindList, clock)
 
 		aclGetter := &mockAccessListAndMembersGetter{
-			accessLists: map[string]*accesslist.AccessList{
-				"root":   rootList,
-				"middle": middleList,
-				"leaf":   leafList,
-			},
-			members: map[string][]*accesslist.AccessListMember{
-				"root":   {middleInRoot},
-				"middle": {leafInMiddle},
-				"leaf":   {userMember},
-			},
+			accessLists: mockAccessLists(rootList, middleList, leafList),
+			members:     mockAccessListMembers(middleInRoot, leafInMiddle, userMember),
 		}
 
 		user, err := types.NewUser(userName)
@@ -399,16 +407,8 @@ func TestAccessListIsMember_NestedRequirements(t *testing.T) {
 		middleInRoot := newAccessListMember(t, rootList.GetName(), middleList.GetName(), accesslist.MembershipKindList, clock)
 
 		aclGetter := &mockAccessListAndMembersGetter{
-			accessLists: map[string]*accesslist.AccessList{
-				"root":   rootList,
-				"middle": middleList,
-				"leaf":   leafList,
-			},
-			members: map[string][]*accesslist.AccessListMember{
-				"root":   {middleInRoot},
-				"middle": {leafInMiddle},
-				"leaf":   {userMember},
-			},
+			accessLists: mockAccessLists(rootList, middleList, leafList),
+			members:     mockAccessListMembers(middleInRoot, leafInMiddle, userMember),
 		}
 
 		user, err := types.NewUser(userName)
@@ -440,16 +440,8 @@ func TestAccessListIsMember_NestedRequirements(t *testing.T) {
 		thirdArc := newAccessListMember(t, thirdList.GetName(), firstList.GetName(), accesslist.MembershipKindList, clock)
 
 		aclGetter := &mockAccessListAndMembersGetter{
-			accessLists: map[string]*accesslist.AccessList{
-				firstList.GetName():  firstList,
-				secondList.GetName(): secondList,
-				thirdList.GetName():  thirdList,
-			},
-			members: map[string][]*accesslist.AccessListMember{
-				firstList.GetName():  {firstArc},
-				secondList.GetName(): {secondArc},
-				thirdList.GetName():  {thirdArc},
-			},
+			accessLists: mockAccessLists(firstList, secondList, thirdList),
+			members:     mockAccessListMembers(firstArc, secondArc, thirdArc),
 		}
 
 		user, err := types.NewUser("alice")
@@ -490,16 +482,8 @@ func TestAccessListIsMember_NestedRequirements(t *testing.T) {
 		userMembership := newAccessListMember(t, thirdList.GetName(), user.GetName(), accesslist.MembershipKindUser, clock)
 
 		aclGetter := &mockAccessListAndMembersGetter{
-			accessLists: map[string]*accesslist.AccessList{
-				firstList.GetName():  firstList,
-				secondList.GetName(): secondList,
-				thirdList.GetName():  thirdList,
-			},
-			members: map[string][]*accesslist.AccessListMember{
-				firstList.GetName():  {firstArc},
-				secondList.GetName(): {secondArc},
-				thirdList.GetName():  {thirdArc, userMembership},
-			},
+			accessLists: mockAccessLists(firstList, secondList, thirdList),
+			members:     mockAccessListMembers(firstArc, secondArc, thirdArc, userMembership),
 		}
 
 		typ, err := IsAccessListMember(ctx, user, firstList, aclGetter, locks, clock)
@@ -565,10 +549,7 @@ func TestGetOwners(t *testing.T) {
 	acl3m1 := newAccessListMember(t, acl3.GetName(), "memberC", accesslist.MembershipKindUser, clock)
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members: map[string][]*accesslist.AccessListMember{
-			acl2.GetName(): {acl2m1},
-			acl3.GetName(): {acl3m1},
-		},
+		members: mockAccessListMembers(acl2m1, acl3m1),
 	}
 
 	// Test GetOwners for acl1
@@ -673,11 +654,7 @@ func TestGetInheritedGrants(t *testing.T) {
 	acl1.Status.OwnerOf = append(acl1.Status.OwnerOf, aclroot.GetName())
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		accessLists: map[string]*accesslist.AccessList{
-			aclroot.GetName(): aclroot,
-			acl1.GetName():    acl1,
-			acl2.GetName():    acl2,
-		},
+		accessLists: mockAccessLists(aclroot, acl1, acl2),
 	}
 
 	// acl1 is an Owner of aclroot, and acl2 is a Member of acl1.
@@ -872,7 +849,7 @@ func TestGetInheritedRequires(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			listsByID := make(map[string]*accesslist.AccessList, len(tc.lists))
+			listsByID := make(map[NormalizedSQN]*accesslist.AccessList, len(tc.lists))
 			listsByName := make(map[string]*accesslist.AccessList, len(tc.lists))
 			for _, ls := range tc.lists {
 				acl, err := accesslist.NewAccessList(
@@ -886,17 +863,18 @@ func TestGetInheritedRequires(t *testing.T) {
 					},
 				)
 				require.NoError(t, err)
-				listsByID[acl.GetName()] = acl
+				listsByID[ScopeQualifiedName(acl)] = acl
 				listsByName[ls.name] = acl
 			}
 
-			members := make(map[string][]*accesslist.AccessListMember)
+			members := make(map[NormalizedSQN][]*accesslist.AccessListMember)
 			for _, ls := range tc.lists {
 				child := listsByName[ls.name]
 				for _, parentName := range ls.memberOf {
 					parent := listsByName[parentName]
 					child.Status.MemberOf = append(child.Status.MemberOf, parent.GetName())
-					members[parent.GetName()] = append(members[parent.GetName()], newAccessListMember(t, parent.GetName(), child.GetName(), accesslist.MembershipKindList, clock))
+					members[ScopeQualifiedName(parent)] = append(members[ScopeQualifiedName(parent)],
+						newAccessListMember(t, parent.GetName(), child.GetName(), accesslist.MembershipKindList, clock))
 				}
 			}
 
@@ -928,17 +906,15 @@ func TestGetMembersFor_FlattensAndStopsOnCycles(t *testing.T) {
 	c := newAccessList(t, "C", clock)
 
 	getter := &mockAccessListAndMembersGetter{
-		accessLists: map[string]*accesslist.AccessList{
-			"A": a, "B": b, "C": c,
-		},
-		members: map[string][]*accesslist.AccessListMember{
-			"A": {newAccessListMember(t, "A", "userA", accesslist.MembershipKindUser, clock),
-				newAccessListMember(t, "A", "B", accesslist.MembershipKindList, clock)},
-			"B": {newAccessListMember(t, "B", "userB", accesslist.MembershipKindUser, clock),
-				newAccessListMember(t, "B", "C", accesslist.MembershipKindList, clock)},
-			"C": {newAccessListMember(t, "C", "userC", accesslist.MembershipKindUser, clock),
-				newAccessListMember(t, "C", "B", accesslist.MembershipKindList, clock)}, // cycle back
-		},
+		accessLists: mockAccessLists(a, b, c),
+		members: mockAccessListMembers(
+			newAccessListMember(t, "A", "userA", accesslist.MembershipKindUser, clock),
+			newAccessListMember(t, "A", "B", accesslist.MembershipKindList, clock),
+			newAccessListMember(t, "B", "userB", accesslist.MembershipKindUser, clock),
+			newAccessListMember(t, "B", "C", accesslist.MembershipKindList, clock),
+			newAccessListMember(t, "C", "userC", accesslist.MembershipKindUser, clock),
+			newAccessListMember(t, "C", "B", accesslist.MembershipKindList, clock), // cycle back
+		),
 	}
 
 	members, err := GetMembersFor(ctx, "A", getter)

--- a/lib/accesslists/hierarchy_test.go
+++ b/lib/accesslists/hierarchy_test.go
@@ -23,6 +23,7 @@ import (
 	"iter"
 	"slices"
 	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -47,17 +48,35 @@ type mockAccessListAndMembersGetter struct {
 }
 
 func (m *mockAccessListAndMembersGetter) GetAccessListMember(ctx context.Context, accessListName, memberName string) (*accesslist.AccessListMember, error) {
-	// TODO(nklaassen): support scoped access list members.
-	member, exists := m.members[NormalizedSQN{Name: accessListName}]
+	return m.GetAccessListMemberV2(ctx, accesslistv1.GetAccessListMemberRequest_builder{
+		AccessList: accessListName,
+		MemberName: memberName,
+	}.Build())
+}
+
+func (m *mockAccessListAndMembersGetter) GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error) {
+	accessListName := NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	memberName := NormalizedSQN(scopes.QualifiedName{
+		Scope: req.GetMemberScope(),
+		Name:  req.GetMemberName(),
+	})
+	members, exists := m.members[accessListName]
 	if !exists {
-		return nil, trace.NotFound("access list %v member %v not found", accessListName, memberName)
+		return nil, trace.NotFound("access list %s member %s not found", accessListName.String(), memberName.String())
 	}
-	for _, m := range member {
-		if m.GetName() == memberName {
+	for _, m := range members {
+		memberSQN, err := MemberScopeQualifiedName(m)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if memberSQN == memberName {
 			return m, nil
 		}
 	}
-	return nil, trace.NotFound("access list %v member %v not found", accessListName, memberName)
+	return nil, trace.NotFound("access list %s member %s not found", accessListName.String(), memberName.String())
 }
 
 func (m *mockAccessListAndMembersGetter) GetAccessList(ctx context.Context, accessListName string) (*accesslist.AccessList, error) {
@@ -79,8 +98,19 @@ func (m *mockAccessListAndMembersGetter) GetAccessListV2(ctx context.Context, re
 }
 
 func (m *mockAccessListAndMembersGetter) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
-	// TODO(nklaassen): support scoped access list members.
-	members, exists := m.members[NormalizedSQN{Name: accessListName}]
+	return m.ListAccessListMembersV2(ctx, accesslistv1.ListAccessListMembersRequest_builder{
+		AccessList: accessListName,
+		PageSize:   int32(pageSize),
+		PageToken:  pageToken,
+	}.Build())
+}
+
+func (m *mockAccessListAndMembersGetter) ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) ([]*accesslist.AccessListMember, string, error) {
+	accessListName := NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	members, exists := m.members[accessListName]
 	if !exists {
 		return nil, "", nil
 	}
@@ -95,10 +125,11 @@ func mockAccessLists(accessLists ...*accesslist.AccessList) map[NormalizedSQN]*a
 	return out
 }
 
-func mockAccessListMembers(members ...*accesslist.AccessListMember) map[NormalizedSQN][]*accesslist.AccessListMember {
+func mockAccessListMembers(t testing.TB, members ...*accesslist.AccessListMember) map[NormalizedSQN][]*accesslist.AccessListMember {
 	out := make(map[NormalizedSQN][]*accesslist.AccessListMember)
 	for _, member := range members {
-		listName := NormalizedSQN{Name: member.Spec.AccessList}
+		listName, err := ParentListOf(member)
+		require.NoError(t, err)
 		out[listName] = append(out[listName], member)
 	}
 	return out
@@ -196,7 +227,7 @@ func TestAccessListHierarchyIsOwner(t *testing.T) {
 	acl1.Status.OwnerOf = append(acl1.Status.OwnerOf, acl4.GetName())
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members:     mockAccessListMembers(acl1m1, acl1m2, acl2m1, acl4m1),
+		members:     mockAccessListMembers(t, acl1m1, acl1m2, acl2m1, acl4m1),
 		accessLists: mockAccessLists(acl1, acl2, acl3, acl4),
 	}
 
@@ -268,7 +299,7 @@ func TestIsAccessListOwnerScopedNameCollision(t *testing.T) {
 
 	unscopedOwnerMember := newAccessListMember(t, unscopedOwnerList.GetName(), member1, accesslist.MembershipKindUser, clock)
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members:     mockAccessListMembers(unscopedOwnerMember),
+		members:     mockAccessListMembers(t, unscopedOwnerMember),
 		accessLists: mockAccessLists(unscopedOwnerList, scopedOwnerList, targetList),
 	}
 
@@ -300,6 +331,163 @@ func TestIsAccessListOwnerScopedNameCollision(t *testing.T) {
 	require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED, assignmentType)
 }
 
+// TestMembershipScopedNameCollision asserts that GetHierarchyForUser and
+// IsAccessListMember keep direct memberships separate for scoped and unscoped
+// access lists with the same unqualified name.
+func TestMembershipScopedNameCollision(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	ctx := context.Background()
+
+	unscopedList := newAccessList(t, "team", clock)
+	scopedList := newAccessList(t, "team", clock)
+	scopedList.Scope = "/eng"
+	parentList := newAccessList(t, "parent", clock)
+	parentList.Scope = "/eng/test"
+
+	scopedListName := ScopeQualifiedName(scopedList)
+	parentListName := ScopeQualifiedName(parentList)
+
+	unscopedList.Status.ScopedMemberOf = []string{parentListName.String()}
+	scopedList.Status.ScopedMemberOf = []string{parentListName.String()}
+
+	unscopedUserMember := newAccessListMember(t, unscopedList.GetName(), member1, accesslist.MembershipKindUser, clock)
+	scopedUserMember, err := accesslist.NewAccessListMemberWithScope(
+		header.Metadata{Name: member2},
+		accesslist.AccessListMemberSpec{
+			AccessList:     scopedListName.String(),
+			Name:           member2,
+			Joined:         clock.Now().UTC(),
+			Expires:        clock.Now().UTC().Add(24 * time.Hour),
+			Reason:         "because",
+			AddedBy:        "tester",
+			MembershipKind: accesslist.MembershipKindUser,
+		},
+		scopedList.GetScope(),
+	)
+	require.NoError(t, err)
+	unscopedListMember, err := accesslist.NewAccessListMemberWithScope(
+		header.Metadata{Name: unscopedList.GetName()},
+		accesslist.AccessListMemberSpec{
+			AccessList:     parentListName.String(),
+			Name:           unscopedList.GetName(),
+			Joined:         clock.Now().UTC(),
+			Expires:        clock.Now().UTC().Add(24 * time.Hour),
+			Reason:         "because",
+			AddedBy:        "tester",
+			MembershipKind: accesslist.MembershipKindList,
+		},
+		parentList.GetScope(),
+	)
+	require.NoError(t, err)
+	scopedListMember, err := accesslist.NewAccessListMemberWithScope(
+		header.Metadata{Name: scopedListName.String()},
+		accesslist.AccessListMemberSpec{
+			AccessList:     parentListName.String(),
+			Name:           scopedListName.String(),
+			Joined:         clock.Now().UTC(),
+			Expires:        clock.Now().UTC().Add(24 * time.Hour),
+			Reason:         "because",
+			AddedBy:        "tester",
+			MembershipKind: accesslist.MembershipKindScopedList,
+		},
+		parentList.GetScope(),
+	)
+	require.NoError(t, err)
+
+	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
+		members:     mockAccessListMembers(t, unscopedUserMember, scopedUserMember, unscopedListMember, scopedListMember),
+		accessLists: mockAccessLists(unscopedList, scopedList, parentList),
+	}
+
+	unscopedUser, err := types.NewUser(member1)
+	require.NoError(t, err)
+	unscopedUser.SetTraits(map[string][]string{
+		"mtrait1": {"mvalue1", "mvalue2"},
+		"mtrait2": {"mvalue3", "mvalue4"},
+	})
+	unscopedUser.SetRoles([]string{"mrole1", "mrole2"})
+
+	scopedUser, err := types.NewUser(member2)
+	require.NoError(t, err)
+	scopedUser.SetTraits(map[string][]string{
+		"mtrait1": {"mvalue1", "mvalue2"},
+		"mtrait2": {"mvalue3", "mvalue4"},
+	})
+	scopedUser.SetRoles([]string{"mrole1", "mrole2"})
+
+	locksGetter := &mockLocksGetter{
+		targets: map[string][]types.Lock{},
+	}
+
+	t.Run("GetHierarchyForUser", func(t *testing.T) {
+		hierarchy, err := NewHierarchy(HierarchyConfig{
+			AccessListsService: accessListAndMembersGetter,
+			Clock:              clock,
+		})
+		require.NoError(t, err)
+
+		// GetHierarchyForUser must not consider a user to be a member of the scoped
+		// access list if they are actually a member of the unscoped access list with
+		// the same unqualified name.
+		memberOf, ownerOf, err := hierarchy.GetHierarchyForUser(ctx, scopedList, unscopedUser)
+		require.NoError(t, err)
+		require.Empty(t, memberOf)
+		require.Empty(t, ownerOf)
+
+		// Sanity check the user is legitimately a member of the unscoped access list.
+		memberOf, ownerOf, err = hierarchy.GetHierarchyForUser(ctx, unscopedList, unscopedUser)
+		require.NoError(t, err, trace.DebugReport(err))
+		require.Equal(t, []*accesslist.AccessList{unscopedList, parentList}, memberOf)
+		require.Empty(t, ownerOf)
+
+		// GetHierarchyForUser must not consider a user to be a member of the unscoped
+		// access list if they are actually a member of the scoped access list with
+		// the same unqualified name.
+		memberOf, ownerOf, err = hierarchy.GetHierarchyForUser(ctx, unscopedList, scopedUser)
+		require.NoError(t, err)
+		require.Empty(t, memberOf)
+		require.Empty(t, ownerOf)
+
+		// Sanity check the user is legitimately a member of the scoped access list.
+		memberOf, ownerOf, err = hierarchy.GetHierarchyForUser(ctx, scopedList, scopedUser)
+		require.NoError(t, err)
+		require.Equal(t, []*accesslist.AccessList{scopedList, parentList}, memberOf)
+		require.Empty(t, ownerOf)
+	})
+
+	t.Run("IsAccessListMember", func(t *testing.T) {
+		// IsAccessListMember must not consider a user to be a member of the scoped
+		// access list if they are actually a member of the unscoped access list with
+		// the same unqualified name.
+		_, err := IsAccessListMember(ctx, unscopedUser, scopedList, accessListAndMembersGetter, locksGetter, clock)
+		require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+
+		// Sanity check the user is legitimately a member of the unscoped access list.
+		assignmentType, err := IsAccessListMember(ctx, unscopedUser, unscopedList, accessListAndMembersGetter, locksGetter, clock)
+		require.NoError(t, err)
+		require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_EXPLICIT, assignmentType)
+
+		// GetHierarchyForUser must not consider a user to be a member of the unscoped
+		// access list if they are actually a member of the scoped access list with
+		// the same unqualified name.
+		_, err = IsAccessListMember(ctx, scopedUser, unscopedList, accessListAndMembersGetter, locksGetter, clock)
+		require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+
+		// Sanity check the user is legitimately a member of the scoped access list.
+		assignmentType, err = IsAccessListMember(ctx, scopedUser, scopedList, accessListAndMembersGetter, locksGetter, clock)
+		require.NoError(t, err)
+		require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_EXPLICIT, assignmentType)
+
+		// IsAccessListMember should consider both users to be an inherited member of the common parent list.
+		assignmentType, err = IsAccessListMember(ctx, unscopedUser, parentList, accessListAndMembersGetter, locksGetter, clock)
+		require.NoError(t, err)
+		require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED, assignmentType)
+		assignmentType, err = IsAccessListMember(ctx, scopedUser, parentList, accessListAndMembersGetter, locksGetter, clock)
+		require.NoError(t, err)
+		require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED, assignmentType)
+	})
+}
+
 func TestAccessListIsMember(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	ctx := context.Background()
@@ -311,7 +499,7 @@ func TestAccessListIsMember(t *testing.T) {
 		targets: map[string][]types.Lock{},
 	}
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members:     mockAccessListMembers(acl1m1),
+		members:     mockAccessListMembers(t, acl1m1),
 		accessLists: mockAccessLists(acl1),
 	}
 
@@ -351,7 +539,7 @@ func TestAccessListIsMember_RequirementsAndExpiry(t *testing.T) {
 	member := newAccessListMember(t, "acl", "u", accesslist.MembershipKindUser, clock)
 	aclGetter := &mockAccessListAndMembersGetter{
 		accessLists: mockAccessLists(acl),
-		members:     mockAccessListMembers(member),
+		members:     mockAccessListMembers(t, member),
 	}
 
 	u, _ := types.NewUser("u")
@@ -409,7 +597,7 @@ func TestAccessListIsMember_NestedRequirements(t *testing.T) {
 
 		aclGetter := &mockAccessListAndMembersGetter{
 			accessLists: mockAccessLists(rootList, middleList, leafList),
-			members:     mockAccessListMembers(middleInRoot, leafInMiddle, userMember),
+			members:     mockAccessListMembers(t, middleInRoot, leafInMiddle, userMember),
 		}
 
 		user, err := types.NewUser(userName)
@@ -460,7 +648,7 @@ func TestAccessListIsMember_NestedRequirements(t *testing.T) {
 
 		aclGetter := &mockAccessListAndMembersGetter{
 			accessLists: mockAccessLists(rootList, middleList, leafList),
-			members:     mockAccessListMembers(middleInRoot, leafInMiddle, userMember),
+			members:     mockAccessListMembers(t, middleInRoot, leafInMiddle, userMember),
 		}
 
 		user, err := types.NewUser(userName)
@@ -493,7 +681,7 @@ func TestAccessListIsMember_NestedRequirements(t *testing.T) {
 
 		aclGetter := &mockAccessListAndMembersGetter{
 			accessLists: mockAccessLists(firstList, secondList, thirdList),
-			members:     mockAccessListMembers(firstArc, secondArc, thirdArc),
+			members:     mockAccessListMembers(t, firstArc, secondArc, thirdArc),
 		}
 
 		user, err := types.NewUser("alice")
@@ -535,7 +723,7 @@ func TestAccessListIsMember_NestedRequirements(t *testing.T) {
 
 		aclGetter := &mockAccessListAndMembersGetter{
 			accessLists: mockAccessLists(firstList, secondList, thirdList),
-			members:     mockAccessListMembers(firstArc, secondArc, thirdArc, userMembership),
+			members:     mockAccessListMembers(t, firstArc, secondArc, thirdArc, userMembership),
 		}
 
 		typ, err := IsAccessListMember(ctx, user, firstList, aclGetter, locks, clock)
@@ -601,7 +789,7 @@ func TestGetOwners(t *testing.T) {
 	acl3m1 := newAccessListMember(t, acl3.GetName(), "memberC", accesslist.MembershipKindUser, clock)
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members: mockAccessListMembers(acl2m1, acl3m1),
+		members: mockAccessListMembers(t, acl2m1, acl3m1),
 	}
 
 	// Test GetOwners for acl1
@@ -959,7 +1147,7 @@ func TestGetMembersFor_FlattensAndStopsOnCycles(t *testing.T) {
 
 	getter := &mockAccessListAndMembersGetter{
 		accessLists: mockAccessLists(a, b, c),
-		members: mockAccessListMembers(
+		members: mockAccessListMembers(t,
 			newAccessListMember(t, "A", "userA", accesslist.MembershipKindUser, clock),
 			newAccessListMember(t, "A", "B", accesslist.MembershipKindList, clock),
 			newAccessListMember(t, "B", "userB", accesslist.MembershipKindUser, clock),
@@ -969,7 +1157,7 @@ func TestGetMembersFor_FlattensAndStopsOnCycles(t *testing.T) {
 		),
 	}
 
-	members, err := GetMembersFor(ctx, "A", getter)
+	members, err := GetMembersForV2(ctx, ScopeQualifiedName(a), getter)
 	require.NoError(t, err)
 
 	names := make([]string, 0, len(members))
@@ -1046,4 +1234,226 @@ func newAccessListMember(t *testing.T, accessListName, memberName string, member
 		})
 	require.NoError(t, err)
 	return member
+}
+
+func generateAccessList(name string) *accesslist.AccessList {
+	return &accesslist.AccessList{
+		ResourceHeader: header.ResourceHeader{
+			Metadata: header.Metadata{
+				Name: name,
+			},
+		},
+	}
+}
+
+func generateNestedALs(level, directMembers int, rootListName, userName string) (map[NormalizedSQN]*accesslist.AccessList, map[NormalizedSQN][]*accesslist.AccessListMember) {
+	accesslists := []*accesslist.AccessList{generateAccessList(rootListName)}
+	members := make(map[NormalizedSQN][]*accesslist.AccessListMember)
+
+	for i := range level - 1 {
+		parentName := accesslists[i].GetName()
+		name := "nested-al-" + strconv.Itoa(i)
+		accesslists = append(accesslists, generateAccessList(name))
+		listMembers := generateUserMembers(directMembers/2, name)
+		listMembers = append(listMembers, &accesslist.AccessListMember{
+			ResourceHeader: header.ResourceHeader{
+				Metadata: header.Metadata{
+					Name: name,
+				},
+			},
+			Spec: accesslist.AccessListMemberSpec{
+				AccessList:     parentName,
+				Name:           name,
+				MembershipKind: accesslist.MembershipKindList,
+			},
+		})
+		listMembers = append(listMembers, generateUserMembers(directMembers/2+directMembers%2, name)...)
+
+		listMembers = append(listMembers, &accesslist.AccessListMember{
+			ResourceHeader: header.ResourceHeader{
+				Metadata: header.Metadata{
+					Name: userName,
+				},
+			},
+			Spec: accesslist.AccessListMemberSpec{
+				AccessList:     parentName,
+				Name:           userName,
+				MembershipKind: accesslist.MembershipKindUser,
+			},
+		})
+
+		members[NormalizedSQN{Name: parentName}] = listMembers
+	}
+
+	alMap := make(map[NormalizedSQN]*accesslist.AccessList)
+	for _, al := range accesslists {
+		alMap[ScopeQualifiedName(al)] = al
+	}
+	return alMap, members
+}
+
+func generateUserMembers(count int, alName string) []*accesslist.AccessListMember {
+	var members []*accesslist.AccessListMember
+	for i := range count {
+		memberName := "member-" + strconv.Itoa(i)
+		members = append(members, &accesslist.AccessListMember{
+			ResourceHeader: header.ResourceHeader{
+				Metadata: header.Metadata{
+					Name: memberName,
+				},
+			},
+			Spec: accesslist.AccessListMemberSpec{
+				AccessList:     alName,
+				Name:           memberName,
+				MembershipKind: accesslist.MembershipKindUser,
+			},
+		})
+	}
+	return members
+}
+
+func BenchmarkIsAccessListMember(b *testing.B) {
+	const mainAccessListName = "main-al"
+	const testUserName = "test-user"
+
+	lockGetter := &mockLocksGetter{}
+	clock := clockwork.NewFakeClock()
+
+	b.Run("no accessPaths", func(b *testing.B) {
+		accessList := generateAccessList(mainAccessListName)
+		mock := &mockAccessListAndMembersGetter{
+			accessLists: mockAccessLists(accessList),
+		}
+
+		for b.Loop() {
+			_, err := IsAccessListMember(
+				b.Context(),
+				&types.UserV2{Metadata: types.Metadata{Name: testUserName}},
+				accessList,
+				mock,
+				lockGetter,
+				clock)
+			if !trace.IsAccessDenied(err) {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("single-page direct member", func(b *testing.B) {
+		accessList := generateAccessList(mainAccessListName)
+		member := &accesslist.AccessListMember{
+			ResourceHeader: header.ResourceHeader{
+				Metadata: header.Metadata{
+					Name: testUserName,
+				},
+			},
+			Spec: accesslist.AccessListMemberSpec{
+				AccessList:     mainAccessListName,
+				Name:           testUserName,
+				MembershipKind: accesslist.MembershipKindUser,
+			},
+		}
+		generatedMembers := generateUserMembers(50, mainAccessListName)
+		// We inject the member we are looking for in the middle of the member list
+		members := append(generatedMembers[:25], member)
+		members = append(members, generatedMembers[25:]...)
+
+		mock := &mockAccessListAndMembersGetter{
+			accessLists: mockAccessLists(accessList),
+			members:     mockAccessListMembers(b, members...),
+		}
+
+		for b.Loop() {
+			_, err := IsAccessListMember(
+				b.Context(),
+				&types.UserV2{Metadata: types.Metadata{Name: testUserName}},
+				accessList,
+				mock,
+				lockGetter,
+				clock)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("multiple-pages direct member", func(b *testing.B) {
+		accessList := generateAccessList(mainAccessListName)
+		member := &accesslist.AccessListMember{
+			ResourceHeader: header.ResourceHeader{
+				Metadata: header.Metadata{
+					Name: testUserName,
+				},
+			},
+			Spec: accesslist.AccessListMemberSpec{
+				AccessList:     mainAccessListName,
+				Name:           testUserName,
+				MembershipKind: accesslist.MembershipKindUser,
+			},
+		}
+		generatedMembers := generateUserMembers(500, mainAccessListName)
+		// We inject the member we are looking for in the middle of the member list
+		members := append(generatedMembers[:250], member)
+		members = append(members, generatedMembers[250:]...)
+
+		mock := &mockAccessListAndMembersGetter{
+			accessLists: mockAccessLists(accessList),
+			members:     mockAccessListMembers(b, members...),
+		}
+
+		for b.Loop() {
+			_, err := IsAccessListMember(
+				b.Context(),
+				&types.UserV2{Metadata: types.Metadata{Name: testUserName}},
+				accessList,
+				mock,
+				lockGetter,
+				clock)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("single-page nested member", func(b *testing.B) {
+		lists, members := generateNestedALs(5, 0, mainAccessListName, testUserName)
+		mock := &mockAccessListAndMembersGetter{
+			accessLists: lists,
+			members:     members,
+		}
+
+		for b.Loop() {
+			_, err := IsAccessListMember(
+				b.Context(),
+				&types.UserV2{Metadata: types.Metadata{Name: testUserName}},
+				generateAccessList(mainAccessListName),
+				mock,
+				lockGetter,
+				clock)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("multiple pages nested member", func(b *testing.B) {
+		lists, members := generateNestedALs(5, 501, mainAccessListName, testUserName)
+		mock := &mockAccessListAndMembersGetter{
+			accessLists: lists,
+			members:     members,
+		}
+
+		for b.Loop() {
+			_, err := IsAccessListMember(
+				b.Context(),
+				&types.UserV2{Metadata: types.Metadata{Name: testUserName}},
+				generateAccessList(mainAccessListName),
+				mock,
+				lockGetter,
+				clock)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }

--- a/lib/accesslists/hierarchy_test.go
+++ b/lib/accesslists/hierarchy_test.go
@@ -73,7 +73,7 @@ func (m *mockAccessListAndMembersGetter) GetAccessListV2(ctx context.Context, re
 	})
 	accessList, exists := m.accessLists[accessListName]
 	if !exists {
-		return nil, trace.NotFound("access list %v not found", accessListName)
+		return nil, trace.NotFound("access list %s not found", accessListName.String())
 	}
 	return accessList, nil
 }
@@ -246,6 +246,58 @@ func TestAccessListHierarchyIsOwner(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorAs(t, err, new(*trace.AccessDeniedError))
 	require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, ownershipType)
+}
+
+// TestIsAccessListOwnerScopedNameCollision asserts that IsAccessListOwner does
+// not consider a user to be an owner of a scoped access list if they are
+// actually a member of an unscoped access list with the same unqualified name
+// as a legimate scoped owner list.
+func TestIsAccessListOwnerScopedNameCollision(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	ctx := context.Background()
+
+	unscopedOwnerList := newAccessList(t, "owners", clock)
+	scopedOwnerList := newAccessList(t, "owners", clock)
+	scopedOwnerList.Scope = "/eng"
+	targetList := newAccessList(t, "target", clock)
+	targetList.Scope = "/eng/app"
+	targetList.Spec.Owners = []accesslist.Owner{{
+		Name:           ScopeQualifiedName(scopedOwnerList).String(),
+		MembershipKind: accesslist.MembershipKindScopedList,
+	}}
+
+	unscopedOwnerMember := newAccessListMember(t, unscopedOwnerList.GetName(), member1, accesslist.MembershipKindUser, clock)
+	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
+		members:     mockAccessListMembers(unscopedOwnerMember),
+		accessLists: mockAccessLists(unscopedOwnerList, scopedOwnerList, targetList),
+	}
+
+	stubUser, err := types.NewUser(member1)
+	require.NoError(t, err)
+	stubUser.SetTraits(map[string][]string{
+		"mtrait1": {"mvalue1", "mvalue2"},
+		"mtrait2": {"mvalue3", "mvalue4"},
+		"otrait1": {"ovalue1", "ovalue2"},
+		"otrait2": {"ovalue3", "ovalue4"},
+	})
+	stubUser.SetRoles([]string{"mrole1", "mrole2", "orole1", "orole2"})
+
+	// Sanity check the user is legimately a member of the unscoped access list.
+	_, err = IsAccessListMember(ctx, stubUser, unscopedOwnerList, accessListAndMembersGetter, nil, clock)
+	require.NoError(t, err)
+
+	// IsAccessListOwner must return an error when checking if the user is an owner of the target list.
+	_, err = IsAccessListOwner(ctx, stubUser, targetList, accessListAndMembersGetter, nil, clock)
+	require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+
+	// If we make the unscoped owner list an owner, the user becomes a legimate owner.
+	targetList.Spec.Owners = append(targetList.Spec.Owners, accesslist.Owner{
+		Name:           unscopedOwnerList.GetName(),
+		MembershipKind: accesslist.MembershipKindList,
+	})
+	assignmentType, err := IsAccessListOwner(ctx, stubUser, targetList, accessListAndMembersGetter, nil, clock)
+	require.NoError(t, err)
+	require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED, assignmentType)
 }
 
 func TestAccessListIsMember(t *testing.T) {

--- a/lib/accesslists/hierarchy_test.go
+++ b/lib/accesslists/hierarchy_test.go
@@ -853,11 +853,11 @@ func TestGetInheritedGrants(t *testing.T) {
 		Roles: []string{"root-owner-role"},
 		ScopedRoles: []accesslist.ScopedRoleGrant{
 			{
-				Role:  "root-scoped-role",
+				Role:  "/::root-scoped-role",
 				Scope: "/root/bb",
 			},
 			{
-				Role:  "root-scoped-role",
+				Role:  "/::root-scoped-role",
 				Scope: "/root/aa",
 			},
 		},
@@ -872,11 +872,11 @@ func TestGetInheritedGrants(t *testing.T) {
 		Roles: []string{"1-member-role"},
 		ScopedRoles: []accesslist.ScopedRoleGrant{
 			{
-				Role:  "1-scoped-role",
+				Role:  "/::1-scoped-role",
 				Scope: "/1/bb",
 			},
 			{
-				Role:  "1-scoped-role",
+				Role:  "/::1-scoped-role",
 				Scope: "/1/aa",
 			},
 		},
@@ -909,19 +909,19 @@ func TestGetInheritedGrants(t *testing.T) {
 		Roles: []string{"1-member-role", "root-owner-role"},
 		ScopedRoles: []accesslist.ScopedRoleGrant{
 			{
-				Role:  "1-scoped-role",
+				Role:  "/::1-scoped-role",
 				Scope: "/1/aa",
 			},
 			{
-				Role:  "1-scoped-role",
+				Role:  "/::1-scoped-role",
 				Scope: "/1/bb",
 			},
 			{
-				Role:  "root-scoped-role",
+				Role:  "/::root-scoped-role",
 				Scope: "/root/aa",
 			},
 			{
-				Role:  "root-scoped-role",
+				Role:  "/::root-scoped-role",
 				Scope: "/root/bb",
 			},
 		},

--- a/lib/accesslists/scopedcollection.go
+++ b/lib/accesslists/scopedcollection.go
@@ -1,0 +1,272 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package accesslists
+
+import (
+	"context"
+	"slices"
+	"strconv"
+
+	"github.com/gravitational/trace"
+
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/lib/scopes"
+)
+
+// ScopedCollection represents a complete batch of access list and members from
+// one source (e.g. entraID or okta). It is a clone of [Collection] that
+// supports inclusion of scoped access lists and nested scoped access list
+// members.
+//
+// All access lists and members in the batch are expected to be created/updated
+// together as a snapshot of a final complete state of the access lists and
+// their member hierarchy.
+//
+// For instance, imagine an access list import from EntraID directory where the
+// access list can't be modified outside EntraID and teleport only fetches the
+// complete state of access lists and members from EntraID.
+// This is useful to validate nested hierarchy on the fly and preset the
+// reference updates (Status.MemberOf and Status.OwnerOf) before starting the
+// actual creation/update process in the backend.
+// Relationships with access lists outside the ScopedCollection is not possible
+// because the collection source is aware only of the access lists and members
+// they contain.
+type ScopedCollection struct {
+	// MembersByAccessList maps access list names to their members
+	MembersByAccessList map[NormalizedSQN][]*accesslist.AccessListMember
+	// AccessListsByName is an internal map for fast lookup by name
+	AccessListsByName map[NormalizedSQN]*accesslist.AccessList
+}
+
+// Validate validates all access lists and members in the batch.
+func (b *ScopedCollection) Validate(ctx context.Context) error {
+	for aclName, accessList := range b.AccessListsByName {
+		if err := accessList.CheckAndSetDefaults(); err != nil {
+			return trace.Wrap(err)
+		}
+		if ScopeQualifiedName(accessList) != aclName {
+			return trace.BadParameter("AccessListsByName key %s does not match actual access list name %s",
+				aclName.String(), ScopeQualifiedName(accessList))
+		}
+	}
+	for aclName, members := range b.MembersByAccessList {
+		if _, ok := b.AccessListsByName[aclName]; !ok {
+			return trace.BadParameter("MembersByAccessList key %s has no corresponding list in AccessListsByName", aclName.String())
+		}
+		for _, member := range members {
+			if err := member.CheckAndSetDefaults(); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+	}
+	for _, accessList := range b.AccessListsByName {
+		members := b.MembersByAccessList[ScopeQualifiedName(accessList)]
+		if err := ValidateAccessListWithMembers(ctx, nil, accessList, members, b); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	if err := b.RefUpdates(); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// AddAccessList adds an access list and its members to the batch.
+func (b *ScopedCollection) AddAccessList(accessList *accesslist.AccessList, members []*accesslist.AccessListMember) error {
+	if accessList == nil {
+		return trace.BadParameter("access list is nil")
+	}
+	if b.MembersByAccessList == nil {
+		b.MembersByAccessList = make(map[NormalizedSQN][]*accesslist.AccessListMember)
+	}
+	if b.AccessListsByName == nil {
+		b.AccessListsByName = make(map[NormalizedSQN]*accesslist.AccessList)
+	}
+	b.MembersByAccessList[ScopeQualifiedName(accessList)] = members
+	b.AccessListsByName[ScopeQualifiedName(accessList)] = accessList
+
+	if accessList.Status.MemberOf == nil {
+		accessList.Status.MemberOf = []string{}
+	}
+	if accessList.Status.OwnerOf == nil {
+		accessList.Status.OwnerOf = []string{}
+	}
+	return nil
+}
+
+// GetAccessList retrieves an access list from the batch by name.
+// Implements accesslists.AccessListAndMembersGetter interface.
+func (b *ScopedCollection) GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error) {
+	al, exists := b.AccessListsByName[NormalizedSQN{Name: name}]
+	if !exists {
+		return nil, trace.NotFound("access list %q not found in batch", name)
+	}
+	return al, nil
+}
+
+// GetAccessListV2 retrieves an access list from the batch by scoped name.
+// Implements accesslists.AccessListAndMembersGetter interface.
+func (b *ScopedCollection) GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error) {
+	listName := NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetScope(),
+		Name:  req.GetName(),
+	})
+	al, exists := b.AccessListsByName[listName]
+	if !exists {
+		return nil, trace.NotFound("access list %q not found in batch", listName.String())
+	}
+	return al, nil
+}
+
+// ListAccessListMembers retrieves members for an access list from the batch.
+// Implements accesslists.AccessListAndMembersGetter interface.
+func (b *ScopedCollection) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+	return b.ListAccessListMembersV2(ctx, accesslistv1.ListAccessListMembersRequest_builder{
+		AccessList: accessListName,
+		PageSize:   int32(pageSize),
+		PageToken:  pageToken,
+	}.Build())
+}
+
+// ListAccessListMembersV2 retrieves members for an access list from the batch.
+func (b *ScopedCollection) ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) ([]*accesslist.AccessListMember, string, error) {
+	listName := NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	members, exists := b.MembersByAccessList[listName]
+	if !exists {
+		return nil, "", trace.NotFound("access list %q not found in batch", listName.String())
+	}
+
+	// Handle pagination
+	startIdx := 0
+	if req.GetPageToken() != "" {
+		idx, err := strconv.Atoi(req.GetPageToken())
+		if err != nil {
+			return nil, "", trace.BadParameter("invalid page token: %v", err)
+		}
+		startIdx = idx
+	}
+
+	// If startIdx is beyond the members slice, return empty result
+	if startIdx >= len(members) {
+		return []*accesslist.AccessListMember{}, "", nil
+	}
+
+	// Calculate end index based on pageSize
+	endIdx := len(members)
+	if req.GetPageSize() > 0 {
+		endIdx = min(startIdx+int(req.GetPageSize()), len(members))
+	}
+
+	// Slice members for this page
+	pageMembers := members[startIdx:endIdx]
+
+	// Generate next page token if there are more members
+	nextToken := ""
+	if endIdx < len(members) {
+		nextToken = strconv.Itoa(endIdx)
+	}
+
+	return pageMembers, nextToken, nil
+}
+
+// GetAccessListMember retrieves a specific member from an access list in the batch.
+// Implements accesslists.AccessListAndMembersGetter interface.
+func (b *ScopedCollection) GetAccessListMember(ctx context.Context, accessListName, memberName string) (*accesslist.AccessListMember, error) {
+	return b.GetAccessListMemberV2(ctx, accesslistv1.GetAccessListMemberRequest_builder{
+		AccessList: accessListName,
+		MemberName: memberName,
+	}.Build())
+}
+
+// GetAccessListMemberV2 retrieves a specific member from an access list in the batch.
+func (b *ScopedCollection) GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error) {
+	listName := NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	memberName := NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetMemberScope(),
+		Name:  req.GetMemberName(),
+	})
+	members, exists := b.MembersByAccessList[listName]
+	if !exists {
+		return nil, trace.NotFound("access list %q not found in batch", listName.String())
+	}
+	for _, member := range members {
+		thisMemberName, err := MemberScopeQualifiedName(member)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if thisMemberName == memberName {
+			return member, nil
+		}
+	}
+	return nil, trace.NotFound("member %q not found in access list %q", memberName.String(), listName.String())
+}
+
+// RefUpdates calculates and applies reference updates (Status.MemberOf and Status.OwnerOf)
+// based on the nested access list relationships in the collection.
+func (b *ScopedCollection) RefUpdates() error {
+	for name, accessList := range b.AccessListsByName {
+		for _, owner := range accessList.Spec.Owners {
+			if !owner.IsMembershipKindList() {
+				continue
+			}
+			ownerName, err := OwnerScopeQualifiedName(owner)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if targetList, exists := b.AccessListsByName[ownerName]; exists {
+				target := &targetList.Status.OwnerOf
+				if name.Scope != "" {
+					target = &targetList.Status.ScopedOwnerOf
+				}
+				if slices.Contains(*target, name.String()) {
+					continue
+				}
+				*target = append(*target, name.String())
+			}
+		}
+	}
+
+	for accessListName, members := range b.MembersByAccessList {
+		for _, member := range members {
+			if !member.IsList() {
+				continue
+			}
+			memberName, err := MemberScopeQualifiedName(member)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if targetList, exists := b.AccessListsByName[memberName]; exists {
+				target := &targetList.Status.MemberOf
+				if accessListName.Scope != "" {
+					target = &targetList.Status.ScopedMemberOf
+				}
+				if slices.Contains(*target, accessListName.String()) {
+					continue
+				}
+				*target = append(*target, accessListName.String())
+			}
+		}
+	}
+	return nil
+}

--- a/lib/accesslists/scopequalifiedname.go
+++ b/lib/accesslists/scopequalifiedname.go
@@ -21,10 +21,36 @@ import (
 	"github.com/gravitational/teleport/lib/scopes"
 )
 
-// ScopeQualifiedName returns the scope-qualified name of the given access list.
-func ScopeQualifiedName(list *accesslist.AccessList) scopes.QualifiedName {
+// NormalizedSQN is a scope-qualified name that has been normalized for
+// comparisons and usage as a map key.
+type NormalizedSQN struct {
+	// Scope is the resource's normalized scope path, e.g. "/staging/west".
+	Scope string
+	// Name is the resource's name within its scope, e.g. "mylist".
+	Name string
+}
+
+// NormalizeSQN returns a scope-qualified name that has been normalized for
+// comparisons and usage as a map key.
+func NormalizeSQN(sqn scopes.QualifiedName) NormalizedSQN {
+	return NormalizedSQN{
+		Scope: scopes.NormalizeForEquality(sqn.Scope),
+		Name:  sqn.Name,
+	}
+}
+
+// ToScopesQualifiedName converts the NormalizedSQN to a [scopes.QualifiedName].
+func (n NormalizedSQN) ToScopesQualifiedName() scopes.QualifiedName {
 	return scopes.QualifiedName{
+		Scope: n.Scope,
+		Name:  n.Name,
+	}
+}
+
+// ScopeQualifiedName returns the normalized scope-qualified name of the given access list.
+func ScopeQualifiedName(list *accesslist.AccessList) NormalizedSQN {
+	return NormalizeSQN(scopes.QualifiedName{
 		Scope: list.Scope,
 		Name:  list.Metadata.Name,
-	}
+	})
 }

--- a/lib/accesslists/scopequalifiedname.go
+++ b/lib/accesslists/scopequalifiedname.go
@@ -148,3 +148,40 @@ func ParentListOf(member *accesslist.AccessListMember) (NormalizedSQN, error) {
 	}
 	return ParseScopeQualifiedName(member.Spec.AccessList)
 }
+
+// ReviewedList returns the scope-qualified name of the access list reviewed by
+// the given review.
+func ReviewedList(review *accesslist.Review) (NormalizedSQN, error) {
+	if review.Scope == "" {
+		return NormalizedSQN{
+			Name: review.Spec.AccessList,
+		}, nil
+	}
+	listName, err := ParseScopeQualifiedName(review.Spec.AccessList)
+	if err != nil {
+		return NormalizedSQN{}, trace.Wrap(err)
+	}
+	if review.Scope != listName.Scope {
+		return NormalizedSQN{}, trace.BadParameter("access list review scope %q does not match the scope of the reviewed list %q", review.Scope, listName.Scope)
+	}
+	return listName, nil
+}
+
+// AllRemovedMembers returns the scope-qualified names of all members removed
+// by this access list review.
+func AllRemovedMembers(review *accesslist.Review) ([]NormalizedSQN, error) {
+	removedMembers := make([]NormalizedSQN, 0, len(review.Spec.Changes.RemovedMembers)+len(review.Spec.Changes.ScopedRemovedMembers))
+	for _, removedMember := range review.Spec.Changes.RemovedMembers {
+		removedMembers = append(removedMembers, NormalizedSQN{
+			Name: removedMember,
+		})
+	}
+	for _, scopedRemovedMember := range review.Spec.Changes.ScopedRemovedMembers {
+		sqn, err := ParseScopeQualifiedName(scopedRemovedMember)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		removedMembers = append(removedMembers, sqn)
+	}
+	return removedMembers, nil
+}

--- a/lib/accesslists/scopequalifiedname.go
+++ b/lib/accesslists/scopequalifiedname.go
@@ -17,6 +17,8 @@
 package accesslists
 
 import (
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/lib/scopes"
 )
@@ -47,10 +49,90 @@ func (n NormalizedSQN) ToScopesQualifiedName() scopes.QualifiedName {
 	}
 }
 
+// String formates the NormalizedSQN as a string.
+func (n NormalizedSQN) String() string {
+	return n.ToScopesQualifiedName().String()
+}
+
+// ParseScopeQualifiedName parses the given scope-qualified name string,
+// applies weak validation, and normalizes it.
+func ParseScopeQualifiedName(str string) (NormalizedSQN, error) {
+	sqn, err := scopes.ParseQualifiedName(str)
+	if err != nil {
+		return NormalizedSQN{}, trace.Wrap(err)
+	}
+	if err := sqn.WeakValidate(); err != nil {
+		return NormalizedSQN{}, trace.Wrap(err)
+	}
+	return NormalizeSQN(sqn), nil
+}
+
 // ScopeQualifiedName returns the normalized scope-qualified name of the given access list.
 func ScopeQualifiedName(list *accesslist.AccessList) NormalizedSQN {
 	return NormalizeSQN(scopes.QualifiedName{
 		Scope: list.Scope,
 		Name:  list.Metadata.Name,
 	})
+}
+
+// OwnerScopeQualifiedName returns the scope-qualified name of an access list owner.
+func OwnerScopeQualifiedName(owner accesslist.Owner) (NormalizedSQN, error) {
+	switch owner.MembershipKind {
+	case accesslist.MembershipKindUser, accesslist.MembershipKindList, accesslist.MembershipKindUnspecified, "":
+		return NormalizedSQN{
+			Name: owner.Name,
+		}, nil
+	case accesslist.MembershipKindScopedList:
+		return ParseScopeQualifiedName(owner.Name)
+	default:
+		return NormalizedSQN{}, trace.BadParameter("unhandled membership kind %s", owner.MembershipKind)
+	}
+}
+
+// MemberScopeQualifiedName returns the scope-qualified name of an access list member.
+func MemberScopeQualifiedName(member *accesslist.AccessListMember) (NormalizedSQN, error) {
+	switch member.Spec.MembershipKind {
+	case accesslist.MembershipKindUser, accesslist.MembershipKindList, accesslist.MembershipKindUnspecified, "":
+		return NormalizedSQN{
+			Name: member.GetName(),
+		}, nil
+	case accesslist.MembershipKindScopedList:
+		return ParseScopeQualifiedName(member.GetName())
+	default:
+		return NormalizedSQN{}, trace.BadParameter("unhandled membership kind %s", member.Spec.MembershipKind)
+	}
+}
+
+// AllOwnedLists returns the scope-qualified names of all access lists owned by
+// the given list, as recorded in Status.OwnerOf and Status.ScopedOwnerOf.
+func AllOwnedLists(list *accesslist.AccessList) ([]NormalizedSQN, error) {
+	ownedLists := make([]NormalizedSQN, 0, len(list.Status.OwnerOf)+len(list.Status.ScopedOwnerOf))
+	for _, ownerOf := range list.Status.OwnerOf {
+		ownedLists = append(ownedLists, NormalizedSQN{Name: ownerOf})
+	}
+	for _, scopedOwnerOf := range list.Status.ScopedOwnerOf {
+		ownedSQN, err := ParseScopeQualifiedName(scopedOwnerOf)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		ownedLists = append(ownedLists, ownedSQN)
+	}
+	return ownedLists, nil
+}
+
+// AllParentLists returns the scope-qualified names of all direct parent access
+// lists of the given list, as recorded in Status.MemberOf and Status.ScopedMemberOf.
+func AllParentLists(list *accesslist.AccessList) ([]NormalizedSQN, error) {
+	parentLists := make([]NormalizedSQN, 0, len(list.Status.MemberOf)+len(list.Status.ScopedMemberOf))
+	for _, memberOf := range list.Status.MemberOf {
+		parentLists = append(parentLists, NormalizedSQN{Name: memberOf})
+	}
+	for _, scopedMemberOf := range list.Status.ScopedMemberOf {
+		parentSQN, err := ParseScopeQualifiedName(scopedMemberOf)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		parentLists = append(parentLists, parentSQN)
+	}
+	return parentLists, nil
 }

--- a/lib/accesslists/scopequalifiedname.go
+++ b/lib/accesslists/scopequalifiedname.go
@@ -1,0 +1,30 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package accesslists
+
+import (
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/lib/scopes"
+)
+
+// ScopeQualifiedName returns the scope-qualified name of the given access list.
+func ScopeQualifiedName(list *accesslist.AccessList) scopes.QualifiedName {
+	return scopes.QualifiedName{
+		Scope: list.Scope,
+		Name:  list.Metadata.Name,
+	}
+}

--- a/lib/accesslists/scopequalifiedname.go
+++ b/lib/accesslists/scopequalifiedname.go
@@ -136,3 +136,15 @@ func AllParentLists(list *accesslist.AccessList) ([]NormalizedSQN, error) {
 	}
 	return parentLists, nil
 }
+
+// ParentListOf returns the scope-qualified name of the parent list of the
+// given access list member.
+func ParentListOf(member *accesslist.AccessListMember) (NormalizedSQN, error) {
+	if member.Scope == "" {
+		if member.Spec.AccessList == "" {
+			return NormalizedSQN{}, trace.BadParameter("member spec.access_list field empty")
+		}
+		return NormalizedSQN{Name: member.Spec.AccessList}, nil
+	}
+	return ParseScopeQualifiedName(member.Spec.AccessList)
+}

--- a/lib/accesslists/validate.go
+++ b/lib/accesslists/validate.go
@@ -95,6 +95,40 @@ func validateAccessList(a *accesslist.AccessList) error {
 		}
 	}
 
+	// Any access lists that assign scoped roles cannot contain
+	// membership_requires or ownership_requires.
+	hasRequirements := !a.Spec.MembershipRequires.IsEmpty() || !a.Spec.OwnershipRequires.IsEmpty()
+	hasScopedRoleGrants := len(a.Spec.Grants.ScopedRoles) > 0 || len(a.Spec.OwnerGrants.ScopedRoles) > 0
+	if hasScopedRoleGrants && hasRequirements {
+		return trace.BadParameter("access lists cannot contain both scoped_role grants and non-empty membership_requires or ownership_requires blocks")
+	}
+
+	if a.Scope != "" {
+		if err := scopes.StrongValidate(a.Scope); err != nil {
+			return trace.Wrap(err, "access list has invalid scope")
+		}
+
+		// Scoped access lists cannot contain requirements.
+		if hasRequirements {
+			return trace.BadParameter("scoped access lists cannot contain non-empty membership_requires or ownership_requires blocks")
+		}
+
+		// Scoped access lists cannot grant unscoped roles or traits.
+		if len(a.Spec.Grants.Roles) > 0 || len(a.Spec.OwnerGrants.Roles) > 0 {
+			return trace.BadParameter("scoped access lists cannot grant unscoped roles")
+		}
+		if len(a.Spec.Grants.Traits) > 0 || len(a.Spec.OwnerGrants.Traits) > 0 {
+			return trace.BadParameter("scoped access lists cannot grant traits")
+		}
+
+		for _, owner := range a.Spec.Owners {
+			switch owner.MembershipKind {
+			case accesslist.MembershipKindList, accesslist.MembershipKindScopedList:
+				return trace.BadParameter("access list owners are not yet supported for scoped access lists")
+			}
+		}
+	}
+
 	if err := validateScopedRoleGrants(a); err != nil {
 		return trace.Wrap(err)
 	}
@@ -103,13 +137,6 @@ func validateAccessList(a *accesslist.AccessList) error {
 }
 
 func validateScopedRoleGrants(a *accesslist.AccessList) error {
-	// Access lists that assign scoped roles cannot contain membership_requires or ownership_requires.
-	hasScopedRoleGrants := len(a.Spec.Grants.ScopedRoles) > 0 || len(a.Spec.OwnerGrants.ScopedRoles) > 0
-	hasRequires := !a.Spec.MembershipRequires.IsEmpty() || !a.Spec.OwnershipRequires.IsEmpty()
-	if hasScopedRoleGrants && hasRequires {
-		return trace.BadParameter("access lists cannot contain both scoped_role grants and non-empty membership_requires or ownership_requires blocks")
-	}
-
 	uniqueScopedRoleGrants := make(map[accesslist.ScopedRoleGrant]struct{})
 	validateScopedRoleGrant := func(grant accesslist.ScopedRoleGrant) error {
 		if _, alreadyValidated := uniqueScopedRoleGrants[grant]; alreadyValidated {
@@ -123,6 +150,15 @@ func validateScopedRoleGrants(a *accesslist.AccessList) error {
 		}
 		if err := scopes.StrongValidate(grant.Scope); err != nil {
 			return trace.Wrap(err, "validating scope")
+		}
+		if scopes.Compare(grant.Scope, scopes.Root) == scopes.Equivalent {
+			return trace.BadParameter("root scope cannot be used as a scope of effect")
+		}
+		if a.Scope != "" {
+			// Scoped access lists can only assign scoped roles to their own scope or a descendent scope.
+			if !scopes.ScopeOfOrigin(a.Scope).IsAssignableToScopeOfEffect(grant.Scope) {
+				return trace.BadParameter("scoped role grant has scope %q that is not a sub-scope of the access list's scope %q", grant.Scope, a.Scope)
+			}
 		}
 		uniqueScopedRoleGrants[grant] = struct{}{}
 		return nil
@@ -180,6 +216,9 @@ func validateAccessListNesting(ctx context.Context, accessList *accesslist.Acces
 			return trace.Wrap(err)
 		}
 	}
+	if accessList.Scope != "" && len(members) > 0 {
+		return trace.BadParameter("scoped access list members are not yet supported")
+	}
 	for _, member := range members {
 		if err := ValidateAccessListMember(ctx, accessList, member, g); err != nil {
 			return trace.Wrap(err)
@@ -208,6 +247,10 @@ func ValidateAccessListMember(
 // validateAccessListMemberBasic performs basic fields validation for AccessListMember
 // and performs the cross membership integrity check.
 func validateAccessListMemberBasic(parent *accesslist.AccessList, member *accesslist.AccessListMember) error {
+	if member.Scope != "" {
+		// TODO(nklaassen): support scoped access list members.
+		return trace.BadParameter("scoped access list members are not yet supported")
+	}
 	if member.Spec.AccessList == "" {
 		return trace.BadParameter("member %s: access_list field empty", member.Metadata.Name)
 	}
@@ -235,6 +278,13 @@ func validateAccessListOwner(
 	owner accesslist.Owner,
 	g AccessListAndMembersGetter,
 ) error {
+	// TODO(nklaassen): support non-user scoped access list owners.
+	if parentList.Scope != "" && owner.MembershipKind == accesslist.MembershipKindList {
+		return trace.BadParameter("scoped access lists do not yet support nested list ownership")
+	}
+	if owner.MembershipKind == accesslist.MembershipKindScopedList {
+		return trace.BadParameter("scoped access lists do not yet support nested list ownership")
+	}
 	if err := validateAccessListMemberOrOwnerNesting(ctx, parentList, owner.Name, RelationshipKindOwner, owner.MembershipKind, g); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/accesslists/validate.go
+++ b/lib/accesslists/validate.go
@@ -121,12 +121,11 @@ func validateAccessList(a *accesslist.AccessList) error {
 			return trace.BadParameter("scoped access lists cannot grant traits")
 		}
 
-		for _, owner := range a.Spec.Owners {
-			switch owner.MembershipKind {
-			case accesslist.MembershipKindList, accesslist.MembershipKindScopedList:
-				return trace.BadParameter("access list owners are not yet supported for scoped access lists")
-			}
-		}
+		// TODO(nklaassen): after scoped role assignments have been updated to
+		// refer to scoped access lists with scope-qualified names, access
+		// lists should do the same. At that point we must validate that the
+		// scope of origin of each granted scoped role is equal or ancestor to
+		// the scope of the access list.
 	}
 
 	if err := validateScopedRoleGrants(a); err != nil {
@@ -148,18 +147,22 @@ func validateScopedRoleGrants(a *accesslist.AccessList) error {
 		case grant.Scope == "":
 			return trace.BadParameter("scope is empty")
 		}
+
 		if err := scopes.StrongValidate(grant.Scope); err != nil {
 			return trace.Wrap(err, "validating scope")
 		}
+
 		if scopes.Compare(grant.Scope, scopes.Root) == scopes.Equivalent {
 			return trace.BadParameter("root scope cannot be used as a scope of effect")
 		}
+
 		if a.Scope != "" {
 			// Scoped access lists can only assign scoped roles to their own scope or a descendent scope.
 			if !scopes.ScopeOfOrigin(a.Scope).IsAssignableToScopeOfEffect(grant.Scope) {
 				return trace.BadParameter("scoped role grant has scope %q that is not a sub-scope of the access list's scope %q", grant.Scope, a.Scope)
 			}
 		}
+
 		uniqueScopedRoleGrants[grant] = struct{}{}
 		return nil
 	}
@@ -174,8 +177,8 @@ func validateScopedRoleGrants(a *accesslist.AccessList) error {
 		}
 	}
 	// Unique scoped role grants per access list have the same limit as role
-	// grants per scoped_role_assignment for the same reason: each role may
-	// require two backend.ConditionalActions to include in an AtomicWrite.
+	// grants per scoped role assignment, because each access list materializes
+	// to a single scoped roles assignment.
 	if len(uniqueScopedRoleGrants) > scopedaccess.MaxRolesPerAssignment {
 		return trace.BadParameter("access list contains too many unique scoped role grants (max %d)", scopedaccess.MaxRolesPerAssignment)
 	}
@@ -217,6 +220,7 @@ func validateAccessListNesting(ctx context.Context, accessList *accesslist.Acces
 		}
 	}
 	if accessList.Scope != "" && len(members) > 0 {
+		// TODO(nklaassen): support scoped access list members.
 		return trace.BadParameter("scoped access list members are not yet supported")
 	}
 	for _, member := range members {
@@ -238,7 +242,11 @@ func ValidateAccessListMember(
 	if err := validateAccessListMemberBasic(parentList, member); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := validateAccessListMemberOrOwnerNesting(ctx, parentList, member.GetName(), RelationshipKindMember, member.Spec.MembershipKind, g); err != nil {
+	memberName, err := MemberScopeQualifiedName(member)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if err := validateAccessListMemberOrOwnerNesting(ctx, parentList, memberName, RelationshipKindMember, member.Spec.MembershipKind, g); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
@@ -278,14 +286,16 @@ func validateAccessListOwner(
 	owner accesslist.Owner,
 	g AccessListAndMembersGetter,
 ) error {
-	// TODO(nklaassen): support non-user scoped access list owners.
-	if parentList.Scope != "" && owner.MembershipKind == accesslist.MembershipKindList {
-		return trace.BadParameter("scoped access lists do not yet support nested list ownership")
+	ownerName, err := OwnerScopeQualifiedName(owner)
+	if err != nil {
+		return trace.Wrap(err)
 	}
-	if owner.MembershipKind == accesslist.MembershipKindScopedList {
-		return trace.BadParameter("scoped access lists do not yet support nested list ownership")
+	if ownerName.Scope != "" {
+		if err := ownerName.ToScopesQualifiedName().StrongValidate(); err != nil {
+			return trace.Wrap(err)
+		}
 	}
-	if err := validateAccessListMemberOrOwnerNesting(ctx, parentList, owner.Name, RelationshipKindOwner, owner.MembershipKind, g); err != nil {
+	if err := validateAccessListMemberOrOwnerNesting(ctx, parentList, ownerName, RelationshipKindOwner, owner.MembershipKind, g); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
@@ -294,22 +304,60 @@ func validateAccessListOwner(
 func validateAccessListMemberOrOwnerNesting(
 	ctx context.Context,
 	parentList *accesslist.AccessList,
-	memberOrOwnerName string,
+	memberOrOwnerName NormalizedSQN,
 	relationshipKind RelationshipKind,
 	membershipKind string,
 	g AccessListAndMembersGetter,
 ) error {
-	if membershipKind != accesslist.MembershipKindList {
+	if !accesslist.IsMembershipKindList(membershipKind) {
 		return nil
 	}
+
+	if err := validateMemberOrOwnerScopeHierarchy(parentList, memberOrOwnerName, relationshipKind); err != nil {
+		return trace.Wrap(err)
+	}
+
 	// If it is a AccessList member/owner then the referenced AccessList must exist.
-	memberOrOwnerList, err := g.GetAccessList(ctx, memberOrOwnerName)
+	memberOrOwnerList, err := getAccessList(ctx, g, memberOrOwnerName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	if err := validateAddition(ctx, parentList, memberOrOwnerList, relationshipKind, g); err != nil {
 		return trace.Wrap(err)
 	}
+	return nil
+}
+
+func validateMemberOrOwnerScopeHierarchy(
+	list *accesslist.AccessList,
+	memberOrOwnerName NormalizedSQN,
+	relationshipKind RelationshipKind,
+) error {
+	if memberOrOwnerName.Scope == "" {
+		// Unscoped access lists can be members or owners of scoped or unscoped lists.
+		return nil
+	}
+
+	if list.GetScope() == memberOrOwnerName.Scope {
+		// Members or owners are always allowed at the same scope of the parent/owned list.
+		return nil
+	}
+
+	kindStr := "a Member"
+	if relationshipKind == RelationshipKindOwner {
+		kindStr = "an Owner"
+	}
+
+	if list.GetScope() == "" {
+		return trace.BadParameter("Access List '%s' cannot name '%s' as %s because scoped access lists cannot be members or owners of unscoped access lists",
+			list.Spec.Title, memberOrOwnerName.String(), kindStr)
+	}
+
+	if !scopes.PolicyResourceScope(list.GetScope()).CanDependOnStateFromPolicyResourceAtScope(memberOrOwnerName.Scope) {
+		return trace.BadParameter("Access List '%s' cannot name '%s' as %s because it is not at an equal or ancestor scope",
+			list.Spec.Title, memberOrOwnerName.String(), kindStr)
+	}
+
 	return nil
 }
 
@@ -326,7 +374,7 @@ func validateAddition(
 	}
 
 	// Cycle detection
-	reachable, err := isReachable(ctx, childList, parentList, make(map[string]struct{}), g)
+	reachable, err := isReachable(ctx, childList, parentList, make(map[NormalizedSQN]struct{}), g)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -352,52 +400,62 @@ func isReachable(
 	ctx context.Context,
 	currentList *accesslist.AccessList,
 	targetList *accesslist.AccessList,
-	visited map[string]struct{},
+	visited map[NormalizedSQN]struct{},
 	g AccessListAndMembersGetter,
 ) (bool, error) {
-	if currentList.GetName() == targetList.GetName() {
+	if ScopeQualifiedName(currentList) == ScopeQualifiedName(targetList) {
 		return true, nil
 	}
-	if _, ok := visited[currentList.GetName()]; ok {
+	if _, ok := visited[ScopeQualifiedName(currentList)]; ok {
 		return false, nil
 	}
-	visited[currentList.GetName()] = struct{}{}
+	visited[ScopeQualifiedName(currentList)] = struct{}{}
 
 	// Traverse member lists
-	listMembers, err := fetchMembers(ctx, currentList.GetName(), g)
+	listMembers, err := fetchMembers(ctx, ScopeQualifiedName(currentList), g)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
 	for _, member := range listMembers {
-		if member.Spec.MembershipKind == accesslist.MembershipKindList {
-			childList, err := g.GetAccessList(ctx, member.GetName())
-			if err != nil {
-				return false, trace.Wrap(err)
-			}
-			reachable, err := isReachable(ctx, childList, targetList, visited, g)
-			if err != nil {
-				return false, trace.Wrap(err)
-			}
-			if reachable {
-				return true, nil
-			}
+		if !member.IsList() {
+			continue
+		}
+		childListName, err := MemberScopeQualifiedName(member)
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+		childList, err := getAccessList(ctx, g, childListName)
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+		reachable, err := isReachable(ctx, childList, targetList, visited, g)
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+		if reachable {
+			return true, nil
 		}
 	}
 
 	// Traverse owner lists
 	for _, owner := range currentList.Spec.Owners {
-		if owner.MembershipKind == accesslist.MembershipKindList {
-			ownerList, err := g.GetAccessList(ctx, owner.Name)
-			if err != nil {
-				return false, trace.Wrap(err)
-			}
-			reachable, err := isReachable(ctx, ownerList, targetList, visited, g)
-			if err != nil {
-				return false, trace.Wrap(err)
-			}
-			if reachable {
-				return true, nil
-			}
+		if !owner.IsMembershipKindList() {
+			continue
+		}
+		ownerName, err := OwnerScopeQualifiedName(owner)
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+		ownerList, err := getAccessList(ctx, g, ownerName)
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+		reachable, err := isReachable(ctx, ownerList, targetList, visited, g)
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+		if reachable {
+			return true, nil
 		}
 	}
 
@@ -414,18 +472,18 @@ func exceedsMaxDepth(
 	switch kind {
 	case RelationshipKindOwner:
 		// For Owners, only consider the depth downwards from the child node
-		depthDownwards, err := maxDepthDownwards(ctx, childList.GetName(), make(map[string]struct{}), g)
+		depthDownwards, err := maxDepthDownwards(ctx, ScopeQualifiedName(childList), make(map[NormalizedSQN]struct{}), g)
 		if err != nil {
 			return false, trace.Wrap(err)
 		}
 		return depthDownwards > accesslist.MaxAllowedDepth, nil
 	default:
 		// For Members, consider the depth upwards from the parent node, downwards from the child node, and the edge between them
-		depthUpwards, err := maxDepthUpwards(ctx, parentList, make(map[string]struct{}), g)
+		depthUpwards, err := maxDepthUpwards(ctx, parentList, make(map[NormalizedSQN]struct{}), g)
 		if err != nil {
 			return false, trace.Wrap(err)
 		}
-		depthDownwards, err := maxDepthDownwards(ctx, childList.GetName(), make(map[string]struct{}), g)
+		depthDownwards, err := maxDepthDownwards(ctx, ScopeQualifiedName(childList), make(map[NormalizedSQN]struct{}), g)
 		if err != nil {
 			return false, trace.Wrap(err)
 		}

--- a/lib/accesslists/validate.go
+++ b/lib/accesslists/validate.go
@@ -219,10 +219,6 @@ func validateAccessListNesting(ctx context.Context, accessList *accesslist.Acces
 			return trace.Wrap(err)
 		}
 	}
-	if accessList.Scope != "" && len(members) > 0 {
-		// TODO(nklaassen): support scoped access list members.
-		return trace.BadParameter("scoped access list members are not yet supported")
-	}
 	for _, member := range members {
 		if err := ValidateAccessListMember(ctx, accessList, member, g); err != nil {
 			return trace.Wrap(err)
@@ -255,25 +251,49 @@ func ValidateAccessListMember(
 // validateAccessListMemberBasic performs basic fields validation for AccessListMember
 // and performs the cross membership integrity check.
 func validateAccessListMemberBasic(parent *accesslist.AccessList, member *accesslist.AccessListMember) error {
-	if member.Scope != "" {
-		// TODO(nklaassen): support scoped access list members.
-		return trace.BadParameter("scoped access list members are not yet supported")
-	}
 	if member.Spec.AccessList == "" {
 		return trace.BadParameter("member %s: access_list field empty", member.Metadata.Name)
 	}
 	if member.Spec.Name != member.Metadata.Name {
 		return trace.BadParameter("member metadata name = %q and spec name = %q must be equal", member.Metadata.Name, member.Spec.Name)
 	}
+	if member.Scope != parent.Scope {
+		return trace.BadParameter("member resource scope %q must be equal to parent list scope %q", member.Scope, parent.Scope)
+	}
+	parentName := ScopeQualifiedName(parent)
+	if member.Scope != "" {
+		if err := scopes.StrongValidate(member.Scope); err != nil {
+			return trace.Wrap(err, "access list member has invalid scope")
+		}
+		memberSQN, err := MemberScopeQualifiedName(member)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if memberSQN.Scope != "" {
+			if err := memberSQN.ToScopesQualifiedName().StrongValidate(); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		// The member must belong to the parent access list.
+		memberParentName, err := ParentListOf(member)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if memberParentName != parentName {
+			return trace.BadParameter("member spec.access_list %q must match parent list name %q",
+				member.Spec.AccessList, parentName.String())
+		}
+	} else {
+		// The member must belong to the parent access list.
+		if member.Spec.AccessList != parent.GetName() {
+			return trace.BadParameter("member %s: spec.access_list field %q doesn't match parent list name %q", member.Metadata.Name, member.Spec.AccessList, parent.GetName())
+		}
+	}
 	if member.Spec.Joined.IsZero() || member.Spec.Joined.Unix() == 0 {
 		return trace.BadParameter("member %s: joined field empty or missing", member.Metadata.Name)
 	}
 	if member.Spec.AddedBy == "" {
 		return trace.BadParameter("member %s: added_by field is empty", member.Metadata.Name)
-	}
-	// The member must belong to the parent access list.
-	if member.Spec.AccessList != parent.GetName() {
-		return trace.BadParameter("member %s: spec.access_list field %q doesn't match parent list name %q", member.Metadata.Name, member.Spec.AccessList, parent.GetName())
 	}
 	return nil
 }

--- a/lib/accesslists/validate.go
+++ b/lib/accesslists/validate.go
@@ -120,12 +120,6 @@ func validateAccessList(a *accesslist.AccessList) error {
 		if len(a.Spec.Grants.Traits) > 0 || len(a.Spec.OwnerGrants.Traits) > 0 {
 			return trace.BadParameter("scoped access lists cannot grant traits")
 		}
-
-		// TODO(nklaassen): after scoped role assignments have been updated to
-		// refer to scoped access lists with scope-qualified names, access
-		// lists should do the same. At that point we must validate that the
-		// scope of origin of each granted scoped role is equal or ancestor to
-		// the scope of the access list.
 	}
 
 	if err := validateScopedRoleGrants(a); err != nil {
@@ -148,18 +142,36 @@ func validateScopedRoleGrants(a *accesslist.AccessList) error {
 			return trace.BadParameter("scope is empty")
 		}
 
-		if err := scopes.StrongValidate(grant.Scope); err != nil {
-			return trace.Wrap(err, "validating scope")
+		roleName, err := scopes.ParseQualifiedName(grant.Role)
+		if err != nil {
+			return trace.Wrap(err, "parsing granted role name")
+		}
+		if err := roleName.StrongValidate(); err != nil {
+			return trace.Wrap(err, "validating granted role name")
 		}
 
+		if err := scopes.StrongValidate(grant.Scope); err != nil {
+			return trace.Wrap(err, "validating granted scope")
+		}
 		if scopes.Compare(grant.Scope, scopes.Root) == scopes.Equivalent {
 			return trace.BadParameter("root scope cannot be used as a scope of effect")
 		}
 
 		if a.Scope != "" {
-			// Scoped access lists can only assign scoped roles to their own scope or a descendent scope.
+			// Scoped access lists can only assign scoped roles defined in
+			// their own scope or an ancestor scope, to their own scope or a
+			// descendent scope.
+			//
+			// E.g. An access list in /aa/bb can grant /aa::role to /aa/bb/cc
+			if !scopes.PolicyResourceScope(a.Scope).CanDependOnStateFromPolicyResourceAtScope(roleName.Scope) {
+				return trace.BadParameter("cannot grant %q because it is not defined in a scope equal or ancestor to the list's scope %q", grant.Role, a.Scope)
+			}
 			if !scopes.ScopeOfOrigin(a.Scope).IsAssignableToScopeOfEffect(grant.Scope) {
 				return trace.BadParameter("scoped role grant has scope %q that is not a sub-scope of the access list's scope %q", grant.Scope, a.Scope)
+			}
+		} else {
+			if scopes.Compare(roleName.Scope, scopes.Root) != scopes.Equivalent {
+				return trace.BadParameter("unscoped access lists can only grant scoped role defined in the root scope")
 			}
 		}
 

--- a/lib/accesslists/validate_test.go
+++ b/lib/accesslists/validate_test.go
@@ -326,6 +326,80 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 			}
 		})
 
+		t.Run("owner list scope hierarchy is validated", func(t *testing.T) {
+			testCases := []struct {
+				name       string
+				listScope  string
+				ownerScope string
+				ownerKind  string
+				wantErr    string
+			}{
+				{
+					name:       "unscoped owner can own scoped list",
+					listScope:  "/eng/platform",
+					ownerScope: "",
+					ownerKind:  accesslist.MembershipKindList,
+				},
+				{
+					name:       "same scope owner can own scoped list",
+					listScope:  "/eng/platform",
+					ownerScope: "/eng/platform",
+					ownerKind:  accesslist.MembershipKindScopedList,
+				},
+				{
+					name:       "ancestor scope owner can own scoped list",
+					listScope:  "/eng/platform",
+					ownerScope: "/eng",
+					ownerKind:  accesslist.MembershipKindScopedList,
+				},
+				{
+					name:       "descendant scope owner is rejected",
+					listScope:  "/eng/platform",
+					ownerScope: "/eng/platform/team",
+					ownerKind:  accesslist.MembershipKindScopedList,
+					wantErr:    "because it is not at an equal or ancestor scope",
+				},
+				{
+					name:       "sibling scope owner is rejected",
+					listScope:  "/eng/platform",
+					ownerScope: "/eng/infra",
+					ownerKind:  accesslist.MembershipKindScopedList,
+					wantErr:    "because it is not at an equal or ancestor scope",
+				},
+				{
+					name:       "unscoped list cannot name scoped owner",
+					listScope:  "",
+					ownerScope: "/eng",
+					ownerKind:  accesslist.MembershipKindScopedList,
+					wantErr:    "because scoped access lists cannot be members or owners of unscoped access lists",
+				},
+			}
+
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					accessList := newScopedAccessList("test_scoped_access_list_owner_scope")
+					accessList.Scope = tc.listScope
+					ownerList := newScopedAccessList("owner-list")
+					ownerList.Scope = tc.ownerScope
+
+					accessList.Spec.Owners = []accesslist.Owner{{
+						Name:           ScopeQualifiedName(ownerList).String(),
+						MembershipKind: tc.ownerKind,
+					}}
+
+					getter := &mockAccessListAndMembersGetter{
+						accessLists: mockAccessLists(accessList, ownerList),
+					}
+					err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, getter)
+					if tc.wantErr != "" {
+						require.ErrorContains(t, err, tc.wantErr)
+						return
+					}
+					require.NoError(t, err)
+				})
+			}
+		})
+
 		t.Run("owner scoped role grant scope must be equal or descendant", func(t *testing.T) {
 			accessList := newScopedAccessList("test_scoped_access_list_owner_grant_scope")
 			accessList.Scope = "/eng/platform"
@@ -381,22 +455,6 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 
 			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
 			require.ErrorContains(t, err, "scoped access lists cannot grant traits")
-		})
-
-		t.Run("nested list owners are rejected", func(t *testing.T) {
-			accessList := newScopedAccessList("test_scoped_access_list_owner_list")
-			accessList.Spec.Owners = []accesslist.Owner{{Name: "owner-list", MembershipKind: accesslist.MembershipKindList}}
-
-			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
-			require.ErrorContains(t, err, "access list owners are not yet supported for scoped access lists")
-		})
-
-		t.Run("scoped list owners are rejected", func(t *testing.T) {
-			accessList := newScopedAccessList("test_scoped_access_list_scoped_owner_list")
-			accessList.Spec.Owners = []accesslist.Owner{{Name: "/eng::owner-list", MembershipKind: accesslist.MembershipKindScopedList}}
-
-			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
-			require.ErrorContains(t, err, "access list owners are not yet supported for scoped access lists")
 		})
 
 		t.Run("members are rejected", func(t *testing.T) {

--- a/lib/accesslists/validate_test.go
+++ b/lib/accesslists/validate_test.go
@@ -273,6 +273,155 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 		})
 	}
 
+	t.Run("scoped access lists are validated", func(t *testing.T) {
+		newScopedAccessList := func(name string) *accesslist.AccessList {
+			accessList := newAccessList(t, name, clock)
+			accessList.Scope = "/eng"
+			accessList.Spec.MembershipRequires = accesslist.Requires{}
+			accessList.Spec.OwnershipRequires = accesslist.Requires{}
+			accessList.Spec.Grants.Roles = nil
+			accessList.Spec.Grants.Traits = nil
+			accessList.Spec.OwnerGrants.Roles = nil
+			accessList.Spec.OwnerGrants.Traits = nil
+			return accessList
+		}
+
+		t.Run("valid with user owners", func(t *testing.T) {
+			accessList := newScopedAccessList("test_scoped_access_list")
+
+			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+			require.NoError(t, err)
+		})
+
+		t.Run("scoped role grant scope must be equal or descendant", func(t *testing.T) {
+			testCases := []struct {
+				name       string
+				grantScope string
+				wantErr    string
+			}{
+				{
+					name:       "equal scope is allowed",
+					grantScope: "/eng/platform",
+				},
+				{
+					name:       "descendant scope is allowed",
+					grantScope: "/eng/platform/team",
+				},
+				{
+					name:       "ancestor scope is rejected",
+					grantScope: "/eng",
+					wantErr:    `scoped role grant has scope "/eng" that is not a sub-scope of the access list's scope "/eng/platform"`,
+				},
+				{
+					name:       "sibling scope is rejected",
+					grantScope: "/eng/infra",
+					wantErr:    `scoped role grant has scope "/eng/infra" that is not a sub-scope of the access list's scope "/eng/platform"`,
+				},
+				{
+					name:       "root scope is rejected",
+					grantScope: "/",
+					wantErr:    "root scope cannot be used as a scope of effect",
+				},
+			}
+
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					accessList := newScopedAccessList("test_scoped_access_list_grant_scope")
+					accessList.Scope = "/eng/platform"
+					accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role", Scope: tc.grantScope}}
+
+					err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+					if tc.wantErr != "" {
+						require.ErrorContains(t, err, tc.wantErr)
+						return
+					}
+					require.NoError(t, err)
+				})
+			}
+		})
+
+		t.Run("owner scoped role grant scope must be equal or descendant", func(t *testing.T) {
+			accessList := newScopedAccessList("test_scoped_access_list_owner_grant_scope")
+			accessList.Scope = "/eng/platform"
+			accessList.Spec.OwnerGrants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role", Scope: "/eng"}}
+
+			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, `scoped role grant has scope "/eng" that is not a sub-scope of the access list's scope "/eng/platform"`)
+		})
+
+		t.Run("invalid scope is rejected", func(t *testing.T) {
+			accessList := newScopedAccessList("test_scoped_access_list_invalid_scope")
+			accessList.Scope = "not-a-scope"
+
+			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, "access list has invalid scope")
+		})
+
+		t.Run("requirements are rejected", func(t *testing.T) {
+			accessList := newScopedAccessList("test_scoped_access_list_requires")
+			accessList.Spec.MembershipRequires = accesslist.Requires{Roles: []string{"role"}}
+
+			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, "scoped access lists cannot contain non-empty membership_requires or ownership_requires blocks")
+		})
+
+		t.Run("unscoped role grants are rejected", func(t *testing.T) {
+			accessList := newScopedAccessList("test_scoped_access_list_roles")
+			accessList.Spec.Grants.Roles = []string{"role"}
+
+			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, "scoped access lists cannot grant unscoped roles")
+		})
+
+		t.Run("owner unscoped role grants are rejected", func(t *testing.T) {
+			accessList := newScopedAccessList("test_scoped_access_list_owner_roles")
+			accessList.Spec.OwnerGrants.Roles = []string{"role"}
+
+			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, "scoped access lists cannot grant unscoped roles")
+		})
+
+		t.Run("trait grants are rejected", func(t *testing.T) {
+			accessList := newScopedAccessList("test_scoped_access_list_traits")
+			accessList.Spec.Grants.Traits = map[string][]string{"trait": {"value"}}
+
+			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, "scoped access lists cannot grant traits")
+		})
+
+		t.Run("owner trait grants are rejected", func(t *testing.T) {
+			accessList := newScopedAccessList("test_scoped_access_list_owner_traits")
+			accessList.Spec.OwnerGrants.Traits = map[string][]string{"trait": {"value"}}
+
+			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, "scoped access lists cannot grant traits")
+		})
+
+		t.Run("nested list owners are rejected", func(t *testing.T) {
+			accessList := newScopedAccessList("test_scoped_access_list_owner_list")
+			accessList.Spec.Owners = []accesslist.Owner{{Name: "owner-list", MembershipKind: accesslist.MembershipKindList}}
+
+			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, "access list owners are not yet supported for scoped access lists")
+		})
+
+		t.Run("scoped list owners are rejected", func(t *testing.T) {
+			accessList := newScopedAccessList("test_scoped_access_list_scoped_owner_list")
+			accessList.Spec.Owners = []accesslist.Owner{{Name: "/eng::owner-list", MembershipKind: accesslist.MembershipKindScopedList}}
+
+			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, "access list owners are not yet supported for scoped access lists")
+		})
+
+		t.Run("members are rejected", func(t *testing.T) {
+			accessList := newScopedAccessList("test_scoped_access_list_members")
+			member := newAccessListMember(t, accessList.GetName(), "alice", accesslist.MembershipKindUser, clock)
+
+			err := ValidateAccessListWithMembers(ctx, nil, accessList, []*accesslist.AccessListMember{member}, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, "scoped access list members are not yet supported")
+		})
+	})
+
 	t.Run("scoped role grants are validated", func(t *testing.T) {
 		newScopedAccessList := func(name string) *accesslist.AccessList {
 			accessList := newAccessList(t, name, clock)

--- a/lib/accesslists/validate_test.go
+++ b/lib/accesslists/validate_test.go
@@ -50,16 +50,8 @@ func TestAccessListHierarchyCircularRefsCheck(t *testing.T) {
 	acl3m1 := newAccessListMember(t, acl3.GetName(), acl1.GetName(), accesslist.MembershipKindList, clock)
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members: map[string][]*accesslist.AccessListMember{
-			acl1.GetName(): {acl1m1},
-			acl2.GetName(): {acl2m1},
-			acl3.GetName(): {},
-		},
-		accessLists: map[string]*accesslist.AccessList{
-			acl1.GetName(): acl1,
-			acl2.GetName(): acl2,
-			acl3.GetName(): acl3,
-		},
+		members:     mockAccessListMembers(acl1m1, acl2m1),
+		accessLists: mockAccessLists(acl1, acl2, acl3),
 	}
 
 	// Circular references should not be allowed.
@@ -70,8 +62,8 @@ func TestAccessListHierarchyCircularRefsCheck(t *testing.T) {
 	require.ErrorIs(t, err, ErrCyclicMembership)
 
 	// By removing acl3 as a member of acl2, the relationship should be valid.
-	accessListAndMembersGetter.members[acl2.GetName()] = []*accesslist.AccessListMember{}
-	accessListAndMembersGetter.accessLists[acl3.GetName()].Status.MemberOf = []string{}
+	accessListAndMembersGetter.members[ScopeQualifiedName(acl2)] = []*accesslist.AccessListMember{}
+	accessListAndMembersGetter.accessLists[ScopeQualifiedName(acl3)].Status.MemberOf = []string{}
 	err = ValidateAccessListMember(ctx, acl3, acl3m1, accessListAndMembersGetter)
 	require.NoError(t, err)
 
@@ -92,14 +84,8 @@ func TestAccessListHierarchyCircularRefsCheck(t *testing.T) {
 	acl4.Status.OwnerOf = append(acl4.Status.OwnerOf, acl5.GetName())
 
 	accessListAndMembersGetter = &mockAccessListAndMembersGetter{
-		members: map[string][]*accesslist.AccessListMember{
-			acl4.GetName(): {acl4m1},
-			acl5.GetName(): {},
-		},
-		accessLists: map[string]*accesslist.AccessList{
-			acl4.GetName(): acl4,
-			acl5.GetName(): acl5,
-		},
+		members:     mockAccessListMembers(acl4m1),
+		accessLists: mockAccessLists(acl4, acl5),
 	}
 
 	err = ValidateAccessListWithMembers(ctx, nil, acl5, []*accesslist.AccessListMember{acl4m1}, accessListAndMembersGetter)
@@ -121,25 +107,25 @@ func TestAccessListHierarchyDepthCheck(t *testing.T) {
 	}
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members:     make(map[string][]*accesslist.AccessListMember),
-		accessLists: make(map[string]*accesslist.AccessList),
+		members:     make(map[NormalizedSQN][]*accesslist.AccessListMember),
+		accessLists: make(map[NormalizedSQN]*accesslist.AccessList),
 	}
 
 	// Create members up to MaxAllowedDepth
 	for i := range accesslist.MaxAllowedDepth {
 		member := newAccessListMember(t, acls[i].GetName(), acls[i+1].GetName(), accesslist.MembershipKindList, clock)
 		acls[i+1].Status.MemberOf = append(acls[i+1].Status.MemberOf, acls[i].GetName())
-		accessListAndMembersGetter.members[acls[i].GetName()] = []*accesslist.AccessListMember{member}
-		accessListAndMembersGetter.accessLists[acls[i].GetName()] = acls[i]
+		accessListAndMembersGetter.members[ScopeQualifiedName(acls[i])] = []*accesslist.AccessListMember{member}
+		accessListAndMembersGetter.accessLists[ScopeQualifiedName(acls[i])] = acls[i]
 	}
 	// Set remaining Access Lists' members to empty slices
 	for i := accesslist.MaxAllowedDepth; i < numAcls; i++ {
-		accessListAndMembersGetter.members[acls[i].GetName()] = []*accesslist.AccessListMember{}
-		accessListAndMembersGetter.accessLists[acls[i].GetName()] = acls[i]
+		accessListAndMembersGetter.members[ScopeQualifiedName(acls[i])] = []*accesslist.AccessListMember{}
+		accessListAndMembersGetter.accessLists[ScopeQualifiedName(acls[i])] = acls[i]
 	}
 
 	// Should be valid with existing member < MaxAllowedDepth
-	err := ValidateAccessListMember(ctx, acls[accesslist.MaxAllowedDepth-1], accessListAndMembersGetter.members[acls[accesslist.MaxAllowedDepth-1].GetName()][0], accessListAndMembersGetter)
+	err := ValidateAccessListMember(ctx, acls[accesslist.MaxAllowedDepth-1], accessListAndMembersGetter.members[ScopeQualifiedName(acls[accesslist.MaxAllowedDepth-1])][0], accessListAndMembersGetter)
 	require.NoError(t, err)
 
 	// Now, attempt to add a member that increases the depth beyond MaxAllowedDepth
@@ -521,24 +507,22 @@ func TestAccessListValidateWithMembers_members(t *testing.T) {
 	}
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members: map[string][]*accesslist.AccessListMember{
-			rootAcl.GetName(): {},
+		members: map[NormalizedSQN][]*accesslist.AccessListMember{
+			ScopeQualifiedName(rootAcl): {},
 		},
-		accessLists: map[string]*accesslist.AccessList{
-			rootAcl.GetName(): rootAcl,
-		},
+		accessLists: mockAccessLists(rootAcl),
 	}
 	for i := range accesslist.MaxAllowedDepth + 1 {
 		if i < accesslist.MaxAllowedDepth {
-			accessListAndMembersGetter.members[nestedAcls[i].GetName()] = []*accesslist.AccessListMember{members[i]}
+			accessListAndMembersGetter.members[ScopeQualifiedName(nestedAcls[i])] = []*accesslist.AccessListMember{members[i]}
 		}
-		accessListAndMembersGetter.accessLists[nestedAcls[i].GetName()] = nestedAcls[i]
+		accessListAndMembersGetter.accessLists[ScopeQualifiedName(nestedAcls[i])] = nestedAcls[i]
 	}
 
 	// Should validate successfully, as acl-0 -> acl-10 is a valid hierarchy of depth 10.
 	err := ValidateAccessListWithMembers(ctx, nil, rootAcl, []*accesslist.AccessListMember{}, accessListAndMembersGetter)
 	require.NoError(t, err)
-	err = ValidateAccessListWithMembers(ctx, nil, nestedAcls[0], []*accesslist.AccessListMember{accessListAndMembersGetter.members[nestedAcls[0].GetName()][0]}, accessListAndMembersGetter)
+	err = ValidateAccessListWithMembers(ctx, nil, nestedAcls[0], []*accesslist.AccessListMember{accessListAndMembersGetter.members[ScopeQualifiedName(nestedAcls[0])][0]}, accessListAndMembersGetter)
 	require.NoError(t, err)
 
 	// Calling `ValidateAccessListWithMembers`, with `rootAclm1`, should fail, as it would exceed the maximum nesting depth.
@@ -565,33 +549,33 @@ func TestAccessListValidateWithMembers_members(t *testing.T) {
 	}
 
 	accessListAndMembersGetter = &mockAccessListAndMembersGetter{
-		members:     map[string][]*accesslist.AccessListMember{},
-		accessLists: map[string]*accesslist.AccessList{},
+		members:     map[NormalizedSQN][]*accesslist.AccessListMember{},
+		accessLists: map[NormalizedSQN]*accesslist.AccessList{},
 	}
 
 	// Create the members for the first hierarchy.
 	for i := range Length {
 		member := newAccessListMember(t, nestedAcls1[i].GetName(), nestedAcls1[i+1].GetName(), accesslist.MembershipKindList, clock)
 		nestedAcls1[i+1].Status.MemberOf = append(nestedAcls1[i+1].Status.MemberOf, nestedAcls1[i].GetName())
-		accessListAndMembersGetter.members[nestedAcls1[i].GetName()] = []*accesslist.AccessListMember{member}
-		accessListAndMembersGetter.accessLists[nestedAcls1[i].GetName()] = nestedAcls1[i]
+		accessListAndMembersGetter.members[ScopeQualifiedName(nestedAcls1[i])] = []*accesslist.AccessListMember{member}
+		accessListAndMembersGetter.accessLists[ScopeQualifiedName(nestedAcls1[i])] = nestedAcls1[i]
 	}
 
 	// Create the members for the second hierarchy.
 	for i := range Length {
 		member := newAccessListMember(t, nestedAcls2[i].GetName(), nestedAcls2[i+1].GetName(), accesslist.MembershipKindList, clock)
 		nestedAcls2[i+1].Status.MemberOf = append(nestedAcls2[i+1].Status.MemberOf, nestedAcls2[i].GetName())
-		accessListAndMembersGetter.members[nestedAcls2[i].GetName()] = []*accesslist.AccessListMember{member}
-		accessListAndMembersGetter.accessLists[nestedAcls2[i].GetName()] = nestedAcls2[i]
+		accessListAndMembersGetter.members[ScopeQualifiedName(nestedAcls2[i])] = []*accesslist.AccessListMember{member}
+		accessListAndMembersGetter.accessLists[ScopeQualifiedName(nestedAcls2[i])] = nestedAcls2[i]
 	}
 
 	// For the first hierarchy
 	nestedAcls1Last := nestedAcls1[len(nestedAcls1)-1]
-	accessListAndMembersGetter.accessLists[nestedAcls1Last.GetName()] = nestedAcls1Last
+	accessListAndMembersGetter.accessLists[ScopeQualifiedName(nestedAcls1Last)] = nestedAcls1Last
 
 	// For the second hierarchy
 	nestedAcls2Last := nestedAcls2[len(nestedAcls2)-1]
-	accessListAndMembersGetter.accessLists[nestedAcls2Last.GetName()] = nestedAcls2Last
+	accessListAndMembersGetter.accessLists[ScopeQualifiedName(nestedAcls2Last)] = nestedAcls2Last
 
 	// Should validate successfully when adding another list, as both hierarchies are valid.
 	err = ValidateAccessListWithMembers(ctx, nil, nestedAcls1Last, []*accesslist.AccessListMember{newAccessListMember(t, nestedAcls1Last.GetName(), nestedAcls2Last.GetName(), accesslist.MembershipKindList, clock)}, accessListAndMembersGetter)
@@ -614,9 +598,9 @@ func Test_ValidateAccessListWithMembers_audit(t *testing.T) {
 	var accessList *accesslist.AccessList
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members: map[string][]*accesslist.AccessListMember{},
-		accessLists: map[string]*accesslist.AccessList{
-			accessListName: accessList,
+		members: map[NormalizedSQN][]*accesslist.AccessListMember{},
+		accessLists: map[NormalizedSQN]*accesslist.AccessList{
+			{Name: accessListName}: accessList,
 		},
 	}
 

--- a/lib/accesslists/validate_test.go
+++ b/lib/accesslists/validate_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/header"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 )
 
@@ -50,7 +51,7 @@ func TestAccessListHierarchyCircularRefsCheck(t *testing.T) {
 	acl3m1 := newAccessListMember(t, acl3.GetName(), acl1.GetName(), accesslist.MembershipKindList, clock)
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members:     mockAccessListMembers(acl1m1, acl2m1),
+		members:     mockAccessListMembers(t, acl1m1, acl2m1),
 		accessLists: mockAccessLists(acl1, acl2, acl3),
 	}
 
@@ -84,7 +85,7 @@ func TestAccessListHierarchyCircularRefsCheck(t *testing.T) {
 	acl4.Status.OwnerOf = append(acl4.Status.OwnerOf, acl5.GetName())
 
 	accessListAndMembersGetter = &mockAccessListAndMembersGetter{
-		members:     mockAccessListMembers(acl4m1),
+		members:     mockAccessListMembers(t, acl4m1),
 		accessLists: mockAccessLists(acl4, acl5),
 	}
 
@@ -326,6 +327,101 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 			}
 		})
 
+		t.Run("member list scope hierarchy is validated", func(t *testing.T) {
+			testCases := []struct {
+				name        string
+				listScope   string
+				memberScope string
+				memberKind  string
+				wantErr     string
+			}{
+				{
+					name:        "unscoped list can be member of scoped list",
+					listScope:   "/eng/platform",
+					memberScope: "",
+					memberKind:  accesslist.MembershipKindList,
+				},
+				{
+					name:        "same scope member can be member of scoped list",
+					listScope:   "/eng/platform",
+					memberScope: "/eng/platform",
+					memberKind:  accesslist.MembershipKindScopedList,
+				},
+				{
+					name:        "ancestor scope member can be member of scoped list",
+					listScope:   "/eng/platform",
+					memberScope: "/eng",
+					memberKind:  accesslist.MembershipKindScopedList,
+				},
+				{
+					name:        "descendant scope member is rejected",
+					listScope:   "/eng/platform",
+					memberScope: "/eng/platform/team",
+					memberKind:  accesslist.MembershipKindScopedList,
+					wantErr:     "because it is not at an equal or ancestor scope",
+				},
+				{
+					name:        "sibling scope member is rejected",
+					listScope:   "/eng/platform",
+					memberScope: "/eng/infra",
+					memberKind:  accesslist.MembershipKindScopedList,
+					wantErr:     "because it is not at an equal or ancestor scope",
+				},
+				{
+					name:        "unscoped list cannot have scoped member",
+					listScope:   "",
+					memberScope: "/eng",
+					memberKind:  accesslist.MembershipKindScopedList,
+					wantErr:     "because scoped access lists cannot be members or owners of unscoped access lists",
+				},
+			}
+
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					parentList := newScopedAccessList("parent-list")
+					parentList.Scope = tc.listScope
+					memberList := newScopedAccessList("member-list")
+					memberList.Scope = tc.memberScope
+
+					parentListName := ScopeQualifiedName(parentList)
+					memberName := ScopeQualifiedName(memberList)
+
+					memberResource, err := accesslist.NewAccessListMemberWithScope(
+						header.Metadata{
+							Name: memberName.String(),
+						},
+						accesslist.AccessListMemberSpec{
+							AccessList:     parentListName.String(),
+							Name:           memberName.String(),
+							MembershipKind: tc.memberKind,
+							Joined:         clock.Now().UTC(),
+							Expires:        clock.Now().UTC().Add(24 * time.Hour),
+							Reason:         "because",
+							AddedBy:        "tester",
+						},
+						tc.listScope,
+					)
+					require.NoError(t, err)
+
+					getter := &mockAccessListAndMembersGetter{
+						accessLists: mockAccessLists(parentList, memberList),
+					}
+					err = ValidateAccessListWithMembers(
+						ctx,
+						nil, // existingList
+						parentList,
+						[]*accesslist.AccessListMember{memberResource},
+						getter,
+					)
+					if tc.wantErr != "" {
+						require.ErrorContains(t, err, tc.wantErr)
+						return
+					}
+					require.NoError(t, err)
+				})
+			}
+		})
+
 		t.Run("owner list scope hierarchy is validated", func(t *testing.T) {
 			testCases := []struct {
 				name       string
@@ -457,12 +553,76 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 			require.ErrorContains(t, err, "scoped access lists cannot grant traits")
 		})
 
-		t.Run("members are rejected", func(t *testing.T) {
+		t.Run("mismatched member scope is rejected", func(t *testing.T) {
 			accessList := newScopedAccessList("test_scoped_access_list_members")
 			member := newAccessListMember(t, accessList.GetName(), "alice", accesslist.MembershipKindUser, clock)
+			member.Scope = "/other/scope"
 
 			err := ValidateAccessListWithMembers(ctx, nil, accessList, []*accesslist.AccessListMember{member}, &mockAccessListAndMembersGetter{})
-			require.ErrorContains(t, err, "scoped access list members are not yet supported")
+			require.ErrorContains(t, err, `member resource scope "/other/scope" must be equal to parent list scope "/eng"`)
+		})
+
+		t.Run("mismatched member access list scope is rejected", func(t *testing.T) {
+			accessList := newScopedAccessList("test_scoped_access_list_members")
+			member, err := accesslist.NewAccessListMemberWithScope(
+				header.Metadata{Name: "alice"},
+				accesslist.AccessListMemberSpec{
+					AccessList:     "/other::" + accessList.GetName(),
+					Name:           "alice",
+					MembershipKind: accesslist.MembershipKindUser,
+					Joined:         clock.Now().UTC(),
+					Expires:        clock.Now().UTC().Add(24 * time.Hour),
+					Reason:         "because",
+					AddedBy:        "tester",
+				},
+				accessList.GetScope(),
+			)
+			require.NoError(t, err)
+
+			err = ValidateAccessListWithMembers(ctx, nil, accessList, []*accesslist.AccessListMember{member}, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, `member spec.access_list "/other::test_scoped_access_list_members" must match parent list name "/eng::test_scoped_access_list_members"`)
+		})
+
+		t.Run("plain list kind with scoped member name is rejected", func(t *testing.T) {
+			accessList := newScopedAccessList("test_scoped_access_list_members")
+			member, err := accesslist.NewAccessListMemberWithScope(
+				header.Metadata{Name: "/eng::member-list"},
+				accesslist.AccessListMemberSpec{
+					AccessList:     ScopeQualifiedName(accessList).String(),
+					Name:           "/eng::member-list",
+					MembershipKind: accesslist.MembershipKindList,
+					Joined:         clock.Now().UTC(),
+					Expires:        clock.Now().UTC().Add(24 * time.Hour),
+					Reason:         "because",
+					AddedBy:        "tester",
+				},
+				accessList.GetScope(),
+			)
+			require.NoError(t, err)
+
+			err = ValidateAccessListWithMembers(ctx, nil, accessList, []*accesslist.AccessListMember{member}, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, `access list /eng::member-list not found`)
+		})
+
+		t.Run("scoped list kind with plain member name is rejected", func(t *testing.T) {
+			accessList := newScopedAccessList("test_scoped_access_list_members")
+			member, err := accesslist.NewAccessListMemberWithScope(
+				header.Metadata{Name: "member-list"},
+				accesslist.AccessListMemberSpec{
+					AccessList:     ScopeQualifiedName(accessList).String(),
+					Name:           "member-list",
+					MembershipKind: accesslist.MembershipKindScopedList,
+					Joined:         clock.Now().UTC(),
+					Expires:        clock.Now().UTC().Add(24 * time.Hour),
+					Reason:         "because",
+					AddedBy:        "tester",
+				},
+				accessList.GetScope(),
+			)
+			require.NoError(t, err)
+
+			err = ValidateAccessListWithMembers(ctx, nil, accessList, []*accesslist.AccessListMember{member}, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, `scope-qualified name "member-list" missing "::" separator`)
 		})
 	})
 

--- a/lib/accesslists/validate_test.go
+++ b/lib/accesslists/validate_test.go
@@ -280,6 +280,57 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("granted scoped role origin must be equal or ancestor", func(t *testing.T) {
+			testCases := []struct {
+				name          string
+				scopeOfOrigin string
+				wantErr       string
+			}{
+				{
+					name:          "equal scope is allowed",
+					scopeOfOrigin: "/eng/platform",
+				},
+				{
+					name:          "descendant scope is rejected",
+					scopeOfOrigin: "/eng/platform/team",
+					wantErr:       `cannot grant "/eng/platform/team::role" because it is not defined in a scope equal or ancestor to the list's scope "/eng/platform"`,
+				},
+				{
+					name:          "ancestor scope is allowed",
+					scopeOfOrigin: "/eng",
+				},
+				{
+					name:          "sibling scope is rejected",
+					scopeOfOrigin: "/eng/infra",
+					wantErr:       `cannot grant "/eng/infra::role" because it is not defined in a scope equal or ancestor to the list's scope "/eng/platform"`,
+				},
+				{
+					name:          "root scope is allowed",
+					scopeOfOrigin: "/",
+				},
+			}
+
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					accessList := newScopedAccessList("test_scoped_access_list_grant_scope")
+					accessList.Scope = "/eng/platform"
+					accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{
+						{
+							Role:  NormalizedSQN{Scope: tc.scopeOfOrigin, Name: "role"}.String(),
+							Scope: "/eng/platform/team",
+						},
+					}
+
+					err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+					if tc.wantErr != "" {
+						require.ErrorContains(t, err, tc.wantErr)
+						return
+					}
+					require.NoError(t, err)
+				})
+			}
+		})
+
 		t.Run("scoped role grant scope must be equal or descendant", func(t *testing.T) {
 			testCases := []struct {
 				name       string
@@ -307,7 +358,7 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 				{
 					name:       "root scope is rejected",
 					grantScope: "/",
-					wantErr:    "root scope cannot be used as a scope of effect",
+					wantErr:    `root scope cannot be used as a scope of effect`,
 				},
 			}
 
@@ -315,7 +366,9 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 				t.Run(tc.name, func(t *testing.T) {
 					accessList := newScopedAccessList("test_scoped_access_list_grant_scope")
 					accessList.Scope = "/eng/platform"
-					accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role", Scope: tc.grantScope}}
+					accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{
+						{Role: "/eng/platform::role", Scope: tc.grantScope},
+					}
 
 					err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
 					if tc.wantErr != "" {
@@ -499,7 +552,7 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 		t.Run("owner scoped role grant scope must be equal or descendant", func(t *testing.T) {
 			accessList := newScopedAccessList("test_scoped_access_list_owner_grant_scope")
 			accessList.Scope = "/eng/platform"
-			accessList.Spec.OwnerGrants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role", Scope: "/eng"}}
+			accessList.Spec.OwnerGrants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "/::role", Scope: "/eng"}}
 
 			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
 			require.ErrorContains(t, err, `scoped role grant has scope "/eng" that is not a sub-scope of the access list's scope "/eng/platform"`)
@@ -639,7 +692,7 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 		t.Run("scoped roles conflict with membership requires", func(t *testing.T) {
 			accessList := newScopedAccessList("test_access_list_membership_requires")
 			accessList.Spec.MembershipRequires = accesslist.Requires{Roles: []string{"member-role"}}
-			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role-a", Scope: "/eng"}}
+			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "/::role-a", Scope: "/eng"}}
 
 			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
 			require.ErrorContains(t, err, "cannot contain both scoped_role grants")
@@ -648,7 +701,7 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 		t.Run("scoped roles conflict with ownership requires", func(t *testing.T) {
 			accessList := newScopedAccessList("test_access_list_ownership_requires")
 			accessList.Spec.OwnershipRequires = accesslist.Requires{Roles: []string{"owner-role"}}
-			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role-a", Scope: "/eng"}}
+			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "/::role-a", Scope: "/eng"}}
 
 			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
 			require.ErrorContains(t, err, "cannot contain both scoped_role grants")
@@ -665,7 +718,7 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 
 		t.Run("empty scoped role scope is rejected", func(t *testing.T) {
 			accessList := newScopedAccessList("test_access_list_empty_scope")
-			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role-a"}}
+			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "/::role-a"}}
 
 			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
 			require.ErrorContains(t, err, "validating grants.scoped_roles[0]")
@@ -674,18 +727,18 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 
 		t.Run("invalid scoped role scope syntax is rejected", func(t *testing.T) {
 			accessList := newScopedAccessList("test_access_list_invalid_scope")
-			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role-a", Scope: "not-a-scope"}}
+			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "/::role-a", Scope: "not-a-scope"}}
 
 			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
 			require.ErrorContains(t, err, "validating grants.scoped_roles[0]")
-			require.ErrorContains(t, err, "validating scope")
+			require.ErrorContains(t, err, "validating granted scope")
 		})
 
 		t.Run("too many unique scoped role grants are rejected", func(t *testing.T) {
 			accessList := newScopedAccessList("test_access_list_too_many_scoped_roles")
 			for i := range scopedaccess.MaxRolesPerAssignment + 1 {
 				accessList.Spec.Grants.ScopedRoles = append(accessList.Spec.Grants.ScopedRoles, accesslist.ScopedRoleGrant{
-					Role:  fmt.Sprintf("role-%02d", i),
+					Role:  fmt.Sprintf("/::role-%02d", i),
 					Scope: "/eng",
 				})
 			}
@@ -696,7 +749,7 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 
 		t.Run("valid owner grants scoped roles pass validation", func(t *testing.T) {
 			accessList := newScopedAccessList("test_access_list_valid_owner_scoped_roles")
-			accessList.Spec.OwnerGrants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "owner-role", Scope: "/eng"}}
+			accessList.Spec.OwnerGrants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "/::owner-role", Scope: "/eng"}}
 
 			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
 			require.NoError(t, err)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1374,7 +1374,11 @@ func (a *ServerWithRoles) hasWatchPermissionForKind(
 // resources is only meaningful for these kinds.
 func supportedScopedWatchKind(kind string) bool {
 	switch kind {
-	case scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment:
+	case types.KindAccessList,
+		types.KindAccessListMember,
+		types.KindAccessListReview,
+		scopedaccess.KindScopedRole,
+		scopedaccess.KindScopedRoleAssignment:
 		return true
 	default:
 		return false

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -1371,15 +1371,25 @@ type Cache interface {
 	ListAccessListsV2(context.Context, *accesslistv1.ListAccessListsV2Request) ([]*accesslist.AccessList, string, error)
 	// GetAccessList returns the specified access list resource.
 	GetAccessList(context.Context, string) (*accesslist.AccessList, error)
+	// GetAccessListV2 returns the specified access list resource.
+	GetAccessListV2(context.Context, *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error)
 
 	// CountAccessListMembers will count all access list members.
 	CountAccessListMembers(ctx context.Context, accessListName string) (users uint32, lists uint32, err error)
+	// CountAccessListMembersV2 will count all access list members.
+	CountAccessListMembersV2(ctx context.Context, req *accesslistv1.CountAccessListMembersRequest) (users uint32, lists uint32, err error)
 	// ListAccessListMembers returns a paginated list of all access list members.
 	ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
+	// ListAccessListMembersV2 returns a paginated list of all access list members.
+	ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error)
 	// ListAllAccessListMembers returns a paginated list of all members of all access lists.
 	ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
+	// ListAllAccessListMembersV2 returns a paginated list of all members of all access lists.
+	ListAllAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAllAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error)
 	// GetAccessListMember returns the specified access list member resource.
 	GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error)
+	// GetAccessListMemberV2 returns the specified access list member resource.
+	GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error)
 
 	// GetAccessListOwners returns a list of owners for a particular access list.
 	GetAccessListOwners(ctx context.Context, accessList string) ([]*accesslist.Owner, error)

--- a/lib/auth/userloginstate/generator.go
+++ b/lib/auth/userloginstate/generator.go
@@ -270,6 +270,7 @@ func (g *Generator) addAccessListsToState(ctx context.Context, user types.User, 
 	h, err := accesslists.NewHierarchy(accesslists.HierarchyConfig{
 		AccessListsService: g.accessLists,
 		Clock:              g.clock,
+		IgnoreScoped:       true,
 	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/lib/backend/key.go
+++ b/lib/backend/key.go
@@ -124,6 +124,22 @@ func (k Key) TrimPrefix(prefix Key) Key {
 	return KeyFromString(key)
 }
 
+// CutPrefix returns the key without the provided leading prefix string
+// and reports whether it found the prefix.
+// If the key doesn't start with prefix, CutPrefix returns k, false.
+// If prefix is the empty string, CutPrefix returns k, true.
+func (k Key) CutPrefix(prefix Key) (after Key, found bool) {
+	key, found := strings.CutPrefix(k.s, prefix.s)
+	if !found {
+		return k, false
+	}
+	if key == "" {
+		return Key{}, true
+	}
+
+	return KeyFromString(key), true
+}
+
 // PrependKey returns a new [Key] that joins p and k
 // with the components of p followed by the components from k.
 func (k Key) PrependKey(p Key) Key {

--- a/lib/backend/key_test.go
+++ b/lib/backend/key_test.go
@@ -391,6 +391,55 @@ func TestKeyTrimPrefix(t *testing.T) {
 	}
 }
 
+func TestKeyCutPrefix(t *testing.T) {
+	tests := []struct {
+		name          string
+		key           backend.Key
+		prefix        backend.Key
+		expectedAfter backend.Key
+		expectedFound bool
+	}{
+		{
+			name:          "empty key with empty prefix",
+			expectedFound: true,
+		},
+		{
+			name:          "empty prefix matches",
+			key:           backend.NewKey("a", "b"),
+			expectedAfter: backend.NewKey("a", "b"),
+			expectedFound: true,
+		},
+		{
+			name:          "non-matching prefix returns original key",
+			key:           backend.NewKey("a", "b"),
+			prefix:        backend.NewKey("c", "d"),
+			expectedAfter: backend.NewKey("a", "b"),
+		},
+		{
+			name:          "matching prefix returns remaining key",
+			key:           backend.NewKey("a", "b", "c"),
+			prefix:        backend.ExactKey("a", "b"),
+			expectedAfter: backend.KeyFromString("c"),
+			expectedFound: true,
+		},
+		{
+			name:          "exact match returns empty key",
+			key:           backend.NewKey("a", "b"),
+			prefix:        backend.NewKey("a", "b"),
+			expectedAfter: backend.Key{},
+			expectedFound: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			after, found := test.key.CutPrefix(test.prefix)
+			assert.Equal(t, test.expectedAfter, after)
+			assert.Equal(t, test.expectedFound, found)
+		})
+	}
+}
+
 func TestKeyPrependKey(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/lib/cache/access_list.go
+++ b/lib/cache/access_list.go
@@ -20,15 +20,18 @@ import (
 	"context"
 
 	"github.com/gravitational/trace"
+	"rsc.io/ordered"
 
 	"github.com/gravitational/teleport/api/defaults"
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/accesslists"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils/sortcache"
 )
@@ -45,6 +48,10 @@ func newAccessListCollection(upstream services.AccessLists, w types.WatchKind) (
 	if upstream == nil {
 		return nil, trace.BadParameter("missing parameter AccessLists")
 	}
+	scopeFilter := w.ScopeFilter.ToProto()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	return &collection[*accesslist.AccessList, accessListIndex]{
 		store: newStore(
@@ -59,9 +66,18 @@ func newAccessListCollection(upstream services.AccessLists, w types.WatchKind) (
 				accessListAuditNextDateIndex: services.AccessListAuditDateIndexKey,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*accesslist.AccessList, error) {
-			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListAccessLists))
+			out, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessList, string, error) {
+				return upstream.ListAccessListsV2(ctx, accesslistv1.ListAccessListsV2Request_builder{
+					PageSize:    int32(pageSize),
+					PageToken:   pageToken,
+					ScopeFilter: scopeFilter,
+				}.Build())
+			}))
 			return out, trace.Wrap(err)
 		},
+		// Note: scoped access list refs are never sent in a ResourceHeader, they
+		// use *accesslist.AccessList for delete events, so this transform will
+		// not apply to scoped access lists.
 		headerTransform: func(hdr *types.ResourceHeader) *accesslist.AccessList {
 			return &accesslist.AccessList{
 				ResourceHeader: header.ResourceHeader{
@@ -77,7 +93,7 @@ func newAccessListCollection(upstream services.AccessLists, w types.WatchKind) (
 	}, nil
 }
 
-// GetAccessLists returns a list of all access lists.
+// GetAccessLists returns a list of all unscoped access lists.
 func (c *Cache) GetAccessLists(ctx context.Context) ([]*accesslist.AccessList, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetAccessLists")
 	defer span.End()
@@ -94,7 +110,7 @@ func (c *Cache) GetAccessLists(ctx context.Context) ([]*accesslist.AccessList, e
 	}
 
 	out := make([]*accesslist.AccessList, 0, rg.store.len())
-	for n := range rg.store.resources(accessListNameIndex, "", "") {
+	for n := range rg.store.resources(accessListNameIndex, "", scopes.ResourceCursorScopedStart()) {
 		out = append(out, n.Clone())
 	}
 	return out, nil
@@ -104,6 +120,11 @@ func (c *Cache) GetAccessLists(ctx context.Context) ([]*accesslist.AccessList, e
 func (c *Cache) ListAccessListsV2(ctx context.Context, req *accesslistv1.ListAccessListsV2Request) ([]*accesslist.AccessList, string, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/ListAccessListsV2")
 	defer span.End()
+
+	scopeFilter := req.GetScopeFilter()
+	if err := scopes.ValidateFilter(req.GetScopeFilter()); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
 
 	index := accessListNameIndex
 
@@ -133,7 +154,7 @@ func (c *Cache) ListAccessListsV2(ctx context.Context, req *accesslistv1.ListAcc
 			return c.Config.AccessLists.ListAccessListsV2(ctx, req)
 		},
 		filter: func(al *accesslist.AccessList) bool {
-			return services.MatchAccessList(al, req.GetFilter())
+			return services.MatchAccessList(al, req.GetFilter()) && scopes.MatchScope(scopeFilter, al.GetScope())
 		},
 		nextToken: func(al *accesslist.AccessList) string {
 			// ignore error because CreateAccessListNextKey only errors
@@ -161,13 +182,20 @@ func (c *Cache) ListAccessLists(ctx context.Context, pageSize int, pageToken str
 			return t.GetMetadata().Name
 		},
 	}
-	out, next, err := lister.list(ctx, pageSize, pageToken)
+	out, next, err := lister.listRange(ctx, pageSize, pageToken, scopes.ResourceCursorScopedStart())
 	return out, next, trace.Wrap(err)
 }
 
 // GetAccessList returns the specified access list resource.
 func (c *Cache) GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/GetAccessList")
+	return c.GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Name: name,
+	}.Build())
+}
+
+// GetAccessListV2 returns the specified access list resource.
+func (c *Cache) GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetAccessListV2")
 	defer span.End()
 
 	var upstreamRead bool
@@ -177,14 +205,17 @@ func (c *Cache) GetAccessList(ctx context.Context, name string) (*accesslist.Acc
 		index:      accessListNameIndex,
 		upstreamGet: func(ctx context.Context, s string) (*accesslist.AccessList, error) {
 			upstreamRead = true
-			return c.Config.AccessLists.GetAccessList(ctx, s)
+			return c.Config.AccessLists.GetAccessListV2(ctx, req)
 		},
 	}
-	out, err := getter.get(ctx, name)
+	out, err := getter.get(ctx, accessListCursor(scopes.QualifiedName{
+		Scope: req.GetScope(),
+		Name:  req.GetName(),
+	}))
 	if trace.IsNotFound(err) && !upstreamRead {
 		// fallback is sane because method is never used
 		// in construction of derivative caches.
-		if item, err := c.Config.AccessLists.GetAccessList(ctx, name); err == nil {
+		if item, err := c.Config.AccessLists.GetAccessListV2(ctx, req); err == nil {
 			return item, nil
 		}
 	}
@@ -199,12 +230,48 @@ const (
 )
 
 func accessListMemberNameIndexKey(r *accesslist.AccessListMember) string {
-	return r.Spec.AccessList + "/" + r.GetName()
+	if r.GetScope() == "" {
+		return r.Spec.AccessList + "/" + r.GetName()
+	}
+	listSQN, listErr := accesslists.ParentListOf(r)
+	memberSQN, memberErr := accesslists.MemberScopeQualifiedName(r)
+	if listErr != nil || memberErr != nil {
+		return "~invalid/" + base32Encode(string(ordered.Encode(r.Spec.AccessList, r.GetName())))
+	}
+	return namedAccessListMemberNameIndexKey(listSQN.ToScopesQualifiedName(), memberSQN.ToScopesQualifiedName())
+}
+
+func namedAccessListMemberNameIndexKey(listName, memberName scopes.QualifiedName) string {
+	return scopes.MakeNestedResourceCursor(listName, memberName)
+}
+
+func accessListCursor(listName scopes.QualifiedName) string {
+	return scopes.MakeResourceCursor(listName.Scope, listName.Name)
+}
+
+func accessListMemberKindIndexKey(r *accesslist.AccessListMember) string {
+	if r.GetScope() == "" {
+		return r.Spec.AccessList + "/" + r.Spec.MembershipKind + "/" + r.GetName()
+	}
+
+	listSQN, listErr := scopes.ParseQualifiedName(r.Spec.AccessList)
+	memberSQN, memberErr := accesslists.MemberScopeQualifiedName(r)
+	if listErr != nil || memberErr != nil {
+		return "~invalid/" + base32Encode(string(ordered.Encode(r.Spec.AccessList, r.Spec.MembershipKind, r.GetName())))
+	}
+
+	listCursor := scopes.MakeResourceCursor(listSQN.Scope, listSQN.Name)
+	encodedMemberScope := scopes.EncodeForResourceCursor(memberSQN.Scope)
+	return listCursor + "/" + r.Spec.MembershipKind + "/" + encodedMemberScope + "/" + memberSQN.Name
 }
 
 func newAccessListMemberCollection(upstream services.AccessLists, w types.WatchKind) (*collection[*accesslist.AccessListMember, accessListMemberIndex], error) {
 	if upstream == nil {
 		return nil, trace.BadParameter("missing parameter AccessLists")
+	}
+	scopeFilter := w.ScopeFilter.ToProto()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	return &collection[*accesslist.AccessListMember, accessListMemberIndex]{
@@ -212,17 +279,22 @@ func newAccessListMemberCollection(upstream services.AccessLists, w types.WatchK
 			types.KindAccessListMember,
 			(*accesslist.AccessListMember).Clone,
 			map[accessListMemberIndex]func(*accesslist.AccessListMember) string{
-				accessListMemberNameIndex: func(r *accesslist.AccessListMember) string {
-					return accessListMemberNameIndexKey(r)
-				},
-				accessListMemberKindIndex: func(r *accesslist.AccessListMember) string {
-					return r.Spec.AccessList + "/" + r.Spec.MembershipKind + "/" + r.GetName()
-				},
+				accessListMemberNameIndex: accessListMemberNameIndexKey,
+				accessListMemberKindIndex: accessListMemberKindIndexKey,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*accesslist.AccessListMember, error) {
-			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListAllAccessListMembers))
+			out, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+				return upstream.ListAllAccessListMembersV2(ctx, accesslistv1.ListAllAccessListMembersRequest_builder{
+					PageSize:    int32(pageSize),
+					PageToken:   pageToken,
+					ScopeFilter: scopeFilter,
+				}.Build())
+			}))
 			return out, trace.Wrap(err)
 		},
+		// Note: scoped member refs are never sent in a ResourceHeader, they
+		// use *accesslist.AccessListMember for delete events, so this
+		// transform will not apply to scoped members.
 		headerTransform: func(hdr *types.ResourceHeader) *accesslist.AccessListMember {
 			return &accesslist.AccessListMember{
 				ResourceHeader: header.ResourceHeader{
@@ -243,7 +315,14 @@ func newAccessListMemberCollection(upstream services.AccessLists, w types.WatchK
 
 // CountAccessListMembers will count all access list members.
 func (c *Cache) CountAccessListMembers(ctx context.Context, accessListName string) (uint32, uint32, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/CountAccessListMembers")
+	return c.CountAccessListMembersV2(ctx, accesslistv1.CountAccessListMembersRequest_builder{
+		AccessListName: accessListName,
+	}.Build())
+}
+
+// CountAccessListMembersV2 will count all access list members.
+func (c *Cache) CountAccessListMembersV2(ctx context.Context, req *accesslistv1.CountAccessListMembersRequest) (uint32, uint32, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/CountAccessListMembersV2")
 	defer span.End()
 
 	rg, err := acquireReadGuard(c, c.collections.accessListMembers)
@@ -253,23 +332,40 @@ func (c *Cache) CountAccessListMembers(ctx context.Context, accessListName strin
 	defer rg.Release()
 
 	if !rg.ReadCache() {
-		count, listCount, err := c.Config.AccessLists.CountAccessListMembers(ctx, accessListName)
+		count, listCount, err := c.Config.AccessLists.CountAccessListMembersV2(ctx, req)
 		return count, listCount, trace.Wrap(err)
 	}
 
-	startUserKey := accessListName + "/" + accesslist.MembershipKindUser + "/"
+	listCursor := accessListCursor(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessListName(),
+	})
+
+	startUserKey := listCursor + "/" + accesslist.MembershipKindUser + "/"
 	endUserKey := sortcache.NextKey(startUserKey)
 	userCount := uint32(rg.store.count(accessListMemberKindIndex, startUserKey, endUserKey))
 
-	startListKey := accessListName + "/" + accesslist.MembershipKindList + "/"
+	startListKey := listCursor + "/" + accesslist.MembershipKindList + "/"
 	endListKey := sortcache.NextKey(startListKey)
 	listCount := uint32(rg.store.count(accessListMemberKindIndex, startListKey, endListKey))
+	startScopedListKey := listCursor + "/" + accesslist.MembershipKindScopedList + "/"
+	endScopedListKey := sortcache.NextKey(startScopedListKey)
+	listCount += uint32(rg.store.count(accessListMemberKindIndex, startScopedListKey, endScopedListKey))
 
 	return userCount, listCount, nil
 }
 
 // ListAccessListMembers returns a paginated list of all access list members.
 func (c *Cache) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error) {
+	return c.ListAccessListMembersV2(ctx, accesslistv1.ListAccessListMembersRequest_builder{
+		AccessList: accessListName,
+		PageSize:   int32(pageSize),
+		PageToken:  pageToken,
+	}.Build())
+}
+
+// ListAccessListMembersV2 returns a paginated list of all access list members.
+func (c *Cache) ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/ListAccessListMembers")
 	defer span.End()
 
@@ -280,21 +376,27 @@ func (c *Cache) ListAccessListMembers(ctx context.Context, accessListName string
 	defer rg.Release()
 
 	if !rg.ReadCache() {
-		out, next, err := c.Config.AccessLists.ListAccessListMembers(ctx, accessListName, pageSize, pageToken)
+		out, next, err := c.Config.AccessLists.ListAccessListMembersV2(ctx, req)
 		return out, next, trace.Wrap(err)
 	}
 
-	return listAccessListMembers(rg.store, accessListName, pageSize, pageToken)
+	return listAccessListMembers(rg.store, req)
 }
 
-func listAccessListMembers(store *store[*accesslist.AccessListMember, accessListMemberIndex], accessListName string, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+func listAccessListMembers(store *store[*accesslist.AccessListMember, accessListMemberIndex], req *accesslistv1.ListAccessListMembersRequest) ([]*accesslist.AccessListMember, string, error) {
+	listCursor := accessListCursor(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+
 	// The ending "/" is very important here, otherwise we can start listing members of access
 	// lists which names are prefixed with this access list name. E.g. we'd list members of
 	// "dev-suffix" for list "dev".
-	start := accessListName + "/"
-	current := start + pageToken
+	start := listCursor + "/"
+	current := start + req.GetPageToken()
 	end := sortcache.NextKey(start)
 
+	pageSize := int(req.GetPageSize())
 	if pageSize <= 0 {
 		pageSize = defaults.DefaultChunkSize
 	}
@@ -302,7 +404,8 @@ func listAccessListMembers(store *store[*accesslist.AccessListMember, accessList
 	var out []*accesslist.AccessListMember
 	for member := range store.resources(accessListMemberNameIndex, current, end) {
 		if len(out) == pageSize {
-			return out, member.GetName(), nil
+			key := accessListMemberNameIndexKey(member)
+			return out, key[len(start):], nil
 		}
 
 		out = append(out, member.Clone())
@@ -313,25 +416,55 @@ func listAccessListMembers(store *store[*accesslist.AccessListMember, accessList
 
 // ListAllAccessListMembers returns a paginated list of all access list members for all access lists.
 func (c *Cache) ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/ListAllAccessListMembers")
+	return c.ListAllAccessListMembersV2(ctx, accesslistv1.ListAllAccessListMembersRequest_builder{
+		PageSize:  int32(pageSize),
+		PageToken: pageToken,
+		ScopeFilter: scopesv1.Filter_builder{
+			Mode: scopesv1.Mode_MODE_UNSCOPED,
+		}.Build(),
+	}.Build())
+
+}
+
+// ListAllAccessListMembersV2 returns a paginated list of all access list members for all access lists.
+func (c *Cache) ListAllAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAllAccessListMembersRequest) ([]*accesslist.AccessListMember, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListAllAccessListMembersV2")
 	defer span.End()
+
+	scopeFilter := req.GetScopeFilter()
+	if err := scopes.ValidateFilter(req.GetScopeFilter()); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
 
 	lister := genericLister[*accesslist.AccessListMember, accessListMemberIndex]{
 		cache:           c,
 		collection:      c.collections.accessListMembers,
 		index:           accessListMemberNameIndex,
 		defaultPageSize: 200,
-		upstreamList:    c.Config.AccessLists.ListAllAccessListMembers,
+		upstreamList: func(ctx context.Context, _ int, _ string) ([]*accesslist.AccessListMember, string, error) {
+			return c.Config.AccessLists.ListAllAccessListMembersV2(ctx, req)
+		},
 		nextToken: func(t *accesslist.AccessListMember) string {
 			return accessListMemberNameIndexKey(t)
 		},
+		filter: func(member *accesslist.AccessListMember) bool {
+			return scopes.MatchScope(scopeFilter, member.GetScope())
+		},
 	}
-	out, next, err := lister.list(ctx, pageSize, pageToken)
+	out, next, err := lister.list(ctx, int(req.GetPageSize()), req.GetPageToken())
 	return out, next, trace.Wrap(err)
 }
 
 // GetAccessListMember returns the specified access list member resource.
 func (c *Cache) GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error) {
+	return c.GetAccessListMemberV2(ctx, accesslistv1.GetAccessListMemberRequest_builder{
+		AccessList: accessList,
+		MemberName: memberName,
+	}.Build())
+}
+
+// GetAccessListMemberV2 returns the specified access list member resource.
+func (c *Cache) GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetAccessListMember")
 	defer span.End()
 
@@ -342,11 +475,21 @@ func (c *Cache) GetAccessListMember(ctx context.Context, accessList string, memb
 	defer rg.Release()
 
 	if !rg.ReadCache() {
-		out, err := c.Config.AccessLists.GetAccessListMember(ctx, accessList, memberName)
+		out, err := c.Config.AccessLists.GetAccessListMemberV2(ctx, req)
 		return out, trace.Wrap(err)
 	}
 
-	member, err := rg.store.get(accessListMemberNameIndex, accessList+"/"+memberName)
+	listName := scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	}
+	memberName := scopes.QualifiedName{
+		Scope: req.GetMemberScope(),
+		Name:  req.GetMemberName(),
+	}
+	key := namedAccessListMemberNameIndexKey(listName, memberName)
+
+	member, err := rg.store.get(accessListMemberNameIndex, key)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -359,15 +502,33 @@ type accessListMembersListerStore struct {
 
 // ListAccessListMembers implements [accesslists.AccessListMembersLister].
 func (l accessListMembersListerStore) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error) {
-	return listAccessListMembers(l.store, accessListName, pageSize, pageToken)
+	return listAccessListMembers(l.store, accesslistv1.ListAccessListMembersRequest_builder{
+		AccessList: accessListName,
+		PageSize:   int32(pageSize),
+		PageToken:  pageToken,
+	}.Build())
+}
+
+func (l accessListMembersListerStore) ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error) {
+	return listAccessListMembers(l.store, req)
 }
 
 // GetAccessListOwners returns the owners of the specified access list, including those inherited.
 func (c *Cache) GetAccessListOwners(ctx context.Context, accessListName string) ([]*accesslist.Owner, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/GetAccessListOwners")
+	return c.GetAccessListOwnersV2(ctx, accesslistv1.GetAccessListOwnersRequest_builder{
+		AccessList: accessListName,
+	}.Build())
+}
+
+// GetAccessListOwnersV2 returns the owners of the specified access list, including those inherited.
+func (c *Cache) GetAccessListOwnersV2(ctx context.Context, req *accesslistv1.GetAccessListOwnersRequest) ([]*accesslist.Owner, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetAccessListOwnersV2")
 	defer span.End()
 
-	accessList, err := c.GetAccessList(ctx, accessListName)
+	accessList, err := c.GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -389,9 +550,27 @@ type accessListReviewIndex string
 
 const accessListReviewNameIndex = "name"
 
+func accessListReviewNameIndexKey(r *accesslist.Review) string {
+	if r.GetScope() == "" {
+		return r.Spec.AccessList + "/" + r.GetName()
+	}
+
+	listSQN, err := accesslists.ReviewedList(r)
+	if err != nil {
+		return "~invalid/" + base32Encode(string(ordered.Encode(r.Spec.AccessList, r.GetName())))
+	}
+
+	listCursor := accessListCursor(listSQN.ToScopesQualifiedName())
+	return listCursor + "/" + r.GetName()
+}
+
 func newAccessListReviewCollection(upstream services.AccessLists, w types.WatchKind) (*collection[*accesslist.Review, accessListReviewIndex], error) {
 	if upstream == nil {
 		return nil, trace.BadParameter("missing parameter AccessLists")
+	}
+	scopeFilter := w.ScopeFilter.ToProto()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	return &collection[*accesslist.Review, accessListReviewIndex]{
@@ -399,14 +578,21 @@ func newAccessListReviewCollection(upstream services.AccessLists, w types.WatchK
 			types.KindAccessListReview,
 			(*accesslist.Review).Clone,
 			map[accessListReviewIndex]func(*accesslist.Review) string{
-				accessListReviewNameIndex: func(r *accesslist.Review) string {
-					return r.Spec.AccessList + "/" + r.GetName()
-				},
+				accessListReviewNameIndex: accessListReviewNameIndexKey,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*accesslist.Review, error) {
-			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListAllAccessListReviews))
+			out, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.Review, string, error) {
+				return upstream.ListAllAccessListReviewsV2(ctx, accesslistv1.ListAllAccessListReviewsRequest_builder{
+					PageSize:    int32(pageSize),
+					NextToken:   pageToken,
+					ScopeFilter: scopeFilter,
+				}.Build())
+			}))
 			return out, trace.Wrap(err)
 		},
+		// Note: scoped review refs are never sent in a ResourceHeader, they
+		// use *accesslist.Review for delete events, so this transform will not apply
+		// to scoped reviews.
 		headerTransform: func(hdr *types.ResourceHeader) *accesslist.Review {
 			return &accesslist.Review{
 				ResourceHeader: header.ResourceHeader{
@@ -427,6 +613,15 @@ func newAccessListReviewCollection(upstream services.AccessLists, w types.WatchK
 
 // ListAccessListReviews will list access list reviews for a particular access list.
 func (c *Cache) ListAccessListReviews(ctx context.Context, accessList string, pageSize int, pageToken string) ([]*accesslist.Review, string, error) {
+	return c.ListAccessListReviewsV2(ctx, accesslistv1.ListAccessListReviewsRequest_builder{
+		AccessList: accessList,
+		PageSize:   int32(pageSize),
+		NextToken:  pageToken,
+	}.Build())
+}
+
+// ListAccessListReviewsV2 will list access list reviews for a particular access list.
+func (c *Cache) ListAccessListReviewsV2(ctx context.Context, req *accesslistv1.ListAccessListReviewsRequest) ([]*accesslist.Review, string, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/ListAccessListReviews")
 	defer span.End()
 
@@ -435,21 +630,26 @@ func (c *Cache) ListAccessListReviews(ctx context.Context, accessList string, pa
 		collection:      c.collections.accessListReviews,
 		index:           accessListReviewNameIndex,
 		defaultPageSize: 200,
-		upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.Review, string, error) {
-			reviews, next, err := c.AccessLists.ListAccessListReviews(ctx, accessList, pageSize, pageToken)
-			return reviews, next, trace.Wrap(err)
+		upstreamList: func(ctx context.Context, _ int, _ string) ([]*accesslist.Review, string, error) {
+			return c.AccessLists.ListAccessListReviewsV2(ctx, req)
 		},
 		nextToken: func(t *accesslist.Review) string {
 			return t.GetName()
 		},
 	}
 
-	start := accessList + "/"
+	listCursor := accessListCursor(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+
+	start := listCursor + "/"
 	end := sortcache.NextKey(start)
+	pageToken := req.GetNextToken()
 	if pageToken != "" {
 		start += pageToken
 	}
 
-	out, next, err := lister.listRange(ctx, pageSize, start, end)
+	out, next, err := lister.listRange(ctx, int(req.GetPageSize()), start, end)
 	return out, next, trace.Wrap(err)
 }

--- a/lib/cache/access_list_test.go
+++ b/lib/cache/access_list_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -36,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/accesslists"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 )
 
@@ -638,4 +640,259 @@ func makeMembers(t *testing.T, alName string, count int) []*accesslist.AccessLis
 		members = append(members, newAccessListMember(t, alName, fmt.Sprintf("member-%d", i)))
 	}
 	return members
+}
+
+func TestScopedAccessListsCache(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		p := newTestPack(t, ForAuth)
+		t.Cleanup(p.Close)
+
+		// Create some scoped and unscoped lists in the backend.
+		listNames := []accesslists.NormalizedSQN{
+			{Name: "test1"},
+			{Name: "test2"},
+			{Name: "test3"},
+			{Scope: "/scope1", Name: "test1"},
+			{Scope: "/scope1", Name: "test2"},
+			{Scope: "/scope2", Name: "test3"},
+		}
+		for _, listName := range listNames {
+			list, err := accesslist.NewAccessListWithScope(
+				header.Metadata{
+					Name: listName.Name,
+				},
+				accesslist.Spec{
+					Title:  "test list",
+					Owners: []accesslist.Owner{{Name: "ownername"}},
+				},
+				listName.Scope,
+			)
+			require.NoError(t, err)
+
+			_, err = p.accessLists.UpsertAccessList(t.Context(), list)
+			require.NoError(t, err)
+		}
+
+		collectListNames := func() []accesslists.NormalizedSQN {
+			collectedNames := make([]accesslists.NormalizedSQN, 0, len(listNames))
+			for list, err := range clientutils.Resources(t.Context(), func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessList, string, error) {
+				return p.cache.ListAccessListsV2(t.Context(), accesslistv1.ListAccessListsV2Request_builder{
+					PageSize:  int32(pageSize),
+					PageToken: pageToken,
+				}.Build())
+			}) {
+				require.NoError(t, err)
+				collectedNames = append(collectedNames, accesslists.ScopeQualifiedName(list))
+			}
+			return collectedNames
+		}
+
+		// Assert the cache sees all the created lists, after backend events propagate.
+		synctest.Wait()
+		require.Equal(t, listNames, collectListNames())
+
+		// Delete each list one by one, the cache view should agree.
+		for len(listNames) > 0 {
+			err := p.accessLists.DeleteAccessListV2(t.Context(), accesslistv1.DeleteAccessListRequest_builder{
+				Scope: listNames[0].Scope,
+				Name:  listNames[0].Name,
+			}.Build())
+			require.NoError(t, err)
+
+			synctest.Wait()
+			listNames = listNames[1:]
+			require.Equal(t, listNames, collectListNames())
+		}
+	})
+}
+
+func TestScopedAccessListMembersCache(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		p := newTestPack(t, ForAuth)
+		t.Cleanup(p.Close)
+
+		// Create user and scoped-list members under scoped and unscoped lists.
+		type memberRef struct {
+			parent accesslists.NormalizedSQN
+			member accesslists.NormalizedSQN
+		}
+		memberRefs := []memberRef{
+			{parent: accesslists.NormalizedSQN{Name: "test1"}, member: accesslists.NormalizedSQN{Name: "member"}},
+			{parent: accesslists.NormalizedSQN{Name: "test2"}, member: accesslists.NormalizedSQN{Name: "member"}},
+			{parent: accesslists.NormalizedSQN{Name: "test3"}, member: accesslists.NormalizedSQN{Name: "member"}},
+			{parent: accesslists.NormalizedSQN{Scope: "/scope1", Name: "test1"}, member: accesslists.NormalizedSQN{Name: "member"}},
+			{parent: accesslists.NormalizedSQN{Scope: "/scope1", Name: "test2"}, member: accesslists.NormalizedSQN{Scope: "/scope1", Name: "nested2"}},
+			{parent: accesslists.NormalizedSQN{Scope: "/scope2", Name: "test3"}, member: accesslists.NormalizedSQN{Scope: "/scope2", Name: "nested3"}},
+		}
+		for _, ref := range memberRefs {
+			list, err := accesslist.NewAccessListWithScope(
+				header.Metadata{Name: ref.parent.Name},
+				accesslist.Spec{
+					Title:  "test list",
+					Owners: []accesslist.Owner{{Name: "ownername"}},
+				},
+				ref.parent.Scope,
+			)
+			require.NoError(t, err)
+			_, err = p.accessLists.UpsertAccessList(t.Context(), list)
+			require.NoError(t, err)
+
+			membershipKind := accesslist.MembershipKindUser
+			if ref.member.Scope != "" {
+				membershipKind = accesslist.MembershipKindScopedList
+				nestedList, err := accesslist.NewAccessListWithScope(
+					header.Metadata{Name: ref.member.Name},
+					accesslist.Spec{
+						Title:  "nested test list",
+						Owners: []accesslist.Owner{{Name: "ownername"}},
+					},
+					ref.member.Scope,
+				)
+				require.NoError(t, err)
+				_, err = p.accessLists.UpsertAccessList(t.Context(), nestedList)
+				require.NoError(t, err)
+			}
+
+			member, err := accesslist.NewAccessListMemberWithScope(
+				header.Metadata{Name: ref.member.String()},
+				accesslist.AccessListMemberSpec{
+					AccessList:     ref.parent.String(),
+					Name:           ref.member.String(),
+					Joined:         time.Now(),
+					Expires:        time.Now().Add(24 * time.Hour),
+					Reason:         "a reason",
+					AddedBy:        "dummy",
+					MembershipKind: membershipKind,
+				},
+				ref.parent.Scope,
+			)
+			require.NoError(t, err)
+			_, err = p.accessLists.UpsertAccessListMember(t.Context(), member)
+			require.NoError(t, err)
+		}
+
+		collectMemberRefs := func() []memberRef {
+			refs := make([]memberRef, 0, len(memberRefs))
+			for member, err := range clientutils.Resources(t.Context(), func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+				return p.cache.ListAllAccessListMembersV2(ctx, accesslistv1.ListAllAccessListMembersRequest_builder{
+					PageSize:  int32(pageSize),
+					PageToken: pageToken,
+				}.Build())
+			}) {
+				require.NoError(t, err)
+				parentListName, err := accesslists.ParentListOf(member)
+				require.NoError(t, err)
+				memberName, err := accesslists.MemberScopeQualifiedName(member)
+				require.NoError(t, err)
+				refs = append(refs, memberRef{parent: parentListName, member: memberName})
+			}
+			return refs
+		}
+
+		// Assert the cache sees all the created members, after backend events propagate.
+		synctest.Wait()
+		require.Equal(t, memberRefs, collectMemberRefs())
+
+		// Delete each member one by one, the cache view should agree.
+		for len(memberRefs) > 0 {
+			err := p.accessLists.DeleteAccessListMemberV2(t.Context(), accesslistv1.DeleteAccessListMemberRequest_builder{
+				AccessListScope: memberRefs[0].parent.Scope,
+				AccessList:      memberRefs[0].parent.Name,
+				MemberScope:     memberRefs[0].member.Scope,
+				MemberName:      memberRefs[0].member.Name,
+			}.Build())
+			require.NoError(t, err)
+
+			synctest.Wait()
+			memberRefs = memberRefs[1:]
+			require.Equal(t, memberRefs, collectMemberRefs())
+		}
+	})
+}
+
+func TestScopedAccessListReviewsCache(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		p := newTestPack(t, ForAuth)
+		t.Cleanup(p.Close)
+
+		type reviewRef struct {
+			parent accesslists.NormalizedSQN
+			review string
+		}
+		reviewRefs := []reviewRef{
+			{parent: accesslists.NormalizedSQN{Name: "test1"}},
+			{parent: accesslists.NormalizedSQN{Name: "test2"}},
+			{parent: accesslists.NormalizedSQN{Name: "test3"}},
+			{parent: accesslists.NormalizedSQN{Scope: "/scope1", Name: "test1"}},
+			{parent: accesslists.NormalizedSQN{Scope: "/scope1", Name: "test2"}},
+			{parent: accesslists.NormalizedSQN{Scope: "/scope2", Name: "test3"}},
+		}
+		for i, ref := range reviewRefs {
+			list, err := accesslist.NewAccessListWithScope(
+				header.Metadata{Name: ref.parent.Name},
+				accesslist.Spec{
+					Title:  "test list",
+					Owners: []accesslist.Owner{{Name: "ownername"}},
+				},
+				ref.parent.Scope,
+			)
+			require.NoError(t, err)
+			_, err = p.accessLists.UpsertAccessList(t.Context(), list)
+			require.NoError(t, err)
+
+			review, err := accesslist.NewReviewWithScope(
+				header.Metadata{Name: "ignored-by-create"},
+				accesslist.ReviewSpec{
+					AccessList: ref.parent.String(),
+					Reviewers:  []string{"reviewer"},
+					ReviewDate: time.Now(),
+				},
+				ref.parent.Scope,
+			)
+			require.NoError(t, err)
+			createdReview, _, err := p.accessLists.CreateAccessListReview(t.Context(), review)
+			require.NoError(t, err)
+			reviewRefs[i].review = createdReview.GetName()
+		}
+
+		collectReviewRefs := func() []reviewRef {
+			refs := make([]reviewRef, 0, len(reviewRefs))
+			for _, ref := range reviewRefs {
+				for review, err := range clientutils.Resources(t.Context(), func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.Review, string, error) {
+					return p.cache.ListAccessListReviewsV2(ctx, accesslistv1.ListAccessListReviewsRequest_builder{
+						AccessListScope: ref.parent.Scope,
+						AccessList:      ref.parent.Name,
+						PageSize:        int32(pageSize),
+						NextToken:       pageToken,
+					}.Build())
+				}) {
+					require.NoError(t, err)
+					parent, err := accesslists.ReviewedList(review)
+					require.NoError(t, err)
+					refs = append(refs, reviewRef{parent: parent, review: review.GetName()})
+				}
+			}
+			return refs
+		}
+
+		// Assert the cache sees all the created reviews, after backend events propagate.
+		synctest.Wait()
+		require.Equal(t, reviewRefs, collectReviewRefs())
+
+		// Delete each review one by one, the cache view should agree.
+		for i, ref := range reviewRefs {
+			err := p.accessLists.DeleteAccessListReviewV2(t.Context(), accesslistv1.DeleteAccessListReviewRequest_builder{
+				AccessListScope: ref.parent.Scope,
+				AccessListName:  ref.parent.Name,
+				ReviewName:      ref.review,
+			}.Build())
+			require.NoError(t, err)
+
+			synctest.Wait()
+			require.Equal(t, reviewRefs[i+1:], collectReviewRefs())
+		}
+	})
 }

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -137,10 +137,6 @@ func makeAllKnownCAsFilter() types.CertAuthorityFilter {
 func ForAuth(cfg Config) Config {
 	cfg.target = "auth"
 	cfg.EnableRelativeExpiry = true
-	// Explicitly filter to only unscoped resources for scope-aware kinds with
-	// scoped events but no cache support yet.
-	// TODO(nklaassen): delete when scoped access lists have cache support.
-	unscoped := types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build())
 	cfg.Watches = []types.WatchKind{
 		{Kind: types.KindCertAuthority, LoadSecrets: true},
 		{Kind: types.KindCertAuthorityOverride},
@@ -194,9 +190,9 @@ func ForAuth(cfg Config) Config {
 		{Kind: types.KindAuditQuery},
 		{Kind: types.KindSecurityReport},
 		{Kind: types.KindSecurityReportState},
-		{Kind: types.KindAccessList, ScopeFilter: unscoped},
-		{Kind: types.KindAccessListMember, ScopeFilter: unscoped},
-		{Kind: types.KindAccessListReview, ScopeFilter: unscoped},
+		{Kind: types.KindAccessList},
+		{Kind: types.KindAccessListMember},
+		{Kind: types.KindAccessListReview},
 		{Kind: types.KindKubeWaitingContainer},
 		{Kind: types.KindNotification},
 		{Kind: types.KindGlobalNotification},

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -137,6 +137,10 @@ func makeAllKnownCAsFilter() types.CertAuthorityFilter {
 func ForAuth(cfg Config) Config {
 	cfg.target = "auth"
 	cfg.EnableRelativeExpiry = true
+	// Explicitly filter to only unscoped resources for scope-aware kinds with
+	// scoped events but no cache support yet.
+	// TODO(nklaassen): delete when scoped access lists have cache support.
+	unscoped := types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build())
 	cfg.Watches = []types.WatchKind{
 		{Kind: types.KindCertAuthority, LoadSecrets: true},
 		{Kind: types.KindCertAuthorityOverride},
@@ -190,9 +194,9 @@ func ForAuth(cfg Config) Config {
 		{Kind: types.KindAuditQuery},
 		{Kind: types.KindSecurityReport},
 		{Kind: types.KindSecurityReportState},
-		{Kind: types.KindAccessList},
-		{Kind: types.KindAccessListMember},
-		{Kind: types.KindAccessListReview},
+		{Kind: types.KindAccessList, ScopeFilter: unscoped},
+		{Kind: types.KindAccessListMember, ScopeFilter: unscoped},
+		{Kind: types.KindAccessListReview, ScopeFilter: unscoped},
 		{Kind: types.KindKubeWaitingContainer},
 		{Kind: types.KindNotification},
 		{Kind: types.KindGlobalNotification},
@@ -482,8 +486,6 @@ func ForOkta(cfg Config) Config {
 		{Kind: types.KindProxy},
 		{Kind: types.KindRole},
 		{Kind: types.KindClusterAuthPreference},
-		{Kind: types.KindAccessList},
-		{Kind: types.KindAccessListMember},
 	}
 	cfg.QueueSize = defaults.DiscoveryQueueSize
 	return cfg

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -85,6 +85,7 @@ import (
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -426,6 +427,9 @@ func newPackWithoutCache(dir string, opts ...packOption) (*testPack, error) {
 	accessListsSvc, err := local.NewAccessListServiceV2(local.AccessListServiceConfig{
 		Backend: p.backend,
 		Modules: modulestest.EnterpriseModules(),
+		ScopesFeatures: scopes.Features{
+			Enabled: true,
+		},
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/scopes/access/verbs.go
+++ b/lib/scopes/access/verbs.go
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package access
 
 import "github.com/gravitational/teleport/api/types"
@@ -35,6 +36,11 @@ func isAllowedScopedRule(kind string, verb string) bool {
 		return isReadWriteNoSecrets(verb)
 	case types.KindBotInstance:
 		// bot instances can be read/written, and do not currently contain a concept of a secret.
+		return isReadWriteNoSecrets(verb)
+	case types.KindAccessList:
+		// access lists can be read/written, and do not contain a concept of a secret.
+		// permissions for access list members are conferred by permissions for
+		// access list themselves, and/or list ownership.
 		return isReadWriteNoSecrets(verb)
 	default:
 		return false

--- a/lib/scopes/cache/access/access.go
+++ b/lib/scopes/cache/access/access.go
@@ -325,13 +325,11 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry retryutils.Retry) error
 	// watcher which watches backend events. It is used for driving changes to
 	// scoped role assignments materialized from access lists and their
 	// memberships.
-	// TODO(nklaassen): remove scope filter when materializer supports scoped lists.
-	unscoped := types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build())
 	aclWatcher, err := c.cfg.AccessListEvents.NewWatcher(ctx, types.Watch{
 		Name: "scoped-access-cache-acl-watcher",
 		Kinds: []types.WatchKind{
-			{Kind: types.KindAccessList, ScopeFilter: unscoped},
-			{Kind: types.KindAccessListMember, ScopeFilter: unscoped},
+			{Kind: types.KindAccessList},
+			{Kind: types.KindAccessListMember},
 		},
 	})
 	if err != nil {

--- a/lib/scopes/cache/access/access.go
+++ b/lib/scopes/cache/access/access.go
@@ -325,11 +325,13 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry retryutils.Retry) error
 	// watcher which watches backend events. It is used for driving changes to
 	// scoped role assignments materialized from access lists and their
 	// memberships.
+	// TODO(nklaassen): remove scope filter when materializer supports scoped lists.
+	unscoped := types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build())
 	aclWatcher, err := c.cfg.AccessListEvents.NewWatcher(ctx, types.Watch{
 		Name: "scoped-access-cache-acl-watcher",
 		Kinds: []types.WatchKind{
-			{Kind: types.KindAccessList},
-			{Kind: types.KindAccessListMember},
+			{Kind: types.KindAccessList, ScopeFilter: unscoped},
+			{Kind: types.KindAccessListMember, ScopeFilter: unscoped},
 		},
 	})
 	if err != nil {

--- a/lib/scopes/cache/access/materializer.go
+++ b/lib/scopes/cache/access/materializer.go
@@ -17,10 +17,10 @@
 package access
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/binary"
 	"iter"
 	"log/slog"
 	"maps"
@@ -32,12 +32,14 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/gravitational/teleport"
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/accesslists"
 	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/utils"
@@ -62,12 +64,12 @@ const (
 
 // AccessListReader provides the upstream source of access list and member resources.
 type AccessListReader interface {
-	ListAccessLists(context.Context, int, string) ([]*accesslist.AccessList, string, error)
-	GetAccessList(ctx context.Context, accessListName string) (*accesslist.AccessList, error)
+	ListAccessListsV2(context.Context, *accesslistv1.ListAccessListsV2Request) ([]*accesslist.AccessList, string, error)
+	GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error)
 
-	ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
-	ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
-	GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error)
+	ListAllAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAllAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error)
+	ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error)
+	GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error)
 }
 
 // AssignmentStore is the interface the materializer uses to persist
@@ -79,10 +81,53 @@ type AssignmentStore interface {
 
 // listAccessListMembers is a helper for calling clientutils.Resources to range
 // over all members of [listName].
-func listAccessListMembers(aclReader AccessListReader, listName string) func(context.Context, int, string) ([]*accesslist.AccessListMember, string, error) {
+func listAccessListMembers(aclReader AccessListReader, listName accesslists.NormalizedSQN) func(context.Context, int, string) ([]*accesslist.AccessListMember, string, error) {
 	return func(ctx context.Context, pageSize int, cursor string) ([]*accesslist.AccessListMember, string, error) {
-		return aclReader.ListAccessListMembers(ctx, listName, pageSize, cursor)
+		return aclReader.ListAccessListMembersV2(ctx, accesslistv1.ListAccessListMembersRequest_builder{
+			AccessListScope: listName.Scope,
+			AccessList:      listName.Name,
+			PageSize:        int32(pageSize),
+			PageToken:       cursor,
+		}.Build())
 	}
+}
+
+// listAllAccessListMembers is a helper for calling clientutils.Resources to range
+// over all access list members.
+func listAllAccessListMembers(aclReader AccessListReader) func(context.Context, int, string) ([]*accesslist.AccessListMember, string, error) {
+	return func(ctx context.Context, pageSize int, cursor string) ([]*accesslist.AccessListMember, string, error) {
+		return aclReader.ListAllAccessListMembersV2(ctx, accesslistv1.ListAllAccessListMembersRequest_builder{
+			PageSize:  int32(pageSize),
+			PageToken: cursor,
+		}.Build())
+	}
+}
+
+// listAccessLists is a helper for calling clientutils.Resources to range
+// over all access lists.
+func listAccessLists(aclReader AccessListReader) func(context.Context, int, string) ([]*accesslist.AccessList, string, error) {
+	return func(ctx context.Context, pageSize int, cursor string) ([]*accesslist.AccessList, string, error) {
+		return aclReader.ListAccessListsV2(ctx, accesslistv1.ListAccessListsV2Request_builder{
+			PageSize:  int32(pageSize),
+			PageToken: cursor,
+		}.Build())
+	}
+}
+
+func getAccessList(ctx context.Context, aclReader AccessListReader, listName accesslists.NormalizedSQN) (*accesslist.AccessList, error) {
+	return aclReader.GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Scope: listName.Scope,
+		Name:  listName.Name,
+	}.Build())
+}
+
+func getAccessListMember(ctx context.Context, aclReader AccessListReader, listName, memberName accesslists.NormalizedSQN) (*accesslist.AccessListMember, error) {
+	return aclReader.GetAccessListMemberV2(ctx, accesslistv1.GetAccessListMemberRequest_builder{
+		AccessListScope: listName.Scope,
+		AccessList:      listName.Name,
+		MemberScope:     memberName.Scope,
+		MemberName:      memberName.Name,
+	}.Build())
 }
 
 // Materializer is responsible for "materializing" scoped role assignments into
@@ -146,17 +191,45 @@ type Materializer struct {
 type MaterializedAssignmentKey struct {
 	// User is the name of the user the assignment is materialized for.
 	User string
-	// List is the name of the access list the assignment is materialized for.
-	List string
+	// ListName is the name of the access list the assignment is materialized for.
+	ListName string
+	// ListScope is the normalized scope of the access list the assignment is materialized for.
+	ListScope string
+}
+
+func newMaterializedAssignmentKey(list *accesslist.AccessList, userName string) MaterializedAssignmentKey {
+	return MaterializedAssignmentKey{
+		User:      userName,
+		ListName:  list.GetName(),
+		ListScope: scopes.NormalizeForEquality(list.GetScope()),
+	}
 }
 
 // AssignmentName returns the canonical name for the materialized scoped role assignment.
 func (k MaterializedAssignmentKey) AssignmentName() string {
 	h := sha256.New224()
-	binary.Write(h, binary.LittleEndian, uint16(len(k.User)))
 	h.Write([]byte(k.User))
-	h.Write([]byte(k.List))
+	h.Write([]byte{0})
+	h.Write([]byte(k.ListName))
+	h.Write([]byte{0})
+	h.Write([]byte(k.ListScope))
 	return "acl-" + base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+}
+
+// AssignmentScope returns the scope of the materialized assignment. For
+// assignments materialized for an unscoped access list, this will be the root
+// scope. Otherwise, it will be the scope of the access list.
+func (k MaterializedAssignmentKey) AssignmentScope() string {
+	return cmp.Or(k.ListScope, scopes.Root)
+}
+
+// listSQN returns the scope-qualified name of the access list the asignment
+// was materialized for.
+func (k MaterializedAssignmentKey) listSQN() accesslists.NormalizedSQN {
+	return accesslists.NormalizedSQN{
+		Name:  k.ListName,
+		Scope: k.ListScope,
+	}
 }
 
 // NewMaterializer returns a new scoped role assignment materializer.
@@ -193,12 +266,20 @@ func (m *Materializer) Init(ctx context.Context) (err error) {
 	// can react to member expiration.
 	now := time.Now()
 	nextExpiry := now.Add(century)
-	for member, err := range clientutils.Resources(ctx, m.aclReader.ListAllAccessListMembers) {
+	for member, err := range clientutils.Resources(ctx, listAllAccessListMembers(m.aclReader)) {
 		if err != nil {
 			return trace.Wrap(err, "reading access list members")
 		}
-		if member.Spec.MembershipKind == accesslist.MembershipKindList {
-			m.ancestorCache.addMembership(member.Spec.AccessList, member.GetName())
+		if member.IsList() {
+			memberSQN, err := accesslists.MemberScopeQualifiedName(member)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			parentSQN, err := accesslists.ParentListOf(member)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			m.ancestorCache.addMembership(parentSQN, memberSQN)
 		}
 		if member.Spec.Expires.After(now) && member.Spec.Expires.Before(nextExpiry) {
 			nextExpiry = member.Spec.Expires
@@ -206,21 +287,27 @@ func (m *Materializer) Init(ctx context.Context) (err error) {
 	}
 	m.reportFutureMemberExpiry(ctx, nextExpiry)
 
-	for list, err := range clientutils.Resources(ctx, m.aclReader.ListAccessLists) {
+	for list, err := range clientutils.Resources(ctx, listAccessLists(m.aclReader)) {
 		if err != nil {
 			return trace.Wrap(err, "reading access lists")
 		}
+		listSQN := accesslists.ScopeQualifiedName(list)
 		for _, owner := range list.Spec.Owners {
-			if owner.MembershipKind == accesslist.MembershipKindList {
-				m.ancestorCache.addOwnership(owner.Name, list.GetName())
+			if !owner.IsMembershipKindList() {
+				continue
 			}
+			ownerSQN, err := accesslists.OwnerScopeQualifiedName(owner)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			m.ancestorCache.addOwnership(ownerSQN, listSQN)
 		}
 	}
 
 	// We iterate the access lists again separately so that the ancestor cache
 	// is fully initialized before it may be referenced in
 	// m.initAccessListMembers.
-	for list, err := range clientutils.Resources(ctx, m.aclReader.ListAccessLists) {
+	for list, err := range clientutils.Resources(ctx, listAccessLists(m.aclReader)) {
 		if err != nil {
 			return trace.Wrap(err, "reading access lists")
 		}
@@ -252,14 +339,34 @@ func (m *Materializer) ProcessEvent(ctx context.Context, event types.Event) (err
 	case types.OpDelete:
 		switch event.Resource.GetKind() {
 		case types.KindAccessList:
-			m.handleAccessListDelete(ctx, event.Resource.GetName())
+			if list, ok := event.Resource.(*accesslist.AccessList); ok {
+				m.handleAccessListDelete(ctx, accesslists.ScopeQualifiedName(list))
+				return nil
+			}
+			m.handleAccessListDelete(ctx, accesslists.NormalizedSQN{Name: event.Resource.GetName()})
 		case types.KindAccessListMember:
+			if member, ok := event.Resource.(*accesslist.AccessListMember); ok {
+				listName, err := accesslists.ParentListOf(member)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				memberName, err := accesslists.MemberScopeQualifiedName(member)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				if memberName.Scope == "" {
+					m.handleAccessListMemberDelete(ctx, listName, memberName.Name)
+				} else {
+					m.handleListMemberDelete(ctx, listName, memberName)
+				}
+				return nil
+			}
 			listName := event.Resource.GetMetadata().Description
 			if listName == "" {
 				// This is a bug, return a hard failure.
 				return trace.Errorf("missing access list name in access list member delete event description")
 			}
-			m.handleAccessListMemberDelete(ctx, listName, event.Resource.GetName())
+			m.handleAccessListMemberDelete(ctx, accesslists.NormalizedSQN{Name: listName}, event.Resource.GetName())
 		}
 	}
 	return nil
@@ -269,7 +376,7 @@ func (m *Materializer) handleAccessListMemberPut(ctx context.Context, member *ac
 	if member.IsUser() {
 		m.handleUserMemberPut(ctx, member)
 	}
-	if member.Spec.MembershipKind == accesslist.MembershipKindList {
+	if member.IsList() {
 		m.handleListMemberPut(ctx, member)
 	}
 }
@@ -280,15 +387,19 @@ func (m *Materializer) handleAccessListMemberPut(ctx context.Context, member *ac
 // If the member resource is expired, it re-checks all materialized assignments
 // for the user in case they were granted via this membership.
 func (m *Materializer) handleUserMemberPut(ctx context.Context, member *accesslist.AccessListMember) {
-	listName := member.Spec.AccessList
 	userName := member.GetName()
+	listName, err := accesslists.ParentListOf(member)
+	if err != nil {
+		m.logger.WarnContext(ctx, "Access list member is invalid, unable to parse parent list", "error", err)
+		return
+	}
 
-	if m.ancestorCache.children.Get(listName).Contains(userName) {
+	if m.ancestorCache.children.Get(listName).Contains(accesslists.NormalizedSQN{Name: userName}) {
 		// Due to presence in the ancestor cache, this access list member must
 		// have been observed with membership kind list before, and now has
 		// membership kind user. Process a list member delete first, and then
 		// carry on to handle the user member put.
-		m.handleListMemberDelete(ctx, listName, userName)
+		m.handleListMemberDelete(ctx, listName, accesslists.NormalizedSQN{Name: userName})
 	}
 
 	if member.IsExpired(time.Now()) {
@@ -297,7 +408,7 @@ func (m *Materializer) handleUserMemberPut(ctx context.Context, member *accessli
 	}
 	m.reportFutureMemberExpiry(ctx, member.Spec.Expires)
 
-	list, err := m.aclReader.GetAccessList(ctx, listName)
+	list, err := getAccessList(ctx, m.aclReader, listName)
 	if err != nil {
 		m.logger.InfoContext(ctx, "Failed to get access list while handling member put",
 			"error", err,
@@ -322,7 +433,7 @@ func (m *Materializer) handleUserMemberPut(ctx context.Context, member *accessli
 			"list", list.GetName())
 	}
 
-	ancestors, validationErrors := m.collectAncestors(ctx, list.GetName())
+	ancestors, validationErrors := m.collectAncestors(ctx, listName)
 	for _, validationError := range validationErrors {
 		m.logger.InfoContext(ctx, "Error while validating access list ancestors, some scoped role assignments may not be materialized",
 			"error", validationError)
@@ -338,7 +449,7 @@ func (m *Materializer) handleUserMemberPut(ctx context.Context, member *accessli
 			m.logger.WarnContext(ctx, "Failed to materialize assignment",
 				"error", err,
 				"user", userName,
-				"list", ancestor.list.GetName())
+				"list", accesslists.ScopeQualifiedName(ancestor.list))
 		}
 	}
 }
@@ -351,12 +462,23 @@ func (m *Materializer) handleUserMemberPut(ctx context.Context, member *accessli
 // If the member resource is expired, it re-checks all materialized assignments
 // for the parent list and all of its ancestors, in case they were granted via this membership.
 func (m *Materializer) handleListMemberPut(ctx context.Context, member *accesslist.AccessListMember) {
-	parentListName, memberListName := member.Spec.AccessList, member.Spec.Name
+	parentListName, err := accesslists.ParentListOf(member)
+	if err != nil {
+		m.logger.WarnContext(ctx, "Access list member is invalid, unable to parse parent list", "error", err)
+		return
+	}
+	memberListName, err := accesslists.MemberScopeQualifiedName(member)
+	if err != nil {
+		m.logger.WarnContext(ctx, "Access list member is invalid, unable to parse member name", "error", err)
+		return
+	}
 
-	// It's possible this member resource used to have membership kind user and
-	// was updated to have membership kind list, so we must clear anything
-	// related to a previous user membership.
-	m.handleUserMemberDeleteOrExpired(ctx, parentListName, memberListName)
+	// If unscoped it's possible this member resource used to have membership
+	// kind user and was updated to have membership kind list, so we must clear
+	// anything related to a previous user membership.
+	if memberListName.Scope == "" {
+		m.handleUserMemberDeleteOrExpired(ctx, parentListName, memberListName.Name)
+	}
 
 	m.ancestorCache.addMembership(parentListName, memberListName)
 
@@ -369,7 +491,7 @@ func (m *Materializer) handleListMemberPut(ctx context.Context, member *accessli
 	// Every user that is a nested member of memberList may have just become a
 	// member of parentList and all lists it is a nested member of. They also
 	// may have become an owner of every list parentList is an owner of.
-	parentList, err := m.aclReader.GetAccessList(ctx, parentListName)
+	parentList, err := getAccessList(ctx, m.aclReader, parentListName)
 	if err != nil {
 		m.logger.InfoContext(ctx, "Failed to get access list while handling list member put, some scoped role assignments may not be materialized",
 			"error", err,
@@ -378,7 +500,7 @@ func (m *Materializer) handleListMemberPut(ctx context.Context, member *accessli
 		m.scheduleMissedMembersRepair(ctx)
 		return
 	}
-	memberList, err := m.aclReader.GetAccessList(ctx, memberListName)
+	memberList, err := getAccessList(ctx, m.aclReader, memberListName)
 	if err != nil {
 		m.logger.InfoContext(ctx, "Failed to get access list while handling list member put, some scoped role assignments may not be materialized",
 			"error", err,
@@ -440,22 +562,22 @@ func (m *Materializer) handleListMemberPut(ctx context.Context, member *accessli
 	}
 }
 
-func (m *Materializer) handleAccessListMemberDelete(ctx context.Context, listName, memberName string) {
+func (m *Materializer) handleAccessListMemberDelete(ctx context.Context, listName accesslists.NormalizedSQN, memberName string) {
 	// We don't get enough info from the event to know if the deleted member
 	// was a user or a list. Luckily member names are unique, so we know that
 	// if this membership is present in the ancestor cache as a list, then this
 	// member was last observed as a list. If it is not present in the ancestor
 	// cache, then it was last observed as a user (or not observed at all) and
 	// we handle it as a user member delete.
-	if m.ancestorCache.children.Get(listName).Contains(memberName) {
-		m.handleListMemberDelete(ctx, listName, memberName)
+	if m.ancestorCache.children.Get(listName).Contains(accesslists.NormalizedSQN{Name: memberName}) {
+		m.handleListMemberDelete(ctx, listName, accesslists.NormalizedSQN{Name: memberName})
 		return
 	}
 	m.handleUserMemberDeleteOrExpired(ctx, listName, memberName)
 }
 
 // handleListMemberDelete handles delete events for nested access list memberships.
-func (m *Materializer) handleListMemberDelete(ctx context.Context, parentListName, memberListName string) {
+func (m *Materializer) handleListMemberDelete(ctx context.Context, parentListName, memberListName accesslists.NormalizedSQN) {
 	// First and foremost, always keep the ancestor cache up to date with all
 	// direct list->list memberships.
 	m.ancestorCache.removeMembership(parentListName, memberListName)
@@ -470,7 +592,7 @@ func (m *Materializer) handleListMemberDelete(ctx context.Context, parentListNam
 // no longer be valid members or owners of the parent list or any of its
 // ancestors. At risk of being overly pessimistic, we re-check every
 // materialized assignment for the parent list and all of its ancestors.
-func (m *Materializer) handleListMemberExpired(ctx context.Context, parentListName string) {
+func (m *Materializer) handleListMemberExpired(ctx context.Context, parentListName accesslists.NormalizedSQN) {
 	// We must iterate all ancestors without relying on paging through
 	// collections in the cache to make sure we don't miss any assignments that
 	// need to be invalidated due to a paging error or any other transient
@@ -480,8 +602,8 @@ func (m *Materializer) handleListMemberExpired(ctx context.Context, parentListNa
 
 	// Iterate all currently materialized assignments.
 	for key := range m.materializedAssignments {
-		_, isAncestor := ancestors[key.List]
-		if key.List != parentListName && !isAncestor {
+		_, isAncestor := ancestors[key.listSQN()]
+		if key.listSQN() != parentListName && !isAncestor {
 			// We don't need to validate any assignments that are not for the
 			// parent list or any of its ancestors.
 			continue
@@ -502,7 +624,7 @@ func (m *Materializer) handleListMemberExpired(ctx context.Context, parentListNa
 // It's possible they are no longer a valid member of the parent list or any of
 // its ancestors. We need to re-check all current materialized assignments for
 // this user in the initial list or any of its ancestors.
-func (m *Materializer) handleUserMemberDeleteOrExpired(ctx context.Context, parentListName, userName string) {
+func (m *Materializer) handleUserMemberDeleteOrExpired(ctx context.Context, parentListName accesslists.NormalizedSQN, userName string) {
 	// We must iterate all ancestors without relying on paging through
 	// collections in the cache to make sure we don't miss any assignments that
 	// need to be invalidated due to a paging error or any other transient
@@ -510,8 +632,8 @@ func (m *Materializer) handleUserMemberDeleteOrExpired(ctx context.Context, pare
 	// memberships and ownerships, which is sufficient.
 	ancestors := m.collectAncestorListsWithoutValidation(parentListName)
 	for key := range m.materializedAssignmentsForUser(userName) {
-		_, isAncestor := ancestors[key.List]
-		if key.List != parentListName && !isAncestor {
+		_, isAncestor := ancestors[key.listSQN()]
+		if key.listSQN() != parentListName && !isAncestor {
 			// We don't need to validate any assignments that are not for the
 			// parent list or any of its ancestors.
 			continue
@@ -543,19 +665,27 @@ func (m *Materializer) handleUserMemberDeleteOrExpired(ctx context.Context, pare
 // If the list has any scoped owner grants and any owner lists were added,
 // materialize an assignment for them.
 func (m *Materializer) handleAccessListPut(ctx context.Context, list *accesslist.AccessList) {
+	listName := accesslists.ScopeQualifiedName(list)
+
 	// Update any owner list edges in the ancestor cache.
-	m.ancestorCache.clearOwnersOf(list.GetName())
+	m.ancestorCache.clearOwnersOf(listName)
 	for _, owner := range list.Spec.Owners {
-		if owner.MembershipKind != accesslist.MembershipKindList {
+		if !owner.IsMembershipKindList() {
 			continue
 		}
-		m.ancestorCache.addOwnership(owner.Name, list.GetName())
+		ownerName, err := accesslists.OwnerScopeQualifiedName(owner)
+		if err != nil {
+			m.logger.WarnContext(ctx, "Failed to parse owner name, ownership will not be considered",
+				"error", err, "name", owner.Name)
+			continue
+		}
+		m.ancestorCache.addOwnership(ownerName, listName)
 	}
 
 	// Re-check all extant assignments for this list in case any grants were added
 	// or removed or ownership status changed.
 	hasScopedGrants := hasMemberGrants(list) || hasOwnerGrants(list)
-	for key := range m.materializedAssignmentsForList(list.GetName()) {
+	for key := range m.materializedAssignmentsForList(listName) {
 		if hasScopedGrants {
 			// The list has some grants we should re-check. This may delete
 			// assignments as necessary.
@@ -580,7 +710,7 @@ func (m *Materializer) handleAccessListPut(ctx context.Context, list *accesslist
 	// is not possible for an access list update to invalidate membership in
 	// any other lists.
 	if hasMembershipRequires(list) {
-		ancestors := m.collectAncestorListsWithoutValidation(list.GetName())
+		ancestors := m.collectAncestorListsWithoutValidation(listName)
 		for ancestorListName := range ancestors {
 			for key := range m.materializedAssignmentsForList(ancestorListName) {
 				if err := m.recheckAssignment(ctx, key); err != nil {
@@ -611,7 +741,7 @@ func (m *Materializer) initAccessListMembers(ctx context.Context, list *accessli
 		return
 	}
 
-	ancestors, validationErrors := m.collectAncestors(ctx, list.GetName())
+	ancestors, validationErrors := m.collectAncestors(ctx, accesslists.ScopeQualifiedName(list))
 	for _, validationError := range validationErrors {
 		m.logger.InfoContext(ctx, "Error while validating access list ancestors, some scoped role assignments may not be materialized",
 			"error", validationError)
@@ -673,11 +803,12 @@ func (m *Materializer) initAccessListOwners(ctx context.Context, list *accesslis
 		// There is nothing to materialize for owners of this list.
 		return
 	}
+	listName := accesslists.ScopeQualifiedName(list)
 
 	// Keep track of users and lists that have already been seen across member
 	// iterations to avoid duplicating work if the same user or list is a
 	// member of multiple owner lists.
-	seenLists := utils.NewSet[string]()
+	seenLists := utils.NewSet[accesslists.NormalizedSQN]()
 	seenUsers := utils.NewSet[string]()
 
 	for _, owner := range list.Spec.Owners {
@@ -689,16 +820,22 @@ func (m *Materializer) initAccessListOwners(ctx context.Context, list *accesslis
 				m.logger.WarnContext(ctx, "Failed to materialize assignment",
 					"error", err,
 					"user", owner.Name,
-					"list", list.GetName())
+					"list", listName)
 			}
 			continue
 		}
 
-		if owner.MembershipKind != accesslist.MembershipKindList {
+		if !owner.IsMembershipKindList() {
 			continue
 		}
 
-		ownerList, err := m.aclReader.GetAccessList(ctx, owner.Name)
+		ownerName, err := accesslists.OwnerScopeQualifiedName(owner)
+		if err != nil {
+			m.logger.InfoContext(ctx, "Owner is invalid, failed to parse name",
+				"error", err, "name", owner.Name)
+			return
+		}
+		ownerList, err := getAccessList(ctx, m.aclReader, ownerName)
 		if err != nil {
 			m.logger.InfoContext(ctx, "Failed to get owner list, some scoped role assignments may not be materialized for owners",
 				"error", err)
@@ -713,7 +850,7 @@ func (m *Materializer) initAccessListOwners(ctx context.Context, list *accesslis
 			if err != nil {
 				m.logger.WarnContext(ctx, "Error while walking members of access list, some scoped role assignments may not be materialized",
 					"error", err,
-					"list", list.GetName())
+					"list", listName)
 				m.scheduleMissedMembersRepair(ctx)
 				// walkUserMembersRecursive may yield errors from walking members of any
 				// member lists, but it may not be done, so continue the loop.
@@ -723,7 +860,7 @@ func (m *Materializer) initAccessListOwners(ctx context.Context, list *accesslis
 				m.logger.WarnContext(ctx, "Failed to materialize assignment",
 					"error", err,
 					"user", member.GetName(),
-					"list", list.GetName())
+					"list", listName)
 			}
 		}
 	}
@@ -734,7 +871,7 @@ func (m *Materializer) initAccessListOwners(ctx context.Context, list *accesslis
 // another list (the access list service attempts to prevent it), but to be
 // defensive we re-check assignments for all ancestors anyway in case a
 // membership path through this list has been broken.
-func (m *Materializer) handleAccessListDelete(ctx context.Context, listName string) {
+func (m *Materializer) handleAccessListDelete(ctx context.Context, listName accesslists.NormalizedSQN) {
 	// First of all, keep the ancestor cache up to date with respect to owners.
 	// Access lists are the source of truth for direct owner relationships.
 	// While the deletion of the access list may invalidate a direct membership
@@ -752,8 +889,8 @@ func (m *Materializer) handleAccessListDelete(ctx context.Context, listName stri
 
 	// Iterate all currently materialized assignments.
 	for key := range m.materializedAssignments {
-		_, isAncestor := ancestors[key.List]
-		if key.List != listName && !isAncestor {
+		_, isAncestor := ancestors[key.listSQN()]
+		if key.listSQN() != listName && !isAncestor {
 			// We don't need to validate any assignments that are not for the
 			// deleted list or any of its ancestors.
 			continue
@@ -800,10 +937,7 @@ func (m *Materializer) updateRelationshipAndMaterialize(
 	relation ancestorRelation,
 	userName string,
 ) error {
-	currentRelation := m.materializedAssignments[MaterializedAssignmentKey{
-		List: list.GetName(),
-		User: userName,
-	}]
+	currentRelation := m.materializedAssignments[newMaterializedAssignmentKey(list, userName)]
 	relation.isMember = relation.isMember || currentRelation.isMember
 	relation.isOwner = relation.isOwner || currentRelation.isOwner
 	return m.materializeAssignment(ctx, list, relation, userName)
@@ -820,10 +954,7 @@ func (m *Materializer) materializeAssignment(
 	relation ancestorRelation,
 	userName string,
 ) error {
-	key := MaterializedAssignmentKey{
-		User: userName,
-		List: list.GetName(),
-	}
+	key := newMaterializedAssignmentKey(list, userName)
 
 	if (!relation.isMember || !hasMemberGrants(list)) && (!relation.isOwner || !hasOwnerGrants(list)) {
 		// This access list does not grant any scoped roles to this user,
@@ -832,24 +963,24 @@ func (m *Materializer) materializeAssignment(
 		return nil
 	}
 
-	assignment := &scopedaccessv1.ScopedRoleAssignment{
+	assignment := scopedaccessv1.ScopedRoleAssignment_builder{
 		Kind:    scopedaccess.KindScopedRoleAssignment,
 		SubKind: scopedaccess.SubKindMaterialized,
 		Version: types.V1,
-		Scope:   scopes.Root,
+		Scope:   key.AssignmentScope(),
 		Metadata: headerv1.Metadata_builder{
 			Name: key.AssignmentName(),
 		}.Build(),
-		Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+		Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
 			User: userName,
-		},
-		Status: &scopedaccessv1.ScopedRoleAssignmentStatus{
-			Origin: &scopedaccessv1.ScopedRoleAssignmentStatus_Origin{
+		}.Build(),
+		Status: scopedaccessv1.ScopedRoleAssignmentStatus_builder{
+			Origin: scopedaccessv1.ScopedRoleAssignmentStatus_Origin_builder{
 				CreatorKind: scopedaccess.CreatorKindAccessList,
-				CreatorName: list.GetName(),
-			},
-		},
-	}
+				CreatorName: key.listSQN().String(),
+			}.Build(),
+		}.Build(),
+	}.Build()
 
 	if relation.isMember {
 		for _, grant := range list.Spec.Grants.ScopedRoles {
@@ -870,7 +1001,7 @@ func (m *Materializer) materializeAssignment(
 
 	m.logger.DebugContext(ctx, "Materializing scoped role assignment",
 		"user", key.User,
-		"list", key.List)
+		"list", key.listSQN().String())
 	if err := m.assignmentStore.Put(assignment); err != nil {
 		return trace.Wrap(err, "putting materialized assignment into cache")
 	}
@@ -883,9 +1014,10 @@ func (m *Materializer) deleteMaterializedAssignment(ctx context.Context, key Mat
 	if _, ok := m.materializedAssignments[key]; ok {
 		m.logger.DebugContext(ctx, "Deleting materialized scoped role assignment",
 			"user", key.User,
-			"list", key.List)
+			"list", key.listSQN().String(),
+		)
 		m.assignmentStore.Delete(scopes.QualifiedName{
-			Scope: scopes.Root,
+			Scope: key.AssignmentScope(),
 			Name:  key.AssignmentName(),
 		}, scopedaccess.SubKindMaterialized)
 		delete(m.materializedAssignments, key)
@@ -899,9 +1031,9 @@ func (m *Materializer) syncMaterializedAssignmentsMetric() {
 }
 
 func (m *Materializer) recheckAssignment(ctx context.Context, key MaterializedAssignmentKey) error {
-	list, err := m.aclReader.GetAccessList(ctx, key.List)
+	list, err := getAccessList(ctx, m.aclReader, key.listSQN())
 	if err != nil {
-		return trace.Wrap(err, "getting access list %v", key.List)
+		return trace.Wrap(err, "getting access list %v", key.listSQN().String())
 	}
 
 	relation := ancestorRelation{
@@ -934,10 +1066,15 @@ func (m *Materializer) checkNestedOwnership(ctx context.Context, list *accesslis
 
 	// Then check if user is a member or nested member of any owner lists.
 	for _, owner := range list.Spec.Owners {
-		if owner.MembershipKind != accesslist.MembershipKindList {
+		if !owner.IsMembershipKindList() {
 			continue
 		}
-		ownerList, err := m.aclReader.GetAccessList(ctx, owner.Name)
+		ownerName, err := accesslists.OwnerScopeQualifiedName(owner)
+		if err != nil {
+			// Must assume any membership is invalid if the owner name can't be parsed
+			continue
+		}
+		ownerList, err := getAccessList(ctx, m.aclReader, ownerName)
 		if err != nil {
 			// Must assume any membership is invalid if we can't fetch the access list.
 			continue
@@ -951,14 +1088,15 @@ func (m *Materializer) checkNestedOwnership(ctx context.Context, list *accesslis
 }
 
 func (m *Materializer) checkNestedMembership(ctx context.Context, list *accesslist.AccessList, userName string) bool {
-	seen := utils.NewSet[string]()
+	seen := utils.NewSet[accesslists.NormalizedSQN]()
 
 	var checkNestedMembershipRecursive func(*accesslist.AccessList) bool
 	checkNestedMembershipRecursive = func(list *accesslist.AccessList) bool {
-		if seen.Contains(list.GetName()) {
+		listName := accesslists.ScopeQualifiedName(list)
+		if seen.Contains(listName) {
 			return false
 		}
-		seen.Add(list.GetName())
+		seen.Add(listName)
 
 		if hasMembershipRequires(list) {
 			// Memberships can not be valid, for the purposes of granting scoped
@@ -967,7 +1105,7 @@ func (m *Materializer) checkNestedMembership(ctx context.Context, list *accessli
 		}
 
 		// Check if the user is a non-expired direct member of this list.
-		member, err := m.aclReader.GetAccessListMember(ctx, list.GetName(), userName)
+		member, err := getAccessListMember(ctx, m.aclReader, listName, accesslists.NormalizedSQN{Name: userName})
 		if err == nil {
 			if member.IsUser() && !member.IsExpired(time.Now()) {
 				// This user is a valid member.
@@ -976,14 +1114,14 @@ func (m *Materializer) checkNestedMembership(ctx context.Context, list *accessli
 		}
 
 		// Recursively check if the user is a valid member of any child lists.
-		for childListName := range m.ancestorCache.children.Get(list.GetName()).Items() {
-			listMember, err := m.aclReader.GetAccessListMember(ctx, list.GetName(), childListName)
+		for childListName := range m.ancestorCache.children.Get(listName).Items() {
+			listMember, err := getAccessListMember(ctx, m.aclReader, listName, childListName)
 			if err != nil || listMember.IsExpired(time.Now()) {
 				// Couldn't fetch child list member or its membership is
 				// expired, don't walk this membership path.
 				continue
 			}
-			childList, err := m.aclReader.GetAccessList(ctx, childListName)
+			childList, err := getAccessList(ctx, m.aclReader, childListName)
 			if err != nil {
 				// Must assume any membership is invalid if we can't fetch the access list.
 				continue
@@ -1000,10 +1138,10 @@ func (m *Materializer) checkNestedMembership(ctx context.Context, list *accessli
 	return checkNestedMembershipRecursive(list)
 }
 
-func (m *Materializer) materializedAssignmentsForList(listName string) iter.Seq2[MaterializedAssignmentKey, ancestorRelation] {
+func (m *Materializer) materializedAssignmentsForList(listName accesslists.NormalizedSQN) iter.Seq2[MaterializedAssignmentKey, ancestorRelation] {
 	return func(yield func(MaterializedAssignmentKey, ancestorRelation) bool) {
 		for key, relation := range m.materializedAssignments {
-			if key.List != listName {
+			if key.listSQN() != listName {
 				continue
 			}
 			if !yield(key, relation) {
@@ -1037,7 +1175,7 @@ func (m *Materializer) materializedAssignmentsForUser(userName string) iter.Seq2
 // It will yield any errors encountered while fetching list or member resources
 // but may continue iterating over other lists/members.
 func (m *Materializer) walkUserMembers(ctx context.Context, list *accesslist.AccessList) iter.Seq2[*accesslist.AccessListMember, error] {
-	seenLists := utils.NewSet[string]()
+	seenLists := utils.NewSet[accesslists.NormalizedSQN]()
 	seenUsers := utils.NewSet[string]()
 	return m.walkUserMembersRecursive(ctx, list, seenLists, seenUsers)
 }
@@ -1060,16 +1198,17 @@ func (m *Materializer) walkUserMembers(ctx context.Context, list *accesslist.Acc
 //
 // It will yield any errors encountered while fetching list or member resources
 // but may continue iterating over other lists/members.
-func (m *Materializer) walkUserMembersRecursive(ctx context.Context, list *accesslist.AccessList, seenLists utils.Set[string], seenUsers utils.Set[string]) iter.Seq2[*accesslist.AccessListMember, error] {
+func (m *Materializer) walkUserMembersRecursive(ctx context.Context, list *accesslist.AccessList, seenLists utils.Set[accesslists.NormalizedSQN], seenUsers utils.Set[string]) iter.Seq2[*accesslist.AccessListMember, error] {
 	return func(yield func(*accesslist.AccessListMember, error) bool) {
-		seenLists.Add(list.GetName())
+		listName := accesslists.ScopeQualifiedName(list)
+		seenLists.Add(listName)
 		if hasMembershipRequires(list) {
 			// membership requires are not supported in lists that transitively
 			// grant scoped roles, do not walk members of this list.
 			return
 		}
 
-		for member, err := range clientutils.Resources(ctx, listAccessListMembers(m.aclReader, list.GetName())) {
+		for member, err := range clientutils.Resources(ctx, listAccessListMembers(m.aclReader, listName)) {
 			if err != nil {
 				if !yield(nil, trace.Wrap(err)) {
 					return
@@ -1094,20 +1233,26 @@ func (m *Materializer) walkUserMembersRecursive(ctx context.Context, list *acces
 				}
 			}
 
-			if member.Spec.MembershipKind != accesslist.MembershipKindList {
-				// Currently members can only be users or lists, may need to
-				// handle bots in the future.
+			if !member.IsList() {
+				continue
+			}
+
+			memberListName, err := accesslists.MemberScopeQualifiedName(member)
+			if err != nil {
+				if !yield(nil, trace.Wrap(err)) {
+					return
+				}
 				continue
 			}
 
 			// Don't walk through this list if has already been seen.
-			if seenLists.Contains(member.GetName()) {
+			if seenLists.Contains(memberListName) {
 				continue
 			}
 
 			// Fetch the member list resource so the recursive call can check
 			// if it has any membership requires.
-			memberList, err := m.aclReader.GetAccessList(ctx, member.GetName())
+			memberList, err := getAccessList(ctx, m.aclReader, memberListName)
 			if err != nil {
 				// Yield the error so the caller can handle it how it wants,
 				// but continue iterating other nested members.
@@ -1123,96 +1268,96 @@ func (m *Materializer) walkUserMembersRecursive(ctx context.Context, list *acces
 	}
 }
 
-type mapStringSet struct {
-	m map[string]utils.Set[string]
+type mapNormalizedSQNSet struct {
+	m map[accesslists.NormalizedSQN]utils.Set[accesslists.NormalizedSQN]
 }
 
-func newMapStringSet() mapStringSet {
-	return mapStringSet{
-		m: make(map[string]utils.Set[string]),
+func newMapNormalizedSQNSet() mapNormalizedSQNSet {
+	return mapNormalizedSQNSet{
+		m: make(map[accesslists.NormalizedSQN]utils.Set[accesslists.NormalizedSQN]),
 	}
 }
 
 // readOnlySet implements a read-only view of a utils.Set[string] that only
 // contains methods guaranteed to work even if the underlying map is nil.
 type readOnlySet struct {
-	s utils.Set[string]
+	s utils.Set[accesslists.NormalizedSQN]
 }
 
 // Contains implements a membership test for the readOnlySet.
-func (s readOnlySet) Contains(key string) bool {
+func (s readOnlySet) Contains(key accesslists.NormalizedSQN) bool {
 	return s.s.Contains(key)
 }
 
 // Items returns an iterator over all items in the set.
-func (s readOnlySet) Items() iter.Seq[string] {
+func (s readOnlySet) Items() iter.Seq[accesslists.NormalizedSQN] {
 	return maps.Keys(s.s)
 }
 
 // Get returns a read-only view of the set for the given key, it does not
 // allocate a set if the key is not present.
-func (m *mapStringSet) Get(key string) readOnlySet {
+func (m *mapNormalizedSQNSet) Get(key accesslists.NormalizedSQN) readOnlySet {
 	return readOnlySet{m.m[key]}
 }
 
 // Ensure returns a set for the given key, creating an empty set if one is not
-// currently present. Prefer [mapStringSet.Get] if the retuned set does not
+// currently present. Prefer [mapNormalizedSQNSet.Get] if the returned set does not
 // need to be mutated.
-func (m *mapStringSet) Ensure(key string) utils.Set[string] {
+func (m *mapNormalizedSQNSet) Ensure(key accesslists.NormalizedSQN) utils.Set[accesslists.NormalizedSQN] {
 	if s, ok := m.m[key]; ok {
 		return s
 	}
-	s := utils.NewSet[string]()
+	s := utils.NewSet[accesslists.NormalizedSQN]()
 	m.m[key] = s
 	return s
 }
 
 type ancestorCache struct {
-	parents  mapStringSet
-	children mapStringSet
-	ownedBy  mapStringSet
-	ownersOf mapStringSet
+	parents  mapNormalizedSQNSet
+	children mapNormalizedSQNSet
+	ownedBy  mapNormalizedSQNSet
+	ownersOf mapNormalizedSQNSet
 }
 
 func newAncestorCache() *ancestorCache {
 	return &ancestorCache{
-		parents:  newMapStringSet(),
-		children: newMapStringSet(),
-		ownedBy:  newMapStringSet(),
-		ownersOf: newMapStringSet(),
+		parents:  newMapNormalizedSQNSet(),
+		children: newMapNormalizedSQNSet(),
+		ownedBy:  newMapNormalizedSQNSet(),
+		ownersOf: newMapNormalizedSQNSet(),
 	}
 }
 
-func (c *ancestorCache) addMembership(parent, member string) {
+func (c *ancestorCache) addMembership(parent, member accesslists.NormalizedSQN) {
 	c.parents.Ensure(member).Add(parent)
 	c.children.Ensure(parent).Add(member)
 }
 
-func (c *ancestorCache) removeMembership(parent, member string) {
+func (c *ancestorCache) removeMembership(parent, member accesslists.NormalizedSQN) {
 	c.parents.Ensure(member).Remove(parent)
 	c.children.Ensure(parent).Remove(member)
 }
 
-func (c *ancestorCache) addOwnership(owner, owned string) {
+func (c *ancestorCache) addOwnership(owner, owned accesslists.NormalizedSQN) {
 	c.ownedBy.Ensure(owner).Add(owned)
 	c.ownersOf.Ensure(owned).Add(owner)
 }
 
-func (c *ancestorCache) removeOwnership(owner, owned string) {
+func (c *ancestorCache) removeOwnership(owner, owned accesslists.NormalizedSQN) {
 	c.ownedBy.Ensure(owner).Remove(owned)
 	c.ownersOf.Ensure(owned).Remove(owner)
 }
 
-func (c *ancestorCache) clearOwnersOf(owned string) {
+func (c *ancestorCache) clearOwnersOf(owned accesslists.NormalizedSQN) {
 	for owner := range c.ownersOf.Get(owned).Items() {
 		c.removeOwnership(owner, owned)
 	}
 }
 
 type collectAncestorListsParams struct {
-	startListName      string
-	validateMembership func(parentListName, memberListName string) bool
-	validateOwnership  func(ownerListName, ownedListName string) bool
+	startListName      accesslists.NormalizedSQN
+	validateMembership func(parentListName, memberListName accesslists.NormalizedSQN) bool
+	validateOwnership  func(ownerListName, ownedListName accesslists.NormalizedSQN) bool
 }
 
 type ancestorRelation struct {
@@ -1224,23 +1369,23 @@ type ancestorRelation struct {
 // list, that is all lists where the given list is a (nested) member or owner.
 // This may be useful for calculating all related lists that may require an
 // assignment to be materialized for members of the starting list.
-func (c *ancestorCache) collectAncestorLists(params collectAncestorListsParams) map[string]ancestorRelation {
-	result := make(map[string]ancestorRelation)
-	markOwned := func(ownedListName string) {
+func (c *ancestorCache) collectAncestorLists(params collectAncestorListsParams) map[accesslists.NormalizedSQN]ancestorRelation {
+	result := make(map[accesslists.NormalizedSQN]ancestorRelation)
+	markOwned := func(ownedListName accesslists.NormalizedSQN) {
 		curr := result[ownedListName]
 		curr.isOwner = true
 		result[ownedListName] = curr
 	}
-	markMember := func(parentListName string) {
+	markMember := func(parentListName accesslists.NormalizedSQN) {
 		curr := result[parentListName]
 		curr.isMember = true
 		result[parentListName] = curr
 	}
 
-	seen := utils.NewSet[string]()
+	seen := utils.NewSet[accesslists.NormalizedSQN]()
 
-	var collectAncestorsRecursive func(currListName string)
-	collectAncestorsRecursive = func(currListName string) {
+	var collectAncestorsRecursive func(currListName accesslists.NormalizedSQN)
+	collectAncestorsRecursive = func(currListName accesslists.NormalizedSQN) {
 		if seen.Contains(currListName) {
 			return
 		}
@@ -1282,11 +1427,11 @@ func (c *ancestorCache) collectAncestorLists(params collectAncestorListsParams) 
 // This is useful when handling membership deletions, which requires
 // pessimistic validation of every possible already-materialized assignment
 // that may need to be invalidated.
-func (m *Materializer) collectAncestorListsWithoutValidation(startListName string) map[string]ancestorRelation {
+func (m *Materializer) collectAncestorListsWithoutValidation(startListName accesslists.NormalizedSQN) map[accesslists.NormalizedSQN]ancestorRelation {
 	return m.ancestorCache.collectAncestorLists(collectAncestorListsParams{
 		startListName:      startListName,
-		validateMembership: func(string, string) bool { return true },
-		validateOwnership:  func(string, string) bool { return true },
+		validateMembership: func(accesslists.NormalizedSQN, accesslists.NormalizedSQN) bool { return true },
+		validateOwnership:  func(accesslists.NormalizedSQN, accesslists.NormalizedSQN) bool { return true },
 	})
 }
 
@@ -1313,15 +1458,23 @@ type ancestor struct {
 // contain any ownership requires.
 //
 // Finally, any lists that do not contain any effective scoped role grants are
-// filted out. It is safe to materialize an assignment for all returned lists
+// filtered out. It is safe to materialize an assignment for all returned lists
 // without any further validation.
-func (m *Materializer) collectAncestors(ctx context.Context, startListName string) ([]ancestor, []error) {
+func (m *Materializer) collectAncestors(ctx context.Context, startListName accesslists.NormalizedSQN) ([]ancestor, []error) {
 	var validationErrors []error
-	fetchedLists := make(map[string]*accesslist.AccessList)
+	fetchedLists := make(map[accesslists.NormalizedSQN]*accesslist.AccessList)
 	ancestorRelations := m.ancestorCache.collectAncestorLists(collectAncestorListsParams{
 		startListName: startListName,
-		validateMembership: func(parentListName, memberListName string) bool {
-			memberResource, err := m.aclReader.GetAccessListMember(ctx, parentListName, memberListName)
+		validateMembership: func(parentListName, memberListName accesslists.NormalizedSQN) bool {
+			if memberListName.Scope != "" && !scopes.PolicyResourceScope(parentListName.Scope).CanDependOnStateFromPolicyResourceAtScope(memberListName.Scope) {
+				return false
+			}
+			memberResource, err := m.aclReader.GetAccessListMemberV2(ctx, accesslistv1.GetAccessListMemberRequest_builder{
+				AccessList:      parentListName.Name,
+				AccessListScope: parentListName.Scope,
+				MemberName:      memberListName.Name,
+				MemberScope:     memberListName.Scope,
+			}.Build())
 			if err != nil {
 				validationErrors = append(validationErrors,
 					trace.Wrap(err, "getting access list member %q in list %q", memberListName, parentListName))
@@ -1332,7 +1485,7 @@ func (m *Materializer) collectAncestors(ctx context.Context, startListName strin
 				// expected but should not be followed.
 				return false
 			}
-			parentList, err := m.aclReader.GetAccessList(ctx, parentListName)
+			parentList, err := getAccessList(ctx, m.aclReader, parentListName)
 			if err != nil {
 				validationErrors = append(validationErrors,
 					trace.Wrap(err, "getting access list %q", parentListName))
@@ -1348,8 +1501,11 @@ func (m *Materializer) collectAncestors(ctx context.Context, startListName strin
 			}
 			return true
 		},
-		validateOwnership: func(parentListName, ownedListName string) bool {
-			ownedList, err := m.aclReader.GetAccessList(ctx, ownedListName)
+		validateOwnership: func(ownerListName, ownedListName accesslists.NormalizedSQN) bool {
+			if ownerListName.Scope != "" && !scopes.PolicyResourceScope(ownedListName.Scope).CanDependOnStateFromPolicyResourceAtScope(ownerListName.Scope) {
+				return false
+			}
+			ownedList, err := getAccessList(ctx, m.aclReader, ownedListName)
 			if err != nil {
 				validationErrors = append(validationErrors,
 					trace.Wrap(err, "getting access list %q", ownedListName))
@@ -1529,7 +1685,7 @@ func (m *Materializer) repairExpiredMembers(ctx context.Context) {
 
 // collectExpiredMembers collects all expired access list members by parent
 // list, and returns the earliest seen future expiry.
-func (m *Materializer) collectExpiredMembers(ctx context.Context) (expiredMembersOf map[string]expiredMembers, nextExpiry time.Time) {
+func (m *Materializer) collectExpiredMembers(ctx context.Context) (expiredMembersOf map[accesslists.NormalizedSQN]expiredMembers, nextExpiry time.Time) {
 	// Use a consistent time for "now" so that this will report all members
 	// expired before this time, and schedule another repair for any members
 	// expiring after this time.
@@ -1538,11 +1694,11 @@ func (m *Materializer) collectExpiredMembers(ctx context.Context) (expiredMember
 	// Keep track of the nearest seen member expiry time that's in the future.
 	nextExpiry = now.Add(century)
 
-	expiredMembersOf = make(map[string]expiredMembers)
+	expiredMembersOf = make(map[accesslists.NormalizedSQN]expiredMembers)
 	expiredCount := 0
 
 	// Iterate all access list members to find any that are expired.
-	for member, err := range clientutils.Resources(ctx, m.aclReader.ListAllAccessListMembers) {
+	for member, err := range clientutils.Resources(ctx, listAllAccessListMembers(m.aclReader)) {
 		if err != nil {
 			// Failed to iterate all access list member resources, we may have
 			// missed an expired member or one that will be expiring soon.
@@ -1568,10 +1724,19 @@ func (m *Materializer) collectExpiredMembers(ctx context.Context) (expiredMember
 			"membership_kind", member.Spec.MembershipKind,
 			"expired", member.Spec.Expires)
 
+		parentList, err := accesslists.ParentListOf(member)
+		if err != nil {
+			m.logger.DebugContext(ctx, "Failed to parse parent list of expired member resource",
+				"list", member.Spec.AccessList,
+				"member", member.GetName(),
+				"membership_kind", member.Spec.MembershipKind,
+				"expired", member.Spec.Expires)
+		}
+
 		// Collect the expired membership.
-		knownExpiredMembers := expiredMembersOf[member.Spec.AccessList]
+		knownExpiredMembers := expiredMembersOf[parentList]
 		knownExpiredMembers.insert(member)
-		expiredMembersOf[member.Spec.AccessList] = knownExpiredMembers
+		expiredMembersOf[parentList] = knownExpiredMembers
 		expiredCount++
 	}
 	oteltrace.SpanFromContext(ctx).SetAttributes(attribute.Int("members.expired", expiredCount))
@@ -1581,8 +1746,8 @@ func (m *Materializer) collectExpiredMembers(ctx context.Context) (expiredMember
 
 // affectedAssignmentsForExpiredMembers returns an iterator of all current
 // materialized assignments that may be affected by an expired membership.
-func (m *Materializer) affectedAssignmentsForExpiredMembers(expiredMembersOf map[string]expiredMembers) iter.Seq[MaterializedAssignmentKey] {
-	assignmentFilters := make(map[string]assignmentFilter)
+func (m *Materializer) affectedAssignmentsForExpiredMembers(expiredMembersOf map[accesslists.NormalizedSQN]expiredMembers) iter.Seq[MaterializedAssignmentKey] {
+	assignmentFilters := make(map[accesslists.NormalizedSQN]assignmentFilter)
 	for parentListName, knownExpiredMembers := range expiredMembersOf {
 		currFilter := assignmentFilters[parentListName]
 		currFilter.merge(assignmentFilter{
@@ -1615,7 +1780,7 @@ func (m *Materializer) affectedAssignmentsForExpiredMembers(expiredMembersOf map
 
 	return func(yield func(MaterializedAssignmentKey) bool) {
 		for key := range m.materializedAssignments {
-			if !assignmentFilters[key.List].match(key.User) {
+			if !assignmentFilters[key.listSQN()].match(key.User) {
 				continue
 			}
 			if !yield(key) {
@@ -1631,7 +1796,7 @@ type expiredMembers struct {
 }
 
 func (m *expiredMembers) insert(member *accesslist.AccessListMember) {
-	m.hasExpiredListMember = m.hasExpiredListMember || member.Spec.MembershipKind == accesslist.MembershipKindList
+	m.hasExpiredListMember = m.hasExpiredListMember || member.IsList()
 	if m.hasExpiredListMember {
 		// users set is unneeded if there is an expired list member.
 		m.users = nil
@@ -1681,7 +1846,7 @@ func (m *Materializer) repairMissedMembers(ctx context.Context) {
 	// Iterate all access lists to additively materialize assignments for all
 	// their members and owners.
 	repairedLists := 0
-	for list, err := range clientutils.Resources(ctx, m.aclReader.ListAccessLists) {
+	for list, err := range clientutils.Resources(ctx, listAccessLists(m.aclReader)) {
 		if err != nil {
 			m.logger.InfoContext(ctx, "Missed membership repair failed to read all access lists, scheduling another repair",
 				"error", err)

--- a/lib/scopes/cache/access/materializer_test.go
+++ b/lib/scopes/cache/access/materializer_test.go
@@ -26,10 +26,12 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -40,6 +42,7 @@ import (
 	cachepkg "github.com/gravitational/teleport/lib/cache"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/observability/tracing"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/cache/access"
 	"github.com/gravitational/teleport/lib/scopes/cache/assignments"
@@ -55,7 +58,7 @@ func TestMain(m *testing.M) {
 
 type materializerTestcase struct {
 	// An initial collection of access lists and members for the test case.
-	collection accesslists.Collection
+	collection accesslists.ScopedCollection
 	// Expected assignments after cache init (and materialization).
 	expectedAssignments []*scopedaccessv1.ScopedRoleAssignment
 	// Optional extra mutation steps the test may run.
@@ -86,11 +89,15 @@ func runMaterializerTestcase(t *testing.T, tc materializerTestcase) {
 	aclService, err := local.NewAccessListServiceV2(local.AccessListServiceConfig{
 		Backend: backend,
 		Modules: modulestest.EnterpriseModules(),
+		ScopesFeatures: scopes.Features{
+			Enabled: true,
+		},
 	})
 	require.NoError(t, err)
 
 	// Insert the access lists and members into the backend.
-	require.NoError(t, aclService.InsertAccessListCollection(t.Context(), &tc.collection))
+	err = aclService.InsertScopedAccessListCollection(t.Context(), &tc.collection)
+	require.NoError(t, err, trace.DebugReport(err))
 
 	// Create the access lists cache.
 	aclCache, err := cachepkg.New(cachepkg.Config{
@@ -164,95 +171,179 @@ func runMaterializerTestcase(t *testing.T, tc materializerTestcase) {
 
 func TestMaterializerSimpleChain(t *testing.T) {
 	t.Parallel()
-	runMaterializerTestcase(t, materializerTestcase{
-		collection: accesslists.Collection{
-			AccessListsByName: map[string]*accesslist.AccessList{
-				"grandparent": newAccessList(t, "grandparent", withMemberGrants([]accesslist.ScopedRoleGrant{{
-					Scope: "/aa/bb/cc",
-					Role:  "/::grandparentrole",
-				}})),
-				"parent": newAccessList(t, "parent", withMemberGrants([]accesslist.ScopedRoleGrant{{
-					Scope: "/aa/bb",
-					Role:  "/::parentrole",
-				}})),
-				"base": newAccessList(t, "base", withMemberGrants([]accesslist.ScopedRoleGrant{{
-					Scope: "/aa",
+	t.Run("unscoped", func(t *testing.T) {
+		grandparentName := accesslists.NormalizedSQN{Name: "grandparent"}
+		parentName := accesslists.NormalizedSQN{Name: "parent"}
+		baseName := accesslists.NormalizedSQN{Name: "base"}
+		testMaterializerSimpleChain(t, grandparentName, parentName, baseName)
+	})
+	t.Run("scoped", func(t *testing.T) {
+		grandparentName := accesslists.NormalizedSQN{
+			Scope: "/aa/bb/cc",
+			Name:  "grandparent",
+		}
+		parentName := accesslists.NormalizedSQN{
+			Scope: "/aa/bb",
+			Name:  "parent",
+		}
+		baseName := accesslists.NormalizedSQN{
+			Scope: "/aa",
+			Name:  "base",
+		}
+		testMaterializerSimpleChain(t, grandparentName, parentName, baseName)
+	})
+}
+
+func testMaterializerSimpleChain(t *testing.T, grandparentName, parentName, baseName accesslists.NormalizedSQN) {
+	synctest.Test(t, func(t *testing.T) {
+		runMaterializerTestcase(t, materializerTestcase{
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+					grandparentName: newAccessList(t, grandparentName, withMemberGrants([]accesslist.ScopedRoleGrant{{
+						Role:  "/::grandparentrole",
+						Scope: "/aa/bb/cc",
+					}})),
+					parentName: newAccessList(t, parentName, withMemberGrants([]accesslist.ScopedRoleGrant{{
+						Role:  "/::parentrole",
+						Scope: "/aa/bb",
+					}})),
+					baseName: newAccessList(t, baseName, withMemberGrants([]accesslist.ScopedRoleGrant{{
+						Role:  "/::baserole",
+						Scope: "/aa",
+					}})),
+				},
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					grandparentName: {
+						newAccessListMember(t, grandparentName, parentName),
+					},
+					parentName: {
+						newAccessListMember(t, parentName, baseName),
+					},
+					baseName: {
+						newUserMember(t, baseName, "tester"),
+					},
+				},
+			},
+			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+				expectedScopedRoleAssignment("tester", baseName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::baserole",
-				}})),
+					Scope: "/aa",
+				}.Build()}),
+				expectedScopedRoleAssignment("tester", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+					Role:  "/::parentrole",
+					Scope: "/aa/bb",
+				}.Build()}),
+				expectedScopedRoleAssignment("tester", grandparentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+					Role:  "/::grandparentrole",
+					Scope: "/aa/bb/cc",
+				}.Build()}),
 			},
-			MembersByAccessList: map[string][]*accesslist.AccessListMember{
-				"grandparent": {
-					newAccessListMember(t, "grandparent", "parent", accesslist.MembershipKindList),
+			steps: []materializerTestcaseStep{
+				// Delete each membership in the chain one by one, the materialized assignments should be deleted.
+				{
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
+						require.NoError(t, state.aclService.DeleteAccessListMemberV2(t.Context(), accesslistv1.DeleteAccessListMemberRequest_builder{
+							AccessList:      grandparentName.Name,
+							AccessListScope: grandparentName.Scope,
+							MemberName:      parentName.Name,
+							MemberScope:     parentName.Scope,
+						}.Build()))
+					},
+					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+						expectedScopedRoleAssignment("tester", baseName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+							Role:  "/::baserole",
+							Scope: "/aa",
+						}.Build()}),
+						expectedScopedRoleAssignment("tester", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+							Role:  "/::parentrole",
+							Scope: "/aa/bb",
+						}.Build()}),
+					},
 				},
-				"parent": {
-					newAccessListMember(t, "parent", "base", accesslist.MembershipKindList),
+				{
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
+						require.NoError(t, state.aclService.DeleteAccessListMemberV2(t.Context(), accesslistv1.DeleteAccessListMemberRequest_builder{
+							AccessList:      parentName.Name,
+							AccessListScope: parentName.Scope,
+							MemberName:      baseName.Name,
+							MemberScope:     baseName.Scope,
+						}.Build()))
+					},
+					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+						expectedScopedRoleAssignment("tester", baseName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+							Role:  "/::baserole",
+							Scope: "/aa",
+						}.Build()}),
+					},
 				},
-				"base": {
-					newAccessListMember(t, "base", "tester", accesslist.MembershipKindUser),
+				{
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
+						require.NoError(t, state.aclService.DeleteAccessListMemberV2(t.Context(), accesslistv1.DeleteAccessListMemberRequest_builder{
+							AccessList:      baseName.Name,
+							AccessListScope: baseName.Scope,
+							MemberName:      "tester",
+						}.Build()))
+					},
+					expectedAssignments: nil,
 				},
 			},
-		},
-		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-			expectedScopedRoleAssignment("tester", "base", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
-				Role:  "/::baserole",
-				Scope: "/aa",
-			}.Build()}),
-			expectedScopedRoleAssignment("tester", "parent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
-				Role:  "/::parentrole",
-				Scope: "/aa/bb",
-			}.Build()}),
-			expectedScopedRoleAssignment("tester", "grandparent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
-				Role:  "/::grandparentrole",
-				Scope: "/aa/bb/cc",
-			}.Build()}),
-		},
+		})
 	})
 }
 
 func TestMaterializerDoubleListMembership(t *testing.T) {
 	t.Parallel()
+	parentName := accesslists.NormalizedSQN{
+		Scope: "/parentscope",
+		Name:  "parent",
+	}
+	memberListAName := accesslists.NormalizedSQN{
+		Scope: "/parentscope",
+		Name:  "member-list-a",
+	}
+	memberListBName := accesslists.NormalizedSQN{Name: "memberListB"}
 	runMaterializerTestcase(t, materializerTestcase{
-		collection: accesslists.Collection{
-			AccessListsByName: map[string]*accesslist.AccessList{
-				"parent": newAccessList(t, "parent", withMemberGrants([]accesslist.ScopedRoleGrant{{
+		collection: accesslists.ScopedCollection{
+			AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+				parentName: newAccessList(t, parentName, withMemberGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/parentscope",
 					Role:  "/::parentrole",
 				}})),
-				"memberListA": newAccessList(t, "memberListA"),
-				"memberListB": newAccessList(t, "memberListB"),
+				memberListAName: newAccessList(t, memberListAName),
+				memberListBName: newAccessList(t, memberListBName),
 			},
-			MembersByAccessList: map[string][]*accesslist.AccessListMember{
-				"parent": {
-					newAccessListMember(t, "parent", "memberListA", accesslist.MembershipKindList),
-					newAccessListMember(t, "parent", "memberListB", accesslist.MembershipKindList),
-					newAccessListMember(t, "parent", "testerD", accesslist.MembershipKindUser),
+			MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+				parentName: {
+					newAccessListMember(t, parentName, memberListAName),
+					newAccessListMember(t, parentName, memberListBName),
+					newUserMember(t, parentName, "testerD"),
 				},
-				"memberListA": {
-					newAccessListMember(t, "memberListA", "testerA", accesslist.MembershipKindUser),
-					newAccessListMember(t, "memberListA", "testerC", accesslist.MembershipKindUser),
+				memberListAName: {
+					newUserMember(t, memberListAName, "testerA"),
+					newUserMember(t, memberListAName, "testerC"),
 				},
-				"memberListB": {
-					newAccessListMember(t, "memberListB", "testerB", accesslist.MembershipKindUser),
-					newAccessListMember(t, "memberListB", "testerC", accesslist.MembershipKindUser),
+				memberListBName: {
+					newUserMember(t, memberListBName, "testerB"),
+					newUserMember(t, memberListBName, "testerC"),
 				},
 			},
 		},
 		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 			// All users should be direct or nested members of the parent role,
 			// expect exactly one materialized assignment each.
-			expectedScopedRoleAssignment("testerA", "parent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("testerA", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::parentrole",
 				Scope: "/parentscope",
 			}.Build()}),
-			expectedScopedRoleAssignment("testerB", "parent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("testerB", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::parentrole",
 				Scope: "/parentscope",
 			}.Build()}),
-			expectedScopedRoleAssignment("testerC", "parent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("testerC", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::parentrole",
 				Scope: "/parentscope",
 			}.Build()}),
-			expectedScopedRoleAssignment("testerD", "parent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("testerD", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::parentrole",
 				Scope: "/parentscope",
 			}.Build()}),
@@ -262,38 +353,41 @@ func TestMaterializerDoubleListMembership(t *testing.T) {
 
 func TestMaterializerDoubleListParents(t *testing.T) {
 	t.Parallel()
+	parentAName := accesslists.NormalizedSQN{Scope: "/aa", Name: "parent-a"}
+	parentBName := accesslists.NormalizedSQN{Scope: "/bb", Name: "parent-b"}
+	childName := accesslists.NormalizedSQN{Scope: "/", Name: "child"}
 	runMaterializerTestcase(t, materializerTestcase{
-		collection: accesslists.Collection{
-			AccessListsByName: map[string]*accesslist.AccessList{
-				"parentA": newAccessList(t, "parentA", withMemberGrants([]accesslist.ScopedRoleGrant{{
+		collection: accesslists.ScopedCollection{
+			AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+				parentAName: newAccessList(t, parentAName, withMemberGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/aa",
 					Role:  "/::rolea",
 				}})),
-				"parentB": newAccessList(t, "parentB", withMemberGrants([]accesslist.ScopedRoleGrant{{
+				parentBName: newAccessList(t, parentBName, withMemberGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/bb",
 					Role:  "/::roleb",
 				}})),
-				"child": newAccessList(t, "child"),
+				childName: newAccessList(t, childName),
 			},
-			MembersByAccessList: map[string][]*accesslist.AccessListMember{
-				"parentA": {
-					newAccessListMember(t, "parentA", "child", accesslist.MembershipKindList),
+			MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+				parentAName: {
+					newAccessListMember(t, parentAName, childName),
 				},
-				"parentB": {
-					newAccessListMember(t, "parentB", "child", accesslist.MembershipKindList),
+				parentBName: {
+					newAccessListMember(t, parentBName, childName),
 				},
-				"child": {
-					newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser),
+				childName: {
+					newUserMember(t, childName, "tester"),
 				},
 			},
 		},
 		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 			// User should be a nested member of both parents and get an assignment for each.
-			expectedScopedRoleAssignment("tester", "parentA", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("tester", parentAName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::rolea",
 				Scope: "/aa",
 			}.Build()}),
-			expectedScopedRoleAssignment("tester", "parentB", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("tester", parentBName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::roleb",
 				Scope: "/bb",
 			}.Build()}),
@@ -303,10 +397,11 @@ func TestMaterializerDoubleListParents(t *testing.T) {
 
 func TestMaterializerDirectOwner(t *testing.T) {
 	t.Parallel()
+	listName := accesslists.NormalizedSQN{Scope: "/aa", Name: "testlist"}
 	runMaterializerTestcase(t, materializerTestcase{
-		collection: accesslists.Collection{
-			AccessListsByName: map[string]*accesslist.AccessList{
-				"testlist": newAccessList(t, "testlist", withOwnerGrants([]accesslist.ScopedRoleGrant{{
+		collection: accesslists.ScopedCollection{
+			AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+				listName: newAccessList(t, listName, withOwnerGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/aa",
 					Role:  "/::testrole",
 				}}), withOwners([]accesslist.Owner{{
@@ -314,14 +409,14 @@ func TestMaterializerDirectOwner(t *testing.T) {
 					MembershipKind: accesslist.MembershipKindUser,
 				}})),
 			},
-			MembersByAccessList: map[string][]*accesslist.AccessListMember{
-				"testlist": {},
+			MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+				listName: {},
 			},
 		},
 		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 			// The user is simply a direct owner of the access list and an
 			// assignment is expected.
-			expectedScopedRoleAssignment("tester", "testlist", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("tester", listName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::testrole",
 				Scope: "/aa",
 			}.Build()}),
@@ -331,11 +426,13 @@ func TestMaterializerDirectOwner(t *testing.T) {
 
 func TestMaterializerUserMemberPutPreservesExistingOwnerGrant(t *testing.T) {
 	t.Parallel()
+	grantedName := accesslists.NormalizedSQN{Scope: "/", Name: "granted"}
+	childName := accesslists.NormalizedSQN{Scope: "/", Name: "child"}
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: accesslists.Collection{
-				AccessListsByName: map[string]*accesslist.AccessList{
-					"granted": newAccessList(t, "granted",
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+					grantedName: newAccessList(t, grantedName,
 						withMemberGrants([]accesslist.ScopedRoleGrant{{
 							Scope: "/member",
 							Role:  "/::memberrole",
@@ -349,31 +446,30 @@ func TestMaterializerUserMemberPutPreservesExistingOwnerGrant(t *testing.T) {
 							MembershipKind: accesslist.MembershipKindUser,
 						}}),
 					),
-					"child": newAccessList(t, "child"),
+					childName: newAccessList(t, childName),
 				},
-				MembersByAccessList: map[string][]*accesslist.AccessListMember{
-					"granted": {
-						newAccessListMember(t, "granted", "child", accesslist.MembershipKindList),
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					grantedName: {
+						newAccessListMember(t, grantedName, childName),
 					},
-					"child": {},
+					childName: {},
 				},
 			},
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-				expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("tester", grantedName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::ownerrole",
 					Scope: "/owner",
 				}.Build()}),
 			},
 			steps: []materializerTestcaseStep{{
 				mutateState: func(t *testing.T, state *materializerTestcaseState) {
-					_, err := state.aclService.UpsertAccessListMember(t.Context(),
-						newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser))
+					_, err := state.aclService.UpsertAccessListMember(t.Context(), newUserMember(t, childName, "tester"))
 					require.NoError(t, err)
 				},
 				expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 					// tester is now both a direct owner of granted and a nested member via child,
 					// so the materialized assignment must include both grants.
-					expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+					expectedScopedRoleAssignment("tester", grantedName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 						Role:  "/::memberrole",
 						Scope: "/member",
 					}.Build(), scopedaccessv1.Assignment_builder{
@@ -388,11 +484,14 @@ func TestMaterializerUserMemberPutPreservesExistingOwnerGrant(t *testing.T) {
 
 func TestMaterializerListMemberPutPreservesExistingOwnerGrant(t *testing.T) {
 	t.Parallel()
+	grantedName := accesslists.NormalizedSQN{Scope: "/", Name: "granted"}
+	parentName := accesslists.NormalizedSQN{Scope: "/", Name: "parent"}
+	childName := accesslists.NormalizedSQN{Scope: "/", Name: "child"}
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: accesslists.Collection{
-				AccessListsByName: map[string]*accesslist.AccessList{
-					"granted": newAccessList(t, "granted",
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+					grantedName: newAccessList(t, grantedName,
 						withMemberGrants([]accesslist.ScopedRoleGrant{{
 							Scope: "/member",
 							Role:  "/::memberrole",
@@ -406,21 +505,21 @@ func TestMaterializerListMemberPutPreservesExistingOwnerGrant(t *testing.T) {
 							MembershipKind: accesslist.MembershipKindUser,
 						}}),
 					),
-					"parent": newAccessList(t, "parent"),
-					"child":  newAccessList(t, "child"),
+					parentName: newAccessList(t, parentName),
+					childName:  newAccessList(t, childName),
 				},
-				MembersByAccessList: map[string][]*accesslist.AccessListMember{
-					"granted": {
-						newAccessListMember(t, "granted", "parent", accesslist.MembershipKindList),
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					grantedName: {
+						newAccessListMember(t, grantedName, parentName),
 					},
-					"parent": {},
-					"child": {
-						newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser),
+					parentName: {},
+					childName: {
+						newUserMember(t, childName, "tester"),
 					},
 				},
 			},
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-				expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("tester", grantedName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::ownerrole",
 					Scope: "/owner",
 				}.Build()}),
@@ -428,13 +527,13 @@ func TestMaterializerListMemberPutPreservesExistingOwnerGrant(t *testing.T) {
 			steps: []materializerTestcaseStep{{
 				mutateState: func(t *testing.T, state *materializerTestcaseState) {
 					_, err := state.aclService.UpsertAccessListMember(t.Context(),
-						newAccessListMember(t, "parent", "child", accesslist.MembershipKindList))
+						newAccessListMember(t, parentName, childName))
 					require.NoError(t, err)
 				},
 				expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 					// tester is now both a direct owner of granted and a nested member via
 					// parent->child, so the materialized assignment must include both grants.
-					expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+					expectedScopedRoleAssignment("tester", grantedName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 						Role:  "/::memberrole",
 						Scope: "/member",
 					}.Build(), scopedaccessv1.Assignment_builder{
@@ -449,11 +548,13 @@ func TestMaterializerListMemberPutPreservesExistingOwnerGrant(t *testing.T) {
 
 func TestMaterializerAccessListPutPreservesExistingOwnerGrant(t *testing.T) {
 	t.Parallel()
+	grantedName := accesslists.NormalizedSQN{Scope: "/", Name: "granted"}
+	childName := accesslists.NormalizedSQN{Name: "child"}
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: accesslists.Collection{
-				AccessListsByName: map[string]*accesslist.AccessList{
-					"granted": newAccessList(t, "granted",
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+					grantedName: newAccessList(t, grantedName,
 						withMemberGrants([]accesslist.ScopedRoleGrant{{
 							Scope: "/member",
 							Role:  "/::memberrole",
@@ -469,20 +570,20 @@ func TestMaterializerAccessListPutPreservesExistingOwnerGrant(t *testing.T) {
 					),
 					// child list starts with membership requirements, so any
 					// memberships are initially invalid.
-					"child": newAccessList(t, "child", withMembershipRequires()),
+					childName: newAccessList(t, childName, withMembershipRequires()),
 				},
-				MembersByAccessList: map[string][]*accesslist.AccessListMember{
-					"granted": {
-						newAccessListMember(t, "granted", "child", accesslist.MembershipKindList),
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					grantedName: {
+						newAccessListMember(t, grantedName, childName),
 					},
-					"child": {
-						newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser),
+					childName: {
+						newUserMember(t, childName, "tester"),
 					},
 				},
 			},
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 				// tests is initially ownly an owner of the granted list.
-				expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("tester", grantedName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::ownerrole",
 					Scope: "/owner",
 				}.Build()}),
@@ -491,13 +592,13 @@ func TestMaterializerAccessListPutPreservesExistingOwnerGrant(t *testing.T) {
 				mutateState: func(t *testing.T, state *materializerTestcaseState) {
 					// remove the membership requirements so that tester
 					// becomes a legitimate member of child and granted lists.
-					_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, "child"))
+					_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, childName))
 					require.NoError(t, err)
 				},
 				expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 					// as tests is now a member and owner of granted, make sure
 					// the materialiazed assignment includes both grants.
-					expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+					expectedScopedRoleAssignment("tester", grantedName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 						Role:  "/::memberrole",
 						Scope: "/member",
 					}.Build(), scopedaccessv1.Assignment_builder{
@@ -512,26 +613,29 @@ func TestMaterializerAccessListPutPreservesExistingOwnerGrant(t *testing.T) {
 
 func TestMaterializerOwnerRequirements(t *testing.T) {
 	t.Parallel()
+	grantedName := accesslists.NormalizedSQN{Scope: "/aa", Name: "granted"}
+	ownersName := accesslists.NormalizedSQN{Name: "owners"}
+	nestedName := accesslists.NormalizedSQN{Name: "nested"}
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: accesslists.Collection{
-				AccessListsByName: map[string]*accesslist.AccessList{
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
 					// Ownership requirements in the owner list should not block
 					// _members_ of the owner list from receiving owner grants
 					// present in the granted list.
-					"granted": newAccessList(t, "granted", withOwnerGrants([]accesslist.ScopedRoleGrant{{
+					grantedName: newAccessList(t, grantedName, withOwnerGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/aa",
 						Role:  "/::ownerrole",
 					}}), withOwners([]accesslist.Owner{{
 						Name:           "owners",
 						MembershipKind: accesslist.MembershipKindList,
 					}})),
-					"owners": newAccessList(t, "owners", withOwnershipRequires()),
+					ownersName: newAccessList(t, ownersName, withOwnershipRequires()),
 				},
-				MembersByAccessList: map[string][]*accesslist.AccessListMember{
-					"granted": {},
-					"owners": {
-						newAccessListMember(t, "owners", "tester", accesslist.MembershipKindUser),
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					grantedName: {},
+					ownersName: {
+						newUserMember(t, ownersName, "tester"),
 					},
 				},
 			},
@@ -539,7 +643,7 @@ func TestMaterializerOwnerRequirements(t *testing.T) {
 				// tester is a valid member of list "owners". All valid members of
 				// list "owners" are valid _owners_ of list "granted", so the
 				// assignment should be materialized.
-				expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("tester", grantedName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::ownerrole",
 					Scope: "/aa",
 				}.Build()}),
@@ -547,24 +651,24 @@ func TestMaterializerOwnerRequirements(t *testing.T) {
 			steps: []materializerTestcaseStep{{
 				mutateState: func(t *testing.T, state *materializerTestcaseState) {
 					// Add a nested list as a member of the owners list.
-					_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, "nested"))
+					_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, nestedName))
 					require.NoError(t, err)
 					_, err = state.aclService.UpsertAccessListMember(t.Context(),
-						newAccessListMember(t, "owners", "nested", accesslist.MembershipKindList))
+						newAccessListMember(t, ownersName, nestedName))
 					require.NoError(t, err)
 					// Add a user as a member of the nested list.
 					_, err = state.aclService.UpsertAccessListMember(t.Context(),
-						newAccessListMember(t, "nested", "nested_tester", accesslist.MembershipKindUser))
+						newUserMember(t, nestedName, "nested_tester"))
 					require.NoError(t, err)
 				},
 				expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 					// The nested user is also a valid member of the owners list so
 					// should also have an assignment materialized.
-					expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+					expectedScopedRoleAssignment("tester", grantedName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 						Role:  "/::ownerrole",
 						Scope: "/aa",
 					}.Build()}),
-					expectedScopedRoleAssignment("nested_tester", "granted", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+					expectedScopedRoleAssignment("nested_tester", grantedName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 						Role:  "/::ownerrole",
 						Scope: "/aa",
 					}.Build()}),
@@ -576,24 +680,27 @@ func TestMaterializerOwnerRequirements(t *testing.T) {
 
 func TestMaterializerOwnerChain(t *testing.T) {
 	t.Parallel()
+	grandParentName := accesslists.NormalizedSQN{Scope: "/aa/bb/cc", Name: "grandparent"}
+	parentName := accesslists.NormalizedSQN{Scope: "/aa/bb", Name: "parent"}
+	baseName := accesslists.NormalizedSQN{Scope: "/aa", Name: "base"}
 	runMaterializerTestcase(t, materializerTestcase{
-		collection: accesslists.Collection{
-			AccessListsByName: map[string]*accesslist.AccessList{
-				"grandparent": newAccessList(t, "grandparent", withOwnerGrants([]accesslist.ScopedRoleGrant{{
+		collection: accesslists.ScopedCollection{
+			AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+				grandParentName: newAccessList(t, grandParentName, withOwnerGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/aa/bb/cc",
 					Role:  "/::grandparentownerrole",
 				}}), withOwners([]accesslist.Owner{{
-					Name:           "parent",
-					MembershipKind: accesslist.MembershipKindList,
+					Name:           parentName.String(),
+					MembershipKind: accesslist.MembershipKindScopedList,
 				}})),
-				"parent": newAccessList(t, "parent", withOwnerGrants([]accesslist.ScopedRoleGrant{{
+				parentName: newAccessList(t, parentName, withOwnerGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/aa/bb",
 					Role:  "/::parentownerrole",
 				}}), withOwners([]accesslist.Owner{{
-					Name:           "base",
-					MembershipKind: accesslist.MembershipKindList,
+					Name:           baseName.String(),
+					MembershipKind: accesslist.MembershipKindScopedList,
 				}})),
-				"base": newAccessList(t, "base", withOwnerGrants([]accesslist.ScopedRoleGrant{{
+				baseName: newAccessList(t, baseName, withOwnerGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/aa",
 					Role:  "/::baseownerrole",
 				}}), withOwners([]accesslist.Owner{{
@@ -601,38 +708,38 @@ func TestMaterializerOwnerChain(t *testing.T) {
 					MembershipKind: accesslist.MembershipKindUser,
 				}})),
 			},
-			MembersByAccessList: map[string][]*accesslist.AccessListMember{
-				"grandparent": {
-					newAccessListMember(t, "grandparent", "parent", accesslist.MembershipKindList),
-					newAccessListMember(t, "grandparent", "grandparentmember", accesslist.MembershipKindUser),
+			MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+				grandParentName: {
+					newAccessListMember(t, grandParentName, parentName),
+					newUserMember(t, grandParentName, "grandparentmember"),
 				},
-				"parent": {
-					newAccessListMember(t, "parent", "base", accesslist.MembershipKindList),
-					newAccessListMember(t, "parent", "parentmember", accesslist.MembershipKindUser),
+				parentName: {
+					newAccessListMember(t, parentName, baseName),
+					newUserMember(t, parentName, "parentmember"),
 				},
-				"base": {
-					newAccessListMember(t, "base", "basemember", accesslist.MembershipKindUser),
+				baseName: {
+					newUserMember(t, baseName, "basemember"),
 				},
 			},
 		},
 		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 			// baseowner is a direct owner of base list. Ownership is not inherited.
-			expectedScopedRoleAssignment("baseowner", "base", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("baseowner", baseName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::baseownerrole",
 				Scope: "/aa",
 			}.Build()}),
 			// basemember is a member of base list, base list is an owner of parent list.
-			expectedScopedRoleAssignment("basemember", "parent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("basemember", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::parentownerrole",
 				Scope: "/aa/bb",
 			}.Build()}),
 			// basemember is a nested member of parent list, parent list is an owner of grandparent list.
-			expectedScopedRoleAssignment("basemember", "grandparent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("basemember", grandParentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::grandparentownerrole",
 				Scope: "/aa/bb/cc",
 			}.Build()}),
 			// parentmember is a member of parent list, parent list is an owner of grandparent list.
-			expectedScopedRoleAssignment("parentmember", "grandparent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+			expectedScopedRoleAssignment("parentmember", grandParentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 				Role:  "/::grandparentownerrole",
 				Scope: "/aa/bb/cc",
 			}.Build()}),
@@ -642,27 +749,29 @@ func TestMaterializerOwnerChain(t *testing.T) {
 
 func TestMaterializerAccessListPutWithMembershipRequirements(t *testing.T) {
 	t.Parallel()
+	topName := accesslists.NormalizedSQN{Scope: "/aa", Name: "top"}
+	middleName := accesslists.NormalizedSQN{Name: "middle"}
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: accesslists.Collection{
-				AccessListsByName: map[string]*accesslist.AccessList{
-					"top": newAccessList(t, "top", withMemberGrants([]accesslist.ScopedRoleGrant{{
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+					topName: newAccessList(t, topName, withMemberGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/aa",
 						Role:  "/::toprole",
 					}})),
-					"middle": newAccessList(t, "middle"),
+					middleName: newAccessList(t, middleName),
 				},
-				MembersByAccessList: map[string][]*accesslist.AccessListMember{
-					"top": {
-						newAccessListMember(t, "top", "middle", accesslist.MembershipKindList),
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					topName: {
+						newAccessListMember(t, topName, middleName),
 					},
-					"middle": {
-						newAccessListMember(t, "middle", "tester", accesslist.MembershipKindUser),
+					middleName: {
+						newUserMember(t, middleName, "tester"),
 					},
 				},
 			},
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-				expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("tester", topName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::toprole",
 					Scope: "/aa",
 				}.Build()}),
@@ -672,7 +781,7 @@ func TestMaterializerAccessListPutWithMembershipRequirements(t *testing.T) {
 				// assignment for the top list should be deleted as the
 				// membership path is broken.
 				mutateState: func(t *testing.T, state *materializerTestcaseState) {
-					_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, "middle", withMembershipRequires()))
+					_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, middleName, withMembershipRequires()))
 					require.NoError(t, err)
 				},
 				expectedAssignments: nil,
@@ -683,22 +792,24 @@ func TestMaterializerAccessListPutWithMembershipRequirements(t *testing.T) {
 
 func TestMaterializerAccessListMemberKindUpdateInvalidatesPriorKind(t *testing.T) {
 	t.Parallel()
+	parentName := accesslists.NormalizedSQN{Scope: "/aa", Name: "parent"}
+	childName := accesslists.NormalizedSQN{Name: "child"}
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: accesslists.Collection{
-				AccessListsByName: map[string]*accesslist.AccessList{
-					"parent": newAccessList(t, "parent", withMemberGrants([]accesslist.ScopedRoleGrant{{
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+					parentName: newAccessList(t, parentName, withMemberGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/aa",
 						Role:  "/::parentrole",
 					}})),
-					"child": newAccessList(t, "child"),
+					childName: newAccessList(t, childName),
 				},
-				MembersByAccessList: map[string][]*accesslist.AccessListMember{
-					"parent": {
-						newAccessListMember(t, "parent", "child", accesslist.MembershipKindList),
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					parentName: {
+						newAccessListMember(t, parentName, childName),
 					},
-					"child": {
-						newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser),
+					childName: {
+						newUserMember(t, childName, "tester"),
 					},
 				},
 			},
@@ -706,7 +817,7 @@ func TestMaterializerAccessListMemberKindUpdateInvalidatesPriorKind(t *testing.T
 				// Initially tester is a member of list child which is a member
 				// of list parent, resulting in a materialized assignment for
 				// tester in parent.
-				expectedScopedRoleAssignment("tester", "parent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("tester", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::parentrole",
 					Scope: "/aa",
 				}.Build()}),
@@ -715,7 +826,11 @@ func TestMaterializerAccessListMemberKindUpdateInvalidatesPriorKind(t *testing.T
 				{
 					// Update the member resource in place to change the membership kind from list to user.
 					mutateState: func(t *testing.T, state *materializerTestcaseState) {
-						member, err := state.aclService.GetAccessListMember(t.Context(), "parent", "child")
+						member, err := state.aclService.GetAccessListMemberV2(t.Context(), accesslistv1.GetAccessListMemberRequest_builder{
+							AccessListScope: parentName.Scope,
+							AccessList:      parentName.Name,
+							MemberName:      childName.Name,
+						}.Build())
 						require.NoError(t, err)
 
 						member.Spec.MembershipKind = accesslist.MembershipKindUser
@@ -728,7 +843,7 @@ func TestMaterializerAccessListMemberKindUpdateInvalidatesPriorKind(t *testing.T
 					// member because the path through the list named child is
 					// now broken.
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-						expectedScopedRoleAssignment("child", "parent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("child", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::parentrole",
 							Scope: "/aa",
 						}.Build()}),
@@ -739,7 +854,11 @@ func TestMaterializerAccessListMemberKindUpdateInvalidatesPriorKind(t *testing.T
 					// back to a list, and the original assignment should be
 					// restored.
 					mutateState: func(t *testing.T, state *materializerTestcaseState) {
-						member, err := state.aclService.GetAccessListMember(t.Context(), "parent", "child")
+						member, err := state.aclService.GetAccessListMemberV2(t.Context(), accesslistv1.GetAccessListMemberRequest_builder{
+							AccessListScope: parentName.Scope,
+							AccessList:      parentName.Name,
+							MemberName:      childName.Name,
+						}.Build())
 						require.NoError(t, err)
 
 						member.Spec.MembershipKind = accesslist.MembershipKindList
@@ -748,7 +867,7 @@ func TestMaterializerAccessListMemberKindUpdateInvalidatesPriorKind(t *testing.T
 						require.Equal(t, accesslist.MembershipKindList, updatedMember.Spec.MembershipKind)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-						expectedScopedRoleAssignment("tester", "parent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("tester", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::parentrole",
 							Scope: "/aa",
 						}.Build()}),
@@ -777,37 +896,41 @@ func TestMaterializerDiamond(t *testing.T) {
 	//        v
 	//      tester
 	t.Parallel()
+	topName := accesslists.NormalizedSQN{Scope: "/aa", Name: "top"}
+	leftName := accesslists.NormalizedSQN{Name: "left"}
+	rightName := accesslists.NormalizedSQN{Scope: "/aa", Name: "right"}
+	bottomName := accesslists.NormalizedSQN{Name: "bottom"}
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: accesslists.Collection{
-				AccessListsByName: map[string]*accesslist.AccessList{
-					"top": newAccessList(t, "top", withMemberGrants([]accesslist.ScopedRoleGrant{{
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+					topName: newAccessList(t, topName, withMemberGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/aa",
 						Role:  "/::toprole",
 					}})),
-					"left":   newAccessList(t, "left"),
-					"right":  newAccessList(t, "right"),
-					"bottom": newAccessList(t, "bottom"),
+					leftName:   newAccessList(t, leftName),
+					rightName:  newAccessList(t, rightName),
+					bottomName: newAccessList(t, bottomName),
 				},
-				MembersByAccessList: map[string][]*accesslist.AccessListMember{
-					"top": {
-						newAccessListMember(t, "top", "left", accesslist.MembershipKindList),
-						newAccessListMember(t, "top", "right", accesslist.MembershipKindList),
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					topName: {
+						newAccessListMember(t, topName, leftName),
+						newAccessListMember(t, topName, rightName),
 					},
-					"left": {
-						newAccessListMember(t, "left", "bottom", accesslist.MembershipKindList),
+					leftName: {
+						newAccessListMember(t, leftName, bottomName),
 					},
-					"right": {
-						newAccessListMember(t, "right", "bottom", accesslist.MembershipKindList),
+					rightName: {
+						newAccessListMember(t, rightName, bottomName),
 					},
-					"bottom": {
-						newAccessListMember(t, "bottom", "tester", accesslist.MembershipKindUser),
+					bottomName: {
+						newUserMember(t, bottomName, "tester"),
 					},
 				},
 			},
 			// Initially the user is a valid member of the top list by 2 paths.
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-				expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("tester", topName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::toprole",
 					Scope: "/aa",
 				}.Build()}),
@@ -818,11 +941,11 @@ func TestMaterializerDiamond(t *testing.T) {
 					// should stay via the right list.
 					mutateState: func(t *testing.T, state *materializerTestcaseState) {
 						// Upsert the access list to remove the membership requires.
-						_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, "left", withMembershipRequires()))
+						_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, leftName, withMembershipRequires()))
 						require.NoError(t, err)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-						expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("tester", topName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::toprole",
 							Scope: "/aa",
 						}.Build()}),
@@ -832,7 +955,12 @@ func TestMaterializerDiamond(t *testing.T) {
 					// Delete the membership path on the right, the assignment
 					// should be deleted as there is no more path.
 					mutateState: func(t *testing.T, state *materializerTestcaseState) {
-						err := state.aclService.DeleteAccessListMember(t.Context(), "top", "right")
+						err := state.aclService.DeleteAccessListMemberV2(t.Context(), accesslistv1.DeleteAccessListMemberRequest_builder{
+							AccessListScope: topName.Scope,
+							AccessList:      topName.Name,
+							MemberScope:     rightName.Scope,
+							MemberName:      rightName.Name,
+						}.Build())
 						require.NoError(t, err)
 					},
 					expectedAssignments: nil,
@@ -842,11 +970,11 @@ func TestMaterializerDiamond(t *testing.T) {
 					// should come back.
 					mutateState: func(t *testing.T, state *materializerTestcaseState) {
 						// Upsert the access list to remove the membership requires.
-						_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, "left"))
+						_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, leftName))
 						require.NoError(t, err)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-						expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("tester", topName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::toprole",
 							Scope: "/aa",
 						}.Build()}),
@@ -859,37 +987,38 @@ func TestMaterializerDiamond(t *testing.T) {
 
 func TestMaterializerCascadingMemberExpiries(t *testing.T) {
 	t.Parallel()
+	listName := accesslists.NormalizedSQN{Scope: "/test", Name: "testlist"}
 	synctest.Test(t, func(t *testing.T) {
 
 		testStart := time.Now()
 
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: accesslists.Collection{
-				AccessListsByName: map[string]*accesslist.AccessList{
-					"testlist": newAccessList(t, "testlist", withMemberGrants([]accesslist.ScopedRoleGrant{{
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+					listName: newAccessList(t, listName, withMemberGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/test",
 						Role:  "/::testrole",
 					}})),
 				},
-				MembersByAccessList: map[string][]*accesslist.AccessListMember{
-					"testlist": {
-						newAccessListMember(t, "testlist", "alice", accesslist.MembershipKindUser, withExpires(testStart.Add(time.Minute))),
-						newAccessListMember(t, "testlist", "bob", accesslist.MembershipKindUser, withExpires(testStart.Add(2*time.Minute))),
-						newAccessListMember(t, "testlist", "charlie", accesslist.MembershipKindUser, withExpires(testStart.Add(3*time.Minute))),
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					listName: {
+						newUserMember(t, listName, "alice", withExpires(testStart.Add(time.Minute))),
+						newUserMember(t, listName, "bob", withExpires(testStart.Add(2*time.Minute))),
+						newUserMember(t, listName, "charlie", withExpires(testStart.Add(3*time.Minute))),
 					},
 				},
 			},
 			// Initially all users are valid members of testlist.
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-				expectedScopedRoleAssignment("alice", "testlist", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("alice", listName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::testrole",
 					Scope: "/test",
 				}.Build()}),
-				expectedScopedRoleAssignment("bob", "testlist", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("bob", listName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::testrole",
 					Scope: "/test",
 				}.Build()}),
-				expectedScopedRoleAssignment("charlie", "testlist", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("charlie", listName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::testrole",
 					Scope: "/test",
 				}.Build()}),
@@ -902,11 +1031,11 @@ func TestMaterializerCascadingMemberExpiries(t *testing.T) {
 						time.Sleep(time.Minute)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-						expectedScopedRoleAssignment("bob", "testlist", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("bob", listName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::testrole",
 							Scope: "/test",
 						}.Build()}),
-						expectedScopedRoleAssignment("charlie", "testlist", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("charlie", listName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::testrole",
 							Scope: "/test",
 						}.Build()}),
@@ -919,7 +1048,7 @@ func TestMaterializerCascadingMemberExpiries(t *testing.T) {
 						time.Sleep(time.Minute)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-						expectedScopedRoleAssignment("charlie", "testlist", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("charlie", listName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::testrole",
 							Scope: "/test",
 						}.Build()}),
@@ -940,22 +1069,24 @@ func TestMaterializerCascadingMemberExpiries(t *testing.T) {
 
 func TestMaterializerRepairFailedReads(t *testing.T) {
 	t.Parallel()
+	parentName := accesslists.NormalizedSQN{Scope: "/test", Name: "parent"}
+	childName := accesslists.NormalizedSQN{Scope: "/test", Name: "child"}
 	synctest.Test(t, func(t *testing.T) {
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: accesslists.Collection{
-				AccessListsByName: map[string]*accesslist.AccessList{
-					"parent": newAccessList(t, "parent", withMemberGrants([]accesslist.ScopedRoleGrant{{
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+					parentName: newAccessList(t, parentName, withMemberGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/test/parent",
 						Role:  "/::testrole",
 					}})),
-					"child": newAccessList(t, "child", withMemberGrants([]accesslist.ScopedRoleGrant{{
+					childName: newAccessList(t, childName, withMemberGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/test/child",
 						Role:  "/::testrole",
 					}})),
 				},
-				MembersByAccessList: map[string][]*accesslist.AccessListMember{
-					"parent": {},
-					"child":  {},
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					parentName: {},
+					childName:  {},
 				},
 			},
 			// Initially there are no members and therefore no assignments.
@@ -967,7 +1098,7 @@ func TestMaterializerRepairFailedReads(t *testing.T) {
 						// with the access list reader broken, the assignment
 						// cannot be validated and should not be materialized.
 						state.breakableACLReader.Break()
-						state.aclService.UpsertAccessListMember(t.Context(), newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser))
+						state.aclService.UpsertAccessListMember(t.Context(), newUserMember(t, childName, "tester"))
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{},
 				},
@@ -979,7 +1110,7 @@ func TestMaterializerRepairFailedReads(t *testing.T) {
 						time.Sleep(access.MissedMembersRepairBackoff)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-						expectedScopedRoleAssignment("tester", "child", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("tester", childName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::testrole",
 							Scope: "/test/child",
 						}.Build()}),
@@ -990,7 +1121,7 @@ func TestMaterializerRepairFailedReads(t *testing.T) {
 						// Break the access list reader again and add the child
 						// list as a member of parent list.
 						state.breakableACLReader.Break()
-						state.aclService.UpsertAccessListMember(t.Context(), newAccessListMember(t, "parent", "child", accesslist.MembershipKindList))
+						state.aclService.UpsertAccessListMember(t.Context(), newAccessListMember(t, parentName, childName))
 					},
 					// The access list service will update the child list with
 					// a Status.MemberOf reference. While handling the access
@@ -1009,11 +1140,11 @@ func TestMaterializerRepairFailedReads(t *testing.T) {
 						time.Sleep(access.MissedMembersRepairBackoff)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-						expectedScopedRoleAssignment("tester", "child", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("tester", childName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::testrole",
 							Scope: "/test/child",
 						}.Build()}),
-						expectedScopedRoleAssignment("tester", "parent", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("tester", parentName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::testrole",
 							Scope: "/test/parent",
 						}.Build()}),
@@ -1042,6 +1173,10 @@ func TestMaterializerDiamondExpiry(t *testing.T) {
 	//        v
 	//      tester
 	t.Parallel()
+	topName := accesslists.NormalizedSQN{Scope: "/aa", Name: "top"}
+	leftName := accesslists.NormalizedSQN{Scope: "/aa", Name: "left"}
+	rightName := accesslists.NormalizedSQN{Scope: "/aa", Name: "right"}
+	bottomName := accesslists.NormalizedSQN{Scope: "/aa", Name: "bottom"}
 	synctest.Test(t, func(t *testing.T) {
 
 		testStart := time.Now()
@@ -1049,35 +1184,35 @@ func TestMaterializerDiamondExpiry(t *testing.T) {
 		rightExpires := testStart.Add(3 * time.Hour)
 
 		runMaterializerTestcase(t, materializerTestcase{
-			collection: accesslists.Collection{
-				AccessListsByName: map[string]*accesslist.AccessList{
-					"top": newAccessList(t, "top", withMemberGrants([]accesslist.ScopedRoleGrant{{
+			collection: accesslists.ScopedCollection{
+				AccessListsByName: map[accesslists.NormalizedSQN]*accesslist.AccessList{
+					topName: newAccessList(t, topName, withMemberGrants([]accesslist.ScopedRoleGrant{{
 						Scope: "/aa",
 						Role:  "/::toprole",
 					}})),
-					"left":   newAccessList(t, "left"),
-					"right":  newAccessList(t, "right"),
-					"bottom": newAccessList(t, "bottom"),
+					leftName:   newAccessList(t, leftName),
+					rightName:  newAccessList(t, rightName),
+					bottomName: newAccessList(t, bottomName),
 				},
-				MembersByAccessList: map[string][]*accesslist.AccessListMember{
-					"top": {
-						newAccessListMember(t, "top", "left", accesslist.MembershipKindList, withExpires(leftExpires)),
-						newAccessListMember(t, "top", "right", accesslist.MembershipKindList, withExpires(rightExpires)),
+				MembersByAccessList: map[accesslists.NormalizedSQN][]*accesslist.AccessListMember{
+					topName: {
+						newAccessListMember(t, topName, leftName, withExpires(leftExpires)),
+						newAccessListMember(t, topName, rightName, withExpires(rightExpires)),
 					},
-					"left": {
-						newAccessListMember(t, "left", "bottom", accesslist.MembershipKindList),
+					leftName: {
+						newAccessListMember(t, leftName, bottomName),
 					},
-					"right": {
-						newAccessListMember(t, "right", "bottom", accesslist.MembershipKindList),
+					rightName: {
+						newAccessListMember(t, rightName, bottomName),
 					},
-					"bottom": {
-						newAccessListMember(t, "bottom", "tester", accesslist.MembershipKindUser),
+					bottomName: {
+						newUserMember(t, bottomName, "tester"),
 					},
 				},
 			},
 			// Initially the user is a valid member of the top list by 2 paths.
 			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-				expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+				expectedScopedRoleAssignment("tester", topName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 					Role:  "/::toprole",
 					Scope: "/aa",
 				}.Build()}),
@@ -1091,7 +1226,7 @@ func TestMaterializerDiamondExpiry(t *testing.T) {
 						time.Sleep(time.Minute)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-						expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("tester", topName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::toprole",
 							Scope: "/aa",
 						}.Build()}),
@@ -1109,12 +1244,12 @@ func TestMaterializerDiamondExpiry(t *testing.T) {
 				{
 					// Upsert the left membership with a future expiry, the assignment should come back.
 					mutateState: func(t *testing.T, state *materializerTestcaseState) {
-						member := newAccessListMember(t, "top", "left", accesslist.MembershipKindList, withExpires(time.Now().Add(time.Minute)))
+						member := newAccessListMember(t, topName, leftName, withExpires(time.Now().Add(time.Minute)))
 						_, err := state.aclService.UpsertAccessListMember(t.Context(), member)
 						require.NoError(t, err)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
-						expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
+						expectedScopedRoleAssignment("tester", topName, []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
 							Role:  "/::toprole",
 							Scope: "/aa",
 						}.Build()}),
@@ -1155,16 +1290,16 @@ func BenchmarkMaterializerInit(b *testing.B) {
 		},
 		// These cases are theoretically realistic for very large clusters, but pretty slow to run in CI.
 		// {
-		//  // benchmarked this case at 6.2 seconds for a materializer init,
-		//  // vs 3.4 seconds for the baseline case that just copies the
-		//  // assignments with no logic. It materializes 2 million assignments.
+		// 	// benchmarked this case at 6.2 seconds for a materializer init,
+		// 	// vs 3.4 seconds for the baseline case that just copies the
+		// 	// assignments with no logic. It materializes 2 million assignments.
 		// 	listCount:      100,
 		// 	membersPerList: 20000,
 		// },
 		// {
-		//  // benchmarked this case at 26.6 seconds for a materializer init,
-		//  // vs 14.7 seconds for the baseline case that just copies the
-		//  // assignments with no logic. It materializes 5 million assignments.
+		// 	// benchmarked this case at 26.6 seconds for a materializer init,
+		// 	// vs 14.7 seconds for the baseline case that just copies the
+		// 	// assignments with no logic. It materializes 5 million assignments.
 		// 	listCount:      25000,
 		// 	membersPerList: 200,
 		// },
@@ -1180,6 +1315,9 @@ func BenchmarkMaterializerInit(b *testing.B) {
 			aclService, err := local.NewAccessListServiceV2(local.AccessListServiceConfig{
 				Backend: backend,
 				Modules: modulestest.EnterpriseModules(),
+				ScopesFeatures: scopes.Features{
+					Enabled: true,
+				},
 			})
 			require.NoError(b, err)
 
@@ -1190,7 +1328,7 @@ func BenchmarkMaterializerInit(b *testing.B) {
 			t1 := time.Now()
 
 			// Insert the access lists and members into the backend.
-			require.NoError(b, aclService.InsertAccessListCollection(b.Context(), collection))
+			require.NoError(b, aclService.InsertScopedAccessListCollection(b.Context(), collection))
 
 			t2 := time.Now()
 
@@ -1251,8 +1389,9 @@ initializing acl cache: %v`, t1.Sub(t0), t2.Sub(t1), t3.Sub(t2))
 						continue
 					}
 					key := access.MaterializedAssignmentKey{
-						List: listName,
-						User: member.GetName(),
+						ListName:  listName.Name,
+						ListScope: listName.Scope,
+						User:      member.GetName(),
 					}
 					_, err := assignmentCache.GetScopedRoleAssignment(b.Context(), scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
 						Name:    key.AssignmentName(),
@@ -1266,8 +1405,8 @@ initializing acl cache: %v`, t1.Sub(t0), t2.Sub(t1), t3.Sub(t2))
 	}
 }
 
-func createBenchmarkCollection(b require.TestingT, listCount, membersPerList, nestingDepth int) *accesslists.Collection {
-	var collection accesslists.Collection
+func createBenchmarkCollection(b require.TestingT, listCount, membersPerList, nestingDepth int) *accesslists.ScopedCollection {
+	var collection accesslists.ScopedCollection
 
 	grants := []accesslist.ScopedRoleGrant{{
 		Role:  "/::testrole",
@@ -1276,7 +1415,7 @@ func createBenchmarkCollection(b require.TestingT, listCount, membersPerList, ne
 	listIndex := 0
 	memberIndex := 0
 	for range listCount {
-		listName := fmt.Sprintf("list-%d", listIndex)
+		listName := accesslists.NormalizedSQN{Name: fmt.Sprintf("list-%d", listIndex)}
 		listIndex++
 
 		list := newAccessList(b, listName, withMemberGrants(grants))
@@ -1286,7 +1425,7 @@ func createBenchmarkCollection(b require.TestingT, listCount, membersPerList, ne
 			memberName := fmt.Sprintf("user-%d", listIndex*membersPerList+memberIndex)
 			memberIndex++
 
-			members[i] = newAccessListMember(b, listName, memberName, accesslist.MembershipKindUser)
+			members[i] = newUserMember(b, listName, memberName)
 		}
 
 		require.NoError(b, collection.AddAccessList(list, members))
@@ -1299,17 +1438,17 @@ func createBenchmarkCollection(b require.TestingT, listCount, membersPerList, ne
 		ancestorListCount = ancestorListCount / 2
 
 		for range ancestorListCount {
-			listName := fmt.Sprintf("list-%d", listIndex)
+			listName := accesslists.NormalizedSQN{Name: fmt.Sprintf("list-%d", listIndex)}
 			listIndex++
 
 			list := newAccessList(b, listName, withMemberGrants(grants))
 
 			members := make([]*accesslist.AccessListMember, 2)
 			for i := range 2 {
-				childListName := fmt.Sprintf("list-%d", childListIndex)
+				childListName := accesslists.NormalizedSQN{Name: fmt.Sprintf("list-%d", childListIndex)}
 				childListIndex++
 
-				members[i] = newAccessListMember(b, listName, childListName, accesslist.MembershipKindList)
+				members[i] = newAccessListMember(b, listName, childListName)
 			}
 
 			require.NoError(b, collection.AddAccessList(list, members))
@@ -1349,16 +1488,16 @@ func withOwnershipRequires() aclOption {
 	}
 }
 
-func newAccessList(t require.TestingT, name string, opts ...aclOption) *accesslist.AccessList {
-	list, err := accesslist.NewAccessList(header.Metadata{
-		Name: name,
+func newAccessList(t require.TestingT, name accesslists.NormalizedSQN, opts ...aclOption) *accesslist.AccessList {
+	list, err := accesslist.NewAccessListWithScope(header.Metadata{
+		Name: name.Name,
 	}, accesslist.Spec{
-		Title: name,
+		Title: name.String(),
 		Owners: []accesslist.Owner{{
 			Name:           "testowner",
 			MembershipKind: accesslist.MembershipKindUser,
 		}},
-	})
+	}, name.Scope)
 	require.NoError(t, err)
 	for _, opt := range opts {
 		opt(list)
@@ -1374,16 +1513,26 @@ func withExpires(expires time.Time) memberOption {
 	}
 }
 
-func newAccessListMember(t require.TestingT, parent, member, membershipKind string, opts ...memberOption) *accesslist.AccessListMember {
-	memberResource, err := accesslist.NewAccessListMember(header.Metadata{
-		Name: member,
+func withMembershipKind(kind string) memberOption {
+	return func(member *accesslist.AccessListMember) {
+		member.Spec.MembershipKind = kind
+	}
+}
+
+func newAccessListMember(t require.TestingT, parent, member accesslists.NormalizedSQN, opts ...memberOption) *accesslist.AccessListMember {
+	membershipKind := accesslist.MembershipKindList
+	if member.Scope != "" {
+		membershipKind = accesslist.MembershipKindScopedList
+	}
+	memberResource, err := accesslist.NewAccessListMemberWithScope(header.Metadata{
+		Name: member.String(),
 	}, accesslist.AccessListMemberSpec{
-		AccessList:     parent,
-		Name:           member,
+		AccessList:     parent.String(),
+		Name:           member.String(),
 		MembershipKind: membershipKind,
 		Joined:         time.Now(),
 		AddedBy:        "testowner",
-	})
+	}, parent.Scope)
 	require.NoError(t, err)
 	for _, opt := range opts {
 		opt(memberResource)
@@ -1391,30 +1540,35 @@ func newAccessListMember(t require.TestingT, parent, member, membershipKind stri
 	return memberResource
 }
 
-func expectedScopedRoleAssignment(userName, listName string, assignments []*scopedaccessv1.Assignment) *scopedaccessv1.ScopedRoleAssignment {
+func newUserMember(t require.TestingT, parent accesslists.NormalizedSQN, userName string, opts ...memberOption) *accesslist.AccessListMember {
+	return newAccessListMember(t, parent, accesslists.NormalizedSQN{Name: userName}, append(opts, withMembershipKind(accesslist.MembershipKindUser))...)
+}
+
+func expectedScopedRoleAssignment(userName string, listName accesslists.NormalizedSQN, assignments []*scopedaccessv1.Assignment) *scopedaccessv1.ScopedRoleAssignment {
 	key := access.MaterializedAssignmentKey{
-		User: userName,
-		List: listName,
+		User:      userName,
+		ListName:  listName.Name,
+		ListScope: listName.Scope,
 	}
-	return &scopedaccessv1.ScopedRoleAssignment{
+	return scopedaccessv1.ScopedRoleAssignment_builder{
 		Kind:    scopedaccess.KindScopedRoleAssignment,
 		SubKind: scopedaccess.SubKindMaterialized,
 		Version: types.V1,
-		Metadata: &headerv1.Metadata{
+		Metadata: headerv1.Metadata_builder{
 			Name: key.AssignmentName(),
-		},
-		Scope: "/",
-		Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+		}.Build(),
+		Scope: key.AssignmentScope(),
+		Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
 			User:        userName,
 			Assignments: assignments,
-		},
-		Status: &scopedaccessv1.ScopedRoleAssignmentStatus{
-			Origin: &scopedaccessv1.ScopedRoleAssignmentStatus_Origin{
+		}.Build(),
+		Status: scopedaccessv1.ScopedRoleAssignmentStatus_builder{
+			Origin: scopedaccessv1.ScopedRoleAssignmentStatus_Origin_builder{
 				CreatorKind: scopedaccess.CreatorKindAccessList,
-				CreatorName: listName,
-			},
-		},
-	}
+				CreatorName: listName.String(),
+			}.Build(),
+		}.Build(),
+	}.Build()
 }
 
 type breakableAccessListReader struct {
@@ -1435,37 +1589,30 @@ func (b *breakableAccessListReader) err() error {
 	return fmt.Errorf("access list reader is broken")
 }
 
-func (b *breakableAccessListReader) ListAccessLists(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessList, string, error) {
+func (b *breakableAccessListReader) ListAccessListsV2(ctx context.Context, req *accesslistv1.ListAccessListsV2Request) ([]*accesslist.AccessList, string, error) {
 	if b.broken.Load() {
 		return nil, "", b.err()
 	}
-	return b.AccessListReader.ListAccessLists(ctx, pageSize, pageToken)
+	return b.AccessListReader.ListAccessListsV2(ctx, req)
 }
 
-func (b *breakableAccessListReader) GetAccessList(ctx context.Context, accessListName string) (*accesslist.AccessList, error) {
+func (b *breakableAccessListReader) GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error) {
 	if b.broken.Load() {
 		return nil, b.err()
 	}
-	return b.AccessListReader.GetAccessList(ctx, accessListName)
+	return b.AccessListReader.GetAccessListV2(ctx, req)
 }
 
-func (b *breakableAccessListReader) ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+func (b *breakableAccessListReader) ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) ([]*accesslist.AccessListMember, string, error) {
 	if b.broken.Load() {
 		return nil, "", b.err()
 	}
-	return b.AccessListReader.ListAllAccessListMembers(ctx, pageSize, pageToken)
+	return b.AccessListReader.ListAccessListMembersV2(ctx, req)
 }
 
-func (b *breakableAccessListReader) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
-	if b.broken.Load() {
-		return nil, "", b.err()
-	}
-	return b.AccessListReader.ListAccessListMembers(ctx, accessListName, pageSize, pageToken)
-}
-
-func (b *breakableAccessListReader) GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error) {
+func (b *breakableAccessListReader) GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error) {
 	if b.broken.Load() {
 		return nil, b.err()
 	}
-	return b.AccessListReader.GetAccessListMember(ctx, accessList, memberName)
+	return b.AccessListReader.GetAccessListMemberV2(ctx, req)
 }

--- a/lib/scopes/cache/access/materializer_test.go
+++ b/lib/scopes/cache/access/materializer_test.go
@@ -267,11 +267,11 @@ func TestMaterializerDoubleListParents(t *testing.T) {
 			AccessListsByName: map[string]*accesslist.AccessList{
 				"parentA": newAccessList(t, "parentA", withMemberGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/aa",
-					Role:  "/::roleA",
+					Role:  "/::rolea",
 				}})),
 				"parentB": newAccessList(t, "parentB", withMemberGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/bb",
-					Role:  "/::roleB",
+					Role:  "/::roleb",
 				}})),
 				"child": newAccessList(t, "child"),
 			},
@@ -290,11 +290,11 @@ func TestMaterializerDoubleListParents(t *testing.T) {
 		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 			// User should be a nested member of both parents and get an assignment for each.
 			expectedScopedRoleAssignment("tester", "parentA", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
-				Role:  "/::roleA",
+				Role:  "/::rolea",
 				Scope: "/aa",
 			}.Build()}),
 			expectedScopedRoleAssignment("tester", "parentB", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
-				Role:  "/::roleB",
+				Role:  "/::roleb",
 				Scope: "/bb",
 			}.Build()}),
 		},

--- a/lib/scopes/cursor.go
+++ b/lib/scopes/cursor.go
@@ -18,6 +18,7 @@ package scopes
 
 import (
 	"encoding/hex"
+	"slices"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -69,20 +70,83 @@ func IsScopedResourceCursor(cursor string) bool {
 // degraded cursor that is deterministic, unique per scope and name, sorts after
 // all valid cursors, and fails [ParseResourceCursor].
 func MakeResourceCursor(scope, name string) string {
-	if scope == "" {
-		return name
+	return MakeNestedResourceCursor(QualifiedName{
+		Scope: scope,
+		Name:  name,
+	})
+}
+
+// MakeNestedResourceCursor returns the cursor for a scoped or unscoped nested
+// resource in a logical, lexicographically ordered range of nested resources.
+// The motivating example is scoped access list members, where members are
+// keyed under their parent list.
+//
+// Resource cursors are intended for pagination tokens, range bounds, and
+// in-memory cache indexes. They are not backend storage keys and must not be
+// used to construct backend keys.
+//
+// If all provided scopes are empty, all names will simply be joined with the
+// separator, to maintain compatibility with existing unscoped resource cursors
+// and avoid wastefully encoding multiple empty scopes:
+//
+//	<root-name>[/<descendent-name>]...
+//
+// Scoped resource cursors use a synthetic prefix that cannot appear in
+// backend-safe resource names and sorts after all backend-safe name bytes.
+//
+//	~scoped/<encoded-root-scope>/<root-name>[/<encoded-descendent-scope>/<descendent-name>]...
+//
+// Each scope component is encoded with [EncodeForKey] so that scoped cursors
+// preserve scope ordering and can safely use '/' as the cursor separator.
+//
+// MakeNestedResourceCursor is infallible so that it can back key derivation with no
+// error path (in-memory cache indexes, pagination cursors). A scope that
+// cannot be encoded (which is only possible for invalid stored data) yields a
+// degraded cursor that is deterministic, unique per scope and name, sorts after
+// all valid cursors, and fails [ParseResourceCursor].
+func MakeNestedResourceCursor(root QualifiedName, descendents ...QualifiedName) string {
+	hasNonEmptyScope := root.Scope != "" || slices.ContainsFunc(descendents, func(descendent QualifiedName) bool {
+		return descendent.Scope != ""
+	})
+	if !hasNonEmptyScope {
+		var sb strings.Builder
+		sb.WriteString(root.Name)
+		for _, descendent := range descendents {
+			sb.WriteString(separator)
+			sb.WriteString(descendent.Name)
+		}
+		return sb.String()
 	}
 
-	encodedScope, err := EncodeForKey(scope)
+	var sb strings.Builder
+	sb.WriteString(ResourceCursorPrefix)
+	sb.WriteString(EncodeForResourceCursor(root.Scope))
+	sb.WriteString(separator)
+	sb.WriteString(root.Name)
+	for _, descendent := range descendents {
+		sb.WriteString(separator)
+		sb.WriteString(EncodeForResourceCursor(descendent.Scope))
+		sb.WriteString(separator)
+		sb.WriteString(descendent.Name)
+	}
+	return sb.String()
+}
+
+// EncodeForResourceCursor is infallible so that it can back key derivation with no
+// error path (in-memory cache indexes, pagination cursors). A scope that
+// cannot be encoded (which is only possible for invalid stored data) yields a
+// degraded cursor that is deterministic, unique per scope and name, sorts after
+// all valid cursors, and fails [ParseResourceCursor].
+func EncodeForResourceCursor(scope string) string {
+	encoded, err := EncodeForKey(scope)
 	if err != nil {
 		// '~' cannot appear in a valid scope encoding (which starts with '+'),
 		// so degraded cursors never collide with valid cursors and sort after
 		// them. The scope is hex-encoded so the cursor's scope component is a
 		// single path segment regardless of the scope's contents.
-		encodedScope = "~invalid+" + hex.EncodeToString([]byte(scope))
+		return "~invalid+" + hex.EncodeToString([]byte(scope))
 	}
-
-	return ResourceCursorPrefix + encodedScope + separator + name
+	return encoded
 }
 
 // ParseResourceCursor parses a resource cursor produced by [MakeResourceCursor]

--- a/lib/scopes/cursor_test.go
+++ b/lib/scopes/cursor_test.go
@@ -17,10 +17,13 @@
 package scopes
 
 import (
+	"math/rand/v2"
 	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	sliceutils "github.com/gravitational/teleport/lib/utils/slices"
 )
 
 func TestResourceCursor(t *testing.T) {
@@ -128,4 +131,116 @@ func TestResourceCursorSort(t *testing.T) {
 		{Scope: "/aa/bb", Name: "aaa"},
 		{Scope: "/bb", Name: "aaa"},
 	}, got)
+}
+
+func TestNestedResourceCursor(t *testing.T) {
+	for _, tc := range []struct {
+		desc        string
+		root        QualifiedName
+		descendents []QualifiedName
+		expected    string
+	}{
+		{
+			desc: "empty",
+		},
+		{
+			desc:     "unscoped",
+			root:     QualifiedName{Name: "test"},
+			expected: "test",
+		},
+		{
+			desc: "unscoped nested",
+			root: QualifiedName{Name: "test"},
+			descendents: []QualifiedName{
+				{Name: "nested"},
+			},
+			expected: "test/nested",
+		},
+		{
+			desc: "unscoped double nested",
+			root: QualifiedName{Name: "test"},
+			descendents: []QualifiedName{
+				{Name: "nested"},
+				{Name: "doublenested"},
+			},
+			expected: "test/nested/doublenested",
+		},
+		{
+			desc:     "scoped",
+			root:     QualifiedName{Scope: "/aa", Name: "test"},
+			expected: ResourceCursorPrefix + EncodeForResourceCursor("/aa") + separator + "test",
+		},
+		{
+			desc: "scoped nested",
+			root: QualifiedName{Scope: "/aa", Name: "test"},
+			descendents: []QualifiedName{
+				{Scope: "/", Name: "nested"},
+			},
+			expected: ResourceCursorPrefix + EncodeForResourceCursor("/aa") + separator + "test" +
+				separator + EncodeForResourceCursor("/") + separator + "nested",
+		},
+		{
+			desc: "scoped double nested",
+			root: QualifiedName{Scope: "/aa", Name: "test"},
+			descendents: []QualifiedName{
+				{Scope: "/", Name: "nested"},
+				{Scope: "/", Name: "doublenested"},
+			},
+			expected: ResourceCursorPrefix + EncodeForResourceCursor("/aa") + separator + "test" +
+				separator + EncodeForResourceCursor("/") + separator + "nested" +
+				separator + EncodeForResourceCursor("/") + separator + "doublenested",
+		},
+		{
+			desc:        "mixed scopes",
+			root:        QualifiedName{Scope: "/aa", Name: "test"},
+			descendents: []QualifiedName{{Name: "nested"}},
+			expected: ResourceCursorPrefix + EncodeForResourceCursor("/aa") + separator + "test" +
+				separator + EncodeForResourceCursor("") + separator + "nested",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.expected, MakeNestedResourceCursor(tc.root, tc.descendents...))
+		})
+	}
+}
+
+func TestNestedResourceCursorSort(t *testing.T) {
+	sorted := [][]QualifiedName{
+		{{Name: "a"}},
+		{{Name: "a"}, {Name: "a"}},
+		{{Name: "a"}, {Name: "b"}},
+
+		{{Name: "b"}},
+		{{Name: "b"}, {Name: "a"}},
+		{{Name: "b"}, {Name: "b"}},
+		{{Name: "b"}, {Name: "b"}, {Name: "a"}},
+
+		{{Scope: "/aa", Name: "a"}},
+		{{Scope: "/aa", Name: "a"}, {Scope: "/bb", Name: "a"}},
+		{{Scope: "/aa", Name: "a"}, {Scope: "/bb", Name: "b"}},
+		{{Scope: "/aa", Name: "a"}, {Scope: "/bb", Name: "b"}, {Scope: "/cc/dd", Name: "a"}},
+		{{Scope: "/aa", Name: "a"}, {Scope: "/cc", Name: "a"}},
+		{{Scope: "/aa", Name: "b"}},
+
+		{{Scope: "/zz/aa", Name: "z"}},
+		{{Scope: "/zz/aa/bb", Name: "z"}},
+		{{Scope: "/zz/aa/cc", Name: "z"}},
+		{{Scope: "/zz/bb", Name: "z"}},
+		{{Scope: "/zz/cc", Name: "z"}},
+
+		{{Scope: "bad scope 1"}},
+		{{Scope: "bad scope 2"}},
+	}
+	expectSortedCursors := sliceutils.Map(sorted, func(names []QualifiedName) string {
+		return MakeNestedResourceCursor(names[0], names[1:]...)
+	})
+
+	shuffledCursors := slices.Clone(expectSortedCursors)
+	rand.Shuffle(len(shuffledCursors), func(i, j int) {
+		shuffledCursors[i], shuffledCursors[j] = shuffledCursors[j], shuffledCursors[i]
+	})
+
+	// Assert that a string sort gets us back to the expected sorted order.
+	slices.Sort(shuffledCursors)
+	require.Equal(t, expectSortedCursors, shuffledCursors)
 }

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -77,6 +77,8 @@ type AccessLists interface {
 	UpdateAccessList(context.Context, *accesslist.AccessList) (*accesslist.AccessList, error)
 	// DeleteAccessList removes the specified access list resource.
 	DeleteAccessList(context.Context, string) error
+	// DeleteAccessList removes the specified access list resource.
+	DeleteAccessListV2(context.Context, *accesslistv1.DeleteAccessListRequest) error
 
 	// UpsertAccessListWithMembers creates or updates an access list resource and its members.
 	UpsertAccessListWithMembers(context.Context, *accesslist.AccessList, []*accesslist.AccessListMember) (*accesslist.AccessList, []*accesslist.AccessListMember, error)
@@ -96,10 +98,16 @@ type AccessListsInternal interface {
 
 	// CleanupAccessListStatus removes invalid Status.OwnerOf and Status.MemberOf references.
 	CleanupAccessListStatus(ctx context.Context, accessListName string) (*accesslist.AccessList, error)
+	// CleanupAccessListStatusV2 removes invalid Status.(Scoped)OwnerOf and Status.(Scoped)MemberOf references.
+	CleanupAccessListStatusV2(ctx context.Context, accessListName accesslists.NormalizedSQN) (*accesslist.AccessList, error)
 
 	// EnsureNestedAccessListStatuses goes over all nested owners and nested members of the named
 	// access list and ensures nested lists' statuses owner_of/member_of contain the access list name.
 	EnsureNestedAccessListStatuses(ctx context.Context, accessListName string) error
+	// EnsureNestedAccessListStatusesV2 goes over all nested owners and nested members of the named
+	// access list and ensures nested lists' statuses (scoped_)owner_of/(scoped_)member_of contain
+	// the access list name.
+	EnsureNestedAccessListStatusesV2(ctx context.Context, accessListName accesslists.NormalizedSQN) error
 
 	// InsertAccessListCollection inserts a complete collection of access lists and their members from a single
 	// upstream source (e.g. EntraID) using a batch operation for improved performance.
@@ -222,8 +230,12 @@ type AccessListMembers interface {
 	UpdateAccessListMember(ctx context.Context, member *accesslist.AccessListMember) (*accesslist.AccessListMember, error)
 	// DeleteAccessListMember hard deletes the specified access list member resource.
 	DeleteAccessListMember(ctx context.Context, accessList string, memberName string) error
+	// DeleteAccessListMemberV2 hard deletes the specified access list member resource.
+	DeleteAccessListMemberV2(ctx context.Context, req *accesslistv1.DeleteAccessListMemberRequest) error
 	// DeleteAllAccessListMembersForAccessList hard deletes all access list members for an access list.
 	DeleteAllAccessListMembersForAccessList(ctx context.Context, accessList string) error
+	// DeleteAllAccessListMembersForAccessListV2 hard deletes all access list members for an access list.
+	DeleteAllAccessListMembersForAccessListV2(ctx context.Context, req *accesslistv1.DeleteAllAccessListMembersForAccessListRequest) error
 }
 
 // MarshalAccessListMember marshals the access list member resource to JSON.
@@ -287,6 +299,8 @@ type AccessListReviews interface {
 
 	// DeleteAccessListReview will delete an access list review from the backend.
 	DeleteAccessListReview(ctx context.Context, accessListName, reviewName string) error
+	// DeleteAccessListReviewV2 will delete an access list review from the backend.
+	DeleteAccessListReviewV2(ctx context.Context, req *accesslistv1.DeleteAccessListReviewRequest) error
 }
 
 // MarshalAccessListReview marshals the access list review resource to JSON.

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -33,6 +33,7 @@ import (
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/lib/accesslists"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -48,8 +49,6 @@ type AccessListsGetter interface {
 	ListAccessLists(context.Context, int, string) ([]*accesslist.AccessList, string, error)
 	// ListAccessListsV2 returns a filtered and sorted paginated list of access lists.
 	ListAccessListsV2(context.Context, *accesslistv1.ListAccessListsV2Request) ([]*accesslist.AccessList, string, error)
-	// GetAccessList returns the specified access list resource.
-	GetAccessList(context.Context, string) (*accesslist.AccessList, error)
 	// GetAccessListsToReview returns access lists that the user needs to review.
 	GetAccessListsToReview(context.Context) ([]*accesslist.AccessList, error)
 	// GetInheritedGrants returns grants inherited by access list accessListID from parent access lists.
@@ -181,8 +180,12 @@ func (ImplicitAccessListError) Error() string {
 type AccessListMemberGetter interface {
 	// GetAccessListMember returns the specified access list member resource.
 	GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error)
+	// GetAccessListMemberV2 returns the specified access list member resource.
+	GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error)
 	// GetAccessList returns the specified access list resource.
 	GetAccessList(context.Context, string) (*accesslist.AccessList, error)
+	// GetAccessListV2 returns the specified access list resource.
+	GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error)
 	// GetAccessLists returns a list of all access lists.
 	GetAccessLists(context.Context) ([]*accesslist.AccessList, error)
 }
@@ -193,13 +196,20 @@ type AccessListMembersGetter interface {
 
 	// CountAccessListMembers will count all access list members.
 	CountAccessListMembers(ctx context.Context, accessListName string) (membersCount uint32, listCount uint32, err error)
+	// CountAccessListMembersV2 will count all access list members.
+	CountAccessListMembersV2(ctx context.Context, req *accesslistv1.CountAccessListMembersRequest) (membersCount uint32, listCount uint32, err error)
 	// ListAccessListMembers returns a paginated list of all access list members.
 	ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
+	// ListAccessListMembersV2 returns a paginated list of all access list members.
+	ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error)
 	// ListAllAccessListMembers returns a paginated list of all access list members for all access lists.
 	ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
-	GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error)
+	// ListAllAccessListMembers returns a paginated list of all access list members for all access lists.
+	ListAllAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAllAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error)
 	// GetAccessListOwners returns a list of all owners in an Access List, including those inherited from nested Access Lists.
 	GetAccessListOwners(ctx context.Context, accessList string) ([]*accesslist.Owner, error)
+	// GetAccessListOwnersV2 returns a list of all owners in an Access List, including those inherited from nested Access Lists.
+	GetAccessListOwnersV2(ctx context.Context, req *accesslistv1.GetAccessListOwnersRequest) ([]*accesslist.Owner, error)
 }
 
 // AccessListMembers defines an interface for managing AccessListMembers.
@@ -264,9 +274,13 @@ func UnmarshalAccessListMember(data []byte, opts ...MarshalOption) (*accesslist.
 type AccessListReviews interface {
 	// ListAccessListReviews will list access list reviews for a particular access list.
 	ListAccessListReviews(ctx context.Context, accessList string, pageSize int, pageToken string) (reviews []*accesslist.Review, nextToken string, err error)
+	// ListAccessListReviewsV2 will list access list reviews for a particular access list.
+	ListAccessListReviewsV2(ctx context.Context, req *accesslistv1.ListAccessListReviewsRequest) (reviews []*accesslist.Review, nextToken string, err error)
 
-	// ListAllAccessListReviews will list access list reviews for all access lists. Only to be used by the cache.
+	// ListAllAccessListReviews will list access list reviews for all unscoped access lists. Only to be used by the cache.
 	ListAllAccessListReviews(ctx context.Context, pageSize int, pageToken string) (reviews []*accesslist.Review, nextToken string, err error)
+	// ListAllAccessListReviewsV2 will list access list reviews for all access lists. Only to be used by the cache.
+	ListAllAccessListReviewsV2(ctx context.Context, req *accesslistv1.ListAllAccessListReviewsRequest) (reviews []*accesslist.Review, nextToken string, err error)
 
 	// CreateAccessListReview will create a new review for an access list.
 	CreateAccessListReview(ctx context.Context, review *accesslist.Review) (updatedReview *accesslist.Review, nextReviewDate time.Time, err error)
@@ -335,7 +349,7 @@ func CreateAccessListNextKey(al *accesslist.AccessList, indexName string) (strin
 
 // AccessListNameIndexKey returns the resource name returned from GetName().
 func AccessListNameIndexKey(al *accesslist.AccessList) string {
-	return al.GetName()
+	return scopes.MakeResourceCursor(al.GetScope(), al.GetName())
 }
 
 // AccessListAuditDateIndexKey returns the DateOnly formatted next audit date
@@ -346,9 +360,9 @@ func AccessListAuditDateIndexKey(al *accesslist.AccessList) string {
 		// appear at the end when sorted. Otherwise we would compare against
 		// `0001-01-01 00:00:00` which would sort first, but actually means
 		// the access list is not eligible for review.
-		return "z/" + al.GetName()
+		return "z/" + AccessListNameIndexKey(al)
 	}
-	return al.Spec.Audit.NextAuditDate.Format(time.DateOnly) + "/" + al.GetName()
+	return al.Spec.Audit.NextAuditDate.Format(time.DateOnly) + "/" + AccessListNameIndexKey(al)
 }
 
 // AccessListTitleIndexKey returns the access list title base32hex encoded
@@ -356,7 +370,7 @@ func AccessListAuditDateIndexKey(al *accesslist.AccessList) string {
 func AccessListTitleIndexKey(al *accesslist.AccessList) string {
 	title := cases.Fold().String(al.Spec.Title)
 	title = base32.HexEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte(title))
-	return title + "/" + al.GetName()
+	return title + "/" + AccessListNameIndexKey(al)
 }
 
 // MatchAccessList returns true if the access list matches the given filter criteria.

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -919,6 +919,16 @@ func (a *AccessListService) UpsertAccessListMember(ctx context.Context, member *
 			return trace.Wrap(err)
 		}
 
+		// Remove stale member_of refs if the membership kind has changed.
+		// Switching between MembershipKindList and MembershipKindScopedList is
+		// impossible, by definition scoped lists have a non-empty scope, which
+		// would mean the member resource would have a different name and key.
+		if existingMember != nil && existingMember.IsList() && !member.IsList() {
+			if err := a.updateAccessListMemberOf(ctx, parentListName, memberName, false); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+
 		if member.IsList() {
 			if err := a.updateAccessListMemberOf(ctx, parentListName, memberName, true); err != nil {
 				return trace.Wrap(err)
@@ -977,6 +987,13 @@ func (a *AccessListService) UpdateAccessListMember(ctx context.Context, member *
 			updated, err = memberService.conditionalUpdateResource(ctx, member)
 			if err != nil {
 				return trace.Wrap(err)
+			}
+
+			// Remove stale member_of refs if the membership kind has changed.
+			if existingMember != nil && existingMember.IsList() && !member.IsList() {
+				if err := a.updateAccessListMemberOf(ctx, parentListName, memberName, false); err != nil {
+					return trace.Wrap(err)
+				}
 			}
 
 			if member.IsList() {
@@ -1238,6 +1255,13 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 					}
 
 					existingMember.SetRevision(upserted.GetRevision())
+				}
+
+				// Update the status member_of ref if membership kind has changed.
+				if existingMember.IsList() != newMember.IsList() {
+					if err := a.updateAccessListMemberOf(ctx, accessListName, existingMemberName, newMember.IsList()); err != nil {
+						return trace.Wrap(err)
+					}
 				}
 			}
 

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -58,6 +58,7 @@ const (
 
 	accessListReviewPrefix      = "access_list_review"
 	accessListReviewMaxPageSize = 200
+	scopedPrefix                = "scoped"
 
 	// This lock is necessary to prevent a race condition between access lists and members and to ensure
 	// consistency of the one-to-many relationship between them.
@@ -84,13 +85,13 @@ type AccessListService struct {
 	modules modules.Modules
 	// scopesFeatures dictates whether scoped role grants are enabled.
 	scopesFeatures scopes.Features
-	service        *generic.Service[*accesslist.AccessList]
+	service        *generic.ScopeAwareService[*accesslist.AccessList]
 	memberService  *generic.Service[*accesslist.AccessListMember]
 	reviewService  *generic.Service[*accesslist.Review]
 }
 
 type accessListAndMembersGetter struct {
-	service       *generic.Service[*accesslist.AccessList]
+	service       *generic.ScopeAwareService[*accesslist.AccessList]
 	memberService *generic.Service[*accesslist.AccessListMember]
 }
 
@@ -99,7 +100,7 @@ func (s *accessListAndMembersGetter) ListAccessListMembers(ctx context.Context, 
 }
 
 func (s *accessListAndMembersGetter) GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error) {
-	return s.service.GetResource(ctx, name)
+	return s.service.GetResource(ctx, scopes.QualifiedName{Name: name})
 }
 
 // GetAccessListMember returns the specified access list member resource.
@@ -132,11 +133,12 @@ func NewAccessListServiceV2(cfg AccessListServiceConfig) (*AccessListService, er
 		return nil, trace.BadParameter("Modules are a required parameter for the AccessListService")
 	}
 
-	service, err := generic.NewService(&generic.ServiceConfig[*accesslist.AccessList]{
+	service, err := generic.NewScopeAwareService(&generic.ScopeAwareServiceConfig[*accesslist.AccessList]{
 		Backend:                     cfg.Backend,
 		PageLimit:                   accessListMaxPageSize,
 		ResourceKind:                types.KindAccessList,
-		BackendPrefix:               backend.NewKey(accessListPrefix),
+		UnscopedBackendPrefix:       backend.NewKey(accessListPrefix),
+		ScopedBackendPrefix:         backend.NewKey(scopedPrefix, accessListPrefix),
 		MarshalFunc:                 services.MarshalAccessList,
 		UnmarshalFunc:               services.UnmarshalAccessList,
 		RunWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
@@ -183,7 +185,8 @@ func NewAccessListServiceV2(cfg AccessListServiceConfig) (*AccessListService, er
 
 // GetAccessLists returns a list of all access lists.
 func (a *AccessListService) GetAccessLists(ctx context.Context) ([]*accesslist.AccessList, error) {
-	accessLists, err := a.service.GetResources(ctx)
+	// TODO(nklaassen): support listing scoped access lists.
+	accessLists, err := a.service.UnscopedService.GetResources(ctx)
 	return accessLists, trace.Wrap(err)
 }
 
@@ -195,7 +198,8 @@ func (a *AccessListService) GetInheritedGrants(ctx context.Context, accessListID
 
 // ListAccessLists returns a paginated list of access lists.
 func (a *AccessListService) ListAccessLists(ctx context.Context, pageSize int, nextToken string) ([]*accesslist.AccessList, string, error) {
-	return a.service.ListResources(ctx, pageSize, nextToken)
+	// TODO(nklaassen): support listing scoped access lists.
+	return a.service.UnscopedService.ListResources(ctx, pageSize, nextToken)
 }
 
 // ListAccessListsV2 returns a filtered and sorted paginated list of access lists.
@@ -206,14 +210,28 @@ func (a *AccessListService) ListAccessListsV2(ctx context.Context, req *accessli
 		return nil, "", trace.CompareFailed("unsupported sort, only name:asc is supported, but got %q (desc = %t)", req.GetSortBy().Field, req.GetSortBy().IsDesc)
 	}
 
-	return a.service.ListResourcesWithFilter(ctx, int(req.GetPageSize()), req.GetPageToken(), func(item *accesslist.AccessList) bool {
+	// TODO(nklaassen): support listing scoped access lists.
+	return a.service.UnscopedService.ListResourcesWithFilter(ctx, int(req.GetPageSize()), req.GetPageToken(), func(item *accesslist.AccessList) bool {
 		return services.MatchAccessList(item, req.GetFilter())
 	})
 }
 
 // GetAccessList returns the specified access list resource.
 func (a *AccessListService) GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error) {
-	return a.service.GetResource(ctx, name)
+	return a.getAccessList(ctx, scopes.QualifiedName{Name: name})
+}
+
+// GetAccessListV2 returns the specified access list resource, supporting
+// scoped or unscoped access lists.
+func (a *AccessListService) GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error) {
+	return a.getAccessList(ctx, scopes.QualifiedName{
+		Scope: req.GetScope(),
+		Name:  req.GetName(),
+	})
+}
+
+func (a *AccessListService) getAccessList(ctx context.Context, listName scopes.QualifiedName) (*accesslist.AccessList, error) {
+	return a.service.GetResource(ctx, listName)
 }
 
 // GetAccessListsToReview returns access lists that the user needs to review. This is not implemented in the local service.
@@ -249,7 +267,7 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 	validateAccessList := func() error {
 		var err error
 
-		existingAccessList, err = a.service.GetResource(ctx, accessList.GetName())
+		existingAccessList, err = a.getAccessList(ctx, accesslists.ScopeQualifiedName(accessList))
 		if op == opTypeUpsert && trace.IsNotFound(err) {
 			// Not having already existing access_list in the backend is ok in case of
 			// upsert.
@@ -257,9 +275,14 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 			return trace.Wrap(err)
 		}
 		preserveAccessListFields(existingAccessList, accessList)
-		listMembers, err := a.memberService.WithPrefix(accessList.GetName()).GetResources(ctx)
-		if err != nil {
-			return trace.Wrap(err)
+
+		// TODO(nklaassen): support scoped access list members.
+		var listMembers []*accesslist.AccessListMember
+		if accessList.Scope == "" {
+			listMembers, err = a.memberService.WithPrefix(accessList.GetName()).GetResources(ctx)
+			if err != nil {
+				return trace.Wrap(err)
+			}
 		}
 
 		if err := accesslists.ValidateAccessListWithMembers(ctx, existingAccessList, accessList, listMembers, &accessListAndMembersGetter{a.service, a.memberService}); err != nil {
@@ -323,7 +346,7 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 	// access lists in the cluster in order to prevent un-authorized use of
 	// the AccessList feature
 	if !a.modules.Features().GetEntitlement(entitlements.Identity).Enabled {
-		actions = append(actions, func() error { return a.VerifyAccessListCreateLimit(ctx, accessList.GetName()) })
+		actions = append(actions, func() error { return a.verifyAccessListCreateLimit(ctx, accesslists.ScopeQualifiedName(accessList)) })
 	}
 
 	// Note we need to reconcile the old owners (clean status.owner_of for the owner lists
@@ -333,9 +356,13 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 	// interrupted as we user status.owner_of to calculate hierarchy.
 	actions = append(actions, validateAccessList, reconcileOldOwners, updateAccessList, reconcileNewOwners)
 
-	err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL,
+	resourceLockName, err := scopeAwareLockName(accesslists.ScopeQualifiedName(accessList))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	err = a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL,
 		func(ctx context.Context, _ backend.Backend) error {
-			return a.service.RunWhileLocked(ctx, lockName(accessList.GetName()), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+			return a.service.RunWhileLocked(ctx, resourceLockName, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 				for _, action := range actions {
 					if err := action(); err != nil {
 						return trace.Wrap(err)
@@ -350,9 +377,21 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 
 // DeleteAccessList removes the specified access list resource.
 func (a *AccessListService) DeleteAccessList(ctx context.Context, name string) error {
+	return a.DeleteAccessListV2(ctx, accesslistv1.DeleteAccessListRequest_builder{
+		Name: name,
+	}.Build())
+}
+
+// DeleteAccessListV2 removes the specified access list resource, supporting
+// scoped or unscoped access lists.
+func (a *AccessListService) DeleteAccessListV2(ctx context.Context, req *accesslistv1.DeleteAccessListRequest) error {
+	name := scopes.QualifiedName{
+		Scope: req.GetScope(),
+		Name:  req.GetName(),
+	}
 	action := func(ctx context.Context, _ backend.Backend) error {
 		// Get list resource.
-		accessList, err := a.service.GetResource(ctx, name)
+		accessList, err := a.getAccessList(ctx, name)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -363,22 +402,24 @@ func (a *AccessListService) DeleteAccessList(ctx context.Context, name string) e
 		}
 
 		// Delete all associated members.
-		members, err := a.memberService.WithPrefix(name).GetResources(ctx)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		if err := a.memberService.WithPrefix(name).DeleteAllResources(ctx); err != nil {
-			return trace.Wrap(err)
-		}
-
-		// Update memberOf refs.
-		for _, member := range members {
-			if member.Spec.MembershipKind != accesslist.MembershipKindList {
-				continue
-			}
-			if err := a.updateAccessListMemberOf(ctx, name, member.GetName(), false); err != nil {
+		if name.Scope == "" {
+			members, err := a.memberService.WithPrefix(name.Name).GetResources(ctx)
+			if err != nil {
 				return trace.Wrap(err)
+			}
+
+			if err := a.memberService.WithPrefix(name.Name).DeleteAllResources(ctx); err != nil {
+				return trace.Wrap(err)
+			}
+
+			// Update memberOf refs.
+			for _, member := range members {
+				if member.Spec.MembershipKind != accesslist.MembershipKindList {
+					continue
+				}
+				if err := a.updateAccessListMemberOf(ctx, name.Name, member.GetName(), false); err != nil {
+					return trace.Wrap(err)
+				}
 			}
 		}
 
@@ -392,7 +433,7 @@ func (a *AccessListService) DeleteAccessList(ctx context.Context, name string) e
 			if owner.MembershipKind != accesslist.MembershipKindList {
 				continue
 			}
-			if err := a.updateAccessListOwnerOf(ctx, name, owner.Name, false); err != nil {
+			if err := a.updateAccessListOwnerOf(ctx, name.Name, owner.Name, false); err != nil {
 				return trace.Wrap(err)
 			}
 		}
@@ -400,8 +441,12 @@ func (a *AccessListService) DeleteAccessList(ctx context.Context, name string) e
 		return nil
 	}
 
+	resourceLockName, err := scopeAwareLockName(name)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	return trace.Wrap(a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		return a.service.RunWhileLocked(ctx, lockName(name), accessListLockTTL, action)
+		return a.service.RunWhileLocked(ctx, resourceLockName, accessListLockTTL, action)
 	}))
 }
 
@@ -443,7 +488,7 @@ func (a *AccessListService) CountAccessListMembers(ctx context.Context, accessLi
 
 // ListAccessListMembers returns a paginated list of all access list members.
 func (a *AccessListService) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, nextToken string) ([]*accesslist.AccessListMember, string, error) {
-	_, err := a.service.GetResource(ctx, accessListName)
+	_, err := a.service.UnscopedService.GetResource(ctx, accessListName)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -470,7 +515,7 @@ func (a *AccessListService) ListAllAccessListMembers(ctx context.Context, pageSi
 
 // GetAccessListMember returns the specified access list member resource.
 func (a *AccessListService) GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error) {
-	_, err := a.service.GetResource(ctx, accessList)
+	_, err := a.service.UnscopedService.GetResource(ctx, accessList)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -487,7 +532,7 @@ func (a *AccessListService) updateAccessListRefField(
 	new bool,
 	fieldSelector func(status *accesslist.Status) *[]string,
 ) error {
-	targetAccessList, err := a.service.GetResource(ctx, targetName)
+	targetAccessList, err := a.service.UnscopedService.GetResource(ctx, targetName)
 	if err != nil {
 		if trace.IsNotFound(err) {
 			// If list is not found, it's possible that it was deleted. Regardless, there's nothing to update.
@@ -540,7 +585,7 @@ func (a *AccessListService) updateAccessListOwnerOf(ctx context.Context, accessL
 // Returned Owners are not validated for ownership requirements – use `IsAccessListOwner` for validation.
 func (a *AccessListService) GetAccessListOwners(ctx context.Context, accessListName string) ([]*accesslist.Owner, error) {
 	var owners []*accesslist.Owner
-	accessList, err := a.service.GetResource(ctx, accessListName)
+	accessList, err := a.service.UnscopedService.GetResource(ctx, accessListName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -552,7 +597,7 @@ func (a *AccessListService) GetAccessListOwners(ctx context.Context, accessListN
 func (a *AccessListService) UpsertAccessListMember(ctx context.Context, member *accesslist.AccessListMember) (*accesslist.AccessListMember, error) {
 	var upserted *accesslist.AccessListMember
 	action := func(ctx context.Context, _ backend.Backend) error {
-		memberList, err := a.service.GetResource(ctx, member.Spec.AccessList)
+		memberList, err := a.service.UnscopedService.GetResource(ctx, member.Spec.AccessList)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -599,7 +644,7 @@ func (a *AccessListService) UpdateAccessListMember(ctx context.Context, member *
 	}
 	err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 		return a.service.RunWhileLocked(ctx, lockName(member.Spec.AccessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-			memberList, err := a.service.GetResource(ctx, member.Spec.AccessList)
+			memberList, err := a.service.UnscopedService.GetResource(ctx, member.Spec.AccessList)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -634,7 +679,7 @@ func (a *AccessListService) UpdateAccessListMember(ctx context.Context, member *
 func (a *AccessListService) DeleteAccessListMember(ctx context.Context, accessList string, memberName string) error {
 	err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 		return a.service.RunWhileLocked(ctx, lockName(accessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-			_, err := a.service.GetResource(ctx, accessList)
+			_, err := a.service.UnscopedService.GetResource(ctx, accessList)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -667,7 +712,7 @@ func (a *AccessListService) DeleteAccessListMember(ctx context.Context, accessLi
 func (a *AccessListService) DeleteAllAccessListMembersForAccessList(ctx context.Context, accessList string) error {
 	err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 		return a.service.RunWhileLocked(ctx, lockName(accessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-			_, err := a.service.GetResource(ctx, accessList)
+			_, err := a.service.UnscopedService.GetResource(ctx, accessList)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -734,7 +779,7 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 
 	validateAccessList := func() error {
 		var err error
-		existingAccessList, err = a.service.GetResource(ctx, accessList.GetName())
+		existingAccessList, err = a.getAccessList(ctx, accesslists.ScopeQualifiedName(accessList))
 		if err != nil {
 			// a not found error is totally legal for an upsert operation, but
 			// fatal for an update.
@@ -873,7 +918,7 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 	// access lists in the cluster in order to  prevent un-authorized use of the
 	// AccessList feature
 	if !a.modules.Features().GetEntitlement(entitlements.Identity).Enabled {
-		actions = append(actions, func() error { return a.VerifyAccessListCreateLimit(ctx, accessList.GetName()) })
+		actions = append(actions, func() error { return a.verifyAccessListCreateLimit(ctx, accesslists.ScopeQualifiedName(accessList)) })
 	}
 
 	// Note we need to reconcile the old owners (clean status.owner_of for the owner lists
@@ -950,7 +995,7 @@ func (a *AccessListService) AccessRequestPromote(_ context.Context, _ *accesslis
 
 // ListAccessListReviews will list access list reviews for a particular access list.
 func (a *AccessListService) ListAccessListReviews(ctx context.Context, accessList string, pageSize int, pageToken string) (reviews []*accesslist.Review, nextToken string, err error) {
-	_, err = a.service.GetResource(ctx, accessList)
+	_, err = a.service.UnscopedService.GetResource(ctx, accessList)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -997,7 +1042,7 @@ func (a *AccessListService) CreateAccessListReview(ctx context.Context, review *
 	var nextAuditDate time.Time
 
 	err = a.service.RunWhileLocked(ctx, lockName(review.Spec.AccessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		accessList, err := a.service.GetResource(ctx, review.Spec.AccessList)
+		accessList, err := a.service.UnscopedService.GetResource(ctx, review.Spec.AccessList)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1111,7 +1156,7 @@ func accessListRequiresEqual(a, b accesslist.Requires) bool {
 
 // DeleteAccessListReview will delete an access list review from the backend.
 func (a *AccessListService) DeleteAccessListReview(ctx context.Context, accessListName, reviewName string) error {
-	_, err := a.service.GetResource(ctx, accessListName)
+	_, err := a.service.UnscopedService.GetResource(ctx, accessListName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1129,38 +1174,49 @@ func lockName(accessListName string) []string {
 	return []string{accessListPrefix, accessListName}
 }
 
-// VerifyAccessListCreateLimit ensures creating access list is limited to no more than 1 (updating is allowed).
+func scopeAwareLockName(accessListName scopes.QualifiedName) ([]string, error) {
+	if accessListName.Scope == "" {
+		return lockName(accessListName.Name), nil
+	}
+	encodedScope, err := scopes.EncodeForKey(accessListName.Scope)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return []string{scopedPrefix, accessListPrefix, encodedScope, accessListName.Name}, nil
+}
+
+// verifyAccessListCreateLimit ensures creating access list is limited to no more than 1 (updating is allowed).
 // It differentiates request for `creating` and `updating` by checking to see if the request
 // access list name matches the ones we retrieved.
 // Returns error if limit has been reached.
-func (a *AccessListService) VerifyAccessListCreateLimit(ctx context.Context, targetAccessListName string) error {
+func (a *AccessListService) verifyAccessListCreateLimit(ctx context.Context, targetAccessListName scopes.QualifiedName) error {
 	f := a.modules.Features()
 	if f.GetEntitlement(entitlements.Identity).Enabled {
 		return nil // unlimited
 	}
 
-	lists, err := a.service.GetResources(ctx)
-	if err != nil {
-		return trace.Wrap(err)
+	// Iterate through all lists, to check if the request was an update, which
+	// is allowed.
+	numLists := 0
+	for list, err := range a.service.Resources(ctx, "", "") {
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if accesslists.ScopeQualifiedName(list) == targetAccessListName {
+			return nil
+		}
+		numLists++
 	}
 
 	// We are *always* allowed to create at least one AccessLists in order to
 	// demonstrate the functionality.
 	// TODO(tcsc): replace with a default OSS entitlement of 1
-	if len(lists) == 0 {
+	if numLists == 0 {
 		return nil
 	}
 
-	// Iterate through fetched lists, to check if the request was
-	// an update, which is allowed.
-	for _, list := range lists {
-		if list.GetName() == targetAccessListName {
-			return nil
-		}
-	}
-
 	accessListEntitlement := f.GetEntitlement(entitlements.AccessLists)
-	if accessListEntitlement.UnderLimit(len(lists)) {
+	if accessListEntitlement.UnderLimit(numLists) {
 		return nil
 	}
 
@@ -1249,14 +1305,14 @@ func (a *AccessListService) updatedMembersNestedRelationships(ctx context.Contex
 // CleanupAccessListStatus removes invalid Status.OwnerOf and Status.MemberOf references.
 func (a *AccessListService) CleanupAccessListStatus(ctx context.Context, accessListName string) (*accesslist.AccessList, error) {
 	return a.runWithGlobalLockAccessList(ctx, accessListName, func() (*accesslist.AccessList, error) {
-		accessList, err := a.service.GetResource(ctx, accessListName)
+		accessList, err := a.service.UnscopedService.GetResource(ctx, accessListName)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
 		var ownerRefreshErr error
 		accessList.Status.OwnerOf = slices.DeleteFunc(accessList.Status.OwnerOf, func(ownerOf string) bool {
-			ownedList, err := a.service.GetResource(ctx, ownerOf)
+			ownedList, err := a.service.UnscopedService.GetResource(ctx, ownerOf)
 			if err != nil {
 				if trace.IsNotFound(err) {
 					return true
@@ -1296,7 +1352,7 @@ func (a *AccessListService) CleanupAccessListStatus(ctx context.Context, accessL
 // access list and ensures nested lists' statuses owner_of/member_of contain the access list name.
 func (a *AccessListService) EnsureNestedAccessListStatuses(ctx context.Context, accessListName string) error {
 	return a.runWithGlobalLock(ctx, accessListName, func() error {
-		accessList, err := a.service.GetResource(ctx, accessListName)
+		accessList, err := a.service.UnscopedService.GetResource(ctx, accessListName)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1382,7 +1438,7 @@ func (a *AccessListService) collectionToBackendItemsIter(collection *accesslists
 					return
 				}
 			}
-			item, err := a.service.MakeBackendItem(acl)
+			item, err := a.service.UnscopedService.MakeBackendItem(acl)
 			if err != nil {
 				yield(backend.Item{}, trace.Wrap(err))
 				return
@@ -1437,7 +1493,7 @@ func (a *AccessListService) checkDeletionBlockingMemberRelationships(ctx context
 
 	memberOfTitles := make([]string, 0, len(memberOf))
 	for _, memberOf := range memberOf {
-		parentList, err := a.service.GetResource(ctx, memberOf)
+		parentList, err := a.service.UnscopedService.GetResource(ctx, memberOf)
 		if err != nil {
 			if trace.IsNotFound(err) {
 				continue
@@ -1474,7 +1530,7 @@ func (a *AccessListService) checkDeletionBlockingOwnerRelationships(ctx context.
 
 	ownerOfTitles := make([]string, 0, len(ownerOf))
 	for _, ownerOf := range ownerOf {
-		ownedList, err := a.service.GetResource(ctx, ownerOf)
+		ownedList, err := a.service.UnscopedService.GetResource(ctx, ownerOf)
 		if err != nil {
 			if trace.IsNotFound(err) {
 				continue

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -58,7 +58,8 @@ const (
 
 	accessListReviewPrefix      = "access_list_review"
 	accessListReviewMaxPageSize = 200
-	scopedPrefix                = "scoped"
+
+	scopedPrefix = "scoped"
 
 	// This lock is necessary to prevent a race condition between access lists and members and to ensure
 	// consistency of the one-to-many relationship between them.
@@ -100,7 +101,18 @@ func (s *accessListAndMembersGetter) ListAccessListMembers(ctx context.Context, 
 }
 
 func (s *accessListAndMembersGetter) GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error) {
-	return s.service.GetResource(ctx, scopes.QualifiedName{Name: name})
+	return s.getAccessList(ctx, accesslists.NormalizedSQN{Name: name})
+}
+
+func (s *accessListAndMembersGetter) GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error) {
+	return s.getAccessList(ctx, accesslists.NormalizedSQN(scopes.QualifiedName{
+		Scope: req.GetScope(),
+		Name:  req.GetName(),
+	}))
+}
+
+func (s *accessListAndMembersGetter) getAccessList(ctx context.Context, listName accesslists.NormalizedSQN) (*accesslist.AccessList, error) {
+	return s.service.GetResource(ctx, listName.ToScopesQualifiedName())
 }
 
 // GetAccessListMember returns the specified access list member resource.
@@ -289,7 +301,7 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 			return trace.Wrap(err)
 		}
 
-		if err := a.checkScopedRoleGrants(existingAccessList, accessList); err != nil {
+		if err := a.checkScopesFeatures(existingAccessList, accessList); err != nil {
 			return trace.Wrap(err)
 		}
 
@@ -297,25 +309,39 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 	}
 
 	reconcileOldOwners := func() error {
-		currentOwnersMap := make(map[string]struct{})
+		if existingAccessList == nil {
+			return nil
+		}
+
+		currentOwnersMap := make(map[accesslists.NormalizedSQN]struct{})
 		for _, owner := range accessList.Spec.Owners {
-			if owner.MembershipKind == accesslist.MembershipKindList {
-				currentOwnersMap[owner.Name] = struct{}{}
+			if !owner.IsMembershipKindList() {
+				continue
 			}
+
+			ownerSQN, err := accesslists.OwnerScopeQualifiedName(owner)
+			if err != nil {
+				return trace.Wrap(err, "getting scope-qualified name of access list owner")
+			}
+			currentOwnersMap[ownerSQN] = struct{}{}
 		}
 
 		// update references for old owners
-		if existingAccessList != nil {
-			for _, owner := range existingAccessList.Spec.Owners {
-				if owner.MembershipKind != accesslist.MembershipKindList {
-					continue
-				}
-				// If this owner access list is not an owner anymore after the
-				// update/upsert, its status.owner_of has to be updated.
-				if _, exists := currentOwnersMap[owner.Name]; !exists {
-					if err := a.updateAccessListOwnerOf(ctx, accessList.GetName(), owner.Name, false); err != nil {
-						return trace.Wrap(err)
-					}
+		for _, owner := range existingAccessList.Spec.Owners {
+			if !owner.IsMembershipKindList() {
+				continue
+			}
+
+			ownerSQN, err := accesslists.OwnerScopeQualifiedName(owner)
+			if err != nil {
+				return trace.Wrap(err, "getting scope-qualified name of existing access list owner")
+			}
+
+			// If this owner access list is not an owner anymore after the
+			// update/upsert, its status.owner_of has to be updated.
+			if _, exists := currentOwnersMap[ownerSQN]; !exists {
+				if err := a.updateAccessListOwnerOf(ctx, accesslists.ScopeQualifiedName(accessList), ownerSQN, false); err != nil {
+					return trace.Wrap(err)
 				}
 			}
 		}
@@ -330,10 +356,15 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 
 	reconcileNewOwners := func() error {
 		for _, owner := range accessList.Spec.Owners {
-			if owner.MembershipKind == accesslist.MembershipKindList {
-				if err := a.updateAccessListOwnerOf(ctx, accessList.GetName(), owner.Name, true); err != nil {
-					return trace.Wrap(err)
-				}
+			if !owner.IsMembershipKindList() {
+				continue
+			}
+			ownerScopedName, err := accesslists.OwnerScopeQualifiedName(owner)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if err := a.updateAccessListOwnerOf(ctx, accesslists.ScopeQualifiedName(accessList), ownerScopedName, true); err != nil {
+				return trace.Wrap(err)
 			}
 		}
 		return nil
@@ -401,8 +432,9 @@ func (a *AccessListService) DeleteAccessListV2(ctx context.Context, req *accessl
 			return trace.Wrap(err)
 		}
 
-		// Delete all associated members.
+		// TODO(nklaassen): support scoped access list members
 		if name.Scope == "" {
+			// Delete all associated members.
 			members, err := a.memberService.WithPrefix(name.Name).GetResources(ctx)
 			if err != nil {
 				return trace.Wrap(err)
@@ -430,10 +462,14 @@ func (a *AccessListService) DeleteAccessListV2(ctx context.Context, req *accessl
 
 		// Update ownerOf refs.
 		for _, owner := range accessList.Spec.Owners {
-			if owner.MembershipKind != accesslist.MembershipKindList {
+			if !owner.IsMembershipKindList() {
 				continue
 			}
-			if err := a.updateAccessListOwnerOf(ctx, name.Name, owner.Name, false); err != nil {
+			ownerSQN, err := accesslists.OwnerScopeQualifiedName(owner)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if err := a.updateAccessListOwnerOf(ctx, name, ownerSQN, false); err != nil {
 				return trace.Wrap(err)
 			}
 		}
@@ -488,7 +524,7 @@ func (a *AccessListService) CountAccessListMembers(ctx context.Context, accessLi
 
 // ListAccessListMembers returns a paginated list of all access list members.
 func (a *AccessListService) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, nextToken string) ([]*accesslist.AccessListMember, string, error) {
-	_, err := a.service.UnscopedService.GetResource(ctx, accessListName)
+	_, err := a.getAccessList(ctx, accesslists.NormalizedSQN{Name: accessListName})
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -515,7 +551,7 @@ func (a *AccessListService) ListAllAccessListMembers(ctx context.Context, pageSi
 
 // GetAccessListMember returns the specified access list member resource.
 func (a *AccessListService) GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error) {
-	_, err := a.service.UnscopedService.GetResource(ctx, accessList)
+	_, err := a.getAccessList(ctx, accesslists.NormalizedSQN{Name: accessList})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -527,12 +563,12 @@ func (a *AccessListService) GetAccessListMember(ctx context.Context, accessList 
 // adding or removing the specified accessListName to the field of targetName.
 func (a *AccessListService) updateAccessListRefField(
 	ctx context.Context,
-	accessListName string,
-	targetName string,
+	ref accesslists.NormalizedSQN,
+	target accesslists.NormalizedSQN,
 	new bool,
 	fieldSelector func(status *accesslist.Status) *[]string,
 ) error {
-	targetAccessList, err := a.service.UnscopedService.GetResource(ctx, targetName)
+	targetAccessList, err := a.getAccessList(ctx, target)
 	if err != nil {
 		if trace.IsNotFound(err) {
 			// If list is not found, it's possible that it was deleted. Regardless, there's nothing to update.
@@ -543,17 +579,19 @@ func (a *AccessListService) updateAccessListRefField(
 
 	field := fieldSelector(&targetAccessList.Status)
 
+	value := ref.String()
+
 	// If the field already contains the Access List, and we're adding,
 	// or doesn't contain it, and we're removing, there's nothing to do.
-	if slices.Contains(*field, accessListName) == new {
+	if slices.Contains(*field, value) == new {
 		return nil
 	}
 
 	if new {
-		*field = append(*field, accessListName)
+		*field = append(*field, value)
 	} else {
 		*field = slices.DeleteFunc(*field, func(e string) bool {
-			return e == accessListName
+			return e == value
 		})
 	}
 
@@ -567,16 +605,22 @@ func (a *AccessListService) updateAccessListRefField(
 // updateAccessListMemberOf updates the memberOf field for the specified memberName and accessListName.
 // Should only be called after the relevant member has been successfully upserted or deleted.
 func (a *AccessListService) updateAccessListMemberOf(ctx context.Context, accessListName, memberName string, new bool) error {
-	return a.updateAccessListRefField(ctx, accessListName, memberName, new, func(status *accesslist.Status) *[]string {
+	// TODO(nklaassen): support scoped access list members.
+	listSQN := accesslists.NormalizedSQN{Name: accessListName}
+	memberSQN := accesslists.NormalizedSQN{Name: memberName}
+	return a.updateAccessListRefField(ctx, listSQN, memberSQN, new, func(status *accesslist.Status) *[]string {
 		return &status.MemberOf
 	})
 }
 
 // updateAccessListOwnerOf updates the ownerOf field for the specified ownerName and accessListName.
 // Should only be called after the relevant owner has been successfully upserted or deleted.
-func (a *AccessListService) updateAccessListOwnerOf(ctx context.Context, accessListName, ownerName string, new bool) error {
+func (a *AccessListService) updateAccessListOwnerOf(ctx context.Context, accessListName, ownerName accesslists.NormalizedSQN, new bool) error {
 	return a.updateAccessListRefField(ctx, accessListName, ownerName, new, func(status *accesslist.Status) *[]string {
-		return &status.OwnerOf
+		if accessListName.Scope == "" {
+			return &status.OwnerOf
+		}
+		return &status.ScopedOwnerOf
 	})
 }
 
@@ -584,8 +628,21 @@ func (a *AccessListService) updateAccessListOwnerOf(ctx context.Context, accessL
 //
 // Returned Owners are not validated for ownership requirements – use `IsAccessListOwner` for validation.
 func (a *AccessListService) GetAccessListOwners(ctx context.Context, accessListName string) ([]*accesslist.Owner, error) {
+	return a.GetAccessListOwnersV2(ctx, accesslistv1.GetAccessListOwnersRequest_builder{
+		AccessList: accessListName,
+	}.Build())
+}
+
+// GetAccessListOwnersV2 returns a list of all owners in an Access List, including those inherited from nested Access Lists.
+//
+// Returned Owners are not validated for ownership requirements – use `IsAccessListOwner` for validation.
+func (a *AccessListService) GetAccessListOwnersV2(ctx context.Context, req *accesslistv1.GetAccessListOwnersRequest) ([]*accesslist.Owner, error) {
+	accessListName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
 	var owners []*accesslist.Owner
-	accessList, err := a.service.UnscopedService.GetResource(ctx, accessListName)
+	accessList, err := a.getAccessList(ctx, accessListName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -597,7 +654,7 @@ func (a *AccessListService) GetAccessListOwners(ctx context.Context, accessListN
 func (a *AccessListService) UpsertAccessListMember(ctx context.Context, member *accesslist.AccessListMember) (*accesslist.AccessListMember, error) {
 	var upserted *accesslist.AccessListMember
 	action := func(ctx context.Context, _ backend.Backend) error {
-		memberList, err := a.service.UnscopedService.GetResource(ctx, member.Spec.AccessList)
+		memberList, err := a.GetAccessList(ctx, member.Spec.AccessList)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -644,7 +701,7 @@ func (a *AccessListService) UpdateAccessListMember(ctx context.Context, member *
 	}
 	err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 		return a.service.RunWhileLocked(ctx, lockName(member.Spec.AccessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-			memberList, err := a.service.UnscopedService.GetResource(ctx, member.Spec.AccessList)
+			memberList, err := a.GetAccessList(ctx, member.Spec.AccessList)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -679,7 +736,7 @@ func (a *AccessListService) UpdateAccessListMember(ctx context.Context, member *
 func (a *AccessListService) DeleteAccessListMember(ctx context.Context, accessList string, memberName string) error {
 	err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 		return a.service.RunWhileLocked(ctx, lockName(accessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-			_, err := a.service.UnscopedService.GetResource(ctx, accessList)
+			_, err := a.GetAccessList(ctx, accessList)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -712,7 +769,7 @@ func (a *AccessListService) DeleteAccessListMember(ctx context.Context, accessLi
 func (a *AccessListService) DeleteAllAccessListMembersForAccessList(ctx context.Context, accessList string) error {
 	err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 		return a.service.RunWhileLocked(ctx, lockName(accessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-			_, err := a.service.UnscopedService.GetResource(ctx, accessList)
+			_, err := a.GetAccessList(ctx, accessList)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -800,7 +857,7 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 			return trace.Wrap(err)
 		}
 
-		if err := a.checkScopedRoleGrants(existingAccessList, accessList); err != nil {
+		if err := a.checkScopesFeatures(existingAccessList, accessList); err != nil {
 			return trace.Wrap(err)
 		}
 
@@ -808,6 +865,14 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 	}
 
 	reconcileMembers := func() error {
+		// TODO(nklaassen): support scoped access list members.
+		if accessList.Scope != "" {
+			if len(membersIn) > 0 {
+				return trace.BadParameter("scoped access list members are not yet supported")
+			}
+			return nil
+		}
+
 		// Convert the members slice to a map for easier lookup.
 		membersMap := utils.FromSlice(membersIn, types.GetName)
 
@@ -882,13 +947,26 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 			return nil
 		}
 		for _, existingOwner := range existingAccessList.Spec.Owners {
-			if existingOwner.MembershipKind == accesslist.MembershipKindList {
-				if !slices.ContainsFunc(accessList.Spec.Owners, func(owner accesslist.Owner) bool {
-					return owner.Name == existingOwner.Name
-				}) {
-					if err := a.updateAccessListOwnerOf(ctx, existingAccessList.GetName(), existingOwner.Name, false); err != nil {
-						return trace.Wrap(err)
-					}
+			if !existingOwner.IsMembershipKindList() {
+				continue
+			}
+			existingOwnerName, err := accesslists.OwnerScopeQualifiedName(existingOwner)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			isStillAnOwnerList := slices.ContainsFunc(accessList.Spec.Owners, func(owner accesslist.Owner) bool {
+				if !owner.IsMembershipKindList() {
+					return false
+				}
+				ownerName, err := accesslists.OwnerScopeQualifiedName(owner)
+				if err != nil {
+					return false
+				}
+				return ownerName == existingOwnerName
+			})
+			if !isStillAnOwnerList {
+				if err := a.updateAccessListOwnerOf(ctx, accesslists.ScopeQualifiedName(existingAccessList), existingOwnerName, false); err != nil {
+					return trace.Wrap(err)
 				}
 			}
 		}
@@ -902,10 +980,15 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 
 	reconcileNewOwners := func() error {
 		for _, owner := range accessList.Spec.Owners {
-			if owner.MembershipKind == accesslist.MembershipKindList {
-				if err := a.updateAccessListOwnerOf(ctx, accessList.GetName(), owner.Name, true); err != nil {
-					return trace.Wrap(err)
-				}
+			if !owner.IsMembershipKindList() {
+				continue
+			}
+			ownerName, err := accesslists.OwnerScopeQualifiedName(owner)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if err := a.updateAccessListOwnerOf(ctx, accesslists.ScopeQualifiedName(accessList), ownerName, true); err != nil {
+				return trace.Wrap(err)
 			}
 		}
 		return nil
@@ -928,8 +1011,12 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 	// interrupted as we use status.owner_of to calculate hierarchy.
 	actions = append(actions, validateAccessList, reconcileMembers, reconcileOldOwners, writeAccessList, reconcileNewOwners)
 
+	lockName, err := scopeAwareLockName(accesslists.ScopeQualifiedName(accessList))
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
 	if err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, 2*accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		return a.service.RunWhileLocked(ctx, lockName(accessList.GetName()), 2*accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		return a.service.RunWhileLocked(ctx, lockName, 2*accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 			for _, action := range actions {
 				if err := action(); err != nil {
 					return trace.Wrap(err)
@@ -944,9 +1031,18 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 	return accessList, membersIn, nil
 }
 
-// checkScopedRoleGrants checks if there are any *new* scoped role grants in the list. If there are, it
-// requires the scopes feature to be enabled.
-func (a *AccessListService) checkScopedRoleGrants(existingList, newList *accesslist.AccessList) error {
+// checkScopesFeatures requires the scopes feature to be enabled if a new
+// scoped access list is being created or there are any *new* scoped role
+// grants in a list update.
+func (a *AccessListService) checkScopesFeatures(existingList, newList *accesslist.AccessList) error {
+	if a.scopesFeatures.Enabled {
+		return nil
+	}
+
+	if existingList == nil && newList.GetScope() != "" {
+		return trace.Wrap(a.scopesFeatures.AssertEnabled())
+	}
+
 	if len(newList.Spec.Grants.ScopedRoles) == 0 && len(newList.Spec.OwnerGrants.ScopedRoles) == 0 {
 		// The new list does not grant any scoped roles, so no checks are needed.
 		return nil
@@ -995,7 +1091,7 @@ func (a *AccessListService) AccessRequestPromote(_ context.Context, _ *accesslis
 
 // ListAccessListReviews will list access list reviews for a particular access list.
 func (a *AccessListService) ListAccessListReviews(ctx context.Context, accessList string, pageSize int, pageToken string) (reviews []*accesslist.Review, nextToken string, err error) {
-	_, err = a.service.UnscopedService.GetResource(ctx, accessList)
+	_, err = a.GetAccessList(ctx, accessList)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -1042,7 +1138,7 @@ func (a *AccessListService) CreateAccessListReview(ctx context.Context, review *
 	var nextAuditDate time.Time
 
 	err = a.service.RunWhileLocked(ctx, lockName(review.Spec.AccessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		accessList, err := a.service.UnscopedService.GetResource(ctx, review.Spec.AccessList)
+		accessList, err := a.GetAccessList(ctx, review.Spec.AccessList)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1156,7 +1252,7 @@ func accessListRequiresEqual(a, b accesslist.Requires) bool {
 
 // DeleteAccessListReview will delete an access list review from the backend.
 func (a *AccessListService) DeleteAccessListReview(ctx context.Context, accessListName, reviewName string) error {
-	_, err := a.service.UnscopedService.GetResource(ctx, accessListName)
+	_, err := a.GetAccessList(ctx, accessListName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1229,10 +1325,15 @@ func preserveAccessListFields(existingAccessList, accessList *accesslist.AccessL
 		// Set MemberOf/OwnerOf to the existing values to prevent them from being updated.
 		accessList.Status.MemberOf = existingAccessList.Status.MemberOf
 		accessList.Status.OwnerOf = existingAccessList.Status.OwnerOf
+		accessList.Status.ScopedMemberOf = existingAccessList.Status.ScopedMemberOf
+		accessList.Status.ScopedOwnerOf = existingAccessList.Status.ScopedOwnerOf
 	} else {
 		// For newly created AccessList make sure MemberOf/OwnerOf are empty.
 		accessList.Status.MemberOf = []string{}
 		accessList.Status.OwnerOf = []string{}
+		// Must be nil for the tests in teleport.e to pass.
+		accessList.Status.ScopedMemberOf = nil
+		accessList.Status.ScopedOwnerOf = nil
 	}
 }
 
@@ -1304,15 +1405,39 @@ func (a *AccessListService) updatedMembersNestedRelationships(ctx context.Contex
 
 // CleanupAccessListStatus removes invalid Status.OwnerOf and Status.MemberOf references.
 func (a *AccessListService) CleanupAccessListStatus(ctx context.Context, accessListName string) (*accesslist.AccessList, error) {
+	return a.CleanupAccessListStatusV2(ctx, accesslists.NormalizedSQN{Name: accessListName})
+}
+
+// CleanupAccessListStatusV2 removes invalid Status.(Scoped)OwnerOf and Status.(Scoped)MemberOf references.
+func (a *AccessListService) CleanupAccessListStatusV2(ctx context.Context, accessListName accesslists.NormalizedSQN) (*accesslist.AccessList, error) {
 	return a.runWithGlobalLockAccessList(ctx, accessListName, func() (*accesslist.AccessList, error) {
-		accessList, err := a.service.UnscopedService.GetResource(ctx, accessListName)
+		accessList, err := a.getAccessList(ctx, accessListName)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
+		isActualOwner := func(ownedList *accesslist.AccessList) bool {
+			return slices.ContainsFunc(ownedList.Spec.Owners, func(ownedListOwner accesslist.Owner) bool {
+				if !ownedListOwner.IsMembershipKindList() {
+					return false
+				}
+				ownedListOwnerName, err := accesslists.OwnerScopeQualifiedName(ownedListOwner)
+				if err != nil {
+					return false
+				}
+				return ownedListOwnerName == accessListName
+			})
+		}
+
 		var ownerRefreshErr error
+
+		// OwnerOf names unscoped access lists that this access list supposedly owns.
 		accessList.Status.OwnerOf = slices.DeleteFunc(accessList.Status.OwnerOf, func(ownerOf string) bool {
-			ownedList, err := a.service.UnscopedService.GetResource(ctx, ownerOf)
+			if accessList.Scope != "" {
+				// Scoped access lists can never own unscoped access lists.
+				return true
+			}
+			ownedList, err := a.GetAccessList(ctx, ownerOf)
 			if err != nil {
 				if trace.IsNotFound(err) {
 					return true
@@ -1320,27 +1445,48 @@ func (a *AccessListService) CleanupAccessListStatus(ctx context.Context, accessL
 				ownerRefreshErr = err
 				return false
 			}
-			isActualOwner := slices.ContainsFunc(ownedList.Spec.Owners, func(ownedListOwner accesslist.Owner) bool {
-				return ownedListOwner.MembershipKind == accesslist.MembershipKindList && ownedListOwner.Name == accessList.GetName()
-			})
-			return !isActualOwner
+			return !isActualOwner(ownedList)
 		})
 		if ownerRefreshErr != nil {
 			return nil, trace.Wrap(ownerRefreshErr)
 		}
 
-		var memberRefreshErr error
-		accessList.Status.MemberOf = slices.DeleteFunc(accessList.Status.MemberOf, func(memberOf string) bool {
-			if _, err := a.memberService.WithPrefix(memberOf).GetResource(ctx, accessList.GetName()); err != nil {
+		// ScopedOwnerOf names scoped access lists that this access list supposedly owns.
+		accessList.Status.ScopedOwnerOf = slices.DeleteFunc(accessList.Status.ScopedOwnerOf, func(scopedOwnerOf string) bool {
+			ownedListName, err := accesslists.ParseScopeQualifiedName(scopedOwnerOf)
+			if err != nil {
+				// If we can't parse the name, it is invalid and should be removed.
+				return true
+			}
+			ownedList, err := a.getAccessList(ctx, ownedListName)
+			if err != nil {
 				if trace.IsNotFound(err) {
 					return true
 				}
-				memberRefreshErr = err
+				ownerRefreshErr = err
+				return false
 			}
-			return false
+			return !isActualOwner(ownedList)
 		})
-		if memberRefreshErr != nil {
-			return nil, trace.Wrap(memberRefreshErr)
+		if ownerRefreshErr != nil {
+			return nil, trace.Wrap(ownerRefreshErr)
+		}
+
+		// TODO(nklaassen): support scoped access list members.
+		if accessListName.Scope == "" {
+			var memberRefreshErr error
+			accessList.Status.MemberOf = slices.DeleteFunc(accessList.Status.MemberOf, func(memberOf string) bool {
+				if _, err := a.memberService.WithPrefix(memberOf).GetResource(ctx, accessList.GetName()); err != nil {
+					if trace.IsNotFound(err) {
+						return true
+					}
+					memberRefreshErr = err
+				}
+				return false
+			})
+			if memberRefreshErr != nil {
+				return nil, trace.Wrap(memberRefreshErr)
+			}
 		}
 
 		accessList, err = a.service.UpdateResource(ctx, accessList)
@@ -1351,28 +1497,42 @@ func (a *AccessListService) CleanupAccessListStatus(ctx context.Context, accessL
 // EnsureNestedAccessListStatuses goes over all nested owners and nested members of the named
 // access list and ensures nested lists' statuses owner_of/member_of contain the access list name.
 func (a *AccessListService) EnsureNestedAccessListStatuses(ctx context.Context, accessListName string) error {
+	return a.EnsureNestedAccessListStatusesV2(ctx, accesslists.NormalizedSQN{Name: accessListName})
+}
+
+// EnsureNestedAccessListStatusesV2 goes over all nested owners and nested members of the named
+// access list and ensures nested lists' statuses owner_of/member_of contain the access list name.
+func (a *AccessListService) EnsureNestedAccessListStatusesV2(ctx context.Context, accessListName accesslists.NormalizedSQN) error {
 	return a.runWithGlobalLock(ctx, accessListName, func() error {
-		accessList, err := a.service.UnscopedService.GetResource(ctx, accessListName)
+		accessList, err := a.getAccessList(ctx, accessListName)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 
 		for _, owner := range accessList.Spec.Owners {
-			if owner.MembershipKind == accesslist.MembershipKindList {
-				if err := a.updateAccessListOwnerOf(ctx, accessListName, owner.Name, true); err != nil {
-					return trace.Wrap(err)
-				}
+			if !owner.IsMembershipKindList() {
+				continue
+			}
+			ownerName, err := accesslists.OwnerScopeQualifiedName(owner)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if err := a.updateAccessListOwnerOf(ctx, accessListName, ownerName, true); err != nil {
+				return trace.Wrap(err)
 			}
 		}
 
-		members, err := a.memberService.WithPrefix(accessListName).GetResources(ctx)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		for _, member := range members {
-			if member.Spec.MembershipKind == accesslist.MembershipKindList {
-				if err := a.updateAccessListMemberOf(ctx, accessListName, member.GetName(), true); err != nil {
-					return trace.Wrap(err)
+		// TODO(nklaassen): support scoped access list members.
+		if accessListName.Scope == "" {
+			members, err := a.memberService.WithPrefix(accessListName.Name).GetResources(ctx)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			for _, member := range members {
+				if member.Spec.MembershipKind == accesslist.MembershipKindList {
+					if err := a.updateAccessListMemberOf(ctx, accessListName.Name, member.GetName(), true); err != nil {
+						return trace.Wrap(err)
+					}
 				}
 			}
 		}
@@ -1438,6 +1598,7 @@ func (a *AccessListService) collectionToBackendItemsIter(collection *accesslists
 					return
 				}
 			}
+			// TODO(nklaassen): support collections of scoped access lists.
 			item, err := a.service.UnscopedService.MakeBackendItem(acl)
 			if err != nil {
 				yield(backend.Item{}, trace.Wrap(err))
@@ -1455,15 +1616,19 @@ func (a *AccessListService) ListUserAccessLists(ctx context.Context, req *access
 	return nil, "", trace.NotImplemented("ListUserAccessLists should not be called on local service")
 }
 
-func (a *AccessListService) runWithGlobalLock(ctx context.Context, accessListName string, fn func() error) error {
+func (a *AccessListService) runWithGlobalLock(ctx context.Context, accessListName accesslists.NormalizedSQN, fn func() error) error {
+	lockName, err := scopeAwareLockName(accessListName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	return a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, 2*accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		return a.service.RunWhileLocked(ctx, lockName(accessListName), 2*accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		return a.service.RunWhileLocked(ctx, lockName, 2*accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 			return trace.Wrap(fn())
 		})
 	})
 }
 
-func (a *AccessListService) runWithGlobalLockAccessList(ctx context.Context, accessListName string, fn func() (*accesslist.AccessList, error)) (*accesslist.AccessList, error) {
+func (a *AccessListService) runWithGlobalLockAccessList(ctx context.Context, accessListName accesslists.NormalizedSQN, fn func() (*accesslist.AccessList, error)) (*accesslist.AccessList, error) {
 	var res *accesslist.AccessList
 	err := a.runWithGlobalLock(ctx, accessListName, func() error {
 		var err error
@@ -1493,7 +1658,7 @@ func (a *AccessListService) checkDeletionBlockingMemberRelationships(ctx context
 
 	memberOfTitles := make([]string, 0, len(memberOf))
 	for _, memberOf := range memberOf {
-		parentList, err := a.service.UnscopedService.GetResource(ctx, memberOf)
+		parentList, err := a.GetAccessList(ctx, memberOf)
 		if err != nil {
 			if trace.IsNotFound(err) {
 				continue
@@ -1523,27 +1688,33 @@ func (a *AccessListService) checkDeletionBlockingMemberRelationships(ctx context
 
 // checkDeletionBlockingOwnerRelationships checks if the access list owns any other access lists that would block deletion
 func (a *AccessListService) checkDeletionBlockingOwnerRelationships(ctx context.Context, accessList *accesslist.AccessList) error {
-	ownerOf := accessList.GetStatus().OwnerOf
-	if len(ownerOf) == 0 {
+	allOwnedLists, err := accesslists.AllOwnedLists(accessList)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if len(allOwnedLists) == 0 {
 		return nil
 	}
 
-	ownerOfTitles := make([]string, 0, len(ownerOf))
-	for _, ownerOf := range ownerOf {
-		ownedList, err := a.service.UnscopedService.GetResource(ctx, ownerOf)
+	ownerOfTitles := make([]string, 0, len(allOwnedLists))
+	for _, ownedListName := range allOwnedLists {
+		ownedList, err := a.getAccessList(ctx, ownedListName)
 		if err != nil {
 			if trace.IsNotFound(err) {
 				continue
 			}
-			return trace.Wrap(err, `fetching owned list "%s"`, ownerOf)
+			return trace.Wrap(err, `fetching owned list "%s"`, ownedListName.String())
 		}
-		isActualOwner := false
-		for _, owner := range ownedList.Spec.Owners {
-			if owner.Name == accessList.GetName() && owner.MembershipKind == accesslist.MembershipKindList {
-				isActualOwner = true
-				break
+		isActualOwner := slices.ContainsFunc(ownedList.Spec.Owners, func(owner accesslist.Owner) bool {
+			if !owner.IsMembershipKindList() {
+				return false
 			}
-		}
+			actualOwnerSQN, err := accesslists.OwnerScopeQualifiedName(owner)
+			if err != nil {
+				return false
+			}
+			return actualOwnerSQN == accesslists.ScopeQualifiedName(accessList)
+		})
 		if isActualOwner {
 			ownerOfTitles = append(ownerOfTitles, ownedList.Spec.Title)
 		}

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -218,20 +218,20 @@ func (a *AccessListService) ListAccessListsV2(ctx context.Context, req *accessli
 
 // GetAccessList returns the specified access list resource.
 func (a *AccessListService) GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error) {
-	return a.getAccessList(ctx, scopes.QualifiedName{Name: name})
+	return a.getAccessList(ctx, accesslists.NormalizedSQN{Name: name})
 }
 
 // GetAccessListV2 returns the specified access list resource, supporting
 // scoped or unscoped access lists.
 func (a *AccessListService) GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error) {
-	return a.getAccessList(ctx, scopes.QualifiedName{
+	return a.getAccessList(ctx, accesslists.NormalizeSQN(scopes.QualifiedName{
 		Scope: req.GetScope(),
 		Name:  req.GetName(),
-	})
+	}))
 }
 
-func (a *AccessListService) getAccessList(ctx context.Context, listName scopes.QualifiedName) (*accesslist.AccessList, error) {
-	return a.service.GetResource(ctx, listName)
+func (a *AccessListService) getAccessList(ctx context.Context, listName accesslists.NormalizedSQN) (*accesslist.AccessList, error) {
+	return a.service.GetResource(ctx, listName.ToScopesQualifiedName())
 }
 
 // GetAccessListsToReview returns access lists that the user needs to review. This is not implemented in the local service.
@@ -385,10 +385,10 @@ func (a *AccessListService) DeleteAccessList(ctx context.Context, name string) e
 // DeleteAccessListV2 removes the specified access list resource, supporting
 // scoped or unscoped access lists.
 func (a *AccessListService) DeleteAccessListV2(ctx context.Context, req *accesslistv1.DeleteAccessListRequest) error {
-	name := scopes.QualifiedName{
+	name := accesslists.NormalizeSQN(scopes.QualifiedName{
 		Scope: req.GetScope(),
 		Name:  req.GetName(),
-	}
+	})
 	action := func(ctx context.Context, _ backend.Backend) error {
 		// Get list resource.
 		accessList, err := a.getAccessList(ctx, name)
@@ -424,7 +424,7 @@ func (a *AccessListService) DeleteAccessListV2(ctx context.Context, req *accessl
 		}
 
 		// Delete list itself.
-		if err := a.service.DeleteResource(ctx, name); err != nil {
+		if err := a.service.DeleteResource(ctx, name.ToScopesQualifiedName()); err != nil {
 			return trace.Wrap(err)
 		}
 
@@ -1174,7 +1174,7 @@ func lockName(accessListName string) []string {
 	return []string{accessListPrefix, accessListName}
 }
 
-func scopeAwareLockName(accessListName scopes.QualifiedName) ([]string, error) {
+func scopeAwareLockName(accessListName accesslists.NormalizedSQN) ([]string, error) {
 	if accessListName.Scope == "" {
 		return lockName(accessListName.Name), nil
 	}
@@ -1189,7 +1189,7 @@ func scopeAwareLockName(accessListName scopes.QualifiedName) ([]string, error) {
 // It differentiates request for `creating` and `updating` by checking to see if the request
 // access list name matches the ones we retrieved.
 // Returns error if limit has been reached.
-func (a *AccessListService) verifyAccessListCreateLimit(ctx context.Context, targetAccessListName scopes.QualifiedName) error {
+func (a *AccessListService) verifyAccessListCreateLimit(ctx context.Context, targetAccessListName accesslists.NormalizedSQN) error {
 	f := a.modules.Features()
 	if f.GetEntitlement(entitlements.Identity).Enabled {
 		return nil // unlimited

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -50,16 +50,22 @@ import (
 const (
 	scopedPrefix = "scoped"
 
+	// Access lists are stored under one of the following key ranges, depending
+	// on their scope:
+	// - /access_list/<list-name>                             (for unscoped lists)
+	// - /scoped/access_list/<encoded-list-scope>/<list-name> (for scoped lists)
 	accessListPrefix      = "access_list"
 	accessListMaxPageSize = 100
 
+	// Access list members are stored under one of the following key ranges,
+	// depending on the scope of the parent list:
+	// - /access_list_member/<list-name>/<member-name>                                                    (for unscoped lists)
+	// - /scoped/access_list_member/<encoded-list-scope>/<list-name>/<encoded-member-scope>/<member-name> (for scoped lists)
 	accessListMemberPrefix      = "access_list_member"
 	accessListMemberMaxPageSize = 200
 
 	accessListReviewPrefix      = "access_list_review"
 	accessListReviewMaxPageSize = 200
-
-	scopedPrefix = "scoped"
 
 	// This lock is necessary to prevent a race condition between access lists and members and to ensure
 	// consistency of the one-to-many relationship between them.
@@ -87,17 +93,35 @@ type AccessListService struct {
 	// scopesFeatures dictates whether scoped role grants are enabled.
 	scopesFeatures scopes.Features
 	service        *generic.ScopeAwareService[*accesslist.AccessList]
-	memberService  *generic.Service[*accesslist.AccessListMember]
+	memberService  *generic.ScopeAwareService[*accesslist.AccessListMember]
 	reviewService  *generic.Service[*accesslist.Review]
 }
 
 type accessListAndMembersGetter struct {
 	service       *generic.ScopeAwareService[*accesslist.AccessList]
-	memberService *generic.Service[*accesslist.AccessListMember]
+	memberService *generic.ScopeAwareService[*accesslist.AccessListMember]
 }
 
 func (s *accessListAndMembersGetter) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
-	return s.memberService.WithPrefix(accessListName).ListResources(ctx, pageSize, pageToken)
+	membersService, err := membersServiceForAccessList(s.memberService, accesslists.NormalizedSQN{
+		Name: accessListName,
+	})
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return membersService.listResources(ctx, pageSize, pageToken)
+}
+
+func (s *accessListAndMembersGetter) ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) ([]*accesslist.AccessListMember, string, error) {
+	listName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	membersService, err := membersServiceForAccessList(s.memberService, listName)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return membersService.listResources(ctx, int(req.GetPageSize()), req.GetPageToken())
 }
 
 func (s *accessListAndMembersGetter) GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error) {
@@ -118,7 +142,155 @@ func (s *accessListAndMembersGetter) getAccessList(ctx context.Context, listName
 // GetAccessListMember returns the specified access list member resource.
 // If a user is not directly a member of the access list the NotFound error is returned.
 func (s *accessListAndMembersGetter) GetAccessListMember(ctx context.Context, accessListName, memberName string) (*accesslist.AccessListMember, error) {
-	return s.memberService.WithPrefix(accessListName).GetResource(ctx, memberName)
+	memberService, err := memberServiceForNamedMember(s.memberService,
+		accesslists.NormalizedSQN{Name: accessListName},
+		accesslists.NormalizedSQN{Name: memberName},
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return memberService.get(ctx)
+}
+
+// GetAccessListMemberV2 returns the specified access list member resource.
+// If a user is not directly a member of the access list the NotFound error is returned.
+func (s *accessListAndMembersGetter) GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error) {
+	accessListName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	memberName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetMemberScope(),
+		Name:  req.GetMemberName(),
+	})
+	memberService, err := memberServiceForNamedMember(s.memberService, accessListName, memberName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return memberService.get(ctx)
+}
+
+// membersServiceForAccessList returns a [*membersService] valid only for
+// operations on _all_ members of the given access list, it cannot be used to
+// get, create, or delete any single member, use [memberServiceForNamedMember]
+// in those cases.
+func membersServiceForAccessList(
+	genericService *generic.ScopeAwareService[*accesslist.AccessListMember],
+	listName accesslists.NormalizedSQN,
+) (*membersService, error) {
+	service, err := genericService.WithScopedResourcePrefix(listName.ToScopesQualifiedName())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &membersService{service}, nil
+}
+
+type membersService struct {
+	service *generic.Service[*accesslist.AccessListMember]
+}
+
+func (s *membersService) resources(ctx context.Context, startKey, endKey string) iter.Seq2[*accesslist.AccessListMember, error] {
+	return s.service.Resources(ctx, startKey, endKey)
+}
+
+func (s *membersService) listResources(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+	return s.service.ListResources(ctx, pageSize, pageToken)
+}
+
+func (s *membersService) getResources(ctx context.Context) ([]*accesslist.AccessListMember, error) {
+	return s.service.GetResources(ctx)
+}
+
+func (s *membersService) deleteAllResources(ctx context.Context) error {
+	return s.service.DeleteAllResources(ctx)
+}
+
+// memberServiceForNamedMember returns a [*memberService] valid for only the
+// exact named member, with an appropriate backend prefix and NameKeyFunc configured.
+func memberServiceForNamedMember(
+	membersService *generic.ScopeAwareService[*accesslist.AccessListMember],
+	listName, memberName accesslists.NormalizedSQN,
+) (*memberService, error) {
+	service, err := membersService.WithScopedResourcePrefix(listName.ToScopesQualifiedName())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if listName.Scope == "" {
+		// For unscoped parent lists we need only the following backend prefix,
+		// which we will already have after calling WithScopedResourcePrefix.
+		// We just need to assert that the member is unscoped.
+		// - /access_list_member/<list-name>
+		if memberName.Scope != "" {
+			return nil, trace.BadParameter("unscoped access lists cannot have scoped members")
+		}
+	} else {
+		// For scoped parent lists we need the following backend prefix, after
+		// calling WithScopedResourcePrefix we need only to append the encoded
+		// member scope. Even if the member has the empty scope, it must be
+		// encoded and included in the key.
+		// - /scoped/access_list_member/<encoded-list-scope>/<list-name>/<encoded-member-scope>
+		encodedMemberScope, err := scopes.EncodeForKey(memberName.Scope)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		service = service.WithPrefix(encodedMemberScope)
+	}
+
+	// For scoped members, the metadata.name is a scope-qualified name.
+	// The scope is already encoded in the backend prefix, so we must
+	// override the NameKeyFunc to use only the plain name.
+	// We do this unconditionally even for unscoped members, so that we can
+	// return a [memberService] that operates on a single member without
+	// requiring a name parameter that may be inaccurate or misleading.
+	service = service.WithNameKeyFunc(func() backend.Key {
+		return backend.NewKey(memberName.Name)
+	})
+
+	return &memberService{
+		service:    service,
+		memberName: memberName.String(),
+	}, nil
+}
+
+// memberService wraps a generic service with an overridden NameKeyFunc so that
+// is valid for exactly one access list member. The get and delete methods
+// don't accept a name parameter to make it clear that it will not be used.
+type memberService struct {
+	service    *generic.Service[*accesslist.AccessListMember]
+	memberName string
+}
+
+func (s *memberService) get(ctx context.Context) (*accesslist.AccessListMember, error) {
+	// NameKeyFunc has been set, so the name param does not matter except that
+	// it will be shown in error messages.
+	return s.service.GetResource(ctx, s.memberName)
+}
+
+func (s *memberService) delete(ctx context.Context) error {
+	// NameKeyFunc has been set, so the name param does not matter except that
+	// it will be shown in error messages.
+	return s.service.DeleteResource(ctx, s.memberName)
+}
+
+func (s *memberService) makeBackendItem(member *accesslist.AccessListMember) (backend.Item, error) {
+	// service.MakeBackendItem respects the overridden NameKeyFunc.
+	return s.service.MakeBackendItem(member)
+}
+
+func (s *memberService) upsert(ctx context.Context, member *accesslist.AccessListMember) (*accesslist.AccessListMember, error) {
+	// service.UpsertResource respects the overridden NameKeyFunc.
+	return s.service.UpsertResource(ctx, member)
+}
+
+func (s *memberService) conditionalUpdateResource(ctx context.Context, member *accesslist.AccessListMember) (*accesslist.AccessListMember, error) {
+	// service.ConditionalUpdateResource respects the overridden NameKeyFunc.
+	updated, err := s.service.ConditionalUpdateResource(ctx, member)
+	if trace.IsNotFound(err) {
+		// Re-write NotFound errors to include the member scope.
+		return nil, trace.NotFound("%s %q doesn't exist", types.KindAccessListMember, s.memberName)
+	}
+	return updated, trace.Wrap(err)
 }
 
 // compile-time assertion that the AccessListService implements the AccessLists
@@ -159,11 +331,12 @@ func NewAccessListServiceV2(cfg AccessListServiceConfig) (*AccessListService, er
 		return nil, trace.Wrap(err)
 	}
 
-	memberService, err := generic.NewService(&generic.ServiceConfig[*accesslist.AccessListMember]{
+	memberService, err := generic.NewScopeAwareService(&generic.ScopeAwareServiceConfig[*accesslist.AccessListMember]{
 		Backend:                     cfg.Backend,
 		PageLimit:                   accessListMemberMaxPageSize,
 		ResourceKind:                types.KindAccessListMember,
-		BackendPrefix:               backend.NewKey(accessListMemberPrefix),
+		UnscopedBackendPrefix:       backend.NewKey(accessListMemberPrefix),
+		ScopedBackendPrefix:         backend.NewKey(scopedPrefix, accessListMemberPrefix),
 		MarshalFunc:                 services.MarshalAccessListMember,
 		UnmarshalFunc:               services.UnmarshalAccessListMember,
 		RunWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
@@ -276,6 +449,11 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 	var upserted *accesslist.AccessList
 	var existingAccessList *accesslist.AccessList
 
+	membersService, err := a.membersServiceForAccessList(accesslists.ScopeQualifiedName(accessList))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	validateAccessList := func() error {
 		var err error
 
@@ -288,13 +466,9 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 		}
 		preserveAccessListFields(existingAccessList, accessList)
 
-		// TODO(nklaassen): support scoped access list members.
-		var listMembers []*accesslist.AccessListMember
-		if accessList.Scope == "" {
-			listMembers, err = a.memberService.WithPrefix(accessList.GetName()).GetResources(ctx)
-			if err != nil {
-				return trace.Wrap(err)
-			}
+		listMembers, err := membersService.getResources(ctx)
+		if err != nil {
+			return trace.Wrap(err)
 		}
 
 		if err := accesslists.ValidateAccessListWithMembers(ctx, existingAccessList, accessList, listMembers, &accessListAndMembersGetter{a.service, a.memberService}); err != nil {
@@ -420,6 +594,11 @@ func (a *AccessListService) DeleteAccessListV2(ctx context.Context, req *accessl
 		Scope: req.GetScope(),
 		Name:  req.GetName(),
 	})
+	membersService, err := a.membersServiceForAccessList(name)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	action := func(ctx context.Context, _ backend.Backend) error {
 		// Get list resource.
 		accessList, err := a.getAccessList(ctx, name)
@@ -432,26 +611,27 @@ func (a *AccessListService) DeleteAccessListV2(ctx context.Context, req *accessl
 			return trace.Wrap(err)
 		}
 
-		// TODO(nklaassen): support scoped access list members
-		if name.Scope == "" {
-			// Delete all associated members.
-			members, err := a.memberService.WithPrefix(name.Name).GetResources(ctx)
+		// Delete all associated members.
+		members, err := membersService.getResources(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		if err := membersService.deleteAllResources(ctx); err != nil {
+			return trace.Wrap(err)
+		}
+
+		// Update memberOf refs.
+		for _, member := range members {
+			if !member.IsList() {
+				continue
+			}
+			memberName, err := accesslists.MemberScopeQualifiedName(member)
 			if err != nil {
 				return trace.Wrap(err)
 			}
-
-			if err := a.memberService.WithPrefix(name.Name).DeleteAllResources(ctx); err != nil {
+			if err := a.updateAccessListMemberOf(ctx, name, memberName, false); err != nil {
 				return trace.Wrap(err)
-			}
-
-			// Update memberOf refs.
-			for _, member := range members {
-				if member.Spec.MembershipKind != accesslist.MembershipKindList {
-					continue
-				}
-				if err := a.updateAccessListMemberOf(ctx, name.Name, member.GetName(), false); err != nil {
-					return trace.Wrap(err)
-				}
 			}
 		}
 
@@ -505,14 +685,28 @@ func (a *AccessListService) GetSuggestedAccessLists(ctx context.Context, accessR
 
 // CountAccessListMembers will count all access list members.
 func (a *AccessListService) CountAccessListMembers(ctx context.Context, accessListName string) (users uint32, lists uint32, err error) {
+	return a.CountAccessListMembersV2(ctx, accesslistv1.CountAccessListMembersRequest_builder{
+		AccessListName: accessListName,
+	}.Build())
+}
+
+// CountAccessListMembersV2 will count all access list members.
+func (a *AccessListService) CountAccessListMembersV2(ctx context.Context, req *accesslistv1.CountAccessListMembersRequest) (users uint32, lists uint32, err error) {
 	count := uint(0)
 	listCount := uint(0)
-	members, err := a.memberService.WithPrefix(accessListName).GetResources(ctx)
+	membersService, err := a.membersServiceForAccessList(accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessListName(),
+	}))
 	if err != nil {
 		return 0, 0, trace.Wrap(err)
 	}
-	for _, member := range members {
-		if member.Spec.MembershipKind == accesslist.MembershipKindList {
+	for member, err := range membersService.resources(ctx, "", "") {
+		if err != nil {
+			return 0, 0, trace.Wrap(err)
+		}
+
+		if member.IsList() {
 			listCount++
 		} else {
 			count++
@@ -522,41 +716,80 @@ func (a *AccessListService) CountAccessListMembers(ctx context.Context, accessLi
 	return uint32(count), uint32(listCount), trace.Wrap(err)
 }
 
-// ListAccessListMembers returns a paginated list of all access list members.
+// ListAccessListMembers returns a paginated list of all members of the given list.
 func (a *AccessListService) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, nextToken string) ([]*accesslist.AccessListMember, string, error) {
-	_, err := a.getAccessList(ctx, accesslists.NormalizedSQN{Name: accessListName})
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-	members, nextToken, err := a.memberService.WithPrefix(accessListName).ListResources(ctx, pageSize, nextToken)
+	return a.ListAccessListMembersV2(ctx, accesslistv1.ListAccessListMembersRequest_builder{
+		AccessList: accessListName,
+		PageSize:   int32(pageSize),
+		PageToken:  nextToken,
+	}.Build())
+}
 
+// ListAccessListMembersV2 returns a paginated list of all members of the given list.
+func (a *AccessListService) ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) ([]*accesslist.AccessListMember, string, error) {
+	accessListName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	_, err := a.getAccessList(ctx, accessListName)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
-	return members, nextToken, nil
+	membersService, err := a.membersServiceForAccessList(accessListName)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return membersService.listResources(ctx, int(req.GetPageSize()), req.GetPageToken())
 }
 
 // ListAllAccessListMembers returns a paginated list of all access list members for all access lists.
 func (a *AccessListService) ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
-	members, next, err := a.memberService.ListResourcesReturnNextResource(ctx, pageSize, pageToken)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-	var nextKey string
-	if next != nil {
-		nextKey = (*next).Spec.AccessList + string(backend.Separator) + (*next).Metadata.Name
-	}
-	return members, nextKey, nil
+	// TODO(nklaassen): support listing scoped access list members with opt-in.
+	return a.memberService.UnscopedService.ListResources(ctx, pageSize, pageToken)
 }
 
 // GetAccessListMember returns the specified access list member resource.
 func (a *AccessListService) GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error) {
-	_, err := a.getAccessList(ctx, accesslists.NormalizedSQN{Name: accessList})
+	return a.GetAccessListMemberV2(ctx, accesslistv1.GetAccessListMemberRequest_builder{
+		AccessList: accessList,
+		MemberName: memberName,
+	}.Build())
+}
+
+// GetAccessListMemberV2 returns the specified access list member resource.
+func (a *AccessListService) GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error) {
+	accessListName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	memberName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetMemberScope(),
+		Name:  req.GetMemberName(),
+	})
+	_, err := a.getAccessList(ctx, accessListName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	member, err := a.memberService.WithPrefix(accessList).GetResource(ctx, memberName)
+	memberService, err := a.memberServiceForNamedMember(accessListName, memberName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	member, err := memberService.get(ctx)
 	return member, trace.Wrap(err)
+}
+
+// memberServiceForNamedMember returns a [*memberService] valid for only the
+// exact named member, with an appropriate backend prefix and NameKeyFunc configured.
+func (a *AccessListService) memberServiceForNamedMember(listName, memberName accesslists.NormalizedSQN) (*memberService, error) {
+	return memberServiceForNamedMember(a.memberService, listName, memberName)
+}
+
+// membersServiceForAccessList returns a [*membersService] valid only for
+// operations on _all_ members of the given access list, it cannot be used to
+// get, create, or delete any single member, use [memberServiceForNamedMember]
+// in those cases.
+func (a *AccessListService) membersServiceForAccessList(listName accesslists.NormalizedSQN) (*membersService, error) {
+	return membersServiceForAccessList(a.memberService, listName)
 }
 
 // updateAccessListRefField is a helper that updates the specified field (memberOf or ownerOf) of an Access List,
@@ -604,12 +837,12 @@ func (a *AccessListService) updateAccessListRefField(
 
 // updateAccessListMemberOf updates the memberOf field for the specified memberName and accessListName.
 // Should only be called after the relevant member has been successfully upserted or deleted.
-func (a *AccessListService) updateAccessListMemberOf(ctx context.Context, accessListName, memberName string, new bool) error {
-	// TODO(nklaassen): support scoped access list members.
-	listSQN := accesslists.NormalizedSQN{Name: accessListName}
-	memberSQN := accesslists.NormalizedSQN{Name: memberName}
-	return a.updateAccessListRefField(ctx, listSQN, memberSQN, new, func(status *accesslist.Status) *[]string {
-		return &status.MemberOf
+func (a *AccessListService) updateAccessListMemberOf(ctx context.Context, accessListName, memberName accesslists.NormalizedSQN, new bool) error {
+	return a.updateAccessListRefField(ctx, accessListName, memberName, new, func(status *accesslist.Status) *[]string {
+		if accessListName.Scope == "" {
+			return &status.MemberOf
+		}
+		return &status.ScopedMemberOf
 	})
 }
 
@@ -652,29 +885,42 @@ func (a *AccessListService) GetAccessListOwnersV2(ctx context.Context, req *acce
 
 // UpsertAccessListMember creates or updates an access list member resource.
 func (a *AccessListService) UpsertAccessListMember(ctx context.Context, member *accesslist.AccessListMember) (*accesslist.AccessListMember, error) {
+	parentListName, err := accesslists.ParentListOf(member)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	memberName, err := accesslists.MemberScopeQualifiedName(member)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	memberService, err := a.memberServiceForNamedMember(parentListName, memberName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	var upserted *accesslist.AccessListMember
 	action := func(ctx context.Context, _ backend.Backend) error {
-		memberList, err := a.GetAccessList(ctx, member.Spec.AccessList)
+		parentList, err := a.getAccessList(ctx, parentListName)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		existingMember, err := a.memberService.GetResource(ctx, member.GetName())
+		existingMember, err := memberService.get(ctx)
 		if err != nil && !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
 		keepAWSIdentityCenterLabels(existingMember, member)
 
-		if err := accesslists.ValidateAccessListMember(ctx, memberList, member, &accessListAndMembersGetter{a.service, a.memberService}); err != nil {
+		if err := accesslists.ValidateAccessListMember(ctx, parentList, member, &accessListAndMembersGetter{a.service, a.memberService}); err != nil {
 			return trace.Wrap(err)
 		}
 
-		upserted, err = a.memberService.WithPrefix(member.Spec.AccessList).UpsertResource(ctx, member)
+		upserted, err = memberService.upsert(ctx, member)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 
-		if member.Spec.MembershipKind == accesslist.MembershipKindList {
-			if err := a.updateAccessListMemberOf(ctx, member.Spec.AccessList, member.Spec.Name, true); err != nil {
+		if member.IsList() {
+			if err := a.updateAccessListMemberOf(ctx, parentListName, memberName, true); err != nil {
 				return trace.Wrap(err)
 			}
 		}
@@ -682,30 +928,43 @@ func (a *AccessListService) UpsertAccessListMember(ctx context.Context, member *
 		return nil
 	}
 
-	// without this check creating the lock may fail with "special characters are not allowed in resource names"
-	if member.Spec.AccessList == "" {
-		return nil, trace.BadParameter("access_list_member %s: spec.access_list field empty", member.GetName())
+	lockName, err := scopeAwareLockName(parentListName)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		return a.service.RunWhileLocked(ctx, lockName(member.Spec.AccessList), accessListLockTTL, action)
+	err = a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		return a.service.RunWhileLocked(ctx, lockName, accessListLockTTL, action)
 	})
 	return upserted, trace.Wrap(err)
 }
 
 // UpdateAccessListMember conditionally updates an access list member resource.
 func (a *AccessListService) UpdateAccessListMember(ctx context.Context, member *accesslist.AccessListMember) (*accesslist.AccessListMember, error) {
-	var updated *accesslist.AccessListMember
-	// without this check creating the lock may fail with "special characters are not allowed in resource names"
-	if member.Spec.AccessList == "" {
-		return nil, trace.BadParameter("access_list_member %s: spec.access_list field empty", member.GetName())
+	parentListName, err := accesslists.ParentListOf(member)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		return a.service.RunWhileLocked(ctx, lockName(member.Spec.AccessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-			memberList, err := a.GetAccessList(ctx, member.Spec.AccessList)
+	memberName, err := accesslists.MemberScopeQualifiedName(member)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	memberService, err := a.memberServiceForNamedMember(parentListName, memberName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var updated *accesslist.AccessListMember
+	lockName, err := scopeAwareLockName(parentListName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	err = a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		return a.service.RunWhileLocked(ctx, lockName, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+			memberList, err := a.getAccessList(ctx, parentListName)
 			if err != nil {
 				return trace.Wrap(err)
 			}
-			existingMember, err := a.memberService.GetResource(ctx, member.GetName())
+			existingMember, err := memberService.get(ctx)
 			if err != nil && !trace.IsNotFound(err) {
 				return trace.Wrap(err)
 			}
@@ -715,13 +974,13 @@ func (a *AccessListService) UpdateAccessListMember(ctx context.Context, member *
 				return trace.Wrap(err)
 			}
 
-			updated, err = a.memberService.WithPrefix(member.Spec.AccessList).ConditionalUpdateResource(ctx, member)
+			updated, err = memberService.conditionalUpdateResource(ctx, member)
 			if err != nil {
 				return trace.Wrap(err)
 			}
 
-			if member.Spec.MembershipKind == accesslist.MembershipKindList {
-				if err := a.updateAccessListMemberOf(ctx, member.Spec.AccessList, member.Spec.Name, true); err != nil {
+			if member.IsList() {
+				if err := a.updateAccessListMemberOf(ctx, parentListName, memberName, true); err != nil {
 					return trace.Wrap(err)
 				}
 			}
@@ -734,24 +993,48 @@ func (a *AccessListService) UpdateAccessListMember(ctx context.Context, member *
 
 // DeleteAccessListMember hard deletes the specified access list member resource.
 func (a *AccessListService) DeleteAccessListMember(ctx context.Context, accessList string, memberName string) error {
-	err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		return a.service.RunWhileLocked(ctx, lockName(accessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-			_, err := a.GetAccessList(ctx, accessList)
+	return a.DeleteAccessListMemberV2(ctx, accesslistv1.DeleteAccessListMemberRequest_builder{
+		AccessList: accessList,
+		MemberName: memberName,
+	}.Build())
+}
+
+// DeleteAccessListMemberV2 hard deletes the specified access list member resource.
+func (a *AccessListService) DeleteAccessListMemberV2(ctx context.Context, req *accesslistv1.DeleteAccessListMemberRequest) error {
+	accessListName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	memberName := accesslists.NormalizedSQN(scopes.QualifiedName{
+		Scope: req.GetMemberScope(),
+		Name:  req.GetMemberName(),
+	})
+	lockName, err := scopeAwareLockName(accessListName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	memberService, err := a.memberServiceForNamedMember(accessListName, memberName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		return a.service.RunWhileLocked(ctx, lockName, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+			_, err := a.getAccessList(ctx, accessListName)
 			if err != nil {
 				return trace.Wrap(err)
 			}
 
-			member, err := a.memberService.WithPrefix(accessList).GetResource(ctx, memberName)
+			member, err := memberService.get(ctx)
 			if err != nil {
 				return trace.Wrap(err)
 			}
 
-			if err := a.memberService.WithPrefix(accessList).DeleteResource(ctx, memberName); err != nil {
+			if err := memberService.delete(ctx); err != nil {
 				return trace.Wrap(err)
 			}
 
-			if member.Spec.MembershipKind == accesslist.MembershipKindList {
-				if err := a.updateAccessListMemberOf(ctx, accessList, memberName, false); err != nil {
+			if member.IsList() {
+				if err := a.updateAccessListMemberOf(ctx, accessListName, memberName, false); err != nil {
 					return trace.Wrap(err)
 				}
 			}
@@ -767,27 +1050,53 @@ func (a *AccessListService) DeleteAccessListMember(ctx context.Context, accessLi
 // allowed on a list with implicit membership, as it provides a mechanism for
 // cleaning out the user list if a list is converted from explicit to implicit.
 func (a *AccessListService) DeleteAllAccessListMembersForAccessList(ctx context.Context, accessList string) error {
-	err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		return a.service.RunWhileLocked(ctx, lockName(accessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-			_, err := a.GetAccessList(ctx, accessList)
+	return a.DeleteAllAccessListMembersForAccessListV2(ctx, accesslistv1.DeleteAllAccessListMembersForAccessListRequest_builder{
+		AccessList: accessList,
+	}.Build())
+}
+
+// DeleteAllAccessListMembersForAccessListV2 hard deletes all access list members
+// for an access list. Note that deleting all members is the only member operation
+// allowed on a list with implicit membership, as it provides a mechanism for
+// cleaning out the user list if a list is converted from explicit to implicit.
+func (a *AccessListService) DeleteAllAccessListMembersForAccessListV2(ctx context.Context, req *accesslistv1.DeleteAllAccessListMembersForAccessListRequest) error {
+	accessListName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	membersService, err := a.membersServiceForAccessList(accessListName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	lockName, err := scopeAwareLockName(accessListName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		return a.service.RunWhileLocked(ctx, lockName, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+			_, err := a.getAccessList(ctx, accessListName)
 			if err != nil {
 				return trace.Wrap(err)
 			}
 
-			allMembers, err := a.memberService.WithPrefix(accessList).GetResources(ctx)
+			allMembers, err := membersService.getResources(ctx)
 			if err != nil {
 				return trace.Wrap(err)
 			}
 
-			if err := a.memberService.WithPrefix(accessList).DeleteAllResources(ctx); err != nil {
+			if err := membersService.deleteAllResources(ctx); err != nil {
 				return trace.Wrap(err)
 			}
 
 			for _, member := range allMembers {
-				if member.Spec.MembershipKind != accesslist.MembershipKindList {
+				if !member.IsList() {
 					continue
 				}
-				if err := a.updateAccessListMemberOf(ctx, accessList, member.Spec.Name, false); err != nil {
+				memberName, err := accesslists.MemberScopeQualifiedName(member)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				if err := a.updateAccessListMemberOf(ctx, accessListName, memberName, false); err != nil {
 					return trace.Wrap(err)
 				}
 			}
@@ -820,11 +1129,12 @@ func (a *AccessListService) writeAccessList(
 }
 
 // writeAccessListWithMembers holds all of the common logic for updating and
-// upserting an access list and it's collection of members.
+// upserting an access list and its collection of members.
 func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, accessList *accesslist.AccessList, membersIn []*accesslist.AccessListMember, op opType) (*accesslist.AccessList, []*accesslist.AccessListMember, error) {
 	if err := accessList.CheckAndSetDefaults(); err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
+	accessListName := accesslists.ScopeQualifiedName(accessList)
 
 	for _, m := range membersIn {
 		if err := m.CheckAndSetDefaults(); err != nil {
@@ -836,7 +1146,7 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 
 	validateAccessList := func() error {
 		var err error
-		existingAccessList, err = a.getAccessList(ctx, accesslists.ScopeQualifiedName(accessList))
+		existingAccessList, err = a.getAccessList(ctx, accessListName)
 		if err != nil {
 			// a not found error is totally legal for an upsert operation, but
 			// fatal for an update.
@@ -865,78 +1175,77 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 	}
 
 	reconcileMembers := func() error {
-		// TODO(nklaassen): support scoped access list members.
-		if accessList.Scope != "" {
-			if len(membersIn) > 0 {
-				return trace.BadParameter("scoped access list members are not yet supported")
+		// Convert the members slice to a map for easier lookup.
+		membersMap := make(map[accesslists.NormalizedSQN]*accesslist.AccessListMember, len(membersIn))
+		for _, member := range membersIn {
+			memberName, err := accesslists.MemberScopeQualifiedName(member)
+			if err != nil {
+				return trace.Wrap(err)
 			}
-			return nil
+			membersMap[memberName] = member
 		}
 
-		// Convert the members slice to a map for easier lookup.
-		membersMap := utils.FromSlice(membersIn, types.GetName)
+		membersService, err := a.membersServiceForAccessList(accessListName)
+		if err != nil {
+			return trace.Wrap(err)
+		}
 
-		var (
-			members      []*accesslist.AccessListMember
-			membersToken string
-		)
-
-		for {
-			// List all members for the access list.
-			var err error
-			members, membersToken, err = a.memberService.WithPrefix(accessList.GetName()).ListResources(ctx, 0 /* default size */, membersToken)
+		for existingMember, err := range membersService.resources(ctx, "", "") {
 			if err != nil {
 				return trace.Wrap(err)
 			}
 
-			for _, existingMember := range members {
-				// If the member is not in the new members map (request), delete it.
-				if newMember, ok := membersMap[existingMember.GetName()]; !ok {
-					err = a.memberService.WithPrefix(accessList.GetName()).DeleteResource(ctx, existingMember.GetName())
+			existingMemberName, err := accesslists.MemberScopeQualifiedName(existingMember)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			memberService, err := a.memberServiceForNamedMember(accessListName, existingMemberName)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			// If the member is not in the new members map (request), delete it.
+			if newMember, ok := membersMap[existingMemberName]; !ok {
+				if err := memberService.delete(ctx); err != nil {
+					return trace.Wrap(err)
+				}
+				// Update memberOf field if nested list.
+				if existingMember.IsList() {
+					if err := a.updateAccessListMemberOf(ctx, accessListName, existingMemberName, false); err != nil {
+						return trace.Wrap(err)
+					}
+				}
+			} else {
+				// Preserve the membership metadata for any existing members
+				// to suppress member records flipping back and forth due
+				// due SCIM pushes or Sync Service updates.
+				if !existingMember.Spec.Expires.IsZero() {
+					newMember.Spec.Expires = existingMember.Spec.Expires
+				}
+				if existingMember.Spec.Reason != "" {
+					newMember.Spec.Reason = existingMember.Spec.Reason
+				}
+				keepAWSIdentityCenterLabels(existingMember, newMember)
+				newMember.Spec.AddedBy = existingMember.Spec.AddedBy
+
+				// Compare members and update if necessary.
+				if !cmp.Equal(newMember, existingMember) {
+					// Update the member.
+					upserted, err := memberService.upsert(ctx, newMember)
 					if err != nil {
 						return trace.Wrap(err)
 					}
-					// Update memberOf field if nested list.
-					if existingMember.Spec.MembershipKind == accesslist.MembershipKindList {
-						if err := a.updateAccessListMemberOf(ctx, accessList.GetName(), existingMember.GetName(), false); err != nil {
-							return trace.Wrap(err)
-						}
-					}
-				} else {
-					// Preserve the membership metadata for any existing members
-					// to suppress member records flipping back and forth due
-					// due SCIM pushes or Sync Service updates.
-					if !existingMember.Spec.Expires.IsZero() {
-						newMember.Spec.Expires = existingMember.Spec.Expires
-					}
-					if existingMember.Spec.Reason != "" {
-						newMember.Spec.Reason = existingMember.Spec.Reason
-					}
-					keepAWSIdentityCenterLabels(existingMember, newMember)
-					newMember.Spec.AddedBy = existingMember.Spec.AddedBy
 
-					// Compare members and update if necessary.
-					if !cmp.Equal(newMember, existingMember) {
-						// Update the member.
-						upserted, err := a.memberService.WithPrefix(accessList.GetName()).UpsertResource(ctx, newMember)
-						if err != nil {
-							return trace.Wrap(err)
-						}
-
-						existingMember.SetRevision(upserted.GetRevision())
-					}
+					existingMember.SetRevision(upserted.GetRevision())
 				}
-
-				// Remove the member from the map.
-				delete(membersMap, existingMember.GetName())
 			}
 
-			if membersToken == "" {
-				break
-			}
+			// Remove the member from the map.
+			delete(membersMap, existingMemberName)
 		}
 
-		if err := a.insertMembersAndUpdateNestedRelationships(ctx, accessList.GetName(), slices.Collect(maps.Values(membersMap))); err != nil {
+		if err := a.insertMembersAndUpdateNestedRelationships(ctx, accessListName, slices.Collect(maps.Values(membersMap))); err != nil {
 			return trace.Wrap(err)
 		}
 		return nil
@@ -987,7 +1296,7 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 			if err != nil {
 				return trace.Wrap(err)
 			}
-			if err := a.updateAccessListOwnerOf(ctx, accesslists.ScopeQualifiedName(accessList), ownerName, true); err != nil {
+			if err := a.updateAccessListOwnerOf(ctx, accessListName, ownerName, true); err != nil {
 				return trace.Wrap(err)
 			}
 		}
@@ -1001,7 +1310,7 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 	// access lists in the cluster in order to  prevent un-authorized use of the
 	// AccessList feature
 	if !a.modules.Features().GetEntitlement(entitlements.Identity).Enabled {
-		actions = append(actions, func() error { return a.verifyAccessListCreateLimit(ctx, accesslists.ScopeQualifiedName(accessList)) })
+		actions = append(actions, func() error { return a.verifyAccessListCreateLimit(ctx, accessListName) })
 	}
 
 	// Note we need to reconcile the old owners (clean status.owner_of for the owner lists
@@ -1011,7 +1320,7 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 	// interrupted as we use status.owner_of to calculate hierarchy.
 	actions = append(actions, validateAccessList, reconcileMembers, reconcileOldOwners, writeAccessList, reconcileNewOwners)
 
-	lockName, err := scopeAwareLockName(accesslists.ScopeQualifiedName(accessList))
+	lockName, err := scopeAwareLockName(accessListName)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -1118,6 +1427,11 @@ func (a *AccessListService) ListAllAccessListReviews(ctx context.Context, pageSi
 
 // CreateAccessListReview will create a new review for an access list.
 func (a *AccessListService) CreateAccessListReview(ctx context.Context, review *accesslist.Review) (*accesslist.Review, time.Time, error) {
+	if review.Scope != "" {
+		// TODO(nklaassen): support scoped access list reviews.
+		return nil, time.Time{}, trace.BadParameter("scoped access list reviews are not yet supported")
+	}
+
 	reviewName := uuid.New().String()
 	createdReview, err := accesslist.NewReview(header.Metadata{
 		Name:        reviewName,
@@ -1182,19 +1496,22 @@ func (a *AccessListService) CreateAccessListReview(ctx context.Context, review *
 		}
 		accessList.Spec.Audit.NextAuditDate = nextAuditDate
 
+		// TODO(nklaassen): support scoped access list reviews.
+		reviewedListName := accesslists.NormalizedSQN{Name: review.Spec.AccessList}
+
 		for _, removedMember := range review.Spec.Changes.RemovedMembers {
-			_, err := a.memberService.WithPrefix(review.Spec.AccessList).GetResource(ctx, removedMember)
+			_, err := a.memberService.UnscopedService.WithPrefix(review.Spec.AccessList).GetResource(ctx, removedMember)
 			if err != nil && !trace.IsNotFound(err) {
 				return trace.Wrap(err)
 			}
 			isAccessListMember := err == nil
 
 			if isAccessListMember {
-				if err := a.updateAccessListMemberOf(ctx, review.Spec.AccessList, removedMember, false); err != nil {
+				if err := a.updateAccessListMemberOf(ctx, reviewedListName, accesslists.NormalizedSQN{Name: removedMember}, false); err != nil {
 					return trace.Wrap(err)
 				}
 			}
-			if err := a.memberService.WithPrefix(review.Spec.AccessList).DeleteResource(ctx, removedMember); err != nil {
+			if err := a.memberService.UnscopedService.WithPrefix(review.Spec.AccessList).DeleteResource(ctx, removedMember); err != nil {
 				return trace.Wrap(err)
 			}
 		}
@@ -1351,7 +1668,7 @@ func keepAWSIdentityCenterLabels(old, new *accesslist.AccessListMember) {
 	}
 }
 
-func (a *AccessListService) insertMembersAndUpdateNestedRelationships(ctx context.Context, accessListName string, members []*accesslist.AccessListMember) error {
+func (a *AccessListService) insertMembersAndUpdateNestedRelationships(ctx context.Context, accessListName accesslists.NormalizedSQN, members []*accesslist.AccessListMember) error {
 	if err := a.insertMembers(ctx, accessListName, members); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1362,7 +1679,7 @@ func (a *AccessListService) insertMembersAndUpdateNestedRelationships(ctx contex
 	return nil
 }
 
-func (a *AccessListService) insertMembers(ctx context.Context, acl string, members []*accesslist.AccessListMember) error {
+func (a *AccessListService) insertMembers(ctx context.Context, acl accesslists.NormalizedSQN, members []*accesslist.AccessListMember) error {
 	items, err := a.membersToBackendItems(acl, members)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1378,10 +1695,18 @@ func (a *AccessListService) insertMembers(ctx context.Context, acl string, membe
 	return nil
 }
 
-func (a *AccessListService) membersToBackendItems(acl string, members []*accesslist.AccessListMember) ([]backend.Item, error) {
+func (a *AccessListService) membersToBackendItems(acl accesslists.NormalizedSQN, members []*accesslist.AccessListMember) ([]backend.Item, error) {
 	out := make([]backend.Item, 0, len(members))
 	for _, member := range members {
-		item, err := a.memberService.WithPrefix(acl).MakeBackendItem(member)
+		memberName, err := accesslists.MemberScopeQualifiedName(member)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		memberService, err := a.memberServiceForNamedMember(acl, memberName)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		item, err := memberService.makeBackendItem(member)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -1390,13 +1715,17 @@ func (a *AccessListService) membersToBackendItems(acl string, members []*accessl
 	return out, nil
 }
 
-func (a *AccessListService) updatedMembersNestedRelationships(ctx context.Context, acl string, members []*accesslist.AccessListMember) error {
+func (a *AccessListService) updatedMembersNestedRelationships(ctx context.Context, acl accesslists.NormalizedSQN, members []*accesslist.AccessListMember) error {
 	for _, member := range members {
-		if member.Spec.MembershipKind != accesslist.MembershipKindList {
+		if !member.IsList() {
 			continue
 		}
+		memberName, err := accesslists.MemberScopeQualifiedName(member)
+		if err != nil {
+			return trace.Wrap(err)
+		}
 		// Update memberOf field if nested list.
-		if err := a.updateAccessListMemberOf(ctx, acl, member.Spec.Name, true); err != nil {
+		if err := a.updateAccessListMemberOf(ctx, acl, memberName, true); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -1472,21 +1801,48 @@ func (a *AccessListService) CleanupAccessListStatusV2(ctx context.Context, acces
 			return nil, trace.Wrap(ownerRefreshErr)
 		}
 
-		// TODO(nklaassen): support scoped access list members.
-		if accessListName.Scope == "" {
-			var memberRefreshErr error
-			accessList.Status.MemberOf = slices.DeleteFunc(accessList.Status.MemberOf, func(memberOf string) bool {
-				if _, err := a.memberService.WithPrefix(memberOf).GetResource(ctx, accessList.GetName()); err != nil {
-					if trace.IsNotFound(err) {
-						return true
-					}
-					memberRefreshErr = err
-				}
-				return false
-			})
-			if memberRefreshErr != nil {
-				return nil, trace.Wrap(memberRefreshErr)
+		var memberRefreshErr error
+
+		// MemberOf names unscoped access lists that this access list is supposedly a member of.
+		accessList.Status.MemberOf = slices.DeleteFunc(accessList.Status.MemberOf, func(memberOf string) bool {
+			if accessList.Scope != "" {
+				// Scoped access lists can never be members of unscoped access lists.
+				return true
 			}
+			if _, err := a.memberService.UnscopedService.WithPrefix(memberOf).GetResource(ctx, accessList.GetName()); err != nil {
+				if trace.IsNotFound(err) {
+					return true
+				}
+				memberRefreshErr = err
+			}
+			return false
+		})
+		if memberRefreshErr != nil {
+			return nil, trace.Wrap(memberRefreshErr)
+		}
+
+		// ScopedMemberOf names scoped access lists that this access list is supposedly a member of.
+		accessList.Status.ScopedMemberOf = slices.DeleteFunc(accessList.Status.ScopedMemberOf, func(scopedMemberOf string) bool {
+			parentListName, err := accesslists.ParseScopeQualifiedName(scopedMemberOf)
+			if err != nil {
+				// If we can't parse the name, it is invalid and should be removed.
+				return true
+			}
+			memberService, err := a.memberServiceForNamedMember(parentListName, accessListName)
+			if err != nil {
+				memberRefreshErr = err
+				return false
+			}
+			if _, err := memberService.get(ctx); err != nil {
+				if trace.IsNotFound(err) {
+					return true
+				}
+				memberRefreshErr = err
+			}
+			return false
+		})
+		if memberRefreshErr != nil {
+			return nil, trace.Wrap(memberRefreshErr)
 		}
 
 		accessList, err = a.service.UpdateResource(ctx, accessList)
@@ -1522,18 +1878,23 @@ func (a *AccessListService) EnsureNestedAccessListStatusesV2(ctx context.Context
 			}
 		}
 
-		// TODO(nklaassen): support scoped access list members.
-		if accessListName.Scope == "" {
-			members, err := a.memberService.WithPrefix(accessListName.Name).GetResources(ctx)
+		membersService, err := a.membersServiceForAccessList(accessListName)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		for member, err := range membersService.resources(ctx, "", "") {
 			if err != nil {
 				return trace.Wrap(err)
 			}
-			for _, member := range members {
-				if member.Spec.MembershipKind == accesslist.MembershipKindList {
-					if err := a.updateAccessListMemberOf(ctx, accessListName.Name, member.GetName(), true); err != nil {
-						return trace.Wrap(err)
-					}
-				}
+			if !member.IsList() {
+				continue
+			}
+			memberName, err := accesslists.MemberScopeQualifiedName(member)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if err := a.updateAccessListMemberOf(ctx, accessListName, memberName, true); err != nil {
+				return trace.Wrap(err)
 			}
 		}
 
@@ -1588,8 +1949,9 @@ func (a *AccessListService) collectionToBackendItemsIter(collection *accesslists
 				yield(backend.Item{}, trace.NotFound("access list %q not found", aclName))
 				return
 			}
+			// TODO(nklaassen): support collections of scoped access lists.
 			for _, member := range members {
-				item, err := a.memberService.WithPrefix(member.Spec.AccessList).MakeBackendItem(member)
+				item, err := a.memberService.UnscopedService.WithPrefix(member.Spec.AccessList).MakeBackendItem(member)
 				if err != nil {
 					yield(backend.Item{}, trace.Wrap(err))
 					return
@@ -1651,28 +2013,36 @@ func (a *AccessListService) checkDeletionBlockingRelationships(ctx context.Conte
 
 // checkDeletionBlockingMemberRelationships checks if the access list is a member of any other access lists that would block deletion
 func (a *AccessListService) checkDeletionBlockingMemberRelationships(ctx context.Context, accessList *accesslist.AccessList) error {
-	memberOf := accessList.GetStatus().MemberOf
-	if len(memberOf) == 0 {
+	accessListName := accesslists.ScopeQualifiedName(accessList)
+	allParentLists, err := accesslists.AllParentLists(accessList)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if len(allParentLists) == 0 {
 		return nil
 	}
 
-	memberOfTitles := make([]string, 0, len(memberOf))
-	for _, memberOf := range memberOf {
-		parentList, err := a.GetAccessList(ctx, memberOf)
+	memberOfTitles := make([]string, 0, len(allParentLists))
+	for _, parentListName := range allParentLists {
+		parentList, err := a.getAccessList(ctx, parentListName)
 		if err != nil {
 			if trace.IsNotFound(err) {
 				continue
 			}
-			return trace.Wrap(err, `fetching parent list "%s"`, memberOf)
+			return trace.Wrap(err, `fetching parent list "%s"`, parentListName)
 		}
-		member, err := a.memberService.WithPrefix(parentList.GetName()).GetResource(ctx, accessList.GetName())
+		memberService, err := a.memberServiceForNamedMember(parentListName, accessListName)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		member, err := memberService.get(ctx)
 		if err != nil {
 			if trace.IsNotFound(err) {
 				continue
 			}
-			return trace.Wrap(err, `fetching access list member for "%s"`, memberOf)
+			return trace.Wrap(err, `fetching access list member for "%s"`, parentListName.String())
 		}
-		if member.Spec.MembershipKind == accesslist.MembershipKindList {
+		if member.IsList() {
 			memberOfTitles = append(memberOfTitles, parentList.Spec.Title)
 		}
 	}

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -373,11 +373,9 @@ func NewAccessListServiceV2(cfg AccessListServiceConfig) (*AccessListService, er
 	}, nil
 }
 
-// GetAccessLists returns a list of all access lists.
+// GetAccessLists returns a list of all unscoped access lists.
 func (a *AccessListService) GetAccessLists(ctx context.Context) ([]*accesslist.AccessList, error) {
-	// TODO(nklaassen): support listing scoped access lists.
-	accessLists, err := a.service.UnscopedService.GetResources(ctx)
-	return accessLists, trace.Wrap(err)
+	return a.service.UnscopedService.GetResources(ctx)
 }
 
 // GetInheritedGrants returns grants inherited by access list accessListID from parent access lists.
@@ -386,9 +384,8 @@ func (a *AccessListService) GetInheritedGrants(ctx context.Context, accessListID
 	return nil, trace.NotImplemented("GetInheritedGrants should not be called")
 }
 
-// ListAccessLists returns a paginated list of access lists.
+// ListAccessLists returns a paginated list of unscoped access lists.
 func (a *AccessListService) ListAccessLists(ctx context.Context, pageSize int, nextToken string) ([]*accesslist.AccessList, string, error) {
-	// TODO(nklaassen): support listing scoped access lists.
 	return a.service.UnscopedService.ListResources(ctx, pageSize, nextToken)
 }
 
@@ -396,13 +393,17 @@ func (a *AccessListService) ListAccessLists(ctx context.Context, pageSize int, n
 func (a *AccessListService) ListAccessListsV2(ctx context.Context, req *accesslistv1.ListAccessListsV2Request) ([]*accesslist.AccessList, string, error) {
 	// Currently, the backend only sorts on lexicographical keys and not
 	// based on fields within a resource
-	if req.SortBy != nil && (req.GetSortBy().Field != "name" || req.GetSortBy().IsDesc != false) {
+	if req.GetSortBy() != nil && (req.GetSortBy().Field != "name" || req.GetSortBy().IsDesc) {
 		return nil, "", trace.CompareFailed("unsupported sort, only name:asc is supported, but got %q (desc = %t)", req.GetSortBy().Field, req.GetSortBy().IsDesc)
 	}
 
-	// TODO(nklaassen): support listing scoped access lists.
-	return a.service.UnscopedService.ListResourcesWithFilter(ctx, int(req.GetPageSize()), req.GetPageToken(), func(item *accesslist.AccessList) bool {
-		return services.MatchAccessList(item, req.GetFilter())
+	scopeFilter := req.GetScopeFilter()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	return a.service.ListResourcesWithFilter(ctx, int(req.GetPageSize()), req.GetPageToken(), func(item *accesslist.AccessList) bool {
+		return services.MatchAccessList(item, req.GetFilter()) && scopes.MatchScope(scopeFilter, item.GetScope())
 	})
 }
 
@@ -747,10 +748,20 @@ func (a *AccessListService) ListAccessListMembersV2(ctx context.Context, req *ac
 	return membersService.listResources(ctx, int(req.GetPageSize()), req.GetPageToken())
 }
 
-// ListAllAccessListMembers returns a paginated list of all access list members for all access lists.
+// ListAllAccessListMembers returns a paginated list of all access list members for all unscoped access lists.
 func (a *AccessListService) ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
-	// TODO(nklaassen): support listing scoped access list members with opt-in.
 	return a.memberService.UnscopedService.ListResources(ctx, pageSize, pageToken)
+}
+
+// ListAllAccessListMembersV2 returns a paginated list of all access list members for all access lists.
+func (a *AccessListService) ListAllAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAllAccessListMembersRequest) ([]*accesslist.AccessListMember, string, error) {
+	scopeFilter := req.GetScopeFilter()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return a.memberService.ListResourcesWithFilter(ctx, int(req.GetPageSize()), req.GetPageToken(), func(member *accesslist.AccessListMember) bool {
+		return scopes.MatchScope(scopeFilter, member.GetScope())
+	})
 }
 
 // GetAccessListMember returns the specified access list member resource.
@@ -1458,18 +1469,20 @@ func (a *AccessListService) ListAccessListReviewsV2(ctx context.Context, req *ac
 	return reviews, nextToken, nil
 }
 
-// ListAllAccessListReviews will list access list reviews for all access lists.
+// ListAllAccessListReviews will list access list reviews for all unscoped access lists.
 func (a *AccessListService) ListAllAccessListReviews(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.Review, string, error) {
-	// TODO(nklaassen): support listing reviews of scoped access lists.
-	reviews, next, err := a.reviewService.UnscopedService.ListResourcesReturnNextResource(ctx, pageSize, pageToken)
-	if err != nil {
+	return a.reviewService.UnscopedService.ListResources(ctx, pageSize, pageToken)
+}
+
+// ListAllAccessListReviewsV2 will list access list reviews for all access lists.
+func (a *AccessListService) ListAllAccessListReviewsV2(ctx context.Context, req *accesslistv1.ListAllAccessListReviewsRequest) ([]*accesslist.Review, string, error) {
+	scopeFilter := req.GetScopeFilter()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
 		return nil, "", trace.Wrap(err)
 	}
-	var nextKey string
-	if next != nil {
-		nextKey = (*next).Spec.AccessList + string(backend.Separator) + (*next).Metadata.Name
-	}
-	return reviews, nextKey, nil
+	return a.reviewService.ListResourcesWithFilter(ctx, int(req.GetPageSize()), req.GetNextToken(), func(review *accesslist.Review) bool {
+		return scopes.MatchScope(scopeFilter, review.GetScope())
+	})
 }
 
 // CreateAccessListReview will create a new review for an access list.

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -64,6 +64,10 @@ const (
 	accessListMemberPrefix      = "access_list_member"
 	accessListMemberMaxPageSize = 200
 
+	// Access list reviews are stored under one of the following key ranges,
+	// depending on the scope of the reviewed list:
+	// - /access_list_review/<list-name>/<review-id>                             (for unscoped lists)
+	// - /scoped/access_list_review/<encoded-list-scope>/<list-name>/<review-id> (for scoped lists)
 	accessListReviewPrefix      = "access_list_review"
 	accessListReviewMaxPageSize = 200
 
@@ -94,7 +98,7 @@ type AccessListService struct {
 	scopesFeatures scopes.Features
 	service        *generic.ScopeAwareService[*accesslist.AccessList]
 	memberService  *generic.ScopeAwareService[*accesslist.AccessListMember]
-	reviewService  *generic.Service[*accesslist.Review]
+	reviewService  *generic.ScopeAwareService[*accesslist.Review]
 }
 
 type accessListAndMembersGetter struct {
@@ -345,11 +349,12 @@ func NewAccessListServiceV2(cfg AccessListServiceConfig) (*AccessListService, er
 		return nil, trace.Wrap(err)
 	}
 
-	reviewService, err := generic.NewService(&generic.ServiceConfig[*accesslist.Review]{
+	reviewService, err := generic.NewScopeAwareService(&generic.ScopeAwareServiceConfig[*accesslist.Review]{
 		Backend:                     cfg.Backend,
 		PageLimit:                   accessListReviewMaxPageSize,
 		ResourceKind:                types.KindAccessListReview,
-		BackendPrefix:               backend.NewKey(accessListReviewPrefix),
+		UnscopedBackendPrefix:       backend.NewKey(accessListReviewPrefix),
+		ScopedBackendPrefix:         backend.NewKey(scopedPrefix, accessListReviewPrefix),
 		MarshalFunc:                 services.MarshalAccessListReview,
 		UnmarshalFunc:               services.UnmarshalAccessListReview,
 		RunWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
@@ -1424,12 +1429,29 @@ func (a *AccessListService) AccessRequestPromote(_ context.Context, _ *accesslis
 
 // ListAccessListReviews will list access list reviews for a particular access list.
 func (a *AccessListService) ListAccessListReviews(ctx context.Context, accessList string, pageSize int, pageToken string) (reviews []*accesslist.Review, nextToken string, err error) {
-	_, err = a.GetAccessList(ctx, accessList)
+	return a.ListAccessListReviewsV2(ctx, accesslistv1.ListAccessListReviewsRequest_builder{
+		AccessList: accessList,
+		PageSize:   int32(pageSize),
+		NextToken:  pageToken,
+	}.Build())
+}
+
+func (a *AccessListService) ListAccessListReviewsV2(ctx context.Context, req *accesslistv1.ListAccessListReviewsRequest) (reviews []*accesslist.Review, nextToken string, err error) {
+	listName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	_, err = a.getAccessList(ctx, listName)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 
-	reviews, nextToken, err = a.reviewService.WithPrefix(accessList).ListResources(ctx, pageSize, pageToken)
+	reviewService, err := a.reviewService.WithScopedResourcePrefix(listName.ToScopesQualifiedName())
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	reviews, nextToken, err = reviewService.ListResources(ctx, int(req.GetPageSize()), req.GetNextToken())
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -1438,7 +1460,8 @@ func (a *AccessListService) ListAccessListReviews(ctx context.Context, accessLis
 
 // ListAllAccessListReviews will list access list reviews for all access lists.
 func (a *AccessListService) ListAllAccessListReviews(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.Review, string, error) {
-	reviews, next, err := a.reviewService.ListResourcesReturnNextResource(ctx, pageSize, pageToken)
+	// TODO(nklaassen): support listing reviews of scoped access lists.
+	reviews, next, err := a.reviewService.UnscopedService.ListResourcesReturnNextResource(ctx, pageSize, pageToken)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -1451,13 +1474,8 @@ func (a *AccessListService) ListAllAccessListReviews(ctx context.Context, pageSi
 
 // CreateAccessListReview will create a new review for an access list.
 func (a *AccessListService) CreateAccessListReview(ctx context.Context, review *accesslist.Review) (*accesslist.Review, time.Time, error) {
-	if review.Scope != "" {
-		// TODO(nklaassen): support scoped access list reviews.
-		return nil, time.Time{}, trace.BadParameter("scoped access list reviews are not yet supported")
-	}
-
 	reviewName := uuid.New().String()
-	createdReview, err := accesslist.NewReview(header.Metadata{
+	createdReview, err := accesslist.NewReviewWithScope(header.Metadata{
 		Name:        reviewName,
 		Labels:      review.GetAllLabels(),
 		Description: review.Metadata.Description,
@@ -1468,21 +1486,44 @@ func (a *AccessListService) CreateAccessListReview(ctx context.Context, review *
 		ReviewDate: review.Spec.ReviewDate,
 		Notes:      review.Spec.Notes,
 		Changes:    review.Spec.Changes,
-	})
+	}, review.Scope)
 	if err != nil {
 		return nil, time.Time{}, trace.Wrap(err)
 	}
 
+	reviewedListName, err := accesslists.ReviewedList(review)
+	if err != nil {
+		return nil, time.Time{}, trace.Wrap(err)
+	}
+	reviewService, err := a.reviewService.WithScopedResourcePrefix(reviewedListName.ToScopesQualifiedName())
+	if err != nil {
+		return nil, time.Time{}, trace.Wrap(err)
+	}
+	allRemovedMembers, err := accesslists.AllRemovedMembers(review)
+	if err != nil {
+		return nil, time.Time{}, trace.Wrap(err)
+	}
+	if review.Scope != "" && !review.Spec.Changes.MembershipRequirementsChanged.IsEmpty() {
+		return nil, time.Time{}, trace.BadParameter("scoped access lists cannot contain membership requirements")
+	}
+	if review.Scope == "" && len(review.Spec.Changes.ScopedRemovedMembers) > 0 {
+		return nil, time.Time{}, trace.BadParameter("unscoped access lists cannot have scoped members")
+	}
+
 	var nextAuditDate time.Time
 
-	err = a.service.RunWhileLocked(ctx, lockName(review.Spec.AccessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		accessList, err := a.GetAccessList(ctx, review.Spec.AccessList)
+	lockName, err := scopeAwareLockName(reviewedListName)
+	if err != nil {
+		return nil, time.Time{}, trace.Wrap(err)
+	}
+	err = a.service.RunWhileLocked(ctx, lockName, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		accessList, err := a.getAccessList(ctx, reviewedListName)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 
 		if !accessList.IsReviewable() {
-			return trace.BadParameter("access_list %q is not reviewable", accessList.GetName())
+			return trace.BadParameter("access_list %q is not reviewable", reviewedListName.String())
 		}
 
 		if createdReview.Spec.Changes.MembershipRequirementsChanged != nil {
@@ -1509,7 +1550,7 @@ func (a *AccessListService) CreateAccessListReview(ctx context.Context, review *
 			}
 		}
 
-		createdReview, err = a.reviewService.WithPrefix(review.Spec.AccessList).CreateResource(ctx, createdReview)
+		createdReview, err = reviewService.CreateResource(ctx, createdReview)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1520,22 +1561,23 @@ func (a *AccessListService) CreateAccessListReview(ctx context.Context, review *
 		}
 		accessList.Spec.Audit.NextAuditDate = nextAuditDate
 
-		// TODO(nklaassen): support scoped access list reviews.
-		reviewedListName := accesslists.NormalizedSQN{Name: review.Spec.AccessList}
-
-		for _, removedMember := range review.Spec.Changes.RemovedMembers {
-			_, err := a.memberService.UnscopedService.WithPrefix(review.Spec.AccessList).GetResource(ctx, removedMember)
+		for _, removedMember := range allRemovedMembers {
+			memberService, err := a.memberServiceForNamedMember(reviewedListName, removedMember)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			_, err = memberService.get(ctx)
 			if err != nil && !trace.IsNotFound(err) {
 				return trace.Wrap(err)
 			}
 			isAccessListMember := err == nil
 
 			if isAccessListMember {
-				if err := a.updateAccessListMemberOf(ctx, reviewedListName, accesslists.NormalizedSQN{Name: removedMember}, false); err != nil {
+				if err := a.updateAccessListMemberOf(ctx, reviewedListName, removedMember, false); err != nil {
 					return trace.Wrap(err)
 				}
 			}
-			if err := a.memberService.UnscopedService.WithPrefix(review.Spec.AccessList).DeleteResource(ctx, removedMember); err != nil {
+			if err := memberService.delete(ctx); err != nil {
 				return trace.Wrap(err)
 			}
 		}
@@ -1593,11 +1635,27 @@ func accessListRequiresEqual(a, b accesslist.Requires) bool {
 
 // DeleteAccessListReview will delete an access list review from the backend.
 func (a *AccessListService) DeleteAccessListReview(ctx context.Context, accessListName, reviewName string) error {
-	_, err := a.GetAccessList(ctx, accessListName)
+	return a.DeleteAccessListReviewV2(ctx, accesslistv1.DeleteAccessListReviewRequest_builder{
+		AccessListName: accessListName,
+		ReviewName:     reviewName,
+	}.Build())
+}
+
+// DeleteAccessListReviewV2 will delete an access list review from the backend.
+func (a *AccessListService) DeleteAccessListReviewV2(ctx context.Context, req *accesslistv1.DeleteAccessListReviewRequest) error {
+	accessListName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessListName(),
+	})
+	_, err := a.getAccessList(ctx, accessListName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return trace.Wrap(a.reviewService.WithPrefix(accessListName).DeleteResource(ctx, reviewName))
+	reviewService, err := a.reviewService.WithScopedResourcePrefix(accessListName.ToScopesQualifiedName())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(reviewService.DeleteResource(ctx, req.GetReviewName()))
 }
 
 // DeleteAllAccessListReviews will delete all access list reviews from all access lists.

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -1775,7 +1775,7 @@ func (a *AccessListService) insertMembersAndUpdateNestedRelationships(ctx contex
 }
 
 func (a *AccessListService) insertMembers(ctx context.Context, acl accesslists.NormalizedSQN, members []*accesslist.AccessListMember) error {
-	items, err := a.membersToBackendItems(acl, members)
+	items, err := stream.Collect(a.membersToBackendItems(acl, members))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1790,24 +1790,30 @@ func (a *AccessListService) insertMembers(ctx context.Context, acl accesslists.N
 	return nil
 }
 
-func (a *AccessListService) membersToBackendItems(acl accesslists.NormalizedSQN, members []*accesslist.AccessListMember) ([]backend.Item, error) {
-	out := make([]backend.Item, 0, len(members))
-	for _, member := range members {
-		memberName, err := accesslists.MemberScopeQualifiedName(member)
-		if err != nil {
-			return nil, trace.Wrap(err)
+func (a *AccessListService) membersToBackendItems(acl accesslists.NormalizedSQN, members []*accesslist.AccessListMember) iter.Seq2[backend.Item, error] {
+	return func(yield func(backend.Item, error) bool) {
+		for _, member := range members {
+			memberName, err := accesslists.MemberScopeQualifiedName(member)
+			if err != nil {
+				yield(backend.Item{}, trace.Wrap(err))
+				return
+			}
+			memberService, err := a.memberServiceForNamedMember(acl, memberName)
+			if err != nil {
+				yield(backend.Item{}, trace.Wrap(err))
+				return
+			}
+			item, err := memberService.makeBackendItem(member)
+			if err != nil {
+				yield(backend.Item{}, trace.Wrap(err))
+				return
+			}
+			if !yield(item, nil) {
+				return
+			}
 		}
-		memberService, err := a.memberServiceForNamedMember(acl, memberName)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		item, err := memberService.makeBackendItem(member)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		out = append(out, item)
+
 	}
-	return out, nil
 }
 
 func (a *AccessListService) updatedMembersNestedRelationships(ctx context.Context, acl accesslists.NormalizedSQN, members []*accesslist.AccessListMember) error {
@@ -2044,7 +2050,6 @@ func (a *AccessListService) collectionToBackendItemsIter(collection *accesslists
 				yield(backend.Item{}, trace.NotFound("access list %q not found", aclName))
 				return
 			}
-			// TODO(nklaassen): support collections of scoped access lists.
 			for _, member := range members {
 				item, err := a.memberService.UnscopedService.WithPrefix(member.Spec.AccessList).MakeBackendItem(member)
 				if err != nil {
@@ -2055,7 +2060,6 @@ func (a *AccessListService) collectionToBackendItemsIter(collection *accesslists
 					return
 				}
 			}
-			// TODO(nklaassen): support collections of scoped access lists.
 			item, err := a.service.UnscopedService.MakeBackendItem(acl)
 			if err != nil {
 				yield(backend.Item{}, trace.Wrap(err))
@@ -2071,6 +2075,93 @@ func (a *AccessListService) collectionToBackendItemsIter(collection *accesslists
 // ListUserAccessLists is not implemented in the local service.
 func (a *AccessListService) ListUserAccessLists(ctx context.Context, req *accesslistv1.ListUserAccessListsRequest) ([]*accesslist.AccessList, string, error) {
 	return nil, "", trace.NotImplemented("ListUserAccessLists should not be called on local service")
+}
+
+// InsertScopedAccessListCollection inserts a complete collection of access lists and their members from a single
+// upstream source (e.g. EntraID) using a batch operation for improved performance.
+//
+// This method is designed for bulk import scenarios where an entire access list collection needs to be
+// synchronized from an external source. All access lists and members in the collection are
+// inserted using chunked batch operations, minimizing memory allocation while still reducing
+// the number of write operations. Due to the batch nature of this operation (access list hierarchy
+// is known upfront), we can avoid per-access-list locking and global locks to improve performance.
+//
+// Important: This method assumes the collection is self-contained. Access lists in the collection
+// cannot reference access lists outside the collection as members or owners. This is intentional for
+// collections representing a complete snapshot from a single upstream source.
+// The function should be used only once during initial import where
+// we are sure that Teleport doesn't have any pre-existing access lists from the upstream and the
+// internal relation between upstream access lists and internal access lists doesn't exist yet.
+//
+// Operation can fail due to backend shutdown. In that case, if partial state was created,
+// use UpsertAccessListWithMembers/DeleteAccessListMember to reconcile to the desired state.
+func (a *AccessListService) InsertScopedAccessListCollection(ctx context.Context, collection *accesslists.ScopedCollection) error {
+	if err := a.scopesFeatures.AssertEnabled(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := collection.Validate(ctx); err != nil {
+		return trace.Wrap(err)
+	}
+	// Collect backend items in chunks of 800 items each to avoid high memory consumption
+	// from constructing a large slice of all backend items at once. PutBatch will then
+	// leverage its own internal chunking to write items to the backend in smaller batches.
+	// TODO(smallinsky) align the chunk size with the one used in backend.PutBatch
+	for chunk, err := range stream.Chunks(a.scopedCollectionToBackendItemsIter(collection), 800) {
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if _, err := backend.PutBatch(ctx, a.backend, chunk); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}
+
+// scopedCollectionToBackendItemsIter converts access list collection to an iterator of backend items.
+// The iterator yields access list members first, followed by their parent access list.
+func (a *AccessListService) scopedCollectionToBackendItemsIter(collection *accesslists.ScopedCollection) iter.Seq2[backend.Item, error] {
+	return func(yield func(backend.Item, error) bool) {
+		seenLists := make(map[accesslists.NormalizedSQN]struct{}, len(collection.MembersByAccessList))
+		for aclName, members := range collection.MembersByAccessList {
+			acl, ok := collection.AccessListsByName[aclName]
+			if !ok {
+				yield(backend.Item{}, trace.NotFound("access list %q not found", aclName))
+				return
+			}
+			for item, err := range a.membersToBackendItems(aclName, members) {
+				if err != nil {
+					yield(backend.Item{}, err)
+					return
+				}
+				if !yield(item, nil) {
+					return
+				}
+			}
+			item, err := a.service.MakeBackendItem(acl)
+			if err != nil {
+				yield(backend.Item{}, trace.Wrap(err))
+				return
+			}
+			if !yield(item, nil) {
+				return
+			}
+			seenLists[aclName] = struct{}{}
+		}
+		for aclName, acl := range collection.AccessListsByName {
+			if _, ok := seenLists[aclName]; ok {
+				continue
+			}
+			item, err := a.service.MakeBackendItem(acl)
+			if err != nil {
+				yield(backend.Item{}, trace.Wrap(err))
+				return
+			}
+			if !yield(item, nil) {
+				return
+			}
+		}
+	}
 }
 
 func (a *AccessListService) runWithGlobalLock(ctx context.Context, accessListName accesslists.NormalizedSQN, fn func() error) error {

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -168,7 +168,12 @@ func TestAccessListCRUDScoped(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, modulestest.EnterpriseModules())
+	service, err := NewAccessListServiceV2(AccessListServiceConfig{
+		Backend:        backend.NewSanitizer(mem),
+		Modules:        modulestest.EnterpriseModules(),
+		ScopesFeatures: scopes.Features{Enabled: true},
+	})
+	require.NoError(t, err)
 
 	newScopedAccessList := func(name, scope string) *accesslist.AccessList {
 		acl := newAccessList(t, name, clock,

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -155,6 +156,104 @@ func TestAccessListCRUD(t *testing.T) {
 	created, err := service.UpsertAccessList(ctx, accessListDuplicateOwners)
 	require.NoError(t, err)
 	require.ElementsMatch(t, expectedAccessList, created.Spec.Owners)
+}
+
+func TestAccessListCRUDScoped(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service := newAccessListService(t, mem, modulestest.EnterpriseModules())
+
+	newScopedAccessList := func(name, scope string) *accesslist.AccessList {
+		acl := newAccessList(t, name, clock,
+			withMemberRequires(accesslist.Requires{}),
+			withOwnerRequires(accesslist.Requires{}),
+		)
+		acl.Scope = scope
+		acl.Spec.Grants.Roles = nil
+		acl.Spec.Grants.Traits = nil
+		acl.Spec.OwnerGrants.Roles = nil
+		acl.Spec.OwnerGrants.Traits = nil
+		return acl
+	}
+
+	cmpOpts := []cmp.Option{
+		cmpopts.IgnoreFields(header.Metadata{}, "Revision"),
+	}
+
+	const listName = "accessList"
+	scopedName := scopes.QualifiedName{Scope: "/eng", Name: listName}
+	scopedAccessList := newScopedAccessList(listName, scopedName.Scope)
+	unscopedAccessList := newAccessList(t, listName, clock)
+
+	created, err := service.UpsertAccessList(ctx, scopedAccessList)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(scopedAccessList, created, cmpOpts...))
+
+	fetched, err := service.GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Scope: scopedName.Scope,
+		Name:  scopedName.Name,
+	}.Build())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(scopedAccessList, fetched, cmpOpts...))
+
+	_, err = service.GetAccessList(ctx, listName)
+	require.True(t, trace.IsNotFound(err), "expected not found error, got %v", err)
+
+	lists, err := service.GetAccessLists(ctx)
+	require.NoError(t, err)
+	require.Empty(t, lists)
+
+	listed, nextToken, err := service.ListAccessLists(ctx, 100, "")
+	require.NoError(t, err)
+	require.Empty(t, nextToken)
+	require.Empty(t, listed)
+
+	unscopedCreated, err := service.UpsertAccessList(ctx, unscopedAccessList)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(unscopedAccessList, unscopedCreated, cmpOpts...))
+
+	unscopedFetched, err := service.GetAccessList(ctx, listName)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(unscopedAccessList, unscopedFetched, cmpOpts...))
+
+	fetched.Spec.Description = "updated scoped access list"
+	updated, err := service.UpdateAccessList(ctx, fetched)
+	require.NoError(t, err)
+	require.Equal(t, "updated scoped access list", updated.Spec.Description)
+
+	fetched, err = service.GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Scope: scopedName.Scope,
+		Name:  scopedName.Name,
+	}.Build())
+	require.NoError(t, err)
+	require.Equal(t, "updated scoped access list", fetched.Spec.Description)
+
+	unscopedFetched, err = service.GetAccessList(ctx, listName)
+	require.NoError(t, err)
+	require.Equal(t, unscopedAccessList.Spec.Description, unscopedFetched.Spec.Description)
+
+	err = service.DeleteAccessListV2(ctx, accesslistv1.DeleteAccessListRequest_builder{
+		Scope: scopedName.Scope,
+		Name:  scopedName.Name,
+	}.Build())
+	require.NoError(t, err)
+
+	_, err = service.GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Scope: scopedName.Scope,
+		Name:  scopedName.Name,
+	}.Build())
+	require.True(t, trace.IsNotFound(err), "expected not found error, got %v", err)
+
+	unscopedFetched, err = service.GetAccessList(ctx, listName)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(unscopedAccessList, unscopedFetched, cmpOpts...))
 }
 
 func TestAccessListCRUDScopedRoleGrants(t *testing.T) {
@@ -323,7 +422,7 @@ func Test_AccessList_validation_DeprecatedDynamic_special_case(t *testing.T) {
 	accessList := newAccessList(t, "test-scim-access-list-1", clock)
 
 	t.Run("dynamic is stored as default", func(t *testing.T) {
-		_, err := backend.NewSanitizer(mem).Get(ctx, service.service.MakeKey(backend.NewKey(accessList.GetName())))
+		_, err := backend.NewSanitizer(mem).Get(ctx, service.service.UnscopedService.MakeKey(backend.NewKey(accessList.GetName())))
 		require.Error(t, err)
 		require.True(t, trace.IsNotFound(err))
 
@@ -331,7 +430,7 @@ func Test_AccessList_validation_DeprecatedDynamic_special_case(t *testing.T) {
 		_, err = service.UpsertAccessList(ctx, accessList)
 		require.NoError(t, err)
 
-		accessList = getAccessListDirectlyFromBackend(t, mem, service.service.MakeKey(backend.NewKey(accessList.GetName())))
+		accessList = getAccessListDirectlyFromBackend(t, mem, service.service.UnscopedService.MakeKey(backend.NewKey(accessList.GetName())))
 		require.NoError(t, err)
 		require.Equal(t, accesslist.Default, accessList.Spec.Type)
 	})
@@ -344,7 +443,7 @@ func Test_AccessList_validation_DeprecatedDynamic_special_case(t *testing.T) {
 			require.NoError(t, err)
 			require.NotEqual(t, verificationDescValue, accessList.Spec.Description)
 
-			modifyAccessListDirectlyInBackend(t, mem, accessList, service.service.MakeBackendItem, func(al *accesslist.AccessList) {
+			modifyAccessListDirectlyInBackend(t, mem, accessList, service.service.UnscopedService.MakeBackendItem, func(al *accesslist.AccessList) {
 				al.Spec.Type = accesslist.DeprecatedDynamic
 				al.Spec.Description = verificationDescValue
 			})
@@ -356,13 +455,13 @@ func Test_AccessList_validation_DeprecatedDynamic_special_case(t *testing.T) {
 			require.Equal(t, verificationDescValue, accessList.Spec.Description)
 			require.Equal(t, accesslist.Default, accessList.Spec.Type)
 
-			accessList = getAccessListDirectlyFromBackend(t, mem, service.service.MakeKey(backend.NewKey(accessList.GetName())))
+			accessList = getAccessListDirectlyFromBackend(t, mem, service.service.UnscopedService.MakeKey(backend.NewKey(accessList.GetName())))
 			require.Equal(t, verificationDescValue, accessList.Spec.Description)
 			require.Equal(t, accesslist.DeprecatedDynamic, accessList.Spec.Type)
 		})
 
 		t.Run("modifying access list type stored as deprecated dynamic is still not allowed", func(t *testing.T) {
-			accessList = getAccessListDirectlyFromBackend(t, mem, service.service.MakeKey(backend.NewKey(accessList.GetName())))
+			accessList = getAccessListDirectlyFromBackend(t, mem, service.service.UnscopedService.MakeKey(backend.NewKey(accessList.GetName())))
 			require.Equal(t, verificationDescValue, accessList.Spec.Description)
 			require.Equal(t, accesslist.DeprecatedDynamic, accessList.Spec.Type)
 
@@ -387,7 +486,7 @@ func Test_AccessList_validation_DeprecatedDynamic_special_case(t *testing.T) {
 		})
 
 		t.Run("modifying through service changes stored as deprecated dynamic type to default", func(t *testing.T) {
-			accessList = getAccessListDirectlyFromBackend(t, mem, service.service.MakeKey(backend.NewKey(accessList.GetName())))
+			accessList = getAccessListDirectlyFromBackend(t, mem, service.service.UnscopedService.MakeKey(backend.NewKey(accessList.GetName())))
 			require.Equal(t, verificationDescValue, accessList.Spec.Description)
 			require.Equal(t, accesslist.DeprecatedDynamic, accessList.Spec.Type)
 
@@ -404,7 +503,7 @@ func Test_AccessList_validation_DeprecatedDynamic_special_case(t *testing.T) {
 			require.Equal(t, verificationDescValue, accessList.Spec.Description)
 			require.Equal(t, accesslist.Default, accessList.Spec.Type)
 
-			accessList = getAccessListDirectlyFromBackend(t, mem, service.service.MakeKey(backend.NewKey(accessList.GetName())))
+			accessList = getAccessListDirectlyFromBackend(t, mem, service.service.UnscopedService.MakeKey(backend.NewKey(accessList.GetName())))
 			require.Equal(t, verificationDescValue, accessList.Spec.Description)
 			require.Equal(t, accesslist.Default, accessList.Spec.Type)
 		})
@@ -705,7 +804,7 @@ func TestAccessListDedupeOwnersBackwardsCompat(t *testing.T) {
 	accessListDuplicateOwners.Spec.Owners = append(accessListDuplicateOwners.Spec.Owners, accessListDuplicateOwners.Spec.Owners[0])
 	require.Len(t, accessListDuplicateOwners.Spec.Owners, 3)
 
-	item, err := service.service.MakeBackendItem(accessListDuplicateOwners)
+	item, err := service.service.UnscopedService.MakeBackendItem(accessListDuplicateOwners)
 	require.NoError(t, err)
 	_, err = mem.Put(ctx, item)
 	require.NoError(t, err)
@@ -2456,9 +2555,9 @@ func TestAccessListService_CleanupAccessListStatus(t *testing.T) {
 
 	// Let's now break the a1 status, we need to use generic service directly to bypass status
 	// updates
-	service.service.DeleteResource(ctx, a3)
+	service.service.UnscopedService.DeleteResource(ctx, a3)
 	a4List.Spec.Owners = []accesslist.Owner{userOwner} // remove a1Owner
-	service.service.UpdateResource(ctx, a4List)
+	service.service.UnscopedService.UpdateResource(ctx, a4List)
 	service.memberService.WithPrefix(a6).DeleteResource(ctx, a1)
 
 	// Let's check the status remain untouched:
@@ -2486,7 +2585,7 @@ func TestAccessListService_CleanupAccessListStatus(t *testing.T) {
 	// therefore bypassing status update
 	a2List := getAccessList(t, service, a2)
 	a2List.Spec.Owners = []accesslist.Owner{userOwner} // remove a1Owner
-	service.service.UpdateResource(ctx, a2List)
+	service.service.UnscopedService.UpdateResource(ctx, a2List)
 	service.memberService.WithPrefix(a5).DeleteResource(ctx, a1)
 
 	// Verify the status is broken now as it should be empty
@@ -2597,7 +2696,7 @@ func TestAccessListService_EnsureNestedAccessListStatuses(t *testing.T) {
 	a4List.Status.MemberOf = nil
 	a5List.Status.MemberOf = []string{ghost}
 	for _, al := range []*accesslist.AccessList{a2List, a3List, a4List, a5List} {
-		_, err := service.service.UpdateResource(ctx, al)
+		_, err := service.service.UnscopedService.UpdateResource(ctx, al)
 		require.NoError(t, err, "access_list = %q", al.GetName())
 	}
 
@@ -2802,7 +2901,7 @@ func TestInsertAccessListCollection(t *testing.T) {
 		err = service.InsertAccessListCollection(ctx, collection)
 		require.NoError(t, err)
 
-		acls, err := service.service.GetResources(ctx)
+		acls, err := service.service.UnscopedService.GetResources(ctx)
 		require.NoError(t, err)
 		require.Len(t, acls, 3)
 
@@ -2986,7 +3085,7 @@ func TestAccessListDeletePrevention_MissingReferences(t *testing.T) {
 		func(t *testing.T, ctx context.Context, service *AccessListService, target *accesslist.AccessList, related []*accesslist.AccessList) {
 			// Simulate stale references: hard-delete related lists and their members.
 			for _, parent := range related {
-				err := service.service.DeleteResource(ctx, parent.GetName())
+				err := service.service.UnscopedService.DeleteResource(ctx, parent.GetName())
 				require.NoError(t, err)
 				err = service.memberService.WithPrefix(parent.GetName()).DeleteAllResources(ctx)
 				require.NoError(t, err)
@@ -3018,7 +3117,7 @@ func TestAccessListDeletePrevention_MissingReferences(t *testing.T) {
 		func(t *testing.T, ctx context.Context, service *AccessListService, target *accesslist.AccessList, related []*accesslist.AccessList) {
 			// Simulate stale references: hard-delete related lists and their members.
 			for _, owned := range related {
-				err := service.service.DeleteResource(ctx, owned.GetName())
+				err := service.service.UnscopedService.DeleteResource(ctx, owned.GetName())
 				require.NoError(t, err)
 				err = service.memberService.WithPrefix(owned.GetName()).DeleteAllResources(ctx)
 				require.NoError(t, err)

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -2724,6 +2724,179 @@ func TestAccessListService_Status_MemberOf(t *testing.T) {
 		requireStatusMemberOf(t, service, nestedAccessList.GetName(), []string{accessList.GetName()})
 	})
 
+	// Assert that when a member's kind changes from a list to a user, stale
+	// member_of refs on the previous member list are removed.
+	t.Run("status member_of and scoped_member_of fixed on kind change", func(t *testing.T) {
+		// Set up a child list with a scoped and unscoped parent list.
+		suffix := uuid.NewString()[:8]
+		scopedParentListName := scopes.QualifiedName{Scope: "/eng/platform", Name: "acl-" + suffix}
+		unscopedParentListName := scopes.QualifiedName{Name: "acl-" + suffix}
+		scopedChildName := scopes.QualifiedName{Scope: "/eng/platform", Name: "child-" + suffix}
+		unscopedChildName := scopes.QualifiedName{Name: "child-" + suffix}
+
+		for _, tc := range []struct {
+			desc                   string
+			parentListName         scopes.QualifiedName
+			childListName          scopes.QualifiedName
+			initialMembershipKind  string
+			targetMembershipKind   string
+			requireKindChangeError require.ErrorAssertionFunc
+			requireMemberOf        func(t *testing.T)
+			requireNotMemberOf     func(t *testing.T)
+		}{
+			{
+				desc:                  "scoped parent, unscoped child",
+				parentListName:        scopedParentListName,
+				childListName:         unscopedChildName,
+				initialMembershipKind: accesslist.MembershipKindList,
+				targetMembershipKind:  accesslist.MembershipKindUser,
+				requireMemberOf: func(t *testing.T) {
+					requireStatusScopedMemberOf(t, service, unscopedChildName, []string{scopedParentListName.String()})
+				},
+				requireNotMemberOf: func(t *testing.T) {
+					requireStatusScopedMemberOf(t, service, unscopedChildName, []string{})
+				},
+			},
+			{
+				desc:                  "unscoped parent, unscoped child",
+				parentListName:        unscopedParentListName,
+				childListName:         unscopedChildName,
+				initialMembershipKind: accesslist.MembershipKindList,
+				targetMembershipKind:  accesslist.MembershipKindUser,
+				requireMemberOf: func(t *testing.T) {
+					requireStatusMemberOfV2(t, service, unscopedChildName, []string{unscopedParentListName.Name})
+				},
+				requireNotMemberOf: func(t *testing.T) {
+					requireStatusMemberOfV2(t, service, unscopedChildName, []string{})
+				},
+			},
+			{
+				desc:                  "scoped parent, scoped child",
+				parentListName:        scopedParentListName,
+				childListName:         scopedChildName,
+				initialMembershipKind: accesslist.MembershipKindScopedList,
+				targetMembershipKind:  accesslist.MembershipKindUser,
+				requireKindChangeError: func(t require.TestingT, err error, msg ...any) {
+					// The user name will be invalid if trying to change a scoped list member to a user.
+					require.ErrorAs(t, err, new(*trace.BadParameterError), msg...)
+				},
+				requireMemberOf: func(t *testing.T) {
+					requireStatusScopedMemberOf(t, service, scopedChildName, []string{scopedParentListName.String()})
+				},
+			},
+			{
+				desc:                  "scoped parent, scoped child, changed to unscoped child",
+				parentListName:        scopedParentListName,
+				childListName:         scopedChildName,
+				initialMembershipKind: accesslist.MembershipKindScopedList,
+				targetMembershipKind:  accesslist.MembershipKindList,
+				requireKindChangeError: func(t require.TestingT, err error, msg ...any) {
+					// The member key will change if trying to change a scoped
+					// list member to an unscoped list member, and the member
+					// will not be found.
+					require.ErrorAs(t, err, new(*trace.NotFoundError), msg...)
+				},
+				requireMemberOf: func(t *testing.T) {
+					requireStatusScopedMemberOf(t, service, scopedChildName, []string{scopedParentListName.String()})
+				},
+			},
+			{
+				desc:                  "scoped parent, unscoped child, changed to scoped child",
+				parentListName:        scopedParentListName,
+				childListName:         unscopedChildName,
+				initialMembershipKind: accesslist.MembershipKindList,
+				targetMembershipKind:  accesslist.MembershipKindScopedList,
+				requireKindChangeError: func(t require.TestingT, err error, msg ...any) {
+					// The member name will be invalid if trying to change an
+					// unscoped list member to a scoped list member.
+					require.ErrorAs(t, err, new(*trace.BadParameterError), msg...)
+				},
+				requireMemberOf: func(t *testing.T) {
+					requireStatusScopedMemberOf(t, service, unscopedChildName, []string{scopedParentListName.String()})
+				},
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				parentList, err := service.UpsertAccessList(ctx, newScopedAccessList(t, tc.parentListName, clock))
+				require.NoError(t, err)
+				_, err = service.UpsertAccessList(ctx, newScopedAccessList(t, tc.childListName, clock))
+				require.NoError(t, err)
+
+				for _, ttc := range []struct {
+					desc                 string
+					changeMembershipKind func(member *accesslist.AccessListMember, kind string) (*accesslist.AccessListMember, error)
+				}{
+					{
+						desc: "UpdateAccessListMember",
+						changeMembershipKind: func(member *accesslist.AccessListMember, kind string) (*accesslist.AccessListMember, error) {
+							member.Spec.MembershipKind = kind
+							return service.UpdateAccessListMember(ctx, member)
+						},
+					},
+					{
+						desc: "UpsertAccessListMember",
+						changeMembershipKind: func(member *accesslist.AccessListMember, kind string) (*accesslist.AccessListMember, error) {
+							member.Spec.MembershipKind = kind
+							return service.UpsertAccessListMember(ctx, member)
+						},
+					},
+					{
+						desc: "UpsertAccessListWithMembers",
+						changeMembershipKind: func(member *accesslist.AccessListMember, kind string) (*accesslist.AccessListMember, error) {
+							member.Spec.MembershipKind = kind
+							_, newMembers, err := service.UpsertAccessListWithMembers(ctx, parentList, []*accesslist.AccessListMember{member})
+							if err != nil {
+								return nil, err
+							}
+							return newMembers[0], nil
+						},
+					},
+					{
+						desc: "UpdateAccessListAndOverwriteMembers",
+						changeMembershipKind: func(member *accesslist.AccessListMember, kind string) (*accesslist.AccessListMember, error) {
+							member.Spec.MembershipKind = kind
+							_, newMembers, err := service.UpdateAccessListAndOverwriteMembers(ctx, parentList, []*accesslist.AccessListMember{member})
+							if err != nil {
+								return nil, err
+							}
+							return newMembers[0], nil
+						},
+					},
+				} {
+					t.Run(ttc.desc, func(t *testing.T) {
+						member, err := service.UpsertAccessListMember(ctx, newScopedAccessListMember(t,
+							tc.parentListName,
+							tc.childListName,
+							withMembershipKind(tc.initialMembershipKind),
+						))
+						require.NoError(t, err)
+
+						// Initially the child list status should reference the parent list.
+						tc.requireMemberOf(t)
+
+						// Change the membership kind to invalidate the initial membership.
+						member, err = ttc.changeMembershipKind(member, tc.targetMembershipKind)
+						if tc.requireKindChangeError != nil {
+							tc.requireKindChangeError(t, err)
+							return
+						}
+						require.NoError(t, err)
+
+						// The child list status should no longer reference the parent list.
+						tc.requireNotMemberOf(t)
+
+						// Make the child list a member again.
+						_, err = ttc.changeMembershipKind(member, tc.initialMembershipKind)
+						require.NoError(t, err)
+
+						// The child list status should reference the parent list again.
+						tc.requireMemberOf(t)
+					})
+				}
+			})
+		}
+	})
+
 	t.Run("scoped parent updates scoped_member_of for scoped and unscoped child lists", func(t *testing.T) {
 		suffix := uuid.NewString()[:8]
 		parentName := scopes.QualifiedName{Scope: "/eng/platform", Name: "acl-" + suffix}

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -837,109 +837,134 @@ func getAccessListMembers(t *testing.T, service *AccessListService, listName str
 	return members
 }
 
+// getScopedAccessListMembers fetches the current list of members for the given access
+// list, sorted by name
+func getScopedAccessListMembers(t *testing.T, service *AccessListService, listName scopes.QualifiedName) []*accesslist.AccessListMember {
+	getPage := func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+		return service.ListAccessListMembersV2(ctx, accesslistv1.ListAccessListMembersRequest_builder{
+			AccessListScope: listName.Scope,
+			AccessList:      listName.Name,
+			PageSize:        int32(pageSize),
+			PageToken:       pageToken,
+		}.Build())
+	}
+	members, err := stream.Collect(clientutils.Resources(t.Context(), getPage))
+	require.NoError(t, err)
+	return members
+}
+
 type writeAccessListWithMembersFn func(context.Context, *accesslist.AccessList, []*accesslist.AccessListMember) (*accesslist.AccessList, []*accesslist.AccessListMember, error)
 
 func testAddAndRemoveAccessListMembers(t *testing.T, service *AccessListService, clock clockwork.Clock, fnUnderTest writeAccessListWithMembersFn) {
-	t.Run("add and remove members", func(t *testing.T) {
-		const listName = "test-add-members-list"
-		t.Cleanup(deleteAllAccessLists(t, service))
-		ctx := t.Context()
+	for _, listName := range []scopes.QualifiedName{
+		{Name: "test-add-member-list"},
+		{Scope: "/test", Name: "test-scoped-add-member-list"},
+	} {
+		t.Run("add and remove members "+listName.String(), func(t *testing.T) {
+			t.Cleanup(deleteAllAccessLists(t, service))
+			ctx := t.Context()
 
-		toAccessListMember := func(name string) *accesslist.AccessListMember {
-			return newAccessListMember(t, listName, name)
-		}
+			toAccessListMember := func(name string) *accesslist.AccessListMember {
+				return newScopedAccessListMember(t, listName, scopes.QualifiedName{Name: name})
+			}
 
-		cmpOpts := []cmp.Option{
-			cmpopts.IgnoreFields(header.Metadata{}, "Revision"),
-			cmpopts.EquateEmpty(),
-		}
+			cmpOpts := []cmp.Option{
+				cmpopts.IgnoreFields(header.Metadata{}, "Revision"),
+				cmpopts.EquateEmpty(),
+			}
 
-		// GIVEN an existing Access List
-		acl, err := service.UpsertAccessList(ctx, newAccessList(t, listName, clock))
-		require.NoError(t, err)
-
-		var expectedMemberNames []string
-		for _, memberName := range []string{"alice", "bob", "carol", "dave"} {
-			expectedMemberNames = append(expectedMemberNames, memberName)
-			members := sliceutils.Map(expectedMemberNames, toAccessListMember)
-
-			// WHEN I update the Access List to have one or more users,
-			// EXPECT that the operation succeeds and all member are present
-			// in both the returned member list and in the backend service
-			updatedACL, updatedMembers, err := fnUnderTest(ctx, acl, members)
+			// GIVEN an existing Access List
+			acl, err := service.UpsertAccessList(ctx, newScopedAccessList(t, listName, clock))
 			require.NoError(t, err)
-			require.Empty(t, cmp.Diff(acl, updatedACL, cmpOpts...))
-			require.Empty(t, cmp.Diff(members, updatedMembers, cmpOpts...))
 
-			backendMembers := getAccessListMembers(t, service, listName)
-			require.Empty(t, cmp.Diff(members, backendMembers, cmpOpts...))
-		}
+			var expectedMemberNames []string
+			for _, memberName := range []string{"alice", "bob", "carol", "dave"} {
+				expectedMemberNames = append(expectedMemberNames, memberName)
+				members := sliceutils.Map(expectedMemberNames, toAccessListMember)
 
-		for len(expectedMemberNames) > 0 {
-			expectedMemberNames = expectedMemberNames[1:]
-			members := sliceutils.Map(expectedMemberNames, toAccessListMember)
+				// WHEN I update the Access List to have one or more users,
+				// EXPECT that the operation succeeds and all member are present
+				// in both the returned member list and in the backend service
+				updatedACL, updatedMembers, err := fnUnderTest(ctx, acl, members)
+				require.NoError(t, err)
+				require.Empty(t, cmp.Diff(acl, updatedACL, cmpOpts...))
+				require.Empty(t, cmp.Diff(members, updatedMembers, cmpOpts...))
 
-			// WHEN I update the Access List to remove a user, EXPECT that
-			// the operation succeeds and that only the expected members
-			// are present in the returned member list and in the backend
-			// service
-			updatedACL, updatedMembers, err := fnUnderTest(ctx, acl, members)
-			require.NoError(t, err)
-			require.Empty(t, cmp.Diff(acl, updatedACL, cmpOpts...))
-			require.Empty(t, cmp.Diff(members, updatedMembers, cmpOpts...))
+				backendMembers := getScopedAccessListMembers(t, service, listName)
+				require.Empty(t, cmp.Diff(members, backendMembers, cmpOpts...))
+			}
 
-			backendMembers := getAccessListMembers(t, service, listName)
-			require.Empty(t, cmp.Diff(members, backendMembers, cmpOpts...))
-		}
-	})
+			for len(expectedMemberNames) > 0 {
+				expectedMemberNames = expectedMemberNames[1:]
+				members := sliceutils.Map(expectedMemberNames, toAccessListMember)
+
+				// WHEN I update the Access List to remove a user, EXPECT that
+				// the operation succeeds and that only the expected members
+				// are present in the returned member list and in the backend
+				// service
+				updatedACL, updatedMembers, err := fnUnderTest(ctx, acl, members)
+				require.NoError(t, err)
+				require.Empty(t, cmp.Diff(acl, updatedACL, cmpOpts...))
+				require.Empty(t, cmp.Diff(members, updatedMembers, cmpOpts...))
+
+				backendMembers := getScopedAccessListMembers(t, service, listName)
+				require.Empty(t, cmp.Diff(members, backendMembers, cmpOpts...))
+			}
+
+		})
+	}
 }
 
 func testSetEmptyAccessListMembers(t *testing.T, service *AccessListService, clock clockwork.Clock, fnUnderTest writeAccessListWithMembersFn) {
-	t.Run("setting empty member list deletes members", func(t *testing.T) {
-		ctx := t.Context()
+	for _, listName := range []scopes.QualifiedName{
+		{Name: "test-add-member-list"},
+		{Scope: "/test", Name: "test-scoped-add-member-list"},
+	} {
+		t.Run("setting empty member list deletes members "+listName.String(), func(t *testing.T) {
+			ctx := t.Context()
 
-		emptyLists := []struct {
-			name  string
-			value []*accesslist.AccessListMember
-		}{
-			{
-				name:  "nil",
-				value: nil,
-			},
-			{
-				name:  "zero-length",
-				value: []*accesslist.AccessListMember{},
-			},
-		}
+			emptyLists := []struct {
+				name  string
+				value []*accesslist.AccessListMember
+			}{
+				{
+					name:  "nil",
+					value: nil,
+				},
+				{
+					name:  "zero-length",
+					value: []*accesslist.AccessListMember{},
+				},
+			}
 
-		for _, emptyList := range emptyLists {
-			t.Run(emptyList.name, func(t *testing.T) {
-				t.Cleanup(deleteAllAccessLists(t, service))
-				listName := "test-set-empty-members-list" + emptyList.name
+			for _, emptyList := range emptyLists {
+				t.Run(emptyList.name, func(t *testing.T) {
+					t.Cleanup(deleteAllAccessLists(t, service))
 
-				// GIVEN an access list with several members...
-				acl, _, err := service.UpsertAccessListWithMembers(ctx,
-					newAccessList(t, listName, clock),
-					[]*accesslist.AccessListMember{
-						newAccessListMember(t, listName, "alice"),
-						newAccessListMember(t, listName, "bob"),
-						newAccessListMember(t, listName, "carol"),
-						newAccessListMember(t, listName, "dave"),
-					})
-				require.NoError(t, err)
-				require.Len(t, getAccessListMembers(t, service, listName), 4)
+					// GIVEN an access list with several members...
+					acl, _, err := service.UpsertAccessListWithMembers(ctx,
+						newScopedAccessList(t, listName, clock),
+						[]*accesslist.AccessListMember{
+							newScopedAccessListMember(t, listName, scopes.QualifiedName{Name: "alice"}),
+							newScopedAccessListMember(t, listName, scopes.QualifiedName{Name: "bob"}),
+							newScopedAccessListMember(t, listName, scopes.QualifiedName{Name: "carol"}),
+							newScopedAccessListMember(t, listName, scopes.QualifiedName{Name: "dave"}),
+						})
+					require.NoError(t, err)
+					require.Len(t, getScopedAccessListMembers(t, service, listName), 4)
 
-				// WHEN I update it with an empty member list
-				_, members, err := fnUnderTest(ctx, acl, emptyList.value)
-				require.NoError(t, err)
+					// WHEN I update it with an empty member list
+					_, members, err := fnUnderTest(ctx, acl, emptyList.value)
+					require.NoError(t, err)
 
-				// EXPECT that both the returned member list and the member
-				// collection from the backend are empty
-				require.Empty(t, members)
-				require.Empty(t, getAccessListMembers(t, service, listName))
-			})
-		}
-	})
+					// EXPECT that both the returned member list and the member
+					// collection from the backend are empty
+					require.Empty(t, members)
+					require.Empty(t, getScopedAccessListMembers(t, service, listName))
+				})
+			}
+		})
+	}
 }
 
 func TestUpsertAccessListWithMembers(t *testing.T) {
@@ -1318,6 +1343,145 @@ func TestAccessListMembersCRUD(t *testing.T) {
 	require.ErrorIs(t, err, trace.NotFound("access_list %q doesn't exist", accessList2.GetName()))
 }
 
+func TestAccessListMembersCRUDScoped(t *testing.T) {
+	ctx := t.Context()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service := newAccessListService(t, mem, modulestest.EnterpriseModules())
+
+	cmpOpts := []cmp.Option{
+		cmpopts.IgnoreFields(header.Metadata{}, "Revision"),
+		cmpopts.EquateEmpty(),
+	}
+
+	t.Run("scoped parent separates unscoped and scoped members with the same name", func(t *testing.T) {
+		t.Cleanup(deleteAllAccessLists(t, service))
+
+		getAccessListMemberRequest := func(listName, memberName scopes.QualifiedName) *accesslistv1.GetAccessListMemberRequest {
+			return accesslistv1.GetAccessListMemberRequest_builder{
+				AccessListScope: listName.Scope,
+				AccessList:      listName.Name,
+				MemberScope:     memberName.Scope,
+				MemberName:      memberName.Name,
+			}.Build()
+		}
+
+		parentName := scopes.QualifiedName{Scope: "/eng/platform", Name: "parent"}
+		unscopedChildName := scopes.QualifiedName{Name: "team"}
+		scopedChildName := scopes.QualifiedName{Scope: "/eng", Name: "team"}
+
+		parent, err := service.UpsertAccessList(ctx, newScopedAccessList(t, parentName, clock))
+		require.NoError(t, err)
+		_, err = service.UpsertAccessList(ctx, newScopedAccessList(t, unscopedChildName, clock))
+		require.NoError(t, err)
+		_, err = service.UpsertAccessList(ctx, newScopedAccessList(t, scopedChildName, clock))
+		require.NoError(t, err)
+
+		unscopedChildMember := newScopedAccessListMember(t, parentName, unscopedChildName, withMembershipKind(accesslist.MembershipKindList))
+		scopedChildMember := newScopedAccessListMember(t, parentName, scopedChildName, withMembershipKind(accesslist.MembershipKindScopedList))
+		userMember := newScopedAccessListMember(t, parentName, scopes.QualifiedName{Name: "alice"}, withMembershipKind(accesslist.MembershipKindUser))
+		expectedMembers := []*accesslist.AccessListMember{userMember, unscopedChildMember, scopedChildMember}
+
+		_, returnedMembers, err := service.UpsertAccessListWithMembers(ctx, parent, expectedMembers)
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(expectedMembers, returnedMembers, cmpOpts...))
+
+		gotUnscoped, err := service.GetAccessListMemberV2(ctx, getAccessListMemberRequest(parentName, unscopedChildName))
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(unscopedChildMember, gotUnscoped, cmpOpts...))
+
+		gotScoped, err := service.GetAccessListMemberV2(ctx, getAccessListMemberRequest(parentName, scopedChildName))
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(scopedChildMember, gotScoped, cmpOpts...))
+
+		users, lists, err := service.CountAccessListMembersV2(ctx, accesslistv1.CountAccessListMembersRequest_builder{
+			AccessListScope: parentName.Scope,
+			AccessListName:  parentName.Name,
+		}.Build())
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), users)
+		require.Equal(t, uint32(2), lists)
+
+		var paginatedMembers []*accesslist.AccessListMember
+		req := accesslistv1.ListAccessListMembersRequest_builder{
+			AccessListScope: parentName.Scope,
+			AccessList:      parentName.Name,
+			PageSize:        1,
+		}.Build()
+		for {
+			members, next, err := service.ListAccessListMembersV2(ctx, req)
+			require.NoError(t, err)
+			paginatedMembers = append(paginatedMembers, members...)
+			if next == "" {
+				break
+			}
+			req.SetPageToken(next)
+		}
+		require.Empty(t, cmp.Diff(expectedMembers, paginatedMembers, append(cmpOpts, cmpopts.SortSlices(func(a, b *accesslist.AccessListMember) bool {
+			// Access list member metadata names are scope-qualified for scoped-list members,
+			// so this orders by the same identity used in the backend key
+			return a.GetName() < b.GetName()
+		}))...))
+
+		err = service.DeleteAccessListMemberV2(ctx, accesslistv1.DeleteAccessListMemberRequest_builder{
+			AccessListScope: parentName.Scope,
+			AccessList:      parentName.Name,
+			MemberScope:     unscopedChildName.Scope,
+			MemberName:      unscopedChildName.Name,
+		}.Build())
+		require.NoError(t, err)
+		_, err = service.GetAccessListMemberV2(ctx, getAccessListMemberRequest(parentName, unscopedChildName))
+		require.True(t, trace.IsNotFound(err), "expected not found error, got %v", err)
+		_, err = service.GetAccessListMemberV2(ctx, getAccessListMemberRequest(parentName, scopedChildName))
+		require.NoError(t, err)
+
+		_, returnedMembers, err = service.UpsertAccessListWithMembers(ctx, parent, []*accesslist.AccessListMember{userMember, unscopedChildMember})
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff([]*accesslist.AccessListMember{userMember, unscopedChildMember}, returnedMembers, cmpOpts...))
+		_, err = service.GetAccessListMemberV2(ctx, getAccessListMemberRequest(parentName, scopedChildName))
+		require.True(t, trace.IsNotFound(err), "expected not found error, got %v", err)
+		_, err = service.GetAccessListMemberV2(ctx, getAccessListMemberRequest(parentName, unscopedChildName))
+		require.NoError(t, err)
+	})
+
+	t.Run("old member APIs only see unscoped lists and members", func(t *testing.T) {
+		t.Cleanup(deleteAllAccessLists(t, service))
+
+		unscopedParentName := scopes.QualifiedName{Name: "parent"}
+		scopedParentName := scopes.QualifiedName{Scope: "/eng", Name: "parent"}
+
+		unscopedParent, err := service.UpsertAccessList(ctx, newScopedAccessList(t, unscopedParentName, clock))
+		require.NoError(t, err)
+		scopedParent, err := service.UpsertAccessList(ctx, newScopedAccessList(t, scopedParentName, clock))
+		require.NoError(t, err)
+
+		unscopedMember := newScopedAccessListMember(t, unscopedParentName, scopes.QualifiedName{Name: "alice"}, withMembershipKind(accesslist.MembershipKindUser))
+		scopedMember := newScopedAccessListMember(t, scopedParentName, scopes.QualifiedName{Name: "bob"}, withMembershipKind(accesslist.MembershipKindUser))
+		_, _, err = service.UpsertAccessListWithMembers(ctx, unscopedParent, []*accesslist.AccessListMember{unscopedMember})
+		require.NoError(t, err)
+		_, _, err = service.UpsertAccessListWithMembers(ctx, scopedParent, []*accesslist.AccessListMember{scopedMember})
+		require.NoError(t, err)
+
+		members, _, err := service.ListAccessListMembers(ctx, unscopedParentName.Name, 0, "")
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff([]*accesslist.AccessListMember{unscopedMember}, members, cmpOpts...))
+
+		_, err = service.GetAccessListMember(ctx, unscopedParentName.Name, scopedMember.GetName())
+		require.True(t, trace.IsNotFound(err), "expected not found error, got %v", err)
+
+		users, lists, err := service.CountAccessListMembers(ctx, unscopedParentName.Name)
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), users)
+		require.Equal(t, uint32(0), lists)
+	})
+}
+
 func Test_AccessListMember_Validation(t *testing.T) {
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
@@ -1414,7 +1578,6 @@ func runAccessListMemberValidationSuite(
 	makeBad, makeGood func(*accesslist.AccessListMember),
 	errorCheck func(t *testing.T, err error),
 ) {
-	t.Helper()
 	ctx := context.Background()
 
 	makeBad(member)
@@ -1905,6 +2068,10 @@ func withMemberRequires(requires accesslist.Requires) newAccessListOpt {
 }
 
 func newAccessList(t *testing.T, name string, clock clockwork.Clock, opts ...newAccessListOpt) *accesslist.AccessList {
+	return newScopedAccessList(t, scopes.QualifiedName{Name: name}, clock, opts...)
+}
+
+func newScopedAccessList(t *testing.T, name scopes.QualifiedName, clock clockwork.Clock, opts ...newAccessListOpt) *accesslist.AccessList {
 	t.Helper()
 
 	options := newAccessListOptions{
@@ -1918,20 +2085,22 @@ func newAccessList(t *testing.T, name string, clock clockwork.Clock, opts ...new
 				Description: "test user 2",
 			},
 		},
-		memberRequires: accesslist.Requires{
+	}
+	if name.Scope == "" {
+		options.memberRequires = accesslist.Requires{
 			Roles: []string{"mrole1", "mrole2"},
 			Traits: map[string][]string{
 				"mtrait1": {"mvalue1", "mvalue2"},
 				"mtrait2": {"mvalue3", "mvalue4"},
 			},
-		},
-		ownerRequires: accesslist.Requires{
+		}
+		options.ownerRequires = accesslist.Requires{
 			Roles: []string{"orole1", "orole2"},
 			Traits: map[string][]string{
 				"otrait1": {"ovalue1", "ovalue2"},
 				"otrait2": {"ovalue3", "ovalue4"},
 			},
-		},
+		}
 	}
 	for _, o := range opts {
 		o(&options)
@@ -1942,28 +2111,35 @@ func newAccessList(t *testing.T, name string, clock clockwork.Clock, opts ...new
 		audit.NextAuditDate = clock.Now()
 	}
 
-	accessList, err := accesslist.NewAccessList(
+	accessList, err := accesslist.NewAccessListWithScope(
 		header.Metadata{
-			Name: name,
+			Name: name.Name,
 		},
 		accesslist.Spec{
 			Type:               options.typ,
-			Title:              name + " title",
+			Title:              name.String() + " title",
 			Description:        "test access list",
 			Owners:             options.owners,
 			Audit:              audit,
 			MembershipRequires: options.memberRequires,
 			OwnershipRequires:  options.ownerRequires,
-			Grants: accesslist.Grants{
-				Roles: []string{"grole1", "grole2"},
-				Traits: map[string][]string{
-					"gtrait1": {"gvalue1", "gvalue2"},
-					"gtrait2": {"gvalue3", "gvalue4"},
-				},
-			},
 		},
+		name.Scope,
 	)
 	require.NoError(t, err)
+
+	if name.Scope == "" {
+		accessList.Spec.Grants.Roles = []string{"grole1", "grole2"}
+		accessList.Spec.Grants.Traits = map[string][]string{
+			"gtrait1": {"gvalue1", "gvalue2"},
+			"gtrait2": {"gvalue3", "gvalue4"},
+		}
+	} else {
+		accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{
+			{Role: "gscopedrole1", Scope: name.Scope},
+			{Role: "gscopedrole2", Scope: name.Scope},
+		}
+	}
 
 	return accessList
 }
@@ -2023,6 +2199,36 @@ func newAccessListMember(t *testing.T, accessList, name string, opts ...accessLi
 			AddedBy:        "dummy",
 			MembershipKind: options.membershipKind,
 		},
+	)
+	require.NoError(t, err)
+
+	return member
+}
+
+func newScopedAccessListMember(t *testing.T, accessList, memberName scopes.QualifiedName, opts ...accessListMemberOpt) *accesslist.AccessListMember {
+	t.Helper()
+
+	options := accessListMemberOptions{
+		expires: time.Now().Add(time.Hour * 24),
+	}
+	for _, o := range opts {
+		o(&options)
+	}
+
+	member, err := accesslist.NewAccessListMemberWithScope(
+		header.Metadata{
+			Name: memberName.String(),
+		},
+		accesslist.AccessListMemberSpec{
+			AccessList:     accessList.String(),
+			Name:           memberName.String(),
+			Joined:         time.Now(),
+			Expires:        options.expires,
+			Reason:         "a reason",
+			AddedBy:        "dummy",
+			MembershipKind: options.membershipKind,
+		},
+		accessList.Scope,
 	)
 	require.NoError(t, err)
 
@@ -2501,7 +2707,7 @@ func TestAccessListService_Status_MemberOf(t *testing.T) {
 
 		requireStatusMemberOf(t, service, nestedAccessList.GetName(), []string{accessList.GetName()})
 
-		err = service.updateAccessListMemberOf(ctx, accessList.GetName(), nestedAccessList.GetName(), false /* new - this will delete */)
+		err = service.updateAccessListMemberOf(ctx, accesslists.ScopeQualifiedName(accessList), accesslists.ScopeQualifiedName(nestedAccessList), false /* new - this will delete */)
 		require.NoError(t, err)
 		requireStatusMemberOf(t, service, nestedAccessList.GetName(), []string{})
 
@@ -2509,13 +2715,76 @@ func TestAccessListService_Status_MemberOf(t *testing.T) {
 		require.NoError(t, err)
 		requireStatusMemberOf(t, service, nestedAccessList.GetName(), []string{accessList.GetName()})
 
-		err = service.updateAccessListMemberOf(ctx, accessList.GetName(), nestedAccessList.GetName(), false /* new - this will delete */)
+		err = service.updateAccessListMemberOf(ctx, accesslists.ScopeQualifiedName(accessList), accesslists.ScopeQualifiedName(nestedAccessList), false /* new - this will delete */)
 		require.NoError(t, err)
 		requireStatusMemberOf(t, service, nestedAccessList.GetName(), []string{})
 
 		_, err = service.UpsertAccessListMember(ctx, updatedMember)
 		require.NoError(t, err)
 		requireStatusMemberOf(t, service, nestedAccessList.GetName(), []string{accessList.GetName()})
+	})
+
+	t.Run("scoped parent updates scoped_member_of for scoped and unscoped child lists", func(t *testing.T) {
+		suffix := uuid.NewString()[:8]
+		parentName := scopes.QualifiedName{Scope: "/eng/platform", Name: "acl-" + suffix}
+		unscopedChildName := scopes.QualifiedName{Name: "child-u-" + suffix}
+		scopedChildName := scopes.QualifiedName{Scope: "/eng", Name: "child-s-" + suffix}
+		parentRef := parentName.String()
+
+		_, err = service.UpsertAccessList(ctx, newScopedAccessList(t, parentName, clock))
+		require.NoError(t, err)
+		_, err = service.UpsertAccessList(ctx, newScopedAccessList(t, unscopedChildName, clock))
+		require.NoError(t, err)
+		_, err = service.UpsertAccessList(ctx, newScopedAccessList(t, scopedChildName, clock))
+		require.NoError(t, err)
+
+		unscopedMember, err := service.UpsertAccessListMember(ctx, newScopedAccessListMember(t,
+			parentName,
+			unscopedChildName,
+			withMembershipKind(accesslist.MembershipKindList),
+		))
+		require.NoError(t, err)
+		scopedMember, err := service.UpsertAccessListMember(ctx, newScopedAccessListMember(t,
+			parentName,
+			scopedChildName,
+			withMembershipKind(accesslist.MembershipKindScopedList),
+		))
+		require.NoError(t, err)
+
+		requireStatusMemberOfV2(t, service, unscopedChildName, nil)
+		requireStatusScopedMemberOf(t, service, unscopedChildName, []string{parentRef})
+		requireStatusMemberOfV2(t, service, scopedChildName, nil)
+		requireStatusScopedMemberOf(t, service, scopedChildName, []string{parentRef})
+
+		unscopedMember, err = service.UpdateAccessListMember(ctx, unscopedMember)
+		require.NoError(t, err)
+		scopedMember, err = service.UpdateAccessListMember(ctx, scopedMember)
+		require.NoError(t, err)
+		requireStatusScopedMemberOf(t, service, unscopedChildName, []string{parentRef})
+		requireStatusScopedMemberOf(t, service, scopedChildName, []string{parentRef})
+
+		_, err = service.UpsertAccessListMember(ctx, unscopedMember)
+		require.NoError(t, err)
+		_, err = service.UpsertAccessListMember(ctx, scopedMember)
+		require.NoError(t, err)
+		requireStatusScopedMemberOf(t, service, unscopedChildName, []string{parentRef})
+		requireStatusScopedMemberOf(t, service, scopedChildName, []string{parentRef})
+
+		err = service.DeleteAccessListMemberV2(ctx, accesslistv1.DeleteAccessListMemberRequest_builder{
+			AccessListScope: parentName.Scope,
+			AccessList:      parentName.Name,
+			MemberName:      unscopedChildName.Name,
+		}.Build())
+		require.NoError(t, err)
+		requireStatusScopedMemberOf(t, service, unscopedChildName, nil)
+		requireStatusScopedMemberOf(t, service, scopedChildName, []string{parentRef})
+
+		err = service.DeleteAllAccessListMembersForAccessListV2(ctx, accesslistv1.DeleteAllAccessListMembersForAccessListRequest_builder{
+			AccessListScope: parentName.Scope,
+			AccessList:      parentName.Name,
+		}.Build())
+		require.NoError(t, err)
+		requireStatusScopedMemberOf(t, service, scopedChildName, nil)
 	})
 }
 
@@ -2563,7 +2832,7 @@ func TestAccessListService_CleanupAccessListStatus(t *testing.T) {
 	service.service.UnscopedService.DeleteResource(ctx, a3)
 	a4List.Spec.Owners = []accesslist.Owner{userOwner} // remove a1Owner
 	service.service.UnscopedService.UpdateResource(ctx, a4List)
-	service.memberService.WithPrefix(a6).DeleteResource(ctx, a1)
+	service.memberService.UnscopedService.WithPrefix(a6).DeleteResource(ctx, a1)
 
 	// Let's check the status remain untouched:
 	// - a3 should be removed from owner_of because it doesn't exist anymore
@@ -2591,7 +2860,7 @@ func TestAccessListService_CleanupAccessListStatus(t *testing.T) {
 	a2List := getAccessList(t, service, a2)
 	a2List.Spec.Owners = []accesslist.Owner{userOwner} // remove a1Owner
 	service.service.UnscopedService.UpdateResource(ctx, a2List)
-	service.memberService.WithPrefix(a5).DeleteResource(ctx, a1)
+	service.memberService.UnscopedService.WithPrefix(a5).DeleteResource(ctx, a1)
 
 	// Verify the status is broken now as it should be empty
 	requireStatusOwnerOf(t, service, a1, []string{a2})
@@ -2737,6 +3006,10 @@ type testAccessListGetter interface {
 	GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error)
 }
 
+type testAccessListGetterV2 interface {
+	GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error)
+}
+
 type testAccessListGetterFunc func(ctx context.Context, name string) (*accesslist.AccessList, error)
 
 func (fn testAccessListGetterFunc) GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error) {
@@ -2748,8 +3021,6 @@ func requireStatusOwnerOf(t *testing.T, service testAccessListGetter, accessList
 	ctx := context.Background()
 	accessList, err := service.GetAccessList(ctx, accessListName)
 	require.NoError(t, err)
-	slices.Sort(ownerOf)
-	slices.Sort(accessList.Status.OwnerOf)
 	require.ElementsMatch(t, ownerOf, accessList.Status.OwnerOf)
 }
 
@@ -2758,9 +3029,29 @@ func requireStatusMemberOf(t *testing.T, service testAccessListGetter, accessLis
 	ctx := context.Background()
 	accessList, err := service.GetAccessList(ctx, accessListName)
 	require.NoError(t, err)
-	slices.Sort(memberOf)
-	slices.Sort(accessList.Status.MemberOf)
 	require.ElementsMatch(t, memberOf, accessList.Status.MemberOf)
+}
+
+func requireStatusMemberOfV2(t *testing.T, service testAccessListGetterV2, accessListName scopes.QualifiedName, memberOf []string) {
+	t.Helper()
+	ctx := context.Background()
+	accessList, err := service.GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Scope: accessListName.Scope,
+		Name:  accessListName.Name,
+	}.Build())
+	require.NoError(t, err)
+	require.ElementsMatch(t, memberOf, accessList.Status.MemberOf)
+}
+
+func requireStatusScopedMemberOf(t *testing.T, service testAccessListGetterV2, accessListName scopes.QualifiedName, memberOf []string) {
+	t.Helper()
+	ctx := context.Background()
+	accessList, err := service.GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Scope: accessListName.Scope,
+		Name:  accessListName.Name,
+	}.Build())
+	require.NoError(t, err)
+	require.ElementsMatch(t, memberOf, accessList.Status.ScopedMemberOf)
 }
 
 func newAccessListService(t *testing.T, b backend.Backend, m *modulestest.Modules) *AccessListService {
@@ -2769,6 +3060,9 @@ func newAccessListService(t *testing.T, b backend.Backend, m *modulestest.Module
 	service, err := NewAccessListServiceV2(AccessListServiceConfig{
 		Backend: backend.NewSanitizer(b),
 		Modules: m,
+		ScopesFeatures: scopes.Features{
+			Enabled: true,
+		},
 	})
 	require.NoError(t, err)
 
@@ -2910,15 +3204,15 @@ func TestInsertAccessListCollection(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, acls, 3)
 
-		allMembers1, err := service.memberService.WithPrefix(list1.GetName()).GetResources(ctx)
+		allMembers1, err := service.memberService.UnscopedService.WithPrefix(list1.GetName()).GetResources(ctx)
 		require.NoError(t, err)
 		require.Len(t, allMembers1, 500)
 
-		allMembers2, err := service.memberService.WithPrefix(list2.GetName()).GetResources(ctx)
+		allMembers2, err := service.memberService.UnscopedService.WithPrefix(list2.GetName()).GetResources(ctx)
 		require.NoError(t, err)
 		require.Len(t, allMembers2, 600)
 
-		allMembers3, err := service.memberService.WithPrefix(list3.GetName()).GetResources(ctx)
+		allMembers3, err := service.memberService.UnscopedService.WithPrefix(list3.GetName()).GetResources(ctx)
 		require.NoError(t, err)
 		require.Len(t, allMembers3, 400)
 	})
@@ -3092,7 +3386,7 @@ func TestAccessListDeletePrevention_MissingReferences(t *testing.T) {
 			for _, parent := range related {
 				err := service.service.UnscopedService.DeleteResource(ctx, parent.GetName())
 				require.NoError(t, err)
-				err = service.memberService.WithPrefix(parent.GetName()).DeleteAllResources(ctx)
+				err = service.memberService.UnscopedService.WithPrefix(parent.GetName()).DeleteAllResources(ctx)
 				require.NoError(t, err)
 			}
 		},
@@ -3124,7 +3418,7 @@ func TestAccessListDeletePrevention_MissingReferences(t *testing.T) {
 			for _, owned := range related {
 				err := service.service.UnscopedService.DeleteResource(ctx, owned.GetName())
 				require.NoError(t, err)
-				err = service.memberService.WithPrefix(owned.GetName()).DeleteAllResources(ctx)
+				err = service.memberService.UnscopedService.WithPrefix(owned.GetName()).DeleteAllResources(ctx)
 				require.NoError(t, err)
 			}
 		},

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -37,6 +37,7 @@ import (
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/common"
@@ -193,7 +194,7 @@ func TestAccessListCRUDScoped(t *testing.T) {
 	}
 
 	const listName = "accessList"
-	scopedName := scopes.QualifiedName{Scope: "/eng", Name: listName}
+	scopedName := accesslists.NormalizedSQN{Scope: "/eng", Name: listName}
 	scopedAccessList := newScopedAccessList(listName, scopedName.Scope)
 	unscopedAccessList := newAccessList(t, listName, clock)
 
@@ -211,14 +212,21 @@ func TestAccessListCRUDScoped(t *testing.T) {
 	_, err = service.GetAccessList(ctx, listName)
 	require.True(t, trace.IsNotFound(err), "expected not found error, got %v", err)
 
-	lists, err := service.GetAccessLists(ctx)
+	// Legacy list APIs should not return scoped access lists.
+	listed, err := service.GetAccessLists(ctx)
 	require.NoError(t, err)
-	require.Empty(t, lists)
-
+	require.Empty(t, listed)
 	listed, nextToken, err := service.ListAccessLists(ctx, 100, "")
 	require.NoError(t, err)
 	require.Empty(t, nextToken)
 	require.Empty(t, listed)
+
+	// ListAccessListsV2 _should_ return all access lists by default.
+	listed, nextToken, err = service.ListAccessListsV2(ctx, nil)
+	require.NoError(t, err)
+	require.Empty(t, nextToken)
+	require.Len(t, listed, 1)
+	require.Equal(t, scopedName, accesslists.ScopeQualifiedName(listed[0]))
 
 	unscopedCreated, err := service.UpsertAccessList(ctx, unscopedAccessList)
 	require.NoError(t, err)
@@ -243,6 +251,39 @@ func TestAccessListCRUDScoped(t *testing.T) {
 	unscopedFetched, err = service.GetAccessList(ctx, listName)
 	require.NoError(t, err)
 	require.Equal(t, unscopedAccessList.Spec.Description, unscopedFetched.Spec.Description)
+
+	// Legacy list APIs should not return scoped access lists.
+	listed, err = service.GetAccessLists(ctx)
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	require.Empty(t, cmp.Diff(unscopedAccessList, listed[0], cmpOpts...))
+	listed, nextToken, err = service.ListAccessLists(ctx, 100, "")
+	require.NoError(t, err)
+	require.Empty(t, nextToken)
+	require.Len(t, listed, 1)
+	require.Empty(t, cmp.Diff(unscopedAccessList, listed[0], cmpOpts...))
+
+	// ListAccessListsV2 _should_ return all access lists by default.
+	listed, _, err = service.ListAccessListsV2(ctx, nil)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff([]*accesslist.AccessList{unscopedAccessList, updated}, listed, cmpOpts...))
+
+	// ListAccessListsV2 can filter to include or exclude scoped lists.
+	listed, _, err = service.ListAccessListsV2(ctx, accesslistv1.ListAccessListsV2Request_builder{
+		ScopeFilter: scopesv1.Filter_builder{
+			Mode: scopesv1.Mode_MODE_UNSCOPED,
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff([]*accesslist.AccessList{unscopedAccessList}, listed, cmpOpts...))
+	listed, _, err = service.ListAccessListsV2(ctx, accesslistv1.ListAccessListsV2Request_builder{
+		ScopeFilter: scopesv1.Filter_builder{
+			Scope: "/",
+			Mode:  scopesv1.Mode_MODE_DESCENDANTS,
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff([]*accesslist.AccessList{updated}, listed, cmpOpts...))
 
 	err = service.DeleteAccessListV2(ctx, accesslistv1.DeleteAccessListRequest_builder{
 		Scope: scopedName.Scope,
@@ -2453,8 +2494,9 @@ func TestAccessListService_ListAllAccessListMembers(t *testing.T) {
 	require.NoError(t, err)
 
 	service := newAccessListService(t, mem, modulestest.EnterpriseModules())
-	const numAccessLists = 10
-	const numAccessListMembersPerAccessList = 250
+	const numAccessLists = 2
+	const numAccessListMembersPerAccessList = 3
+	const pageSize = 2
 	totalMembers := numAccessLists * numAccessListMembersPerAccessList
 
 	// Create several access lists.
@@ -2472,22 +2514,70 @@ func TestAccessListService_ListAllAccessListMembers(t *testing.T) {
 		}
 	}
 
-	allMembers := make([]*accesslist.AccessListMember, 0, totalMembers)
-	var nextToken string
-	for {
-		var members []*accesslist.AccessListMember
-		var err error
-		members, nextToken, err = service.ListAllAccessListMembers(ctx, 0, nextToken)
+	allMembers, err := stream.Collect(clientutils.ResourcesWithPageSize(t.Context(), service.ListAllAccessListMembers, pageSize))
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(expectedMembers, allMembers, cmpopts.IgnoreFields(header.Metadata{}, "Revision")))
+
+	// Add a scoped access list with some members.
+	scopedListName := scopes.QualifiedName{Scope: "/example", Name: "scoped"}
+	_, err = service.UpsertAccessList(ctx, newScopedAccessList(t, scopedListName, clock))
+	require.NoError(t, err)
+	expectedScopedMembers := make([]*accesslist.AccessListMember, numAccessListMembersPerAccessList)
+	for j := range numAccessListMembersPerAccessList {
+		memberName := scopes.QualifiedName{Name: fmt.Sprintf("%03d", j)}
+		member := newScopedAccessListMember(t, scopedListName, memberName)
+		expectedScopedMembers[j] = member
+		_, err := service.UpsertAccessListMember(ctx, member)
 		require.NoError(t, err)
-
-		allMembers = append(allMembers, members...)
-
-		if nextToken == "" {
-			break
-		}
 	}
 
-	require.Empty(t, cmp.Diff(expectedMembers, allMembers, cmpopts.IgnoreFields(header.Metadata{}, "Revision")))
+	// Legacy ListAllAccessListMembers should _not_ return the scoped list members.
+	gotMembers, err := stream.Collect(clientutils.ResourcesWithPageSize(t.Context(), service.ListAllAccessListMembers, pageSize))
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(expectedMembers, gotMembers, cmpopts.IgnoreFields(header.Metadata{}, "Revision")))
+
+	// ListAllAccessListMembersV2 should _not_ return the scoped list members if
+	// they are filtered out.
+	gotMembers, err = stream.Collect(clientutils.ResourcesWithPageSize(t.Context(),
+		func(ctx context.Context, pageLimit int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+			return service.ListAllAccessListMembersV2(ctx, accesslistv1.ListAllAccessListMembersRequest_builder{
+				PageSize:  int32(pageLimit),
+				PageToken: pageToken,
+				ScopeFilter: scopesv1.Filter_builder{
+					Mode: scopesv1.Mode_MODE_UNSCOPED,
+				}.Build(),
+			}.Build())
+		}, pageSize))
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(expectedMembers, gotMembers, cmpopts.IgnoreFields(header.Metadata{}, "Revision")))
+
+	// ListAllAccessListMembersV2 should _only_ return the scoped list members
+	// if unscoped members are filtered out.
+	gotMembers, err = stream.Collect(clientutils.ResourcesWithPageSize(t.Context(),
+		func(ctx context.Context, pageLimit int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+			return service.ListAllAccessListMembersV2(ctx, accesslistv1.ListAllAccessListMembersRequest_builder{
+				PageSize:  int32(pageLimit),
+				PageToken: pageToken,
+				ScopeFilter: scopesv1.Filter_builder{
+					Scope: "/",
+					Mode:  scopesv1.Mode_MODE_DESCENDANTS,
+				}.Build(),
+			}.Build())
+		}, pageSize))
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(expectedScopedMembers, gotMembers, cmpopts.IgnoreFields(header.Metadata{}, "Revision")))
+
+	// ListAllAccessListMembersV2 should return all list members by default.
+	expectedMembers = append(expectedMembers, expectedScopedMembers...)
+	gotMembers, err = stream.Collect(clientutils.ResourcesWithPageSize(t.Context(),
+		func(ctx context.Context, pageLimit int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+			return service.ListAllAccessListMembersV2(ctx, accesslistv1.ListAllAccessListMembersRequest_builder{
+				PageSize:  int32(pageLimit),
+				PageToken: pageToken,
+			}.Build())
+		}, pageSize))
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(expectedMembers, gotMembers, cmpopts.IgnoreFields(header.Metadata{}, "Revision")))
 }
 
 func TestAccessListService_ListAllAccessListReviews(t *testing.T) {
@@ -2502,8 +2592,9 @@ func TestAccessListService_ListAllAccessListReviews(t *testing.T) {
 
 	service := newAccessListService(t, mem, modulestest.EnterpriseModules())
 
-	const numAccessLists = 10
-	const numAccessListReviewsPerAccessList = 250
+	const numAccessLists = 2
+	const numAccessListReviewsPerAccessList = 3
+	const pageSize = 2
 	totalReviews := numAccessLists * numAccessListReviewsPerAccessList
 
 	// Create several access lists.
@@ -2533,26 +2624,91 @@ func TestAccessListService_ListAllAccessListReviews(t *testing.T) {
 		}
 	}
 
-	allReviews := make([]*accesslist.Review, 0, totalReviews)
-	var nextToken string
-	for {
-		var reviews []*accesslist.Review
-		var err error
-		reviews, nextToken, err = service.ListAllAccessListReviews(ctx, 0, nextToken)
-		require.NoError(t, err)
-
-		allReviews = append(allReviews, reviews...)
-
-		if nextToken == "" {
-			break
-		}
+	expectReviews := func(t *testing.T, expected, actual []*accesslist.Review) {
+		t.Helper()
+		require.Empty(t, cmp.Diff(expected, actual, cmpopts.IgnoreFields(header.Metadata{}, "Revision"), cmpopts.SortSlices(
+			func(r1, r2 *accesslist.Review) bool {
+				return r1.GetName() < r2.GetName()
+			}),
+		))
 	}
 
-	require.Empty(t, cmp.Diff(expectedReviews, allReviews, cmpopts.IgnoreFields(header.Metadata{}, "Revision"), cmpopts.SortSlices(
-		func(r1, r2 *accesslist.Review) bool {
-			return r1.GetName() < r2.GetName()
-		}),
-	))
+	allReviews, err := stream.Collect(clientutils.ResourcesWithPageSize(ctx, service.ListAllAccessListReviews, pageSize))
+	require.NoError(t, err)
+	expectReviews(t, expectedReviews, allReviews)
+
+	// Add a scoped access list with some reviews.
+	scopedListName := scopes.QualifiedName{Scope: "/example", Name: "scoped"}
+	_, err = service.UpsertAccessList(ctx, newScopedAccessList(t, scopedListName, clock))
+	require.NoError(t, err)
+	expectedScopedReviews := make([]*accesslist.Review, numAccessListReviewsPerAccessList)
+	for j := range numAccessListReviewsPerAccessList {
+		review, err := accesslist.NewReviewWithScope(
+			header.Metadata{
+				Name: strconv.Itoa(j),
+			},
+			accesslist.ReviewSpec{
+				AccessList: scopedListName.String(),
+				Reviewers: []string{
+					"user1",
+				},
+				ReviewDate: time.Now(),
+			},
+			scopedListName.Scope,
+		)
+		require.NoError(t, err)
+		review, _, err = service.CreateAccessListReview(ctx, review)
+		require.NoError(t, err)
+		expectedScopedReviews[j] = review
+	}
+
+	// Legacy ListAllAccessListReviews should _not_ return the scoped list members.
+	gotReviews, err := stream.Collect(clientutils.ResourcesWithPageSize(t.Context(), service.ListAllAccessListReviews, pageSize))
+	require.NoError(t, err)
+	expectReviews(t, expectedReviews, gotReviews)
+
+	// ListAllAccessListReviewsV2 should _not_ return the scoped list members if
+	// they are filtered out.
+	gotReviews, err = stream.Collect(clientutils.ResourcesWithPageSize(t.Context(),
+		func(ctx context.Context, pageLimit int, pageToken string) ([]*accesslist.Review, string, error) {
+			return service.ListAllAccessListReviewsV2(ctx, accesslistv1.ListAllAccessListReviewsRequest_builder{
+				PageSize:  int32(pageLimit),
+				NextToken: pageToken,
+				ScopeFilter: scopesv1.Filter_builder{
+					Mode: scopesv1.Mode_MODE_UNSCOPED,
+				}.Build(),
+			}.Build())
+		}, pageSize))
+	require.NoError(t, err)
+	expectReviews(t, expectedReviews, gotReviews)
+
+	// ListAllAccessListReviewsV2 should _only_ return the scoped list members
+	// if unscoped members are filtered out.
+	gotReviews, err = stream.Collect(clientutils.ResourcesWithPageSize(t.Context(),
+		func(ctx context.Context, pageLimit int, pageToken string) ([]*accesslist.Review, string, error) {
+			return service.ListAllAccessListReviewsV2(ctx, accesslistv1.ListAllAccessListReviewsRequest_builder{
+				PageSize:  int32(pageLimit),
+				NextToken: pageToken,
+				ScopeFilter: scopesv1.Filter_builder{
+					Scope: "/",
+					Mode:  scopesv1.Mode_MODE_DESCENDANTS,
+				}.Build(),
+			}.Build())
+		}, pageSize))
+	require.NoError(t, err)
+	expectReviews(t, expectedScopedReviews, gotReviews)
+
+	// ListAllAccessListReviewsV2 should return all list members by default.
+	expectedReviews = append(expectedReviews, expectedScopedReviews...)
+	gotReviews, err = stream.Collect(clientutils.ResourcesWithPageSize(t.Context(),
+		func(ctx context.Context, pageLimit int, pageToken string) ([]*accesslist.Review, string, error) {
+			return service.ListAllAccessListReviewsV2(ctx, accesslistv1.ListAllAccessListReviewsRequest_builder{
+				PageSize:  int32(pageLimit),
+				NextToken: pageToken,
+			}.Build())
+		}, pageSize))
+	require.NoError(t, err)
+	expectReviews(t, expectedReviews, gotReviews)
 }
 
 func TestAccessListService_Status_OwnerOf(t *testing.T) {

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -1838,6 +1838,156 @@ func TestAccessListReviewCRUD(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestAccessListReviewCRUDScoped(t *testing.T) {
+	ctx := t.Context()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service := newAccessListService(t, mem, modulestest.EnterpriseModules())
+
+	// Create an access list with 2 members, the review will remove the members.
+	listName := scopes.QualifiedName{Scope: "/eng/platform", Name: "reviewed"}
+	unscopedMemberName := scopes.QualifiedName{Name: "alice"}
+	scopedMemberName := scopes.QualifiedName{Scope: "/eng", Name: "team"}
+
+	accessList, err := service.UpsertAccessList(ctx, newScopedAccessList(t, listName, clock))
+	require.NoError(t, err)
+	_, err = service.UpsertAccessList(ctx, newScopedAccessList(t, scopedMemberName, clock))
+	require.NoError(t, err)
+
+	unscopedMember := newScopedAccessListMember(t, listName, unscopedMemberName, withMembershipKind(accesslist.MembershipKindUser))
+	scopedMember := newScopedAccessListMember(t, listName, scopedMemberName, withMembershipKind(accesslist.MembershipKindScopedList))
+	_, returnedMembers, err := service.UpsertAccessListWithMembers(ctx, accessList, []*accesslist.AccessListMember{unscopedMember, scopedMember})
+	require.NoError(t, err)
+	require.Len(t, returnedMembers, 2)
+
+	// Create a review.
+	review, err := accesslist.NewReviewWithScope(header.Metadata{Name: "ignored-by-create"}, accesslist.ReviewSpec{
+		AccessList: listName.String(),
+		Reviewers:  []string{"user1"},
+		ReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+		Changes: accesslist.ReviewChanges{
+			// Remove both the scoped and unscoped members.
+			RemovedMembers:         []string{unscopedMemberName.Name},
+			ScopedRemovedMembers:   []string{scopedMemberName.String()},
+			ReviewFrequencyChanged: accesslist.ThreeMonths,
+		},
+	}, listName.Scope)
+	require.NoError(t, err)
+
+	createdReview, nextAuditDate, err := service.CreateAccessListReview(ctx, review)
+	require.NoError(t, err)
+	require.NotEmpty(t, createdReview.GetName())
+	require.Equal(t, listName.Scope, createdReview.Scope)
+	require.Equal(t, listName.String(), createdReview.Spec.AccessList)
+	updatedAccessList, err := service.GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Scope: listName.Scope,
+		Name:  listName.Name,
+	}.Build())
+	require.NoError(t, err)
+	require.Equal(t, updatedAccessList.Spec.Audit.NextAuditDate, nextAuditDate)
+	require.Equal(t, accesslist.ThreeMonths, updatedAccessList.Spec.Audit.Recurrence.Frequency)
+
+	// Assert that both the members were actually removed.
+	_, err = service.GetAccessListMemberV2(ctx, accesslistv1.GetAccessListMemberRequest_builder{
+		AccessListScope: listName.Scope,
+		AccessList:      listName.Name,
+		MemberName:      unscopedMemberName.Name,
+	}.Build())
+	require.True(t, trace.IsNotFound(err), "expected not found error, got %v", err)
+	_, err = service.GetAccessListMemberV2(ctx, accesslistv1.GetAccessListMemberRequest_builder{
+		AccessListScope: listName.Scope,
+		AccessList:      listName.Name,
+		MemberScope:     scopedMemberName.Scope,
+		MemberName:      scopedMemberName.Name,
+	}.Build())
+	require.True(t, trace.IsNotFound(err), "expected not found error, got %v", err)
+
+	// Make sure the review can be listed.
+	reviews, nextToken, err := service.ListAccessListReviewsV2(ctx, accesslistv1.ListAccessListReviewsRequest_builder{
+		AccessListScope: listName.Scope,
+		AccessList:      listName.Name,
+		PageSize:        1,
+	}.Build())
+	require.NoError(t, err)
+	require.Empty(t, nextToken)
+	require.Len(t, reviews, 1)
+	require.Equal(t, createdReview.GetName(), reviews[0].GetName())
+	require.Equal(t, listName.Scope, reviews[0].Scope)
+
+	// Legacy ListAccessListReviews is unscoped, if there is an unscoped access
+	// list with a colliding name, listing its reviews should return nothing.
+	_, err = service.UpsertAccessList(ctx, newAccessList(t, listName.Name, clock))
+	require.NoError(t, err)
+	reviews, nextToken, err = service.ListAccessListReviews(ctx, listName.Name, 1, "")
+	require.NoError(t, err)
+	require.Empty(t, nextToken)
+	require.Empty(t, reviews)
+
+	// Delete the review and assert that it's not longer listed.
+	err = service.DeleteAccessListReviewV2(ctx, accesslistv1.DeleteAccessListReviewRequest_builder{
+		AccessListScope: listName.Scope,
+		AccessListName:  listName.Name,
+		ReviewName:      createdReview.GetName(),
+	}.Build())
+	require.NoError(t, err)
+
+	reviews, _, err = service.ListAccessListReviewsV2(ctx, accesslistv1.ListAccessListReviewsRequest_builder{
+		AccessListScope: listName.Scope,
+		AccessList:      listName.Name,
+	}.Build())
+	require.NoError(t, err)
+	require.Empty(t, reviews)
+}
+
+func TestCreateAccessListReviewScopedValidation(t *testing.T) {
+	ctx := t.Context()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service := newAccessListService(t, mem, modulestest.EnterpriseModules())
+	listName := scopes.QualifiedName{Scope: "/eng", Name: "reviewed"}
+	_, err = service.UpsertAccessList(ctx, newScopedAccessList(t, listName, clock))
+	require.NoError(t, err)
+
+	newReview := func(t *testing.T) *accesslist.Review {
+		t.Helper()
+		review, err := accesslist.NewReviewWithScope(header.Metadata{Name: "review"}, accesslist.ReviewSpec{
+			AccessList: listName.String(),
+			Reviewers:  []string{"user1"},
+			ReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+		}, listName.Scope)
+		require.NoError(t, err)
+		return review
+	}
+
+	t.Run("review scope must match access list scope", func(t *testing.T) {
+		review := newReview(t)
+		review.Scope = "/ops"
+
+		_, _, err := service.CreateAccessListReview(ctx, review)
+		require.ErrorContains(t, err, `access list review scope "/ops" does not match the scope of the reviewed list "/eng"`)
+	})
+
+	t.Run("membership requirements are rejected", func(t *testing.T) {
+		review := newReview(t)
+		review.Spec.Changes.MembershipRequirementsChanged = &accesslist.Requires{Roles: []string{"role"}}
+
+		_, _, err := service.CreateAccessListReview(ctx, review)
+		require.ErrorContains(t, err, "scoped access lists cannot contain membership requirements")
+	})
+}
+
 func Test_CreateAccessListReview_NestedListMemberRemoval(t *testing.T) {
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -342,11 +342,11 @@ func TestAccessListCRUDScopedRoleGrants(t *testing.T) {
 	accessList := newAccessList(t, "accessList-scoped", clock, withOwnerRequires(accesslist.Requires{}), withMemberRequires(accesslist.Requires{}))
 	accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{
 		{
-			Role:  "scoped-role-1",
+			Role:  "/::scoped-role-1",
 			Scope: "/eng",
 		},
 		{
-			Role:  "scoped-role-2",
+			Role:  "/::scoped-role-2",
 			Scope: "/platform",
 		},
 	}
@@ -365,7 +365,7 @@ func TestAccessListCRUDScopedRoleGrants(t *testing.T) {
 
 	fetched.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{
 		{
-			Role:  "scoped-role-3",
+			Role:  "/::scoped-role-3",
 			Scope: "/ops",
 		},
 	}
@@ -2327,8 +2327,8 @@ func newScopedAccessList(t *testing.T, name scopes.QualifiedName, clock clockwor
 		}
 	} else {
 		accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{
-			{Role: "gscopedrole1", Scope: name.Scope},
-			{Role: "gscopedrole2", Scope: name.Scope},
+			{Role: "/::gscopedrole1", Scope: name.Scope},
+			{Role: "/::gscopedrole2", Scope: name.Scope},
 		}
 	}
 

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -40,6 +40,8 @@ import (
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/kubewaitingcontainer"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -220,6 +222,10 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 			parser = p
 		case types.KindAccessList:
 			parser = newAccessListParser()
+		case types.KindAccessListMember:
+			parser = newAccessListMemberParser()
+		case types.KindAccessListReview:
+			parser = newAccessListReviewParser()
 		case types.KindAuditQuery:
 			parser = newAuditQueryParser()
 		case types.KindSecurityReport:
@@ -228,10 +234,6 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 			parser = newSecurityReportStateParser()
 		case types.KindUserLoginState:
 			parser = newUserLoginStateParser()
-		case types.KindAccessListMember:
-			parser = newAccessListMemberParser()
-		case types.KindAccessListReview:
-			parser = newAccessListReviewParser()
 		case types.KindKubeWaitingContainer:
 			parser = newKubeWaitingContainerParser()
 		case types.KindNotification:
@@ -2577,9 +2579,25 @@ func (p *headlessAuthenticationParser) parse(event backend.Event) (types.Resourc
 	}
 }
 
+func trimScopePrefix(key backend.Key) (scope string, remaining []string, err error) {
+	parts := key.Components()
+	if len(parts) < 2 {
+		return "", nil, trace.NotFound("failed parsing %v", key.String())
+	}
+	encodedScope := parts[0]
+	scope, err = scopes.DecodeFromKey(encodedScope)
+	if err != nil {
+		return "", nil, trace.Wrap(err)
+	}
+	return scope, parts[1:], nil
+}
+
 func newAccessListParser() *accessListParser {
 	return &accessListParser{
-		baseParser: newBaseParser(backend.ExactKey(accessListPrefix)),
+		baseParser: newBaseParser(
+			backend.ExactKey(accessListPrefix),
+			backend.ExactKey(scopedPrefix, accessListPrefix),
+		),
 	}
 }
 
@@ -2590,6 +2608,29 @@ type accessListParser struct {
 func (p *accessListParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
+		if key, found := event.Item.Key.CutPrefix(backend.ExactKey(scopedPrefix, accessListPrefix)); found {
+			scope, remaining, err := trimScopePrefix(key)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			if len(remaining) != 1 {
+				return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+			}
+			name := remaining[0]
+			// Delete events for scoped resources use an AccessList rather than
+			// ResourceHeader, to include the scope.
+			return &accesslist.AccessList{
+				ResourceHeader: header.ResourceHeader{
+					Kind:    types.KindAccessList,
+					Version: types.V1,
+					Metadata: header.Metadata{
+						Name: name,
+					},
+				},
+				Scope: scope,
+			}, nil
+		}
+
 		name := event.Item.Key.TrimPrefix(backend.NewKey(accessListPrefix)).String()
 		if name == "" {
 			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
@@ -2756,7 +2797,10 @@ func (p *userLoginStateParser) parse(event backend.Event) (types.Resource, error
 
 func newAccessListMemberParser() *accessListMemberParser {
 	return &accessListMemberParser{
-		baseParser: newBaseParser(backend.ExactKey(accessListMemberPrefix)),
+		baseParser: newBaseParser(
+			backend.ExactKey(accessListMemberPrefix),
+			backend.ExactKey(scopedPrefix, accessListMemberPrefix),
+		),
 	}
 }
 
@@ -2767,6 +2811,49 @@ type accessListMemberParser struct {
 func (p *accessListMemberParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
+		if key, found := event.Item.Key.CutPrefix(backend.ExactKey(scopedPrefix, accessListMemberPrefix)); found {
+			listScope, remaining, err := trimScopePrefix(key)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			if len(remaining) != 3 {
+				return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+			}
+			listName, encodedMemberScope, memberName := remaining[0], remaining[1], remaining[2]
+			memberScope, err := scopes.DecodeFromKey(encodedMemberScope)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			listSQN := scopes.QualifiedName{
+				Scope: listScope,
+				Name:  listName,
+			}
+			memberSQN := scopes.QualifiedName{
+				Scope: memberScope,
+				Name:  memberName,
+			}
+			membershipKind := accesslist.MembershipKindUnspecified
+			if memberScope != "" {
+				membershipKind = accesslist.MembershipKindScopedList
+			}
+			// Delete events for scoped resources use an AccessListMember rather than
+			// ResourceHeader, to include the scope.
+			return &accesslist.AccessListMember{
+				ResourceHeader: header.ResourceHeader{
+					Kind:    types.KindAccessListMember,
+					Version: types.V1,
+					Metadata: header.Metadata{
+						Name: memberSQN.String(),
+					},
+				},
+				Scope: listScope,
+				Spec: accesslist.AccessListMemberSpec{
+					AccessList:     listSQN.String(),
+					Name:           memberSQN.String(),
+					MembershipKind: membershipKind,
+				},
+			}, nil
+		}
 		key := event.Item.Key.TrimPrefix(backend.NewKey(accessListMemberPrefix))
 		if len(key.Components()) < 2 {
 			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
@@ -2794,7 +2881,10 @@ func (p *accessListMemberParser) parse(event backend.Event) (types.Resource, err
 
 func newAccessListReviewParser() *accessListReviewParser {
 	return &accessListReviewParser{
-		baseParser: newBaseParser(backend.ExactKey(accessListReviewPrefix)),
+		baseParser: newBaseParser(
+			backend.ExactKey(accessListReviewPrefix),
+			backend.ExactKey(scopedPrefix, accessListReviewPrefix),
+		),
 	}
 }
 
@@ -2805,6 +2895,35 @@ type accessListReviewParser struct {
 func (p *accessListReviewParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
+		if key, found := event.Item.Key.CutPrefix(backend.ExactKey(scopedPrefix, accessListReviewPrefix)); found {
+			listScope, remaining, err := trimScopePrefix(key)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			if len(remaining) != 2 {
+				return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+			}
+			listName, reviewName := remaining[0], remaining[1]
+			listSQN := scopes.QualifiedName{
+				Scope: listScope,
+				Name:  listName,
+			}
+			// Delete events for scoped resources use a Review rather than
+			// ResourceHeader, to include the scope.
+			return &accesslist.Review{
+				ResourceHeader: header.ResourceHeader{
+					Kind:    types.KindAccessListReview,
+					Version: types.V1,
+					Metadata: header.Metadata{
+						Name: reviewName,
+					},
+				},
+				Scope: listScope,
+				Spec: accesslist.ReviewSpec{
+					AccessList: listSQN.String(),
+				},
+			}, nil
+		}
 		key := event.Item.Key.TrimPrefix(backend.NewKey(accessListReviewPrefix))
 		if len(key.Components()) < 2 {
 			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())

--- a/lib/services/local/events_test.go
+++ b/lib/services/local/events_test.go
@@ -28,9 +28,11 @@ import (
 
 	provisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/provisioning/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/lib/auth/authcatest"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils/set"
 )
@@ -62,6 +64,151 @@ func unwrapResource153[T types.Resource153](t *testing.T, r types.Resource) T {
 
 	dst := u.UnwrapT()
 	return dst
+}
+
+func mustEncodeScopeForKey(t *testing.T, scope string) string {
+	t.Helper()
+
+	encoded, err := scopes.EncodeForKey(scope)
+	require.NoError(t, err)
+	return encoded
+}
+
+func TestAccessListParserScopedDelete(t *testing.T) {
+	const scope = "/eng/platform"
+	key := backend.NewKey(scopedPrefix, accessListPrefix, mustEncodeScopeForKey(t, scope), "reviewed")
+	event := backend.Event{
+		Type: types.OpDelete,
+		Item: backend.Item{Key: key},
+	}
+
+	parser := newAccessListParser()
+	require.True(t, parser.match(key))
+
+	resource, err := parser.parse(event)
+	require.NoError(t, err)
+
+	accessList, ok := resource.(*accesslist.AccessList)
+	require.True(t, ok)
+	require.Equal(t, types.KindAccessList, accessList.GetKind())
+	require.Equal(t, "reviewed", accessList.GetName())
+	require.Equal(t, scope, accessList.Scope)
+}
+
+func TestAccessListMemberParserScopedDelete(t *testing.T) {
+	const listScope = "/eng/platform"
+
+	tests := []struct {
+		name                   string
+		member                 scopes.QualifiedName
+		expectedMembershipKind string
+	}{
+		{
+			name:                   "unscoped member",
+			member:                 scopes.QualifiedName{Name: "alice"},
+			expectedMembershipKind: accesslist.MembershipKindUnspecified,
+		},
+		{
+			name:                   "scoped list member",
+			member:                 scopes.QualifiedName{Scope: "/eng", Name: "team"},
+			expectedMembershipKind: accesslist.MembershipKindScopedList,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			key := backend.NewKey(
+				scopedPrefix,
+				accessListMemberPrefix,
+				mustEncodeScopeForKey(t, listScope),
+				"reviewed",
+				mustEncodeScopeForKey(t, test.member.Scope),
+				test.member.Name,
+			)
+			event := backend.Event{
+				Type: types.OpDelete,
+				Item: backend.Item{Key: key},
+			}
+
+			parser := newAccessListMemberParser()
+			require.True(t, parser.match(key))
+
+			resource, err := parser.parse(event)
+			require.NoError(t, err)
+
+			member, ok := resource.(*accesslist.AccessListMember)
+			require.True(t, ok)
+			require.Equal(t, types.KindAccessListMember, member.GetKind())
+			require.Equal(t, test.member.String(), member.GetName())
+			require.Equal(t, listScope, member.Scope)
+			require.Equal(t, scopes.QualifiedName{Scope: listScope, Name: "reviewed"}.String(), member.Spec.AccessList)
+			require.Equal(t, test.member.String(), member.Spec.Name)
+			require.Equal(t, test.expectedMembershipKind, member.Spec.MembershipKind)
+		})
+	}
+}
+
+func TestAccessListReviewParserScopedDelete(t *testing.T) {
+	const scope = "/eng/platform"
+	key := backend.NewKey(scopedPrefix, accessListReviewPrefix, mustEncodeScopeForKey(t, scope), "reviewed", "review-1")
+	event := backend.Event{
+		Type: types.OpDelete,
+		Item: backend.Item{Key: key},
+	}
+
+	parser := newAccessListReviewParser()
+	require.True(t, parser.match(key))
+
+	resource, err := parser.parse(event)
+	require.NoError(t, err)
+
+	review, ok := resource.(*accesslist.Review)
+	require.True(t, ok)
+	require.Equal(t, types.KindAccessListReview, review.GetKind())
+	require.Equal(t, "review-1", review.GetName())
+	require.Equal(t, scope, review.Scope)
+	require.Equal(t, scopes.QualifiedName{Scope: scope, Name: "reviewed"}.String(), review.Spec.AccessList)
+}
+
+func TestAccessListScopedDeleteParserRejectsMalformedKeys(t *testing.T) {
+	tests := []struct {
+		name   string
+		parser resourceParser
+		key    backend.Key
+	}{
+		{
+			name:   "access list missing name",
+			parser: newAccessListParser(),
+			key:    backend.NewKey(scopedPrefix, accessListPrefix, mustEncodeScopeForKey(t, "/eng/platform")),
+		},
+		{
+			name:   "member missing member name",
+			parser: newAccessListMemberParser(),
+			key: backend.NewKey(
+				scopedPrefix,
+				accessListMemberPrefix,
+				mustEncodeScopeForKey(t, "/eng/platform"),
+				"reviewed",
+				mustEncodeScopeForKey(t, "/eng"),
+			),
+		},
+		{
+			name:   "review has bad encoded scope",
+			parser: newAccessListReviewParser(),
+			key:    backend.NewKey(scopedPrefix, accessListReviewPrefix, "bad-scope", "reviewed", "review-1"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.True(t, test.parser.match(test.key))
+			_, err := test.parser.parse(backend.Event{
+				Type: types.OpDelete,
+				Item: backend.Item{Key: test.key},
+			})
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestWatchers(t *testing.T) {

--- a/lib/services/local/generic/scopeaware.go
+++ b/lib/services/local/generic/scopeaware.go
@@ -333,6 +333,15 @@ func (s *ScopeAwareService[T]) ConditionalUpdateResource(ctx context.Context, re
 	return svc.ConditionalUpdateResource(ctx, resource)
 }
 
+// MakeBackendItem will check and make the backend item.
+func (s *ScopeAwareService[T]) MakeBackendItem(resource T) (backend.Item, error) {
+	svc, err := s.WithScopePrefix(resource.GetScope())
+	if err != nil {
+		return backend.Item{}, trace.Wrap(err)
+	}
+	return svc.MakeBackendItem(resource)
+}
+
 // WithScopePrefix returns the unscoped service when scope is empty, otherwise
 // returns the scoped service with the encoded scope appended to its backend prefix.
 func (s *ScopeAwareService[T]) WithScopePrefix(scope string) (*Service[T], error) {

--- a/lib/services/local/generic/scopeaware.go
+++ b/lib/services/local/generic/scopeaware.go
@@ -57,6 +57,9 @@ type ScopeAwareService[T ScopedResource] struct {
 	// ScopedService is the underlying service for resources with a scope.
 	// Resources will be keyed at <scoped_prefix>/<backend_prefix>/<encoded_scope>/<name>
 	ScopedService *Service[T]
+
+	backend                     backend.Backend
+	runWhileLockedRetryInterval time.Duration
 }
 
 // ScopeAwareServiceConfig holds configuration options for ScopeAwareService.
@@ -125,8 +128,10 @@ func NewScopeAwareService[T ScopedResource](cfg *ScopeAwareServiceConfig[T]) (*S
 	}
 
 	return &ScopeAwareService[T]{
-		UnscopedService: unscopedService,
-		ScopedService:   scopedService,
+		UnscopedService:             unscopedService,
+		ScopedService:               scopedService,
+		backend:                     cfg.Backend,
+		runWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
 	}, nil
 }
 
@@ -367,4 +372,19 @@ func (s *ScopeAwareService[T]) WithScopedResourcePrefix(scopedName scopes.Qualif
 		return nil, trace.Wrap(err)
 	}
 	return s.ScopedService.WithPrefix(encodedScope, scopedName.Name), nil
+}
+
+// RunWhileLocked will run the given function in a backend lock. This is a wrapper around the backend.RunWhileLocked function.
+func (s *ScopeAwareService[T]) RunWhileLocked(ctx context.Context, lockNameComponents []string, ttl time.Duration, fn func(context.Context, backend.Backend) error) error {
+	return trace.Wrap(backend.RunWhileLocked(ctx,
+		backend.RunWhileLockedConfig{
+			LockConfiguration: backend.LockConfiguration{
+				Backend:            s.backend,
+				LockNameComponents: lockNameComponents,
+				TTL:                ttl,
+				RetryInterval:      s.runWhileLockedRetryInterval,
+			},
+		}, func(ctx context.Context) error {
+			return fn(ctx, s.backend)
+		}))
 }

--- a/tool/tctl/common/acl_command.go
+++ b/tool/tctl/common/acl_command.go
@@ -32,12 +32,16 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/accesslists"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
@@ -62,9 +66,9 @@ type ACLCommand struct {
 	memberKind string
 
 	// Used for managing membership to an access list.
-	userName string
-	expires  string
-	reason   string
+	memberName string
+	expires    string
+	reason     string
 
 	// Used for creating reviews.
 	notes         string
@@ -99,13 +103,13 @@ func (c *ACLCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFl
 	c.usersAdd = users.Command("add", "Add a user to an Access List.")
 	c.usersAdd.Flag("kind", "Access list member kind.").Default(memberKindUser).EnumVar(&c.memberKind, memberKindUser, memberKindList)
 	c.usersAdd.Arg("access-list-name", "The Access List name.").Required().StringVar(&c.accessListName)
-	c.usersAdd.Arg("user", "The user to add to the Access List.").Required().StringVar(&c.userName)
+	c.usersAdd.Arg("user", "The member to add to the Access List.").Required().StringVar(&c.memberName)
 	c.usersAdd.Arg("expires", "When the user's access expires (must be in RFC3339). Defaults to the expiration time of the Access List.").StringVar(&c.expires)
 	c.usersAdd.Arg("reason", "The reason the user has been added to the Access List. Defaults to empty.").StringVar(&c.reason)
 
 	c.usersRemove = users.Command("rm", "Remove a user from an Access List.")
 	c.usersRemove.Arg("access-list-name", "The Access List name.").Required().StringVar(&c.accessListName)
-	c.usersRemove.Arg("user", "The user to remove from the Access List.").Required().StringVar(&c.userName)
+	c.usersRemove.Arg("user", "The member to remove from the Access List.").Required().StringVar(&c.memberName)
 
 	c.usersList = users.Command("ls", "List users that are members of an Access List.")
 	c.usersList.Arg("access-list-name", "The Access List name.").Required().StringVar(&c.accessListName)
@@ -169,7 +173,19 @@ func (c *ACLCommand) List(ctx context.Context, client *authclient.Client) error 
 			return trace.Wrap(err)
 		}
 	} else {
-		accessLists, err = stream.Collect(clientutils.Resources(ctx, client.AccessListClient().ListAccessLists))
+		accessLists, err = stream.Collect(clientutils.Resources(ctx,
+			func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessList, string, error) {
+				return client.AccessListClient().ListAccessListsV2(ctx, accesslistv1.ListAccessListsV2Request_builder{
+					PageSize:  int32(pageSize),
+					PageToken: pageToken,
+					ScopeFilter: scopesv1.Filter_builder{
+						Mode: scopesv1.Mode_MODE_ALL,
+					}.Build(),
+				}.Build())
+			}))
+		if trace.IsNotImplemented(err) {
+			accessLists, err = stream.Collect(clientutils.Resources(ctx, client.AccessListClient().ListAccessLists))
+		}
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -183,9 +199,53 @@ func (c *ACLCommand) List(ctx context.Context, client *authclient.Client) error 
 	return trace.Wrap(c.displayAccessLists(accessLists...))
 }
 
+func parseACLQualifiedName(name string) (scopes.QualifiedName, error) {
+	// For backward compatibility, an argument is considered a scope-qualified
+	// name only if it:
+	// 1. parses as a qualified name (contains :: somewhere in the middle)
+	// 2. contains /
+	// otherwise it is considered a plain unscoped name. This allows access
+	// lists with names like 'example::list' to continue to be referenced in
+	// CLI commands as unscoped lists, only params like '/example::list' will
+	// be considered scoped.
+	if sqn, err := scopes.ParseQualifiedName(name); err == nil && strings.Contains(name, "/") {
+		return sqn, sqn.StrongValidate()
+	}
+	return scopes.QualifiedName{Name: name}, nil
+}
+
+func (c *ACLCommand) accessListQualifiedName() (scopes.QualifiedName, error) {
+	sqn, err := parseACLQualifiedName(c.accessListName)
+	return sqn, trace.Wrap(err, "validating access list name as a scope-qualified name")
+}
+
+func (c *ACLCommand) memberQualifiedName() (scopes.QualifiedName, error) {
+	sqn, err := parseACLQualifiedName(c.memberName)
+	return sqn, trace.Wrap(err, "validating member name as a scope-qualified name")
+}
+
+func splitACLQualifiedNames(names string) ([]scopes.QualifiedName, error) {
+	var sqns []scopes.QualifiedName
+	for _, name := range utils.SplitIdentifiers(names) {
+		sqn, err := parseACLQualifiedName(strings.TrimSpace(name))
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		sqns = append(sqns, sqn)
+	}
+	return sqns, nil
+}
+
 // Get will display information about an access list visible to the user.
 func (c *ACLCommand) Get(ctx context.Context, client *authclient.Client) error {
-	accessList, err := client.AccessListClient().GetAccessList(ctx, c.accessListName)
+	aclName, err := c.accessListQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	accessList, err := client.AccessListClient().GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Scope: aclName.Scope,
+		Name:  aclName.Name,
+	}.Build())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -203,20 +263,34 @@ func (c *ACLCommand) UsersAdd(ctx context.Context, client *authclient.Client) er
 			return trace.Wrap(err)
 		}
 	}
+	aclName, err := c.accessListQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	memberName, err := c.memberQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
 
 	var membershipKind string
 	switch c.memberKind {
 	case memberKindList:
 		membershipKind = accesslist.MembershipKindList
+		if memberName.Scope != "" {
+			membershipKind = accesslist.MembershipKindScopedList
+		}
 	case "", memberKindUser:
+		if memberName.Scope != "" {
+			return trace.BadParameter("user members cannot be scoped, got %q", c.memberName)
+		}
 		membershipKind = accesslist.MembershipKindUser
 	}
 
-	member, err := accesslist.NewAccessListMember(header.Metadata{
-		Name: c.userName,
+	member, err := accesslist.NewAccessListMemberWithScope(header.Metadata{
+		Name: memberName.String(),
 	}, accesslist.AccessListMemberSpec{
-		AccessList: c.accessListName,
-		Name:       c.userName,
+		AccessList: aclName.String(),
+		Name:       memberName.String(),
 		Reason:     c.reason,
 		Expires:    expires,
 
@@ -224,7 +298,7 @@ func (c *ACLCommand) UsersAdd(ctx context.Context, client *authclient.Client) er
 		Joined:         time.Now(),
 		AddedBy:        "dummy",
 		MembershipKind: membershipKind,
-	})
+	}, aclName.Scope)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -234,36 +308,57 @@ func (c *ACLCommand) UsersAdd(ctx context.Context, client *authclient.Client) er
 		return trace.Wrap(err)
 	}
 
-	fmt.Fprintf(c.Stdout, "successfully added user %s to access list %s", c.userName, c.accessListName)
+	fmt.Fprintf(c.Stdout, "successfully added member %s to access list %s", memberName.String(), aclName.String())
 
 	return nil
 }
 
 // UsersRemove will remove a user to an access list.
 func (c *ACLCommand) UsersRemove(ctx context.Context, client *authclient.Client) error {
-	err := client.AccessListClient().DeleteAccessListMember(ctx, c.accessListName, c.userName)
+	aclName, err := c.accessListQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	memberName, err := c.memberQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = client.AccessListClient().DeleteAccessListMemberV2(ctx, accesslistv1.DeleteAccessListMemberRequest_builder{
+		AccessListScope: aclName.Scope,
+		AccessList:      aclName.Name,
+		MemberScope:     memberName.Scope,
+		MemberName:      memberName.Name,
+	}.Build())
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	fmt.Fprintf(c.Stdout, "successfully removed user %s from access list %s\n", c.userName, c.accessListName)
+	fmt.Fprintf(c.Stdout, "successfully removed member %s from access list %s\n", memberName.String(), aclName.String())
 
 	return nil
 }
 
 // UsersList will list the users in an access list.
 func (c *ACLCommand) UsersList(ctx context.Context, client *authclient.Client) error {
+	aclName, err := c.accessListQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	var (
 		allMembers []*accesslist.AccessListMember
 		nextToken  string
-		err        error
+		listErr    error
 		members    []*accesslist.AccessListMember
 	)
 
 	for {
-		members, nextToken, err = client.AccessListClient().ListAccessListMembers(ctx, c.accessListName, 0, nextToken)
-		if err != nil {
-			return trace.Wrap(err)
+		members, nextToken, listErr = client.AccessListClient().ListAccessListMembersV2(ctx, accesslistv1.ListAccessListMembersRequest_builder{
+			PageToken:       nextToken,
+			AccessListScope: aclName.Scope,
+			AccessList:      aclName.Name,
+		}.Build())
+		if listErr != nil {
+			return trace.Wrap(listErr)
 		}
 		allMembers = append(allMembers, members...)
 		if nextToken == "" {
@@ -276,15 +371,19 @@ func (c *ACLCommand) UsersList(ctx context.Context, client *authclient.Client) e
 		return trace.Wrap(utils.WriteJSONArray(c.Stdout, allMembers))
 	case teleport.Text:
 		if len(allMembers) == 0 {
-			fmt.Fprintf(c.Stdout, "No members found for access list %s.\nYou may not have access to see the members for this list.\n", c.accessListName)
+			fmt.Fprintf(c.Stdout, "No members found for access list %s.\nYou may not have access to see the members for this list.\n", aclName.String())
 			return nil
 		}
-		fmt.Fprintf(c.Stdout, "Members of %s:\n", c.accessListName)
+		fmt.Fprintf(c.Stdout, "Members of %s:\n", aclName.String())
 		for _, member := range allMembers {
-			if member.Spec.MembershipKind == accesslist.MembershipKindList {
-				fmt.Fprintf(c.Stdout, "- (Access List) %s \n", member.Spec.Name)
+			memberName, err := accesslists.MemberScopeQualifiedName(member)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if member.IsList() {
+				fmt.Fprintf(c.Stdout, "- (Access List) %s \n", memberName.String())
 			} else {
-				fmt.Fprintf(c.Stdout, "- %s\n", member.Spec.Name)
+				fmt.Fprintf(c.Stdout, "- %s\n", memberName.String())
 			}
 		}
 		return nil
@@ -310,32 +409,53 @@ func (c *ACLCommand) ReviewsCreate(ctx context.Context, client *authclient.Clien
 }
 
 func (c *ACLCommand) makeReview() (*accesslist.Review, error) {
+	aclName, err := c.accessListQualifiedName()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	var removeMembers []string
-	for _, member := range strings.Split(c.removeMembers, ",") {
-		member = strings.TrimSpace(member)
-		if member != "" {
-			removeMembers = append(removeMembers, member)
+	var removeScopedMembers []string
+	removedMemberNames, err := splitACLQualifiedNames(c.removeMembers)
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing removed member name")
+	}
+	for _, member := range removedMemberNames {
+		if member.Scope == "" {
+			removeMembers = append(removeMembers, member.String())
+		} else {
+			removeScopedMembers = append(removeScopedMembers, member.String())
 		}
 	}
-	return accesslist.NewReview(
+	return accesslist.NewReviewWithScope(
 		header.Metadata{
 			Name: uuid.NewString(),
 		},
 		accesslist.ReviewSpec{
-			AccessList: c.accessListName,
+			AccessList: aclName.String(),
 			Reviewers:  []string{"placeholder"}, // Reviewers is set server-side but API requires it.
 			ReviewDate: time.Now(),              // Review date will be set server-side as well.
 			Notes:      c.notes,
 			Changes: accesslist.ReviewChanges{
-				RemovedMembers: removeMembers,
+				RemovedMembers:       removeMembers,
+				ScopedRemovedMembers: removeScopedMembers,
 			},
-		})
+		},
+		aclName.Scope)
 }
 
 func (c *ACLCommand) ReviewsList(ctx context.Context, client *authclient.Client) error {
+	aclName, err := c.accessListQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	reviews, err := stream.Collect(clientutils.Resources(ctx,
 		func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.Review, string, error) {
-			return client.AccessListClient().ListAccessListReviews(ctx, c.accessListName, pageSize, pageToken)
+			return client.AccessListClient().ListAccessListReviewsV2(ctx, accesslistv1.ListAccessListReviewsRequest_builder{
+				PageSize:        int32(pageSize),
+				NextToken:       pageToken,
+				AccessListScope: aclName.Scope,
+				AccessList:      aclName.Name,
+			}.Build())
 		}))
 	if err != nil {
 		return trace.Wrap(err)
@@ -365,7 +485,7 @@ func (c *ACLCommand) displayAccessListReviewsText(reviews []*accesslist.Review) 
 			review.GetName(),
 			strings.Join(review.Spec.Reviewers, ","),
 			review.Spec.ReviewDate.Format(time.DateOnly),
-			strings.Join(review.Spec.Changes.RemovedMembers, ","),
+			strings.Join(append(review.Spec.Changes.RemovedMembers, review.Spec.Changes.ScopedRemovedMembers...), ","),
 			review.Spec.Notes,
 		})
 	}
@@ -390,7 +510,10 @@ func (c *ACLCommand) displayAccessLists(accessLists ...*accesslist.AccessList) e
 func (c *ACLCommand) displayAccessListsText(accessLists ...*accesslist.AccessList) error {
 	table := asciitable.MakeTable([]string{"ID", "Title", "Next Audit", "Granted Roles", "Granted Traits"})
 	for _, accessList := range accessLists {
-		grantedRoles := strings.Join(accessList.GetGrants().Roles, ",")
+		grantedRoles := append([]string(nil), accessList.GetGrants().Roles...)
+		for _, grant := range accessList.GetGrants().ScopedRoles {
+			grantedRoles = append(grantedRoles, grant.Role)
+		}
 		traitStrings := make([]string, 0, len(accessList.GetGrants().Traits))
 		for k, values := range accessList.GetGrants().Traits {
 			traitStrings = append(traitStrings, fmt.Sprintf("%s:{%s}", k, strings.Join(values, ",")))
@@ -398,10 +521,10 @@ func (c *ACLCommand) displayAccessListsText(accessLists ...*accesslist.AccessLis
 
 		grantedTraits := strings.Join(traitStrings, ",")
 		table.AddRow([]string{
-			accessList.GetName(),
+			accesslists.ScopeQualifiedName(accessList).String(),
 			accessList.Spec.Title,
 			accessList.Spec.Audit.NextAuditDate.Format(time.DateOnly),
-			grantedRoles,
+			strings.Join(grantedRoles, ","),
 			grantedTraits,
 		})
 	}

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -47,7 +47,6 @@ import (
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/externalauditstorage"
 	"github.com/gravitational/teleport/api/types/label"
@@ -1460,32 +1459,6 @@ func (c *serverInfoCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Labels"})
 	for _, si := range c.serverInfos {
 		t.AddRow([]string{si.GetName(), printMetadataLabels(si.GetNewLabels())})
-	}
-	_, err := t.AsBuffer().WriteTo(w)
-	return trace.Wrap(err)
-}
-
-type accessListCollection struct {
-	accessLists []*accesslist.AccessList
-}
-
-func (c *accessListCollection) Resources() []types.Resource {
-	r := make([]types.Resource, len(c.accessLists))
-	for i, resource := range c.accessLists {
-		r[i] = resource
-	}
-	return r
-}
-
-func (c *accessListCollection) WriteText(w io.Writer, verbose bool) error {
-	t := asciitable.MakeTable([]string{"Name", "Title", "Review Frequency", "Next Audit Date"})
-	for _, al := range c.accessLists {
-		t.AddRow([]string{
-			al.GetName(),
-			al.Spec.Title,
-			al.Spec.Audit.Recurrence.Frequency.String(),
-			al.Spec.Audit.NextAuditDate.Format(time.RFC822),
-		})
 	}
 	_, err := t.AsBuffer().WriteTo(w)
 	return trace.Wrap(err)

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -63,7 +63,6 @@ import (
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/trail"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/externalauditstorage"
 	"github.com/gravitational/teleport/api/types/installers"
@@ -166,7 +165,6 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 		types.KindIntegration:                        rc.createIntegration,
 		types.KindWindowsDesktop:                     rc.createWindowsDesktop,
 		types.KindDynamicWindowsDesktop:              rc.createDynamicWindowsDesktop,
-		types.KindAccessList:                         rc.createAccessList,
 		types.KindDiscoveryConfig:                    rc.createDiscoveryConfig,
 		types.KindAuditQuery:                         rc.createAuditQuery,
 		types.KindSecurityReport:                     rc.createSecurityReport,
@@ -1758,30 +1756,6 @@ func (rc *ResourceCommand) createDiscoveryConfig(ctx context.Context, client *au
 		return trace.Wrap(err)
 	}
 	fmt.Printf("DiscoveryConfig %q has been created\n", discoveryConfig.GetName())
-
-	return nil
-}
-
-func (rc *ResourceCommand) createAccessList(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
-	accessList, err := services.UnmarshalAccessList(raw.Raw, services.DisallowUnknown())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	_, err = client.AccessListClient().GetAccessList(ctx, accessList.GetName())
-	if err != nil && !trace.IsNotFound(err) {
-		return trace.Wrap(err)
-	}
-	exists := (err == nil)
-
-	if exists && !rc.IsForced() {
-		return trace.AlreadyExists("Access list %q already exists", accessList.GetName())
-	}
-
-	if _, err := client.AccessListClient().UpsertAccessList(ctx, accessList); err != nil {
-		return trace.Wrap(err)
-	}
-	fmt.Printf("Access list %q has been %s\n", accessList.GetName(), UpsertVerb(exists, rc.IsForced()))
 
 	return nil
 }
@@ -3442,17 +3416,6 @@ func (rc *ResourceCommand) getCollectionByRef(ctx context.Context, client *authc
 			return nil, trace.Wrap(err)
 		}
 		return &serverInfoCollection{serverInfos: serverInfos}, nil
-	case types.KindAccessList:
-		if ref.Name != "" {
-			resource, err := client.AccessListClient().GetAccessList(ctx, ref.Name)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			return &accessListCollection{accessLists: []*accesslist.AccessList{resource}}, nil
-		}
-		accessLists, err := client.AccessListClient().GetAccessLists(ctx)
-
-		return &accessListCollection{accessLists: accessLists}, trace.Wrap(err)
 	case types.KindVnetConfig:
 		vnetConfig, err := client.VnetConfigClient().GetVnetConfig(ctx)
 		if err != nil {

--- a/tool/tctl/common/resources/accesslist.go
+++ b/tool/tctl/common/resources/accesslist.go
@@ -1,0 +1,175 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/accesslists"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type accessListCollection struct {
+	accessLists []*accesslist.AccessList
+}
+
+func (c *accessListCollection) Resources() []types.Resource {
+	r := make([]types.Resource, len(c.accessLists))
+	for i, resource := range c.accessLists {
+		r[i] = resource
+	}
+	return r
+}
+
+func (c *accessListCollection) WriteText(w io.Writer, verbose bool) error {
+	t := asciitable.MakeTable([]string{"Name", "Title", "Review Frequency", "Next Audit Date"})
+	for _, al := range c.accessLists {
+		t.AddRow([]string{
+			accesslists.ScopeQualifiedName(al).String(),
+			al.Spec.Title,
+			al.Spec.Audit.Recurrence.Frequency.String(),
+			al.Spec.Audit.NextAuditDate.Format(time.RFC822),
+		})
+	}
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+func accessListHandler() Handler {
+	return Handler{
+		getHandler:    getUnscopedAccessList,
+		createHandler: createAccessList,
+		deleteHandler: deleteUnscopedAccessList,
+		singleton:     false,
+		mfaRequired:   true,
+		description:   "Used to grant roles or traits to users or other lists. Part of Identity Governance.",
+	}
+}
+
+func accessListScopedHandler() ScopedHandler {
+	return ScopedHandler{
+		getHandler:    getAccessList,
+		createHandler: createAccessList,
+		deleteHandler: deleteAccessList,
+		mfaRequired:   true,
+		description:   "Used to grant roles or traits to users or other lists. Part of Identity Governance.",
+	}
+}
+
+// getAccessList implements `tctl get accesslist /scope::my-list` command.
+func getAccessList(ctx context.Context, client *authclient.Client, subKind string, sqn *scopes.QualifiedName, opts GetOpts) (Collection, error) {
+	if subKind != "" {
+		return nil, rejectSubKind(types.KindAccessList, subKind)
+	}
+
+	if sqn != nil {
+		resource, err := client.AccessListClient().GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+			Scope: sqn.Scope,
+			Name:  sqn.Name,
+		}.Build())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &accessListCollection{accessLists: []*accesslist.AccessList{resource}}, nil
+	}
+
+	accessLists, err := stream.Collect(
+		clientutils.Resources(ctx, func(ctx context.Context, size int, token string) ([]*accesslist.AccessList, string, error) {
+			return client.AccessListClient().ListAccessListsV2(ctx,
+				accesslistv1.ListAccessListsV2Request_builder{
+					PageSize:  int32(size),
+					PageToken: token,
+					ScopeFilter: scopesv1.Filter_builder{
+						Mode: scopesv1.Mode_MODE_ALL,
+					}.Build(),
+				}.Build())
+		}),
+	)
+
+	return &accessListCollection{accessLists: accessLists}, trace.Wrap(err)
+}
+
+// getUnscopedAccessList implements `tctl get accesslist/my-list` command.
+func getUnscopedAccessList(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
+	if ref.Name != "" {
+		return getAccessList(ctx, client, ref.SubKind, &scopes.QualifiedName{Name: ref.Name}, opts)
+	}
+	return getAccessList(ctx, client, ref.SubKind, nil, opts)
+}
+
+// createAccessList implements `tctl create accesslist/my-list` command.
+func createAccessList(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	accessList, err := services.UnmarshalAccessList(raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = client.AccessListClient().GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Scope: accessList.GetScope(),
+		Name:  accessList.GetName(),
+	}.Build())
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+	exists := (err == nil)
+
+	if exists && !opts.Force {
+		return trace.AlreadyExists("Access list %q already exists", accessList.GetName())
+	}
+
+	if _, err := client.AccessListClient().UpsertAccessList(ctx, accessList); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("Access list %q has been %s\n", accessList.GetName(), upsertVerb(exists, opts.Force))
+
+	return nil
+
+}
+
+// deleteAccessList implements `tctl rm accesslist /scope::my-list` command.
+func deleteAccessList(ctx context.Context, client *authclient.Client, subKind string, sqn scopes.QualifiedName) error {
+	if subKind != "" {
+		return rejectSubKind(types.KindAccessList, subKind)
+	}
+
+	if err := client.AccessListClient().DeleteAccessListV2(ctx, accesslistv1.DeleteAccessListRequest_builder{
+		Scope: sqn.Scope,
+		Name:  sqn.Name,
+	}.Build()); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("Access list %q has been deleted\n", sqn.String())
+	return nil
+}
+
+func deleteUnscopedAccessList(ctx context.Context, client *authclient.Client, ref services.Ref) error {
+	return deleteAccessList(ctx, client, ref.SubKind, scopes.QualifiedName{Name: ref.Name})
+}

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -36,6 +36,7 @@ func Handlers() map[string]Handler {
 	// Note: scoped_role, scoped_role_assignment, and scoped_token are registered in
 	// ScopedHandlers() rather than here because they require scope-qualified names.
 	return map[string]Handler{
+		types.KindAccessList:          accessListHandler(),
 		types.KindClientIPRestriction: clientIPRestrictionHandler(),
 		types.KindNode:                serverHandler(),
 	}

--- a/tool/tctl/common/resources/scoped_handler.go
+++ b/tool/tctl/common/resources/scoped_handler.go
@@ -38,6 +38,7 @@ func ScopedHandlers() map[string]ScopedHandler {
 		scopedaccess.KindScopedRole:           scopedRoleScopedHandler(),
 		types.KindScopedToken:                 scopedTokenScopedHandler(),
 		scopedaccess.KindScopedRoleAssignment: scopedRoleAssignmentScopedHandler(),
+		types.KindAccessList:                  accessListScopedHandler(),
 	}
 }
 


### PR DESCRIPTION
Part of [RFD 308](https://github.com/gravitational/rfd/pull/22).

This PR backports support for scoped access lists to branch/v18. This includes the following PRs originally merged to master:
- https://github.com/gravitational/teleport/pull/67988
- https://github.com/gravitational/teleport/pull/67989
- https://github.com/gravitational/teleport/pull/68409
- https://github.com/gravitational/teleport/pull/67990
- https://github.com/gravitational/teleport/pull/68030
- https://github.com/gravitational/teleport/pull/68031
- https://github.com/gravitational/teleport/pull/68095
- https://github.com/gravitational/teleport/pull/68179
- https://github.com/gravitational/teleport/pull/68477
- https://github.com/gravitational/teleport/pull/68478
- https://github.com/gravitational/teleport/pull/68724
- https://github.com/gravitational/teleport/pull/68696
- https://github.com/gravitational/teleport/pull/68479
- https://github.com/gravitational/teleport/pull/68480
- https://github.com/gravitational/teleport/pull/68564
- https://github.com/gravitational/teleport/pull/68567
- https://github.com/gravitational/teleport/pull/68568

Manually tested with the test plan at https://github.com/gravitational/teleport.e/pull/9198 (enterprise features are required)

Changelog: Added scopes to access lists
