### PR TITLE
[v18] Added flag to prevent tsh proxy from writing to stdout

### DIFF
--- a/docs/pages/reference/cli/tbot.mdx
+++ b/docs/pages/reference/cli/tbot.mdx
@@ -71,6 +71,7 @@ Flags:
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--[no-]specific-tls-extensions`|`false`|If set, includes additional `tls.crt`, `tls.key`, and `tls.cas` for apps that require these file extensions|
+|`-o`, `--output`|*no default*|Path to write the generated configuration file to. If unspecified, the generated configuration is written to stdout.|
 |`--pid-file`|*no default*|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|*no default*|Address of the Teleport Proxy Server.|
 |`--reader-group`|*no default*|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
@@ -113,6 +114,7 @@ Flags:
 |`--listen`|*no default*|The socket URI on which the local proxy should listen, such as `tcp://0.0.0.0:8080`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
+|`-o`, `--output`|*no default*|Path to write the generated configuration file to. If unspecified, the generated configuration is written to stdout.|
 |`--pid-file`|*no default*|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|*no default*|Address of the Teleport Proxy Server.|
 |`--registration-secret`|*no default*|For bound keypair joining, specifies a registration secret for use at first join.|
@@ -154,6 +156,7 @@ Flags:
 |`--listen`|*no default*|The socket URI on which the tunnel should listen, such as `tcp://0.0.0.0:8080`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
+|`-o`, `--output`|*no default*|Path to write the generated configuration file to. If unspecified, the generated configuration is written to stdout.|
 |`--pid-file`|*no default*|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|*no default*|Address of the Teleport Proxy Server.|
 |`--registration-secret`|*no default*|For bound keypair joining, specifies a registration secret for use at first join.|
@@ -196,6 +199,7 @@ Flags:
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
+|`-o`, `--output`|*no default*|Path to write the generated configuration file to. If unspecified, the generated configuration is written to stdout.|
 |`--pid-file`|*no default*|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|*no default*|Address of the Teleport Proxy Server.|
 |`--reader-group`|*no default*|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
@@ -241,6 +245,7 @@ Flags:
 |`--listen`|*no default*|A socket URI to listen on, such as `tcp://0.0.0.0:3306`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
+|`-o`, `--output`|*no default*|Path to write the generated configuration file to. If unspecified, the generated configuration is written to stdout.|
 |`--pid-file`|*no default*|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|*no default*|Address of the Teleport Proxy Server.|
 |`--registration-secret`|*no default*|For bound keypair joining, specifies a registration secret for use at first join.|
@@ -285,6 +290,7 @@ Flags:
 |`--[no-]allow-reissue`|`false`|Allow the credentials output by this command to be reissued.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
+|`-o`, `--output`|*no default*|Path to write the generated configuration file to. If unspecified, the generated configuration is written to stdout.|
 |`--pid-file`|*no default*|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|*no default*|Address of the Teleport Proxy Server.|
 |`--reader-group`|*no default*|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
@@ -329,6 +335,7 @@ Flags:
 |`--[no-]disable-exec-plugin`|`false`|If set, disables the exec plugin. This allows credentials to be used without the `tbot` binary.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
+|`-o`, `--output`|*no default*|Path to write the generated configuration file to. If unspecified, the generated configuration is written to stdout.|
 |`--pid-file`|*no default*|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|*no default*|Address of the Teleport Proxy Server.|
 |`--reader-group`|*no default*|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
@@ -374,6 +381,7 @@ Flags:
 |`--[no-]disable-exec-plugin`|`false`|If set, disables the exec plugin. This allows credentials to be used without the `tbot` binary.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
+|`-o`, `--output`|*no default*|Path to write the generated configuration file to. If unspecified, the generated configuration is written to stdout.|
 |`--pid-file`|*no default*|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|*no default*|Address of the Teleport Proxy Server.|
 |`--reader-group`|*no default*|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
@@ -416,6 +424,7 @@ Flags:
 |`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
+|`-o`, `--output`|*no default*|Path to write the generated configuration file to. If unspecified, the generated configuration is written to stdout.|
 |`--pid-file`|*no default*|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|*no default*|Address of the Teleport Proxy Server.|
 |`--renewal-interval`|*no default*|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
@@ -451,6 +460,7 @@ Flags:
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
+|`-o`, `--output`|*no default*|Path to write the generated configuration file to. If unspecified, the generated configuration is written to stdout.|
 |`--pid-file`|*no default*|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|*no default*|Address of the Teleport Proxy Server.|
 |`--registration-secret`|*no default*|For bound keypair joining, specifies a registration secret for use at first join.|
@@ -492,6 +502,7 @@ Flags:
 |`--[no-]enable-resumption`|`false`|If set, disables SSH session resumption.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
+|`-o`, `--output`|*no default*|Path to write the generated configuration file to. If unspecified, the generated configuration is written to stdout.|
 |`--pid-file`|*no default*|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-command`|*no default*|The command to run as the SSH ProxyCommand, such as `fdpass-teleport`. Defaults to this tbot binary. Repeatable to add additional args.|
 |`--proxy-server`|*no default*|Address of the Teleport Proxy Server.|
@@ -539,6 +550,7 @@ Flags:
 |`--name-selector`|*no default*|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
+|`-o`, `--output`|*no default*|Path to write the generated configuration file to. If unspecified, the generated configuration is written to stdout.|
 |`--pid-file`|*no default*|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|*no default*|Address of the Teleport Proxy Server.|
 |`--registration-secret`|*no default*|For bound keypair joining, specifies a registration secret for use at first join.|
@@ -582,6 +594,7 @@ Flags:
 |`--name-selector`|*no default*|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
+|`-o`, `--output`|*no default*|Path to write the generated configuration file to. If unspecified, the generated configuration is written to stdout.|
 |`--pid-file`|*no default*|Full path to the PID file. By default no PID file will be created.|
 |`--profile-arn`|*no default*|The ARN of the Roles Anywhere profile to use.|
 |`--proxy-server`|*no default*|Address of the Teleport Proxy Server.|
@@ -633,6 +646,7 @@ Flags:
 |`--name-selector`|*no default*|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
+|`-o`, `--output`|*no default*|Path to write the generated configuration file to. If unspecified, the generated configuration is written to stdout.|
 |`--pid-file`|*no default*|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|*no default*|Address of the Teleport Proxy Server.|
 |`--reader-group`|*no default*|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
@@ -678,6 +692,7 @@ Flags:
 |`--[no-]include-federated-trust-bundles`|`false`|If set, include federated trust bundles in the output.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
+|`-o`, `--output`|*no default*|Path to write the generated configuration file to. If unspecified, the generated configuration is written to stdout.|
 |`--pid-file`|*no default*|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|*no default*|Address of the Teleport Proxy Server.|
 |`--reader-group`|*no default*|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -325,6 +325,8 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
+|`--days`|`7`|Days range (default 7)|
+|`--format`|`yaml`|Output format: 'yaml' or 'json'|
 |`--name`|*no default*|Audit query name|
 
 Arguments:
@@ -340,8 +342,15 @@ Execute audit query.
 Usage:
 
 ```code
-$ tctl audit query exec [<query>]
+$ tctl audit query exec [<flags>] [<query>]
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--days`|`7`|Days range (default 7)|
+|`--format`|`yaml`|Output format: 'yaml' or 'json'|
 
 Arguments:
 
@@ -356,8 +365,15 @@ Get audit query.
 Usage:
 
 ```code
-$ tctl audit query get <name>
+$ tctl audit query get [<flags>] <name>
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--days`|`7`|Days range (default 7)|
+|`--format`|`yaml`|Output format: 'yaml' or 'json'|
 
 Arguments:
 
@@ -372,8 +388,15 @@ List audit queries.
 Usage:
 
 ```code
-$ tctl audit query ls
+$ tctl audit query ls [<flags>]
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--days`|`7`|Days range (default 7)|
+|`--format`|`yaml`|Output format: 'yaml' or 'json'|
 
 ## tctl audit query rm
 
@@ -382,8 +405,15 @@ Remove audit query.
 Usage:
 
 ```code
-$ tctl audit query rm <name>
+$ tctl audit query rm [<flags>] <name>
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--days`|`7`|Days range (default 7)|
+|`--format`|`yaml`|Output format: 'yaml' or 'json'|
 
 Arguments:
 
@@ -398,8 +428,15 @@ Get security report.
 Usage:
 
 ```code
-$ tctl audit report get <name>
+$ tctl audit report get [<flags>] <name>
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--days`|`7`|Days range (default 7)|
+|`--format`|`yaml`|Output format: 'yaml' or 'json'|
 
 Arguments:
 
@@ -414,8 +451,15 @@ List security reports.
 Usage:
 
 ```code
-$ tctl audit report ls
+$ tctl audit report ls [<flags>]
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--days`|`7`|Days range (default 7)|
+|`--format`|`yaml`|Output format: 'yaml' or 'json'|
 
 ## tctl audit report run
 
@@ -424,8 +468,15 @@ Run the security report.
 Usage:
 
 ```code
-$ tctl audit report run <name>
+$ tctl audit report run [<flags>] <name>
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--days`|`7`|Days range (default 7)|
+|`--format`|`yaml`|Output format: 'yaml' or 'json'|
 
 Arguments:
 
@@ -440,8 +491,15 @@ Print the state of the security report.
 Usage:
 
 ```code
-$ tctl audit report state <name>
+$ tctl audit report state [<flags>] <name>
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--days`|`7`|Days range (default 7)|
+|`--format`|`yaml`|Output format: 'yaml' or 'json'|
 
 Arguments:
 
@@ -456,8 +514,15 @@ Print audit query schema.
 Usage:
 
 ```code
-$ tctl audit schema
+$ tctl audit schema [<flags>]
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--days`|`7`|Days range (default 7)|
+|`--format`|`yaml`|Output format: 'yaml' or 'json'|
 
 ## tctl auth create-override
 

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -2147,7 +2147,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
 |`--role`|*no default*|Filter by assigned role.|
 |`--user`|*no default*|Filter by user.|
 
@@ -2176,7 +2176,7 @@ Flags:
 |Flag|Default|Description|
 |---|---|---|
 |`--assign-scope`|*no default*|Scope that should be applied to resources provisioned by this token|
-|`--format`|*no default* (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
+|`--format`|*no default* (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
 |`--labels`|*no default*|Set token labels, e.g. env=prod,region=us-west|
 |`--mode`|*no default*|Usage mode of a token (default: unlimited, single_use)|
 |`--name`|*no default*|Override the default, randomly generated token name with a specified name|
@@ -2199,7 +2199,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-f`, `--format`|*no default* (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
+|`-f`, `--format`|*no default* (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
 |`--[no-]with-secrets`|`false`|Do not redact join tokens|
 
 ## tctl scoped tokens rm

--- a/docs/pages/reference/cli/teleport.mdx
+++ b/docs/pages/reference/cli/teleport.mdx
@@ -105,7 +105,7 @@ Flags:
 |Flag|Default|Description|
 |---|---|---|
 |`-c`, `--config`|*no default*|Path to the config file.|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
 
 Arguments:
 
@@ -128,7 +128,7 @@ Flags:
 |Flag|Default|Description|
 |---|---|---|
 |`-c`, `--config`|*no default*|Path to the config file.|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
 
 Arguments:
 

--- a/docs/pages/reference/cli/teleport.mdx
+++ b/docs/pages/reference/cli/teleport.mdx
@@ -59,8 +59,14 @@ Clones data from a source to a destination backend.
 Usage:
 
 ```code
-$ teleport backend clone
+$ teleport backend clone [<flags>]
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--config`|*no default*|Path to the config file.|
 
 ## teleport backend edit
 
@@ -69,8 +75,14 @@ Modify a single item from the cluster state backend.
 Usage:
 
 ```code
-$ teleport backend edit <key>
+$ teleport backend edit [<flags>] <key>
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--config`|*no default*|Path to the config file.|
 
 Arguments:
 
@@ -92,6 +104,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
+|`-c`, `--config`|*no default*|Path to the config file.|
 |`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
 
 Arguments:
@@ -114,6 +127,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
+|`-c`, `--config`|*no default*|Path to the config file.|
 |`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
 
 Arguments:
@@ -129,8 +143,14 @@ Removes a single item from the cluster state backend.
 Usage:
 
 ```code
-$ teleport backend rm <key>
+$ teleport backend rm [<flags>] <key>
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--config`|*no default*|Path to the config file.|
 
 Arguments:
 
@@ -349,8 +369,14 @@ Checks if the embedded session helper is working, if available in this build.
 Usage:
 
 ```code
-$ teleport debug check-session-helper
+$ teleport debug check-session-helper [<flags>]
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--config`|*no default*|Path to a configuration file \[/etc/teleport.yaml\].|
 
 ## teleport debug get-log-level
 
@@ -359,8 +385,14 @@ Fetches current log level.
 Usage:
 
 ```code
-$ teleport debug get-log-level
+$ teleport debug get-log-level [<flags>]
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--config`|*no default*|Path to a configuration file \[/etc/teleport.yaml\].|
 
 ## teleport debug metrics
 
@@ -369,8 +401,14 @@ Fetches the cluster's Prometheus metrics.
 Usage:
 
 ```code
-$ teleport debug metrics
+$ teleport debug metrics [<flags>]
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--config`|*no default*|Path to a configuration file \[/etc/teleport.yaml\].|
 
 ## teleport debug profile
 
@@ -387,6 +425,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
+|`-c`, `--config`|*no default*|Path to a configuration file \[/etc/teleport.yaml\].|
 |`-s`, `--seconds`|`0`|For CPU and trace profiles, profile for the given duration (if set to 0, it returns a profile snapshot). For other profiles, return a delta profile. Default: 0|
 
 Arguments:
@@ -402,8 +441,14 @@ Checks if the instance is ready to serve requests.
 Usage:
 
 ```code
-$ teleport debug readyz
+$ teleport debug readyz [<flags>]
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--config`|*no default*|Path to a configuration file \[/etc/teleport.yaml\].|
 
 ## teleport debug require-session-helper
 
@@ -413,8 +458,14 @@ this build.
 Usage:
 
 ```code
-$ teleport debug require-session-helper
+$ teleport debug require-session-helper [<flags>]
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--config`|*no default*|Path to a configuration file \[/etc/teleport.yaml\].|
 
 ## teleport debug set-log-level
 
@@ -423,8 +474,14 @@ Changes the log level.
 Usage:
 
 ```code
-$ teleport debug set-log-level <LEVEL>
+$ teleport debug set-log-level [<flags>] <LEVEL>
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--config`|*no default*|Path to a configuration file \[/etc/teleport.yaml\].|
 
 Arguments:
 

--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -26,26 +26,26 @@ Global flags:
 |Flag|Default|Description|
 |---|---|---|
 |`--auth`|*no default*|Specify the name of authentication connector to use.|
-|`--bind-addr`|*no default*|Override host:port used when opening a browser for cluster logins|
+|`--bind-addr`|*no default*|Override host:port used when opening a browser for cluster logins.|
 |`--callback`|*no default*|Override the base URL (host:port) of the link shown when opening a browser for cluster logins. Must be used with --bind-addr.|
-|`--cert-format`|*no default*|SSH certificate format|
+|`--cert-format`|*no default*|SSH certificate format.|
 |`-d`, `--[no-]debug`|`false`|Verbose logging to stdout.|
-|`-i`, `--identity`|*no default*|Identity file|
-|`-J`, `--jumphost`|*no default*|SSH jumphost|
+|`-i`, `--identity`|*no default*|Identity file.|
+|`-J`, `--jumphost`|*no default*|SSH jumphost.|
 |`-k`, `--add-keys-to-agent`|`auto`|Controls how keys are handled. Valid values are \[auto no yes only\].|
-|`-l`, `--login`|*no default*|Remote host login|
-|`--mfa-mode`|`auto` (one of: `auto`, `cross-platform`, `platform`, `otp`, `sso`, `browser`)|Preferred mode for MFA and Passwordless assertions.|
+|`-l`, `--login`|*no default*|Remote host login.|
+|`--mfa-mode`|`auto` (one of: `auto`, `cross-platform`, `platform`, `otp`, `sso`, `browser`)|Preferred mode for MFA and Passwordless assertions (auto, cross-platform, platform, otp, sso, browser).|
 |`--mlock`|`auto`|Determines whether process memory will be locked and whether failure to do so will be accepted (off, auto, best_effort, strict).|
 |`--[no-]enable-escape-sequences`|`true`|Enable support for SSH escape sequences. Type '~?' during an SSH session to list supported sequences. Default is enabled.|
 |`--[no-]headless`|`false`|Use headless login. Shorthand for --auth=headless.|
-|`--[no-]insecure`|`false`|Do not verify server's certificate and host name. Use only in test environments|
-|`--[no-]os-log`|`false`|Verbose logging to the unified logging system. This flag implies --debug. Also available through the TELEPORT_OS_LOG env var. https://goteleport.com/docs/connect-your-client/tsh/#debug-logs|
+|`--[no-]insecure`|`false`|Do not verify server's certificate and host name. Use only in test environments.|
+|`--[no-]os-log`|`false`|Verbose logging to the unified logging system. This flag implies --debug. Also available through the TELEPORT_OS_LOG env var. More details see https://goteleport.com/docs/connect-your-client/tsh/#debug-logs.|
 |`--[no-]skip-version-check`|`false`|Skip version checking between server and client.|
-|`--piv-slot`|*no default*|Specify a PIV slot key to use for Hardware Key support instead of the default. Ex: "9d"|
-|`--proxy`|*no default*|Teleport proxy address|
+|`--piv-slot`|*no default*|Specify a PIV slot key to use for Hardware Key support instead of the default. Ex: "9d".|
+|`--proxy`|*no default*|Teleport proxy address.|
 |`--relay`|*no default*|Teleport relay address, "none" to explicitly disable the use of a relay, or "default" to use the cluster-provided address even if a different address was specified at login time.|
-|`--ttl`|*no default*|Minutes to live for a session|
-|`--user`|*no default*|Teleport user, defaults to current local user|
+|`--ttl`|*no default*|Minutes to live for a session.|
+|`--user`|*no default*|Teleport user, defaults to current local user.|
 
 Global environment variables:
 
@@ -57,15 +57,15 @@ Global environment variables:
 |`TELEPORT_GLOBAL_TSH_CONFIG`|`none`|Override location of global `tsh` config file from default `/etc/tsh.yaml`|
 |`TELEPORT_HEADLESS`|`false`|Use headless login. Shorthand for --auth=headless.|
 |`TELEPORT_HOME`|`none`|Home location for tsh configuration and data|
-|`TELEPORT_IDENTITY_FILE`|*no default*|Identity file|
-|`TELEPORT_LOGIN`|*no default*|Remote host login|
-|`TELEPORT_LOGIN_BIND_ADDR`|*no default*|Override host:port used when opening a browser for cluster logins|
-|`TELEPORT_MFA_MODE`|`auto` (one of: `auto`, `cross-platform`, `platform`, `otp`, `sso`, `browser`)|Preferred mode for MFA and Passwordless assertions.|
+|`TELEPORT_IDENTITY_FILE`|*no default*|Identity file.|
+|`TELEPORT_LOGIN`|*no default*|Remote host login.|
+|`TELEPORT_LOGIN_BIND_ADDR`|*no default*|Override host:port used when opening a browser for cluster logins.|
+|`TELEPORT_MFA_MODE`|`auto` (one of: `auto`, `cross-platform`, `platform`, `otp`, `sso`, `browser`)|Preferred mode for MFA and Passwordless assertions (auto, cross-platform, platform, otp, sso, browser).|
 |`TELEPORT_MLOCK_MODE`|`auto`|Determines whether process memory will be locked and whether failure to do so will be accepted (off, auto, best_effort, strict).|
-|`TELEPORT_PIV_SLOT`|*no default*|Specify a PIV slot key to use for Hardware Key support instead of the default. Ex: "9d"|
-|`TELEPORT_PROXY`|*no default*|Teleport proxy address|
+|`TELEPORT_PIV_SLOT`|*no default*|Specify a PIV slot key to use for Hardware Key support instead of the default. Ex: "9d".|
+|`TELEPORT_PROXY`|*no default*|Teleport proxy address.|
 |`TELEPORT_RELAY`|*no default*|Teleport relay address, "none" to explicitly disable the use of a relay, or "default" to use the cluster-provided address even if a different address was specified at login time.|
-|`TELEPORT_USER`|*no default*|Teleport user, defaults to current local user|
+|`TELEPORT_USER`|*no default*|Teleport user, defaults to current local user.|
 
 ## tsh apps config
 
@@ -81,7 +81,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
 |`-f`, `--format`|*no default*|Optional print format, one of: "uri" to print app address, "ca" to print CA cert path, "cert" to print cert path, "key" print key path, "curl" to print example curl command, "json" or "yaml" to print everything as JSON or YAML.|
 
 Arguments:
@@ -112,9 +112,9 @@ Flags:
 |---|---|---|
 |`--aws-role`|*no default*|(For AWS CLI access only) Amazon IAM role ARN or role name.|
 |`--azure-identity`|*no default*|(For Azure CLI access only) Azure managed identity name.|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
 |`--gcp-service-account`|*no default*|(For GCP CLI access only) GCP service account name.|
-|`-q`, `--[no-]quiet`|`false`|Quiet mode|
+|`-q`, `--[no-]quiet`|`false`|Quiet mode.|
 |`--target-port`|*no default*|Port to which connections made using this cert should be routed to. Valid only for multi-port TCP apps.|
 |`-T`, `--[no-]interactive`|`false`|Prompt for AWS Roles interactively (--aws-role takes precedence).|
 
@@ -138,8 +138,8 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
 
 Arguments:
 
@@ -161,7 +161,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
 
 Arguments:
 
@@ -183,18 +183,18 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
-|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
+|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
 |`-R`, `--[no-]all`|`false`|List apps from all clusters and proxies.|
-|`--search`|*no default*|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase")|
+|`--search`|*no default*|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase").|
 |`-v`, `--[no-]verbose`|`false`|Show extra application fields.|
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|labels|*no default* (optional)|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
+|labels|*no default* (optional)|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
 
 ## tsh aws
 
@@ -212,7 +212,7 @@ Flags:
 |---|---|---|
 |`--app`|*no default*|Optional Name of the AWS application to use if logged into multiple.|
 |`--aws-role`|*no default*|(For AWS CLI access only) Amazon IAM role ARN or role name.|
-|`--exec`|*no default*|Execute different commands (e.g. terraform) under Teleport credentials|
+|`--exec`|*no default*|Execute different commands (e.g. terraform) under Teleport credentials.|
 
 Arguments:
 
@@ -275,7 +275,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
 |`--[no-]console`|`true`|Connect to the beam via SSH after creation.|
 
 ## tsh beams exec
@@ -309,7 +309,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
 |`--[no-]all`|`false`|List all beams. By default, filters to show only beams belonging to the current user.|
 
 ## tsh beams publish
@@ -326,7 +326,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
 |`--[no-]tcp`|`false`|Publish as a TCP app instead of an HTTP app.|
 
 Arguments:
@@ -365,7 +365,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
 |`-q`, `--[no-]quiet`|`false`|Quiet mode.|
 |`-r`, `--[no-]recursive`|`false`|Recursive copy of subdirectories.|
 
@@ -422,9 +422,9 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
-|`-q`, `--[no-]quiet`|`false`|Quiet mode|
-|`-v`, `--[no-]verbose`|`false`|Verbose table output, shows full label output|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
+|`-q`, `--[no-]quiet`|`false`|Quiet mode.|
+|`-v`, `--[no-]verbose`|`false`|Verbose table output, shows full label output.|
 
 ## tsh config
 
@@ -440,7 +440,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-p`, `--port`|*no default*|SSH port on a remote host|
+|`-p`, `--port`|*no default*|SSH port on a remote host.|
 
 ## tsh db config
 
@@ -456,10 +456,10 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
 |`-f`, `--format`|*no default* (one of: `text`, `cmd`, `json`, `yaml`)|Print format: "text" to print in table format (default), "cmd" to print connect command, "json" or "yaml" to print in JSON or YAML.|
-|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
-|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
+|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
+|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
 
 Arguments:
 
@@ -481,13 +481,13 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
-|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
+|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
 |`-n`, `--db-name`|*no default*|Database name to log in to.|
-|`--[no-]disable-access-request`|`false`|Disable automatic resource access requests|
-|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
+|`--[no-]disable-access-request`|`false`|Disable automatic resource access requests.|
+|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
 |`-r`, `--db-roles`|*no default*|List of comma separate database roles to use for auto-provisioned user.|
-|`--request-reason`|*no default*|Reason for requesting access|
+|`--request-reason`|*no default*|Reason for requesting access.|
 |`-u`, `--db-user`|*no default*|Database user to log in as.|
 
 Arguments:
@@ -510,16 +510,16 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
-|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
-|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
+|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
+|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|db|*no default* (optional)|Print environment for the specified database|
+|db|*no default* (optional)|Print environment for the specified database.|
 
 ## tsh db exec
 
@@ -535,15 +535,15 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
 |`--dbs`|*no default*|List of comma separated target database services. Mutually exclusive with --search or --labels.|
-|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
+|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
 |`-n`, `--db-name`|*no default*|Database name to log in to.|
 |`--[no-]confirm`|`true`|Confirm selected database services before executing command.|
 |`--output-dir`|*no default*|Directory to store command output per target database service. A summary is saved as "summary.json".|
 |`--parallel`|`1`|Run commands on target databases in parallel. Defaults to 1, and maximum allowed is 10.|
 |`-r`, `--db-roles`|*no default*|List of comma separate database roles to use for auto-provisioned user.|
-|`--search`|*no default*|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase")|
+|`--search`|*no default*|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase").|
 |`-u`, `--db-user`|*no default*|Database user to log in as.|
 
 Arguments:
@@ -566,13 +566,13 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
-|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
+|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
 |`-n`, `--db-name`|*no default*|Database name to configure as default.|
-|`--[no-]disable-access-request`|`false`|Disable automatic resource access requests|
-|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
+|`--[no-]disable-access-request`|`false`|Disable automatic resource access requests.|
+|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
 |`-r`, `--db-roles`|*no default*|List of comma separate database roles to use for auto-provisioned user.|
-|`--request-reason`|*no default*|Reason for requesting access|
+|`--request-reason`|*no default*|Reason for requesting access.|
 |`-u`, `--db-user`|*no default*|Database user to configure as default.|
 
 Arguments:
@@ -595,9 +595,9 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
-|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
-|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
+|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
+|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
 
 Arguments:
 
@@ -619,18 +619,18 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
-|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
+|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
 |`-R`, `--[no-]all`|`false`|List databases from all clusters and proxies.|
-|`--search`|*no default*|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase")|
+|`--search`|*no default*|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase").|
 |`-v`, `--[no-]verbose`|`false`|Show extra database fields.|
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|labels|*no default* (optional)|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
+|labels|*no default* (optional)|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
 
 ## tsh delegation create-session
 
@@ -672,7 +672,7 @@ Flags:
 |Flag|Default|Description|
 |---|---|---|
 |`--[no-]current-device`|`false`|Attempts to register and enroll the current device. Requires device admin privileges.|
-|`--token`|*no default*|Device enrollment token|
+|`--token`|*no default*|Device enrollment token.|
 
 ## tsh env
 
@@ -688,8 +688,8 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
-|`--[no-]unset`|`false`|Print commands to clear Teleport session environment variables|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
+|`--[no-]unset`|`false`|Print commands to clear Teleport session environment variables.|
 
 ## tsh gcloud
 
@@ -762,8 +762,8 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`--github-org`|*no default*|GitHub organization|
-|`--[no-]force`|`false`|Force a login|
+|`--github-org`|*no default*|GitHub organization.|
+|`--[no-]force`|`false`|Force a login.|
 
 ## tsh git ls
 
@@ -779,15 +779,15 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
-|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
-|`--search`|*no default*|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase")|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
+|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
+|`--search`|*no default*|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase").|
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|labels|*no default* (optional)|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
+|labels|*no default* (optional)|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
 
 ## tsh gsutil
 
@@ -826,19 +826,19 @@ Environment variables:
 
 |Variable|Default|Description|
 |---|---|---|
-|`TELEPORT_HEADLESS_SKIP_CONFIRM`|`false`|Skip confirmation and prompt for MFA immediately|
+|`TELEPORT_HEADLESS_SKIP_CONFIRM`|`false`|Skip confirmation and prompt for MFA immediately.|
 
 Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`--[no-]skip-confirm`|`false`|Skip confirmation and prompt for MFA immediately|
+|`--[no-]skip-confirm`|`false`|Skip confirmation and prompt for MFA immediately.|
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|request id|*no default* (optional)|Headless authentication request ID|
+|request id|*no default* (optional)|Headless authentication request ID.|
 
 ## tsh help
 
@@ -870,14 +870,14 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
 |`-m`, `--mode`|`observer` (one of: `observer`, `moderator`, `peer`)|Mode of joining the session, valid modes are observer, moderator and peer.|
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|session-id|*no default* (required)|ID of the session to join|
+|session-id|*no default* (required)|ID of the session to join.|
 
 ## tsh kube exec
 
@@ -893,22 +893,22 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--container`|*no default*|Container name. If omitted, use the kubectl.kubernetes.io/default-container annotation for selecting the container to be attached or the first container in the pod will be chosen|
-|`-f`, `--filename`|*no default*|to use to exec into the resource|
+|`-c`, `--container`|*no default*|Container name. If omitted, use the kubectl.kubernetes.io/default-container annotation for selecting the container to be attached or the first container in the pod will be chosen.|
+|`-f`, `--filename`|*no default*|To use to exec into the resource.|
 |`--invite`|*no default*|A comma separated list of people to mark as invited for the session.|
 |`-n`, `--namespace`|*no default*|Configure the default Kubernetes namespace.|
 |`--[no-]participant-req`|`false`|Displays a verbose list of required participants in a moderated session.|
-|`-q`, `--[no-]quiet`|`false`|Only print output from the remote session|
+|`-q`, `--[no-]quiet`|`false`|Only print output from the remote session.|
 |`--reason`|*no default*|The purpose of the session.|
-|`-s`, `--[no-]stdin`|`false`|Pass stdin to the container|
-|`-t`, `--[no-]tty`|`false`|Stdin is a TTY|
+|`-s`, `--[no-]stdin`|`false`|Pass stdin to the container.|
+|`-t`, `--[no-]tty`|`false`|Stdin is a TTY.|
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|command|*no default* (required)|Command to execute in the container|
-|target|*no default* (required)|Pod or deployment name|
+|command|*no default* (required)|Command to execute in the container.|
+|target|*no default* (required)|Pod or deployment name.|
 
 ## tsh kube join
 
@@ -924,7 +924,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
 |`-m`, `--mode`|`observer` (one of: `observer`, `moderator`, `peer`)|Mode of joining the session.|
 
 Arguments:
@@ -949,14 +949,14 @@ Flags:
 |---|---|---|
 |`--as`|*no default*|Configure custom Kubernetes user impersonation.|
 |`--as-groups`|*no default*|Configure custom Kubernetes group impersonation.|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
-|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
+|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
 |`-n`, `--namespace`|*no default*|Configure the default Kubernetes namespace.|
 |`--[no-]all`|`false`|Generate a kubeconfig with every cluster the user has access to. Mutually exclusive with --labels or --query.|
-|`--[no-]disable-access-request`|`false`|Disable automatic resource access requests|
-|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
-|`--request-reason`|*no default*|Reason for requesting access|
-|`--set-context-name`|`{{.ClusterName}}-{{.KubeName}}`|Define a custom context name. To use it with --all include "\{\{.KubeName\}\}"|
+|`--[no-]disable-access-request`|`false`|Disable automatic resource access requests.|
+|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
+|`--request-reason`|*no default*|Reason for requesting access.|
+|`--set-context-name`|`{{.ClusterName}}-{{.KubeName}}`|Define a custom context name. To use it with --all include "\{\{.KubeName\}\}".|
 
 Arguments:
 
@@ -978,24 +978,24 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
 |`-q`, `--[no-]quiet`|`false`|Quiet mode.|
-|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
+|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
 |`-R`, `--[no-]all`|`false`|List Kubernetes clusters from all clusters and proxies.|
-|`--search`|*no default*|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase")|
+|`--search`|*no default*|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase").|
 |`-v`, `--[no-]verbose`|`false`|Show an untruncated list of labels.|
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|labels|*no default* (optional)|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
+|labels|*no default* (optional)|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
 
 ## tsh kube sessions
 
 Get a list of active Kubernetes sessions. (DEPRECATED: use tsh sessions ls
---kind=kube instead)
+--kind=kube instead.)
 
 Usage:
 
@@ -1007,8 +1007,8 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
 
 ## tsh kubectl
 
@@ -1040,20 +1040,20 @@ Environment variables:
 
 |Variable|Default|Description|
 |---|---|---|
-|`TELEPORT_NO_RESUME`|`false`|Disable SSH connection resumption|
+|`TELEPORT_NO_RESUME`|`false`|Disable SSH connection resumption.|
 
 Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
-|`--[no-]no-resume`|`false`|Disable SSH connection resumption|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
+|`--[no-]no-resume`|`false`|Disable SSH connection resumption.|
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|[user@]host|*no default* (required)|Remote hostname and the login to use|
+|[user@]host|*no default* (required)|Remote hostname and the login to use.|
 
 ## tsh login
 
@@ -1069,24 +1069,24 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`--browser`|*no default*|Set to 'none' to suppress browser opening on login|
-|`-f`, `--format`|`file`|Identity format: file, openssh (for OpenSSH compatibility) or kubernetes (for kubeconfig)|
-|`--kube-cluster`|*no default*|Name of the Kubernetes cluster to login to|
+|`--browser`|*no default*|Set to 'none' to suppress browser opening on login.|
+|`-f`, `--format`|`file`|Identity format: file, openssh (for OpenSSH compatibility) or kubernetes (for kubeconfig).|
+|`--kube-cluster`|*no default*|Name of the Kubernetes cluster to login to.|
 |`--[no-]overwrite`|`false`|Whether to overwrite the existing identity file.|
-|`--[no-]request-nowait`|`false`|Finish without waiting for request resolution|
-|`-o`, `--out`|*no default*|Identity output|
-|`--request-id`|*no default*|Login with the roles requested in the given request|
-|`--request-reason`|*no default*|Reason for requesting additional roles|
-|`--request-reviewers`|*no default*|Suggested reviewers for role request|
-|`--request-roles`|*no default*|Request one or more extra roles|
+|`--[no-]request-nowait`|`false`|Finish without waiting for request resolution.|
+|`-o`, `--out`|*no default*|Identity output.|
+|`--request-id`|*no default*|Login with the roles requested in the given request.|
+|`--request-reason`|*no default*|Reason for requesting additional roles.|
+|`--request-reviewers`|*no default*|Suggested reviewers for role request.|
+|`--request-roles`|*no default*|Request one or more extra roles.|
 |`--scope`|*no default*|Scope pins credentials to a given scope. Use "" to explicitly remove scoping.|
-|`-v`, `--[no-]verbose`|`false`|Show extra status information|
+|`-v`, `--[no-]verbose`|`false`|Show extra status information.|
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|cluster|*no default* (optional)|Specify the Teleport cluster to connect|
+|cluster|*no default* (optional)|Specify the Teleport cluster to connect.|
 
 ## tsh logout
 
@@ -1112,18 +1112,18 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`, `names`)|Format output (text, json, yaml, names)|
-|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`, `names`)|Format output (text, json, yaml, names).|
+|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
 |`-R`, `--[no-]all`|`false`|List nodes from all clusters and proxies.|
-|`--search`|*no default*|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase")|
-|`-v`, `--[no-]verbose`|`false`|One-line output (for text format), including node UUIDs|
+|`--search`|*no default*|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase").|
+|`-v`, `--[no-]verbose`|`false`|One-line output (for text format), including node UUIDs.|
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|labels|*no default* (optional)|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
+|labels|*no default* (optional)|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
 
 ## tsh mcp config
 
@@ -1150,9 +1150,9 @@ Flags:
 |`--format`|*no default*|Format specifies the configuration format (claude, vscode, cursor). If not provided it will assume format from the configuration file, When no configuration file is provided it defaults to "claude".|
 |`-H`, `--header`|*no default*|Extra custom headers used for streamable HTTP MCP servers.|
 |`--json-format`|`auto` (one of: `pretty`, `compact`, `auto`, `none`)|Format the JSON file (pretty, compact, auto, none). auto saves in compact if the file is already compact, otherwise pretty. Can also be set with environment variable TELEPORT_MCP_CONFIG_JSON_FORMAT. Default is auto.|
-|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
+|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
 |`--[no-]auto-reconnect`|`false`|Automatically starts a new remote MCP session when the previous remote session is interrupted by network issues or tsh session expirations. Recommended for stateless MCP sessions. Defaults to true.|
-|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
+|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
 |`-R`, `--[no-]all`|`false`|Select all MCP servers. Mutually exclusive with --labels or --query.|
 
 Arguments:
@@ -1209,16 +1209,16 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
-|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
-|`--search`|*no default*|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase")|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
+|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
+|`--search`|*no default*|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase").|
 |`-v`, `--[no-]verbose`|`false`|Show extra MCP server fields.|
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|labels|*no default* (optional)|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
+|labels|*no default* (optional)|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
 
 ## tsh mfa add
 
@@ -1234,8 +1234,8 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`--name`|*no default*|Name of the new MFA device|
-|`--type`|*no default* (one of: `TOTP`, `WEBAUTHN`)|Type of the new MFA device (TOTP, WEBAUTHN)|
+|`--name`|*no default*|Name of the new MFA device.|
+|`--type`|*no default* (one of: `TOTP`, `WEBAUTHN`)|Type of the new MFA device (TOTP, WEBAUTHN).|
 
 ## tsh mfa ls
 
@@ -1251,8 +1251,8 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
-|`-v`, `--[no-]verbose`|`false`|Print more information about MFA devices|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
+|`-v`, `--[no-]verbose`|`false`|Print more information about MFA devices.|
 
 ## tsh mfa rm
 
@@ -1268,7 +1268,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|name|*no default* (required)|Name or ID of the MFA device to remove|
+|name|*no default* (required)|Name or ID of the MFA device to remove.|
 
 ## tsh piv agent
 
@@ -1294,8 +1294,8 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
-|`-f`, `--format`|`pty` (one of: `pty`, `json`, `yaml`, `text`)|Format output (pty, json, yaml, text)|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
+|`-f`, `--format`|`pty` (one of: `pty`, `json`, `yaml`, `text`)|Format output (pty, json, yaml, text).|
 |`--[no-]skip-idle-time`|`false`|Quickly skip over idle time, applicable when streaming SSH or Kubernetes sessions.|
 |`--speed`|`1x` (one of: `0.5x`, `1x`, `2x`, `4x`, `8x`)|Playback speed, applicable when streaming SSH or Kubernetes sessions.|
 
@@ -1303,7 +1303,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|session-id|*no default* (required)|ID or path to session file to play|
+|session-id|*no default* (required)|ID or path to session file to play.|
 
 ## tsh proxy app
 
@@ -1326,15 +1326,15 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
-|`-p`, `--port`|*no default*|Specifies the listening port used by the proxy app listener. Accepts an optional target port of a multi-port TCP app after a colon, e.g. "1234:5678"|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
+|`-p`, `--port`|*no default*|Specifies the listening port used by by the proxy app listener. Accepts an optional target port of a multi-port TCP app after a colon, e.g. "1234:5678".|
 |`--proxy-log-output`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|app|*no default* (required)|The name of the application to start local proxy for|
+|app|*no default* (required)|The name of the application to start local proxy for.|
 
 ## tsh proxy aws
 
@@ -1357,7 +1357,7 @@ Flags:
 |Flag|Default|Description|
 |---|---|---|
 |`--app`|*no default*|Optional Name of the AWS application to use if logged into multiple.|
-|`-f`, `--format`|`unix` (one of: `unix`, `command-prompt`, `powershell`, `text`, `athena-odbc`, `athena-jdbc`)|Optional format to print the commands for setting environment variables, one of: unix, command-prompt, powershell, text. Default is unix. Or specify a service format, one of: athena-odbc, athena-jdbc|
+|`-f`, `--format`|`unix` (one of: `unix`, `command-prompt`, `powershell`, `text`, `athena-odbc`, `athena-jdbc`)|Optional format to print the commands for setting environment variables, one of: unix, command-prompt, powershell, text. Default is unix. Or specify a service format, one of: athena-odbc, athena-jdbc.|
 |`-p`, `--port`|*no default*|Specifies the source port used by the proxy listener.|
 |`--proxy-log-output`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
 
@@ -1407,18 +1407,18 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
-|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
+|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
 |`--listen`|*no default*|Specifies the source address used by proxy db listener. Mutually exclusive with --port.|
 |`-n`, `--db-name`|*no default*|Database name to log in to.|
-|`--[no-]disable-access-request`|`false`|Disable automatic resource access requests|
+|`--[no-]disable-access-request`|`false`|Disable automatic resource access requests.|
 |`--[no-]insecure-listen-anywhere`|`false`|Allows the local proxy to listen on any address without restrictions. WARNING: this will expose unsecured listener to anyone in the network. Only use when network access is otherwise restricted.|
 |`--[no-]tunnel`|`false`|Open authenticated tunnel using database's client certificate so clients don't need to authenticate.|
 |`-p`, `--port`|*no default*|Specifies the source port used by proxy db listener.|
 |`--proxy-log-output`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
-|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
+|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
 |`-r`, `--db-roles`|*no default*|List of comma separate database roles to use for auto-provisioned user.|
-|`--request-reason`|*no default*|Reason for requesting access|
+|`--request-reason`|*no default*|Reason for requesting access.|
 |`-u`, `--db-user`|*no default*|Database user to log in as.|
 
 Arguments:
@@ -1474,16 +1474,16 @@ Flags:
 |---|---|---|
 |`--as`|*no default*|Configure custom Kubernetes user impersonation.|
 |`--as-groups`|*no default*|Configure custom Kubernetes group impersonation.|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
 |`--exec-arg`|*no default*|Arguments to pass to the executed command (can be specified multiple times).|
 |`--exec-cmd`|*no default*|Command to execute when --exec is enabled. If not specified, defaults to $SHELL or /bin/bash. Implicitly enables exec mode.|
 |`-f`, `--format`|`unix` (one of: `unix`, `command-prompt`, `powershell`, `text`)|Optional format to print the commands for setting environment variables, one of: unix, command-prompt, powershell, text. Default is unix.|
-|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
+|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
 |`-n`, `--namespace`|*no default*|Configure the default Kubernetes namespace.|
 |`--[no-]exec`|`false`|Run the proxy in the background and reexec into a new shell with $KUBECONFIG already pointed to our config file.|
-|`-p`, `--port`|*no default*|Specifies the source port used by the proxy listener|
+|`-p`, `--port`|*no default*|Specifies the source port used by the proxy listener.|
 |`--proxy-log-output`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
-|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
+|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
 |`--set-context-name`|`{{.ClusterName}}-{{.KubeName}}`|Define a custom context name or template.|
 
 Arguments:
@@ -1512,7 +1512,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
 |`-p`, `--port`|*no default*|Specifies the listening port used by the proxy app listener.|
 |`--proxy-log-output`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
 
@@ -1537,23 +1537,23 @@ Environment variables:
 
 |Variable|Default|Description|
 |---|---|---|
-|`TELEPORT_NO_RESUME`|`false`|Disable SSH connection resumption|
+|`TELEPORT_NO_RESUME`|`false`|Disable SSH connection resumption.|
 |`TELEPORT_PROXY_LOG_OUTPUT`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
 
 Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
-|`--[no-]no-resume`|`false`|Disable SSH connection resumption|
-|`--[no-]relogin`|`true`|Permit performing an authentication attempt on a failed command|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
+|`--[no-]no-resume`|`false`|Disable SSH connection resumption.|
+|`--[no-]relogin`|`true`|Permit performing an authentication attempt on a failed command.|
 |`--proxy-log-output`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|[user@]host|*no default* (required)|Remote hostname and the login to use|
+|[user@]host|*no default* (required)|Remote hostname and the login to use.|
 
 ## tsh recordings export
 
@@ -1569,13 +1569,13 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`--out`|*no default*|Override output file name|
+|`--out`|*no default*|Override output file name.|
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|session-id|*no default* (required)|ID of the session to export|
+|session-id|*no default* (required)|ID of the session to export.|
 
 ## tsh recordings ls
 
@@ -1593,7 +1593,7 @@ Flags:
 |---|---|---|
 |`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml). Defaults to 'text'.|
 |`--from-utc`|*no default*|Start of time range in which recordings are listed. Format 2006-01-02. Defaults to 24 hours ago.|
-|`--last`|*no default*|Duration into the past from which session recordings should be listed. Format 5h30m40s|
+|`--last`|*no default*|Duration into the past from which session recordings should be listed. Format "5h30m40s".|
 |`--limit`|`50`|Maximum number of recordings to show. Default 50.|
 |`--to-utc`|*no default*|End of time range in which recordings are listed. Format 2006-01-02. Defaults to current time.|
 
@@ -1611,15 +1611,15 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`--assume-start-time`|*no default*|Sets time roles can be assumed by requestor (RFC3339 e.g 2023-12-12T23:20:50.52Z)|
-|`--max-duration`|*no default*|How long the access should be granted for|
-|`--[no-]nowait`|`false`|Finish without waiting for request resolution|
-|`--reason`|*no default*|Reason for requesting|
-|`--request-ttl`|*no default*|Expiration time for the access request|
-|`--resource`|*no default*|Resource ID to be requested|
-|`--reviewers`|*no default*|Suggested reviewers|
-|`--roles`|*no default*|Roles to be requested|
-|`--session-ttl`|*no default*|Expiration time for the elevated certificate|
+|`--assume-start-time`|*no default*|Sets time roles can be assumed by requestor (RFC3339 e.g 2023-12-12T23:20:50.52Z).|
+|`--max-duration`|*no default*|How long the access should be granted for.|
+|`--[no-]nowait`|`false`|Finish without waiting for request resolution.|
+|`--reason`|*no default*|Reason for requesting.|
+|`--request-ttl`|*no default*|Expiration time for the access request.|
+|`--resource`|*no default*|Resource ID to be requested.|
+|`--reviewers`|*no default*|Suggested reviewers.|
+|`--roles`|*no default*|Roles to be requested.|
+|`--session-ttl`|*no default*|Expiration time for the elevated certificate.|
 
 ## tsh request drop
 
@@ -1635,7 +1635,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|request-id|`*` (optional)|IDs of requests to drop (default drops all requests)|
+|request-id|`*` (optional)|IDs of requests to drop (default drops all requests).|
 
 ## tsh request ls
 
@@ -1651,10 +1651,10 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
-|`--[no-]my-requests`|`false`|Only show requests created by current user|
-|`--[no-]reviewable`|`false`|Only show requests reviewable by current user|
-|`--[no-]suggested`|`false`|Only show requests that suggest current user as reviewer|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
+|`--[no-]my-requests`|`false`|Only show requests created by current user.|
+|`--[no-]reviewable`|`false`|Only show requests reviewable by current user.|
+|`--[no-]suggested`|`false`|Only show requests that suggest current user as reviewer.|
 
 ## tsh request review
 
@@ -1670,16 +1670,16 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`--assume-start-time`|*no default*|Sets time roles can be assumed by requestor (RFC3339 e.g 2023-12-12T23:20:50.52Z)|
-|`--[no-]approve`|`false`|Review proposes approval|
-|`--[no-]deny`|`false`|Review proposes denial|
-|`--reason`|*no default*|Review reason message|
+|`--assume-start-time`|*no default*|Sets time roles can be assumed by requestor (RFC3339 e.g 2023-12-12T23:20:50.52Z).|
+|`--[no-]approve`|`false`|Review proposes approval.|
+|`--[no-]deny`|`false`|Review proposes denial.|
+|`--reason`|*no default*|Review reason message.|
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|request-id|*no default* (required)|ID of target request|
+|request-id|*no default* (required)|ID of target request.|
 
 ## tsh request search
 
@@ -1695,18 +1695,18 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
 |`--kind`|*no default*|Resource kind to search for (node, kube_cluster, kube_resource, db, app, windows_desktop, user_group, saml_idp_service_provider, aws_ic_account, aws_ic_account_assignment, git_server).  Mutually exclusive with --roles.|
 |`--kube-api-group`|*no default*|Kubernetes API group to search for resources.|
-|`--kube-cluster`|*no default*|Kubernetes Cluster to search for Pods|
+|`--kube-cluster`|*no default*|Kubernetes Cluster to search for Pods.|
 |`--kube-kind`|*no default*|Kubernetes resource kind name (plural) to search for. Required with --kind="kube_resource" Ex: pods, deployments, namespaces, etc.|
-|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
-|`--namespace`|`default`|Kubernetes Namespace to search for Pods|
-|`--[no-]all-kube-namespaces`|`false`|Search Pods in every namespace|
+|`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
+|`--namespace`|`default`|Kubernetes Namespace to search for Pods.|
+|`--[no-]all-kube-namespaces`|`false`|Search Pods in every namespace.|
 |`--[no-]roles`|`false`|List requestable roles instead of searching for resources. Mutually exclusive with --kind.|
-|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
-|`--search`|*no default*|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase")|
-|`-v`, `--[no-]verbose`|`false`|Verbose table output, shows full label output|
+|`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
+|`--search`|*no default*|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase").|
+|`-v`, `--[no-]verbose`|`false`|Verbose table output, shows full label output.|
 
 ## tsh request show
 
@@ -1722,13 +1722,13 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|request-id|*no default* (required)|ID of the target request|
+|request-id|*no default* (required)|ID of the target request.|
 
 ## tsh resolve
 
@@ -1744,14 +1744,14 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
-|`-q`, `--[no-]quiet`|`false`|Quiet mode|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
+|`-q`, `--[no-]quiet`|`false`|Quiet mode.|
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|host|*no default* (required)|Remote hostname to resolve|
+|host|*no default* (required)|Remote hostname to resolve.|
 
 ## tsh scan keys
 
@@ -1800,25 +1800,25 @@ Environment variables:
 
 |Variable|Default|Description|
 |---|---|---|
-|`TELEPORT_NO_RESUME`|`false`|Disable SSH connection resumption|
+|`TELEPORT_NO_RESUME`|`false`|Disable SSH connection resumption.|
 
 Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
-|`--[no-]no-resume`|`false`|Disable SSH connection resumption|
-|`--[no-]relogin`|`true`|Permit performing an authentication attempt on a failed command|
-|`-p`, `--[no-]preserve`|`false`|Preserves access and modification times from the original file|
-|`-P`, `--port`|*no default*|Port to connect to on the remote host|
-|`-q`, `--[no-]quiet`|`false`|Quiet mode|
-|`-r`, `--[no-]recursive`|`false`|Recursive copy of subdirectories|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
+|`--[no-]no-resume`|`false`|Disable SSH connection resumption.|
+|`--[no-]relogin`|`true`|Permit performing an authentication attempt on a failed command.|
+|`-p`, `--[no-]preserve`|`false`|Preserves access and modification times from the original file.|
+|`-P`, `--port`|*no default*|Port to connect to on the remote host.|
+|`-q`, `--[no-]quiet`|`false`|Quiet mode.|
+|`-r`, `--[no-]recursive`|`false`|Recursive copy of subdirectories.|
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|from, to|*no default* (required)|Source and destination to copy, one must be a local path and one must be a remote path|
+|from, to|*no default* (required)|Source and destination to copy, one must be a local path and one must be a remote path.|
 
 ## tsh sessions ls
 
@@ -1834,8 +1834,8 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
-|`--kind`|`ssh`,`k8s`,`db`,`app`,`desktop` (any of (repeatable): `ssh`, `k8s`, `kube`, `db`, `app`, `desktop`)|Filter by session kind(s)|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
+|`--kind`|`ssh`,`k8s`,`db`,`app`,`desktop` (any of (repeatable): `ssh`, `k8s`, `kube`, `db`, `app`, `desktop`)|Filter by session kind(s).|
 
 ## tsh ssh
 
@@ -1851,43 +1851,43 @@ Environment variables:
 
 |Variable|Default|Description|
 |---|---|---|
-|`TELEPORT_NO_RESUME`|`false`|Disable SSH connection resumption|
-|`TELEPORT_REQUEST_MODE`|`resource` (one of: `off`, `resource`, `role`)|Type of automatic access request to make (off, resource, role)|
+|`TELEPORT_NO_RESUME`|`false`|Disable SSH connection resumption.|
+|`TELEPORT_REQUEST_MODE`|`resource` (one of: `off`, `resource`, `role`)|Type of automatic access request to make (off, resource, role).|
 
 Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-A`, `--[no-]forward-agent`|`false`|Forward agent to target node|
-|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
-|`-D`, `--dynamic-forward`|*no default*|Forward localhost connections to remote server using SOCKS5|
+|`-A`, `--[no-]forward-agent`|`false`|Forward agent to target node.|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect.|
+|`-D`, `--dynamic-forward`|*no default*|Forward localhost connections to remote server using SOCKS5.|
 |`-f`, `--[no-]fork-after-authentication`|`false`|Run in background after authentication is complete.|
 |`--invite`|*no default*|A comma separated list of people to mark as invited for the session.|
-|`-L`, `--forward`|*no default*|Forward localhost connections to remote server|
+|`-L`, `--forward`|*no default*|Forward localhost connections to remote server.|
 |`--log-dir`|*no default*|Directory to log separated command output, when executing on multiple nodes. If set, output from each node will also be labeled in the terminal.|
-|`-N`, `--[no-]no-remote-exec`|`false`|Don't execute remote command, useful for port forwarding|
-|`--[no-]disable-access-request`|`false`|Disable automatic resource access requests (DEPRECATED: use --request-mode=off)|
-|`--[no-]local`|`false`|Execute command on localhost after connecting to SSH node|
-|`--[no-]no-resume`|`false`|Disable SSH connection resumption|
+|`-N`, `--[no-]no-remote-exec`|`false`|Don't execute remote command, useful for port forwarding.|
+|`--[no-]disable-access-request`|`false`|Disable automatic resource access requests (DEPRECATED: use --request-mode=off).|
+|`--[no-]local`|`false`|Execute command on localhost after connecting to SSH node.|
+|`--[no-]no-resume`|`false`|Disable SSH connection resumption.|
 |`--[no-]participant-req`|`false`|Displays a verbose list of required participants in a moderated session.|
-|`--[no-]relogin`|`true`|Permit performing an authentication attempt on a failed command|
-|`-o`, `--option`|*no default*|OpenSSH options in the format used in the configuration file|
-|`-p`, `--port`|*no default*|SSH port on a remote host|
+|`--[no-]relogin`|`true`|Permit performing an authentication attempt on a failed command.|
+|`-o`, `--option`|*no default*|OpenSSH options in the format used in the configuration file.|
+|`-p`, `--port`|*no default*|SSH port on a remote host.|
 |`--reason`|*no default*|The purpose of the session.|
-|`--request-mode`|`resource` (one of: `off`, `resource`, `role`)|Type of automatic access request to make (off, resource, role)|
-|`--request-reason`|*no default*|Reason for requesting access|
-|`-R`, `--remote-forward`|*no default*|Forward remote connections to localhost|
-|`-t`, `--[no-]tty`|`false`|Allocate TTY|
-|`--x11-untrusted-timeout`|`10m`|Sets a timeout for untrusted X11 forwarding, after which the client will reject any forwarding requests from the server|
-|`-X`, `--[no-]x11-untrusted`|`false`|Requests untrusted (secure) X11 forwarding for this session|
-|`-Y`, `--[no-]x11-trusted`|`false`|Requests trusted (insecure) X11 forwarding for this session. This can make your local machine vulnerable to attacks, use with caution|
+|`--request-mode`|`resource` (one of: `off`, `resource`, `role`)|Type of automatic access request to make (off, resource, role).|
+|`--request-reason`|*no default*|Reason for requesting access.|
+|`-R`, `--remote-forward`|*no default*|Forward remote connections to localhost.|
+|`-t`, `--[no-]tty`|`false`|Allocate TTY.|
+|`--x11-untrusted-timeout`|`10m`|Sets a timeout for untrusted X11 forwarding, after which the client will reject any forwarding requests from the server.|
+|`-X`, `--[no-]x11-untrusted`|`false`|Requests untrusted (secure) X11 forwarding for this session.|
+|`-Y`, `--[no-]x11-trusted`|`false`|Requests trusted (insecure) X11 forwarding for this session. This can make your local machine vulnerable to attacks, use with caution.|
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|command|*no default* (optional)|Command to execute on a remote host|
-|[user@]host|*no default* (optional)|Remote hostname and the login to use, this argument is required|
+|command|*no default* (optional)|Command to execute on a remote host.|
+|[user@]host|*no default* (optional)|Remote hostname and the login to use, this argument is required.|
 
 ## tsh status
 
@@ -1903,7 +1903,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
 |`--[no-]client`|`false`|Show client information only (no server required).|
 |`-v`, `--[no-]verbose`|`false`|Show extra status information after successful login.|
 
@@ -1965,7 +1965,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
 |`--[no-]client`|`false`|Show the client version only (no server required).|
 
 ## tsh vnet
@@ -2027,6 +2027,6 @@ Flags:
 |---|---|---|
 |`--credential-ttl`|`1h`|Sets the time to live for the credential.|
 |`--label-selector`|*no default*|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.|
-|`--name-selector`|*no default*|The name of the workload identity to issue|
+|`--name-selector`|*no default*|The name of the workload identity to issue.|
 |`--output`|*no default*|Path to the directory to write the SVID into.|
 

--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -81,6 +81,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
 |`-f`, `--format`|*no default*|Optional print format, one of: "uri" to print app address, "ca" to print CA cert path, "cert" to print cert path, "key" print key path, "curl" to print example curl command, "json" or "yaml" to print everything as JSON or YAML.|
 
 Arguments:
@@ -111,6 +112,7 @@ Flags:
 |---|---|---|
 |`--aws-role`|*no default*|(For AWS CLI access only) Amazon IAM role ARN or role name.|
 |`--azure-identity`|*no default*|(For Azure CLI access only) Azure managed identity name.|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
 |`--gcp-service-account`|*no default*|(For GCP CLI access only) GCP service account name.|
 |`-q`, `--[no-]quiet`|`false`|Quiet mode|
 |`--target-port`|*no default*|Port to which connections made using this cert should be routed to. Valid only for multi-port TCP apps.|
@@ -136,6 +138,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
 |`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
 
 Arguments:
@@ -151,8 +154,14 @@ Remove app certificate.
 Usage:
 
 ```code
-$ tsh apps logout [<app>]
+$ tsh apps logout [<flags>] [<app>]
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
 
 Arguments:
 
@@ -174,6 +183,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
 |`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
 |`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
 |`-R`, `--[no-]all`|`false`|List apps from all clusters and proxies.|
@@ -446,6 +456,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
 |`-f`, `--format`|*no default* (one of: `text`, `cmd`, `json`, `yaml`)|Print format: "text" to print in table format (default), "cmd" to print connect command, "json" or "yaml" to print in JSON or YAML.|
 |`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
 |`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
@@ -470,6 +481,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
 |`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
 |`-n`, `--db-name`|*no default*|Database name to log in to.|
 |`--[no-]disable-access-request`|`false`|Disable automatic resource access requests|
@@ -498,6 +510,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
 |`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
 |`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
 |`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
@@ -522,6 +535,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
 |`--dbs`|*no default*|List of comma separated target database services. Mutually exclusive with --search or --labels.|
 |`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
 |`-n`, `--db-name`|*no default*|Database name to log in to.|
@@ -552,6 +566,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
 |`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
 |`-n`, `--db-name`|*no default*|Database name to configure as default.|
 |`--[no-]disable-access-request`|`false`|Disable automatic resource access requests|
@@ -580,6 +595,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
 |`--labels`|*no default*|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
 |`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
 
@@ -603,6 +619,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
+|`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
 |`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml)|
 |`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
 |`-R`, `--[no-]all`|`false`|List databases from all clusters and proxies.|
@@ -1299,12 +1316,19 @@ Usage:
 $ tsh proxy app [<flags>] <app>
 ```
 
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_PROXY_LOG_OUTPUT`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
+
 Flags:
 
 |Flag|Default|Description|
 |---|---|---|
 |`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
 |`-p`, `--port`|*no default*|Specifies the listening port used by the proxy app listener. Accepts an optional target port of a multi-port TCP app after a colon, e.g. "1234:5678"|
+|`--proxy-log-output`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
 
 Arguments:
 
@@ -1322,6 +1346,12 @@ Usage:
 $ tsh proxy aws [<flags>]
 ```
 
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_PROXY_LOG_OUTPUT`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
+
 Flags:
 
 |Flag|Default|Description|
@@ -1329,6 +1359,7 @@ Flags:
 |`--app`|*no default*|Optional Name of the AWS application to use if logged into multiple.|
 |`-f`, `--format`|`unix` (one of: `unix`, `command-prompt`, `powershell`, `text`, `athena-odbc`, `athena-jdbc`)|Optional format to print the commands for setting environment variables, one of: unix, command-prompt, powershell, text. Default is unix. Or specify a service format, one of: athena-odbc, athena-jdbc|
 |`-p`, `--port`|*no default*|Specifies the source port used by the proxy listener.|
+|`--proxy-log-output`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
 
 ## tsh proxy azure
 
@@ -1340,6 +1371,12 @@ Usage:
 $ tsh proxy azure [<flags>]
 ```
 
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_PROXY_LOG_OUTPUT`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
+
 Flags:
 
 |Flag|Default|Description|
@@ -1347,6 +1384,7 @@ Flags:
 |`--app`|*no default*|Optional Name of the Azure application to use if logged into multiple.|
 |`-f`, `--format`|`unix` (one of: `unix`, `command-prompt`, `powershell`, `text`)|Optional format to print the commands for setting environment variables, one of: unix, command-prompt, powershell, text. Default is unix.|
 |`-p`, `--port`|*no default*|Specifies the source port used by the proxy listener.|
+|`--proxy-log-output`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
 
 ## tsh proxy db
 
@@ -1358,6 +1396,12 @@ Usage:
 ```code
 $ tsh proxy db [<flags>] [<db>]
 ```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_PROXY_LOG_OUTPUT`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
 
 Flags:
 
@@ -1371,6 +1415,7 @@ Flags:
 |`--[no-]insecure-listen-anywhere`|`false`|Allows the local proxy to listen on any address without restrictions. WARNING: this will expose unsecured listener to anyone in the network. Only use when network access is otherwise restricted.|
 |`--[no-]tunnel`|`false`|Open authenticated tunnel using database's client certificate so clients don't need to authenticate.|
 |`-p`, `--port`|*no default*|Specifies the source port used by proxy db listener.|
+|`--proxy-log-output`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
 |`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
 |`-r`, `--db-roles`|*no default*|List of comma separate database roles to use for auto-provisioned user.|
 |`--request-reason`|*no default*|Reason for requesting access|
@@ -1392,6 +1437,12 @@ Usage:
 $ tsh proxy gcloud [<flags>]
 ```
 
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_PROXY_LOG_OUTPUT`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
+
 Flags:
 
 |Flag|Default|Description|
@@ -1399,6 +1450,7 @@ Flags:
 |`--app`|*no default*|Optional Name of the GCP application to use if logged into multiple.|
 |`-f`, `--format`|`unix` (one of: `unix`, `command-prompt`, `powershell`, `text`)|Optional format to print the commands for setting environment variables, one of: unix, command-prompt, powershell, text. Default is unix.|
 |`-p`, `--port`|*no default*|Specifies the source port used by the proxy listener.|
+|`--proxy-log-output`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
 
 ## tsh proxy kube
 
@@ -1409,6 +1461,12 @@ Usage:
 ```code
 $ tsh proxy kube [<flags>] [<kube-cluster>...]
 ```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_PROXY_LOG_OUTPUT`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
 
 Flags:
 
@@ -1424,6 +1482,7 @@ Flags:
 |`-n`, `--namespace`|*no default*|Configure the default Kubernetes namespace.|
 |`--[no-]exec`|`false`|Run the proxy in the background and reexec into a new shell with $KUBECONFIG already pointed to our config file.|
 |`-p`, `--port`|*no default*|Specifies the source port used by the proxy listener|
+|`--proxy-log-output`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
 |`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
 |`--set-context-name`|`{{.ClusterName}}-{{.KubeName}}`|Define a custom context name or template.|
 
@@ -1443,12 +1502,19 @@ Usage:
 $ tsh proxy mcp [<flags>] <app>
 ```
 
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_PROXY_LOG_OUTPUT`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
+
 Flags:
 
 |Flag|Default|Description|
 |---|---|---|
 |`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
 |`-p`, `--port`|*no default*|Specifies the listening port used by the proxy app listener.|
+|`--proxy-log-output`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
 
 Arguments:
 
@@ -1472,6 +1538,7 @@ Environment variables:
 |Variable|Default|Description|
 |---|---|---|
 |`TELEPORT_NO_RESUME`|`false`|Disable SSH connection resumption|
+|`TELEPORT_PROXY_LOG_OUTPUT`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
 
 Flags:
 
@@ -1480,6 +1547,7 @@ Flags:
 |`-c`, `--cluster`|*no default*|Specify the Teleport cluster to connect|
 |`--[no-]no-resume`|`false`|Disable SSH connection resumption|
 |`--[no-]relogin`|`true`|Permit performing an authentication attempt on a failed command|
+|`--proxy-log-output`|`stderr` (one of: `stdout`, `stderr`, `none`)|Select where proxy status messages are printed. Defaults to "stderr", but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are "stdout", "stderr", and "none".|
 
 Arguments:
 

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -938,7 +938,7 @@ var DefaultFormats = []string{teleport.Text, teleport.JSON, teleport.YAML}
 
 // FormatFlagDescription creates the description for the --format flag.
 func FormatFlagDescription(formats ...string) string {
-	return fmt.Sprintf("Format output (%s)", strings.Join(formats, ", "))
+	return fmt.Sprintf("Format output (%s).", strings.Join(formats, ", "))
 }
 
 func SearchSessionRange(clock clockwork.Clock, fromUTC, toUTC, recordingsSince string) (from time.Time, to time.Time, err error) {

--- a/lib/utils/docs-usage.md.tmpl
+++ b/lib/utils/docs-usage.md.tmpl
@@ -1,5 +1,6 @@
 {{define "FormatCommand" -}}
-{{if .Flags|AnyVisibleFlags}}{{if .FlagSummary }} {{.FlagSummary}}{{end}}{{end -}}
+{{$flags := EffectiveFlags . -}}
+{{if $flags|AnyVisibleFlags}}{{if $flags|FlagSummary }} {{ $flags|FlagSummary }}{{end}}{{end -}}
     {{range .Args}}{{if not .Hidden}} {{ .|FormatUsageArg}}{{end}}{{end -}}
 {{end -}}
 
@@ -16,21 +17,22 @@ Usage:
 $ {{$appName}} {{.FullCommand}}{{template "FormatCommand" .}}
 ```
 
-{{if AnyEnvVarsForCmd .Args .Flags -}}
+{{$flags := EffectiveFlags . -}}
+{{if AnyEnvVarsForCmd .Args $flags -}}
 Environment variables:
 
 |Variable|Default|Description|
 |---|---|---|
-{{- EnvVarsToRows .Args .Flags|FormatThreeColMarkdownTable}}
+{{- EnvVarsToRows .Args $flags|FormatThreeColMarkdownTable}}
 
 {{end -}}
 
-{{ if .Flags|AnyVisibleFlags -}}
+{{ if $flags|AnyVisibleFlags -}}
 Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-{{- (ReplaceFlagDefaults (printf "%v %v" $appName .FullCommand) .Flags)|FlagsToRows|FormatThreeColMarkdownTable }}
+{{- (ReplaceFlagDefaults (printf "%v %v" $appName .FullCommand) $flags)|FlagsToRows|FormatThreeColMarkdownTable }}
 
 {{end -}}
 {{ if .Args -}}

--- a/lib/utils/testutils/kingpin.go
+++ b/lib/utils/testutils/kingpin.go
@@ -1,0 +1,97 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package testutils
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/alecthomas/kingpin/v2"
+)
+
+func checkKingpinHelp(help, where string) (issues []KingpinHelpIssue) {
+	// Some hidden flags are empty.
+	if help == "" {
+		return nil
+	}
+
+	// Help should end with `.`, or `.)` in case the sentence is in brackets.
+	if !strings.HasSuffix(help, ".") && !strings.HasSuffix(help, ".)") {
+		issues = append(issues, KingpinHelpIssue{
+			Where: where,
+			Value: help,
+			Issue: "help is missing period",
+		})
+	}
+
+	// Help should start with upper case letter.
+	if unicode.IsLower(rune(help[0])) {
+		issues = append(issues, KingpinHelpIssue{
+			Where: where,
+			Value: help,
+			Issue: "help starts with lower case letter",
+		})
+	}
+	return
+}
+
+func checkKingpinCmdHelps(cmd *kingpin.CmdModel) (issues []KingpinHelpIssue) {
+	cmdWhere := fmt.Sprintf("command %q", cmd.FullCommand)
+	issues = append(issues, checkKingpinHelp(cmd.Help, cmdWhere)...)
+
+	for _, arg := range cmd.Args {
+		where := fmt.Sprintf("%s arg %q", cmdWhere, arg.Name)
+		issues = append(issues, checkKingpinHelp(arg.Help, where)...)
+	}
+	for _, flag := range cmd.Flags {
+		where := fmt.Sprintf("%s flag %q", cmdWhere, flag.Name)
+		issues = append(issues, checkKingpinHelp(flag.Help, where)...)
+	}
+	for _, subCmd := range cmd.Commands {
+		issues = append(issues, checkKingpinCmdHelps(subCmd)...)
+	}
+	return issues
+}
+
+type KingpinHelpIssue struct {
+	Where string
+	Value string
+	Issue string
+}
+
+func (i KingpinHelpIssue) String() string {
+	return fmt.Sprintf("%s %s: %s", i.Where, i.Issue, i.Value)
+}
+
+// FindKingpinAppHelpIssues checks common app issues like help description
+// missing periods.
+func FindKingpinAppHelpIssues(app *kingpin.Application) []KingpinHelpIssue {
+	appModel := app.Model()
+	// convert appModel to CmdModel.
+	cmdProxy := &kingpin.CmdModel{
+		Name:           appModel.Name,
+		Help:           appModel.Help,
+		FullCommand:    appModel.Name,
+		ArgGroupModel:  appModel.ArgGroupModel,
+		FlagGroupModel: appModel.FlagGroupModel,
+		CmdGroupModel:  appModel.CmdGroupModel,
+	}
+	return checkKingpinCmdHelps(cmdProxy)
+}

--- a/lib/utils/usage_docs.go
+++ b/lib/utils/usage_docs.go
@@ -103,6 +103,10 @@ func anyVisibleFlags(f []*kingpin.FlagModel) bool {
 	})
 }
 
+func flagSummary(flags []*kingpin.FlagModel) string {
+	return (&kingpin.FlagGroupModel{Flags: flags}).FlagSummary()
+}
+
 // anyEnvVarsForCmd indicates whether at least one of the arguments and flags
 // provided exposes an environment variable for configuration.
 func anyEnvVarsForCmd(args []*kingpin.ArgModel, flags []*kingpin.FlagModel) bool {
@@ -184,6 +188,53 @@ func sortCommandsByName(cmds []*kingpin.CmdModel) []*kingpin.CmdModel {
 		}
 	})
 	return cmds
+}
+
+// makeEffectiveFlags returns the flags available to each command, including
+// flags declared on its non-global ancestors.
+func makeEffectiveFlags(app *kingpin.ApplicationModel) func(any) []*kingpin.FlagModel {
+	effectiveFlags := make(map[string][]*kingpin.FlagModel)
+
+	var visit func([]*kingpin.CmdModel, []*kingpin.FlagModel)
+	visit = func(commands []*kingpin.CmdModel, inherited []*kingpin.FlagModel) {
+		for _, command := range commands {
+			flags := mergeFlags(inherited, command.Flags)
+			effectiveFlags[command.FullCommand] = flags
+			visit(command.Commands, flags)
+		}
+	}
+	visit(app.Commands, nil)
+
+	return func(model any) []*kingpin.FlagModel {
+		switch command := model.(type) {
+		case *kingpin.ApplicationModel:
+			return command.Flags
+		case *kingpin.CmdModel:
+			return effectiveFlags[command.FullCommand]
+		default:
+			return nil
+		}
+	}
+}
+
+// mergeFlags combines flags from two kingpin FlagModels. It gets called on a
+// command's flags and those of its ancestor commands to build the command's
+// final effective flags.
+func mergeFlags(inherited, declared []*kingpin.FlagModel) []*kingpin.FlagModel {
+	flags := slices.Clone(inherited)
+	indices := make(map[string]int, len(flags))
+	for i, flag := range flags {
+		indices[flag.Name] = i
+	}
+	for _, flag := range declared {
+		if index, ok := indices[flag.Name]; ok {
+			flags[index] = flag
+			continue
+		}
+		indices[flag.Name] = len(flags)
+		flags = append(flags, flag)
+	}
+	return flags
 }
 
 const noDefaultSet = "*no default*"
@@ -365,6 +416,7 @@ func updateAppUsageTemplate(r io.Reader, config generatorConfig, app *kingpin.Ap
 
 	replaceFlagDefaults := makeDefaultFlagValueOverrider(config.FlagDefaultOverrides)
 	replaceArgDefaults := makeDefaultArgValueOverrider(config.ArgDefaultOverrides)
+	effectiveFlags := makeEffectiveFlags(app.Model())
 
 	// We override the default app description with a custom description
 	// that is better suited to the docs.
@@ -376,8 +428,10 @@ func updateAppUsageTemplate(r io.Reader, config generatorConfig, app *kingpin.Ap
 		"ArgsToRows":                  argsToRows,
 		"EnvVarsToRows":               envVarsToRows,
 		"FlagsToRows":                 flagsToRows,
+		"FlagSummary":                 flagSummary,
 		"FormatThreeColMarkdownTable": formatThreeColMarkdownTable,
 		"FormatUsageArg":              formatUsageArg,
+		"EffectiveFlags":              effectiveFlags,
 		"ReplaceFlagDefaults":         replaceFlagDefaults,
 		"ReplaceArgDefaults":          replaceArgDefaults,
 		"SortCommandsByName":          sortCommandsByName,

--- a/lib/utils/usage_docs_test.go
+++ b/lib/utils/usage_docs_test.go
@@ -59,6 +59,8 @@ tags:
   - reference
   - platform-wide
 ---
+{/*GENERATED FILE. DO NOT EDIT.*/}
+{/*To generate, run: make cli-docs-myapp*/}
 {/*vale messaging = NO*/}
 
 This guide provides a comprehensive list of commands, arguments, and flags for
@@ -90,6 +92,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
+|@--name@|@myresource@|The name of the resource|
 |@--[no-]launch@|@false@|Whether to launch the Rocket|
 
 ## myapp hello
@@ -116,7 +119,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|command|none (optional)|Show help on command.|
+|command|*no default* (optional)|Show help on command.|
 
 `,
 		},
@@ -176,9 +179,7 @@ Flags:
 |Flag|Default|Description|
 |---|---|---|
 |@--[no-]dry-run@|@false@|Whether to use dry-run mode|
-|@--verbosity@|@3@|Verbosity level.|
-
-`,
+|@--verbosity@|@3@|Verbosity level.|`,
 		},
 		{
 			name: "multiple sub-command args",
@@ -253,7 +254,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|command|none (optional)|Show help on command.|
+|command|*no default* (optional)|Show help on command.|
 
 ## myapp validate
 
@@ -301,7 +302,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|command|none (optional)|Show help on command.|
+|command|*no default* (optional)|Show help on command.|
 
 ## myapp mfa add
 
@@ -341,7 +342,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|args|none (optional)|Arbitrary arguments|
+|args|*no default* (optional)|Arbitrary arguments|
 
 `,
 		},
@@ -417,7 +418,7 @@ Environment variables:
 |Variable|Default|Description|
 |---|---|---|
 |@CREATE_NAME@|@myresource@|The name of the resource|
-|@CREATE_TYPE@|none (optional)|The type of the resource|
+|@CREATE_TYPE@|*no default* (optional)|The type of the resource|
 
 Flags:
 
@@ -429,7 +430,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|type|none (optional)|The type of the resource|
+|type|*no default* (optional)|The type of the resource|
 
 `,
 		},
@@ -458,6 +459,8 @@ tags:
   - reference
   - platform-wide
 ---
+{/*GENERATED FILE. DO NOT EDIT.*/}
+{/*To generate, run: make cli-docs-myapp*/}
 {/*vale messaging = NO*/}
 
 This guide provides a comprehensive list of commands, arguments, and flags for
@@ -529,7 +532,7 @@ Arguments:
 
 |Flag|Default|Description|
 |---|---|---|
-|@--format@|@text@ (valid: @text@, @json@, @yaml@)|Output format|
+|@--format@|@text@ (one of: @text@, @json@, @yaml@)|Output format|
 
 `,
 		},
@@ -559,7 +562,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|@--mode@|@all@ (valid: @all@, @active@, @inactive@)|List mode|
+|@--mode@|@all@ (one of: @all@, @active@, @inactive@)|List mode|
 
 `,
 		},

--- a/tool/common/fido2/fido2.go
+++ b/tool/common/fido2/fido2.go
@@ -50,14 +50,14 @@ func NewCommand(app *kingpin.Application) *Command {
 		Attobj: &AttobjCommand{},
 	}
 
-	f2 := app.Command("fido2", "FIDO2 commands").Hidden()
+	f2 := app.Command("fido2", "FIDO2 commands.").Hidden()
 
-	diag := f2.Command("diag", "Run FIDO2 diagnostics").Hidden()
+	diag := f2.Command("diag", "Run FIDO2 diagnostics.").Hidden()
 	root.Diag.CmdClause = diag
 
-	attObj := f2.Command("attobj", "Parse a stored attestation object").Hidden()
+	attObj := f2.Command("attobj", "Parse a stored attestation object.").Hidden()
 	attObj.
-		Arg("att-obj", "Attestation object encoded in base64 standard or RawURL").
+		Arg("att-obj", "Attestation object encoded in base64 standard or RawURL.").
 		Required().
 		StringVar(&root.Attobj.attObjB64)
 	root.Attobj.CmdClause = attObj

--- a/tool/common/touchid/touchid.go
+++ b/tool/common/touchid/touchid.go
@@ -44,7 +44,7 @@ type Command struct {
 // Diag is always available.
 // Ls and Rm may not be available depending on binary and platform limitations.
 func NewCommand(app *kingpin.Application) *Command {
-	tid := app.Command("touchid", "Manage Touch ID credentials").Hidden()
+	tid := app.Command("touchid", "Manage Touch ID credentials.").Hidden()
 	cmd := &Command{
 		Diag: newDiagCommand(tid),
 	}
@@ -75,7 +75,7 @@ type DiagCommand struct {
 
 func newDiagCommand(app *kingpin.CmdClause) *DiagCommand {
 	return &DiagCommand{
-		CmdClause: app.Command("diag", "Run Touch ID diagnostics").Hidden(),
+		CmdClause: app.Command("diag", "Run Touch ID diagnostics.").Hidden(),
 	}
 }
 

--- a/tool/common/webauthnwin/webauthnwin.go
+++ b/tool/common/webauthnwin/webauthnwin.go
@@ -36,7 +36,7 @@ type Command struct {
 
 // NewCommand creates a new [Command] instance.
 func NewCommand(app *kingpin.Application) *Command {
-	wid := app.Command("webauthnwin", "Manage Windows WebAuthn").Hidden()
+	wid := app.Command("webauthnwin", "Manage Windows WebAuthn.").Hidden()
 	cmd := &Command{
 		Diag: newDiagCommand(wid),
 	}
@@ -58,7 +58,7 @@ type DiagCommand struct {
 
 func newDiagCommand(app *kingpin.CmdClause) *DiagCommand {
 	return &DiagCommand{
-		CmdClause: app.Command("diag", "Run windows webauthn diagnostics").Hidden(),
+		CmdClause: app.Command("diag", "Run windows webauthn diagnostics.").Hidden(),
 	}
 }
 

--- a/tool/tctl/common/recordings_command.go
+++ b/tool/tctl/common/recordings_command.go
@@ -140,7 +140,7 @@ func (c *RecordingsCommand) Initialize(app *kingpin.Application, t *tctlcfg.Glob
 	c.config = config
 	recordings := app.Command("recordings", "View and control session recordings.")
 	c.recordingsList = recordings.Command("ls", "List recorded sessions.")
-	c.recordingsList.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)+". Defaults to 'text'.").Default(teleport.Text).StringVar(&c.format)
+	c.recordingsList.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)+" Defaults to 'text'.").Default(teleport.Text).StringVar(&c.format)
 	c.recordingsList.Flag("from-utc", fmt.Sprintf("Start of time range in which recordings are listed. Format %s. Defaults to 24 hours ago.", defaults.TshTctlSessionListTimeFormat)).StringVar(&c.fromUTC)
 	c.recordingsList.Flag("to-utc", fmt.Sprintf("End of time range in which recordings are listed. Format %s. Defaults to current time.", defaults.TshTctlSessionListTimeFormat)).StringVar(&c.toUTC)
 	c.recordingsList.Flag("limit", fmt.Sprintf("Maximum number of recordings to show. Default %s.", defaults.TshTctlSessionListLimit)).Default(defaults.TshTctlSessionListLimit).IntVar(&c.maxRecordingsToShow)
@@ -166,7 +166,7 @@ func (c *RecordingsCommand) Initialize(app *kingpin.Application, t *tctlcfg.Glob
 	c.recordingsSearch.Flag("severity", "Minimum severity level to include (low, medium, high, critical).").StringVar(&c.searchSeverity)
 	c.recordingsSearch.Flag("search-mode", "Search strategy to use when search queries are provided.").Default(searchModeHybrid).EnumVar(&c.searchMode, searchModeHybrid, searchModeKeyword, searchModeEmbedding)
 	c.recordingsSearch.Flag("limit", "Maximum number of results to return.").Default(defaults.TshTctlSessionListLimit).Uint32Var(&c.searchLimit)
-	c.recordingsSearch.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)+". Defaults to 'text'.").Default(teleport.Text).StringVar(&c.searchFormat)
+	c.recordingsSearch.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)+" Defaults to 'text'.").Default(teleport.Text).StringVar(&c.searchFormat)
 	c.recordingsSearch.Flag("resume-token", "Resume a previous JSON/YAML search from a truncated result set (token printed to stderr when results are truncated).").StringVar(&c.searchResumeToken)
 
 	c.recordingsEncryption.Initialize(recordings, c.stdout)

--- a/tool/tctl/common/recordings_encryption_command.go
+++ b/tool/tctl/common/recordings_encryption_command.go
@@ -64,7 +64,7 @@ func (c *recordingsEncryptionCommand) Initialize(recordingsCmd *kingpin.CmdClaus
 
 	c.rotateCmd = c.cmd.Command("rotate", "Rotate encryption keys used for encrypting session recordings.")
 	c.statusCmd = c.cmd.Command("status", "Show current rotation status.")
-	c.statusCmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)+". Defaults to 'text'.").Default(teleport.Text).StringVar(&c.format)
+	c.statusCmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)+" Defaults to 'text'.").Default(teleport.Text).StringVar(&c.format)
 	c.completeCmd = c.cmd.Command("complete-rotation", "Completes an in-progress encryption key rotation.")
 	c.rollbackCmd = c.cmd.Command("rollback-rotation", "Rolls back an in-progress encryption key rotation.")
 	if stdout == nil {

--- a/tool/tsh/common/device.go
+++ b/tool/tsh/common/device.go
@@ -74,12 +74,12 @@ func newDeviceCommand(app *kingpin.Application) *deviceCommand {
 		"current-device",
 		"Attempts to register and enroll the current device. Requires device admin privileges.").
 		BoolVar(&root.enroll.currentDevice)
-	root.enroll.Flag("token", "Device enrollment token").StringVar(&root.enroll.token)
+	root.enroll.Flag("token", "Device enrollment token.").StringVar(&root.enroll.token)
 
 	// "tsh device" hidden debug commands.
-	root.collect.CmdClause = parentCmd.Command("collect", "Simulate enroll/authn device data collection").Hidden()
-	root.assetTag.CmdClause = parentCmd.Command("asset-tag", "Print the detected device asset tag").Hidden()
-	root.keyget.CmdClause = parentCmd.Command("keyget", "Get information about the device key").Hidden()
+	root.collect.CmdClause = parentCmd.Command("collect", "Simulate enroll/authn device data collection.").Hidden()
+	root.assetTag.CmdClause = parentCmd.Command("asset-tag", "Print the detected device asset tag.").Hidden()
+	root.keyget.CmdClause = parentCmd.Command("keyget", "Get information about the device key.").Hidden()
 
 	// Windows TPM hidden support commands.
 	root.activateCredential.CmdClause = parentCmd.Command("tpm-activate-credential", "").Hidden()
@@ -91,7 +91,7 @@ func newDeviceCommand(app *kingpin.Application) *deviceCommand {
 		StringVar(&root.activateCredential.encryptedCredentialSecret)
 
 	// Linux TPM hidden support commands.
-	root.dmiRead.CmdClause = parentCmd.Command("dmi-read", "Read device DMI information").Hidden()
+	root.dmiRead.CmdClause = parentCmd.Command("dmi-read", "Read device DMI information.").Hidden()
 
 	return root
 }

--- a/tool/tsh/common/git_login.go
+++ b/tool/tsh/common/git_login.go
@@ -44,8 +44,8 @@ func newGitLoginCommand(parent *kingpin.CmdClause) *gitLoginCommand {
 	// single Git server configured anyway so do a "list" op then use the
 	// organization from that Git server. If more than one Git servers are
 	// found, prompt the user to pick one.
-	cmd.Flag("github-org", "GitHub organization").Required().StringVar(&cmd.gitHubOrganization)
-	cmd.Flag("force", "Force a login").BoolVar(&cmd.force)
+	cmd.Flag("github-org", "GitHub organization.").Required().StringVar(&cmd.gitHubOrganization)
+	cmd.Flag("force", "Force a login.").BoolVar(&cmd.force)
 	return cmd
 }
 

--- a/tool/tsh/common/git_ssh.go
+++ b/tool/tsh/common/git_ssh.go
@@ -47,13 +47,13 @@ type gitSSHCommand struct {
 
 func newGitSSHCommand(parent *kingpin.CmdClause) *gitSSHCommand {
 	cmd := &gitSSHCommand{
-		CmdClause: parent.Command("ssh", "Proxy Git commands using SSH").Hidden(),
+		CmdClause: parent.Command("ssh", "Proxy Git commands using SSH.").Hidden(),
 	}
 
 	cmd.Flag("github-org", "GitHub organization.").Required().StringVar(&cmd.gitHubOrg)
-	cmd.Arg("[user@]host", "Remote hostname and the login to use").Required().StringVar(&cmd.userHost)
-	cmd.Arg("command", "Command to execute on a remote host").StringsVar(&cmd.command)
-	cmd.Flag("option", "OpenSSH options in the format used in the configuration file").Short('o').AllowDuplicate().StringsVar(&cmd.options)
+	cmd.Arg("[user@]host", "Remote hostname and the login to use.").Required().StringVar(&cmd.userHost)
+	cmd.Arg("command", "Command to execute on a remote host.").StringsVar(&cmd.command)
+	cmd.Flag("option", "OpenSSH options in the format used in the configuration file.").Short('o').AllowDuplicate().StringsVar(&cmd.options)
 	return cmd
 }
 

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -86,7 +86,7 @@ type kubeCommands struct {
 }
 
 func newKubeCommand(app *kingpin.Application) kubeCommands {
-	kube := app.Command("kube", "Manage available Kubernetes clusters")
+	kube := app.Command("kube", "Manage available Kubernetes clusters.")
 	cmds := kubeCommands{
 		credentials: newKubeCredentialsCommand(kube),
 		ls:          newKubeLSCommand(kube),
@@ -492,19 +492,19 @@ func newKubeExecCommand(parent *kingpin.CmdClause) *kubeExecCommand {
 		CmdClause: parent.Command("exec", "Execute a command in a Kubernetes pod."),
 	}
 
-	c.Flag("container", "Container name. If omitted, use the kubectl.kubernetes.io/default-container annotation for selecting the container to be attached or the first container in the pod will be chosen").Short('c').StringVar(&c.container)
+	c.Flag("container", "Container name. If omitted, use the kubectl.kubernetes.io/default-container annotation for selecting the container to be attached or the first container in the pod will be chosen.").Short('c').StringVar(&c.container)
 	c.Flag("namespace", "Configure the default Kubernetes namespace.").Short('n').StringVar(&c.namespace)
 	// kube-namespace exists for backwards compatibility.
 	c.Flag("kube-namespace", "Configure the default Kubernetes namespace.").Hidden().StringVar(&c.namespace)
-	c.Flag("filename", "to use to exec into the resource").Short('f').StringVar(&c.filename)
-	c.Flag("quiet", "Only print output from the remote session").Short('q').BoolVar(&c.quiet)
-	c.Flag("stdin", "Pass stdin to the container").Short('s').BoolVar(&c.stdin)
-	c.Flag("tty", "Stdin is a TTY").Short('t').BoolVar(&c.tty)
+	c.Flag("filename", "To use to exec into the resource.").Short('f').StringVar(&c.filename)
+	c.Flag("quiet", "Only print output from the remote session.").Short('q').BoolVar(&c.quiet)
+	c.Flag("stdin", "Pass stdin to the container.").Short('s').BoolVar(&c.stdin)
+	c.Flag("tty", "Stdin is a TTY.").Short('t').BoolVar(&c.tty)
 	c.Flag("reason", "The purpose of the session.").StringVar(&c.reason)
 	c.Flag("invite", "A comma separated list of people to mark as invited for the session.").StringVar(&c.invited)
 	c.Flag("participant-req", "Displays a verbose list of required participants in a moderated session.").BoolVar(&c.displayParticipantRequirements)
-	c.Arg("target", "Pod or deployment name").Required().StringVar(&c.target)
-	c.Arg("command", "Command to execute in the container").Required().StringsVar(&c.command)
+	c.Arg("target", "Pod or deployment name.").Required().StringVar(&c.target)
+	c.Arg("command", "Command to execute in the container.").Required().StringsVar(&c.command)
 	return c
 }
 
@@ -578,7 +578,7 @@ type kubeSessionsCommand struct {
 
 func newKubeSessionsCommand(parent *kingpin.CmdClause) *kubeSessionsCommand {
 	c := &kubeSessionsCommand{
-		CmdClause: parent.Command("sessions", "Get a list of active Kubernetes sessions. (DEPRECATED: use tsh sessions ls --kind=kube instead)"),
+		CmdClause: parent.Command("sessions", "Get a list of active Kubernetes sessions. (DEPRECATED: use tsh sessions ls --kind=kube instead.)"),
 	}
 	c.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&c.format, defaults.DefaultFormats...)
 	c.Flag("cluster", clusterHelp).Short('c').StringVar(&c.siteName)
@@ -619,7 +619,7 @@ func newKubeCredentialsCommand(parent *kingpin.CmdClause) *kubeCredentialsComman
 	c := &kubeCredentialsCommand{
 		// This command is always hidden. It's called from the kubeconfig that
 		// tsh generates and never by users directly.
-		CmdClause: parent.Command("credentials", "Get credentials for kubectl access").Hidden(),
+		CmdClause: parent.Command("credentials", "Get credentials for kubectl access.").Hidden(),
 	}
 	c.Flag("teleport-cluster", "Name of the Teleport cluster to get credentials for.").Required().StringVar(&c.teleportCluster)
 	c.Flag("kube-cluster", "Name of the Kubernetes cluster to get credentials for.").Required().StringVar(&c.kubeCluster)
@@ -1242,13 +1242,13 @@ func newKubeLoginCommand(parent *kingpin.CmdClause) *kubeLoginCommand {
 	c.Flag("kube-namespace", "Configure the default Kubernetes namespace.").Hidden().StringVar(&c.namespace)
 	c.Flag("namespace", "Configure the default Kubernetes namespace.").Short('n').StringVar(&c.namespace)
 	c.Flag("all", "Generate a kubeconfig with every cluster the user has access to. Mutually exclusive with --labels or --query.").BoolVar(&c.all)
-	c.Flag("set-context-name", "Define a custom context name. To use it with --all include \"{{.KubeName}}\"").
+	c.Flag("set-context-name", "Define a custom context name. To use it with --all include \"{{.KubeName}}\".").
 		// Use the default context name template if --set-context-name is not set.
 		// This works as an hint to the user that the context name can be customized.
 		Default(kubeconfig.ContextName("{{.ClusterName}}", "{{.KubeName}}")).
 		StringVar(&c.overrideContextName)
-	c.Flag("request-reason", "Reason for requesting access").StringVar(&c.requestReason)
-	c.Flag("disable-access-request", "Disable automatic resource access requests").BoolVar(&c.disableAccessRequest)
+	c.Flag("request-reason", "Reason for requesting access.").StringVar(&c.requestReason)
+	c.Flag("disable-access-request", "Disable automatic resource access requests.").BoolVar(&c.disableAccessRequest)
 
 	return c
 }

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -78,7 +78,7 @@ func newProxyKubeCommand(parent *kingpin.CmdClause) *proxyKubeCommand {
 	// kube-namespace exists for backwards compatibility.
 	c.Flag("kube-namespace", "Configure the default Kubernetes namespace.").Hidden().StringVar(&c.namespace)
 	c.Flag("namespace", "Configure the default Kubernetes namespace.").Short('n').StringVar(&c.namespace)
-	c.Flag("port", "Specifies the source port used by the proxy listener").Short('p').StringVar(&c.port)
+	c.Flag("port", "Specifies the source port used by the proxy listener.").Short('p').StringVar(&c.port)
 	c.Flag("format", envVarFormatFlagDescription()).Short('f').Default(envVarDefaultFormat()).EnumVar(&c.format, envVarFormats...)
 	c.Flag("labels", labelHelp).StringVar(&c.labels)
 	c.Flag("query", queryHelp).StringVar(&c.predicateExpression)

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -133,7 +133,7 @@ func (c *proxyKubeCommand) run(cf *CLIConf) error {
 	// re-exec into a new shell with $KUBECONFIG already pointed to our config file
 	// if --exec flag is set, --exec-cmd is provided, or headless mode is enabled.
 	reexecIntoShell := cf.Headless || c.exec || c.execCmd != ""
-	if err := c.printTemplate(cf.Stdout(), reexecIntoShell, localProxy); err != nil {
+	if err := c.printTemplate(cf.ProxyStatusOutput(), reexecIntoShell, localProxy); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -197,7 +197,7 @@ func runHeadlessKubeProxy(cf *CLIConf, localProxy *kubeLocalProxy, command strin
 
 	err = reexecToShell(ctx, configBytes, command, args)
 	err = trace.NewAggregate(err, localProxy.Close())
-	_, _ = fmt.Fprint(cf.Stdout(), "Local proxy for Kubernetes is closed.\n")
+	_, _ = fmt.Fprint(cf.ProxyStatusOutput(), "Local proxy for Kubernetes is closed.\n")
 	err = trace.NewAggregate(err, <-lpErrChan)
 	return err
 }
@@ -283,7 +283,7 @@ func (c *proxyKubeCommand) prepare(cf *CLIConf, tc *client.TeleportClient) (*cli
 }
 
 func (c *proxyKubeCommand) printPrepare(cf *CLIConf, title string, clusters kubeconfig.LocalProxyClusters) {
-	fmt.Fprintln(cf.Stdout(), title)
+	fmt.Fprintln(cf.ProxyStatusOutput(), title)
 	table := asciitable.MakeTable([]string{"Teleport Cluster Name", "Kube Cluster Name", "Context Name"})
 	for _, cluster := range clusters {
 		contextName, err := kubeconfig.ContextNameFromTemplate(c.overrideContextName, cluster.TeleportCluster, cluster.KubeCluster)
@@ -293,7 +293,7 @@ func (c *proxyKubeCommand) printPrepare(cf *CLIConf, title string, clusters kube
 		}
 		table.AddRow([]string{cluster.TeleportCluster, cluster.KubeCluster, contextName})
 	}
-	fmt.Fprintln(cf.Stdout(), table.AsBuffer().String())
+	fmt.Fprintln(cf.ProxyStatusOutput(), table.AsBuffer().String())
 }
 
 func (c *proxyKubeCommand) printTemplate(w io.Writer, isReexec bool, localProxy *kubeLocalProxy) error {

--- a/tool/tsh/common/mcp_db.go
+++ b/tool/tsh/common/mcp_db.go
@@ -55,7 +55,7 @@ func newMCPDBCommand(parent *kingpin.CmdClause, cf *CLIConf) *mcpDBStartCommand 
 		cf:        cf,
 	}
 
-	cmd.Arg("uris", "List of database MCP resource URIs that will be served by the server").Required().StringsVar(&cmd.databaseURIs)
+	cmd.Arg("uris", "List of database MCP resource URIs that will be served by the server.").Required().StringsVar(&cmd.databaseURIs)
 	return cmd
 }
 

--- a/tool/tsh/common/mfa.go
+++ b/tool/tsh/common/mfa.go
@@ -100,7 +100,7 @@ func newMFALSCommand(parent *kingpin.CmdClause) *mfaLSCommand {
 	c := &mfaLSCommand{
 		CmdClause: parent.Command("ls", "Get a list of registered MFA devices."),
 	}
-	c.Flag("verbose", "Print more information about MFA devices").Short('v').BoolVar(&c.verbose)
+	c.Flag("verbose", "Print more information about MFA devices.").Short('v').BoolVar(&c.verbose)
 	c.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&c.format, defaults.DefaultFormats...)
 	return c
 }
@@ -211,11 +211,11 @@ func newMFAAddCommand(parent *kingpin.CmdClause) *mfaAddCommand {
 	c := &mfaAddCommand{
 		CmdClause: parent.Command("add", "Add a new MFA device."),
 	}
-	c.Flag("name", "Name of the new MFA device").StringVar(&c.devName)
-	c.Flag("type", fmt.Sprintf("Type of the new MFA device (%s)", strings.Join(defaultDeviceTypes, ", "))).
+	c.Flag("name", "Name of the new MFA device.").StringVar(&c.devName)
+	c.Flag("type", fmt.Sprintf("Type of the new MFA device (%s).", strings.Join(defaultDeviceTypes, ", "))).
 		EnumVar(&c.devType, defaultDeviceTypes...)
 	if wancli.IsFIDO2Available() {
-		c.Flag("allow-passwordless", "Allow passwordless logins").
+		c.Flag("allow-passwordless", "Allow passwordless logins.").
 			IsSetByUser(&c.allowPasswordlessSet).
 			BoolVar(&c.allowPasswordless)
 	}
@@ -555,7 +555,7 @@ func newMFARemoveCommand(parent *kingpin.CmdClause) *mfaRemoveCommand {
 	c := &mfaRemoveCommand{
 		CmdClause: parent.Command("rm", "Remove a MFA device."),
 	}
-	c.Arg("name", "Name or ID of the MFA device to remove").Required().StringVar(&c.name)
+	c.Arg("name", "Name or ID of the MFA device to remove.").Required().StringVar(&c.name)
 	return c
 }
 

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -913,7 +913,7 @@ func envVarFormatFlagDescription() string {
 
 func awsProxyFormatFlagDescription() string {
 	return fmt.Sprintf(
-		"%s Or specify a service format, one of: %s",
+		"%s Or specify a service format, one of: %s.",
 		envVarFormatFlagDescription(),
 		strings.Join(awsProxyServiceFormats, ", "),
 	)

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -531,10 +531,10 @@ func onProxyCommandApp(cf *CLIConf) error {
 	if portMapping.TargetPort != 0 {
 		appName = fmt.Sprintf("%s:%d", appName, portMapping.TargetPort)
 	}
-	fmt.Fprintf(cf.Stdout(), "Proxying connections to %s on %v\n", appName, proxyApp.GetAddr())
+	fmt.Fprintf(cf.ProxyStatusOutput(), "Proxying connections to %s on %v\n", appName, proxyApp.GetAddr())
 	// If target port is not equal to zero, the user must know about the port flag.
 	if portMapping.LocalPort == 0 && portMapping.TargetPort == 0 {
-		fmt.Fprintln(cf.Stdout(), "To avoid port randomization, you can choose the listening port using the --port flag.")
+		fmt.Fprintln(cf.ProxyStatusOutput(), "To avoid port randomization, you can choose the listening port using the --port flag.")
 	}
 
 	if cf.AppHTTPSTunnel {
@@ -542,7 +542,7 @@ func onProxyCommandApp(cf *CLIConf) error {
 		if cf.InsecureSkipVerify {
 			curlCmd += " -k"
 		}
-		fmt.Fprintf(cf.Stdout(), "\nExample curl command:\n%s\n", curlCmd)
+		fmt.Fprintf(cf.ProxyStatusOutput(), "\nExample curl command:\n%s\n", curlCmd)
 	}
 
 	defer func() {

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -707,6 +707,8 @@ type CLIConf struct {
 	// databaseMCPRegistryOverride overrides database access MCP servers
 	// registry. used in tests.
 	databaseMCPRegistryOverride dbmcp.Registry
+
+	kingpinApp *kingpin.Application
 }
 
 func (c *CLIConf) isForkAuthChild() bool {
@@ -863,11 +865,12 @@ const (
 	proxyStatusOutputStderr  = "stderr"
 	proxyStatusOutputNone    = "none"
 
-	clusterHelp = "Specify the Teleport cluster to connect"
-	browserHelp = "Set to 'none' to suppress browser opening on login"
-	searchHelp  = `List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase")`
-	queryHelp   = `Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and || (e.g. --query='labels["key1"] == "value1" && labels["key2"] != "value2"')`
-	labelHelp   = "List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)"
+	clusterHelp = "Specify the Teleport cluster to connect."
+	browserHelp = "Set to 'none' to suppress browser opening on login."
+	searchHelp  = `List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase").`
+	queryHelp   = `Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and || (e.g. --query='labels["key1"] == "value1" && labels["key2"] != "value2"').`
+	labelHelp   = "List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)."
+	quietHelp   = "Quiet mode."
 	// proxyDefaultResolutionTimeout is how long to wait for an unknown proxy
 	// port to be resolved.
 	//
@@ -940,25 +943,26 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	proxyStatusOutput := proxyStatusOutputDefault
 
 	// configure CLI argument parser:
-	app := utils.InitCLIParser("tsh", "Teleport Command Line Client").Interspersed(true)
+	cf.kingpinApp = utils.InitCLIParser("tsh", "Teleport Command Line Client.").Interspersed(true)
+	app := cf.kingpinApp
 
-	app.Flag("login", "Remote host login").Short('l').Envar(loginEnvVar).StringVar(&cf.NodeLogin)
-	app.Flag("proxy", "Teleport proxy address").Envar(proxyEnvVar).StringVar(&cf.Proxy)
+	app.Flag("login", "Remote host login.").Short('l').Envar(loginEnvVar).StringVar(&cf.NodeLogin)
+	app.Flag("proxy", "Teleport proxy address.").Envar(proxyEnvVar).StringVar(&cf.Proxy)
 	app.Flag("relay", "Teleport relay address, \"none\" to explicitly disable the use of a relay, or \"default\" to use the cluster-provided address even if a different address was specified at login time.").Envar(relayEnvVar).StringVar(&cf.Relay)
-	app.Flag("nocache", "do not cache cluster discovery locally").Hidden().BoolVar(&cf.NoCache)
-	app.Flag("user", "Teleport user, defaults to current local user").Envar(userEnvVar).StringVar(&cf.Username)
-	app.Flag("mem-profile", "Write memory profile to file").Hidden().StringVar(&memProfile)
-	app.Flag("cpu-profile", "Write CPU profile to file").Hidden().StringVar(&cpuProfile)
-	app.Flag("trace-profile", "Write trace profile to file").Hidden().StringVar(&traceProfile)
+	app.Flag("nocache", "Do not cache cluster discovery locally.").Hidden().BoolVar(&cf.NoCache)
+	app.Flag("user", "Teleport user, defaults to current local user.").Envar(userEnvVar).StringVar(&cf.Username)
+	app.Flag("mem-profile", "Write memory profile to file.").Hidden().StringVar(&memProfile)
+	app.Flag("cpu-profile", "Write CPU profile to file.").Hidden().StringVar(&cpuProfile)
+	app.Flag("trace-profile", "Write trace profile to file.").Hidden().StringVar(&traceProfile)
 	app.Flag("option", "").Short('o').Hidden().AllowDuplicate().PreAction(func(ctx *kingpin.ParseContext) error {
 		return trace.BadParameter("invalid flag, perhaps you want to use this flag as tsh ssh -o?")
 	}).String()
 
-	app.Flag("ttl", "Minutes to live for a session").Int32Var(&cf.MinsToLive)
-	app.Flag("identity", "Identity file").Short('i').Envar(identityFileEnvVar).StringVar(&cf.IdentityFileIn)
-	app.Flag("compat", "OpenSSH compatibility flag").Hidden().StringVar(&cf.Compatibility)
-	app.Flag("cert-format", "SSH certificate format").StringVar(&cf.CertificateFormat)
-	app.Flag("trace", "Capture and export distributed traces").Hidden().BoolVar(&cf.SampleTraces)
+	app.Flag("ttl", "Minutes to live for a session.").Int32Var(&cf.MinsToLive)
+	app.Flag("identity", "Identity file.").Short('i').Envar(identityFileEnvVar).StringVar(&cf.IdentityFileIn)
+	app.Flag("compat", "OpenSSH compatibility flag.").Hidden().StringVar(&cf.Compatibility)
+	app.Flag("cert-format", "SSH certificate format.").StringVar(&cf.CertificateFormat)
+	app.Flag("trace", "Capture and export distributed traces.").Hidden().BoolVar(&cf.SampleTraces)
 	app.Flag("trace-exporter", "An OTLP exporter URL to send spans to. Note - only tsh spans will be included.").Hidden().StringVar(&cf.TraceExporter)
 	// This flag only applies to tsh ssh; it's defined here to make configuring
 	// the re-exec command easier.
@@ -967,7 +971,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 
 	if !moduleCfg.IsBoringBinary() {
 		// The user is *never* allowed to do this in FIPS mode.
-		app.Flag("insecure", "Do not verify server's certificate and host name. Use only in test environments").
+		app.Flag("insecure", "Do not verify server's certificate and host name. Use only in test environments.").
 			Default("false").
 			BoolVar(&cf.InsecureSkipVerify)
 	}
@@ -979,7 +983,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	// - Kingpin is strict about syntax, so TELEPORT_DEBUG=rubbish will crash a program; we don't want such behavior for this variable.
 	app.Flag("debug", "Verbose logging to stdout.").Short('d').IsSetByUser(&cf.DebugSetByUser).BoolVar(&cf.Debug)
 	osLogFlag := app.Flag("os-log",
-		fmt.Sprintf("Verbose logging to the unified logging system. This flag implies --debug. Also available through the %s env var. https://goteleport.com/docs/connect-your-client/tsh/#debug-logs",
+		fmt.Sprintf("Verbose logging to the unified logging system. This flag implies --debug. Also available through the %s env var. More details see https://goteleport.com/docs/connect-your-client/tsh/#debug-logs.",
 			osLogEnvVar)).
 		IsSetByUser(&cf.OSLogSetByUser)
 	if runtime.GOOS != constants.DarwinOS && !utils.DocsMode {
@@ -995,11 +999,11 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	app.Flag("enable-escape-sequences", "Enable support for SSH escape sequences. Type '~?' during an SSH session to list supported sequences. Default is enabled.").
 		Default("true").
 		BoolVar(&cf.EnableEscapeSequences)
-	app.Flag("bind-addr", "Override host:port used when opening a browser for cluster logins").Envar(bindAddrEnvVar).StringVar(&cf.BindAddr)
+	app.Flag("bind-addr", "Override host:port used when opening a browser for cluster logins.").Envar(bindAddrEnvVar).StringVar(&cf.BindAddr)
 	app.Flag("callback", "Override the base URL (host:port) of the link shown when opening a browser for cluster logins. Must be used with --bind-addr.").StringVar(&cf.CallbackAddr)
 	app.Flag("browser-login", browserHelp).Hidden().Envar(browserEnvVar).StringVar(&cf.Browser)
 	modes := []string{mfaModeAuto, mfaModeCrossPlatform, mfaModePlatform, mfaModeOTP, mfaModeSSO, mfaModeBrowser}
-	app.Flag("mfa-mode", "Preferred mode for MFA and Passwordless assertions.").
+	app.Flag("mfa-mode", fmt.Sprintf("Preferred mode for MFA and Passwordless assertions (%v).", strings.Join(modes, ", "))).
 		Default(mfaModeAuto).
 		Envar(mfaModeEnvVar).
 		EnumVar(&cf.MFAMode, modes...)
@@ -1009,7 +1013,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		Envar(mlockModeEnvVar).
 		StringVar(&cf.MlockMode)
 	app.HelpFlag.Short('h')
-	app.Flag("piv-slot", "Specify a PIV slot key to use for Hardware Key support instead of the default. Ex: \"9d\"").Envar("TELEPORT_PIV_SLOT").StringVar(&cf.PIVSlot)
+	app.Flag("piv-slot", "Specify a PIV slot key to use for Hardware Key support instead of the default. Ex: \"9d\".").Envar("TELEPORT_PIV_SLOT").StringVar(&cf.PIVSlot)
 	app.Flag("check-update", "Check for availability of managed update.").Envar(toolsCheckUpdateEnvVar).Hidden().BoolVar(&cf.checkManagedUpdates)
 
 	ver := app.Command("version", "Print the tsh client and Proxy server versions for the current context.")
@@ -1019,31 +1023,31 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	// ssh
 	// Use Interspersed(false) to forward all flags to ssh.
 	ssh := app.Command("ssh", "Run shell or execute a command on a remote SSH node.").Interspersed(false)
-	ssh.Arg("[user@]host", "Remote hostname and the login to use, this argument is required").StringVar(&cf.UserHost)
-	ssh.Arg("command", "Command to execute on a remote host").StringsVar(&cf.RemoteCommand)
-	app.Flag("jumphost", "SSH jumphost").Short('J').StringVar(&cf.ProxyJump)
-	ssh.Flag("port", "SSH port on a remote host").Short('p').Int32Var(&cf.NodePort)
-	ssh.Flag("forward-agent", "Forward agent to target node").Short('A').BoolVar(&cf.ForwardAgent)
-	ssh.Flag("forward", "Forward localhost connections to remote server").Short('L').StringsVar(&cf.LocalForwardPorts)
-	ssh.Flag("dynamic-forward", "Forward localhost connections to remote server using SOCKS5").Short('D').StringsVar(&cf.DynamicForwardedPorts)
-	ssh.Flag("remote-forward", "Forward remote connections to localhost").Short('R').StringsVar(&cf.RemoteForwardPorts)
-	ssh.Flag("local", "Execute command on localhost after connecting to SSH node").Default("false").BoolVar(&cf.LocalExec)
-	ssh.Flag("tty", "Allocate TTY").Short('t').BoolVar(&cf.Interactive)
+	ssh.Arg("[user@]host", "Remote hostname and the login to use, this argument is required.").StringVar(&cf.UserHost)
+	ssh.Arg("command", "Command to execute on a remote host.").StringsVar(&cf.RemoteCommand)
+	app.Flag("jumphost", "SSH jumphost.").Short('J').StringVar(&cf.ProxyJump)
+	ssh.Flag("port", "SSH port on a remote host.").Short('p').Int32Var(&cf.NodePort)
+	ssh.Flag("forward-agent", "Forward agent to target node.").Short('A').BoolVar(&cf.ForwardAgent)
+	ssh.Flag("forward", "Forward localhost connections to remote server.").Short('L').StringsVar(&cf.LocalForwardPorts)
+	ssh.Flag("dynamic-forward", "Forward localhost connections to remote server using SOCKS5.").Short('D').StringsVar(&cf.DynamicForwardedPorts)
+	ssh.Flag("remote-forward", "Forward remote connections to localhost.").Short('R').StringsVar(&cf.RemoteForwardPorts)
+	ssh.Flag("local", "Execute command on localhost after connecting to SSH node.").Default("false").BoolVar(&cf.LocalExec)
+	ssh.Flag("tty", "Allocate TTY.").Short('t').BoolVar(&cf.Interactive)
 	ssh.Flag("cluster", clusterHelp).Short('c').StringVar(&cf.SiteName)
-	ssh.Flag("option", "OpenSSH options in the format used in the configuration file").Short('o').AllowDuplicate().StringsVar(&cf.Options)
-	ssh.Flag("no-remote-exec", "Don't execute remote command, useful for port forwarding").Short('N').BoolVar(&cf.NoRemoteExec)
-	ssh.Flag("x11-untrusted", "Requests untrusted (secure) X11 forwarding for this session").Short('X').BoolVar(&cf.X11ForwardingUntrusted)
-	ssh.Flag("x11-trusted", "Requests trusted (insecure) X11 forwarding for this session. This can make your local machine vulnerable to attacks, use with caution").Short('Y').BoolVar(&cf.X11ForwardingTrusted)
-	ssh.Flag("x11-untrusted-timeout", "Sets a timeout for untrusted X11 forwarding, after which the client will reject any forwarding requests from the server").Default("10m").DurationVar((&cf.X11ForwardingTimeout))
+	ssh.Flag("option", "OpenSSH options in the format used in the configuration file.").Short('o').AllowDuplicate().StringsVar(&cf.Options)
+	ssh.Flag("no-remote-exec", "Don't execute remote command, useful for port forwarding.").Short('N').BoolVar(&cf.NoRemoteExec)
+	ssh.Flag("x11-untrusted", "Requests untrusted (secure) X11 forwarding for this session.").Short('X').BoolVar(&cf.X11ForwardingUntrusted)
+	ssh.Flag("x11-trusted", "Requests trusted (insecure) X11 forwarding for this session. This can make your local machine vulnerable to attacks, use with caution.").Short('Y').BoolVar(&cf.X11ForwardingTrusted)
+	ssh.Flag("x11-untrusted-timeout", "Sets a timeout for untrusted X11 forwarding, after which the client will reject any forwarding requests from the server.").Default("10m").DurationVar((&cf.X11ForwardingTimeout))
 	ssh.Flag("invite", "A comma separated list of people to mark as invited for the session.").StringsVar(&cf.Invited)
 	ssh.Flag("reason", "The purpose of the session.").StringVar(&cf.Reason)
 	ssh.Flag("participant-req", "Displays a verbose list of required participants in a moderated session.").BoolVar(&cf.displayParticipantRequirements)
-	ssh.Flag("request-reason", "Reason for requesting access").StringVar(&cf.RequestReason)
-	ssh.Flag("request-mode", fmt.Sprintf("Type of automatic access request to make (%s)", strings.Join(accessRequestModes, ", "))).Envar(requestModeEnvVar).Default(accessRequestModeResource).EnumVar(&cf.RequestMode, accessRequestModes...)
-	ssh.Flag("disable-access-request", "Disable automatic resource access requests (DEPRECATED: use --request-mode=off)").BoolVar(&cf.disableAccessRequest)
+	ssh.Flag("request-reason", "Reason for requesting access.").StringVar(&cf.RequestReason)
+	ssh.Flag("request-mode", fmt.Sprintf("Type of automatic access request to make (%s).", strings.Join(accessRequestModes, ", "))).Envar(requestModeEnvVar).Default(accessRequestModeResource).EnumVar(&cf.RequestMode, accessRequestModes...)
+	ssh.Flag("disable-access-request", "Disable automatic resource access requests (DEPRECATED: use --request-mode=off).").BoolVar(&cf.disableAccessRequest)
 	ssh.Flag("log-dir", "Directory to log separated command output, when executing on multiple nodes. If set, output from each node will also be labeled in the terminal.").StringVar(&cf.SSHLogDir)
-	ssh.Flag("no-resume", "Disable SSH connection resumption").Envar(noResumeEnvVar).BoolVar(&cf.DisableSSHResumption)
-	ssh.Flag("relogin", "Permit performing an authentication attempt on a failed command").Default("true").BoolVar(&cf.Relogin)
+	ssh.Flag("no-resume", "Disable SSH connection resumption.").Envar(noResumeEnvVar).BoolVar(&cf.DisableSSHResumption)
+	ssh.Flag("relogin", "Permit performing an authentication attempt on a failed command.").Default("true").BoolVar(&cf.Relogin)
 	ssh.Flag("fork-after-authentication", "Run in background after authentication is complete.").Short('f').BoolVar(&cf.ForkAfterAuthentication)
 	// The following flags are OpenSSH compatibility flags. They are used for
 	// users that alias "ssh" to "tsh ssh." The following OpenSSH flags are
@@ -1055,22 +1059,22 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	ssh.Flag(uuid.New().String(), "").Short('V').Hidden().BoolVar(&cf.ShowVersion)
 
 	resolve := app.Command("resolve", "Resolves an SSH host.")
-	resolve.Arg("host", "Remote hostname to resolve").Required().StringVar(&cf.UserHost)
-	resolve.Flag("quiet", "Quiet mode").Short('q').BoolVar(&cf.Quiet)
+	resolve.Arg("host", "Remote hostname to resolve.").Required().StringVar(&cf.UserHost)
+	resolve.Flag("quiet", quietHelp).Short('q').BoolVar(&cf.Quiet)
 	resolve.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaults.DefaultFormats...)
 
 	// Daemon service for teleterm client
 	daemon := app.Command("daemon", "Daemon is the tsh daemon service.").Hidden()
 	daemonStart := daemon.Command("start", "Starts tsh daemon service.").Hidden()
 	daemonStart.Flag("addr", "Addr is the daemon listening address.").StringVar(&cf.DaemonAddr)
-	daemonStart.Flag("certs-dir", "Directory containing certs used to create secure gRPC connection with daemon service").StringVar(&cf.DaemonCertsDir)
-	daemonStart.Flag("prehog-addr", "URL where prehog events should be submitted").StringVar(&cf.DaemonPrehogAddr)
-	daemonStart.Flag("kubeconfigs-dir", "Directory containing kubeconfig for Kubernetes Access").StringVar(&cf.DaemonKubeconfigsDir)
-	daemonStart.Flag("agents-dir", "Directory containing agent config files and data directories for Connect My Computer").StringVar(&cf.DaemonAgentsDir)
-	daemonStart.Flag("installation-id", "Unique ID identifying a specific Teleport Connect installation").StringVar(&cf.DaemonInstallationID)
-	daemonStart.Flag("hardware-key-agent", "Serve the hardware key agent as part of the daemon process").BoolVar(&cf.HardwareKeyAgentServer)
+	daemonStart.Flag("certs-dir", "Directory containing certs used to create secure gRPC connection with daemon service.").StringVar(&cf.DaemonCertsDir)
+	daemonStart.Flag("prehog-addr", "URL where prehog events should be submitted.").StringVar(&cf.DaemonPrehogAddr)
+	daemonStart.Flag("kubeconfigs-dir", "Directory containing kubeconfig for Kubernetes Access.").StringVar(&cf.DaemonKubeconfigsDir)
+	daemonStart.Flag("agents-dir", "Directory containing agent config files and data directories for Connect My Computer.").StringVar(&cf.DaemonAgentsDir)
+	daemonStart.Flag("installation-id", "Unique ID identifying a specific Teleport Connect installation.").StringVar(&cf.DaemonInstallationID)
+	daemonStart.Flag("hardware-key-agent", "Serve the hardware key agent as part of the daemon process.").BoolVar(&cf.HardwareKeyAgentServer)
 	daemonStop := daemon.Command("stop", "Gracefully stops a process on Windows by sending Ctrl-Break to it.").Hidden()
-	daemonStop.Flag("pid", "PID to be stopped").IntVar(&cf.DaemonPid)
+	daemonStop.Flag("pid", "PID to be stopped.").IntVar(&cf.DaemonPid)
 
 	// AWS.
 	// Use Interspersed(false) to forward all flags to AWS CLI.
@@ -1079,7 +1083,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	aws.Flag("app", "Optional Name of the AWS application to use if logged into multiple.").StringVar(&cf.AppName)
 	aws.Flag("endpoint-url", "Run local proxy to serve as an AWS endpoint URL. If not specified, local proxy serves as an HTTPS proxy.").
 		Short('e').Hidden().BoolVar(&cf.AWSEndpointURLMode)
-	aws.Flag("exec", "Execute different commands (e.g. terraform) under Teleport credentials").StringVar(&cf.Exec)
+	aws.Flag("exec", "Execute different commands (e.g. terraform) under Teleport credentials.").StringVar(&cf.Exec)
 	aws.Flag("aws-role", "(For AWS CLI access only) Amazon IAM role ARN or role name.").StringVar(&cf.AWSRole)
 
 	// Generate AWS profiles via AWS Identity Center integration.
@@ -1121,7 +1125,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	appLogin.Flag("gcp-service-account", "(For GCP CLI access only) GCP service account name.").StringVar(&cf.GCPServiceAccount)
 	appLogin.Flag("target-port", "Port to which connections made using this cert should be routed to. Valid only for multi-port TCP apps.").Uint16Var(&cf.TargetPort)
 	appLogin.Flag("interactive", "Prompt for AWS Roles interactively (--aws-role takes precedence).").Short('T').Envar(awsLoginInteractive).BoolVar(&cf.Interactive)
-	appLogin.Flag("quiet", "Quiet mode").Short('q').BoolVar(&cf.Quiet)
+	appLogin.Flag("quiet", quietHelp).Short('q').BoolVar(&cf.Quiet)
 	appLogout := apps.Command("logout", "Remove app certificate.")
 	appLogout.Arg("app", "App to remove credentials for.").StringVar(&cf.AppName)
 	appConfig := apps.Command("config", "Print app connection information.")
@@ -1136,23 +1140,23 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	// Recordings.
 	recordings := app.Command("recordings", "View and control session recordings.").Alias("recording")
 	lsRecordings := recordings.Command("ls", "List recorded sessions.")
-	lsRecordings.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)+". Defaults to 'text'.").Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaults.DefaultFormats...)
+	lsRecordings.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)+" Defaults to 'text'.").Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaults.DefaultFormats...)
 	lsRecordings.Flag("from-utc", fmt.Sprintf("Start of time range in which recordings are listed. Format %s. Defaults to 24 hours ago.", defaults.TshTctlSessionListTimeFormat)).StringVar(&cf.FromUTC)
 	lsRecordings.Flag("to-utc", fmt.Sprintf("End of time range in which recordings are listed. Format %s. Defaults to current time.", defaults.TshTctlSessionListTimeFormat)).StringVar(&cf.ToUTC)
 	lsRecordings.Flag("limit", fmt.Sprintf("Maximum number of recordings to show. Default %s.", defaults.TshTctlSessionListLimit)).Default(defaults.TshTctlSessionListLimit).IntVar(&cf.maxRecordingsToShow)
-	lsRecordings.Flag("last", "Duration into the past from which session recordings should be listed. Format 5h30m40s").StringVar(&cf.recordingsSince)
+	lsRecordings.Flag("last", "Duration into the past from which session recordings should be listed. Format \"5h30m40s\".").StringVar(&cf.recordingsSince)
 	exportRecordings := recordings.Command("export", "Export recorded desktop sessions to video.")
-	exportRecordings.Flag("out", "Override output file name").StringVar(&cf.OutFile)
-	exportRecordings.Arg("session-id", "ID of the session to export").Required().StringVar(&cf.SessionID)
+	exportRecordings.Flag("out", "Override output file name.").StringVar(&cf.OutFile)
+	exportRecordings.Arg("session-id", "ID of the session to export.").Required().StringVar(&cf.SessionID)
 
 	// Local TLS proxy.
 	proxy := app.Command("proxy", "Run local TLS proxy allowing connecting to Teleport in single-port mode.")
 	proxy.Flag("proxy-log-output", fmt.Sprintf("Select where proxy status messages are printed. Defaults to %q, but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are %q, %q, and %q.", proxyStatusOutputDefault, proxyStatusOutputStdout, proxyStatusOutputStderr, proxyStatusOutputNone)).Envar(proxyStatusOutputEnvVar).Default(proxyStatusOutputDefault).EnumVar(&proxyStatusOutput, proxyStatusOutputStdout, proxyStatusOutputStderr, proxyStatusOutputNone)
 	proxySSH := proxy.Command("ssh", "Start local TLS proxy for ssh connections when using Teleport in single-port mode.")
-	proxySSH.Arg("[user@]host", "Remote hostname and the login to use").Required().StringVar(&cf.UserHost)
+	proxySSH.Arg("[user@]host", "Remote hostname and the login to use.").Required().StringVar(&cf.UserHost)
 	proxySSH.Flag("cluster", clusterHelp).Short('c').StringVar(&cf.SiteName)
-	proxySSH.Flag("no-resume", "Disable SSH connection resumption").Envar(noResumeEnvVar).BoolVar(&cf.DisableSSHResumption)
-	proxySSH.Flag("relogin", "Permit performing an authentication attempt on a failed command").Default("true").BoolVar(&cf.Relogin)
+	proxySSH.Flag("no-resume", "Disable SSH connection resumption.").Envar(noResumeEnvVar).BoolVar(&cf.DisableSSHResumption)
+	proxySSH.Flag("relogin", "Permit performing an authentication attempt on a failed command.").Default("true").BoolVar(&cf.Relogin)
 	proxyDB := proxy.Command("db", "Start local TLS proxy for database connections when using Teleport in single-port mode.")
 	// don't require <db> positional argument, user can select with --labels/--query alone.
 	proxyDB.Arg("db", "The name of the database to start local proxy for.").StringVar(&cf.DatabaseService)
@@ -1166,12 +1170,12 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	proxyDB.Flag("cluster", clusterHelp).Short('c').StringVar(&cf.SiteName)
 	proxyDB.Flag("labels", labelHelp).StringVar(&cf.Labels)
 	proxyDB.Flag("query", queryHelp).StringVar(&cf.PredicateExpression)
-	proxyDB.Flag("request-reason", "Reason for requesting access").StringVar(&cf.RequestReason)
-	proxyDB.Flag("disable-access-request", "Disable automatic resource access requests").BoolVar(&cf.disableAccessRequest)
+	proxyDB.Flag("request-reason", "Reason for requesting access.").StringVar(&cf.RequestReason)
+	proxyDB.Flag("disable-access-request", "Disable automatic resource access requests.").BoolVar(&cf.disableAccessRequest)
 
 	proxyApp := proxy.Command("app", "Start local TLS proxy for app connection when using Teleport in single-port mode.")
-	proxyApp.Arg("app", "The name of the application to start local proxy for").Required().StringVar(&cf.AppName)
-	proxyApp.Flag("port", "Specifies the listening port used by the proxy app listener. Accepts an optional target port of a multi-port TCP app after a colon, e.g. \"1234:5678\"").Short('p').StringVar(&cf.LocalProxyPortMapping)
+	proxyApp.Arg("app", "The name of the application to start local proxy for.").Required().StringVar(&cf.AppName)
+	proxyApp.Flag("port", "Specifies the listening port used by by the proxy app listener. Accepts an optional target port of a multi-port TCP app after a colon, e.g. \"1234:5678\".").Short('p').StringVar(&cf.LocalProxyPortMapping)
 	proxyApp.Flag("cluster", clusterHelp).Short('c').StringVar(&cf.SiteName)
 	proxyApp.Flag("https-tunnel", "Use the teleport-app-https ALPN protocol (HTTPS tunneled over mTLS) for HTTP apps.").Hidden().BoolVar(&cf.AppHTTPSTunnel)
 
@@ -1219,14 +1223,14 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	dbLogin.Flag("db-user", "Database user to configure as default.").Short('u').StringVar(&cf.DatabaseUser)
 	dbLogin.Flag("db-name", "Database name to configure as default.").Short('n').StringVar(&cf.DatabaseName)
 	dbLogin.Flag("db-roles", "List of comma separate database roles to use for auto-provisioned user.").Short('r').StringVar(&cf.DatabaseRoles)
-	dbLogin.Flag("request-reason", "Reason for requesting access").StringVar(&cf.RequestReason)
-	dbLogin.Flag("disable-access-request", "Disable automatic resource access requests").BoolVar(&cf.disableAccessRequest)
+	dbLogin.Flag("request-reason", "Reason for requesting access.").StringVar(&cf.RequestReason)
+	dbLogin.Flag("disable-access-request", "Disable automatic resource access requests.").BoolVar(&cf.disableAccessRequest)
 	dbLogout := db.Command("logout", "Remove database credentials.")
 	dbLogout.Arg("db", "Database to remove credentials for.").StringVar(&cf.DatabaseService)
 	dbLogout.Flag("labels", labelHelp).StringVar(&cf.Labels)
 	dbLogout.Flag("query", queryHelp).StringVar(&cf.PredicateExpression)
 	dbEnv := db.Command("env", "Print environment variables for the configured database.")
-	dbEnv.Arg("db", "Print environment for the specified database").StringVar(&cf.DatabaseService)
+	dbEnv.Arg("db", "Print environment for the specified database.").StringVar(&cf.DatabaseService)
 	dbEnv.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaults.DefaultFormats...)
 	dbEnv.Flag("labels", labelHelp).StringVar(&cf.Labels)
 	dbEnv.Flag("query", queryHelp).StringVar(&cf.PredicateExpression)
@@ -1246,9 +1250,9 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	dbConnect.Flag("db-roles", "List of comma separate database roles to use for auto-provisioned user.").Short('r').StringVar(&cf.DatabaseRoles)
 	dbConnect.Flag("labels", labelHelp).StringVar(&cf.Labels)
 	dbConnect.Flag("query", queryHelp).StringVar(&cf.PredicateExpression)
-	dbConnect.Flag("request-reason", "Reason for requesting access").StringVar(&cf.RequestReason)
-	dbConnect.Flag("disable-access-request", "Disable automatic resource access requests").BoolVar(&cf.disableAccessRequest)
-	dbConnect.Flag("tunnel", "Open authenticated tunnel using database's client certificate so clients don't need to authenticate").Hidden().BoolVar(&cf.LocalProxyTunnel)
+	dbConnect.Flag("request-reason", "Reason for requesting access.").StringVar(&cf.RequestReason)
+	dbConnect.Flag("disable-access-request", "Disable automatic resource access requests.").BoolVar(&cf.disableAccessRequest)
+	dbConnect.Flag("tunnel", "Open authenticated tunnel using database's client certificate so clients don't need to authenticate.").Hidden().BoolVar(&cf.LocalProxyTunnel)
 	dbExec := db.Command("exec", "Execute database commands on target database services.")
 	dbExec.Flag("db-user", "Database user to log in as.").Short('u').StringVar(&cf.DatabaseUser)
 	dbExec.Flag("db-name", "Database name to log in to.").Short('n').StringVar(&cf.DatabaseName)
@@ -1266,7 +1270,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	join := app.Command("join", "Join the active SSH or Kubernetes session.")
 	join.Flag("cluster", clusterHelp).Short('c').StringVar(&cf.SiteName)
 	join.Flag("mode", "Mode of joining the session, valid modes are observer, moderator and peer.").Short('m').Default("observer").EnumVar(&cf.JoinMode, "observer", "moderator", "peer")
-	join.Arg("session-id", "ID of the session to join").Required().StringVar(&cf.SessionID)
+	join.Arg("session-id", "ID of the session to join.").Required().StringVar(&cf.SessionID)
 	// play
 	play := app.Command("play", "Replay the recorded session (SSH, Kubernetes, App, DB).")
 	play.Flag("cluster", clusterHelp).Short('c').StringVar(&cf.SiteName)
@@ -1275,22 +1279,22 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	play.Flag("format", defaults.FormatFlagDescription(
 		teleport.PTY, teleport.JSON, teleport.YAML, teleport.Text,
 	)).Short('f').Default(teleport.PTY).EnumVar(&cf.Format, teleport.PTY, teleport.JSON, teleport.YAML, teleport.Text)
-	play.Arg("session-id", "ID or path to session file to play").Required().StringVar(&cf.SessionID)
+	play.Arg("session-id", "ID or path to session file to play.").Required().StringVar(&cf.SessionID)
 
 	// scp
 	scp := app.Command("scp", "Transfer files to a remote SSH node.")
 	scp.Flag("cluster", clusterHelp).Short('c').StringVar(&cf.SiteName)
-	scp.Arg("from, to", "Source and destination to copy, one must be a local path and one must be a remote path").Required().StringsVar(&cf.CopySpec)
-	scp.Flag("recursive", "Recursive copy of subdirectories").Short('r').BoolVar(&cf.RecursiveCopy)
-	scp.Flag("port", "Port to connect to on the remote host").Short('P').Int32Var(&cf.NodePort)
-	scp.Flag("preserve", "Preserves access and modification times from the original file").Short('p').BoolVar(&cf.PreserveAttrs)
-	scp.Flag("quiet", "Quiet mode").Short('q').BoolVar(&cf.Quiet)
-	scp.Flag("no-resume", "Disable SSH connection resumption").Envar(noResumeEnvVar).BoolVar(&cf.DisableSSHResumption)
-	scp.Flag("relogin", "Permit performing an authentication attempt on a failed command").Default("true").BoolVar(&cf.Relogin)
+	scp.Arg("from, to", "Source and destination to copy, one must be a local path and one must be a remote path.").Required().StringsVar(&cf.CopySpec)
+	scp.Flag("recursive", "Recursive copy of subdirectories.").Short('r').BoolVar(&cf.RecursiveCopy)
+	scp.Flag("port", "Port to connect to on the remote host.").Short('P').Int32Var(&cf.NodePort)
+	scp.Flag("preserve", "Preserves access and modification times from the original file.").Short('p').BoolVar(&cf.PreserveAttrs)
+	scp.Flag("quiet", quietHelp).Short('q').BoolVar(&cf.Quiet)
+	scp.Flag("no-resume", "Disable SSH connection resumption.").Envar(noResumeEnvVar).BoolVar(&cf.DisableSSHResumption)
+	scp.Flag("relogin", "Permit performing an authentication attempt on a failed command.").Default("true").BoolVar(&cf.Relogin)
 	// ls
 	ls := app.Command("ls", "List remote SSH nodes.")
 	ls.Flag("cluster", clusterHelp).Short('c').StringVar(&cf.SiteName)
-	ls.Flag("verbose", "One-line output (for text format), including node UUIDs").Short('v').BoolVar(&cf.Verbose)
+	ls.Flag("verbose", "One-line output (for text format), including node UUIDs.").Short('v').BoolVar(&cf.Verbose)
 	ls.Flag("format", defaults.FormatFlagDescription(
 		teleport.Text, teleport.JSON, teleport.YAML, teleport.Names,
 	)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, teleport.Text, teleport.JSON, teleport.YAML, teleport.Names)
@@ -1302,37 +1306,37 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	// clusters
 	clusters := app.Command("clusters", "List available Teleport clusters.")
 	clusters.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaults.DefaultFormats...)
-	clusters.Flag("quiet", "Quiet mode").Short('q').BoolVar(&cf.Quiet)
-	clusters.Flag("verbose", "Verbose table output, shows full label output").Short('v').BoolVar(&cf.Verbose)
+	clusters.Flag("quiet", quietHelp).Short('q').BoolVar(&cf.Quiet)
+	clusters.Flag("verbose", "Verbose table output, shows full label output.").Short('v').BoolVar(&cf.Verbose)
 
 	// sessions
 	sessions := app.Command("sessions", "Operate on active sessions.")
 	sessionsList := sessions.Command("ls", "List active sessions.")
 	sessionsList.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaults.DefaultFormats...)
-	sessionsList.Flag("kind", "Filter by session kind(s)").Default("ssh", "k8s", "db", "app", "desktop").EnumsVar(&cf.SessionKinds, "ssh", "k8s", "kube", "db", "app", "desktop")
+	sessionsList.Flag("kind", "Filter by session kind(s).").Default("ssh", "k8s", "db", "app", "desktop").EnumsVar(&cf.SessionKinds, "ssh", "k8s", "kube", "db", "app", "desktop")
 
 	// login logs in with remote proxy and obtains a "session certificate" which gets
 	// stored in ~/.tsh directory
 	login := app.Command("login", "Log in to a cluster and retrieve the session certificate.")
-	login.Flag("out", "Identity output").Short('o').AllowDuplicate().StringVar(&cf.IdentityFileOut)
-	login.Flag("format", fmt.Sprintf("Identity format: %s, %s (for OpenSSH compatibility) or %s (for kubeconfig)",
+	login.Flag("out", "Identity output.").Short('o').AllowDuplicate().StringVar(&cf.IdentityFileOut)
+	login.Flag("format", fmt.Sprintf("Identity format: %s, %s (for OpenSSH compatibility) or %s (for kubeconfig).",
 		identityfile.DefaultFormat,
 		identityfile.FormatOpenSSH,
 		identityfile.FormatKubernetes,
 	)).Default(string(identityfile.DefaultFormat)).Short('f').StringVar((*string)(&cf.IdentityFormat))
 	login.Flag("overwrite", "Whether to overwrite the existing identity file.").BoolVar(&cf.IdentityOverwrite)
-	login.Flag("request-roles", "Request one or more extra roles").StringVar(&cf.DesiredRoles)
-	login.Flag("request-reason", "Reason for requesting additional roles").StringVar(&cf.RequestReason)
-	login.Flag("request-reviewers", "Suggested reviewers for role request").StringVar(&cf.SuggestedReviewers)
-	login.Flag("request-nowait", "Finish without waiting for request resolution").BoolVar(&cf.NoWait)
-	login.Flag("request-id", "Login with the roles requested in the given request").StringVar(&cf.RequestID)
+	login.Flag("request-roles", "Request one or more extra roles.").StringVar(&cf.DesiredRoles)
+	login.Flag("request-reason", "Reason for requesting additional roles.").StringVar(&cf.RequestReason)
+	login.Flag("request-reviewers", "Suggested reviewers for role request.").StringVar(&cf.SuggestedReviewers)
+	login.Flag("request-nowait", "Finish without waiting for request resolution.").BoolVar(&cf.NoWait)
+	login.Flag("request-id", "Login with the roles requested in the given request.").StringVar(&cf.RequestID)
 	login.Arg("cluster", clusterHelp).StringVar(&cf.SiteName)
 	login.Flag("scope", `Scope pins credentials to a given scope. Use "" to explicitly remove scoping.`).
 		IsSetByUser(&cf.ScopeSetByUser).
 		StringVar(&cf.Scope)
 	login.Flag("browser", browserHelp).StringVar(&cf.Browser)
-	login.Flag("kube-cluster", "Name of the Kubernetes cluster to login to").StringVar(&cf.KubernetesCluster)
-	login.Flag("verbose", "Show extra status information").Short('v').BoolVar(&cf.Verbose)
+	login.Flag("kube-cluster", "Name of the Kubernetes cluster to login to.").StringVar(&cf.KubernetesCluster)
+	login.Flag("verbose", "Show extra status information.").Short('v').BoolVar(&cf.Verbose)
 	login.Alias(loginUsageFooter)
 
 	// logout deletes obtained session certificates in ~/.tsh
@@ -1342,66 +1346,66 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	latency := app.Command("latency", "Run latency diagnostics.").Hidden()
 
 	latencySSH := latency.Command("ssh", "Measure latency to a particular SSH host.")
-	latencySSH.Arg("[user@]host", "Remote hostname and the login to use").Required().StringVar(&cf.UserHost)
+	latencySSH.Arg("[user@]host", "Remote hostname and the login to use.").Required().StringVar(&cf.UserHost)
 	latencySSH.Flag("cluster", clusterHelp).Short('c').StringVar(&cf.SiteName)
-	latencySSH.Flag("no-resume", "Disable SSH connection resumption").Envar(noResumeEnvVar).BoolVar(&cf.DisableSSHResumption)
+	latencySSH.Flag("no-resume", "Disable SSH connection resumption.").Envar(noResumeEnvVar).BoolVar(&cf.DisableSSHResumption)
 
 	// bench
 	bench := app.Command("bench", "Run Teleport benchmark tests.").Hidden()
 	bench.Flag("cluster", clusterHelp).Short('c').StringVar(&cf.SiteName)
-	bench.Flag("duration", "Test duration").Default("1s").DurationVar(&cf.BenchDuration)
-	bench.Flag("rate", "Requests per second rate").Default("10").IntVar(&cf.BenchRate)
-	bench.Flag("export", "Export the latency profile").BoolVar(&cf.BenchExport)
-	bench.Flag("path", "Directory to save the latency profile to, default path is the current directory").Default(".").StringVar(&cf.BenchExportPath)
-	bench.Flag("ticks", "Ticks per half distance").Default("100").Int32Var(&cf.BenchTicks)
-	bench.Flag("scale", "Value scale in which to scale the recorded values").Default("1.0").Float64Var(&cf.BenchValueScale)
+	bench.Flag("duration", "Test duration.").Default("1s").DurationVar(&cf.BenchDuration)
+	bench.Flag("rate", "Requests per second rate.").Default("10").IntVar(&cf.BenchRate)
+	bench.Flag("export", "Export the latency profile.").BoolVar(&cf.BenchExport)
+	bench.Flag("path", "Directory to save the latency profile to, default path is the current directory.").Default(".").StringVar(&cf.BenchExportPath)
+	bench.Flag("ticks", "Ticks per half distance.").Default("100").Int32Var(&cf.BenchTicks)
+	bench.Flag("scale", "Value scale in which to scale the recorded values.").Default("1.0").Float64Var(&cf.BenchValueScale)
 
-	benchSSH := bench.Command("ssh", "Run SSH benchmark tests").Hidden()
-	benchSSH.Arg("[user@]host", "Remote hostname and the login to use").Required().StringVar(&cf.UserHost)
-	benchSSH.Arg("command", "Command to execute on a remote host").Required().StringsVar(&cf.RemoteCommand)
-	benchSSH.Flag("port", "SSH port on a remote host").Short('p').Int32Var(&cf.NodePort)
-	benchSSH.Flag("random", "Connect to random hosts for each SSH session. The provided hostname must be all: tsh bench ssh --random <user>@all <command>").BoolVar(&cf.BenchRandom)
-	benchSSH.Flag("no-resume", "Disable SSH connection resumption").Envar(noResumeEnvVar).BoolVar(&cf.DisableSSHResumption)
+	benchSSH := bench.Command("ssh", "Run SSH benchmark tests.").Hidden()
+	benchSSH.Arg("[user@]host", "Remote hostname and the login to use.").Required().StringVar(&cf.UserHost)
+	benchSSH.Arg("command", "Command to execute on a remote host.").Required().StringsVar(&cf.RemoteCommand)
+	benchSSH.Flag("port", "SSH port on a remote host.").Short('p').Int32Var(&cf.NodePort)
+	benchSSH.Flag("random", "Connect to random hosts for each SSH session. The provided hostname must be all: tsh bench ssh --random <user>@all <command>.").BoolVar(&cf.BenchRandom)
+	benchSSH.Flag("no-resume", "Disable SSH connection resumption.").Envar(noResumeEnvVar).BoolVar(&cf.DisableSSHResumption)
 
-	benchWeb := bench.Command("web", "Run Web benchmark tests").Hidden()
-	benchWebSSH := benchWeb.Command("ssh", "Run SSH benchmark tests").Hidden()
-	benchWebSSH.Arg("[user@]host", "Remote hostname and the login to use").Required().StringVar(&cf.UserHost)
-	benchWebSSH.Arg("command", "Command to execute on a remote host").Required().StringsVar(&cf.RemoteCommand)
-	benchWebSSH.Flag("port", "SSH port on a remote host").Short('p').Int32Var(&cf.NodePort)
-	benchWebSSH.Flag("random", "Connect to random hosts for each SSH session. The provided hostname must be all: tsh bench ssh --random <user>@all <command>").BoolVar(&cf.BenchRandom)
+	benchWeb := bench.Command("web", "Run Web benchmark tests.").Hidden()
+	benchWebSSH := benchWeb.Command("ssh", "Run SSH benchmark tests.").Hidden()
+	benchWebSSH.Arg("[user@]host", "Remote hostname and the login to use.").Required().StringVar(&cf.UserHost)
+	benchWebSSH.Arg("command", "Command to execute on a remote host.").Required().StringsVar(&cf.RemoteCommand)
+	benchWebSSH.Flag("port", "SSH port on a remote host.").Short('p').Int32Var(&cf.NodePort)
+	benchWebSSH.Flag("random", "Connect to random hosts for each SSH session. The provided hostname must be all: tsh bench ssh --random <user>@all <command>.").BoolVar(&cf.BenchRandom)
 
-	benchWebSessions := benchWeb.Command("sessions", "Run session benchmark tests").Hidden()
-	benchWebSessions.Arg("[user@]host", "Remote hostname and the login to use").Required().StringVar(&cf.UserHost)
-	benchWebSessions.Arg("command", "Command to execute on a remote host").Required().StringsVar(&cf.RemoteCommand)
+	benchWebSessions := benchWeb.Command("sessions", "Run session benchmark tests.").Hidden()
+	benchWebSessions.Arg("[user@]host", "Remote hostname and the login to use.").Required().StringVar(&cf.UserHost)
+	benchWebSessions.Arg("command", "Command to execute on a remote host.").Required().StringsVar(&cf.RemoteCommand)
 	benchWebSessions.Flag("max", "The maximum number of sessions to open. If not specified a single session per node will be opened.").IntVar(&cf.BenchMaxSessions)
 
 	var benchKubeOpts benchKubeOptions
-	benchKube := bench.Command("kube", "Run Kube benchmark tests").Hidden()
+	benchKube := bench.Command("kube", "Run Kube benchmark tests.").Hidden()
 	// kube-namespace exists for backwards compatibility.
-	benchKube.Flag("kube-namespace", "Selects the ").Default("default").Hidden().StringVar(&benchKubeOpts.namespace)
-	benchKube.Flag("namespace", "Selects the ").Default("default").StringVar(&benchKubeOpts.namespace)
-	benchListKube := benchKube.Command("ls", "Run a benchmark test to list Pods").Hidden()
-	benchListKube.Arg("kube_cluster", "Kubernetes cluster to use").Required().StringVar(&cf.KubernetesCluster)
-	benchExecKube := benchKube.Command("exec", "Run a benchmark test to exec into the specified Pod").Hidden()
-	benchExecKube.Arg("kube_cluster", "Kubernetes cluster to use").Required().StringVar(&cf.KubernetesCluster)
-	benchExecKube.Arg("pod", "Pod name to exec into").Required().StringVar(&benchKubeOpts.pod)
-	benchExecKube.Arg("command", "Command to execute on a pod").Required().StringsVar(&cf.RemoteCommand)
+	benchKube.Flag("kube-namespace", "Selects the Kubernetes namespace.").Default("default").Hidden().StringVar(&benchKubeOpts.namespace)
+	benchKube.Flag("namespace", "Selects the Kubernetes namespace.").Default("default").StringVar(&benchKubeOpts.namespace)
+	benchListKube := benchKube.Command("ls", "Run a benchmark test to list Pods.").Hidden()
+	benchListKube.Arg("kube_cluster", "Kubernetes cluster to use.").Required().StringVar(&cf.KubernetesCluster)
+	benchExecKube := benchKube.Command("exec", "Run a benchmark test to exec into the specified Pod.").Hidden()
+	benchExecKube.Arg("kube_cluster", "Kubernetes cluster to use.").Required().StringVar(&cf.KubernetesCluster)
+	benchExecKube.Arg("pod", "Pod name to exec into.").Required().StringVar(&benchKubeOpts.pod)
+	benchExecKube.Arg("command", "Command to execute on a pod.").Required().StringsVar(&cf.RemoteCommand)
 	benchExecKube.Flag("container", "Selects the container to exec into.").StringVar(&benchKubeOpts.container)
-	benchExecKube.Flag("interactive", "Create interactive Kube session").BoolVar(&cf.BenchInteractive)
+	benchExecKube.Flag("interactive", "Create interactive Kube session.").BoolVar(&cf.BenchInteractive)
 
-	benchPostgres := bench.Command("postgres", "Run PostgreSQL database benchmark tests").Hidden()
+	benchPostgres := bench.Command("postgres", "Run PostgreSQL database benchmark tests.").Hidden()
 	benchPostgres.Flag("db-user", "Database user used to connect to the target database. The user must have enough permissions on the database to execute all the benchmark queries.").StringVar(&cf.DatabaseUser)
 	benchPostgres.Flag("db-name", "Database name where benchmark queries will be executed.").StringVar(&cf.DatabaseName)
 	benchPostgres.Arg("database", "Teleport target database name or the direct database URI. Available databases can be retrieved by running `tsh db ls`. When using direct connection, the benchmark will issue connections directly to this database, and no Teleport is involved in the testing. It must contain all the connection information, including authentication credentials.").StringVar(&cf.DatabaseService)
 
-	benchMySQL := bench.Command("mysql", "Run MySQL database benchmark tests").Hidden()
+	benchMySQL := bench.Command("mysql", "Run MySQL database benchmark tests.").Hidden()
 	benchMySQL.Flag("db-user", "Database user used to connect to the target database. The user must have enough permissions on the database to execute all the benchmark queries.").StringVar(&cf.DatabaseUser)
 	benchMySQL.Flag("db-name", "Database name where benchmark queries will be executed.").StringVar(&cf.DatabaseName)
 	benchMySQL.Arg("database", "Teleport target database name or the direct database URI. Available databases can be retrieved by running `tsh db ls`. When using direct connection, the benchmark will issue connections directly to this database, and no Teleport is involved in the testing. It must contain all the connection information, including authentication credentials.").StringVar(&cf.DatabaseService)
 
 	// show key
 	show := app.Command("show", "Read an identity from file and print to stdout.").Hidden()
-	show.Arg("identity_file", "The file containing a public key or a certificate").Required().StringVar(&cf.IdentityFileIn)
+	show.Arg("identity_file", "The file containing a public key or a certificate.").Required().StringVar(&cf.IdentityFileIn)
 
 	// The status command shows which proxy the user is logged into and metadata
 	// about the certificate.
@@ -1415,7 +1419,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	// even if the user runs "tsh login" again in another window.
 	environment := app.Command("env", "Print commands to set Teleport session environment variables.")
 	environment.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaults.DefaultFormats...)
-	environment.Flag("unset", "Print commands to clear Teleport session environment variables").BoolVar(&cf.unsetEnvironment)
+	environment.Flag("unset", "Print commands to clear Teleport session environment variables.").BoolVar(&cf.unsetEnvironment)
 
 	delegation := app.Command("delegation", "Manage delegation sessions.")
 	delegationCreateSession := delegation.Command("create-session", "Create a delegation session, allowing a bot or workload to temporarily act on your behalf.")
@@ -1433,34 +1437,34 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 
 	reqList := req.Command("ls", "List access requests.").Alias("list")
 	reqList.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaults.DefaultFormats...)
-	reqList.Flag("reviewable", "Only show requests reviewable by current user").BoolVar(&cf.ReviewableRequests)
-	reqList.Flag("suggested", "Only show requests that suggest current user as reviewer").BoolVar(&cf.SuggestedRequests)
-	reqList.Flag("my-requests", "Only show requests created by current user").BoolVar(&cf.MyRequests)
+	reqList.Flag("reviewable", "Only show requests reviewable by current user.").BoolVar(&cf.ReviewableRequests)
+	reqList.Flag("suggested", "Only show requests that suggest current user as reviewer.").BoolVar(&cf.SuggestedRequests)
+	reqList.Flag("my-requests", "Only show requests created by current user.").BoolVar(&cf.MyRequests)
 
 	reqShow := req.Command("show", "Show request details.").Alias("details")
 	reqShow.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaults.DefaultFormats...)
-	reqShow.Arg("request-id", "ID of the target request").Required().StringVar(&cf.RequestID)
+	reqShow.Arg("request-id", "ID of the target request.").Required().StringVar(&cf.RequestID)
 
 	// Note: The "tsh request new" subcommand should not be used anymore. It
 	// will be kept around for users that built automation around it, but all
 	// public facing documentation should now refer to "tsh request create".
 	reqCreate := req.Command("create", "Create a new access request.").Alias("new")
-	reqCreate.Flag("roles", "Roles to be requested").StringVar(&cf.DesiredRoles)
-	reqCreate.Flag("reason", "Reason for requesting").StringVar(&cf.RequestReason)
-	reqCreate.Flag("reviewers", "Suggested reviewers").StringVar(&cf.SuggestedReviewers)
-	reqCreate.Flag("nowait", "Finish without waiting for request resolution").BoolVar(&cf.NoWait)
-	reqCreate.Flag("resource", "Resource ID to be requested").StringsVar(&cf.RequestedResourceIDs)
-	reqCreate.Flag("request-ttl", "Expiration time for the access request").DurationVar(&cf.RequestTTL)
-	reqCreate.Flag("session-ttl", "Expiration time for the elevated certificate").DurationVar(&cf.SessionTTL)
-	reqCreate.Flag("max-duration", "How long the access should be granted for").DurationVar(&cf.MaxDuration)
-	reqCreate.Flag("assume-start-time", "Sets time roles can be assumed by requestor (RFC3339 e.g 2023-12-12T23:20:50.52Z)").StringVar(&cf.AssumeStartTimeRaw)
+	reqCreate.Flag("roles", "Roles to be requested.").StringVar(&cf.DesiredRoles)
+	reqCreate.Flag("reason", "Reason for requesting.").StringVar(&cf.RequestReason)
+	reqCreate.Flag("reviewers", "Suggested reviewers.").StringVar(&cf.SuggestedReviewers)
+	reqCreate.Flag("nowait", "Finish without waiting for request resolution.").BoolVar(&cf.NoWait)
+	reqCreate.Flag("resource", "Resource ID to be requested.").StringsVar(&cf.RequestedResourceIDs)
+	reqCreate.Flag("request-ttl", "Expiration time for the access request.").DurationVar(&cf.RequestTTL)
+	reqCreate.Flag("session-ttl", "Expiration time for the elevated certificate.").DurationVar(&cf.SessionTTL)
+	reqCreate.Flag("max-duration", "How long the access should be granted for.").DurationVar(&cf.MaxDuration)
+	reqCreate.Flag("assume-start-time", "Sets time roles can be assumed by requestor (RFC3339 e.g 2023-12-12T23:20:50.52Z).").StringVar(&cf.AssumeStartTimeRaw)
 
 	reqReview := req.Command("review", "Review an access request.")
-	reqReview.Arg("request-id", "ID of target request").Required().StringVar(&cf.RequestID)
-	reqReview.Flag("approve", "Review proposes approval").BoolVar(&cf.Approve)
-	reqReview.Flag("deny", "Review proposes denial").BoolVar(&cf.Deny)
-	reqReview.Flag("reason", "Review reason message").StringVar(&cf.ReviewReason)
-	reqReview.Flag("assume-start-time", "Sets time roles can be assumed by requestor (RFC3339 e.g 2023-12-12T23:20:50.52Z)").StringVar(&cf.AssumeStartTimeRaw)
+	reqReview.Arg("request-id", "ID of target request.").Required().StringVar(&cf.RequestID)
+	reqReview.Flag("approve", "Review proposes approval.").BoolVar(&cf.Approve)
+	reqReview.Flag("deny", "Review proposes denial.").BoolVar(&cf.Deny)
+	reqReview.Flag("reason", "Review reason message.").StringVar(&cf.ReviewReason)
+	reqReview.Flag("assume-start-time", "Sets time roles can be assumed by requestor (RFC3339 e.g 2023-12-12T23:20:50.52Z).").StringVar(&cf.AssumeStartTimeRaw)
 
 	reqSearch := req.Command("search", "Search for resources to request access to.")
 	reqSearch.Flag("kind", fmt.Sprintf("Resource kind to search for (%s).  Mutually exclusive with --roles.", strings.Join(types.RequestableResourceKinds, ", "))).StringVar(&cf.ResourceKind)
@@ -1520,21 +1524,21 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	reqSearch.Flag("search", searchHelp).StringVar(&cf.SearchKeywords)
 	reqSearch.Flag("query", queryHelp).StringVar(&cf.PredicateExpression)
 	reqSearch.Flag("labels", labelHelp).StringVar(&cf.Labels)
-	reqSearch.Flag("kube-cluster", "Kubernetes Cluster to search for Pods").StringVar(&cf.KubernetesCluster)
+	reqSearch.Flag("kube-cluster", "Kubernetes Cluster to search for Pods.").StringVar(&cf.KubernetesCluster)
 	// kube-namespace exists for backwards compatibility.
-	reqSearch.Flag("kube-namespace", "Kubernetes Namespace to search for Pods").Hidden().Default(corev1.NamespaceDefault).StringVar(&cf.kubeNamespace)
-	reqSearch.Flag("namespace", "Kubernetes Namespace to search for Pods").Default(corev1.NamespaceDefault).StringVar(&cf.kubeNamespace)
-	reqSearch.Flag("all-kube-namespaces", "Search Pods in every namespace").BoolVar(&cf.kubeAllNamespaces)
-	reqSearch.Flag("verbose", "Verbose table output, shows full label output").Short('v').BoolVar(&cf.Verbose)
+	reqSearch.Flag("kube-namespace", "Kubernetes Namespace to search for Pods.").Hidden().Default(corev1.NamespaceDefault).StringVar(&cf.kubeNamespace)
+	reqSearch.Flag("namespace", "Kubernetes Namespace to search for Pods.").Default(corev1.NamespaceDefault).StringVar(&cf.kubeNamespace)
+	reqSearch.Flag("all-kube-namespaces", "Search Pods in every namespace.").BoolVar(&cf.kubeAllNamespaces)
+	reqSearch.Flag("verbose", "Verbose table output, shows full label output.").Short('v').BoolVar(&cf.Verbose)
 
 	// Headless login approval
 	headless := app.Command("headless", "Headless authentication commands.").Interspersed(true)
 	headlessApprove := headless.Command("approve", "Approve a headless authentication request.").Interspersed(true)
-	headlessApprove.Arg("request id", "Headless authentication request ID").StringVar(&cf.HeadlessAuthenticationID)
-	headlessApprove.Flag("skip-confirm", "Skip confirmation and prompt for MFA immediately").Envar(headlessSkipConfirmEnvVar).BoolVar(&cf.headlessSkipConfirm)
+	headlessApprove.Arg("request id", "Headless authentication request ID.").StringVar(&cf.HeadlessAuthenticationID)
+	headlessApprove.Flag("skip-confirm", "Skip confirmation and prompt for MFA immediately.").Envar(headlessSkipConfirmEnvVar).BoolVar(&cf.headlessSkipConfirm)
 
 	reqDrop := req.Command("drop", "Drop one or more access requests from current identity.")
-	reqDrop.Arg("request-id", "IDs of requests to drop (default drops all requests)").Default("*").StringsVar(&cf.RequestIDs)
+	reqDrop.Arg("request-id", "IDs of requests to drop (default drops all requests).").Default("*").StringsVar(&cf.RequestIDs)
 	kubectl := app.Command("kubectl", "Runs a kubectl command on a Kubernetes cluster.").Interspersed(false)
 	// This hack is required in order to accept any args for tsh kubectl.
 	kubectl.Arg("", "").StringsVar(new([]string))
@@ -1548,12 +1552,12 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	scopes := newScopesCommand(app)
 
 	config := app.Command("config", "Print OpenSSH configuration details.")
-	config.Flag("port", "SSH port on a remote host").Short('p').Int32Var(&cf.NodePort)
+	config.Flag("port", "SSH port on a remote host.").Short('p').Int32Var(&cf.NodePort)
 
-	puttyConfig := app.Command("puttyconfig", "Add PuTTY saved session configuration for specified hostname to Windows registry")
-	puttyConfig.Arg("[user@]host", "Remote hostname and optional login to use").Required().StringVar(&cf.UserHost)
-	puttyConfig.Flag("port", "SSH port on a remote host").Short('p').Int32Var(&cf.NodePort)
-	puttyConfig.Flag("leaf", "Add a configuration for connecting to a leaf cluster").StringVar(&cf.LeafClusterName)
+	puttyConfig := app.Command("puttyconfig", "Add PuTTY saved session configuration for specified hostname to Windows registry.")
+	puttyConfig.Arg("[user@]host", "Remote hostname and optional login to use.").Required().StringVar(&cf.UserHost)
+	puttyConfig.Flag("port", "SSH port on a remote host.").Short('p').Int32Var(&cf.NodePort)
+	puttyConfig.Flag("leaf", "Add a configuration for connecting to a leaf cluster.").StringVar(&cf.LeafClusterName)
 	// only expose `tsh puttyconfig` subcommand on windows
 	if runtime.GOOS != constants.WindowsOS {
 		puttyConfig.Hidden()

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -458,6 +458,8 @@ type CLIConf struct {
 
 	// OverrideStdout allows to switch standard output source for resource command. Used in tests.
 	OverrideStdout io.Writer
+	// proxyStatusOutputWriter is where human-oriented proxy status messages are written.
+	proxyStatusOutputWriter io.Writer
 	// overrideStderr allows to switch standard error source for resource command. Used in tests.
 	overrideStderr io.Writer
 	// overrideStdin allows to switch standard in source for resource command. Used in tests.
@@ -719,6 +721,24 @@ func (c *CLIConf) Stdout() io.Writer {
 	return os.Stdout
 }
 
+// ProxyStatusOutput returns the writer used for human-oriented proxy status
+// messages.
+//
+// This must be distinct from Stdout so that shell pipelines like
+// `echo 'kubectl config view' | tsh proxy kube my-cluster --exec | yq` can
+// suppress or redirect proxy status text without also changing the command's
+// actual stdout stream.
+func (c *CLIConf) ProxyStatusOutput() io.Writer {
+	if c.proxyStatusOutputWriter != nil {
+		return c.proxyStatusOutputWriter
+	}
+	// Note: See the proxyStatusOutputDefault constant used by
+	// configureProxyStatusOutput() for the real default. This return is just
+	// defensive code in case this function is called before
+	// configureProxyStatusOutput().
+	return os.Stderr
+}
+
 // Stderr returns the stderr writer.
 func (c *CLIConf) Stderr() io.Writer {
 	if c.overrideStderr != nil {
@@ -836,6 +856,12 @@ const (
 	mcpClientConfigEnvVar     = "TELEPORT_MCP_CLIENT_CONFIG"
 	mcpConfigJSONFormatEnvVar = "TELEPORT_MCP_CONFIG_JSON_FORMAT"
 	toolsCheckUpdateEnvVar    = "TELEPORT_TOOLS_CHECK_UPDATE"
+	proxyStatusOutputEnvVar   = "TELEPORT_PROXY_LOG_OUTPUT"
+
+	proxyStatusOutputDefault = "stderr"
+	proxyStatusOutputStdout  = "stdout"
+	proxyStatusOutputStderr  = "stderr"
+	proxyStatusOutputNone    = "none"
 
 	clusterHelp = "Specify the Teleport cluster to connect"
 	browserHelp = "Set to 'none' to suppress browser opening on login"
@@ -911,6 +937,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 
 	moduleCfg := modules.GetModules()
 	var cpuProfile, memProfile, traceProfile string
+	proxyStatusOutput := proxyStatusOutputDefault
 
 	// configure CLI argument parser:
 	app := utils.InitCLIParser("tsh", "Teleport Command Line Client").Interspersed(true)
@@ -1120,6 +1147,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 
 	// Local TLS proxy.
 	proxy := app.Command("proxy", "Run local TLS proxy allowing connecting to Teleport in single-port mode.")
+	proxy.Flag("proxy-log-output", fmt.Sprintf("Select where proxy status messages are printed. Defaults to %q, but can be used to revert to legacy behavior of send proxy output to stdout. Valid values are %q, %q, and %q.", proxyStatusOutputDefault, proxyStatusOutputStdout, proxyStatusOutputStderr, proxyStatusOutputNone)).Envar(proxyStatusOutputEnvVar).Default(proxyStatusOutputDefault).EnumVar(&proxyStatusOutput, proxyStatusOutputStdout, proxyStatusOutputStderr, proxyStatusOutputNone)
 	proxySSH := proxy.Command("ssh", "Start local TLS proxy for ssh connections when using Teleport in single-port mode.")
 	proxySSH.Arg("[user@]host", "Remote hostname and the login to use").Required().StringVar(&cf.UserHost)
 	proxySSH.Flag("cluster", clusterHelp).Short('c').StringVar(&cf.SiteName)
@@ -1684,6 +1712,9 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		if err := opt(&cf); err != nil {
 			return trace.Wrap(err)
 		}
+	}
+	if err := configureProxyStatusOutput(&cf, proxyStatusOutput); err != nil {
+		return trace.Wrap(err)
 	}
 
 	// Enable debug logging if requested by --debug.
@@ -6482,6 +6513,25 @@ func onHeadlessApprove(cf *CLIConf) error {
 		return tc.HeadlessApprove(cf.Context, cf.HeadlessAuthenticationID, !cf.headlessSkipConfirm)
 	})
 	return trace.Wrap(err)
+}
+
+func configureProxyStatusOutput(cf *CLIConf, proxyStatusOutput string) error {
+	// This should be unreachable because Kingpin validates the flag value against
+	// the allowed enum values.
+	if proxyStatusOutput == "" {
+		proxyStatusOutput = proxyStatusOutputDefault
+	}
+	switch proxyStatusOutput {
+	case proxyStatusOutputStdout:
+		cf.proxyStatusOutputWriter = cf.Stdout()
+	case proxyStatusOutputStderr:
+		cf.proxyStatusOutputWriter = cf.Stderr()
+	case proxyStatusOutputNone:
+		cf.proxyStatusOutputWriter = io.Discard
+	default:
+		return trace.BadParameter("unreachable code: proxyStatusOutput %q is not a known output destination", proxyStatusOutput)
+	}
+	return nil
 }
 
 var mlockModes = []string{mlockModeNo, mlockModeAuto, mlockModeBestEffort, mlockModeStrict}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1329,8 +1329,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		identityfile.FormatKubernetes,
 	)).Default(string(identityfile.DefaultFormat)).Short('f').StringVar((*string)(&cf.IdentityFormat))
 	login.Flag("overwrite", "Whether to overwrite the existing identity file.").BoolVar(&cf.IdentityOverwrite)
-  login.Flag("force", "Force re-authentication even if the current session is still valid.").BoolVar(&cf.ForceReauth)
-  login.Flag("request-roles", "Request one or more extra roles.").StringVar(&cf.DesiredRoles)
+	login.Flag("force", "Force re-authentication even if the current session is still valid.").BoolVar(&cf.ForceReauth)
+	login.Flag("request-roles", "Request one or more extra roles.").StringVar(&cf.DesiredRoles)
 	login.Flag("request-reason", "Reason for requesting additional roles.").StringVar(&cf.RequestReason)
 	login.Flag("request-reviewers", "Suggested reviewers for role request.").StringVar(&cf.SuggestedReviewers)
 	login.Flag("request-nowait", "Finish without waiting for request resolution.").BoolVar(&cf.NoWait)

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -98,6 +98,7 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
+	"github.com/gravitational/teleport/lib/utils/testutils"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 	"github.com/gravitational/teleport/session/networking/x11"
 	"github.com/gravitational/teleport/session/reexec"
@@ -8161,6 +8162,28 @@ func prepareCLIOptionForReadingLoggingOpts() (func(t *testing.T) loggingOpts, Cl
 	}
 
 	return mustReadLoggingOpts, setLoggingOptsFromCLIConf
+}
+
+func Test_validateKingpinAppHelp(t *testing.T) {
+	err := Run(
+		context.Background(),
+		[]string{"version"},
+		setHomePath(t.TempDir()),
+		func(cf *CLIConf) error {
+			require.NotNil(t, cf.kingpinApp)
+
+			issues := testutils.FindKingpinAppHelpIssues(cf.kingpinApp)
+			if len(issues) > 0 {
+				t.Log("Found", len(issues), "issues")
+				for _, issue := range issues {
+					t.Log(issue)
+				}
+			}
+			require.Empty(t, issues)
+			return trace.BadParameter("no need to continue")
+		},
+	)
+	require.ErrorIs(t, err, trace.BadParameter("no need to continue"))
 }
 
 func TestSSHForkAfterAuthentication(t *testing.T) {

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -8483,3 +8483,178 @@ func TestSSHEnv(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigureProxyStatusOutput(t *testing.T) {
+	t.Run("stdout preserves override", func(t *testing.T) {
+		stdout := &bytes.Buffer{}
+		cf := &CLIConf{
+			OverrideStdout: stdout,
+		}
+
+		require.NoError(t, configureProxyStatusOutput(cf, proxyStatusOutputStdout))
+
+		require.Same(t, stdout, cf.ProxyStatusOutput())
+	})
+
+	t.Run("stderr uses stderr writer", func(t *testing.T) {
+		stderr := &bytes.Buffer{}
+		cf := &CLIConf{
+			OverrideStdout: &bytes.Buffer{},
+			overrideStderr: stderr,
+		}
+
+		require.NoError(t, configureProxyStatusOutput(cf, proxyStatusOutputStderr))
+
+		require.Same(t, stderr, cf.ProxyStatusOutput())
+		require.NotSame(t, stderr, cf.Stdout())
+	})
+
+	t.Run("none discards output", func(t *testing.T) {
+		cf := &CLIConf{}
+
+		require.NoError(t, configureProxyStatusOutput(cf, proxyStatusOutputNone))
+
+		require.Equal(t, io.Discard, cf.ProxyStatusOutput())
+	})
+
+	t.Run("empty output defaults to stderr", func(t *testing.T) {
+		cf := &CLIConf{}
+
+		require.NoError(t, configureProxyStatusOutput(cf, ""))
+
+		require.Equal(t, os.Stderr, cf.ProxyStatusOutput())
+	})
+
+	t.Run("unknown output fails", func(t *testing.T) {
+		err := configureProxyStatusOutput(&CLIConf{}, "unknown")
+
+		require.ErrorContains(t, err, "unreachable code")
+	})
+}
+
+func TestProxyStatusOutputParsing(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		args     []string
+		env      map[string]string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "default stderr",
+			expected: proxyStatusOutputStderr,
+		},
+		// Kingpin treats an empty environment variable as unset, so the default
+		// value is used. An explicitly empty flag is rejected as an invalid enum.
+		{
+			name: "empty env defaults to stderr",
+			env: map[string]string{
+				proxyStatusOutputEnvVar: "",
+			},
+			expected: proxyStatusOutputStderr,
+		},
+		{
+			name: "env stdout",
+			env: map[string]string{
+				proxyStatusOutputEnvVar: proxyStatusOutputStdout,
+			},
+			expected: proxyStatusOutputStdout,
+		},
+		{
+			name: "env stderr",
+			env: map[string]string{
+				proxyStatusOutputEnvVar: proxyStatusOutputStderr,
+			},
+			expected: proxyStatusOutputStderr,
+		},
+		{
+			name: "env none",
+			env: map[string]string{
+				proxyStatusOutputEnvVar: proxyStatusOutputNone,
+			},
+			expected: proxyStatusOutputNone,
+		},
+		{
+			name:     "flag stdout",
+			args:     []string{"--proxy-log-output=stdout"},
+			expected: proxyStatusOutputStdout,
+		},
+		{
+			name:    "empty flag fails parsing",
+			args:    []string{"--proxy-log-output="},
+			wantErr: true,
+		},
+		{
+			name:     "flag stderr",
+			args:     []string{"--proxy-log-output=stderr"},
+			expected: proxyStatusOutputStderr,
+		},
+		{
+			name:     "flag none",
+			args:     []string{"--proxy-log-output=none"},
+			expected: proxyStatusOutputNone,
+		},
+		{
+			name: "flag overrides env",
+			args: []string{"--proxy-log-output=none"},
+			env: map[string]string{
+				proxyStatusOutputEnvVar: proxyStatusOutputStderr,
+			},
+			expected: proxyStatusOutputNone,
+		},
+		{
+			name:    "invalid env",
+			env:     map[string]string{proxyStatusOutputEnvVar: "foobar"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid flag",
+			args:    []string{"--proxy-log-output=foobar"},
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			var proxyStatusOutput string
+			app := utils.InitCLIParser("tsh", "Teleport Command Line Client.")
+			app.Flag("proxy-log-output", "Test fixture only, help message not tested in this test").
+				Envar(proxyStatusOutputEnvVar).
+				Hidden().
+				Default(proxyStatusOutputDefault).
+				EnumVar(&proxyStatusOutput, proxyStatusOutputStdout, proxyStatusOutputStderr, proxyStatusOutputNone)
+			_, err := app.Parse(tt.args)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, proxyStatusOutput)
+		})
+	}
+}
+
+func TestProxyStatusOutputHelp(t *testing.T) {
+	const success_param = "parameters-verified, short-circuit success"
+	err := Run(
+		context.Background(),
+		[]string{"version"},
+		setHomePath(t.TempDir()),
+		func(cf *CLIConf) error {
+			require.NotNil(t, cf.kingpinApp)
+
+			var buf bytes.Buffer
+			cf.kingpinApp.UsageWriter(&buf)
+			ctx, err := cf.kingpinApp.ParseContext([]string{"proxy", "--help"})
+			require.NoError(t, err)
+			require.NoError(t, cf.kingpinApp.UsageForContext(ctx))
+
+			help := buf.String()
+			require.Contains(t, help, "--proxy-log-output")
+			return trace.BadParameter(success_param)
+		},
+	)
+	require.ErrorIs(t, err, trace.BadParameter(success_param))
+}

--- a/tool/tsh/common/vnet.go
+++ b/tool/tsh/common/vnet.go
@@ -49,7 +49,7 @@ func newVnetCommand(app *kingpin.Application) *vnetCommand {
 	cmd := &vnetCommand{
 		CmdClause: app.Command("vnet", "Start Teleport VNet, a virtual network for TCP application access."),
 	}
-	cmd.Flag("diag", "Run diagnostics after starting VNet").Hidden().BoolVar(&cmd.runDiag)
+	cmd.Flag("diag", "Run diagnostics after starting VNet.").Hidden().BoolVar(&cmd.runDiag)
 	return cmd
 }
 

--- a/tool/tsh/common/vnet_darwin.go
+++ b/tool/tsh/common/vnet_darwin.go
@@ -47,8 +47,8 @@ func newPlatformVnetAdminSetupCommand(app *kingpin.Application) *vnetAdminSetupC
 	cmd := &vnetAdminSetupCommand{
 		CmdClause: app.Command(teleport.VnetAdminSetupSubCommand, "Start the VNet admin subprocess.").Hidden(),
 	}
-	cmd.Flag("addr", "client application service address").Required().StringVar(&cmd.addr)
-	cmd.Flag("cred-path", "path to TLS credentials for connecting to client application").Required().StringVar(&cmd.credPath)
+	cmd.Flag("addr", "Client application service address.").Required().StringVar(&cmd.addr)
+	cmd.Flag("cred-path", "Path to TLS credentials for connecting to client application.").Required().StringVar(&cmd.credPath)
 	return cmd
 }
 

--- a/tool/tsh/common/workload_identity.go
+++ b/tool/tsh/common/workload_identity.go
@@ -59,7 +59,7 @@ type workloadIdentityCommands struct {
 func newWorkloadIdentityCommands(
 	app *kingpin.Application,
 ) workloadIdentityCommands {
-	cmd := app.Command("workload-identity", "Issue Workload Identity credentials")
+	cmd := app.Command("workload-identity", "Issue Workload Identity credentials.")
 	cmds := workloadIdentityCommands{
 		issueX509: newIssueX509Command(cmd),
 		issueJWT:  newIssueJWTCommand(cmd),
@@ -82,7 +82,7 @@ func newIssueX509Command(parent *kingpin.CmdClause) *issueX509Command {
 
 	cmd.Flag(
 		"name-selector",
-		"The name of the workload identity to issue",
+		"The name of the workload identity to issue.",
 	).StringVar(&cmd.nameSelector)
 	cmd.Flag(
 		"label-selector",


### PR DESCRIPTION
Changelog: Status messages from `tsh proxy` now go to stderr by default and can now be redirected with `--proxy-log-output` / `TELEPORT_PROXY_LOG_OUTPUT`.

Backports the following changes to v18:

- [Added flag to prevent tsh proxy from writing to stdout #68562](https://github.com/gravitational/teleport/pull/68562)
  (Primary backport)
- [Fix intermediate flags in docs gen and correct test drift #68591](https://github.com/gravitational/teleport/pull/68591)
  (Dependency)
- [add missing periods for tsh help usage #55686 ](https://github.com/gravitational/teleport/pull/55686)
  (Dependency)

## Manual Test Plan

### Test Environment

Teleport Cloud or a local `k3d` cluster with `kubectl` installed and a working
`tsh` login for the target cluster.

### Test Cases

- [x] Confirm the new flag is shown in proxy help:

  ```bash
  TELEPORT_TOOLS_VERSION=off \
  build/tsh --skip-version-check proxy kube --help 2>&1 \
    | grep -- '--proxy-log-output'
  ```

  The help output should include `--proxy-log-output`.

- [x] Confirm proxy status text goes to stderr when nothing is set:

  ```bash
  echo 'kubectl version' \
    | TELEPORT_TOOLS_VERSION=off \
    build/tsh --skip-version-check proxy kube my-cluster --exec 1>/dev/null
  ```

  The first visible line should contain the
  `Preparing the following Teleport Kubernetes clusters:` message.

- [x] Confirm `--proxy-log-output=stdout` keeps proxy status text on stdout:

  ```bash
  echo 'kubectl config view' \
    | TELEPORT_TOOLS_VERSION=off \
    build/tsh --skip-version-check proxy --proxy-log-output=stdout kube my-cluster --exec 2>/dev/null
  ```

  The first line should be "Preparing the following Teleport Kubernetes
  clusters:"

- [x] Confirm `--proxy-log-output=stderr` puts the proxy status text to stderr:

  ```bash
  echo 'kubectl config view' \
    | TELEPORT_TOOLS_VERSION=off \
    build/tsh --skip-version-check proxy --proxy-log-output=stderr kube my-cluster --exec \
    | yq
  ```

  `yq` should correctly parse the `kubectl` yaml output and the output should
  contain the `Preparing the following Teleport Kubernetes clusters:` message.

- [x] Confirm `--proxy-log-output=none` suppresses proxy status text:

  ```bash
  echo 'kubectl config view' \
    | TELEPORT_TOOLS_VERSION=off \
    build/tsh --skip-version-check proxy --proxy-log-output=none kube my-cluster --exec \
    | yq
  ```

  `yq` should correctly parse the `kubectl` yaml output and the proxy status
  messages should not appear.

- [x] Confirm `TELEPORT_PROXY_LOG_OUTPUT=stdout` puts proxy status text on
      stdout:

  ```bash
  echo 'kubectl config view' \
    | TELEPORT_TOOLS_VERSION=off \
    TELEPORT_PROXY_LOG_OUTPUT=stdout \
    build/tsh --skip-version-check proxy kube my-cluster --exec 2>/dev/null
  ```

  The first line should contain the
  `Preparing the following Teleport Kubernetes clusters:` message.

- [x] Confirm `TELEPORT_PROXY_LOG_OUTPUT=stderr` leaves the proxy status text on
      stderr:

  ```bash
  echo 'kubectl config view' \
    | TELEPORT_TOOLS_VERSION=off \
    TELEPORT_PROXY_LOG_OUTPUT=stderr \
    build/tsh --skip-version-check proxy kube my-cluster --exec
    | yq
  ```

  `yq` should correctly parse the `kubectl` yaml output and the output should
  contain the `Preparing the following Teleport Kubernetes clusters:` message.

- [x] Confirm `TELEPORT_PROXY_LOG_OUTPUT=none` suppresses proxy status text:

  ```bash
  echo 'kubectl config view' \
    | TELEPORT_TOOLS_VERSION=off \
    TELEPORT_PROXY_LOG_OUTPUT=none \
    build/tsh --skip-version-check proxy kube my-cluster --exec \
    | yq
  ```

  `yq` should correctly parse the `kubectl` yaml output and the proxy status
  message should not appear.

- [x] Confirm the flag takes precedence when both are set:

  ```bash
  echo 'kubectl config view' \
    | TELEPORT_TOOLS_VERSION=off \
    TELEPORT_PROXY_LOG_OUTPUT=none \
    build/tsh --skip-version-check proxy --proxy-log-output=stdout kube my-cluster --exec \
  ```

  The first line should contain the
  `Preparing the following Teleport Kubernetes clusters:` message.