### PR TITLE
[v18] Add `tctl integrations awsic accounts`

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -1249,6 +1249,22 @@ Flags:
 |`--sp`|*no default*|name of a file containing service provider spec|
 |`-u`, `--users`|*no default*|username or name of a file containing user spec|
 
+## tctl integrations awsic accounts
+
+List AWS Identity Center accounts and their permission sets.
+
+Usage:
+
+```code
+$ tctl integrations awsic accounts [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--format`|`text` (one of: `text`, `json`, `yaml`)|Output format.|
+
 ## tctl integrations test
 
 Verify an integration.

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -1256,8 +1256,14 @@ List AWS Identity Center accounts and their permission sets.
 Usage:
 
 ```code
-$ tctl integrations awsic accounts ls
+$ tctl integrations awsic accounts ls [<flags>]
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--format`|`text` (one of: `text`, `json`, `yaml`)|Output format.|
 
 ## tctl integrations test
 

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -1249,21 +1249,15 @@ Flags:
 |`--sp`|*no default*|name of a file containing service provider spec|
 |`-u`, `--users`|*no default*|username or name of a file containing user spec|
 
-## tctl integrations awsic accounts
+## tctl integrations awsic accounts ls
 
 List AWS Identity Center accounts and their permission sets.
 
 Usage:
 
 ```code
-$ tctl integrations awsic accounts [<flags>]
+$ tctl integrations awsic accounts ls
 ```
-
-Flags:
-
-|Flag|Default|Description|
-|---|---|---|
-|`--format`|`text` (one of: `text`, `json`, `yaml`)|Output format.|
 
 ## tctl integrations test
 

--- a/tool/tctl/common/integrations/awsic.go
+++ b/tool/tctl/common/integrations/awsic.go
@@ -23,18 +23,12 @@ import (
 
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
-	"github.com/gravitational/teleport/lib/utils"
 )
-
-type awsicArgs struct {
-	format string
-}
 
 // listAWSICAccounts prints the AWS Identity Center accounts synced into the
 // cluster along with their permission sets.
@@ -49,17 +43,7 @@ func (c *Command) listAWSICAccounts(ctx context.Context, clt *authclient.Client)
 	}
 
 	servers := filterICAccounts(resources)
-
-	switch c.awsicArgs.format {
-	case teleport.Text:
-		return trace.Wrap(c.writeAWSICText(servers))
-	case teleport.JSON:
-		return trace.Wrap(utils.WriteJSONArray(c.Stdout, servers))
-	case teleport.YAML:
-		return trace.Wrap(utils.WriteYAML(c.Stdout, servers))
-	default:
-		return trace.BadParameter("unknown value for --format flag: %s", c.awsicArgs.format)
-	}
+	return trace.Wrap(c.writeAWSICText(servers))
 }
 
 func filterICAccounts(resources []*types.EnrichedResource) []types.AppServer {

--- a/tool/tctl/common/integrations/awsic.go
+++ b/tool/tctl/common/integrations/awsic.go
@@ -1,0 +1,126 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package integrations
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	apiclient "github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+type awsicArgs struct {
+	format string
+}
+
+// listAWSICAccounts prints the AWS Identity Center accounts synced into the
+// cluster along with their permission sets.
+func (c *Command) listAWSICAccounts(ctx context.Context, clt *authclient.Client) error {
+	resources, err := apiclient.GetAllUnifiedResources(ctx, clt, &proto.ListUnifiedResourcesRequest{
+		Kinds: []string{types.KindApp},
+		// Returns only the permission sets the user is able to assume.
+		IncludeLogins: true,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	servers := filterICAccounts(resources)
+
+	switch c.awsicArgs.format {
+	case teleport.Text:
+		return trace.Wrap(c.writeAWSICText(servers))
+	case teleport.JSON:
+		return trace.Wrap(utils.WriteJSONArray(c.Stdout, servers))
+	case teleport.YAML:
+		return trace.Wrap(utils.WriteYAML(c.Stdout, servers))
+	default:
+		return trace.BadParameter("unknown value for --format flag: %s", c.awsicArgs.format)
+	}
+}
+
+func filterICAccounts(resources []*types.EnrichedResource) []types.AppServer {
+	var servers []types.AppServer
+	for _, r := range resources {
+		appServer, ok := r.ResourceWithLabels.(types.AppServer)
+		if !ok {
+			continue
+		}
+		if appServer.GetApp().GetIdentityCenter() == nil {
+			continue
+		}
+		servers = append(servers, appServer)
+	}
+
+	sort.Slice(servers, func(i, j int) bool {
+		return icAccountName(servers[i].GetApp()) < icAccountName(servers[j].GetApp())
+	})
+
+	return servers
+}
+
+func (c *Command) writeAWSICText(servers []types.AppServer) error {
+	headers := []string{"Account Name", "Account ID", "Permission Sets"}
+	rows := make([][]string, 0, len(servers))
+	for _, server := range servers {
+		app := server.GetApp()
+		ic := app.GetIdentityCenter()
+		name := icAccountName(app)
+
+		if len(ic.PermissionSets) == 0 {
+			rows = append(rows, []string{name, ic.AccountID, ""})
+			continue
+		}
+
+		// Print each permission set in its own row.
+		for i, ps := range ic.PermissionSets {
+			permSet := fmt.Sprintf("%s (%s)", ps.Name, ps.ARN)
+			if i == 0 {
+				rows = append(rows, []string{name, ic.AccountID, permSet})
+				continue
+			}
+			rows = append(rows, []string{"", "", permSet})
+		}
+	}
+	t := asciitable.MakeTable(headers, rows...)
+	_, err := t.AsBuffer().WriteTo(c.Stdout)
+	return trace.Wrap(err)
+}
+
+// icAccountName returns human-readable name for an Identity Center account
+// (versus the AWS account ID).
+func icAccountName(app types.Application) string {
+	if name := types.FriendlyName(app); name != "" {
+		return name
+	}
+	if name, ok := app.GetLabel(types.AWSAccountNameLabel); ok && name != "" {
+		return name
+	}
+	if ic := app.GetIdentityCenter(); ic != nil {
+		return ic.AccountID
+	}
+	return ""
+}

--- a/tool/tctl/common/integrations/awsic.go
+++ b/tool/tctl/common/integrations/awsic.go
@@ -19,74 +19,95 @@ package integrations
 import (
 	"context"
 	"fmt"
-	"sort"
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
+	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/utils"
 )
+
+type awsicAccount struct {
+	name     string
+	permSets []string
+}
 
 // listAWSICAccounts prints the AWS Identity Center accounts synced into the
 // cluster along with their permission sets.
 func (c *Command) listAWSICAccounts(ctx context.Context, clt *authclient.Client) error {
-	resources, err := apiclient.GetAllUnifiedResources(ctx, clt, &proto.ListUnifiedResourcesRequest{
-		Kinds: []string{types.KindApp},
-		// Returns only the permission sets the user is able to assume.
-		IncludeLogins: true,
-	})
+	assignments, err := getAllAWSICAccountAssignments(ctx, clt)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	servers := filterICAccounts(resources)
-	return trace.Wrap(c.writeAWSICText(servers))
+	return trace.Wrap(c.writeAWSICOutput(assignments))
 }
 
-func filterICAccounts(resources []*types.EnrichedResource) []types.AppServer {
-	var servers []types.AppServer
-	for _, r := range resources {
-		appServer, ok := r.ResourceWithLabels.(types.AppServer)
-		if !ok {
-			continue
-		}
-		if appServer.GetApp().GetIdentityCenter() == nil {
-			continue
-		}
-		servers = append(servers, appServer)
+func getAllAWSICAccountAssignments(ctx context.Context, clt *authclient.Client) ([]*identitycenterv1.AccountAssignment, error) {
+	resources, err := apiclient.GetResourcesWithFilters(ctx, clt, proto.ListResourcesRequest{
+		ResourceType: types.KindIdentityCenterAccountAssignment,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	sort.Slice(servers, func(i, j int) bool {
-		return icAccountName(servers[i].GetApp()) < icAccountName(servers[j].GetApp())
-	})
-
-	return servers
+	accAssignments := make([]*identitycenterv1.AccountAssignment, 0, len(resources))
+	for _, resource := range resources {
+		unwrapper, ok := resource.(types.Resource153UnwrapperT[*identitycenterv1.AccountAssignment])
+		if !ok {
+			return nil, trace.BadParameter("expected account assignment type, got %T", resource)
+		}
+		accAssignments = append(accAssignments, unwrapper.UnwrapT())
+	}
+	return accAssignments, nil
 }
 
-func (c *Command) writeAWSICText(servers []types.AppServer) error {
-	headers := []string{"Account Name", "Account ID", "Permission Sets"}
-	rows := make([][]string, 0, len(servers))
-	for _, server := range servers {
-		app := server.GetApp()
-		ic := app.GetIdentityCenter()
-		name := icAccountName(app)
+func (c *Command) writeAWSICOutput(assignments []*identitycenterv1.AccountAssignment) error {
+	switch c.awsicAccountsLsFormat {
+	case teleport.JSON:
+		return trace.Wrap(utils.WriteJSONArray(c.Stdout, awsicResources(assignments)))
+	case teleport.YAML:
+		return trace.Wrap(utils.WriteYAML(c.Stdout, awsicResources(assignments)))
+	default:
+		return trace.Wrap(c.writeAWSICText(assignments))
+	}
+}
 
-		if len(ic.PermissionSets) == 0 {
-			rows = append(rows, []string{name, ic.AccountID, ""})
-			continue
+func (c *Command) writeAWSICText(assignments []*identitycenterv1.AccountAssignment) error {
+	accountIDs := []string{}
+	accountLookup := make(map[string]*awsicAccount)
+
+	for _, assignment := range assignments {
+		spec := assignment.GetSpec()
+		accountID := spec.GetAccountId()
+		ps := spec.GetPermissionSet()
+
+		account, ok := accountLookup[accountID]
+		if !ok {
+			account = &awsicAccount{name: spec.GetAccountName()}
+			accountLookup[accountID] = account
+			accountIDs = append(accountIDs, accountID)
 		}
+		account.permSets = append(account.permSets, fmt.Sprintf("%s (%s)", ps.GetName(), ps.GetArn()))
+	}
 
+	headers := []string{"Account Name", "Account ID", "Permission Sets"}
+	rows := make([][]string, 0, len(assignments))
+
+	for _, accountID := range accountIDs {
+		account := accountLookup[accountID]
 		// Print each permission set in its own row.
-		for i, ps := range ic.PermissionSets {
-			permSet := fmt.Sprintf("%s (%s)", ps.Name, ps.ARN)
+		for i, permSet := range account.permSets {
 			if i == 0 {
-				rows = append(rows, []string{name, ic.AccountID, permSet})
-				continue
+				rows = append(rows, []string{account.name, accountID, permSet})
+			} else {
+				rows = append(rows, []string{"", "", permSet})
 			}
-			rows = append(rows, []string{"", "", permSet})
 		}
 	}
 	t := asciitable.MakeTable(headers, rows...)
@@ -94,17 +115,10 @@ func (c *Command) writeAWSICText(servers []types.AppServer) error {
 	return trace.Wrap(err)
 }
 
-// icAccountName returns human-readable name for an Identity Center account
-// (versus the AWS account ID).
-func icAccountName(app types.Application) string {
-	if name := types.FriendlyName(app); name != "" {
-		return name
+func awsicResources(assignments []*identitycenterv1.AccountAssignment) []types.Resource {
+	r := make([]types.Resource, len(assignments))
+	for i, assignment := range assignments {
+		r[i] = types.ProtoResource153ToLegacy(assignment)
 	}
-	if name, ok := app.GetLabel(types.AWSAccountNameLabel); ok && name != "" {
-		return name
-	}
-	if ic := app.GetIdentityCenter(); ic != nil {
-		return ic.AccountID
-	}
-	return ""
+	return r
 }

--- a/tool/tctl/common/integrations/awsic_test.go
+++ b/tool/tctl/common/integrations/awsic_test.go
@@ -1,0 +1,100 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package integrations
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils/testutils/golden"
+)
+
+func TestFilterICAccounts(t *testing.T) {
+	t.Parallel()
+
+	node := &types.ServerV2{
+		Kind:     types.KindNode,
+		Version:  types.V2,
+		Metadata: types.Metadata{Name: "node1"},
+	}
+
+	regularApp := &types.AppServerV3{
+		Spec: types.AppServerSpecV3{App: &types.AppV3{}},
+	}
+
+	resources := []*types.EnrichedResource{
+		{ResourceWithLabels: newICAppServer("222222222222", "alpaca")},
+		{ResourceWithLabels: regularApp},
+		{ResourceWithLabels: node},
+		{ResourceWithLabels: newICAppServer("111111111111", "llama")},
+	}
+
+	got := filterICAccounts(resources)
+
+	// Non IC resources should be dropped.
+	require.Len(t, got, 2)
+	require.Equal(t, "alpaca", icAccountName(got[0].GetApp()))
+	require.Equal(t, "llama", icAccountName(got[1].GetApp()))
+}
+
+func TestWriteAWSICText(t *testing.T) {
+	t.Parallel()
+
+	servers := []types.AppServer{
+		newICAppServer("111111111111", "Production",
+			&types.IdentityCenterPermissionSet{
+				Name: "AdminAccess", ARN: "arn:aws:sso:::permissionSet/abc/ps-aaaa",
+			},
+			&types.IdentityCenterPermissionSet{
+				Name: "ReadOnly", ARN: "arn:aws:sso:::permissionSet/abc/ps-bbbb",
+			},
+		),
+		newICAppServer("222222222222", "Staging",
+			&types.IdentityCenterPermissionSet{
+				Name: "ReadOnly", ARN: "arn:aws:sso:::permissionSet/abc/ps-bbbb",
+			},
+		),
+	}
+
+	var buf bytes.Buffer
+	c := &Command{Stdout: &buf}
+	require.NoError(t, c.writeAWSICText(servers))
+
+	if golden.ShouldSet() {
+		golden.Set(t, buf.Bytes())
+	}
+	require.Equal(t, string(golden.Get(t)), buf.String())
+}
+
+func newICAppServer(accountID, accountName string, pss ...*types.IdentityCenterPermissionSet) *types.AppServerV3 {
+	return &types.AppServerV3{
+		Spec: types.AppServerSpecV3{
+			App: &types.AppV3{
+				Metadata: types.Metadata{Description: accountName},
+				Spec: types.AppSpecV3{
+					IdentityCenter: &types.AppIdentityCenter{
+						AccountID:      accountID,
+						PermissionSets: pss,
+					},
+				},
+			},
+		},
+	}
+}

--- a/tool/tctl/common/integrations/awsic_test.go
+++ b/tool/tctl/common/integrations/awsic_test.go
@@ -22,79 +22,60 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport"
+	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 )
 
-func TestFilterICAccounts(t *testing.T) {
+func TestWriteAWSICOutput(t *testing.T) {
 	t.Parallel()
 
-	node := &types.ServerV2{
-		Kind:     types.KindNode,
-		Version:  types.V2,
-		Metadata: types.Metadata{Name: "node1"},
+	assignments := []*identitycenterv1.AccountAssignment{
+		newICAccountAssignment("111111111111", "Production", "AdminAccess", "arn:aws:sso:::permissionSet/abc/ps-aaaa"),
+		newICAccountAssignment("111111111111", "Production", "ReadOnly", "arn:aws:sso:::permissionSet/abc/ps-bbbb"),
+		newICAccountAssignment("222222222222", "Staging", "ReadOnly", "arn:aws:sso:::permissionSet/abc/ps-bbbb"),
 	}
 
-	regularApp := &types.AppServerV3{
-		Spec: types.AppServerSpecV3{App: &types.AppV3{}},
-	}
-
-	resources := []*types.EnrichedResource{
-		{ResourceWithLabels: newICAppServer("222222222222", "alpaca")},
-		{ResourceWithLabels: regularApp},
-		{ResourceWithLabels: node},
-		{ResourceWithLabels: newICAppServer("111111111111", "llama")},
-	}
-
-	got := filterICAccounts(resources)
-
-	// Non IC resources should be dropped.
-	require.Len(t, got, 2)
-	require.Equal(t, "alpaca", icAccountName(got[0].GetApp()))
-	require.Equal(t, "llama", icAccountName(got[1].GetApp()))
-}
-
-func TestWriteAWSICText(t *testing.T) {
-	t.Parallel()
-
-	servers := []types.AppServer{
-		newICAppServer("111111111111", "Production",
-			&types.IdentityCenterPermissionSet{
-				Name: "AdminAccess", ARN: "arn:aws:sso:::permissionSet/abc/ps-aaaa",
-			},
-			&types.IdentityCenterPermissionSet{
-				Name: "ReadOnly", ARN: "arn:aws:sso:::permissionSet/abc/ps-bbbb",
-			},
-		),
-		newICAppServer("222222222222", "Staging",
-			&types.IdentityCenterPermissionSet{
-				Name: "ReadOnly", ARN: "arn:aws:sso:::permissionSet/abc/ps-bbbb",
-			},
-		),
-	}
-
-	var buf bytes.Buffer
-	c := &Command{Stdout: &buf}
-	require.NoError(t, c.writeAWSICText(servers))
-
-	if golden.ShouldSet() {
-		golden.Set(t, buf.Bytes())
-	}
-	require.Equal(t, string(golden.Get(t)), buf.String())
-}
-
-func newICAppServer(accountID, accountName string, pss ...*types.IdentityCenterPermissionSet) *types.AppServerV3 {
-	return &types.AppServerV3{
-		Spec: types.AppServerSpecV3{
-			App: &types.AppV3{
-				Metadata: types.Metadata{Description: accountName},
-				Spec: types.AppSpecV3{
-					IdentityCenter: &types.AppIdentityCenter{
-						AccountID:      accountID,
-						PermissionSets: pss,
-					},
-				},
-			},
+	tests := []struct {
+		name   string
+		format string
+	}{
+		{
+			name:   "text",
+			format: "", // default text
+		},
+		{
+			name:   "json",
+			format: teleport.JSON,
+		},
+		{
+			name:   "yaml",
+			format: teleport.YAML,
 		},
 	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			c := &Command{Stdout: &buf, awsicAccountsLsFormat: tt.format}
+			require.NoError(t, c.writeAWSICOutput(assignments))
+			if golden.ShouldSet() {
+				golden.Set(t, buf.Bytes())
+			}
+			require.Equal(t, string(golden.Get(t)), buf.String())
+		})
+	}
+}
+
+func newICAccountAssignment(accountID, accountName, permSetName, permSetARN string) *identitycenterv1.AccountAssignment {
+	return identitycenterv1.AccountAssignment_builder{
+		Spec: identitycenterv1.AccountAssignmentSpec_builder{
+			AccountId:   accountID,
+			AccountName: accountName,
+			PermissionSet: identitycenterv1.PermissionSetInfo_builder{
+				Name: permSetName,
+				Arn:  permSetARN,
+			}.Build(),
+		}.Build(),
+	}.Build()
 }

--- a/tool/tctl/common/integrations/integrations_command.go
+++ b/tool/tctl/common/integrations/integrations_command.go
@@ -45,14 +45,26 @@ func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags
 	c.testCmd.Arg("integration", "Name of the integration to test. Use `tctl get integrations` to list integrations.").Required().StringVar(&c.testArgs.integration)
 	c.testCmd.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.testArgs.format, teleport.Text, teleport.JSON, teleport.YAML)
 
-	if c.stdout == nil {
-		c.stdout = os.Stdout
+	awsicCmd := integrationsCmd.Command("awsic", "Operate on AWS Identity Center resources synced with the cluster.")
+	c.awsicAccountsCmd = awsicCmd.Command("accounts", "List AWS Identity Center accounts and their permission sets.")
+	c.awsicAccountsCmd.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.awsicArgs.format, teleport.Text, teleport.JSON, teleport.YAML)
+
+	if c.Stdout == nil {
+		c.Stdout = os.Stdout
 	}
 }
 
 // TryRun executes the matched subcommand.
 func (c *Command) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	if cmd != c.testCmd.FullCommand() {
+	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	switch cmd {
+	case c.testCmd.FullCommand():
+		commandFunc = func(ctx context.Context, client *authclient.Client) error {
+			return c.test(ctx, testClientAdapter{client: client})
+		}
+	case c.awsicAccountsCmd.FullCommand():
+		commandFunc = c.listAWSICAccounts
+	default:
 		return false, nil
 	}
 
@@ -61,8 +73,9 @@ func (c *Command) TryRun(ctx context.Context, cmd string, clientFunc commonclien
 		return true, trace.Wrap(err)
 	}
 	defer closeFn(ctx)
+	err = commandFunc(ctx, client)
 
-	return true, trace.Wrap(c.test(ctx, testClientAdapter{client: client}))
+	return true, trace.Wrap(err)
 }
 
 func (c *Command) test(ctx context.Context, client testClient) error {
@@ -84,11 +97,11 @@ func (c *Command) test(ctx context.Context, client testClient) error {
 
 	switch c.testArgs.format {
 	case teleport.Text:
-		fmt.Fprint(c.stdout, output)
+		fmt.Fprint(c.Stdout, output)
 	case teleport.JSON:
-		return trace.Wrap(utils.WriteJSON(c.stdout, output))
+		return trace.Wrap(utils.WriteJSON(c.Stdout, output))
 	case teleport.YAML:
-		return trace.Wrap(utils.WriteYAML(c.stdout, output))
+		return trace.Wrap(utils.WriteYAML(c.Stdout, output))
 	default:
 		return trace.BadParameter("unknown value for --format flag: %s", c.testArgs.format)
 	}
@@ -98,11 +111,14 @@ func (c *Command) test(ctx context.Context, client testClient) error {
 
 // Command implements integrations helper commands.
 type Command struct {
-	testCmd *kingpin.CmdClause
-
+	testCmd  *kingpin.CmdClause
 	testArgs testArgs
 
-	stdout io.Writer
+	awsicAccountsCmd *kingpin.CmdClause
+	awsicArgs        awsicArgs
+
+	// Stdout allows to switch the standard output source. Used in tests.
+	Stdout io.Writer
 }
 
 type testArgs struct {

--- a/tool/tctl/common/integrations/integrations_command.go
+++ b/tool/tctl/common/integrations/integrations_command.go
@@ -45,9 +45,10 @@ func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags
 	c.testCmd.Arg("integration", "Name of the integration to test. Use `tctl get integrations` to list integrations.").Required().StringVar(&c.testArgs.integration)
 	c.testCmd.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.testArgs.format, teleport.Text, teleport.JSON, teleport.YAML)
 
-	awsicCmd := integrationsCmd.Command("awsic", "Operate on AWS Identity Center resources synced with the cluster.")
-	c.awsicAccountsCmd = awsicCmd.Command("accounts", "List AWS Identity Center accounts and their permission sets.")
-	c.awsicAccountsCmd.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.awsicArgs.format, teleport.Text, teleport.JSON, teleport.YAML)
+	awsicCmd := integrationsCmd.Command("awsic", "View AWS Identity Center resources synced with the cluster. "+
+		"To configure the AWS Identity Center integration itself, use `tctl plugins install awsic` or `tctl plugins edit awsic`.")
+	awsicAccountsCmd := awsicCmd.Command("accounts", "View AWS Identity Center accounts synced with the cluster.")
+	c.awsicAccountsLsCmd = awsicAccountsCmd.Command("ls", "List AWS Identity Center accounts and their permission sets.")
 
 	if c.Stdout == nil {
 		c.Stdout = os.Stdout
@@ -62,7 +63,7 @@ func (c *Command) TryRun(ctx context.Context, cmd string, clientFunc commonclien
 		commandFunc = func(ctx context.Context, client *authclient.Client) error {
 			return c.test(ctx, testClientAdapter{client: client})
 		}
-	case c.awsicAccountsCmd.FullCommand():
+	case c.awsicAccountsLsCmd.FullCommand():
 		commandFunc = c.listAWSICAccounts
 	default:
 		return false, nil
@@ -114,8 +115,7 @@ type Command struct {
 	testCmd  *kingpin.CmdClause
 	testArgs testArgs
 
-	awsicAccountsCmd *kingpin.CmdClause
-	awsicArgs        awsicArgs
+	awsicAccountsLsCmd *kingpin.CmdClause
 
 	// Stdout allows to switch the standard output source. Used in tests.
 	Stdout io.Writer

--- a/tool/tctl/common/integrations/integrations_command.go
+++ b/tool/tctl/common/integrations/integrations_command.go
@@ -49,6 +49,7 @@ func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags
 		"To configure the AWS Identity Center integration itself, use `tctl plugins install awsic` or `tctl plugins edit awsic`.")
 	awsicAccountsCmd := awsicCmd.Command("accounts", "View AWS Identity Center accounts synced with the cluster.")
 	c.awsicAccountsLsCmd = awsicAccountsCmd.Command("ls", "List AWS Identity Center accounts and their permission sets.")
+	c.awsicAccountsLsCmd.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.awsicAccountsLsFormat, teleport.Text, teleport.JSON, teleport.YAML)
 
 	if c.Stdout == nil {
 		c.Stdout = os.Stdout
@@ -115,7 +116,8 @@ type Command struct {
 	testCmd  *kingpin.CmdClause
 	testArgs testArgs
 
-	awsicAccountsLsCmd *kingpin.CmdClause
+	awsicAccountsLsCmd    *kingpin.CmdClause
+	awsicAccountsLsFormat string
 
 	// Stdout allows to switch the standard output source. Used in tests.
 	Stdout io.Writer

--- a/tool/tctl/common/integrations/integrations_command_test.go
+++ b/tool/tctl/common/integrations/integrations_command_test.go
@@ -87,7 +87,7 @@ func TestIntegrationsCommandTest_AWSOIDC(t *testing.T) {
 
 			var out bytes.Buffer
 			cmd := &Command{
-				stdout: &out,
+				Stdout: &out,
 				testArgs: testArgs{
 					integration: "my-integration",
 					format:      tc.format,

--- a/tool/tctl/common/integrations/testdata/TestWriteAWSICOutput/json.golden
+++ b/tool/tctl/common/integrations/testdata/TestWriteAWSICOutput/json.golden
@@ -1,0 +1,32 @@
+[
+    {
+        "spec": {
+            "permission_set": {
+                "arn": "arn:aws:sso:::permissionSet/abc/ps-aaaa",
+                "name": "AdminAccess"
+            },
+            "account_name": "Production",
+            "account_id": "111111111111"
+        }
+    },
+    {
+        "spec": {
+            "permission_set": {
+                "arn": "arn:aws:sso:::permissionSet/abc/ps-bbbb",
+                "name": "ReadOnly"
+            },
+            "account_name": "Production",
+            "account_id": "111111111111"
+        }
+    },
+    {
+        "spec": {
+            "permission_set": {
+                "arn": "arn:aws:sso:::permissionSet/abc/ps-bbbb",
+                "name": "ReadOnly"
+            },
+            "account_name": "Staging",
+            "account_id": "222222222222"
+        }
+    }
+]

--- a/tool/tctl/common/integrations/testdata/TestWriteAWSICOutput/text.golden
+++ b/tool/tctl/common/integrations/testdata/TestWriteAWSICOutput/text.golden
@@ -1,0 +1,5 @@
+Account Name Account ID   Permission Sets                                       
+------------ ------------ ----------------------------------------------------- 
+Production   111111111111 AdminAccess (arn:aws:sso:::permissionSet/abc/ps-aaaa) 
+                          ReadOnly (arn:aws:sso:::permissionSet/abc/ps-bbbb)    
+Staging      222222222222 ReadOnly (arn:aws:sso:::permissionSet/abc/ps-bbbb)    

--- a/tool/tctl/common/integrations/testdata/TestWriteAWSICOutput/yaml.golden
+++ b/tool/tctl/common/integrations/testdata/TestWriteAWSICOutput/yaml.golden
@@ -1,0 +1,20 @@
+spec:
+  account_id: "111111111111"
+  account_name: Production
+  permission_set:
+    arn: arn:aws:sso:::permissionSet/abc/ps-aaaa
+    name: AdminAccess
+---
+spec:
+  account_id: "111111111111"
+  account_name: Production
+  permission_set:
+    arn: arn:aws:sso:::permissionSet/abc/ps-bbbb
+    name: ReadOnly
+---
+spec:
+  account_id: "222222222222"
+  account_name: Staging
+  permission_set:
+    arn: arn:aws:sso:::permissionSet/abc/ps-bbbb
+    name: ReadOnly

--- a/tool/tctl/common/integrations/testdata/TestWriteAWSICText.golden
+++ b/tool/tctl/common/integrations/testdata/TestWriteAWSICText.golden
@@ -1,0 +1,5 @@
+Account Name Account ID   Permission Sets                                       
+------------ ------------ ----------------------------------------------------- 
+Production   111111111111 AdminAccess (arn:aws:sso:::permissionSet/abc/ps-aaaa) 
+                          ReadOnly (arn:aws:sso:::permissionSet/abc/ps-bbbb)    
+Staging      222222222222 ReadOnly (arn:aws:sso:::permissionSet/abc/ps-bbbb)    


### PR DESCRIPTION
Backport #68177 to branch/v18

changelog: Added `tctl integrations awsic accounts ls` for listing AWS Identity Center accounts and its permission sets.

## Manual Test Plan
### Test Environment

cloud staging that has AWS IC integration

### Test Cases
- [x] tctl integrations awsic accounts ls
- [x] tctl integrations awsic accounts--format=json
- [x] tctl integrations awsic accounts --format=yaml  
