### PR TITLE
Fix `FeatureHiding`

### DIFF
--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -47,6 +47,7 @@ import { CatchError } from 'teleport/components/CatchError';
 import { Redirect, Route, Switch } from 'teleport/components/Router';
 import { InfoGuideSidePanel } from 'teleport/components/SlidingSidePanel/InfoGuideSidePanel';
 import cfg from 'teleport/config';
+import { canShowFeature } from 'teleport/features';
 import { FeaturesContextProvider, useFeatures } from 'teleport/FeaturesContext';
 import { Navigation } from 'teleport/Navigation';
 import {
@@ -96,7 +97,7 @@ export function Main(props: MainProps) {
     () =>
       props.features.filter(
         feature =>
-          feature.hasAccess(featureFlags) &&
+          canShowFeature(feature, featureFlags) &&
           supportsCurrentScope(feature, scope)
       ),
     [featureFlags, props.features, scope]

--- a/web/packages/teleport/src/Navigation/Navigation.tsx
+++ b/web/packages/teleport/src/Navigation/Navigation.tsx
@@ -42,6 +42,7 @@ import { useFeatures } from 'teleport/FeaturesContext';
 import type { TeleportFeature } from 'teleport/types';
 import { useUser } from 'teleport/User/UserContext';
 import useStickyClusterId from 'teleport/useStickyClusterId';
+import useTeleport from 'teleport/useTeleport';
 
 import {
   CustomNavigationSubcategory,
@@ -343,6 +344,7 @@ export function Navigation({
 }: {
   showPoweredByLogo?: boolean;
 }) {
+  const ctx = useTeleport();
   const features = useFeatures();
   const location = useLocation();
   const { clusterId } = useStickyClusterId();
@@ -408,8 +410,9 @@ export function Navigation({
       preferences,
       updatePreferences,
       searchParams,
+      flags: ctx.getFeatureFlags(),
     });
-  }, [clusterId, preferences, updatePreferences]);
+  }, [clusterId, preferences, updatePreferences, ctx]);
 
   const handleSetExpandedSection = useCallback(
     (section: NavigationSection) => {

--- a/web/packages/teleport/src/Navigation/ResourcesSection.test.tsx
+++ b/web/packages/teleport/src/Navigation/ResourcesSection.test.tsx
@@ -16,22 +16,25 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import cfg from 'teleport/config';
+import { createTeleportContext, getAcl } from 'teleport/mocks/contexts';
 import { getResourcesSection } from 'teleport/Navigation/ResourcesSection';
 import { makeDefaultUserPreferences } from 'teleport/services/userPreferences/userPreferences';
 
 describe('getResourcesSection', () => {
+  const fixed = ['All Resources', 'Pinned Resources'];
+
   test('titles for subsections by kind are sorted', () => {
+    const ctx = createTeleportContext();
     const navSections = getResourcesSection({
       clusterId: 'cluster',
       preferences: makeDefaultUserPreferences(),
       updatePreferences: async () => {},
       searchParams: new URLSearchParams(),
+      flags: ctx.getFeatureFlags(),
     });
 
     const titles = navSections.subsections.map(s => s.title);
-
-    // First two sections are fixed.
-    const fixed = ['All Resources', 'Pinned Resources'];
 
     // Kind filters that should be sorted alphabetically.
     const kindFilters = [
@@ -50,5 +53,43 @@ describe('getResourcesSection', () => {
     ];
 
     expect(titles).toEqual(expected);
+  });
+
+  test('all kind shortcuts are shown when feature hiding is off', () => {
+    const ctx = createTeleportContext({
+      customAcl: getAcl({ noAccess: true }),
+    });
+    const navSections = getResourcesSection({
+      clusterId: 'cluster',
+      preferences: makeDefaultUserPreferences(),
+      updatePreferences: async () => {},
+      searchParams: new URLSearchParams(),
+      flags: ctx.getFeatureFlags(),
+    });
+
+    const titles = navSections.subsections.map(s => s.title);
+    expect(titles).toHaveLength(fixed.length + 7);
+  });
+
+  test('inaccessible kind shortcuts are hidden when feature hiding is on', () => {
+    const defaultFeatureHiding = cfg.entitlements.FeatureHiding.enabled;
+    cfg.entitlements.FeatureHiding.enabled = true;
+    try {
+      const ctx = createTeleportContext({
+        customAcl: getAcl({ noAccess: true }),
+      });
+      const navSections = getResourcesSection({
+        clusterId: 'cluster',
+        preferences: makeDefaultUserPreferences(),
+        updatePreferences: async () => {},
+        searchParams: new URLSearchParams(),
+        flags: ctx.getFeatureFlags(),
+      });
+
+      const titles = navSections.subsections.map(s => s.title);
+      expect(titles).toEqual(fixed);
+    } finally {
+      cfg.entitlements.FeatureHiding.enabled = defaultFeatureHiding;
+    }
   });
 });

--- a/web/packages/teleport/src/Navigation/ResourcesSection.tsx
+++ b/web/packages/teleport/src/Navigation/ResourcesSection.tsx
@@ -31,8 +31,11 @@ import {
 import { encodeUrlQueryParams } from 'teleport/components/hooks/useUrlFiltering';
 import { EncodeUrlQueryParamsProps } from 'teleport/components/hooks/useUrlFiltering/encodeUrlQueryParams';
 import cfg from 'teleport/config';
+import { shouldHideInaccessibleFeatures } from 'teleport/features';
+import { FeatureFlags } from 'teleport/types';
 import { useUser } from 'teleport/User/UserContext';
 import useStickyClusterId from 'teleport/useStickyClusterId';
+import useTeleport from 'teleport/useTeleport';
 
 import { CustomNavigationSubcategory, NavigationCategory } from './categories';
 import {
@@ -68,7 +71,35 @@ type GetSubsectionProps = {
   preferences: UserPreferences;
   updatePreferences: (preferences: Partial<UserPreferences>) => Promise<void>;
   searchParams: URLSearchParams;
+  flags: FeatureFlags;
 };
+
+// hasAccessToResourceKind returns whether the user has RBAC access to the given
+// resource kind.
+function hasAccessToResourceKind(
+  kind: ResourceFilterKind,
+  flags: FeatureFlags
+): boolean {
+  switch (kind) {
+    case 'app':
+    case 'mcp':
+      // MCP servers are app resources, so they share the same RBAC rule
+      return flags.applications;
+    case 'db':
+      return flags.databases;
+    case 'windows_desktop':
+    case 'linux_desktop':
+      return flags.desktops;
+    case 'kube_cluster':
+      return flags.kubernetes;
+    case 'git_server':
+      return flags.gitServers;
+    case 'node':
+      return flags.nodes;
+    default:
+      return true;
+  }
+}
 
 function encodeUrlQueryParamsWithTypedKinds(
   params: Omit<EncodeUrlQueryParamsProps, 'kinds'> & {
@@ -83,6 +114,7 @@ function getResourcesSubsections({
   preferences,
   updatePreferences,
   searchParams,
+  flags,
 }: GetSubsectionProps): NavigationSubsection[] {
   const baseRoute = cfg.getUnifiedResourcesRoute(clusterId);
 
@@ -168,7 +200,7 @@ function getResourcesSubsections({
     pinnedOnly: false,
   });
 
-  return [
+  const baseSubsections: NavigationSubsection[] = [
     {
       title: 'All Resources',
       icon: Icons.Server,
@@ -203,85 +235,121 @@ function getResourcesSubsections({
         currentKinds.length !== 1,
       onClick: () => setPinnedUserPreference(true),
     },
+  ];
+
+  const filteredViews: {
+    kind: ResourceFilterKind;
+    subsection: NavigationSubsection;
+  }[] = [
     {
-      title: getFilterKindName('app'),
-      icon: Icons.Application,
-      route: applicationsOnlyRoute,
-      searchableTags: ['resources', 'apps', 'applications'],
-      category: NavigationCategory.Resources,
-      exact: false,
-      customRouteMatchFn: () => isKindActive('app'),
-      onClick: () => setPinnedUserPreference(false),
-      subCategory: CustomNavigationSubcategory.FilteredViews,
+      kind: 'app',
+      subsection: {
+        title: getFilterKindName('app'),
+        icon: Icons.Application,
+        route: applicationsOnlyRoute,
+        searchableTags: ['resources', 'apps', 'applications'],
+        category: NavigationCategory.Resources,
+        exact: false,
+        customRouteMatchFn: () => isKindActive('app'),
+        onClick: () => setPinnedUserPreference(false),
+        subCategory: CustomNavigationSubcategory.FilteredViews,
+      },
     },
     {
-      title: getFilterKindName('db'),
-      icon: Icons.Database,
-      route: databasesOnlyRoute,
-      searchableTags: ['resources', 'dbs', 'databases'],
-      category: NavigationCategory.Resources,
-      exact: false,
-      customRouteMatchFn: () => isKindActive('db'),
-      onClick: () => setPinnedUserPreference(false),
-      subCategory: CustomNavigationSubcategory.FilteredViews,
+      kind: 'db',
+      subsection: {
+        title: getFilterKindName('db'),
+        icon: Icons.Database,
+        route: databasesOnlyRoute,
+        searchableTags: ['resources', 'dbs', 'databases'],
+        category: NavigationCategory.Resources,
+        exact: false,
+        customRouteMatchFn: () => isKindActive('db'),
+        onClick: () => setPinnedUserPreference(false),
+        subCategory: CustomNavigationSubcategory.FilteredViews,
+      },
     },
     {
-      title: getFilterKindName('windows_desktop'),
-      icon: Icons.Desktop,
-      route: desktopsOnlyRoute,
-      searchableTags: ['resources', 'desktops', 'rdp', 'windows'],
-      category: NavigationCategory.Resources,
-      exact: false,
-      customRouteMatchFn: () =>
-        isKindActive('windows_desktop') || isKindActive('linux_desktop'),
-      onClick: () => setPinnedUserPreference(false),
-      subCategory: CustomNavigationSubcategory.FilteredViews,
+      kind: 'windows_desktop',
+      subsection: {
+        title: getFilterKindName('windows_desktop'),
+        icon: Icons.Desktop,
+        route: desktopsOnlyRoute,
+        searchableTags: ['resources', 'desktops', 'rdp', 'windows'],
+        category: NavigationCategory.Resources,
+        exact: false,
+        customRouteMatchFn: () =>
+          isKindActive('windows_desktop') || isKindActive('linux_desktop'),
+        onClick: () => setPinnedUserPreference(false),
+        subCategory: CustomNavigationSubcategory.FilteredViews,
+      },
     },
     {
-      title: getFilterKindName('git_server'),
-      icon: Icons.GitHub,
-      route: gitOnlyRoute,
-      searchableTags: ['resources', 'git', 'github', 'git servers'],
-      category: NavigationCategory.Resources,
-      exact: false,
-      customRouteMatchFn: () => isKindActive('git_server'),
-      onClick: () => setPinnedUserPreference(false),
-      subCategory: CustomNavigationSubcategory.FilteredViews,
+      kind: 'git_server',
+      subsection: {
+        title: getFilterKindName('git_server'),
+        icon: Icons.GitHub,
+        route: gitOnlyRoute,
+        searchableTags: ['resources', 'git', 'github', 'git servers'],
+        category: NavigationCategory.Resources,
+        exact: false,
+        customRouteMatchFn: () => isKindActive('git_server'),
+        onClick: () => setPinnedUserPreference(false),
+        subCategory: CustomNavigationSubcategory.FilteredViews,
+      },
     },
     {
-      title: getFilterKindName('kube_cluster'),
-      icon: Icons.Kubernetes,
-      route: kubesOnlyRoute,
-      searchableTags: ['resources', 'k8s', 'kubes', 'kubernetes'],
-      category: NavigationCategory.Resources,
-      exact: false,
-      customRouteMatchFn: () => isKindActive('kube_cluster'),
-      onClick: () => setPinnedUserPreference(false),
-      subCategory: CustomNavigationSubcategory.FilteredViews,
+      kind: 'kube_cluster',
+      subsection: {
+        title: getFilterKindName('kube_cluster'),
+        icon: Icons.Kubernetes,
+        route: kubesOnlyRoute,
+        searchableTags: ['resources', 'k8s', 'kubes', 'kubernetes'],
+        category: NavigationCategory.Resources,
+        exact: false,
+        customRouteMatchFn: () => isKindActive('kube_cluster'),
+        onClick: () => setPinnedUserPreference(false),
+        subCategory: CustomNavigationSubcategory.FilteredViews,
+      },
     },
     {
-      title: getFilterKindName('mcp'),
-      icon: Icons.ModelContextProtocol,
-      route: mcpOnlyRoute,
-      searchableTags: ['resources', 'mcp', 'mcp servers'],
-      category: NavigationCategory.Resources,
-      exact: false,
-      customRouteMatchFn: () => isKindActive('mcp'),
-      onClick: () => setPinnedUserPreference(false),
-      subCategory: CustomNavigationSubcategory.FilteredViews,
+      kind: 'mcp',
+      subsection: {
+        title: getFilterKindName('mcp'),
+        icon: Icons.ModelContextProtocol,
+        route: mcpOnlyRoute,
+        searchableTags: ['resources', 'mcp', 'mcp servers'],
+        category: NavigationCategory.Resources,
+        exact: false,
+        customRouteMatchFn: () => isKindActive('mcp'),
+        onClick: () => setPinnedUserPreference(false),
+        subCategory: CustomNavigationSubcategory.FilteredViews,
+      },
     },
     {
-      title: getFilterKindName('node'),
-      icon: Icons.Server,
-      route: nodesOnlyRoute,
-      searchableTags: ['resources', 'servers', 'nodes', 'ssh resources'],
-      category: NavigationCategory.Resources,
-      exact: false,
-      customRouteMatchFn: () => isKindActive('node'),
-      onClick: () => setPinnedUserPreference(false),
-      subCategory: CustomNavigationSubcategory.FilteredViews,
+      kind: 'node',
+      subsection: {
+        title: getFilterKindName('node'),
+        icon: Icons.Server,
+        route: nodesOnlyRoute,
+        searchableTags: ['resources', 'servers', 'nodes', 'ssh resources'],
+        category: NavigationCategory.Resources,
+        exact: false,
+        customRouteMatchFn: () => isKindActive('node'),
+        onClick: () => setPinnedUserPreference(false),
+        subCategory: CustomNavigationSubcategory.FilteredViews,
+      },
     },
   ];
+
+  const hideInaccessible = shouldHideInaccessibleFeatures(cfg);
+  const visibleFilteredViews = filteredViews
+    .filter(
+      ({ kind }) => !hideInaccessible || hasAccessToResourceKind(kind, flags)
+    )
+    .map(({ subsection }) => subsection);
+
+  return [...baseSubsections, ...visibleFilteredViews];
 }
 
 export function ResourcesSection({
@@ -303,6 +371,7 @@ export function ResourcesSection({
   canToggleStickyMode: boolean;
   showPoweredByLogo: boolean;
 }) {
+  const ctx = useTeleport();
   const { clusterId } = useStickyClusterId();
   const { preferences, updatePreferences } = useUser();
   const section: NavigationSection = {
@@ -320,6 +389,7 @@ export function ResourcesSection({
     preferences,
     updatePreferences,
     searchParams,
+    flags: ctx.getFeatureFlags(),
   });
 
   const currentViewRoute = currentView?.route;

--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -60,6 +60,7 @@ import {
 import { ServersideSearchPanel } from 'teleport/components/ServersideSearchPanel';
 import cfg from 'teleport/config';
 import { SearchResource } from 'teleport/Discover/SelectResource';
+import { shouldHideInaccessibleFeatures } from 'teleport/features';
 import { useNoMinWidth } from 'teleport/Main';
 import {
   SamlAppActionProvider,
@@ -113,7 +114,7 @@ function expandDesktopKinds(kinds?: string[]): string[] | undefined {
 }
 
 const getAvailableKindsWithAccess = (flags: FeatureFlags): FilterKind[] => {
-  return [
+  const kinds: FilterKind[] = [
     {
       kind: 'node',
       disabled: !flags.nodes,
@@ -143,6 +144,13 @@ const getAvailableKindsWithAccess = (flags: FeatureFlags): FilterKind[] => {
       disabled: !flags.applications,
     },
   ];
+
+  // When feature hiding is enabled, kinds the user can't access are removed from the filter entirely.
+  if (shouldHideInaccessibleFeatures(cfg)) {
+    return kinds.filter(kind => !kind.disabled);
+  }
+
+  return kinds;
 };
 
 export function ClusterResources({

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -243,7 +243,9 @@ const cfg = {
   // If you have no other options, use the `isStripeManaged` config flag to determine if product used is Team.
   // EUB can be determined from a combination of existing config flags eg: `isUsageBasedBilling && !isStripeManaged`.
   isUsageBasedBilling: false,
-  hideInaccessibleFeatures: false,
+  get hideInaccessibleFeatures(): boolean {
+    return this.entitlements.FeatureHiding.enabled;
+  },
   customTheme: '',
   isStripeManaged: false,
   hasQuestionnaire: false,

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -79,11 +79,21 @@ import { UnifiedResources } from './UnifiedResources';
 import { Users } from './Users';
 import { WorkloadIdentities } from './WorkloadIdentity/WorkloadIdentities';
 
-// to promote feature discoverability, most features should be visible in the navigation even if a user doesnt have access.
-// However, there are some cases where hiding the feature is explicitly requested. Use this as a backdoor to hide the features that
-// are usually "always visible"
-export function shouldHideFromNavigation(cfg: Cfg) {
+// shouldHideInaccessibleFeatures returns whether features the user lacks access to
+// should be hidden from the navigation entirely, rather than shown for
+// discoverability. This is the case for dashboard tenants, and when feature
+// hiding is enabled in the license.
+export function shouldHideInaccessibleFeatures(cfg: Cfg) {
   return cfg.isDashboard || cfg.hideInaccessibleFeatures;
+}
+
+// canShowFeature returns whether the user can see a given feature based on their RBAC permissions,
+// whether the feature is discoverable and whether featurehiding is enabled in the license.
+export function canShowFeature(feature: TeleportFeature, flags: FeatureFlags) {
+  if (feature.hasAccess(flags)) {
+    return true;
+  }
+  return !!feature.discoverable && !shouldHideInaccessibleFeatures(cfg);
 }
 
 class AccessRequests implements TeleportFeature {
@@ -252,13 +262,10 @@ export class FeatureBots implements TeleportFeature {
     component: Bots,
   };
 
+  discoverable = true;
+
   hasAccess(flags: FeatureFlags) {
-    // if feature hiding is enabled, only show
-    // if the user has access
-    if (shouldHideFromNavigation(cfg)) {
-      return flags.listBots;
-    }
-    return true;
+    return flags.listBots;
   }
 
   navigationItem = {
@@ -286,13 +293,10 @@ export class FeatureBotInstances implements TeleportFeature {
     component: BotInstances,
   };
 
+  discoverable = true;
+
   hasAccess(flags: FeatureFlags) {
-    // if feature hiding is enabled, only show
-    // if the user has access
-    if (shouldHideFromNavigation(cfg)) {
-      return flags.listBotInstances;
-    }
-    return true;
+    return flags.listBotInstances;
   }
 
   navigationItem = {
@@ -328,13 +332,10 @@ export class FeatureInstances implements TeleportFeature {
     component: Instances,
   };
 
+  discoverable = true;
+
   hasAccess(flags: FeatureFlags) {
-    // if feature hiding is enabled, only show
-    // if the user has access
-    if (shouldHideFromNavigation(cfg)) {
-      return flags.listInstances || flags.listBotInstances;
-    }
-    return true;
+    return flags.listInstances || flags.listBotInstances;
   }
 
   navigationItem = {
@@ -585,13 +586,10 @@ export class FeatureDiscover implements TeleportFeature {
 export class FeatureIntegrations implements TeleportFeature {
   category = NavigationCategory.ZeroTrustAccess;
 
+  discoverable = true;
+
   hasAccess(flags: FeatureFlags) {
-    // if feature hiding is enabled, only show
-    // if the user has access
-    if (shouldHideFromNavigation(cfg)) {
-      return flags.integrations;
-    }
-    return true;
+    return flags.integrations;
   }
 
   route = {
@@ -626,11 +624,10 @@ export class FeatureIntegrationEnroll implements TeleportFeature {
     component: IntegrationEnroll,
   };
 
+  discoverable = true;
+
   hasAccess(flags: FeatureFlags) {
-    if (shouldHideFromNavigation(cfg)) {
-      return flags.enrollIntegrations;
-    }
-    return true;
+    return flags.enrollIntegrations;
   }
 
   navigationItem = {
@@ -659,16 +656,14 @@ export class FeatureManagedUpdates implements TeleportFeature {
     component: ManagedUpdates,
   };
 
+  discoverable = true;
+
   hasAccess(flags: FeatureFlags) {
-    const canViewPage =
+    return (
       flags.readAutoUpdateConfig ||
       flags.readAutoUpdateVersion ||
-      flags.readAutoUpdateAgentRollout;
-
-    if (shouldHideFromNavigation(cfg)) {
-      return canViewPage;
-    }
-    return true;
+      flags.readAutoUpdateAgentRollout
+    );
   }
 
   navigationItem = {
@@ -803,13 +798,10 @@ export class FeatureWorkloadIdentity implements TeleportFeature {
     component: WorkloadIdentities,
   };
 
+  discoverable = true;
+
   hasAccess(flags: FeatureFlags): boolean {
-    // if feature hiding is enabled, only show
-    // if the user has access
-    if (shouldHideFromNavigation(cfg)) {
-      return flags.listWorkloadIdentities;
-    }
-    return true;
+    return flags.listWorkloadIdentities;
   }
   navigationItem = {
     title: NavTitle.WorkloadIdentity,
@@ -830,11 +822,10 @@ class FeatureDeviceTrust implements TeleportFeature {
     component: DeviceTrustLocked,
   };
 
+  discoverable = true;
+
   hasAccess(flags: FeatureFlags) {
-    if (shouldHideFromNavigation(cfg)) {
-      return flags.deviceTrust;
-    }
-    return true;
+    return flags.deviceTrust;
   }
 
   navigationItem = {

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -138,19 +138,16 @@ class TeleportContext implements types.Context {
     }
 
     function hasAccessRequestsAccess() {
-      // If feature hiding is enabled in the license, only allow access to access requests if the user has permission to access them, either by
-      // having list access, requestable roles, or allowed search_as_roles.
-      if (cfg.hideInaccessibleFeatures) {
-        return !!(
-          userContext.getReviewRequests() ||
-          userContext.getAccessRequestAccess().list ||
-          userContext.getRequestableRoles().length ||
-          userContext.getAllowedSearchAsRoles().length
-        );
+      if (cfg.isDashboard) {
+        return false;
       }
 
-      // Return true if this isn't a Cloud dashboard cluster.
-      return !cfg.isDashboard;
+      return !!(
+        userContext.getReviewRequests() ||
+        userContext.getAccessRequestAccess().list ||
+        userContext.getRequestableRoles().length ||
+        userContext.getAllowedSearchAsRoles().length
+      );
     }
 
     function hasAccessMonitoringAccess() {
@@ -212,6 +209,16 @@ class TeleportContext implements types.Context {
         userContext.getLockAccess().create && userContext.getLockAccess().edit, // Presumably because this is an upsert operation so needs both create and edit permissions
       removeLocks: userContext.getLockAccess().remove,
       accessMonitoring: hasAccessMonitoringAccess(),
+      accessAutomations:
+        userContext.getAccessMonitoringRuleAccess().list &&
+        userContext.getAccessMonitoringRuleAccess().read,
+      accessLists:
+        userContext.getAccessListAccess().list &&
+        userContext.getAccessListAccess().read,
+      addAccessList:
+        userContext.getAccessListAccess().create &&
+        userContext.getAccessListAccess().list &&
+        userContext.getAccessListAccess().read,
       accessGraph: userContext.getAccessGraphAccess().list,
       accessGraphIntegrations: hasAccessGraphIntegrationsAccess(),
       createTokens: userContext.getTokenAccess().create,
@@ -276,6 +283,9 @@ export const disabledFeatureFlags: types.FeatureFlags = {
   addLocks: false,
   removeLocks: false,
   accessMonitoring: false,
+  accessAutomations: false,
+  accessLists: false,
+  addAccessList: false,
   accessGraph: false,
   accessGraphIntegrations: false,
   externalAuditStorage: false,

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -134,7 +134,17 @@ export interface TeleportFeature {
   category?: NavigationCategory;
   /** standalone is whether this feature has no subsections */
   standalone?: boolean;
+  /**
+   * hasAccess returns whether the user has RBAC access to this feature.
+   */
   hasAccess(flags: FeatureFlags): boolean;
+  /**
+   * discoverable, when true, keeps this feature visible in the navigation (and
+   * routable) even if the user doesn't have access to it. This is ignored when feature
+   * hiding is enabled (or on dashboard tenants), where inaccessible features are
+   * always hidden. Defaults to false.
+   */
+  discoverable?: boolean;
   // logoOnlyTopbar is used to optionally hide the elements in the topbar from view except for the logo.
   // The features that use this are supposed to be "full page" features where navigation
   // is either blocked, or done explicitly through the page (such as device trust authorize)
@@ -219,6 +229,9 @@ export interface FeatureFlags {
   createTokens: boolean;
   listTokens: boolean;
   accessMonitoring: boolean;
+  accessAutomations: boolean;
+  accessLists: boolean;
+  addAccessList: boolean;
   accessGraph: boolean;
   accessGraphIntegrations: boolean;
   externalAuditStorage: boolean;


### PR DESCRIPTION
This PR fixes bugs related to `FeatureHiding` and improves the implementation such that it is less prone to regressions in the future.

`e` counterpart: https://github.com/gravitational/teleport.e/pull/9166

## Manual Test Plan
### Test Environment

Local teleport running v19.0.0-alpha.2

### Test Cases
- [x] Verify that with `FeatureHiding` enabled, features in the sidenav that the user doesn't have access to are not shown, and entire sections are hidden if the user doesn't have access to anything nested inside of it.
- [x] Re-test the above with the same role but with `FeatureHiding` not enabled, and verify that discoverable features are still visible even without RBAC access.
- [x] Verify that with `FeatureHiding` enabled, if a user doesn't have access to any agent kinds, their shortcut link in the sidenav is hidden and the kind is not visible in the kinds filter on the Resources page.
