### PR TITLE
[v18] Fix slack plugin http client transport setting

### DIFF
--- a/integrations/access/slack/http.go
+++ b/integrations/access/slack/http.go
@@ -33,12 +33,10 @@ func makeSlackClient(apiURL string) *resty.Client {
 			Transport: &http.Transport{
 				MaxConnsPerHost:     slackMaxConns,
 				MaxIdleConnsPerHost: slackMaxConns,
+				Proxy:               http.ProxyFromEnvironment,
 			},
 		}).
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetBaseURL(apiURL).
-		SetTransport(&http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-		})
+		SetBaseURL(apiURL)
 }


### PR DESCRIPTION
Backport #68556 to branch/v18

changelog: Improved reliability of Teleport Slack plugin under high Slack API request volume
