### PR TITLE
[scopes] update acl scoped role grant validation for SQNs

### DIFF
--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_protohybrid.pb.go
@@ -1279,7 +1279,7 @@ func (b0 AccessListGrants_builder) Build() *AccessListGrants {
 // ScopedRoleGrant describes a scoped role granted at a specific scope.
 type ScopedRoleGrant struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
-	// role is scope-qualified name of the scoped role to be granted.
+	// role is the scope-qualified name of the scoped role to be granted.
 	Role string `protobuf:"bytes,1,opt,name=role,proto3" json:"role,omitempty"`
 	// scope is the scope the role will be granted at. It must be an assignable
 	// scope of the role.
@@ -1338,7 +1338,7 @@ func (x *ScopedRoleGrant) SetScope(v string) {
 type ScopedRoleGrant_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// role is scope-qualified name of the scoped role to be granted.
+	// role is the scope-qualified name of the scoped role to be granted.
 	Role string
 	// scope is the scope the role will be granted at. It must be an assignable
 	// scope of the role.

--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_protoopaque.pb.go
@@ -1296,7 +1296,7 @@ func (x *ScopedRoleGrant) SetScope(v string) {
 type ScopedRoleGrant_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// role is scope-qualified name of the scoped role to be granted.
+	// role is the scope-qualified name of the scoped role to be granted.
 	Role string
 	// scope is the scope the role will be granted at. It must be an assignable
 	// scope of the role.

--- a/api/proto/teleport/accesslist/v1/accesslist.proto
+++ b/api/proto/teleport/accesslist/v1/accesslist.proto
@@ -180,7 +180,7 @@ message AccessListGrants {
 
 // ScopedRoleGrant describes a scoped role granted at a specific scope.
 message ScopedRoleGrant {
-  // role is scope-qualified name of the scoped role to be granted.
+  // role is the scope-qualified name of the scoped role to be granted.
   string role = 1;
   // scope is the scope the role will be granted at. It must be an assignable
   // scope of the role.

--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -354,7 +354,7 @@ func (grants *Grants) Clone() Grants {
 
 // ScopedRoleGrant describes a scoped role granted at a specific scope.
 type ScopedRoleGrant struct {
-	// Role is the name of the scoped role to be granted.
+	// Role is the scope-qualified name of the scoped role to be granted.
 	Role string `json:"role" yaml:"role"`
 	// Scope is the scope the role will be assigned at. It must be an assignable
 	// scope of the role.

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
@@ -72,7 +72,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 |Field|Type|Description|
 |---|---|---|
-|role|string|role is scope-qualified name of the scoped role to be granted.|
+|role|string|role is the scope-qualified name of the scoped role to be granted.|
 |scope|string|scope is the scope the role will be granted at. It must be an assignable scope of the role.|
 
 ### spec.grants.traits
@@ -108,7 +108,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 |Field|Type|Description|
 |---|---|---|
-|role|string|role is scope-qualified name of the scoped role to be granted.|
+|role|string|role is the scope-qualified name of the scoped role to be granted.|
 |scope|string|scope is the scope the role will be granted at. It must be an assignable scope of the role.|
 
 ### spec.owner_grants.traits

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list.mdx
@@ -117,7 +117,7 @@ Optional:
 
 Optional:
 
-- `role` (String) role is scope-qualified name of the scoped role to be granted.
+- `role` (String) role is the scope-qualified name of the scoped role to be granted.
 - `scope` (String) scope is the scope the role will be granted at. It must be an assignable scope of the role.
 
 
@@ -158,7 +158,7 @@ Optional:
 
 Optional:
 
-- `role` (String) role is scope-qualified name of the scoped role to be granted.
+- `role` (String) role is the scope-qualified name of the scoped role to be granted.
 - `scope` (String) scope is the scope the role will be granted at. It must be an assignable scope of the role.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list.mdx
@@ -160,7 +160,7 @@ Optional:
 
 Optional:
 
-- `role` (String) role is scope-qualified name of the scoped role to be granted.
+- `role` (String) role is the scope-qualified name of the scoped role to be granted.
 - `scope` (String) scope is the scope the role will be granted at. It must be an assignable scope of the role.
 
 
@@ -201,7 +201,7 @@ Optional:
 
 Optional:
 
-- `role` (String) role is scope-qualified name of the scoped role to be granted.
+- `role` (String) role is the scope-qualified name of the scoped role to be granted.
 - `scope` (String) scope is the scope the role will be granted at. It must be an assignable scope of the role.
 
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accesslists.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accesslists.yaml
@@ -93,7 +93,7 @@ spec:
                     items:
                       properties:
                         role:
-                          description: role is scope-qualified name of the scoped
+                          description: role is the scope-qualified name of the scoped
                             role to be granted.
                           type: string
                         scope:
@@ -150,7 +150,7 @@ spec:
                     items:
                       properties:
                         role:
-                          description: role is scope-qualified name of the scoped
+                          description: role is the scope-qualified name of the scoped
                             role to be granted.
                           type: string
                         scope:

--- a/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
+++ b/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
@@ -286,7 +286,7 @@ export interface AccessListGrants {
  */
 export interface ScopedRoleGrant {
     /**
-     * role is scope-qualified name of the scoped role to be granted.
+     * role is the scope-qualified name of the scoped role to be granted.
      *
      * @generated from protobuf field: string role = 1;
      */

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_accesslists.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_accesslists.yaml
@@ -93,7 +93,7 @@ spec:
                     items:
                       properties:
                         role:
-                          description: role is scope-qualified name of the scoped
+                          description: role is the scope-qualified name of the scoped
                             role to be granted.
                           type: string
                         scope:
@@ -150,7 +150,7 @@ spec:
                     items:
                       properties:
                         role:
-                          description: role is scope-qualified name of the scoped
+                          description: role is the scope-qualified name of the scoped
                             role to be granted.
                           type: string
                         scope:

--- a/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
+++ b/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
@@ -178,7 +178,7 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 						"scoped_roles": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 								"role": {
-									Description: "role is scope-qualified name of the scoped role to be granted.",
+									Description: "role is the scope-qualified name of the scoped role to be granted.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
@@ -248,7 +248,7 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 						"scoped_roles": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 								"role": {
-									Description: "role is scope-qualified name of the scoped role to be granted.",
+									Description: "role is the scope-qualified name of the scoped role to be granted.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},

--- a/lib/accesslists/hierarchy_test.go
+++ b/lib/accesslists/hierarchy_test.go
@@ -853,11 +853,11 @@ func TestGetInheritedGrants(t *testing.T) {
 		Roles: []string{"root-owner-role"},
 		ScopedRoles: []accesslist.ScopedRoleGrant{
 			{
-				Role:  "root-scoped-role",
+				Role:  "/::root-scoped-role",
 				Scope: "/root/bb",
 			},
 			{
-				Role:  "root-scoped-role",
+				Role:  "/::root-scoped-role",
 				Scope: "/root/aa",
 			},
 		},
@@ -872,11 +872,11 @@ func TestGetInheritedGrants(t *testing.T) {
 		Roles: []string{"1-member-role"},
 		ScopedRoles: []accesslist.ScopedRoleGrant{
 			{
-				Role:  "1-scoped-role",
+				Role:  "/::1-scoped-role",
 				Scope: "/1/bb",
 			},
 			{
-				Role:  "1-scoped-role",
+				Role:  "/::1-scoped-role",
 				Scope: "/1/aa",
 			},
 		},
@@ -909,19 +909,19 @@ func TestGetInheritedGrants(t *testing.T) {
 		Roles: []string{"1-member-role", "root-owner-role"},
 		ScopedRoles: []accesslist.ScopedRoleGrant{
 			{
-				Role:  "1-scoped-role",
+				Role:  "/::1-scoped-role",
 				Scope: "/1/aa",
 			},
 			{
-				Role:  "1-scoped-role",
+				Role:  "/::1-scoped-role",
 				Scope: "/1/bb",
 			},
 			{
-				Role:  "root-scoped-role",
+				Role:  "/::root-scoped-role",
 				Scope: "/root/aa",
 			},
 			{
-				Role:  "root-scoped-role",
+				Role:  "/::root-scoped-role",
 				Scope: "/root/bb",
 			},
 		},

--- a/lib/accesslists/validate.go
+++ b/lib/accesslists/validate.go
@@ -120,12 +120,6 @@ func validateAccessList(a *accesslist.AccessList) error {
 		if len(a.Spec.Grants.Traits) > 0 || len(a.Spec.OwnerGrants.Traits) > 0 {
 			return trace.BadParameter("scoped access lists cannot grant traits")
 		}
-
-		// TODO(nklaassen): after scoped role assignments have been updated to
-		// refer to scoped access lists with scope-qualified names, access
-		// lists should do the same. At that point we must validate that the
-		// scope of origin of each granted scoped role is equal or ancestor to
-		// the scope of the access list.
 	}
 
 	if err := validateScopedRoleGrants(a); err != nil {
@@ -148,18 +142,36 @@ func validateScopedRoleGrants(a *accesslist.AccessList) error {
 			return trace.BadParameter("scope is empty")
 		}
 
-		if err := scopes.StrongValidate(grant.Scope); err != nil {
-			return trace.Wrap(err, "validating scope")
+		roleName, err := scopes.ParseQualifiedName(grant.Role)
+		if err != nil {
+			return trace.Wrap(err, "parsing granted role name")
+		}
+		if err := roleName.StrongValidate(); err != nil {
+			return trace.Wrap(err, "validating granted role name")
 		}
 
+		if err := scopes.StrongValidate(grant.Scope); err != nil {
+			return trace.Wrap(err, "validating granted scope")
+		}
 		if scopes.Compare(grant.Scope, scopes.Root) == scopes.Equivalent {
 			return trace.BadParameter("root scope cannot be used as a scope of effect")
 		}
 
 		if a.Scope != "" {
-			// Scoped access lists can only assign scoped roles to their own scope or a descendent scope.
+			// Scoped access lists can only assign scoped roles defined in
+			// their own scope or an ancestor scope, to their own scope or a
+			// descendent scope.
+			//
+			// E.g. An access list in /aa/bb can grant /aa::role to /aa/bb/cc
+			if !scopes.PolicyResourceScope(a.Scope).CanDependOnStateFromPolicyResourceAtScope(roleName.Scope) {
+				return trace.BadParameter("cannot grant %q because it is not defined in a scope equal or ancestor to the list's scope %q", grant.Role, a.Scope)
+			}
 			if !scopes.ScopeOfOrigin(a.Scope).IsAssignableToScopeOfEffect(grant.Scope) {
 				return trace.BadParameter("scoped role grant has scope %q that is not a sub-scope of the access list's scope %q", grant.Scope, a.Scope)
+			}
+		} else {
+			if scopes.Compare(roleName.Scope, scopes.Root) != scopes.Equivalent {
+				return trace.BadParameter("unscoped access lists can only grant scoped role defined in the root scope")
 			}
 		}
 

--- a/lib/accesslists/validate_test.go
+++ b/lib/accesslists/validate_test.go
@@ -280,6 +280,57 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("granted scoped role origin must be equal or ancestor", func(t *testing.T) {
+			testCases := []struct {
+				name          string
+				scopeOfOrigin string
+				wantErr       string
+			}{
+				{
+					name:          "equal scope is allowed",
+					scopeOfOrigin: "/eng/platform",
+				},
+				{
+					name:          "descendant scope is rejected",
+					scopeOfOrigin: "/eng/platform/team",
+					wantErr:       `cannot grant "/eng/platform/team::role" because it is not defined in a scope equal or ancestor to the list's scope "/eng/platform"`,
+				},
+				{
+					name:          "ancestor scope is allowed",
+					scopeOfOrigin: "/eng",
+				},
+				{
+					name:          "sibling scope is rejected",
+					scopeOfOrigin: "/eng/infra",
+					wantErr:       `cannot grant "/eng/infra::role" because it is not defined in a scope equal or ancestor to the list's scope "/eng/platform"`,
+				},
+				{
+					name:          "root scope is allowed",
+					scopeOfOrigin: "/",
+				},
+			}
+
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					accessList := newScopedAccessList("test_scoped_access_list_grant_scope")
+					accessList.Scope = "/eng/platform"
+					accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{
+						{
+							Role:  NormalizedSQN{Scope: tc.scopeOfOrigin, Name: "role"}.String(),
+							Scope: "/eng/platform/team",
+						},
+					}
+
+					err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+					if tc.wantErr != "" {
+						require.ErrorContains(t, err, tc.wantErr)
+						return
+					}
+					require.NoError(t, err)
+				})
+			}
+		})
+
 		t.Run("scoped role grant scope must be equal or descendant", func(t *testing.T) {
 			testCases := []struct {
 				name       string
@@ -307,7 +358,7 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 				{
 					name:       "root scope is rejected",
 					grantScope: "/",
-					wantErr:    "root scope cannot be used as a scope of effect",
+					wantErr:    `root scope cannot be used as a scope of effect`,
 				},
 			}
 
@@ -315,7 +366,9 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 				t.Run(tc.name, func(t *testing.T) {
 					accessList := newScopedAccessList("test_scoped_access_list_grant_scope")
 					accessList.Scope = "/eng/platform"
-					accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role", Scope: tc.grantScope}}
+					accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{
+						{Role: "/eng/platform::role", Scope: tc.grantScope},
+					}
 
 					err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
 					if tc.wantErr != "" {
@@ -499,7 +552,7 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 		t.Run("owner scoped role grant scope must be equal or descendant", func(t *testing.T) {
 			accessList := newScopedAccessList("test_scoped_access_list_owner_grant_scope")
 			accessList.Scope = "/eng/platform"
-			accessList.Spec.OwnerGrants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role", Scope: "/eng"}}
+			accessList.Spec.OwnerGrants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "/::role", Scope: "/eng"}}
 
 			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
 			require.ErrorContains(t, err, `scoped role grant has scope "/eng" that is not a sub-scope of the access list's scope "/eng/platform"`)
@@ -639,7 +692,7 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 		t.Run("scoped roles conflict with membership requires", func(t *testing.T) {
 			accessList := newScopedAccessList("test_access_list_membership_requires")
 			accessList.Spec.MembershipRequires = accesslist.Requires{Roles: []string{"member-role"}}
-			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role-a", Scope: "/eng"}}
+			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "/::role-a", Scope: "/eng"}}
 
 			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
 			require.ErrorContains(t, err, "cannot contain both scoped_role grants")
@@ -648,7 +701,7 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 		t.Run("scoped roles conflict with ownership requires", func(t *testing.T) {
 			accessList := newScopedAccessList("test_access_list_ownership_requires")
 			accessList.Spec.OwnershipRequires = accesslist.Requires{Roles: []string{"owner-role"}}
-			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role-a", Scope: "/eng"}}
+			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "/::role-a", Scope: "/eng"}}
 
 			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
 			require.ErrorContains(t, err, "cannot contain both scoped_role grants")
@@ -665,7 +718,7 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 
 		t.Run("empty scoped role scope is rejected", func(t *testing.T) {
 			accessList := newScopedAccessList("test_access_list_empty_scope")
-			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role-a"}}
+			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "/::role-a"}}
 
 			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
 			require.ErrorContains(t, err, "validating grants.scoped_roles[0]")
@@ -674,18 +727,18 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 
 		t.Run("invalid scoped role scope syntax is rejected", func(t *testing.T) {
 			accessList := newScopedAccessList("test_access_list_invalid_scope")
-			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role-a", Scope: "not-a-scope"}}
+			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "/::role-a", Scope: "not-a-scope"}}
 
 			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
 			require.ErrorContains(t, err, "validating grants.scoped_roles[0]")
-			require.ErrorContains(t, err, "validating scope")
+			require.ErrorContains(t, err, "validating granted scope")
 		})
 
 		t.Run("too many unique scoped role grants are rejected", func(t *testing.T) {
 			accessList := newScopedAccessList("test_access_list_too_many_scoped_roles")
 			for i := range scopedaccess.MaxRolesPerAssignment + 1 {
 				accessList.Spec.Grants.ScopedRoles = append(accessList.Spec.Grants.ScopedRoles, accesslist.ScopedRoleGrant{
-					Role:  fmt.Sprintf("role-%02d", i),
+					Role:  fmt.Sprintf("/::role-%02d", i),
 					Scope: "/eng",
 				})
 			}
@@ -696,7 +749,7 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 
 		t.Run("valid owner grants scoped roles pass validation", func(t *testing.T) {
 			accessList := newScopedAccessList("test_access_list_valid_owner_scoped_roles")
-			accessList.Spec.OwnerGrants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "owner-role", Scope: "/eng"}}
+			accessList.Spec.OwnerGrants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "/::owner-role", Scope: "/eng"}}
 
 			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
 			require.NoError(t, err)

--- a/lib/scopes/cache/access/materializer_test.go
+++ b/lib/scopes/cache/access/materializer_test.go
@@ -267,11 +267,11 @@ func TestMaterializerDoubleListParents(t *testing.T) {
 			AccessListsByName: map[string]*accesslist.AccessList{
 				"parentA": newAccessList(t, "parentA", withMemberGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/aa",
-					Role:  "/::roleA",
+					Role:  "/::rolea",
 				}})),
 				"parentB": newAccessList(t, "parentB", withMemberGrants([]accesslist.ScopedRoleGrant{{
 					Scope: "/bb",
-					Role:  "/::roleB",
+					Role:  "/::roleb",
 				}})),
 				"child": newAccessList(t, "child"),
 			},
@@ -290,11 +290,11 @@ func TestMaterializerDoubleListParents(t *testing.T) {
 		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
 			// User should be a nested member of both parents and get an assignment for each.
 			expectedScopedRoleAssignment("tester", "parentA", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
-				Role:  "/::roleA",
+				Role:  "/::rolea",
 				Scope: "/aa",
 			}.Build()}),
 			expectedScopedRoleAssignment("tester", "parentB", []*scopedaccessv1.Assignment{scopedaccessv1.Assignment_builder{
-				Role:  "/::roleB",
+				Role:  "/::roleb",
 				Scope: "/bb",
 			}.Build()}),
 		},

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -342,11 +342,11 @@ func TestAccessListCRUDScopedRoleGrants(t *testing.T) {
 	accessList := newAccessList(t, "accessList-scoped", clock, withOwnerRequires(accesslist.Requires{}), withMemberRequires(accesslist.Requires{}))
 	accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{
 		{
-			Role:  "scoped-role-1",
+			Role:  "/::scoped-role-1",
 			Scope: "/eng",
 		},
 		{
-			Role:  "scoped-role-2",
+			Role:  "/::scoped-role-2",
 			Scope: "/platform",
 		},
 	}
@@ -365,7 +365,7 @@ func TestAccessListCRUDScopedRoleGrants(t *testing.T) {
 
 	fetched.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{
 		{
-			Role:  "scoped-role-3",
+			Role:  "/::scoped-role-3",
 			Scope: "/ops",
 		},
 	}
@@ -2327,8 +2327,8 @@ func newScopedAccessList(t *testing.T, name scopes.QualifiedName, clock clockwor
 		}
 	} else {
 		accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{
-			{Role: "gscopedrole1", Scope: name.Scope},
-			{Role: "gscopedrole2", Scope: name.Scope},
+			{Role: "/::gscopedrole1", Scope: name.Scope},
+			{Role: "/::gscopedrole2", Scope: name.Scope},
 		}
 	}
 


### PR DESCRIPTION
Since https://github.com/gravitational/teleport/pull/68457, scoped role assignments now refer to scoped roles with a scope-qualified name. Since scoped role grants in access lists materialize to scoped role assignments, I have here updated the scoped role grant validation to validate the scope-qualified name and required scope hierarchy. This is an expected breaking change necessitated by the breaking change to scoped role assignments.

## Manual Test Plan
### Test Environment

A cluster running this branch with TELEPORT_UNSTABLE_SCOPES=yes

### Test Cases
- [x] create an access list granting a scoped role referenced with a scope-qualified name
- [x] a scoped role assignment should be materialized
- [x] access list members should receive the granted role upon login