### PR TITLE
Try to avoid capturing stack traces when checking system roles

### DIFF
--- a/api/types/system_role.go
+++ b/api/types/system_role.go
@@ -304,17 +304,19 @@ func (r SystemRole) String() string {
 	}
 }
 
-// Check checks if this a a valid teleport role value, returns nil
-// if it's ok, false otherwise
-// Check checks if this a a valid teleport role value, returns nil
-// if it's ok, false otherwise
-func (r SystemRole) Check() error {
+// IsValid returns true if this is a valid Teleport system role.
+func (r SystemRole) IsValid() bool {
 	sr, ok := roleMappings[strings.ToLower(string(r))]
-	if ok && string(r) == string(sr) {
-		return nil
-	}
+	return ok && r == sr
+}
 
-	return trace.BadParameter("role %v is not registered", r)
+// Check checks if this a valid Teleport system role, returning an error
+// otherwise.
+func (r SystemRole) Check() error {
+	if !r.IsValid() {
+		return trace.BadParameter("role %+q is not a valid system role", r)
+	}
+	return nil
 }
 
 // IsLocalService checks if the given system role is a teleport service (e.g. auth),

--- a/api/types/system_role.go
+++ b/api/types/system_role.go
@@ -202,15 +202,15 @@ func NewTeleportRoles(in []string) (SystemRoles, error) {
 // of teleport roles, or an error if parsing failed
 func ParseTeleportRoles(str string) (SystemRoles, error) {
 	var roles SystemRoles
-	for _, s := range strings.Split(str, ",") {
-		if r := normalizedSystemRole(s); r.Check() == nil {
+	for s := range strings.SplitSeq(str, ",") {
+		if r := normalizedSystemRole(s); r.IsValid() {
 			roles = append(roles, r)
 			continue
 		}
-		return nil, trace.BadParameter("invalid role %q", s)
+		return nil, trace.BadParameter("invalid role %+q", s)
 	}
 	if len(roles) == 0 {
-		return nil, trace.BadParameter("no valid roles in $%q", str)
+		return nil, trace.BadParameter("no valid roles in %+q", str)
 	}
 
 	return roles, roles.Check()

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -5431,7 +5431,7 @@ func (a *Server) GenerateHostCerts(ctx context.Context, params HostCertsParams) 
 	}
 
 	if err := req.Role.Check(); err != nil {
-		return nil, err
+		return nil, trace.Wrap(err)
 	}
 
 	if err := a.limiter.AcquireConnection(req.Role.String()); err != nil {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -810,11 +810,11 @@ func (a *ScopedServerWithRoles) checkAdditionalSystemRoles(ctx context.Context, 
 	// check that additional system roles are theoretically valid (distinct from permissibility, which
 	// is checked in the following loop).
 	for _, r := range req.SystemRoles {
-		if r.Check() != nil {
-			return trace.AccessDenied("additional system role %q cannot be applied (not a valid system role)", r)
+		if !r.IsValid() {
+			return trace.AccessDenied("additional system role %+q cannot be applied (not a valid system role)", r)
 		}
 		if !r.IsLocalService() {
-			return trace.AccessDenied("additional system role %q cannot be applied (not a builtin service role)", r)
+			return trace.AccessDenied("additional system role %+q cannot be applied (not a builtin service role)", r)
 		}
 	}
 
@@ -831,7 +831,7 @@ func (a *ScopedServerWithRoles) checkAdditionalSystemRoles(ctx context.Context, 
 				"instance", req.HostID,
 				"error", err,
 			)
-			return trace.AccessDenied("failed to load system role assertion set with ID %q", req.SystemRoleAssertionID)
+			return trace.AccessDenied("failed to load system role assertion set with ID %+q", req.SystemRoleAssertionID)
 		}
 	}
 
@@ -850,7 +850,7 @@ Outer:
 			}
 		}
 
-		return trace.AccessDenied("additional system role %q cannot be applied (not authorized)", requestedRole)
+		return trace.AccessDenied("additional system role %+q cannot be applied (not authorized)", requestedRole)
 	}
 
 	return nil

--- a/lib/auth/client_tls_config_generator.go
+++ b/lib/auth/client_tls_config_generator.go
@@ -99,15 +99,14 @@ type HostAndUserCAPoolInfo struct {
 func findPrimarySystemRole(i *tlsca.Identity) (types.SystemRole, bool) {
 	if i.ScopePin.GetKind() == scopesv1.PinKind_PIN_KIND_AGENT {
 		role := types.SystemRole(i.ScopePin.GetSystemRoles().GetPrimary())
-		if err := role.Check(); err != nil {
+		if !role.IsValid() {
 			return "", false
 		}
 		return role, true
 	}
 	for _, role := range i.Groups {
 		systemRole := types.SystemRole(role)
-		err := systemRole.Check()
-		if err == nil {
+		if systemRole.IsValid() {
 			return systemRole, true
 		}
 	}

--- a/lib/authz/middleware.go
+++ b/lib/authz/middleware.go
@@ -313,8 +313,7 @@ func extractAdditionalSystemRoles(ctx context.Context, roles []string) types.Sys
 	var systemRoles types.SystemRoles
 	for _, role := range roles {
 		systemRole := types.SystemRole(role)
-		err := systemRole.Check()
-		if err != nil {
+		if !systemRole.IsValid() {
 			// ignore unknown system roles rather than rejecting them, since new unknown system
 			// roles may be present on certs if we rolled back from a newer version.
 			logger.WarnContext(ctx, "Ignoring unknown system role", "unknown_role", role)
@@ -328,8 +327,7 @@ func extractAdditionalSystemRoles(ctx context.Context, roles []string) types.Sys
 func findPrimarySystemRole(roles []string) *types.SystemRole {
 	for _, role := range roles {
 		systemRole := types.SystemRole(role)
-		err := systemRole.Check()
-		if err == nil {
+		if systemRole.IsValid() {
 			return &systemRole
 		}
 	}

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -237,11 +237,8 @@ func RoleForCertAuthority(ca types.CertAuthority) types.Role {
 // ValidateRoleName checks that the role name is allowed to be created.
 func ValidateRoleName(role types.Role) error {
 	// System role names are not allowed.
-	systemRoles := types.SystemRoles([]types.SystemRole{
-		types.SystemRole(role.GetMetadata().Name),
-	})
-	if err := systemRoles.Check(); err == nil {
-		return trace.BadParameter("reserved role: %s", role.GetMetadata().Name)
+	if types.SystemRole(role.GetMetadata().Name).IsValid() {
+		return trace.BadParameter("reserved role: %+q", role.GetMetadata().Name)
 	}
 	return nil
 }

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -1657,7 +1657,7 @@ func TestValidateRoleName(t *testing.T) {
 			name:         "reserved role name proxy",
 			roleName:     string(types.RoleProxy),
 			err:          trace.BadParameter(""),
-			matchMessage: fmt.Sprintf("reserved role: %s", types.RoleProxy),
+			matchMessage: "reserved role: \"Proxy\"",
 		},
 		{
 			name:     "valid role name test-1",

--- a/lib/utils/roles_test.go
+++ b/lib/utils/roles_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -50,12 +51,16 @@ func TestBadRoles(t *testing.T) {
 	t.Parallel()
 
 	bad := types.SystemRole("bad-role")
-	require.ErrorContains(t, bad.Check(), "role bad-role is not registered")
+	err := bad.Check()
+	require.ErrorAs(t, err, new(*trace.BadParameterError))
+	require.ErrorContains(t, err, "role \"bad-role\" is not a valid system role")
 	badRoles := types.SystemRoles{
 		bad,
 		types.RoleAdmin,
 	}
-	require.ErrorContains(t, badRoles.Check(), "role bad-role is not registered")
+	err = badRoles.Check()
+	require.ErrorAs(t, err, new(*trace.BadParameterError))
+	require.ErrorContains(t, err, "role \"bad-role\" is not a valid system role")
 }
 
 func TestEquivalence(t *testing.T) {


### PR DESCRIPTION
This PR adds a method to check if a `types.SystemRole` is valid without returning a stack trace-capturing error that is just immediately discarded in a lot of places. This is actually noticeable in Kubernetes access when a user has a lot of roles, because `(*lib/authz.Middleware).extractIdentityFromImpersonationHeader` currently calls `(types.SystemRole).Check` on all the roles of the impersonated user to reject impersonation of system roles. With 1000 roles (which is, admittedly, excessive for many other reasons) and simple Kube api queries, the stack trace capturing ends up costing something like 8% of the CPU time spent handling the request, which is quite significant.