### PR TITLE
Namespace application server in presence service

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -1589,13 +1589,23 @@ func (c *Client) UpsertApplicationServer(ctx context.Context, server types.AppSe
 	return keepAlive, nil
 }
 
-// DeleteApplicationServer removes specified application server.
+// DeleteApplicationServer removes an unscoped application server.
+//
+// Deprecated: Use [Client.DeleteAppServer] instead, which supports
+// scoped application servers.
+// TODO (williamo): Remove in v20
 func (c *Client) DeleteApplicationServer(ctx context.Context, namespace, hostID, name string) error {
 	_, err := c.grpc.DeleteApplicationServer(ctx, &proto.DeleteApplicationServerRequest{
 		Namespace: namespace,
 		HostID:    hostID,
 		Name:      name,
 	})
+	return trace.Wrap(err)
+}
+
+// DeleteAppServer removes a scoped or unscoped application server.
+func (c *Client) DeleteAppServer(ctx context.Context, req *presencepb.DeleteAppServerRequest) error {
+	_, err := c.PresenceServiceClient().DeleteAppServer(ctx, req)
 	return trace.Wrap(err)
 }
 

--- a/api/gen/proto/go/teleport/presence/v1/service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/presence/v1/service_grpc.pb.go
@@ -52,6 +52,7 @@ const (
 	PresenceService_GetKubeCluster_FullMethodName      = "/teleport.presence.v1.PresenceService/GetKubeCluster"
 	PresenceService_ListKubeClusters_FullMethodName    = "/teleport.presence.v1.PresenceService/ListKubeClusters"
 	PresenceService_DeleteKubeCluster_FullMethodName   = "/teleport.presence.v1.PresenceService/DeleteKubeCluster"
+	PresenceService_DeleteAppServer_FullMethodName     = "/teleport.presence.v1.PresenceService/DeleteAppServer"
 )
 
 // PresenceServiceClient is the client API for PresenceService service.
@@ -94,6 +95,8 @@ type PresenceServiceClient interface {
 	ListKubeClusters(ctx context.Context, in *ListKubeClustersRequest, opts ...grpc.CallOption) (*ListKubeClustersResponse, error)
 	// Deletes a kube cluster resource from the backend.
 	DeleteKubeCluster(ctx context.Context, in *DeleteKubeClusterRequest, opts ...grpc.CallOption) (*DeleteKubeClusterResponse, error)
+	// Deletes a specific scoped or unscoped application server.
+	DeleteAppServer(ctx context.Context, in *DeleteAppServerRequest, opts ...grpc.CallOption) (*DeleteAppServerResponse, error)
 }
 
 type presenceServiceClient struct {
@@ -274,6 +277,16 @@ func (c *presenceServiceClient) DeleteKubeCluster(ctx context.Context, in *Delet
 	return out, nil
 }
 
+func (c *presenceServiceClient) DeleteAppServer(ctx context.Context, in *DeleteAppServerRequest, opts ...grpc.CallOption) (*DeleteAppServerResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteAppServerResponse)
+	err := c.cc.Invoke(ctx, PresenceService_DeleteAppServer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // PresenceServiceServer is the server API for PresenceService service.
 // All implementations must embed UnimplementedPresenceServiceServer
 // for forward compatibility.
@@ -314,6 +327,8 @@ type PresenceServiceServer interface {
 	ListKubeClusters(context.Context, *ListKubeClustersRequest) (*ListKubeClustersResponse, error)
 	// Deletes a kube cluster resource from the backend.
 	DeleteKubeCluster(context.Context, *DeleteKubeClusterRequest) (*DeleteKubeClusterResponse, error)
+	// Deletes a specific scoped or unscoped application server.
+	DeleteAppServer(context.Context, *DeleteAppServerRequest) (*DeleteAppServerResponse, error)
 	mustEmbedUnimplementedPresenceServiceServer()
 }
 
@@ -374,6 +389,9 @@ func (UnimplementedPresenceServiceServer) ListKubeClusters(context.Context, *Lis
 }
 func (UnimplementedPresenceServiceServer) DeleteKubeCluster(context.Context, *DeleteKubeClusterRequest) (*DeleteKubeClusterResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteKubeCluster not implemented")
+}
+func (UnimplementedPresenceServiceServer) DeleteAppServer(context.Context, *DeleteAppServerRequest) (*DeleteAppServerResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteAppServer not implemented")
 }
 func (UnimplementedPresenceServiceServer) mustEmbedUnimplementedPresenceServiceServer() {}
 func (UnimplementedPresenceServiceServer) testEmbeddedByValue()                         {}
@@ -702,6 +720,24 @@ func _PresenceService_DeleteKubeCluster_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _PresenceService_DeleteAppServer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteAppServerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PresenceServiceServer).DeleteAppServer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PresenceService_DeleteAppServer_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PresenceServiceServer).DeleteAppServer(ctx, req.(*DeleteAppServerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // PresenceService_ServiceDesc is the grpc.ServiceDesc for PresenceService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -776,6 +812,10 @@ var PresenceService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteKubeCluster",
 			Handler:    _PresenceService_DeleteKubeCluster_Handler,
+		},
+		{
+			MethodName: "DeleteAppServer",
+			Handler:    _PresenceService_DeleteAppServer_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/api/gen/proto/go/teleport/presence/v1/service_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/presence/v1/service_protohybrid.pb.go
@@ -2098,6 +2098,144 @@ func (b0 DeleteKubeClusterResponse_builder) Build() *DeleteKubeClusterResponse {
 	return m0
 }
 
+// The request to delete a specific scoped or unscoped application server.
+type DeleteAppServerRequest struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// HostId is the app server host uuid.
+	HostId string `protobuf:"bytes,1,opt,name=host_id,json=hostId,proto3" json:"host_id,omitempty"`
+	// Name is the name of the application to delete.
+	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	// Scope is the scope of the application to delete. Empty for unscoped
+	// applications.
+	Scope         string `protobuf:"bytes,3,opt,name=scope,proto3" json:"scope,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteAppServerRequest) Reset() {
+	*x = DeleteAppServerRequest{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteAppServerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteAppServerRequest) ProtoMessage() {}
+
+func (x *DeleteAppServerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *DeleteAppServerRequest) GetHostId() string {
+	if x != nil {
+		return x.HostId
+	}
+	return ""
+}
+
+func (x *DeleteAppServerRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *DeleteAppServerRequest) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
+func (x *DeleteAppServerRequest) SetHostId(v string) {
+	x.HostId = v
+}
+
+func (x *DeleteAppServerRequest) SetName(v string) {
+	x.Name = v
+}
+
+func (x *DeleteAppServerRequest) SetScope(v string) {
+	x.Scope = v
+}
+
+type DeleteAppServerRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// HostId is the app server host uuid.
+	HostId string
+	// Name is the name of the application to delete.
+	Name string
+	// Scope is the scope of the application to delete. Empty for unscoped
+	// applications.
+	Scope string
+}
+
+func (b0 DeleteAppServerRequest_builder) Build() *DeleteAppServerRequest {
+	m0 := &DeleteAppServerRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.HostId = b.HostId
+	x.Name = b.Name
+	x.Scope = b.Scope
+	return m0
+}
+
+// The response for deleting an application server.
+type DeleteAppServerResponse struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteAppServerResponse) Reset() {
+	*x = DeleteAppServerResponse{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteAppServerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteAppServerResponse) ProtoMessage() {}
+
+func (x *DeleteAppServerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type DeleteAppServerResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 DeleteAppServerResponse_builder) Build() *DeleteAppServerResponse {
+	m0 := &DeleteAppServerResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
 var File_teleport_presence_v1_service_proto protoreflect.FileDescriptor
 
 const file_teleport_presence_v1_service_proto_rawDesc = "" +
@@ -2180,7 +2318,12 @@ const file_teleport_presence_v1_service_proto_rawDesc = "" +
 	"\x18DeleteKubeClusterRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05scope\x18\x02 \x01(\tR\x05scope\"\x1b\n" +
-	"\x19DeleteKubeClusterResponse2\xdd\x0e\n" +
+	"\x19DeleteKubeClusterResponse\"[\n" +
+	"\x16DeleteAppServerRequest\x12\x17\n" +
+	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
+	"\x05scope\x18\x03 \x01(\tR\x05scope\"\x19\n" +
+	"\x17DeleteAppServerResponse2\xcd\x0f\n" +
 	"\x0fPresenceService\x12Y\n" +
 	"\x10GetRemoteCluster\x12-.teleport.presence.v1.GetRemoteClusterRequest\x1a\x16.types.RemoteClusterV3\x12w\n" +
 	"\x12ListRemoteClusters\x12/.teleport.presence.v1.ListRemoteClustersRequest\x1a0.teleport.presence.v1.ListRemoteClustersResponse\x12_\n" +
@@ -2198,9 +2341,10 @@ const file_teleport_presence_v1_service_proto_rawDesc = "" +
 	"\x11DeleteProxyServer\x12..teleport.presence.v1.DeleteProxyServerRequest\x1a/.teleport.presence.v1.DeleteProxyServerResponse\x12k\n" +
 	"\x0eGetKubeCluster\x12+.teleport.presence.v1.GetKubeClusterRequest\x1a,.teleport.presence.v1.GetKubeClusterResponse\x12q\n" +
 	"\x10ListKubeClusters\x12-.teleport.presence.v1.ListKubeClustersRequest\x1a..teleport.presence.v1.ListKubeClustersResponse\x12t\n" +
-	"\x11DeleteKubeCluster\x12..teleport.presence.v1.DeleteKubeClusterRequest\x1a/.teleport.presence.v1.DeleteKubeClusterResponseBTZRgithub.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1;presencev1b\x06proto3"
+	"\x11DeleteKubeCluster\x12..teleport.presence.v1.DeleteKubeClusterRequest\x1a/.teleport.presence.v1.DeleteKubeClusterResponse\x12n\n" +
+	"\x0fDeleteAppServer\x12,.teleport.presence.v1.DeleteAppServerRequest\x1a-.teleport.presence.v1.DeleteAppServerResponseBTZRgithub.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1;presencev1b\x06proto3"
 
-var file_teleport_presence_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
+var file_teleport_presence_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
 var file_teleport_presence_v1_service_proto_goTypes = []any{
 	(*GetRemoteClusterRequest)(nil),    // 0: teleport.presence.v1.GetRemoteClusterRequest
 	(*ListRemoteClustersRequest)(nil),  // 1: teleport.presence.v1.ListRemoteClustersRequest
@@ -2231,30 +2375,32 @@ var file_teleport_presence_v1_service_proto_goTypes = []any{
 	(*ListKubeClustersResponse)(nil),   // 26: teleport.presence.v1.ListKubeClustersResponse
 	(*DeleteKubeClusterRequest)(nil),   // 27: teleport.presence.v1.DeleteKubeClusterRequest
 	(*DeleteKubeClusterResponse)(nil),  // 28: teleport.presence.v1.DeleteKubeClusterResponse
-	(*types.RemoteClusterV3)(nil),      // 29: types.RemoteClusterV3
-	(*fieldmaskpb.FieldMask)(nil),      // 30: google.protobuf.FieldMask
-	(*types.ReverseTunnelV2)(nil),      // 31: types.ReverseTunnelV2
-	(*RelayServer)(nil),                // 32: teleport.presence.v1.RelayServer
-	(*types.ServerV2)(nil),             // 33: types.ServerV2
-	(*types.KubernetesClusterV3)(nil),  // 34: types.KubernetesClusterV3
-	(*v1.Filter)(nil),                  // 35: teleport.scopes.v1.Filter
-	(*emptypb.Empty)(nil),              // 36: google.protobuf.Empty
+	(*DeleteAppServerRequest)(nil),     // 29: teleport.presence.v1.DeleteAppServerRequest
+	(*DeleteAppServerResponse)(nil),    // 30: teleport.presence.v1.DeleteAppServerResponse
+	(*types.RemoteClusterV3)(nil),      // 31: types.RemoteClusterV3
+	(*fieldmaskpb.FieldMask)(nil),      // 32: google.protobuf.FieldMask
+	(*types.ReverseTunnelV2)(nil),      // 33: types.ReverseTunnelV2
+	(*RelayServer)(nil),                // 34: teleport.presence.v1.RelayServer
+	(*types.ServerV2)(nil),             // 35: types.ServerV2
+	(*types.KubernetesClusterV3)(nil),  // 36: types.KubernetesClusterV3
+	(*v1.Filter)(nil),                  // 37: teleport.scopes.v1.Filter
+	(*emptypb.Empty)(nil),              // 38: google.protobuf.Empty
 }
 var file_teleport_presence_v1_service_proto_depIdxs = []int32{
-	29, // 0: teleport.presence.v1.ListRemoteClustersResponse.remote_clusters:type_name -> types.RemoteClusterV3
-	29, // 1: teleport.presence.v1.UpdateRemoteClusterRequest.remote_cluster:type_name -> types.RemoteClusterV3
-	30, // 2: teleport.presence.v1.UpdateRemoteClusterRequest.update_mask:type_name -> google.protobuf.FieldMask
-	31, // 3: teleport.presence.v1.ListReverseTunnelsResponse.reverse_tunnels:type_name -> types.ReverseTunnelV2
-	31, // 4: teleport.presence.v1.UpsertReverseTunnelRequest.reverse_tunnel:type_name -> types.ReverseTunnelV2
-	32, // 5: teleport.presence.v1.GetRelayServerResponse.relay_server:type_name -> teleport.presence.v1.RelayServer
-	32, // 6: teleport.presence.v1.ListRelayServersResponse.relays:type_name -> teleport.presence.v1.RelayServer
-	33, // 7: teleport.presence.v1.ListAuthServersResponse.servers:type_name -> types.ServerV2
-	33, // 8: teleport.presence.v1.ListProxyServersResponse.servers:type_name -> types.ServerV2
-	33, // 9: teleport.presence.v1.UpsertProxyServerRequest.server:type_name -> types.ServerV2
-	33, // 10: teleport.presence.v1.UpsertProxyServerResponse.server:type_name -> types.ServerV2
-	34, // 11: teleport.presence.v1.GetKubeClusterResponse.cluster:type_name -> types.KubernetesClusterV3
-	35, // 12: teleport.presence.v1.ListKubeClustersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
-	34, // 13: teleport.presence.v1.ListKubeClustersResponse.clusters:type_name -> types.KubernetesClusterV3
+	31, // 0: teleport.presence.v1.ListRemoteClustersResponse.remote_clusters:type_name -> types.RemoteClusterV3
+	31, // 1: teleport.presence.v1.UpdateRemoteClusterRequest.remote_cluster:type_name -> types.RemoteClusterV3
+	32, // 2: teleport.presence.v1.UpdateRemoteClusterRequest.update_mask:type_name -> google.protobuf.FieldMask
+	33, // 3: teleport.presence.v1.ListReverseTunnelsResponse.reverse_tunnels:type_name -> types.ReverseTunnelV2
+	33, // 4: teleport.presence.v1.UpsertReverseTunnelRequest.reverse_tunnel:type_name -> types.ReverseTunnelV2
+	34, // 5: teleport.presence.v1.GetRelayServerResponse.relay_server:type_name -> teleport.presence.v1.RelayServer
+	34, // 6: teleport.presence.v1.ListRelayServersResponse.relays:type_name -> teleport.presence.v1.RelayServer
+	35, // 7: teleport.presence.v1.ListAuthServersResponse.servers:type_name -> types.ServerV2
+	35, // 8: teleport.presence.v1.ListProxyServersResponse.servers:type_name -> types.ServerV2
+	35, // 9: teleport.presence.v1.UpsertProxyServerRequest.server:type_name -> types.ServerV2
+	35, // 10: teleport.presence.v1.UpsertProxyServerResponse.server:type_name -> types.ServerV2
+	36, // 11: teleport.presence.v1.GetKubeClusterResponse.cluster:type_name -> types.KubernetesClusterV3
+	37, // 12: teleport.presence.v1.ListKubeClustersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
+	36, // 13: teleport.presence.v1.ListKubeClustersResponse.clusters:type_name -> types.KubernetesClusterV3
 	0,  // 14: teleport.presence.v1.PresenceService.GetRemoteCluster:input_type -> teleport.presence.v1.GetRemoteClusterRequest
 	1,  // 15: teleport.presence.v1.PresenceService.ListRemoteClusters:input_type -> teleport.presence.v1.ListRemoteClustersRequest
 	3,  // 16: teleport.presence.v1.PresenceService.UpdateRemoteCluster:input_type -> teleport.presence.v1.UpdateRemoteClusterRequest
@@ -2272,25 +2418,27 @@ var file_teleport_presence_v1_service_proto_depIdxs = []int32{
 	23, // 28: teleport.presence.v1.PresenceService.GetKubeCluster:input_type -> teleport.presence.v1.GetKubeClusterRequest
 	25, // 29: teleport.presence.v1.PresenceService.ListKubeClusters:input_type -> teleport.presence.v1.ListKubeClustersRequest
 	27, // 30: teleport.presence.v1.PresenceService.DeleteKubeCluster:input_type -> teleport.presence.v1.DeleteKubeClusterRequest
-	29, // 31: teleport.presence.v1.PresenceService.GetRemoteCluster:output_type -> types.RemoteClusterV3
-	2,  // 32: teleport.presence.v1.PresenceService.ListRemoteClusters:output_type -> teleport.presence.v1.ListRemoteClustersResponse
-	29, // 33: teleport.presence.v1.PresenceService.UpdateRemoteCluster:output_type -> types.RemoteClusterV3
-	36, // 34: teleport.presence.v1.PresenceService.DeleteRemoteCluster:output_type -> google.protobuf.Empty
-	6,  // 35: teleport.presence.v1.PresenceService.ListReverseTunnels:output_type -> teleport.presence.v1.ListReverseTunnelsResponse
-	31, // 36: teleport.presence.v1.PresenceService.UpsertReverseTunnel:output_type -> types.ReverseTunnelV2
-	36, // 37: teleport.presence.v1.PresenceService.DeleteReverseTunnel:output_type -> google.protobuf.Empty
-	10, // 38: teleport.presence.v1.PresenceService.GetRelayServer:output_type -> teleport.presence.v1.GetRelayServerResponse
-	12, // 39: teleport.presence.v1.PresenceService.ListRelayServers:output_type -> teleport.presence.v1.ListRelayServersResponse
-	14, // 40: teleport.presence.v1.PresenceService.DeleteRelayServer:output_type -> teleport.presence.v1.DeleteRelayServerResponse
-	16, // 41: teleport.presence.v1.PresenceService.ListAuthServers:output_type -> teleport.presence.v1.ListAuthServersResponse
-	18, // 42: teleport.presence.v1.PresenceService.ListProxyServers:output_type -> teleport.presence.v1.ListProxyServersResponse
-	20, // 43: teleport.presence.v1.PresenceService.UpsertProxyServer:output_type -> teleport.presence.v1.UpsertProxyServerResponse
-	22, // 44: teleport.presence.v1.PresenceService.DeleteProxyServer:output_type -> teleport.presence.v1.DeleteProxyServerResponse
-	24, // 45: teleport.presence.v1.PresenceService.GetKubeCluster:output_type -> teleport.presence.v1.GetKubeClusterResponse
-	26, // 46: teleport.presence.v1.PresenceService.ListKubeClusters:output_type -> teleport.presence.v1.ListKubeClustersResponse
-	28, // 47: teleport.presence.v1.PresenceService.DeleteKubeCluster:output_type -> teleport.presence.v1.DeleteKubeClusterResponse
-	31, // [31:48] is the sub-list for method output_type
-	14, // [14:31] is the sub-list for method input_type
+	29, // 31: teleport.presence.v1.PresenceService.DeleteAppServer:input_type -> teleport.presence.v1.DeleteAppServerRequest
+	31, // 32: teleport.presence.v1.PresenceService.GetRemoteCluster:output_type -> types.RemoteClusterV3
+	2,  // 33: teleport.presence.v1.PresenceService.ListRemoteClusters:output_type -> teleport.presence.v1.ListRemoteClustersResponse
+	31, // 34: teleport.presence.v1.PresenceService.UpdateRemoteCluster:output_type -> types.RemoteClusterV3
+	38, // 35: teleport.presence.v1.PresenceService.DeleteRemoteCluster:output_type -> google.protobuf.Empty
+	6,  // 36: teleport.presence.v1.PresenceService.ListReverseTunnels:output_type -> teleport.presence.v1.ListReverseTunnelsResponse
+	33, // 37: teleport.presence.v1.PresenceService.UpsertReverseTunnel:output_type -> types.ReverseTunnelV2
+	38, // 38: teleport.presence.v1.PresenceService.DeleteReverseTunnel:output_type -> google.protobuf.Empty
+	10, // 39: teleport.presence.v1.PresenceService.GetRelayServer:output_type -> teleport.presence.v1.GetRelayServerResponse
+	12, // 40: teleport.presence.v1.PresenceService.ListRelayServers:output_type -> teleport.presence.v1.ListRelayServersResponse
+	14, // 41: teleport.presence.v1.PresenceService.DeleteRelayServer:output_type -> teleport.presence.v1.DeleteRelayServerResponse
+	16, // 42: teleport.presence.v1.PresenceService.ListAuthServers:output_type -> teleport.presence.v1.ListAuthServersResponse
+	18, // 43: teleport.presence.v1.PresenceService.ListProxyServers:output_type -> teleport.presence.v1.ListProxyServersResponse
+	20, // 44: teleport.presence.v1.PresenceService.UpsertProxyServer:output_type -> teleport.presence.v1.UpsertProxyServerResponse
+	22, // 45: teleport.presence.v1.PresenceService.DeleteProxyServer:output_type -> teleport.presence.v1.DeleteProxyServerResponse
+	24, // 46: teleport.presence.v1.PresenceService.GetKubeCluster:output_type -> teleport.presence.v1.GetKubeClusterResponse
+	26, // 47: teleport.presence.v1.PresenceService.ListKubeClusters:output_type -> teleport.presence.v1.ListKubeClustersResponse
+	28, // 48: teleport.presence.v1.PresenceService.DeleteKubeCluster:output_type -> teleport.presence.v1.DeleteKubeClusterResponse
+	30, // 49: teleport.presence.v1.PresenceService.DeleteAppServer:output_type -> teleport.presence.v1.DeleteAppServerResponse
+	32, // [32:50] is the sub-list for method output_type
+	14, // [14:32] is the sub-list for method input_type
 	14, // [14:14] is the sub-list for extension type_name
 	14, // [14:14] is the sub-list for extension extendee
 	0,  // [0:14] is the sub-list for field type_name
@@ -2308,7 +2456,7 @@ func file_teleport_presence_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_presence_v1_service_proto_rawDesc), len(file_teleport_presence_v1_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   29,
+			NumMessages:   31,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/presence/v1/service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/presence/v1/service_protoopaque.pb.go
@@ -2057,6 +2057,140 @@ func (b0 DeleteKubeClusterResponse_builder) Build() *DeleteKubeClusterResponse {
 	return m0
 }
 
+// The request to delete a specific scoped or unscoped application server.
+type DeleteAppServerRequest struct {
+	state             protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_HostId string                 `protobuf:"bytes,1,opt,name=host_id,json=hostId,proto3"`
+	xxx_hidden_Name   string                 `protobuf:"bytes,2,opt,name=name,proto3"`
+	xxx_hidden_Scope  string                 `protobuf:"bytes,3,opt,name=scope,proto3"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *DeleteAppServerRequest) Reset() {
+	*x = DeleteAppServerRequest{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteAppServerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteAppServerRequest) ProtoMessage() {}
+
+func (x *DeleteAppServerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *DeleteAppServerRequest) GetHostId() string {
+	if x != nil {
+		return x.xxx_hidden_HostId
+	}
+	return ""
+}
+
+func (x *DeleteAppServerRequest) GetName() string {
+	if x != nil {
+		return x.xxx_hidden_Name
+	}
+	return ""
+}
+
+func (x *DeleteAppServerRequest) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
+func (x *DeleteAppServerRequest) SetHostId(v string) {
+	x.xxx_hidden_HostId = v
+}
+
+func (x *DeleteAppServerRequest) SetName(v string) {
+	x.xxx_hidden_Name = v
+}
+
+func (x *DeleteAppServerRequest) SetScope(v string) {
+	x.xxx_hidden_Scope = v
+}
+
+type DeleteAppServerRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// HostId is the app server host uuid.
+	HostId string
+	// Name is the name of the application to delete.
+	Name string
+	// Scope is the scope of the application to delete. Empty for unscoped
+	// applications.
+	Scope string
+}
+
+func (b0 DeleteAppServerRequest_builder) Build() *DeleteAppServerRequest {
+	m0 := &DeleteAppServerRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_HostId = b.HostId
+	x.xxx_hidden_Name = b.Name
+	x.xxx_hidden_Scope = b.Scope
+	return m0
+}
+
+// The response for deleting an application server.
+type DeleteAppServerResponse struct {
+	state         protoimpl.MessageState `protogen:"opaque.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteAppServerResponse) Reset() {
+	*x = DeleteAppServerResponse{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteAppServerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteAppServerResponse) ProtoMessage() {}
+
+func (x *DeleteAppServerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type DeleteAppServerResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 DeleteAppServerResponse_builder) Build() *DeleteAppServerResponse {
+	m0 := &DeleteAppServerResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
 var File_teleport_presence_v1_service_proto protoreflect.FileDescriptor
 
 const file_teleport_presence_v1_service_proto_rawDesc = "" +
@@ -2139,7 +2273,12 @@ const file_teleport_presence_v1_service_proto_rawDesc = "" +
 	"\x18DeleteKubeClusterRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05scope\x18\x02 \x01(\tR\x05scope\"\x1b\n" +
-	"\x19DeleteKubeClusterResponse2\xdd\x0e\n" +
+	"\x19DeleteKubeClusterResponse\"[\n" +
+	"\x16DeleteAppServerRequest\x12\x17\n" +
+	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
+	"\x05scope\x18\x03 \x01(\tR\x05scope\"\x19\n" +
+	"\x17DeleteAppServerResponse2\xcd\x0f\n" +
 	"\x0fPresenceService\x12Y\n" +
 	"\x10GetRemoteCluster\x12-.teleport.presence.v1.GetRemoteClusterRequest\x1a\x16.types.RemoteClusterV3\x12w\n" +
 	"\x12ListRemoteClusters\x12/.teleport.presence.v1.ListRemoteClustersRequest\x1a0.teleport.presence.v1.ListRemoteClustersResponse\x12_\n" +
@@ -2157,9 +2296,10 @@ const file_teleport_presence_v1_service_proto_rawDesc = "" +
 	"\x11DeleteProxyServer\x12..teleport.presence.v1.DeleteProxyServerRequest\x1a/.teleport.presence.v1.DeleteProxyServerResponse\x12k\n" +
 	"\x0eGetKubeCluster\x12+.teleport.presence.v1.GetKubeClusterRequest\x1a,.teleport.presence.v1.GetKubeClusterResponse\x12q\n" +
 	"\x10ListKubeClusters\x12-.teleport.presence.v1.ListKubeClustersRequest\x1a..teleport.presence.v1.ListKubeClustersResponse\x12t\n" +
-	"\x11DeleteKubeCluster\x12..teleport.presence.v1.DeleteKubeClusterRequest\x1a/.teleport.presence.v1.DeleteKubeClusterResponseBTZRgithub.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1;presencev1b\x06proto3"
+	"\x11DeleteKubeCluster\x12..teleport.presence.v1.DeleteKubeClusterRequest\x1a/.teleport.presence.v1.DeleteKubeClusterResponse\x12n\n" +
+	"\x0fDeleteAppServer\x12,.teleport.presence.v1.DeleteAppServerRequest\x1a-.teleport.presence.v1.DeleteAppServerResponseBTZRgithub.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1;presencev1b\x06proto3"
 
-var file_teleport_presence_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
+var file_teleport_presence_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
 var file_teleport_presence_v1_service_proto_goTypes = []any{
 	(*GetRemoteClusterRequest)(nil),    // 0: teleport.presence.v1.GetRemoteClusterRequest
 	(*ListRemoteClustersRequest)(nil),  // 1: teleport.presence.v1.ListRemoteClustersRequest
@@ -2190,30 +2330,32 @@ var file_teleport_presence_v1_service_proto_goTypes = []any{
 	(*ListKubeClustersResponse)(nil),   // 26: teleport.presence.v1.ListKubeClustersResponse
 	(*DeleteKubeClusterRequest)(nil),   // 27: teleport.presence.v1.DeleteKubeClusterRequest
 	(*DeleteKubeClusterResponse)(nil),  // 28: teleport.presence.v1.DeleteKubeClusterResponse
-	(*types.RemoteClusterV3)(nil),      // 29: types.RemoteClusterV3
-	(*fieldmaskpb.FieldMask)(nil),      // 30: google.protobuf.FieldMask
-	(*types.ReverseTunnelV2)(nil),      // 31: types.ReverseTunnelV2
-	(*RelayServer)(nil),                // 32: teleport.presence.v1.RelayServer
-	(*types.ServerV2)(nil),             // 33: types.ServerV2
-	(*types.KubernetesClusterV3)(nil),  // 34: types.KubernetesClusterV3
-	(*v1.Filter)(nil),                  // 35: teleport.scopes.v1.Filter
-	(*emptypb.Empty)(nil),              // 36: google.protobuf.Empty
+	(*DeleteAppServerRequest)(nil),     // 29: teleport.presence.v1.DeleteAppServerRequest
+	(*DeleteAppServerResponse)(nil),    // 30: teleport.presence.v1.DeleteAppServerResponse
+	(*types.RemoteClusterV3)(nil),      // 31: types.RemoteClusterV3
+	(*fieldmaskpb.FieldMask)(nil),      // 32: google.protobuf.FieldMask
+	(*types.ReverseTunnelV2)(nil),      // 33: types.ReverseTunnelV2
+	(*RelayServer)(nil),                // 34: teleport.presence.v1.RelayServer
+	(*types.ServerV2)(nil),             // 35: types.ServerV2
+	(*types.KubernetesClusterV3)(nil),  // 36: types.KubernetesClusterV3
+	(*v1.Filter)(nil),                  // 37: teleport.scopes.v1.Filter
+	(*emptypb.Empty)(nil),              // 38: google.protobuf.Empty
 }
 var file_teleport_presence_v1_service_proto_depIdxs = []int32{
-	29, // 0: teleport.presence.v1.ListRemoteClustersResponse.remote_clusters:type_name -> types.RemoteClusterV3
-	29, // 1: teleport.presence.v1.UpdateRemoteClusterRequest.remote_cluster:type_name -> types.RemoteClusterV3
-	30, // 2: teleport.presence.v1.UpdateRemoteClusterRequest.update_mask:type_name -> google.protobuf.FieldMask
-	31, // 3: teleport.presence.v1.ListReverseTunnelsResponse.reverse_tunnels:type_name -> types.ReverseTunnelV2
-	31, // 4: teleport.presence.v1.UpsertReverseTunnelRequest.reverse_tunnel:type_name -> types.ReverseTunnelV2
-	32, // 5: teleport.presence.v1.GetRelayServerResponse.relay_server:type_name -> teleport.presence.v1.RelayServer
-	32, // 6: teleport.presence.v1.ListRelayServersResponse.relays:type_name -> teleport.presence.v1.RelayServer
-	33, // 7: teleport.presence.v1.ListAuthServersResponse.servers:type_name -> types.ServerV2
-	33, // 8: teleport.presence.v1.ListProxyServersResponse.servers:type_name -> types.ServerV2
-	33, // 9: teleport.presence.v1.UpsertProxyServerRequest.server:type_name -> types.ServerV2
-	33, // 10: teleport.presence.v1.UpsertProxyServerResponse.server:type_name -> types.ServerV2
-	34, // 11: teleport.presence.v1.GetKubeClusterResponse.cluster:type_name -> types.KubernetesClusterV3
-	35, // 12: teleport.presence.v1.ListKubeClustersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
-	34, // 13: teleport.presence.v1.ListKubeClustersResponse.clusters:type_name -> types.KubernetesClusterV3
+	31, // 0: teleport.presence.v1.ListRemoteClustersResponse.remote_clusters:type_name -> types.RemoteClusterV3
+	31, // 1: teleport.presence.v1.UpdateRemoteClusterRequest.remote_cluster:type_name -> types.RemoteClusterV3
+	32, // 2: teleport.presence.v1.UpdateRemoteClusterRequest.update_mask:type_name -> google.protobuf.FieldMask
+	33, // 3: teleport.presence.v1.ListReverseTunnelsResponse.reverse_tunnels:type_name -> types.ReverseTunnelV2
+	33, // 4: teleport.presence.v1.UpsertReverseTunnelRequest.reverse_tunnel:type_name -> types.ReverseTunnelV2
+	34, // 5: teleport.presence.v1.GetRelayServerResponse.relay_server:type_name -> teleport.presence.v1.RelayServer
+	34, // 6: teleport.presence.v1.ListRelayServersResponse.relays:type_name -> teleport.presence.v1.RelayServer
+	35, // 7: teleport.presence.v1.ListAuthServersResponse.servers:type_name -> types.ServerV2
+	35, // 8: teleport.presence.v1.ListProxyServersResponse.servers:type_name -> types.ServerV2
+	35, // 9: teleport.presence.v1.UpsertProxyServerRequest.server:type_name -> types.ServerV2
+	35, // 10: teleport.presence.v1.UpsertProxyServerResponse.server:type_name -> types.ServerV2
+	36, // 11: teleport.presence.v1.GetKubeClusterResponse.cluster:type_name -> types.KubernetesClusterV3
+	37, // 12: teleport.presence.v1.ListKubeClustersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
+	36, // 13: teleport.presence.v1.ListKubeClustersResponse.clusters:type_name -> types.KubernetesClusterV3
 	0,  // 14: teleport.presence.v1.PresenceService.GetRemoteCluster:input_type -> teleport.presence.v1.GetRemoteClusterRequest
 	1,  // 15: teleport.presence.v1.PresenceService.ListRemoteClusters:input_type -> teleport.presence.v1.ListRemoteClustersRequest
 	3,  // 16: teleport.presence.v1.PresenceService.UpdateRemoteCluster:input_type -> teleport.presence.v1.UpdateRemoteClusterRequest
@@ -2231,25 +2373,27 @@ var file_teleport_presence_v1_service_proto_depIdxs = []int32{
 	23, // 28: teleport.presence.v1.PresenceService.GetKubeCluster:input_type -> teleport.presence.v1.GetKubeClusterRequest
 	25, // 29: teleport.presence.v1.PresenceService.ListKubeClusters:input_type -> teleport.presence.v1.ListKubeClustersRequest
 	27, // 30: teleport.presence.v1.PresenceService.DeleteKubeCluster:input_type -> teleport.presence.v1.DeleteKubeClusterRequest
-	29, // 31: teleport.presence.v1.PresenceService.GetRemoteCluster:output_type -> types.RemoteClusterV3
-	2,  // 32: teleport.presence.v1.PresenceService.ListRemoteClusters:output_type -> teleport.presence.v1.ListRemoteClustersResponse
-	29, // 33: teleport.presence.v1.PresenceService.UpdateRemoteCluster:output_type -> types.RemoteClusterV3
-	36, // 34: teleport.presence.v1.PresenceService.DeleteRemoteCluster:output_type -> google.protobuf.Empty
-	6,  // 35: teleport.presence.v1.PresenceService.ListReverseTunnels:output_type -> teleport.presence.v1.ListReverseTunnelsResponse
-	31, // 36: teleport.presence.v1.PresenceService.UpsertReverseTunnel:output_type -> types.ReverseTunnelV2
-	36, // 37: teleport.presence.v1.PresenceService.DeleteReverseTunnel:output_type -> google.protobuf.Empty
-	10, // 38: teleport.presence.v1.PresenceService.GetRelayServer:output_type -> teleport.presence.v1.GetRelayServerResponse
-	12, // 39: teleport.presence.v1.PresenceService.ListRelayServers:output_type -> teleport.presence.v1.ListRelayServersResponse
-	14, // 40: teleport.presence.v1.PresenceService.DeleteRelayServer:output_type -> teleport.presence.v1.DeleteRelayServerResponse
-	16, // 41: teleport.presence.v1.PresenceService.ListAuthServers:output_type -> teleport.presence.v1.ListAuthServersResponse
-	18, // 42: teleport.presence.v1.PresenceService.ListProxyServers:output_type -> teleport.presence.v1.ListProxyServersResponse
-	20, // 43: teleport.presence.v1.PresenceService.UpsertProxyServer:output_type -> teleport.presence.v1.UpsertProxyServerResponse
-	22, // 44: teleport.presence.v1.PresenceService.DeleteProxyServer:output_type -> teleport.presence.v1.DeleteProxyServerResponse
-	24, // 45: teleport.presence.v1.PresenceService.GetKubeCluster:output_type -> teleport.presence.v1.GetKubeClusterResponse
-	26, // 46: teleport.presence.v1.PresenceService.ListKubeClusters:output_type -> teleport.presence.v1.ListKubeClustersResponse
-	28, // 47: teleport.presence.v1.PresenceService.DeleteKubeCluster:output_type -> teleport.presence.v1.DeleteKubeClusterResponse
-	31, // [31:48] is the sub-list for method output_type
-	14, // [14:31] is the sub-list for method input_type
+	29, // 31: teleport.presence.v1.PresenceService.DeleteAppServer:input_type -> teleport.presence.v1.DeleteAppServerRequest
+	31, // 32: teleport.presence.v1.PresenceService.GetRemoteCluster:output_type -> types.RemoteClusterV3
+	2,  // 33: teleport.presence.v1.PresenceService.ListRemoteClusters:output_type -> teleport.presence.v1.ListRemoteClustersResponse
+	31, // 34: teleport.presence.v1.PresenceService.UpdateRemoteCluster:output_type -> types.RemoteClusterV3
+	38, // 35: teleport.presence.v1.PresenceService.DeleteRemoteCluster:output_type -> google.protobuf.Empty
+	6,  // 36: teleport.presence.v1.PresenceService.ListReverseTunnels:output_type -> teleport.presence.v1.ListReverseTunnelsResponse
+	33, // 37: teleport.presence.v1.PresenceService.UpsertReverseTunnel:output_type -> types.ReverseTunnelV2
+	38, // 38: teleport.presence.v1.PresenceService.DeleteReverseTunnel:output_type -> google.protobuf.Empty
+	10, // 39: teleport.presence.v1.PresenceService.GetRelayServer:output_type -> teleport.presence.v1.GetRelayServerResponse
+	12, // 40: teleport.presence.v1.PresenceService.ListRelayServers:output_type -> teleport.presence.v1.ListRelayServersResponse
+	14, // 41: teleport.presence.v1.PresenceService.DeleteRelayServer:output_type -> teleport.presence.v1.DeleteRelayServerResponse
+	16, // 42: teleport.presence.v1.PresenceService.ListAuthServers:output_type -> teleport.presence.v1.ListAuthServersResponse
+	18, // 43: teleport.presence.v1.PresenceService.ListProxyServers:output_type -> teleport.presence.v1.ListProxyServersResponse
+	20, // 44: teleport.presence.v1.PresenceService.UpsertProxyServer:output_type -> teleport.presence.v1.UpsertProxyServerResponse
+	22, // 45: teleport.presence.v1.PresenceService.DeleteProxyServer:output_type -> teleport.presence.v1.DeleteProxyServerResponse
+	24, // 46: teleport.presence.v1.PresenceService.GetKubeCluster:output_type -> teleport.presence.v1.GetKubeClusterResponse
+	26, // 47: teleport.presence.v1.PresenceService.ListKubeClusters:output_type -> teleport.presence.v1.ListKubeClustersResponse
+	28, // 48: teleport.presence.v1.PresenceService.DeleteKubeCluster:output_type -> teleport.presence.v1.DeleteKubeClusterResponse
+	30, // 49: teleport.presence.v1.PresenceService.DeleteAppServer:output_type -> teleport.presence.v1.DeleteAppServerResponse
+	32, // [32:50] is the sub-list for method output_type
+	14, // [14:32] is the sub-list for method input_type
 	14, // [14:14] is the sub-list for extension type_name
 	14, // [14:14] is the sub-list for extension extendee
 	0,  // [0:14] is the sub-list for field type_name
@@ -2267,7 +2411,7 @@ func file_teleport_presence_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_presence_v1_service_proto_rawDesc), len(file_teleport_presence_v1_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   29,
+			NumMessages:   31,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/proto/teleport/presence/v1/service.proto
+++ b/api/proto/teleport/presence/v1/service.proto
@@ -65,6 +65,9 @@ service PresenceService {
   rpc ListKubeClusters(ListKubeClustersRequest) returns (ListKubeClustersResponse);
   // Deletes a kube cluster resource from the backend.
   rpc DeleteKubeCluster(DeleteKubeClusterRequest) returns (DeleteKubeClusterResponse);
+
+  // Deletes a specific scoped or unscoped application server.
+  rpc DeleteAppServer(DeleteAppServerRequest) returns (DeleteAppServerResponse);
 }
 
 // Request for GetRemoteCluster
@@ -282,3 +285,17 @@ message DeleteKubeClusterRequest {
 
 // The response for deleting a specific scoped or unscoped kube cluster resource.
 message DeleteKubeClusterResponse {}
+
+// The request to delete a specific scoped or unscoped application server.
+message DeleteAppServerRequest {
+  // HostId is the app server host uuid.
+  string host_id = 1;
+  // Name is the name of the application to delete.
+  string name = 2;
+  // Scope is the scope of the application to delete. Empty for unscoped
+  // applications.
+  string scope = 3;
+}
+
+// The response for deleting an application server.
+message DeleteAppServerResponse {}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -47,6 +47,7 @@ import (
 	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	linuxdesktopv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/linuxdesktop/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/metadata"
@@ -63,7 +64,6 @@ import (
 	"github.com/gravitational/teleport/lib/auth/moderation"
 	"github.com/gravitational/teleport/lib/auth/okta"
 	"github.com/gravitational/teleport/lib/authz"
-	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
 	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
 	"github.com/gravitational/teleport/lib/events"
@@ -370,57 +370,6 @@ func (a *ServerWithRoles) hasBuiltinRole(roles ...types.SystemRole) bool {
 		}
 	}
 	return false
-}
-
-// hasBuiltinRole checks that the attached identity is a builtin role and
-// whether any of the given roles match the role set.
-func (a *ScopedServerWithRoles) hasBuiltinRole(roles ...types.SystemRole) bool {
-	unscopedCtx, isUnscoped := a.scopedContext.UnscopedContext()
-	if isUnscoped {
-		for _, role := range roles {
-			if authz.HasBuiltinRole(*unscopedCtx, string(role)) {
-				return true
-			}
-		}
-		return false
-	}
-
-	// since we check if the underlying SWR is unscoped, and defer to the
-	// unscoped behavior if it is, the only valid role type at this point
-	// will be a [authz.ScopedBuiltinRole].
-	role, isBuiltin := a.scopedContext.Identity.(authz.ScopedBuiltinRole)
-	if !isBuiltin {
-		return false
-	}
-	// for service certs, the additional system roles will be empty so we only check if the
-	// primary role is included in the given roles
-	if primary := types.SystemRole(role.ScopePin.GetSystemRoles().GetPrimary()); primary != types.RoleInstance {
-		return types.SystemRoles(roles).Include(primary)
-	}
-	// for instance certs, we check if there is any overlap between the given roles and the
-	// additional system roles included in the scope pin
-	existingRoles := role.ScopePin.GetSystemRoles().GetAdditional()
-	for _, role := range roles {
-		if slices.Contains(existingRoles, string(role)) {
-			return true
-		}
-	}
-	return false
-}
-
-// agentOwnedResourceAction authorizes an agent identity to perform actions on its own resources.
-func (a *ScopedServerWithRoles) agentOwnedResourceAction(ctx context.Context, hostID string, systemRoles ...types.SystemRole) error {
-	if !a.hasBuiltinRole(systemRoles...) {
-		return trace.AccessDenied("this request can be only executed by a teleport built-in server")
-	}
-	serverID, ok := getLocalServerID(a.scopedContext.Identity)
-	if !ok {
-		return trace.BadParameter("no agent identity after confirming that request context is BuiltinRole (this is a bug)")
-	}
-	if hostID != serverID {
-		return trace.AccessDenied("resource host ID %+q does not match agent identity ID %+q", hostID, serverID)
-	}
-	return nil
 }
 
 // HasRemoteBuiltinRole checks if the identity is a remote builtin role with the
@@ -786,7 +735,7 @@ func (a *ScopedServerWithRoles) GenerateHostCerts(ctx context.Context, req *prot
 	}
 
 	// prohibit privilege escalations through role changes (except the instance cert exception, handled above).
-	if !a.hasBuiltinRole(req.Role) && req.Role != types.RoleInstance {
+	if !a.scopedContext.HasBuiltinRole(req.Role) && req.Role != types.RoleInstance {
 		return nil, trace.AccessDenied(
 			"roles do not match: %v and %v",
 			existingServerRoles,
@@ -841,7 +790,7 @@ func (a *ScopedServerWithRoles) checkAdditionalSystemRoles(ctx context.Context, 
 	// check if additional system roles are permissible
 Outer:
 	for _, requestedRole := range req.SystemRoles {
-		if a.hasBuiltinRole(requestedRole) {
+		if a.scopedContext.HasBuiltinRole(requestedRole) {
 			// instance is already known to hold this role
 			continue Outer
 		}
@@ -919,7 +868,7 @@ func (a *ScopedServerWithRoles) RegisterInventoryControlStream(ics client.Upstre
 	// services that are unrecognized or unauthorized, rather than rejecting hellos that claim them.
 	var filteredServices []string
 	for _, service := range hello.GetServices() {
-		if !a.hasBuiltinRole(types.SystemRole(service)) {
+		if !a.scopedContext.HasBuiltinRole(types.SystemRole(service)) {
 			a.authServer.logger.WarnContext(a.CloseContext(), "Omitting unknown or unauthorized service for instance control stream",
 				"omitted_service", service,
 				"instance", serverID,
@@ -1142,7 +1091,7 @@ func (a *ScopedServerWithRoles) UpsertNode(ctx context.Context, s types.Server) 
 	// Note: UpsertNode doesn't allow any namespaces but "default".
 	// The Decision API only checks on the default namespace.
 	if err := a.scopedContext.CheckerContext.Decision(ctx, s.GetScope(), func(checker *services.ScopedAccessChecker) error {
-		if err := a.agentOwnedResourceAction(ctx, s.GetName(), types.RoleNode); err == nil {
+		if err := a.scopedContext.AgentOwnedResourceAction(s.GetScope(), s.GetName(), types.RoleNode); err == nil {
 			return nil
 		}
 		return checker.CheckAccessToRules(&ruleCtx, types.KindNode, types.VerbCreate, types.VerbUpdate)
@@ -1165,7 +1114,7 @@ func (a *ServerWithRoles) KeepAliveServer(ctx context.Context, handle types.Keep
 	scopedServer := a.ScopedServerWithRoles()
 	switch handle.GetType() {
 	case constants.KeepAliveNode:
-		if err := scopedServer.agentOwnedResourceAction(ctx, handle.Name, types.RoleNode); err != nil {
+		if err := scopedServer.scopedContext.AgentOwnedResourceAction("", handle.Name, types.RoleNode); err != nil {
 			return trace.Wrap(err)
 		}
 	case constants.KeepAliveApp:
@@ -1173,28 +1122,28 @@ func (a *ServerWithRoles) KeepAliveServer(ctx context.Context, handle types.Keep
 		if hostID == "" { // DELETE IN 9.0. Legacy app server is heartbeating back.
 			hostID = handle.Name
 		}
-		if err := scopedServer.agentOwnedResourceAction(ctx, hostID, types.RoleApp, types.RoleOkta); err != nil {
+		if err := scopedServer.scopedContext.AgentOwnedResourceAction("", hostID, types.RoleApp, types.RoleOkta); err != nil {
 			return trace.Wrap(err)
 		}
 	case constants.KeepAliveDatabase:
 		// There can be multiple database servers per host so they send their
 		// host ID in a separate field because unlike SSH nodes the resource
 		// name cannot be the host ID.
-		if err := scopedServer.agentOwnedResourceAction(ctx, handle.HostID, types.RoleDatabase); err != nil {
+		if err := scopedServer.scopedContext.AgentOwnedResourceAction("", handle.HostID, types.RoleDatabase); err != nil {
 			return trace.Wrap(err)
 		}
 	case constants.KeepAliveWindowsDesktopService:
-		if err := scopedServer.agentOwnedResourceAction(ctx, handle.Name, types.RoleWindowsDesktop); err != nil {
+		if err := scopedServer.scopedContext.AgentOwnedResourceAction("", handle.Name, types.RoleWindowsDesktop); err != nil {
 			return trace.Wrap(err)
 		}
 	case constants.KeepAliveKube:
 		// Legacy kube proxy can heartbeat kube servers from the proxy itself so
 		// we need to check if the host has the Kube or Proxy role.
-		if err := scopedServer.agentOwnedResourceAction(ctx, handle.HostID, types.RoleKube, types.RoleProxy); err != nil {
+		if err := scopedServer.scopedContext.AgentOwnedResourceAction("", handle.HostID, types.RoleKube, types.RoleProxy); err != nil {
 			return trace.Wrap(err)
 		}
 	case constants.KeepAliveDatabaseService:
-		if err := scopedServer.agentOwnedResourceAction(ctx, handle.Name, types.RoleDatabase); err != nil {
+		if err := scopedServer.scopedContext.AgentOwnedResourceAction("", handle.Name, types.RoleDatabase); err != nil {
 			return trace.Wrap(err)
 		}
 	default:
@@ -1252,9 +1201,9 @@ func (a *ScopedServerWithRoles) authorizeWatchRequest(ctx context.Context, watch
 
 	watch.Kinds = validKinds
 	switch {
-	case a.hasBuiltinRole(types.RoleProxy):
+	case a.scopedContext.HasBuiltinRole(types.RoleProxy):
 		watch.QueueSize = defaults.ProxyQueueSize
-	case a.hasBuiltinRole(types.RoleNode):
+	case a.scopedContext.HasBuiltinRole(types.RoleNode):
 		watch.QueueSize = defaults.NodeQueueSize
 	}
 
@@ -2336,7 +2285,7 @@ func (a *ScopedServerWithRoles) ListResources(ctx context.Context, req proto.Lis
 	var resp types.ListResourcesResponse
 	if err := a.authServer.IterateResources(ctx, req, func(resource types.ResourceWithLabels) error {
 		if len(resp.Resources) == limit {
-			resp.NextKey = backend.GetPaginationKey(resource)
+			resp.NextKey = services.GetCursorForResource(resource)
 			return ErrDone
 		}
 
@@ -2488,7 +2437,7 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 	var resp types.ListResourcesResponse
 	if err := a.authServer.IterateResources(ctx, req, func(resource types.ResourceWithLabels) error {
 		if len(resp.Resources) == limit {
-			resp.NextKey = backend.GetPaginationKey(resource)
+			resp.NextKey = services.GetCursorForResource(resource)
 			return ErrDone
 		}
 
@@ -5360,7 +5309,7 @@ func (a *ScopedServerWithRoles) EmitAuditEvent(ctx context.Context, event apieve
 	if !isServer {
 		return trace.AccessDenied("this request can be only executed by a teleport built-in server")
 	}
-	err := events.ValidateServerMetadata(event, serverID, a.hasBuiltinRole(types.RoleProxy))
+	err := events.ValidateServerMetadata(event, serverID, a.scopedContext.HasBuiltinRole(types.RoleProxy))
 	if err != nil {
 		// TODO: this should be a proper audit event
 		// notifying about access violation
@@ -5450,7 +5399,7 @@ func (s *streamWithRoles) Close(ctx context.Context) error {
 
 func (s *streamWithRoles) RecordEvent(ctx context.Context, pe apievents.PreparedSessionEvent) error {
 	event := pe.GetAuditEvent()
-	err := events.ValidateServerMetadata(event, s.serverID, s.a.hasBuiltinRole(types.RoleProxy))
+	err := events.ValidateServerMetadata(event, s.serverID, s.a.scopedContext.HasBuiltinRole(types.RoleProxy))
 	if err != nil {
 		// TODO: this should be a proper audit event
 		// notifying about access violation
@@ -6394,7 +6343,7 @@ func (a *ServerWithRoles) GetDatabaseServers(ctx context.Context, namespace stri
 
 // UpsertDatabaseServer creates or updates a new database proxy server.
 func (a *ServerWithRoles) UpsertDatabaseServer(ctx context.Context, server types.DatabaseServer) (*types.KeepAlive, error) {
-	if err := a.ScopedServerWithRoles().agentOwnedResourceAction(ctx, server.GetHostID(), types.RoleDatabase); err != nil {
+	if err := a.ScopedServerWithRoles().scopedContext.AgentOwnedResourceAction("", server.GetHostID(), types.RoleDatabase); err != nil {
 		if err := a.actionNamespace(server.GetNamespace(), types.KindDatabaseServer, types.VerbCreate, types.VerbUpdate); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -6407,7 +6356,7 @@ func (a *ServerWithRoles) UpsertDatabaseServer(ctx context.Context, server types
 
 // DeleteDatabaseServer removes the specified database proxy server.
 func (a *ServerWithRoles) DeleteDatabaseServer(ctx context.Context, namespace, hostID, name string) error {
-	if err := a.ScopedServerWithRoles().agentOwnedResourceAction(ctx, hostID, types.RoleDatabase); err != nil {
+	if err := a.ScopedServerWithRoles().scopedContext.AgentOwnedResourceAction("", hostID, types.RoleDatabase); err != nil {
 		if err := a.actionNamespace(namespace, types.KindDatabaseServer, types.VerbDelete); err != nil {
 			return trace.Wrap(err)
 		}
@@ -6425,7 +6374,7 @@ func (a *ServerWithRoles) DeleteAllDatabaseServers(ctx context.Context, namespac
 
 // UpsertDatabaseService creates or updates a new DatabaseService resource.
 func (a *ServerWithRoles) UpsertDatabaseService(ctx context.Context, service types.DatabaseService) (*types.KeepAlive, error) {
-	if err := a.ScopedServerWithRoles().agentOwnedResourceAction(ctx, service.GetName(), types.RoleDatabase); err != nil {
+	if err := a.ScopedServerWithRoles().scopedContext.AgentOwnedResourceAction("", service.GetName(), types.RoleDatabase); err != nil {
 		if err := a.actionNamespace(service.GetNamespace(), types.KindDatabaseService, types.VerbCreate, types.VerbUpdate); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -6557,7 +6506,7 @@ func (a *ServerWithRoles) checkAccessToApp(app types.Application) error {
 
 // UpsertApplicationServer registers an application server.
 func (a *ServerWithRoles) UpsertApplicationServer(ctx context.Context, server types.AppServer) (*types.KeepAlive, error) {
-	if err := a.ScopedServerWithRoles().agentOwnedResourceAction(ctx, server.GetHostID(), types.RoleApp); err != nil {
+	if err := a.ScopedServerWithRoles().scopedContext.AgentOwnedResourceAction("", server.GetHostID(), types.RoleApp); err != nil {
 		if err := a.actionNamespace(server.GetNamespace(), types.KindAppServer, types.VerbCreate, types.VerbUpdate); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -6568,14 +6517,21 @@ func (a *ServerWithRoles) UpsertApplicationServer(ctx context.Context, server ty
 	return a.authServer.UpsertApplicationServer(ctx, server)
 }
 
-// DeleteApplicationServer deletes specified application server.
+// DeleteApplicationServer deletes an unscoped application server. It serves
+// the legacy AuthService RPC for pre-scopes clients.
+//
+// Deprecated: Use DeleteAppServer from the presence service instead.
+// TODO (williamo): Remove in v20
 func (a *ServerWithRoles) DeleteApplicationServer(ctx context.Context, namespace, hostID, name string) error {
-	if err := a.ScopedServerWithRoles().agentOwnedResourceAction(ctx, hostID, types.RoleApp); err != nil {
+	if err := a.ScopedServerWithRoles().scopedContext.AgentOwnedResourceAction("", hostID, types.RoleApp); err != nil {
 		if err := a.actionNamespace(namespace, types.KindAppServer, types.VerbDelete); err != nil {
 			return trace.Wrap(err)
 		}
 	}
-	return a.authServer.DeleteApplicationServer(ctx, namespace, hostID, name)
+	return trace.Wrap(a.authServer.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+		HostId: hostID,
+		Name:   name,
+	}.Build()))
 }
 
 // DeleteAllApplicationServers deletes all registered application servers.
@@ -7027,7 +6983,7 @@ func (a *ScopedServerWithRoles) GetApplicationServers(ctx context.Context, names
 // UpsertKubernetesServer creates or updates a Server representing a teleport
 // kubernetes server.
 func (a *ServerWithRoles) UpsertKubernetesServer(ctx context.Context, s types.KubeServer) (*types.KeepAlive, error) {
-	if err := a.ScopedServerWithRoles().agentOwnedResourceAction(ctx, s.GetHostID(), types.RoleKube); err != nil {
+	if err := a.ScopedServerWithRoles().scopedContext.AgentOwnedResourceAction("", s.GetHostID(), types.RoleKube); err != nil {
 		if err := a.authorizeAction(types.KindKubeServer, types.VerbCreate, types.VerbUpdate); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -7040,7 +6996,7 @@ func (a *ServerWithRoles) UpsertKubernetesServer(ctx context.Context, s types.Ku
 
 // DeleteKubernetesServer deletes specified kubernetes server.
 func (a *ServerWithRoles) DeleteKubernetesServer(ctx context.Context, hostID, name string) error {
-	if err := a.ScopedServerWithRoles().agentOwnedResourceAction(ctx, hostID, types.RoleKube); err != nil {
+	if err := a.ScopedServerWithRoles().scopedContext.AgentOwnedResourceAction("", hostID, types.RoleKube); err != nil {
 		if err := a.authorizeAction(types.KindKubeServer, types.VerbDelete); err != nil {
 			return trace.Wrap(err)
 		}
@@ -7576,7 +7532,7 @@ func (a *ScopedServerWithRoles) CreateKubernetesCluster(ctx context.Context, clu
 		return trace.Wrap(err)
 	}
 	// Don't allow discovery service to create clusters with dynamic labels.
-	if a.hasBuiltinRole(types.RoleDiscovery) && len(cluster.GetDynamicLabels()) > 0 {
+	if a.scopedContext.HasBuiltinRole(types.RoleDiscovery) && len(cluster.GetDynamicLabels()) > 0 {
 		return trace.AccessDenied("discovered kubernetes cluster must not have dynamic labels")
 	}
 	return trace.Wrap(a.authServer.CreateKubernetesCluster(ctx, cluster))
@@ -7618,7 +7574,7 @@ func (a *ScopedServerWithRoles) UpdateKubernetesCluster(ctx context.Context, clu
 	}
 
 	// Don't allow discovery service to create clusters with dynamic labels.
-	if a.hasBuiltinRole(types.RoleDiscovery) && len(cluster.GetDynamicLabels()) > 0 {
+	if a.scopedContext.HasBuiltinRole(types.RoleDiscovery) && len(cluster.GetDynamicLabels()) > 0 {
 		return trace.AccessDenied("discovered kubernetes cluster must not have dynamic labels")
 	}
 
@@ -7951,7 +7907,7 @@ func (a *ServerWithRoles) GetWindowsDesktopService(ctx context.Context, name str
 
 // UpsertWindowsDesktopService creates or updates a new windows desktop service.
 func (a *ServerWithRoles) UpsertWindowsDesktopService(ctx context.Context, s types.WindowsDesktopService) (*types.KeepAlive, error) {
-	if err := a.ScopedServerWithRoles().agentOwnedResourceAction(ctx, s.GetName(), types.RoleWindowsDesktop); err != nil {
+	if err := a.ScopedServerWithRoles().scopedContext.AgentOwnedResourceAction("", s.GetName(), types.RoleWindowsDesktop); err != nil {
 		if err := a.authorizeAction(types.KindWindowsDesktopService, types.VerbCreate, types.VerbUpdate); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -8063,7 +8019,7 @@ func (a *ServerWithRoles) UpdateWindowsDesktop(ctx context.Context, s types.Wind
 
 // UpsertWindowsDesktop updates a windows desktop resource, creating it if it doesn't exist.
 func (a *ServerWithRoles) UpsertWindowsDesktop(ctx context.Context, s types.WindowsDesktop) error {
-	if err := a.ScopedServerWithRoles().agentOwnedResourceAction(ctx, s.GetHostID(), types.RoleWindowsDesktop); err == nil {
+	if err := a.ScopedServerWithRoles().scopedContext.AgentOwnedResourceAction("", s.GetHostID(), types.RoleWindowsDesktop); err == nil {
 		return a.authServer.UpsertWindowsDesktop(ctx, s)
 	}
 
@@ -8101,7 +8057,7 @@ func (a *ServerWithRoles) UpsertWindowsDesktop(ctx context.Context, s types.Wind
 // Passing an empty host ID will not trigger "delete all" behavior. To delete
 // all desktops, use DeleteAllWindowsDesktops.
 func (a *ServerWithRoles) DeleteWindowsDesktop(ctx context.Context, hostID, name string) error {
-	if err := a.ScopedServerWithRoles().agentOwnedResourceAction(ctx, hostID, types.RoleWindowsDesktop); err == nil {
+	if err := a.ScopedServerWithRoles().scopedContext.AgentOwnedResourceAction("", hostID, types.RoleWindowsDesktop); err == nil {
 		return a.authServer.DeleteWindowsDesktop(ctx, hostID, name)
 	}
 	if err := a.authorizeAction(types.KindWindowsDesktop, types.VerbDelete); err != nil {

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -1140,8 +1140,15 @@ type OktaAccessPoint interface {
 	// ConditionalDeleteOktaAssignment removes the specified Okta assignment resource, protected by optimistic locking.
 	ConditionalDeleteOktaAssignment(ctx context.Context, name, revision string) error
 
-	// DeleteApplicationServer removes specified application server.
+	// DeleteApplicationServer removes an unscoped application server.
+	//
+	// Deprecated: use DeleteAppServer instead. Kept temporarily so
+	// gravitational/teleport.e compiles across the rename; remove once e
+	// has migrated.
 	DeleteApplicationServer(ctx context.Context, namespace, hostID, name string) error
+
+	// DeleteAppServer removes a scoped or unscoped application server.
+	DeleteAppServer(ctx context.Context, req *presencev1.DeleteAppServerRequest) error
 
 	// UpsertLock creates or updates a given lock
 	UpsertLock(ctx context.Context, lock types.Lock) error
@@ -2020,7 +2027,14 @@ func (w *OktaWrapper) ConditionalDeleteOktaAssignment(ctx context.Context, name,
 	return w.NoCache.ConditionalDeleteOktaAssignment(ctx, name, revision)
 }
 
+// DeleteAppServer removes a scoped or unscoped application server.
+func (w *OktaWrapper) DeleteAppServer(ctx context.Context, req *presencev1.DeleteAppServerRequest) error {
+	return w.NoCache.DeleteAppServer(ctx, req)
+}
+
 // DeleteApplicationServer removes specified application server.
+//
+// Deprecated: Use [DeleteAppServer] instead.
 func (w *OktaWrapper) DeleteApplicationServer(ctx context.Context, namespace, hostID, name string) error {
 	return w.NoCache.DeleteApplicationServer(ctx, namespace, hostID, name)
 }

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -1708,13 +1708,15 @@ func (g *GRPCServer) UpsertApplicationServer(ctx context.Context, req *authpb.Up
 }
 
 // DeleteApplicationServer deletes an application server.
+//
+// Deprecated: Use DeleteAppServer from the presence service instead.
+// TODO (williamo): Remove in v20
 func (g *GRPCServer) DeleteApplicationServer(ctx context.Context, req *authpb.DeleteApplicationServerRequest) (*emptypb.Empty, error) {
 	auth, err := g.authenticate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	err = auth.DeleteApplicationServer(ctx, req.GetNamespace(), req.GetHostID(), req.GetName())
-	if err != nil {
+	if err := auth.DeleteApplicationServer(ctx, req.GetNamespace(), req.GetHostID(), req.GetName()); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &emptypb.Empty{}, nil

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -62,6 +62,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	vnetv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
@@ -3981,7 +3982,11 @@ func TestApplicationServersCRUD(t *testing.T) {
 	))
 
 	// Delete an app server.
-	err = clt.DeleteApplicationServer(ctx, server1.GetNamespace(), server1.GetHostID(), server1.GetName())
+	err = clt.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+		HostId: server1.GetHostID(),
+		Name:   server1.GetName(),
+		Scope:  server1.GetScope(),
+	}.Build())
 	require.NoError(t, err)
 	out, err = clt.GetApplicationServers(ctx, apidefaults.Namespace)
 	require.NoError(t, err)
@@ -4217,7 +4222,11 @@ func TestAppServersCRUD(t *testing.T) {
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
 	))
 
-	require.NoError(t, clt.DeleteApplicationServer(ctx, apidefaults.Namespace, "hostID", appServer1.GetName()))
+	require.NoError(t, clt.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+		HostId: "hostID",
+		Name:   appServer1.GetName(),
+		Scope:  appServer1.GetScope(),
+	}.Build()))
 
 	resources, err = clt.ListResources(ctx, proto.ListResourcesRequest{
 		ResourceType: types.KindAppServer,
@@ -4270,7 +4279,11 @@ func TestAppServersCRUD(t *testing.T) {
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
 	))
 
-	require.NoError(t, clt.DeleteApplicationServer(ctx, apidefaults.Namespace, "hostID", appServer2.GetName()))
+	require.NoError(t, clt.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+		HostId: "hostID",
+		Name:   appServer2.GetName(),
+		Scope:  appServer2.GetScope(),
+	}.Build()))
 
 	resources, err = clt.ListResources(ctx, proto.ListResourcesRequest{
 		ResourceType: types.KindAppServer,

--- a/lib/auth/integration/integrationv1/awsoidc.go
+++ b/lib/auth/integration/integrationv1/awsoidc.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/defaults"
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	awsutils "github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/api/utils/clientutils"
@@ -170,8 +171,11 @@ func (s *Service) deleteAWSOIDCAssociatedResources(ctx context.Context, authCtx 
 				"app_server", appServer.GetName(),
 				"integration", ig.GetName())
 
-			err := s.backend.DeleteApplicationServer(ctx,
-				appServer.GetNamespace(), appServer.GetHostID(), appServer.GetName())
+			err := s.backend.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+				HostId: appServer.GetHostID(),
+				Name:   appServer.GetName(),
+				Scope:  appServer.GetScope(),
+			}.Build())
 
 			if err != nil && !trace.IsNotFound(err) {
 				return trace.Wrap(err)

--- a/lib/auth/presence/presencev1/service.go
+++ b/lib/auth/presence/presencev1/service.go
@@ -52,6 +52,8 @@ type Backend interface {
 
 	UpsertProxyServer(ctx context.Context, server types.Server) (types.Server, error)
 	DeleteProxyServer(ctx context.Context, name string) error
+
+	DeleteAppServer(ctx context.Context, req *presencepb.DeleteAppServerRequest) error
 }
 
 type Cache interface {
@@ -338,6 +340,41 @@ func (s *Service) DeleteRemoteCluster(
 	}
 
 	return &emptypb.Empty{}, nil
+}
+
+// DeleteApplicationServer deletes a scoped or unscoped application server.
+func (s *Service) DeleteAppServer(
+	ctx context.Context, req *presencepb.DeleteAppServerRequest,
+) (*presencepb.DeleteAppServerResponse, error) {
+	authzCtx, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	switch {
+	case req.GetHostId() == "":
+		return nil, trace.BadParameter("host_id: must be specified")
+	case req.GetName() == "":
+		return nil, trace.BadParameter("name: must be specified")
+	}
+
+	// App agents can delete their own app servers
+	// (builtin RoleApp only grants read on app_server rules); anyone else
+	// needs an app_server delete rule granted in the target scope.
+	ruleCtx := authzCtx.RuleContext()
+	if err := authzCtx.CheckerContext.Decision(ctx, req.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		if err := authzCtx.AgentOwnedResourceAction(req.GetScope(), req.GetHostId(), types.RoleApp); err != nil {
+			return checker.CheckAccessToRules(&ruleCtx, types.KindAppServer, types.VerbDelete)
+		}
+		return nil
+	}); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := s.backend.DeleteAppServer(ctx, req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return presencepb.DeleteAppServerResponse_builder{}.Build(), nil
 }
 
 // ListAuthServers returns a page of auth servers.

--- a/lib/auth/presence/presencev1/service_test.go
+++ b/lib/auth/presence/presencev1/service_test.go
@@ -29,14 +29,19 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/gravitational/teleport"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	presencev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/trail"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
@@ -44,12 +49,19 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	scopedapp "github.com/gravitational/teleport/lib/scopes/app"
 )
 
 func newTestTLSServer(t testing.TB) *authtest.TLSServer {
 	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		Dir:   t.TempDir(),
 		Clock: clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC()),
+		ScopesFeatures: scopes.Features{
+			Enabled:         true,
+			AgentPinEnabled: true,
+		},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, as.Close()) })
@@ -1434,5 +1446,260 @@ func TestUpsertReverseTunnel(t *testing.T) {
 			}
 		})
 	}
+}
 
+// TestDeleteAppServer is an integration test that uses a real gRPC
+// client/server to exercise deleting scoped and unscoped application servers
+// through the presence service with authorized and unauthorized callers.
+func TestDeleteAppServer(t *testing.T) {
+	t.Parallel()
+	srv := newTestTLSServer(t)
+	ctx := t.Context()
+	const (
+		parentScope     = "/aa"
+		scope           = "/aa/aa"
+		orthogonalScope = "/aa/bb"
+	)
+
+	deleteUser, _, err := authtest.CreateUserAndRole(
+		srv.Auth(),
+		"app-server-deleter",
+		[]string{},
+		[]types.Rule{
+			{
+				Resources: []string{types.KindAppServer},
+				Verbs:     []string{types.VerbDelete},
+			},
+		})
+	require.NoError(t, err)
+	unprivilegedUser, _, err := authtest.CreateUserAndRole(
+		srv.Auth(),
+		"app-server-no-perms",
+		[]string{},
+		[]types.Rule{},
+	)
+	require.NoError(t, err)
+
+	createScopedRole := func(name string, verbs []string) *scopedaccessv1.ScopedRole {
+		scopedRole, err := srv.Auth().ScopedAccess().CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+			Role: scopedaccessv1.ScopedRole_builder{
+				Kind:    scopedaccess.KindScopedRole,
+				Version: types.V1,
+				Metadata: headerv1.Metadata_builder{
+					Name: name,
+				}.Build(),
+				Scope: parentScope,
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{scope, orthogonalScope},
+					Rules: []*scopedaccessv1.ScopedRule{
+						scopedaccessv1.ScopedRule_builder{
+							Resources: []string{types.KindAppServer},
+							Verbs:     verbs,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		return scopedRole.GetRole()
+	}
+
+	scopedDeleteRole := createScopedRole("app-server-delete-role", []string{types.VerbDelete})
+	scopedReadRole := createScopedRole("app-server-read-role", []string{types.VerbRead})
+
+	createAssignment := func(role *scopedaccessv1.ScopedRole, username, assignedScope string) *scopedaccessv1.ScopedRoleAssignment {
+		sra, err := srv.Auth().ScopedAccess().CreateScopedRoleAssignment(ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
+			Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
+				Kind:    scopedaccess.KindScopedRoleAssignment,
+				SubKind: scopedaccess.SubKindDynamic,
+				Version: types.V1,
+				Metadata: headerv1.Metadata_builder{
+					Name: uuid.NewString(),
+				}.Build(),
+				Scope: assignedScope,
+				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+					User: username,
+					Assignments: []*scopedaccessv1.Assignment{
+						scopedaccessv1.Assignment_builder{
+							Role:  scopes.QualifiedName{Scope: role.GetScope(), Name: role.GetMetadata().GetName()}.String(),
+							Scope: assignedScope,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		return sra.GetAssignment()
+	}
+
+	waitForSRACache(t, srv,
+		createAssignment(scopedDeleteRole, deleteUser.GetName(), scope),
+		createAssignment(scopedReadRole, unprivilegedUser.GetName(), scope),
+	)
+
+	// newAppServer registers a fresh app server in the given scope. Each test
+	// case gets its own server since successful deletions are destructive.
+	newAppServer := func(t *testing.T, scope string) types.AppServer {
+		t.Helper()
+		name := "app-" + uuid.NewString()
+		spec := types.AppSpecV3{URI: "http://localhost:8080"}
+		if scope != "" {
+			// Scoped apps must register with their derived public address.
+			spec.PublicAddr = scopedapp.ScopedAppPublicAddr(scope, name, "proxy.example.com")
+		}
+		app, err := types.NewAppV3(types.Metadata{Name: name}, spec, scope)
+		require.NoError(t, err)
+		server, err := types.NewAppServerV3FromApp(app, "localhost", uuid.NewString())
+		require.NoError(t, err)
+		_, err = srv.Auth().UpsertApplicationServer(ctx, server)
+		require.NoError(t, err)
+		return server
+	}
+
+	tests := []struct {
+		name        string
+		identity    authtest.TestIdentity
+		targetScope string
+		// req overrides the request derived from a freshly created target.
+		req          *presencev1pb.DeleteAppServerRequest
+		assertError  require.ErrorAssertionFunc
+		checkDeleted bool
+	}{
+		{
+			name:         "unscoped user with delete rule deletes unscoped server",
+			identity:     authtest.TestUser(deleteUser.GetName()),
+			targetScope:  "",
+			assertError:  require.NoError,
+			checkDeleted: true,
+		},
+		{
+			name:         "unscoped user with delete rule deletes scoped server",
+			identity:     authtest.TestUser(deleteUser.GetName()),
+			targetScope:  scope,
+			assertError:  require.NoError,
+			checkDeleted: true,
+		},
+		{
+			name:        "unscoped user without delete rule cannot delete unscoped server",
+			identity:    authtest.TestUser(unprivilegedUser.GetName()),
+			targetScope: "",
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAccessDenied(err), "expected access denied, got %v", err)
+			},
+		},
+		{
+			name:        "unscoped user without delete rule cannot delete scoped server",
+			identity:    authtest.TestUser(unprivilegedUser.GetName()),
+			targetScope: scope,
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAccessDenied(err), "expected access denied, got %v", err)
+			},
+		},
+		{
+			name:         "scoped user with delete rule deletes server in its scope",
+			identity:     authtest.TestScopedUser(deleteUser.GetName(), scope),
+			targetScope:  scope,
+			assertError:  require.NoError,
+			checkDeleted: true,
+		},
+		{
+			name:        "scoped user with delete rule cannot delete server in orthogonal scope",
+			identity:    authtest.TestScopedUser(deleteUser.GetName(), scope),
+			targetScope: orthogonalScope,
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAccessDenied(err), "expected access denied, got %v", err)
+			},
+		},
+		{
+			name:        "scoped user with delete rule cannot delete unscoped server",
+			identity:    authtest.TestScopedUser(deleteUser.GetName(), scope),
+			targetScope: "",
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAccessDenied(err), "expected access denied, got %v", err)
+			},
+		},
+		{
+			name:        "scoped user with read-only rule cannot delete server in its scope",
+			identity:    authtest.TestScopedUser(unprivilegedUser.GetName(), scope),
+			targetScope: scope,
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAccessDenied(err), "expected access denied, got %v", err)
+			},
+		},
+		{
+			name:     "missing host_id",
+			identity: authtest.TestUser(deleteUser.GetName()),
+			req: presencev1pb.DeleteAppServerRequest_builder{
+				Name: "some-app",
+			}.Build(),
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+			},
+		},
+		{
+			name:     "missing name",
+			identity: authtest.TestUser(deleteUser.GetName()),
+			req: presencev1pb.DeleteAppServerRequest_builder{
+				HostId: uuid.NewString(),
+			}.Build(),
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+			},
+		},
+		{
+			name:     "non existent server",
+			identity: authtest.TestUser(deleteUser.GetName()),
+			req: presencev1pb.DeleteAppServerRequest_builder{
+				HostId: uuid.NewString(),
+				Name:   "does-not-exist",
+			}.Build(),
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsNotFound(err), "expected not found, got %v", err)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := srv.NewClient(tt.identity)
+			require.NoError(t, err)
+			t.Cleanup(func() { client.Close() })
+
+			req := tt.req
+			var target types.AppServer
+			if req == nil {
+				target = newAppServer(t, tt.targetScope)
+				req = presencev1pb.DeleteAppServerRequest_builder{
+					HostId: target.GetHostID(),
+					Name:   target.GetName(),
+					Scope:  target.GetScope(),
+				}.Build()
+			}
+
+			_, err = client.PresenceServiceClient().DeleteAppServer(t.Context(), req)
+			tt.assertError(t, err)
+
+			if tt.checkDeleted {
+				servers, err := srv.Auth().GetApplicationServers(t.Context(), apidefaults.Namespace)
+				require.NoError(t, err)
+				for _, s := range servers {
+					require.NotEqual(t, target.GetHostID(), s.GetHostID(), "app server should be deleted")
+				}
+			}
+		})
+	}
+}
+
+func waitForSRACache(t *testing.T, srv *authtest.TLSServer, sras ...*scopedaccessv1.ScopedRoleAssignment) {
+	t.Helper()
+	ctx := t.Context()
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		for _, sra := range sras {
+			_, err := srv.Auth().ScopedAccessCache.GetScopedRoleAssignment(ctx, scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
+				Name:    sra.GetMetadata().GetName(),
+				SubKind: sra.GetSubKind(),
+				Scope:   sra.GetScope(),
+			}.Build())
+			require.NoError(t, err)
+		}
+	}, 10*time.Second, 100*time.Millisecond)
 }

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -2049,7 +2049,11 @@ func TestAppServerCRUD(t *testing.T) {
 	require.Empty(t, cmp.Diff([]types.AppServer{server}, out, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
 	// Remove the application.
-	err = clt.DeleteApplicationServer(ctx, server.Metadata.Namespace, server.GetHostID(), server.GetName())
+	err = clt.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+		HostId: server.GetHostID(),
+		Name:   server.GetName(),
+		Scope:  server.GetScope(),
+	}.Build())
 	require.NoError(t, err)
 
 	// Now expect no applications to be returned.

--- a/lib/authz/scoped.go
+++ b/lib/authz/scoped.go
@@ -21,11 +21,13 @@ package authz
 import (
 	"context"
 	"errors"
+	"slices"
 	"time"
 
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
@@ -293,6 +295,53 @@ func (s *ScopedContext) LockTargets() []types.LockTarget {
 	return lockTargets
 }
 
+// HasBuiltinRole reports whether the calling identity is a local builtin role
+// (scoped or unscoped) matching any of the given system roles.
+func (s *ScopedContext) HasBuiltinRole(roles ...types.SystemRole) bool {
+	if unscopedCtx, isUnscoped := s.UnscopedContext(); isUnscoped {
+		for _, role := range roles {
+			if HasBuiltinRole(*unscopedCtx, string(role)) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Since unscoped contexts are handled above, the only valid builtin
+	// identity at this point is a [ScopedBuiltinRole].
+	role, isBuiltin := s.Identity.(ScopedBuiltinRole)
+	if !isBuiltin {
+		return false
+	}
+	// For service certs, the additional system roles will be empty so we only
+	// check if the primary role is included in the given roles.
+	if primary := types.SystemRole(role.ScopePin.GetSystemRoles().GetPrimary()); primary != types.RoleInstance {
+		return types.SystemRoles(roles).Include(primary)
+	}
+	// For instance certs, we check if there is any overlap between the given
+	// roles and the additional system roles included in the scope pin.
+	existingRoles := role.ScopePin.GetSystemRoles().GetAdditional()
+	for _, r := range roles {
+		if slices.Contains(existingRoles, string(r)) {
+			return true
+		}
+	}
+	return false
+}
+
+// LocalServerID returns the builtin server ID associated with the calling
+// identity. If the identity is not a builtin server role, an empty string and
+// false are returned.
+func (s *ScopedContext) LocalServerID() (serverID string, isBuiltinServer bool) {
+	switch role := s.Identity.(type) {
+	case BuiltinRole:
+		return role.GetServerID(), role.IsServer()
+	case ScopedBuiltinRole:
+		return role.GetServerID(), role.IsServer()
+	}
+	return "", false
+}
+
 // DisplayName returns a display name for the calling identity.
 // authzContext.User is nil for non-user (agent/builtin) identities, so fall back to
 // the identity's username.
@@ -305,4 +354,34 @@ func (s *ScopedContext) DisplayName() string {
 		return s.Identity.GetIdentity().Username
 	}
 	return ""
+}
+
+// AgentOwnedResourceAction authorizes an agent identity to perform actions on its own resources.
+func (s *ScopedContext) AgentOwnedResourceAction(scope, hostID string, systemRoles ...types.SystemRole) error {
+	if !s.HasBuiltinRole(systemRoles...) {
+		return trace.AccessDenied("this request can be only executed by a teleport built-in server")
+	}
+
+	serverID, isAgent := s.LocalServerID()
+	if !isAgent {
+		return trace.BadParameter("no agent identity after confirming that request context is BuiltinRole (this is a bug)")
+	}
+	// For now, agents must also check that
+	if hostID != serverID {
+		return trace.AccessDenied("resource host ID %+q does not match agent identity ID %+q", hostID, serverID)
+	}
+
+	agentScope := s.Identity.GetIdentity().GetAgentScope()
+	// Unscoped agents must be only allowed to delete unscoped resources.
+	// Scoped pinned agents must have matching agent and resource scopes.
+	// TODO (williamo/scopes): We most likely will relax this rule in the future.
+	if agentScope == "" && scope == "" {
+		return nil
+	}
+	if scopes.Compare(agentScope, scope) == scopes.Equivalent {
+		return nil
+	}
+
+	return trace.AccessDenied("agent scope %+q does not match resource scope %+q", agentScope, scope)
+
 }

--- a/lib/cache/app.go
+++ b/lib/cache/app.go
@@ -19,7 +19,6 @@ package cache
 import (
 	"context"
 	"iter"
-	"strings"
 
 	"github.com/gravitational/trace"
 	"rsc.io/ordered"
@@ -28,7 +27,6 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
-	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
@@ -168,7 +166,11 @@ func appServerByAppNameKey(s types.AppServer) string {
 	if app == nil {
 		return ""
 	}
-	return string(ordered.Encode(app.GetName(), s.GetHostID(), s.GetName()))
+	// The second component is the scope-aware resource cursor, so within each
+	// app name the in-memory ordering matches the backend listing order
+	// (unscoped first, then scoped) and index keys are interchangeable with
+	// the fallback pagination tokens.
+	return string(ordered.Encode(app.GetName(), services.GetCursorForAppServer(s)))
 }
 
 func newAppServerCollection(p services.Presence, w types.WatchKind) (*collection[types.AppServer, appServerIndex], error) {
@@ -181,9 +183,7 @@ func newAppServerCollection(p services.Presence, w types.WatchKind) (*collection
 			types.KindAppServer,
 			types.AppServer.Copy,
 			map[appServerIndex]func(types.AppServer) string{
-				appServerNameIndex: func(u types.AppServer) string {
-					return u.GetHostID() + "/" + u.GetName()
-				},
+				appServerNameIndex:    services.GetCursorForAppServer,
 				appServerAppNameIndex: appServerByAppNameKey,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.AppServer, error) {
@@ -253,20 +253,20 @@ func (c *Cache) RangeApplicationServersWithName(ctx context.Context, appName str
 				return nil, "", trace.BadParameter("pagination token does not match the requested application name")
 			}
 
-			backendKey := ""
+			// The remainder of the token is the scope aware resource
+			// cursor
+			startKey := ""
 			if len(rest) > 0 {
-				var hostID, serverName string
-				if err := ordered.Decode(rest, &hostID, &serverName); err != nil {
+				if err := ordered.Decode(rest, &startKey); err != nil {
 					return nil, "", trace.Wrap(err)
 				}
-				backendKey = hostID + "/" + serverName
 			}
 
 			resp, err := c.Config.Presence.ListResources(ctx, clientproto.ListResourcesRequest{
 				ResourceType: types.KindAppServer,
 				Namespace:    defaults.Namespace,
 				Limit:        int32(pageSize),
-				StartKey:     backendKey,
+				StartKey:     startKey,
 			})
 			if err != nil {
 				return nil, "", trace.Wrap(err)
@@ -286,11 +286,7 @@ func (c *Cache) RangeApplicationServersWithName(ctx context.Context, appName str
 
 			next := ""
 			if resp.NextKey != "" {
-				hostID, serverName, ok := strings.Cut(resp.NextKey, backend.SeparatorString)
-				if !ok {
-					return nil, "", trace.BadParameter("invalid pagination token: %q", resp.NextKey)
-				}
-				next = string(ordered.Encode(appName, hostID, serverName))
+				next = string(ordered.Encode(appName, resp.NextKey))
 			}
 			return page, next, nil
 		}

--- a/lib/cache/app_test.go
+++ b/lib/cache/app_test.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
@@ -26,7 +27,9 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -165,7 +168,11 @@ var appServerRangeFuncs = rangeServersWithTargetNameFuncs[types.AppServer]{
 		return err
 	},
 	delete: func(ctx context.Context, presence services.Presence, s types.AppServer) error {
-		return presence.DeleteApplicationServer(ctx, s.GetNamespace(), s.GetHostID(), s.GetName())
+		return presence.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+			HostId: s.GetHostID(),
+			Name:   s.GetName(),
+			Scope:  s.GetScope(),
+		}.Build())
 	},
 	rangeByName: (*Cache).RangeApplicationServersWithName,
 }
@@ -173,6 +180,93 @@ var appServerRangeFuncs = rangeServersWithTargetNameFuncs[types.AppServer]{
 func TestRangeApplicationServersWithName(t *testing.T) {
 	t.Parallel()
 	testRangeServersWithTargetName(t, appServerRangeFuncs)
+}
+
+// TestListResourcesAppServerScopedPagination verifies that ListResources
+// pagination spanning unscoped and scoped app servers returns every server
+func TestListResourcesAppServerScopedPagination(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name    string
+		neverOK bool
+	}{
+		{name: "HealthyCache", neverOK: false},
+		{name: "Fallback", neverOK: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx := t.Context()
+
+				p := newTestPack(t, func(cfg Config) Config {
+					cfg = ForAuth(cfg)
+					cfg.neverOK = tt.neverOK
+					return cfg
+				})
+				t.Cleanup(p.Close)
+
+				go func() {
+					for {
+						select {
+						case <-ctx.Done():
+							return
+						case <-p.eventsC:
+							// Discard events to avoid blocking the test.
+						}
+					}
+				}()
+
+				key := func(s types.AppServer) string {
+					return s.GetScope() + "/" + s.GetHostID() + "/" + s.GetName()
+				}
+
+				var expectedKeys []string
+				for _, scope := range []string{"", "", "", "/prod", "/prod", "/staging"} {
+					server := mustCreateAppServer(t, uuid.New().String(), "graf").(*types.AppServerV3)
+					server.Scope = scope
+					server.Spec.App.Scope = scope
+					_, err := p.presenceS.UpsertApplicationServer(ctx, server)
+					require.NoError(t, err)
+					expectedKeys = append(expectedKeys, key(server))
+				}
+
+				// Wait for the cache to replicate all servers.
+				synctest.Wait()
+
+				var actualKeys []string
+				startKey := ""
+				for {
+					resp, err := p.cache.ListResources(ctx, proto.ListResourcesRequest{
+						ResourceType: types.KindAppServer,
+						Namespace:    apidefaults.Namespace,
+						Limit:        1,
+						StartKey:     startKey,
+					})
+					require.NoError(t, err)
+					r := resp.Resources[0]
+					server, ok := r.(types.AppServer)
+					require.True(t, ok)
+					if startKey != "" { // first entry
+						if startKey == scopes.ResourceCursorScopedStart() {
+							// The unscoped range ended exactly at a page boundary;
+							// next entry should be scoped
+							require.NotEmpty(t, server.GetScope())
+						} else {
+							require.Equal(t, startKey, services.GetCursorForAppServer(server))
+						}
+					}
+					actualKeys = append(actualKeys, key(server))
+
+					if resp.NextKey == "" {
+						break
+					}
+					startKey = resp.NextKey
+				}
+
+				require.ElementsMatch(t, expectedKeys, actualKeys)
+			})
+		})
+	}
 }
 
 func BenchmarkRangeApplicationServersWithName(b *testing.B) {

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -1890,7 +1890,7 @@ func buildListResourcesResponse[T types.ResourceWithLabels](resources iter.Seq[T
 			return nil, trace.Wrap(err)
 		case match:
 			if len(resp.Resources) == limit {
-				resp.NextKey = backend.GetPaginationKey(r)
+				resp.NextKey = services.GetCursorForResource(r)
 				return &resp, nil
 			}
 

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -60,7 +60,7 @@ type Auth interface {
 
 	UpsertApplicationServer(context.Context, types.AppServer) (*types.KeepAlive, error)
 	UnconditionalUpdateApplicationServer(context.Context, types.AppServer) (types.AppServer, error)
-	DeleteApplicationServer(ctx context.Context, namespace, hostID, name string) error
+	DeleteAppServer(ctx context.Context, req *presencev1.DeleteAppServerRequest) error
 
 	UpsertDatabaseServer(context.Context, types.DatabaseServer) (*types.KeepAlive, error)
 	DeleteDatabaseServer(ctx context.Context, namespace, hostID, name string) error
@@ -791,7 +791,11 @@ func (c *Controller) doResourceCleanup(handle *upstreamHandle) {
 			return
 		}
 
-		if err := c.auth.DeleteApplicationServer(cleanupCtx, apidefaults.Namespace, app.resource.GetHostID(), app.resource.GetName()); err != nil && !trace.IsNotFound(err) {
+		if err := c.auth.DeleteAppServer(cleanupCtx, presencev1.DeleteAppServerRequest_builder{
+			HostId: app.resource.GetHostID(),
+			Name:   app.resource.GetName(),
+			Scope:  app.resource.GetScope(),
+		}.Build()); err != nil && !trace.IsNotFound(err) {
 			if cleanupCtx.Err() != nil {
 				slog.WarnContext(c.closeContext, "halting remaining resource cleanup", "instance_id", handle.Hello().GetServerID(), "error", err)
 				return

--- a/lib/inventory/controller_test.go
+++ b/lib/inventory/controller_test.go
@@ -128,7 +128,7 @@ func (a *fakeAuth) UnconditionalUpdateApplicationServer(_ context.Context, serve
 	return server, a.err
 }
 
-func (a *fakeAuth) DeleteApplicationServer(ctx context.Context, namespace, hostID, name string) error {
+func (a *fakeAuth) DeleteAppServer(ctx context.Context, req *presencev1.DeleteAppServerRequest) error {
 	return nil
 }
 

--- a/lib/join/join_ec2_test.go
+++ b/lib/join/join_ec2_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gravitational/teleport/api/defaults"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authtest"
@@ -721,7 +722,11 @@ func TestHostUniqueCheck(t *testing.T) {
 				require.NoError(t, err)
 			},
 			deleter: func(t *testing.T, hostID string) {
-				require.NoError(t, a.DeleteApplicationServer(t.Context(), defaults.Namespace, hostID, "test-app"))
+				require.NoError(t, a.DeleteAppServer(t.Context(),
+					presencev1.DeleteAppServerRequest_builder{
+						HostId: hostID,
+						Name:   "test-app",
+					}.Build()))
 			},
 		},
 		{
@@ -768,7 +773,10 @@ func TestHostUniqueCheck(t *testing.T) {
 				require.NoError(t, err)
 			},
 			deleter: func(t *testing.T, hostID string) {
-				require.NoError(t, a.DeleteApplicationServer(t.Context(), defaults.Namespace, hostID, "test-okta-app"))
+				require.NoError(t, a.DeleteAppServer(t.Context(), presencev1.DeleteAppServerRequest_builder{
+					HostId: hostID,
+					Name:   "test-okta-app",
+				}.Build()))
 			},
 		},
 	}

--- a/lib/scopes/access/verbs.go
+++ b/lib/scopes/access/verbs.go
@@ -41,6 +41,8 @@ func isAllowedScopedRule(kind string, verb string) bool {
 		return isReadWriteNoSecrets(verb)
 	case types.KindKubernetesCluster:
 		return isReadWriteWithSecrets(verb) || isReadWriteNoSecrets(verb)
+	case types.KindAppServer:
+		return isReadWriteWithSecrets(verb) || isReadWriteNoSecrets(verb)
 	case types.KindAccessList:
 		// access lists can be read/written, and do not contain a concept of a secret.
 		// permissions for access list members are conferred by permissions for

--- a/lib/scopes/cursor.go
+++ b/lib/scopes/cursor.go
@@ -149,6 +149,18 @@ func EncodeForResourceCursor(scope string) string {
 	return encoded
 }
 
+// MakeResourceCursorWithHost returns the cursor for a scoped or unscoped
+// host-keyed resource — one keyed by (host ID, name), such as an app server —
+// in a logical, lexicographically ordered resource stream:
+//
+//	scoped:   ~scoped/<encoded-scope>/<host-id>/<name>
+//
+// See [MakeResourceCursor] for cursor semantics. Host cursors are not
+// parseable by [ParseResourceCursor], which rejects composite names.
+func MakeResourceCursorWithHost(scope, hostID, name string) string {
+	return MakeResourceCursor(scope, hostID+separator+name)
+}
+
 // ParseResourceCursor parses a resource cursor produced by [MakeResourceCursor]
 // into its scope and name components.
 //

--- a/lib/scopes/cursor_test.go
+++ b/lib/scopes/cursor_test.go
@@ -53,6 +53,18 @@ func TestResourceCursor(t *testing.T) {
 		require.Equal(t, ResourceCursorPrefix, ResourceCursorScopedStart())
 		require.True(t, IsScopedResourceCursor(ResourceCursorScopedStart()))
 	})
+
+	t.Run("unscoped with host", func(t *testing.T) {
+		cursor := MakeResourceCursorWithHost("", "host-id", "name")
+		require.Equal(t, "host-id/name", cursor)
+		require.False(t, IsScopedResourceCursor(cursor))
+	})
+
+	t.Run("scoped with host", func(t *testing.T) {
+		cursor := MakeResourceCursorWithHost("/aa/bb", "host-id", "name")
+		require.True(t, IsScopedResourceCursor(cursor))
+		require.Equal(t, MakeResourceCursor("/aa/bb", "host-id/name"), cursor)
+	})
 }
 
 func TestParseResourceCursorErrors(t *testing.T) {

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -337,6 +337,22 @@ func AppServerScopesEqual(serverScope, appScope string) bool {
 	return scopes.Compare(serverScope, appScope) == scopes.Equivalent
 }
 
+// GetCursorForAppServer returns the resource cursor identifying an app server
+// in the logical resource stream: "<host-id>/<name>" for unscoped app servers
+// and "~scoped/<encoded-scope>/<host-id>/<name>" for scoped apps.
+func GetCursorForAppServer(server types.AppServer) string {
+	return scopes.MakeResourceCursorWithHost(server.GetScope(), server.GetHostID(), server.GetName())
+}
+
+// GetCursorForResource returns the pagination cursor for a
+// resource used in ListResources.
+func GetCursorForResource(r types.ResourceWithLabels) string {
+	if s, ok := r.(types.AppServer); ok {
+		return GetCursorForAppServer(s)
+	}
+	return backend.GetPaginationKey(r)
+}
+
 // ValidatePublicAddr requires a lowercase DNS-1123 hostname. An
 // empty addr is treated as unset.
 func ValidatePublicAddr(appName, addr string) error {

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -1509,7 +1509,10 @@ func (p *reverseTunnelParser) parse(event backend.Event) (types.Resource, error)
 
 func newAppServerV3Parser() *appServerV3Parser {
 	return &appServerV3Parser{
-		baseParser: newBaseParser(backend.NewKey(appServersPrefix, apidefaults.Namespace)),
+		baseParser: newBaseParser(
+			backend.NewKey(appServersPrefix, apidefaults.Namespace),
+			backend.NewKey(scopedPrefix, appServersPrefix),
+		),
 	}
 }
 
@@ -1520,6 +1523,34 @@ type appServerV3Parser struct {
 func (p *appServerV3Parser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
+		// Scoped app servers live under
+		// /scoped/appServers/<encoded-scope>/<host-id>/<name>.
+		scopedAppServersKey := backend.NewKey(scopedPrefix, appServersPrefix)
+		if event.Item.Key.HasPrefix(scopedAppServersKey) {
+			components := event.Item.Key.TrimPrefix(scopedAppServersKey).Components()
+			if len(components) != 3 {
+				return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+			}
+			scope, err := scopes.DecodeFromKey(components[0])
+			if err != nil {
+				return nil, trace.Wrap(err, "failed decoding scope from app server key %q", event.Item.Key.String())
+			}
+			return &types.AppServerV3{
+				Kind:    types.KindAppServer,
+				Version: types.V3,
+				Metadata: types.Metadata{
+					Name: components[2],
+					// The host ID is stored in the description for compatibility
+					// with resource header stubs; some caches rely on it
+					Description: components[1],
+				},
+				Scope: scope,
+				Spec: types.AppServerSpecV3{
+					HostID: components[1],
+				},
+			}, nil
+		}
+
 		components := event.Item.Key.TrimPrefix(backend.NewKey(appServersPrefix, apidefaults.Namespace)).Components()
 		if len(components) != 2 {
 			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())

--- a/lib/services/local/generic/scopeaware.go
+++ b/lib/services/local/generic/scopeaware.go
@@ -92,6 +92,10 @@ type ScopeAwareServiceConfig[T ScopedResource] struct {
 
 // NewScopeAwareService returns a new scope-aware service.
 func NewScopeAwareService[T ScopedResource](cfg *ScopeAwareServiceConfig[T]) (*ScopeAwareService[T], error) {
+	if !cfg.ScopedOnly && cfg.ScopedBackendPrefix.Compare(cfg.UnscopedBackendPrefix) == 0 {
+		return nil, trace.BadParameter("scoped and unscoped backend services cannot have the same prefix")
+	}
+
 	scopedService, err := NewService(&ServiceConfig[T]{
 		Backend:                     cfg.Backend,
 		ResourceKind:                cfg.ResourceKind,

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -56,6 +56,33 @@ type PresenceService struct {
 	backend.Backend
 
 	relayServers *generic.ServiceWrapper[*presencev1.RelayServer]
+	appServers   *generic.ScopeAwareService[types.AppServer]
+}
+
+type appServerServiceParams struct {
+	Scope, Host string
+}
+
+// appServerServiceForHost returns a [*generic.Service] prefixed for the app
+// servers of a single host:
+//   - unscoped: /appServers/default/<host-id>/<name>
+//   - scoped:   /scoped/appServers/<encoded-scope>/<host-id>/<name>
+//
+// The legacy default namespace is part of the unscoped backend prefix, as we
+// do not support anything other than default.
+//
+// Since an app server represents a single proxied application, there may be
+// multiple app servers on a single host, so the hostID prefix is needed.
+func appServerServiceForHost(
+	appServers *generic.ScopeAwareService[types.AppServer],
+	params appServerServiceParams,
+) (*generic.Service[types.AppServer], error) {
+	service, err := appServers.WithScopePrefix(params.Scope)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return service.WithPrefix(params.Host), nil
 }
 
 var _ services.PresenceInternal = (*PresenceService)(nil)
@@ -77,12 +104,26 @@ func NewPresenceService(b backend.Backend) *PresenceService {
 	if err != nil {
 		panic("impossible: failed to construct relay_server service wrapper")
 	}
+
+	appServers, err := generic.NewScopeAwareService(&generic.ScopeAwareServiceConfig[types.AppServer]{
+		Backend:               b,
+		ResourceKind:          types.KindAppServer,
+		UnscopedBackendPrefix: backend.NewKey(appServersPrefix, apidefaults.Namespace),
+		ScopedBackendPrefix:   backend.NewKey(scopedPrefix, appServersPrefix),
+		MarshalFunc:           services.MarshalAppServer,
+		UnmarshalFunc:         services.UnmarshalAppServer,
+	})
+	if err != nil {
+		panic("impossible: failed to construct app_server service wrapper")
+	}
+
 	return &PresenceService{
 		logger:  slog.With(teleport.ComponentKey, "Presence"),
 		jitter:  retryutils.FullJitter,
 		Backend: b,
 
 		relayServers: relayServers,
+		appServers:   appServers,
 	}
 }
 
@@ -1197,31 +1238,8 @@ func (s *PresenceService) GetApplicationServers(ctx context.Context, namespace s
 	if namespace == "" {
 		return nil, trace.BadParameter("missing namespace")
 	}
-	servers, err := s.getApplicationServers(ctx, namespace)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return servers, nil
-}
 
-func (s *PresenceService) getApplicationServers(ctx context.Context, namespace string) ([]types.AppServer, error) {
-	startKey := backend.ExactKey(appServersPrefix, namespace)
-	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	servers := make([]types.AppServer, len(result.Items))
-	for i, item := range result.Items {
-		server, err := services.UnmarshalAppServer(
-			item.Value,
-			services.WithExpires(item.Expires),
-			services.WithRevision(item.Revision))
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		servers[i] = server
-	}
-	return servers, nil
+	return stream.Collect(s.appServers.Resources(ctx, "", ""))
 }
 
 // RangeApplicationServersWithName returns an iterator over application servers for a given app name.
@@ -1229,25 +1247,12 @@ func (s *PresenceService) RangeApplicationServersWithName(ctx context.Context, a
 	if appName == "" {
 		return stream.Fail[types.AppServer](trace.BadParameter("missing application name"))
 	}
-
-	mapFn := func(item backend.Item) (types.AppServer, bool) {
-		server, err := services.UnmarshalAppServer(
-			item.Value,
-			services.WithExpires(item.Expires),
-			services.WithRevision(item.Revision),
-		)
-		if err != nil {
-			s.logger.WarnContext(ctx, "Failed to unmarshal application server", "key", item.Key, "error", err)
-			return nil, false
-		}
+	mapFn := func(server types.AppServer) (types.AppServer, bool) {
 		app := server.GetApp()
 		return server, app != nil && app.GetName() == appName
 	}
 
-	startKey := backend.ExactKey(appServersPrefix, apidefaults.Namespace)
-	endKey := backend.RangeEnd(startKey)
-
-	return stream.FilterMap(s.Backend.Items(ctx, backend.ItemsParams{StartKey: startKey, EndKey: endKey}), mapFn)
+	return stream.FilterMap(s.appServers.Resources(ctx, "", ""), mapFn)
 }
 
 // UpsertApplicationServer registers an application server.
@@ -1259,36 +1264,25 @@ func (s *PresenceService) UpsertApplicationServer(ctx context.Context, server ty
 		return nil, trace.Wrap(err)
 	}
 
-	rev := server.GetRevision()
-	value, err := services.MarshalAppServer(server)
+	svc, err := appServerServiceForHost(s.appServers, appServerServiceParams{Scope: server.GetScope(), Host: server.GetHostID()})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// Since an app server represents a single proxied application, there may
-	// be multiple database servers on a single host, so they are stored under
-	// the following path in the backend:
-	//   /appServers/<namespace>/<host-uuid>/<name>
-	_, err = s.Put(ctx, backend.Item{
-		Key: backend.NewKey(appServersPrefix,
-			server.GetNamespace(),
-			server.GetHostID(),
-			server.GetName()),
-		Value:    value,
-		Expires:  server.Expiry(),
-		Revision: rev,
-	})
+	upserted, err := svc.UpsertResource(ctx, server)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if server.Expiry().IsZero() {
+
+	if upserted.Expiry().IsZero() {
 		return &types.KeepAlive{}, nil
 	}
+
 	return &types.KeepAlive{
 		Type:      types.KeepAlive_APP,
 		Name:      server.GetName(),
 		Namespace: server.GetNamespace(),
 		HostID:    server.GetHostID(),
-		Expires:   server.Expiry(),
+		Expires:   upserted.Expiry(),
 	}, nil
 }
 
@@ -1301,43 +1295,45 @@ func (s *PresenceService) UnconditionalUpdateApplicationServer(ctx context.Conte
 		return nil, trace.Wrap(err)
 	}
 
-	value, err := services.MarshalAppServer(server)
+	svc, err := appServerServiceForHost(s.appServers, appServerServiceParams{Scope: server.GetScope(), Host: server.GetHostID()})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	// Since an app server represents a single proxied application, there may
-	// be multiple database servers on a single host, so they are stored under
-	// the following path in the backend:
-	//   /appServers/<namespace>/<host-uuid>/<name>
-	lease, err := s.Update(ctx, backend.Item{
-		Key: backend.NewKey(appServersPrefix,
-			server.GetNamespace(),
-			server.GetHostID(),
-			server.GetName(),
-		),
-		Value:    value,
-		Expires:  server.Expiry(),
-		Revision: server.GetRevision(),
-	})
+	updated, err := svc.UpdateResource(ctx, server)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	server.SetRevision(lease.Revision)
-	return server, nil
+	return updated, nil
 }
 
-// DeleteApplicationServer removes specified application server.
+// DeleteAppServer removes a scoped or unscoped application server.
+// Unscoped app servers always use the legacy default namespace and scoped app
+// servers have no namespace.
+func (s *PresenceService) DeleteAppServer(ctx context.Context, req *presencev1.DeleteAppServerRequest) error {
+	svc, err := appServerServiceForHost(s.appServers, appServerServiceParams{Scope: req.GetScope(), Host: req.GetHostId()})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(svc.DeleteResource(ctx, req.GetName()))
+}
+
+// DeleteApplicationServer removes an unscoped application server.
+//
+// Deprecated: use DeleteAppServer instead. Kept temporarily so
+// gravitational/teleport.e compiles across the rename; remove once e
+// has migrated.
 func (s *PresenceService) DeleteApplicationServer(ctx context.Context, namespace, hostID, name string) error {
-	key := backend.NewKey(appServersPrefix, namespace, hostID, name)
-	return s.Delete(ctx, key)
+	return trace.Wrap(s.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+		HostId: hostID,
+		Name:   name,
+	}.Build()))
 }
 
 // DeleteAllApplicationServers removes all registered application servers.
 func (s *PresenceService) DeleteAllApplicationServers(ctx context.Context, namespace string) error {
-	startKey := backend.ExactKey(appServersPrefix, namespace)
-	return s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
+	return trace.Wrap(s.appServers.DeleteAllResources(ctx))
 }
 
 // KeepAliveServer updates expiry time of a server resource.
@@ -1576,8 +1572,7 @@ func (s *PresenceService) listResources(ctx context.Context, req proto.ListResou
 		keyPrefix = []string{databaseServicePrefix}
 		unmarshalItemFunc = backendItemToDatabaseService
 	case types.KindAppServer:
-		keyPrefix = []string{appServersPrefix, req.Namespace}
-		unmarshalItemFunc = backendItemToApplicationServer
+		return s.listAppServers(ctx, req)
 	case types.KindNode:
 		keyPrefix = []string{nodesPrefix, req.Namespace}
 		unmarshalItemFunc = backendItemToServer(types.KindNode)
@@ -1651,6 +1646,47 @@ func (s *PresenceService) listResources(ctx context.Context, req proto.ListResou
 	}
 
 	return &resp, nil
+}
+
+// listAppServers returns a page of application servers retrieving both the
+// unscoped and the scoped backend entries.
+func (s *PresenceService) listAppServers(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
+	filter := services.MatchResourceFilter{
+		ResourceKind:   req.ResourceType,
+		Labels:         req.Labels,
+		SearchKeywords: req.SearchKeywords,
+	}
+	if req.PredicateExpression != "" {
+		expression, err := services.NewResourceExpression(req.PredicateExpression)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		filter.PredicateExpression = expression
+	}
+
+	var matchErr error
+	servers, nextKey, err := s.appServers.ListResourcesWithFilter(ctx, int(req.Limit), req.StartKey, func(server types.AppServer) bool {
+		if matchErr != nil {
+			return false
+		}
+		match, err := services.MatchResourceByFilters(server, filter, nil /* ignore dup matches */)
+		if err != nil {
+			matchErr = err
+			return false
+		}
+		return match
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if matchErr != nil {
+		return nil, trace.Wrap(matchErr)
+	}
+
+	return &types.ListResourcesResponse{
+		Resources: types.AppServers(servers).AsResources(),
+		NextKey:   nextKey,
+	}, nil
 }
 
 func getFakePaginationKey(ki backend.KeyedItem) string {
@@ -1933,17 +1969,6 @@ func backendItemToDatabaseService(item backend.Item) (types.ResourceWithLabels, 
 	return services.UnmarshalDatabaseService(
 		item.Value,
 		services.WithExpires(item.Expires),
-		services.WithRevision(item.Revision),
-	)
-}
-
-// backendItemToApplicationServer unmarshals `backend.Item` into a
-// `types.AppServer`, returning it as a `types.ResourceWithLabels`.
-func backendItemToApplicationServer(item backend.Item) (types.ResourceWithLabels, error) {
-	return services.UnmarshalAppServer(
-		item.Value,
-		services.WithExpires(item.Expires),
-		services.WithRevision(item.Revision),
 		services.WithRevision(item.Revision),
 	)
 }

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -49,99 +49,261 @@ import (
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/defaults"
 	iterstream "github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 // TestApplicationServersCRUD verifies backend operations on app servers.
 func TestApplicationServersCRUD(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 
-	backend, err := memory.New(memory.Config{
+	mem, err := memory.New(memory.Config{
 		Clock: clock,
 	})
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = backend.Close() })
+	t.Cleanup(func() { _ = mem.Close() })
 
-	presence := NewPresenceService(backend)
+	// Wrap in the sanitizer so keys with illegal component characters (e.g. a
+	// "/" inside a single component) fail the same way they would on real
+	// backends; the raw memory backend accepts them silently.
+	presence := NewPresenceService(backend.NewSanitizer(mem))
 
-	// Make an app and an app server.
-	appA, err := types.NewAppV3(types.Metadata{Name: "a"},
-		types.AppSpecV3{URI: "http://localhost:8080"})
-	require.NoError(t, err)
-	serverA, err := types.NewAppServerV3(types.Metadata{
-		Name: appA.GetName(),
-	}, types.AppServerSpecV3{
-		Hostname: "localhost",
-		HostID:   uuid.New().String(),
-		App:      appA,
+	t.Run("unscoped application servers", func(t *testing.T) {
+		ctx := t.Context()
+		// Make an app and an app server.
+		appA, err := types.NewAppV3(types.Metadata{Name: "a"},
+			types.AppSpecV3{URI: "http://localhost:8080"})
+		require.NoError(t, err)
+		serverA, err := types.NewAppServerV3(types.Metadata{
+			Name: appA.GetName(),
+		}, types.AppServerSpecV3{
+			Hostname: "localhost",
+			HostID:   uuid.New().String(),
+			App:      appA,
+		})
+		require.NoError(t, err)
+
+		// Make another app and an app server.
+		appB, err := types.NewAppV3(types.Metadata{Name: "b"},
+			types.AppSpecV3{URI: "http://localhost:8081"})
+		require.NoError(t, err)
+		serverB, err := types.NewAppServerV3(types.Metadata{
+			Name: appB.GetName(),
+		}, types.AppServerSpecV3{
+			Hostname: "localhost",
+			HostID:   uuid.New().String(),
+			App:      appB,
+		})
+		require.NoError(t, err)
+
+		// No app servers should be registered initially
+		out, err := presence.GetApplicationServers(ctx, apidefaults.Namespace)
+		require.NoError(t, err)
+		require.Empty(t, out)
+
+		// Create app servers.
+		lease, err := presence.UpsertApplicationServer(ctx, serverA)
+		require.NoError(t, err)
+		require.Equal(t, &types.KeepAlive{}, lease)
+		lease, err = presence.UpsertApplicationServer(ctx, serverB)
+		require.NoError(t, err)
+		require.Equal(t, &types.KeepAlive{}, lease)
+
+		// Make sure all app servers are registered.
+		out, err = presence.GetApplicationServers(ctx, serverA.GetNamespace())
+		require.NoError(t, err)
+		servers := types.AppServers(out)
+		require.NoError(t, servers.SortByCustom(types.SortBy{Field: types.ResourceMetadataName}))
+		require.Empty(t, cmp.Diff([]types.AppServer{serverA, serverB}, out,
+			cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+
+		// Delete an app server.
+		err = presence.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+			HostId: serverA.GetHostID(),
+			Name:   serverA.GetName(),
+			Scope:  serverA.GetScope(),
+		}.Build())
+		require.NoError(t, err)
+
+		// Expect only one to return.
+		out, err = presence.GetApplicationServers(ctx, apidefaults.Namespace)
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff([]types.AppServer{serverB}, out,
+			cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+
+		// Upsert server with TTL.
+		serverA.SetExpiry(clock.Now().UTC().Add(time.Hour))
+		lease, err = presence.UpsertApplicationServer(ctx, serverA)
+		require.NoError(t, err)
+		require.Equal(t, &types.KeepAlive{
+			Type:      types.KeepAlive_APP,
+			Name:      serverA.GetName(),
+			Namespace: serverA.GetNamespace(),
+			HostID:    serverA.GetHostID(),
+			Expires:   serverA.Expiry(),
+		}, lease)
+
+		// Delete all app servers.
+		err = presence.DeleteAllApplicationServers(ctx, serverA.GetNamespace())
+		require.NoError(t, err)
+
+		// Expect no servers to return.
+		out, err = presence.GetApplicationServers(ctx, apidefaults.Namespace)
+		require.NoError(t, err)
+		require.Empty(t, out)
 	})
-	require.NoError(t, err)
 
-	// Make another app and an app server.
-	appB, err := types.NewAppV3(types.Metadata{Name: "b"},
-		types.AppSpecV3{URI: "http://localhost:8081"})
-	require.NoError(t, err)
-	serverB, err := types.NewAppServerV3(types.Metadata{
-		Name: appB.GetName(),
-	}, types.AppServerSpecV3{
-		Hostname: "localhost",
-		HostID:   uuid.New().String(),
-		App:      appB,
+	t.Run("scoped application servers", func(t *testing.T) {
+		ctx := t.Context()
+		newAppServer := func(scope string) *types.AppServerV3 {
+			app, err := types.NewAppV3(types.Metadata{Name: "graf"},
+				types.AppSpecV3{URI: "http://localhost:8080"})
+			require.NoError(t, err)
+			app.Scope = scope
+			server, err := types.NewAppServerV3(types.Metadata{
+				Name: app.GetName(),
+			}, types.AppServerSpecV3{
+				Hostname: "localhost",
+				HostID:   uuid.New().String(),
+				App:      app,
+			})
+			require.NoError(t, err)
+			server.Scope = scope
+			return server
+		}
+
+		staging := newAppServer("/staging")
+		prod := newAppServer("/prod")
+		unscoped := newAppServer("")
+
+		for _, server := range []*types.AppServerV3{staging, prod, unscoped} {
+			lease, err := presence.UpsertApplicationServer(ctx, server)
+			require.NoError(t, err)
+			require.Equal(t, &types.KeepAlive{}, lease)
+		}
+
+		getScopes := func() []string {
+			out, err := presence.GetApplicationServers(ctx, apidefaults.Namespace)
+			require.NoError(t, err)
+			apps := []string{}
+			for _, server := range out {
+				apps = append(apps, server.GetScope())
+			}
+			return apps
+		}
+
+		// Same-named servers in different scopes must coexist.
+		require.ElementsMatch(t, []string{"", "/staging", "/prod"}, getScopes())
+
+		// Unconditional updates must land in the scoped range.
+		staging.SetExpiry(clock.Now().UTC().Add(time.Hour))
+		_, err := presence.UnconditionalUpdateApplicationServer(ctx, staging)
+		require.NoError(t, err)
+
+		// Deleting by (hostID, name, scope) must locate the scoped entry.
+		require.NoError(t, presence.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+			HostId: staging.GetHostID(),
+			Name:   staging.GetName(),
+			Scope:  staging.GetScope(),
+		}.Build()))
+		require.ElementsMatch(t, []string{"", "/prod"}, getScopes())
+
+		// Deleting an unscoped entry uses the legacy layout.
+		require.NoError(t, presence.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+			HostId: unscoped.GetHostID(),
+			Name:   unscoped.GetName(),
+			Scope:  unscoped.GetScope(),
+		}.Build()))
+		require.ElementsMatch(t, []string{"/prod"}, getScopes())
+
+		// Deleting a nonexistent server errors.
+		require.Error(t, presence.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+			HostId: staging.GetHostID(),
+			Name:   staging.GetName(),
+			Scope:  staging.GetScope(),
+		}.Build()))
+
+		// DeleteAll clears both ranges.
+		require.NoError(t, presence.DeleteAllApplicationServers(ctx, apidefaults.Namespace))
+		require.Empty(t, getScopes())
 	})
-	require.NoError(t, err)
+}
 
-	// No app servers should be registered initially
-	out, err := presence.GetApplicationServers(ctx, apidefaults.Namespace)
-	require.NoError(t, err)
-	require.Empty(t, out)
+func TestListAppServersPagination(t *testing.T) {
+	t.Parallel()
 
-	// Create app servers.
-	lease, err := presence.UpsertApplicationServer(ctx, serverA)
+	mem, err := memory.New(memory.Config{})
 	require.NoError(t, err)
-	require.Equal(t, &types.KeepAlive{}, lease)
-	lease, err = presence.UpsertApplicationServer(ctx, serverB)
-	require.NoError(t, err)
-	require.Equal(t, &types.KeepAlive{}, lease)
+	t.Cleanup(func() { _ = mem.Close() })
+	presence := NewPresenceService(backend.NewSanitizer(mem))
+	ctx := t.Context()
 
-	// Make sure all app servers are registered.
-	out, err = presence.GetApplicationServers(ctx, serverA.GetNamespace())
-	require.NoError(t, err)
-	servers := types.AppServers(out)
-	require.NoError(t, servers.SortByCustom(types.SortBy{Field: types.ResourceMetadataName}))
-	require.Empty(t, cmp.Diff([]types.AppServer{serverA, serverB}, out,
-		cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+	newAppServer := func(name, scope string) *types.AppServerV3 {
+		app, err := types.NewAppV3(types.Metadata{Name: name},
+			types.AppSpecV3{URI: "http://localhost:8080"}, scope)
+		require.NoError(t, err)
+		server, err := types.NewAppServerV3(types.Metadata{
+			Name: app.GetName(),
+		}, types.AppServerSpecV3{
+			Hostname: "localhost",
+			HostID:   uuid.New().String(),
+			App:      app,
+		}, scope)
+		require.NoError(t, err)
+		return server
+	}
 
-	// Delete an app server.
-	err = presence.DeleteApplicationServer(ctx, serverA.GetNamespace(), serverA.GetHostID(), serverA.GetName())
-	require.NoError(t, err)
+	key := func(s types.AppServer) string {
+		return s.GetScope() + "/" + s.GetHostID() + "/" + s.GetName()
+	}
 
-	// Expect only one to return.
-	out, err = presence.GetApplicationServers(ctx, apidefaults.Namespace)
-	require.NoError(t, err)
-	require.Empty(t, cmp.Diff([]types.AppServer{serverB}, out,
-		cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+	var keysExpected []string
+	for _, scope := range []string{"", "", "", "/prod", "/prod", "/staging"} {
+		server := newAppServer("graf", scope)
+		_, err := presence.UpsertApplicationServer(ctx, server)
+		require.NoError(t, err)
+		keysExpected = append(keysExpected, key(server))
+	}
 
-	// Upsert server with TTL.
-	serverA.SetExpiry(clock.Now().UTC().Add(time.Hour))
-	lease, err = presence.UpsertApplicationServer(ctx, serverA)
-	require.NoError(t, err)
-	require.Equal(t, &types.KeepAlive{
-		Type:      types.KeepAlive_APP,
-		Name:      serverA.GetName(),
-		Namespace: serverA.GetNamespace(),
-		HostID:    serverA.GetHostID(),
-		Expires:   serverA.Expiry(),
-	}, lease)
+	var actualKeys []string
+	var sawScopedCursor bool
+	startKey := ""
+	// Loop through all the app servers and check that the NextKey matches the expected key
+	for {
+		resp, err := presence.ListResources(ctx, proto.ListResourcesRequest{
+			ResourceType: types.KindAppServer,
+			Namespace:    apidefaults.Namespace,
+			Limit:        1,
+			StartKey:     startKey,
+		})
+		require.NoError(t, err)
 
-	// Delete all app servers.
-	err = presence.DeleteAllApplicationServers(ctx, serverA.GetNamespace())
-	require.NoError(t, err)
+		r := resp.Resources[0]
+		server, ok := r.(types.AppServer)
+		require.True(t, ok)
+		if startKey != "" { // first entry
+			if startKey == scopes.ResourceCursorScopedStart() {
+				// The unscoped range ended exactly at a page boundary;
+				// next entry should be scoped
+				require.NotEmpty(t, server.GetScope())
+			} else {
+				require.Equal(t, startKey, services.GetCursorForAppServer(server))
+			}
+		}
+		actualKeys = append(actualKeys, key(server))
 
-	// Expect no servers to return.
-	out, err = presence.GetApplicationServers(ctx, apidefaults.Namespace)
-	require.NoError(t, err)
-	require.Empty(t, out)
+		if resp.NextKey == "" {
+			break
+		}
+		if scopes.IsScopedResourceCursor(resp.NextKey) {
+			sawScopedCursor = true
+		}
+		startKey = resp.NextKey
+	}
+
+	require.ElementsMatch(t, keysExpected, actualKeys)
+	require.True(t, sawScopedCursor)
 }
 
 func mustCreateApplicationServer(t *testing.T, appName string) types.AppServer {
@@ -205,7 +367,11 @@ func TestRangeApplicationServersWithName(t *testing.T) {
 	})
 
 	t.Run("DeletedServersNotReturned", func(t *testing.T) {
-		err := presence.DeleteApplicationServer(ctx, server1.GetNamespace(), server1.GetHostID(), server1.GetName())
+		err := presence.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+			HostId: server1.GetHostID(),
+			Name:   server1.GetName(),
+			Scope:  server1.GetScope(),
+		}.Build())
 		require.NoError(t, err)
 
 		servers, err := iterstream.Collect(presence.RangeApplicationServersWithName(ctx, "shared-app"))
@@ -643,6 +809,40 @@ func TestListResources(t *testing.T) {
 					HostID:   uuid.New().String(),
 					App:      app,
 				})
+				if err != nil {
+					return err
+				}
+
+				// Upsert server.
+				_, err = presence.UpsertApplicationServer(ctx, server)
+				return err
+			},
+			deleteAllResourcesFunc: func(ctx context.Context, presence *PresenceService) error {
+				return presence.DeleteAllApplicationServers(ctx, apidefaults.Namespace)
+			},
+		},
+		"ScopedAppServers": {
+			resourceType: types.KindAppServer,
+			createResourceFunc: func(ctx context.Context, presence *PresenceService, name string, labels map[string]string) error {
+				const scope = "/staging"
+				app, err := types.NewAppV3(types.Metadata{
+					Name:   name,
+					Labels: labels,
+				}, types.AppSpecV3{
+					URI: "localhost",
+				}, scope)
+				if err != nil {
+					return err
+				}
+
+				server, err := types.NewAppServerV3(types.Metadata{
+					Name:   name,
+					Labels: labels,
+				}, types.AppServerSpecV3{
+					Hostname: "localhost",
+					HostID:   uuid.New().String(),
+					App:      app,
+				}, scope)
 				if err != nil {
 					return err
 				}

--- a/lib/services/local/suite_test.go
+++ b/lib/services/local/suite_test.go
@@ -42,6 +42,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/clusterconfig"
@@ -463,7 +464,11 @@ func (s *ServicesTestSuite) AppServerCRUD(t *testing.T) {
 	require.Empty(t, cmp.Diff([]types.AppServer{server}, out, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
 	// Remove the application.
-	err = s.PresenceS.DeleteApplicationServer(ctx, server.Metadata.Namespace, server.GetHostID(), server.GetName())
+	err = s.PresenceS.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+		HostId: server.GetHostID(),
+		Name:   server.GetName(),
+		Scope:  server.GetScope(),
+	}.Build())
 	require.NoError(t, err)
 
 	// Now expect no applications to be returned.

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -145,7 +145,14 @@ type Presence interface {
 	GetApplicationServers(context.Context, string) ([]types.AppServer, error)
 	// UpsertApplicationServer registers an application server.
 	UpsertApplicationServer(context.Context, types.AppServer) (*types.KeepAlive, error)
-	// DeleteApplicationServer deletes specified application server.
+	// DeleteAppServer removes a scoped or unscoped application server.
+	DeleteAppServer(ctx context.Context, req *presencev1.DeleteAppServerRequest) error
+
+	// DeleteApplicationServer removes an unscoped application server.
+	//
+	// Deprecated: use DeleteAppServer instead. Kept temporarily so
+	// gravitational/teleport.e compiles across the rename; remove once e
+	// has migrated.
 	DeleteApplicationServer(ctx context.Context, namespace, hostID, name string) error
 	// DeleteAllApplicationServers removes all registered application servers.
 	DeleteAllApplicationServers(context.Context, string) error

--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/componentfeatures"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -551,7 +552,13 @@ func newWatcher(ctx context.Context, resourceCache *UnifiedResourceCache, cfg Re
 
 // resourceName is a unique name to be used as a key in the resources map
 func resourceKey(resource types.Resource) string {
-	return resource.GetName() + "/" + resource.GetKind()
+	key := resource.GetName() + "/" + resource.GetKind()
+	if r, ok := resource.(interface{ GetScope() string }); ok {
+		if scope := r.GetScope(); scope != "" {
+			key = scopes.QualifiedName{Name: key, Scope: scope}.String()
+		}
+	}
+	return key
 }
 
 type resourceSortKey struct {
@@ -583,6 +590,9 @@ func makeResourceSortKey(resource types.Resource) resourceSortKey {
 				name = sanitizedFriendlyName + "/" + app.GetName()
 			} else {
 				name = app.GetName()
+			}
+			if scope := r.GetScope(); scope != "" {
+				name = scopes.QualifiedName{Name: name, Scope: scope}.String()
 			}
 			kind = types.KindApp
 		}

--- a/lib/services/unified_resource_test.go
+++ b/lib/services/unified_resource_test.go
@@ -41,6 +41,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	linuxdesktopv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/linuxdesktop/v1"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/common"
 	"github.com/gravitational/teleport/api/types/header"
@@ -210,7 +211,10 @@ func TestUnifiedResourceWatcher(t *testing.T) {
 	nodeUpdated := newNodeServer(t, "node1", "hostname1", "192.168.0.1:22", false /*tunnel*/)
 	_, err = clt.UpsertNode(ctx, nodeUpdated)
 	require.NoError(t, err)
-	err = clt.DeleteApplicationServer(ctx, defaults.Namespace, "app1-host-id", "app1")
+	err = clt.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+		HostId: "app1-host-id",
+		Name:   "app1",
+	}.Build())
 	require.NoError(t, err)
 
 	// this should include the updated node, and shouldn't have any apps included
@@ -981,6 +985,87 @@ func TestUnifiedResourceCache_AppServerComponentFeaturesIntersection(t *testing.
 	})
 }
 
+func TestUnifiedResourceWatcher_ScopedResources(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	client := newClient(t)
+	w, err := services.NewUnifiedResourceCache(ctx, services.UnifiedResourceCacheConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: teleport.ComponentUnifiedResource,
+			Client:    client,
+		},
+		ResourceGetter: client,
+	})
+	require.NoError(t, err)
+
+	newScopedAppServer := func(scope string) *types.AppServerV3 {
+		app := newApp(t, "graf")
+		app.Scope = scope
+		srv, err := types.NewAppServerV3(types.Metadata{Name: "graf"}, types.AppServerSpecV3{
+			HostID: uuid.NewString(),
+			App:    app,
+		}, scope)
+		require.NoError(t, err)
+		return srv
+	}
+
+	staging := newScopedAppServer("/staging")
+	prod := newScopedAppServer("/prod")
+	unscoped := newScopedAppServer("")
+
+	for _, srv := range []*types.AppServerV3{staging, prod, unscoped} {
+		_, err = client.UpsertApplicationServer(ctx, srv)
+		require.NoError(t, err)
+	}
+
+	getScopes := func(res []types.ResourceWithLabels) []string {
+		require.NoError(t, err)
+		scopes := []string{}
+		for _, r := range res {
+			appServer, ok := r.(types.AppServer)
+			require.True(t, ok, "expected types.AppServer, got %T", r)
+			scopes = append(scopes, appServer.GetScope())
+		}
+		return scopes
+	}
+
+	// All three same-named apps must be distinct entries.
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		res, err := w.GetUnifiedResources(ctx)
+		assert.NoError(t, err)
+		assert.Len(t, res, 3)
+		require.ElementsMatch(t, []string{"", "/staging", "/prod"}, getScopes(res))
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Deleting the staging app server (identified by hostID/name only, like the
+	// real deletion paths) must prune exactly the staging entry.
+	require.NoError(t, client.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+		HostId: staging.Spec.HostID,
+		Name:   staging.GetName(),
+		Scope:  staging.GetScope(),
+	}.Build()))
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		res, err := w.GetUnifiedResources(ctx)
+		assert.NoError(t, err)
+		assert.Len(t, res, 2)
+		require.ElementsMatch(t, []string{"", "/prod"}, getScopes(res))
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// The unscoped app is still deletable through the legacy path.
+	require.NoError(t, client.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+		HostId: unscoped.Spec.HostID,
+		Name:   unscoped.GetName(),
+		Scope:  unscoped.GetScope(),
+	}.Build()))
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		res, err := w.GetUnifiedResources(ctx)
+		assert.NoError(t, err)
+		assert.Len(t, res, 1)
+		require.ElementsMatch(t, []string{"/prod"}, getScopes(res))
+	}, 5*time.Second, 10*time.Millisecond)
+
+}
+
 func TestUnifiedResourceWatcher_DeleteEvent(t *testing.T) {
 	t.Parallel()
 
@@ -1113,7 +1198,11 @@ func TestUnifiedResourceWatcher_DeleteEvent(t *testing.T) {
 	err = clt.DeleteDatabaseServer(ctx, "default", dbServers[0].Spec.HostID, dbServers[0].GetName())
 	require.NoError(t, err)
 	dbServers = dbServers[1:]
-	err = clt.DeleteApplicationServer(ctx, "default", appServers[0].Spec.HostID, appServers[0].GetName())
+	err = clt.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+		HostId: appServers[0].Spec.HostID,
+		Name:   appServers[0].GetName(),
+		Scope:  appServers[0].GetScope(),
+	}.Build())
 	require.NoError(t, err)
 	appServers = appServers[1:]
 	err = clt.DeleteWindowsDesktop(ctx, desktops[0].Spec.HostID, desktops[0].GetName())
@@ -1151,7 +1240,11 @@ func TestUnifiedResourceWatcher_DeleteEvent(t *testing.T) {
 		require.NoError(t, err)
 	}
 	for _, appServer := range appServers {
-		err = clt.DeleteApplicationServer(ctx, "default", appServer.Spec.HostID, appServer.GetName())
+		err = clt.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+			HostId: appServer.Spec.HostID,
+			Name:   appServer.GetName(),
+			Scope:  appServer.GetScope(),
+		}.Build())
 		require.NoError(t, err)
 	}
 	for _, desktop := range desktops {

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -44,6 +44,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/healthcheckconfig"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
@@ -1931,7 +1932,11 @@ func syncTestAppServerWatcher(t *testing.T) {
 	require.Empty(t, diffAppServers(appServers, current))
 
 	// Delete the first app server, ensure watcher correctly removes the entry
-	err = presence.DeleteApplicationServer(ctx, "default", appServers[0].GetHostID(), appServers[0].GetName())
+	err = presence.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+		HostId: appServers[0].GetHostID(),
+		Name:   appServers[0].GetName(),
+		Scope:  appServers[0].GetScope(),
+	}.Build())
 	require.NoError(t, err)
 
 	synctest.Wait()

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -41,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/inventory"
 	"github.com/gravitational/teleport/lib/labels"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
@@ -277,20 +279,44 @@ func (s *Server) stopApp(ctx context.Context, name string) error {
 }
 
 // removeAppServer deletes app server for the specified app.
-func (s *Server) removeAppServer(ctx context.Context, name string) error {
-	return s.c.AuthClient.DeleteApplicationServer(ctx, apidefaults.Namespace,
-		s.c.HostID, name)
+func (s *Server) removeAppServer(ctx context.Context, appSQN scopes.QualifiedName) error {
+	err := s.c.AuthClient.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+		HostId: s.c.HostID,
+		Name:   appSQN.Name,
+		Scope:  appSQN.Scope,
+	}.Build())
+	if trace.IsNotImplemented(err) && appSQN.Scope == "" {
+		// Fall back for auth servers that don't have the DeleteAppServer RPC so
+		// that unscoped app servers are still cleaned up promptly rather
+		// than lingering until TTL expiry. Scoped app servers cannot exist
+		// against such auth servers, so no fallback is possible when a scope is set.
+		//nolint:staticcheck // SA1019. Deliberate fallback to the deprecated RPC.
+		return trace.Wrap(s.c.AuthClient.DeleteApplicationServer(ctx, apidefaults.Namespace, s.c.HostID, appSQN.Name))
+	}
+	return trace.Wrap(err)
+}
+
+// appScope returns the scope of the named app.
+func (s *Server) appScope(name string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if app, ok := s.apps[name]; ok {
+		return app.GetScope()
+	}
+	return ""
 }
 
 // stopAndRemoveApp uninitializes and deletes the app with the specified name.
 func (s *Server) stopAndRemoveApp(ctx context.Context, name string) error {
+	scope := s.appScope(name)
+
 	if err := s.stopApp(ctx, name); err != nil {
 		return trace.Wrap(err)
 	}
 
 	// Heartbeat is stopped but if we don't remove this app server,
 	// it can linger for up to ~10m until its TTL expires.
-	if err := s.removeAppServer(ctx, name); err != nil && !trace.IsNotFound(err) {
+	if err := s.removeAppServer(ctx, scopes.QualifiedName{Name: name, Scope: scope}); err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
 	return nil
@@ -564,7 +590,7 @@ func (s *Server) cleanupOrphanedAppServers(ctx context.Context) {
 		if currentApps[name] {
 			continue
 		}
-		if err := s.removeAppServer(ctx, name); err != nil {
+		if err := s.removeAppServer(ctx, scopes.QualifiedName{Name: name, Scope: server.GetScope()}); err != nil {
 			if !trace.IsNotFound(err) {
 				s.log.WarnContext(ctx, "Failed to remove orphaned app server.", "app", name, "error", err)
 			}
@@ -626,9 +652,10 @@ func (s *Server) close(ctx context.Context) error {
 			}
 
 			if shouldDeleteApps {
+				scope := s.apps[name].GetScope()
 				g.Go(func() error {
 					log.DebugContext(ctx, "Deleting app")
-					if err := s.removeAppServer(gctx, name); err != nil {
+					if err := s.removeAppServer(gctx, scopes.QualifiedName{Name: name, Scope: scope}); err != nil {
 						log.WarnContext(ctx, "Failed to delete app.", "error", err)
 					} else {
 						log.DebugContext(ctx, "Deleted app")

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	integrationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/utils"
@@ -1206,7 +1207,11 @@ func (h *Handler) awsOIDCDeleteAWSAppAccess(w http.ResponseWriter, r *http.Reque
 		return nil, trace.NotFound("app %s is not using integration %s", integrationAppServer.GetName(), integrationName)
 	}
 
-	if err := clt.DeleteApplicationServer(ctx, apidefaults.Namespace, integrationAppServer.GetHostID(), integrationName); err != nil {
+	if err := clt.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+		HostId: integrationAppServer.GetHostID(),
+		Name:   integrationName,
+		Scope:  integrationAppServer.GetScope(),
+	}.Build()); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/tool/tctl/common/resources/app_server.go
+++ b/tool/tctl/common/resources/app_server.go
@@ -28,6 +28,7 @@ import (
 
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -155,7 +156,11 @@ func deleteAppServer(ctx context.Context, client *authclient.Client, ref service
 	}
 
 	for _, server := range appServers {
-		if err := client.DeleteApplicationServer(ctx, server.GetNamespace(), server.GetHostID(), server.GetName()); err != nil {
+		if err := client.DeleteAppServer(ctx, presencev1.DeleteAppServerRequest_builder{
+			HostId: server.GetHostID(),
+			Name:   server.GetName(),
+			Scope:  server.GetScope(),
+		}.Build()); err != nil {
 			return trace.Wrap(err)
 		}
 	}


### PR DESCRIPTION
This PR:

Adds support for scoped app server namespacing in the presence service
Propagates scope in a new `DeleteApplicationServerV2` as mentioned in the [RFD 153 amendment](https://github.com/gravitational/teleport/pull/68436/changes#diff-49c80914f68671852ea118fbd508af507b6b59b196b48a404c658e3eb9f1bf78R521).
Update Unified Resource Cache to handle scoped app deletions.
Update the cache for apps to key on the scope aware paths


Will need to merge this after: https://github.com/gravitational/teleport.e/pull/9224 to support the `DeleteAppServer` changes


<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster, docker apps, local agents

### Test Cases
- [x] Ensure scoped app  servrs and unscoped app servers are registered
- [x] Ensure they are deleted when the agent exits
- [x] Ensure apps in the UI/CLI are properly shown/deleted when agent starts or is stopped. 
- [x] Ensure new agents are still able to manage their application servers when auth is downgraded.
