### PR TITLE
Publish discovery service configuration heartbeats

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/reference/heartbeats.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/reference/heartbeats.mdx
@@ -1,0 +1,78 @@
+---
+title: Discovery Service Heartbeats Reference
+sidebar_label: Discovery Service Heartbeats
+description: Describes how Discovery Services report configuration snapshots and recent authenticated announcements.
+tags:
+ - reference
+ - zero-trust
+ - infrastructure-identity
+page_type: reference
+---
+
+A Teleport Discovery Service periodically attempts to publish a configuration
+heartbeat: a `discovery_service` resource named by the service's host ID. The
+resource is a bounded snapshot of the service's effective static configuration
+and instance context. Dynamic configuration is not included.
+
+The Auth Service assigns an expiry when it stores an announcement. An
+unexpired resource means that Auth authenticated and stored an announcement
+before its server-assigned TTL elapsed. It does not prove that the Discovery
+Service is currently reachable or that a discovery cycle succeeded.
+
+## Reading heartbeats
+
+List all Discovery Service heartbeats:
+
+```code
+$ tctl get discovery_services
+```
+
+Fetch one service's full configuration by host ID. Assign <Var name="host-id" />
+to the host ID of the Discovery Service instance to inspect, shown in the
+`metadata.name` field of the `tctl get discovery_services` output:
+
+```code
+$ tctl get discovery_service/<Var name="host-id" /> --format=yaml
+```
+
+Only the Discovery Service itself can create or modify its heartbeat. A user
+role with the `delete` verb can remove one; if the service is still reporting,
+it recreates the record on its next renewal. The preset `editor` and `auditor`
+roles can read heartbeats; grant a custom role `read` and `list` on the
+`discovery_service` kind to allow access. Teleport denies access when a role
+does not have the required verbs.
+
+## Fields
+
+The heartbeat spec carries configuration only — what the service is set up to
+discover — never runtime results:
+
+- `hostname`, `teleport_version`: identity of the reporting instance.
+- `discovery_group`: the discovery group this instance claims. Dynamic
+  `discovery_config` resources are processed only by services whose group
+  matches exactly.
+- `poll_interval`: the cadence of the service's discovery cycles.
+- `static_matchers`: a discovery-oriented projection of the effective matchers
+  from the service's configuration file after local defaults and filtering.
+  AWS, Azure, and GCP installer parameters are not reported.
+- `matchers_truncated` and `static_matcher_counts`: set when the matcher
+  detail exceeded the reporting size budget; per-cloud counts remain
+  available and consumers must treat matcher visibility as partial.
+
+Dynamic `discovery_config` resources are intended assignments inferred by an
+exact match between their `discovery_group` and the group claimed by a service.
+Read the resources separately with `tctl get discovery_config`. A group match
+does not prove that a configuration was observed, applied, or is running.
+
+## Troubleshooting with heartbeats
+
+Inspect `discovery_service` and `discovery_config` resources separately when
+investigating intended group assignments. A missing heartbeat does
+not identify a single cause. The service may be stopped or running a Teleport
+version that predates heartbeat support, or publication may be failing because
+of Auth Service, network, or authorization problems.
+
+Likewise, the absence of an unexpired heartbeat with a matching
+`discovery_group` does not prove that no service is processing a
+`discovery_config`. Heartbeats are diagnostic evidence, not a complete health
+or reachability check.

--- a/docs/pages/includes/discovery/discovery-group.mdx
+++ b/docs/pages/includes/discovery/discovery-group.mdx
@@ -18,4 +18,10 @@ the following configuration.
 from Production account.
 - 2 Discovery Services configured with `discovery_group: "staging"` polling data
 from Staging account.
+
+Each Discovery Service reports the `discovery_group` it claims on its
+configuration heartbeat, so group assignments can be inspected with
+`tctl get discovery_services`. Dynamic configurations are inferred as intended
+assignments only when their group matches exactly; a heartbeat does not prove
+that they were observed, applied, or are running.
 </Admonition>

--- a/docs/pages/includes/discovery/discovery-service-troubleshooting.mdx
+++ b/docs/pages/includes/discovery/discovery-service-troubleshooting.mdx
@@ -2,7 +2,29 @@
 
 ### Discovery Service troubleshooting
 
-First, check if any {{ resourceKind }}s have been discovered.
+First, inspect the Discovery Service heartbeats that Auth currently stores:
+
+```code
+$ tctl get discovery_services
+```
+
+A listed configuration heartbeat shows the Discovery Service's claimed
+`discovery_group` and a discovery-oriented projection of its effective static
+matchers. AWS, Azure, and GCP installer parameters are not reported. Dynamic
+`discovery_config` resources are inferred as intended assignments when their
+`discovery_group` matches exactly. A heartbeat does not prove that a dynamic
+configuration was observed, applied, or is running; inspect the local
+Discovery Service logs and discovered resources when diagnosing adoption.
+
+Inspect `discovery_service` and `discovery_config` resources separately when
+checking their group values. The absence of an unexpired heartbeat with a
+matching group does not prove that no service is processing a configuration.
+A heartbeat can be absent because the service is stopped, runs a Teleport
+version that predates configuration heartbeats, cannot reach Auth, or cannot
+publish its snapshot. Access to heartbeat resources also requires `read` and
+`list` permissions for the `discovery_service` kind.
+
+Next, check if any {{ resourceKind }}s have been discovered.
 To do this, you can use the `tctl get {{ tctlResource }}` command and check if the
 expected {{ resourceKind }}s have already been registered with your Teleport
 cluster.

--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -83,16 +83,18 @@ func (process *TeleportProcess) initDiscoveryService() error {
 			Kubernetes:  process.Config.Discovery.KubernetesMatchers,
 			AccessGraph: process.Config.Discovery.AccessGraph,
 		},
-		DiscoveryGroup:    process.Config.Discovery.DiscoveryGroup,
-		Emitter:           asyncEmitter,
-		AccessPoint:       accessPoint,
-		ServerID:          conn.HostUUID(),
-		Log:               process.logger,
-		ClusterName:       conn.ClusterName(),
-		ClusterFeatures:   process.GetClusterFeatures,
-		PollInterval:      process.Config.Discovery.PollInterval,
-		GetClientCert:     conn.ClientGetCertificate,
-		AccessGraphConfig: accessGraphCfg,
+		DiscoveryGroup:            process.Config.Discovery.DiscoveryGroup,
+		Emitter:                   asyncEmitter,
+		AccessPoint:               accessPoint,
+		ServerID:                  conn.HostUUID(),
+		Hostname:                  process.Config.Hostname,
+		DiscoveryServiceAnnouncer: conn.Client,
+		Log:                       process.logger,
+		ClusterName:               conn.ClusterName(),
+		ClusterFeatures:           process.GetClusterFeatures,
+		PollInterval:              process.Config.Discovery.PollInterval,
+		GetClientCert:             conn.ClientGetCertificate,
+		AccessGraphConfig:         accessGraphCfg,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -117,9 +119,8 @@ func (process *TeleportProcess) initDiscoveryService() error {
 	}
 	logger.InfoContext(process.ExitContext(), "Discovery service has successfully started")
 
-	// The Discovery service doesn't have heartbeats so we cannot use them to check health.
-	// For now, we just mark ourselves ready all the time on startup.
-	// If we don't, a process only running the Discovery service will never report ready.
+	// Discovery readiness reflects successful role initialization. The
+	// configuration announcer is diagnostic and must not drive process health.
 	process.OnHeartbeat(teleport.ComponentDiscovery)(nil)
 
 	if err := discoveryService.Wait(); err != nil {

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -154,6 +155,12 @@ type Config struct {
 	Log *slog.Logger
 	// ServerID identifies the Teleport instance where this service runs.
 	ServerID string
+	// Hostname is the hostname of the machine running this service, reported
+	// on the configuration heartbeat for troubleshooting.
+	Hostname string
+	// DiscoveryServiceAnnouncer upserts this service's configuration
+	// heartbeat resource. Nil disables heartbeating.
+	DiscoveryServiceAnnouncer Announcer
 	// onDatabaseReconcile is called after each database resource reconciliation.
 	onDatabaseReconcile func()
 	// onKubernetesClusterReconcile is called after each Kubernetes cluster resource reconciliation.
@@ -202,6 +209,9 @@ type Config struct {
 	// jitter is a function which applies random jitter to a duration.
 	// It is used to add Expiration times to Resources that don't support Heartbeats (eg EICE Nodes).
 	jitter retryutils.Jitter
+	// heartbeatJitter applies full jitter to heartbeat scheduling intervals.
+	// It is overridden by heartbeat scheduling tests.
+	heartbeatJitter retryutils.Jitter
 
 	// initAzureClients initializes an instance of Azure clients with particular options.
 	initAzureClients func(opts ...azure.ClientsOption) (azure.Clients, error)
@@ -358,6 +368,16 @@ kubernetes matchers are present.`)
 	if c.Log == nil {
 		c.Log = slog.Default()
 	}
+	if c.Hostname == "" {
+		// Hostname is diagnostic heartbeat context only: when it cannot be
+		// determined, the service starts anyway and heartbeats carry an
+		// empty hostname rather than blocking startup on a cosmetic field.
+		hostname, err := os.Hostname()
+		if err != nil {
+			c.Log.WarnContext(context.Background(), "Failed to determine hostname for discovery service heartbeat", "error", err)
+		}
+		c.Hostname = hostname
+	}
 
 	if c.protocolChecker == nil {
 		c.protocolChecker = fetchers.NewProtoChecker()
@@ -389,6 +409,9 @@ kubernetes matchers are present.`)
 	c.Matchers.Azure = services.SimplifyAzureMatchers(c.Matchers.Azure)
 
 	c.jitter = retryutils.SeventhJitter
+	if c.heartbeatJitter == nil {
+		c.heartbeatJitter = retryutils.FullJitter
+	}
 
 	return nil
 }
@@ -2061,6 +2084,9 @@ func (s *Server) submitFetchEvent(cloudProvider, resourceType string) {
 
 // Start starts the discovery service.
 func (s *Server) Start() error {
+	if s.DiscoveryServiceAnnouncer != nil {
+		s.startHeartbeatAnnouncer()
+	}
 	if s.ec2Watcher != nil {
 		go s.startAWSServerDiscovery()
 		go s.reconciler.run(s.ctx)
@@ -2354,14 +2380,15 @@ func discardAmbientCredentialMatchers(ctx context.Context, log *slog.Logger, m *
 		m.GCP = []types.GCPMatcher{}
 	}
 
-	filtered := slices.DeleteFunc(m.Azure, func(matcher types.AzureMatcher) bool {
+	// Clone before DeleteFunc: m.Azure aliases the process config slice, which
+	// the heartbeat path also reads, and DeleteFunc zeroes the backing array.
+	validAzureMatchers := slices.DeleteFunc(slices.Clone(m.Azure), func(matcher types.AzureMatcher) bool {
 		return matcher.Integration == ""
 	})
-	discarded := len(m.Azure) - len(filtered)
-	if discarded > 0 {
-		m.Azure = filtered
+	if discarded := len(m.Azure) - len(validAzureMatchers); discarded > 0 {
 		log.WarnContext(ctx, "Discarded Azure matchers without integration", "count", discarded)
 	}
+	m.Azure = validAzureMatchers
 
 	if len(m.Kubernetes) > 0 {
 		log.WarnContext(ctx, "Discarding Kubernetes matchers - missing integration")

--- a/lib/srv/discovery/heartbeat.go
+++ b/lib/srv/discovery/heartbeat.go
@@ -1,0 +1,272 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/gravitational/teleport"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	discoveryservicev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryservice/v1"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils/slices"
+)
+
+const (
+	// heartbeatCheckPeriod bounds how late the announcer observes a retry or
+	// renewal deadline. Snapshot construction happens only when one is due.
+	heartbeatCheckPeriod = 5 * time.Second
+	// heartbeatTTL is how long an Auth-stored heartbeat remains present without
+	// renewal. Absence does not identify why announcements stopped.
+	heartbeatTTL = apidefaults.ServerAnnounceTTL
+	// heartbeatRetryPeriod is how long the announcer waits before retrying
+	// after a transient announce failure.
+	heartbeatRetryPeriod = 30 * time.Second
+	// heartbeatRetryJitter is the maximum positive jitter added to each
+	// retry wait so a fleet failing together does not retry together.
+	heartbeatRetryJitter = 5 * time.Second
+	// heartbeatRenewalJitter is the maximum positive jitter added to each
+	// renewal interval so instance renewals spread out across the fleet.
+	heartbeatRenewalJitter = time.Minute
+	// heartbeatRPCTimeout bounds a single announce RPC so a hung call
+	// cannot block the loop past the next check deadline indefinitely.
+	heartbeatRPCTimeout = 20 * time.Second
+
+	// maxStaticMatchersSize caps the serialized size of the static matcher
+	// detail carried on the heartbeat. When the assembled payload exceeds the
+	// cap, detail is replaced by per-cloud counts
+	// with matchers_truncated set; never silently shortened, because a
+	// partial matcher list produces confidently wrong diagnostics.
+	maxStaticMatchersSize = 64 * 1024
+)
+
+// heartbeatAnnouncePeriod returns half the TTL plus positive jitter, bounded
+// so renewal is due no later than six minutes after the attempt starts.
+func (s *Server) heartbeatAnnouncePeriod() time.Duration {
+	jitter := s.heartbeatJitter(heartbeatRenewalJitter)
+	if jitter == 0 {
+		jitter = time.Nanosecond
+	}
+	return heartbeatTTL/2 + jitter
+}
+
+// Announcer upserts this service's configuration heartbeat resource. It is
+// satisfied by the auth client; a nil announcer disables heartbeating.
+type Announcer interface {
+	UpsertDiscoveryService(ctx context.Context, svc *discoveryservicev1.DiscoveryService) (*discoveryservicev1.DiscoveryService, error)
+}
+
+type staticMatcherProjection struct {
+	matchers  *discoveryservicev1.StaticMatchers
+	truncated bool
+	counts    map[string]int32
+}
+
+func projectMatchers[T any](matchers []T, project func(*T)) []*T {
+	return slices.Map(matchers, func(matcher T) *T {
+		if project != nil {
+			project(&matcher)
+		}
+		return &matcher
+	})
+}
+
+// buildStaticMatchers converts the effective static matcher set into its
+// heartbeat representation. Installer parameters are omitted because they
+// control post-discovery enrollment rather than resource selection. When the
+// remaining detail exceeds the size budget, it falls back to per-cloud counts
+// with matchers_truncated set.
+func (s *Server) buildStaticMatchers() (staticMatcherProjection, error) {
+	// Copies are shallow, which is enough: only top-level fields are ever
+	// written (the Params = nil projections below), never nested contents.
+	// Nested slices and label maps still alias live config, which static
+	// discovery treats as immutable after startup.
+	var accessGraph *types.AccessGraphSync
+	if s.Matchers.AccessGraph != nil {
+		accessGraphCopy := *s.Matchers.AccessGraph
+		accessGraph = &accessGraphCopy
+	}
+	staticMatchers := discoveryservicev1.StaticMatchers_builder{
+		Aws: projectMatchers(s.Matchers.AWS, func(matcher *types.AWSMatcher) {
+			matcher.Params = nil
+		}),
+		Azure: projectMatchers(s.Matchers.Azure, func(matcher *types.AzureMatcher) {
+			matcher.Params = nil
+		}),
+		Gcp: projectMatchers(s.Matchers.GCP, func(matcher *types.GCPMatcher) {
+			matcher.Params = nil
+		}),
+		Kube:        projectMatchers(s.Matchers.Kubernetes, nil),
+		AccessGraph: accessGraph,
+	}.Build()
+
+	// encoding/json measures the same open-struct representation the storage
+	// codec persists; like [services.MarshalDiscoveryService], this size check
+	// requires the generated open struct and must be revisited together with
+	// that codec before any protoopaque migration.
+	encoded, err := json.Marshal(staticMatchers)
+	if err != nil {
+		return staticMatcherProjection{}, trace.Wrap(err)
+	}
+	if len(encoded) <= maxStaticMatchersSize {
+		return staticMatcherProjection{matchers: staticMatchers}, nil
+	}
+
+	counts := make(map[string]int32)
+	setCount := func(name string, count int) {
+		if count > 0 {
+			counts[name] = int32(count)
+		}
+	}
+	setCount(services.StaticMatcherCountKeyAWS, len(s.Matchers.AWS))
+	setCount(services.StaticMatcherCountKeyAzure, len(s.Matchers.Azure))
+	setCount(services.StaticMatcherCountKeyGCP, len(s.Matchers.GCP))
+	setCount(services.StaticMatcherCountKeyKube, len(s.Matchers.Kubernetes))
+	if m := s.Matchers.AccessGraph; m != nil {
+		setCount(services.StaticMatcherCountKeyAccessGraph, len(m.AWS)+len(m.Azure))
+	}
+	return staticMatcherProjection{truncated: true, counts: counts}, nil
+}
+
+// buildSelfHeartbeat assembles this service's discovery_service resource from
+// current producer state immediately before a due announcement attempt. v1
+// fields originate in configuration initialized at Server startup.
+func (s *Server) buildSelfHeartbeat() (*discoveryservicev1.DiscoveryService, error) {
+	staticMatchers, err := s.buildStaticMatchers()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return discoveryservicev1.DiscoveryService_builder{
+		Kind:    types.KindDiscoveryService,
+		Version: types.V1,
+		Metadata: headerv1.Metadata_builder{
+			Name: s.ServerID,
+		}.Build(),
+		Spec: discoveryservicev1.DiscoveryServiceSpec_builder{
+			Hostname:            s.Hostname,
+			TeleportVersion:     teleport.Version,
+			DiscoveryGroup:      s.DiscoveryGroup,
+			PollInterval:        durationpb.New(s.PollInterval),
+			StaticMatchers:      staticMatchers.matchers,
+			MatchersTruncated:   staticMatchers.truncated,
+			StaticMatcherCounts: staticMatchers.counts,
+		}.Build(),
+		Status: &discoveryservicev1.DiscoveryServiceStatus{},
+	}.Build(), nil
+}
+
+type heartbeatAnnounceState struct {
+	retryNotBefore       time.Time
+	renewalDeadline      time.Time
+	loggedNotImplemented bool
+	matchersTruncated    bool
+}
+
+func (s heartbeatAnnounceState) attemptDue(now time.Time) bool {
+	if !s.retryNotBefore.IsZero() {
+		return !now.Before(s.retryNotBefore)
+	}
+	return s.renewalDeadline.IsZero() || !now.Before(s.renewalDeadline)
+}
+
+func (s *heartbeatAnnounceState) matcherTruncationStarted(truncated bool) bool {
+	started := truncated && !s.matchersTruncated
+	s.matchersTruncated = truncated
+	return started
+}
+
+func (s *Server) announceHeartbeatOnce(attemptStart time.Time, state *heartbeatAnnounceState) {
+	hb, err := s.buildSelfHeartbeat()
+	if err != nil {
+		s.Log.WarnContext(s.ctx, "Failed to build discovery service heartbeat", "error", err)
+	} else {
+		if state.matcherTruncationStarted(hb.GetSpec().GetMatchersTruncated()) {
+			s.Log.WarnContext(s.ctx, "Static matcher details exceed the discovery service heartbeat size limit and will be omitted", "limit", maxStaticMatchersSize)
+		}
+
+		ctx, cancel := clockwork.WithTimeout(s.ctx, s.clock, heartbeatRPCTimeout)
+		_, err = s.DiscoveryServiceAnnouncer.UpsertDiscoveryService(ctx, hb)
+		cancel()
+		switch {
+		case err == nil:
+			state.retryNotBefore = time.Time{}
+			state.renewalDeadline = attemptStart.Add(s.heartbeatAnnouncePeriod())
+			s.Log.DebugContext(s.ctx, "Announced discovery service heartbeat", "renewal_deadline", state.renewalDeadline)
+			return
+		case trace.IsNotImplemented(err):
+			if !state.loggedNotImplemented {
+				s.Log.WarnContext(s.ctx, "Auth server does not support discovery service heartbeats; will retry periodically until it is upgraded")
+				state.loggedNotImplemented = true
+			}
+		default:
+			// A canceled server context means shutdown interrupted the
+			// RPC; that is not an announce failure and logging it as one
+			// makes a routine shutdown look like a heartbeat problem.
+			if s.ctx.Err() != nil {
+				return
+			}
+			s.Log.WarnContext(s.ctx, "Failed to announce discovery service heartbeat", "error", err)
+		}
+	}
+	state.retryNotBefore = s.clock.Now().Add(heartbeatRetryPeriod + s.heartbeatJitter(heartbeatRetryJitter))
+}
+
+// startHeartbeatAnnouncer runs the announce loop until the server context is
+// done: a full upsert on start and at every jittered renewal interval. The
+// snapshot is rebuilt only when an attempt is due. All failures, including
+// snapshot construction and NotImplemented, use the ordinary bounded retry.
+// Publication is diagnostic and does not affect service readiness.
+//
+// The loop is deliberately not built on srv.Heartbeat or srv.HeartbeatV2:
+// the former announces legacy types.Resource values through a shared per-mode
+// state machine that every new resource kind must be registered into, and the
+// latter rides the inventory control stream, whose fleet-global schema this
+// service-specific payload should not extend. A protov2 resource announced
+// through its own self-scoped RPC needs neither; the cost is this small loop.
+func (s *Server) startHeartbeatAnnouncer() {
+	go func() {
+		var state heartbeatAnnounceState
+
+		ticker := s.clock.NewTicker(heartbeatCheckPeriod)
+		defer ticker.Stop()
+		for {
+			// A due attempt against an already-canceled context would fail
+			// instantly and log a spurious announce failure during shutdown.
+			if s.ctx.Err() != nil {
+				return
+			}
+			now := s.clock.Now()
+			if state.attemptDue(now) {
+				s.announceHeartbeatOnce(now, &state)
+			}
+			select {
+			case <-s.ctx.Done():
+				return
+			case <-ticker.Chan():
+			}
+		}
+	}()
+}

--- a/lib/srv/discovery/heartbeat_test.go
+++ b/lib/srv/discovery/heartbeat_test.go
@@ -1,0 +1,512 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package discovery
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+
+	discoveryservicev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryservice/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+func TestBuildSelfHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	s := &Server{
+		Config: &Config{
+			ServerID:       "aaaaaaaa-1111-2222-3333-444444444444",
+			Hostname:       "disc-1.example.com",
+			DiscoveryGroup: "demo",
+			PollInterval:   5 * time.Minute,
+			Matchers: Matchers{
+				AWS: []types.AWSMatcher{{
+					Types:       []string{"ec2"},
+					Regions:     []string{"us-east-1"},
+					Integration: "my-oidc",
+					Tags:        types.Labels{"env": []string{"prod"}},
+				}},
+				Azure: []types.AzureMatcher{{
+					Types:         []string{"vm"},
+					Regions:       []string{"eastus"},
+					Subscriptions: []string{"sub-1"},
+					Integration:   "azure-int",
+				}},
+			},
+			clock: clock,
+		},
+	}
+
+	first, err := s.buildSelfHeartbeat()
+	require.NoError(t, err)
+
+	require.Equal(t, "demo", first.GetSpec().GetDiscoveryGroup())
+	require.Equal(t, s.ServerID, first.GetMetadata().GetName())
+	require.Nil(t, first.GetMetadata().GetExpires(), "client must leave expiry for Auth to assign")
+	require.Len(t, first.GetSpec().GetStaticMatchers().GetAws(), 1)
+	require.False(t, first.GetSpec().GetMatchersTruncated())
+}
+
+// TestBuildSelfHeartbeatOmitsInstallerParams verifies that the heartbeat
+// reports discovery selectors without post-discovery enrollment settings and
+// does not mutate the matchers used by the service.
+func TestBuildSelfHeartbeatOmitsInstallerParams(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		Config: &Config{
+			ServerID: "host-1",
+			Matchers: Matchers{
+				AWS: []types.AWSMatcher{{
+					Types:   []string{"ec2"},
+					Regions: []string{"us-east-1"},
+					Params: &types.InstallerParams{
+						JoinToken: "aws-token-name",
+						HTTPProxySettings: &types.HTTPProxySettings{
+							HTTPProxy:  "http://aws-user:aws-password@proxy.example.com:8080",
+							HTTPSProxy: "https://aws-user:aws-password@proxy.example.com:8443/path?mode=connect",
+							NoProxy:    "localhost,127.0.0.1",
+						},
+					}}},
+				Azure: []types.AzureMatcher{{
+					Types:   []string{"vm"},
+					Regions: []string{"eastus"},
+					Params: &types.InstallerParams{
+						HTTPProxySettings: &types.HTTPProxySettings{
+							HTTPSProxy: "https://azure-user@proxy.example.com:8443",
+						},
+					}}},
+				GCP: []types.GCPMatcher{{
+					Types:     []string{"vm"},
+					Locations: []string{"us-central1"},
+					Params: &types.InstallerParams{
+						HTTPProxySettings: &types.HTTPProxySettings{
+							HTTPProxy: "gcp-user:gcp-password@proxy.example.com:8080",
+						},
+					}}},
+				Kubernetes: []types.KubernetesMatcher{{
+					Types:      []string{"app"},
+					Namespaces: []string{"production"},
+				}},
+			},
+			clock: clockwork.NewFakeClock(),
+		},
+	}
+	originalMatchers, err := json.Marshal(s.Matchers)
+	require.NoError(t, err)
+
+	hb, err := s.buildSelfHeartbeat()
+	require.NoError(t, err)
+	matchers := hb.GetSpec().GetStaticMatchers()
+	require.Nil(t, matchers.GetAws()[0].Params)
+	require.Nil(t, matchers.GetAzure()[0].Params)
+	require.Nil(t, matchers.GetGcp()[0].Params)
+	require.Equal(t, []string{"ec2"}, matchers.GetAws()[0].Types)
+	require.Equal(t, []string{"us-east-1"}, matchers.GetAws()[0].Regions)
+	require.Equal(t, []string{"vm"}, matchers.GetAzure()[0].Types)
+	require.Equal(t, []string{"eastus"}, matchers.GetAzure()[0].Regions)
+	require.Equal(t, []string{"vm"}, matchers.GetGcp()[0].Types)
+	require.Equal(t, []string{"us-central1"}, matchers.GetGcp()[0].Locations)
+	require.Equal(t, []string{"app"}, matchers.GetKube()[0].Types)
+	require.Equal(t, []string{"production"}, matchers.GetKube()[0].Namespaces)
+
+	encoded, err := json.Marshal(hb)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "aws-token-name")
+	require.NotContains(t, string(encoded), "aws-password")
+	require.NotContains(t, string(encoded), "azure-user")
+	require.NotContains(t, string(encoded), "gcp-password")
+
+	afterBuild, err := json.Marshal(s.Matchers)
+	require.NoError(t, err)
+	require.Equal(t, originalMatchers, afterBuild, "building a heartbeat must not mutate runtime matchers")
+
+	// The projected matcher must not point directly at the live slice element.
+	s.Matchers.Kubernetes[0] = types.KubernetesMatcher{Types: []string{"service"}}
+	require.Equal(t, []string{"app"}, matchers.GetKube()[0].Types)
+}
+
+// TestDiscardUnsupportedMatchers verifies that heartbeats report the effective
+// static matcher set after unsupported matchers have been filtered.
+func TestDiscardUnsupportedMatchers(t *testing.T) {
+	t.Parallel()
+
+	makeMatchers := func() Matchers {
+		return Matchers{
+			AWS: []types.AWSMatcher{
+				{Types: []string{"ec2"}, Integration: "int-1"},
+				{Types: []string{"rds"}}, // no integration -> discarded
+				{Types: []string{"eks"}, Integration: "int-2"},
+			},
+			Azure: []types.AzureMatcher{
+				{Types: []string{"vm"}}, // no integration -> discarded
+				{Types: []string{"aks"}, Integration: "int-3"},
+			},
+			GCP: []types.GCPMatcher{
+				{Types: []string{"gce"}}, // all GCP discarded
+			},
+		}
+	}
+
+	t.Run("integration-only mode reports effective matchers", func(t *testing.T) {
+		s := &Server{Config: &Config{
+			IntegrationOnlyCredentials: true,
+			Log:                        slog.Default(),
+			clock:                      clockwork.NewFakeClock(),
+		}}
+		s.ctx = t.Context()
+
+		m := makeMatchers()
+		s.discardUnsupportedMatchers(&m)
+
+		require.Len(t, m.AWS, 2, "effective AWS set keeps only integration matchers")
+		require.Len(t, m.Azure, 1)
+		require.Empty(t, m.GCP)
+
+		s.Matchers = m
+		hb, err := s.buildSelfHeartbeat()
+		require.NoError(t, err)
+		require.Len(t, hb.GetSpec().GetStaticMatchers().GetAws(), 2)
+		require.Len(t, hb.GetSpec().GetStaticMatchers().GetAzure(), 1)
+		require.Empty(t, hb.GetSpec().GetStaticMatchers().GetGcp())
+	})
+
+	t.Run("self-hosted mode discards nothing", func(t *testing.T) {
+		s := &Server{Config: &Config{
+			IntegrationOnlyCredentials: false,
+			Log:                        slog.Default(),
+		}}
+		s.ctx = t.Context()
+
+		m := makeMatchers()
+		s.discardUnsupportedMatchers(&m)
+		require.Len(t, m.AWS, 3, "matchers untouched")
+	})
+}
+
+// TestStaticMatcherTruncation verifies the size-budget fallback: an
+// over-budget matcher set is replaced by per-cloud counts with the truncation
+// flag set; never a silently shortened list.
+func TestStaticMatcherTruncation(t *testing.T) {
+	t.Parallel()
+
+	huge := make([]types.AWSMatcher, 0, 512)
+	for range 512 {
+		huge = append(huge, types.AWSMatcher{
+			Types:       []string{"ec2", "rds", "eks"},
+			Regions:     []string{"us-east-1", "us-west-2", "eu-central-1"},
+			Integration: strings.Repeat("integration-name-", 8),
+			Tags:        types.Labels{"env": []string{strings.Repeat("v", 64)}},
+		})
+	}
+	s := &Server{
+		Config: &Config{
+			ServerID: "host-1",
+			Matchers: Matchers{
+				AWS: huge,
+				GCP: []types.GCPMatcher{{Types: []string{"gce"}}},
+				AccessGraph: &types.AccessGraphSync{
+					AWS:   []*types.AccessGraphAWSSync{{}, {}},
+					Azure: []*types.AccessGraphAzureSync{{}, {}, {}},
+				},
+			},
+			clock: clockwork.NewFakeClock(),
+		},
+	}
+
+	hb, err := s.buildSelfHeartbeat()
+	require.NoError(t, err)
+	spec := hb.GetSpec()
+	require.True(t, spec.GetMatchersTruncated(), "over-budget matchers must set the truncation flag")
+	require.Nil(t, spec.GetStaticMatchers(), "matcher detail must be dropped wholesale, not shortened")
+	require.EqualValues(t, 512, spec.GetStaticMatcherCounts()[services.StaticMatcherCountKeyAWS])
+	require.EqualValues(t, 1, spec.GetStaticMatcherCounts()[services.StaticMatcherCountKeyGCP])
+	require.EqualValues(t, 5, spec.GetStaticMatcherCounts()[services.StaticMatcherCountKeyAccessGraph])
+}
+
+func TestMatcherTruncationStarted(t *testing.T) {
+	var state heartbeatAnnounceState
+	require.True(t, state.matcherTruncationStarted(true), "initial truncation must be reported")
+	require.False(t, state.matcherTruncationStarted(true), "continued truncation must stay quiet")
+	require.False(t, state.matcherTruncationStarted(false), "recovery must not be reported as truncation")
+	require.True(t, state.matcherTruncationStarted(true), "truncation after recovery must be reported again")
+}
+
+type fakeAnnouncer struct {
+	calls    chan struct{}
+	services chan *discoveryservicev1.DiscoveryService
+	err      atomic.Pointer[error]
+}
+
+func newFakeAnnouncer(err error) *fakeAnnouncer {
+	fa := &fakeAnnouncer{
+		calls:    make(chan struct{}, 100),
+		services: make(chan *discoveryservicev1.DiscoveryService, 100),
+	}
+	fa.err.Store(&err)
+	return fa
+}
+
+func (f *fakeAnnouncer) UpsertDiscoveryService(ctx context.Context, svc *discoveryservicev1.DiscoveryService) (*discoveryservicev1.DiscoveryService, error) {
+	f.services <- svc
+	select {
+	case f.calls <- struct{}{}:
+	case <-ctx.Done():
+	}
+	return svc, *f.err.Load()
+}
+
+func newAnnouncerTestServer(t *testing.T, announcer Announcer, clock clockwork.Clock) *Server {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	return &Server{
+		Config: &Config{
+			ServerID:                  "host-1",
+			Log:                       slog.Default(),
+			clock:                     clock,
+			jitter:                    retryutils.SeventhJitter,
+			heartbeatJitter:           func(time.Duration) time.Duration { return time.Second },
+			DiscoveryServiceAnnouncer: announcer,
+		},
+		ctx:      ctx,
+		cancelfn: cancel,
+	}
+}
+
+// expectAnnounce waits for the bubble to go idle and requires that an
+// announce attempt has happened. Must run inside a synctest bubble.
+func expectAnnounce(t *testing.T, fa *fakeAnnouncer, msg string) {
+	t.Helper()
+	synctest.Wait()
+	select {
+	case <-fa.calls:
+	default:
+		t.Fatal(msg)
+	}
+}
+
+// expectNoAnnounce waits for the bubble to go idle and requires that no
+// announce attempt has happened. Deterministic under synctest: idleness
+// means no goroutine can still be on its way to announcing, so absence is
+// proof rather than a scheduling accident. Must run inside a synctest
+// bubble.
+func expectNoAnnounce(t *testing.T, fa *fakeAnnouncer, msg string) {
+	t.Helper()
+	synctest.Wait()
+	select {
+	case <-fa.calls:
+		t.Fatal(msg)
+	default:
+	}
+}
+
+// TestAnnouncerRenews validates the steady-state loop: announce at start,
+// silence between renewals, and a renewal after the announce period elapses.
+func TestAnnouncerRenews(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		fa := newFakeAnnouncer(nil)
+		s := newAnnouncerTestServer(t, fa, clockwork.NewRealClock())
+
+		s.startHeartbeatAnnouncer()
+		expectAnnounce(t, fa, "expected an initial announce")
+
+		time.Sleep(heartbeatCheckPeriod)
+		expectNoAnnounce(t, fa, "must not announce before renewal is due")
+
+		time.Sleep(heartbeatTTL/2 + time.Second)
+		expectAnnounce(t, fa, "expected a renewal announce after the announce period")
+	})
+}
+
+// TestAnnouncerNotImplemented validates the compatibility behavior: on
+// NotImplemented from an older auth server the announcer goes quiet and
+// uses the ordinary retry schedule so heartbeating resumes after an auth
+// upgrade without an agent restart.
+func TestAnnouncerNotImplemented(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		fa := newFakeAnnouncer(trace.NotImplemented("old auth"))
+		s := newAnnouncerTestServer(t, fa, clockwork.NewRealClock())
+
+		s.startHeartbeatAnnouncer()
+		expectAnnounce(t, fa, "expected an initial announce attempt")
+
+		time.Sleep(heartbeatRetryPeriod)
+		expectNoAnnounce(t, fa, "retry jitter must be observed by the ticker")
+
+		fa.err.Store(new(error))
+		time.Sleep(heartbeatCheckPeriod)
+		expectAnnounce(t, fa, "expected an ordinary retry after NotImplemented")
+	})
+}
+
+// TestAnnouncerRetriesOnTransientError validates that ordinary announce
+// failures retry on the retry period rather than every check period.
+func TestAnnouncerRetriesOnTransientError(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		fa := newFakeAnnouncer(trace.ConnectionProblem(nil, "boom"))
+		s := newAnnouncerTestServer(t, fa, clockwork.NewRealClock())
+
+		s.startHeartbeatAnnouncer()
+		expectAnnounce(t, fa, "expected an initial announce attempt")
+
+		time.Sleep(heartbeatCheckPeriod)
+		expectNoAnnounce(t, fa, "failed announce must back off, not retry every check period")
+
+		time.Sleep(heartbeatRetryPeriod - heartbeatCheckPeriod)
+		expectNoAnnounce(t, fa, "retry must include positive jitter")
+
+		time.Sleep(heartbeatCheckPeriod)
+		expectAnnounce(t, fa, "expected retry when the ticker observes its deadline")
+	})
+}
+
+// TestAnnouncerRebuildsSnapshotForRetry verifies that a due attempt rebuilds
+// from current producer state. v1 inputs are startup-fixed in production, but
+// this prevents a future runtime-varying field from being frozen at startup.
+// gatedAnnouncer holds each RPC open until the test releases it, so a test
+// can mutate producer state while the announcer is provably blocked inside
+// the RPC: the release send is a happens-before edge ordering the mutation
+// before the announcer's next snapshot read. synctest.Wait alone does not
+// provide that edge; it only reports quiescence.
+type gatedAnnouncer struct {
+	fa      *fakeAnnouncer
+	release chan struct{}
+}
+
+func (g *gatedAnnouncer) UpsertDiscoveryService(ctx context.Context, svc *discoveryservicev1.DiscoveryService) (*discoveryservicev1.DiscoveryService, error) {
+	res, err := g.fa.UpsertDiscoveryService(ctx, svc)
+	select {
+	case <-g.release:
+	case <-ctx.Done():
+	}
+	return res, err
+}
+
+func TestAnnouncerRebuildsSnapshotForRetry(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		fa := newFakeAnnouncer(trace.ConnectionProblem(nil, "boom"))
+		ga := &gatedAnnouncer{fa: fa, release: make(chan struct{})}
+		s := newAnnouncerTestServer(t, ga, clockwork.NewRealClock())
+		s.DiscoveryGroup = "before"
+		s.startHeartbeatAnnouncer()
+		expectAnnounce(t, fa, "expected initial attempt")
+		require.Equal(t, "before", (<-fa.services).GetSpec().GetDiscoveryGroup())
+
+		// The announcer is blocked inside the gated RPC; this write is
+		// ordered before its next snapshot read by the release send below.
+		s.DiscoveryGroup = "changed-after-start"
+		ga.release <- struct{}{}
+
+		time.Sleep(heartbeatCheckPeriod)
+		expectNoAnnounce(t, fa, "retry backoff must suppress attempts")
+		fa.err.Store(new(error))
+		time.Sleep(heartbeatRetryPeriod)
+		expectAnnounce(t, fa, "expected retry")
+		require.Equal(t, "changed-after-start", (<-fa.services).GetSpec().GetDiscoveryGroup(), "retry must rebuild from current producer state")
+		ga.release <- struct{}{}
+	})
+}
+
+type deadlineAnnouncer struct {
+	started chan time.Time
+}
+
+func (d *deadlineAnnouncer) UpsertDiscoveryService(ctx context.Context, svc *discoveryservicev1.DiscoveryService) (*discoveryservicev1.DiscoveryService, error) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return nil, trace.BadParameter("missing deadline")
+	}
+	d.started <- deadline
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func TestAnnouncerRPCDeadline(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		da := &deadlineAnnouncer{started: make(chan time.Time, 1)}
+		s := newAnnouncerTestServer(t, da, clockwork.NewRealClock())
+		start := time.Now()
+		s.startHeartbeatAnnouncer()
+
+		synctest.Wait()
+		select {
+		case deadline := <-da.started:
+			require.Equal(t, start.Add(heartbeatRPCTimeout), deadline)
+		default:
+			t.Fatal("RPC did not start")
+		}
+
+		time.Sleep(heartbeatCheckPeriod)
+		synctest.Wait()
+		select {
+		case <-da.started:
+			t.Fatal("a second RPC started while the first was still in flight")
+		default:
+		}
+	})
+}
+
+// cancelingAnnouncer cancels the server context from inside the RPC,
+// simulating a shutdown racing an in-flight announce.
+type cancelingAnnouncer struct{ cancel context.CancelFunc }
+
+func (c cancelingAnnouncer) UpsertDiscoveryService(ctx context.Context, svc *discoveryservicev1.DiscoveryService) (*discoveryservicev1.DiscoveryService, error) {
+	c.cancel()
+	return nil, context.Canceled
+}
+
+// TestAnnouncerShutdownQuiet validates that a shutdown canceling an
+// in-flight announce RPC is not logged as an announce failure: the loop is
+// exiting, and a spurious "Failed to announce" on every shutdown trains
+// operators to ignore the warning that matters.
+func TestAnnouncerShutdownQuiet(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var quiet bytes.Buffer
+		s := newAnnouncerTestServer(t, nil, clockwork.NewRealClock())
+		s.Log = slog.New(slog.NewTextHandler(&quiet, nil))
+		s.DiscoveryServiceAnnouncer = cancelingAnnouncer{cancel: s.cancelfn}
+
+		var state heartbeatAnnounceState
+		s.announceHeartbeatOnce(time.Now(), &state)
+		require.NotContains(t, quiet.String(), "Failed to announce",
+			"shutdown-canceled announce must not be logged as a failure")
+
+		// Control: the same failure with a live server context must log,
+		// proving the capture above can observe the warning at all.
+		var noisy bytes.Buffer
+		s2 := newAnnouncerTestServer(t, newFakeAnnouncer(trace.BadParameter("boom")), clockwork.NewRealClock())
+		s2.Log = slog.New(slog.NewTextHandler(&noisy, nil))
+
+		var state2 heartbeatAnnounceState
+		s2.announceHeartbeatOnce(time.Now(), &state2)
+		require.Contains(t, noisy.String(), "Failed to announce")
+	})
+}


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/61937.

#### What

 The producer half of https://github.com/gravitational/teleport/pull/68655: each Discovery Service instance now announces its configuration heartbeat to Auth on start and renews it on a jittered interval, making the fleet visible via `tctl get discovery_service`.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
