### PR TITLE
[v18] kube: fix hardware-key Kubernetes access failures (#68199)

### DIFF
--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -200,7 +200,13 @@ func (p *Profile) TLSCert() ([]byte, error) {
 // RequireKubeLocalProxy returns true if this profile indicates a local proxy
 // is required for kube access.
 func (p *Profile) RequireKubeLocalProxy() bool {
-	return p.KubeProxyAddr == p.WebProxyAddr && p.TLSRoutingConnUpgradeRequired
+	if p.PrivateKeyPolicy.IsHardwareKeyPolicy() {
+		return true
+	}
+	if p.KubeProxyAddr != p.WebProxyAddr {
+		return false
+	}
+	return p.TLSRoutingConnUpgradeRequired
 }
 
 func certPoolFromProfile(p *Profile) (*x509.CertPool, error) {

--- a/api/profile/profile_test.go
+++ b/api/profile/profile_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/profile"
+	"github.com/gravitational/teleport/api/utils/keys"
 )
 
 // TestProfileBasics verifies basic profile operations such as
@@ -167,6 +168,17 @@ func TestRequireKubeLocalProxy(t *testing.T) {
 				KubeProxyAddr:                 "example.com:443",
 				TLSRoutingEnabled:             true,
 				TLSRoutingConnUpgradeRequired: true,
+			},
+			checkResult: require.True,
+		},
+		{
+			// A hardware-key policy requires the local proxy even without a TLS
+			// routing connection upgrade (the exec-plugin path can't serialize the key).
+			name: "hardware key policy requires local proxy",
+			inputProfile: &profile.Profile{
+				WebProxyAddr:     "example.com:443",
+				KubeProxyAddr:    "example.com:3026",
+				PrivateKeyPolicy: keys.PrivateKeyPolicyHardwareKeyTouch,
 			},
 			checkResult: require.True,
 		},

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -834,7 +834,7 @@ func isNetworkError(err error) bool {
 }
 
 func (c *kubeCredentialsCommand) checkLocalProxyRequirement(profile *profile.Profile) error {
-	if profile.RequireKubeLocalProxy() {
+	if profile.RequireKubeLocalProxy() || profile.PrivateKeyPolicy.IsHardwareKeyPolicy() {
 		return trace.BadParameter("Cannot connect Kubernetes clients to Teleport Proxy directly. Please use `tsh proxy kube` or `tsh kubectl` instead.")
 	}
 	return nil

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -834,7 +834,7 @@ func isNetworkError(err error) bool {
 }
 
 func (c *kubeCredentialsCommand) checkLocalProxyRequirement(profile *profile.Profile) error {
-	if profile.RequireKubeLocalProxy() || profile.PrivateKeyPolicy.IsHardwareKeyPolicy() {
+	if profile.RequireKubeLocalProxy() {
 		// If we're inside an active `tsh proxy kube --exec` shell.
 		// Reaching this exec plugin means a Kubernetes client bypassed the local proxy,
 		// typically because KUBECONFIG was overridden (e.g. by a shell startup file).
@@ -1443,7 +1443,7 @@ func matchClustersByNameOrDiscoveredName(name string, clusters types.KubeCluster
 
 func (c *kubeLoginCommand) printUserMessage(cf *CLIConf, tc *client.TeleportClient, names []string) {
 	if tc.Profile().RequireKubeLocalProxy() {
-		c.printLocalProxyUserMessage(cf, names)
+		c.printLocalProxyUserMessage(cf, names, tc.Profile().PrivateKeyPolicy.IsHardwareKeyPolicy())
 		return
 	}
 
@@ -1461,7 +1461,7 @@ Select a context and try 'kubectl version' to test the connection.
 	}
 }
 
-func (c *kubeLoginCommand) printLocalProxyUserMessage(cf *CLIConf, names []string) {
+func (c *kubeLoginCommand) printLocalProxyUserMessage(cf *CLIConf, names []string, hardwareKey bool) {
 	switch {
 	case c.kubeCluster != "":
 		fmt.Fprintf(cf.Stdout(), `Logged into Kubernetes cluster %q.`, c.kubeCluster)
@@ -1470,6 +1470,22 @@ func (c *kubeLoginCommand) printLocalProxyUserMessage(cf *CLIConf, names []strin
 %v`, strings.Join(names, "\n"))
 	case c.all:
 		fmt.Fprintf(cf.Stdout(), "Logged into all Kubernetes clusters available.")
+	}
+
+	if hardwareKey {
+		fmt.Fprintf(cf.Stdout(), `
+
+This cluster requires a hardware-backed private key, which native Kubernetes
+clients cannot use directly, so Kubernetes access must go through a local proxy.
+
+To access the cluster, use "tsh kubectl" to run the Kubernetes client:
+  tsh kubectl version
+
+Or start a local proxy and drop into a shell where native Kubernetes clients are
+ready to use, so you can re-run the same command:
+  tsh proxy kube --exec
+`)
+		return
 	}
 
 	fmt.Fprintf(cf.Stdout(), `

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -835,6 +835,15 @@ func isNetworkError(err error) bool {
 
 func (c *kubeCredentialsCommand) checkLocalProxyRequirement(profile *profile.Profile) error {
 	if profile.RequireKubeLocalProxy() || profile.PrivateKeyPolicy.IsHardwareKeyPolicy() {
+		// If we're inside an active `tsh proxy kube --exec` shell.
+		// Reaching this exec plugin means a Kubernetes client bypassed the local proxy,
+		// typically because KUBECONFIG was overridden (e.g. by a shell startup file).
+		// Point the user at the fix instead of the generic message.
+		if sessionKubeconfig := os.Getenv(kubeLocalProxyEnvVar); sessionKubeconfig != "" {
+			return trace.BadParameter(`this Kubernetes client invoked "tsh kube credentials" from inside an active "tsh proxy kube" session, bypassing the local proxy.
+Your KUBECONFIG no longer points at the session config, usually because a shell startup file or another tool overrode it.
+Run 'export KUBECONFIG=%s' to use the local proxy, or check your shell configuration.`, sessionKubeconfig)
+		}
 		return trace.BadParameter("Cannot connect Kubernetes clients to Teleport Proxy directly. Please use `tsh proxy kube` or `tsh kubectl` instead.")
 	}
 	return nil

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -48,6 +48,10 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+// kubeLocalProxyEnvVar marks a shell started by `tsh proxy kube --exec` as a
+// live local-proxy session. Its value is the KUBECONFIG path the session set.
+const kubeLocalProxyEnvVar = "TELEPORT_KUBE_LOCAL_PROXY"
+
 type proxyKubeCommand struct {
 	*kingpin.CmdClause
 	kubeClusters        []string

--- a/tool/tsh/common/kube_proxy_darwin.go
+++ b/tool/tsh/common/kube_proxy_darwin.go
@@ -52,7 +52,12 @@ func reexecToShell(ctx context.Context, kubeconfigData []byte, command string, a
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	// Set KUBECONFIG in the environment. Even if it was already set, we override it.
-	cmd.Env = append(os.Environ(), fmt.Sprintf("%s=%s", teleport.EnvKubeConfig, f.Name()))
+	// Also mark the shell as a live local-proxy session so `tsh kube credentials`
+	// can detect a Kubernetes client that bypasses the local proxy.
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("%s=%s", teleport.EnvKubeConfig, f.Name()),
+		fmt.Sprintf("%s=%s", kubeLocalProxyEnvVar, f.Name()),
+	)
 
 	if err := cmd.Start(); err != nil {
 		return trace.Wrap(err)

--- a/tool/tsh/common/kube_proxy_linux.go
+++ b/tool/tsh/common/kube_proxy_linux.go
@@ -84,7 +84,12 @@ func reexecToShell(ctx context.Context, kubeconfigData []byte, command string, a
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	// Set KUBECONFIG in the environment. Even if it was already set, we override it.
-	cmd.Env = append(os.Environ(), fmt.Sprintf("%s=%s", teleport.EnvKubeConfig, "/proc/self/fd/3"))
+	// Also mark the shell as a live local-proxy session so `tsh kube credentials`
+	// can detect a Kubernetes client that bypasses the local proxy.
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("%s=%s", teleport.EnvKubeConfig, "/proc/self/fd/3"),
+		fmt.Sprintf("%s=%s", kubeLocalProxyEnvVar, "/proc/self/fd/3"),
+	)
 	// Pass the file descriptor to the child process as an extra file
 	// descriptor. It will be available as fd 3 in "/proc/self/fd/3".
 	cmd.ExtraFiles = []*os.File{f}

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -870,3 +870,32 @@ func Test_kubeCredentialsCommand_checkLocalProxyRequirement(t *testing.T) {
 		})
 	}
 }
+
+// Test_kubeCredentialsCommand_checkLocalProxyRequirement_inLocalProxyShell
+// covers the case where credentials are requested from inside an active
+// `tsh proxy kube --exec` shell (kubeLocalProxyEnvVar set).
+func Test_kubeCredentialsCommand_checkLocalProxyRequirement_inLocalProxyShell(t *testing.T) {
+	const sessionKubeconfig = "/tmp/proxy-kubeconfig-123"
+	t.Setenv(kubeLocalProxyEnvVar, sessionKubeconfig)
+	c := &kubeCredentialsCommand{}
+
+	t.Run("hardware key -> session-specific error", func(t *testing.T) {
+		err := c.checkLocalProxyRequirement(&profile.Profile{
+			PrivateKeyPolicy: keys.PrivateKeyPolicyHardwareKeyTouch,
+		})
+		require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
+		require.ErrorContains(t, err, "tsh proxy kube")
+		// The error points the user at the session's kubeconfig path.
+		require.ErrorContains(t, err, sessionKubeconfig)
+	})
+
+	t.Run("software key -> no error even inside a session", func(t *testing.T) {
+		// A software key can be served by the exec plugin, so being inside a
+		// local proxy shell must not break it (no regression).
+		err := c.checkLocalProxyRequirement(&profile.Profile{
+			WebProxyAddr:  "example.com:443",
+			KubeProxyAddr: "example.com:3026",
+		})
+		require.NoError(t, err)
+	})
+}

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keypaths"
+	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/asciitable"
@@ -813,4 +814,59 @@ func newKubeSelfSubjectServer(t *testing.T) string {
 	t.Cleanup(func() { srv.Close() })
 
 	return srv.URL
+}
+
+func Test_kubeCredentialsCommand_checkLocalProxyRequirement(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		inputProfile *profile.Profile
+		wantErr      bool
+	}{
+		{
+			name: "no requirement",
+			inputProfile: &profile.Profile{
+				WebProxyAddr:  "example.com:443",
+				KubeProxyAddr: "example.com:3026",
+			},
+			wantErr: false,
+		},
+		{
+			name: "kube local proxy required",
+			inputProfile: &profile.Profile{
+				WebProxyAddr:                  "example.com:443",
+				KubeProxyAddr:                 "example.com:443",
+				TLSRoutingConnUpgradeRequired: true,
+			},
+			wantErr: true,
+		},
+		{
+			// A hardware-key policy can't be serialized for the exec plugin, so
+			// the credentials command must return an actionable error even when
+			// a local proxy would not otherwise be required.
+			name: "hardware key policy",
+			inputProfile: &profile.Profile{
+				WebProxyAddr:     "example.com:443",
+				KubeProxyAddr:    "example.com:3026",
+				PrivateKeyPolicy: keys.PrivateKeyPolicyHardwareKeyTouch,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := &kubeCredentialsCommand{}
+			err := c.checkLocalProxyRequirement(test.inputProfile)
+			if !test.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			// The error must be the actionable one, not the opaque PEM failure.
+			require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
+			require.ErrorContains(t, err, "tsh proxy kube")
+			require.ErrorContains(t, err, "tsh kubectl")
+		})
+	}
 }

--- a/tool/tsh/common/kubectl.go
+++ b/tool/tsh/common/kubectl.go
@@ -496,7 +496,13 @@ func shouldUseKubeLocalProxy(cf *CLIConf, kubectlArgs []string) (*clientcmdapi.C
 	// only a little wasteful to spin up a local proxy it's fine for now, but if
 	// we rework the flow we should add a way to skip the local proxy when using
 	// a relay even if a connection through the control plane would require it
-	if !profile.RequireKubeLocalProxy() {
+	//
+	// A hardware-key policy also requires the local proxy: the exec-plugin
+	// credentials path can't serialize a hardware-backed key, whereas the local
+	// proxy uses it as an in-process signer and hands kubectl a fresh software
+	// key. Without this, `tsh kubectl` falls through to the exec plugin and
+	// fails with "cannot get software key PEM".
+	if !profile.RequireKubeLocalProxy() && !profile.PrivateKeyPolicy.IsHardwareKeyPolicy() {
 		return nil, nil, false
 	}
 

--- a/tool/tsh/common/kubectl.go
+++ b/tool/tsh/common/kubectl.go
@@ -496,13 +496,7 @@ func shouldUseKubeLocalProxy(cf *CLIConf, kubectlArgs []string) (*clientcmdapi.C
 	// only a little wasteful to spin up a local proxy it's fine for now, but if
 	// we rework the flow we should add a way to skip the local proxy when using
 	// a relay even if a connection through the control plane would require it
-	//
-	// A hardware-key policy also requires the local proxy: the exec-plugin
-	// credentials path can't serialize a hardware-backed key, whereas the local
-	// proxy uses it as an in-process signer and hands kubectl a fresh software
-	// key. Without this, `tsh kubectl` falls through to the exec plugin and
-	// fails with "cannot get software key PEM".
-	if !profile.RequireKubeLocalProxy() && !profile.PrivateKeyPolicy.IsHardwareKeyPolicy() {
+	if !profile.RequireKubeLocalProxy() {
 		return nil, nil, false
 	}
 

--- a/tool/tsh/common/kubectl_test.go
+++ b/tool/tsh/common/kubectl_test.go
@@ -98,6 +98,23 @@ func Test_maybeStartKubeLocalProxy(t *testing.T) {
 				KubeCluster:     kubeCluster,
 			}},
 		},
+		{
+			// A hardware-key policy can't be served by the exec-plugin
+			// credentials path, so the local proxy must be used even when ALPN
+			// connection upgrade is not required (RequireKubeLocalProxy is false).
+			name: "use local proxy for hardware key policy",
+			inputProfile: &profile.Profile{
+				WebProxyAddr:     "localhost:443",
+				KubeProxyAddr:    "localhost:443",
+				PrivateKeyPolicy: keys.PrivateKeyPolicyHardwareKeyTouch,
+			},
+			inputArgs:      []string{"kubectl", "--kubeconfig", kubeconfigLocation, "version"},
+			wantLocalProxy: true,
+			wantKubeClusters: kubeconfig.LocalProxyClusters{{
+				TeleportCluster: "localhost",
+				KubeCluster:     kubeCluster,
+			}},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Backports to branch/v18 as one commit per PR.

Together these fix Kubernetes access failures when hardware key support is enabled (#68199):
- #68455
- #68456
- #68512
- #68514

Changelog: Fixed `tsh kubectl` failing with "cannot get software key PEM" when hardware key support is enabled.
Changelog: Fixed an issue where `tsh kube credentials` returned a vague "cannot get software key PEM" error under hardware key policies. It now provides a clear and helpful error message.
Changelog: Improved the error `tsh kube credentials` returns when a Kubernetes client bypasses the `tsh proxy kube` local proxy due to an overridden KUBECONFIG.
Changelog: Improved the `tsh kube login` message for clusters that require a hardware key.
