### PR TITLE
[vnet] Skip D-Bus connection on Linux when DNS config is unchanged

### DIFF
--- a/lib/vnet/osconfig_linux.go
+++ b/lib/vnet/osconfig_linux.go
@@ -126,6 +126,11 @@ func shouldReconfigureDNSZones(cfg *osConfig, state *platformOSConfigState) bool
 	return !utils.ContainSameUniqueElements(cfg.dnsZones, state.configuredDNSZones)
 }
 
+func shouldReconfigureNameserver(cfg *osConfig, state *platformOSConfigState) bool {
+	return len(cfg.dnsAddrs) > 0 && state.tunName != "" &&
+		!utils.ContainSameUniqueElements(cfg.dnsAddrs, state.configuredDNSAddrs)
+}
+
 func configureDNS(ctx context.Context, cfg *osConfig, state *platformOSConfigState) error {
 	// systemd-resolved stores DNS settings per network link. For VNet
 	// we configure DNS on the TUN link. The TUN is ephemeral, when
@@ -143,6 +148,14 @@ func configureDNS(ctx context.Context, cfg *osConfig, state *platformOSConfigSta
 	}
 	deconfigure := len(cfg.dnsAddrs) == 0 && len(cfg.dnsZones) == 0
 
+	needsZoneUpdate := shouldReconfigureDNSZones(cfg, state)
+	needsNameserverUpdate := shouldReconfigureNameserver(cfg, state)
+	if !needsZoneUpdate && !needsNameserverUpdate {
+		// Nothing changed since the last successful application. Return early
+		// to avoid opening a new D-Bus connection on every tick.
+		return nil
+	}
+
 	conn, err := dbus.ConnectSystemBus()
 	if err != nil {
 		return trace.NotFound("system D-Bus is unavailable: %v", err)
@@ -152,7 +165,7 @@ func configureDNS(ctx context.Context, cfg *osConfig, state *platformOSConfigSta
 		return err
 	}
 
-	if shouldReconfigureDNSZones(cfg, state) {
+	if needsZoneUpdate {
 		iface, err := net.InterfaceByName(state.tunName)
 		if err != nil {
 			if deconfigure && isNoSuchNetworkInterfaceError(err) {
@@ -178,7 +191,7 @@ func configureDNS(ctx context.Context, cfg *osConfig, state *platformOSConfigSta
 		state.configuredDNSZones = cfg.dnsZones
 	}
 
-	if len(cfg.dnsAddrs) > 0 && state.tunName != "" && !slices.Equal(cfg.dnsAddrs, state.configuredDNSAddrs) {
+	if needsNameserverUpdate {
 		iface, err := net.InterfaceByName(state.tunName)
 		if err != nil {
 			return trace.Wrap(err, "looking up interface %s", state.tunName)


### PR DESCRIPTION
On Linux, VNet's admin process opened a new D-Bus connection every 10 seconds even when nothing had changed, it now checks for DNS zone/nameserver changes first and skips D-Bus when there are none.

## Manual Test Plan
### Test Environment
- Ubuntu 25.10 vm

### Test Cases
- [x] VNet starts and apps are reachable; change the DNS zone config, confirm DNS is updated.
