### PR TITLE
docs: fix k8s operator link

### DIFF
--- a/docs/pages/includes/iac-clients.mdx
+++ b/docs/pages/includes/iac-clients.mdx
@@ -2,5 +2,5 @@ One of the following client tools for managing Teleport resources:
 
 - The `tctl` CLI, which you can install along with Teleport on your workstation ([documentation](../installation/single-machine/single-machine.mdx)) on your workstation.
 - [Teleport Terraform provider](../configuration/terraform-provider/terraform-provider.mdx)
-- [Teleport Kubernetes operator](../configuration/terraform-provider/terraform-provider.mdx)
+- [Teleport Kubernetes operator](../configuration/teleport-operator/teleport-operator.mdx)
 


### PR DESCRIPTION
Currently links to the terraform provider not the k8s operator.
