### PR TITLE
[v18] Fix intermittent RDP decode errors

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -62,7 +62,9 @@ use ironrdp_session::x224::{self, DisconnectDescription, ProcessorOutput};
 use ironrdp_session::SessionErrorKind::Reason;
 use ironrdp_session::{reason_err, SessionError, SessionResult};
 use ironrdp_svc::{SvcMessage, SvcProcessor, SvcProcessorMessages};
-use ironrdp_tokio::{single_sequence_step_read, Framed, FramedWrite, TokioStream};
+use ironrdp_tokio::{
+    single_sequence_step_read, split_tokio_framed, Framed, FramedWrite, TokioStream,
+};
 use log::{debug, error, warn};
 use rand::{Rng, TryRngCore};
 use std::error::Error;
@@ -71,7 +73,7 @@ use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::net::ToSocketAddrs;
 use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
 use std::time::Duration;
-use tokio::io::{split, ReadHalf, WriteHalf};
+use tokio::io::{ReadHalf, WriteHalf};
 use tokio::net::TcpStream as TokioTcpStream;
 use tokio::sync::mpsc::{channel, error::SendError, Receiver, Sender};
 use tokio::task::{self, JoinError};
@@ -262,11 +264,11 @@ impl Client {
         )
         .await?;
 
-        // Take the stream back out of the framed object for splitting.
-        let rdp_stream = rdp_stream.into_inner_no_leftover();
-        let (read_stream, write_stream) = split(rdp_stream);
-        let read_stream = Some(ironrdp_tokio::TokioFramed::new(read_stream));
-        let write_stream = Some(ironrdp_tokio::TokioFramed::new(write_stream));
+        // Split the framed stream into independent read/write halves for the
+        // read and write loops.
+        let (read_stream, write_stream) = split_tokio_framed(rdp_stream);
+        let read_stream = Some(read_stream);
+        let write_stream = Some(write_stream);
 
         let x224_processor = Arc::new(Mutex::new(x224::Processor::new(
             connection_result.static_channels,


### PR DESCRIPTION
Backport #68602 to branch/v18

changelog: fix intermittent RDP decode errors.

## Manual Test Plan
### Test Environment

### Test Cases

- [x] RDP sessions work.
