### PR TITLE
Enforce label boundary when matching FQDN to proxy

### DIFF
--- a/lib/web/app/match.go
+++ b/lib/web/app/match.go
@@ -21,9 +21,12 @@ package app
 import (
 	"context"
 	"math/rand/v2"
+	"net"
+	"strconv"
 	"strings"
 
 	"github.com/gravitational/trace"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -120,6 +123,11 @@ func ResolveFQDN(
 	fqdn string,
 	canAccess func(types.Application) bool,
 ) (types.AppServer, string, error) {
+	hostname, err := validateFQDN(fqdn)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
 	clusterClient, err := clusterGetter.Cluster(ctx, localClusterName)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
@@ -136,21 +144,19 @@ func ResolveFQDN(
 			// In the case where FindMatchingProxyDNS finds an actual found proxy match, this check is redundant.
 			// In the case where it finds no matches, FindMatchingProxyDNS returns the first element of proxyDNSNames,
 			// we must recheck to make sure that the proxy found matches, and reject if it doesn't.
-			host := strings.Split(fqdn, ":")[0]
 			proxyMatch := strings.Split(utils.FindMatchingProxyDNS(fqdn, proxyDNSNames), ":")[0]
-			if !isHostUnderProxy(host, proxyMatch) {
+			if !hostIsProxyOrSubdomain(hostname, proxyMatch) {
 				return nil, "", trace.BadParameter("FQDN %q is not a subdomain of the proxy", fqdn)
 			}
 		}
 		return srv, localClusterName, nil
 	}
 
-	host := strings.Split(fqdn, ":")[0]
 	proxyPublicAddr := strings.Split(utils.FindMatchingProxyDNS(fqdn, proxyDNSNames), ":")[0]
-	if !isHostUnderProxy(host, proxyPublicAddr) {
+	if !hostIsProxyOrSubdomain(hostname, proxyPublicAddr) {
 		return nil, "", trace.BadParameter("FQDN %q is not a subdomain of the proxy", fqdn)
 	}
-	appName := strings.TrimSuffix(host, "."+proxyPublicAddr)
+	appName := strings.TrimSuffix(hostname, "."+proxyPublicAddr)
 
 	// Loop over all clusters and try and match application name to an
 	// application within the cluster. This also includes the local cluster.
@@ -168,8 +174,27 @@ func ResolveFQDN(
 	return nil, "", trace.NotFound("failed to resolve %v to any application within any cluster", fqdn)
 }
 
-// isHostUnderProxy tells whether host is the proxy DNS name itself or a subdomain of it.
-func isHostUnderProxy(host, proxy string) bool {
+// validateFQDN checks that fqdn is a well-formed hostname with an optional
+// numeric port and returns its hostname without the port.
+func validateFQDN(fqdn string) (string, error) {
+	hostname := fqdn
+	// An error here means the fqdn isn't in proper host:port form. In that case
+	// let the hostname check below reject anything bad.
+	if h, port, err := net.SplitHostPort(fqdn); err == nil {
+		if _, err := strconv.ParseUint(port, 10, 16); err != nil {
+			return "", trace.BadParameter("invalid FQDN %q", fqdn)
+		}
+		hostname = h
+	}
+	if errs := validation.IsDNS1123SubdomainWithUnderscore(hostname); len(errs) > 0 {
+		return "", trace.BadParameter("invalid FQDN %q", fqdn)
+	}
+	return hostname, nil
+}
+
+// hostIsProxyOrSubdomain returns true if the host is the proxy DNS name
+// itself or if it's a subdomain of the proxy.
+func hostIsProxyOrSubdomain(host, proxy string) bool {
 	return host == proxy || strings.HasSuffix(host, "."+proxy)
 }
 

--- a/lib/web/app/match.go
+++ b/lib/web/app/match.go
@@ -123,7 +123,7 @@ func ResolveFQDN(
 	fqdn string,
 	canAccess func(types.Application) bool,
 ) (types.AppServer, string, error) {
-	hostname, err := validateFQDN(fqdn)
+	hostname, err := extractHostname(fqdn)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -174,9 +174,9 @@ func ResolveFQDN(
 	return nil, "", trace.NotFound("failed to resolve %v to any application within any cluster", fqdn)
 }
 
-// validateFQDN checks that fqdn is a well-formed hostname with an optional
+// extractHostname checks that fqdn is a well-formed hostname with an optional
 // numeric port and returns its hostname without the port.
-func validateFQDN(fqdn string) (string, error) {
+func extractHostname(fqdn string) (string, error) {
 	hostname := fqdn
 	// An error here means the fqdn isn't in proper host:port form. In that case
 	// let the hostname check below reject anything bad.

--- a/lib/web/app/match.go
+++ b/lib/web/app/match.go
@@ -20,7 +20,6 @@ package app
 
 import (
 	"context"
-	"fmt"
 	"math/rand/v2"
 	"strings"
 
@@ -134,23 +133,24 @@ func ResolveFQDN(
 		// suffix, so confirm the FQDN actually sits under a configured proxy DNS name before trusting a
 		// scoped match, otherwise "<hash>.somewebsite.com" resolves.
 		if srv.GetApp().GetScope() != "" {
-			host := strings.Split(fqdn, ":")[0]
 			// In the case where FindMatchingProxyDNS finds an actual found proxy match, this check is redundant.
 			// In the case where it finds no matches, FindMatchingProxyDNS returns the first element of proxyDNSNames,
 			// we must recheck to make sure that the proxy found matches, and reject if it doesn't.
+			host := strings.Split(fqdn, ":")[0]
 			proxyMatch := strings.Split(utils.FindMatchingProxyDNS(fqdn, proxyDNSNames), ":")[0]
-			if host != proxyMatch && !strings.HasSuffix(host, "."+proxyMatch) {
+			if !isHostUnderProxy(host, proxyMatch) {
 				return nil, "", trace.BadParameter("FQDN %q is not a subdomain of the proxy", fqdn)
 			}
 		}
 		return srv, localClusterName, nil
 	}
 
-	proxyPublicAddr := utils.FindMatchingProxyDNS(fqdn, proxyDNSNames)
-	if !strings.HasSuffix(fqdn, proxyPublicAddr) {
+	host := strings.Split(fqdn, ":")[0]
+	proxyPublicAddr := strings.Split(utils.FindMatchingProxyDNS(fqdn, proxyDNSNames), ":")[0]
+	if !isHostUnderProxy(host, proxyPublicAddr) {
 		return nil, "", trace.BadParameter("FQDN %q is not a subdomain of the proxy", fqdn)
 	}
-	appName := strings.TrimSuffix(fqdn, fmt.Sprintf(".%s", proxyPublicAddr))
+	appName := strings.TrimSuffix(host, "."+proxyPublicAddr)
 
 	// Loop over all clusters and try and match application name to an
 	// application within the cluster. This also includes the local cluster.
@@ -166,6 +166,11 @@ func ResolveFQDN(
 	}
 
 	return nil, "", trace.NotFound("failed to resolve %v to any application within any cluster", fqdn)
+}
+
+// isHostUnderProxy tells whether host is the proxy DNS name itself or a subdomain of it.
+func isHostUnderProxy(host, proxy string) bool {
+	return host == proxy || strings.HasSuffix(host, "."+proxy)
 }
 
 // pickAppServer chooses one app server from a set of matches. When canAccess is

--- a/lib/web/app/match_test.go
+++ b/lib/web/app/match_test.go
@@ -25,7 +25,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	scopedapp "github.com/gravitational/teleport/lib/scopes/app"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/readonly"
 )
 
 func TestMatchAppServerForRoute(t *testing.T) {
@@ -206,7 +209,7 @@ func TestHostIsProxyOrSubdomain(t *testing.T) {
 	}
 }
 
-func TestValidateFQDN(t *testing.T) {
+func TestExtractHostname(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {
 		desc         string
@@ -267,7 +270,7 @@ func TestValidateFQDN(t *testing.T) {
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			host, err := validateFQDN(test.fqdn)
+			host, err := extractHostname(test.fqdn)
 			if test.wantErr {
 				require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
 				return
@@ -276,6 +279,42 @@ func TestValidateFQDN(t *testing.T) {
 			require.Equal(t, test.wantHostname, host)
 		})
 	}
+}
+
+// emptyCluster is a minimal reversetunnelclient.Cluster without an app-server watcher.
+type emptyCluster struct {
+	reversetunnelclient.Cluster
+	name string
+}
+
+func (c emptyCluster) GetName() string { return c.name }
+
+func (c emptyCluster) AppServerWatcher() (*services.GenericWatcher[types.AppServer, readonly.AppServer], error) {
+	return nil, trace.NotFound("no app server watcher in test")
+}
+
+// TestResolveFQDN_ProxyWithPort verifies that a request under a proxy whose DNS
+// name includes a port does not get rejected as BadParameter.
+func TestResolveFQDN_ProxyWithPort(t *testing.T) {
+	t.Parallel()
+
+	getter := &reversetunnelclient.FakeServer{
+		FakeClusters: []reversetunnelclient.Cluster{emptyCluster{name: "local"}},
+	}
+	proxyDNSNames := []string{"proxy.example.com:3080"}
+
+	_, _, err := ResolveFQDN(
+		t.Context(),
+		getter,
+		"local",
+		proxyDNSNames,
+		"myapp.proxy.example.com",
+		nil,
+	)
+
+	require.Error(t, err)
+	require.False(t, trace.IsBadParameter(err),
+		"proxy with port must not be rejected, got %v", err)
 }
 
 func TestPickAppServer(t *testing.T) {

--- a/lib/web/app/match_test.go
+++ b/lib/web/app/match_test.go
@@ -21,6 +21,7 @@ package app
 import (
 	"testing"
 
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -151,7 +152,7 @@ func TestMatchAppServerForRoute(t *testing.T) {
 	}
 }
 
-func TestIsHostUnderProxy(t *testing.T) {
+func TestHostIsProxyOrSubdomain(t *testing.T) {
 	t.Parallel()
 	const proxy = "teleport.example.com"
 	for _, test := range []struct {
@@ -200,7 +201,79 @@ func TestIsHostUnderProxy(t *testing.T) {
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			require.Equal(t, test.want, isHostUnderProxy(test.host, test.proxy))
+			require.Equal(t, test.want, hostIsProxyOrSubdomain(test.host, test.proxy))
+		})
+	}
+}
+
+func TestValidateFQDN(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		desc         string
+		fqdn         string
+		wantHostname string
+		wantErr      bool
+	}{
+		{
+			desc:         "plain hostname",
+			fqdn:         "blah.teleport.example.com",
+			wantHostname: "blah.teleport.example.com",
+		},
+		{
+			desc:         "numeric port is stripped",
+			fqdn:         "blah.teleport.example.com:8443",
+			wantHostname: "blah.teleport.example.com",
+		},
+		{
+			// App names may contain underscores and start with a digit
+			desc:         "underscore in app label",
+			fqdn:         "my_app.teleport.example.com",
+			wantHostname: "my_app.teleport.example.com",
+		},
+		{
+			desc:         "label starting with a digit",
+			fqdn:         "1stapp.teleport.example.com",
+			wantHostname: "1stapp.teleport.example.com",
+		},
+		{
+			desc:         "all-digit label",
+			fqdn:         "123.teleport.example.com",
+			wantHostname: "123.teleport.example.com",
+		},
+		{
+			desc:    "suffix disguised as a port",
+			fqdn:    "bloo.example.com:443@malicious.com",
+			wantErr: true,
+		},
+		{
+			desc:    "empty port",
+			fqdn:    "bloo.example.com:",
+			wantErr: true,
+		},
+		{
+			desc:    "empty host",
+			fqdn:    ":443",
+			wantErr: true,
+		},
+		{
+			desc:    "too many colons",
+			fqdn:    "a:b:c",
+			wantErr: true,
+		},
+		{
+			desc:    "empty string",
+			fqdn:    "",
+			wantErr: true,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			host, err := validateFQDN(test.fqdn)
+			if test.wantErr {
+				require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.wantHostname, host)
 		})
 	}
 }

--- a/lib/web/app/match_test.go
+++ b/lib/web/app/match_test.go
@@ -151,6 +151,60 @@ func TestMatchAppServerForRoute(t *testing.T) {
 	}
 }
 
+func TestIsHostUnderProxy(t *testing.T) {
+	t.Parallel()
+	const proxy = "teleport.example.com"
+	for _, test := range []struct {
+		desc  string
+		host  string
+		proxy string
+		want  bool
+	}{
+		{
+			desc:  "exact match",
+			host:  proxy,
+			proxy: proxy,
+			want:  true,
+		},
+		{
+			desc:  "subdomain",
+			host:  "app.teleport.example.com",
+			proxy: proxy,
+			want:  true,
+		},
+		{
+			desc:  "multi-label subdomain",
+			host:  "a.b.teleport.example.com",
+			proxy: proxy,
+			want:  true,
+		},
+		{
+			// The bug this guards against: a raw suffix check would accept this
+			// because it ends in "teleport.example.com" with no label boundary.
+			desc:  "no label boundary",
+			host:  "evilteleport.example.com",
+			proxy: proxy,
+			want:  false,
+		},
+		{
+			desc:  "proxy name as a lower-level domain",
+			host:  "teleport.example.com.evil.com",
+			proxy: proxy,
+			want:  false,
+		},
+		{
+			desc:  "unrelated domain",
+			host:  "app.somewebsite.com",
+			proxy: proxy,
+			want:  false,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			require.Equal(t, test.want, isHostUnderProxy(test.host, test.proxy))
+		})
+	}
+}
+
 func TestPickAppServer(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`ResolveFQDN` previously did not check the domain label when matching FQDN to proxy.

Fixes https://github.com/gravitational/pressure-washing/issues/415


## Manual Test Plan
### Test Environment
Tested locally with acme enabled, `https_keypairs` disabled, and `localhost.example.com:443` as the first option listed under `proxy_service: public_addr` on in `teleport.yaml` and this edit under `lib/service/acme.go/checkHost`
```go
defer func() {
		slog.WarnContext(ctx, "ACME host policy decision", "host", host, "allowed", err == nil, "error", err)
	}()
```
Also dynamically create app via `tctl` with the name `evillocalhost.example.com` and another with `debug-app`
### Test Cases


- [x] ACME cert issuance still works and rejects bad input
  - [x] fixed unintended behavior (see comment in pressure-washing issue)

```
// General ACME cert issuance still works

// Valid app should pass
curl -sv -k --resolve debug-app.localhost.example.com:443:127.0.0.1 https://debug-app.localhost.example.com/ 
// Nonexistent app name should fail at check
curl -sv -k --resolve nonexistent.localhost.example.com:443:127.0.0.1 https://nonexistent.localhost.example.com/ 
// Invalid suffix should fail at check
curl -sv -k --resolve debug-app.localhost.example.com.evil.com:443:127.0.0.1 https://debug-app.localhost.example.com.evil.com/

// New behavior should now reject this case (previously passes)
// Note that the correct way to call this would be evillocalhost.example.com.localhost.example.com
curl -k --resolve evillocalhost.example.com:443:127.0.0.1 https://evillocalhost.example.com/
```

