### PR TITLE
[v18] Detect and optionally block cross-site WebSocket hijacking (CSWSH) on app access

### DIFF
--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -29,6 +29,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"slices"
 	"time"
@@ -104,6 +105,11 @@ type Handler struct {
 	clusterName string
 
 	logger *slog.Logger
+
+	// cswshAction controls the response to a detected cross-origin WebSocket
+	// upgrade, configured via TELEPORT_UNSTABLE_APP_CSWSH_ACTION. Defaults to
+	// no-op.
+	cswshAction cswshAction
 }
 
 // NewHandler returns a new application handler.
@@ -117,6 +123,11 @@ func NewHandler(ctx context.Context, c *HandlerConfig) (*Handler, error) {
 		c:            c,
 		closeContext: ctx,
 		logger:       slog.With(teleport.ComponentKey, teleport.ComponentAppProxy),
+		cswshAction:  parseCSWSHAction(os.Getenv(cswshActionEnv)),
+	}
+	if h.cswshAction.enabled() {
+		h.logger.InfoContext(ctx, "Application access cross-site WebSocket (CSWSH) guard enabled",
+			"report", h.cswshAction.report, "block", h.cswshAction.block)
 	}
 
 	// Create a new session cache, this holds sessions that can be used to
@@ -254,6 +265,12 @@ func (h *Handler) HealthCheckAppServer(ctx context.Context, appName, publicAddr,
 // handleHttp forwards the request to the application service or redirects
 // to the application directly.
 func (h *Handler) handleHttp(w http.ResponseWriter, r *http.Request, session *session) error {
+	// Reject (or, in report-only mode, log) cross-site WebSocket upgrades
+	// before forwarding to the application (CSWSH protection).
+	if err := h.guardCrossSiteWebSocket(r); err != nil {
+		return trace.Wrap(err)
+	}
+
 	var redirectURI string
 
 	session.tr.mu.Lock()

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -430,6 +430,93 @@ func TestNewSessionRoutesByAppName(t *testing.T) {
 	}
 }
 
+// TestCrossSiteWebSocketProtection verifies the CSWSH guard is wired into the
+// cookie-authenticated app forward path end-to-end: under block, a cross-origin
+// WebSocket upgrade is rejected with 403, while a non-WebSocket request is still
+// forwarded. The guard's full decision matrix (action modes, origin
+// classification) is unit-tested in TestGuardCrossSiteWebSocket; this test covers
+// the wiring and status propagation through the real handler and middleware.
+//
+// Requests use a realistic handshake (Connection: Upgrade + Origin), matching
+// what a browser actually sends — Chrome attaches no Sec-Fetch-* to a WebSocket
+// upgrade, so Origin is the signal that drives detection.
+func TestCrossSiteWebSocketProtection(t *testing.T) {
+	clusterName := "test-cluster"
+	publicAddr := "app.example.com"
+
+	key, cert, err := tlsca.GenerateSelfSignedCA(
+		pkix.Name{CommonName: clusterName},
+		[]string{publicAddr, apiutils.EncodeClusterName(clusterName)},
+		defaults.CATTL,
+	)
+	require.NoError(t, err)
+
+	fakeClock := clockwork.NewFakeClock()
+	authClient := &mockAuthClient{
+		clusterName: clusterName,
+		appSession:  createAppSession(t, fakeClock, key, cert, clusterName, publicAddr, "testapp"),
+		appServers:  []types.AppServer{createNamedAppServer(t, "testapp", publicAddr)},
+		caKey:       key,
+		caCert:      cert,
+	}
+
+	fakeCluster := startFakeAppServerOnCluster(t, clusterName, authClient, cert, key)
+	tunnel := &reversetunnelclient.FakeServer{
+		FakeClusters: []reversetunnelclient.Cluster{fakeCluster},
+	}
+
+	// Valid victim session cookies. In the real attack the browser attaches
+	// these automatically on cross-site requests because they are SameSite=None.
+	cookies := []http.Cookie{
+		{Name: CookieName, Value: "abc"},
+		{Name: SubjectCookieName, Value: authClient.appSession.GetBearerToken()},
+	}
+	// A cross-origin WebSocket handshake: the Origin host differs from the app's,
+	// and there is no Sec-Fetch-Site (as on a real browser WebSocket upgrade).
+	crossOriginWS := map[string]string{
+		"Connection": "Upgrade",
+		"Upgrade":    "websocket",
+		"Origin":     "https://attacker.example",
+	}
+
+	for _, tc := range []struct {
+		name       string
+		action     string // TELEPORT_UNSTABLE_APP_CSWSH_ACTION
+		method     string
+		headers    map[string]string
+		wantStatus int
+	}{
+		{
+			name:       "block rejects cross-origin WebSocket",
+			action:     "block",
+			method:     "GET",
+			headers:    crossOriginWS,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "report-and-block rejects cross-origin WebSocket",
+			action:     "report-and-block",
+			method:     "GET",
+			headers:    crossOriginWS,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "cross-origin non-WebSocket request is forwarded under block (HTTP CSRF out of scope)",
+			action:     "block",
+			method:     "POST",
+			headers:    map[string]string{"Origin": "https://attacker.example"},
+			wantStatus: http.StatusOK,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(cswshActionEnv, tc.action)
+			p := setup(t, fakeClock, authClient, tunnel)
+			status, _, _ := p.makeRequestWithHeaders(t, tc.method, "/", []byte{}, cookies, tc.headers)
+			require.Equal(t, tc.wantStatus, status)
+		})
+	}
+}
+
 func TestHealthCheckAppServer(t *testing.T) {
 	ctx := context.Background()
 	clusterName := "test-cluster"

--- a/lib/web/app/websocket.go
+++ b/lib/web/app/websocket.go
@@ -1,0 +1,153 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package app
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// cswshActionEnv is the environment variable that controls how the app proxy
+// responds to a detected cross-origin WebSocket upgrade (cross-site WebSocket
+// hijacking, CSWSH). Recognized values: "report", "block", "report-and-block".
+// Any other value, including unset, does nothing.
+const cswshActionEnv = "TELEPORT_UNSTABLE_APP_CSWSH_ACTION"
+
+// cswshAction is the parsed TELEPORT_UNSTABLE_APP_CSWSH_ACTION behavior. report
+// and block are independent: unset of both is the default no-op.
+type cswshAction struct {
+	report bool
+	block  bool
+}
+
+// enabled reports whether the action does anything (report and/or block). The
+// zero value is disabled, which is the safe default.
+func (a cswshAction) enabled() bool { return a.report || a.block }
+
+// parseCSWSHAction parses the TELEPORT_UNSTABLE_APP_CSWSH_ACTION value. Unknown
+// or empty values disable the guard (do nothing) so the default is always safe.
+func parseCSWSHAction(v string) cswshAction {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "report":
+		return cswshAction{report: true}
+	case "block":
+		return cswshAction{block: true}
+	case "report-and-block", "report_and_block":
+		return cswshAction{report: true, block: true}
+	default:
+		return cswshAction{}
+	}
+}
+
+// guardCrossSiteWebSocket detects cross-origin WebSocket upgrades on the app
+// forward path and reacts per the configured action (report, block, both, or —
+// by default — nothing).
+//
+// Scope: only a browser attaches the victim's ambient cookies, so CSWSH is
+// inherently a browser attack, and we police it using signals a browser is forced
+// to send and a script cannot forge (the Origin header — see
+// isCrossOriginWebSocketUpgrade). Non-browser clients carry no such cookies and no
+// Origin, so they pass through. Same-origin upgrades (the app's own page) always
+// pass. Plain HTTP CSRF is out of scope.
+func (h *Handler) guardCrossSiteWebSocket(r *http.Request) error {
+	if !h.cswshAction.enabled() {
+		return nil
+	}
+	if !isWebSocketUpgrade(r) {
+		return nil
+	}
+	if !isCrossOriginWebSocketUpgrade(r) {
+		return nil
+	}
+
+	if h.cswshAction.report {
+		h.logger.WarnContext(r.Context(), "Detected cross-origin WebSocket upgrade to application",
+			"blocked", h.cswshAction.block,
+			"sec_fetch_site", r.Header.Get("Sec-Fetch-Site"),
+			"origin", r.Header.Get("Origin"),
+			"host", r.Host,
+			"path", r.URL.Path,
+		)
+	}
+
+	if h.cswshAction.block {
+		return trace.AccessDenied("cross-origin WebSocket upgrade rejected")
+	}
+	return nil
+}
+
+// isCrossOriginWebSocketUpgrade reports whether a WebSocket upgrade was initiated
+// from an origin other than the app's own. r must already be a WebSocket upgrade
+// (callers check isWebSocketUpgrade first).
+//
+// Origin is the signal: RFC 6455 §4.1 requires browser clients to send it on the
+// handshake and §10.2 sanctions rejecting on it; OWASP's WebSocket Security Cheat
+// Sheet likewise makes Origin validation the primary CSWSH defense. A script
+// cannot forge it, and non-browser clients (which carry no ambient cookies to
+// abuse) may omit it. A present Origin whose host differs from the app's is
+// cross-origin.
+//
+// We do not consult Sec-Fetch-Site: browsers don't attach it to WebSocket
+// handshakes, and where it is present it agrees with the Origin comparison. We
+// also do not distinguish same-site from cross-site — that would need the Public
+// Suffix List and is deferred; today any foreign origin is cross-origin.
+func isCrossOriginWebSocketUpgrade(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return false
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return true // unparseable Origin: treat as foreign
+	}
+	// An origin is (scheme, host, port), so compare scheme too (port is part of
+	// Host). App access is always TLS, so a plain-HTTP page on the same host is a
+	// foreign origin whose wss:// handshake still carries the Secure cookies.
+	return !strings.EqualFold(u.Scheme, "https") || !strings.EqualFold(u.Host, r.Host)
+}
+
+// isWebSocketUpgrade reports whether r is a WebSocket upgrade handshake. A
+// handshake is an HTTP GET carrying Connection: Upgrade and Upgrade: websocket
+// (RFC 6455). Both are forbidden header names, so a script cannot forge them on a
+// non-WebSocket request. Both are RFC 7230 comma-separated token lists, so match
+// each as a token rather than by exact value.
+//
+// This detects HTTP/1.1 upgrades only, which is all the app forward path relays
+// (httputil.ReverseProxy switches protocols on a 101 response). HTTP/2 WebSockets
+// (RFC 8441 Extended CONNECT) carry no Connection/Upgrade headers; if WebSocket
+// forwarding over HTTP/2 is ever added, extend this to also match :method=CONNECT
+// with :protocol=websocket.
+func isWebSocketUpgrade(r *http.Request) bool {
+	return headerListContainsToken(r.Header.Get("Connection"), "upgrade") &&
+		headerListContainsToken(r.Header.Get("Upgrade"), "websocket")
+}
+
+// headerListContainsToken reports whether a comma-separated header value
+// contains the given token, case-insensitively.
+func headerListContainsToken(headerValue, token string) bool {
+	for part := range strings.SplitSeq(headerValue, ",") {
+		if strings.EqualFold(strings.TrimSpace(part), token) {
+			return true
+		}
+	}
+	return false
+}

--- a/lib/web/app/websocket_test.go
+++ b/lib/web/app/websocket_test.go
@@ -1,0 +1,301 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package app
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCSWSHAction(t *testing.T) {
+	for _, tc := range []struct {
+		in            string
+		report, block bool
+	}{
+		{"", false, false},
+		{"off", false, false},
+		{"none", false, false},
+		{"garbage", false, false},
+		{"report", true, false},
+		{"REPORT", true, false},
+		{" report ", true, false},
+		{"block", false, true},
+		{"Block", false, true},
+		{"report-and-block", true, true},
+		{"report_and_block", true, true},
+		{"REPORT-AND-BLOCK", true, true},
+		// Unknown combinations are not parsed loosely; only the exact tokens.
+		{"block,report", false, false},
+		{"report block", false, false},
+	} {
+		t.Run(tc.in, func(t *testing.T) {
+			got := parseCSWSHAction(tc.in)
+			require.Equal(t, tc.report, got.report, "report")
+			require.Equal(t, tc.block, got.block, "block")
+		})
+	}
+}
+
+func TestCSWSHActionEnabled(t *testing.T) {
+	require.False(t, cswshAction{}.enabled())
+	require.True(t, cswshAction{report: true}.enabled())
+	require.True(t, cswshAction{block: true}.enabled())
+	require.True(t, cswshAction{report: true, block: true}.enabled())
+}
+
+func TestHeaderListContainsToken(t *testing.T) {
+	for _, tc := range []struct {
+		header string
+		token  string
+		want   bool
+	}{
+		{"", "upgrade", false},
+		{"upgrade", "upgrade", true},
+		{"Upgrade", "upgrade", true},
+		{"UPGRADE", "upgrade", true},
+		{"keep-alive, Upgrade", "upgrade", true},
+		{"keep-alive,Upgrade", "upgrade", true},
+		{"  upgrade  ", "upgrade", true},
+		{"keep-alive", "upgrade", false},
+		// Token match, not substring.
+		{"upgradeable", "upgrade", false},
+		{"a, b, c", "b", true},
+		{"a, b, c", "d", false},
+	} {
+		t.Run(tc.header+"|"+tc.token, func(t *testing.T) {
+			require.Equal(t, tc.want, headerListContainsToken(tc.header, tc.token))
+		})
+	}
+}
+
+func TestIsWebSocketUpgrade(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		headers map[string]string
+		want    bool
+	}{
+		{
+			name:    "no relevant headers",
+			headers: nil,
+			want:    false,
+		},
+		{
+			name:    "connection upgrade and upgrade websocket",
+			headers: map[string]string{"Connection": "Upgrade", "Upgrade": "websocket"},
+			want:    true,
+		},
+		{
+			name:    "connection list with upgrade",
+			headers: map[string]string{"Connection": "keep-alive, Upgrade", "Upgrade": "websocket"},
+			want:    true,
+		},
+		{
+			name:    "upgrade websocket mixed case",
+			headers: map[string]string{"Connection": "Upgrade", "Upgrade": "WebSocket"},
+			want:    true,
+		},
+		{
+			name:    "connection upgrade without upgrade header",
+			headers: map[string]string{"Connection": "Upgrade"},
+			want:    false,
+		},
+		{
+			name:    "upgrade header without connection",
+			headers: map[string]string{"Upgrade": "websocket"},
+			want:    false,
+		},
+		{
+			name:    "upgrade to non-websocket protocol",
+			headers: map[string]string{"Connection": "Upgrade", "Upgrade": "h2c"},
+			want:    false,
+		},
+		{
+			name:    "upgrade list with websocket first",
+			headers: map[string]string{"Connection": "Upgrade", "Upgrade": "websocket, foo"},
+			want:    true,
+		},
+		{
+			name:    "upgrade list with websocket later",
+			headers: map[string]string{"Connection": "Upgrade", "Upgrade": "foo, websocket"},
+			want:    true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isWebSocketUpgrade(newWSTestRequest(tc.headers)))
+		})
+	}
+}
+
+func TestIsCrossOriginWebSocketUpgrade(t *testing.T) {
+	originWS := func(origin string) map[string]string {
+		if origin == "" {
+			return nil
+		}
+		return map[string]string{"Origin": origin}
+	}
+
+	for _, tc := range []struct {
+		name    string
+		headers map[string]string
+		want    bool
+	}{
+		{
+			name:    "no origin (non-browser)",
+			headers: originWS(""),
+			want:    false,
+		},
+		{
+			name:    "origin matches host",
+			headers: originWS("https://app.example.com"),
+			want:    false,
+		},
+		{
+			name:    "origin host differs",
+			headers: originWS("https://attacker.example"),
+			want:    true,
+		},
+		{
+			name:    "origin host differs by port",
+			headers: originWS("https://app.example.com:8443"),
+			want:    true,
+		},
+		{
+			// A plain-HTTP page on the same host is a foreign origin: its
+			// wss:// handshake still carries the Secure session cookies, so the
+			// scheme mismatch must be treated as cross-origin.
+			name:    "origin scheme differs (http) but host matches",
+			headers: originWS("http://app.example.com"),
+			want:    true,
+		},
+		{
+			name:    "origin scheme differs (ws) but host matches",
+			headers: originWS("ws://app.example.com"),
+			want:    true,
+		},
+		{
+			name:    "origin scheme uppercase https matches",
+			headers: originWS("HTTPS://app.example.com"),
+			want:    false,
+		},
+		{
+			name:    "unparseable origin",
+			headers: originWS("://://"),
+			want:    true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isCrossOriginWebSocketUpgrade(newWSTestRequest(tc.headers)))
+		})
+	}
+}
+
+// TestGuardCrossSiteWebSocket exercises the end-to-end guard decision (detect a
+// WebSocket upgrade, classify its origin, act per the configured action) using
+// realistic handshake headers. It tests the guard directly rather than through
+// the HTTP pipeline because Go's http.Client manages the hop-by-hop Connection
+// header itself and won't deliver a verbatim "Connection: Upgrade".
+func TestGuardCrossSiteWebSocket(t *testing.T) {
+	// A realistic browser WebSocket handshake (Connection/Upgrade, no Sec-Fetch),
+	// carrying the given Origin.
+	ws := func(origin string) map[string]string {
+		h := map[string]string{"Connection": "Upgrade", "Upgrade": "websocket"}
+		if origin != "" {
+			h["Origin"] = origin
+		}
+		return h
+	}
+
+	for _, tc := range []struct {
+		name        string
+		action      cswshAction
+		headers     map[string]string
+		wantBlocked bool
+	}{
+		{
+			name:    "default no-op leaves cross-origin WebSocket alone",
+			action:  cswshAction{},
+			headers: ws("https://attacker.example"),
+		},
+		{
+			name:    "report allows cross-origin WebSocket",
+			action:  cswshAction{report: true},
+			headers: ws("https://attacker.example"),
+		},
+		{
+			name:        "block rejects cross-origin WebSocket",
+			action:      cswshAction{block: true},
+			headers:     ws("https://attacker.example"),
+			wantBlocked: true,
+		},
+		{
+			name:        "report-and-block rejects cross-origin WebSocket",
+			action:      cswshAction{report: true, block: true},
+			headers:     ws("https://attacker.example"),
+			wantBlocked: true,
+		},
+		{
+			name:    "block allows same-origin WebSocket",
+			action:  cswshAction{block: true},
+			headers: ws("https://app.example.com"),
+		},
+		{
+			// Plain-HTTP page on the same host (e.g. injected before HSTS is
+			// effective) is a foreign origin and must be blocked.
+			name:        "block rejects same-host cross-scheme (http) WebSocket",
+			action:      cswshAction{block: true},
+			headers:     ws("http://app.example.com"),
+			wantBlocked: true,
+		},
+		{
+			name:    "block allows non-browser WebSocket with no Origin",
+			action:  cswshAction{block: true},
+			headers: ws(""),
+		},
+		{
+			name:    "block leaves cross-origin non-WebSocket request alone",
+			action:  cswshAction{block: true},
+			headers: map[string]string{"Origin": "https://attacker.example"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &Handler{logger: slog.Default(), cswshAction: tc.action}
+			err := h.guardCrossSiteWebSocket(newWSTestRequest(tc.headers))
+			if tc.wantBlocked {
+				require.True(t, trace.IsAccessDenied(err), "want AccessDenied, got %v", err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// newWSTestRequest builds a request to https://app.example.com with the given
+// headers (so r.Host is "app.example.com" for Origin/Host comparisons).
+func newWSTestRequest(headers map[string]string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "https://app.example.com/socket", nil)
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+	return r
+}


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/67616 to branch/v18