### PR TITLE
appresource: Compile and evaluate where clauses

### DIFF
--- a/lib/appresource/where.go
+++ b/lib/appresource/where.go
@@ -28,57 +28,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils/typical"
 )
 
-// Request encodes the elements of the HTTP request a where clause is
-// evaluated against. It is deliberately not an *http.Request, to make
-// clear which fields matter for evaluation.
-type Request struct {
-	Method string
-}
-
-// Identity is the caller a where clause is evaluated against. It is
-// deliberately not a tlsca.Identity, to make clear which fields matter
-// for evaluation.
-type Identity struct {
-	Name   string
-	Roles  []string
-	Traits map[string][]string
-}
-
-// Env holds the values one where clause evaluation reads.
-type Env struct {
-	Request  Request
-	Identity Identity
-}
-
-// Where is a compiled where clause. Only CompileWhere returns a usable
-// value. Evaluation writes nothing back to a Where, so a single Where can
-// serve concurrent requests.
-type Where struct {
-	expression typical.Expression[Env, bool]
-}
-
-// CompileWhere parses and type-checks a where clause.
-func CompileWhere(expr string) (*Where, error) {
-	expression, err := whereParser.Parse(expr)
-	if err != nil {
-		return nil, trace.NewAggregate(trace.BadParameter("compiling where clause %q", expr), err)
-	}
-	return &Where{expression: expression}, nil
-}
-
-// Evaluate reports whether the where clause matches the environment. On
-// error it reports no match.
-func (w *Where) Evaluate(env Env) (bool, error) {
-	if err := validateEnv(env); err != nil {
-		return false, trace.Wrap(err)
-	}
-	match, err := w.expression.Evaluate(env)
-	if err != nil {
-		return false, trace.Wrap(err)
-	}
-	return match, nil
-}
-
 // validMethods are the HTTP methods a where clause evaluation accepts.
 var validMethods = []string{
 	http.MethodGet,
@@ -91,17 +40,84 @@ var validMethods = []string{
 	http.MethodTrace,
 }
 
-// validateEnv rejects an environment a where clause must not authorize,
-// such as a request method outside the canonical HTTP method list.
-func validateEnv(env Env) error {
-	if !slices.Contains(validMethods, env.Request.Method) {
-		return trace.BadParameter("unsupported HTTP method %q", env.Request.Method)
+// whereParser is the shared cached parser for where clauses.
+var whereParser = mustNewWhereParser()
+
+// Request encodes the elements of the HTTP request a where clause is
+// evaluated against.
+type Request struct {
+	Method string
+}
+
+// Identity is the caller a where clause is evaluated against.
+type Identity struct {
+	Name   string
+	Roles  []string
+	Traits map[string][]string
+}
+
+// Env holds the values one where clause evaluation reads. Request and
+// Identity are deliberately not [http.Request] and tlsca.Identity, to make
+// clear which fields matter for evaluation.
+type Env struct {
+	Request  Request
+	Identity Identity
+}
+
+// Where is a compiled where clause. Only CompileWhere returns a usable
+// value. Evaluation writes nothing back to a Where, so a single Where can
+// serve concurrent requests. The caller must not mutate the slices or
+// map in Env during an evaluation.
+type Where struct {
+	expression typical.Expression[Env, bool]
+}
+
+// NewEnv builds the environment a where clause is evaluated against and
+// rejects a request no rule may authorize. Callers build it once per
+// request, before matching any rule, because a rule without a where
+// clause never reaches Evaluate.
+func NewEnv(request Request, identity Identity) (Env, error) {
+	if err := validateMethod(request.Method); err != nil {
+		return Env{}, trace.Wrap(err)
+	}
+	return Env{Request: request, Identity: identity}, nil
+}
+
+// CompileWhere parses and type-checks a where clause.
+func CompileWhere(expr string) (*Where, error) {
+	expression, err := whereParser.Parse(expr)
+	if err != nil {
+		// The aggregate classifies the result as BadParameter for the
+		// caller and keeps typical's typed error for errors.As. Parse does
+		// not return a BadParameter for every failure.
+		return nil, trace.NewAggregate(trace.BadParameter("compiling where clause %q", expr), err)
+	}
+	return &Where{expression: expression}, nil
+}
+
+// Evaluate reports whether the where clause matches the environment. The
+// result is only meaningful when the error is nil.
+func (w *Where) Evaluate(env Env) (bool, error) {
+	if err := validateMethod(env.Request.Method); err != nil {
+		return false, trace.Wrap(err)
+	}
+	match, err := w.expression.Evaluate(env)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	return match, nil
+}
+
+// validateMethod rejects a request method outside the canonical HTTP
+// method list. NewEnv runs it at the request boundary and Evaluate
+// repeats it, so an environment a caller assembled itself still cannot
+// authorize such a request.
+func validateMethod(method string) error {
+	if !slices.Contains(validMethods, method) {
+		return trace.BadParameter("unsupported HTTP method %q", method)
 	}
 	return nil
 }
-
-// whereParser is the shared cached parser for where clauses.
-var whereParser = mustNewWhereParser()
 
 // mustNewWhereParser builds the where clause parser and panics if the
 // parser spec is invalid or the expression cache cannot be built.
@@ -117,6 +133,9 @@ func mustNewWhereParser() *typical.CachedParser[Env, bool] {
 			"user.roles": typical.DynamicVariable(func(e Env) ([]string, error) {
 				return e.Identity.Roles, nil
 			}),
+			// A key the identity does not have reads as an empty list, as in
+			// the role where-clause language, so a mistyped key under a
+			// negation matches every caller.
 			"user.traits": typical.DynamicMapFunction(func(e Env, key string) ([]string, error) {
 				return e.Identity.Traits[key], nil
 			}),
@@ -125,9 +144,8 @@ func mustNewWhereParser() *typical.CachedParser[Env, bool] {
 			}),
 		},
 		Functions: map[string]typical.Function{
-			// set builds a set from its string arguments for contains membership
-			// tests. set and contains match the functions of the same names in
-			// the role where-clause language, services.NewWhereParser.
+			// set and contains are named after the functions in the role
+			// where-clause language, services.NewWhereParser.
 			"set": typical.UnaryVariadicFunction[Env](func(args ...string) ([]string, error) {
 				return args, nil
 			}),

--- a/lib/appresource/where.go
+++ b/lib/appresource/where.go
@@ -1,0 +1,148 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package appresource
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/utils/typical"
+)
+
+// Request encodes the elements of the HTTP request a where clause is
+// evaluated against. It is deliberately not an *http.Request, to make
+// clear which fields matter for evaluation.
+type Request struct {
+	Method string
+}
+
+// Identity is the caller a where clause is evaluated against. It is
+// deliberately not a tlsca.Identity, to make clear which fields matter
+// for evaluation.
+type Identity struct {
+	Name   string
+	Roles  []string
+	Traits map[string][]string
+}
+
+// Env holds the values one where clause evaluation reads.
+type Env struct {
+	Request  Request
+	Identity Identity
+}
+
+// Where is a compiled where clause. Only CompileWhere returns a usable
+// value. Evaluation writes nothing back to a Where, so a single Where can
+// serve concurrent requests.
+type Where struct {
+	expression typical.Expression[Env, bool]
+}
+
+// CompileWhere parses and type-checks a where clause.
+func CompileWhere(expr string) (*Where, error) {
+	expression, err := whereParser.Parse(expr)
+	if err != nil {
+		return nil, trace.NewAggregate(trace.BadParameter("compiling where clause %q", expr), err)
+	}
+	return &Where{expression: expression}, nil
+}
+
+// Evaluate reports whether the where clause matches the environment. On
+// error it reports no match.
+func (w *Where) Evaluate(env Env) (bool, error) {
+	if err := validateEnv(env); err != nil {
+		return false, trace.Wrap(err)
+	}
+	match, err := w.expression.Evaluate(env)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	return match, nil
+}
+
+// validMethods are the HTTP methods a where clause evaluation accepts.
+var validMethods = []string{"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "TRACE"}
+
+// validateEnv rejects an environment a where clause must not authorize,
+// such as a request method outside the canonical HTTP method list.
+func validateEnv(env Env) error {
+	if !slices.Contains(validMethods, env.Request.Method) {
+		return trace.BadParameter("unsupported HTTP method %q", env.Request.Method)
+	}
+	return nil
+}
+
+// whereParser is the shared cached parser for where clauses.
+var whereParser = mustNewWhereParser()
+
+// mustNewWhereParser builds the where clause parser and panics if the
+// parser spec is invalid or the expression cache cannot be built.
+func mustNewWhereParser() *typical.CachedParser[Env, bool] {
+	p, err := typical.NewCachedParser[Env, bool](typical.ParserSpec[Env]{
+		Variables: map[string]typical.Variable{
+			// true and false are bound because typical has no bool literal.
+			"true":  true,
+			"false": false,
+			"user.name": typical.DynamicVariable(func(e Env) (string, error) {
+				return e.Identity.Name, nil
+			}),
+			"user.roles": typical.DynamicVariable(func(e Env) ([]string, error) {
+				return e.Identity.Roles, nil
+			}),
+			"user.traits": typical.DynamicMapFunction(func(e Env, key string) ([]string, error) {
+				return e.Identity.Traits[key], nil
+			}),
+			"request.method": typical.DynamicVariable(func(e Env) (string, error) {
+				return e.Request.Method, nil
+			}),
+		},
+		Functions: map[string]typical.Function{
+			// set builds a set from its string arguments for contains membership
+			// tests. set and contains match the functions of the same names in
+			// the role where-clause language, services.NewWhereParser.
+			"set": typical.UnaryVariadicFunction[Env](func(args ...string) ([]string, error) {
+				return args, nil
+			}),
+			"contains": typical.BinaryFunction[Env](func(list []string, item string) (bool, error) {
+				return slices.Contains(list, item), nil
+			}),
+			"lower": typical.UnaryFunction[Env](func(s string) (string, error) {
+				return strings.ToLower(s), nil
+			}),
+			"upper": typical.UnaryFunction[Env](func(s string) (string, error) {
+				return strings.ToUpper(s), nil
+			}),
+			"has_prefix": typical.BinaryFunction[Env](func(s, prefix string) (bool, error) {
+				return strings.HasPrefix(s, prefix), nil
+			}),
+			"has_suffix": typical.BinaryFunction[Env](func(s, suffix string) (bool, error) {
+				return strings.HasSuffix(s, suffix), nil
+			}),
+			"has_substring": typical.BinaryFunction[Env](func(s, substr string) (bool, error) {
+				return strings.Contains(s, substr), nil
+			}),
+		},
+	})
+	if err != nil {
+		panic(trace.Wrap(err, "building the where clause parser (this is a bug)"))
+	}
+	return p
+}

--- a/lib/appresource/where.go
+++ b/lib/appresource/where.go
@@ -19,6 +19,7 @@
 package appresource
 
 import (
+	"net/http"
 	"slices"
 	"strings"
 
@@ -79,7 +80,16 @@ func (w *Where) Evaluate(env Env) (bool, error) {
 }
 
 // validMethods are the HTTP methods a where clause evaluation accepts.
-var validMethods = []string{"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "TRACE"}
+var validMethods = []string{
+	http.MethodGet,
+	http.MethodHead,
+	http.MethodPost,
+	http.MethodPut,
+	http.MethodPatch,
+	http.MethodDelete,
+	http.MethodOptions,
+	http.MethodTrace,
+}
 
 // validateEnv rejects an environment a where clause must not authorize,
 // such as a request method outside the canonical HTTP method list.

--- a/lib/appresource/where_property_test.go
+++ b/lib/appresource/where_property_test.go
@@ -1,0 +1,153 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package appresource
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// drawEnv draws a valid environment with a canonical method.
+func drawEnv(t *rapid.T) Env {
+	str := rapid.StringMatching(`[a-zA-Z0-9_\-]{0,8}`)
+	return Env{
+		Request: Request{Method: rapid.SampledFrom(validMethods).Draw(t, "method")},
+		Identity: Identity{
+			Name:   str.Draw(t, "name"),
+			Roles:  rapid.SliceOfN(str, 0, 3).Draw(t, "roles"),
+			Traits: rapid.MapOfN(str, rapid.SliceOfN(str, 0, 3), 0, 3).Draw(t, "traits"),
+		},
+	}
+}
+
+// drawClause draws a well-formed where clause of bounded depth.
+func drawClause(t *rapid.T, depth int) string {
+	if depth == 0 || rapid.Bool().Draw(t, "leaf") {
+		str := rapid.StringMatching(`[a-zA-Z0-9_\-]{0,8}`)
+		switch rapid.IntRange(0, 5).Draw(t, "kind") {
+		case 0:
+			return `true`
+		case 1:
+			return `false`
+		case 2:
+			return fmt.Sprintf(`user.name == %q`, str.Draw(t, "literal"))
+		case 3:
+			return fmt.Sprintf(`contains(user.roles, %q)`, str.Draw(t, "literal"))
+		case 4:
+			return fmt.Sprintf(`request.method == %q`, rapid.SampledFrom(validMethods).Draw(t, "m"))
+		default:
+			return fmt.Sprintf(`has_prefix(user.name, %q)`, str.Draw(t, "literal"))
+		}
+	}
+	switch rapid.IntRange(0, 2).Draw(t, "op") {
+	case 0:
+		return fmt.Sprintf("(%s && %s)", drawClause(t, depth-1), drawClause(t, depth-1))
+	case 1:
+		return fmt.Sprintf("(%s || %s)", drawClause(t, depth-1), drawClause(t, depth-1))
+	default:
+		return fmt.Sprintf("!(%s)", drawClause(t, depth-1))
+	}
+}
+
+// evaluateProp compiles and evaluates a generated clause. A well-formed
+// clause over a valid environment must neither fail to compile nor fail
+// to evaluate.
+func evaluateProp(t *rapid.T, expr string, env Env) bool {
+	t.Helper()
+	where, err := CompileWhere(expr)
+	if err != nil {
+		t.Fatalf("CompileWhere(%q): %v", expr, err)
+	}
+	got, err := where.Evaluate(env)
+	if err != nil {
+		t.Fatalf("Evaluate(%q): %v", expr, err)
+	}
+	return got
+}
+
+func TestCompileNeverPanics(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		expr := rapid.String().Draw(t, "expr")
+		where, err := CompileWhere(expr)
+		if err == nil && where == nil {
+			t.Fatalf("CompileWhere(%q) returned neither a value nor an error", expr)
+		}
+	})
+}
+
+func TestNegationDuality(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		clause := drawClause(t, 2)
+		env := drawEnv(t)
+		got := evaluateProp(t, clause, env)
+		negated := evaluateProp(t, "!("+clause+")", env)
+		if got == negated {
+			t.Fatalf("clause %q and its negation both evaluate to %v", clause, got)
+		}
+	})
+}
+
+func TestInvalidMethodDenied(t *testing.T) {
+	where, err := CompileWhere(`true`)
+	require.NoError(t, err)
+	rapid.Check(t, func(t *rapid.T) {
+		method := rapid.String().Filter(func(s string) bool {
+			return !slices.Contains(validMethods, s)
+		}).Draw(t, "method")
+		got, err := where.Evaluate(Env{Request: Request{Method: method}})
+		if err == nil || got {
+			t.Fatalf("Evaluate with method %q = %v, %v, want false and an error", method, got, err)
+		}
+	})
+}
+
+func TestContainsMatchesSlicesContains(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		str := rapid.StringMatching(`[a-zA-Z0-9_\-]{0,8}`)
+		items := rapid.SliceOfN(str, 0, 4).Draw(t, "items")
+		item := str.Draw(t, "item")
+		quoted := make([]string, len(items))
+		for i, s := range items {
+			quoted[i] = strconv.Quote(s)
+		}
+		expr := fmt.Sprintf("contains(set(%s), %s)", strings.Join(quoted, ", "), strconv.Quote(item))
+		got := evaluateProp(t, expr, drawEnv(t))
+		if want := slices.Contains(items, item); got != want {
+			t.Fatalf("%s = %v, want %v", expr, got, want)
+		}
+	})
+}
+
+func TestEvaluateDeterministic(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		clause := drawClause(t, 2)
+		env := drawEnv(t)
+		first := evaluateProp(t, clause, env)
+		second := evaluateProp(t, clause, env)
+		if first != second {
+			t.Fatalf("clause %q evaluated to %v then %v for the same environment", clause, first, second)
+		}
+	})
+}

--- a/lib/appresource/where_property_test.go
+++ b/lib/appresource/where_property_test.go
@@ -29,9 +29,13 @@ import (
 	"pgregory.net/rapid"
 )
 
+// identifierText draws the short strings the generated clauses use for
+// names, roles, traits, and literals.
+var identifierText = rapid.StringMatching(`[a-zA-Z0-9_\-]{0,8}`)
+
 // drawEnv draws a valid environment with a canonical method.
 func drawEnv(t *rapid.T) Env {
-	str := rapid.StringMatching(`[a-zA-Z0-9_\-]{0,8}`)
+	str := identifierText
 	return Env{
 		Request: Request{Method: rapid.SampledFrom(validMethods).Draw(t, "method")},
 		Identity: Identity{
@@ -45,7 +49,7 @@ func drawEnv(t *rapid.T) Env {
 // drawClause draws a well-formed where clause of bounded depth.
 func drawClause(t *rapid.T, depth int) string {
 	if depth == 0 || rapid.Bool().Draw(t, "leaf") {
-		str := rapid.StringMatching(`[a-zA-Z0-9_\-]{0,8}`)
+		str := identifierText
 		switch rapid.IntRange(0, 5).Draw(t, "kind") {
 		case 0:
 			return `true`
@@ -87,12 +91,18 @@ func evaluateProp(t *rapid.T, expr string, env Env) bool {
 	return got
 }
 
-func TestCompileNeverPanics(t *testing.T) {
+// TestCompileReturnsValueOrError checks that CompileWhere never returns a
+// Where with a nil expression, which is what lets Evaluate dereference it
+// without a guard.
+func TestCompileReturnsValueOrError(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		expr := rapid.String().Draw(t, "expr")
 		where, err := CompileWhere(expr)
-		if err == nil && where == nil {
-			t.Fatalf("CompileWhere(%q) returned neither a value nor an error", expr)
+		if err != nil {
+			return
+		}
+		if where == nil || where.expression == nil {
+			t.Fatalf("CompileWhere(%q) returned a Where with no expression", expr)
 		}
 	})
 }
@@ -109,7 +119,7 @@ func TestNegationDuality(t *testing.T) {
 	})
 }
 
-func TestInvalidMethodDenied(t *testing.T) {
+func TestUnsupportedMethodRejectedForAnyString(t *testing.T) {
 	where, err := CompileWhere(`true`)
 	require.NoError(t, err)
 	rapid.Check(t, func(t *rapid.T) {
@@ -125,7 +135,9 @@ func TestInvalidMethodDenied(t *testing.T) {
 
 func TestContainsMatchesSlicesContains(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		str := rapid.StringMatching(`[a-zA-Z0-9_\-]{0,8}`)
+		// Unrestricted strings, because this property is about the
+		// strconv.Quote round trip through the parser.
+		str := rapid.String()
 		items := rapid.SliceOfN(str, 0, 4).Draw(t, "items")
 		item := str.Draw(t, "item")
 		quoted := make([]string, len(items))

--- a/lib/appresource/where_property_test.go
+++ b/lib/appresource/where_property_test.go
@@ -35,13 +35,12 @@ var identifierText = rapid.StringMatching(`[a-zA-Z0-9_\-]{0,8}`)
 
 // drawEnv draws a valid environment with a canonical method.
 func drawEnv(t *rapid.T) Env {
-	str := identifierText
 	return Env{
 		Request: Request{Method: rapid.SampledFrom(validMethods).Draw(t, "method")},
 		Identity: Identity{
-			Name:   str.Draw(t, "name"),
-			Roles:  rapid.SliceOfN(str, 0, 3).Draw(t, "roles"),
-			Traits: rapid.MapOfN(str, rapid.SliceOfN(str, 0, 3), 0, 3).Draw(t, "traits"),
+			Name:   identifierText.Draw(t, "name"),
+			Roles:  rapid.SliceOfN(identifierText, 0, 3).Draw(t, "roles"),
+			Traits: rapid.MapOfN(identifierText, rapid.SliceOfN(identifierText, 0, 3), 0, 3).Draw(t, "traits"),
 		},
 	}
 }
@@ -49,20 +48,19 @@ func drawEnv(t *rapid.T) Env {
 // drawClause draws a well-formed where clause of bounded depth.
 func drawClause(t *rapid.T, depth int) string {
 	if depth == 0 || rapid.Bool().Draw(t, "leaf") {
-		str := identifierText
 		switch rapid.IntRange(0, 5).Draw(t, "kind") {
 		case 0:
 			return `true`
 		case 1:
 			return `false`
 		case 2:
-			return fmt.Sprintf(`user.name == %q`, str.Draw(t, "literal"))
+			return fmt.Sprintf(`user.name == %q`, identifierText.Draw(t, "literal"))
 		case 3:
-			return fmt.Sprintf(`contains(user.roles, %q)`, str.Draw(t, "literal"))
+			return fmt.Sprintf(`contains(user.roles, %q)`, identifierText.Draw(t, "literal"))
 		case 4:
 			return fmt.Sprintf(`request.method == %q`, rapid.SampledFrom(validMethods).Draw(t, "m"))
 		default:
-			return fmt.Sprintf(`has_prefix(user.name, %q)`, str.Draw(t, "literal"))
+			return fmt.Sprintf(`has_prefix(user.name, %q)`, identifierText.Draw(t, "literal"))
 		}
 	}
 	switch rapid.IntRange(0, 2).Draw(t, "op") {
@@ -93,15 +91,29 @@ func evaluateProp(t *rapid.T, expr string, env Env) bool {
 
 // TestCompileReturnsValueOrError checks that CompileWhere never returns a
 // Where with a nil expression, which is what lets Evaluate dereference it
-// without a guard.
+// without a guard, and that a failure returns no Where at all. Arbitrary
+// strings essentially never parse, so half the draws are well-formed
+// clauses.
 func TestCompileReturnsValueOrError(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		expr := rapid.String().Draw(t, "expr")
+		wellFormed := rapid.Bool().Draw(t, "wellFormed")
+		var expr string
+		if wellFormed {
+			expr = drawClause(t, 2)
+		} else {
+			expr = rapid.String().Draw(t, "expr")
+		}
 		where, err := CompileWhere(expr)
 		if err != nil {
+			if wellFormed {
+				t.Fatalf("CompileWhere(%q) failed for a well-formed clause: %v", expr, err)
+			}
+			if where != nil {
+				t.Fatalf("CompileWhere(%q) returned a Where and an error", expr)
+			}
 			return
 		}
-		if where == nil || where.expression == nil {
+		if where.expression == nil {
 			t.Fatalf("CompileWhere(%q) returned a Where with no expression", expr)
 		}
 	})
@@ -148,18 +160,6 @@ func TestContainsMatchesSlicesContains(t *testing.T) {
 		got := evaluateProp(t, expr, drawEnv(t))
 		if want := slices.Contains(items, item); got != want {
 			t.Fatalf("%s = %v, want %v", expr, got, want)
-		}
-	})
-}
-
-func TestEvaluateDeterministic(t *testing.T) {
-	rapid.Check(t, func(t *rapid.T) {
-		clause := drawClause(t, 2)
-		env := drawEnv(t)
-		first := evaluateProp(t, clause, env)
-		second := evaluateProp(t, clause, env)
-		if first != second {
-			t.Fatalf("clause %q evaluated to %v then %v for the same environment", clause, first, second)
 		}
 	})
 }

--- a/lib/appresource/where_test.go
+++ b/lib/appresource/where_test.go
@@ -19,6 +19,7 @@
 package appresource
 
 import (
+	"net/http"
 	"strconv"
 	"sync"
 	"testing"
@@ -27,6 +28,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var getRequest = Request{Method: http.MethodGet}
 
 func evaluate(t *testing.T, expr string, request Request, identity Identity) bool {
 	t.Helper()
@@ -65,49 +68,69 @@ func TestEnvBindings(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.expr, func(t *testing.T) {
-			require.Equal(t, tt.want, evaluate(t, tt.expr, Request{Method: "GET"}, identity))
+			require.Equal(t, tt.want, evaluate(t, tt.expr, getRequest, identity))
 		})
 	}
+	require.True(t, evaluate(t, `request.method == "DELETE"`, Request{Method: http.MethodDelete}, identity))
+	require.False(t, evaluate(t, `contains(user.traits["allowed_projects"], "acme")`, getRequest, Identity{}))
 }
 
-// TestMethodValidated checks that evaluation fails for any method
+// TestUnsupportedMethodRejected checks that evaluation fails for a method
 // outside the canonical HTTP method list, even when the clause does not
 // read the method.
-func TestMethodValidated(t *testing.T) {
-	require.True(t, evaluate(t, `request.method == "DELETE"`, Request{Method: "DELETE"}, Identity{}))
+func TestUnsupportedMethodRejected(t *testing.T) {
 	for _, expr := range []string{`request.method == "DELETE"`, `true`} {
 		where, err := CompileWhere(expr)
 		require.NoError(t, err)
 		for _, method := range []string{"delete", "DeLeTe", "YOLO", ""} {
 			t.Run(expr+"/"+method, func(t *testing.T) {
 				got, err := where.Evaluate(Env{Request: Request{Method: method}})
-				require.Error(t, err)
+				require.ErrorContains(t, err, "unsupported HTTP method")
 				require.False(t, got)
 			})
 		}
 	}
 }
 
-func TestSet(t *testing.T) {
+// TestNewEnv checks the request boundary, which is where a rule without a
+// where clause has its method validated.
+func TestNewEnv(t *testing.T) {
 	identity := Identity{Name: "alice"}
-	require.True(t, evaluate(t, `contains(set("alice", "bob"), user.name)`, Request{Method: "GET"}, identity))
-	require.False(t, evaluate(t, `contains(set(), user.name)`, Request{Method: "GET"}, identity))
+	env, err := NewEnv(getRequest, identity)
+	require.NoError(t, err)
+	require.Equal(t, Env{Request: getRequest, Identity: identity}, env)
+	for _, method := range []string{"get", "GeT", "PROPFIND", ""} {
+		t.Run(method, func(t *testing.T) {
+			env, err := NewEnv(Request{Method: method}, identity)
+			require.ErrorContains(t, err, "unsupported HTTP method")
+			require.True(t, trace.IsBadParameter(err))
+			require.Zero(t, env)
+		})
+	}
 }
 
-func TestContainsOnStringBinding(t *testing.T) {
+func TestSet(t *testing.T) {
 	identity := Identity{Name: "alice"}
-	require.True(t, evaluate(t, `contains(user.name, "alice")`, Request{Method: "GET"}, identity))
-	require.False(t, evaluate(t, `contains(user.name, "ali")`, Request{Method: "GET"}, identity))
-	require.True(t, evaluate(t, `has_substring(user.name, "ali")`, Request{Method: "GET"}, identity))
+	require.True(t, evaluate(t, `contains(set("alice", "bob"), user.name)`, getRequest, identity))
+	require.False(t, evaluate(t, `contains(set(), user.name)`, getRequest, identity))
+}
+
+// TestContainsOnStringIsEquality checks equality rather than substring,
+// because typical wraps a string argument in a one-element slice.
+func TestContainsOnStringIsEquality(t *testing.T) {
+	identity := Identity{Name: "alice"}
+	require.True(t, evaluate(t, `contains(user.name, "alice")`, getRequest, identity))
+	require.False(t, evaluate(t, `contains(user.name, "ali")`, getRequest, identity))
+	require.True(t, evaluate(t, `has_substring(user.name, "ali")`, getRequest, identity))
 }
 
 func TestLowerUpper(t *testing.T) {
 	identity := Identity{Name: "alice"}
-	require.True(t, evaluate(t, `lower(request.method) == "get"`, Request{Method: "GET"}, identity))
-	require.True(t, evaluate(t, `upper(user.name) == "ALICE"`, Request{Method: "GET"}, identity))
+	require.True(t, evaluate(t, `lower(request.method) == "get"`, getRequest, identity))
+	require.True(t, evaluate(t, `upper(user.name) == "ALICE"`, getRequest, identity))
 }
 
-func TestSubstringFuncs(t *testing.T) {
+func TestHasPrefixSuffixSubstring(t *testing.T) {
 	identity := Identity{Name: "svc-ci-runner"}
 	tests := []struct {
 		expr string
@@ -122,30 +145,37 @@ func TestSubstringFuncs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.expr, func(t *testing.T) {
-			require.Equal(t, tt.want, evaluate(t, tt.expr, Request{Method: "GET"}, identity))
+			require.Equal(t, tt.want, evaluate(t, tt.expr, getRequest, identity))
 		})
 	}
 }
 
 func TestCombinations(t *testing.T) {
 	identity := Identity{Name: "alice", Traits: map[string][]string{"allowed_projects": {"acme"}}}
-	require.True(t, evaluate(t, `contains(user.traits["allowed_projects"], lower("ACME")) && request.method == "GET"`, Request{Method: "GET"}, identity))
-	require.False(t, evaluate(t, `has_prefix(lower(user.name), "bob") || contains(set("dev"), user.name)`, Request{Method: "GET"}, identity))
-	require.True(t, evaluate(t, `!contains(set("dev"), user.name)`, Request{Method: "GET"}, identity))
+	require.True(t, evaluate(t, `contains(user.traits["allowed_projects"], lower("ACME")) && request.method == "GET"`, getRequest, identity))
+	require.False(t, evaluate(t, `has_prefix(lower(user.name), "bob") || contains(set("dev"), user.name)`, getRequest, identity))
+	require.True(t, evaluate(t, `!contains(set("dev"), user.name)`, getRequest, identity))
+	// Conjunction binds tighter than disjunction.
+	require.True(t, evaluate(t, `false || true && true`, getRequest, identity))
 }
 
 // TestInvalidWhereClause checks that an unknown binding, an unknown
-// function, and the empty clause all fail at compile.
+// function, a clause that does not return a bool, and the empty clause
+// all fail to compile.
 func TestInvalidWhereClause(t *testing.T) {
 	for _, expr := range []string{
-		// Bindings the where environment does not provide. Paths are
-		// matched by the paths field, not in where.
+		// Bindings the where environment does not provide. Path matching
+		// is deliberately outside the where language.
 		`request.path == "/api"`,
 		`user.role == "dev"`,
 		// Names outside the function set. Regular expressions are
 		// excluded deliberately.
 		`regex_match("a.*", user.name)`,
 		`equals(user.name, "alice")`,
+		// Clauses that return something other than a bool.
+		`user.name`,
+		`set("a")`,
+		`user.name == user.roles`,
 		// The empty clause never stands for allow-everything.
 		``,
 	} {
@@ -163,7 +193,7 @@ func TestConcurrentEvaluate(t *testing.T) {
 	where, err := CompileWhere(`contains(user.roles, "dev") && request.method == "GET"`)
 	require.NoError(t, err)
 	env := Env{
-		Request:  Request{Method: "GET"},
+		Request:  getRequest,
 		Identity: Identity{Roles: []string{"dev"}},
 	}
 	var wg sync.WaitGroup

--- a/lib/appresource/where_test.go
+++ b/lib/appresource/where_test.go
@@ -1,0 +1,178 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package appresource
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func evaluate(t *testing.T, expr string, request Request, identity Identity) bool {
+	t.Helper()
+	where, err := CompileWhere(expr)
+	require.NoError(t, err)
+	env := Env{Request: request, Identity: identity}
+	got, err := where.Evaluate(env)
+	require.NoError(t, err)
+	return got
+}
+
+func TestEnvBindings(t *testing.T) {
+	identity := Identity{
+		Name:   "alice",
+		Roles:  []string{"dev", "access"},
+		Traits: map[string][]string{"allowed_projects": {"acme", "widgets"}},
+	}
+	tests := []struct {
+		expr string
+		want bool
+	}{
+		{`true`, true},
+		{`false`, false},
+		{`user.name == "alice"`, true},
+		{`user.name == "bob"`, false},
+		{`contains(user.roles, "dev")`, true},
+		{`contains(user.roles, "admin")`, false},
+		{`contains(user.traits["allowed_projects"], "acme")`, true},
+		{`contains(user.traits["allowed_projects"], "secret")`, false},
+		{`contains(user.traits["missing"], "acme")`, false},
+		{`contains(user.traits.allowed_projects, "acme")`, true},
+		{`request.method == "GET"`, true},
+		{`request.method != "GET"`, false},
+		// A method comparison is case-sensitive.
+		{`request.method == "get"`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expr, func(t *testing.T) {
+			require.Equal(t, tt.want, evaluate(t, tt.expr, Request{Method: "GET"}, identity))
+		})
+	}
+}
+
+// TestMethodValidated checks that evaluation fails for any method
+// outside the canonical HTTP method list, even when the clause does not
+// read the method.
+func TestMethodValidated(t *testing.T) {
+	require.True(t, evaluate(t, `request.method == "DELETE"`, Request{Method: "DELETE"}, Identity{}))
+	for _, expr := range []string{`request.method == "DELETE"`, `true`} {
+		where, err := CompileWhere(expr)
+		require.NoError(t, err)
+		for _, method := range []string{"delete", "DeLeTe", "YOLO", ""} {
+			t.Run(expr+"/"+method, func(t *testing.T) {
+				got, err := where.Evaluate(Env{Request: Request{Method: method}})
+				require.Error(t, err)
+				require.False(t, got)
+			})
+		}
+	}
+}
+
+func TestSet(t *testing.T) {
+	identity := Identity{Name: "alice"}
+	require.True(t, evaluate(t, `contains(set("alice", "bob"), user.name)`, Request{Method: "GET"}, identity))
+	require.False(t, evaluate(t, `contains(set(), user.name)`, Request{Method: "GET"}, identity))
+}
+
+func TestContainsOnStringBinding(t *testing.T) {
+	identity := Identity{Name: "alice"}
+	require.True(t, evaluate(t, `contains(user.name, "alice")`, Request{Method: "GET"}, identity))
+	require.False(t, evaluate(t, `contains(user.name, "ali")`, Request{Method: "GET"}, identity))
+	require.True(t, evaluate(t, `has_substring(user.name, "ali")`, Request{Method: "GET"}, identity))
+}
+
+func TestLowerUpper(t *testing.T) {
+	identity := Identity{Name: "alice"}
+	require.True(t, evaluate(t, `lower(request.method) == "get"`, Request{Method: "GET"}, identity))
+	require.True(t, evaluate(t, `upper(user.name) == "ALICE"`, Request{Method: "GET"}, identity))
+}
+
+func TestSubstringFuncs(t *testing.T) {
+	identity := Identity{Name: "svc-ci-runner"}
+	tests := []struct {
+		expr string
+		want bool
+	}{
+		{`has_prefix(user.name, "svc-")`, true},
+		{`has_prefix(user.name, "usr-")`, false},
+		{`has_suffix(user.name, "-runner")`, true},
+		{`has_suffix(user.name, "-admin")`, false},
+		{`has_substring(user.name, "-ci-")`, true},
+		{`has_substring(user.name, "-qa-")`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expr, func(t *testing.T) {
+			require.Equal(t, tt.want, evaluate(t, tt.expr, Request{Method: "GET"}, identity))
+		})
+	}
+}
+
+func TestCombinations(t *testing.T) {
+	identity := Identity{Name: "alice", Traits: map[string][]string{"allowed_projects": {"acme"}}}
+	require.True(t, evaluate(t, `contains(user.traits["allowed_projects"], lower("ACME")) && request.method == "GET"`, Request{Method: "GET"}, identity))
+	require.False(t, evaluate(t, `has_prefix(lower(user.name), "bob") || contains(set("dev"), user.name)`, Request{Method: "GET"}, identity))
+	require.True(t, evaluate(t, `!contains(set("dev"), user.name)`, Request{Method: "GET"}, identity))
+}
+
+// TestInvalidWhereClause checks that an unknown binding, an unknown
+// function, and the empty clause all fail at compile.
+func TestInvalidWhereClause(t *testing.T) {
+	for _, expr := range []string{
+		// Bindings the where environment does not provide. Paths are
+		// matched by the paths field, not in where.
+		`request.path == "/api"`,
+		`user.role == "dev"`,
+		// Names outside the function set. Regular expressions are
+		// excluded deliberately.
+		`regex_match("a.*", user.name)`,
+		`equals(user.name, "alice")`,
+		// The empty clause never stands for allow-everything.
+		``,
+	} {
+		t.Run(expr, func(t *testing.T) {
+			_, err := CompileWhere(expr)
+			require.ErrorContains(t, err, strconv.Quote(expr))
+			require.True(t, trace.IsBadParameter(err))
+		})
+	}
+}
+
+// TestConcurrentEvaluate evaluates one Where from many goroutines so the
+// race detector checks that it is concurrency safe.
+func TestConcurrentEvaluate(t *testing.T) {
+	where, err := CompileWhere(`contains(user.roles, "dev") && request.method == "GET"`)
+	require.NoError(t, err)
+	env := Env{
+		Request:  Request{Method: "GET"},
+		Identity: Identity{Roles: []string{"dev"}},
+	}
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(func() {
+			got, err := where.Evaluate(env)
+			assert.NoError(t, err)
+			assert.True(t, got)
+		})
+	}
+	wg.Wait()
+}

--- a/lib/appresource/where_test.go
+++ b/lib/appresource/where_test.go
@@ -71,6 +71,8 @@ func TestEnvBindings(t *testing.T) {
 			require.Equal(t, tt.want, evaluate(t, tt.expr, getRequest, identity))
 		})
 	}
+	// Cases the fixed table request and identity cannot express, a non-GET
+	// method and a nil traits map.
 	require.True(t, evaluate(t, `request.method == "DELETE"`, Request{Method: http.MethodDelete}, identity))
 	require.False(t, evaluate(t, `contains(user.traits["allowed_projects"], "acme")`, getRequest, Identity{}))
 }
@@ -86,6 +88,7 @@ func TestUnsupportedMethodRejected(t *testing.T) {
 			t.Run(expr+"/"+method, func(t *testing.T) {
 				got, err := where.Evaluate(Env{Request: Request{Method: method}})
 				require.ErrorContains(t, err, "unsupported HTTP method")
+				require.True(t, trace.IsBadParameter(err))
 				require.False(t, got)
 			})
 		}


### PR DESCRIPTION
Add the `where` clause predicate language for fine-grained HTTP app access via `app_resources`. Inside a `where` clause the predicate environment exposes the `user.name`, `user.roles`, `user.traits`, and `request.method` bindings, the `true` and `false` constants, the `set` and `contains` list helpers, and the `lower`, `upper`, `has_prefix`, `has_suffix`, and `has_substring` string helpers. `Where.Evaluate` validates the environment first and rejects any method outside the canonical upper-case HTTP method list, so a case-varied method such as `DeLeTe` can neither slip past a negated comparison nor match a clause while the backend receives a different spelling.

`CompileWhere` parses a where clause, and `Where.Evaluate` matches against a request and a caller identity. A malformed clause returns `trace.BadParameter`, matching the sibling path tokenizer, so a caller can tell bad role config from an internal fault.

Example role showing how `where` will be used under `app_resources`:

```yaml
kind: role
version: v9
metadata:
  name: gitlab-dev
spec:
  allow:
    app_labels:
      vendor: [gitlab]
    app_resources:
      - paths: ["/**"]
        where: request.method == "GET" || contains(user.traits["groups"], "gitlab-writers")
```

The `gitlab-dev` role above allows a user to perform an HTTP GET. A member of the IdP-provided `gitlab-writers` group may use any HTTP method.

There is no test plan because this code change is library prep work for follow-up wiring.

Related-RFD: https://github.com/gravitational/rfd/blob/main/rfd/0303-policy-based-app-access.md










