### PR TITLE
Add OpenAI chat completions API handler

### DIFF
--- a/lib/srv/app/llm/openai/openai.go
+++ b/lib/srv/app/llm/openai/openai.go
@@ -80,6 +80,17 @@ func NewRequest(cfg *llmrequest.Config) (*http.Request, llmrequest.RequestInfo, 
 			providerPath = "/responses"
 			providerMethod = http.MethodPost
 			req = &responsesAPIRequest{}
+		// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
+		case "/chat/completions":
+			if cfg.DownstreamRequest.Method != http.MethodPost {
+				// We're ok with returning 404 back to clients instead 405 status.
+				return nil, info, trace.NotFound("chat completions API supports only POST requests")
+			}
+
+			info.endpointType = endpointTypeChatCompletions
+			providerPath = "/chat/completions"
+			providerMethod = http.MethodPost
+			req = &chatCompletionsAPIRequest{}
 		default:
 			return nil, info, trace.NotFound("unsupported endpoint")
 		}
@@ -125,6 +136,7 @@ func NewRequest(cfg *llmrequest.Config) (*http.Request, llmrequest.RequestInfo, 
 	info.providerModel = providerModel
 	req.SetModel(providerModel)
 	req.EnableReportUsage()
+	req.DisableDataRetention()
 
 	providerBody, err := utils.FastMarshal(req)
 	if err != nil {

--- a/lib/srv/app/llm/openai/openai_test.go
+++ b/lib/srv/app/llm/openai/openai_test.go
@@ -298,6 +298,71 @@ func TestNewRequest(t *testing.T) {
 			expectedRequest: require.Nil,
 			expectedInfo:    require.NotNil,
 		},
+		"successful chat completions": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/chat/completions",
+					strings.NewReader(`{"model":"gpt-5","stream": true,"messages":[{"role":"user","content":"Hello"}]}`),
+				)
+				return r
+			},
+			expectedError: require.NoError,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				require.Equal(tt, "/v1/chat/completions", req.URL.Path)
+				require.Equal(tt, http.MethodPost, req.Method)
+				require.Equal(tt, "Bearer "+apiKey, req.Header.Get("Authorization"))
+				require.NotEmpty(tt, req.Header.Get("content-type"))
+				// Usage reporting is enabled on chat completions requests.
+				body, err := io.ReadAll(req.Body)
+				require.NoError(tt, err)
+				require.Contains(tt, string(body), `"include_usage":true`)
+			},
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Equal(tt, "gpt-5", info.RequestedModel())
+				require.Equal(tt, "gpt-5", info.ProviderModel())
+			},
+		},
+		"chat completions store is not supported": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/chat/completions",
+					strings.NewReader(`{"model":"gpt-5","stream": true,"store":true,"messages":[{"role":"user","content":"Hello"}]}`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"unsupported method on chat completions": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodGet,
+					"/chat/completions",
+					nil,
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			req, info, err := NewRequest(&llmrequest.Config{

--- a/lib/srv/app/llm/openai/recorder.go
+++ b/lib/srv/app/llm/openai/recorder.go
@@ -17,6 +17,7 @@
 package openai
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
@@ -67,6 +68,15 @@ func (e Endpoint) ParseUsage(body []byte) (inputTokens int, outputTokens int, er
 			return 0, 0, trace.Wrap(err)
 		}
 		return result.Usage.InputTokens, result.Usage.OutputTokens, nil
+	case endpointTypeChatCompletions:
+		var result chatCompletionsResponse
+		if err := utils.FastUnmarshal(body, &result); err != nil {
+			return 0, 0, trace.Wrap(err)
+		}
+		if result.Usage == nil {
+			return 0, 0, llmerrors.NewProviderError(llmerrors.ErrBadResponse, "missing usage information")
+		}
+		return result.Usage.PromptTokens, result.Usage.CompletionTokens, nil
 	default:
 		return 0, 0, trace.BadParameter("endpoint type not supported")
 	}
@@ -77,6 +87,8 @@ func (e Endpoint) ProcessSSE(ctx context.Context, log *slog.Logger, reader io.Re
 	switch e.endpointType {
 	case endpointTypeResponses:
 		return processResponsesSSEEvents(ctx, log, reader, writer)
+	case endpointTypeChatCompletions:
+		return processChatCompletionsSSEEvents(ctx, log, reader, writer)
 	default:
 		return 0, 0, trace.BadParameter("endpoint type not supported")
 	}
@@ -196,6 +208,80 @@ func processResponsesSSEEvents(ctx context.Context, log *slog.Logger, r io.ReadC
 	}
 
 	return inputTokensCount, outputTokensCount, nil
+}
+
+// processChatCompletionsSSEEvents process chat completions API streaming (SSE)
+// events.
+//
+// This streaming has only one type of event, and they have roughly the same
+// shape as the non-stream chat completions responses, with only a subset of
+// fields available in the events.
+//
+// Usage information will be available on the last JSON event of the stream, and
+// similarly to responses API streaming, if the request is canceled before the
+// event arrives we cannot determine the token usage. This is a known limitation
+// and will be addressed in the future when we introduce token budgeting.
+func processChatCompletionsSSEEvents(ctx context.Context, log *slog.Logger, r io.ReadCloser, w io.Writer) (int, int, error) {
+	defer r.Close()
+
+	// Instead of trying to unmarshal every chunk to check if usage is
+	// available, we'll do that only on the last JSON event which is the only
+	// event that contains usage information.
+	//
+	// Chat completions always send a `[DONE]` event when streaming is done, and
+	// when usage is enabled the chunk before that will contain the usage
+	// information. We can use that as differentiator of "non-data" event,
+	// but not a requirement. If the last event contains the usage information
+	// we should be good to go.
+	//
+	// Note usage information needs to be enabled in the request using
+	// `stream_options`. Note from OpenAI docs:
+	//
+	//	> If set, an additional chunk will be streamed before the data: [DONE] message.
+	//	> The usage field on this chunk shows the token usage statistics for the
+	//	> entire request, and the choices field will always be an empty array.
+	//	> All other chunks will also include a usage field, but with a null value.
+	//	> NOTE: If the stream is interrupted, you may not receive the final usage
+	//	> chunk which contains the total token usage for the request.
+
+	var lastEventPayload []byte
+	for event, err := range sse.ReadEvents(r) {
+		if err != nil {
+			return 0, 0, trace.Wrap(err)
+		}
+
+		if !bytes.Equal(event.Data, []byte("[DONE]")) {
+			lastEventPayload = event.Data
+		}
+
+		if _, err := sse.WriteEvent(w, event); err != nil {
+			return 0, 0, trace.Wrap(err)
+		}
+	}
+
+	if len(lastEventPayload) == 0 {
+		log.ErrorContext(ctx, "empty chat completion response")
+		return 0, 0, llmerrors.ErrBadResponse
+	}
+
+	var completionResp chatCompletionsResponse
+	if err := utils.FastUnmarshal(lastEventPayload, &completionResp); err != nil {
+		log.ErrorContext(ctx, "failed to parse chat completion event", "error", err)
+		return 0, 0, llmerrors.ErrBadResponse
+	}
+
+	// This behavior is not documented, but the SDKs do handle it. So here we're
+	// being defensive, otherwise an error event would be seen as success with
+	// empty usage.
+	if completionResp.Error != nil {
+		return 0, 0, llmerrors.NewProviderError(llmerrors.ErrUnknown, completionResp.Error.Message)
+	}
+
+	if completionResp.Usage == nil {
+		return 0, 0, llmerrors.NewProviderError(llmerrors.ErrBadResponse, "provider did not send final event")
+	}
+
+	return completionResp.Usage.PromptTokens, completionResp.Usage.CompletionTokens, nil
 }
 
 const (

--- a/lib/srv/app/llm/openai/recorder_test.go
+++ b/lib/srv/app/llm/openai/recorder_test.go
@@ -44,6 +44,16 @@ var responsesSuccessStream = strings.Join([]string{
 var responsesIncompleteStream = "event: response.incomplete\n" +
 	`data: {"type":"response.incomplete","response":{"status":"incomplete","incomplete_details":{"reason":"max_tokens"},"usage":{"input_tokens":15,"output_tokens":60,"total_tokens":75},"sequence_number":1}}`
 
+// chatCompletionsSuccessStream is a valid chat completions API SSE stream. When
+// stream_options.include_usage is set, the usage is reported on the chunk right
+// before the terminal `[DONE]` event.
+var chatCompletionsSuccessStream = strings.Join([]string{
+	`data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"}}],"usage":null}`,
+	`data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"World"}}],"usage":null}`,
+	`data: {"id":"c1","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":15,"completion_tokens":60,"total_tokens":75}}`,
+	`data: [DONE]`,
+}, "\n\n")
+
 // TestParseProviderError covers the OpenAI status-code to Teleport error
 // mapping.
 func TestParseProviderError(t *testing.T) {
@@ -122,6 +132,18 @@ func TestEndpointParseUsage(t *testing.T) {
 		"responses malformed body": {
 			endpointType: endpointTypeResponses,
 			body:         `{"usage":`,
+			expectedErr:  require.Error,
+		},
+		"chat completions success": {
+			endpointType:         endpointTypeChatCompletions,
+			body:                 `{"id":"chatcmpl_123","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Hello"}}],"usage":{"prompt_tokens":15,"completion_tokens":20,"total_tokens":35}}`,
+			expectedInputTokens:  15,
+			expectedOutputTokens: 20,
+			expectedErr:          require.NoError,
+		},
+		"chat malformed body": {
+			endpointType: endpointTypeChatCompletions,
+			body:         `{"usage":{`,
 			expectedErr:  require.Error,
 		},
 	} {
@@ -223,6 +245,69 @@ func TestEndpointProcessSSE(t *testing.T) {
 				require.Empty(t, body)
 			},
 		},
+		"chat completions success extracts usage and forwards events": {
+			endpointType:        endpointTypeChatCompletions,
+			stream:              chatCompletionsSuccessStream,
+			expectedInputTokens: 15,
+			expectedOutput:      60,
+			expectedErr:         require.NoError,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Equal(t, chatCompletionsSuccessStream+"\n\n", body)
+			},
+		},
+		"chat completions empty stream reports no usage": {
+			endpointType:        endpointTypeChatCompletions,
+			stream:              "",
+			expectedInputTokens: 0,
+			expectedOutput:      0,
+			expectedErr:         require.Error,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Empty(t, body)
+			},
+		},
+		"chat completions returns error": {
+			endpointType:        endpointTypeChatCompletions,
+			stream:              "event: data\n" + `data: {"error":{"message":"chat completion failure"}}`,
+			expectedInputTokens: 0,
+			expectedOutput:      0,
+			expectedErr: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorContains(tt, err, "chat completion failure", i...)
+			},
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Equal(
+					t,
+					"event: data\n"+`data: {"error":{"message":"chat completion failure"}}`+"\n\n",
+					body,
+					"expected the exact same SSE event, but got a different result",
+				)
+			},
+		},
+		"chat completions missing usage event": {
+			endpointType: endpointTypeChatCompletions,
+			stream: strings.Join([]string{
+				`data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello World"}}],"usage":null}`,
+				`data: [DONE]`,
+			}, "\n\n"),
+			expectedInputTokens: 0,
+			expectedOutput:      0,
+			expectedErr:         require.Error,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.NotEmpty(t, body)
+			},
+		},
+		"chat completions never sends DONE": {
+			endpointType: endpointTypeChatCompletions,
+			stream: strings.Join([]string{
+				`data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello World"}}],"usage":null}`,
+				`data: {"id":"c1","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":15,"completion_tokens":60,"total_tokens":75}}`,
+			}, "\n\n"),
+			expectedInputTokens: 15,
+			expectedOutput:      60,
+			expectedErr:         require.NoError,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.NotEmpty(t, body)
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -301,6 +386,16 @@ func buildResponsesBody(fillerBytes int) []byte {
 	)
 }
 
+// buildChatCompletionsBody returns a valid non-streaming chat completions API
+// response whose total size is roughly fillerBytes.
+func buildChatCompletionsBody(fillerBytes int) []byte {
+	text := strings.Repeat("A", fillerBytes)
+	return fmt.Appendf(nil,
+		`{"id":"chatcmpl_123","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":%q}}],"usage":{"prompt_tokens":15,"completion_tokens":20,"total_tokens":35}}`,
+		text,
+	)
+}
+
 // buildResponsesStreamEvents returns valid responses API SSE events.
 func buildResponsesStreamEvents(numEvents int) [][]byte {
 	events := make([][]byte, 0, numEvents+2)
@@ -312,8 +407,20 @@ func buildResponsesStreamEvents(numEvents int) [][]byte {
 	return events
 }
 
-// BenchmarkResponseRecorderJSON tracks the non-streaming path for each API
-// endpoint format.
+// buildChatCompletionsStreamEvents returns valid chat completions API SSE
+// events.
+func buildChatCompletionsStreamEvents(numEvents int) [][]byte {
+	events := make([][]byte, 0, numEvents+2)
+	for range numEvents {
+		events = append(events, []byte(`data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"Hello world"}}],"usage":null}`+"\n\n"))
+	}
+	events = append(events, []byte(`data: {"id":"c1","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":15,"completion_tokens":60,"total_tokens":75}}`+"\n\n"))
+	events = append(events, []byte(`data: [DONE]`+"\n\n"))
+	return events
+}
+
+// BenchmarkResponseRecorderJSON tracks the non-streaming path for both API
+// formats.
 //
 //	go test ./lib/srv/app/llm/openai/ -run '^$' -bench BenchmarkResponseRecorderJSON -benchmem
 func BenchmarkResponseRecorderJSON(b *testing.B) {
@@ -326,6 +433,9 @@ func BenchmarkResponseRecorderJSON(b *testing.B) {
 		{"responses/small", endpointTypeResponses, buildResponsesBody(16)},
 		{"responses/medium_32KB", endpointTypeResponses, buildResponsesBody(32 * 1024)},
 		{"responses/large_1MB", endpointTypeResponses, buildResponsesBody(1024 * 1024)},
+		{"chat/small", endpointTypeChatCompletions, buildChatCompletionsBody(16)},
+		{"chat/medium_32KB", endpointTypeChatCompletions, buildChatCompletionsBody(32 * 1024)},
+		{"chat/large_1MB", endpointTypeChatCompletions, buildChatCompletionsBody(1024 * 1024)},
 	} {
 		b.Run(bc.name, func(b *testing.B) {
 			b.SetBytes(int64(len(bc.body)))
@@ -358,6 +468,9 @@ func BenchmarkResponseRecorderStream(b *testing.B) {
 		{"responses/32_events", endpointTypeResponses, buildResponsesStreamEvents(32)},
 		{"responses/256_events", endpointTypeResponses, buildResponsesStreamEvents(256)},
 		{"responses/1024_events", endpointTypeResponses, buildResponsesStreamEvents(1024)},
+		{"chat/32_events", endpointTypeChatCompletions, buildChatCompletionsStreamEvents(32)},
+		{"chat/256_events", endpointTypeChatCompletions, buildChatCompletionsStreamEvents(256)},
+		{"chat/1024_events", endpointTypeChatCompletions, buildChatCompletionsStreamEvents(1024)},
 	} {
 		var total int
 		for _, e := range bc.events {

--- a/lib/srv/app/llm/openai/types.go
+++ b/lib/srv/app/llm/openai/types.go
@@ -32,7 +32,8 @@ import (
 type endpointType string
 
 const (
-	endpointTypeResponses endpointType = "responses"
+	endpointTypeResponses       endpointType = "responses"
+	endpointTypeChatCompletions endpointType = "chat_completions"
 )
 
 // RequestInfo contains the request information.
@@ -54,6 +55,7 @@ type apiRequest interface {
 	SetModel(string)
 	GetStream() bool
 	EnableReportUsage()
+	DisableDataRetention()
 	Validate() error
 }
 
@@ -68,6 +70,11 @@ type responsesAPIRequest struct {
 	Store      bool   `json:"store"`
 
 	raw map[string]json.RawMessage `json:"-"`
+}
+
+func (r *responsesAPIRequest) DisableDataRetention() {
+	r.Store = false
+	r.Background = false
 }
 
 // Nothing to do, usage is always reported on responses API.
@@ -86,6 +93,11 @@ func (r *responsesAPIRequest) Validate() error {
 	return nil
 }
 
+var (
+	_ (apiRequest) = (*responsesAPIRequest)(nil)
+	_ (apiRequest) = (*chatCompletionsAPIRequest)(nil)
+)
+
 func (r *responsesAPIRequest) UnmarshalJSON(data []byte) error {
 	type Alias responsesAPIRequest
 	aux := &struct{ *Alias }{Alias: (*Alias)(r)}
@@ -100,7 +112,7 @@ func (r *responsesAPIRequest) UnmarshalJSON(data []byte) error {
 
 	for key := range raw {
 		switch strings.ToLower(key) {
-		case "model", "stream", "background":
+		case "model", "stream", "store", "background":
 			delete(raw, key)
 		default:
 		}
@@ -121,8 +133,100 @@ func (r responsesAPIRequest) MarshalJSON() ([]byte, error) {
 			return nil, trace.Wrap(err)
 		}
 	}
-	// [Background] and [Store] are expected to always be set `false`, so no
-	// need to marshal it.
+	if err := marshalField(final, "background", r.Background); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := marshalField(final, "store", r.Store); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	res, err := utils.FastMarshal(final)
+	return res, trace.Wrap(err)
+}
+
+// chatCompletionsAPIRequestStreamOptions contains `stream_options` fields from
+// chat completions API.
+type chatCompletionsAPIRequestStreamOptions struct {
+	// `include_obfuscation` defaults to `true` when not set in OpenAI spec,
+	// meaning that we must avoid emitting the value when it is not set to
+	// comply with the default behavior.
+	IncludeObfuscation *bool `json:"include_obfuscation,omitempty"`
+	IncludeUsage       bool  `json:"include_usage"`
+}
+
+// chatCompletionsAPIRequest contains part of the fields from chat completions
+// API request body.
+//
+// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
+type chatCompletionsAPIRequest struct {
+	Model         string                                 `json:"model"`
+	Stream        bool                                   `json:"stream"`
+	StreamOptions chatCompletionsAPIRequestStreamOptions `json:"stream_options"`
+	Store         bool                                   `json:"store"`
+
+	raw map[string]json.RawMessage `json:"-"`
+}
+
+func (r *chatCompletionsAPIRequest) DisableDataRetention() {
+	r.Store = false
+}
+
+func (r *chatCompletionsAPIRequest) EnableReportUsage() {
+	r.StreamOptions.IncludeUsage = true
+}
+func (r *chatCompletionsAPIRequest) GetModel() string      { return r.Model }
+func (r *chatCompletionsAPIRequest) GetStream() bool       { return r.Stream }
+func (r *chatCompletionsAPIRequest) SetModel(model string) { r.Model = model }
+func (r *chatCompletionsAPIRequest) Validate() error {
+	if r.Store {
+		return llmerrors.NewProviderError(llmerrors.ErrUnsupported, "storing chat completions not supported")
+	}
+
+	return nil
+}
+
+func (r *chatCompletionsAPIRequest) UnmarshalJSON(data []byte) error {
+	type Alias chatCompletionsAPIRequest
+	aux := &struct{ *Alias }{Alias: (*Alias)(r)}
+	if err := caseSensitiveJSONConfig.Unmarshal(data, aux); err != nil {
+		return trace.Wrap(err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := utils.FastUnmarshal(data, &raw); err != nil {
+		return trace.Wrap(err)
+	}
+
+	for key := range raw {
+		switch strings.ToLower(key) {
+		case "model", "stream", "stream_options", "store":
+			delete(raw, key)
+		default:
+		}
+	}
+
+	r.raw = raw
+	return nil
+}
+
+func (r chatCompletionsAPIRequest) MarshalJSON() ([]byte, error) {
+	final := make(map[string]json.RawMessage, len(r.raw)+4) // Current len + taken fields.
+	maps.Copy(final, r.raw)
+	if err := marshalField(final, "model", r.Model); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := marshalField(final, "stream", r.Stream); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := marshalField(final, "store", r.Store); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// We must include `stream_options` only for streaming requests, as some
+	// providers might reject it as bad request.
+	if r.Stream {
+		if err := marshalField(final, "stream_options", r.StreamOptions); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
 	res, err := utils.FastMarshal(final)
 	return res, trace.Wrap(err)
 }
@@ -171,6 +275,18 @@ type responsesErrorSSEEvent struct {
 	Type           string `json:"type"`
 	Message        string `json:"message"`
 	SequenceNumber int    `json:"sequence_number"`
+}
+
+// chatCompletionsResponse contains part of the fields from chat completions API
+// response body.
+//
+// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create#(resource)%20chat.completions%20%3E%20(model)%20chat_completion%20%3E%20(schema)
+type chatCompletionsResponse struct {
+	Usage *struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+	} `json:"usage"`
+	Error *errorMessage `json:"error"`
 }
 
 // caseSensitiveJSONConfig is used to decode JSON messages. The config is

--- a/lib/srv/app/llm/openai/types_test.go
+++ b/lib/srv/app/llm/openai/types_test.go
@@ -169,7 +169,7 @@ func TestEncodeResponsesRequest(t *testing.T) {
 			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
 				resp, ok := i1.(string)
 				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
-				require.JSONEq(tt, `{"model": "gpt-5", "stream": true, "max_output_tokens": 1024, "input":"Hello"}`, resp)
+				require.JSONEq(tt, `{"model": "gpt-5", "stream": true, "max_output_tokens": 1024, "input":"Hello","store":false,"background":false}`, resp)
 			},
 		},
 		"modified fields": {
@@ -182,7 +182,7 @@ func TestEncodeResponsesRequest(t *testing.T) {
 			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
 				resp, ok := i1.(string)
 				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
-				require.JSONEq(tt, `{"model": "gpt-5-mini", "max_output_tokens": 1024, "input":"Hello"}`, resp)
+				require.JSONEq(tt, `{"model": "gpt-5-mini", "max_output_tokens": 1024, "input":"Hello","store":false,"background":false}`, resp)
 			},
 		},
 		"set model via SetModel": {
@@ -194,7 +194,7 @@ func TestEncodeResponsesRequest(t *testing.T) {
 			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
 				resp, ok := i1.(string)
 				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
-				require.JSONEq(tt, `{"model": "gpt-4o", "stream": true, "max_output_tokens": 1024, "input":"Hello"}`, resp)
+				require.JSONEq(tt, `{"model": "gpt-4o", "stream": true, "max_output_tokens": 1024, "input":"Hello","store":false,"background":false}`, resp)
 			},
 		},
 		"duplicate fields": {
@@ -204,7 +204,7 @@ func TestEncodeResponsesRequest(t *testing.T) {
 			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
 				resp, ok := i1.(string)
 				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
-				require.JSONEq(tt, `{"model": "gpt-5-mini", "max_output_tokens": 5555, "input":"Hello"}`, resp)
+				require.JSONEq(tt, `{"model": "gpt-5-mini", "max_output_tokens": 5555, "input":"Hello","store":false,"background":false}`, resp)
 			},
 		},
 		"duplicate fields different casing": {
@@ -215,7 +215,7 @@ func TestEncodeResponsesRequest(t *testing.T) {
 				resp, ok := i1.(string)
 				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
 				// Expect values from lowercase keys.
-				require.JSONEq(tt, `{"model": "gpt-5", "stream": true, "input":"Hello"}`, resp)
+				require.JSONEq(tt, `{"model": "gpt-5", "stream": true, "input":"Hello","store":false,"background":false}`, resp)
 			},
 		},
 		"full uppercase keys": {
@@ -225,7 +225,7 @@ func TestEncodeResponsesRequest(t *testing.T) {
 			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
 				resp, ok := i1.(string)
 				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
-				require.JSONEq(tt, `{"model": "", "input":"Hello"}`, resp)
+				require.JSONEq(tt, `{"model": "", "input":"Hello","store":false,"background":false}`, resp)
 			},
 		},
 		"valid json missing fields": {
@@ -235,12 +235,254 @@ func TestEncodeResponsesRequest(t *testing.T) {
 			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
 				resp, ok := i1.(string)
 				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
-				require.JSONEq(tt, `{"model": "", "input":"Hello"}`, resp)
+				require.JSONEq(tt, `{"model": "", "input":"Hello","store":false,"background":false}`, resp)
 			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			var r responsesAPIRequest
+			require.NoError(t, utils.FastUnmarshal([]byte(tc.input), &r))
+			tc.modifyRequest(&r)
+
+			res, err := utils.FastMarshal(r)
+			tc.expectError(t, err)
+			tc.expectValue(t, string(res))
+		})
+	}
+}
+
+func TestParseChatCompletionsRequest(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input       string
+		expectError require.ErrorAssertionFunc
+		expectValue require.ValueAssertionFunc
+	}{
+		"valid json with fields": {
+			input:       `{"model": "gpt-5", "stream": true, "max_completion_tokens": 1024, "stream_options": {"include_usage": true}, "messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(chatCompletionsAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Equal(tt, "gpt-5", req.Model, i2...)
+				require.True(tt, req.Stream, i2...)
+				require.True(tt, req.StreamOptions.IncludeUsage, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"valid json missing fields": {
+			input:       `{"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(chatCompletionsAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Empty(tt, req.Model, i2...)
+				require.False(tt, req.Stream, i2...)
+				require.False(tt, req.StreamOptions.IncludeUsage, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"model duplicates": {
+			input:       `{"model":"gpt-5","model":"gpt-5-mini","MODEL":"gpt-4o","max_completion_tokens":1024,"stream":true,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(chatCompletionsAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Equal(tt, "gpt-5-mini", req.Model, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"model duplicates different casing": {
+			input:       `{"model":"gpt-5","MODEL":"gpt-4o","max_completion_tokens":1024,"stream":true,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(chatCompletionsAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Equal(tt, "gpt-5", req.Model, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"stream duplicates": {
+			input:       `{"model":"gpt-5","stream":true,"stream":false,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(chatCompletionsAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.False(tt, req.Stream, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"stream duplicates different casing": {
+			input:       `{"model":"gpt-5","stream":true,"STREAM":false,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(chatCompletionsAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.True(tt, req.Stream, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"max completion tokens duplicates": {
+			input:       `{"model":"gpt-5","max_completion_tokens":1024,"max_completion_tokens":5555,"stream":true,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(chatCompletionsAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"max completion tokens duplicates different casing": {
+			input:       `{"model":"gpt-5","max_completion_tokens":1024,"MAX_COMPLETION_TOKENS":9999,"stream":true,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(chatCompletionsAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"fields in uppercase": {
+			input:       `{"MODEL":"gpt-5","MAX_COMPLETION_TOKENS":1024,"STREAM":true,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(chatCompletionsAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Empty(tt, req.Model, i2...)
+				require.False(tt, req.Stream, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"stream invalid format": {
+			input:       `{"model":"gpt-5","stream":"yes","messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.Error,
+			expectValue: require.NotEmpty,
+		},
+		"duplicated other fields no error": {
+			input:       `{"model": "gpt-5", "stream": true, "max_completion_tokens": 1024, "messages":[{"role":"user","content":"Hello"}], "reasoning_effort": "low", "reasoning_effort": "high"}`,
+			expectError: require.NoError,
+			expectValue: require.NotEmpty,
+		},
+		"invalid json": {
+			input:       `{random}`,
+			expectError: require.Error,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(chatCompletionsAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Empty(tt, req.Model, i2...)
+				require.False(tt, req.Stream, i2...)
+				require.Empty(tt, req.raw, i2...)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var r chatCompletionsAPIRequest
+			tc.expectError(t, utils.FastUnmarshal([]byte(tc.input), &r))
+			tc.expectValue(t, r)
+		})
+	}
+}
+
+func TestEncodeChatCompletionsRequest(t *testing.T) {
+	// For this test we use the value generated from a raw chat completions API
+	// request, so effectively we're also testing the parsing/decoding part as
+	// well.
+
+	for name, tc := range map[string]struct {
+		input         string
+		modifyRequest func(*chatCompletionsAPIRequest)
+		output        string
+		expectError   require.ErrorAssertionFunc
+		expectValue   require.ValueAssertionFunc
+	}{
+		"unmodified fields": {
+			input:         `{"model": "gpt-5", "stream": true, "max_completion_tokens": 1024, "stream_options": {"include_obfuscation": false, "include_usage": false}, "messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *chatCompletionsAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "gpt-5", "stream": true, "max_completion_tokens": 1024, "stream_options": {"include_obfuscation": false, "include_usage": false}, "messages":[{"role":"user","content":"Hello"}],"store":false}`, resp)
+			},
+		},
+		"modified fields": {
+			input: `{"model": "gpt-5", "stream": true, "max_completion_tokens": 1024, "messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *chatCompletionsAPIRequest) {
+				r.Model = "gpt-5-mini"
+				r.Stream = false
+			},
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "gpt-5-mini", "stream": false, "max_completion_tokens": 1024, "messages":[{"role":"user","content":"Hello"}],"store":false}`, resp)
+			},
+		},
+		"enable report usage": {
+			input: `{"model": "gpt-5", "stream": true, "max_completion_tokens": 1024, "messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *chatCompletionsAPIRequest) {
+				r.EnableReportUsage()
+			},
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "gpt-5", "stream": true, "max_completion_tokens": 1024, "stream_options": {"include_usage": true}, "messages":[{"role":"user","content":"Hello"}],"store":false}`, resp)
+			},
+		},
+		"enable report usage with obfuscation": {
+			input: `{"model": "gpt-5", "stream": true, "stream_options": {"include_obfuscation": false}, "max_completion_tokens": 1024, "messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *chatCompletionsAPIRequest) {
+				r.EnableReportUsage()
+			},
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "gpt-5", "stream": true, "max_completion_tokens": 1024, "stream_options": {"include_obfuscation": false, "include_usage": true}, "messages":[{"role":"user","content":"Hello"}],"store":false}`, resp)
+			},
+		},
+		"duplicate fields": {
+			input:         `{"model": "gpt-5", "model": "gpt-5-mini", "stream": true, "stream": false, "max_completion_tokens": 1024, "max_completion_tokens": 5555, "messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *chatCompletionsAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "gpt-5-mini", "stream": false, "max_completion_tokens": 5555, "messages":[{"role":"user","content":"Hello"}],"store":false}`, resp)
+			},
+		},
+		"duplicate fields different casing": {
+			input:         `{"model": "gpt-5", "MODEL": "gpt-5-mini", "stream": true, "STREAM": false, "messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *chatCompletionsAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				// Expect values from lowercase keys.
+				require.JSONEq(tt, `{"model": "gpt-5", "stream": true, "stream_options": {"include_usage": false}, "messages":[{"role":"user","content":"Hello"}],"store":false}`, resp)
+			},
+		},
+		"full uppercase keys": {
+			input:         `{"MODEL": "gpt-5", "STREAM": true, "messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *chatCompletionsAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "", "stream": false, "messages":[{"role":"user","content":"Hello"}],"store":false}`, resp)
+			},
+		},
+		"valid json missing fields": {
+			input:         `{"messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *chatCompletionsAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "", "stream": false, "messages":[{"role":"user","content":"Hello"}],"store":false}`, resp)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var r chatCompletionsAPIRequest
 			require.NoError(t, utils.FastUnmarshal([]byte(tc.input), &r))
 			tc.modifyRequest(&r)
 


### PR DESCRIPTION
Related to [RFD 0038e - LLM Access](https://github.com/gravitational/teleport.e/blob/rfd/0038e-llm-access/rfd/0038e-llm-access.md).

Adds an [OpenAI chat completions](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create) handler, allowing access to OpenAI-powered LLMs.

We are adding this "legacy" format since it is widely supported by different SDKs and applications. In addition, some open-weight models in Bedrock currently only support this format, so this is a way of enabling access to them as well.

> [!NOTE]
> This PR doesn't have the AWS Bedrock provider. It will be done in a follow-up PR that will work for the responses API and chat completions API.

## Manual Test Plan
### Test Environment

Local cluster with dedicated app service instance.

### Test Cases
- [x] Access using `curl`
  - [x] Mapped model.
  - [x] Streaming requests.
  - [x] Fallback model.
  - [x] Invalid messages/errors returned are from Teleport.
  - [x] Audit events are included in the app session recording. `tsh play -f json <chunk-id>`
  - [x] Prometheus metrics generated.
- [x] Access using Golang and Python SDKs (`codex` no longer supports chat completions format)
  - [x] Mapped model.
  - [x] Streaming requests.
  - [x] Fallback model.
  - [x] Invalid messages/errors returned are from Teleport.
  - [x] Audit events are included in the app session recording. `tsh play -f json <chunk-id>`
  - [x] Prometheus metrics generated.
- [x] Bedrock provider apps fail 100% of requests (return "provider is not supported" error)