### PR TITLE
gha: use kvstore instead of secrets context

### DIFF
--- a/.github/workflows/assign.yaml
+++ b/.github/workflows/assign.yaml
@@ -48,7 +48,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 02af65890b521ecdf79856c00f6d2c875bf40ea3 # workflows/v0.0.5
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
       - name: Installing Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/assign.yaml
+++ b/.github/workflows/assign.yaml
@@ -26,6 +26,7 @@ permissions:
     repository-projects: none
     security-events: none
     statuses: none
+    id-token: write
 
 jobs:
   auto-request-review:
@@ -33,6 +34,14 @@ jobs:
     if: ${{ !github.event.pull_request.draft && !startsWith(github.head_ref, 'dependabot/') }}
     runs-on: ubuntu-latest
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          values: |
+            REVIEWERS,secret
       # Checkout main branch of shared-workflow repository.
       - name: Checkout shared-workflow
         uses: actions/checkout@v6
@@ -46,4 +55,4 @@ jobs:
           go-version: 'stable'
         # Run "check" subcommand on bot.
       - name: Assigning reviewers
-        run: cd .github/shared-workflows/bot && go run main.go -workflow=assign -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=assign -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ env.REVIEWERS }}"

--- a/.github/workflows/assign.yaml
+++ b/.github/workflows/assign.yaml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -48,7 +48,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 02af65890b521ecdf79856c00f6d2c875bf40ea3 # workflows/v0.0.5
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
       - name: Installing Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -55,4 +55,4 @@ jobs:
           go-version: 'stable'
         # Run "backport" subcommand on bot.
       - name: Backport PR
-        run: ( cd .github/shared-workflows/bot && go build ) && .github/shared-workflows/bot/bot -workflow=backport -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ env.reviewers }}"
+        run: ( cd .github/shared-workflows/bot && go build ) && .github/shared-workflows/bot/bot -workflow=backport -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ env.REVIEWERS }}"

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -27,17 +27,16 @@ jobs:
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
-          existing-gh-secrets: "${{ toJSON(secrets) }}"
-          existing-gh-variables: "${{ toJSON(vars) }}"
-          # values: |
-          #   BACKPORT_APP_ID,secret
-          #   BACKPORT_PRIVATE_KEY,secret
+          values: |
+            BACKPORT_APP_ID,secret
+            BACKPORT_PRIVATE_KEY,secret
+            REVIEWERS,secret
       - name: Generate GitHub Token
         id: generate_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.BACKPORT_APP_ID }}
-          private-key: ${{ secrets.BACKPORT_PRIVATE_KEY }}
+          app-id: ${{ env.BACKPORT_APP_ID }}
+          private-key: ${{ env.BACKPORT_PRIVATE_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -56,4 +55,4 @@ jobs:
           go-version: 'stable'
         # Run "backport" subcommand on bot.
       - name: Backport PR
-        run: ( cd .github/shared-workflows/bot && go build ) && .github/shared-workflows/bot/bot -workflow=backport -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}"
+        run: ( cd .github/shared-workflows/bot && go build ) && .github/shared-workflows/bot/bot -workflow=backport -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ env.reviewers }}"

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"

--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -63,7 +63,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 02af65890b521ecdf79856c00f6d2c875bf40ea3 # workflows/v0.0.5
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
 
       - name: Setup base cache
         uses: actions/cache/restore@v5
@@ -114,7 +114,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 02af65890b521ecdf79856c00f6d2c875bf40ea3 # workflows/v0.0.5
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
 
       - name: Build Binaries
         id: build_branch

--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"

--- a/.github/workflows/build-usage-image.yaml
+++ b/.github/workflows/build-usage-image.yaml
@@ -15,10 +15,8 @@ jobs:
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
-          existing-gh-secrets: "${{ toJSON(secrets) }}"
-          existing-gh-variables: "${{ toJSON(vars) }}"
-          # values: |
-          #   TELEPORT_USAGE_IAM_ROLE_ARN,secret
+          values: |
+            TELEPORT_USAGE_IAM_ROLE_ARN,variable
       # This step is used to extract the version of the usage script.
       - name: Trim leading v in release
         id: version
@@ -28,7 +26,7 @@ jobs:
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
         with:
-          role-to-assume: ${{ secrets.TELEPORT_USAGE_IAM_ROLE_ARN }}
+          role-to-assume: ${{ env.TELEPORT_USAGE_IAM_ROLE_ARN }}
           aws-region: us-east-1
       - uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
         with:

--- a/.github/workflows/build-usage-image.yaml
+++ b/.github/workflows/build-usage-image.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -35,4 +35,4 @@ jobs:
         with:
           go-version: 'stable'
       - name: Validate the changelog entry
-        run: cd .github/shared-workflows/bot && go run main.go -workflow=changelog -token="${{ secrets.GITHUB_TOKEN }}" -reviewers='{}'"
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=changelog -token="${{ secrets.GITHUB_TOKEN }}" -reviewers='{}'

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 02af65890b521ecdf79856c00f6d2c875bf40ea3 # workflows/v0.0.5
+          ref: ffda2929b6673b2eddcdf4e43996c28ef7f43d35 # test PR commit - workflows/v0.0.5
       - name: Installing Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: ffda2929b6673b2eddcdf4e43996c28ef7f43d35 # test PR commit - workflows/v0.0.5
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
       - name: Installing Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -35,4 +35,4 @@ jobs:
         with:
           go-version: 'stable'
       - name: Validate the changelog entry
-        run: cd .github/shared-workflows/bot && go run main.go -workflow=changelog -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=changelog -token="${{ secrets.GITHUB_TOKEN }}" -reviewers='{}'"

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -65,4 +65,4 @@ jobs:
           go-version: 'stable'
         # Run "check" subcommand on bot.
       - name: Checking reviewers
-        run: cd .github/shared-workflows/bot && go run main.go -workflow=check -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ env.reviewers }}"
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=check -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ env.REVIEWERS }}"

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 02af65890b521ecdf79856c00f6d2c875bf40ea3 # workflows/v0.0.5
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
       - name: Installing Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -42,18 +42,16 @@ jobs:
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
-          existing-gh-secrets: "${{ toJSON(secrets) }}"
-          existing-gh-variables: "${{ toJSON(vars) }}"
-          # values: |
-          #   REVIEWERS_APP_ID,secret
-          #   REVIEWERS_PRIVATE_KEY,secret
-          #   REVIEWERS,secret
+          values: |
+            REVIEWERS_APP_ID,variable
+            REVIEWERS_PRIVATE_KEY,secret
+            REVIEWERS,secret
       - name: Generate GitHub Token
         id: generate_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.REVIEWERS_APP_ID }}
-          private-key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
+          app-id: ${{ env.REVIEWERS_APP_ID }}
+          private-key: ${{ env.REVIEWERS_PRIVATE_KEY }}
       # Checkout main branch of shared-workflow repository.
       - name: Checkout shared-workflow
         uses: actions/checkout@v6
@@ -67,4 +65,4 @@ jobs:
           go-version: 'stable'
         # Run "check" subcommand on bot.
       - name: Checking reviewers
-        run: cd .github/shared-workflows/bot && go run main.go -workflow=check -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}"
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=check -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ env.reviewers }}"

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"

--- a/.github/workflows/cla-assistant.yaml
+++ b/.github/workflows/cla-assistant.yaml
@@ -8,7 +8,7 @@ on:
       - opened
       - synchronize # Run on any diff changes to the PR (e.g. code updates)
   # merge_group will allow this workflow to be triggered when in merge queue.
-  # The job will end up being skipped due to conditionals below. This will be considered a "Success" 
+  # The job will end up being skipped due to conditionals below. This will be considered a "Success"
   # for the required check as the workflow was triggered but the job was skipped due to conditionals
   # See: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
   merge_group:
@@ -17,6 +17,8 @@ permissions:
   actions: read
   contents: read # this can be 'read' if the signatures are in remote repository
   pull-requests: write
+  id-token: write
+
 jobs:
   cla-assistant:
     # Only do job for pull requests. For issues this is skipped making workflow a no-op
@@ -24,12 +26,21 @@ jobs:
     name: "Check Contributor License Agreement Signed"
     runs-on: ubuntu-latest
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          values: |
+            CLA_ASSISTANT_APP_ID,variable
+            CLA_ASSISTANT_APP_PRIVATE_KEY,secret
       - name: Fetch installation token
         id: fetch-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.CLA_ASSISTANT_APP_ID }}
-          private-key: ${{ secrets.CLA_ASSISTANT_APP_PRIVATE_KEY }}
+          app-id: ${{ env.CLA_ASSISTANT_APP_ID }}
+          private-key: ${{ env.CLA_ASSISTANT_APP_PRIVATE_KEY }}
           repositories: cla-signatures
       - name: "Determine gravitational membership"
         id: get-membership
@@ -47,14 +58,14 @@ jobs:
       # Otherwise for those out of the gravitational org:
       # * CLA Assistant gathers authors from commits made to the PR
       # * Will determine if authors have already signed the CLA
-      # 
+      #
       # To sign the CLA a user can reply to the PR with the comment:
       # * 'I have read the CLA Document and I hereby sign the CLA'
       #
       # The workflow will be rerun again to perform a recheck on:
       # * Any code changes to the PR
       # * PR comment with the body being 'recheck' - In the event of a transient failure
-      # * PR comment with body 'I have read the CLA Document and I hereby sign the CLA' 
+      # * PR comment with body 'I have read the CLA Document and I hereby sign the CLA'
       - name: "CLA Assistant"
         if: steps.get-membership.outcome != 'success' && ((github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target')
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1

--- a/.github/workflows/cla-assistant.yaml
+++ b/.github/workflows/cla-assistant.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"

--- a/.github/workflows/dismiss.yaml
+++ b/.github/workflows/dismiss.yaml
@@ -50,4 +50,4 @@ jobs:
           go-version: 'stable'
         # Run "dismiss" subcommand on bot.
       - name: Dismiss
-        run: cd .github/shared-workflows/bot && go run main.go -workflow=dismiss -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=dismiss -token="${{ secrets.GITHUB_TOKEN }}" -reviewers='{}'

--- a/.github/workflows/dismiss.yaml
+++ b/.github/workflows/dismiss.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 02af65890b521ecdf79856c00f6d2c875bf40ea3 # workflows/v0.0.5
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
       - name: Installing Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Clear runtime values
         id: clear_kvstore_env
-        run: truncate -s 0 $GITHUB_ENV
+        run: echo "REVIEWERS_PRIVATE_KEY=" >> $GITHUB_ENV
 
       - name: Check out shared-workflows
         uses: actions/checkout@v6

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -87,12 +87,9 @@ jobs:
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
-          existing-gh-secrets: "${{ toJSON(secrets) }}"
-          existing-gh-variables: "${{ toJSON(vars) }}"
-          # values: |
-          #   REVIEWERS_APP_ID,secret
-          #   REVIEWERS_PRIVATE_KEY,secret
-          #   REVIEWERS,secret
+          values: |
+            REVIEWERS_APP_ID,variable
+            REVIEWERS_PRIVATE_KEY,secret
 
       - name: Check out teleport
         uses: actions/checkout@v6
@@ -110,8 +107,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.REVIEWERS_APP_ID }}
-          private-key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
+          app-id: ${{ env.REVIEWERS_APP_ID }}
+          private-key: ${{ env.REVIEWERS_PRIVATE_KEY }}
 
       - name: Check out shared-workflows
         uses: actions/checkout@v6
@@ -129,8 +126,7 @@ jobs:
       - name: Ensure docs changes include redirects
         env:
           TOKEN: ${{ steps.generate_token.outputs.token }}
-          REVIEWERS: ${{ secrets.reviewers }}
-        run: cd shared-workflows/bot && go run main.go -workflow=docpaths -token="${TOKEN}" -teleport-path="${GITHUB_WORKSPACE}/teleport" -reviewers="${REVIEWERS}"
+        run: cd shared-workflows/bot && go run main.go -workflow=docpaths -token="${TOKEN}" -teleport-path="${GITHUB_WORKSPACE}/teleport" -reviewers='{}'
 
       - name: Install Node.js
         uses: actions/setup-node@dda4788290998366da86b6a4f497909644397bb2 # v6.0.0

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -83,7 +83,7 @@ jobs:
     steps:
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -110,12 +110,16 @@ jobs:
           app-id: ${{ env.REVIEWERS_APP_ID }}
           private-key: ${{ env.REVIEWERS_PRIVATE_KEY }}
 
+      - name: Clear runtime values
+        id: clear_kvstore_env
+        run: truncate -s 0 $GITHUB_ENV
+
       - name: Check out shared-workflows
         uses: actions/checkout@v6
         with:
           repository: gravitational/shared-workflows
           path: shared-workflows
-          ref: 6f388765b8ce993721502083c74cb9af1fc5658f
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
 
       - name: Install Go
         uses: actions/setup-go@faf52423ec0d44c58f68e83b614bfcd99dded66f # v6.0.0

--- a/.github/workflows/docs-amplify.yaml
+++ b/.github/workflows/docs-amplify.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
     - name: Get runtime values from kvstore
       id: kvstore
-      uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+      uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
       with:
         cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
         cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -55,12 +55,10 @@ jobs:
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
-          existing-gh-secrets: "${{ toJSON(secrets) }}"
-          existing-gh-variables: "${{ toJSON(vars) }}"
-          # values: |
-          #   REVIEWERS_APP_ID,secret
-          #   REVIEWERS_PRIVATE_KEY,secret
-          #   REVIEWERS,secret
+          values: |
+            REVIEWERS_APP_ID,variable
+            REVIEWERS_PRIVATE_KEY,secret
+            REVIEWERS,secret
 
       - name: Checkout Teleport
         uses: actions/checkout@v6
@@ -80,8 +78,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.REVIEWERS_APP_ID }}
-          private-key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
+          app-id: ${{ env.REVIEWERS_APP_ID }}
+          private-key: ${{ env.REVIEWERS_PRIVATE_KEY }}
 
       - name: Checkout shared-workflows
         uses: actions/checkout@v6
@@ -92,7 +90,7 @@ jobs:
 
       - name: Find excluded tests
         id: find_excluded
-        run: cd .github/shared-workflows/bot && go run main.go -workflow=exclude-flakes -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}"
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=exclude-flakes -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ env.reviewers }}"
 
       - name: Run base difftest
         uses: ./.github/actions/difftest

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -49,17 +49,6 @@ jobs:
           - 3379:3379
 
     steps:
-      - name: Get runtime values from kvstore
-        id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
-        with:
-          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
-          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
-          values: |
-            REVIEWERS_APP_ID,variable
-            REVIEWERS_PRIVATE_KEY,secret
-            REVIEWERS,secret
-
       - name: Checkout Teleport
         uses: actions/checkout@v6
         with:
@@ -74,6 +63,17 @@ jobs:
       - name: Prepare unit tests
         run: make test-go-prepare
 
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          values: |
+            REVIEWERS_APP_ID,variable
+            REVIEWERS_PRIVATE_KEY,secret
+            REVIEWERS,secret
+
       - name: Generate GitHub Token
         id: generate_token
         uses: actions/create-github-app-token@v3
@@ -86,11 +86,15 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 02af65890b521ecdf79856c00f6d2c875bf40ea3 # workflows/v0.0.5
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
 
       - name: Find excluded tests
         id: find_excluded
         run: cd .github/shared-workflows/bot && go run main.go -workflow=exclude-flakes -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ env.REVIEWERS }}"
+
+      - name: Clear runtime values
+        id: clear_kvstore_env
+        run: truncate -s 0 $GITHUB_ENV
 
       - name: Run base difftest
         uses: ./.github/actions/difftest

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -94,7 +94,9 @@ jobs:
 
       - name: Clear runtime values
         id: clear_kvstore_env
-        run: truncate -s 0 $GITHUB_ENV
+        run: |
+            echo "REVIEWERS=" >> $GITHUB_ENV
+            echo "REVIEWERS_PRIVATE_KEY=" >> $GITHUB_ENV
 
       - name: Run base difftest
         uses: ./.github/actions/difftest

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Find excluded tests
         id: find_excluded
-        run: cd .github/shared-workflows/bot && go run main.go -workflow=exclude-flakes -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ env.reviewers }}"
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=exclude-flakes -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ env.REVIEWERS }}"
 
       - name: Run base difftest
         uses: ./.github/actions/difftest

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -46,4 +46,4 @@ jobs:
           go-version: 'stable'
         # Run "check" subcommand on bot.
       - name: Labeling PR
-        run: cd .github/shared-workflows/bot && go run main.go -workflow=label -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=label -token="${{ secrets.GITHUB_TOKEN }}" -reviewers='{}'

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 02af65890b521ecdf79856c00f6d2c875bf40ea3 # workflows/v0.0.5
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
       - name: Installing Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/manual-test-plan.yaml
+++ b/.github/workflows/manual-test-plan.yaml
@@ -43,11 +43,21 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write
 
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport19
 
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          values: |
+            REVIEWERS_APP_ID,variable
+            REVIEWERS_PRIVATE_KEY,secret
       - name: Checkout shared-workflows
         uses: actions/checkout@v6
         with:
@@ -59,9 +69,9 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.REVIEWERS_APP_ID }}
-          private-key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
+          app-id: ${{ env.REVIEWERS_APP_ID }}
+          private-key: ${{ env.REVIEWERS_PRIVATE_KEY }}
 
       - name: Validate Test Plan
         id: validate_test_plan
-        run: cd .github/shared-workflows/bot && go run main.go -workflow=manual-test-plan -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}"
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=manual-test-plan -token="${{ steps.generate_token.outputs.token }}" -reviewers='{}'

--- a/.github/workflows/manual-test-plan.yaml
+++ b/.github/workflows/manual-test-plan.yaml
@@ -63,7 +63,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 02af65890b521ecdf79856c00f6d2c875bf40ea3 # workflows/v0.0.5
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
 
       - name: Generate GitHub Token
         id: generate_token

--- a/.github/workflows/manual-test-plan.yaml
+++ b/.github/workflows/manual-test-plan.yaml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"

--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -10,6 +10,7 @@ on:
 # GitHub token is only used to read the repository contents for checkout.
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   renovate:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -16,12 +16,21 @@ jobs:
     name: Renovate
     runs-on: ubuntu-latest
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          values: |
+            PUBLIC_RENOVATE_GHA_APP_ID,variable
+            PUBLIC_RENOVATE_GHA_PRIVATE_KEY,secret
       - name: Generate GitHub App token
         id: generate_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.PUBLIC_RENOVATE_GHA_APP_ID }}
-          private-key: ${{ secrets.PUBLIC_RENOVATE_GHA_PRIVATE_KEY }}
+          app-id: ${{ env.PUBLIC_RENOVATE_GHA_APP_ID }}
+          private-key: ${{ env.PUBLIC_RENOVATE_GHA_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
 

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"

--- a/.github/workflows/update-ami-ids.yaml
+++ b/.github/workflows/update-ami-ids.yaml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"

--- a/.github/workflows/update-docs-webhook.yaml
+++ b/.github/workflows/update-docs-webhook.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"


### PR DESCRIPTION
Contributes to: https://github.com/gravitational/cloud/issues/14222
Requires: https://github.com/gravitational/kvstore/pull/22 before merging.

This PR replaces all usages of the `secrets` and `vars` contexts in GHA workflows, except for `post-release` GHA environment. Workflows will use runtime values retrieved from "kvstore" instead.

Validation already performed:
1. Confirmed the `env-kvstore` step is functional: observed collection of existing runtime values for migration from GHA to kvstore.
2. Two workflows have already been switched over:
- https://github.com/gravitational/teleport/pull/68450
- https://github.com/gravitational/teleport/pull/68508