### PR TITLE
Extend Multi-directory sharing support to Teleport Connect

### DIFF
--- a/gen/proto/go/teleport/lib/teleterm/v1/service_protohybrid.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/v1/service_protohybrid.pb.go
@@ -6441,7 +6441,9 @@ type SetSharedDirectoryForDesktopSessionRequest struct {
 	// Login for the desktop session.
 	Login string `protobuf:"bytes,2,opt,name=login,proto3" json:"login,omitempty"`
 	// Path to share with a remote machine. Must be a directory.
-	Path          string `protobuf:"bytes,3,opt,name=path,proto3" json:"path,omitempty"`
+	Path string `protobuf:"bytes,3,opt,name=path,proto3" json:"path,omitempty"`
+	// DirectoryId assigned to this directory.
+	DirectoryId   uint32 `protobuf:"varint,4,opt,name=directory_id,json=directoryId,proto3" json:"directory_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -6492,6 +6494,13 @@ func (x *SetSharedDirectoryForDesktopSessionRequest) GetPath() string {
 	return ""
 }
 
+func (x *SetSharedDirectoryForDesktopSessionRequest) GetDirectoryId() uint32 {
+	if x != nil {
+		return x.DirectoryId
+	}
+	return 0
+}
+
 func (x *SetSharedDirectoryForDesktopSessionRequest) SetDesktopUri(v string) {
 	x.DesktopUri = v
 }
@@ -6504,6 +6513,10 @@ func (x *SetSharedDirectoryForDesktopSessionRequest) SetPath(v string) {
 	x.Path = v
 }
 
+func (x *SetSharedDirectoryForDesktopSessionRequest) SetDirectoryId(v uint32) {
+	x.DirectoryId = v
+}
+
 type SetSharedDirectoryForDesktopSessionRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -6513,6 +6526,8 @@ type SetSharedDirectoryForDesktopSessionRequest_builder struct {
 	Login string
 	// Path to share with a remote machine. Must be a directory.
 	Path string
+	// DirectoryId assigned to this directory.
+	DirectoryId uint32
 }
 
 func (b0 SetSharedDirectoryForDesktopSessionRequest_builder) Build() *SetSharedDirectoryForDesktopSessionRequest {
@@ -6522,6 +6537,7 @@ func (b0 SetSharedDirectoryForDesktopSessionRequest_builder) Build() *SetSharedD
 	x.DesktopUri = b.DesktopUri
 	x.Login = b.Login
 	x.Path = b.Path
+	x.DirectoryId = b.DirectoryId
 	return m0
 }
 
@@ -7199,12 +7215,13 @@ const file_teleport_lib_teleterm_v1_service_proto_rawDesc = "" +
 	"\x04data\x18\x01 \x01(\fR\x04data\x12N\n" +
 	"\x0etarget_desktop\x18\x02 \x01(\v2'.teleport.lib.teleterm.v1.TargetDesktopR\rtargetDesktop\".\n" +
 	"\x18ConnectToDesktopResponse\x12\x12\n" +
-	"\x04data\x18\x01 \x01(\fR\x04data\"w\n" +
+	"\x04data\x18\x01 \x01(\fR\x04data\"\x9a\x01\n" +
 	"*SetSharedDirectoryForDesktopSessionRequest\x12\x1f\n" +
 	"\vdesktop_uri\x18\x01 \x01(\tR\n" +
 	"desktopUri\x12\x14\n" +
 	"\x05login\x18\x02 \x01(\tR\x05login\x12\x12\n" +
-	"\x04path\x18\x03 \x01(\tR\x04path\"-\n" +
+	"\x04path\x18\x03 \x01(\tR\x04path\x12!\n" +
+	"\fdirectory_id\x18\x04 \x01(\rR\vdirectoryId\"-\n" +
 	"+SetSharedDirectoryForDesktopSessionResponse*\x97\x01\n" +
 	"\x12PasswordlessPrompt\x12#\n" +
 	"\x1fPASSWORDLESS_PROMPT_UNSPECIFIED\x10\x00\x12\x1b\n" +

--- a/gen/proto/go/teleport/lib/teleterm/v1/service_protoopaque.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/v1/service_protoopaque.pb.go
@@ -6350,12 +6350,13 @@ func (b0 ConnectToDesktopResponse_builder) Build() *ConnectToDesktopResponse {
 
 // Request for SetSharedDirectoryForDesktopSession.
 type SetSharedDirectoryForDesktopSessionRequest struct {
-	state                 protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_DesktopUri string                 `protobuf:"bytes,1,opt,name=desktop_uri,json=desktopUri,proto3"`
-	xxx_hidden_Login      string                 `protobuf:"bytes,2,opt,name=login,proto3"`
-	xxx_hidden_Path       string                 `protobuf:"bytes,3,opt,name=path,proto3"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	state                  protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_DesktopUri  string                 `protobuf:"bytes,1,opt,name=desktop_uri,json=desktopUri,proto3"`
+	xxx_hidden_Login       string                 `protobuf:"bytes,2,opt,name=login,proto3"`
+	xxx_hidden_Path        string                 `protobuf:"bytes,3,opt,name=path,proto3"`
+	xxx_hidden_DirectoryId uint32                 `protobuf:"varint,4,opt,name=directory_id,json=directoryId,proto3"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *SetSharedDirectoryForDesktopSessionRequest) Reset() {
@@ -6404,6 +6405,13 @@ func (x *SetSharedDirectoryForDesktopSessionRequest) GetPath() string {
 	return ""
 }
 
+func (x *SetSharedDirectoryForDesktopSessionRequest) GetDirectoryId() uint32 {
+	if x != nil {
+		return x.xxx_hidden_DirectoryId
+	}
+	return 0
+}
+
 func (x *SetSharedDirectoryForDesktopSessionRequest) SetDesktopUri(v string) {
 	x.xxx_hidden_DesktopUri = v
 }
@@ -6416,6 +6424,10 @@ func (x *SetSharedDirectoryForDesktopSessionRequest) SetPath(v string) {
 	x.xxx_hidden_Path = v
 }
 
+func (x *SetSharedDirectoryForDesktopSessionRequest) SetDirectoryId(v uint32) {
+	x.xxx_hidden_DirectoryId = v
+}
+
 type SetSharedDirectoryForDesktopSessionRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -6425,6 +6437,8 @@ type SetSharedDirectoryForDesktopSessionRequest_builder struct {
 	Login string
 	// Path to share with a remote machine. Must be a directory.
 	Path string
+	// DirectoryId assigned to this directory.
+	DirectoryId uint32
 }
 
 func (b0 SetSharedDirectoryForDesktopSessionRequest_builder) Build() *SetSharedDirectoryForDesktopSessionRequest {
@@ -6434,6 +6448,7 @@ func (b0 SetSharedDirectoryForDesktopSessionRequest_builder) Build() *SetSharedD
 	x.xxx_hidden_DesktopUri = b.DesktopUri
 	x.xxx_hidden_Login = b.Login
 	x.xxx_hidden_Path = b.Path
+	x.xxx_hidden_DirectoryId = b.DirectoryId
 	return m0
 }
 
@@ -7102,12 +7117,13 @@ const file_teleport_lib_teleterm_v1_service_proto_rawDesc = "" +
 	"\x04data\x18\x01 \x01(\fR\x04data\x12N\n" +
 	"\x0etarget_desktop\x18\x02 \x01(\v2'.teleport.lib.teleterm.v1.TargetDesktopR\rtargetDesktop\".\n" +
 	"\x18ConnectToDesktopResponse\x12\x12\n" +
-	"\x04data\x18\x01 \x01(\fR\x04data\"w\n" +
+	"\x04data\x18\x01 \x01(\fR\x04data\"\x9a\x01\n" +
 	"*SetSharedDirectoryForDesktopSessionRequest\x12\x1f\n" +
 	"\vdesktop_uri\x18\x01 \x01(\tR\n" +
 	"desktopUri\x12\x14\n" +
 	"\x05login\x18\x02 \x01(\tR\x05login\x12\x12\n" +
-	"\x04path\x18\x03 \x01(\tR\x04path\"-\n" +
+	"\x04path\x18\x03 \x01(\tR\x04path\x12!\n" +
+	"\fdirectory_id\x18\x04 \x01(\rR\vdirectoryId\"-\n" +
 	"+SetSharedDirectoryForDesktopSessionResponse*\x97\x01\n" +
 	"\x12PasswordlessPrompt\x12#\n" +
 	"\x1fPASSWORDLESS_PROMPT_UNSPECIFIED\x10\x00\x12\x1b\n" +

--- a/gen/proto/ts/teleport/lib/teleterm/v1/service_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/v1/service_pb.ts
@@ -1336,6 +1336,12 @@ export interface SetSharedDirectoryForDesktopSessionRequest {
      * @generated from protobuf field: string path = 3;
      */
     path: string;
+    /**
+     * DirectoryId assigned to this directory.
+     *
+     * @generated from protobuf field: uint32 directory_id = 4;
+     */
+    directoryId: number;
 }
 /**
  * Response for SetSharedDirectoryForDesktopSession.
@@ -5759,7 +5765,8 @@ class SetSharedDirectoryForDesktopSessionRequest$Type extends MessageType<SetSha
         super("teleport.lib.teleterm.v1.SetSharedDirectoryForDesktopSessionRequest", [
             { no: 1, name: "desktop_uri", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "login", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 3, name: "path", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+            { no: 3, name: "path", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 4, name: "directory_id", kind: "scalar", T: 13 /*ScalarType.UINT32*/ }
         ]);
     }
     create(value?: PartialMessage<SetSharedDirectoryForDesktopSessionRequest>): SetSharedDirectoryForDesktopSessionRequest {
@@ -5767,6 +5774,7 @@ class SetSharedDirectoryForDesktopSessionRequest$Type extends MessageType<SetSha
         message.desktopUri = "";
         message.login = "";
         message.path = "";
+        message.directoryId = 0;
         if (value !== undefined)
             reflectionMergePartial<SetSharedDirectoryForDesktopSessionRequest>(this, message, value);
         return message;
@@ -5784,6 +5792,9 @@ class SetSharedDirectoryForDesktopSessionRequest$Type extends MessageType<SetSha
                     break;
                 case /* string path */ 3:
                     message.path = reader.string();
+                    break;
+                case /* uint32 directory_id */ 4:
+                    message.directoryId = reader.uint32();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -5806,6 +5817,9 @@ class SetSharedDirectoryForDesktopSessionRequest$Type extends MessageType<SetSha
         /* string path = 3; */
         if (message.path !== "")
             writer.tag(3, WireType.LengthDelimited).string(message.path);
+        /* uint32 directory_id = 4; */
+        if (message.directoryId !== 0)
+            writer.tag(4, WireType.Varint).uint32(message.directoryId);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/teleterm/apiserver/handler/handler_desktops.go
+++ b/lib/teleterm/apiserver/handler/handler_desktops.go
@@ -76,6 +76,6 @@ func (s *Handler) SetSharedDirectoryForDesktopSession(ctx context.Context, in *a
 		return &api.SetSharedDirectoryForDesktopSessionResponse{}, trace.Wrap(err)
 	}
 
-	err = s.DaemonService.SetSharedDirectoryForDesktopSession(ctx, parsed, in.GetLogin(), in.GetPath())
+	err = s.DaemonService.SetSharedDirectoryForDesktopSession(ctx, parsed, in.GetLogin(), in.GetPath(), in.GetDirectoryId())
 	return &api.SetSharedDirectoryForDesktopSessionResponse{}, trace.Wrap(err)
 }

--- a/lib/teleterm/daemon/daemon.go
+++ b/lib/teleterm/daemon/daemon.go
@@ -1286,7 +1286,7 @@ func (s *Service) ClearStaleCachedClientsForRoot(clusterURI uri.ResourceURI) err
 // SetSharedDirectoryForDesktopSession opens a directory for a desktop session and enables file system operations for it.
 // If there is no active desktop session associated with the specified desktop_uri and login,
 // an error is returned.
-func (s *Service) SetSharedDirectoryForDesktopSession(_ context.Context, desktopURI uri.ResourceURI, login, path string) error {
+func (s *Service) SetSharedDirectoryForDesktopSession(_ context.Context, desktopURI uri.ResourceURI, login, path string, directoryID uint32) error {
 	s.desktopSessionsMu.Lock()
 	defer s.desktopSessionsMu.Unlock()
 
@@ -1295,7 +1295,7 @@ func (s *Service) SetSharedDirectoryForDesktopSession(_ context.Context, desktop
 		return trace.BadParameter("there is no desktop session for desktop %s and login %q", desktopURI, login)
 	}
 
-	err := session.SetSharedDirectory(path)
+	err := session.ShareDirectory(path, directoryID)
 	return trace.Wrap(err)
 }
 

--- a/lib/teleterm/services/desktop/desktop.go
+++ b/lib/teleterm/services/desktop/desktop.go
@@ -46,8 +46,8 @@ type Session struct {
 	desktopURI uri.ResourceURI
 	login      string
 
-	dirAccess   *DirectoryAccess
-	dirAccessMu sync.RWMutex
+	sharedDirectories   map[uint32]*DirectoryAccess
+	sharedDirectoriesMu sync.RWMutex
 }
 
 // NewSession initializes a Session struct for a given desktop and login.
@@ -60,8 +60,9 @@ func NewSession(desktopURI uri.ResourceURI, login string) (*Session, error) {
 	}
 
 	return &Session{
-		desktopURI: desktopURI,
-		login:      login,
+		desktopURI:        desktopURI,
+		login:             login,
+		sharedDirectories: map[uint32]*DirectoryAccess{},
 	}, nil
 }
 
@@ -69,46 +70,47 @@ func (s *Session) desktopName() string {
 	return s.desktopURI.GetWindowsDesktopName()
 }
 
-func (s *Session) SetSharedDirectory(basePath string) error {
-	s.dirAccessMu.Lock()
-	defer s.dirAccessMu.Unlock()
+func (s *Session) ShareDirectory(basePath string, directoryID uint32) error {
+	s.sharedDirectoriesMu.Lock()
+	defer s.sharedDirectoriesMu.Unlock()
 
-	if s.dirAccess != nil {
-		return trace.AlreadyExists("directory is already shared for desktop %q and %q login", s.desktopName(), s.login)
+	if _, exists := s.sharedDirectories[directoryID]; exists {
+		return trace.AlreadyExists("directory with identifier '%d' is already shared for desktop %q and %q login", directoryID, s.desktopName(), s.login)
 	}
 
 	dirAccess, err := NewDirectoryAccess(basePath)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	s.dirAccess = dirAccess
+	s.sharedDirectories[directoryID] = dirAccess
 
 	return nil
 }
 
-func (s *Session) GetDirectoryAccess() (*DirectoryAccess, error) {
-	s.dirAccessMu.RLock()
-	defer s.dirAccessMu.RUnlock()
+func (s *Session) GetDirectoryAccess(directoryID uint32) (*DirectoryAccess, error) {
+	s.sharedDirectoriesMu.RLock()
+	defer s.sharedDirectoriesMu.RUnlock()
 
-	if s.dirAccess == nil {
-		return nil, trace.NotFound("directory sharing has not been initialized for desktop %q and login %q", s.desktopName(), s.login)
+	directory, exists := s.sharedDirectories[directoryID]
+	if !exists {
+		return nil, trace.NotFound("directory with id '%d' has not been initialized for desktop %q and login %q", directoryID, s.desktopName(), s.login)
 	}
 
-	return s.dirAccess, nil
+	return directory, nil
 }
 
 // CloseSharedDirectory releases the shared directory handle, if one was opened
 // via SetSharedDirectory. Safe to call multiple times.
 func (s *Session) CloseSharedDirectory() error {
-	s.dirAccessMu.Lock()
-	defer s.dirAccessMu.Unlock()
+	s.sharedDirectoriesMu.Lock()
+	defer s.sharedDirectoriesMu.Unlock()
 
-	if s.dirAccess == nil {
-		return nil
+	errors := []error{}
+	for id, access := range s.sharedDirectories {
+		errors = append(errors, access.Close())
+		delete(s.sharedDirectories, id)
 	}
-	err := s.dirAccess.Close()
-	s.dirAccess = nil
-	return trace.Wrap(err)
+	return trace.Wrap(trace.NewAggregate(errors...))
 }
 
 // Start starts a remote desktop session.
@@ -309,7 +311,7 @@ type fsRequestHandler struct {
 }
 
 type directoryAccessProvider interface {
-	GetDirectoryAccess() (*DirectoryAccess, error)
+	GetDirectoryAccess(uint32) (*DirectoryAccess, error)
 }
 
 func (d *fsRequestHandler) process(msg tdp.Message, sendToServer func(message tdp.Message) error) (tdp.Message, error) {
@@ -317,21 +319,21 @@ func (d *fsRequestHandler) process(msg tdp.Message, sendToServer func(message td
 	case *tdpb.SharedDirectoryRequest:
 		switch op := r.Operation.(type) {
 		case *tdpbv1.SharedDirectoryRequest_Info_:
-			return nil, trace.Wrap(d.handleSharedDirectoryInfoRequest(r.CompletionId, op.Info, sendToServer))
+			return nil, trace.Wrap(d.handleSharedDirectoryInfoRequest(r.DirectoryId, r.CompletionId, op.Info, sendToServer))
 		case *tdpbv1.SharedDirectoryRequest_Create_:
-			return nil, trace.Wrap(d.handleSharedDirectoryCreateRequest(r.CompletionId, op.Create, sendToServer))
+			return nil, trace.Wrap(d.handleSharedDirectoryCreateRequest(r.DirectoryId, r.CompletionId, op.Create, sendToServer))
 		case *tdpbv1.SharedDirectoryRequest_Delete_:
-			return nil, trace.Wrap(d.handleSharedDirectoryDeleteRequest(r.CompletionId, op.Delete, sendToServer))
+			return nil, trace.Wrap(d.handleSharedDirectoryDeleteRequest(r.DirectoryId, r.CompletionId, op.Delete, sendToServer))
 		case *tdpbv1.SharedDirectoryRequest_List_:
-			return nil, trace.Wrap(d.handleSharedDirectoryListRequest(r.CompletionId, op.List, sendToServer))
+			return nil, trace.Wrap(d.handleSharedDirectoryListRequest(r.DirectoryId, r.CompletionId, op.List, sendToServer))
 		case *tdpbv1.SharedDirectoryRequest_Read_:
-			return nil, trace.Wrap(d.handleSharedDirectoryReadRequest(r.CompletionId, op.Read, sendToServer))
+			return nil, trace.Wrap(d.handleSharedDirectoryReadRequest(r.DirectoryId, r.CompletionId, op.Read, sendToServer))
 		case *tdpbv1.SharedDirectoryRequest_Write_:
-			return nil, trace.Wrap(d.handleSharedDirectoryWriteRequest(r.CompletionId, op.Write, sendToServer))
+			return nil, trace.Wrap(d.handleSharedDirectoryWriteRequest(r.DirectoryId, r.CompletionId, op.Write, sendToServer))
 		case *tdpbv1.SharedDirectoryRequest_Move_:
-			return nil, trace.Wrap(d.handleSharedDirectoryMoveRequest(r.CompletionId, op.Move, sendToServer))
+			return nil, trace.Wrap(d.handleSharedDirectoryMoveRequest(r.DirectoryId, r.CompletionId, op.Move, sendToServer))
 		case *tdpbv1.SharedDirectoryRequest_Truncate_:
-			return nil, trace.Wrap(d.handleSharedDirectoryTruncateRequest(r.CompletionId, op.Truncate, sendToServer))
+			return nil, trace.Wrap(d.handleSharedDirectoryTruncateRequest(r.DirectoryId, r.CompletionId, op.Truncate, sendToServer))
 		default:
 			return msg, nil
 		}
@@ -349,8 +351,8 @@ const (
 	SharedDirectoryErrCodeAlreadyExists
 )
 
-func (d *fsRequestHandler) handleSharedDirectoryInfoRequest(completionID uint32, r *tdpbv1.SharedDirectoryRequest_Info, sendToServer func(message tdp.Message) error) error {
-	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess()
+func (d *fsRequestHandler) handleSharedDirectoryInfoRequest(directoryID, completionID uint32, r *tdpbv1.SharedDirectoryRequest_Info, sendToServer func(message tdp.Message) error) error {
+	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess(directoryID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -358,6 +360,7 @@ func (d *fsRequestHandler) handleSharedDirectoryInfoRequest(completionID uint32,
 	info, err := dirAccess.Stat(r.GetPath())
 	if err == nil {
 		return trace.Wrap(sendToServer(&tdpb.SharedDirectoryResponse{
+			DirectoryId:  directoryID,
 			CompletionId: completionID,
 			ErrorCode:    uint32(SharedDirectoryErrCodeNil),
 			Operation: &tdpbv1.SharedDirectoryResponse_Info_{
@@ -369,6 +372,7 @@ func (d *fsRequestHandler) handleSharedDirectoryInfoRequest(completionID uint32,
 	}
 	if errors.Is(err, os.ErrNotExist) {
 		return trace.Wrap(sendToServer(&tdpb.SharedDirectoryResponse{
+			DirectoryId:  directoryID,
 			CompletionId: completionID,
 			ErrorCode:    uint32(SharedDirectoryErrCodeDoesNotExist),
 			Operation: &tdpbv1.SharedDirectoryResponse_Info_{
@@ -381,8 +385,8 @@ func (d *fsRequestHandler) handleSharedDirectoryInfoRequest(completionID uint32,
 	return trace.Wrap(err)
 }
 
-func (d *fsRequestHandler) handleSharedDirectoryListRequest(completionID uint32, r *tdpbv1.SharedDirectoryRequest_List, sendToServer func(message tdp.Message) error) error {
-	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess()
+func (d *fsRequestHandler) handleSharedDirectoryListRequest(directoryID, completionID uint32, r *tdpbv1.SharedDirectoryRequest_List, sendToServer func(message tdp.Message) error) error {
+	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess(directoryID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -392,6 +396,7 @@ func (d *fsRequestHandler) handleSharedDirectoryListRequest(completionID uint32,
 	}
 
 	err = sendToServer(&tdpb.SharedDirectoryResponse{
+		DirectoryId:  directoryID,
 		CompletionId: completionID,
 		ErrorCode:    uint32(SharedDirectoryErrCodeNil),
 		Operation: &tdpbv1.SharedDirectoryResponse_List_{
@@ -403,14 +408,14 @@ func (d *fsRequestHandler) handleSharedDirectoryListRequest(completionID uint32,
 	return trace.Wrap(err)
 }
 
-func (d *fsRequestHandler) handleSharedDirectoryReadRequest(completionID uint32, r *tdpbv1.SharedDirectoryRequest_Read, sendToServer func(message tdp.Message) error) error {
+func (d *fsRequestHandler) handleSharedDirectoryReadRequest(directoryID, completionID uint32, r *tdpbv1.SharedDirectoryRequest_Read, sendToServer func(message tdp.Message) error) error {
 	// Defense in depth: the protocol decoder already caps Length, but re-check here so
 	// the make([]byte, r.Length) below can't be driven into an unbounded allocation by a future caller.
 	if r.GetLength() > tdp.MaxFileReadWriteLength {
 		return tdp.FileReadWriteMaxLenErr
 	}
 
-	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess()
+	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess(directoryID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -422,6 +427,7 @@ func (d *fsRequestHandler) handleSharedDirectoryReadRequest(completionID uint32,
 	}
 
 	err = sendToServer(&tdpb.SharedDirectoryResponse{
+		DirectoryId:  directoryID,
 		CompletionId: completionID,
 		ErrorCode:    uint32(SharedDirectoryErrCodeNil),
 		Operation: &tdpbv1.SharedDirectoryResponse_Read_{
@@ -433,8 +439,9 @@ func (d *fsRequestHandler) handleSharedDirectoryReadRequest(completionID uint32,
 	return trace.Wrap(err)
 }
 
-func (d *fsRequestHandler) handleSharedDirectoryMoveRequest(completionID uint32, _ *tdpbv1.SharedDirectoryRequest_Move, sendToServer func(message tdp.Message) error) error {
+func (d *fsRequestHandler) handleSharedDirectoryMoveRequest(directoryID, completionID uint32, _ *tdpbv1.SharedDirectoryRequest_Move, sendToServer func(message tdp.Message) error) error {
 	err := sendToServer(&tdpb.SharedDirectoryResponse{
+		DirectoryId:  directoryID,
 		CompletionId: completionID,
 		ErrorCode:    uint32(SharedDirectoryErrCodeFailed),
 		Operation:    &tdpbv1.SharedDirectoryResponse_Move_{},
@@ -446,8 +453,8 @@ func (d *fsRequestHandler) handleSharedDirectoryMoveRequest(completionID uint32,
 	return trace.NotImplemented("Moving or renaming files and directories within a shared directory is not supported.")
 }
 
-func (d *fsRequestHandler) handleSharedDirectoryWriteRequest(completionID uint32, r *tdpbv1.SharedDirectoryRequest_Write, sendToServer func(message tdp.Message) error) error {
-	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess()
+func (d *fsRequestHandler) handleSharedDirectoryWriteRequest(directoryID, completionID uint32, r *tdpbv1.SharedDirectoryRequest_Write, sendToServer func(message tdp.Message) error) error {
+	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess(directoryID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -457,6 +464,7 @@ func (d *fsRequestHandler) handleSharedDirectoryWriteRequest(completionID uint32
 	}
 
 	err = sendToServer(&tdpb.SharedDirectoryResponse{
+		DirectoryId:  directoryID,
 		CompletionId: completionID,
 		ErrorCode:    uint32(SharedDirectoryErrCodeNil),
 		Operation: &tdpbv1.SharedDirectoryResponse_Write_{
@@ -468,8 +476,8 @@ func (d *fsRequestHandler) handleSharedDirectoryWriteRequest(completionID uint32
 	return trace.Wrap(err)
 }
 
-func (d *fsRequestHandler) handleSharedDirectoryTruncateRequest(completionID uint32, r *tdpbv1.SharedDirectoryRequest_Truncate, sendToServer func(message tdp.Message) error) error {
-	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess()
+func (d *fsRequestHandler) handleSharedDirectoryTruncateRequest(directoryID, completionID uint32, r *tdpbv1.SharedDirectoryRequest_Truncate, sendToServer func(message tdp.Message) error) error {
+	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess(directoryID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -479,6 +487,7 @@ func (d *fsRequestHandler) handleSharedDirectoryTruncateRequest(completionID uin
 	}
 
 	err = sendToServer(&tdpb.SharedDirectoryResponse{
+		DirectoryId:  directoryID,
 		CompletionId: completionID,
 		ErrorCode:    uint32(SharedDirectoryErrCodeNil),
 		Operation: &tdpbv1.SharedDirectoryResponse_Truncate_{
@@ -488,8 +497,8 @@ func (d *fsRequestHandler) handleSharedDirectoryTruncateRequest(completionID uin
 	return trace.Wrap(err)
 }
 
-func (d *fsRequestHandler) handleSharedDirectoryCreateRequest(completionID uint32, r *tdpbv1.SharedDirectoryRequest_Create, sendToServer func(message tdp.Message) error) error {
-	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess()
+func (d *fsRequestHandler) handleSharedDirectoryCreateRequest(directoryID, completionID uint32, r *tdpbv1.SharedDirectoryRequest_Create, sendToServer func(message tdp.Message) error) error {
+	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess(directoryID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -504,6 +513,7 @@ func (d *fsRequestHandler) handleSharedDirectoryCreateRequest(completionID uint3
 	}
 
 	err = sendToServer(&tdpb.SharedDirectoryResponse{
+		DirectoryId:  directoryID,
 		CompletionId: completionID,
 		ErrorCode:    uint32(SharedDirectoryErrCodeNil),
 		Operation: &tdpbv1.SharedDirectoryResponse_Create_{
@@ -515,8 +525,8 @@ func (d *fsRequestHandler) handleSharedDirectoryCreateRequest(completionID uint3
 	return trace.Wrap(err)
 }
 
-func (d *fsRequestHandler) handleSharedDirectoryDeleteRequest(completionID uint32, r *tdpbv1.SharedDirectoryRequest_Delete, sendToServer func(message tdp.Message) error) error {
-	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess()
+func (d *fsRequestHandler) handleSharedDirectoryDeleteRequest(directoryID, completionID uint32, r *tdpbv1.SharedDirectoryRequest_Delete, sendToServer func(message tdp.Message) error) error {
+	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess(directoryID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -526,6 +536,7 @@ func (d *fsRequestHandler) handleSharedDirectoryDeleteRequest(completionID uint3
 	}
 
 	err = sendToServer(&tdpb.SharedDirectoryResponse{
+		DirectoryId:  directoryID,
 		CompletionId: completionID,
 		ErrorCode:    uint32(SharedDirectoryErrCodeNil),
 		Operation: &tdpbv1.SharedDirectoryResponse_Delete_{

--- a/lib/teleterm/services/desktop/desktop_test.go
+++ b/lib/teleterm/services/desktop/desktop_test.go
@@ -17,6 +17,8 @@
 package desktop
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gravitational/trace"
@@ -28,18 +30,25 @@ import (
 var desktopURI = uri.NewClusterURI("foo").AppendWindowsDesktop("bar")
 var login = "admin"
 
-func TestSetDirectory(t *testing.T) {
-	path := t.TempDir()
+func TestShareDirectory(t *testing.T) {
+	basePath := t.TempDir()
+	directoryOne := filepath.Join(basePath, "one")
+	directoryTwo := filepath.Join(basePath, "two")
+	require.NoError(t, os.Mkdir(directoryOne, 0700))
+	require.NoError(t, os.Mkdir(directoryTwo, 0700))
 	session, err := NewSession(desktopURI, login)
 	require.NoError(t, err)
 
-	// Clean state, share the directory.
-	err = session.SetSharedDirectory(path)
-	require.NoError(t, err)
+	// Share each directory
+	require.NoError(t, session.ShareDirectory(directoryOne, 1))
+	require.NoError(t, session.ShareDirectory(directoryTwo, 2))
 
-	// Attempt to share another directory.
-	err = session.SetSharedDirectory("any_path")
-	require.True(t, trace.IsAlreadyExists(err))
+	// Try to re-use a directory_id
+	err = session.ShareDirectory("any_path", 2)
+	require.ErrorAs(t, err, new(*trace.AlreadyExistsError))
+
+	// Share invalid directory
+	require.ErrorAs(t, session.ShareDirectory("any", 3), new(*trace.NotFoundError))
 }
 
 func TestGetDirectory(t *testing.T) {
@@ -47,13 +56,13 @@ func TestGetDirectory(t *testing.T) {
 	session, err := NewSession(desktopURI, login)
 	require.NoError(t, err)
 
-	_, err = session.GetDirectoryAccess()
+	_, err = session.GetDirectoryAccess(1)
 	require.True(t, trace.IsNotFound(err))
 
-	err = session.SetSharedDirectory(path)
+	err = session.ShareDirectory(path, 1)
 	require.NoError(t, err)
 
-	access, err := session.GetDirectoryAccess()
+	access, err := session.GetDirectoryAccess(1)
 	require.NoError(t, err)
 	_, err = access.Stat("")
 	require.NoError(t, err)

--- a/proto/teleport/lib/teleterm/v1/service.proto
+++ b/proto/teleport/lib/teleterm/v1/service.proto
@@ -744,6 +744,8 @@ message SetSharedDirectoryForDesktopSessionRequest {
   string login = 2;
   // Path to share with a remote machine. Must be a directory.
   string path = 3;
+  // DirectoryId assigned to this directory.
+  uint32 directory_id = 4;
 }
 
 // Response for SetSharedDirectoryForDesktopSession.

--- a/web/packages/shared/components/DesktopSession/DesktopSession.test.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.test.tsx
@@ -248,17 +248,23 @@ test('directory sharing menu', async () => {
   });
   expect(shareButton).toBeVisible();
 
-  // Clicking the new menu icon should open a menu
-  await userEvent.click(shareButton);
+  // The menu closes immediately after clicking the "Share a directory" button.
+  // 'openMenu' will help us open and re-acquire the menu element.
+  let openMenu = async (): Promise<HTMLElement> => {
+    // Clicking the new menu icon should open a menu
+    await userEvent.click(shareButton);
+    // Return the menu element
+    return screen.findByTestId('shared-directory-menu');
+  };
 
-  // Share a couple directories via this menu
-  let shareMenu = await screen.findByTestId('shared-directory-menu');
   await userEvent.click(
-    within(shareMenu).getByRole('button', { name: 'Share a directory' })
+    within(await openMenu()).getByRole('button', { name: 'Share a directory' })
   );
   await userEvent.click(
-    within(shareMenu).getByRole('button', { name: 'Share a directory' })
+    within(await openMenu()).getByRole('button', { name: 'Share a directory' })
   );
+
+  let shareMenu = await openMenu();
 
   // retrieve the directories
   const directories = await getSharedDirectoryEntries(shareMenu);

--- a/web/packages/shared/components/DesktopSession/DirectoryList.tsx
+++ b/web/packages/shared/components/DesktopSession/DirectoryList.tsx
@@ -19,7 +19,7 @@ import styled from 'styled-components';
 
 import { Flex, Stack, P2, H3 } from 'design';
 import { ButtonPrimary, ButtonProps } from 'design/Button/Button';
-import { FolderPlus, Plus } from 'design/Icon';
+import { FolderPlus, IconSize, Plus } from 'design/Icon';
 import { MenuIcon } from 'shared/components/MenuAction';
 
 interface SharedDirectoriesProps {
@@ -28,6 +28,7 @@ interface SharedDirectoriesProps {
   canShareDirectories: boolean;
   maxSharedDirectories: number;
   directorySharingMessage: string;
+  size?: IconSize;
 }
 
 export interface DirectoryItem {
@@ -41,10 +42,11 @@ export function SharedDirectoryList({
   canShareDirectories,
   maxSharedDirectories,
   directorySharingMessage,
+  size = 'large',
 }: SharedDirectoriesProps) {
   return (
     <MenuIcon
-      Icon={props => <FolderPlus {...props} size="large" />}
+      Icon={props => <FolderPlus {...props} size={size} />}
       buttonIconProps={{
         disabled: !canShareDirectories,
         // square highlight instead of default circle
@@ -53,6 +55,7 @@ export function SharedDirectoryList({
       }}
       // Right align the menu with the icon
       menuProps={{
+        updatePositionOnChildResize: true,
         anchorOrigin: {
           vertical: 'bottom',
           horizontal: 'right',
@@ -68,7 +71,7 @@ export function SharedDirectoryList({
         {/* Without e.stopPropagation here, clicking anywhere within the menu
             container closes it. This handler prevents the menu from closing
             until the user clicks outside of the container. */}
-        <Stack gap={3} fullWidth onClick={e => e.stopPropagation()}>
+        <Stack gap={3} fullWidth>
           {/* Header/Share Button */}
           <Flex justifyContent="space-between" alignItems="center">
             <DropdownHeader directoryCount={sharedDirectories.length} />

--- a/web/packages/shared/libs/tdp/client.ts
+++ b/web/packages/shared/libs/tdp/client.ts
@@ -187,7 +187,7 @@ export class TdpClient extends EventEmitter<EventMap> {
 
   constructor(
     private getTransport: (signal: AbortSignal) => Promise<TdpTransport>,
-    selectSharedDirectory: () => Promise<SharedDirectoryAccess>,
+    selectSharedDirectory: (id: number) => Promise<SharedDirectoryAccess>,
     private logger: Logger,
     private policy: ConnectPolicy = { mode: 'tdp' }
   ) {
@@ -1063,7 +1063,9 @@ class SharedDirectoryManager {
   private sharedDirectories: Map<number, SharedDirectoryAccess>;
 
   constructor(
-    private selectSharedDirectory: () => Promise<SharedDirectoryAccess>,
+    private selectSharedDirectory: (
+      id: number
+    ) => Promise<SharedDirectoryAccess>,
     private logger: Logger,
     private maxDirectories: number
   ) {
@@ -1108,10 +1110,17 @@ class SharedDirectoryManager {
       throw Error('Maximum allowed shared directories reached');
     }
 
-    let directory = await this.selectSharedDirectory();
     const id = this.deviceId.acquire();
     if (id === undefined) {
       throw Error('Error acquiring identifier for shared directory');
+    }
+
+    let directory: SharedDirectoryAccess;
+    try {
+      directory = await this.selectSharedDirectory(id);
+    } catch (err) {
+      this.deviceId.release(id);
+      throw err;
     }
 
     this.sharedDirectories.set(id, directory);

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -665,7 +665,10 @@ end run
 
     ipcHandle(
       MainProcessIpc.SelectDirectoryForDesktopSession,
-      async (_, args: { desktopUri: string; login: string }) => {
+      async (
+        _,
+        args: { desktopUri: string; login: string; directoryId: number }
+      ) => {
         const value = await dialog.showOpenDialog({
           properties: ['openDirectory'],
         });
@@ -682,6 +685,7 @@ end run
           desktopUri: args.desktopUri,
           login: args.login,
           path: dirPath,
+          directoryId: args.directoryId,
         });
 
         return path.basename(dirPath);

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -185,6 +185,7 @@ export default function createMainProcessClient(): MainProcessClient {
     selectDirectoryForDesktopSession(args: {
       desktopUri: string;
       login: string;
+      directoryId: number;
     }) {
       return ipcInvoke(MainProcessIpc.SelectDirectoryForDesktopSession, args);
     },

--- a/web/packages/teleterm/src/ui/DocumentDesktopSession/DocumentDesktopSession.tsx
+++ b/web/packages/teleterm/src/ui/DocumentDesktopSession/DocumentDesktopSession.tsx
@@ -106,10 +106,11 @@ function DesktopSessionComponent(props: {
             logger
           );
         },
-        () =>
+        (directoryId: number) =>
           shareDirectoryInTshd(appCtx.mainProcessClient, {
             desktopUri,
             login,
+            directoryId,
           }),
         new Logger('TDPClient'),
         { mode: 'tdpb' }
@@ -229,6 +230,7 @@ async function shareDirectoryInTshd(
   target: {
     desktopUri: string;
     login: string;
+    directoryId: number;
   }
 ): Promise<SharedDirectoryAccess> {
   const directoryName =

--- a/web/packages/teleterm/src/ui/StatusBar/DesktopSessionControls.tsx
+++ b/web/packages/teleterm/src/ui/StatusBar/DesktopSessionControls.tsx
@@ -24,6 +24,7 @@ import { HoverTooltip } from 'design/Tooltip';
 import ActionMenu from 'shared/components/DesktopSession/ActionMenu';
 import { AlertDropdown } from 'shared/components/DesktopSession/AlertDropdown';
 import type { DesktopSessionControlsRenderProps } from 'shared/components/DesktopSession/DesktopSession';
+import { SharedDirectoryList } from 'shared/components/DesktopSession/DirectoryList';
 import { SessionSettings } from 'shared/components/DesktopSession/SessionSettings';
 import { LatencyDiagnostic } from 'shared/components/LatencyDiagnostic';
 
@@ -39,6 +40,9 @@ export function DesktopSessionControls({
   const iconColor = (active: boolean) =>
     active ? theme.colors.text.main : theme.colors.text.muted;
 
+  const maxDirectoriesReached = controls.canShareMultipleDirectories
+    ? controls.sharedDirectories.length >= controls.maxSharedDirectories
+    : controls.sharedDirectories.length > 0;
   const isSharingDirectory = controls.sharedDirectories.length > 0;
 
   return (
@@ -49,19 +53,30 @@ export function DesktopSessionControls({
       {controls.latencyStats && (
         <LatencyDiagnostic latency={controls.latencyStats} />
       )}
-      <HoverTooltip
-        tipContent={directorySharingTooltip(
-          controls.canShareDirectory,
-          isSharingDirectory
-        )}
-        placement="top"
-      >
-        <FolderShared
-          size="small"
-          padding="8px"
-          color={iconColor(isSharingDirectory)}
+      {controls.canShareMultipleDirectories ? (
+        <SharedDirectoryList
+          sharedDirectories={controls.sharedDirectories}
+          onAddSharedDirectory={controls.onAddSharedDirectory}
+          canShareDirectories={controls.canShareDirectory}
+          maxSharedDirectories={controls.maxSharedDirectories}
+          directorySharingMessage={controls.directorySharingMessage}
+          size={'medium'}
         />
-      </HoverTooltip>
+      ) : (
+        <HoverTooltip
+          tipContent={directorySharingTooltip(
+            controls.canShareDirectory,
+            isSharingDirectory
+          )}
+          placement="top"
+        >
+          <FolderShared
+            size="small"
+            padding="8px"
+            color={iconColor(isSharingDirectory)}
+          />
+        </HoverTooltip>
+      )}
       <HoverTooltip
         tipContent={controls.clipboardSharingMessage}
         placement="top"
@@ -90,7 +105,9 @@ export function DesktopSessionControls({
         openUpward
       />
       <ActionMenu
-        showShareDirectory={controls.canShareDirectory && !isSharingDirectory}
+        showShareDirectory={
+          controls.canShareDirectory && !maxDirectoriesReached
+        }
         onShareDirectory={controls.onAddSharedDirectory}
         onCtrlAltDel={controls.onCtrlAltDel}
         onDisconnect={controls.onDisconnect}


### PR DESCRIPTION
This PR adds multi-directory sharing support for desktop sessions to Teleport Connect.


<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Added support for sharing multiple directories within a Windows Desktop Session to Teleport Connect.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local Cluster with at least one Windows desktop resource.
### Test Cases
(Using Teleport Connect)
- [x] Connect to a desktop and validate that the control panel shows the new sharing icon.
- [x] Click the sharing icon and share a directory. Confirm that the shared directory shows up as an entry in the sharing menu and is visible in Windows Explorer.
- [x] Share 10 directories and confirm the the sharing button (the "plus" icon) is disabled. Also confirm that the action menu does not show the "Share Directory" option.
- [x] Connect to an older WDS instance that does not support multi-directory sharing. Confirm that the sharing button is disabled after sharing a single directory. Also confirm that the action menu does not show the "Share Directory" option.
- [x] Login with a user that does not have sharing permissions. Confirm that sharing is disabled.
