### PR TITLE
[v17] Remove generic write permissions from system agent roles

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -279,6 +279,21 @@ func HasBuiltinRole(authContext authz.Context, name string) bool {
 	return authz.HasBuiltinRole(authContext, name)
 }
 
+// agentOwnedResourceAction authorizes an agent identity to perform actions on its own resources.
+func (a *ServerWithRoles) agentOwnedResourceAction(ctx context.Context, hostID string, systemRoles ...types.SystemRole) error {
+	if !a.hasBuiltinRole(systemRoles...) {
+		return trace.AccessDenied("this request can be only executed by a teleport built-in server")
+	}
+	serverID, ok := getLocalServerID(a.context.Identity)
+	if !ok {
+		return trace.BadParameter("no agent identity after confirming that request context is BuiltinRole (this is a bug)")
+	}
+	if hostID != serverID {
+		return trace.AccessDenied("resource host ID %+q does not match agent identity ID %+q", hostID, serverID)
+	}
+	return nil
+}
+
 // HasRemoteBuiltinRole checks if the identity is a remote builtin role with the
 // matching name.
 func HasRemoteBuiltinRole(authContext authz.Context, name string) bool {
@@ -1004,95 +1019,48 @@ func (a *ServerWithRoles) ClearAlertAcks(ctx context.Context, req proto.ClearAle
 }
 
 func (a *ServerWithRoles) UpsertNode(ctx context.Context, s types.Server) (*types.KeepAlive, error) {
-	if err := a.action(s.GetNamespace(), types.KindNode, types.VerbCreate, types.VerbUpdate); err != nil {
-		return nil, trace.Wrap(err)
+	if err := a.agentOwnedResourceAction(ctx, s.GetName(), types.RoleNode); err != nil {
+		if err := a.action(s.GetNamespace(), types.KindNode, types.VerbCreate, types.VerbUpdate); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	return a.authServer.UpsertNode(ctx, s)
 }
 
 // KeepAliveServer updates expiry time of a server resource.
 func (a *ServerWithRoles) KeepAliveServer(ctx context.Context, handle types.KeepAlive) error {
-	clusterName, err := a.GetDomainName(ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	serverName, err := ExtractHostID(a.context.User.GetName(), clusterName)
-	if err != nil {
-		return trace.AccessDenied("access denied")
-	}
-
 	switch handle.GetType() {
 	case constants.KeepAliveNode:
-		if serverName != handle.Name {
-			return trace.AccessDenied("access denied")
-		}
-		if !a.hasBuiltinRole(types.RoleNode) {
-			return trace.AccessDenied("access denied")
-		}
-		if err := a.action(apidefaults.Namespace, types.KindNode, types.VerbUpdate); err != nil {
+		if err := a.agentOwnedResourceAction(ctx, handle.Name, types.RoleNode); err != nil {
 			return trace.Wrap(err)
 		}
 	case constants.KeepAliveApp:
-		if handle.HostID != "" {
-			if serverName != handle.HostID {
-				return trace.AccessDenied("access denied")
-			}
-		} else { // DELETE IN 9.0. Legacy app server is heartbeating back.
-			if serverName != handle.Name {
-				return trace.AccessDenied("access denied")
-			}
+		hostID := handle.HostID
+		if hostID == "" { // DELETE IN 9.0. Legacy app server is heartbeating back.
+			hostID = handle.Name
 		}
-		if !a.hasBuiltinRole(types.RoleApp) && !a.hasBuiltinRole(types.RoleOkta) {
-			return trace.AccessDenied("access denied")
-		}
-		if err := a.action(apidefaults.Namespace, types.KindAppServer, types.VerbUpdate); err != nil {
+		if err := a.agentOwnedResourceAction(ctx, hostID, types.RoleApp, types.RoleOkta); err != nil {
 			return trace.Wrap(err)
 		}
 	case constants.KeepAliveDatabase:
 		// There can be multiple database servers per host so they send their
 		// host ID in a separate field because unlike SSH nodes the resource
 		// name cannot be the host ID.
-		if serverName != handle.HostID {
-			return trace.AccessDenied("access denied")
-		}
-		if !a.hasBuiltinRole(types.RoleDatabase) {
-			return trace.AccessDenied("access denied")
-		}
-		if err := a.action(apidefaults.Namespace, types.KindDatabaseServer, types.VerbUpdate); err != nil {
+		if err := a.agentOwnedResourceAction(ctx, handle.HostID, types.RoleDatabase); err != nil {
 			return trace.Wrap(err)
 		}
 	case constants.KeepAliveWindowsDesktopService:
-		if serverName != handle.Name {
-			return trace.AccessDenied("access denied")
-		}
-		if !a.hasBuiltinRole(types.RoleWindowsDesktop) {
-			return trace.AccessDenied("access denied")
-		}
-		if err := a.action(apidefaults.Namespace, types.KindWindowsDesktopService, types.VerbUpdate); err != nil {
+		if err := a.agentOwnedResourceAction(ctx, handle.Name, types.RoleWindowsDesktop); err != nil {
 			return trace.Wrap(err)
 		}
 	case constants.KeepAliveKube:
-		if handle.HostID == "" {
-			return trace.BadParameter("hostID is required for kubernetes keep alive")
-		} else if serverName != handle.HostID {
-			return trace.AccessDenied("access denied")
-		}
 		// Legacy kube proxy can heartbeat kube servers from the proxy itself so
 		// we need to check if the host has the Kube or Proxy role.
-		if !a.hasBuiltinRole(types.RoleKube, types.RoleProxy) {
-			return trace.AccessDenied("access denied")
-		}
-		if err := a.action(apidefaults.Namespace, types.KindKubeServer, types.VerbUpdate); err != nil {
+		if err := a.agentOwnedResourceAction(ctx, handle.HostID, types.RoleKube, types.RoleProxy); err != nil {
 			return trace.Wrap(err)
 		}
 	case constants.KeepAliveDatabaseService:
-		if serverName != handle.Name {
-			return trace.AccessDenied("access denied")
-		}
-		if !a.hasBuiltinRole(types.RoleDatabase) {
-			return trace.AccessDenied("access denied")
-		}
-		if err := a.action(apidefaults.Namespace, types.KindDatabaseService, types.VerbUpdate); err != nil {
+		if err := a.agentOwnedResourceAction(ctx, handle.Name, types.RoleDatabase); err != nil {
 			return trace.Wrap(err)
 		}
 	default:
@@ -5707,16 +5675,20 @@ func (a *ServerWithRoles) GetDatabaseServers(ctx context.Context, namespace stri
 
 // UpsertDatabaseServer creates or updates a new database proxy server.
 func (a *ServerWithRoles) UpsertDatabaseServer(ctx context.Context, server types.DatabaseServer) (*types.KeepAlive, error) {
-	if err := a.action(server.GetNamespace(), types.KindDatabaseServer, types.VerbCreate, types.VerbUpdate); err != nil {
-		return nil, trace.Wrap(err)
+	if err := a.agentOwnedResourceAction(ctx, server.GetHostID(), types.RoleDatabase); err != nil {
+		if err := a.action(server.GetNamespace(), types.KindDatabaseServer, types.VerbCreate, types.VerbUpdate); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	return a.authServer.UpsertDatabaseServer(ctx, server)
 }
 
 // DeleteDatabaseServer removes the specified database proxy server.
 func (a *ServerWithRoles) DeleteDatabaseServer(ctx context.Context, namespace, hostID, name string) error {
-	if err := a.action(namespace, types.KindDatabaseServer, types.VerbDelete); err != nil {
-		return trace.Wrap(err)
+	if err := a.agentOwnedResourceAction(ctx, hostID, types.RoleDatabase); err != nil {
+		if err := a.action(namespace, types.KindDatabaseServer, types.VerbDelete); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	return a.authServer.DeleteDatabaseServer(ctx, namespace, hostID, name)
 }
@@ -5731,8 +5703,10 @@ func (a *ServerWithRoles) DeleteAllDatabaseServers(ctx context.Context, namespac
 
 // UpsertDatabaseService creates or updates a new DatabaseService resource.
 func (a *ServerWithRoles) UpsertDatabaseService(ctx context.Context, service types.DatabaseService) (*types.KeepAlive, error) {
-	if err := a.action(service.GetNamespace(), types.KindDatabaseService, types.VerbCreate, types.VerbUpdate); err != nil {
-		return nil, trace.Wrap(err)
+	if err := a.agentOwnedResourceAction(ctx, service.GetName(), types.RoleDatabase); err != nil {
+		if err := a.action(service.GetNamespace(), types.KindDatabaseService, types.VerbCreate, types.VerbUpdate); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	return a.authServer.UpsertDatabaseService(ctx, service)
 }
@@ -5921,16 +5895,20 @@ func (a *ServerWithRoles) GetAppServersAndSAMLIdPServiceProviders(ctx context.Co
 
 // UpsertApplicationServer registers an application server.
 func (a *ServerWithRoles) UpsertApplicationServer(ctx context.Context, server types.AppServer) (*types.KeepAlive, error) {
-	if err := a.action(server.GetNamespace(), types.KindAppServer, types.VerbCreate, types.VerbUpdate); err != nil {
-		return nil, trace.Wrap(err)
+	if err := a.agentOwnedResourceAction(ctx, server.GetHostID(), types.RoleApp); err != nil {
+		if err := a.action(server.GetNamespace(), types.KindAppServer, types.VerbCreate, types.VerbUpdate); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	return a.authServer.UpsertApplicationServer(ctx, server)
 }
 
 // DeleteApplicationServer deletes specified application server.
 func (a *ServerWithRoles) DeleteApplicationServer(ctx context.Context, namespace, hostID, name string) error {
-	if err := a.action(namespace, types.KindAppServer, types.VerbDelete); err != nil {
-		return trace.Wrap(err)
+	if err := a.agentOwnedResourceAction(ctx, hostID, types.RoleApp); err != nil {
+		if err := a.action(namespace, types.KindAppServer, types.VerbDelete); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	return a.authServer.DeleteApplicationServer(ctx, namespace, hostID, name)
 }
@@ -6288,16 +6266,20 @@ func (a *ServerWithRoles) GetKubernetesServers(ctx context.Context) ([]types.Kub
 // UpsertKubernetesServer creates or updates a Server representing a teleport
 // kubernetes server.
 func (a *ServerWithRoles) UpsertKubernetesServer(ctx context.Context, s types.KubeServer) (*types.KeepAlive, error) {
-	if err := a.action(apidefaults.Namespace, types.KindKubeServer, types.VerbCreate, types.VerbUpdate); err != nil {
-		return nil, trace.Wrap(err)
+	if err := a.agentOwnedResourceAction(ctx, s.GetHostID(), types.RoleKube); err != nil {
+		if err := a.action(apidefaults.Namespace, types.KindKubeServer, types.VerbCreate, types.VerbUpdate); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	return a.authServer.UpsertKubernetesServer(ctx, s)
 }
 
 // DeleteKubernetesServer deletes specified kubernetes server.
 func (a *ServerWithRoles) DeleteKubernetesServer(ctx context.Context, hostID, name string) error {
-	if err := a.action(apidefaults.Namespace, types.KindKubeServer, types.VerbDelete); err != nil {
-		return trace.Wrap(err)
+	if err := a.agentOwnedResourceAction(ctx, hostID, types.RoleKube); err != nil {
+		if err := a.action(apidefaults.Namespace, types.KindKubeServer, types.VerbDelete); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	return a.authServer.DeleteKubernetesServer(ctx, hostID, name)
 }
@@ -7156,8 +7138,10 @@ func (a *ServerWithRoles) GetWindowsDesktopService(ctx context.Context, name str
 
 // UpsertWindowsDesktopService creates or updates a new windows desktop service.
 func (a *ServerWithRoles) UpsertWindowsDesktopService(ctx context.Context, s types.WindowsDesktopService) (*types.KeepAlive, error) {
-	if err := a.action(apidefaults.Namespace, types.KindWindowsDesktopService, types.VerbCreate, types.VerbUpdate); err != nil {
-		return nil, trace.Wrap(err)
+	if err := a.agentOwnedResourceAction(ctx, s.GetName(), types.RoleWindowsDesktop); err != nil {
+		if err := a.action(apidefaults.Namespace, types.KindWindowsDesktopService, types.VerbCreate, types.VerbUpdate); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	return a.authServer.UpsertWindowsDesktopService(ctx, s)
 }
@@ -7266,6 +7250,10 @@ func (a *ServerWithRoles) UpdateWindowsDesktop(ctx context.Context, s types.Wind
 
 // UpsertWindowsDesktop updates a windows desktop resource, creating it if it doesn't exist.
 func (a *ServerWithRoles) UpsertWindowsDesktop(ctx context.Context, s types.WindowsDesktop) error {
+	if err := a.agentOwnedResourceAction(ctx, s.GetHostID(), types.RoleWindowsDesktop); err == nil {
+		return a.authServer.UpsertWindowsDesktop(ctx, s)
+	}
+
 	// Ensure caller has both Create and Update permissions.
 	if err := a.action(apidefaults.Namespace, types.KindWindowsDesktop, types.VerbCreate, types.VerbUpdate); err != nil {
 		return trace.Wrap(err)
@@ -7299,6 +7287,9 @@ func (a *ServerWithRoles) UpsertWindowsDesktop(ctx context.Context, s types.Wind
 // Passing an empty host ID will not trigger "delete all" behavior. To delete
 // all desktops, use DeleteAllWindowsDesktops.
 func (a *ServerWithRoles) DeleteWindowsDesktop(ctx context.Context, hostID, name string) error {
+	if err := a.agentOwnedResourceAction(ctx, hostID, types.RoleWindowsDesktop); err == nil {
+		return a.authServer.DeleteWindowsDesktop(ctx, hostID, name)
+	}
 	if err := a.action(apidefaults.Namespace, types.KindWindowsDesktop, types.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
@@ -8313,4 +8304,15 @@ func checkOktaLockAccess(ctx context.Context, authzCtx *authz.Context, locks ser
 	}
 
 	return okta.CheckAccess(authzCtx, existingLock, verb)
+}
+
+// getLocalServerID returns the builtin server ID associated with the identity.
+// If the identity is not a builtin server role, and empty string and false are returned.
+func getLocalServerID(identityGetter authz.IdentityGetter) (serverID string, isBuiltinServer bool) {
+	switch role := identityGetter.(type) {
+	case authz.BuiltinRole:
+		return role.GetServerID(), role.IsServer()
+	}
+
+	return "", false
 }

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -10448,10 +10448,13 @@ func TestKubeKeepAliveServer(t *testing.T) {
 			require.NoError(t, err)
 
 			// Create a built-in role.
+			username := authclient.HostFQDN(hostID, domainName)
 			authContext, err := authz.ContextForBuiltinRole(
 				authz.BuiltinRole{
-					Role:     test.builtInRole,
-					Username: fmt.Sprintf("%s.%s", hostID, domainName),
+					Role:        test.builtInRole,
+					Username:    username,
+					ClusterName: domainName,
+					Identity:    tlsca.Identity{Username: username},
 				},
 				types.DefaultSessionRecordingConfig(),
 			)
@@ -11115,4 +11118,503 @@ func createTestAppServerV3(t *testing.T, auth *auth.Server, name string, labels 
 	require.NoError(t, err, "upserting test Application Server")
 
 	return appServer
+}
+
+// newTestServerForHost creates a self-cleaning `ServerWithRoles`, configured
+// for a given host with a single builtin role.
+func newTestServerForHost(t *testing.T, srv *authtest.AuthServer, hostID string, role types.SystemRole) *auth.ServerWithRoles {
+	authzContext := authz.ContextWithUser(t.Context(), authtest.TestServerID(role, hostID).I)
+	ctxIdentity, err := srv.Authorizer.Authorize(authzContext)
+	require.NoError(t, err)
+
+	authWithRole := auth.NewServerWithRoles(
+		srv.AuthServer,
+		srv.AuditLog,
+		*ctxIdentity,
+	)
+
+	t.Cleanup(func() { authWithRole.Close() })
+
+	return authWithRole
+}
+
+func TestRoleNodeLeastPrivilege(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+
+	const ownID = "00000000-0000-0000-0000-000000000001"
+	const otherID = "00000000-0000-0000-0000-000000000002"
+
+	makeNode := func(t *testing.T, name string) types.Server {
+		node, err := types.NewServer(name, types.KindNode, types.ServerSpecV2{
+			Addr:     "node.example.com:3022",
+			Hostname: "hostname",
+		})
+		require.NoError(t, err)
+		return node
+	}
+
+	nodeKeepAlive := func(name string) types.KeepAlive {
+		return types.KeepAlive{
+			Type:      types.KeepAlive_NODE,
+			Name:      name,
+			Namespace: apidefaults.Namespace,
+			Expires:   time.Now().Add(5 * time.Minute),
+		}
+	}
+
+	// node is authenticated as the built-in RoleNode for ownID.
+	node := newTestServerForHost(t, as, ownID, types.RoleNode)
+
+	t.Run("upsert own node allowed", func(t *testing.T) {
+		_, err := node.UpsertNode(ctx, makeNode(t, ownID))
+		require.NoError(t, err)
+	})
+
+	t.Run("upsert other node denied", func(t *testing.T) {
+		_, err := node.UpsertNode(ctx, makeNode(t, otherID))
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	t.Run("keepalive own node allowed", func(t *testing.T) {
+		require.NoError(t, node.KeepAliveServer(ctx, nodeKeepAlive(ownID)))
+	})
+
+	t.Run("keepalive other node denied", func(t *testing.T) {
+		err := node.KeepAliveServer(ctx, nodeKeepAlive(otherID))
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	t.Run("delete node denied", func(t *testing.T) {
+		err := node.DeleteNode(ctx, apidefaults.Namespace, ownID)
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	t.Run("delete all nodes denied", func(t *testing.T) {
+		err := node.DeleteAllNodes(ctx, apidefaults.Namespace)
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+}
+
+func TestRoleDatabaseLeastPrivilege(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+
+	const ownID = "00000000-0000-0000-0000-000000000001"
+	const otherID = "00000000-0000-0000-0000-000000000002"
+
+	makeDBServer := func(t *testing.T, hostID string) types.DatabaseServer {
+		server, err := types.NewDatabaseServerV3(types.Metadata{
+			Name: "db",
+		}, types.DatabaseServerSpecV3{
+			HostID:   hostID,
+			Hostname: "db.example.com",
+			Database: &types.DatabaseV3{
+				Metadata: types.Metadata{Name: "db"},
+				Spec: types.DatabaseSpecV3{
+					Protocol: "postgres",
+					URI:      "localhost:5432",
+				},
+			},
+		})
+		require.NoError(t, err)
+		return server
+	}
+
+	dbKeepAlive := func(hostID string) types.KeepAlive {
+		return types.KeepAlive{
+			Type:      types.KeepAlive_DATABASE,
+			Name:      "db",
+			Namespace: apidefaults.Namespace,
+			HostID:    hostID,
+			Expires:   time.Now().Add(5 * time.Minute),
+		}
+	}
+
+	// A DatabaseService is name-keyed: its name is the host ID of the db_service.
+	makeDBService := func(t *testing.T, hostID string) types.DatabaseService {
+		svc, err := types.NewDatabaseServiceV1(types.Metadata{
+			Name:      hostID,
+			Namespace: apidefaults.Namespace,
+		}, types.DatabaseServiceSpecV1{
+			ResourceMatchers: []*types.DatabaseResourceMatcher{
+				{Labels: &types.Labels{types.Wildcard: []string{types.Wildcard}}},
+			},
+		})
+		require.NoError(t, err)
+		return svc
+	}
+
+	dbServiceKeepAlive := func(hostID string) types.KeepAlive {
+		return types.KeepAlive{
+			Type:      types.KeepAlive_DATABASE_SERVICE,
+			Name:      hostID,
+			Namespace: apidefaults.Namespace,
+			Expires:   time.Now().Add(5 * time.Minute),
+		}
+	}
+
+	// db is authenticated as the built-in RoleDatabase for ownID.
+	db := newTestServerForHost(t, as, ownID, types.RoleDatabase)
+
+	t.Run("upsert own database service allowed", func(t *testing.T) {
+		_, err := db.UpsertDatabaseService(ctx, makeDBService(t, ownID))
+		require.NoError(t, err)
+	})
+
+	t.Run("upsert other database service denied", func(t *testing.T) {
+		_, err := db.UpsertDatabaseService(ctx, makeDBService(t, otherID))
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	t.Run("keepalive own database service allowed", func(t *testing.T) {
+		require.NoError(t, db.KeepAliveServer(ctx, dbServiceKeepAlive(ownID)))
+	})
+
+	t.Run("keepalive other database service denied", func(t *testing.T) {
+		err := db.KeepAliveServer(ctx, dbServiceKeepAlive(otherID))
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	t.Run("upsert own database server allowed", func(t *testing.T) {
+		_, err := db.UpsertDatabaseServer(ctx, makeDBServer(t, ownID))
+		require.NoError(t, err)
+	})
+
+	t.Run("upsert other database server denied", func(t *testing.T) {
+		_, err := db.UpsertDatabaseServer(ctx, makeDBServer(t, otherID))
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	t.Run("keepalive own database server allowed", func(t *testing.T) {
+		require.NoError(t, db.KeepAliveServer(ctx, dbKeepAlive(ownID)))
+	})
+
+	t.Run("keepalive other database server denied", func(t *testing.T) {
+		err := db.KeepAliveServer(ctx, dbKeepAlive(otherID))
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	// Seed both the database's own server and a foreign server directly in the backend.
+	_, err = as.AuthServer.UpsertDatabaseServer(ctx, makeDBServer(t, ownID))
+	require.NoError(t, err)
+	_, err = as.AuthServer.UpsertDatabaseServer(ctx, makeDBServer(t, otherID))
+	require.NoError(t, err)
+
+	t.Run("delete own database server allowed", func(t *testing.T) {
+		require.NoError(t, db.DeleteDatabaseServer(ctx, apidefaults.Namespace, ownID, "db"))
+	})
+
+	t.Run("delete other database server denied", func(t *testing.T) {
+		err := db.DeleteDatabaseServer(ctx, apidefaults.Namespace, otherID, "db")
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	t.Run("delete all database servers denied", func(t *testing.T) {
+		err := db.DeleteAllDatabaseServers(ctx, apidefaults.Namespace)
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+}
+
+func TestRoleAppLeastPrivilege(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+
+	const ownID = "00000000-0000-0000-0000-000000000001"
+	const otherID = "00000000-0000-0000-0000-000000000002"
+
+	makeAppServer := func(t *testing.T, hostID string) types.AppServer {
+		server, err := types.NewAppServerV3(types.Metadata{
+			Name: "app",
+		}, types.AppServerSpecV3{
+			HostID:   hostID,
+			Hostname: "app.example.com",
+			App: &types.AppV3{
+				Metadata: types.Metadata{Name: "app"},
+				Spec:     types.AppSpecV3{URI: "http://localhost:8080"},
+			},
+		})
+		require.NoError(t, err)
+		return server
+	}
+
+	appKeepAlive := func(hostID string) types.KeepAlive {
+		return types.KeepAlive{
+			Type:      types.KeepAlive_APP,
+			Name:      "app",
+			Namespace: apidefaults.Namespace,
+			HostID:    hostID,
+			Expires:   time.Now().Add(5 * time.Minute),
+		}
+	}
+
+	// legacyAppKeepAlive builds a pre-9.0 style keepalive with an empty HostID,
+	// exercising the fallback branch in KeepAliveServer that authorizes on Name.
+	legacyAppKeepAlive := func(name string) types.KeepAlive {
+		return types.KeepAlive{
+			Type:      types.KeepAlive_APP,
+			Name:      name,
+			Namespace: apidefaults.Namespace,
+			Expires:   time.Now().Add(5 * time.Minute),
+		}
+	}
+
+	// app is authenticated as the built-in RoleApp for ownID.
+	app := newTestServerForHost(t, as, ownID, types.RoleApp)
+	// okta is authenticated as the built-in RoleOkta for ownID.
+	okta := newTestServerForHost(t, as, ownID, types.RoleOkta)
+
+	t.Run("upsert own app server allowed", func(t *testing.T) {
+		_, err := app.UpsertApplicationServer(ctx, makeAppServer(t, ownID))
+		require.NoError(t, err)
+	})
+
+	t.Run("upsert other app server denied", func(t *testing.T) {
+		_, err := app.UpsertApplicationServer(ctx, makeAppServer(t, otherID))
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	t.Run("keepalive own app server allowed", func(t *testing.T) {
+		require.NoError(t, app.KeepAliveServer(ctx, appKeepAlive(ownID)))
+	})
+
+	t.Run("keepalive other app server denied", func(t *testing.T) {
+		err := app.KeepAliveServer(ctx, appKeepAlive(otherID))
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	t.Run("okta keepalive own app server allowed", func(t *testing.T) {
+		require.NoError(t, okta.KeepAliveServer(ctx, appKeepAlive(ownID)))
+	})
+
+	t.Run("okta keepalive other app server denied", func(t *testing.T) {
+		err := okta.KeepAliveServer(ctx, appKeepAlive(otherID))
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	t.Run("legacy keepalive own app server allowed", func(t *testing.T) {
+		// The pre-9.0 keepalive format has no HostID; the ownership check is
+		// keyed on handle.Name. Assert authorization succeeds even if the
+		// backend has no legacy-format server to update.
+		err := app.KeepAliveServer(ctx, legacyAppKeepAlive(ownID))
+		require.False(t, trace.IsAccessDenied(err), "unexpected access denied: %v", err)
+	})
+
+	t.Run("legacy keepalive other app server denied", func(t *testing.T) {
+		err := app.KeepAliveServer(ctx, legacyAppKeepAlive(otherID))
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	// Seed the app's own server and a foreign server directly in the backend.
+	_, err = as.AuthServer.UpsertApplicationServer(ctx, makeAppServer(t, ownID))
+	require.NoError(t, err)
+	_, err = as.AuthServer.UpsertApplicationServer(ctx, makeAppServer(t, otherID))
+	require.NoError(t, err)
+
+	t.Run("delete own app server allowed", func(t *testing.T) {
+		require.NoError(t, app.DeleteApplicationServer(ctx, apidefaults.Namespace, ownID, "app"))
+	})
+
+	t.Run("delete other app server denied", func(t *testing.T) {
+		err := app.DeleteApplicationServer(ctx, apidefaults.Namespace, otherID, "app")
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	t.Run("delete all app servers denied", func(t *testing.T) {
+		err := app.DeleteAllApplicationServers(ctx, apidefaults.Namespace)
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+}
+
+func TestRoleKubeLeastPrivilege(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+
+	const ownID = "00000000-0000-0000-0000-000000000001"
+	const otherID = "00000000-0000-0000-0000-000000000002"
+
+	makeKubeServer := func(t *testing.T, hostID string) types.KubeServer {
+		cluster, err := types.NewKubernetesClusterV3(types.Metadata{Name: "kube"}, types.KubernetesClusterSpecV3{})
+		require.NoError(t, err)
+		server, err := types.NewKubernetesServerV3(types.Metadata{
+			Name:      "kube",
+			Namespace: apidefaults.Namespace,
+		}, types.KubernetesServerSpecV3{
+			Cluster: cluster,
+			HostID:  hostID,
+		})
+		require.NoError(t, err)
+		return server
+	}
+
+	kubeKeepAlive := func(hostID string) types.KeepAlive {
+		return types.KeepAlive{
+			Type:      types.KeepAlive_KUBERNETES,
+			Name:      "kube",
+			Namespace: apidefaults.Namespace,
+			HostID:    hostID,
+			Expires:   time.Now().Add(5 * time.Minute),
+		}
+	}
+
+	// kube is authenticated as the built-in RoleKube for ownID.
+	kube := newTestServerForHost(t, as, ownID, types.RoleKube)
+
+	t.Run("upsert own kube server allowed", func(t *testing.T) {
+		_, err := kube.UpsertKubernetesServer(ctx, makeKubeServer(t, ownID))
+		require.NoError(t, err)
+	})
+
+	t.Run("upsert other kube server denied", func(t *testing.T) {
+		_, err := kube.UpsertKubernetesServer(ctx, makeKubeServer(t, otherID))
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	t.Run("keepalive own kube server allowed", func(t *testing.T) {
+		require.NoError(t, kube.KeepAliveServer(ctx, kubeKeepAlive(ownID)))
+	})
+
+	t.Run("keepalive other kube server denied", func(t *testing.T) {
+		err := kube.KeepAliveServer(ctx, kubeKeepAlive(otherID))
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	// Seed the kube service's own server and a foreign server directly in the backend.
+	_, err = as.AuthServer.UpsertKubernetesServer(ctx, makeKubeServer(t, ownID))
+	require.NoError(t, err)
+	_, err = as.AuthServer.UpsertKubernetesServer(ctx, makeKubeServer(t, otherID))
+	require.NoError(t, err)
+
+	t.Run("delete own kube server allowed", func(t *testing.T) {
+		require.NoError(t, kube.DeleteKubernetesServer(ctx, ownID, "kube"))
+	})
+
+	t.Run("delete other kube server denied", func(t *testing.T) {
+		err := kube.DeleteKubernetesServer(ctx, otherID, "kube")
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	t.Run("delete all kube servers denied", func(t *testing.T) {
+		err := kube.DeleteAllKubernetesServers(ctx)
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+}
+
+func TestRoleWindowsDesktopLeastPrivilege(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+
+	const ownID = "00000000-0000-0000-0000-000000000001"
+	const otherID = "00000000-0000-0000-0000-000000000002"
+
+	makeDesktopService := func(t *testing.T, hostID string) types.WindowsDesktopService {
+		svc, err := types.NewWindowsDesktopServiceV3(types.Metadata{
+			Name: hostID,
+		}, types.WindowsDesktopServiceSpecV3{
+			Addr:            "localhost:3028",
+			TeleportVersion: "1.0.0",
+		})
+		require.NoError(t, err)
+		return svc
+	}
+
+	desktopKeepAlive := func(hostID string) types.KeepAlive {
+		return types.KeepAlive{
+			Type:      types.KeepAlive_WINDOWS_DESKTOP,
+			Name:      hostID,
+			Namespace: apidefaults.Namespace,
+			Expires:   time.Now().Add(5 * time.Minute),
+		}
+	}
+
+	makeDesktop := func(t *testing.T, hostID string) types.WindowsDesktop {
+		d, err := types.NewWindowsDesktopV3("desktop", nil, types.WindowsDesktopSpecV3{
+			Addr:   "1.2.3.4",
+			HostID: hostID,
+		})
+		require.NoError(t, err)
+		return d
+	}
+
+	// desktop is authenticated as the built-in RoleWindowsDesktop for ownID.
+	desktop := newTestServerForHost(t, as, ownID, types.RoleWindowsDesktop)
+
+	t.Run("upsert own desktop service allowed", func(t *testing.T) {
+		_, err := desktop.UpsertWindowsDesktopService(ctx, makeDesktopService(t, ownID))
+		require.NoError(t, err)
+	})
+
+	t.Run("upsert other desktop service denied", func(t *testing.T) {
+		_, err := desktop.UpsertWindowsDesktopService(ctx, makeDesktopService(t, otherID))
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	t.Run("keepalive own desktop service allowed", func(t *testing.T) {
+		require.NoError(t, desktop.KeepAliveServer(ctx, desktopKeepAlive(ownID)))
+	})
+
+	t.Run("keepalive other desktop service denied", func(t *testing.T) {
+		err := desktop.KeepAliveServer(ctx, desktopKeepAlive(otherID))
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	// Seed the desktop service and a foreign service directly in the backend.
+	_, err = as.AuthServer.UpsertWindowsDesktopService(ctx, makeDesktopService(t, ownID))
+	require.NoError(t, err)
+	_, err = as.AuthServer.UpsertWindowsDesktopService(ctx, makeDesktopService(t, otherID))
+	require.NoError(t, err)
+
+	t.Run("delete own desktop service denied", func(t *testing.T) {
+		err := desktop.DeleteWindowsDesktopService(ctx, ownID)
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	t.Run("delete all desktop services denied", func(t *testing.T) {
+		err := desktop.DeleteAllWindowsDesktopServices(ctx)
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	t.Run("upsert own desktop allowed", func(t *testing.T) {
+		require.NoError(t, desktop.UpsertWindowsDesktop(ctx, makeDesktop(t, ownID)))
+	})
+
+	t.Run("upsert other desktop denied", func(t *testing.T) {
+		err := desktop.UpsertWindowsDesktop(ctx, makeDesktop(t, otherID))
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	// Seed the desktop service's own desktop and a foreign desktop directly in the backend.
+	err = as.AuthServer.UpsertWindowsDesktop(ctx, makeDesktop(t, ownID))
+	require.NoError(t, err)
+	err = as.AuthServer.UpsertWindowsDesktop(ctx, makeDesktop(t, otherID))
+	require.NoError(t, err)
+
+	t.Run("delete own desktop allowed", func(t *testing.T) {
+		require.NoError(t, desktop.DeleteWindowsDesktop(ctx, ownID, "desktop"))
+	})
+
+	t.Run("delete other desktop denied", func(t *testing.T) {
+		err := desktop.DeleteWindowsDesktop(ctx, otherID, "desktop")
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
 }

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -26,7 +26,6 @@ import (
 	"encoding/base32"
 	"encoding/pem"
 	"errors"
-	"fmt"
 	"net"
 	"net/url"
 	"os"
@@ -36,7 +35,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/pquerna/otp/totp"
@@ -1625,7 +1623,10 @@ func TestAppServerCRUD(t *testing.T) {
 
 	testSrv := newTestTLSServer(t)
 
-	clt, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleApp))
+	// A RoleApp agent may only manage app servers with its own host ID, so the
+	// identity's host ID and the app server's HostID must match.
+	const appHostID = "app-host-id"
+	clt, err := testSrv.NewClient(authtest.TestServerID(types.RoleApp, appHostID))
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -1644,7 +1645,7 @@ func TestAppServerCRUD(t *testing.T) {
 		Namespace: apidefaults.Namespace,
 	}, types.AppServerSpecV3{
 		Hostname: "localhost",
-		HostID:   uuid.New().String(),
+		HostID:   appHostID,
 		App:      app,
 	})
 	require.NoError(t, err)
@@ -4123,12 +4124,9 @@ func TestEventsNodePresence(t *testing.T) {
 		},
 	}
 	node.SetExpiry(time.Now().Add(2 * time.Second))
-	clt, err := testSrv.NewClient(authtest.TestIdentity{
-		I: authz.BuiltinRole{
-			Role:     types.RoleNode,
-			Username: fmt.Sprintf("%v.%v", node.Metadata.Name, testSrv.ClusterName()),
-		},
-	})
+	// A RoleNode agent may only manage the node resource matching its own host
+	// ID, so the identity's server ID must match the node's name.
+	clt, err := testSrv.NewClient(authtest.TestServerID(types.RoleNode, node.Metadata.Name))
 	require.NoError(t, err)
 	defer clt.Close()
 

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1010,7 +1010,8 @@ func definitionForBuiltinRole(clusterName string, recConfig readonly.SessionReco
 					Namespaces: []string{types.Wildcard},
 					NodeLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
 					Rules: []types.Rule{
-						types.NewRule(types.KindNode, services.RW()),
+						// Node agents have implicit permission to write their own node resource.
+						types.NewRule(types.KindNode, services.RO()),
 						types.NewRule(types.KindSSHSession, services.RW()),
 						types.NewRule(types.KindEvent, services.WO()),
 						types.NewRule(types.KindProxy, services.RO()),
@@ -1057,7 +1058,9 @@ func definitionForBuiltinRole(clusterName string, recConfig readonly.SessionReco
 						types.NewRule(types.KindClusterNetworkingConfig, services.RO()),
 						types.NewRule(types.KindSessionRecordingConfig, services.RO()),
 						types.NewRule(types.KindClusterAuthPreference, services.RO()),
-						types.NewRule(types.KindAppServer, services.RW()),
+						// App agents have implicit permission to write their own server resources.
+						types.NewRule(types.KindAppServer, services.RO()),
+						// App agents have implicit permission to write their own App resource.
 						types.NewRule(types.KindApp, services.RO()),
 						types.NewRule(types.KindJWT, services.RW()),
 						types.NewRule(types.KindLock, services.RO()),
@@ -1086,8 +1089,10 @@ func definitionForBuiltinRole(clusterName string, recConfig readonly.SessionReco
 						types.NewRule(types.KindClusterNetworkingConfig, services.RO()),
 						types.NewRule(types.KindSessionRecordingConfig, services.RO()),
 						types.NewRule(types.KindClusterAuthPreference, services.RO()),
-						types.NewRule(types.KindDatabaseServer, services.RW()),
-						types.NewRule(types.KindDatabaseService, services.RW()),
+						// Databases agents have implicit permission to write their own server resources.
+						types.NewRule(types.KindDatabaseServer, services.RO()),
+						// Databases agents have implicit permission to write their own service resource.
+						types.NewRule(types.KindDatabaseService, services.RO()),
 						types.NewRule(types.KindDatabase, services.RO()),
 						types.NewRule(types.KindSemaphore, services.RW()),
 						types.NewRule(types.KindLock, services.RO()),
@@ -1160,7 +1165,8 @@ func definitionForBuiltinRole(clusterName string, recConfig readonly.SessionReco
 					Namespaces:       []string{types.Wildcard},
 					KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
 					Rules: []types.Rule{
-						types.NewRule(types.KindKubeServer, services.RW()),
+						// Kube agents have implicit permission to write their own server resources.
+						types.NewRule(types.KindKubeServer, services.RO()),
 						types.NewRule(types.KindKubeWaitingContainer, services.RW()),
 						types.NewRule(types.KindEvent, services.WO()),
 						types.NewRule(types.KindCertAuthority, services.ReadNoSecrets()),
@@ -1173,6 +1179,7 @@ func definitionForBuiltinRole(clusterName string, recConfig readonly.SessionReco
 						types.NewRule(types.KindRole, services.RO()),
 						types.NewRule(types.KindNamespace, services.RO()),
 						types.NewRule(types.KindLock, services.RO()),
+						// Kube agents have implicit permission to write their own cluster resource.
 						types.NewRule(types.KindKubernetesCluster, services.RO()),
 						types.NewRule(types.KindSemaphore, services.RW()),
 					},
@@ -1197,8 +1204,10 @@ func definitionForBuiltinRole(clusterName string, recConfig readonly.SessionReco
 						types.NewRule(types.KindRole, services.RO()),
 						types.NewRule(types.KindNamespace, services.RO()),
 						types.NewRule(types.KindLock, services.RO()),
-						types.NewRule(types.KindWindowsDesktopService, services.RW()),
-						types.NewRule(types.KindWindowsDesktop, services.RW()),
+						// Desktop agents have implicit permission to write their own service resource.
+						types.NewRule(types.KindWindowsDesktopService, services.RO()),
+						// Desktop agents have implicit permission to write their own desktop resources.
+						types.NewRule(types.KindWindowsDesktop, services.RO()),
 						types.NewRule(types.KindDynamicWindowsDesktop, services.RW()),
 					},
 				},

--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -236,7 +236,7 @@ func testDynamicWindowsDiscovery(t *testing.T, client *authclient.Client, auth *
 	s := &WindowsService{
 		cfg: WindowsServiceConfig{
 			Heartbeat: HeartbeatConfig{
-				HostUUID: "1234",
+				HostUUID: "test-host-id",
 			},
 			Logger:               slog.New(slog.DiscardHandler),
 			Clock:                clockwork.NewRealClock(),
@@ -339,7 +339,7 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 		s := &WindowsService{
 			cfg: WindowsServiceConfig{
 				Heartbeat: HeartbeatConfig{
-					HostUUID: "1234",
+					HostUUID: "test-host-id",
 				},
 				Logger:      slog.New(slog.DiscardHandler),
 				Clock:       clockwork.NewRealClock(),

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -2563,19 +2563,6 @@ func TestParseSubsystemRequest(t *testing.T) {
 		}
 	}()
 
-	agentlessSrv := types.ServerV2{
-		Kind:    types.KindNode,
-		SubKind: types.SubKindOpenSSHNode,
-		Version: types.V2,
-		Metadata: types.Metadata{
-			Name: uuid.NewString(),
-		},
-		Spec: types.ServerSpecV2{
-			Addr:     agentlessListener.Addr().String(),
-			Hostname: "agentless",
-		},
-	}
-
 	getNonProxySession := func() func() *tracessh.Session {
 		f := newFixtureWithoutDiskBasedLogging(t, SetAllowFileCopying(true))
 		return func() *tracessh.Session {
@@ -2619,8 +2606,19 @@ func TestParseSubsystemRequest(t *testing.T) {
 		require.NoError(t, reverseTunnelServer.Start())
 		t.Cleanup(func() { _ = reverseTunnelServer.Close() })
 
-		nodeClient, _ := newNodeClient(t, f.testSrv)
-
+		nodeClient, nodeID := newNodeClient(t, f.testSrv)
+		agentlessSrv := types.ServerV2{
+			Kind:    types.KindNode,
+			SubKind: types.SubKindOpenSSHNode,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name: nodeID,
+			},
+			Spec: types.ServerSpecV2{
+				Addr:     agentlessListener.Addr().String(),
+				Hostname: "agentless",
+			},
+		}
 		_, err = nodeClient.UpsertNode(ctx, &agentlessSrv)
 		require.NoError(t, err)
 
@@ -2709,7 +2707,7 @@ func TestParseSubsystemRequest(t *testing.T) {
 		},
 		{
 			name:                 "proxy:agentlessServer",
-			subsystemOverride:    "proxy:" + agentlessSrv.Spec.Addr,
+			subsystemOverride:    "proxy:" + agentlessListener.Addr().String(),
 			wantErrInProxyMode:   false,
 			wantErrInRegularMode: true,
 		},


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/68400 to branch/v17

Changelog: Remove generic write permissions of system agents on agent backend resources, instead only giving permissions to write resources that match the agent's host ID.

## Manual Test Plan
### Test Environment

In order to exercise the updated auth endpoints, prepare a modified agent binary which uses heartbeat v1 and deletes child resources (e.g. servers). 

Note: heartbeat v2 (used by SSH, Kube, App, and partially by DB) uses an inventory control stream to handle authorization rather than impacted gRPC authz flow (`authWithRoles`).

### Test Cases

- [x] Node 
  - [x] appears in `tctl get node`
  - [x] expiry advances with heartbeats
- [x] App
  - [x] static server appears in `tctl get app_server`
  - [x] dynamic server appears in `tctl get app_server`
  - [x] host_id is correctly set on both servers
  - [x] expiry advances with heartbeats for both servers
  - [x] graceful shutdown removes both servers
- [x] Kube
  - [x] static server appears in `tctl get kube_server`
  - [x] dynamic server appears in `tctl get kube_server`
  - [x] host_id is correctly set on both servers
  - [x] expiry advances with heartbeats for both servers
  - [x] graceful shutdown removes both servers
- [x] DB
  - [x] static server appears in `tctl get db_server`
  - [x] dynamic server appears in `tctl get db_server`
  - [x] host_id is correctly set on both servers
  - [x] expiry advances with heartbeats
  - [x] graceful shutdown removes servers
- [x] Desktop
  - [x] static desktop appears in `tctl get windows_desktop`
  - [x] dynamic desktop appears in `tctl get windows_desktop`
  - [x] host_id is correctly set on both desktops
  - [x] expiry advances with heartbeats
  - [x] graceful shutdown removes desktops
- [x] Agentless (`teleport join openssh`) 
  - [x] appears in `tctl get node`
  - [x] Calling the join command again updates revision