### PR TITLE
docs: fix link to mariadb/mysql rds proxy

### DIFF
--- a/docs/pages/includes/database-access/rds-proxy.mdx
+++ b/docs/pages/includes/database-access/rds-proxy.mdx
@@ -16,7 +16,7 @@
 <Admonition type="note" title="Supported Engine Family">
 Teleport currently supports RDS Proxy instances with engine family
 [PostgreSQL](../../enroll-resources/database-access/enrollment/aws/rds-proxy/rds-proxy-postgres.mdx),
-[MariaDB/MySQL](../../enroll-resources/database-access/enrollment/aws/rds-proxy/rds-proxy-postgres.mdx) or
+[MariaDB/MySQL](../../enroll-resources/database-access/enrollment/aws/rds-proxy/rds-proxy-mysql.mdx) or
 [Microsoft SQL Server](../../enroll-resources/database-access/enrollment/aws/rds-proxy/rds-proxy-sqlserver.mdx).
 </Admonition>
 


### PR DESCRIPTION
Mariadb/mysql link when to postgresql, not mariadb/mysql rds proxy.

