### PR TITLE
Add default Windows installer

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1918,6 +1918,10 @@ const (
 	// DefaultInstallerScriptNameAgentless is the name of the by default populated, EC2
 	// installer script when agentless mode is enabled for a matcher
 	DefaultInstallerScriptNameAgentless = "default-agentless-installer"
+
+	// DefaultInstallerScriptNameWindowsAuthPackage is the name of the default populated
+	// installer script for Windows nodes
+	DefaultInstallerScriptNameWindowsAuthPackage = "default-installer-windows-auth-package"
 )
 
 const (

--- a/api/types/installers/installers.go
+++ b/api/types/installers/installers.go
@@ -77,4 +77,8 @@ type Template struct {
 	// reparse point (symlink or junction) and may redirect to an untrusted
 	// location.
 	WindowsInstallerStagingDirUnsafe int
+	// WindowsInstallerChecksumMismatch is the exit code for when the downloaded
+	// Windows authentication package installer fails SHA256 checksum
+	// verification against the checksum published alongside it.
+	WindowsInstallerChecksumMismatch int
 }

--- a/api/types/installers/installers.go
+++ b/api/types/installers/installers.go
@@ -33,6 +33,10 @@ const InstallerScriptName = types.DefaultInstallerScriptName
 // installer script when agentless mode is enabled for a matcher
 const InstallerScriptNameAgentless = types.DefaultInstallerScriptNameAgentless
 
+// InstallerScriptNameWindowsAuthPackage is the name of the default populated Windows
+// auth package installer script
+const InstallerScriptNameWindowsAuthPackage = types.DefaultInstallerScriptNameWindowsAuthPackage
+
 // DefaultAgentlessInstaller represents a the default agentless installer script provided
 // by teleport
 var DefaultAgentlessInstaller = types.MustNewInstallerV1(InstallerScriptNameAgentless, defaultAgentlessInstallScript)
@@ -55,4 +59,22 @@ type Template struct {
 	// AzureClientID is the client ID of the managed identity to use when joining
 	// the cluster. Only applicable for the azure join method.
 	AzureClientID string
+	// AuthPackageVersion is the full version of Teleport auth package e.g. 18.9.2
+	AuthPackageVersion string
+	// RestartAfterEnrollment indicates whether the Windows auth package installer
+	// should schedule a system restart after enrollment. A restart is required
+	// for smartcard authentication to work, but the user may choose to restart
+	// later.
+	RestartAfterEnrollment bool
+	// WindowsInstallerDownloadFailure is the exit code for when the Windows
+	// auth package installer fails to download the authentication package.
+	WindowsInstallerDownloadFailure int
+	// WindowsInstallerExecutionFailure is the exit code for when the Windows
+	// auth package installer fails to execute the authentication package installer.
+	WindowsInstallerExecutionFailure int
+	// WindowsInstallerStagingDirUnsafe is the exit code for when the Windows
+	// auth package installer staging directory under %WINDIR%\SystemTemp is a
+	// reparse point (symlink or junction) and may redirect to an untrusted
+	// location.
+	WindowsInstallerStagingDirUnsafe int
 }

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5314,6 +5314,8 @@ func (g *GRPCServer) GetInstaller(ctx context.Context, req *types.ResourceReques
 				return g.defaultInstaller(ctx)
 			case installers.InstallerScriptNameAgentless:
 				return installers.DefaultAgentlessInstaller, nil
+			case installers.InstallerScriptNameWindowsAuthPackage:
+				return installer.DefaultWindowsAuthPackageInstaller, nil
 			}
 		}
 		return nil, trace.Wrap(err)
@@ -5343,8 +5345,9 @@ func (g *GRPCServer) GetInstallers(ctx context.Context, _ *emptypb.Empty) (*type
 	}
 
 	defaultInstallers := map[string]*types.InstallerV1{
-		types.DefaultInstallerScriptName:        defaultInstaller,
-		installers.InstallerScriptNameAgentless: installers.DefaultAgentlessInstaller,
+		types.DefaultInstallerScriptName:                 defaultInstaller,
+		installers.InstallerScriptNameAgentless:          installers.DefaultAgentlessInstaller,
+		installers.InstallerScriptNameWindowsAuthPackage: installer.DefaultWindowsAuthPackageInstaller,
 	}
 
 	for _, inst := range res {
@@ -5399,6 +5402,10 @@ func (g *GRPCServer) rangeDefaultInstallers(ctx context.Context, start, end stri
 				}
 			}
 			defaultInstallers = append(defaultInstallers, defaultInstaller)
+		}
+
+		if isInRange(installers.InstallerScriptNameWindowsAuthPackage, start, end) {
+			defaultInstallers = append(defaultInstallers, installer.DefaultWindowsAuthPackageInstaller)
 		}
 
 		// Sort in case the names change in the future as the streams must be sorted.

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -5562,16 +5562,18 @@ func TestGRPCServer_GetInstallers(t *testing.T) {
 		{
 			name: "default installers only",
 			expectedInstallers: map[string]string{
-				types.DefaultInstallerScriptName:        installer.LegacyDefaultInstaller.GetScript(),
-				installers.InstallerScriptNameAgentless: installers.DefaultAgentlessInstaller.GetScript(),
+				types.DefaultInstallerScriptName:                 installer.LegacyDefaultInstaller.GetScript(),
+				installers.InstallerScriptNameAgentless:          installers.DefaultAgentlessInstaller.GetScript(),
+				installers.InstallerScriptNameWindowsAuthPackage: installer.DefaultWindowsAuthPackageInstaller.GetScript(),
 			},
 		},
 		{
 			name:            "new default installers",
 			hasAgentRollout: true,
 			expectedInstallers: map[string]string{
-				types.DefaultInstallerScriptName:        installer.NewDefaultInstaller.GetScript(),
-				installers.InstallerScriptNameAgentless: installers.DefaultAgentlessInstaller.GetScript(),
+				types.DefaultInstallerScriptName:                 installer.NewDefaultInstaller.GetScript(),
+				installers.InstallerScriptNameAgentless:          installers.DefaultAgentlessInstaller.GetScript(),
+				installers.InstallerScriptNameWindowsAuthPackage: installer.DefaultWindowsAuthPackageInstaller.GetScript(),
 			},
 		},
 		{
@@ -5580,9 +5582,10 @@ func TestGRPCServer_GetInstallers(t *testing.T) {
 				"my-custom-installer": "echo test",
 			},
 			expectedInstallers: map[string]string{
-				"my-custom-installer":                   "echo test",
-				types.DefaultInstallerScriptName:        installer.LegacyDefaultInstaller.GetScript(),
-				installers.InstallerScriptNameAgentless: installers.DefaultAgentlessInstaller.GetScript(),
+				"my-custom-installer":                            "echo test",
+				types.DefaultInstallerScriptName:                 installer.LegacyDefaultInstaller.GetScript(),
+				installers.InstallerScriptNameAgentless:          installers.DefaultAgentlessInstaller.GetScript(),
+				installers.InstallerScriptNameWindowsAuthPackage: installer.DefaultWindowsAuthPackageInstaller.GetScript(),
 			},
 		},
 		{
@@ -5591,8 +5594,9 @@ func TestGRPCServer_GetInstallers(t *testing.T) {
 				installers.InstallerScriptName: "echo test",
 			},
 			expectedInstallers: map[string]string{
-				installers.InstallerScriptName:          "echo test",
-				installers.InstallerScriptNameAgentless: installers.DefaultAgentlessInstaller.GetScript(),
+				installers.InstallerScriptName:                   "echo test",
+				installers.InstallerScriptNameAgentless:          installers.DefaultAgentlessInstaller.GetScript(),
+				installers.InstallerScriptNameWindowsAuthPackage: installer.DefaultWindowsAuthPackageInstaller.GetScript(),
 			},
 		},
 	}

--- a/lib/srv/server/azure_installer.go
+++ b/lib/srv/server/azure_installer.go
@@ -57,8 +57,19 @@ func (r AzureInstallResult) Failure() bool {
 	return r.APIError != nil || (r.CommandResult != nil && r.CommandResult.Failure())
 }
 
-// Run initiates Teleport installation on a set of virtual machines and then blocks until the
-// commands have completed.
+func (req *AzureInstallRequest) RunWindowsAuthPackage(ctx context.Context, client azure.RunCommandClient) error {
+	// Azure treats scripts with the same content as the same invocation and
+	// won't run them more than once. This is fine when the installer script
+	// succeeds, but it makes troubleshooting much harder when it fails. To
+	// work around this, we generate a random string and append it as a comment
+	// to the script, forcing Azure to see each invocation as unique.
+	script, err := installerScriptWindowsAuthPackage(ctx, req.InstallerParams, withNonceComment(), withProxyAddrGetter(req.ProxyAddrGetter))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return req.run(ctx, client, script)
+}
+
 func (req *AzureInstallRequest) Run(ctx context.Context, client azure.RunCommandClient) error {
 	// Azure treats scripts with the same content as the same invocation and
 	// won't run them more than once. This is fine when the installer script
@@ -69,6 +80,12 @@ func (req *AzureInstallRequest) Run(ctx context.Context, client azure.RunCommand
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	return req.run(ctx, client, script)
+}
+
+// Run initiates Teleport installation on a set of virtual machines and then blocks until the
+// commands have completed.
+func (req *AzureInstallRequest) run(ctx context.Context, client azure.RunCommandClient, script string) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	g, ctx := errgroup.WithContext(ctx)

--- a/lib/srv/server/installer/defaultinstallers.go
+++ b/lib/srv/server/installer/defaultinstallers.go
@@ -54,10 +54,23 @@ $CertPath      = Join-Path $WorkDir 'teleport.pem'
 Write-Host "Base64-decoding the embedded CA bundle and writing it to $CertPath..."
 [IO.File]::WriteAllBytes($CertPath, [Convert]::FromBase64String($CA))
 
+# Returns whether $TargetHost should be excluded from proxying by NO_PROXY list
+function Test-NoProxyMatch($TargetHost, $NoProxy) {
+	if (-not $NoProxy) { return $false }
+	foreach ($entry in $NoProxy -split ',') {
+		$entry = $entry.Trim()
+		if (-not $entry) { continue }
+		if ($entry -eq '*') { return $true }
+		$entry = $entry.TrimStart('.').ToLowerInvariant()
+		if ($TargetHost -eq $entry -or $TargetHost.EndsWith(".$entry")) { return $true }
+	}
+	return $false
+}
+
 Write-Host "Downloading authentication package installer ($InstallerName)..."
 try {
 	$dl = @{ Uri = "https://cdn.teleport.dev/$InstallerName"; OutFile = $InstallerPath; UseBasicParsing = $true }
-	if ($env:HTTPS_PROXY) { $dl.Proxy = $env:HTTPS_PROXY }
+	if ($env:HTTPS_PROXY -and -not (Test-NoProxyMatch 'cdn.teleport.dev' $env:NO_PROXY)) { $dl.Proxy = $env:HTTPS_PROXY }
 	Invoke-WebRequest @dl
 } catch {
 	Write-Host "Authentication package download failed: $_"

--- a/lib/srv/server/installer/defaultinstallers.go
+++ b/lib/srv/server/installer/defaultinstallers.go
@@ -67,14 +67,35 @@ function Test-NoProxyMatch($TargetHost, $NoProxy) {
 	return $false
 }
 
+$UseProxy = $env:HTTPS_PROXY -and -not (Test-NoProxyMatch 'cdn.teleport.dev' $env:NO_PROXY)
+
 Write-Host "Downloading authentication package installer ($InstallerName)..."
 try {
 	$dl = @{ Uri = "https://cdn.teleport.dev/$InstallerName"; OutFile = $InstallerPath; UseBasicParsing = $true }
-	if ($env:HTTPS_PROXY -and -not (Test-NoProxyMatch 'cdn.teleport.dev' $env:NO_PROXY)) { $dl.Proxy = $env:HTTPS_PROXY }
+	if ($UseProxy) { $dl.Proxy = $env:HTTPS_PROXY }
 	Invoke-WebRequest @dl
 } catch {
 	Write-Host "Authentication package download failed: $_"
 	exit {{ .WindowsInstallerDownloadFailure }}
+}
+
+Write-Host "Downloading authentication package installer checksum..."
+$ChecksumPath = "$InstallerPath.sha256"
+try {
+	$cs = @{ Uri = "https://cdn.teleport.dev/$InstallerName.sha256"; OutFile = $ChecksumPath; UseBasicParsing = $true }
+	if ($UseProxy) { $cs.Proxy = $env:HTTPS_PROXY }
+	Invoke-WebRequest @cs
+} catch {
+	Write-Host "Authentication package checksum download failed: $_"
+	exit {{ .WindowsInstallerDownloadFailure }}
+}
+
+Write-Host "Verifying authentication package installer checksum..."
+$ExpectedHash = ((Get-Content -LiteralPath $ChecksumPath -Raw) -split '\s+' | Where-Object { $_ })[0].ToLowerInvariant()
+$ActualHash = (Get-FileHash -LiteralPath $InstallerPath -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($ExpectedHash -ne $ActualHash) {
+	Write-Host "Authentication package checksum mismatch: expected $ExpectedHash, got $ActualHash"
+	exit {{ .WindowsInstallerChecksumMismatch }}
 }
 
 Write-Host "Running authentication package installer..."

--- a/lib/srv/server/installer/defaultinstallers.go
+++ b/lib/srv/server/installer/defaultinstallers.go
@@ -26,6 +26,63 @@ import (
 	"github.com/gravitational/teleport/lib/web/scripts/oneoff"
 )
 
+const windowsAuthPackageScriptSetup = `$ErrorActionPreference = 'Stop'
+$ProgressPreference    = 'SilentlyContinue'
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+$AuthPackageVersion = '{{.AuthPackageVersion}}'
+$CA = '{{getWindowsCA}}'`
+
+var windowsAuthPackageInstallerScript = `$InstallerName = "teleport-windows-auth-setup-v$AuthPackageVersion-amd64.exe"
+# Stage installer files under %WINDIR%\SystemTemp, which is only writable by
+# SYSTEM and Administrators.
+$SystemTemp    = Join-Path $env:WINDIR 'SystemTemp'
+
+# SystemTemp isn't guaranteed to exist on older builds.
+New-Item -ItemType Directory -Path $SystemTemp -Force | Out-Null
+
+# Refuse to stage under a redirected SystemTemp
+if ((Get-Item -LiteralPath $SystemTemp -Force).Attributes -band [IO.FileAttributes]::ReparsePoint) {
+	Write-Host "$SystemTemp is a reparse point, refusing to stage installer files there."
+	exit {{ .WindowsInstallerStagingDirUnsafe }}
+}
+
+$WorkDir       = Join-Path $SystemTemp ([System.Guid]::NewGuid().ToString())
+New-Item -ItemType Directory -Path $WorkDir | Out-Null
+$InstallerPath = Join-Path $WorkDir $InstallerName
+$CertPath      = Join-Path $WorkDir 'teleport.pem'
+
+Write-Host "Base64-decoding the embedded CA bundle and writing it to $CertPath..."
+[IO.File]::WriteAllBytes($CertPath, [Convert]::FromBase64String($CA))
+
+Write-Host "Downloading authentication package installer ($InstallerName)..."
+try {
+	$dl = @{ Uri = "https://cdn.teleport.dev/$InstallerName"; OutFile = $InstallerPath; UseBasicParsing = $true }
+	if ($env:HTTPS_PROXY) { $dl.Proxy = $env:HTTPS_PROXY }
+	Invoke-WebRequest @dl
+} catch {
+	Write-Host "Authentication package download failed: $_"
+	exit {{ .WindowsInstallerDownloadFailure }}
+}
+
+Write-Host "Running authentication package installer..."
+& $InstallerPath install --cert=$CertPath
+if ($LASTEXITCODE -ne 0) {
+	Write-Host "Authentication package installer failed (exit $LASTEXITCODE)"
+	exit {{ .WindowsInstallerExecutionFailure }}
+}
+
+{{if .RestartAfterEnrollment}}
+Write-Host "Scheduling a system restart in 60 seconds to complete the enrollment process"
+& shutdown.exe /r /t 60 /c "Restarting to complete Teleport enrollment process"
+{{else}}
+Write-Host "A reboot is required to complete installation."
+{{end}}`
+
+var DefaultWindowsAuthPackageInstaller = types.MustNewInstallerV1(
+	installers.InstallerScriptNameWindowsAuthPackage,
+	strings.Join([]string{windowsAuthPackageScriptSetup, windowsAuthPackageInstallerScript}, "\n\n"),
+)
+
 const (
 	scriptShebangAndSetOptions = `#!/usr/bin/env sh
 set -eu`

--- a/lib/srv/server/installer/defaultinstallers_test.go
+++ b/lib/srv/server/installer/defaultinstallers_test.go
@@ -126,14 +126,35 @@ function Test-NoProxyMatch($TargetHost, $NoProxy) {
 	return $false
 }
 
+$UseProxy = $env:HTTPS_PROXY -and -not (Test-NoProxyMatch 'cdn.teleport.dev' $env:NO_PROXY)
+
 Write-Host "Downloading authentication package installer ($InstallerName)..."
 try {
 	$dl = @{ Uri = "https://cdn.teleport.dev/$InstallerName"; OutFile = $InstallerPath; UseBasicParsing = $true }
-	if ($env:HTTPS_PROXY -and -not (Test-NoProxyMatch 'cdn.teleport.dev' $env:NO_PROXY)) { $dl.Proxy = $env:HTTPS_PROXY }
+	if ($UseProxy) { $dl.Proxy = $env:HTTPS_PROXY }
 	Invoke-WebRequest @dl
 } catch {
 	Write-Host "Authentication package download failed: $_"
 	exit 200
+}
+
+Write-Host "Downloading authentication package installer checksum..."
+$ChecksumPath = "$InstallerPath.sha256"
+try {
+	$cs = @{ Uri = "https://cdn.teleport.dev/$InstallerName.sha256"; OutFile = $ChecksumPath; UseBasicParsing = $true }
+	if ($UseProxy) { $cs.Proxy = $env:HTTPS_PROXY }
+	Invoke-WebRequest @cs
+} catch {
+	Write-Host "Authentication package checksum download failed: $_"
+	exit 200
+}
+
+Write-Host "Verifying authentication package installer checksum..."
+$ExpectedHash = ((Get-Content -LiteralPath $ChecksumPath -Raw) -split '\s+' | Where-Object { $_ })[0].ToLowerInvariant()
+$ActualHash = (Get-FileHash -LiteralPath $InstallerPath -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($ExpectedHash -ne $ActualHash) {
+	Write-Host "Authentication package checksum mismatch: expected $ExpectedHash, got $ActualHash"
+	exit 203
 }
 
 Write-Host "Running authentication package installer..."
@@ -168,6 +189,7 @@ func TestDefaultWindowsAuthPackageInstaller(t *testing.T) {
 			WindowsInstallerDownloadFailure:  int(installstatus.WindowsInstallerDownloadFailure),
 			WindowsInstallerExecutionFailure: int(installstatus.WindowsInstallerExecutionFailure),
 			WindowsInstallerStagingDirUnsafe: int(installstatus.WindowsInstallerStagingDirUnsafe),
+			WindowsInstallerChecksumMismatch: int(installstatus.WindowsInstallerChecksumMismatch),
 		}))
 		return buf.String()
 	}

--- a/lib/srv/server/installer/defaultinstallers_test.go
+++ b/lib/srv/server/installer/defaultinstallers_test.go
@@ -113,10 +113,23 @@ $CertPath      = Join-Path $WorkDir 'teleport.pem'
 Write-Host "Base64-decoding the embedded CA bundle and writing it to $CertPath..."
 [IO.File]::WriteAllBytes($CertPath, [Convert]::FromBase64String($CA))
 
+# Returns whether $TargetHost should be excluded from proxying by NO_PROXY list
+function Test-NoProxyMatch($TargetHost, $NoProxy) {
+	if (-not $NoProxy) { return $false }
+	foreach ($entry in $NoProxy -split ',') {
+		$entry = $entry.Trim()
+		if (-not $entry) { continue }
+		if ($entry -eq '*') { return $true }
+		$entry = $entry.TrimStart('.').ToLowerInvariant()
+		if ($TargetHost -eq $entry -or $TargetHost.EndsWith(".$entry")) { return $true }
+	}
+	return $false
+}
+
 Write-Host "Downloading authentication package installer ($InstallerName)..."
 try {
 	$dl = @{ Uri = "https://cdn.teleport.dev/$InstallerName"; OutFile = $InstallerPath; UseBasicParsing = $true }
-	if ($env:HTTPS_PROXY) { $dl.Proxy = $env:HTTPS_PROXY }
+	if ($env:HTTPS_PROXY -and -not (Test-NoProxyMatch 'cdn.teleport.dev' $env:NO_PROXY)) { $dl.Proxy = $env:HTTPS_PROXY }
 	Invoke-WebRequest @dl
 } catch {
 	Write-Host "Authentication package download failed: $_"

--- a/lib/srv/server/installer/defaultinstallers_test.go
+++ b/lib/srv/server/installer/defaultinstallers_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types/installers"
 	"github.com/gravitational/teleport/lib/srv/server/installer"
+	"github.com/gravitational/teleport/lib/srv/server/installstatus"
 )
 
 const defaultInstallerSnapshot = `#!/usr/bin/env sh
@@ -79,4 +80,90 @@ func TestNewDefaultInstaller(t *testing.T) {
 
 	// Test validation: rendered template must look like the snapshot.
 	require.Equal(t, defaultInstallerSnapshot, buf.String())
+}
+
+// defaultWindowsAuthPackageInstallerSnapshot is the rendered Windows auth
+// package installer with RestartAfterEnrollment set. TEST_CA_BUNDLE stands in for the
+// base64 CA the getWindowsCA template func produces at runtime.
+const defaultWindowsAuthPackageInstallerSnapshot = `$ErrorActionPreference = 'Stop'
+$ProgressPreference    = 'SilentlyContinue'
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+$AuthPackageVersion = '1.2.3'
+$CA = 'TEST_CA_BUNDLE'
+
+$InstallerName = "teleport-windows-auth-setup-v$AuthPackageVersion-amd64.exe"
+# Stage installer files under %WINDIR%\SystemTemp, which is only writable by
+# SYSTEM and Administrators.
+$SystemTemp    = Join-Path $env:WINDIR 'SystemTemp'
+
+# SystemTemp isn't guaranteed to exist on older builds.
+New-Item -ItemType Directory -Path $SystemTemp -Force | Out-Null
+
+# Refuse to stage under a redirected SystemTemp
+if ((Get-Item -LiteralPath $SystemTemp -Force).Attributes -band [IO.FileAttributes]::ReparsePoint) {
+	Write-Host "$SystemTemp is a reparse point, refusing to stage installer files there."
+	exit 202
+}
+
+$WorkDir       = Join-Path $SystemTemp ([System.Guid]::NewGuid().ToString())
+New-Item -ItemType Directory -Path $WorkDir | Out-Null
+$InstallerPath = Join-Path $WorkDir $InstallerName
+$CertPath      = Join-Path $WorkDir 'teleport.pem'
+
+Write-Host "Base64-decoding the embedded CA bundle and writing it to $CertPath..."
+[IO.File]::WriteAllBytes($CertPath, [Convert]::FromBase64String($CA))
+
+Write-Host "Downloading authentication package installer ($InstallerName)..."
+try {
+	$dl = @{ Uri = "https://cdn.teleport.dev/$InstallerName"; OutFile = $InstallerPath; UseBasicParsing = $true }
+	if ($env:HTTPS_PROXY) { $dl.Proxy = $env:HTTPS_PROXY }
+	Invoke-WebRequest @dl
+} catch {
+	Write-Host "Authentication package download failed: $_"
+	exit 200
+}
+
+Write-Host "Running authentication package installer..."
+& $InstallerPath install --cert=$CertPath
+if ($LASTEXITCODE -ne 0) {
+	Write-Host "Authentication package installer failed (exit $LASTEXITCODE)"
+	exit 201
+}
+
+
+Write-Host "Scheduling a system restart in 60 seconds to complete the enrollment process"
+& shutdown.exe /r /t 60 /c "Restarting to complete Teleport enrollment process"
+`
+
+func TestDefaultWindowsAuthPackageInstaller(t *testing.T) {
+	// Insert a stub getWindowsCA template func to avoid getting a real CA
+	parse := func() *template.Template {
+		tmpl, err := template.New("").
+			Funcs(template.FuncMap{
+				"getWindowsCA": func() (string, error) { return "TEST_CA_BUNDLE", nil },
+			}).
+			Parse(installer.DefaultWindowsAuthPackageInstaller.GetScript())
+		require.NoError(t, err)
+		return tmpl
+	}
+
+	render := func(restart bool) string {
+		buf := &bytes.Buffer{}
+		require.NoError(t, parse().Execute(buf, installers.Template{
+			AuthPackageVersion:               "1.2.3",
+			RestartAfterEnrollment:           restart,
+			WindowsInstallerDownloadFailure:  int(installstatus.WindowsInstallerDownloadFailure),
+			WindowsInstallerExecutionFailure: int(installstatus.WindowsInstallerExecutionFailure),
+			WindowsInstallerStagingDirUnsafe: int(installstatus.WindowsInstallerStagingDirUnsafe),
+		}))
+		return buf.String()
+	}
+
+	// With a restart, the snapshot matches the generated script
+	require.Equal(t, defaultWindowsAuthPackageInstallerSnapshot, render(true /* restart */))
+
+	// Without a restart, the reboot-notice branch is taken instead.
+	withoutRestart := render(false /* don't restart */)
+	require.Contains(t, withoutRestart, `Write-Host "A reboot is required to complete installation."`)
+	require.NotContains(t, withoutRestart, "shutdown.exe")
 }

--- a/lib/srv/server/installer_script.go
+++ b/lib/srv/server/installer_script.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/google/safetext/shsprintf"
 	"github.com/gravitational/trace"
+	"golang.org/x/net/http/httpproxy"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/srv/server/installstatus"
@@ -64,6 +65,41 @@ func envVarsFromInstallerParams(params *types.InstallerParams) []string {
 		if params.HTTPProxySettings.NoProxy != "" {
 			safeNoProxy := shsprintf.EscapeDefaultContext(params.HTTPProxySettings.NoProxy)
 			envVars = append(envVars, "NO_PROXY="+safeNoProxy)
+		}
+	}
+
+	return envVars
+}
+
+// escapePowerShellSingleQuoted wraps s in a PowerShell single-quoted string
+// literal. Inside single quotes PowerShell treats every character literally
+// except a single quote, which is escaped by doubling it. This prevents
+// interpolation and command injection regardless of the input.
+func escapePowerShellSingleQuoted(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+// envVarsFromInstallerParamsWindows converts InstallerParams into a list of
+// PowerShell statements that set environment variables for the current process,
+// in the form $env:KEY = 'value'. Child processes (i.e. the downloaded
+// installer) inherit these. The output can be used as is without further
+// escaping in scripts.
+func envVarsFromInstallerParamsWindows(params *types.InstallerParams) []string {
+	var envVars []string
+
+	setEnv := func(key, value string) {
+		envVars = append(envVars, fmt.Sprintf("$env:%s = %s", key, escapePowerShellSingleQuoted(value)))
+	}
+
+	if params.HTTPProxySettings != nil {
+		if params.HTTPProxySettings.HTTPProxy != "" {
+			setEnv("HTTP_PROXY", params.HTTPProxySettings.HTTPProxy)
+		}
+		if params.HTTPProxySettings.HTTPSProxy != "" {
+			setEnv("HTTPS_PROXY", params.HTTPProxySettings.HTTPSProxy)
+		}
+		if params.HTTPProxySettings.NoProxy != "" {
+			setEnv("NO_PROXY", params.HTTPProxySettings.NoProxy)
 		}
 	}
 
@@ -109,19 +145,22 @@ func proxyAddress(ctx context.Context, proxyAddr string, getter proxyGetter) (st
 	return "", trace.BadParameter("proxy address is missing from the matcher and there is no available Proxy Service yet")
 }
 
-func installerScript(ctx context.Context, params *types.InstallerParams, opts ...scriptOption) (string, error) {
+// resolveInstallerScript parses options, validates params, resolves the proxy
+// address, and builds the installer script URL. These steps are shared by all
+// platform-specific installer script builders.
+func resolveInstallerScript(ctx context.Context, params *types.InstallerParams, opts ...scriptOption) (proxyAddr, scriptURL string, o *scriptOptions, err error) {
 	scriptOptions := &scriptOptions{}
 	for _, opt := range opts {
 		scriptOptions = opt(scriptOptions)
 	}
 
 	if params == nil {
-		return "", trace.BadParameter("installation parameters must not be nil")
+		return "", "", nil, trace.BadParameter("installation parameters must not be nil")
 	}
 
-	proxyAddr, err := proxyAddress(ctx, params.PublicProxyAddr, scriptOptions.proxyAddr)
+	proxyAddr, err = proxyAddress(ctx, params.PublicProxyAddr, scriptOptions.proxyAddr)
 	if err != nil {
-		return "", trace.Wrap(err)
+		return "", "", nil, trace.Wrap(err)
 	}
 
 	scriptURLQuery := url.Values{}
@@ -129,11 +168,20 @@ func installerScript(ctx context.Context, params *types.InstallerParams, opts ..
 		scriptURLQuery.Set("azure-client-id", shsprintf.EscapeDefaultContext(params.Azure.ClientID))
 	}
 
-	scriptURL := url.URL{
+	u := url.URL{
 		Scheme:   "https",
 		Host:     proxyAddr,
 		Path:     path.Join("v1", "webapi", "scripts", "installer", shsprintf.EscapeDefaultContext(params.ScriptName)),
 		RawQuery: scriptURLQuery.Encode(),
+	}
+
+	return proxyAddr, u.String(), scriptOptions, nil
+}
+
+func installerScript(ctx context.Context, params *types.InstallerParams, opts ...scriptOption) (string, error) {
+	proxyAddr, scriptURL, scriptOptions, err := resolveInstallerScript(ctx, params, opts...)
+	if err != nil {
+		return "", trace.Wrap(err)
 	}
 
 	var installationScript string
@@ -144,10 +192,10 @@ func installerScript(ctx context.Context, params *types.InstallerParams, opts ..
 		installationScript += fmt.Sprintf("export %s; ", strings.Join(envVars, " "))
 	}
 
-	installationScript += preFlightChecksScript(proxyAddr)
+	installationScript += preFlightChecksScript(preFlightInstallerChecks(proxyAddr))
 
 	installationScript += fmt.Sprintf(`bash -c "set -o pipefail; curl --silent --show-error --location %s | bash -s %s"`,
-		scriptURL.String(),
+		scriptURL,
 		shsprintf.EscapeDefaultContext(params.JoinToken),
 	)
 
@@ -163,15 +211,13 @@ func installerScript(ctx context.Context, params *types.InstallerParams, opts ..
 
 // preFlightChecksScript returns a shell script fragment that performs pre-installation checks.
 // Each check exits with a specific non-zero code so the Discovery Service can identify the failure.
-func preFlightChecksScript(proxyAddr string) string {
-	installersCheckMap := preFlightInstallerChecks(proxyAddr)
-
-	exitCodes := slices.Collect(maps.Keys(installersCheckMap))
+func preFlightChecksScript(checks map[installstatus.ExitCode]string) string {
+	exitCodes := slices.Collect(maps.Keys(checks))
 	slices.Sort(exitCodes)
 
 	var checkScriptFragments []string
 	for _, exitCode := range exitCodes {
-		checkScriptFragments = append(checkScriptFragments, installersCheckMap[exitCode])
+		checkScriptFragments = append(checkScriptFragments, checks[exitCode])
 	}
 
 	return strings.Join(checkScriptFragments, "; ") + "; "
@@ -208,5 +254,113 @@ func preFlightInstallerChecks(proxyAddr string) map[installstatus.ExitCode]strin
 			shsprintf.EscapeDefaultContext(proxyFindURL.String()),
 			orExitWithMessageScriptSnippet(installstatus.ProxyPingError, "proxy is unreachable"),
 		),
+	}
+}
+
+func installerScriptWindowsAuthPackage(ctx context.Context, params *types.InstallerParams, opts ...scriptOption) (string, error) {
+	proxyAddr, scriptURL, scriptOptions, err := resolveInstallerScript(ctx, params, opts...)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	// curl.exe (which reads HTTP(S)_PROXY / NO_PROXY natively) is absent on
+	// Windows before version 1803 and on Windows Server 2016, both of which we
+	// support, so the scripts use Invoke-WebRequest. Invoke-WebRequest doesn't
+	// read those env vars, so compute here whether a proxy applies to the proxy
+	// endpoint. proxyCheck is a PowerShell fragment reused for the pre-flight
+	// proxy check and the install script below (both target the proxy over
+	// HTTPS). It reads the value from $env:HTTPS_PROXY at runtime and is empty
+	// when no proxy applies.
+	var proxyCheck string
+	if params.HTTPProxySettings != nil {
+		cfg := httpproxy.Config{
+			HTTPProxy:  params.HTTPProxySettings.HTTPProxy,
+			HTTPSProxy: params.HTTPProxySettings.HTTPSProxy,
+			NoProxy:    params.HTTPProxySettings.NoProxy,
+		}
+		target := &url.URL{Scheme: "https", Host: proxyAddr}
+		if proxyURL, err := cfg.ProxyFunc()(target); err == nil && proxyURL != nil {
+			proxyCheck = `; if ($env:HTTPS_PROXY) { $req.Proxy = $env:HTTPS_PROXY }`
+		}
+	}
+
+	var installationScript strings.Builder
+
+	// Abort on any error and enable TLS 1.2 before any HTTPS request. Windows
+	// PowerShell 5.1 does not always negotiate it by default. This must precede
+	// the pre-flight proxy check, which also makes an HTTPS request.
+	installationScript.WriteString(`$ErrorActionPreference = 'Stop'; [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; `)
+
+	// Export env vars before pre-flight checks so that proxy network check can
+	// use http proxy settings if they are provided in the installer params.
+	envVars := envVarsFromInstallerParamsWindows(params)
+	if len(envVars) > 0 {
+		installationScript.WriteString(strings.Join(envVars, "; "))
+		installationScript.WriteString("; ")
+	}
+
+	installationScript.WriteString(preFlightChecksScript(preFlightInstallerChecksWindows(proxyAddr, proxyCheck)))
+
+	// Fetch the installer script from the proxy and run it in the current session
+	// using iex so it inherits the env vars set above. Set UseBasicParsing to
+	// avoid using IE engine for parsing.
+	fmt.Fprintf(&installationScript, `$req = @{ Uri = %s; UseBasicParsing = $true }%s; iex (Invoke-WebRequest @req).Content`,
+		escapePowerShellSingleQuoted(scriptURL),
+		proxyCheck,
+	)
+
+	if scriptOptions.addNonceComment {
+		installationScript.WriteString(" # ")
+		installationScript.WriteString(rand.Text())
+	}
+
+	return installationScript.String(), nil
+}
+
+// preFlightInstallerChecksWindows returns the Windows pre-flight checks.
+// proxyCheck is a PowerShell fragment (computed by the caller) that routes the
+// proxy check through HTTPS_PROXY when applicable. It is empty when no proxy
+// applies.
+func preFlightInstallerChecksWindows(proxyAddr, proxyCheck string) map[installstatus.ExitCode]string {
+	proxyFindURL := url.URL{
+		Scheme: "https",
+		Host:   proxyAddr,
+		Path:   path.Join("webapi", "find"),
+	}
+
+	exitWithMessage := func(exitCode installstatus.ExitCode, message string) string {
+		return fmt.Sprintf(`{ Write-Host "%s"; exit %d; }`, message, exitCode)
+	}
+
+	return map[installstatus.ExitCode]string{
+		// Check for Invoke-WebRequest
+		installstatus.InvokeWebRequestNotFound: fmt.Sprintf(`if (-not (Get-Command Invoke-WebRequest -ErrorAction SilentlyContinue)) %s`,
+			exitWithMessage(installstatus.InvokeWebRequestNotFound, "Invoke-WebRequest is missing")),
+
+		// Check that we have the correct permissions
+		installstatus.AdministratorPrivilegesRequired: fmt.Sprintf(`if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) %s`,
+			exitWithMessage(installstatus.AdministratorPrivilegesRequired, "Administrator privileges required")),
+
+		// Check if there's enough disk space on the system drive for the installation
+		installstatus.WindowsInsufficientDiskSpace: fmt.Sprintf(`if (([System.IO.DriveInfo]$env:SystemDrive).AvailableFreeSpace -lt %dMB) %s`,
+			installstatus.WindowsAuthPackageInstallerMinFreeDiskMB,
+			exitWithMessage(installstatus.WindowsInsufficientDiskSpace, "Insufficient disk space")),
+
+		// Check if network connection to the proxy is available. Route through
+		// HTTPS_PROXY when it applies and isn't excluded by NO_PROXY.
+		installstatus.ProxyPingError: fmt.Sprintf(`$req = @{ Uri = %s; UseBasicParsing = $true; TimeoutSec = 10 }%s; try { Invoke-WebRequest @req | Out-Null } catch %s`,
+			escapePowerShellSingleQuoted(proxyFindURL.String()),
+			proxyCheck,
+			exitWithMessage(installstatus.ProxyPingError, "Proxy is unreachable")),
+
+		// Check if the system is running a supported version of Windows (Windows Server 2016 or later, Windows 10 or later)
+		// See https://learn.microsoft.com/en-us/windows/win32/sysinfo/operating-system-version
+		installstatus.UnsupportedWindowsVersion: fmt.Sprintf(`if ($([System.Environment]::OSVersion.Version.Major) -lt 10) %s`,
+			exitWithMessage(installstatus.UnsupportedWindowsVersion, "Unsupported Windows version")),
+
+		// Check that the machine is not joined to an Active Directory domain. The
+		// authentication package is only supported on non-domain-joined hosts.
+		installstatus.WindowsMachineDomainJoined: fmt.Sprintf(`if ((Get-CimInstance -ClassName Win32_ComputerSystem).PartOfDomain) %s`,
+			exitWithMessage(installstatus.WindowsMachineDomainJoined, "Machine is joined to a domain")),
 	}
 }

--- a/lib/srv/server/installer_script_test.go
+++ b/lib/srv/server/installer_script_test.go
@@ -39,6 +39,35 @@ func installerScriptChecksFor(proxyAddr string) string {
 		`; `
 }
 
+// windowsInstallerSetup is the fixed PowerShell setup emitted by
+// installerScriptWindowsAuthPackage before the pre-flight checks.
+const windowsInstallerSetup = `$ErrorActionPreference = 'Stop'; [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; `
+
+// windowsInstallerProxyCheck is the PowerShell fragment injected into the proxy
+// pre-flight check and the fetch command when an HTTPS proxy applies to the
+// proxy endpoint. It mirrors the fragment in installerScriptWindowsAuthPackage.
+const windowsInstallerProxyCheck = `; if ($env:HTTPS_PROXY) { $req.Proxy = $env:HTTPS_PROXY }`
+
+// windowsInstallerChecksFor returns the expected Windows pre-flight checks
+// prefix for a given proxy address and proxy-check fragment. It mirrors the
+// logic in preFlightInstallerChecksWindows so that tests stay in sync with the
+// implementation.
+func windowsInstallerChecksFor(proxyAddr, proxyCheck string) string {
+	return `$req = @{ Uri = 'https://` + proxyAddr + `/webapi/find'; UseBasicParsing = $true; TimeoutSec = 10 }` + proxyCheck + `; try { Invoke-WebRequest @req | Out-Null } catch { Write-Host "Proxy is unreachable"; exit 104; }` +
+		`; if (-not (Get-Command Invoke-WebRequest -ErrorAction SilentlyContinue)) { Write-Host "Invoke-WebRequest is missing"; exit 105; }` +
+		`; if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) { Write-Host "Administrator privileges required"; exit 106; }` +
+		`; if (([System.IO.DriveInfo]$env:SystemDrive).AvailableFreeSpace -lt 50MB) { Write-Host "Insufficient disk space"; exit 107; }` +
+		`; if ($([System.Environment]::OSVersion.Version.Major) -lt 10) { Write-Host "Unsupported Windows version"; exit 108; }` +
+		`; if ((Get-CimInstance -ClassName Win32_ComputerSystem).PartOfDomain) { Write-Host "Machine is joined to a domain"; exit 109; }` +
+		`; `
+}
+
+// windowsInstallerFetch returns the expected PowerShell that fetches the auth
+// package installer script from the proxy.
+func windowsInstallerFetch(scriptURL, proxyCheck string) string {
+	return `$req = @{ Uri = '` + scriptURL + `'; UseBasicParsing = $true }` + proxyCheck + `; iex (Invoke-WebRequest @req).Content`
+}
+
 func TestInstallerScript(t *testing.T) {
 	basicParams := func() *types.InstallerParams {
 		return &types.InstallerParams{
@@ -199,6 +228,109 @@ func TestInstallerScript(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			script, err := installerScript(t.Context(), tt.req(), tt.withOptions...)
+			tt.errCheck(t, err)
+
+			if tt.expectedScriptContains != "" {
+				require.Contains(t, script, tt.expectedScriptContains)
+			}
+
+			if tt.expectedScript != "" {
+				require.Equal(t, tt.expectedScript, script)
+			}
+		})
+	}
+}
+
+func TestInstallerScriptWindowsAuthPackage(t *testing.T) {
+	basicParams := func() *types.InstallerParams {
+		return &types.InstallerParams{
+			PublicProxyAddr: "proxy.example.com:443",
+			ScriptName:      "scriptName",
+		}
+	}
+	for _, tt := range []struct {
+		name                   string
+		req                    func() *types.InstallerParams
+		withOptions            []scriptOption
+		errCheck               require.ErrorAssertionFunc
+		expectedScript         string
+		expectedScriptContains string
+	}{
+		{
+			name:     "basic",
+			req:      basicParams,
+			errCheck: require.NoError,
+			expectedScript: windowsInstallerSetup +
+				windowsInstallerChecksFor("proxy.example.com:443", "") +
+				windowsInstallerFetch("https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName", ""),
+		},
+		{
+			name:                   "with nonce to ensure script is unique",
+			req:                    basicParams,
+			withOptions:            []scriptOption{withNonceComment()},
+			errCheck:               require.NoError,
+			expectedScriptContains: windowsInstallerFetch("https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName", "") + " #",
+		},
+		{
+			name: "with HTTP proxy settings set",
+			req: func() *types.InstallerParams {
+				req := basicParams()
+				req.HTTPProxySettings = &types.HTTPProxySettings{
+					HTTPSProxy: "http://local-squid:3128",
+					HTTPProxy:  "http://local-squid:3128",
+					NoProxy:    "http://intranet.local",
+				}
+				return req
+			},
+			errCheck: require.NoError,
+			expectedScript: windowsInstallerSetup +
+				`$env:HTTP_PROXY = 'http://local-squid:3128'; $env:HTTPS_PROXY = 'http://local-squid:3128'; $env:NO_PROXY = 'http://intranet.local'; ` +
+				windowsInstallerChecksFor("proxy.example.com:443", windowsInstallerProxyCheck) +
+				windowsInstallerFetch("https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName", windowsInstallerProxyCheck),
+		},
+		{
+			name: "missing public proxy address but getter was set up",
+			req: func() *types.InstallerParams {
+				req := basicParams()
+				req.PublicProxyAddr = ""
+				return req
+			},
+			withOptions: []scriptOption{
+				withProxyAddrGetter(func(ctx context.Context) (string, error) {
+					return "proxy2.example.com", nil
+				}),
+			},
+			errCheck: require.NoError,
+			expectedScript: windowsInstallerSetup +
+				windowsInstallerChecksFor("proxy2.example.com", "") +
+				windowsInstallerFetch("https://proxy2.example.com/v1/webapi/scripts/installer/scriptName", ""),
+		},
+		{
+			name: "proxy addr is missing but getter returns an error",
+			req: func() *types.InstallerParams {
+				req := basicParams()
+				req.PublicProxyAddr = ""
+				return req
+			},
+			withOptions: []scriptOption{
+				withProxyAddrGetter(func(ctx context.Context) (string, error) {
+					return "", trace.NotFound("proxy service is not yet running")
+				}),
+			},
+			errCheck: require.Error,
+		},
+		{
+			name: "proxy addr is missing and getter is missing",
+			req: func() *types.InstallerParams {
+				req := basicParams()
+				req.PublicProxyAddr = ""
+				return req
+			},
+			errCheck: require.Error,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			script, err := installerScriptWindowsAuthPackage(t.Context(), tt.req(), tt.withOptions...)
 			tt.errCheck(t, err)
 
 			if tt.expectedScriptContains != "" {

--- a/lib/srv/server/installstatus/exitcodes.go
+++ b/lib/srv/server/installstatus/exitcodes.go
@@ -29,14 +29,24 @@ type ExitCode int
 
 const (
 	// Preflight exit codes (shell-side, 100–149).
-	BashNotFound          ExitCode = 100
-	SudoNotFound          ExitCode = 101
-	CurlNotFound          ExitCode = 102
-	InsufficientDiskSpace ExitCode = 103
-	ProxyPingError        ExitCode = 104
+	BashNotFound                    ExitCode = 100
+	SudoNotFound                    ExitCode = 101
+	CurlNotFound                    ExitCode = 102
+	InsufficientDiskSpace           ExitCode = 103
+	ProxyPingError                  ExitCode = 104
+	InvokeWebRequestNotFound        ExitCode = 105
+	AdministratorPrivilegesRequired ExitCode = 106
+	WindowsInsufficientDiskSpace    ExitCode = 107
+	UnsupportedWindowsVersion       ExitCode = 108
+	WindowsMachineDomainJoined      ExitCode = 109
 
 	// Post-install exit codes (Go binary, 150–199).
 	JoinFailure ExitCode = 150
+
+	// Install exit codes (200-249).
+	WindowsInstallerDownloadFailure  ExitCode = 200
+	WindowsInstallerExecutionFailure ExitCode = 201
+	WindowsInstallerStagingDirUnsafe ExitCode = 202
 )
 
 // InstallerMinFreeDiskMB is the minimum free disk space in megabytes required for Teleport installation.
@@ -45,6 +55,13 @@ const (
 //
 // If this value is updated, ensure you also update the docs at "Installation script exit codes" in the Teleport EC2 Server Discovery documentation.
 const InstallerMinFreeDiskMB = 1250
+
+// WindowsAuthPackageInstallerMinFreeDiskMB is the minimum free disk space in megabytes required for Teleport Authentication Package installation on Windows.
+// The .exe is very small at 5.9MB. The installer drops a .dll and a few certificates which are a few megabytes each, at most.
+// 50 MB is more than enough and provides some buffer.
+//
+// As above, if this value is updated, ensure you also update the docs at "Installation script exit codes" in the Teleport Server Discovery documentation.
+const WindowsAuthPackageInstallerMinFreeDiskMB = 50
 
 // String returns a human-readable description for the exit code.
 // Unrecognized codes get a generic fallback.
@@ -67,10 +84,38 @@ func (c ExitCode) String() string {
 	case ProxyPingError:
 		return "Failed to connect to Teleport cluster HTTPS endpoint. " +
 			"Ensure this host can access your cluster and its certificate is trusted."
+	case InvokeWebRequestNotFound:
+		return "Invoke-WebRequest is not available in the instance. " +
+			"Please ensure Invoke-WebRequest is installed and try again."
+	case AdministratorPrivilegesRequired:
+		return "Administrator privileges are required to run the installer. " +
+			"Please run the installer as an administrator and try again."
+	case WindowsInsufficientDiskSpace:
+		return fmt.Sprintf(
+			"Insufficient disk space for installation. "+
+				"Teleport requires at least %dMB in the system drive.",
+			WindowsAuthPackageInstallerMinFreeDiskMB)
+	case UnsupportedWindowsVersion:
+		return "Unsupported Windows version. " +
+			"Please ensure you are running a supported version of Windows " +
+			"(Windows Server 2016 or later, Windows 10 or later) and try again."
+	case WindowsMachineDomainJoined:
+		return "This host is joined to an Active Directory domain. " +
+			"The Teleport authentication package can only be installed on non-domain-joined hosts."
 	case JoinFailure:
 		return "Teleport was installed successfully but the agent " +
 			"did not become ready within the configured timeout. " +
 			"Check standard error output for join diagnostics."
+	case WindowsInstallerDownloadFailure:
+		return "Failed to download the Teleport authentication package installer. " +
+			"Ensure this host can reach https://cdn.teleport.dev and try again."
+	case WindowsInstallerExecutionFailure:
+		return "The Teleport authentication package installer returned an error. " +
+			"Check the standard output and standard error for details."
+	case WindowsInstallerStagingDirUnsafe:
+		return "The installer staging directory under %WINDIR%\\SystemTemp is a " +
+			"reparse point (symlink or junction) and may redirect to an untrusted " +
+			"location. Please ensure it is not a reparse point and try again."
 	default:
 		return fmt.Sprintf(
 			"Installation failed with exit code %d. "+

--- a/lib/srv/server/installstatus/exitcodes.go
+++ b/lib/srv/server/installstatus/exitcodes.go
@@ -47,6 +47,7 @@ const (
 	WindowsInstallerDownloadFailure  ExitCode = 200
 	WindowsInstallerExecutionFailure ExitCode = 201
 	WindowsInstallerStagingDirUnsafe ExitCode = 202
+	WindowsInstallerChecksumMismatch ExitCode = 203
 )
 
 // InstallerMinFreeDiskMB is the minimum free disk space in megabytes required for Teleport installation.
@@ -116,6 +117,10 @@ func (c ExitCode) String() string {
 		return "The installer staging directory under %WINDIR%\\SystemTemp is a " +
 			"reparse point (symlink or junction) and may redirect to an untrusted " +
 			"location. Please ensure it is not a reparse point and try again."
+	case WindowsInstallerChecksumMismatch:
+		return "The downloaded Teleport authentication package installer failed " +
+			"SHA256 checksum verification. This may indicate a corrupted download " +
+			"or a tampered network path. Please try again."
 	default:
 		return fmt.Sprintf(
 			"Installation failed with exit code %d. "+

--- a/lib/srv/server/installstatus/exitcodes_test.go
+++ b/lib/srv/server/installstatus/exitcodes_test.go
@@ -1,0 +1,122 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package installstatus
+
+import (
+	"go/constant"
+	"go/types"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
+)
+
+func TestExitCodeString(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		code ExitCode
+		want string
+	}{
+		{
+			name: "windows installer download failure",
+			code: WindowsInstallerDownloadFailure,
+			want: "Failed to download the Teleport authentication package installer. " +
+				"Ensure this host can reach https://cdn.teleport.dev and try again.",
+		},
+		{
+			name: "windows installer execution failure",
+			code: WindowsInstallerExecutionFailure,
+			want: "The Teleport authentication package installer returned an error. " +
+				"Check the standard output and standard error for details.",
+		},
+		{
+			name: "windows installer staging dir unsafe",
+			code: WindowsInstallerStagingDirUnsafe,
+			want: "The installer staging directory under %WINDIR%\\SystemTemp is a " +
+				"reparse point (symlink or junction) and may redirect to an untrusted " +
+				"location. Please ensure it is not a reparse point and try again.",
+		},
+		{
+			name: "unrecognized code falls back to the generic message",
+			code: ExitCode(999),
+			want: "Installation failed with exit code 999. " +
+				"Please check stdout and stderr and try again.",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.code.String())
+		})
+	}
+}
+
+// TestAllExitCodesHaveDedicatedMessage ensures every registered ExitCode has a
+// dedicated String() case
+func TestAllExitCodesHaveDedicatedMessage(t *testing.T) {
+	// genericMessage returns the fallback String() the default switch branch
+	// produces for the given code. We generate it using the unregistered code
+	// below, then replace the unregistered code with the code being tested.
+	const unregistered ExitCode = -999999
+	genericMessage := func(c ExitCode) string {
+		return strings.Replace(unregistered.String(), strconv.Itoa(int(unregistered)), strconv.Itoa(int(c)), 1)
+	}
+
+	codes := registeredExitCodes(t)
+	t.Log(codes)
+	require.NotEmpty(t, codes, "no ExitCode constants were discovered, the source parser is likely broken")
+
+	for name, code := range codes {
+		require.NotEqualf(t, genericMessage(code), code.String(),
+			"ExitCode %s (%d) has no dedicated message; add a case to ExitCode.String()", name, int(code))
+	}
+}
+
+// registeredExitCodes gets all the registered ExitCodes in exitcodes.go
+func registeredExitCodes(t *testing.T) map[string]ExitCode {
+	t.Helper()
+
+	pkgs, err := packages.Load(&packages.Config{
+		// NeedTypes returns exported ExitCodes types. It doesn't catch unexported constants.
+		Mode: packages.NeedTypes,
+	}, ".")
+	require.NoError(t, err)
+	require.Len(t, pkgs, 1)
+
+	pkg := pkgs[0]
+	require.Empty(t, pkg.Errors, "failed to load and type-check package")
+	require.NotNil(t, pkg.Types)
+
+	codes := make(map[string]ExitCode)
+	scope := pkg.Types.Scope()
+	for _, name := range scope.Names() {
+		c, ok := scope.Lookup(name).(*types.Const)
+		if !ok {
+			continue
+		}
+		named, ok := c.Type().(*types.Named)
+		if !ok || named.Obj().Name() != "ExitCode" {
+			continue
+		}
+		v, ok := constant.Int64Val(c.Val())
+		require.Truef(t, ok, "ExitCode const %s is not an integer", name)
+		codes[name] = ExitCode(v)
+	}
+	return codes
+}

--- a/lib/srv/server/installstatus/exitcodes_test.go
+++ b/lib/srv/server/installstatus/exitcodes_test.go
@@ -55,6 +55,13 @@ func TestExitCodeString(t *testing.T) {
 				"location. Please ensure it is not a reparse point and try again.",
 		},
 		{
+			name: "windows installer checksum mismatch",
+			code: WindowsInstallerChecksumMismatch,
+			want: "The downloaded Teleport authentication package installer failed " +
+				"SHA256 checksum verification. This may indicate a corrupted download " +
+				"or a tampered network path. Please try again.",
+		},
+		{
 			name: "unrecognized code falls back to the generic message",
 			code: ExitCode(999),
 			want: "Installation failed with exit code 999. " +

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -21,11 +21,13 @@
 package web
 
 import (
+	"bytes"
 	"cmp"
 	"context"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
@@ -115,6 +117,7 @@ import (
 	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv/desktop/tdp/protocol/tdpb"
+	"github.com/gravitational/teleport/lib/srv/server/installstatus"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
@@ -2700,7 +2703,30 @@ func (h *Handler) installer(w http.ResponseWriter, r *http.Request, p httprouter
 		targetVersion = teleport.SemVer()
 	}
 
-	instTmpl, err := texttemplate.New("").Parse(installer.GetScript())
+	getWindowsCA := func() (string, error) {
+		authorities, err := client.ExportAllAuthorities(
+			r.Context(),
+			h.GetProxyClient(),
+			client.ExportAuthoritiesRequest{
+				AuthType: "windows",
+			},
+		)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+
+		// Combine all certificates into a single PEM-encoded string and then base64
+		// encode it.
+		var buf bytes.Buffer
+		for _, a := range authorities {
+			pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: a.Data})
+		}
+		return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+	}
+
+	instTmpl, err := texttemplate.New("").
+		Funcs(texttemplate.FuncMap{"getWindowsCA": getWindowsCA}).
+		Parse(installer.GetScript())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -2725,16 +2751,35 @@ func (h *Handler) installer(w http.ResponseWriter, r *http.Request, p httprouter
 	}
 	azureClientID := r.URL.Query().Get("azure-client-id")
 
+	// For windows auth package installer scripts, we need to know if the installer
+	// should restart the machine after installation. A restart is required before
+	// smartcard authentication can be used, but we give the user the option
+	// because they may not want to restart immediately.
+	restartAfterEnrollment := r.URL.Query().Get("restart-after-enrollment") == "true"
+
 	tmpl := installers.Template{
-		PublicProxyAddr:   h.PublicProxyAddr(),
-		MajorVersion:      shsprintf.EscapeDefaultContext(fmt.Sprintf("v%d", targetVersion.Major)),
-		TeleportPackage:   teleportPackage,
-		RepoChannel:       shsprintf.EscapeDefaultContext(repoChannel),
-		AutomaticUpgrades: strconv.FormatBool(installUpdater),
-		AzureClientID:     shsprintf.EscapeDefaultContext(azureClientID),
+		PublicProxyAddr:                  h.PublicProxyAddr(),
+		MajorVersion:                     shsprintf.EscapeDefaultContext(fmt.Sprintf("v%d", targetVersion.Major)),
+		TeleportPackage:                  teleportPackage,
+		RepoChannel:                      shsprintf.EscapeDefaultContext(repoChannel),
+		AutomaticUpgrades:                strconv.FormatBool(installUpdater),
+		AzureClientID:                    shsprintf.EscapeDefaultContext(azureClientID),
+		AuthPackageVersion:               strings.ReplaceAll(targetVersion.String(), "'", "''"),
+		RestartAfterEnrollment:           restartAfterEnrollment,
+		WindowsInstallerDownloadFailure:  int(installstatus.WindowsInstallerDownloadFailure),
+		WindowsInstallerExecutionFailure: int(installstatus.WindowsInstallerExecutionFailure),
+		WindowsInstallerStagingDirUnsafe: int(installstatus.WindowsInstallerStagingDirUnsafe),
 	}
-	err = instTmpl.Execute(w, tmpl)
-	return nil, trace.Wrap(err)
+
+	var buf bytes.Buffer
+	if err := instTmpl.Execute(&buf, tmpl); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if _, err := io.Copy(w, &buf); err != nil {
+		h.logger.DebugContext(r.Context(), "Failed writing installer script response", "error", err)
+	}
+	return nil, nil
+
 }
 
 // AuthParams are used to construct redirect URL containing auth

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2769,6 +2769,7 @@ func (h *Handler) installer(w http.ResponseWriter, r *http.Request, p httprouter
 		WindowsInstallerDownloadFailure:  int(installstatus.WindowsInstallerDownloadFailure),
 		WindowsInstallerExecutionFailure: int(installstatus.WindowsInstallerExecutionFailure),
 		WindowsInstallerStagingDirUnsafe: int(installstatus.WindowsInstallerStagingDirUnsafe),
+		WindowsInstallerChecksumMismatch: int(installstatus.WindowsInstallerChecksumMismatch),
 	}
 
 	var buf bytes.Buffer

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -3762,6 +3762,7 @@ func TestInstallerScriptWindowsAuthPackageRendered(t *testing.T) {
 			// The installstatus exit codes survived the fmt.Sprintf injection.
 			require.Contains(t, response, "exit 200") // WindowsInstallerDownloadFailure
 			require.Contains(t, response, "exit 201") // WindowsInstallerExecutionFailure
+			require.Contains(t, response, "exit 203") // WindowsInstallerChecksumMismatch
 
 			// getWindowsCA rendered a non-empty CA bundle, and no template
 			// directives were left unrendered.

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -3718,6 +3718,63 @@ func TestInstallerScriptRenderedWithTextTemplate(t *testing.T) {
 	require.NotContains(t, response, "&#34;")
 }
 
+// TestInstallerScriptWindowsAuthPackageRendered renders the built-in Windows
+// auth package installer through the endpoint.
+func TestInstallerScriptWindowsAuthPackageRendered(t *testing.T) {
+	t.Parallel()
+	s := newWebSuite(t)
+	wc := s.client(t)
+
+	const rebootNotice = "A reboot is required to complete installation."
+	const scheduleRestart = `& shutdown.exe /r /t 60`
+
+	for _, tt := range []struct {
+		name                   string
+		restartAfterEnrollment string
+		expectContains         string
+		expectNotContains      string
+	}{
+		{
+			name:                   "restart after enrollment",
+			restartAfterEnrollment: "true",
+			expectContains:         scheduleRestart,
+			expectNotContains:      rebootNotice,
+		},
+		{
+			name:                   "no restart after enrollment",
+			restartAfterEnrollment: "false",
+			expectContains:         rebootNotice,
+			expectNotContains:      scheduleRestart,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			re, err := wc.Get(
+				s.ctx,
+				wc.Endpoint("webapi", "scripts", "installer", "default-installer-windows-auth-package"),
+				url.Values{"restart-after-enrollment": []string{tt.restartAfterEnrollment}},
+			)
+			require.NoError(t, err)
+
+			response := string(re.Bytes())
+
+			require.Contains(t, response, `$ErrorActionPreference = 'Stop'`)
+			require.Contains(t, response, `$InstallerName = "teleport-windows-auth-setup-`)
+			// The installstatus exit codes survived the fmt.Sprintf injection.
+			require.Contains(t, response, "exit 200") // WindowsInstallerDownloadFailure
+			require.Contains(t, response, "exit 201") // WindowsInstallerExecutionFailure
+
+			// getWindowsCA rendered a non-empty CA bundle, and no template
+			// directives were left unrendered.
+			require.NotContains(t, response, "{{")
+			require.NotContains(t, response, `$CA = ''`)
+
+			// The RestartAfterEnrollment branch resolved correctly.
+			require.Contains(t, response, tt.expectContains)
+			require.NotContains(t, response, tt.expectNotContains)
+		})
+	}
+}
+
 func TestMultipleConnectors(t *testing.T) {
 	t.Parallel()
 	s := newWebSuite(t)


### PR DESCRIPTION
This PR adds a windows installer script resource that returns a PowerShell script that will:

1. Get the cluster's Windows CA certs
2. Download the Teleport Authentication Package installer
3. Run the installer with the certificates
4. Optionally, restart the host

This work is part of the larger goal of allowing discovery of non-AD Windows desktops on Azure. Issue [here](https://github.com/gravitational/teleport/issues/68240). RFD [here](https://github.com/gravitational/rfd/pull/17).

## Manual Test Plan
### Test Environment
Run a local teleport cluster and call the endpoint to generate a script using:
`curl -k "https://<proxy>/webapi/scripts/installer/default-installer-windows-desktop?restart-after-enrollment=false"`.
No other machinery for auto discovery is in the branch, so to test, I ran the script returned on a Windows Host. This is also dependent on https://github.com/gravitational/teleport.e/pull/9081 which allows the auth package installer to accept PEM bundles. The authentication package installer also has to be dropped on to the box manually because the v19.0.0.blah doesn't exist on the CDN.
### Test Cases
- [x] The script ran the installer with certs and doesn't reboot when `restart-after-enrollment=false`
- [x] The script ran the installer with certs and does reboot when `restart-after-enrollment=true`
- [x] The Windows CA bundle is populated
