### PR TITLE
[v17] Forbid uses of golang.org/x/crypto/openpgp

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -156,6 +156,8 @@ linters:
                 google.golang.org/protobuf/protoadapt instead, or, better yet,
                 see if you can move the code generation for that message to the
                 modern protoc-gen-go.
+            - pkg: golang.org/x/crypto/openpgp
+              desc: use "github.com/ProtonMail/go-crypto/openpgp" instead
         test_packages:
           files:
             - '!$test'


### PR DESCRIPTION
Backport #68732 to branch/v17.