### PR TITLE
Update macOS build setup docs

### DIFF
--- a/BUILD_macos.md
+++ b/BUILD_macos.md
@@ -23,8 +23,13 @@ and updates are welcome!
     ```shell
     brew install rustup
 
-    rustup-init
-    # Accept defaults
+    # Add Homebrew's rustup shims and Cargo-installed tools to PATH.
+    RUSTUP_PREFIX="$(brew --prefix rustup)"
+    echo 'export PATH="$HOME/.cargo/bin:'"${RUSTUP_PREFIX}"'/bin:$PATH"' >> ~/.zshrc
+    source ~/.zshrc
+
+    # Install the toolchain and targets pinned by rust-toolchain.toml.
+    rustup toolchain install
     ```
 
 1. Install Node.js
@@ -78,7 +83,7 @@ and updates are welcome!
     ```shell
     brew install helm
 
-    helm plugin install https://github.com/quintush/helm-unittest --version 0.2.11
+    helm plugin install https://github.com/helm-unittest/helm-unittest --version "$(cat build.assets/helm-unittest.version)" --verify=false
     ```
 
 1. Install `bats`:


### PR DESCRIPTION
Updated the macOS build setup documentation after going through it and addressing a few issues relating to `rustup` and `helm plugin`.

Homebrew's rustup formula no longer provides the `rustup-init` entrypoint — the rustup-init command errored for me when I attempted it. The updated instructions also add Homebrew rustup and Cargo-installed tools to PATH before installing the toolchain pinned by rust-toolchain.toml. This also makes Cargo-installed WASM tools such as wasm-bindgen and wasm-opt available to the build.

The Helm unittest install command now uses the maintained helm-unittest/helm-unittest plugin (which is [referenced in our Makefile here](https://github.com/gravitational/teleport/blob/85aa38c376979a744749da25b32cfa4b13044d00/Makefile#L959)) and reads the pinned version from build.assets/helm-unittest.version. The command also includes `--verify=false`, because my install command would not work without this. `--verify=false` is needed because Helm 4 verifies plugin sources by default, and the helm-unittest GitHub plugin source does not provide Helm-compatible signature verification metadata (a `.prov` file).

## Manual Test Plan
### Test Environment

macOS arm64 local development environment using Homebrew, rustup 1.29.0_2, Helm 4.2.3, and the Teleport repository on branch nickcellino/macos-build-setup-docs.

### Test Cases
- [x] `make all test` was able to build all artifacts (note: not all tests passed for me)