### PR TITLE
Adding kubecluster gRPC service and caching layer for scoped kube clusters

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -93,7 +93,7 @@ import (
 	inventoryv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/inventory/v1"
 	issuancev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/issuance/v1"
 	joinv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/join/v1"
-	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
+	kubev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	kubewaitingcontainerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	linuxdesktopv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/linuxdesktop/v1"
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
@@ -4870,7 +4870,7 @@ func GetResourcesWithFilters(ctx context.Context, clt ListResourcesClient, req p
 
 // GetKubernetesResourcesWithFilters is a helper for getting a list of kubernetes resources with optional filtering. In addition to
 // iterating pages, it also correctly handles downsizing pages when LimitExceeded errors are encountered.
-func GetKubernetesResourcesWithFilters(ctx context.Context, clt kubeproto.KubeServiceClient, req *kubeproto.ListKubernetesResourcesRequest) ([]types.ResourceWithLabels, error) {
+func GetKubernetesResourcesWithFilters(ctx context.Context, clt kubev1.KubeServiceClient, req *kubev1.ListKubernetesResourcesRequest) ([]types.ResourceWithLabels, error) {
 	var (
 		resources []types.ResourceWithLabels
 		startKey  = req.StartKey
@@ -6444,4 +6444,9 @@ func (c *Client) ListCertAuthorityOverrides(
 // IssuanceClient returns an [issuancev1pb.IssuanceServiceClient].
 func (c *Client) IssuanceClient() issuancev1pb.IssuanceServiceClient {
 	return issuancev1pb.NewIssuanceServiceClient(c.conn)
+}
+
+// KubeClusterServiceClient returns a [kubev1.KubeClusterServiceClient].
+func (c *Client) KubeClusterServiceClient() kubev1.KubeClusterServiceClient {
+	return kubev1.NewKubeClusterServiceClient(c.conn)
 }

--- a/lib/auth/accesspoint/accesspoint.go
+++ b/lib/auth/accesspoint/accesspoint.go
@@ -122,6 +122,7 @@ type Config struct {
 	AppAuthConfig           services.AppAuthConfigReader
 	Summarizer              services.Summarizer
 	SubCAService            services.SubCAServiceGetter
+	KubeClusterUpstream     services.KubeClusterUpstream
 }
 
 func (c *Config) CheckAndSetDefaults() error {
@@ -183,6 +184,7 @@ func NewCache(cfg Config) (*cache.Cache, error) {
 		Integrations:            cfg.Integrations,
 		KubeWaitingContainers:   cfg.KubeWaitingContainers,
 		Kubernetes:              cfg.Kubernetes,
+		KubeClusterUpstream:     cfg.KubeClusterUpstream,
 		Notifications:           cfg.Notifications,
 		Okta:                    cfg.Okta,
 		Presence:                cfg.Presence,

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -1584,6 +1584,8 @@ type Cache interface {
 
 	// SubCAServiceGetter reads CertAuthorityOverride resources.
 	services.SubCAServiceGetter
+	// KubeClusterReader reads KubeCluster resources.
+	services.KubeClusterReader
 }
 
 type NodeWrapper struct {

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -50,6 +50,7 @@ import (
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	integrationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	inventoryv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/inventory/v1"
+	kubev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	linuxdesktopv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/linuxdesktop/v1"
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
@@ -682,6 +683,11 @@ func (c *Client) CrownJewelsClient() services.CrownJewels {
 // StaticHostUserClient returns a client for managing static host user resources.
 func (c *Client) StaticHostUserClient() services.StaticHostUser {
 	return c.APIClient.StaticHostUserClient()
+}
+
+// KubeClusterServiceClient returns a client for managing KubeCluster resources.
+func (c *Client) KubeClusterServiceClient() kubev1.KubeClusterServiceClient {
+	return c.APIClient.KubeClusterServiceClient()
 }
 
 // DeleteStaticTokens deletes static tokens
@@ -2002,4 +2008,7 @@ type ClientI interface {
 
 	// BeamServiceClient returns a client for the beam service.
 	BeamServiceClient() beamsv1.BeamServiceClient
+
+	// KubeClusterServiceClient returns a client for the kube cluster service.
+	KubeClusterServiceClient() kubev1.KubeClusterServiceClient
 }

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -624,6 +624,7 @@ func InitAuthCache(p AuthCacheParams) error {
 		Integrations:            p.AuthServer.Services.Integrations,
 		KubeWaitingContainers:   p.AuthServer.Services.KubeWaitingContainer,
 		Kubernetes:              p.AuthServer.Services.Kubernetes,
+		KubeClusterUpstream:     p.AuthServer.Services.KubeClusterService,
 		Notifications:           p.AuthServer.Services.Notifications,
 		Okta:                    p.AuthServer.Services.Okta,
 		Presence:                p.AuthServer.Services.PresenceInternal,

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -73,6 +73,7 @@ import (
 	integrationv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	inventorypb "github.com/gravitational/teleport/api/gen/proto/go/teleport/inventory/v1"
 	issuancev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/issuance/v1"
+	kubev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	kubewaitingcontainerv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	linuxdesktopv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/linuxdesktop/v1"
 	loginrulev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
@@ -124,6 +125,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/integration/integrationv1"
 	"github.com/gravitational/teleport/lib/auth/inventory/inventoryv1"
 	issuancev1 "github.com/gravitational/teleport/lib/auth/issuance/v1"
+	kubecluster "github.com/gravitational/teleport/lib/auth/kubecluster"
 	"github.com/gravitational/teleport/lib/auth/kubewaitingcontainer/kubewaitingcontainerv1"
 	"github.com/gravitational/teleport/lib/auth/linuxdesktop/linuxdesktopv1"
 	"github.com/gravitational/teleport/lib/auth/loginrule/loginrulev1"
@@ -6745,6 +6747,16 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		// start a client IP restriction service that returns errors for all RPCs when not running on Teleport Cloud
 		clientiprestrictionv1pb.RegisterClientIPRestrictionServiceServer(server, clientiprestrictionv1.NewService())
 	}
+
+	kubeClusterSvc, err := kubecluster.New(&kubecluster.Config{
+		ScopedAuthorizer: cfg.ScopedAuthorizer,
+		ClusterWriter:    cfg.AuthServer,
+		ClusterReader:    cfg.AuthServer,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "instantiating kubev1 cluster service")
+	}
+	kubev1.RegisterKubeClusterServiceServer(server, kubeClusterSvc)
 
 	return authServer, nil
 }

--- a/lib/auth/kubecluster/service.go
+++ b/lib/auth/kubecluster/service.go
@@ -1,0 +1,199 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package kubecluster
+
+import (
+	"context"
+	"iter"
+	"log/slog"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	kubev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
+	"github.com/gravitational/teleport/api/types"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local/generic"
+)
+
+// A ClusterReader knows how to get and range over kube clusters.
+type ClusterReader interface {
+	GetKubeCluster(ctx context.Context, req *kubev1.GetKubeClusterRequest) (types.KubeCluster, error)
+	RangeKubeClusters(ctx context.Context, req *kubev1.ListKubeClustersRequest, startKey, endKey string) iter.Seq2[types.KubeCluster, error]
+}
+
+// A ClusterWriter knows how to delete kube clusters.
+type ClusterWriter interface {
+	DeleteKubeCluster(ctx context.Context, req *kubev1.DeleteKubeClusterRequest) error
+}
+
+// Config contains the parameters for building a new [Server].
+type Config struct {
+	ScopedAuthorizer authz.ScopedAuthorizer
+	Logger           *slog.Logger
+	Emitter          apievents.Emitter
+	ClusterReader    ClusterReader
+	ClusterWriter    ClusterWriter
+}
+
+// Server is the [kubev1.UnimplementedKubeClusterServiceServer] returned by
+// [New].
+type Server struct {
+	cfg *Config
+	kubev1.UnimplementedKubeClusterServiceServer
+}
+
+// New returns the auth server implementation for the kube cluster service,
+// including the gRPC interface, authz enforcement, and business logic.
+func New(cfg *Config) (*Server, error) {
+	switch {
+	case cfg.ScopedAuthorizer == nil:
+		return nil, trace.BadParameter("ScopedAuthorizer must be provided")
+	case cfg.ClusterReader == nil:
+		return nil, trace.BadParameter("ClusterReader must be provided")
+	case cfg.ClusterWriter == nil:
+		return nil, trace.BadParameter("ClusterWriter must be provided")
+	case cfg.Logger == nil:
+		cfg.Logger = slog.With(teleport.ComponentKey, "kube")
+	}
+	return &Server{
+		cfg: cfg,
+	}, nil
+}
+
+// GetKubeCluster returns the specified kube cluster resource.
+func (s *Server) GetKubeCluster(ctx context.Context, req *kubev1.GetKubeClusterRequest) (*kubev1.GetKubeClusterResponse, error) {
+	authContext, err := s.cfg.ScopedAuthorizer.AuthorizeScoped(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ruleCtx := authContext.RuleContext()
+	if err := authContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbRead); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	cluster, err := s.cfg.ClusterReader.GetKubeCluster(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authContext.CheckerContext.Decision(ctx, cluster.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbRead); err != nil {
+			return err
+		}
+		return checker.Kube().CanAccessCluster(cluster)
+	}); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	clusterV3, ok := cluster.(*types.KubernetesClusterV3)
+	if !ok {
+		return nil, trace.BadParameter("invalid cluster")
+	}
+	return kubev1.GetKubeClusterResponse_builder{
+		Cluster: clusterV3,
+	}.Build(), nil
+}
+
+// getCursorForKubeCluster wraps [services.GetCursorForKubeCluster] with a signature
+// referencing [*types.KubernetesClusterV3] directly. This helps go infer the proper
+// typing when using [generic.CollectPageAndCursor].
+func getCursorForKubeCluster(cluster *types.KubernetesClusterV3) string {
+	return services.GetCursorForKubeCluster(cluster)
+}
+
+// ListKubeClusters returns a page of registered kube clusters.
+func (s *Server) ListKubeClusters(ctx context.Context, req *kubev1.ListKubeClustersRequest) (*kubev1.ListKubeClustersResponse, error) {
+	authContext, err := s.cfg.ScopedAuthorizer.AuthorizeScoped(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ruleCtx := authContext.RuleContext()
+	if err := authContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbRead, types.VerbList); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	clusters, nextToken, err := generic.CollectPageAndCursor(
+		stream.FilterMap(
+			s.cfg.ClusterReader.RangeKubeClusters(ctx, req, req.GetPageToken(), ""),
+			func(cluster types.KubeCluster) (*types.KubernetesClusterV3, bool) {
+				// Filter out kube clusters user doesn't have access to.
+				if err := authContext.CheckerContext.Decision(ctx, cluster.GetScope(), func(checker *services.ScopedAccessChecker) error {
+					if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbRead, types.VerbList); err != nil {
+						return err
+					}
+					return checker.Kube().CanAccessCluster(cluster)
+				}); err == nil {
+					clusterV3, ok := cluster.(*types.KubernetesClusterV3)
+					return clusterV3, ok
+				}
+				return nil, false
+			},
+		),
+		int(req.GetPageSize()),
+		getCursorForKubeCluster,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return kubev1.ListKubeClustersResponse_builder{
+		Clusters:      clusters,
+		NextPageToken: nextToken,
+	}.Build(), nil
+}
+
+// DeleteKubeCluster removes the specified kube cluster resource.
+func (s *Server) DeleteKubeCluster(ctx context.Context, req *kubev1.DeleteKubeClusterRequest) (*kubev1.DeleteKubeClusterResponse, error) {
+	authContext, err := s.cfg.ScopedAuthorizer.AuthorizeScoped(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ruleCtx := authContext.RuleContext()
+	if err := authContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbDelete); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Make sure user has access to the kubernetes cluster before deleting.
+	cluster, err := s.cfg.ClusterReader.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{
+		Scope: req.GetScope(),
+		Name:  req.GetName(),
+	}.Build())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := authContext.CheckerContext.Decision(ctx, cluster.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbDelete); err != nil {
+			return err
+		}
+		return checker.Kube().CanAccessCluster(cluster)
+	}); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := s.cfg.ClusterWriter.DeleteKubeCluster(ctx, req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return kubev1.DeleteKubeClusterResponse_builder{}.Build(), nil
+}

--- a/lib/auth/kubecluster/service_test.go
+++ b/lib/auth/kubecluster/service_test.go
@@ -1,0 +1,471 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package kubecluster_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	kubev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/kubecluster"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/scopes/pinning"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+const testClusterName = "test-cluster"
+
+func TestKubeClusterService(t *testing.T) {
+	ctx := t.Context()
+	pack := newBackendPack(t)
+
+	scopedCluster := newKubeCluster(t, "/aa/aa", "kube-cluster", map[string]string{
+		"env": "test",
+	})
+	orthogonalCluster := newKubeCluster(t, "/aa/bb", "kube-cluster", map[string]string{
+		"env": "test",
+	})
+	prodCluster := newKubeCluster(t, "/aa/aa", "prod-cluster", map[string]string{
+		"env": "prod",
+	})
+	unscopedCluster := newKubeCluster(t, "", "unscoped-cluster", map[string]string{
+		"env": "test",
+	})
+	for _, cluster := range []types.KubeCluster{scopedCluster, orthogonalCluster, prodCluster, unscopedCluster} {
+		require.NoError(t, pack.kubeService.CreateKubernetesCluster(ctx, cluster))
+	}
+
+	reader := newServerForIdentity(t, pack, &services.AccessInfo{
+		Username: "reader",
+		ScopePin: scopesv1.Pin_builder{
+			Kind:  scopesv1.PinKind_PIN_KIND_USER,
+			Scope: "/aa/aa",
+			AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+				"/aa/aa": {"/aa/aa": {"/aa::staging-read"}},
+			}),
+		}.Build(),
+	}, nil)
+	prodReader := newServerForIdentity(t, pack, &services.AccessInfo{
+		Username: "prod-reader",
+		ScopePin: scopesv1.Pin_builder{
+			Kind:  scopesv1.PinKind_PIN_KIND_USER,
+			Scope: "/aa/aa",
+			AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+				"/aa/aa": {"/aa/aa": {"/aa::staging-prod-read"}},
+			}),
+		}.Build(),
+	}, nil)
+	deleter := newServerForIdentity(t, pack, &services.AccessInfo{
+		Username: "deleter",
+		ScopePin: scopesv1.Pin_builder{
+			Kind:  scopesv1.PinKind_PIN_KIND_USER,
+			Scope: "/aa/aa",
+			AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+				"/aa/aa": {"/aa/aa": {"/aa::staging-delete"}},
+			}),
+		}.Build(),
+	}, nil)
+
+	unscoped := newServerForIdentity(t, pack, &services.AccessInfo{
+		Username: "unscoped",
+	}, nil)
+
+	unscopedDenier := newServerForIdentity(t, pack, &services.AccessInfo{
+		Username: "unscoped-denier",
+	}, errors.New("test failure"))
+
+	t.Run("get scoped cluster", func(t *testing.T) {
+		res, err := reader.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{
+			Scope: scopedCluster.GetScope(),
+			Name:  scopedCluster.GetName(),
+		}.Build())
+		require.NoError(t, err)
+		require.Equal(t, scopedCluster.GetName(), res.GetCluster().GetName())
+		require.Equal(t, scopedCluster.GetScope(), res.GetCluster().GetScope())
+	})
+
+	t.Run("get denies unscoped and orthogonal clusters", func(t *testing.T) {
+		_, err := reader.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{
+			Name: unscopedCluster.GetName(),
+		}.Build())
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got %v", err)
+
+		_, err = reader.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{
+			Scope: orthogonalCluster.GetScope(),
+			Name:  orthogonalCluster.GetName(),
+		}.Build())
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got %v", err)
+	})
+
+	t.Run("get applies kube label access", func(t *testing.T) {
+		_, err := reader.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{
+			Scope: prodCluster.GetScope(),
+			Name:  prodCluster.GetName(),
+		}.Build())
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got %v", err)
+
+		res, err := prodReader.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{
+			Scope: prodCluster.GetScope(),
+			Name:  prodCluster.GetName(),
+		}.Build())
+		require.NoError(t, err)
+		require.Equal(t, prodCluster.GetName(), res.GetCluster().GetName())
+	})
+
+	t.Run("list filters inaccessible clusters", func(t *testing.T) {
+		res, err := reader.ListKubeClusters(ctx, kubev1.ListKubeClustersRequest_builder{
+			PageSize: 10,
+		}.Build())
+		require.NoError(t, err)
+		require.Empty(t, res.GetNextPageToken())
+		require.Len(t, res.GetClusters(), 1)
+		require.Equal(t, scopedCluster.GetName(), res.GetClusters()[0].GetName())
+		require.Equal(t, scopedCluster.GetScope(), res.GetClusters()[0].GetScope())
+	})
+
+	t.Run("list applies kube label access", func(t *testing.T) {
+		res, err := prodReader.ListKubeClusters(ctx, kubev1.ListKubeClustersRequest_builder{
+			PageSize: 10,
+		}.Build())
+		require.NoError(t, err)
+		require.Empty(t, res.GetNextPageToken())
+		require.Len(t, res.GetClusters(), 1)
+		require.Equal(t, prodCluster.GetName(), res.GetClusters()[0].GetName())
+		require.Equal(t, prodCluster.GetScope(), res.GetClusters()[0].GetScope())
+	})
+
+	t.Run("list paginates accessible clusters after filtering", func(t *testing.T) {
+		secondCluster := newKubeCluster(t, "/aa/aa", "second-cluster", map[string]string{
+			"env": "test",
+		})
+		require.NoError(t, pack.kubeService.CreateKubernetesCluster(ctx, secondCluster))
+		t.Cleanup(func() {
+			pack.kubeService.DeleteKubeCluster(ctx, kubev1.DeleteKubeClusterRequest_builder{
+				Scope: secondCluster.GetScope(),
+				Name:  secondCluster.GetName(),
+			}.Build())
+		})
+
+		firstPage, err := reader.ListKubeClusters(ctx, kubev1.ListKubeClustersRequest_builder{
+			PageSize: 1,
+		}.Build())
+		require.NoError(t, err)
+		require.Len(t, firstPage.GetClusters(), 1)
+		require.NotEmpty(t, firstPage.GetNextPageToken())
+
+		secondPage, err := reader.ListKubeClusters(ctx, kubev1.ListKubeClustersRequest_builder{
+			PageSize:  1,
+			PageToken: firstPage.GetNextPageToken(),
+		}.Build())
+		require.NoError(t, err)
+		require.Len(t, secondPage.GetClusters(), 1)
+		require.Empty(t, secondPage.GetNextPageToken())
+		require.NotEqual(t, firstPage.GetClusters()[0].GetName(), secondPage.GetClusters()[0].GetName())
+	})
+
+	t.Run("reader cannot delete cluster", func(t *testing.T) {
+		_, err := reader.DeleteKubeCluster(ctx, kubev1.DeleteKubeClusterRequest_builder{
+			Scope: scopedCluster.GetScope(),
+			Name:  scopedCluster.GetName(),
+		}.Build())
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got %v", err)
+	})
+
+	t.Run("deleter cannot delete orthogonal cluster", func(t *testing.T) {
+		_, err := deleter.DeleteKubeCluster(ctx, kubev1.DeleteKubeClusterRequest_builder{
+			Scope: orthogonalCluster.GetScope(),
+			Name:  orthogonalCluster.GetName(),
+		}.Build())
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got %v", err)
+	})
+
+	t.Run("deleter can delete scoped cluster", func(t *testing.T) {
+		clusterForDelete := newKubeCluster(t, "/aa/aa", "delete-cluster", map[string]string{
+			"env": "test",
+		})
+		require.NoError(t, pack.kubeService.CreateKubernetesCluster(ctx, clusterForDelete))
+
+		_, err := deleter.DeleteKubeCluster(ctx, kubev1.DeleteKubeClusterRequest_builder{
+			Scope: clusterForDelete.GetScope(),
+			Name:  clusterForDelete.GetName(),
+		}.Build())
+		require.NoError(t, err)
+
+		_, err = pack.kubeService.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{
+			Scope: clusterForDelete.GetScope(),
+			Name:  clusterForDelete.GetName(),
+		}.Build())
+		require.True(t, trace.IsNotFound(err), "expected not found, got %v", err)
+	})
+
+	t.Run("unscoped can get a cluster", func(t *testing.T) {
+		res, err := unscoped.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{
+			Scope: scopedCluster.GetScope(),
+			Name:  scopedCluster.GetName(),
+		}.Build())
+		require.NoError(t, err)
+		require.Equal(t, scopedCluster.GetName(), res.GetCluster().GetName())
+		require.Equal(t, scopedCluster.GetScope(), res.GetCluster().GetScope())
+	})
+
+	t.Run("unscoped-denier can not get a cluster", func(t *testing.T) {
+		_, err := unscopedDenier.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{
+			Scope: scopedCluster.GetScope(),
+			Name:  scopedCluster.GetName(),
+		}.Build())
+		require.Error(t, err)
+	})
+
+	t.Run("unscoped can delete a cluster", func(t *testing.T) {
+		clusterForDelete := newKubeCluster(t, "/aa/aa", "delete-cluster", map[string]string{
+			"env": "test",
+		})
+		require.NoError(t, pack.kubeService.CreateKubernetesCluster(ctx, clusterForDelete))
+
+		_, err := unscoped.DeleteKubeCluster(ctx, kubev1.DeleteKubeClusterRequest_builder{
+			Scope: clusterForDelete.GetScope(),
+			Name:  clusterForDelete.GetName(),
+		}.Build())
+		require.NoError(t, err)
+
+		_, err = pack.kubeService.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{
+			Scope: clusterForDelete.GetScope(),
+			Name:  clusterForDelete.GetName(),
+		}.Build())
+		require.True(t, trace.IsNotFound(err), "expected not found, got %v", err)
+	})
+
+	t.Run("unscoped-denier can not delete a cluster", func(t *testing.T) {
+		clusterForDelete := newKubeCluster(t, "/aa/aa", "delete-cluster", map[string]string{
+			"env": "test",
+		})
+		require.NoError(t, pack.kubeService.CreateKubernetesCluster(ctx, clusterForDelete))
+
+		_, err := unscopedDenier.DeleteKubeCluster(ctx, kubev1.DeleteKubeClusterRequest_builder{
+			Scope: clusterForDelete.GetScope(),
+			Name:  clusterForDelete.GetName(),
+		}.Build())
+		require.Error(t, err)
+		t.Cleanup(func() {
+			pack.kubeService.DeleteKubeCluster(ctx, kubev1.DeleteKubeClusterRequest_builder{
+				Scope: clusterForDelete.GetScope(),
+				Name:  clusterForDelete.GetName(),
+			}.Build())
+		})
+
+		cluster, err := pack.kubeService.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{
+			Scope: clusterForDelete.GetScope(),
+			Name:  clusterForDelete.GetName(),
+		}.Build())
+		require.NoError(t, err)
+		require.NotNil(t, cluster)
+	})
+
+	t.Run("unscoped can list all clusters", func(t *testing.T) {
+		res, err := unscoped.ListKubeClusters(ctx, kubev1.ListKubeClustersRequest_builder{
+			PageSize: 10,
+		}.Build())
+		require.NoError(t, err)
+		require.Empty(t, res.GetNextPageToken())
+		require.Len(t, res.GetClusters(), 4)
+	})
+
+	t.Run("unscoped-denier can list no clusters", func(t *testing.T) {
+		_, err := unscopedDenier.ListKubeClusters(ctx, kubev1.ListKubeClustersRequest_builder{
+			PageSize: 10,
+		}.Build())
+		require.Error(t, err)
+	})
+}
+
+func newKubeCluster(t *testing.T, scope string, name string, labels map[string]string) *types.KubernetesClusterV3 {
+	t.Helper()
+
+	cluster, err := types.NewKubernetesClusterV3(types.Metadata{
+		Name:   name,
+		Labels: labels,
+	}, types.KubernetesClusterSpecV3{})
+	require.NoError(t, err)
+	cluster.Scope = scope
+
+	return cluster
+}
+
+func newServerForIdentity(t *testing.T, bk *backendPack, accessInfo *services.AccessInfo, unscopedErr error) *kubecluster.Server {
+	t.Helper()
+
+	authorizer := newFakeAuthorizer(t, newFakeAccessChecker(unscopedErr))
+	if accessInfo.ScopePin != nil {
+		authorizer = newFakeScopedAuthorizer(t, accessInfo, bk.service)
+	}
+	srv, err := kubecluster.New(&kubecluster.Config{
+		ScopedAuthorizer: authorizer,
+		Logger:           logtest.NewLogger(),
+		ClusterReader:    bk.kubeService,
+		ClusterWriter:    bk.kubeService,
+	})
+	require.NoError(t, err)
+	return srv
+}
+
+type backendPack struct {
+	backend     backend.Backend
+	service     *local.ScopedAccessService
+	kubeService *local.KubernetesService
+}
+
+func (p *backendPack) Close() {
+	p.backend.Close()
+}
+
+func newBackendPack(t *testing.T) *backendPack {
+	t.Helper()
+
+	backend, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { backend.Close() })
+
+	service := local.NewScopedAccessService(backend)
+	kubeService, err := local.NewKubernetesService(backend)
+	require.NoError(t, err)
+
+	roles := []*scopedaccessv1.ScopedRole{
+		newScopedKubeRole("staging-read", []string{types.VerbRead, types.VerbList}, map[string][]string{
+			"env": []string{"test"},
+		}),
+		newScopedKubeRole("staging-prod-read", []string{types.VerbRead, types.VerbList}, map[string][]string{
+			"env": []string{"prod"},
+		}),
+		newScopedKubeRole("staging-delete", []string{types.VerbDelete}, map[string][]string{
+			types.Wildcard: []string{types.Wildcard},
+		}),
+	}
+
+	for _, role := range roles {
+		_, err := service.CreateScopedRole(t.Context(), scopedaccessv1.CreateScopedRoleRequest_builder{
+			Role: role,
+		}.Build())
+		require.NoError(t, err)
+	}
+
+	return &backendPack{
+		backend:     backend,
+		service:     service,
+		kubeService: kubeService,
+	}
+}
+
+func newScopedKubeRole(name string, verbs []string, kubeLabels map[string][]string) *scopedaccessv1.ScopedRole {
+	labels := make([]*labelv1.Label, 0, len(kubeLabels))
+	for name, values := range kubeLabels {
+		labels = append(labels, labelv1.Label_builder{
+			Name:   name,
+			Values: values,
+		}.Build())
+	}
+	return scopedaccessv1.ScopedRole_builder{
+		Kind: scopedaccess.KindScopedRole,
+		Metadata: headerv1.Metadata_builder{
+			Name: name,
+		}.Build(),
+		Scope: "/aa",
+		Spec: scopedaccessv1.ScopedRoleSpec_builder{
+			AssignableScopes: []string{"/aa/aa"},
+			Rules: []*scopedaccessv1.ScopedRule{
+				scopedaccessv1.ScopedRule_builder{
+					Resources: []string{types.KindKubernetesCluster},
+					Verbs:     verbs,
+				}.Build(),
+			},
+			Kube: scopedaccessv1.ScopedRoleKube_builder{
+				Labels: labels,
+			}.Build(),
+		}.Build(),
+		Version: types.V1,
+	}.Build()
+}
+
+type fakeAuthorizer struct {
+	ctx *authz.ScopedContext
+}
+
+func (a *fakeAuthorizer) AuthorizeScoped(ctx context.Context) (*authz.ScopedContext, error) {
+	return a.ctx, nil
+}
+
+func newFakeScopedAuthorizer(t *testing.T, accessInfo *services.AccessInfo, reader services.ScopedRoleReader) *fakeAuthorizer {
+	t.Helper()
+
+	scopedCtx, err := services.NewScopedAccessCheckerContext(t.Context(), accessInfo, testClusterName, reader)
+	require.NoError(t, err)
+
+	return &fakeAuthorizer{
+		ctx: &authz.ScopedContext{
+			User: &types.UserV2{
+				Metadata: types.Metadata{
+					Name: accessInfo.Username,
+				},
+			},
+			CheckerContext: scopedCtx,
+		},
+	}
+}
+
+type fakeAccessChecker struct {
+	services.AccessChecker
+	err error
+}
+
+func (ac *fakeAccessChecker) CheckAccess(r services.AccessCheckable, state services.AccessState, matchers ...services.RoleMatcher) error {
+	return ac.err
+}
+
+func (ac *fakeAccessChecker) CheckAccessToRule(ctx services.RuleContext, namespace, rule, verb string) error {
+	return ac.err
+}
+
+func (ac *fakeAccessChecker) GuessIfAccessIsPossible(ctx services.RuleContext, namespace, resource, verb string) error {
+	return ac.err
+}
+
+func newFakeAccessChecker(err error) *fakeAccessChecker {
+	return &fakeAccessChecker{err: err}
+}
+
+func newFakeAuthorizer(t *testing.T, checker services.AccessChecker) *fakeAuthorizer {
+	t.Helper()
+
+	return &fakeAuthorizer{
+		ctx: authz.ScopedContextFromUnscopedContext(&authz.Context{
+			Checker: checker,
+		}),
+	}
+}

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -850,6 +850,8 @@ type Config struct {
 	Summarizer services.Summarizer
 	// SubCAService reads CertAuthorityOverride resources.
 	SubCAService services.SubCAServiceGetter
+	// KubeClusterUpstream reads KubeCluster resources.
+	KubeClusterUpstream services.KubeClusterUpstream
 }
 
 // CheckAndSetDefaults checks parameters and sets default values

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -381,7 +381,10 @@ func newPackWithoutCache(dir string, opts ...packOption) (*testPack, error) {
 	p.webTokenS = idService
 	p.restrictions = local.NewRestrictionsService(p.backend)
 	p.apps = local.NewAppService(p.backend)
-	p.kubernetes = local.NewKubernetesService(p.backend)
+	p.kubernetes, err = local.NewKubernetesService(p.backend)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	p.databases = local.NewDatabasesService(p.backend)
 	p.databaseServices = local.NewDatabaseServicesService(p.backend)
 	p.windowsDesktops = local.NewWindowsDesktopService(p.backend)
@@ -595,6 +598,7 @@ func newPack(t testing.TB, setupConfig func(c Config) Config, opts ...packOption
 		Restrictions:            p.restrictions,
 		Apps:                    p.apps,
 		Kubernetes:              p.kubernetes,
+		KubeClusterUpstream:     p.kubernetes,
 		DatabaseServices:        p.databaseServices,
 		Databases:               p.databases,
 		WindowsDesktops:         p.windowsDesktops,
@@ -871,6 +875,7 @@ func TestCompletenessInit(t *testing.T) {
 			Restrictions:            p.restrictions,
 			Apps:                    p.apps,
 			Kubernetes:              p.kubernetes,
+			KubeClusterUpstream:     p.kubernetes,
 			DatabaseServices:        p.databaseServices,
 			Databases:               p.databases,
 			WindowsDesktops:         p.windowsDesktops,
@@ -966,6 +971,7 @@ func TestCompletenessReset(t *testing.T) {
 		Restrictions:            p.restrictions,
 		Apps:                    p.apps,
 		Kubernetes:              p.kubernetes,
+		KubeClusterUpstream:     p.kubernetes,
 		DatabaseServices:        p.databaseServices,
 		Databases:               p.databases,
 		WindowsDesktops:         p.windowsDesktops,
@@ -1136,6 +1142,7 @@ func TestListResources_NodesTTLVariant(t *testing.T) {
 		Restrictions:            p.restrictions,
 		Apps:                    p.apps,
 		Kubernetes:              p.kubernetes,
+		KubeClusterUpstream:     p.kubernetes,
 		DatabaseServices:        p.databaseServices,
 		Databases:               p.databases,
 		WindowsDesktops:         p.windowsDesktops,
@@ -1243,6 +1250,7 @@ func initStrategy(t *testing.T) {
 		Restrictions:            p.restrictions,
 		Apps:                    p.apps,
 		Kubernetes:              p.kubernetes,
+		KubeClusterUpstream:     p.kubernetes,
 		DatabaseServices:        p.databaseServices,
 		Databases:               p.databases,
 		WindowsDesktops:         p.windowsDesktops,

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -335,7 +335,7 @@ func setupCollections(c Config) (*collections, error) {
 			out.kubeServers = collect
 			out.byKind[resourceKind] = out.kubeServers
 		case types.KindKubernetesCluster:
-			collect, err := newKubernetesClusterCollection(c.Kubernetes, watch)
+			collect, err := newKubernetesClusterCollection(c.KubeClusterUpstream, watch)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}

--- a/lib/cache/inventory/inventory_cache_test.go
+++ b/lib/cache/inventory/inventory_cache_test.go
@@ -123,7 +123,8 @@ func setupTestCache(t *testing.T, setupConfig cache.SetupConfigFn) (*testCache, 
 	dynamicAccessS := local.NewDynamicAccessService(bkWrapper)
 	restrictions := local.NewRestrictionsService(bkWrapper)
 	apps := local.NewAppService(bkWrapper)
-	kubernetes := local.NewKubernetesService(bkWrapper)
+	kubernetes, err := local.NewKubernetesService(bkWrapper)
+	require.NoError(t, err)
 	databases := local.NewDatabasesService(bkWrapper)
 	databaseServices := local.NewDatabaseServicesService(bkWrapper)
 	windowsDesktops := local.NewWindowsDesktopService(bkWrapper)
@@ -251,6 +252,7 @@ func setupTestCache(t *testing.T, setupConfig cache.SetupConfigFn) (*testCache, 
 		Restrictions:            restrictions,
 		Apps:                    apps,
 		Kubernetes:              kubernetes,
+		KubeClusterUpstream:     kubernetes,
 		DatabaseServices:        databaseServices,
 		Databases:               databases,
 		WindowsDesktops:         windowsDesktops,

--- a/lib/cache/kube.go
+++ b/lib/cache/kube.go
@@ -27,11 +27,13 @@ import (
 
 	clientproto "github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/defaults"
+	kubev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	kubewaitingcontainerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -199,9 +201,9 @@ type kubeClusterIndex string
 
 const kubeClusterNameIndex = "name"
 
-func newKubernetesClusterCollection(k services.Kubernetes, w types.WatchKind) (*collection[types.KubeCluster, kubeClusterIndex], error) {
-	if k == nil {
-		return nil, trace.BadParameter("missing parameter Kubernetes")
+func newKubernetesClusterCollection(upstream services.KubeClusterUpstream, w types.WatchKind) (*collection[types.KubeCluster, kubeClusterIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter KubeClusterUpstream")
 	}
 
 	return &collection[types.KubeCluster, kubeClusterIndex]{
@@ -209,11 +211,20 @@ func newKubernetesClusterCollection(k services.Kubernetes, w types.WatchKind) (*
 			types.KindKubernetesCluster,
 			types.KubeCluster.Copy,
 			map[kubeClusterIndex]func(types.KubeCluster) string{
-				kubeClusterNameIndex: types.KubeCluster.GetName,
+				kubeClusterNameIndex: services.GetCursorForKubeCluster,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.KubeCluster, error) {
-			return k.GetKubernetesClusters(ctx)
+			return stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageToken string) ([]types.KubeCluster, string, error) {
+				return upstream.ListKubeClusters(ctx, kubev1.ListKubeClustersRequest_builder{
+					PageSize:  int32(pageSize),
+					PageToken: pageToken,
+					// TODO (eriktate): propagate filter from WatchKind once that's possible
+					ScopeFilter: nil,
+				}.Build())
+			}))
 		},
+		// TODO (eriktate): DELETE IN v21: headerTransform is kept for backwards compatibility, but delete events for
+		// kube clusters are expected to be the resource type going forward
 		headerTransform: func(hdr *types.ResourceHeader) types.KubeCluster {
 			return &types.KubernetesClusterV3{
 				Kind:    hdr.Kind,
@@ -257,11 +268,16 @@ func (c *Cache) ListKubernetesClusters(ctx context.Context, limit int, start str
 	defer span.End()
 
 	lister := genericLister[types.KubeCluster, kubeClusterIndex]{
-		cache:        c,
-		collection:   c.collections.kubeClusters,
-		index:        kubeClusterNameIndex,
-		upstreamList: c.Config.Kubernetes.ListKubernetesClusters,
-		nextToken:    types.KubeCluster.GetName,
+		cache:      c,
+		collection: c.collections.kubeClusters,
+		index:      kubeClusterNameIndex,
+		upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]types.KubeCluster, string, error) {
+			return c.KubeClusterUpstream.ListKubeClusters(ctx, kubev1.ListKubeClustersRequest_builder{
+				PageSize:  int32(pageSize),
+				PageToken: pageToken,
+			}.Build())
+		},
+		nextToken: services.GetCursorForKubeCluster,
 	}
 	out, next, err := lister.list(ctx, limit, start)
 	if err != nil {
@@ -271,14 +287,43 @@ func (c *Cache) ListKubernetesClusters(ctx context.Context, limit int, start str
 	return out, next, nil
 }
 
+// ListKubeClusters returns a page of registered kubernetes clusters.
+func (c *Cache) ListKubeClusters(ctx context.Context, req *kubev1.ListKubeClustersRequest) ([]types.KubeCluster, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListKubeClusters")
+	defer span.End()
+
+	scopeFilter := req.GetScopeFilter()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	lister := genericLister[types.KubeCluster, kubeClusterIndex]{
+		cache:      c,
+		collection: c.collections.kubeClusters,
+		index:      kubeClusterNameIndex,
+		upstreamList: func(ctx context.Context, _ int, _ string) ([]types.KubeCluster, string, error) {
+			return c.KubeClusterUpstream.ListKubeClusters(ctx, req)
+		},
+		nextToken: services.GetCursorForKubeCluster,
+		filter: func(cluster types.KubeCluster) bool {
+			return scopes.MatchScope(scopeFilter, cluster.GetScope())
+		},
+	}
+	return lister.list(ctx, int(req.GetPageSize()), req.GetPageToken())
+}
+
 // RangeKubernetesClusters returns kubernetes clusters within the range [start, end).
 func (c *Cache) RangeKubernetesClusters(ctx context.Context, start, end string) iter.Seq2[types.KubeCluster, error] {
 	lister := genericLister[types.KubeCluster, kubeClusterIndex]{
-		cache:        c,
-		collection:   c.collections.kubeClusters,
-		index:        kubeClusterNameIndex,
-		upstreamList: c.Config.Kubernetes.ListKubernetesClusters,
-		nextToken:    types.KubeCluster.GetName,
+		cache:      c,
+		collection: c.collections.kubeClusters,
+		index:      kubeClusterNameIndex,
+		upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]types.KubeCluster, string, error) {
+			return c.KubeClusterUpstream.ListKubeClusters(ctx, kubev1.ListKubeClustersRequest_builder{
+				PageSize:  int32(pageSize),
+				PageToken: pageToken,
+			}.Build())
+		},
+		nextToken: services.GetCursorForKubeCluster,
 		// TODO(lokraszewski): DELETE IN v21.0.0
 		fallbackGetter: c.Config.Kubernetes.GetKubernetesClusters,
 	}
@@ -299,6 +344,35 @@ func (c *Cache) RangeKubernetesClusters(ctx context.Context, start, end string) 
 	}
 }
 
+// RangeKubeClusters returns kubernetes clusters within the range [start, end).
+func (c *Cache) RangeKubeClusters(ctx context.Context, req *kubev1.ListKubeClustersRequest, startKey, endKey string) iter.Seq2[types.KubeCluster, error] {
+	ctx, span := c.Tracer.Start(ctx, "cache/RangeKubeClusters")
+	defer span.End()
+	scopeFilter := req.GetScopeFilter()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return stream.Fail[types.KubeCluster](trace.Wrap(err))
+	}
+
+	lister := genericLister[types.KubeCluster, kubeClusterIndex]{
+		cache:      c,
+		collection: c.collections.kubeClusters,
+		index:      kubeClusterNameIndex,
+		upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]types.KubeCluster, string, error) {
+			return c.KubeClusterUpstream.ListKubeClusters(ctx, kubev1.ListKubeClustersRequest_builder{
+				PageSize:    int32(pageSize),
+				PageToken:   pageToken,
+				ScopeFilter: scopeFilter,
+			}.Build())
+		},
+		filter: func(cluster types.KubeCluster) bool {
+			return scopes.MatchScope(scopeFilter, cluster.GetScope())
+		},
+		nextToken: services.GetCursorForKubeCluster,
+	}
+
+	return lister.Range(ctx, startKey, endKey)
+}
+
 // GetKubernetesCluster returns the specified kubernetes cluster resource.
 func (c *Cache) GetKubernetesCluster(ctx context.Context, name string) (types.KubeCluster, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetKubernetesCluster")
@@ -311,7 +385,9 @@ func (c *Cache) GetKubernetesCluster(ctx context.Context, name string) (types.Ku
 	defer rg.Release()
 
 	if !rg.ReadCache() {
-		cluster, err := c.Config.Kubernetes.GetKubernetesCluster(ctx, name)
+		cluster, err := c.Config.KubeClusterUpstream.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{
+			Name: name,
+		}.Build())
 		return cluster, trace.Wrap(err)
 	}
 
@@ -321,6 +397,29 @@ func (c *Cache) GetKubernetesCluster(ctx context.Context, name string) (types.Ku
 	}
 
 	return k.Copy(), nil
+}
+
+// GetKubeCluster returns the specified kubernetes cluster resource.
+func (c *Cache) GetKubeCluster(ctx context.Context, req *kubev1.GetKubeClusterRequest) (types.KubeCluster, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetKubeCluster")
+	defer span.End()
+
+	clusterCursor := scopes.MakeResourceCursor(req.GetScope(), req.GetName())
+
+	getter := genericGetter[types.KubeCluster, kubeClusterIndex]{
+		cache:      c,
+		collection: c.collections.kubeClusters,
+		index:      kubeClusterNameIndex,
+		upstreamGet: func(ctx context.Context, _ string) (types.KubeCluster, error) {
+			return c.KubeClusterUpstream.GetKubeCluster(ctx, req)
+		},
+	}
+
+	out, err := getter.get(ctx, clusterCursor)
+	if out == nil {
+		return nil, trace.Wrap(err)
+	}
+	return out.Copy(), trace.Wrap(err)
 }
 
 type kubeWaitingContainerIndex string

--- a/lib/cache/kube_test.go
+++ b/lib/cache/kube_test.go
@@ -18,13 +18,16 @@ package cache
 
 import (
 	"context"
+	"iter"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
+	kubev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	kubewaitingcontainerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/kubewaitingcontainer"
 	"github.com/gravitational/teleport/lib/services"
@@ -71,6 +74,84 @@ func TestKubernetes(t *testing.T) {
 			cacheRange: p.cache.RangeKubernetesClusters,
 		})
 	})
+
+	t.Run("GetKubernetesClusters scoped", func(t *testing.T) {
+		const scope = "/test"
+		testResources(t, p, testFuncs[types.KubeCluster]{
+			newResource: func(name string) (types.KubeCluster, error) {
+				return types.NewKubernetesClusterV3(types.Metadata{
+					Name: name,
+				}, types.KubernetesClusterSpecV3{}, types.KubeClusterWithScope(scope))
+			},
+			create:    p.kubernetes.CreateKubernetesCluster,
+			list:      getAllAdapter(p.kubernetes.GetKubernetesClusters),
+			cacheGet:  cacheGetKubeClusterWithScope(p.cache, scope),
+			cacheList: getAllAdapter(p.cache.GetKubernetesClusters),
+			update:    p.kubernetes.UpdateKubernetesCluster,
+			deleteAll: p.kubernetes.DeleteAllKubernetesClusters,
+		}, withSkipPaginationTest())
+	})
+
+	t.Run("ListKubeClusters scoped", func(t *testing.T) {
+		const scope = "/test"
+		testResources(t, p, testFuncs[types.KubeCluster]{
+			newResource: func(name string) (types.KubeCluster, error) {
+				return types.NewKubernetesClusterV3(types.Metadata{
+					Name: name,
+				}, types.KubernetesClusterSpecV3{}, types.KubeClusterWithScope(scope))
+			},
+			create: p.kubernetes.CreateKubernetesCluster,
+			list: func(ctx context.Context, pageSize int, pageToken string) ([]types.KubeCluster, string, error) {
+				return p.kubernetes.ListKubeClusters(ctx, kubev1.ListKubeClustersRequest_builder{
+					ScopeFilter: scopesv1.Filter_builder{
+						Mode:  scopesv1.Mode_MODE_EXACT,
+						Scope: scope,
+					}.Build(),
+					PageSize:  int32(pageSize),
+					PageToken: pageToken,
+				}.Build())
+			},
+			cacheGet:   cacheGetKubeClusterWithScope(p.cache, scope),
+			cacheList:  cacheListKubeClustersWithScope(p.cache, scope),
+			update:     p.kubernetes.UpdateKubernetesCluster,
+			deleteAll:  p.kubernetes.DeleteAllKubernetesClusters,
+			Range:      p.kubernetes.RangeKubernetesClusters,
+			cacheRange: cacheRangeKubeClustersWithScope(p.cache, scope),
+		})
+	})
+}
+
+func cacheGetKubeClusterWithScope(cache *Cache, scope string) func(context.Context, string) (types.KubeCluster, error) {
+	return func(ctx context.Context, name string) (types.KubeCluster, error) {
+		return cache.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{
+			Scope: scope,
+			Name:  name,
+		}.Build())
+	}
+}
+
+func cacheListKubeClustersWithScope(cache *Cache, scope string) func(context.Context, int, string) ([]types.KubeCluster, string, error) {
+	return func(ctx context.Context, pageSize int, pageToken string) ([]types.KubeCluster, string, error) {
+		return cache.ListKubeClusters(ctx, kubev1.ListKubeClustersRequest_builder{
+			PageSize:  int32(pageSize),
+			PageToken: pageToken,
+			ScopeFilter: scopesv1.Filter_builder{
+				Scope: scope,
+				Mode:  scopesv1.Mode_MODE_EXACT,
+			}.Build(),
+		}.Build())
+	}
+}
+
+func cacheRangeKubeClustersWithScope(cache *Cache, scope string) func(context.Context, string, string) iter.Seq2[types.KubeCluster, error] {
+	return func(ctx context.Context, startKey, endKey string) iter.Seq2[types.KubeCluster, error] {
+		return cache.RangeKubeClusters(ctx, kubev1.ListKubeClustersRequest_builder{
+			ScopeFilter: scopesv1.Filter_builder{
+				Scope: scope,
+				Mode:  scopesv1.Mode_MODE_EXACT,
+			}.Build(),
+		}.Build(), startKey, endKey)
+	}
 }
 
 // TestKubernetesServers tests that CRUD operations on kube servers are

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3182,6 +3182,7 @@ func (process *TeleportProcess) newAccessCacheForServices(cfg accesspoint.Config
 	cfg.Integrations = services.Integrations
 	cfg.KubeWaitingContainers = services.KubeWaitingContainer
 	cfg.Kubernetes = services.Kubernetes
+	cfg.KubeClusterUpstream = services.KubeClusterService
 	cfg.Notifications = services.Notifications
 	cfg.Okta = services.Okta
 	cfg.Presence = services.PresenceInternal
@@ -3243,6 +3244,7 @@ func (process *TeleportProcess) newAccessCacheForClient(cfg accesspoint.Config, 
 	cfg.UserTasks = client.UserTasksServiceClient()
 	cfg.KubeWaitingContainers = client
 	cfg.Kubernetes = client
+	cfg.KubeClusterUpstream = services.NewKubeClusterClientAdapter(client.KubeClusterServiceClient())
 	cfg.Notifications = client
 	cfg.Okta = client.OktaClient()
 	cfg.Presence = client

--- a/tool/tctl/common/resources/kube_cluster.go
+++ b/tool/tctl/common/resources/kube_cluster.go
@@ -23,10 +23,13 @@ import (
 
 	"github.com/gravitational/trace"
 
+	kubev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/tool/common"
 )
@@ -59,7 +62,11 @@ func (c *kubeClusterCollection) WriteText(w io.Writer, verbose bool) error {
 	for _, cluster := range c.clusters {
 		labels := common.FormatLabels(cluster.GetAllLabels(), verbose)
 		rows = append(rows, []string{
-			common.FormatResourceName(cluster, verbose),
+			scopes.QualifiedName{
+				Scope: cluster.GetScope(),
+				Name:  common.FormatResourceName(cluster, verbose),
+			}.String(),
+
 			labels,
 		})
 	}
@@ -94,7 +101,13 @@ func getKubeCluster(ctx context.Context, client *authclient.Client, ref services
 	if ref.Name == "" {
 		return NewKubeClusterCollection(clusters), nil
 	}
-	clusters = FilterByNameOrDiscoveredName(clusters, ref.Name)
+	sqn, err := scopes.ParseQualifiedName(ref.Name)
+	if err != nil {
+		sqn = scopes.QualifiedName{
+			Name: ref.Name,
+		}
+	}
+	clusters = FilterBySQNOrDiscoveredName(clusters, sqn)
 	if len(clusters) == 0 {
 		return nil, trace.NotFound("Kubernetes cluster %q not found", ref.Name)
 	}
@@ -106,6 +119,10 @@ func createKubeCluster(ctx context.Context, client *authclient.Client, raw servi
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	sqn := scopes.QualifiedName{
+		Scope: cluster.GetScope(),
+		Name:  cluster.GetName(),
+	}
 	if err := client.CreateKubernetesCluster(ctx, cluster); err != nil {
 		if trace.IsAlreadyExists(err) {
 			if !opts.Force {
@@ -114,12 +131,12 @@ func createKubeCluster(ctx context.Context, client *authclient.Client, raw servi
 			if err := client.UpdateKubernetesCluster(ctx, cluster); err != nil {
 				return trace.Wrap(err)
 			}
-			fmt.Printf("Kubernetes cluster %q has been updated\n", cluster.GetName())
+			fmt.Printf("Kubernetes cluster %q has been updated\n", sqn.String())
 			return nil
 		}
 		return trace.Wrap(err)
 	}
-	fmt.Printf("Kubernetes cluster %q has been created\n", cluster.GetName())
+	fmt.Printf("Kubernetes cluster %q has been created\n", sqn.String())
 	return nil
 }
 
@@ -130,7 +147,13 @@ func deleteKubeCluster(ctx context.Context, client *authclient.Client, ref servi
 		return trace.Wrap(err)
 	}
 	resDesc := "Kubernetes cluster"
-	clusters = FilterByNameOrDiscoveredName(clusters, ref.Name)
+	sqn, err := scopes.ParseQualifiedName(ref.Name)
+	if err != nil {
+		sqn = scopes.QualifiedName{
+			Name: ref.Name,
+		}
+	}
+	clusters = FilterBySQNOrDiscoveredName(clusters, sqn)
 	name, err := GetOneResourceNameToDelete(clusters, ref, resDesc)
 	if err != nil {
 		return trace.Wrap(err)
@@ -139,5 +162,136 @@ func deleteKubeCluster(ctx context.Context, client *authclient.Client, ref servi
 		return trace.Wrap(err)
 	}
 	fmt.Printf("%s %q has been deleted\n", resDesc, name)
+	return nil
+}
+
+func scopedKubeClusterHandler() ScopedHandler {
+	return ScopedHandler{
+		getHandler:    getScopedKubeCluster,
+		createHandler: createScopedKubeCluster,
+		deleteHandler: deleteScopedKubeCluster,
+		updateHandler: updateScopedKubeCluster,
+		description:   "A dynamic resource representing a Kubernetes cluster that can be accessed via a Kubernetes service.",
+	}
+}
+
+func getScopedKubeCluster(ctx context.Context, client *authclient.Client, subKind string, sqn *scopes.QualifiedName, _ GetOpts) (Collection, error) {
+	if subKind != "" {
+		return nil, rejectSubKind(types.KindKubernetesCluster, subKind)
+	}
+
+	kubeClient := client.KubeClusterServiceClient()
+	if sqn != nil {
+		getRes, err := kubeClient.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{
+			Scope: sqn.Scope,
+			Name:  sqn.Name,
+		}.Build())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		cluster := getRes.GetCluster()
+		if cluster.GetScope() != sqn.Scope {
+			return nil, scopeMismatchNotFound(types.KindKubernetesCluster, *sqn, cluster.GetScope())
+		}
+		return NewKubeClusterCollection([]types.KubeCluster{cluster}), nil
+	}
+
+	var clusters []types.KubeCluster
+	for cluster, err := range clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageKey string) ([]*types.KubernetesClusterV3, string, error) {
+		res, err := kubeClient.ListKubeClusters(ctx, kubev1.ListKubeClustersRequest_builder{
+			PageSize:    int32(pageSize),
+			ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build(),
+		}.Build())
+		if err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+
+		return res.GetClusters(), res.GetNextPageToken(), nil
+	}) {
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		clusters = append(clusters, cluster)
+	}
+
+	return NewKubeClusterCollection(clusters), nil
+}
+
+func createScopedKubeCluster(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	cluster, err := services.UnmarshalKubeCluster(raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	sqn := scopes.QualifiedName{
+		Scope: cluster.GetScope(),
+		Name:  cluster.GetName(),
+	}
+	if err := client.CreateKubernetesCluster(ctx, cluster); err != nil {
+		if trace.IsAlreadyExists(err) {
+			if !opts.Force {
+				return trace.AlreadyExists("Kubernetes cluster %q already exists", sqn.String())
+			}
+			if err := client.UpdateKubernetesCluster(ctx, cluster); err != nil {
+				return trace.Wrap(err)
+			}
+			fmt.Printf("Kubernetes cluster %q has been updated\n", cluster.GetName())
+			return nil
+		}
+		return trace.Wrap(err)
+	}
+	fmt.Printf("Kubernetes cluster %q has been created\n", sqn.String())
+	return nil
+}
+
+func updateScopedKubeCluster(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	cluster, err := services.UnmarshalKubeCluster(raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := client.UpdateKubernetesCluster(ctx, cluster); err != nil {
+		return trace.Wrap(err)
+	}
+
+	sqn := scopes.QualifiedName{
+		Scope: cluster.GetScope(),
+		Name:  cluster.GetName(),
+	}
+	fmt.Printf("%v %q has been updated\n", types.KindKubernetesCluster, sqn.String())
+	return nil
+}
+
+func deleteScopedKubeCluster(ctx context.Context, client *authclient.Client, subKind string, sqn scopes.QualifiedName) error {
+	if subKind != "" {
+		return rejectSubKind(types.KindKubernetesCluster, subKind)
+	}
+
+	kubeClient := client.KubeClusterServiceClient()
+	// Fetch first to verify scope before deleting.
+	getRes, err := kubeClient.GetKubeCluster(ctx, kubev1.GetKubeClusterRequest_builder{
+		Scope: sqn.Scope,
+		Name:  sqn.Name,
+	}.Build())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	cluster := getRes.GetCluster()
+	if cluster.GetScope() != sqn.Scope {
+		return scopeMismatchNotFound(types.KindScopedToken, sqn, cluster.GetScope())
+	}
+
+	if _, err := kubeClient.DeleteKubeCluster(ctx, kubev1.DeleteKubeClusterRequest_builder{
+		Scope: sqn.Scope,
+		Name:  sqn.Name,
+	}.Build()); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf(
+		"%v %q has been deleted\n",
+		types.KindKubernetesCluster,
+		sqn.String(),
+	)
 	return nil
 }

--- a/tool/tctl/common/resources/scoped_handler.go
+++ b/tool/tctl/common/resources/scoped_handler.go
@@ -39,6 +39,7 @@ func ScopedHandlers() map[string]ScopedHandler {
 		scopedaccess.KindScopedRole:           scopedRoleScopedHandler(),
 		types.KindScopedToken:                 scopedTokenScopedHandler(),
 		scopedaccess.KindScopedRoleAssignment: scopedRoleAssignmentScopedHandler(),
+		types.KindKubernetesCluster:           scopedKubeClusterHandler(),
 	}
 }
 

--- a/tool/tctl/common/resources/utils.go
+++ b/tool/tctl/common/resources/utils.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/iterutils"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -75,6 +76,49 @@ func filterResourcesByName[T types.ResourceWithLabels](resources []T, name strin
 		}
 		for _, altName := range altNameFns {
 			if altName(r) == name {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// ScopedResourceWithLabels extends [types.ResourceWithLabels] with a GetScope method for the purposes
+// of working with potentially scoped resources.
+type ScopedResourceWithLabels interface {
+	types.ResourceWithLabels
+	GetScope() string
+}
+
+// FilterBySQNOrDiscoverdName filters resources by scope qualified name or
+// "discovered name". It prefers exact name filtering first - if none of the
+// resource names match exactly (i.e. all of the resources are filtered out),
+// then it retries and filters the resources by "discovered name" of resource
+// name instead, which comes from an auto-discovery label.
+func FilterBySQNOrDiscoveredName[T ScopedResourceWithLabels](resources []T, sqn scopes.QualifiedName, extra ...AltResourceNameFunc[T]) []T {
+	// prefer exact names
+	out := filterScopedResourcesByName(resources, sqn, extra...)
+	if len(out) == 0 {
+		// fallback to looking for discovered name label matches.
+		out = filterByDiscoveredName(resources, sqn.String())
+	}
+	return out
+}
+
+// filterScopedResourcesByName filters resources by exact name match while respecting scopes. This filter is safe
+// for use on both scoped and unscoped resources.
+func filterScopedResourcesByName[T ScopedResourceWithLabels](resources []T, sqn scopes.QualifiedName, altNameFns ...AltResourceNameFunc[T]) []T {
+	return filterResources(resources, func(r T) bool {
+		resourceSQN := scopes.QualifiedName{
+			Scope: r.GetScope(),
+			Name:  r.GetName(),
+		}
+
+		if resourceSQN == sqn {
+			return true
+		}
+		for _, altName := range altNameFns {
+			if altName(r) == sqn.String() {
 				return true
 			}
 		}

--- a/tool/tctl/common/resources/utils_test.go
+++ b/tool/tctl/common/resources/utils_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -124,6 +125,49 @@ func TestFilterByNameOrDiscoveredName(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			got := FilterByNameOrDiscoveredName(resources, test.filter, test.altNameGetters...)
+			require.Empty(t, cmp.Diff(test.want, got))
+
+			// test cases that work for FilterByNameOrDiscoveredName should also
+			// work for FilterBySQNOrDiscoveredName
+			got = FilterBySQNOrDiscoveredName(resources, scopes.QualifiedName{Name: test.filter}, test.altNameGetters...)
+			require.Empty(t, cmp.Diff(test.want, got))
+		})
+	}
+}
+
+func TestFilterBySQNOrDiscoveredName(t *testing.T) {
+	unscopedFoo := mustCreateNewKubeCluster(t, "foo", "foo", nil)
+	scopedFoo := mustCreateNewKubeCluster(t, "foo", "foo", nil)
+	scopedFoo.Scope = "/foo"
+	orthogonalFoo := mustCreateNewKubeCluster(t, "foo", "foo", nil)
+	orthogonalFoo.Scope = "/bar"
+	resources := []types.KubeCluster{
+		unscopedFoo, scopedFoo, orthogonalFoo,
+	}
+	tests := []struct {
+		desc   string
+		filter scopes.QualifiedName
+		want   []types.KubeCluster
+	}{
+		{
+			desc: "filters by exact scoped SQN",
+			filter: scopes.QualifiedName{
+				Scope: "/foo",
+				Name:  "foo",
+			},
+			want: []types.KubeCluster{scopedFoo},
+		},
+		{
+			desc: "filters by exact unscoped SQN",
+			filter: scopes.QualifiedName{
+				Name: "foo",
+			},
+			want: []types.KubeCluster{unscopedFoo},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			got := FilterBySQNOrDiscoveredName(resources, test.filter)
 			require.Empty(t, cmp.Diff(test.want, got))
 		})
 	}


### PR DESCRIPTION
This adds the kubecluster gRPC service and updates the cache layer to support scoped kube clusters. It exposes a new API for reads and deletes through an implementation of the `KubeClusterService` (previously defined in https://github.com/gravitational/teleport/pull/68593). `tctl (create|edit|get|delete)` are also updated to use the client for this service in order to properly resolve scoped resources.

The reasoning for a new kubecluster service is twofold:
- Supporting scopes for existing `Get` and `Delete` RPCs would require updating the `ResourceRequest` message, which is used in many RPCs. This would probably be harmless in practice. However, we can avoid such an unnecessarily broad change by adding new RPCs that accept new request messages.
- Rather than add new RPCs to the legacy auth service, I opted to create a new `KubeCluster` service to implement the three RPCs (Get, List, Delete) that require API changes in order to support scopes.
The existing RPCs for creating and updating kube clusters are already sufficient for adding scope support. Those RPCs will continue to be used as is In order to minimize the number of changes. Although it would probably be better in the long run to eventually move all kube cluster RPCs to `KubeClusterService`. That way a single client is capable of fulfilling all kube cluster requests instead of the current split implementation.

Dynamic kube cluster registration for scoped agents and terraform provider support for scoped kube clusters are not included in this PR in an attempt to cut down on the amount of scope being added all at once. Both will be implemented as followup PRs based on top of the scoped watcher work in https://github.com/gravitational/teleport/pull/68605

## Manual Test Plan
### Test Environment
Local teleport cluster with `TELEPORT_UNSTABLE_SCOPES=yes`
### Test Cases
- [x] Create unscoped, scoped, and orthogonal scoped kube cluster sharing the same name (`tctl create`)
- [x] Get all clusters using unscoped credentials (`tctl get kube_cluster`)
- [x] Get scope isolated clusters using scoped credentials (`tctl get kube_cluster`)
- [x] Get scoped clusters using SQN (`tctl get kube_cluster <scope>::<name>`, easiest to test while unscoped)
- [x] Get unscoped cluster using name (`tctl get kube_cluster/name`)
- [x] Update scoped clusters using SQN (`tctl edit kube_cluster <scope>::<name>`)
- [x] Update unscoped cluster using name (`tctl edit kube_cluster/name`)
- [x] Delete scoped cluster using SQN (`tctl rm kube_cluster <scoped>::<name>`)
- [x] Delete unscoped cluster using name (`tctl rm kube_cluster/<name>`)
- [x] All CRUD operations work for scoped credentials according to their assigned verbs
