### PR TITLE
Forbid use of golang.org/x/crypto/openpgp

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -202,6 +202,8 @@ linters:
                 google.golang.org/protobuf/protoadapt instead, or, better yet,
                 see if you can move the code generation for that message to the
                 modern protoc-gen-go.
+            - pkg: golang.org/x/crypto/openpgp
+              desc: use "github.com/ProtonMail/go-crypto/openpgp" instead
         oidc:
           deny:
             - pkg: github.com/coreos/go-oidc


### PR DESCRIPTION
From https://pkg.go.dev/golang.org/x/crypto/openpgp:

"Deprecated: this package is unsafe by design, and has numerous known security issues. It is not maintained, and should not be used."

See also https://pkg.go.dev/vuln/GO-2026-5932.