### PR TITLE
Fix GCP matcher rejecting the deprecated tags alias

### DIFF
--- a/api/types/matchers_gcp.go
+++ b/api/types/matchers_gcp.go
@@ -17,6 +17,7 @@ limitations under the License.
 package types
 
 import (
+	"maps"
 	"slices"
 
 	"github.com/gravitational/trace"
@@ -64,6 +65,7 @@ func (m GCPMatcher) GetLabels() Labels {
 }
 
 // CheckAndSetDefaults that the matcher is correct and adds default values.
+// On success the deprecated tags alias is folded into labels and cleared.
 func (m *GCPMatcher) CheckAndSetDefaults() error {
 	if len(m.Types) == 0 {
 		return trace.BadParameter("At least one GCP discovery service type must be specified, the supported resource types are: %v",
@@ -125,13 +127,21 @@ func (m *GCPMatcher) CheckAndSetDefaults() error {
 		return trace.BadParameter("GCP discovery service project_ids does cannot be empty; please specify at least one value in project_ids.")
 	}
 
-	if len(m.Labels) > 0 && len(m.Tags) > 0 {
-		return trace.BadParameter("labels and tags should not both be set.")
+	// Older releases copied non-empty tags to labels without clearing tags,
+	// so stored records and writes from older clients can carry both fields
+	// with equal content. Accept that legacy state and normalize non-empty
+	// tags below: only conflicting values are an error. Equality is intentionally
+	// order-sensitive because the legacy alias copy preserved value order.
+	if len(m.Labels) > 0 && len(m.Tags) > 0 &&
+		!maps.EqualFunc(m.Labels, m.Tags, func(a, b apiutils.Strings) bool { return slices.Equal(a, b) }) {
+		return trace.BadParameter("labels (%v) and tags (%v) are both set with different values; tags is a deprecated alias for labels, set only one", m.Labels, m.Tags)
 	}
 
 	if len(m.Tags) > 0 {
 		m.Labels = m.Tags
 	}
+	// Cleared even when empty: defaulting's output never carries the alias.
+	m.Tags = nil
 
 	if len(m.Labels) == 0 {
 		m.Labels = map[string]apiutils.Strings{

--- a/api/types/matchers_gcp.go
+++ b/api/types/matchers_gcp.go
@@ -65,7 +65,8 @@ func (m GCPMatcher) GetLabels() Labels {
 }
 
 // CheckAndSetDefaults that the matcher is correct and adds default values.
-// On success the deprecated tags alias is folded into labels and cleared.
+// The deprecated tags alias is left in place and resolved by GetLabels; it
+// is never copied into or merged with labels.
 func (m *GCPMatcher) CheckAndSetDefaults() error {
 	if len(m.Types) == 0 {
 		return trace.BadParameter("At least one GCP discovery service type must be specified, the supported resource types are: %v",
@@ -127,23 +128,21 @@ func (m *GCPMatcher) CheckAndSetDefaults() error {
 		return trace.BadParameter("GCP discovery service project_ids does cannot be empty; please specify at least one value in project_ids.")
 	}
 
-	// Older releases copied non-empty tags to labels without clearing tags,
-	// so stored records and writes from older clients can carry both fields
-	// with equal content. Accept that legacy state and normalize non-empty
-	// tags below: only conflicting values are an error. Equality is intentionally
-	// order-sensitive because the legacy alias copy preserved value order.
+	// tags is a deprecated alias for labels. Defaulting does not mutate either field
+	// (no copy into labels, no clearing), so the stored spec stays identical to what
+	// the user wrote (RFD 153) and GetLabels resolves the alias at read time.
+	// Reject only conflicting values; accept an equal both-set pair, which older versions
+	// persisted by copying tags into labels without clearing tags, so re-validating such a
+	// stored record after an upgrade must not fail. Equality is order-sensitive on purpose:
+	// that legacy copy preserved order, and any other both-set combination is a real configuration error.
 	if len(m.Labels) > 0 && len(m.Tags) > 0 &&
 		!maps.EqualFunc(m.Labels, m.Tags, func(a, b apiutils.Strings) bool { return slices.Equal(a, b) }) {
-		return trace.BadParameter("labels (%v) and tags (%v) are both set with different values; tags is a deprecated alias for labels, set only one", m.Labels, m.Tags)
+		return trace.BadParameter("labels and tags should not both be set with different values; tags is a deprecated alias for labels, set only one")
 	}
 
-	if len(m.Tags) > 0 {
-		m.Labels = m.Tags
-	}
-	// Cleared even when empty: defaulting's output never carries the alias.
-	m.Tags = nil
-
-	if len(m.Labels) == 0 {
+	// Default labels only when the user set neither field; a tags-only
+	// matcher is matched through GetLabels and must not be wildcarded.
+	if len(m.Labels) == 0 && len(m.Tags) == 0 {
 		m.Labels = map[string]apiutils.Strings{
 			Wildcard: {Wildcard},
 		}

--- a/api/types/matchers_gcp_test.go
+++ b/api/types/matchers_gcp_test.go
@@ -135,18 +135,130 @@ func TestGCPMatcherCheckAndSetDefaults(t *testing.T) {
 			errCheck: isBadParameterErr,
 		},
 		{
-			name: "error if both labels and tags are set",
+			name: "error if labels and tags are set with different values",
 			in: &GCPMatcher{
 				Types:      []string{"gce"},
 				ProjectIDs: []string{"project001"},
 				Labels: Labels{
-					"*": []string{"*"},
+					"env": []string{"prod"},
 				},
 				Tags: Labels{
-					"*": []string{"*"},
+					"env": []string{"dev"},
 				},
 			},
 			errCheck: isBadParameterErr,
+		},
+		{
+			name: "labels and tags with equal values in different order are rejected",
+			in: &GCPMatcher{
+				Types:      []string{"gce"},
+				ProjectIDs: []string{"project001"},
+				Labels: Labels{
+					"env": []string{"prod", "dev"},
+				},
+				Tags: Labels{
+					"env": []string{"dev", "prod"},
+				},
+			},
+			errCheck: isBadParameterErr,
+		},
+		{
+			name: "labels and tags with equal content are tolerated and normalized",
+			in: &GCPMatcher{
+				Types:      []string{"gce"},
+				ProjectIDs: []string{"project001"},
+				Labels: Labels{
+					"env": []string{"prod"},
+				},
+				Tags: Labels{
+					"env": []string{"prod"},
+				},
+			},
+			errCheck: require.NoError,
+			expected: &GCPMatcher{
+				Types:      []string{"gce"},
+				Locations:  []string{"*"},
+				ProjectIDs: []string{"project001"},
+				Labels: Labels{
+					"env": []string{"prod"},
+				},
+				Params: &InstallerParams{
+					JoinMethod: "gcp",
+					JoinToken:  "gcp-discovery-token",
+					ScriptName: "default-installer",
+				},
+			},
+		},
+		{
+			name: "empty tags map is cleared and labels default",
+			in: &GCPMatcher{
+				Types:      []string{"gce"},
+				ProjectIDs: []string{"project001"},
+				Tags:       Labels{},
+			},
+			errCheck: require.NoError,
+			expected: &GCPMatcher{
+				Types:      []string{"gce"},
+				Locations:  []string{"*"},
+				ProjectIDs: []string{"project001"},
+				Labels: Labels{
+					"*": []string{"*"},
+				},
+				Params: &InstallerParams{
+					JoinMethod: "gcp",
+					JoinToken:  "gcp-discovery-token",
+					ScriptName: "default-installer",
+				},
+			},
+		},
+		{
+			name: "empty tags map is cleared and existing labels kept",
+			in: &GCPMatcher{
+				Types:      []string{"gce"},
+				ProjectIDs: []string{"project001"},
+				Labels: Labels{
+					"env": []string{"prod"},
+				},
+				Tags: Labels{},
+			},
+			errCheck: require.NoError,
+			expected: &GCPMatcher{
+				Types:      []string{"gce"},
+				Locations:  []string{"*"},
+				ProjectIDs: []string{"project001"},
+				Labels: Labels{
+					"env": []string{"prod"},
+				},
+				Params: &InstallerParams{
+					JoinMethod: "gcp",
+					JoinToken:  "gcp-discovery-token",
+					ScriptName: "default-installer",
+				},
+			},
+		},
+		{
+			name: "tags only is normalized into labels",
+			in: &GCPMatcher{
+				Types:      []string{"gce"},
+				ProjectIDs: []string{"project001"},
+				Tags: Labels{
+					"env": []string{"prod"},
+				},
+			},
+			errCheck: require.NoError,
+			expected: &GCPMatcher{
+				Types:      []string{"gce"},
+				Locations:  []string{"*"},
+				ProjectIDs: []string{"project001"},
+				Labels: Labels{
+					"env": []string{"prod"},
+				},
+				Params: &InstallerParams{
+					JoinMethod: "gcp",
+					JoinToken:  "gcp-discovery-token",
+					ScriptName: "default-installer",
+				},
+			},
 		},
 		{
 			name: "invalid install suffix",
@@ -192,4 +304,58 @@ func TestGCPMatcherCheckAndSetDefaults(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGCPMatcherCheckAndSetDefaultsIdempotent verifies that re-running
+// defaulting on an already-defaulted matcher succeeds and changes nothing.
+// Defaulting normalizes the deprecated tags alias into labels and clears
+// tags, so its own output must validate cleanly on every later run: stored
+// or republished matchers (for example static snapshot publication) run
+// defaulting again on its own prior output. The both-fields-equal shape
+// written by older releases and older clients must normalize to the same
+// result instead of being rejected.
+func TestGCPMatcherCheckAndSetDefaultsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	newMatcher := func() *GCPMatcher {
+		return &GCPMatcher{
+			Types:      []string{"gce"},
+			ProjectIDs: []string{"project01"},
+			Tags: Labels{
+				"env": []string{"prod"},
+			},
+		}
+	}
+
+	once := newMatcher()
+	require.NoError(t, once.CheckAndSetDefaults())
+	require.Equal(t, Labels{"env": []string{"prod"}}, once.Labels)
+	require.Nil(t, once.Tags)
+
+	twice := newMatcher()
+	require.NoError(t, twice.CheckAndSetDefaults())
+	require.NoError(t, twice.CheckAndSetDefaults())
+	require.Equal(t, once, twice)
+
+	// The shape produced by older releases and by older clients during a
+	// rolling upgrade: both fields populated with equal content. It must
+	// be accepted and normalize to the same result as a fresh tags-only
+	// matcher.
+	legacy := &GCPMatcher{
+		Types:      []string{"gce"},
+		ProjectIDs: []string{"project01"},
+		Labels: Labels{
+			"env": []string{"prod"},
+		},
+		Tags: Labels{
+			"env": []string{"prod"},
+		},
+	}
+	require.NoError(t, legacy.CheckAndSetDefaults())
+	require.Equal(t, once, legacy)
+
+	// The normalized legacy matcher is itself a fixed point:
+	// a further run doesn't change anything.
+	require.NoError(t, legacy.CheckAndSetDefaults())
+	require.Equal(t, once, legacy)
 }

--- a/api/types/matchers_gcp_test.go
+++ b/api/types/matchers_gcp_test.go
@@ -135,7 +135,7 @@ func TestGCPMatcherCheckAndSetDefaults(t *testing.T) {
 			errCheck: isBadParameterErr,
 		},
 		{
-			name: "error if labels and tags are set with different values",
+			name: "error if both labels and tags are set with different values",
 			in: &GCPMatcher{
 				Types:      []string{"gce"},
 				ProjectIDs: []string{"project001"},
@@ -149,7 +149,7 @@ func TestGCPMatcherCheckAndSetDefaults(t *testing.T) {
 			errCheck: isBadParameterErr,
 		},
 		{
-			name: "labels and tags with equal values in different order are rejected",
+			name: "error if both labels and tags are set with equal keys but different values",
 			in: &GCPMatcher{
 				Types:      []string{"gce"},
 				ProjectIDs: []string{"project001"},
@@ -163,7 +163,7 @@ func TestGCPMatcherCheckAndSetDefaults(t *testing.T) {
 			errCheck: isBadParameterErr,
 		},
 		{
-			name: "labels and tags with equal content are tolerated and normalized",
+			name: "equal labels and tags are accepted and preserved (legacy stored shape)",
 			in: &GCPMatcher{
 				Types:      []string{"gce"},
 				ProjectIDs: []string{"project001"},
@@ -182,51 +182,7 @@ func TestGCPMatcherCheckAndSetDefaults(t *testing.T) {
 				Labels: Labels{
 					"env": []string{"prod"},
 				},
-				Params: &InstallerParams{
-					JoinMethod: "gcp",
-					JoinToken:  "gcp-discovery-token",
-					ScriptName: "default-installer",
-				},
-			},
-		},
-		{
-			name: "empty tags map is cleared and labels default",
-			in: &GCPMatcher{
-				Types:      []string{"gce"},
-				ProjectIDs: []string{"project001"},
-				Tags:       Labels{},
-			},
-			errCheck: require.NoError,
-			expected: &GCPMatcher{
-				Types:      []string{"gce"},
-				Locations:  []string{"*"},
-				ProjectIDs: []string{"project001"},
-				Labels: Labels{
-					"*": []string{"*"},
-				},
-				Params: &InstallerParams{
-					JoinMethod: "gcp",
-					JoinToken:  "gcp-discovery-token",
-					ScriptName: "default-installer",
-				},
-			},
-		},
-		{
-			name: "empty tags map is cleared and existing labels kept",
-			in: &GCPMatcher{
-				Types:      []string{"gce"},
-				ProjectIDs: []string{"project001"},
-				Labels: Labels{
-					"env": []string{"prod"},
-				},
-				Tags: Labels{},
-			},
-			errCheck: require.NoError,
-			expected: &GCPMatcher{
-				Types:      []string{"gce"},
-				Locations:  []string{"*"},
-				ProjectIDs: []string{"project001"},
-				Labels: Labels{
+				Tags: Labels{
 					"env": []string{"prod"},
 				},
 				Params: &InstallerParams{
@@ -237,7 +193,7 @@ func TestGCPMatcherCheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "tags only is normalized into labels",
+			name: "tags only is preserved and not copied into labels",
 			in: &GCPMatcher{
 				Types:      []string{"gce"},
 				ProjectIDs: []string{"project001"},
@@ -250,7 +206,7 @@ func TestGCPMatcherCheckAndSetDefaults(t *testing.T) {
 				Types:      []string{"gce"},
 				Locations:  []string{"*"},
 				ProjectIDs: []string{"project001"},
-				Labels: Labels{
+				Tags: Labels{
 					"env": []string{"prod"},
 				},
 				Params: &InstallerParams{
@@ -308,12 +264,11 @@ func TestGCPMatcherCheckAndSetDefaults(t *testing.T) {
 
 // TestGCPMatcherCheckAndSetDefaultsIdempotent verifies that re-running
 // defaulting on an already-defaulted matcher succeeds and changes nothing.
-// Defaulting normalizes the deprecated tags alias into labels and clears
-// tags, so its own output must validate cleanly on every later run: stored
-// or republished matchers (for example static snapshot publication) run
-// defaulting again on its own prior output. The both-fields-equal shape
-// written by older releases and older clients must normalize to the same
-// result instead of being rejected.
+// Defaulting does not mutate the deprecated tags alias: it neither copies
+// tags into labels nor clears either field, so a tags-only matcher stays
+// tags-only and re-running defaulting on its own output changes nothing.
+// This is what lets stored or republished matchers (for example static
+// snapshot publication) be re-validated repeatedly without failing.
 func TestGCPMatcherCheckAndSetDefaultsIdempotent(t *testing.T) {
 	t.Parallel()
 
@@ -329,33 +284,35 @@ func TestGCPMatcherCheckAndSetDefaultsIdempotent(t *testing.T) {
 
 	once := newMatcher()
 	require.NoError(t, once.CheckAndSetDefaults())
-	require.Equal(t, Labels{"env": []string{"prod"}}, once.Labels)
-	require.Nil(t, once.Tags)
+	// The spec is preserved exactly: tags kept, labels not synthesized.
+	require.Equal(t, Labels{"env": []string{"prod"}}, once.Tags)
+	require.Empty(t, once.Labels)
+	// The alias still resolves through GetLabels for matching.
+	require.Equal(t, Labels{"env": []string{"prod"}}, once.GetLabels())
 
 	twice := newMatcher()
 	require.NoError(t, twice.CheckAndSetDefaults())
 	require.NoError(t, twice.CheckAndSetDefaults())
 	require.Equal(t, once, twice)
 
-	// The shape produced by older releases and by older clients during a
-	// rolling upgrade: both fields populated with equal content. It must
-	// be accepted and normalize to the same result as a fresh tags-only
-	// matcher.
-	legacy := &GCPMatcher{
-		Types:      []string{"gce"},
-		ProjectIDs: []string{"project01"},
-		Labels: Labels{
-			"env": []string{"prod"},
-		},
-		Tags: Labels{
-			"env": []string{"prod"},
-		},
+	// A legacy stored shape (older versions copied tags into labels
+	// without clearing tags) must validate, stay unmutated, and be a
+	// fixed point across further runs.
+	newLegacy := func() *GCPMatcher {
+		return &GCPMatcher{
+			Types:      []string{"gce"},
+			ProjectIDs: []string{"project01"},
+			Labels:     Labels{"env": []string{"prod"}},
+			Tags:       Labels{"env": []string{"prod"}},
+		}
 	}
-	require.NoError(t, legacy.CheckAndSetDefaults())
-	require.Equal(t, once, legacy)
+	legacyOnce := newLegacy()
+	require.NoError(t, legacyOnce.CheckAndSetDefaults())
+	require.Equal(t, Labels{"env": []string{"prod"}}, legacyOnce.Labels)
+	require.Equal(t, Labels{"env": []string{"prod"}}, legacyOnce.Tags)
 
-	// The normalized legacy matcher is itself a fixed point:
-	// a further run doesn't change anything.
-	require.NoError(t, legacy.CheckAndSetDefaults())
-	require.Equal(t, once, legacy)
+	legacyTwice := newLegacy()
+	require.NoError(t, legacyTwice.CheckAndSetDefaults())
+	require.NoError(t, legacyTwice.CheckAndSetDefaults())
+	require.Equal(t, legacyOnce, legacyTwice)
 }


### PR DESCRIPTION
Fixes #68791.

## What

GCP discovery matchers using the deprecated `tags` field are rejected with "labels and tags should not both be set", even when the user set only `tags`. This makes the documented backwards-compatibility alias unusable for dynamic `discovery_config` resources

## This blocks discovery service configuration reporting (#61937)

I found this while working on #61937, which re-validates specs the Discovery Service has already defaulted and requires validation to accept its own output. A service with a file-configured `tags` matcher would otherwise be permanently unable to publish its configuration: its in-memory matchers are the output of config-load defaulting (both fields populated), and Auth re-validates every published inventory with the same function. 

The both-fields-set shape the service legitimately runs is rejected as `BadParameter`, which the publisher protocol correctly classifies as a non-retryable publisher bug, so every heartbeat fails identically forever and the instance renders as if it never published at all.

Changelog: Fixed GCP discovery matchers using the deprecated `tags` field being rejected with "labels and tags should not both be set".


<!-- Include manual testing efforts to verify the change. -->

```fish
echo 'kind: discovery_config
version: v1
metadata:
  name: gcp-tags-repro
spec:
  discovery_group: repro
  gcp:
  - types: ["gce"]
    project_ids: ["fake-project-123"]
    tags:
      env: ["prod"]' > dc.yaml
$BIN/tctl -c teleport.yaml create dc.yaml
and echo "STEP1: create OK"
or echo "STEP1: create FAILED"
$BIN/tctl -c teleport.yaml get \
    discovery_config/gcp-tags-repro
and echo "STEP2: get OK"
or echo "STEP2: get FAILED"
```
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->