### PR TITLE
[v18] fix: stop following SAML entity descriptor URL while fetching user SSO MFA device

### DIFF
--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -1471,7 +1471,8 @@ func (s *IdentityService) getSSOMFADevice(ctx context.Context, user string) (*ty
 		return nil, trace.BadParameter("missing parameter user")
 	}
 
-	u, err := s.GetUser(ctx, user, false /* withSecrets */)
+	const withSecrets = false
+	u, err := s.GetUser(ctx, user, withSecrets)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1492,9 +1493,9 @@ func (s *IdentityService) getSSOMFADevice(ctx context.Context, user string) (*ty
 		// Using NoFollowURLs below because getSSOMFADevice only needs connector ID, display and type
 		// to determine if the user has an SSO MFA device.
 		// The URL is followed during connector write and SSO MFA ceremony paths.
-		mfaConnector, err = s.GetSAMLConnectorWithValidationOptions(ctx, cb.Connector.ID, false /* withSecrets */, types.SAMLConnectorValidationFollowURLs(false))
+		mfaConnector, err = s.GetSAMLConnectorWithValidationOptions(ctx, cb.Connector.ID, withSecrets, types.SAMLConnectorValidationFollowURLs(false))
 	case constants.OIDC:
-		mfaConnector, err = s.GetOIDCConnector(ctx, cb.Connector.ID, false /* withSecrets */)
+		mfaConnector, err = s.GetOIDCConnector(ctx, cb.Connector.ID, withSecrets)
 	case constants.Github:
 		// Github connectors do not support SSO MFA.
 		return nil, trace.NotFound("%s", ssoMFADisabledErr)

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -1489,7 +1489,10 @@ func (s *IdentityService) getSSOMFADevice(ctx context.Context, user string) (*ty
 	const ssoMFADisabledErr = "no SSO MFA device found; user's auth connector does not have MFA enabled"
 	switch cb.Connector.Type {
 	case constants.SAML:
-		mfaConnector, err = s.GetSAMLConnector(ctx, cb.Connector.ID, false /* withSecrets */)
+		// Using NoFollowURLs below because getSSOMFADevice only needs connector ID, display and type
+		// to determine if the user has an SSO MFA device.
+		// The URL is followed during connector write and SSO MFA ceremony paths.
+		mfaConnector, err = s.GetSAMLConnectorWithValidationOptions(ctx, cb.Connector.ID, false /* withSecrets */, types.SAMLConnectorValidationFollowURLs(false))
 	case constants.OIDC:
 		mfaConnector, err = s.GetOIDCConnector(ctx, cb.Connector.ID, false /* withSecrets */)
 	case constants.Github:

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -25,8 +25,11 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -573,6 +576,20 @@ func TestIdentityService_GetMFADevices_SSO(t *testing.T) {
 	_, err = identity.UpsertSAMLConnector(ctx, samlConnector)
 	require.NoError(t, err)
 
+	var metadataRequests atomic.Int64
+	idpMetadataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		metadataRequests.Add(1)
+		_, err := w.Write([]byte(entityDescriptor))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(idpMetadataServer.Close)
+
+	samlConnectorWithMatchingSSOAndSSOMFAIdP := newSAMlConenctorWithEDURL(t, identity, "samlConnectorWithMatchingSSOAndSSOMFAIdP", idpMetadataServer.URL, idpMetadataServer.URL)
+	samlConnectorWithDifferentSSOAndSSOMFAIdP := newSAMlConenctorWithEDURL(t, identity, "samlConnectorWithDifferentSSOAndSSOMFAIdP", idpMetadataServer.URL, idpMetadataServer.URL+"/mfa")
+
+	// Reset so we can check the GetMFADevices does not call the endpoint.
+	metadataRequests.Store(0)
+
 	oidcConnector, err := types.NewOIDCConnector("oidc", types.OIDCConnectorSpecV3{
 		ClientID:     "12345",
 		ClientSecret: "678910",
@@ -619,6 +636,28 @@ func TestIdentityService_GetMFADevices_SSO(t *testing.T) {
 				DisplayName:   samlConnector.GetDisplay(),
 			},
 		}, {
+			name: "saml user, with entity descriptor URL, matching SSO and SSO MFA IdP URL",
+			connectorRef: &types.ConnectorRef{
+				Type: "saml",
+				ID:   samlConnectorWithMatchingSSOAndSSOMFAIdP.GetName(),
+			},
+			expectSSODevice: &types.SSOMFADevice{
+				ConnectorType: "saml",
+				ConnectorId:   samlConnectorWithMatchingSSOAndSSOMFAIdP.GetName(),
+				DisplayName:   samlConnectorWithMatchingSSOAndSSOMFAIdP.GetDisplay(),
+			},
+		}, {
+			name: "saml user, with entity descriptor URL, different SSO and SSO MFA IdP URL",
+			connectorRef: &types.ConnectorRef{
+				Type: "saml",
+				ID:   samlConnectorWithDifferentSSOAndSSOMFAIdP.GetName(),
+			},
+			expectSSODevice: &types.SSOMFADevice{
+				ConnectorType: "saml",
+				ConnectorId:   samlConnectorWithDifferentSSOAndSSOMFAIdP.GetName(),
+				DisplayName:   samlConnectorWithDifferentSSOAndSSOMFAIdP.GetDisplay(),
+			},
+		}, {
 			name: "oidc user",
 			connectorRef: &types.ConnectorRef{
 				Type: "oidc",
@@ -644,6 +683,8 @@ func TestIdentityService_GetMFADevices_SSO(t *testing.T) {
 
 			devs, err := identity.GetMFADevices(ctx, "alice", true /* withSecrets */)
 			require.NoError(t, err)
+			// Expected zero attempts to fetch the entity descriptor.
+			require.Zero(t, metadataRequests.Load())
 
 			if test.expectSSODevice == nil {
 				assert.Empty(t, devs)
@@ -1784,4 +1825,40 @@ func TestIdentityService_SSOMFASessionDataCRUD(t *testing.T) {
 	require.NoError(t, err)
 	_, err = identity.GetMFASessionData(ctx, sd.RequestID)
 	require.True(t, trace.IsNotFound(err))
+}
+
+const entityDescriptor = `
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="samlSSOIdP">
+  <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://localhost:65535/sso"/>
+  </md:IDPSSODescriptor>
+</md:EntityDescriptor>`
+
+// newSAMlConenctorWithEDURL returns a new SAML connector configured with Entity Descriptor URL.
+// It expects the endpoint configured in `samlEDURL` and `samlMFAEDURL` to serve a valid SAML metadata.
+func newSAMlConenctorWithEDURL(t *testing.T, idSvc *local.IdentityService, name, samlEDURL, samlMFAEDURL string) types.SAMLConnector {
+	t.Helper()
+
+	connector, err := types.NewSAMLConnector(name, types.SAMLConnectorSpecV2{
+		AssertionConsumerService: "https://localhost:65535/sso", // not called
+		EntityDescriptorURL:      samlEDURL,
+		AttributesToRoles: []types.AttributeMapping{
+			// not used. can be any name, value but role must exist
+			{Name: "groups", Value: "admin", Roles: []string{"access"}},
+		},
+		MFASettings: &types.SAMLConnectorMFASettings{
+			Enabled:             true,
+			EntityDescriptorUrl: samlMFAEDURL,
+		},
+	})
+	require.NoError(t, err)
+	upserted, err := idSvc.UpsertSAMLConnector(t.Context(), connector)
+	require.NoError(t, err)
+
+	// Check that entity descriptor was fetched and set, i.e. URL was followed in general connector validation path.
+	require.NotEmpty(t, upserted.GetEntityDescriptor())
+	require.NotNil(t, upserted.GetMFASettings())
+	require.NotEmpty(t, upserted.GetMFASettings().EntityDescriptor)
+
+	return upserted
 }

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -208,10 +208,11 @@ func ValidateSAMLConnector(sc types.SAMLConnector, rg RoleGetter, opts ...types.
 	// Validate MFA settings.
 	if mfa := sc.GetMFASettings(); mfa != nil {
 		if mfa.EntityDescriptorUrl != "" {
-			if mfa.EntityDescriptorUrl == sc.GetEntityDescriptorURL() {
+			switch {
+			case mfa.EntityDescriptorUrl == sc.GetEntityDescriptorURL():
 				// we got the entity descriptor above, skip the redundant round trip.
 				mfa.EntityDescriptor = sc.GetEntityDescriptor()
-			} else {
+			case !options.NoFollowURLs:
 				entityDescriptor, err := getEntityDescriptorFromURL(mfa.EntityDescriptorUrl)
 				if err != nil {
 					return trace.Wrap(err)


### PR DESCRIPTION
Backport #68717 to branch/v18

https://github.com/gravitational/teleport.e/issues/9100

## Manual Test Plan

### Test Environment

Teleport cluster with SAML connector set up.

### Test Cases
- [x] Regression test: Check `tsh mfa ls` works.
- [x] Regression test: Check user can add new MFA device from Web UI and `tsh`. 
- [x] Check weakest MFA device resolution works. SSO MFA device is not currently accounted for but the test verified resolution for WebAuthn and totp. 