### PR TITLE
Deflake TestHardwareKeySSH

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -9446,29 +9446,10 @@ func CreateAgentlessNode(t *testing.T, authServer *auth.Server, clusterName, nod
 	require.NoError(t, err)
 
 	// wait for node resource to be written to the backend
-	timedCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	t.Cleanup(cancel)
-	w, err := authServer.NewWatcher(timedCtx, types.Watch{
-		Name: "node-create watcher",
-		Kinds: []types.WatchKind{
-			{
-				Kind: types.KindNode,
-			},
-		},
-	})
-	require.NoError(t, err)
-
-	for nodeCreated := false; !nodeCreated; {
-		select {
-		case e := <-w.Events():
-			if e.Type == types.OpPut {
-				nodeCreated = true
-			}
-		case <-w.Done():
-			t.Fatal("Did not receive node create event")
-		}
-	}
-	require.NoError(t, w.Close())
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		_, err := authServer.GetNode(ctx, defaults.Namespace, nodeUUID)
+		assert.NoError(t, err)
+	}, 5*time.Second, 100*time.Millisecond)
 
 	return node
 }

--- a/tool/tsh/common/hardware_key_test.go
+++ b/tool/tsh/common/hardware_key_test.go
@@ -41,6 +41,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport/api/constants"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
@@ -365,29 +366,10 @@ func CreateAgentlessNode(t *testing.T, authServer *auth.Server, clusterName, nod
 	require.NoError(t, err)
 
 	// wait for node resource to be written to the backend
-	timedCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	t.Cleanup(cancel)
-	w, err := authServer.NewWatcher(timedCtx, types.Watch{
-		Name: "node-create watcher",
-		Kinds: []types.WatchKind{
-			{
-				Kind: types.KindNode,
-			},
-		},
-	})
-	require.NoError(t, err)
-
-	for nodeCreated := false; !nodeCreated; {
-		select {
-		case e := <-w.Events():
-			if e.Type == types.OpPut {
-				nodeCreated = true
-			}
-		case <-w.Done():
-			t.Fatal("Did not receive node create event")
-		}
-	}
-	require.NoError(t, w.Close())
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		_, err := authServer.GetNode(ctx, apidefaults.Namespace, nodeUUID)
+		assert.NoError(t, err)
+	}, 5*time.Second, 100*time.Millisecond)
 
 	return node
 }


### PR DESCRIPTION
The test used a watcher to wait for a newly-created node to show up, but they created the watcher only after the node was created, so it was possible for the watcher to miss the put event.

Note: there was a duplicated version of this helper in the integration tests that had the same issue, so I updated it there too.

Closes #66206