### PR TITLE
[v18] Add Organization support in Terraform AWS Discovery modules

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/organization.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/organization.mdx
@@ -1,0 +1,68 @@
+---
+title: Example for discovering AWS resources in all accounts under an organization
+sidebar_label: organization
+description: Configure Teleport to discover resources in accounts within an AWS organization.
+---
+
+{/*
+    Auto-generated file.
+    Do not edit this directly in the docs/pages tree.
+    Instead, edit teleport/discovery/aws/examples/organization/README.md
+    Then, regenerate the docs with `make -C integrations/terraform-modules docs`.
+*/}
+
+Source Code: [github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws/examples/organization](https://github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws/examples/organization)
+
+## Teleport AWS Organization Discovery Example
+
+Configuration in this directory creates AWS and Teleport resources necessary for Teleport to discover resources in multiple AWS accounts under the same Organization.
+
+Currently, only EC2 discovery is supported when doing organization-wide discovery.
+
+Run Terraform with credentials from the AWS Organization management account or a delegated administrator account. The Discovery Service and Auth Service must use credentials from one of these accounts to call the required AWS Organizations APIs.
+
+After applying, you have to manually create an IAM Role in each target account using the details provided in the `aws_child_account_iam_role_template` output, which you can get by running `terraform output`. When the root or `*` is included, this also includes the management or delegated administrator account.
+
+When not using the AWS OIDC integration, you also have to create two extra IAM Roles in a management or delegated administrator account:
+
+- `teleport_organization_account_enumeration_iam_role_template`: must be accessible from the Discovery Service and is used to enumerate all the accounts under the Organization and to assume the role created in each target account.
+- `teleport_organization_join_validation_iam_role_template`: must be accessible from the Auth Service and is used to accept join attempts from target EC2 instances.
+
+You must also set `aws_organization_discovery_iam_principal_arn` to the ARN of the AWS IAM principal used by the Discovery Service. The child account IAM role template uses this ARN in its trust policy.
+
+You can get the role details by running `terraform output`.
+
+{/* BEGIN_TF_DOCS */}
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| terraform | >= 1.5.7 |
+| aws | >= 5.0 |
+| teleport | >= 18.8.3 |
+| tls | >= 4.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| aws\_discovery | ../.. | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| aws\_discovery | n/a |
+{/* END_TF_DOCS */}

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/organization.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/organization.mdx
@@ -12,7 +12,6 @@ description: Configure Teleport to discover resources in accounts within an AWS 
 */}
 
 Source Code: [github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws/examples/organization](https://github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws/examples/organization)
-
 ## Teleport AWS Organization Discovery Example
 
 Configuration in this directory creates AWS and Teleport resources necessary for Teleport to discover resources in multiple AWS accounts under the same Organization.
@@ -22,6 +21,54 @@ Currently, only EC2 discovery is supported when doing organization-wide discover
 Run Terraform with credentials from the AWS Organization management account or a delegated administrator account. The Discovery Service and Auth Service must use credentials from one of these accounts to call the required AWS Organizations APIs.
 
 After applying, you have to manually create an IAM Role in each target account using the details provided in the `aws_child_account_iam_role_template` output, which you can get by running `terraform output`. When the root or `*` is included, this also includes the management or delegated administrator account.
+
+Use the following template, obtained from `terraform output`, to create the IAM role in each target account.
+```hcl
+{
+  "aws_child_account_iam_role_template" = {
+    "assume_role_policy" = <<-EOT
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "sts:AssumeRole",
+          "Principal": {
+            "AWS": "arn:aws:iam::<aws-root-account-id>:role/teleport-discovery-<timestamp>"
+          },
+          "Condition": {
+            "StringEquals": {
+              "aws:PrincipalOrgID": "<aws-organization-id>"
+            }
+          }
+        }
+      ]
+    }
+    EOT
+    "policy" = <<-EOT
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ssm:SendCommand",
+            "ssm:ListCommandInvocations",
+            "ssm:GetCommandInvocation",
+            "ssm:DescribeInstanceInformation",
+            "ec2:DescribeInstances",
+            "account:ListRegions"
+          ],
+          "Resource": "*"
+        }
+      ]
+    }
+    EOT
+    "role_name" = "teleport-organization-discovery-child-account-role"
+  }
+  # ...
+}
+```
 
 When not using the AWS OIDC integration, you also have to create two extra IAM Roles in a management or delegated administrator account:
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
@@ -94,7 +94,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 | terraform | >= 1.5.7 |
 | aws | >= 5.0 |
 | http | >= 3.0 |
-| teleport | >= 18.8.0 |
+| teleport | >= 18.8.3 |
 | tls | >= 4.0 |
 
 ## Providers
@@ -103,7 +103,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 | ---- | ------- |
 | aws | >= 5.0 |
 | http | >= 3.0 |
-| teleport | >= 18.8.0 |
+| teleport | >= 18.8.3 |
 | tls | >= 4.0 |
 
 ## Modules
@@ -116,14 +116,22 @@ No modules.
 | ---- | ---- |
 | [aws_iam_openid_connect_provider.teleport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
 | [aws_iam_policy.teleport_discovery_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.teleport_organization_account_enumeration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.teleport_organization_join_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.teleport_discovery_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.teleport_discovery_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.teleport_organization_account_enumeration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.teleport_organization_join_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | teleport_discovery_config.aws | resource |
 | teleport_integration.aws_oidc | resource |
 | teleport_provision_token.aws_iam | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.allow_assume_role_for_child_accounts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.teleport_discovery_service_iam_role_trust](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.teleport_discovery_service_single_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.teleport_organization_account_enumeration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.teleport_organization_join_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_organizations_organization.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 | [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [http_http.teleport_ping](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 | [tls_certificate.teleport_proxy](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
@@ -134,12 +142,16 @@ No modules.
 | ---- | ----------- | ---- | ------- | :------: |
 | apply\_aws\_tags | Additional AWS tags to apply to all created AWS resources. | `map(string)` | `{}` | no |
 | apply\_teleport\_resource\_labels | Additional Teleport resource labels to apply to all created Teleport resources. | `map(string)` | `{}` | no |
+| aws\_child\_account\_iam\_role\_name | Name for the AWS IAM role to assume in child accounts. This role must be created manually in each account. Check the module outputs `aws_child_account_iam_role_template` for the trust relationship and permissions required. | `string` | `"teleport-organization-discovery-child-account-role"` | no |
 | aws\_iam\_policy\_document | Override the AWS IAM policy document attached to the AWS IAM role for resource discovery. | `string` | `""` | no |
 | aws\_iam\_policy\_name | Name for the AWS IAM policy for discovery. | `string` | `"teleport-discovery"` | no |
 | aws\_iam\_policy\_use\_name\_prefix | Determines whether the name of the AWS IAM policy (`aws_iam_policy_name`) is used as a prefix. | `bool` | `true` | no |
 | aws\_iam\_role\_name | Name for the AWS IAM role for discovery. | `string` | `"teleport-discovery"` | no |
 | aws\_iam\_role\_use\_name\_prefix | Determines whether the name of the AWS IAM role (`aws_iam_role_name`) is used as a prefix. | `bool` | `true` | no |
 | aws\_matchers | AWS resource discovery matchers. Valid values for aws\_matchers.types are: ec2, eks, rds. | ```list(object({ types = list(string) regions = optional(list(string), ["*"]) tags = optional(map(list(string)), { "*" : ["*"] }) setup_access_for_arn = optional(string, "") kube_app_discovery = optional(bool) }))``` | `[]` | no |
+| aws\_organization\_discovery | Discover resources in accounts under the organization, filtered by Organizational Units (the Organization's Root ID or `*` can be used to include the entire organization). A specific IAM role must be created in each account, to be assumed by the Discovery Service. Check the module outputs for the trust relationship and permissions required for the role. Limitations: only EC2 is supported. | ```object({ organizational_units = object({ include = list(string) exclude = optional(list(string), null) }) })``` | `null` | no |
+| aws\_organization\_discovery\_iam\_principal\_arn | ARN of the AWS IAM principal used by the Discovery Service when AWS Organization discovery is configured without an OIDC integration. Required only when aws\_organization\_discovery is set and discovery\_service\_iam\_credential\_source.use\_oidc\_integration is false; this ARN is used in the child-account IAM role trust policy template. | `string` | `""` | no |
+| aws\_organization\_iam\_policies | AWS IAM policy customizations for organization-wide discovery to be created in AWS management account. | ```object({ account_enumeration = optional(object({ name = optional(string, "teleport-organization-account-enumeration") use_name_prefix = optional(bool, true) document = optional(string, "") }), {}) join_validation = optional(object({ name = optional(string, "teleport-organization-join-validation") use_name_prefix = optional(bool, true) document = optional(string, "") }), {}) })``` | `{}` | no |
 | create | Toggle creation of all resources. | `bool` | `true` | no |
 | create\_aws\_iam\_openid\_connect\_provider | Toggle AWS IAM OIDC provider creation. If false and using OIDC, then the AWS IAM OIDC provider must already exist. | `bool` | `true` | no |
 | discovery\_service\_iam\_credential\_source | Configure the AWS credential source for Teleport Discovery Service instances. The default uses AWS OIDC integration. | ```object({ use_oidc_integration = optional(bool, true) trust_role = optional(object({ role_arn = string external_id = optional(string, "") })) })``` | ```{ "trust_role": null, "use_oidc_integration": true }``` | no |
@@ -159,10 +171,15 @@ No modules.
 
 | Name | Description |
 | ---- | ----------- |
+| aws\_child\_account\_iam\_role\_template | Create this AWS IAM Role in each Organization's account, so that the Discovery Service can assume it to discover resources in those accounts. |
 | aws\_oidc\_provider\_arn | AWS resource name (ARN) of the AWS OpenID Connect (OIDC) provider that allows Teleport Discovery Service to assume an AWS IAM role using OIDC. |
 | teleport\_discovery\_config\_name | Name of the Teleport dynamic `discovery_config`. Configuration details can be viewed with `tctl get discovery_config/<name>`. Teleport Discovery Service instances will use this `discovery_config` if they are in the same discovery group as the `discovery_config`. |
 | teleport\_discovery\_service\_iam\_policy\_arn | AWS resource name (ARN) of the AWS IAM policy that grants the permissions needed for Teleport to discover resources in AWS. |
 | teleport\_discovery\_service\_iam\_role\_arn | AWS resource name (ARN) of the AWS IAM role that Teleport Discovery Service will assume. |
 | teleport\_integration\_name | Name of the Teleport `integration` resource. The integration resource configures Teleport Discovery Service instances to assume an AWS IAM role for discovery using AWS OIDC federation. Integration details can be viewed with `tctl get integrations/<name>` or by visiting the Teleport web UI under 'Zero Trust Access' > 'Integrations'. |
+| teleport\_organization\_account\_enumeration\_iam\_policy\_arn | AWS resource name (ARN) of the AWS IAM policy that grants the permissions needed for Teleport to enumerate accounts in the AWS organization. Only set when aws\_organization\_discovery is configured with the OIDC integration. |
+| teleport\_organization\_account\_enumeration\_iam\_role\_template | When not using OIDC, attach this policy to the AWS principal used by the Discovery Service. |
+| teleport\_organization\_join\_validation\_iam\_policy\_arn | AWS resource name (ARN) of the AWS IAM policy that grants the permissions needed for the Teleport Auth Service to validate IAM-method join attempts against the organization. Only set when aws\_organization\_discovery is configured with the OIDC integration. |
+| teleport\_organization\_join\_validation\_iam\_role\_template | When not using OIDC, attach this policy to the AWS principal used by the Auth Service. |
 | teleport\_provision\_token\_name | Name of the Teleport provision `token` that allows Teleport nodes to join the Teleport cluster using AWS IAM credentials. Token details can be viewed with `tctl get token/<name>`. |
 {/* END_TF_DOCS */}

--- a/integrations/terraform-modules/gen/docs.sh
+++ b/integrations/terraform-modules/gen/docs.sh
@@ -141,6 +141,10 @@ EOF
             example_title="Example for discovering ${remote_system} resources in a single account"
             example_description="Configure Teleport to discover resources in an ${remote_system} account."
             ;;
+          organization)
+            example_title="Example for discovering ${remote_system} resources in all accounts under an organization"
+            example_description="Configure Teleport to discover resources in accounts within an ${remote_system} organization."
+            ;;
           *)
             example_title="Example for discovering ${remote_system} resources"
             example_description="Configure Teleport to discover resources in ${remote_system}."

--- a/integrations/terraform-modules/teleport/discovery/aws/README.md
+++ b/integrations/terraform-modules/teleport/discovery/aws/README.md
@@ -80,7 +80,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 | terraform | >= 1.5.7 |
 | aws | >= 5.0 |
 | http | >= 3.0 |
-| teleport | >= 18.8.0 |
+| teleport | >= 18.8.3 |
 | tls | >= 4.0 |
 
 ## Providers
@@ -89,7 +89,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 | ---- | ------- |
 | aws | >= 5.0 |
 | http | >= 3.0 |
-| teleport | >= 18.8.0 |
+| teleport | >= 18.8.3 |
 | tls | >= 4.0 |
 
 ## Modules
@@ -102,14 +102,22 @@ No modules.
 | ---- | ---- |
 | [aws_iam_openid_connect_provider.teleport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
 | [aws_iam_policy.teleport_discovery_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.teleport_organization_account_enumeration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.teleport_organization_join_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.teleport_discovery_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.teleport_discovery_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.teleport_organization_account_enumeration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.teleport_organization_join_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | teleport_discovery_config.aws | resource |
 | teleport_integration.aws_oidc | resource |
 | teleport_provision_token.aws_iam | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.allow_assume_role_for_child_accounts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.teleport_discovery_service_iam_role_trust](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.teleport_discovery_service_single_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.teleport_organization_account_enumeration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.teleport_organization_join_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_organizations_organization.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 | [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [http_http.teleport_ping](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 | [tls_certificate.teleport_proxy](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
@@ -120,12 +128,16 @@ No modules.
 | ---- | ----------- | ---- | ------- | :------: |
 | apply\_aws\_tags | Additional AWS tags to apply to all created AWS resources. | `map(string)` | `{}` | no |
 | apply\_teleport\_resource\_labels | Additional Teleport resource labels to apply to all created Teleport resources. | `map(string)` | `{}` | no |
+| aws\_child\_account\_iam\_role\_name | Name for the AWS IAM role to assume in child accounts. This role must be created manually in each account. Check the module outputs `aws_child_account_iam_role_template` for the trust relationship and permissions required. | `string` | `"teleport-organization-discovery-child-account-role"` | no |
 | aws\_iam\_policy\_document | Override the AWS IAM policy document attached to the AWS IAM role for resource discovery. | `string` | `""` | no |
 | aws\_iam\_policy\_name | Name for the AWS IAM policy for discovery. | `string` | `"teleport-discovery"` | no |
 | aws\_iam\_policy\_use\_name\_prefix | Determines whether the name of the AWS IAM policy (`aws_iam_policy_name`) is used as a prefix. | `bool` | `true` | no |
 | aws\_iam\_role\_name | Name for the AWS IAM role for discovery. | `string` | `"teleport-discovery"` | no |
 | aws\_iam\_role\_use\_name\_prefix | Determines whether the name of the AWS IAM role (`aws_iam_role_name`) is used as a prefix. | `bool` | `true` | no |
 | aws\_matchers | AWS resource discovery matchers. Valid values for aws\_matchers.types are: ec2, eks, rds. | ```list(object({ types = list(string) regions = optional(list(string), ["*"]) tags = optional(map(list(string)), { "*" : ["*"] }) setup_access_for_arn = optional(string, "") kube_app_discovery = optional(bool) }))``` | `[]` | no |
+| aws\_organization\_discovery | Discover resources in accounts under the organization, filtered by Organizational Units (the Organization's Root ID or `*` can be used to include the entire organization). A specific IAM role must be created in each account, to be assumed by the Discovery Service. Check the module outputs for the trust relationship and permissions required for the role. Limitations: only EC2 is supported. | ```object({ organizational_units = object({ include = list(string) exclude = optional(list(string), null) }) })``` | `null` | no |
+| aws\_organization\_discovery\_iam\_principal\_arn | ARN of the AWS IAM principal used by the Discovery Service when AWS Organization discovery is configured without an OIDC integration. Required only when aws\_organization\_discovery is set and discovery\_service\_iam\_credential\_source.use\_oidc\_integration is false; this ARN is used in the child-account IAM role trust policy template. | `string` | `""` | no |
+| aws\_organization\_iam\_policies | AWS IAM policy customizations for organization-wide discovery to be created in AWS management account. | ```object({ account_enumeration = optional(object({ name = optional(string, "teleport-organization-account-enumeration") use_name_prefix = optional(bool, true) document = optional(string, "") }), {}) join_validation = optional(object({ name = optional(string, "teleport-organization-join-validation") use_name_prefix = optional(bool, true) document = optional(string, "") }), {}) })``` | `{}` | no |
 | create | Toggle creation of all resources. | `bool` | `true` | no |
 | create\_aws\_iam\_openid\_connect\_provider | Toggle AWS IAM OIDC provider creation. If false and using OIDC, then the AWS IAM OIDC provider must already exist. | `bool` | `true` | no |
 | discovery\_service\_iam\_credential\_source | Configure the AWS credential source for Teleport Discovery Service instances. The default uses AWS OIDC integration. | ```object({ use_oidc_integration = optional(bool, true) trust_role = optional(object({ role_arn = string external_id = optional(string, "") })) })``` | ```{ "trust_role": null, "use_oidc_integration": true }``` | no |
@@ -145,10 +157,15 @@ No modules.
 
 | Name | Description |
 | ---- | ----------- |
+| aws\_child\_account\_iam\_role\_template | Create this AWS IAM Role in each Organization's account, so that the Discovery Service can assume it to discover resources in those accounts. |
 | aws\_oidc\_provider\_arn | AWS resource name (ARN) of the AWS OpenID Connect (OIDC) provider that allows Teleport Discovery Service to assume an AWS IAM role using OIDC. |
 | teleport\_discovery\_config\_name | Name of the Teleport dynamic `discovery_config`. Configuration details can be viewed with `tctl get discovery_config/<name>`. Teleport Discovery Service instances will use this `discovery_config` if they are in the same discovery group as the `discovery_config`. |
 | teleport\_discovery\_service\_iam\_policy\_arn | AWS resource name (ARN) of the AWS IAM policy that grants the permissions needed for Teleport to discover resources in AWS. |
 | teleport\_discovery\_service\_iam\_role\_arn | AWS resource name (ARN) of the AWS IAM role that Teleport Discovery Service will assume. |
 | teleport\_integration\_name | Name of the Teleport `integration` resource. The integration resource configures Teleport Discovery Service instances to assume an AWS IAM role for discovery using AWS OIDC federation. Integration details can be viewed with `tctl get integrations/<name>` or by visiting the Teleport web UI under 'Zero Trust Access' > 'Integrations'. |
+| teleport\_organization\_account\_enumeration\_iam\_policy\_arn | AWS resource name (ARN) of the AWS IAM policy that grants the permissions needed for Teleport to enumerate accounts in the AWS organization. Only set when aws\_organization\_discovery is configured with the OIDC integration. |
+| teleport\_organization\_account\_enumeration\_iam\_role\_template | When not using OIDC, attach this policy to the AWS principal used by the Discovery Service. |
+| teleport\_organization\_join\_validation\_iam\_policy\_arn | AWS resource name (ARN) of the AWS IAM policy that grants the permissions needed for the Teleport Auth Service to validate IAM-method join attempts against the organization. Only set when aws\_organization\_discovery is configured with the OIDC integration. |
+| teleport\_organization\_join\_validation\_iam\_role\_template | When not using OIDC, attach this policy to the AWS principal used by the Auth Service. |
 | teleport\_provision\_token\_name | Name of the Teleport provision `token` that allows Teleport nodes to join the Teleport cluster using AWS IAM credentials. Token details can be viewed with `tctl get token/<name>`. |
 <!-- END_TF_DOCS -->

--- a/integrations/terraform-modules/teleport/discovery/aws/aws_iam_policy.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/aws_iam_policy.tf
@@ -14,6 +14,36 @@ locals {
     : var.aws_iam_policy_name
   )
 
+  aws_iam_policy_organization_account_enumeration_name_prefix = (
+    var.aws_organization_iam_policies.account_enumeration.use_name_prefix
+    ? "${var.aws_organization_iam_policies.account_enumeration.name}-"
+    : null
+  )
+  aws_iam_policy_organization_account_enumeration_name = (
+    var.aws_organization_iam_policies.account_enumeration.use_name_prefix
+    ? null
+    : var.aws_organization_iam_policies.account_enumeration.name
+  )
+  organization_account_enumeration_actions = [
+    "organizations:ListAccountsForParent",
+    "organizations:ListChildren",
+    "organizations:ListRoots",
+  ]
+
+  aws_iam_policy_organization_join_validation_name_prefix = (
+    var.aws_organization_iam_policies.join_validation.use_name_prefix
+    ? "${var.aws_organization_iam_policies.join_validation.name}-"
+    : null
+  )
+  aws_iam_policy_organization_join_validation_name = (
+    var.aws_organization_iam_policies.join_validation.use_name_prefix
+    ? null
+    : var.aws_organization_iam_policies.join_validation.name
+  )
+  organization_join_validation_actions = [
+    "organizations:DescribeAccount",
+  ]
+
   uses_ec2             = contains(local.aws_matcher_types, "ec2")
   uses_eks             = contains(local.aws_matcher_types, "eks")
   uses_rds             = contains(local.aws_matcher_types, "rds")
@@ -44,7 +74,7 @@ locals {
     "rds:DescribeDBInstances",
   ]
 
-  policy_actions = concat(
+  resource_discovery_policy_actions = concat(
     local.uses_wildcard_region ? ["account:ListRegions"] : [],
     local.uses_ec2 ? local.ec2_actions : [],
     local.uses_eks ? local.eks_actions : [],
@@ -57,13 +87,13 @@ data "aws_iam_policy_document" "teleport_discovery_service_single_account" {
 
   statement {
     effect    = "Allow"
-    actions   = local.policy_actions
+    actions   = local.resource_discovery_policy_actions
     resources = ["*"]
   }
 }
 
 resource "aws_iam_policy" "teleport_discovery_service" {
-  count = local.create ? 1 : 0
+  count = local.create && local.single_account_deployment ? 1 : 0
 
   description = "AWS IAM policy that grants the permissions needed for Teleport to discover resources in AWS."
   name        = local.aws_iam_policy_name
@@ -76,14 +106,116 @@ resource "aws_iam_policy" "teleport_discovery_service" {
   )
 }
 
+data "aws_iam_policy_document" "teleport_organization_account_enumeration" {
+  count = local.create && local.organization_deployment ? 1 : 0
+
+  statement {
+    effect    = "Allow"
+    actions   = local.organization_account_enumeration_actions
+    resources = ["*"]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["sts:AssumeRole"]
+    resources = ["arn:${local.aws_partition}:iam::*:role/${var.aws_child_account_iam_role_name}"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceOrgID"
+      values   = [local.aws_organization_id]
+    }
+  }
+}
+
+# Trust policy for the IAM role created in each member account that allows the discovery service in the management account to assume it.
+data "aws_iam_policy_document" "allow_assume_role_for_child_accounts" {
+  count = local.create_child_account_iam_role_template ? 1 : 0
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [local.aws_child_account_trusted_principal_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+      values   = [local.aws_organization_id]
+    }
+  }
+}
+
+resource "aws_iam_policy" "teleport_organization_account_enumeration" {
+  count = local.create && local.organization_discovery_with_integration ? 1 : 0
+
+  description = "AWS IAM policy that grants the permissions needed for Teleport Discovery Service to enumerate accounts in the AWS organization."
+  name        = local.aws_iam_policy_organization_account_enumeration_name
+  name_prefix = local.aws_iam_policy_organization_account_enumeration_name_prefix
+  path        = "/"
+  tags        = local.apply_aws_tags
+  policy = coalesce(
+    var.aws_organization_iam_policies.account_enumeration.document,
+    data.aws_iam_policy_document.teleport_organization_account_enumeration[0].json,
+  )
+}
+
+data "aws_iam_policy_document" "teleport_organization_join_validation" {
+  count = local.create && local.organization_deployment ? 1 : 0
+
+  # Allow describing accounts so the Auth Service can resolve the joining identity's organization and Organizational Units when validating IAM-method join attempts.
+  statement {
+    effect    = "Allow"
+    actions   = local.organization_join_validation_actions
+    resources = ["*"]
+  }
+}
+
+# This policy is only created in organization discovery mode when using the OIDC integration.
+# When discovering an organization without using an OIDC integration, the permissions must be manually added and accessible to the Auth Service as ambient credentials.
+resource "aws_iam_policy" "teleport_organization_join_validation" {
+  count = local.create && local.organization_discovery_with_integration ? 1 : 0
+
+  description = "AWS IAM policy that grants the permissions needed for Teleport Auth Service to accept join attempts based on the identity's organization."
+  name        = local.aws_iam_policy_organization_join_validation_name
+  name_prefix = local.aws_iam_policy_organization_join_validation_name_prefix
+  path        = "/"
+  tags        = local.apply_aws_tags
+  policy = coalesce(
+    var.aws_organization_iam_policies.join_validation.document,
+    data.aws_iam_policy_document.teleport_organization_join_validation[0].json,
+  )
+}
+
 ################################################################################
 # AWS IAM policy attachment for Teleport Discovery Service
 ################################################################################
 
 resource "aws_iam_role_policy_attachment" "teleport_discovery_service" {
-  count = local.create ? 1 : 0
+  count = local.create && local.single_account_deployment ? 1 : 0
 
   policy_arn = one(aws_iam_policy.teleport_discovery_service[*].arn)
+  # we already know the role name, but use expression reference to establish
+  # dependency on the role's existence
+  role = one(aws_iam_role.teleport_discovery_service[*].name)
+}
+
+resource "aws_iam_role_policy_attachment" "teleport_organization_account_enumeration" {
+  count = local.create && local.organization_discovery_with_integration ? 1 : 0
+
+  policy_arn = one(aws_iam_policy.teleport_organization_account_enumeration[*].arn)
+  # we already know the role name, but use expression reference to establish
+  # dependency on the role's existence
+  role = one(aws_iam_role.teleport_discovery_service[*].name)
+}
+
+resource "aws_iam_role_policy_attachment" "teleport_organization_join_validation" {
+  count = local.create && local.organization_discovery_with_integration ? 1 : 0
+
+  policy_arn = one(aws_iam_policy.teleport_organization_join_validation[*].arn)
   # we already know the role name, but use expression reference to establish
   # dependency on the role's existence
   role = one(aws_iam_role.teleport_discovery_service[*].name)

--- a/integrations/terraform-modules/teleport/discovery/aws/aws_iam_role.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/aws_iam_role.tf
@@ -16,7 +16,7 @@ locals {
 }
 
 data "aws_iam_policy_document" "teleport_discovery_service_iam_role_trust" {
-  count = local.create ? 1 : 0
+  count = local.create_discovery_service_iam_role ? 1 : 0
 
   dynamic "statement" {
     for_each = var.discovery_service_iam_credential_source.use_oidc_integration ? [1] : []
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "teleport_discovery_service_iam_role_trust" {
 }
 
 resource "aws_iam_role" "teleport_discovery_service" {
-  count = local.create ? 1 : 0
+  count = local.create_discovery_service_iam_role ? 1 : 0
 
   assume_role_policy   = data.aws_iam_policy_document.teleport_discovery_service_iam_role_trust[0].json
   description          = "AWS IAM role that Teleport Discovery Service will assume."

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/organization/README.md
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/organization/README.md
@@ -1,0 +1,53 @@
+## Teleport AWS Organization Discovery Example
+
+Configuration in this directory creates AWS and Teleport resources necessary for Teleport to discover resources in multiple AWS accounts under the same Organization.
+
+Currently, only EC2 discovery is supported when doing organization-wide discovery.
+
+Run Terraform with credentials from the AWS Organization management account or a delegated administrator account. The Discovery Service and Auth Service must use credentials from one of these accounts to call the required AWS Organizations APIs.
+
+After applying, you have to manually create an IAM Role in each target account using the details provided in the `aws_child_account_iam_role_template` output, which you can get by running `terraform output`. When the root or `*` is included, this also includes the management or delegated administrator account.
+
+When not using the AWS OIDC integration, you also have to create two extra IAM Roles in a management or delegated administrator account:
+
+- `teleport_organization_account_enumeration_iam_role_template`: must be accessible from the Discovery Service and is used to enumerate all the accounts under the Organization and to assume the role created in each target account.
+- `teleport_organization_join_validation_iam_role_template`: must be accessible from the Auth Service and is used to accept join attempts from target EC2 instances.
+
+You must also set `aws_organization_discovery_iam_principal_arn` to the ARN of the AWS IAM principal used by the Discovery Service. The child account IAM role template uses this ARN in its trust policy.
+
+You can get the role details by running `terraform output`.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| terraform | >= 1.5.7 |
+| aws | >= 5.0 |
+| teleport | >= 18.8.3 |
+| tls | >= 4.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| aws\_discovery | ../.. | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| aws\_discovery | n/a |
+<!-- END_TF_DOCS -->

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/organization/README.md
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/organization/README.md
@@ -8,6 +8,54 @@ Run Terraform with credentials from the AWS Organization management account or a
 
 After applying, you have to manually create an IAM Role in each target account using the details provided in the `aws_child_account_iam_role_template` output, which you can get by running `terraform output`. When the root or `*` is included, this also includes the management or delegated administrator account.
 
+Use the following template, obtained from `terraform output`, to create the IAM role in each target account.
+```hcl
+{
+  "aws_child_account_iam_role_template" = {
+    "assume_role_policy" = <<-EOT
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "sts:AssumeRole",
+          "Principal": {
+            "AWS": "arn:aws:iam::<aws-root-account-id>:role/teleport-discovery-<timestamp>"
+          },
+          "Condition": {
+            "StringEquals": {
+              "aws:PrincipalOrgID": "<aws-organization-id>"
+            }
+          }
+        }
+      ]
+    }
+    EOT
+    "policy" = <<-EOT
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ssm:SendCommand",
+            "ssm:ListCommandInvocations",
+            "ssm:GetCommandInvocation",
+            "ssm:DescribeInstanceInformation",
+            "ec2:DescribeInstances",
+            "account:ListRegions"
+          ],
+          "Resource": "*"
+        }
+      ]
+    }
+    EOT
+    "role_name" = "teleport-organization-discovery-child-account-role"
+  }
+  # ...
+}
+```
+
 When not using the AWS OIDC integration, you also have to create two extra IAM Roles in a management or delegated administrator account:
 
 - `teleport_organization_account_enumeration_iam_role_template`: must be accessible from the Discovery Service and is used to enumerate all the accounts under the Organization and to assume the role created in each target account.

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/organization/docs_description
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/organization/docs_description
@@ -1,0 +1,1 @@
+Configure Teleport to discover resources in accounts within an AWS organization.

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/organization/docs_title
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/organization/docs_title
@@ -1,0 +1,1 @@
+Example for discovering AWS resources in all accounts under an organization

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/organization/main.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/organization/main.tf
@@ -1,0 +1,44 @@
+module "aws_discovery" {
+  source = "../.."
+
+  teleport_proxy_public_addr    = "example.teleport.sh:443"
+  teleport_discovery_group_name = "cloud-discovery-group"
+
+  # Enroll resources from all AWS Accounts in the Organization
+  # Only EC2 resource discovery is supported for organization-wide discovery.
+  aws_organization_discovery = {
+    organizational_units = {
+      # Include accounts under any Organizational Unit.
+      # At least one organizational unit must be included. You can use the root ID or the `*` to include the entire organization.
+      include = ["*"]
+      # Exclude the Organizational Unit's accounts and all their descendants.
+      # Takes precedence over the include rule, so accounts under this OU will not be enrolled even if the include rule matches them.
+      # Only exact matches are supported for exclusion, wildcards are not allowed.
+      exclude = ["ou-1234-abcdwxyz"]
+    }
+  }
+
+  # Each child account in the organization must have an IAM role with this name.
+  # This role is assumed by the discovery service to enroll resources from that account.
+  # The required trust relationship and permissions for this role can be found in the module outputs and documentation.
+  aws_child_account_iam_role_name = "teleport-organization-discovery-child-account-role"
+
+  # Discover EC2 instances using matching rules.
+  # Accepts "*" to discover across all enabled regions.
+  # The module adds account:ListRegions to the IAM policy automatically when "*" is used.
+  aws_matchers = [
+    {
+      types = ["ec2"]
+      # EC2 discovery supports a wildcard to find instances in all regions.
+      regions = ["*"]
+      tags = {
+        env = ["prod"]
+      }
+    }
+  ]
+
+  # Apply the additional Teleport label "origin=example" to all Teleport resources created by this module
+  apply_teleport_resource_labels = { origin = "example" }
+  # Apply the additional AWS tag "origin=example" to all AWS resources created by this module
+  apply_aws_tags = { origin = "example" }
+}

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/organization/outputs.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/organization/outputs.tf
@@ -1,0 +1,3 @@
+output "aws_discovery" {
+  value = module.aws_discovery
+}

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/organization/versions.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/organization/versions.tf
@@ -6,17 +6,13 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0"
     }
-    http = {
-      source  = "hashicorp/http"
-      version = ">= 3.0"
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0"
     }
     teleport = {
       source  = "terraform.releases.teleport.dev/gravitational/teleport"
       version = ">= 18.8.3"
-    }
-    tls = {
-      source  = "hashicorp/tls"
-      version = ">= 4.0"
     }
   }
 }

--- a/integrations/terraform-modules/teleport/discovery/aws/main.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/main.tf
@@ -9,13 +9,40 @@ locals {
     "teleport.dev/iac-tool" = "terraform",
   })
 
+  organization_deployment   = var.aws_organization_discovery != null
+  single_account_deployment = !local.organization_deployment
+
+  organization_discovery_with_integration    = local.organization_deployment && var.discovery_service_iam_credential_source.use_oidc_integration
+  organization_discovery_without_integration = local.organization_deployment && !var.discovery_service_iam_credential_source.use_oidc_integration
+  create_discovery_service_iam_role          = local.create && !local.organization_discovery_without_integration
+  create_child_account_iam_role_template = (
+    local.create
+    && local.organization_deployment
+    && (
+      local.organization_discovery_with_integration
+      || var.aws_organization_discovery_iam_principal_arn != ""
+    )
+  )
+
+  aws_organization_id = try(data.aws_organizations_organization.this[0].id, "")
+
+  aws_child_account_trusted_principal_arn = (
+    local.organization_discovery_with_integration
+    ? one(aws_iam_role.teleport_discovery_service[*].arn)
+    : local.organization_discovery_without_integration
+    ? var.aws_organization_discovery_iam_principal_arn
+    : null
+  )
+
+  integration_name = try(teleport_integration.aws_oidc[0].metadata.name, local.teleport_integration_name, "")
+
   aws_account_id = try(data.aws_caller_identity.this[0].account_id, "")
   aws_partition  = try(data.aws_partition.this[0].partition, "")
 
   teleport_cluster_name         = try(local.teleport_ping.cluster_name, "")
   teleport_ping                 = try(jsondecode(data.http.teleport_ping[0].response_body), null)
   teleport_proxy_public_url     = "https://${var.teleport_proxy_public_addr}"
-  teleport_resource_name_suffix = "aws-account-${local.aws_account_id}"
+  teleport_resource_name_suffix = (local.organization_deployment ? "aws-organization-${local.aws_organization_id}" : "aws-account-${local.aws_account_id}")
 }
 
 data "aws_caller_identity" "this" {
@@ -24,6 +51,10 @@ data "aws_caller_identity" "this" {
 
 data "aws_partition" "this" {
   count = local.create ? 1 : 0
+}
+
+data "aws_organizations_organization" "this" {
+  count = local.create && local.organization_deployment ? 1 : 0
 }
 
 data "http" "teleport_ping" {

--- a/integrations/terraform-modules/teleport/discovery/aws/outputs.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/outputs.tf
@@ -27,3 +27,47 @@ output "teleport_provision_token_name" {
   description = "Name of the Teleport provision `token` that allows Teleport nodes to join the Teleport cluster using AWS IAM credentials. Token details can be viewed with `tctl get token/<name>`."
   value       = try(nonsensitive(teleport_provision_token.aws_iam[0].metadata.name), null)
 }
+
+output "teleport_organization_account_enumeration_iam_policy_arn" {
+  description = "AWS resource name (ARN) of the AWS IAM policy that grants the permissions needed for Teleport to enumerate accounts in the AWS organization. Only set when aws_organization_discovery is configured with the OIDC integration."
+  value       = one(aws_iam_policy.teleport_organization_account_enumeration[*].arn)
+}
+
+output "teleport_organization_join_validation_iam_policy_arn" {
+  description = "AWS resource name (ARN) of the AWS IAM policy that grants the permissions needed for the Teleport Auth Service to validate IAM-method join attempts against the organization. Only set when aws_organization_discovery is configured with the OIDC integration."
+  value       = one(aws_iam_policy.teleport_organization_join_validation[*].arn)
+}
+
+output "aws_child_account_iam_role_template" {
+  description = "Create this AWS IAM Role in each Organization's account, so that the Discovery Service can assume it to discover resources in those accounts."
+  value = local.create_child_account_iam_role_template ? {
+    role_name          = var.aws_child_account_iam_role_name,
+    assume_role_policy = data.aws_iam_policy_document.allow_assume_role_for_child_accounts[0].json,
+    policy = coalesce(
+      var.aws_iam_policy_document,
+      data.aws_iam_policy_document.teleport_discovery_service_single_account[0].json,
+    )
+  } : null
+}
+
+output "teleport_organization_account_enumeration_iam_role_template" {
+  description = "When not using OIDC, attach this policy to the AWS principal used by the Discovery Service."
+  value = local.create && local.organization_discovery_without_integration ? {
+    role_name = var.aws_organization_iam_policies.account_enumeration.name,
+    policy = coalesce(
+      var.aws_organization_iam_policies.account_enumeration.document,
+      data.aws_iam_policy_document.teleport_organization_account_enumeration[0].json,
+    )
+  } : null
+}
+
+output "teleport_organization_join_validation_iam_role_template" {
+  description = "When not using OIDC, attach this policy to the AWS principal used by the Auth Service."
+  value = local.create && local.organization_discovery_without_integration ? {
+    role_name = var.aws_organization_iam_policies.join_validation.name,
+    policy = coalesce(
+      var.aws_organization_iam_policies.join_validation.document,
+      data.aws_iam_policy_document.teleport_organization_join_validation[0].json,
+    )
+  } : null
+}

--- a/integrations/terraform-modules/teleport/discovery/aws/teleport_discovery_config.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/teleport_discovery_config.tf
@@ -32,11 +32,14 @@ locals {
   assume_role = (
     local.organization_deployment
     ? {
-      role_name = var.aws_child_account_iam_role_name
+      role_name   = var.aws_child_account_iam_role_name
+      role_arn    = null
+      external_id = null
     }
     : var.discovery_service_iam_credential_source.trust_role != null
     ? {
-      role_arn = one(aws_iam_role.teleport_discovery_service[*].arn)
+      role_name = null
+      role_arn  = one(aws_iam_role.teleport_discovery_service[*].arn)
       external_id = (
         var.discovery_service_iam_credential_source.trust_role.external_id != ""
         ? var.discovery_service_iam_credential_source.trust_role.external_id

--- a/integrations/terraform-modules/teleport/discovery/aws/teleport_discovery_config.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/teleport_discovery_config.tf
@@ -25,29 +25,40 @@ locals {
     : local.legacy_aws_matchers
   )
 
+  organization = local.organization_deployment ? {
+    organization_id      = local.aws_organization_id
+    organizational_units = var.aws_organization_discovery.organizational_units
+  } : null
+  assume_role = (
+    local.organization_deployment
+    ? {
+      role_name = var.aws_child_account_iam_role_name
+    }
+    : var.discovery_service_iam_credential_source.trust_role != null
+    ? {
+      role_arn = one(aws_iam_role.teleport_discovery_service[*].arn)
+      external_id = (
+        var.discovery_service_iam_credential_source.trust_role.external_id != ""
+        ? var.discovery_service_iam_credential_source.trust_role.external_id
+        : null
+      )
+    }
+    : null
+  )
+
   aws_matchers = [
     for matcher in local.effective_aws_matchers : merge(
       {
-        types   = matcher.types
-        regions = matcher.regions
-        tags    = try(matcher.tags, { "*" : ["*"] })
-        assume_role = (
-          var.discovery_service_iam_credential_source.trust_role != null
-          ? {
-            role_arn = one(aws_iam_role.teleport_discovery_service[*].arn)
-            external_id = (
-              var.discovery_service_iam_credential_source.trust_role.external_id != ""
-              ? var.discovery_service_iam_credential_source.trust_role.external_id
-              : null
-            )
-          }
-          : null
-        )
+        types       = matcher.types
+        regions     = matcher.regions
+        tags        = try(matcher.tags, { "*" : ["*"] })
+        assume_role = local.assume_role
         integration = (
           var.discovery_service_iam_credential_source.use_oidc_integration
-          ? try(teleport_integration.aws_oidc[0].metadata.name, local.teleport_integration_name)
+          ? local.integration_name
           : null
         )
+        organization = local.organization
       },
       contains(matcher.types, "ec2") ? {
         install = {
@@ -110,6 +121,30 @@ resource "teleport_discovery_config" "aws" {
         && !var.discovery_service_iam_credential_source.use_oidc_integration
       )
       error_message = "The Discovery Service running in a Teleport Cloud cluster must use OIDC integration credentials. Either set discovery_service_iam_credential_source.use_oidc_integration to true or set teleport_discovery_group_name to a discovery group that is not `cloud-discovery-group`."
+    }
+    precondition {
+      condition = !(
+        !var.discovery_service_iam_credential_source.use_oidc_integration
+        && try(var.discovery_service_iam_credential_source.trust_role.role_arn, "") == ""
+      ) || var.aws_organization_discovery != null
+      error_message = "If the discovery service is to assume the discovery IAM role without OIDC (`use_oidc_integration` is set to false), then `trust_role.role_arn` must be set to a non-empty value."
+    }
+    precondition {
+      condition = local.single_account_deployment || alltrue([
+        for matcher in local.effective_aws_matchers : length(matcher.types) == 1 && matcher.types[0] == "ec2"
+      ])
+      error_message = "AWS Organization discovery is only supported for EC2 resources. Remove any non-EC2 entries from aws_matchers (or the legacy match_aws_resource_types), or disable organization-wide discovery."
+    }
+    precondition {
+      condition     = local.single_account_deployment || var.discovery_service_iam_credential_source.trust_role == null
+      error_message = "AWS Organization discovery does not support assuming another role (`discovery_service_iam_credential_source.trust_role`). Remove trust_role or disable organization-wide discovery."
+    }
+    precondition {
+      condition = (
+        !local.organization_discovery_without_integration
+        || var.aws_organization_discovery_iam_principal_arn != ""
+      )
+      error_message = "AWS Organization discovery without OIDC Integration requires aws_organization_discovery_iam_principal_arn value to be set. Its value must be the ARN of the AWS identity which is used by the Discovery Service."
     }
   }
 

--- a/integrations/terraform-modules/teleport/discovery/aws/teleport_provision_token.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/teleport_provision_token.tf
@@ -22,8 +22,15 @@ resource "teleport_provision_token" "aws_iam" {
     labels      = local.apply_teleport_resource_labels
   }
   spec = {
+    integration = (
+      local.organization_discovery_with_integration ?
+      local.integration_name :
+      null
+    )
     allow = [{
-      aws_account = local.aws_account_id
+      aws_account              = (local.single_account_deployment ? local.aws_account_id : null)
+      aws_organization_id      = (local.organization_deployment ? local.aws_organization_id : null)
+      aws_organizational_units = (local.organization_deployment ? var.aws_organization_discovery.organizational_units : null)
     }]
     join_method = "iam"
     roles       = ["Node"]

--- a/integrations/terraform-modules/teleport/discovery/aws/variables.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/variables.tf
@@ -229,12 +229,119 @@ variable "discovery_service_iam_credential_source" {
     )
     error_message = "The discovery service AWS IAM credential source must be configured to assume the AWS IAM role for discovery either via OIDC integration or by assuming the role with an external ID, but not both."
   }
+}
+
+variable "aws_organization_iam_policies" {
+  description = "AWS IAM policy customizations for organization-wide discovery to be created in AWS management account."
+  type = object({
+    account_enumeration = optional(object({
+      name            = optional(string, "teleport-organization-account-enumeration")
+      use_name_prefix = optional(bool, true)
+      document        = optional(string, "")
+    }), {})
+    join_validation = optional(object({
+      name            = optional(string, "teleport-organization-join-validation")
+      use_name_prefix = optional(bool, true)
+      document        = optional(string, "")
+    }), {})
+  })
+  default  = {}
+  nullable = false
 
   validation {
-    condition = !(
-      !var.discovery_service_iam_credential_source.use_oidc_integration
-      && try(var.discovery_service_iam_credential_source.trust_role.role_arn, "") == ""
+    condition = can(regex("^[\\w+=,.@-]{1,128}$", var.aws_organization_iam_policies.account_enumeration.name))
+    # Regex can be found at:
+    # https://docs.aws.amazon.com/IAM/latest/APIReference/API_Policy.html
+    error_message = "Provide a valid AWS IAM Policy name for account_enumeration."
+  }
+  validation {
+    condition = can(regex("^[\\w+=,.@-]{1,128}$", var.aws_organization_iam_policies.join_validation.name))
+    # Regex can be found at:
+    # https://docs.aws.amazon.com/IAM/latest/APIReference/API_Policy.html
+    error_message = "Provide a valid AWS IAM Policy name for join_validation."
+  }
+}
+
+variable "aws_organization_discovery" {
+  description = <<EOT
+Discover resources in accounts under the organization, filtered by Organizational Units (the Organization's Root ID or `*` can be used to include the entire organization).
+A specific IAM role must be created in each account, to be assumed by the Discovery Service. Check the module outputs for the trust relationship and permissions required for the role.
+Limitations: only EC2 is supported.
+EOT
+
+  type = object({
+    organizational_units = object({
+      include = list(string)
+      exclude = optional(list(string), null)
+    })
+  })
+  default  = null
+  nullable = true
+
+  validation {
+    condition = var.aws_organization_discovery == null ? true : (
+      length(var.aws_organization_discovery.organizational_units.include) > 0
     )
-    error_message = "If the discovery service is to assume the discovery IAM role without OIDC (`use_oidc_integration` is set to false), then `trust_role.role_arn` must be set to a non-empty value."
+    error_message = "When enabling AWS Organization discovery, at least one organizational unit must be included - the root ID or `*` can be used to include the entire organization."
+  }
+
+  validation {
+    condition = var.aws_organization_discovery == null ? true : (
+      !contains(var.aws_organization_discovery.organizational_units.include, "*")
+      || length(var.aws_organization_discovery.organizational_units.include) == 1
+    )
+    error_message = "When using `*` to include all Organizational Units, it must be the only entry in organizational_units.include."
+  }
+
+  validation {
+    condition = var.aws_organization_discovery == null ? true : alltrue([
+      for ou in var.aws_organization_discovery.organizational_units.include :
+      ou == "*" || can(regex("^(r-[a-z0-9]{4,32}|ou-[a-z0-9]{4,32}-[a-z0-9]{8,32})$", ou))
+    ])
+    # Regex can be found at:
+    # https://docs.aws.amazon.com/organizations/latest/APIReference/API_Root.html
+    # https://docs.aws.amazon.com/organizations/latest/APIReference/API_OrganizationalUnit.html
+    error_message = "Included Organizational Units must each be `*`, the Organization Root ID (`r-xy`), or an Organizational Unit ID (`ou-xy-abcdefgh`)."
+  }
+
+  validation {
+    condition = var.aws_organization_discovery == null ? true : (
+      var.aws_organization_discovery.organizational_units.exclude == null ? true : alltrue([
+        for ou in var.aws_organization_discovery.organizational_units.exclude :
+        can(regex("^(r-[a-z0-9]{4,32}|ou-[a-z0-9]{4,32}-[a-z0-9]{8,32})$", ou))
+      ])
+    )
+    # Regex can be found at:
+    # https://docs.aws.amazon.com/organizations/latest/APIReference/API_Root.html
+    # https://docs.aws.amazon.com/organizations/latest/APIReference/API_OrganizationalUnit.html
+    error_message = "Excluded Organizational Units must each be an Organization Root ID (`r-xy`) or an Organizational Unit ID (`ou-xy-abcdefgh`). Wildcards are not allowed in exclude."
+  }
+}
+
+variable "aws_child_account_iam_role_name" {
+  description = "Name for the AWS IAM role to assume in child accounts. This role must be created manually in each account. Check the module outputs `aws_child_account_iam_role_template` for the trust relationship and permissions required."
+  type        = string
+  default     = "teleport-organization-discovery-child-account-role"
+  nullable    = false
+  validation {
+    condition = can(regex("^[\\w+=,.@-]{1,64}$", var.aws_child_account_iam_role_name))
+    # Regex can be found at:
+    # https://docs.aws.amazon.com/IAM/latest/APIReference/API_Role.html
+    error_message = "Provide a valid AWS IAM Role name."
+  }
+}
+
+variable "aws_organization_discovery_iam_principal_arn" {
+  description = "ARN of the AWS IAM principal used by the Discovery Service when AWS Organization discovery is configured without an OIDC integration. Required only when aws_organization_discovery is set and discovery_service_iam_credential_source.use_oidc_integration is false; this ARN is used in the child-account IAM role trust policy template."
+  type        = string
+  default     = ""
+  nullable    = false
+
+  validation {
+    condition = (
+      var.aws_organization_discovery_iam_principal_arn == ""
+      || can(regex("^arn:aws[a-zA-Z-]*:iam::[0-9]{12}:(role|user)/[^*?]+$", var.aws_organization_discovery_iam_principal_arn))
+    )
+    error_message = "Provide a valid AWS IAM role or user ARN for aws_organization_discovery_iam_principal_arn."
   }
 }


### PR DESCRIPTION
Backport #63502 to branch/v18

changelog: Added a Terraform module to configure Teleport and AWS for EC2 discovery in an AWS organization.


## Manual Test Plan
### Test Environment

Test with a local cluster

### Test Cases
- [x] Removing entire module works
- [x] Adding module to Teleport Cluster and AWS Organization creates the expected resources