### PR TITLE
Adding retry to mac notarization for Mac signing

### DIFF
--- a/darwin-signing.mk
+++ b/darwin-signing.mk
@@ -19,7 +19,7 @@ RETRY_TOOL_ENABLED ?= $(if $(filter true yes 1,$(CI)),true)
 RETRY_TOOL_ENABLED := $(if $(filter true yes 1,$(RETRY_TOOL_ENABLED)),true,)
 RETRY_TOOL_RETRIES ?= 3
 RETRY_TOOL_INITIAL ?= 30s
-RETRY_TOOL = $(if $(RETRY_TOOL_ENABLED),go run github.com/gravitational/shared-workflows/tools/retry@main --retries $(RETRY_TOOL_RETRIES) --initial $(RETRY_TOOL_INITIAL) --)
+RETRY_TOOL = $(if $(RETRY_TOOL_ENABLED),go run github.com/gravitational/shared-workflows/tools/retry@v0.0.2 --retries $(RETRY_TOOL_RETRIES) --initial $(RETRY_TOOL_INITIAL) --)
 
 # Default environment name if not specified. This is currently for running
 # locally instead of from GitHub Actions, where ENVIRONMENT_NAME would not be

--- a/darwin-signing.mk
+++ b/darwin-signing.mk
@@ -19,7 +19,7 @@ RETRY_TOOL_ENABLED ?= $(if $(filter true yes 1,$(CI)),true)
 RETRY_TOOL_ENABLED := $(if $(filter true yes 1,$(RETRY_TOOL_ENABLED)),true,)
 RETRY_TOOL_RETRIES ?= 3
 RETRY_TOOL_INITIAL ?= 30s
-RETRY_TOOL = $(if $(RETRY_TOOL_ENABLED),go run github.com/gravitational/shared-workflows/tools/retry@latest --retries $(RETRY_TOOL_RETRIES) --initial $(RETRY_TOOL_INITIAL) --)
+RETRY_TOOL = $(if $(RETRY_TOOL_ENABLED),go run github.com/gravitational/shared-workflows/tools/retry@main --retries $(RETRY_TOOL_RETRIES) --initial $(RETRY_TOOL_INITIAL) --)
 
 # Default environment name if not specified. This is currently for running
 # locally instead of from GitHub Actions, where ENVIRONMENT_NAME would not be

--- a/darwin-signing.mk
+++ b/darwin-signing.mk
@@ -11,6 +11,16 @@
 # profile alongside build.assets/macos/*/*.provisioningprofile. We also need
 # to update these profiles if the keys are changed/rotated.
 
+# RETRY_TOOL_ENABLED defaults to true in CI so transient notarization failures
+# get retried automatically. It can be forced on or off with:
+#   make RETRY_TOOL_ENABLED=true ...
+#   make RETRY_TOOL_ENABLED=false ...
+RETRY_TOOL_ENABLED ?= $(if $(filter true yes 1,$(CI)),true)
+RETRY_TOOL_ENABLED := $(if $(filter true yes 1,$(RETRY_TOOL_ENABLED)),true,)
+RETRY_TOOL_RETRIES ?= 3
+RETRY_TOOL_INITIAL ?= 30s
+RETRY_TOOL = $(if $(RETRY_TOOL_ENABLED),go run github.com/gravitational/shared-workflows/tools/retry@latest --retries $(RETRY_TOOL_RETRIES) --initial $(RETRY_TOOL_INITIAL) --)
+
 # Default environment name if not specified. This is currently for running
 # locally instead of from GitHub Actions, where ENVIRONMENT_NAME would not be
 # set.
@@ -98,7 +108,7 @@ define notarize_binaries_cmd
 	mkdir $(notary_dir)
 	ditto $(BINARIES) $(notary_dir)
 	ditto -c -k $(notary_dir) $(notary_file)
-	xcrun notarytool submit $(notary_file) \
+	$(RETRY_TOOL) xcrun notarytool submit $(notary_file) \
 		--team-id="$(TEAMID)" \
 		--apple-id="$(APPLE_USERNAME)" \
 		--password="$(APPLE_PASSWORD)" \
@@ -141,7 +151,7 @@ define notarize_app_bundle
 		"$($@_BUNDLE)"
 
 	ditto -c -k --keepParent $($@_BUNDLE) $(notary_file)
-	xcrun notarytool submit $(notary_file) \
+	$(RETRY_TOOL) xcrun notarytool submit $(notary_file) \
 		--team-id="$(TEAMID)" \
 		--apple-id="$(APPLE_USERNAME)" \
 		--password="$(APPLE_PASSWORD)" \
@@ -157,7 +167,7 @@ define notarize_pkg
 		--timestamp \
 		$($@_IN_PKG) \
 		$($@_OUT_PKG)
-	xcrun notarytool submit $($@_OUT_PKG) \
+	$(RETRY_TOOL) xcrun notarytool submit $($@_OUT_PKG) \
 		--team-id="$(TEAMID)" \
 		--apple-id="$(APPLE_USERNAME)" \
 		--password="$(APPLE_PASSWORD)" \
@@ -180,3 +190,6 @@ print-darwin-signing-vars:
 	$(call echo_var,TSH_SKELETON)
 	$(call echo_var,TCTL_BUNDLEID)
 	$(call echo_var,TCTL_SKELETON)
+	$(call echo_var,RETRY_TOOL_ENABLED)
+	$(call echo_var,RETRY_TOOL_RETRIES)
+	$(call echo_var,RETRY_TOOL_INITIAL)


### PR DESCRIPTION
This adds retry for Mac notarization. This complements https://github.com/gravitational/teleport.e/pull/9167 and includes updates to the Makefile to include the `retry` tool only to the notarization commands.

## Manual Test Plan
### Test Environment

### Test Cases
- [x] Dev Release
  - Build: https://github.com/gravitational/teleport.e/actions/runs/29609563678
  - Publish: https://github.com/gravitational/teleport.e/actions/runs/29613892475
