### PR TITLE
update SELinux docs to add teleport-update install section and remove the "active development" warning

### DIFF
--- a/docs/pages/reference/cli/teleport-update.mdx
+++ b/docs/pages/reference/cli/teleport-update.mdx
@@ -64,6 +64,7 @@ To change these flags, run `enable` again with the new flags.
 | -g, --group          | Update group for this agent installation.                                                      |
 | -b, --base-url       | Base URL used to override the Teleport download URL.                                           |
 | -o, --[no-]overwrite | Allow existing installed Teleport binaries to be overwritten.                                  |
+| --enable-selinux.    | Install an SELinux module to constrain Teleport SSH.                                           |
 
 ### Examples
 
@@ -158,6 +159,7 @@ New versions will continue to be reported in SystemD `teleport-update.service` l
 | -b, --base-url       | Base URL used to override the Teleport download URL.                                           |
 | -o, --[no-]overwrite | Allow existing installed Teleport binaries to be overwritten.                                  |
 | -f, --force-version  | Force the provided version instead of using the version provided by the Teleport cluster.      |
+| --enable-selinux.    | Install an SELinux module to constrain Teleport SSH.                                           |
 
 ### Examples
 

--- a/docs/pages/reference/cli/teleport-update.mdx
+++ b/docs/pages/reference/cli/teleport-update.mdx
@@ -64,7 +64,7 @@ To change these flags, run `enable` again with the new flags.
 | -g, --group          | Update group for this agent installation.                                                      |
 | -b, --base-url       | Base URL used to override the Teleport download URL.                                           |
 | -o, --[no-]overwrite | Allow existing installed Teleport binaries to be overwritten.                                  |
-| --enable-selinux.    | Install an SELinux module to constrain Teleport SSH.                                           |
+| --selinux-ssh        | Install an SELinux module to constrain Teleport SSH.                                           |
 
 ### Examples
 
@@ -159,7 +159,7 @@ New versions will continue to be reported in SystemD `teleport-update.service` l
 | -b, --base-url       | Base URL used to override the Teleport download URL.                                           |
 | -o, --[no-]overwrite | Allow existing installed Teleport binaries to be overwritten.                                  |
 | -f, --force-version  | Force the provided version instead of using the version provided by the Teleport cluster.      |
-| --enable-selinux.    | Install an SELinux module to constrain Teleport SSH.                                           |
+| --selinux-ssh        | Install an SELinux module to constrain Teleport SSH.                                           |
 
 ### Examples
 

--- a/docs/pages/zero-trust-access/management/security/selinux.mdx
+++ b/docs/pages/zero-trust-access/management/security/selinux.mdx
@@ -8,13 +8,6 @@ tags:
  - resiliency
 ---
 
-<Admonition type="note">
-
-This feature is currently under active development. Future releases will extend SELinux policy to support
-more Teleport features, and integration with Teleport Managed Updates.
-
-</Admonition>
-
 The Teleport SSH Service SELinux module allows SELinux to confine the Teleport SSH Service. It ensures that Teleport SSH Service processes can only perform explicitly allowed operations, reducing the attack surface and preventing unauthorized actions even if the Teleport binary were compromised.
 
 ## Prerequisites
@@ -72,6 +65,22 @@ Before installing the SELinux module ensure that the `selinux-policy-devel` pack
 $ sudo dnf install selinux-policy-devel
 ```
 
+### Using teleport-update
+
+`teleport-update` is the recommended way to install the SELinux module for Teleport SSH Service as it will
+ensure the SELinux module version is kept in sync with the installed version of Teleport. Once `teleport-update`
+is configured to handle the SELinux module, it will update the SELinux module automatically when it updates Teleport.
+
+This can be done by passing `--selinux-ssh` to `teleport-update enable` or `teleport-update pin`:
+
+```code
+$ teleport-update enable --selinux-ssh
+```
+
+If you are unable to use `teleport-update`, you can install the SELinux module manually by following the steps below.
+
+### Using the install script
+
 To install the SELinux module, run the `install-selinux.sh` script included in Linux tarballs as `root`:
 
 ```code
@@ -99,8 +108,6 @@ $ sudo ./install-selinux.sh -c /path/to/teleport.yaml
 You must re-run `install-selinux.sh` whenever your Teleport SSH Service agents are updated. This ensures the SELinux module matches the version of the binaries in use.
 
 </Admonition>
-
-Future versions of Teleport will make managed updates with `teleport-update` the primary way to manage the SELinux module.
 
 ## SELinux modes
 
@@ -145,6 +152,8 @@ $ sudo semanage fcontext -a -t teleport_ssh_exec_t /path/to/teleport
 <Admonition type="note">
 
 Teleport will probably not run under the correct `teleport_ssh_t` domain and not be enforced by SELinux unless it is running as a **systemd service**. For more information on SELinux domains refer to the Red Hat article [Getting started with SELinux](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/using_selinux/getting-started-with-selinux_using-selinux).
+
+If you are running Teleport as a systemd service you will need to add the `--enable-selinux` flag to the `ExecStart` option in the Teleport systemd service file.
 
 </Admonition>
 

--- a/docs/pages/zero-trust-access/management/security/selinux.mdx
+++ b/docs/pages/zero-trust-access/management/security/selinux.mdx
@@ -155,6 +155,8 @@ Teleport will probably not run under the correct `teleport_ssh_t` domain and not
 
 If you are running Teleport as a systemd service you will need to add the `--enable-selinux` flag to the `ExecStart` option in the Teleport systemd service file.
 
+A future version of `teleport-update` will handle this automatically.
+
 </Admonition>
 
 The optional `--ensure-selinux-enforcing` flag causes Teleport to exit with an error if:

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -145,7 +145,7 @@ func Run(args []string) int {
 	enableCmd.Flag("path", "Directory to link the active Teleport installation's binaries into.").
 		Hidden().Envar(pathEnvVar).StringVar(&ccfg.Path)
 	enableCmd.Flag("selinux-ssh", "Install an SELinux module to constrain Teleport SSH.").
-		Hidden().Envar(autoupdate.SetupSELinuxSSHEnvVar).IsSetByUser(&ccfg.SELinuxSSHChanged).BoolVar(&ccfg.SELinuxSSH)
+		Envar(autoupdate.SetupSELinuxSSHEnvVar).IsSetByUser(&ccfg.SELinuxSSHChanged).BoolVar(&ccfg.SELinuxSSH)
 
 	disableCmd := app.Command("disable", "Disable agent managed updates. Does not affect the active installation of Teleport.")
 
@@ -169,7 +169,7 @@ func Run(args []string) int {
 	pinCmd.Flag("path", "Directory to link the active Teleport installation's binaries into.").
 		Hidden().Envar(pathEnvVar).StringVar(&ccfg.Path)
 	pinCmd.Flag("selinux-ssh", "Install an SELinux module to constrain Teleport SSH.").
-		Hidden().Envar(autoupdate.SetupSELinuxSSHEnvVar).IsSetByUser(&ccfg.SELinuxSSHChanged).BoolVar(&ccfg.SELinuxSSH)
+		Envar(autoupdate.SetupSELinuxSSHEnvVar).IsSetByUser(&ccfg.SELinuxSSHChanged).BoolVar(&ccfg.SELinuxSSH)
 
 	unpinCmd := app.Command("unpin", "Unpin the current version, allowing it to be updated.")
 


### PR DESCRIPTION
Updates https://github.com/gravitational/teleport/issues/51316.

<!-- Provide a descriptive entry for the changelog of the next release. -->



<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->
