### PR TITLE
Fix flaky TestProxyKubeServerWatcher_StartsWithFaultyPrimary

### DIFF
--- a/lib/kube/proxy/watcher/watcher_test.go
+++ b/lib/kube/proxy/watcher/watcher_test.go
@@ -149,9 +149,11 @@ func testProxyKubeServerWatcherStartsWithFaultyPrimarySynctest(t *testing.T) {
 	fallback := &mockKubeServerWatcherGetter{}
 
 	var calls int32
+	primaryReady := make(chan time.Time)
 
 	primary.On("NewWatcher", mock.Anything, mock.Anything).
 		Return(nil, context.DeadlineExceeded).
+		WaitUntil(primaryReady).
 		Run(func(args mock.Arguments) {
 			atomic.AddInt32(&calls, 1)
 		})
@@ -169,16 +171,17 @@ func testProxyKubeServerWatcherStartsWithFaultyPrimarySynctest(t *testing.T) {
 	t.Cleanup(w.Close)
 
 	waitCh := make(chan error)
-	defer close(waitCh)
 
 	go func() {
 		// This should block until the watcher is ready or closed.
 		waitCh <- w.WaitInitialization()
 	}()
+	synctest.Wait()
 
 	require.True(t, isHealthy(w), "Watcher starts healthy")
 	require.False(t, w.IsInitialized())
 
+	close(primaryReady)
 	time.Sleep(2 * time.Second)
 	require.False(t, w.IsInitialized())
 	require.False(t, isHealthy(w), "Watcher should not be hot since primary is failing")


### PR DESCRIPTION
Before this commit, NewProxyKubeServerWatcher started runWatchLoop immediately, and the mocked primary NewWatcher returned context.DeadlineExceeded immediately. Under synctest, the goroutine could run before the test reaches healthy assertion which makes the test flaky. With this change the synctest waits until the goroutine is blocked, then verifies health state and only after that unblocks the primary to start failing.


Fixes #68652 

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local.
### Test Cases
- [x] `stress -p 300 -failfast /tmp/kubewatcher.test -test.run '^TestProxyKubeServerWatcher_StartsWithFaultyPrimary$'`
