### PR TITLE
[v18] Avoid opening excessive browser windows on tsh relogin

### DIFF
--- a/api/utils/keypaths/keypaths.go
+++ b/api/utils/keypaths/keypaths.go
@@ -63,6 +63,8 @@ const (
 	kubeConfigSuffix = "-kubeconfig"
 	// fileNameKubeCredLock is file name of lockfile used to prevent excessive login attempts.
 	fileNameKubeCredLock = "kube_credentials.lock"
+	// fileNameProxySSHRetryerLock is the file name of the lockfile used to synchronize relogin attempts for 'tsh proxy ssh'.
+	fileNameProxySSHRetryerLock = "proxy_ssh_retryer.lock"
 	// casDir is the directory name for where clusters certs are stored.
 	casDir = "cas"
 	// fileExtPem is the extension of a file where a public certificate is stored.
@@ -106,6 +108,7 @@ const (
 //    │   ├── foo.pub                  --> SSH Public Key
 //    │   ├── foo.ppk                  --> PuTTY PPK-formatted keypair for user "foo"
 //    │   ├── kube_credentials.lock    --> Kube credential lockfile, used to prevent excessive relogin attempts
+//    │   ├── proxy_ssh_retryer.lock   --> Proxy SSH retryer lockfile, used to synchronize relogin in 'tsh proxy ssh'
 //    │   ├── foo-ssh                  --> SSH certs for user "foo"
 //    │   │   ├── root-cert.pub        --> SSH cert for Teleport cluster "root"
 //    │   │   └── leaf-cert.pub        --> SSH cert for Teleport cluster "leaf"
@@ -424,6 +427,13 @@ func KubeConfigPath(baseDir, proxy, username, cluster, kubename string) string {
 // <baseDir>/keys/<proxy>/kube_credentials.lock
 func KubeCredLockfilePath(baseDir, proxy string) string {
 	return filepath.Join(ProxyKeyDir(baseDir, proxy), fileNameKubeCredLock)
+}
+
+// ProxySSHRetryerLockfilePath returns the SSH retryer lock file for the given proxy.
+//
+// <baseDir>/keys/<proxy>/ssh_retryer.lock
+func ProxySSHRetryerLockfilePath(baseDir, proxy string) string {
+	return filepath.Join(ProxyKeyDir(baseDir, proxy), fileNameProxySSHRetryerLock)
 }
 
 // IsProfileKubeConfigPath makes a best effort attempt to check if the given

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -681,43 +681,11 @@ func VirtualPathEnvNames(kind VirtualPathKind, params VirtualPathParams) []strin
 	return vars
 }
 
-// RetryWithRelogin is a helper error handling method, attempts to relogin and
-// retry the function once.
-func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error, opts ...RetryWithReloginOption) error {
-	fnErr := fn()
-	switch {
-	case fnErr == nil:
-		return nil
-	case utils.IsPredicateError(fnErr):
-		return trace.Wrap(utils.PredicateError{Err: fnErr})
-	case tc.NonInteractive:
-		return trace.Wrap(fnErr, "cannot relogin in non-interactive session")
-	case !IsErrorResolvableWithRelogin(fnErr):
-		// If the connection to Auth was unexpectedly cut, see if the client is too
-		// old to interact with the cluster.
-		if errors.Is(fnErr, io.EOF) || (trace.IsConnectionProblem(fnErr) && strings.Contains(fnErr.Error(), "error reading from server: EOF")) {
-			// The results are intentionally ignored - Ping prints warnings
-			// related to versions, and that's all that is needed here.
-			_, _ = tc.Ping(ctx)
-		}
-
-		return trace.Wrap(fnErr)
-	}
+// Relogin attempts to relogin and runs before/after login hooks.
+func Relogin(ctx context.Context, tc *TeleportClient, opts ...RetryWithReloginOption) error {
 	opt := defaultRetryWithReloginOptions()
 	for _, o := range opts {
 		o(opt)
-	}
-	log.DebugContext(ctx, "Activating relogin on error", "error", fnErr, "error_type", logutils.TypeAttr(trace.Unwrap(fnErr)))
-
-	if keys.IsPrivateKeyPolicyError(fnErr) {
-		privateKeyPolicy, err := keys.ParsePrivateKeyPolicyError(fnErr)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		if err := tc.updatePrivateKeyPolicy(privateKeyPolicy); err != nil {
-			return trace.Wrap(err)
-		}
 	}
 
 	if opt.beforeLoginHook != nil {
@@ -729,7 +697,6 @@ func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error, 
 	if err != nil {
 		if errors.Is(err, prompt.ErrNotTerminal) {
 			log.DebugContext(ctx, "Relogin is not available in this environment", "error", err)
-			return trace.Wrap(fnErr)
 		}
 		if trace.IsTrustError(err) {
 			return trace.Wrap(err, "refusing to connect to untrusted proxy %v without --insecure flag\n", tc.SSHProxyAddr)
@@ -761,6 +728,63 @@ func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error, 
 		if err := opt.afterLoginHook(); err != nil {
 			return trace.Wrap(err)
 		}
+	}
+	return nil
+}
+
+// ShouldRetryWithRelogin determines if the error should be retried. It applies more scrutiny than
+// 'IsErrorResolvableWithRelogin' by checking if the client is non-interactive or if a predicate error occurred.
+// Returns the original error (possibly wrapped with additional context) and a boolean indicating whether or not
+// relogin should be attempted.
+func ShouldRetryWithRelogin(ctx context.Context, tc *TeleportClient, fnErr error) (bool, error) {
+	if keys.IsPrivateKeyPolicyError(fnErr) {
+		privateKeyPolicy, err := keys.ParsePrivateKeyPolicyError(fnErr)
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+
+		tc.updatePrivateKeyPolicy(privateKeyPolicy)
+	}
+
+	switch {
+	case utils.IsPredicateError(fnErr):
+		return false, trace.Wrap(utils.PredicateError{Err: fnErr})
+	case tc.NonInteractive:
+		return false, trace.Wrap(fnErr, "cannot relogin in non-interactive session")
+	case !IsErrorResolvableWithRelogin(fnErr):
+		// If the connection to Auth was unexpectedly cut, see if the client is too
+		// old to interact with the cluster.
+		if errors.Is(fnErr, io.EOF) || (trace.IsConnectionProblem(fnErr) && strings.Contains(fnErr.Error(), "error reading from server: EOF")) {
+			// The results are intentionally ignored - Ping prints warnings
+			// related to versions, and that's all that is needed here.
+			_, _ = tc.Ping(ctx)
+		}
+
+		return false, trace.Wrap(fnErr)
+	}
+	return true, fnErr
+}
+
+// RetryWithRelogin is a helper error handling method, attempts to relogin and
+// retry the function once.
+func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error, opts ...RetryWithReloginOption) error {
+	fnErr := fn()
+	if fnErr == nil {
+		return nil
+	}
+
+	var shouldRetry bool
+	if shouldRetry, fnErr = ShouldRetryWithRelogin(ctx, tc, fnErr); !shouldRetry {
+		return fnErr
+	}
+
+	log.DebugContext(ctx, "Activating relogin on error", "error", fnErr, "error_type", logutils.TypeAttr(trace.Unwrap(fnErr)))
+	err := Relogin(ctx, tc, opts...)
+	if err != nil {
+		if errors.Is(err, prompt.ErrNotTerminal) {
+			return trace.Wrap(fnErr)
+		}
+		return trace.Wrap(err)
 	}
 
 	return fn()
@@ -4063,9 +4087,7 @@ func (tc *TeleportClient) loginWithHardwareKeyRetry(ctx context.Context, login f
 				return nil, trace.Wrap(err)
 			}
 
-			if err := tc.updatePrivateKeyPolicy(privateKeyPolicy); err != nil {
-				return nil, trace.Wrap(err)
-			}
+			tc.updatePrivateKeyPolicy(privateKeyPolicy)
 
 			fmt.Fprintf(tc.Stderr, "Relogging in with hardware-backed private key.\n")
 			keyRing, err = tc.GetNewLoginKeyRing(ctx)
@@ -4080,13 +4102,12 @@ func (tc *TeleportClient) loginWithHardwareKeyRetry(ctx context.Context, login f
 	return keyRing, trace.Wrap(loginErr)
 }
 
-func (tc *TeleportClient) updatePrivateKeyPolicy(policy keys.PrivateKeyPolicy) error {
+func (tc *TeleportClient) updatePrivateKeyPolicy(policy keys.PrivateKeyPolicy) {
 	// The current private key was rejected due to an unmet key policy requirement.
 	fmt.Fprintf(tc.Stderr, "Unmet private key policy %q.\n", policy)
 
 	// Set the private key policy to the expected value and re-login.
 	tc.PrivateKeyPolicy = policy
-	return nil
 }
 
 // GetNewLoginKeyRing gets a KeyRing with new private keys for login.

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -23,6 +23,7 @@ import (
 	"crypto"
 	"crypto/tls"
 	"crypto/x509/pkix"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -31,6 +32,7 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"time"
 	"unicode"
 
 	"github.com/coreos/go-semver/semver"
@@ -38,8 +40,11 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/api/utils/keypaths"
+	"github.com/gravitational/teleport/api/utils/retryutils"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/db/dbcmd"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -95,7 +100,143 @@ func onProxyCommandSSH(cf *CLIConf, initFunc ClientInitFunc) error {
 		return trace.Wrap(sshFunc())
 	}
 
-	return trace.Wrap(libclient.RetryWithRelogin(cf.Context, tc, sshFunc))
+	return trace.Wrap(sshRetryer{
+		shouldRetry:  libclient.ShouldRetryWithRelogin,
+		relogin:      libclient.Relogin,
+		lockfilePath: GetProxySSHRetryerLockfilePath(cf.HomePath, tc.WebProxyHost()),
+		// Try to provide enough time for a manual login or
+		// retry attempts due to network issues.
+		waitDuration:  30 * time.Second,
+		retryAttempts: 3,
+		retryDriver:   retryutils.NewLinearDriver(1 * time.Second),
+	}.retryWithLimitedRelogin(cf.Context, tc, sshFunc))
+}
+
+// GetProxySSHRetryerLockfilePath gets the path to the proxy ssh retryer lockfile.
+func GetProxySSHRetryerLockfilePath(baseDir, proxy string) string {
+	return keypaths.ProxySSHRetryerLockfilePath(profile.FullProfilePath(baseDir), proxy)
+}
+
+type shouldRetryFunc func(context.Context, *libclient.TeleportClient, error) (bool, error)
+type reloginFunc func(context.Context, *libclient.TeleportClient, ...libclient.RetryWithReloginOption) error
+
+// sshRetryer is a more bespoke of libclient.RetryWithRelogin.
+// It uses a file lock to allow a single tsh process to handle relogin
+// while holding an exclusive lock, while other concurrently executing tsh
+// processes wait on shared lock for relogin to complete. This prevents
+// concurrently executing instances of 'tsh proxy ssh' commands from
+// opening an excessive number of browser windows for relogin.
+type sshRetryer struct {
+	// shouldRetry checks if the error can be retried. Wraps the error and returns a boolean
+	// indicating whether or not the original error should retried after relogin.
+	shouldRetry shouldRetryFunc
+	// relogin performs re-authentication.
+	relogin reloginFunc
+	// lockfilePath is the path to the lockfile which will be used to synchronize relogin attempts.
+	lockfilePath string
+	// waitDuration determines how long a command invocation will wait for a concurrent tsh process
+	// to perform a relogin before giving up and trying again anyway.
+	waitDuration time.Duration
+	// retryConfig determines the retry strategy to use when recovering
+	// from transient network errors.
+	retryDriver retryutils.Driver
+	// retryAttempts determines how many times sshRetryer will attempt to
+	// recover from transient network errors. e.g. (1 means that we will
+	// try to relogin once, and then *retry* once more).
+	retryAttempts int
+}
+
+// acquireLock acquires either the exclusive lock, or the shared lock.
+// is returns a boolean indiciating whether or not the lock is exclusive, and unlock callback,
+// and an error. If error is non nil, the caller should discard the boolean and unlock function.
+func (s sshRetryer) acquireLock(ctx context.Context) (bool, func() error, error) {
+	if _, err := utils.EnsureLocalPath(s.lockfilePath, "", ""); err != nil {
+		return false, nil, trace.Wrap(err)
+	}
+
+	// Try to grab the exclusive lock first
+	exclusiveUnlock, err := utils.FSTryWriteLock(s.lockfilePath)
+	if err == nil {
+		return true, exclusiveUnlock, nil
+	}
+
+	// Failed to get exclusive lock. Is something wrong, or did we just
+	// lose the race?
+	if !errors.Is(err, utils.ErrUnsuccessfulLockTry) {
+		return false, nil, trace.Wrap(err)
+	}
+
+	// Someone else has the exclusive lock. Let's wait for the shared lock then.
+	// We don't necessarily _need_ a timeout. We will unblock when the exclusive lock holder releases
+	// or exits. We'll try with a timeout anyway not because we're concerned about blocking forever,
+	// but because FSTryReadLockTimeout is the only API that exposes a context that we can cancel on.
+	sharedUnlock, err := utils.FSTryReadLockTimeout(ctx, s.lockfilePath, s.waitDuration)
+	return false, sharedUnlock, trace.Wrap(err)
+}
+
+func (s sshRetryer) tryRelogin(ctx context.Context, tc *libclient.TeleportClient) error {
+	driver := s.retryDriver
+	if driver == nil {
+		driver = retryutils.NewLinearDriver(1 * time.Second)
+	}
+
+	var reloginErr error
+	// "+1" to attempt relogin at least once in case
+	// retryAttempts is set to zero.
+	for attempt := range s.retryAttempts + 1 {
+		// Backoff per our retry driver
+		// (attempt "0" does not wait)
+		select {
+		case <-time.After(driver.Duration(int64(attempt))):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		reloginErr = s.relogin(ctx, tc)
+		if reloginErr == nil {
+			// Success!
+			return nil
+		}
+
+		if !isNetworkError(reloginErr) {
+			// Only retry network errors.
+			return trace.Wrap(reloginErr)
+		}
+	}
+	return reloginErr
+}
+
+func (s sshRetryer) retryWithLimitedRelogin(ctx context.Context, tc *libclient.TeleportClient, operation func() error) error {
+	const reloginErrorMessage = "Having problems with relogin, please use 'tsh login' manually"
+	opErr := operation()
+	if opErr == nil {
+		return nil
+	}
+
+	var shouldRetry bool
+	if shouldRetry, opErr = s.shouldRetry(ctx, tc, opErr); !shouldRetry {
+		return opErr
+	}
+
+	// Either acquire the exclusive lock, or block until either another instance
+	// releases the exclusive lock, or a timeout occurs.
+	isExclusive, unlock, err := s.acquireLock(ctx)
+	if err != nil {
+		return trace.Wrap(err, reloginErrorMessage)
+	}
+
+	if isExclusive {
+		// We got the exclusive lock, so we're responsible for attempting relogin.
+		if err := s.tryRelogin(ctx, tc); err != nil {
+			unlock()
+			return trace.Wrap(err, reloginErrorMessage)
+		}
+	}
+
+	// We must unlock *before* retrying the operation. arbitrary SSH commands
+	// can run indefinitely. We don't want to block other tsh processes.
+	unlock()
+	return operation()
 }
 
 // cleanTargetHost cleans the targetHost and remote site and proxy suffixes.

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -31,15 +31,20 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
 	"os/user"
+	"path"
 	"path/filepath"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"text/template"
 	"time"
 
@@ -1901,4 +1906,182 @@ func Test_alpnProtocolForApp(t *testing.T) {
 			require.Equal(t, tt.wantProtocol, got)
 		})
 	}
+}
+
+func TestRetryLock(t *testing.T) {
+	testDirPath := t.TempDir()
+	lockFilePath := func(lockFileName string) string {
+		return path.Join(testDirPath, lockFileName)
+	}
+
+	tc := &client.TeleportClient{}
+
+	// Relogin functions each call synctest.Wait to ensure that the shared lock holders
+	// are blocked waiting on the exclusive lock to release. Otherwise we'll have flaky tests.
+	successRelogin := func(ctx context.Context, tc *client.TeleportClient, rwro ...client.RetryWithReloginOption) error {
+		synctest.Wait()
+		return nil
+	}
+
+	failedRelogin := func(ctx context.Context, tc *client.TeleportClient, rwro ...client.RetryWithReloginOption) error {
+		synctest.Wait()
+		return errors.New("relogin failed")
+	}
+
+	networkIssuesResolveAfter := func(attempt int) reloginFunc {
+		return func(_ context.Context, _ *client.TeleportClient, _ ...client.RetryWithReloginOption) error {
+			synctest.Wait()
+			if attempt > 0 {
+				attempt--
+				return trace.ConnectionProblem(io.ErrClosedPipe, "network problem")
+			}
+			return nil
+		}
+	}
+
+	reloginCallCounter := func(f reloginFunc) (reloginFunc, *atomic.Int32, *atomic.Bool) {
+		var calls atomic.Int32
+		var reloginSuccess atomic.Bool
+		return func(ctx context.Context, tc *client.TeleportClient, rwro ...client.RetryWithReloginOption) error {
+			calls.Add(1)
+			if err := f(ctx, tc, rwro...); err != nil {
+				return err
+			}
+			reloginSuccess.Store(true)
+			return nil
+		}, &calls, &reloginSuccess
+	}
+
+	operationCallCounter := func(op func() error) (func() error, *atomic.Int32) {
+		var calls atomic.Int32
+		return func() error {
+			calls.Add(1)
+			return op()
+		}, &calls
+	}
+
+	// Returns an operation function that only returns successfully after relogin is called AND succeeds.
+	successOnRelogin := func(rf reloginFunc) (reloginFunc, func() error, *atomic.Int32, *atomic.Int32) {
+		rf, reloginCalls, reloginSuccess := reloginCallCounter(rf)
+		op, opCalls := operationCallCounter(func() error {
+			if reloginSuccess.Load() {
+				return nil
+			}
+			return errors.New("ssh: cert has expired")
+		})
+		return rf, op, reloginCalls, opCalls
+	}
+
+	tests := []struct {
+		name                   string
+		relogin                reloginFunc
+		errorAssertion         func(t require.TestingT, err error, msgAndArgs ...interface{})
+		expectedReloginCalls   int
+		expectedOperationCalls int
+	}{
+		{
+			name:           "transient network errors are retried",
+			relogin:        networkIssuesResolveAfter(3),
+			errorAssertion: require.NoError,
+			// Expect 6 operation calls
+			// 3 "first attempts" initially and 3
+			// retry attempts after relogin eventually succeeds.
+			expectedOperationCalls: 6,
+			// Relogin is attempted 4 times
+			expectedReloginCalls: 4,
+		},
+		{
+			name:           "relogin succeeds - each instance's operation succeeds",
+			relogin:        successRelogin,
+			errorAssertion: require.NoError,
+			// Each operation tries to run, fails the first attempt,
+			// then retries after successful relogin.
+			expectedOperationCalls: 6,
+			expectedReloginCalls:   1,
+		},
+
+		{
+			name:           "relogin eventually gives up retrying network errors",
+			relogin:        networkIssuesResolveAfter(4),
+			errorAssertion: require.Error,
+			// Expect 5 operation calls
+			// 3 "first attempts" initially and 2
+			// retry attempts by the shared lock holders.
+			// Exclusive lock holder will not retry after relogin failure.
+			expectedOperationCalls: 5,
+			expectedReloginCalls:   4,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				lockPath := lockFilePath("testlock.lock")
+				t.Cleanup(func() {
+					os.Remove(lockPath)
+				})
+				relogin, operation, reloginCalls, operationCalls := successOnRelogin(test.relogin)
+				errors := make(chan error, 3)
+				wg := sync.WaitGroup{}
+				for range 3 {
+					wg.Go(func() {
+						errors <- sshRetryer{
+							shouldRetry:   client.ShouldRetryWithRelogin,
+							relogin:       relogin,
+							lockfilePath:  lockFilePath(lockPath),
+							waitDuration:  30 * time.Second,
+							retryDriver:   retryutils.NewLinearDriver(1 * time.Second),
+							retryAttempts: 3,
+						}.retryWithLimitedRelogin(t.Context(), tc, operation)
+					})
+				}
+				wg.Wait()
+				close(errors)
+				for err := range errors {
+					test.errorAssertion(t, err)
+				}
+				assert.Equal(t, test.expectedOperationCalls, int(operationCalls.Load()))
+				assert.Equal(t, test.expectedReloginCalls, int(reloginCalls.Load()))
+			})
+
+		})
+	}
+
+	t.Run("relogin fails open", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			relogin, operation, reloginCalls, operationCalls := successOnRelogin(failedRelogin)
+			// run two batches of operation attempts.
+			for i := range 2 {
+				errors := make(chan error, 3)
+				wg := sync.WaitGroup{}
+				for range 3 {
+					wg.Go(func() {
+						errors <- sshRetryer{
+							shouldRetry:   client.ShouldRetryWithRelogin,
+							relogin:       relogin,
+							lockfilePath:  lockFilePath("failopen"),
+							waitDuration:  60 * time.Second,
+							retryDriver:   retryutils.NewLinearDriver(1 * time.Second),
+							retryAttempts: 3,
+						}.retryWithLimitedRelogin(t.Context(), tc, operation)
+					})
+				}
+				wg.Wait()
+				close(errors)
+				for err := range errors {
+					// All operations should fail since
+					// relogin never succeeds
+					require.Error(t, err)
+				}
+
+				// Expect 5 operation calls per batch
+				// 3 "first attempts" initially. The exclusive lock
+				// holder won't retry after relogin failure, but the
+				// shared lock holders *will* retry anyway.
+				assert.Equal(t, 5*(i+1), int(operationCalls.Load()))
+				// Relogin is called once per batch.
+				assert.Equal(t, i+1, int(reloginCalls.Load()))
+			}
+		})
+	})
 }

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2394,6 +2394,17 @@ func onLogin(cf *CLIConf, reExecArgs ...string) (err error) {
 		return trace.Wrap(err)
 	}
 
+	// On successful login, try to remove the tsh proxy ssh lockfile.
+	// This is just a safeguard in case a tsh process somehow hangs while
+	// holding the lock.
+	defer func() {
+		if err == nil {
+			if rmErr := os.Remove(GetProxySSHRetryerLockfilePath(cf.HomePath, tc.WebProxyHost())); rmErr != nil && !os.IsNotExist(rmErr) {
+				logger.WarnContext(cf.Context, "Failed to remove proxy ssh lockfile", "error", rmErr)
+			}
+		}
+	}()
+
 	// If the user requested tracing and the login succeeds (even if the user
 	// was already logged in) report the tracing client to the trace provider
 	// to that spans can be exported.


### PR DESCRIPTION
Backports #68504

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Added synchronization that mitigates an issue where concurrent tsh proxy ssh invocations open an excessive number of browser tabs for reauthentication when tsh credentials expire.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local cluster with at least one SSH resource and user configured with a very short session TTL.
### Test Cases
- [ ] Run `tsh login` and wait for the session to expire. Execute multiple concurrent `tsh proxy ssh` commands (a simple loop in bash works well). Validate that only a single browser tab opens and that all command instances succeed.
- [ ] Note that the previous command created a file `./tsh/keys/<profile>/proxy_ssh_retrier.lock`. Run `tsh login` and verify that this file is removed.
