### PR TITLE
[v18] Forbid use of golang.org/x/crypto/openpgp

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -199,6 +199,8 @@ linters:
                 google.golang.org/protobuf/protoadapt instead, or, better yet,
                 see if you can move the code generation for that message to the
                 modern protoc-gen-go.
+            - pkg: golang.org/x/crypto/openpgp
+              desc: use "github.com/ProtonMail/go-crypto/openpgp" instead
         oidc:
           deny:
             - pkg: github.com/coreos/go-oidc


### PR DESCRIPTION
Backport #68732 to branch/v18.