### PR TITLE
Integrate Windows VM discovery in to Azure watcher

### DIFF
--- a/api/types/matchers_azure.go
+++ b/api/types/matchers_azure.go
@@ -41,6 +41,8 @@ const (
 	AzureMatcherRedis = "redis"
 	// AzureMatcherSQLServer is the Azure matcher type for SQL Server databases.
 	AzureMatcherSQLServer = "sqlserver"
+	// AzureMatcherWindowsVM is the Azure matcher type for Azure VMs with Windows OS.
+	AzureMatcherWindowsVM = "windows-vm"
 )
 
 // SupportedAzureMatchers is list of Azure services currently supported by the
@@ -54,6 +56,7 @@ var SupportedAzureMatchers = []string{
 	AzureMatcherPostgres,
 	AzureMatcherRedis,
 	AzureMatcherSQLServer,
+	AzureMatcherWindowsVM,
 }
 
 // GetTypes gets the types that the matcher can match.

--- a/api/types/matchers_azure_test.go
+++ b/api/types/matchers_azure_test.go
@@ -152,6 +152,20 @@ func TestAzureMatcherCheckAndSetDefaults(t *testing.T) {
 			},
 			errCheck: isBadParameterErr,
 		},
+		{
+			name: "windows-vm is a valid type",
+			in: &AzureMatcher{
+				Types: []string{"windows-vm"},
+			},
+			errCheck: require.NoError,
+		},
+		{
+			name: "vm and windows-vm can be combined",
+			in: &AzureMatcher{
+				Types: []string{"vm", "windows-vm"},
+			},
+			errCheck: require.NoError,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.in.CheckAndSetDefaults()

--- a/lib/cloud/azure/azuretest/azure.go
+++ b/lib/cloud/azure/azuretest/azure.go
@@ -41,6 +41,7 @@ type Clients struct {
 	AzureMySQLFlex          azure.MySQLFlexServersClient
 	AzurePostgresFlex       azure.PostgresFlexServersClient
 	AzureRunCommand         azure.RunCommandClient
+	AzureNetworkInterfaces  azure.NetworkInterfacesClient
 }
 
 var _ azure.Clients = (*Clients)(nil)
@@ -119,4 +120,8 @@ func (c *Clients) GetPostgresFlexServersClient(ctx context.Context, subscription
 // GetRunCommandClient returns an Azure Run Command client for the given subscription.
 func (c *Clients) GetRunCommandClient(ctx context.Context, subscription string) (azure.RunCommandClient, error) {
 	return c.AzureRunCommand, nil
+}
+
+func (c *Clients) GetNetworkInterfacesClient(ctx context.Context, subscription string) (azure.NetworkInterfacesClient, error) {
+	return c.AzureNetworkInterfaces, nil
 }

--- a/lib/cloud/azure/azuretest/azure.go
+++ b/lib/cloud/azure/azuretest/azure.go
@@ -122,6 +122,7 @@ func (c *Clients) GetRunCommandClient(ctx context.Context, subscription string) 
 	return c.AzureRunCommand, nil
 }
 
+// GetNetworkInterfacesClient returns an Azure Network Interfaces client for the given subscription.
 func (c *Clients) GetNetworkInterfacesClient(ctx context.Context, subscription string) (azure.NetworkInterfacesClient, error) {
 	return c.AzureNetworkInterfaces, nil
 }

--- a/lib/cloud/azure/clients.go
+++ b/lib/cloud/azure/clients.go
@@ -66,6 +66,8 @@ type Clients interface {
 	GetPostgresFlexServersClient(ctx context.Context, subscription string) (PostgresFlexServersClient, error)
 	// GetRunCommandClient returns an Azure Run Command client for the given subscription.
 	GetRunCommandClient(ctx context.Context, subscription string) (RunCommandClient, error)
+	// GetNetworkInterfacesClient returns an Azure Network Interfaces client for the given subscription.
+	GetNetworkInterfacesClient(ctx context.Context, subscription string) (NetworkInterfacesClient, error)
 }
 
 // ClientsOption is an option to pass to NewAzureClients
@@ -140,6 +142,10 @@ func NewClients(opts ...ClientsOption) (Clients, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	azClients.networkInterfacesClients, err = NewClientMap(NewNetworkInterfacesClient)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	azClients.credentialFunc = func(ctx context.Context) (azcore.TokenCredential, error) {
 		// TODO(gavin): if/when we support AzureChina/AzureGovernment, we will need to specify the cloud in these options
@@ -174,6 +180,7 @@ type clients struct {
 	mySQLFlexServersClients    ClientMap[MySQLFlexServersClient]
 	postgresFlexServersClients ClientMap[PostgresFlexServersClient]
 	runCommandClients          ClientMap[RunCommandClient]
+	networkInterfacesClients   ClientMap[NetworkInterfacesClient]
 }
 
 // GetCredential returns default Azure token credential chain.
@@ -272,6 +279,12 @@ func (c *clients) GetPostgresFlexServersClient(ctx context.Context, subscription
 // subscription.
 func (c *clients) GetRunCommandClient(ctx context.Context, subscription string) (RunCommandClient, error) {
 	return c.runCommandClients.Get(ctx, subscription, c.GetCredential)
+}
+
+// GetNetworkInterfacesClient returns an Azure Network Interfaces client for the
+// given subscription.
+func (c *clients) GetNetworkInterfacesClient(ctx context.Context, subscription string) (NetworkInterfacesClient, error) {
+	return c.networkInterfacesClients.Get(ctx, subscription, c.GetCredential)
 }
 
 func (c *clients) initCredential(ctx context.Context) (azcore.TokenCredential, error) {

--- a/lib/cloud/azure/vm.go
+++ b/lib/cloud/azure/vm.go
@@ -103,13 +103,23 @@ type VirtualMachine struct {
 	Identities []Identity
 	// Tags are the VM tags, e.g. {"env": "prod"}. Empty map (not nil) when the VM has no tags.
 	Tags map[string]string
-
+	// PrimaryPrivateIP is the private IP address used to reach the VM, e.g.
+	// "10.0.0.5". It is populated only by the Windows VM discovery path. It is
+	// empty for Linux VMs and when no usable private IP could be resolved.
+	PrimaryPrivateIP string
+	// operatingSystem is the operating system of the VM. It is nil if the operating system is unknown.
 	operatingSystem *armcompute.OperatingSystemTypes
 }
 
 // IsLinuxOrUnknown returns whether the VM is running Linux or if the operating system is unknown.
 func (vm *VirtualMachine) IsLinuxOrUnknown() bool {
 	return vm.operatingSystem == nil || *vm.operatingSystem == armcompute.OperatingSystemTypesLinux
+}
+
+// IsWindowsOrUnknown returns whether the VM is running Windows or if the
+// operating system is unknown.
+func (vm *VirtualMachine) IsWindowsOrUnknown() bool {
+	return vm.operatingSystem == nil || *vm.operatingSystem == armcompute.OperatingSystemTypesWindows
 }
 
 // Identity represents an Azure virtual machine identity.

--- a/lib/cloud/azure/vm_test.go
+++ b/lib/cloud/azure/vm_test.go
@@ -1443,45 +1443,39 @@ func TestVirtualMachineFromVirtualMachineScaleSetVM(t *testing.T) {
 	}
 }
 
-func TestVirtualMachineIsLinuxOrUnknown(t *testing.T) {
+func TestVirtualMachineOSPredicates(t *testing.T) {
 	t.Parallel()
 	linuxOS := armcompute.OperatingSystemTypesLinux
 	windowsOS := armcompute.OperatingSystemTypesWindows
 
 	for _, tc := range []struct {
-		desc     string
-		vm       *VirtualMachine
-		want     bool
-		wantDesc string
+		desc        string
+		vm          *VirtualMachine
+		wantLinux   bool
+		wantWindows bool
 	}{
 		{
-			desc: "Linux VM",
-			vm: &VirtualMachine{
-				operatingSystem: &linuxOS,
-			},
-			want:     true,
-			wantDesc: "Linux",
+			desc:        "Linux VM",
+			vm:          &VirtualMachine{operatingSystem: &linuxOS},
+			wantLinux:   true,
+			wantWindows: false,
 		},
 		{
-			desc: "Windows VM",
-			vm: &VirtualMachine{
-				operatingSystem: &windowsOS,
-			},
-			want:     false,
-			wantDesc: "Windows",
+			desc:        "Windows VM",
+			vm:          &VirtualMachine{operatingSystem: &windowsOS},
+			wantLinux:   false,
+			wantWindows: true,
 		},
 		{
-			desc: "Unknown OSType",
-			vm: &VirtualMachine{
-				operatingSystem: nil,
-			},
-			want:     true,
-			wantDesc: "Unknown",
+			desc:        "Unknown OSType",
+			vm:          &VirtualMachine{operatingSystem: nil},
+			wantLinux:   true,
+			wantWindows: true,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			got := tc.vm.IsLinuxOrUnknown()
-			require.Equal(t, tc.want, got, "expected IsLinuxOrUnknown() to return %v for %s VM, got %v", tc.want, tc.wantDesc, got)
+			require.Equal(t, tc.wantLinux, tc.vm.IsLinuxOrUnknown(), "IsLinuxOrUnknown()")
+			require.Equal(t, tc.wantWindows, tc.vm.IsWindowsOrUnknown(), "IsWindowsOrUnknown()")
 		})
 	}
 }

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -419,18 +419,19 @@ func (f *azureInstanceFetcher) primaryPrivateIPByVM(
 	}
 
 	// Find scale set names of uniform VMSS VMs in the matched instances.
-	var scaleSetNames []string
-	for _, vms := range instanceGroups {
+	scaleSetNamesByRG := make(map[string][]string)
+	for batchGroup, vms := range instanceGroups {
+		rg := strings.ToLower(batchGroup.resourceGroup)
 		for _, vm := range vms {
 			if vm.UniformScaleSetName != "" {
-				scaleSetNames = append(scaleSetNames, vm.UniformScaleSetName)
+				scaleSetNamesByRG[rg] = append(scaleSetNamesByRG[rg], vm.UniformScaleSetName)
 			}
 		}
 	}
 
 	var privateIPByVM = make(map[string]string)
 	for resourceGroup := range resourceGroups {
-		nics, err := nicClient.ListNetworkInterfaces(ctx, resourceGroup, scaleSetNames)
+		nics, err := nicClient.ListNetworkInterfaces(ctx, resourceGroup, scaleSetNamesByRG[resourceGroup])
 		if err != nil {
 			return nil, trace.Wrap(err, "listing network interfaces for resource group %q", resourceGroup)
 		}

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -19,8 +19,10 @@
 package server
 
 import (
+	"cmp"
 	"context"
 	"log/slog"
+	"maps"
 	"slices"
 	"strings"
 
@@ -177,50 +179,53 @@ func (instances *AzureInstances) FilterExistingNodes(existingNodes []types.Serve
 
 type azureClientGetter func(ctx context.Context, integration string) (azure.Clients, error)
 
-// interfacesClientGetter returns the Azure network interfaces client for a
+// networkInterfacesClientGetter returns the Azure network interfaces client for a
 // resolved azure.Clients.
-type interfacesClientGetter func(ctx context.Context, azureClients azure.Clients) (network.InterfacesClient, error)
+type networkInterfacesClientGetter func(ctx context.Context, azureClients azure.Clients) (network.InterfacesClient, error)
 
 type listSubscriptionsFunc func(ctx context.Context, integration string) (subscriptions []string, err error)
 
-// MatcherToAzureInstanceFetchers converts an Azure VM matcher into Azure VM fetchers.
-func MatcherToAzureInstanceFetchers(
+// MatchersToAzureInstanceFetchers converts a list of Azure VM Matchers into a list of Azure VM Fetchers.
+func MatchersToAzureInstanceFetchers(
 	ctx context.Context,
 	logger *slog.Logger,
-	matcher types.AzureMatcher,
+	matchers []types.AzureMatcher,
 	getClient azureClientGetter,
 	discoveryConfigName string,
 	listSubs listSubscriptionsFunc,
-) ([]Fetcher[*AzureInstances], error) {
-	subscriptions, err := expandAzureMatcherSubscriptions(ctx, matcher.Subscriptions, matcher.Integration, listSubs)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	fetchers := make([]Fetcher[*AzureInstances], 0, len(subscriptions)*len(matcher.ResourceGroups))
-	for _, subscription := range subscriptions {
-		for _, resourceGroup := range matcher.ResourceGroups {
-			fetchers = append(fetchers, newAzureInstanceFetcher(azureFetcherConfig{
-				Matcher:             matcher,
-				Subscription:        subscription,
-				ResourceGroup:       resourceGroup,
-				AzureClientGetter:   getClient,
-				DiscoveryConfigName: discoveryConfigName,
-				Logger:              logger,
-			}))
+) []Fetcher[*AzureInstances] {
+	ret := make([]Fetcher[*AzureInstances], 0)
+	for _, matcher := range matchers {
+		matcher.Subscriptions = expandAzureMatcherSubscriptions(ctx, logger, matcher.Subscriptions, matcher.Integration, listSubs)
+		for _, matcherType := range matcher.Types {
+			for _, subscription := range matcher.Subscriptions {
+				for _, resourceGroup := range matcher.ResourceGroups {
+					fetcher := newAzureInstanceFetcher(azureFetcherConfig{
+						Matcher:             matcher,
+						MatcherType:         matcherType,
+						Subscription:        subscription,
+						ResourceGroup:       resourceGroup,
+						AzureClientGetter:   getClient,
+						DiscoveryConfigName: discoveryConfigName,
+						Logger:              logger,
+					})
+					ret = append(ret, fetcher)
+				}
+			}
 		}
 	}
-	return fetchers, nil
+	return ret
 }
 
 // expandAzureMatcherSubscriptions fetches the subscriptions for any wildcard
 // subscriptions and replaces the wildcard with the subscriptions list.
 func expandAzureMatcherSubscriptions(
 	ctx context.Context,
+	logger *slog.Logger,
 	subscriptions []string,
 	integration string,
 	listSubs listSubscriptionsFunc,
-) ([]string, error) {
+) []string {
 	var out []string
 	for _, sub := range subscriptions {
 		if sub != types.Wildcard {
@@ -228,58 +233,49 @@ func expandAzureMatcherSubscriptions(
 			continue
 		}
 		subs, err := listSubs(ctx, integration)
-		// Azure can return a successful response with no subscriptions when the
-		// identity has no subscription-scoped access. Treat this as a resolution
-		// failure so wildcard discovery doesn't silently produce 0 fetchers.
-		if err == nil && len(subs) == 0 {
-			err = trace.NotFound("Azure returned no subscriptions for wildcard in discovery configuration")
-		}
 		if err != nil {
-			return nil, trace.Wrap(err)
+			// TODO(gavin): make a user task
+			logger.WarnContext(ctx, "Failed to fetch Azure subscription list for wildcard in discovery configuration",
+				"integration", integration,
+				"error", err,
+			)
+			continue
 		}
 		out = append(out, subs...)
 	}
-	return utils.Deduplicate(out), nil
+	return utils.Deduplicate(out)
 }
 
 type azureFetcherConfig struct {
 	Matcher             types.AzureMatcher
+	MatcherType         string
 	Subscription        string
 	ResourceGroup       string
 	AzureClientGetter   azureClientGetter
 	DiscoveryConfigName string
 	Logger              *slog.Logger
-	// InterfacesClientGetter returns the Azure network interfaces client used by
+	// NetworkInterfacesClientGetter returns the Azure network interfaces client used by
 	// the Windows VM path to resolve private IPs. It exists so tests can inject a
 	// fake. When nil, the fetcher builds the real InterfacesClient.
-	InterfacesClientGetter interfacesClientGetter
+	NetworkInterfacesClientGetter networkInterfacesClientGetter
 }
 
 type azureInstanceFetcher struct {
-	InstallerParams     *types.InstallerParams
-	AzureClientGetter   azureClientGetter
-	Regions             []string
-	Subscription        string
-	ResourceGroup       string
-	Labels              types.Labels
-	DiscoveryConfigName string
-	Integration         string
-	Logger              *slog.Logger
-	MatcherType         string
-	interfacesClientFn  interfacesClientGetter
+	InstallerParams           *types.InstallerParams
+	AzureClientGetter         azureClientGetter
+	Regions                   []string
+	Subscription              string
+	ResourceGroup             string
+	Labels                    types.Labels
+	DiscoveryConfigName       string
+	Integration               string
+	Logger                    *slog.Logger
+	MatcherType               string
+	osMatches                 func(vm *azure.VirtualMachine) bool
+	networkInterfacesClientFn networkInterfacesClientGetter
 }
 
 func newAzureInstanceFetcher(cfg azureFetcherConfig) *azureInstanceFetcher {
-	// cfg.Matcher.Types will only contain one of AzureMatcherVM or
-	// AzureMatcherWindowsVM. Here we check which one is present and set the
-	// matcher type so we can filter the correct OS types. If somehow both are
-	// present, prefer AzureMatcherVM .
-	matcherType := types.AzureMatcherVM
-	if slices.Contains(cfg.Matcher.Types, types.AzureMatcherWindowsVM) &&
-		!slices.Contains(cfg.Matcher.Types, types.AzureMatcherVM) {
-		matcherType = types.AzureMatcherWindowsVM
-	}
-
 	fetcher := &azureInstanceFetcher{
 		InstallerParams:     cfg.Matcher.Params,
 		AzureClientGetter:   cfg.AzureClientGetter,
@@ -290,11 +286,15 @@ func newAzureInstanceFetcher(cfg azureFetcherConfig) *azureInstanceFetcher {
 		DiscoveryConfigName: cfg.DiscoveryConfigName,
 		Integration:         cfg.Matcher.Integration,
 		Logger:              cfg.Logger,
-		MatcherType:         matcherType,
+		MatcherType:         cfg.MatcherType,
 	}
-	fetcher.interfacesClientFn = cfg.InterfacesClientGetter
-	if fetcher.interfacesClientFn == nil {
-		fetcher.interfacesClientFn = fetcher.newInterfacesClient
+	fetcher.osMatches = (*azure.VirtualMachine).IsLinuxOrUnknown
+	if cfg.MatcherType == types.AzureMatcherWindowsVM {
+		fetcher.osMatches = (*azure.VirtualMachine).IsWindowsOrUnknown
+	}
+	fetcher.networkInterfacesClientFn = cfg.NetworkInterfacesClientGetter
+	if fetcher.networkInterfacesClientFn == nil {
+		fetcher.networkInterfacesClientFn = fetcher.newInterfacesClient
 	}
 	return fetcher
 }
@@ -311,15 +311,6 @@ func (f *azureInstanceFetcher) GetDiscoveryConfigName() string {
 // Might be empty when the fetcher is using ambient credentials.
 func (f *azureInstanceFetcher) IntegrationName() string {
 	return f.Integration
-}
-
-// osMatches checks if the OS type of the given VM matches based on the matcher
-// type of this fetcher.
-func (f *azureInstanceFetcher) osMatches(vm *azure.VirtualMachine) bool {
-	if f.MatcherType == types.AzureMatcherWindowsVM {
-		return vm.IsWindowsOrUnknown()
-	}
-	return vm.IsLinuxOrUnknown()
 }
 
 type resourceGroupLocation struct {
@@ -344,17 +335,6 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 		return nil, trace.Wrap(err)
 	}
 
-	// Windows VM discovery needs each VM's private IP to register a dynamic
-	// Windows desktop, but the compute API doesn't return it. Resolve the IPs
-	// from the VMs' network interfaces and join them to the VMs by resource ID.
-	var nicsByVM map[string][]*network.Interface
-	if f.MatcherType == types.AzureMatcherWindowsVM {
-		nicsByVM, err = f.listNICsByVM(ctx, azureClients)
-		if err != nil {
-			return nil, trace.Wrap(err, "listing network interfaces for Windows VM discovery")
-		}
-	}
-
 	instanceGroups := make(map[resourceGroupLocation][]*azure.VirtualMachine)
 
 	allowAllLocations := slices.Contains(f.Regions, types.Wildcard)
@@ -374,12 +354,6 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 		}
 		if match, _, _ := services.MatchLabels(f.Labels, vm.Tags); !match {
 			continue
-		}
-
-		// For Windows VMs, attach the private IP resolved from the VM's NIC(s) so
-		// it can be registered as a dynamic Windows desktop downstream.
-		if f.MatcherType == types.AzureMatcherWindowsVM {
-			vm.PrimaryPrivateIP = primaryPrivateIP(nicsByVM[strings.ToLower(vm.ID)])
 		}
 
 		batchGroup := resourceGroupLocation{
@@ -404,6 +378,21 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 		)
 	}
 
+	// Windows VM discovery needs each VM's private IP to register a dynamic
+	// Windows desktop, but the compute API doesn't return it. Resolve the IPs
+	// from the VMs' network interfaces and join them to the VMs by resource ID.
+	if f.MatcherType == types.AzureMatcherWindowsVM {
+		nicsByVM, err := f.listNICsByVM(ctx, azureClients, instanceGroups)
+		if err != nil {
+			return nil, trace.Wrap(err, "listing network interfaces for Windows VM discovery")
+		}
+		for _, vms := range instanceGroups {
+			for _, vm := range vms {
+				vm.PrimaryPrivateIP = primaryPrivateIP(nicsByVM[strings.ToLower(vm.ID)])
+			}
+		}
+	}
+
 	var instances []*AzureInstances
 	for batchGroup, vms := range instanceGroups {
 		instances = append(instances, &AzureInstances{
@@ -422,15 +411,36 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 	return instances, nil
 }
 
-// listNICsByVM lists every network interface in the fetcher's subscription and
-// resource group, grouped by the lower-cased resource ID of the VM each NIC is
-// attached to. It is used by the Windows VM path to resolve each VM's private IP.
-func (f *azureInstanceFetcher) listNICsByVM(ctx context.Context, azureClients azure.Clients) (map[string][]*network.Interface, error) {
-	nicClient, err := f.interfacesClientFn(ctx, azureClients)
+// listNICsByVM lists the network interfaces in each resource group that
+// contains a matched VM, grouped by the lower-cased resource ID of the VM each
+// NIC is attached to. It is used by the Windows VM path to resolve each VM's
+// private IP.
+func (f *azureInstanceFetcher) listNICsByVM(
+	ctx context.Context,
+	azureClients azure.Clients,
+	instanceGroups map[resourceGroupLocation][]*azure.VirtualMachine,
+) (map[string][]*network.Interface, error) {
+	nicClient, err := f.networkInterfacesClientFn(ctx, azureClients)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return nicClient.List(ctx, f.Subscription, f.ResourceGroup)
+
+	resourceGroups := make(map[string]struct{})
+	for batchGroup := range instanceGroups {
+		resourceGroups[strings.ToLower(batchGroup.resourceGroup)] = struct{}{}
+	}
+
+	var nicsByVM = make(map[string][]*network.Interface)
+	for resourceGroup := range resourceGroups {
+		nics, err := nicClient.List(ctx, f.Subscription, resourceGroup)
+		if err != nil {
+			return nil, trace.Wrap(err, "listing network interfaces for resource group %q", resourceGroup)
+		}
+		// We can safely copy the NICs into the map because VMs belong to a single
+		// resource group, so there won't be any duplicates.
+		maps.Copy(nicsByVM, nics)
+	}
+	return nicsByVM, nil
 }
 
 // newInterfacesClient builds the Azure network interfaces client from the
@@ -463,9 +473,7 @@ func primaryPrivateIP(nics []*network.Interface) string {
 		if nic.Primary {
 			return nic.PrivateIP
 		}
-		if fallback == "" {
-			fallback = nic.PrivateIP
-		}
+		fallback = cmp.Or(fallback, nic.PrivateIP)
 	}
 	return fallback
 }

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -183,51 +183,51 @@ type azureClientGetter func(ctx context.Context, integration string) (azure.Clie
 
 type listSubscriptionsFunc func(ctx context.Context, integration string) (subscriptions []string, err error)
 
-// MatchersToAzureInstanceFetchers converts a list of Azure VM Matchers into a list of Azure VM Fetchers.
-func MatchersToAzureInstanceFetchers(
+// MatcherToAzureInstanceFetchers converts an Azure VM matcher into Azure VM fetchers.
+func MatcherToAzureInstanceFetchers(
 	ctx context.Context,
 	logger *slog.Logger,
-	matchers []types.AzureMatcher,
+	matcher types.AzureMatcher,
 	getClient azureClientGetter,
 	discoveryConfigName string,
 	listSubs listSubscriptionsFunc,
-) []Fetcher[*AzureInstances] {
-	ret := make([]Fetcher[*AzureInstances], 0)
-	for _, matcher := range matchers {
-		matcher.Subscriptions = expandAzureMatcherSubscriptions(ctx, logger, matcher.Subscriptions, matcher.Integration, listSubs)
-		for _, matcherType := range matcher.Types {
-			if matcherType != types.AzureMatcherVM && matcherType != types.AzureMatcherWindowsVM {
-				logger.WarnContext(ctx, "Skipping unsupported matcher type", "matcher_type", matcherType)
-				continue
-			}
-			for _, subscription := range matcher.Subscriptions {
-				for _, resourceGroup := range matcher.ResourceGroups {
-					fetcher := newAzureInstanceFetcher(azureFetcherConfig{
-						Matcher:             matcher,
-						MatcherType:         matcherType,
-						Subscription:        subscription,
-						ResourceGroup:       resourceGroup,
-						AzureClientGetter:   getClient,
-						DiscoveryConfigName: discoveryConfigName,
-						Logger:              logger,
-					})
-					ret = append(ret, fetcher)
-				}
+) ([]Fetcher[*AzureInstances], error) {
+	subscriptions, err := expandAzureMatcherSubscriptions(ctx, matcher.Subscriptions, matcher.Integration, listSubs)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	fetchers := make([]Fetcher[*AzureInstances], 0, len(matcher.Types)*len(subscriptions)*len(matcher.ResourceGroups))
+	for _, matcherType := range matcher.Types {
+		if matcherType != types.AzureMatcherVM && matcherType != types.AzureMatcherWindowsVM {
+			logger.WarnContext(ctx, "Skipping unsupported matcher type", "matcher_type", matcherType)
+			continue
+		}
+		for _, subscription := range subscriptions {
+			for _, resourceGroup := range matcher.ResourceGroups {
+				fetchers = append(fetchers, newAzureInstanceFetcher(azureFetcherConfig{
+					Matcher:             matcher,
+					MatcherType:         matcherType,
+					Subscription:        subscription,
+					ResourceGroup:       resourceGroup,
+					AzureClientGetter:   getClient,
+					DiscoveryConfigName: discoveryConfigName,
+					Logger:              logger,
+				}))
 			}
 		}
 	}
-	return ret
+	return fetchers, nil
 }
 
 // expandAzureMatcherSubscriptions fetches the subscriptions for any wildcard
 // subscriptions and replaces the wildcard with the subscriptions list.
 func expandAzureMatcherSubscriptions(
 	ctx context.Context,
-	logger *slog.Logger,
 	subscriptions []string,
 	integration string,
 	listSubs listSubscriptionsFunc,
-) []string {
+) ([]string, error) {
 	var out []string
 	for _, sub := range subscriptions {
 		if sub != types.Wildcard {
@@ -235,17 +235,18 @@ func expandAzureMatcherSubscriptions(
 			continue
 		}
 		subs, err := listSubs(ctx, integration)
+		// Azure can return a successful response with no subscriptions when the
+		// identity has no subscription-scoped access. Treat this as a resolution
+		// failure so wildcard discovery doesn't silently produce 0 fetchers.
+		if err == nil && len(subs) == 0 {
+			err = trace.NotFound("Azure returned no subscriptions for wildcard in discovery configuration")
+		}
 		if err != nil {
-			// TODO(gavin): make a user task
-			logger.WarnContext(ctx, "Failed to fetch Azure subscription list for wildcard in discovery configuration",
-				"integration", integration,
-				"error", err,
-			)
-			continue
+			return nil, trace.Wrap(err)
 		}
 		out = append(out, subs...)
 	}
-	return utils.Deduplicate(out)
+	return utils.Deduplicate(out), nil
 }
 
 type azureFetcherConfig struct {

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -57,6 +57,9 @@ type AzureInstancesMetadata struct {
 
 	// InstallerParams are the installer parameters used for installation.
 	InstallerParams *types.InstallerParams
+
+	// MatcherType is the type of matcher that discovered these instances.
+	MatcherType string
 }
 
 func (md AzureInstancesMetadata) LogValue() slog.Value {
@@ -392,6 +395,7 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 				Integration:         f.Integration,
 				InstallerParams:     f.InstallerParams,
 				DiscoveryConfigName: f.DiscoveryConfigName,
+				MatcherType:         f.MatcherType,
 			},
 			Instances: vms,
 		})
@@ -412,16 +416,13 @@ func (f *azureInstanceFetcher) primaryPrivateIPByVM(
 		return nil, trace.Wrap(err, "getting network interfaces client")
 	}
 
-	// Create a set of resource groups to list NICs for.
+	// Create a set of resource groups to list NICs for and find scale set names
+	// of uniform VMSS VMs.
 	resourceGroups := make(map[string]struct{})
-	for batchGroup := range instanceGroups {
-		resourceGroups[strings.ToLower(batchGroup.resourceGroup)] = struct{}{}
-	}
-
-	// Find scale set names of uniform VMSS VMs in the matched instances.
 	scaleSetNamesByRG := make(map[string][]string)
 	for batchGroup, vms := range instanceGroups {
 		rg := strings.ToLower(batchGroup.resourceGroup)
+		resourceGroups[rg] = struct{}{}
 		for _, vm := range vms {
 			if vm.UniformScaleSetName != "" {
 				scaleSetNamesByRG[rg] = append(scaleSetNamesByRG[rg], vm.UniformScaleSetName)
@@ -429,19 +430,26 @@ func (f *azureInstanceFetcher) primaryPrivateIPByVM(
 		}
 	}
 
-	var privateIPByVM = make(map[string]string)
+	// Gather all NICs for the matched resource groups
+	var nicsByAttachedVM = make(map[string][]*azure.NetworkInterface)
 	for resourceGroup := range resourceGroups {
 		nics, err := nicClient.ListNetworkInterfaces(ctx, resourceGroup, scaleSetNamesByRG[resourceGroup])
 		if err != nil {
 			return nil, trace.Wrap(err, "listing network interfaces for resource group %q", resourceGroup)
 		}
-		var nicsByAttachedVM = make(map[string][]*azure.NetworkInterface)
 		for _, nic := range nics {
+			// Skip NICs that aren't attached to a VM
+			if nic.AttachedVMID == "" {
+				continue
+			}
 			nicsByAttachedVM[strings.ToLower(nic.AttachedVMID)] = append(nicsByAttachedVM[strings.ToLower(nic.AttachedVMID)], nic)
 		}
-		for vmId, nics := range nicsByAttachedVM {
-			privateIPByVM[vmId] = primaryPrivateIP(nics)
-		}
+	}
+
+	// For each VM, find the primary private IP
+	var privateIPByVM = make(map[string]string)
+	for vmId, nics := range nicsByAttachedVM {
+		privateIPByVM[vmId] = primaryPrivateIP(nics)
 	}
 	return privateIPByVM, nil
 }
@@ -451,7 +459,7 @@ func (f *azureInstanceFetcher) primaryPrivateIPByVM(
 // flagged as primary. If no NIC/IP config is flagged primary (which would be an
 // Azure error) it falls back to the first NIC with a usable private IP.
 func primaryPrivateIP(nics []*azure.NetworkInterface) string {
-	var fallback, primaryFallback string
+	var fallback, primaryNICFallback, primaryConfigFallback string
 	for _, nic := range nics {
 		for _, ipConfig := range nic.IPConfigurations {
 			// Some non-primary IP Configurations can have a CIDR address as their
@@ -466,15 +474,20 @@ func primaryPrivateIP(nics []*azure.NetworkInterface) string {
 			}
 			// If the NIC is primary but the IP configuration is not, save it as a
 			// fallback in case no primary IP configuration is found.
-			if nic.Primary && primaryFallback == "" {
-				primaryFallback = ipConfig.PrivateIP
+			if nic.Primary && primaryNICFallback == "" {
+				primaryNICFallback = ipConfig.PrivateIP
+			}
+			// If the IP configuration is primary but the NIC is not, save it as a
+			// fallback in case no primary NIC is found.
+			if ipConfig.Primary && primaryConfigFallback == "" {
+				primaryConfigFallback = ipConfig.PrivateIP
 			}
 			if fallback == "" {
 				fallback = ipConfig.PrivateIP
 			}
 		}
 	}
-	return cmp.Or(primaryFallback, fallback)
+	return cmp.Or(primaryNICFallback, primaryConfigFallback, fallback)
 }
 
 // LogValue implements [slog.LogValuer].

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"log/slog"
 	"slices"
+	"strings"
 
 	"github.com/gravitational/trace"
 
@@ -31,6 +32,8 @@ import (
 	"github.com/gravitational/teleport/api/types/installers"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/cloud/azure"
+	"github.com/gravitational/teleport/lib/cloud/azure/client"
+	"github.com/gravitational/teleport/lib/cloud/azure/network"
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/server/installstatus"
@@ -174,6 +177,10 @@ func (instances *AzureInstances) FilterExistingNodes(existingNodes []types.Serve
 
 type azureClientGetter func(ctx context.Context, integration string) (azure.Clients, error)
 
+// interfacesClientGetter returns the Azure network interfaces client for a
+// resolved azure.Clients.
+type interfacesClientGetter func(ctx context.Context, azureClients azure.Clients) (network.InterfacesClient, error)
+
 type listSubscriptionsFunc func(ctx context.Context, integration string) (subscriptions []string, err error)
 
 // MatcherToAzureInstanceFetchers converts an Azure VM matcher into Azure VM fetchers.
@@ -242,6 +249,10 @@ type azureFetcherConfig struct {
 	AzureClientGetter   azureClientGetter
 	DiscoveryConfigName string
 	Logger              *slog.Logger
+	// InterfacesClientGetter returns the Azure network interfaces client used by
+	// the Windows VM path to resolve private IPs. It exists so tests can inject a
+	// fake. When nil, the fetcher builds the real InterfacesClient.
+	InterfacesClientGetter interfacesClientGetter
 }
 
 type azureInstanceFetcher struct {
@@ -254,10 +265,22 @@ type azureInstanceFetcher struct {
 	DiscoveryConfigName string
 	Integration         string
 	Logger              *slog.Logger
+	MatcherType         string
+	interfacesClientFn  interfacesClientGetter
 }
 
 func newAzureInstanceFetcher(cfg azureFetcherConfig) *azureInstanceFetcher {
-	return &azureInstanceFetcher{
+	// cfg.Matcher.Types will only contain one of AzureMatcherVM or
+	// AzureMatcherWindowsVM. Here we check which one is present and set the
+	// matcher type so we can filter the correct OS types. If somehow both are
+	// present, prefer AzureMatcherVM .
+	matcherType := types.AzureMatcherVM
+	if slices.Contains(cfg.Matcher.Types, types.AzureMatcherWindowsVM) &&
+		!slices.Contains(cfg.Matcher.Types, types.AzureMatcherVM) {
+		matcherType = types.AzureMatcherWindowsVM
+	}
+
+	fetcher := &azureInstanceFetcher{
 		InstallerParams:     cfg.Matcher.Params,
 		AzureClientGetter:   cfg.AzureClientGetter,
 		Regions:             cfg.Matcher.Regions,
@@ -267,7 +290,13 @@ func newAzureInstanceFetcher(cfg azureFetcherConfig) *azureInstanceFetcher {
 		DiscoveryConfigName: cfg.DiscoveryConfigName,
 		Integration:         cfg.Matcher.Integration,
 		Logger:              cfg.Logger,
+		MatcherType:         matcherType,
 	}
+	fetcher.interfacesClientFn = cfg.InterfacesClientGetter
+	if fetcher.interfacesClientFn == nil {
+		fetcher.interfacesClientFn = fetcher.newInterfacesClient
+	}
+	return fetcher
 }
 
 func (*azureInstanceFetcher) GetMatchingInstances(_ context.Context, _ []types.Server, _ bool) ([]*AzureInstances, error) {
@@ -284,6 +313,15 @@ func (f *azureInstanceFetcher) IntegrationName() string {
 	return f.Integration
 }
 
+// osMatches checks if the OS type of the given VM matches based on the matcher
+// type of this fetcher.
+func (f *azureInstanceFetcher) osMatches(vm *azure.VirtualMachine) bool {
+	if f.MatcherType == types.AzureMatcherWindowsVM {
+		return vm.IsWindowsOrUnknown()
+	}
+	return vm.IsLinuxOrUnknown()
+}
+
 type resourceGroupLocation struct {
 	resourceGroup string
 	location      string
@@ -296,26 +334,38 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 		return nil, trace.Wrap(err)
 	}
 
-	client, err := azureClients.GetVirtualMachinesClient(ctx, f.Subscription)
+	vmClient, err := azureClients.GetVirtualMachinesClient(ctx, f.Subscription)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	vms, err := client.ListVirtualMachines(ctx, f.ResourceGroup)
+	vms, err := vmClient.ListVirtualMachines(ctx, f.ResourceGroup)
 	if err != nil {
 		return nil, trace.Wrap(err)
+	}
+
+	// Windows VM discovery needs each VM's private IP to register a dynamic
+	// Windows desktop, but the compute API doesn't return it. Resolve the IPs
+	// from the VMs' network interfaces and join them to the VMs by resource ID.
+	var nicsByVM map[string][]*network.Interface
+	if f.MatcherType == types.AzureMatcherWindowsVM {
+		nicsByVM, err = f.listNICsByVM(ctx, azureClients)
+		if err != nil {
+			return nil, trace.Wrap(err, "listing network interfaces for Windows VM discovery")
+		}
 	}
 
 	instanceGroups := make(map[resourceGroupLocation][]*azure.VirtualMachine)
 
 	allowAllLocations := slices.Contains(f.Regions, types.Wildcard)
 
-	nonLinuxVMIDs := make([]string, 0)
+	skippedVMIDs := make([]string, 0)
 	for _, vm := range vms {
-		// Teleport only supports Linux nodes, so we filter out non-Linux VMs.
-		// If the OS is unknown, we allow it because the OS type might not always be present in the API response.
-		if !vm.IsLinuxOrUnknown() {
-			nonLinuxVMIDs = append(nonLinuxVMIDs, vm.ID)
+		// Skip VMs where the OS doesn't match this fetcher's matcher type. VMs with
+		// an unknown OS are kept because the OS type is not always present in the
+		// API response.
+		if !f.osMatches(vm) {
+			skippedVMIDs = append(skippedVMIDs, vm.ID)
 			continue
 		}
 
@@ -326,6 +376,12 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 			continue
 		}
 
+		// For Windows VMs, attach the private IP resolved from the VM's NIC(s) so
+		// it can be registered as a dynamic Windows desktop downstream.
+		if f.MatcherType == types.AzureMatcherWindowsVM {
+			vm.PrimaryPrivateIP = primaryPrivateIP(nicsByVM[strings.ToLower(vm.ID)])
+		}
+
 		batchGroup := resourceGroupLocation{
 			resourceGroup: vm.ResourceGroup,
 			location:      vm.Location,
@@ -333,17 +389,18 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 
 		instanceGroups[batchGroup] = append(instanceGroups[batchGroup], vm)
 	}
-	if len(nonLinuxVMIDs) > 0 {
-		// Show at most 10 non-Linux VM IDs in the log message to avoid spamming the logs.
-		sampleSize := min(len(nonLinuxVMIDs), 10)
-		nonLinuxVMIDsSample := make([]string, sampleSize)
-		copy(nonLinuxVMIDsSample, nonLinuxVMIDs[:sampleSize])
+	if len(skippedVMIDs) > 0 {
+		// Show at most 10 skipped VM IDs in the log message to avoid spamming the logs.
+		sampleSize := min(len(skippedVMIDs), 10)
+		skippedVMIDsSample := make([]string, sampleSize)
+		copy(skippedVMIDsSample, skippedVMIDs[:sampleSize])
 
-		f.Logger.DebugContext(ctx, "Skipped non Linux VMs in Azure Server Discovery",
+		f.Logger.DebugContext(ctx, "Skipped VMs with non-matching OS in Azure Server Discovery",
 			"fetcher", f,
+			"matcher_type", f.MatcherType,
 			"total_vms", len(vms),
-			"skipped_vms", len(nonLinuxVMIDs),
-			"skipped_vms_sample", nonLinuxVMIDsSample,
+			"skipped_vms", len(skippedVMIDs),
+			"skipped_vms_sample", skippedVMIDsSample,
 		)
 	}
 
@@ -363,6 +420,54 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 	}
 
 	return instances, nil
+}
+
+// listNICsByVM lists every network interface in the fetcher's subscription and
+// resource group, grouped by the lower-cased resource ID of the VM each NIC is
+// attached to. It is used by the Windows VM path to resolve each VM's private IP.
+func (f *azureInstanceFetcher) listNICsByVM(ctx context.Context, azureClients azure.Clients) (map[string][]*network.Interface, error) {
+	nicClient, err := f.interfacesClientFn(ctx, azureClients)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return nicClient.List(ctx, f.Subscription, f.ResourceGroup)
+}
+
+// newInterfacesClient builds the Azure network interfaces client from the
+// shared token credential.
+func (f *azureInstanceFetcher) newInterfacesClient(ctx context.Context, azureClients azure.Clients) (network.InterfacesClient, error) {
+	cred, err := azureClients.GetCredential(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	c, err := client.NewClient(cred,
+		client.WithRetryOnRateLimitErrors(),
+		client.WithLogger(f.Logger),
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return network.NewInterfacesClient(c, network.WithLogger(f.Logger)), nil
+}
+
+// primaryPrivateIP returns the private IP to register for a VM given its
+// network interfaces. It prefers the IP of the NIC that Azure flagged as
+// primary. If no NIC is flagged primary (which would be an Azure error) it
+// falls back to the first NIC with a usable private IP.
+func primaryPrivateIP(nics []*network.Interface) string {
+	var fallback string
+	for _, nic := range nics {
+		if nic.PrivateIP == "" {
+			continue
+		}
+		if nic.Primary {
+			return nic.PrivateIP
+		}
+		if fallback == "" {
+			fallback = nic.PrivateIP
+		}
+	}
+	return fallback
 }
 
 // LogValue implements [slog.LogValuer].

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -22,7 +22,7 @@ import (
 	"cmp"
 	"context"
 	"log/slog"
-	"maps"
+	"net"
 	"slices"
 	"strings"
 
@@ -34,8 +34,6 @@ import (
 	"github.com/gravitational/teleport/api/types/installers"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/cloud/azure"
-	"github.com/gravitational/teleport/lib/cloud/azure/client"
-	"github.com/gravitational/teleport/lib/cloud/azure/network"
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/server/installstatus"
@@ -179,10 +177,6 @@ func (instances *AzureInstances) FilterExistingNodes(existingNodes []types.Serve
 
 type azureClientGetter func(ctx context.Context, integration string) (azure.Clients, error)
 
-// networkInterfacesClientGetter returns the Azure network interfaces client for a
-// resolved azure.Clients.
-type networkInterfacesClientGetter func(ctx context.Context, azureClients azure.Clients) (network.InterfacesClient, error)
-
 type listSubscriptionsFunc func(ctx context.Context, integration string) (subscriptions []string, err error)
 
 // MatchersToAzureInstanceFetchers converts a list of Azure VM Matchers into a list of Azure VM Fetchers.
@@ -198,6 +192,10 @@ func MatchersToAzureInstanceFetchers(
 	for _, matcher := range matchers {
 		matcher.Subscriptions = expandAzureMatcherSubscriptions(ctx, logger, matcher.Subscriptions, matcher.Integration, listSubs)
 		for _, matcherType := range matcher.Types {
+			if matcherType != types.AzureMatcherVM && matcherType != types.AzureMatcherWindowsVM {
+				logger.WarnContext(ctx, "Skipping unsupported matcher type", "matcher_type", matcherType)
+				continue
+			}
 			for _, subscription := range matcher.Subscriptions {
 				for _, resourceGroup := range matcher.ResourceGroups {
 					fetcher := newAzureInstanceFetcher(azureFetcherConfig{
@@ -254,25 +252,20 @@ type azureFetcherConfig struct {
 	AzureClientGetter   azureClientGetter
 	DiscoveryConfigName string
 	Logger              *slog.Logger
-	// NetworkInterfacesClientGetter returns the Azure network interfaces client used by
-	// the Windows VM path to resolve private IPs. It exists so tests can inject a
-	// fake. When nil, the fetcher builds the real InterfacesClient.
-	NetworkInterfacesClientGetter networkInterfacesClientGetter
 }
 
 type azureInstanceFetcher struct {
-	InstallerParams           *types.InstallerParams
-	AzureClientGetter         azureClientGetter
-	Regions                   []string
-	Subscription              string
-	ResourceGroup             string
-	Labels                    types.Labels
-	DiscoveryConfigName       string
-	Integration               string
-	Logger                    *slog.Logger
-	MatcherType               string
-	osMatches                 func(vm *azure.VirtualMachine) bool
-	networkInterfacesClientFn networkInterfacesClientGetter
+	InstallerParams     *types.InstallerParams
+	AzureClientGetter   azureClientGetter
+	Regions             []string
+	Subscription        string
+	ResourceGroup       string
+	Labels              types.Labels
+	DiscoveryConfigName string
+	Integration         string
+	Logger              *slog.Logger
+	MatcherType         string
+	osMatches           func(vm *azure.VirtualMachine) bool
 }
 
 func newAzureInstanceFetcher(cfg azureFetcherConfig) *azureInstanceFetcher {
@@ -291,10 +284,6 @@ func newAzureInstanceFetcher(cfg azureFetcherConfig) *azureInstanceFetcher {
 	fetcher.osMatches = (*azure.VirtualMachine).IsLinuxOrUnknown
 	if cfg.MatcherType == types.AzureMatcherWindowsVM {
 		fetcher.osMatches = (*azure.VirtualMachine).IsWindowsOrUnknown
-	}
-	fetcher.networkInterfacesClientFn = cfg.NetworkInterfacesClientGetter
-	if fetcher.networkInterfacesClientFn == nil {
-		fetcher.networkInterfacesClientFn = fetcher.newInterfacesClient
 	}
 	return fetcher
 }
@@ -382,13 +371,13 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 	// Windows desktop, but the compute API doesn't return it. Resolve the IPs
 	// from the VMs' network interfaces and join them to the VMs by resource ID.
 	if f.MatcherType == types.AzureMatcherWindowsVM {
-		nicsByVM, err := f.listNICsByVM(ctx, azureClients, instanceGroups)
+		privateIPByVM, err := f.primaryPrivateIPByVM(ctx, azureClients, instanceGroups)
 		if err != nil {
 			return nil, trace.Wrap(err, "listing network interfaces for Windows VM discovery")
 		}
 		for _, vms := range instanceGroups {
 			for _, vm := range vms {
-				vm.PrimaryPrivateIP = primaryPrivateIP(nicsByVM[strings.ToLower(vm.ID)])
+				vm.PrimaryPrivateIP = privateIPByVM[strings.ToLower(vm.ID)]
 			}
 		}
 	}
@@ -411,71 +400,80 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 	return instances, nil
 }
 
-// listNICsByVM lists the network interfaces in each resource group that
-// contains a matched VM, grouped by the lower-cased resource ID of the VM each
-// NIC is attached to. It is used by the Windows VM path to resolve each VM's
-// private IP.
-func (f *azureInstanceFetcher) listNICsByVM(
+// primaryPrivateIPByVM gets the primary private IP address for each VM, grouped
+// by the lower-cased resource ID of the VM each NIC is attached to.
+func (f *azureInstanceFetcher) primaryPrivateIPByVM(
 	ctx context.Context,
 	azureClients azure.Clients,
 	instanceGroups map[resourceGroupLocation][]*azure.VirtualMachine,
-) (map[string][]*network.Interface, error) {
-	nicClient, err := f.networkInterfacesClientFn(ctx, azureClients)
+) (map[string]string, error) {
+	nicClient, err := azureClients.GetNetworkInterfacesClient(ctx, f.Subscription)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(err, "getting network interfaces client")
 	}
 
+	// Create a set of resource groups to list NICs for.
 	resourceGroups := make(map[string]struct{})
 	for batchGroup := range instanceGroups {
 		resourceGroups[strings.ToLower(batchGroup.resourceGroup)] = struct{}{}
 	}
 
-	var nicsByVM = make(map[string][]*network.Interface)
+	// Find scale set names of uniform VMSS VMs in the matched instances.
+	var scaleSetNames []string
+	for _, vms := range instanceGroups {
+		for _, vm := range vms {
+			if vm.UniformScaleSetName != "" {
+				scaleSetNames = append(scaleSetNames, vm.UniformScaleSetName)
+			}
+		}
+	}
+
+	var privateIPByVM = make(map[string]string)
 	for resourceGroup := range resourceGroups {
-		nics, err := nicClient.List(ctx, f.Subscription, resourceGroup)
+		nics, err := nicClient.ListNetworkInterfaces(ctx, resourceGroup, scaleSetNames)
 		if err != nil {
 			return nil, trace.Wrap(err, "listing network interfaces for resource group %q", resourceGroup)
 		}
-		// We can safely copy the NICs into the map because VMs belong to a single
-		// resource group, so there won't be any duplicates.
-		maps.Copy(nicsByVM, nics)
+		var nicsByAttachedVM = make(map[string][]*azure.NetworkInterface)
+		for _, nic := range nics {
+			nicsByAttachedVM[strings.ToLower(nic.AttachedVMID)] = append(nicsByAttachedVM[strings.ToLower(nic.AttachedVMID)], nic)
+		}
+		for vmId, nics := range nicsByAttachedVM {
+			privateIPByVM[vmId] = primaryPrivateIP(nics)
+		}
 	}
-	return nicsByVM, nil
-}
-
-// newInterfacesClient builds the Azure network interfaces client from the
-// shared token credential.
-func (f *azureInstanceFetcher) newInterfacesClient(ctx context.Context, azureClients azure.Clients) (network.InterfacesClient, error) {
-	cred, err := azureClients.GetCredential(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	c, err := client.NewClient(cred,
-		client.WithRetryOnRateLimitErrors(),
-		client.WithLogger(f.Logger),
-	)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return network.NewInterfacesClient(c, network.WithLogger(f.Logger)), nil
+	return privateIPByVM, nil
 }
 
 // primaryPrivateIP returns the private IP to register for a VM given its
-// network interfaces. It prefers the IP of the NIC that Azure flagged as
-// primary. If no NIC is flagged primary (which would be an Azure error) it
-// falls back to the first NIC with a usable private IP.
-func primaryPrivateIP(nics []*network.Interface) string {
-	var fallback string
+// network interfaces. It prefers the IP of the NIC and IP config that Azure
+// flagged as primary. If no NIC/IP config is flagged primary (which would be an
+// Azure error) it falls back to the first NIC with a usable private IP.
+func primaryPrivateIP(nics []*azure.NetworkInterface) string {
+	var fallback, primaryFallback string
 	for _, nic := range nics {
-		if nic.PrivateIP == "" {
-			continue
+		for _, ipConfig := range nic.IPConfigurations {
+			// Some non-primary IP Configurations can have a CIDR address as their
+			// private IP, so skip them.
+			if net.ParseIP(ipConfig.PrivateIP) == nil {
+				continue
+			}
+			// If the NIC is primary and the IP configuration is primary,
+			// return that IP.
+			if nic.Primary && ipConfig.Primary {
+				return ipConfig.PrivateIP
+			}
+			// If the NIC is primary but the IP configuration is not, save it as a
+			// fallback in case no primary IP configuration is found.
+			if nic.Primary && primaryFallback == "" {
+				primaryFallback = ipConfig.PrivateIP
+			}
+			if fallback == "" {
+				fallback = ipConfig.PrivateIP
+			}
 		}
-		if nic.Primary {
-			return nic.PrivateIP
-		}
-		fallback = cmp.Or(fallback, nic.PrivateIP)
 	}
-	return fallback
+	return cmp.Or(primaryFallback, fallback)
 }
 
 // LogValue implements [slog.LogValuer].

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -26,6 +26,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/gravitational/trace"
 
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
@@ -404,46 +405,55 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 	return instances, nil
 }
 
-// primaryPrivateIPByVM gets the primary private IP address for each VM, grouped
-// by the lower-cased resource ID of the VM each NIC is attached to.
+// primaryPrivateIPByVM gets the primary private IP address for each VM.
 func (f *azureInstanceFetcher) primaryPrivateIPByVM(
 	ctx context.Context,
 	azureClients azure.Clients,
 	instanceGroups map[resourceGroupLocation][]*azure.VirtualMachine,
 ) (map[string]string, error) {
+	if len(instanceGroups) == 0 {
+		return nil, nil
+	}
+
 	nicClient, err := azureClients.GetNetworkInterfacesClient(ctx, f.Subscription)
 	if err != nil {
 		return nil, trace.Wrap(err, "getting network interfaces client")
 	}
 
-	// Create a set of resource groups to list NICs for and find scale set names
-	// of uniform VMSS VMs.
-	resourceGroups := make(map[string]struct{})
-	scaleSetNamesByRG := make(map[string][]string)
-	for batchGroup, vms := range instanceGroups {
-		rg := strings.ToLower(batchGroup.resourceGroup)
-		resourceGroups[rg] = struct{}{}
+	// Get a list of scaleSetIDs (this slice is deduped by the NIC client)
+	scaleSetIDs := []string{}
+	for _, vms := range instanceGroups {
 		for _, vm := range vms {
 			if vm.UniformScaleSetName != "" {
-				scaleSetNamesByRG[rg] = append(scaleSetNamesByRG[rg], vm.UniformScaleSetName)
+				id, err := arm.ParseResourceID(vm.ID)
+				if err != nil {
+					f.Logger.WarnContext(ctx, "Skipping uniform scale set with unparsable resource id", "resource_id", vm.ID)
+					continue
+				}
+				if id.Parent == nil {
+					f.Logger.WarnContext(ctx, "Skipping uniform scale set because parent of uniform scale set instance not found", "resource_id", vm.ID)
+					continue
+				}
+				scaleSetIDs = append(scaleSetIDs, id.Parent.String())
 			}
 		}
 	}
 
 	// Gather all NICs for the matched resource groups
 	var nicsByAttachedVM = make(map[string][]*azure.NetworkInterface)
-	for resourceGroup := range resourceGroups {
-		nics, err := nicClient.ListNetworkInterfaces(ctx, resourceGroup, scaleSetNamesByRG[resourceGroup])
-		if err != nil {
-			return nil, trace.Wrap(err, "listing network interfaces for resource group %q", resourceGroup)
+	// We have to list NICs in the whole subscription because a NIC can be in a
+	// different resource group than the VM it is attached to. There is currently
+	// no way to filter this API call by any other means (e.g. location, tags, etc.)
+	nics, err := nicClient.ListNetworkInterfaces(ctx, types.Wildcard, scaleSetIDs...)
+	if err != nil {
+		return nil, trace.Wrap(err, "listing network interfaces")
+	}
+	for _, nic := range nics {
+		// Skip NICs that aren't attached to a VM
+		if nic.AttachedVMID == "" {
+			continue
 		}
-		for _, nic := range nics {
-			// Skip NICs that aren't attached to a VM
-			if nic.AttachedVMID == "" {
-				continue
-			}
-			nicsByAttachedVM[strings.ToLower(nic.AttachedVMID)] = append(nicsByAttachedVM[strings.ToLower(nic.AttachedVMID)], nic)
-		}
+		nicsByAttachedVM[strings.ToLower(nic.AttachedVMID)] = append(nicsByAttachedVM[strings.ToLower(nic.AttachedVMID)], nic)
 	}
 
 	// For each VM, find the primary private IP

--- a/lib/srv/server/azure_watcher_integration_test.go
+++ b/lib/srv/server/azure_watcher_integration_test.go
@@ -1,0 +1,102 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package server
+
+import (
+	"cmp"
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud/azure"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+// TestAzureFetcherGetInstancesWindowsLive exercises the full Windows VM discovery
+// path — listing VMs and resolving each VM's private IP from its NIC — against a
+// real Azure subscription. It is skipped unless TELEPORT_TEST_AZURE is set. No
+// fakes are injected, so it builds and calls the real virtual machines and
+// network interfaces clients.
+//
+// Prerequisites:
+//   - Authenticate so DefaultAzureCredential can find a credential, e.g. run
+//     `az login`, or set AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET.
+//     The identity needs Microsoft.Compute/virtualMachines/read and
+//     Microsoft.Network/networkInterfaces/read on the target resources.
+//   - Set AZURE_SUBSCRIPTION_ID to a subscription that has at least one Windows VM.
+//   - Optionally set AZURE_RESOURCE_GROUP and AZURE_REGION to narrow the search;
+//     both default to the wildcard (whole subscription / all regions).
+//
+// Run with:
+//
+//	TELEPORT_TEST_AZURE=1 \
+//	AZURE_SUBSCRIPTION_ID=<sub> \
+//	AZURE_RESOURCE_GROUP=<rg> \
+//	AZURE_REGION=<region> \
+//	go test ./lib/srv/server/ -run TestAzureFetcherGetInstancesWindowsLive -v
+func TestAzureFetcherGetInstancesWindowsLive(t *testing.T) {
+	if os.Getenv("TELEPORT_TEST_AZURE") == "" {
+		t.Skip("Set TELEPORT_TEST_AZURE to run this test against a real Azure subscription.")
+	}
+	subscription := os.Getenv("AZURE_SUBSCRIPTION_ID")
+	if subscription == "" {
+		t.Skip("Set AZURE_SUBSCRIPTION_ID to the subscription to search for Windows VMs.")
+	}
+	resourceGroup := cmp.Or(os.Getenv("AZURE_RESOURCE_GROUP"), types.Wildcard)
+	region := cmp.Or(os.Getenv("AZURE_REGION"), types.Wildcard)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	defer cancel()
+
+	clients, err := azure.NewClients()
+	require.NoError(t, err, "failed to build Azure clients, have you run `az login`?")
+
+	fetcher := newAzureInstanceFetcher(azureFetcherConfig{
+		Matcher: types.AzureMatcher{
+			Types:        []string{types.AzureMatcherWindowsVM},
+			Regions:      []string{region},
+			ResourceTags: types.Labels{"*": []string{"*"}},
+		},
+		MatcherType:   types.AzureMatcherWindowsVM,
+		Subscription:  subscription,
+		ResourceGroup: resourceGroup,
+		AzureClientGetter: func(context.Context, string) (azure.Clients, error) {
+			return clients, nil
+		},
+		// InterfacesClientGetter is intentionally left unset so the fetcher builds
+		// and uses the real Azure network interfaces client.
+		Logger: logtest.NewLogger(),
+	})
+
+	instances, err := fetcher.GetInstances(ctx, false)
+	require.NoError(t, err)
+
+	var total int
+	for _, group := range instances {
+		for _, vm := range group.Instances {
+			total++
+			t.Logf("Windows VM %q (region=%q, resourceGroup=%q, vmID=%q): private IP=%q",
+				vm.Name, vm.Location, vm.ResourceGroup, vm.VMID, vm.PrimaryPrivateIP)
+		}
+	}
+	t.Logf("Discovered %d Windows VM(s) in subscription %q (resourceGroup=%q, region=%q)",
+		total, subscription, resourceGroup, region)
+}

--- a/lib/srv/server/azure_watcher_test.go
+++ b/lib/srv/server/azure_watcher_test.go
@@ -1125,21 +1125,22 @@ func TestAzureFetcherGetInstancesWindowsUniformVMSS(t *testing.T) {
 	require.Equal(t, "10.0.0.42", vm.PrimaryPrivateIP)
 }
 
-func TestMatchersToAzureInstanceFetchersMatcherTypes(t *testing.T) {
+func TestMatcherToAzureInstanceFetchersMatcherTypes(t *testing.T) {
 	t.Parallel()
 
-	fetchers := MatchersToAzureInstanceFetchers(
+	fetchers, err := MatcherToAzureInstanceFetchers(
 		t.Context(),
 		logtest.NewLogger(),
-		[]types.AzureMatcher{{
+		types.AzureMatcher{
 			Types:          []string{types.AzureMatcherVM, types.AzureMatcherWindowsVM},
 			Subscriptions:  []string{"sub1"},
 			ResourceGroups: []string{"rg1"},
-		}},
+		},
 		nil,
 		"",
 		nil,
 	)
+	require.NoError(t, err)
 
 	var matcherTypes []string
 	for _, fetcher := range fetchers {

--- a/lib/srv/server/azure_watcher_test.go
+++ b/lib/srv/server/azure_watcher_test.go
@@ -19,8 +19,11 @@
 package server
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -35,6 +38,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/installers"
 	"github.com/gravitational/teleport/lib/cloud/azure"
+	"github.com/gravitational/teleport/lib/cloud/azure/network"
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
@@ -761,4 +765,287 @@ func TestMakeUsageEvent(t *testing.T) {
 			require.Equal(t, tc.want, evt)
 		})
 	}
+}
+
+func TestNewAzureInstanceFetcherMatcherType(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		types []string
+		want  string
+	}{
+		{name: "vm", types: []string{types.AzureMatcherVM}, want: types.AzureMatcherVM},
+		{name: "windows-vm", types: []string{types.AzureMatcherWindowsVM}, want: types.AzureMatcherWindowsVM},
+		{name: "combined prefers vm", types: []string{types.AzureMatcherVM, types.AzureMatcherWindowsVM}, want: types.AzureMatcherVM},
+		{name: "empty defaults to vm", types: nil, want: types.AzureMatcherVM},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newAzureInstanceFetcher(azureFetcherConfig{
+				Matcher: types.AzureMatcher{Types: tc.types},
+			})
+			require.Equal(t, tc.want, f.MatcherType)
+		})
+	}
+}
+
+func TestPrimaryPrivateIP(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		nics []*network.Interface
+		want string
+	}{
+		{name: "no NICs", nics: nil, want: ""},
+		{
+			name: "single primary NIC",
+			nics: []*network.Interface{{PrivateIP: "10.0.0.1", Primary: true}},
+			want: "10.0.0.1",
+		},
+		{
+			name: "prefers the primary NIC over the first one",
+			nics: []*network.Interface{
+				{PrivateIP: "10.0.0.9"},
+				{PrivateIP: "10.0.0.1", Primary: true},
+			},
+			want: "10.0.0.1",
+		},
+		{
+			name: "falls back to the first usable IP when none is primary",
+			nics: []*network.Interface{
+				{PrivateIP: ""},
+				{PrivateIP: "10.0.0.5"},
+				{PrivateIP: "10.0.0.6"},
+			},
+			want: "10.0.0.5",
+		},
+		{
+			name: "skips NICs without an IP before the primary",
+			nics: []*network.Interface{
+				{PrivateIP: ""},
+				{PrivateIP: "10.0.0.7", Primary: true},
+			},
+			want: "10.0.0.7",
+		},
+		{
+			name: "returns empty when no NIC has an IP",
+			nics: []*network.Interface{{PrivateIP: ""}, {PrivateIP: ""}},
+			want: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, primaryPrivateIP(tc.nics))
+		})
+	}
+}
+
+// fakeInterfacesClient is a network.InterfacesClient that returns canned NICs,
+// used to drive the Windows VM discovery path without real Azure API calls.
+type fakeInterfacesClient struct {
+	nicsByVM map[string][]*network.Interface
+	listErr  error
+}
+
+func (f *fakeInterfacesClient) Get(context.Context, string) (*network.Interface, error) {
+	return nil, trace.NotImplemented("Get not implemented in fake")
+}
+
+func (f *fakeInterfacesClient) List(context.Context, string, string) (map[string][]*network.Interface, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.nicsByVM, nil
+}
+
+func windowsVMFetcher(t *testing.T, clients azure.Clients, nicGetter interfacesClientGetter, regions []string) *azureInstanceFetcher {
+	t.Helper()
+	const (
+		sub = "00000000-0000-0000-0000-000000000000"
+		rg  = "rg1"
+	)
+	return newAzureInstanceFetcher(azureFetcherConfig{
+		Matcher: types.AzureMatcher{
+			Types:        []string{types.AzureMatcherWindowsVM},
+			Regions:      regions,
+			ResourceTags: types.Labels{"*": []string{"*"}},
+		},
+		Subscription:  sub,
+		ResourceGroup: rg,
+		AzureClientGetter: func(context.Context, string) (azure.Clients, error) {
+			return clients, nil
+		},
+		InterfacesClientGetter: nicGetter,
+		Logger:                 logtest.NewLogger(),
+	})
+}
+
+// windowsVMClients builds mock Azure clients whose VM client returns a  mix of
+// Windows, Linux, and unknown-OS VMs across two regions in resource group rg1.
+func windowsVMClients(t *testing.T) (*mockClients, map[string]string) {
+	t.Helper()
+	const (
+		sub = "00000000-0000-0000-0000-000000000000"
+		rg  = "rg1"
+	)
+	windowsOS := armcompute.OperatingSystemTypesWindows
+	linuxOS := armcompute.OperatingSystemTypesLinux
+
+	makeVM := func(name, location string, os *armcompute.OperatingSystemTypes) *armcompute.VirtualMachine {
+		vm := &armcompute.VirtualMachine{
+			ID:       to.Ptr(makeAzureVMID(sub, rg, name)),
+			Location: to.Ptr(location),
+		}
+		if os != nil {
+			vm.Properties = &armcompute.VirtualMachineProperties{
+				StorageProfile: &armcompute.StorageProfile{
+					OSDisk: &armcompute.OSDisk{OSType: os},
+				},
+			}
+		}
+		return vm
+	}
+
+	ids := map[string]string{
+		"winvm1":     makeAzureVMID(sub, rg, "winvm1"),
+		"winvm2":     makeAzureVMID(sub, rg, "winvm2"),
+		"linuxvm":    makeAzureVMID(sub, rg, "linuxvm"),
+		"unknownvm":  makeAzureVMID(sub, rg, "unknownvm"),
+		"winvm-west": makeAzureVMID(sub, rg, "winvm-west"),
+	}
+
+	vmClient := azure.NewVirtualMachinesClientByAPI(azure.VirtualMachinesClientConfig{
+		VirtualMachineAPI: &azure.ARMComputeMock{
+			VirtualMachines: map[string][]*armcompute.VirtualMachine{
+				rg: {
+					makeVM("winvm1", "eastus", &windowsOS),
+					makeVM("winvm2", "eastus", &windowsOS),
+					makeVM("linuxvm", "eastus", &linuxOS),
+					makeVM("unknownvm", "eastus", nil),
+					makeVM("winvm-west", "westus", &windowsOS),
+				},
+			},
+		},
+		ScaleSetVMsAPI: &azure.ARMScaleSetVMsMock{},
+		ScaleSetsAPI:   &azure.ARMScaleSetsMock{},
+	})
+
+	return &mockClients{
+		vmClients: map[string]azure.VirtualMachinesClient{sub: vmClient},
+	}, ids
+}
+
+func TestAzureFetcherGetInstancesWindows(t *testing.T) {
+	t.Parallel()
+
+	clients, ids := windowsVMClients(t)
+
+	// NICs are keyed by the lower-cased VM resource ID, as the real network
+	// interfaces client returns them.
+	nicsByVM := map[string][]*network.Interface{
+		strings.ToLower(ids["winvm1"]): {{PrivateIP: "10.0.0.1", Primary: true}},
+		strings.ToLower(ids["winvm2"]): {
+			{PrivateIP: "10.0.0.99"},
+			{PrivateIP: "10.0.0.2", Primary: true},
+		},
+		strings.ToLower(ids["unknownvm"]): {{PrivateIP: "10.0.0.3", Primary: true}},
+	}
+
+	fetcher := windowsVMFetcher(t, clients,
+		func(context.Context, azure.Clients) (network.InterfacesClient, error) {
+			return &fakeInterfacesClient{nicsByVM: nicsByVM}, nil
+		},
+		[]string{"eastus"},
+	)
+
+	instances, err := fetcher.GetInstances(t.Context(), false)
+	require.NoError(t, err)
+
+	gotIPByName := map[string]string{}
+	for _, group := range instances {
+		require.Equal(t, "eastus", group.Metadata.Region)
+		for _, vm := range group.Instances {
+			parsed, err := arm.ParseResourceID(vm.ID)
+			require.NoError(t, err)
+			gotIPByName[parsed.Name] = vm.PrimaryPrivateIP
+		}
+	}
+
+	// Only Windows and unknown-OS VMs in the eastus region, each carrying the
+	// primary NIC's private IP. The Linux VM and the westus Windows VM are excluded.
+	require.Equal(t, map[string]string{
+		"winvm1":    "10.0.0.1",
+		"winvm2":    "10.0.0.2",
+		"unknownvm": "10.0.0.3",
+	}, gotIPByName)
+}
+
+// TestAzureFetcherGetInstancesWindowsLive exercises the full Windows VM discovery
+// path — listing VMs and resolving each VM's private IP from its NIC — against a
+// real Azure subscription. It is skipped unless TELEPORT_TEST_AZURE is set. No
+// fakes are injected, so it builds and calls the real virtual machines and
+// network interfaces clients.
+//
+// Prerequisites:
+//   - Authenticate so DefaultAzureCredential can find a credential, e.g. run
+//     `az login`, or set AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET.
+//     The identity needs Microsoft.Compute/virtualMachines/read and
+//     Microsoft.Network/networkInterfaces/read on the target resources.
+//   - Set AZURE_SUBSCRIPTION_ID to a subscription that has at least one Windows VM.
+//   - Optionally set AZURE_RESOURCE_GROUP and AZURE_REGION to narrow the search;
+//     both default to the wildcard (whole subscription / all regions).
+//
+// Run with:
+//
+//	TELEPORT_TEST_AZURE=1 \
+//	AZURE_SUBSCRIPTION_ID=<sub> \
+//	AZURE_RESOURCE_GROUP=<rg> \
+//	AZURE_REGION=<region> \
+//	go test ./lib/srv/server/ -run TestAzureFetcherGetInstancesWindowsLive -v
+func TestAzureFetcherGetInstancesWindowsLive(t *testing.T) {
+	if os.Getenv("TELEPORT_TEST_AZURE") == "" {
+		t.Skip("Set TELEPORT_TEST_AZURE to run this test against a real Azure subscription.")
+	}
+	subscription := os.Getenv("AZURE_SUBSCRIPTION_ID")
+	if subscription == "" {
+		t.Skip("Set AZURE_SUBSCRIPTION_ID to the subscription to search for Windows VMs.")
+	}
+	resourceGroup := cmp.Or(os.Getenv("AZURE_RESOURCE_GROUP"), types.Wildcard)
+	region := cmp.Or(os.Getenv("AZURE_REGION"), types.Wildcard)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	defer cancel()
+
+	clients, err := azure.NewClients()
+	require.NoError(t, err, "failed to build Azure clients, have you run `az login`?")
+
+	fetcher := newAzureInstanceFetcher(azureFetcherConfig{
+		Matcher: types.AzureMatcher{
+			Types:        []string{types.AzureMatcherWindowsVM},
+			Regions:      []string{region},
+			ResourceTags: types.Labels{"*": []string{"*"}},
+		},
+		Subscription:  subscription,
+		ResourceGroup: resourceGroup,
+		AzureClientGetter: func(context.Context, string) (azure.Clients, error) {
+			return clients, nil
+		},
+		// InterfacesClientGetter is intentionally left unset so the fetcher builds
+		// and uses the real Azure network interfaces client.
+		Logger: logtest.NewLogger(),
+	})
+
+	instances, err := fetcher.GetInstances(ctx, false)
+	require.NoError(t, err)
+
+	var total int
+	for _, group := range instances {
+		for _, vm := range group.Instances {
+			total++
+			t.Logf("Windows VM %q (region=%q, resourceGroup=%q, vmID=%q): private IP=%q",
+				vm.Name, vm.Location, vm.ResourceGroup, vm.VMID, vm.PrimaryPrivateIP)
+		}
+	}
+	t.Logf("Discovered %d Windows VM(s) in subscription %q (resourceGroup=%q, region=%q)",
+		total, subscription, resourceGroup, region)
 }

--- a/lib/srv/server/azure_watcher_test.go
+++ b/lib/srv/server/azure_watcher_test.go
@@ -871,27 +871,24 @@ func TestPrimaryPrivateIP(t *testing.T) {
 }
 
 // fakeNetworkInterfacesClient is an azure.NetworkInterfacesClient that returns
-// canned NICs per resource group, used to drive the Windows VM discovery path
-// without real Azure API calls.
+// canned NICs, used to drive the Windows VM discovery path without real Azure
+// API calls.
 type fakeNetworkInterfacesClient struct {
-	nicsByRG map[string][]*azure.NetworkInterface
-	listErr  error
-	// gotScaleSetNamesByRG records the scale-set names passed to
-	// ListNetworkInterfaces, keyed by the resource group argument.
-	gotScaleSetNamesByRG map[string][]string
+	nics    []*azure.NetworkInterface
+	listErr error
+	// gotResourceGroups and gotScaleSetIDs record the arguments of each
+	// ListNetworkInterfaces call.
+	gotResourceGroups []string
+	gotScaleSetIDs    []string
 }
 
-func (f *fakeNetworkInterfacesClient) ListNetworkInterfaces(_ context.Context, resourceGroup string, scaleSetNames []string) ([]*azure.NetworkInterface, error) {
+func (f *fakeNetworkInterfacesClient) ListNetworkInterfaces(_ context.Context, resourceGroup string, scaleSetIDs ...string) ([]*azure.NetworkInterface, error) {
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
-	if len(scaleSetNames) > 0 {
-		if f.gotScaleSetNamesByRG == nil {
-			f.gotScaleSetNamesByRG = make(map[string][]string)
-		}
-		f.gotScaleSetNamesByRG[resourceGroup] = append(f.gotScaleSetNamesByRG[resourceGroup], scaleSetNames...)
-	}
-	return f.nicsByRG[resourceGroup], nil
+	f.gotResourceGroups = append(f.gotResourceGroups, resourceGroup)
+	f.gotScaleSetIDs = append(f.gotScaleSetIDs, scaleSetIDs...)
+	return f.nics, nil
 }
 
 func windowsVMFetcher(t *testing.T, clients azure.Clients, regions []string) *azureInstanceFetcher {
@@ -980,44 +977,45 @@ func TestAzureFetcherGetInstancesWindows(t *testing.T) {
 
 	// NICs reference their VM via AttachedVMID. winvm1 uses an upper-cased ID to
 	// verify the case-insensitive join between compute and network resource IDs.
-	clients.nicClients = map[string]azure.NetworkInterfacesClient{
-		sub: &fakeNetworkInterfacesClient{
-			nicsByRG: map[string][]*azure.NetworkInterface{
-				"rg1": {
-					{
-						AttachedVMID:     strings.ToUpper(ids["winvm1"]),
-						Primary:          true,
-						IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.1", Primary: true}},
-					},
-					// winvm2 has two NICs; the non-primary one comes first to
-					// verify the primary NIC's IP is preferred.
-					{
-						AttachedVMID:     ids["winvm2"],
-						IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.99"}},
-					},
-					{
-						AttachedVMID:     ids["winvm2"],
-						Primary:          true,
-						IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.2", Primary: true}},
-					},
-					{
-						AttachedVMID:     ids["unknownvm"],
-						Primary:          true,
-						IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.3", Primary: true}},
-					},
-					// A NIC not attached to any VM must not affect the results.
-					{
-						IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.50", Primary: true}},
-					},
-				},
+	nicClient := &fakeNetworkInterfacesClient{
+		nics: []*azure.NetworkInterface{
+			{
+				AttachedVMID:     strings.ToUpper(ids["winvm1"]),
+				Primary:          true,
+				IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.1", Primary: true}},
+			},
+			// winvm2 has two NICs; the non-primary one comes first to
+			// verify the primary NIC's IP is preferred.
+			{
+				AttachedVMID:     ids["winvm2"],
+				IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.99"}},
+			},
+			{
+				AttachedVMID:     ids["winvm2"],
+				Primary:          true,
+				IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.2", Primary: true}},
+			},
+			{
+				AttachedVMID:     ids["unknownvm"],
+				Primary:          true,
+				IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.3", Primary: true}},
+			},
+			// A NIC not attached to any VM must not affect the results.
+			{
+				IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.50", Primary: true}},
 			},
 		},
 	}
+	clients.nicClients = map[string]azure.NetworkInterfacesClient{sub: nicClient}
 
 	fetcher := windowsVMFetcher(t, clients, []string{"eastus"})
 
 	instances, err := fetcher.GetInstances(t.Context(), false)
 	require.NoError(t, err)
+
+	// NICs are listed once, subscription-wide, because a NIC can live in a
+	// different resource group than its VM.
+	require.Equal(t, []string{types.Wildcard}, nicClient.gotResourceGroups)
 
 	gotIPByName := map[string]string{}
 	for _, group := range instances {
@@ -1096,13 +1094,11 @@ func TestAzureFetcherGetInstancesWindowsUniformVMSS(t *testing.T) {
 	})
 
 	nicClient := &fakeNetworkInterfacesClient{
-		nicsByRG: map[string][]*azure.NetworkInterface{
-			"rg1": {{
-				AttachedVMID:     vmssVMID,
-				Primary:          true,
-				IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.42", Primary: true}},
-			}},
-		},
+		nics: []*azure.NetworkInterface{{
+			AttachedVMID:     vmssVMID,
+			Primary:          true,
+			IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.42", Primary: true}},
+		}},
 	}
 
 	clients := &mockClients{
@@ -1115,9 +1111,11 @@ func TestAzureFetcherGetInstancesWindowsUniformVMSS(t *testing.T) {
 	instances, err := fetcher.GetInstances(t.Context(), false)
 	require.NoError(t, err)
 
-	// The matched VM's scale-set name must be passed to the NIC client under
-	// the lower-cased resource group.
-	require.Equal(t, map[string][]string{"rg1": {scaleSetName}}, nicClient.gotScaleSetNamesByRG)
+	// A single subscription-wide NIC listing, carrying the full resource ID of
+	// the matched VM's scale set so the client can list uniform VMSS NICs,
+	// which are absent from the flat NIC list.
+	require.Equal(t, []string{types.Wildcard}, nicClient.gotResourceGroups)
+	require.Equal(t, []string{scaleSetID}, nicClient.gotScaleSetIDs)
 
 	// The scale-set VM is discovered with the private IP joined from its NIC.
 	require.Len(t, instances, 1)

--- a/lib/srv/server/azure_watcher_test.go
+++ b/lib/srv/server/azure_watcher_test.go
@@ -36,7 +36,6 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/installers"
 	"github.com/gravitational/teleport/lib/cloud/azure"
-	"github.com/gravitational/teleport/lib/cloud/azure/network"
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
@@ -44,7 +43,8 @@ import (
 type mockClients struct {
 	azure.Clients
 
-	vmClients map[string]azure.VirtualMachinesClient
+	vmClients  map[string]azure.VirtualMachinesClient
+	nicClients map[string]azure.NetworkInterfacesClient
 }
 
 func (c *mockClients) GetVirtualMachinesClient(ctx context.Context, subscription string) (azure.VirtualMachinesClient, error) {
@@ -53,6 +53,14 @@ func (c *mockClients) GetVirtualMachinesClient(ctx context.Context, subscription
 		return nil, trace.NotFound("subscription %s not found", subscription)
 	}
 	return vmClient, nil
+}
+
+func (c *mockClients) GetNetworkInterfacesClient(ctx context.Context, subscription string) (azure.NetworkInterfacesClient, error) {
+	nicClient, ok := c.nicClients[subscription]
+	if !ok {
+		return nil, trace.NotFound("subscription %s not found", subscription)
+	}
+	return nicClient, nil
 }
 
 func TestAzureWatcher(t *testing.T) {
@@ -770,43 +778,71 @@ func TestPrimaryPrivateIP(t *testing.T) {
 
 	for _, tc := range []struct {
 		name string
-		nics []*network.Interface
+		nics []*azure.NetworkInterface
 		want string
 	}{
 		{name: "no NICs", nics: nil, want: ""},
 		{
-			name: "single primary NIC",
-			nics: []*network.Interface{{PrivateIP: "10.0.0.1", Primary: true}},
+			name: "single primary NIC with primary IP config",
+			nics: []*azure.NetworkInterface{{
+				Primary:          true,
+				IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.1", Primary: true}},
+			}},
 			want: "10.0.0.1",
 		},
 		{
 			name: "prefers the primary NIC over the first one",
-			nics: []*network.Interface{
-				{PrivateIP: "10.0.0.9"},
-				{PrivateIP: "10.0.0.1", Primary: true},
+			nics: []*azure.NetworkInterface{
+				{IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.9", Primary: true}}},
+				{Primary: true, IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.1", Primary: true}}},
 			},
 			want: "10.0.0.1",
 		},
 		{
-			name: "falls back to the first usable IP when none is primary",
-			nics: []*network.Interface{
-				{PrivateIP: ""},
-				{PrivateIP: "10.0.0.5"},
-				{PrivateIP: "10.0.0.6"},
+			name: "prefers the primary IP config on the primary NIC",
+			nics: []*azure.NetworkInterface{{
+				Primary: true,
+				IPConfigurations: []azure.IPConfiguration{
+					{PrivateIP: "10.0.0.9"},
+					{PrivateIP: "10.0.0.1", Primary: true},
+				},
+			}},
+			want: "10.0.0.1",
+		},
+		{
+			name: "prefers a non-primary IP config on the primary NIC over other NICs",
+			nics: []*azure.NetworkInterface{
+				{IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.9"}}},
+				{Primary: true, IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.1"}}},
+			},
+			want: "10.0.0.1",
+		},
+		{
+			name: "falls back to the first usable IP when no NIC is primary",
+			nics: []*azure.NetworkInterface{
+				{IPConfigurations: []azure.IPConfiguration{{PrivateIP: ""}}},
+				{IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.5"}}},
+				{IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.6"}}},
 			},
 			want: "10.0.0.5",
 		},
 		{
-			name: "skips NICs without an IP before the primary",
-			nics: []*network.Interface{
-				{PrivateIP: ""},
-				{PrivateIP: "10.0.0.7", Primary: true},
-			},
-			want: "10.0.0.7",
+			name: "skips CIDR-notation IPs",
+			nics: []*azure.NetworkInterface{{
+				Primary: true,
+				IPConfigurations: []azure.IPConfiguration{
+					{PrivateIP: "10.0.1.4/24"},
+					{PrivateIP: "10.0.0.4"},
+				},
+			}},
+			want: "10.0.0.4",
 		},
 		{
-			name: "returns empty when no NIC has an IP",
-			nics: []*network.Interface{{PrivateIP: ""}, {PrivateIP: ""}},
+			name: "returns empty when no NIC has a usable IP",
+			nics: []*azure.NetworkInterface{
+				{IPConfigurations: []azure.IPConfiguration{{PrivateIP: ""}}},
+				{Primary: true, IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.7/16", Primary: true}}},
+			},
 			want: "",
 		},
 	} {
@@ -816,25 +852,25 @@ func TestPrimaryPrivateIP(t *testing.T) {
 	}
 }
 
-// fakeInterfacesClient is a network.InterfacesClient that returns canned NICs,
-// used to drive the Windows VM discovery path without real Azure API calls.
-type fakeInterfacesClient struct {
-	nicsByVM map[string][]*network.Interface
+// fakeNetworkInterfacesClient is an azure.NetworkInterfacesClient that returns
+// canned NICs per resource group, used to drive the Windows VM discovery path
+// without real Azure API calls.
+type fakeNetworkInterfacesClient struct {
+	nicsByRG map[string][]*azure.NetworkInterface
 	listErr  error
 }
 
-func (f *fakeInterfacesClient) Get(context.Context, string) (*network.Interface, error) {
-	return nil, trace.NotImplemented("Get not implemented in fake")
-}
-
-func (f *fakeInterfacesClient) List(context.Context, string, string) (map[string][]*network.Interface, error) {
+func (f *fakeNetworkInterfacesClient) ListNetworkInterfaces(_ context.Context, resourceGroup string, _ []string) ([]*azure.NetworkInterface, error) {
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
-	return f.nicsByVM, nil
+	if resourceGroup == types.Wildcard {
+		return nil, trace.BadParameter("wildcard resource group names are not supported")
+	}
+	return f.nicsByRG[resourceGroup], nil
 }
 
-func windowsVMFetcher(t *testing.T, clients azure.Clients, nicGetter networkInterfacesClientGetter, regions []string) *azureInstanceFetcher {
+func windowsVMFetcher(t *testing.T, clients azure.Clients, regions []string) *azureInstanceFetcher {
 	t.Helper()
 	const (
 		sub = "00000000-0000-0000-0000-000000000000"
@@ -852,8 +888,7 @@ func windowsVMFetcher(t *testing.T, clients azure.Clients, nicGetter networkInte
 		AzureClientGetter: func(context.Context, string) (azure.Clients, error) {
 			return clients, nil
 		},
-		NetworkInterfacesClientGetter: nicGetter,
-		Logger:                        logtest.NewLogger(),
+		Logger: logtest.NewLogger(),
 	})
 }
 
@@ -915,25 +950,47 @@ func windowsVMClients(t *testing.T) (*mockClients, map[string]string) {
 func TestAzureFetcherGetInstancesWindows(t *testing.T) {
 	t.Parallel()
 
+	const sub = "00000000-0000-0000-0000-000000000000"
+
 	clients, ids := windowsVMClients(t)
 
-	// NICs are keyed by the lower-cased VM resource ID, as the real network
-	// interfaces client returns them.
-	nicsByVM := map[string][]*network.Interface{
-		strings.ToLower(ids["winvm1"]): {{PrivateIP: "10.0.0.1", Primary: true}},
-		strings.ToLower(ids["winvm2"]): {
-			{PrivateIP: "10.0.0.99"},
-			{PrivateIP: "10.0.0.2", Primary: true},
+	// NICs reference their VM via AttachedVMID. winvm1 uses an upper-cased ID to
+	// verify the case-insensitive join between compute and network resource IDs.
+	clients.nicClients = map[string]azure.NetworkInterfacesClient{
+		sub: &fakeNetworkInterfacesClient{
+			nicsByRG: map[string][]*azure.NetworkInterface{
+				"rg1": {
+					{
+						AttachedVMID:     strings.ToUpper(ids["winvm1"]),
+						Primary:          true,
+						IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.1", Primary: true}},
+					},
+					// winvm2 has two NICs; the non-primary one comes first to
+					// verify the primary NIC's IP is preferred.
+					{
+						AttachedVMID:     ids["winvm2"],
+						IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.99"}},
+					},
+					{
+						AttachedVMID:     ids["winvm2"],
+						Primary:          true,
+						IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.2", Primary: true}},
+					},
+					{
+						AttachedVMID:     ids["unknownvm"],
+						Primary:          true,
+						IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.3", Primary: true}},
+					},
+					// A NIC not attached to any VM must not affect the results.
+					{
+						IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.50", Primary: true}},
+					},
+				},
+			},
 		},
-		strings.ToLower(ids["unknownvm"]): {{PrivateIP: "10.0.0.3", Primary: true}},
 	}
 
-	fetcher := windowsVMFetcher(t, clients,
-		func(context.Context, azure.Clients) (network.InterfacesClient, error) {
-			return &fakeInterfacesClient{nicsByVM: nicsByVM}, nil
-		},
-		[]string{"eastus"},
-	)
+	fetcher := windowsVMFetcher(t, clients, []string{"eastus"})
 
 	instances, err := fetcher.GetInstances(t.Context(), false)
 	require.NoError(t, err)
@@ -955,6 +1012,24 @@ func TestAzureFetcherGetInstancesWindows(t *testing.T) {
 		"winvm2":    "10.0.0.2",
 		"unknownvm": "10.0.0.3",
 	}, gotIPByName)
+}
+
+func TestAzureFetcherGetInstancesWindowsNICListError(t *testing.T) {
+	t.Parallel()
+
+	const sub = "00000000-0000-0000-0000-000000000000"
+
+	clients, _ := windowsVMClients(t)
+	clients.nicClients = map[string]azure.NetworkInterfacesClient{
+		sub: &fakeNetworkInterfacesClient{listErr: trace.AccessDenied("no network access")},
+	}
+
+	fetcher := windowsVMFetcher(t, clients, []string{"eastus"})
+
+	// A NIC listing failure must fail the whole fetch rather than silently
+	// discovering Windows VMs without private IPs.
+	_, err := fetcher.GetInstances(t.Context(), false)
+	require.ErrorContains(t, err, "no network access")
 }
 
 func TestMatchersToAzureInstanceFetchersMatcherTypes(t *testing.T) {

--- a/lib/srv/server/azure_watcher_test.go
+++ b/lib/srv/server/azure_watcher_test.go
@@ -19,10 +19,8 @@
 package server
 
 import (
-	"cmp"
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -767,28 +765,6 @@ func TestMakeUsageEvent(t *testing.T) {
 	}
 }
 
-func TestNewAzureInstanceFetcherMatcherType(t *testing.T) {
-	t.Parallel()
-
-	for _, tc := range []struct {
-		name  string
-		types []string
-		want  string
-	}{
-		{name: "vm", types: []string{types.AzureMatcherVM}, want: types.AzureMatcherVM},
-		{name: "windows-vm", types: []string{types.AzureMatcherWindowsVM}, want: types.AzureMatcherWindowsVM},
-		{name: "combined prefers vm", types: []string{types.AzureMatcherVM, types.AzureMatcherWindowsVM}, want: types.AzureMatcherVM},
-		{name: "empty defaults to vm", types: nil, want: types.AzureMatcherVM},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			f := newAzureInstanceFetcher(azureFetcherConfig{
-				Matcher: types.AzureMatcher{Types: tc.types},
-			})
-			require.Equal(t, tc.want, f.MatcherType)
-		})
-	}
-}
-
 func TestPrimaryPrivateIP(t *testing.T) {
 	t.Parallel()
 
@@ -858,7 +834,7 @@ func (f *fakeInterfacesClient) List(context.Context, string, string) (map[string
 	return f.nicsByVM, nil
 }
 
-func windowsVMFetcher(t *testing.T, clients azure.Clients, nicGetter interfacesClientGetter, regions []string) *azureInstanceFetcher {
+func windowsVMFetcher(t *testing.T, clients azure.Clients, nicGetter networkInterfacesClientGetter, regions []string) *azureInstanceFetcher {
 	t.Helper()
 	const (
 		sub = "00000000-0000-0000-0000-000000000000"
@@ -870,13 +846,14 @@ func windowsVMFetcher(t *testing.T, clients azure.Clients, nicGetter interfacesC
 			Regions:      regions,
 			ResourceTags: types.Labels{"*": []string{"*"}},
 		},
+		MatcherType:   types.AzureMatcherWindowsVM,
 		Subscription:  sub,
 		ResourceGroup: rg,
 		AzureClientGetter: func(context.Context, string) (azure.Clients, error) {
 			return clients, nil
 		},
-		InterfacesClientGetter: nicGetter,
-		Logger:                 logtest.NewLogger(),
+		NetworkInterfacesClientGetter: nicGetter,
+		Logger:                        logtest.NewLogger(),
 	})
 }
 
@@ -980,72 +957,25 @@ func TestAzureFetcherGetInstancesWindows(t *testing.T) {
 	}, gotIPByName)
 }
 
-// TestAzureFetcherGetInstancesWindowsLive exercises the full Windows VM discovery
-// path — listing VMs and resolving each VM's private IP from its NIC — against a
-// real Azure subscription. It is skipped unless TELEPORT_TEST_AZURE is set. No
-// fakes are injected, so it builds and calls the real virtual machines and
-// network interfaces clients.
-//
-// Prerequisites:
-//   - Authenticate so DefaultAzureCredential can find a credential, e.g. run
-//     `az login`, or set AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET.
-//     The identity needs Microsoft.Compute/virtualMachines/read and
-//     Microsoft.Network/networkInterfaces/read on the target resources.
-//   - Set AZURE_SUBSCRIPTION_ID to a subscription that has at least one Windows VM.
-//   - Optionally set AZURE_RESOURCE_GROUP and AZURE_REGION to narrow the search;
-//     both default to the wildcard (whole subscription / all regions).
-//
-// Run with:
-//
-//	TELEPORT_TEST_AZURE=1 \
-//	AZURE_SUBSCRIPTION_ID=<sub> \
-//	AZURE_RESOURCE_GROUP=<rg> \
-//	AZURE_REGION=<region> \
-//	go test ./lib/srv/server/ -run TestAzureFetcherGetInstancesWindowsLive -v
-func TestAzureFetcherGetInstancesWindowsLive(t *testing.T) {
-	if os.Getenv("TELEPORT_TEST_AZURE") == "" {
-		t.Skip("Set TELEPORT_TEST_AZURE to run this test against a real Azure subscription.")
+func TestMatchersToAzureInstanceFetchersMatcherTypes(t *testing.T) {
+	t.Parallel()
+
+	fetchers := MatchersToAzureInstanceFetchers(
+		t.Context(),
+		logtest.NewLogger(),
+		[]types.AzureMatcher{{
+			Types:          []string{types.AzureMatcherVM, types.AzureMatcherWindowsVM},
+			Subscriptions:  []string{"sub1"},
+			ResourceGroups: []string{"rg1"},
+		}},
+		nil,
+		"",
+		nil,
+	)
+
+	var matcherTypes []string
+	for _, fetcher := range fetchers {
+		matcherTypes = append(matcherTypes, fetcher.(*azureInstanceFetcher).MatcherType)
 	}
-	subscription := os.Getenv("AZURE_SUBSCRIPTION_ID")
-	if subscription == "" {
-		t.Skip("Set AZURE_SUBSCRIPTION_ID to the subscription to search for Windows VMs.")
-	}
-	resourceGroup := cmp.Or(os.Getenv("AZURE_RESOURCE_GROUP"), types.Wildcard)
-	region := cmp.Or(os.Getenv("AZURE_REGION"), types.Wildcard)
-
-	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
-	defer cancel()
-
-	clients, err := azure.NewClients()
-	require.NoError(t, err, "failed to build Azure clients, have you run `az login`?")
-
-	fetcher := newAzureInstanceFetcher(azureFetcherConfig{
-		Matcher: types.AzureMatcher{
-			Types:        []string{types.AzureMatcherWindowsVM},
-			Regions:      []string{region},
-			ResourceTags: types.Labels{"*": []string{"*"}},
-		},
-		Subscription:  subscription,
-		ResourceGroup: resourceGroup,
-		AzureClientGetter: func(context.Context, string) (azure.Clients, error) {
-			return clients, nil
-		},
-		// InterfacesClientGetter is intentionally left unset so the fetcher builds
-		// and uses the real Azure network interfaces client.
-		Logger: logtest.NewLogger(),
-	})
-
-	instances, err := fetcher.GetInstances(ctx, false)
-	require.NoError(t, err)
-
-	var total int
-	for _, group := range instances {
-		for _, vm := range group.Instances {
-			total++
-			t.Logf("Windows VM %q (region=%q, resourceGroup=%q, vmID=%q): private IP=%q",
-				vm.Name, vm.Location, vm.ResourceGroup, vm.VMID, vm.PrimaryPrivateIP)
-		}
-	}
-	t.Logf("Discovered %d Windows VM(s) in subscription %q (resourceGroup=%q, region=%q)",
-		total, subscription, resourceGroup, region)
+	require.ElementsMatch(t, []string{types.AzureMatcherVM, types.AzureMatcherWindowsVM}, matcherTypes)
 }

--- a/lib/srv/server/azure_watcher_test.go
+++ b/lib/srv/server/azure_watcher_test.go
@@ -845,6 +845,24 @@ func TestPrimaryPrivateIP(t *testing.T) {
 			},
 			want: "",
 		},
+		{
+			name: "prefers the primary IP config when the NIC primary flag is unset",
+			nics: []*azure.NetworkInterface{{
+				IPConfigurations: []azure.IPConfiguration{
+					{PrivateIP: "10.0.0.9"},
+					{PrivateIP: "10.0.0.1", Primary: true},
+				},
+			}},
+			want: "10.0.0.1",
+		},
+		{
+			name: "prefers any IP on the primary NIC over a primary config on another NIC",
+			nics: []*azure.NetworkInterface{
+				{IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.9", Primary: true}}},
+				{Primary: true, IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.1"}}},
+			},
+			want: "10.0.0.1",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.want, primaryPrivateIP(tc.nics))
@@ -858,14 +876,20 @@ func TestPrimaryPrivateIP(t *testing.T) {
 type fakeNetworkInterfacesClient struct {
 	nicsByRG map[string][]*azure.NetworkInterface
 	listErr  error
+	// gotScaleSetNamesByRG records the scale-set names passed to
+	// ListNetworkInterfaces, keyed by the resource group argument.
+	gotScaleSetNamesByRG map[string][]string
 }
 
-func (f *fakeNetworkInterfacesClient) ListNetworkInterfaces(_ context.Context, resourceGroup string, _ []string) ([]*azure.NetworkInterface, error) {
+func (f *fakeNetworkInterfacesClient) ListNetworkInterfaces(_ context.Context, resourceGroup string, scaleSetNames []string) ([]*azure.NetworkInterface, error) {
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
-	if resourceGroup == types.Wildcard {
-		return nil, trace.BadParameter("wildcard resource group names are not supported")
+	if len(scaleSetNames) > 0 {
+		if f.gotScaleSetNamesByRG == nil {
+			f.gotScaleSetNamesByRG = make(map[string][]string)
+		}
+		f.gotScaleSetNamesByRG[resourceGroup] = append(f.gotScaleSetNamesByRG[resourceGroup], scaleSetNames...)
 	}
 	return f.nicsByRG[resourceGroup], nil
 }
@@ -1030,6 +1054,77 @@ func TestAzureFetcherGetInstancesWindowsNICListError(t *testing.T) {
 	// discovering Windows VMs without private IPs.
 	_, err := fetcher.GetInstances(t.Context(), false)
 	require.ErrorContains(t, err, "no network access")
+}
+
+func TestAzureFetcherGetInstancesWindowsUniformVMSS(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sub          = "00000000-0000-0000-0000-000000000000"
+		scaleSetName = "scaleset1"
+	)
+	windowsOS := armcompute.OperatingSystemTypesWindows
+
+	// Mixed case to test that the ID is compared case-insensitively
+	scaleSetID := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/RG1/providers/Microsoft.Compute/virtualMachineScaleSets/%s",
+		sub, scaleSetName,
+	)
+	vmssVMID := scaleSetID + "/virtualMachines/0"
+
+	vmClient := azure.NewVirtualMachinesClientByAPI(azure.VirtualMachinesClientConfig{
+		VirtualMachineAPI: &azure.ARMComputeMock{},
+		ScaleSetsAPI: &azure.ARMScaleSetsMock{
+			ScaleSetRecords: []*armcompute.VirtualMachineScaleSet{{
+				ID:   to.Ptr(scaleSetID),
+				Name: to.Ptr(scaleSetName),
+			}},
+		},
+		ScaleSetVMsAPI: &azure.ARMScaleSetVMsMock{
+			GetResult: armcompute.VirtualMachineScaleSetVM{
+				ID:         to.Ptr(vmssVMID),
+				Name:       to.Ptr(scaleSetName + "_0"),
+				InstanceID: to.Ptr("0"),
+				Location:   to.Ptr("eastus"),
+				Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+					StorageProfile: &armcompute.StorageProfile{
+						OSDisk: &armcompute.OSDisk{OSType: &windowsOS},
+					},
+				},
+			},
+		},
+	})
+
+	nicClient := &fakeNetworkInterfacesClient{
+		nicsByRG: map[string][]*azure.NetworkInterface{
+			"rg1": {{
+				AttachedVMID:     vmssVMID,
+				Primary:          true,
+				IPConfigurations: []azure.IPConfiguration{{PrivateIP: "10.0.0.42", Primary: true}},
+			}},
+		},
+	}
+
+	clients := &mockClients{
+		vmClients:  map[string]azure.VirtualMachinesClient{sub: vmClient},
+		nicClients: map[string]azure.NetworkInterfacesClient{sub: nicClient},
+	}
+
+	fetcher := windowsVMFetcher(t, clients, []string{"eastus"})
+
+	instances, err := fetcher.GetInstances(t.Context(), false)
+	require.NoError(t, err)
+
+	// The matched VM's scale-set name must be passed to the NIC client under
+	// the lower-cased resource group.
+	require.Equal(t, map[string][]string{"rg1": {scaleSetName}}, nicClient.gotScaleSetNamesByRG)
+
+	// The scale-set VM is discovered with the private IP joined from its NIC.
+	require.Len(t, instances, 1)
+	require.Len(t, instances[0].Instances, 1)
+	vm := instances[0].Instances[0]
+	require.Equal(t, scaleSetName, vm.UniformScaleSetName)
+	require.Equal(t, "10.0.0.42", vm.PrimaryPrivateIP)
 }
 
 func TestMatchersToAzureInstanceFetchersMatcherTypes(t *testing.T) {


### PR DESCRIPTION
This PR adds the discovery/listing layer for Azure Windows VMs. It introduces a new `windows-vm` Azure matcher type and adds to the existing Azure instance fetcher the ability to discover Windows VMs and resolve each one's primary private IP. The IP is needed to register `dynamic_windows_desktop`s which will be coming in future PRs.

This work is part of the larger goal of allowing discovery of non-AD Windows desktops on Azure. Issue [here](https://github.com/gravitational/teleport/issues/68240). RFD [here](https://github.com/gravitational/rfd/pull/17).

## Manual Test Plan
### Test Environment
Added Live test to run the full path against a real Azure subscription. Live test command (to be ran after `az login`):
```
TELEPORT_TEST_AZURE=1 AZURE_SUBSCRIPTION_ID="<sub-id>" \
go test ./lib/srv/server/ -run TestAzureFetcherGetInstancesWindowsLive -v
```
### Test Cases
- [x] Live test successfully lists Windows VMs and their primary private IP address
