### PR TITLE
[v18] MCP: Remove tool access checker cache

### DIFF
--- a/lib/srv/mcp/helpers_test.go
+++ b/lib/srv/mcp/helpers_test.go
@@ -137,7 +137,7 @@ func withDenyToolsRole(t *testing.T) setupTestContextOptionFunc {
 	return withRole(role)
 }
 
-func makeDualPipeNetConn(t *testing.T) (net.Conn, net.Conn) {
+func makeDualPipeNetConn(t testing.TB) (net.Conn, net.Conn) {
 	t.Helper()
 	clientSourceConn, clientDestConn, err := utils.DualPipeNetConn(
 		utils.MustParseAddr("127.0.0.1:1111"),
@@ -158,7 +158,7 @@ type testContext struct {
 	clientSourceConn net.Conn
 }
 
-func setupTestContext(t *testing.T, applyOpts ...setupTestContextOptionFunc) testContext {
+func setupTestContext(t testing.TB, applyOpts ...setupTestContextOptionFunc) testContext {
 	t.Helper()
 
 	var opts setupTestContextOptions
@@ -206,7 +206,7 @@ func setupTestContext(t *testing.T, applyOpts ...setupTestContextOptionFunc) tes
 	}
 }
 
-func makeTestAuthContext(t *testing.T, user types.User, roleSet services.RoleSet, app types.Application) *authz.Context {
+func makeTestAuthContext(t testing.TB, user types.User, roleSet services.RoleSet, app types.Application) *authz.Context {
 	t.Helper()
 	var err error
 

--- a/lib/srv/mcp/session.go
+++ b/lib/srv/mcp/session.go
@@ -23,7 +23,6 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -37,7 +36,6 @@ import (
 	"github.com/gravitational/teleport/lib/session"
 	appcommon "github.com/gravitational/teleport/lib/srv/app/common"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/mcputils"
 )
 
@@ -143,8 +141,7 @@ func (c *sessionHandlerConfig) checkAndSetDefaults() error {
 type sessionHandler struct {
 	sessionHandlerConfig
 
-	idTracker   *mcputils.IDTracker
-	accessCache *utils.FnCache
+	idTracker *mcputils.IDTracker
 }
 
 func newSessionHandler(cfg sessionHandlerConfig) (*sessionHandler, error) {
@@ -161,15 +158,6 @@ func newSessionHandler(cfg sessionHandlerConfig) (*sessionHandler, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	// Cache access check like tool name for a small period of time.
-	accessCache, err := utils.NewFnCache(utils.FnCacheConfig{
-		TTL:   time.Minute * 10,
-		Clock: cfg.clock,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	// Always begins with session start event for single-connection sessions.
 	if cfg.sessionCtx.transport != types.MCPTransportHTTP {
 		cfg.sessionAuditor.appendStartEvent(cfg.parentCtx)
@@ -178,24 +166,19 @@ func newSessionHandler(cfg sessionHandlerConfig) (*sessionHandler, error) {
 	return &sessionHandler{
 		sessionHandlerConfig: cfg,
 		idTracker:            idTracker,
-		accessCache:          accessCache,
 	}, nil
 }
 
 func (s *sessionHandler) checkAccessToTool(ctx context.Context, toolName string) error {
-	authErr, err := utils.FnCacheGet(ctx, s.accessCache, toolName, func(ctx context.Context) (error, error) {
-		authPref, err := s.accessPoint.GetAuthPreference(ctx)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		matcher := &services.MCPToolMatcher{
-			Name: toolName,
-		}
-		authErr := s.AuthCtx.Checker.CheckAccess(s.App, s.getAccessState(authPref), matcher)
-		return trace.Wrap(authErr), nil
-	})
-	// Fails the check on either authErr or internal error.
-	return trace.NewAggregate(authErr, err)
+	authPref, err := s.accessPoint.GetAuthPreference(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	matcher := &services.MCPToolMatcher{
+		Name: toolName,
+	}
+	err = s.AuthCtx.Checker.CheckAccess(s.App, s.getAccessState(authPref), matcher)
+	return trace.Wrap(err)
 }
 
 // NOTE: the onClientXXX/onServerXXX functions and the close function below

--- a/lib/srv/mcp/session_test.go
+++ b/lib/srv/mcp/session_test.go
@@ -28,7 +28,9 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/utils/mcputils"
@@ -220,5 +222,241 @@ func Test_sessionHandler(t *testing.T) {
 				checkToolsListResponse(t, clientMessages[0], clientReq.ID, tt.allowedTools)
 			})
 		})
+	}
+}
+
+func BenchmarkAccessToTool(b *testing.B) {
+	ctx := b.Context()
+
+	tools := []string{
+		"get_file_contents",
+		"get_file_blame",
+		"github_push_files",
+		"list_directory",
+		"get_repository",
+		"list_repositories",
+		"create_issue",
+		"update_issue",
+		"get_issue",
+		"list_issues",
+		"add_issue_comment",
+		"get_issue_comments",
+		"assign_copilot_to_issue",
+		"get_copilot_job_status",
+		"create_pull_request",
+		"list_pull_requests",
+		"get_pull_request",
+		"pull_request_read",
+		"merge_pull_request",
+		"get_pull_request_files",
+		"get_pull_request_status",
+		"update_pull_request_branch",
+		"get_pull_request_comments",
+		"get_pull_request_reviews",
+		"create_pull_request_review",
+		"create_pull_request_with_copilot",
+		"search_code",
+		"search_repositories",
+		"search_issues",
+		"search_pull_requests",
+		"search_users",
+		"search_orgs",
+		"actions_list",
+		"actions_get",
+		"get_job_logs",
+		"actions_run_trigger",
+		"get_workflow",
+		"get_workflow_run",
+		"get_workflow_run_usage",
+		"get_workflow_run_logs_url",
+		"download_workflow_run_artifact",
+		"get_workflow_job",
+		"projects_list",
+		"projects_get",
+		"projects_write",
+		"code_security",
+		"secret_protection",
+		"dependabot",
+		"discussions",
+		"labels",
+		"gists",
+		"notifications",
+	}
+
+	complexMCPAccessRole, err := types.NewRole("complex_mcp_access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: map[string]apiutils.Strings{
+				"env": {"prod"},
+			},
+			MCP: &types.MCPPermissions{
+				Tools: []string{
+					`^(get|read|list|search).*$`,
+					`^.*_read$`,
+
+					// 1. Matches file retrieval and metadata tools: get_file_contents, get_file_blame, get_repository, list_repositories
+					`^get_(file_(contents|blame)|repositor(y|ies))$`,
+
+					// 2. Deep workflow inspector matching: get_workflow, get_workflow_job, get_workflow_run, get_workflow_run_usage, get_workflow_run_logs_url
+					`^get_workflow(_job|_run(_(usage|logs_url))?)?$`,
+
+					// 3. Matches basic issue lifecycle tools: create_issue, update_issue, get_issue, list_issues, add_issue_comment, get_issue_comments
+					`^(create|update|get|list|add)_issue(_comments?)?$`,
+
+					// 4. Captures PR read states: pull_request_read, get_pull_request_files, get_pull_request_status, get_pull_request_comments, get_pull_request_reviews
+					`^(pull_request_read|[a-z]+_pull_request_(files|status|comments|reviews))$`,
+
+					// 5. Explicitly matches all 6 standalone global search utilities (code, repositories, issues, etc.)
+					`^search_(code|repositories|issues|pull_requests|users|orgs)$`,
+
+					// 6. Focuses specifically on automation log extraction: actions_list, actions_get, actions_run_trigger, get_job_logs
+					`^(actions_(list|get|run_trigger)|get_job_logs)$`,
+
+					// 7. Isolates administrative Project Kanban actions: projects_list, projects_get, projects_write
+					`^projects_(list|get|write)$`,
+
+					// 8. Filters down to security compliance features: code_security, secret_protection, dependabot
+					`^(code_security|secret_protection|dependabot)$`,
+
+					// 9. Captures PR generation and merge events: create_pull_request, merge_pull_request, create_pull_request_with_copilot, create_pull_request_review
+					`^(create|merge)_pull_request(_(with_copilot|review))?$,`,
+
+					// 10. Catches single-word metadata tools: labels, gists, notifications, discussions
+					`^(labels|gists|notifications|discussions)$`,
+
+					// 11. Matches status checks ending specifically in "_status": get_copilot_job_status, get_pull_request_status
+					`^get_(copilot_job|pull_request)_status$`,
+
+					// 12. Generically identifies any AI-assisted capability containing the "copilot" token
+					`^[a-z]+_copilot_[a-z_]+$`,
+
+					// 13. Targets artifact or flat file retrieval: list_directory, download_workflow_run_artifact
+					`^(list_directory|download_workflow_run_artifact)$`,
+
+					// 14. Groups high-privilege structural state changes: github_push_files, projects_write, merge_pull_request
+					`^(github_push_files|projects_write|merge_pull_request)$`,
+
+					// 15. Length-bounded match for tools containing exactly 3 snake_case words (e.g., assign_copilot_to_issue)
+					`^[a-z]{3,7}_[a-z]{4,12}_[a-z]{4,12}$`,
+
+					// 16. Flags any execution tracker capturing operational logs or triggers containing "run"
+					`^[a-z_]+_run(_[a-z_]+)*$`,
+
+					// 17. Isolates collection/list targets processing multiple entries: list_issues, search_pull_requests, etc.
+					`^[a-z]+_(issue|pull_request)s?$`,
+
+					// 18. Matches highly specialized, deeply nested getters containing 3 or 4 snake_case segments
+					`^get_([a-z]+_){2,3}[a-z]+$`,
+
+					// 19. Matches simplistic, shallow tool naming conventions containing exactly one underscore (e.g., code_security)
+					`^[^_]+_[^_]+$`,
+
+					// 20. Enforces rigid structural validation matching standardized API action prefixes
+					`^(get|list|create|update|merge|add|download|search)_[a-z_]+$`,
+				},
+			},
+		},
+		Deny: types.RoleConditions{
+
+			AppLabels: map[string]apiutils.Strings{
+				"env": {"prod"},
+			},
+			MCP: &types.MCPPermissions{
+				Tools: []string{
+					// 1. Fails because GitHub MCP tools are strictly snake_case; this targets PascalCase/CamelCase.
+					`^(Get|List|Create|Update)[A-Z][a-z]+$`,
+
+					// 2. Fails because there are no digits or hyphens used anywhere in the official tool names.
+					`^.*-[0-9]+$`,
+
+					// 3. Fails because core Git plumbing/porcelain commands are not exposed as direct tools.
+					`^git_(clone|commit|checkout|stash|rebase|cherry_pick)$`,
+
+					// 4. Fails because the MCP server does not implement any destructive "delete_" endpoints.
+					`^delete_(branch|tag|repository|issue_comment)$`,
+
+					// 5. Fails because Webhook primitives are completely absent from the current MCP implementation.
+					`^webhook_(create|delete|ping|trigger)_(event|delivery)$`,
+
+					// 6. Fails because GitHub Releases are not supported by any tool in this server.
+					`^release_(draft|publish|latest|assets)$`,
+
+					// 7. Fails because project Milestones are currently a missing capability.
+					`^milestone_(list|create|close|update)_all$`,
+
+					// 8. Fails because organization Team management endpoints are not exposed (only general 'orgs').
+					`^org_team_(members|repos|invitations)$`,
+
+					// 9. Fails because GitHub Actions self-hosted Runner infrastructure is out of scope for the server.
+					`^runner_(register|unregister|status|labels)$`,
+
+					// 10. Fails because Deployment Environments are not manageable via this toolset.
+					`^environment_(deploy|secrets|variables)$`,
+
+					// 11. Fails because repository Forking operations are not natively implemented.
+					`^fork_(repository|sync|status)$`,
+
+					// 12. Fails because GitHub Wikis are completely unsupported by the server's file operations.
+					`^wiki_(page_edit|history|create)$`,
+
+					// 13. Fails because enterprise or user Billing APIs are intentionally omitted for security.
+					`^billing_(actions|packages|storage|copilot)$`,
+
+					// 14. Fails because specific user-profile social sub-resources are not mapped to getter tools.
+					`^get_user_(followers|following|starred|gpg_keys)$`,
+
+					// 15. Fails because api version suffixes (e.g., "_v2") are not appended to the tool names.
+					`^[a-z]+_[a-z]+_v[0-9]+$`,
+
+					// 16. Fails because the server handles actions logs and triggers, but not deployment pipelines.
+					`^deploy(ment)?_(status|created|triggered|failed)$`,
+
+					// 17. Fails because toggling repository states via user interactions (star/watch) isn't built this way.
+					`^(star|watch)_repository_toggle$`,
+
+					// 18. Fails because while Copilot integration exists, administrative seat/billing management does not.
+					`^copilot_(settings|billing|seat_management)$`,
+
+					// 19. Fails because the longest single-word tool is "notifications" (13 letters). This demands 14+ letters without underscores.
+					`^[^_]{14,}$`,
+
+					// 20. Fails because Branch Protection rule management is not exposed as a configurable toolset.
+					`^(create|delete|update)_branch_protection_rule$`,
+				},
+			},
+		},
+	})
+	require.NoError(b, err)
+
+	testCtx := setupTestContext(b, withRole(complexMCPAccessRole))
+
+	mockEmitter := &eventstest.MockRecorderEmitter{}
+	auditor, err := newSessionAuditor(sessionAuditorConfig{
+		emitter:    mockEmitter,
+		hostID:     "test-host-id",
+		sessionCtx: testCtx.SessionCtx,
+		preparer:   &libevents.NoOpPreparer{},
+	})
+	require.NoError(b, err)
+	handler, err := newSessionHandler(sessionHandlerConfig{
+		SessionCtx:     testCtx.SessionCtx,
+		sessionAuth:    &sessionAuth{},
+		sessionAuditor: auditor,
+		accessPoint:    fakeAccessPoint{},
+		parentCtx:      ctx,
+	})
+	require.NoError(b, err)
+
+	requestBuilder := &requestBuilder{}
+
+	requests := make([]*mcputils.JSONRPCRequest, len(tools))
+	for i, tool := range tools {
+		requests[i] = requestBuilder.makeToolsCallRequest(tool)
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		for _, req := range requests {
+			_ = handler.processClientRequest(ctx, req)
+		}
 	}
 }


### PR DESCRIPTION
Backport #67671 to branch/v18

## Manual Test Plan
### Test Environment

Teleport with enrolled streamable-http MCP server.

### Test Cases

- [x] Check basic RBAC for a tools/call access for streamable-http transport
