### PR TITLE
Validate Linux Desktop Kind

### DIFF
--- a/lib/auth/linuxdesktop/linuxdesktopv1/desktop.go
+++ b/lib/auth/linuxdesktop/linuxdesktopv1/desktop.go
@@ -50,6 +50,8 @@ func ValidateLinuxDesktop(desktop *linuxdesktopv1pb.LinuxDesktop) error {
 		return trace.BadParameter("spec.addr is required")
 	case desktop.GetSpec().GetHostname() == "":
 		return trace.BadParameter("spec.hostname is required")
+	case desktop.GetKind() != types.KindLinuxDesktop:
+		return trace.BadParameter("kind must be %q", types.KindLinuxDesktop)
 	}
 	return nil
 }

--- a/lib/auth/linuxdesktop/linuxdesktopv1/desktop_test.go
+++ b/lib/auth/linuxdesktop/linuxdesktopv1/desktop_test.go
@@ -115,6 +115,26 @@ func TestValidateLinuxDesktop(t *testing.T) {
 			}.Build(),
 			wantErr: true,
 		},
+		{
+			name: "incorrect kind",
+			desktop: linuxdesktopv1pb.LinuxDesktop_builder{
+				Kind:     "node",
+				Version:  types.V1,
+				Metadata: valid.GetMetadata(),
+				Spec:     valid.GetSpec(),
+			}.Build(),
+			wantErr: true,
+		},
+		{
+			name: "empty kind",
+			desktop: linuxdesktopv1pb.LinuxDesktop_builder{
+				Kind:     "",
+				Version:  types.V1,
+				Metadata: valid.GetMetadata(),
+				Spec:     valid.GetSpec(),
+			}.Build(),
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/lib/services/local/linux_desktop.go
+++ b/lib/services/local/linux_desktop.go
@@ -34,6 +34,13 @@ type LinuxDesktopService struct {
 
 const linuxDesktopKey = "linux_desktop"
 
+func validateLinuxDesktopKind(d *linuxdesktopv1.LinuxDesktop) error {
+	if d.GetKind() != types.KindLinuxDesktop {
+		return trace.CompareFailed("expecting kind %q but got %q", types.KindLinuxDesktop, d.GetKind())
+	}
+	return nil
+}
+
 // NewLinuxDesktopService creates a new LinuxDesktopService.
 func NewLinuxDesktopService(b backend.Backend) (*LinuxDesktopService, error) {
 	service, err := generic.NewServiceWrapper(
@@ -43,6 +50,7 @@ func NewLinuxDesktopService(b backend.Backend) (*LinuxDesktopService, error) {
 			BackendPrefix: backend.NewKey(linuxDesktopKey),
 			MarshalFunc:   services.MarshalLinuxDesktop,
 			UnmarshalFunc: services.UnmarshalLinuxDesktop,
+			ValidateFunc:  validateLinuxDesktopKind,
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/local/linux_desktop_test.go
+++ b/lib/services/local/linux_desktop_test.go
@@ -76,6 +76,11 @@ func TestLinuxDesktopServiceCRUD(t *testing.T) {
 	out, _, err = service.ListLinuxDesktops(ctx, 10, "")
 	require.NoError(t, err)
 	require.Empty(t, out)
+
+	badKindDesktop := newLinuxDesktop("bad-kind")
+	badKindDesktop.SetKind("bad-kind")
+	_, err = service.CreateLinuxDesktop(ctx, badKindDesktop)
+	require.Error(t, err)
 }
 
 func newLinuxDesktop(name string) *linuxdesktopv1.LinuxDesktop {


### PR DESCRIPTION
Fixes https://github.com/gravitational/pressure-washing/issues/498. The bug allowed a user with write permissions for linux desktops to create desktops outside of their given labels.

## Manual Test Plan
### Test Environment
Running a cluster locally
### Test Cases
- [x] A user can create a linux desktop
- [x] A user can update a linux desktop
- [x] A user can upsert a linux desktop
- [x] A user cannot create a linux desktop with an incorrect kind
