### PR TITLE
docs: add skills page and banners

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -691,6 +691,7 @@
     "libpq",
     "lifecycle",
     "livez",
+    "llms",
     "lmnop",
     "loadbalancer",
     "localca",

--- a/docs/pages/get-started/agent-skills.mdx
+++ b/docs/pages/get-started/agent-skills.mdx
@@ -1,0 +1,17 @@
+---
+title: Agent Skills for Teleport
+description: Install reusable skills for common Teleport operations.
+tags:
+  - get-started
+page_type: how-to
+sidebar_label: Agent Skills
+---
+
+Skills help AI agents work more effectively with Teleport by providing task-specific instructions and 
+recommended workflows for common operations such as infrastructure access, resource enrollment, access 
+requests, and identity management. Rather than relying solely on general knowledge, agents can follow 
+guidance tailored to Teleport workflows and resources.
+
+<SkillsTable>
+  ## Available skills
+</SkillsTable>

--- a/docs/pages/identity-governance/access-lists/guide.mdx
+++ b/docs/pages/identity-governance/access-lists/guide.mdx
@@ -8,6 +8,8 @@ tags:
  - privileged-access
 enterprise: Identity Governance
 page_type: how-to
+skills:
+  - teleport-acl-review
 ---
 
 {/* lint disable page-structure remark-lint */}
@@ -21,6 +23,8 @@ In this guide, you will use the Teleport Web UI to:
 If you'd rather manage Access Lists as code, follow the
 [Access Lists with Terraform and Kubernetes Operator](../../configuration/resource-guides/access-list.mdx)
 guide instead.
+
+<SkillsBanner />
 
 ## Prerequisites
 

--- a/docs/pages/identity-security/session-summaries/session-summaries.mdx
+++ b/docs/pages/identity-security/session-summaries/session-summaries.mdx
@@ -11,12 +11,16 @@ tags:
   - ai
 enterprise: Identity Security
 page_type: how-to
+skills:
+  - teleport-session-review
 ---
 
 Teleport Identity Security allows you to generate and view session recording
 summaries for shell and database sessions. This allows you to see at a glance
 what your users do and estimate legitimacy of their actions before digging
 deeper and reviewing the entire recording.
+
+<SkillsBanner />
 
 In this guide, you will configure session recording summaries for your cluster.
 

--- a/docs/pages/identity-security/usage/investigate.mdx
+++ b/docs/pages/identity-security/usage/investigate.mdx
@@ -7,7 +7,11 @@ tags:
  - access-risks
  - conceptual
 enterprise: Identity Security
+skills:
+  - teleport-investigate
 ---
+
+<SkillsBanner />
 
 The Investigate dashboard provides an overview of recent identity activity
 across your infrastructure, helping you investigate security risks and

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -49,6 +49,12 @@
               "type": "doc",
               "id": "get-started/audit",
               "label": "Step 4: Monitor Audit Logs"
+            },
+            {
+              "type": "doc",
+              "id": "get-started/agent-skills",
+              "label": "Agent Skills",
+              "customProps": { "tag": "new" }
             }
           ]
         },


### PR DESCRIPTION
This commit adds a new docs skills page, under `/get-started/` listing available skills, benefits, and usages. 

It also adds a new skills banner on applicable pages where skills can be used, see preview links below.
