### PR TITLE
Add Cloud SQL instance to `types.Database` conversion

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -980,10 +980,9 @@ const (
 	// cloud-specific labels from eachother.
 	cloudKubeClusterNameOverrideLabel = "TeleportKubernetesName"
 
-	// cloudDatabaseNameOverrideLabel is a cloud agnostic label key for
-	// overriding the database name in discovered cloud databases.
-	// It's used for AWS, GCP, and Azure, but not exported to decouple the
-	// cloud-specific labels from eachother.
+	// cloudDatabaseNameOverrideLabel is a label key for overriding the database
+	// name in discovered cloud databases. It is used for AWS and Azure. GCP uses
+	// GCPDatabaseNameOverrideLabel instead, as GCP label keys must be lowercase.
 	cloudDatabaseNameOverrideLabel = "TeleportDatabaseName"
 
 	// AzureDatabaseNameOverrideLabel is the label key containing the database
@@ -991,6 +990,17 @@ const (
 	// Azure tags cannot contain these characters: "<>%&\?/", so it doesn't
 	// start with the namespace prefix.
 	AzureDatabaseNameOverrideLabel = cloudDatabaseNameOverrideLabel
+
+	// GCPDatabaseNameOverrideLabel is the GCP user-label key that overrides the
+	// database name for discovered GCP databases.
+	//
+	// GCP label keys must be lowercase, which makes the default "TeleportDatabaseName" unusable for GCP.
+	GCPDatabaseNameOverrideLabel = "teleport-database-name"
+
+	// GCPDatabaseEndpointTypeOverrideLabel is the GCP user-label key on a Cloud
+	// SQL instance that overrides the connection endpoint type chosen by
+	// discovery. Valid values are "public", "private", and "psc".
+	GCPDatabaseEndpointTypeOverrideLabel = "teleport-database-endpoint-type"
 
 	// AzureKubeClusterNameOverrideLabel is the label key containing the
 	// kubernetes cluster name override for discovered Azure kube clusters.
@@ -1151,6 +1161,8 @@ const (
 	DiscoveryLabelEngineVersion = "engine-version"
 	// DiscoveryLabelEndpointType is the label key containing the endpoint type.
 	DiscoveryLabelEndpointType = "endpoint-type"
+	// DiscoveryLabelInstanceType is the label key containing the instance type.
+	DiscoveryLabelInstanceType = "instance-type"
 	// DiscoveryLabelVPCID is the label key containing the VPC ID.
 	DiscoveryLabelVPCID = "vpc-id"
 	// DiscoveryLabelNamespace is the label key for namespace name.

--- a/api/types/matchers_gcp.go
+++ b/api/types/matchers_gcp.go
@@ -33,6 +33,8 @@ const (
 	GCPMatcherKubernetes = "gke"
 	// GCPMatcherCompute is the GCP matcher for GCP VMs.
 	GCPMatcherCompute = "gce"
+	// GCPMatcherCloudSQL is the GCP matcher type for Cloud SQL databases.
+	GCPMatcherCloudSQL = "cloudsql"
 )
 
 // SupportedGCPMatchers is list of GCP services currently supported by the

--- a/lib/cloud/gcp/sql.go
+++ b/lib/cloud/gcp/sql.go
@@ -52,7 +52,7 @@ type SQLAdminClient interface {
 	GenerateEphemeralCert(ctx context.Context, db types.Database, certExpiry time.Time, pubKey crypto.PublicKey) (string, error)
 }
 
-// NewSQLAdminClient returns a SQLAdminClient interface wrapping sqladmin.Service.
+// NewSQLAdminClient returns a [SQLAdminClient] interface wrapping [sqladmin.Service].
 func NewSQLAdminClient(ctx context.Context) (SQLAdminClient, error) {
 	service, err := sqladmin.NewService(ctx)
 	if err != nil {

--- a/lib/cloud/gcp/sql.go
+++ b/lib/cloud/gcp/sql.go
@@ -25,6 +25,8 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -43,12 +45,14 @@ type SQLAdminClient interface {
 	// GetDatabaseInstance returns database instance details for the project/instance
 	// configured in a session.
 	GetDatabaseInstance(ctx context.Context, db types.Database) (*sqladmin.DatabaseInstance, error)
+	// ListDatabaseInstances lists all Cloud SQL instances in the given project, with optional region filter.
+	ListDatabaseInstances(ctx context.Context, projectID string, regions []string) ([]*sqladmin.DatabaseInstance, error)
 	// GenerateEphemeralCert returns a new PEM-encoded client certificate for
 	// the project/instance configured in a session.
 	GenerateEphemeralCert(ctx context.Context, db types.Database, certExpiry time.Time, pubKey crypto.PublicKey) (string, error)
 }
 
-// NewGCPSQLAdminClient returns a GCPSQLAdminClient interface wrapping sqladmin.Service.
+// NewSQLAdminClient returns a SQLAdminClient interface wrapping sqladmin.Service.
 func NewSQLAdminClient(ctx context.Context) (SQLAdminClient, error) {
 	service, err := sqladmin.NewService(ctx)
 	if err != nil {
@@ -95,6 +99,58 @@ func (g *gcpSQLAdminClient) GetDatabaseInstance(ctx context.Context, db types.Da
 		return nil, trace.Wrap(convertAPIError(err))
 	}
 	return dbi, nil
+}
+
+func regionsFilter(regions []string) (string, error) {
+	if len(regions) == 0 {
+		return "", nil
+	}
+	var parts []string
+	for _, region := range regions {
+		part, err := oneRegionFilter(region)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+		parts = append(parts, part)
+	}
+	return strings.Join(parts, " OR "), nil
+}
+
+var regionRe = regexp.MustCompile(`^[a-z]+-[a-z]+\d+$`)
+
+func oneRegionFilter(region string) (string, error) {
+	region = strings.TrimSpace(region)
+
+	if len(region) == 0 {
+		return "", trace.BadParameter("region cannot be blank")
+	}
+	if !regionRe.MatchString(region) {
+		return "", trace.BadParameter("invalid region: %q", region)
+	}
+
+	return fmt.Sprintf("region=%q", region), nil
+}
+
+// ListDatabaseInstances lists all Cloud SQL instances in the given project,
+// following pagination, with optional region filter.
+func (g *gcpSQLAdminClient) ListDatabaseInstances(ctx context.Context, projectID string, regions []string) ([]*sqladmin.DatabaseInstance, error) {
+	filter, err := regionsFilter(regions)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	call := g.service.Instances.List(projectID)
+	if filter != "" {
+		call = call.Filter(filter)
+	}
+	var instances []*sqladmin.DatabaseInstance
+	err = call.Pages(ctx, func(page *sqladmin.InstancesListResponse) error {
+		instances = append(instances, page.Items...)
+		return nil
+	})
+	if err != nil {
+		return nil, trace.Wrap(convertAPIError(err))
+	}
+	return instances, nil
 }
 
 // GenerateEphemeralCert returns a new client certificate created using the

--- a/lib/cloud/gcp/sql_test.go
+++ b/lib/cloud/gcp/sql_test.go
@@ -1,0 +1,78 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package gcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegionsFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		regions []string
+		want    string
+		wantErr string
+	}{
+		{
+			name:    "no regions means no filter",
+			regions: nil,
+			want:    "",
+		},
+		{
+			name:    "single region",
+			regions: []string{"us-central1"},
+			want:    `region="us-central1"`,
+		},
+		{
+			name:    "multiple regions are joined with OR",
+			regions: []string{"us-central1", "europe-west1"},
+			want:    `region="us-central1" OR region="europe-west1"`,
+		},
+		{
+			name:    "blank region is rejected",
+			regions: []string{"  "},
+			wantErr: "region cannot be blank",
+		},
+		{
+			name:    "zone is rejected",
+			regions: []string{"us-central1-a"},
+			wantErr: `invalid region: "us-central1-a"`,
+		},
+		{
+			name:    "uppercase region is rejected",
+			regions: []string{"US-CENTRAL1"},
+			wantErr: `invalid region: "US-CENTRAL1"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			filter, err := regionsFilter(tt.regions)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.want, filter)
+		})
+	}
+}

--- a/lib/cloud/mocks/gcp.go
+++ b/lib/cloud/mocks/gcp.go
@@ -21,6 +21,7 @@ package mocks
 import (
 	"context"
 	"crypto"
+	"slices"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -44,6 +45,9 @@ type GCPSQLAdminClientMock struct {
 	EphemeralCert string
 	// DatabaseUser is returned from GetUser.
 	DatabaseUser *sqladmin.User
+	// DatabaseInstances is the set of instances; ListDatabaseInstances returns
+	// those whose Project matches the requested project ID.
+	DatabaseInstances []*sqladmin.DatabaseInstance
 }
 
 func (g *GCPSQLAdminClientMock) GetUser(ctx context.Context, db types.Database, dbUser string) (*sqladmin.User, error) {
@@ -63,6 +67,30 @@ func (g *GCPSQLAdminClientMock) GetDatabaseInstance(ctx context.Context, db type
 
 func (g *GCPSQLAdminClientMock) GenerateEphemeralCert(_ context.Context, _ types.Database, _ time.Time, _ crypto.PublicKey) (string, error) {
 	return g.EphemeralCert, nil
+}
+
+func (g *GCPSQLAdminClientMock) ListDatabaseInstances(ctx context.Context, projectID string, regions []string) ([]*sqladmin.DatabaseInstance, error) {
+	var instances []*sqladmin.DatabaseInstance
+	for _, instance := range g.DatabaseInstances {
+		if len(regions) == 0 || slices.Contains(regions, instance.Region) {
+			if instance.Project == projectID {
+				instances = append(instances, instance)
+			}
+		}
+	}
+	return instances, nil
+}
+
+var _ gcp.ProjectsClient = (*GCPProjectsClientMock)(nil)
+
+// GCPProjectsClientMock implements the gcp.ProjectsClient interface for tests.
+type GCPProjectsClientMock struct {
+	// Projects is returned from ListProjects.
+	Projects []gcp.Project
+}
+
+func (m *GCPProjectsClientMock) ListProjects(ctx context.Context) ([]gcp.Project, error) {
+	return m.Projects, nil
 }
 
 // GKEClusterEntry is an entry in the GKEMock.Clusters list.

--- a/lib/srv/discovery/common/cloudsql/database.go
+++ b/lib/srv/discovery/common/cloudsql/database.go
@@ -66,15 +66,16 @@ func protocolAndPort(databaseVersion string) (protocol, port string, ok bool) {
 		versionPrefixMySQL    = "MYSQL_"
 		versionPrefixPostgres = "POSTGRES_"
 
-		defaultPortMySQL    = "3306"
-		defaultPortPostgres = "5432"
+		// these ports are not configurable
+		portMySQL    = "3306"
+		portPostgres = "5432"
 	)
 
 	switch {
 	case strings.HasPrefix(databaseVersion, versionPrefixMySQL):
-		return defaults.ProtocolMySQL, defaultPortMySQL, true
+		return defaults.ProtocolMySQL, portMySQL, true
 	case strings.HasPrefix(databaseVersion, versionPrefixPostgres):
-		return defaults.ProtocolPostgres, defaultPortPostgres, true
+		return defaults.ProtocolPostgres, portPostgres, true
 	default:
 		return "", "", false
 	}

--- a/lib/srv/discovery/common/cloudsql/database.go
+++ b/lib/srv/discovery/common/cloudsql/database.go
@@ -1,0 +1,282 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cloudsql
+
+import (
+	"fmt"
+	"maps"
+	"net"
+	"strings"
+
+	"github.com/gravitational/trace"
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/defaults"
+)
+
+// The google.golang.org/api SDK types Cloud SQL enum-like fields as plain
+// strings with no generated constants, so the values we depend on are named here.
+const (
+	// Accepted values for types.GCPDatabaseEndpointTypeOverrideLabel
+	endpointTypePublic  = "public"
+	endpointTypePrivate = "private"
+	endpointTypePSC     = "psc"
+
+	instanceTypePrimary     = "CLOUD_SQL_INSTANCE"
+	instanceTypeReadReplica = "READ_REPLICA_INSTANCE"
+
+	labelInstanceTypePrimary     = "primary"
+	labelInstanceTypeReadReplica = "read-replica"
+)
+
+func checkInstanceAvailable(instance *sqladmin.DatabaseInstance) (ok bool, reason string) {
+	const (
+		stateRunnable         = "RUNNABLE"
+		activationPolicyNever = "NEVER"
+	)
+	if instance.State != stateRunnable {
+		return false, fmt.Sprintf("instance is not available (state %q)", instance.State)
+	}
+	// Instances stopped by their owner stay RUNNABLE; only the activation policy tells.
+	if instance.Settings != nil && instance.Settings.ActivationPolicy == activationPolicyNever {
+		return false, fmt.Sprintf("instance is stopped (activation policy %q)", instance.Settings.ActivationPolicy)
+	}
+	return true, ""
+}
+
+func protocolAndPort(databaseVersion string) (protocol, port string, ok bool) {
+	const (
+		versionPrefixMySQL    = "MYSQL_"
+		versionPrefixPostgres = "POSTGRES_"
+
+		defaultPortMySQL    = "3306"
+		defaultPortPostgres = "5432"
+	)
+
+	switch {
+	case strings.HasPrefix(databaseVersion, versionPrefixMySQL):
+		return defaults.ProtocolMySQL, defaultPortMySQL, true
+	case strings.HasPrefix(databaseVersion, versionPrefixPostgres):
+		return defaults.ProtocolPostgres, defaultPortPostgres, true
+	default:
+		return "", "", false
+	}
+}
+
+func pscEnabled(instance *sqladmin.DatabaseInstance) bool {
+	return instance.Settings != nil &&
+		instance.Settings.IpConfiguration != nil &&
+		instance.Settings.IpConfiguration.PscConfig != nil &&
+		instance.Settings.IpConfiguration.PscConfig.PscEnabled
+}
+
+type instanceEndpoints struct {
+	public, private, psc string
+}
+
+func findInstanceEndpoints(instance *sqladmin.DatabaseInstance) instanceEndpoints {
+	const (
+		scopeInstance = "INSTANCE"
+
+		connectionTypePublic = "PUBLIC"
+		connectionTypePSA    = "PRIVATE_SERVICES_ACCESS"
+		connectionTypePSC    = "PRIVATE_SERVICE_CONNECT"
+
+		ipTypePrimary = "PRIMARY"
+		ipTypePrivate = "PRIVATE"
+	)
+
+	endpoints := instanceEndpoints{}
+
+	// find usable DNS names
+	for _, dns := range instance.DnsNames {
+		if dns.Name == "" || dns.DnsScope != scopeInstance {
+			continue
+		}
+		switch dns.ConnectionType {
+		case connectionTypePublic:
+			endpoints.public = dns.Name
+		case connectionTypePSA:
+			endpoints.private = dns.Name
+		case connectionTypePSC:
+			if pscEnabled(instance) {
+				endpoints.psc = dns.Name
+			}
+		}
+	}
+
+	// fallback to IP addresses
+	for _, ipAddr := range instance.IpAddresses {
+		if ipAddr.IpAddress == "" {
+			continue
+		}
+
+		switch {
+		case ipAddr.Type == ipTypePrimary && endpoints.public == "":
+			endpoints.public = ipAddr.IpAddress
+		case ipAddr.Type == ipTypePrivate && endpoints.private == "":
+			endpoints.private = ipAddr.IpAddress
+		}
+	}
+
+	return endpoints
+}
+
+func instanceUserLabel(instance *sqladmin.DatabaseInstance, key string) string {
+	if instance.Settings == nil || instance.Settings.UserLabels == nil {
+		return ""
+	}
+	return instance.Settings.UserLabels[key]
+}
+
+func chooseEndpoint(instance *sqladmin.DatabaseInstance) (host, endpointType string, err error) {
+	endpoints := findInstanceEndpoints(instance)
+
+	candidates := map[string]string{
+		endpointTypePublic:  endpoints.public,
+		endpointTypePrivate: endpoints.private,
+		endpointTypePSC:     endpoints.psc,
+	}
+
+	// the override label limits the choice to a single endpoint type,
+	// with no fallback even if the chosen endpoint is absent.
+	override := instanceUserLabel(instance, types.GCPDatabaseEndpointTypeOverrideLabel)
+	if override != "" {
+		value, found := candidates[override]
+		if !found {
+			return "", "", trace.BadParameter("unknown endpoint type %q in the %q label", override, types.GCPDatabaseEndpointTypeOverrideLabel)
+		}
+		return value, override, nil
+	}
+
+	// key order determines preference
+	keys := []string{endpointTypePublic, endpointTypePrivate, endpointTypePSC}
+	for _, key := range keys {
+		c := candidates[key]
+		if c != "" {
+			return c, key, nil
+		}
+	}
+
+	// all empty
+	return "", "", nil
+}
+
+func checkSupportedInstanceType(instance *sqladmin.DatabaseInstance) (ok bool, reason string) {
+	if mapInstanceTypeLabel(instance.InstanceType) == "" {
+		return false, fmt.Sprintf("unsupported instance type %q", instance.InstanceType)
+	}
+	return true, ""
+}
+
+func mapInstanceTypeLabel(instanceType string) string {
+	switch instanceType {
+	case instanceTypePrimary:
+		return labelInstanceTypePrimary
+	case instanceTypeReadReplica:
+		return labelInstanceTypeReadReplica
+	}
+	// Currently we don't support:
+	// - READ_POOL_INSTANCE: need changes in DB agent TLS checks.
+	// - ON_PREMISES_INSTANCE: not tested.
+	return ""
+}
+
+// routing is the resolved protocol and connection endpoint for an instance.
+type routing struct {
+	protocol     string
+	uri          string
+	endpointType string
+}
+
+// resolveRouting determines how Teleport would route to an instance. On
+// failure it returns a nil routing and the reason the instance is unroutable.
+func resolveRouting(instance *sqladmin.DatabaseInstance) (_ *routing, reason string) {
+	protocol, port, ok := protocolAndPort(instance.DatabaseVersion)
+	if !ok {
+		return nil, fmt.Sprintf("unsupported database version %q", instance.DatabaseVersion)
+	}
+	host, endpointType, err := chooseEndpoint(instance)
+	if err != nil {
+		return nil, fmt.Sprintf("unable to choose endpoint: %v", err)
+	}
+	if host == "" {
+		return nil, "no reachable connection endpoint"
+	}
+	return &routing{
+		protocol:     protocol,
+		uri:          net.JoinHostPort(host, port),
+		endpointType: endpointType,
+	}, ""
+}
+
+// labelsFromInstance assembles the discovery labels for a Cloud SQL
+// instance, including its user labels.
+func labelsFromInstance(instance *sqladmin.DatabaseInstance, routing *routing) map[string]string {
+	labels := make(map[string]string)
+
+	if instance.Settings != nil {
+		maps.Copy(labels, instance.Settings.UserLabels)
+	}
+
+	labels[types.CloudLabel] = types.CloudGCP
+	labels[types.DiscoveryLabelGCPProjectID] = instance.Project
+	labels[types.DiscoveryLabelRegion] = instance.Region
+	labels[types.DiscoveryLabelEngine] = routing.protocol
+	labels[types.DiscoveryLabelEngineVersion] = instance.DatabaseVersion
+	labels[types.DiscoveryLabelStatus] = instance.State
+	labels[types.DiscoveryLabelInstanceType] = mapInstanceTypeLabel(instance.InstanceType)
+	labels[types.DiscoveryLabelEndpointType] = routing.endpointType
+	return labels
+}
+
+// NewDatabaseFromInstance builds a types.Database from an instance.
+// The metadata is passed through modifyMeta before construction.
+// Ineligible instances are skipped: a non-empty skipReason is returned
+// with a nil database and a nil error.
+func NewDatabaseFromInstance(instance *sqladmin.DatabaseInstance, modifyMeta func(types.Metadata) types.Metadata) (db types.Database, skipReason string, err error) {
+	if ok, reason := checkInstanceAvailable(instance); !ok {
+		return nil, reason, nil
+	}
+	if ok, reason := checkSupportedInstanceType(instance); !ok {
+		return nil, reason, nil
+	}
+	rt, skipReason := resolveRouting(instance)
+	if rt == nil {
+		return nil, skipReason, nil
+	}
+
+	labels := labelsFromInstance(instance, rt)
+	db, err = types.NewDatabaseV3(
+		modifyMeta(types.Metadata{
+			Name:        instance.Name,
+			Description: fmt.Sprintf("Cloud SQL instance in %v", instance.Region),
+			Labels:      labels,
+		}),
+		types.DatabaseSpecV3{
+			Protocol: rt.protocol,
+			URI:      rt.uri,
+			GCP: types.GCPCloudSQL{
+				ProjectID:  instance.Project,
+				InstanceID: instance.Name,
+			},
+		})
+	return db, "", trace.Wrap(err)
+}

--- a/lib/srv/discovery/common/cloudsql/database_test.go
+++ b/lib/srv/discovery/common/cloudsql/database_test.go
@@ -217,9 +217,48 @@ func TestInstanceUserLabel(t *testing.T) {
 
 func TestChooseEndpoint(t *testing.T) {
 	t.Parallel()
-	overrideLabels := func(surface string) *sqladmin.Settings {
-		return &sqladmin.Settings{UserLabels: map[string]string{types.GCPDatabaseEndpointTypeOverrideLabel: surface}}
+
+	type endpoints = int
+
+	const (
+		withPublic = endpoints(iota)
+		withPrivate
+		withPSC
+	)
+
+	const noOverride = ""
+
+	instance := func(overrideSurface string, opts ...endpoints) *sqladmin.DatabaseInstance {
+		db := &sqladmin.DatabaseInstance{
+			IpAddresses: []*sqladmin.IpMapping{},
+			Settings:    &sqladmin.Settings{},
+		}
+
+		for _, opt := range opts {
+			switch opt {
+			case withPublic:
+				db.IpAddresses = append(db.IpAddresses, ipMapping("PRIMARY", "1.2.3.4"))
+			case withPrivate:
+				db.IpAddresses = append(db.IpAddresses, ipMapping("PRIVATE", "10.0.0.1"))
+			case withPSC:
+				db.DnsNames = []*sqladmin.DnsNameMapping{dnsMapping("psc.example", "PRIVATE_SERVICE_CONNECT", "INSTANCE")}
+				db.Settings.IpConfiguration = &sqladmin.IpConfiguration{PscConfig: &sqladmin.PscConfig{PscEnabled: true}}
+			default:
+				t.Fatalf("unknown option: %v", opt)
+			}
+		}
+
+		if overrideSurface != noOverride {
+			db.Settings.UserLabels = map[string]string{types.GCPDatabaseEndpointTypeOverrideLabel: overrideSurface}
+		}
+
+		return db
 	}
+
+	instanceDefaultEndpoint := func(opts ...endpoints) *sqladmin.DatabaseInstance {
+		return instance(noOverride, opts...)
+	}
+
 	tests := []struct {
 		name     string
 		instance *sqladmin.DatabaseInstance
@@ -229,80 +268,68 @@ func TestChooseEndpoint(t *testing.T) {
 	}{
 		// Default precedence (no override): public > private > psc.
 		{
-			name: "public preferred over private",
-			instance: &sqladmin.DatabaseInstance{IpAddresses: []*sqladmin.IpMapping{
-				ipMapping("PRIMARY", "1.2.3.4"),
-				ipMapping("PRIVATE", "10.0.0.1"),
-			}},
+			name:     "public preferred over private",
+			instance: instanceDefaultEndpoint(withPrivate, withPublic),
 			want:     "1.2.3.4",
 			wantType: endpointTypePublic,
 		},
 		{
 			name:     "private when no public",
-			instance: &sqladmin.DatabaseInstance{IpAddresses: []*sqladmin.IpMapping{ipMapping("PRIVATE", "10.0.0.1")}},
+			instance: instanceDefaultEndpoint(withPrivate),
 			want:     "10.0.0.1",
 			wantType: endpointTypePrivate,
 		},
 		{
-			name: "psc when only psc",
-			instance: &sqladmin.DatabaseInstance{
-				DnsNames: []*sqladmin.DnsNameMapping{dnsMapping("psc.example", "PRIVATE_SERVICE_CONNECT", "INSTANCE")},
-				Settings: &sqladmin.Settings{IpConfiguration: &sqladmin.IpConfiguration{PscConfig: &sqladmin.PscConfig{PscEnabled: true}}},
-			},
+			name:     "psc when only psc",
+			instance: instanceDefaultEndpoint(withPSC),
 			want:     "psc.example",
 			wantType: endpointTypePSC,
 		},
 		{
 			name:     "no endpoint",
-			instance: &sqladmin.DatabaseInstance{},
+			instance: instanceDefaultEndpoint(),
 			want:     "",
 		},
 		{
-			name: "override public",
-			instance: &sqladmin.DatabaseInstance{
-				IpAddresses: []*sqladmin.IpMapping{ipMapping("PRIMARY", "1.2.3.4")},
-				Settings:    overrideLabels(endpointTypePublic),
-			},
+			name:     "override public with all surfaces",
+			instance: instance(endpointTypePublic, withPublic, withPrivate, withPSC),
 			want:     "1.2.3.4",
 			wantType: endpointTypePublic,
 		},
 		{
-			name: "override private",
-			instance: &sqladmin.DatabaseInstance{
-				IpAddresses: []*sqladmin.IpMapping{ipMapping("PRIMARY", "1.2.3.4"), ipMapping("PRIVATE", "10.0.0.1")},
-				Settings:    overrideLabels(endpointTypePrivate),
-			},
+			name:     "override private with all surfaces",
+			instance: instance(endpointTypePrivate, withPublic, withPrivate, withPSC),
 			want:     "10.0.0.1",
 			wantType: endpointTypePrivate,
 		},
 		{
-			name: "override psc",
-			instance: &sqladmin.DatabaseInstance{
-				DnsNames: []*sqladmin.DnsNameMapping{dnsMapping("psc.example", "PRIVATE_SERVICE_CONNECT", "INSTANCE")},
-				Settings: &sqladmin.Settings{
-					IpConfiguration: &sqladmin.IpConfiguration{PscConfig: &sqladmin.PscConfig{PscEnabled: true}},
-					UserLabels:      map[string]string{types.GCPDatabaseEndpointTypeOverrideLabel: endpointTypePSC},
-				},
-			},
+			name:     "override psc with all surfaces",
+			instance: instance(endpointTypePSC, withPublic, withPrivate, withPSC),
 			want:     "psc.example",
 			wantType: endpointTypePSC,
 		},
 		{
-			name: "override to absent surface returns empty",
-			instance: &sqladmin.DatabaseInstance{
-				IpAddresses: []*sqladmin.IpMapping{ipMapping("PRIMARY", "1.2.3.4")}, // only public present
-				Settings:    overrideLabels(endpointTypePrivate),
-			},
+			name:     "override public absent returns empty",
+			instance: instance(endpointTypePublic, withPrivate),
+			want:     "",
+			wantType: endpointTypePublic,
+		},
+		{
+			name:     "override private absent returns empty",
+			instance: instance(endpointTypePrivate, withPublic),
 			want:     "",
 			wantType: endpointTypePrivate,
 		},
 		{
-			name: "unrecognized override fails closed",
-			instance: &sqladmin.DatabaseInstance{
-				IpAddresses: []*sqladmin.IpMapping{ipMapping("PRIMARY", "1.2.3.4")},
-				Settings:    overrideLabels("bogus"),
-			},
-			wantErr: `unknown endpoint type "bogus" in the "teleport-database-endpoint-type" label`,
+			name:     "override psc absent returns empty",
+			instance: instance(endpointTypePSC, withPublic),
+			want:     "",
+			wantType: endpointTypePSC,
+		},
+		{
+			name:     "unrecognized override fails closed",
+			instance: instance("bogus"),
+			wantErr:  `unknown endpoint type "bogus" in the "teleport-database-endpoint-type" label`,
 		},
 	}
 	for _, tt := range tests {

--- a/lib/srv/discovery/common/cloudsql/database_test.go
+++ b/lib/srv/discovery/common/cloudsql/database_test.go
@@ -1,0 +1,569 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cloudsql
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/defaults"
+)
+
+func ipMapping(ipType, addr string) *sqladmin.IpMapping {
+	return &sqladmin.IpMapping{Type: ipType, IpAddress: addr}
+}
+
+func dnsMapping(name, connType, scope string) *sqladmin.DnsNameMapping {
+	return &sqladmin.DnsNameMapping{Name: name, ConnectionType: connType, DnsScope: scope}
+}
+
+func TestCheckInstanceAvailable(t *testing.T) {
+	withPolicy := func(policy string) *sqladmin.Settings {
+		return &sqladmin.Settings{ActivationPolicy: policy}
+	}
+	tests := []struct {
+		name       string
+		state      string
+		settings   *sqladmin.Settings
+		wantReason string
+	}{
+		{name: "runnable", state: "RUNNABLE"},
+		{name: "runnable always", state: "RUNNABLE", settings: withPolicy("ALWAYS")},
+		{name: "runnable on demand", state: "RUNNABLE", settings: withPolicy("ON_DEMAND")},
+		{name: "runnable unspecified policy", state: "RUNNABLE", settings: withPolicy("")},
+		{name: "stopped by owner", state: "RUNNABLE", settings: withPolicy("NEVER"), wantReason: `instance is stopped (activation policy "NEVER")`},
+		{name: "suspended", state: "SUSPENDED", wantReason: `instance is not available (state "SUSPENDED")`},
+		{name: "empty", state: "", wantReason: `instance is not available (state "")`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ok, reason := checkInstanceAvailable(&sqladmin.DatabaseInstance{State: tt.state, Settings: tt.settings})
+			require.Equal(t, tt.wantReason == "", ok)
+			require.Equal(t, tt.wantReason, reason)
+		})
+	}
+}
+
+func TestProtocolAndPort(t *testing.T) {
+	tests := []struct {
+		name         string
+		version      string
+		wantProtocol string
+		wantPort     string
+		wantOK       bool
+	}{
+		{name: "postgres", version: "POSTGRES_14", wantProtocol: defaults.ProtocolPostgres, wantPort: "5432", wantOK: true},
+		{name: "mysql", version: "MYSQL_8_0", wantProtocol: defaults.ProtocolMySQL, wantPort: "3306", wantOK: true},
+		{name: "sqlserver unsupported", version: "SQLSERVER_2019_STANDARD", wantOK: false},
+		{name: "prefix without underscore", version: "POSTGRES", wantOK: false},
+		{name: "case sensitive", version: "mysql_8_0", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			protocol, port, ok := protocolAndPort(tt.version)
+			require.Equal(t, tt.wantOK, ok)
+			require.Equal(t, tt.wantProtocol, protocol)
+			require.Equal(t, tt.wantPort, port)
+		})
+	}
+}
+
+func TestPSCEnabled(t *testing.T) {
+	enabled := func(b bool) *sqladmin.Settings {
+		return &sqladmin.Settings{
+			IpConfiguration: &sqladmin.IpConfiguration{PscConfig: &sqladmin.PscConfig{PscEnabled: b}},
+		}
+	}
+	tests := []struct {
+		name     string
+		settings *sqladmin.Settings
+		want     bool
+	}{
+		{name: "nil settings", settings: nil, want: false},
+		{name: "nil ip configuration", settings: &sqladmin.Settings{}, want: false},
+		{name: "nil psc config", settings: &sqladmin.Settings{IpConfiguration: &sqladmin.IpConfiguration{}}, want: false},
+		{name: "psc disabled", settings: enabled(false), want: false},
+		{name: "psc enabled", settings: enabled(true), want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, pscEnabled(&sqladmin.DatabaseInstance{Settings: tt.settings}))
+		})
+	}
+}
+
+func TestFindInstanceEndpoints(t *testing.T) {
+	tests := []struct {
+		name     string
+		instance *sqladmin.DatabaseInstance
+		want     instanceEndpoints
+	}{
+		{
+			name:     "public DNS name",
+			instance: &sqladmin.DatabaseInstance{DnsNames: []*sqladmin.DnsNameMapping{dnsMapping("pub.example", "PUBLIC", "INSTANCE")}},
+			want:     instanceEndpoints{public: "pub.example"},
+		},
+		{
+			name:     "PSA DNS name maps to private",
+			instance: &sqladmin.DatabaseInstance{DnsNames: []*sqladmin.DnsNameMapping{dnsMapping("priv.example", "PRIVATE_SERVICES_ACCESS", "INSTANCE")}},
+			want:     instanceEndpoints{private: "priv.example"},
+		},
+		{
+			name:     "PSC DNS name ignored when PSC disabled",
+			instance: &sqladmin.DatabaseInstance{DnsNames: []*sqladmin.DnsNameMapping{dnsMapping("psc.example", "PRIVATE_SERVICE_CONNECT", "INSTANCE")}},
+			want:     instanceEndpoints{},
+		},
+		{
+			name: "PSC DNS name used when PSC enabled",
+			instance: &sqladmin.DatabaseInstance{
+				DnsNames: []*sqladmin.DnsNameMapping{dnsMapping("psc.example", "PRIVATE_SERVICE_CONNECT", "INSTANCE")},
+				Settings: &sqladmin.Settings{IpConfiguration: &sqladmin.IpConfiguration{PscConfig: &sqladmin.PscConfig{PscEnabled: true}}},
+			},
+			want: instanceEndpoints{psc: "psc.example"},
+		},
+		{
+			name:     "non-INSTANCE scope ignored",
+			instance: &sqladmin.DatabaseInstance{DnsNames: []*sqladmin.DnsNameMapping{dnsMapping("pub.example", "PUBLIC", "REGIONAL")}},
+			want:     instanceEndpoints{},
+		},
+		{
+			name:     "empty DNS name ignored",
+			instance: &sqladmin.DatabaseInstance{DnsNames: []*sqladmin.DnsNameMapping{dnsMapping("", "PUBLIC", "INSTANCE")}},
+			want:     instanceEndpoints{},
+		},
+		{
+			name: "IP fallback for primary and private",
+			instance: &sqladmin.DatabaseInstance{IpAddresses: []*sqladmin.IpMapping{
+				ipMapping("PRIMARY", "1.2.3.4"),
+				ipMapping("PRIVATE", "10.0.0.1"),
+			}},
+			want: instanceEndpoints{public: "1.2.3.4", private: "10.0.0.1"},
+		},
+		{
+			name: "DNS public not overridden by primary IP",
+			instance: &sqladmin.DatabaseInstance{
+				DnsNames:    []*sqladmin.DnsNameMapping{dnsMapping("pub.example", "PUBLIC", "INSTANCE")},
+				IpAddresses: []*sqladmin.IpMapping{ipMapping("PRIMARY", "1.2.3.4")},
+			},
+			want: instanceEndpoints{public: "pub.example"},
+		},
+		{
+			name:     "empty IP address ignored",
+			instance: &sqladmin.DatabaseInstance{IpAddresses: []*sqladmin.IpMapping{ipMapping("PRIMARY", "")}},
+			want:     instanceEndpoints{},
+		},
+		{
+			name: "private IP does not override private DNS name",
+			instance: &sqladmin.DatabaseInstance{
+				DnsNames:    []*sqladmin.DnsNameMapping{dnsMapping("priv.example", "PRIVATE_SERVICES_ACCESS", "INSTANCE")},
+				IpAddresses: []*sqladmin.IpMapping{ipMapping("PRIVATE", "10.0.0.1")},
+			},
+			want: instanceEndpoints{private: "priv.example"},
+		},
+		{
+			name:     "unknown connection type ignored",
+			instance: &sqladmin.DatabaseInstance{DnsNames: []*sqladmin.DnsNameMapping{dnsMapping("weird.example", "SOMETHING_ELSE", "INSTANCE")}},
+			want:     instanceEndpoints{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, findInstanceEndpoints(tt.instance))
+		})
+	}
+}
+
+func TestInstanceUserLabel(t *testing.T) {
+	require.Empty(t, instanceUserLabel(&sqladmin.DatabaseInstance{}, "key"),
+		"nil Settings yields empty string")
+	require.Empty(t, instanceUserLabel(&sqladmin.DatabaseInstance{Settings: &sqladmin.Settings{}}, "key"),
+		"nil UserLabels yields empty string")
+
+	instance := &sqladmin.DatabaseInstance{
+		Settings: &sqladmin.Settings{UserLabels: map[string]string{"env": "prod"}},
+	}
+	require.Equal(t, "prod", instanceUserLabel(instance, "env"))
+	require.Empty(t, instanceUserLabel(instance, "missing"))
+}
+
+func TestChooseEndpoint(t *testing.T) {
+	overrideLabels := func(surface string) *sqladmin.Settings {
+		return &sqladmin.Settings{UserLabels: map[string]string{types.GCPDatabaseEndpointTypeOverrideLabel: surface}}
+	}
+	tests := []struct {
+		name     string
+		instance *sqladmin.DatabaseInstance
+		want     string
+		wantType string
+		wantErr  string
+	}{
+		// Default precedence (no override): public > private > psc.
+		{
+			name: "public preferred over private",
+			instance: &sqladmin.DatabaseInstance{IpAddresses: []*sqladmin.IpMapping{
+				ipMapping("PRIMARY", "1.2.3.4"),
+				ipMapping("PRIVATE", "10.0.0.1"),
+			}},
+			want:     "1.2.3.4",
+			wantType: endpointTypePublic,
+		},
+		{
+			name:     "private when no public",
+			instance: &sqladmin.DatabaseInstance{IpAddresses: []*sqladmin.IpMapping{ipMapping("PRIVATE", "10.0.0.1")}},
+			want:     "10.0.0.1",
+			wantType: endpointTypePrivate,
+		},
+		{
+			name: "psc when only psc",
+			instance: &sqladmin.DatabaseInstance{
+				DnsNames: []*sqladmin.DnsNameMapping{dnsMapping("psc.example", "PRIVATE_SERVICE_CONNECT", "INSTANCE")},
+				Settings: &sqladmin.Settings{IpConfiguration: &sqladmin.IpConfiguration{PscConfig: &sqladmin.PscConfig{PscEnabled: true}}},
+			},
+			want:     "psc.example",
+			wantType: endpointTypePSC,
+		},
+		{
+			name:     "no endpoint",
+			instance: &sqladmin.DatabaseInstance{},
+			want:     "",
+		},
+		{
+			name: "override public",
+			instance: &sqladmin.DatabaseInstance{
+				IpAddresses: []*sqladmin.IpMapping{ipMapping("PRIMARY", "1.2.3.4")},
+				Settings:    overrideLabels(endpointTypePublic),
+			},
+			want:     "1.2.3.4",
+			wantType: endpointTypePublic,
+		},
+		{
+			name: "override private",
+			instance: &sqladmin.DatabaseInstance{
+				IpAddresses: []*sqladmin.IpMapping{ipMapping("PRIMARY", "1.2.3.4"), ipMapping("PRIVATE", "10.0.0.1")},
+				Settings:    overrideLabels(endpointTypePrivate),
+			},
+			want:     "10.0.0.1",
+			wantType: endpointTypePrivate,
+		},
+		{
+			name: "override psc",
+			instance: &sqladmin.DatabaseInstance{
+				DnsNames: []*sqladmin.DnsNameMapping{dnsMapping("psc.example", "PRIVATE_SERVICE_CONNECT", "INSTANCE")},
+				Settings: &sqladmin.Settings{
+					IpConfiguration: &sqladmin.IpConfiguration{PscConfig: &sqladmin.PscConfig{PscEnabled: true}},
+					UserLabels:      map[string]string{types.GCPDatabaseEndpointTypeOverrideLabel: endpointTypePSC},
+				},
+			},
+			want:     "psc.example",
+			wantType: endpointTypePSC,
+		},
+		{
+			name: "override to absent surface returns empty",
+			instance: &sqladmin.DatabaseInstance{
+				IpAddresses: []*sqladmin.IpMapping{ipMapping("PRIMARY", "1.2.3.4")}, // only public present
+				Settings:    overrideLabels(endpointTypePrivate),
+			},
+			want:     "",
+			wantType: endpointTypePrivate,
+		},
+		{
+			name: "unrecognized override fails closed",
+			instance: &sqladmin.DatabaseInstance{
+				IpAddresses: []*sqladmin.IpMapping{ipMapping("PRIMARY", "1.2.3.4")},
+				Settings:    overrideLabels("bogus"),
+			},
+			wantErr: `unknown endpoint type "bogus" in the "teleport-database-endpoint-type" label`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, endpointType, err := chooseEndpoint(tt.instance)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.wantType, endpointType)
+		})
+	}
+}
+
+func TestMapInstanceTypeLabel(t *testing.T) {
+	tests := []struct {
+		instanceType string
+		want         string
+	}{
+		{instanceType: instanceTypePrimary, want: labelInstanceTypePrimary},
+		{instanceType: instanceTypeReadReplica, want: labelInstanceTypeReadReplica},
+		{instanceType: "READ_POOL_INSTANCE", want: ""},
+		{instanceType: "ON_PREMISES_INSTANCE", want: ""},
+		{instanceType: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.instanceType, func(t *testing.T) {
+			require.Equal(t, tt.want, mapInstanceTypeLabel(tt.instanceType))
+		})
+	}
+}
+
+func TestResolveRouting(t *testing.T) {
+	tests := []struct {
+		name             string
+		instance         *sqladmin.DatabaseInstance
+		wantNil          bool
+		wantProtocol     string
+		wantURI          string
+		wantEndpointType string
+	}{
+		{
+			name: "supported engine with reachable endpoint",
+			instance: &sqladmin.DatabaseInstance{
+				DatabaseVersion: "POSTGRES_14",
+				IpAddresses:     []*sqladmin.IpMapping{ipMapping("PRIMARY", "1.2.3.4")},
+			},
+			wantProtocol:     defaults.ProtocolPostgres,
+			wantURI:          "1.2.3.4:5432",
+			wantEndpointType: endpointTypePublic,
+		},
+		{
+			name: "hostname endpoint joined without brackets",
+			instance: &sqladmin.DatabaseInstance{
+				DatabaseVersion: "POSTGRES_14",
+				DnsNames:        []*sqladmin.DnsNameMapping{dnsMapping("inst.psc.example", "PRIVATE_SERVICE_CONNECT", "INSTANCE")},
+				Settings:        &sqladmin.Settings{IpConfiguration: &sqladmin.IpConfiguration{PscConfig: &sqladmin.PscConfig{PscEnabled: true}}},
+			},
+			wantProtocol:     defaults.ProtocolPostgres,
+			wantURI:          "inst.psc.example:5432",
+			wantEndpointType: endpointTypePSC,
+		},
+		{
+			name: "unsupported engine",
+			instance: &sqladmin.DatabaseInstance{
+				DatabaseVersion: "SQLSERVER_2019_STANDARD",
+				IpAddresses:     []*sqladmin.IpMapping{ipMapping("PRIMARY", "1.2.3.4")},
+			},
+			wantNil: true,
+		},
+		{
+			name:     "no reachable endpoint",
+			instance: &sqladmin.DatabaseInstance{DatabaseVersion: "POSTGRES_14"},
+			wantNil:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, skipReason := resolveRouting(tt.instance)
+			if tt.wantNil {
+				require.Nil(t, r)
+				require.NotEmpty(t, skipReason)
+				return
+			}
+			require.NotNil(t, r)
+			require.Empty(t, skipReason)
+			require.Equal(t, tt.wantProtocol, r.protocol)
+			require.Equal(t, tt.wantURI, r.uri)
+			require.Equal(t, tt.wantEndpointType, r.endpointType)
+		})
+	}
+}
+
+func TestLabelsFromInstance(t *testing.T) {
+	tests := []struct {
+		name     string
+		instance *sqladmin.DatabaseInstance
+		routing  *routing
+		want     map[string]string
+	}{
+		{
+			name: "user labels merged with discovery labels",
+			instance: &sqladmin.DatabaseInstance{
+				Project:         "proj-1",
+				Region:          "us-central1",
+				State:           "RUNNABLE",
+				DatabaseVersion: "POSTGRES_14",
+				InstanceType:    instanceTypePrimary,
+				Settings:        &sqladmin.Settings{UserLabels: map[string]string{"env": "prod", "team": "data"}},
+			},
+			routing: &routing{protocol: defaults.ProtocolPostgres, endpointType: endpointTypePublic},
+			want: map[string]string{
+				"env":                             "prod",
+				"team":                            "data",
+				types.CloudLabel:                  types.CloudGCP,
+				types.DiscoveryLabelGCPProjectID:  "proj-1",
+				types.DiscoveryLabelRegion:        "us-central1",
+				types.DiscoveryLabelEngine:        defaults.ProtocolPostgres,
+				types.DiscoveryLabelEngineVersion: "POSTGRES_14",
+				types.DiscoveryLabelStatus:        "RUNNABLE",
+				types.DiscoveryLabelInstanceType:  labelInstanceTypePrimary,
+				types.DiscoveryLabelEndpointType:  endpointTypePublic,
+			},
+		},
+		{
+			name: "nil settings yields discovery labels only",
+			instance: &sqladmin.DatabaseInstance{
+				Project:         "proj-1",
+				Region:          "us-central1",
+				State:           "RUNNABLE",
+				DatabaseVersion: "POSTGRES_14",
+				InstanceType:    instanceTypePrimary,
+			},
+			routing: &routing{protocol: defaults.ProtocolPostgres, endpointType: endpointTypePrivate},
+			want: map[string]string{
+				types.CloudLabel:                  types.CloudGCP,
+				types.DiscoveryLabelGCPProjectID:  "proj-1",
+				types.DiscoveryLabelRegion:        "us-central1",
+				types.DiscoveryLabelEngine:        defaults.ProtocolPostgres,
+				types.DiscoveryLabelEngineVersion: "POSTGRES_14",
+				types.DiscoveryLabelStatus:        "RUNNABLE",
+				types.DiscoveryLabelInstanceType:  labelInstanceTypePrimary,
+				types.DiscoveryLabelEndpointType:  endpointTypePrivate,
+			},
+		},
+		{
+			// raw engine-version enum; empty fields yield empty labels.
+			name:     "mysql raw engine version, sparse instance",
+			instance: &sqladmin.DatabaseInstance{DatabaseVersion: "MYSQL_8_0"},
+			routing:  &routing{protocol: defaults.ProtocolMySQL},
+			want: map[string]string{
+				types.CloudLabel:                  types.CloudGCP,
+				types.DiscoveryLabelGCPProjectID:  "",
+				types.DiscoveryLabelRegion:        "",
+				types.DiscoveryLabelEngine:        defaults.ProtocolMySQL,
+				types.DiscoveryLabelEngineVersion: "MYSQL_8_0",
+				types.DiscoveryLabelStatus:        "",
+				types.DiscoveryLabelInstanceType:  "",
+				types.DiscoveryLabelEndpointType:  "",
+			},
+		},
+		{
+			// computed keys override colliding user labels ("us-spoof"/"backdoor" lose).
+			name: "computed discovery labels win over colliding user labels",
+			instance: &sqladmin.DatabaseInstance{
+				Project:         "proj-1",
+				Region:          "us-central1",
+				State:           "RUNNABLE",
+				DatabaseVersion: "POSTGRES_14",
+				InstanceType:    instanceTypePrimary,
+				Settings: &sqladmin.Settings{UserLabels: map[string]string{
+					types.DiscoveryLabelRegion:       "us-spoof", // collides with computed region
+					types.DiscoveryLabelInstanceType: "backdoor", // collides with computed instance-type
+					"env":                            "prod",     // non-colliding control
+				}},
+			},
+			routing: &routing{protocol: defaults.ProtocolPostgres, endpointType: endpointTypePublic},
+			want: map[string]string{
+				"env":                             "prod",
+				types.CloudLabel:                  types.CloudGCP,
+				types.DiscoveryLabelGCPProjectID:  "proj-1",
+				types.DiscoveryLabelRegion:        "us-central1",
+				types.DiscoveryLabelEngine:        defaults.ProtocolPostgres,
+				types.DiscoveryLabelEngineVersion: "POSTGRES_14",
+				types.DiscoveryLabelStatus:        "RUNNABLE",
+				types.DiscoveryLabelInstanceType:  labelInstanceTypePrimary,
+				types.DiscoveryLabelEndpointType:  endpointTypePublic,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, labelsFromInstance(tt.instance, tt.routing))
+		})
+	}
+}
+
+func TestNewDatabaseFromInstance(t *testing.T) {
+	makeInstance := func(opts ...func(*sqladmin.DatabaseInstance)) *sqladmin.DatabaseInstance {
+		instance := &sqladmin.DatabaseInstance{
+			Name:            "pg-instance",
+			Project:         "proj-1",
+			Region:          "us-central1",
+			State:           "RUNNABLE",
+			DatabaseVersion: "POSTGRES_14",
+			InstanceType:    instanceTypePrimary,
+			IpAddresses:     []*sqladmin.IpMapping{ipMapping("PRIMARY", "1.2.3.4")},
+			Settings:        &sqladmin.Settings{UserLabels: map[string]string{"env": "prod"}},
+		}
+		for _, opt := range opts {
+			opt(instance)
+		}
+		return instance
+	}
+
+	wantDatabase, err := types.NewDatabaseV3(types.Metadata{
+		Name:        "pg-instance",
+		Description: "Cloud SQL instance in us-central1",
+		Labels: map[string]string{
+			"env":                             "prod",
+			types.CloudLabel:                  types.CloudGCP,
+			types.DiscoveryLabelGCPProjectID:  "proj-1",
+			types.DiscoveryLabelRegion:        "us-central1",
+			types.DiscoveryLabelEngine:        defaults.ProtocolPostgres,
+			types.DiscoveryLabelEngineVersion: "POSTGRES_14",
+			types.DiscoveryLabelStatus:        "RUNNABLE",
+			types.DiscoveryLabelInstanceType:  labelInstanceTypePrimary,
+			types.DiscoveryLabelEndpointType:  endpointTypePublic,
+		},
+	}, types.DatabaseSpecV3{
+		Protocol: defaults.ProtocolPostgres,
+		URI:      "1.2.3.4:5432",
+		GCP: types.GCPCloudSQL{
+			ProjectID:  "proj-1",
+			InstanceID: "pg-instance",
+		},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		instance       *sqladmin.DatabaseInstance
+		want           types.Database
+		wantSkipReason string
+	}{
+		{
+			name:     "eligible instance",
+			instance: makeInstance(),
+			want:     wantDatabase,
+		},
+		{
+			name: "stopped instance is skipped",
+			instance: makeInstance(func(instance *sqladmin.DatabaseInstance) {
+				instance.Settings.ActivationPolicy = "NEVER"
+			}),
+			wantSkipReason: `instance is stopped (activation policy "NEVER")`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			identity := func(meta types.Metadata) types.Metadata { return meta }
+			got, skipReason, err := NewDatabaseFromInstance(tt.instance, identity)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantSkipReason, skipReason)
+			if tt.wantSkipReason != "" {
+				require.Nil(t, got)
+				return
+			}
+			require.Empty(t, cmp.Diff(tt.want, got))
+		})
+	}
+}

--- a/lib/srv/discovery/common/cloudsql/database_test.go
+++ b/lib/srv/discovery/common/cloudsql/database_test.go
@@ -38,6 +38,7 @@ func dnsMapping(name, connType, scope string) *sqladmin.DnsNameMapping {
 }
 
 func TestCheckInstanceAvailable(t *testing.T) {
+	t.Parallel()
 	withPolicy := func(policy string) *sqladmin.Settings {
 		return &sqladmin.Settings{ActivationPolicy: policy}
 	}
@@ -57,6 +58,7 @@ func TestCheckInstanceAvailable(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ok, reason := checkInstanceAvailable(&sqladmin.DatabaseInstance{State: tt.state, Settings: tt.settings})
 			require.Equal(t, tt.wantReason == "", ok)
 			require.Equal(t, tt.wantReason, reason)
@@ -65,6 +67,7 @@ func TestCheckInstanceAvailable(t *testing.T) {
 }
 
 func TestProtocolAndPort(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		version      string
@@ -80,6 +83,7 @@ func TestProtocolAndPort(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			protocol, port, ok := protocolAndPort(tt.version)
 			require.Equal(t, tt.wantOK, ok)
 			require.Equal(t, tt.wantProtocol, protocol)
@@ -89,6 +93,7 @@ func TestProtocolAndPort(t *testing.T) {
 }
 
 func TestPSCEnabled(t *testing.T) {
+	t.Parallel()
 	enabled := func(b bool) *sqladmin.Settings {
 		return &sqladmin.Settings{
 			IpConfiguration: &sqladmin.IpConfiguration{PscConfig: &sqladmin.PscConfig{PscEnabled: b}},
@@ -107,12 +112,14 @@ func TestPSCEnabled(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(t, tt.want, pscEnabled(&sqladmin.DatabaseInstance{Settings: tt.settings}))
 		})
 	}
 }
 
 func TestFindInstanceEndpoints(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		instance *sqladmin.DatabaseInstance
@@ -188,12 +195,14 @@ func TestFindInstanceEndpoints(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(t, tt.want, findInstanceEndpoints(tt.instance))
 		})
 	}
 }
 
 func TestInstanceUserLabel(t *testing.T) {
+	t.Parallel()
 	require.Empty(t, instanceUserLabel(&sqladmin.DatabaseInstance{}, "key"),
 		"nil Settings yields empty string")
 	require.Empty(t, instanceUserLabel(&sqladmin.DatabaseInstance{Settings: &sqladmin.Settings{}}, "key"),
@@ -207,6 +216,7 @@ func TestInstanceUserLabel(t *testing.T) {
 }
 
 func TestChooseEndpoint(t *testing.T) {
+	t.Parallel()
 	overrideLabels := func(surface string) *sqladmin.Settings {
 		return &sqladmin.Settings{UserLabels: map[string]string{types.GCPDatabaseEndpointTypeOverrideLabel: surface}}
 	}
@@ -297,6 +307,7 @@ func TestChooseEndpoint(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, endpointType, err := chooseEndpoint(tt.instance)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
@@ -310,6 +321,7 @@ func TestChooseEndpoint(t *testing.T) {
 }
 
 func TestMapInstanceTypeLabel(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		instanceType string
 		want         string
@@ -322,12 +334,14 @@ func TestMapInstanceTypeLabel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.instanceType, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(t, tt.want, mapInstanceTypeLabel(tt.instanceType))
 		})
 	}
 }
 
 func TestResolveRouting(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name             string
 		instance         *sqladmin.DatabaseInstance
@@ -373,6 +387,7 @@ func TestResolveRouting(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			r, skipReason := resolveRouting(tt.instance)
 			if tt.wantNil {
 				require.Nil(t, r)
@@ -389,6 +404,7 @@ func TestResolveRouting(t *testing.T) {
 }
 
 func TestLabelsFromInstance(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		instance *sqladmin.DatabaseInstance
@@ -487,12 +503,14 @@ func TestLabelsFromInstance(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(t, tt.want, labelsFromInstance(tt.instance, tt.routing))
 		})
 	}
 }
 
 func TestNewDatabaseFromInstance(t *testing.T) {
+	t.Parallel()
 	makeInstance := func(opts ...func(*sqladmin.DatabaseInstance)) *sqladmin.DatabaseInstance {
 		instance := &sqladmin.DatabaseInstance{
 			Name:            "pg-instance",
@@ -555,6 +573,7 @@ func TestNewDatabaseFromInstance(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			identity := func(meta types.Metadata) types.Metadata { return meta }
 			got, skipReason, err := NewDatabaseFromInstance(tt.instance, identity)
 			require.NoError(t, err)

--- a/lib/srv/discovery/common/database_cloudsql.go
+++ b/lib/srv/discovery/common/database_cloudsql.go
@@ -1,0 +1,57 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"context"
+	"log/slog"
+
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/srv/discovery/common/cloudsql"
+)
+
+// setGCPDBName overrides the first name part from the GCP name-override label (if
+// present) and sets the database name on the metadata.
+func setGCPDBName(meta types.Metadata, firstNamePart string, extraNameParts ...string) types.Metadata {
+	return setResourceName([]string{types.GCPDatabaseNameOverrideLabel}, meta, firstNamePart, extraNameParts...)
+}
+
+// DiscoverCloudSQLDatabases converts eligible Cloud SQL instances to
+// types.Database. Ineligible instances are logged but discarded.
+func DiscoverCloudSQLDatabases(ctx context.Context, logger *slog.Logger, instances []*sqladmin.DatabaseInstance) []types.Database {
+	var databases []types.Database
+	for _, instance := range instances {
+		db, skipReason, err := cloudsql.NewDatabaseFromInstance(instance, func(meta types.Metadata) types.Metadata {
+			return setGCPDBName(meta, instance.Name)
+		})
+		if err != nil {
+			// a single bad instance must not abort discovery of the rest.
+			logger.WarnContext(ctx, "Failed to build database object", "name", instance.Name, "project", instance.Project, "error", err)
+			continue
+		}
+		if db == nil || skipReason != "" {
+			logger.DebugContext(ctx, "Skipping Cloud SQL instance", "name", instance.Name, "project", instance.Project, "reason", skipReason)
+			continue
+		}
+		databases = append(databases, db)
+	}
+	return databases
+}

--- a/lib/srv/discovery/common/database_cloudsql_test.go
+++ b/lib/srv/discovery/common/database_cloudsql_test.go
@@ -1,0 +1,111 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+func TestSetGCPDBName(t *testing.T) {
+	tests := []struct {
+		desc           string
+		labels         map[string]string
+		firstNamePart  string
+		extraNameParts []string
+		wantName       string
+	}{
+		{
+			desc:          "no override label, single part",
+			firstNamePart: "my-instance",
+			wantName:      "my-instance",
+		},
+		{
+			desc:           "no override label, extra parts",
+			firstNamePart:  "my-instance",
+			extraNameParts: []string{"x"},
+			wantName:       "my-instance-x",
+		},
+		{
+			desc: "override label replaces first part",
+			labels: map[string]string{
+				types.GCPDatabaseNameOverrideLabel: "custom",
+			},
+			firstNamePart: "my-instance",
+			wantName:      "custom",
+		},
+		{
+			desc: "override label replaces first part, extra parts appended",
+			labels: map[string]string{
+				types.GCPDatabaseNameOverrideLabel: "custom",
+			},
+			firstNamePart:  "my-instance",
+			extraNameParts: []string{"x"},
+			wantName:       "custom-x",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			meta := types.Metadata{
+				Name:   "original",
+				Labels: tt.labels,
+			}
+			got := setGCPDBName(meta, tt.firstNamePart, tt.extraNameParts...)
+			require.Equal(t, tt.wantName, got.Name)
+		})
+	}
+}
+
+func TestDiscoverCloudSQLDatabases(t *testing.T) {
+	runnable := func(name string) *sqladmin.DatabaseInstance {
+		return &sqladmin.DatabaseInstance{
+			Name:            name,
+			Project:         "proj-1",
+			Region:          "us-central1",
+			State:           "RUNNABLE",
+			DatabaseVersion: "POSTGRES_14",
+			InstanceType:    "CLOUD_SQL_INSTANCE",
+			IpAddresses:     []*sqladmin.IpMapping{{Type: "PRIMARY", IpAddress: "1.2.3.4"}},
+		}
+	}
+	unavailable := runnable("unavailable")
+	unavailable.State = "SUSPENDED"
+	unsupportedType := runnable("unsupported-type")
+	unsupportedType.InstanceType = "ON_PREMISES_INSTANCE"
+	noEndpoint := runnable("no-endpoint")
+	noEndpoint.IpAddresses = nil
+
+	instances := []*sqladmin.DatabaseInstance{
+		runnable("a"),
+		unavailable,
+		unsupportedType,
+		noEndpoint,
+		runnable("b"),
+	}
+
+	databases := DiscoverCloudSQLDatabases(t.Context(), logtest.NewLogger(), instances)
+	require.Len(t, databases, 2)
+	require.Equal(t, "a", databases[0].GetGCP().InstanceID)
+	require.Equal(t, "b", databases[1].GetGCP().InstanceID)
+}

--- a/lib/srv/discovery/common/renaming.go
+++ b/lib/srv/discovery/common/renaming.go
@@ -67,6 +67,24 @@ func ApplyAzureDatabaseNameSuffix(db types.Database, matcherType string) {
 	applyDiscoveryNameSuffix(db, suffix)
 }
 
+// ApplyGCPDatabaseNameSuffix applies the GCP Database Discovery name suffix to
+// the given database.
+// Format: <name>-<matcher type>-<region>-<project ID>.
+func ApplyGCPDatabaseNameSuffix(db types.Database, matcherType string) {
+	if hasOverrideLabel(db, types.GCPDatabaseNameOverrideLabel) {
+		return
+	}
+	region, _ := db.GetLabel(types.DiscoveryLabelRegion)
+	suffix := makeGCPDiscoverySuffix(databaseNamePartValidator,
+		db.GetName(),
+		matcherType,
+		getDBMatcherSubtype(matcherType, db),
+		region,
+		db.GetGCP().ProjectID,
+	)
+	applyDiscoveryNameSuffix(db, suffix)
+}
+
 // getDBMatcherSubtype gets a "subtype" for a given DB matcher, based on the
 // database metadata. This is needed for AWS RDS and Azure Redis databases
 // to ensure unique naming.

--- a/lib/srv/discovery/common/renaming_test.go
+++ b/lib/srv/discovery/common/renaming_test.go
@@ -32,6 +32,7 @@ import (
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 
 	"github.com/gravitational/teleport/api/types"
 	azureutils "github.com/gravitational/teleport/api/utils/azure"
@@ -39,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/cloud/gcp"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/discovery/common/cloudsql"
 )
 
 // TestMakeDiscoverySuffix tests makeDiscoverySuffix in isolation.
@@ -329,6 +331,39 @@ func TestApplyGKENameSuffix(t *testing.T) {
 		wantNewName:       "some-cluster-gke-central-1-dev-123456",
 	}
 	runRenameTest(t, test)
+}
+
+func TestApplyGCPDatabaseNameSuffix(t *testing.T) {
+	dbName := "some-db"
+	location := "us-central1"
+	project := "my-project"
+	instance := &sqladmin.DatabaseInstance{
+		Name:            dbName,
+		Project:         project,
+		Region:          location,
+		State:           "RUNNABLE",
+		DatabaseVersion: "POSTGRES_14",
+		InstanceType:    "CLOUD_SQL_INSTANCE",
+		IpAddresses:     []*sqladmin.IpMapping{{Type: "PRIMARY", IpAddress: "1.2.3.4"}},
+		Settings: &sqladmin.Settings{UserLabels: map[string]string{
+			types.GCPDatabaseNameOverrideLabel: dbName,
+		}},
+	}
+	database, skipReason, err := cloudsql.NewDatabaseFromInstance(instance, func(meta types.Metadata) types.Metadata {
+		return setGCPDBName(meta, instance.Name)
+	})
+	require.NoError(t, err)
+	require.Empty(t, skipReason)
+	runRenameTest(t, renameTest{
+		resource: database,
+		renameFn: func(r types.ResourceWithLabels) {
+			db := r.(types.Database)
+			ApplyGCPDatabaseNameSuffix(db, types.GCPMatcherCloudSQL)
+		},
+		originalName:      dbName,
+		nameOverrideLabel: types.GCPDatabaseNameOverrideLabel,
+		wantNewName:       "some-db-cloudsql-us-central1-my-project",
+	})
 }
 
 // requireDiscoveredNameLabel is a test helper that requires a resource have


### PR DESCRIPTION
Part 3 of the series; manual testing was performed against the final part.

- https://github.com/gravitational/teleport/pull/68660
- https://github.com/gravitational/teleport/pull/68661
- https://github.com/gravitational/teleport/pull/68662
- https://github.com/gravitational/teleport/pull/68663
- https://github.com/gravitational/teleport/pull/68501 