### PR TITLE
Fix macOS helm-unittest install docs

### DIFF
--- a/BUILD_macos.md
+++ b/BUILD_macos.md
@@ -92,8 +92,7 @@ and updates are welcome!
     ```shell
     brew install helm
 
-    # The pinned helm-unittest version is tracked in build.assets/helm-unittest.version.
-    helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.0.3 --verify=false
+    make helmunit/installed
     ```
 
 1. Install `bats`:


### PR DESCRIPTION
Changelog:

None. Documentation-only fix.

This restores the macOS setup instructions for helm-unittest to use `make helmunit/installed` instead of `helm plugin install`.

I attempted to fix the archived helm-unittest repository issue described in #68720 by pointing users at the maintained plugin repository directly, but that reintroduced an unsafe install path. The `make helmunit/installed` target is the better fix because it points users at the pinned release archive and checksum verification flow from `build.assets/helm-unittest.sha256`.

## Manual Test Plan
### Test Environment

macOS arm64 development checkout.

### Test Cases
- [x] Ran `make helmunit/installed` with the plugin already installed and verified it exits successfully.
- [x] Ran `HELM_PLUGINS=/tmp/codex-empty-helm-plugins make helmunit/installed` and verified it prints the manual install steps that download the pinned release archive and verify it against `build.assets/helm-unittest.sha256`.
