### PR TITLE
iOS: Add "Delete all clusters" button

### DIFF
--- a/mobile/Verify/Verify/App Lifecycle/VerifyApp.swift
+++ b/mobile/Verify/Verify/App Lifecycle/VerifyApp.swift
@@ -79,7 +79,6 @@ struct VerifyApp: App {
 	var body: some Scene {
 		WindowGroup {
 			LandingView(viewModel: appModel.landingViewModel)
-				.tint(.teleport)
 				.onOpenURL { url in
 					appModel.openDeepLink(url)
 				}

--- a/mobile/Verify/Verify/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/mobile/Verify/Verify/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.788",
+          "green" : "0.184",
+          "red" : "0.318"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.522",
+          "red" : "0.624"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/mobile/Verify/Verify/Features/Landing/LandingView.swift
+++ b/mobile/Verify/Verify/Features/Landing/LandingView.swift
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import Dependencies
+import SQLiteData
 import SwiftUI
 import SwiftUINavigation
 
@@ -43,6 +45,16 @@ struct LandingView: View {
 			}
 			.padding(.horizontal)
 			.background(Color.Background.depth3)
+			.toolbarVisibility(viewModel.shouldShowToolbar ? .visible : .hidden)
+			.toolbar {
+				ToolbarItem {
+					Menu {
+						Button("Hello") {}
+					} label: {
+						Label("Menu", systemImage: "ellipsis")
+					}
+				}
+			}
 
 			// MARK: Navigation
 
@@ -61,8 +73,17 @@ struct LandingView: View {
 	}
 }
 
-#Preview("Landing") {
+#Preview("Pre-enrollment") {
+	LandingView(viewModel: LandingViewModel())
+}
+
+#Preview("Post-enrollment") {
 	@Previewable @State
-	var viewModel = LandingViewModel()
+	var viewModel = withDependencies {
+		$0.defaultDatabase = AppDatabase.makePreviewDatabase()
+	} operation: {
+		LandingViewModel()
+	}
+
 	LandingView(viewModel: viewModel)
 }

--- a/mobile/Verify/Verify/Features/Landing/LandingView.swift
+++ b/mobile/Verify/Verify/Features/Landing/LandingView.swift
@@ -49,7 +49,12 @@ struct LandingView: View {
 			.toolbar {
 				ToolbarItem {
 					Menu {
-						Button("Hello") {}
+						Button(
+							"Delete all clusters",
+							systemImage: "trash",
+							role: .destructive,
+							action: viewModel.userTappedDeleteAllClusters,
+						)
 					} label: {
 						Label("Menu", systemImage: "ellipsis")
 					}
@@ -65,6 +70,12 @@ struct LandingView: View {
 				EnrollCameraScannerView(viewModel: enrollCameraScannerViewModel)
 			}
 			.alert($viewModel.destination.notice) { _ in }
+			.alert($viewModel.destination.deleteAllClustersAlert) { action in
+				switch action {
+					case .confirm: Task { await viewModel.userConfirmedDeleteAllClusters() }
+					case .none: break
+				}
+			}
 
 			// MARK: Haptics
 

--- a/mobile/Verify/Verify/Features/Landing/LandingView.swift
+++ b/mobile/Verify/Verify/Features/Landing/LandingView.swift
@@ -50,7 +50,7 @@ struct LandingView: View {
 				ToolbarItem {
 					Menu {
 						Button(
-							"Delete all clusters",
+							"Delete All Clusters",
 							systemImage: "trash",
 							role: .destructive,
 							action: viewModel.userTappedDeleteAllClusters,

--- a/mobile/Verify/Verify/Features/Landing/LandingView.swift
+++ b/mobile/Verify/Verify/Features/Landing/LandingView.swift
@@ -50,10 +50,10 @@ struct LandingView: View {
 				ToolbarItem {
 					Menu {
 						Button(
-							"Delete All Clusters",
+							"Forget All Clusters",
 							systemImage: "trash",
 							role: .destructive,
-							action: viewModel.userTappedDeleteAllClusters,
+							action: viewModel.userTappedForgetAllClusters,
 						)
 					} label: {
 						Label("Menu", systemImage: "ellipsis")
@@ -70,9 +70,9 @@ struct LandingView: View {
 				EnrollCameraScannerView(viewModel: enrollCameraScannerViewModel)
 			}
 			.alert($viewModel.destination.notice) { _ in }
-			.alert($viewModel.destination.deleteAllClustersAlert) { action in
+			.alert($viewModel.destination.forgetAllClustersAlert) { action in
 				switch action {
-					case .confirm: Task { await viewModel.userConfirmedDeleteAllClusters() }
+					case .confirm: Task { await viewModel.userConfirmedForgetAllClusters() }
 					case .none: break
 				}
 			}

--- a/mobile/Verify/Verify/Features/Landing/LandingViewModel.swift
+++ b/mobile/Verify/Verify/Features/Landing/LandingViewModel.swift
@@ -28,6 +28,7 @@ final class LandingViewModel {
 	@CasePathable
 	enum Destination {
 		case cameraScanner(EnrollCameraScannerViewModel)
+		case deleteAllClustersAlert(AlertState<DeleteAllClustersAlertAction>)
 		case enrollDevice(EnrollDeviceViewModel)
 		case notice(AlertState<Void>)
 	}
@@ -46,6 +47,14 @@ final class LandingViewModel {
 
 	var destination: Destination? = nil
 	var sensoryFeedbackTrigger = false
+}
+
+// MARK: - LandingViewModel.DeleteAllClustersAlertAction
+
+extension LandingViewModel {
+	enum DeleteAllClustersAlertAction {
+		case confirm
+	}
 }
 
 // MARK: - UI Helper
@@ -83,24 +92,28 @@ extension LandingViewModel {
 	}
 
 	func userDeletedClusters(at indexSet: IndexSet) async {
-		let clustersToDelete = clusters.values(at: indexSet)
-		do {
-			try await database.write { db in
-				for clusterToDelete in clustersToDelete {
-					try Cluster.delete(clusterToDelete).execute(db)
-				}
-			}
-		} catch {
-			Self.logger.warning("Failed to delete clusters: \(error)")
-			destination = .notice(AlertState(
-				title: {
-					TextState("Could Not Delete Clusters")
-				},
-				message: {
-					TextState("An error occurred when trying to deregister the cluster from your device.")
-				},
-			))
+		let idsToDelete = clusters.values(at: indexSet).map(\.id)
+		await deleteClusters {
+			Cluster
+				.delete()
+				.where { idsToDelete.contains($0.id) }
 		}
+	}
+
+	func userTappedDeleteAllClusters() {
+		let alertState = AlertState<DeleteAllClustersAlertAction> {
+			TextState("Are you sure you want to unenroll your device from all clusters?")
+		} actions: {
+			ButtonState(role: .destructive, action: .confirm) { TextState("Confirm") }
+			ButtonState(role: .cancel) { TextState("Cancel") }
+		} message: {
+			TextState("This action cannot be undone. You will need to re-enroll this device with each cluster.")
+		}
+		destination = .deleteAllClustersAlert(alertState)
+	}
+
+	func userConfirmedDeleteAllClusters() async {
+		await deleteClusters { Cluster.delete() }
 	}
 }
 
@@ -141,5 +154,28 @@ extension LandingViewModel: EnrollCameraScannerViewModel.Delegate {
 	) {
 		sensoryFeedbackTrigger.toggle()
 		destination = .enrollDevice(EnrollDeviceViewModel(deepLink: deepLink, delegate: self))
+	}
+}
+
+// MARK: - Private Helpers
+
+extension LandingViewModel {
+	/// A helper function that encapsulates running a cluster deletion and showing an error upon failure.
+	private func deleteClusters(using deleteOperation: @Sendable () -> DeleteOf<Cluster>) async {
+		do {
+			try await database.write { db in
+				try deleteOperation().execute(db)
+			}
+		} catch {
+			Self.logger.warning("Failed to delete clusters: \(error)")
+			destination = .notice(AlertState(
+				title: {
+					TextState("Could Not Delete Clusters")
+				},
+				message: {
+					TextState("An error occurred when trying to deregister the cluster from your device.")
+				},
+			))
+		}
 	}
 }

--- a/mobile/Verify/Verify/Features/Landing/LandingViewModel.swift
+++ b/mobile/Verify/Verify/Features/Landing/LandingViewModel.swift
@@ -54,6 +54,10 @@ extension LandingViewModel {
 	var shouldShowPreEnrollmentLanding: Bool {
 		clusters.isEmpty
 	}
+
+	var shouldShowToolbar: Bool {
+		!shouldShowPreEnrollmentLanding
+	}
 }
 
 // MARK: - User Actions

--- a/mobile/Verify/Verify/Features/Landing/LandingViewModel.swift
+++ b/mobile/Verify/Verify/Features/Landing/LandingViewModel.swift
@@ -28,8 +28,8 @@ final class LandingViewModel {
 	@CasePathable
 	enum Destination {
 		case cameraScanner(EnrollCameraScannerViewModel)
-		case deleteAllClustersAlert(AlertState<DeleteAllClustersAlertAction>)
 		case enrollDevice(EnrollDeviceViewModel)
+		case forgetAllClustersAlert(AlertState<ForgetAllClustersAlertAction>)
 		case notice(AlertState<Void>)
 	}
 
@@ -49,10 +49,10 @@ final class LandingViewModel {
 	var sensoryFeedbackTrigger = false
 }
 
-// MARK: - LandingViewModel.DeleteAllClustersAlertAction
+// MARK: - LandingViewModel.ForgetAllClustersAlertAction
 
 extension LandingViewModel {
-	enum DeleteAllClustersAlertAction {
+	enum ForgetAllClustersAlertAction {
 		case confirm
 	}
 }
@@ -100,19 +100,24 @@ extension LandingViewModel {
 		}
 	}
 
-	func userTappedDeleteAllClusters() {
-		let alertState = AlertState<DeleteAllClustersAlertAction> {
-			TextState("Are you sure you want to unenroll your device from all clusters?")
+	func userTappedForgetAllClusters() {
+		let alertState = AlertState<ForgetAllClustersAlertAction> {
+			TextState("Are you sure you want to forget all clusters?")
 		} actions: {
 			ButtonState(role: .destructive, action: .confirm) { TextState("Confirm") }
 			ButtonState(role: .cancel) { TextState("Cancel") }
 		} message: {
-			TextState("This action cannot be undone. You will need to re-enroll this device with each cluster.")
+			TextState(
+				"""
+				This action cannot be undone. You will still be able to authenticate using this device until you \
+				remove it from your trusted devices in Account Settings in the web UI.
+				""",
+			)
 		}
-		destination = .deleteAllClustersAlert(alertState)
+		destination = .forgetAllClustersAlert(alertState)
 	}
 
-	func userConfirmedDeleteAllClusters() async {
+	func userConfirmedForgetAllClusters() async {
 		await deleteClusters { Cluster.delete() }
 	}
 }
@@ -167,13 +172,13 @@ extension LandingViewModel {
 				try deleteOperation().execute(db)
 			}
 		} catch {
-			Self.logger.warning("Failed to delete clusters: \(error)")
+			Self.logger.warning("Failed to forget clusters: \(error)")
 			destination = .notice(AlertState(
 				title: {
-					TextState("Could Not Delete Clusters")
+					TextState("Could Not Forget Clusters")
 				},
 				message: {
-					TextState("An error occurred when trying to deregister the cluster from your device.")
+					TextState("An error occurred when trying to forget the cluster on this device.")
 				},
 			))
 		}

--- a/mobile/Verify/Verify/Persistence/AppDatabase.swift
+++ b/mobile/Verify/Verify/Persistence/AppDatabase.swift
@@ -90,12 +90,6 @@ extension AppDatabase {
 		return database
 	}
 
-	/// An in-memory database that can be used when persisting to disk isn't appropriate, such as in SwiftUI Previews.
-	///
-	/// This property will always return the same in-memory database when called multiple times. If a brand new
-	/// in-memory database is explicitly required, call `makeInMemoryDatabase()` instead.
-	static let inMemory: any DatabaseWriter = makeInMemoryDatabase()
-
 	/// Initializes an in-memory database suitable for scenarios where persistence across runs is not required.
 	static func makeInMemoryDatabase() -> any DatabaseWriter {
 		do {
@@ -109,6 +103,25 @@ extension AppDatabase {
 		} catch {
 			fatalError("Error while initializing in-memory database: \(error)")
 		}
+	}
+
+	/// Initializes an in-memory database with some dummy values pre-populated values for SwiftUI previews.
+	static func makePreviewDatabase() -> any DatabaseWriter {
+		let database = makeInMemoryDatabase()
+
+		do {
+			try database.write { db in
+				try Cluster.insert { Cluster.previews }.execute(db)
+			}
+		} catch {
+			// We `print(...)` to the console instead of calling `logger.error(...)` because the SwiftUI preview console
+			// only sees stdout.
+			let errorMessage = "Failed to seed preview database: \(error)"
+			print(errorMessage)
+			fatalError(errorMessage)
+		}
+
+		return database
 	}
 }
 

--- a/mobile/Verify/Verify/Persistence/Models/Cluster.swift
+++ b/mobile/Verify/Verify/Persistence/Models/Cluster.swift
@@ -41,3 +41,13 @@ extension Cluster {
 		return components.url
 	}
 }
+
+// MARK: - Preview Data
+
+extension Cluster {
+	static let previews: [Cluster] = [
+		Cluster(id: UUID(0), host: "production.teleport.example.com", port: 443),
+		Cluster(id: UUID(1), host: "staging.teleport.example.com", port: 3080),
+		Cluster(id: UUID(2), host: "development.teleport.example.com", port: 443),
+	]
+}


### PR DESCRIPTION
This PR adds a new toolbar item at the top of the landing view which contains a menu where we can put relevant global actions. For now, it just contains a "Delete all clusters" button. While this button wasn't strictly in the designs, it could be generally useful for anyone trying to troubleshoot an issue.

This is also a good thing to implement as it demonstrates more sophisticated ways of using `SwiftNavigation` to wire together complex things like an alert with multiple buttons in a testable way.

Lastly, but perhaps most importantly for the immediate future, is that putting this menu here gives me a surface in which I can add an entrypoint to a "debug view". In order to keep making forward progress on the app without backend code being quite ready, I need a surface where I can create full features that don't actually get shipped in the app. The `Menu` I added to `LandingView` will sneakily be that entrypoint, but it will be guarded behind `#if DEBUG` flags, and won't come until my next PR. Stay tuned!

In the meantime, here's a video of the deletion confirmation alert in action:



https://github.com/user-attachments/assets/8af3900d-7808-4d6a-9540-af91027973c6

