### PR TITLE
docs: Fix field name comment in tpm join docs

### DIFF
--- a/docs/pages/includes/provision-token/tpm-spec.mdx
+++ b/docs/pages/includes/provision-token/tpm-spec.mdx
@@ -47,8 +47,8 @@ spec:
         # ek_certificate_serial is the serial number of the EKCert in hexadecimal
         # with colon separated nibbles. This value will not be checked when a TPM
         # does not have an EKCert configured. Setting this field requires that
-	# either ek_publish_hash be set or a certificate is configured in
-	# ekcert_allowed_cas so that the integrity of the certificate with the
-	# serial number can be verified.
+        # either ek_public_hash be set or a certificate be configured in
+        # ekcert_allowed_cas so that the integrity of the certificate with the
+        # serial number can be verified.
         ek_certificate_serial: "01:23:45:67:89:ex:am:pl:e0:23:45:67:89:ab:cd:ef"
 ```


### PR DESCRIPTION
Fix a typo in a comment in a tpm join token resource in the provision
token docs where "publish" was written instead of "public".

Also fix indenting to use spaces not tabs.
