### PR TITLE
[v18] [Web] Fix bug causing `*` in a Resources page search to break the page

### DIFF
--- a/web/packages/teleport/src/Navigation/Navigation.test.tsx
+++ b/web/packages/teleport/src/Navigation/Navigation.test.tsx
@@ -98,6 +98,33 @@ test('show all dashboard navigation items', async () => {
   });
 });
 
+test("a wildcard in the current URL's query doesn't break the page", () => {
+  const originalIsDashboard = cfg.isDashboard;
+  cfg.isDashboard = false;
+  window.history.replaceState({}, '', '/web/some-page?query=*');
+  mockUserContextProviderWith(
+    makeTestUserContext({ preferences: makeDefaultUserPreferences() })
+  );
+
+  expect(() =>
+    render(
+      <MemoryRouter initialEntries={['/web/some-page?query=*']}>
+        <ContextProvider ctx={createTeleportContext()}>
+          <FeaturesContextProvider value={getOSSFeatures()}>
+            <Navigation />
+          </FeaturesContextProvider>
+        </ContextProvider>
+      </MemoryRouter>
+    )
+  ).not.toThrow();
+  expect(
+    screen.getByRole('button', { name: NavTitle.Resources })
+  ).toBeInTheDocument();
+
+  cfg.isDashboard = originalIsDashboard;
+  window.history.replaceState({}, '', '/');
+});
+
 describe('Beams nav category', () => {
   const originalIsDashboard = cfg.isDashboard;
 

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -998,7 +998,7 @@ const cfg = {
     if (options?.activeTab) {
       search.set('tab', options.activeTab);
     }
-    return generatePath(`${cfg.routes.botInstances}?${search.toString()}`);
+    return `${generatePath(cfg.routes.botInstances)}?${search.toString()}`;
   },
 
   getInstancesRoute() {


### PR DESCRIPTION
Backport #68778 to branch/v18

## Manual Test Plan
### Test Environment

Teleport v19 and v18

### Test Cases
- [x] Verify that searching Resources using `*` doesn't crash the page.