### PR TITLE
Lock qoiz encoding/decoding behind build tags / cargo feature

### DIFF
--- a/lib/srv/desktop/linux_server.go
+++ b/lib/srv/desktop/linux_server.go
@@ -898,9 +898,9 @@ func (sess *linuxSession) innerProcessScreenChanges() (int, error) {
 			return 0, trace.Wrap(err, "couldn't get image from backend")
 		}
 
-		//nolint:staticcheck
+		//nolint:staticcheck // TODO(rhammonds): Eventually we'll remove the stubbed out qoiz encoder and restore linting
 		frames, err := rdpclient.EncodeQOIZ(img.Pix, uint16(change.X), uint16(change.Y), change.Width, change.Height)
-		//nolint:staticcheck
+		//nolint:staticcheck // TODO(rhammonds): Eventually we'll remove the stubbed out qoiz encoder and restore linting
 		if err != nil {
 			return 0, trace.Wrap(err, "couldn't encode image frame")
 		}

--- a/lib/srv/desktop/linux_server.go
+++ b/lib/srv/desktop/linux_server.go
@@ -898,7 +898,9 @@ func (sess *linuxSession) innerProcessScreenChanges() (int, error) {
 			return 0, trace.Wrap(err, "couldn't get image from backend")
 		}
 
+		//nolint:staticcheck
 		frames, err := rdpclient.EncodeQOIZ(img.Pix, uint16(change.X), uint16(change.Y), change.Width, change.Height)
+		//nolint:staticcheck
 		if err != nil {
 			return 0, trace.Wrap(err, "couldn't encode image frame")
 		}

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -45,13 +45,12 @@ reqwest = { version = "0.13", default-features = false }
 rustls = { version = "0.23.40", default-features = false, features = [
     "aws-lc-rs",
 ] }
-qoi = "0.4.1"
-zstd = "0.13.3"
+qoi  = { version = "0.4.1",  optional = true }
+zstd = { version = "0.13.3", optional = true }
 
 [dev-dependencies]
 ironrdp-graphics.workspace = true
 ironrdp-session.workspace = true
-ironrdp-session.features = ["qoiz"]
 base64 = "0.22.1"
 
 [build-dependencies]
@@ -60,3 +59,4 @@ tempfile = "3.27.0"
 
 [features]
 fips = ["tokio-boring/fips", "boring/fips"]
+desktop-encoder = ["dep:qoi", "dep:zstd", "ironrdp-session/qoiz"]

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -1341,34 +1341,3 @@ func isEmpty(b bool) C.uint8_t {
 func (c *Client) DisableNLA() {
 	c.cfg.NLA = false
 }
-
-// EncodeQOIZ encodes changed frame to series of FastPath SetSurface PDUs using QOIZ codec.
-// Resulting frames can be consumed directly by the FastPath processor from IronRDP if qoiz
-// feature is enabled in ironrdp-session crate
-func EncodeQOIZ(frame []byte, x, y, width, height uint16) ([]*tdpb.FastPathPDU, error) {
-	if len(frame) == 0 {
-		return nil, nil
-	}
-	if len(frame) != int(width)*int(height)*4 {
-		return nil, trace.BadParameter("incorrect frame size")
-	}
-	data := unsafe.SliceData(frame)
-	encodingResult := C.encode_qoiz((*C.uint8_t)(data), C.uint16_t(x), C.uint16_t(y), C.uint16_t(width), C.uint16_t(height))
-	defer C.free_encoding_result(encodingResult)
-	if encodingResult.error_code != C.ErrCodeSuccess {
-		msg := C.GoBytes(unsafe.Pointer(encodingResult.error_msg), C.int(encodingResult.length))
-		return nil, trace.Errorf("Couldn't encode frame: %s", string(msg))
-	}
-	pdus := unsafe.Slice((*C.Pdu)(encodingResult.pdus), encodingResult.length)
-	messages := make([]*tdpb.FastPathPDU, 0, encodingResult.length)
-	for _, frame := range pdus {
-		messages = append(messages, &tdpb.FastPathPDU{
-			Pdu: C.GoBytes(unsafe.Pointer(frame.data), C.int(frame.length)),
-		})
-	}
-	return messages, nil
-}
-
-func EncodeQOIZAvailable() bool {
-	return true
-}

--- a/lib/srv/desktop/rdp/rdpclient/client_nop.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_nop.go
@@ -71,14 +71,3 @@ func PrepareConnecton(_ string, _ *tdp.Conn, _ *slog.Logger) (tdp.MessageReadWri
 
 // DisableNLA disables NLA in the client configuration.
 func (c *Client) DisableNLA() {}
-
-// EncodeQOIZ encodes changed frame to series of FastPath SetSurface PDUs using QOIZ codec.
-// Resulting frames can be consumed directly by the FastPath processor from IronRDP if qoiz
-// feature is enabled in ironrdp-session crate
-func EncodeQOIZ(frame []byte, x, y, width, height uint16) ([]*tdpb.FastPathPDU, error) {
-	return nil, errors.New("the real rdpclient implementation was not included in this build")
-}
-
-func EncodeQOIZAvailable() bool {
-	return false
-}

--- a/lib/srv/desktop/rdp/rdpclient/client_qoiz.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_qoiz.go
@@ -1,3 +1,5 @@
+//go:build desktop_access_rdp && desktop_encoder
+
 // Teleport
 // Copyright (C) 2026 Gravitational, Inc.
 //
@@ -13,8 +15,6 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-//go:build desktop_access_rdp && desktop_encoder
 
 package rdpclient
 

--- a/lib/srv/desktop/rdp/rdpclient/client_qoiz.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_qoiz.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 //go:build desktop_access_rdp && desktop_encoder
 
 package rdpclient

--- a/lib/srv/desktop/rdp/rdpclient/client_qoiz.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_qoiz.go
@@ -1,0 +1,46 @@
+//go:build desktop_access_rdp && desktop_encoder
+
+package rdpclient
+
+import (
+	"unsafe"
+
+	"github.com/gravitational/teleport/lib/srv/desktop/tdp/protocol/tdpb"
+	"github.com/gravitational/trace"
+)
+
+/*
+#include <librdpclient.h>
+*/
+import "C"
+
+// EncodeQOIZ encodes changed frame to series of FastPath SetSurface PDUs using QOIZ codec.
+// Resulting frames can be consumed directly by the FastPath processor from IronRDP if qoiz
+// feature is enabled in ironrdp-session crate
+func EncodeQOIZ(frame []byte, x, y, width, height uint16) ([]*tdpb.FastPathPDU, error) {
+	if len(frame) == 0 {
+		return nil, nil
+	}
+	if len(frame) != int(width)*int(height)*4 {
+		return nil, trace.BadParameter("incorrect frame size")
+	}
+	data := unsafe.SliceData(frame)
+	encodingResult := C.encode_qoiz((*C.uint8_t)(data), C.uint16_t(x), C.uint16_t(y), C.uint16_t(width), C.uint16_t(height))
+	defer C.free_encoding_result(encodingResult)
+	if encodingResult.error_code != C.ErrCodeSuccess {
+		msg := C.GoBytes(unsafe.Pointer(encodingResult.error_msg), C.int(encodingResult.length))
+		return nil, trace.Errorf("Couldn't encode frame: %s", string(msg))
+	}
+	pdus := unsafe.Slice((*C.Pdu)(encodingResult.pdus), encodingResult.length)
+	messages := make([]*tdpb.FastPathPDU, 0, encodingResult.length)
+	for _, frame := range pdus {
+		messages = append(messages, &tdpb.FastPathPDU{
+			Pdu: C.GoBytes(unsafe.Pointer(frame.data), C.int(frame.length)),
+		})
+	}
+	return messages, nil
+}
+
+func EncodeQOIZAvailable() bool {
+	return true
+}

--- a/lib/srv/desktop/rdp/rdpclient/client_qoiz_stub.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_qoiz_stub.go
@@ -19,8 +19,9 @@
 package rdpclient
 
 import (
-	"github.com/gravitational/teleport/lib/srv/desktop/tdp/protocol/tdpb"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/srv/desktop/tdp/protocol/tdpb"
 )
 
 func EncodeQOIZ(frame []byte, x, y, width, height uint16) ([]*tdpb.FastPathPDU, error) {

--- a/lib/srv/desktop/rdp/rdpclient/client_qoiz_stub.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_qoiz_stub.go
@@ -1,3 +1,5 @@
+//go:build !(desktop_access_rdp && desktop_encoder)
+
 // Teleport
 // Copyright (C) 2026 Gravitational, Inc.
 //
@@ -13,8 +15,6 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-//go:build !(desktop_access_rdp && desktop_encoder)
 
 package rdpclient
 

--- a/lib/srv/desktop/rdp/rdpclient/client_qoiz_stub.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_qoiz_stub.go
@@ -1,0 +1,14 @@
+//go:build !(desktop_access_rdp && desktop_encoder)
+
+package rdpclient
+
+import (
+	"github.com/gravitational/teleport/lib/srv/desktop/tdp/protocol/tdpb"
+	"github.com/gravitational/trace"
+)
+
+func EncodeQOIZ(frame []byte, x, y, width, height uint16) ([]*tdpb.FastPathPDU, error) {
+	return nil, trace.NotImplemented("qoiz encoding not built into this binary")
+}
+
+func EncodeQOIZAvailable() bool { return false }

--- a/lib/srv/desktop/rdp/rdpclient/client_qoiz_stub.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_qoiz_stub.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 //go:build !(desktop_access_rdp && desktop_encoder)
 
 package rdpclient

--- a/lib/srv/desktop/rdp/rdpclient/client_qoiz_test.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_qoiz_test.go
@@ -1,0 +1,68 @@
+//go:build desktop_access_rdp && desktop_encoder
+
+/*
+ * *
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package rdpclient
+
+import (
+	"math/rand/v2"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeQOIZ(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		frames, err := EncodeQOIZ(nil, 0, 0, 0, 0)
+		require.NoError(t, err)
+		require.Empty(t, frames)
+	})
+
+	t.Run("size mismatch", func(t *testing.T) {
+		_, err := EncodeQOIZ([]byte{0xFF}, 0, 0, 2, 5)
+		require.Error(t, err)
+	})
+
+	t.Run("single pixel", func(t *testing.T) {
+		// this test aim is to verify we get the same data as in tests on Rust side:
+		// encode_qoiz_single in encoder.rs
+		frames, err := EncodeQOIZ([]byte{0xFF, 0xFF, 0xFF, 0xFF}, 0, 0, 1, 1)
+		require.NoError(t, err)
+		require.Len(t, frames, 1)
+		require.Equal(t, []byte{0, 59, 4, 54, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 11, 1, 0, 1, 0, 32, 0, 0,
+			0, 40, 181, 47, 253, 0, 88, 185, 0, 0, 113, 111, 105, 102, 0, 0, 0, 1, 0, 0, 0, 1,
+			3, 0, 85, 0, 0, 0, 0, 0, 0, 0, 1}, frames[0].Pdu)
+	})
+
+	t.Run("random", func(t *testing.T) {
+		// test with random data to verify we get correct number of frames from Rust
+		data := make([]byte, 4*500*500)
+		for i := 0; i < 4*500*500; i += 4 {
+			data[i] = byte(rand.IntN(256))
+			data[i+1] = byte(rand.IntN(256))
+			data[i+2] = byte(rand.IntN(256))
+			data[i+3] = 0xFF
+		}
+
+		frames, err := EncodeQOIZ(data, 0, 0, 500, 500)
+		require.NoError(t, err)
+		require.Len(t, frames, 27)
+	})
+}

--- a/lib/srv/desktop/rdp/rdpclient/client_test.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_test.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"io"
 	"log/slog"
-	"math/rand/v2"
 	"testing"
 
 	"github.com/google/uuid"
@@ -140,44 +139,5 @@ func TestRDPClientID(t *testing.T) {
 		// test to ensure that we don't switch hash algorithms by mistake.
 		got := rdpClientIDToUint32Array[uint32](newRDPClientID(""))
 		require.Equal(t, expected, got)
-	})
-}
-
-func TestEncodeQOIZ(t *testing.T) {
-	t.Run("empty", func(t *testing.T) {
-		frames, err := EncodeQOIZ(nil, 0, 0, 0, 0)
-		require.NoError(t, err)
-		require.Empty(t, frames)
-	})
-
-	t.Run("size mismatch", func(t *testing.T) {
-		_, err := EncodeQOIZ([]byte{0xFF}, 0, 0, 2, 5)
-		require.Error(t, err)
-	})
-
-	t.Run("single pixel", func(t *testing.T) {
-		// this test aim is to verify we get the same data as in tests on Rust side:
-		// encode_qoiz_single in encoder.rs
-		frames, err := EncodeQOIZ([]byte{0xFF, 0xFF, 0xFF, 0xFF}, 0, 0, 1, 1)
-		require.NoError(t, err)
-		require.Len(t, frames, 1)
-		require.Equal(t, []byte{0, 59, 4, 54, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 11, 1, 0, 1, 0, 32, 0, 0,
-			0, 40, 181, 47, 253, 0, 88, 185, 0, 0, 113, 111, 105, 102, 0, 0, 0, 1, 0, 0, 0, 1,
-			3, 0, 85, 0, 0, 0, 0, 0, 0, 0, 1}, frames[0].Pdu)
-	})
-
-	t.Run("random", func(t *testing.T) {
-		// test with random data to verify we get correct number of frames from Rust
-		data := make([]byte, 4*500*500)
-		for i := 0; i < 4*500*500; i += 4 {
-			data[i] = byte(rand.IntN(256))
-			data[i+1] = byte(rand.IntN(256))
-			data[i+2] = byte(rand.IntN(256))
-			data[i+3] = 0xFF
-		}
-
-		frames, err := EncodeQOIZ(data, 0, 0, 500, 500)
-		require.NoError(t, err)
-		require.Len(t, frames, 27)
 	})
 }

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -49,6 +49,7 @@ use util::{from_c_string, from_go_array};
 pub mod client;
 mod cliprdr;
 mod license;
+#[cfg(feature = "desktop-encoder")]
 mod linux_desktop_encoder;
 mod network_client;
 mod piv;

--- a/web/packages/shared/libs/ironrdp/Cargo.toml
+++ b/web/packages/shared/libs/ironrdp/Cargo.toml
@@ -15,7 +15,6 @@ console_error_panic_hook = "0.1.7"
 getrandom1 = { package = "getrandom", version = "0.2", features = ["js"] }
 getrandom2 = { package = "getrandom", version = "0.4.2", features = ["wasm_js"] }
 ironrdp-session.workspace = true
-ironrdp-session.features = ["qoiz"]
 ironrdp-pdu.workspace = true
 ironrdp-core.workspace = true
 ironrdp-graphics.workspace = true
@@ -28,3 +27,7 @@ tracing-web = "0.1.2"
 uuid = { version = ">=1.16, <1.24", features = ["js"] } # Pinned below 1.21: uuid 1.21+ needs getrandom 0.4 -> rand_core 0.10 (stable), which conflicts with picky rc.22's pinned rand_core = "=0.10.0-rc-3". Remove this pin when picky ships with stable RustCrypto deps.
 wasm-bindgen = "0.2.95"
 web-sys = { version = "0.3.95", features = ["ImageData"] }
+
+[features]
+default = []
+qoiz = ["ironrdp-session/qoiz"]


### PR DESCRIPTION
Attempt unblock the build after changes introduced by #6584. Most of the current build failures seem to stem from the new `zstd-sys` dependency which is very particular about its C/C++ toolchain. Since we've been struggling to find a solution to these build issues in a timely manner, I've opted to temporarily stub out the `qoiz` encoding/decoding feature. This will cause a runtime breakage for Linux desktops, but will restore the build while we figure this out.


<!-- Provide a descriptive entry for the changelog of the next release. -->


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
Simple regression testing to ensure that Windows desktop behavior in not affected.
### Test Environment
Local cluster with reachable Windows desktop resources
### Test Cases
- [x] Connect to Windows desktop as a local user and ensure graphics display correctly.
- [x] Connect to Windows desktop as an AD user and ensure graphics display correctly.
- [x] Tag build succeeds https://github.com/gravitational/teleport.e/actions/runs/29365808062
