### PR TITLE
[v18] Reject outdated clients joining via proxy

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -6364,6 +6364,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 			OracleHTTPClient:   cfg.OracleHTTPClient,
 			ScopedTokenService: cfg.AuthServer.Services,
 			ScopesFeatures:     cfg.AuthServer.scopesFeatures,
+			AlertCreator:       cfg.AuthServer.UpsertClusterAlert,
 		}))
 	}
 

--- a/lib/join/join_test.go
+++ b/lib/join/join_test.go
@@ -18,12 +18,14 @@ package join_test
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"slices"
 	"testing"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
@@ -33,9 +35,12 @@ import (
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 
+	"github.com/gravitational/teleport/api"
 	"github.com/gravitational/teleport/api/constants"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	joinv1proto "github.com/gravitational/teleport/api/gen/proto/go/teleport/join/v1"
@@ -49,6 +54,7 @@ import (
 	authjoin "github.com/gravitational/teleport/lib/auth/join"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/join/internal/messages"
 	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/join/joinv1"
 	"github.com/gravitational/teleport/lib/scopes"
@@ -482,6 +488,119 @@ func TestJoinToken(t *testing.T) {
 			tc.assertRejoinExpectation(t, newIdentity, err)
 		})
 	}
+}
+
+// startOutdatedClientJoin sets up an auth service and proxy, opens a Join stream
+// over the proxy-forwarded path reporting a version two majors behind (below the
+// minimum supported version), and sends a ClientInit. It returns the stream and
+// auth service so callers can assert on the outcome.
+func startOutdatedClientJoin(t *testing.T) (stream messages.ClientStream, authService *fakeAuthService) {
+	t.Helper()
+
+	// The proxy joins with this token and so does the outdated node below.
+	token, err := types.NewProvisionTokenFromSpec("token1", time.Now().Add(time.Minute), types.ProvisionTokenSpecV2{
+		Roles: []types.SystemRole{types.RoleInstance, types.RoleProxy},
+	})
+	require.NoError(t, err)
+
+	authService = newFakeAuthService(t)
+	require.NoError(t, authService.Auth().UpsertToken(t.Context(), token))
+
+	proxy := newFakeProxy(authService)
+	proxy.join(t)
+	proxyListener := bufconn.Listen(1024)
+	t.Cleanup(func() { proxyListener.Close() })
+	proxy.runGRPCServer(t, proxyListener)
+
+	conn, err := grpc.NewClient("passthrough:///bufconn",
+		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})),
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return proxyListener.DialContext(ctx)
+		}),
+		// Decodes trace errors from the server so IsAccessDenied works on the rejection.
+		grpc.WithStreamInterceptor(interceptors.GRPCClientStreamErrorInterceptor),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+
+	joinClient := joinv1.NewClientFromConn(conn)
+
+	// Report a version two majors behind, which is below the minimum supported
+	// version. The version interceptor honors a version already set on the
+	// outgoing context, so this value reaches the proxy unchanged.
+	oldVersion := semver.Version{Major: api.VersionMajor - 2}.String()
+	ctx := metadata.AppendToOutgoingContext(t.Context(), "version", oldVersion)
+
+	stream, err = joinClient.Join(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, stream.Send(&messages.ClientInit{
+		TokenName:  token.GetName(),
+		SystemRole: types.RoleInstance.String(),
+	}))
+
+	return stream, authService
+}
+
+// TestJoinRejectsOutdatedClient asserts a too-old client is rejected before any
+// credentials are issued, over the proxy-forwarded path. The auth middleware's
+// version gate can't cover it, since it sees the proxy's version.
+func TestJoinRejectsOutdatedClient(t *testing.T) {
+	t.Parallel()
+
+	stream, authService := startOutdatedClientJoin(t)
+
+	// The very first response is the rejection, confirming the check runs before
+	// any credentials are issued (no ServerInit precedes it).
+	_, err := stream.Recv()
+	require.True(t, trace.IsAccessDenied(err), "got %T, expected access denied error", err)
+	// Assert only that the minimum version is surfaced, not the exact wording,
+	// so the test survives copy edits to the rejection message.
+	minVersion := semver.Version{Major: api.VersionMajor - 1}.String()
+	require.ErrorContains(t, err, minVersion)
+
+	evt, err := authService.lastEvent(t.Context(), events.InstanceJoinEvent)
+	require.NoError(t, err)
+	instanceJoin, ok := evt.(*apievents.InstanceJoin)
+	require.True(t, ok, "got %T, expected *apievents.InstanceJoin", evt)
+	require.Contains(t, instanceJoin.Status.Error, minVersion)
+	// Clear the asserted error so the structural comparison below doesn't couple
+	// to the exact message wording.
+	instanceJoin.Status.Error = ""
+	require.Empty(t, cmp.Diff(
+		&apievents.InstanceJoin{
+			Metadata: apievents.Metadata{
+				Type: events.InstanceJoinEvent,
+				Code: events.InstanceJoinFailureCode,
+			},
+			Status: apievents.Status{
+				Success: false,
+			},
+			ConnectionMetadata: apievents.ConnectionMetadata{
+				RemoteAddr: "bufconn",
+			},
+			Role: types.RoleInstance.String(),
+		},
+		instanceJoin,
+		protocmp.Transform(),
+		cmpopts.IgnoreMapEntries(func(key string, val any) bool {
+			return key == "Time" || key == "ID"
+		}),
+	))
+}
+
+// TestJoinAllowsOutdatedClientWithOverride asserts that when the env variable
+// "TELEPORT_UNSTABLE_ALLOW_OLD_CLIENTS=yes" is set, the join-time version check
+// is disabled, so an outdated client proceeds to the normal join flow instead
+// of being rejected.
+func TestJoinAllowsOutdatedClientWithOverride(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_ALLOW_OLD_CLIENTS", "yes")
+
+	stream, _ := startOutdatedClientJoin(t)
+
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+	require.IsType(t, &messages.ServerInit{}, resp)
 }
 
 // TestJoinError asserts that attempts to join with an invalid token return an

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -23,12 +23,15 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"log/slog"
+	"os"
 	"slices"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"golang.org/x/crypto/ssh"
@@ -38,6 +41,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/defaults"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -126,12 +130,25 @@ type ServerConfig struct {
 	Logger             *slog.Logger
 	// ScopesFeatures dictate which scoped components are enabled.
 	ScopesFeatures scopes.Features
+	// AlertCreator, if set, raises a cluster alert when a client is rejected
+	// for running an unsupported version.
+	AlertCreator func(context.Context, types.ClusterAlert) error
 }
 
 // Server implements cluster joining for nodes and bots.
 type Server struct {
 	cfg               *ServerConfig
 	oracleRootCACache *oraclejoin.RootCACache
+	// oldestSupportedVersion is the oldest client version that is allowed to
+	// join the cluster. If "TELEPORT_UNSTABLE_ALLOW_OLD_CLIENTS=yes" is set,
+	// this will be nil and no version checks will be performed.
+	oldestSupportedVersion *semver.Version
+	// mu is used to rate limit the creation of rejected client alerts to at
+	// most once per day.
+	mu sync.Mutex
+	// nextAllowedAlertTime is the earliest time at which a new client
+	// rejection alert can be created.
+	nextAllowedAlertTime time.Time
 }
 
 // NewServer returns a new [Server] instance.
@@ -139,9 +156,14 @@ func NewServer(cfg *ServerConfig) *Server {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.With(teleport.ComponentKey, "join")
 	}
+	oldestSupportedVersion := teleport.MinClientSemVer()
+	if os.Getenv("TELEPORT_UNSTABLE_ALLOW_OLD_CLIENTS") == "yes" {
+		oldestSupportedVersion = nil
+	}
 	return &Server{
-		cfg:               cfg,
-		oracleRootCACache: oraclejoin.NewRootCACache(),
+		cfg:                    cfg,
+		oracleRootCACache:      oraclejoin.NewRootCACache(),
+		oldestSupportedVersion: oldestSupportedVersion,
 	}
 }
 
@@ -276,6 +298,12 @@ func (s *Server) Join(stream messages.ServerStream) (err error) {
 		return trace.Wrap(err)
 	}
 
+	// Must run after authenticate, which records the client version on the
+	// diagnostic for proxy-forwarded requests.
+	if err := s.validateClientVersion(ctx, diag.Get()); err != nil {
+		return trace.Wrap(err)
+	}
+
 	token, err := s.getProvisionToken(ctx, clientInit.TokenName)
 	if err != nil {
 		return trace.Wrap(err)
@@ -379,6 +407,87 @@ func (s *Server) handleJoinMethod(
 		// TODO(nklaassen): implement checks for all join methods.
 		return nil, trace.NotImplemented("join method %s is not yet implemented by the new join service", joinMethod)
 	}
+}
+
+// validateClientVersion checks the version of the joining client against the
+// server's oldest supported version. If the client is too old or reports a
+// version that cannot be parsed, it returns an error. A client that reports no
+// version is allowed.
+func (s *Server) validateClientVersion(ctx context.Context, info diagnostic.Info) error {
+	if s.oldestSupportedVersion == nil {
+		return nil // TELEPORT_UNSTABLE_ALLOW_OLD_CLIENTS=yes is set, don't enforce version checks
+	}
+
+	clientVersion := info.ClientVersion
+	if clientVersion == "" {
+		return nil
+	}
+
+	minVersion := *s.oldestSupportedVersion
+	minVersion.PreRelease = ""
+
+	clientSemVer, err := semver.NewVersion(clientVersion)
+	if err != nil || clientSemVer.LessThan(*s.oldestSupportedVersion) {
+		s.displayRejectedClientAlert(ctx)
+		return trace.AccessDenied("client version is unsupported, minimum supported version is %s", minVersion.String())
+	}
+	return nil
+}
+
+const (
+	// rejectedAlertInterval is the minimum interval between successfully
+	// created rejected-client alerts.
+	rejectedAlertInterval = 24 * time.Hour
+	// failedAlertCooldown is the shorter interval before retrying after a
+	// failed alert write, so a degraded backend isn't hammered.
+	failedAlertCooldown = 5 * time.Minute
+)
+
+// displayRejectedClientAlert raises a once-per-day cluster alert for rejected
+// outdated clients. It shares the auth middleware's alert name so rejections
+// coalesce into a single alert. If the alert write fails, it sets a short
+// cooldown before retrying so a degraded backend isn't hammered.
+func (s *Server) displayRejectedClientAlert(ctx context.Context) {
+	if s.cfg.AlertCreator == nil {
+		return
+	}
+
+	alert, err := types.NewClusterAlert(
+		"rejected-unsupported-connection",
+		"One or more agents or bots were rejected from joining due to running unsupported versions. Check the audit log for more details.",
+		types.WithAlertSeverity(types.AlertSeverity_MEDIUM),
+		types.WithAlertLabel(types.AlertOnLogin, "yes"),
+		types.WithAlertLabel(types.AlertVerbPermit, fmt.Sprintf("%s:%s", types.KindToken, types.VerbCreate)),
+	)
+	if err != nil {
+		s.cfg.Logger.WarnContext(ctx, "failed to create rejected-unsupported-connection alert", "error", err)
+		return
+	}
+
+	clock := s.cfg.AuthService.GetClock()
+	now := clock.Now()
+	reserved := now.Add(rejectedAlertInterval)
+	s.mu.Lock()
+	if now.Before(s.nextAllowedAlertTime) {
+		s.mu.Unlock()
+		return
+	}
+	s.nextAllowedAlertTime = reserved
+	s.mu.Unlock()
+
+	alertCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), defaults.DefaultIOTimeout)
+	defer cancel()
+	err = s.cfg.AlertCreator(alertCtx, alert)
+	if err == nil {
+		return
+	}
+
+	s.cfg.Logger.WarnContext(ctx, "failed to persist rejected-unsupported-connection alert", "error", err)
+	s.mu.Lock()
+	if s.nextAllowedAlertTime.Equal(reserved) {
+		s.nextAllowedAlertTime = clock.Now().Add(failedAlertCooldown)
+	}
+	s.mu.Unlock()
 }
 
 func (s *Server) authenticate(ctx context.Context, diag *diagnostic.Diagnostic, clientInit *messages.ClientInit) (*joinauthz.Context, error) {

--- a/lib/join/version_test.go
+++ b/lib/join/version_test.go
@@ -1,0 +1,232 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package join
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/join/internal/diagnostic"
+)
+
+// clockAuthService is a minimal AuthService that only supplies a clock; the
+// alert rate-limiter is the only caller of GetClock reached by these tests.
+type clockAuthService struct {
+	AuthService
+	clock clockwork.Clock
+}
+
+func (s clockAuthService) GetClock() clockwork.Clock { return s.clock }
+
+func requireAccessDenied(t require.TestingT, err error, _ ...any) {
+	require.True(t, trace.IsAccessDenied(err), "got %v, expected access denied error", err)
+}
+
+func TestValidateClientVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name                   string
+		oldestSupportedVersion *semver.Version
+		version                string
+		assertErr              require.ErrorAssertionFunc
+	}{
+		{
+			name:                   "check disabled allows old client",
+			oldestSupportedVersion: nil,
+			version:                "1.0.0",
+			assertErr:              require.NoError,
+		},
+		{
+			name:                   "client too old",
+			oldestSupportedVersion: &semver.Version{Major: 2},
+			version:                "1.0.0",
+			assertErr:              requireAccessDenied,
+		},
+		{
+			name:                   "client meets minimum",
+			oldestSupportedVersion: &semver.Version{Major: 2},
+			version:                "2.0.0",
+			assertErr:              require.NoError,
+		},
+		{
+			name:                   "client newer than minimum",
+			oldestSupportedVersion: &semver.Version{Major: 2},
+			version:                "3.0.0",
+			assertErr:              require.NoError,
+		},
+		{
+			// An unreported version fails open so clients that don't send a
+			// version are not blocked from joining.
+			name:                   "empty version fails open",
+			oldestSupportedVersion: &semver.Version{Major: 2},
+			version:                "",
+			assertErr:              require.NoError,
+		},
+		{
+			// A present-but-unparseable version is rejected rather than
+			// failing open, unlike an absent version.
+			name:                   "malformed version rejected",
+			oldestSupportedVersion: &semver.Version{Major: 2},
+			version:                "not-a-version",
+			assertErr:              requireAccessDenied,
+		},
+		{
+			// MinClientSemVer carries an "aa" prerelease so that alpha, beta,
+			// rc, and dev builds of the minimum major sort after it and are
+			// permitted.
+			name:                   "prerelease at minimum major allowed",
+			oldestSupportedVersion: &semver.Version{Major: 17, PreRelease: "aa"},
+			version:                "17.0.0-dev.1",
+			assertErr:              require.NoError,
+		},
+		{
+			name:                   "stable release at minimum major allowed",
+			oldestSupportedVersion: &semver.Version{Major: 17, PreRelease: "aa"},
+			version:                "17.0.0",
+			assertErr:              require.NoError,
+		},
+		{
+			name:                   "prior major rejected against prerelease minimum",
+			oldestSupportedVersion: &semver.Version{Major: 17, PreRelease: "aa"},
+			version:                "16.9.9",
+			assertErr:              requireAccessDenied,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := &Server{
+				cfg:                    &ServerConfig{Logger: slog.Default()},
+				oldestSupportedVersion: tc.oldestSupportedVersion,
+			}
+			tc.assertErr(t, s.validateClientVersion(t.Context(), diagnostic.Info{ClientVersion: tc.version}))
+		})
+	}
+}
+
+func TestValidateClientVersionRaisesAlert(t *testing.T) {
+	t.Parallel()
+
+	var alerts []types.ClusterAlert
+	clock := clockwork.NewFakeClock()
+	s := &Server{
+		cfg: &ServerConfig{
+			Logger:      slog.Default(),
+			AuthService: clockAuthService{clock: clock},
+			AlertCreator: func(_ context.Context, a types.ClusterAlert) error {
+				alerts = append(alerts, a)
+				return nil
+			},
+		},
+		oldestSupportedVersion: &semver.Version{Major: 2, PreRelease: "aa"},
+	}
+
+	reject := func() error {
+		return s.validateClientVersion(t.Context(), diagnostic.Info{
+			ClientVersion: "1.0.0",
+			RemoteAddr:    "10.1.2.3:4567",
+			Role:          "Instance",
+		})
+	}
+
+	// An allowed client raises no alert.
+	require.NoError(t, s.validateClientVersion(t.Context(), diagnostic.Info{ClientVersion: "2.0.0"}))
+	require.Empty(t, alerts)
+
+	// A rejected client raises one alert and the rejection is returned to the caller.
+	require.True(t, trace.IsAccessDenied(reject()))
+	require.Len(t, alerts, 1)
+	require.Equal(t, "rejected-unsupported-connection", alerts[0].Metadata.Name)
+	require.Equal(t, "One or more agents or bots were rejected from joining due to running unsupported versions. Check the audit log for more details.", alerts[0].Spec.Message)
+
+	// A second rejection within the 24h window is suppressed.
+	clock.Advance(23 * time.Hour)
+	require.True(t, trace.IsAccessDenied(reject()))
+	require.Len(t, alerts, 1)
+
+	// Once the window elapses, a rejection raises a fresh alert.
+	clock.Advance(2 * time.Hour)
+	require.True(t, trace.IsAccessDenied(reject()))
+	require.Len(t, alerts, 2)
+}
+
+// TestValidateClientVersionAlertRetriesAfterWriteFailure asserts that a failed
+// alert write shortens the alert cooldown, allowing a retry to succeed after a
+// short wait rather than the full alert interval.
+func TestValidateClientVersionAlertRetriesAfterWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	var writes int
+	clock := clockwork.NewFakeClock()
+	s := &Server{
+		cfg: &ServerConfig{
+			Logger:      slog.Default(),
+			AuthService: clockAuthService{clock: clock},
+			AlertCreator: func(_ context.Context, _ types.ClusterAlert) error {
+				writes++
+				if writes == 1 {
+					return trace.ConnectionProblem(nil, "backend unavailable")
+				}
+				return nil
+			},
+		},
+		oldestSupportedVersion: &semver.Version{Major: 2, PreRelease: "aa"},
+	}
+
+	reject := func() error {
+		return s.validateClientVersion(t.Context(), diagnostic.Info{ClientVersion: "1.0.0", Role: "Instance"})
+	}
+
+	// First rejection attempts the write, which fails and sets a short cooldown.
+	require.True(t, trace.IsAccessDenied(reject()))
+	require.Equal(t, 1, writes)
+
+	// A second rejection within the cooldown is suppressed.
+	clock.Advance(failedAlertCooldown - time.Second)
+	require.True(t, trace.IsAccessDenied(reject()))
+	require.Equal(t, 1, writes)
+
+	// Once the cooldown elapses, a rejection retries the write, which succeeds.
+	clock.Advance(time.Second)
+	require.True(t, trace.IsAccessDenied(reject()))
+	require.Equal(t, 2, writes)
+}
+
+func TestNewServerOldestSupportedVersion(t *testing.T) {
+	t.Run("enforces the minimum client version by default", func(t *testing.T) {
+		t.Setenv("TELEPORT_UNSTABLE_ALLOW_OLD_CLIENTS", "")
+		s := NewServer(&ServerConfig{})
+		require.Equal(t, teleport.MinClientSemVer(), s.oldestSupportedVersion)
+	})
+
+	t.Run("override disables the version check", func(t *testing.T) {
+		t.Setenv("TELEPORT_UNSTABLE_ALLOW_OLD_CLIENTS", "yes")
+		s := NewServer(&ServerConfig{})
+		require.Nil(t, s.oldestSupportedVersion)
+	})
+}


### PR DESCRIPTION
Backport #68482

Changelog: Outdated agents and tbots joining through a Proxy are now rejected with a clear minimum-version error before the join is processed.

Part of #64567 

## Manual Test Plan
### Test Environment
Local build. Two `teleport` binaries built at different major versions to induce skew (Auth/Proxy at the current version, and an instance stamped below the cluster's minimum client version). The outdated instance joins by token through the Proxy with `--skip-version-check` to bypass the client-side check and isolate the server gate. The tbot needs no flag since it does not implement client-side checks.

### Test Cases
- [x] A compatible instance joins normally
- [x] An instance older than the cluster's minimum client version is rejected at join time with a clear error (not an EOF)
- [x] The rejection is recorded as an `instance.join`/`bot.join` failure audit event
- [x] A `rejected-unsupported-connection` cluster alert appears (repeat rejections are suppressed)
- [x] `TELEPORT_UNSTABLE_ALLOW_OLD_CLIENTS=yes` on Auth disables the gate and the outdated instance joins
- [x] An outdated tbot is likewise rejected