### PR TITLE
Add utils to wait for a resource to enter/leave cache.

### DIFF
--- a/api/utils/retryutils/retry.go
+++ b/api/utils/retryutils/retry.go
@@ -223,6 +223,19 @@ func (e *permanentRetryError) Error() string {
 	return e.err.Error()
 }
 
+// Unwrap returns the original error.
+func (e *permanentRetryError) Unwrap() error {
+	return e.err
+}
+
+// IsPermanent returns true if the error is a permanent retry error.
+// Useful when testing functions used in the retry loop.
+func IsPermanent(err error) bool {
+	var permanentRetryError *permanentRetryError
+	ok := errors.As(err, &permanentRetryError)
+	return ok
+}
+
 // RetryStaticFor retries a function repeatedly for a set amount of
 // time before returning an error.
 //

--- a/api/utils/wait/until.go
+++ b/api/utils/wait/until.go
@@ -1,0 +1,196 @@
+// Copyright 2026 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wait
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/api/utils/retryutils"
+)
+
+const defaultMaxTries = 7
+
+type untilConfig struct {
+	retryConfig *retryutils.LinearConfig
+	maxTries    int
+}
+
+type UntilOpts func(*untilConfig)
+
+// WithRetryConfig sets a non-default retry configuration. Default is a linear retry with 100ms steps.
+func WithRetryConfig(retryConfig *retryutils.LinearConfig) UntilOpts {
+	return func(opts *untilConfig) {
+		opts.retryConfig = retryConfig
+	}
+}
+
+// WithMaxTries sets a non-default maximum number of tries. Default is 7.
+func WithMaxTries(maxTries int) UntilOpts {
+	return func(opts *untilConfig) {
+		opts.maxTries = maxTries
+	}
+}
+
+// Until runs the [get] function until the [check] function returns nil.
+// [check] returning an error will cause the function to retry later.
+// Early error exit can be performed by returning [retryutils.PermanentRetryError]
+// (e.g. in case of unexpected error).
+func Until[T any](
+	ctx context.Context,
+	get func(context.Context) (T, error),
+	check func(T, error) error,
+	opts ...UntilOpts,
+) (T, error) {
+	var resp T
+
+	// Apply options
+	config := new(untilConfig)
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	// Set defaults
+	if config.retryConfig == nil {
+		config.retryConfig = &retryutils.LinearConfig{
+			First:  0,
+			Step:   100 * time.Millisecond,
+			Max:    time.Second,
+			Jitter: retryutils.DefaultJitter,
+		}
+	}
+	if config.maxTries == 0 {
+		config.maxTries = defaultMaxTries
+	}
+
+	backoff, err := retryutils.NewLinear(*config.retryConfig)
+	if err != nil {
+		return resp, trace.Wrap(err, "building backoff, this is a bug")
+	}
+
+	var tries int
+
+	err = backoff.For(ctx, func() error {
+		tries += 1
+		resp, err = get(ctx)
+		checkErr := check(resp, err)
+		if checkErr != nil && tries >= config.maxTries {
+			// Too many tries, and the last one failed, stop now.
+			return retryutils.PermanentRetryError(checkErr)
+		}
+		return checkErr
+	})
+	return resp, trace.Wrap(err)
+}
+
+// UntilFound runs a command until it stops returning a [trace.NotFoundErr].
+// This allows clients to wait for a resource to be created and in cache.
+// This is required to avoid races for new cached resources not falling back to
+// backend in case of cache miss.
+//
+// IMPORTANT: this function only guarantees that the Auth Service instance the client
+// is currently connected has the resource in its cache. This provides no guarantees
+// about the other Auth Service instances.
+func UntilFound[T any](
+	ctx context.Context,
+	get func(context.Context) (T, error),
+	opts ...UntilOpts,
+) (T, error) {
+	return Until(ctx, get, checkFound, opts...)
+}
+
+func checkFound[T any](res T, err error) error {
+	if err == nil {
+		// No error, resource found.
+		return nil
+	}
+	if trace.IsNotFound(err) {
+		// Resource not found, retry later.
+		return trace.CompareFailed("resource not found: %s", err.Error())
+	}
+	// Unexpected error, stop now.
+	return retryutils.PermanentRetryError(err)
+}
+
+// UntilNotFound runs a command until it returns a [trace.NotFoundErr].
+// This allows clients to wait for a resource to be deleted and removed from cache.
+// This is required to avoid races for newly deleted resources.
+//
+// IMPORTANT: this function only guarantees that the Auth Service instance the client
+// is currently connected doesn't have the resource in its cache. This provides no guarantees
+// about the other Auth Service instances.
+func UntilNotFound[T any](
+	ctx context.Context,
+	get func(context.Context) (T, error),
+	opts ...UntilOpts,
+) (T, error) {
+	return Until(ctx, get, checkNotFound, opts...)
+}
+
+func checkNotFound[T any](res T, err error) error {
+	if err == nil {
+		// No error, condition resource is still found.
+		return trace.CompareFailed("resource still exists")
+	}
+	if trace.IsNotFound(err) {
+		// Resource was not found, condition met.
+		return nil
+	}
+	// Unexpected error, stop now.
+	return retryutils.PermanentRetryError(err)
+}
+
+type withMetadata interface {
+	GetMetadata() *headerv1.Metadata
+}
+
+// UntilRevisionChange gets a resource until its revision changes.
+// This allows clients to wait for a change on an already cached resource to be propagated.
+// This is required to avoid races for newly updated resources.
+//
+// IMPORTANT: this function only guarantees that the Auth Service instance the client
+// is currently connected has the resource in its cache. This provides no guarantees
+// about the other Auth Service instances.
+//
+// While one might want to wait for a specific revision, as often done in unit tests,
+// this is not possible without a risk of deadlock. Teleport revisions are not monotonically
+// increasing, and when two backend writes happen quickly, the client has no way to know
+// if it observes an earlier or later revision.
+func UntilRevisionChange[T withMetadata](
+	ctx context.Context,
+	initialRevision string,
+	get func(context.Context) (T, error),
+	opts ...UntilOpts,
+) (T, error) {
+	return Until(ctx, get, checkRevisionChange[T](initialRevision), opts...)
+}
+
+func checkRevisionChange[T withMetadata](initialRevision string) func(res T, err error) error {
+	return func(res T, err error) error {
+		if err != nil {
+			// Unexpected error, stop now.
+			return retryutils.PermanentRetryError(err)
+		}
+		if metadata := res.GetMetadata(); metadata.Revision == initialRevision {
+			// Resource revision did not change, retry later.
+			return trace.CompareFailed("Resource %q still has old revision %q", metadata.Name, initialRevision)
+		}
+		// Resource has a new revision, condition met.
+		return nil
+	}
+}

--- a/api/utils/wait/until_test.go
+++ b/api/utils/wait/until_test.go
@@ -1,0 +1,303 @@
+// Copyright 2026 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wait
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/api/utils/retryutils"
+)
+
+func errIsRetryable(t require.TestingT, err error, args ...interface{}) {
+	require.Error(t, err)
+	require.False(t, retryutils.IsPermanent(err))
+}
+
+func errIsNotRetryable(t require.TestingT, err error, args ...interface{}) {
+	require.Error(t, err)
+	require.True(t, retryutils.IsPermanent(err))
+}
+
+func TestCheckFound(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		res       string
+		err       error
+		assertErr require.ErrorAssertionFunc
+	}{
+		{
+			name:      "found",
+			res:       "found",
+			assertErr: require.NoError,
+		},
+		{
+			name:      "not found",
+			err:       trace.NotFound("not found"),
+			assertErr: errIsRetryable,
+		},
+		{
+			name:      "other error",
+			err:       trace.BadParameter("bad parameter"),
+			assertErr: errIsNotRetryable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertErr(t, checkFound(tt.res, tt.err))
+		})
+	}
+}
+
+func TestCheckNotFound(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		res       string
+		err       error
+		assertErr require.ErrorAssertionFunc
+	}{
+		{
+			name:      "found",
+			res:       "found",
+			assertErr: errIsRetryable,
+		},
+		{
+			name:      "not found",
+			err:       trace.NotFound("not found"),
+			assertErr: require.NoError,
+		},
+		{
+			name:      "other error",
+			err:       trace.BadParameter("bad parameter"),
+			assertErr: errIsNotRetryable,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertErr(t, checkNotFound(tt.res, tt.err))
+		})
+	}
+}
+
+type fakeResource struct {
+	name     string
+	revision string
+}
+
+func (f fakeResource) GetMetadata() *headerv1.Metadata {
+	return headerv1.Metadata_builder{
+		Name:     f.name,
+		Revision: f.revision,
+	}.Build()
+}
+
+func TestCheckRevisionChanged(t *testing.T) {
+	t.Parallel()
+	const resourceName = "test"
+	initialRevision := uuid.NewString()
+	tests := []struct {
+		name      string
+		res       fakeResource
+		err       error
+		assertErr require.ErrorAssertionFunc
+	}{
+		{
+			name:      "same metadata",
+			res:       fakeResource{name: resourceName, revision: initialRevision},
+			assertErr: errIsRetryable,
+		},
+		{
+			name:      "different metadata",
+			res:       fakeResource{name: resourceName, revision: uuid.NewString()},
+			assertErr: require.NoError,
+		},
+		{
+			name:      "error",
+			err:       trace.NotFound("not found"),
+			assertErr: errIsNotRetryable,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertErr(t, checkRevisionChange[fakeResource](initialRevision)(tt.res, tt.err))
+		})
+	}
+
+}
+
+type mockCheck struct {
+	t         *testing.T
+	counter   int
+	responses []error
+}
+
+func (m *mockCheck) check(string, error) error {
+	m.counter += 1
+	assert.LessOrEqual(m.t, m.counter, len(m.responses), "no response left")
+	return m.responses[m.counter-1]
+}
+
+func (m *mockCheck) empty() bool {
+	return m.counter == len(m.responses)
+}
+
+func TestWaitUntil(t *testing.T) {
+	const response = "response"
+	// creating the notFoundErr once to avoid capturing the call track dozens of times
+	notFoundErr := trace.NotFound("not found")
+	tests := []struct {
+		name          string
+		mock          *mockCheck
+		prepareCtx    func(ctx context.Context) context.Context
+		expectedTries int
+		assertErr     assert.ErrorAssertionFunc
+	}{
+		{
+			name:       "immediately return",
+			prepareCtx: func(ctx context.Context) context.Context { return ctx },
+			mock: &mockCheck{
+				responses: []error{nil},
+			},
+			expectedTries: 1,
+			assertErr:     assert.NoError,
+		},
+		{
+			name:       "with retries",
+			prepareCtx: func(ctx context.Context) context.Context { return ctx },
+			mock: &mockCheck{
+				responses: []error{notFoundErr, notFoundErr, nil},
+			},
+			expectedTries: 3,
+			assertErr:     assert.NoError,
+		},
+		{
+			name: "expired context",
+			prepareCtx: func(ctx context.Context) context.Context {
+				newCtx, cancel := context.WithCancel(ctx)
+				cancel()
+				return newCtx
+			},
+			mock: &mockCheck{
+				responses: []error{notFoundErr},
+			},
+			// Linear retry `For` function runs at least once, even if context is canceled.
+			expectedTries: 1,
+			assertErr:     assert.Error,
+		},
+		{
+			name:       "permanent error",
+			prepareCtx: func(ctx context.Context) context.Context { return ctx },
+			mock: &mockCheck{
+				responses: []error{notFoundErr, retryutils.PermanentRetryError(notFoundErr)},
+			},
+			expectedTries: 2,
+			assertErr:     assert.Error,
+		},
+		{
+			name:       "maxTries exceeded",
+			prepareCtx: func(ctx context.Context) context.Context { return ctx },
+			mock: &mockCheck{
+				responses: []error{
+					// Max tries is 4
+					notFoundErr,
+					notFoundErr,
+					notFoundErr,
+					notFoundErr,
+				},
+			},
+			expectedTries: 4,
+			assertErr:     assert.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				// Test setup: construct fixtures and ways to track the test's progress.'
+				var done atomic.Bool
+				var getCalls atomic.Int64
+				var tries int
+				// inject the test-specific context into the mock (this saves us from making tt.mock a constructor)
+				tt.mock.t = t
+
+				get := func(_ context.Context) (string, error) {
+					getCalls.Add(1)
+					return response, nil
+				}
+
+				clock := clockwork.NewFakeClock()
+
+				// Test setup: build a controlled retry config that is deterministic.
+				// This allows us to inject a fake clock and know how to to advance it for every iteration.
+				retryConfig := &retryutils.LinearConfig{
+					// Prevent immediate start
+					First:     1,
+					Step:      100 * time.Millisecond,
+					Max:       time.Second,
+					AutoReset: 0,
+					// No jitter so we can be deterministic
+					Clock: clock,
+				}
+
+				backoff, err := retryutils.NewLinear(*retryConfig)
+				require.NoError(t, err)
+
+				go func() {
+					// Test execution: run WaitUntil. This will routine will block waiting for the clock.
+					// The main test routine is responsible for unblocking it.
+					result, err := Until[string](tt.prepareCtx(t.Context()), get, tt.mock.check, WithMaxTries(4), WithRetryConfig(retryConfig))
+
+					// Test validation: check the function return value and error.
+					tt.assertErr(t, err)
+					// Implementation details: we always return the last get value, and for the sake of simplicity, get always returns [response].
+					assert.Equal(t, response, result)
+					assert.Equal(t, int64(tt.expectedTries), getCalls.Load())
+					done.Store(true)
+				}()
+
+				for {
+					tries += 1
+					synctest.Wait()
+					if done.Load() {
+						// Test validation, if the function returned, validate the numberof tries and calls that were performned.
+						require.Equal(t, tt.expectedTries, tries, "WaitUntil returned too early, was expecting more tries")
+						require.True(t, tt.mock.empty(), "mock is not empty")
+						return
+					}
+					if tries > tt.expectedTries {
+						require.FailNow(t, "WaitUntil did not return after expected number of tries")
+					}
+					// Test execution: advance clock to the next try.
+					backoff.Inc()
+					clock.Advance(backoff.Duration())
+				}
+			})
+		})
+	}
+
+}


### PR DESCRIPTION
I got asked to add helper to retry getting resources in the Terraform tctl PR so here it is.

This will be used in the following other places:
- operator tests (needed to sync with cache to avoid races)
- terraform provider tests
- tctl terraform env --scope and its tests (it needs to create and wait for scoped resource and there's no fallback)

Notes:
- I intentionally did not add a "force this revision" helper for safety. This can be done in unit tests using `WaitUntil` if you know what you are doing.
- I put it in its own package and not clientutils to avoid adding a dependency on the headerv1 proto types. Package name is `wait` but I can change it to `util` or whatever name you see fit.
- I only added support for RFD 153 resource, I might add legacy ones later.
- I added `Unwrap` to the retry permanent errr as it seemed to be the thing to do to keep errors.As working after a retry. This might have unintended effect if we were relying on errors.As not working on permanent errors, I can undo this if you think it's too risky.