### PR TITLE
[7] httprecorder: size recorded body chunks below the per-event recording cap

### DIFF
--- a/lib/events/stream_test.go
+++ b/lib/events/stream_test.go
@@ -214,6 +214,68 @@ func TestProtoStreamLargeEvent(t *testing.T) {
 	require.NoError(t, stream.Complete(ctx))
 }
 
+// makeBodyChunkEvent builds an AppSessionHTTPResponseBodyChunk event carrying
+// dataSize bytes of recognizable, non-repeating-block data so that a
+// round-tripped event can be checked for byte-for-byte equality.
+func makeBodyChunkEvent(dataSize int) *apievents.AppSessionHTTPResponseBodyChunk {
+	data := make([]byte, dataSize)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	return &apievents.AppSessionHTTPResponseBodyChunk{
+		Metadata: apievents.Metadata{
+			Type:  events.AppSessionHTTPResponseBodyChunkEvent,
+			Code:  events.AppSessionHTTPResponseBodyChunkCode,
+			Index: 0,
+			Time:  time.Now().UTC(),
+		},
+		SessionMetadata: apievents.SessionMetadata{
+			SessionID: "1",
+		},
+		RequestId:  "req-1",
+		ChunkIndex: 0,
+		IsLast:     true,
+		Data:       data,
+	}
+}
+
+// TestProtoStreamDefaultCapTrimsLargeEvent documents that a streamer trims
+// large events down to the 64KB cap (constants.MaxProtoMessageSizeBytes).
+func TestProtoStreamDefaultCapTrimsLargeEvent(t *testing.T) {
+	ctx := context.Background()
+	uploader := eventstest.NewMemoryUploader()
+
+	streamer, err := events.NewProtoStreamer(events.ProtoStreamerConfig{
+		Uploader: uploader,
+	})
+	require.NoError(t, err)
+
+	sid := session.ID("default-cap-session")
+	stream, err := streamer.CreateAuditStream(ctx, sid)
+	require.NoError(t, err)
+
+	const dataSize = 200 * 1024 // 200KB, > default 64KB cap
+	event := makeBodyChunkEvent(dataSize)
+
+	require.NoError(t, stream.RecordEvent(ctx, eventstest.PrepareEvent(event)))
+	require.NoError(t, stream.Complete(ctx))
+
+	rc, err := uploader.StreamSessionRecording(ctx, sid)
+	require.NoError(t, err)
+	defer rc.Close()
+
+	reader := events.NewProtoReader(rc, nil)
+	defer reader.Close()
+
+	got, err := reader.Read(ctx)
+	require.NoError(t, err)
+
+	chunk, ok := got.(*apievents.AppSessionHTTPResponseBodyChunk)
+	require.True(t, ok, "expected *apievents.AppSessionHTTPResponseBodyChunk, got %T", got)
+	require.Less(t, len(chunk.Data), dataSize, "data should have been trimmed down from the original size")
+	require.LessOrEqual(t, chunk.Size(), constants.MaxProtoMessageSizeBytes, "trimmed event must fit within the default cap")
+}
+
 // TestReadCorruptedRecording tests that the streamer can successfully decode the kind of corrupted
 // recordings that some older bugged versions of teleport might end up producing when under heavy load/throttling.
 func TestReadCorruptedRecording(t *testing.T) {

--- a/lib/httplib/httprecorder/recorder.go
+++ b/lib/httplib/httprecorder/recorder.go
@@ -32,17 +32,27 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/constants"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
 )
 
 const (
 	// maxChunkSize is the largest body payload stored in one chunk event.
-	// These events are never sent to the audit log, so the limit is to allow
-	// consumers to receive the message via streaming without being impacted
-	// by the gRPC message size limit. The default gRPC limit is 4MB, so
-	// 1MB is a safe choice.
-	maxChunkSize = 1024 * 1024 // 1MB
+	//
+	// Body chunk events are part of the session recording, and every streamer
+	// on the path to final storage trims any single event whose serialized
+	// size exceeds constants.MaxProtoMessageSizeBytes (64KiB): the local
+	// async file, the async upload streamer (api/client.auditStreamer, which
+	// re-records each event read back from disk) and the sync SyncStreamer.
+	// A chunk larger than that cap would have its body data silently
+	// truncated before it reaches storage.
+	//
+	// So a chunk must fit within that cap, including the event's own metadata
+	// (type/code/cluster name, session and request IDs, indices). That
+	// metadata is only a few hundred bytes for these events (they carry no
+	// AppMetadata or headers), so 4KiB of headroom is comfortably enough.
+	maxChunkSize = constants.MaxProtoMessageSizeBytes - 4*1024
 )
 
 // Config contains the inputs New needs to record one HTTP exchange.

--- a/lib/httplib/httprecorder/recorder_test.go
+++ b/lib/httplib/httprecorder/recorder_test.go
@@ -32,13 +32,73 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/constants"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 )
+
+// TestBodyChunkEventFitsRecordingCap asserts that a body chunk carrying a
+// full maxChunkSize payload, plus generously oversized event metadata,
+// serializes below the per-event session-recording cap
+// (constants.MaxProtoMessageSizeBytes, 64KiB).
+//
+// Body chunk events are part of the session recording, and every streamer on
+// the way to final storage -- the local file, the async upload streamer
+// (api/client.auditStreamer) and the sync SyncStreamer -- trims any event
+// larger than that cap. If a single chunk doesn't fit, its body data is
+// silently truncated before it's stored. Keeping maxChunkSize under the cap
+// (minus headroom for metadata) is what guarantees chunks survive intact.
+func TestBodyChunkEventFitsRecordingCap(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		event apievents.AuditEvent
+	}{
+		{
+			name: "response",
+			event: &apievents.AppSessionHTTPResponseBodyChunk{
+				Metadata: apievents.Metadata{
+					Type:        events.AppSessionHTTPResponseBodyChunkEvent,
+					Code:        events.AppSessionHTTPResponseBodyChunkCode,
+					ID:          uuid.NewString(),
+					ClusterName: strings.Repeat("c", 255), // pathologically long
+					Index:       1 << 40,
+				},
+				SessionMetadata: apievents.SessionMetadata{SessionID: uuid.NewString()},
+				RequestId:       uuid.NewString(),
+				ChunkIndex:      1 << 40,
+				IsLast:          true,
+				Data:            bytes.Repeat([]byte("x"), maxChunkSize),
+			},
+		},
+		{
+			name: "request",
+			event: &apievents.AppSessionHTTPRequestBodyChunk{
+				Metadata: apievents.Metadata{
+					Type:        events.AppSessionHTTPRequestBodyChunkEvent,
+					Code:        events.AppSessionHTTPRequestBodyChunkCode,
+					ID:          uuid.NewString(),
+					ClusterName: strings.Repeat("c", 255),
+					Index:       1 << 40,
+				},
+				SessionMetadata: apievents.SessionMetadata{SessionID: uuid.NewString()},
+				RequestId:       uuid.NewString(),
+				ChunkIndex:      1 << 40,
+				IsLast:          true,
+				Data:            bytes.Repeat([]byte("x"), maxChunkSize),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.LessOrEqual(t, tc.event.Size(), constants.MaxProtoMessageSizeBytes,
+				"a full-size body chunk must fit the per-event recording cap so it survives the audit stream without being trimmed")
+		})
+	}
+}
 
 // newCaptureRecorder returns a capturing recorder with a no-op event preparer.
 func newCaptureRecorder() (*eventstest.MockRecorderEmitter, events.SessionPreparerRecorder) {


### PR DESCRIPTION
Session recordings trim any event whose serialized size exceeds the 64KiB
MaxProtoMessageSizeBytes cap. httprecorder split HTTP body-chunk events at 1MB,
on the assumption that the recording layer could be configured to accept them.
