### PR TITLE
fix: don't cache GitHub org SSO check failures for the full TTL

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -829,6 +829,10 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 	}
 	as.githubOrgSSOCache, err = utils.NewFnCache(utils.FnCacheConfig{
 		TTL: githubCacheTimeout,
+		// Transient network errors must not be served for the full TTL,
+		// which would break GitHub SSO logins until the Auth Service
+		// restarts or the entry expires.
+		ReloadOnErr: true,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -214,6 +214,11 @@ func FormatGithubURL(host string, path string) string {
 	return formatGithubURL(host, path)
 }
 
+// GithubOrgSSOCache lets tests verify the production cache configuration.
+func (a *Server) GithubOrgSSOCache() *utils.FnCache {
+	return a.githubOrgSSOCache
+}
+
 func CheckGithubOrgSSOSupport(ctx context.Context, conn types.GithubConnector, userTeams []GithubTeamResponse, buildType string, orgCache *utils.FnCache, client httpRequester) error {
 	return checkGithubOrgSSOSupport(ctx, conn, userTeams, buildType, orgCache, client)
 }

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -552,6 +552,32 @@ func TestCheckGithubOrgSSOSupport(t *testing.T) {
 			}
 		})
 	}
+
+	// Regression test: a transient network error must not be served from the
+	// cache for the full TTL (the production cache in NewServer sets
+	// ReloadOnErr). The first login attempt after connectivity recovers must
+	// succeed instead of failing from a poisoned cache until restart.
+	t.Run("reload cached errors", func(t *testing.T) {
+		orgCache, err := utils.NewFnCache(utils.FnCacheConfig{
+			TTL:         time.Hour,
+			ReloadOnErr: true,
+		})
+		require.NoError(t, err)
+
+		client := mockHTTPRequester{
+			succeed: false,
+		}
+		err = auth.CheckGithubOrgSSOSupport(ctx, noSSOOrg, nil, modules.BuildOSS, orgCache, client)
+		require.Error(t, err)
+		require.True(t, trace.IsConnectionProblem(err))
+
+		client = mockHTTPRequester{
+			succeed:    true,
+			statusCode: http.StatusNotFound,
+		}
+		err = auth.CheckGithubOrgSSOSupport(ctx, noSSOOrg, nil, modules.BuildOSS, orgCache, client)
+		require.NoError(t, err)
+	})
 }
 
 func TestGithubURLFormat(t *testing.T) {

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -554,20 +554,16 @@ func TestCheckGithubOrgSSOSupport(t *testing.T) {
 	}
 
 	// Regression test: a transient network error must not be served from the
-	// cache for the full TTL (the production cache in NewServer sets
-	// ReloadOnErr). The first login attempt after connectivity recovers must
-	// succeed instead of failing from a poisoned cache until restart.
+	// cache for the full TTL. This exercises the production cache config from
+	// NewServer so removing ReloadOnErr in auth.go fails this test.
 	t.Run("reload cached errors", func(t *testing.T) {
-		orgCache, err := utils.NewFnCache(utils.FnCacheConfig{
-			TTL:         time.Hour,
-			ReloadOnErr: true,
-		})
-		require.NoError(t, err)
+		p := newAuthSuite(t)
+		orgCache := p.a.GithubOrgSSOCache()
 
 		client := mockHTTPRequester{
 			succeed: false,
 		}
-		err = auth.CheckGithubOrgSSOSupport(ctx, noSSOOrg, nil, modules.BuildOSS, orgCache, client)
+		err := auth.CheckGithubOrgSSOSupport(ctx, noSSOOrg, nil, modules.BuildOSS, orgCache, client)
 		require.Error(t, err)
 		require.True(t, trace.IsConnectionProblem(err))
 


### PR DESCRIPTION
Fixes #68615

## What

Set `ReloadOnErr: true` on `githubOrgSSOCache` so a failed GitHub org external-SSO check is retried on the next login attempt instead of being served from the cache for the full 1-hour TTL. Successful results keep the existing TTL.

## Why

A single transient network timeout during the login-time check of `https://github.com/orgs/<org>/sso` poisoned the cache for an hour: every subsequent GitHub SSO login failed instantly with

```
Timed out trying to reach GitHub to check for organization external SSO.
```

without any new outbound request, until the Auth Service was restarted (clearing the in-memory cache) or the entry expired. On links with recurring blips the error keeps getting re-cached, so logins can stay broken indefinitely. Field details and reproduction in #68615.

`FnCache` only reloads error entries immediately when `ReloadOnErr` is set (`lib/utils/fncache.go`); the option exists precisely for long-TTL caches like this one.

## Testing

Added a regression subtest to `TestCheckGithubOrgSSOSupport` (`reload cached errors`): with the production cache config, a timed-out check returns a `ConnectionProblem`, and a subsequent call with recovered connectivity must succeed. Without `ReloadOnErr` the subtest fails with the exact production error message (cached error served); with it, it passes.

```
go test ./lib/auth/ -run 'TestCheckGithubOrgSSOSupport' -count=1
--- PASS: TestCheckGithubOrgSSOSupport (0.00s)
    ...
    --- PASS: TestCheckGithubOrgSSOSupport/reload_cached_errors (0.00s)
```

Please consider backporting to `branch/v18` (reproduced on 18.7.6).

changelog: Fixed GitHub SSO logins staying broken for up to an hour after a transient network failure of the organization external-SSO check
