### PR TITLE
Add `ListDatabaseInstances` to GCP SQL admin client

### DIFF
--- a/lib/cloud/gcp/sql.go
+++ b/lib/cloud/gcp/sql.go
@@ -52,7 +52,7 @@ type SQLAdminClient interface {
 	GenerateEphemeralCert(ctx context.Context, db types.Database, certExpiry time.Time, pubKey crypto.PublicKey) (string, error)
 }
 
-// NewSQLAdminClient returns a SQLAdminClient interface wrapping sqladmin.Service.
+// NewSQLAdminClient returns a [SQLAdminClient] interface wrapping [sqladmin.Service].
 func NewSQLAdminClient(ctx context.Context) (SQLAdminClient, error) {
 	service, err := sqladmin.NewService(ctx)
 	if err != nil {

--- a/lib/cloud/gcp/sql.go
+++ b/lib/cloud/gcp/sql.go
@@ -25,6 +25,8 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -43,12 +45,14 @@ type SQLAdminClient interface {
 	// GetDatabaseInstance returns database instance details for the project/instance
 	// configured in a session.
 	GetDatabaseInstance(ctx context.Context, db types.Database) (*sqladmin.DatabaseInstance, error)
+	// ListDatabaseInstances lists all Cloud SQL instances in the given project, with optional region filter.
+	ListDatabaseInstances(ctx context.Context, projectID string, regions []string) ([]*sqladmin.DatabaseInstance, error)
 	// GenerateEphemeralCert returns a new PEM-encoded client certificate for
 	// the project/instance configured in a session.
 	GenerateEphemeralCert(ctx context.Context, db types.Database, certExpiry time.Time, pubKey crypto.PublicKey) (string, error)
 }
 
-// NewGCPSQLAdminClient returns a GCPSQLAdminClient interface wrapping sqladmin.Service.
+// NewSQLAdminClient returns a SQLAdminClient interface wrapping sqladmin.Service.
 func NewSQLAdminClient(ctx context.Context) (SQLAdminClient, error) {
 	service, err := sqladmin.NewService(ctx)
 	if err != nil {
@@ -95,6 +99,58 @@ func (g *gcpSQLAdminClient) GetDatabaseInstance(ctx context.Context, db types.Da
 		return nil, trace.Wrap(convertAPIError(err))
 	}
 	return dbi, nil
+}
+
+func regionsFilter(regions []string) (string, error) {
+	if len(regions) == 0 {
+		return "", nil
+	}
+	var parts []string
+	for _, region := range regions {
+		part, err := oneRegionFilter(region)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+		parts = append(parts, part)
+	}
+	return strings.Join(parts, " OR "), nil
+}
+
+var regionRe = regexp.MustCompile(`^[a-z]+-[a-z]+\d+$`)
+
+func oneRegionFilter(region string) (string, error) {
+	region = strings.TrimSpace(region)
+
+	if len(region) == 0 {
+		return "", trace.BadParameter("region cannot be blank")
+	}
+	if !regionRe.MatchString(region) {
+		return "", trace.BadParameter("invalid region: %q", region)
+	}
+
+	return fmt.Sprintf("region=%q", region), nil
+}
+
+// ListDatabaseInstances lists all Cloud SQL instances in the given project,
+// following pagination, with optional region filter.
+func (g *gcpSQLAdminClient) ListDatabaseInstances(ctx context.Context, projectID string, regions []string) ([]*sqladmin.DatabaseInstance, error) {
+	filter, err := regionsFilter(regions)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	call := g.service.Instances.List(projectID)
+	if filter != "" {
+		call = call.Filter(filter)
+	}
+	var instances []*sqladmin.DatabaseInstance
+	err = call.Pages(ctx, func(page *sqladmin.InstancesListResponse) error {
+		instances = append(instances, page.Items...)
+		return nil
+	})
+	if err != nil {
+		return nil, trace.Wrap(convertAPIError(err))
+	}
+	return instances, nil
 }
 
 // GenerateEphemeralCert returns a new client certificate created using the

--- a/lib/cloud/gcp/sql_test.go
+++ b/lib/cloud/gcp/sql_test.go
@@ -1,0 +1,78 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package gcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegionsFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		regions []string
+		want    string
+		wantErr string
+	}{
+		{
+			name:    "no regions means no filter",
+			regions: nil,
+			want:    "",
+		},
+		{
+			name:    "single region",
+			regions: []string{"us-central1"},
+			want:    `region="us-central1"`,
+		},
+		{
+			name:    "multiple regions are joined with OR",
+			regions: []string{"us-central1", "europe-west1"},
+			want:    `region="us-central1" OR region="europe-west1"`,
+		},
+		{
+			name:    "blank region is rejected",
+			regions: []string{"  "},
+			wantErr: "region cannot be blank",
+		},
+		{
+			name:    "zone is rejected",
+			regions: []string{"us-central1-a"},
+			wantErr: `invalid region: "us-central1-a"`,
+		},
+		{
+			name:    "uppercase region is rejected",
+			regions: []string{"US-CENTRAL1"},
+			wantErr: `invalid region: "US-CENTRAL1"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			filter, err := regionsFilter(tt.regions)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.want, filter)
+		})
+	}
+}

--- a/lib/cloud/mocks/gcp.go
+++ b/lib/cloud/mocks/gcp.go
@@ -21,6 +21,7 @@ package mocks
 import (
 	"context"
 	"crypto"
+	"slices"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -44,6 +45,9 @@ type GCPSQLAdminClientMock struct {
 	EphemeralCert string
 	// DatabaseUser is returned from GetUser.
 	DatabaseUser *sqladmin.User
+	// DatabaseInstances is the set of instances; ListDatabaseInstances returns
+	// those whose Project matches the requested project ID.
+	DatabaseInstances []*sqladmin.DatabaseInstance
 }
 
 func (g *GCPSQLAdminClientMock) GetUser(ctx context.Context, db types.Database, dbUser string) (*sqladmin.User, error) {
@@ -63,6 +67,30 @@ func (g *GCPSQLAdminClientMock) GetDatabaseInstance(ctx context.Context, db type
 
 func (g *GCPSQLAdminClientMock) GenerateEphemeralCert(_ context.Context, _ types.Database, _ time.Time, _ crypto.PublicKey) (string, error) {
 	return g.EphemeralCert, nil
+}
+
+func (g *GCPSQLAdminClientMock) ListDatabaseInstances(ctx context.Context, projectID string, regions []string) ([]*sqladmin.DatabaseInstance, error) {
+	var instances []*sqladmin.DatabaseInstance
+	for _, instance := range g.DatabaseInstances {
+		if len(regions) == 0 || slices.Contains(regions, instance.Region) {
+			if instance.Project == projectID {
+				instances = append(instances, instance)
+			}
+		}
+	}
+	return instances, nil
+}
+
+var _ gcp.ProjectsClient = (*GCPProjectsClientMock)(nil)
+
+// GCPProjectsClientMock implements the gcp.ProjectsClient interface for tests.
+type GCPProjectsClientMock struct {
+	// Projects is returned from ListProjects.
+	Projects []gcp.Project
+}
+
+func (m *GCPProjectsClientMock) ListProjects(ctx context.Context) ([]gcp.Project, error) {
+	return m.Projects, nil
 }
 
 // GKEClusterEntry is an entry in the GKEMock.Clusters list.


### PR DESCRIPTION
Part 1 of the series; manual testing was performed against the final part.

- https://github.com/gravitational/teleport/pull/68660
- https://github.com/gravitational/teleport/pull/68661
- https://github.com/gravitational/teleport/pull/68662
- https://github.com/gravitational/teleport/pull/68663
- https://github.com/gravitational/teleport/pull/68501 