### PR TITLE
ui: include SPIFFE Federation audit event codes to display in audit log

### DIFF
--- a/docs/pages/reference/audit-events.mdx
+++ b/docs/pages/reference/audit-events.mdx
@@ -7608,6 +7608,36 @@ Example:
 }
 ```
 
+## spiffe.federation.create
+
+SPIFFE Federation Created
+
+Example:
+
+```json
+{
+  "code": "TSPIFFE001I",
+  "event": "spiffe.federation.create",
+  "time": "2020-06-05T16:24:05Z",
+  "uid": "68a83a99-73ce-4bd7-bbf7-99103c2ba6a0"
+}
+```
+
+## spiffe.federation.delete
+
+SPIFFE Federation Deleted
+
+Example:
+
+```json
+{
+  "code": "TSPIFFE002I",
+  "event": "spiffe.federation.delete",
+  "time": "2020-06-05T16:24:05Z",
+  "uid": "68a83a99-73ce-4bd7-bbf7-99103c2ba6a0"
+}
+```
+
 ## spiffe.svid.issued
 
 There are multiple events with the `spiffe.svid.issued` type.

--- a/web/packages/teleport/src/Audit/EventList/EventTypeCell.tsx
+++ b/web/packages/teleport/src/Audit/EventList/EventTypeCell.tsx
@@ -289,6 +289,8 @@ export const EventIconMap: Record<EventCode, any> = {
   [eventCodes.EXTERNAL_AUDIT_STORAGE_DISABLE]: Icons.Database,
   [eventCodes.SPIFFE_SVID_ISSUED]: Icons.Keypair,
   [eventCodes.SPIFFE_SVID_ISSUED_FAILURE]: Icons.Warning,
+  [eventCodes.SPIFFE_FEDERATION_CREATE]: Icons.Info,
+  [eventCodes.SPIFFE_FEDERATION_DELETE]: Icons.Info,
   [eventCodes.AUTH_PREFERENCE_UPDATE]: Icons.Info,
   [eventCodes.CLUSTER_NETWORKING_CONFIG_UPDATE]: Icons.Info,
   [eventCodes.SESSION_RECORDING_CONFIG_UPDATE]: Icons.Info,

--- a/web/packages/teleport/src/services/audit/makeEvent.test.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.test.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import makeEvent from './makeEvent';
+import makeEvent, { formatters } from './makeEvent';
 import { eventCodes } from './types';
 
 describe('formatRawEventForUI', () => {
@@ -69,22 +69,26 @@ describe('makeEvent', () => {
   test.each([
     [
       eventCodes.SPIFFE_FEDERATION_CREATE,
-      'spiffe_federation.create',
+      // Must match SPIFFEFederationCreateEvent in lib/events/api.go, since
+      // this is what the backend emits and matches against when filtering
+      // the audit log by event type.
+      'spiffe.federation.create',
       'SPIFFE Federation Created',
       'User [alice] created a SPIFFE federation [example.com]',
     ],
     [
       eventCodes.SPIFFE_FEDERATION_DELETE,
-      'spiffe_federation.delete',
+      // Must match SPIFFEFederationDeleteEvent in lib/events/api.go.
+      'spiffe.federation.delete',
       'SPIFFE Federation Deleted',
       'User [alice] deleted a SPIFFE federation [example.com]',
     ],
   ])(
     'formats %s events instead of falling back to Unknown Event',
-    (code, eventType, expectedDesc, expectedMessage) => {
+    (code, backendEventType, expectedDesc, expectedMessage) => {
       const event = makeEvent({
         code,
-        event: eventType,
+        event: backendEventType,
         user: 'alice',
         time: '2026-01-01T00:00:00.000Z',
         name: 'example.com',
@@ -92,6 +96,10 @@ describe('makeEvent', () => {
 
       expect(event.codeDesc).toBe(expectedDesc);
       expect(event.message).toBe(expectedMessage);
+      // The formatter's `type` is used as the audit log's event-type filter
+      // value, so it must match the backend's emitted event name or the
+      // filter silently returns no results.
+      expect(formatters[code].type).toBe(backendEventType);
     }
   );
 });

--- a/web/packages/teleport/src/services/audit/makeEvent.test.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.test.ts
@@ -64,3 +64,34 @@ describe('formatRawEventForUI', () => {
     expect(event.raw).toBe(input);
   });
 });
+
+describe('makeEvent', () => {
+  test.each([
+    [
+      eventCodes.SPIFFE_FEDERATION_CREATE,
+      'spiffe_federation.create',
+      'SPIFFE Federation Created',
+      'User [alice] created a SPIFFE federation [example.com]',
+    ],
+    [
+      eventCodes.SPIFFE_FEDERATION_DELETE,
+      'spiffe_federation.delete',
+      'SPIFFE Federation Deleted',
+      'User [alice] deleted a SPIFFE federation [example.com]',
+    ],
+  ])(
+    'formats %s events instead of falling back to Unknown Event',
+    (code, eventType, expectedDesc, expectedMessage) => {
+      const event = makeEvent({
+        code,
+        event: eventType,
+        user: 'alice',
+        time: '2026-01-01T00:00:00.000Z',
+        name: 'example.com',
+      });
+
+      expect(event.codeDesc).toBe(expectedDesc);
+      expect(event.message).toBe(expectedMessage);
+    }
+  );
+});

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1976,13 +1976,13 @@ export const formatters: Formatters = {
       `User [${user}] failed to issue SPIFFE SVID [${spiffe_id}]`,
   },
   [eventCodes.SPIFFE_FEDERATION_CREATE]: {
-    type: 'spiffe_federation.create',
+    type: 'spiffe.federation.create',
     desc: 'SPIFFE Federation Created',
     format: ({ user, name }) =>
       `User [${user}] created a SPIFFE federation [${name}]`,
   },
   [eventCodes.SPIFFE_FEDERATION_DELETE]: {
-    type: 'spiffe_federation.delete',
+    type: 'spiffe.federation.delete',
     desc: 'SPIFFE Federation Deleted',
     format: ({ user, name }) =>
       `User [${user}] deleted a SPIFFE federation [${name}]`,

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1975,6 +1975,18 @@ export const formatters: Formatters = {
     format: ({ user, spiffe_id }) =>
       `User [${user}] failed to issue SPIFFE SVID [${spiffe_id}]`,
   },
+  [eventCodes.SPIFFE_FEDERATION_CREATE]: {
+    type: 'spiffe_federation.create',
+    desc: 'SPIFFE Federation Created',
+    format: ({ user, name }) =>
+      `User [${user}] created a SPIFFE federation [${name}]`,
+  },
+  [eventCodes.SPIFFE_FEDERATION_DELETE]: {
+    type: 'spiffe_federation.delete',
+    desc: 'SPIFFE Federation Deleted',
+    format: ({ user, name }) =>
+      `User [${user}] deleted a SPIFFE federation [${name}]`,
+  },
   [eventCodes.AUTH_PREFERENCE_UPDATE]: {
     type: 'auth_preference.update',
     desc: 'Cluster Authentication Preferences Updated',

--- a/web/packages/teleport/src/services/audit/types.ts
+++ b/web/packages/teleport/src/services/audit/types.ts
@@ -306,6 +306,8 @@ export const eventCodes = {
   EXTERNAL_AUDIT_STORAGE_DISABLE: 'TEA002I',
   SPIFFE_SVID_ISSUED: 'TSPIFFE000I',
   SPIFFE_SVID_ISSUED_FAILURE: 'TSPIFFE000E',
+  SPIFFE_FEDERATION_CREATE: 'TSPIFFE001I',
+  SPIFFE_FEDERATION_DELETE: 'TSPIFFE002I',
   AUTH_PREFERENCE_UPDATE: 'TCAUTH001I',
   CLUSTER_NETWORKING_CONFIG_UPDATE: 'TCNET002I',
   SESSION_RECORDING_CONFIG_UPDATE: 'TCREC003I',
@@ -1928,6 +1930,14 @@ export type RawEvents = {
       spiffe_id: string;
       workload_identity_scope?: string;
     }
+  >;
+  [eventCodes.SPIFFE_FEDERATION_CREATE]: RawEvent<
+    typeof eventCodes.SPIFFE_FEDERATION_CREATE,
+    HasName
+  >;
+  [eventCodes.SPIFFE_FEDERATION_DELETE]: RawEvent<
+    typeof eventCodes.SPIFFE_FEDERATION_DELETE,
+    HasName
   >;
   [eventCodes.AUTH_PREFERENCE_UPDATE]: RawEvent<
     typeof eventCodes.AUTH_PREFERENCE_UPDATE,


### PR DESCRIPTION

TSPIFFE001I/TSPIFFE002I (SPIFFEFederationCreate/Delete) were emitted by
the backend but never registered in the audit log's event code map,
so they rendered as "Unknown Event" in the Web UI.




<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
   Dev
### Test Cases
- [x] Create Spiffe federation and confirm audit event lists in the web ui
- [x] Delete Spiffe federation and confirm audit event lists in the web ui
