### PR TITLE
iOS: Add plumbing for new DebugView

### DIFF
--- a/mobile/Verify/Verify/Architecture/SheetPresentable.swift
+++ b/mobile/Verify/Verify/Architecture/SheetPresentable.swift
@@ -21,6 +21,6 @@ protocol SheetPresentable {
 	associatedtype PresentationID: Hashable
 	/// The ID to use for presentation purposes in things like `.sheet` SwiftUI modifiers
 	///
-	/// If there is no real distinction bewteen instances of a particular type, consider supplying a constant value.
+	/// If there is no real distinction between instances of a particular type, consider supplying a constant value.
 	var presentationID: PresentationID { get }
 }

--- a/mobile/Verify/Verify/Architecture/SheetPresentable.swift
+++ b/mobile/Verify/Verify/Architecture/SheetPresentable.swift
@@ -1,0 +1,26 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/
+
+/// For the purposes of presentation, we often need some kind of identifier which will distinguish between two view
+/// models of the same type. This protocol formalizes the concept and gives us a place to put convenience accessors
+/// and documentation.
+protocol SheetPresentable {
+	associatedtype PresentationID: Hashable
+	/// The ID to use for presentation purposes in things like `.sheet` SwiftUI modifiers
+	///
+	/// If there is no real distinction bewteen instances of a particular type, consider supplying a constant value.
+	var presentationID: PresentationID { get }
+}

--- a/mobile/Verify/Verify/Features/Debugging/DebugView.swift
+++ b/mobile/Verify/Verify/Features/Debugging/DebugView.swift
@@ -1,0 +1,33 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/
+
+#if DEBUG
+
+	import SwiftUI
+
+	/// DebugView serves as the entrypoint for in-development ideas, UI component catalogs, and any other bits that we
+	/// want to be able to see when testing on a device, but which we don't want to ship to customers.
+	///
+	/// - Note: DebugView and all its associated components should always be wrapped in `#if DEBUG` checks.
+	struct DebugView: View {
+		var viewModel: DebugViewModel
+
+		var body: some View {
+			Text("Placeholder for DebugView")
+		}
+	}
+
+#endif

--- a/mobile/Verify/Verify/Features/Debugging/DebugViewModel.swift
+++ b/mobile/Verify/Verify/Features/Debugging/DebugViewModel.swift
@@ -1,0 +1,32 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/
+
+#if DEBUG
+
+	import Observation
+
+	@Observable
+	final class DebugViewModel {}
+
+	// MARK: - SheetPresentable
+
+	extension DebugViewModel: SheetPresentable {
+		var presentationID: some Hashable {
+			"DebugViewModel"
+		}
+	}
+
+#endif

--- a/mobile/Verify/Verify/Features/Enrollment/EnrollCameraScannerViewModel.swift
+++ b/mobile/Verify/Verify/Features/Enrollment/EnrollCameraScannerViewModel.swift
@@ -72,12 +72,10 @@ extension EnrollCameraScannerViewModel {
 	}
 }
 
-// MARK: - Navigation Helpers
+// MARK: - SheetPresentable
 
-extension EnrollCameraScannerViewModel {
-	/// For the purposes of presentation, there is no distinction between instances of EnrollCameraScannerViewModel,
-	/// so we vend this constant presentation ID to express that to SwiftUI.
-	var presentationID: String {
+extension EnrollCameraScannerViewModel: SheetPresentable {
+	var presentationID: some Hashable {
 		"EnrollCameraScannerViewModel"
 	}
 }

--- a/mobile/Verify/Verify/Features/Landing/LandingView.swift
+++ b/mobile/Verify/Verify/Features/Landing/LandingView.swift
@@ -45,6 +45,9 @@ struct LandingView: View {
 			}
 			.padding(.horizontal)
 			.background(Color.Background.depth3)
+
+			// MARK: Toolbar
+			
 			.toolbarVisibility(viewModel.shouldShowToolbar ? .visible : .hidden)
 			.toolbar {
 				ToolbarItem {
@@ -55,6 +58,14 @@ struct LandingView: View {
 							role: .destructive,
 							action: viewModel.userTappedForgetAllClusters,
 						)
+						#if DEBUG
+							Divider()
+							Button(
+								"Debug",
+								systemImage: "apple.terminal",
+								action: viewModel.userTappedOnDebugButton,
+							)
+						#endif
 					} label: {
 						Label("Menu", systemImage: "ellipsis")
 					}
@@ -80,6 +91,17 @@ struct LandingView: View {
 			// MARK: Haptics
 
 			.sensoryFeedback(.success, trigger: viewModel.sensoryFeedbackTrigger)
+
+			// MARK: Debug
+
+			// swiftformat:disable indent
+			#if DEBUG
+			.sheet(item: $viewModel.destination.debug, id: \.presentationID) { debugViewModel in
+				DebugView(viewModel: debugViewModel)
+			}
+			#endif
+			// swiftformat:enable indent
+
 		}
 	}
 }

--- a/mobile/Verify/Verify/Features/Landing/LandingViewModel.swift
+++ b/mobile/Verify/Verify/Features/Landing/LandingViewModel.swift
@@ -31,6 +31,9 @@ final class LandingViewModel {
 		case enrollDevice(EnrollDeviceViewModel)
 		case forgetAllClustersAlert(AlertState<ForgetAllClustersAlertAction>)
 		case notice(AlertState<Void>)
+		#if DEBUG
+			case debug(DebugViewModel)
+		#endif
 	}
 
 	@ObservationIgnored
@@ -120,6 +123,12 @@ extension LandingViewModel {
 	func userConfirmedForgetAllClusters() async {
 		await deleteClusters { Cluster.delete() }
 	}
+
+	#if DEBUG
+	func userTappedOnDebugButton() {
+		destination = .debug(DebugViewModel())
+	}
+	#endif
 }
 
 // MARK: - Programmatic Navigation


### PR DESCRIPTION
It's often desirable in iOS apps to have a view that's "debug-only" (i.e. only for local testing) because it gives us a surface to put things for testing purposes without shipping it to customers. Among these are UI component catalogs, works-in-progress, and demonstrations of features that are otherwise difficult to test. The immediate impetus for me creating this now is that I wanted a surface where I can iterate on work with the secure enclave on iOS.

This PR merely sets up all the plumbing for the `DebugView` to appear from a menu item in `LandingView`.


https://github.com/user-attachments/assets/c170c303-dd72-4c10-afa8-c53c4a101650

