### PR TITLE
Add `--force` flag to `tsh login` for re-authentication

### DIFF
--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -1072,6 +1072,7 @@ Flags:
 |`--browser`|*no default*|Set to 'none' to suppress browser opening on login.|
 |`-f`, `--format`|`file`|Identity format: file, openssh (for OpenSSH compatibility) or kubernetes (for kubeconfig).|
 |`--kube-cluster`|*no default*|Name of the Kubernetes cluster to login to.|
+|`--[no-]force`|`false`|Force re-authentication even if the current session is still valid.|
 |`--[no-]overwrite`|`false`|Whether to overwrite the existing identity file.|
 |`--[no-]request-nowait`|`false`|Finish without waiting for request resolution.|
 |`-o`, `--out`|*no default*|Identity output.|

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -337,6 +337,10 @@ type CLIConf struct {
 	// any files.
 	IdentityOverwrite bool
 
+	// ForceReauth when true makes `tsh login` re-authenticate even if the active
+	// profile is still valid.
+	ForceReauth bool
+
 	// BindAddr is an address in the form of host:port to bind to
 	// during `tsh login` command
 	BindAddr string
@@ -1325,6 +1329,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		identityfile.FormatKubernetes,
 	)).Default(string(identityfile.DefaultFormat)).Short('f').StringVar((*string)(&cf.IdentityFormat))
 	login.Flag("overwrite", "Whether to overwrite the existing identity file.").BoolVar(&cf.IdentityOverwrite)
+	login.Flag("force", "Force re-authentication even if the current session is still valid.").BoolVar(&cf.ForceReauth)
 	login.Flag("request-roles", "Request one or more extra roles.").StringVar(&cf.DesiredRoles)
 	login.Flag("request-reason", "Reason for requesting additional roles.").StringVar(&cf.RequestReason)
 	login.Flag("request-reviewers", "Suggested reviewers for role request.").StringVar(&cf.SuggestedReviewers)
@@ -2456,7 +2461,7 @@ func onLogin(cf *CLIConf, reExecArgs ...string) (err error) {
 	}
 
 	// client is already logged in and profile is not expired and scope hasn't changed
-	if profile != nil && !profile.IsExpired(time.Now()) && !scopeChanged {
+	if profile != nil && !profile.IsExpired(time.Now()) && !scopeChanged && !cf.ForceReauth {
 		switch {
 		// in case if nothing is specified, re-fetch kube clusters and print
 		// current status

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -954,6 +954,69 @@ func TestLoginScopeChangeClearsAgentKeys(t *testing.T) {
 	require.NotContains(t, keysAfterMaxRescoped, keysAfterMax)
 }
 
+// TestLoginForceReauth verifies that "tsh login --force" re-authenticates even
+// when the active profile is still valid, so a role granted server-side is
+// picked up without a separate logout. A plain "tsh login" on a valid session
+// short-circuits and keeps the existing certificate, so the new role does not
+// appear until --force is used.
+func TestLoginForceReauth(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	tmpHomePath := t.TempDir()
+
+	// A role alice does not hold at first login.
+	extra, err := types.NewRole("extra", types.RoleSpecV6{})
+	require.NoError(t, err)
+
+	alice, err := types.NewUser("alice@example.com")
+	require.NoError(t, err)
+	alice.SetRoles([]string{"access"})
+
+	connector := mockConnector(t)
+	authProcess, proxyProcess := makeTestServers(t, withBootstrap(connector, extra, alice))
+	authServer := authProcess.GetAuthServer()
+	require.NotNil(t, authServer)
+
+	proxyAddr, err := proxyProcess.ProxyWebAddr()
+	require.NoError(t, err)
+
+	login := func(t *testing.T, extraArgs ...string) string {
+		t.Helper()
+		out := &output{}
+		args := append([]string{
+			"login",
+			"--insecure",
+			"--proxy", proxyAddr.String(),
+			"--user", alice.GetName(),
+		}, extraArgs...)
+		err := Run(ctx, args,
+			setHomePath(tmpHomePath),
+			setMockSSOLogin(authServer, alice, connector.GetName()),
+			func(cf *CLIConf) error {
+				cf.OverrideStdout = out
+				return nil
+			})
+		require.NoError(t, err)
+		return out.String()
+	}
+
+	// Initial login: the certificate carries only "access".
+	require.NotContains(t, login(t), extra.GetName())
+
+	// Grant the extra role server-side.
+	alice.SetRoles([]string{"access", extra.GetName()})
+	_, err = authServer.UpsertUser(ctx, alice)
+	require.NoError(t, err)
+
+	// A plain login on a still-valid session short-circuits: the certificate is
+	// not reissued, so the new role is not reflected.
+	require.NotContains(t, login(t), extra.GetName())
+
+	// --force re-authenticates and reissues the certificate, picking up the new
+	// role without a separate logout.
+	require.Regexp(t, regexp.MustCompile(`Roles:\s.*\bextra\b`), login(t, "--force"))
+}
+
 func TestRelogin(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Add a `--force` flag to `tsh login` that re-authenticates even when the current session is still valid.

Related: https://github.com/gravitational/teleport/issues/28368. 

## Why

When your roles or traits change server-side, they aren't picked up until you re-authenticate: a certificate reissue copies the roles and traits from your existing certificate instead of re-reading them from the backend user. Today that means running `tsh logout` and then `tsh login`. `--force` collapses that into one command by skipping the "already logged in" short-circuit and running the full login ceremony.

I made re-auth opt-in rather than the default so plain `tsh login` stays a no-op on a valid session. Defaulting it would prompt on every invocation, which would break the existing `--cluster` and `--request` reissue fast paths.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Added a `tsh login --force` flag to force re-authentication and pick up server-side role or trait changes without logging out first.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local single-node Teleport cluster, `tsh` built from master.

### Test Cases
- [x] `--force` is listed in `tsh login --help`.
- [x] Plain `tsh login` on a valid session does not prompt and does not pick up a newly granted role.
- [x] `tsh login --force` on a valid session re-prompts for password and OTP, then reissues a certificate with the newly granted role, with no `tsh logout` needed.
