### PR TITLE
discovery: surface Azure subscription resolution failures as UserTasks

### DIFF
--- a/api/types/usertasks/object.go
+++ b/api/types/usertasks/object.go
@@ -316,6 +316,11 @@ var DiscoverRDSIssueTypes = []string{
 // List of Auto Discover Azure VM issues identifiers.
 // This value is used to populate the UserTasks.Spec.IssueType for Discover Azure VM tasks.
 const (
+	// AutoDiscoverAzureVMIssueSubscriptionListDenied indicates the integration
+	// lacks permission to list subscriptions while expanding a wildcard
+	// subscription matcher.
+	AutoDiscoverAzureVMIssueSubscriptionListDenied = "azure-vm-subscription-list-denied"
+
 	// AutoDiscoverAzureVMIssueMissingRunCommandsPermission is used to identify VMs that failed to auto-enroll
 	// because the Azure integration is missing runCommands permissions (runCommands/write or runCommands/read).
 	AutoDiscoverAzureVMIssueMissingRunCommandsPermission = "azure-vm-missing-run-commands-permission"
@@ -335,6 +340,7 @@ const (
 
 // DiscoverAzureVMIssueTypes is a list of issue types that can occur when trying to auto enroll Azure VMs.
 var DiscoverAzureVMIssueTypes = []string{
+	AutoDiscoverAzureVMIssueSubscriptionListDenied,
 	AutoDiscoverAzureVMIssueMissingRunCommandsPermission,
 	AutoDiscoverAzureVMIssueVMNotRunning,
 	AutoDiscoverAzureVMIssueVMAgentNotAvailable,
@@ -625,14 +631,20 @@ func validateDiscoverAzureVMTaskType(ut *usertasksv1.UserTask) error {
 	if discover == nil {
 		return trace.BadParameter("%s: discover_azure_vm field is required", TaskTypeDiscoverAzureVM)
 	}
-	switch {
-	case discover.SubscriptionId == "":
-		return trace.BadParameter("%s: discover_azure_vm.subscription_id field is required", TaskTypeDiscoverAzureVM)
-	case discover.ResourceGroup == "":
-		return trace.BadParameter("%s: discover_azure_vm.resource_group field is required", TaskTypeDiscoverAzureVM)
-	case discover.Region == "":
-		return trace.BadParameter("%s: discover_azure_vm.region field is required", TaskTypeDiscoverAzureVM)
+	isSubscriptionListIssue := spec.IssueType == AutoDiscoverAzureVMIssueSubscriptionListDenied
+	if !isSubscriptionListIssue {
+		switch {
+		case discover.SubscriptionId == "":
+			return trace.BadParameter("%s: discover_azure_vm.subscription_id field is required", TaskTypeDiscoverAzureVM)
+		case discover.ResourceGroup == "":
+			return trace.BadParameter("%s: discover_azure_vm.resource_group field is required", TaskTypeDiscoverAzureVM)
+		case discover.Region == "":
+			return trace.BadParameter("%s: discover_azure_vm.region field is required", TaskTypeDiscoverAzureVM)
+		case len(discover.Instances) == 0:
+			return trace.BadParameter("%s: discover_azure_vm.instances field is required", TaskTypeDiscoverAzureVM)
+		}
 	}
+
 	expectedTaskName := taskNameForDiscoverAzureVM(
 		TaskGroup{
 			Integration: spec.Integration,
@@ -650,9 +662,12 @@ func validateDiscoverAzureVMTaskType(ut *usertasksv1.UserTask) error {
 			ut.Metadata.Name,
 		)
 	}
-	if len(discover.Instances) == 0 {
-		return trace.BadParameter("%s: discover_azure_vm.instances field is required", TaskTypeDiscoverAzureVM)
+
+	// Subscription resolution fails before VM scope or instance data is known.
+	if isSubscriptionListIssue {
+		return nil
 	}
+
 	for vmID, vmIssue := range discover.Instances {
 		switch {
 		case vmIssue == nil:

--- a/api/types/usertasks/object_test.go
+++ b/api/types/usertasks/object_test.go
@@ -150,6 +150,20 @@ func TestValidateUserTask(t *testing.T) {
 		require.NoError(t, err)
 		return userTask
 	}
+	baseAzureVMPermissionTask := func(t *testing.T) *usertasksv1.UserTask {
+		userTask, err := NewDiscoverAzureVMUserTask(
+			TaskGroup{
+				Integration: "my-integration",
+				IssueType:   AutoDiscoverAzureVMIssueSubscriptionListDenied,
+			},
+			time.Now().Add(24*time.Hour),
+			&usertasksv1.DiscoverAzureVM{
+				Instances: map[string]*usertasksv1.DiscoverAzureVMInstance{},
+			},
+		)
+		require.NoError(t, err)
+		return userTask
+	}
 
 	const noError = ""
 
@@ -618,6 +632,20 @@ func TestValidateUserTask(t *testing.T) {
 			name:    "DiscoverAzureVM: valid",
 			task:    baseAzureVMDiscoverTask,
 			wantErr: noError,
+		},
+		{
+			name:    "DiscoverAzureVM: subscription list permission issue allows empty scope and instances",
+			task:    baseAzureVMPermissionTask,
+			wantErr: noError,
+		},
+		{
+			name: "DiscoverAzureVM: subscription list permission issue requires deterministic task name",
+			task: func(t *testing.T) *usertasksv1.UserTask {
+				ut := baseAzureVMPermissionTask(t)
+				ut.Metadata.Name = "another-name"
+				return ut
+			},
+			wantErr: "task name must be",
 		},
 		{
 			name: "DiscoverAzureVM: invalid issue type",

--- a/lib/srv/discovery/azure_vm_error_parser.go
+++ b/lib/srv/discovery/azure_vm_error_parser.go
@@ -34,6 +34,15 @@ func classifyAzureInstallResultIssue(installResult server.AzureInstallResult) st
 	return classifyAzureVMEnrollmentError(installResult.APIError)
 }
 
+// classifyAzureSubscriptionListError classifies errors returned while
+// resolving a wildcard subscription matcher.
+func classifyAzureSubscriptionListError(err error) string {
+	if trace.IsAccessDenied(err) || trace.IsNotFound(err) {
+		return usertasks.AutoDiscoverAzureVMIssueSubscriptionListDenied
+	}
+	return ""
+}
+
 // classifyAzureVMEnrollmentError classifies Azure API errors into user-facing
 // messages for VM auto-discovery. This is best-effort based on error strings
 // which may change without notice. The matching logic may require future

--- a/lib/srv/discovery/azure_vm_error_parser_test.go
+++ b/lib/srv/discovery/azure_vm_error_parser_test.go
@@ -106,3 +106,17 @@ func TestClassifyAzureVMEnrollmentError(t *testing.T) {
 		})
 	}
 }
+
+func TestClassifyAzureSubscriptionListError(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t,
+		usertasks.AutoDiscoverAzureVMIssueSubscriptionListDenied,
+		classifyAzureSubscriptionListError(trace.AccessDenied("missing subscriptions/read")),
+	)
+	require.Equal(t,
+		usertasks.AutoDiscoverAzureVMIssueSubscriptionListDenied,
+		classifyAzureSubscriptionListError(trace.NotFound("no accessible subscriptions")),
+	)
+	require.Empty(t, classifyAzureSubscriptionListError(trace.ConnectionProblem(nil, "Azure unavailable")))
+}

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -855,7 +855,42 @@ func (s *Server) azureServerFetchersFromMatchers(matchers []types.AzureMatcher, 
 		return matcherType == types.AzureMatcherVM
 	})
 
-	return server.MatchersToAzureInstanceFetchers(s.ctx, s.Log, serverMatchers, s.getAzureClients, discoveryConfigName, s.getAzureSubscriptionList)
+	var allFetchers []server.Fetcher[*server.AzureInstances]
+	for _, matcher := range serverMatchers {
+		fetchers, err := server.MatcherToAzureInstanceFetchers(
+			s.ctx,
+			s.Log,
+			matcher,
+			s.getAzureClients,
+			discoveryConfigName,
+			s.getAzureSubscriptionList,
+		)
+		if err != nil {
+			s.Log.WarnContext(s.ctx, "Failed to resolve Azure subscription wildcard in discovery configuration",
+				"integration", matcher.Integration,
+				"discovery_config", discoveryConfigName,
+				"error", err,
+			)
+			s.handleAzureSubscriptionListError(matcher.Integration, err)
+			continue
+		}
+		allFetchers = append(allFetchers, fetchers...)
+	}
+	return allFetchers
+}
+
+func (s *Server) handleAzureSubscriptionListError(integration string, err error) {
+	issueType := classifyAzureSubscriptionListError(err)
+	if integration == "" || issueType == "" {
+		return
+	}
+
+	if err := s.taskUpdater().upsertAzureSubscriptionListTask(integration, issueType); err != nil {
+		s.Log.WarnContext(s.ctx, "Failed to upsert Azure subscription list permission User Task",
+			"integration", integration,
+			"error", err,
+		)
+	}
 }
 
 func (s *Server) getAzureSubscriptionListNoCache(ctx context.Context, integration string) ([]string, error) {

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -1049,6 +1049,24 @@ type taskUpdater struct {
 	Log            *slog.Logger
 }
 
+func (s *taskUpdater) upsertAzureSubscriptionListTask(integration, issueType string) error {
+	task, err := usertasks.NewDiscoverAzureVMUserTask(
+		usertasks.TaskGroup{
+			Integration: integration,
+			IssueType:   issueType,
+		},
+		s.clock.Now().Add(2*s.PollInterval),
+		usertasksv1.DiscoverAzureVM_builder{
+			Instances: map[string]*usertasksv1.DiscoverAzureVMInstance{},
+		}.Build(),
+	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return trace.Wrap(s.mergeUpsertUserTask(task, s.mergeAzure))
+}
+
 func (s *taskUpdater) mergeUpsertUserTask(newTask *usertasksv1.UserTask, mergeUserTasks func(oldTask *usertasksv1.UserTaskSpec, newTask *usertasksv1.UserTaskSpec)) error {
 	taskName := newTask.GetMetadata().GetName()
 

--- a/lib/srv/discovery/status_test.go
+++ b/lib/srv/discovery/status_test.go
@@ -339,6 +339,26 @@ func newTaskUpdater(t *testing.T, existingTasks ...*usertasksv1.UserTask) (*task
 	return manager, ap
 }
 
+func TestUpsertAzureSubscriptionListTask(t *testing.T) {
+	t.Parallel()
+
+	updater, ap := newTaskUpdater(t)
+	require.NoError(t, updater.upsertAzureSubscriptionListTask(
+		"azure-integration",
+		usertasks.AutoDiscoverAzureVMIssueSubscriptionListDenied,
+	))
+	require.Len(t, ap.tasks, 1)
+
+	for _, task := range ap.tasks {
+		require.Equal(t, usertasks.TaskTypeDiscoverAzureVM, task.GetSpec().GetTaskType())
+		require.Equal(t, usertasks.AutoDiscoverAzureVMIssueSubscriptionListDenied, task.GetSpec().GetIssueType())
+		require.Equal(t, "azure-integration", task.GetSpec().GetIntegration())
+		require.Empty(t, task.GetSpec().GetDiscoverAzureVm().GetSubscriptionId())
+		require.Empty(t, task.GetSpec().GetDiscoverAzureVm().GetInstances())
+		require.True(t, updater.clock.Now().Add(2*updater.PollInterval).Equal(task.GetMetadata().GetExpires().AsTime()))
+	}
+}
+
 func TestAWSEC2Tasks_AddFailedEnrollment(t *testing.T) {
 	t.Parallel()
 

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -176,44 +176,44 @@ type azureClientGetter func(ctx context.Context, integration string) (azure.Clie
 
 type listSubscriptionsFunc func(ctx context.Context, integration string) (subscriptions []string, err error)
 
-// MatchersToAzureInstanceFetchers converts a list of Azure VM Matchers into a list of Azure VM Fetchers.
-func MatchersToAzureInstanceFetchers(
+// MatcherToAzureInstanceFetchers converts an Azure VM matcher into Azure VM fetchers.
+func MatcherToAzureInstanceFetchers(
 	ctx context.Context,
 	logger *slog.Logger,
-	matchers []types.AzureMatcher,
+	matcher types.AzureMatcher,
 	getClient azureClientGetter,
 	discoveryConfigName string,
 	listSubs listSubscriptionsFunc,
-) []Fetcher[*AzureInstances] {
-	ret := make([]Fetcher[*AzureInstances], 0)
-	for _, matcher := range matchers {
-		matcher.Subscriptions = expandAzureMatcherSubscriptions(ctx, logger, matcher.Subscriptions, matcher.Integration, listSubs)
-		for _, subscription := range matcher.Subscriptions {
-			for _, resourceGroup := range matcher.ResourceGroups {
-				fetcher := newAzureInstanceFetcher(azureFetcherConfig{
-					Matcher:             matcher,
-					Subscription:        subscription,
-					ResourceGroup:       resourceGroup,
-					AzureClientGetter:   getClient,
-					DiscoveryConfigName: discoveryConfigName,
-					Logger:              logger,
-				})
-				ret = append(ret, fetcher)
-			}
+) ([]Fetcher[*AzureInstances], error) {
+	subscriptions, err := expandAzureMatcherSubscriptions(ctx, matcher.Subscriptions, matcher.Integration, listSubs)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	fetchers := make([]Fetcher[*AzureInstances], 0, len(subscriptions)*len(matcher.ResourceGroups))
+	for _, subscription := range subscriptions {
+		for _, resourceGroup := range matcher.ResourceGroups {
+			fetchers = append(fetchers, newAzureInstanceFetcher(azureFetcherConfig{
+				Matcher:             matcher,
+				Subscription:        subscription,
+				ResourceGroup:       resourceGroup,
+				AzureClientGetter:   getClient,
+				DiscoveryConfigName: discoveryConfigName,
+				Logger:              logger,
+			}))
 		}
 	}
-	return ret
+	return fetchers, nil
 }
 
 // expandAzureMatcherSubscriptions fetches the subscriptions for any wildcard
 // subscriptions and replaces the wildcard with the subscriptions list.
 func expandAzureMatcherSubscriptions(
 	ctx context.Context,
-	logger *slog.Logger,
 	subscriptions []string,
 	integration string,
 	listSubs listSubscriptionsFunc,
-) []string {
+) ([]string, error) {
 	var out []string
 	for _, sub := range subscriptions {
 		if sub != types.Wildcard {
@@ -221,17 +221,18 @@ func expandAzureMatcherSubscriptions(
 			continue
 		}
 		subs, err := listSubs(ctx, integration)
+		// Azure can return a successful response with no subscriptions when the
+		// identity has no subscription-scoped access. Treat this as a resolution
+		// failure so wildcard discovery doesn't silently produce 0 fetchers.
+		if err == nil && len(subs) == 0 {
+			err = trace.NotFound("Azure returned no subscriptions for wildcard in discovery configuration")
+		}
 		if err != nil {
-			// TODO(gavin): make a user task
-			logger.WarnContext(ctx, "Failed to fetch Azure subscription list for wildcard in discovery configuration",
-				"integration", integration,
-				"error", err,
-			)
-			continue
+			return nil, trace.Wrap(err)
 		}
 		out = append(out, subs...)
 	}
-	return utils.Deduplicate(out)
+	return utils.Deduplicate(out), nil
 }
 
 type azureFetcherConfig struct {

--- a/lib/srv/server/azure_watcher_test.go
+++ b/lib/srv/server/azure_watcher_test.go
@@ -268,20 +268,20 @@ func TestAzureWatcher(t *testing.T) {
 			watcher := NewWatcher[*AzureInstances](ctx, logger)
 
 			const noDiscoveryConfig = ""
-			watcher.SetFetchers(noDiscoveryConfig,
-				MatchersToAzureInstanceFetchers(
-					t.Context(),
-					logger,
-					[]types.AzureMatcher{tc.matcher},
-					func(ctx context.Context, integration string) (azure.Clients, error) {
-						return &clients, nil
-					},
-					noDiscoveryConfig,
-					func(ctx context.Context, integration string) (subscriptions []string, err error) {
-						return []string{sub1, sub2}, nil
-					},
-				),
+			fetchers, err := MatcherToAzureInstanceFetchers(
+				t.Context(),
+				logger,
+				tc.matcher,
+				func(ctx context.Context, integration string) (azure.Clients, error) {
+					return &clients, nil
+				},
+				noDiscoveryConfig,
+				func(ctx context.Context, integration string) (subscriptions []string, err error) {
+					return []string{sub1, sub2}, nil
+				},
 			)
+			require.NoError(t, err)
+			watcher.SetFetchers(noDiscoveryConfig, fetchers)
 
 			go watcher.Run()
 			t.Cleanup(watcher.Stop)
@@ -307,6 +307,50 @@ func TestAzureWatcher(t *testing.T) {
 			require.ElementsMatch(t, tc.wantVMs, vmIDs)
 		})
 	}
+}
+
+func TestMatcherToAzureInstanceFetchersSubscriptionListError(t *testing.T) {
+	t.Parallel()
+
+	permissionErr := trace.AccessDenied("missing subscriptions/read")
+	fetchers, err := MatcherToAzureInstanceFetchers(
+		t.Context(),
+		logtest.NewLogger(),
+		types.AzureMatcher{
+			Types:          []string{types.AzureMatcherVM},
+			Subscriptions:  []string{types.Wildcard},
+			ResourceGroups: []string{types.Wildcard},
+			Integration:    "azure-integration",
+		},
+		func(context.Context, string) (azure.Clients, error) { return nil, nil },
+		"discovery-config",
+		func(context.Context, string) ([]string, error) { return nil, permissionErr },
+	)
+
+	require.Empty(t, fetchers)
+	require.ErrorIs(t, err, permissionErr)
+}
+
+func TestMatcherToAzureInstanceFetchersEmptySubscriptionList(t *testing.T) {
+	t.Parallel()
+
+	fetchers, err := MatcherToAzureInstanceFetchers(
+		t.Context(),
+		logtest.NewLogger(),
+		types.AzureMatcher{
+			Types:          []string{types.AzureMatcherVM},
+			Subscriptions:  []string{types.Wildcard},
+			ResourceGroups: []string{types.Wildcard},
+			Integration:    "azure-integration",
+		},
+		func(context.Context, string) (azure.Clients, error) { return nil, nil },
+		"discovery-config",
+		func(context.Context, string) ([]string, error) { return nil, nil },
+	)
+
+	require.Empty(t, fetchers)
+	require.Error(t, err)
+	require.True(t, trace.IsNotFound(err))
 }
 
 func TestAzureInstances_FilterExistingNodes(t *testing.T) {

--- a/lib/usertasks/descriptions/azure-vm-subscription-list-denied.md
+++ b/lib/usertasks/descriptions/azure-vm-subscription-list-denied.md
@@ -1,0 +1,18 @@
+# Cannot access Azure subscriptions
+
+Teleport could not resolve the wildcard subscription matcher because the Azure integration cannot access any subscriptions.
+
+Verify that the integration uses the intended Azure tenant and managed identity or service principal. Grant that identity a role with the following actions at the management group or subscription scope that Teleport should discover:
+
+- `Microsoft.Compute/virtualMachines/read`
+- `Microsoft.Compute/virtualMachines/runCommands/write`
+- `Microsoft.Compute/virtualMachines/runCommands/read`
+- `Microsoft.Compute/virtualMachineScaleSets/read`
+- `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read`
+- `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommands/write`
+- `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommands/read`
+- `Microsoft.Resources/subscriptions/read`
+
+Alternatively, replace the wildcard (`"*"`) in the DiscoveryConfig with explicit subscription IDs. The integration identity must still have the required VM discovery permissions in those subscriptions.
+
+Azure role assignments may take several minutes to propagate. After the permissions propagate, update the DiscoveryConfig to trigger reconciliation. This task expires automatically if the issue is not observed again.


### PR DESCRIPTION
Fixes #68805

Changelog: Surface Azure VM auto-discovery wildcard subscription resolution failures as UserTasks.

## Summary

Azure VM discovery must list subscriptions when a DiscoveryConfig uses a wildcard subscription matcher:

```yaml
subscriptions: ["*"]
```

Previously, if the Azure integration could not list any subscriptions, wildcard expansion produced no Azure VM fetchers and discovery silently returned zero results.

Azure can represent this failure in two ways:

- Return an access-denied error from the subscription-list API.
- Return a successful response containing no visible subscriptions when the integration identity has no subscription-scoped access.

This PR surfaces both outcomes as an `integration-scoped discover-azure-vm` UserTask with the issue type: `azure-vm-subscription-list-denied`

The task does not require subscription, resource group, region, or VM instance data because the failure occurs before those values are known.

This applies only to integration-backed discovery. Ambient-credential failures are logged but do not create a UserTask because Discover Azure VM UserTasks require an integration.

## Manual Test Plan

### Test Environment

Tested against https://mpmonboarding.cloud.gravitational.io/ using:

- A real Azure OIDC integration backed by a user-assigned managed identity.
- A federated identity credential configured for the Teleport cluster.
- An Azure VM DiscoveryConfig using subscriptions: ["*"].
- Two Discovery Service replicas running as part of the Teleport Auth deployment.
- A custom Teleport image containing this change.

### Test Cases

- [x] With the Azure role assignment present, wildcard subscription resolution succeeded and did not create an azure-vm-subscription-list-denied task.
- [x] Removed the managed identity's Azure role assignment and waited for RBAC propagation.
- [x] Confirmed Azure returned a successful but empty subscription list rather than an HTTP 403.
- [x] Confirmed Teleport created an open azure-vm-subscription-list-denied UserTask with the expected integration and no VM scope or instance data.
- [x] Confirmed both Discovery Service replicas repeatedly upserted the same deterministic task ID.
- [x] Confirmed a wildcard subscription-list failure does not prevent explicitly configured subscriptions from producing fetchers.

Test output:

  ```yaml
spec:
  discover_azure_vm: {}
  integration: mpm-68805-test
  issue_type: azure-vm-subscription-list-denied
  state: OPEN
  task_type: discover-azure-vm
```