### PR TITLE
Restore Stripe CSP for stripe-managed tenants

### DIFF
--- a/lib/httplib/httpheaders.go
+++ b/lib/httplib/httpheaders.go
@@ -50,6 +50,16 @@ var (
 	defaultFontSrc     = CSPMap{"font-src": {"'self'", "data:"}}
 	defaultConnectSrc  = CSPMap{"connect-src": {"'self'", "wss:"}}
 	wasmSecurityPolicy = CSPMap{"script-src": {"'self'", "'wasm-unsafe-eval'"}}
+
+	// stripeSecurityPolicy grants the origins Stripe.js and the Payment Element
+	// need to load and communicate with Stripe. Applied only to stripe-managed
+	// tenants — see getIndexContentSecurityPolicyString.
+	// https://docs.stripe.com/security/guide#content-security-policy
+	stripeSecurityPolicy = CSPMap{
+		"script-src":  {"https://js.stripe.com", "https://*.js.stripe.com"},
+		"frame-src":   {"https://js.stripe.com", "https://*.js.stripe.com", "https://hooks.stripe.com"},
+		"connect-src": {"https://api.stripe.com"},
+	}
 )
 
 // combineCSPMaps combines multiple CSP maps into a single map.
@@ -137,11 +147,22 @@ func SetDefaultSecurityHeaders(h http.Header) {
 	h.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 }
 
-func getIndexContentSecurityPolicy(withWasm bool) CSPMap {
-	cspMaps := []CSPMap{defaultContentSecurityPolicy, defaultFontSrc, defaultConnectSrc}
+type cspOption int
 
-	if withWasm {
-		cspMaps = append(cspMaps, wasmSecurityPolicy)
+const (
+	withWASM cspOption = iota
+	withStripe
+)
+
+func getIndexContentSecurityPolicy(options ...cspOption) CSPMap {
+	cspMaps := []CSPMap{defaultContentSecurityPolicy, defaultFontSrc, defaultConnectSrc}
+	for _, option := range options {
+		switch option {
+		case withWASM:
+			cspMaps = append(cspMaps, wasmSecurityPolicy)
+		case withStripe:
+			cspMaps = append(cspMaps, stripeSecurityPolicy)
+		}
 	}
 
 	return combineCSPMaps(cspMaps...)
@@ -172,23 +193,34 @@ const (
 )
 
 var (
-	indexCSPWithWASM    = GetContentSecurityPolicyString(getIndexContentSecurityPolicy(true))
-	indexCSPWithoutWASM = GetContentSecurityPolicyString(getIndexContentSecurityPolicy(false))
+	indexCSPWithWASM          = GetContentSecurityPolicyString(getIndexContentSecurityPolicy(withWASM))
+	indexCSPWithoutWASM       = GetContentSecurityPolicyString(getIndexContentSecurityPolicy())
+	indexCSPStripeWithWASM    = GetContentSecurityPolicyString(getIndexContentSecurityPolicy(withStripe, withWASM))
+	indexCSPStripeWithoutWASM = GetContentSecurityPolicyString(getIndexContentSecurityPolicy(withStripe))
 )
 
-func getIndexContentSecurityPolicyString(urlPath string) string {
-	if wasm := desktopSessionRe.MatchString(urlPath) ||
+func getIndexContentSecurityPolicyString(withStripe bool, urlPath string) string {
+	wasm := desktopSessionRe.MatchString(urlPath) ||
 		linuxDesktopSessionRe.MatchString(urlPath) ||
 		recordingRe.MatchString(urlPath) ||
-		sshSessionRe.MatchString(urlPath); wasm {
+		sshSessionRe.MatchString(urlPath)
+	switch {
+	case wasm && withStripe:
+		return indexCSPStripeWithWASM
+	case wasm:
 		return indexCSPWithWASM
+	case withStripe:
+		return indexCSPStripeWithoutWASM
+	default:
+		return indexCSPWithoutWASM
 	}
-	return indexCSPWithoutWASM
 }
 
 // SetIndexContentSecurityPolicy sets the Content-Security-Policy header for main index.html page.
-func SetIndexContentSecurityPolicy(h http.Header, urlPath string) {
-	h.Set(cspHeaderName, getIndexContentSecurityPolicyString(urlPath))
+// withStripe should be true for stripe-managed tenants so that Stripe.js and the Payment Element
+// can load in the cloud panel.
+func SetIndexContentSecurityPolicy(h http.Header, withStripe bool, urlPath string) {
+	h.Set(cspHeaderName, getIndexContentSecurityPolicyString(withStripe, urlPath))
 }
 
 // SetRedirectPageContentSecurityPolicy sets the Content-Security-Policy header

--- a/lib/httplib/httplib_test.go
+++ b/lib/httplib/httplib_test.go
@@ -272,6 +272,7 @@ func TestSetIndexContentSecurityPolicy(t *testing.T) {
 
 	for _, tt := range []struct {
 		name            string
+		withStripe      bool
 		urlPath         string
 		expectedCSPVals map[string]string
 	}{
@@ -370,14 +371,45 @@ func TestSetIndexContentSecurityPolicy(t *testing.T) {
 				"connect-src":     "'self' wss:",
 			},
 		},
+		{
+			name:       "for stripe-managed tenant (no wasm)",
+			withStripe: true,
+			urlPath:    "/web/index.js",
+			expectedCSPVals: map[string]string{
+				"default-src":     "'self'",
+				"base-uri":        "'self'",
+				"form-action":     "'self'",
+				"frame-ancestors": "'none'",
+				"object-src":      "'none'",
+				"script-src":      "'self' https://js.stripe.com https://*.js.stripe.com",
+				"frame-src":       "https://js.stripe.com https://*.js.stripe.com https://hooks.stripe.com",
+				"connect-src":     "'self' wss: https://api.stripe.com",
+				"style-src":       "'self' 'unsafe-inline'",
+				"img-src":         "'self' data: blob:",
+				"font-src":        "'self' data:",
+			},
+		},
+		{
+			name:       "for stripe-managed tenant on desktop session (with wasm)",
+			withStripe: true,
+			urlPath:    "/web/cluster/:clusterId/desktops/:desktopName/:username",
+			expectedCSPVals: map[string]string{
+				"script-src":  "'self' https://js.stripe.com https://*.js.stripe.com 'wasm-unsafe-eval'",
+				"frame-src":   "https://js.stripe.com https://*.js.stripe.com https://hooks.stripe.com",
+				"connect-src": "'self' wss: https://api.stripe.com",
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			h := make(http.Header)
-			SetIndexContentSecurityPolicy(h, tt.urlPath)
+			SetIndexContentSecurityPolicy(h, tt.withStripe, tt.urlPath)
 			actualCSP := h.Get("Content-Security-Policy")
 			for k, v := range tt.expectedCSPVals {
 				expectedCSPSubstring := fmt.Sprintf("%s %s;", k, v)
 				require.Contains(t, actualCSP, expectedCSPSubstring)
+			}
+			if !tt.withStripe {
+				require.NotContains(t, actualCSP, "stripe.com")
 			}
 		})
 	}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -797,7 +797,8 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 			session.XCSRF = csrfToken
 
 			httplib.SetNoCacheHeaders(w.Header())
-			httplib.SetIndexContentSecurityPolicy(w.Header(), r.URL.Path)
+			features := h.GetClusterFeatures()
+			httplib.SetIndexContentSecurityPolicy(w.Header(), features.GetIsStripeManaged(), r.URL.Path)
 
 			if err := indexPage.Execute(w, session); err != nil {
 				h.logger.ErrorContext(r.Context(), "Failed to execute index page template", "error", err)


### PR DESCRIPTION
Re-adds the Stripe CSP block removed in #44328, expanded per Stripe's Payment Element requirements (script-src + frame-src on js.stripe.com and *.js.stripe.com, frame-src on hooks.stripe.com for 3DS, connect-src on api.stripe.com). Gated on Features.IsStripeManaged so non-stripe tenants keep the tighter default CSP.

Needed for the Cloud Panel to render Stripe.js + Payment Element on stripe-managed tenants.

Refs gravitational/cloud#17563

## Manual Test Plan
### Test Environment

This can only be tested in a cloud color environment.

* Deploy latest cloud to /orange
* Enable stripe-based products in /orange
* Onboard a stripe-based product in /orange SC
* Use make-deploy-cloud to push an image with the CSP changes
* Patch a tenant in /orange to use image

### Test Cases

- [x] Stripe loads for stripe managed products (Tested against m-1785358473 in dev/orange)
- [x] No change for non stripe managed products (no Stripe CSP) (tested against michelle-sf-linked-2 in test)
