### PR TITLE
Add Auth support for static snapshot DiscoveryConfigs

### DIFF
--- a/api/client/discoveryconfig/discoveryconfig.go
+++ b/api/client/discoveryconfig/discoveryconfig.go
@@ -50,7 +50,7 @@ func (c *Client) ListDiscoveryConfigs(ctx context.Context, pageSize int, nextTok
 	discoveryConfigs := make([]*discoveryconfig.DiscoveryConfig, len(resp.DiscoveryConfigs))
 	for i, discoveryConfig := range resp.DiscoveryConfigs {
 		var err error
-		discoveryConfigs[i], err = conv.FromProto(discoveryConfig)
+		discoveryConfigs[i], err = conv.FromProtoWithSubKind(discoveryConfig)
 		if err != nil {
 			return nil, "", trace.Wrap(err)
 		}
@@ -68,7 +68,7 @@ func (c *Client) GetDiscoveryConfig(ctx context.Context, name string) (*discover
 		return nil, trace.Wrap(err)
 	}
 
-	discoveryConfig, err := conv.FromProto(resp)
+	discoveryConfig, err := conv.FromProtoWithSubKind(resp)
 	return discoveryConfig, trace.Wrap(err)
 }
 
@@ -80,7 +80,7 @@ func (c *Client) CreateDiscoveryConfig(ctx context.Context, discoveryConfig *dis
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	dc, err := conv.FromProto(resp)
+	dc, err := conv.FromProtoWithSubKind(resp)
 	return dc, trace.Wrap(err)
 }
 
@@ -92,7 +92,7 @@ func (c *Client) UpdateDiscoveryConfig(ctx context.Context, discoveryConfig *dis
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	dc, err := conv.FromProto(resp)
+	dc, err := conv.FromProtoWithSubKind(resp)
 	return dc, trace.Wrap(err)
 }
 
@@ -104,7 +104,7 @@ func (c *Client) UpsertDiscoveryConfig(ctx context.Context, discoveryConfig *dis
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	dc, err := conv.FromProto(resp)
+	dc, err := conv.FromProtoWithSubKind(resp)
 	return dc, trace.Wrap(err)
 }
 
@@ -131,6 +131,6 @@ func (c *Client) UpdateDiscoveryConfigStatus(ctx context.Context, name string, s
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	dc, err := conv.FromProto(resp)
+	dc, err := conv.FromProtoWithSubKind(resp)
 	return dc, trace.Wrap(err)
 }

--- a/api/types/discoveryconfig/convert/v1/discoveryconfig.go
+++ b/api/types/discoveryconfig/convert/v1/discoveryconfig.go
@@ -23,54 +23,46 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	headerv1 "github.com/gravitational/teleport/api/types/header/convert/v1"
 )
 
-// FromProto converts a v1 discovery config into an internal discovery config object.
+// FromProto converts a v1 discovery config into an internal one, discarding the client-supplied
+// subkind so that it cannot relax validation or alter installer parameters. This preserves the
+// conversion behavior from before static snapshots existed and is the safe default for every user-input path.
 func FromProto(msg *discoveryconfigv1.DiscoveryConfig) (*discoveryconfig.DiscoveryConfig, error) {
 	if msg == nil {
 		return nil, trace.BadParameter("discovery config message is nil")
 	}
+	return fromProto(msg, "")
+}
 
+// FromProtoWithSubKind converts a server-returned v1 discovery config into an internal one,
+// preserving its subkind. Use this only for trusted read responses, where retaining the
+// server-assigned static-snapshot marker is required.
+func FromProtoWithSubKind(msg *discoveryconfigv1.DiscoveryConfig) (*discoveryconfig.DiscoveryConfig, error) {
+	if msg == nil {
+		return nil, trace.BadParameter("discovery config message is nil")
+	}
+	return fromProto(msg, msg.GetHeader().GetSubKind())
+}
+
+func fromProto(msg *discoveryconfigv1.DiscoveryConfig, subKind string) (*discoveryconfig.DiscoveryConfig, error) {
 	if msg.GetSpec() == nil {
 		return nil, trace.BadParameter("spec is missing")
 	}
-	if msg.GetSpec().GetDiscoveryGroup() == "" {
+	// Static snapshots mirror the owning service's file configuration, which may legitimately
+	// have no discovery group. Unknown subkinds retain regular validation. Snapshot specs are
+	// additionally sanitized inside the constructor, so unsupported installer params in a
+	// received snapshot are discarded rather than rejected.
+	if msg.GetSpec().GetDiscoveryGroup() == "" && subKind != discoveryconfig.SubKindStaticSnapshot {
 		return nil, trace.BadParameter("discovery group is missing")
 	}
 
-	awsMatchers := make([]types.AWSMatcher, 0, len(msg.GetSpec().GetAws()))
-	for _, m := range msg.GetSpec().GetAws() {
-		awsMatchers = append(awsMatchers, *m)
-	}
-
-	azureMatchers := make([]types.AzureMatcher, 0, len(msg.GetSpec().GetAzure()))
-	for _, m := range msg.GetSpec().GetAzure() {
-		azureMatchers = append(azureMatchers, *m)
-	}
-
-	gcpMatchers := make([]types.GCPMatcher, 0, len(msg.GetSpec().GetGcp()))
-	for _, m := range msg.GetSpec().GetGcp() {
-		gcpMatchers = append(gcpMatchers, *m)
-	}
-
-	kubeMatchers := make([]types.KubernetesMatcher, 0, len(msg.GetSpec().GetKube()))
-	for _, m := range msg.GetSpec().GetKube() {
-		kubeMatchers = append(kubeMatchers, *m)
-	}
-
-	discoveryConfig, err := discoveryconfig.NewDiscoveryConfig(
+	discoveryConfig, err := discoveryconfig.NewDiscoveryConfigWithSubKind(
 		headerv1.FromMetadataProto(msg.GetHeader().GetMetadata()),
-		discoveryconfig.Spec{
-			DiscoveryGroup: msg.GetSpec().GetDiscoveryGroup(),
-			AWS:            awsMatchers,
-			Azure:          azureMatchers,
-			GCP:            gcpMatchers,
-			Kube:           kubeMatchers,
-			AccessGraph:    msg.GetSpec().GetAccessGraph(),
-		},
+		SpecFromProto(msg.GetSpec()),
+		subKind,
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -112,39 +104,30 @@ func StatusFromProto(msg *discoveryconfigv1.DiscoveryConfigStatus) discoveryconf
 	}
 }
 
+// SpecFromProto converts a v1 discovery config spec into its internal
+// representation.
+func SpecFromProto(msg *discoveryconfigv1.DiscoveryConfigSpec) discoveryconfig.Spec {
+	s := discoveryconfig.Spec{DiscoveryGroup: msg.GetDiscoveryGroup(), AccessGraph: msg.GetAccessGraph()}
+	for _, m := range msg.GetAws() {
+		s.AWS = append(s.AWS, *m)
+	}
+	for _, m := range msg.GetAzure() {
+		s.Azure = append(s.Azure, *m)
+	}
+	for _, m := range msg.GetGcp() {
+		s.GCP = append(s.GCP, *m)
+	}
+	for _, m := range msg.GetKube() {
+		s.Kube = append(s.Kube, *m)
+	}
+	return s
+}
+
 // ToProto converts an internal discovery config into a v1 discovery config object.
 func ToProto(discoveryConfig *discoveryconfig.DiscoveryConfig) *discoveryconfigv1.DiscoveryConfig {
-	awsMatchers := make([]*types.AWSMatcher, 0, len(discoveryConfig.Spec.AWS))
-	for _, m := range discoveryConfig.Spec.AWS {
-		m := m
-		awsMatchers = append(awsMatchers, &m)
-	}
-
-	azureMatchers := make([]*types.AzureMatcher, 0, len(discoveryConfig.Spec.Azure))
-	for _, m := range discoveryConfig.Spec.Azure {
-		azureMatchers = append(azureMatchers, &m)
-	}
-
-	gcpMatchers := make([]*types.GCPMatcher, 0, len(discoveryConfig.Spec.GCP))
-	for _, m := range discoveryConfig.Spec.GCP {
-		gcpMatchers = append(gcpMatchers, &m)
-	}
-
-	kubeMatchers := make([]*types.KubernetesMatcher, 0, len(discoveryConfig.Spec.Kube))
-	for _, m := range discoveryConfig.Spec.Kube {
-		kubeMatchers = append(kubeMatchers, &m)
-	}
-
 	return &discoveryconfigv1.DiscoveryConfig{
 		Header: headerv1.ToResourceHeaderProto(discoveryConfig.ResourceHeader),
-		Spec: &discoveryconfigv1.DiscoveryConfigSpec{
-			DiscoveryGroup: discoveryConfig.GetDiscoveryGroup(),
-			Aws:            awsMatchers,
-			Azure:          azureMatchers,
-			Gcp:            gcpMatchers,
-			Kube:           kubeMatchers,
-			AccessGraph:    discoveryConfig.Spec.AccessGraph,
-		},
+		Spec:   specToProto(discoveryConfig.Spec),
 		Status: StatusToProto(discoveryConfig.Status),
 	}
 }
@@ -186,4 +169,23 @@ func StatusToProto(status discoveryconfig.Status) *discoveryconfigv1.DiscoveryCo
 		IntegrationDiscoveredResources: integrationDiscoveredResources,
 		ServerStatus:                   serverStatus,
 	}
+}
+
+// specToProto shallow-copies each matcher so the returned message does not
+// alias the source spec's slice elements.
+func specToProto(s discoveryconfig.Spec) *discoveryconfigv1.DiscoveryConfigSpec {
+	p := &discoveryconfigv1.DiscoveryConfigSpec{DiscoveryGroup: s.DiscoveryGroup, AccessGraph: s.AccessGraph}
+	for _, m := range s.AWS {
+		p.Aws = append(p.Aws, &m)
+	}
+	for _, m := range s.Azure {
+		p.Azure = append(p.Azure, &m)
+	}
+	for _, m := range s.GCP {
+		p.Gcp = append(p.Gcp, &m)
+	}
+	for _, m := range s.Kube {
+		p.Kube = append(p.Kube, &m)
+	}
+	return p
 }

--- a/api/types/discoveryconfig/convert/v1/discoveryconfig_test.go
+++ b/api/types/discoveryconfig/convert/v1/discoveryconfig_test.go
@@ -21,7 +21,9 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -32,15 +34,138 @@ import (
 func TestRoundtrip(t *testing.T) {
 	discoveryConfig := newDiscoveryConfig(t, "discovery-config-01")
 
-	converted, err := FromProto(ToProto(discoveryConfig))
+	converted, err := FromProtoWithSubKind(ToProto(discoveryConfig))
 	require.NoError(t, err)
 
 	require.Empty(t, cmp.Diff(discoveryConfig, converted))
 }
 
-// Make sure that we don't panic if any of the message fields are missing.
-func TestFromProtoNils(t *testing.T) {
-	// Spec is nil
+// TestRoundtripStaticSnapshot ensures a static snapshot survives the proto conversion in
+// both directions: the subkind marks it for authorization and consumption filtering,
+// and the spec carries the observed inventory.
+func TestRoundtripStaticSnapshot(t *testing.T) {
+	discoveryConfig, err := discoveryconfig.NewStaticSnapshotDiscoveryConfig("server-01", discoveryconfig.Spec{
+		DiscoveryGroup: "discovery-group-01",
+		AWS: []types.AWSMatcher{{
+			Types:   []string{types.AWSMatcherEC2},
+			Regions: []string{"eu-west-2"},
+		}},
+	})
+	require.NoError(t, err)
+	discoveryConfig.SetExpiry(time.Now().UTC().Truncate(time.Second).Add(time.Hour))
+
+	converted, err := FromProtoWithSubKind(ToProto(discoveryConfig))
+	require.NoError(t, err)
+
+	require.True(t, converted.IsStaticSnapshot())
+	require.Empty(t, cmp.Diff(discoveryConfig, converted))
+
+	// A snapshot of a service with no discovery group must roundtrip too:
+	// only the static-snapshot subkind relaxes the group requirement.
+	groupless, err := discoveryconfig.NewStaticSnapshotDiscoveryConfig("server-01", discoveryconfig.Spec{})
+	require.NoError(t, err)
+	converted, err = FromProtoWithSubKind(ToProto(groupless))
+	require.NoError(t, err)
+	require.True(t, converted.IsStaticSnapshot())
+	require.Empty(t, converted.GetDiscoveryGroup())
+}
+
+// TestRoundtripEmptySnapshotNormalizesMatcherFamilies pins the nil-versus-
+// empty representation of an inventory-less snapshot across the proto
+// conversion: proto repeated fields cannot distinguish nil from empty, so
+// the roundtrip must land every matcher family on the validation-normalized
+// form (an empty, non-nil list), identical to the source resource.
+func TestRoundtripEmptySnapshotNormalizesMatcherFamilies(t *testing.T) {
+	groupless, err := discoveryconfig.NewStaticSnapshotDiscoveryConfig("server-01", discoveryconfig.Spec{})
+	require.NoError(t, err)
+
+	converted, err := FromProtoWithSubKind(ToProto(groupless))
+	require.NoError(t, err)
+
+	require.NotNil(t, converted.Spec.AWS, "AWS matchers must normalize to an empty list, not nil")
+	require.Empty(t, converted.Spec.AWS)
+	require.NotNil(t, converted.Spec.Azure, "Azure matchers must normalize to an empty list, not nil")
+	require.Empty(t, converted.Spec.Azure)
+	require.NotNil(t, converted.Spec.GCP, "GCP matchers must normalize to an empty list, not nil")
+	require.Empty(t, converted.Spec.GCP)
+	require.NotNil(t, converted.Spec.Kube, "Kube matchers must normalize to an empty list, not nil")
+	require.Empty(t, converted.Spec.Kube)
+
+	// cmp.Diff distinguishes nil from empty slices, so full equality with
+	// the source pins the representation of every remaining field too.
+	require.Empty(t, cmp.Diff(groupless, converted))
+}
+
+// TestFromProtoSanitizesStaticSnapshot ensures received snapshots have
+// installer params discarded before validation, in their entirety: installer
+// params are excluded from snapshot inventory including non-secret fields
+// such as EnrollMode. The conversion must not mutate its input.
+func TestFromProtoSanitizesStaticSnapshot(t *testing.T) {
+	discoveryConfig, err := discoveryconfig.NewStaticSnapshotDiscoveryConfig("server-01", discoveryconfig.Spec{
+		AWS: []types.AWSMatcher{{
+			Types:   []string{types.AWSMatcherEC2},
+			Regions: []string{"eu-west-2"},
+		}},
+	})
+	require.NoError(t, err)
+	msg := ToProto(discoveryConfig)
+	params := &types.InstallerParams{
+		EnrollMode: types.InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_SCRIPT,
+		JoinToken:  "secret-token",
+		HTTPProxySettings: &types.HTTPProxySettings{
+			HTTPSProxy: "not-a-valid-proxy-with-secret",
+		},
+	}
+	msg.Spec.Aws[0].Params = params
+	before := proto.Clone(msg).(*discoveryconfigv1.DiscoveryConfig)
+
+	converted, err := FromProtoWithSubKind(msg)
+	require.NoError(t, err)
+	require.Nil(t, converted.Spec.AWS[0].Params)
+	require.True(t, proto.Equal(before, msg), "conversion must not mutate its input")
+}
+
+// TestFromProtoPreservesUnknownSubKind ensures conversion preserves unknown
+// subkinds without weakening regular DiscoveryConfig validation.
+func TestFromProtoPreservesUnknownSubKind(t *testing.T) {
+	msg := ToProto(newDiscoveryConfig(t, "discovery-config-01"))
+	msg.Header.SubKind = "some-future-subkind"
+
+	converted, err := FromProtoWithSubKind(msg)
+	require.NoError(t, err)
+	require.Equal(t, "some-future-subkind", converted.GetSubKind())
+	require.Equal(t, "discovery-group-01", converted.Spec.DiscoveryGroup)
+
+	msg.Spec.DiscoveryGroup = ""
+	_, err = FromProtoWithSubKind(msg)
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+}
+
+// TestFromProtoDiscardsSubKind pins the generic-write conversion: any
+// client-supplied subkind is discarded, installer params survive regardless
+// of the claimed subkind, and regular validation applies in full.
+func TestFromProtoDiscardsSubKind(t *testing.T) {
+	msg := ToProto(newDiscoveryConfig(t, "discovery-config-01"))
+	msg.Header.SubKind = discoveryconfig.SubKindStaticSnapshot
+	msg.Spec.Aws[0].Params = &types.InstallerParams{JoinToken: "token-name"}
+
+	converted, err := FromProto(msg)
+	require.NoError(t, err)
+	require.Empty(t, converted.GetSubKind())
+	require.Equal(t, "token-name", converted.Spec.AWS[0].Params.JoinToken,
+		"the default user-input conversion keeps installer params regardless of claimed subkind")
+
+	msg.Spec.DiscoveryGroup = ""
+	_, err = FromProto(msg)
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+
+	_, err = FromProto(nil)
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+}
+
+// TestFromProtoMissingSpec ensures conversion rejects a message without a
+// spec instead of panicking on it.
+func TestFromProtoMissingSpec(t *testing.T) {
 	discoveryConfig := ToProto(newDiscoveryConfig(t, "discovery-config-01"))
 	discoveryConfig.Spec = nil
 

--- a/api/types/discoveryconfig/discoveryconfig.go
+++ b/api/types/discoveryconfig/discoveryconfig.go
@@ -92,16 +92,39 @@ type Status struct {
 
 // NewDiscoveryConfig will create a new discovery config.
 func NewDiscoveryConfig(metadata header.Metadata, spec Spec) (*DiscoveryConfig, error) {
-	discoveryConfig := &DiscoveryConfig{
+	return NewDiscoveryConfigWithSubKind(metadata, spec, "")
+}
+
+// NewDiscoveryConfigWithSubKind creates a DiscoveryConfig with the given
+// subkind. Static snapshot specs are copied and sanitized before validation
+// (received installer params are discarded rather than validated, and the
+// caller's spec is never mutated); snapshot validation itself runs against
+// a throwaway copy and persists nothing it derives, so one sanitization
+// suffices.
+//
+// Sanitization deliberately lives here and NOT in CheckAndSetDefaults: this
+// constructor is only reached with a subkind the caller vouches for (proto
+// conversion, snapshot construction), while CheckAndSetDefaults also runs on
+// user-supplied YAML, where a claimed static-snapshot subkind must not
+// silently delete a regular config's installer params.
+func NewDiscoveryConfigWithSubKind(metadata header.Metadata, spec Spec, subKind string) (*DiscoveryConfig, error) {
+	if subKind == SubKindStaticSnapshot {
+		var clonedSpec Spec
+		if err := utils.StrictObjectToStruct(&spec, &clonedSpec); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		spec = clonedSpec
+		SanitizeStaticSnapshotSpec(&spec)
+	}
+	dc := &DiscoveryConfig{
 		ResourceHeader: header.ResourceHeaderFromMetadata(metadata),
 		Spec:           spec,
 	}
-
-	if err := discoveryConfig.CheckAndSetDefaults(); err != nil {
+	dc.SetSubKind(subKind)
+	if err := dc.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	return discoveryConfig, nil
+	return dc, nil
 }
 
 // IntegrationDiscoveredSummary holds the summary of resources discovered for a specific integration.
@@ -161,52 +184,70 @@ func (a *DiscoveryConfig) CheckAndSetDefaults() error {
 		return trace.Wrap(err)
 	}
 
-	if a.Spec.DiscoveryGroup == "" {
+	// Static snapshots mirror the owning service's file configuration, which
+	// may legitimately have no discovery group. Every other subkind remains a
+	// regular discovery config and must identify the Discovery Services that
+	// consume it.
+	if a.Spec.DiscoveryGroup == "" && !a.IsStaticSnapshot() {
 		return trace.BadParameter("discovery config group required")
 	}
 
 	if a.Spec.AWS == nil {
 		a.Spec.AWS = make([]types.AWSMatcher, 0)
 	}
-	for i := range a.Spec.AWS {
-		if err := a.Spec.AWS[i].CheckAndSetDefaults(); err != nil {
-			return trace.Wrap(err)
-		}
-	}
-
 	if a.Spec.Azure == nil {
 		a.Spec.Azure = make([]types.AzureMatcher, 0)
 	}
-	for i := range a.Spec.Azure {
-		if err := a.Spec.Azure[i].CheckAndSetDefaults(); err != nil {
-			return trace.Wrap(err)
-		}
-	}
-
 	if a.Spec.GCP == nil {
 		a.Spec.GCP = make([]types.GCPMatcher, 0)
 	}
-	for i := range a.Spec.GCP {
-		if err := a.Spec.GCP[i].CheckAndSetDefaults(); err != nil {
-			return trace.Wrap(err)
-		}
-	}
-
 	if a.Spec.Kube == nil {
 		a.Spec.Kube = make([]types.KubernetesMatcher, 0)
 	}
-	for i := range a.Spec.Kube {
-		if err := a.Spec.Kube[i].CheckAndSetDefaults(); err != nil {
+
+	// Snapshot matchers are validated without being mutated: persisted
+	// inventory stays exactly what the publisher sent, never enriched with
+	// Auth-derived defaults such as installer params or wildcard scoping.
+	if a.IsStaticSnapshot() {
+		if err := validateStaticSnapshotSpec(&a.Spec); err != nil {
+			return trace.Wrap(err)
+		}
+	} else if err := a.Spec.checkAndSetMatcherDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// checkAndSetMatcherDefaults validates every matcher family and applies its
+// in-place defaulting. Regular configs run it on the live spec; snapshot
+// validation runs it on a throwaway copy so derived defaults never persist.
+func (s *Spec) checkAndSetMatcherDefaults() error {
+	for i := range s.AWS {
+		if err := s.AWS[i].CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err)
 		}
 	}
-
-	if a.Spec.AccessGraph != nil {
-		if err := a.Spec.AccessGraph.CheckAndSetDefaults(); err != nil {
+	for i := range s.Azure {
+		if err := s.Azure[i].CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err)
 		}
 	}
-
+	for i := range s.GCP {
+		if err := s.GCP[i].CheckAndSetDefaults(); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	for i := range s.Kube {
+		if err := s.Kube[i].CheckAndSetDefaults(); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	if s.AccessGraph != nil {
+		if err := s.AccessGraph.CheckAndSetDefaults(); err != nil {
+			return trace.Wrap(err)
+		}
+	}
 	return nil
 }
 

--- a/api/types/discoveryconfig/static_snapshot.go
+++ b/api/types/discoveryconfig/static_snapshot.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2026 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discoveryconfig
+
+import (
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/api/utils"
+)
+
+// SubKindStaticSnapshot marks a DiscoveryConfig that was self-published by a
+// Discovery Service to expose its static (file-based) matcher configuration to
+// the backend. The snapshot reuses the regular DiscoveryConfig schema: the
+// observed discovery group and sanitized matchers live in the spec.
+//
+// Static snapshots are informational only and must never be loaded back as
+// dynamic matchers by Discovery Services: the publishing service already runs
+// the same matchers from its file configuration, so consuming the snapshot
+// would duplicate them. Snapshots therefore live in an isolated backend range
+// that generates no DiscoveryConfig watch events and is absent from generic
+// listings; the only read path is a named lookup.
+//
+// The publication contract reserves writes for the owning Discovery Service
+// (see StaticSnapshotName) and uses periodic upserts with a short TTL so
+// snapshots disappear shortly after the publishing service stops.
+const SubKindStaticSnapshot = "static-snapshot"
+
+const (
+	// StaticSnapshotTTL is how long the publication contract keeps a static
+	// snapshot without an owner renewal.
+	StaticSnapshotTTL = 10 * time.Minute
+	// MaxStaticSnapshotSize is the publication contract's maximum serialized
+	// stored static snapshot size, covering the spec inventory and the
+	// reported status together. 256KiB is the largest power of two that
+	// stays comfortably under the tightest backend item limit (DynamoDB's
+	// 400KB), leaving the remainder for the backend key, lease metadata,
+	// and value-encoding overhead.
+	MaxStaticSnapshotSize = 256 * 1024
+)
+
+const (
+	staticSnapshotNamePrefix       = "static-snapshot-"
+	staticSnapshotHashedNamePrefix = "static-snapshot-hashed-"
+)
+
+var staticSnapshotNameNamespace = uuid.NewSHA1(uuid.NameSpaceOID, []byte("teleport.discovery-config.static-snapshot"))
+
+// StaticSnapshotName returns the name of the static snapshot published by the
+// Discovery Service running on the host identified by serverID. The name
+// preserves canonical UUID server IDs and deterministically maps historical
+// non-UUID IDs into the UUID-shaped reserved namespace. This lets Auth derive
+// and authorize every owner's name without reserving legacy human-readable
+// names such as "static-snapshot-aws-prod".
+func StaticSnapshotName(serverID string) string {
+	if isCanonicalUUID(serverID) {
+		return staticSnapshotNamePrefix + serverID
+	}
+	return staticSnapshotHashedNamePrefix + uuid.NewSHA1(staticSnapshotNameNamespace, []byte(serverID)).String()
+}
+
+// IsReservedStaticSnapshotName reports whether name is in the canonical
+// static snapshot namespace reserved for UUID-based Discovery Service IDs.
+// Prefix-matching alone is intentionally insufficient: a regular
+// DiscoveryConfig named "static-snapshot-aws-prod" predating the reservation
+// must remain recreatable.
+func IsReservedStaticSnapshotName(name string) bool {
+	if serverID, ok := strings.CutPrefix(name, staticSnapshotHashedNamePrefix); ok {
+		return isCanonicalUUID(serverID)
+	}
+	serverID, ok := strings.CutPrefix(name, staticSnapshotNamePrefix)
+	return ok && isCanonicalUUID(serverID)
+}
+
+func isCanonicalUUID(value string) bool {
+	id, err := uuid.Parse(value)
+	return err == nil && id.String() == value
+}
+
+// IsStaticSnapshot returns true if the discovery config is a static snapshot
+// self-published by a Discovery Service. See SubKindStaticSnapshot.
+func (m *DiscoveryConfig) IsStaticSnapshot() bool {
+	return m.SubKind == SubKindStaticSnapshot
+}
+
+// NewStaticSnapshotDiscoveryConfig creates the static snapshot DiscoveryConfig
+// describing the file-based configuration of the Discovery Service running on
+// the host identified by serverID.
+//
+// The constructor owns the resource-envelope invariants: canonical name
+// derivation, the static-snapshot subkind, and the config-file origin. The
+// supplied spec is the observed inventory; it is copied during construction so
+// the caller cannot mutate the resource afterward.
+//
+// Publication is fail-closed: a spec still carrying installer params is
+// rejected rather than silently stripped, because sanitizing observed
+// configuration is the publisher's job (see SanitizeStaticSnapshotSpec).
+func NewStaticSnapshotDiscoveryConfig(serverID string, spec Spec) (*DiscoveryConfig, error) {
+	if serverID == "" {
+		return nil, trace.BadParameter("server ID is required")
+	}
+	if err := CheckStaticSnapshotSpecSanitized(&spec); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	dc, err := NewDiscoveryConfigWithSubKind(header.Metadata{
+		Name:   StaticSnapshotName(serverID),
+		Labels: map[string]string{types.OriginLabel: types.OriginConfigFile},
+	}, spec, SubKindStaticSnapshot)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := CheckStaticSnapshotDiscoveryConfig(dc, serverID); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return dc, nil
+}
+
+// CheckStaticSnapshotDiscoveryConfig verifies the invariants that must hold
+// for a static snapshot published by the Discovery Service running on the host
+// identified by serverID. The owner-only publication path enforces it on
+// writes and the publisher can use it as a sanity check.
+//
+// The discovery group is intentionally unconstrained: it mirrors whatever the
+// owning service has configured, including no group at all.
+func CheckStaticSnapshotDiscoveryConfig(dc *DiscoveryConfig, serverID string) error {
+	if dc == nil {
+		return trace.BadParameter("discovery config is required")
+	}
+	if serverID == "" {
+		return trace.BadParameter("server ID is required")
+	}
+	if !dc.IsStaticSnapshot() {
+		return trace.BadParameter("discovery config %q is not a static snapshot", dc.GetName())
+	}
+	if expected := StaticSnapshotName(serverID); dc.GetName() != expected {
+		return trace.BadParameter("static snapshot published by server %q must be named %q, got %q", serverID, expected, dc.GetName())
+	}
+	if dc.Origin() != types.OriginConfigFile {
+		return trace.BadParameter("static snapshot %q must have origin %q", dc.GetName(), types.OriginConfigFile)
+	}
+	if err := CheckStaticSnapshotSpecSanitized(&dc.Spec); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// SanitizeStaticSnapshotSpec removes secret-bearing installer settings that
+// are not part of a static snapshot's matcher inventory contract.
+func SanitizeStaticSnapshotSpec(spec *Spec) {
+	if spec == nil {
+		return
+	}
+	spec.eachInstallerParams(func(p **types.InstallerParams) {
+		*p = nil
+	})
+}
+
+// CheckStaticSnapshotSpecSanitized verifies the spec carries no installer
+// params, the fail-closed invariant every static snapshot write path
+// enforces instead of silently stripping observed configuration.
+func CheckStaticSnapshotSpecSanitized(spec *Spec) error {
+	var unsanitized bool
+	spec.eachInstallerParams(func(p **types.InstallerParams) { unsanitized = unsanitized || *p != nil })
+	if unsanitized {
+		return trace.BadParameter("static snapshot matchers must not contain installer params")
+	}
+	return nil
+}
+
+// validateStaticSnapshotSpec validates snapshot inventory against a throwaway
+// deep copy of the whole spec, so no value derived by matcher defaulting
+// (installer params, SSM document names, wildcard scoping such as Azure
+// regions or GCP locations) reaches the stored record. A snapshot records
+// the publisher's configuration; values derived on the Auth side can differ
+// from what the publishing service derived for itself (defaulting an absent
+// installer document from a sanitized, params-less matcher picks the
+// agentless document where the service's own defaulting picks the agent one)
+// and must never be persisted as if published.
+//
+// The temporary SCRIPT enroll mode prevents ordinary EC2 defaulting from
+// deriving the removed EICE enrollment mode for an integration-based matcher
+// whose installer params were removed by snapshot sanitization. Params
+// supplied by the caller are validated as they are: the isolated snapshot
+// persistence path, not a caller-controlled subkind, is the sanitization
+// trust boundary.
+func validateStaticSnapshotSpec(spec *Spec) error {
+	var scratch Spec
+	if err := utils.StrictObjectToStruct(spec, &scratch); err != nil {
+		return trace.Wrap(err)
+	}
+	for i := range scratch.AWS {
+		matcher := &scratch.AWS[i]
+		if matcher.Params != nil || !slices.Contains(matcher.Types, types.AWSMatcherEC2) {
+			continue
+		}
+		// Mirror ordinary file-config defaulting (InstallTeleport: true) so
+		// the copy is validated in the shape the publishing service actually
+		// runs; only the enroll mode is pinned to SCRIPT, to avoid deriving
+		// and validating the removed EICE mode.
+		matcher.Params = &types.InstallerParams{
+			InstallTeleport: true,
+			EnrollMode:      types.InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_SCRIPT,
+		}
+	}
+	if err := scratch.checkAndSetMatcherDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// eachInstallerParams calls fn with each matcher installer params slot in the
+// spec. New matcher families with installer params must be added here so
+// static snapshot sanitization and its checks stay in sync.
+// TestEachInstallerParamsCoversAllFamilies enforces that contract by
+// reflection.
+func (s *Spec) eachInstallerParams(fn func(p **types.InstallerParams)) {
+	for i := range s.AWS {
+		fn(&s.AWS[i].Params)
+	}
+	for i := range s.Azure {
+		fn(&s.Azure[i].Params)
+	}
+	for i := range s.GCP {
+		fn(&s.GCP[i].Params)
+	}
+}

--- a/api/types/discoveryconfig/static_snapshot_test.go
+++ b/api/types/discoveryconfig/static_snapshot_test.go
@@ -1,0 +1,335 @@
+/*
+Copyright 2026 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discoveryconfig
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils"
+)
+
+const sentinelJoinToken = "sentinel"
+
+var installerParamsType = reflect.TypeFor[*types.InstallerParams]()
+
+func TestNewStaticSnapshotDiscoveryConfig(t *testing.T) {
+	const serverID = "00000000-0000-0000-0000-000000000001"
+	input := Spec{DiscoveryGroup: "group", AWS: []types.AWSMatcher{{
+		Types: []string{types.AWSMatcherEC2}, Regions: []string{"us-east-1"},
+	}}}
+	dc, err := NewStaticSnapshotDiscoveryConfig(serverID, input)
+	require.NoError(t, err)
+	require.True(t, dc.IsStaticSnapshot())
+	require.Equal(t, StaticSnapshotName(serverID), dc.GetName())
+	require.Equal(t, types.OriginConfigFile, dc.Origin())
+	require.Equal(t, "group", dc.GetDiscoveryGroup())
+	require.Len(t, dc.Spec.AWS, 1)
+	// Validation runs against a throwaway copy, so the stored inventory
+	// never gains installer settings.
+	require.Nil(t, dc.Spec.AWS[0].Params)
+
+	// The spec is copied on construction: mutating the input afterward must
+	// not reach the resource.
+	input.AWS[0].Regions[0] = "mutated"
+	require.Equal(t, "us-east-1", dc.Spec.AWS[0].Regions[0])
+
+	// Publication is fail-closed: unsanitized installer params are rejected
+	// rather than silently stripped.
+	_, err = NewStaticSnapshotDiscoveryConfig(serverID, Spec{AWS: []types.AWSMatcher{{
+		Types: []string{types.AWSMatcherEC2}, Regions: []string{"us-east-1"},
+		Params: &types.InstallerParams{JoinToken: "secret"},
+	}}})
+	requireBadParameter(t, err)
+
+	// A service with no discovery group and no matchers still publishes a
+	// valid (empty) snapshot.
+	empty, err := NewStaticSnapshotDiscoveryConfig(serverID, Spec{})
+	require.NoError(t, err)
+	require.Empty(t, empty.GetDiscoveryGroup())
+	require.NoError(t, CheckStaticSnapshotDiscoveryConfig(empty, serverID))
+
+	_, err = NewStaticSnapshotDiscoveryConfig("", Spec{})
+	requireBadParameter(t, err)
+}
+
+// TestStaticSnapshotPreservesNonInstallerMatcherFields pins the inventory
+// contract: snapshot validation must not enrich stored matchers with values
+// derived by ordinary matcher defaulting. A publisher sending raw file
+// configuration (no ssm document, no installer params) must get exactly that
+// stored; deriving the absent document from a sanitized, params-less matcher
+// would pick the agentless installer document where the publishing service's
+// own defaulting picks the agent one, misrepresenting the effective config.
+func TestStaticSnapshotPreservesNonInstallerMatcherFields(t *testing.T) {
+	// Snapshot validation of the integration matcher below must not depend
+	// on the Auth host's environment: pin EICE explicitly disabled.
+	t.Setenv(constants.UnstableEnableEICEEnvVar, "")
+	const serverID = "00000000-0000-0000-0000-000000000001"
+	input := types.AWSMatcher{
+		Types:       []string{types.AWSMatcherEC2},
+		Regions:     []string{"us-east-1"},
+		Integration: "integration",
+	}
+
+	dc, err := NewStaticSnapshotDiscoveryConfig(serverID, Spec{AWS: []types.AWSMatcher{input}})
+	require.NoError(t, err)
+	require.Nil(t, dc.Spec.AWS[0].SSM, "an absent SSM document must stay absent, not be derived")
+	require.Equal(t, input, dc.Spec.AWS[0], "snapshot construction must store the matcher exactly as published")
+
+	// A publisher-supplied document name passes through unchanged.
+	custom := input
+	custom.SSM = &types.AWSSSM{DocumentName: "custom-installer-document"}
+	dc, err = NewStaticSnapshotDiscoveryConfig(serverID, Spec{AWS: []types.AWSMatcher{custom}})
+	require.NoError(t, err)
+	require.Equal(t, custom, dc.Spec.AWS[0])
+
+	// Re-running validation on the stored form (backend reads, the marshal
+	// path) must leave it unchanged as well.
+	require.NoError(t, dc.CheckAndSetDefaults())
+	require.Equal(t, custom, dc.Spec.AWS[0])
+
+	// Validation still runs against the throwaway copy: an invalid matcher
+	// is rejected even though nothing is mutated.
+	_, err = NewStaticSnapshotDiscoveryConfig(serverID, Spec{AWS: []types.AWSMatcher{{
+		Types:   []string{"not-a-matcher-type"},
+		Regions: []string{"us-east-1"},
+	}}})
+	requireBadParameter(t, err)
+
+	// Azure, GCP, and Kube matchers get the same treatment: validation must
+	// not stamp the wildcard scoping their defaulting derives (regions,
+	// resource groups, locations, namespaces, labels) into the inventory.
+	multi := Spec{
+		Azure: []types.AzureMatcher{{Types: []string{types.AzureMatcherVM}, Subscriptions: []string{"sub-1"}}},
+		GCP:   []types.GCPMatcher{{Types: []string{types.GCPMatcherCompute}, ProjectIDs: []string{"project-1"}}},
+		Kube:  []types.KubernetesMatcher{{Types: []string{types.KubernetesMatchersApp}}},
+	}
+	dcMulti, err := NewStaticSnapshotDiscoveryConfig(serverID, multi)
+	require.NoError(t, err)
+	require.Empty(t, dcMulti.Spec.Azure[0].Regions, "absent Azure regions must stay absent, not default to the wildcard")
+	require.Empty(t, dcMulti.Spec.Azure[0].ResourceGroups)
+	require.Empty(t, dcMulti.Spec.Azure[0].ResourceTags)
+	require.Equal(t, []string{"sub-1"}, dcMulti.Spec.Azure[0].Subscriptions)
+	require.Nil(t, dcMulti.Spec.Azure[0].Params)
+	require.Empty(t, dcMulti.Spec.GCP[0].Locations, "absent GCP locations must stay absent, not default to the wildcard")
+	require.Empty(t, dcMulti.Spec.GCP[0].Labels)
+	require.Nil(t, dcMulti.Spec.GCP[0].Params)
+	require.Empty(t, dcMulti.Spec.Kube[0].Namespaces, "absent Kube namespaces must stay absent, not default to the wildcard")
+	require.Empty(t, dcMulti.Spec.Kube[0].Labels)
+}
+
+// TestStaticSnapshotMatchesRegularDefaulting pins the publisher contract end
+// to end: a matcher that went through ordinary file-config defaulting (as
+// the running service applies it) and was sanitized of installer params is
+// stored by snapshot construction exactly as sent. Every non-installer field
+// the service derived, especially SSM.DocumentName, is what the snapshot
+// reports; the bug this guards against stored AWSAgentlessInstallerDocument
+// where the service runs with AWSInstallerDocument.
+func TestStaticSnapshotMatchesRegularDefaulting(t *testing.T) {
+	t.Setenv(constants.UnstableEnableEICEEnvVar, "true")
+	const serverID = "00000000-0000-0000-0000-000000000001"
+
+	tests := map[string]struct {
+		matcher    types.AWSMatcher
+		wantSSMDoc string
+	}{
+		"default EC2 script enrollment": {
+			matcher: types.AWSMatcher{
+				Types: []string{types.AWSMatcherEC2}, Regions: []string{"us-east-1"},
+			},
+			wantSSMDoc: types.AWSInstallerDocument,
+		},
+		"integration-backed EC2": {
+			matcher: types.AWSMatcher{
+				Types: []string{types.AWSMatcherEC2}, Regions: []string{"us-east-1"},
+				Integration: "integration",
+			},
+			wantSSMDoc: types.AWSInstallerDocument,
+		},
+		"custom SSM document": {
+			matcher: types.AWSMatcher{
+				Types: []string{types.AWSMatcherEC2}, Regions: []string{"us-east-1"},
+				SSM: &types.AWSSSM{DocumentName: "custom-installer-document"},
+			},
+			wantSSMDoc: "custom-installer-document",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Ordinary file-config defaulting, then the publisher-side
+			// sanitization that strips installer params before publication.
+			spec := Spec{DiscoveryGroup: "group", AWS: []types.AWSMatcher{tc.matcher}}
+			require.NoError(t, spec.AWS[0].CheckAndSetDefaults())
+			SanitizeStaticSnapshotSpec(&spec)
+
+			var sourceBefore types.AWSMatcher
+			require.NoError(t, utils.StrictObjectToStruct(&spec.AWS[0], &sourceBefore))
+
+			dc, err := NewStaticSnapshotDiscoveryConfig(serverID, spec)
+			require.NoError(t, err)
+			stored := dc.Spec.AWS[0]
+			require.Nil(t, stored.Params, "installer params must be absent from the snapshot")
+			require.Equal(t, sourceBefore, stored,
+				"the snapshot must store the service's effective matcher exactly")
+			require.NotNil(t, stored.SSM)
+			require.Equal(t, tc.wantSSMDoc, stored.SSM.DocumentName,
+				"the snapshot must report the SSM document the service actually runs with")
+			require.Equal(t, sourceBefore, spec.AWS[0],
+				"construction must not modify the caller's spec")
+		})
+	}
+}
+
+func TestCheckStaticSnapshotDiscoveryConfig(t *testing.T) {
+	const serverID = "00000000-0000-0000-0000-000000000001"
+	snapshot, err := NewStaticSnapshotDiscoveryConfig(serverID, Spec{DiscoveryGroup: "group"})
+	require.NoError(t, err)
+	require.NoError(t, CheckStaticSnapshotDiscoveryConfig(snapshot, serverID))
+
+	for name, mutate := range map[string]func(*DiscoveryConfig){
+		"wrong subkind": func(dc *DiscoveryConfig) { dc.SetSubKind("") },
+		"foreign name":  func(dc *DiscoveryConfig) { dc.SetName(StaticSnapshotName("00000000-0000-0000-0000-000000000002")) },
+		"wrong origin":  func(dc *DiscoveryConfig) { dc.SetOrigin(types.OriginDynamic) },
+		"installer params": func(dc *DiscoveryConfig) {
+			dc.Spec.AWS = []types.AWSMatcher{{Params: &types.InstallerParams{JoinToken: "secret"}}}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dc := snapshot.Clone()
+			mutate(dc)
+			requireBadParameter(t, CheckStaticSnapshotDiscoveryConfig(dc, serverID))
+		})
+	}
+
+	requireBadParameter(t, CheckStaticSnapshotDiscoveryConfig(snapshot, ""))
+	requireBadParameter(t, CheckStaticSnapshotDiscoveryConfig(nil, serverID))
+}
+
+// TestEachInstallerParamsCoversAllFamilies enforces the eachInstallerParams
+// contract by reflection: every Spec matcher family whose elements carry
+// installer params must be visited, so static snapshot sanitization and
+// validation cannot silently miss a family added later.
+func TestEachInstallerParamsCoversAllFamilies(t *testing.T) {
+	var spec Spec
+	want := populateSentinelInstallerParams(&spec)
+	require.NotZero(t, want, "expected at least one matcher family with installer params")
+
+	visited := 0
+	spec.eachInstallerParams(func(p **types.InstallerParams) {
+		if *p != nil && (*p).JoinToken == sentinelJoinToken {
+			visited++
+		}
+	})
+	require.Equal(t, want, visited,
+		"eachInstallerParams must visit every matcher family carrying installer params; update it for the new family")
+
+	SanitizeStaticSnapshotSpec(&spec)
+	require.Empty(t, familiesWithInstallerParams(&spec), "sanitization left installer params behind")
+}
+
+func populateSentinelInstallerParams(spec *Spec) int {
+	specValue := reflect.ValueOf(spec).Elem()
+	specType := specValue.Type()
+	populated := 0
+	for i := range specType.NumField() {
+		field := specType.Field(i)
+		params, ok := installerParamsField(field.Type)
+		if !ok {
+			continue
+		}
+		entry := newMatcherValue(field.Type)
+		matcher := entry
+		if matcher.Kind() == reflect.Pointer {
+			matcher = matcher.Elem()
+		}
+		matcher.FieldByIndex(params.Index).Set(reflect.ValueOf(&types.InstallerParams{JoinToken: sentinelJoinToken}))
+		specValue.Field(i).Set(reflect.Append(reflect.MakeSlice(field.Type, 0, 1), entry))
+		populated++
+	}
+	return populated
+}
+
+func familiesWithInstallerParams(spec *Spec) []string {
+	var found []string
+	specValue := reflect.ValueOf(spec).Elem()
+	specType := specValue.Type()
+	for i := range specType.NumField() {
+		field := specType.Field(i)
+		params, ok := installerParamsField(field.Type)
+		if !ok {
+			continue
+		}
+		matchers := specValue.Field(i)
+		for j := range matchers.Len() {
+			matcher := matchers.Index(j)
+			if matcher.Kind() == reflect.Pointer {
+				if matcher.IsNil() {
+					continue
+				}
+				matcher = matcher.Elem()
+			}
+			if !matcher.FieldByIndex(params.Index).IsNil() {
+				found = append(found, field.Name)
+			}
+		}
+	}
+	return found
+}
+
+func installerParamsField(fieldType reflect.Type) (reflect.StructField, bool) {
+	if fieldType.Kind() != reflect.Slice {
+		return reflect.StructField{}, false
+	}
+	elementType := fieldType.Elem()
+	if elementType.Kind() == reflect.Pointer {
+		elementType = elementType.Elem()
+	}
+	if elementType.Kind() != reflect.Struct {
+		return reflect.StructField{}, false
+	}
+	for field := range elementType.Fields() {
+		if field.Type == installerParamsType {
+			return field, true
+		}
+	}
+	return reflect.StructField{}, false
+}
+
+func newMatcherValue(sliceType reflect.Type) reflect.Value {
+	elementType := sliceType.Elem()
+	if elementType.Kind() == reflect.Pointer {
+		return reflect.New(elementType.Elem())
+	}
+	return reflect.New(elementType).Elem()
+}
+
+func TestStaticSnapshotNames(t *testing.T) {
+	uuid := "00000000-0000-0000-0000-000000000001"
+	require.Equal(t, "static-snapshot-"+uuid, StaticSnapshotName(uuid))
+	require.True(t, IsReservedStaticSnapshotName(StaticSnapshotName(uuid)))
+	hashed := StaticSnapshotName("legacy-server")
+	require.True(t, strings.HasPrefix(hashed, staticSnapshotHashedNamePrefix))
+	require.Equal(t, hashed, StaticSnapshotName("legacy-server"))
+	require.True(t, IsReservedStaticSnapshotName(hashed))
+	require.False(t, IsReservedStaticSnapshotName("static-snapshot-aws-prod"))
+}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -479,10 +479,16 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 			return nil, trace.Wrap(err)
 		}
 	}
-	if cfg.DiscoveryConfigs == nil {
-		cfg.DiscoveryConfigs, err = local.NewDiscoveryConfigService(cfg.Backend)
+	if cfg.DiscoveryConfigs == nil || cfg.StaticSnapshotDiscoveryConfigs == nil {
+		discoveryConfigs, err := local.NewDiscoveryConfigService(cfg.Backend)
 		if err != nil {
 			return nil, trace.Wrap(err)
+		}
+		if cfg.DiscoveryConfigs == nil {
+			cfg.DiscoveryConfigs = discoveryConfigs
+		}
+		if cfg.StaticSnapshotDiscoveryConfigs == nil {
+			cfg.StaticSnapshotDiscoveryConfigs = discoveryConfigs
 		}
 	}
 	if cfg.UserPreferences == nil {
@@ -714,7 +720,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		ConnectionsDiagnostic:           cfg.ConnectionsDiagnostic,
 		Integrations:                    cfg.Integrations,
 		UserTasks:                       cfg.UserTasks,
-		DiscoveryConfigs:                cfg.DiscoveryConfigs,
+		DiscoveryConfigsInternal:        cfg.DiscoveryConfigs,
 		Okta:                            cfg.Okta,
 		AccessListsInternal:             cfg.AccessLists,
 		DatabaseObjectImportRules:       cfg.DatabaseObjectImportRules,
@@ -755,6 +761,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		BeamsConfigService:              cfg.BeamsConfigService,
 		SubCAService:                    cfg.SubCAService,
 		EnrollPairing:                   cfg.EnrollPairing,
+		StaticSnapshotDiscoveryConfigs:  cfg.StaticSnapshotDiscoveryConfigs,
 	}
 
 	if cfg.FakePasswordHash == nil {

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -618,7 +618,7 @@ func InitAuthCache(p AuthCacheParams) error {
 		DatabaseServices:        p.AuthServer.Services.DatabaseServices,
 		Databases:               p.AuthServer.Services.Databases,
 		DelegationSessions:      p.AuthServer.Services.DelegationSessions,
-		DiscoveryConfigs:        p.AuthServer.Services.DiscoveryConfigs,
+		DiscoveryConfigs:        p.AuthServer.Services.DiscoveryConfigsInternal,
 		DynamicAccess:           p.AuthServer.Services.DynamicAccessExt,
 		Events:                  p.AuthServer.Services.Events,
 		Integrations:            p.AuthServer.Services.Integrations,

--- a/lib/auth/discoveryconfig/discoveryconfigv1/service.go
+++ b/lib/auth/discoveryconfig/discoveryconfigv1/service.go
@@ -25,6 +25,7 @@ import (
 	"maps"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
@@ -39,6 +40,7 @@ import (
 	conv "github.com/gravitational/teleport/api/types/discoveryconfig/convert/v1"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/aws"
+	"github.com/gravitational/teleport/api/utils/retryutils"
 	prehogv1a "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
@@ -55,8 +57,11 @@ type ServiceConfig struct {
 	// Authorizer is the authorizer to use.
 	Authorizer authz.Authorizer
 
-	// Backend is the backend for storing DiscoveryConfigs.
-	Backend services.DiscoveryConfigs
+	// Backend stores regular DiscoveryConfigs.
+	Backend services.DiscoveryConfigsInternal
+	// StaticSnapshotBackend is the isolated backend for owner-published
+	// static snapshot DiscoveryConfigs.
+	StaticSnapshotBackend services.StaticSnapshotDiscoveryConfigs
 
 	// Clock is the clock.
 	Clock clockwork.Clock
@@ -77,6 +82,9 @@ func (s *ServiceConfig) CheckAndSetDefaults() error {
 	}
 	if s.Backend == nil {
 		return trace.BadParameter("backend is required")
+	}
+	if s.StaticSnapshotBackend == nil {
+		return trace.BadParameter("static snapshot backend is required")
 	}
 	if s.Emitter == nil {
 		return trace.BadParameter("emitter is required")
@@ -100,13 +108,29 @@ func (s *ServiceConfig) CheckAndSetDefaults() error {
 type Service struct {
 	discoveryconfigv1.UnimplementedDiscoveryConfigServiceServer
 
-	log           *slog.Logger
-	authorizer    authz.Authorizer
-	backend       services.DiscoveryConfigs
-	clock         clockwork.Clock
-	emitter       apievents.Emitter
-	usageReporter usagereporter.UsageReporter
+	log             *slog.Logger
+	authorizer      authz.Authorizer
+	backend         services.DiscoveryConfigsInternal
+	snapshotBackend services.StaticSnapshotDiscoveryConfigs
+	clock           clockwork.Clock
+	emitter         apievents.Emitter
+	usageReporter   usagereporter.UsageReporter
 }
+
+const (
+	// discoveryConfigWriteAttempts bounds every CAS retry loop on the
+	// discovery config write paths. Contention per record comes from a
+	// handful of periodic writers (the owner's publication and status
+	// reporting for a snapshot, a discovery group's status reports for a
+	// regular config), so a few backed-off retries converge; 4 keeps the
+	// worst-case added wait under 2s (jitter draws total at most
+	// 1*base + 2*base + 3*base = 1.8s), and exhaustion returns
+	// CompareFailed for the caller's next periodic cycle to retry.
+	discoveryConfigWriteAttempts = 4
+	// discoveryConfigWriteBackoffBase scales the jittered linear backoff
+	// before CAS retry attempt N, drawn from [0, N*base).
+	discoveryConfigWriteBackoffBase = 300 * time.Millisecond
+)
 
 // NewService returns a new DiscoveryConfigs gRPC service.
 func NewService(cfg ServiceConfig) (*Service, error) {
@@ -115,12 +139,13 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	}
 
 	return &Service{
-		log:           cfg.Logger,
-		authorizer:    cfg.Authorizer,
-		backend:       cfg.Backend,
-		clock:         cfg.Clock,
-		emitter:       cfg.Emitter,
-		usageReporter: cfg.UsageReporter,
+		log:             cfg.Logger,
+		authorizer:      cfg.Authorizer,
+		backend:         cfg.Backend,
+		snapshotBackend: cfg.StaticSnapshotBackend,
+		clock:           cfg.Clock,
+		emitter:         cfg.Emitter,
+		usageReporter:   cfg.UsageReporter,
 	}, nil
 }
 
@@ -155,7 +180,23 @@ func (s *Service) ListDiscoveryConfigs(ctx context.Context, req *discoveryconfig
 	}.Build(), nil
 }
 
-// GetDiscoveryConfig returns the specified DiscoveryConfig resource.
+// GetDiscoveryConfig returns the named DiscoveryConfig resource: regular
+// resources first, falling back to owner-published static snapshots for
+// reserved snapshot names. When both exist, the grandfathered regular
+// resource wins.
+//
+// The snapshot fallback never returns matcher inventory to a Discovery
+// Service identity: a service may fetch its own snapshot inventory-stripped
+// (envelope and status only, the same shape as the write echoes; see
+// staticSnapshotOwnerResponse) so read-modify-write status reporting can
+// merge against stored history, while every foreign snapshot name answers
+// the unoccupied NotFound. Together this closes every read channel that
+// could feed a snapshot's spec-carried matchers back into a service as
+// dynamic configuration, without disclosing which snapshots exist.
+// Clients that predate the static-snapshot subkind (or report no version)
+// also receive NotFound: their unconditional validation cannot decode a
+// group-less snapshot, so a successful RPC would surface as a misleading
+// client-side "discovery group is missing" failure.
 func (s *Service) GetDiscoveryConfig(ctx context.Context, req *discoveryconfigv1.GetDiscoveryConfigRequest) (*discoveryconfigv1.DiscoveryConfig, error) {
 	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
@@ -168,7 +209,40 @@ func (s *Service) GetDiscoveryConfig(ctx context.Context, req *discoveryconfigv1
 
 	dc, err := s.backend.GetDiscoveryConfig(ctx, req.GetName())
 	if err != nil {
-		return nil, trace.Wrap(err)
+		if !trace.IsNotFound(err) || !discoveryconfig.IsReservedStaticSnapshotName(req.GetName()) {
+			return nil, trace.Wrap(err)
+		}
+		if authz.HasBuiltinRole(*authCtx, string(types.RoleDiscovery)) {
+			identity, ok := authCtx.Identity.(authz.BuiltinRole)
+			if !ok || identity.GetServerID() == "" || req.GetName() != discoveryconfig.StaticSnapshotName(identity.GetServerID()) {
+				return nil, trace.Wrap(err)
+			}
+			snapshot, snapshotErr := s.snapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, req.GetName())
+			if snapshotErr != nil {
+				return nil, trace.Wrap(snapshotErr)
+			}
+			return staticSnapshotOwnerResponse(snapshot), nil
+		}
+		supported, supportErr := staticSnapshotClientSupported(ctx)
+		if supportErr != nil {
+			return nil, trace.Wrap(supportErr)
+		}
+		if !supported {
+			return nil, trace.Wrap(err)
+		}
+		snapshot, snapshotErr := s.snapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, req.GetName())
+		if snapshotErr != nil {
+			return nil, trace.Wrap(snapshotErr)
+		}
+		// Snapshots follow the same response pipeline as regular configs.
+		// Every current downgrade rule targets clients older than the
+		// snapshot support gate, so this is a no-op today; it keeps future
+		// compatibility rules from silently applying only to regular configs.
+		downgraded, downgradeErr := MaybeDowngradeDiscoveryConfig(ctx, snapshot)
+		if downgradeErr != nil {
+			return nil, trace.Wrap(downgradeErr)
+		}
+		return conv.ToProto(downgraded), nil
 	}
 
 	downgraded, err := MaybeDowngradeDiscoveryConfig(ctx, dc)
@@ -177,6 +251,34 @@ func (s *Service) GetDiscoveryConfig(ctx context.Context, req *discoveryconfigv1
 	}
 
 	return conv.ToProto(downgraded), nil
+}
+
+// minStaticSnapshotClientVersion is the first stable release whose
+// DiscoveryConfig validation accepts a group-less static snapshot spec.
+// All v19 prereleases are excluded because multiple builds can report the
+// same prerelease version despite straddling the introduction of the static
+// snapshot contract.
+//
+// TODO: DELETE IN v20.0.0, when the oldest supported client is v19.
+var minStaticSnapshotClientVersion = semver.Version{Major: 19}
+
+// staticSnapshotClientSupported reports whether the calling client can decode
+// a static snapshot. Clients that do not report a version are treated as too
+// old: unlike resource downgrading, where serving the resource unchanged is
+// the safe default, serving a possibly group-less snapshot to an unknown
+// client risks a misleading client-side validation failure. A version that
+// does not parse is an error, matching MaybeDowngradeDiscoveryConfig, so the
+// caller surfaces it instead of folding it into a misleading NotFound.
+func staticSnapshotClientSupported(ctx context.Context) (bool, error) {
+	clientVersionString, ok := metadata.ClientVersionFromContext(ctx)
+	if !ok {
+		return false, nil
+	}
+	clientVersion, err := semver.NewVersion(clientVersionString)
+	if err != nil {
+		return false, trace.BadParameter("unrecognized client version: %s is not a valid semver", clientVersionString)
+	}
+	return !clientVersion.LessThan(minStaticSnapshotClientVersion), nil
 }
 
 // CreateDiscoveryConfig creates a new DiscoveryConfig resource.
@@ -190,6 +292,9 @@ func (s *Service) CreateDiscoveryConfig(ctx context.Context, req *discoveryconfi
 		return nil, trace.Wrap(err)
 	}
 
+	if err := checkReservedName(req.GetDiscoveryConfig().GetHeader().GetMetadata().GetName()); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	dc, err := conv.FromProto(req.GetDiscoveryConfig())
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -235,12 +340,16 @@ func (s *Service) UpdateDiscoveryConfig(ctx context.Context, req *discoveryconfi
 		return nil, trace.Wrap(err)
 	}
 
+	if err := checkReservedName(req.GetDiscoveryConfig().GetHeader().GetMetadata().GetName()); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	dc, err := conv.FromProto(req.GetDiscoveryConfig())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	// Set the status to the existing status to ensure it is not cleared.
+	// Preserve the stored status. Static snapshots are in a different key
+	// range, so regular updates retain their historical write behavior.
 	oldDiscoveryConfig, err := s.backend.GetDiscoveryConfig(ctx, dc.GetName())
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -279,10 +388,22 @@ func (s *Service) UpsertDiscoveryConfig(ctx context.Context, req *discoveryconfi
 		return nil, trace.Wrap(err)
 	}
 
+	// Owner publication routes before generic RBAC: the Discovery role
+	// deliberately has no generic write verbs on the kind. Every other caller
+	// keeps the regular path, which discards subkinds, so a user cannot
+	// self-declare a static snapshot to bypass regular validation.
+	if req.GetDiscoveryConfig().GetHeader().GetSubKind() == discoveryconfig.SubKindStaticSnapshot &&
+		authz.HasBuiltinRole(*authCtx, string(types.RoleDiscovery)) {
+		return s.upsertStaticSnapshot(ctx, authCtx, req.GetDiscoveryConfig())
+	}
+
 	if err := authCtx.CheckAccessToKind(types.KindDiscoveryConfig, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
+	if err := checkReservedName(req.GetDiscoveryConfig().GetHeader().GetMetadata().GetName()); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	dc, err := conv.FromProto(req.GetDiscoveryConfig())
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -317,6 +438,100 @@ func (s *Service) UpsertDiscoveryConfig(ctx context.Context, req *discoveryconfi
 	return conv.ToProto(resp), nil
 }
 
+// upsertStaticSnapshot publishes only the authenticated owner's observed
+// inventory. Periodic machine renewals intentionally emit neither generic
+// DiscoveryConfig CRUD audit events nor lifecycle usage events: like discovery
+// status updates, they report observed state rather than a user configuration
+// change.
+//
+// Only the observed spec is taken from the request. Every trusted envelope
+// field (name, subkind, origin, expiry, revision) is rebuilt server-side and
+// the request's status is ignored: the publisher owns the spec, status
+// reporting owns the status. Publication is fail-closed: a spec still
+// carrying installer params is rejected inside the constructor rather than
+// silently stripped.
+func (s *Service) upsertStaticSnapshot(ctx context.Context, authCtx *authz.Context, msg *discoveryconfigv1.DiscoveryConfig) (*discoveryconfigv1.DiscoveryConfig, error) {
+	identity, ok := authCtx.Identity.(authz.BuiltinRole)
+	if !ok || identity.GetServerID() == "" {
+		return nil, trace.AccessDenied("static snapshot discovery configs may only be published by their owning Discovery Service")
+	}
+	if msg.GetSpec() == nil {
+		return nil, trace.BadParameter("spec is missing")
+	}
+	serverID := identity.GetServerID()
+	name := discoveryconfig.StaticSnapshotName(serverID)
+	if requested := msg.GetHeader().GetMetadata().GetName(); requested != "" && requested != name {
+		return nil, trace.AccessDenied("static snapshot discovery configs are owner-managed; server %q publishes %q", serverID, name)
+	}
+	if _, err := s.backend.GetDiscoveryConfig(ctx, name); err == nil {
+		return nil, trace.AlreadyExists("regular discovery config %q occupies the static snapshot owner name", name)
+	} else if !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+	dc, err := discoveryconfig.NewStaticSnapshotDiscoveryConfig(serverID, conv.SpecFromProto(msg.GetSpec()))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	retry, err := s.newDiscoveryConfigWriteRetry()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	for attempt := range discoveryConfigWriteAttempts {
+		if err := waitForDiscoveryConfigRetry(ctx, retry, attempt); err != nil {
+			return nil, err
+		}
+		dc.SetExpiry(s.clock.Now().Add(discoveryconfig.StaticSnapshotTTL))
+		existing, err := s.snapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, name)
+		if trace.IsNotFound(err) {
+			// A fresh publication must not carry status merged from a record
+			// observed by an earlier iteration and deleted since.
+			dc.Status = discoveryconfig.Status{}
+			dc.SetRevision("")
+			created, err := s.snapshotBackend.CreateStaticSnapshotDiscoveryConfig(ctx, dc)
+			if trace.IsAlreadyExists(err) {
+				continue
+			}
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return staticSnapshotOwnerResponse(created), nil
+		}
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		// Renewal replaces the inventory and preserves whatever status
+		// reporting has stored since. The storage layer enforces the
+		// stored-size cap on the merged record.
+		dc.Status = existing.Status
+		dc.SetRevision(existing.GetRevision())
+		updated, err := s.snapshotBackend.ConditionalUpdateStaticSnapshotDiscoveryConfig(ctx, dc)
+		if trace.IsCompareFailed(err) {
+			continue
+		}
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return staticSnapshotOwnerResponse(updated), nil
+	}
+	// CompareFailed matches the status loops' exhaustion category and keeps
+	// LimitExceeded reserved for the stored-size cap, so a publisher can tell
+	// write contention (retry soon) from an oversized record (shrink first).
+	return nil, trace.CompareFailed("static snapshot discovery config write failed after %d attempts", discoveryConfigWriteAttempts)
+}
+
+// staticSnapshotOwnerResponse is the RPC echo of a snapshot write, with the
+// spec inventory removed. Snapshot write responses go only to the owning
+// Discovery Service, which published the data and has no read use for the
+// echo; stripping it enforces the "Discovery Service identities never
+// receive snapshot matchers" invariant on every channel instead of
+// documenting it on the Get gate alone. The envelope (name, subkind, expiry)
+// and the merged status remain for the caller's bookkeeping.
+func staticSnapshotOwnerResponse(dc *discoveryconfig.DiscoveryConfig) *discoveryconfigv1.DiscoveryConfig {
+	msg := conv.ToProto(dc)
+	msg.SetSpec(&discoveryconfigv1.DiscoveryConfigSpec{})
+	return msg
+}
+
 // DeleteDiscoveryConfig removes the specified DiscoveryConfig resource.
 func (s *Service) DeleteDiscoveryConfig(ctx context.Context, req *discoveryconfigv1.DeleteDiscoveryConfigRequest) (*emptypb.Empty, error) {
 	authCtx, err := s.authorizer.Authorize(ctx)
@@ -330,6 +545,14 @@ func (s *Service) DeleteDiscoveryConfig(ctx context.Context, req *discoveryconfi
 
 	// Fetch the DiscoveryConfig before deletion to capture metadata for the usage event.
 	dc, err := s.backend.GetDiscoveryConfig(ctx, req.GetName())
+	// Delete is the one write verb that discloses snapshot occupancy: the
+	// owner-managed AccessDenied goes only to callers holding the read verb,
+	// who could learn the occupancy via Get anyway.
+	if trace.IsNotFound(err) && discoveryconfig.IsReservedStaticSnapshotName(req.GetName()) {
+		if ownerErr := s.snapshotOwnerManagedForReaders(ctx, authCtx, req.GetName()); ownerErr != nil {
+			return nil, trace.Wrap(ownerErr)
+		}
+	}
 	if err != nil && !trace.IsNotFound(err) {
 		s.log.WarnContext(ctx, "Skipping DiscoveryConfig delete usage event due to GetDiscoveryConfig failure.",
 			"discovery_config_name", req.GetName(),
@@ -400,18 +623,26 @@ func (s *Service) UpdateDiscoveryConfigStatus(ctx context.Context, req *discover
 	if !authz.HasBuiltinRole(*authCtx, string(types.RoleDiscovery)) {
 		return nil, trace.AccessDenied("UpdateDiscoveryConfigStatus request can be only executed by a Discovery Service")
 	}
-
-	for {
+	retry, err := s.newDiscoveryConfigWriteRetry()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	for attempt := range discoveryConfigWriteAttempts {
+		if err := waitForDiscoveryConfigRetry(ctx, retry, attempt); err != nil {
+			return nil, err
+		}
 		dc, err := s.backend.GetDiscoveryConfig(ctx, req.GetName())
 		switch {
 		case trace.IsNotFound(err):
-			return nil, trace.NotFound("discovery config %q not found", req.GetName())
+			return s.updateStaticSnapshotStatus(ctx, authCtx, req)
 		case err != nil:
 			return nil, trace.Wrap(err)
 		}
-
 		dc.Status = conv.StatusFromProto(req.GetStatus())
-		resp, err := s.backend.UpdateDiscoveryConfig(ctx, dc)
+		// The revision-checked update makes the retry loop real: a stale
+		// working copy must not clobber a concurrent spec edit with the
+		// spec it fetched before that edit.
+		resp, err := s.backend.ConditionalUpdateDiscoveryConfig(ctx, dc)
 		if err != nil {
 			if trace.IsCompareFailed(err) {
 				continue
@@ -421,6 +652,132 @@ func (s *Service) UpdateDiscoveryConfigStatus(ctx context.Context, req *discover
 
 		return conv.ToProto(resp), nil
 	}
+	return nil, trace.CompareFailed("discovery config status update failed after %d attempts", discoveryConfigWriteAttempts)
+}
+
+// updateStaticSnapshotStatus handles the status report for a name absent from
+// the regular range, mirroring upsertStaticSnapshot: the identity, ownership,
+// and payload checks are loop-invariant and run once; only the read-merge-CAS
+// cycle retries.
+//
+// Ownership is derivable from the caller's identity alone, so it is checked
+// before the snapshot store is ever consulted: a foreign reserved name
+// answers the same NotFound as an unoccupied one, disclosing nothing about
+// which snapshots exist and costing no backend read.
+func (s *Service) updateStaticSnapshotStatus(ctx context.Context, authCtx *authz.Context, req *discoveryconfigv1.UpdateDiscoveryConfigStatusRequest) (*discoveryconfigv1.DiscoveryConfig, error) {
+	identity, ok := authCtx.Identity.(authz.BuiltinRole)
+	if !discoveryconfig.IsReservedStaticSnapshotName(req.GetName()) ||
+		!ok || identity.GetServerID() == "" ||
+		req.GetName() != discoveryconfig.StaticSnapshotName(identity.GetServerID()) {
+		return nil, trace.NotFound("discovery config %q not found", req.GetName())
+	}
+	status := conv.StatusFromProto(req.GetStatus())
+	for serverID := range status.ServerStatus {
+		if serverID != identity.GetServerID() {
+			return nil, trace.BadParameter("static snapshot status contains foreign server %q", serverID)
+		}
+	}
+	retry, err := s.newDiscoveryConfigWriteRetry()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	for attempt := range discoveryConfigWriteAttempts {
+		if err := waitForDiscoveryConfigRetry(ctx, retry, attempt); err != nil {
+			return nil, err
+		}
+		dc, err := s.snapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, req.GetName())
+		if trace.IsNotFound(err) {
+			return nil, trace.NotFound("discovery config %q not found", req.GetName())
+		}
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		// Reporting owns the status and must not touch the spec inventory
+		// or renew the publication expiry. The storage layer enforces the
+		// stored-size cap on the merged record, so an oversized report is
+		// rejected here rather than persisted; if a previously accepted
+		// status ever blocks a larger inventory renewal, the record
+		// TTL-expires and the fresh publication (which carries no status)
+		// re-establishes the inventory, after which the oversized report
+		// no longer fits and keeps failing loudly.
+		dc.Status = status
+		resp, err := s.snapshotBackend.ConditionalUpdateStaticSnapshotDiscoveryConfig(ctx, dc)
+		if trace.IsCompareFailed(err) {
+			continue
+		}
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return staticSnapshotOwnerResponse(resp), nil
+	}
+	return nil, trace.CompareFailed("static snapshot status update failed after %d attempts", discoveryConfigWriteAttempts)
+}
+
+func reservedStaticSnapshotNameError(name string) error {
+	return trace.BadParameter("discovery config name %q is reserved for static snapshot discovery configs; a pre-existing config with this name remains readable and deletable but cannot be modified; recreate it under a different name to keep managing it", name)
+}
+
+// checkReservedName rejects every generic write (Create, Update, Upsert) to
+// a reserved static snapshot name so get-then-mutate flows (web UI edits,
+// tctl edit) fail with the ownership story rather than conversion or
+// existence noise. It runs before proto conversion on purpose: the regular
+// write path discards subkinds, so a round-tripped group-less snapshot would
+// otherwise fail validation with a misleading "discovery group is missing".
+//
+// The check is a pure name-shape test that reads nothing from the backend:
+// the response is identical whether the name is occupied by a grandfathered
+// regular config, a snapshot, or nothing, so the write verbs disclose no
+// occupancy information to any caller. Snapshot-occupancy disclosure lives
+// only in DeleteDiscoveryConfig, via snapshotOwnerManagedForReaders.
+func checkReservedName(name string) error {
+	if discoveryconfig.IsReservedStaticSnapshotName(name) {
+		return reservedStaticSnapshotNameError(name)
+	}
+	return nil
+}
+
+// snapshotOwnerManagedForReaders returns the owner-managed AccessDenied when
+// a snapshot occupies name and the caller holds the read verb; callers
+// without it learn nothing (nil), so deletes of names they cannot read keep
+// the unoccupied-name NotFound and disclose no snapshot existence.
+func (s *Service) snapshotOwnerManagedForReaders(ctx context.Context, authCtx *authz.Context, name string) error {
+	if authCtx.CheckAccessToKind(types.KindDiscoveryConfig, types.VerbRead) != nil {
+		return nil
+	}
+	if _, err := s.snapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, name); err == nil {
+		return trace.AccessDenied("static snapshot discovery config %q is owner-managed", name)
+	} else if !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// newDiscoveryConfigWriteRetry builds the jittered linear backoff shared by
+// the discovery config CAS write loops: retry attempt N waits a duration
+// drawn from [0, N*discoveryConfigWriteBackoffBase).
+func (s *Service) newDiscoveryConfigWriteRetry() (*retryutils.RetryV2, error) {
+	retry, err := retryutils.NewRetryV2(retryutils.RetryV2Config{
+		Driver: retryutils.NewLinearDriver(discoveryConfigWriteBackoffBase),
+		Max:    (discoveryConfigWriteAttempts - 1) * discoveryConfigWriteBackoffBase,
+		Jitter: retryutils.FullJitter,
+		Clock:  s.clock,
+	})
+	return retry, trace.Wrap(err)
+}
+
+// waitForDiscoveryConfigRetry waits for the next CAS retry slot, honoring
+// context cancellation. The first attempt proceeds without waiting.
+func waitForDiscoveryConfigRetry(ctx context.Context, retry *retryutils.RetryV2, attempt int) error {
+	if attempt == 0 {
+		return nil
+	}
+	retry.Inc()
+	select {
+	case <-ctx.Done():
+		return trace.Wrap(ctx.Err())
+	case <-retry.After():
+	}
+	return nil
 }
 
 // emitUsageEvent emits a DiscoveryConfigEvent usage event.

--- a/lib/auth/discoveryconfig/discoveryconfigv1/service_test.go
+++ b/lib/auth/discoveryconfig/discoveryconfigv1/service_test.go
@@ -20,12 +20,15 @@ package discoveryconfigv1
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+	grpcmetadata "google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	discoveryconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
@@ -34,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	convert "github.com/gravitational/teleport/api/types/discoveryconfig/convert/v1"
 	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/events"
@@ -106,8 +110,15 @@ func TestDiscoveryConfigCRUD(t *testing.T) {
 			ErrAssertion: requireTraceErrorFn(trace.IsAccessDenied),
 		},
 		{
+			// The role allows the read so the rejection can only come from
+			// the deny rule winning; a deny-only role would be rejected even
+			// if deny rules were ignored.
 			Name: "denied access to read discovery configs",
 			Role: types.RoleSpecV6{
+				Allow: types.RoleConditions{Rules: []types.Rule{{
+					Resources: []string{types.KindDiscoveryConfig},
+					Verbs:     []string{types.VerbRead},
+				}}},
 				Deny: types.RoleConditions{Rules: []types.Rule{{
 					Resources: []string{types.KindDiscoveryConfig},
 					Verbs:     []string{types.VerbRead},
@@ -138,11 +149,22 @@ func TestDiscoveryConfigCRUD(t *testing.T) {
 				}
 			},
 			Test: func(ctx context.Context, resourceSvc *Service, dcName string) error {
-				_, err := resourceSvc.ListDiscoveryConfigs(ctx, discoveryconfigpb.ListDiscoveryConfigsRequest_builder{
-					PageSize:  0,
+				// Ten stored configs against a page size of five must fill
+				// the page and report a next page.
+				resp, err := resourceSvc.ListDiscoveryConfigs(ctx, discoveryconfigpb.ListDiscoveryConfigsRequest_builder{
+					PageSize:  5,
 					NextToken: "",
 				}.Build())
-				return err
+				if err != nil {
+					return err
+				}
+				if got := len(resp.GetDiscoveryConfigs()); got != 5 {
+					return trace.BadParameter("expected a full page of 5 discovery configs, got %d", got)
+				}
+				if resp.GetNextKey() == "" {
+					return trace.BadParameter("expected a next page key with more configs stored than the page size")
+				}
+				return nil
 			},
 			ErrAssertion: require.NoError,
 		},
@@ -256,7 +278,6 @@ func TestDiscoveryConfigCRUD(t *testing.T) {
 					Verbs:     []string{types.VerbUpdate, types.VerbCreate},
 				}}},
 			},
-			Setup: func(t *testing.T, dcName string) {},
 			Test: func(ctx context.Context, resourceSvc *Service, dcName string) error {
 				dc := sampleDiscoveryConfigFn(t, dcName)
 				_, err := resourceSvc.UpsertDiscoveryConfig(ctx, discoveryconfigpb.UpsertDiscoveryConfigRequest_builder{
@@ -321,8 +342,17 @@ func TestDiscoveryConfigCRUD(t *testing.T) {
 				}
 			},
 			Test: func(ctx context.Context, resourceSvc *Service, dcName string) error {
-				_, err := resourceSvc.DeleteAllDiscoveryConfigs(ctx, &discoveryconfigpb.DeleteAllDiscoveryConfigsRequest{})
-				return err
+				if _, err := resourceSvc.DeleteAllDiscoveryConfigs(ctx, &discoveryconfigpb.DeleteAllDiscoveryConfigsRequest{}); err != nil {
+					return err
+				}
+				remaining, _, err := localClient.ListDiscoveryConfigs(ctx, 0, "")
+				if err != nil {
+					return err
+				}
+				if len(remaining) != 0 {
+					return trace.BadParameter("expected the store emptied, %d discovery configs remain", len(remaining))
+				}
+				return nil
 			},
 			ErrAssertion: require.NoError,
 		},
@@ -341,6 +371,921 @@ func TestDiscoveryConfigCRUD(t *testing.T) {
 			tc.ErrAssertion(t, err)
 		})
 	}
+}
+
+func TestDiscoveryConfigWritesDiscardSubKind(t *testing.T) {
+	t.Parallel()
+
+	ctx, localClient, resourceSvc := initSvc(t, "test-cluster")
+	writeCtx := authorizerForDummyUser(t, ctx, types.RoleSpecV6{
+		Allow: types.RoleConditions{Rules: []types.Rule{{
+			Resources: []string{types.KindDiscoveryConfig},
+			Verbs:     []string{types.VerbCreate, types.VerbUpdate},
+		}}},
+	}, localClient)
+
+	for _, subKind := range []string{"future-subkind", discoveryconfig.SubKindStaticSnapshot} {
+		t.Run(subKind, func(t *testing.T) {
+			dc, err := discoveryconfig.NewDiscoveryConfig(
+				header.Metadata{Name: uuid.NewString()},
+				discoveryconfig.Spec{
+					DiscoveryGroup: "some-group",
+					AWS: []types.AWSMatcher{{
+						Types:   []string{types.AWSMatcherEC2},
+						Regions: []string{"us-east-1"},
+						Params: &types.InstallerParams{
+							JoinToken: "token-name",
+							HTTPProxySettings: &types.HTTPProxySettings{
+								HTTPSProxy: "http://user:password@proxy.example.com",
+							},
+						},
+					}},
+				},
+			)
+			require.NoError(t, err)
+			wantParams := dc.Spec.AWS[0].Params
+			dc.SetSubKind(subKind)
+
+			created, err := resourceSvc.CreateDiscoveryConfig(writeCtx, discoveryconfigpb.CreateDiscoveryConfigRequest_builder{
+				DiscoveryConfig: convert.ToProto(dc),
+			}.Build())
+			require.NoError(t, err)
+			require.Empty(t, created.GetHeader().GetSubKind())
+			require.Equal(t, wantParams, created.GetSpec().GetAws()[0].Params)
+
+			dc.SetSubKind(subKind)
+			updated, err := resourceSvc.UpdateDiscoveryConfig(writeCtx, discoveryconfigpb.UpdateDiscoveryConfigRequest_builder{
+				DiscoveryConfig: convert.ToProto(dc),
+			}.Build())
+			require.NoError(t, err)
+			require.Empty(t, updated.GetHeader().GetSubKind())
+			require.Equal(t, wantParams, updated.GetSpec().GetAws()[0].Params)
+
+			dc.SetSubKind(subKind)
+			upserted, err := resourceSvc.UpsertDiscoveryConfig(writeCtx, discoveryconfigpb.UpsertDiscoveryConfigRequest_builder{
+				DiscoveryConfig: convert.ToProto(dc),
+			}.Build())
+			require.NoError(t, err)
+			require.Empty(t, upserted.GetHeader().GetSubKind())
+			require.Equal(t, wantParams, upserted.GetSpec().GetAws()[0].Params)
+		})
+	}
+}
+
+func TestStaticSnapshotPublication(t *testing.T) {
+	t.Parallel()
+	const clusterName = "test-cluster"
+	serverID := uuid.NewString()
+	ctx, _, resourceSvc, cfg := initSvcWithConfig(t, clusterName)
+	ownerCtx := authorizerForDiscoveryOwner(ctx, clusterName, serverID)
+	name := discoveryconfig.StaticSnapshotName(serverID)
+
+	before := time.Now()
+	got, err := resourceSvc.UpsertDiscoveryConfig(ownerCtx, staticSnapshotUpsertRequest(t, serverID, "configured-group"))
+	require.NoError(t, err)
+	after := time.Now()
+	echo, err := convert.FromProtoWithSubKind(got)
+	require.NoError(t, err)
+	require.True(t, echo.IsStaticSnapshot())
+	require.Equal(t, name, echo.GetName())
+	require.Equal(t, types.OriginConfigFile, echo.Origin())
+	require.False(t, echo.Expiry().Before(before.Add(discoveryconfig.StaticSnapshotTTL)))
+	require.False(t, echo.Expiry().After(after.Add(discoveryconfig.StaticSnapshotTTL)))
+	// The write echo goes to a Discovery Service identity and must not carry
+	// the matcher inventory back to it.
+	require.Empty(t, echo.GetDiscoveryGroup())
+	require.Empty(t, echo.Spec.AWS)
+
+	// The snapshot must live in the isolated range only: the regular range is
+	// what Discovery Services list and watch for dynamic matchers.
+	regular, _, err := cfg.Backend.ListDiscoveryConfigs(ctx, 0, "")
+	require.NoError(t, err)
+	require.Empty(t, regular)
+	stored, err := cfg.StaticSnapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, name)
+	require.NoError(t, err)
+	require.Equal(t, "configured-group", stored.GetDiscoveryGroup())
+	require.Len(t, stored.Spec.AWS, 1)
+
+	// Production Discovery Services may carry Discovery as an additional role
+	// on their instance identity.
+	_, err = resourceSvc.UpsertDiscoveryConfig(
+		authorizerForInstanceDiscoveryOwner(ctx, clusterName, serverID), staticSnapshotUpsertRequest(t, serverID, "configured-group"))
+	require.NoError(t, err)
+
+	// A service with no discovery group still publishes: only the
+	// static-snapshot subkind relaxes the group requirement.
+	groupless, err := discoveryconfig.NewStaticSnapshotDiscoveryConfig(serverID, discoveryconfig.Spec{})
+	require.NoError(t, err)
+	_, err = resourceSvc.UpsertDiscoveryConfig(ownerCtx, discoveryconfigpb.UpsertDiscoveryConfigRequest_builder{DiscoveryConfig: convert.ToProto(groupless)}.Build())
+	require.NoError(t, err)
+}
+
+func TestStaticSnapshotRenewalAdvancesExpiryAndPreservesStatus(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, testStaticSnapshotRenewalAdvancesExpiryAndPreservesStatus)
+}
+
+func testStaticSnapshotRenewalAdvancesExpiryAndPreservesStatus(t *testing.T) {
+	const clusterName = "test-cluster"
+	serverID := uuid.NewString()
+	ctx, _, resourceSvc, cfg := initSvcWithConfig(t, clusterName)
+	ownerCtx := authorizerForDiscoveryOwner(ctx, clusterName, serverID)
+	name := discoveryconfig.StaticSnapshotName(serverID)
+
+	_, err := resourceSvc.UpsertDiscoveryConfig(ownerCtx, staticSnapshotUpsertRequest(t, serverID, "group-one"))
+	require.NoError(t, err)
+	report := discoveryconfigpb.DiscoveryConfigStatus_builder{
+		DiscoveredResources: 42,
+		ServerStatus: map[string]*discoveryconfigpb.DiscoveryStatusServer{
+			serverID: discoveryconfigpb.DiscoveryStatusServer_builder{}.Build(),
+		},
+	}.Build()
+	_, err = resourceSvc.UpdateDiscoveryConfigStatus(ownerCtx, discoveryconfigpb.UpdateDiscoveryConfigStatusRequest_builder{Name: name, Status: report}.Build())
+	require.NoError(t, err)
+
+	before, err := cfg.StaticSnapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, name)
+	require.NoError(t, err)
+	time.Sleep(time.Minute)
+	_, err = resourceSvc.UpsertDiscoveryConfig(ownerCtx, staticSnapshotUpsertRequest(t, serverID, "group-two"))
+	require.NoError(t, err)
+
+	after, err := cfg.StaticSnapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, name)
+	require.NoError(t, err)
+	require.Equal(t, before.Expiry().Add(time.Minute), after.Expiry(), "renewal must advance the Auth-owned expiry")
+	require.Equal(t, "group-two", after.GetDiscoveryGroup(), "renewal must replace the spec inventory")
+	require.Equal(t, before.Status.DiscoveredResources, after.Status.DiscoveredResources, "renewal must preserve the report counters")
+	require.Contains(t, after.Status.ServerStatus, serverID, "renewal must preserve the owner's server report")
+}
+
+func TestStaticSnapshotPublicationValidation(t *testing.T) {
+	t.Parallel()
+	const clusterName = "test-cluster"
+	serverID := uuid.NewString()
+	ctx, _, resourceSvc, cfg := initSvcWithConfig(t, clusterName)
+	ownerCtx := authorizerForDiscoveryOwner(ctx, clusterName, serverID)
+
+	// Publication is fail-closed: unsanitized installer params are rejected
+	// rather than silently stripped.
+	req := staticSnapshotUpsertRequest(t, serverID, "group")
+	req.GetDiscoveryConfig().GetSpec().GetAws()[0].Params = &types.InstallerParams{JoinToken: "secret"}
+	_, err := resourceSvc.UpsertDiscoveryConfig(ownerCtx, req)
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+
+	// A missing spec is malformed publication, not an empty inventory update.
+	req = staticSnapshotUpsertRequest(t, serverID, "group")
+	req.GetDiscoveryConfig().ClearSpec()
+	_, err = resourceSvc.UpsertDiscoveryConfig(ownerCtx, req)
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+	require.Contains(t, err.Error(), "spec is missing")
+
+	// Owners cannot publish under another server's name.
+	req = staticSnapshotUpsertRequest(t, serverID, "group")
+	req.GetDiscoveryConfig().GetHeader().GetMetadata().SetName(discoveryconfig.StaticSnapshotName(uuid.NewString()))
+	_, err = resourceSvc.UpsertDiscoveryConfig(ownerCtx, req)
+	require.True(t, trace.IsAccessDenied(err), "got %v", err)
+
+	// A Discovery Service identity keeps no generic write access outside the
+	// snapshot publication path.
+	regularWrite, err := discoveryconfig.NewDiscoveryConfig(header.Metadata{Name: "regular"}, discoveryconfig.Spec{DiscoveryGroup: "group"})
+	require.NoError(t, err)
+	_, err = resourceSvc.UpsertDiscoveryConfig(ownerCtx, discoveryconfigpb.UpsertDiscoveryConfigRequest_builder{DiscoveryConfig: convert.ToProto(regularWrite)}.Build())
+	require.True(t, trace.IsAccessDenied(err), "got %v", err)
+
+	// The stored-size cap covers the whole record.
+	req = staticSnapshotUpsertRequest(t, serverID, strings.Repeat("x", discoveryconfig.MaxStaticSnapshotSize))
+	_, err = resourceSvc.UpsertDiscoveryConfig(ownerCtx, req)
+	require.True(t, trace.IsLimitExceeded(err), "got %v", err)
+
+	// A grandfathered regular config occupying the owner name blocks publication.
+	regular, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{Name: discoveryconfig.StaticSnapshotName(serverID)},
+		discoveryconfig.Spec{DiscoveryGroup: "legacy"},
+	)
+	require.NoError(t, err)
+	_, err = cfg.Backend.CreateDiscoveryConfig(ctx, regular)
+	require.NoError(t, err)
+	_, err = resourceSvc.UpsertDiscoveryConfig(ownerCtx, staticSnapshotUpsertRequest(t, serverID, "group"))
+	require.True(t, trace.IsAlreadyExists(err), "got %v", err)
+}
+
+func TestStaticSnapshotStatusOwnershipAndCASMerges(t *testing.T) {
+	t.Parallel()
+	const clusterName = "test-cluster"
+	serverID := uuid.NewString()
+	ctx, _, resourceSvc, cfg := initSvcWithConfig(t, clusterName)
+	ownerCtx := authorizerForDiscoveryOwner(ctx, clusterName, serverID)
+	name := discoveryconfig.StaticSnapshotName(serverID)
+	_, err := resourceSvc.UpsertDiscoveryConfig(ownerCtx, staticSnapshotUpsertRequest(t, serverID, "group-one"))
+	require.NoError(t, err)
+
+	before, err := cfg.StaticSnapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, name)
+	require.NoError(t, err)
+	report := discoveryconfigpb.DiscoveryConfigStatus_builder{
+		State:               discoveryconfigpb.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_RUNNING,
+		DiscoveredResources: 42,
+		ServerStatus: map[string]*discoveryconfigpb.DiscoveryStatusServer{
+			serverID: discoveryconfigpb.DiscoveryStatusServer_builder{}.Build(),
+		},
+	}.Build()
+	updated, err := resourceSvc.UpdateDiscoveryConfigStatus(ownerCtx, discoveryconfigpb.UpdateDiscoveryConfigStatusRequest_builder{Name: name, Status: report}.Build())
+	require.NoError(t, err)
+	updatedInternal, err := convert.FromProtoWithSubKind(updated)
+	require.NoError(t, err)
+	require.Equal(t, before.Expiry(), updatedInternal.Expiry(), "report updates must not renew expiry")
+	require.Equal(t, uint64(42), updatedInternal.Status.DiscoveredResources)
+	require.Empty(t, updatedInternal.GetDiscoveryGroup(), "write echoes to Discovery identities must not carry inventory")
+	afterReport, err := cfg.StaticSnapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, name)
+	require.NoError(t, err)
+	require.Equal(t, "group-one", afterReport.GetDiscoveryGroup(), "report updates must not touch the spec inventory")
+	require.Equal(t, before.Spec, afterReport.Spec, "report updates must not touch the spec inventory")
+	_, err = resourceSvc.UpdateDiscoveryConfigStatus(
+		authorizerForInstanceDiscoveryOwner(ctx, clusterName, serverID),
+		discoveryconfigpb.UpdateDiscoveryConfigStatusRequest_builder{Name: name, Status: report}.Build(),
+	)
+	require.NoError(t, err)
+
+	// A foreign Discovery Service gets the same NotFound an unoccupied name
+	// produces: the status RPC must not disclose which snapshots exist.
+	_, err = resourceSvc.UpdateDiscoveryConfigStatus(
+		authorizerForDiscoveryOwner(ctx, clusterName, uuid.NewString()),
+		discoveryconfigpb.UpdateDiscoveryConfigStatusRequest_builder{Name: name, Status: report}.Build(),
+	)
+	require.True(t, trace.IsNotFound(err), "got %v", err)
+	foreign := discoveryconfigpb.DiscoveryConfigStatus_builder{
+		ServerStatus: map[string]*discoveryconfigpb.DiscoveryStatusServer{
+			"foreign": discoveryconfigpb.DiscoveryStatusServer_builder{}.Build(),
+		},
+	}.Build()
+	_, err = resourceSvc.UpdateDiscoveryConfigStatus(ownerCtx, discoveryconfigpb.UpdateDiscoveryConfigStatusRequest_builder{Name: name, Status: foreign}.Build())
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+
+	// A publication racing a report update retries from the latest report.
+	baseSnapshotBackend := cfg.StaticSnapshotBackend
+	raceCfg := cfg
+	raceCfg.StaticSnapshotBackend = &snapshotUpdateHookBackend{
+		StaticSnapshotDiscoveryConfigs: baseSnapshotBackend,
+		hook: func() error {
+			current, err := baseSnapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, name)
+			if err != nil {
+				return err
+			}
+			current.Status.DiscoveredResources = 99
+			_, err = baseSnapshotBackend.ConditionalUpdateStaticSnapshotDiscoveryConfig(ctx, current)
+			return err
+		},
+	}
+	resourceSvc = newService(t, raceCfg)
+	_, err = resourceSvc.UpsertDiscoveryConfig(ownerCtx, staticSnapshotUpsertRequest(t, serverID, "group-two"))
+	require.NoError(t, err)
+	stored, err := baseSnapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, name)
+	require.NoError(t, err)
+	require.Equal(t, "group-two", stored.GetDiscoveryGroup())
+	require.Equal(t, uint64(99), stored.Status.DiscoveredResources)
+
+	// A report update racing an inventory renewal retries from the latest inventory.
+	raceCfg = cfg
+	raceCfg.StaticSnapshotBackend = &snapshotUpdateHookBackend{
+		StaticSnapshotDiscoveryConfigs: baseSnapshotBackend,
+		hook: func() error {
+			current, err := baseSnapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, name)
+			if err != nil {
+				return err
+			}
+			current.Spec.DiscoveryGroup = "group-three"
+			_, err = baseSnapshotBackend.ConditionalUpdateStaticSnapshotDiscoveryConfig(ctx, current)
+			return err
+		},
+	}
+	resourceSvc = newService(t, raceCfg)
+	_, err = resourceSvc.UpdateDiscoveryConfigStatus(ownerCtx, discoveryconfigpb.UpdateDiscoveryConfigStatusRequest_builder{Name: name, Status: report}.Build())
+	require.NoError(t, err)
+	stored, err = baseSnapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, name)
+	require.NoError(t, err)
+	require.Equal(t, "group-three", stored.GetDiscoveryGroup())
+	require.Equal(t, uint64(42), stored.Status.DiscoveredResources)
+}
+
+func TestStaticSnapshotRejectsOversizedReport(t *testing.T) {
+	t.Parallel()
+	const clusterName = "test-cluster"
+	serverID := uuid.NewString()
+	ctx, _, resourceSvc, cfg := initSvcWithConfig(t, clusterName)
+	ownerCtx := authorizerForDiscoveryOwner(ctx, clusterName, serverID)
+	name := discoveryconfig.StaticSnapshotName(serverID)
+
+	_, err := resourceSvc.UpsertDiscoveryConfig(ownerCtx, staticSnapshotUpsertRequest(t, serverID, "group"))
+	require.NoError(t, err)
+
+	// The stored-size cap is validated against the merged record, so an
+	// oversized report fails loudly instead of consuming the space the owner
+	// needs to renew its inventory.
+	errorMessage := strings.Repeat("x", discoveryconfig.MaxStaticSnapshotSize)
+	report := discoveryconfigpb.DiscoveryConfigStatus_builder{ErrorMessage: &errorMessage}.Build()
+	_, err = resourceSvc.UpdateDiscoveryConfigStatus(ownerCtx, discoveryconfigpb.UpdateDiscoveryConfigStatusRequest_builder{Name: name, Status: report}.Build())
+	require.True(t, trace.IsLimitExceeded(err), "got %v", err)
+
+	stored, err := cfg.StaticSnapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, name)
+	require.NoError(t, err)
+	require.Nil(t, stored.Status.ErrorMessage, "rejected report must not replace stored status")
+
+	// Inventory renewal keeps working after the rejected report.
+	_, err = resourceSvc.UpsertDiscoveryConfig(ownerCtx, staticSnapshotUpsertRequest(t, serverID, "group"))
+	require.NoError(t, err)
+}
+
+// TestStaticSnapshotReadThenWriteContract covers get-then-mutate flows (web UI
+// edits, tctl edit): a snapshot is readable through the legacy Get fallback,
+// and every generic write against its name fails with the stateless
+// reserved-name rejection, not validation noise, and not NotFound.
+func TestStaticSnapshotReadThenWriteContract(t *testing.T) {
+	t.Parallel()
+	const clusterName = "test-cluster"
+	serverID := uuid.NewString()
+	ctx, localClient, resourceSvc := initSvc(t, clusterName)
+	ownerCtx := authorizerForDiscoveryOwner(ctx, clusterName, serverID)
+	name := discoveryconfig.StaticSnapshotName(serverID)
+	_, err := resourceSvc.UpsertDiscoveryConfig(ownerCtx, staticSnapshotUpsertRequest(t, serverID, "snapshot-group"))
+	require.NoError(t, err)
+
+	userCtx := authorizerForDummyUser(t, ctx, types.RoleSpecV6{Allow: types.RoleConditions{Rules: []types.Rule{{
+		Resources: []string{types.KindDiscoveryConfig},
+		Verbs:     []string{types.VerbRead, types.VerbCreate, types.VerbUpdate},
+	}}}}, localClient)
+	got, err := resourceSvc.GetDiscoveryConfig(withClientVersion(userCtx, "19.0.0"), discoveryconfigpb.GetDiscoveryConfigRequest_builder{Name: name}.Build())
+	require.NoError(t, err)
+
+	_, err = resourceSvc.UpdateDiscoveryConfig(userCtx, discoveryconfigpb.UpdateDiscoveryConfigRequest_builder{DiscoveryConfig: got}.Build())
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+	require.Contains(t, err.Error(), "reserved for static snapshot")
+	_, err = resourceSvc.UpsertDiscoveryConfig(userCtx, discoveryconfigpb.UpsertDiscoveryConfigRequest_builder{DiscoveryConfig: got}.Build())
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+	require.Contains(t, err.Error(), "reserved for static snapshot")
+	_, err = resourceSvc.CreateDiscoveryConfig(userCtx, discoveryconfigpb.CreateDiscoveryConfigRequest_builder{DiscoveryConfig: got}.Build())
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+	require.Contains(t, err.Error(), "reserved for static snapshot")
+}
+
+func TestStaticSnapshotClientSupported(t *testing.T) {
+	tests := []struct {
+		name      string
+		version   string
+		supported bool
+		wantErr   bool
+	}{
+		{name: "older stable", version: "18.5.0"},
+		{name: "v19 prealpha before feature", version: "19.0.0-prealpha.1"},
+		{name: "v19 current prealpha", version: "19.0.0-prealpha.2"},
+		{name: "v19 release candidate", version: "19.0.0-rc.1"},
+		{name: "v19 stable", version: "19.0.0", supported: true},
+		{name: "future prerelease", version: "20.0.0-prealpha.1", supported: true},
+		{name: "invalid", version: "not-semver", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := withClientVersion(t.Context(), tt.version)
+			supported, err := staticSnapshotClientSupported(ctx)
+			if tt.wantErr {
+				require.True(t, trace.IsBadParameter(err),
+					"a version that does not parse must be a BadParameter, got %v", err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.supported, supported)
+		})
+	}
+
+	supported, err := staticSnapshotClientSupported(t.Context())
+	require.NoError(t, err)
+	require.False(t, supported,
+		"clients that do not report a version must fail closed")
+}
+
+// TestStaticSnapshotPublicationDoesNotResurrectDeletedStatus covers the
+// retry-loop race where an update attempt observes an existing record
+// (merging its status into the working copy), loses the CAS race, and the
+// record is deleted before the next iteration: the create that follows must
+// publish a fresh record, not the deleted record's status.
+func TestStaticSnapshotPublicationDoesNotResurrectDeletedStatus(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, testStaticSnapshotPublicationDoesNotResurrectDeletedStatus)
+}
+
+func testStaticSnapshotPublicationDoesNotResurrectDeletedStatus(t *testing.T) {
+	const clusterName = "test-cluster"
+	serverID := uuid.NewString()
+	ctx, _, _, cfg := initSvcWithConfig(t, clusterName)
+	ownerCtx := authorizerForDiscoveryOwner(ctx, clusterName, serverID)
+
+	stale, err := discoveryconfig.NewStaticSnapshotDiscoveryConfig(serverID, discoveryconfig.Spec{DiscoveryGroup: "stale-group"})
+	require.NoError(t, err)
+	stale.Status.DiscoveredResources = 7
+	stale.SetRevision("stale-revision")
+
+	race := &snapshotDeletionRaceBackend{stale: stale}
+	cfg.StaticSnapshotBackend = race
+	resourceSvc := newService(t, cfg)
+
+	// The lost CAS race parks the retry loop on its backoff timer; the
+	// bubble's fake clock advances past it without real sleeping.
+	_, err = resourceSvc.UpsertDiscoveryConfig(ownerCtx, staticSnapshotUpsertRequest(t, serverID, "fresh-group"))
+	require.NoError(t, err)
+	require.NotNil(t, race.created)
+	require.Equal(t, "fresh-group", race.created.GetDiscoveryGroup())
+	require.Zero(t, race.created.Status.DiscoveredResources,
+		"a fresh publication must not resurrect status from a deleted record")
+	require.Empty(t, race.created.Status.ServerStatus)
+	require.Empty(t, race.created.GetRevision())
+}
+
+// snapshotDeletionRaceBackend scripts the deletion race: the first Get
+// returns a pre-existing record, the update attempt against it loses the CAS
+// race, and every later Get reports the record gone so the retry takes the
+// create branch.
+type snapshotDeletionRaceBackend struct {
+	services.StaticSnapshotDiscoveryConfigs
+	stale   *discoveryconfig.DiscoveryConfig
+	gets    int
+	created *discoveryconfig.DiscoveryConfig
+}
+
+func (b *snapshotDeletionRaceBackend) GetStaticSnapshotDiscoveryConfig(ctx context.Context, name string) (*discoveryconfig.DiscoveryConfig, error) {
+	b.gets++
+	if b.gets == 1 {
+		return b.stale, nil
+	}
+	return nil, trace.NotFound("static snapshot discovery config %q not found", name)
+}
+
+func (b *snapshotDeletionRaceBackend) ConditionalUpdateStaticSnapshotDiscoveryConfig(ctx context.Context, dc *discoveryconfig.DiscoveryConfig) (*discoveryconfig.DiscoveryConfig, error) {
+	return nil, trace.CompareFailed("concurrent write")
+}
+
+func (b *snapshotDeletionRaceBackend) CreateStaticSnapshotDiscoveryConfig(ctx context.Context, dc *discoveryconfig.DiscoveryConfig) (*discoveryconfig.DiscoveryConfig, error) {
+	b.created = dc.Clone()
+	return dc, nil
+}
+
+// TestStaticSnapshotPublicationRetryExhaustion pins the error category of an
+// exhausted publication CAS loop: CompareFailed, matching the status loops,
+// with LimitExceeded reserved for the stored-size cap. A publisher relies on
+// the distinction to tell write contention (retry soon) from an oversized
+// record (shrink first).
+func TestStaticSnapshotPublicationRetryExhaustion(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, testStaticSnapshotPublicationRetryExhaustion)
+}
+
+func testStaticSnapshotPublicationRetryExhaustion(t *testing.T) {
+	const clusterName = "test-cluster"
+	serverID := uuid.NewString()
+	ctx, _, resourceSvc, cfg := initSvcWithConfig(t, clusterName)
+	ownerCtx := authorizerForDiscoveryOwner(ctx, clusterName, serverID)
+	name := discoveryconfig.StaticSnapshotName(serverID)
+	_, err := resourceSvc.UpsertDiscoveryConfig(ownerCtx, staticSnapshotUpsertRequest(t, serverID, "group"))
+	require.NoError(t, err)
+	before, err := cfg.StaticSnapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, name)
+	require.NoError(t, err)
+
+	baseSnapshotBackend := cfg.StaticSnapshotBackend
+	failingBackend := &alwaysCompareFailedSnapshotBackend{StaticSnapshotDiscoveryConfigs: baseSnapshotBackend}
+	cfg.StaticSnapshotBackend = failingBackend
+	resourceSvc = newService(t, cfg)
+
+	// The bubble's fake clock walks the retry loop through its backoff
+	// timers, so exhaustion needs no goroutine or clock choreography.
+	_, err = resourceSvc.UpsertDiscoveryConfig(ownerCtx, staticSnapshotUpsertRequest(t, serverID, "contended-group"))
+	require.True(t, trace.IsCompareFailed(err), "got %v", err)
+	require.False(t, trace.IsLimitExceeded(err),
+		"contention exhaustion must not share the oversized-record category")
+	require.Equal(t, discoveryConfigWriteAttempts, failingBackend.attempts)
+
+	after, err := baseSnapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, name)
+	require.NoError(t, err)
+	require.Equal(t, before.Spec, after.Spec, "exhausted retries must not alter the stored spec")
+	require.Equal(t, before.Expiry(), after.Expiry(), "exhausted retries must not alter the stored expiry")
+	require.Equal(t, before.GetRevision(), after.GetRevision(), "exhausted retries must not alter the stored revision")
+}
+
+// TestStaticSnapshotStatusRetryExhaustion pins the bounded status CAS loop:
+// exactly discoveryConfigWriteAttempts attempts, a CompareFailed terminal
+// category, and an unchanged stored record afterward.
+func TestStaticSnapshotStatusRetryExhaustion(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, testStaticSnapshotStatusRetryExhaustion)
+}
+
+func testStaticSnapshotStatusRetryExhaustion(t *testing.T) {
+	const clusterName = "test-cluster"
+	serverID := uuid.NewString()
+	ctx, _, resourceSvc, cfg := initSvcWithConfig(t, clusterName)
+	ownerCtx := authorizerForDiscoveryOwner(ctx, clusterName, serverID)
+	name := discoveryconfig.StaticSnapshotName(serverID)
+	_, err := resourceSvc.UpsertDiscoveryConfig(ownerCtx, staticSnapshotUpsertRequest(t, serverID, "group"))
+	require.NoError(t, err)
+	before, err := cfg.StaticSnapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, name)
+	require.NoError(t, err)
+
+	baseSnapshotBackend := cfg.StaticSnapshotBackend
+	failingBackend := &alwaysCompareFailedSnapshotBackend{StaticSnapshotDiscoveryConfigs: baseSnapshotBackend}
+	cfg.StaticSnapshotBackend = failingBackend
+	resourceSvc = newService(t, cfg)
+
+	// The bubble's fake clock walks the retry loop through its backoff
+	// timers, so exhaustion needs no goroutine or clock choreography.
+	_, err = resourceSvc.UpdateDiscoveryConfigStatus(ownerCtx, discoveryconfigpb.UpdateDiscoveryConfigStatusRequest_builder{
+		Name:   name,
+		Status: discoveryconfigpb.DiscoveryConfigStatus_builder{DiscoveredResources: 42}.Build(),
+	}.Build())
+	require.True(t, trace.IsCompareFailed(err), "got %v", err)
+	require.Equal(t, discoveryConfigWriteAttempts, failingBackend.attempts)
+
+	after, err := baseSnapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, name)
+	require.NoError(t, err)
+	require.Equal(t, before.Spec, after.Spec, "exhausted retries must not alter the stored spec")
+	require.Equal(t, before.Status.DiscoveredResources, after.Status.DiscoveredResources, "exhausted retries must not alter the stored report counters")
+	require.Equal(t, before.Status.ServerStatus, after.Status.ServerStatus, "exhausted retries must not alter the stored server reports")
+	require.Equal(t, before.Expiry(), after.Expiry(), "exhausted retries must not alter the stored expiry")
+	require.Equal(t, before.GetRevision(), after.GetRevision(), "exhausted retries must not alter the stored revision")
+}
+
+// TestStaticSnapshotStatusRetryCancellation pins that context cancellation
+// wins over the retry backoff timer: the RPC returns the context error after
+// exactly one attempt instead of burning the remaining retries.
+func TestStaticSnapshotStatusRetryCancellation(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, testStaticSnapshotStatusRetryCancellation)
+}
+
+func testStaticSnapshotStatusRetryCancellation(t *testing.T) {
+	const clusterName = "test-cluster"
+	serverID := uuid.NewString()
+	ctx, _, resourceSvc, cfg := initSvcWithConfig(t, clusterName)
+	ownerCtx := authorizerForDiscoveryOwner(ctx, clusterName, serverID)
+	name := discoveryconfig.StaticSnapshotName(serverID)
+	_, err := resourceSvc.UpsertDiscoveryConfig(ownerCtx, staticSnapshotUpsertRequest(t, serverID, "group"))
+	require.NoError(t, err)
+
+	failingBackend := &alwaysCompareFailedSnapshotBackend{StaticSnapshotDiscoveryConfigs: cfg.StaticSnapshotBackend}
+	cfg.StaticSnapshotBackend = failingBackend
+	resourceSvc = newService(t, cfg)
+	canceledCtx, cancel := context.WithCancel(ownerCtx)
+	result := make(chan error, 1)
+	go func() {
+		_, err := resourceSvc.UpdateDiscoveryConfigStatus(canceledCtx, discoveryconfigpb.UpdateDiscoveryConfigStatusRequest_builder{
+			Name: name,
+		}.Build())
+		result <- err
+	}()
+	// Wait until the RPC is durably parked on the first retry timer,
+	// then cancel while it waits: the cancellation must win over the
+	// timer instead of the clock advancing past it.
+	synctest.Wait()
+	cancel()
+	err = <-result
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, failingBackend.attempts, "cancellation must stop before the first retry")
+}
+
+type alwaysCompareFailedSnapshotBackend struct {
+	services.StaticSnapshotDiscoveryConfigs
+	attempts int
+}
+
+func (b *alwaysCompareFailedSnapshotBackend) ConditionalUpdateStaticSnapshotDiscoveryConfig(context.Context, *discoveryconfig.DiscoveryConfig) (*discoveryconfig.DiscoveryConfig, error) {
+	b.attempts++
+	return nil, trace.CompareFailed("concurrent write")
+}
+
+func TestStaticSnapshotGenericReadAndDeletion(t *testing.T) {
+	t.Parallel()
+	const clusterName = "test-cluster"
+	serverID := uuid.NewString()
+	ctx, localClient, resourceSvc, cfg := initSvcWithConfig(t, clusterName)
+	ownerCtx := authorizerForDiscoveryOwner(ctx, clusterName, serverID)
+	name := discoveryconfig.StaticSnapshotName(serverID)
+	_, err := resourceSvc.UpsertDiscoveryConfig(ownerCtx, staticSnapshotUpsertRequest(t, serverID, "snapshot-group"))
+	require.NoError(t, err)
+
+	userCtx := authorizerForDummyUser(t, ctx, types.RoleSpecV6{Allow: types.RoleConditions{Rules: []types.Rule{{
+		Resources: []string{types.KindDiscoveryConfig},
+		Verbs:     []string{types.VerbRead, types.VerbList, types.VerbDelete},
+	}}}}, localClient)
+
+	// Clients that can decode static snapshots receive them from the legacy
+	// Get RPC.
+	got, err := resourceSvc.GetDiscoveryConfig(withClientVersion(userCtx, "19.0.0"), discoveryconfigpb.GetDiscoveryConfigRequest_builder{Name: name}.Build())
+	require.NoError(t, err)
+	require.Equal(t, discoveryconfig.SubKindStaticSnapshot, got.GetHeader().GetSubKind())
+	require.Equal(t, "snapshot-group", got.GetSpec().GetDiscoveryGroup())
+
+	// Clients that predate the static-snapshot subkind (or report no
+	// version at all) would fail decoding a group-less snapshot client-side,
+	// so they receive NotFound.
+	_, err = resourceSvc.GetDiscoveryConfig(withClientVersion(userCtx, "18.4.0"), discoveryconfigpb.GetDiscoveryConfigRequest_builder{Name: name}.Build())
+	require.True(t, trace.IsNotFound(err), "got %v", err)
+	_, err = resourceSvc.GetDiscoveryConfig(userCtx, discoveryconfigpb.GetDiscoveryConfigRequest_builder{Name: name}.Build())
+	require.True(t, trace.IsNotFound(err), "got %v", err)
+
+	// A version that does not parse surfaces as BadParameter, consistent
+	// with the regular-config downgrade path, instead of folding into the
+	// NotFound reserved for too-old clients.
+	_, err = resourceSvc.GetDiscoveryConfig(withClientVersion(userCtx, "not-semver"), discoveryconfigpb.GetDiscoveryConfigRequest_builder{Name: name}.Build())
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+
+	// The owning Discovery Service reads its own snapshot inventory-stripped
+	// (envelope and status only) so read-modify-write status reporting can
+	// merge against stored history without any channel carrying matchers
+	// back to a service.
+	report := discoveryconfigpb.DiscoveryConfigStatus_builder{DiscoveredResources: 7}.Build()
+	_, err = resourceSvc.UpdateDiscoveryConfigStatus(ownerCtx, discoveryconfigpb.UpdateDiscoveryConfigStatusRequest_builder{Name: name, Status: report}.Build())
+	require.NoError(t, err)
+	ownerGot, err := resourceSvc.GetDiscoveryConfig(ownerCtx, discoveryconfigpb.GetDiscoveryConfigRequest_builder{Name: name}.Build())
+	require.NoError(t, err)
+	require.Equal(t, discoveryconfig.SubKindStaticSnapshot, ownerGot.GetHeader().GetSubKind())
+	require.Empty(t, ownerGot.GetSpec().GetDiscoveryGroup(), "owner reads must not carry inventory")
+	require.Empty(t, ownerGot.GetSpec().GetAws(), "owner reads must not carry inventory")
+	require.Equal(t, uint64(7), ownerGot.GetStatus().GetDiscoveredResources(), "owner reads must carry stored status for merge loops")
+
+	// A foreign Discovery Service gets the unoccupied-name NotFound.
+	_, err = resourceSvc.GetDiscoveryConfig(
+		authorizerForDiscoveryOwner(ctx, clusterName, uuid.NewString()),
+		discoveryconfigpb.GetDiscoveryConfigRequest_builder{Name: name}.Build())
+	require.True(t, trace.IsNotFound(err), "got %v", err)
+
+	_, err = resourceSvc.DeleteDiscoveryConfig(userCtx, discoveryconfigpb.DeleteDiscoveryConfigRequest_builder{Name: name}.Build())
+	require.True(t, trace.IsAccessDenied(err), "got %v", err)
+
+	// Bulk deletion clears the regular store but must not reach the isolated
+	// snapshot record.
+	doomed, err := discoveryconfig.NewDiscoveryConfig(header.Metadata{Name: "regular-config"}, discoveryconfig.Spec{DiscoveryGroup: "regular-group"})
+	require.NoError(t, err)
+	_, err = cfg.Backend.CreateDiscoveryConfig(ctx, doomed)
+	require.NoError(t, err)
+	_, err = resourceSvc.DeleteAllDiscoveryConfigs(userCtx, &discoveryconfigpb.DeleteAllDiscoveryConfigsRequest{})
+	require.NoError(t, err)
+	_, err = cfg.Backend.GetDiscoveryConfig(ctx, doomed.GetName())
+	require.True(t, trace.IsNotFound(err), "got %v", err)
+	_, err = cfg.StaticSnapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, name)
+	require.NoError(t, err)
+
+	// A pre-existing regular config with the same name wins the legacy Get
+	// without affecting the isolated snapshot record.
+	regular, err := discoveryconfig.NewDiscoveryConfig(header.Metadata{Name: name}, discoveryconfig.Spec{DiscoveryGroup: "regular-group"})
+	require.NoError(t, err)
+	_, err = cfg.Backend.CreateDiscoveryConfig(ctx, regular)
+	require.NoError(t, err)
+	got, err = resourceSvc.GetDiscoveryConfig(withClientVersion(userCtx, "19.0.0"), discoveryconfigpb.GetDiscoveryConfigRequest_builder{Name: name}.Build())
+	require.NoError(t, err)
+	require.Empty(t, got.GetHeader().GetSubKind())
+	require.Equal(t, "regular-group", got.GetSpec().GetDiscoveryGroup())
+	_, err = cfg.StaticSnapshotBackend.GetStaticSnapshotDiscoveryConfig(ctx, name)
+	require.NoError(t, err)
+}
+
+// TestStaticSnapshotExistenceOnlyDisclosedToReaders pins the anti-oracle
+// contract: whether a snapshot occupies a reserved name is only revealed
+// (via the owner-managed AccessDenied on delete attempts) to callers holding
+// the read verb, who could learn it through Get anyway. Every other caller
+// receives exactly the unoccupied-name responses; Create, Update, and Upsert
+// reject every reserved name statelessly, so no RPC works as an existence
+// probe.
+func TestStaticSnapshotExistenceOnlyDisclosedToReaders(t *testing.T) {
+	t.Parallel()
+	const clusterName = "test-cluster"
+	serverID := uuid.NewString()
+	ctx, localClient, resourceSvc, cfg := initSvcWithConfig(t, clusterName)
+	ownerCtx := authorizerForDiscoveryOwner(ctx, clusterName, serverID)
+	name := discoveryconfig.StaticSnapshotName(serverID)
+	_, err := resourceSvc.UpsertDiscoveryConfig(ownerCtx, staticSnapshotUpsertRequest(t, serverID, "group"))
+	require.NoError(t, err)
+
+	writeOnlyCtx := authorizerForDummyUser(t, ctx, types.RoleSpecV6{Allow: types.RoleConditions{Rules: []types.Rule{{
+		Resources: []string{types.KindDiscoveryConfig},
+		Verbs:     []string{types.VerbCreate, types.VerbUpdate, types.VerbDelete},
+	}}}}, localClient)
+	payload, err := discoveryconfig.NewDiscoveryConfig(header.Metadata{Name: name}, discoveryconfig.Spec{DiscoveryGroup: "group"})
+	require.NoError(t, err)
+
+	_, err = resourceSvc.DeleteDiscoveryConfig(writeOnlyCtx, discoveryconfigpb.DeleteDiscoveryConfigRequest_builder{Name: name}.Build())
+	require.True(t, trace.IsNotFound(err), "got %v", err)
+	_, err = resourceSvc.CreateDiscoveryConfig(writeOnlyCtx, discoveryconfigpb.CreateDiscoveryConfigRequest_builder{DiscoveryConfig: convert.ToProto(payload)}.Build())
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+	_, err = resourceSvc.UpsertDiscoveryConfig(writeOnlyCtx, discoveryconfigpb.UpsertDiscoveryConfigRequest_builder{DiscoveryConfig: convert.ToProto(payload)}.Build())
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+	_, err = resourceSvc.UpdateDiscoveryConfig(writeOnlyCtx, discoveryconfigpb.UpdateDiscoveryConfigRequest_builder{DiscoveryConfig: convert.ToProto(payload)}.Build())
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+
+	// The snapshot store is never consulted for names outside the reserved
+	// namespace: a snapshot-backend outage must not turn an ordinary delete
+	// miss into an internal error.
+	cfg.StaticSnapshotBackend = failingSnapshotBackend{}
+	resourceSvc = newService(t, cfg)
+	_, err = resourceSvc.DeleteDiscoveryConfig(writeOnlyCtx, discoveryconfigpb.DeleteDiscoveryConfigRequest_builder{Name: "no-such-config"}.Build())
+	require.True(t, trace.IsNotFound(err), "got %v", err)
+}
+
+type failingSnapshotBackend struct {
+	services.StaticSnapshotDiscoveryConfigs
+}
+
+func (failingSnapshotBackend) GetStaticSnapshotDiscoveryConfig(context.Context, string) (*discoveryconfig.DiscoveryConfig, error) {
+	return nil, trace.Errorf("the snapshot store must not be consulted")
+}
+
+func TestRegularReservedAndLegacyNames(t *testing.T) {
+	t.Parallel()
+	ctx, localClient, resourceSvc, cfg := initSvcWithConfig(t, "test-cluster")
+	writeCtx := authorizerForDummyUser(t, ctx, types.RoleSpecV6{Allow: types.RoleConditions{Rules: []types.Rule{{
+		Resources: []string{types.KindDiscoveryConfig},
+		Verbs:     []string{types.VerbCreate, types.VerbUpdate, types.VerbDelete},
+	}}}}, localClient)
+
+	reserved, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{Name: discoveryconfig.StaticSnapshotName(uuid.NewString())},
+		discoveryconfig.Spec{DiscoveryGroup: "group"},
+	)
+	require.NoError(t, err)
+	// Every generic write to a reserved name is rejected by the stateless
+	// name-shape check with guidance to use a different name. Nothing is
+	// read from the backend, so the answer cannot depend on occupancy, and
+	// an IaC reconcile loop is not sent chasing a phantom resource
+	// (BadParameter, never AlreadyExists).
+	_, err = resourceSvc.CreateDiscoveryConfig(writeCtx, discoveryconfigpb.CreateDiscoveryConfigRequest_builder{DiscoveryConfig: convert.ToProto(reserved)}.Build())
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+	_, err = resourceSvc.UpsertDiscoveryConfig(writeCtx, discoveryconfigpb.UpsertDiscoveryConfigRequest_builder{DiscoveryConfig: convert.ToProto(reserved)}.Build())
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+	require.Contains(t, err.Error(), "recreate it under a different name")
+	_, err = resourceSvc.UpdateDiscoveryConfig(writeCtx, discoveryconfigpb.UpdateDiscoveryConfigRequest_builder{DiscoveryConfig: convert.ToProto(reserved)}.Build())
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+	_, err = resourceSvc.DeleteDiscoveryConfig(writeCtx, discoveryconfigpb.DeleteDiscoveryConfigRequest_builder{Name: reserved.GetName()}.Build())
+	require.True(t, trace.IsNotFound(err), "got %v", err)
+
+	// A reserved-shaped regular config predating the reservation keeps its
+	// read/delete contract, but its spec is frozen: the same stateless
+	// rejection answers every write, occupied or not, and the rejected
+	// writes leave the stored record untouched.
+	_, err = cfg.Backend.CreateDiscoveryConfig(ctx, reserved)
+	require.NoError(t, err)
+	_, err = resourceSvc.CreateDiscoveryConfig(writeCtx, discoveryconfigpb.CreateDiscoveryConfigRequest_builder{DiscoveryConfig: convert.ToProto(reserved)}.Build())
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+
+	reserved.Spec.DiscoveryGroup = "updated-group"
+	_, err = resourceSvc.UpdateDiscoveryConfig(writeCtx, discoveryconfigpb.UpdateDiscoveryConfigRequest_builder{DiscoveryConfig: convert.ToProto(reserved)}.Build())
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+	_, err = resourceSvc.UpsertDiscoveryConfig(writeCtx, discoveryconfigpb.UpsertDiscoveryConfigRequest_builder{DiscoveryConfig: convert.ToProto(reserved)}.Build())
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+	stored, err := cfg.Backend.GetDiscoveryConfig(ctx, reserved.GetName())
+	require.NoError(t, err)
+	require.Equal(t, "group", stored.GetDiscoveryGroup(), "rejected writes must leave the frozen spec untouched")
+
+	// The migration path the rejection error spells out: deletion still
+	// works, exactly once, and the name then keeps the unoccupied contract.
+	_, err = resourceSvc.DeleteDiscoveryConfig(writeCtx, discoveryconfigpb.DeleteDiscoveryConfigRequest_builder{Name: reserved.GetName()}.Build())
+	require.NoError(t, err)
+	_, err = resourceSvc.CreateDiscoveryConfig(writeCtx, discoveryconfigpb.CreateDiscoveryConfigRequest_builder{DiscoveryConfig: convert.ToProto(reserved)}.Build())
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+	require.Contains(t, err.Error(), "recreate it under a different name")
+	_, err = resourceSvc.UpsertDiscoveryConfig(writeCtx, discoveryconfigpb.UpsertDiscoveryConfigRequest_builder{DiscoveryConfig: convert.ToProto(reserved)}.Build())
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+	_, err = resourceSvc.UpdateDiscoveryConfig(writeCtx, discoveryconfigpb.UpdateDiscoveryConfigRequest_builder{DiscoveryConfig: convert.ToProto(reserved)}.Build())
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+	_, err = resourceSvc.DeleteDiscoveryConfig(writeCtx, discoveryconfigpb.DeleteDiscoveryConfigRequest_builder{Name: reserved.GetName()}.Build())
+	require.True(t, trace.IsNotFound(err), "got %v", err)
+
+	legacy, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{Name: "static-snapshot-aws-prod"},
+		discoveryconfig.Spec{DiscoveryGroup: "group"},
+	)
+	require.NoError(t, err)
+	_, err = resourceSvc.CreateDiscoveryConfig(writeCtx, discoveryconfigpb.CreateDiscoveryConfigRequest_builder{DiscoveryConfig: convert.ToProto(legacy)}.Build())
+	require.NoError(t, err)
+	legacy.Spec.DiscoveryGroup = "updated"
+	_, err = resourceSvc.UpdateDiscoveryConfig(writeCtx, discoveryconfigpb.UpdateDiscoveryConfigRequest_builder{DiscoveryConfig: convert.ToProto(legacy)}.Build())
+	require.NoError(t, err)
+	_, err = resourceSvc.UpsertDiscoveryConfig(writeCtx, discoveryconfigpb.UpsertDiscoveryConfigRequest_builder{DiscoveryConfig: convert.ToProto(legacy)}.Build())
+	require.NoError(t, err)
+}
+
+// TestRegularStatusUpdateDoesNotClobberConcurrentSpecEdit pins the regular
+// status path's revision-checked write: a status report whose working copy
+// was fetched before a concurrent matcher edit must lose the CAS race and
+// retry from the edited config, not silently revert the user's edit.
+func TestRegularStatusUpdateDoesNotClobberConcurrentSpecEdit(t *testing.T) {
+	t.Parallel()
+	const clusterName = "test-cluster"
+	serverID := uuid.NewString()
+	ctx, _, _, cfg := initSvcWithConfig(t, clusterName)
+
+	dc, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{Name: "racy-config"},
+		discoveryconfig.Spec{DiscoveryGroup: "original-group"},
+	)
+	require.NoError(t, err)
+	_, err = cfg.Backend.CreateDiscoveryConfig(ctx, dc)
+	require.NoError(t, err)
+
+	baseBackend := cfg.Backend
+	racingBackend := &regularUpdateHookBackend{DiscoveryConfigsInternal: baseBackend}
+	racingBackend.beforeConditionalUpdate = func() error {
+		current, err := baseBackend.GetDiscoveryConfig(ctx, dc.GetName())
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		current.Spec.DiscoveryGroup = "edited-group"
+		_, err = baseBackend.UpdateDiscoveryConfig(ctx, current)
+		return trace.Wrap(err)
+	}
+	cfg.Backend = racingBackend
+	resourceSvc := newService(t, cfg)
+
+	report := discoveryconfigpb.DiscoveryConfigStatus_builder{DiscoveredResources: 42}.Build()
+	_, err = resourceSvc.UpdateDiscoveryConfigStatus(
+		authorizerForDiscoveryOwner(ctx, clusterName, serverID),
+		discoveryconfigpb.UpdateDiscoveryConfigStatusRequest_builder{Name: dc.GetName(), Status: report}.Build(),
+	)
+	require.NoError(t, err)
+
+	stored, err := baseBackend.GetDiscoveryConfig(ctx, dc.GetName())
+	require.NoError(t, err)
+	require.Equal(t, "edited-group", stored.GetDiscoveryGroup(),
+		"a stale status write must not revert a concurrent spec edit")
+	require.Equal(t, uint64(42), stored.Status.DiscoveredResources)
+}
+
+func TestDeletedGrandfatheredConfigStatusReturnsNotFound(t *testing.T) {
+	t.Parallel()
+	const clusterName = "test-cluster"
+	serverID := uuid.NewString()
+	ctx, _, resourceSvc, cfg := initSvcWithConfig(t, clusterName)
+	name := discoveryconfig.StaticSnapshotName(uuid.NewString())
+
+	regular, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{Name: name},
+		discoveryconfig.Spec{DiscoveryGroup: "group"},
+	)
+	require.NoError(t, err)
+	_, err = cfg.Backend.CreateDiscoveryConfig(ctx, regular)
+	require.NoError(t, err)
+	require.NoError(t, cfg.Backend.DeleteDiscoveryConfig(ctx, name))
+
+	_, err = resourceSvc.UpdateDiscoveryConfigStatus(
+		authorizerForDiscoveryOwner(ctx, clusterName, serverID),
+		discoveryconfigpb.UpdateDiscoveryConfigStatusRequest_builder{Name: name}.Build(),
+	)
+	require.True(t, trace.IsNotFound(err), "got %v", err)
+}
+
+type regularUpdateHookBackend struct {
+	services.DiscoveryConfigsInternal
+	beforeConditionalUpdate func() error
+}
+
+func (b *regularUpdateHookBackend) ConditionalUpdateDiscoveryConfig(ctx context.Context, dc *discoveryconfig.DiscoveryConfig) (*discoveryconfig.DiscoveryConfig, error) {
+	if b.beforeConditionalUpdate != nil {
+		beforeConditionalUpdate := b.beforeConditionalUpdate
+		b.beforeConditionalUpdate = nil
+		if err := beforeConditionalUpdate(); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	return b.DiscoveryConfigsInternal.ConditionalUpdateDiscoveryConfig(ctx, dc)
+}
+
+// staticSnapshotUpsertRequest builds the publication request a Discovery
+// Service sends: its own snapshot resource through the generic upsert RPC.
+func staticSnapshotUpsertRequest(t *testing.T, serverID, group string) *discoveryconfigpb.UpsertDiscoveryConfigRequest {
+	t.Helper()
+	dc, err := discoveryconfig.NewStaticSnapshotDiscoveryConfig(serverID, discoveryconfig.Spec{
+		DiscoveryGroup: group,
+		AWS: []types.AWSMatcher{{
+			Types: []string{types.AWSMatcherEC2}, Regions: []string{"us-east-1"},
+		}},
+	})
+	require.NoError(t, err)
+	return discoveryconfigpb.UpsertDiscoveryConfigRequest_builder{DiscoveryConfig: convert.ToProto(dc)}.Build()
+}
+
+// withClientVersion stamps the incoming gRPC client version metadata the
+// service's version gate reads.
+func withClientVersion(ctx context.Context, version string) context.Context {
+	return grpcmetadata.NewIncomingContext(ctx, grpcmetadata.Pairs(metadata.VersionKey, version))
+}
+
+type snapshotUpdateHookBackend struct {
+	services.StaticSnapshotDiscoveryConfigs
+	hook func() error
+}
+
+func (b *snapshotUpdateHookBackend) ConditionalUpdateStaticSnapshotDiscoveryConfig(ctx context.Context, dc *discoveryconfig.DiscoveryConfig) (*discoveryconfig.DiscoveryConfig, error) {
+	if b.hook != nil {
+		hook := b.hook
+		b.hook = nil
+		if err := hook(); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	return b.StaticSnapshotDiscoveryConfigs.ConditionalUpdateStaticSnapshotDiscoveryConfig(ctx, dc)
 }
 
 func TestUpdateDiscoveryConfigStatus(t *testing.T) {
@@ -480,10 +1425,38 @@ func authorizerForSystemRole(ctx context.Context, systemRole string) context.Con
 	})
 }
 
+func authorizerForDiscoveryOwner(ctx context.Context, clusterName, serverID string) context.Context {
+	return authz.ContextWithUser(ctx, authz.BuiltinRole{
+		Role:        types.RoleDiscovery,
+		Username:    serverID,
+		ClusterName: clusterName,
+		Identity: tlsca.Identity{
+			Username:    serverID + "." + clusterName,
+			SystemRoles: []string{string(types.RoleDiscovery)},
+			Groups:      []string{string(types.RoleDiscovery)},
+		},
+	})
+}
+
+func authorizerForInstanceDiscoveryOwner(ctx context.Context, clusterName, serverID string) context.Context {
+	return authz.ContextWithUser(ctx, authz.BuiltinRole{
+		Role:                  types.RoleInstance,
+		AdditionalSystemRoles: types.SystemRoles{types.RoleDiscovery},
+		Username:              serverID,
+		ClusterName:           clusterName,
+		Identity: tlsca.Identity{
+			Username:    serverID + "." + clusterName,
+			SystemRoles: []string{string(types.RoleInstance), string(types.RoleDiscovery)},
+			Groups:      []string{string(types.RoleInstance), string(types.RoleDiscovery)},
+		},
+	})
+}
+
 type localClient interface {
 	CreateUser(ctx context.Context, user types.User) (types.User, error)
 	CreateRole(ctx context.Context, role types.Role) (types.Role, error)
 	CreateDiscoveryConfig(ctx context.Context, dc *discoveryconfig.DiscoveryConfig) (*discoveryconfig.DiscoveryConfig, error)
+	ListDiscoveryConfigs(ctx context.Context, pageSize int, pageToken string) ([]*discoveryconfig.DiscoveryConfig, string, error)
 }
 
 type testClient struct {
@@ -495,6 +1468,26 @@ type testClient struct {
 }
 
 func initSvc(t *testing.T, clusterName string) (context.Context, localClient, *Service) {
+	ctx, lc, svc, _ := initSvcWithConfig(t, clusterName)
+	return ctx, lc, svc
+}
+
+// newService constructs a Service through the public constructor, failing the
+// test on an invalid config.
+func newService(t *testing.T, cfg ServiceConfig) *Service {
+	t.Helper()
+	svc, err := NewService(cfg)
+	require.NoError(t, err)
+	return svc
+}
+
+// initSvcWithConfig additionally returns the ServiceConfig the service was
+// built from. Tests that need doubles (failing backends, fake clocks) rebuild
+// the service through newService with an adjusted copy of that config rather
+// than assigning the returned service's unexported fields: construction
+// invariants then apply to the doubles, and the tests stay decoupled from the
+// Service struct layout.
+func initSvcWithConfig(t *testing.T, clusterName string) (context.Context, localClient, *Service, ServiceConfig) {
 	ctx := context.Background()
 	backend, err := memory.New(memory.Config{})
 	require.NoError(t, err)
@@ -531,6 +1524,11 @@ func initSvc(t *testing.T, clusterName string) (context.Context, localClient, *S
 		LockGetter: accessService,
 	})
 	require.NoError(t, err)
+	// synctest bubbles require every goroutine started inside them to exit
+	// before the bubble does; close the watcher and backend so tests can run
+	// inside synctest.Test.
+	t.Cleanup(lockWatcher.Close)
+	t.Cleanup(func() { require.NoError(t, backend.Close()) })
 
 	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
 		ClusterName: clusterName,
@@ -544,13 +1542,14 @@ func initSvc(t *testing.T, clusterName string) (context.Context, localClient, *S
 
 	emitter := events.NewDiscardEmitter()
 
-	resourceSvc, err := NewService(ServiceConfig{
-		Backend:       localResourceService,
-		Authorizer:    authorizer,
-		Emitter:       emitter,
-		UsageReporter: usagereporter.DiscardUsageReporter{},
-	})
-	require.NoError(t, err)
+	cfg := ServiceConfig{
+		Backend:               localResourceService,
+		StaticSnapshotBackend: localResourceService,
+		Authorizer:            authorizer,
+		Emitter:               emitter,
+		UsageReporter:         usagereporter.DiscardUsageReporter{},
+	}
+	resourceSvc := newService(t, cfg)
 
 	return ctx, struct {
 		*local.AccessService
@@ -560,7 +1559,7 @@ func initSvc(t *testing.T, clusterName string) (context.Context, localClient, *S
 		AccessService:          roleSvc,
 		IdentityService:        userSvc,
 		DiscoveryConfigService: localResourceService,
-	}, resourceSvc
+	}, resourceSvc, cfg
 }
 
 func TestExtractDiscoveryConfigMetadata(t *testing.T) {
@@ -593,93 +1592,40 @@ func TestExtractDiscoveryConfigMetadata(t *testing.T) {
 	require.ElementsMatch(t, []string{"aws", "azure", "gcp", "k8s"}, cloudProviders)
 }
 
+// TestDowngrade pins the AWS wildcard-region downgrade against incoming
+// client-version metadata (the previous form stamped outgoing metadata the
+// server never reads, so no version reached the code under test and both
+// cases passed vacuously).
 func TestDowngrade(t *testing.T) {
-	for _, tc := range []struct {
-		name          string
-		clientVersion string
-		input         *discoveryconfig.DiscoveryConfig
-		expected      *discoveryconfig.DiscoveryConfig
-	}{
-		{
-			name:          "no downgrade for recent client",
-			clientVersion: "18.5.0",
-			input: func() *discoveryconfig.DiscoveryConfig {
-				dc, err := discoveryconfig.NewDiscoveryConfig(
-					header.Metadata{Name: "dc1"},
-					discoveryconfig.Spec{
-						DiscoveryGroup: "group1",
-						AWS: []types.AWSMatcher{
-							{
-								Regions: []string{types.Wildcard},
-								Types:   []string{"ec2"},
-							},
-						},
-					},
-				)
-				require.NoError(t, err)
-				return dc
-			}(),
-			expected: func() *discoveryconfig.DiscoveryConfig {
-				dc, err := discoveryconfig.NewDiscoveryConfig(
-					header.Metadata{Name: "dc1"},
-					discoveryconfig.Spec{
-						DiscoveryGroup: "group1",
-						AWS: []types.AWSMatcher{
-							{
-								Regions: []string{types.Wildcard},
-								Types:   []string{"ec2"},
-							},
-						},
-					},
-				)
-				require.NoError(t, err)
-				return dc
-			}(),
-		},
-		{
-			name:          "downgrade for old client",
-			clientVersion: "18.4.2",
-			input: func() *discoveryconfig.DiscoveryConfig {
-				dc, err := discoveryconfig.NewDiscoveryConfig(
-					header.Metadata{Name: "dc1"},
-					discoveryconfig.Spec{
-						DiscoveryGroup: "group1",
-						AWS: []types.AWSMatcher{
-							{
-								Regions: []string{types.Wildcard},
-								Types:   []string{"ec2"},
-							},
-						},
-					},
-				)
-				require.NoError(t, err)
-				return dc
-			}(),
-			expected: func() *discoveryconfig.DiscoveryConfig {
-				dc, err := discoveryconfig.NewDiscoveryConfig(
-					header.Metadata{Name: "dc1"},
-					discoveryconfig.Spec{
-						DiscoveryGroup: "group1",
-						AWS: []types.AWSMatcher{
-							{
-								Regions: []string{types.Wildcard},
-								Types:   []string{"ec2"},
-							},
-						},
-					},
-				)
-				require.NoError(t, err)
-				return dc
-			}(),
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := metadata.AddMetadataToContext(t.Context(), map[string]string{
-				metadata.VersionKey: tc.clientVersion,
-			})
-			downgraded, err := MaybeDowngradeDiscoveryConfig(ctx, tc.input)
-			require.NoError(t, err)
-			require.Equal(t, tc.expected, downgraded)
-		})
+	t.Parallel()
+	wildcardDC := func() *discoveryconfig.DiscoveryConfig {
+		dc, err := discoveryconfig.NewDiscoveryConfig(
+			header.Metadata{Name: "dc1"},
+			discoveryconfig.Spec{
+				DiscoveryGroup: "group1",
+				AWS: []types.AWSMatcher{{
+					Regions: []string{types.Wildcard},
+					Types:   []string{"ec2"},
+				}},
+			},
+		)
+		require.NoError(t, err)
+		return dc
 	}
+
+	t.Run("no downgrade for recent client", func(t *testing.T) {
+		downgraded, err := MaybeDowngradeDiscoveryConfig(withClientVersion(t.Context(), "18.5.0"), wildcardDC())
+		require.NoError(t, err)
+		require.Equal(t, []string{types.Wildcard}, downgraded.Spec.AWS[0].Regions)
+	})
+
+	t.Run("downgrade for old client", func(t *testing.T) {
+		input := wildcardDC()
+		downgraded, err := MaybeDowngradeDiscoveryConfig(withClientVersion(t.Context(), "18.4.2"), input)
+		require.NoError(t, err)
+		require.Equal(t, []string{aws.AWSGlobalRegion}, downgraded.Spec.AWS[0].Regions,
+			"pre-18.5 clients must receive the wildcard region downgraded")
+		require.Equal(t, []string{types.Wildcard}, input.Spec.AWS[0].Regions,
+			"downgrading must not mutate the source resource")
+	})
 }

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -6460,12 +6460,13 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	usertaskv1pb.RegisterUserTaskServiceServer(server, userTask)
 
 	discoveryConfig, err := discoveryconfigv1.NewService(discoveryconfigv1.ServiceConfig{
-		Authorizer:    cfg.Authorizer,
-		Backend:       cfg.AuthServer.Services,
-		Clock:         cfg.AuthServer.clock,
-		Emitter:       cfg.Emitter,
-		UsageReporter: cfg.AuthServer.UsageReporter,
-		Logger:        cfg.AuthServer.logger.With(teleport.ComponentKey, "discoveryconfig_crud_service"),
+		Authorizer:            cfg.Authorizer,
+		Backend:               cfg.AuthServer.Services,
+		StaticSnapshotBackend: cfg.AuthServer.Services,
+		Clock:                 cfg.AuthServer.clock,
+		Emitter:               cfg.Emitter,
+		UsageReporter:         cfg.AuthServer.UsageReporter,
+		Logger:                cfg.AuthServer.logger.With(teleport.ComponentKey, "discoveryconfig_crud_service"),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -276,7 +276,10 @@ type InitConfig struct {
 	UserTasks services.UserTasks
 
 	// DiscoveryConfigs is a service that manages DiscoveryConfigs.
-	DiscoveryConfigs services.DiscoveryConfigs
+	DiscoveryConfigs services.DiscoveryConfigsInternal
+
+	// StaticSnapshotDiscoveryConfigs manages isolated static snapshot DiscoveryConfigs.
+	StaticSnapshotDiscoveryConfigs services.StaticSnapshotDiscoveryConfigs
 
 	// SessionTrackerService is a service that manages trackers for all active sessions.
 	SessionTrackerService services.SessionTrackerService

--- a/lib/auth/services.go
+++ b/lib/auth/services.go
@@ -56,7 +56,7 @@ type Services struct {
 	services.Integrations
 	services.IntegrationsTokenGenerator
 	services.UserTasks
-	services.DiscoveryConfigs
+	services.DiscoveryConfigsInternal
 	services.Okta
 	services.AccessListsInternal
 	services.DatabaseObjectImportRules
@@ -102,6 +102,7 @@ type Services struct {
 	services.BeamsConfigService
 	services.SubCAService
 	services.EnrollPairing
+	services.StaticSnapshotDiscoveryConfigs
 }
 
 // MFAService defines the interface for managing MFA resources in the backend.

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3176,7 +3176,7 @@ func (process *TeleportProcess) newAccessCacheForServices(cfg accesspoint.Config
 	cfg.DatabaseServices = services.DatabaseServices
 	cfg.Databases = services.Databases
 	cfg.DelegationSessions = services.DelegationSessions
-	cfg.DiscoveryConfigs = services.DiscoveryConfigs
+	cfg.DiscoveryConfigs = services.DiscoveryConfigsInternal
 	cfg.DynamicAccess = services.DynamicAccessExt
 	cfg.Events = services.Events
 	cfg.Integrations = services.Integrations

--- a/lib/services/discoveryconfig.go
+++ b/lib/services/discoveryconfig.go
@@ -45,6 +45,31 @@ type DiscoveryConfigs interface {
 	DeleteAllDiscoveryConfigs(context.Context) error
 }
 
+// DiscoveryConfigsInternal extends DiscoveryConfigs with operations available
+// only on the Auth-local store. ConditionalUpdateDiscoveryConfig deliberately
+// stays out of DiscoveryConfigs: the public UpdateDiscoveryConfig API is
+// unconditional, so remote clients cannot conform to a revision-checked
+// contract.
+type DiscoveryConfigsInternal interface {
+	DiscoveryConfigs
+	// ConditionalUpdateDiscoveryConfig updates a DiscoveryConfig resource if
+	// the revision matches, returning CompareFailed otherwise.
+	ConditionalUpdateDiscoveryConfig(context.Context, *discoveryconfig.DiscoveryConfig) (*discoveryconfig.DiscoveryConfig, error)
+}
+
+// StaticSnapshotDiscoveryConfigs is the isolated persistence API for
+// owner-managed static snapshot DiscoveryConfigs. The isolated range keeps
+// snapshots out of DiscoveryConfig watch events and generic listings; the only
+// read path is a named lookup, so the interface deliberately has no List.
+// It also has no Delete: snapshots expire when their owner stops renewing
+// them, and deleting one while its owner is active would only cause it to be
+// recreated on the next publication.
+type StaticSnapshotDiscoveryConfigs interface {
+	GetStaticSnapshotDiscoveryConfig(context.Context, string) (*discoveryconfig.DiscoveryConfig, error)
+	CreateStaticSnapshotDiscoveryConfig(context.Context, *discoveryconfig.DiscoveryConfig) (*discoveryconfig.DiscoveryConfig, error)
+	ConditionalUpdateStaticSnapshotDiscoveryConfig(context.Context, *discoveryconfig.DiscoveryConfig) (*discoveryconfig.DiscoveryConfig, error)
+}
+
 // DiscoveryConfigWithStatusUpdater defines an interface for managing DiscoveryConfig resources including updating their status.
 type DiscoveryConfigWithStatusUpdater interface {
 	DiscoveryConfigs
@@ -78,6 +103,64 @@ func MarshalDiscoveryConfig(discoveryConfig *discoveryconfig.DiscoveryConfig, op
 		discoveryConfig = &copy
 	}
 	return utils.FastMarshal(discoveryConfig)
+}
+
+// MarshalStaticSnapshotDiscoveryConfig marshals a static snapshot
+// DiscoveryConfig to its stored JSON representation and enforces the
+// complete-resource size limit, covering the spec inventory and the reported
+// status together. An accepted status can block a later, larger inventory
+// renewal only until the record TTL-expires: the fresh publication carries no
+// status, and the oversized status is then rejected against the merged record
+// instead of being re-accepted.
+//
+// Like MarshalDiscoveryConfig, the resource is validated before it is
+// serialized. On top of that, the storage boundary enforces the fail-closed
+// invariants that protect stored bytes: no installer params and the
+// stored-size cap. The sanitized check is separate because
+// CheckAndSetDefaults deliberately does not enforce it (a claimed
+// static-snapshot subkind in user-supplied YAML must not be treated as
+// sanitized; see NewDiscoveryConfigWithSubKind).
+func MarshalStaticSnapshotDiscoveryConfig(discoveryConfig *discoveryconfig.DiscoveryConfig, opts ...MarshalOption) ([]byte, error) {
+	if err := discoveryConfig.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := discoveryconfig.CheckStaticSnapshotSpecSanitized(&discoveryConfig.Spec); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	cfg, err := CollectOptions(opts)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// A shallow copy isolates the revision reset from the caller's resource.
+	record := *discoveryConfig
+	if !cfg.PreserveRevision {
+		record.SetRevision("")
+	}
+	data, err := utils.FastMarshal(&record)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if len(data) > discoveryconfig.MaxStaticSnapshotSize {
+		return nil, trace.LimitExceeded("static snapshot discovery config exceeds maximum stored size of %d bytes", discoveryconfig.MaxStaticSnapshotSize)
+	}
+	return data, nil
+}
+
+// UnmarshalStaticSnapshotDiscoveryConfig unmarshals a static snapshot from
+// its stored JSON representation. Records from the isolated snapshot range
+// are sanitized after unmarshal so the no-installer-params invariant holds
+// on every read, even for stored bytes that predate the invariant. The
+// generic UnmarshalDiscoveryConfig deliberately does not do this: it also
+// handles user-supplied YAML (tctl create), where a claimed static-snapshot
+// subkind must not silently delete a regular config's installer params; the
+// isolated backend range, not the subkind field, is the trust boundary.
+func UnmarshalStaticSnapshotDiscoveryConfig(data []byte, opts ...MarshalOption) (*discoveryconfig.DiscoveryConfig, error) {
+	dc, err := UnmarshalDiscoveryConfig(data, opts...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	discoveryconfig.SanitizeStaticSnapshotSpec(&dc.Spec)
+	return dc, nil
 }
 
 // UnmarshalDiscoveryConfig unmarshals the DiscoveryConfig resource from JSON.

--- a/lib/services/discoveryconfig_test.go
+++ b/lib/services/discoveryconfig_test.go
@@ -19,12 +19,15 @@
 package services
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 
+	"github.com/gravitational/teleport/api/constants"
 	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
@@ -78,6 +81,109 @@ func TestDiscoveryConfigMarshal(t *testing.T) {
 	actual, err := UnmarshalDiscoveryConfig(data)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
+}
+
+// TestUnmarshalPreservesInstallerParamsForClaimedSnapshotSubKind pins the
+// tctl-create trust boundary: UnmarshalDiscoveryConfig also parses
+// user-supplied YAML, so a claimed static-snapshot subkind (copy-pasted from a
+// tctl get dump, or a mistake) must not silently delete a regular config's
+// installer params. Sanitization belongs to the isolated snapshot range's
+// UnmarshalStaticSnapshotDiscoveryConfig only.
+func TestUnmarshalPreservesInstallerParamsForClaimedSnapshotSubKind(t *testing.T) {
+	dc, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{Name: "user-config"},
+		discoveryconfig.Spec{
+			DiscoveryGroup: "group",
+			AWS: []types.AWSMatcher{{
+				Types:   []string{types.AWSMatcherEC2},
+				Regions: []string{"us-east-1"},
+				Params: &types.InstallerParams{
+					JoinToken: "my-enrollment-token",
+				},
+			}},
+		},
+	)
+	require.NoError(t, err)
+	dc.SetSubKind(discoveryconfig.SubKindStaticSnapshot)
+	wantParams := dc.Spec.AWS[0].Params
+
+	data, err := MarshalDiscoveryConfig(dc)
+	require.NoError(t, err)
+
+	parsed, err := UnmarshalDiscoveryConfig(data)
+	require.NoError(t, err)
+	// The round trip must carry the claimed subkind: were the marshal to
+	// strip it, the assertions below would pass without ever exercising a
+	// config that claims to be a snapshot.
+	require.Equal(t, discoveryconfig.SubKindStaticSnapshot, parsed.GetSubKind())
+	require.Equal(t, wantParams, parsed.Spec.AWS[0].Params,
+		"user-supplied configs must keep installer params regardless of claimed subkind")
+
+	sanitized, err := UnmarshalStaticSnapshotDiscoveryConfig(data)
+	require.NoError(t, err)
+	require.Nil(t, sanitized.Spec.AWS[0].Params,
+		"the isolated snapshot range's unmarshal must sanitize")
+}
+
+func TestMarshalStaticSnapshotDiscoveryConfigSizeLimit(t *testing.T) {
+	dc, err := discoveryconfig.NewStaticSnapshotDiscoveryConfig("server-01", discoveryconfig.Spec{})
+	require.NoError(t, err)
+
+	_, err = MarshalStaticSnapshotDiscoveryConfig(dc)
+	require.NoError(t, err)
+
+	errorMessage := strings.Repeat("x", discoveryconfig.MaxStaticSnapshotSize)
+	dc.Status.ErrorMessage = &errorMessage
+	_, err = MarshalStaticSnapshotDiscoveryConfig(dc)
+	require.True(t, trace.IsLimitExceeded(err), "got %v", err)
+}
+
+// TestMarshalStaticSnapshotDiscoveryConfigRejectsInvalidUTF8Status pins the
+// failure mode of the pre-serialization copy: status strings originate in
+// cloud APIs and are not guaranteed to be valid UTF-8, which protojson
+// refuses to encode. The write must be rejected with the encoding error, not
+// panic on a nil copy the way the error-swallowing Clone() would.
+func TestMarshalStaticSnapshotDiscoveryConfigRejectsInvalidUTF8Status(t *testing.T) {
+	dc, err := discoveryconfig.NewStaticSnapshotDiscoveryConfig("server-01", discoveryconfig.Spec{})
+	require.NoError(t, err)
+
+	dc.Status.ServerStatus = map[string]*discoveryconfig.DiscoveryStatusServer{
+		"server-01": {DiscoveryStatusServer: discoveryconfigv1.DiscoveryStatusServer_builder{
+			IntegrationSummaries: map[string]*discoveryconfigv1.DiscoverSummary{
+				"bad-\xff-integration": {},
+			},
+		}.Build()},
+	}
+	_, err = MarshalStaticSnapshotDiscoveryConfig(dc)
+	require.ErrorContains(t, err, "UTF-8")
+}
+
+func TestStaticSnapshotIntegrationEC2MatcherStorageRoundtrip(t *testing.T) {
+	t.Setenv(constants.UnstableEnableEICEEnvVar, "")
+
+	dc, err := discoveryconfig.NewStaticSnapshotDiscoveryConfig("server-01", discoveryconfig.Spec{
+		AWS: []types.AWSMatcher{{
+			Types:       []string{types.AWSMatcherEC2},
+			Regions:     []string{"us-east-1"},
+			Integration: "integration",
+		}},
+		GCP: []types.GCPMatcher{{
+			Types:      []string{types.GCPMatcherCompute},
+			ProjectIDs: []string{"project"},
+		}},
+	})
+	require.NoError(t, err)
+
+	data, err := MarshalStaticSnapshotDiscoveryConfig(dc)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "\"params\"", "stored snapshots must not contain installer params")
+	got, err := UnmarshalStaticSnapshotDiscoveryConfig(data)
+	require.NoError(t, err)
+	require.Equal(t, "integration", got.Spec.AWS[0].Integration)
+	require.Nil(t, got.Spec.AWS[0].Params)
+	require.Nil(t, got.Spec.AWS[0].SSM,
+		"the storage path must not derive an SSM document the publisher never sent")
+	require.Nil(t, got.Spec.GCP[0].Params)
 }
 
 var discoveryConfigYAML = `---

--- a/lib/services/local/discoveryconfig.go
+++ b/lib/services/local/discoveryconfig.go
@@ -33,11 +33,17 @@ import (
 
 const (
 	discoveryConfigPrefix = "discovery_config"
+	// staticSnapshotDiscoveryConfigPrefix isolates owner-published static
+	// snapshots from the regular range: no DiscoveryConfig event parser
+	// watches it, so snapshots never surface through caches or watchers and
+	// cannot be consumed as dynamic matchers by Discovery Services.
+	staticSnapshotDiscoveryConfigPrefix = "static_snapshot_discovery_config"
 )
 
 // DiscoveryConfigService manages DiscoveryConfigs in the Backend.
 type DiscoveryConfigService struct {
-	svc generic.Service[*discoveryconfig.DiscoveryConfig]
+	svc         generic.Service[*discoveryconfig.DiscoveryConfig]
+	snapshotSvc generic.Service[*discoveryconfig.DiscoveryConfig]
 }
 
 // NewDiscoveryConfigService creates a new DiscoveryConfigService.
@@ -53,10 +59,40 @@ func NewDiscoveryConfigService(b backend.Backend) (*DiscoveryConfigService, erro
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	snapshotSvc, err := generic.NewService(&generic.ServiceConfig[*discoveryconfig.DiscoveryConfig]{
+		Backend:       b,
+		PageLimit:     defaults.MaxIterationLimit,
+		ResourceKind:  types.KindDiscoveryConfig,
+		BackendPrefix: backend.NewKey(staticSnapshotDiscoveryConfigPrefix),
+		MarshalFunc:   services.MarshalStaticSnapshotDiscoveryConfig,
+		UnmarshalFunc: services.UnmarshalStaticSnapshotDiscoveryConfig,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	return &DiscoveryConfigService{
-		svc: *svc,
+		svc:         *svc,
+		snapshotSvc: *snapshotSvc,
 	}, nil
+}
+
+// GetStaticSnapshotDiscoveryConfig returns the named static snapshot from the isolated range.
+func (s *DiscoveryConfigService) GetStaticSnapshotDiscoveryConfig(ctx context.Context, name string) (*discoveryconfig.DiscoveryConfig, error) {
+	r, err := s.snapshotSvc.GetResource(ctx, name)
+	return r, trace.Wrap(err)
+}
+
+// CreateStaticSnapshotDiscoveryConfig creates a static snapshot in the isolated range.
+func (s *DiscoveryConfigService) CreateStaticSnapshotDiscoveryConfig(ctx context.Context, dc *discoveryconfig.DiscoveryConfig) (*discoveryconfig.DiscoveryConfig, error) {
+	r, err := s.snapshotSvc.CreateResource(ctx, dc)
+	return r, trace.Wrap(err)
+}
+
+// ConditionalUpdateStaticSnapshotDiscoveryConfig updates a static snapshot if the revision matches.
+func (s *DiscoveryConfigService) ConditionalUpdateStaticSnapshotDiscoveryConfig(ctx context.Context, dc *discoveryconfig.DiscoveryConfig) (*discoveryconfig.DiscoveryConfig, error) {
+	r, err := s.snapshotSvc.ConditionalUpdateResource(ctx, dc)
+	return r, trace.Wrap(err)
 }
 
 // ListDiscoveryConfigs returns a paginated list of DiscoveryConfig resources.
@@ -96,6 +132,17 @@ func (s *DiscoveryConfigService) UpdateDiscoveryConfig(ctx context.Context, dc *
 	}
 
 	updated, err := s.svc.UpdateResource(ctx, dc)
+	return updated, trace.Wrap(err)
+}
+
+// ConditionalUpdateDiscoveryConfig updates a DiscoveryConfig resource if the
+// revision matches, returning CompareFailed otherwise.
+func (s *DiscoveryConfigService) ConditionalUpdateDiscoveryConfig(ctx context.Context, dc *discoveryconfig.DiscoveryConfig) (*discoveryconfig.DiscoveryConfig, error) {
+	if err := dc.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	updated, err := s.svc.ConditionalUpdateResource(ctx, dc)
 	return updated, trace.Wrap(err)
 }
 

--- a/lib/services/local/discoveryconfig_test.go
+++ b/lib/services/local/discoveryconfig_test.go
@@ -20,6 +20,7 @@ package local
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/lib/backend"
@@ -138,6 +140,84 @@ func TestDiscoveryConfigCRUD(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, nextToken)
 	require.Empty(t, out)
+}
+
+func TestStaticSnapshotDiscoveryConfigStorageIsolation(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	mem, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, mem.Close()) })
+
+	service, err := NewDiscoveryConfigService(mem)
+	require.NoError(t, err)
+
+	snapshot := newDiscoveryConfig(t, "a-snapshot")
+	snapshot.SetSubKind(discoveryconfig.SubKindStaticSnapshot)
+	snapshot.Spec.AWS = []types.AWSMatcher{{
+		Types: []string{types.AWSMatcherEC2}, Regions: []string{"us-east-1"},
+	}}
+	_, err = service.CreateStaticSnapshotDiscoveryConfig(ctx, snapshot)
+	require.NoError(t, err)
+	_, err = service.CreateDiscoveryConfig(ctx, newDiscoveryConfig(t, "b-regular"))
+	require.NoError(t, err)
+
+	// The regular range must not surface the snapshot: generic listings (and
+	// the watchers built on the regular prefix) are how Discovery Services
+	// load dynamic matchers.
+	page, nextToken, err := service.ListDiscoveryConfigs(ctx, 0, "")
+	require.NoError(t, err)
+	require.Len(t, page, 1)
+	require.Equal(t, "b-regular", page[0].GetName())
+	require.Empty(t, nextToken)
+	_, err = service.GetDiscoveryConfig(ctx, snapshot.GetName())
+	require.True(t, trace.IsNotFound(err), "got %v", err)
+
+	got, err := service.GetStaticSnapshotDiscoveryConfig(ctx, snapshot.GetName())
+	require.NoError(t, err)
+	require.Equal(t, snapshot.GetName(), got.GetName())
+	// Reads from the isolated range keep the no-installer-params invariant.
+	require.Nil(t, got.Spec.AWS[0].Params)
+}
+
+// TestStaticSnapshotDiscoveryConfigStorageSizeLimit pins the storage-layer
+// stored-size cap: it covers the complete resource, so an oversized status
+// alone rejects the write.
+func TestStaticSnapshotDiscoveryConfigStorageSizeLimit(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	mem, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, mem.Close()) })
+
+	service, err := NewDiscoveryConfigService(mem)
+	require.NoError(t, err)
+
+	oversized := newDiscoveryConfig(t, "c-oversized")
+	oversized.SetSubKind(discoveryconfig.SubKindStaticSnapshot)
+	errorMessage := strings.Repeat("x", discoveryconfig.MaxStaticSnapshotSize)
+	oversized.Status.ErrorMessage = &errorMessage
+	_, err = service.CreateStaticSnapshotDiscoveryConfig(ctx, oversized)
+	require.True(t, trace.IsLimitExceeded(err), "expected full stored resource size enforcement, got %v", err)
+}
+
+func TestDiscoveryConfigStorageRejectsUnknownSubKindWithoutGroup(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	mem, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, mem.Close()) })
+
+	service, err := NewDiscoveryConfigService(mem)
+	require.NoError(t, err)
+
+	dc := newDiscoveryConfig(t, "unknown-subkind")
+	dc.SetSubKind("some-future-subkind")
+	dc.Spec.DiscoveryGroup = ""
+	_, err = service.CreateDiscoveryConfig(ctx, dc)
+	require.True(t, trace.IsBadParameter(err), "got %v", err)
+	_, err = service.GetDiscoveryConfig(ctx, dc.GetName())
+	require.True(t, trace.IsNotFound(err), "invalid config must not be persisted, got %v", err)
 }
 
 func newDiscoveryConfig(t *testing.T, name string) *discoveryconfig.DiscoveryConfig {

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -948,7 +948,7 @@ func TestDiscoveryServer(t *testing.T) {
 				tlsServer.Auth().SetUsageReporter(reporter)
 
 				if tc.discoveryConfig != nil {
-					_, err := tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, tc.discoveryConfig)
+					_, err := tlsServer.Auth().DiscoveryConfigsInternal.CreateDiscoveryConfig(ctx, tc.discoveryConfig)
 					require.NoError(t, err)
 				}
 
@@ -994,7 +994,7 @@ func TestDiscoveryServer(t *testing.T) {
 
 				// Discovery Config Status is updated accordingly
 				if tc.wantDiscoveryConfigStatus != nil {
-					storedDiscoveryConfig, err := tlsServer.Auth().DiscoveryConfigs.GetDiscoveryConfig(ctx, tc.discoveryConfig.GetName())
+					storedDiscoveryConfig, err := tlsServer.Auth().DiscoveryConfigsInternal.GetDiscoveryConfig(ctx, tc.discoveryConfig.GetName())
 					require.NoError(t, err)
 					require.NotZero(t, storedDiscoveryConfig.Status.IntegrationDiscoveredResources, "expected at least one integration discovered resource in status")
 
@@ -2978,7 +2978,7 @@ func TestDiscoveryDatabase(t *testing.T) {
 				// Add Dynamic Matchers and wait for reconcile again
 				if tc.discoveryConfigs != nil {
 					for _, dc := range tc.discoveryConfigs(t) {
-						_, err := tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, dc)
+						_, err := tlsServer.Auth().DiscoveryConfigsInternal.CreateDiscoveryConfig(ctx, dc)
 						require.NoError(t, err)
 					}
 
@@ -3125,7 +3125,7 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		_, err = tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, dc1)
+		_, err = tlsServer.Auth().DiscoveryConfigsInternal.CreateDiscoveryConfig(ctx, dc1)
 		require.NoError(t, err)
 
 		actualDatabases, err = tlsServer.Auth().GetDatabases(ctx)
@@ -3150,7 +3150,7 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Zero(t, reporter.DiscoveryFetchEventCount())
-		_, err = tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, dc2)
+		_, err = tlsServer.Auth().DiscoveryConfigsInternal.CreateDiscoveryConfig(ctx, dc2)
 		require.NoError(t, err)
 		synctest.Wait()
 
@@ -3175,7 +3175,7 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 
 		// Removing the DiscoveryConfig: fetcher is removed and database is removed
 		// Remove DiscoveryConfig
-		err = tlsServer.Auth().DiscoveryConfigs.DeleteDiscoveryConfig(ctx, dc2.GetName())
+		err = tlsServer.Auth().DiscoveryConfigsInternal.DeleteDiscoveryConfig(ctx, dc2.GetName())
 		require.NoError(t, err)
 
 		currentEmittedEvents = reporter.DiscoveryFetchEventCount()
@@ -3731,7 +3731,7 @@ func TestAzureVMDiscovery(t *testing.T) {
 				emitter.t = t
 
 				if tc.discoveryConfig != nil {
-					_, err := tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(t.Context(), tc.discoveryConfig)
+					_, err := tlsServer.Auth().DiscoveryConfigsInternal.CreateDiscoveryConfig(t.Context(), tc.discoveryConfig)
 					require.NoError(t, err)
 				}
 
@@ -4062,7 +4062,7 @@ func TestGCPVMDiscovery(t *testing.T) {
 				emitter.t = t
 
 				if tc.discoveryConfig != nil {
-					_, err := tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, tc.discoveryConfig)
+					_, err := tlsServer.Auth().DiscoveryConfigsInternal.CreateDiscoveryConfig(ctx, tc.discoveryConfig)
 					require.NoError(t, err)
 				}
 

--- a/lib/srv/discovery/kube_integration_watcher_test.go
+++ b/lib/srv/discovery/kube_integration_watcher_test.go
@@ -445,7 +445,7 @@ func TestDiscoveryKubeIntegrationEKS(t *testing.T) {
 
 				if tc.discoveryConfig != nil {
 					dc := tc.discoveryConfig(t)
-					_, err := tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, dc)
+					_, err := tlsServer.Auth().DiscoveryConfigsInternal.CreateDiscoveryConfig(ctx, dc)
 					require.NoError(t, err)
 				}
 				synctest.Wait()

--- a/rfd/0125-dynamic-auto-discovery-config.md
+++ b/rfd/0125-dynamic-auto-discovery-config.md
@@ -6,6 +6,7 @@ state: draft
 # RFD 0125 - Dynamic Auto-Discovery Configuration
 
 Related RFDs:
+
 - RFD 57 - Automatic discovery and enrollment of AWS servers (`discovery_service` RFD)
 
 ## Required Approvers
@@ -15,9 +16,11 @@ Related RFDs:
 - Security: `@reedloden || @jentfoo`
 
 ## What
+
 Dynamically configure matchers for the Auto-Discovery service.
 
 ## Why
+
 Teleport Discover will implement a flow where users are able to install a `discovery_service` and configure it without ever leaving the WebApp.
 
 To do so, the `discovery_service` will be deployed with minimal configuration and let the user configure the matchers afterwards.
@@ -28,11 +31,13 @@ Having an almost stateless configuration eases the configuration and deployment 
 Users no longer need to log in to a machine that is running this service to change the matchers, and can do any sort of configuration from the clients (ie WebApp, `tctl`, Terraform Provider and Kubernetes Operator).
 
 ## Details
+
 There will be a new resource - `DiscoveryConfig` - which will be used by the `discovery_service` to add extra matchers for that particular service.
 
 `discovery_service` must support having only the `discovery_group` and still run, even if no `DiscoveryConfig` matches that group.
 
 ### New `DiscoveryConfig` resource
+
 A new resource will be created to store the desired matchers.
 
 The `spec` schema will contain a `discovery_group` and a list of matchers.
@@ -41,6 +46,7 @@ The `discovery_group` will be used by `discovery_service` to include matchers fr
 
 The list of matchers is the same list that exists in `discovery_service` (for AWS, Azure and GCP).
 Currently, that list is composed using the following matchers:
+
 - `lib/config.AWSMatcher`
 - `lib/config.AzureMatcher`
 - `lib/config.GCPMatcher`
@@ -51,32 +57,33 @@ This way, we have a single place where we define the matchers properties.
 They are then used when loading the configuration from file or when defining `DiscoveryConfig` resources.
 
 Example:
+
 ```yaml
 kind: DiscoveryConfig
 version: v1
 metadata:
   name: production-resources
 spec:
-    discovery_group: prod-resources-all-clouds
-    aws:
-     - types: ["ec2"]
-       regions: ["us-east-1","us-west-1"]
-       tags:
-         "*": "*"
-       install:
-         join_params:
-           token_name:  "aws-discovery-iam-token"
-         script_name: "default-installer"
-       ssm:
-         document_name: "TeleportDiscoveryInstaller"
-    azure:
+  discovery_group: prod-resources-all-clouds
+  aws:
+    - types: ["ec2"]
+      regions: ["us-east-1", "us-west-1"]
+      tags:
+        "*": "*"
+      install:
+        join_params:
+          token_name: "aws-discovery-iam-token"
+        script_name: "default-installer"
+      ssm:
+        document_name: "TeleportDiscoveryInstaller"
+  azure:
     - types: ["aks"]
       regions: ["eastus", "westus"]
       subscriptions: ["11111111-2222-3333-4444-555555555555"]
       resource_groups: ["group1", "group2"]
       tags:
         "*": "*"
-    gcp:
+  gcp:
     - types: ["gke"]
       locations: ["*"]
       tags:
@@ -85,11 +92,13 @@ spec:
 ```
 
 ### Discovery Group
+
 The Discovery Group is used to match between `discovery_service` and `DiscoveryConfig`.
 
 So, all `discovery_service`s with Group _X_ will include all the matchers from `DiscoveryConfig`s whose Group is also _X_.
 
 ### Hot-reloading `DiscoveryConfig` matchers
+
 When the `discovery_service` starts, it loads all the static matchers plus the dynamic ones (using `DiscoveryConfig` resources).
 
 When the user changes (either creating, deleting or updating) a `DiscoveryConfig`, the `discovery_service` must update its discovery matchers.
@@ -129,6 +138,7 @@ To achieve this, `discovery_service` must create a Watcher over the `DiscoveryCo
 ```
 
 ### Proto Specification for `DiscoveryConfig`
+
 `DiscoveryConfig` will have the following protobuf specification
 
 ```proto
@@ -251,14 +261,17 @@ message GCPMatcher {
 ### Backward Compatibility
 
 #### Watcher on `DiscoveryConfig`
+
 If the `discovery_service` tries to lookup `DiscoveryConfig` resources, but Teleport Auth/Proxy is not yet aware of this resource, then `discovery_service` will log a warning but continue with the static configuration.
 
 ### UX
 
 #### `discovery_service` new service configuration properties
+
 Users need to ensure the `discovery_group` (which is optional) is set, in order for it to include extra matchers from `DiscoveryConfig`.
 
 Example:
+
 ```yaml
 discovery_service:
   enabled: "yes"
@@ -266,7 +279,9 @@ discovery_service:
 ```
 
 #### gRPC: manage `DiscoveryConfig` resource
+
 The following methods will be created in the gRPC server to allow `DiscoveryConfig` resource management:
+
 ```proto
 // DiscoveryConfigService provides methods to manage DiscoveryConfig resources.
 // These resources are used by `discovery_service` to set up the matchers.
@@ -292,7 +307,9 @@ service DiscoveryConfigService {
 ```
 
 #### WebAPI: manage `DiscoveryConfig` resource
+
 The following endpoints must be create to be used by WebAPI:
+
 ```
 Methods:
 GET .../discoveryconfig
@@ -303,102 +320,122 @@ DELETE .../discoveryconfig/:id
 ```
 
 JSON representation:
+
 ```json
 {
-   "discovery_group": "prod-resources-all-clouds",
-   "aws":[
-      {
-         "types":[
-            "ec2"
-         ],
-         "regions":[
-            "us-east-1",
-            "us-west-1"
-         ],
-         "tags":{
-            "*":"*"
-         },
-         "install":{
-            "join_params":{
-               "token_name":"aws-discovery-iam-token"
-            },
-            "script_name":"default-installer"
-         },
-         "ssm":{
-            "document_name":"TeleportDiscoveryInstaller"
-         }
+  "discovery_group": "prod-resources-all-clouds",
+  "aws": [
+    {
+      "types": ["ec2"],
+      "regions": ["us-east-1", "us-west-1"],
+      "tags": {
+        "*": "*"
+      },
+      "install": {
+        "join_params": {
+          "token_name": "aws-discovery-iam-token"
+        },
+        "script_name": "default-installer"
+      },
+      "ssm": {
+        "document_name": "TeleportDiscoveryInstaller"
       }
-   ],
-   "azure":[
-      {
-         "types":[
-            "aks"
-         ],
-         "regions":[
-            "eastus",
-            "westus"
-         ],
-         "subscriptions":[
-            "11111111-2222-3333-4444-555555555555"
-         ],
-         "resource_groups":[
-            "group1",
-            "group2"
-         ],
-         "tags":{
-            "*":"*"
-         }
+    }
+  ],
+  "azure": [
+    {
+      "types": ["aks"],
+      "regions": ["eastus", "westus"],
+      "subscriptions": ["11111111-2222-3333-4444-555555555555"],
+      "resource_groups": ["group1", "group2"],
+      "tags": {
+        "*": "*"
       }
-   ],
-   "gcp":[
-      {
-         "types":[
-            "gke"
-         ],
-         "locations":[
-            "*"
-         ],
-         "tags":{
-            "*":"*"
-         },
-         "project_ids":[
-            "myproject"
-         ]
-      }
-   ]
+    }
+  ],
+  "gcp": [
+    {
+      "types": ["gke"],
+      "locations": ["*"],
+      "tags": {
+        "*": "*"
+      },
+      "project_ids": ["myproject"]
+    }
+  ]
 }
 ```
 
 #### `tctl`: manage `DiscoveryConfig` resource
+
 Users must be able to create, list, read, update and delete `DiscoveryConfig`s using `tctl`.
 
 Example of `$ tctl get discovery_config`:
+
 ```yaml
 kind: DiscoveryConfig
 version: v1
 metadata:
   name: production-resources
 spec:
-    discovery_group: my-ec2
-    aws:
-     - types: ["ec2"]
-       regions: ["us-east-1","us-west-1"]
-       tags:
-         "*": "*"
+  discovery_group: my-ec2
+  aws:
+    - types: ["ec2"]
+      regions: ["us-east-1", "us-west-1"]
+      tags:
+        "*": "*"
 ```
 
 #### IaC - Terraform
+
 A new resource `DiscoveryConfig` must be created to allow its management from the Terraform provider.
 
 #### IaC - Kube Operator
+
 A new resource `DiscoveryConfig` must be created to allow its management from the Kube Operator.
 
 #### IaC - Helm Charts
+
 Helm charts must support the new property when setting up a `discovery_service`.
 
 ### Security
 
 #### RBAC for `DiscoveryConfig` resource
+
 The `editor` preset role will include read and write access to this new resource.
 
 The `discovery` system role (used by `discovery_service`) must be able to list and read `DiscoveryConfig` resources to be able to update the matchers of its service.
+
+### Static snapshot publication
+
+Discovery Services self-publish their static (file-based) matcher configuration as owner-managed "static snapshot" `DiscoveryConfig` resources so the backend can expose each service's effective configuration. The snapshot reuses the existing resource schema and RPC surface; no new protobuf messages or RPCs:
+
+- The resource carries `sub_kind: static-snapshot`, origin `config-file`, and the observed discovery group and sanitized matchers in the ordinary `spec`. Installer parameters are excluded from the inventory in their entirety; publication is fail-closed (an unsanitized spec is rejected), and storage reads re-sanitize loaded records so the invariant holds even for stored bytes that predate it. Validation never enriches the stored inventory: the snapshot spec is validated against a throwaway copy, so values that ordinary matcher defaulting derives (installer parameters, SSM document names, wildcard scoping such as Azure regions or GCP locations) are never persisted as if the publisher had sent them, and the stored record stays exactly the publisher's effective configuration. Inventory validation runs at the RPC boundary and again in the storage layer, which validates on every write and read like any other resource; the snapshot marshal additionally enforces the byte-level invariants, namely the absence of installer params and the stored-size cap. A service configured without a discovery group publishes an empty group: only the static-snapshot subkind relaxes the group-required validation.
+
+- Writes reuse `UpsertDiscoveryConfig`, routed before generic RBAC when the caller is a built-in Discovery Service identity and the payload carries the static-snapshot subkind. The server derives the name from the caller's server ID and rebuilds every trusted envelope field; only the spec is taken from the request. All other callers keep the regular path, which discards subkinds, so a user cannot self-declare a snapshot. On Auth servers that predate the feature, publication fails with `AccessDenied` (the Discovery role has no generic write verbs), which publishers must treat as "unsupported version."
+
+- Snapshots persist in an isolated backend range that no `DiscoveryConfig` event parser watches and generic listings never touch, so they cannot surface through caches, watchers, or `ListDiscoveryConfigs`, the channels Discovery Services use to load dynamic matchers. This isolation is what makes spec-carried matchers safe for already-released services.
+
+- Reads reuse `GetDiscoveryConfig`: regular resources first, snapshots second for reserved names. No channel carries snapshot matchers back to a Discovery Service. A service may fetch its own snapshot inventory-stripped (envelope and status only), enabling read-modify-write status reporting to merge against stored history. Foreign snapshot names return the unoccupied `NotFound`, and publication and status-update responses echo the same inventory-stripped shape.
+
+  Clients that report no version or a version older than v19.0.0 also receive `NotFound` because their unconditional validation cannot decode a group-less snapshot. All v19 prereleases count as too old: multiple builds can report the same prerelease version while straddling the feature's introduction. A client version that does not parse is rejected with `BadParameter`, consistent with the regular-config downgrade path, rather than folded into `NotFound`. Served snapshots pass through the same client-version downgrade pipeline as regular configs (a no-op today, since every current downgrade rule targets clients older than the gate). The gate itself is transition code, marked for deletion once v19 is the oldest supported client version.
+
+  The initial implementation ships named snapshot reads only, and there is intentionally no snapshot List API: generic listings, including `tctl get discovery_config`, return regular configs without combining snapshots.
+
+  Instance-driven enumeration and its presentation are follow-up work. A consumer will list the existing TTL-backed `Instance` inventory filtered to `RoleDiscovery`, derive each snapshot name from the instance's server ID, and perform bounded-concurrency named gets, treating `NotFound` as expected when an instance heartbeat precedes the first successful snapshot publication. Consumers of that follow-up will need `instance` list/read access in addition to `DiscoveryConfig` permissions.
+
+- Renewal replaces the spec and preserves the stored status; status reporting replaces the status and preserves the spec and expiry. A single stored-size cap covers the merged record. A previously accepted status can block a larger inventory renewal only until the record TTL expires: the fresh publication carries no status, after which the oversized report no longer fits and fails loudly instead of being reaccepted.
+
+  Publication and reporting run independently, so both use bounded read/merge/revision-CAS updates (a small fixed number of attempts with jittered linear backoff) rather than unconditional full-resource writes. This reuses the existing dynamic `DiscoveryConfig` reporting path. Unlike a service heartbeat with one full-resource writer, either unconditional writer could otherwise restore stale inventory or status over the other. The two failure categories stay distinct: exceeding the stored-size cap returns `LimitExceeded`, while exhausting the CAS attempts returns `CompareFailed`, so a publisher can tell an oversized record (shrink it, or wait for the TTL to clear a blocking status) from write contention (retry soon).
+
+## Namespace compatibility
+
+Names of the form `static-snapshot-<canonical-UUID>` and the equivalent hashed form (for historical non-UUID server IDs) are reserved for snapshots.
+
+Create, Update, and Upsert reject every reserved name with `BadParameter`, with guidance to recreate the config under a different name. The check is a pure name-shape test: it reads nothing from the backend, so the response is identical whether the name is occupied by a grandfathered regular config, a snapshot, or nothing; these three verbs disclose no occupancy information to any caller.
+
+A regular `DiscoveryConfig` that used a reserved name before the namespace was reserved remains readable and deletable, and continues to be served to its discovery group and to accept status reports for as long as it exists. Its spec is frozen: the migration path is to read the config, delete it, and recreate it under a non-reserved name. While such a config exists, the owner's snapshot publication remains blocked.
+
+Whether a snapshot occupies a reserved name is disclosed (via the owner-managed `AccessDenied` on delete attempts) only to callers holding the read verb, who could learn it through Get anyway. All other callers, including foreign Discovery Services using the status RPC, receive exactly the unoccupied-name responses, so no RPC works as a snapshot-existence oracle.
+
+Freezing grandfathered specs rather than supporting in-place management is a policy choice. Allowing updates would keep dual occupancy alive indefinitely and require update-only upsert semantics with deletion-race handling; the freeze makes every write verb's reserved-name behavior a stateless check and guarantees the namespace converges to its reserved owner through exactly one operator action, which the rejection error spells out.

--- a/rfd/cspell.json
+++ b/rfd/cspell.json
@@ -941,6 +941,7 @@
     "unpadded",
     "unrecovered",
     "Unregisters",
+    "unsanitized",
     "unscalable",
     "unshallow",
     "Unstarted",


### PR DESCRIPTION
This is the first of a series of PRs that combined will address both https://github.com/gravitational/teleport/issues/61937 and https://github.com/gravitational/teleport/issues/60807.

### Why

Static matchers configured in `teleport.yaml` currently have no persistent DiscoveryConfig identity. That prevents the existing DiscoveryConfig reporting and troubleshooting model from being reused for static discovery.

This PR establishes the persistence boundary, ownership, and concurrency contract required by the later publisher and reporting changes. Once reports begin (subsequent PRs), publication and reporting are independent writers:

- publication heartbeats the service's matcher inventory (spec + expiry)
- reporting owns status.

Notes:

`Services.DiscoveryConfigs` is now `Services.DiscoveryConfigsInternal`: the status and publication write paths use revision-checked updates (`ConditionalUpdateDiscoveryConfig`), which cannot live on the public `services.DiscoveryConfigs` interface because remote clients cannot implement CAS semantics over the unconditional Update RPC. `auth.Services` embeds the new interface (following the `services.PresenceInternal` pattern), and Go names embedded fields by type, so every `Auth().DiscoveryConfigs` reference renames mechanically. Test-only ripple: `authtest.go` plus nine call sites in `lib/srv/discovery` tests; no behavior change, and consumers like the cache still receive the narrow public interface via implicit narrowing.

`DiscoveryConfig` names of the form `static-snapshot-<canonical-UUID>` are reserved: they cannot be created or modified, and in the very unlikely case of a pre-existing config holding such a name in real deployment, it remains readable, deletable, and fully in service until it is recreated under a different name. I considered this edge case too unlikely to merit the machinery that would be needed to handle it in any different way, in this and in the upcoming PRs.

Why isn't this more like the Database heartbeat? Because Database heartbeat records have one writer constructing the complete record. Static snapshots have two independently scheduled writers: inventory publication and runtime reporting, so unconditional replacement is not equivalent.

### Out of scope

Follow-up PRs will add:

- the Discovery Service publisher;
- static report attribution;
- source-aware UserTasks;
- broader static/dynamic and ambient/integration parity;
- combined `tctl` and integration presentation.