### PR TITLE
[v18] join: Require TPM tokens with cert serial to have CAs or cert hash

### DIFF
--- a/docs/pages/includes/provision-token/tpm-spec.mdx
+++ b/docs/pages/includes/provision-token/tpm-spec.mdx
@@ -46,6 +46,9 @@ spec:
         ek_public_hash: "d4b4example6fabfc568d74f2example6c35a05337d7af9a6example6c891aa6"
         # ek_certificate_serial is the serial number of the EKCert in hexadecimal
         # with colon separated nibbles. This value will not be checked when a TPM
-        # does not have an EKCert configured.
+        # does not have an EKCert configured. Setting this field requires that
+	# either ek_publish_hash be set or a certificate is configured in
+	# ekcert_allowed_cas so that the integrity of the certificate with the
+	# serial number can be verified.
         ek_certificate_serial: "01:23:45:67:89:ex:am:pl:e0:23:45:67:89:ab:cd:ef"
 ```

--- a/docs/pages/includes/provision-token/tpm-spec.mdx
+++ b/docs/pages/includes/provision-token/tpm-spec.mdx
@@ -47,8 +47,8 @@ spec:
         # ek_certificate_serial is the serial number of the EKCert in hexadecimal
         # with colon separated nibbles. This value will not be checked when a TPM
         # does not have an EKCert configured. Setting this field requires that
-	# either ek_publish_hash be set or a certificate is configured in
-	# ekcert_allowed_cas so that the integrity of the certificate with the
-	# serial number can be verified.
+        # either ek_public_hash be set or a certificate be configured in
+        # ekcert_allowed_cas so that the integrity of the certificate with the
+        # serial number can be verified.
         ek_certificate_serial: "01:23:45:67:89:ex:am:pl:e0:23:45:67:89:ab:cd:ef"
 ```

--- a/lib/join/tpmjoin/join_test.go
+++ b/lib/join/tpmjoin/join_test.go
@@ -37,10 +37,12 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/state"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/tpm"
 )
@@ -97,14 +99,19 @@ func TestJoinTPM(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		desc            string
-		tokenSpec       *types.ProvisionTokenSpecV2TPM
-		tpmKey          crypto.Signer
-		tpmCert         []byte
-		badTPMSolution  bool
-		oss             bool
-		assertError     require.ErrorAssertionFunc
-		expectJoinAttrs verifiedAttrs
+		desc           string
+		tokenSpec      *types.ProvisionTokenSpecV2TPM
+		tpmKey         crypto.Signer
+		tpmCert        []byte
+		badTPMSolution bool
+		oss            bool
+		// bypassAdmissionValidation injects the token directly into
+		// the backend, bypassing the admission validation. This allows
+		// testing that old non-conformant tokens still work for
+		// backward compatibility.
+		bypassAdmissionValidation bool
+		assertError               require.ErrorAssertionFunc
+		expectJoinAttrs           verifiedAttrs
 	}{
 		{
 			desc: "success, ekpub",
@@ -119,23 +126,6 @@ func TestJoinTPM(t *testing.T) {
 			assertError: require.NoError,
 			expectJoinAttrs: verifiedAttrs{
 				ekPubHash: goodTPMPubHash,
-			},
-		},
-		{
-			desc: "success, ekcert",
-			tokenSpec: &types.ProvisionTokenSpecV2TPM{
-				Allow: []*types.ProvisionTokenSpecV2TPM_Rule{
-					{
-						EKCertificateSerial: tpmCertSerial1,
-					},
-				},
-			},
-			tpmKey:      goodTPMKey,
-			tpmCert:     tpmCert1,
-			assertError: require.NoError,
-			expectJoinAttrs: verifiedAttrs{
-				ekPubHash:    goodTPMPubHash,
-				ekCertSerial: tpmCertSerial1,
 			},
 		},
 		{
@@ -209,7 +199,13 @@ func TestJoinTPM(t *testing.T) {
 			assertError: allowRulesNotMatched,
 		},
 		{
-			desc: "failure, mismatched ekcert serial",
+			// A serial-only token with no ekcert_allowed_cas can
+			// no longer be created (admission rejects it), but
+			// tokens that already exist from before that
+			// validation must continue to work. The token is
+			// injected straight into the backend to simulate this,
+			// and joining must still succeed.
+			desc: "success, legacy ekcert serial without ekcert_allowed_cas",
 			tokenSpec: &types.ProvisionTokenSpecV2TPM{
 				Allow: []*types.ProvisionTokenSpecV2TPM_Rule{
 					{
@@ -217,8 +213,30 @@ func TestJoinTPM(t *testing.T) {
 					},
 				},
 			},
+			bypassAdmissionValidation: true,
+			tpmKey:                    goodTPMKey,
+			tpmCert:                   tpmCert1,
+			assertError:               require.NoError,
+			expectJoinAttrs: verifiedAttrs{
+				ekPubHash:      goodTPMPubHash,
+				ekCertSerial:   tpmCertSerial1,
+				ekCertVerified: false,
+			},
+		},
+		{
+			desc: "failure, mismatched ekcert serial",
+			tokenSpec: &types.ProvisionTokenSpecV2TPM{
+				// A CA is required for a serial-only allow rule to be admitted;
+				// see lib/services/local validateTPMToken.
+				EKCertAllowedCAs: []string{string(goodTPMCA.caCertPEM)},
+				Allow: []*types.ProvisionTokenSpecV2TPM_Rule{
+					{
+						EKCertificateSerial: tpmCertSerial1,
+					},
+				},
+			},
 			tpmKey: goodTPMKey,
-			// TPM cert does not match serial in token.
+			// TPM cert is verified, but its serial does not match the rule.
 			tpmCert:     tpmCert2,
 			assertError: allowRulesNotMatched,
 		},
@@ -285,7 +303,20 @@ func TestJoinTPM(t *testing.T) {
 				TPM:        tc.tokenSpec,
 			})
 			require.NoError(t, err)
-			require.NoError(t, server.Auth().UpsertToken(t.Context(), token))
+			if tc.bypassAdmissionValidation {
+				// Write the token straight to the backend, bypassing
+				// UpsertToken's validateProvisionToken admission check (which
+				// would now reject it). This goes through MarshalProvisionToken
+				// only, which still permits the configuration, simulating a
+				// token created before admission control was added.
+				ps := local.NewProvisioningService(server.AuthServer.Backend)
+				actions, err := ps.AppendPutProvisionTokenActions(nil, token, backend.Whatever())
+				require.NoError(t, err)
+				_, err = server.AuthServer.Backend.AtomicWrite(t.Context(), actions)
+				require.NoError(t, err)
+			} else {
+				require.NoError(t, server.Auth().UpsertToken(t.Context(), token))
+			}
 
 			fakeTPM, err := newFakeTPM(tc.tpmKey, tc.tpmCert)
 			require.NoError(t, err)

--- a/lib/services/local/provisioning.go
+++ b/lib/services/local/provisioning.go
@@ -109,6 +109,10 @@ func (s *ProvisioningService) AppendDeleteProvisionTokenActions(
 // PatchToken uses the supplied function to attempt to patch a token resource.
 // Up to 3 update attempts will be made if the conditional update fails due to
 // a revision comparison failure.
+//
+// Unlike CreateToken/UpsertToken, this skips validateProvisionToken admission
+// checks. Safe only while no user-facing RPC reaches it; if one is added,
+// validate here too.
 func (s *ProvisioningService) PatchToken(
 	ctx context.Context,
 	tokenName string,
@@ -316,6 +320,9 @@ func validateProvisionToken(token types.ProvisionToken) error {
 
 	case types.JoinMethodIAM:
 		return validateIAMToken(token)
+
+	case types.JoinMethodTPM:
+		return validateTPMToken(token)
 	}
 
 	return nil
@@ -401,6 +408,40 @@ func validateOracleJoinToken(token types.ProvisionToken) error {
 			if _, err := oracle.ParseRegionFromOCID(instanceID); err != nil {
 				return trace.BadParameter("invalid instance OCID: %s", instanceID)
 			}
+		}
+	}
+	return nil
+}
+
+// validateTPMToken enforces admission-time constraints on TPM join tokens.
+//
+// A TPM allow rule that matches only on ek_certificate_serial provides no
+// proof of identity unless the EK certificate is verified against a configured
+// CA or it pins ek_public_hash: without ekcert_allowed_cas a joining client
+// can present a self-signed EK certificate bearing any serial it chooses. Such
+// a token is therefore rejected on create/update.
+//
+// This is deliberately enforced here, on admission, rather than in
+// CheckAndSetDefaults so that existing tokens with this configuration continue
+// to load.
+func validateTPMToken(token types.ProvisionToken) error {
+	tokenV2, ok := token.(*types.ProvisionTokenV2)
+	if !ok {
+		return trace.BadParameter("%v join method requires ProvisionTokenV2", types.JoinMethodTPM)
+	}
+	tpmSpec := tokenV2.Spec.TPM
+	if tpmSpec == nil {
+		return trace.BadParameter("missing spec")
+	}
+	// When EK certificates are verified against a configured CA, the serial they
+	// carry is trustworthy.
+	if len(tpmSpec.EKCertAllowedCAs) > 0 {
+		return nil
+	}
+	for i, rule := range tpmSpec.Allow {
+		if rule.EKCertificateSerial != "" && rule.EKPublicHash == "" {
+			return trace.BadParameter(
+				"allow[%d]: ek_certificate_serial requires ek_public_hash or ekcert_allowed_cas to be set so that the EK certificate can be verified", i)
 		}
 	}
 	return nil

--- a/lib/services/local/provisioning_test.go
+++ b/lib/services/local/provisioning_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -536,6 +537,56 @@ func TestValidateProvisionToken(t *testing.T) {
 						AWSOrganizationalUnits: &types.AWSOrganizationUnitsMatcher{
 							Include: []string{"ou-1234"},
 							Exclude: []string{"ou-5678"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "tpm rejects ek_certificate_serial without ekcert_allowed_cas",
+			spec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodTPM,
+				TPM: &types.ProvisionTokenSpecV2TPM{
+					Allow: []*types.ProvisionTokenSpecV2TPM_Rule{
+						{EKCertificateSerial: "73:df:dc:bd"},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "ek_certificate_serial requires ek_public_hash or ekcert_allowed_cas to be set",
+		},
+		{
+			name: "tpm accepts ek_certificate_serial with ekcert_allowed_cas",
+			spec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodTPM,
+				TPM: &types.ProvisionTokenSpecV2TPM{
+					EKCertAllowedCAs: []string{fixtures.TLSCACertPEM},
+					Allow: []*types.ProvisionTokenSpecV2TPM_Rule{
+						{EKCertificateSerial: "73:df:dc:bd"},
+					},
+				},
+			},
+		},
+		{
+			name: "tpm accepts ek_public_hash without ekcert_allowed_cas",
+			spec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodTPM,
+				TPM: &types.ProvisionTokenSpecV2TPM{
+					Allow: []*types.ProvisionTokenSpecV2TPM_Rule{
+						{EKPublicHash: "d4b45864d9d6fabfc568d74f26c35ababde2105337d7af9a6605e1c56c891aa6"},
+					},
+				},
+			},
+		},
+		{
+			name: "tpm accepts ek_certificate_serial alongside ek_public_hash without a CA",
+			spec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodTPM,
+				TPM: &types.ProvisionTokenSpecV2TPM{
+					Allow: []*types.ProvisionTokenSpecV2TPM_Rule{
+						{
+							EKPublicHash:        "d4b45864d9d6fabfc568d74f26c35ababde2105337d7af9a6605e1c56c891aa6",
+							EKCertificateSerial: "73:df:dc:bd",
 						},
 					},
 				},


### PR DESCRIPTION
Require any newly created TPM join tokens that have the ekCertSerial set
in an allow rule to also have the ekPubHash or EKCertAllowedCAs set. A
certificate serial number on its own is not sufficient to validate a tpm
join operation - the cert must have a known hash or be signed by a known
CA.

It is arguably a misconfiguration to have just the serial number
configured, but it is possible to have created such a join token, so
adding the check to ProvisionTokenSpecV2TPM.validate() will impact any
existing tokens as they are read from the backend. Likewise, changing
the validation in lib/tpm/tpmjoin will break existing configurations.

Changelog: Changed TPM tokens to require either `ek_certificate_hash` or `ekcert_allowed_cas` if a rule has `ek_certificate_serial`.
Backport: https://github.com/gravitational/teleport/pull/67960


## Manual Test Plan
### Test Environment

Teleport enterprise before and after this PR

### Test Cases
- [x] Stand up Teleport Enterprise without the changes in this PR
- [x] Create a TPM join token without `ekcert_allowed_cas` with an `allow` rule with just `ek_certificate_serial`
- [x] Stop Teleport
- [x] Start up Teleport Enterprise with the changes in this PR
- [x] List tokens (`tctl tokens ls`) and ensure the previously created token is present
- [x] Create token with allow rule with `ek_certificate_serial` without `ekcert_allowed_ca` or `ek_public_hash`
  - [x] Verify it fails to create
- [x] Successfully create token with allow rule with `ek_certificate_serial` with `ekcert_allowed_ca` and without `ek_public_hash`
- [x] Successfully create token with allow rule with `ek_certificate_serial` without `ekcert_allowed_ca` and with `ek_public_hash`
