### PR TITLE
[v18] trigger linter on any go.mod changes

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,8 +35,8 @@ jobs:
             has_go:
               - '.github/workflows/lint.yaml'
               - '**.go'
-              - 'go.mod'
-              - 'go.sum'
+              - '**/go.mod'
+              - '**/go.sum'
               - 'build.assets/Makefile'
               - 'build.assets/Dockerfile*'
               - 'Makefile'


### PR DESCRIPTION
Backport #68756 to branch/v18

Trigger linter on ANY go.mod or go.sum changes. Currently it only is triggered on those in the root of the project.