### PR TITLE
[scopes] events for scoped access lists

### DIFF
--- a/lib/backend/key.go
+++ b/lib/backend/key.go
@@ -124,6 +124,22 @@ func (k Key) TrimPrefix(prefix Key) Key {
 	return KeyFromString(key)
 }
 
+// CutPrefix returns the key without the provided leading prefix string
+// and reports whether it found the prefix.
+// If the key doesn't start with prefix, CutPrefix returns k, false.
+// If prefix is the empty string, CutPrefix returns k, true.
+func (k Key) CutPrefix(prefix Key) (after Key, found bool) {
+	key, found := strings.CutPrefix(k.s, prefix.s)
+	if !found {
+		return k, false
+	}
+	if key == "" {
+		return Key{}, true
+	}
+
+	return KeyFromString(key), true
+}
+
 // PrependKey returns a new [Key] that joins p and k
 // with the components of p followed by the components from k.
 func (k Key) PrependKey(p Key) Key {

--- a/lib/backend/key_test.go
+++ b/lib/backend/key_test.go
@@ -391,6 +391,55 @@ func TestKeyTrimPrefix(t *testing.T) {
 	}
 }
 
+func TestKeyCutPrefix(t *testing.T) {
+	tests := []struct {
+		name          string
+		key           backend.Key
+		prefix        backend.Key
+		expectedAfter backend.Key
+		expectedFound bool
+	}{
+		{
+			name:          "empty key with empty prefix",
+			expectedFound: true,
+		},
+		{
+			name:          "empty prefix matches",
+			key:           backend.NewKey("a", "b"),
+			expectedAfter: backend.NewKey("a", "b"),
+			expectedFound: true,
+		},
+		{
+			name:          "non-matching prefix returns original key",
+			key:           backend.NewKey("a", "b"),
+			prefix:        backend.NewKey("c", "d"),
+			expectedAfter: backend.NewKey("a", "b"),
+		},
+		{
+			name:          "matching prefix returns remaining key",
+			key:           backend.NewKey("a", "b", "c"),
+			prefix:        backend.ExactKey("a", "b"),
+			expectedAfter: backend.KeyFromString("c"),
+			expectedFound: true,
+		},
+		{
+			name:          "exact match returns empty key",
+			key:           backend.NewKey("a", "b"),
+			prefix:        backend.NewKey("a", "b"),
+			expectedAfter: backend.Key{},
+			expectedFound: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			after, found := test.key.CutPrefix(test.prefix)
+			assert.Equal(t, test.expectedAfter, after)
+			assert.Equal(t, test.expectedFound, found)
+		})
+	}
+}
+
 func TestKeyPrependKey(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -138,6 +138,10 @@ func makeAllKnownCAsFilter() types.CertAuthorityFilter {
 func ForAuth(cfg Config) Config {
 	cfg.target = "auth"
 	cfg.EnableRelativeExpiry = true
+	// Explicitly filter to only unscoped resources for scope-aware kinds with
+	// scoped events but no cache support yet.
+	// TODO(nklaassen): delete when scoped access lists have cache support.
+	unscoped := types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build())
 	cfg.Watches = []types.WatchKind{
 		{Kind: types.KindCertAuthority, LoadSecrets: true},
 		{Kind: types.KindCertAuthorityOverride},
@@ -193,9 +197,9 @@ func ForAuth(cfg Config) Config {
 		{Kind: types.KindAuditQuery},
 		{Kind: types.KindSecurityReport},
 		{Kind: types.KindSecurityReportState},
-		{Kind: types.KindAccessList},
-		{Kind: types.KindAccessListMember},
-		{Kind: types.KindAccessListReview},
+		{Kind: types.KindAccessList, ScopeFilter: unscoped},
+		{Kind: types.KindAccessListMember, ScopeFilter: unscoped},
+		{Kind: types.KindAccessListReview, ScopeFilter: unscoped},
 		{Kind: types.KindKubeWaitingContainer},
 		{Kind: types.KindNotification},
 		{Kind: types.KindGlobalNotification},
@@ -519,8 +523,6 @@ func ForOkta(cfg Config) Config {
 		{Kind: types.KindProxy},
 		{Kind: types.KindRole},
 		{Kind: types.KindClusterAuthPreference},
-		{Kind: types.KindAccessList},
-		{Kind: types.KindAccessListMember},
 	}
 	cfg.QueueSize = defaults.DiscoveryQueueSize
 	return cfg

--- a/lib/scopes/cache/access/access.go
+++ b/lib/scopes/cache/access/access.go
@@ -325,11 +325,13 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry retryutils.Retry) error
 	// watcher which watches backend events. It is used for driving changes to
 	// scoped role assignments materialized from access lists and their
 	// memberships.
+	// TODO(nklaassen): remove scope filter when materializer supports scoped lists.
+	unscoped := types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build())
 	aclWatcher, err := c.cfg.AccessListEvents.NewWatcher(ctx, types.Watch{
 		Name: "scoped-access-cache-acl-watcher",
 		Kinds: []types.WatchKind{
-			{Kind: types.KindAccessList},
-			{Kind: types.KindAccessListMember},
+			{Kind: types.KindAccessList, ScopeFilter: unscoped},
+			{Kind: types.KindAccessListMember, ScopeFilter: unscoped},
 		},
 	})
 	if err != nil {

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -41,6 +41,8 @@ import (
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/kubewaitingcontainer"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -225,6 +227,10 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 			parser = p
 		case types.KindAccessList:
 			parser = newAccessListParser()
+		case types.KindAccessListMember:
+			parser = newAccessListMemberParser()
+		case types.KindAccessListReview:
+			parser = newAccessListReviewParser()
 		case types.KindAuditQuery:
 			parser = newAuditQueryParser()
 		case types.KindSecurityReport:
@@ -233,10 +239,6 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 			parser = newSecurityReportStateParser()
 		case types.KindUserLoginState:
 			parser = newUserLoginStateParser()
-		case types.KindAccessListMember:
-			parser = newAccessListMemberParser()
-		case types.KindAccessListReview:
-			parser = newAccessListReviewParser()
 		case types.KindKubeWaitingContainer:
 			parser = newKubeWaitingContainerParser()
 		case types.KindNotification:
@@ -2623,9 +2625,25 @@ func (p *headlessAuthenticationParser) parse(event backend.Event) (types.Resourc
 	}
 }
 
+func trimScopePrefix(key backend.Key) (scope string, remaining []string, err error) {
+	parts := key.Components()
+	if len(parts) < 2 {
+		return "", nil, trace.NotFound("failed parsing %v", key.String())
+	}
+	encodedScope := parts[0]
+	scope, err = scopes.DecodeFromKey(encodedScope)
+	if err != nil {
+		return "", nil, trace.Wrap(err)
+	}
+	return scope, parts[1:], nil
+}
+
 func newAccessListParser() *accessListParser {
 	return &accessListParser{
-		baseParser: newBaseParser(backend.ExactKey(accessListPrefix)),
+		baseParser: newBaseParser(
+			backend.ExactKey(accessListPrefix),
+			backend.ExactKey(scopedPrefix, accessListPrefix),
+		),
 	}
 }
 
@@ -2636,6 +2654,29 @@ type accessListParser struct {
 func (p *accessListParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
+		if key, found := event.Item.Key.CutPrefix(backend.ExactKey(scopedPrefix, accessListPrefix)); found {
+			scope, remaining, err := trimScopePrefix(key)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			if len(remaining) != 1 {
+				return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+			}
+			name := remaining[0]
+			// Delete events for scoped resources use an AccessList rather than
+			// ResourceHeader, to include the scope.
+			return &accesslist.AccessList{
+				ResourceHeader: header.ResourceHeader{
+					Kind:    types.KindAccessList,
+					Version: types.V1,
+					Metadata: header.Metadata{
+						Name: name,
+					},
+				},
+				Scope: scope,
+			}, nil
+		}
+
 		name := event.Item.Key.TrimPrefix(backend.NewKey(accessListPrefix)).String()
 		if name == "" {
 			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
@@ -2802,7 +2843,10 @@ func (p *userLoginStateParser) parse(event backend.Event) (types.Resource, error
 
 func newAccessListMemberParser() *accessListMemberParser {
 	return &accessListMemberParser{
-		baseParser: newBaseParser(backend.ExactKey(accessListMemberPrefix)),
+		baseParser: newBaseParser(
+			backend.ExactKey(accessListMemberPrefix),
+			backend.ExactKey(scopedPrefix, accessListMemberPrefix),
+		),
 	}
 }
 
@@ -2813,6 +2857,49 @@ type accessListMemberParser struct {
 func (p *accessListMemberParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
+		if key, found := event.Item.Key.CutPrefix(backend.ExactKey(scopedPrefix, accessListMemberPrefix)); found {
+			listScope, remaining, err := trimScopePrefix(key)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			if len(remaining) != 3 {
+				return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+			}
+			listName, encodedMemberScope, memberName := remaining[0], remaining[1], remaining[2]
+			memberScope, err := scopes.DecodeFromKey(encodedMemberScope)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			listSQN := scopes.QualifiedName{
+				Scope: listScope,
+				Name:  listName,
+			}
+			memberSQN := scopes.QualifiedName{
+				Scope: memberScope,
+				Name:  memberName,
+			}
+			membershipKind := accesslist.MembershipKindUnspecified
+			if memberScope != "" {
+				membershipKind = accesslist.MembershipKindScopedList
+			}
+			// Delete events for scoped resources use an AccessListMember rather than
+			// ResourceHeader, to include the scope.
+			return &accesslist.AccessListMember{
+				ResourceHeader: header.ResourceHeader{
+					Kind:    types.KindAccessListMember,
+					Version: types.V1,
+					Metadata: header.Metadata{
+						Name: memberSQN.String(),
+					},
+				},
+				Scope: listScope,
+				Spec: accesslist.AccessListMemberSpec{
+					AccessList:     listSQN.String(),
+					Name:           memberSQN.String(),
+					MembershipKind: membershipKind,
+				},
+			}, nil
+		}
 		key := event.Item.Key.TrimPrefix(backend.NewKey(accessListMemberPrefix))
 		if len(key.Components()) < 2 {
 			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
@@ -2840,7 +2927,10 @@ func (p *accessListMemberParser) parse(event backend.Event) (types.Resource, err
 
 func newAccessListReviewParser() *accessListReviewParser {
 	return &accessListReviewParser{
-		baseParser: newBaseParser(backend.ExactKey(accessListReviewPrefix)),
+		baseParser: newBaseParser(
+			backend.ExactKey(accessListReviewPrefix),
+			backend.ExactKey(scopedPrefix, accessListReviewPrefix),
+		),
 	}
 }
 
@@ -2851,6 +2941,35 @@ type accessListReviewParser struct {
 func (p *accessListReviewParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
+		if key, found := event.Item.Key.CutPrefix(backend.ExactKey(scopedPrefix, accessListReviewPrefix)); found {
+			listScope, remaining, err := trimScopePrefix(key)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			if len(remaining) != 2 {
+				return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+			}
+			listName, reviewName := remaining[0], remaining[1]
+			listSQN := scopes.QualifiedName{
+				Scope: listScope,
+				Name:  listName,
+			}
+			// Delete events for scoped resources use a Review rather than
+			// ResourceHeader, to include the scope.
+			return &accesslist.Review{
+				ResourceHeader: header.ResourceHeader{
+					Kind:    types.KindAccessListReview,
+					Version: types.V1,
+					Metadata: header.Metadata{
+						Name: reviewName,
+					},
+				},
+				Scope: listScope,
+				Spec: accesslist.ReviewSpec{
+					AccessList: listSQN.String(),
+				},
+			}, nil
+		}
 		key := event.Item.Key.TrimPrefix(backend.NewKey(accessListReviewPrefix))
 		if len(key.Components()) < 2 {
 			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())

--- a/lib/services/local/events_test.go
+++ b/lib/services/local/events_test.go
@@ -31,9 +31,11 @@ import (
 	mfav2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v2"
 	provisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/provisioning/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/lib/auth/authcatest"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils/set"
 )
@@ -65,6 +67,151 @@ func unwrapResource153[T types.Resource153](t *testing.T, r types.Resource) T {
 
 	dst := u.UnwrapT()
 	return dst
+}
+
+func mustEncodeScopeForKey(t *testing.T, scope string) string {
+	t.Helper()
+
+	encoded, err := scopes.EncodeForKey(scope)
+	require.NoError(t, err)
+	return encoded
+}
+
+func TestAccessListParserScopedDelete(t *testing.T) {
+	const scope = "/eng/platform"
+	key := backend.NewKey(scopedPrefix, accessListPrefix, mustEncodeScopeForKey(t, scope), "reviewed")
+	event := backend.Event{
+		Type: types.OpDelete,
+		Item: backend.Item{Key: key},
+	}
+
+	parser := newAccessListParser()
+	require.True(t, parser.match(key))
+
+	resource, err := parser.parse(event)
+	require.NoError(t, err)
+
+	accessList, ok := resource.(*accesslist.AccessList)
+	require.True(t, ok)
+	require.Equal(t, types.KindAccessList, accessList.GetKind())
+	require.Equal(t, "reviewed", accessList.GetName())
+	require.Equal(t, scope, accessList.Scope)
+}
+
+func TestAccessListMemberParserScopedDelete(t *testing.T) {
+	const listScope = "/eng/platform"
+
+	tests := []struct {
+		name                   string
+		member                 scopes.QualifiedName
+		expectedMembershipKind string
+	}{
+		{
+			name:                   "unscoped member",
+			member:                 scopes.QualifiedName{Name: "alice"},
+			expectedMembershipKind: accesslist.MembershipKindUnspecified,
+		},
+		{
+			name:                   "scoped list member",
+			member:                 scopes.QualifiedName{Scope: "/eng", Name: "team"},
+			expectedMembershipKind: accesslist.MembershipKindScopedList,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			key := backend.NewKey(
+				scopedPrefix,
+				accessListMemberPrefix,
+				mustEncodeScopeForKey(t, listScope),
+				"reviewed",
+				mustEncodeScopeForKey(t, test.member.Scope),
+				test.member.Name,
+			)
+			event := backend.Event{
+				Type: types.OpDelete,
+				Item: backend.Item{Key: key},
+			}
+
+			parser := newAccessListMemberParser()
+			require.True(t, parser.match(key))
+
+			resource, err := parser.parse(event)
+			require.NoError(t, err)
+
+			member, ok := resource.(*accesslist.AccessListMember)
+			require.True(t, ok)
+			require.Equal(t, types.KindAccessListMember, member.GetKind())
+			require.Equal(t, test.member.String(), member.GetName())
+			require.Equal(t, listScope, member.Scope)
+			require.Equal(t, scopes.QualifiedName{Scope: listScope, Name: "reviewed"}.String(), member.Spec.AccessList)
+			require.Equal(t, test.member.String(), member.Spec.Name)
+			require.Equal(t, test.expectedMembershipKind, member.Spec.MembershipKind)
+		})
+	}
+}
+
+func TestAccessListReviewParserScopedDelete(t *testing.T) {
+	const scope = "/eng/platform"
+	key := backend.NewKey(scopedPrefix, accessListReviewPrefix, mustEncodeScopeForKey(t, scope), "reviewed", "review-1")
+	event := backend.Event{
+		Type: types.OpDelete,
+		Item: backend.Item{Key: key},
+	}
+
+	parser := newAccessListReviewParser()
+	require.True(t, parser.match(key))
+
+	resource, err := parser.parse(event)
+	require.NoError(t, err)
+
+	review, ok := resource.(*accesslist.Review)
+	require.True(t, ok)
+	require.Equal(t, types.KindAccessListReview, review.GetKind())
+	require.Equal(t, "review-1", review.GetName())
+	require.Equal(t, scope, review.Scope)
+	require.Equal(t, scopes.QualifiedName{Scope: scope, Name: "reviewed"}.String(), review.Spec.AccessList)
+}
+
+func TestAccessListScopedDeleteParserRejectsMalformedKeys(t *testing.T) {
+	tests := []struct {
+		name   string
+		parser resourceParser
+		key    backend.Key
+	}{
+		{
+			name:   "access list missing name",
+			parser: newAccessListParser(),
+			key:    backend.NewKey(scopedPrefix, accessListPrefix, mustEncodeScopeForKey(t, "/eng/platform")),
+		},
+		{
+			name:   "member missing member name",
+			parser: newAccessListMemberParser(),
+			key: backend.NewKey(
+				scopedPrefix,
+				accessListMemberPrefix,
+				mustEncodeScopeForKey(t, "/eng/platform"),
+				"reviewed",
+				mustEncodeScopeForKey(t, "/eng"),
+			),
+		},
+		{
+			name:   "review has bad encoded scope",
+			parser: newAccessListReviewParser(),
+			key:    backend.NewKey(scopedPrefix, accessListReviewPrefix, "bad-scope", "reviewed", "review-1"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.True(t, test.parser.match(test.key))
+			_, err := test.parser.parse(backend.Event{
+				Type: types.OpDelete,
+				Item: backend.Item{Key: test.key},
+			})
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestWatchers(t *testing.T) {


### PR DESCRIPTION
Part of [RFD 308](https://github.com/gravitational/rfd/pull/22)

This PR adds events for scoped access lists, and their members and reviews.

Depends on https://github.com/gravitational/teleport/pull/68605

Child: https://github.com/gravitational/teleport/pull/68479