### PR TITLE
[e2e] Allow e2e tests to declare a custom Teleport config

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -172,6 +172,27 @@ the same `user`/`users`. Concretely:
 `e2e/.auth/<browser>-<username>.json`. Tests pick up that state via Playwright's `storageState`, so they
 start already authenticated without running the UI login flow.
 
+### Teleport config
+
+If a test requires a Teleport config different from the base config that e2e tests use by default, it can declare one
+with `test.use({ teleport: { config: {...} } })`. The `config` will be deep merged and with the base config. Each test file may only
+declare up to one custom config. Values are evaluated as a JS object literal, so they must be static (no imports or function calls).
+
+```ts
+test.use({
+  teleport: {
+    config: {
+      auth_service: {
+        license_file: '${E2E_DIR}/testdata/licenses/custom-license.pem',
+      },
+    },
+  },
+});
+```
+
+Note that the e2e runner will only restart Teleport with the different config and not re-initialize it from fresh, so the data directory
+will remains the same for all tests which means the cluster's identity like cluster name, CA, bootstrapped users, and roles will carry over unchanged.
+
 ### Session Recordings
 
 The runner automatically seeds session recordings into Teleport's data directory at startup so the Web UI's

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -175,19 +175,20 @@ start already authenticated without running the UI login flow.
 ### Teleport config
 
 If a test requires a Teleport config different from the base config that e2e tests use by default, it can declare one
-with `test.use({ teleport: { config: {...} } })`. The `config` is deep merged into the base config. A config can be either be 
-declared at the top of the file (for it to apply to all tests in the file), or inside a specific `test.describe()` block.
+with `test.use({ teleport: { config: {...} } })` inside a `test.describe()` block.
 Values are evaluated as a JS object literal, so they must be static (no imports or function calls).
 
 ```ts
-test.use({
-  teleport: {
-    config: {
-      auth_service: {
-        license_file: '${E2E_DIR}/testdata/licenses/custom-license.pem',
+test.describe('custom license', () => {
+  test.use({
+    teleport: {
+      config: {
+        auth_service: {
+          license_file: '${E2E_DIR}/testdata/licenses/custom-license.pem',
+        },
       },
     },
-  },
+  });
 });
 ```
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -175,8 +175,9 @@ start already authenticated without running the UI login flow.
 ### Teleport config
 
 If a test requires a Teleport config different from the base config that e2e tests use by default, it can declare one
-with `test.use({ teleport: { config: {...} } })`. The `config` will be deep merged and with the base config. Each test file may only
-declare up to one custom config. Values are evaluated as a JS object literal, so they must be static (no imports or function calls).
+with `test.use({ teleport: { config: {...} } })`. The `config` is deep merged into the base config. A config can be either be 
+declared at the top of the file (for it to apply to all tests in the file), or inside a specific `test.describe()` block.
+Values are evaluated as a JS object literal, so they must be static (no imports or function calls).
 
 ```ts
 test.use({

--- a/e2e/helpers/test.ts
+++ b/e2e/helpers/test.ts
@@ -58,6 +58,13 @@ export interface UserDefinition {
   loginAs?: boolean;
 }
 
+/**
+ * TeleportOption lets a test declare a custom Teleport cluster config to use.
+ **/
+export interface TeleportOption {
+  config: Record<string, unknown>;
+}
+
 const e2eDir =
   process.env.E2E_DIR ?? join(dirname(fileURLToPath(import.meta.url)), '..');
 const authDir = join(e2eDir, '.auth');
@@ -75,6 +82,7 @@ interface E2EFixtures {
   recordings: string[];
   user: UserDefinition;
   users: UserDefinition[];
+  teleport: TeleportOption;
   username: string;
   loginAs: (index: number) => Promise<LoginAsResult>;
   recordingIds: Record<string, string>;
@@ -95,6 +103,7 @@ export const test = base.extend<E2EFixtures>({
   recordings: [[], { option: true }],
   user: [undefined as unknown as UserDefinition, { option: true }],
   users: [[], { option: true }],
+  teleport: [undefined as unknown as TeleportOption, { option: true }],
   username: async ({ user, users }, use, testInfo) => {
     const mapping = tryLoadUserMapping() ?? {};
 

--- a/e2e/runner/go.mod
+++ b/e2e/runner/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/lmittmann/tint v1.1.3
 	github.com/moby/moby/api v1.54.2
 	github.com/moby/moby/client v0.4.1
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.54.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0
@@ -235,7 +236,6 @@ require (
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/theupdateframework/go-tuf/v2 v2.4.2-0.20260407074541-7e8f69f906ef // indirect
 	github.com/tidwall/gjson v1.14.4 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/e2e/runner/main.go
+++ b/e2e/runner/main.go
@@ -146,6 +146,9 @@ type e2eConfig struct {
 
 	instances       []*testInstance
 	connectInstance *testInstance
+
+	// teleportConfigs are the unique custom Teleport configs declared by tests.
+	teleportConfigs []uniqueTeleportConfig
 }
 
 // run sets up the test environment (ports, certs, credentials, teleport instance)
@@ -290,6 +293,11 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 			return fmt.Errorf("failed to scan users: %w", err)
 		}
 		slog.Debug("discovered bootstrap users", "count", len(scannedUsers))
+
+		config.teleportConfigs, err = scanTeleportConfigs(targets)
+		if err != nil {
+			return fmt.Errorf("failed to scan teleport configs: %w", err)
+		}
 
 		bootstrap, err := buildBootstrapState(e2eDir, scannedUsers)
 		if err != nil {

--- a/e2e/runner/main.go
+++ b/e2e/runner/main.go
@@ -149,6 +149,8 @@ type e2eConfig struct {
 
 	// teleportConfigs are the unique custom Teleport configs declared by tests.
 	teleportConfigs []uniqueTeleportConfig
+	// defaultTestFiles are the selectors for the tests that run against the base config.
+	defaultTestFiles []string
 }
 
 // run sets up the test environment (ports, certs, credentials, teleport instance)
@@ -294,7 +296,7 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 		}
 		slog.Debug("discovered bootstrap users", "count", len(scannedUsers))
 
-		config.teleportConfigs, err = scanTeleportConfigs(targets)
+		config.teleportConfigs, config.defaultTestFiles, err = scanTeleportConfigs(targets)
 		if err != nil {
 			return fmt.Errorf("failed to scan teleport configs: %w", err)
 		}

--- a/e2e/runner/playwright.go
+++ b/e2e/runner/playwright.go
@@ -29,6 +29,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -36,6 +37,8 @@ import (
 type playwrightRunner struct {
 	config *e2eConfig
 }
+
+var baseProjects = []string{"authenticated", "unauthenticated"}
 
 func (p *playwrightRunner) startURL(inst *testInstance) string {
 	if p.config.teleportURL != "" {
@@ -95,8 +98,6 @@ func (p *playwrightRunner) test(ctx context.Context, debug bool) error {
 		return fmt.Errorf("cleaning blob-reports directory: %w", err)
 	}
 
-	baseProjects := []string{"authenticated", "unauthenticated"}
-
 	var extraArgs []string
 	if p.config.updateSnapshots {
 		extraArgs = append(extraArgs, "--update-snapshots")
@@ -113,38 +114,27 @@ func (p *playwrightRunner) test(ctx context.Context, debug bool) error {
 			}
 			defer inst.stop()
 
-			env, err := p.startEnv(inst)
-			if err != nil {
-				return fmt.Errorf("building env for %s: %w", inst.browser, err)
-			}
-			if debug {
-				env = append(env, "PWDEBUG=1")
-			}
-
-			env = append(env, "PLAYWRIGHT_BLOB_OUTPUT_FILE="+filepath.Join(blobBaseDir, inst.browser+".zip"))
-
-			args := []string{"exec", "playwright", "test", p.configFlag()}
-			args = append(args, extraArgs...)
-			args = append(args, "--reporter=blob,"+filepath.Join(p.config.sharedDir, "scripts", "dot-progress-reporter.ts"))
-			// Avoid `.playwright-artifacts-<n>` collisions across parallel pnpm runs.
-			args = append(args, "--output=test-results/"+inst.browser)
-
-			for _, proj := range baseProjects {
-				args = append(args, "--project="+inst.browser+":"+proj)
+			// The default pass runs all the tests that didn't declare a custom config.
+			hasConfigs := len(p.config.teleportConfigs) > 0
+			defaultFiles := p.config.testFiles
+			if hasConfigs {
+				defaultFiles = defaultConfigFiles(p.config.scanTargets, p.config.teleportConfigs)
 			}
 
-			if len(p.config.testFiles) > 0 {
-				args = append(args, p.config.testFiles...)
+			// Skip the default pass if every selected test declared a custom config (nothing left to run against the base config).
+			if !hasConfigs || len(defaultFiles) > 0 {
+				blobPath := filepath.Join(blobBaseDir, inst.browser+".zip")
+				if err := p.runInstanceTests(ctx, inst, defaultFiles, blobPath, debug, extraArgs); err != nil {
+					return err
+				}
 			}
 
-			if len(p.config.testFiles) > 0 {
-				inst.log.Info("running e2e tests", "files", p.config.testFiles)
-			} else {
-				inst.log.Info("running e2e tests", "projects", baseProjects)
-			}
-
-			if err := p.pnpm(ctx, args, env); err != nil {
-				return fmt.Errorf("playwright tests failed for %s: %w", inst.browser, err)
+			// Re-init Teleport with each unique custom declared config and run that config's tests.
+			baseConfigPath := inst.teleportConfigPath
+			for i, cfg := range p.config.teleportConfigs {
+				if err := p.runTeleportConfig(ctx, inst, baseConfigPath, cfg, i, blobBaseDir, debug, extraArgs); err != nil {
+					return err
+				}
 			}
 			return nil
 		})
@@ -211,6 +201,64 @@ func (p *playwrightRunner) test(ctx context.Context, debug bool) error {
 	}
 
 	return testErr
+}
+
+// runInstanceTests runs Playwright against a running Teleport instance for the
+// given test files. If `files` is empty, all tests are run.
+func (p *playwrightRunner) runInstanceTests(ctx context.Context, inst *testInstance, files []string, blobPath string, debug bool, extraArgs []string) error {
+	env, err := p.startEnv(inst)
+	if err != nil {
+		return fmt.Errorf("building env for %s: %w", inst.browser, err)
+	}
+	if debug {
+		env = append(env, "PWDEBUG=1")
+	}
+	env = append(env, "PLAYWRIGHT_BLOB_OUTPUT_FILE="+blobPath)
+
+	args := []string{"exec", "playwright", "test", p.configFlag()}
+	args = append(args, extraArgs...)
+	args = append(args, "--reporter=blob,"+filepath.Join(p.config.sharedDir, "scripts", "dot-progress-reporter.ts"))
+	// Avoid `.playwright-artifacts-<n>` collisions across parallel pnpm runs.
+	args = append(args, "--output=test-results/"+inst.browser)
+	for _, proj := range baseProjects {
+		args = append(args, "--project="+inst.browser+":"+proj)
+	}
+	args = append(args, files...)
+
+	if len(files) > 0 {
+		inst.log.Info("running e2e tests", "files", files)
+	} else {
+		inst.log.Info("running e2e tests", "projects", baseProjects)
+	}
+
+	if err := p.pnpm(ctx, args, env); err != nil {
+		return fmt.Errorf("playwright tests failed for %s: %w", inst.browser, err)
+	}
+	return nil
+}
+
+// runTeleportConfig re-inits the instance's Teleport with a test-declared config.
+func (p *playwrightRunner) runTeleportConfig(ctx context.Context, inst *testInstance, baseConfigPath string, cfg uniqueTeleportConfig, idx int, blobBaseDir string, debug bool, extraArgs []string) error {
+	inst.log.Info("re-initializing teleport with a test-declared config", "files", cfg.files)
+
+	inst.teleport.stop()
+
+	mergedPath := filepath.Join(p.config.e2eDir, "config", fmt.Sprintf("%s-teleport-config-%d.yaml", inst.browser, idx))
+	if err := mergeTeleportConfig(baseConfigPath, mergedPath, p.config.e2eDir, cfg.raw); err != nil {
+		return fmt.Errorf("merging teleport config for %s: %w", inst.browser, err)
+	}
+	inst.teleport.configPath = mergedPath
+	inst.teleportConfigPath = mergedPath
+
+	if err := inst.teleport.start(ctx); err != nil {
+		return fmt.Errorf("re-initializing teleport for %s: %w", inst.browser, err)
+	}
+	if err := inst.teleport.waitReady(ctx, 30*time.Second); err != nil {
+		return fmt.Errorf("teleport for %s not ready after config change: %w", inst.browser, err)
+	}
+
+	blobPath := filepath.Join(blobBaseDir, fmt.Sprintf("%s-config-%d.zip", inst.browser, idx))
+	return p.runInstanceTests(ctx, inst, cfg.files, blobPath, debug, extraArgs)
 }
 
 func (p *playwrightRunner) ui(ctx context.Context) error {

--- a/e2e/runner/playwright.go
+++ b/e2e/runner/playwright.go
@@ -153,10 +153,10 @@ func (p *playwrightRunner) runInstance(ctx context.Context, inst *testInstance, 
 	hasConfigs := len(p.config.teleportConfigs) > 0
 	defaultFiles := filesForProject(inst, p.config.testFiles)
 	if hasConfigs {
-		defaultFiles = filesForProject(inst, defaultConfigFiles(p.config.scanTargets, p.config.teleportConfigs))
+		defaultFiles = filesForProject(inst, p.config.defaultTestFiles)
 	}
 
-	// Skip the default pass if there's nothing to run against the base config
+	// Skip the default pass if this instance has nothing to run against the base config
 	if !hasConfigs || len(defaultFiles) > 0 {
 		blobPath := filepath.Join(blobBaseDir, inst.browser+".zip")
 		if err := p.runInstanceTests(ctx, inst, defaultFiles, blobPath, debug, extraArgs); err != nil {
@@ -248,6 +248,12 @@ func (p *playwrightRunner) runTeleportConfig(ctx context.Context, inst *testInst
 	}
 	if err := inst.teleport.waitReady(ctx, 30*time.Second); err != nil {
 		return fmt.Errorf("teleport for %s not ready after config change: %w", inst.browser, err)
+	}
+
+	if inst.node != nil {
+		if err := inst.node.waitJoined(ctx, 30*time.Second); err != nil {
+			return fmt.Errorf("node for %s failed to rejoin: %w", inst.browser, err)
+		}
 	}
 
 	blobPath := filepath.Join(blobBaseDir, fmt.Sprintf("%s-config-%d.zip", inst.browser, idx))

--- a/e2e/runner/playwright.go
+++ b/e2e/runner/playwright.go
@@ -109,72 +109,13 @@ func (p *playwrightRunner) test(ctx context.Context, debug bool) error {
 
 	for _, inst := range p.config.instances {
 		g.Go(func() error {
-			if err := inst.start(ctx); err != nil {
-				return err
-			}
-			defer inst.stop()
-
-			// The default pass runs all the tests that didn't declare a custom config.
-			hasConfigs := len(p.config.teleportConfigs) > 0
-			defaultFiles := p.config.testFiles
-			if hasConfigs {
-				defaultFiles = defaultConfigFiles(p.config.scanTargets, p.config.teleportConfigs)
-			}
-
-			// Skip the default pass if every selected test declared a custom config (nothing left to run against the base config).
-			if !hasConfigs || len(defaultFiles) > 0 {
-				blobPath := filepath.Join(blobBaseDir, inst.browser+".zip")
-				if err := p.runInstanceTests(ctx, inst, defaultFiles, blobPath, debug, extraArgs); err != nil {
-					return err
-				}
-			}
-
-			// Re-init Teleport with each unique custom declared config and run that config's tests.
-			baseConfigPath := inst.teleportConfigPath
-			for i, cfg := range p.config.teleportConfigs {
-				if err := p.runTeleportConfig(ctx, inst, baseConfigPath, cfg, i, blobBaseDir, debug, extraArgs); err != nil {
-					return err
-				}
-			}
-			return nil
+			return p.runInstance(ctx, inst, blobBaseDir, debug, extraArgs)
 		})
 	}
 
 	if ci := p.config.connectInstance; ci != nil {
 		g.Go(func() error {
-			if err := ci.start(ctx); err != nil {
-				return err
-			}
-			defer ci.stop()
-
-			env, err := p.startEnv(ci)
-			if err != nil {
-				return fmt.Errorf("building env for connect: %w", err)
-			}
-			if debug {
-				env = append(env, "PWDEBUG=1")
-			}
-
-			env = append(env, "PLAYWRIGHT_BLOB_OUTPUT_FILE="+filepath.Join(blobBaseDir, "connect.zip"))
-
-			args := []string{"exec", "playwright", "test", p.configFlag()}
-			args = append(args, extraArgs...)
-			args = append(args, "--reporter=blob,"+filepath.Join(p.config.sharedDir, "scripts", "dot-progress-reporter.ts"), "--project=connect", "--output=test-results/connect")
-
-			if len(p.config.testFiles) > 0 {
-				args = append(args, p.config.testFiles...)
-			}
-
-			if len(p.config.testFiles) > 0 {
-				ci.log.Info("running e2e tests", "files", p.config.testFiles)
-			} else {
-				ci.log.Info("running e2e tests", "projects", []string{"connect"})
-			}
-
-			if err := p.pnpm(ctx, args, env); err != nil {
-				return fmt.Errorf("playwright tests failed for connect: %w", err)
-			}
-			return nil
+			return p.runInstance(ctx, ci, blobBaseDir, debug, extraArgs)
 		})
 	}
 
@@ -203,6 +144,54 @@ func (p *playwrightRunner) test(ctx context.Context, debug bool) error {
 	return testErr
 }
 
+func (p *playwrightRunner) runInstance(ctx context.Context, inst *testInstance, blobBaseDir string, debug bool, extraArgs []string) error {
+	if err := inst.start(ctx); err != nil {
+		return err
+	}
+	defer inst.stop()
+
+	hasConfigs := len(p.config.teleportConfigs) > 0
+	defaultFiles := filesForProject(inst, p.config.testFiles)
+	if hasConfigs {
+		defaultFiles = filesForProject(inst, defaultConfigFiles(p.config.scanTargets, p.config.teleportConfigs))
+	}
+
+	// Skip the default pass if there's nothing to run against the base config
+	if !hasConfigs || len(defaultFiles) > 0 {
+		blobPath := filepath.Join(blobBaseDir, inst.browser+".zip")
+		if err := p.runInstanceTests(ctx, inst, defaultFiles, blobPath, debug, extraArgs); err != nil {
+			return err
+		}
+	}
+
+	baseConfigPath := inst.teleportConfigPath
+	for i, cfg := range p.config.teleportConfigs {
+		files := filesForProject(inst, cfg.files)
+		if len(files) == 0 {
+			continue // no tests for this instance's project
+		}
+		if err := p.runTeleportConfig(ctx, inst, baseConfigPath, cfg, files, i, blobBaseDir, debug, extraArgs); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// filesForProject picks the connect specs or browser specs for a testInstance
+func filesForProject(inst *testInstance, files []string) []string {
+	if len(files) == 0 {
+		return files
+	}
+	var out []string
+	for _, f := range files {
+		isConnect := strings.HasPrefix(filepath.ToSlash(f), "tests/connect/")
+		if isConnect == (inst.browser == "connect") {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
 // runInstanceTests runs Playwright against a running Teleport instance for the
 // given test files. If `files` is empty, all tests are run.
 func (p *playwrightRunner) runInstanceTests(ctx context.Context, inst *testInstance, files []string, blobPath string, debug bool, extraArgs []string) error {
@@ -220,8 +209,12 @@ func (p *playwrightRunner) runInstanceTests(ctx context.Context, inst *testInsta
 	args = append(args, "--reporter=blob,"+filepath.Join(p.config.sharedDir, "scripts", "dot-progress-reporter.ts"))
 	// Avoid `.playwright-artifacts-<n>` collisions across parallel pnpm runs.
 	args = append(args, "--output=test-results/"+inst.browser)
-	for _, proj := range baseProjects {
-		args = append(args, "--project="+inst.browser+":"+proj)
+	if inst.browser == "connect" {
+		args = append(args, "--project=connect")
+	} else {
+		for _, proj := range baseProjects {
+			args = append(args, "--project="+inst.browser+":"+proj)
+		}
 	}
 	args = append(args, files...)
 
@@ -238,8 +231,8 @@ func (p *playwrightRunner) runInstanceTests(ctx context.Context, inst *testInsta
 }
 
 // runTeleportConfig re-inits the instance's Teleport with a test-declared config.
-func (p *playwrightRunner) runTeleportConfig(ctx context.Context, inst *testInstance, baseConfigPath string, cfg uniqueTeleportConfig, idx int, blobBaseDir string, debug bool, extraArgs []string) error {
-	inst.log.Info("re-initializing teleport with a test-declared config", "files", cfg.files)
+func (p *playwrightRunner) runTeleportConfig(ctx context.Context, inst *testInstance, baseConfigPath string, cfg uniqueTeleportConfig, files []string, idx int, blobBaseDir string, debug bool, extraArgs []string) error {
+	inst.log.Info("re-initializing teleport with a test-declared config", "files", files)
 
 	inst.teleport.stop()
 
@@ -258,7 +251,7 @@ func (p *playwrightRunner) runTeleportConfig(ctx context.Context, inst *testInst
 	}
 
 	blobPath := filepath.Join(blobBaseDir, fmt.Sprintf("%s-config-%d.zip", inst.browser, idx))
-	return p.runInstanceTests(ctx, inst, cfg.files, blobPath, debug, extraArgs)
+	return p.runInstanceTests(ctx, inst, files, blobPath, debug, extraArgs)
 }
 
 func (p *playwrightRunner) ui(ctx context.Context) error {

--- a/e2e/runner/scan.go
+++ b/e2e/runner/scan.go
@@ -29,6 +29,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/gravitational/teleport/e2e/runner/fixtures"
 )
@@ -282,13 +283,11 @@ func parseHelperImports(path string) []string {
 }
 
 func scanFile(path string, targetLine int) []*fixtures.Fixture {
-	data, err := os.ReadFile(path)
-	if err != nil {
+	cleaned, ok := readCleaned(path)
+	if !ok {
 		return nil
 	}
 
-	lines := strings.Split(string(data), "\n")
-	cleaned := stripComments(lines)
 	blocks := parseBlocks(cleaned)
 	content := strings.Join(cleaned, "\n")
 
@@ -309,6 +308,16 @@ func scanFile(path string, targetLine int) []*fixtures.Fixture {
 	}
 
 	return result
+}
+
+// readCleaned reads a spec file and returns its lines with comments stripped.
+func readCleaned(path string) ([]string, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		slog.Warn("scan: could not read file", "path", path, "error", err)
+		return nil, false
+	}
+	return stripComments(strings.Split(string(data), "\n")), true
 }
 
 func stripComments(lines []string) []string {
@@ -577,17 +586,11 @@ func defaultUsers() []scannedUser {
 // are rejected if they declare user/users/recordings since runtime would
 // merge them into every importing spec.
 func scanFileUsers(path string, targetLine int, sourceFile string) ([]scannedUser, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		// Helper module paths are guessed from import names (see
-		// resolveTargetsWithHelpers), so the file may not exist. Warn
-		// but continue rather than failing the whole scan.
-		slog.Warn("scan: could not read file", "path", path, "error", err)
+	cleaned, ok := readCleaned(path)
+	if !ok {
 		return nil, nil
 	}
 
-	lines := strings.Split(string(data), "\n")
-	cleaned := stripComments(lines)
 	blocks := parseBlocks(cleaned)
 	content := strings.Join(cleaned, "\n")
 
@@ -1108,4 +1111,128 @@ func sortRoles(roles []scannedRole) {
 
 		return strings.Compare(a.file, b.file)
 	})
+}
+
+// uniqueTeleportConfig is a distinct custom Teleport config declared by one or more
+// test files, and the test files that declare it.
+type uniqueTeleportConfig struct {
+	// raw is the config object's raw JS text.
+	raw string
+	// files are the test files that declared this config.
+	files []string
+}
+
+// scanTeleportConfigs looks for custom Teleport config declarations, dedupes them, and
+// returns them alongside the test files using them.
+func scanTeleportConfigs(targets []scanTarget) ([]uniqueTeleportConfig, error) {
+	byKey := make(map[string]*uniqueTeleportConfig)
+	var order []string
+
+	for _, t := range targets {
+		if t.sourceFile == "" {
+			continue
+		}
+
+		raw, err := scanFileTeleportConfig(t.path)
+		if err != nil {
+			return nil, err
+		}
+		if raw == "" {
+			continue
+		}
+
+		key := normalizeConfigText(raw)
+		u, ok := byKey[key]
+		if !ok {
+			u = &uniqueTeleportConfig{raw: raw}
+			byKey[key] = u
+			order = append(order, key)
+		}
+		u.files = append(u.files, t.sourceFile)
+	}
+
+	result := make([]uniqueTeleportConfig, 0, len(order))
+	for _, k := range order {
+		result = append(result, *byKey[k])
+	}
+	return result, nil
+}
+
+// scanFileTeleportConfig returns the teleport config object text declared in a
+// test file, or "" if none.
+func scanFileTeleportConfig(path string) (string, error) {
+	cleaned, ok := readCleaned(path)
+	if !ok {
+		return "", nil
+	}
+	return extractTeleportConfig(strings.Join(cleaned, "\n"), path)
+}
+
+// extractTeleportConfig pulls the `config` object out of every
+// test.use({ teleport: { config: {...} } }) call in content.
+func extractTeleportConfig(content, path string) (string, error) {
+	var found string
+
+	for _, call := range findTestUseCalls(content) {
+		body := content[call.start:call.end]
+
+		teleportOpen, teleportClose := findKeyValueAtDepth(body, "teleport", '{', '}', 1)
+		if teleportOpen < 0 {
+			continue
+		}
+
+		teleportBody := body[teleportOpen:teleportClose]
+		configOpen, configClose := findKeyValueAtDepth(teleportBody, "config", '{', '}', 1)
+		if configOpen < 0 {
+			return "", fmt.Errorf("%s: test.use({ teleport }) must contain a `config` object", path)
+		}
+
+		raw := teleportBody[configOpen:configClose]
+if found != "" && strings.Join(strings.Fields(found), " ") != strings.Join(strings.Fields(raw), " ") {
+      return "", fmt.Errorf("%s: a test file may only declare one teleport config", path)
+}
+found = raw
+	}
+
+	return found, nil
+}
+
+// normalizeConfigText gets rid of whitespace.
+func normalizeConfigText(s string) string {
+	var b strings.Builder
+	space := false
+	for _, r := range s {
+		if unicode.IsSpace(r) {
+			space = true
+			continue
+		}
+		if space && b.Len() > 0 {
+			b.WriteByte(' ')
+		}
+		space = false
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// defaultConfigFiles returns the test files that didn't declare a custom config and thus will use the default base config.
+func defaultConfigFiles(targets []scanTarget, configs []uniqueTeleportConfig) []string {
+	if len(configs) == 0 {
+		return nil
+	}
+
+	configured := make(map[string]bool)
+	for _, c := range configs {
+		for _, f := range c.files {
+			configured[f] = true
+		}
+	}
+
+	var out []string
+	for _, t := range targets {
+		if t.sourceFile != "" && !configured[t.sourceFile] {
+			out = append(out, t.sourceFile)
+		}
+	}
+	return out
 }

--- a/e2e/runner/scan.go
+++ b/e2e/runner/scan.go
@@ -40,6 +40,9 @@ var (
 	fixtureRefRe       = regexp.MustCompile(`['"]([^'"]+)['"]`)
 	helperImportRe     = regexp.MustCompile(`from\s+['"]@gravitational/e2e/helpers/(\w+)['"]`)
 	roleFileRe         = regexp.MustCompile(`\bfile:\s*['"]@gravitational/e2e/roles/([^'"]+)['"]`)
+	describeTitleRe    = regexp.MustCompile(`\.describe\(\s*['"]([^'"]*)['"]`)
+	testDefRe          = regexp.MustCompile(`\btest(?:\.(?:only|skip|fixme))?\(\s*['"]`)
+	teleportKeyRe      = regexp.MustCompile(`\bteleport\s*:`)
 
 	// The "key" regexes below require a word boundary so identifiers like
 	// `super_user:` or `myRoles:` don't match as `user:` / `roles:`.
@@ -1122,29 +1125,38 @@ type uniqueTeleportConfig struct {
 	files []string
 }
 
-// scanTeleportConfigs looks for custom Teleport config declarations, dedupes them, and
-// returns them alongside the test files using them.
-func scanTeleportConfigs(targets []scanTarget) ([]uniqueTeleportConfig, error) {
+// scanTeleportConfigs finds the unique custom Teleport configs declared by tests
+// and the base-config selectors (tests that run without one).
+func scanTeleportConfigs(targets []scanTarget) ([]uniqueTeleportConfig, []string, error) {
 	byKey := make(map[string]*uniqueTeleportConfig)
 	var order []string
+	var defaults []string
 
 	for _, t := range targets {
+		cleaned, ok := readCleaned(t.path)
+		if !ok {
+			continue
+		}
+		content := strings.Join(cleaned, "\n")
+
+		// A config declared in a helper has no describe to scope it to so it should be rejected
 		if t.sourceFile == "" {
+			for _, call := range findTestUseCalls(content) {
+				if open, _ := findKeyValueAtDepth(content[call.start:call.end], "teleport", '{', '}', 1); open >= 0 {
+					return nil, nil, fmt.Errorf(
+						"%s:%d: helper modules cannot declare teleport: in test.use()",
+						t.path, 1+strings.Count(content[:call.start], "\n"))
+				}
+			}
 			continue
 		}
 
-		configs, err := scanFileTeleportConfig(t.path)
+		configs, err := extractTeleportConfigs(content, parseBlocks(cleaned), t.path)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		for _, sc := range configs {
-			// Block-scoped configs target their describe and file-level ones target the whole file
-			line := sc.line
-			if line == 0 {
-				line = t.line
-			}
-
 			key := normalizeConfigText(sc.raw)
 			u, ok := byKey[key]
 			if !ok {
@@ -1152,35 +1164,55 @@ func scanTeleportConfigs(targets []scanTarget) ([]uniqueTeleportConfig, error) {
 				byKey[key] = u
 				order = append(order, key)
 			}
-			u.files = append(u.files, fileSelector(t.sourceFile, line))
+			u.files = append(u.files, fileSelector(t.sourceFile, sc.line))
 		}
+
+		defaults = append(defaults, defaultSelectors(t.sourceFile, content, configs, t.line)...)
 	}
 
 	result := make([]uniqueTeleportConfig, 0, len(order))
 	for _, k := range order {
 		result = append(result, *byKey[k])
 	}
-	return result, nil
+	return result, defaults, nil
 }
 
-// scopedTeleportConfig is a declared config and its scope line, 0 for a
-// file-level test.use or the describe's line for a block-scoped one
-type scopedTeleportConfig struct {
-	raw  string
-	line int
-}
-
-// scanFileTeleportConfig returns the teleport config object text declared in a
-// test file, or "" if none.
-func scanFileTeleportConfig(path string) ([]scopedTeleportConfig, error) {
-	cleaned, ok := readCleaned(path)
-	if !ok {
-		return nil, nil
+// defaultSelectors returns the selectors for this file's tests that run against
+// the base config which is either the whole file if it declares no config, or each test
+// defined outside a config-scoped describe.
+func defaultSelectors(sourceFile, content string, configs []scopedTeleportConfig, line int) []string {
+	if len(configs) == 0 {
+		return []string{fileSelector(sourceFile, line)}
 	}
-	return extractTeleportConfigs(strings.Join(cleaned, "\n"), parseBlocks(cleaned), path)
+
+	var out []string
+	for _, loc := range testDefRe.FindAllStringIndex(content, -1) {
+		if inConfiguredBlock(loc[0], configs) {
+			continue
+		}
+		out = append(out, fileSelector(sourceFile, 1+strings.Count(content[:loc[0]], "\n")))
+	}
+	return out
 }
 
-// extractTeleportConfigs returns every declared config with its describe's line (or 0 if it's file-level)
+func inConfiguredBlock(pos int, configs []scopedTeleportConfig) bool {
+	for _, c := range configs {
+		if pos > c.startByte && pos < c.endByte {
+			return true
+		}
+	}
+	return false
+}
+
+// scopedTeleportConfig is a declared config and the describe block it's scoped to.
+type scopedTeleportConfig struct {
+	raw                string
+	line               int
+	startByte, endByte int
+}
+
+// extractTeleportConfigs returns every declared config with the describe it is
+// scoped to.
 func extractTeleportConfigs(content string, blocks []blockRange, path string) ([]scopedTeleportConfig, error) {
 	var out []scopedTeleportConfig
 
@@ -1189,6 +1221,9 @@ func extractTeleportConfigs(content string, blocks []blockRange, path string) ([
 
 		teleportOpen, teleportClose := findKeyValueAtDepth(body, "teleport", '{', '}', 1)
 		if teleportOpen < 0 {
+			if teleportKeyRe.MatchString(body) {
+				return nil, fmt.Errorf("%s: the teleport option in test.use() must be an inline object", path)
+			}
 			continue
 		}
 
@@ -1198,20 +1233,36 @@ func extractTeleportConfigs(content string, blocks []blockRange, path string) ([
 			return nil, fmt.Errorf("%s: test.use({ teleport }) must contain a `config` object", path)
 		}
 
-		sc := scopedTeleportConfig{raw: teleportBody[configOpen:configClose]}
-		if b := smallestEnclosingBlock(call.start, blocks); b != nil {
-			sc.line = b.start
+		b := smallestEnclosingBlock(call.start, blocks)
+		if b == nil || describeTitle(content, b.startByte) == "" {
+			return nil, fmt.Errorf("%s: a teleport config must be declared inside a named test.describe block", path)
 		}
 
+		sc := scopedTeleportConfig{
+			raw:       teleportBody[configOpen:configClose],
+			line:      b.start,
+			startByte: b.startByte,
+			endByte:   b.endByte,
+		}
 		for _, existing := range out {
 			if existing.line == sc.line && normalizeConfigText(existing.raw) != normalizeConfigText(sc.raw) {
-				return nil, fmt.Errorf("%s: conflicting teleport configs declared at the same scope", path)
+				return nil, fmt.Errorf("%s: conflicting teleport configs declared in the same describe", path)
 			}
 		}
 		out = append(out, sc)
 	}
 
 	return out, nil
+}
+
+// describeTitle returns the title of the innermost test.describe enclosing the
+// block that opens at blockStart, or "" if it isn't a named describe
+func describeTitle(content string, blockStart int) string {
+	ms := describeTitleRe.FindAllStringSubmatch(content[:blockStart], -1)
+	if len(ms) == 0 {
+		return ""
+	}
+	return ms[len(ms)-1][1]
 }
 
 // normalizeConfigText gets rid of whitespace.
@@ -1230,28 +1281,6 @@ func normalizeConfigText(s string) string {
 		b.WriteRune(r)
 	}
 	return b.String()
-}
-
-// defaultConfigFiles returns the test files that didn't declare a custom config and thus will use the default base config.
-func defaultConfigFiles(targets []scanTarget, configs []uniqueTeleportConfig) []string {
-	if len(configs) == 0 {
-		return nil
-	}
-
-	configured := make(map[string]bool)
-	for _, c := range configs {
-		for _, f := range c.files {
-			configured[lineNumberSuffixRe.ReplaceAllString(f, "")] = true
-		}
-	}
-
-	var out []string
-	for _, t := range targets {
-		if t.sourceFile != "" && !configured[t.sourceFile] {
-			out = append(out, fileSelector(t.sourceFile, t.line))
-		}
-	}
-	return out
 }
 
 func fileSelector(sourceFile string, line int) string {

--- a/e2e/runner/scan.go
+++ b/e2e/runner/scan.go
@@ -1133,22 +1133,27 @@ func scanTeleportConfigs(targets []scanTarget) ([]uniqueTeleportConfig, error) {
 			continue
 		}
 
-		raw, err := scanFileTeleportConfig(t.path)
+		configs, err := scanFileTeleportConfig(t.path)
 		if err != nil {
 			return nil, err
 		}
-		if raw == "" {
-			continue
-		}
 
-		key := normalizeConfigText(raw)
-		u, ok := byKey[key]
-		if !ok {
-			u = &uniqueTeleportConfig{raw: raw}
-			byKey[key] = u
-			order = append(order, key)
+		for _, sc := range configs {
+			// Block-scoped configs target their describe and file-level ones target the whole file
+			line := sc.line
+			if line == 0 {
+				line = t.line
+			}
+
+			key := normalizeConfigText(sc.raw)
+			u, ok := byKey[key]
+			if !ok {
+				u = &uniqueTeleportConfig{raw: sc.raw}
+				byKey[key] = u
+				order = append(order, key)
+			}
+			u.files = append(u.files, fileSelector(t.sourceFile, line))
 		}
-		u.files = append(u.files, t.sourceFile)
 	}
 
 	result := make([]uniqueTeleportConfig, 0, len(order))
@@ -1158,20 +1163,26 @@ func scanTeleportConfigs(targets []scanTarget) ([]uniqueTeleportConfig, error) {
 	return result, nil
 }
 
-// scanFileTeleportConfig returns the teleport config object text declared in a
-// test file, or "" if none.
-func scanFileTeleportConfig(path string) (string, error) {
-	cleaned, ok := readCleaned(path)
-	if !ok {
-		return "", nil
-	}
-	return extractTeleportConfig(strings.Join(cleaned, "\n"), path)
+// scopedTeleportConfig is a declared config and its scope line, 0 for a
+// file-level test.use or the describe's line for a block-scoped one
+type scopedTeleportConfig struct {
+	raw  string
+	line int
 }
 
-// extractTeleportConfig pulls the `config` object out of every
-// test.use({ teleport: { config: {...} } }) call in content.
-func extractTeleportConfig(content, path string) (string, error) {
-	var found string
+// scanFileTeleportConfig returns the teleport config object text declared in a
+// test file, or "" if none.
+func scanFileTeleportConfig(path string) ([]scopedTeleportConfig, error) {
+	cleaned, ok := readCleaned(path)
+	if !ok {
+		return nil, nil
+	}
+	return extractTeleportConfigs(strings.Join(cleaned, "\n"), parseBlocks(cleaned), path)
+}
+
+// extractTeleportConfigs returns every declared config with its describe's line (or 0 if it's file-level)
+func extractTeleportConfigs(content string, blocks []blockRange, path string) ([]scopedTeleportConfig, error) {
+	var out []scopedTeleportConfig
 
 	for _, call := range findTestUseCalls(content) {
 		body := content[call.start:call.end]
@@ -1184,17 +1195,23 @@ func extractTeleportConfig(content, path string) (string, error) {
 		teleportBody := body[teleportOpen:teleportClose]
 		configOpen, configClose := findKeyValueAtDepth(teleportBody, "config", '{', '}', 1)
 		if configOpen < 0 {
-			return "", fmt.Errorf("%s: test.use({ teleport }) must contain a `config` object", path)
+			return nil, fmt.Errorf("%s: test.use({ teleport }) must contain a `config` object", path)
 		}
 
-		raw := teleportBody[configOpen:configClose]
-if found != "" && strings.Join(strings.Fields(found), " ") != strings.Join(strings.Fields(raw), " ") {
-      return "", fmt.Errorf("%s: a test file may only declare one teleport config", path)
-}
-found = raw
+		sc := scopedTeleportConfig{raw: teleportBody[configOpen:configClose]}
+		if b := smallestEnclosingBlock(call.start, blocks); b != nil {
+			sc.line = b.start
+		}
+
+		for _, existing := range out {
+			if existing.line == sc.line && normalizeConfigText(existing.raw) != normalizeConfigText(sc.raw) {
+				return nil, fmt.Errorf("%s: conflicting teleport configs declared at the same scope", path)
+			}
+		}
+		out = append(out, sc)
 	}
 
-	return found, nil
+	return out, nil
 }
 
 // normalizeConfigText gets rid of whitespace.
@@ -1224,15 +1241,22 @@ func defaultConfigFiles(targets []scanTarget, configs []uniqueTeleportConfig) []
 	configured := make(map[string]bool)
 	for _, c := range configs {
 		for _, f := range c.files {
-			configured[f] = true
+			configured[lineNumberSuffixRe.ReplaceAllString(f, "")] = true
 		}
 	}
 
 	var out []string
 	for _, t := range targets {
 		if t.sourceFile != "" && !configured[t.sourceFile] {
-			out = append(out, t.sourceFile)
+			out = append(out, fileSelector(t.sourceFile, t.line))
 		}
 	}
 	return out
+}
+
+func fileSelector(sourceFile string, line int) string {
+	if line > 0 {
+		return fmt.Sprintf("%s:%d", sourceFile, line)
+	}
+	return sourceFile
 }

--- a/e2e/runner/scan_test.go
+++ b/e2e/runner/scan_test.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/gravitational/teleport/e2e/runner/fixtures"
 )
 
@@ -1214,4 +1216,71 @@ func fixtureNames(ff []*fixtures.Fixture) []string {
 		names[i] = f.Name
 	}
 	return names
+}
+
+func TestExtractTeleportConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "no declaration",
+			content: `test.use({ user: { roles: ['access'] } });`,
+			want:    "",
+		},
+		{
+			name:    "simple config",
+			content: `test.use({ teleport: { config: { auth_service: { license_file: 'x.pem' } } } });`,
+			want:    `{ auth_service: { license_file: 'x.pem' } }`,
+		},
+		{
+			name: "config alongside a user",
+			content: `test.use({
+  user: { roles: [{ file: 'r.yaml' }] },
+  teleport: { config: { auth_service: { license_file: 'lic.pem' } } },
+});`,
+			want: `{ auth_service: { license_file: 'lic.pem' } }`,
+		},
+		{
+			name: "same config twice is fine",
+			content: `test.use({ teleport: { config: { a: 1 } } });
+test.use({ teleport: { config: { a: 1 } } });`,
+			want: `{ a: 1 }`,
+		},
+		{
+			name: "two different configs in one file errors",
+			content: `test.use({ teleport: { config: { a: 1 } } });
+test.use({ teleport: { config: { a: 2 } } });`,
+			wantErr: true,
+		},
+		{
+			name:    "teleport without config errors",
+			content: `test.use({ teleport: { foo: 1 } });`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractTeleportConfig(tt.content, "test.spec.ts")
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNormalizeConfigText(t *testing.T) {
+	// Differently-formatted but identical configs normalize the same (so they can be deduped).
+	a := normalizeConfigText("{ auth_service: { license_file: 'x.pem' } }")
+	b := normalizeConfigText("{\n  auth_service: {\n    license_file: 'x.pem'\n  }\n}")
+	require.Equal(t, a, b)
+
+	c := normalizeConfigText("{ auth_service: { license_file: 'y.pem' } }")
+	require.NotEqual(t, a, c)
 }

--- a/e2e/runner/scan_test.go
+++ b/e2e/runner/scan_test.go
@@ -566,7 +566,7 @@ func TestScanRecordings(t *testing.T) {
 		},
 		{
 			name:           "no recordings",
-			content:         `test.use({ user: { roles: ['access'] } });`,
+			content:        `test.use({ user: { roles: ['access'] } });`,
 			wantUsers:      1,
 			wantRecordings: nil,
 			wantLoginAs:    true,
@@ -1231,11 +1231,6 @@ func TestExtractTeleportConfigs(t *testing.T) {
 			want:    nil,
 		},
 		{
-			name:    "file-level config has line 0",
-			content: `test.use({ teleport: { config: { auth_service: { license_file: 'x.pem' } } } });`,
-			want:    []scopedTeleportConfig{{raw: `{ auth_service: { license_file: 'x.pem' } }`, line: 0}},
-		},
-		{
 			name: "describe-scoped config carries its line",
 			content: `test.describe('grp', () => {
   test.use({ teleport: { config: { a: 1 } } });
@@ -1244,23 +1239,29 @@ func TestExtractTeleportConfigs(t *testing.T) {
 			want: []scopedTeleportConfig{{raw: `{ a: 1 }`, line: 1}},
 		},
 		{
-			name: "a file-level and describe-level config can both be defined",
-			content: `test.use({ teleport: { config: { a: 1 } } });
-test.describe('grp', () => {
+			name: "two describes with different configs",
+			content: `test.describe('one', () => {
+  test.use({ teleport: { config: { a: 1 } } });
+});
+test.describe('two', () => {
   test.use({ teleport: { config: { a: 2 } } });
 });`,
-			want: []scopedTeleportConfig{{raw: `{ a: 1 }`, line: 0}, {raw: `{ a: 2 }`, line: 2}},
+			want: []scopedTeleportConfig{
+				{raw: `{ a: 1 }`, line: 1},
+				{raw: `{ a: 2 }`, line: 4},
+			},
 		},
 		{
-			name: "same config twice at file level is fine",
-			content: `test.use({ teleport: { config: { a: 1 } } });
-test.use({ teleport: { config: { a: 1 } } });`,
-			want: []scopedTeleportConfig{{raw: `{ a: 1 }`, line: 0}, {raw: `{ a: 1 }`, line: 0}},
+			name:    "file-level config errors",
+			content: `test.use({ teleport: { config: { a: 1 } } });`,
+			wantErr: true,
 		},
 		{
-			name: "conflicting configs at the same scope errors",
-			content: `test.use({ teleport: { config: { a: 1 } } });
-test.use({ teleport: { config: { a: 2 } } });`,
+			name: "conflicting configs in one describe errors",
+			content: `test.describe('grp', () => {
+  test.use({ teleport: { config: { a: 1 } } });
+  test.use({ teleport: { config: { a: 2 } } });
+});`,
 			wantErr: true,
 		},
 		{
@@ -1279,9 +1280,33 @@ test.use({ teleport: { config: { a: 2 } } });`,
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, tt.want, got)
+			require.Len(t, got, len(tt.want))
+			for i := range tt.want {
+				require.Equal(t, tt.want[i].raw, got[i].raw)
+				require.Equal(t, tt.want[i].line, got[i].line)
+			}
 		})
 	}
+}
+
+func TestDefaultSelectors(t *testing.T) {
+	content := `test.describe('configured', () => {
+  test.use({ teleport: { config: { a: 1 } } });
+  test('in scope', () => {});
+});
+test('bare', () => {});
+test.describe('other', () => {
+  test('nested', () => {});
+});`
+
+	configs, err := extractTeleportConfigs(content, parseBlocks(strings.Split(content, "\n")), "x.spec.ts")
+	require.NoError(t, err)
+
+	got := defaultSelectors("tests/x.spec.ts", content, configs, 0)
+	require.Equal(t, []string{"tests/x.spec.ts:5", "tests/x.spec.ts:7"}, got)
+
+	// A file with no config just runs as a whole
+	require.Equal(t, []string{"tests/x.spec.ts"}, defaultSelectors("tests/x.spec.ts", content, nil, 0))
 }
 
 func TestNormalizeConfigText(t *testing.T) {
@@ -1292,4 +1317,37 @@ func TestNormalizeConfigText(t *testing.T) {
 
 	c := normalizeConfigText("{ auth_service: { license_file: 'y.pem' } }")
 	require.NotEqual(t, a, c)
+}
+
+func TestScanTeleportConfigsRejectsHelperConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "helper.ts", `
+test.use({
+  teleport: {
+    config: { proxy_service: { ssh_public_addr: ['example.com:3023'] } },
+  },
+});
+`)
+
+	_, _, err := scanTeleportConfigs([]scanTarget{{path: filepath.Join(dir, "helper.ts")}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "helper modules cannot declare teleport:")
+}
+
+func TestScanTeleportConfigsAllowsHelperWithoutConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "helper.ts", `test.use({ fixtures: ['connect'] });`)
+
+	_, _, err := scanTeleportConfigs([]scanTarget{{path: filepath.Join(dir, "helper.ts")}})
+	require.NoError(t, err)
+}
+
+func TestExtractTeleportConfigsRejectsNonInlineOption(t *testing.T) {
+	content := `test.describe('d', () => {
+  test.use({ teleport: customTeleport });
+  test('t', async () => {});
+});`
+	_, err := extractTeleportConfigs(content, parseBlocks(strings.Split(content, "\n")), "spec.ts")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must be an inline object")
 }

--- a/e2e/runner/scan_test.go
+++ b/e2e/runner/scan_test.go
@@ -1218,39 +1218,47 @@ func fixtureNames(ff []*fixtures.Fixture) []string {
 	return names
 }
 
-func TestExtractTeleportConfig(t *testing.T) {
+func TestExtractTeleportConfigs(t *testing.T) {
 	tests := []struct {
 		name    string
 		content string
-		want    string
+		want    []scopedTeleportConfig
 		wantErr bool
 	}{
 		{
 			name:    "no declaration",
 			content: `test.use({ user: { roles: ['access'] } });`,
-			want:    "",
+			want:    nil,
 		},
 		{
-			name:    "simple config",
+			name:    "file-level config has line 0",
 			content: `test.use({ teleport: { config: { auth_service: { license_file: 'x.pem' } } } });`,
-			want:    `{ auth_service: { license_file: 'x.pem' } }`,
+			want:    []scopedTeleportConfig{{raw: `{ auth_service: { license_file: 'x.pem' } }`, line: 0}},
 		},
 		{
-			name: "config alongside a user",
-			content: `test.use({
-  user: { roles: [{ file: 'r.yaml' }] },
-  teleport: { config: { auth_service: { license_file: 'lic.pem' } } },
+			name: "describe-scoped config carries its line",
+			content: `test.describe('grp', () => {
+  test.use({ teleport: { config: { a: 1 } } });
+  test('x', () => {});
 });`,
-			want: `{ auth_service: { license_file: 'lic.pem' } }`,
+			want: []scopedTeleportConfig{{raw: `{ a: 1 }`, line: 1}},
 		},
 		{
-			name: "same config twice is fine",
+			name: "a file-level and describe-level config can both be defined",
+			content: `test.use({ teleport: { config: { a: 1 } } });
+test.describe('grp', () => {
+  test.use({ teleport: { config: { a: 2 } } });
+});`,
+			want: []scopedTeleportConfig{{raw: `{ a: 1 }`, line: 0}, {raw: `{ a: 2 }`, line: 2}},
+		},
+		{
+			name: "same config twice at file level is fine",
 			content: `test.use({ teleport: { config: { a: 1 } } });
 test.use({ teleport: { config: { a: 1 } } });`,
-			want: `{ a: 1 }`,
+			want: []scopedTeleportConfig{{raw: `{ a: 1 }`, line: 0}, {raw: `{ a: 1 }`, line: 0}},
 		},
 		{
-			name: "two different configs in one file errors",
+			name: "conflicting configs at the same scope errors",
 			content: `test.use({ teleport: { config: { a: 1 } } });
 test.use({ teleport: { config: { a: 2 } } });`,
 			wantErr: true,
@@ -1264,7 +1272,8 @@ test.use({ teleport: { config: { a: 2 } } });`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := extractTeleportConfig(tt.content, "test.spec.ts")
+			blocks := parseBlocks(strings.Split(tt.content, "\n"))
+			got, err := extractTeleportConfigs(tt.content, blocks, "test.spec.ts")
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/e2e/runner/teleport_config.go
+++ b/e2e/runner/teleport_config.go
@@ -1,0 +1,70 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// mergeTeleportConfig deep-merges a custom config into the base Teleport config at basePath and writes the
+// result to outPath.
+func mergeTeleportConfig(basePath, outPath, e2eDir, raw string) error {
+	raw = strings.ReplaceAll(raw, "${E2E_DIR}", e2eDir)
+
+	var override map[string]any
+	if err := yaml.Unmarshal([]byte(raw), &override); err != nil {
+		return fmt.Errorf("parsing declared teleport config %q: %w", raw, err)
+	}
+
+	baseData, err := os.ReadFile(basePath)
+	if err != nil {
+		return fmt.Errorf("reading base config %s: %w", basePath, err)
+	}
+	base := map[string]any{}
+	if err := yaml.Unmarshal(baseData, &base); err != nil {
+		return fmt.Errorf("parsing base config %s: %w", basePath, err)
+	}
+
+	deepMerge(base, override)
+
+	merged, err := yaml.Marshal(base)
+	if err != nil {
+		return fmt.Errorf("marshaling merged config: %w", err)
+	}
+	if err := os.WriteFile(outPath, merged, 0o644); err != nil {
+		return fmt.Errorf("writing merged config %s: %w", outPath, err)
+	}
+	return nil
+}
+
+func deepMerge(dst, src map[string]any) {
+	for k, sv := range src {
+		if svMap, ok := sv.(map[string]any); ok {
+			if dvMap, ok := dst[k].(map[string]any); ok {
+				deepMerge(dvMap, svMap)
+				continue
+			}
+		}
+		dst[k] = sv
+	}
+}

--- a/e2e/tests/web/authenticated/customConfig.spec.ts
+++ b/e2e/tests/web/authenticated/customConfig.spec.ts
@@ -19,24 +19,26 @@
 import { expect, test } from '@gravitational/e2e/helpers/test';
 
 // Verify that an e2e test can be run with a custom config
-test.use({
-  teleport: {
-    config: {
-      proxy_service: {
-        ssh_public_addr: ['e2e-custom-config.example.com:3023'],
+test.describe('custom config', () => {
+  test.use({
+    teleport: {
+      config: {
+        proxy_service: {
+          ssh_public_addr: ['e2e-custom-config.example.com:3023'],
+        },
       },
     },
-  },
-});
+  });
 
-test('runs against a test-declared custom Teleport config', async ({
-  page,
-}) => {
-  const response = await page.request.get('/webapi/ping');
-  expect(response.ok()).toBeTruthy();
+  test('runs against a test-declared custom Teleport config', async ({
+    page,
+  }) => {
+    const response = await page.request.get('/webapi/ping');
+    expect(response.ok()).toBeTruthy();
 
-  const ping = await response.json();
-  expect(ping.proxy.ssh.ssh_public_addr).toBe(
-    'e2e-custom-config.example.com:3023'
-  );
+    const ping = await response.json();
+    expect(ping.proxy.ssh.ssh_public_addr).toBe(
+      'e2e-custom-config.example.com:3023'
+    );
+  });
 });

--- a/e2e/tests/web/unauthenticated/customConfig.spec.ts
+++ b/e2e/tests/web/unauthenticated/customConfig.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { expect, test } from '@gravitational/e2e/helpers/test';
+
+// Verify that an e2e test can be run with a custom config
+test.use({
+  teleport: {
+    config: {
+      proxy_service: {
+        ssh_public_addr: ['e2e-custom-config.example.com:3023'],
+      },
+    },
+  },
+});
+
+test('runs against a test-declared custom Teleport config', async ({
+  page,
+}) => {
+  const response = await page.request.get('/webapi/ping');
+  expect(response.ok()).toBeTruthy();
+
+  const ping = await response.json();
+  expect(ping.proxy.ssh.ssh_public_addr).toBe(
+    'e2e-custom-config.example.com:3023'
+  );
+});


### PR DESCRIPTION
This PR adds support for e2e tests to declare their own custom Teleport config.

Currently, all e2e tests have to use the same Teleport config we have hardcoded as a fixture, with this change, a test can customize the config Teleport runs for it (for example if a different license needs to be used). The data dir however remains the same which allows the other bootstrapped data (like users) to persist. The test runner will look through and deduplicate all unique declared configs so that all the tests using them can be batched and Teleport only has to be restarted once per custom config.

## Manual Test Plan
### Test Environment

Local v19 and CI

### Test Cases
- [x] Verify that in CI, all existing e2e tests pass including tests that declare a custom config.
- [x] Verify that locally, all existing e2e tests pass including tests that declare a custom config.
