### PR TITLE
Tscolari/625/service retry poc

### DIFF
--- a/lib/tbot/internal/tunnel_retry.go
+++ b/lib/tbot/internal/tunnel_retry.go
@@ -1,0 +1,89 @@
+package internal
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
+)
+
+const tunnelInitializationMaxBackoff = 10 * time.Second
+
+// RetryTunnelInitialization retries remote tunnel initialization until it
+// succeeds or ctx is canceled. It reports failures as unhealthy.
+// On recovery (or success) it does not report Success, it's up to the
+// caller to do so once it finishes creating the proxy.
+func RetryTunnelInitialization(
+	ctx context.Context,
+	log *slog.Logger,
+	statusReporter readyz.Reporter,
+	initialize func(context.Context) error,
+) error {
+	return retryTunnelInitialization(ctx, log, statusReporter, retryutils.HalfJitter, initialize)
+}
+
+// retryTunnelInitialization exposes the jitter setting to allow predictable testing.
+func retryTunnelInitialization(
+	ctx context.Context,
+	log *slog.Logger,
+	statusReporter readyz.Reporter,
+	jitter retryutils.Jitter,
+	initialize func(context.Context) error,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	retry, err := retryutils.NewRetryV2(retryutils.RetryV2Config{
+		Driver: retryutils.NewExponentialDriver(time.Second),
+		Max:    tunnelInitializationMaxBackoff,
+		Jitter: jitter,
+	})
+	if err != nil {
+		return trace.Wrap(err, "creating tunnel initialization retry")
+	}
+
+	failures := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		err := initialize(ctx)
+		if err == nil {
+			if failures > 0 {
+				log.InfoContext(ctx, "Tunnel initialization recovered", "failed_attempts", failures)
+			}
+			return nil
+		}
+
+		// Cancellation can race with the operation returning an error. Do not
+		// report shutdown as another unhealthy initialization attempt.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+
+		failures++
+		statusReporter.ReportReason(readyz.Unhealthy, err.Error())
+
+		retry.Inc()
+
+		retryAfter := retry.Duration()
+
+		log.WarnContext(ctx, "Tunnel initialization failed, will retry",
+			"error", err,
+			"failed_attempts", failures,
+			"retry_after", retryAfter,
+		)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(retryAfter):
+		}
+	}
+}

--- a/lib/tbot/internal/tunnel_retry_test.go
+++ b/lib/tbot/internal/tunnel_retry_test.go
@@ -1,9 +1,12 @@
 package internal
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
@@ -23,16 +26,22 @@ func Test_RetryTunnelInitialization(t *testing.T) {
 		return nil
 	}
 
+	var loggerContents bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&loggerContents, nil))
+
 	registry := readyz.NewRegistry()
 	reporter := registry.AddService("application-tunnel", "test")
 
-	err := RetryTunnelInitialization(t.Context(), logtest.NewLogger(), reporter, init)
+	err := RetryTunnelInitialization(t.Context(), logger, reporter, init)
 	require.NoError(t, err)
 	require.True(t, initCalled)
 
 	status, ok := registry.ServiceStatus("test")
 	require.True(t, ok)
 	require.Equal(t, readyz.Initializing, status.Status)
+
+	// It should never show recovery logs if it succeeds at first attempt.
+	require.NotContains(t, loggerContents.String(), "Tunnel initialization recovered")
 }
 
 func Test_RetryTunnelInitialization_Retries(t *testing.T) {
@@ -59,11 +68,19 @@ func Test_RetryTunnelInitialization_Retries(t *testing.T) {
 		retryCtx, cancelCtx := context.WithCancel(t.Context())
 		defer cancelCtx()
 
-		deterministicJitter := func(d time.Duration) time.Duration { return d / 2 }
+		var jitterCallCount atomic.Int32
+		deterministicJitter := func(d time.Duration) time.Duration {
+			jitterCallCount.Add(1)
+			return d / 2
+		}
+
+		var loggerContents bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&loggerContents, nil))
+
 		go func() {
 			result <- retryTunnelInitialization(
 				retryCtx,
-				logtest.NewLogger(),
+				logger,
 				reporter,
 				deterministicJitter,
 				init)
@@ -96,6 +113,8 @@ func Test_RetryTunnelInitialization_Retries(t *testing.T) {
 		for i, d := range backoffs {
 			before, after := int32(i+1), int32(i+2)
 
+			require.Equal(t, i+1, int(jitterCallCount.Load()))
+
 			// Just before the backoff value: no new attempt yet.
 			time.Sleep(d - time.Nanosecond)
 			synctest.Wait()
@@ -127,6 +146,10 @@ func Test_RetryTunnelInitialization_Retries(t *testing.T) {
 			require.Fail(t, "timed out waiting for RetryTunnelInitialization to return")
 		}
 
+		// Validate that log reporting is correct
+		require.Equal(t, 7, strings.Count(loggerContents.String(), "Tunnel initialization failed, will retry"))
+		require.Equal(t, 1, strings.Count(loggerContents.String(), "Tunnel initialization recovered"))
+
 		// There should have been 7 failed attempts, plus one successful.
 		require.Equal(t, int32(8), initCallCount.Load())
 
@@ -147,6 +170,12 @@ func Test_RetryTunnelInitialization_ContextCancellation(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		cancel()
 
+		var initCalled bool
+		init := func(_ context.Context) error {
+			initCalled = true
+			return nil
+		}
+
 		registry := readyz.NewRegistry()
 		reporter := registry.AddService("application-tunnel", "test")
 
@@ -154,7 +183,7 @@ func Test_RetryTunnelInitialization_ContextCancellation(t *testing.T) {
 			ctx,
 			logtest.NewLogger(),
 			reporter,
-			func(ctx context.Context) error { return nil })
+			init)
 
 		require.Error(t, err)
 		require.ErrorIs(t, err, context.Canceled)
@@ -163,6 +192,8 @@ func Test_RetryTunnelInitialization_ContextCancellation(t *testing.T) {
 		status, ok := registry.ServiceStatus("test")
 		require.True(t, ok)
 		require.Equal(t, readyz.Initializing, status.Status)
+
+		require.False(t, initCalled, "the init function was called when it shouldn't")
 	})
 
 	t.Run("mid-init cancellation", func(t *testing.T) {

--- a/lib/tbot/internal/tunnel_retry_test.go
+++ b/lib/tbot/internal/tunnel_retry_test.go
@@ -1,0 +1,261 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/gravitational/teleport/lib/tbot/readyz"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_RetryTunnelInitialization(t *testing.T) {
+	t.Parallel()
+
+	var initCalled bool
+	init := func(_ context.Context) error {
+		initCalled = true
+		return nil
+	}
+
+	registry := readyz.NewRegistry()
+	reporter := registry.AddService("application-tunnel", "test")
+
+	err := RetryTunnelInitialization(t.Context(), logtest.NewLogger(), reporter, init)
+	require.NoError(t, err)
+	require.True(t, initCalled)
+
+	status, ok := registry.ServiceStatus("test")
+	require.True(t, ok)
+	require.Equal(t, readyz.Initializing, status.Status)
+}
+
+func Test_RetryTunnelInitialization_Retries(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		registry := readyz.NewRegistry()
+		reporter := registry.AddService("application-tunnel", "test")
+
+		var initCallCount atomic.Int32
+		var initReturnNil atomic.Bool
+
+		init := func(_ context.Context) error {
+			initCallCount.Add(1)
+			if initReturnNil.Load() {
+				return nil
+			}
+
+			return fmt.Errorf("init function call is failing (%d)", initCallCount.Load())
+		}
+
+		result := make(chan error, 1)
+
+		retryCtx, cancelCtx := context.WithCancel(t.Context())
+		defer cancelCtx()
+
+		deterministicJitter := func(d time.Duration) time.Duration { return d / 2 }
+		go func() {
+			result <- retryTunnelInitialization(
+				retryCtx,
+				logtest.NewLogger(),
+				reporter,
+				deterministicJitter,
+				init)
+		}()
+
+		synctest.Wait()
+
+		status, ok := registry.ServiceStatus("test")
+		require.True(t, ok)
+		require.Equal(t, readyz.Unhealthy, status.Status)
+		require.Equal(t, "init function call is failing (1)", status.Reason)
+
+		calls := initCallCount.Load()
+		require.Equal(t, int32(1), calls)
+
+		backoffs := []time.Duration{
+			500 * time.Millisecond, // attempt 2
+			1 * time.Second,        // attempt 3
+			2 * time.Second,        // attempt 4
+			4 * time.Second,        // attempt 5
+			// max is set to 10s, but jitter halves it = 5
+			5 * time.Second, // attempt 6
+			5 * time.Second, // attempt 7
+		}
+
+		// Attempt 1 runs at t=0.
+		synctest.Wait()
+		require.Equal(t, int32(1), initCallCount.Load())
+
+		for i, d := range backoffs {
+			before, after := int32(i+1), int32(i+2)
+
+			// Just before the backoff value: no new attempt yet.
+			time.Sleep(d - time.Nanosecond)
+			synctest.Wait()
+			require.Equal(t, before, initCallCount.Load(),
+				"retry #%d triggered before the %s backoff elapsed", i+1, d)
+
+			// At the backoff value: exactly one new attempt.
+			time.Sleep(time.Nanosecond)
+			synctest.Wait()
+			require.Equal(t, after, initCallCount.Load(),
+				"retry #%d did not fire after %s", i+1, d)
+		}
+
+		select {
+		case <-result:
+			require.Fail(t, "RetryTunnelInitialization returned when it shouldn't yet")
+		default:
+		}
+
+		initReturnNil.Store(true)
+
+		select {
+		case err := <-result:
+			require.NoError(t, err)
+
+		// The "1 minute" is just to ensure the check happens after all the other timed
+		// events inside synctest.
+		case <-time.After(1 * time.Minute):
+			require.Fail(t, "timed out waiting for RetryTunnelInitialization to return")
+		}
+
+		// There should have been 7 failed attempts, plus one successful.
+		require.Equal(t, int32(8), initCallCount.Load())
+
+		// The RetryTunnelInitialization intentionally never sets the status to Healthy.
+		status, ok = registry.ServiceStatus("test")
+		require.True(t, ok)
+		require.Equal(t, readyz.Unhealthy, status.Status)
+		require.Equal(t, "init function call is failing (7)", status.Reason)
+	})
+}
+
+func Test_RetryTunnelInitialization_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("starting with a canceled context", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		registry := readyz.NewRegistry()
+		reporter := registry.AddService("application-tunnel", "test")
+
+		err := RetryTunnelInitialization(
+			ctx,
+			logtest.NewLogger(),
+			reporter,
+			func(ctx context.Context) error { return nil })
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.Canceled)
+
+		// It should not report any status change when the context is canceled.
+		status, ok := registry.ServiceStatus("test")
+		require.True(t, ok)
+		require.Equal(t, readyz.Initializing, status.Status)
+	})
+
+	t.Run("mid-init cancellation", func(t *testing.T) {
+		t.Parallel()
+
+		synctest.Test(t, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			registry := readyz.NewRegistry()
+			reporter := registry.AddService("application-tunnel", "test")
+
+			init := func(ctx context.Context) error {
+				<-ctx.Done()
+				return errors.New("failed mid-init")
+			}
+
+			result := make(chan error, 1)
+
+			go func() {
+				result <- RetryTunnelInitialization(
+					ctx,
+					logtest.NewLogger(),
+					reporter,
+					init)
+			}()
+
+			synctest.Wait()
+			cancel()
+			synctest.Wait()
+
+			select {
+			case err := <-result:
+				require.ErrorIs(t, err, context.Canceled)
+				require.NotContains(t, err.Error(), "failed mid-init")
+			default:
+				require.Fail(t, "expected result but there was none")
+			}
+
+			// It should not report any status change when the context is canceled.
+			status, ok := registry.ServiceStatus("test")
+			require.True(t, ok)
+			require.Equal(t, readyz.Initializing, status.Status)
+		})
+	})
+
+	t.Run("context gets canceled during retries", func(t *testing.T) {
+		t.Parallel()
+
+		synctest.Test(t, func(t *testing.T) {
+			init := func(_ context.Context) error {
+				return errors.New("init function call is failing")
+			}
+
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			registry := readyz.NewRegistry()
+			reporter := registry.AddService("application-tunnel", "test")
+
+			result := make(chan error, 1)
+
+			go func() {
+				result <- RetryTunnelInitialization(
+					ctx,
+					logtest.NewLogger(),
+					reporter,
+					init)
+			}()
+
+			synctest.Wait()
+
+			// Status change is being caused by the failing init function.
+			status, ok := registry.ServiceStatus("test")
+			require.True(t, ok)
+			require.Equal(t, readyz.Unhealthy, status.Status)
+
+			select {
+			case <-result:
+				require.Fail(t, "RetryTunnelInitialization returned when it shouldn't yet")
+			default:
+			}
+
+			cancel()
+
+			select {
+			case err := <-result:
+				require.Error(t, err)
+				require.ErrorIs(t, err, context.Canceled)
+
+			case <-time.After(1 * time.Minute):
+				require.Fail(t, "timed out waiting for RetryTunnelInitialization to return")
+			}
+		})
+	})
+}

--- a/lib/tbot/services/application/tunnel_service.go
+++ b/lib/tbot/services/application/tunnel_service.go
@@ -22,6 +22,7 @@ import (
 	"cmp"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -108,8 +109,20 @@ func (s *TunnelService) Run(ctx context.Context) error {
 		}()
 	}
 
-	lpCfg, err := s.buildLocalProxyConfig(ctx)
+	var lpCfg alpnproxy.LocalProxyConfig
+	err := internal.RetryTunnelInitialization(ctx, s.log, s.statusReporter, func(ctx context.Context) error {
+		var proxyErr error
+		lpCfg, proxyErr = s.buildLocalProxyConfig(ctx)
+		return proxyErr
+	})
 	if err != nil {
+		// If the context got canceled do not to pollute
+		// the shutdown with that error. Similar to what is
+		// being done at the end of this function.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil
+		}
+
 		return trace.Wrap(err, "building local proxy config")
 	}
 	lpCfg.Listener = l

--- a/lib/tbot/services/application/tunnel_service_test.go
+++ b/lib/tbot/services/application/tunnel_service_test.go
@@ -344,7 +344,8 @@ func Test_TunnelService_Run_CancellationDuringRetry(t *testing.T) {
 		// Verify that the reporter wiring is correct and it's reporting Unhealthy
 		status, ok := registry.ServiceStatus("test")
 		require.True(t, ok)
-		assert.Equal(t, readyz.Unhealthy, status.Status)
+		require.Equal(t, readyz.Unhealthy, status.Status)
+		require.Contains(t, status.Reason, "proxy unreachable")
 
 		// Verify that Run has not returned, therefore it's retrying.
 		select {

--- a/lib/tbot/services/application/tunnel_service_test.go
+++ b/lib/tbot/services/application/tunnel_service_test.go
@@ -20,6 +20,7 @@ package application
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -28,6 +29,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/jonboulle/clockwork"
@@ -39,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
@@ -310,4 +313,59 @@ func TestE2E_ApplicationTunnelService_Leeway(t *testing.T) {
 	clock.Advance(bot.DefaultCredentialLifetime.TTL - bot.DefaultCredentialLifetime.RenewalInterval - time.Minute)
 	makeTunnelRequest(t, botListener, wantStatus, wantBody)
 	require.EqualValues(t, 2, certsIssued.Load())
+}
+
+func Test_TunnelService_Run_CancellationDuringRetry(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		pinger := &fakePinger{err: errors.New("proxy unreachable")}
+		registry := readyz.NewRegistry()
+		reporter := registry.AddService("application-tunnel", "test")
+		readyCh := make(chan struct{})
+		close(readyCh)
+
+		listener, err := net.Listen("tcp", "127.0.0.1:")
+		require.NoError(t, err)
+
+		svc := &TunnelService{
+			cfg:                &TunnelConfig{AppName: "test", Listener: listener},
+			proxyPinger:        pinger,
+			botIdentityReadyCh: readyCh,
+			statusReporter:     reporter,
+			log:                logtest.NewLogger(),
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		done := make(chan error, 1)
+		go func() { done <- svc.Run(ctx) }()
+
+		synctest.Wait()
+
+		// Verify that the reporter wiring is correct and it's reporting Unhealthy
+		status, ok := registry.ServiceStatus("test")
+		require.True(t, ok)
+		assert.Equal(t, readyz.Unhealthy, status.Status)
+
+		// Verify that Run has not returned, therefore it's retrying.
+		select {
+		case <-done:
+			require.Fail(t, "Run returned instead of retrying")
+		default:
+		}
+
+		cancel()
+		synctest.Wait()
+
+		// Verify that context cancellation is not propagating an error
+		// from the retry wrapper.
+		require.NoError(t, <-done)
+	})
+}
+
+type fakePinger struct {
+	err error
+}
+
+func (p fakePinger) Ping(_ context.Context) (*connection.ProxyPong, error) {
+	return nil, p.err
 }

--- a/lib/tbot/services/database/tunnel_service.go
+++ b/lib/tbot/services/database/tunnel_service.go
@@ -22,6 +22,7 @@ import (
 	"cmp"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -189,7 +190,6 @@ func (s *TunnelService) buildLocalProxyConfig(ctx context.Context) (lpCfg alpnpr
 	alpnProtocol, err := common.ToALPNProtocol(routeToDatabase.Protocol)
 	if err != nil {
 		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err)
-
 	}
 	lpConfig := alpnproxy.LocalProxyConfig{
 		Middleware: middleware,
@@ -233,8 +233,20 @@ func (s *TunnelService) Run(ctx context.Context) error {
 		}()
 	}
 
-	lpCfg, err := s.buildLocalProxyConfig(ctx)
+	var lpCfg alpnproxy.LocalProxyConfig
+	err := internal.RetryTunnelInitialization(ctx, s.log, s.statusReporter, func(ctx context.Context) error {
+		var proxyErr error
+		lpCfg, proxyErr = s.buildLocalProxyConfig(ctx)
+		return proxyErr
+	})
 	if err != nil {
+		// If the context got canceled do not to pollute
+		// the shutdown with that error. Similar to what is
+		// being done at the end of this function.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil
+		}
+
 		return trace.Wrap(err, "building local proxy config")
 	}
 	lpCfg.Listener = l

--- a/lib/tbot/services/database/tunnel_service_test.go
+++ b/lib/tbot/services/database/tunnel_service_test.go
@@ -1,0 +1,70 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"testing/synctest"
+
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_TunnelService_Run_CancellationDuringRetry(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		pinger := &fakePinger{err: errors.New("proxy unreachable")}
+		registry := readyz.NewRegistry()
+		reporter := registry.AddService("application-tunnel", "test")
+		readyCh := make(chan struct{})
+		close(readyCh)
+
+		listener, err := net.Listen("tcp", "127.0.0.1:")
+		require.NoError(t, err)
+
+		svc := &TunnelService{
+			cfg:                &TunnelConfig{Name: "test", Listener: listener},
+			proxyPinger:        pinger,
+			botIdentityReadyCh: readyCh,
+			statusReporter:     reporter,
+			log:                logtest.NewLogger(),
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		done := make(chan error, 1)
+		go func() { done <- svc.Run(ctx) }()
+
+		synctest.Wait()
+
+		// Verify that the reporter wiring is correct and it's reporting Unhealthy
+		status, ok := registry.ServiceStatus("test")
+		require.True(t, ok)
+		require.Equal(t, readyz.Unhealthy, status.Status)
+		require.Contains(t, status.Reason, "proxy unreachable")
+
+		// Verify that Run has not returned, therefore it's retrying.
+		select {
+		case <-done:
+			require.Fail(t, "Run returned instead of retrying")
+		default:
+		}
+
+		cancel()
+		synctest.Wait()
+
+		// Verify that context cancellation is not propagating an error
+		// from the retry wrapper.
+		require.NoError(t, <-done)
+	})
+}
+
+type fakePinger struct {
+	err error
+}
+
+func (p fakePinger) Ping(_ context.Context) (*connection.ProxyPong, error) {
+	return nil, p.err
+}

--- a/lib/tbot/tunnel_recovery_test.go
+++ b/lib/tbot/tunnel_recovery_test.go
@@ -161,7 +161,7 @@ func waitForTunnelRecoveryServiceStatus(
 			return nil, fmt.Errorf("tbot exited before %q became %s: %w", serviceName, want, run.err)
 		case <-ctx.Done():
 			return nil, fmt.Errorf(
-				"waiting for %q to become %s (last status: %v, last error: %v): %w",
+				"waiting for %q to become %s (last status: %v, last error: %w): %w",
 				serviceName,
 				want,
 				lastStatus,
@@ -442,5 +442,4 @@ func TestBotTunnelServicesRecoverWhenServersAppear(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, appStatus.Reason)
 	run.requireRunning(t)
-
 }

--- a/lib/tbot/tunnel_recovery_test.go
+++ b/lib/tbot/tunnel_recovery_test.go
@@ -1,0 +1,446 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tbot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
+	libdefaults "github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/db/common"
+	"github.com/gravitational/teleport/lib/srv/db/postgres"
+	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
+	"github.com/gravitational/teleport/lib/tbot/services/application"
+	"github.com/gravitational/teleport/lib/tbot/services/database"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+	"github.com/gravitational/teleport/tool/teleport/testenv"
+)
+
+type tunnelRecoveryTestBot struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+	err    error
+}
+
+func startTunnelRecoveryTestBot(t *testing.T, parent context.Context, bot *Bot) *tunnelRecoveryTestBot {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(parent)
+	run := &tunnelRecoveryTestBot{
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+	go func() {
+		run.err = bot.Run(ctx)
+		close(run.done)
+	}()
+
+	t.Cleanup(func() {
+		run.cancel()
+		select {
+		case <-run.done:
+			if !t.Failed() {
+				assert.NoError(t, run.err, "bot should exit cleanly")
+			}
+		case <-time.After(10 * time.Second):
+			assert.Fail(t, "bot did not stop within 10 seconds")
+		}
+	})
+	return run
+}
+
+func (r *tunnelRecoveryTestBot) requireRunning(t *testing.T) {
+	t.Helper()
+
+	select {
+	case <-r.done:
+		require.Fail(t, "bot exited unexpectedly", "error: %v", r.err)
+	default:
+	}
+}
+
+func newTunnelRecoveryDiagnosticsClient(t *testing.T, socketPath string) *http.Client {
+	t.Helper()
+
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var dialer net.Dialer
+			return dialer.DialContext(ctx, "unix", socketPath)
+		},
+	}
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   time.Second,
+	}
+	t.Cleanup(client.CloseIdleConnections)
+	return client
+}
+
+func waitForTunnelRecoveryServiceStatus(
+	ctx context.Context,
+	run *tunnelRecoveryTestBot,
+	client *http.Client,
+	serviceName string,
+	want readyz.Status,
+) (*readyz.ServiceStatus, error) {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	var lastStatus *readyz.ServiceStatus
+	var lastErr error
+	for {
+		select {
+		case <-run.done:
+			return nil, fmt.Errorf("tbot exited before %q became %s: %w", serviceName, want, run.err)
+		default:
+		}
+
+		req, err := http.NewRequestWithContext(
+			ctx,
+			http.MethodGet,
+			"http://unix/readyz/"+serviceName,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := client.Do(req)
+		if err == nil {
+			status := new(readyz.ServiceStatus)
+			decodeErr := json.NewDecoder(resp.Body).Decode(status)
+			resp.Body.Close()
+			if decodeErr == nil {
+				lastStatus = status
+				if status.Status == want {
+					return status, nil
+				}
+			} else {
+				lastErr = decodeErr
+			}
+		} else {
+			lastErr = err
+		}
+
+		select {
+		case <-run.done:
+			return nil, fmt.Errorf("tbot exited before %q became %s: %w", serviceName, want, run.err)
+		case <-ctx.Done():
+			return nil, fmt.Errorf(
+				"waiting for %q to become %s (last status: %v, last error: %v): %w",
+				serviceName,
+				want,
+				lastStatus,
+				lastErr,
+				ctx.Err(),
+			)
+		case <-ticker.C:
+		}
+	}
+}
+
+// TestBotTunnelServicesRecoverWhenServersAppear verifies recovery when existing
+// resources begin to be served after tbot starts. Label matching exercises the
+// real agent reconciliation and heartbeat paths, but not cold agent joining.
+func TestBotTunnelServicesRecoverWhenServersAppear(t *testing.T) {
+	t.Parallel()
+
+	const (
+		matcherLabel       = "tbot-test"
+		matcherValue       = "enabled"
+		appName            = "delayed-app"
+		databaseService    = "delayed-database"
+		databaseName       = "testdb"
+		databaseUser       = "llama"
+		appTunnelName      = "delayed-app-tunnel"
+		databaseTunnelName = "delayed-database-tunnel"
+	)
+
+	ctx := t.Context()
+	log := logtest.NewLogger()
+	matcher := services.ResourceMatcher{
+		Labels: types.Labels{matcherLabel: []string{matcherValue}},
+	}
+
+	process, err := testenv.NewTeleportProcess(
+		t.TempDir(),
+		defaultTestServerOpts(log),
+		testenv.WithConfig(func(cfg *servicecfg.Config) {
+			cfg.Apps.Enabled = true
+			cfg.Apps.ResourceMatchers = []services.ResourceMatcher{matcher}
+			cfg.Databases.Enabled = true
+			cfg.Databases.ResourceMatchers = []services.ResourceMatcher{matcher}
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, process.Close())
+		require.NoError(t, process.Wait())
+	})
+
+	rootClient, err := testenv.NewDefaultAuthClient(process)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rootClient.Close() })
+
+	wantStatus := http.StatusTeapot
+	wantBody := "application tunnel response"
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(wantStatus)
+		_, _ = io.WriteString(w, wantBody)
+	}))
+	t.Cleanup(httpServer.Close)
+
+	postgresServer, err := postgres.NewTestServer(common.TestServerConfig{
+		AuthClient: rootClient,
+		Users:      []string{databaseUser},
+	})
+	require.NoError(t, err)
+	postgresDone := make(chan error, 1)
+	go func() {
+		postgresDone <- postgresServer.Serve()
+	}()
+	t.Cleanup(func() {
+		postgresServer.Close()
+		select {
+		case err := <-postgresDone:
+			assert.NoError(t, err)
+		case <-time.After(10 * time.Second):
+			assert.Fail(t, "Postgres test server did not stop within 10 seconds")
+		}
+	})
+
+	app, err := types.NewAppV3(types.Metadata{
+		Name: appName,
+		Labels: map[string]string{
+			matcherLabel: "disabled",
+		},
+	}, types.AppSpecV3{
+		URI:        httpServer.URL,
+		PublicAddr: appName + ".example.com",
+	})
+	require.NoError(t, err)
+	require.NoError(t, rootClient.CreateApp(ctx, app))
+
+	db, err := types.NewDatabaseV3(types.Metadata{
+		Name: databaseService,
+		Labels: map[string]string{
+			matcherLabel: "disabled",
+		},
+	}, types.DatabaseSpecV3{
+		Protocol: libdefaults.ProtocolPostgres,
+		URI:      net.JoinHostPort("localhost", postgresServer.Port()),
+	})
+	require.NoError(t, err)
+	require.NoError(t, rootClient.CreateDatabase(ctx, db))
+
+	role, err := types.NewRole("tunnel-access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: types.Labels{
+				"*": apiutils.Strings{"*"},
+			},
+			DatabaseLabels: types.Labels{
+				"*": apiutils.Strings{"*"},
+			},
+			DatabaseNames: []string{databaseName},
+			DatabaseUsers: []string{databaseUser},
+		},
+	})
+	require.NoError(t, err)
+	role, err = rootClient.UpsertRole(ctx, role)
+	require.NoError(t, err)
+
+	appListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = appListener.Close() })
+	databaseListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = databaseListener.Close() })
+
+	diagDir, err := os.MkdirTemp("", "tbot-tunnel-recovery-")
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, os.RemoveAll(diagDir)) })
+	diagSocketPath := filepath.Join(diagDir, "diag.sock")
+
+	onboarding, _ := makeBot(t, rootClient, "tunnel-recovery", role.GetName())
+	botConfig := defaultBotConfig(
+		t,
+		process,
+		onboarding,
+		config.ServiceConfigs{
+			&application.TunnelConfig{
+				Name:     appTunnelName,
+				Listener: appListener,
+				AppName:  appName,
+			},
+			&database.TunnelConfig{
+				Name:     databaseTunnelName,
+				Listener: databaseListener,
+				Service:  databaseService,
+				Database: databaseName,
+				Username: databaseUser,
+			},
+		},
+		defaultBotConfigOpts{
+			useAuthServer: true,
+			insecure:      true,
+		},
+	)
+	botConfig.Oneshot = false
+	botConfig.DiagSocketForUpdater = diagSocketPath
+
+	run := startTunnelRecoveryTestBot(t, ctx, New(botConfig, log))
+	diagnosticsClient := newTunnelRecoveryDiagnosticsClient(t, diagSocketPath)
+
+	// Before startup retries are implemented, either tunnel may return its
+	// missing-server error first and cancel the whole bot. The done-channel
+	// error from this wait is the intended pre-fix regression signal; do not
+	// depend on which tunnel wins that race.
+	statusCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	appStatus, err := waitForTunnelRecoveryServiceStatus(
+		statusCtx, run, diagnosticsClient, appTunnelName, readyz.Unhealthy,
+	)
+	cancel()
+	require.NoError(t, err)
+	require.NotEmpty(t, appStatus.Reason)
+	require.Contains(t, appStatus.Reason, appName)
+
+	statusCtx, cancel = context.WithTimeout(ctx, 30*time.Second)
+	databaseStatus, err := waitForTunnelRecoveryServiceStatus(
+		statusCtx, run, diagnosticsClient, databaseTunnelName, readyz.Unhealthy,
+	)
+	cancel()
+	require.NoError(t, err)
+	require.NotEmpty(t, databaseStatus.Reason)
+	require.Contains(t, databaseStatus.Reason, databaseService)
+	run.requireRunning(t)
+
+	app.SetStaticLabels(map[string]string{matcherLabel: matcherValue})
+	require.NoError(t, rootClient.UpdateApp(ctx, app))
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		servers, err := rootClient.GetApplicationServers(ctx, apidefaults.Namespace)
+		require.NoError(t, err)
+		for _, server := range servers {
+			if server.GetApp().GetName() == appName {
+				return
+			}
+		}
+		require.Fail(t, "application server heartbeat not found")
+	}, 30*time.Second, 100*time.Millisecond)
+
+	statusCtx, cancel = context.WithTimeout(ctx, 30*time.Second)
+	appStatus, err = waitForTunnelRecoveryServiceStatus(
+		statusCtx, run, diagnosticsClient, appTunnelName, readyz.Healthy,
+	)
+	cancel()
+	require.NoError(t, err)
+	require.Empty(t, appStatus.Reason)
+
+	statusCtx, cancel = context.WithTimeout(ctx, 30*time.Second)
+	databaseStatus, err = waitForTunnelRecoveryServiceStatus(
+		statusCtx, run, diagnosticsClient, databaseTunnelName, readyz.Unhealthy,
+	)
+	cancel()
+	require.NoError(t, err)
+	require.Contains(t, databaseStatus.Reason, databaseService)
+	run.requireRunning(t)
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{DisableKeepAlives: true},
+		Timeout:   2 * time.Second,
+	}
+	t.Cleanup(httpClient.CloseIdleConnections)
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		resp, err := httpClient.Get("http://" + appListener.Addr().String())
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, wantStatus, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, wantBody, string(body))
+	}, 30*time.Second, 100*time.Millisecond)
+
+	db.SetStaticLabels(map[string]string{matcherLabel: matcherValue})
+	require.NoError(t, rootClient.UpdateDatabase(ctx, db))
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		servers, err := rootClient.GetDatabaseServers(ctx, apidefaults.Namespace)
+		require.NoError(t, err)
+		for _, server := range servers {
+			if server.GetDatabase().GetName() == databaseService {
+				return
+			}
+		}
+		require.Fail(t, "database server heartbeat not found")
+	}, 30*time.Second, 100*time.Millisecond)
+
+	statusCtx, cancel = context.WithTimeout(ctx, 30*time.Second)
+	databaseStatus, err = waitForTunnelRecoveryServiceStatus(
+		statusCtx, run, diagnosticsClient, databaseTunnelName, readyz.Healthy,
+	)
+	cancel()
+	require.NoError(t, err)
+	require.Empty(t, databaseStatus.Reason)
+	run.requireRunning(t)
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		attemptCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+		conn, err := pgconn.Connect(
+			attemptCtx,
+			fmt.Sprintf(
+				"postgres://%s/%s?user=%s",
+				databaseListener.Addr().String(),
+				databaseName,
+				databaseUser,
+			),
+		)
+		require.NoError(t, err)
+		defer conn.Close(attemptCtx)
+		results, err := conn.Exec(attemptCtx, "SELECT 1;").ReadAll()
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+	}, 30*time.Second, 100*time.Millisecond)
+
+	statusCtx, cancel = context.WithTimeout(ctx, 30*time.Second)
+	appStatus, err = waitForTunnelRecoveryServiceStatus(
+		statusCtx, run, diagnosticsClient, appTunnelName, readyz.Healthy,
+	)
+	cancel()
+	require.NoError(t, err)
+	require.Empty(t, appStatus.Reason)
+	run.requireRunning(t)
+
+}


### PR DESCRIPTION
Application and database tunnel services resolved their target and issued the initial certificate exactly once at startup, returning any error directly.
Because all tbot services share an errgroup, one tunnel's startup error cancelled the group and took down every other service in the process.

This wraps the initialization of both tunnel services in a bounded retry with backoff, reporting Unhealthy via /readyz on each failed attempt and recovering automatically once the target becomes available.
Cancellation is translated to a clean shutdown so normal termination is not reported as an error. Listener creation and local proxy construction remain outside the retry and stay fatal.

---

Changelog: tbot application and database tunnels now retry initialization instead of exiting when their target is temporarily unavailable, so a single unavailable target no longer stops other tunnels running in the same bot.



## Manual Test Plan
### Test Environment

local

### Test Cases
- [ ] start tbot with an application-tunnel configured but not reporting, tbot should report the service as Unhealthy without crashing.
- [ ] start tbot with a database-tunnel configured but not reporting, tbot should report the service as Unhealthy without crashing.
- [ ] start tbot with an application-tunnel configured and reporting, should produce no retry logs/attempts.
- [ ] start tbot with a database-tunnel configured and reporting, should produce no retry logs/attempts.
