### PR TITLE
Deprecate `TrustedDeviceOSType` in favor of `TrustedDevice['osType']`

### DIFF
--- a/web/packages/teleport/src/DeviceTrust/DeviceList/DeviceList.tsx
+++ b/web/packages/teleport/src/DeviceTrust/DeviceList/DeviceList.tsx
@@ -23,10 +23,7 @@ import Table, { Cell } from 'design/DataTable';
 import { ResourceIcon, ResourceIconName } from 'design/ResourceIcon';
 import { P2 } from 'design/Text';
 
-import {
-  DeviceListProps,
-  TrustedDeviceOSType,
-} from 'teleport/DeviceTrust/types';
+import { DeviceListProps, TrustedDevice } from 'teleport/DeviceTrust/types';
 
 export const DeviceList = ({
   items = [],
@@ -84,7 +81,7 @@ const EnrollmentStatusCell = ({ status }: { status: string }) => {
   );
 };
 
-export const IconCell = ({ osType }: { osType: TrustedDeviceOSType }) => {
+export const IconCell = ({ osType }: { osType: TrustedDevice['osType'] }) => {
   let iconName: ResourceIconName;
   switch (osType) {
     case 'Windows':

--- a/web/packages/teleport/src/DeviceTrust/DeviceList/DeviceList.tsx
+++ b/web/packages/teleport/src/DeviceTrust/DeviceList/DeviceList.tsx
@@ -23,7 +23,10 @@ import Table, { Cell } from 'design/DataTable';
 import { ResourceIcon, ResourceIconName } from 'design/ResourceIcon';
 import { P2 } from 'design/Text';
 
-import { DeviceListProps, TrustedDevice } from 'teleport/DeviceTrust/types';
+import {
+  type DeviceListProps,
+  type TrustedDevice,
+} from 'teleport/DeviceTrust/types';
 
 export const DeviceList = ({
   items = [],

--- a/web/packages/teleport/src/DeviceTrust/types.ts
+++ b/web/packages/teleport/src/DeviceTrust/types.ts
@@ -21,7 +21,7 @@ import { PagerPosition } from 'design/DataTable/types';
 export type TrustedDevice = {
   id: string;
   assetTag: string;
-  osType: TrustedDeviceOSType;
+  osType: 'Windows' | 'Linux' | 'macOS' | 'iOS' | 'iPadOS';
   enrollStatus: 'enrolled' | 'not enrolled';
   owner: string;
   createTime?: Date;
@@ -50,12 +50,11 @@ export type DeviceSource = {
   origin: DeviceOrigin;
 };
 
-export type TrustedDeviceOSType =
-  | 'Windows'
-  | 'Linux'
-  | 'macOS'
-  | 'iOS'
-  | 'iPadOS';
+/**
+ * @deprecated Use TrustedDevice['osType'] instead.
+ * TODO(ravicious): Remove once teleport.e no longer imports it.
+ */
+export type TrustedDeviceOSType = TrustedDevice['osType'];
 
 export type TrustedDeviceResponse = {
   items: TrustedDevice[];


### PR DESCRIPTION
This is because in https://github.com/gravitational/teleport/pull/68835 we start using [`teleport.devicetrust.v1.OSType`](https://github.com/gravitational/teleport/blob/35d66cdd0285b1e96f0766b695931f83590bc45c/api/proto/teleport/devicetrust/v1/os_type.proto) proto enum which has numeric values as member values.

`TrustedDevice['osType']` is [`OSType` converted into a string](https://github.com/gravitational/teleport/blob/35d66cdd0285b1e96f0766b695931f83590bc45c/lib/devicetrust/friendly_enums.go#L23-L25) on [the API layer](https://github.com/gravitational/teleport.e/blob/dd283130a0bafd411848327e2183c4e9204a78f2/lib/web/devices.go#L121).