### PR TITLE
Update references to archived helm-unittest plugin

### DIFF
--- a/BUILD_macos.md
+++ b/BUILD_macos.md
@@ -78,7 +78,16 @@ and updates are welcome!
     ```shell
     brew install helm
 
-    helm plugin install https://github.com/quintush/helm-unittest --version 0.2.11
+    helm plugin install https://github.com/helm-unittest/helm-unittest \
+        --version $(cat build.assets/helm-unittest.version) \
+        --verify=false
+    ```
+
+    If you're running helm v3, the `--verify=false` flag is not supported:
+
+    ```shell
+    helm plugin install https://github.com/helm-unittest/helm-unittest \
+        --version $(cat build.assets/helm-unittest.version)
     ```
 
 1. Install `bats`:

--- a/BUILD_macos.md
+++ b/BUILD_macos.md
@@ -77,17 +77,7 @@ and updates are welcome!
 
     ```shell
     brew install helm
-
-    helm plugin install https://github.com/helm-unittest/helm-unittest \
-        --version $(cat build.assets/helm-unittest.version) \
-        --verify=false
-    ```
-
-    If you're running helm v3, the `--verify=false` flag is not supported:
-
-    ```shell
-    helm plugin install https://github.com/helm-unittest/helm-unittest \
-        --version $(cat build.assets/helm-unittest.version)
+    make helmunit/installed
     ```
 
 1. Install `bats`:

--- a/Makefile
+++ b/Makefile
@@ -990,7 +990,7 @@ helmunit/installed:
 	fi; \
 	printf '%s\n' \
 		'helm-unittest does not provide the plugin signature required for Helm plugin signature verification, so we verify the release archive ourselves when installing:' \
-		'  plugin_dir="$${HELM_PLUGINS:-$$HOME/.local/share/helm/plugins}/helm-unittest"' \
+		'  plugin_dir="$$(helm env HELM_PLUGINS)/helm-unittest"' \
 		'  rm -rf "$$plugin_dir"' \
 		'  mkdir -p "$$plugin_dir"' \
 		'  curl -fsSL -o "$(HELM_UNITTEST_ARCHIVE)" https://github.com/helm-unittest/helm-unittest/releases/download/$(HELM_UNITTEST_VERSION)/$(HELM_UNITTEST_ARCHIVE)' \

--- a/examples/chart/CONTRIBUTING.md
+++ b/examples/chart/CONTRIBUTING.md
@@ -37,14 +37,9 @@ will ensure that Helm is able to validate values at install-time and can prevent
 4) Document any new values or changes to existing behaviour in the [chart reference](../../docs/pages/reference/helm-reference).
 
 5) Run `make lint-helm test-helm` from the root of the repo before raising your PR.
-You will need `yamllint`, `helm` and [helm-unittest](https://github.com/quintush/helm-unittest) installed locally.
+You will need `yamllint`, `helm` and [helm-unittest](https://github.com/helm-unittest/helm-unittest) installed locally.
 
 `make -C build.assets lint-helm test-helm` will run these via Docker if you'd prefer not to install locally.
-
-*Note: there are multiple forks for the helm-unittest plugin.
-They are not compatible and don't provide the same featureset (e.g. including templates from sub-directories).
-Our tests rely on features and bugfixes that are only available on the quintush fork
-(which seems to be the most maintained at the time of writing)*
 
 6) If you get a snapshot error during your testing, you should verify that your changes intended to alter the output,
 then run `make test-helm-update-snapshots` to update the snapshots and commit these changes along with your PR.

--- a/examples/chart/teleport-cluster/tests/README.md
+++ b/examples/chart/teleport-cluster/tests/README.md
@@ -1,11 +1,6 @@
 ## Unit tests for Helm charts
 
-Helm chart unit tests run here using the [helm-unittest](https://github.com/quintush/helm-unittest/) Helm plugin.
-
-*Note: there are multiple forks for the helm-unittest plugin.
-They are not compatible and don't provide the same featureset (e.g. including templates from sub-directories).
-Our tests rely on features and bugfixes that are only available on the quintush fork
-(which seems to be the most maintained at the time of writing)*
+Helm chart unit tests run here using the [helm-unittest](https://github.com/helm-unittest/helm-unittest/) Helm plugin.
 
 If you get a snapshot error during your testing, you should verify that your changes intended to alter the output, then run
 this command from the root of your Teleport checkout to update the snapshots:

--- a/examples/chart/teleport-kube-agent/tests/README.md
+++ b/examples/chart/teleport-kube-agent/tests/README.md
@@ -1,11 +1,6 @@
 ## Unit tests for Helm charts
 
-Helm chart unit tests run here using the [helm-unittest](https://github.com/quintush/helm-unittest/) Helm plugin.
-
-*Note: there are multiple forks for the helm-unittest plugin.
-They are not compatible and don't provide the same featureset (e.g. including templates from sub-directories).
-Our tests rely on features and bugfixes that are only available on the quintush fork
-(which seems to be the most maintained at the time of writing)*
+Helm chart unit tests run here using the [helm-unittest](https://github.com/helm-unittest/helm-unittest/) Helm plugin.
 
 If you get a snapshot error during your testing, you should verify that your changes intended to alter the output, then run
 this command from the root of your Teleport checkout to update the snapshots:


### PR DESCRIPTION
https://github.com/quintush/helm-unittest/ was archived last year. This PR replaces documentation references to this repo with the new repo that's maintaining this helm plugin: https://github.com/helm-unittest/helm-unittest.

## Manual Test Plan
### Test Environment

Teleport mac. 

### Test Cases
- [x] Manually ran the new commands mentioned in the documentation. 
