### PR TITLE
docs: update the path to documentation-style-guide in AGENTS-STYLE.md

### DIFF
--- a/docs/AGENTS-STYLE.md
+++ b/docs/AGENTS-STYLE.md
@@ -3,7 +3,7 @@
 This file tells an AI agent **how to apply** Teleport's documentation
 conventions when reviewing a docs PR. It deliberately does not restate the
 conventions themselves: those live in
-[`../contributing/documentation-style-guide.md`](../contributing/documentation-style-guide.md),
+[`contributing/documentation-style-guide.md`](contributing/documentation-style-guide.md),
 the single source of truth shared by human contributors and agents. When a
 question isn't answered there, consistency within the page wins — do not flag
 it.


### PR DESCRIPTION
AGENTS-STYLE.md links to the style guide as `[`../contributing/documentation-style-guide.md`](../contributing/documentation-style-guide.md)`

The actual file lives at: `docs/contributing/documentation-style-guide.md` This was my mistake, made in https://github.com/gravitational/teleport/pull/67631 

Doing agentic testing revealed that it hit the broken path and got a 404.

