### PR TITLE
[v18] Make error message on login failure for aws console "tsh app login" clearer

### DIFF
--- a/tool/tsh/common/app_aws.go
+++ b/tool/tsh/common/app_aws.go
@@ -228,7 +228,7 @@ func getARNFromFlags(cf *CLIConf, app types.Application, logins []string) (strin
 	roles := awsutils.FilterAWSRoles(logins, app.GetAWSAccountID())
 
 	if len(roles) == 0 {
-		return "", trace.NotFound("there are no roles configured for the AWS app")
+		return "", trace.NotFound("could not determine any allowed IAM role ARNs for %q: this can indicate lack of permissions or app misconfiguration", app.GetName())
 	}
 
 	if cf.AWSRole == "" {
@@ -332,7 +332,7 @@ func printAWSAppLogins(cf *CLIConf, app types.Application, logins []string) erro
 	roles := awsutils.FilterAWSRoles(logins, app.GetAWSAccountID())
 
 	if len(roles) == 0 {
-		return trace.NotFound("there are no roles configured for the AWS app %q", app.GetName())
+		return trace.NotFound("could not determine any allowed IAM role ARNs for %q: this can indicate lack of permissions or app misconfiguration", app.GetName())
 	}
 
 	// Output based on format.

--- a/tool/tsh/common/app_aws_test.go
+++ b/tool/tsh/common/app_aws_test.go
@@ -869,7 +869,7 @@ func TestAppLogins(t *testing.T) {
 			setHomePath(tmpHomePath),
 		)
 		require.Error(t, err)
-		require.ErrorContains(t, err, "there are no roles configured for the AWS app \"aws-console-special\"")
+		require.ErrorContains(t, err, "could not determine any allowed IAM role ARNs for \"aws-console-special\": this can indicate lack of permissions or app misconfiguration")
 		require.True(t, trace.IsNotFound(err))
 	})
 


### PR DESCRIPTION
Backport #68577 to branch/v18

Issue: https://github.com/gravitational/teleport/issues/68523

## What
Change error message of "tsh app login" for AWS apps.


## Why
The term role is overloaded when it comes to AWS apps, because it may mean teleport role or AWS role. Hence the error message should be more specific about the role in question.
The error should be more informative and provide a better idea why the aws-console app login is not successful.

```
$ tsh app login aws-console
ERROR: could not determine any allowed IAM role ARNs for "aws-console" this can indicate lack of permissions or app misconfiguration
```

Current behaviour:

```
$ tsh app login aws-console
ERROR: there are no roles configured for the AWS app
```

The error means there are no eligible ARNs in the currently assigned role(s), but the wording is misleading and not helpful and does not suggest the actual root cause of the login failure.
Here the term `role` is a bit overloaded because it has at least 2 meanings in the context (eg. teleport role and AWS role (ARN)), so the error should have at least specified that `there are no *AWS* roles configured for the AWS app`.

Changelog: Make error message on aws app login failure clearer.

## Manual Test Plan
- [x] test with interactive and non-interactive workflows when the user teleport role does not have AWS ARNs configured.

### Test Environment
Simple AWS console application and a user that does not have ARNs for the app in any of the assigned teleport roles.

### Test Cases
- [x] updated unit tests expecting the updated error messages on login failure.
