### PR TITLE
Allow tctl CRUD operations for Linux Desktop type

### DIFF
--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -215,6 +215,8 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindWindowsDesktop, nil
 	case types.KindDynamicWindowsDesktop, "dynamic_win_desktop", "dynamic_desktop":
 		return types.KindDynamicWindowsDesktop, nil
+	case types.KindLinuxDesktop, types.KindLinuxDesktop + "s":
+		return types.KindLinuxDesktop, nil
 	case types.KindToken, "tokens":
 		return types.KindToken, nil
 	case types.KindInstaller:

--- a/lib/services/resource_test.go
+++ b/lib/services/resource_test.go
@@ -137,6 +137,13 @@ func TestParseShortcut(t *testing.T) {
 		"windows_desktop": {expectedOutput: types.KindWindowsDesktop},
 		"win_desktop":     {expectedOutput: types.KindWindowsDesktop},
 
+		"dynamic_windows_desktop": {expectedOutput: types.KindDynamicWindowsDesktop},
+		"dynamic_win_desktop":     {expectedOutput: types.KindDynamicWindowsDesktop},
+		"dynamic_desktop":         {expectedOutput: types.KindDynamicWindowsDesktop},
+
+		"linux_desktop":  {expectedOutput: types.KindLinuxDesktop},
+		"linux_desktops": {expectedOutput: types.KindLinuxDesktop},
+
 		"token":  {expectedOutput: types.KindToken},
 		"tokens": {expectedOutput: types.KindToken},
 


### PR DESCRIPTION
This small change allows a user to `tctl (get|edit|rm) linux_desktop(/resource)`.

## Manual Test Plan
### Test Environment
Running commands against a local cluster
### Test Cases
- [x] A user can `tctl get linux_desktop`
- [x] A user can `tctl rm linux_desktop/resource`
- [x] A user can `tctl edit linux_desktop/resource`
