### PR TITLE
docs(Discovery): configure Azure Discovery using management groups

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery-management-group.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery-management-group.mdx
@@ -32,6 +32,11 @@ additional subscriptions and management groups added later, using the
 group](https://learn.microsoft.com/en-us/azure/governance/management-groups/overview#root-management-group-for-each-directory).
 The Tenant root management group ID is the same as your Azure tenant ID.
 
+<Admonition type="note">
+Discovery for Azure using management groups is currently only supported for virtual
+machines and virtual machine scale sets.
+</Admonition>
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery-management-group.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery-management-group.mdx
@@ -1,7 +1,7 @@
 ---
-title: Manual Azure VM Auto-Discovery Configuration
-sidebar_label: Manual
-description: How to manually configure Teleport to automatically enroll Azure virtual machines.
+title: Azure VM Auto-Discovery for Management Groups
+sidebar_label: Management Group Discovery
+description: How to configure Teleport Azure VM auto-discovery across subscriptions using management group scope.
 page_type: how-to
 tags:
  - how-to
@@ -10,34 +10,39 @@ tags:
  - azure
 ---
 
-This guide shows you how to set up automatic server discovery for Azure virtual
-machines.
+This guide shows you how to configure Teleport to automatically enroll Azure
+virtual machines across multiple subscriptions using management groups.
+
+If you only want to discover VMs in specific subscriptions, read
+[Manual Azure VM Auto-Discovery](azure-vm-discovery-manual.mdx).
 
 ## How it works
 
-The Teleport Discovery Service can connect to Azure and automatically
-discover and enroll virtual machines matching configured labels. It will then
-execute a script on these discovered instances that will install Teleport,
-start it and join the cluster.
+The Teleport Discovery Service authenticates to Azure as a service principal
+with permissions assigned at the management group scope. This allows it to list
+all subscriptions under that management group and discover virtual machines in
+each one.
 
-To discover VMs across multiple subscriptions in a management group, see
-[Management Group Azure VM Auto-Discovery](azure-vm-discovery-management-group.mdx).
+For each discovered VM, the Discovery Service executes a script using the Azure
+Run Command feature that installs Teleport, starts it and joins the cluster.
 
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-- Azure subscription with virtual machines and permissions to create and attach
-managed identities.
+- Azure management group or tenant containing subscriptions for discovery.
+- Permissions to create managed identities, custom role definitions, and role
+  assignments at the management group scope.
 - Azure virtual machines to join the Teleport cluster, running
-Ubuntu/Debian/RHEL if making use of the default Teleport install script. (For
-other Linux distributions, you can install Teleport manually.)
+  Ubuntu/Debian/RHEL if making use of the default Teleport install script. (For
+  other Linux distributions, you can install Teleport manually.)
 - (!docs/pages/includes/tctl.mdx!)
 
-## Step 1/5. Create an Azure invite token
+## Step 1/6. Create an Azure invite token
 
 When discovering Azure virtual machines, Teleport makes use of Azure invite tokens for
-authenticating joining SSH Service instances.
+authenticating joining SSH Service instances. Using an allow rule scoped to the
+tenant allows VMs from any subscription in the tenant to join the cluster.
 
 Create a file called `token.yaml`:
 
@@ -46,25 +51,20 @@ Create a file called `token.yaml`:
 kind: token
 version: v2
 metadata:
-  # the token name is not a secret because instances must prove that they are
-  # running in your Azure subscription to use this token
   name: azure-discovery-token
-  # set a long expiry time, as the default for tokens is only 30 minutes
   expires: "3000-01-01T00:00:00Z"
 spec:
-  # use the minimal set of roles required
   roles: [Node]
-
-  # set the join method allowed for this token
   join_method: azure
 
   azure:
     allow:
-    # specify the Azure subscription which Nodes may join from
-    - subscription: "00000000-0000-0000-0000-000000000000"
+    # specify the Azure tenant which Nodes may join from.
+    # this allows joining from any subscription in the tenant.
+    - tenant: "<Var name="tenant-id" />"
 ```
 
-Assign the `subscription` field to your Azure subscription ID.
+Assign <Var name="tenant-id" /> to your Azure tenant ID.
 
 Add the token to the Teleport cluster with:
 
@@ -72,9 +72,10 @@ Add the token to the Teleport cluster with:
 $ tctl create -f token.yaml
 ```
 
-## Step 2/5. Configure IAM permissions for Teleport
+## Step 2/6. Configure IAM permissions for Teleport
 
-The Teleport Discovery Service needs Azure IAM permissions to discover and register Azure virtual machines.
+The Teleport Discovery Service needs Azure IAM permissions to discover and
+register Azure virtual machines.
 
 ### Configure an Azure service principal
 
@@ -153,7 +154,8 @@ resources:
 
 ### Create a custom role
 
-Teleport requires the following permissions to discover and enroll Azure VMs:
+Teleport requires the following permissions to discover and enroll Azure VMs
+across a management group:
 
 - `Microsoft.Compute/virtualMachines/read`
 - `Microsoft.Compute/virtualMachines/runCommands/write`
@@ -162,9 +164,14 @@ Teleport requires the following permissions to discover and enroll Azure VMs:
 - `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read`
 - `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommands/read`
 - `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommands/write`
+- `Microsoft.Resources/subscriptions/read`
 
-Here is a sample role definition allowing Teleport to read and run commands on Azure
-virtual machines:
+The `Microsoft.Resources/subscriptions/read` permission is required so the
+Discovery Service can list subscriptions under the management group when using a
+wildcard subscription matcher.
+
+Here is a sample role definition allowing Teleport to read and run commands on
+Azure virtual machines at the management group scope:
 
 ```json
 {
@@ -172,7 +179,7 @@ virtual machines:
         "roleName": "TeleportDiscovery",
         "description": "Allows Teleport to discover Azure virtual machines",
         "assignableScopes": [
-            "/subscriptions/11111111-2222-3333-4444-555555555555"
+            "/providers/Microsoft.Management/managementGroups/<management-group-id>"
         ],
         "permissions": [
             {
@@ -183,7 +190,8 @@ virtual machines:
                     "Microsoft.Compute/virtualMachineScaleSets/read",
                     "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read",
                     "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommands/write",
-                    "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommands/read"
+                    "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommands/read",
+                    "Microsoft.Resources/subscriptions/read"
                 ],
                 "notActions": [],
                 "dataActions": [],
@@ -194,6 +202,38 @@ virtual machines:
 }
 ```
 
+Replace `<management-group-id>` with your management group ID. The
+`assignableScopes` field determines where the role can be assigned — set it to
+the management group that contains the subscriptions you want to discover.
+
+Azure allows [only one management group in
+`assignableScopes`](https://learn.microsoft.com/en-us/azure/role-based-access-control/custom-roles#custom-role-limits). To
+discover VMs across multiple management groups, set `assignableScopes` to a
+management group at the top of your resource hierarchy and create a role
+assignment for each management group you wish to discover.
+
+To discover VMs across all subscriptions in the tenant, use the tenant ID as
+the management group ID, which targets the
+[Tenant root group](https://learn.microsoft.com/en-us/azure/governance/management-groups/overview#root-management-group-for-each-directory).
+
+<Admonition type="warning">
+Using the tenant ID as the management group ID targets the Tenant root group,
+which requires
+[elevated access](https://learn.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin).
+
+If you have recently elevated privileges in the Azure CLI or Azure portal, you
+may need to refresh your Azure CLI credentials before proceeding:
+
+```code
+$ az logout && az login
+```
+
+</Admonition>
+
+Navigate to the [Management Groups](https://portal.azure.com/#view/Microsoft_Azure_ManagementGroups/ManagementGroupBrowseBlade)
+page and select your management group. Click on *Access control (IAM)* and
+select *Add > Add custom role*, then paste the JSON role definition above.
+
 <Admonition type="tip">
 Using the role definition above grants Teleport access to enroll VMs and VMs from Virtual Machine Scale Sets (VMSSs).
 
@@ -203,27 +243,23 @@ If you are not using or don't want to enroll VMSSs with Uniform orchestration mo
 Navigate to the [Azure portal](https://portal.azure.com/#view/Microsoft_Azure_ComputeHub/ComputeHubMenuBlade/~/virtualMachineScaleSetsBrowse) and look for the Orchestration mode column to check the orchestration mode of your VMSSs and make sure to adjust the role permissions accordingly.
 </Admonition>
 
-The `assignableScopes` field above includes a subscription
-`/subscriptions/<subscription>`, allowing the role to be assigned at any
-resource scope within that subscription or the subscription scope itself. If
-you want to further limit the `assignableScopes`, you can use a resource group
-`/subscriptions/<subscription>/resourceGroups/<group>` or a management group
-`/providers/Microsoft.Management/managementGroups/<group>` instead.
-
-Now go to the [Subscriptions](https://portal.azure.com/#view/Microsoft_Azure_Billing/SubscriptionsBlade) page and select a subscription.
-
-Click on *Access control (IAM)* in the subscription and select *Add > Add custom role*:
-![IAM custom role](../../../../../img/azure/add-custom-role@2x.png)
-
-In the custom role creation page, click the *JSON* tab and click *Edit*, then paste the JSON example
-and replace the subscription in `assignableScopes` with your own subscription id:
-![Create JSON role](../../../../../img/server-access/guides/azure/vm-create-role-from-json@2x.png)
-
 ### Create a role assignment for the Teleport Discovery Service principal
 
-(!docs/pages/includes/server-access/azure-assign-service-principal.mdx!)
+To grant Teleport permissions, the custom role you created must be assigned to
+the Teleport service principal at the management group level.
 
-## Step 3/5. Set up an identity for discovered nodes
+Navigate to the
+[Management Groups](https://portal.azure.com/#view/Microsoft_Azure_ManagementGroups/ManagementGroupBrowseBlade)
+page, select your management group, and click *Access control (IAM)*. Select
+*Add > Add role assignment*. Choose the custom role you created as the role and
+the Teleport service principal as a member.
+
+![Assign role](../../../../../img/server-access/guides/azure/create-role-assignment@2x.png)
+
+The Discovery Service will discover VMs in all subscriptions under the assigned
+management group scope.
+
+## Step 3/6. Set up an identity for discovered nodes
 
 Every Azure VM to be discovered must have an identity assigned to it: either system assigned or user assigned managed identity.
 
@@ -232,7 +268,7 @@ Every Azure VM to be discovered must have an identity assigned to it: either sys
 If the VMs to be discovered have no system-managed identity and more than one user-managed identity assigned to them,
 copy the client ID of one of your user-managed identities for Step 5.
 
-## Step 4/5. Install the Teleport Discovery Service
+## Step 4/6. Install the Teleport Discovery Service
 
 <Admonition type="tip">
 
@@ -245,7 +281,7 @@ Install Teleport on the virtual machine that will run the Discovery Service:
 
 (!docs/pages/includes/install-linux.mdx!)
 
-## Step 5/5. Configure Teleport to discover Azure instances
+## Step 5/6. Configure Teleport to discover Azure instances
 
 If you are running the Discovery Service on its own host, the service requires a
 valid invite token to connect to the cluster. Generate one by running the
@@ -305,8 +341,8 @@ Static configuration while simpler at first, has less flexibility because enroll
     discovery_group: <Var name="azure-prod" />
     azure:
       - types: ["vm"]
-        subscriptions: ["<subscription>"]
-        resource_groups: ["<resource-group>"]
+        # Only exact matches or wildcard (*) are supported.
+        subscriptions: ["*"]
         regions: ["<region>"]
         tags:
           "env": "prod" # Match virtual machines where tag:env=prod
@@ -318,7 +354,7 @@ Static configuration while simpler at first, has less flexibility because enroll
             client_id: "<client-id>"
   ```
   Adjust the keys under `spec.azure` to match your Azure environment,
-  specifically the resource groups, regions and tags you want to associate with the Discovery Service.
+  specifically the regions and tags you want to associate with the Discovery Service.
 
   Create the Discovery Config by running the following command:
   ```code
@@ -342,8 +378,8 @@ Static configuration while simpler at first, has less flexibility because enroll
     discovery_group: <Var name="azure-prod" />
     azure:
       - types: ["vm"]
-        subscriptions: ["<subscription>"]
-        resource_groups: ["<resource-group>"]
+        # Only exact matches or wildcard (*) are supported.
+        subscriptions: ["*"]
         regions: ["<region>"]
         tags:
           "env": "prod" # Match virtual machines where tag:env=prod
@@ -354,12 +390,26 @@ Static configuration while simpler at first, has less flexibility because enroll
             # ID of the identity created in step 3.
             client_id: "<client-id>"
   ```
-  
-  Adjust the keys under `discovery_service.azure` to match your Azure environment, 
+
+  Adjust the keys under `discovery_service.azure` to match your Azure environment,
   specifically the regions and tags you want to associate with the Discovery Service.
 </TabItem>
 
 </Tabs>
+
+<Admonition type="tip">
+To configure Terraform for VM discovery across subscriptions in a management group, see
+[Discover VMs in multiple subscriptions using management groups](azure-vm-discovery-terraform.mdx#discover-vms-in-multiple-subscriptions-using-management-groups)
+in the Terraform Azure VM Auto-Discovery guide.
+</Admonition>
+
+## Step 6/6. Start Teleport
+
+(!docs/pages/includes/start-teleport.mdx service="the Discovery Service"!)
+
+Once you have started the Discovery Service, Azure virtual machines matching the
+tags you specified earlier will begin to be added to the Teleport cluster
+automatically across all subscriptions under the management group.
 
 ## Auto-discovery labels
 

--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery-management-group.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery-management-group.mdx
@@ -26,6 +26,12 @@ each one.
 For each discovered VM, the Discovery Service executes a script using the Azure
 Run Command feature that installs Teleport, starts it and joins the cluster.
 
+You can also enroll VMs across your entire Azure environment, including any
+additional subscriptions and management groups added later, using the
+[Tenant root
+group](https://learn.microsoft.com/en-us/azure/governance/management-groups/overview#root-management-group-for-each-directory).
+The Tenant root management group ID is the same as your Azure tenant ID.
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
@@ -38,9 +44,9 @@ Run Command feature that installs Teleport, starts it and joins the cluster.
   other Linux distributions, you can install Teleport manually.)
 - (!docs/pages/includes/tctl.mdx!)
 
-## Step 1/6. Create an Azure invite token
+## Step 1/5. Create an Azure join token
 
-When discovering Azure virtual machines, Teleport makes use of Azure invite tokens for
+When discovering Azure virtual machines, Teleport uses Azure join tokens for
 authenticating joining SSH Service instances. Using an allow rule scoped to the
 tenant allows VMs from any subscription in the tenant to join the cluster.
 
@@ -72,85 +78,12 @@ Add the token to the Teleport cluster with:
 $ tctl create -f token.yaml
 ```
 
-## Step 2/6. Configure IAM permissions for Teleport
+## Step 2/5. Configure IAM permissions for Teleport
 
 The Teleport Discovery Service needs Azure IAM permissions to discover and
 register Azure virtual machines.
 
-### Configure an Azure service principal
-
-There are a couple of ways for the Teleport Discovery Service to access Azure
-resources:
-
-- The Discovery Service can run on an Azure VM with attached managed identity. This
-  is the recommended way of deploying the Discovery Service in production since
-  it eliminates the need to manage Azure credentials.
-- The Discovery Service can be registered as a Microsoft Entra ID application
-  and configured with its credentials. This is only recommended for development
-  and testing purposes since it requires Azure credentials to be present in the
-  Discovery Service's environment.
-
-<Tabs>
-<TabItem label="Using managed identity">
-  Go to the [Managed Identities](https://portal.azure.com/#browse/Microsoft.ManagedIdentity%2FuserAssignedIdentities)
-  page in your Azure portal and click *Create* to create a new user-assigned
-  managed identity:
-
-  ![Managed identities](../../../../../img/azure/managed-identities@2x.png)
-
-  Pick a name and resource group for the new identity and create it:
-
-  ![New identity](../../../../../img/server-access/guides/azure/new-identity@2x.png)
-
-  Take note of the created identity's *Client ID*:
-
-  ![Created identity](../../../../../img/server-access/guides/azure/created-identity@2x.png)
-
-  Next, navigate to the Azure VM that will run your Discovery Service instance and
-  add the identity you've just created to it:
-
-  ![VM identity](../../../../../img/server-access/guides/azure/vm-identity@2x.png)
-
-  Attach this identity to all Azure VMs that will be running the Discovery
-  Service.
-</TabItem>
-<TabItem label="Using app registrations">
-  <Admonition type="note">
-    Registering the Discovery Service as a Microsoft Entra ID application is
-    suitable for test and development scenarios, or if your Discovery Service
-    does not run on an Azure VM. For production scenarios prefer to use the
-    managed identity approach.
-  </Admonition>
-
-  Go to the [App registrations](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps)
-  page in Microsoft Entra ID and click on *New registration*:
-
-  ![App registrations](../../../../../img/azure/app-registrations@2x.png)
-
-  Pick a name (e.g. *DiscoveryService*) and register a new application. Once the
-  app has been created, take note of its *Application (client) ID* and click on
-  *Add a certificate or secret*:
-
-  ![Registered app](../../../../../img/server-access/guides/azure/registered-app@2x.png)
-
-  Create a new client secret that the Discovery Service agent will use to
-  authenticate with the Azure API:
-
-  ![Registered app secrets](../../../../../img/azure/registered-app-secrets@2x.png)
-
-  The Teleport Discovery Service uses Azure SDK's default credential provider chain to
-  look for credentials. Refer to [Azure SDK Authorization](https://docs.microsoft.com/en-us/azure/developer/go/azure-sdk-authorization)
-  to pick a method suitable for your use-case. For example, to use
-  environment-based authentication with a client secret, the Discovery Service should
-  have the following environment variables set:
-
-  ```text
-  export AZURE_TENANT_ID=
-  export AZURE_CLIENT_ID=
-  export AZURE_CLIENT_SECRET=
-  ```
-</TabItem>
-</Tabs>
+(!docs/pages/includes/auto-discovery/azure-vm-configure-service-principal.mdx!)
 
 ### Create a custom role
 
@@ -259,7 +192,7 @@ the Teleport service principal as a member.
 The Discovery Service will discover VMs in all subscriptions under the assigned
 management group scope.
 
-## Step 3/6. Set up an identity for discovered nodes
+## Step 3/5. Set up an identity for discovered nodes
 
 Every Azure VM to be discovered must have an identity assigned to it: either system assigned or user assigned managed identity.
 
@@ -268,7 +201,7 @@ Every Azure VM to be discovered must have an identity assigned to it: either sys
 If the VMs to be discovered have no system-managed identity and more than one user-managed identity assigned to them,
 copy the client ID of one of your user-managed identities for Step 5.
 
-## Step 4/6. Install the Teleport Discovery Service
+## Step 4/5. Install the Teleport Discovery Service
 
 <Admonition type="tip">
 
@@ -281,51 +214,9 @@ Install Teleport on the virtual machine that will run the Discovery Service:
 
 (!docs/pages/includes/install-linux.mdx!)
 
-## Step 5/6. Configure Teleport to discover Azure instances
+## Step 5/5. Configure Teleport to discover Azure instances
 
-If you are running the Discovery Service on its own host, the service requires a
-valid invite token to connect to the cluster. Generate one by running the
-following command against your Teleport Auth Service:
-
-```code
-$ tctl tokens add --type=discovery
-```
-
-Save the generated token in `/tmp/token` on the virtual machine that will run
-the Discovery Service.
-
-(!docs/pages/includes/discovery/discovery-group.mdx!)
-
-Assign <Var name="teleport.example.com:443" /> to the host and port of the Teleport Proxy Service in your cluster,
-and <Var name="azure-prod" /> to a name that identifies a group of resources that you will enroll:
-
-```yaml
-# teleport.yaml
-version: v3
-teleport:
-  join_params:
-    token_name: "/tmp/token"
-    method: token
-  proxy_server: "<Var name="teleport.example.com:443" />"
-auth_service:
-  enabled: false
-proxy_service:
-  enabled: false
-ssh_service:
-  enabled: false
-discovery_service:
-  enabled: true
-  discovery_group: <Var name="azure-prod" />
-```
-
-Create a matcher for the resources you want to enroll.
-
-<Admonition type="tip">
-Dynamic configuration uses Discovery Configs which can be managed using Terraform.
-See the [Terraform `discovery_config` reference](../../../../reference/infrastructure-as-code/terraform-provider/resources/discovery_config.mdx) for more information.
-
-Static configuration while simpler at first, has less flexibility because enrollment changes require edits to `teleport.yaml` and the restart of the Discovery Service.
-</Admonition>
+(!docs/pages/includes/auto-discovery/azure-vm-configure-discovery-service.mdx!)
 
 <Tabs>
 <TabItem label="Dynamic configuration (recommended)">
@@ -402,8 +293,6 @@ To configure Terraform for VM discovery across subscriptions in a management gro
 [Discover VMs in multiple subscriptions using management groups](azure-vm-discovery-terraform.mdx#discover-vms-in-multiple-subscriptions-using-management-groups)
 in the Terraform Azure VM Auto-Discovery guide.
 </Admonition>
-
-## Step 6/6. Start Teleport
 
 (!docs/pages/includes/start-teleport.mdx service="the Discovery Service"!)
 

--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery-manual.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery-manual.mdx
@@ -61,7 +61,7 @@ spec:
   azure:
     allow:
     # specify the Azure subscription which Nodes may join from
-    - subscription: "00000000-0000-0000-0000-000000000000"
+    - subscription: "11111111-1111-1111-1111-111111111111"
 ```
 
 Assign the `subscription` field to your Azure subscription ID.

--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery-manual.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery-manual.mdx
@@ -76,80 +76,7 @@ $ tctl create -f token.yaml
 
 The Teleport Discovery Service needs Azure IAM permissions to discover and register Azure virtual machines.
 
-### Configure an Azure service principal
-
-There are a couple of ways for the Teleport Discovery Service to access Azure
-resources:
-
-- The Discovery Service can run on an Azure VM with attached managed identity. This
-  is the recommended way of deploying the Discovery Service in production since
-  it eliminates the need to manage Azure credentials.
-- The Discovery Service can be registered as a Microsoft Entra ID application
-  and configured with its credentials. This is only recommended for development
-  and testing purposes since it requires Azure credentials to be present in the
-  Discovery Service's environment.
-
-<Tabs>
-<TabItem label="Using managed identity">
-  Go to the [Managed Identities](https://portal.azure.com/#browse/Microsoft.ManagedIdentity%2FuserAssignedIdentities)
-  page in your Azure portal and click *Create* to create a new user-assigned
-  managed identity:
-
-  ![Managed identities](../../../../../img/azure/managed-identities@2x.png)
-
-  Pick a name and resource group for the new identity and create it:
-
-  ![New identity](../../../../../img/server-access/guides/azure/new-identity@2x.png)
-
-  Take note of the created identity's *Client ID*:
-
-  ![Created identity](../../../../../img/server-access/guides/azure/created-identity@2x.png)
-
-  Next, navigate to the Azure VM that will run your Discovery Service instance and
-  add the identity you've just created to it:
-
-  ![VM identity](../../../../../img/server-access/guides/azure/vm-identity@2x.png)
-
-  Attach this identity to all Azure VMs that will be running the Discovery
-  Service.
-</TabItem>
-<TabItem label="Using app registrations">
-  <Admonition type="note">
-    Registering the Discovery Service as a Microsoft Entra ID application is
-    suitable for test and development scenarios, or if your Discovery Service
-    does not run on an Azure VM. For production scenarios prefer to use the
-    managed identity approach.
-  </Admonition>
-
-  Go to the [App registrations](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps)
-  page in Microsoft Entra ID and click on *New registration*:
-
-  ![App registrations](../../../../../img/azure/app-registrations@2x.png)
-
-  Pick a name (e.g. *DiscoveryService*) and register a new application. Once the
-  app has been created, take note of its *Application (client) ID* and click on
-  *Add a certificate or secret*:
-
-  ![Registered app](../../../../../img/server-access/guides/azure/registered-app@2x.png)
-
-  Create a new client secret that the Discovery Service agent will use to
-  authenticate with the Azure API:
-
-  ![Registered app secrets](../../../../../img/azure/registered-app-secrets@2x.png)
-
-  The Teleport Discovery Service uses Azure SDK's default credential provider chain to
-  look for credentials. Refer to [Azure SDK Authorization](https://docs.microsoft.com/en-us/azure/developer/go/azure-sdk-authorization)
-  to pick a method suitable for your use-case. For example, to use
-  environment-based authentication with a client secret, the Discovery Service should
-  have the following environment variables set:
-
-  ```text
-  export AZURE_TENANT_ID=
-  export AZURE_CLIENT_ID=
-  export AZURE_CLIENT_SECRET=
-  ```
-</TabItem>
-</Tabs>
+(!docs/pages/includes/auto-discovery/azure-vm-configure-service-principal.mdx!)
 
 ### Create a custom role
 
@@ -247,49 +174,7 @@ Install Teleport on the virtual machine that will run the Discovery Service:
 
 ## Step 5/5. Configure Teleport to discover Azure instances
 
-If you are running the Discovery Service on its own host, the service requires a
-valid invite token to connect to the cluster. Generate one by running the
-following command against your Teleport Auth Service:
-
-```code
-$ tctl tokens add --type=discovery
-```
-
-Save the generated token in `/tmp/token` on the virtual machine that will run
-the Discovery Service.
-
-(!docs/pages/includes/discovery/discovery-group.mdx!)
-
-Assign <Var name="teleport.example.com:443" /> to the host and port of the Teleport Proxy Service in your cluster,
-and <Var name="azure-prod" /> to a name that identifies a group of resources that you will enroll:
-
-```yaml
-# teleport.yaml
-version: v3
-teleport:
-  join_params:
-    token_name: "/tmp/token"
-    method: token
-  proxy_server: "<Var name="teleport.example.com:443" />"
-auth_service:
-  enabled: false
-proxy_service:
-  enabled: false
-ssh_service:
-  enabled: false
-discovery_service:
-  enabled: true
-  discovery_group: <Var name="azure-prod" />
-```
-
-Create a matcher for the resources you want to enroll.
-
-<Admonition type="tip">
-Dynamic configuration uses Discovery Configs which can be managed using Terraform.
-See the [Terraform `discovery_config` reference](../../../../reference/infrastructure-as-code/terraform-provider/resources/discovery_config.mdx) for more information.
-
-Static configuration while simpler at first, has less flexibility because enrollment changes require edits to `teleport.yaml` and the restart of the Discovery Service.
-</Admonition>
+(!docs/pages/includes/auto-discovery/azure-vm-configure-discovery-service.mdx!)
 
 <Tabs>
 <TabItem label="Dynamic configuration (recommended)">

--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery-terraform.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery-terraform.mdx
@@ -154,6 +154,10 @@ If you are running Terraform in a remote environment, such as a cloud VM, an on-
 
 Add the `teleport-discovery-azure` module to your Terraform configuration.
 
+<Admonition type="tip">
+To discover VMs across subscriptions in a management group, see [Discover VMs in multiple subscriptions using management groups](#discover-vms-in-multiple-subscriptions-using-management-groups).
+</Admonition>
+
 <Tabs>
 
 <TabItem label="Teleport Cloud">
@@ -284,7 +288,7 @@ Terraform should plan to create the following resources:
 - Azure user-assigned managed identity for the Teleport Discovery Service
 - Azure federated identity credential for OIDC workload identity federation
 - Azure custom role definition with the required VM discovery permissions
-- Azure role assignment scoped to the configured subscription(s)
+- Azure role assignment scoped to the configured subscription(s) or management group
 - Teleport `discovery_config` cluster resource that configures Teleport for Azure resource discovery
 - Teleport `integration` cluster resource for Azure OIDC
 - Teleport `token` cluster resource that allows Teleport nodes to join the cluster using Azure credentials
@@ -399,6 +403,106 @@ Review the Terraform plan before confirming the changes.
 After Terraform finishes applying its plan, the Discovery Service will pick up
 the change to the dynamic `discovery_config` and begin to enroll VMs in the
 newly-configured regions.
+
+## Discover VMs in multiple subscriptions using management groups
+
+To discover VMs across all subscriptions in a management group,
+add the `azure_management_group_id` input and use a wildcard (`"*"`)
+subscription matcher. A tenant ID can be provided to target the Tenant root group.
+
+```hcl
+module "azure_discovery" {
+  source  = "terraform.releases.teleport.dev/teleport/discovery/azure"
+  version = "~> (=teleport.major_version=).0"
+
+  teleport_proxy_public_addr    = "<Var name="teleport.example.com:443" />"
+  teleport_discovery_group_name = "<Var name="discovery-group-name" />"
+
+  # Management group ID or tenant ID. Using a tenant ID targets the
+  # Tenant root group, which requires elevated access.
+  azure_management_group_id = "<Var name="management-group-id" />"
+
+  # Name of an existing Azure Resource Group where Azure resources will be created.
+  azure_resource_group_name       = "<Var name="my-resource-group" />"
+  # Azure region where the managed identity used by the Discovery Service will be created.
+  azure_managed_identity_location = "<Var name="eastus" />"
+
+  azure_matchers = [
+    {
+      types = ["vm"]
+      # The wildcard discovers VMs across all subscriptions visible to the
+      # managed identity's role assignment scope.
+      subscriptions = ["*"]
+      # regions filters which Azure regions are scanned. The wildcard matches all regions.
+      regions = ["*"]
+      # tags filter which VMs are enrolled. The wildcard matches all tags.
+      tags = { "*" : ["*"] }
+    }
+  ]
+}
+```
+
+The module will create the role definition and assignment using the provided management
+group scope and generate a provision token allow rule using your tenant ID.
+
+<Admonition type="warning">
+Using the tenant ID as the management group ID targets the
+[Tenant root group](https://learn.microsoft.com/en-us/azure/governance/management-groups/overview#root-management-group-for-each-directory),
+which requires
+[elevated access](https://learn.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin).
+</Admonition>
+
+See the
+[management group example](../../../../reference/infrastructure-as-code/terraform-modules/teleport-discovery-azure/examples/management-group.mdx)
+for a complete example configuration.
+
+### Discover VMs across multiple management groups
+
+To discover VMs across multiple management groups, set `azure_management_group_id`
+to a management group at the top of the hierarchy of the child management groups.
+Use `azure_role_assignment_scopes` input to explicitly set the qualified scopes for the
+managed identity's role assignments.
+
+Using the wildcard subscription matcher (`["*"]`), the Discovery Service will
+discover VMs in subscriptions visible to the role assignments in
+`azure_role_assignment_scopes`.
+
+When `azure_role_assignment_scopes` is provided,
+`teleport_provision_token_allow_rules` must be explicitly set.
+
+```hcl
+module "azure_discovery" {
+  source  = "terraform.releases.teleport.dev/teleport/discovery/azure"
+  version = "~> (=teleport.major_version=).0"
+
+  teleport_proxy_public_addr    = "<Var name="teleport.example.com:443" />"
+  teleport_discovery_group_name = "<Var name="discovery-group-name" />"
+
+  azure_resource_group_name       = "<Var name="my-resource-group" />"
+  azure_managed_identity_location = "<Var name="eastus" />"
+
+  # Common parent management group, used as the role definition's assignable scope.
+  azure_management_group_id = "<Var name="management-group-id" />"
+
+  # Role assignments are created at each scope. The wildcard subscription
+  # matcher will discover subscriptions visible to the assigned scopes.
+  azure_role_assignment_scopes = [
+    "/providers/Microsoft.Management/managementGroups/management-group-1",
+    "/providers/Microsoft.Management/managementGroups/management-group-2",
+  ]
+
+  azure_matchers = [
+    {
+      types         = ["vm"]
+      subscriptions = ["*"]
+    }
+  ]
+
+  teleport_provision_token_allow_rules = [
+    { tenant = "00000000-0000-0000-0000-000000000000" }
+  ]
+}
+```
 
 ## Troubleshooting
 

--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery.mdx
@@ -20,7 +20,15 @@ and enroll virtual machines matching configured labels. It will then execute a
 script on these discovered instances that will install Teleport, start it and
 join the cluster.
 
+## Choosing subscription or management group scope
+
+If you want to discover Azure VMs in specific subscriptions, follow the "Single Subscription" guide below.
+
+If you want to discover Azure VMs across subscriptions in a management group
+or tenant, follow the [Management Group Azure VM Auto-Discovery](azure-vm-discovery-management-group.mdx) guide.
+
 ## Guides
 
-- [Manual Azure VM Auto-Discovery](azure-vm-discovery-manual.mdx)
+- [Single Subscription Manual Azure VM Auto-Discovery](azure-vm-discovery-manual.mdx)
 - [Terraform Azure VM Auto-Discovery Configuration](azure-vm-discovery-terraform.mdx)
+- [Management Group Azure VM Auto-Discovery](azure-vm-discovery-management-group.mdx)

--- a/docs/pages/includes/auto-discovery/azure-vm-configure-discovery-service.mdx
+++ b/docs/pages/includes/auto-discovery/azure-vm-configure-discovery-service.mdx
@@ -1,6 +1,6 @@
 If you are running the Discovery Service on its own host, the service requires a
 valid join token to connect to the cluster. Generate one by running the
-following command against your Teleport Auth Service:
+following command:
 
 ```code
 $ tctl tokens add --type=discovery

--- a/docs/pages/includes/auto-discovery/azure-vm-configure-discovery-service.mdx
+++ b/docs/pages/includes/auto-discovery/azure-vm-configure-discovery-service.mdx
@@ -1,0 +1,43 @@
+If you are running the Discovery Service on its own host, the service requires a
+valid join token to connect to the cluster. Generate one by running the
+following command against your Teleport Auth Service:
+
+```code
+$ tctl tokens add --type=discovery
+```
+
+Save the generated token in `/tmp/token` on the virtual machine that will run
+the Discovery Service.
+
+(!docs/pages/includes/discovery/discovery-group.mdx!)
+
+Assign <Var name="teleport.example.com:443" /> to the host and port of the Teleport Proxy Service in your cluster,
+and <Var name="azure-prod" /> to a name that identifies a group of resources that you will enroll:
+
+```yaml
+# teleport.yaml
+version: v3
+teleport:
+  join_params:
+    token_name: "/tmp/token"
+    method: token
+  proxy_server: "<Var name="teleport.example.com:443" />"
+auth_service:
+  enabled: false
+proxy_service:
+  enabled: false
+ssh_service:
+  enabled: false
+discovery_service:
+  enabled: true
+  discovery_group: <Var name="azure-prod" />
+```
+
+Create a matcher for the resources you want to enroll.
+
+<Admonition type="tip">
+Dynamic configuration uses Discovery Configs which can be managed using Terraform.
+See the [Terraform `discovery_config` reference](../../reference/infrastructure-as-code/terraform-provider/resources/discovery_config.mdx) for more information.
+
+Static configuration while simpler at first, has less flexibility because enrollment changes require edits to `teleport.yaml` and the restart of the Discovery Service.
+</Admonition>

--- a/docs/pages/includes/auto-discovery/azure-vm-configure-service-principal.mdx
+++ b/docs/pages/includes/auto-discovery/azure-vm-configure-service-principal.mdx
@@ -1,0 +1,74 @@
+### Configure an Azure service principal
+
+There are a couple of ways for the Teleport Discovery Service to access Azure
+resources:
+
+- The Discovery Service can run on an Azure VM with attached managed identity. This
+  is the recommended way of deploying the Discovery Service in production since
+  it eliminates the need to manage Azure credentials.
+- The Discovery Service can be registered as a Microsoft Entra ID application
+  and configured with its credentials. This is only recommended for development
+  and testing purposes since it requires Azure credentials to be present in the
+  Discovery Service's environment.
+
+<Tabs>
+<TabItem label="Using managed identity">
+  Go to the [Managed Identities](https://portal.azure.com/#browse/Microsoft.ManagedIdentity%2FuserAssignedIdentities)
+  page in your Azure portal and click *Create* to create a new user-assigned
+  managed identity:
+
+  ![Managed identities](../../../img/azure/managed-identities@2x.png)
+
+  Pick a name and resource group for the new identity and create it:
+
+  ![New identity](../../../img/server-access/guides/azure/new-identity@2x.png)
+
+  Take note of the created identity's *Client ID*:
+
+  ![Created identity](../../../img/server-access/guides/azure/created-identity@2x.png)
+
+  Next, navigate to the Azure VM that will run your Discovery Service instance and
+  add the identity you've just created to it:
+
+  ![VM identity](../../../img/server-access/guides/azure/vm-identity@2x.png)
+
+  Attach this identity to all Azure VMs that will be running the Discovery
+  Service.
+</TabItem>
+<TabItem label="Using app registrations">
+  <Admonition type="note">
+    Registering the Discovery Service as a Microsoft Entra ID application is
+    suitable for test and development scenarios, or if your Discovery Service
+    does not run on an Azure VM. For production scenarios prefer to use the
+    managed identity approach.
+  </Admonition>
+
+  Go to the [App registrations](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps)
+  page in Microsoft Entra ID and click on *New registration*:
+
+  ![App registrations](../../../img/azure/app-registrations@2x.png)
+
+  Pick a name (e.g. *DiscoveryService*) and register a new application. Once the
+  app has been created, take note of its *Application (client) ID* and click on
+  *Add a certificate or secret*:
+
+  ![Registered app](../../../img/server-access/guides/azure/registered-app@2x.png)
+
+  Create a new client secret that the Discovery Service agent will use to
+  authenticate with the Azure API:
+
+  ![Registered app secrets](../../../img/azure/registered-app-secrets@2x.png)
+
+  The Teleport Discovery Service uses Azure SDK's default credential provider chain to
+  look for credentials. Refer to [Azure SDK Authorization](https://docs.microsoft.com/en-us/azure/developer/go/azure-sdk-authorization)
+  to pick a method suitable for your use-case. For example, to use
+  environment-based authentication with a client secret, the Discovery Service should
+  have the following environment variables set:
+
+  ```text
+  export AZURE_TENANT_ID=
+  export AZURE_CLIENT_ID=
+  export AZURE_CLIENT_SECRET=
+  ```
+</TabItem>
+</Tabs>

--- a/docs/pages/includes/provision-token/azure-spec-hcl.mdx
+++ b/docs/pages/includes/provision-token/azure-spec-hcl.mdx
@@ -30,6 +30,10 @@ resource "teleport_provision_token" "azure-token" {
           subscription = "33333333-3333-3333-3333-333333333333"
           resource_groups = ["group1", "group2"]
         },
+        {
+          # tenant can be used to allow joining from any subscription an Azure tenant
+          tenant = "44444444-4444-4444-4444-444444444444"
+        },
       ]
     }
   }

--- a/docs/pages/includes/provision-token/azure-spec-kube.mdx
+++ b/docs/pages/includes/provision-token/azure-spec-kube.mdx
@@ -21,4 +21,6 @@ spec:
       # joining Teleport processes
       - subscription: 33333333-3333-3333-3333-333333333333
         resource_groups: ["group1", "group2"]
+      # tenant can be used to allow joining from any subscription an Azure tenant
+      - tenant: 44444444-4444-4444-4444-444444444444
 ```

--- a/docs/pages/includes/provision-token/azure-spec.mdx
+++ b/docs/pages/includes/provision-token/azure-spec.mdx
@@ -20,4 +20,6 @@ spec:
       # joining Teleport processes
       - subscription: 33333333-3333-3333-3333-333333333333
         resource_groups: ["group1", "group2"]
+      # tenant can be used to allow joining from any subscription an Azure tenant
+      - tenant: 44444444-4444-4444-4444-444444444444
 ```

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-azure/teleport-discovery-azure.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-azure/teleport-discovery-azure.mdx
@@ -34,6 +34,7 @@ This Terraform module creates the Azure and Teleport cluster resources necessary
 ## Examples
 
 - [Discover VMs in a single Azure subscription](./examples/single-subscription.mdx)
+- [Discover VMs in an Azure management group](./examples/management-group.mdx)
 
 ## How to get help
 

--- a/integrations/terraform-modules/teleport/discovery/azure/README.md
+++ b/integrations/terraform-modules/teleport/discovery/azure/README.md
@@ -19,6 +19,7 @@ This Terraform module creates the Azure and Teleport cluster resources necessary
 ## Examples
 
 - [Discover VMs in a single Azure subscription](./examples/single-subscription.mdx)
+- [Discover VMs in an Azure management group](./examples/management-group.mdx)
 
 ## How to get help
 


### PR DESCRIPTION
Issue: https://github.com/gravitational/teleport/issues/60822

Documentation for Azure VM Discovery using managment groups and terraform module changes introduced in https://github.com/gravitational/teleport/pull/67215

## Manual Test Plan
### Test Environment

- local 

### Test Cases
- [x] ensure local docs build
