### PR TITLE
Validate Kind at service level

### DIFF
--- a/lib/services/local/linux_desktop.go
+++ b/lib/services/local/linux_desktop.go
@@ -34,6 +34,13 @@ type LinuxDesktopService struct {
 
 const linuxDesktopKey = "linux_desktop"
 
+func validateLinuxDesktopKind(d *linuxdesktopv1.LinuxDesktop) error {
+	if d.GetKind() != types.KindLinuxDesktop {
+		return trace.CompareFailed("expecting kind %q but got %q", types.KindLinuxDesktop, d.GetKind())
+	}
+	return nil
+}
+
 // NewLinuxDesktopService creates a new LinuxDesktopService.
 func NewLinuxDesktopService(b backend.Backend) (*LinuxDesktopService, error) {
 	service, err := generic.NewServiceWrapper(
@@ -43,6 +50,7 @@ func NewLinuxDesktopService(b backend.Backend) (*LinuxDesktopService, error) {
 			BackendPrefix: backend.NewKey(linuxDesktopKey),
 			MarshalFunc:   services.MarshalLinuxDesktop,
 			UnmarshalFunc: services.UnmarshalLinuxDesktop,
+			ValidateFunc:  validateLinuxDesktopKind,
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/local/linux_desktop_test.go
+++ b/lib/services/local/linux_desktop_test.go
@@ -76,6 +76,11 @@ func TestLinuxDesktopServiceCRUD(t *testing.T) {
 	out, _, err = service.ListLinuxDesktops(ctx, 10, "")
 	require.NoError(t, err)
 	require.Empty(t, out)
+
+	badKindDesktop := newLinuxDesktop("bad-kind")
+	badKindDesktop.SetKind("bad-kind")
+	_, err = service.CreateLinuxDesktop(ctx, badKindDesktop)
+	require.Error(t, err)
 }
 
 func newLinuxDesktop(name string) *linuxdesktopv1.LinuxDesktop {


### PR DESCRIPTION
Added Linux Desktop kind validation at the service level as prompted by [Codex](https://github.com/gravitational/teleport/pull/68674#discussion_r3593456754).

## Manual Test Plan
### Test Environment
Running the cluster locally
### Test Cases
- [x] A linux desktop with a correct kind can still be created
- [x] Tests pass
