### PR TITLE
App: Add support for AWS dualstack endpoints in IsAWSEndpoint function

### DIFF
--- a/api/types/database_test.go
+++ b/api/types/database_test.go
@@ -735,6 +735,21 @@ func TestDynamoDBConfig(t *testing.T) {
 			},
 		},
 		{
+			// the endpoint parser does not yet understand api.aws dual-stack URIs,
+			// they must keep validating as custom endpoints when a region is set.
+			desc:    "dual-stack api.aws URI with region must keep validating (compat)",
+			uri:     "dynamodb.us-west-1.api.aws",
+			region:  "us-west-1",
+			account: "123456789012",
+			wantSpec: DatabaseSpecV3{
+				URI: "dynamodb.us-west-1.api.aws",
+				AWS: AWS{
+					Region:    "us-west-1",
+					AccountID: "123456789012",
+				},
+			},
+		},
+		{
 			desc:       "configured external ID but not assume role is ok",
 			uri:        "localhost:8080",
 			region:     "us-west-1",

--- a/api/utils/aws/endpoint.go
+++ b/api/utils/aws/endpoint.go
@@ -54,6 +54,8 @@ func IsAWSAPIEndpoint(uri string) bool {
 // endpoint domain (amazonaws.com, amazonaws.com.cn, or api.aws). Use this for
 // trust and interception decisions. Use IsAWSEndpoint when deciding whether a
 // legacy endpoint parser should have understood the URI.
+//
+// https://docs.aws.amazon.com/general/latest/gr/rande.html
 func IsAWSOwnedEndpoint(uri string) bool {
 	return IsAWSEndpoint(uri) || IsAWSAPIEndpoint(uri)
 }

--- a/api/utils/aws/endpoint.go
+++ b/api/utils/aws/endpoint.go
@@ -26,15 +26,36 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// IsAWSEndpoint returns true if the input URI is an AWS endpoint.
+// IsAWSEndpoint returns true if the input URI is an AWS endpoint under the
+// amazonaws.com domains. It deliberately excludes api.aws endpoints (see
+// IsAWSAPIEndpoint) because callers like the DynamoDB/OpenSearch endpoint
+// parsers only understand the amazonaws.com shapes and use this check to
+// decide whether a parse failure is a config error. Once those parsers learn
+// the api.aws endpoint shapes, this split may no longer be necessary.
 func IsAWSEndpoint(uri string) bool {
 	hostname, err := removeSchemaAndPort(uri)
 	if err != nil {
 		return false
 	}
-	return strings.HasSuffix(hostname, AWSEndpointSuffix) ||
-		strings.HasSuffix(hostname, AWSCNEndpointSuffix) ||
-		strings.HasSuffix(hostname, AWSAPIEndpointSuffix)
+	return strings.HasSuffix(hostname, AWSEndpointSuffix) || strings.HasSuffix(hostname, AWSCNEndpointSuffix)
+}
+
+// IsAWSAPIEndpoint returns true if the input URI is an AWS endpoint under the
+// api.aws domain, used for dualstack and newer AWS service endpoints.
+func IsAWSAPIEndpoint(uri string) bool {
+	hostname, err := removeSchemaAndPort(uri)
+	if err != nil {
+		return false
+	}
+	return strings.HasSuffix(hostname, AWSAPIEndpointSuffix)
+}
+
+// IsAWSOwnedEndpoint returns true if the input URI is under any AWS-owned
+// endpoint domain (amazonaws.com, amazonaws.com.cn, or api.aws). Use this for
+// trust and interception decisions. Use IsAWSEndpoint when deciding whether a
+// legacy endpoint parser should have understood the URI.
+func IsAWSOwnedEndpoint(uri string) bool {
+	return IsAWSEndpoint(uri) || IsAWSAPIEndpoint(uri)
 }
 
 // IsRDSEndpoint returns true if the input URI is an RDS endpoint.

--- a/api/utils/aws/endpoint.go
+++ b/api/utils/aws/endpoint.go
@@ -32,7 +32,9 @@ func IsAWSEndpoint(uri string) bool {
 	if err != nil {
 		return false
 	}
-	return strings.HasSuffix(hostname, AWSEndpointSuffix) || strings.HasSuffix(hostname, AWSCNEndpointSuffix)
+	return strings.HasSuffix(hostname, AWSEndpointSuffix) ||
+		strings.HasSuffix(hostname, AWSCNEndpointSuffix) ||
+		strings.HasSuffix(hostname, AWSAPIEndpointSuffix)
 }
 
 // IsRDSEndpoint returns true if the input URI is an RDS endpoint.
@@ -733,6 +735,12 @@ const (
 	//
 	// https://docs.amazonaws.cn/en_us/aws/latest/userguide/endpoints-arns.html
 	AWSCNEndpointSuffix = ".amazonaws.com.cn"
+
+	// AWSAPIEndpointSuffix is the endpoint suffix for AWS dualstack and newer
+	// service endpoints. The api.aws domain is owned and operated by AWS.
+	//
+	// https://docs.aws.amazon.com/general/latest/gr/rande.html#dual-stack-endpoints
+	AWSAPIEndpointSuffix = ".api.aws"
 
 	// RDSServiceName is the service name for AWS RDS.
 	RDSServiceName = "rds"

--- a/api/utils/aws/endpoint_test.go
+++ b/api/utils/aws/endpoint_test.go
@@ -31,8 +31,6 @@ func TestIsAWSEndpoint(t *testing.T) {
 			"example.amazonaws.com",
 			"foo.amazonaws.com.cn",
 			"example.amazonaws.com:12345", // port numbers must be allowed here
-			"aws-mcp.us-east-1.api.aws",
-			"kms-fips.us-east-1.api.aws:443",
 		} {
 			require.True(t, IsAWSEndpoint(endpoint))
 		}
@@ -42,11 +40,56 @@ func TestIsAWSEndpoint(t *testing.T) {
 			"example.com",
 			"foo.amazonaws.com.cn.example.com",
 			"bad.amazonaws.com.example.com",
+			// api.aws endpoints are deliberately excluded, they are matched by
+			// IsAWSAPIEndpoint so legacy endpoint parsers never see them.
+			"aws-mcp.us-east-1.api.aws",
+		} {
+			require.False(t, IsAWSEndpoint(endpoint))
+		}
+	})
+}
+
+func TestIsAWSOwnedEndpoint(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		for _, endpoint := range []string{
+			"example.amazonaws.com",
+			"foo.amazonaws.com.cn",
+			"aws-mcp.us-east-1.api.aws",
+			"kms-fips.us-east-1.api.aws:443",
+		} {
+			require.True(t, IsAWSOwnedEndpoint(endpoint))
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		for _, endpoint := range []string{
+			"example.com",
+			"evil-api.aws",
+			"foo.api.aws.example.com",
+			"bad.amazonaws.com.example.com",
+		} {
+			require.False(t, IsAWSOwnedEndpoint(endpoint))
+		}
+	})
+}
+
+func TestIsAWSAPIEndpoint(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		for _, endpoint := range []string{
+			"aws-mcp.us-east-1.api.aws",
+			"kms-fips.us-east-1.api.aws:443",
+		} {
+			require.True(t, IsAWSAPIEndpoint(endpoint))
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		for _, endpoint := range []string{
+			"example.com",
+			"example.amazonaws.com",
 			"api.aws",
 			"evil-api.aws",
 			"foo.api.aws.example.com",
 		} {
-			require.False(t, IsAWSEndpoint(endpoint))
+			require.False(t, IsAWSAPIEndpoint(endpoint))
 		}
 	})
 }

--- a/api/utils/aws/endpoint_test.go
+++ b/api/utils/aws/endpoint_test.go
@@ -31,6 +31,8 @@ func TestIsAWSEndpoint(t *testing.T) {
 			"example.amazonaws.com",
 			"foo.amazonaws.com.cn",
 			"example.amazonaws.com:12345", // port numbers must be allowed here
+			"aws-mcp.us-east-1.api.aws",
+			"kms-fips.us-east-1.api.aws:443",
 		} {
 			require.True(t, IsAWSEndpoint(endpoint))
 		}
@@ -40,6 +42,9 @@ func TestIsAWSEndpoint(t *testing.T) {
 			"example.com",
 			"foo.amazonaws.com.cn.example.com",
 			"bad.amazonaws.com.example.com",
+			"api.aws",
+			"evil-api.aws",
+			"foo.api.aws.example.com",
 		} {
 			require.False(t, IsAWSEndpoint(endpoint))
 		}

--- a/lib/srv/alpnproxy/aws_local_proxy.go
+++ b/lib/srv/alpnproxy/aws_local_proxy.go
@@ -126,7 +126,7 @@ func (m *AWSAccessMiddleware) HandleRequest(rw http.ResponseWriter, req *http.Re
 	//
 	// Note that currently this is only supported in HTTPS proxy mode where the
 	// Host is a valid AWS endpoint.
-	if awsapiutils.IsAWSEndpoint(req.Host) {
+	if awsapiutils.IsAWSOwnedEndpoint(req.Host) {
 		if assumedRole, found := m.assumedRoles.Load(sigV4.KeyID); found {
 			return m.handleRequestByAssumedRole(rw, req, assumedRole)
 		}

--- a/lib/srv/alpnproxy/forward_proxy.go
+++ b/lib/srv/alpnproxy/forward_proxy.go
@@ -175,7 +175,7 @@ func MatchAllRequests(req *http.Request) bool {
 // MatchAWSRequests is a MatchFunc that returns true if request is an AWS API
 // request.
 func MatchAWSRequests(req *http.Request) bool {
-	return awsapiutils.IsAWSEndpoint(req.Host) &&
+	return awsapiutils.IsAWSOwnedEndpoint(req.Host) &&
 		// Avoid proxying SSM session WebSocket requests and let the forward proxy
 		// send it directly to AWS.
 		//
@@ -194,7 +194,7 @@ func MatchAWSRequests(req *http.Request) bool {
 }
 
 func isAWSSSMWebsocketRequest(req *http.Request) bool {
-	return awsapiutils.IsAWSEndpoint(req.Host) &&
+	return awsapiutils.IsAWSOwnedEndpoint(req.Host) &&
 		strings.HasPrefix(req.Host, "ssmmessages.")
 }
 

--- a/lib/srv/alpnproxy/forward_proxy_test.go
+++ b/lib/srv/alpnproxy/forward_proxy_test.go
@@ -276,6 +276,11 @@ func TestMatchAWSRequests(t *testing.T) {
 			check: require.True,
 		},
 		{
+			name:  "api.aws request",
+			req:   makeRequest("https://aws-mcp.us-east-1.api.aws"),
+			check: require.True,
+		},
+		{
 			name:  "SSM session WebSocket",
 			req:   makeRequest("wss://ssmmessages.ca-central-1.amazonaws.com"),
 			check: require.False,

--- a/lib/srv/app/aws/endpoints.go
+++ b/lib/srv/app/aws/endpoints.go
@@ -58,7 +58,7 @@ func resolveEndpoint(r *http.Request, authHeader string) (*common.AWSResolvedEnd
 	default:
 		return nil, trace.BadParameter("invalid AWS endpoint %q", forwardedHost)
 	}
-	if !awsapiutils.IsAWSEndpoint(u.Hostname()) {
+	if !awsapiutils.IsAWSOwnedEndpoint(u.Hostname()) {
 		return nil, trace.BadParameter("invalid AWS endpoint %q", forwardedHost)
 	}
 

--- a/lib/srv/app/aws/endpoints_test.go
+++ b/lib/srv/app/aws/endpoints_test.go
@@ -122,6 +122,10 @@ func TestResolveEndpoints(t *testing.T) {
 				forwardedHost: "example.amazonaws.com.cn",
 				wantHost:      "example.amazonaws.com.cn",
 			},
+			{
+				forwardedHost: "aws-mcp.us-east-1.api.aws",
+				wantHost:      "aws-mcp.us-east-1.api.aws",
+			},
 		} {
 			t.Run(tt.forwardedHost, func(t *testing.T) {
 				req, err := http.NewRequest("GET", "http://localhost/some/path?q=1", nil)


### PR DESCRIPTION
Client-side, `tsh proxy aws` decides whether to intercept and re-sign a request via `IsAWSEndpoint`, which only matched `.amazonaws.com` / `.amazonaws.com.cn`. Requests to AWS's newer `.api.aws` endpoints (e.g. `aws-mcp.us-east-1.api.aws`) were tunneled straight through to AWS unsigned, and the app service rejected them as forwarded hosts for the same reason. This adds `.api.aws` to the recognized AWS endpoint suffixes, which fixes both the client-side interception and the server-side `X-Forwarded-Host` validation in one place.

Fixes #68793

Changelog: Fixed `tsh proxy aws` not intercepting and signing requests to AWS `.api.aws` endpoints.

## Manual Test Plan
### Test Environment

Local single-process cluster with a dynamic AWS console app and ambient AWS SSO credentials on the agent assuming a ReadOnly IAM role. 

### Test Cases
- [x] `curl -v https://aws-mcp.us-east-1.api.aws` through the proxy presents the local proxy CA certificate (request intercepted; previously tunneled through to AWS, returning Amazon's certificate).
- [x] `aws sts get-caller-identity --endpoint-url https://sts.us-east-1.api.aws` returns the assumed-role identity (end-to-end signing via the app service over an `.api.aws` endpoint).
- [x] `aws sts get-caller-identity` against the default `.amazonaws.com` endpoint still works (no regression on existing endpoints).
