### PR TITLE
tool/tsh: Integrate with tbot's `login-agent` service

### DIFF
--- a/api/utils/keys/hardwarekeyagent/service.go
+++ b/api/utils/keys/hardwarekeyagent/service.go
@@ -63,7 +63,7 @@ func (s *Service) NewPrivateKey(ctx context.Context, config hardwarekey.PrivateK
 func (s *Service) Sign(ctx context.Context, ref *hardwarekey.PrivateKeyRef, keyInfo hardwarekey.ContextualKeyInfo, rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
 	// First try to sign with the agent, then fallback to the direct service if needed.
 	signature, err := s.agentSign(ctx, ref, keyInfo, rand, digest, opts)
-	if err != nil {
+	if err != nil && s.fallbackService != nil {
 		slog.ErrorContext(ctx, "Failed to perform signature over hardware key agent, falling back to fallback service", "agent_err", err)
 		signature, err = s.fallbackService.Sign(ctx, ref, keyInfo, rand, digest, opts)
 	}

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -3778,6 +3778,11 @@ func (tc *TeleportClient) DeviceLogin(ctx context.Context, params *dtauthntypes.
 
 // getSSHLoginFunc returns an SSHLoginFunc that matches client and cluster settings.
 func (tc *TeleportClient) getSSHLoginFunc(pr *webclient.PingResponse) (SSHLoginFunc, error) {
+	// Use the Machine ID login agent to non-interactively log in, if it is available.
+	if dir := os.Getenv(LoginAgentDirEnvVar); dir != "" {
+		return tc.loginWithMachineIDAgent(dir), nil
+	}
+
 	switch pr.Auth.Type {
 	case constants.Local:
 		authType := constants.LocalConnector

--- a/lib/client/login_agent.go
+++ b/lib/client/login_agent.go
@@ -1,0 +1,93 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package client
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	hardwarekeyagentv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/hardwarekeyagent/v1"
+	pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginagent/v1"
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/api/utils/keys/hardwarekeyagent"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/localagent"
+)
+
+// LoginAgentDirEnvVar is the name of the environment variable that will be used
+// to configure the Machine ID login agent.
+const LoginAgentDirEnvVar = "TELEPORT_LOGIN_AGENT_DIR"
+
+// loginWithMachineIDAgent logs the user in non-interactively using the Machine
+// ID login agent.
+func (tc *TeleportClient) loginWithMachineIDAgent(agentDir string) SSHLoginFunc {
+	return func(ctx context.Context, keyRing *KeyRing) (*authclient.CLILoginResponse, error) {
+		conn, err := localagent.NewClient(agentDir)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		defer conn.Close()
+
+		rsp, err := pb.NewLoginAgentServiceClient(conn).
+			Login(ctx, pb.LoginRequest_builder{
+				RouteToCluster:    tc.SiteName,
+				KubernetesCluster: tc.KubernetesCluster,
+			}.Build())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		// Login agent also implements the Hardware Key Agent service so we can
+		// keep the private key material in-memory.
+		hwkService := hardwarekeyagent.NewService(
+			hardwarekeyagentv1.NewHardwareKeyAgentServiceClient(conn),
+			nil, /* fallbackService */
+		)
+
+		// Overwrite the key ring's private key. The other fields (e.g. Username,
+		// Cert) are set by SSHLogin.
+		privKey, err := keys.ParsePrivateKey(rsp.GetPrivateKey(), keys.WithHardwareKeyService(hwkService))
+		if err != nil {
+			return nil, trace.Wrap(err, "parsing private key")
+		}
+		keyRing.SSHPrivateKey = privKey
+		keyRing.TLSPrivateKey = privKey
+
+		// Reset outdated fields.
+		keyRing.KubeTLSCredentials = make(map[string]TLSCredential)
+		keyRing.AppTLSCredentials = make(map[string]TLSCredential)
+		keyRing.DBTLSCredentials = make(map[string]TLSCredential)
+		keyRing.WindowsDesktopTLSCredentials = make(map[string]TLSCredential)
+
+		hostSigners := make([]authclient.TrustedCerts, len(rsp.GetHostSigners()))
+		for idx, hs := range rsp.GetHostSigners() {
+			hostSigners[idx] = authclient.TrustedCerts{
+				ClusterName:     hs.GetClusterName(),
+				AuthorizedKeys:  hs.GetSshAuthorizedKeys(),
+				TLSCertificates: hs.GetTlsCaCerts(),
+			}
+		}
+
+		return &authclient.CLILoginResponse{
+			Username:    rsp.GetUsername(),
+			Cert:        rsp.GetSshCert(),
+			TLSCert:     rsp.GetTlsCert(),
+			HostSigners: hostSigners,
+		}, nil
+	}
+}

--- a/lib/hardwarekey/agent.go
+++ b/lib/hardwarekey/agent.go
@@ -40,15 +40,19 @@ const (
 	// server certificate.
 	CertFileName = localagent.CertFileName
 
-	dirName     = ".Teleport-PIV"
-	agentDirEnv = "TELEPORT_KEY_AGENT_DIR"
+	dirName          = ".Teleport-PIV"
+	keyAgentDirEnv   = "TELEPORT_KEY_AGENT_DIR"
+	loginAgentDirEnv = "TELEPORT_LOGIN_AGENT_DIR"
 )
 
 // AgentDirFromEnv returns the directory for the hardware key agent's socket and
-// certificate files from $TELEPORT_KEY_AGENT_DIR, or defaultDir if the environment
-// variable was not set.
+// certificate files from $TELEPORT_KEY_AGENT_DIR, $TELEPORT_LOGIN_AGENT_DIR, or
+// defaultDir if neither environment variable was set.
 func AgentDirFromEnv(defaultDir string) string {
-	if dir := os.Getenv(agentDirEnv); dir != "" {
+	if dir := os.Getenv(keyAgentDirEnv); dir != "" {
+		return dir
+	}
+	if dir := os.Getenv(loginAgentDirEnv); dir != "" {
 		return dir
 	}
 	return defaultDir

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2344,9 +2344,11 @@ func onLogin(cf *CLIConf, reExecArgs ...string) (err error) {
 		cf.DesiredRoles = ""
 	}
 
-	// For login operations, we use the hardware key
-	// service directly instead of the agent.
-	cf.disableHardwareKeyAgentClient = true
+	// For login operations, we use the hardware key service directly instead of
+	// the agent; unless we're using the login agent which requires it.
+	if os.Getenv(client.LoginAgentDirEnvVar) == "" {
+		cf.disableHardwareKeyAgentClient = true
+	}
 
 	if cf.IdentityFileIn != "" {
 		err := flattenIdentity(cf)

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -63,6 +63,8 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	hardwarekeyagentv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/hardwarekeyagent/v1"
+	loginagentv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginagent/v1"
 	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
@@ -72,6 +74,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keypaths"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
+	"github.com/gravitational/teleport/api/utils/keys/hardwarekeyagent"
 	"github.com/gravitational/teleport/api/utils/prompt"
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/integration/kube"
@@ -88,6 +91,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
+	"github.com/gravitational/teleport/lib/localagent"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/observability/tracing"
@@ -521,6 +525,74 @@ func TestFailedLogin(t *testing.T) {
 		"--proxy", proxyAddr.String(),
 	}, setHomePath(tmpHomePath), setMockSSOLoginCustom(ssoLogin, connector.GetName()))
 	require.ErrorIs(t, err, loginFailed)
+}
+
+func TestLoginWithMachineIDAgent(t *testing.T) {
+	ctx := t.Context()
+
+	homeDir := filepath.Join(t.TempDir(), "home")
+
+	// Use os.MkdirTemp instead of t.TempDir for the agent socket directory.
+	// t.TempDir includes the test name and sequence directories, which can exceed
+	// Unix socket path limits on platforms like macOS.
+	agentDir, err := os.MkdirTemp("", "tsh-agent-")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(agentDir) })
+
+	// Stand up a Teleport cluster with a user and role.
+	role, err := types.NewRole("access", types.RoleSpecV6{})
+	require.NoError(t, err)
+
+	user, err := types.NewUser("alice@example.com")
+	require.NoError(t, err)
+	user.SetRoles([]string{role.GetName()})
+
+	authProcess, proxyProcess := makeTestServers(t, withBootstrap(role, user))
+	authServer := authProcess.GetAuthServer()
+	require.NotNil(t, authServer)
+
+	clusterName, err := authServer.GetClusterName(ctx)
+	require.NoError(t, err)
+	rootClusterName := clusterName.GetClusterName()
+
+	proxyAddr, err := proxyProcess.ProxyWebAddr()
+	require.NoError(t, err)
+
+	// Run test agent.
+	loginAgent := runTestLoginAgent(t, agentDir, authServer, user)
+
+	// Point TELEPORT_LOGIN_AGENT_DIR at our test agent.
+	t.Setenv(client.LoginAgentDirEnvVar, agentDir)
+
+	// Run tsh login.
+	err = Run(ctx, []string{
+		"login",
+		"--insecure",
+		"--debug",
+		"--proxy", proxyAddr.String(),
+		rootClusterName,
+	}, setHomePath(homeDir))
+	require.NoError(t, err)
+
+	// Check the login agent was called.
+	require.Equal(t, 1, loginAgent.loginCount())
+	require.Equal(t, rootClusterName, loginAgent.routeToCluster())
+
+	// Check the profile was written.
+	store := client.NewFSClientStore(homeDir)
+	profile, _, err := store.FullProfileStatus("")
+	require.NoError(t, err)
+	require.Equal(t, user.GetName(), profile.Username)
+	require.Equal(t, rootClusterName, profile.Cluster)
+
+	proxyHost := utils.TryHost(profile.ProxyURL.Host)
+	keyRing, err := store.GetKeyRing(client.KeyRingIndex{
+		ProxyHost:   proxyHost,
+		Username:    profile.Username,
+		ClusterName: profile.Cluster,
+	}, client.WithSSHCerts{})
+	require.NoError(t, err)
+	require.True(t, keyRing.SSHPrivateKey.IsHardware())
 }
 
 func TestOIDCLogin(t *testing.T) {
@@ -4594,6 +4666,173 @@ func mockSSOLogin(authServer *auth.Server, user types.User) client.SSOLoginFunc 
 			HostSigners: authclient.AuthoritiesToTrustedCerts([]types.CertAuthority{authority}),
 		}, nil
 	}
+}
+
+type testLoginAgentService struct {
+	loginagentv1.UnimplementedLoginAgentServiceServer
+
+	authServer *auth.Server
+	user       types.User
+	privateKey crypto.Signer
+
+	mu                  sync.Mutex
+	loginCountValue     int
+	routeToClusterValue string
+}
+
+func runTestLoginAgent(t *testing.T, dir string, authServer *auth.Server, user types.User) *testLoginAgentService {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	svc := &testLoginAgentService{
+		authServer: authServer,
+		user:       user,
+		privateKey: privateKey,
+	}
+
+	server, err := localagent.NewServer(dir)
+	require.NoError(t, err)
+
+	loginagentv1.RegisterLoginAgentServiceServer(server, svc)
+	err = hardwarekeyagent.RegisterServer(
+		server,
+		svc,
+		func(*hardwarekey.PrivateKeyRef, hardwarekey.ContextualKeyInfo) (bool, error) {
+			return true, nil
+		},
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	errCh := make(chan error, 1)
+	go func() { errCh <- server.Serve(ctx) }()
+
+	t.Cleanup(func() {
+		cancel()
+
+		select {
+		case err := <-errCh:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for test login agent to stop")
+		}
+	})
+
+	return svc
+}
+
+func (s *testLoginAgentService) Login(ctx context.Context, req *loginagentv1.LoginRequest) (*loginagentv1.LoginResponse, error) {
+	s.mu.Lock()
+	s.loginCountValue++
+	s.routeToClusterValue = req.GetRouteToCluster()
+	s.mu.Unlock()
+
+	clusterName, err := s.authServer.GetClusterName(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	slotKey, err := hardwarekey.PIVSlotKeyFromProto(hardwarekeyagentv1.PIVSlotKey_PIV_SLOT_KEY_9A)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	hwSigner := &hardwarekey.Signer{
+		Ref: &hardwarekey.PrivateKeyRef{
+			SerialNumber:         0xFFFFFFFF,
+			SlotKey:              slotKey,
+			PublicKey:            s.privateKey.Public(),
+			Policy:               hardwarekey.PromptPolicyNone,
+			AttestationStatement: &hardwarekey.AttestationStatement{},
+		},
+	}
+	loginKey, err := keys.NewPrivateKey(hwSigner)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	tlsPubKey, err := loginKey.MarshalTLSPublicKey()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	routeToCluster := req.GetRouteToCluster()
+	if routeToCluster == "" {
+		routeToCluster = clusterName.GetClusterName()
+	}
+
+	sshCert, tlsCert, err := s.authServer.GenerateUserTestCertsWithContext(ctx, auth.GenerateUserTestCertsRequest{
+		SSHPubKey:               loginKey.MarshalSSHPublicKey(),
+		TLSPubKey:               tlsPubKey,
+		Username:                s.user.GetName(),
+		TTL:                     time.Hour,
+		Compatibility:           constants.CertificateFormatStandard,
+		RouteToCluster:          routeToCluster,
+		KubernetesCluster:       req.GetKubernetesCluster(),
+		SSHAttestationStatement: loginKey.GetAttestationStatement(),
+		TLSAttestationStatement: loginKey.GetAttestationStatement(),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	privateKey, err := keys.MarshalPrivateKey(hwSigner)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	hostCAs, err := s.authServer.GetCertAuthorities(ctx, types.HostCA, false)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	hostSigners := make([]*loginagentv1.TrustedCerts, len(hostCAs))
+	for idx, cert := range hostCAs {
+		hostSigners[idx] = loginagentv1.TrustedCerts_builder{
+			ClusterName:       cert.GetClusterName(),
+			SshAuthorizedKeys: services.GetSSHCheckingKeys(cert),
+			TlsCaCerts:        services.GetTLSCerts(cert),
+		}.Build()
+	}
+
+	return loginagentv1.LoginResponse_builder{
+		Username:    s.user.GetName(),
+		SshCert:     sshCert,
+		TlsCert:     tlsCert,
+		PrivateKey:  privateKey,
+		HostSigners: hostSigners,
+	}.Build(), nil
+}
+
+func (s *testLoginAgentService) Sign(
+	_ context.Context,
+	_ *hardwarekey.PrivateKeyRef,
+	_ hardwarekey.ContextualKeyInfo,
+	rand io.Reader,
+	digest []byte,
+	opts crypto.SignerOpts,
+) ([]byte, error) {
+	return s.privateKey.Sign(rand, digest, opts)
+}
+
+func (*testLoginAgentService) NewPrivateKey(context.Context, hardwarekey.PrivateKeyConfig) (*hardwarekey.Signer, error) {
+	return nil, trace.NotImplemented("NewPrivateKey is not implemented")
+}
+
+func (*testLoginAgentService) GetFullKeyRef(uint32, hardwarekey.PIVSlotKey) (*hardwarekey.PrivateKeyRef, error) {
+	return nil, trace.NotImplemented("GetFullKeyRef is not implemented")
+}
+
+func (s *testLoginAgentService) loginCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.loginCountValue
+}
+
+func (s *testLoginAgentService) routeToCluster() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.routeToClusterValue
 }
 
 func mockHeadlessLogin(t *testing.T, authServer *auth.Server, user types.User) client.SSHLoginFunc {


### PR DESCRIPTION
Requires: https://github.com/gravitational/teleport/pull/68612

Integrates with tbot's `login-agent` service (described in [RFD 0329: Delegation V2](https://github.com/gravitational/rfd/pull/66)), an alternative to the `identity` service(s) that allows the Teleport Client (i.e. tsh) to "own" the credentials, and perform its own profile management, etc. This is a prerequisite for agentic access requests. Without it, even if the client were able to reissue its certificates to assume or drop access requests, the `identity` services would clobber the changes at the next renewal.

### How it works:

Alongside agents (e.g. in beams) will be a tbot sidecar with the following configuration:

```yaml
services:
  - type: login-agent
    destination:
      type: directory
      path: /path/to/agent/dir
```

In the agent's environment, the following environment variables will be set:

```bash
export TELEPORT_PROXY="<proxy-addr>"
export TELEPORT_LOGIN_AGENT_DIR="/path/to/agent/dir"
```

The agent (or runtime harness) will run:

```shell
$ tsh login
```

tsh will connect to tbot's login agent service, and issue a `Login` RPC; tbot will call the auth server to generate credentials, and return them to tsh. tsh will update its keyring and write the credentials to disk (including a pseudo hardware key reference). tsh will call the hardware key agent service (on the same socket) for signing operations.

Whenever the credentials expire, the usual `RetryWithRelogin` logic will obtain new credentials from the login agent service.

## Manual Test Plan

### Test Environment

### Test Cases
- [ ] Logging into a root cluster works
- [ ] Logging into a trusted cluster works
- [ ] `RetryWithRelogin` works when the credentials expire
