### PR TITLE
Adding scope-aware backend for local kube service

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -351,8 +351,23 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		}
 	}
 	if cfg.Kubernetes == nil {
-		cfg.Kubernetes = local.NewKubernetesService(cfg.Backend)
+		cfg.Kubernetes, err = local.NewKubernetesService(cfg.Backend)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
+
+	if cfg.KubeClusterService == nil {
+		if service, ok := cfg.Kubernetes.(*local.KubernetesService); ok {
+			cfg.KubeClusterService = service
+		} else {
+			cfg.KubeClusterService, err = local.NewKubernetesService(cfg.Backend)
+			if err != nil {
+				return nil, trace.Wrap(err, "creating KubeClusterService")
+			}
+		}
+	}
+
 	if cfg.Status == nil {
 		cfg.Status = local.NewStatusService(cfg.Backend)
 	}
@@ -755,6 +770,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		BeamsConfigService:              cfg.BeamsConfigService,
 		SubCAService:                    cfg.SubCAService,
 		EnrollPairing:                   cfg.EnrollPairing,
+		KubeClusterService:              cfg.KubeClusterService,
 	}
 
 	if cfg.FakePasswordHash == nil {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -45,6 +45,7 @@ import (
 	auditlogpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
+	kubev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	linuxdesktopv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/linuxdesktop/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
@@ -7411,7 +7412,10 @@ func (a *ScopedServerWithRoles) UpdateKubernetesCluster(ctx context.Context, clu
 
 	// Don't allow users update clusters they don't have access to (e.g.
 	// non-matching labels). Make sure to check existing cluster too.
-	existing, err := a.authServer.GetKubernetesCluster(ctx, cluster.GetName())
+	existing, err := a.authServer.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{
+		Scope: cluster.GetScope(),
+		Name:  cluster.GetName(),
+	}.Build())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -7570,7 +7574,10 @@ func (a *ScopedServerWithRoles) DeleteAllKubernetesClusters(ctx context.Context)
 			}
 			return checker.Kube().CanAccessCluster(cluster)
 		}); err == nil {
-			if err := a.authServer.DeleteKubernetesCluster(ctx, cluster.GetName()); err != nil {
+			if err := a.authServer.DeleteKubeCluster(ctx, kubev1.DeleteKubeClusterRequest_builder{
+				Scope: cluster.GetScope(),
+				Name:  cluster.GetName(),
+			}.Build()); err != nil {
 				return trace.Wrap(err)
 			}
 			deletedAtLeastOneCluster = true

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -3460,7 +3460,7 @@ func TestKubernetesClusterCRUD_DiscoveryService(t *testing.T) {
 
 	scopedCluster, err := types.NewKubernetesClusterV3(
 		types.Metadata{
-			Name: "scoped-cluster",
+			Name: "cluster",
 			Labels: map[string]string{
 				types.CloudLabel: types.CloudAWS,
 			},
@@ -3502,7 +3502,9 @@ func TestKubernetesClusterCRUD_DiscoveryService(t *testing.T) {
 		scopedEKSCluster, ok := eksCluster.Copy().(*types.KubernetesClusterV3)
 		require.True(t, ok, "expected eksCluster copy to be a *types.KubernetesClusterV3")
 		scopedEKSCluster.Scope = "/test"
-		require.True(t, trace.IsBadParameter(discoveryClt.UpdateKubernetesCluster(ctx, scopedEKSCluster)))
+		// should fail with not found because adding a scope to an unscoped cluster name results in a new resource,
+		// which means the fetch for the existing cluster before updating will return trace.NotFoundError
+		require.True(t, trace.IsNotFound(discoveryClt.UpdateKubernetesCluster(ctx, scopedEKSCluster)), "expected trace.NotFoundError when fetching existing kube cluster before update")
 	})
 	t.Run("Delete", func(t *testing.T) {
 		require.NoError(t, discoveryClt.DeleteAllKubernetesClusters(ctx))
@@ -3533,7 +3535,8 @@ func TestKubeCRUDFromKubeService(t *testing.T) {
 		AgentPinEnabled: true,
 	}))
 
-	scopedIdent := authtest.TestScopePinnedHost(srv.ClusterName(), "scoped-host", "/test", types.RoleKube)
+	const scope = "/test"
+	scopedIdent := authtest.TestScopePinnedHost(srv.ClusterName(), "scoped-host", scope, types.RoleKube)
 	scopedKubeClient, err := srv.NewClient(scopedIdent)
 	require.NoError(t, err)
 
@@ -3559,9 +3562,9 @@ func TestKubeCRUDFromKubeService(t *testing.T) {
 	scopedKubeCluster := &types.KubernetesClusterV3{
 		Kind:    types.KindKubernetesCluster,
 		Version: types.V3,
-		Scope:   "/test",
+		Scope:   scope,
 		Metadata: types.Metadata{
-			Name: "scoped-" + clusterName,
+			Name: clusterName,
 			Labels: map[string]string{
 				"env": "test",
 			},
@@ -3633,20 +3636,15 @@ func TestKubeCRUDFromKubeService(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, scopedCluster, "expected unscoped kube cluster to be nil")
 		require.True(t, trace.IsAccessDenied(err), "expected trace.AccessDeniedError")
-
-		// scoped kube clients SHOULD be able to fetch a scoped kube cluster
-		scopedCluster, err = scopedKubeClient.GetKubernetesCluster(ctx, "scoped-"+clusterName)
-		require.NoError(t, err)
-		require.NotNil(t, scopedCluster)
 	})
 
 	t.Run("GetKubernetesClusters", func(t *testing.T) {
-		// unscoped kube clients SHOULD be able to list kube clusters
+		// unscoped kube clients SHOULD be able to list all kube clusters
 		clusters, err := unscopedKubeClient.GetKubernetesClusters(ctx)
 		require.NoError(t, err)
 		require.Len(t, clusters, 2)
 
-		// scoped kube clients SHOULD be able to list a kube clusters
+		// scoped kube clients SHOULD be able to list kube clusters within their scope
 		scopedClusters, err := scopedKubeClient.GetKubernetesClusters(ctx)
 		require.NoError(t, err)
 		require.Len(t, scopedClusters, 1)
@@ -3655,12 +3653,12 @@ func TestKubeCRUDFromKubeService(t *testing.T) {
 	})
 
 	t.Run("ListKubernetesClusters", func(t *testing.T) {
-		// unscoped kube clients SHOULD be able to list kube clusters
+		// unscoped kube clients SHOULD be able to list kube all clusters
 		clusters, _, err := unscopedKubeClient.ListKubernetesClusters(ctx, 10, "")
 		require.NoError(t, err)
 		require.Len(t, clusters, 2)
 
-		// scoped kube clients SHOULD be able to list kube clusters
+		// scoped kube clients SHOULD be able to list kube clusters within their scope
 		scopedClusters, _, err := scopedKubeClient.ListKubernetesClusters(ctx, 10, "")
 		require.NoError(t, err)
 		require.Len(t, scopedClusters, 1)

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -292,6 +292,8 @@ type InitConfig struct {
 
 	// Kubernetes is a service that manages kubernetes cluster resources.
 	Kubernetes services.Kubernetes
+	// KubeClusterService is a service that manages kube cluster resources.
+	KubeClusterService services.KubeClusterService
 
 	// AssertionReplayService is a service that mitigates SSO assertion replay.
 	*local.AssertionReplayService

--- a/lib/auth/services.go
+++ b/lib/auth/services.go
@@ -102,6 +102,7 @@ type Services struct {
 	services.BeamsConfigService
 	services.SubCAService
 	services.EnrollPairing
+	services.KubeClusterService
 }
 
 // MFAService defines the interface for managing MFA resources in the backend.

--- a/lib/services/kube.go
+++ b/lib/services/kube.go
@@ -1,0 +1,90 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package services
+
+import (
+	"context"
+	"iter"
+
+	"github.com/gravitational/trace"
+
+	kubev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/scopes"
+)
+
+// KubeClusterService handles read, list, and delete operations for [types.KubeCluster] resources.
+type KubeClusterService interface {
+	DeleteKubeCluster(ctx context.Context, req *kubev1.DeleteKubeClusterRequest) error
+	GetKubeCluster(ctx context.Context, req *kubev1.GetKubeClusterRequest) (types.KubeCluster, error)
+	ListKubeClusters(ctx context.Context, req *kubev1.ListKubeClustersRequest) ([]types.KubeCluster, string, error)
+	RangeKubeClusters(ctx context.Context, req *kubev1.ListKubeClustersRequest, startKey, endKey string) iter.Seq2[types.KubeCluster, error]
+}
+
+// KubeClusterReader implements fetching and ranging over [types.KubeCluster] resources.
+type KubeClusterReader interface {
+	GetKubeCluster(ctx context.Context, req *kubev1.GetKubeClusterRequest) (types.KubeCluster, error)
+	RangeKubeClusters(ctx context.Context, req *kubev1.ListKubeClustersRequest, startKey, endKey string) iter.Seq2[types.KubeCluster, error]
+}
+
+// KubeClusterUpstream implements fetching and listing over [types.KubeCluster] resources.
+type KubeClusterUpstream interface {
+	GetKubeCluster(ctx context.Context, req *kubev1.GetKubeClusterRequest) (types.KubeCluster, error)
+	ListKubeClusters(ctx context.Context, req *kubev1.ListKubeClustersRequest) ([]types.KubeCluster, string, error)
+}
+
+type kubeClusterClientAdapter struct {
+	grpcClient kubev1.KubeClusterServiceClient
+}
+
+// NewKubeClusterClientAdapter returns a wrapped [kubev1.KubeClusterServiceClient] that implements the
+// [KubeClusterUpstream] interface.
+func NewKubeClusterClientAdapter(grpcClient kubev1.KubeClusterServiceClient) KubeClusterUpstream {
+	return kubeClusterClientAdapter{
+		grpcClient: grpcClient,
+	}
+}
+
+// GetKubeCluster fetches a specific [types.KubeCluster] resource using the wrapped client.
+func (c kubeClusterClientAdapter) GetKubeCluster(ctx context.Context, req *kubev1.GetKubeClusterRequest) (types.KubeCluster, error) {
+	res, err := c.grpcClient.GetKubeCluster(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return res.GetCluster(), nil
+}
+
+// ListKubeClusters fetches a page of [types.KubeCluster] resources using the wrapped client.
+func (c kubeClusterClientAdapter) ListKubeClusters(ctx context.Context, req *kubev1.ListKubeClustersRequest) ([]types.KubeCluster, string, error) {
+	res, err := c.grpcClient.ListKubeClusters(ctx, req)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	clusters := make([]types.KubeCluster, len(res.GetClusters()))
+	for i, cluster := range res.GetClusters() {
+		clusters[i] = cluster
+	}
+	return clusters, res.GetNextPageToken(), nil
+}
+
+// GetCursorForKubeCluster returns the backend key for a kube cluster with
+// consideration for whether or not it is scoped.
+func GetCursorForKubeCluster(cluster types.KubeCluster) string {
+	return scopes.MakeResourceCursor(cluster.GetScope(), cluster.GetName())
+}

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/devicetrust"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
@@ -1760,7 +1761,10 @@ func (p *databaseServiceParser) parse(event backend.Event) (types.Resource, erro
 
 func newKubeClusterParser() *kubeClusterParser {
 	return &kubeClusterParser{
-		baseParser: newBaseParser(backend.NewKey(kubernetesPrefix)),
+		baseParser: newBaseParser(
+			kubeUnscopedPrefix(),
+			kubeScopedPrefix(),
+		),
 	}
 }
 
@@ -1771,17 +1775,19 @@ type kubeClusterParser struct {
 func (p *kubeClusterParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		name := event.Item.Key.TrimPrefix(backend.NewKey(kubernetesPrefix)).String()
-		if name == "" {
-			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		sqn, err := kubeNameFromKey(event.Item.Key)
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
-		return &types.ResourceHeader{
+
+		return &types.KubernetesClusterV3{
 			Kind:    types.KindKubernetesCluster,
 			Version: types.V3,
 			Metadata: types.Metadata{
-				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Name:      sqn.Name,
 				Namespace: apidefaults.Namespace,
 			},
+			Scope: sqn.Scope,
 		}, nil
 	case types.OpPut:
 		return services.UnmarshalKubeCluster(event.Item.Value,
@@ -1790,6 +1796,35 @@ func (p *kubeClusterParser) parse(event backend.Event) (types.Resource, error) {
 		)
 	default:
 		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
+}
+
+func kubeNameFromKey(key backend.Key) (scopes.QualifiedName, error) {
+	switch {
+	case key.HasPrefix(kubeScopedPrefix()):
+		components := key.TrimPrefix(kubeScopedPrefix()).Components()
+		if len(components) != 2 {
+			return scopes.QualifiedName{}, trace.NotFound("failed parsing %v", key.String())
+		}
+		encodedScope, name := components[0], components[1]
+		scope, err := scopes.DecodeFromKey(encodedScope)
+		if err != nil {
+			return scopes.QualifiedName{}, trace.Wrap(err)
+		}
+		return scopes.QualifiedName{
+			Scope: scope,
+			Name:  name,
+		}, nil
+	case key.HasPrefix(kubeUnscopedPrefix()):
+		components := key.TrimPrefix(kubeUnscopedPrefix()).Components()
+		if len(components) != 1 {
+			return scopes.QualifiedName{}, trace.NotFound("failed parsing %v", key.String())
+		}
+		return scopes.QualifiedName{
+			Name: components[0],
+		}, nil
+	default:
+		return scopes.QualifiedName{}, trace.NotFound("failed parsing %v", key.String())
 	}
 }
 

--- a/lib/services/local/kube.go
+++ b/lib/services/local/kube.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+	kubev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/itertools/stream"
@@ -38,14 +39,36 @@ import (
 type KubernetesService struct {
 	backend.Backend
 	logger *slog.Logger
+	svc    *generic.ScopeAwareService[types.KubeCluster]
 }
 
 // NewKubernetesService creates a new KubernetesService.
-func NewKubernetesService(backend backend.Backend) *KubernetesService {
-	return &KubernetesService{
-		Backend: backend,
-		logger:  slog.With(teleport.ComponentKey, "KubernetesService"),
+func NewKubernetesService(b backend.Backend) (*KubernetesService, error) {
+	svc, err := generic.NewScopeAwareService(&generic.ScopeAwareServiceConfig[types.KubeCluster]{
+		Backend:               b,
+		ResourceKind:          types.KindKubernetesCluster,
+		UnscopedBackendPrefix: kubeUnscopedPrefix(),
+		ScopedBackendPrefix:   kubeScopedPrefix(),
+		MarshalFunc: func(kc types.KubeCluster, option ...services.MarshalOption) ([]byte, error) {
+			return services.MarshalKubeCluster(kc, option...)
+		},
+		UnmarshalFunc: func(bytes []byte, option ...services.MarshalOption) (types.KubeCluster, error) {
+			cluster, err := services.UnmarshalKubeCluster(bytes, option...)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return cluster, nil
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
+
+	return &KubernetesService{
+		Backend: b,
+		logger:  slog.With(teleport.ComponentKey, "KubernetesService"),
+		svc:     svc,
+	}, nil
 }
 
 // GetKubernetesClusters returns all kubernetes cluster resources.
@@ -61,62 +84,57 @@ func (s *KubernetesService) GetKubernetesClusters(ctx context.Context) ([]types.
 
 // ListKubernetesClusters returns a page of registered kubernetes clusters.
 func (s *KubernetesService) ListKubernetesClusters(ctx context.Context, limit int, start string) ([]types.KubeCluster, string, error) {
-	return generic.CollectPageAndCursor(s.RangeKubernetesClusters(ctx, start, ""), limit, types.KubeCluster.GetName)
+	return s.svc.ListResources(ctx, limit, start)
+}
+
+// ListKubeClusters returns a page of registered kube clusters respecting scope filters.
+func (s *KubernetesService) ListKubeClusters(ctx context.Context, req *kubev1.ListKubeClustersRequest) ([]types.KubeCluster, string, error) {
+	scopeFilter := req.GetScopeFilter()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	filterFn := func(kc types.KubeCluster) bool {
+		return scopes.MatchScope(scopeFilter, kc.GetScope())
+	}
+
+	return s.svc.ListResourcesWithFilter(ctx, int(req.GetPageSize()), req.GetPageToken(), filterFn)
 }
 
 // RangeKubernetesClusters returns kubernetes clusters within the range [start, end).
 func (s *KubernetesService) RangeKubernetesClusters(ctx context.Context, start, end string) iter.Seq2[types.KubeCluster, error] {
-	mapFn := func(item backend.Item) (types.KubeCluster, bool) {
-		cluster, err := services.UnmarshalKubeCluster(item.Value,
-			services.WithExpires(item.Expires),
-			services.WithRevision(item.Revision))
-		if err != nil {
-			s.logger.WarnContext(ctx, "Failed to unmarshal kubernetes cluster",
-				"key", item.Key,
-				"error", err,
-			)
-			return nil, false
-		}
-		return cluster, true
+	return s.svc.Resources(ctx, start, end)
+}
+
+// RangeKubeClusters returns kubernetes clusters within the range [start, end).
+func (s *KubernetesService) RangeKubeClusters(ctx context.Context, req *kubev1.ListKubeClustersRequest, start, end string) iter.Seq2[types.KubeCluster, error] {
+	scopeFilter := req.GetScopeFilter()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return stream.Fail[types.KubeCluster](trace.Wrap(err))
+	}
+	filterFn := func(kc types.KubeCluster) (types.KubeCluster, bool) {
+		return kc, scopes.MatchScope(scopeFilter, kc.GetScope())
 	}
 
-	kubernetesKey := backend.NewKey(kubernetesPrefix)
-	startKey := kubernetesKey.AppendKey(backend.KeyFromString(start))
-	endKey := backend.RangeEnd(kubernetesKey)
-	if end != "" {
-		endKey = kubernetesKey.AppendKey(backend.KeyFromString(end)).ExactKey()
-	}
-
-	return stream.TakeWhile(
-		stream.FilterMap(
-			s.Backend.Items(ctx, backend.ItemsParams{
-				StartKey: startKey,
-				EndKey:   endKey,
-			}),
-			mapFn,
-		),
-		func(cluster types.KubeCluster) bool {
-			// The range is not inclusive of the end key, so return early
-			// if the end has been reached.
-			return end == "" || cluster.GetName() < end
-		})
+	return stream.FilterMap(s.svc.Resources(ctx, start, end), filterFn)
 }
 
 // GetKubernetesCluster returns the specified kubernetes cluster resource.
 func (s *KubernetesService) GetKubernetesCluster(ctx context.Context, name string) (types.KubeCluster, error) {
-	item, err := s.Get(ctx, backend.NewKey(kubernetesPrefix, name))
-	if err != nil {
-		if trace.IsNotFound(err) {
-			return nil, trace.NotFound("kubernetes cluster %q doesn't exist", name)
+	return s.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{Name: name}.Build())
+}
+
+// GetKubeCluster returns the specified kubernetes cluster resource.
+func (s *KubernetesService) GetKubeCluster(ctx context.Context, req *kubev1.GetKubeClusterRequest) (types.KubeCluster, error) {
+	sqn := scopes.QualifiedName{
+		Scope: req.GetScope(),
+		Name:  req.GetName(),
+	}
+	if sqn.Scope != "" {
+		if err := sqn.WeakValidate(); err != nil {
+			return nil, trace.Wrap(err)
 		}
-		return nil, trace.Wrap(err)
 	}
-	cluster, err := services.UnmarshalKubeCluster(item.Value,
-		services.WithExpires(item.Expires), services.WithRevision(item.Revision))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return cluster, nil
+	return s.svc.GetResource(ctx, sqn)
 }
 
 // CreateKubernetesCluster creates a new kubernetes cluster resource.
@@ -124,24 +142,9 @@ func (s *KubernetesService) CreateKubernetesCluster(ctx context.Context, cluster
 	if err := validateKubeCluster(cluster); err != nil {
 		return trace.Wrap(err)
 	}
-	value, err := services.MarshalKubeCluster(cluster)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	item := backend.Item{
-		Key:     backend.NewKey(kubernetesPrefix, cluster.GetName()),
-		Value:   value,
-		Expires: cluster.Expiry(),
-	}
-	_, err = s.Create(ctx, item)
-	if trace.IsAlreadyExists(err) {
-		return trace.AlreadyExists("kubernetes cluster %q already exists", cluster.GetName())
-	}
 
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
+	_, err := s.svc.CreateResource(ctx, cluster)
+	return trace.Wrap(err)
 }
 
 // UpdateKubernetesCluster updates an existing kubernetes cluster resource.
@@ -149,47 +152,28 @@ func (s *KubernetesService) UpdateKubernetesCluster(ctx context.Context, cluster
 	if err := validateKubeCluster(cluster); err != nil {
 		return trace.Wrap(err)
 	}
-	rev := cluster.GetRevision()
-	value, err := services.MarshalKubeCluster(cluster)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	item := backend.Item{
-		Key:      backend.NewKey(kubernetesPrefix, cluster.GetName()),
-		Value:    value,
-		Expires:  cluster.Expiry(),
-		Revision: rev,
-	}
-	_, err = s.Update(ctx, item)
-	if trace.IsNotFound(err) {
-		return trace.NotFound("kubernetes cluster %q doesn't exist", cluster.GetName())
-	}
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
+	_, err := s.svc.UpdateResource(ctx, cluster)
+	return trace.Wrap(err)
 }
 
 // DeleteKubernetesCluster removes the specified kubernetes cluster resource.
 func (s *KubernetesService) DeleteKubernetesCluster(ctx context.Context, name string) error {
-	err := s.Delete(ctx, backend.NewKey(kubernetesPrefix, name))
-	if err != nil {
-		if trace.IsNotFound(err) {
-			return trace.NotFound("kubernetes cluster %q doesn't exist", name)
-		}
-		return trace.Wrap(err)
-	}
-	return nil
+	return s.svc.DeleteResource(ctx, scopes.QualifiedName{
+		Name: name,
+	})
+}
+
+// DeleteKubeCluster removes the specified kubernetes cluster resource.
+func (s *KubernetesService) DeleteKubeCluster(ctx context.Context, req *kubev1.DeleteKubeClusterRequest) error {
+	return s.svc.DeleteResource(ctx, scopes.QualifiedName{
+		Scope: req.GetScope(),
+		Name:  req.GetName(),
+	})
 }
 
 // DeleteAllKubernetesClusters removes all kubernetes cluster resources.
 func (s *KubernetesService) DeleteAllKubernetesClusters(ctx context.Context) error {
-	startKey := backend.ExactKey(kubernetesPrefix)
-	err := s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
+	return s.svc.DeleteAllResources(ctx)
 }
 
 func validateKubeCluster(cluster types.KubeCluster) error {
@@ -212,6 +196,10 @@ func validateKubeCluster(cluster types.KubeCluster) error {
 	return nil
 }
 
-const (
-	kubernetesPrefix = "kubernetes"
-)
+func kubeUnscopedPrefix() backend.Key {
+	return backend.NewKey("kubernetes")
+}
+
+func kubeScopedPrefix() backend.Key {
+	return backend.NewKey("scoped", "kubernetes")
+}

--- a/lib/services/local/kube_test.go
+++ b/lib/services/local/kube_test.go
@@ -19,7 +19,6 @@
 package local
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -28,6 +27,8 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
+	kubev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/itertools/stream"
@@ -35,7 +36,7 @@ import (
 
 // TestKubernetesCRUD tests backend operations with kubernetes resources.
 func TestKubernetesCRUD(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	backend, err := memory.New(memory.Config{
 		Context: ctx,
@@ -43,9 +44,10 @@ func TestKubernetesCRUD(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := NewKubernetesService(backend)
+	service, err := NewKubernetesService(backend)
+	require.NoError(t, err)
 
-	// Create a couple kube clusters.
+	// Create a few couple kube clusters.
 	kubeCluster1, err := types.NewKubernetesClusterV3(types.Metadata{
 		Name: "c1",
 	}, types.KubernetesClusterSpecV3{})
@@ -59,93 +61,241 @@ func TestKubernetesCRUD(t *testing.T) {
 	}, types.KubernetesClusterSpecV3{})
 	require.NoError(t, err)
 
-	// Initially we expect no Kubernetess.
-	out, err := service.GetKubernetesClusters(ctx)
-	require.NoError(t, err)
-	require.Empty(t, out)
+	testLegacyMethods(t, service, []types.KubeCluster{
+		kubeCluster1,
+		kubeCluster2,
+		kubeCluster3,
+	})
+}
 
-	// Create both Kubernetess.
-	err = service.CreateKubernetesCluster(ctx, kubeCluster1)
-	require.NoError(t, err)
-	err = service.CreateKubernetesCluster(ctx, kubeCluster2)
-	require.NoError(t, err)
-	err = service.CreateKubernetesCluster(ctx, kubeCluster3)
+// TestScopedKubeClusterCRUD tests backend operations with kubernetes resources.
+func TestScopedKubeClusterCRUD(t *testing.T) {
+	ctx := t.Context()
+
+	backend, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clockwork.NewFakeClock(),
+	})
 	require.NoError(t, err)
 
-	expectedAll := []types.KubeCluster{kubeCluster1, kubeCluster2, kubeCluster3}
+	service, err := NewKubernetesService(backend)
+	require.NoError(t, err)
+
+	const (
+		scope           = "/aa"
+		orthogonalScope = "/bb"
+	)
+
+	// Create a couple kube clusters.
+	unscopedCluster, err := types.NewKubernetesClusterV3(types.Metadata{
+		Name: "kube-cluster",
+	}, types.KubernetesClusterSpecV3{})
+	require.NoError(t, err)
+	scopedCluster, err := types.NewKubernetesClusterV3(types.Metadata{
+		Name: "kube-cluster",
+	}, types.KubernetesClusterSpecV3{}, types.KubeClusterWithScope(scope))
+	require.NoError(t, err)
+	orthogonalCluster, err := types.NewKubernetesClusterV3(types.Metadata{
+		Name: "kube-cluster",
+	}, types.KubernetesClusterSpecV3{}, types.KubeClusterWithScope(orthogonalScope))
+	require.NoError(t, err)
+
+	clusters := []types.KubeCluster{
+		unscopedCluster,
+		scopedCluster,
+		orthogonalCluster,
+	}
+	testLegacyMethods(t, service, clusters)
+
+	// test new kube cluster methods
+	//
+	// Create all clusters
+	for _, cluster := range clusters {
+		err = service.CreateKubernetesCluster(ctx, cluster)
+		require.NoError(t, err)
+	}
+
+	// ensure each cluster can be updated and fetched
 	diffopt := cmpopts.IgnoreFields(types.Metadata{}, "Revision")
+	for _, cluster := range clusters {
+		cluster.SetStaticLabels(map[string]string{"updated": "updated"})
+		err := service.UpdateKubernetesCluster(ctx, cluster)
+		require.NoError(t, err)
 
-	// Fetch all Kubernetess.
-	out, err = service.GetKubernetesClusters(ctx)
+		res, err := service.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{
+			Scope: cluster.GetScope(),
+			Name:  cluster.GetName(),
+		}.Build())
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(cluster, res, diffopt))
+		require.Equal(t, "updated", res.GetStaticLabels()["updated"])
+	}
+
+	// ensure all clusters can be listed
+	list, nextToken, err := service.ListKubeClusters(ctx, kubev1.ListKubeClustersRequest_builder{
+		PageSize: 10,
+	}.Build())
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(expectedAll, out, diffopt))
+	require.Empty(t, nextToken)
+	require.Len(t, list, 3)
 
-	// List with page limit
-	page1, page2Start, err := service.ListKubernetesClusters(ctx, 2, "")
+	// ensure scope filtering works
+	list, nextToken, err = service.ListKubeClusters(ctx, kubev1.ListKubeClustersRequest_builder{
+		PageSize: 10,
+		ScopeFilter: scopesv1.Filter_builder{
+			Scope: scopedCluster.GetScope(),
+			Mode:  scopesv1.Mode_MODE_EXACT,
+		}.Build(),
+	}.Build())
 	require.NoError(t, err)
-	require.NotEmpty(t, page2Start)
-	require.Len(t, page1, 2)
+	require.Empty(t, nextToken)
+	require.Len(t, list, 1)
+	require.Empty(t, cmp.Diff(scopedCluster, list[0], diffopt))
 
-	// List with start
-	page2, next, err := service.ListKubernetesClusters(ctx, 2, page2Start)
+	// ensure unscoped filtering works
+	list, nextToken, err = service.ListKubeClusters(ctx, kubev1.ListKubeClustersRequest_builder{
+		PageSize: 10,
+		ScopeFilter: scopesv1.Filter_builder{
+			Mode: scopesv1.Mode_MODE_UNSCOPED,
+		}.Build(),
+	}.Build())
 	require.NoError(t, err)
-	require.Empty(t, next)
-	require.Len(t, page2, 1)
-	require.Empty(t, cmp.Diff(expectedAll, append(page1, page2...), diffopt))
+	require.Empty(t, nextToken)
+	require.Len(t, list, 1)
+	require.Empty(t, cmp.Diff(unscopedCluster, list[0], diffopt))
 
-	// Range over all
-	out, err = stream.Collect(service.RangeKubernetesClusters(ctx, "", ""))
-	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(expectedAll, out, diffopt))
+	// ensure clusters can be deleted
+	for _, cluster := range clusters {
+		cluster.SetStaticLabels(map[string]string{"updated": "updated"})
+		err := service.UpdateKubernetesCluster(ctx, cluster)
+		require.NoError(t, err)
 
-	// Range with upper bound
-	out, err = stream.Collect(service.RangeKubernetesClusters(ctx, "", page2Start))
-	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(page1, out, diffopt))
+		err = service.DeleteKubeCluster(ctx, kubev1.DeleteKubeClusterRequest_builder{
+			Scope: cluster.GetScope(),
+			Name:  cluster.GetName(),
+		}.Build())
+		require.NoError(t, err)
 
-	// Range with lower bound
-	out, err = stream.Collect(service.RangeKubernetesClusters(ctx, page2Start, ""))
-	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(page2, out, diffopt))
+		_, err = service.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{
+			Scope: cluster.GetScope(),
+			Name:  cluster.GetName(),
+		}.Build())
+		require.Error(t, err)
+		require.True(t, trace.IsNotFound(err), "expected not found error after kube cluster deletion")
+	}
+}
 
-	// Fetch a specific Kubernetes.
-	cluster, err := service.GetKubernetesCluster(ctx, kubeCluster2.GetName())
-	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(kubeCluster2, cluster, diffopt))
+func testLegacyMethods(t *testing.T, service *KubernetesService, clusters []types.KubeCluster) {
+	t.Helper()
+	if len(clusters) < 3 {
+		require.FailNow(t, "need at least 3 clusters to run legacy method test")
+	}
 
-	// Try to fetch a Kubernetes that doesn't exist.
-	_, err = service.GetKubernetesCluster(ctx, "doesnotexist")
-	require.ErrorAs(t, err, new(*trace.NotFoundError))
+	t.Run("legacy methods", func(t *testing.T) {
+		ctx := t.Context()
+		// We should start out with no clusters
+		out, err := service.GetKubernetesClusters(ctx)
+		require.NoError(t, err)
+		require.Empty(t, out)
 
-	// Try to create the same Kubernetes.
-	err = service.CreateKubernetesCluster(ctx, kubeCluster1)
-	require.ErrorAs(t, err, new(*trace.AlreadyExistsError))
+		// Create all clusters
+		for _, cluster := range clusters {
+			err = service.CreateKubernetesCluster(ctx, cluster)
+			require.NoError(t, err)
+		}
 
-	// Update a Kubernetes.
-	kubeCluster1.Metadata.Description = "description"
-	err = service.UpdateKubernetesCluster(ctx, kubeCluster1)
-	require.NoError(t, err)
-	cluster, err = service.GetKubernetesCluster(ctx, kubeCluster1.GetName())
-	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(kubeCluster1, cluster, diffopt))
+		diffopt := cmpopts.IgnoreFields(types.Metadata{}, "Revision")
 
-	// Delete a Kubernetes.
-	err = service.DeleteKubernetesCluster(ctx, kubeCluster1.GetName())
-	require.NoError(t, err)
+		// Fetch all clusters
+		out, err = service.GetKubernetesClusters(ctx)
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(clusters, out, diffopt))
 
-	expectedAll = []types.KubeCluster{kubeCluster2, kubeCluster3}
-	out, err = service.GetKubernetesClusters(ctx)
-	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(expectedAll, out, diffopt))
+		// List with page limit
+		page1, page2Start, err := service.ListKubernetesClusters(ctx, 2, "")
+		require.NoError(t, err)
+		require.NotEmpty(t, page2Start)
+		require.Len(t, page1, 2)
 
-	// Try to delete a Kubernetes that doesn't exist.
-	err = service.DeleteKubernetesCluster(ctx, "doesnotexist")
-	require.ErrorAs(t, err, new(*trace.NotFoundError))
+		// List with start
+		page2, next, err := service.ListKubernetesClusters(ctx, 2, page2Start)
+		require.NoError(t, err)
+		require.Empty(t, next)
+		require.Len(t, page2, 1)
+		require.Empty(t, cmp.Diff(clusters, append(page1, page2...), diffopt))
 
-	// Delete all Kubernetess.
-	err = service.DeleteAllKubernetesClusters(ctx)
-	require.NoError(t, err)
-	out, err = service.GetKubernetesClusters(ctx)
-	require.NoError(t, err)
-	require.Empty(t, out)
+		// Range over all
+		out, err = stream.Collect(service.RangeKubernetesClusters(ctx, "", ""))
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(clusters, out, diffopt))
+
+		// Range with upper bound
+		out, err = stream.Collect(service.RangeKubernetesClusters(ctx, "", page2Start))
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(page1, out, diffopt))
+
+		// Range with lower bound
+		out, err = stream.Collect(service.RangeKubernetesClusters(ctx, page2Start, ""))
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(page2, out, diffopt))
+
+		// Fetch a specific kube cluster
+		if clusters[1].GetScope() == "" {
+			cluster, err := service.GetKubernetesCluster(ctx, clusters[1].GetName())
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(clusters[1], cluster, diffopt))
+		} else {
+			cluster, err := service.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{
+				Scope: clusters[1].GetScope(),
+				Name:  clusters[1].GetName(),
+			}.Build())
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(clusters[1], cluster, diffopt))
+		}
+
+		// Try to fetch a kube cluster that doesn't exist
+		_, err = service.GetKubernetesCluster(ctx, "doesnotexist")
+		require.ErrorAs(t, err, new(*trace.NotFoundError))
+
+		// Try to create the same kube cluster
+		err = service.CreateKubernetesCluster(ctx, clusters[0])
+		require.ErrorAs(t, err, new(*trace.AlreadyExistsError))
+
+		// Update a kube cluster
+		clusters[0].SetStaticLabels(map[string]string{"updated": "yes"})
+		err = service.UpdateKubernetesCluster(ctx, clusters[0])
+		require.NoError(t, err)
+		if clusters[0].GetScope() == "" {
+			cluster, err := service.GetKubernetesCluster(ctx, clusters[0].GetName())
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(clusters[0], cluster, diffopt))
+		} else {
+			cluster, err := service.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{
+				Scope: clusters[0].GetScope(),
+				Name:  clusters[0].GetName(),
+			}.Build())
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(clusters[0], cluster, diffopt))
+		}
+
+		// Delete a Kubernetes.
+		err = service.DeleteKubernetesCluster(ctx, clusters[0].GetName())
+		require.NoError(t, err)
+
+		expectedClusters := []types.KubeCluster{clusters[1], clusters[2]}
+		out, err = service.GetKubernetesClusters(ctx)
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(expectedClusters, out, diffopt))
+
+		// Try to delete a Kubernetes that doesn't exist.
+		err = service.DeleteKubernetesCluster(ctx, "doesnotexist")
+		require.ErrorAs(t, err, new(*trace.NotFoundError))
+
+		// Delete all Kubernetess.
+		err = service.DeleteAllKubernetesClusters(ctx)
+		require.NoError(t, err)
+		out, err = service.GetKubernetesClusters(ctx)
+		require.NoError(t, err)
+		require.Empty(t, out)
+	})
 }


### PR DESCRIPTION
Replaces the backend used for kube resources with the a scope-aware generic service.


## Manual Test Plan
### Test Environment
Local teleport cluster with `TELEPORT_UNSTABLE_SCOPES=yes`
### Test Cases
- [ ] General CRUD still works for unscoped kube clusters
- [ ] Creating, updating, and listing all scoped kube clusters works
- [ ] Fetching clusters whose names collide using an SQN does not work (coming later)
