### PR TITLE
Implement the PendingCSRRequest storage service

### DIFF
--- a/api/client/events.go
+++ b/api/client/events.go
@@ -220,6 +220,10 @@ func EventToGRPC(in types.Event) (*proto.Event, error) {
 		out.Resource = &proto.Event_CertAuthorityOverride{
 			CertAuthorityOverride: r.UnwrapT(),
 		}
+	case types.Resource153UnwrapperT[*subcav1.PendingCSRRequest]:
+		out.Resource = &proto.Event_PendingCSRRequest{
+			PendingCSRRequest: r.UnwrapT(),
+		}
 	case types.Resource153UnwrapperT[*mfav2.ValidatedMFAChallenge]:
 		out.Resource = &proto.Event_ValidatedMFAChallengeV2{
 			ValidatedMFAChallengeV2: r.UnwrapT(),
@@ -761,6 +765,9 @@ func EventFromGRPC(in *proto.Event) (*types.Event, error) {
 		out.Resource = types.Resource153ToLegacy(r)
 		return &out, nil
 	} else if r := in.GetCertAuthorityOverride(); r != nil {
+		out.Resource = types.ProtoResource153ToLegacy(r)
+		return &out, nil
+	} else if r := in.GetPendingCSRRequest(); r != nil {
 		out.Resource = types.ProtoResource153ToLegacy(r)
 		return &out, nil
 	} else if r := in.GetValidatedMFAChallengeV2(); r != nil {

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -742,6 +742,9 @@ const (
 	// KindCertAuthorityOverride is the resource kind for CA overrides.
 	KindCertAuthorityOverride = "cert_authority_override"
 
+	// KindPendingCSRRequest is the resource kind for pending CSR requests.
+	KindPendingCSRRequest = "pending_csr_request"
+
 	// KindDelegationSession is the resource kind for Delegation Sessions.
 	//
 	// Delegation Sessions allow users to temporarily lend (a subset of) their

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -671,13 +671,18 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		}
 	}
 
-	if cfg.SubCAService == nil {
-		var err error
-		cfg.SubCAService, err = local.NewSubCAService(local.SubCAServiceParams{
+	if cfg.SubCAService == nil || cfg.PendingCSRRequestService == nil {
+		localSubCA, err := local.NewSubCAService(local.SubCAServiceParams{
 			Backend: cfg.Backend,
 		})
 		if err != nil {
 			return nil, trace.Wrap(err, "creating SubCAService")
+		}
+		if cfg.SubCAService == nil {
+			cfg.SubCAService = localSubCA
+		}
+		if cfg.PendingCSRRequestService == nil {
+			cfg.PendingCSRRequestService = localSubCA
 		}
 	}
 
@@ -754,6 +759,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		Beams:                           cfg.Beams,
 		BeamsConfigService:              cfg.BeamsConfigService,
 		SubCAService:                    cfg.SubCAService,
+		PendingCSRRequestService:        cfg.PendingCSRRequestService,
 		EnrollPairing:                   cfg.EnrollPairing,
 	}
 

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -458,6 +458,8 @@ type InitConfig struct {
 
 	// SubCAService manages CertAuthorityOverride resources.
 	SubCAService services.SubCAService
+	// PendingCSRRequestService manages PendingCSRRequest resources.
+	PendingCSRRequestService services.PendingCSRRequestService
 
 	// FakePasswordHash is the password hash given to all users without a password.
 	// This helps eliminate timing attacks by ensuring that all authentication attempts

--- a/lib/auth/services.go
+++ b/lib/auth/services.go
@@ -101,6 +101,7 @@ type Services struct {
 	services.Beams
 	services.BeamsConfigService
 	services.SubCAService
+	services.PendingCSRRequestService
 	services.EnrollPairing
 }
 

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -141,6 +141,7 @@ func ForAuth(cfg Config) Config {
 	cfg.Watches = []types.WatchKind{
 		{Kind: types.KindCertAuthority, LoadSecrets: true},
 		{Kind: types.KindCertAuthorityOverride},
+		{Kind: types.KindPendingCSRRequest},
 		{Kind: types.KindClusterName},
 		{Kind: types.KindClusterAuditConfig},
 		{Kind: types.KindClusterNetworkingConfig},

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -2038,6 +2038,7 @@ func TestCacheWatchKindExistsInEvents(t *testing.T) {
 		types.KindClassifier:                        types.Resource153ToLegacy(new(summaryv1.Classifier)),
 		types.KindRetrievalModel:                    types.Resource153ToLegacy(new(summaryv1.RetrievalModel)),
 		types.KindCertAuthorityOverride:             types.Resource153ToLegacy(&subcav1.CertAuthorityOverride{}),
+		types.KindPendingCSRRequest:                 types.Resource153ToLegacy(&subcav1.PendingCSRRequest{}),
 		types.KindValidatedMFAChallenge:             types.Resource153ToLegacy(new(mfav2.ValidatedMFAChallenge)),
 	}
 
@@ -2126,6 +2127,8 @@ func TestCacheWatchKindExistsInEvents(t *testing.T) {
 					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*summaryv1.RetrievalModel]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
 				case types.Resource153UnwrapperT[*subcav1.CertAuthorityOverride]:
 					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*subcav1.CertAuthorityOverride]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
+				case types.Resource153UnwrapperT[*subcav1.PendingCSRRequest]:
+					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*subcav1.PendingCSRRequest]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
 				case types.Resource153UnwrapperT[*beamsv1.Beam]:
 					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*beamsv1.Beam]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
 				case types.Resource153UnwrapperT[*beamsv1.BeamsConfig]:

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -168,7 +168,12 @@ type collections struct {
 // resources events can be processed by downstream watchers.
 func isKnownUncollectedKind(kind string) bool {
 	switch kind {
-	case types.KindAccessRequest, types.KindHeadlessAuthentication, scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment, types.KindValidatedMFAChallenge:
+	case types.KindAccessRequest,
+		types.KindHeadlessAuthentication,
+		types.KindPendingCSRRequest,
+		scopedaccess.KindScopedRole,
+		scopedaccess.KindScopedRoleAssignment,
+		types.KindValidatedMFAChallenge:
 		return true
 	default:
 		return false

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -303,6 +303,8 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 			parser = newRetrievalModelParser()
 		case types.KindCertAuthorityOverride:
 			parser = newCertAuthorityOverrideParser()
+		case types.KindPendingCSRRequest:
+			parser = newPendingCSRRequestParser()
 		case types.KindValidatedMFAChallenge:
 			parser = newValidatedMFAChallengeParser(kind.Filter)
 		default:

--- a/lib/services/local/events_test.go
+++ b/lib/services/local/events_test.go
@@ -541,9 +541,9 @@ func TestWatchers(t *testing.T) {
 					subcav1.PendingCSRRequest_builder{
 						Kind:    types.KindPendingCSRRequest,
 						Version: types.V1,
-						Metadata: &headerv1.Metadata{
+						Metadata: headerv1.Metadata_builder{
 							Name: "2f878e0f-115c-4b48-a4f6-f4deae8efb6f",
-						},
+						}.Build(),
 						Spec: subcav1.PendingCSRRequestSpec_builder{
 							ClusterName: "example.com",
 							CaType:      string(types.WindowsCA),

--- a/lib/services/local/events_test.go
+++ b/lib/services/local/events_test.go
@@ -30,6 +30,7 @@ import (
 	linuxdesktopv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/linuxdesktop/v1"
 	mfav2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v2"
 	provisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/provisioning/v1"
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/lib/auth/authcatest"
@@ -523,6 +524,60 @@ func TestWatchers(t *testing.T) {
 				require.Equal(subtestT, types.KindValidatedMFAChallenge, chal.GetKind())
 				require.Equal(subtestT, "test-challenge", chal.GetMetadata().GetName())
 				require.Equal(subtestT, "leaf.example.com", chal.GetSpec().GetTargetCluster())
+			},
+		},
+		{
+			name: "PendingCSRRequest PUT/DELETE",
+			kind: types.KindPendingCSRRequest,
+			causeEvents: func(ctx context.Context, t *testing.T, bk backend.Backend) {
+				service, err := NewSubCAService(SubCAServiceParams{
+					Backend: bk,
+				})
+				require.NoError(t, err)
+
+				// PUT.
+				res, err := service.CreatePendingCSRRequest(
+					ctx,
+					subcav1.PendingCSRRequest_builder{
+						Kind:    types.KindPendingCSRRequest,
+						Version: types.V1,
+						Metadata: &headerv1.Metadata{
+							Name: "2f878e0f-115c-4b48-a4f6-f4deae8efb6f",
+						},
+						Spec: subcav1.PendingCSRRequestSpec_builder{
+							ClusterName: "example.com",
+							CaType:      string(types.WindowsCA),
+							PublicKeyHashes: []*subcav1.PublicKeyHash{
+								subcav1.PublicKeyHash_builder{
+									Value: "ea16c3a8c1f31943019ecc9bfb2899b60e8ec156874bdf4606a899c95392cef3",
+								}.Build(),
+							},
+						}.Build(),
+					}.Build(),
+				)
+				require.NoError(t, err)
+
+				// DELETE.
+				require.NoError(t,
+					service.DeletePendingCSRRequest(ctx, res.GetMetadata().GetName()),
+				)
+			},
+			validateEvents: func(ctx context.Context, t *testing.T, watcher types.Watcher) {
+				const wantName = "2f878e0f-115c-4b48-a4f6-f4deae8efb6f"
+
+				// PUT.
+				event := fetchEvent(t, watcher, fetchTimeout)
+				require.Equal(t, types.OpPut, event.Type)
+				res, err := types.ConvertResource[*subcav1.PendingCSRRequest](event.Resource)
+				require.NoError(t, err)
+				require.Equal(t, wantName, res.GetMetadata().GetName())
+
+				// DELETE.
+				event = fetchEvent(t, watcher, fetchTimeout)
+				require.Equal(t, types.OpDelete, event.Type)
+				res, err = types.ConvertResource[*subcav1.PendingCSRRequest](event.Resource)
+				require.NoError(t, err)
+				require.Equal(t, wantName, res.GetMetadata().GetName())
 			},
 		},
 	}

--- a/lib/services/local/subca_service.go
+++ b/lib/services/local/subca_service.go
@@ -18,8 +18,13 @@ package local
 
 import (
 	"context"
+	"slices"
+	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
@@ -71,11 +76,14 @@ type SubCAServiceParams struct {
 //
 // Follows RFD 153 / generic.Service semantics.
 type SubCAService struct {
-	service *generic.ServiceWrapper[*subcav1.CertAuthorityOverride]
+	clock      clockwork.Clock
+	service    *generic.ServiceWrapper[*subcav1.CertAuthorityOverride]
+	csrService *generic.ServiceWrapper[*subcav1.PendingCSRRequest]
 }
 
 // Keep interface in-sync with implementation.
 var _ services.SubCAService = (*SubCAService)(nil)
+var _ services.PendingCSRRequestService = (*SubCAService)(nil)
 
 // NewSubCAService creates a new service using the provided params.
 func NewSubCAService(p SubCAServiceParams) (*SubCAService, error) {
@@ -94,8 +102,27 @@ func NewSubCAService(p SubCAServiceParams) (*SubCAService, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	csrService, err := generic.NewServiceWrapper(generic.ServiceConfig[*subcav1.PendingCSRRequest]{
+		Backend:       p.Backend,
+		ResourceKind:  types.KindPendingCSRRequest,
+		BackendPrefix: newPendingCSRRequestPrefix(),
+		MarshalFunc:   services.MarshalPendingCSRRequest,
+		UnmarshalFunc: services.UnmarshalPendingCSRRequest,
+		ValidateFunc:  validatePendingCSRRequest,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	clock := p.Backend.Clock()
+	if clock == nil {
+		clock = clockwork.NewRealClock()
+	}
+
 	return &SubCAService{
-		service: service,
+		clock:      clock,
+		service:    service,
+		csrService: csrService,
 	}, nil
 }
 
@@ -310,4 +337,115 @@ func itemFromCertAuthorityOverride(resource *subcav1.CertAuthorityOverride) (*ba
 		Expires:  expires,
 		Revision: resource.GetMetadata().GetRevision(),
 	}, nil
+}
+
+// CreatePendingCSRRequest creates a PendingCSRRequest.
+//
+// PendingCSRRequest instances must have an expiration. If they don't a
+// default expiration is assigned on creation.
+func (s *SubCAService) CreatePendingCSRRequest(ctx context.Context, resource *subcav1.PendingCSRRequest) (*subcav1.PendingCSRRequest, error) {
+	s.setPendingCSRRequestDefaultExpires(resource)
+
+	created, err := s.csrService.CreateResource(ctx, resource)
+	return created, trace.Wrap(err)
+}
+
+// UpdatePendingCSRRequest conditionally updates a PendingCSRRequest.
+func (s *SubCAService) UpdatePendingCSRRequest(ctx context.Context, resource *subcav1.PendingCSRRequest) (*subcav1.PendingCSRRequest, error) {
+	s.setPendingCSRRequestDefaultExpires(resource)
+
+	updated, err := s.csrService.ConditionalUpdateResource(ctx, resource)
+	return updated, trace.Wrap(err)
+}
+
+// DeletePendingCSRRequest hard-deletes a PendingCSRRequest.
+func (s *SubCAService) DeletePendingCSRRequest(ctx context.Context, name string) error {
+	if name == "" {
+		return trace.BadParameter("name required")
+	}
+	return trace.Wrap(s.csrService.DeleteResource(ctx, name))
+}
+
+// GetPendingCSRRequest reads a PendingCSRRequest by name.
+func (s *SubCAService) GetPendingCSRRequest(ctx context.Context, name string) (*subcav1.PendingCSRRequest, error) {
+	if name == "" {
+		return nil, trace.BadParameter("name required")
+	}
+	resource, err := s.csrService.GetResource(ctx, name)
+	return resource, trace.Wrap(err)
+}
+
+// ListPendingCSRRequest lists all PendingCSRRequests.
+func (s *SubCAService) ListPendingCSRRequest(ctx context.Context, pageSize int, pageToken string) (_ []*subcav1.PendingCSRRequest, nextPageToken string, _ error) {
+	resources, nextPageToken, err := s.csrService.ListResources(ctx, pageSize, pageToken)
+	return resources, nextPageToken, trace.Wrap(err)
+}
+
+func (s *SubCAService) setPendingCSRRequestDefaultExpires(resource *subcav1.PendingCSRRequest) {
+	if !resource.HasMetadata() || resource.GetMetadata().HasExpires() {
+		return
+	}
+	const defaultExpires = 5 * time.Minute
+	resource.GetMetadata().SetExpires(timestamppb.New(s.clock.Now().Add(defaultExpires)))
+}
+
+func newPendingCSRRequestPrefix() backend.Key {
+	return backend.NewKey("cert_authority_overrides", "csr_req")
+}
+
+func validatePendingCSRRequest(resource *subcav1.PendingCSRRequest) error {
+	switch {
+	case resource == nil:
+		return trace.BadParameter("nil PendingCSRRequest")
+	case resource.GetKind() != types.KindPendingCSRRequest:
+		return trace.BadParameter("invalid kind: %q", resource.GetKind())
+	case resource.GetSubKind() != "":
+		return trace.BadParameter("invalid sub_kind: %q (sub_kind not supported)", resource.GetSubKind())
+	case resource.GetVersion() != types.V1:
+		return trace.BadParameter("invalid or unsupported version: %q)", resource.GetVersion())
+	case resource.GetMetadata().GetName() == "":
+		return trace.BadParameter("metadata.name required")
+	case !resource.GetMetadata().HasExpires():
+		return trace.BadParameter("metadata.expires required")
+	case !resource.HasSpec():
+		return trace.BadParameter("spec required")
+	case resource.GetSpec().GetClusterName() == "":
+		return trace.BadParameter("spec.cluster_name required")
+	case !slices.Contains(subca.SupportedCATypes(), resource.GetSpec().GetCaType()):
+		return trace.BadParameter("spec.ca_type invalid or unsupported: %q", resource.GetSpec().GetCaType())
+	case len(resource.GetSpec().GetPublicKeyHashes()) == 0:
+		return trace.BadParameter("spec.public_key_hashes required")
+	}
+
+	// spec.custom_subject.
+	if subj := resource.GetSpec().GetCustomSubject(); subj != nil {
+		if _, err := subca.DistinguishedNameProtoToRDNSequence(subj); err != nil {
+			return trace.Wrap(err, "parse spec.custom_subject")
+		}
+	}
+
+	// spec.public_key_hashes.
+	knownPKHs := make(map[string]struct{})
+	for i, pkh := range resource.GetSpec().GetPublicKeyHashes() {
+		if pkh.GetValue() == "" {
+			return trace.BadParameter("spec.public_key_hashes[%d]: value required", i)
+		}
+		knownPKHs[pkh.GetValue()] = struct{}{}
+	}
+
+	// status.public_key_hash_to_pending_csr.
+	const pkhToPendingField = "status.public_key_hash_to_pending_csr"
+	for k, v := range resource.GetStatus().GetPublicKeyHashToPendingCsr() {
+		if _, ok := knownPKHs[k]; !ok {
+			return trace.BadParameter("%s[%s]: unrequested key not allowed", pkhToPendingField, k)
+		}
+		switch {
+		case !v.HasStatus():
+			return trace.BadParameter("%s[%s]: status required", pkhToPendingField, k)
+		case codes.Code(v.GetStatus().GetCode()) == codes.OK && v.GetCsr().GetPem() == "":
+			return trace.BadParameter("%s[%s]: csr required for status OK", pkhToPendingField, k)
+		}
+	}
+
+	return nil
 }

--- a/lib/services/local/subca_service.go
+++ b/lib/services/local/subca_service.go
@@ -411,7 +411,7 @@ func validatePendingCSRRequest(resource *subcav1.PendingCSRRequest) error {
 	case resource.GetSubKind() != "":
 		return trace.BadParameter("invalid sub_kind: %q (sub_kind not supported)", resource.GetSubKind())
 	case resource.GetVersion() != types.V1:
-		return trace.BadParameter("invalid or unsupported version: %q)", resource.GetVersion())
+		return trace.BadParameter("invalid or unsupported version: %q", resource.GetVersion())
 	case resource.GetMetadata().GetName() == "":
 		return trace.BadParameter("metadata.name required")
 	case !resource.GetMetadata().HasExpires():

--- a/lib/services/local/subca_service.go
+++ b/lib/services/local/subca_service.go
@@ -19,6 +19,7 @@ package local
 import (
 	"context"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -448,4 +449,44 @@ func validatePendingCSRRequest(resource *subcav1.PendingCSRRequest) error {
 	}
 
 	return nil
+}
+
+type pendingCSRRequestParser struct {
+	baseParser
+}
+
+func newPendingCSRRequestParser() *pendingCSRRequestParser {
+	return &pendingCSRRequestParser{
+		baseParser: newBaseParser(newPendingCSRRequestPrefix()),
+	}
+}
+
+func (p *pendingCSRRequestParser) parse(event backend.Event) (types.Resource, error) {
+	switch event.Type {
+	case types.OpDelete:
+		name := event.Item.Key.TrimPrefix(newPendingCSRRequestPrefix()).String()
+		name = strings.TrimPrefix(name, backend.SeparatorString)
+		if name == "" {
+			return nil, trace.BadParameter("unexpected %s key: %s", types.KindPendingCSRRequest, event.Item.Key)
+		}
+
+		return types.Resource153ToLegacy(subcav1.PendingCSRRequest_builder{
+			Kind:    types.KindPendingCSRRequest,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: name,
+			}.Build(),
+		}.Build()), nil
+	case types.OpPut:
+		r, err := services.UnmarshalPendingCSRRequest(event.Item.Value,
+			services.WithExpires(event.Item.Expires),
+			services.WithRevision(event.Item.Revision),
+		)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return types.Resource153ToLegacy(r), nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
 }

--- a/lib/services/local/subca_service.go
+++ b/lib/services/local/subca_service.go
@@ -107,8 +107,8 @@ func NewSubCAService(p SubCAServiceParams) (*SubCAService, error) {
 		Backend:       p.Backend,
 		ResourceKind:  types.KindPendingCSRRequest,
 		BackendPrefix: newPendingCSRRequestPrefix(),
-		MarshalFunc:   services.MarshalPendingCSRRequest,
-		UnmarshalFunc: services.UnmarshalPendingCSRRequest,
+		MarshalFunc:   marshalPendingCSRRequest,
+		UnmarshalFunc: unmarshalPendingCSRRequest,
 		ValidateFunc:  validatePendingCSRRequest,
 	})
 	if err != nil {
@@ -394,6 +394,14 @@ func newPendingCSRRequestPrefix() backend.Key {
 	return backend.NewKey("cert_authority_overrides", "csr_req")
 }
 
+func marshalPendingCSRRequest(resource *subcav1.PendingCSRRequest, opts ...services.MarshalOption) ([]byte, error) {
+	return services.MarshalProtoResource(resource, opts...)
+}
+
+func unmarshalPendingCSRRequest(data []byte, opts ...services.MarshalOption) (*subcav1.PendingCSRRequest, error) {
+	return services.UnmarshalProtoResource[*subcav1.PendingCSRRequest](data, opts...)
+}
+
 func validatePendingCSRRequest(resource *subcav1.PendingCSRRequest) error {
 	switch {
 	case resource == nil:
@@ -478,7 +486,7 @@ func (p *pendingCSRRequestParser) parse(event backend.Event) (types.Resource, er
 			}.Build(),
 		}.Build()), nil
 	case types.OpPut:
-		r, err := services.UnmarshalPendingCSRRequest(event.Item.Value,
+		r, err := unmarshalPendingCSRRequest(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
 			services.WithRevision(event.Item.Revision),
 		)

--- a/lib/services/local/subca_service.go
+++ b/lib/services/local/subca_service.go
@@ -376,8 +376,8 @@ func (s *SubCAService) GetPendingCSRRequest(ctx context.Context, name string) (*
 	return resource, trace.Wrap(err)
 }
 
-// ListPendingCSRRequest lists all PendingCSRRequests.
-func (s *SubCAService) ListPendingCSRRequest(ctx context.Context, pageSize int, pageToken string) (_ []*subcav1.PendingCSRRequest, nextPageToken string, _ error) {
+// ListPendingCSRRequests lists all PendingCSRRequests.
+func (s *SubCAService) ListPendingCSRRequests(ctx context.Context, pageSize int, pageToken string) (_ []*subcav1.PendingCSRRequest, nextPageToken string, _ error) {
 	resources, nextPageToken, err := s.csrService.ListResources(ctx, pageSize, pageToken)
 	return resources, nextPageToken, trace.Wrap(err)
 }

--- a/lib/services/local/subca_service_test.go
+++ b/lib/services/local/subca_service_test.go
@@ -18,12 +18,18 @@ package local_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 
@@ -531,4 +537,240 @@ func TestCreateResource_CertAuthorityOverride(t *testing.T) {
 			t.Errorf("CertAuthorityOverride mismatch (-want +got)\n%s", diff)
 		}
 	})
+}
+
+func TestSubCAService_PendingCSRRequest_CRUD(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	env := subcaenv.New(t, subcaenv.EnvParams{
+		Clock: clock,
+	})
+	service := env.SubCA
+
+	const pkh1 = "ea16c3a8c1f31943019ecc9bfb2899b60e8ec156874bdf4606a899c95392cef3"
+	const pkh2 = "1cd6a96e049f643d1f8c1cdd0390c08c2a7587df204ba254ee46009c08e80456"
+	req := subcav1.PendingCSRRequest_builder{
+		Kind:    types.KindPendingCSRRequest,
+		Version: types.V1,
+		Metadata: headerv1.Metadata_builder{
+			Name: uuid.NewString(),
+		}.Build(),
+		Spec: subcav1.PendingCSRRequestSpec_builder{
+			ClusterName: env.ClusterName,
+			CaType:      string(types.WindowsCA),
+			PublicKeyHashes: []*subcav1.PublicKeyHash{
+				subcav1.PublicKeyHash_builder{Value: pkh1}.Build(),
+				subcav1.PublicKeyHash_builder{Value: pkh2}.Build(),
+			},
+		}.Build(),
+	}.Build()
+
+	if !t.Run("create", func(t *testing.T) {
+		got, err := service.CreatePendingCSRRequest(t.Context(), proto.CloneOf(req))
+		require.NoError(t, err)
+		// Drift clock so we can detect eventual changes to metadata.expires.
+		clock.Advance(1 * time.Minute)
+
+		assert.NotNil(t, got.GetMetadata().GetExpires(), "PendingCSRRequest.Metadata.Expires is nil")
+
+		req.GetMetadata().SetExpires(got.GetMetadata().GetExpires())
+		req.GetMetadata().SetRevision(got.GetMetadata().GetRevision())
+		if diff := cmp.Diff(req, got, protocmp.Transform()); diff != "" {
+			t.Errorf("Create mismatch (-want +got)\n%s", diff)
+		}
+	}) {
+		t.Skip("create test failed, skipping other tests")
+	}
+
+	name := req.GetMetadata().GetName()
+
+	t.Run("update", func(t *testing.T) {
+		const csr = `
+-----BEGIN CERTIFICATE REQUEST-----
+CSR GOES HERE
+-----END CERTIFICATE REQUEST-----`
+
+		newReq := proto.CloneOf(req)
+		newReq.SetStatus(subcav1.PendingCSRRequestStatus_builder{
+			PublicKeyHashToPendingCsr: map[string]*subcav1.PendingCSR{
+				pkh1: subcav1.PendingCSR_builder{
+					Status: &status.Status{}, // zero == success
+					Csr: subcav1.CertificateSigningRequest_builder{
+						Pem: strings.TrimSpace(csr),
+					}.Build(),
+				}.Build(),
+				pkh2: subcav1.PendingCSR_builder{
+					Status: &status.Status{
+						Code:    int32(codes.Internal),
+						Message: "failed to sign CSR",
+					},
+				}.Build(),
+			},
+		}.Build())
+
+		updated, err := service.UpdatePendingCSRRequest(t.Context(), proto.CloneOf(newReq))
+		require.NoError(t, err)
+		// Assign updated so other tests use the latest instance.
+		req = updated
+
+		newReq.GetMetadata().SetRevision(updated.GetMetadata().GetRevision())
+		if diff := cmp.Diff(newReq, updated, protocmp.Transform()); diff != "" {
+			t.Errorf("Update mismatch (-want +got)\n%s", diff)
+		}
+	})
+
+	t.Run("get", func(t *testing.T) {
+		got, err := service.GetPendingCSRRequest(t.Context(), name)
+		require.NoError(t, err)
+
+		if diff := cmp.Diff(req, got, protocmp.Transform()); diff != "" {
+			t.Errorf("Get mismatch (-want +got)\n%s", diff)
+		}
+	})
+
+	t.Run("list", func(t *testing.T) {
+		const pageSize = 0
+		const pageToken = ""
+		got, nextPageToken, err := service.ListPendingCSRRequest(t.Context(), pageSize, pageToken)
+		require.NoError(t, err)
+		assert.Empty(t, nextPageToken, "nextPageToken not empty")
+
+		want := []*subcav1.PendingCSRRequest{req}
+		if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+			t.Errorf("List mismatch (-want +got)\n%s", diff)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		require.NoError(t, service.DeletePendingCSRRequest(t.Context(), name))
+
+		assert.ErrorAs(t,
+			service.DeletePendingCSRRequest(t.Context(), name),
+			new(*trace.NotFoundError),
+		)
+	})
+}
+
+func TestSubCAService_PendingCSRRequest_validation(t *testing.T) {
+	t.Parallel()
+
+	env := subcaenv.New(t, subcaenv.EnvParams{})
+	service := env.SubCA
+
+	const pkh1 = "ea16c3a8c1f31943019ecc9bfb2899b60e8ec156874bdf4606a899c95392cef3"
+	const pkh2 = "1cd6a96e049f643d1f8c1cdd0390c08c2a7587df204ba254ee46009c08e80456"
+	const pkhUnrelated = "4531b8b283404ec913dc02c136efa16aea35465d19ec828b52056a1b593ecac1"
+
+	makeReq := func(modify func(*subcav1.PendingCSRRequest)) *subcav1.PendingCSRRequest {
+		validReq := subcav1.PendingCSRRequest_builder{
+			Kind:    types.KindPendingCSRRequest,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: "aa8fa139-c4bf-4cb8-821a-3be57565d231",
+			}.Build(),
+			Spec: subcav1.PendingCSRRequestSpec_builder{
+				ClusterName: env.ClusterName,
+				CaType:      string(types.DatabaseClientCA),
+				PublicKeyHashes: []*subcav1.PublicKeyHash{
+					subcav1.PublicKeyHash_builder{Value: pkh1}.Build(),
+					subcav1.PublicKeyHash_builder{Value: pkh2}.Build(),
+				},
+			}.Build(),
+		}.Build()
+		modify(validReq)
+		return validReq
+	}
+
+	tests := []struct {
+		name    string
+		req     *subcav1.PendingCSRRequest
+		wantErr string
+	}{
+		{
+			name: "cluster_name required",
+			req: makeReq(func(req *subcav1.PendingCSRRequest) {
+				req.GetSpec().SetClusterName("")
+			}),
+			wantErr: "spec.cluster_name",
+		},
+		{
+			name: "ca_type required",
+			req: makeReq(func(req *subcav1.PendingCSRRequest) {
+				req.GetSpec().SetCaType("")
+			}),
+			wantErr: "spec.ca_type",
+		},
+		{
+			name: "custom_subject invalid",
+			req: makeReq(func(req *subcav1.PendingCSRRequest) {
+				req.GetSpec().SetCustomSubject(subcav1.DistinguishedName_builder{
+					Names: []*subcav1.AttributeTypeAndValue{
+						nil, // invalid
+					},
+				}.Build())
+			}),
+			wantErr: "custom_subject",
+		},
+		{
+			name: "public_key_hashes required",
+			req: makeReq(func(req *subcav1.PendingCSRRequest) {
+				req.GetSpec().SetPublicKeyHashes([]*subcav1.PublicKeyHash{})
+			}),
+			wantErr: "public_key_hashes required",
+		},
+		{
+			name: "public_key_hashes must not be empty",
+			req: makeReq(func(req *subcav1.PendingCSRRequest) {
+				pkhs := req.GetSpec().GetPublicKeyHashes()
+				pkhs = append(pkhs, nil)
+				req.GetSpec().SetPublicKeyHashes(pkhs)
+			}),
+			wantErr: "public_key_hashes[2]: value required",
+		},
+		{
+			name: "status CSR keys must match spec keys",
+			req: makeReq(func(req *subcav1.PendingCSRRequest) {
+				req.SetStatus(subcav1.PendingCSRRequestStatus_builder{
+					PublicKeyHashToPendingCsr: map[string]*subcav1.PendingCSR{
+						pkhUnrelated: subcav1.PendingCSR_builder{
+							Status: &status.Status{Code: int32(codes.Internal)},
+						}.Build(),
+					},
+				}.Build())
+			}),
+			wantErr: "unrequested key not allowed",
+		},
+		{
+			name: "status CSR entries must have a status",
+			req: makeReq(func(req *subcav1.PendingCSRRequest) {
+				req.SetStatus(subcav1.PendingCSRRequestStatus_builder{
+					PublicKeyHashToPendingCsr: map[string]*subcav1.PendingCSR{
+						pkh1: nil,
+					},
+				}.Build())
+			}),
+			wantErr: "status required",
+		},
+		{
+			name: "status CSR `OK` entries must have a PEM",
+			req: makeReq(func(req *subcav1.PendingCSRRequest) {
+				req.SetStatus(subcav1.PendingCSRRequestStatus_builder{
+					PublicKeyHashToPendingCsr: map[string]*subcav1.PendingCSR{
+						pkh1: subcav1.PendingCSR_builder{
+							Status: &status.Status{}, // zero == OK
+						}.Build(),
+					},
+				}.Build())
+			}),
+			wantErr: "csr required",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := service.CreatePendingCSRRequest(t.Context(), test.req)
+			assert.ErrorContains(t, err, test.wantErr, "PendingCSRRequest validation error mismatch")
+		})
+	}
 }

--- a/lib/services/local/subca_service_test.go
+++ b/lib/services/local/subca_service_test.go
@@ -632,7 +632,7 @@ CSR GOES HERE
 	t.Run("list", func(t *testing.T) {
 		const pageSize = 0
 		const pageToken = ""
-		got, nextPageToken, err := service.ListPendingCSRRequest(t.Context(), pageSize, pageToken)
+		got, nextPageToken, err := service.ListPendingCSRRequests(t.Context(), pageSize, pageToken)
 		require.NoError(t, err)
 		assert.Empty(t, nextPageToken, "nextPageToken not empty")
 

--- a/lib/services/subca.go
+++ b/lib/services/subca.go
@@ -78,8 +78,8 @@ func UnmarshalCertAuthorityOverride(data []byte, opts ...MarshalOption) (*subcav
 type PendingCSRRequestServiceGetter interface {
 	// GetPendingCSRRequest reads a PendingCSRRequest by name.
 	GetPendingCSRRequest(ctx context.Context, name string) (*subcav1.PendingCSRRequest, error)
-	// ListPendingCSRRequest lists all PendingCSRRequests.
-	ListPendingCSRRequest(ctx context.Context, pageSize int, pageToken string) (_ []*subcav1.PendingCSRRequest, nextPageToken string, _ error)
+	// ListPendingCSRRequests lists all PendingCSRRequests.
+	ListPendingCSRRequests(ctx context.Context, pageSize int, pageToken string) (_ []*subcav1.PendingCSRRequest, nextPageToken string, _ error)
 }
 
 // PendingCSRRequestService manages PendingCSRRequest resources.

--- a/lib/services/subca.go
+++ b/lib/services/subca.go
@@ -98,13 +98,3 @@ type PendingCSRRequestService interface {
 	// DeletePendingCSRRequest hard-deletes a PendingCSRRequest.
 	DeletePendingCSRRequest(ctx context.Context, name string) error
 }
-
-// MarshalPendingCSRRequest marshals a PendingCSRRequest.
-func MarshalPendingCSRRequest(resource *subcav1.PendingCSRRequest, opts ...MarshalOption) ([]byte, error) {
-	return MarshalProtoResource(resource, opts...)
-}
-
-// UnmarshalPendingCSRRequest unmarshals a PendingCSRRequest.
-func UnmarshalPendingCSRRequest(data []byte, opts ...MarshalOption) (*subcav1.PendingCSRRequest, error) {
-	return UnmarshalProtoResource[*subcav1.PendingCSRRequest](data, opts...)
-}

--- a/lib/services/subca.go
+++ b/lib/services/subca.go
@@ -70,3 +70,41 @@ func MarshalCertAuthorityOverride(resource *subcav1.CertAuthorityOverride, opts 
 func UnmarshalCertAuthorityOverride(data []byte, opts ...MarshalOption) (*subcav1.CertAuthorityOverride, error) {
 	return UnmarshalProtoResource[*subcav1.CertAuthorityOverride](data, opts...)
 }
+
+// PendingCSRRequestServiceGetter is the read-only PendingCSRRequestService
+// interface.
+//
+// This service is not exposed to Auth clients.
+type PendingCSRRequestServiceGetter interface {
+	// GetPendingCSRRequest reads a PendingCSRRequest by name.
+	GetPendingCSRRequest(ctx context.Context, name string) (*subcav1.PendingCSRRequest, error)
+	// ListPendingCSRRequest lists all PendingCSRRequests.
+	ListPendingCSRRequest(ctx context.Context, pageSize int, pageToken string) (_ []*subcav1.PendingCSRRequest, nextPageToken string, _ error)
+}
+
+// PendingCSRRequestService manages PendingCSRRequest resources.
+//
+// This service is not exposed to Auth clients.
+type PendingCSRRequestService interface {
+	PendingCSRRequestServiceGetter
+
+	// CreatePendingCSRRequest creates a PendingCSRRequest.
+	//
+	// PendingCSRRequest instances must have an expiration. If they don't a
+	// default expiration is assigned on creation.
+	CreatePendingCSRRequest(ctx context.Context, resource *subcav1.PendingCSRRequest) (*subcav1.PendingCSRRequest, error)
+	// UpdatePendingCSRRequest conditionally updates a PendingCSRRequest.
+	UpdatePendingCSRRequest(ctx context.Context, resource *subcav1.PendingCSRRequest) (*subcav1.PendingCSRRequest, error)
+	// DeletePendingCSRRequest hard-deletes a PendingCSRRequest.
+	DeletePendingCSRRequest(ctx context.Context, name string) error
+}
+
+// MarshalPendingCSRRequest marshals a PendingCSRRequest.
+func MarshalPendingCSRRequest(resource *subcav1.PendingCSRRequest, opts ...MarshalOption) ([]byte, error) {
+	return MarshalProtoResource(resource, opts...)
+}
+
+// UnmarshalPendingCSRRequest unmarshals a PendingCSRRequest.
+func UnmarshalPendingCSRRequest(data []byte, opts ...MarshalOption) (*subcav1.PendingCSRRequest, error) {
+	return UnmarshalProtoResource[*subcav1.PendingCSRRequest](data, opts...)
+}


### PR DESCRIPTION
Define and implement lib/services.PendingCSRRequestService, the storage service for PendingCSRRequest resources.

The resource is plugged into cache/event streams as an "uncollected kind" resource, meaning it passes through the cache without really being cached. This is intended, as the resource is transient and reflects a request for work from remote Auth servers.

See #68759 for the proto definitions and documentation around it.

https://github.com/gravitational/teleport.e/issues/7675