### PR TITLE
[v18] Postgres: handle backends without query cancellation

### DIFF
--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -127,9 +127,7 @@ func TestMain(m *testing.M) {
 // on the configured RBAC rules.
 func TestAccessPostgres(t *testing.T) {
 	ctx := context.Background()
-	testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres", func(db *types.DatabaseV3) {
-		db.SetStaticLabels(map[string]string{"foo": "bar"})
-	}))
+	testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres", withPostgresStaticLabels(map[string]string{"foo": "bar"})))
 	go testCtx.startHandlingConnections()
 
 	dynamicDBLabels := types.Labels{"echo": {"test"}}
@@ -2759,13 +2757,40 @@ type withDatabaseOption func(t testing.TB, ctx context.Context, testCtx *testCon
 
 type databaseOption func(*types.DatabaseV3)
 
-func withSelfHostedPostgres(name string, dbOpts ...databaseOption) withDatabaseOption {
+type testPostgresOptions struct {
+	serverOptions   []postgres.TestServerOption
+	databaseOptions []databaseOption
+}
+
+type testPostgresOption func(opts *testPostgresOptions)
+
+// withPostgresNoCancelKey makes the test server skip BackendKeyData (e.g. RDS Proxy).
+func withPostgresNoCancelKey() testPostgresOption {
+	return func(opts *testPostgresOptions) {
+		opts.serverOptions = append(opts.serverOptions, postgres.WithNoCancelKey())
+	}
+}
+
+// withPostgresStaticLabels sets static labels on the database resource.
+func withPostgresStaticLabels(labels map[string]string) testPostgresOption {
+	return func(opts *testPostgresOptions) {
+		opts.databaseOptions = append(opts.databaseOptions, func(db *types.DatabaseV3) {
+			db.SetStaticLabels(labels)
+		})
+	}
+}
+
+func withSelfHostedPostgres(name string, applyOpts ...testPostgresOption) withDatabaseOption {
 	return func(t testing.TB, ctx context.Context, testCtx *testContext) types.Database {
+		var opts testPostgresOptions
+		for _, applyOpt := range applyOpts {
+			applyOpt(&opts)
+		}
 		postgresServer, err := postgres.NewTestServer(common.TestServerConfig{
 			Name:       name,
 			AuthClient: testCtx.authClient,
 			ClientAuth: tls.RequireAndVerifyClientCert,
-		})
+		}, opts.serverOptions...)
 		require.NoError(t, err)
 		go postgresServer.Serve()
 		t.Cleanup(func() { postgresServer.Close() })
@@ -2777,7 +2802,7 @@ func withSelfHostedPostgres(name string, dbOpts ...databaseOption) withDatabaseO
 			DynamicLabels: dynamicLabels,
 		})
 		require.NoError(t, err)
-		for _, dbOpt := range dbOpts {
+		for _, dbOpt := range opts.databaseOptions {
 			dbOpt(database)
 		}
 		testCtx.postgres[name] = testPostgres{

--- a/lib/srv/db/benchmark_test.go
+++ b/lib/srv/db/benchmark_test.go
@@ -47,9 +47,7 @@ func BenchmarkPostgresReadLargeTable(b *testing.B) {
 		b.Skip("skipping heavy benchmark")
 	}
 	ctx := context.Background()
-	testCtx := setupTestContext(ctx, b, withSelfHostedPostgres("postgres", func(db *types.DatabaseV3) {
-		db.SetStaticLabels(map[string]string{"foo": "bar"})
-	}))
+	testCtx := setupTestContext(ctx, b, withSelfHostedPostgres("postgres", withPostgresStaticLabels(map[string]string{"foo": "bar"})))
 	go testCtx.startHandlingConnections()
 
 	user := "alice"

--- a/lib/srv/db/local_proxy_test.go
+++ b/lib/srv/db/local_proxy_test.go
@@ -36,14 +36,14 @@ import (
 // through the local authenticated ALPN proxy.
 func TestLocalProxyPostgres(t *testing.T) {
 	tests := []struct {
-		name               string
+		name        string
 		noCancelKey bool
 	}{
 		{
 			name: "with query cancellation",
 		},
 		{
-			name:               "without query cancellation",
+			name:        "without query cancellation",
 			noCancelKey: true,
 		},
 	}

--- a/lib/srv/db/local_proxy_test.go
+++ b/lib/srv/db/local_proxy_test.go
@@ -35,39 +35,70 @@ import (
 // TestLocalProxyPostgres verifies connecting to a Postgres database
 // through the local authenticated ALPN proxy.
 func TestLocalProxyPostgres(t *testing.T) {
-	ctx := context.Background()
-	testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres"))
-	go testCtx.startHandlingConnections()
+	tests := []struct {
+		name               string
+		noCancelKey bool
+	}{
+		{
+			name: "with query cancellation",
+		},
+		{
+			name:               "without query cancellation",
+			noCancelKey: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			var opts []testPostgresOption
+			if tt.noCancelKey {
+				opts = append(opts, withPostgresNoCancelKey())
+			}
+			testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres", opts...))
+			go testCtx.startHandlingConnections()
 
-	// Create test user/role.
-	testCtx.createUserAndRole(ctx, t, "alice", "admin", []string{types.Wildcard}, []string{types.Wildcard})
+			// Create test user/role.
+			testCtx.createUserAndRole(ctx, t, "alice", "admin", []string{types.Wildcard}, []string{types.Wildcard})
 
-	// Try to connect to the database as this user.
-	conn, proxy, err := testCtx.postgresClientLocalProxy(ctx, "alice", "postgres", "postgres", "postgres")
-	require.NoError(t, err)
+			// Try to connect to the database as this user.
+			conn, proxy, err := testCtx.postgresClientLocalProxy(ctx, "alice", "postgres", "postgres", "postgres")
+			require.NoError(t, err)
 
-	// Close connection and local proxy after the test.
-	t.Cleanup(func() {
-		require.NoError(t, conn.Close(ctx))
-		require.NoError(t, proxy.Close())
-	})
+			// Close connection and local proxy after the test.
+			t.Cleanup(func() {
+				require.NoError(t, conn.Close(ctx))
+				require.NoError(t, proxy.Close())
+			})
 
-	// Execute a query.
-	results, err := conn.Exec(ctx, "select 1").ReadAll()
-	require.NoError(t, err)
-	require.Equal(t, []*pgconn.Result{postgres.TestQueryResponse}, results)
+			// Execute a query.
+			results, err := conn.Exec(ctx, "select 1").ReadAll()
+			require.NoError(t, err)
+			require.Equal(t, []*pgconn.Result{postgres.TestQueryResponse}, results)
 
-	// Execute a "long running" query and cancel it.
-	resultReader := conn.Exec(ctx, postgres.TestLongRunningQuery)
-	require.NoError(t, conn.CancelRequest(ctx))
-	// timeout this test quickly if the cancel request fails to propagate.
-	conn.Conn().SetDeadline(time.Now().Add(time.Second * 10))
-	results, err = resultReader.ReadAll()
-	require.Error(t, err)
-	var pgErr *pgconn.PgError
-	require.ErrorAs(t, err, &pgErr)
-	require.Equal(t, pgerrcode.QueryCanceled, pgErr.Code)
-	require.Empty(t, results)
+			if tt.noCancelKey {
+				// No BackendKeyData should reach the client; nothing to cancel.
+				require.Zero(t, conn.PID())
+				require.Empty(t, conn.SecretKey())
+				return
+			}
+
+			// The backend's cancel key must reach the client.
+			require.NotZero(t, conn.PID())
+			require.NotEmpty(t, conn.SecretKey())
+
+			// Execute a "long running" query and cancel it.
+			resultReader := conn.Exec(ctx, postgres.TestLongRunningQuery)
+			require.NoError(t, conn.CancelRequest(ctx))
+			// timeout this test quickly if the cancel request fails to propagate.
+			conn.Conn().SetDeadline(time.Now().Add(time.Second * 10))
+			results, err = resultReader.ReadAll()
+			require.Error(t, err)
+			var pgErr *pgconn.PgError
+			require.ErrorAs(t, err, &pgErr)
+			require.Equal(t, pgerrcode.QueryCanceled, pgErr.Code)
+			require.Empty(t, results)
+		})
+	}
 }
 
 // TestLocalProxyMySQL verifies connecting to a MySQL database

--- a/lib/srv/db/postgres/engine.go
+++ b/lib/srv/db/postgres/engine.go
@@ -304,9 +304,10 @@ func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (*pgpr
 func (e *Engine) makeClientReady(client *pgproto3.Backend, hijackedConn *pgconn.HijackedConn) error {
 	// AuthenticationOk indicates that the authentication was successful.
 	client.Send(&pgproto3.AuthenticationOk{})
-	// BackendKeyData provides secret-key data that the frontend must save
-	// if it wants to be able to issue cancel requests later.
-	client.Send(&pgproto3.BackendKeyData{ProcessID: hijackedConn.PID, SecretKey: hijackedConn.SecretKey})
+	// Forward the cancel key, unless the backend omits it (e.g. RDS Proxy).
+	if len(hijackedConn.SecretKey) > 0 {
+		client.Send(&pgproto3.BackendKeyData{ProcessID: hijackedConn.PID, SecretKey: hijackedConn.SecretKey})
+	}
 	// ParameterStatuses contains parameters reported by the server such as
 	// server version, relay them back to the client.
 	for k, v := range hijackedConn.ParameterStatuses {

--- a/lib/srv/db/postgres/test.go
+++ b/lib/srv/db/postgres/test.go
@@ -108,6 +108,19 @@ type TestServer struct {
 
 	// mmCache caches multiMessage for reuse in benchmark
 	mmCache map[string]*multiMessage
+
+	// noCancelKey skips BackendKeyData on startup (e.g. RDS Proxy).
+	noCancelKey bool
+}
+
+// TestServerOption allows setting test server options.
+type TestServerOption func(*TestServer)
+
+// WithNoCancelKey makes the server skip BackendKeyData (e.g. RDS Proxy).
+func WithNoCancelKey() TestServerOption {
+	return func(ts *TestServer) {
+		ts.noCancelKey = true
+	}
 }
 
 // pidHandle represents a fake pid handle that can cancel operations in progress.
@@ -145,7 +158,7 @@ type storedProcedure struct {
 }
 
 // NewTestServer returns a new instance of a test Postgres server.
-func NewTestServer(config common.TestServerConfig) (svr *TestServer, err error) {
+func NewTestServer(config common.TestServerConfig, opts ...TestServerOption) (svr *TestServer, err error) {
 	err = config.CheckAndSetDefaults()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -166,7 +179,7 @@ func NewTestServer(config common.TestServerConfig) (svr *TestServer, err error) 
 		allowedUsers.Store(user, struct{}{})
 	}
 
-	return &TestServer{
+	server := &TestServer{
 		cfg:       config,
 		listener:  config.Listener,
 		port:      port,
@@ -182,7 +195,11 @@ func NewTestServer(config common.TestServerConfig) (svr *TestServer, err error) 
 		userPermissionEventsCh: make(chan UserPermissionEvent, 100),
 		allowedUsers:           &allowedUsers,
 		mmCache:                make(map[string]*multiMessage),
-	}, nil
+	}
+	for _, opt := range opts {
+		opt(server)
+	}
+	return server, nil
 }
 
 // Serve starts serving client connections.
@@ -280,14 +297,16 @@ func (s *TestServer) handleStartup(client *pgproto3.Backend, startupMessage *pgp
 	pid := s.newPid()
 	defer s.cleanupPid(pid)
 
-	if err := s.sendMessages(client,
-		&pgproto3.AuthenticationOk{},
-		&pgproto3.BackendKeyData{
+	messages := []pgproto3.BackendMessage{&pgproto3.AuthenticationOk{}}
+	// BackendKeyData carries the cancel-request key; some backends omit it.
+	if !s.noCancelKey {
+		messages = append(messages, &pgproto3.BackendKeyData{
 			ProcessID: pid,
 			SecretKey: testSecretKey,
-		},
-		&pgproto3.ReadyForQuery{},
-	); err != nil {
+		})
+	}
+	messages = append(messages, &pgproto3.ReadyForQuery{})
+	if err := s.sendMessages(client, messages...); err != nil {
 		return trace.Wrap(err)
 	}
 	// Enter the loop replying to client messages.


### PR DESCRIPTION
Backport #68711 to branch/v18

changelog: Fixed Postgres connection failures to RDS Proxy and other servers without query cancellation.
