### PR TITLE
[v18] Anthropic LLM access

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -1294,6 +1294,9 @@ message AppAWS {
   // RolesAnywhereProfile contains the IAM Roles Anywhere fields associated with this Application.
   // These fields are set when performing the synchronization of AWS IAM Roles Anywhere Profiles into Teleport Apps.
   AppAWSRolesAnywhereProfile RolesAnywhereProfile = 2 [(gogoproto.jsontag) = "roles_anywhere_profile,omitempty"];
+  // Region is a cloud region for the app.
+  // This field is set for apps that integrates with AWS applications/APIs.
+  string region = 3;
 }
 
 // AppAWSRolesAnywhereProfile contains the fields that represent an AWS IAM Roles Anywhere Profile.

--- a/api/types/app.go
+++ b/api/types/app.go
@@ -609,7 +609,7 @@ func (a *AppV3) checkMCPStdio() error {
 // format.
 var supportedFormatInferenceProviders = map[LLMFormat][]LLMProvider{
 	LLMFormatAnthropic: {LLMProviderAnthropic, LLMProviderAWSBedrock},
-	LLMFormatOpenAI:    {LLMProviderOpenAI},
+	LLMFormatOpenAI:    {LLMProviderOpenAI, LLMProviderAWSBedrock},
 }
 
 func (a *AppV3) checkLLM() error {

--- a/api/types/app.go
+++ b/api/types/app.go
@@ -87,6 +87,8 @@ type Application interface {
 	GetAWSRolesAnywhereProfileARN() string
 	// GetAWSRolesAnywhereAcceptRoleSessionName returns whether the IAM Roles Anywhere Profile supports defining a custom AWS Session Name.
 	GetAWSRolesAnywhereAcceptRoleSessionName() bool
+	// GetAWSRegion returns the AWS region configured for the app.
+	GetAWSRegion() string
 	// GetUserGroups will get the list of user group IDs associated with the application.
 	GetUserGroups() []string
 	// SetUserGroups will set the list of user group IDs associated with the application.
@@ -365,6 +367,14 @@ func (a *AppV3) GetAWSRolesAnywhereProfileARN() string {
 	return a.Spec.AWS.RolesAnywhereProfile.ProfileARN
 }
 
+// GetAWSRegion returns the AWS region configured for the app.
+func (a *AppV3) GetAWSRegion() string {
+	if a.Spec.AWS == nil {
+		return ""
+	}
+	return a.Spec.AWS.Region
+}
+
 // GetAWSRolesAnywhereAcceptRoleSessionName returns whether the IAM Roles Anywhere Profile supports defining a custom AWS Session Name.
 func (a *AppV3) GetAWSRolesAnywhereAcceptRoleSessionName() bool {
 	if a.Spec.AWS == nil || a.Spec.AWS.RolesAnywhereProfile == nil {
@@ -616,8 +626,6 @@ func (a *AppV3) checkLLM() error {
 		return trace.BadParameter("Inference endpoint %q cannot specify 'tcp_ports' configuration", a.GetName())
 	case a.Spec.Rewrite != nil:
 		return trace.BadParameter("Inference endpoint %q cannot specify 'rewrite' configuration", a.GetName())
-	case a.Spec.AWS != nil:
-		return trace.BadParameter("Inference endpoint %q cannot specify 'aws' configuration", a.GetName())
 	}
 
 	llm := a.Spec.LLM
@@ -630,6 +638,10 @@ func (a *AppV3) checkLLM() error {
 
 	if !slices.Contains(providers, llm.Provider) {
 		return trace.BadParameter("Inference endpoint %q must set one of the providers supported by %q format: %s", a.GetName(), llm.Format, strings.Join(providers, ", "))
+	}
+
+	if a.Spec.AWS != nil && llm.Provider != LLMProviderAWSBedrock {
+		return trace.BadParameter("Inference endpoint %q can only define 'aws' options for provider %q", a.GetName(), LLMProviderAWSBedrock)
 	}
 
 	for _, model := range llm.Models {

--- a/api/types/app_test.go
+++ b/api/types/app_test.go
@@ -1019,8 +1019,8 @@ func TestLLMConfiguration(t *testing.T) {
 				spec.URI = SchemeLLMEndpoint + "://my-inference-endpoint"
 				return spec
 			},
-			"aws": func(spec AppSpecV3) AppSpecV3 {
-				spec.AWS = &AppAWS{ExternalID: "default-external-id"}
+			"non-bedrock aws configuration": func(spec AppSpecV3) AppSpecV3 {
+				spec.AWS = &AppAWS{Region: "us-west-2"}
 				return spec
 			},
 			"llm provider": func(spec AppSpecV3) AppSpecV3 {

--- a/api/types/derived.gen.go
+++ b/api/types/derived.gen.go
@@ -491,7 +491,8 @@ func deriveTeleportEqual_23(this, that *AppAWS) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.ExternalID == that.ExternalID &&
-			deriveTeleportEqual_43(this.RolesAnywhereProfile, that.RolesAnywhereProfile)
+			deriveTeleportEqual_43(this.RolesAnywhereProfile, that.RolesAnywhereProfile) &&
+			this.Region == that.Region
 }
 
 // deriveTeleportEqual_24 returns whether this and that are equal.

--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -2946,6 +2946,8 @@ func (m *AppSessionLLMRequest) TrimToMaxSize(maxSize int) AuditEvent {
 			newStrTrimmer(m.Path, &out.Path),
 			newStrTrimmer(m.Method, &out.Method),
 			newStrTrimmer(m.RequestedModel, &out.RequestedModel),
+			newStrTrimmer(m.Model, &out.Model),
+			newGenericTrimmer(&m.Status, &out.Status),
 		}
 	})
 }

--- a/api/types/events/events_test.go
+++ b/api/types/events/events_test.go
@@ -347,24 +347,31 @@ func TestTrimToMaxSize(t *testing.T) {
 					Code: "T2014I",
 					Type: "app.session.llm.request.success",
 				},
+				Status: Status{
+					Error:       strings.Repeat("A", 200),
+					UserMessage: strings.Repeat("B", 200),
+				},
 				Path:           strings.Repeat("/path", 20),
 				Method:         strings.Repeat("POST", 20),
 				RequestedModel: strings.Repeat("requested-model", 20),
-				// Models and provider comes from the app config and should not
-				// be trimmed.
+				Model:          strings.Repeat("model", 20),
+				// Provider comes from the app config and should not be trimmed.
 				Provider: "a-long-provider-name-not-trimmed",
-				Model:    "a-long-model-name-not-trimmed",
 			},
 			want: &AppSessionLLMRequest{
 				Metadata: Metadata{
 					Code: "T2014I",
 					Type: "app.session.llm.request.success",
 				},
-				Path:           "/path/path/path/",
-				Method:         "POSTPOSTPOSTPOST",
-				RequestedModel: "requested-modelr",
+				Status: Status{
+					Error:       "AAAAAAAAAAAA",
+					UserMessage: "BBBBBBBBBBBB",
+				},
+				Path:           "/path/path/p",
+				Method:         "POSTPOSTPOST",
+				RequestedModel: "requested-mo",
+				Model:          "modelmodelmo",
 				Provider:       "a-long-provider-name-not-trimmed",
-				Model:          "a-long-model-name-not-trimmed",
 			},
 		},
 	}

--- a/constants.go
+++ b/constants.go
@@ -302,6 +302,9 @@ const (
 	// ComponentMCP represents the MCP server handler.
 	ComponentMCP = "mcp"
 
+	// ComponentLLM represents the LLM server handler.
+	ComponentLLM = "llm"
+
 	// ComponentRecordingEncryption represents recording encryption
 	ComponentRecordingEncryption = "recording-encryption"
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-appsv3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-appsv3.mdx
@@ -48,6 +48,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |Field|Type|Description|
 |---|---|---|
 |external_id|string|ExternalID is the AWS External ID used when assuming roles in this app.|
+|region|string|Region is a cloud region for the app. This field is set for apps that integrates with AWS applications/APIs.|
 |roles_anywhere_profile|[object](#specawsroles_anywhere_profile)|RolesAnywhereProfile contains the IAM Roles Anywhere fields associated with this Application. These fields are set when performing the synchronization of AWS IAM Roles Anywhere Profiles into Teleport Apps.|
 
 ### spec.aws.roles_anywhere_profile

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/app-server-v3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/app-server-v3.mdx
@@ -60,11 +60,13 @@ Example:
 ```yaml
 external_id: "string"
 roles_anywhere_profile: # [...]
+region: "string"
 ```
 
 |Field Name|Description|Type|
 |---|---|---|
 |external_id|The AWS External ID used when assuming roles in this app.|string|
+|region|A cloud region for the app. This field is set for apps that integrates with AWS applications/APIs.|string|
 |roles_anywhere_profile|Contains the IAM Roles Anywhere fields associated with this Application. These fields are set when performing the synchronization of AWS IAM Roles Anywhere Profiles into Teleport Apps.|[App AWS Roles Anywhere Profile](#app-aws-roles-anywhere-profile)|
 
 ## App AWS Roles Anywhere Profile

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/app-v3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/app-v3.mdx
@@ -56,11 +56,13 @@ Example:
 ```yaml
 external_id: "string"
 roles_anywhere_profile: # [...]
+region: "string"
 ```
 
 |Field Name|Description|Type|
 |---|---|---|
 |external_id|The AWS External ID used when assuming roles in this app.|string|
+|region|A cloud region for the app. This field is set for apps that integrates with AWS applications/APIs.|string|
 |roles_anywhere_profile|Contains the IAM Roles Anywhere fields associated with this Application. These fields are set when performing the synchronization of AWS IAM Roles Anywhere Profiles into Teleport Apps.|[App AWS Roles Anywhere Profile](#app-aws-roles-anywhere-profile)|
 
 ## App AWS Roles Anywhere Profile

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/app.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/app.mdx
@@ -67,6 +67,7 @@ Optional:
 Optional:
 
 - `external_id` (String) ExternalID is the AWS External ID used when assuming roles in this app.
+- `region` (String) Region is a cloud region for the app. This field is set for apps that integrates with AWS applications/APIs.
 - `roles_anywhere_profile` (Attributes) RolesAnywhereProfile contains the IAM Roles Anywhere fields associated with this Application. These fields are set when performing the synchronization of AWS IAM Roles Anywhere Profiles into Teleport Apps. (see [below for nested schema](#nested-schema-for-specawsroles_anywhere_profile))
 
 ### Nested Schema for `spec.aws.roles_anywhere_profile`

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/app.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/app.mdx
@@ -86,6 +86,7 @@ Optional:
 Optional:
 
 - `external_id` (String) ExternalID is the AWS External ID used when assuming roles in this app.
+- `region` (String) Region is a cloud region for the app. This field is set for apps that integrates with AWS applications/APIs.
 - `roles_anywhere_profile` (Attributes) RolesAnywhereProfile contains the IAM Roles Anywhere fields associated with this Application. These fields are set when performing the synchronization of AWS IAM Roles Anywhere Profiles into Teleport Apps. (see [below for nested schema](#nested-schema-for-specawsroles_anywhere_profile))
 
 ### Nested Schema for `spec.aws.roles_anywhere_profile`

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_appsv3.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_appsv3.yaml
@@ -49,6 +49,10 @@ spec:
                     description: ExternalID is the AWS External ID used when assuming
                       roles in this app.
                     type: string
+                  region:
+                    description: Region is a cloud region for the app. This field
+                      is set for apps that integrates with AWS applications/APIs.
+                    type: string
                   roles_anywhere_profile:
                     description: RolesAnywhereProfile contains the IAM Roles Anywhere
                       fields associated with this Application. These fields are set

--- a/fuzz/oss-fuzz-build.sh
+++ b/fuzz/oss-fuzz-build.sh
@@ -133,6 +133,9 @@ build_teleport_fuzzers() {
 
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/scopes \
     FuzzValidateQualifiedName fuzz_validate_qualified_name
+
+  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/httplib/sse \
+    FuzzRead fuzz_read_sse_events
 }
 
 build_teleport_api_fuzzers() {

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_appsv3.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_appsv3.yaml
@@ -49,6 +49,10 @@ spec:
                     description: ExternalID is the AWS External ID used when assuming
                       roles in this app.
                     type: string
+                  region:
+                    description: Region is a cloud region for the app. This field
+                      is set for apps that integrates with AWS applications/APIs.
+                    type: string
                   roles_anywhere_profile:
                     description: RolesAnywhereProfile contains the IAM Roles Anywhere
                       fields associated with this Application. These fields are set

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -918,6 +918,11 @@ func GenSchemaAppV3(ctx context.Context) (github_com_hashicorp_terraform_plugin_
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
+						"region": {
+							Description: "Region is a cloud region for the app. This field is set for apps that integrates with AWS applications/APIs.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
 						"roles_anywhere_profile": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 								"accept_role_session_name": {
@@ -13266,6 +13271,23 @@ func CopyAppV3FromTerraform(_ context.Context, tf github_com_hashicorp_terraform
 											}
 										}
 									}
+									{
+										a, ok := tf.Attrs["region"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"AppV3.Spec.AWS.region"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"AppV3.Spec.AWS.region", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.Region = t
+											}
+										}
+									}
 								}
 							}
 						}
@@ -14884,6 +14906,28 @@ func CopyAppV3ToTerraform(ctx context.Context, obj *github_com_gravitational_tel
 												v.Unknown = false
 												tf.Attrs["roles_anywhere_profile"] = v
 											}
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["region"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"AppV3.Spec.AWS.region"})
+										} else {
+											v, ok := tf.Attrs["region"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"AppV3.Spec.AWS.region", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"AppV3.Spec.AWS.region", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.Region) == ""
+											}
+											v.Value = string(obj.Region)
+											v.Unknown = false
+											tf.Attrs["region"] = v
 										}
 									}
 								}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2131,6 +2131,7 @@ func applyAppsConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		if application.AWS != nil {
 			app.AWS = &servicecfg.AppAWS{
 				ExternalID: application.AWS.ExternalID,
+				Region:     application.AWS.Region,
 			}
 		}
 

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -459,7 +459,7 @@ func TestConfigReading(t *testing.T) {
 					},
 				},
 				{
-					Name:         "anthropic",
+					Name:         "anthropic-bedrock",
 					StaticLabels: Labels,
 					LLM: &LLM{
 						Format:   "anthropic",
@@ -471,6 +471,17 @@ func TestConfigReading(t *testing.T) {
 							},
 						},
 						FallbackModel: "claude-opus-4-6",
+					},
+					AWS: &AppAWS{
+						Region: "us-west-2",
+					},
+				},
+				{
+					Name:         "anthropic",
+					StaticLabels: Labels,
+					LLM: &LLM{
+						Format:   "anthropic",
+						Provider: "anthropic",
 					},
 				},
 				{
@@ -1694,7 +1705,7 @@ func makeConfigFixture() string {
 			},
 		},
 		{
-			Name:         "anthropic",
+			Name:         "anthropic-bedrock",
 			StaticLabels: Labels,
 			LLM: &LLM{
 				Format:   "anthropic",
@@ -1706,6 +1717,17 @@ func makeConfigFixture() string {
 					},
 				},
 				FallbackModel: "claude-opus-4-6",
+			},
+			AWS: &AppAWS{
+				Region: "us-west-2",
+			},
+		},
+		{
+			Name:         "anthropic",
+			StaticLabels: Labels,
+			LLM: &LLM{
+				Format:   "anthropic",
+				Provider: "anthropic",
 			},
 		},
 		{
@@ -2737,6 +2759,21 @@ app_service:
 `,
 			name:   "App TLS configuration fails to read file",
 			outErr: require.Error,
+		},
+		{
+			inConfigString: `
+app_service:
+  enabled: true
+  apps:
+    - name: app-llm-bedrock
+      inference:
+        format: anthropic
+        provider: bedrock
+      aws:
+        region: us-west-2
+`,
+			name:   "App configuration with valid AWS region",
+			outErr: require.NoError,
 		},
 	}
 

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -2520,6 +2520,9 @@ type Rewrite struct {
 type AppAWS struct {
 	// ExternalID is the AWS External ID used when assuming roles in this app.
 	ExternalID string `yaml:"external_id,omitempty"`
+	// Region is a cloud region for the app.
+	// This field is set for apps that integrates with AWS applications/APIs.
+	Region string `yaml:"region,omitempty"`
 }
 
 // PortRange describes a port range for TCP apps. The range starts with Port and ends with EndPort.

--- a/lib/events/emitter.go
+++ b/lib/events/emitter.go
@@ -269,7 +269,13 @@ func (l *LoggingEmitter) EmitAuditEvent(ctx context.Context, event apievents.Aud
 	}
 
 	switch event.GetType() {
-	case ResizeEvent, SessionDiskEvent, SessionPrintEvent, AppSessionRequestEvent, "":
+	case ResizeEvent,
+		SessionDiskEvent,
+		SessionPrintEvent,
+		AppSessionRequestEvent,
+		AppSessionLLMRequestSuccessEvent,
+		AppSessionLLMRequestFailureEvent,
+		"":
 		return nil
 	}
 

--- a/lib/httplib/sse/sse.go
+++ b/lib/httplib/sse/sse.go
@@ -1,0 +1,359 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package sse
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"iter"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+)
+
+var (
+	// ErrEventTooLarge is the error returned when SSE event is larger than
+	// [MaxReadEventSize].
+	ErrEventTooLarge = errors.New("sse event exceeded max size")
+)
+
+// MaxReadEventSize defines the max size that can be read from an [io.Reader]
+// to complete the event.
+const MaxReadEventSize = teleport.MaxHTTPResponseSize
+
+// Event is a server-sent event.
+type Event struct {
+	Event string
+	ID    string
+	Data  []byte
+	Retry string
+}
+
+// Empty reports whether the event is empty.
+func (e Event) Empty() bool {
+	return e.len() == 0
+}
+
+// Equal returns `true` if both events have the same contents.
+func (e Event) Equal(b Event) bool {
+	return e.Event == b.Event && e.ID == b.ID &&
+		bytes.Equal(e.Data, b.Data) && e.Retry == b.Retry
+}
+
+func (e Event) len() int {
+	return len(e.Event) + len(e.ID) + len(e.Data) + len(e.Retry)
+}
+
+// Validates the fields of the SSE event.
+func (e Event) validate() error {
+	switch {
+	case strings.ContainsAny(e.Event, "\r\n"):
+		return trace.BadParameter("Event field cannot contain line feed or carriage return")
+	case strings.ContainsAny(e.ID, "\r\n"):
+		return trace.BadParameter("ID field cannot contain line feed or carriage return")
+	case strings.ContainsAny(e.Retry, "\r\n"):
+		return trace.BadParameter("Retry field cannot contain line feed or carriage return")
+	case !onlyDigits(e.Retry):
+		return trace.BadParameter("Retry field can only contain digits")
+	}
+
+	return nil
+}
+
+// ReadEvents reads SSE events from the provided reader.
+func ReadEvents(r io.Reader) iter.Seq2[Event, error] {
+	return func(yield func(Event, error) bool) {
+		var currentEvent *Event
+		scanner := bufio.NewScanner(r)
+		scanner.Buffer(nil, MaxReadEventSize)
+		scanner.Split(scanLines())
+
+		yieldEvent := func() bool {
+			// This handles cases where the stream has empty lines, so we
+			// consumed them, and there is no need to invoke `yield`.
+			if currentEvent == nil {
+				return true
+			}
+			if !yield(*currentEvent, nil) {
+				return false
+			}
+
+			// Reset for next event.
+			currentEvent = nil
+			return true
+		}
+
+		// For fields that get their value replaced, we compare against the
+		// current total of all fields values rather than per-field, so
+		// re-assigned fields still count their prior length.
+		//
+		// This can reject some valid events but reliably bounds memory.
+		ensureRoom := func(addedSize int) bool {
+			if currentEvent == nil {
+				currentEvent = &Event{}
+			}
+			if currentEvent.len()+addedSize > MaxReadEventSize {
+				return false
+			}
+			return true
+		}
+
+		for scanner.Scan() {
+			line := scanner.Bytes()
+
+			if len(line) == 0 {
+				if !yieldEvent() {
+					return
+				}
+				continue
+			}
+			// Ignore "comment" lines.
+			//
+			// > If the line starts with a U+003A COLON character (:)
+			// >   Ignore the line.
+			//
+			// https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+			if line[0] == ':' {
+				continue
+			}
+
+			// A field line without colon is considered valid with empty value.
+			//
+			// > Note: If a line doesn't contain a colon, the entire line is treated as the field name with an empty value string.
+			//
+			// From https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#fields
+			before, after, _ := bytes.Cut(line, []byte{':'})
+			// Per spec we must only trim the leading space from the field data.
+			// This avoids breaking the data sent by the server.
+			after = bytes.TrimPrefix(after, []byte{' '})
+			switch {
+			case bytes.Equal(before, sseEventKey):
+				if !ensureRoom(len(after)) {
+					yield(Event{}, trace.Wrap(ErrEventTooLarge))
+					return
+				}
+				currentEvent.Event = string(after)
+			case bytes.Equal(before, sseIDKey):
+				if !ensureRoom(len(after)) {
+					yield(Event{}, trace.Wrap(ErrEventTooLarge))
+					return
+				}
+				currentEvent.ID = string(after)
+			case bytes.Equal(before, sseRetryKey):
+				if !ensureRoom(len(after)) {
+					yield(Event{}, trace.Wrap(ErrEventTooLarge))
+					return
+				}
+				currentEvent.Retry = string(after)
+			case bytes.Equal(before, sseDataKey):
+				// Account for the new line added after the `data` field.
+				if !ensureRoom(len(after) + 1) {
+					yield(Event{}, trace.Wrap(ErrEventTooLarge))
+					return
+				}
+				// Cases where first data is empty, we cannot rely only on
+				// append as it would still return nil (so we wouldn't know a
+				// data field happened before). That's why we initialize the
+				// slice here.
+				if currentEvent.Data == nil {
+					currentEvent.Data = make([]byte, 0, len(after))
+				} else {
+					currentEvent.Data = append(currentEvent.Data, '\n')
+				}
+				currentEvent.Data = append(currentEvent.Data, after...)
+			default:
+				// Following the spec, unknown fields are just ignored.
+				continue
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			if errors.Is(err, bufio.ErrTooLong) {
+				yield(Event{}, trace.Wrap(ErrEventTooLarge))
+				return
+			}
+
+			yield(Event{}, trace.Wrap(err))
+			return
+		}
+
+		yieldEvent()
+	}
+}
+
+// WriteEvent writes an (non-empty) SSE event into the provided Writer.
+//
+// This function does not flush the writer. Callers using HTTP streaming should
+// flush their response after a successful write when events must be delivered
+// promptly.
+func WriteEvent(w io.Writer, event Event) (int, error) {
+	// Dropping empty events is acceptable as they don't carry values (only
+	// fields).
+	//
+	// In case callers need to write empty fields, we'd need a separate writer
+	// that preserves empty fields.
+	if event.Empty() {
+		return 0, nil
+	}
+	if err := event.validate(); err != nil {
+		return 0, trace.Wrap(err)
+	}
+
+	// Use internal buffer so we only write once to the target writer.
+	var buf bytes.Buffer
+	if event.Event != "" {
+		writeField(&buf, sseEventKey, event.Event)
+	}
+	if event.ID != "" {
+		writeField(&buf, sseIDKey, event.ID)
+	}
+	for data := range splitDataLines(event.Data) {
+		buf.Write(sseDataKey)
+		buf.WriteString(": ")
+		buf.Write(data)
+		buf.WriteByte('\n')
+	}
+	if event.Retry != "" {
+		writeField(&buf, sseRetryKey, event.Retry)
+	}
+	buf.WriteByte('\n')
+
+	n, err := buf.WriteTo(w)
+	return int(n), trace.Wrap(err)
+}
+
+// writeField internal helper that writes fields to buffer without allocating
+// additional strings.
+func writeField(b *bytes.Buffer, fieldName []byte, fieldData string) {
+	b.Write(fieldName)
+	b.WriteString(": ")
+	b.WriteString(fieldData)
+	b.WriteByte('\n')
+}
+
+// scanLines implements a custom scan line for bytes.Scanner that honors the
+// SSE spec in addition to the [MaxReadEventSize].
+//
+// By the spec, the data can be split using \r (cr) \n (lf) following the end of
+// line definition:
+//
+//	end-of-line   = ( cr lf / cr / lf )
+//
+// https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream
+func scanLines() bufio.SplitFunc {
+	var skipLF bool
+
+	return func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		// If previous chunk ended on \r, swallow a leading \n here so \r\n
+		// count as one terminator across reads. Bare \r line endings still work.
+		if skipLF {
+			if len(data) == 0 {
+				return 0, nil, nil
+			}
+			skipLF = false
+			if data[0] == '\n' {
+				return 1, nil, nil
+			}
+		}
+
+		for i, b := range data {
+			if i > MaxReadEventSize {
+				return 0, nil, bufio.ErrTooLong
+			}
+
+			switch b {
+			case '\n':
+				return i + 1, data[:i], nil
+			case '\r':
+				// \r\n must count a single line break as per spec.
+				if i+1 < len(data) && data[i+1] == '\n' {
+					return i + 2, data[:i], nil
+				}
+				if i+1 == len(data) && !atEOF {
+					skipLF = true
+				}
+				return i + 1, data[:i], nil
+			}
+		}
+
+		if len(data) > MaxReadEventSize {
+			return 0, nil, bufio.ErrTooLong
+		}
+
+		if atEOF && len(data) > 0 {
+			return len(data), data, nil
+		}
+
+		return 0, nil, nil
+	}
+}
+
+// splitDataLines splits data into multiple event lines.
+//
+// By the spec, the data can be split using \r (cr) \n (lf) following the end of
+// line definition:
+//
+//	end-of-line   = ( cr lf / cr / lf )
+//
+// https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream
+func splitDataLines(data []byte) iter.Seq[[]byte] {
+	return func(yield func([]byte) bool) {
+		// No data available, return nothing to the caller.
+		if len(data) == 0 {
+			return
+		}
+
+		for {
+			i := bytes.IndexAny(data, "\r\n")
+			if i < 0 {
+				yield(data)
+				return
+			}
+
+			if !yield(data[:i]) {
+				return
+			}
+
+			// \r\n must count a single line break as per spec.
+			if data[i] == '\r' && i+1 < len(data) && data[i+1] == '\n' {
+				data = data[i+2:]
+			} else {
+				data = data[i+1:]
+			}
+		}
+	}
+}
+
+func onlyDigits(str string) bool {
+	return strings.IndexFunc(str, func(r rune) bool {
+		return r < '0' || r > '9'
+	}) == -1
+}
+
+// SSE supported fields names.
+//
+// Ref: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#fields.
+var (
+	sseEventKey = []byte("event")
+	sseIDKey    = []byte("id")
+	sseDataKey  = []byte("data")
+	sseRetryKey = []byte("retry")
+)

--- a/lib/httplib/sse/sse_test.go
+++ b/lib/httplib/sse/sse_test.go
@@ -1,0 +1,495 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package sse
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"testing/iotest"
+	"testing/synctest"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/itertools/stream"
+)
+
+func TestEventsRead(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input        string
+		expectError  require.ErrorAssertionFunc
+		expectEvents require.ValueAssertionFunc
+	}{
+		"data only": {
+			input:       dataOnlyExample,
+			expectError: require.NoError,
+			expectEvents: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.Len(tt, i1, 2, i2...)
+				events := i1.([]Event)
+				requireEqualEvent(tt, Event{Data: []byte("some text")}, events[0])
+				requireEqualEvent(tt, Event{Data: []byte("another message\nwith two lines")}, events[1])
+			},
+		},
+		"named events": {
+			input:       namedEventsExample,
+			expectError: require.NoError,
+			expectEvents: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.Len(tt, i1, 4, i2...)
+				events := i1.([]Event)
+				requireEqualEvent(tt, Event{Event: "userconnect", Data: []byte(`{"username": "bobby", "time": "02:33:48"}`)}, events[0])
+				requireEqualEvent(tt, Event{Event: "usermessage", Data: []byte(`{"username": "bobby", "time": "02:34:11", "text": "Hi everyone."}`)}, events[1])
+				requireEqualEvent(tt, Event{Event: "userdisconnect", Data: []byte(`{"username": "bobby", "time": "02:34:23"}`)}, events[2])
+				requireEqualEvent(tt, Event{Event: "usermessage", Data: []byte(`{"username": "sean", "time": "02:34:36", "text": "Bye, bobby."}`)}, events[3])
+			},
+		},
+		"mixed and matching events": {
+			input:       mixingAndMatchingExample,
+			expectError: require.NoError,
+			expectEvents: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.Len(tt, i1, 3, i2...)
+				events := i1.([]Event)
+				requireEqualEvent(tt, Event{Event: "userconnect", Data: []byte(`{"username": "bobby", "time": "02:33:48"}`)}, events[0])
+				requireEqualEvent(tt, Event{Data: []byte("Here's a system message of some kind that will get used\nto accomplish some task.")}, events[1])
+				requireEqualEvent(tt, Event{Event: "usermessage", Data: []byte(`{"username": "bobby", "time": "02:34:11", "text": "Hi everyone."}`)}, events[2])
+			},
+		},
+		"field without colon": {
+			input:       "id\n\nevent\ndata: something\n\nevent: another event",
+			expectError: require.NoError,
+			expectEvents: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.Len(tt, i1, 3, i2...)
+				events := i1.([]Event)
+				// ID event with no values.
+				requireEqualEvent(tt, Event{ID: ""}, events[0])
+				requireEqualEvent(tt, Event{Event: "", Data: []byte("something")}, events[1])
+				requireEqualEvent(tt, Event{Event: "another event"}, events[2])
+			},
+		},
+		"multiple data fields": {
+			input:       "event: hello\ndata: start of message\nid: 1\ndata: end of message\n",
+			expectError: require.NoError,
+			expectEvents: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.Len(tt, i1, 1, i2...)
+				events := i1.([]Event)
+				requireEqualEvent(tt, Event{ID: "1", Event: "hello", Data: []byte("start of message\nend of message")}, events[0])
+			},
+		},
+		"carriage return line endings": {
+			input:       "event: hello\rdata: start of message\rdata: end of message\r",
+			expectError: require.NoError,
+			expectEvents: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.Len(tt, i1, 1, i2...)
+				events := i1.([]Event)
+				requireEqualEvent(tt, Event{Event: "hello", Data: []byte("start of message\nend of message")}, events[0])
+			},
+		},
+		"carriage return and line feed line endings": {
+			input:       "event: hello\r\ndata: start of message\r\ndata: end of message\r\n",
+			expectError: require.NoError,
+			expectEvents: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.Len(tt, i1, 1, i2...)
+				events := i1.([]Event)
+				requireEqualEvent(tt, Event{Event: "hello", Data: []byte("start of message\nend of message")}, events[0])
+			},
+		},
+		"preserve data whitespace": {
+			input:       "data:  token  \ndata:\ttab\t\n\n",
+			expectError: require.NoError,
+			expectEvents: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.Len(tt, i1, 1, i2...)
+				events := i1.([]Event)
+				requireEqualEvent(tt, Event{Data: []byte(" token  \n\ttab\t")}, events[0])
+			},
+		},
+		"comment between fields": {
+			input:       "event: message\n: ping\ndata: body\n\n",
+			expectError: require.NoError,
+			expectEvents: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.Len(tt, i1, 1, i2...)
+				events := i1.([]Event)
+				requireEqualEvent(tt, Event{Event: "message", Data: []byte("body")}, events[0])
+			},
+		},
+		"leading empty data line": {
+			input:       "data:\ndata: foo\n\n",
+			expectError: require.NoError,
+			expectEvents: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.Len(tt, i1, 1, i2...)
+				events := i1.([]Event)
+				requireEqualEvent(tt, Event{Data: []byte("\nfoo")}, events[0])
+			},
+		},
+		"multiple empty data lines": {
+			input:       "data:\ndata:\ndata: foo\n\n",
+			expectError: require.NoError,
+			expectEvents: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.Len(tt, i1, 1, i2...)
+				events := i1.([]Event)
+				requireEqualEvent(tt, Event{Data: []byte("\n\nfoo")}, events[0])
+			},
+		},
+		"single event data exceeds max size": {
+			input: "data: " + strings.Repeat("x", MaxReadEventSize),
+			expectError: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorIs(tt, err, ErrEventTooLarge, i...)
+			},
+			expectEvents: require.Empty,
+		},
+		"single event field exceeds max size": {
+			input: "event: " + strings.Repeat("x", MaxReadEventSize),
+			expectError: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorIs(tt, err, ErrEventTooLarge, i...)
+			},
+			expectEvents: require.Empty,
+		},
+		"single event exceeds max size multi lines": {
+			input: "data: " + strings.Repeat("x", MaxReadEventSize/2) + "\ndata:" + strings.Repeat("y", MaxReadEventSize/2),
+			expectError: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorIs(tt, err, ErrEventTooLarge, i...)
+			},
+			expectEvents: require.Empty,
+		},
+		"invalid event field is ignored": {
+			input:       "event: hello\nrandom: error\ndata: something",
+			expectError: require.NoError,
+			expectEvents: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.Len(tt, i1, 1, i2...)
+				events := i1.([]Event)
+				requireEqualEvent(tt, Event{Event: "hello", Data: []byte("something")}, events[0])
+			},
+		},
+		"empty": {
+			input:        "",
+			expectError:  require.NoError,
+			expectEvents: require.Empty,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			events, err := stream.Collect(ReadEvents(strings.NewReader(tc.input)))
+			tc.expectError(t, err)
+			tc.expectEvents(t, events)
+		})
+	}
+}
+
+func TestReadBareCRLiveStream(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		chunks := make(chan []byte, 1)
+		reader := &chunkReader{chunks: chunks}
+
+		events := make(chan Event, 1)
+		errs := make(chan error, 1)
+		go func() {
+			for event, err := range ReadEvents(reader) {
+				if err != nil {
+					errs <- err
+					return
+				}
+				events <- event
+				return
+			}
+		}()
+
+		chunks <- []byte("data: ok\r\r")
+		synctest.Wait()
+
+		select {
+		case event := <-events:
+			requireEqualEvent(t, Event{Data: []byte("ok")}, event)
+		case err := <-errs:
+			t.Fatalf("expected no errors but got %v", err)
+		}
+	})
+}
+
+func TestReadSplitCRLFLiveStream(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		chunks := make(chan []byte, 1)
+		reader := &chunkReader{chunks: chunks}
+
+		events := make(chan Event, 1)
+		errs := make(chan error, 1)
+		go func() {
+			for event, err := range ReadEvents(reader) {
+				if err != nil {
+					errs <- err
+					return
+				}
+				events <- event
+				return
+			}
+		}()
+
+		chunks <- []byte("data: ok\r")
+		synctest.Wait()
+		requireNoEvent(t, events, errs)
+
+		chunks <- []byte("\n")
+		synctest.Wait()
+		requireNoEvent(t, events, errs)
+
+		chunks <- []byte("data: there\r\n\r\n")
+		synctest.Wait()
+
+		select {
+		case event := <-events:
+			requireEqualEvent(t, Event{Data: []byte("ok\nthere")}, event)
+		case err := <-errs:
+			t.Fatalf("expected no errors but got %v", err)
+		}
+	})
+}
+
+func TestWrite(t *testing.T) {
+	expectedString := func(str string) require.ValueAssertionFunc {
+		return func(tt require.TestingT, i1 any, i2 ...any) {
+			require.IsType(t, []byte{}, i1, "expected result to be `[]byte` but got %T", i1)
+			b := i1.([]byte)
+			require.Equal(tt, str, string(b), i2...)
+		}
+	}
+
+	for name, tc := range map[string]struct {
+		event        Event
+		expectError  require.ErrorAssertionFunc
+		expectOutput require.ValueAssertionFunc
+	}{
+		"no data event": {
+			event:        Event{ID: "1", Event: "hello"},
+			expectError:  require.NoError,
+			expectOutput: expectedString("event: hello\nid: 1\n\n"),
+		},
+		"data only": {
+			event:        Event{Data: []byte("some text")},
+			expectError:  require.NoError,
+			expectOutput: expectedString("data: some text\n\n"),
+		},
+		"multiline data": {
+			event:        Event{Data: []byte("another message\nwith two lines")},
+			expectError:  require.NoError,
+			expectOutput: expectedString("data: another message\ndata: with two lines\n\n"),
+		},
+		"multiline data escaped": {
+			event:        Event{Data: []byte("{\"response\": \"hello\\nworld\"}\n{\"response\": \"second\"}")},
+			expectError:  require.NoError,
+			expectOutput: expectedString("data: {\"response\": \"hello\\nworld\"}\ndata: {\"response\": \"second\"}\n\n"),
+		},
+		"carriage return data": {
+			event:        Event{Data: []byte("ok\revent: injected")},
+			expectError:  require.NoError,
+			expectOutput: expectedString("data: ok\ndata: event: injected\n\n"),
+		},
+		"carriage return newline data": {
+			event:        Event{Data: []byte("first\r\nsecond")},
+			expectError:  require.NoError,
+			expectOutput: expectedString("data: first\ndata: second\n\n"),
+		},
+		"named events": {
+			event:        Event{Event: "userconnect", Data: []byte(`{"username": "bobby", "time": "02:33:48"}`)},
+			expectError:  require.NoError,
+			expectOutput: expectedString("event: userconnect\ndata: {\"username\": \"bobby\", \"time\": \"02:33:48\"}\n\n"),
+		},
+		"all fields": {
+			event:        Event{ID: "1", Event: "hello", Data: []byte("start of message\nend of message"), Retry: "5"},
+			expectError:  require.NoError,
+			expectOutput: expectedString("event: hello\nid: 1\ndata: start of message\ndata: end of message\nretry: 5\n\n"),
+		},
+		"invalid fields": {
+			event: Event{ID: "1\n\r", Event: "hello", Data: []byte("start of message\nend of message"), Retry: "5"},
+			expectError: func(tt require.TestingT, err error, i ...any) {
+				require.True(tt, trace.IsBadParameter(err), "expected error %v to be BadParameter", err)
+			},
+			expectOutput: require.Empty,
+		},
+		"invalid retry field": {
+			event: Event{Event: "hello", Data: []byte("start of message\nend of message"), Retry: "non-digits"},
+			expectError: func(tt require.TestingT, err error, i ...any) {
+				require.True(tt, trace.IsBadParameter(err), "expected error %v to be BadParameter", err)
+			},
+			expectOutput: require.Empty,
+		},
+		"empty": {
+			event:        Event{},
+			expectError:  require.NoError,
+			expectOutput: require.Empty,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			_, err := WriteEvent(&buf, tc.event)
+			tc.expectError(t, err)
+			tc.expectOutput(t, buf.Bytes())
+		})
+	}
+}
+
+// TestSSEEventsWriteRead ensures both write and read SSE events functions
+// produce results that are compatible with each other.
+func TestWriteRead(t *testing.T) {
+	for name, input := range map[string]string{
+		// We use the version that doesn't include the comment as it is not read
+		// by the reader.
+		"data only":                 dataOnlyWithoutCommentExample,
+		"named events":              namedEventsExample,
+		"mixed and matching events": mixingAndMatchingExample,
+		"multiple data fields":      "event: hello\nid: 1\ndata: start of message\ndata: end of message\n\n",
+		"empty":                     "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			inputEvents, err := stream.Collect(ReadEvents(strings.NewReader(input)))
+			require.NoError(t, err)
+
+			var buf bytes.Buffer
+			for _, event := range inputEvents {
+				_, err := WriteEvent(&buf, event)
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, input, buf.String())
+		})
+	}
+}
+
+// TestReadFieldsAreCopied ensures ReadSSEEvents returns events whose
+// fields own their bytes rather than aliasing the scanner's internal buffer.
+// bufio.Scanner compacts its buffer between Scan() calls, so any retained
+// sub-slice of scanner.Bytes() would be overwritten by later reads.
+func TestReadFieldsAreCopied(t *testing.T) {
+	const n = 200
+
+	var buf bytes.Buffer
+	for i := range n {
+		_, err := WriteEvent(&buf, Event{
+			ID:    fmt.Sprintf("%d", i),
+			Event: fmt.Sprintf("e%d", i),
+			// Multi-line data exercises the append branch of Data
+			// accumulation in addition to the initial allocation.
+			Data: fmt.Appendf(nil, "first-%d\nsecond-%d", i, i),
+		})
+		require.NoError(t, err)
+	}
+
+	// We force multiple Scan calls by using a one byte reader.
+	got, err := stream.Collect(ReadEvents(iotest.OneByteReader(&buf)))
+	require.NoError(t, err)
+	require.Len(t, got, n)
+
+	for i, ev := range got {
+		require.Equal(t, fmt.Sprintf("%d", i), ev.ID)
+		require.Equal(t, fmt.Sprintf("e%d", i), ev.Event)
+		require.Equal(t, fmt.Appendf(nil, "first-%d\nsecond-%d", i, i), ev.Data)
+	}
+}
+
+func FuzzRead(f *testing.F) {
+	f.Add("")
+	f.Add(dataOnlyExample)
+	f.Add(namedEventsExample)
+	f.Add(mixingAndMatchingExample)
+	f.Fuzz(func(t *testing.T, a string) {
+		reader := strings.NewReader(a)
+		require.NotPanics(t, func() {
+			for range ReadEvents(reader) {
+			}
+		})
+	})
+}
+
+func requireEqualEvent(t require.TestingT, expected Event, target Event) {
+	require.Equal(t, expected.Event, target.Event)
+	require.Equal(t, expected.Data, target.Data)
+	require.Equal(t, expected.ID, target.ID)
+	require.Equal(t, expected.Retry, target.Retry)
+}
+
+func requireNoEvent(t *testing.T, events <-chan Event, errs <-chan error) {
+	t.Helper()
+
+	select {
+	case event := <-events:
+		require.Failf(t, "unexpected SSE event", "event = %+v", event)
+	case err := <-errs:
+		t.Fatalf("expected no errors but got %v", err)
+	default:
+	}
+}
+
+type chunkReader struct {
+	chunks  <-chan []byte
+	pending []byte
+}
+
+func (r *chunkReader) Read(p []byte) (int, error) {
+	for len(r.pending) == 0 {
+		chunk, ok := <-r.chunks
+		if !ok {
+			return 0, io.EOF
+		}
+		r.pending = chunk
+	}
+
+	n := copy(p, r.pending)
+	r.pending = r.pending[n:]
+	return n, nil
+}
+
+// SSE stream examples from https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#examples
+//
+// Note all examples here contain two line breaks at the end to simulate the end
+// of message.
+const (
+	dataOnlyExample = `: this is a test stream
+
+data: some text
+
+data: another message
+data: with two lines
+
+`
+	namedEventsExample = `event: userconnect
+data: {"username": "bobby", "time": "02:33:48"}
+
+event: usermessage
+data: {"username": "bobby", "time": "02:34:11", "text": "Hi everyone."}
+
+event: userdisconnect
+data: {"username": "bobby", "time": "02:34:23"}
+
+event: usermessage
+data: {"username": "sean", "time": "02:34:36", "text": "Bye, bobby."}
+
+`
+	mixingAndMatchingExample = `event: userconnect
+data: {"username": "bobby", "time": "02:33:48"}
+
+data: Here's a system message of some kind that will get used
+data: to accomplish some task.
+
+event: usermessage
+data: {"username": "bobby", "time": "02:34:11", "text": "Hi everyone."}
+
+`
+	dataOnlyWithoutCommentExample = `data: some text
+
+data: another message
+data: with two lines
+
+`
+)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6870,6 +6870,7 @@ func (process *TeleportProcess) initApps() {
 			if app.AWS != nil {
 				aws = &types.AppAWS{
 					ExternalID: app.AWS.ExternalID,
+					Region:     app.AWS.Region,
 				}
 			}
 

--- a/lib/service/servicecfg/app.go
+++ b/lib/service/servicecfg/app.go
@@ -262,6 +262,9 @@ func (a *App) checkPorts() error {
 type AppAWS struct {
 	// ExternalID is the AWS External ID used when assuming roles in this app.
 	ExternalID string
+	// Region is a cloud region for the app.
+	// This field is set for apps that integrates with AWS applications/APIs.
+	Region string
 }
 
 // Rewrite is a list of rewriting rules to apply to requests and responses.

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
+	"github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/api/utils/tlsutils"
 	"github.com/gravitational/teleport/lib/backend"
@@ -103,7 +104,16 @@ func ValidateApp(app types.Application, proxyGetter ProxyGetter) error {
 		}
 	}
 
-	// If no public address is set, there's nothing to validate.
+	if region := app.GetAWSRegion(); region != "" {
+		if err := aws.IsValidRegion(region); err != nil {
+			return trace.BadParameter(
+				"Application %q is configured with an invalid AWS region (%q)",
+				app.GetName(),
+				region,
+			)
+		}
+	}
+
 	if app.GetPublicAddr() == "" {
 		return nil
 	}

--- a/lib/services/app_test.go
+++ b/lib/services/app_test.go
@@ -173,6 +173,39 @@ func TestValidateApp(t *testing.T) {
 			proxyAddrs: []string{"example.com:443", "example.com:80"},
 			wantErr:    "conflicts with the Teleport Proxy public address",
 		},
+		{
+			name: "valid aws region",
+			app: func() types.Application {
+				app, err := types.NewAppV3(types.Metadata{Name: "app"}, types.AppSpecV3{
+					AWS: &types.AppAWS{
+						Region: "us-west-2",
+					},
+					LLM: &types.LLM{
+						Format:   types.LLMFormatAnthropic,
+						Provider: types.LLMProviderAWSBedrock,
+					},
+				})
+				require.NoError(t, err)
+				return app
+			}(),
+		},
+		{
+			name: "invalid aws region",
+			app: func() types.Application {
+				app, err := types.NewAppV3(types.Metadata{Name: "app"}, types.AppSpecV3{
+					AWS: &types.AppAWS{
+						Region: "random",
+					},
+					LLM: &types.LLM{
+						Format:   types.LLMFormatAnthropic,
+						Provider: types.LLMProviderAWSBedrock,
+					},
+				})
+				require.NoError(t, err)
+				return app
+			}(),
+			wantErr: "invalid AWS region",
+		},
 	}
 
 	for _, tt := range tests {

--- a/lib/srv/app/azure/handler_test.go
+++ b/lib/srv/app/azure/handler_test.go
@@ -97,6 +97,10 @@ func (noopAudit) OnDynamoDBRequest(context.Context, *common.SessionContext, *htt
 	return nil
 }
 
+func (noopAudit) OnLLMRequest(context.Context, *common.SessionContext, *http.Request, common.LLMRequest, common.LLMResponse) error {
+	return nil
+}
+
 func (noopAudit) EmitEvent(context.Context, apievents.AuditEvent) error {
 	return nil
 }

--- a/lib/srv/app/common/audit.go
+++ b/lib/srv/app/common/audit.go
@@ -46,6 +46,8 @@ type Audit interface {
 	OnRequest(ctx context.Context, sessionCtx *SessionContext, req *http.Request, status uint32, re *AWSResolvedEndpoint) error
 	// OnDynamoDBRequest is called when app request for a DynamoDB API is sent and a response is received.
 	OnDynamoDBRequest(ctx context.Context, sessionCtx *SessionContext, req *http.Request, status uint32, re *AWSResolvedEndpoint) error
+	// OnLLMRequest is called when app request for LLM inference endpoint is sent and a response is received.
+	OnLLMRequest(ctx context.Context, sessionCtx *SessionContext, req *http.Request, llmReq LLMRequest, llmResp LLMResponse) error
 	// EmitEvent emits the provided audit event.
 	EmitEvent(ctx context.Context, event apievents.AuditEvent) error
 }
@@ -179,6 +181,8 @@ func (a *audit) OnSessionChunk(ctx context.Context, serverID, chunkID string, id
 }
 
 // OnRequest is called when an app request is sent during the session and a response is received.
+//
+// This event only goes to app session recording (chunk).
 func (a *audit) OnRequest(ctx context.Context, sessionCtx *SessionContext, req *http.Request, status uint32, re *AWSResolvedEndpoint) error {
 	event := &apievents.AppSessionRequest{
 		Metadata: apievents.Metadata{
@@ -192,7 +196,7 @@ func (a *audit) OnRequest(ctx context.Context, sessionCtx *SessionContext, req *
 		StatusCode:         status,
 		AWSRequestMetadata: *MakeAWSRequestMetadata(req, re),
 	}
-	return trace.Wrap(a.EmitEvent(ctx, event))
+	return trace.Wrap(a.recordEvent(ctx, event))
 }
 
 // OnDynamoDBRequest is called when a DynamoDB app request is sent during the session.
@@ -225,22 +229,56 @@ func (a *audit) OnDynamoDBRequest(ctx context.Context, sessionCtx *SessionContex
 	return trace.Wrap(a.EmitEvent(ctx, event))
 }
 
-// EmitEvent emits the provided audit event.
+// OnLLMRequest is called when app request for LLM inference endpoint is sent and a response is received.
+//
+// This event only goes to app session recording (chunk).
+func (a *audit) OnLLMRequest(ctx context.Context, sessionCtx *SessionContext, req *http.Request, llmReq LLMRequest, llmResp LLMResponse) error {
+	event := &apievents.AppSessionLLMRequest{
+		Metadata: apievents.Metadata{
+			Type: events.AppSessionLLMRequestSuccessEvent,
+			Code: events.AppSessionLLMRequestSuccessCode,
+		},
+		Status: apievents.Status{
+			Success: true,
+		},
+		AppMetadata:      *MakeAppMetadata(sessionCtx.App),
+		Method:           req.Method,
+		Path:             req.URL.Path,
+		Provider:         llmReq.Provider,
+		Model:            llmReq.Model,
+		RequestedModel:   llmReq.RequestedModel,
+		InputTokenCount:  int64(llmResp.InputTokenCount),
+		OutputTokenCount: int64(llmResp.OutputTokenCount),
+	}
+	if llmResp.Error != nil {
+		event.Metadata.Type = events.AppSessionLLMRequestFailureEvent
+		event.Metadata.Code = events.AppSessionLLMRequestFailureCode
+		event.Status.Success = false
+		event.Status.Error = llmResp.Error.Error()
+	}
+	return trace.Wrap(a.recordEvent(ctx, event))
+}
+
+// EmitEvent emits and records the provided audit event.
 func (a *audit) EmitEvent(ctx context.Context, e apievents.AuditEvent) error {
 	preparedEvent, err := a.cfg.Recorder.PrepareSessionEvent(e)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	recErr := a.cfg.Recorder.RecordEvent(ctx, preparedEvent)
-	event := preparedEvent.GetAuditEvent()
-	var emitErr error
-	// AppSessionRequest events should only go to session recording
-	if event.GetType() != events.AppSessionRequestEvent {
-		emitErr = a.cfg.Emitter.EmitAuditEvent(ctx, event)
+	return trace.NewAggregate(
+		a.cfg.Recorder.RecordEvent(ctx, preparedEvent),
+		a.cfg.Emitter.EmitAuditEvent(ctx, preparedEvent.GetAuditEvent()),
+	)
+}
+
+func (a *audit) recordEvent(ctx context.Context, e apievents.AuditEvent) error {
+	preparedEvent, err := a.cfg.Recorder.PrepareSessionEvent(e)
+	if err != nil {
+		return trace.Wrap(err)
 	}
 
-	return trace.NewAggregate(recErr, emitErr)
+	return trace.Wrap(a.cfg.Recorder.RecordEvent(ctx, preparedEvent))
 }
 
 // MakeAppMetadata returns common server metadata for database session.

--- a/lib/srv/app/common/llm.go
+++ b/lib/srv/app/common/llm.go
@@ -1,0 +1,43 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"github.com/gravitational/teleport/api/types"
+)
+
+// LLMRequest describes an inbound LLM API request being proxied to a provider.
+type LLMRequest struct {
+	// Format identifies the LLM format used on the request.
+	Format types.LLMFormat
+	// Provider identifies the LLM provider handling the request.
+	Provider types.LLMProvider
+	// Model is the resolved model name sent to the provider.
+	Model string
+	// RequestedModel is the original model name as specified by the client.
+	RequestedModel string
+}
+
+// LLMResponse describes the outcome of a proxied LLM API request.
+type LLMResponse struct {
+	// Error is the error encountered while handling the request, if any.
+	Error error
+	// InputTokenCount is the number of tokens consumed by the request input.
+	InputTokenCount int
+	// OutputTokenCount is the number of tokens produced in the response.
+	OutputTokenCount int
+}

--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -56,6 +56,7 @@ import (
 	appazure "github.com/gravitational/teleport/lib/srv/app/azure"
 	"github.com/gravitational/teleport/lib/srv/app/common"
 	appgcp "github.com/gravitational/teleport/lib/srv/app/gcp"
+	appllm "github.com/gravitational/teleport/lib/srv/app/llm"
 	"github.com/gravitational/teleport/lib/srv/mcp"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -200,6 +201,7 @@ type ConnectionsHandler struct {
 	awsHandler   http.Handler
 	azureHandler http.Handler
 	gcpHandler   http.Handler
+	llmHandler   http.Handler
 
 	// authMiddleware allows wrapping connections with identity information.
 	authMiddleware *auth.Middleware
@@ -242,6 +244,14 @@ func NewConnectionsHandler(closeContext context.Context, cfg *ConnectionsHandler
 		return nil, trace.Wrap(err)
 	}
 
+	llmHandler, err := appllm.NewHandler(closeContext, appllm.HandlerConfig{
+		Log:               cfg.Logger.With(teleport.ComponentKey, teleport.ComponentLLM),
+		AWSConfigProvider: awsConfigProvider,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	clusterName, err := cfg.AccessPoint.GetClusterName(closeContext)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -253,6 +263,7 @@ func NewConnectionsHandler(closeContext context.Context, cfg *ConnectionsHandler
 		awsHandler:   awsHandler,
 		azureHandler: azureHandler,
 		gcpHandler:   gcpHandler,
+		llmHandler:   llmHandler,
 		connAuth:     make(map[net.Conn]error),
 		log:          slog.With(teleport.ComponentKey, cfg.ServiceComponent),
 		clusterName:  clusterName.GetClusterName(),
@@ -483,9 +494,8 @@ func (c *ConnectionsHandler) serveHTTP(w http.ResponseWriter, r *http.Request) e
 	case app.IsGCP():
 		return c.serveSession(w, r, &identity, app, c.withGCPHandler)
 
-	// TODO(gabrielcorado): implement inference endpoint handler.
 	case app.IsLLM():
-		return trace.NotImplemented("LLM access is not implemented")
+		return c.serveSession(w, r, &identity, app, c.withLLMHandler)
 
 	default:
 		return c.serveSession(w, r, &identity, app, c.withJWTTokenForwarder)

--- a/lib/srv/app/llm/anthropic/anthropic.go
+++ b/lib/srv/app/llm/anthropic/anthropic.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/srv/app/llm/bedrock"
 	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
 	"github.com/gravitational/teleport/lib/srv/app/llm/models"
 	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
@@ -48,18 +49,18 @@ func NewRequest(cfg *llmrequest.Config) (*http.Request, *RequestInfo, error) {
 		return nil, info, trace.Wrap(err)
 	}
 
-	// Default URL address.
-	//
-	// https://platform.claude.com/docs/en/api/overview
-	cfg.ProviderURL = cmp.Or(cfg.ProviderURL, &url.URL{
-		Scheme: "https",
-		Host:   "api.anthropic.com",
-		Path:   "/v1",
-	})
-
-	// TODO(gabrielcorado): add support for bedrock provider.
-	switch cfg.LLM.Provider {
+	llm := cfg.App.GetLLM()
+	switch llm.Provider {
 	case types.LLMProviderAnthropic:
+		// Default URL address.
+		//
+		// https://platform.claude.com/docs/en/api/overview
+		cfg.ProviderURL = cmp.Or(cfg.ProviderURL, &url.URL{
+			Scheme: "https",
+			Host:   "api.anthropic.com",
+			Path:   "/v1",
+		})
+
 		switch strings.TrimPrefix(cfg.DownstreamRequest.URL.Path, "/v1") {
 		case "/messages":
 			if cfg.DownstreamRequest.Method != http.MethodPost {
@@ -87,8 +88,36 @@ func NewRequest(cfg *llmrequest.Config) (*http.Request, *RequestInfo, error) {
 		default:
 			return nil, info, trace.NotFound("unsupported endpoint")
 		}
+	case types.LLMProviderAWSBedrock:
+		var err error
+		cfg.ProviderURL, err = bedrock.BuildURL(cfg.Logger, cfg.App)
+		if err != nil {
+			return nil, info, trace.Wrap(err)
+		}
+
+		switch strings.TrimPrefix(cfg.DownstreamRequest.URL.Path, "/v1") {
+		case "/messages":
+			if cfg.DownstreamRequest.Method != http.MethodPost {
+				// We're ok with returning 404 back to clients instead 405 status.
+				return nil, info, trace.NotFound("messages API supports only POST requests")
+			}
+			// Messages API endpoint supported.
+			//
+			// https://docs.aws.amazon.com/bedrock/latest/userguide/inference-messages-api.html
+			providerPath = "/messages"
+			providerMethod = http.MethodPost
+
+			// Bedrock mantle require a specific API version and we're using
+			// signed requests.
+			//
+			// https://docs.aws.amazon.com/bedrock/latest/userguide/inference-messages-api.html#inference-messages-api-prereq
+			providerHeaders.Set("anthropic-version", "2023-06-01")
+			providerHeaders.Set("content-type", "application/json")
+		default:
+			return nil, info, trace.NotFound("unsupported endpoint")
+		}
 	default:
-		return nil, info, trace.NotImplemented("provider %q is not supported", cfg.LLM.Provider)
+		return nil, info, trace.NotImplemented("provider %q is not supported", llm.Provider)
 	}
 
 	body, err := utils.ReadAtMost(cfg.DownstreamRequest.Body, teleport.MaxHTTPRequestSize)
@@ -104,7 +133,7 @@ func NewRequest(cfg *llmrequest.Config) (*http.Request, *RequestInfo, error) {
 	info.requestedModel = req.Model
 	info.stream = req.Stream
 
-	providerModel, found := models.ConvertName(cfg.LLM.Models, cfg.LLM.FallbackModel, req.Model)
+	providerModel, found := models.ConvertName(llm.Models, llm.FallbackModel, req.Model)
 	if !found {
 		return nil, info, trace.BadParameter("requested model %q is not supported", req.Model)
 	}
@@ -119,6 +148,7 @@ func NewRequest(cfg *llmrequest.Config) (*http.Request, *RequestInfo, error) {
 	if err != nil {
 		return nil, info, trace.ConnectionProblem(err, "failed to generate provider request")
 	}
+
 	info.requestSize = len(providerBody)
 
 	// Since we're doing a complete rewrite of the downstream request, it is
@@ -134,6 +164,16 @@ func NewRequest(cfg *llmrequest.Config) (*http.Request, *RequestInfo, error) {
 		return nil, info, trace.Wrap(err)
 	}
 	providerReq.Header = providerHeaders
+
+	if llm.Provider == types.LLMProviderAWSBedrock {
+		if err := cfg.SignBedrockRequest(providerReq.Context(), cfg.App, providerReq, providerBody); err != nil {
+			// The signing failure cause can carry AWS credentials/config
+			// details, so it is only logged, and clients receive a generic
+			// internal error message.
+			cfg.Logger.ErrorContext(providerReq.Context(), "failed to sign provider request", "error", err)
+			return nil, info, llmerrors.ErrConfig
+		}
+	}
 	return providerReq, info, nil
 }
 

--- a/lib/srv/app/llm/anthropic/anthropic.go
+++ b/lib/srv/app/llm/anthropic/anthropic.go
@@ -30,46 +30,13 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
 	"github.com/gravitational/teleport/lib/srv/app/llm/models"
+	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-// NewRequestConfig is config used to create a new provide request.
-type NewRequestConfig struct {
-	// LLM inference endpoint configuration.
-	LLM *types.LLM
-	// DownstreamRequest is the received downstream request.
-	DownstreamRequest *http.Request
-	// ProviderURL is the provider URL address.
-	ProviderURL *url.URL
-	// GetAPIKeyFunc is the function used to retrieve Anthropic API keys.
-	GetAPIKeyFunc func() string
-}
-
-func (c *NewRequestConfig) CheckAndSetDefaults() error {
-	if c.LLM == nil {
-		return trace.BadParameter("llm information is required")
-	}
-	if c.DownstreamRequest == nil {
-		return trace.BadParameter("downstream request is required")
-	}
-	if c.GetAPIKeyFunc == nil {
-		return trace.BadParameter("get api key function is required")
-	}
-
-	// Default URL address.
-	//
-	// https://platform.claude.com/docs/en/api/overview
-	c.ProviderURL = cmp.Or(c.ProviderURL, &url.URL{
-		Scheme: "https",
-		Host:   "api.anthropic.com",
-		Path:   "/v1",
-	})
-	return nil
-}
-
 // NewRequest creates a new provider request based on the downstream request,
 // and inference endpoint configuration.
-func NewRequest(cfg *NewRequestConfig) (*http.Request, *RequestInfo, error) {
+func NewRequest(cfg *llmrequest.Config) (*http.Request, *RequestInfo, error) {
 	var (
 		info            = &RequestInfo{}
 		providerPath    string
@@ -80,6 +47,15 @@ func NewRequest(cfg *NewRequestConfig) (*http.Request, *RequestInfo, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, info, trace.Wrap(err)
 	}
+
+	// Default URL address.
+	//
+	// https://platform.claude.com/docs/en/api/overview
+	cfg.ProviderURL = cmp.Or(cfg.ProviderURL, &url.URL{
+		Scheme: "https",
+		Host:   "api.anthropic.com",
+		Path:   "/v1",
+	})
 
 	// TODO(gabrielcorado): add support for bedrock provider.
 	switch cfg.LLM.Provider {

--- a/lib/srv/app/llm/anthropic/anthropic.go
+++ b/lib/srv/app/llm/anthropic/anthropic.go
@@ -1,0 +1,246 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package anthropic
+
+import (
+	"bytes"
+	"cmp"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+	"github.com/gravitational/teleport/lib/srv/app/llm/models"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// NewRequestConfig is config used to create a new provide request.
+type NewRequestConfig struct {
+	// LLM inference endpoint configuration.
+	LLM *types.LLM
+	// DownstreamRequest is the received downstream request.
+	DownstreamRequest *http.Request
+	// ProviderURL is the provider URL address.
+	ProviderURL *url.URL
+	// GetAPIKeyFunc is the function used to retrieve Anthropic API keys.
+	GetAPIKeyFunc func() string
+}
+
+func (c *NewRequestConfig) CheckAndSetDefaults() error {
+	if c.LLM == nil {
+		return trace.BadParameter("llm information is required")
+	}
+	if c.DownstreamRequest == nil {
+		return trace.BadParameter("downstream request is required")
+	}
+	if c.GetAPIKeyFunc == nil {
+		return trace.BadParameter("get api key function is required")
+	}
+
+	// Default URL address.
+	//
+	// https://platform.claude.com/docs/en/api/overview
+	c.ProviderURL = cmp.Or(c.ProviderURL, &url.URL{
+		Scheme: "https",
+		Host:   "api.anthropic.com",
+		Path:   "/v1",
+	})
+	return nil
+}
+
+// NewRequest creates a new provider request based on the downstream request,
+// and inference endpoint configuration.
+func NewRequest(cfg *NewRequestConfig) (*http.Request, *RequestInfo, error) {
+	var (
+		info            = &RequestInfo{}
+		providerPath    string
+		providerMethod  string
+		providerHeaders = http.Header{}
+	)
+
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, info, trace.Wrap(err)
+	}
+
+	// TODO(gabrielcorado): add support for bedrock provider.
+	switch cfg.LLM.Provider {
+	case types.LLMProviderAnthropic:
+		switch strings.TrimPrefix(cfg.DownstreamRequest.URL.Path, "/v1") {
+		case "/messages":
+			if cfg.DownstreamRequest.Method != http.MethodPost {
+				// We're ok with returning 404 back to clients instead 405 status.
+				return nil, info, trace.NotFound("messages API supports only POST requests")
+			}
+			// Messages API endpoint supported.
+			//
+			// https://platform.claude.com/docs/en/api/messages/create
+			providerPath = "/messages"
+			providerMethod = http.MethodPost
+
+			// Anthropic API supports the following headers:
+			//   - "x-api-key": Holds the Anthropic API key. Mutually exclusive with "Authorization".
+			//   - "Authorization": Carries short lived token generated using
+			//     "Workload identity federation". We currently don't have support
+			//     for this flow. Mutually exclusive with "x-api-key".
+			//   - "anthropic-version": Indicates the Anthropic API version.
+			//   - "content-type": Request content type.
+			//
+			// https://platform.claude.com/docs/en/api/overview#authentication
+			providerHeaders.Set("x-api-key", cfg.GetAPIKeyFunc())
+			providerHeaders.Set("anthropic-version", "2023-06-01") // Currently, the only version supported.
+			providerHeaders.Set("content-type", "application/json")
+		default:
+			return nil, info, trace.NotFound("unsupported endpoint")
+		}
+	default:
+		return nil, info, trace.NotImplemented("provider %q is not supported", cfg.LLM.Provider)
+	}
+
+	body, err := utils.ReadAtMost(cfg.DownstreamRequest.Body, teleport.MaxHTTPRequestSize)
+	if err != nil {
+		return nil, info, trace.Wrap(err)
+	}
+	defer cfg.DownstreamRequest.Body.Close()
+
+	var req messagesAPIRequest
+	if err := utils.FastUnmarshal(body, &req); err != nil {
+		return nil, info, trace.BadParameter("unable to parse request body")
+	}
+	info.requestedModel = req.Model
+	info.stream = req.Stream
+
+	providerModel, found := models.ConvertName(cfg.LLM.Models, cfg.LLM.FallbackModel, req.Model)
+	if !found {
+		return nil, info, trace.BadParameter("requested model %q is not supported", req.Model)
+	}
+	info.providerModel = providerModel
+	req.Model = providerModel
+
+	if req.MaxTokens > maxNonStreamingTokens && !info.IsStream() {
+		return nil, info, trace.BadParameter("max_tokens must be %d or less for non-streaming requests", maxNonStreamingTokens)
+	}
+
+	providerBody, err := utils.FastMarshal(req)
+	if err != nil {
+		return nil, info, trace.ConnectionProblem(err, "failed to generate provider request")
+	}
+	info.requestSize = len(providerBody)
+
+	// Since we're doing a complete rewrite of the downstream request, it is
+	// easier to use a "fresh" request, and copy what is used from downstream
+	// request.
+	providerReq, err := http.NewRequestWithContext(
+		cfg.DownstreamRequest.Context(), // Keep original context so cancelation propagates.
+		providerMethod,
+		cfg.ProviderURL.JoinPath(providerPath).String(),
+		bytes.NewBuffer(providerBody),
+	)
+	if err != nil {
+		return nil, info, trace.Wrap(err)
+	}
+	providerReq.Header = providerHeaders
+	return providerReq, info, nil
+}
+
+// WriteError writes an error in Anthropic format.
+func WriteError(w http.ResponseWriter, err error) error {
+	w.WriteHeader(llmerrors.StatusCodeFromErr(err))
+	_, werr := w.Write(marshalError(newErrorMessage(err)))
+	return trace.Wrap(werr)
+}
+
+// marshalError marshals an error into Anthropic format.
+func marshalError(apiErr *errorEnvelope) []byte {
+	enc, err := utils.FastMarshal(apiErr)
+	if err != nil {
+		return []byte(
+			`{"type": "error", "error": {"type": "api_error", "message": "` + llmerrors.ErrUnknown.Error() + `"}}`,
+		)
+	}
+	return enc
+}
+
+// newErrorMessage creates a new error message.
+func newErrorMessage(err error) *errorEnvelope {
+	if err == nil {
+		return nil
+	}
+
+	r := &errorEnvelope{
+		Type: "error",
+		Error: errorMessage{
+			Type:    errorTypeAPIError,
+			Message: err.Error(),
+		},
+	}
+	switch {
+	case errors.Is(err, llmerrors.ErrCanceled), errors.Is(err, llmerrors.ErrTimeout):
+		r.Error.Type = errorTypeTimeoutError
+	case errors.Is(err, llmerrors.ErrBadRequest), trace.IsBadParameter(err):
+		r.Error.Type = errorTypeInvalidRequestError
+	case errors.Is(err, llmerrors.ErrUnauthorized):
+		r.Error.Type = errorTypeAuthenticationError
+	case errors.Is(err, llmerrors.ErrRejected):
+		r.Error.Type = errorTypeRateLimitError
+	case errors.Is(err, llmerrors.ErrUnsupported), trace.IsNotFound(err):
+		r.Error.Type = errorTypeNotFoundError
+	}
+
+	return r
+}
+
+// parseProviderError parses errors that come from Anthropic API.
+func parseProviderError(body []byte) (*llmerrors.ProviderError, error) {
+	var r errorEnvelope
+	if err := utils.FastUnmarshal(body, &r); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	message := r.Error.Message
+	switch r.Error.Type {
+	case errorTypeTimeoutError:
+		return llmerrors.NewProviderError(llmerrors.ErrTimeout, message), nil
+	case errorTypeInvalidRequestError:
+		return llmerrors.NewProviderError(llmerrors.ErrBadRequest, message), nil
+	case errorTypeAuthenticationError, errorTypePermissionError:
+		return llmerrors.NewProviderError(llmerrors.ErrUnauthorized, ""), nil
+	case errorTypeRateLimitError, errorTypeOverloadedError, errorTypeBillingError:
+		return llmerrors.NewProviderError(llmerrors.ErrRejected, message), nil
+	case errorTypeNotFoundError:
+		return llmerrors.NewProviderError(llmerrors.ErrUnsupported, message), nil
+	default:
+		return llmerrors.NewProviderError(llmerrors.ErrUnknown, ""), nil
+	}
+}
+
+const (
+	// maxNonStreamingTokens defines the max tokens that can be generated for
+	// non-streaming requests.
+	//
+	// The rule for this definition by Anthropic is any request that might take
+	// more than 10 minutes to complete, must use streaming.
+	// To calculate how many tokens would 10 minutes take, we use the formula
+	// available on Anthropic SDKs, for example, in the Golang SDK: https://github.com/anthropics/anthropic-sdk-go/blob/058d85cd7e656f5fe972591bcf841c99564581e9/client.go#L297
+	// The result give us around 21k tokens. This value covers all non-legacy
+	// models.
+	maxNonStreamingTokens = 21_000
+)

--- a/lib/srv/app/llm/anthropic/anthropic_test.go
+++ b/lib/srv/app/llm/anthropic/anthropic_test.go
@@ -18,6 +18,10 @@ package anthropic
 
 import (
 	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -34,17 +38,27 @@ import (
 func TestNewRequest(t *testing.T) {
 	apiKey := "random-api-key"
 
+	signAWSRequest := func(_ context.Context, _ types.Application, req *http.Request, reqBody []byte) error {
+		hash := sha256.New()
+		hash.Write(reqBody)
+		req.Header.Set("X-Amz-Content-Sha256", hex.EncodeToString(hash.Sum(nil)))
+		req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=test")
+		return nil
+	}
+
 	for name, tc := range map[string]struct {
-		llm             *types.LLM
+		llm             types.Application
 		request         func() *http.Request
+		signAWSRequest  func(context.Context, types.Application, *http.Request, []byte) error
 		expectedError   require.ErrorAssertionFunc
 		expectedRequest require.ValueAssertionFunc
 		expectedInfo    require.ValueAssertionFunc
 	}{
 		"successful messages": {
-			llm: &types.LLM{
+			llm: newApp(t, &types.LLM{
+				Format:   types.LLMFormatAnthropic,
 				Provider: types.LLMProviderAnthropic,
-			},
+			}, nil /* appAWS */),
 			request: func() *http.Request {
 				r, _ := http.NewRequest(
 					http.MethodPost,
@@ -69,9 +83,10 @@ func TestNewRequest(t *testing.T) {
 			},
 		},
 		"includes single /v1 prefix": {
-			llm: &types.LLM{
+			llm: newApp(t, &types.LLM{
+				Format:   types.LLMFormatAnthropic,
 				Provider: types.LLMProviderAnthropic,
-			},
+			}, nil /* appAWS */),
 			request: func() *http.Request {
 				r, _ := http.NewRequest(
 					http.MethodPost,
@@ -88,12 +103,13 @@ func TestNewRequest(t *testing.T) {
 			expectedInfo: require.NotNil,
 		},
 		"convert model name": {
-			llm: &types.LLM{
+			llm: newApp(t, &types.LLM{
+				Format:   types.LLMFormatAnthropic,
 				Provider: types.LLMProviderAnthropic,
 				Models: []*types.LLM_Model{
 					{ProviderName: "claude-opus-4-8", Name: "claude-sonnet-4-20250514"},
 				},
-			},
+			}, nil /* appAWS */),
 			request: func() *http.Request {
 				r, _ := http.NewRequest(
 					http.MethodPost,
@@ -116,13 +132,14 @@ func TestNewRequest(t *testing.T) {
 			},
 		},
 		"fallback model name": {
-			llm: &types.LLM{
+			llm: newApp(t, &types.LLM{
+				Format:   types.LLMFormatAnthropic,
 				Provider: types.LLMProviderAnthropic,
 				Models: []*types.LLM_Model{
 					{ProviderName: "claude-opus-4-8", Name: "claude-sonnet-4-20250514"},
 				},
 				FallbackModel: "claude-sonnet-4-20250514",
-			},
+			}, nil /* appAWS */),
 			request: func() *http.Request {
 				r, _ := http.NewRequest(
 					http.MethodPost,
@@ -145,12 +162,13 @@ func TestNewRequest(t *testing.T) {
 			},
 		},
 		"unsupported model name": {
-			llm: &types.LLM{
+			llm: newApp(t, &types.LLM{
+				Format:   types.LLMFormatAnthropic,
 				Provider: types.LLMProviderAnthropic,
 				Models: []*types.LLM_Model{
 					{ProviderName: "claude-opus-4-8", Name: "claude-sonnet-4-20250514"},
 				},
-			},
+			}, nil /* appAWS */),
 			request: func() *http.Request {
 				r, _ := http.NewRequest(
 					http.MethodPost,
@@ -168,9 +186,10 @@ func TestNewRequest(t *testing.T) {
 			},
 		},
 		"exceeds max tokens": {
-			llm: &types.LLM{
+			llm: newApp(t, &types.LLM{
+				Format:   types.LLMFormatAnthropic,
 				Provider: types.LLMProviderAnthropic,
-			},
+			}, nil /* appAWS */),
 			request: func() *http.Request {
 				r, _ := http.NewRequest(
 					http.MethodPost,
@@ -188,9 +207,10 @@ func TestNewRequest(t *testing.T) {
 			},
 		},
 		"request exceeds max size": {
-			llm: &types.LLM{
+			llm: newApp(t, &types.LLM{
+				Format:   types.LLMFormatAnthropic,
 				Provider: types.LLMProviderAnthropic,
-			},
+			}, nil /* appAWS */),
 			request: func() *http.Request {
 				r, _ := http.NewRequest(
 					http.MethodPost,
@@ -210,9 +230,10 @@ func TestNewRequest(t *testing.T) {
 			},
 		},
 		"unsupported endpoint": {
-			llm: &types.LLM{
+			llm: newApp(t, &types.LLM{
+				Format:   types.LLMFormatAnthropic,
 				Provider: types.LLMProviderAnthropic,
-			},
+			}, nil /* appAWS */),
 			request: func() *http.Request {
 				r, _ := http.NewRequest(
 					http.MethodPost,
@@ -226,9 +247,136 @@ func TestNewRequest(t *testing.T) {
 			expectedInfo:    require.NotNil,
 		},
 		"unsupported method": {
-			llm: &types.LLM{
+			llm: newApp(t, &types.LLM{
+				Format:   types.LLMFormatAnthropic,
 				Provider: types.LLMProviderAnthropic,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodGet,
+					"/messages",
+					nil,
+				)
+				return r
 			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"bedrock successful messages": {
+			llm: newApp(t, &types.LLM{
+				Format:   types.LLMFormatAnthropic,
+				Provider: types.LLMProviderAWSBedrock,
+				Models: []*types.LLM_Model{
+					{ProviderName: "us.anthropic.claude-sonnet-4-20250514-v1:0", Name: "claude-sonnet-4-20250514"},
+				},
+			}, &types.AppAWS{
+				Region: "us-west-2",
+			}),
+			signAWSRequest: signAWSRequest,
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/messages",
+					strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"Hello"}]}`),
+				)
+				return r
+			},
+			expectedError: require.NoError,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				require.Equal(tt, "bedrock-mantle.us-west-2.api.aws", req.URL.Host)
+				require.Equal(tt, "/anthropic/v1/messages", req.URL.Path)
+				require.NotEmpty(tt, req.Header.Get("anthropic-version"))
+				require.NotEmpty(tt, req.Header.Get("content-type"))
+				require.Empty(tt, req.Header.Get("x-api-key"))
+				require.NotEmpty(tt, req.Header.Get("Authorization"))
+
+				body, err := io.ReadAll(req.Body)
+				require.NoError(tt, err)
+				require.Contains(tt, string(body), "us.anthropic.claude-sonnet-4-20250514-v1:0")
+				bodyHash := sha256.Sum256(body)
+				require.Equal(tt, hex.EncodeToString(bodyHash[:]), req.Header.Get("X-Amz-Content-Sha256"))
+			},
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Equal(tt, "claude-sonnet-4-20250514", info.RequestedModel())
+				require.Equal(tt, "us.anthropic.claude-sonnet-4-20250514-v1:0", info.ProviderModel())
+			},
+		},
+		"bedrock signer failure": {
+			llm: newApp(t, &types.LLM{
+				Format:   types.LLMFormatAnthropic,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{
+				Region: "us-west-2",
+			}),
+			signAWSRequest: func(ctx context.Context, a types.Application, r *http.Request, b []byte) error {
+				return errors.New("signing failed")
+			},
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/messages",
+					strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"Hello"}]}`),
+				)
+				return r
+			},
+			expectedError: func(tt require.TestingT, err error, i ...any) {
+				require.Error(tt, err)
+				// The signing failure cause must not reach clients.
+				require.NotContains(tt, err.Error(), "signing failed")
+			},
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"bedrock missing signer": {
+			llm: newApp(t, &types.LLM{
+				Format:   types.LLMFormatAnthropic,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{
+				Region: "us-west-2",
+			}),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/messages",
+					strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"Hello"}]}`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"bedrock unsupported endpoint": {
+			llm: newApp(t, &types.LLM{
+				Format:   types.LLMFormatAnthropic,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{
+				Region: "us-west-2",
+			}),
+			signAWSRequest: signAWSRequest,
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/complete",
+					strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"Hello"}]}`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"bedrock unsupported method": {
+			llm: newApp(t, &types.LLM{
+				Format:   types.LLMFormatAnthropic,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{
+				Region: "us-west-2",
+			}),
+			signAWSRequest: signAWSRequest,
 			request: func() *http.Request {
 				r, _ := http.NewRequest(
 					http.MethodGet,
@@ -244,17 +392,27 @@ func TestNewRequest(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			req, info, err := NewRequest(&llmrequest.Config{
-				LLM:               tc.llm,
+				App:               tc.llm,
 				DownstreamRequest: tc.request(),
 				GetAPIKeyFunc: func() string {
 					return apiKey
 				},
+				SignBedrockRequest: tc.signAWSRequest,
 			})
 			tc.expectedError(t, err)
 			tc.expectedRequest(t, req)
 			tc.expectedInfo(t, info)
 		})
 	}
+}
+
+func newApp(t *testing.T, llm *types.LLM, appAWS *types.AppAWS) types.Application {
+	app, err := types.NewAppV3(types.Metadata{Name: "llm-app"}, types.AppSpecV3{
+		LLM: llm,
+		AWS: appAWS,
+	})
+	require.NoError(t, err)
+	return app
 }
 
 // buildRequestBody returns a valid messages API request body whose total size
@@ -274,12 +432,16 @@ func buildRequestBody(fillerBytes int) []byte {
 func BenchmarkNewRequest(b *testing.B) {
 	// Maps the requested model to a provider model so the conversion path
 	// (the common case in production) is exercised.
-	llm := &types.LLM{
-		Provider: types.LLMProviderAnthropic,
-		Models: []*types.LLM_Model{
-			{ProviderName: "claude-opus-4-8", Name: "claude-sonnet-4-20250514"},
+	app, err := types.NewAppV3(types.Metadata{Name: "benchmark-app"}, types.AppSpecV3{
+		LLM: &types.LLM{
+			Format:   types.LLMFormatAnthropic,
+			Provider: types.LLMProviderAnthropic,
+			Models: []*types.LLM_Model{
+				{ProviderName: "claude-opus-4-8", Name: "claude-sonnet-4-20250514"},
+			},
 		},
-	}
+	})
+	require.NoError(b, err)
 
 	for _, bc := range []struct {
 		name string
@@ -301,7 +463,7 @@ func BenchmarkNewRequest(b *testing.B) {
 			for b.Loop() {
 				r.Body = io.NopCloser(bytes.NewReader(bc.body))
 				if _, _, err := NewRequest(&llmrequest.Config{
-					LLM:               llm,
+					App:               app,
 					DownstreamRequest: r,
 					GetAPIKeyFunc:     func() string { return "" },
 				}); err != nil {

--- a/lib/srv/app/llm/anthropic/anthropic_test.go
+++ b/lib/srv/app/llm/anthropic/anthropic_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
+	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
 )
 
 func TestNewRequest(t *testing.T) {
@@ -242,7 +243,7 @@ func TestNewRequest(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			req, info, err := NewRequest(&NewRequestConfig{
+			req, info, err := NewRequest(&llmrequest.Config{
 				LLM:               tc.llm,
 				DownstreamRequest: tc.request(),
 				GetAPIKeyFunc: func() string {
@@ -299,7 +300,7 @@ func BenchmarkNewRequest(b *testing.B) {
 
 			for b.Loop() {
 				r.Body = io.NopCloser(bytes.NewReader(bc.body))
-				if _, _, err := NewRequest(&NewRequestConfig{
+				if _, _, err := NewRequest(&llmrequest.Config{
 					LLM:               llm,
 					DownstreamRequest: r,
 					GetAPIKeyFunc:     func() string { return "" },

--- a/lib/srv/app/llm/anthropic/anthropic_test.go
+++ b/lib/srv/app/llm/anthropic/anthropic_test.go
@@ -1,0 +1,312 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package anthropic
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestNewRequest(t *testing.T) {
+	apiKey := "random-api-key"
+
+	for name, tc := range map[string]struct {
+		llm             *types.LLM
+		request         func() *http.Request
+		expectedError   require.ErrorAssertionFunc
+		expectedRequest require.ValueAssertionFunc
+		expectedInfo    require.ValueAssertionFunc
+	}{
+		"successful messages": {
+			llm: &types.LLM{
+				Provider: types.LLMProviderAnthropic,
+			},
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/messages",
+					strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"Hello"}]}`),
+				)
+				return r
+			},
+			expectedError: require.NoError,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				require.Equal(tt, "/v1/messages", req.URL.Path)
+				require.Equal(tt, "api.anthropic.com", req.URL.Host)
+				require.Equal(tt, apiKey, req.Header.Get("x-api-key"))
+				require.NotEmpty(tt, req.Header.Get("anthropic-version"))
+				require.NotEmpty(tt, req.Header.Get("content-type"))
+			},
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Equal(tt, "claude-sonnet-4-20250514", info.RequestedModel())
+				require.Equal(tt, "claude-sonnet-4-20250514", info.ProviderModel())
+			},
+		},
+		"includes single /v1 prefix": {
+			llm: &types.LLM{
+				Provider: types.LLMProviderAnthropic,
+			},
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/v1/messages",
+					strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"Hello"}]}`),
+				)
+				return r
+			},
+			expectedError: require.NoError,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				require.Equal(tt, "/v1/messages", req.URL.Path)
+			},
+			expectedInfo: require.NotNil,
+		},
+		"convert model name": {
+			llm: &types.LLM{
+				Provider: types.LLMProviderAnthropic,
+				Models: []*types.LLM_Model{
+					{ProviderName: "claude-opus-4-8", Name: "claude-sonnet-4-20250514"},
+				},
+			},
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/messages",
+					strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"Hello"}]}`),
+				)
+				return r
+			},
+			expectedError: require.NoError,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				body, err := io.ReadAll(req.Body)
+				require.NoError(tt, err)
+				require.Contains(tt, string(body), "claude-opus-4-8")
+			},
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Equal(tt, "claude-sonnet-4-20250514", info.RequestedModel())
+				require.Equal(tt, "claude-opus-4-8", info.ProviderModel())
+			},
+		},
+		"fallback model name": {
+			llm: &types.LLM{
+				Provider: types.LLMProviderAnthropic,
+				Models: []*types.LLM_Model{
+					{ProviderName: "claude-opus-4-8", Name: "claude-sonnet-4-20250514"},
+				},
+				FallbackModel: "claude-sonnet-4-20250514",
+			},
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/messages",
+					strings.NewReader(`{"model":"claude-haiku-4-20250514","messages":[{"role":"user","content":"Hello"}]}`),
+				)
+				return r
+			},
+			expectedError: require.NoError,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				body, err := io.ReadAll(req.Body)
+				require.NoError(tt, err)
+				require.Contains(tt, string(body), "claude-opus-4-8")
+			},
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Equal(tt, "claude-haiku-4-20250514", info.RequestedModel())
+				require.Equal(tt, "claude-opus-4-8", info.ProviderModel())
+			},
+		},
+		"unsupported model name": {
+			llm: &types.LLM{
+				Provider: types.LLMProviderAnthropic,
+				Models: []*types.LLM_Model{
+					{ProviderName: "claude-opus-4-8", Name: "claude-sonnet-4-20250514"},
+				},
+			},
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/messages",
+					strings.NewReader(`{"model":"claude-haiku-4-20250514","messages":[{"role":"user","content":"Hello"}]}`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Equal(tt, "claude-haiku-4-20250514", info.RequestedModel())
+				require.Empty(tt, info.ProviderModel())
+			},
+		},
+		"exceeds max tokens": {
+			llm: &types.LLM{
+				Provider: types.LLMProviderAnthropic,
+			},
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/messages",
+					strings.NewReader(`{"model":"claude-sonnet-4-20250514", "max_tokens": 99999,"messages":[{"role":"user","content":"Hello"}]}`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Equal(tt, "claude-sonnet-4-20250514", info.RequestedModel())
+				require.Equal(tt, "claude-sonnet-4-20250514", info.ProviderModel())
+			},
+		},
+		"request exceeds max size": {
+			llm: &types.LLM{
+				Provider: types.LLMProviderAnthropic,
+			},
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/messages",
+					strings.NewReader(
+						`{"model":"claude-sonnet-4-20250514", "max_tokens": 1024,"messages":[{"role":"user","content":"`+strings.Repeat("a", teleport.MaxHTTPRequestSize)+`"}]}`,
+					),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Empty(tt, info.RequestedModel())
+				require.Empty(tt, info.ProviderModel())
+			},
+		},
+		"unsupported endpoint": {
+			llm: &types.LLM{
+				Provider: types.LLMProviderAnthropic,
+			},
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/complete",
+					strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"Hello"}]}`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"unsupported method": {
+			llm: &types.LLM{
+				Provider: types.LLMProviderAnthropic,
+			},
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodGet,
+					"/messages",
+					nil,
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			req, info, err := NewRequest(&NewRequestConfig{
+				LLM:               tc.llm,
+				DownstreamRequest: tc.request(),
+				GetAPIKeyFunc: func() string {
+					return apiKey
+				},
+			})
+			tc.expectedError(t, err)
+			tc.expectedRequest(t, req)
+			tc.expectedInfo(t, info)
+		})
+	}
+}
+
+// buildRequestBody returns a valid messages API request body whose total size
+// is roughly fillerBytes.
+func buildRequestBody(fillerBytes int) []byte {
+	content := strings.Repeat("A", fillerBytes)
+	return fmt.Appendf(nil,
+		`{"model":"claude-sonnet-4-20250514","max_tokens":1024,"stream":false,"messages":[{"role":"user","content":%q}]}`,
+		content,
+	)
+}
+
+// BenchmarkNewRequest tracks the cost of the downstream request "parsing" and
+// generation of the provider request, across different body sizes.
+//
+//	go test ./lib/srv/app/llm/anthropic/ -run '^$' -bench BenchmarkNewRequest -benchmem
+func BenchmarkNewRequest(b *testing.B) {
+	// Maps the requested model to a provider model so the conversion path
+	// (the common case in production) is exercised.
+	llm := &types.LLM{
+		Provider: types.LLMProviderAnthropic,
+		Models: []*types.LLM_Model{
+			{ProviderName: "claude-opus-4-8", Name: "claude-sonnet-4-20250514"},
+		},
+	}
+
+	for _, bc := range []struct {
+		name string
+		body []byte
+	}{
+		{"small_chat", buildRequestBody(16)},
+		{"medium_32KB", buildRequestBody(32 * 1024)},
+		{"large_1MB", buildRequestBody(1024 * 1024)},
+		{"xlarge_8MB", buildRequestBody(8 * 1024 * 1024)},
+	} {
+		b.Run(bc.name, func(b *testing.B) {
+			// Reuse a single request and only reset the body each iteration.
+			r, err := http.NewRequest(http.MethodPost, "/messages", nil)
+			require.NoError(b, err)
+
+			b.SetBytes(int64(len(bc.body)))
+			b.ReportAllocs()
+
+			for b.Loop() {
+				r.Body = io.NopCloser(bytes.NewReader(bc.body))
+				if _, _, err := NewRequest(&NewRequestConfig{
+					LLM:               llm,
+					DownstreamRequest: r,
+					GetAPIKeyFunc:     func() string { return "" },
+				}); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/lib/srv/app/llm/anthropic/recorder.go
+++ b/lib/srv/app/llm/anthropic/recorder.go
@@ -17,255 +17,50 @@
 package anthropic
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"log/slog"
-	"mime"
 	"net/http"
-	"sync"
-	"sync/atomic"
 
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/lib/httplib/sse"
 	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+	llmrecorder "github.com/gravitational/teleport/lib/srv/app/llm/recorder"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-// ResponseRecorder is the Anthropic's response modifier and recorder.
-type ResponseRecorder struct {
-	http.ResponseWriter
-	flusher http.Flusher
-
-	log          *slog.Logger
-	status       int
-	written      int
-	containsErr  bool
-	err          error
-	responseType func() string
-	closed       atomic.Bool
-
-	// usage-related fields
-	inputTokensCount  int
-	outputTokensCount int
-
-	// used for non-streaming requests.
-	writer io.Writer
-	buf    *bytes.Buffer
-
-	// used for streaming requests.
-	startSSEOnce sync.Once
-	streamDoneCh chan struct{}
-	sseWriter    io.WriteCloser
-
-	// This values is guarded as atomic values since `Flush` calls may happen
-	// from different goroutines.
-	skipFlush atomic.Bool
+// NewResponseRecorder creates a new Anthropic response recorder.
+func NewResponseRecorder(log *slog.Logger, w http.ResponseWriter) (*llmrecorder.ResponseRecorder, error) {
+	return llmrecorder.NewResponseRecorder(log, w, Endpoint{})
 }
 
-// NewResponseRecorder creates a new response recorder.
-func NewResponseRecorder(log *slog.Logger, w http.ResponseWriter) (*ResponseRecorder, error) {
-	f, ok := w.(http.Flusher)
-	if !ok {
-		return nil, trace.BadParameter("response writer must be flusher")
-	}
-	r := &ResponseRecorder{
-		ResponseWriter: w,
-		// Defaults to 200, this matches the [http.ResponseWriter] expectation when
-		// [WriteHeader] is not called.
-		status:  http.StatusOK,
-		flusher: f,
-		log:     log,
-		buf:     new(bytes.Buffer),
-	}
-	r.writer = io.MultiWriter(w, r.buf)
-	r.responseType = sync.OnceValue(func() string {
-		mediaType, _, err := mime.ParseMediaType(w.Header().Get("Content-Type"))
-		if err != nil {
-			// No need to log the error here, the caller of this function will
-			// do the proper handling of this case (including logs).
-			return ""
-		}
-		return mediaType
-	})
-	return r, nil
+// Endpoint implements [llmrecorder.Endpoint] for the Anthropic messages API.
+type Endpoint struct{}
+
+// ParseError implements [llmrecorder.Endpoint]. The Anthropic API presents
+// errors in the body, so the status code is ignored.
+func (Endpoint) ParseError(_ int, body []byte) (*llmerrors.ProviderError, error) {
+	return parseProviderError(body)
 }
 
-// WriteHeader implements [http.ResponseWriter].
-func (r *ResponseRecorder) WriteHeader(status int) {
-	// In case of errors or response type not JSON, we delete the original
-	// Content-Length because we might rewrite the result contents, changing the
-	// total length.
-	contentType := r.responseType()
-	if status != http.StatusOK || contentType != "application/json" {
-		r.Header().Del("Content-Length")
-	}
-
-	// When the result is an unsupported content-type we set as error
-	// here since it might not contain a body (resulting in no [Write] calls).
-	//
-	// In addition, we "force" an error status code. This is done to keep the
-	// API contract where errors return only when status code is not 200.
-	if contentType != "application/json" && contentType != "text/event-stream" {
-		status = http.StatusInternalServerError
-		r.log.ErrorContext(context.Background(), "unsupported response content-type", "content_type", contentType)
-		r.err = llmerrors.NewProviderError(llmerrors.ErrBadResponse, "unsupported %q response type", contentType)
-	}
-	if status != http.StatusOK {
-		r.containsErr = true
-	}
-	r.status = status
-	r.ResponseWriter.WriteHeader(status)
+// MarshalError implements [llmrecorder.Endpoint].
+func (Endpoint) MarshalError(err error) []byte {
+	return marshalError(newErrorMessage(err))
 }
 
-// Writer implements [http.ResponseWriter].
-func (r *ResponseRecorder) Write(data []byte) (int, error) {
-	if r.status != http.StatusOK {
-		// Necessary because [WriteHeader] might not have been called before
-		// [Write].
-		r.containsErr = true
-		return r.writeError(data)
-	}
-
-	contentType := r.responseType()
-	switch contentType {
-	case "application/json":
-		n, err := r.writer.Write(data)
-		r.written += n
-		return n, trace.Wrap(err)
-	case "text/event-stream":
-		return r.writeStream(data)
-	default:
-		// This handling exists because callers are not guaranteed to call
-		// [WriteHeader]. So we must mimic the behavior here in case it wasn't
-		// called before.
-		//
-		// Note that at this point, we cannot change the status code returned,
-		// but we'll still return an error object here.
-		if !r.containsErr {
-			r.log.ErrorContext(context.Background(), "unsupported response content-type", "content_type", contentType)
-			r.err = llmerrors.NewProviderError(llmerrors.ErrBadResponse, "unsupported %q response type", contentType)
-			r.containsErr = true
-		}
-		return len(data), nil
-	}
-}
-
-// Flush implements [http.Flusher].
-func (r *ResponseRecorder) Flush() {
-	if r.skipFlush.Load() {
-		return
-	}
-
-	if r.flusher != nil {
-		r.flusher.Flush()
-	}
-}
-
-// Written is the number of bytes written in the downstream connection.
-//
-// Must be called after [Close].
-func (r *ResponseRecorder) Written() int {
-	return r.written
-}
-
-// Err is the error encountered while processing/forwarding the response.
-//
-// Must be called after [Close].
-func (r *ResponseRecorder) Err() error {
-	return r.err
-}
-
-// InputTokensCount is the number of input tokens that were used on the request.
-//
-// Must be called after [Close].
-func (r *ResponseRecorder) InputTokensCount() int {
-	return r.inputTokensCount
-}
-
-// OutputTokensCount is the number of output tokens generated by the request.
-//
-// Must be called after [Close].
-func (r *ResponseRecorder) OutputTokensCount() int {
-	return r.outputTokensCount
-}
-
-// Close implements [io.Closer]. Errors returned are only related to the
-// recorder teardown. For processing errors, callers must retrieve errors using
-// [Err].
-//
-// Must be called once.
-func (r *ResponseRecorder) Close() error {
-	if r.closed.Swap(true) {
-		return nil
-	}
-
-	// In case the response contains an error, this is the place where we write
-	// it back to the upstream.
-	if r.containsErr {
-		// Error might already be defined, so we can skip parsing it.
-		if r.err == nil {
-			var err error
-			r.err, err = parseProviderError(r.buf.Bytes())
-			// Failure here could indicate that the message is incomplete or
-			// that it is malformed.
-			if err != nil {
-				r.log.WarnContext(context.Background(), "unable to parse the provider error message", "error", err)
-				r.err = llmerrors.NewProviderError(llmerrors.ErrBadResponse, "invalid JSON response")
-			}
-		}
-
-		encodedErr := marshalError(newErrorMessage(r.err))
-		r.written += len(encodedErr)
-		if _, err := r.ResponseWriter.Write(encodedErr); err != nil {
-			r.log.WarnContext(context.Background(), "unable to write error message to downstream", "error", err)
-		}
-	}
-
-	if r.sseWriter != nil {
-		err := r.sseWriter.Close()
-		<-r.streamDoneCh
-		return trace.Wrap(err)
-	}
-
-	// When request contains error, it won't contain usage information, so we
-	// can skip it.
-	if r.containsErr {
-		return nil
-	}
-
-	// Non-streaming requests we must try to extract result metrics at the end.
+// ParseUsage implements [llmrecorder.Endpoint].
+func (Endpoint) ParseUsage(body []byte) (int, int, error) {
 	var result messagesAPIResult
-	err := utils.FastUnmarshal(r.buf.Bytes(), &result)
-	if err != nil {
-		r.log.WarnContext(context.Background(), "unable to parse messages result", "error", err)
-		r.err = llmerrors.NewProviderError(llmerrors.ErrBadResponse, "invalid JSON response")
-		return nil
+	if err := utils.FastUnmarshal(body, &result); err != nil {
+		return 0, 0, trace.Wrap(err)
 	}
-
-	r.inputTokensCount = result.Usage.InputTokens
-	r.outputTokensCount = result.Usage.OutputTokens
-	return nil
+	return result.Usage.InputTokens, result.Usage.OutputTokens, nil
 }
 
-func (r *ResponseRecorder) writeStream(data []byte) (int, error) {
-	// first write should initialize the pipe and start the read events
-	// goroutine.
-	r.startSSEOnce.Do(func() {
-		pr, pw := io.Pipe()
-		r.sseWriter = pw
-		r.streamDoneCh = make(chan struct{})
-		r.skipFlush.Store(true)
-		go func() {
-			defer close(r.streamDoneCh)
-			w := &writeFlusher{writer: r.ResponseWriter, flushFunc: r.flusher.Flush}
-			r.inputTokensCount, r.outputTokensCount, r.err = processSSEEvents(context.Background(), r.log, pr, w)
-			r.written = w.written
-		}()
-	})
-
-	return r.sseWriter.Write(data)
+// ProcessSSE implements [llmrecorder.Endpoint].
+func (Endpoint) ProcessSSE(ctx context.Context, log *slog.Logger, r io.ReadCloser, w io.Writer) (int, int, error) {
+	return processSSEEvents(ctx, log, r, w)
 }
 
 func processSSEEvents(ctx context.Context, log *slog.Logger, r io.ReadCloser, w io.Writer) (int, int, error) {
@@ -330,34 +125,4 @@ func processSSEEvents(ctx context.Context, log *slog.Logger, r io.ReadCloser, w 
 	}
 
 	return inputTokensCount, outputTokensCount, nil
-}
-
-func (r *ResponseRecorder) writeError(data []byte) (int, error) {
-	// Collect the error, but do not immediately forward it as we might need
-	// to perform modifications to it.
-	n, err := r.buf.Write(data)
-	if err != nil {
-		return 0, trace.Wrap(err)
-	}
-
-	// We might not write the error data as is, but we should return the
-	// original written value for writter that double check the total amount of
-	// data written.
-	return n, nil
-}
-
-type writeFlusher struct {
-	written   int
-	writer    io.Writer
-	flushFunc func()
-}
-
-func (w *writeFlusher) Write(data []byte) (int, error) {
-	n, err := w.writer.Write(data)
-	if err != nil {
-		return 0, trace.Wrap(err)
-	}
-	w.written += n
-	w.flushFunc()
-	return n, nil
 }

--- a/lib/srv/app/llm/anthropic/recorder.go
+++ b/lib/srv/app/llm/anthropic/recorder.go
@@ -1,0 +1,363 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package anthropic
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"mime"
+	"net/http"
+	"sync"
+	"sync/atomic"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/httplib/sse"
+	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// ResponseRecorder is the Anthropic's response modifier and recorder.
+type ResponseRecorder struct {
+	http.ResponseWriter
+	flusher http.Flusher
+
+	log          *slog.Logger
+	status       int
+	written      int
+	containsErr  bool
+	err          error
+	responseType func() string
+	closed       atomic.Bool
+
+	// usage-related fields
+	inputTokensCount  int
+	outputTokensCount int
+
+	// used for non-streaming requests.
+	writer io.Writer
+	buf    *bytes.Buffer
+
+	// used for streaming requests.
+	startSSEOnce sync.Once
+	streamDoneCh chan struct{}
+	sseWriter    io.WriteCloser
+
+	// This values is guarded as atomic values since `Flush` calls may happen
+	// from different goroutines.
+	skipFlush atomic.Bool
+}
+
+// NewResponseRecorder creates a new response recorder.
+func NewResponseRecorder(log *slog.Logger, w http.ResponseWriter) (*ResponseRecorder, error) {
+	f, ok := w.(http.Flusher)
+	if !ok {
+		return nil, trace.BadParameter("response writer must be flusher")
+	}
+	r := &ResponseRecorder{
+		ResponseWriter: w,
+		// Defaults to 200, this matches the [http.ResponseWriter] expectation when
+		// [WriteHeader] is not called.
+		status:  http.StatusOK,
+		flusher: f,
+		log:     log,
+		buf:     new(bytes.Buffer),
+	}
+	r.writer = io.MultiWriter(w, r.buf)
+	r.responseType = sync.OnceValue(func() string {
+		mediaType, _, err := mime.ParseMediaType(w.Header().Get("Content-Type"))
+		if err != nil {
+			// No need to log the error here, the caller of this function will
+			// do the proper handling of this case (including logs).
+			return ""
+		}
+		return mediaType
+	})
+	return r, nil
+}
+
+// WriteHeader implements [http.ResponseWriter].
+func (r *ResponseRecorder) WriteHeader(status int) {
+	// In case of errors or response type not JSON, we delete the original
+	// Content-Length because we might rewrite the result contents, changing the
+	// total length.
+	contentType := r.responseType()
+	if status != http.StatusOK || contentType != "application/json" {
+		r.Header().Del("Content-Length")
+	}
+
+	// When the result is an unsupported content-type we set as error
+	// here since it might not contain a body (resulting in no [Write] calls).
+	//
+	// In addition, we "force" an error status code. This is done to keep the
+	// API contract where errors return only when status code is not 200.
+	if contentType != "application/json" && contentType != "text/event-stream" {
+		status = http.StatusInternalServerError
+		r.log.ErrorContext(context.Background(), "unsupported response content-type", "content_type", contentType)
+		r.err = llmerrors.NewProviderError(llmerrors.ErrBadResponse, "unsupported %q response type", contentType)
+	}
+	if status != http.StatusOK {
+		r.containsErr = true
+	}
+	r.status = status
+	r.ResponseWriter.WriteHeader(status)
+}
+
+// Writer implements [http.ResponseWriter].
+func (r *ResponseRecorder) Write(data []byte) (int, error) {
+	if r.status != http.StatusOK {
+		// Necessary because [WriteHeader] might not have been called before
+		// [Write].
+		r.containsErr = true
+		return r.writeError(data)
+	}
+
+	contentType := r.responseType()
+	switch contentType {
+	case "application/json":
+		n, err := r.writer.Write(data)
+		r.written += n
+		return n, trace.Wrap(err)
+	case "text/event-stream":
+		return r.writeStream(data)
+	default:
+		// This handling exists because callers are not guaranteed to call
+		// [WriteHeader]. So we must mimic the behavior here in case it wasn't
+		// called before.
+		//
+		// Note that at this point, we cannot change the status code returned,
+		// but we'll still return an error object here.
+		if !r.containsErr {
+			r.log.ErrorContext(context.Background(), "unsupported response content-type", "content_type", contentType)
+			r.err = llmerrors.NewProviderError(llmerrors.ErrBadResponse, "unsupported %q response type", contentType)
+			r.containsErr = true
+		}
+		return len(data), nil
+	}
+}
+
+// Flush implements [http.Flusher].
+func (r *ResponseRecorder) Flush() {
+	if r.skipFlush.Load() {
+		return
+	}
+
+	if r.flusher != nil {
+		r.flusher.Flush()
+	}
+}
+
+// Written is the number of bytes written in the downstream connection.
+//
+// Must be called after [Close].
+func (r *ResponseRecorder) Written() int {
+	return r.written
+}
+
+// Err is the error encountered while processing/forwarding the response.
+//
+// Must be called after [Close].
+func (r *ResponseRecorder) Err() error {
+	return r.err
+}
+
+// InputTokensCount is the number of input tokens that were used on the request.
+//
+// Must be called after [Close].
+func (r *ResponseRecorder) InputTokensCount() int {
+	return r.inputTokensCount
+}
+
+// OutputTokensCount is the number of output tokens generated by the request.
+//
+// Must be called after [Close].
+func (r *ResponseRecorder) OutputTokensCount() int {
+	return r.outputTokensCount
+}
+
+// Close implements [io.Closer]. Errors returned are only related to the
+// recorder teardown. For processing errors, callers must retrieve errors using
+// [Err].
+//
+// Must be called once.
+func (r *ResponseRecorder) Close() error {
+	if r.closed.Swap(true) {
+		return nil
+	}
+
+	// In case the response contains an error, this is the place where we write
+	// it back to the upstream.
+	if r.containsErr {
+		// Error might already be defined, so we can skip parsing it.
+		if r.err == nil {
+			var err error
+			r.err, err = parseProviderError(r.buf.Bytes())
+			// Failure here could indicate that the message is incomplete or
+			// that it is malformed.
+			if err != nil {
+				r.log.WarnContext(context.Background(), "unable to parse the provider error message", "error", err)
+				r.err = llmerrors.NewProviderError(llmerrors.ErrBadResponse, "invalid JSON response")
+			}
+		}
+
+		encodedErr := marshalError(newErrorMessage(r.err))
+		r.written += len(encodedErr)
+		if _, err := r.ResponseWriter.Write(encodedErr); err != nil {
+			r.log.WarnContext(context.Background(), "unable to write error message to downstream", "error", err)
+		}
+	}
+
+	if r.sseWriter != nil {
+		err := r.sseWriter.Close()
+		<-r.streamDoneCh
+		return trace.Wrap(err)
+	}
+
+	// When request contains error, it won't contain usage information, so we
+	// can skip it.
+	if r.containsErr {
+		return nil
+	}
+
+	// Non-streaming requests we must try to extract result metrics at the end.
+	var result messagesAPIResult
+	err := utils.FastUnmarshal(r.buf.Bytes(), &result)
+	if err != nil {
+		r.log.WarnContext(context.Background(), "unable to parse messages result", "error", err)
+		r.err = llmerrors.NewProviderError(llmerrors.ErrBadResponse, "invalid JSON response")
+		return nil
+	}
+
+	r.inputTokensCount = result.Usage.InputTokens
+	r.outputTokensCount = result.Usage.OutputTokens
+	return nil
+}
+
+func (r *ResponseRecorder) writeStream(data []byte) (int, error) {
+	// first write should initialize the pipe and start the read events
+	// goroutine.
+	r.startSSEOnce.Do(func() {
+		pr, pw := io.Pipe()
+		r.sseWriter = pw
+		r.streamDoneCh = make(chan struct{})
+		r.skipFlush.Store(true)
+		go func() {
+			defer close(r.streamDoneCh)
+			w := &writeFlusher{writer: r.ResponseWriter, flushFunc: r.flusher.Flush}
+			r.inputTokensCount, r.outputTokensCount, r.err = processSSEEvents(context.Background(), r.log, pr, w)
+			r.written = w.written
+		}()
+	})
+
+	return r.sseWriter.Write(data)
+}
+
+func processSSEEvents(ctx context.Context, log *slog.Logger, r io.ReadCloser, w io.Writer) (int, int, error) {
+	defer r.Close()
+
+	var (
+		inputTokensCount  int
+		outputTokensCount int
+	)
+	for event, err := range sse.ReadEvents(r) {
+		if err != nil {
+			return inputTokensCount, outputTokensCount, trace.Wrap(err)
+		}
+
+		switch event.Event {
+		case "error":
+			apiErr, parseErr := parseProviderError(event.Data)
+			if parseErr == nil {
+				if _, err := sse.WriteEvent(w, sse.Event{Event: "error", Data: marshalError(newErrorMessage(apiErr))}); err != nil {
+					// Preserve the provider error for recorder Err(). A failed
+					// downstream write here often means the client canceled or
+					// timed out after the provider had already rejected the
+					// request.
+					log.ErrorContext(ctx, "failed to write error event", "error", err)
+				}
+				return inputTokensCount, outputTokensCount, apiErr
+			}
+			log.ErrorContext(ctx, "failed to parse error event", "error", parseErr)
+			if _, err := sse.WriteEvent(w, sse.Event{Event: "error", Data: marshalError(newErrorMessage(llmerrors.ErrBadResponse))}); err != nil {
+				// Preserve the provider response for recorder Err().
+				// Downstream delivery failure is a secondary transport
+				// condition here.
+				log.ErrorContext(ctx, "failed to write error event", "error", err)
+			}
+			return inputTokensCount, outputTokensCount, llmerrors.ErrBadResponse
+		case "message_start":
+			// This event will include the input tokens information.
+			//
+			// https://platform.claude.com/docs/en/api/messages/create#raw_message_start_event
+			var d sseMessageStartEvent
+			if err := utils.FastUnmarshal(event.Data, &d); err != nil {
+				log.ErrorContext(ctx, "failed to parse message_start event", "error", err)
+				continue
+			}
+			inputTokensCount = d.Message.Usage.InputTokens
+		case "message_delta":
+			// Message delta progressively sends the accumulative output tokens
+			// information.
+			//
+			// https://platform.claude.com/docs/en/api/messages/create#raw_message_delta_event
+			var d messagesAPIResult
+			if err := utils.FastUnmarshal(event.Data, &d); err != nil {
+				log.ErrorContext(ctx, "failed to parse message_delta event", "error", err)
+				continue
+			}
+			outputTokensCount = d.Usage.OutputTokens
+		}
+
+		if _, err := sse.WriteEvent(w, event); err != nil {
+			return inputTokensCount, outputTokensCount, trace.Wrap(err)
+		}
+	}
+
+	return inputTokensCount, outputTokensCount, nil
+}
+
+func (r *ResponseRecorder) writeError(data []byte) (int, error) {
+	// Collect the error, but do not immediately forward it as we might need
+	// to perform modifications to it.
+	n, err := r.buf.Write(data)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+
+	// We might not write the error data as is, but we should return the
+	// original written value for writter that double check the total amount of
+	// data written.
+	return n, nil
+}
+
+type writeFlusher struct {
+	written   int
+	writer    io.Writer
+	flushFunc func()
+}
+
+func (w *writeFlusher) Write(data []byte) (int, error) {
+	n, err := w.writer.Write(data)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+	w.written += n
+	w.flushFunc()
+	return n, nil
+}

--- a/lib/srv/app/llm/anthropic/recorder_test.go
+++ b/lib/srv/app/llm/anthropic/recorder_test.go
@@ -17,418 +17,199 @@
 package anthropic
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
-	"net/http/httptest"
-	"slices"
-	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/lib/httplib/sse"
-	"github.com/gravitational/teleport/lib/itertools/stream"
 	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+	llmtesting "github.com/gravitational/teleport/lib/srv/app/llm/testing"
 )
 
-func TestHandleNonStreaming(t *testing.T) {
-	expectStatus := func(statusCode int) require.ValueAssertionFunc {
-		return func(tt require.TestingT, i1 any, i2 ...any) {
-			require.Equal(tt, statusCode, i1, i2...)
-		}
-	}
+// successStream is a valid messages API SSE stream. Input tokens are reported
+// on message_start and output tokens on message_delta.
+var successStream = strings.Join([]string{
+	"event: message_start\n" + `data: {"type":"message_start","message":{"id":"msg_123","type":"message","content":[],"usage":{"input_tokens":15}}}`,
+	"event: content_block_start\n" + `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"Hello"}}`,
+	"event: message_delta\n" + `data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":15,"output_tokens":60}}`,
+	"event: message_stop",
+}, "\n\n")
 
-	expectContentLength := func(length int) require.ValueAssertionFunc {
-		return func(tt require.TestingT, i1 any, i2 ...any) {
-			contentLength, err := strconv.Atoi(i1.(string))
-			require.NoError(tt, err, "expected content length to not be empty")
-			require.Equal(tt, length, contentLength, i2...)
-		}
-	}
-
-	const successResponse = `{"id":"msg_123","type":"message","content":[{"type":"text","text":"Hello"}],"usage":{"input_tokens":15, "output_tokens": 20}}`
+// TestParseProviderError covers the Anthropic error type to Teleport error
+// mapping.
+func TestParseProviderError(t *testing.T) {
+	t.Parallel()
 
 	for name, tc := range map[string]struct {
-		providerStatusCode           int
-		providerBody                 string
-		providerContentType          string
-		expectedDownstreamBody       require.ValueAssertionFunc
-		expectedDownstreamStatusCode require.ValueAssertionFunc
-		expectedContentLength        require.ValueAssertionFunc
-		expectedRecorder             require.ValueAssertionFunc
+		body        string
+		expectedErr error
 	}{
-		"success": {
-			providerStatusCode:  http.StatusOK,
-			providerBody:        successResponse,
-			providerContentType: "application/json",
-			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
-				body, _ := i1.(string)
-				// Expect unmodified response.
-				require.Equal(tt, successResponse, body, i2...)
-			},
-			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
-			// Expect content length equal to the original message.
-			expectedContentLength: expectContentLength(len(successResponse)),
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.Equal(tt, len(successResponse), rec.Written())
-				require.Equal(tt, 15, rec.InputTokensCount(), i2...)
-				require.Equal(tt, 20, rec.OutputTokensCount(), i2...)
-				require.NoError(tt, rec.Err(), i2...)
-			},
-		},
-		"non-json response": {
-			providerStatusCode:  http.StatusOK,
-			providerBody:        "Non-JSON result",
-			providerContentType: "text/html",
-			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
-				body, _ := i1.(string)
-				var apiErr errorEnvelope
-				require.NoError(tt, json.Unmarshal([]byte(body), &apiErr), "expected message to be in JSON format")
-				require.Contains(tt, apiErr.Error.Message, llmerrors.ErrBadResponse.Error(), "expected error response to include Teleport message")
-				require.Contains(tt, apiErr.Error.Message, `unsupported "text/html" response type`, "expected error response to include the unsupported content-type detail")
-			},
-			expectedDownstreamStatusCode: expectStatus(http.StatusInternalServerError),
-			// In case of errors, we always expect empty Content-Length.
-			expectedContentLength: require.Empty,
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.NotEmpty(tt, rec.Written(), i2...)
-				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
-			},
-		},
-		"api invalid request includes original message": {
-			providerStatusCode:  http.StatusBadRequest,
-			providerBody:        `{"error":{"type":"invalid_request_error","message":"invalid model"}}`,
-			providerContentType: "application/json",
-			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
-				body, _ := i1.(string)
-				var apiErr errorEnvelope
-				require.NoError(tt, json.Unmarshal([]byte(body), &apiErr), "expected message to be in JSON format")
-				require.Contains(tt, apiErr.Error.Message, "invalid model", "expected error response to include original message")
-				require.Contains(tt, apiErr.Error.Message, llmerrors.ErrBadRequest.Error(), "expected error response to include Teleport message")
-			},
-			expectedDownstreamStatusCode: expectStatus(http.StatusBadRequest),
-			// In case of errors, we always expect empty Content-Length.
-			expectedContentLength: require.Empty,
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.NotEmpty(tt, rec.Written(), i2...)
-				require.Equal(tt, 0, rec.OutputTokensCount(), i2...)
-				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadRequest, i2...)
-			},
-		},
-		"auth error 401 rewrites message": {
-			providerStatusCode:  http.StatusUnauthorized,
-			providerBody:        `{"error":{"type":"authentication_error","message":"original provider secret"}}`,
-			providerContentType: "application/json",
-			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
-				body, _ := i1.(string)
-				var apiErr errorEnvelope
-				require.NoError(tt, json.Unmarshal([]byte(body), &apiErr), "expected message to be in JSON format")
-				require.NotContains(tt, body, "original provider secret", "expected error response to NOT include original message")
-				require.Contains(tt, apiErr.Error.Message, llmerrors.ErrUnauthorized.Error(), "expected error response to include Teleport message")
-			},
-			expectedDownstreamStatusCode: expectStatus(http.StatusUnauthorized),
-			// In case of errors, we always expect empty Content-Length.
-			expectedContentLength: require.Empty,
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.NotEmpty(tt, rec.Written(), i2...)
-				require.ErrorIs(tt, rec.Err(), llmerrors.ErrUnauthorized, i2...)
-			},
-		},
-		"empty success response": {
-			providerStatusCode:           http.StatusOK,
-			providerBody:                 "",
-			providerContentType:          "application/json",
-			expectedDownstreamBody:       require.Empty,
-			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
-			expectedContentLength:        expectContentLength(0),
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.Empty(tt, rec.Written(), i2...)
-				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
-			},
-		},
-		"empty error response": {
-			providerStatusCode:  http.StatusUnauthorized,
-			providerBody:        "",
-			providerContentType: "application/json",
-			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
-				body, _ := i1.(string)
-				var apiErr errorEnvelope
-				require.NoError(tt, json.Unmarshal([]byte(body), &apiErr), "expected message to be in JSON format")
-				require.Contains(tt, apiErr.Error.Message, llmerrors.ErrBadResponse.Error(), "expected error response to include Teleport message")
-				require.Contains(tt, apiErr.Error.Message, "invalid JSON response", "expected error response to include the unparseable-body detail")
-			},
-			expectedDownstreamStatusCode: expectStatus(http.StatusUnauthorized),
-			expectedContentLength:        require.Empty,
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.NotEmpty(tt, rec.Written(), i2...)
-				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+		"timeout":         {`{"error":{"type":"timeout_error","message":"slow"}}`, llmerrors.ErrTimeout},
+		"invalid request": {`{"error":{"type":"invalid_request_error","message":"bad"}}`, llmerrors.ErrBadRequest},
+		"authentication":  {`{"error":{"type":"authentication_error","message":"nope"}}`, llmerrors.ErrUnauthorized},
+		"permission":      {`{"error":{"type":"permission_error","message":"nope"}}`, llmerrors.ErrUnauthorized},
+		"rate limit":      {`{"error":{"type":"rate_limit_error","message":"slow down"}}`, llmerrors.ErrRejected},
+		"overloaded":      {`{"error":{"type":"overloaded_error","message":"busy"}}`, llmerrors.ErrRejected},
+		"billing":         {`{"error":{"type":"billing_error","message":"pay"}}`, llmerrors.ErrRejected},
+		"not found":       {`{"error":{"type":"not_found_error","message":"missing"}}`, llmerrors.ErrUnsupported},
+		"unknown type":    {`{"error":{"type":"some_new_error","message":"?"}}`, llmerrors.ErrUnknown},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			apiErr, err := parseProviderError([]byte(tc.body))
+			require.NoError(t, err)
+			require.ErrorIs(t, apiErr, tc.expectedErr)
+		})
+	}
+
+	t.Run("malformed body returns parse error", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseProviderError([]byte(`{"error":`))
+		require.Error(t, err)
+	})
+}
+
+// TestNewErrorMessage covers the Teleport error to Anthropic error type
+// mapping.
+func TestNewErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		err          error
+		expectedType string
+	}{
+		"timeout":      {llmerrors.ErrTimeout, errorTypeTimeoutError},
+		"canceled":     {llmerrors.ErrCanceled, errorTypeTimeoutError},
+		"bad request":  {llmerrors.ErrBadRequest, errorTypeInvalidRequestError},
+		"unauthorized": {llmerrors.ErrUnauthorized, errorTypeAuthenticationError},
+		"rejected":     {llmerrors.ErrRejected, errorTypeRateLimitError},
+		"unsupported":  {llmerrors.ErrUnsupported, errorTypeNotFoundError},
+		"unknown":      {llmerrors.ErrUnknown, errorTypeAPIError},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			msg := newErrorMessage(tc.err)
+			require.Equal(t, tc.expectedType, msg.Error.Type)
+			require.Contains(t, msg.Error.Message, tc.err.Error())
+		})
+	}
+
+	require.Nil(t, newErrorMessage(nil))
+}
+
+// TestEndpointParseUsage covers extraction of token usage from a non-streaming
+// messages API response.
+func TestEndpointParseUsage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		in, out, err := Endpoint{}.ParseUsage([]byte(`{"usage":{"input_tokens":15,"output_tokens":20}}`))
+		require.NoError(t, err)
+		require.Equal(t, 15, in)
+		require.Equal(t, 20, out)
+	})
+
+	t.Run("malformed body", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := Endpoint{}.ParseUsage([]byte(`{"usage":`))
+		require.Error(t, err)
+	})
+}
+
+// TestProcessSSEEvents covers the messages API SSE processing.
+func TestProcessSSEEvents(t *testing.T) {
+	t.Parallel()
+
+	log := slog.New(slog.DiscardHandler)
+
+	for name, tc := range map[string]struct {
+		stream              string
+		expectedInputTokens int
+		expectedOutput      int
+		expectedErr         require.ErrorAssertionFunc
+		expectedDownstream  func(t *testing.T, body string)
+	}{
+		"success extracts usage and forwards events": {
+			stream:              successStream,
+			expectedInputTokens: 15,
+			expectedOutput:      60,
+			expectedErr:         require.NoError,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Equal(t, successStream+"\n\n", body)
 			},
 		},
-		"broken response": {
-			providerStatusCode:  http.StatusOK,
-			providerBody:        `{"id":"msg_123","type":"message","content"`,
-			providerContentType: "application/json",
-			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
-				body, _ := i1.(string)
-				// Expect unmodified response.
-				require.Equal(tt, `{"id":"msg_123","type":"message","content"`, body, i2...)
+		"error event surfaces provider error": {
+			stream: "event: error\n" + `data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`,
+			expectedErr: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorIs(tt, err, llmerrors.ErrRejected, i...)
 			},
-			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
-			// Here, the original message is not parsed as error, and will be
-			// forwarded as is to downstream.
-			expectedContentLength: expectContentLength(42),
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.Equal(tt, 42, rec.Written(), i2...)
-				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Contains(t, body, "Overloaded")
+				require.Contains(t, body, llmerrors.ErrRejected.Error())
 			},
 		},
-		"no write header success": {
-			// WriteHeader is not called.
-			providerStatusCode:  0,
-			providerBody:        successResponse,
-			providerContentType: "application/json",
-			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
-				body, _ := i1.(string)
-				// Expect unmodified response.
-				require.Equal(tt, successResponse, body, i2...)
+		"invalid error event surfaces bad response": {
+			stream: "event: error\n" + `data: {"type":"error","error":`,
+			expectedErr: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorIs(tt, err, llmerrors.ErrBadResponse, i...)
 			},
-			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
-			expectedContentLength:        expectContentLength(len(successResponse)),
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.Equal(tt, len(successResponse), rec.Written(), i2...)
-				require.Equal(tt, 15, rec.InputTokensCount(), i2...)
-				require.Equal(tt, 20, rec.OutputTokensCount(), i2...)
-				require.NoError(tt, rec.Err(), i2...)
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Contains(t, body, llmerrors.ErrBadResponse.Error())
 			},
 		},
-		"no write header unsupported content-type": {
-			// WriteHeader is not called.
-			providerStatusCode:  0,
-			providerBody:        "Non-JSON result",
-			providerContentType: "text/html",
-			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
-				body, _ := i1.(string)
-				var apiErr errorEnvelope
-				require.NoError(tt, json.Unmarshal([]byte(body), &apiErr), "expected message to be in JSON format")
-				require.Contains(tt, apiErr.Error.Message, llmerrors.ErrBadResponse.Error(), "expected error response to include Teleport message")
-				require.Contains(tt, apiErr.Error.Message, `unsupported "text/html" response type`, "expected error response to include the unsupported content-type detail")
-			},
-			// Without WriteHeader the recorder cannot force a 500 status nor
-			// strip the original Content-Length, so the status stays 200.
-			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
-			expectedContentLength:        expectContentLength(len("Non-JSON result")),
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.NotEmpty(tt, rec.Written(), i2...)
-				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+		"malformed message_start is skipped": {
+			stream:      "event: message_start\n" + `data: {"type":"message_start","message":`,
+			expectedErr: require.NoError,
+			expectedDownstream: func(t *testing.T, body string) {
+				// The malformed event is dropped (continue), so nothing is
+				// forwarded downstream.
+				require.Empty(t, body)
 			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// This scenario covers when the provider responses returns all
-			// at once (single write). This is less realistic for large
-			// responses.
-			t.Run("single write", func(t *testing.T) {
-				w := httptest.NewRecorder()
-				rec, err := NewResponseRecorder(slog.Default(), w)
-				require.NoError(t, err)
-
-				rec.Header().Add("Content-Type", tc.providerContentType)
-				rec.Header().Add("Content-Length", strconv.Itoa(len(tc.providerBody)))
-				// A status code of 0 simulates a caller that never calls
-				// WriteHeader, exercising the default 200 status path.
-				if tc.providerStatusCode != 0 {
-					rec.WriteHeader(tc.providerStatusCode)
-				}
-				if len(tc.providerBody) > 0 {
-					_, err = io.WriteString(rec, tc.providerBody)
-					require.NoError(t, err)
-				}
-
-				require.NoError(t, rec.Close())
-
-				resp := w.Result()
-				body, err := io.ReadAll(resp.Body)
-				require.NoError(t, err)
-				tc.expectedRecorder(t, rec)
-				tc.expectedDownstreamStatusCode(t, resp.StatusCode)
-				tc.expectedContentLength(t, w.Header().Get("Content-Length"))
-				tc.expectedDownstreamBody(t, string(body))
-			})
-			// This scenario covers when the provider responses returns in
-			// multiple writes. This is more realistic considering larger
-			// responses and network conditions.
-			t.Run("multi write", func(t *testing.T) {
-				w := httptest.NewRecorder()
-				rec, err := NewResponseRecorder(slog.Default(), w)
-				require.NoError(t, err)
-
-				rec.Header().Add("Content-Type", tc.providerContentType)
-				rec.Header().Add("Content-Length", strconv.Itoa(len(tc.providerBody)))
-				// A status code of 0 simulates a caller that never calls
-				// WriteHeader, exercising the default 200 status path.
-				if tc.providerStatusCode != 0 {
-					rec.WriteHeader(tc.providerStatusCode)
-				}
-				for chunk := range slices.Chunk([]byte(tc.providerBody), 1) {
-					_, err = rec.Write(chunk)
-					require.NoError(t, err)
-				}
-
-				require.NoError(t, rec.Close())
-
-				resp := w.Result()
-				body, err := io.ReadAll(resp.Body)
-				require.NoError(t, err)
-				tc.expectedRecorder(t, rec)
-				tc.expectedDownstreamStatusCode(t, resp.StatusCode)
-				tc.expectedContentLength(t, w.Header().Get("Content-Length"))
-				tc.expectedDownstreamBody(t, string(body))
-			})
+			var out strings.Builder
+			in, out2, err := processSSEEvents(
+				context.Background(),
+				log,
+				io.NopCloser(strings.NewReader(tc.stream)),
+				&out,
+			)
+			tc.expectedErr(t, err)
+			require.Equal(t, tc.expectedInputTokens, in)
+			require.Equal(t, tc.expectedOutput, out2)
+			tc.expectedDownstream(t, out.String())
 		})
 	}
 }
 
-func TestHandleStreaming(t *testing.T) {
-	expectStatus := func(statusCode int) require.ValueAssertionFunc {
-		return func(tt require.TestingT, i1 any, i2 ...any) {
-			require.Equal(tt, statusCode, i1, i2...)
-		}
-	}
+// TestProcessSSEEventsWriteFailure covers the error-event branch when the
+// downstream write fails: the recorder must still surface the semantic error.
+func TestProcessSSEEventsWriteFailure(t *testing.T) {
+	t.Parallel()
 
-	successStream := strings.Join([]string{
-		"event: message_start\n" + `data: {"type": "message_start", "message":{"id":"msg_123","type":"message","content":[],"usage":{"input_tokens":15}}}`,
-		"event: content_block_start\n" + `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
-		"event: content_block_start\n" + `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"Hello"}}`,
-		"event: content_block_start\n" + `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"World"}}`,
-		"event: content_block_stop\n" + `data: {"type":"content_block_stop","index":0}`,
-		"event: message_delta\n" + `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":15,"output_tokens":60}}`,
-		"event: message_stop",
-	}, "\n\n")
+	log := slog.New(slog.DiscardHandler)
 
-	for name, tc := range map[string]struct {
-		providerResp                 func(w http.ResponseWriter)
-		expectedDownstreamBody       require.ValueAssertionFunc
-		expectedDownstreamStatusCode require.ValueAssertionFunc
-		expectedRecorder             require.ValueAssertionFunc
-	}{
-		"success": {
-			providerResp: func(w http.ResponseWriter) {
-				w.Header().Add("Content-Type", "text/event-stream")
-				w.WriteHeader(http.StatusOK)
-				io.WriteString(w, successStream)
-			},
-			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
-				body, _ := i1.(string)
-				// Expect unmodified response.
-				require.Equal(tt, successStream+"\n\n", body, i2...)
-			},
-			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				// events length + last event line break.
-				require.Equal(tt, len(successStream)+2, rec.Written())
-				require.Equal(tt, 15, rec.InputTokensCount(), i2...)
-				require.Equal(tt, 60, rec.OutputTokensCount(), i2...)
-				require.NoError(tt, rec.Err())
-			},
-		},
-		"with error": {
-			providerResp: func(w http.ResponseWriter) {
-				w.Header().Add("Content-Type", "text/event-stream")
-				w.WriteHeader(http.StatusOK)
-				io.WriteString(w, "event: error\n"+`data: {"type": "error", "error": {"type": "overloaded_error", "message": "Overloaded"}}`)
-			},
-			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
-				body, _ := i1.(string)
-				evt := readSSEOneEvent(tt, body)
-				var apiErr errorEnvelope
-				require.Equal(t, "error", evt.Event)
-				require.NoError(tt, json.Unmarshal(evt.Data, &apiErr), "expected message to be in JSON format")
-				require.Contains(tt, body, "Overloaded", "expected error response to include original message")
-				require.Contains(tt, body, llmerrors.ErrRejected.Error(), "expected error response to include Teleport message")
-			},
-			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.Equal(tt, 198, rec.Written())
-				require.ErrorIs(tt, rec.Err(), llmerrors.ErrRejected)
-			},
-		},
-		"empty stream": {
-			providerResp: func(w http.ResponseWriter) {
-				w.Header().Add("Content-Type", "text/event-stream")
-				w.WriteHeader(http.StatusOK)
-			},
-			expectedDownstreamBody:       require.Empty,
-			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.Empty(tt, rec.Written())
-			},
-		},
-		"broken stream": {
-			providerResp: func(w http.ResponseWriter) {
-				w.Header().Add("Content-Type", "text/event-stream")
-				w.WriteHeader(http.StatusOK)
-				// Broken JSON response.
-				io.WriteString(w, "event: message_start\n"+`data: {"type": "message_start", "message":{"id":"msg_123","type":"message","content":`)
-			},
-			expectedDownstreamBody:       require.Empty,
-			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
-			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
-				rec, _ := i1.(*ResponseRecorder)
-				require.Empty(tt, rec.Written())
-			},
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			w := httptest.NewRecorder()
-			rec, err := NewResponseRecorder(slog.Default(), w)
-			require.NoError(t, err)
-			tc.providerResp(rec)
-			require.NoError(t, rec.Close())
-
-			resp := w.Result()
-			body, err := io.ReadAll(resp.Body)
-			require.NoError(t, err)
-			tc.expectedRecorder(t, rec)
-			tc.expectedDownstreamStatusCode(t, resp.StatusCode)
-			tc.expectedDownstreamBody(t, string(body))
-		})
-	}
-}
-
-// TestHandleStreamingErrorEventWriteFailure covers the error-event branch of
-// processSSEEvents when the downstream write fails: the client connection is
-// broken, but the recorder must still surface the semantic error via Err().
-func TestHandleStreamingErrorEventWriteFailure(t *testing.T) {
 	for name, tc := range map[string]struct {
 		stream      string
 		expectedErr require.ErrorAssertionFunc
 	}{
 		"write error surfaces provider error": {
-			stream: "event: error\n" + `data: {"type": "error", "error": {"type": "overloaded_error", "message": "Overloaded"}}`,
+			stream: "event: error\n" + `data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`,
 			expectedErr: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorIs(tt, err, llmerrors.ErrRejected, i...)
 			},
 		},
 		"invalid error event surfaces bad response": {
-			stream: "event: error\n" + `data: {"type": "error", "error":`,
+			stream: "event: error\n" + `data: {"type":"error","error":`,
 			expectedErr: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorIs(tt, err, llmerrors.ErrBadResponse, i...)
 			},
@@ -437,50 +218,17 @@ func TestHandleStreamingErrorEventWriteFailure(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			w := &failingResponseWriter{header: http.Header{}}
-			w.header.Set("Content-Type", "text/event-stream")
-
-			rec, err := NewResponseRecorder(slog.Default(), w)
-			require.NoError(t, err)
-
-			rec.WriteHeader(http.StatusOK)
-			_, err = io.WriteString(rec, tc.stream)
-			require.NoError(t, err)
-			// Close waits on the streaming goroutine, so Err() is populated.
-			require.NoError(t, rec.Close())
-			tc.expectedErr(t, rec.Err())
+			w := llmtesting.NewFailingResponseWriter("text/event-stream")
+			_, _, err := processSSEEvents(
+				context.Background(),
+				log,
+				io.NopCloser(strings.NewReader(tc.stream)),
+				w,
+			)
+			tc.expectedErr(t, err)
 		})
 	}
 }
-
-func readSSEOneEvent(t require.TestingT, str string) sse.Event {
-	events, err := stream.Collect(sse.ReadEvents(strings.NewReader(str)))
-	require.NoError(t, err)
-	require.Len(t, events, 1)
-	return events[0]
-}
-
-// discardResponseWriter is a minimal [http.ResponseWriter] + [http.Flusher]
-// that discards all writes.
-type discardResponseWriter struct {
-	header http.Header
-}
-
-func (w *discardResponseWriter) Header() http.Header         { return w.header }
-func (w *discardResponseWriter) Write(p []byte) (int, error) { return len(p), nil }
-func (w *discardResponseWriter) WriteHeader(int)             {}
-func (w *discardResponseWriter) Flush()                      {}
-
-// failingResponseWriter is a minimal [http.ResponseWriter] + [http.Flusher]
-// whose Write always fails, simulating a broken downstream connection.
-type failingResponseWriter struct {
-	header http.Header
-}
-
-func (w *failingResponseWriter) Header() http.Header       { return w.header }
-func (w *failingResponseWriter) Write([]byte) (int, error) { return 0, io.ErrClosedPipe }
-func (w *failingResponseWriter) WriteHeader(int)           {}
-func (w *failingResponseWriter) Flush()                    {}
 
 // buildResponseBody returns a valid non-streaming messages API response whose
 // total size is roughly fillerBytes.
@@ -522,8 +270,7 @@ func BenchmarkResponseRecorderJSON(b *testing.B) {
 			b.ReportAllocs()
 
 			for b.Loop() {
-				w := &discardResponseWriter{header: http.Header{}}
-				w.header.Set("Content-Type", "application/json")
+				w := llmtesting.NewDiscardResponseWriter("application/json")
 				rec, err := NewResponseRecorder(log, w)
 				require.NoError(b, err)
 				rec.WriteHeader(http.StatusOK)
@@ -535,8 +282,7 @@ func BenchmarkResponseRecorderJSON(b *testing.B) {
 	}
 }
 
-// BenchmarkResponseRecorderStreamChunked mirrors BenchmarkResponseRecorderStream
-// but issues one Write per SSE event.
+// BenchmarkResponseRecorderStream issues one Write per SSE event.
 //
 //	go test ./lib/srv/app/llm/anthropic/ -run '^$' -bench BenchmarkResponseRecorderStream -benchmem
 func BenchmarkResponseRecorderStream(b *testing.B) {
@@ -559,8 +305,7 @@ func BenchmarkResponseRecorderStream(b *testing.B) {
 			b.ReportAllocs()
 
 			for b.Loop() {
-				w := &discardResponseWriter{header: http.Header{}}
-				w.header.Set("Content-Type", "text/event-stream")
+				w := llmtesting.NewDiscardResponseWriter("text/event-stream")
 				rec, err := NewResponseRecorder(log, w)
 				require.NoError(b, err)
 				rec.WriteHeader(http.StatusOK)

--- a/lib/srv/app/llm/anthropic/recorder_test.go
+++ b/lib/srv/app/llm/anthropic/recorder_test.go
@@ -1,0 +1,576 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package anthropic
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/httplib/sse"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+)
+
+func TestHandleNonStreaming(t *testing.T) {
+	expectStatus := func(statusCode int) require.ValueAssertionFunc {
+		return func(tt require.TestingT, i1 any, i2 ...any) {
+			require.Equal(tt, statusCode, i1, i2...)
+		}
+	}
+
+	expectContentLength := func(length int) require.ValueAssertionFunc {
+		return func(tt require.TestingT, i1 any, i2 ...any) {
+			contentLength, err := strconv.Atoi(i1.(string))
+			require.NoError(tt, err, "expected content length to not be empty")
+			require.Equal(tt, length, contentLength, i2...)
+		}
+	}
+
+	const successResponse = `{"id":"msg_123","type":"message","content":[{"type":"text","text":"Hello"}],"usage":{"input_tokens":15, "output_tokens": 20}}`
+
+	for name, tc := range map[string]struct {
+		providerStatusCode           int
+		providerBody                 string
+		providerContentType          string
+		expectedDownstreamBody       require.ValueAssertionFunc
+		expectedDownstreamStatusCode require.ValueAssertionFunc
+		expectedContentLength        require.ValueAssertionFunc
+		expectedRecorder             require.ValueAssertionFunc
+	}{
+		"success": {
+			providerStatusCode:  http.StatusOK,
+			providerBody:        successResponse,
+			providerContentType: "application/json",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				body, _ := i1.(string)
+				// Expect unmodified response.
+				require.Equal(tt, successResponse, body, i2...)
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
+			// Expect content length equal to the original message.
+			expectedContentLength: expectContentLength(len(successResponse)),
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec, _ := i1.(*ResponseRecorder)
+				require.Equal(tt, len(successResponse), rec.Written())
+				require.Equal(tt, 15, rec.InputTokensCount(), i2...)
+				require.Equal(tt, 20, rec.OutputTokensCount(), i2...)
+				require.NoError(tt, rec.Err(), i2...)
+			},
+		},
+		"non-json response": {
+			providerStatusCode:  http.StatusOK,
+			providerBody:        "Non-JSON result",
+			providerContentType: "text/html",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				body, _ := i1.(string)
+				var apiErr errorEnvelope
+				require.NoError(tt, json.Unmarshal([]byte(body), &apiErr), "expected message to be in JSON format")
+				require.Contains(tt, apiErr.Error.Message, llmerrors.ErrBadResponse.Error(), "expected error response to include Teleport message")
+				require.Contains(tt, apiErr.Error.Message, `unsupported "text/html" response type`, "expected error response to include the unsupported content-type detail")
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusInternalServerError),
+			// In case of errors, we always expect empty Content-Length.
+			expectedContentLength: require.Empty,
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec, _ := i1.(*ResponseRecorder)
+				require.NotEmpty(tt, rec.Written(), i2...)
+				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+			},
+		},
+		"api invalid request includes original message": {
+			providerStatusCode:  http.StatusBadRequest,
+			providerBody:        `{"error":{"type":"invalid_request_error","message":"invalid model"}}`,
+			providerContentType: "application/json",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				body, _ := i1.(string)
+				var apiErr errorEnvelope
+				require.NoError(tt, json.Unmarshal([]byte(body), &apiErr), "expected message to be in JSON format")
+				require.Contains(tt, apiErr.Error.Message, "invalid model", "expected error response to include original message")
+				require.Contains(tt, apiErr.Error.Message, llmerrors.ErrBadRequest.Error(), "expected error response to include Teleport message")
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusBadRequest),
+			// In case of errors, we always expect empty Content-Length.
+			expectedContentLength: require.Empty,
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec, _ := i1.(*ResponseRecorder)
+				require.NotEmpty(tt, rec.Written(), i2...)
+				require.Equal(tt, 0, rec.OutputTokensCount(), i2...)
+				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadRequest, i2...)
+			},
+		},
+		"auth error 401 rewrites message": {
+			providerStatusCode:  http.StatusUnauthorized,
+			providerBody:        `{"error":{"type":"authentication_error","message":"original provider secret"}}`,
+			providerContentType: "application/json",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				body, _ := i1.(string)
+				var apiErr errorEnvelope
+				require.NoError(tt, json.Unmarshal([]byte(body), &apiErr), "expected message to be in JSON format")
+				require.NotContains(tt, body, "original provider secret", "expected error response to NOT include original message")
+				require.Contains(tt, apiErr.Error.Message, llmerrors.ErrUnauthorized.Error(), "expected error response to include Teleport message")
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusUnauthorized),
+			// In case of errors, we always expect empty Content-Length.
+			expectedContentLength: require.Empty,
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec, _ := i1.(*ResponseRecorder)
+				require.NotEmpty(tt, rec.Written(), i2...)
+				require.ErrorIs(tt, rec.Err(), llmerrors.ErrUnauthorized, i2...)
+			},
+		},
+		"empty success response": {
+			providerStatusCode:           http.StatusOK,
+			providerBody:                 "",
+			providerContentType:          "application/json",
+			expectedDownstreamBody:       require.Empty,
+			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
+			expectedContentLength:        expectContentLength(0),
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec, _ := i1.(*ResponseRecorder)
+				require.Empty(tt, rec.Written(), i2...)
+				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+			},
+		},
+		"empty error response": {
+			providerStatusCode:  http.StatusUnauthorized,
+			providerBody:        "",
+			providerContentType: "application/json",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				body, _ := i1.(string)
+				var apiErr errorEnvelope
+				require.NoError(tt, json.Unmarshal([]byte(body), &apiErr), "expected message to be in JSON format")
+				require.Contains(tt, apiErr.Error.Message, llmerrors.ErrBadResponse.Error(), "expected error response to include Teleport message")
+				require.Contains(tt, apiErr.Error.Message, "invalid JSON response", "expected error response to include the unparseable-body detail")
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusUnauthorized),
+			expectedContentLength:        require.Empty,
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec, _ := i1.(*ResponseRecorder)
+				require.NotEmpty(tt, rec.Written(), i2...)
+				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+			},
+		},
+		"broken response": {
+			providerStatusCode:  http.StatusOK,
+			providerBody:        `{"id":"msg_123","type":"message","content"`,
+			providerContentType: "application/json",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				body, _ := i1.(string)
+				// Expect unmodified response.
+				require.Equal(tt, `{"id":"msg_123","type":"message","content"`, body, i2...)
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
+			// Here, the original message is not parsed as error, and will be
+			// forwarded as is to downstream.
+			expectedContentLength: expectContentLength(42),
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec, _ := i1.(*ResponseRecorder)
+				require.Equal(tt, 42, rec.Written(), i2...)
+				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+			},
+		},
+		"no write header success": {
+			// WriteHeader is not called.
+			providerStatusCode:  0,
+			providerBody:        successResponse,
+			providerContentType: "application/json",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				body, _ := i1.(string)
+				// Expect unmodified response.
+				require.Equal(tt, successResponse, body, i2...)
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
+			expectedContentLength:        expectContentLength(len(successResponse)),
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec, _ := i1.(*ResponseRecorder)
+				require.Equal(tt, len(successResponse), rec.Written(), i2...)
+				require.Equal(tt, 15, rec.InputTokensCount(), i2...)
+				require.Equal(tt, 20, rec.OutputTokensCount(), i2...)
+				require.NoError(tt, rec.Err(), i2...)
+			},
+		},
+		"no write header unsupported content-type": {
+			// WriteHeader is not called.
+			providerStatusCode:  0,
+			providerBody:        "Non-JSON result",
+			providerContentType: "text/html",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				body, _ := i1.(string)
+				var apiErr errorEnvelope
+				require.NoError(tt, json.Unmarshal([]byte(body), &apiErr), "expected message to be in JSON format")
+				require.Contains(tt, apiErr.Error.Message, llmerrors.ErrBadResponse.Error(), "expected error response to include Teleport message")
+				require.Contains(tt, apiErr.Error.Message, `unsupported "text/html" response type`, "expected error response to include the unsupported content-type detail")
+			},
+			// Without WriteHeader the recorder cannot force a 500 status nor
+			// strip the original Content-Length, so the status stays 200.
+			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
+			expectedContentLength:        expectContentLength(len("Non-JSON result")),
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec, _ := i1.(*ResponseRecorder)
+				require.NotEmpty(tt, rec.Written(), i2...)
+				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// This scenario covers when the provider responses returns all
+			// at once (single write). This is less realistic for large
+			// responses.
+			t.Run("single write", func(t *testing.T) {
+				w := httptest.NewRecorder()
+				rec, err := NewResponseRecorder(slog.Default(), w)
+				require.NoError(t, err)
+
+				rec.Header().Add("Content-Type", tc.providerContentType)
+				rec.Header().Add("Content-Length", strconv.Itoa(len(tc.providerBody)))
+				// A status code of 0 simulates a caller that never calls
+				// WriteHeader, exercising the default 200 status path.
+				if tc.providerStatusCode != 0 {
+					rec.WriteHeader(tc.providerStatusCode)
+				}
+				if len(tc.providerBody) > 0 {
+					_, err = io.WriteString(rec, tc.providerBody)
+					require.NoError(t, err)
+				}
+
+				require.NoError(t, rec.Close())
+
+				resp := w.Result()
+				body, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+				tc.expectedRecorder(t, rec)
+				tc.expectedDownstreamStatusCode(t, resp.StatusCode)
+				tc.expectedContentLength(t, w.Header().Get("Content-Length"))
+				tc.expectedDownstreamBody(t, string(body))
+			})
+			// This scenario covers when the provider responses returns in
+			// multiple writes. This is more realistic considering larger
+			// responses and network conditions.
+			t.Run("multi write", func(t *testing.T) {
+				w := httptest.NewRecorder()
+				rec, err := NewResponseRecorder(slog.Default(), w)
+				require.NoError(t, err)
+
+				rec.Header().Add("Content-Type", tc.providerContentType)
+				rec.Header().Add("Content-Length", strconv.Itoa(len(tc.providerBody)))
+				// A status code of 0 simulates a caller that never calls
+				// WriteHeader, exercising the default 200 status path.
+				if tc.providerStatusCode != 0 {
+					rec.WriteHeader(tc.providerStatusCode)
+				}
+				for chunk := range slices.Chunk([]byte(tc.providerBody), 1) {
+					_, err = rec.Write(chunk)
+					require.NoError(t, err)
+				}
+
+				require.NoError(t, rec.Close())
+
+				resp := w.Result()
+				body, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+				tc.expectedRecorder(t, rec)
+				tc.expectedDownstreamStatusCode(t, resp.StatusCode)
+				tc.expectedContentLength(t, w.Header().Get("Content-Length"))
+				tc.expectedDownstreamBody(t, string(body))
+			})
+		})
+	}
+}
+
+func TestHandleStreaming(t *testing.T) {
+	expectStatus := func(statusCode int) require.ValueAssertionFunc {
+		return func(tt require.TestingT, i1 any, i2 ...any) {
+			require.Equal(tt, statusCode, i1, i2...)
+		}
+	}
+
+	successStream := strings.Join([]string{
+		"event: message_start\n" + `data: {"type": "message_start", "message":{"id":"msg_123","type":"message","content":[],"usage":{"input_tokens":15}}}`,
+		"event: content_block_start\n" + `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		"event: content_block_start\n" + `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"Hello"}}`,
+		"event: content_block_start\n" + `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"World"}}`,
+		"event: content_block_stop\n" + `data: {"type":"content_block_stop","index":0}`,
+		"event: message_delta\n" + `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":15,"output_tokens":60}}`,
+		"event: message_stop",
+	}, "\n\n")
+
+	for name, tc := range map[string]struct {
+		providerResp                 func(w http.ResponseWriter)
+		expectedDownstreamBody       require.ValueAssertionFunc
+		expectedDownstreamStatusCode require.ValueAssertionFunc
+		expectedRecorder             require.ValueAssertionFunc
+	}{
+		"success": {
+			providerResp: func(w http.ResponseWriter) {
+				w.Header().Add("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				io.WriteString(w, successStream)
+			},
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				body, _ := i1.(string)
+				// Expect unmodified response.
+				require.Equal(tt, successStream+"\n\n", body, i2...)
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec, _ := i1.(*ResponseRecorder)
+				// events length + last event line break.
+				require.Equal(tt, len(successStream)+2, rec.Written())
+				require.Equal(tt, 15, rec.InputTokensCount(), i2...)
+				require.Equal(tt, 60, rec.OutputTokensCount(), i2...)
+				require.NoError(tt, rec.Err())
+			},
+		},
+		"with error": {
+			providerResp: func(w http.ResponseWriter) {
+				w.Header().Add("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				io.WriteString(w, "event: error\n"+`data: {"type": "error", "error": {"type": "overloaded_error", "message": "Overloaded"}}`)
+			},
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				body, _ := i1.(string)
+				evt := readSSEOneEvent(tt, body)
+				var apiErr errorEnvelope
+				require.Equal(t, "error", evt.Event)
+				require.NoError(tt, json.Unmarshal(evt.Data, &apiErr), "expected message to be in JSON format")
+				require.Contains(tt, body, "Overloaded", "expected error response to include original message")
+				require.Contains(tt, body, llmerrors.ErrRejected.Error(), "expected error response to include Teleport message")
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec, _ := i1.(*ResponseRecorder)
+				require.Equal(tt, 198, rec.Written())
+				require.ErrorIs(tt, rec.Err(), llmerrors.ErrRejected)
+			},
+		},
+		"empty stream": {
+			providerResp: func(w http.ResponseWriter) {
+				w.Header().Add("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+			},
+			expectedDownstreamBody:       require.Empty,
+			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec, _ := i1.(*ResponseRecorder)
+				require.Empty(tt, rec.Written())
+			},
+		},
+		"broken stream": {
+			providerResp: func(w http.ResponseWriter) {
+				w.Header().Add("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				// Broken JSON response.
+				io.WriteString(w, "event: message_start\n"+`data: {"type": "message_start", "message":{"id":"msg_123","type":"message","content":`)
+			},
+			expectedDownstreamBody:       require.Empty,
+			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec, _ := i1.(*ResponseRecorder)
+				require.Empty(tt, rec.Written())
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			rec, err := NewResponseRecorder(slog.Default(), w)
+			require.NoError(t, err)
+			tc.providerResp(rec)
+			require.NoError(t, rec.Close())
+
+			resp := w.Result()
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			tc.expectedRecorder(t, rec)
+			tc.expectedDownstreamStatusCode(t, resp.StatusCode)
+			tc.expectedDownstreamBody(t, string(body))
+		})
+	}
+}
+
+// TestHandleStreamingErrorEventWriteFailure covers the error-event branch of
+// processSSEEvents when the downstream write fails: the client connection is
+// broken, but the recorder must still surface the semantic error via Err().
+func TestHandleStreamingErrorEventWriteFailure(t *testing.T) {
+	for name, tc := range map[string]struct {
+		stream      string
+		expectedErr require.ErrorAssertionFunc
+	}{
+		"write error surfaces provider error": {
+			stream: "event: error\n" + `data: {"type": "error", "error": {"type": "overloaded_error", "message": "Overloaded"}}`,
+			expectedErr: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorIs(tt, err, llmerrors.ErrRejected, i...)
+			},
+		},
+		"invalid error event surfaces bad response": {
+			stream: "event: error\n" + `data: {"type": "error", "error":`,
+			expectedErr: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorIs(tt, err, llmerrors.ErrBadResponse, i...)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			w := &failingResponseWriter{header: http.Header{}}
+			w.header.Set("Content-Type", "text/event-stream")
+
+			rec, err := NewResponseRecorder(slog.Default(), w)
+			require.NoError(t, err)
+
+			rec.WriteHeader(http.StatusOK)
+			_, err = io.WriteString(rec, tc.stream)
+			require.NoError(t, err)
+			// Close waits on the streaming goroutine, so Err() is populated.
+			require.NoError(t, rec.Close())
+			tc.expectedErr(t, rec.Err())
+		})
+	}
+}
+
+func readSSEOneEvent(t require.TestingT, str string) sse.Event {
+	events, err := stream.Collect(sse.ReadEvents(strings.NewReader(str)))
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	return events[0]
+}
+
+// discardResponseWriter is a minimal [http.ResponseWriter] + [http.Flusher]
+// that discards all writes.
+type discardResponseWriter struct {
+	header http.Header
+}
+
+func (w *discardResponseWriter) Header() http.Header         { return w.header }
+func (w *discardResponseWriter) Write(p []byte) (int, error) { return len(p), nil }
+func (w *discardResponseWriter) WriteHeader(int)             {}
+func (w *discardResponseWriter) Flush()                      {}
+
+// failingResponseWriter is a minimal [http.ResponseWriter] + [http.Flusher]
+// whose Write always fails, simulating a broken downstream connection.
+type failingResponseWriter struct {
+	header http.Header
+}
+
+func (w *failingResponseWriter) Header() http.Header       { return w.header }
+func (w *failingResponseWriter) Write([]byte) (int, error) { return 0, io.ErrClosedPipe }
+func (w *failingResponseWriter) WriteHeader(int)           {}
+func (w *failingResponseWriter) Flush()                    {}
+
+// buildResponseBody returns a valid non-streaming messages API response whose
+// total size is roughly fillerBytes.
+func buildResponseBody(fillerBytes int) []byte {
+	text := strings.Repeat("A", fillerBytes)
+	return fmt.Appendf(nil,
+		`{"id":"msg_123","type":"message","content":[{"type":"text","text":%q}],"usage":{"input_tokens":15,"output_tokens":20}}`,
+		text,
+	)
+}
+
+// buildStreamEvents returns valid messages API SSE events.
+func buildStreamEvents(numEvents int) [][]byte {
+	events := make([][]byte, 0, numEvents+3)
+	events = append(events, []byte("event: message_start\n"+`data: {"type":"message_start","message":{"id":"msg_123","type":"message","content":[],"usage":{"input_tokens":15}}}`+"\n\n"))
+	for range numEvents {
+		events = append(events, []byte("event: content_block_delta\n"+`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello world"}}`+"\n\n"))
+	}
+	events = append(events, []byte("event: message_delta\n"+`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":15,"output_tokens":60}}`+"\n\n"))
+	events = append(events, []byte("event: message_stop"))
+	return events
+}
+
+// BenchmarkResponseRecorderJSON tracks the non-streaming path.
+//
+//	go test ./lib/srv/app/llm/anthropic/ -run '^$' -bench BenchmarkResponseRecorderJSON -benchmem
+func BenchmarkResponseRecorderJSON(b *testing.B) {
+	log := slog.New(slog.DiscardHandler)
+	for _, bc := range []struct {
+		name string
+		body []byte
+	}{
+		{"small", buildResponseBody(16)},
+		{"medium_32KB", buildResponseBody(32 * 1024)},
+		{"large_1MB", buildResponseBody(1024 * 1024)},
+	} {
+		b.Run(bc.name, func(b *testing.B) {
+			b.SetBytes(int64(len(bc.body)))
+			b.ReportAllocs()
+
+			for b.Loop() {
+				w := &discardResponseWriter{header: http.Header{}}
+				w.header.Set("Content-Type", "application/json")
+				rec, err := NewResponseRecorder(log, w)
+				require.NoError(b, err)
+				rec.WriteHeader(http.StatusOK)
+				_, err = rec.Write(bc.body)
+				require.NoError(b, err)
+				require.NoError(b, rec.Close())
+			}
+		})
+	}
+}
+
+// BenchmarkResponseRecorderStreamChunked mirrors BenchmarkResponseRecorderStream
+// but issues one Write per SSE event.
+//
+//	go test ./lib/srv/app/llm/anthropic/ -run '^$' -bench BenchmarkResponseRecorderStream -benchmem
+func BenchmarkResponseRecorderStream(b *testing.B) {
+	log := slog.New(slog.DiscardHandler)
+	for _, bc := range []struct {
+		name    string
+		nEvents int
+	}{
+		{"32_events", 32},
+		{"256_events", 256},
+		{"1024_events", 1024},
+	} {
+		events := buildStreamEvents(bc.nEvents)
+		var total int
+		for _, e := range events {
+			total += len(e)
+		}
+		b.Run(bc.name, func(b *testing.B) {
+			b.SetBytes(int64(total))
+			b.ReportAllocs()
+
+			for b.Loop() {
+				w := &discardResponseWriter{header: http.Header{}}
+				w.header.Set("Content-Type", "text/event-stream")
+				rec, err := NewResponseRecorder(log, w)
+				require.NoError(b, err)
+				rec.WriteHeader(http.StatusOK)
+				for _, e := range events {
+					_, err := rec.Write(e)
+					require.NoError(b, err)
+				}
+				// Close waits for the SSE-processing goroutine to drain.
+				require.NoError(b, rec.Close())
+			}
+		})
+	}
+}

--- a/lib/srv/app/llm/anthropic/types.go
+++ b/lib/srv/app/llm/anthropic/types.go
@@ -1,0 +1,170 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package anthropic
+
+import (
+	"encoding/json"
+	"maps"
+	"strings"
+
+	"github.com/gravitational/trace"
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// RequestInfo contains the request information.
+type RequestInfo struct {
+	requestedModel string
+	providerModel  string
+	stream         bool
+	requestSize    int
+}
+
+func (r *RequestInfo) RequestedModel() string { return r.requestedModel }
+func (r *RequestInfo) ProviderModel() string  { return r.providerModel }
+func (r *RequestInfo) IsStream() bool         { return r.stream }
+func (r *RequestInfo) RequestSize() int       { return r.requestSize }
+
+// messagesAPIResult contains part of the fields from messages API response body.
+//
+// https://platform.claude.com/docs/en/api/messages/create#message
+type messagesAPIResult struct {
+	Usage struct {
+		OutputTokens int `json:"output_tokens"`
+		InputTokens  int `json:"input_tokens"`
+	} `json:"usage"`
+}
+
+// sseMessageStartEvent contains part of the fields from messages API SSE
+// "message_start" event.
+//
+// https://platform.claude.com/docs/en/api/messages/create#raw_message_start_event
+type sseMessageStartEvent struct {
+	Message struct {
+		Usage struct {
+			OutputTokens int `json:"output_tokens"`
+			InputTokens  int `json:"input_tokens"`
+		} `json:"usage"`
+	} `json:"message"`
+}
+
+// errorMessage contains the error returned from Anthropic's API.
+type errorMessage struct {
+	Type    string `json:"type,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// errorEnvelope wraps the error message from Anthropic's API.
+type errorEnvelope struct {
+	Type  string       `json:"type,omitempty"`
+	Error errorMessage `json:"error"`
+}
+
+// List of Anthropic error types.
+//
+// https://platform.claude.com/docs/en/api/errors
+const (
+	errorTypeInvalidRequestError = "invalid_request_error"
+	errorTypeAuthenticationError = "authentication_error"
+	errorTypePermissionError     = "permission_error"
+	errorTypeNotFoundError       = "not_found_error"
+	errorTypeRateLimitError      = "rate_limit_error"
+	errorTypeTimeoutError        = "timeout_error"
+	errorTypeOverloadedError     = "overloaded_error"
+	errorTypeAPIError            = "api_error"
+	errorTypeBillingError        = "billing_error"
+)
+
+// messagesAPIRequest contains part of the fields from messages API request
+// body.
+//
+// https://platform.claude.com/docs/en/api/messages/create
+type messagesAPIRequest struct {
+	Model     string `json:"model"`
+	Stream    bool   `json:"stream"`
+	MaxTokens int    `json:"max_tokens"`
+
+	raw map[string]json.RawMessage `json:"-"`
+}
+
+func (m *messagesAPIRequest) UnmarshalJSON(data []byte) error {
+	type Alias messagesAPIRequest
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+	if err := caseSensitiveJSONConfig.Unmarshal(data, aux); err != nil {
+		return trace.Wrap(err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := utils.FastUnmarshal(data, &raw); err != nil {
+		return trace.Wrap(err)
+	}
+
+	for key := range raw {
+		if isKnownMessagesJSONKey(key) {
+			delete(raw, key)
+		}
+	}
+
+	m.raw = raw
+	return nil
+}
+
+func isKnownMessagesJSONKey(key string) bool {
+	switch strings.ToLower(key) {
+	case "model", "stream", "max_tokens":
+		return true
+	default:
+		return false
+	}
+}
+
+func (m messagesAPIRequest) MarshalJSON() ([]byte, error) {
+	final := make(map[string]json.RawMessage, len(m.raw)+3) // Current len + taken fields.
+	maps.Copy(final, m.raw)
+	if err := marshalField(final, "model", m.Model); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := marshalField(final, "stream", m.Stream); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := marshalField(final, "max_tokens", m.MaxTokens); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	res, err := utils.FastMarshal(final)
+	return res, trace.Wrap(err)
+}
+
+func marshalField(raw map[string]json.RawMessage, fieldName string, value any) error {
+	field, err := json.Marshal(value)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	raw[fieldName] = field
+	return nil
+}
+
+// caseSensitiveJSONConfig is used to decode JSON messages. The config is
+// based on jsoniter.ConfigCompatibleWithStandardLibrary with the addition of
+// CaseSensitive enabled.
+// TODO(gabrielcorado): Migrate to encoding/json/v2 once it's out of experimentation.
+var caseSensitiveJSONConfig = jsoniter.Config{
+	EscapeHTML:             true,
+	SortMapKeys:            true,
+	ValidateJsonRawMessage: true,
+	CaseSensitive:          true,
+}.Froze()

--- a/lib/srv/app/llm/anthropic/types_test.go
+++ b/lib/srv/app/llm/anthropic/types_test.go
@@ -1,0 +1,252 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func TestParseMessagesRequest(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input       string
+		expectError require.ErrorAssertionFunc
+		expectValue require.ValueAssertionFunc
+	}{
+		"valid json with fields": {
+			input:       `{"model": "claude-opus-4-7", "stream": true, "max_tokens": 1024, "messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(messagesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Equal(tt, "claude-opus-4-7", req.Model, i2...)
+				require.True(tt, req.Stream, i2...)
+				require.Equal(tt, 1024, req.MaxTokens, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"valid json missing fields": {
+			input:       `{"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(messagesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Empty(tt, req.Model, i2...)
+				require.False(tt, req.Stream, i2...)
+				require.Empty(tt, req.MaxTokens, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"model duplicates": {
+			input:       `{"model":"claude-sonnet-4-20250514","model":"claude-haiku-4-5","MODEL":"claude-sonnet-4-7","max_tokens":1024,"stream":true,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(messagesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Equal(tt, "claude-haiku-4-5", req.Model, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"model duplicates different casing": {
+			input:       `{"model":"claude-sonnet-4-20250514","MODEL":"claude-opus-4-7","max_tokens":1024,"stream":true,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(messagesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Equal(tt, "claude-sonnet-4-20250514", req.Model, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"stream duplicates": {
+			input:       `{"model":"claude-sonnet-4-20250514","stream":true,"stream":false,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(messagesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.False(tt, req.Stream, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"stream duplicates different casing": {
+			input:       `{"model":"claude-sonnet-4-20250514","stream":true,"STREAM":false,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(messagesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.True(tt, req.Stream, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"max tokens duplicates different casing": {
+			input:       `{"model":"claude-sonnet-4-20250514","max_tokens":1024,"MAX_TOKENS":9999,"stream":true,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(messagesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Equal(tt, 1024, req.MaxTokens, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"max tokens duplicates": {
+			input:       `{"model":"claude-sonnet-4-20250514","max_tokens":1024,"max_tokens":5555,"stream": true,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(messagesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Equal(tt, 5555, req.MaxTokens, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"fields in uppercase": {
+			input:       `{"MODEL":"claude-sonnet-4-20250514","MAX_TOKENS":1024,"STREAM":true,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(messagesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Empty(tt, req.Model, i2...)
+				require.Empty(tt, req.MaxTokens, i2...)
+				require.False(tt, req.Stream, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"stream invalid format": {
+			input:       `{"model":"claude-sonnet-4-20250514","stream":"yes","messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.Error,
+			expectValue: require.NotEmpty,
+		},
+		"duplicated other fields no error": {
+			input:       `{"model": "claude-opus-4-7", "stream": true, "max_tokens": 1024, "messages":[{"role":"user","content":"Hello"}], "thinking": {"type": "adaptive"}, "thinking": {"type": "disabled"}}}`,
+			expectError: require.NoError,
+			expectValue: require.NotEmpty,
+		},
+		"duplicated other nested fields no error": {
+			input:       `{"model": "claude-opus-4-7", "stream": true, "max_tokens": 1024, "messages":[{"role":"user","content":"Hello"}], "thinking": {"type": "adaptive", "type": "disabled"}}}`,
+			expectError: require.NoError,
+			expectValue: require.NotEmpty,
+		},
+		"invalid json": {
+			input:       `{random}`,
+			expectError: require.Error,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(messagesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Empty(tt, req.Model, i2...)
+				require.False(tt, req.Stream, i2...)
+				require.Empty(tt, req.MaxTokens, i2...)
+				require.Empty(tt, req.raw, i2...)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var r messagesAPIRequest
+			tc.expectError(t, utils.FastUnmarshal([]byte(tc.input), &r))
+			tc.expectValue(t, r)
+		})
+	}
+}
+
+func TestEncodeMessagesRequest(t *testing.T) {
+	// For this test we use the value generated from a raw AnthropicAPI message,
+	// so effectively we're also testing the parsing/decoding part as well.
+
+	for name, tc := range map[string]struct {
+		input         string
+		modifyRequest func(*messagesAPIRequest)
+		output        string
+		expectError   require.ErrorAssertionFunc
+		expectValue   require.ValueAssertionFunc
+	}{
+		"unmodified fields": {
+			input:         `{"model": "claude-opus-4-7", "stream": true, "max_tokens": 1024, "messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *messagesAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "claude-opus-4-7", "stream": true, "max_tokens": 1024, "messages":[{"role":"user","content":"Hello"}]}`, resp)
+			},
+		},
+		"modified fields": {
+			input: `{"model": "claude-opus-4-7", "stream": true, "max_tokens": 1024, "messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *messagesAPIRequest) {
+				r.Model = "claude-sonnet-4-7"
+				r.Stream = false
+				r.MaxTokens = 2048
+			},
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "claude-sonnet-4-7", "stream": false, "max_tokens": 2048, "messages":[{"role":"user","content":"Hello"}]}`, resp)
+			},
+		},
+		"duplicate fields": {
+			input:         `{"model": "claude-opus-4-7", "model": "claude-sonnet-4-7", "stream": true, "stream": false, "max_tokens": 1024, "max_tokens": 5555, "messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *messagesAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "claude-sonnet-4-7", "stream": false, "max_tokens": 5555, "messages":[{"role":"user","content":"Hello"}]}`, resp)
+			},
+		},
+		"duplicate fields different casing": {
+			input:         `{"model": "claude-opus-4-7", "MODEL": "claude-sonnet-4-7", "stream": true, "STREAM": false, "max_tokens": 1024, "MAX_TOKENS": 5555, "messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *messagesAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				// Expect values from lowercase keys.
+				require.JSONEq(tt, `{"model": "claude-opus-4-7", "stream": true, "max_tokens": 1024, "messages":[{"role":"user","content":"Hello"}]}`, resp)
+			},
+		},
+		"full uppercase keys": {
+			input:         `{"MODEL": "claude-opus-4-7", "STREAM": true, "MAX_TOKENS": 1024, "messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *messagesAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "", "stream": false, "max_tokens": 0, "messages":[{"role":"user","content":"Hello"}]}`, resp)
+			},
+		},
+		"valid json missing fields": {
+			input:         `{"messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *messagesAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "", "stream": false, "max_tokens": 0, "messages":[{"role":"user","content":"Hello"}]}`, resp)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var r messagesAPIRequest
+			require.NoError(t, utils.FastUnmarshal([]byte(tc.input), &r))
+			tc.modifyRequest(&r)
+
+			res, err := utils.FastMarshal(r)
+			tc.expectError(t, err)
+			tc.expectValue(t, string(res))
+		})
+	}
+}

--- a/lib/srv/app/llm/bedrock/bedrock.go
+++ b/lib/srv/app/llm/bedrock/bedrock.go
@@ -1,0 +1,151 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package bedrock
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
+
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
+)
+
+// SignRequestOptions contains the options used to sign a Bedrock request.
+type SignRequestOptions struct {
+	// Logger is the logger used to emit log entries.
+	Logger *slog.Logger
+	// App is the application the request is being made to.
+	App types.Application
+	// Credentials provides the AWS configuration used to retrieve the
+	// credentials that sign the request.
+	Credentials awsconfig.Provider
+	// Request is the HTTP request to be signed.
+	Request *http.Request
+	// RequestBody is the raw request body used to compute the payload hash.
+	RequestBody []byte
+}
+
+// CheckAndSetDefaults validates the options and sets default values.
+func (o *SignRequestOptions) CheckAndSetDefaults() error {
+	if o.Logger == nil {
+		o.Logger = slog.Default()
+	}
+	if o.App == nil {
+		return trace.BadParameter("app is required")
+	}
+	if o.Credentials == nil {
+		return trace.BadParameter("credentials is required")
+	}
+	if o.Request == nil {
+		return trace.BadParameter("http request is required")
+	}
+	return nil
+}
+
+// SignRequest signs Bedrock requests.
+func SignRequest(ctx context.Context, opts SignRequestOptions) error {
+	if err := opts.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	region := resolveRegion(ctx, opts.Logger, opts.App)
+	hash := sha256.New()
+	hash.Write(opts.RequestBody)
+	bodyHash := hex.EncodeToString(hash.Sum(nil))
+
+	awsCfg, err := opts.Credentials.GetConfig(ctx, region,
+		// When empty this already defaults to using ambient credentials.
+		awsconfig.WithCredentialsMaybeIntegration(awsconfig.IntegrationMetadata{
+			Name: opts.App.GetIntegration(),
+		}),
+	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	creds, err := awsCfg.Credentials.Retrieve(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	signer := v4.NewSigner()
+	if err := signer.SignHTTP(ctx, creds, opts.Request, bodyHash, mantleServiceName, region, time.Now()); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// BuildURL builds the Bedrock URL address.
+func BuildURL(log *slog.Logger, app types.Application) (*url.URL, error) {
+	format := app.GetLLM().Format
+	region := resolveRegion(context.Background(), log, app)
+	// https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html
+	host := "bedrock-mantle." + region + ".api.aws"
+
+	switch format {
+	case types.LLMFormatAnthropic:
+		// Messages API: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-messages-api.html
+		return &url.URL{
+			Scheme: "https",
+			Host:   host,
+			Path:   "/anthropic/v1",
+		}, nil
+	case types.LLMFormatOpenAI:
+		// Responses API: https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html
+		// Chat completions API: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-chat-completions-mantle.html
+		return &url.URL{
+			Scheme: "https",
+			Host:   host,
+			Path:   "/v1",
+		}, nil
+	default:
+		return nil, trace.BadParameter("format %q not supported on AWS Bedrock", format)
+	}
+}
+
+// resolveRegion resolves which AWS region to use.
+//
+// We highly recommend apps to explicitly configure the region, however it
+// is currently optional. So, instead of letting a valid app fails 100% of
+// the requests (due to missing the AWS region), we set a default region
+// and emit a log message.
+func resolveRegion(ctx context.Context, log *slog.Logger, app types.Application) string {
+	if region := app.GetAWSRegion(); region != "" {
+		return region
+	}
+
+	log.InfoContext(ctx, "app doesn't specify a region, using default value", "region", defaultRegion)
+	return defaultRegion
+}
+
+const (
+	// mantleServiceName is the bedrock mantle IAM service name used to sign
+	// requests.
+	mantleServiceName = "bedrock-mantle"
+
+	// defaultRegion is the bedrock mantle region used if none was provided.
+	defaultRegion = "us-east-1"
+)

--- a/lib/srv/app/llm/bedrock/bedrock_test.go
+++ b/lib/srv/app/llm/bedrock/bedrock_test.go
@@ -1,0 +1,258 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package bedrock
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
+)
+
+func TestBuildURL(t *testing.T) {
+	for name, tc := range map[string]struct {
+		app           types.Application
+		expectedError require.ErrorAssertionFunc
+		expectedURL   require.ValueAssertionFunc
+	}{
+		"anthropic format": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatAnthropic,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{Region: "us-east-2"}),
+			expectedError: require.NoError,
+			expectedURL: func(tt require.TestingT, i1 any, i2 ...any) {
+				u, _ := i1.(*url.URL)
+				require.Equal(tt, "https", u.Scheme)
+				require.Equal(tt, "bedrock-mantle.us-east-2.api.aws", u.Host)
+				require.Equal(tt, "/anthropic/v1", u.Path)
+			},
+		},
+		"openai format": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{Region: "eu-central-1"}),
+			expectedError: require.NoError,
+			expectedURL: func(tt require.TestingT, i1 any, i2 ...any) {
+				u, _ := i1.(*url.URL)
+				require.Equal(tt, "https", u.Scheme)
+				require.Equal(tt, "bedrock-mantle.eu-central-1.api.aws", u.Host)
+				require.Equal(tt, "/v1", u.Path)
+			},
+		},
+		"default region": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{}),
+			expectedError: require.NoError,
+			expectedURL: func(tt require.TestingT, i1 any, i2 ...any) {
+				u, _ := i1.(*url.URL)
+				require.Equal(tt, "https", u.Scheme)
+				require.Equal(tt, "bedrock-mantle."+defaultRegion+".api.aws", u.Host)
+				require.Equal(tt, "/v1", u.Path)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			u, err := BuildURL(slog.Default(), tc.app)
+			tc.expectedError(t, err)
+			tc.expectedURL(t, u)
+		})
+	}
+}
+
+func TestSignRequest(t *testing.T) {
+	app := newApp(t, &types.LLM{
+		Format:   types.LLMFormatAnthropic,
+		Provider: types.LLMProviderAWSBedrock,
+	}, &types.AppAWS{Region: "us-east-2"})
+
+	staticCredentials := func(gotRegion *string) awsconfig.Provider {
+		return awsconfig.ProviderFunc(func(_ context.Context, region string, _ ...awsconfig.OptionsFn) (aws.Config, error) {
+			*gotRegion = region
+			return aws.Config{
+				Credentials: credentials.NewStaticCredentialsProvider("AKID", "SECRET", "TOKEN"),
+			}, nil
+		})
+	}
+
+	newRequest := func() *http.Request {
+		r, _ := http.NewRequest(http.MethodPost, "https://bedrock-mantle.us-east-2.api.aws/anthropic/v1/messages", nil)
+		return r
+	}
+
+	for name, tc := range map[string]struct {
+		app             types.Application
+		request         func() *http.Request
+		credentials     func(gotRegion *string) awsconfig.Provider
+		expectedError   require.ErrorAssertionFunc
+		expectedRequest require.ValueAssertionFunc
+		expectedRegion  string
+	}{
+		"successful": {
+			app:            app,
+			request:        newRequest,
+			credentials:    staticCredentials,
+			expectedError:  require.NoError,
+			expectedRegion: "us-east-2",
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				require.Contains(tt, req.Header.Get("Authorization"), "AWS4-HMAC-SHA256")
+				require.Contains(tt, req.Header.Get("Authorization"), mantleServiceName)
+				require.NotEmpty(tt, req.Header.Get("X-Amz-Date"))
+				require.Equal(tt, "TOKEN", req.Header.Get("X-Amz-Security-Token"))
+			},
+		},
+		"successful with default region": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatAnthropic,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{Region: ""}),
+			request:        newRequest,
+			credentials:    staticCredentials,
+			expectedError:  require.NoError,
+			expectedRegion: defaultRegion,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				require.Contains(tt, req.Header.Get("Authorization"), "AWS4-HMAC-SHA256")
+				require.Contains(tt, req.Header.Get("Authorization"), mantleServiceName)
+				require.NotEmpty(tt, req.Header.Get("X-Amz-Date"))
+				require.Equal(tt, "TOKEN", req.Header.Get("X-Amz-Security-Token"))
+			},
+		},
+		"successful with integration": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatAnthropic,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{Region: "us-east-2"}, withIntegration("my-integration")),
+			request:        newRequest,
+			credentials:    staticCredentials,
+			expectedError:  require.NoError,
+			expectedRegion: "us-east-2",
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				require.Contains(tt, req.Header.Get("Authorization"), "AWS4-HMAC-SHA256")
+				require.NotEmpty(tt, req.Header.Get("X-Amz-Date"))
+			},
+		},
+		"get config failure": {
+			app:     app,
+			request: newRequest,
+			credentials: func(*string) awsconfig.Provider {
+				return awsconfig.ProviderFunc(func(context.Context, string, ...awsconfig.OptionsFn) (aws.Config, error) {
+					return aws.Config{}, errors.New("get config failed")
+				})
+			},
+			expectedError: require.Error,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				require.Empty(tt, req.Header.Get("Authorization"))
+			},
+		},
+		"retrieve credentials failure": {
+			app:     app,
+			request: newRequest,
+			credentials: func(*string) awsconfig.Provider {
+				return awsconfig.ProviderFunc(func(context.Context, string, ...awsconfig.OptionsFn) (aws.Config, error) {
+					return aws.Config{Credentials: failingCredentialsProvider{}}, nil
+				})
+			},
+			expectedError: require.Error,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				require.Empty(tt, req.Header.Get("Authorization"))
+			},
+		},
+		"missing app": {
+			app:             nil,
+			request:         newRequest,
+			credentials:     staticCredentials,
+			expectedError:   require.Error,
+			expectedRequest: require.NotNil,
+		},
+		"missing credentials": {
+			app:             app,
+			request:         newRequest,
+			credentials:     func(*string) awsconfig.Provider { return nil },
+			expectedError:   require.Error,
+			expectedRequest: require.NotNil,
+		},
+		"missing request": {
+			app:             app,
+			request:         func() *http.Request { return nil },
+			credentials:     staticCredentials,
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var gotRegion string
+			opts := SignRequestOptions{
+				App:         tc.app,
+				Credentials: tc.credentials(&gotRegion),
+				Request:     tc.request(),
+				RequestBody: []byte(`{"model":"claude-sonnet-4-20250514"}`),
+			}
+
+			err := SignRequest(t.Context(), opts)
+			tc.expectedError(t, err)
+			tc.expectedRequest(t, opts.Request)
+			require.Equal(t, tc.expectedRegion, gotRegion)
+		})
+	}
+}
+
+// failingCredentialsProvider is an [aws.CredentialsProvider] that always fails
+// to retrieve credentials.
+type failingCredentialsProvider struct{}
+
+func (failingCredentialsProvider) Retrieve(context.Context) (aws.Credentials, error) {
+	return aws.Credentials{}, errors.New("retrieve failed")
+}
+
+type appOption func(*types.AppSpecV3)
+
+func withIntegration(name string) appOption {
+	return func(spec *types.AppSpecV3) {
+		spec.Integration = name
+	}
+}
+
+func newApp(t *testing.T, llm *types.LLM, appAWS *types.AppAWS, opts ...appOption) types.Application {
+	t.Helper()
+	spec := types.AppSpecV3{
+		LLM: llm,
+		AWS: appAWS,
+	}
+	for _, opt := range opts {
+		opt(&spec)
+	}
+	app, err := types.NewAppV3(types.Metadata{Name: "llm-app"}, spec)
+	require.NoError(t, err)
+	return app
+}

--- a/lib/srv/app/llm/errors/errors.go
+++ b/lib/srv/app/llm/errors/errors.go
@@ -39,6 +39,8 @@ var (
 	ErrUnsupported = errors.New("teleport doesn't support the requested endpoint, please check the list of supported endpoints in the documentation")
 	// ErrBadResponse returned when the provider replied the request with an unsupported message or format.
 	ErrBadResponse = errors.New("the inference provider returned an unexpected response. Contact your Teleport administrator")
+	// ErrConfig returned when the app or app service are misconfigured, requiring admin intervention.
+	ErrConfig = errors.New("unable to serve request due to an app configuration error. Contact your Teleport administrator")
 	// ErrUnknown returned when the handler could not identify the error.
 	ErrUnknown = errors.New("the inference provider returned an unexpected error. Contact your Teleport administrator")
 )

--- a/lib/srv/app/llm/errors/errors.go
+++ b/lib/srv/app/llm/errors/errors.go
@@ -1,0 +1,94 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/gravitational/trace"
+)
+
+var (
+	// ErrTimeout returned when the request times out.
+	ErrTimeout = errors.New("the request timed out. Try again or use streaming for long responses")
+	// ErrBadRequest returned when the request has bad format or invalid fields.
+	ErrBadRequest = errors.New("the inference provider rejected the request as invalid. Check the request body for unsupported or invalid fields")
+	// ErrCanceled returned when the request is canceled.
+	ErrCanceled = errors.New("the request was canceled")
+	// ErrUnauthorized returned when the request is unauthorized.
+	ErrUnauthorized = errors.New("the inference provider rejected the request due to authentication or authorization configuration. Contact your Teleport administrator")
+	// ErrRejected returned when the provider rejects the request.
+	ErrRejected = errors.New("the inference provider rejected the request due to usage limits. Contact your Teleport administrator")
+	// ErrUnsupported returned when the requested endpoint is not supported.
+	ErrUnsupported = errors.New("teleport doesn't support the requested endpoint, please check the list of supported endpoints in the documentation")
+	// ErrBadResponse returned when the provider replied the request with an unsupported message or format.
+	ErrBadResponse = errors.New("the inference provider returned an unexpected response. Contact your Teleport administrator")
+	// ErrUnknown returned when the handler could not identify the error.
+	ErrUnknown = errors.New("the inference provider returned an unexpected error. Contact your Teleport administrator")
+)
+
+// ProviderError is an error in the provider format.
+type ProviderError struct {
+	err    error
+	detail string
+}
+
+// NewProviderError creates a new provider error with details.
+func NewProviderError(err error, detail string, args ...any) *ProviderError {
+	if len(args) > 0 {
+		detail = fmt.Sprintf(detail, args...)
+	}
+	return &ProviderError{err, detail}
+}
+
+func (e *ProviderError) Error() string {
+	return e.UserMessage()
+}
+
+func (e *ProviderError) Unwrap() error {
+	return e.err
+}
+
+func (e *ProviderError) UserMessage() string {
+	if e.detail != "" {
+		return e.err.Error() + ": " + e.detail
+	}
+	return e.err.Error()
+}
+
+// StatusCodeFromErr returns HTTP status code from error.
+//
+// When cannot fully rely on `trace.ErrorToCode` because LLM endpoints require
+// a more granular error codes than what is provided by `trace`.
+func StatusCodeFromErr(err error) int {
+	switch {
+	case errors.Is(err, ErrCanceled), errors.Is(err, ErrTimeout):
+		return http.StatusGatewayTimeout
+	case errors.Is(err, ErrBadRequest), errors.Is(err, ErrBadResponse):
+		return http.StatusBadRequest
+	case errors.Is(err, ErrUnauthorized):
+		return http.StatusUnauthorized
+	case errors.Is(err, ErrRejected):
+		return http.StatusTooManyRequests
+	case errors.Is(err, ErrUnsupported):
+		return http.StatusNotFound
+	default:
+		return trace.ErrorToCode(err)
+	}
+}

--- a/lib/srv/app/llm/handler.go
+++ b/lib/srv/app/llm/handler.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/srv/app/common"
 	"github.com/gravitational/teleport/lib/srv/app/llm/anthropic"
+	"github.com/gravitational/teleport/lib/srv/app/llm/bedrock"
 	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
 	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
 )
@@ -151,14 +152,15 @@ func (h *Handler) serveHTTP(w http.ResponseWriter, r *http.Request) error {
 	case types.LLMFormatAnthropic:
 		h.handleRequest(
 			sessionCtx, w, r,
-			func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error) {
+			func(app types.Application, r *http.Request) (*http.Request, RequestInfo, error) {
 				return anthropic.NewRequest(&llmrequest.Config{
-					LLM:               llm,
+					App:               app,
 					DownstreamRequest: r,
 					ProviderURL:       h.anthropicProviderURL,
 					GetAPIKeyFunc: func() string {
 						return h.anthropicApiKey
 					},
+					SignBedrockRequest: h.signBedrockRequest,
 				})
 			},
 			func(l *slog.Logger, w http.ResponseWriter) (UpstreamRecorder, error) {
@@ -171,6 +173,15 @@ func (h *Handler) serveHTTP(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	return nil
+}
+
+func (h *Handler) signBedrockRequest(ctx context.Context, app types.Application, request *http.Request, requestBody []byte) error {
+	return trace.Wrap(bedrock.SignRequest(ctx, bedrock.SignRequestOptions{
+		App:         app,
+		Credentials: h.cfg.AWSConfigProvider,
+		Request:     request,
+		RequestBody: requestBody,
+	}))
 }
 
 // WriteErrorFunc is function used to write an error into the downstream request.
@@ -189,7 +200,7 @@ type RequestInfo interface {
 }
 
 // NewUpstreamRequestFunc function used to create a new upstream request.
-type NewUpstreamRequestFunc func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error)
+type NewUpstreamRequestFunc func(app types.Application, r *http.Request) (*http.Request, RequestInfo, error)
 
 // NewUpstreamRecoderFunc function used to initialize a upstream response
 // recorder.
@@ -252,7 +263,7 @@ func (h *Handler) handleRequest(
 	}()
 
 	var req *http.Request
-	req, info, err = newRequestFunc(llm, r)
+	req, info, err = newRequestFunc(sessionCtx.App, r)
 	if err != nil {
 		log.ErrorContext(r.Context(), "failed to rewrite request", "error", err)
 		if werr := writeErrorFunc(w, err); werr != nil {

--- a/lib/srv/app/llm/handler.go
+++ b/lib/srv/app/llm/handler.go
@@ -1,0 +1,349 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package llm
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
+	"github.com/gravitational/teleport/lib/observability/metrics"
+	"github.com/gravitational/teleport/lib/srv/app/common"
+	"github.com/gravitational/teleport/lib/srv/app/llm/anthropic"
+	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
+)
+
+// Handler proxies LLM API requests for authorized app sessions.
+type Handler struct {
+	cfg          HandlerConfig
+	closeContext context.Context
+	metrics      *llmMetrics
+
+	anthropicProviderURL *url.URL
+	anthropicApiKey      string
+}
+
+// HandlerConfig configures dependencies for the LLM proxy handler.
+type HandlerConfig struct {
+	// Log is the logger used by the handler.
+	Log *slog.Logger
+	// MetricsRegistry configures where metrics should be registered.
+	// When nil, metrics are created but not registered.
+	MetricsRegistry *metrics.Registry
+	// AWSConfigProvider is the AWS config provider used by the handler.
+	AWSConfigProvider awsconfig.Provider
+	// Transport is the transport used to issue requests to the upstream
+	// LLM provider.
+	Transport *http.Transport
+}
+
+// CheckAndSetDefaults validates required dependencies and sets defaults.
+func (c *HandlerConfig) CheckAndSetDefaults() error {
+	if c.Log == nil {
+		c.Log = slog.With(teleport.ComponentKey, teleport.ComponentLLM)
+	}
+	if c.MetricsRegistry == nil {
+		c.MetricsRegistry = metrics.NoopRegistry()
+	}
+	if c.AWSConfigProvider == nil {
+		var err error
+		c.AWSConfigProvider, err = awsconfig.NewCache()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	if c.Transport == nil {
+		tr, err := defaults.Transport()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		c.Transport = tr
+	}
+	return nil
+}
+
+// NewHandler creates a configured LLM proxy handler.
+func NewHandler(ctx context.Context, cfg HandlerConfig) (*Handler, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	m, err := newMetrics(cfg.MetricsRegistry)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	h := &Handler{
+		closeContext: ctx,
+		cfg:          cfg,
+		metrics:      m,
+		// Not much validation can be applied here since some providers might
+		// not require an actual API key.
+		anthropicApiKey: os.Getenv(anthropicApiKeyEnvVarName),
+	}
+
+	// It ok to leave this value as `nil`, the value receivers must implement a
+	// default value for it.
+	if rawAnthropicURL := os.Getenv(anthropicAddressEnvVarName); rawAnthropicURL != "" {
+		var err error
+		h.anthropicProviderURL, err = url.Parse(rawAnthropicURL)
+		if err != nil {
+			// Hard failure.
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	return h, nil
+}
+
+// ServeHTTP handles an authorized client connection.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if err := h.serveHTTP(w, r); err != nil {
+		h.cfg.Log.ErrorContext(r.Context(), "failed to handle LLM request", "error", err)
+		trace.WriteError(w, err)
+	}
+}
+
+// serveHTTP routes requests to the configured LLM provider handler.
+func (h *Handler) serveHTTP(w http.ResponseWriter, r *http.Request) error {
+	sessionCtx, err := common.GetSessionContext(r)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	llm := sessionCtx.App.GetLLM()
+	start := time.Now()
+	defer func() {
+		h.metrics.requestDuration.WithLabelValues(
+			teleport.ComponentLLM,
+			llm.Format,
+			llm.Provider,
+		).Observe(time.Since(start).Seconds())
+	}()
+
+	// TODO(gabrielcorado): implement OpenAI handler.
+	switch llm.Format {
+	case types.LLMFormatAnthropic:
+		h.handleRequest(
+			sessionCtx, w, r,
+			func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error) {
+				return anthropic.NewRequest(&llmrequest.Config{
+					LLM:               llm,
+					DownstreamRequest: r,
+					ProviderURL:       h.anthropicProviderURL,
+					GetAPIKeyFunc: func() string {
+						return h.anthropicApiKey
+					},
+				})
+			},
+			func(l *slog.Logger, w http.ResponseWriter) (UpstreamRecorder, error) {
+				return anthropic.NewResponseRecorder(l, w)
+			},
+			anthropic.WriteError,
+		)
+	default:
+		return trace.NotImplemented("llm format %q not supported", llm.Format)
+	}
+
+	return nil
+}
+
+// WriteErrorFunc is function used to write an error into the downstream request.
+type WriteErrorFunc func(http.ResponseWriter, error) error
+
+// RequestInfo interface that contains the request information.
+type RequestInfo interface {
+	// RequestedModel returns the requested model name.
+	RequestedModel() string
+	// ProviderModel returns the model name sent to the provider.
+	ProviderModel() string
+	// IsStream indicates if the request uses streaming.
+	IsStream() bool
+	// RequestSize contains the total request size in bytes.
+	RequestSize() int
+}
+
+// NewUpstreamRequestFunc function used to create a new upstream request.
+type NewUpstreamRequestFunc func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error)
+
+// NewUpstreamRecoderFunc function used to initialize a upstream response
+// recorder.
+type NewUpstreamRecoderFunc func(*slog.Logger, http.ResponseWriter) (UpstreamRecorder, error)
+
+// UpstreamRecorder records upstream results.
+type UpstreamRecorder interface {
+	http.ResponseWriter
+
+	// Written is the number of bytes written in the downstream connection.
+	Written() int
+	// Err is the error returned to the downstream connection.
+	Err() error
+	// InputTokensCount is the number of input tokens that were used on the
+	// request.
+	InputTokensCount() int
+	// OutputTokensCount is the number of output tokens generated by the
+	// request.
+	OutputTokensCount() int
+	// Close closes the recorder.
+	Close() error
+}
+
+// handleRequest handles an LLM request.
+func (h *Handler) handleRequest(
+	sessionCtx *common.SessionContext,
+	w http.ResponseWriter,
+	r *http.Request,
+	newRequestFunc NewUpstreamRequestFunc,
+	newRecorderFunc NewUpstreamRecoderFunc,
+	writeErrorFunc WriteErrorFunc,
+) {
+	llm := sessionCtx.App.GetLLM()
+	log := h.cfg.Log.With(
+		"app", sessionCtx.App.GetName(),
+		"format", llm.Format,
+		"provider", llm.Provider,
+	)
+
+	var (
+		err  error
+		info RequestInfo
+		rec  UpstreamRecorder
+	)
+
+	defer func() {
+		req := common.LLMRequest{Format: llm.Format, Provider: llm.Provider}
+		if info != nil {
+			req.Model = info.ProviderModel()
+			req.RequestedModel = info.RequestedModel()
+		}
+		resp := common.LLMResponse{Error: err}
+		if rec != nil {
+			resp.InputTokenCount = rec.InputTokensCount()
+			resp.OutputTokenCount = rec.OutputTokensCount()
+		}
+		if err := sessionCtx.Audit.OnLLMRequest(h.closeContext, sessionCtx, r, req, resp); err != nil {
+			log.ErrorContext(h.closeContext, "failed to emit audit event", "error", err)
+		}
+	}()
+
+	var req *http.Request
+	req, info, err = newRequestFunc(llm, r)
+	if err != nil {
+		log.ErrorContext(r.Context(), "failed to rewrite request", "error", err)
+		if werr := writeErrorFunc(w, err); werr != nil {
+			log.ErrorContext(h.closeContext, "failed to write error", "error", werr)
+		}
+		return
+	}
+
+	rec, err = newRecorderFunc(log, w)
+	if err != nil {
+		log.ErrorContext(r.Context(), "failed to initialize recorder", "error", err)
+		// This is considered an "internal" error. For downstream connections,
+		// just return a generic error.
+		if werr := writeErrorFunc(w, llmerrors.ErrUnknown); werr != nil {
+			log.ErrorContext(h.closeContext, "failed to write error", "error", werr)
+		}
+		return
+	}
+
+	h.metrics.requestSize.WithLabelValues(
+		teleport.ComponentLLM,
+		llm.Format,
+		llm.Provider,
+	).Observe(float64(info.RequestSize()))
+
+	fwd, err := reverseproxy.New(
+		// TODO(gabrielcorado): revisit this flush interval to reduce time to first token (TTFT).
+		reverseproxy.WithFlushInterval(50*time.Millisecond),
+		reverseproxy.WithRoundTripper(h.cfg.Transport),
+		reverseproxy.WithLogger(log),
+		reverseproxy.WithErrorHandler(func(_ http.ResponseWriter, r *http.Request, fwdErr error) {
+			// reverseproxy already logs this error, so no need to log it here.
+			if werr := writeErrorFunc(w, fwdErr); werr != nil {
+				log.ErrorContext(h.closeContext, "failed to write error", "error", werr)
+			}
+			err = fwdErr
+		}),
+	)
+	if err != nil {
+		log.ErrorContext(h.closeContext, "failed to initialize provider forwarder", "error", err)
+		if werr := writeErrorFunc(w, err); werr != nil {
+			log.ErrorContext(h.closeContext, "failed to write error", "error", werr)
+		}
+		return
+	}
+
+	start := time.Now()
+	fwd.ServeHTTP(rec, req)
+	if err := rec.Close(); err != nil {
+		log.ErrorContext(h.closeContext, "failed to close llm recorder", "error", err)
+	}
+
+	// In case a forwarder error happens, we must keep that.
+	if err == nil {
+		err = rec.Err()
+	}
+
+	h.metrics.providerRequestDuration.WithLabelValues(
+		teleport.ComponentLLM,
+		llm.Format,
+		llm.Provider,
+		strconv.FormatBool(info.IsStream()),
+	).Observe(time.Since(start).Seconds())
+
+	h.metrics.providerResponseSize.WithLabelValues(
+		teleport.ComponentLLM,
+		llm.Format,
+		llm.Provider,
+		strconv.FormatBool(info.IsStream()),
+	).Observe(float64(rec.Written()))
+
+	h.metrics.inputTokens.WithLabelValues(
+		teleport.ComponentLLM,
+		llm.Format,
+	).Add(float64(rec.InputTokensCount()))
+
+	h.metrics.outputTokens.WithLabelValues(
+		teleport.ComponentLLM,
+		llm.Format,
+	).Add(float64(rec.OutputTokensCount()))
+}
+
+const (
+	// anthropicAddressEnvVarName is the Anthropic's default environment
+	// variable used to set base API address.
+	//
+	// https://code.claude.com/docs/en/env-vars#variables
+	anthropicAddressEnvVarName = "ANTHROPIC_BASE_URL"
+	// anthropicApiKeyEnvVarName is the Anthropic's default environment variable
+	// used to set API keys.
+	//
+	// https://code.claude.com/docs/en/env-vars#variables
+	anthropicApiKeyEnvVarName = "ANTHROPIC_API_KEY"
+)

--- a/lib/srv/app/llm/handler_test.go
+++ b/lib/srv/app/llm/handler_test.go
@@ -60,7 +60,7 @@ func TestHandleRequest(t *testing.T) {
 	}{
 		"success request": {
 			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
-				return func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error) {
+				return func(_ types.Application, _ *http.Request) (*http.Request, RequestInfo, error) {
 					req, err := http.NewRequest(http.MethodPost, s.URL, nil)
 					if err != nil {
 						return nil, nil, trace.Wrap(err)
@@ -95,7 +95,7 @@ func TestHandleRequest(t *testing.T) {
 		},
 		"new request error": {
 			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
-				return func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error) {
+				return func(_ types.Application, _ *http.Request) (*http.Request, RequestInfo, error) {
 					return nil, nil, trace.BadParameter("invalid request")
 				}
 			},
@@ -117,7 +117,7 @@ func TestHandleRequest(t *testing.T) {
 		},
 		"new request error with partial info": {
 			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
-				return func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error) {
+				return func(_ types.Application, _ *http.Request) (*http.Request, RequestInfo, error) {
 					return nil, &mockRequestInfo{
 						requestedModel: "requested",
 						providerModel:  "provider",
@@ -142,7 +142,7 @@ func TestHandleRequest(t *testing.T) {
 		},
 		"successful request with recorder error": {
 			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
-				return func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error) {
+				return func(_ types.Application, _ *http.Request) (*http.Request, RequestInfo, error) {
 					req, err := http.NewRequest(http.MethodPost, s.URL, nil)
 					if err != nil {
 						return nil, nil, trace.Wrap(err)
@@ -176,7 +176,7 @@ func TestHandleRequest(t *testing.T) {
 		// This case covers scenarios where upstream is not reachable.
 		"upstream forward error": {
 			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
-				return func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error) {
+				return func(_ types.Application, _ *http.Request) (*http.Request, RequestInfo, error) {
 					req, err := http.NewRequest(http.MethodPost, s.URL, nil)
 					if err != nil {
 						return nil, nil, trace.Wrap(err)

--- a/lib/srv/app/llm/handler_test.go
+++ b/lib/srv/app/llm/handler_test.go
@@ -1,0 +1,373 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package llm
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/srv/app/common"
+)
+
+// TestHandleRequest covers `handleRequest` function which is responsible for
+// "orchestrating" the LLM handling. Instead of verifying provider-specific
+// implementations (which are covered on their respective package) we test with
+// mocks, ensure the flow is correct and that it generates audit events
+// correctly.
+func TestHandleRequest(t *testing.T) {
+	expectString := func(str string) require.ValueAssertionFunc {
+		return func(tt require.TestingT, i1 any, i2 ...any) {
+			require.Equal(tt, str, i1, i2...)
+		}
+	}
+
+	for name, tc := range map[string]struct {
+		transport            *http.Transport
+		newRequestFunc       func(http.ResponseWriter, *httptest.Server) NewUpstreamRequestFunc
+		modifyRecorderFunc   func(*mockUpstreamRecorder)
+		writeErrorFunc       WriteErrorFunc
+		upstreamBody         string
+		expectUpstreamCalled bool
+		expectAuditEvent     require.ValueAssertionFunc
+		expectedResponse     require.ValueAssertionFunc
+	}{
+		"success request": {
+			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
+				return func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error) {
+					req, err := http.NewRequest(http.MethodPost, s.URL, nil)
+					if err != nil {
+						return nil, nil, trace.Wrap(err)
+					}
+
+					return req, &mockRequestInfo{
+						requestedModel: "requested",
+						providerModel:  "provider",
+					}, nil
+				}
+			},
+			modifyRecorderFunc: func(r *mockUpstreamRecorder) {
+				r.err = nil
+				r.inputTokensCount = 10
+				r.outputTokensCount = 20
+			},
+			writeErrorFunc: func(w http.ResponseWriter, err error) error {
+				return nil
+			},
+			upstreamBody:         "REPLY",
+			expectUpstreamCalled: true,
+			expectAuditEvent: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.NotNil(tt, i1, i2...)
+				evt := i1.(*apievents.AppSessionLLMRequest)
+				require.True(tt, evt.Status.Success, i2...)
+				require.Equal(tt, "requested", evt.RequestedModel, i2...)
+				require.Equal(tt, "provider", evt.Model, i2...)
+				require.Equal(tt, int64(10), evt.InputTokenCount, i2...)
+				require.Equal(tt, int64(20), evt.OutputTokenCount, i2...)
+			},
+			expectedResponse: expectString("REPLY"),
+		},
+		"new request error": {
+			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
+				return func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error) {
+					return nil, nil, trace.BadParameter("invalid request")
+				}
+			},
+			writeErrorFunc: func(w http.ResponseWriter, err error) error {
+				_, werr := io.WriteString(w, err.Error())
+				return trace.Wrap(werr)
+			},
+			expectUpstreamCalled: false,
+			expectAuditEvent: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.NotNil(tt, i1, i2...)
+				evt := i1.(*apievents.AppSessionLLMRequest)
+				require.False(tt, evt.Status.Success, i2...)
+				require.Empty(tt, evt.RequestedModel, i2...)
+				require.Empty(tt, evt.Model, i2...)
+				require.Empty(tt, evt.InputTokenCount, i2...)
+				require.Empty(tt, evt.OutputTokenCount, i2...)
+			},
+			expectedResponse: expectString("invalid request"),
+		},
+		"new request error with partial info": {
+			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
+				return func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error) {
+					return nil, &mockRequestInfo{
+						requestedModel: "requested",
+						providerModel:  "provider",
+					}, trace.BadParameter("invalid request")
+				}
+			},
+			writeErrorFunc: func(w http.ResponseWriter, err error) error {
+				_, werr := io.WriteString(w, err.Error())
+				return trace.Wrap(werr)
+			},
+			expectUpstreamCalled: false,
+			expectAuditEvent: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.NotNil(tt, i1, i2...)
+				evt := i1.(*apievents.AppSessionLLMRequest)
+				require.False(tt, evt.Status.Success, i2...)
+				require.Equal(tt, "requested", evt.RequestedModel, i2...)
+				require.Equal(tt, "provider", evt.Model, i2...)
+				require.Empty(tt, evt.InputTokenCount, i2...)
+				require.Empty(tt, evt.OutputTokenCount, i2...)
+			},
+			expectedResponse: expectString("invalid request"),
+		},
+		"successful request with recorder error": {
+			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
+				return func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error) {
+					req, err := http.NewRequest(http.MethodPost, s.URL, nil)
+					if err != nil {
+						return nil, nil, trace.Wrap(err)
+					}
+
+					return req, &mockRequestInfo{
+						requestedModel: "requested",
+						providerModel:  "provider",
+					}, nil
+				}
+			},
+			modifyRecorderFunc: func(r *mockUpstreamRecorder) {
+				r.err = trace.AccessDenied("model denied")
+			},
+			writeErrorFunc: func(w http.ResponseWriter, err error) error {
+				return nil
+			},
+			upstreamBody:         "REPLY",
+			expectUpstreamCalled: true,
+			expectAuditEvent: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.NotNil(tt, i1, i2...)
+				evt := i1.(*apievents.AppSessionLLMRequest)
+				require.False(tt, evt.Status.Success, i2...)
+				require.Equal(tt, "requested", evt.RequestedModel, i2...)
+				require.Equal(tt, "provider", evt.Model, i2...)
+				require.Empty(tt, evt.InputTokenCount, i2...)
+				require.Empty(tt, evt.OutputTokenCount, i2...)
+			},
+			expectedResponse: expectString("REPLY"),
+		},
+		// This case covers scenarios where upstream is not reachable.
+		"upstream forward error": {
+			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
+				return func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error) {
+					req, err := http.NewRequest(http.MethodPost, s.URL, nil)
+					if err != nil {
+						return nil, nil, trace.Wrap(err)
+					}
+
+					return req, &mockRequestInfo{
+						requestedModel: "requested",
+						providerModel:  "provider",
+					}, nil
+				}
+			},
+			modifyRecorderFunc: func(r *mockUpstreamRecorder) {
+				r.err = nil
+				r.inputTokensCount = 10
+				r.outputTokensCount = 20
+			},
+			writeErrorFunc: func(w http.ResponseWriter, err error) error {
+				_, werr := io.WriteString(w, err.Error())
+				return trace.Wrap(werr)
+			},
+			transport: &http.Transport{
+				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					return nil, trace.ConnectionProblem(nil, "failed to connect to upstream")
+				},
+			},
+			expectUpstreamCalled: false,
+			expectAuditEvent: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.NotNil(tt, i1, i2...)
+				evt := i1.(*apievents.AppSessionLLMRequest)
+				require.False(tt, evt.Status.Success, i2...)
+				require.Equal(tt, "requested", evt.RequestedModel, i2...)
+				require.Equal(tt, "provider", evt.Model, i2...)
+				require.Equal(tt, int64(10), evt.InputTokenCount, i2...)
+				require.Equal(tt, int64(20), evt.OutputTokenCount, i2...)
+			},
+			expectedResponse: expectString("failed to connect to upstream"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var upstreamCalled bool
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				io.WriteString(w, tc.upstreamBody)
+				upstreamCalled = true
+			}))
+			t.Cleanup(mockServer.Close)
+
+			var auditEvent *apievents.AppSessionLLMRequest
+			audit := newTestAudit(t, func(pe apievents.PreparedSessionEvent) {
+				if evt, ok := pe.GetAuditEvent().(*apievents.AppSessionLLMRequest); ok {
+					auditEvent = evt
+				}
+			})
+
+			h := newTestHandler(t, tc.transport)
+			app := newTestApp(t, &types.LLM{Format: types.LLMFormatAnthropic, Provider: types.LLMProviderAnthropic})
+			sessionCtx := &common.SessionContext{App: app, Audit: audit}
+			req := newTestSessionRequest(
+				t,
+				http.MethodPost,
+				mockServer.URL,
+				"/",
+				nil,
+				sessionCtx,
+			)
+
+			w := httptest.NewRecorder()
+			h.handleRequest(
+				sessionCtx,
+				w,
+				req,
+				tc.newRequestFunc(w, mockServer),
+				func(_ *slog.Logger, w http.ResponseWriter) (UpstreamRecorder, error) {
+					rec := &mockUpstreamRecorder{ResponseWriter: w}
+					tc.modifyRecorderFunc(rec)
+					return rec, nil
+				},
+				tc.writeErrorFunc,
+			)
+			require.Equal(t, tc.expectUpstreamCalled, upstreamCalled)
+			require.NotNil(t, auditEvent)
+			tc.expectAuditEvent(t, auditEvent)
+			tc.expectedResponse(t, w.Body.String())
+		})
+	}
+}
+
+type mockUpstreamRecorder struct {
+	http.ResponseWriter
+
+	err               error
+	inputTokensCount  int
+	outputTokensCount int
+	written           int
+}
+
+// Close implements [UpstreamRecorder].
+func (m *mockUpstreamRecorder) Close() error {
+	return nil
+}
+
+// Err implements [UpstreamRecorder].
+func (m *mockUpstreamRecorder) Err() error {
+	return m.err
+}
+
+// InputTokensCount implements [UpstreamRecorder].
+func (m *mockUpstreamRecorder) InputTokensCount() int {
+	return m.inputTokensCount
+}
+
+// OutputTokensCount implements [UpstreamRecorder].
+func (m *mockUpstreamRecorder) OutputTokensCount() int {
+	return m.outputTokensCount
+}
+
+// Written implements [UpstreamRecorder].
+func (m *mockUpstreamRecorder) Written() int {
+	return m.written
+}
+
+type mockRequestInfo struct {
+	RequestInfo
+
+	requestedModel string
+	providerModel  string
+	stream         bool
+	requestSize    int
+}
+
+func (r *mockRequestInfo) RequestedModel() string { return r.requestedModel }
+func (r *mockRequestInfo) ProviderModel() string  { return r.providerModel }
+func (r *mockRequestInfo) IsStream() bool         { return r.stream }
+func (r *mockRequestInfo) RequestSize() int       { return r.requestSize }
+
+// streamRecorder adapts an apievents.Stream to an events.SessionRecorder
+// by adding a no-op io.Writer (required by the interface).
+type streamRecorder struct {
+	apievents.Stream
+}
+
+func (s *streamRecorder) Write(p []byte) (int, error) { return len(p), nil }
+
+// newTestAudit creates a common.Audit that calls onRecord for each recorded event.
+func newTestAudit(t *testing.T, onRecord func(apievents.PreparedSessionEvent)) common.Audit {
+	t.Helper()
+	streamer, err := events.NewCallbackStreamer(events.CallbackStreamerConfig{
+		Inner: events.NewDiscardStreamer(),
+		OnRecordEvent: func(_ context.Context, _ session.ID, pe apievents.PreparedSessionEvent) error {
+			onRecord(pe)
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	stream, err := streamer.CreateAuditStream(t.Context(), "test-session")
+	require.NoError(t, err)
+	audit, err := common.NewAudit(common.AuditConfig{
+		Emitter:  events.NewDiscardEmitter(),
+		Recorder: events.WithNoOpPreparer(&streamRecorder{stream}),
+	})
+	require.NoError(t, err)
+	return audit
+}
+
+// newTestApp creates a types.Application configured with the given LLM options.
+func newTestApp(t *testing.T, llm *types.LLM) types.Application {
+	t.Helper()
+	app, err := types.NewAppV3(types.Metadata{
+		Name: "test-llm-app",
+	}, types.AppSpecV3{
+		LLM: llm,
+	})
+	require.NoError(t, err)
+	return app
+}
+
+// newTestSessionRequest creates an *http.Request with a SessionContext attached.
+func newTestSessionRequest(t *testing.T, method, addr string, path string, body io.Reader, sessionCtx *common.SessionContext) *http.Request {
+	t.Helper()
+	target, err := url.JoinPath(addr, path)
+	require.NoError(t, err)
+	req := httptest.NewRequest(method, target, body)
+	return common.WithSessionContext(req, sessionCtx)
+}
+
+func newTestHandler(t *testing.T, tr *http.Transport) *Handler {
+	t.Helper()
+	h, err := NewHandler(t.Context(), HandlerConfig{
+		Log:       slog.Default(),
+		Transport: tr,
+	})
+	require.NoError(t, err)
+	return h
+}

--- a/lib/srv/app/llm/metrics.go
+++ b/lib/srv/app/llm/metrics.go
@@ -1,0 +1,128 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package llm
+
+import (
+	"github.com/gravitational/trace"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/observability/metrics"
+)
+
+const (
+	// llmSubsystem is used to prefix Prometheus metrics for this subsystem.
+	//
+	// See https://prometheus.io/docs/practices/naming/#subsystem-name
+	llmSubsystem = "llm"
+)
+
+// llmMetrics contains all metrics related to LLM access.
+type llmMetrics struct {
+	// requestDuration keeps track of the request duration, in seconds.
+	requestDuration *prometheus.HistogramVec
+	// requestSize keeps track of the request size, in bytes.
+	requestSize *prometheus.HistogramVec
+	// providerRequestDuration keeps track of the provider request duration, in
+	// seconds.
+	providerRequestDuration *prometheus.HistogramVec
+	// providerRequestDuration keeps track of the provider response size, in
+	// bytes.
+	providerResponseSize *prometheus.HistogramVec
+	// inputTokens keeps track of the LLM input token count.
+	inputTokens *prometheus.CounterVec
+	// outputTokens keeps track of the LLM output token count.
+	outputTokens *prometheus.CounterVec
+}
+
+func newMetrics(reg *metrics.Registry) (*llmMetrics, error) {
+	m := &llmMetrics{
+		requestDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: reg.Namespace(),
+				Subsystem: llmSubsystem,
+				Name:      "request_duration_seconds",
+				Help:      "Latency distribution of the total request time.",
+				Buckets:   prometheus.DefBuckets,
+			},
+			[]string{teleport.ComponentLabel, "format", "provider"},
+		),
+		requestSize: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: reg.Namespace(),
+				Subsystem: llmSubsystem,
+				Name:      "request_size_bytes",
+				Help:      "Distribution of the request size.",
+				// 1KiB ... 32MiB
+				Buckets: prometheus.ExponentialBuckets(1024, 2, 16),
+			},
+			[]string{teleport.ComponentLabel, "format", "provider"},
+		),
+		providerRequestDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: reg.Namespace(),
+				Subsystem: llmSubsystem,
+				Name:      "provider_request_duration_seconds",
+				Help:      "Latency distribution of the provider request time.",
+				Buckets:   prometheus.DefBuckets,
+			},
+			[]string{teleport.ComponentLabel, "format", "provider", "streaming"},
+		),
+		providerResponseSize: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: reg.Namespace(),
+				Subsystem: llmSubsystem,
+				Name:      "provider_response_size_bytes",
+				Help:      "Distribution of the provider response size.",
+				// Responses doesn't have a hard limit, meaning they can go up to
+				// any size. We might need to tweak the bucket sizes in the future
+				// to better match the actual response sizes.
+				//
+				// 1KiB ... 32MiB
+				Buckets: prometheus.ExponentialBuckets(1024, 2, 16),
+			},
+			[]string{teleport.ComponentLabel, "format", "provider", "streaming"},
+		),
+		inputTokens: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: reg.Namespace(),
+				Subsystem: llmSubsystem,
+				Name:      "input_tokens_count",
+				Help:      "Number of input tokens sent by clients.",
+			},
+			[]string{teleport.ComponentLabel, "format"},
+		),
+		outputTokens: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: reg.Namespace(),
+				Subsystem: llmSubsystem,
+				Name:      "output_tokens_count",
+				Help:      "Number of output tokens sent by providers.",
+			},
+			[]string{teleport.ComponentLabel, "format"},
+		),
+	}
+
+	return m, trace.NewAggregate(
+		reg.Register(m.requestDuration),
+		reg.Register(m.requestSize),
+		reg.Register(m.providerRequestDuration),
+		reg.Register(m.providerResponseSize),
+		reg.Register(m.inputTokens),
+		reg.Register(m.outputTokens),
+	)
+}

--- a/lib/srv/app/llm/models/models.go
+++ b/lib/srv/app/llm/models/models.go
@@ -1,0 +1,46 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package models
+
+import (
+	"cmp"
+	"strings"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// ConvertName takes a set model name and do the conversion based on the
+// mapping rules.
+func ConvertName(mappings []*types.LLM_Model, fallbackModelName string, reqModel string) (string, bool) {
+	if len(mappings) == 0 && reqModel != "" {
+		return reqModel, true
+	}
+
+	for _, m := range mappings {
+		if strings.EqualFold(strings.TrimSpace(reqModel), m.Name) {
+			return cmp.Or(m.ProviderName, m.Name), true
+		}
+	}
+
+	for _, m := range mappings {
+		if m.Name == fallbackModelName {
+			return cmp.Or(m.ProviderName, m.Name), true
+		}
+	}
+
+	return "", false
+}

--- a/lib/srv/app/llm/models/models_test.go
+++ b/lib/srv/app/llm/models/models_test.go
@@ -1,0 +1,115 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestConvertModelName(t *testing.T) {
+	for name, tc := range map[string]struct {
+		mappings      []*types.LLM_Model
+		fallbackModel string
+		reqModel      string
+		expected      string
+		expectedFound bool
+	}{
+		"exact match": {
+			mappings: []*types.LLM_Model{
+				{Name: "claude-sonnet", ProviderName: "us.anthropic.claude-sonnet-v2:0"},
+			},
+			reqModel:      "claude-sonnet",
+			expected:      "us.anthropic.claude-sonnet-v2:0",
+			expectedFound: true,
+		},
+		"case insensitive match": {
+			mappings: []*types.LLM_Model{
+				{Name: "claude-sonnet", ProviderName: "us.anthropic.claude-sonnet-v2:0"},
+			},
+			reqModel:      "Claude-Sonnet",
+			expected:      "us.anthropic.claude-sonnet-v2:0",
+			expectedFound: true,
+		},
+		"leading and trailing whitespace trimmed": {
+			mappings: []*types.LLM_Model{
+				{Name: "claude-sonnet", ProviderName: "us.anthropic.claude-sonnet-v2:0"},
+			},
+			reqModel:      "  claude-sonnet  ",
+			expected:      "us.anthropic.claude-sonnet-v2:0",
+			expectedFound: true,
+		},
+		"first matching mapping wins": {
+			mappings: []*types.LLM_Model{
+				{Name: "claude-sonnet", ProviderName: "first-match"},
+				{Name: "claude-sonnet", ProviderName: "second-match"},
+			},
+			reqModel:      "claude-sonnet",
+			expected:      "first-match",
+			expectedFound: true,
+		},
+		"no match returns fallback model": {
+			mappings: []*types.LLM_Model{
+				{Name: "claude-opus", ProviderName: "us.anthropic.claude-opus:0"},
+			},
+			fallbackModel: "claude-opus",
+			reqModel:      "claude-haiku",
+			expected:      "us.anthropic.claude-opus:0",
+			expectedFound: true,
+		},
+		"nil mappings returns provided model": {
+			mappings:      nil,
+			reqModel:      "claude-sonnet",
+			expected:      "claude-sonnet",
+			expectedFound: true,
+		},
+		"empty requested model found false": {
+			mappings: []*types.LLM_Model{
+				{Name: "claude-sonnet", ProviderName: "us.anthropic.claude-sonnet-v2:0"},
+			},
+			reqModel:      "",
+			expected:      "",
+			expectedFound: false,
+		},
+		"empty fallback model and no match returns empty": {
+			mappings: []*types.LLM_Model{
+				{Name: "claude-sonnet", ProviderName: "us.anthropic.claude-sonnet-v2:0"},
+			},
+			fallbackModel: "",
+			reqModel:      "unknown-model",
+			expected:      "",
+			expectedFound: false,
+		},
+		"match without provider name": {
+			mappings: []*types.LLM_Model{
+				{Name: "claude-sonnet"},
+			},
+			reqModel:      "claude-sonnet",
+			expected:      "claude-sonnet",
+			expectedFound: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result, found := ConvertName(tc.mappings, tc.fallbackModel, tc.reqModel)
+			require.Equal(t, tc.expected, result)
+			require.Equal(t, tc.expectedFound, found)
+		})
+	}
+}

--- a/lib/srv/app/llm/recorder/recorder.go
+++ b/lib/srv/app/llm/recorder/recorder.go
@@ -1,0 +1,336 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package recorder provides a provider-agnostic LLM response recorder. The
+// recorder modifies and records the upstream provider response while forwarding
+// it downstream, tracking the bytes written, the token usage and any provider
+// error. All provider-specific behavior is supplied through the [Endpoint]
+// interface.
+package recorder
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"mime"
+	"net/http"
+	"sync"
+	"sync/atomic"
+
+	"github.com/gravitational/trace"
+
+	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+)
+
+// Endpoint supplies the provider-specific behavior needed by a
+// [ResponseRecorder].
+type Endpoint interface {
+	EndpointNonStreaming
+	EndpointStreaming
+
+	// MarshalError encodes err into the provider's on-the-wire error format. It
+	// must always return a valid payload, even when err cannot be marshaled.
+	MarshalError(err error) (body []byte)
+}
+
+// EndpointNonStreaming contains the endpoint functions used for non streaming
+// requests.
+type EndpointNonStreaming interface {
+	// ParseError parses a non-streaming error response body into a provider
+	// error. statusCode is the HTTP status of the response. The second return
+	// value is non-nil only when the body itself could not be parsed.
+	ParseError(statusCode int, body []byte) (providerError *llmerrors.ProviderError, err error)
+	// ParseUsage extracts the input/output token usage from a non-streaming
+	// success response body.
+	ParseUsage(body []byte) (inputTokens int, outputTokens int, err error)
+}
+
+// EndpointNonStreaming contains the endpoint functions used for streaming
+// requests.
+type EndpointStreaming interface {
+	// ProcessSSE reads SSE events from reader, forwarding them to writer while
+	// recording token usage.
+	ProcessSSE(ctx context.Context, log *slog.Logger, reader io.ReadCloser, writer io.Writer) (inputTokens int, outputTokens int, err error)
+}
+
+// ResponseRecorder is the provider-agnostic response modifier and recorder.
+type ResponseRecorder struct {
+	http.ResponseWriter
+	flusher  http.Flusher
+	endpoint Endpoint
+
+	log          *slog.Logger
+	status       int
+	written      int
+	containsErr  bool
+	err          error
+	responseType func() string
+	closed       atomic.Bool
+
+	// usage-related fields
+	inputTokensCount  int
+	outputTokensCount int
+
+	// used for non-streaming requests.
+	writer io.Writer
+	buf    *bytes.Buffer
+
+	// used for streaming requests.
+	startSSEOnce sync.Once
+	streamDoneCh chan struct{}
+	sseWriter    io.WriteCloser
+
+	// This values is guarded as atomic values since `Flush` calls may happen
+	// from different goroutines.
+	skipFlush atomic.Bool
+}
+
+// NewResponseRecorder creates a new response recorder backed by the given
+// endpoint.
+func NewResponseRecorder(log *slog.Logger, w http.ResponseWriter, endpoint Endpoint) (*ResponseRecorder, error) {
+	f, ok := w.(http.Flusher)
+	if !ok {
+		return nil, trace.BadParameter("response writer must be flusher")
+	}
+	r := &ResponseRecorder{
+		ResponseWriter: w,
+		endpoint:       endpoint,
+		// Defaults to 200, this matches the [http.ResponseWriter] expectation when
+		// [WriteHeader] is not called.
+		status:  http.StatusOK,
+		flusher: f,
+		log:     log,
+		buf:     new(bytes.Buffer),
+	}
+	r.writer = io.MultiWriter(w, r.buf)
+	r.responseType = sync.OnceValue(func() string {
+		mediaType, _, err := mime.ParseMediaType(w.Header().Get("Content-Type"))
+		if err != nil {
+			// No need to log the error here, the caller of this function will
+			// do the proper handling of this case (including logs).
+			return ""
+		}
+		return mediaType
+	})
+	return r, nil
+}
+
+// WriteHeader implements [http.ResponseWriter].
+func (r *ResponseRecorder) WriteHeader(status int) {
+	// In case of errors or response type not JSON, we delete the original
+	// Content-Length because we might rewrite the result contents, changing the
+	// total length.
+	contentType := r.responseType()
+	if status != http.StatusOK || contentType != "application/json" {
+		r.Header().Del("Content-Length")
+	}
+
+	// When the result is an unsupported content-type we set as error
+	// here since it might not contain a body (resulting in no [Write] calls).
+	//
+	// In addition, we "force" an error status code. This is done to keep the
+	// API contract where errors return only when status code is not 200.
+	if contentType != "application/json" && contentType != "text/event-stream" {
+		status = http.StatusInternalServerError
+		r.log.ErrorContext(context.Background(), "unsupported response content-type", "content_type", contentType)
+		r.err = llmerrors.NewProviderError(llmerrors.ErrBadResponse, "unsupported %q response type", contentType)
+	}
+	if status != http.StatusOK {
+		r.containsErr = true
+	}
+	r.status = status
+	r.ResponseWriter.WriteHeader(status)
+}
+
+// Write implements [http.ResponseWriter].
+func (r *ResponseRecorder) Write(data []byte) (int, error) {
+	if r.status != http.StatusOK {
+		// Necessary because [WriteHeader] might not have been called before
+		// [Write].
+		r.containsErr = true
+		return r.writeError(data)
+	}
+
+	contentType := r.responseType()
+	switch contentType {
+	case "application/json":
+		n, err := r.writer.Write(data)
+		r.written += n
+		return n, trace.Wrap(err)
+	case "text/event-stream":
+		return r.writeStream(data)
+	default:
+		// This handling exists because callers are not guaranteed to call
+		// [WriteHeader]. So we must mimic the behavior here in case it wasn't
+		// called before.
+		//
+		// Note that at this point, we cannot change the status code returned,
+		// but we'll still return an error object here.
+		if !r.containsErr {
+			r.log.ErrorContext(context.Background(), "unsupported response content-type", "content_type", contentType)
+			r.err = llmerrors.NewProviderError(llmerrors.ErrBadResponse, "unsupported %q response type", contentType)
+			r.containsErr = true
+		}
+		return len(data), nil
+	}
+}
+
+// Flush implements [http.Flusher].
+func (r *ResponseRecorder) Flush() {
+	if r.skipFlush.Load() {
+		return
+	}
+
+	if r.flusher != nil {
+		r.flusher.Flush()
+	}
+}
+
+// Written is the number of bytes written in the downstream connection.
+//
+// Must be called after [ResponseRecorder.Close].
+func (r *ResponseRecorder) Written() int {
+	return r.written
+}
+
+// Err is the error encountered while processing/forwarding the response.
+//
+// Must be called after [ResponseRecorder.Close].
+func (r *ResponseRecorder) Err() error {
+	return r.err
+}
+
+// InputTokensCount is the number of input tokens that were used on the request.
+//
+// Must be called after [ResponseRecorder.Close].
+func (r *ResponseRecorder) InputTokensCount() int {
+	return r.inputTokensCount
+}
+
+// OutputTokensCount is the number of output tokens generated by the request.
+//
+// Must be called after [ResponseRecorder.Close].
+func (r *ResponseRecorder) OutputTokensCount() int {
+	return r.outputTokensCount
+}
+
+// Close implements [io.Closer]. Errors returned are only related to the
+// recorder teardown. For processing errors, callers must retrieve errors using
+// [ResponseRecorder.Err].
+//
+// Must be called once.
+func (r *ResponseRecorder) Close() error {
+	if r.closed.Swap(true) {
+		return nil
+	}
+
+	// In case the response contains an error, this is the place where we write
+	// it back to the upstream.
+	if r.containsErr {
+		// Error might already be defined, so we can skip parsing it.
+		if r.err == nil {
+			apiErr, err := r.endpoint.ParseError(r.status, r.buf.Bytes())
+			// Failure here could indicate that the message is incomplete or
+			// that it is malformed.
+			if err != nil {
+				r.log.WarnContext(context.Background(), "unable to parse the provider error message", "error", err)
+				r.err = llmerrors.NewProviderError(llmerrors.ErrBadResponse, "invalid JSON response")
+			} else if apiErr != nil {
+				r.err = apiErr
+			}
+		}
+
+		encodedErr := r.endpoint.MarshalError(r.err)
+		r.written += len(encodedErr)
+		if _, err := r.ResponseWriter.Write(encodedErr); err != nil {
+			r.log.WarnContext(context.Background(), "unable to write error message to downstream", "error", err)
+		}
+	}
+
+	if r.sseWriter != nil {
+		err := r.sseWriter.Close()
+		<-r.streamDoneCh
+		return trace.Wrap(err)
+	}
+
+	// When request contains error, it won't contain usage information, so we
+	// can skip it.
+	if r.containsErr {
+		return nil
+	}
+
+	// Non-streaming requests we must try to extract result metrics at the end.
+	inputTokens, outputTokens, err := r.endpoint.ParseUsage(r.buf.Bytes())
+	if err != nil {
+		r.log.WarnContext(context.Background(), "unable to parse messages result", "error", err)
+		r.err = llmerrors.NewProviderError(llmerrors.ErrBadResponse, "invalid JSON response")
+		return nil
+	}
+
+	r.inputTokensCount = inputTokens
+	r.outputTokensCount = outputTokens
+	return nil
+}
+
+func (r *ResponseRecorder) writeStream(data []byte) (int, error) {
+	// first write should initialize the pipe and start the read events
+	// goroutine.
+	r.startSSEOnce.Do(func() {
+		pr, pw := io.Pipe()
+		r.sseWriter = pw
+		r.streamDoneCh = make(chan struct{})
+		r.skipFlush.Store(true)
+		go func() {
+			defer close(r.streamDoneCh)
+			w := &writeFlusher{writer: r.ResponseWriter, flushFunc: r.flusher.Flush}
+			r.inputTokensCount, r.outputTokensCount, r.err = r.endpoint.ProcessSSE(context.Background(), r.log, pr, w)
+			r.written = w.written
+		}()
+	})
+
+	return r.sseWriter.Write(data)
+}
+
+func (r *ResponseRecorder) writeError(data []byte) (int, error) {
+	// Collect the error, but do not immediately forward it as we might need
+	// to perform modifications to it.
+	n, err := r.buf.Write(data)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+
+	// We might not write the error data as is, but we should return the
+	// original written value for writter that double check the total amount of
+	// data written.
+	return n, nil
+}
+
+type writeFlusher struct {
+	written   int
+	writer    io.Writer
+	flushFunc func()
+}
+
+func (w *writeFlusher) Write(data []byte) (int, error) {
+	n, err := w.writer.Write(data)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+	w.written += n
+	w.flushFunc()
+	return n, nil
+}

--- a/lib/srv/app/llm/recorder/recorder_test.go
+++ b/lib/srv/app/llm/recorder/recorder_test.go
@@ -1,0 +1,420 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package recorder_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+	"github.com/gravitational/teleport/lib/srv/app/llm/recorder"
+	llmtesting "github.com/gravitational/teleport/lib/srv/app/llm/testing"
+)
+
+// TestNonStreaming exercises the provider-agnostic non-streaming
+// (application/json) recorder pipeline against a stub endpoint.
+func TestNonStreaming(t *testing.T) {
+	t.Parallel()
+
+	const successResponse = `{"In":15,"Out":20}`
+
+	for name, tc := range map[string]struct {
+		providerStatusCode           int
+		providerBody                 string
+		providerContentType          string
+		expectedDownstreamBody       require.ValueAssertionFunc
+		expectedDownstreamStatusCode require.ValueAssertionFunc
+		expectedContentLength        require.ValueAssertionFunc
+		expectedRecorder             require.ValueAssertionFunc
+	}{
+		"success forwards body and records usage": {
+			providerStatusCode:  http.StatusOK,
+			providerBody:        successResponse,
+			providerContentType: "application/json",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.Equal(tt, successResponse, i1.(string), i2...)
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
+			expectedContentLength:        expectContentLength(len(successResponse)),
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec := i1.(*recorder.ResponseRecorder)
+				require.Equal(tt, len(successResponse), rec.Written())
+				require.Equal(tt, 15, rec.InputTokensCount(), i2...)
+				require.Equal(tt, 20, rec.OutputTokensCount(), i2...)
+				require.NoError(tt, rec.Err(), i2...)
+			},
+		},
+		"unsupported content-type forces error": {
+			providerStatusCode:  http.StatusOK,
+			providerBody:        "Non-JSON result",
+			providerContentType: "text/html",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				body := i1.(string)
+				require.Contains(tt, body, llmerrors.ErrBadResponse.Error(), "expected Teleport message")
+				require.Contains(tt, body, "text/html", "expected unsupported content-type detail")
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusInternalServerError),
+			expectedContentLength:        require.Empty,
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec := i1.(*recorder.ResponseRecorder)
+				require.NotEmpty(tt, rec.Written(), i2...)
+				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+			},
+		},
+		"error status is parsed by endpoint": {
+			providerStatusCode:  http.StatusUnauthorized,
+			providerBody:        `{"error":"boom"}`,
+			providerContentType: "application/json",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				body := i1.(string)
+				require.Contains(tt, body, "stub provider error", "expected endpoint-provided detail")
+				require.Contains(tt, body, llmerrors.ErrUnauthorized.Error(), "expected mapped Teleport message")
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusUnauthorized),
+			expectedContentLength:        require.Empty,
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec := i1.(*recorder.ResponseRecorder)
+				require.NotEmpty(tt, rec.Written(), i2...)
+				require.Equal(tt, 0, rec.OutputTokensCount(), i2...)
+				require.ErrorIs(tt, rec.Err(), llmerrors.ErrUnauthorized, i2...)
+			},
+		},
+		"empty success body is bad response": {
+			providerStatusCode:           http.StatusOK,
+			providerBody:                 "",
+			providerContentType:          "application/json",
+			expectedDownstreamBody:       require.Empty,
+			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
+			expectedContentLength:        expectContentLength(0),
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec := i1.(*recorder.ResponseRecorder)
+				require.Empty(tt, rec.Written(), i2...)
+				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+			},
+		},
+		"empty error body falls back to bad response": {
+			providerStatusCode:  http.StatusUnauthorized,
+			providerBody:        "",
+			providerContentType: "application/json",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.Contains(tt, i1.(string), llmerrors.ErrBadResponse.Error(), "expected fallback Teleport message")
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusUnauthorized),
+			expectedContentLength:        require.Empty,
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec := i1.(*recorder.ResponseRecorder)
+				require.NotEmpty(tt, rec.Written(), i2...)
+				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+			},
+		},
+		"unparseable success body forwarded as-is": {
+			providerStatusCode:  http.StatusOK,
+			providerBody:        `{"In":`,
+			providerContentType: "application/json",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.Equal(tt, `{"In":`, i1.(string), i2...)
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
+			expectedContentLength:        expectContentLength(len(`{"In":`)),
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec := i1.(*recorder.ResponseRecorder)
+				require.Equal(tt, len(`{"In":`), rec.Written(), i2...)
+				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+			},
+		},
+		"no write header success uses default 200": {
+			// WriteHeader is not called.
+			providerStatusCode:  0,
+			providerBody:        successResponse,
+			providerContentType: "application/json",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.Equal(tt, successResponse, i1.(string), i2...)
+			},
+			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
+			expectedContentLength:        expectContentLength(len(successResponse)),
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec := i1.(*recorder.ResponseRecorder)
+				require.Equal(tt, len(successResponse), rec.Written(), i2...)
+				require.Equal(tt, 15, rec.InputTokensCount(), i2...)
+				require.Equal(tt, 20, rec.OutputTokensCount(), i2...)
+				require.NoError(tt, rec.Err(), i2...)
+			},
+		},
+		"no write header unsupported content-type": {
+			// WriteHeader is not called.
+			providerStatusCode:  0,
+			providerBody:        "Non-JSON result",
+			providerContentType: "text/html",
+			expectedDownstreamBody: func(tt require.TestingT, i1 any, i2 ...any) {
+				body := i1.(string)
+				require.Contains(tt, body, llmerrors.ErrBadResponse.Error(), "expected Teleport message")
+				require.Contains(tt, body, "text/html", "expected unsupported content-type detail")
+			},
+			// Without WriteHeader the recorder cannot force a 500 status nor
+			// strip the original Content-Length, so the status stays 200.
+			expectedDownstreamStatusCode: expectStatus(http.StatusOK),
+			expectedContentLength:        expectContentLength(len("Non-JSON result")),
+			expectedRecorder: func(tt require.TestingT, i1 any, i2 ...any) {
+				rec := i1.(*recorder.ResponseRecorder)
+				require.NotEmpty(tt, rec.Written(), i2...)
+				require.ErrorIs(tt, rec.Err(), llmerrors.ErrBadResponse, i2...)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			run := func(t *testing.T, write func(rec *recorder.ResponseRecorder)) {
+				w := httptest.NewRecorder()
+				rec, err := recorder.NewResponseRecorder(slog.Default(), w, newFakeEndpoint())
+				require.NoError(t, err)
+
+				rec.Header().Add("Content-Type", tc.providerContentType)
+				rec.Header().Add("Content-Length", strconv.Itoa(len(tc.providerBody)))
+				// A status code of 0 simulates a caller that never calls
+				// WriteHeader, exercising the default 200 status path.
+				if tc.providerStatusCode != 0 {
+					rec.WriteHeader(tc.providerStatusCode)
+				}
+				write(rec)
+
+				require.NoError(t, rec.Close())
+
+				resp := w.Result()
+				body, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+				tc.expectedRecorder(t, rec)
+				tc.expectedDownstreamStatusCode(t, resp.StatusCode)
+				tc.expectedContentLength(t, w.Header().Get("Content-Length"))
+				tc.expectedDownstreamBody(t, string(body))
+			}
+
+			// Provider responses can arrive all at once (single write) or
+			// across multiple writes (more realistic for large responses).
+			t.Run("single write", func(t *testing.T) {
+				run(t, func(rec *recorder.ResponseRecorder) {
+					if len(tc.providerBody) > 0 {
+						_, err := io.WriteString(rec, tc.providerBody)
+						require.NoError(t, err)
+					}
+				})
+			})
+			t.Run("multi write", func(t *testing.T) {
+				run(t, func(rec *recorder.ResponseRecorder) {
+					for chunk := range slices.Chunk([]byte(tc.providerBody), 1) {
+						_, err := rec.Write(chunk)
+						require.NoError(t, err)
+					}
+				})
+			})
+		})
+	}
+}
+
+// TestStreaming exercises the provider-agnostic streaming (text/event-stream)
+// recorder pipeline: the recorder hands the stream to the endpoint's ProcessSSE
+// and records the bytes written, usage and error it reports.
+func TestStreaming(t *testing.T) {
+	t.Parallel()
+
+	const stream = "event: message\n" + `data: {"hello":"world"}` + "\n\n"
+
+	t.Run("success records usage and forwards stream", func(t *testing.T) {
+		t.Parallel()
+
+		w := httptest.NewRecorder()
+		rec, err := recorder.NewResponseRecorder(slog.Default(), w, newFakeEndpoint())
+		require.NoError(t, err)
+
+		rec.Header().Add("Content-Type", "text/event-stream")
+		rec.WriteHeader(http.StatusOK)
+		_, err = io.WriteString(rec, stream)
+		require.NoError(t, err)
+		require.NoError(t, rec.Close())
+
+		resp := w.Result()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, stream, string(body))
+		require.Equal(t, len(stream), rec.Written())
+		require.Equal(t, 15, rec.InputTokensCount())
+		require.Equal(t, 60, rec.OutputTokensCount())
+		require.NoError(t, rec.Err())
+	})
+
+	t.Run("processor error surfaces via Err", func(t *testing.T) {
+		t.Parallel()
+
+		ep := newFakeEndpoint()
+		ep.processSSE = func(_ context.Context, _ *slog.Logger, r io.ReadCloser, _ io.Writer) (int, int, error) {
+			defer r.Close()
+			_, _ = io.ReadAll(r)
+			return 0, 0, llmerrors.ErrRejected
+		}
+
+		w := httptest.NewRecorder()
+		rec, err := recorder.NewResponseRecorder(slog.Default(), w, ep)
+		require.NoError(t, err)
+
+		rec.Header().Add("Content-Type", "text/event-stream")
+		rec.WriteHeader(http.StatusOK)
+		_, err = io.WriteString(rec, stream)
+		require.NoError(t, err)
+		require.NoError(t, rec.Close())
+
+		require.ErrorIs(t, rec.Err(), llmerrors.ErrRejected)
+	})
+
+	t.Run("empty stream writes nothing", func(t *testing.T) {
+		t.Parallel()
+
+		w := httptest.NewRecorder()
+		rec, err := recorder.NewResponseRecorder(slog.Default(), w, newFakeEndpoint())
+		require.NoError(t, err)
+
+		rec.Header().Add("Content-Type", "text/event-stream")
+		rec.WriteHeader(http.StatusOK)
+		// No body written, so the SSE processing goroutine never starts.
+		require.NoError(t, rec.Close())
+
+		require.Empty(t, rec.Written())
+	})
+}
+
+// TestDownstreamWriteFailure ensures the recorder still surfaces the semantic
+// error via Err() when writing to a broken downstream connection.
+func TestDownstreamWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-streaming error write", func(t *testing.T) {
+		t.Parallel()
+
+		w := llmtesting.NewFailingResponseWriter("application/json")
+		rec, err := recorder.NewResponseRecorder(slog.Default(), w, newFakeEndpoint())
+		require.NoError(t, err)
+
+		rec.WriteHeader(http.StatusUnauthorized)
+		// Empty error body drives the ParseError fallback.
+		require.NoError(t, rec.Close())
+		require.ErrorIs(t, rec.Err(), llmerrors.ErrBadResponse)
+	})
+
+	t.Run("streaming processor error", func(t *testing.T) {
+		t.Parallel()
+
+		ep := newFakeEndpoint()
+		ep.processSSE = func(_ context.Context, _ *slog.Logger, r io.ReadCloser, w io.Writer) (int, int, error) {
+			defer r.Close()
+			_, _ = io.ReadAll(r)
+			// The provider error must be preserved even when the downstream
+			// write fails.
+			_, _ = w.Write([]byte("ignored"))
+			return 0, 0, llmerrors.ErrRejected
+		}
+
+		w := llmtesting.NewFailingResponseWriter("text/event-stream")
+		rec, err := recorder.NewResponseRecorder(slog.Default(), w, ep)
+		require.NoError(t, err)
+
+		rec.WriteHeader(http.StatusOK)
+		_, err = io.WriteString(rec, "event: message\ndata: {}\n\n")
+		require.NoError(t, err)
+		// Close waits on the streaming goroutine, so Err() is populated.
+		require.NoError(t, rec.Close())
+		require.ErrorIs(t, rec.Err(), llmerrors.ErrRejected)
+	})
+}
+
+// fakeEndpoint is a configurable [recorder.Endpoint] stub used to exercise the
+// provider-agnostic recorder pipeline in isolation.
+type fakeEndpoint struct {
+	parseError   func(int, []byte) (*llmerrors.ProviderError, error)
+	marshalError func(error) []byte
+	parseUsage   func([]byte) (int, int, error)
+	processSSE   func(context.Context, *slog.Logger, io.ReadCloser, io.Writer) (int, int, error)
+}
+
+func (e fakeEndpoint) ParseError(status int, body []byte) (*llmerrors.ProviderError, error) {
+	return e.parseError(status, body)
+}
+
+func (e fakeEndpoint) MarshalError(err error) []byte { return e.marshalError(err) }
+
+func (e fakeEndpoint) ParseUsage(body []byte) (int, int, error) {
+	return e.parseUsage(body)
+}
+
+func (e fakeEndpoint) ProcessSSE(ctx context.Context, log *slog.Logger, r io.ReadCloser, w io.Writer) (int, int, error) {
+	return e.processSSE(ctx, log, r, w)
+}
+
+func newFakeEndpoint() fakeEndpoint {
+	return fakeEndpoint{
+		parseError: func(_ int, body []byte) (*llmerrors.ProviderError, error) {
+			if len(body) == 0 {
+				return nil, errors.New("empty error body")
+			}
+			return llmerrors.NewProviderError(llmerrors.ErrUnauthorized, "stub provider error"), nil
+		},
+		marshalError: func(err error) []byte {
+			return fmt.Appendf(nil, `{"message":%q}`, err.Error())
+		},
+		parseUsage: func(body []byte) (int, int, error) {
+			var u struct{ In, Out int }
+			if err := json.Unmarshal(body, &u); err != nil {
+				return 0, 0, err
+			}
+			return u.In, u.Out, nil
+		},
+		processSSE: func(_ context.Context, _ *slog.Logger, r io.ReadCloser, w io.Writer) (int, int, error) {
+			defer r.Close()
+			data, err := io.ReadAll(r)
+			if err != nil {
+				return 0, 0, err
+			}
+			if _, err := w.Write(data); err != nil {
+				return 0, 0, err
+			}
+			return 15, 60, nil
+		},
+	}
+}
+
+func expectStatus(statusCode int) require.ValueAssertionFunc {
+	return func(tt require.TestingT, i1 any, i2 ...any) {
+		require.Equal(tt, statusCode, i1, i2...)
+	}
+}
+
+func expectContentLength(length int) require.ValueAssertionFunc {
+	return func(tt require.TestingT, i1 any, i2 ...any) {
+		contentLength, err := strconv.Atoi(i1.(string))
+		require.NoError(tt, err, "expected content length to not be empty")
+		require.Equal(tt, length, contentLength, i2...)
+	}
+}

--- a/lib/srv/app/llm/request/request.go
+++ b/lib/srv/app/llm/request/request.go
@@ -17,6 +17,8 @@
 package request
 
 import (
+	"context"
+	"log/slog"
 	"net/http"
 	"net/url"
 
@@ -27,25 +29,41 @@ import (
 
 // Config is config used to create a new provide request.
 type Config struct {
-	// LLM inference endpoint configuration.
-	LLM *types.LLM
+	// Logger is the logger used to emit log entries.
+	Logger *slog.Logger
+	// App is the app being served.
+	App types.Application
 	// DownstreamRequest is the received downstream request.
 	DownstreamRequest *http.Request
 	// ProviderURL is the provider URL address.
 	ProviderURL *url.URL
 	// GetAPIKeyFunc is the function used to retrieve Anthropic API keys.
 	GetAPIKeyFunc func() string
+	// SignBedrockRequest signs the AWS Bedrock request.
+	// Required for the AWS Bedrock provider.
+	SignBedrockRequest func(ctx context.Context, app types.Application, request *http.Request, requestBody []byte) error
 }
 
 func (c *Config) CheckAndSetDefaults() error {
-	if c.LLM == nil {
-		return trace.BadParameter("llm information is required")
+	if c.Logger == nil {
+		c.Logger = slog.Default()
+	}
+	if c.App == nil {
+		return trace.BadParameter("app is required")
+	}
+	if c.App.GetLLM() == nil {
+		return trace.BadParameter("app llm information is required")
 	}
 	if c.DownstreamRequest == nil {
 		return trace.BadParameter("downstream request is required")
 	}
 	if c.GetAPIKeyFunc == nil {
 		return trace.BadParameter("get api key function is required")
+	}
+	if c.App.GetLLM().Provider == types.LLMProviderAWSBedrock {
+		if c.SignBedrockRequest == nil {
+			return trace.BadParameter("sign aws bedrock request function is required for the bedrock provider")
+		}
 	}
 
 	return nil

--- a/lib/srv/app/llm/request/request.go
+++ b/lib/srv/app/llm/request/request.go
@@ -1,0 +1,52 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package request
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// Config is config used to create a new provide request.
+type Config struct {
+	// LLM inference endpoint configuration.
+	LLM *types.LLM
+	// DownstreamRequest is the received downstream request.
+	DownstreamRequest *http.Request
+	// ProviderURL is the provider URL address.
+	ProviderURL *url.URL
+	// GetAPIKeyFunc is the function used to retrieve Anthropic API keys.
+	GetAPIKeyFunc func() string
+}
+
+func (c *Config) CheckAndSetDefaults() error {
+	if c.LLM == nil {
+		return trace.BadParameter("llm information is required")
+	}
+	if c.DownstreamRequest == nil {
+		return trace.BadParameter("downstream request is required")
+	}
+	if c.GetAPIKeyFunc == nil {
+		return trace.BadParameter("get api key function is required")
+	}
+
+	return nil
+}

--- a/lib/srv/app/llm/testing/testing.go
+++ b/lib/srv/app/llm/testing/testing.go
@@ -1,0 +1,83 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package testing
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/httplib/sse"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+)
+
+// DiscardResponseWriter is a minimal [http.ResponseWriter] + [http.Flusher]
+// that discards all writes.
+type DiscardResponseWriter struct {
+	header http.Header
+}
+
+// NewDiscardResponseWriter creates a [DiscardResponseWriter] with the given
+// Content-Type header set (when non-empty).
+func NewDiscardResponseWriter(contentType string) *DiscardResponseWriter {
+	h := http.Header{}
+	if contentType != "" {
+		h.Set("Content-Type", contentType)
+	}
+	return &DiscardResponseWriter{header: h}
+}
+
+func (w *DiscardResponseWriter) Header() http.Header         { return w.header }
+func (w *DiscardResponseWriter) Write(p []byte) (int, error) { return len(p), nil }
+func (w *DiscardResponseWriter) WriteHeader(int)             {}
+func (w *DiscardResponseWriter) Flush()                      {}
+
+// FailingResponseWriter is a minimal [http.ResponseWriter] + [http.Flusher]
+// whose Write always fails, simulating a broken downstream connection.
+type FailingResponseWriter struct {
+	header http.Header
+}
+
+// NewFailingResponseWriter creates a [FailingResponseWriter] with the given
+// Content-Type header set (when non-empty).
+func NewFailingResponseWriter(contentType string) *FailingResponseWriter {
+	h := http.Header{}
+	if contentType != "" {
+		h.Set("Content-Type", contentType)
+	}
+	return &FailingResponseWriter{header: h}
+}
+
+func (w *FailingResponseWriter) Header() http.Header       { return w.header }
+func (w *FailingResponseWriter) Write([]byte) (int, error) { return 0, io.ErrClosedPipe }
+func (w *FailingResponseWriter) WriteHeader(int)           {}
+func (w *FailingResponseWriter) Flush()                    {}
+
+// ReadSSEOneEvent parses str and asserts it contains exactly one SSE event,
+// which it returns.
+func ReadSSEOneEvent(str string) (sse.Event, error) {
+	events, err := stream.Collect(sse.ReadEvents(strings.NewReader(str)))
+	if err != nil {
+		return sse.Event{}, trace.Wrap(err)
+	}
+	if len(events) != 1 {
+		return sse.Event{}, trace.BadParameter("must contain exactly one SSE event")
+	}
+	return events[0], nil
+}

--- a/lib/srv/app/session.go
+++ b/lib/srv/app/session.go
@@ -214,6 +214,11 @@ func (c *ConnectionsHandler) withGCPHandler(ctx context.Context, sess *sessionCh
 	return nil
 }
 
+func (c *ConnectionsHandler) withLLMHandler(ctx context.Context, sess *sessionChunk, identity *tlsca.Identity, app types.Application) error {
+	sess.handler = c.llmHandler
+	return nil
+}
+
 // acquire() increments in-flight request count by 1.
 // It is supposed to be paired with a `release()` call,
 // after the chunk is done with for the individual request

--- a/lib/srv/app/transport_test.go
+++ b/lib/srv/app/transport_test.go
@@ -271,6 +271,10 @@ func (noopAudit) OnDynamoDBRequest(context.Context, *common.SessionContext, *htt
 	return nil
 }
 
+func (noopAudit) OnLLMRequest(context.Context, *common.SessionContext, *http.Request, common.LLMRequest, common.LLMResponse) error {
+	return nil
+}
+
 func (noopAudit) EmitEvent(context.Context, apievents.AuditEvent) error {
 	return nil
 }


### PR DESCRIPTION
This PR backports LLM access for Anthropic (`anthropic` and `bedrock` providers). It includes the following:

- #68407
- #68370
- #68202
- #67744
- #67417
- #67042

## Manual Test Plan
### Test Environment

Local environment with a dedicated app service instance.

### Test Cases
- [x] Access using `curl` and `claude` (provider: `anthropic`)
  <details>
  <summary>App configuration</summary>

  ```yaml
  kind: app
  version: v3
  metadata:
    name: anthropic
    description: "Anthropic API"
    labels:
      env: local
  spec:
    inference:
      format: "anthropic"
      provider: "bedrock"
      models:
      - name: claude-opus-4-7
        provider_name: anthropic.claude-opus-4-7
      fallback_model: claude-opus-4-7
    aws:
      region: us-east-1
  ```
  </details>

  - [x] Mapped model.
  - [x] Streaming requests.
  - [x] Fallback model.
  - [x] Invalid messages/errors returned are from Teleport.
  - [x] Audit events are included in the app session recording. `tsh play -f json <chunk-id>`
  - [x] Prometheus metrics generated.

- [x] Access using `curl` and `claude` (provider: `bedrock`)
  <details>
  <summary>App configuration</summary>

  ```yaml
  kind: app
  version: v3
  metadata:
    name: anthropic
    description: "Anthropic API"
    labels:
      env: local
  spec:
    integration: aws-oidc-integration
    inference:
      format: "anthropic"
      provider: "bedrock"
      models:
      - name: claude-opus-4-7
        provider_name: anthropic.claude-opus-4-7
      fallback_model: claude-opus-4-7
    aws:
      region: us-east-1
  ```
  </details>

  - [x] Mapped model.
  - [x] Streaming requests.
  - [x] Fallback model.
  - [x] Invalid messages/errors returned are from Teleport.
  - [x] Audit events are included in the app session recording. `tsh play -f json <chunk-id>`
  - [x] Prometheus metrics generated.