### PR TITLE
Validate Linux Desktop Kind

### DIFF
--- a/lib/auth/linuxdesktop/linuxdesktopv1/desktop.go
+++ b/lib/auth/linuxdesktop/linuxdesktopv1/desktop.go
@@ -50,6 +50,8 @@ func ValidateLinuxDesktop(desktop *linuxdesktopv1pb.LinuxDesktop) error {
 		return trace.BadParameter("spec.addr is required")
 	case desktop.GetSpec().GetHostname() == "":
 		return trace.BadParameter("spec.hostname is required")
+	case desktop.GetKind() != types.KindLinuxDesktop:
+		return trace.BadParameter("kind must be %q", types.KindLinuxDesktop)
 	}
 	return nil
 }

--- a/lib/auth/linuxdesktop/linuxdesktopv1/desktop_test.go
+++ b/lib/auth/linuxdesktop/linuxdesktopv1/desktop_test.go
@@ -115,6 +115,26 @@ func TestValidateLinuxDesktop(t *testing.T) {
 			}.Build(),
 			wantErr: true,
 		},
+		{
+			name: "incorrect kind",
+			desktop: linuxdesktopv1pb.LinuxDesktop_builder{
+				Kind:     "node",
+				Version:  types.V1,
+				Metadata: valid.GetMetadata(),
+				Spec:     valid.GetSpec(),
+			}.Build(),
+			wantErr: true,
+		},
+		{
+			name: "empty kind",
+			desktop: linuxdesktopv1pb.LinuxDesktop_builder{
+				Kind:     "",
+				Version:  types.V1,
+				Metadata: valid.GetMetadata(),
+				Spec:     valid.GetSpec(),
+			}.Build(),
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes https://github.com/gravitational/pressure-washing/issues/498. The bug allowed a user with write permissions for linux desktops to create desktops outside of their given labels.

## Manual Test Plan
### Test Environment
Running a cluster locally
### Test Cases
- [x] A user can create a linux desktop
- [x] A user can update a linux desktop
- [x] A user can upsert a linux desktop
- [x] A user cannot create a linux desktop with an incorrect kind