### PR TITLE
[vnet] Skip rewriting /etc/resolver files when DNS config is unchanged on macOS

### DIFF
--- a/lib/vnet/osconfig_darwin.go
+++ b/lib/vnet/osconfig_darwin.go
@@ -143,9 +143,8 @@ func configureDNS(ctx context.Context, state *platformOSConfigState, nameservers
 	if state.configuredDNS != nil &&
 		bytes.Equal(state.configuredDNS.fileContents, desiredContents) &&
 		slices.Equal(state.configuredDNS.files, files) {
-		// Check managed files for size changes to catch external drift
-		// This misses same-size edits, but those should be rare.
-		if resolverFileSizesMatch(files, int64(len(desiredContents))) {
+		// Read the managed files to catch external drift
+		if resolverFilesMatch(files, desiredContents) {
 			return nil
 		}
 		log.InfoContext(ctx, "Resolver files changed externally, re-applying DNS configuration.")
@@ -202,11 +201,12 @@ func resolverFileContents(nameservers []string) []byte {
 	return fileContents.Bytes()
 }
 
-// resolverFileSizesMatch reports whether every file exists with the expected.
-func resolverFileSizesMatch(files []string, wantSize int64) bool {
+// resolverFilesMatch reports whether every managed resolver file still has
+// the expected contents.
+func resolverFilesMatch(files []string, wantContents []byte) bool {
 	for _, f := range files {
-		info, err := os.Stat(f)
-		if err != nil || info.Size() != wantSize {
+		contents, err := os.ReadFile(f)
+		if err != nil || !bytes.Equal(contents, wantContents) {
 			return false
 		}
 	}

--- a/lib/vnet/osconfig_darwin.go
+++ b/lib/vnet/osconfig_darwin.go
@@ -36,6 +36,15 @@ type platformOSConfigState struct {
 	configuredIPv6       bool
 	configuredIPv6Route  bool
 	configuredCidrRanges []string
+	configuredDNS        *appliedDNSConfig
+}
+
+// appliedDNSConfig records what configureDNS last wrote.
+type appliedDNSConfig struct {
+	// fileContents is the content written to every managed resolver file.
+	fileContents []byte
+	// files holds the sorted absolute paths of the managed resolver files.
+	files []string
 }
 
 // platformConfigureOS reconciles host OS state for cfg. It is safe
@@ -45,7 +54,7 @@ func platformConfigureOS(ctx context.Context, cfg *osConfig, state *platformOSCo
 	// IPs and routes are cleaned up when the TUN is deleted on exit,
 	// so no removal is needed.
 	if cfg.tunName == "" {
-		if err := configureDNS(ctx, cfg.dnsAddrs, cfg.dnsZones); err != nil {
+		if err := configureDNS(ctx, state, cfg.dnsAddrs, cfg.dnsZones); err != nil {
 			return trace.Wrap(err, "configuring DNS")
 		}
 		*state = platformOSConfigState{}
@@ -100,7 +109,7 @@ func platformConfigureOS(ctx context.Context, cfg *osConfig, state *platformOSCo
 		state.configuredIPv6Route = true
 	}
 
-	if err := configureDNS(ctx, cfg.dnsAddrs, cfg.dnsZones); err != nil {
+	if err := configureDNS(ctx, state, cfg.dnsAddrs, cfg.dnsZones); err != nil {
 		return trace.Wrap(err, "configuring DNS")
 	}
 
@@ -117,11 +126,29 @@ const resolverFileComment = "# automatically installed by Teleport VNet"
 
 var resolverPath = filepath.Join("/", "etc", "resolver")
 
-func configureDNS(ctx context.Context, nameservers []string, zones []string) error {
+func configureDNS(ctx context.Context, state *platformOSConfigState, nameservers []string, zones []string) error {
 	if len(nameservers) == 0 {
 		// There are no nameservers so VNet can't handle any DNS zones. Continue
 		// so that any VNet-managed resolver files can be deleted.
 		zones = nil
+	}
+
+	desiredContents := resolverFileContents(nameservers)
+	files := make([]string, 0, len(zones))
+	for _, zone := range zones {
+		files = append(files, filepath.Join(resolverPath, zone))
+	}
+	slices.Sort(files)
+
+	if state.configuredDNS != nil &&
+		bytes.Equal(state.configuredDNS.fileContents, desiredContents) &&
+		slices.Equal(state.configuredDNS.files, files) {
+		// Check managed files for size changes to catch external drift
+		// This misses same-size edits, but those should be rare.
+		if resolverFileSizesMatch(files, int64(len(desiredContents))) {
+			return nil
+		}
+		log.InfoContext(ctx, "Resolver files changed externally, re-applying DNS configuration.")
 	}
 
 	log.DebugContext(ctx, "Configuring DNS.", "nameservers", nameservers, "zones", zones)
@@ -138,18 +165,8 @@ func configureDNS(ctx context.Context, nameservers []string, zones []string) err
 	// errors with one or more of them.
 	var allErrors []error
 
-	var fileContents bytes.Buffer
-	fileContents.WriteString(resolverFileComment)
-	fileContents.WriteByte('\n')
-	for _, nameserver := range nameservers {
-		fileContents.WriteString("nameserver ")
-		fileContents.WriteString(nameserver)
-		fileContents.WriteByte('\n')
-	}
-
-	for _, zone := range zones {
-		fileName := filepath.Join(resolverPath, zone)
-		if err := renameio.WriteFile(fileName, fileContents.Bytes(), 0644); err != nil {
+	for _, fileName := range files {
+		if err := renameio.WriteFile(fileName, desiredContents, 0644); err != nil {
 			allErrors = append(allErrors, trace.Wrap(err, "writing DNS configuration file %s", fileName))
 		} else {
 			// Successfully wrote this file, don't clean it up below.
@@ -164,7 +181,36 @@ func configureDNS(ctx context.Context, nameservers []string, zones []string) err
 		}
 	}
 
+	if len(allErrors) == 0 {
+		state.configuredDNS = &appliedDNSConfig{
+			fileContents: desiredContents,
+			files:        files,
+		}
+	}
 	return trace.NewAggregate(allErrors...)
+}
+
+func resolverFileContents(nameservers []string) []byte {
+	var fileContents bytes.Buffer
+	fileContents.WriteString(resolverFileComment)
+	fileContents.WriteByte('\n')
+	for _, nameserver := range nameservers {
+		fileContents.WriteString("nameserver ")
+		fileContents.WriteString(nameserver)
+		fileContents.WriteByte('\n')
+	}
+	return fileContents.Bytes()
+}
+
+// resolverFileSizesMatch reports whether every file exists with the expected.
+func resolverFileSizesMatch(files []string, wantSize int64) bool {
+	for _, f := range files {
+		info, err := os.Stat(f)
+		if err != nil || info.Size() != wantSize {
+			return false
+		}
+	}
+	return true
 }
 
 func vnetManagedResolverFiles() (map[string]struct{}, error) {
@@ -179,18 +225,29 @@ func vnetManagedResolverFiles() (map[string]struct{}, error) {
 			continue
 		}
 		filePath := filepath.Join(resolverPath, entry.Name())
-		file, err := os.Open(filePath)
+		matches, err := fileStartsWithVNetComment(filePath)
 		if err != nil {
-			return nil, trace.Wrap(err, "opening %s", filePath)
+			return nil, trace.Wrap(err)
 		}
-		defer file.Close()
-
-		scanner := bufio.NewScanner(file)
-		if scanner.Scan() {
-			if resolverFileComment == scanner.Text() {
-				matchingFiles[filePath] = struct{}{}
-			}
+		if matches {
+			matchingFiles[filePath] = struct{}{}
 		}
 	}
 	return matchingFiles, nil
+}
+
+// fileStartsWithVNetComment reports whether the first line of the file at
+// path is the comment marking a VNet managed resolver file.
+func fileStartsWithVNetComment(path string) (bool, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return false, trace.Wrap(err, "opening %s", path)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	if !scanner.Scan() {
+		return false, trace.Wrap(scanner.Err(), "reading %s", path)
+	}
+	return scanner.Text() == resolverFileComment, nil
 }

--- a/lib/vnet/osconfig_darwin.go
+++ b/lib/vnet/osconfig_darwin.go
@@ -157,7 +157,7 @@ func configureDNS(ctx context.Context, state *platformOSConfigState, nameservers
 		return trace.Wrap(err, "creating %s", resolverPath)
 	}
 
-	managedFiles, err := vnetManagedResolverFiles()
+	managedFiles, err := vnetManagedResolverFiles(ctx)
 	if err != nil {
 		return trace.Wrap(err, "finding VNet managed files in /etc/resolver")
 	}
@@ -220,7 +220,7 @@ func resolverFilesMatch(ctx context.Context, files []string, wantContents []byte
 	return true
 }
 
-func vnetManagedResolverFiles() (map[string]struct{}, error) {
+func vnetManagedResolverFiles(ctx context.Context) (map[string]struct{}, error) {
 	entries, err := os.ReadDir(resolverPath)
 	if err != nil {
 		return nil, trace.Wrap(err, "reading %s", resolverPath)
@@ -232,7 +232,7 @@ func vnetManagedResolverFiles() (map[string]struct{}, error) {
 			continue
 		}
 		filePath := filepath.Join(resolverPath, entry.Name())
-		matches, err := fileStartsWithVNetComment(filePath)
+		matches, err := fileStartsWithVNetComment(ctx, filePath)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -244,8 +244,9 @@ func vnetManagedResolverFiles() (map[string]struct{}, error) {
 }
 
 // fileStartsWithVNetComment reports whether the first line of the file at
-// path is the comment marking a VNet managed resolver file.
-func fileStartsWithVNetComment(path string) (bool, error) {
+// path is the comment marking a VNet managed resolver file. Files whose
+// first line cannot be read are treated as not managed by VNet.
+func fileStartsWithVNetComment(ctx context.Context, path string) (bool, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return false, trace.Wrap(err, "opening %s", path)
@@ -254,7 +255,11 @@ func fileStartsWithVNetComment(path string) (bool, error) {
 
 	scanner := bufio.NewScanner(file)
 	if !scanner.Scan() {
-		return false, trace.Wrap(scanner.Err(), "reading %s", path)
+		if err := scanner.Err(); err != nil {
+			log.DebugContext(ctx, "Failed to read first line of resolver file, treating it as not managed by VNet.",
+				"file", path, "error", err)
+		}
+		return false, nil
 	}
 	return scanner.Text() == resolverFileComment, nil
 }

--- a/lib/vnet/osconfig_darwin.go
+++ b/lib/vnet/osconfig_darwin.go
@@ -126,6 +126,8 @@ const resolverFileComment = "# automatically installed by Teleport VNet"
 
 var resolverPath = filepath.Join("/", "etc", "resolver")
 
+// configureDNS writes resolver files for the zones to /etc/resolver, skipping
+// the write when nothing changed. A change in nameserver order triggers a rewrite.
 func configureDNS(ctx context.Context, state *platformOSConfigState, nameservers []string, zones []string) error {
 	if len(nameservers) == 0 {
 		// There are no nameservers so VNet can't handle any DNS zones. Continue
@@ -133,7 +135,7 @@ func configureDNS(ctx context.Context, state *platformOSConfigState, nameservers
 		zones = nil
 	}
 
-	desiredContents := resolverFileContents(nameservers)
+	desiredContents := desiredResolverFileContents(nameservers)
 	files := make([]string, 0, len(zones))
 	for _, zone := range zones {
 		files = append(files, filepath.Join(resolverPath, zone))
@@ -144,10 +146,10 @@ func configureDNS(ctx context.Context, state *platformOSConfigState, nameservers
 		bytes.Equal(state.configuredDNS.fileContents, desiredContents) &&
 		slices.Equal(state.configuredDNS.files, files) {
 		// Read the managed files to catch external drift
-		if resolverFilesMatch(files, desiredContents) {
+		if resolverFilesMatch(ctx, files, desiredContents) {
 			return nil
 		}
-		log.InfoContext(ctx, "Resolver files changed externally, re-applying DNS configuration.")
+		log.InfoContext(ctx, "Resolver files no longer match the applied DNS configuration, re-applying.")
 	}
 
 	log.DebugContext(ctx, "Configuring DNS.", "nameservers", nameservers, "zones", zones)
@@ -189,7 +191,7 @@ func configureDNS(ctx context.Context, state *platformOSConfigState, nameservers
 	return trace.NewAggregate(allErrors...)
 }
 
-func resolverFileContents(nameservers []string) []byte {
+func desiredResolverFileContents(nameservers []string) []byte {
 	var fileContents bytes.Buffer
 	fileContents.WriteString(resolverFileComment)
 	fileContents.WriteByte('\n')
@@ -203,10 +205,15 @@ func resolverFileContents(nameservers []string) []byte {
 
 // resolverFilesMatch reports whether every managed resolver file still has
 // the expected contents.
-func resolverFilesMatch(files []string, wantContents []byte) bool {
+func resolverFilesMatch(ctx context.Context, files []string, wantContents []byte) bool {
 	for _, f := range files {
 		contents, err := os.ReadFile(f)
-		if err != nil || !bytes.Equal(contents, wantContents) {
+		if err != nil {
+			log.DebugContext(ctx, "Failed to read resolver file.", "file", f, "error", err)
+			return false
+		}
+		if !bytes.Equal(contents, wantContents) {
+			log.DebugContext(ctx, "Resolver file does not have the expected contents.", "file", f)
 			return false
 		}
 	}

--- a/lib/vnet/osconfig_darwin_test.go
+++ b/lib/vnet/osconfig_darwin_test.go
@@ -17,6 +17,7 @@
 package vnet
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"os"
@@ -327,8 +328,11 @@ func TestConfigureDNSRestoresModifiedResolverFile(t *testing.T) {
 	cfg := dnsTestOSConfig()
 
 	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+	// Tamper without changing the file size to make sure drift detection
+	// doesn't rely on cheap size checks.
+	tampered := bytes.ToUpper(resolverFileContents(cfg.dnsAddrs))
 	require.NoError(t, os.WriteFile(
-		resolverFileForZone("example.com"), []byte("# tampered\n"), 0644))
+		resolverFileForZone("example.com"), tampered, 0644))
 	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
 
 	requireResolverFiles(t, cfg.dnsAddrs, "example.com", "leaf.example.com")

--- a/lib/vnet/osconfig_darwin_test.go
+++ b/lib/vnet/osconfig_darwin_test.go
@@ -19,7 +19,10 @@ package vnet
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -244,6 +247,134 @@ func TestPlatformConfigureOS_RetriesIPv6RouteAfterFailure(t *testing.T) {
 		{path: "route", args: []string{"add", "-inet6", "fdd4:a23:da97::1", "-prefixlen", "64", "-interface", "utun4"}},
 		{path: "route", args: []string{"add", "-inet6", "fdd4:a23:da97::1", "-prefixlen", "64", "-interface", "utun4"}},
 	}, recorder.cmds, "ifconfig must run only once; route must be retried")
+}
+
+func dnsTestOSConfig() *osConfig {
+	return &osConfig{
+		tunName:  "utun4",
+		tunIPv4:  "100.64.0.1",
+		dnsAddrs: []string{"100.64.0.2", "fdd4:a23:da97::2"},
+		dnsZones: []string{"example.com", "leaf.example.com"},
+	}
+}
+
+func resolverFileForZone(zone string) string {
+	return filepath.Join(resolverPath, zone)
+}
+
+func requireResolverFiles(t *testing.T, nameservers []string, zones ...string) {
+	t.Helper()
+	want := string(resolverFileContents(nameservers))
+	entries, err := os.ReadDir(resolverPath)
+	require.NoError(t, err)
+	require.Len(t, entries, len(zones))
+	for _, zone := range zones {
+		contents, err := os.ReadFile(resolverFileForZone(zone))
+		require.NoError(t, err)
+		require.Equal(t, want, string(contents))
+	}
+}
+
+func TestConfigureDNSWritesResolverFiles(t *testing.T) {
+	setupOSConfigTest(t)
+	state := &platformOSConfigState{}
+	cfg := dnsTestOSConfig()
+
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+
+	requireResolverFiles(t, cfg.dnsAddrs, "example.com", "leaf.example.com")
+}
+
+func TestConfigureDNSSkipsRewriteWhenUnchanged(t *testing.T) {
+	setupOSConfigTest(t)
+	state := &platformOSConfigState{}
+	cfg := dnsTestOSConfig()
+
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+
+	// Backdate the files; if the second call rewrote them the mtime
+	// would jump back to ~now.
+	past := time.Now().Add(-time.Hour)
+	for _, zone := range cfg.dnsZones {
+		require.NoError(t, os.Chtimes(resolverFileForZone(zone), past, past))
+	}
+
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+
+	for _, zone := range cfg.dnsZones {
+		info, err := os.Stat(resolverFileForZone(zone))
+		require.NoError(t, err)
+		require.True(t, info.ModTime().Equal(past),
+			"second call with unchanged config must not rewrite %s", zone)
+	}
+}
+
+func TestConfigureDNSRestoresDeletedResolverFile(t *testing.T) {
+	setupOSConfigTest(t)
+	state := &platformOSConfigState{}
+	cfg := dnsTestOSConfig()
+
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+	require.NoError(t, os.Remove(resolverFileForZone("example.com")))
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+
+	requireResolverFiles(t, cfg.dnsAddrs, "example.com", "leaf.example.com")
+}
+
+func TestConfigureDNSRestoresModifiedResolverFile(t *testing.T) {
+	setupOSConfigTest(t)
+	state := &platformOSConfigState{}
+	cfg := dnsTestOSConfig()
+
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+	require.NoError(t, os.WriteFile(
+		resolverFileForZone("example.com"), []byte("# tampered\n"), 0644))
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+
+	requireResolverFiles(t, cfg.dnsAddrs, "example.com", "leaf.example.com")
+}
+
+func TestConfigureDNSReappliesOnZoneChange(t *testing.T) {
+	setupOSConfigTest(t)
+	state := &platformOSConfigState{}
+	cfg := dnsTestOSConfig()
+
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+
+	cfg.dnsZones = []string{"example.com", "other.example.org"}
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+
+	requireResolverFiles(t, cfg.dnsAddrs, "example.com", "other.example.org")
+}
+
+func TestConfigureDNSDeconfigureRemovesResolverFiles(t *testing.T) {
+	setupOSConfigTest(t)
+	state := &platformOSConfigState{}
+	cfg := dnsTestOSConfig()
+
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+	require.NoError(t, platformConfigureOS(t.Context(), &osConfig{}, state))
+
+	entries, err := os.ReadDir(resolverPath)
+	require.NoError(t, err)
+	require.Empty(t, entries, "deconfigure must remove all managed resolver files")
+}
+
+func TestConfigureDNSLeavesUnmanagedFilesAlone(t *testing.T) {
+	setupOSConfigTest(t)
+	state := &platformOSConfigState{}
+	cfg := dnsTestOSConfig()
+
+	unmanaged := filepath.Join(resolverPath, "corp.internal")
+	require.NoError(t, os.WriteFile(unmanaged, []byte("nameserver 10.0.0.53\n"), 0644))
+
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+	require.NoError(t, platformConfigureOS(t.Context(), &osConfig{}, state))
+
+	contents, err := os.ReadFile(unmanaged)
+	require.NoError(t, err)
+	require.Equal(t, "nameserver 10.0.0.53\n", string(contents))
 }
 
 // Covers the typical production cfg: IPv4, IPv6 and a CIDR together.

--- a/lib/vnet/osconfig_darwin_test.go
+++ b/lib/vnet/osconfig_darwin_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -263,16 +264,17 @@ func resolverFileForZone(zone string) string {
 	return filepath.Join(resolverPath, zone)
 }
 
-func requireResolverFiles(t *testing.T, nameservers []string, zones ...string) {
+func assertResolverFiles(t *testing.T, nameservers []string, zones ...string) {
 	t.Helper()
-	want := string(resolverFileContents(nameservers))
+	want := string(desiredResolverFileContents(nameservers))
 	entries, err := os.ReadDir(resolverPath)
 	require.NoError(t, err)
-	require.Len(t, entries, len(zones))
+	assert.Len(t, entries, len(zones))
 	for _, zone := range zones {
 		contents, err := os.ReadFile(resolverFileForZone(zone))
-		require.NoError(t, err)
-		require.Equal(t, want, string(contents))
+		if assert.NoError(t, err) {
+			assert.Equal(t, want, string(contents))
+		}
 	}
 }
 
@@ -283,7 +285,7 @@ func TestConfigureDNSWritesResolverFiles(t *testing.T) {
 
 	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
 
-	requireResolverFiles(t, cfg.dnsAddrs, "example.com", "leaf.example.com")
+	assertResolverFiles(t, cfg.dnsAddrs, "example.com", "leaf.example.com")
 }
 
 func TestConfigureDNSSkipsRewriteWhenUnchanged(t *testing.T) {
@@ -319,7 +321,7 @@ func TestConfigureDNSRestoresDeletedResolverFile(t *testing.T) {
 	require.NoError(t, os.Remove(resolverFileForZone("example.com")))
 	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
 
-	requireResolverFiles(t, cfg.dnsAddrs, "example.com", "leaf.example.com")
+	assertResolverFiles(t, cfg.dnsAddrs, "example.com", "leaf.example.com")
 }
 
 func TestConfigureDNSRestoresModifiedResolverFile(t *testing.T) {
@@ -328,14 +330,12 @@ func TestConfigureDNSRestoresModifiedResolverFile(t *testing.T) {
 	cfg := dnsTestOSConfig()
 
 	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
-	// Tamper without changing the file size to make sure drift detection
-	// doesn't rely on cheap size checks.
-	tampered := bytes.ToUpper(resolverFileContents(cfg.dnsAddrs))
+	tampered := bytes.ToUpper(desiredResolverFileContents(cfg.dnsAddrs))
 	require.NoError(t, os.WriteFile(
 		resolverFileForZone("example.com"), tampered, 0644))
 	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
 
-	requireResolverFiles(t, cfg.dnsAddrs, "example.com", "leaf.example.com")
+	assertResolverFiles(t, cfg.dnsAddrs, "example.com", "leaf.example.com")
 }
 
 func TestConfigureDNSReappliesOnZoneChange(t *testing.T) {
@@ -348,7 +348,7 @@ func TestConfigureDNSReappliesOnZoneChange(t *testing.T) {
 	cfg.dnsZones = []string{"example.com", "other.example.org"}
 	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
 
-	requireResolverFiles(t, cfg.dnsAddrs, "example.com", "other.example.org")
+	assertResolverFiles(t, cfg.dnsAddrs, "example.com", "other.example.org")
 }
 
 func TestConfigureDNSDeconfigureRemovesResolverFiles(t *testing.T) {


### PR DESCRIPTION
changelog: Fixed VNet rewriting `/etc/resolver` files every 10 seconds on macOS even when the DNS configuration was unchanged, which triggered periodic Wi-Fi scans and latency spikes.


The OS configuration loop runs every 10 seconds and unconditionally reconfigured DNS on macOS, it scanned every file in /etc/resolver and rewrote every VNet-managed zone file even when nothing changed. This PR caches the last applied resolver configuration and skips the rewrite when it's unchanged.

## Manual Test Plan
### Test Environment
- macOS

### Test Cases
- [x] VNet starts, apps are reachable, /etc/resolver has a file per zone, and there are no repeated writes to /etc/resolver.