### PR TITLE
Fix macOS helm-unittest install docs

### DIFF
--- a/BUILD_macos.md
+++ b/BUILD_macos.md
@@ -92,8 +92,7 @@ and updates are welcome!
     ```shell
     brew install helm
 
-    # The pinned helm-unittest version is tracked in build.assets/helm-unittest.version.
-    helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.0.3 --verify=false
+    make helmunit/installed
     ```
 
 1. Install `bats`:

--- a/Makefile
+++ b/Makefile
@@ -980,16 +980,17 @@ helmunit/installed:
 	required="$(HELM_UNITTEST_VERSION:v%=%)"; \
 	if [ -z "$$actual" ]; then \
 		printf '%s\n' \
-			'Helm unittest plugin is required to test Helm charts. Run:'; \
+			'Helm unittest plugin is required to test Helm charts.'; \
 	elif [ "$$(printf '%s\n' "$$actual" "$$required" | sort -V | head -n1)" != "$$required" ]; then \
 		printf '%s\n' \
 			"Helm unittest plugin $$actual is too old; version $(HELM_UNITTEST_VERSION) or newer is required." \
-			'Run:'; \
+			''; \
 	else \
 		exit 0; \
 	fi; \
 	printf '%s\n' \
 		'helm-unittest does not provide the plugin signature required for Helm plugin signature verification, so we verify the release archive ourselves when installing:' \
+		'Run:' \
 		'  plugin_dir="$$(helm env HELM_PLUGINS)/helm-unittest"' \
 		'  rm -rf "$$plugin_dir"' \
 		'  mkdir -p "$$plugin_dir"' \


### PR DESCRIPTION
This restores the macOS setup instructions for helm-unittest to use `make helmunit/installed` instead of `helm plugin install`.

I [previously attempted](https://github.com/gravitational/teleport/pull/68597) to fix the archived helm-unittest repository issue described in #68720 by pointing users at the maintained plugin repository, but I used `--verify=false` which is not ideal. I did not see the PR #68720, so my change accidentally overwrote it. The `make helmunit/installed` target is the better fix because it points users at the pinned release archive and checksum verification flow from `build.assets/helm-unittest.sha256`.

I also changed the placement of the word `Run:` in the output because it was a little wrong/awkward:
Before:
```
Helm unittest plugin is required to test Helm charts. Run:
helm-unittest does not provide the plugin signature required for Helm plugin signature verification, so we verify the release archive ourselves when installing:
  plugin_dir="$(helm env HELM_PLUGINS)/helm-unittest"
  rm -rf "$plugin_dir"
  mkdir -p "$plugin_dir"
  curl -fsSL -o "helm-unittest-macos-arm64-1.0.3.tgz" https://github.com/helm-unittest/helm-unittest/releases/download/v1.0.3/helm-unittest-macos-arm64-1.0.3.tgz
  grep "[[:space:]]helm-unittest-macos-arm64-1.0.3.tgz$" build.assets/helm-unittest.sha256 | sha256sum -c -
  tar -xz -f "helm-unittest-macos-arm64-1.0.3.tgz" -C "$plugin_dir"
make: *** [helmunit/installed] Error 1
```

After:
```
Helm unittest plugin is required to test Helm charts.
helm-unittest does not provide the plugin signature required for Helm plugin signature verification, so we verify the release archive ourselves when installing:
Run:
  plugin_dir="$(helm env HELM_PLUGINS)/helm-unittest"
  rm -rf "$plugin_dir"
  mkdir -p "$plugin_dir"
  curl -fsSL -o "helm-unittest-macos-arm64-1.0.3.tgz" https://github.com/helm-unittest/helm-unittest/releases/download/v1.0.3/helm-unittest-macos-arm64-1.0.3.tgz
  grep "[[:space:]]helm-unittest-macos-arm64-1.0.3.tgz$" build.assets/helm-unittest.sha256 | sha256sum -c -
  tar -xz -f "helm-unittest-macos-arm64-1.0.3.tgz" -C "$plugin_dir"
make: *** [helmunit/installed] Error 1
```

## Manual Test Plan
### Test Environment

macOS arm64 development checkout.

### Test Cases
- [x] Ran `make helmunit/installed` with the plugin already installed and verified it exits successfully.
- [x] Ran `helm plugin uninstall unittest`, then `make helmunit/installed` and verified it prints the manual install steps, then ran those and verified that they ran correctly
