### PR TITLE
[5] Add UploadHandler replay-object storage for beam traffic replay

### DIFF
--- a/lib/events/azsessions/azsessions.go
+++ b/lib/events/azsessions/azsessions.go
@@ -336,6 +336,12 @@ func (h *Handler) UploadSummary(ctx context.Context, sessionID session.ID, reade
 	return path, nil
 }
 
+// UploadReplayObject implements [events.UploadHandler]. Beam replay is not
+// supported by the Azure Blob Storage session backend.
+func (h *Handler) UploadReplayObject(ctx context.Context, sessionID session.ID, name string, reader io.Reader) (string, error) {
+	return "", trace.NotImplemented("beam replay is not supported by the Azure Blob Storage session backend")
+}
+
 // UploadMetadata implements [events.UploadHandler] and uploads the session
 // metadata.
 func (h *Handler) UploadMetadata(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
@@ -413,6 +419,12 @@ func (h *Handler) blobStream(ctx context.Context, blobClient *blockblob.Client) 
 		return nil, trace.Wrap(err)
 	}
 	return resp.Body, nil
+}
+
+// StreamReplayObjectRange implements [events.UploadHandler]. Beam replay is
+// not supported by the Azure Blob Storage session backend.
+func (h *Handler) StreamReplayObjectRange(ctx context.Context, sessionID session.ID, name string, offset, length int64) (io.ReadCloser, error) {
+	return nil, trace.NotImplemented("beam replay is not supported by the Azure Blob Storage session backend")
 }
 
 // StreamSessionMetadata implements [events.UploadHandler] and downloads a session's metadata.

--- a/lib/events/eventstest/uploader.go
+++ b/lib/events/eventstest/uploader.go
@@ -56,6 +56,7 @@ func NewMemoryUploader(cfg ...MemoryUploaderConfig) *MemoryUploader {
 		pendingSummaries: make(map[session.ID][]byte),
 		metadata:         make(map[session.ID][]byte),
 		thumbnails:       make(map[session.ID][]byte),
+		replays:          make(map[string][]byte),
 	}
 	if len(cfg) != 0 {
 		up.cfg = cfg[0]
@@ -74,6 +75,9 @@ type MemoryUploader struct {
 	pendingSummaries map[session.ID][]byte
 	metadata         map[session.ID][]byte
 	thumbnails       map[session.ID][]byte
+	// replays holds named beam-replay artifact objects, keyed by
+	// "<sessionID>/<name>".
+	replays map[string][]byte
 
 	// Clock is an optional [clockwork.Clock] to determine the time to associate
 	// with uploads and parts.
@@ -120,6 +124,13 @@ func (m *MemoryUploader) Reset() {
 	m.pendingSummaries = make(map[session.ID][]byte)
 	m.metadata = make(map[session.ID][]byte)
 	m.thumbnails = make(map[session.ID][]byte)
+	m.replays = make(map[string][]byte)
+}
+
+// replayKey returns the map key used to store a named replay object for a
+// given session.
+func replayKey(sessionID session.ID, name string) string {
+	return string(sessionID) + "/" + name
 }
 
 // CreateUpload creates a multipart upload
@@ -321,6 +332,19 @@ func (m *MemoryUploader) UploadSummary(ctx context.Context, sessionID session.ID
 	return string(sessionID), nil
 }
 
+// UploadReplayObject uploads a named beam-replay artifact object and returns
+// URL with uploaded file in case of success.
+func (m *MemoryUploader) UploadReplayObject(ctx context.Context, sessionID session.ID, name string, readCloser io.Reader) (string, error) {
+	data, err := io.ReadAll(readCloser)
+	if err != nil {
+		return "", trace.ConvertSystemError(err)
+	}
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	m.replays[replayKey(sessionID, name)] = data
+	return string(sessionID), nil
+}
+
 // UploadMetadata uploads session metadata and returns URL with uploaded file in
 // case of success.
 func (m *MemoryUploader) UploadMetadata(ctx context.Context, sessionID session.ID, readCloser io.Reader) (string, error) {
@@ -380,6 +404,31 @@ func (m *MemoryUploader) StreamSessionSummary(ctx context.Context, sessionID ses
 		return nil, trace.NotFound("summary %q is not found", sessionID)
 	}
 	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+// StreamReplayObjectRange streams a ranged read over a named beam-replay
+// artifact object and returns a ReadCloser for the content. A length <= 0
+// reads to the end of the object.
+func (m *MemoryUploader) StreamReplayObjectRange(ctx context.Context, sessionID session.ID, name string, offset, length int64) (io.ReadCloser, error) {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	data, ok := m.replays[replayKey(sessionID, name)]
+	if !ok {
+		return nil, trace.NotFound("replay object %q for session %q is not found", name, sessionID)
+	}
+
+	total := int64(len(data))
+	if offset < 0 || offset > total {
+		return nil, trace.BadParameter("offset %d out of range for replay object %q of length %d", offset, name, total)
+	}
+
+	end := total
+	if length > 0 && offset+length < total {
+		end = offset + length
+	}
+
+	return io.NopCloser(bytes.NewReader(data[offset:end])), nil
 }
 
 // StreamSessionMetadata streams session metadata and returns a ReadCloser for the content.

--- a/lib/events/eventstest/uploader.go
+++ b/lib/events/eventstest/uploader.go
@@ -334,8 +334,8 @@ func (m *MemoryUploader) UploadSummary(ctx context.Context, sessionID session.ID
 
 // UploadReplayObject uploads a named beam-replay artifact object and returns
 // URL with uploaded file in case of success.
-func (m *MemoryUploader) UploadReplayObject(ctx context.Context, sessionID session.ID, name string, readCloser io.Reader) (string, error) {
-	data, err := io.ReadAll(readCloser)
+func (m *MemoryUploader) UploadReplayObject(ctx context.Context, sessionID session.ID, name string, reader io.Reader) (string, error) {
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return "", trace.ConvertSystemError(err)
 	}

--- a/lib/events/eventstest/uploader_test.go
+++ b/lib/events/eventstest/uploader_test.go
@@ -1,0 +1,54 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package eventstest
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/session"
+)
+
+func TestReplayObjectRoundTripAndRange(t *testing.T) {
+	ctx := context.Background()
+	u := NewMemoryUploader()
+	sid := session.ID("beam-1")
+	_, err := u.UploadReplayObject(ctx, sid, "blob.0", bytes.NewReader([]byte("0123456789")))
+	require.NoError(t, err)
+
+	rc, err := u.StreamReplayObjectRange(ctx, sid, "blob.0", 0, 0)
+	require.NoError(t, err)
+	got, _ := io.ReadAll(rc)
+	rc.Close()
+	require.Equal(t, "0123456789", string(got))
+
+	rc, err = u.StreamReplayObjectRange(ctx, sid, "blob.0", 3, 4)
+	require.NoError(t, err)
+	got, _ = io.ReadAll(rc)
+	rc.Close()
+	require.Equal(t, "3456", string(got))
+
+	_, err = u.StreamReplayObjectRange(ctx, sid, "missing", 0, 0)
+	require.True(t, trace.IsNotFound(err))
+}

--- a/lib/events/filesessions/fileuploader.go
+++ b/lib/events/filesessions/fileuploader.go
@@ -142,6 +142,27 @@ func (l *Handler) StreamSessionSummary(ctx context.Context, sessionID session.ID
 	return nil, trace.NotFound("summary for session %v not found", sessionID)
 }
 
+// StreamReplayObjectRange reads a ranged portion of a named beam-replay
+// artifact object from a local directory. A length <= 0 reads to the end of
+// the object. Returns a "not found" error if the object does not exist.
+func (l *Handler) StreamReplayObjectRange(ctx context.Context, sessionID session.ID, name string, offset, length int64) (io.ReadCloser, error) {
+	if err := events.ValidateReplayObjectName(name); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	f, err := os.Open(l.replayPath(sessionID, name))
+	if err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+	if _, err := f.Seek(offset, io.SeekStart); err != nil {
+		_ = f.Close()
+		return nil, trace.ConvertSystemError(err)
+	}
+	if length <= 0 {
+		return f, nil
+	}
+	return &limitedReadCloser{Reader: io.LimitReader(f, length), Closer: f}, nil
+}
+
 // StreamSessionMetadata reads session metadata from a local directory.
 func (l *Handler) StreamSessionMetadata(ctx context.Context, sessionID session.ID) (io.ReadCloser, error) {
 	return openFile(l.metadataPath(sessionID))
@@ -182,6 +203,16 @@ func (l *Handler) UploadSummary(ctx context.Context, sessionID session.ID, reade
 	return name, nil
 }
 
+// UploadReplayObject writes a named beam-replay artifact object to a local
+// directory. This function can be called only once for a given sessionID and
+// name; subsequent calls will return an error.
+func (l *Handler) UploadReplayObject(ctx context.Context, sessionID session.ID, name string, reader io.Reader) (string, error) {
+	if err := events.ValidateReplayObjectName(name); err != nil {
+		return "", trace.Wrap(err)
+	}
+	return uploadFile(l.replayPath(sessionID, name), reader)
+}
+
 // UploadMetadata writes session metadata to a local directory.
 func (l *Handler) UploadMetadata(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
 	return uploadFile(l.metadataPath(sessionID), reader)
@@ -198,6 +229,14 @@ func openFile(path string) (io.ReadCloser, error) {
 		return nil, trace.ConvertSystemError(err)
 	}
 	return f, nil
+}
+
+// limitedReadCloser wraps a Reader (typically an [io.LimitReader] over an
+// open file) together with the underlying Closer, so that callers can close
+// the underlying file once done reading a bounded range of it.
+type limitedReadCloser struct {
+	io.Reader
+	io.Closer
 }
 
 type fileUploadConfig struct {
@@ -251,6 +290,12 @@ func (l *Handler) summaryPath(sessionID session.ID) string {
 
 func (l *Handler) metadataPath(sessionID session.ID) string {
 	return filepath.Join(l.Directory, string(sessionID)+metadataExt)
+}
+
+// replayPath returns the path of a named beam-replay artifact object for a
+// given session, e.g. "<sessionID>.replay.<name>".
+func (l *Handler) replayPath(sessionID session.ID, name string) string {
+	return filepath.Join(l.Directory, string(sessionID)+".replay."+name)
 }
 
 func (l *Handler) thumbnailPath(sessionID session.ID) string {

--- a/lib/events/filesessions/fileuploader_test.go
+++ b/lib/events/filesessions/fileuploader_test.go
@@ -19,7 +19,9 @@
 package filesessions
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"os"
 	"sync/atomic"
 	"testing"
@@ -29,6 +31,7 @@ import (
 
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/test"
+	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
@@ -77,4 +80,101 @@ func TestStreams(t *testing.T) {
 	t.Run("DownloadNotFound", func(t *testing.T) {
 		test.DownloadNotFound(t, handler)
 	})
+}
+
+// TestReplayObjectRoundTripAndRange verifies that replay objects can be
+// uploaded and read back in full or in byte ranges, and that reading a
+// nonexistent replay object returns a "not found" error.
+func TestReplayObjectRoundTripAndRange(t *testing.T) {
+	dir := t.TempDir()
+
+	handler, err := NewHandler(Config{
+		Directory: dir,
+		OpenFile:  os.OpenFile,
+	})
+	require.NoError(t, err)
+	defer handler.Close()
+
+	ctx := context.Background()
+	sid := session.ID("beam-1")
+
+	_, err = handler.UploadReplayObject(ctx, sid, "blob.0", bytes.NewReader([]byte("0123456789")))
+	require.NoError(t, err)
+
+	rc, err := handler.StreamReplayObjectRange(ctx, sid, "blob.0", 0, 0)
+	require.NoError(t, err)
+	got, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.NoError(t, rc.Close())
+	require.Equal(t, "0123456789", string(got))
+
+	rc, err = handler.StreamReplayObjectRange(ctx, sid, "blob.0", 3, 4)
+	require.NoError(t, err)
+	got, err = io.ReadAll(rc)
+	require.NoError(t, err)
+	require.NoError(t, rc.Close())
+	require.Equal(t, "3456", string(got))
+
+	// "blob.99" is a well-formed replay object name (matches the naming
+	// scheme ValidateReplayObjectName enforces) that was simply never
+	// uploaded -- distinct from a malformed name, which
+	// TestReplayObjectNameRejectsPathTraversal covers below.
+	_, err = handler.StreamReplayObjectRange(ctx, sid, "blob.99", 0, 0)
+	require.True(t, trace.IsNotFound(err))
+}
+
+// TestReplayObjectNameRejectsPathTraversal asserts that UploadReplayObject
+// and StreamReplayObjectRange reject any object name outside the
+// well-known manifest/index/blob naming scheme used by ReplaySink --
+// crucially, names containing path traversal segments, which would
+// otherwise resolve straight through filepath.Join(l.Directory, ...) in
+// replayPath to read or write files outside the beam's own replay
+// artifact.
+func TestReplayObjectNameRejectsPathTraversal(t *testing.T) {
+	dir := t.TempDir()
+
+	handler, err := NewHandler(Config{
+		Directory: dir,
+		OpenFile:  os.OpenFile,
+	})
+	require.NoError(t, err)
+	defer handler.Close()
+
+	ctx := context.Background()
+	sid := session.ID("beam-1")
+
+	badNames := []string{
+		"../x",
+		"blob.0/../manifest",
+		"/../../etc/passwd",
+		"..",
+		"blob.-1",
+		"blob",
+		"manifest.json",
+		"",
+	}
+	for _, name := range badNames {
+		t.Run(name, func(t *testing.T) {
+			_, err := handler.UploadReplayObject(ctx, sid, name, bytes.NewReader([]byte("x")))
+			require.True(t, trace.IsBadParameter(err), "UploadReplayObject(%q): got %v", name, err)
+
+			_, err = handler.StreamReplayObjectRange(ctx, sid, name, 0, 0)
+			require.True(t, trace.IsBadParameter(err), "StreamReplayObjectRange(%q): got %v", name, err)
+		})
+	}
+
+	goodNames := []string{"manifest", "index.0", "index.12", "blob.0", "blob.12", "commands.0", "commands.7"}
+	for _, name := range goodNames {
+		t.Run(name, func(t *testing.T) {
+			_, err := handler.UploadReplayObject(ctx, sid, name, bytes.NewReader([]byte("ok")))
+			require.NoError(t, err)
+
+			rc, err := handler.StreamReplayObjectRange(ctx, sid, name, 0, 0)
+			require.NoError(t, err)
+			got, err := io.ReadAll(rc)
+			require.NoError(t, err)
+			require.NoError(t, rc.Close())
+			require.Equal(t, "ok", string(got))
+		})
+	}
 }

--- a/lib/events/gcssessions/gcshandler.go
+++ b/lib/events/gcssessions/gcshandler.go
@@ -275,6 +275,11 @@ func (h *Handler) UploadSummary(ctx context.Context, sessionID session.ID, reade
 	return path, nil
 }
 
+// UploadReplayObject is not supported by the GCS session backend.
+func (h *Handler) UploadReplayObject(ctx context.Context, sessionID session.ID, name string, reader io.Reader) (string, error) {
+	return "", trace.NotImplemented("beam replay is not supported by the GCS session backend")
+}
+
 // UploadMetadata reads the session metadata from a reader and uploads it to a GCS
 // bucket. If successful, it returns URL of the uploaded object.
 func (h *Handler) UploadMetadata(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
@@ -367,6 +372,11 @@ func (h *Handler) gcsStream(ctx context.Context, objectPath string) (io.ReadClos
 		return nil, convertGCSError(err)
 	}
 	return reader, nil
+}
+
+// StreamReplayObjectRange is not supported by the GCS session backend.
+func (h *Handler) StreamReplayObjectRange(ctx context.Context, sessionID session.ID, name string, offset, length int64) (io.ReadCloser, error) {
+	return nil, trace.NotImplemented("beam replay is not supported by the GCS session backend")
 }
 
 // StreamSessionMetadata downloads a session's metadata from a GCS bucket and

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -344,6 +344,18 @@ func (h *Handler) UploadSummary(ctx context.Context, sessionID session.ID, reade
 	return path, trace.Wrap(err)
 }
 
+// UploadReplayObject reads the content of a named beam-replay artifact object
+// from a reader and uploads it to an S3 bucket. If successful, it returns URL
+// of the uploaded object. This function can be called only once for a given
+// sessionID and name; subsequent calls will return an error.
+func (h *Handler) UploadReplayObject(ctx context.Context, sessionID session.ID, name string, reader io.Reader) (string, error) {
+	if err := events.ValidateReplayObjectName(name); err != nil {
+		return "", trace.Wrap(err)
+	}
+	path, err := h.uploadFile(ctx, h.replayPath(sessionID, name), reader)
+	return path, trace.Wrap(err)
+}
+
 // UploadMetadata reads the content of a session's metadata from a reader and
 // uploads it to an S3 bucket. If successful, it returns URL of the uploaded
 // object.
@@ -458,6 +470,45 @@ func (h *Handler) StreamSessionRecording(ctx context.Context, sessionID session.
 // summary is not found or is not final.
 func (h *Handler) StreamSessionSummary(ctx context.Context, sessionID session.ID) (io.ReadCloser, error) {
 	return h.downloadFileRetrier(ctx, h.summaryPath(sessionID), nil /* versionID */)
+}
+
+// StreamReplayObjectRange downloads a ranged portion of a named beam-replay
+// artifact object from an S3 bucket and returns a ReadCloser for the content.
+// A length <= 0 reads to the end of the object. Returns trace.NotFound error
+// if the object is not found.
+func (h *Handler) StreamReplayObjectRange(ctx context.Context, sessionID session.ID, name string, offset, length int64) (io.ReadCloser, error) {
+	if err := events.ValidateReplayObjectName(name); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	path := h.replayPath(sessionID, name)
+
+	// Check existence and fetch content-length upfront so that NotFound is
+	// returned before the caller attempts any reads.
+	headOutput, err := h.client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(h.Bucket),
+		Key:    aws.String(path),
+	})
+	if err != nil {
+		return nil, awsutils.ConvertS3Error(err)
+	}
+
+	contentLength := aws.ToInt64(headOutput.ContentLength)
+
+	end := contentLength - 1
+	if length > 0 {
+		end = offset + length - 1
+	}
+	rangeStr := fmt.Sprintf("bytes=%d-%d", offset, end)
+
+	output, err := h.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(h.Bucket),
+		Key:    aws.String(path),
+		Range:  aws.String(rangeStr),
+	})
+	if err != nil {
+		return nil, awsutils.ConvertS3Error(err)
+	}
+	return output.Body, nil
 }
 
 // StreamSessionMetadata downloads a session's metadata from an S3 bucket and
@@ -607,6 +658,13 @@ func (h *Handler) summaryPath(sessionID session.ID) string {
 		return string(sessionID) + ".summary.json"
 	}
 	return strings.TrimPrefix(path.Join(h.Path, string(sessionID)+".summary.json"), "/")
+}
+
+func (h *Handler) replayPath(sessionID session.ID, name string) string {
+	if h.Path == "" {
+		return string(sessionID) + ".replay." + name
+	}
+	return strings.TrimPrefix(path.Join(h.Path, string(sessionID)+".replay."+name), "/")
 }
 
 func (h *Handler) metadataPath(sessionID session.ID) string {

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -493,22 +493,31 @@ func (h *Handler) StreamReplayObjectRange(ctx context.Context, sessionID session
 	}
 
 	contentLength := aws.ToInt64(headOutput.ContentLength)
-
-	end := contentLength - 1
-	if length > 0 {
-		end = offset + length - 1
+	if offset < 0 || offset > contentLength {
+		return nil, trace.BadParameter("offset %d out of range for replay object of length %d", offset, contentLength)
 	}
-	rangeStr := fmt.Sprintf("bytes=%d-%d", offset, end)
 
-	output, err := h.client.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: aws.String(h.Bucket),
-		Key:    aws.String(path),
-		Range:  aws.String(rangeStr),
-	})
-	if err != nil {
-		return nil, awsutils.ConvertS3Error(err)
+	rangeLength := contentLength - offset
+	if length > 0 && length < rangeLength {
+		rangeLength = length
 	}
-	return output.Body, nil
+	if rangeLength == 0 {
+		return io.NopCloser(bytes.NewReader(nil)), nil
+	}
+
+	end := offset + rangeLength - 1
+	return downloadretrier.New(ctx, rangeLength, func(ctx context.Context, retryOffset int64) (io.ReadCloser, error) {
+		rangeStr := fmt.Sprintf("bytes=%d-%d", offset+retryOffset, end)
+		output, err := h.client.GetObject(ctx, &s3.GetObjectInput{
+			Bucket: aws.String(h.Bucket),
+			Key:    aws.String(path),
+			Range:  aws.String(rangeStr),
+		})
+		if err != nil {
+			return nil, awsutils.ConvertS3Error(err)
+		}
+		return output.Body, nil
+	}), nil
 }
 
 // StreamSessionMetadata downloads a session's metadata from an S3 bucket and

--- a/lib/events/s3sessions/s3handler_test.go
+++ b/lib/events/s3sessions/s3handler_test.go
@@ -23,14 +23,17 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/events/test"
+	"github.com/gravitational/teleport/lib/session"
 )
 
 // TestStreams tests various streaming upload scenarios
@@ -117,6 +120,41 @@ func (m *mockS3Client) PutBucketEncryption(ctx context.Context, params *s3.PutBu
 	args := m.Called(ctx, params, optFns)
 	return args.Get(0).(*s3.PutBucketEncryptionOutput), args.Error(1)
 }
+
+// TestReplayObjectNameRejectsPathTraversal asserts that UploadReplayObject
+// and StreamReplayObjectRange reject any object name outside the
+// well-known manifest/index/blob naming scheme used by ReplaySink --
+// crucially, names containing path traversal segments, which would
+// otherwise resolve straight through path.Join in replayPath to read or
+// write objects outside the beam's own replay artifact. The check must
+// happen before any S3 call, so a zero-value Handler (no client) is enough
+// to exercise it.
+func TestReplayObjectNameRejectsPathTraversal(t *testing.T) {
+	h := &Handler{}
+	ctx := context.Background()
+	sid := session.ID("beam-1")
+
+	badNames := []string{
+		"../x",
+		"blob.0/../manifest",
+		"/../../etc/passwd",
+		"..",
+		"blob.-1",
+		"blob",
+		"manifest.json",
+		"",
+	}
+	for _, name := range badNames {
+		t.Run(name, func(t *testing.T) {
+			_, err := h.UploadReplayObject(ctx, sid, name, strings.NewReader("x"))
+			require.True(t, trace.IsBadParameter(err), "UploadReplayObject(%q): got %v", name, err)
+
+			_, err = h.StreamReplayObjectRange(ctx, sid, name, 0, 0)
+			require.True(t, trace.IsBadParameter(err), "StreamReplayObjectRange(%q): got %v", name, err)
+		})
+	}
+}
+
 func TestEnsureBucket(t *testing.T) {
 	mockClient := &mockS3Client{}
 	var gotRegion s3types.BucketLocationConstraint

--- a/lib/events/s3sessions/s3handler_test.go
+++ b/lib/events/s3sessions/s3handler_test.go
@@ -19,13 +19,18 @@
 package s3sessions
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"strings"
 	"testing"
+	"testing/iotest"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/gravitational/trace"
@@ -153,6 +158,94 @@ func TestReplayObjectNameRejectsPathTraversal(t *testing.T) {
 			require.True(t, trace.IsBadParameter(err), "StreamReplayObjectRange(%q): got %v", name, err)
 		})
 	}
+}
+
+func TestStreamReplayObjectRangeRetries(t *testing.T) {
+	data := []byte("0123456789")
+
+	tests := []struct {
+		name       string
+		length     int64
+		firstBody  func() io.ReadCloser
+		want       []byte
+		wantRanges []string
+	}{
+		{
+			name:   "truncated range",
+			length: 6,
+			firstBody: func() io.ReadCloser {
+				return io.NopCloser(bytes.NewReader(data[2:5]))
+			},
+			want:       data[2:8],
+			wantRanges: []string{"bytes=2-7", "bytes=5-7"},
+		},
+		{
+			name:   "connection error",
+			length: 0,
+			firstBody: func() io.ReadCloser {
+				return io.NopCloser(io.MultiReader(
+					bytes.NewReader(data[2:5]),
+					iotest.ErrReader(errors.New("connection reset")),
+				))
+			},
+			want:       data[2:],
+			wantRanges: []string{"bytes=2-9", "bytes=5-9"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &replayRangeS3Client{
+				t:         t,
+				data:      data,
+				firstBody: tt.firstBody(),
+			}
+			h := &Handler{
+				Config: Config{Bucket: "recordings"},
+				client: client,
+			}
+
+			rc, err := h.StreamReplayObjectRange(t.Context(), session.ID("beam-1"), "blob.0", 2, tt.length)
+			require.NoError(t, err)
+			defer rc.Close()
+
+			got, err := io.ReadAll(rc)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.wantRanges, client.ranges)
+		})
+	}
+}
+
+type replayRangeS3Client struct {
+	s3Client
+	t         *testing.T
+	data      []byte
+	firstBody io.ReadCloser
+	ranges    []string
+}
+
+func (c *replayRangeS3Client) HeadObject(context.Context, *s3.HeadObjectInput, ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+	return &s3.HeadObjectOutput{ContentLength: aws.Int64(int64(len(c.data)))}, nil
+}
+
+func (c *replayRangeS3Client) GetObject(_ context.Context, input *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	rangeStr := aws.ToString(input.Range)
+	c.ranges = append(c.ranges, rangeStr)
+	if c.firstBody != nil {
+		body := c.firstBody
+		c.firstBody = nil
+		return &s3.GetObjectOutput{Body: body}, nil
+	}
+
+	var start, end int64
+	_, err := fmt.Sscanf(rangeStr, "bytes=%d-%d", &start, &end)
+	require.NoError(c.t, err)
+	require.GreaterOrEqual(c.t, start, int64(0))
+	require.Less(c.t, end, int64(len(c.data)))
+	return &s3.GetObjectOutput{
+		Body: io.NopCloser(bytes.NewReader(c.data[start : end+1])),
+	}, nil
 }
 
 func TestEnsureBucket(t *testing.T) {

--- a/lib/events/uploader.go
+++ b/lib/events/uploader.go
@@ -21,10 +21,38 @@ package events
 import (
 	"context"
 	"io"
+	"regexp"
 	"time"
+
+	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/lib/session"
 )
+
+// replayObjectNameRE matches the only object names ReplaySink ever writes
+// for a beam's replay artifact: the manifest, and the blob/index/command/
+// agent/activity/conversation pages numbered from 0 (see partName/
+// indexPageName/commandsPageName/agentsPageName/activitiesPageName/
+// conversationsPageName/manifestObjectName in e/lib/beams/v1/replay).
+var replayObjectNameRE = regexp.MustCompile(`^(manifest|index\.[0-9]+|blob\.[0-9]+|commands\.[0-9]+|agents\.[0-9]+|activities\.[0-9]+|conversations\.[0-9]+)$`)
+
+// ValidateReplayObjectName returns a trace.BadParameter error unless name is
+// one of the well-known beam-replay artifact object names (the manifest, or
+// a numbered index/blob/command-index part).
+//
+// UploadHandler implementations must call this before using a caller- or
+// client-influenced name to build a storage path/key: name ultimately
+// derives from a PayloadRef.PartName that travels over the wire in a
+// FetchPayloadRequest, so without this check a forged name containing path
+// traversal segments (e.g. "../other-session.summary.json") could escape
+// the beam's own object namespace once joined into a filepath.Join or
+// path.Join call.
+func ValidateReplayObjectName(name string) error {
+	if !replayObjectNameRE.MatchString(name) {
+		return trace.BadParameter("invalid replay object name %q", name)
+	}
+	return nil
+}
 
 // UploadHandler uploads and downloads session-related files.
 type UploadHandler interface {
@@ -47,6 +75,12 @@ type UploadHandler interface {
 	// StreamSessionSummary streams a session summary and returns a ReadCloser for
 	// the content. Returns a "not found" error if there's no such summary.
 	StreamSessionSummary(ctx context.Context, sessionID session.ID) (io.ReadCloser, error)
+	// UploadReplayObject writes a named beam-replay artifact object (e.g.
+	// "manifest", "index.0", "blob.0") for a beam and returns its URL.
+	UploadReplayObject(ctx context.Context, sessionID session.ID, name string, readCloser io.Reader) (string, error)
+	// StreamReplayObjectRange returns a ranged reader over a replay object.
+	// A length <= 0 reads to the end of the object.
+	StreamReplayObjectRange(ctx context.Context, sessionID session.ID, name string, offset, length int64) (io.ReadCloser, error)
 	// UploadMetadata uploads session metadata and returns a URL with the uploaded
 	// file in case of success. Session metadata is a file with a [recordingmetadatav1.SessionRecordingMetadata]
 	// protobuf message containing info about the session (duration, events, etc), as well as

--- a/lib/events/uploader_test.go
+++ b/lib/events/uploader_test.go
@@ -1,0 +1,69 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package events
+
+import (
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateReplayObjectName covers every object name the beam replay sink
+// writes, and the traversal attempts the check exists to stop.
+func TestValidateReplayObjectName(t *testing.T) {
+	valid := []string{
+		"manifest",
+		"blob.0",
+		"blob.12",
+		"index.0",
+		"commands.3",
+		"agents.0",
+		"activities.0",
+		"conversations.7",
+	}
+	for _, name := range valid {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, ValidateReplayObjectName(name))
+		})
+	}
+
+	invalid := []string{
+		"",
+		"manifest.json",
+		"manifests",
+		"blob",
+		"blob.",
+		"blob.x",
+		"blob.0.0",
+		"../other-session.summary.json",
+		"blob.0/../../etc/passwd",
+		"/manifest",
+		"blob.0\n",
+		"activities.0 ",
+		"summary",
+	}
+	for _, name := range invalid {
+		t.Run("rejects "+name, func(t *testing.T) {
+			err := ValidateReplayObjectName(name)
+			require.Error(t, err)
+			require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
+		})
+	}
+}

--- a/lib/integrations/externalauditstorage/error_counter.go
+++ b/lib/integrations/externalauditstorage/error_counter.go
@@ -395,6 +395,13 @@ func (c *ErrorCountingSessionHandler) UploadSummary(ctx context.Context, session
 	return res, err
 }
 
+// UploadReplayObject calls [c.wrapped.UploadReplayObject] and counts the error or success.
+func (c *ErrorCountingSessionHandler) UploadReplayObject(ctx context.Context, sessionID session.ID, name string, reader io.Reader) (string, error) {
+	res, err := c.wrapped.UploadReplayObject(ctx, sessionID, name, reader)
+	c.uploads.observe(err)
+	return res, err
+}
+
 // UploadMetadata calls [c.wrapped.UploadMetadata] and counts the error or success.
 func (c *ErrorCountingSessionHandler) UploadMetadata(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
 	res, err := c.wrapped.UploadMetadata(ctx, sessionID, reader)
@@ -422,6 +429,16 @@ func (c *ErrorCountingSessionHandler) StreamSessionRecording(ctx context.Context
 // StreamSessionSummary calls [c.wrapped.StreamSessionSummary] and counts the error or success.
 func (c *ErrorCountingSessionHandler) StreamSessionSummary(ctx context.Context, sessionID session.ID) (io.ReadCloser, error) {
 	rc, err := c.wrapped.StreamSessionSummary(ctx, sessionID)
+	if err != nil {
+		c.downloads.observe(err)
+		return nil, err
+	}
+	return newErrorReportReader(rc, c.downloads), nil
+}
+
+// StreamReplayObjectRange calls [c.wrapped.StreamReplayObjectRange] and counts the error or success.
+func (c *ErrorCountingSessionHandler) StreamReplayObjectRange(ctx context.Context, sessionID session.ID, name string, offset, length int64) (io.ReadCloser, error) {
+	rc, err := c.wrapped.StreamReplayObjectRange(ctx, sessionID, name, offset, length)
 	if err != nil {
 		c.downloads.observe(err)
 		return nil, err


### PR DESCRIPTION
Introduce two methods on events.UploadHandler for the beam traffic replay artifact:

  - UploadReplayObject(ctx, sessionID, name, r) writes a named artifact object (the manifest, or a numbered "index.N"/"blob.N" part) for a beam.
  - StreamReplayObjectRange(ctx, sessionID, name, offset, length) returns a ranged reader over one, so the replay service can page the index and fetch individual payload/attachment byte ranges without downloading whole objects.

Implement both on the S3, filesessions, and in-memory backends; GCS and Azure return trace.NotImplemented (beams are only supported in teleport cloud for now), and the external-audit-storage wrapper delegates to its inner handler.

Object names are validated by ValidateReplayObjectName against a strict allowlist (manifest | index.N | blob.N) before being joined into a storage key/path. The name ultimately derives from a client-supplied PayloadRef sent over the wire, so this prevents a forged name with path-traversal segments (e.g. "../<other-session>.summary.json") from escaping the beam's object namespace and reading arbitrary bucket/disk objects.

