### PR TITLE
Add OpenAI Bedrock support

### DIFF
--- a/lib/srv/app/llm/anthropic/anthropic.go
+++ b/lib/srv/app/llm/anthropic/anthropic.go
@@ -89,12 +89,7 @@ func NewRequest(cfg *llmrequest.Config) (*http.Request, llmrequest.RequestInfo, 
 			return nil, info, trace.NotFound("unsupported endpoint")
 		}
 	case types.LLMProviderAWSBedrock:
-		var err error
-		cfg.ProviderURL, err = bedrock.BuildURL(cfg.Logger, cfg.App)
-		if err != nil {
-			return nil, info, trace.Wrap(err)
-		}
-
+		cfg.ProviderURL = bedrock.BuildAnthropicURL(cfg.Logger, cfg.App)
 		switch strings.TrimPrefix(cfg.DownstreamRequest.URL.Path, "/v1") {
 		case "/messages":
 			if cfg.DownstreamRequest.Method != http.MethodPost {

--- a/lib/srv/app/llm/bedrock/bedrock.go
+++ b/lib/srv/app/llm/bedrock/bedrock.go
@@ -98,32 +98,43 @@ func SignRequest(ctx context.Context, opts SignRequestOptions) error {
 	return nil
 }
 
-// BuildURL builds the Bedrock URL address.
-func BuildURL(log *slog.Logger, app types.Application) (*url.URL, error) {
-	format := app.GetLLM().Format
-	region := resolveRegion(context.Background(), log, app)
-	// https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html
-	host := "bedrock-mantle." + region + ".api.aws"
-
-	switch format {
-	case types.LLMFormatAnthropic:
-		// Messages API: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-messages-api.html
-		return &url.URL{
-			Scheme: "https",
-			Host:   host,
-			Path:   "/anthropic/v1",
-		}, nil
-	case types.LLMFormatOpenAI:
-		// Responses API: https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html
-		// Chat completions API: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-chat-completions-mantle.html
-		return &url.URL{
-			Scheme: "https",
-			Host:   host,
-			Path:   "/v1",
-		}, nil
-	default:
-		return nil, trace.BadParameter("format %q not supported on AWS Bedrock", format)
+// BuildURL builds the Anthropic-compatible Bedrock URL address.
+//
+// Messages API: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-messages-api.html
+func BuildAnthropicURL(log *slog.Logger, app types.Application) *url.URL {
+	return &url.URL{
+		Scheme: "https",
+		Host:   buildMantleEndpoint(log, app),
+		Path:   "/anthropic/v1",
 	}
+}
+
+// BuildURL builds the OpenAI-compatible Bedrock URL address.
+//
+// Responses API: https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html
+// Chat completions API: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-chat-completions-mantle.html
+func BuildOpenAIURL(log *slog.Logger, app types.Application, isResponses bool) *url.URL {
+	if isResponses {
+		return &url.URL{
+			Scheme: "https",
+			Host:   buildMantleEndpoint(log, app),
+			Path:   "/openai/v1",
+		}
+	}
+
+	return &url.URL{
+		Scheme: "https",
+		Host:   buildMantleEndpoint(log, app),
+		Path:   "/v1",
+	}
+}
+
+// buildMantleEndpoint builds Bedrock mantle address.
+//
+// https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html
+func buildMantleEndpoint(log *slog.Logger, app types.Application) string {
+	region := resolveRegion(context.Background(), log, app)
+	return "bedrock-mantle." + region + ".api.aws"
 }
 
 // resolveRegion resolves which AWS region to use.

--- a/lib/srv/app/llm/bedrock/bedrock.go
+++ b/lib/srv/app/llm/bedrock/bedrock.go
@@ -98,7 +98,7 @@ func SignRequest(ctx context.Context, opts SignRequestOptions) error {
 	return nil
 }
 
-// BuildURL builds the Anthropic-compatible Bedrock URL address.
+// BuildAnthropicURL builds the Anthropic-compatible Bedrock URL address.
 //
 // Messages API: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-messages-api.html
 func BuildAnthropicURL(log *slog.Logger, app types.Application) *url.URL {
@@ -109,7 +109,7 @@ func BuildAnthropicURL(log *slog.Logger, app types.Application) *url.URL {
 	}
 }
 
-// BuildURL builds the OpenAI-compatible Bedrock URL address.
+// BuildOpenAIURL builds the OpenAI-compatible Bedrock URL address.
 //
 // Responses API: https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html
 // Chat completions API: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-chat-completions-mantle.html

--- a/lib/srv/app/llm/bedrock/bedrock_test.go
+++ b/lib/srv/app/llm/bedrock/bedrock_test.go
@@ -32,18 +32,16 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 )
 
-func TestBuildURL(t *testing.T) {
+func TestBuildAnthropicURL(t *testing.T) {
 	for name, tc := range map[string]struct {
-		app           types.Application
-		expectedError require.ErrorAssertionFunc
-		expectedURL   require.ValueAssertionFunc
+		app         types.Application
+		expectedURL require.ValueAssertionFunc
 	}{
-		"anthropic format": {
+		"messages": {
 			app: newApp(t, &types.LLM{
 				Format:   types.LLMFormatAnthropic,
 				Provider: types.LLMProviderAWSBedrock,
 			}, &types.AppAWS{Region: "us-east-2"}),
-			expectedError: require.NoError,
 			expectedURL: func(tt require.TestingT, i1 any, i2 ...any) {
 				u, _ := i1.(*url.URL)
 				require.Equal(tt, "https", u.Scheme)
@@ -51,12 +49,50 @@ func TestBuildURL(t *testing.T) {
 				require.Equal(tt, "/anthropic/v1", u.Path)
 			},
 		},
-		"openai format": {
+		"default region": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatAnthropic,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{}),
+			expectedURL: func(tt require.TestingT, i1 any, i2 ...any) {
+				u, _ := i1.(*url.URL)
+				require.Equal(tt, "https", u.Scheme)
+				require.Equal(tt, "bedrock-mantle."+defaultRegion+".api.aws", u.Host)
+				require.Equal(tt, "/anthropic/v1", u.Path)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			tc.expectedURL(t, BuildAnthropicURL(slog.Default(), tc.app))
+		})
+	}
+}
+
+func TestBuildOpenAIURL(t *testing.T) {
+	for name, tc := range map[string]struct {
+		app         types.Application
+		isResponses bool
+		expectedURL require.ValueAssertionFunc
+	}{
+		"responses": {
 			app: newApp(t, &types.LLM{
 				Format:   types.LLMFormatOpenAI,
 				Provider: types.LLMProviderAWSBedrock,
 			}, &types.AppAWS{Region: "eu-central-1"}),
-			expectedError: require.NoError,
+			isResponses: true,
+			expectedURL: func(tt require.TestingT, i1 any, i2 ...any) {
+				u, _ := i1.(*url.URL)
+				require.Equal(tt, "https", u.Scheme)
+				require.Equal(tt, "bedrock-mantle.eu-central-1.api.aws", u.Host)
+				require.Equal(tt, "/openai/v1", u.Path)
+			},
+		},
+		"chat completions": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{Region: "eu-central-1"}),
+			isResponses: false,
 			expectedURL: func(tt require.TestingT, i1 any, i2 ...any) {
 				u, _ := i1.(*url.URL)
 				require.Equal(tt, "https", u.Scheme)
@@ -69,19 +105,17 @@ func TestBuildURL(t *testing.T) {
 				Format:   types.LLMFormatOpenAI,
 				Provider: types.LLMProviderAWSBedrock,
 			}, &types.AppAWS{}),
-			expectedError: require.NoError,
+			isResponses: true,
 			expectedURL: func(tt require.TestingT, i1 any, i2 ...any) {
 				u, _ := i1.(*url.URL)
 				require.Equal(tt, "https", u.Scheme)
 				require.Equal(tt, "bedrock-mantle."+defaultRegion+".api.aws", u.Host)
-				require.Equal(tt, "/v1", u.Path)
+				require.Equal(tt, "/openai/v1", u.Path)
 			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			u, err := BuildURL(slog.Default(), tc.app)
-			tc.expectedError(t, err)
-			tc.expectedURL(t, u)
+			tc.expectedURL(t, BuildOpenAIURL(slog.Default(), tc.app, tc.isResponses))
 		})
 	}
 }

--- a/lib/srv/app/llm/handler.go
+++ b/lib/srv/app/llm/handler.go
@@ -193,6 +193,7 @@ func (h *Handler) serveHTTP(w http.ResponseWriter, r *http.Request) error {
 					GetAPIKeyFunc: func() string {
 						return h.openAIAPIKey
 					},
+					SignBedrockRequest: h.signBedrockRequest,
 				})
 			},
 			func(l *slog.Logger, info llmrequest.RequestInfo, w http.ResponseWriter) (UpstreamRecorder, error) {

--- a/lib/srv/app/llm/openai/openai.go
+++ b/lib/srv/app/llm/openai/openai.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/srv/app/llm/bedrock"
+	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
 	"github.com/gravitational/teleport/lib/srv/app/llm/models"
 	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
 	"github.com/gravitational/teleport/lib/utils"
@@ -57,49 +59,56 @@ func NewRequest(cfg *llmrequest.Config) (*http.Request, llmrequest.RequestInfo, 
 		Path:   "/v1",
 	})
 
+	// All endpoints use JSON content-type.
+	providerHeaders.Set("Content-Type", "application/json")
 	llm := cfg.App.GetLLM()
-	// TODO(gabrielcorado): add support for bedrock provider.
-	switch llm.Provider {
-	case types.LLMProviderOpenAI:
-		switch strings.TrimPrefix(cfg.DownstreamRequest.URL.Path, "/v1") {
-		// https://developers.openai.com/api/reference/resources/responses/methods/create
-		case "/responses":
-			if cfg.DownstreamRequest.Method != http.MethodPost {
-				// We're ok with returning 404 back to clients instead 405 status.
-				return nil, info, trace.NotFound("responses API supports only POST requests")
-			}
 
-			// Currently, websocket mode is not supported.
-			//
-			// https://developers.openai.com/api/docs/guides/websocket-mode
-			if websocket.IsWebSocketUpgrade(cfg.DownstreamRequest) {
-				return nil, info, trace.NotFound("websocket mode is not supported")
-			}
-
-			info.endpointType = endpointTypeResponses
-			providerPath = "/responses"
-			providerMethod = http.MethodPost
-			req = &responsesAPIRequest{}
-		// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
-		case "/chat/completions":
-			if cfg.DownstreamRequest.Method != http.MethodPost {
-				// We're ok with returning 404 back to clients instead 405 status.
-				return nil, info, trace.NotFound("chat completions API supports only POST requests")
-			}
-
-			info.endpointType = endpointTypeChatCompletions
-			providerPath = "/chat/completions"
-			providerMethod = http.MethodPost
-			req = &chatCompletionsAPIRequest{}
-		default:
-			return nil, info, trace.NotFound("unsupported endpoint")
+	// Both `openai` and `bedrock` providers support responses and chat
+	// completions endpoints.
+	//
+	// https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html
+	switch strings.TrimPrefix(cfg.DownstreamRequest.URL.Path, "/v1") {
+	// https://developers.openai.com/api/reference/resources/responses/methods/create
+	case "/responses":
+		if cfg.DownstreamRequest.Method != http.MethodPost {
+			// We're ok with returning 404 back to clients instead 405 status.
+			return nil, info, trace.NotFound("responses API supports only POST requests")
 		}
 
+		// Teleport and Bedrock don't support WebSocket mode.
+		//
+		// https://developers.openai.com/api/docs/guides/websocket-mode
+		// https://developers.openai.com/api/docs/guides/amazon-bedrock#responses-api-feature-availability
+		if websocket.IsWebSocketUpgrade(cfg.DownstreamRequest) {
+			return nil, info, trace.NotFound("websocket mode is not supported")
+		}
+
+		info.endpointType = endpointTypeResponses
+		providerPath = "/responses"
+		providerMethod = http.MethodPost
+		req = &responsesAPIRequest{}
+	case "/chat/completions":
+		if cfg.DownstreamRequest.Method != http.MethodPost {
+			// We're ok with returning 404 back to clients instead 405 status.
+			return nil, info, trace.NotFound("chat completions API supports only POST requests")
+		}
+
+		info.endpointType = endpointTypeChatCompletions
+		providerPath = "/chat/completions"
+		providerMethod = http.MethodPost
+		req = &chatCompletionsAPIRequest{}
+	default:
+		return nil, info, trace.NotFound("unsupported endpoint")
+	}
+
+	switch llm.Provider {
+	case types.LLMProviderOpenAI:
 		// OpenAI API requires only `Authorization` header carrying the API key.
 		//
 		// https://developers.openai.com/api/reference/overview#authentication
 		providerHeaders.Set("Authorization", "Bearer "+cfg.GetAPIKeyFunc())
-		providerHeaders.Set("Content-Type", "application/json")
+	case types.LLMProviderAWSBedrock:
+		cfg.ProviderURL = bedrock.BuildOpenAIURL(cfg.Logger, cfg.App, info.endpointType == endpointTypeResponses)
 	default:
 		return nil, info, trace.NotImplemented("provider %q is not supported", llm.Provider)
 	}
@@ -157,5 +166,16 @@ func NewRequest(cfg *llmrequest.Config) (*http.Request, llmrequest.RequestInfo, 
 		return nil, info, trace.Wrap(err)
 	}
 	providerReq.Header = providerHeaders
+
+	if llm.Provider == types.LLMProviderAWSBedrock {
+		if err := cfg.SignBedrockRequest(providerReq.Context(), cfg.App, providerReq, providerBody); err != nil {
+			// The signing failure cause can carry AWS credentials/config
+			// details, so it is only logged, and clients receive a generic
+			// internal error message.
+			cfg.Logger.ErrorContext(providerReq.Context(), "failed to sign provider request", "error", err)
+			return nil, info, llmerrors.ErrConfig
+		}
+	}
+
 	return providerReq, info, nil
 }

--- a/lib/srv/app/llm/openai/openai_test.go
+++ b/lib/srv/app/llm/openai/openai_test.go
@@ -18,6 +18,10 @@ package openai
 
 import (
 	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -34,9 +38,18 @@ import (
 func TestNewRequest(t *testing.T) {
 	apiKey := "random-api-key"
 
+	signAWSRequest := func(_ context.Context, _ types.Application, req *http.Request, reqBody []byte) error {
+		hash := sha256.New()
+		hash.Write(reqBody)
+		req.Header.Set("X-Amz-Content-Sha256", hex.EncodeToString(hash.Sum(nil)))
+		req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=test")
+		return nil
+	}
+
 	for name, tc := range map[string]struct {
 		app             types.Application
 		request         func() *http.Request
+		signAWSRequest  func(context.Context, types.Application, *http.Request, []byte) error
 		expectedError   require.ErrorAssertionFunc
 		expectedRequest require.ValueAssertionFunc
 		expectedInfo    require.ValueAssertionFunc
@@ -363,6 +376,169 @@ func TestNewRequest(t *testing.T) {
 			expectedRequest: require.Nil,
 			expectedInfo:    require.NotNil,
 		},
+		"bedrock responses successful messages": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderAWSBedrock,
+				Models: []*types.LLM_Model{
+					{ProviderName: "openai.gpt-5.6-terra", Name: "gpt-5.6-terra"},
+				},
+			}, &types.AppAWS{
+				Region: "us-east-2",
+			}),
+			signAWSRequest: signAWSRequest,
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`{"model":"gpt-5.6-terra","input":"Hello"}`),
+				)
+				return r
+			},
+			expectedError: require.NoError,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				require.Equal(tt, "bedrock-mantle.us-east-2.api.aws", req.URL.Host)
+				require.Equal(tt, "/openai/v1/responses", req.URL.Path)
+				require.NotEmpty(tt, req.Header.Get("content-type"))
+				require.NotEmpty(tt, req.Header.Get("Authorization"))
+
+				body, err := io.ReadAll(req.Body)
+				require.NoError(tt, err)
+				require.Contains(tt, string(body), "openai.gpt-5.6-terra")
+				bodyHash := sha256.Sum256(body)
+				require.Equal(tt, hex.EncodeToString(bodyHash[:]), req.Header.Get("X-Amz-Content-Sha256"))
+			},
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Equal(tt, "gpt-5.6-terra", info.RequestedModel())
+				require.Equal(tt, "openai.gpt-5.6-terra", info.ProviderModel())
+			},
+		},
+		"bedrock chat completions successful messages": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderAWSBedrock,
+				Models: []*types.LLM_Model{
+					{ProviderName: "openai.gpt-5.6-terra", Name: "gpt-5.6-terra"},
+				},
+			}, &types.AppAWS{
+				Region: "us-east-2",
+			}),
+			signAWSRequest: signAWSRequest,
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/chat/completions",
+					strings.NewReader(`{"model":"gpt-5.6-terra","stream": true,"messages":[{"role":"user","content":"Hello"}]}`),
+				)
+				return r
+			},
+			expectedError: require.NoError,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				require.Equal(tt, "bedrock-mantle.us-east-2.api.aws", req.URL.Host)
+				require.Equal(tt, "/v1/chat/completions", req.URL.Path)
+				require.NotEmpty(tt, req.Header.Get("content-type"))
+				require.NotEmpty(tt, req.Header.Get("Authorization"))
+
+				body, err := io.ReadAll(req.Body)
+				require.NoError(tt, err)
+				require.Contains(tt, string(body), "openai.gpt-5.6-terra")
+				bodyHash := sha256.Sum256(body)
+				require.Equal(tt, hex.EncodeToString(bodyHash[:]), req.Header.Get("X-Amz-Content-Sha256"))
+			},
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Equal(tt, "gpt-5.6-terra", info.RequestedModel())
+				require.Equal(tt, "openai.gpt-5.6-terra", info.ProviderModel())
+			},
+		},
+		"bedrock signer failure": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{
+				Region: "us-east-2",
+			}),
+			signAWSRequest: func(ctx context.Context, a types.Application, r *http.Request, b []byte) error {
+				return errors.New("signing failed")
+			},
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`{"model":"gpt-5.6-terra","input":"Hello"}`),
+				)
+				return r
+			},
+			expectedError: func(tt require.TestingT, err error, i ...any) {
+				require.Error(tt, err)
+				// The signing failure cause must not reach clients.
+				require.NotContains(tt, err.Error(), "signing failed")
+			},
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"bedrock missing signer": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{
+				Region: "us-east-2",
+			}),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`{"model":"gpt-5.6-terra","input":"Hello"}`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"bedrock unsupported endpoint": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{
+				Region: "us-east-2",
+			}),
+			signAWSRequest: signAWSRequest,
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/complete",
+					strings.NewReader(`{"model":"gpt-5.6-terra","input":"Hello"}`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"bedrock unsupported method": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{
+				Region: "us-east-2",
+			}),
+			signAWSRequest: signAWSRequest,
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodGet,
+					"/responses",
+					nil,
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			req, info, err := NewRequest(&llmrequest.Config{
@@ -371,6 +547,7 @@ func TestNewRequest(t *testing.T) {
 				GetAPIKeyFunc: func() string {
 					return apiKey
 				},
+				SignBedrockRequest: tc.signAWSRequest,
 			})
 			tc.expectedError(t, err)
 			tc.expectedRequest(t, req)


### PR DESCRIPTION
Adds support for AWS Bedrock Mantle with OpenAI APIs (responses and chat completions).

## Manual Test Plan
### Test Environment

Local environment with a dedicated app service instance.

<details>
<summary>Example app configuration</summary>

```yaml
kind: app
version: v3
metadata:
  name: openai-bedrock
  description: "OpenAI API"
  labels:
    env: local
spec:
  inference:
    format: "openai"
    provider: "bedrock"
    models:
    - name: gpt-5.6-terra
      provider_name: openai.gpt-5.6-terra
    fallback_model: gpt-5.6-terra
  aws:
    region: us-east-1
```
</details>

### Test Cases
- [x] Access using `codex -c model_providers.amazon-bedrock.base_url=http://0.0.0.0:12345 -c model_providers.amazon-bedrock.auth.command=cat -c model_provider=amazon-bedrock` (Requires `codex` 0.145.0)
  - [x] Mapped model.
  - [x] Streaming requests.
  - [x] Fallback model.
  - [x] Invalid messages/errors returned are from Teleport.

- [x] Access to chat completions (using [MiniMax 2.5 model](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2-5.html#model-card-minimax-minimax-m2-5-programmatic-access))
  - [x] Mapped model.
  - [x] Streaming requests.
  - [x] Fallback model.
  - [x] Invalid messages/errors returned are from Teleport.

- [x] Access to app configured with OIDC integration
  - [x] Mapped model.
  - [x] Streaming requests.
  - [x] Fallback model.
  - [x] Invalid messages/errors returned are from Teleport.