### PR TITLE
[v18] [Access Requests] Clarify why long-term approval is unavailable in review

### DIFF
--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestReview/RequestReview.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestReview/RequestReview.tsx
@@ -302,18 +302,29 @@ function makeReviewStateOptions(
   ) {
     promotedContent = <Text>{promotedTxt}</Text>;
   } else {
-    let msg = 'No Access Lists will grant the requested resources';
+    let msg =
+      'To approve long-term access, you must own an Access List that grants every requested resource, ' +
+      'including any resources automatically added to the request. None you own covers them all.';
     if (fetchSuggestedAccessListsAttempt.status === 'error') {
-      msg = fetchSuggestedAccessListsAttempt.statusText;
+      // A permission failure (HTTP 403 in the web UI, gRPC PERMISSION_DENIED in
+      // Connect) means the reviewer can't see the eligible Access Lists, which
+      // is distinct from there being none. Detect it by status code rather than
+      // message text so it survives across versions; surface other errors as-is.
+      const err = fetchSuggestedAccessListsAttempt.error;
+      const isPermissionError =
+        err?.response?.status === 403 || err?.code === 'PERMISSION_DENIED';
+      msg = isPermissionError
+        ? "You don't have permission to view the Access Lists eligible for long-term approval of this request. You can still reject it."
+        : fetchSuggestedAccessListsAttempt.statusText;
     } else if (request.resources.length === 0) {
       msg = 'Only supported for resource based access requests';
     }
     promotedContent = (
       <HoverTooltip tipContent={msg}>
-        <Flex alignItems="center">
+        <Flex alignItems="center" gap={2}>
           <Text>{promotedTxt}</Text>
           {fetchSuggestedAccessListsAttempt.status === 'error' && (
-            <Warning color="warning.active" ml={1} size={20} />
+            <Warning color="warning.active" size={20} />
           )}
         </Flex>
       </HoverTooltip>

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.story.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.story.tsx
@@ -16,12 +16,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { action } from 'storybook/actions';
+
 import {
+  Attempt,
   makeEmptyAttempt,
   makeErrorAttempt,
   makeProcessingAttempt,
   makeSuccessAttempt,
 } from 'shared/hooks/useAsync';
+import { AccessRequest, RequestKind } from 'shared/services/accessRequests';
 
 import {
   requestResourceApprovedWithConstraints,
@@ -36,235 +41,290 @@ import {
   requestSearchPending,
 } from '../../fixtures';
 import { RequestView, RequestViewProps } from './RequestView';
-import { RequestFlags, SuggestedAccessList } from './types';
+import { SuggestedAccessList } from './types';
 
-export default {
-  title: 'Shared/AccessRequests/RequestView',
+type RequestState =
+  | 'searchPending'
+  | 'rolePending'
+  | 'roleDenied'
+  | 'roleApproved'
+  | 'roleApprovedWithStartTime'
+  | 'resourcePendingWithConstraints'
+  | 'resourceApprovedWithConstraints'
+  | 'rolePromoted'
+  | 'roleEmpty'
+  | 'shortTermResource'
+  | 'longTermResource'
+  | 'processing'
+  | 'failed';
+
+type SuggestionsState =
+  | 'empty'
+  | 'lists'
+  | 'constraintLists'
+  | 'permissionDenied'
+  | 'error'
+  | 'processing';
+
+type StoryArgs = {
+  request: RequestState;
+  suggestions: SuggestionsState;
+  canReview: boolean;
+  canDelete: boolean;
+  canAssume: boolean;
+  isAssumed: boolean;
+  isPromoted: boolean;
+  ownRequest: boolean;
 };
 
-export const LoadedSearchPending = () => {
-  const flags = {
-    ...sampleFlags,
-    canReview: true,
-    canDelete: true,
-  };
-  return (
-    <RequestView
-      {...sample}
-      fetchRequestAttempt={makeSuccessAttempt(requestSearchPending)}
-      getFlags={() => flags}
-    />
-  );
-};
+function requestAttempt(r: RequestState): Attempt<AccessRequest> {
+  switch (r) {
+    case 'processing':
+      return makeProcessingAttempt();
+    case 'failed':
+      return makeErrorAttempt(new Error('some error message'));
+    case 'searchPending':
+      return makeSuccessAttempt(requestSearchPending);
+    case 'rolePending':
+      return makeSuccessAttempt(requestRolePending);
+    case 'roleDenied':
+      return makeSuccessAttempt(requestRoleDenied);
+    case 'roleApproved':
+      return makeSuccessAttempt(requestRoleApproved);
+    case 'roleApprovedWithStartTime':
+      return makeSuccessAttempt(requestRoleApprovedWithStartTime);
+    case 'resourcePendingWithConstraints':
+      return makeSuccessAttempt(requestResourcePendingWithConstraints);
+    case 'resourceApprovedWithConstraints':
+      return makeSuccessAttempt(requestResourceApprovedWithConstraints);
+    case 'rolePromoted':
+      return makeSuccessAttempt(requestRolePromoted);
+    case 'roleEmpty':
+      return makeSuccessAttempt(requestRoleEmpty);
+    case 'shortTermResource':
+      return makeSuccessAttempt({
+        ...requestResourcePendingWithConstraints,
+        requestKind: RequestKind.ShortTerm,
+      });
+    case 'longTermResource':
+      return makeSuccessAttempt({
+        ...requestResourcePendingWithConstraints,
+        requestKind: RequestKind.LongTerm,
+      });
+  }
+}
 
-export const LoadedRolePending = () => {
-  const flags = {
-    ...sampleFlags,
-    canReview: true,
-    canDelete: true,
-  };
-  return <RequestView {...sample} getFlags={() => flags} />;
-};
-
-export const LoadedRoleDenied = () => {
-  const flags = {
-    ...sampleFlags,
-    canDelete: true,
-  };
-  return (
-    <RequestView
-      {...sample}
-      fetchRequestAttempt={makeSuccessAttempt(requestRoleDenied)}
-      getFlags={() => flags}
-    />
-  );
-};
-
-export const LoadedRoleApproved = () => {
-  const flags = {
-    ...sampleFlags,
-    canDelete: true,
-    canAssume: true,
-  };
-  return (
-    <RequestView
-      {...sample}
-      fetchRequestAttempt={makeSuccessAttempt(requestRoleApproved)}
-      getFlags={() => flags}
-    />
-  );
-};
-
-export const LoadedRoleApprovedWithStartTime = () => {
-  const flags = {
-    ...sampleFlags,
-    canAssume: true,
-  };
-  return (
-    <RequestView
-      {...sample}
-      fetchRequestAttempt={makeSuccessAttempt(requestRoleApprovedWithStartTime)}
-      getFlags={() => flags}
-    />
-  );
-};
-
-export const LoadedResourcePendingWithConstraints = () => {
-  const flags = {
-    ...sampleFlags,
-    canReview: true,
-    canDelete: true,
-  };
-  return (
-    <RequestView
-      {...sample}
-      fetchRequestAttempt={makeSuccessAttempt(
-        requestResourcePendingWithConstraints
-      )}
-      fetchSuggestedAccessListsAttempt={makeSuccessAttempt(
+function suggestionsAttempt(
+  s: SuggestionsState
+): Attempt<SuggestedAccessList[]> {
+  switch (s) {
+    case 'empty':
+      return makeSuccessAttempt([]);
+    case 'lists':
+      return makeSuccessAttempt(suggestedAccessLists);
+    case 'constraintLists':
+      return makeSuccessAttempt(
         requestResourceWithConstraintsSuggestedAccessLists
-      )}
-      getFlags={() => flags}
-    />
-  );
+      );
+    case 'permissionDenied':
+      // Mirrors a backend RBAC error
+      return makeErrorAttempt(
+        Object.assign(
+          new Error('access denied to perform action "read" on access list'),
+          { response: { status: 403 } }
+        )
+      );
+    case 'error':
+      return makeErrorAttempt(
+        new Error('some kind of error came back from the backend')
+      );
+    case 'processing':
+      return makeProcessingAttempt();
+  }
+}
+
+const meta = {
+  title: 'Shared/AccessRequests/RequestView',
+  argTypes: {
+    request: {
+      control: 'select',
+      options: [
+        'searchPending',
+        'rolePending',
+        'roleDenied',
+        'roleApproved',
+        'roleApprovedWithStartTime',
+        'resourcePendingWithConstraints',
+        'resourceApprovedWithConstraints',
+        'rolePromoted',
+        'roleEmpty',
+        'shortTermResource',
+        'longTermResource',
+        'processing',
+        'failed',
+      ],
+      description:
+        'The request being reviewed. Long-term resource requests hide short-term approval, leaving only Access List promotion and reject.',
+    },
+    suggestions: {
+      control: 'select',
+      options: [
+        'empty',
+        'lists',
+        'constraintLists',
+        'permissionDenied',
+        'error',
+        'processing',
+      ],
+      description:
+        'State of the suggested Access Lists fetch that gates the long-term promote option.',
+    },
+    canReview: { control: 'boolean' },
+    canDelete: { control: 'boolean' },
+    canAssume: { control: 'boolean' },
+    isAssumed: { control: 'boolean' },
+    isPromoted: { control: 'boolean' },
+    ownRequest: { control: 'boolean' },
+  },
+  args: {
+    request: 'rolePending',
+    suggestions: 'empty',
+    canReview: false,
+    canDelete: false,
+    canAssume: false,
+    isAssumed: false,
+    isPromoted: false,
+    ownRequest: false,
+  },
+  render: (args: StoryArgs) => {
+    const props: RequestViewProps = {
+      user: 'loggedInUsername',
+      fetchRequestAttempt: requestAttempt(args.request),
+      submitReviewAttempt: makeEmptyAttempt(),
+      getFlags: () => ({
+        canReview: args.canReview,
+        canDelete: args.canDelete,
+        canAssume: args.canAssume,
+        isAssumed: args.isAssumed,
+        isPromoted: args.isPromoted,
+        ownRequest: args.ownRequest,
+      }),
+      confirmDelete: false,
+      toggleConfirmDelete: action('toggleConfirmDelete'),
+      submitReview: action('submitReview'),
+      assumeRole: action('assumeRole'),
+      fetchSuggestedAccessListsAttempt: suggestionsAttempt(args.suggestions),
+      assumeRoleAttempt: makeEmptyAttempt(),
+      assumeAccessList: action('assumeAccessList'),
+      deleteRequestAttempt: makeEmptyAttempt(),
+      deleteRequest: action('deleteRequest'),
+    };
+    return (
+      <RequestView key={`${args.request}-${args.suggestions}`} {...props} />
+    );
+  },
+} satisfies Meta<StoryArgs>;
+
+export default meta;
+
+type Story = StoryObj<StoryArgs>;
+
+export const LoadedSearchPending: Story = {
+  args: { request: 'searchPending', canReview: true, canDelete: true },
 };
 
-export const LoadedResourceApprovedWithConstraints = () => {
-  const flags = {
-    ...sampleFlags,
-    canAssume: true,
-  };
-  return (
-    <RequestView
-      {...sample}
-      fetchRequestAttempt={makeSuccessAttempt(
-        requestResourceApprovedWithConstraints
-      )}
-      getFlags={() => flags}
-    />
-  );
+export const LoadedRolePending: Story = {
+  args: { request: 'rolePending', canReview: true, canDelete: true },
 };
 
-export const AccessListPromoted = () => {
-  const flags = {
-    ...sampleFlags,
-    isPromoted: true,
-  };
-  return (
-    <RequestView
-      {...sample}
-      fetchRequestAttempt={makeSuccessAttempt(requestRolePromoted)}
-      getFlags={() => flags}
-      fetchSuggestedAccessListsAttempt={makeSuccessAttempt(
-        suggestedAccessLists
-      )}
-    />
-  );
+export const LoadedRoleDenied: Story = {
+  args: { request: 'roleDenied', canDelete: true },
 };
 
-export const AccessListPromotedOwnRequest = () => {
-  const flags = {
-    ...sampleFlags,
+export const LoadedRoleApproved: Story = {
+  args: { request: 'roleApproved', canDelete: true, canAssume: true },
+};
+
+export const LoadedRoleApprovedWithStartTime: Story = {
+  args: { request: 'roleApprovedWithStartTime', canAssume: true },
+};
+
+export const LoadedResourcePendingWithConstraints: Story = {
+  args: {
+    request: 'resourcePendingWithConstraints',
+    suggestions: 'constraintLists',
+    canReview: true,
+    canDelete: true,
+  },
+};
+
+export const LoadedResourceApprovedWithConstraints: Story = {
+  args: { request: 'resourceApprovedWithConstraints', canAssume: true },
+};
+
+export const AccessListPromoted: Story = {
+  args: { request: 'rolePromoted', suggestions: 'lists', isPromoted: true },
+};
+
+export const AccessListPromotedOwnRequest: Story = {
+  args: {
+    request: 'rolePromoted',
+    suggestions: 'lists',
     isPromoted: true,
     ownRequest: true,
-  };
-  return (
-    <RequestView
-      {...sample}
-      fetchRequestAttempt={makeSuccessAttempt(requestRolePromoted)}
-      getFlags={() => flags}
-      fetchSuggestedAccessListsAttempt={makeSuccessAttempt(
-        suggestedAccessLists
-      )}
-    />
-  );
+  },
 };
 
-export const AccessListPending = () => {
-  const flags = {
-    ...sampleFlags,
+export const AccessListPending: Story = {
+  args: { request: 'rolePending', suggestions: 'lists', canReview: true },
+};
+
+export const AccessListPendingWithError: Story = {
+  args: { request: 'rolePending', suggestions: 'error', canReview: true },
+};
+
+export const LongTermWithSuggestedAccessLists: Story = {
+  args: {
+    request: 'longTermResource',
+    suggestions: 'constraintLists',
     canReview: true,
-  };
-  return (
-    <RequestView
-      {...sample}
-      getFlags={() => flags}
-      fetchSuggestedAccessListsAttempt={makeSuccessAttempt(
-        suggestedAccessLists
-      )}
-    />
-  );
+  },
 };
 
-export const AccessListPendingWithError = () => {
-  const flags = {
-    ...sampleFlags,
+export const LongTermNoEligibleAccessList: Story = {
+  args: {
+    request: 'longTermResource',
+    suggestions: 'empty',
     canReview: true,
-  };
-  return (
-    <RequestView
-      {...sample}
-      getFlags={() => flags}
-      fetchSuggestedAccessListsAttempt={makeErrorAttempt(
-        new Error('some kind of error came back from the backend')
-      )}
-    />
-  );
+  },
 };
 
-export const LoadedEmpty = () => {
-  const flags = {
-    ...sampleFlags,
-    canAssume: true,
-    isAssumed: true,
-  };
-  return (
-    <RequestView
-      {...sample}
-      fetchRequestAttempt={makeSuccessAttempt(requestRoleEmpty)}
-      getFlags={() => flags}
-    />
-  );
+export const LongTermSuggestionsPermissionDenied: Story = {
+  args: {
+    request: 'longTermResource',
+    suggestions: 'permissionDenied',
+    canReview: true,
+  },
 };
 
-export const Processing = () => {
-  return (
-    <RequestView {...sample} fetchRequestAttempt={makeProcessingAttempt()} />
-  );
+export const LongTermSuggestionsError: Story = {
+  args: {
+    request: 'longTermResource',
+    suggestions: 'error',
+    canReview: true,
+  },
 };
 
-export const Failed = () => {
-  return (
-    <RequestView
-      {...sample}
-      fetchRequestAttempt={makeErrorAttempt(new Error('some error message'))}
-    />
-  );
+export const LoadedEmpty: Story = {
+  args: { request: 'roleEmpty', canAssume: true, isAssumed: true },
 };
 
-const sample: RequestViewProps = {
-  user: 'loggedInUsername',
-  fetchRequestAttempt: makeSuccessAttempt(requestRolePending),
-  submitReviewAttempt: makeEmptyAttempt(),
-  getFlags: () => sampleFlags,
-  confirmDelete: false,
-  toggleConfirmDelete: () => null,
-  submitReview: () => null,
-  assumeRole: () => null,
-  fetchSuggestedAccessListsAttempt: makeSuccessAttempt([]),
-  assumeRoleAttempt: makeEmptyAttempt(),
-  assumeAccessList: () => null,
-  deleteRequestAttempt: makeEmptyAttempt(),
-  deleteRequest: () => null,
+export const Processing: Story = {
+  args: { request: 'processing' },
 };
 
-const sampleFlags: RequestFlags = {
-  canAssume: false,
-  isAssumed: false,
-  canDelete: false,
-  canReview: false,
-  ownRequest: false,
-  isPromoted: false,
+export const Failed: Story = {
+  args: { request: 'failed' },
 };
 
 const suggestedAccessLists: SuggestedAccessList[] = [

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.test.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.test.tsx
@@ -16,12 +16,25 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { render, screen } from 'design/utils/testing';
-import { makeEmptyAttempt, makeSuccessAttempt } from 'shared/hooks/useAsync';
+import { render, screen, userEvent, within } from 'design/utils/testing';
+import {
+  makeEmptyAttempt,
+  makeErrorAttempt,
+  makeSuccessAttempt,
+} from 'shared/hooks/useAsync';
+import { RequestKind } from 'shared/services/accessRequests';
 
-import { requestRolePending } from '../../fixtures';
+import {
+  requestResourcePendingWithConstraints,
+  requestRolePending,
+} from '../../fixtures';
 import { RequestView, RequestViewProps } from './RequestView';
 import { RequestFlags } from './types';
+
+const longTermResourceRequest = {
+  ...requestResourcePendingWithConstraints,
+  requestKind: RequestKind.LongTerm,
+};
 
 const sampleFlags: RequestFlags = {
   canAssume: false,
@@ -66,4 +79,94 @@ test('does not render review box if user cannot review', async () => {
     />
   );
   expect(screen.queryByText(reviewBoxText)).not.toBeInTheDocument();
+});
+
+// When no Access List can be promoted to (e.g., reviewer doesn't own one that
+// grants every requested resource, including implicitly-added ones), long-term
+// approval is disabled, leaving only Reject. The disabled option explains why.
+test('disables long-term approval and explains why when no Access List is suggested', async () => {
+  const user = userEvent.setup();
+  render(
+    <RequestView
+      {...props}
+      fetchRequestAttempt={makeSuccessAttempt(longTermResourceRequest)}
+      fetchSuggestedAccessListsAttempt={makeSuccessAttempt([])}
+    />
+  );
+
+  expect(screen.getAllByText('aws-console-prod').length).toBeGreaterThan(0);
+
+  expect(screen.getByRole('radio', { name: 'Reject request' })).toBeEnabled();
+
+  const promote = screen.getByRole('radio', {
+    name: /Approve long-term access via Access List/,
+  });
+  expect(promote).toBeDisabled();
+
+  await user.hover(
+    screen.getByText(
+      'Approve long-term access via Access List with the requested resources'
+    )
+  );
+  const tooltip = await screen.findByRole('tooltip');
+  expect(
+    within(tooltip).getByText(
+      /you must own an Access List that grants every requested resource/i
+    )
+  ).toBeInTheDocument();
+});
+
+// A permission failure (the reviewer can't read the eligible Access Lists) is a
+// distinct state from there being none, and gets its own message.
+test('shows a permission-specific message when the reviewer cannot view eligible Access Lists', async () => {
+  const user = userEvent.setup();
+  const permissionError = Object.assign(
+    new Error('access denied to perform action "read" on access list'),
+    { response: { status: 403 } }
+  );
+  render(
+    <RequestView
+      {...props}
+      fetchRequestAttempt={makeSuccessAttempt(longTermResourceRequest)}
+      fetchSuggestedAccessListsAttempt={makeErrorAttempt(permissionError)}
+    />
+  );
+
+  expect(
+    screen.getByRole('radio', {
+      name: /Approve long-term access via Access List/,
+    })
+  ).toBeDisabled();
+
+  await user.hover(
+    screen.getByText(
+      'Approve long-term access via Access List with the requested resources'
+    )
+  );
+  const tooltip = await screen.findByRole('tooltip');
+  expect(
+    within(tooltip).getByText(/you don't have permission to view/i)
+  ).toBeInTheDocument();
+});
+
+// Non-permission errors stay visible so they aren't hidden behind a generic message.
+test('surfaces non-permission fetch errors as-is', async () => {
+  const user = userEvent.setup();
+  render(
+    <RequestView
+      {...props}
+      fetchRequestAttempt={makeSuccessAttempt(longTermResourceRequest)}
+      fetchSuggestedAccessListsAttempt={makeErrorAttempt(
+        new Error('backend exploded')
+      )}
+    />
+  );
+
+  await user.hover(
+    screen.getByText(
+      'Approve long-term access via Access List with the requested resources'
+    )
+  );
+  const tooltip = await screen.findByRole('tooltip');
+  expect(within(tooltip).getByText('backend exploded')).toBeInTheDocument();
 });

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/ResourcesRequested.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/ResourcesRequested.tsx
@@ -27,7 +27,7 @@ export default function ResourcesRequested({
 }) {
   const $resources = resources.map(resource => (
     <Label mr={1} key={resource.id.name} kind="secondary">
-      {resource.details.friendlyName || formattedName(resource)}
+      {resource.details?.friendlyName || formattedName(resource)}
     </Label>
   ));
 


### PR DESCRIPTION
## Context
Backport #68032 to branch/v18.

## Manual Test Plan
### Test Environment
- Storybook

### Test Cases
- [x] `LongTermWithSuggestedAccessLists`: verify only Reject and "Approve long-term access" are offered and the promote dropdown is enabled.
- [x] `LongTermNoEligibleAccessList`: verify promote is disabled and that hovering it explains long-term approval requires owning an Access List that grants every requested resource. (Also covers case of a reviewer who can't read the satisfying lists, which the backend collapses to an empty result.)
- [x] `LongTermSuggestionsPermissionDenied`: verify promote is disabled and that hovering it shows the permission-specific message and notes you can still reject.
- [x] `LongTermSuggestionsError`: verify promote is disabled and that hovering it surfaces the raw backend error.
- [x] From any story, verify the `request` and `suggestions` controls can be used to move between these and other states.
