### PR TITLE
[v18] [Web UI] management group scope for Azure discovery

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -905,6 +905,9 @@ const (
 	// AzureManagedIdentityResourceGroupLabel is the label key for the Azure resource
 	// group for the managed identity created by the Azure discovery Terraform module.
 	AzureManagedIdentityResourceGroupLabel = TeleportNamespace + "/azure-managed-identity-resource-group"
+	// AzureManagementGroupIDLabel is the label key for the Azure management group ID
+	// used for tenant-wide discovery scoping.
+	AzureManagementGroupIDLabel = TeleportNamespace + "/azure-management-group-id"
 	// ZoneLabelDiscovery is used to identify virtual machines by GCP zone
 	// found via automatic discovery, to avoid re-running installation
 	// commands on the node.

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -75,6 +75,8 @@ type IntegrationAzureManagedIdentitySpec struct {
 	Region string `json:"region,omitempty"`
 	// ResourceGroup is the Azure resource group containing the managed identity.
 	ResourceGroup string `json:"resourceGroup,omitempty"`
+	// ManagementGroupID is the Azure management group ID scope used for the managed identity.
+	ManagementGroupID string `json:"managementGroupId,omitempty"`
 }
 
 // AWSRAProfileSync contains the configuration for the AWS Roles Anywhere Profile Sync.
@@ -457,10 +459,12 @@ func MakeIntegration(ig types.Integration) (*Integration, error) {
 		}
 		region, _ := ig.GetLabel(types.AzureManagedIdentityRegionLabel)
 		resourceGroup, _ := ig.GetLabel(types.AzureManagedIdentityResourceGroupLabel)
-		if region != "" || resourceGroup != "" {
+		managementGroupID, _ := ig.GetLabel(types.AzureManagementGroupIDLabel)
+		if region != "" || resourceGroup != "" || managementGroupID != "" {
 			azureSpec.ManagedIdentity = &IntegrationAzureManagedIdentitySpec{
-				Region:        region,
-				ResourceGroup: resourceGroup,
+				Region:            region,
+				ResourceGroup:     resourceGroup,
+				ManagementGroupID: managementGroupID,
 			}
 		}
 		ret.AzureOIDC = azureSpec

--- a/lib/web/ui/integration_test.go
+++ b/lib/web/ui/integration_test.go
@@ -67,6 +67,7 @@ func TestMakeIntegration(t *testing.T) {
 				types.CreatedByIaCLabel:                      IaCTerraformLabel,
 				types.AzureManagedIdentityRegionLabel:        "eastus",
 				types.AzureManagedIdentityResourceGroupLabel: "my-azure-resource-group",
+				types.AzureManagementGroupIDLabel:            "my-management-group",
 			},
 		},
 		&types.AzureOIDCIntegrationSpecV1{
@@ -120,8 +121,9 @@ func TestMakeIntegration(t *testing.T) {
 					TenantID: "foo",
 					ClientID: "bar",
 					ManagedIdentity: &IntegrationAzureManagedIdentitySpec{
-						Region:        "eastus",
-						ResourceGroup: "my-azure-resource-group",
+						Region:            "eastus",
+						ResourceGroup:     "my-azure-resource-group",
+						ManagementGroupID: "my-management-group",
 					},
 				},
 				IsManagedByTerraform: true,

--- a/web/packages/teleport/src/Discover/Overview/Aws/SettingsTab.tsx
+++ b/web/packages/teleport/src/Discover/Overview/Aws/SettingsTab.tsx
@@ -44,6 +44,7 @@ import {
 import { AwsResource } from 'teleport/Integrations/status/AwsOidc/Cards/StatCard';
 import {
   IntegrationDiscoveryRule,
+  IntegrationKind,
   integrationService,
   IntegrationWithSummary,
   Regions,
@@ -173,7 +174,10 @@ export function SettingsTab({
               />
             </Card>
 
-            <DeleteIntegrationSection integrationName={integrationName} />
+            <DeleteIntegrationSection
+              integrationName={integrationName}
+              kind={IntegrationKind.AwsOidc}
+            />
           </Box>
 
           <TerraformInfoGuideSidePanel

--- a/web/packages/teleport/src/Discover/Overview/Azure/SettingsTab.test.tsx
+++ b/web/packages/teleport/src/Discover/Overview/Azure/SettingsTab.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { QueryClientProvider } from '@tanstack/react-query';
+
+import { render, screen, testQueryClient, waitFor } from 'design/utils/testing';
+import 'shared/components/TextEditor/TextEditor.mock';
+
+import { ContextProvider } from 'teleport';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import {
+  IntegrationAzureOidc,
+  IntegrationDiscoveryRule,
+  IntegrationKind,
+  IntegrationWithSummary,
+  integrationService,
+} from 'teleport/services/integrations';
+
+import { SettingsTab } from './SettingsTab';
+
+const baseStats: IntegrationWithSummary = {
+  name: 'my-azure-integration',
+  subKind: IntegrationKind.AzureOidc,
+  unresolvedUserTasks: 0,
+  userTasks: [],
+  awsra: {} as any,
+  awsoidc: {} as any,
+  awsec2: {} as any,
+  awsrds: {} as any,
+  awseks: {} as any,
+  azurevm: {} as any,
+  rolesAnywhereProfileSync: {} as any,
+};
+
+const baseIntegration: IntegrationAzureOidc = {
+  resourceType: 'integration',
+  kind: IntegrationKind.AzureOidc,
+  name: 'my-azure-integration',
+  spec: {
+    tenantId: 'tenant-123',
+    clientId: 'client-456',
+    managedIdentity: {
+      resourceGroup: 'my-rg',
+      region: 'eastus',
+      managementGroupId: '',
+    },
+  },
+  statusCode: 1,
+};
+
+const baseRule: IntegrationDiscoveryRule = {
+  resourceType: 'vm',
+  region: 'eastus',
+  labelMatcher: [],
+  subscriptions: ['sub-a'],
+  resourceGroups: [],
+  discoveryConfig: 'dc-1',
+  lastSync: 0,
+};
+
+function setupMocks(rules: IntegrationDiscoveryRule[] = []) {
+  jest
+    .spyOn(integrationService, 'fetchIntegration')
+    .mockResolvedValue(baseIntegration);
+  jest
+    .spyOn(integrationService, 'fetchIntegrationRules')
+    .mockResolvedValue({ rules, nextKey: '' });
+}
+
+function renderSettingsTab() {
+  const ctx = createTeleportContext();
+  ctx.storeUser.state.cluster.authVersion = '1.0.0';
+
+  return render(
+    <ContextProvider ctx={ctx}>
+      <QueryClientProvider client={testQueryClient}>
+        <SettingsTab
+          stats={baseStats}
+          activeInfoGuideTab={null}
+          onInfoGuideTabChange={() => {}}
+        />
+      </QueryClientProvider>
+    </ContextProvider>
+  );
+}
+
+describe('SettingsTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    testQueryClient.clear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('does not mention other cloud providers', async () => {
+    setupMocks();
+    const { container } = renderSettingsTab();
+    await waitFor(() => {
+      expect(screen.getByText(/Integration Details/i)).toBeInTheDocument();
+    });
+    expect(container).not.toHaveTextContent(/\bAWS\b/);
+  });
+
+  test('shows unsupported notice when rules have different subscriptions', async () => {
+    setupMocks([
+      { ...baseRule, region: 'eastus', subscriptions: ['sub-a'] },
+      { ...baseRule, region: 'westus', subscriptions: ['sub-b'] },
+    ]);
+    renderSettingsTab();
+    await waitFor(() => {
+      expect(screen.getByText(/unsupported by this form/i)).toBeInTheDocument();
+    });
+  });
+
+  test('shows unsupported notice when rules have different resource groups', async () => {
+    setupMocks([
+      { ...baseRule, region: 'eastus', resourceGroups: ['rg-1'] },
+      { ...baseRule, region: 'westus', resourceGroups: ['rg-2'] },
+    ]);
+    renderSettingsTab();
+    await waitFor(() => {
+      expect(screen.getByText(/unsupported by this form/i)).toBeInTheDocument();
+    });
+  });
+
+  test('does not show unsupported notice when rules are from a single matcher', async () => {
+    setupMocks([
+      { ...baseRule, region: 'eastus' },
+      { ...baseRule, region: 'westus' },
+    ]);
+    renderSettingsTab();
+    await waitFor(() => {
+      expect(screen.getByText(/Integration Details/i)).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText(/unsupported by this form/i)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/packages/teleport/src/Discover/Overview/Azure/SettingsTab.tsx
+++ b/web/packages/teleport/src/Discover/Overview/Azure/SettingsTab.tsx
@@ -45,6 +45,7 @@ import {
 import {
   IntegrationAzureOidc,
   IntegrationDiscoveryRule,
+  IntegrationKind,
   IntegrationWithSummary,
   integrationService,
   AzureRegion,
@@ -53,6 +54,29 @@ import {
 import { useClusterVersion } from 'teleport/useClusterVersion';
 
 import { DeleteIntegrationSection } from '../DeleteIntegrationSection';
+
+// check rules are representable by the settings tab
+const isRepresentable = (rules: IntegrationDiscoveryRule[] = []): boolean => {
+  if (rules.length === 0) return true;
+
+  const subs = (r: IntegrationDiscoveryRule) =>
+    [...(r.subscriptions || [])].sort().join();
+  const rgs = (r: IntegrationDiscoveryRule) =>
+    [...(r.resourceGroups || [])].sort().join();
+  const labels = (r: IntegrationDiscoveryRule) =>
+    [...(r.labelMatcher || [])]
+      .map(l => `${l.name}=${l.value}`)
+      .sort()
+      .join();
+
+  // all rules must have the same subscriptions, resource groups, and labels
+  const sub = subs(rules[0]);
+  const rg = rgs(rules[0]);
+  const label = labels(rules[0]);
+  return rules.every(
+    r => subs(r) === sub && rgs(r) === rg && labels(r) === label
+  );
+};
 
 const vmConfigFromRules = (rules?: IntegrationDiscoveryRule[]): VmConfig => {
   const regions: (AzureRegion | '*')[] =
@@ -83,11 +107,17 @@ const vmConfigFromRules = (rules?: IntegrationDiscoveryRule[]): VmConfig => {
 
 const managedIdentityFromIntegration = (
   integration?: IntegrationAzureOidc
-): AzureManagedIdentity => ({
-  resourceGroup: integration?.spec?.managedIdentity?.resourceGroup || '',
-  region: (integration?.spec?.managedIdentity?.region ||
-    'eastus') as AzureRegion,
-});
+): AzureManagedIdentity => {
+  const managementGroupId =
+    integration?.spec?.managedIdentity?.managementGroupId || undefined;
+  return {
+    resourceGroup: integration?.spec?.managedIdentity?.resourceGroup || '',
+    region: (integration?.spec?.managedIdentity?.region ||
+      'eastus') as AzureRegion,
+    scope: managementGroupId ? 'managementGroup' : 'subscription',
+    managementGroupId,
+  };
+};
 
 export function SettingsTab({
   stats,
@@ -142,17 +172,12 @@ export function SettingsTab({
     return <Danger>Failed to load the integration settings.</Danger>;
   }
 
-  const hasWildcardSubscription =
-    vmRules?.rules?.some(r => r.subscriptions?.includes('*')) ?? false;
-
-  // relax uuid validation if wildcard subscription returned in rules
-  const allowWildcardSubscriptions = updatedVmConfig
-    ? false
-    : hasWildcardSubscription;
-
   const vmConfig = updatedVmConfig ?? vmConfigFromRules(vmRules?.rules);
   const managedIdentity =
     updatedManagedIdentity ?? managedIdentityFromIntegration(integration);
+
+  const isManagementGroupScope = managedIdentity.scope === 'managementGroup';
+  const hasTerraformOnlyConfiguration = !isRepresentable(vmRules?.rules);
 
   const terraformConfig = buildTerraformConfig({
     integrationName,
@@ -166,11 +191,10 @@ export function SettingsTab({
       {({ validator }) => (
         <Flex>
           <Box flex="1">
-            {hasWildcardSubscription && (
+            {hasTerraformOnlyConfiguration && (
               <Info mb={3}>
-                This integration was configured with a wildcard subscription
-                matcher in Terraform, which is currently unsupported by this
-                form. Please update your Terraform configuration directly.
+                This integration has a configuration which is unsupported by
+                this form. Please update your Terraform configuration directly.
               </Info>
             )}
             <Card p={4} mb={3}>
@@ -186,6 +210,8 @@ export function SettingsTab({
                 <ManagedIdentitySection
                   managedIdentity={managedIdentity}
                   onChange={setManagedIdentity}
+                  vmConfig={vmConfig}
+                  onVmChange={setVmConfig}
                   disabled={false}
                 />
               </Box>
@@ -193,7 +219,7 @@ export function SettingsTab({
               <ResourcesSection
                 vmConfig={vmConfig}
                 onVmChange={setVmConfig}
-                allowWildcardSubscriptions={allowWildcardSubscriptions}
+                allowWildcardSubscriptions={isManagementGroupScope}
               />
               <Divider />
               <ApplyTerraformSection
@@ -207,7 +233,10 @@ export function SettingsTab({
               />
             </Card>
 
-            <DeleteIntegrationSection integrationName={integrationName} />
+            <DeleteIntegrationSection
+              integrationName={integrationName}
+              kind={IntegrationKind.AzureOidc}
+            />
           </Box>
 
           <TerraformInfoGuideSidePanel

--- a/web/packages/teleport/src/Discover/Overview/DeleteIntegrationSection.tsx
+++ b/web/packages/teleport/src/Discover/Overview/DeleteIntegrationSection.tsx
@@ -19,13 +19,26 @@
 import { Alert, Card, Flex, Text } from 'design';
 import { TextSelectCopyMulti } from 'shared/components/TextSelectCopy';
 
+import { IntegrationKind } from 'teleport/services/integrations';
+
+type IaCIntegrationKind = IntegrationKind.AwsOidc | IntegrationKind.AzureOidc;
+
+const cloudName: Record<IaCIntegrationKind, string> = {
+  [IntegrationKind.AwsOidc]: 'AWS',
+  [IntegrationKind.AzureOidc]: 'Azure',
+};
+
 type DeleteIntegrationSectionProps = {
   integrationName: string;
+  kind: IaCIntegrationKind;
 };
 
 export function DeleteIntegrationSection({
   integrationName,
+  kind,
 }: DeleteIntegrationSectionProps) {
+  const cloud = cloudName[kind];
+
   return (
     <Card>
       <Flex flexDirection="column" p={4} mt={3}>
@@ -40,8 +53,8 @@ export function DeleteIntegrationSection({
               <Text as="strong" fontWeight="bold">
                 {integrationName}
               </Text>{' '}
-              module from your Terraform configuration will remove Teleport and
-              AWS resources used for auto-discovery.
+              module from your Terraform configuration will remove Teleport and{' '}
+              {cloud} resources used for auto-discovery.
             </Text>
           </Flex>
         </Alert>
@@ -54,8 +67,8 @@ export function DeleteIntegrationSection({
         <TextSelectCopyMulti lines={[{ text: 'terraform apply' }]} />
 
         <Text mt={2} fontSize={1} color="text.slightlyMuted">
-          Note: This removes the integration and dependent IAM resources but
-          does not delete your AWS resources in Teleport. To remove resources
+          Note: This removes the integration and dependent resources but does
+          not delete your {cloud} resources in Teleport. To remove resources
           from Teleport, delete them via the Teleport UI or CLI.
         </Text>
       </Flex>

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/EnrollAzure.test.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/EnrollAzure.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router';
+
+import { fireEvent, render, screen, waitFor } from 'design/utils/testing';
+import { InfoGuidePanelProvider } from 'shared/components/SlidingSidePanel/InfoGuide';
+import 'shared/components/TextEditor/TextEditor.mock';
+
+import { ContextProvider } from 'teleport';
+import { ContentMinWidth } from 'teleport/Main/Main';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import { userEventService } from 'teleport/services/userEvent';
+
+import { EnrollAzure } from './EnrollAzure';
+
+describe('EnrollAzure', () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  function renderEnrollAzure() {
+    const ctx = createTeleportContext();
+    ctx.storeUser.state.cluster.authVersion = '1.0.0';
+
+    return render(
+      <ContextProvider ctx={ctx}>
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <InfoGuidePanelProvider>
+              <ContentMinWidth>
+                <EnrollAzure />
+              </ContentMinWidth>
+            </InfoGuidePanelProvider>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </ContextProvider>
+    );
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryClient.clear();
+    jest
+      .spyOn(userEventService, 'captureIntegrationEnrollEvent')
+      .mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('does not contain any AWS references', () => {
+    const { container } = renderEnrollAzure();
+    expect(container).not.toHaveTextContent(/\bAWS\b/);
+  });
+
+  test('validates integration name is required', async () => {
+    renderEnrollAzure();
+
+    const input = screen.getByLabelText(/integration name/i);
+    fireEvent.change(input, { target: { value: '' } });
+
+    const copyButtons = screen.getAllByRole('button', {
+      name: /copy terraform module/i,
+    });
+    fireEvent.click(copyButtons[0]);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/integration name is required/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('validates resource group name is required', async () => {
+    renderEnrollAzure();
+
+    const copyButtons = screen.getAllByRole('button', {
+      name: /copy terraform module/i,
+    });
+    fireEvent.click(copyButtons[0]);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/resource group name is required/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('scope', () => {
+    describe('management group', () => {
+      test('is selected by default', () => {
+        renderEnrollAzure();
+        expect(screen.getByLabelText(/^management group$/i)).toBeChecked();
+        expect(
+          screen.getByLabelText(/management group id/i)
+        ).toBeInTheDocument();
+      });
+
+      test('subscription matcher is not required', () => {
+        renderEnrollAzure();
+        expect(screen.getByText(/match subscriptions/i)).not.toHaveTextContent(
+          '*'
+        );
+      });
+    });
+
+    describe('subscription', () => {
+      test('shows subscription ID field instead of management group ID', () => {
+        renderEnrollAzure();
+        fireEvent.click(screen.getByLabelText(/^subscription$/i));
+        expect(screen.getByLabelText(/subscription id/i)).toBeInTheDocument();
+        expect(
+          screen.queryByLabelText(/management group id/i)
+        ).not.toBeInTheDocument();
+      });
+
+      test('subscription ID mirrors first subscription matcher', () => {
+        renderEnrollAzure();
+        fireEvent.click(screen.getByLabelText(/^subscription$/i));
+        const input = screen.getByLabelText(/subscription id/i);
+        fireEvent.change(input, {
+          target: { value: '11111111-2222-3333-4444-555555555555' },
+        });
+
+        const matchers = screen.getAllByPlaceholderText(
+          '11111111-2222-3333-4444-555555555555'
+        );
+        expect(matchers[0]).toHaveValue('11111111-2222-3333-4444-555555555555');
+      });
+
+      test('validates subscription ID is required', async () => {
+        renderEnrollAzure();
+        fireEvent.click(screen.getByLabelText(/^subscription$/i));
+        const copyButtons = screen.getAllByRole('button', {
+          name: /copy terraform module/i,
+        });
+        fireEvent.click(copyButtons[0]);
+
+        await waitFor(() => {
+          expect(
+            screen.getByText(/subscription id is required/i)
+          ).toBeInTheDocument();
+        });
+      });
+    });
+  });
+});

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/EnrollAzure.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/EnrollAzure.tsx
@@ -20,10 +20,12 @@ import { useMemo, useState } from 'react';
 import { Link as InternalLink } from 'react-router-dom';
 
 import { Box, ButtonSecondary, Flex, Subtitle1, Text } from 'design';
+import { RadioGroup } from 'design/RadioGroup';
 import { copyToClipboard } from 'design/utils/copyToClipboard';
 import FieldInput from 'shared/components/FieldInput';
 import Validation from 'shared/components/Validation';
 import {
+  requiredAzureSubscriptionId,
   requiredField,
   requiredIntegrationName,
 } from 'shared/components/Validation/rules';
@@ -85,6 +87,8 @@ export function EnrollAzure() {
   const [managedIdentity, setManagedIdentity] = useState<AzureManagedIdentity>({
     region: 'eastus',
     resourceGroup: '',
+    scope: 'managementGroup',
+    managementGroupId: '',
   });
 
   const terraformConfig = useMemo(
@@ -97,6 +101,8 @@ export function EnrollAzure() {
       }),
     [integrationName, clusterVersion, vmConfig, managedIdentity]
   );
+
+  const isManagementGroupScope = managedIdentity.scope === 'managementGroup';
 
   const {
     isPanelOpen,
@@ -132,10 +138,16 @@ export function EnrollAzure() {
               <ManagedIdentitySection
                 managedIdentity={managedIdentity}
                 onChange={setManagedIdentity}
+                vmConfig={vmConfig}
+                onVmChange={setVmConfig}
                 disabled={isFetching}
               />
               <Divider />
-              <ResourcesSection vmConfig={vmConfig} onVmChange={setVmConfig} />
+              <ResourcesSection
+                vmConfig={vmConfig}
+                onVmChange={setVmConfig}
+                allowWildcardSubscriptions={isManagementGroupScope}
+              />
               <Divider />
               <ApplyTerraformSection
                 handleCopy={() => {
@@ -231,24 +243,99 @@ export function IntegrationSection({
 type ManagedIdentitySectionProps = {
   managedIdentity: AzureManagedIdentity;
   onChange: (identity: AzureManagedIdentity) => void;
+  vmConfig: VmConfig;
+  onVmChange: (config: VmConfig) => void;
   disabled?: boolean;
 };
 
 export function ManagedIdentitySection({
   managedIdentity,
   onChange,
+  vmConfig,
+  onVmChange,
   disabled = false,
 }: ManagedIdentitySectionProps) {
+  const isManagementGroupScope = managedIdentity.scope === 'managementGroup';
+
   return (
     <>
-      <Flex alignItems="center" fontSize={4} fontWeight="medium" mb={3}>
+      <Flex alignItems="center" fontSize={4} fontWeight="medium" mb={1}>
         <CircleNumber>2</CircleNumber>
         Azure Managed Identity
       </Flex>
-      <Box ml={4} mb={3} color="text.slightlyMuted" maxWidth={500}>
-        Configure the region and resource group for the Azure Managed Identity
-        used by the Teleport discovery service.
+      <Text ml={4} mb={3}>
+        Configure access for the managed identity used by the Discovery Service
+        and where it is deployed.
+      </Text>
+
+      <Text ml={4} bold>
+        Scope
+      </Text>
+      <Text ml={4} mb={1} fontSize="small" color="text.slightlyMuted">
+        Configure the scope for the managed identity's role assignments. Use a
+        root Management Group to discover resources across all child
+        subscriptions or specific subscriptions.
+      </Text>
+      <Box ml={4} mb={3}>
+        <RadioGroup
+          name="azureScope"
+          options={[
+            { value: 'managementGroup', label: 'Management Group' },
+            { value: 'subscription', label: 'Subscription' },
+          ]}
+          value={managedIdentity.scope}
+          size="small"
+          onChange={value =>
+            onChange({
+              ...managedIdentity,
+              scope: value as AzureManagedIdentity['scope'],
+              ...(value === 'managementGroup'
+                ? { managementGroupId: managedIdentity.managementGroupId ?? '' }
+                : { managementGroupId: undefined }),
+            })
+          }
+        />
       </Box>
+      {isManagementGroupScope ? (
+        <FieldInput
+          ml={4}
+          mb={3}
+          rule={requiredField('Management Group ID is required')}
+          value={managedIdentity.managementGroupId || ''}
+          required
+          label="Management Group ID"
+          placeholder="my-management-group-id"
+          maxWidth={400}
+          disabled={disabled}
+          onChange={e =>
+            onChange({
+              ...managedIdentity,
+              managementGroupId: e.target.value,
+            })
+          }
+        />
+      ) : (
+        <FieldInput
+          ml={4}
+          mb={3}
+          rule={requiredAzureSubscriptionId}
+          value={vmConfig.subscriptions[0] || ''}
+          required
+          label="Subscription ID"
+          placeholder="11111111-2222-3333-4444-555555555555"
+          maxWidth={400}
+          disabled={disabled}
+          onChange={e =>
+            onVmChange({
+              ...vmConfig,
+              subscriptions: [
+                e.target.value,
+                ...vmConfig.subscriptions.slice(1),
+              ],
+            })
+          }
+        />
+      )}
 
       <Box ml={4} mb={0} maxWidth={400}>
         <RegionSelect

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/InfoGuide.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/InfoGuide.tsx
@@ -53,15 +53,19 @@ export function InfoGuideContent() {
         >
           <li>
             <strong>Configure what to discover.</strong> <br />
-            Specify resource types, subscriptions, regions, and tag filters to
-            control which resources are discovered.
+            <Text as="span" color="text.slightlyMuted">
+              Specify resource types, subscriptions, regions, and tag filters to
+              control which resources are discovered.
+            </Text>
           </li>
           <li>
             <strong>Use the generated Terraform module.</strong> <br />
-            The generated Terraform module configuration will create an Azure
-            managed identity that grants Teleport read-only access and
-            configures Teleport discovery service to scan for your Azure
-            resources.
+            <Text as="span" color="text.slightlyMuted">
+              The generated Terraform module configuration will create an Azure
+              managed identity that grants Teleport read-only access and
+              configures Teleport discovery service to scan for your Azure
+              resources.
+            </Text>
           </li>
           <li>
             <strong>

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/ResourcesSection.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/ResourcesSection.tsx
@@ -43,6 +43,9 @@ import { AzureTag, VmConfig } from './types';
 const subscriptionRule =
   (allowWildcard: boolean) => (values: string[]) => () => {
     if (values.length === 0) {
+      if (allowWildcard) {
+        return { valid: true, results: [] };
+      }
       return {
         valid: false,
         results: [
@@ -121,13 +124,14 @@ function AzureService({
         size="small"
         label={label}
         checked={config.enabled}
+        onChange={() => {}}
       />
       {config.enabled && (
         <Box ml={4}>
           <Box mb={3} maxWidth={432}>
             <FieldMultiInput
               label="Match subscriptions"
-              required
+              required={!allowWildcardSubscriptions}
               value={config.subscriptions}
               placeholder="11111111-2222-3333-4444-555555555555"
               onChange={subscriptions => onUpdate({ subscriptions })}

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/tf_module.test.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/tf_module.test.ts
@@ -36,6 +36,8 @@ describe('buildTerraformConfig', () => {
     managedIdentity: {
       resourceGroup: 'my-resource-group',
       region: 'eastus',
+      scope: 'managementGroup',
+      managementGroupId: 'my-mg',
     },
   };
 
@@ -100,10 +102,10 @@ describe('buildTerraformConfig', () => {
     expect(result).toContain('subscriptions = ["sub-a", "sub-b"]');
   });
 
-  test('includes empty subscriptions array when none provided', () => {
+  test('management group scope defaults to wildcard subscription matcher', () => {
     const result = buildTerraformConfig(baseConfig);
 
-    expect(result).toContain('subscriptions = []');
+    expect(result).toContain('subscriptions = ["*"]');
   });
 
   test('includes resource_groups sorted', () => {
@@ -149,6 +151,20 @@ describe('buildTerraformConfig', () => {
     });
 
     expect(result).not.toContain('tags');
+  });
+
+  test('subscription scope does not include azure_management_group_id', () => {
+    const result = buildTerraformConfig({
+      ...baseConfig,
+      managedIdentity: {
+        ...baseConfig.managedIdentity,
+        scope: 'subscription',
+        managementGroupId: undefined,
+      },
+      vmConfig: { ...baseConfig.vmConfig, subscriptions: ['sub-a'] },
+    });
+
+    expect(result).not.toContain('azure_management_group_id');
   });
 
   test('collects multiple values for the same tag key', () => {

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/tf_module.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/tf_module.ts
@@ -58,13 +58,16 @@ export const buildTerraformConfig = ({
 
   const integrationNameOrNull = integrationName.trim() || null;
 
-  const matcher = buildMatcher(vmConfig);
+  const isManagementGroupScope = managedIdentity.scope === 'managementGroup';
+  const matcher = buildMatcher(vmConfig, isManagementGroupScope);
 
   const azureMatchers = matcher ? [matcher] : null;
 
   const resourceGroup = managedIdentity.resourceGroup.trim();
 
   const managedIdentityRegionOrNull = managedIdentity.region;
+
+  const managementGroupIdOrNull = managedIdentity.managementGroupId ?? null;
 
   const tfModule = hcl`# Terraform Module
 module "azure_discovery" {
@@ -76,6 +79,11 @@ module "azure_discovery" {
   teleport_proxy_public_addr    = ${cfg.proxyCluster + ':443'}
   teleport_discovery_group_name = "cloud-discovery-group"
   teleport_integration_name	    = ${integrationNameOrNull}
+
+  # Scope role assignment to a Management Group for discovering resources
+  # across all child subscriptions. Provide the Tenant ID to use the
+  # Tenant Root Group scope.
+  azure_management_group_id = ${managementGroupIdOrNull}
 
   # Name of an existing Azure Resource Group where
   # Azure resources will be created.
@@ -92,13 +100,20 @@ module "azure_discovery" {
   return tfModule;
 };
 
-const buildMatcher = (config: ServiceConfig): TFObject | null => {
+const buildMatcher = (
+  config: ServiceConfig,
+  isManagementGroupScope: boolean
+): TFObject | null => {
   if (!config.enabled) return null;
 
   const matcher: { [key: string]: TFValue } = { types: [config.type] };
 
-  // required by azure discovery module
-  matcher.subscriptions = [...config.subscriptions].sort();
+  const subscriptions = config.subscriptions.filter(s => s.trim()).sort();
+  if (isManagementGroupScope && subscriptions.length === 0) {
+    matcher.subscriptions = ['*'];
+  } else {
+    matcher.subscriptions = subscriptions;
+  }
 
   if (config.resourceGroups?.length > 0) {
     matcher['resource_groups'] = [...config.resourceGroups].sort();

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/types.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/types.ts
@@ -36,7 +36,11 @@ export type AzureTag = {
   value: string;
 };
 
+export type AzureScope = 'managementGroup' | 'subscription';
+
 export type AzureManagedIdentity = {
   region: AzureRegion;
   resourceGroup: string;
+  scope: AzureScope;
+  managementGroupId?: string;
 };

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -118,6 +118,7 @@ export type IntegrationSpecAzureOidc = {
   managedIdentity?: {
     region: string;
     resourceGroup: string;
+    managementGroupId?: string;
   };
 };
 


### PR DESCRIPTION
Backport #68434 to branch/v18

changelog: Added management group scope to Azure Discovery enrollment in the Web UI

## Manual Test Plan
### Test Environment

cloud

### Test Cases
- [x] Configure discovery w/ Management Group Scope using Enroll Azure form
- [x] Configure discovery w/ Subscription Scope using Enroll Azure form
- [x] View Integration > Edit Integration renders correctly for subscription, management group scope config