### PR TITLE
feature/deployment 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,9 @@ unit-tests*.json
 
 # Local Claude config
 .claude
+
+# PAM POC — VM-local secrets and runtime state, never commit.
+# See teleport-agent.yaml.example / resources/node.yaml.example for templates.
+/teleport-agent.yaml
+/teleport-data/
+/teleport

--- a/Dockerfile.teleport-agent
+++ b/Dockerfile.teleport-agent
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates dumb-init sudo \
+        xvfb xfce4 xfce4-terminal dbus-x11 \
+        chromium fonts-liberation fonts-noto \
+        openssh-client curl wget git vim nano net-tools iputils-ping \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -m -s /bin/bash gor \
+    && echo "gor ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
+    && mkdir -p /var/lib/teleport /etc/teleport
+
+COPY teleport /usr/local/bin/teleport
+
+ENTRYPOINT ["dumb-init", "teleport"]
+CMD ["start", "-c", "/etc/teleport/teleport.yaml"]

--- a/Dockerfile.teleport-proxy
+++ b/Dockerfile.teleport-proxy
@@ -1,0 +1,75 @@
+# Self-contained multi-stage build for a Teleport PAM POC image.
+# Builds Teleport (with embedded web UI) from source inside a Linux container,
+# so there is no macOS cross-compile pain — the binary is native linux/<arch>.
+#
+# Build (from repo root):
+#   docker buildx build --network=host --platform linux/amd64 -f Dockerfile.poc -t teleport-pam:20 .
+#
+# Run:
+#   docker run -d --name teleport \
+#     -p 3080:3080 -p 3025:3025 \
+#     -v "$PWD/teleport.yaml:/etc/teleport/teleport.yaml" \
+#     -v teleport-data:/var/lib/teleport \
+#     teleport-pam:20
+
+# ---------- build stage ----------
+FROM golang:1.26-bookworm AS build
+
+ARG TARGETARCH
+ARG NODE_VERSION=24.16.0
+
+# Build deps + the native libs Teleport links by default (fido2/pcsc/pam),
+# plus clang/lld — required by cc-rs to compile the Rust RDP client and the
+# IronRDP WASM decoder now that we build them (needed for Linux desktop access).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential git ca-certificates curl xz-utils pkg-config \
+        libfido2-dev libpcsclite-dev libpam0g-dev \
+        clang lld \
+    && rm -rf /var/lib/apt/lists/* \
+    && command -v clang || ln -s "$(command -v clang-14 || ls /usr/bin/clang-* | head -1)" /usr/bin/clang
+
+# Fast sanity check — fails in seconds instead of ~4 minutes into `make full`
+# if clang isn't actually resolvable.
+RUN clang --version && which lld
+
+# Node.js (exact version the web UI build expects) + pnpm via corepack.
+RUN NODE_ARCH="$([ "$TARGETARCH" = "amd64" ] && echo x64 || echo arm64)" && \
+    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
+      | tar -xJ -C /usr/local --strip-components=1 && \
+    corepack enable
+
+# Rust toolchain (required for wasm-bindgen web UI components).
+ENV CARGO_HOME=/usr/local/cargo
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV PATH=/usr/local/cargo/bin:$PATH
+RUN echo '--http1.1' > /etc/curlrc && \
+    curl --http1.1 --retry 5 --retry-delay 10 --retry-connrefused \
+         -sSf -o /tmp/rustup-init.sh https://sh.rustup.rs && \
+    sh /tmp/rustup-init.sh -y --profile minimal \
+         --default-toolchain 1.94.0 \
+         --target wasm32-unknown-unknown \
+         --no-modify-path && \
+    rm /tmp/rustup-init.sh
+
+WORKDIR /src
+COPY . .
+
+# Binaries + embedded web UI, including the RDP client and IronRDP WASM
+# decoder (needed for Windows and Linux desktop access session recording).
+RUN make full
+
+# ---------- runtime stage ----------
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates dumb-init libfido2-1 libpcsclite1 libpam0g libelf1 \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /var/lib/teleport /etc/teleport
+
+COPY --from=build /src/build/teleport /usr/local/bin/teleport
+COPY --from=build /src/build/tctl     /usr/local/bin/tctl
+COPY --from=build /src/build/tsh      /usr/local/bin/tsh
+
+EXPOSE 3080 3025
+ENTRYPOINT ["dumb-init", "teleport"]
+CMD ["start", "-c", "/etc/teleport/teleport.yaml"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  teleport:
+    build:
+      context: .
+      dockerfile: Dockerfile.teleport-proxy
+      network: host          # avoids the apt-get/cargo DNS issue we hit building manually
+    image: teleport-pam:latest
+    container_name: teleport
+    restart: unless-stopped
+    ports:
+      - "3080:3080"
+      - "3025:3025"
+    volumes:
+      - ./teleport.yaml:/etc/teleport/teleport.yaml:ro
+      - teleport-data:/var/lib/teleport
+      - ./resources:/etc/teleport/resources:ro   # node.yaml, new-node.yaml, etc.
+
+volumes:
+  teleport-data:

--- a/resources/node.yaml.example
+++ b/resources/node.yaml.example
@@ -1,0 +1,10 @@
+kind: node
+version: v2
+sub_kind: openssh
+metadata:
+  name: server-225
+  labels:
+    env: staging
+spec:
+  addr: 192.168.35.225:22
+  hostname: 192.168.35.225

--- a/teleport-agent.yaml.example
+++ b/teleport-agent.yaml.example
@@ -1,0 +1,22 @@
+version: v3
+teleport:
+  nodename: linux-desktop-1
+  data_dir: /var/lib/teleport
+  log:
+    output: stderr
+    severity: DEBUG
+  proxy_server: 192.168.6.34:3080
+  auth_token: REPLACE_WITH_TOKEN
+  ca_pin: "REPLACE_WITH_CA_PIN"
+
+auth_service:
+  enabled: false
+proxy_service:
+  enabled: false
+ssh_service:
+  enabled: false
+
+linux_desktop_service:
+  enabled: yes
+  labels:
+    env: staging


### PR DESCRIPTION
- **Clarify number of deployed services in Get Started (#67574)**
- **Make golangci-lint auto-detect Go version from go.mod file. (#67888)**
- **Add Slack review helm chart config (#67786)**
- **feat: add `tctl access-changes ls` command (#67328)**
- **MCP: Remove all non-canonical fields impacting RBAC from tools/call request  (#67262)**
- **feat: add `tctl access-changes get` command (#67329)**
- **Improve Azure VM discovery performance (#67737)**
- **Connect: Fix progress reporting for empty file uploads (#67885)**
- **Add interative mode to tsh apps login aws-console (#60151) (#67755)**
- **Increase the timeout for TestTeleportClient_Login_local (#67851)**
- **Add page_type and outcome statements to 47 guides (#67771)**
- **Add `TestLoginShell` to avoid lib/web tests polluting shell history (#67594)**
- **Fix TestSSHOnMultipleNodes flaking (#67503)**
- **Fix MFA flags (#67849)**
- **Fix license header (#67927)**
- **Add ConditionalDelete to CA overrides and generic.Service (#67870)**
- **Improve Scoped Token UX (#67819)**
- **[auto] Update AMI IDs for 18.9.0 (#67911)**
- **fix: Impl `ListAuthServers`/`ListProxyServers` on presencev1 (#66150)**
- **Support resource constraints for narrower access request role suggestions (#67152)**
- **app access: improve handling of overlapping public addrs (#67519)**
- **docs: Update access list guide docs (#66733)**
- **[3] Final migration to the Opaque API (#67385)**
- **MCP: Protect against potential session ID forgery (#67397)**
- **iOS: Add linting and formatting utilities (#67897)**
- **stub scope encoding (#67732)**
- **[AWSIC] Tightened filter validation and application (#67234)**
- **Unskip classifier enterprise tests (#67886)**
- **Bump undici from 8.4.1 to 8.5.0, from 7.25.0 to 7.28.0 (#67944)**
- **Declare missing peers so pnpm global virtual store works (#67855)**
- **Add the `tctl auth create-override` command (#67907)**
- **Capture inactivity periods when processing desktop sessions (#67721)**
- **Fix TestHandleConnection and TestHandleConnectWS slowness (#67940)**
- **Add the `tctl auth delete-override` command (#67923)**
- **Ensure request body is correctly closed in debug server (#67965)**
- **Stop swallowing gRPC error in join client (#67964)**
- **feat(proto): add beam_id to audit + decision identity protos (#67966)**
- **RFD 229C: Extend ScopedRole for WorkloadIdentity, extend audit log events (1/5) (#67889)**
- **docs: Update CA overrides (#67970)**
- **Remove some sources of AI agent friction (#67866)**
- **msgraphtest: monkeypatch user and group delta endpoint (#67980)**
- **Avoid reentrancy in Cache.GetAccessListOwners (#67963)**
- **Update `form-data`, `tar`, `protobufjs`, `js-yaml`, and `esbuild` (#67918)**
- **[scopes] scope-aware generic resource backend (#67682)**
- **Add BeamCreate and BeamDestroy usage events (#67738)**
- **Bump go.mongodb.org/mongo-driver from 1.17.6 to 1.17.9 (#67977)**
- **fix comment (#67492)**
- **feat(lib/services): remove workload cluster backend support (#67630)**
- **fix: tctl help message broken with investigate (#67930)**
- **Change slack oauth call to use formdata instead of url params (#67932)**
- **Make rejected accepts retryable in lib/limiter (#66928)**
- **Add configurable backoff values to Okta sync settings (#67997)**
- **Azure Client Join: discard non-Microsoft hosted AIA intermediate CAs (#68004)**
- **Add protos and OSS storage for `EnrollPairing` (#67862)**
- **Add a field mask to UpdateCertificateOverrideRequest (#68018)**
- **MCP: Fix HTTPS support for SSE (#68020)**
- **feat(beams): carry beam_id through identity certificates (#67972)**
- **MCP: Remove tool access checker cache (#67671)**
- **tsh: add "tsh apps logins" command. (#67899)**
- **Generic RFD153 Scopes Aware Service (#68042)**
- **Add `aws` commands for IAM steps in four guides (#68019)**
- **Enable slack native review with UI and plugin app (#67821)**
- **Add tctl rm support for access list (#67463)**
- **Bump e/ (#68061)**
- **Bump github.com/containerd/containerd from 1.7.32 to 1.7.33 (#68011)**
- **docs: Adds a left-nav Beams entry to the docs navigation (#68070)**
- **Add client-side version verification to join flow (#67627)**
- **RFD 229C: Add `scope` field to WorkloadIdentity resource and validation rules (2/5) (#67891)**
- **MCP: Update docs for the configured URI /path (#67634)**
- **removed presence check for IntegrationName as this can be empty when the fetcher is using ambient credentials. (#67987)**
- **discovery: split tctl discovery nodes command wiring (#68000)**
- **Desktop Access: Plumb Directory IDs through TDPB (#68033)**
- **support disk events on Linux kernel 7.0+ by conditionally hooking do_file_open (#67650)**
- **add scoped joining for app svc (#67101)**
- **Fix DynamoDB DeleteRange unprocessed item handling (#66954)**
- **Close expired app connections (#67937)**
- **discovery: Tie lifetime of EKS audit log fetcher to main function (#67962)**
- **kube: enforce kubernetes_resources RBAC for unknown resource kinds (#67801)**
- **Initial LLM access handler (Anthropic) (#67744)**
- **Add page_type and outcome statements to 44 guides (#68050)**
- **tctl: add structured output to selected mutation commands (#67261)**
- **Add scope to ScopedToken get/delete APIs and token abstractions (#68097)**
- **iOS: Core Framework (#67939)**
- **add scopes to access list protos (#67988)**
- **Caching OIDC validator improvements (#67913)**
- **Add tctl acl update for access list (#67656)**
- **Detect and optionally block cross-site WebSocket hijacking (CSWSH) on app access (#67616)**
- **web: Update IAM join token assumed-role arn placeholder (#68083)**
- **Enforce connection limits on the ALPN proxy listener (#67686)**
- **Honor wildcard kube RBAC verb regardless of position (#67598)**
- **Add the subca.NormalizePublicKey method (#68059)**
- **Add ScopedOnly mode to the generic scope-aware service (#68096)**
- **[auto] Update AMI IDs for 18.9.1 (#68022)**
- **add scope to go types (#67989)**
- **kube: require exec and patch for pods/ephemeralcontainers (#67595)**
- **Add `mobile_device.create_enroll_token` permission; make `boombuler/barcode` a direct dep (#67863)**
- **fix: deflake TestIntegrations/LeafAgentlessConnection (#68157)**
- **chore: Address the latest govulncheck findings (#68149)**
- **Remove unused comment to helm chart values (#68108)**
- **docs: Add event handler reference links to "Export Audit Events" guides (#68114)**
- **Cleanup event handler different install methods (#68129)**
- **Add helm chart references for access plugin docs; remove trailing newlines (#68127)**
- **iOS: Implement RFD Architecture (#68026)**
- **Fix checkSCPAllowed() whitespace parsing (#67526)**
- **Add Azure label helper functions (#68023)**
- **Generic OIDC joining: protos (#67914)**
- **kube proxy: fix CPU hot-spin in session terminal-resize handling (#68155)**
- **Desktop Access: Support Multiple Devices in Filesystem Backend (#68034)**
- **Desktop Access: Support Multi-Directory Sharing and Removal (#65952)**
- **Add dsql and kinesis to go.mod (#68169)**
- **Add the `tctl auth update-override` command (#68024)**
- **Add page_type and outcome statements to 47 guides (#68107)**
- **Update audit cache and handlers to match shared directory read/write respponses based on (deviceId, completionId) tuples rather than just the completionId. (#68156)**
- **Add AuthCallback to SSH clients to perform in-band MFA (#65904)**
- **Deflake TestPlayerError (#68132)**
- **[auto] Update AMI IDs for 18.9.2 (#68196)**
- **Improve Sub CA Windows docs (#67768)**
- **Let agents that are scope pinned read ancestor scoped role (#68133)**
- **Edit MongoDB Atlas trust policy instructions (#68104)**
- **Add a check against reentrancy in lib/cache tests (#67973)**
- **Add commands to five how-to guides (#68090)**
- **[beams] beams_config storage, cache, presets (#67338)**
- **[entraid] docs: integration sync mode and intervals (#67530)**
- **kube: guard force_terminate channel close with sync.Once (#67156)**
- **backoff failing Azure VM installations (#68035)**
- **adding audit events for scoped tokens and adding scope field to (#65523)**
- **porting GetUser, GetRole, EmitAuditEvent, CreateAuditStream, and ResumeAuditStream to support scopes (#67879)**
- **Add Display to the Access List Member and Owner API Surface #67636 (#67790)**
- **updating ValidateTokenForUse to enforce that scoped tokens only provision for node and bot when agent scope pins are disabled (#67813)**
- **Reset Okta assignment target failure count on op change (#68188)**
- **Azure Server Discovery: ignore non-linux VMs (#68082)**
- **Bump electron, electron-updater, electron-builder, node-pty, Node.js, and pnpm (#67542)**
- **oslog_darwin.go: Add blank line after build constraint (#68231)**
- **Remove deprecated scopes.AssertFeatureEnabled (#68219)**
- **Update `js-yaml` to 3.15.0 (#68234)**
- **Atempt to reduce flakiness of Test_consumer_sqsMessagesCollector (#68210)**
- **Implement app access managed client certificates (#67701)**
- **Allow for wasm-bindgen to be installed into target/ (#68247)**
- **[Access Requests] Clarify why long-term approval is unavailable in review (#68032)**
- **docs: Update admonition about Deny Rules in Access Lists (#67210)**
- **Add the new design system (#61524)**
- **Enforce a max limit on the proxy jump address (#68172)**
- **Make spiffe role deny rules greedy (#67020)**
- **iOS: Add Test Target (#68062)**
- **Skip flaky firefox e2e test (#68257)**
- **Porting kube cluster APIs to scoped authZ (#67881)**
- **Desktop Access: Drop Shared Directory Removal (#68260)**
- **Fix copy-paste error in app access test (#68259)**
- **Azure Server Discovery: fix User Tasks classification (#68088)**
- **Update e ref (#68269)**
- **Update e (#68278)**
- **Add stderr Message for SSH Agent Forwarding Failure (#66772)**
- **Fix potential race in agentpool (#68243)**
- **mcp: use `QueryExecModeExec` for redshift access (#68250)**
- **gha: include kvstore action in workflows (#68046)**
- **Refactor LLM requests recorder into a dedicated package (#68202)**
- **feat: Add `tctl integrations test` command (#68086)**
- **Bump docker/build-push-action from 7.0.0 to 7.2.0 in /.github/workflows (#67240)**
- **Bump renovatebot/github-action in /.github/workflows (#67239)**
- **iOS: Landing View (#68067)**
- **Exempt tbot from client-side join version check (#68134)**
- **docs: Add docs-review guidelines AGENTS.md (#67631)**
- **Fix Auth Connectors UI UX papercuts related to MFA (#67593)**
- **Bump the ui group with 25 updates (#68290)**
- **Fix dynamodbbk's interactions with item expiry (#68038)**
- **Fix bash autocomplete output (#66821)**
- **Bump github.com/sigstore/rekor from 1.5.0 to 1.5.2 (#68125)**
- **Bump the rust group with 7 updates (#68289)**
- **Supress IronRDP's decode tracing logs (#68324)**
- **Atempt to reduce flakiness of TestMigrationCheckpoint (#68218)**
- **Remove unused CertAuthorityOverride event codes (#68319)**
- **Add initial protos for public Device Trust service (#68254)**
- **Make helm linting support helm4 (#68315)**
- **iOS: QR Code Scanner (#68181)**
- **Bump @typescript/native-preview from 7.0.0-dev.20260527.1 to 7.0.0-dev.20260629.1 (#68296)**
- **reversetunnel: fix smoothed round trip time test flakiness (#67928)**
- **Discovery - Separate EKS fetch from access management (#67563)**
- **iOS: Revise EnrollDeviceView (#68225)**
- **teleport-discovery skill combined azure and aws version (#68029)**
- **Temporarily disable DBSC (#68357)**
- **Remove references to `roles` config in `tbot` (#68347)**
- **Remove `--integrations` flag from AWS OIDC guide (#68329)**
- **session-search[31]: add needs_further_review filter and response field (#67754)**
- **Improve the error message when pin doesn't apply to resource scope (#68209)**
- **Fix docs paper cuts found by an agent (#68350)**
- **`client-ip-restriction`: resource and oss service (#67679)**
- **`client_ip_restriction`: add `tctl` support (#67676)**
- **[app]: record proxied HTTP request/response audit events (#68191)**
- **[Docs] Add docs for `web_terminal_clipboard_mode` role option (#67902)**
- **Implement SQLite based audit log queue (#66883)**
- **[terraform] add azure_management_group_id var to azure discovery module (#67215)**
- **docs: Add docs for `review_requests.submit_for_users` (#67948)**
- **Encode Bot Scope into TLS/SSH identity (#68385)**
- **Add AWS region field to app spec (#68370)**
- **iOS: Add color design tokens (#68317)**
- **iOS: Make an event timeline view to communicate longrunning processes (#68355)**
- **autoupdate: Create slices with zero length for appending (#68229)**
- **Azure Server Discovery: check VM and Guest Agent before running command (#68164)**
- **Bump react-router from 7.15.1 to 8.1.0 (#68299)**
- **Update design-system to v0.1.3 (#68377)**
- **Fix some docs papercuts that hindered an agent (#68342)**
- **add scopes to access list request protos (#68409)**
- **Make scopes.MakeResourceCursor infallible (#68414)**
- **hash public_addr support for scoped apps (#68074)**
- **Add in-band MFA desktop protos and Go bindings. (#68397)**
- **Add Anthropic Bedrock support (#68407)**
- **Update e (#68432)**
- **Disable various features for scoped apps (#68274)**
- **fully port over createsessiontracker, updatesessiontracker, and generateapptoken to scoped maturity level 3 porting for create/updatesessiontracker and GenereateAppToken (#68227)**
- **Fix resource filtering for ValidatedMFAChallenge resources (#68348)**
- **Port over UpsertNode RPC to support scoped openssh access (#68351)**
- **Fix dynamic desktop rbac bypass when creating desktops (#68186)**
- **Improve logging for AMI publishing tool (#68421)**
- **chore: Bump github.com/sigstore/timestamp-authority/v2 to v2.1.0 (#68446)**
- **Use string.Fields for checkSCPAllowed() (#68423)**
- **Update Go toolchain version to v1.26.5 (#68439)**
- **kube: route tsh kubectl through local proxy under hardware keys (#68455)**
- **chore: Bump github.com/yuin/goldmark to v1.7.17 (#68466)**
- **[auto] Update AMI IDs for 18.10.0 (#68476)**
- **Limit the maximum input length for types.ParseDuration (#68438)**
- **Add Linux desktop support (#65841)**
- **Add PAM POC Dockerfiles, compose, and config templates**
