### PR TITLE
Show User Display Names in Access Request UI Surfaces

### DIFF
--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.story.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.story.tsx
@@ -36,6 +36,7 @@ import {
   RequestCheckoutWithSlider,
   RequestCheckoutWithSliderProps,
 } from './RequestCheckout';
+import type { ReviewerOption } from './types';
 
 export default {
   title: 'Shared/AccessRequests/Checkout',
@@ -129,6 +130,61 @@ export const LoadedResourceRequest = () => {
         fetchResourceRequestRolesAttempt={{ status: 'success' }}
         selectedResourceRequestRoles={selectedResourceRequestRoles}
         setSelectedResourceRequestRoles={setSelectedResourceRequestRoles}
+        selectedReviewers={selectedReviewers}
+        setSelectedReviewers={setSelectedReviewers}
+      />
+    </MemoryRouter>
+  );
+};
+
+export const LoadedResourceRequestWithReviewerDisplays = () => {
+  const [selectedReviewers, setSelectedReviewers] = useState<ReviewerOption[]>([
+    {
+      value: 'reviewer-one',
+      label: 'reviewer-one',
+      isSelected: true,
+    },
+    {
+      value: 'manual-reviewer',
+      label: 'manual-reviewer',
+      isSelected: true,
+    },
+  ]);
+  const dryRunResponseWithReviewerDisplays = {
+    ...dryRunResponse,
+    reviewers: [
+      {
+        name: 'reviewer-one',
+        display: {
+          primary: 'Shared Reviewer',
+          secondary: 'reviewer-one@example.com',
+        },
+        state: 'PENDING' as const,
+      },
+      {
+        name: 'reviewer-two',
+        display: { primary: 'Shared Reviewer' },
+        state: 'PENDING' as const,
+      },
+      {
+        name: 'username-only-reviewer',
+        display: {},
+        state: 'PENDING' as const,
+      },
+      {
+        name: 'absent-display-reviewer',
+        state: 'PENDING' as const,
+      },
+    ],
+  } satisfies AccessRequest;
+
+  return (
+    <MemoryRouter>
+      <RequestCheckoutWithSlider
+        {...baseProps}
+        isResourceRequest={true}
+        fetchResourceRequestRolesAttempt={{ status: 'success' }}
+        dryRunResponse={dryRunResponseWithReviewerDisplays}
         selectedReviewers={selectedReviewers}
         setSelectedReviewers={setSelectedReviewers}
       />

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -780,9 +780,7 @@ export function RequestCheckout<T extends PendingListItem>({
                   {!isLongTerm && (
                     <Box my={4}>
                       <SelectReviewers
-                        reviewers={
-                          dryRunResponse?.reviewers.map(r => r.name) ?? []
-                        }
+                        reviewers={dryRunResponse?.reviewers ?? []}
                         selectedReviewers={selectedReviewers}
                         setSelectedReviewers={setSelectedReviewers}
                       />

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/SelectReviewers.test.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/SelectReviewers.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useState } from 'react';
+
+import { render, screen, userEvent, within } from 'design/utils/testing';
+import type { AccessRequestReviewer } from 'shared/services/accessRequests';
+
+import { SelectReviewers } from './SelectReviewers';
+import type { ReviewerOption } from './types';
+
+test('renders duplicate display names with distinguishable usernames', async () => {
+  const user = userEvent.setup();
+  render(
+    <SelectReviewersHarness
+      reviewers={reviewersWithDuplicateDisplays}
+      initialSelectedReviewers={[selectedReviewer('reviewer-one')]}
+    />
+  );
+
+  const selectedReviewers = screen.getByTestId('reviewers');
+  expect(within(selectedReviewers).getByText('Shared Reviewer')).toBeVisible();
+  expect(within(selectedReviewers).getByText('reviewer-one')).toBeVisible();
+  expect(
+    within(selectedReviewers).getByText('reviewer-one@example.com')
+  ).toBeVisible();
+
+  await user.click(screen.getByRole('button', { name: 'Edit' }));
+
+  const firstReviewer = screen.getByRole('option', {
+    name: /Shared Reviewer.*reviewer-one/,
+  });
+  expect(firstReviewer).toBeVisible();
+  expect(within(firstReviewer).getByText('reviewer-one')).toHaveStyle({
+    color: 'inherit',
+  });
+  expect(
+    within(firstReviewer).getByText('reviewer-one@example.com')
+  ).toHaveStyle({ color: 'inherit' });
+  expect(
+    screen.getByRole('option', {
+      name: /Shared Reviewer.*reviewer-two/,
+    })
+  ).toBeVisible();
+
+  await user.click(firstReviewer);
+  expect(
+    within(selectedReviewers).queryByText('reviewer-one')
+  ).not.toBeInTheDocument();
+
+  const deselectedReviewer = screen.getByRole('option', {
+    name: /Shared Reviewer.*reviewer-one/,
+  });
+  await user.click(deselectedReviewer);
+
+  expect(within(selectedReviewers).getByText('Shared Reviewer')).toBeVisible();
+  expect(within(selectedReviewers).getByText('reviewer-one')).toBeVisible();
+  expect(
+    within(selectedReviewers).getByText('reviewer-one@example.com')
+  ).toBeVisible();
+});
+
+test('filters suggested reviewers by primary display, secondary display, and username', async () => {
+  const user = userEvent.setup();
+  render(<SelectReviewersHarness reviewers={reviewersWithDistinctDisplays} />);
+
+  await user.click(screen.getByRole('button', { name: 'Add' }));
+  const input = screen.getByRole('combobox');
+
+  await user.type(input, 'Alice Jones');
+  expect(
+    screen.getByRole('option', { name: /Alice Jones.*reviewer-one/ })
+  ).toBeVisible();
+  expect(
+    screen.queryByRole('option', { name: /Bob Smith.*reviewer-two/ })
+  ).not.toBeInTheDocument();
+
+  await user.clear(input);
+  await user.type(input, 'alice@example.com');
+  expect(
+    screen.getByRole('option', { name: /Alice Jones.*reviewer-one/ })
+  ).toBeVisible();
+  expect(
+    screen.queryByRole('option', { name: /Bob Smith.*reviewer-two/ })
+  ).not.toBeInTheDocument();
+
+  await user.clear(input);
+  await user.type(input, 'reviewer-two');
+  expect(
+    screen.getByRole('option', { name: /Bob Smith.*reviewer-two/ })
+  ).toBeVisible();
+  expect(
+    screen.queryByRole('option', { name: /Alice Jones.*reviewer-one/ })
+  ).not.toBeInTheDocument();
+});
+
+test('shows the create label for a manually entered reviewer', async () => {
+  const user = userEvent.setup();
+  render(<SelectReviewersHarness reviewers={[]} />);
+
+  await user.click(screen.getByRole('button', { name: 'Add' }));
+  await user.type(screen.getByRole('combobox'), 'manual-reviewer');
+
+  expect(
+    screen.getByRole('option', { name: 'Create "manual-reviewer"' })
+  ).toBeVisible();
+});
+
+test('updates selected and suggested displays when reviewer data changes', async () => {
+  const user = userEvent.setup();
+  const { rerender } = render(
+    <SelectReviewersHarness
+      reviewers={[reviewer('reviewer-one')]}
+      initialSelectedReviewers={[selectedReviewer('reviewer-one')]}
+    />
+  );
+
+  const selectedReviewers = screen.getByTestId('reviewers');
+  expect(within(selectedReviewers).getByText('reviewer-one')).toBeVisible();
+  expect(
+    within(selectedReviewers).queryByText('Alice Jones')
+  ).not.toBeInTheDocument();
+
+  rerender(
+    <SelectReviewersHarness
+      reviewers={[reviewer('reviewer-one', 'Alice Jones')]}
+      initialSelectedReviewers={[selectedReviewer('reviewer-one')]}
+    />
+  );
+
+  expect(within(selectedReviewers).getByText('Alice Jones')).toBeVisible();
+  expect(within(selectedReviewers).getByText('reviewer-one')).toBeVisible();
+
+  await user.click(screen.getByRole('button', { name: 'Edit' }));
+  expect(
+    screen.getByRole('option', { name: /Alice Jones.*reviewer-one/ })
+  ).toBeVisible();
+});
+
+function SelectReviewersHarness({
+  reviewers,
+  initialSelectedReviewers = [],
+}: {
+  reviewers: AccessRequestReviewer[];
+  initialSelectedReviewers?: ReviewerOption[];
+}) {
+  const [selectedReviewers, setSelectedReviewers] = useState(
+    initialSelectedReviewers
+  );
+
+  return (
+    <SelectReviewers
+      reviewers={reviewers}
+      selectedReviewers={selectedReviewers}
+      setSelectedReviewers={setSelectedReviewers}
+    />
+  );
+}
+
+function reviewer(
+  name: string,
+  primary?: string,
+  secondary?: string
+): AccessRequestReviewer {
+  return {
+    name,
+    display: primary || secondary ? { primary, secondary } : undefined,
+    state: 'PENDING',
+  };
+}
+
+function selectedReviewer(value: string): ReviewerOption {
+  return { value, label: value, isSelected: true };
+}
+
+const reviewersWithDuplicateDisplays = [
+  reviewer('reviewer-one', 'Shared Reviewer', 'reviewer-one@example.com'),
+  reviewer('reviewer-two', 'Shared Reviewer', 'reviewer-two@example.com'),
+];
+
+const reviewersWithDistinctDisplays = [
+  reviewer('reviewer-one', 'Alice Jones', 'alice@example.com'),
+  reviewer('reviewer-two', 'Bob Smith'),
+];

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/SelectReviewers.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/SelectReviewers.tsx
@@ -16,13 +16,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { components } from 'react-select';
 import ReactSelectCreatable from 'react-select/creatable';
 import styled from 'styled-components';
 
 import { Box, ButtonBorder, ButtonIcon, Flex, Text } from 'design';
 import * as Icon from 'design/Icon';
+import { UserDisplayName } from 'shared/components/UserDisplayName';
 
 import { ReviewerOption } from './types';
 
@@ -34,11 +35,32 @@ export function SelectReviewers({
   const selectWrapperRef = useRef(null);
   const reactSelectRef = useRef(null);
   const [editReviewers, setEditReviewers] = useState(false);
-  const [suggestedReviewers, setSuggestedReviewers] = useState<
-    ReviewerOption[]
-  >(
-    // Initially, all suggested reviewers are selected for the requestor.
-    () => reviewers.map(r => ({ value: r, label: r, isDisabled: true }))
+
+  const suggestedReviewerDisplays = useMemo(
+    () => new Map(reviewers.map(reviewer => [reviewer.name, reviewer.display])),
+    [reviewers]
+  );
+  const selectedReviewerOptions = useMemo(
+    () =>
+      selectedReviewers.map(reviewer => ({
+        ...reviewer,
+        display: suggestedReviewerDisplays.get(reviewer.value),
+      })),
+    [selectedReviewers, suggestedReviewerDisplays]
+  );
+  const selectedReviewerNames = useMemo(
+    () => new Set(selectedReviewers.map(reviewer => reviewer.value)),
+    [selectedReviewers]
+  );
+  const suggestedReviewers = useMemo<ReviewerOption[]>(
+    () =>
+      reviewers.map(reviewer => ({
+        value: reviewer.name,
+        label: reviewer.name,
+        display: reviewer.display,
+        isDisabled: selectedReviewerNames.has(reviewer.name),
+      })),
+    [reviewers, selectedReviewerNames]
   );
 
   useEffect(() => {
@@ -66,7 +88,7 @@ export function SelectReviewers({
   const reviewerOptions = [
     {
       label: '',
-      options: selectedReviewers,
+      options: selectedReviewerOptions,
     },
     {
       label: 'Suggested Reviewers',
@@ -94,7 +116,14 @@ export function SelectReviewers({
           <Flex alignItems="center" justifyContent="space-between">
             <Flex alignItems="center" width="210px">
               <Icon.CircleCheck size="medium" color="success.main" mr={2} />
-              <Text title={props.data.value}>{props.data.value}</Text>
+              <UserDisplayName
+                username={props.data.value}
+                primaryText={props.data.display?.primary}
+                secondaryText={props.data.display?.secondary}
+                usernameTextProps={{ style: { color: 'inherit' } }}
+                secondaryTextProps={{ style: { color: 'inherit' } }}
+                layout="stacked"
+              />
             </Flex>
             <Icon.Cross size="small" />
           </Flex>
@@ -104,9 +133,20 @@ export function SelectReviewers({
 
     return (
       <components.Option {...props}>
-        <Text mx={4} title={props.data.value}>
-          {props.data.label}
-        </Text>
+        {props.data.display ? (
+          <UserDisplayName
+            username={props.data.value}
+            primaryText={props.data.display.primary}
+            secondaryText={props.data.display.secondary}
+            usernameTextProps={{ style: { color: 'inherit' } }}
+            secondaryTextProps={{ style: { color: 'inherit' } }}
+            layout="stacked"
+          />
+        ) : (
+          <Text mx={4} title={props.data.value}>
+            {props.data.label}
+          </Text>
+        )}
       </components.Option>
     );
   };
@@ -119,18 +159,7 @@ export function SelectReviewers({
       isSelected: true,
     }));
 
-    const updateSuggestedReviewers = suggestedReviewers.map(r => {
-      if (values.find(t => t.value === r.value)) {
-        // isDisabled flag is used to not render this name in suggested list.
-        r.isDisabled = true;
-      } else {
-        r.isDisabled = false;
-      }
-      return r;
-    });
-
     setSelectedReviewers(updateSelectedReviewers);
-    setSuggestedReviewers(updateSuggestedReviewers);
   }
 
   function toggleEditReviewers() {
@@ -153,9 +182,10 @@ export function SelectReviewers({
           controlShouldRenderValue={false}
           hideSelectedOptions={false}
           placeholder="Type or select a name"
-          value={selectedReviewers}
+          value={selectedReviewerOptions}
           options={reviewerOptions}
           onChange={handleOnChange}
+          filterOption={filterReviewerOption}
           formatGroupLabel={formatGroupLabel}
           components={{ Option }}
           noOptionsMessage={() => null}
@@ -163,7 +193,7 @@ export function SelectReviewers({
         />
       </SelectWrapper>
       <Reviewers
-        reviewers={selectedReviewers}
+        reviewers={selectedReviewerOptions}
         editReviewers={editReviewers}
         toggleEditReviewers={toggleEditReviewers}
         updateReviewers={handleOnChange}
@@ -201,14 +231,13 @@ function Reviewers({
           background: ${props => props.theme.colors.spotBackground[0]};
         `}
       >
-        <Text
-          typography="body3"
-          bold
-          style={{ whiteSpace: 'nowrap', maxWidth: '200px' }}
-          title={reviewer.value}
-        >
-          {reviewer.value}
-        </Text>
+        <UserDisplayName
+          username={reviewer.value}
+          primaryText={reviewer.display?.primary}
+          secondaryText={reviewer.display?.secondary}
+          primaryTextProps={{ fontWeight: 'bold' }}
+          layout="stacked"
+        />
         <ButtonIcon
           size={0}
           title="Remove reviewer"
@@ -275,6 +304,13 @@ function Reviewers({
       </Flex>
       {expanded && <Box data-testid="reviewers">{$reviewers}</Box>}
     </>
+  );
+}
+
+function filterReviewerOption({ data }, inputValue) {
+  const normalizedInput = inputValue.trim().toLocaleLowerCase();
+  return [data.value, data.display?.primary, data.display?.secondary].some(
+    value => value?.toLocaleLowerCase().includes(normalizedInput)
   );
 }
 

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/types.ts
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/types.ts
@@ -17,8 +17,10 @@
  */
 
 import { Option } from 'shared/components/Select';
+import type { UserDisplay } from 'shared/services/accessRequests';
 
 export type ReviewerOption = Option & {
+  display?: UserDisplay;
   isDisabled?: boolean;
   isSelected?: boolean;
 };

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestList/RequestList.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestList/RequestList.tsx
@@ -20,9 +20,10 @@ import { Flex, Text } from 'design';
 import { Cell } from 'design/DataTable';
 import { ArrowFatLinesUp } from 'design/Icon';
 import { StatusDot, type StatusKind } from 'design/Status';
+import { UserDisplayName } from 'shared/components/UserDisplayName';
 import { AccessRequest } from 'shared/services/accessRequests';
 
-export const renderUserCell = ({ user }: AccessRequest) => {
+export const renderUserCell = ({ user, userDisplay }: AccessRequest) => {
   return (
     <Cell
       style={{
@@ -31,9 +32,13 @@ export const renderUserCell = ({ user }: AccessRequest) => {
         overflow: 'hidden',
         textOverflow: 'ellipsis',
       }}
-      title={user}
     >
-      {user}
+      <UserDisplayName
+        username={user}
+        primaryText={userDisplay?.primary}
+        secondaryText={userDisplay?.secondary}
+        layout="stacked"
+      />
     </Cell>
   );
 };

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestDelete/RequestDelete.story.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestDelete/RequestDelete.story.tsx
@@ -38,6 +38,39 @@ export const Loaded = () => {
   );
 };
 
+export const WithDisplayName = () => {
+  return (
+    <RequestDelete
+      {...props}
+      userDisplay={{ primary: 'Alice Example' }}
+      requestState="PENDING"
+      deleteRequestAttempt={makeEmptyAttempt()}
+    />
+  );
+};
+
+export const WithEmptyDisplay = () => {
+  return (
+    <RequestDelete
+      {...props}
+      userDisplay={{}}
+      requestState="PENDING"
+      deleteRequestAttempt={makeEmptyAttempt()}
+    />
+  );
+};
+
+export const WithPartialDisplay = () => {
+  return (
+    <RequestDelete
+      {...props}
+      userDisplay={{ secondary: 'alice@example.com' }}
+      requestState="PENDING"
+      deleteRequestAttempt={makeEmptyAttempt()}
+    />
+  );
+};
+
 export const Processing = () => {
   return (
     <RequestDelete

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestDelete/RequestDelete.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestDelete/RequestDelete.tsx
@@ -25,8 +25,9 @@ import Dialog, {
 } from 'design/Dialog';
 import { P } from 'design/Text/Text';
 import { TextSelectCopy } from 'shared/components/TextSelectCopy';
+import { UserDisplayName } from 'shared/components/UserDisplayName';
 import { Attempt } from 'shared/hooks/useAsync';
-import type { RequestState } from 'shared/services/accessRequests';
+import type { RequestState, UserDisplay } from 'shared/services/accessRequests';
 
 import RolesRequested from '../RolesRequested';
 
@@ -34,6 +35,7 @@ export interface RequestDeleteProps {
   requestId: string;
   requestState: RequestState;
   user: string;
+  userDisplay?: UserDisplay;
   roles: string[];
   onClose(): void;
   deleteRequestAttempt: Attempt<void>;
@@ -43,6 +45,7 @@ export interface RequestDeleteProps {
 export function RequestDelete({
   deleteRequestAttempt,
   user,
+  userDisplay,
   roles,
   requestId,
   requestState,
@@ -65,8 +68,16 @@ export function RequestDelete({
         )}
         <Flex flexWrap="wrap" gap={1} alignItems="baseline">
           <P>
-            You are about to delete a request from <strong>{user}</strong> for
-            the following roles:
+            You are about to delete a request from{' '}
+            <strong>
+              <UserDisplayName
+                username={user}
+                primaryText={userDisplay?.primary}
+                primaryTextProps={{ style: { font: 'inherit' } }}
+                layout="inline"
+              />
+            </strong>{' '}
+            for the following roles:
           </P>
           <RolesRequested roles={roles} />
         </Flex>

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.story.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.story.tsx
@@ -47,6 +47,7 @@ type RequestState =
   | 'searchPending'
   | 'rolePending'
   | 'roleDenied'
+  | 'roleDeniedWithDisplays'
   | 'roleApproved'
   | 'roleApprovedWithStartTime'
   | 'resourcePendingWithConstraints'
@@ -89,6 +90,8 @@ function requestAttempt(r: RequestState): Attempt<AccessRequest> {
       return makeSuccessAttempt(requestRolePending);
     case 'roleDenied':
       return makeSuccessAttempt(requestRoleDenied);
+    case 'roleDeniedWithDisplays':
+      return makeSuccessAttempt(requestRoleDeniedWithDisplays);
     case 'roleApproved':
       return makeSuccessAttempt(requestRoleApproved);
     case 'roleApprovedWithStartTime':
@@ -152,6 +155,7 @@ const meta = {
         'searchPending',
         'rolePending',
         'roleDenied',
+        'roleDeniedWithDisplays',
         'roleApproved',
         'roleApprovedWithStartTime',
         'resourcePendingWithConstraints',
@@ -241,6 +245,10 @@ export const LoadedRoleDenied: Story = {
   args: { request: 'roleDenied', canDelete: true },
 };
 
+export const LoadedRoleDeniedWithDisplays: Story = {
+  args: { request: 'roleDeniedWithDisplays', canDelete: true },
+};
+
 export const LoadedRoleApproved: Story = {
   args: { request: 'roleApproved', canDelete: true, canAssume: true },
 };
@@ -297,6 +305,45 @@ export const LongTermNoEligibleAccessList: Story = {
     suggestions: 'empty',
     canReview: true,
   },
+};
+
+const requestRoleDeniedWithDisplays: AccessRequest = {
+  ...requestRoleDenied,
+  user: 'requester',
+  userDisplay: { primary: 'Requesting User' },
+  reviews: [
+    {
+      ...requestRoleDenied.reviews[0],
+      author: 'reviewer-one',
+      authorDisplay: { primary: 'Shared Reviewer' },
+    },
+  ],
+  reviewers: [
+    {
+      name: 'reviewer-one',
+      display: { primary: 'Shared Reviewer' },
+      state: 'DENIED',
+    },
+    {
+      name: 'reviewer-two',
+      display: { primary: 'Shared Reviewer' },
+      state: 'PENDING',
+    },
+    {
+      name: 'empty-display',
+      display: {},
+      state: 'PENDING',
+    },
+    {
+      name: 'secondary-only',
+      display: { secondary: 'secondary@example.com' },
+      state: 'PENDING',
+    },
+    {
+      name: 'absent-display',
+      state: 'PENDING',
+    },
+  ],
 };
 
 export const LongTermSuggestionsPermissionDenied: Story = {

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.test.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.test.tsx
@@ -81,6 +81,126 @@ test('does not render review box if user cannot review', async () => {
   expect(screen.queryByText(reviewBoxText)).not.toBeInTheDocument();
 });
 
+test('renders requester and reviewer display names with usernames', () => {
+  const request = {
+    ...requestRolePending,
+    user: 'requester',
+    userDisplay: { primary: 'Requesting User' },
+    reviews: [
+      {
+        author: 'reviewer-one',
+        authorDisplay: { primary: 'Review Author' },
+        createdDuration: 'one minute ago',
+        state: 'APPROVED' as const,
+        reason: 'Approved',
+        roles: ['admin'],
+      },
+    ],
+    reviewers: [
+      {
+        name: 'reviewer-one',
+        display: {
+          primary: 'First Reviewer',
+          secondary: 'reviewer-one@example.com',
+        },
+        state: 'APPROVED' as const,
+      },
+      {
+        name: 'reviewer-two',
+        display: { primary: 'Second Reviewer' },
+        state: 'PENDING' as const,
+      },
+    ],
+  };
+
+  render(
+    <RequestView {...props} fetchRequestAttempt={makeSuccessAttempt(request)} />
+  );
+
+  const requestHeader = screen.getByText('is requesting roles:')
+    .parentElement as HTMLElement;
+  expect(within(requestHeader).getByText('Requesting User')).toBeVisible();
+  expect(within(requestHeader).getByText('requester')).toBeVisible();
+
+  const requestTimestamp = screen.getByText(
+    'submitted this request 1 minute ago'
+  ).parentElement as HTMLElement;
+  expect(within(requestTimestamp).getByText('Requesting User')).toBeVisible();
+  expect(within(requestTimestamp).getByText('requester')).toBeVisible();
+
+  const requestComment = screen.getByText(/Testing long message format/)
+    .parentElement as HTMLElement;
+  expect(within(requestComment).getByText('Requesting User')).toBeVisible();
+  expect(within(requestComment).getByText('requester')).toBeVisible();
+
+  const reviewTimestamp = screen.getByText(
+    'approved this request one minute ago'
+  ).parentElement as HTMLElement;
+  expect(within(reviewTimestamp).getByText('Review Author')).toBeVisible();
+  expect(within(reviewTimestamp).getByText('reviewer-one')).toBeVisible();
+
+  const reviewComment = screen.getByText('Approved')
+    .parentElement as HTMLElement;
+  expect(within(reviewComment).getByText('Review Author')).toBeVisible();
+  expect(within(reviewComment).getByText('reviewer-one')).toBeVisible();
+
+  const reviewers = screen.getByText('Reviewers').parentElement
+    ?.parentElement as HTMLElement;
+  expect(within(reviewers).getByText('First Reviewer')).toBeVisible();
+  expect(within(reviewers).getByText('reviewer-one')).toBeVisible();
+  expect(within(reviewers).getByText('reviewer-one@example.com')).toBeVisible();
+  expect(within(reviewers).getByText('Second Reviewer')).toBeVisible();
+  expect(within(reviewers).getByText('reviewer-two')).toBeVisible();
+});
+
+test('renders usernames when display values are empty, partial, or absent', () => {
+  const request = {
+    ...requestRolePending,
+    user: 'requester',
+    userDisplay: { primary: '   ' },
+    reviewers: [
+      {
+        name: 'empty-reviewer',
+        display: {},
+        state: 'PENDING' as const,
+      },
+      {
+        name: 'secondary-reviewer',
+        display: { secondary: 'secondary@example.com' },
+        state: 'PENDING' as const,
+      },
+      {
+        name: 'absent-reviewer',
+        state: 'PENDING' as const,
+      },
+    ],
+  };
+
+  render(
+    <RequestView {...props} fetchRequestAttempt={makeSuccessAttempt(request)} />
+  );
+
+  const requestHeader = screen.getByText('is requesting roles:')
+    .parentElement as HTMLElement;
+  expect(within(requestHeader).getByText('requester')).toBeVisible();
+
+  const requestTimestamp = screen.getByText(
+    'submitted this request 1 minute ago'
+  ).parentElement as HTMLElement;
+  expect(within(requestTimestamp).getByText('requester')).toBeVisible();
+
+  const requestComment = screen.getByText(/Testing long message format/)
+    .parentElement as HTMLElement;
+  expect(within(requestComment).getByText('requester')).toBeVisible();
+
+  const reviewers = screen.getByText('Reviewers').parentElement
+    ?.parentElement as HTMLElement;
+  expect(within(reviewers).getByText('empty-reviewer')).toBeVisible();
+  expect(within(reviewers).getByText('secondary-reviewer')).toBeVisible();
+  expect(within(reviewers).getByText('absent-reviewer')).toBeVisible();
+  expect(within(reviewers).getByText('secondary@example.com')).toBeVisible();
+});
+
 // When no Access List can be promoted to (e.g., reviewer doesn't own one that
 // grants every requested resource, including implicitly-added ones), long-term
 // approval is disabled, leaving only Reject. The disabled option explains why.

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
@@ -43,6 +43,7 @@ import { Status, StatusDot, StatusKind } from 'design/Status';
 import { TeleportGearIcon } from 'design/SVGIcon';
 import { HoverTooltip } from 'design/Tooltip';
 import ResourcesRequested from 'shared/components/AccessRequests/ReviewRequests/RequestView/ResourcesRequested';
+import { UserDisplayName } from 'shared/components/UserDisplayName';
 import { Attempt, hasFinished } from 'shared/hooks/useAsync';
 import {
   AccessRequest,
@@ -53,6 +54,7 @@ import {
   RequestKind,
   RequestState,
   Resource,
+  UserDisplay,
   WithResourceConstraints,
 } from 'shared/services/accessRequests';
 
@@ -176,6 +178,7 @@ export function RequestView({
       {confirmDelete && (
         <RequestDelete
           user={request.user}
+          userDisplay={request.userDisplay}
           roles={request.roles}
           requestId={request.id}
           requestState={request.state}
@@ -220,16 +223,12 @@ export function RequestView({
                 />
                 <H3>
                   <Flex flexWrap="wrap" alignItems="baseline">
-                    <Text
-                      mr={1}
-                      title={request.user}
-                      bold
-                      style={{
-                        maxWidth: '120px',
-                      }}
-                    >
-                      {request.user}
-                    </Text>
+                    <RequesterDisplayName
+                      username={request.user}
+                      primaryText={request.userDisplay?.primary}
+                      primaryTextProps={{ fontWeight: 'bold' }}
+                      layout="inline"
+                    />
                     {request.requestKind === RequestKind.LongTerm ? (
                       <>
                         <Text
@@ -294,6 +293,7 @@ export function RequestView({
               <Timeline />
               <RequestorTimestamp
                 user={request.user}
+                display={request.userDisplay}
                 reason={request.requestReason}
                 createdDuration={request.createdDuration}
                 resources={request.resources}
@@ -357,21 +357,28 @@ export const Timeline = styled.div`
 
 export function RequestorTimestamp({
   user,
+  display,
   reason,
   createdDuration,
   resources,
 }: {
   user: string;
+  display?: UserDisplay;
   reason: string;
   createdDuration: string;
   resources: Resource[];
 }) {
   return (
     <>
-      <Timestamp author={user} createdDuration={createdDuration} />
+      <Timestamp
+        author={user}
+        display={display}
+        createdDuration={createdDuration}
+      />
       {(reason || resources?.length > 0) && (
         <Comment
           author={user}
+          display={display}
           comment={reason}
           createdDuration={createdDuration}
           resources={resources}
@@ -383,12 +390,14 @@ export function RequestorTimestamp({
 
 export function Timestamp({
   author,
+  display,
   state,
   createdDuration,
   promotedAccessListTitle,
   assumeStartTime,
 }: {
   author: string;
+  display?: UserDisplay;
   state?: RequestState;
   createdDuration: string;
   promotedAccessListTitle?: string;
@@ -431,7 +440,12 @@ export function Timestamp({
         {$icon}
       </Box>
       <Text typography="body2">
-        <b>{author}</b>{' '}
+        <UserDisplayName
+          username={author}
+          primaryText={display?.primary}
+          primaryTextProps={{ fontWeight: 'bold' }}
+          layout="inline"
+        />{' '}
         {!isPromoted ? (
           assumeStartTime ? (
             <span>
@@ -508,11 +522,13 @@ const SshConstraintsList = <R extends object>({
 
 function Comment({
   author,
+  display,
   comment,
   createdDuration,
   resources,
 }: {
   author: string;
+  display?: UserDisplay;
   comment: string;
   createdDuration: string;
   resources?: Resource[];
@@ -553,7 +569,14 @@ function Comment({
       style={{ position: 'relative' }}
     >
       <Flex bg="levels.sunken" py={1} px={3} alignItems="baseline">
-        <H3 mr={2}>{author}</H3>
+        <H3 mr={2}>
+          <UserDisplayName
+            username={author}
+            primaryText={display?.primary}
+            primaryTextProps={{ fontWeight: 'bold' }}
+            layout="inline"
+          />
+        </H3>
         <Text typography="body3">{createdDuration}</Text>
       </Flex>
       {comment && (
@@ -616,18 +639,15 @@ function Reviewers({ reviewers }: { reviewers: AccessRequestReviewer[] }) {
           background: ${props => props.theme.colors.spotBackground[0]};
         `}
       >
-        <Text
-          typography="body3"
-          bold
-          mr={3}
-          style={{
-            whiteSpace: 'nowrap',
-            maxWidth: '200px',
+        <UserDisplayName
+          username={reviewer.name}
+          primaryText={reviewer.display?.primary}
+          secondaryText={reviewer.display?.secondary}
+          primaryTextProps={{
+            fontWeight: 'bold',
           }}
-          title={reviewer.name}
-        >
-          {reviewer.name}
-        </Text>
+          layout="stacked"
+        />
         <StatusDot kind={dotKind} />
       </Flex>
     );
@@ -706,6 +726,7 @@ function Reviews({ reviews }: { reviews: AccessRequestReview[] }) {
       <Fragment key={index}>
         <Timestamp
           author={author}
+          display={review.authorDisplay}
           state={state}
           createdDuration={createdDuration}
           promotedAccessListTitle={promotedAccessListTitle}
@@ -714,6 +735,7 @@ function Reviews({ reviews }: { reviews: AccessRequestReview[] }) {
         {reason && (
           <Comment
             author={author}
+            display={review.authorDisplay}
             comment={reason}
             createdDuration={createdDuration}
           />
@@ -773,6 +795,10 @@ const StyledTable = styled(Table)`
 const BrandName = styled.span`
   font-weight: bold;
   color: ${p => p.theme.colors.brand};
+`;
+
+const RequesterDisplayName = styled(UserDisplayName)`
+  margin-right: ${props => props.theme.space[1]}px;
 `;
 
 export const TimelineCommentAndReviewsContainer = styled.div`

--- a/web/packages/shared/components/UserDisplayName/UserDisplayName.tsx
+++ b/web/packages/shared/components/UserDisplayName/UserDisplayName.tsx
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import type { ComponentProps } from 'react';
 import styled, { css } from 'styled-components';
 
 import { Text } from 'design';
@@ -29,12 +30,14 @@ export function UserDisplayName({
   secondaryText,
   layout = 'tooltip',
   className,
+  primaryTextProps,
 }: {
   username: string;
   primaryText?: string;
   secondaryText?: string;
   layout?: UserDisplayNameLayout;
   className?: string;
+  primaryTextProps?: ComponentProps<typeof Text>;
 }) {
   const displayPrimary = normalizeText(primaryText);
   const displaySecondary = normalizeText(secondaryText);
@@ -42,7 +45,7 @@ export function UserDisplayName({
   const tooltipLabel = getTooltipAriaLabel(primary, displaySecondary, username);
 
   const primaryValue = (ariaLabel?: string) => (
-    <PrimaryValue title={primary} aria-label={ariaLabel}>
+    <PrimaryValue {...primaryTextProps} title={primary} aria-label={ariaLabel}>
       {primary}
     </PrimaryValue>
   );

--- a/web/packages/shared/components/UserDisplayName/UserDisplayName.tsx
+++ b/web/packages/shared/components/UserDisplayName/UserDisplayName.tsx
@@ -31,6 +31,8 @@ export function UserDisplayName({
   layout = 'tooltip',
   className,
   primaryTextProps,
+  usernameTextProps,
+  secondaryTextProps,
 }: {
   username: string;
   primaryText?: string;
@@ -38,6 +40,8 @@ export function UserDisplayName({
   layout?: UserDisplayNameLayout;
   className?: string;
   primaryTextProps?: ComponentProps<typeof Text>;
+  usernameTextProps?: ComponentProps<typeof Text>;
+  secondaryTextProps?: ComponentProps<typeof Text>;
 }) {
   const displayPrimary = normalizeText(primaryText);
   const displaySecondary = normalizeText(secondaryText);
@@ -51,18 +55,22 @@ export function UserDisplayName({
   );
 
   const secondaryValue = displaySecondary && (
-    <SecondaryValue title={displaySecondary}>{displaySecondary}</SecondaryValue>
+    <SecondaryValue {...secondaryTextProps} title={displaySecondary}>
+      {displaySecondary}
+    </SecondaryValue>
   );
 
   const separatedSecondaryValue = displaySecondary && (
-    <SeparatedSecondaryValue title={displaySecondary}>
+    <SeparatedSecondaryValue {...secondaryTextProps} title={displaySecondary}>
       {displaySecondary}
     </SeparatedSecondaryValue>
   );
 
   const supportingValues = displayPrimary ? (
     <>
-      <UsernameValue title={username}>{username}</UsernameValue>
+      <UsernameValue {...usernameTextProps} title={username}>
+        {username}
+      </UsernameValue>
       {separatedSecondaryValue}
     </>
   ) : (

--- a/web/packages/shared/services/accessRequests/accessRequests.ts
+++ b/web/packages/shared/services/accessRequests/accessRequests.ts
@@ -33,6 +33,11 @@ export enum RequestKind {
   LongTerm = 2,
 }
 
+export type UserDisplay = {
+  primary?: string;
+  secondary?: string;
+};
+
 /**
  * LongTermResourceGrouping contains information about how resources can be grouped
  * for long-term Access Requests.
@@ -64,6 +69,7 @@ export interface AccessRequest {
   id: string;
   state: RequestState;
   user: string;
+  userDisplay?: UserDisplay;
   expires: Date;
   expiresDuration: string;
   created: Date;
@@ -92,6 +98,7 @@ export interface AccessRequest {
 
 export interface AccessRequestReview {
   author: string;
+  authorDisplay?: UserDisplay;
   roles: string[];
   state: RequestState;
   reason: string;
@@ -102,6 +109,7 @@ export interface AccessRequestReview {
 
 export interface AccessRequestReviewer {
   name: string;
+  display?: UserDisplay;
   state: RequestState;
 }
 

--- a/web/packages/shared/services/accessRequests/makeAccessRequest.test.ts
+++ b/web/packages/shared/services/accessRequests/makeAccessRequest.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { makeAccessRequest } from './makeAccessRequest';
+
+test('maps current user info fields and display values', () => {
+  const request = makeAccessRequest({
+    ...requestJson,
+    user: 'legacy-requester',
+    userInfo: {
+      username: 'requester',
+      display: {
+        primary: 'Requesting User',
+        secondary: 'requester@example.com',
+      },
+    },
+    suggestedReviewers: ['legacy-reviewer'],
+    suggestedReviewersInfo: [
+      {
+        username: 'reviewer-one',
+        display: { primary: 'Shared Reviewer' },
+      },
+      {
+        username: 'reviewer-two',
+        display: { primary: 'Shared Reviewer' },
+      },
+      {
+        username: 'reviewer-empty',
+        display: {},
+      },
+      {
+        username: 'reviewer-secondary',
+        display: { secondary: 'secondary@example.com' },
+      },
+    ],
+    reviews: [
+      {
+        author: 'legacy-author',
+        authorInfo: {
+          username: 'reviewer-one',
+          display: { primary: 'Shared Reviewer' },
+        },
+        state: 'APPROVED',
+        reason: 'Approved',
+        roles: ['editor'],
+        created: '2026-07-16T12:30:00.000Z',
+      },
+      {
+        author: 'legacy-unsuggested-author',
+        authorInfo: {
+          username: 'unsuggested-reviewer',
+          display: { primary: 'Unlisted Reviewer' },
+        },
+        state: 'DENIED',
+        reason: 'Denied',
+        roles: [],
+        created: '2026-07-16T12:45:00.000Z',
+      },
+    ],
+  });
+
+  expect(request).toMatchObject({
+    user: 'requester',
+    userDisplay: {
+      primary: 'Requesting User',
+      secondary: 'requester@example.com',
+    },
+    reviews: [
+      {
+        author: 'reviewer-one',
+        authorDisplay: { primary: 'Shared Reviewer' },
+      },
+      {
+        author: 'unsuggested-reviewer',
+        authorDisplay: { primary: 'Unlisted Reviewer' },
+      },
+    ],
+    reviewers: [
+      {
+        name: 'reviewer-one',
+        display: { primary: 'Shared Reviewer' },
+        state: 'APPROVED',
+      },
+      {
+        name: 'reviewer-two',
+        display: { primary: 'Shared Reviewer' },
+        state: 'PENDING',
+      },
+      {
+        name: 'reviewer-empty',
+        display: {},
+        state: 'PENDING',
+      },
+      {
+        name: 'reviewer-secondary',
+        display: { secondary: 'secondary@example.com' },
+        state: 'PENDING',
+      },
+      {
+        name: 'unsuggested-reviewer',
+        display: { primary: 'Unlisted Reviewer' },
+        state: 'DENIED',
+      },
+    ],
+  });
+});
+
+test('falls back to legacy usernames when current info fields are absent', () => {
+  const request = makeAccessRequest({
+    ...requestJson,
+    user: 'legacy-requester',
+    suggestedReviewers: ['legacy-reviewer'],
+    reviews: [
+      {
+        author: 'legacy-author',
+        state: 'APPROVED',
+        reason: '',
+        roles: [],
+        created: '2026-07-16T12:30:00.000Z',
+      },
+    ],
+  });
+
+  expect(request).toMatchObject({
+    user: 'legacy-requester',
+    userDisplay: undefined,
+    reviews: [
+      {
+        author: 'legacy-author',
+        authorDisplay: undefined,
+      },
+    ],
+    reviewers: [
+      {
+        name: 'legacy-reviewer',
+        display: undefined,
+        state: 'PENDING',
+      },
+      {
+        name: 'legacy-author',
+        display: undefined,
+        state: 'APPROVED',
+      },
+    ],
+  });
+  expect(request).toHaveProperty('userDisplay', undefined);
+  expect(request.reviews[0]).toHaveProperty('authorDisplay', undefined);
+  expect(request.reviewers[0]).toHaveProperty('display', undefined);
+  expect(request.reviewers[1]).toHaveProperty('display', undefined);
+});
+
+test('preserves the difference between empty and absent displays', () => {
+  const request = makeAccessRequest({
+    ...requestJson,
+    userInfo: { username: 'requester', display: {} },
+    suggestedReviewersInfo: [
+      { username: 'empty-display', display: {} },
+      { username: 'absent-display' },
+    ],
+  });
+
+  expect(request.user).toBe('requester');
+  expect(request).toHaveProperty('userDisplay', {});
+  expect(request.reviewers[0]).toHaveProperty('display', {});
+  expect(request.reviewers[1]).toHaveProperty('display', undefined);
+});
+
+const requestJson = {
+  id: 'request-id',
+  state: 'PENDING',
+  expires: '2026-07-17T12:00:00.000Z',
+  created: '2026-07-16T12:00:00.000Z',
+  requestTTL: '2026-07-17T12:00:00.000Z',
+  roles: ['editor'],
+};

--- a/web/packages/shared/services/accessRequests/makeAccessRequest.ts
+++ b/web/packages/shared/services/accessRequests/makeAccessRequest.ts
@@ -38,13 +38,20 @@ import {
 export function makeAccessRequest(json?): AccessRequest {
   json = json || {};
 
+  // DELETE IN 20.0: Remove the fallback to the legacy user field.
+  const user = json.userInfo?.username ?? json.user;
   const reviews = makeReviews(json.reviews);
-  const reviewers = makeReviewers(json.suggestedReviewers, reviews);
+  // DELETE IN 20.0: Remove the fallback to legacy suggested reviewers.
+  const suggestedReviewersInfo =
+    json.suggestedReviewersInfo ??
+    (json.suggestedReviewers || []).map(username => ({ username }));
+  const reviewers = makeReviewers(suggestedReviewersInfo, reviews);
 
   return {
     id: json.id,
     state: json.state,
-    user: json.user,
+    user,
+    userDisplay: json.userInfo?.display,
     expires: new Date(json.expires),
     expiresDuration: getDurationText(json.expires),
     created: new Date(json.created),
@@ -92,26 +99,36 @@ function getRequestKind(jsonKind: unknown): RequestKind {
 function makeReviews(jsonReviews): AccessRequestReview[] {
   jsonReviews = jsonReviews || [];
 
-  return jsonReviews.map(review => ({
-    author: review.author,
-    state: review.state,
-    reason: review.reason,
-    roles: review.roles || [],
-    createdDuration: getDurationAgoText(review.created),
-    promotedAccessListTitle: review.promotedAccessListTitle,
-    assumeStartTime: review.assumeStartTime
-      ? new Date(review.assumeStartTime)
-      : null,
-  }));
+  return jsonReviews.map(review => {
+    // DELETE IN 20.0: Remove the fallback to the legacy author field.
+    const author = review.authorInfo?.username ?? review.author;
+
+    return {
+      author,
+      authorDisplay: review.authorInfo?.display,
+      state: review.state,
+      reason: review.reason,
+      roles: review.roles || [],
+      createdDuration: getDurationAgoText(review.created),
+      promotedAccessListTitle: review.promotedAccessListTitle,
+      assumeStartTime: review.assumeStartTime
+        ? new Date(review.assumeStartTime)
+        : null,
+    };
+  });
 }
 
-function makeReviewers(jsonSuggestedReviewers, reviews: AccessRequestReview[]) {
-  jsonSuggestedReviewers = jsonSuggestedReviewers || [];
+function makeReviewers(
+  jsonSuggestedReviewersInfo,
+  reviews: AccessRequestReview[]
+) {
+  jsonSuggestedReviewersInfo = jsonSuggestedReviewersInfo || [];
 
-  let allReviewers: AccessRequestReviewer[] = jsonSuggestedReviewers.map(
-    name =>
+  let allReviewers: AccessRequestReviewer[] = jsonSuggestedReviewersInfo.map(
+    reviewer =>
       ({
-        name,
+        name: reviewer.username,
+        display: reviewer.display,
         state: 'PENDING',
       }) as AccessRequestReviewer
   );
@@ -119,14 +136,21 @@ function makeReviewers(jsonSuggestedReviewers, reviews: AccessRequestReview[]) {
   // The reviewers in reviews list, may not be a part of the suggested reviewers list
   // b/c any user with permission can review a request.
   reviews.forEach(review => {
-    const index = jsonSuggestedReviewers.indexOf(review.author);
+    const index = jsonSuggestedReviewersInfo.findIndex(
+      reviewer => reviewer.username === review.author
+    );
 
     if (index > -1) {
       allReviewers[index].state = review.state;
+      allReviewers[index].display ??= review.authorDisplay;
     } else {
       allReviewers = [
         ...allReviewers,
-        { name: review.author, state: review.state },
+        {
+          name: review.author,
+          display: review.authorDisplay,
+          state: review.state,
+        },
       ];
     }
   });

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.test.tsx
@@ -129,10 +129,12 @@ test('makeUiAccessRequest', async () => {
     ],
     reviewers: [
       {
+        display: undefined,
         name: 'sugested-reviewer-1',
         state: 'PENDING',
       },
       {
+        display: undefined,
         name: 'llama',
         state: 'DENIED',
       },
@@ -140,6 +142,7 @@ test('makeUiAccessRequest', async () => {
     reviews: [
       {
         author: 'llama',
+        authorDisplay: undefined,
         createdDuration: '6 days ago',
         promotedAccessListTitle: '',
         reason: 'not today',
@@ -154,6 +157,7 @@ test('makeUiAccessRequest', async () => {
     state: 'PENDING',
     thresholdNames: ['default'],
     user: 'sevy',
+    userDisplay: undefined,
     assumeStartTime: new Date('2024-03-07T23:20:50.520Z'),
     assumeStartTimeDuration: 'now',
     reasonMode: 'optional',


### PR DESCRIPTION
This PR addresses [#66993](https://github.com/gravitational/teleport/issues/66993) by rendering user display names across the Access Request surfaces in the Web UI: the request list requester column, the request detail header and timeline, review history entries, the reviewers sidebar, the delete-confirmation dialog and the suggested reviewers display for the creation flow. 

[Figma design](https://www.figma.com/design/v6GunK50D2VC7w7I2FBDNf/Zero-Trust-Access?node-id=11246-142946&t=4StlDaSbNZpvd8UK-0)

## Screenshots
  <img width="2550" height="1002" alt="Screenshot 2026-07-19 at 12 58 24 PM" src="https://github.com/user-attachments/assets/4e7b3a02-8954-4b70-8499-3edaf97a2fbe" />

  <img width="1451" height="797" alt="Screenshot 2026-07-19 at 5 55 45 PM" src="https://github.com/user-attachments/assets/895405e9-c110-4b09-a988-e31a59feacd6" />

  <img width="730" height="313" alt="Screenshot 2026-07-19 at 12 47 57 PM" src="https://github.com/user-attachments/assets/ce918654-b808-479a-bad3-9bd1e95d5644" />
  
<img width="479" height="720" alt="Screenshot 2026-07-20 at 4 50 33 PM" src="https://github.com/user-attachments/assets/9e4f4101-5f46-4fa7-a7bc-a14651b9c6cf" />
 
 <img width="419" height="347" alt="Screenshot 2026-07-20 at 4 58 02 PM" src="https://github.com/user-attachments/assets/04cbf782-1999-442a-8005-9709fd28f54c" />

## Manual Test Plan

### Test Environment

- A local cluster with a few access requests that have been reviewed
- The requester and the reviewers should have some display traits populated (e.g. `displayName` or `email`)

### Test Cases

- [x] Verify the access request list shows enriched user displays
   1. Visit https://localhost:3000/web/requests
   2. Verify the User column shows the display name
- [x] Verify the access request details page shows enriched user displays
   1. Visit https://localhost:3000/web/requests/<request id>
   2. Verify that everywhere previously rendering only a username (header, timeline, review history, and reviewers sidebar) now shows the enriched user display
   3. Click the Delete button and verify the confirmation dialog also shows the enriched user display
- [x] Verify the access request creation page shows enriched suggested reviewers
  1. Start the flow of creating a temporary access request
  2. Verify the suggested reviewer displays are enriched




changelog: The web UI now shows user display names on the Access Request list, request details, delete confirmation views and request creation flows.