### PR TITLE
[v18] scoped watches & role/assignment namespacing

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -27,6 +27,7 @@ import "teleport/legacy/types/mfa_device.proto";
 import "teleport/legacy/types/resources.proto";
 import "teleport/legacy/types/trusted_device_requirement.proto";
 import "teleport/legacy/types/wrappers/wrappers.proto";
+import "teleport/scopes/v1/scopes.proto";
 
 option go_package = "github.com/gravitational/teleport/api/types";
 option (gogoproto.goproto_getters_all) = false;
@@ -9238,6 +9239,15 @@ enum HeadlessAuthenticationState {
   HEADLESS_AUTHENTICATION_STATE_APPROVED = 3;
 }
 
+// ScopeFilter is a gogo-native mirror of teleport.scopes.v1.Filter for use on WatchKind. Gogo uses
+// marshaling/unmarshaling logic that is incompatible with our newer proto messages.
+message ScopeFilter {
+  // Scope is the scope the filter is anchored at.
+  string scope = 1;
+  // Mode determines how the scope is matched (exact, descendants, etc.).
+  teleport.scopes.v1.Mode mode = 2;
+}
+
 // WatchKind specifies resource kind to watch
 // When adding fields to this struct, make sure to review/update WatchKind.Contains method.
 message WatchKind {
@@ -9257,6 +9267,10 @@ message WatchKind {
   // Version optionally specifies the resource version to watch.
   // Currently this field is ignored.
   string Version = 6 [(gogoproto.jsontag) = "version,omitempty"];
+  // ScopeFilter optionally filters events by scope. Filtering is performed against the scope of the
+  // resource itself. Defaults to one of EXACT or UNSCOPED depending on wether the caller is
+  // a scoped or unscoped identity for most kinds.
+  ScopeFilter ScopeFilter = 7 [(gogoproto.jsontag) = "scope_filter,omitempty"];
 }
 
 // WatchStatusV1 is intended to be attached to OpInit events and contain information about a successful WatchEvents call.

--- a/api/types/events.go
+++ b/api/types/events.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 
 	"github.com/gravitational/trace"
+
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 )
 
 // String returns text description of this event
@@ -154,11 +156,6 @@ func (kind WatchKind) Matches(e Event) (bool, error) {
 	return true, nil
 }
 
-// IsTrivial returns true iff the WatchKind only specifies a Kind but no other field.
-func (kind WatchKind) IsTrivial() bool {
-	return kind.SubKind == "" && kind.Name == "" && kind.Version == "" && !kind.LoadSecrets && len(kind.Filter) == 0
-}
-
 // Contains determines whether kind (receiver) targets exactly the same or a wider scope of events as the given subset kind.
 // Generally this means that if kind specifies a filter, its subset must have exactly the same or a narrower one.
 // Currently, does not take resource versions into account.
@@ -189,7 +186,32 @@ func (kind WatchKind) Contains(subset WatchKind) bool {
 		}
 	}
 
+	// TODO(fspmarshall/scopes): determine set containment model for scope filter. Any such model
+	// must be sane in the context of the filter-defaulting behavior of the watch API's authz layer.
+
 	return true
+}
+
+// ToProto converts the gogo-native ScopeFilter to the authoritative scopesv1.Filter.
+func (f *ScopeFilter) ToProto() *scopesv1.Filter {
+	if f == nil {
+		return nil
+	}
+	return scopesv1.Filter_builder{
+		Scope: f.Scope,
+		Mode:  f.Mode,
+	}.Build()
+}
+
+// ScopeFilterFromProto converts a scopesv1.Filter to the gogo-native ScopeFilter.
+func ScopeFilterFromProto(f *scopesv1.Filter) *ScopeFilter {
+	if f == nil {
+		return nil
+	}
+	return &ScopeFilter{
+		Scope: f.GetScope(),
+		Mode:  f.GetMode(),
+	}
 }
 
 // Events returns new events interface

--- a/api/types/resource_153.go
+++ b/api/types/resource_153.go
@@ -175,6 +175,16 @@ func (r *resource153ToLegacyAdapter[T]) GetKind() string {
 	return r.inner.GetKind()
 }
 
+// GetScope returns the scope of the wrapped resource if it is scope-aware, or "" otherwise. This lets
+// scope-based event/watch filtering extract scope uniformly from wrapped resources without needing to
+// know their concrete type.
+func (r *resource153ToLegacyAdapter[T]) GetScope() string {
+	if scoped, ok := any(r.inner).(interface{ GetScope() string }); ok {
+		return scoped.GetScope()
+	}
+	return ""
+}
+
 // Metadata153ToLegacy converts RFD153-style resource metadata to legacy
 // metadata.
 func Metadata153ToLegacy(md *headerv1.Metadata) Metadata {

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -29,6 +29,7 @@ import (
 	github_com_gravitational_teleport_api_constants "github.com/gravitational/teleport/api/constants"
 	_ "github.com/gravitational/teleport/api/gen/proto/go/attestation/v1"
 	_ "github.com/gravitational/teleport/api/gen/proto/go/teleport/componentfeatures/v1"
+	_ "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	github_com_gravitational_teleport_api_types "github.com/gravitational/teleport/api/types"
 	github_com_hashicorp_terraform_plugin_framework_attr "github.com/hashicorp/terraform-plugin-framework/attr"
 	github_com_hashicorp_terraform_plugin_framework_diag "github.com/hashicorp/terraform-plugin-framework/diag"

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -46,6 +46,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
@@ -69,7 +70,9 @@ import (
 	iterstream "github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/joining"
+	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/services/local/generic"
@@ -1251,19 +1254,9 @@ func (a *ServerWithRoles) KeepAliveServer(ctx context.Context, handle types.Keep
 
 // NewStream returns a new event stream (equivalent to NewWatcher, but with slightly different
 // performance characteristics).
-func (a *ServerWithRoles) NewStream(ctx context.Context, watch types.Watch) (stream.Stream[types.Event], error) {
-	if err := a.authorizeWatchRequest(ctx, &watch); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return a.authServer.NewStream(ctx, watch)
-}
-
-// NewStream is the scoped equivalent of [ServerWithRoles.NewStream]. This method currently only supports a
-// small subset of the functionality of its unscoped counterpart when invoked by scoped callers.
 func (a *ScopedServerWithRoles) NewStream(ctx context.Context, watch types.Watch) (stream.Stream[types.Event], error) {
-	if unscoped, ok := a.UnscopedServerWithRoles(); ok {
-		return unscoped.NewStream(ctx, watch)
-	}
+	// NOTE: authorizeWatchRequest modifies requests inflight in order to apply proper scope filtering to the
+	// event stream and to apply partial success subselection (if appropriate).
 	if err := a.authorizeWatchRequest(ctx, &watch); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1271,45 +1264,36 @@ func (a *ScopedServerWithRoles) NewStream(ctx context.Context, watch types.Watch
 	return a.authServer.NewStream(ctx, watch)
 }
 
-// NewWatcher returns a new event watcher
-func (a *ServerWithRoles) NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error) {
-	if err := a.authorizeWatchRequest(ctx, &watch); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return a.authServer.NewWatcher(ctx, watch)
-}
-
-// NewWatcher is the scoped equivalent of [ServerWithRoles.NewWatcher].  This method currently only supports a
-// small subset of the functionality of its unscoped counterpart when invoked by scoped callers.
+// NewWatcher returns a new event watcher.
 func (a *ScopedServerWithRoles) NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error) {
-	if unscoped, ok := a.UnscopedServerWithRoles(); ok {
-		return unscoped.NewWatcher(ctx, watch)
-	}
+	// NOTE: authorizeWatchRequest modifies requests inflight in order to apply proper scope filtering to the
+	// event stream and to apply partial success subselection (if appropriate).
 	if err := a.authorizeWatchRequest(ctx, &watch); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.NewWatcher(ctx, watch)
 }
 
-// authorizeWatchRequest performs permission checks and filtering on incoming watch requests.
-func (a *ServerWithRoles) authorizeWatchRequest(ctx context.Context, watch *types.Watch) error {
+// authorizeWatchRequest performs permission checks and filtering on incoming watch requests from both
+// scoped and unscoped callers. Each requested kind is authorized by authorizeWatchKind, and the effective
+// scope filter it returns is written back onto the kind so the event stream only yields events for the scoping
+// that was authorized.
+func (a *ScopedServerWithRoles) authorizeWatchRequest(ctx context.Context, watch *types.Watch) error {
 	if len(watch.Kinds) == 0 {
 		return trace.AccessDenied("can't setup global watch")
 	}
-
 	validKinds := make([]types.WatchKind, 0, len(watch.Kinds))
 	for _, kind := range watch.Kinds {
-		err := a.hasWatchPermissionForKind(ctx, kind)
+		filter, err := a.authorizeWatchKind(ctx, kind)
 		if err != nil {
 			if watch.AllowPartialSuccess {
 				continue
 			}
 			return trace.Wrap(err)
 		}
-
+		kind.ScopeFilter = types.ScopeFilterFromProto(filter)
 		validKinds = append(validKinds, kind)
 	}
-
 	if len(validKinds) == 0 {
 		return trace.BadParameter("none of the requested kinds can be watched")
 	}
@@ -1319,34 +1303,6 @@ func (a *ServerWithRoles) authorizeWatchRequest(ctx context.Context, watch *type
 	case a.hasBuiltinRole(types.RoleProxy):
 		watch.QueueSize = defaults.ProxyQueueSize
 	case a.hasBuiltinRole(types.RoleNode):
-		watch.QueueSize = defaults.NodeQueueSize
-	}
-
-	return nil
-}
-
-// authorizeWatchRequest is the scoped equivalent of [ServerWithRoles.authorizeWatchRequest].
-// Queue-size tuning for built-in roles is omitted; kind support is restricted (see hasWatchPermissionForKind).
-func (a *ScopedServerWithRoles) authorizeWatchRequest(ctx context.Context, watch *types.Watch) error {
-	if len(watch.Kinds) == 0 {
-		return trace.AccessDenied("can't setup global watch")
-	}
-	validKinds := make([]types.WatchKind, 0, len(watch.Kinds))
-	for _, kind := range watch.Kinds {
-		if err := a.hasWatchPermissionForKind(ctx, kind); err != nil {
-			if watch.AllowPartialSuccess {
-				continue
-			}
-			return trace.Wrap(err)
-		}
-		validKinds = append(validKinds, kind)
-	}
-	if len(validKinds) == 0 {
-		return trace.BadParameter("none of the requested kinds can be watched")
-	}
-
-	watch.Kinds = validKinds
-	if a.hasBuiltinRole(types.RoleNode) {
 		watch.QueueSize = defaults.NodeQueueSize
 	}
 
@@ -1363,10 +1319,6 @@ func (a *ServerWithRoles) hasWatchPermissionForKind(
 
 	verb := types.VerbRead
 	switch kind.Kind {
-	case types.KindCertAuthority:
-		if !kind.LoadSecrets {
-			verb = types.VerbReadNoSecrets
-		}
 	case types.KindAccessRequest:
 		var filter types.AccessRequestFilter
 		if err := filter.FromMap(kind.Filter); err != nil {
@@ -1417,22 +1369,196 @@ func (a *ServerWithRoles) hasWatchPermissionForKind(
 	return trace.Wrap(a.authorizeAction(kind.Kind, verb))
 }
 
-// hasWatchPermissionForKind is the scoped equivalent of [ServerWithRoles.hasWatchPermissionForKind].
-// Currently only cert_authority (with load_secrets=false) and spiffe_federation are permitted for
-// scoped identities. Both are cluster-global config and are authorized as unpinned root reads.
-func (a *ScopedServerWithRoles) hasWatchPermissionForKind(ctx context.Context, kind types.WatchKind) error {
-	ruleCtx := a.scopedContext.RuleContext()
-	switch kind.Kind {
-	case types.KindCertAuthority:
-		if kind.LoadSecrets {
-			return trace.AccessDenied("scoped identities are not permitted to watch cert_authority with load_secrets=true")
-		}
-		return a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadCertAuthority, &ruleCtx)
-	case types.KindSPIFFEFederation:
-		return a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadSPIFFEFederation, &ruleCtx)
+// supportedScopedWatchKind matches the set of resource kinds that have been converted to support scoped watch
+// (namespaced + scope-carrying delete events). A scope filter that targets scoped
+// resources is only meaningful for these kinds.
+func supportedScopedWatchKind(kind string) bool {
+	switch kind {
+	case scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment:
+		return true
 	default:
-		return trace.AccessDenied("scoped identities are not permitted to watch kind %q", kind.Kind)
+		return false
 	}
+}
+
+// authorizeWatchKind authorizes watching the given kind and returns the effective scope filter to apply
+// to its event stream. Kinds whose classical authz includes user-filter-conditioned grants are routed
+// to the classical implementation (and denied for scoped callers); everything else goes through the
+// unified scoped-first path.
+func (a *ScopedServerWithRoles) authorizeWatchKind(ctx context.Context, kind types.WatchKind) (*scopesv1.Filter, error) {
+	// do a pre-check for kinds that have exceptional behavior we haven't integrated into the unified
+	// scoped authz path yet.
+	switch kind.Kind {
+	case types.KindAccessRequest, types.KindWebSession, types.KindHeadlessAuthentication:
+		switch kind.ScopeFilter.ToProto().GetMode() {
+		case scopesv1.Mode_MODE_UNSPECIFIED, scopesv1.Mode_MODE_UNSCOPED, scopesv1.Mode_MODE_ALL:
+			// all equivalent to the unscoped subset for these kinds
+		default:
+			return nil, trace.BadParameter("kind %q does not support scope filter mode %v", kind.Kind, kind.ScopeFilter.ToProto().GetMode())
+		}
+
+		// TODO(fspmarshall/scopes): figure out how current-user exceptions/filters aught to be expressed
+		// in the scoped model so that we can fully eliminate dependence on unscoped server with roles.
+		unscoped, ok := a.UnscopedServerWithRoles()
+		if !ok {
+			return nil, trace.AccessDenied("scoped identities are not permitted to watch kind %q", kind.Kind)
+		}
+		if err := unscoped.hasWatchPermissionForKind(ctx, kind); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build(), nil
+	}
+
+	// everything else goes through the unified scoped-first path, which reduces to a classical rule
+	// check for unscoped callers and carries the named unpinned-read exceptions for scoped callers.
+	return a.authorizeWatchKindCore(ctx, kind)
+}
+
+// unscopedWatchKindException maps *unscoped* kinds that permit scoped identities to read them via
+// unpinned-read exceptions to their associated authorization. This category is conceptually distinct
+// from optionally scoped kinds like nodes, or scoped kinds that permit upward-reaching queries such
+// as scoped roles.
+func unscopedWatchKindException(kind string) (ura services.UnpinnedReadAuthorization, ok bool) {
+	switch kind {
+	case types.KindCertAuthority:
+		return services.UnpinnedReadCertAuthority, true
+	case types.KindSPIFFEFederation:
+		return services.UnpinnedReadSPIFFEFederation, true
+	default:
+		return services.UnpinnedReadAuthorization{}, false
+	}
+}
+
+// authorizeUnscopedWatchKindException authorizes a scoped identity to watch the unscoped region of
+// the specific cluster-global kinds matched by unscopedWatchKindException, which are readable
+// regardless of pin. Note that this is conceptually distinct from ancestral watch exceptions.
+func (a *ScopedServerWithRoles) authorizeUnscopedWatchKindException(ctx context.Context, kind types.WatchKind) error {
+	authorization, ok := unscopedWatchKindException(kind.Kind)
+	if !ok {
+		return trace.AccessDenied("scoped identities are not permitted to watch kind %q with an unscoped filter", kind.Kind)
+	}
+	if kind.LoadSecrets {
+		return trace.AccessDenied("scoped identities are not permitted to watch kind %q with load_secrets=true", kind.Kind)
+	}
+	ruleCtx := a.scopedContext.RuleContext()
+	return trace.Wrap(a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, authorization, &ruleCtx))
+}
+
+// authorizeAncestralWatchException authorizes the special case where a watch request is made against a scoped kind that
+// includes events in ancestors of the target scope. Only specific resources permit this under specific conditions.
+func (a *ScopedServerWithRoles) authorizeAncestralWatchException(ctx context.Context, kind types.WatchKind, filter *scopesv1.Filter) error {
+	// if the caller is scope-pinned, we want to apply the additional requirement that the requested scope filter is subject
+	// to the pinned scope. this prevents registration of filters that would select orthogonal resources, which are not
+	// covered by unpinned read exceptions. we typically don't have to do this kind of check when we have per-resource RBAC
+	// because the unpinned read helper can validate that the resource is non-orthogonal internally. However, for watches, we
+	// need to be more strict in order to ensure that the filter *could never* match an orthogonal resource.
+	if pin, ok := a.scopedContext.CheckerContext.ScopePin(); ok && !pinning.PinAppliesToResourceScope(pin, filter.GetScope()) {
+		return trace.AccessDenied("scope filter %q is not subject to the caller's pinned scope %q", filter.GetScope(), pin.GetScope())
+	}
+
+	// upward-reaching filter modes are never permitted to load secrets
+	if kind.LoadSecrets {
+		return trace.AccessDenied("cannot watch events with mode %v and load_secrets=true for kind %q", filter.GetMode(), kind.Kind)
+	}
+
+	switch kind.Kind {
+	case scopedaccess.KindScopedRole:
+		// the unpinned read exception for scoped roles is only granted to services.
+		if !authz.ScopedIsLocalOrRemoteService(a.scopedContext) {
+			return trace.AccessDenied("non-service identities are not permitted to watch kind %q with mode %v", kind.Kind, filter.GetMode())
+		}
+		ruleCtx := a.scopedContext.RuleContext()
+		return trace.Wrap(a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedReadWithScope(ctx, services.UnpinnedReadScopedRole, &ruleCtx, filter.GetScope()))
+	default:
+		return trace.AccessDenied("watches are not permitted for kind %q with mode %v", kind.Kind, filter.GetMode())
+	}
+}
+
+// authorizeWatchKindCore implements the core logic of watch kind authorization and scope filter resolution
+// for scoped and unscoped callers. Authz logic is specialized by scope filter mode, and pinning exceptions
+// are applied to select unscoped and parent-scoped types that must be watchable because they have configuration
+// or policy effects.
+func (a *ScopedServerWithRoles) authorizeWatchKindCore(ctx context.Context, kind types.WatchKind) (*scopesv1.Filter, error) {
+	filter := kind.ScopeFilter.ToProto()
+	if err := scopes.ValidateFilter(filter); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// apply special watcher system specific defaulting behaviors
+	switch filter.GetMode() {
+	case scopesv1.Mode_MODE_UNSPECIFIED:
+		// certain unscoped kinds are always watchable from any scope. we override the default
+		// filter setting behavior for them.
+		// NOTE: in theory it would be more consistent to require setting UNSCOPED explicitly for the
+		// exception to be honored, however the ubiquity of CA watching and the fact that the List APIs
+		// for these types do not accept scope filter parameters makes us wary about doing that.
+		if _, ok := unscopedWatchKindException(kind.Kind); ok {
+			filter = scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build()
+		}
+	case scopesv1.Mode_MODE_ALL:
+		// As a special case, we need to translate mode ALL to DESCENDANTS@pin for scoped callers because we
+		// don't have per-event RBAC and rely on the filter matching permissions for event RBAC to work
+		// correctly.
+		// NOTE: its pssible that this could instead be an inbuilt behavior of ScopedAccessCheckerContext.ResolveScopeFilter,
+		// a reasonable argument could be made that no use of mode ALL aught to inherit unpinned exceptions.
+		if pin, ok := a.scopedContext.CheckerContext.ScopePin(); ok {
+			filter = scopesv1.Filter_builder{Scope: pin.GetScope(), Mode: scopesv1.Mode_MODE_DESCENDANTS}.Build()
+		}
+	}
+
+	// apply standard defaulting behavior (unscopded callers get UNSCOPED filter and scoped calelrs get EXACT@pin filters)
+	filter = a.scopedContext.CheckerContext.ResolveScopeFilter(filter)
+
+	// scoped-kind-whitelist: going forward all kinds updated to include a scope attribute will also be
+	// updated to support namespacing.  however, we haven't achieved full namespacing coverage yet. as such,
+	// we need to explicitly reject attempts to use a scope-specific filter against kinds that don't support
+	// namespacing since their delete events don't include `scope` yet. this check can be removed once all
+	// scoped kinds are namespaced.
+	if !supportedScopedWatchKind(kind.Kind) && filter.GetScope() != "" {
+		return nil, trace.AccessDenied("watch of kind %q with a scope-targeting filter is not supported until the kind is namespaced (unscoped callers may use mode ALL to watch all instances)", kind.Kind)
+	}
+
+	// determine the scope of the authorization decision base on filter mode. some filter modes have special
+	// behavior/rules that must be observed.
+	var decisionScope string
+	switch filter.GetMode() {
+	case scopesv1.Mode_MODE_EXACT, scopesv1.Mode_MODE_DESCENDANTS:
+		// a "standard" scoped decision
+		decisionScope = filter.GetScope()
+	case scopesv1.Mode_MODE_ALL, scopesv1.Mode_MODE_UNSCOPED:
+		// these modes select unscoped resources. mode ALL from scoped callers was rewritten to DESCENDANT@pin
+		// above. excluding the unscoped kind exceptions, scoped callers are not permitted to watch unscoped
+		// resources.
+		if _, ok := a.scopedContext.UnscopedContext(); !ok {
+			return filter, trace.Wrap(a.authorizeUnscopedWatchKindException(ctx, kind))
+		}
+		decisionScope = scopes.Unscoped
+	case scopesv1.Mode_MODE_ANCESTORS, scopesv1.Mode_MODE_RELATIVES:
+		// modes that "reach up" the scope hierarchy are only permitted for specific kinds.
+		// NOTE: per the scoped security model, it would be permissible to allow unscoped callers to use these
+		// modes for all kinds. we have omitted making that exception for simplicity's sake, but may revisit
+		// if a specific need arises.
+		if _, ok := a.scopedContext.UnscopedContext(); !ok {
+			return filter, trace.Wrap(a.authorizeAncestralWatchException(ctx, kind, filter))
+		}
+		decisionScope = scopes.Unscoped
+	default:
+		return nil, trace.BadParameter("cannot watch kind %q with unknown mode %v", kind.Kind, filter.GetMode())
+	}
+
+	verb := types.VerbReadNoSecrets
+	if kind.LoadSecrets {
+		verb = types.VerbRead
+	}
+
+	ruleCtx := a.scopedContext.RuleContext()
+	if err := a.scopedContext.CheckerContext.Decision(ctx, decisionScope, func(checker *services.ScopedAccessChecker) error {
+		return checker.CheckAccessToRules(&ruleCtx, kind.Kind, verb)
+	}); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return filter, nil
 }
 
 // DeleteAllNodes deletes all nodes in a given namespace
@@ -8848,7 +8974,7 @@ func (a *ServerWithRoles) WatchPendingHeadlessAuthentications(ctx context.Contex
 		State:    types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_PENDING,
 	}
 
-	return a.NewWatcher(ctx, types.Watch{
+	return a.ScopedServerWithRoles().NewWatcher(ctx, types.Watch{
 		Name: username,
 		Kinds: []types.WatchKind{{
 			Kind:   types.KindHeadlessAuthentication,

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -12000,13 +12000,18 @@ func TestScopedRoleEvents(t *testing.T) {
 	client, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
+	// scoped resource kinds default to only matching unscoped resources (which never exist for these
+	// kinds), so watch with an explicit MODE_ALL filter to observe scoped roles/assignments at all scopes.
+	allScopes := types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build())
 	watcher, err := client.NewWatcher(ctx, types.Watch{
 		Kinds: []types.WatchKind{
 			{
-				Kind: scopedaccess.KindScopedRole,
+				Kind:        scopedaccess.KindScopedRole,
+				ScopeFilter: allScopes,
 			},
 			{
-				Kind: scopedaccess.KindScopedRoleAssignment,
+				Kind:        scopedaccess.KindScopedRoleAssignment,
+				ScopeFilter: allScopes,
 			},
 		},
 	})
@@ -12068,12 +12073,15 @@ func TestScopedRoleEvents(t *testing.T) {
 	event = getNextEvent()
 	require.Equal(t, types.OpDelete, event.Type)
 
-	require.Empty(t, cmp.Diff(&types.ResourceHeader{
+	// delete events carry a skeleton typed resource (kind + scope + name), not a bare ResourceHeader.
+	deletedRole := event.Resource.(types.Resource153UnwrapperT[*scopedaccessv1.ScopedRole]).UnwrapT()
+	require.Empty(t, cmp.Diff(scopedaccessv1.ScopedRole_builder{
 		Kind: scopedaccess.KindScopedRole,
-		Metadata: types.Metadata{
-			Name: role.Metadata.Name,
-		},
-	}, event.Resource.(*types.ResourceHeader), protocmp.Transform()))
+		Metadata: headerv1.Metadata_builder{
+			Name: role.GetMetadata().GetName(),
+		}.Build(),
+		Scope: role.GetScope(),
+	}.Build(), deletedRole, protocmp.Transform()))
 
 	// recreate scoped role so that we can use it for testing assignment events
 	_, err = service.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
@@ -12123,13 +12131,15 @@ func TestScopedRoleEvents(t *testing.T) {
 	event = getNextEvent()
 	require.Equal(t, types.OpDelete, event.Type)
 
-	require.Empty(t, cmp.Diff(&types.ResourceHeader{
+	deletedAssignment := event.Resource.(types.Resource153UnwrapperT[*scopedaccessv1.ScopedRoleAssignment]).UnwrapT()
+	require.Empty(t, cmp.Diff(scopedaccessv1.ScopedRoleAssignment_builder{
 		Kind:    scopedaccess.KindScopedRoleAssignment,
 		SubKind: scopedaccess.SubKindDynamic,
-		Metadata: types.Metadata{
-			Name: assignment.Metadata.Name,
-		},
-	}, event.Resource.(*types.ResourceHeader), protocmp.Transform()))
+		Metadata: headerv1.Metadata_builder{
+			Name: assignment.GetMetadata().GetName(),
+		}.Build(),
+		Scope: assignment.GetScope(),
+	}.Build(), deletedAssignment, protocmp.Transform()))
 }
 
 // TestWatchAllCacheKinds ensures the system builtin roles can watch every

--- a/lib/auth/auth_with_roles_watch_authz_test.go
+++ b/lib/auth/auth_with_roles_watch_authz_test.go
@@ -1,0 +1,435 @@
+// Teleport
+// Copyright (C) 2026  Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// newScopedAgentServerWithRoles builds a ScopedServerWithRoles whose identity is a scoped agent pinned
+// at the given scope with wildcard permissions. Used for exercising the scoped watch authz logic.
+func newScopedAgentServerWithRoles(t *testing.T, pinScope string) *ScopedServerWithRoles {
+	t.Helper()
+
+	pin := scopesv1.Pin_builder{
+		Kind:        scopesv1.PinKind_PIN_KIND_AGENT,
+		Scope:       pinScope,
+		SystemRoles: scopesv1.SystemRoles_builder{Primary: string(types.RoleNode)}.Build(),
+	}.Build()
+
+	roleSet, err := services.RoleSetFromSpec("agent-role", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Rules: []types.Rule{types.NewRule(types.Wildcard, []string{types.Wildcard})},
+		},
+	})
+	require.NoError(t, err)
+
+	checker := services.NewAccessCheckerWithRoleSet(&services.AccessInfo{}, "test-cluster", roleSet)
+	checkerCtx, err := services.NewScopedAccessCheckerContextForAgentPin(pin, map[string]*services.ScopedAccessChecker{
+		string(types.RoleNode): services.NewScopedAccessCheckerForSystemRole(string(types.RoleNode), checker),
+	})
+	require.NoError(t, err)
+
+	return &ScopedServerWithRoles{
+		scopedContext: &authz.ScopedContext{
+			User:           &types.UserV2{Metadata: types.Metadata{Name: "agent"}},
+			Identity:       authz.ScopedBuiltinRole{ScopePin: pin},
+			CheckerContext: checkerCtx,
+		},
+	}
+}
+
+// TestScopedWatchKindAuthz verifies the per-mode authorization, pin enforcement, and scoped kind whitelist
+// applied to watch kinds requested by a scoped identity.
+func TestScopedWatchKindAuthz(t *testing.T) {
+	ctx := context.Background()
+	const pinScope = "/foo"
+	a := newScopedAgentServerWithRoles(t, pinScope)
+
+	filter := func(mode scopesv1.Mode, scope string) *types.ScopeFilter {
+		return types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: mode, Scope: scope}.Build())
+	}
+
+	tests := []struct {
+		name        string
+		kind        string
+		filter      *types.ScopeFilter
+		loadSecrets bool
+		assertErr   require.ErrorAssertionFunc
+		wantMode    scopesv1.Mode
+		wantScope   string
+	}{
+		{
+			name:      "scoped_role default resolves to EXACT at pin",
+			kind:      scopedaccess.KindScopedRole,
+			filter:    nil,
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_EXACT,
+			wantScope: pinScope,
+		},
+		{
+			name:      "scoped_role EXACT at pin",
+			kind:      scopedaccess.KindScopedRole,
+			filter:    filter(scopesv1.Mode_MODE_EXACT, pinScope),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_EXACT,
+			wantScope: pinScope,
+		},
+		{
+			name:      "scoped_role EXACT at descendant of pin",
+			kind:      scopedaccess.KindScopedRole,
+			filter:    filter(scopesv1.Mode_MODE_EXACT, "/foo/sub"),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_EXACT,
+			wantScope: "/foo/sub",
+		},
+		{
+			name:      "scoped_role DESCENDANTS at pin",
+			kind:      scopedaccess.KindScopedRole,
+			filter:    filter(scopesv1.Mode_MODE_DESCENDANTS, pinScope),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_DESCENDANTS,
+			wantScope: pinScope,
+		},
+		{
+			name:      "scoped_role ALL rewritten to DESCENDANTS at pin",
+			kind:      scopedaccess.KindScopedRole,
+			filter:    filter(scopesv1.Mode_MODE_ALL, ""),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_DESCENDANTS,
+			wantScope: pinScope,
+		},
+		{
+			name:      "scoped_role EXACT at orthogonal scope denied by pin enforcement",
+			kind:      scopedaccess.KindScopedRole,
+			filter:    filter(scopesv1.Mode_MODE_EXACT, "/bar"),
+			assertErr: requireAccessDenied,
+		},
+		{
+			name:      "scoped_role EXACT at ancestor of pin denied by pin enforcement",
+			kind:      scopedaccess.KindScopedRole,
+			filter:    filter(scopesv1.Mode_MODE_EXACT, scopes.Root),
+			assertErr: requireAccessDenied,
+		},
+		{
+			name:      "scoped_role ANCESTORS at pin allowed for agent via ancestral exception",
+			kind:      scopedaccess.KindScopedRole,
+			filter:    filter(scopesv1.Mode_MODE_ANCESTORS, pinScope),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_ANCESTORS,
+			wantScope: pinScope,
+		},
+		{
+			name:      "scoped_role RELATIVES at pin allowed for agent via ancestral exception",
+			kind:      scopedaccess.KindScopedRole,
+			filter:    filter(scopesv1.Mode_MODE_RELATIVES, pinScope),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_RELATIVES,
+			wantScope: pinScope,
+		},
+		{
+			name:      "scoped_role ANCESTORS at descendant of pin allowed for agent",
+			kind:      scopedaccess.KindScopedRole,
+			filter:    filter(scopesv1.Mode_MODE_ANCESTORS, "/foo/sub"),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_ANCESTORS,
+			wantScope: "/foo/sub",
+		},
+		{
+			name:      "scoped_role ANCESTORS at orthogonal scope denied",
+			kind:      scopedaccess.KindScopedRole,
+			filter:    filter(scopesv1.Mode_MODE_ANCESTORS, "/bar"),
+			assertErr: requireAccessDenied,
+		},
+		{
+			// the filter scope must be subject to the pin. while unpinned read exceptions permit reads
+			// of parent scopes, a filter at a parent scope would also match orthogonal resources, which
+			// unpinned read exceptions do not cover.
+			name:      "scoped_role ANCESTORS at ancestor of pin denied",
+			kind:      scopedaccess.KindScopedRole,
+			filter:    filter(scopesv1.Mode_MODE_ANCESTORS, scopes.Root),
+			assertErr: requireAccessDenied,
+		},
+		{
+			name:        "scoped_role ANCESTORS with secrets denied",
+			kind:        scopedaccess.KindScopedRole,
+			filter:      filter(scopesv1.Mode_MODE_ANCESTORS, pinScope),
+			loadSecrets: true,
+			assertErr:   requireAccessDenied,
+		},
+		{
+			// the choice of scoped role assignment in this test-case is arbitrary, we're just varifying
+			// that ancestral watch isn't permitted for a kind that we haven't written an exception for.
+			name:      "scoped_role_assignment ANCESTORS denied",
+			kind:      scopedaccess.KindScopedRoleAssignment,
+			filter:    filter(scopesv1.Mode_MODE_ANCESTORS, pinScope),
+			assertErr: requireAccessDenied,
+		},
+		{
+			name:      "scoped_role UNSCOPED denied for scoped caller",
+			kind:      scopedaccess.KindScopedRole,
+			filter:    filter(scopesv1.Mode_MODE_UNSCOPED, ""),
+			assertErr: requireAccessDenied,
+		},
+		{
+			// scoped-kind-whitelist: this test case and associated behaviore can be removed once all scoped
+			// kinds are namespaced.
+			name:      "non-namespaced kind EXACT denied by whitelist",
+			kind:      types.KindNode,
+			filter:    filter(scopesv1.Mode_MODE_EXACT, pinScope),
+			assertErr: requireAccessDenied,
+		},
+		{
+			// scoped-kind-whitelist: this test case and associated behaviore can be removed once all scoped
+			// kinds are namespaced.
+			name:      "non-namespaced kind ALL denied by whitelist for scoped caller",
+			kind:      types.KindNode,
+			filter:    filter(scopesv1.Mode_MODE_ALL, ""),
+			assertErr: requireAccessDenied,
+		},
+		{
+			name:      "malformed filter (mode without scope) rejected",
+			kind:      scopedaccess.KindScopedRole,
+			filter:    filter(scopesv1.Mode_MODE_EXACT, ""),
+			assertErr: requireBadParameter,
+		},
+		{
+			name:      "malformed filter (scope without mode) rejected",
+			kind:      scopedaccess.KindScopedRole,
+			filter:    filter(scopesv1.Mode_MODE_UNSPECIFIED, pinScope),
+			assertErr: requireBadParameter,
+		},
+		{
+			name:      "cert_authority UNSCOPED allowed via unscoped-kind exception",
+			kind:      types.KindCertAuthority,
+			filter:    filter(scopesv1.Mode_MODE_UNSCOPED, ""),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_UNSCOPED,
+		},
+		{
+			name:      "spiffe_federation UNSCOPED allowed via unscoped-kind exception",
+			kind:      types.KindSPIFFEFederation,
+			filter:    filter(scopesv1.Mode_MODE_UNSCOPED, ""),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_UNSCOPED,
+		},
+		{
+			name:        "cert_authority UNSCOPED with secrets denied",
+			kind:        types.KindCertAuthority,
+			filter:      filter(scopesv1.Mode_MODE_UNSCOPED, ""),
+			loadSecrets: true,
+			assertErr:   requireAccessDenied,
+		},
+		{
+			// unscoped-kind exception translates missing filters to UNSCOPED even for scoped callers
+			name:      "cert_authority default resolves to UNSCOPED via unscoped-kind exception",
+			kind:      types.KindCertAuthority,
+			filter:    nil,
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_UNSCOPED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := a.authorizeWatchKind(ctx, types.WatchKind{Kind: tt.kind, ScopeFilter: tt.filter, LoadSecrets: tt.loadSecrets})
+			tt.assertErr(t, err)
+			if err != nil {
+				return
+			}
+			require.Equal(t, tt.wantMode, got.GetMode())
+			require.Equal(t, tt.wantScope, got.GetScope())
+
+			// authorizeWatchRequest writes the effective filter back onto the accepted kind.
+			watch := types.Watch{Kinds: []types.WatchKind{{Kind: tt.kind, ScopeFilter: tt.filter, LoadSecrets: tt.loadSecrets}}}
+			require.NoError(t, a.authorizeWatchRequest(ctx, &watch))
+			require.Len(t, watch.Kinds, 1)
+			require.Equal(t, tt.wantMode, watch.Kinds[0].ScopeFilter.ToProto().GetMode())
+			require.Equal(t, tt.wantScope, watch.Kinds[0].ScopeFilter.ToProto().GetScope())
+		})
+	}
+}
+
+// TestAncestralWatchExceptionServiceSpecific verifies that the scoped-role ancestral watch exception is
+// restricted to service identities. A user with equivalent permissions is denied.
+func TestAncestralWatchExceptionServiceSpecific(t *testing.T) {
+	ctx := context.Background()
+	const pinScope = "/foo"
+	a := newScopedAgentServerWithRoles(t, pinScope)
+
+	// same checker context, but a non-service identity.
+	userCtx := *a.scopedContext
+	userCtx.Identity = authz.LocalUser{}
+	u := &ScopedServerWithRoles{scopedContext: &userCtx}
+
+	kind := types.WatchKind{
+		Kind: scopedaccess.KindScopedRole,
+		ScopeFilter: types.ScopeFilterFromProto(
+			scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ANCESTORS, Scope: pinScope}.Build(),
+		),
+	}
+
+	_, err := a.authorizeWatchKind(ctx, kind)
+	require.NoError(t, err)
+
+	_, err = u.authorizeWatchKind(ctx, kind)
+	requireAccessDenied(t, err)
+	require.ErrorContains(t, err, "non-service identities are not permitted to watch")
+}
+
+func requireAccessDenied(t require.TestingT, err error, _ ...any) {
+	require.Error(t, err)
+	require.True(t, trace.IsAccessDenied(err), "expected AccessDenied, got %v", err)
+}
+
+func requireBadParameter(t require.TestingT, err error, _ ...any) {
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
+}
+
+// newUnscopedServerWithRoles builds a ScopedServerWithRoles whose identity is a classical unscoped
+// caller with wildcard permissions. Used for exercising the unscoped side of the scoped watch authz.
+func newUnscopedServerWithRoles(t *testing.T) *ScopedServerWithRoles {
+	t.Helper()
+
+	roleSet, err := services.RoleSetFromSpec("admin-role", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Rules: []types.Rule{types.NewRule(types.Wildcard, []string{types.Wildcard})},
+		},
+	})
+	require.NoError(t, err)
+
+	unscopedCtx := &authz.Context{
+		User:    &types.UserV2{Metadata: types.Metadata{Name: "admin"}},
+		Checker: services.NewAccessCheckerWithRoleSet(&services.AccessInfo{}, "test-cluster", roleSet),
+	}
+	return &ScopedServerWithRoles{
+		scopedContext: authz.ScopedContextFromUnscopedContext(unscopedCtx),
+	}
+}
+
+// TestUnscopedWatchKindAuthz verifies the scoped watch authz for classical unscoped callers on the
+// scoped-first path: they default to (and may only scope-target via) safe filters, and can opt into all
+// instances of a not-yet-namespaced kind via MODE_ALL.
+func TestUnscopedWatchKindAuthz(t *testing.T) {
+	ctx := context.Background()
+	a := newUnscopedServerWithRoles(t)
+
+	filter := func(mode scopesv1.Mode, scope string) *types.ScopeFilter {
+		return types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: mode, Scope: scope}.Build())
+	}
+
+	tests := []struct {
+		name      string
+		kind      string
+		filter    *types.ScopeFilter
+		assertErr require.ErrorAssertionFunc
+		wantMode  scopesv1.Mode
+	}{
+		{
+			name:      "non-namespaced kind defaults to UNSCOPED",
+			kind:      types.KindNode,
+			filter:    nil,
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_UNSCOPED,
+		},
+		{
+			// scoped-kind-whitelist: this test case and associated behaviore can be removed once all scoped
+			// kinds are namespaced.
+			name:      "non-namespaced kind ALL is allowed for unscoped caller",
+			kind:      types.KindNode,
+			filter:    filter(scopesv1.Mode_MODE_ALL, ""),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_ALL,
+		},
+		{
+			// scoped-kind-whitelist: this test case and associated behaviore can be removed once all scoped
+			// kinds are namespaced.
+			name:      "non-namespaced kind EXACT denied by whitelist",
+			kind:      types.KindNode,
+			filter:    filter(scopesv1.Mode_MODE_EXACT, "/foo"),
+			assertErr: requireAccessDenied,
+		},
+		{
+			// this may seem somewhat nonsensical in this specific example, but in general we aren't actually
+			// attempting to prevent the creation of filters that will never match anything, so long as said
+			// filters are sound from a cache-correctness point of view.
+			name:      "scoped_role defaults to UNSCOPED for unscoped caller",
+			kind:      scopedaccess.KindScopedRole,
+			filter:    nil,
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_UNSCOPED,
+		},
+		{
+			name:      "scoped_role ALL allowed for unscoped caller",
+			kind:      scopedaccess.KindScopedRole,
+			filter:    filter(scopesv1.Mode_MODE_ALL, ""),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_ALL,
+		},
+		{
+			name:      "scoped_role EXACT allowed for unscoped caller",
+			kind:      scopedaccess.KindScopedRole,
+			filter:    filter(scopesv1.Mode_MODE_EXACT, "/foo"),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_EXACT,
+		},
+		{
+			name:      "scoped_role ANCESTORS allowed for unscoped caller (ordinary decision at root)",
+			kind:      scopedaccess.KindScopedRole,
+			filter:    filter(scopesv1.Mode_MODE_ANCESTORS, "/foo"),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_ANCESTORS,
+		},
+		{
+			name:      "malformed filter (mode without scope) rejected",
+			kind:      scopedaccess.KindScopedRole,
+			filter:    filter(scopesv1.Mode_MODE_EXACT, ""),
+			assertErr: requireBadParameter,
+		},
+		{
+			// scoped-kind-whitelist: this test case and associated behaviore can be removed once all scoped
+			// kinds are namespaced.
+			name:      "cert_authority scope-targeting filter denied by whitelist",
+			kind:      types.KindCertAuthority,
+			filter:    filter(scopesv1.Mode_MODE_EXACT, "/foo"),
+			assertErr: requireAccessDenied,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := a.authorizeWatchKind(ctx, types.WatchKind{Kind: tt.kind, ScopeFilter: tt.filter})
+			tt.assertErr(t, err)
+			if err != nil {
+				return
+			}
+			require.Equal(t, tt.wantMode, got.GetMode())
+		})
+	}
+}

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -52,6 +52,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
 	"github.com/gravitational/teleport/api/metadata"
@@ -4552,7 +4553,7 @@ func TestEventsPermissionsPartialSuccess(t *testing.T) {
 				AllowPartialSuccess: true,
 			},
 			expectedConfirmedKinds: []types.WatchKind{
-				{Kind: types.KindStaticTokens},
+				{Kind: types.KindStaticTokens, ScopeFilter: types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build())},
 			},
 		},
 		{
@@ -4945,7 +4946,7 @@ func runEventsTests(t *testing.T, testCases []eventTest, events types.Events, wa
 		require.Equal(t, types.OpInit, event.Type)
 		watchStatus, ok := event.Resource.(types.WatchStatus)
 		require.True(t, ok)
-		expectedKinds := eventsTestKinds(testCases)
+		expectedKinds := eventsTestConfirmedKinds(testCases)
 		require.Equal(t, expectedKinds, watchStatus.GetKinds())
 	case <-w.Done():
 		t.Fatalf("Watcher exited with error %v", w.Error())
@@ -5017,6 +5018,16 @@ func eventsTestKinds(tests []eventTest) []types.WatchKind {
 	out := make([]types.WatchKind, len(tests))
 	for i, tc := range tests {
 		out[i] = tc.kind
+	}
+	return out
+}
+
+// eventsTestConfirmedKinds returns the watch kinds as the server confirms them for an unscoped watcher:
+// every kind's confirmed watch kind carries the caller's defaulted MODE_UNSCOPED scope filter.
+func eventsTestConfirmedKinds(tests []eventTest) []types.WatchKind {
+	out := eventsTestKinds(tests)
+	for i := range out {
+		out[i].ScopeFilter = types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build())
 	}
 	return out
 }

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -39,6 +39,7 @@ import (
 	authproto "github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	apitracing "github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/types"
@@ -235,6 +236,10 @@ func ForAuth(cfg Config) Config {
 // ForProxy sets up watch configuration for proxy
 func ForProxy(cfg Config) Config {
 	cfg.target = "proxy"
+	// Scope-aware kinds default (for unscoped callers) to matching only unscoped instances. The proxy is
+	// unscoped but must see all instances (scoped and unscoped) of the resources it routes on, so it
+	// watches those kinds with an explicit MODE_ALL filter.
+	allScopes := types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build())
 	cfg.Watches = []types.WatchKind{
 		{Kind: types.KindCertAuthority, LoadSecrets: false, Filter: makeAllKnownCAsFilter().IntoMap()},
 		{Kind: types.KindClusterName},
@@ -245,26 +250,26 @@ func ForProxy(cfg Config) Config {
 		{Kind: types.KindUIConfig},
 		{Kind: types.KindUser},
 		{Kind: types.KindRole},
-		{Kind: types.KindNode},
+		{Kind: types.KindNode, ScopeFilter: allScopes},
 		{Kind: types.KindProxy},
 		{Kind: types.KindAuthServer},
 		{Kind: types.KindReverseTunnel},
 		{Kind: types.KindTunnelConnection},
-		{Kind: types.KindAppServer},
-		{Kind: types.KindApp},
+		{Kind: types.KindAppServer, ScopeFilter: allScopes},
+		{Kind: types.KindApp, ScopeFilter: allScopes},
 		{Kind: types.KindWebSession, SubKind: types.KindSnowflakeSession, LoadSecrets: true},
 		{Kind: types.KindWebSession, SubKind: types.KindAppSession, LoadSecrets: true},
 		{Kind: types.KindWebSession, SubKind: types.KindWebSession, LoadSecrets: true},
 		{Kind: types.KindWebToken},
 		{Kind: types.KindRemoteCluster},
-		{Kind: types.KindDatabaseServer},
+		{Kind: types.KindDatabaseServer, ScopeFilter: allScopes},
 		{Kind: types.KindDatabaseService},
 		{Kind: types.KindDatabase},
 		{Kind: types.KindWindowsDesktopService},
 		{Kind: types.KindWindowsDesktop},
 		{Kind: types.KindDynamicWindowsDesktop},
-		{Kind: types.KindKubeServer},
-		{Kind: types.KindKubernetesCluster},
+		{Kind: types.KindKubeServer, ScopeFilter: allScopes},
+		{Kind: types.KindKubernetesCluster, ScopeFilter: allScopes},
 		{Kind: types.KindSAMLIdPServiceProvider},
 		{Kind: types.KindUserGroup},
 		{Kind: types.KindIntegration},

--- a/lib/kube/proxy/watcher/watcher.go
+++ b/lib/kube/proxy/watcher/watcher.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"github.com/gravitational/teleport"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -241,7 +242,12 @@ func (w *ProxyKubeServerWatcher) createWatcherAndInit() (_ types.Watcher, err er
 	watcher, err := w.AccessPoint.NewWatcher(w.ctx, types.Watch{
 		Name:            componentName,
 		MetricComponent: componentName,
-		Kinds:           []types.WatchKind{{Kind: types.KindKubeServer}},
+		// The proxy kube server watcher only ever runs on the teleport proxy, and the proxy must route
+		// to kube servers in every scope, so it watches with MODE_ALL rather than the default UNSCOPED/EXACT.
+		Kinds: []types.WatchKind{{
+			Kind:        types.KindKubeServer,
+			ScopeFilter: types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build()),
+		}},
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating a watcher")
@@ -379,6 +385,11 @@ func kubeServerDeleteKey(resource types.Resource) serverKey {
 
 // getAllKubeServers fetches all kube servers from the given getter and returns them as a map keyed by the watcher's cache keys.
 func (w *ProxyKubeServerWatcher) getAllKubeServers(ctx context.Context, getter KubernetesServerGetter) (map[serverKey]types.KubeServer, error) {
+	// TODO(fspmarshall/scopes): this list seed does not yet honor scope filters, so it currently
+	// returns kube servers in every scope and happens to match the MODE_ALL watch in
+	// createWatcherAndInit. Once the list API supports scope filters (and defaults unscoped callers
+	// to unscoped-only, like the watch API), this call must explicitly request MODE_ALL as well, or
+	// the proxy will be unable to route to scoped kube servers.
 	resources, err := getter.GetKubernetesServers(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/scopes/cache/access/access.go
+++ b/lib/scopes/cache/access/access.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/observability/tracing"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/cache/assignments"
 	"github.com/gravitational/teleport/lib/scopes/cache/roles"
@@ -437,11 +438,25 @@ func processEvent(ctx context.Context, state state, event types.Event) error {
 	case types.OpDelete:
 		switch event.Resource.GetKind() {
 		case scopedaccess.KindScopedRole:
-			state.roles.Delete(event.Resource.GetName())
+			role, err := types.ConvertResource[*scopedaccessv1.ScopedRole](event.Resource)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			state.roles.Delete(scopes.QualifiedName{
+				Scope: role.GetScope(),
+				Name:  role.GetMetadata().GetName(),
+			})
 		case scopedaccess.KindScopedRoleAssignment:
-			state.assignments.Delete(event.Resource.GetName(), event.Resource.GetSubKind())
+			assignment, err := types.ConvertResource[*scopedaccessv1.ScopedRoleAssignment](event.Resource)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			state.assignments.Delete(scopes.QualifiedName{
+				Scope: assignment.GetScope(),
+				Name:  assignment.GetMetadata().GetName(),
+			}, assignment.GetSubKind())
 		default:
-			return trace.BadParameter("unexpected resource kind %q in event delete event", event.Resource.GetKind())
+			return trace.BadParameter("unexpected resource kind %q in delete event", event.Resource.GetKind())
 		}
 	default:
 		slog.WarnContext(ctx, "scoped access cache skipping unexpected event type", "event_type", event.Type)

--- a/lib/scopes/cache/access/materializer.go
+++ b/lib/scopes/cache/access/materializer.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -73,7 +74,7 @@ type AccessListReader interface {
 // materialized assignments.
 type AssignmentStore interface {
 	Put(assignment *scopedaccessv1.ScopedRoleAssignment) error
-	Delete(name, subKind string)
+	Delete(assignment scopes.QualifiedName, subKind string)
 }
 
 // listAccessListMembers is a helper for calling clientutils.Resources to range
@@ -835,10 +836,10 @@ func (m *Materializer) materializeAssignment(
 		Kind:    scopedaccess.KindScopedRoleAssignment,
 		SubKind: scopedaccess.SubKindMaterialized,
 		Version: types.V1,
-		Scope:   "/",
-		Metadata: &headerv1.Metadata{
+		Scope:   scopes.Root,
+		Metadata: headerv1.Metadata_builder{
 			Name: key.AssignmentName(),
-		},
+		}.Build(),
 		Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 			User: userName,
 		},
@@ -883,7 +884,10 @@ func (m *Materializer) deleteMaterializedAssignment(ctx context.Context, key Mat
 		m.logger.DebugContext(ctx, "Deleting materialized scoped role assignment",
 			"user", key.User,
 			"list", key.List)
-		m.assignmentStore.Delete(key.AssignmentName(), scopedaccess.SubKindMaterialized)
+		m.assignmentStore.Delete(scopes.QualifiedName{
+			Scope: scopes.Root,
+			Name:  key.AssignmentName(),
+		}, scopedaccess.SubKindMaterialized)
 		delete(m.materializedAssignments, key)
 		m.syncMaterializedAssignmentsMetric()
 

--- a/lib/scopes/cache/assignments/assignment_cache.go
+++ b/lib/scopes/cache/assignments/assignment_cache.go
@@ -88,17 +88,14 @@ func (c *AssignmentCache) GetScopedRoleAssignment(ctx context.Context, req *scop
 		return nil, trace.BadParameter("missing scoped role assignment name in get request")
 	}
 
-	assignment, ok := c.cache.Get(assignmentKey{
-		name:    req.GetName(),
-		subKind: req.GetSubKind(),
-	}.String())
+	assignment, ok := c.cache.Get(cache.ScopedKey[string]{
+		Scope: req.GetScope(),
+		Key: assignmentKey{
+			name:    req.GetName(),
+			subKind: req.GetSubKind(),
+		}.String(),
+	})
 	if !ok {
-		return nil, trace.NotFound("scoped role assignment %q not found", req.GetName())
-	}
-
-	// emulate namespace-like behavior by treating mismatched scopes as NotFound (prep for the transition
-	// to true namespacing).
-	if scopes.Compare(req.GetScope(), assignment.GetScope()) != scopes.Equivalent {
 		return nil, trace.NotFound("scoped role assignment %q not found in scope %q", req.GetName(), req.GetScope())
 	}
 
@@ -200,12 +197,15 @@ func (c *AssignmentCache) Put(assignment *scopedaccessv1.ScopedRoleAssignment) e
 	return nil
 }
 
-// Delete removes an assignment from the cache by name.
-func (c *AssignmentCache) Delete(name, subKind string) {
-	c.cache.Del(assignmentKey{
-		name:    name,
-		subKind: subKind,
-	}.String())
+// Delete removes an assignment from the cache by its scope-qualified name and sub-kind.
+func (c *AssignmentCache) Delete(assignment scopes.QualifiedName, subKind string) {
+	c.cache.Del(cache.ScopedKey[string]{
+		Scope: assignment.Scope,
+		Key: assignmentKey{
+			name:    assignment.Name,
+			subKind: subKind,
+		}.String(),
+	})
 }
 
 // Len returns the total number of assignments in the cache.

--- a/lib/scopes/cache/cache.go
+++ b/lib/scopes/cache/cache.go
@@ -35,7 +35,7 @@ import (
 type Cursor[K cmp.Ordered] struct {
 	// Scope is the scope to resume from.
 	Scope string
-	// Key is the primary key of the item to resume from.
+	// Key is the key of the item to resume from.
 	Key K
 }
 
@@ -52,11 +52,19 @@ type options[T any, K cmp.Ordered] struct {
 	filter func(T) bool
 }
 
+// ScopedKey uniquely identifies a value within the cache by its scope and key.
+type ScopedKey[K cmp.Ordered] struct {
+	// Scope is the scope of the target value.
+	Scope string
+	// Key is the key of the target value within its scope.
+	Key K
+}
+
 // Config configures a cache.
 type Config[T any, K cmp.Ordered] struct {
 	// Scope is the function used to determine the scope of a value.
 	Scope func(T) string
-	// Key is the function used to determine the primary key of a value.
+	// Key is the function used to determine the key of a value.
 	Key func(T) K
 	// Clone is an optional clone function that can be used to create deep copies
 	// of values prior to yielding them.
@@ -64,18 +72,18 @@ type Config[T any, K cmp.Ordered] struct {
 }
 
 // node is a tree node in the cache which stores values at a given scope.
-type node[K cmp.Ordered] struct {
-	// members is the set of values "at" this scope.
-	members *sortmap.Map[K, struct{}]
+type node[K cmp.Ordered, T any] struct {
+	// members is the set of values "at" this scope indexed by key.
+	members *sortmap.Map[K, T]
 
 	// children is the set of child scopes.
-	children *sortmap.Map[string, *node[K]]
+	children *sortmap.Map[string, *node[K, T]]
 }
 
-func newNode[K cmp.Ordered]() *node[K] {
-	return &node[K]{
-		members:  sortmap.New[K, struct{}](),
-		children: sortmap.New[string, *node[K]](),
+func newNode[K cmp.Ordered, T any]() *node[K, T] {
+	return &node[K, T]{
+		members:  sortmap.New[K, T](),
+		children: sortmap.New[string, *node[K, T]](),
 	}
 }
 
@@ -89,10 +97,9 @@ func newNode[K cmp.Ordered]() *node[K] {
 //   - Iteration order of read methods is nondeterministic.
 //   - No cleanup of empty scopes.
 type Cache[T any, K cmp.Ordered] struct {
-	cfg   Config[T, K]
-	rw    sync.RWMutex
-	items map[K]T
-	root  *node[K]
+	cfg  Config[T, K]
+	rw   sync.RWMutex
+	root *node[K, T]
 }
 
 // New builds a new cache instance based on the supplied config.
@@ -110,8 +117,7 @@ func New[T any, K cmp.Ordered](cfg Config[T, K]) (*Cache[T, K], error) {
 	}
 
 	return &Cache[T, K]{
-		cfg:   cfg,
-		items: make(map[K]T),
+		cfg: cfg,
 	}, nil
 }
 
@@ -126,7 +132,7 @@ func Must[T any, K cmp.Ordered](cfg Config[T, K]) *Cache[T, K] {
 	return cache
 }
 
-// KeyOf returns the primary key of the given value.
+// KeyOf returns the key of the given value.
 func (c *Cache[T, K]) KeyOf(value T) K {
 	return c.cfg.Key(value)
 }
@@ -149,12 +155,26 @@ func (c *Cache[T, K]) WithFilter(filter func(T) bool) Option[T, K] {
 	}
 }
 
-// Get retrieves the value associated with the given primary key.
-func (c *Cache[T, K]) Get(key K) (T, bool) {
+// Get retrieves the value associated with the given scope and key.
+func (c *Cache[T, K]) Get(sk ScopedKey[K]) (T, bool) {
 	c.rw.RLock()
 	defer c.rw.RUnlock()
 
-	value, ok := c.items[key]
+	if c.root == nil {
+		return *new(T), false
+	}
+
+	// navigate to the node for the requested scope.
+	current := c.root
+	for segment := range scopes.DescendingSegments(sk.Scope) {
+		var ok bool
+		current, ok = current.children.Get(segment)
+		if !ok {
+			return *new(T), false
+		}
+	}
+
+	value, ok := current.members.Get(sk.Key)
 	if !ok {
 		return *new(T), false
 	}
@@ -242,7 +262,7 @@ func (c *Cache[T, K]) ExactScope(scope string, opts ...Option[T, K]) iter.Seq[Sc
 		}
 
 		// yield only the members at exactly the target scope (no recursion into descendants).
-		if !maybeYieldScopedItems(yield, visited, &descender, current.members, c.items, c.cfg.Clone, options.filter) {
+		if !maybeYieldScopedItems(yield, visited, &descender, current.members, c.cfg.Clone, options.filter) {
 			return
 		}
 	}
@@ -275,7 +295,7 @@ func (c *Cache[T, K]) ScopeAndAncestors(scope string, opts ...Option[T, K]) iter
 		defer descender.Stop()
 
 		for segment := range scopes.DescendingSegments(scope) {
-			if !maybeYieldScopedItems(yield, visited, &descender, current.members, c.items, c.cfg.Clone, options.filter) {
+			if !maybeYieldScopedItems(yield, visited, &descender, current.members, c.cfg.Clone, options.filter) {
 				return
 			}
 
@@ -294,7 +314,7 @@ func (c *Cache[T, K]) ScopeAndAncestors(scope string, opts ...Option[T, K]) iter
 		}
 
 		// yield the final scope if it is non-empty
-		if !maybeYieldScopedItems(yield, visited, &descender, current.members, c.items, c.cfg.Clone, options.filter) {
+		if !maybeYieldScopedItems(yield, visited, &descender, current.members, c.cfg.Clone, options.filter) {
 			return
 		}
 	}
@@ -344,7 +364,7 @@ func (c *Cache[T, K]) ScopeAndDescendants(scope string, opts ...Option[T, K]) it
 		}
 
 		// recursively yield starting position and all of its descendants
-		if !recursiveYield(yield, visited, &descender, current, c.items, c.cfg.Clone, options.filter) {
+		if !recursiveYield(yield, visited, &descender, current, c.cfg.Clone, options.filter) {
 			return
 		}
 	}
@@ -380,7 +400,7 @@ func (c *Cache[T, K]) ScopeAndRelatives(scope string, opts ...Option[T, K]) iter
 		defer descender.Stop()
 
 		for segment := range scopes.DescendingSegments(scope) {
-			if !maybeYieldScopedItems(yield, visited, &descender, current.members, c.items, c.cfg.Clone, options.filter) {
+			if !maybeYieldScopedItems(yield, visited, &descender, current.members, c.cfg.Clone, options.filter) {
 				return
 			}
 
@@ -401,7 +421,7 @@ func (c *Cache[T, K]) ScopeAndRelatives(scope string, opts ...Option[T, K]) iter
 		}
 
 		// recursively yield current position and all of its descendants
-		if !recursiveYield(yield, visited, &descender, current, c.items, c.cfg.Clone, options.filter) {
+		if !recursiveYield(yield, visited, &descender, current, c.cfg.Clone, options.filter) {
 			return
 		}
 	}
@@ -409,9 +429,9 @@ func (c *Cache[T, K]) ScopeAndRelatives(scope string, opts ...Option[T, K]) iter
 
 // recursiveYield is a helper function for recursively yielding all members of a given scope node, and all
 // members of all of its children. The returned bool is the return value of the last call to yield.
-func recursiveYield[T any, K cmp.Ordered](yield func(ScopedItems[T]) bool, visited []string, descender *descender[K], current *node[K], items map[K]T, clone func(T) T, filter func(T) bool) bool {
+func recursiveYield[T any, K cmp.Ordered](yield func(ScopedItems[T]) bool, visited []string, descender *descender[K], current *node[K, T], clone func(T) T, filter func(T) bool) bool {
 	// yield the current scope if we've finished descending to resume position and it is non-empty
-	if !maybeYieldScopedItems(yield, visited, descender, current.members, items, clone, filter) {
+	if !maybeYieldScopedItems(yield, visited, descender, current.members, clone, filter) {
 		return false
 	}
 
@@ -420,7 +440,7 @@ func recursiveYield[T any, K cmp.Ordered](yield func(ScopedItems[T]) bool, visit
 		descender.Descend(segment)
 
 		// recursively yield all child and all of its descendants
-		if !recursiveYield(yield, append(visited, segment), descender, child, items, clone, filter) {
+		if !recursiveYield(yield, append(visited, segment), descender, child, clone, filter) {
 			return false
 		}
 	}
@@ -428,8 +448,23 @@ func recursiveYield[T any, K cmp.Ordered](yield func(ScopedItems[T]) bool, visit
 	return true
 }
 
+// recursiveLen is a helper function for recursively counting all members of a given scope node, and all
+// members of its children.
+func recursiveLen[T any, K cmp.Ordered](current *node[K, T]) int {
+	if current == nil {
+		return 0
+	}
+
+	count := current.members.Len()
+	for _, child := range current.children.Ascend("") {
+		count += recursiveLen(child)
+	}
+
+	return count
+}
+
 // Put inserts the given value, potentially displacing an existing value with the same
-// primary key.
+// scope and key.
 func (c *Cache[T, K]) Put(value T) {
 	c.rw.Lock()
 	defer c.rw.Unlock()
@@ -437,62 +472,48 @@ func (c *Cache[T, K]) Put(value T) {
 	// get scope and key for this value
 	scope, key := c.cfg.Scope(value), c.cfg.Key(value)
 
-	// ensure that any previous value at this primary key has been removed
-	c.deleteLocked(key)
-
 	if c.root == nil {
-		c.root = newNode[K]()
+		c.root = newNode[K, T]()
 	}
 
 	// find the node for this scope
 	current := c.root
 	for segment := range scopes.DescendingSegments(scope) {
-		current = current.children.GetOrCreate(segment, newNode[K])
+		current = current.children.GetOrCreate(segment, newNode[K, T])
 	}
 
 	// add the value to the set of members at this scope
-	current.members.Set(key, struct{}{})
-
-	// add the value to the set of members at this primary key
-	c.items[key] = value
+	current.members.Set(key, value)
 }
 
-// Del deletes the value associated with the given primary key.
-func (c *Cache[T, K]) Del(key K) {
+// Del deletes the value associated with the given scope and key.
+func (c *Cache[T, K]) Del(sk ScopedKey[K]) {
 	c.rw.Lock()
 	defer c.rw.Unlock()
 
-	c.deleteLocked(key)
-}
-
-func (c *Cache[T, K]) deleteLocked(key K) {
-	// get the value associated with this primary key
-	value, ok := c.items[key]
-	if !ok {
+	if c.root == nil {
 		return
 	}
 
-	// determine the scope for this value
-	scope := c.cfg.Scope(value)
-
-	// get the node for this scope
+	// navigate to the node for the requested scope.
 	current := c.root
-	for segment := range scopes.DescendingSegments(scope) {
-		current, _ = current.children.Get(segment)
+	for segment := range scopes.DescendingSegments(sk.Scope) {
+		var ok bool
+		current, ok = current.children.Get(segment)
+		if !ok {
+			return
+		}
 	}
 
-	// remove the value from the set of members at this scope
-	current.members.Del(key)
-
-	// remove the value from the set of members at this primary key
-	delete(c.items, key)
+	current.members.Del(sk.Key)
 }
 
 // Len gets the total number of unique items stored in the cache.
 func (c *Cache[T, K]) Len() int {
 	c.rw.RLock()
 	defer c.rw.RUnlock()
-	return len(c.items)
+
+	return recursiveLen(c.root)
 }
 
 // ScopedItems provides the canonical representation of a scope and an iterator over the items within it. Typically
@@ -517,7 +538,7 @@ func (s *ScopedItems[T]) Items() iter.Seq[T] {
 	return s.items()
 }
 
-func maybeYieldScopedItems[T any, K cmp.Ordered](yield func(ScopedItems[T]) bool, segments []string, descender *descender[K], members *sortmap.Map[K, struct{}], items map[K]T, clone func(T) T, filter func(T) bool) bool {
+func maybeYieldScopedItems[T any, K cmp.Ordered](yield func(ScopedItems[T]) bool, segments []string, descender *descender[K], members *sortmap.Map[K, T], clone func(T) T, filter func(T) bool) bool {
 
 	if !descender.Yield() || members.Len() == 0 {
 		// we are still descending to a cursor position or there are no items to yield
@@ -530,8 +551,8 @@ func maybeYieldScopedItems[T any, K cmp.Ordered](yield func(ScopedItems[T]) bool
 		// we don't want to yield a scope unless it contains at least one value that matches the filter,
 		// so we seek to the position of the first item prior to yielding.
 		var foundMatch bool
-		for key, _ := range members.Ascend(start) {
-			if !filter(items[key]) {
+		for key, val := range members.Ascend(start) {
+			if !filter(val) {
 				continue
 			}
 			start = key
@@ -543,17 +564,16 @@ func maybeYieldScopedItems[T any, K cmp.Ordered](yield func(ScopedItems[T]) bool
 		}
 	}
 
-	return yield(newScopedItems(segments, start, members, items, clone, filter))
+	return yield(newScopedItems(segments, start, members, clone, filter))
 }
 
 // newScopedItems is a helper function for creating a ScopedItems instance within a top-level iterator.
-func newScopedItems[T any, K cmp.Ordered](segments []string, start K, members *sortmap.Map[K, struct{}], items map[K]T, clone func(T) T, filter func(T) bool) ScopedItems[T] {
+func newScopedItems[T any, K cmp.Ordered](segments []string, start K, members *sortmap.Map[K, T], clone func(T) T, filter func(T) bool) ScopedItems[T] {
 	return ScopedItems[T]{
 		segments: segments,
 		items: func() iter.Seq[T] {
 			return func(yield func(T) bool) {
-				for key, _ := range members.Ascend(start) {
-					val := items[key]
+				for _, val := range members.Ascend(start) {
 					if filter != nil && !filter(val) {
 						continue
 					}

--- a/lib/scopes/cache/cache_test.go
+++ b/lib/scopes/cache/cache_test.go
@@ -209,12 +209,18 @@ func TestCacheFiltering(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, item := range items {
-				_, ok := cache.Get(item.Key())
+				_, ok := cache.Get(ScopedKey[int]{
+					Scope: item.Scope(),
+					Key:   item.Key(),
+				})
 				require.False(t, ok, "item %+v should not be in cache before Put", item)
 
 				cache.Put(item)
 
-				got, ok := cache.Get(item.Key())
+				got, ok := cache.Get(ScopedKey[int]{
+					Scope: item.Scope(),
+					Key:   item.Key(),
+				})
 				require.True(t, ok, "item %+v should be in cache after Put", item)
 				require.Equal(t, item, got, "item %+v should match after Put", item)
 				require.Equal(t, 1, cloned)
@@ -344,12 +350,18 @@ func TestCacheScopeAndRelatives(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, item := range items {
-				_, ok := cache.Get(item.Key())
+				_, ok := cache.Get(ScopedKey[int]{
+					Scope: item.Scope(),
+					Key:   item.Key(),
+				})
 				require.False(t, ok, "item %+v should not be in cache before Put", item)
 
 				cache.Put(item)
 
-				got, ok := cache.Get(item.Key())
+				got, ok := cache.Get(ScopedKey[int]{
+					Scope: item.Scope(),
+					Key:   item.Key(),
+				})
 				require.True(t, ok, "item %+v should be in cache after Put", item)
 				require.Equal(t, item, got, "item %+v should match after Put", item)
 			}
@@ -401,12 +413,18 @@ func TestCacheConcurrency(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, item := range items {
-		_, ok := cache.Get(item.Key())
+		_, ok := cache.Get(ScopedKey[int]{
+			Scope: item.Scope(),
+			Key:   item.Key(),
+		})
 		require.False(t, ok, "item %+v should not be in cache before Put", item)
 
 		cache.Put(item)
 
-		got, ok := cache.Get(item.Key())
+		got, ok := cache.Get(ScopedKey[int]{
+			Scope: item.Scope(),
+			Key:   item.Key(),
+		})
 		require.True(t, ok, "item %+v should be in cache after Put", item)
 		require.Equal(t, item, got, "item %+v should match after Put", item)
 	}
@@ -452,7 +470,10 @@ func TestCacheConcurrency(t *testing.T) {
 	delDone := make(chan struct{})
 	go func() {
 		// perform a delete that will block until the background queries are done
-		cache.Del(1)
+		cache.Del(ScopedKey[int]{
+			Scope: "/",
+			Key:   1,
+		})
 		close(delDone)
 	}()
 
@@ -772,12 +793,18 @@ func TestCursorScenarios(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, item := range tt.items {
-				_, ok := cache.Get(item.Key())
+				_, ok := cache.Get(ScopedKey[int]{
+					Scope: item.Scope(),
+					Key:   item.Key(),
+				})
 				require.False(t, ok, "item %+v should not be in cache before Put", item)
 
 				cache.Put(item)
 
-				got, ok := cache.Get(item.Key())
+				got, ok := cache.Get(ScopedKey[int]{
+					Scope: item.Scope(),
+					Key:   item.Key(),
+				})
 				require.True(t, ok, "item %+v should be in cache after Put", item)
 				require.Equal(t, item, got, "item %+v should match after Put", item)
 			}
@@ -958,12 +985,18 @@ func TestCursorPagination(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, item := range tt.items {
-				_, ok := cache.Get(item.Key())
+				_, ok := cache.Get(ScopedKey[int]{
+					Scope: item.Scope(),
+					Key:   item.Key(),
+				})
 				require.False(t, ok, "item %+v should not be in cache before Put", item)
 
 				cache.Put(item)
 
-				got, ok := cache.Get(item.Key())
+				got, ok := cache.Get(ScopedKey[int]{
+					Scope: item.Scope(),
+					Key:   item.Key(),
+				})
 				require.True(t, ok, "item %+v should be in cache after Put", item)
 				require.Equal(t, item, got, "item %+v should match after Put", item)
 			}
@@ -1137,7 +1170,10 @@ func TestCacheOperations(t *testing.T) {
 	}
 
 	// verify deletion of a single intermediate item
-	cache.Del("child-scoped")
+	cache.Del(ScopedKey[string]{
+		Scope: "/child",
+		Key:   "child-scoped",
+	})
 	require.Equal(t, len(items)-1, cache.Len())
 
 	require.Equal(t, map[string][]string{
@@ -1154,7 +1190,10 @@ func TestCacheOperations(t *testing.T) {
 	}, collectScopedItemKeys(cache.ScopeAndDescendants("/")))
 
 	// verify deletion of a single root-scoped item
-	cache.Del("root-scoped")
+	cache.Del(ScopedKey[string]{
+		Scope: "/",
+		Key:   "root-scoped",
+	})
 	require.Equal(t, len(items)-2, cache.Len())
 
 	require.Equal(t, map[string][]string{
@@ -1171,7 +1210,10 @@ func TestCacheOperations(t *testing.T) {
 	}, collectScopedItemKeys(cache.ScopeAndDescendants("/")))
 
 	// verify full deletion of all contents of an intermediate scope
-	cache.Del("child-scoped-other")
+	cache.Del(ScopedKey[string]{
+		Scope: "/child",
+		Key:   "child-scoped-other",
+	})
 	require.Equal(t, len(items)-3, cache.Len())
 
 	require.Equal(t, map[string][]string{
@@ -1186,7 +1228,10 @@ func TestCacheOperations(t *testing.T) {
 	}, collectScopedItemKeys(cache.ScopeAndDescendants("/")))
 
 	// verfiy full deletion of all contents of a root scope
-	cache.Del("root-scoped-other")
+	cache.Del(ScopedKey[string]{
+		Scope: "/",
+		Key:   "root-scoped-other",
+	})
 	require.Equal(t, len(items)-4, cache.Len())
 
 	require.Equal(t, map[string][]string{
@@ -1199,7 +1244,10 @@ func TestCacheOperations(t *testing.T) {
 	}, collectScopedItemKeys(cache.ScopeAndDescendants("/")))
 
 	// verify deletion of leaf scope
-	cache.Del("child-sub-scoped")
+	cache.Del(ScopedKey[string]{
+		Scope: "/child/subchild",
+		Key:   "child-sub-scoped",
+	})
 	require.Equal(t, len(items)-5, cache.Len())
 
 	require.Equal(t, map[string][]string{},
@@ -1225,21 +1273,40 @@ func TestCacheOperations(t *testing.T) {
 		"/orthogonal": {"child-orthogonal"},
 	}, collectScopedItemKeys(cache.ScopeAndDescendants("/")))
 
-	// verify overwrite of existing item by primary key
+	// verify that the same key at a different scope is a distinct entry rather than
+	// displacing the existing one.
 	cache.Put(item[string]{
 		key:   "child-scoped",
 		scope: "/child/other",
 	})
-	require.Equal(t, len(items)-4, cache.Len())
+	require.Equal(t, len(items)-3, cache.Len())
 
-	require.Equal(t, map[string][]string{},
-		collectScopedItemKeys(cache.ScopeAndAncestors("/child/subchild")))
+	// /child still contains its own "child-scoped" (it was not moved).
+	require.Equal(t, map[string][]string{
+		"/child": {"child-scoped"},
+	}, collectScopedItemKeys(cache.ScopeAndAncestors("/child/subchild")))
 
 	require.Equal(t, map[string][]string{
+		"/child":       {"child-scoped"},
 		"/child/other": {"child-scoped"},
 	}, collectScopedItemKeys(cache.ScopeAndAncestors("/child/other")))
 
 	require.Equal(t, map[string][]string{
+		"/child":       {"child-scoped"},
+		"/child/other": {"child-scoped"},
+		"/orthogonal":  {"child-orthogonal"},
+	}, collectScopedItemKeys(cache.ScopeAndDescendants("/")))
+
+	// verify overwrite of an existing item at the same (scope, key) replaces in place without
+	// growing the cache.
+	cache.Put(item[string]{
+		key:   "child-scoped",
+		scope: "/child/other",
+	})
+	require.Equal(t, len(items)-3, cache.Len())
+
+	require.Equal(t, map[string][]string{
+		"/child":       {"child-scoped"},
 		"/child/other": {"child-scoped"},
 		"/orthogonal":  {"child-orthogonal"},
 	}, collectScopedItemKeys(cache.ScopeAndDescendants("/")))

--- a/lib/scopes/cache/roles/role_cache.go
+++ b/lib/scopes/cache/roles/role_cache.go
@@ -62,14 +62,11 @@ func (c *RoleCache) GetScopedRole(ctx context.Context, req *scopedaccessv1.GetSc
 		return nil, trace.BadParameter("missing scoped role name in get request")
 	}
 
-	role, ok := c.cache.Get(req.GetName())
+	role, ok := c.cache.Get(cache.ScopedKey[string]{
+		Scope: req.GetScope(),
+		Key:   req.GetName(),
+	})
 	if !ok {
-		return nil, trace.NotFound("scoped role %q not found", req.GetName())
-	}
-
-	// emulate namespace-like behavior by treating mismatched scopes as NotFound (prep for the transition
-	// to true namespacing).
-	if scopes.Compare(req.GetScope(), role.GetScope()) != scopes.Equivalent {
 		return nil, trace.NotFound("scoped role %q not found in scope %q", req.GetName(), req.GetScope())
 	}
 
@@ -152,7 +149,10 @@ func (c *RoleCache) Put(role *scopedaccessv1.ScopedRole) error {
 	return nil
 }
 
-// Delete removes a role from the cache by name.
-func (c *RoleCache) Delete(name string) {
-	c.cache.Del(name)
+// Delete removes a role from the cache by its scope-qualified name.
+func (c *RoleCache) Delete(role scopes.QualifiedName) {
+	c.cache.Del(cache.ScopedKey[string]{
+		Scope: role.Scope,
+		Key:   role.Name,
+	})
 }

--- a/lib/scopes/scopes.go
+++ b/lib/scopes/scopes.go
@@ -69,6 +69,10 @@ const (
 // for a policy. Policy resources should never use this or any other default scope value.
 const Root = separator
 
+// Unscoped is an empty string constant used in code to improve the readability of code that is intended
+// to handle a mix of scoped and unscoped values.
+const Unscoped = ""
+
 // StrongValidate checks if the scope is valid according to all scope formatting rules. This function
 // *must* be called on all scope values received from user input and/or cluster-external sources (e.g.
 // an identity provider). Use of this function should be avoided when checking the validity of scopes

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -5072,6 +5072,12 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			MaxStaleness: time.Minute,
 		},
 		NodesGetter: accessPoint,
+		// The proxy's node watcher is a routing construct; it must observe nodes in
+		// every scope, not just unscoped ones, so it watches with MODE_ALL. This is
+		// backed by the ForProxy cache, which mirrors nodes in all scopes (see
+		// cache.ForProxy). Sibling routing watchers backed by ForRelay/ForRemoteProxy
+		// intentionally stay unscoped since those caches do not mirror scoped nodes.
+		ScopeFilter: types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build()),
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/services/fanoutv2.go
+++ b/lib/services/fanoutv2.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/scopes"
 	fb "github.com/gravitational/teleport/lib/utils/fanoutbuffer"
 )
 
@@ -343,6 +344,12 @@ func (f *fanoutV2Stream) advance() (event types.Event, ok bool, err error) {
 				continue
 			}
 
+			// scope filtering is applied here rather than inside kind.Matches because the scope-matching
+			// logic lives in lib/scopes, which the api/types package that defines Matches cannot import.
+			if !WatchKindMatchesScope(kind, entry.Event.Resource) {
+				continue
+			}
+
 			if kind.LoadSecrets {
 				return entry.EventWithSecrets, true, nil
 			}
@@ -351,6 +358,30 @@ func (f *fanoutV2Stream) advance() (event types.Event, ok bool, err error) {
 	}
 
 	return types.Event{}, false, nil
+}
+
+// WatchKindMatchesScope reports whether the given resource satisfies the watch kind's scope filter. A
+// nil scope filter matches everything. The resource's scope is read via the optional GetScope accessor
+// (implemented by scoped resources and the Resource153 legacy adapter); resources that are not scope-aware
+// report an empty scope, which scopes.MatchScope treats as unscoped.
+//
+// This is the scope-filtering counterpart to [types.WatchKind.Matches] and must be applied by every
+// event source that honors watch kinds (the fanout and the local backend event parsers), so that a
+// scope filter selects the same set of events regardless of which source serves the watch.
+//
+// TODO(fspmarshall/scopes): at some point it may be worth moving core scope-matching logic to api
+// so that we can fold this functionality back into [WatchKind.Matches].
+func WatchKindMatchesScope(kind types.WatchKind, resource types.Resource) bool {
+	if kind.ScopeFilter == nil {
+		return true
+	}
+
+	var scope string
+	if scoped, ok := resource.(interface{ GetScope() string }); ok {
+		scope = scoped.GetScope()
+	}
+
+	return scopes.MatchScope(kind.ScopeFilter.ToProto(), scope)
 }
 
 // fanoutV2Entry is the underlying buffer entry that is fanned out to all

--- a/lib/services/fanoutv2_test.go
+++ b/lib/services/fanoutv2_test.go
@@ -26,7 +26,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 )
 
 // TestFanoutV2Init verifies that Init event is sent exactly once.
@@ -91,6 +95,88 @@ func TestFanoutV2StreamFiltering(t *testing.T) {
 	require.Equal(t, "spam", stream.Item().Resource.GetKind())
 
 	require.NoError(t, stream.Done())
+}
+
+// TestFanoutV2ScopeFiltering verifies that a watch kind's scope filter selects which scoped events a
+// stream receives, that it applies to delete events (which carry scope) as well as puts, and that a
+// stream with no scope filter receives every event for the kind.
+func TestFanoutV2ScopeFiltering(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	scopedRole := func(scope string) types.Resource {
+		return types.Resource153ToLegacy(scopedaccessv1.ScopedRole_builder{
+			Kind:     scopedaccess.KindScopedRole,
+			Metadata: headerv1.Metadata_builder{Name: "role"}.Build(),
+			Scope:    scope,
+		}.Build())
+	}
+
+	scopeOf := func(r types.Resource) string {
+		scoped, ok := r.(interface{ GetScope() string })
+		require.True(t, ok, "resource %T does not expose a scope", r)
+		return scoped.GetScope()
+	}
+
+	f := NewFanoutV2(FanoutV2Config{})
+
+	// a stream that watches only the exact scope /foo.
+	exact := f.NewStream(ctx, types.Watch{
+		Name: "exact",
+		Kinds: []types.WatchKind{{
+			Kind:        scopedaccess.KindScopedRole,
+			ScopeFilter: types.ScopeFilterFromProto(scopesv1.Filter_builder{Scope: "/foo", Mode: scopesv1.Mode_MODE_EXACT}.Build()),
+		}},
+	})
+
+	// a stream with no scope filter, which should receive every event for the kind.
+	all := f.NewStream(ctx, types.Watch{
+		Name:  "all",
+		Kinds: []types.WatchKind{{Kind: scopedaccess.KindScopedRole}},
+	})
+
+	f.SetInit([]types.WatchKind{{Kind: scopedaccess.KindScopedRole}})
+
+	require.True(t, exact.Next())
+	require.Equal(t, types.OpInit, exact.Item().Type)
+	require.True(t, all.Next())
+	require.Equal(t, types.OpInit, all.Item().Type)
+
+	events := []struct {
+		op    types.OpType
+		scope string
+	}{
+		{types.OpPut, "/foo"},
+		{types.OpPut, "/bar"},
+		{types.OpPut, "/foo/sub"},
+		{types.OpDelete, "/foo"},
+		{types.OpDelete, "/bar"},
+	}
+	for _, e := range events {
+		f.Emit(types.Event{Type: e.op, Resource: scopedRole(e.scope)})
+	}
+
+	// the exact-scope stream sees only the two /foo events (put and delete), in order.
+	for _, want := range []struct {
+		op    types.OpType
+		scope string
+	}{
+		{types.OpPut, "/foo"},
+		{types.OpDelete, "/foo"},
+	} {
+		require.True(t, exact.Next())
+		require.Equal(t, want.op, exact.Item().Type)
+		require.Equal(t, want.scope, scopeOf(exact.Item().Resource))
+	}
+	require.NoError(t, exact.Done())
+
+	// the unfiltered stream sees every event, in order.
+	for _, want := range events {
+		require.True(t, all.Next())
+		require.Equal(t, want.op, all.Item().Type)
+		require.Equal(t, want.scope, scopeOf(all.Item().Resource))
+	}
+	require.NoError(t, all.Done())
 }
 
 func TestFanoutV2StreamOrdering(t *testing.T) {

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -48,6 +48,8 @@ import (
 )
 
 const (
+	scopedPrefix = "scoped"
+
 	accessListPrefix      = "access_list"
 	accessListMaxPageSize = 100
 

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -37,12 +37,14 @@ import (
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
 	provisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/provisioning/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/kubewaitingcontainer"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/devicetrust"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
@@ -297,6 +299,8 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 			return nil, trace.BadParameter("watcher on object kind %q is not supported", kind.Kind)
 		}
 		prefixes = append(prefixes, parser.prefixes()...)
+
+		// NOTE: we rely on parsers[<some-index>] being the parser associated with validKinds[<some-index>] and vise-versa.
 		parsers = append(parsers, parser)
 		validKinds = append(validKinds, kind)
 	}
@@ -356,7 +360,7 @@ func (w *watcher) parseEvent(e backend.Event) ([]types.Event, []error) {
 	}
 	events := []types.Event{}
 	errs := []error{}
-	for _, p := range w.parsers {
+	for i, p := range w.parsers {
 		if p.match(e.Item.Key) {
 			resource, err := p.parse(e)
 			if err != nil {
@@ -369,6 +373,10 @@ func (w *watcher) parseEvent(e backend.Event) ([]types.Event, []error) {
 			}
 			// if resource is nil, then it was well-formed but is being filtered out.
 			if resource == nil {
+				continue
+			}
+			// apply the watch kind's scope filter. parsers[i] always correponds to kinds[i].
+			if !services.WatchKindMatchesScope(w.kinds[i], resource) {
 				continue
 			}
 			events = append(events, types.Event{Type: e.Type, Resource: resource})
@@ -1094,16 +1102,22 @@ type scopedRoleParser struct {
 func (p *scopedRoleParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		name := strings.TrimPrefix(event.Item.Key.TrimPrefix(scopedRoleWatchPrefix()).String(), backend.SeparatorString)
-		if name == "" || strings.Contains(name, "/") {
-			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		// delete events must use full type instead of resource header in order to propagate scope
+		components := event.Item.Key.TrimPrefix(scopedRoleWatchPrefix()).Components()
+		if len(components) != 2 {
+			return nil, trace.NotFound("malformed scoped role key %q", event.Item.Key.String())
 		}
-		return &types.ResourceHeader{
+		scope, err := scopes.DecodeFromKey(components[0])
+		if err != nil {
+			return nil, trace.Wrap(err, "failed decoding scope from scoped role key %q", event.Item.Key.String())
+		}
+		return types.Resource153ToLegacy(scopedaccessv1.ScopedRole_builder{
 			Kind: scopedaccess.KindScopedRole,
-			Metadata: types.Metadata{
-				Name: name,
-			},
-		}, nil
+			Metadata: headerv1.Metadata_builder{
+				Name: components[1],
+			}.Build(),
+			Scope: scope,
+		}.Build()), nil
 	case types.OpPut:
 		role, err := scopedRoleFromItem(&event.Item)
 		if err != nil {
@@ -1128,34 +1142,30 @@ type scopedRoleAssignmentParser struct {
 func (p *scopedRoleAssignmentParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
+		// delete events must use full type instead of resource header in order to propagate scope
 		components := event.Item.Key.TrimPrefix(scopedRoleAssignmentWatchPrefix()).Components()
-		name := ""
-		subKind := ""
-		switch len(components) {
-		case 1:
-			name = components[0]
-		case 2:
-			name = components[0]
-			subKind = components[1]
-		default:
-			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		if len(components) != 3 {
+			return nil, trace.NotFound("malformed scoped role assignment key %q", event.Item.Key.String())
 		}
-		if name == "" {
-			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
-		}
+		encodedScope, name, subKind := components[0], components[1], components[2]
 		if subKind == scopedaccess.SubKindMaterialized {
 			// Materialized assignments are filtered out from backend events in
 			// case a future version persists materialized assignments to the
 			// backend.
 			return nil, nil
 		}
-		return &types.ResourceHeader{
-			Kind:    scopedaccess.KindScopedRoleAssignment,
-			SubKind: subKind,
-			Metadata: types.Metadata{
+		scope, err := scopes.DecodeFromKey(encodedScope)
+		if err != nil {
+			return nil, trace.Wrap(err, "failed decoding scope from scoped role assignment key %q", event.Item.Key.String())
+		}
+		return types.Resource153ToLegacy(scopedaccessv1.ScopedRoleAssignment_builder{
+			Kind: scopedaccess.KindScopedRoleAssignment,
+			Metadata: headerv1.Metadata_builder{
 				Name: name,
-			},
-		}, nil
+			}.Build(),
+			SubKind: subKind,
+			Scope:   scope,
+		}.Build()), nil
 	case types.OpPut:
 		assignment, err := scopedRoleAssignmentFromItem(&event.Item)
 		if err != nil {

--- a/lib/services/local/scoped_access.go
+++ b/lib/services/local/scoped_access.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"time"
 
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -30,7 +29,6 @@ import (
 	"github.com/gravitational/teleport"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	apiutils "github.com/gravitational/teleport/api/utils"
-	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/scopes"
@@ -51,14 +49,12 @@ import (
 // assignments must be filtered by that function prior to being used to make any access decisions. Currently this happens
 // in exactly one place: services.scopedAccessCheckerBuilder.newCheckerForRole.
 
+// scoped roles and assignments are keyed by their resource kind directly beneath the shared scoped
+// prefix (i.e. /scoped/<kind>/...), consistent with the other scoped resource families. We reuse the
+// canonical kind constants so that the key's kind component can never drift from the resource kind.
 const (
-	scopedRolePrefix              = "scoped_role"
-	scopedRoleRoleComponent       = "role"
-	scopedRoleAssignmentComponent = "assignment"
-
-	// maxScopedResourceUpsertAttempts is the maximum number of times an upsert
-	// operation will retry on a concurrent modification before giving up.
-	maxScopedResourceUpsertAttempts = 4
+	scopedRolePrefix           = scopedaccess.KindScopedRole
+	scopedRoleAssignmentPrefix = scopedaccess.KindScopedRoleAssignment
 )
 
 // ScopedAccessService manages backend state for the ScopedRole and ScopedRoleAssignment types.
@@ -69,23 +65,28 @@ type ScopedAccessService struct {
 
 // NewScopedAccessService creates a new ScopedAccessService for the specified backend.
 func NewScopedAccessService(bk backend.Backend) *ScopedAccessService {
+	// TODO(fspmarshall/scopes): switch this over to use the generic scoped backend once
+	// it can support the kind of sub_kind model we use here.
 	return &ScopedAccessService{
 		bk:     bk,
 		logger: slog.With(teleport.ComponentKey, "scopedrole"),
 	}
 }
 
-// getScopedRoleByName is equivalent to GetScopedRole, but does not enforce scope equivalence. Can be safely
-// folded back into GetScopedRole and removed once the backend is namespaced by key.
-func (s *ScopedAccessService) getScopedRoleByName(ctx context.Context, req *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {
+func (s *ScopedAccessService) GetScopedRole(ctx context.Context, req *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {
 	if req.GetName() == "" {
 		return nil, trace.BadParameter("missing scoped role name in get request")
 	}
 
-	item, err := s.bk.Get(ctx, scopedRoleKey(req.GetName()))
+	key, err := scopedRoleKey{scope: req.GetScope(), name: req.GetName()}.Key()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	item, err := s.bk.Get(ctx, key)
 	if err != nil {
 		if trace.IsNotFound(err) {
-			return nil, trace.NotFound("scoped role %q not found", req.GetName())
+			return nil, trace.NotFound("scoped role %q not found in scope %q", req.GetName(), req.GetScope())
 		}
 		return nil, trace.Wrap(err)
 	}
@@ -102,21 +103,6 @@ func (s *ScopedAccessService) getScopedRoleByName(ctx context.Context, req *scop
 	return &scopedaccessv1.GetScopedRoleResponse{
 		Role: role,
 	}, nil
-}
-
-func (s *ScopedAccessService) GetScopedRole(ctx context.Context, req *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {
-	rsp, err := s.getScopedRoleByName(ctx, req)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// emulate namespace-like behavior by treating mismatched scopes as NotFound (prep for the transition
-	// to true namespacing).
-	if scopes.Compare(req.GetScope(), rsp.GetRole().GetScope()) != scopes.Equivalent {
-		return nil, trace.NotFound("scoped role %q not found in scope %q", req.GetName(), req.GetScope())
-	}
-
-	return rsp, nil
 }
 
 // ListScopedRoles returns a paginated list of scoped roles.
@@ -156,7 +142,7 @@ func (s *ScopedAccessService) ListScopedRoles(ctx context.Context, req *scopedac
 // have had weak validation applied.
 func (s *ScopedAccessService) StreamScopedRoles(ctx context.Context) stream.Stream[*scopedaccessv1.ScopedRole] {
 	return func(yield func(*scopedaccessv1.ScopedRole, error) bool) {
-		startKey := scopedRoleKey("")
+		startKey := scopedRoleWatchPrefix()
 		params := backend.ItemsParams{
 			StartKey: startKey,
 			EndKey:   backend.RangeEnd(startKey),
@@ -172,7 +158,7 @@ func (s *ScopedAccessService) StreamScopedRoles(ctx context.Context) stream.Stre
 			role, err := scopedRoleFromItem(&item)
 			if err != nil {
 				// per-role errors are logged and skipped
-				s.logger.WarnContext(ctx, "skipping scoped role due to unmarshal error", "error", err, "key", logutils.StringerAttr(item.Key))
+				s.logger.WarnContext(ctx, "skipping malformed scoped role", "error", err, "key", logutils.StringerAttr(item.Key))
 				continue
 			}
 
@@ -228,7 +214,7 @@ func (s *ScopedAccessService) UpdateScopedRole(ctx context.Context, req *scopeda
 		return nil, trace.Wrap(err)
 	}
 
-	extant, err := s.getScopedRoleByName(ctx, scopedaccessv1.GetScopedRoleRequest_builder{
+	extant, err := s.GetScopedRole(ctx, scopedaccessv1.GetScopedRoleRequest_builder{
 		Name:  role.GetMetadata().GetName(),
 		Scope: role.GetScope(),
 	}.Build())
@@ -242,15 +228,6 @@ func (s *ScopedAccessService) UpdateScopedRole(ctx context.Context, req *scopeda
 
 	if role.GetMetadata().GetRevision() != "" && role.GetMetadata().GetRevision() != extant.GetRole().GetMetadata().GetRevision() {
 		return nil, trace.CompareFailed("scoped role %q has been concurrently modified", role.GetMetadata().GetName())
-	}
-
-	// disallow change of resource scope via update. use of scopes.Compare directly is generally discouraged,
-	// but that is due to ease of misuse, which isn't really a concern for a simple equivalence check.
-	if scopes.Compare(role.GetScope(), extant.GetRole().GetScope()) != scopes.Equivalent {
-		// XXX: the current implementation of our access-control logic relies upon this invariant being enforced. if we ever
-		// relax this restriction here we *must* first modify the outer access-control logic to understand the concept of
-		// scope changing and correctly validate the transition.
-		return nil, trace.BadParameter("cannot modify the resource scope of scoped role %q (%q -> %q)", role.GetMetadata().GetName(), extant.GetRole().GetScope(), role.GetScope())
 	}
 
 	// use the observed revision as the condition so that a concurrent modification is detected.
@@ -279,30 +256,23 @@ func (s *ScopedAccessService) DeleteScopedRole(ctx context.Context, req *scopeda
 		return nil, trace.BadParameter("missing scoped role name in delete request")
 	}
 
-	// emulate namespace-like behavior by treating mismatched scopes as NotFound (prep for the transition
-	// to true namespacing). Note that we ignore malformed roles below in order to ensure they remain deletable.
-	item, err := s.bk.Get(ctx, scopedRoleKey(roleName))
+	key, err := scopedRoleKey{scope: req.GetScope(), name: roleName}.Key()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if role, decErr := scopedRoleFromItem(item); decErr == nil {
-		if scopes.Compare(req.GetScope(), role.GetScope()) != scopes.Equivalent {
-			return nil, trace.NotFound("scoped role %q not found in scope %q", roleName, req.GetScope())
-		}
-	}
 
 	if rev := req.GetRevision(); rev != "" {
-		if err := s.bk.ConditionalDelete(ctx, scopedRoleKey(roleName), rev); err != nil {
+		if err := s.bk.ConditionalDelete(ctx, key, rev); err != nil {
 			if errors.Is(err, backend.ErrIncorrectRevision) {
 				return nil, trace.CompareFailed("scoped role %q has been concurrently modified", roleName)
 			}
 			return nil, trace.Wrap(err)
 		}
 	} else {
-		if err := s.bk.Delete(ctx, scopedRoleKey(roleName)); err != nil {
+		if err := s.bk.Delete(ctx, key); err != nil {
 			if trace.IsNotFound(err) {
 				// generic condition failure keeps error handling simpler
-				return nil, trace.NotFound("scoped role %q not found", roleName)
+				return nil, trace.NotFound("scoped role %q not found in scope %q", roleName, req.GetScope())
 			}
 			return nil, trace.Wrap(err)
 		}
@@ -324,53 +294,22 @@ func (s *ScopedAccessService) UpsertScopedRole(ctx context.Context, req *scopeda
 	// upsert operations ignore user-provided revision
 	role = scopedRoleWithRevision(role, "")
 
-	for attempt := range maxScopedResourceUpsertAttempts {
-		if attempt != 0 {
-			select {
-			case <-time.After(retryutils.FullJitter(time.Duration(300*attempt) * time.Millisecond)):
-			case <-ctx.Done():
-				return nil, trace.Wrap(ctx.Err())
-			}
-		}
-
-		existing, err := s.getScopedRoleByName(ctx, scopedaccessv1.GetScopedRoleRequest_builder{
-			Name:  role.GetMetadata().GetName(),
-			Scope: role.GetScope(),
-		}.Build())
-		if trace.IsNotFound(err) {
-			rsp, err := s.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
-				Role: role,
-			})
-			if err != nil {
-				if trace.IsCompareFailed(err) {
-					continue
-				}
-				return nil, trace.Wrap(err)
-			}
-			return &scopedaccessv1.UpsertScopedRoleResponse{Role: rsp.GetRole()}, nil
-		}
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		rsp, err := s.UpdateScopedRole(ctx, &scopedaccessv1.UpdateScopedRoleRequest{
-			Role: scopedRoleWithRevision(role, existing.GetRole().GetMetadata().GetRevision()),
-		})
-		if err != nil {
-			if trace.IsCompareFailed(err) || trace.IsNotFound(err) {
-				continue
-			}
-			return nil, trace.Wrap(err)
-		}
-		return &scopedaccessv1.UpsertScopedRoleResponse{Role: rsp.GetRole()}, nil
+	item, err := scopedRoleToItem(role)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	return nil, trace.LimitExceeded("exceeded max retries attempting to upsert scoped role %q", role.GetMetadata().GetName())
+	lease, err := s.bk.Put(ctx, item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return scopedaccessv1.UpsertScopedRoleResponse_builder{
+		Role: scopedRoleWithRevision(role, lease.Revision),
+	}.Build(), nil
 }
 
-// getScopedRoleAssignmentByName is equivalent to GetScopedRoleAssignment, but does not enforce scope equivalence. Can be safely
-// folded back into GetScopedRoleAssignment and removed once the backend is namespaced by key.
-func (s *ScopedAccessService) getScopedRoleAssignmentByName(ctx context.Context, req *scopedaccessv1.GetScopedRoleAssignmentRequest) (*scopedaccessv1.GetScopedRoleAssignmentResponse, error) {
+func (s *ScopedAccessService) GetScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.GetScopedRoleAssignmentRequest) (*scopedaccessv1.GetScopedRoleAssignmentResponse, error) {
 	if req.GetName() == "" {
 		return nil, trace.BadParameter("missing scoped role assignment name in get request")
 	}
@@ -378,13 +317,19 @@ func (s *ScopedAccessService) getScopedRoleAssignmentByName(ctx context.Context,
 		return nil, trace.BadParameter(`reading scoped role assignments with sub_kind "materialized" from the backend is not supported`)
 	}
 
-	item, err := s.bk.Get(ctx, scopedRoleAssignmentKey{
+	key, err := scopedRoleAssignmentKey{
+		scope:   req.GetScope(),
 		name:    req.GetName(),
 		subKind: req.GetSubKind(),
-	}.Key())
+	}.Key()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	item, err := s.bk.Get(ctx, key)
 	if err != nil {
 		if trace.IsNotFound(err) {
-			return nil, trace.NotFound("scoped role assignment %q not found", req.GetName())
+			return nil, trace.NotFound("scoped role assignment %q not found in scope %q", req.GetName(), req.GetScope())
 		}
 		return nil, trace.Wrap(err)
 	}
@@ -401,21 +346,6 @@ func (s *ScopedAccessService) getScopedRoleAssignmentByName(ctx context.Context,
 	return &scopedaccessv1.GetScopedRoleAssignmentResponse{
 		Assignment: assignment,
 	}, nil
-}
-
-func (s *ScopedAccessService) GetScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.GetScopedRoleAssignmentRequest) (*scopedaccessv1.GetScopedRoleAssignmentResponse, error) {
-	rsp, err := s.getScopedRoleAssignmentByName(ctx, req)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// emulate namespace-like behavior by treating mismatched scopes as NotFound (prep for the transition
-	// to true namespacing).
-	if scopes.Compare(req.GetScope(), rsp.GetAssignment().GetScope()) != scopes.Equivalent {
-		return nil, trace.NotFound("scoped role assignment %q not found in scope %q", req.GetName(), req.GetScope())
-	}
-
-	return rsp, nil
 }
 
 // ListScopedRoleAssignments returns a paginated list of scoped role assignments.
@@ -474,7 +404,7 @@ func (s *ScopedAccessService) StreamScopedRoleAssignments(ctx context.Context) s
 			assignment, err := scopedRoleAssignmentFromItem(&item)
 			if err != nil {
 				// per-assignment errors are logged and skipped
-				s.logger.WarnContext(ctx, "skipping scoped role assignment due to unmarshal error", "error", err, "key", logutils.StringerAttr(item.Key))
+				s.logger.WarnContext(ctx, "skipping malformed scoped role assignment", "error", err, "key", logutils.StringerAttr(item.Key))
 				continue
 			}
 
@@ -555,7 +485,7 @@ func (s *ScopedAccessService) UpdateScopedRoleAssignment(ctx context.Context, re
 		return nil, trace.BadParameter("scoped role assignment resource %q contains too many sub-assignments (max %d)", assignment.GetMetadata().GetName(), scopedaccess.MaxRolesPerAssignment)
 	}
 
-	extant, err := s.getScopedRoleAssignmentByName(ctx, scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
+	extant, err := s.GetScopedRoleAssignment(ctx, scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
 		Name:    assignment.GetMetadata().GetName(),
 		SubKind: assignment.GetSubKind(),
 		Scope:   assignment.GetScope(),
@@ -570,11 +500,6 @@ func (s *ScopedAccessService) UpdateScopedRoleAssignment(ctx context.Context, re
 
 	if rev := assignment.GetMetadata().GetRevision(); rev != "" && rev != extant.GetAssignment().GetMetadata().GetRevision() {
 		return nil, trace.CompareFailed("scoped role assignment %q has been concurrently modified", assignment.GetMetadata().GetName())
-	}
-
-	// disallow change of resource scope; this invariant is load-bearing for ACL logic.
-	if scopes.Compare(assignment.GetScope(), extant.GetAssignment().GetScope()) != scopes.Equivalent {
-		return nil, trace.BadParameter("cannot modify the resource scope of scoped role assignment %q (%q -> %q)", assignment.GetMetadata().GetName(), extant.GetAssignment().GetScope(), assignment.GetScope())
 	}
 
 	// use the observed revision as the condition so that a concurrent modification is detected.
@@ -607,51 +532,32 @@ func (s *ScopedAccessService) UpsertScopedRoleAssignment(ctx context.Context, re
 		return nil, trace.Wrap(err)
 	}
 
+	switch assignment.GetSubKind() {
+	case scopedaccess.SubKindDynamic:
+	default:
+		return nil, trace.BadParameter("upserting scoped role assignments with sub_kind %q is not supported", assignment.GetSubKind())
+	}
+
+	if len(assignment.GetSpec().GetAssignments()) > scopedaccess.MaxRolesPerAssignment {
+		return nil, trace.BadParameter("scoped role assignment resource %q contains too many sub-assignments (max %d)", assignment.GetMetadata().GetName(), scopedaccess.MaxRolesPerAssignment)
+	}
+
 	// upsert operations ignore user-provided revision
 	assignment = scopedRoleAssignmentWithRevision(assignment, "")
 
-	for attempt := range maxScopedResourceUpsertAttempts {
-		if attempt != 0 {
-			select {
-			case <-time.After(retryutils.FullJitter(time.Duration(300*attempt) * time.Millisecond)):
-			case <-ctx.Done():
-				return nil, trace.Wrap(ctx.Err())
-			}
-		}
-
-		_, err := s.getScopedRoleAssignmentByName(ctx, scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
-			Name:    assignment.GetMetadata().GetName(),
-			SubKind: assignment.GetSubKind(),
-			Scope:   assignment.GetScope(),
-		}.Build())
-		if trace.IsNotFound(err) {
-			rsp, err := s.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
-				Assignment: assignment,
-			})
-			if err != nil {
-				if trace.IsCompareFailed(err) {
-					continue
-				}
-				return nil, trace.Wrap(err)
-			}
-			return &scopedaccessv1.UpsertScopedRoleAssignmentResponse{Assignment: rsp.GetAssignment()}, nil
-		}
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		// update path
-		ursp, err := s.UpdateScopedRoleAssignment(ctx, &scopedaccessv1.UpdateScopedRoleAssignmentRequest{Assignment: assignment})
-		if err != nil {
-			if trace.IsCompareFailed(err) || trace.IsNotFound(err) {
-				continue
-			}
-			return nil, trace.Wrap(err)
-		}
-		return &scopedaccessv1.UpsertScopedRoleAssignmentResponse{Assignment: ursp.GetAssignment()}, nil
+	item, err := scopedRoleAssignmentToItem(assignment)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	return nil, trace.LimitExceeded("exceeded max retries attempting to upsert scoped role assignment %q", assignment.GetMetadata().GetName())
+	lease, err := s.bk.Put(ctx, item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return scopedaccessv1.UpsertScopedRoleAssignmentResponse_builder{
+		Assignment: scopedRoleAssignmentWithRevision(assignment, lease.Revision),
+	}.Build(), nil
 }
 
 func (s *ScopedAccessService) DeleteScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.DeleteScopedRoleAssignmentRequest) (*scopedaccessv1.DeleteScopedRoleAssignmentResponse, error) {
@@ -662,25 +568,16 @@ func (s *ScopedAccessService) DeleteScopedRoleAssignment(ctx context.Context, re
 
 	subKind := req.GetSubKind()
 	switch subKind {
-	case scopedaccess.SubKindDynamic, "":
+	case scopedaccess.SubKindDynamic:
 	case scopedaccess.SubKindMaterialized:
 		return nil, trace.BadParameter(`deleting scoped role assignments with sub_kind "materialized" is not supported`)
 	default:
 		return nil, trace.BadParameter("unhandled sub_kind %q in scoped role assignment delete request", subKind)
 	}
 
-	key := scopedRoleAssignmentKey{name: assignmentName, subKind: subKind}.Key()
-
-	// emulate namespace-like behavior by treating mismatched scopes as NotFound (prep for the transition
-	// to true namespacing). Note that we ignore malformed roles below in order to ensure they remain deletable.
-	item, err := s.bk.Get(ctx, key)
+	key, err := scopedRoleAssignmentKey{scope: req.GetScope(), name: assignmentName, subKind: subKind}.Key()
 	if err != nil {
 		return nil, trace.Wrap(err)
-	}
-	if assignment, decErr := scopedRoleAssignmentFromItem(item); decErr == nil {
-		if scopes.Compare(req.GetScope(), assignment.GetScope()) != scopes.Equivalent {
-			return nil, trace.NotFound("scoped role assignment %q not found in scope %q", assignmentName, req.GetScope())
-		}
 	}
 
 	if rev := req.GetRevision(); rev != "" {
@@ -694,7 +591,7 @@ func (s *ScopedAccessService) DeleteScopedRoleAssignment(ctx context.Context, re
 		if err := s.bk.Delete(ctx, key); err != nil {
 			if trace.IsNotFound(err) {
 				// generic condition failure keeps error handling simpler
-				return nil, trace.NotFound("scoped role assignment %q not found", assignmentName)
+				return nil, trace.NotFound("scoped role assignment %q not found in scope %q", assignmentName, req.GetScope())
 			}
 			return nil, trace.Wrap(err)
 		}
@@ -703,29 +600,66 @@ func (s *ScopedAccessService) DeleteScopedRoleAssignment(ctx context.Context, re
 	return &scopedaccessv1.DeleteScopedRoleAssignmentResponse{}, nil
 }
 
-func scopedRoleKey(roleName string) backend.Key {
-	return backend.NewKey(scopedRolePrefix, scopedRoleRoleComponent, roleName)
+type scopedRoleKey struct {
+	scope string
+	name  string
+}
+
+// Key builds the backend key for a scoped role. The layout
+// is /scoped/scoped_role/<encoded_scope>/<name>.
+func (k scopedRoleKey) Key() (backend.Key, error) {
+	encodedScope, err := scopes.EncodeForKey(k.scope)
+	if err != nil {
+		return backend.Key{}, trace.Wrap(err)
+	}
+	return backend.NewKey(scopedPrefix, scopedRolePrefix, encodedScope, k.name), nil
 }
 
 func scopedRoleWatchPrefix() backend.Key {
-	return backend.ExactKey(scopedRolePrefix, scopedRoleRoleComponent)
+	return backend.ExactKey(scopedPrefix, scopedRolePrefix)
 }
 
 type scopedRoleAssignmentKey struct {
+	scope   string
 	name    string
 	subKind string
 }
 
-func (k scopedRoleAssignmentKey) Key() backend.Key {
+// Key builds the backend key for a scoped role assignment. The layout is
+// /scoped/scoped_role_assignment/<encoded_scope>/<name>/<sub_kind>.
+func (k scopedRoleAssignmentKey) Key() (backend.Key, error) {
 	if k.subKind == "" {
-		// Supports reading old scoped role assignments created without a subkind.
-		return backend.NewKey(scopedRolePrefix, scopedRoleAssignmentComponent, k.name)
+		return backend.Key{}, trace.BadParameter("scoped role assignment sub_kind is required")
 	}
-	return backend.NewKey(scopedRolePrefix, scopedRoleAssignmentComponent, k.name, k.subKind)
+	encodedScope, err := scopes.EncodeForKey(k.scope)
+	if err != nil {
+		return backend.Key{}, trace.Wrap(err)
+	}
+	return backend.NewKey(scopedPrefix, scopedRoleAssignmentPrefix, encodedScope, k.name, k.subKind), nil
 }
 
 func scopedRoleAssignmentWatchPrefix() backend.Key {
-	return backend.ExactKey(scopedRolePrefix, scopedRoleAssignmentComponent)
+	return backend.ExactKey(scopedPrefix, scopedRoleAssignmentPrefix)
+}
+
+// verifyKeyScope checks that a scoped resource's scope field agrees with the scope encoded in its
+// backend key, rejecting the resource if they disagree.
+func verifyKeyScope(key, watchPrefix backend.Key, fieldScope string) error {
+	components := key.TrimPrefix(watchPrefix).Components()
+	if len(components) == 0 {
+		return trace.BadParameter("scoped resource key %q is missing its scope component", key)
+	}
+
+	keyScope, err := scopes.DecodeFromKey(components[0])
+	if err != nil {
+		return trace.Wrap(err, "failed decoding scope from scoped resource key %q", key)
+	}
+
+	if scopes.Compare(keyScope, fieldScope) != scopes.Equivalent {
+		return trace.BadParameter("scoped resource at key %q has scope field %q conflicting with key-encoded scope %q", key, fieldScope, keyScope)
+	}
+
+	return nil
 }
 
 func scopedRoleFromItem(item *backend.Item) (*scopedaccessv1.ScopedRole, error) {
@@ -739,8 +673,12 @@ func scopedRoleFromItem(item *backend.Item) (*scopedaccessv1.ScopedRole, error) 
 		return nil, trace.BadParameter("role at %q is critically malformed (missing metadata)", item.Key)
 	}
 
-	role.Metadata.Revision = item.Revision
-	role.Metadata.Expires = utils.TimeIntoProto(item.Expires)
+	if err := verifyKeyScope(item.Key, scopedRoleWatchPrefix(), role.GetScope()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	role.GetMetadata().SetRevision(item.Revision)
+	role.GetMetadata().SetExpires(utils.TimeIntoProto(item.Expires))
 	return &role, nil
 }
 
@@ -758,8 +696,13 @@ func scopedRoleToItem(role *scopedaccessv1.ScopedRole) (backend.Item, error) {
 		return backend.Item{}, trace.Wrap(err)
 	}
 
+	key, err := scopedRoleKey{scope: role.GetScope(), name: role.GetMetadata().GetName()}.Key()
+	if err != nil {
+		return backend.Item{}, trace.Wrap(err)
+	}
+
 	return backend.Item{
-		Key:      scopedRoleKey(role.GetMetadata().GetName()),
+		Key:      key,
 		Value:    data,
 		Revision: role.GetMetadata().GetRevision(),
 	}, nil
@@ -775,8 +718,12 @@ func scopedRoleAssignmentFromItem(item *backend.Item) (*scopedaccessv1.ScopedRol
 		return nil, trace.BadParameter("assignment at %q is critically malformed (missing metadata)", item.Key)
 	}
 
-	assignment.Metadata.Revision = item.Revision
-	assignment.Metadata.Expires = utils.TimeIntoProto(item.Expires)
+	if err := verifyKeyScope(item.Key, scopedRoleAssignmentWatchPrefix(), assignment.GetScope()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	assignment.GetMetadata().SetRevision(item.Revision)
+	assignment.GetMetadata().SetExpires(utils.TimeIntoProto(item.Expires))
 	return &assignment, nil
 }
 
@@ -798,11 +745,17 @@ func scopedRoleAssignmentToItem(assignment *scopedaccessv1.ScopedRoleAssignment)
 		return backend.Item{}, trace.Wrap(err)
 	}
 
+	key, err := scopedRoleAssignmentKey{
+		scope:   assignment.GetScope(),
+		name:    assignment.GetMetadata().GetName(),
+		subKind: assignment.GetSubKind(),
+	}.Key()
+	if err != nil {
+		return backend.Item{}, trace.Wrap(err)
+	}
+
 	return backend.Item{
-		Key: scopedRoleAssignmentKey{
-			name:    assignment.GetMetadata().GetName(),
-			subKind: assignment.GetSubKind(),
-		}.Key(),
+		Key:      key,
 		Value:    data,
 		Revision: assignment.GetMetadata().GetRevision(),
 	}, nil

--- a/lib/services/local/scoped_access_test.go
+++ b/lib/services/local/scoped_access_test.go
@@ -31,8 +31,10 @@ import (
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
@@ -123,12 +125,14 @@ func testScopedRoleEvents(t *testing.T) {
 	event = getNextEvent()
 	require.Equal(t, types.OpDelete, event.Type)
 
-	require.Empty(t, cmp.Diff(&types.ResourceHeader{
+	deletedRole := event.Resource.(types.Resource153UnwrapperT[*scopedaccessv1.ScopedRole]).UnwrapT()
+	require.Empty(t, cmp.Diff(scopedaccessv1.ScopedRole_builder{
 		Kind: scopedaccess.KindScopedRole,
-		Metadata: types.Metadata{
-			Name: role.Metadata.Name,
-		},
-	}, event.Resource.(*types.ResourceHeader), protocmp.Transform()))
+		Metadata: headerv1.Metadata_builder{
+			Name: role.GetMetadata().GetName(),
+		}.Build(),
+		Scope: "/",
+	}.Build(), deletedRole, protocmp.Transform()))
 
 	// recreate scoped role so that we can use it for testing assignment events
 	_, err = service.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
@@ -178,13 +182,15 @@ func testScopedRoleEvents(t *testing.T) {
 	event = getNextEvent()
 	require.Equal(t, types.OpDelete, event.Type)
 
-	require.Empty(t, cmp.Diff(&types.ResourceHeader{
+	deletedAssignment := event.Resource.(types.Resource153UnwrapperT[*scopedaccessv1.ScopedRoleAssignment]).UnwrapT()
+	require.Empty(t, cmp.Diff(scopedaccessv1.ScopedRoleAssignment_builder{
 		Kind:    scopedaccess.KindScopedRoleAssignment,
 		SubKind: scopedaccess.SubKindDynamic,
-		Metadata: types.Metadata{
-			Name: assignment.Metadata.Name,
-		},
-	}, event.Resource.(*types.ResourceHeader), protocmp.Transform()))
+		Metadata: headerv1.Metadata_builder{
+			Name: assignment.GetMetadata().GetName(),
+		}.Build(),
+		Scope: "/",
+	}.Build(), deletedAssignment, protocmp.Transform()))
 
 	// Assert that any materialized assignments put into the backend (possibly
 	// by an auth service on a later version) don't make it into the event
@@ -200,6 +206,108 @@ func testScopedRoleEvents(t *testing.T) {
 		t.Fatalf("expected no event, got %v", evt)
 	default:
 	}
+}
+
+// TestScopedRoleEventsScopeFilter verifies that the local backend event watcher honors a watch kind's
+// scope filter (equivalently to the fanout), applying it to both put and delete events.
+func TestScopedRoleEventsScopeFilter(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, testScopedRoleEventsScopeFilter)
+}
+
+func testScopedRoleEventsScopeFilter(t *testing.T) {
+	ctx := t.Context()
+
+	backend, err := memory.New(memory.Config{Context: ctx})
+	require.NoError(t, err)
+	defer backend.Close()
+
+	service := NewScopedAccessService(backend)
+	events := NewEventsService(backend)
+
+	// watch scoped roles at exactly "/foo".
+	watcher, err := events.NewWatcher(ctx, types.Watch{
+		Kinds: []types.WatchKind{{
+			Kind:        scopedaccess.KindScopedRole,
+			ScopeFilter: types.ScopeFilterFromProto(scopesv1.Filter_builder{Scope: "/foo", Mode: scopesv1.Mode_MODE_EXACT}.Build()),
+		}},
+	})
+	require.NoError(t, err)
+	defer watcher.Close()
+
+	getNextEvent := func() types.Event {
+		t.Helper()
+		synctest.Wait()
+		select {
+		case event := <-watcher.Events():
+			return event
+		case <-watcher.Done():
+			require.FailNow(t, "Watcher exited with error", watcher.Error())
+		default:
+			require.FailNow(t, "No event ready, synctest bubble is durably blocked")
+		}
+		panic("unreachable")
+	}
+
+	expectNoEvent := func() {
+		t.Helper()
+		synctest.Wait()
+		select {
+		case event := <-watcher.Events():
+			require.FailNow(t, "expected no event", "got %v of kind %q at scope %q", event.Type, event.Resource.GetKind(), event.Resource.GetSubKind())
+		default:
+		}
+	}
+
+	createRole := func(name, scope string) {
+		t.Helper()
+		_, err := service.CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+			Role: scopedaccessv1.ScopedRole_builder{
+				Kind:     scopedaccess.KindScopedRole,
+				Metadata: headerv1.Metadata_builder{Name: name}.Build(),
+				Scope:    scope,
+				Spec:     scopedaccessv1.ScopedRoleSpec_builder{AssignableScopes: []string{scope}}.Build(),
+				Version:  types.V1,
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+	}
+
+	deleteRole := func(name, scope string) {
+		t.Helper()
+		_, err := service.DeleteScopedRole(ctx, scopedaccessv1.DeleteScopedRoleRequest_builder{
+			Name:  name,
+			Scope: scope,
+		}.Build())
+		require.NoError(t, err)
+	}
+
+	event := getNextEvent()
+	require.Equal(t, types.OpInit, event.Type)
+
+	// a role at "/foo" matches the filter: its put event is delivered.
+	createRole("foo-role", "/foo")
+	event = getNextEvent()
+	require.Equal(t, types.OpPut, event.Type)
+	require.Equal(t, "/foo", event.Resource.(types.Resource153UnwrapperT[*scopedaccessv1.ScopedRole]).UnwrapT().GetScope())
+
+	// a role at "/bar" (orthogonal) does not match: no event.
+	createRole("bar-role", "/bar")
+	expectNoEvent()
+
+	// a role at "/foo/sub" (descendant) does not match an EXACT filter: no event.
+	createRole("sub-role", "/foo/sub")
+	expectNoEvent()
+
+	// the delete of the "/foo" role matches the filter (scoped deletes carry scope): delete is delivered.
+	deleteRole("foo-role", "/foo")
+	event = getNextEvent()
+	require.Equal(t, types.OpDelete, event.Type)
+	require.Equal(t, "/foo", event.Resource.(types.Resource153UnwrapperT[*scopedaccessv1.ScopedRole]).UnwrapT().GetScope())
+
+	// the delete of the "/bar" role does not match: no event.
+	deleteRole("bar-role", "/bar")
+	expectNoEvent()
 }
 
 // TestScopedRoleBasicCRUD tests the basic CRUD operations of the ScopedAccessService, excluding the more non-trivial
@@ -419,15 +527,33 @@ func TestScopedRoleBasicCRUD(t *testing.T) {
 	require.NoError(t, err, "upsert should succeed despite stale revision")
 	require.Empty(t, cmp.Diff(basic04Mod, uprsp2.Role, protocmp.Transform(), protocmp.IgnoreFields(&headerv1.Metadata{}, "revision")))
 
-	// verify upsert rejects scope change
-	basic04ScopeChange := apiutils.CloneProtoMsg(uprsp2.Role)
-	basic04ScopeChange.Scope = "/other"
-	basic04ScopeChange.Spec.AssignableScopes = []string{"/other"}
-	_, err = service.UpsertScopedRole(ctx, &scopedaccessv1.UpsertScopedRoleRequest{
-		Role: basic04ScopeChange,
-	})
-	require.Error(t, err)
-	require.True(t, trace.IsBadParameter(err), "expected BadParameter error, got %v", err)
+	// namespaced by scope, so upserting the same name at a different scope creates a distinct role
+	// rather than "moving" the existing one.
+	basic04OtherScope := apiutils.CloneProtoMsg(uprsp2.GetRole())
+	basic04OtherScope.SetScope("/other")
+	basic04OtherScope.GetSpec().SetAssignableScopes([]string{"/other"})
+	basic04OtherScope.GetMetadata().SetRevision("")
+	upOther, err := service.UpsertScopedRole(ctx, scopedaccessv1.UpsertScopedRoleRequest_builder{
+		Role: basic04OtherScope,
+	}.Build())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(basic04OtherScope, upOther.GetRole(), protocmp.Transform(), protocmp.IgnoreFields(&headerv1.Metadata{}, "revision")))
+
+	// the original role at /qux is untouched.
+	origGet, err := service.GetScopedRole(ctx, scopedaccessv1.GetScopedRoleRequest_builder{
+		Name:  basic04.GetMetadata().GetName(),
+		Scope: "/qux",
+	}.Build())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(basic04Mod, origGet.GetRole(), protocmp.Transform(), protocmp.IgnoreFields(&headerv1.Metadata{}, "revision")))
+
+	// and the distinct role at /other is independently retrievable.
+	otherGet, err := service.GetScopedRole(ctx, scopedaccessv1.GetScopedRoleRequest_builder{
+		Name:  basic04.GetMetadata().GetName(),
+		Scope: "/other",
+	}.Build())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(basic04OtherScope, otherGet.GetRole(), protocmp.Transform(), protocmp.IgnoreFields(&headerv1.Metadata{}, "revision")))
 }
 
 // TestScopedRoleAssignmentBasicCRD tests the basic CRD operations of the ScopedRoleAssignmentService, excluding the more non-trivial
@@ -624,14 +750,15 @@ func TestScopedRoleAssignmentBasicCRD(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
 
-	// verify that update is rejected if the assignment's resource scope is changed
-	assignment01ScopeChange := apiutils.CloneProtoMsg(ursp.Assignment)
-	assignment01ScopeChange.Scope = "/foo"
-	_, err = service.UpdateScopedRoleAssignment(ctx, &scopedaccessv1.UpdateScopedRoleAssignmentRequest{
-		Assignment: assignment01ScopeChange,
-	})
+	// namespaced by scope, so changing the scope targets a different (nonexistent) resource
+	// and fails rather than mutating the original.
+	assignment01OtherScope := apiutils.CloneProtoMsg(ursp.GetAssignment())
+	assignment01OtherScope.SetScope("/foo")
+	_, err = service.UpdateScopedRoleAssignment(ctx, scopedaccessv1.UpdateScopedRoleAssignmentRequest_builder{
+		Assignment: assignment01OtherScope,
+	}.Build())
 	require.Error(t, err)
-	require.True(t, trace.IsBadParameter(err), "expected BadParameter error, got %v", err)
+	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
 
 	// verify that update fails if the assignment does not exist
 	_, err = service.UpdateScopedRoleAssignment(ctx, &scopedaccessv1.UpdateScopedRoleAssignmentRequest{
@@ -826,12 +953,115 @@ func TestScopedRoleAssignmentBasicCRD(t *testing.T) {
 	require.NoError(t, err, "upsert should succeed despite stale revision")
 	require.Len(t, uaprsp2.Assignment.Spec.Assignments, 2)
 
-	// verify upsert rejects scope change
-	assignment04ScopeChange := apiutils.CloneProtoMsg(uaprsp2.Assignment)
-	assignment04ScopeChange.Scope = "/foo"
-	_, err = service.UpsertScopedRoleAssignment(ctx, &scopedaccessv1.UpsertScopedRoleAssignmentRequest{
-		Assignment: assignment04ScopeChange,
-	})
+	// under namespacing an assignment's (scope, name) is its identity, so upserting the same name at a
+	// different scope creates a distinct assignment rather than moving the existing one; both coexist.
+	assignment04OtherScope := apiutils.CloneProtoMsg(uaprsp2.GetAssignment())
+	assignment04OtherScope.SetScope("/foo")
+	assignment04OtherScope.GetMetadata().SetRevision("") // distinct resource, no prior revision
+	upOther, err := service.UpsertScopedRoleAssignment(ctx, scopedaccessv1.UpsertScopedRoleAssignmentRequest_builder{
+		Assignment: assignment04OtherScope,
+	}.Build())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(assignment04OtherScope, upOther.GetAssignment(), protocmp.Transform(), protocmp.IgnoreFields(&headerv1.Metadata{}, "revision")))
+
+	// the original assignment at / is untouched.
+	origGet, err := service.GetScopedRoleAssignment(ctx, scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
+		Name:    assignment04.GetMetadata().GetName(),
+		SubKind: assignment04.GetSubKind(),
+		Scope:   "/",
+	}.Build())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(assignment04Mod, origGet.GetAssignment(), protocmp.Transform(), protocmp.IgnoreFields(&headerv1.Metadata{}, "revision")))
+
+	// and the distinct assignment at /foo is independently retrievable.
+	otherGet, err := service.GetScopedRoleAssignment(ctx, scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
+		Name:    assignment04.GetMetadata().GetName(),
+		SubKind: assignment04.GetSubKind(),
+		Scope:   "/foo",
+	}.Build())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(assignment04OtherScope, otherGet.GetAssignment(), protocmp.Transform(), protocmp.IgnoreFields(&headerv1.Metadata{}, "revision")))
+}
+
+// TestScopedAccessScopeConflict verifies that when a scoped resource's scope field disagrees with the
+// scope encoded in its backend key, the resource is rejected appropriately. Get errors, List skips,
+// and the event parser errors (closing the watcher). Delete succeeds when targeting the.
+func TestScopedAccessScopeConflict(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	bk, err := memory.New(memory.Config{Context: ctx})
+	require.NoError(t, err)
+	defer bk.Close()
+
+	service := NewScopedAccessService(bk)
+
+	// role definition specifies scope `/foo`
+	role := scopedaccessv1.ScopedRole_builder{
+		Kind:     scopedaccess.KindScopedRole,
+		Metadata: headerv1.Metadata_builder{Name: "conflicted"}.Build(),
+		Scope:    "/foo",
+		Spec:     scopedaccessv1.ScopedRoleSpec_builder{AssignableScopes: []string{"/foo"}}.Build(),
+		Version:  types.V1,
+	}.Build()
+
+	validItem, err := scopedRoleToItem(role)
+	require.NoError(t, err)
+
+	// role key specified scope `/bar`
+	conflictKey, err := scopedRoleKey{scope: "/bar", name: role.GetMetadata().GetName()}.Key()
+	require.NoError(t, err)
+	conflictItem := backend.Item{Key: conflictKey, Value: validItem.Value}
+	_, err = service.bk.Put(ctx, conflictItem)
+	require.NoError(t, err)
+
+	//  write a well-formed role so we can confirm List skips only the conflicting one.
+	validRole := scopedaccessv1.ScopedRole_builder{
+		Kind:     scopedaccess.KindScopedRole,
+		Metadata: headerv1.Metadata_builder{Name: "valid"}.Build(),
+		Scope:    "/baz",
+		Spec:     scopedaccessv1.ScopedRoleSpec_builder{AssignableScopes: []string{"/baz"}}.Build(),
+		Version:  types.V1,
+	}.Build()
+	_, err = service.CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{Role: validRole}.Build())
+	require.NoError(t, err)
+
+	// Get at the key-encoded scope finds the item but rejects it as a scope conflict.
+	_, err = service.GetScopedRole(ctx, scopedaccessv1.GetScopedRoleRequest_builder{
+		Name:  role.GetMetadata().GetName(),
+		Scope: "/bar",
+	}.Build())
 	require.Error(t, err)
 	require.True(t, trace.IsBadParameter(err), "expected BadParameter error, got %v", err)
+
+	// List skips the conflicting role but still returns the valid one.
+	lrsp, err := service.ListScopedRoles(ctx, &scopedaccessv1.ListScopedRolesRequest{})
+	require.NoError(t, err)
+	var listedNames []string
+	for _, r := range lrsp.GetRoles() {
+		listedNames = append(listedNames, r.GetMetadata().GetName())
+	}
+	require.Equal(t, []string{"valid"}, listedNames)
+
+	parser := newScopedRoleParser()
+
+	// the Put event parser errors on the conflict.
+	_, err = parser.parse(backend.Event{Type: types.OpPut, Item: conflictItem})
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter error, got %v", err)
+
+	// the Delete event parser is unaffecte.
+	deleted, err := parser.parse(backend.Event{Type: types.OpDelete, Item: conflictItem})
+	require.NoError(t, err)
+	deletedRole := deleted.(types.Resource153UnwrapperT[*scopedaccessv1.ScopedRole]).UnwrapT()
+	require.Equal(t, "/bar", deletedRole.GetScope())
+	require.Equal(t, role.GetMetadata().GetName(), deletedRole.GetMetadata().GetName())
+
+	// Delete by the key-encoded scope succeeds
+	_, err = service.DeleteScopedRole(ctx, scopedaccessv1.DeleteScopedRoleRequest_builder{
+		Name:  role.GetMetadata().GetName(),
+		Scope: "/bar",
+	}.Build())
+	require.NoError(t, err)
 }

--- a/lib/services/scoped_access_checker_context.go
+++ b/lib/services/scoped_access_checker_context.go
@@ -309,6 +309,10 @@ func (c *ScopedAccessCheckerContext) riskyEnumerateScopedCheckers(ctx context.Co
 // filters through this method so that an omitted filter is consistently and safely defaulted, minimizing
 // per-API defaulting logic. Note that this method only handles defaulting; callers are still responsible for
 // validating (see [scopes.ValidateFilter]) and authorizing the resulting filter.
+//
+// There is one subtle exception to this default behavior. The event system treats requests to watch certain
+// *always unscoped* kinds as having a default UNSCOPED filter, even for scoped callers. This behavior is only
+// present for unscoped kinds that have an unscoped read exception in place (e.g. cert authorities).
 func (c *ScopedAccessCheckerContext) ResolveScopeFilter(filter *scopesv1.Filter) *scopesv1.Filter {
 	if filter.GetMode() != scopesv1.Mode_MODE_UNSPECIFIED {
 		// the caller specified an explicit filter; return it unchanged.

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/clientutils"
@@ -490,6 +491,70 @@ func NewAppWatcher(ctx context.Context, cfg AppWatcherConfig) (*GenericWatcher[t
 	return w, trace.Wrap(err)
 }
 
+type AppServersWatcherConfig struct {
+	AppServersGetter
+	ResourceWatcherConfig
+}
+
+// CheckAndSetDefaults checks parameters and sets default values.
+func (cfg *AppServersWatcherConfig) CheckAndSetDefaults() error {
+	if err := cfg.ResourceWatcherConfig.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if cfg.MaxStaleness == 0 {
+		const appServerMaxStaleness = time.Minute
+		cfg.MaxStaleness = appServerMaxStaleness
+	}
+
+	if cfg.AppServersGetter == nil {
+		getter, ok := cfg.Client.(AppServersGetter)
+		if !ok {
+			return trace.BadParameter("missing parameter AppServersGetter and Client not usable as AppServersGetter")
+		}
+		cfg.AppServersGetter = getter
+	}
+
+	return nil
+}
+
+func NewAppServersWatcher(ctx context.Context, cfg AppServersWatcherConfig) (*GenericWatcher[types.AppServer, readonly.AppServer], error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	w, err := NewGenericResourceWatcher(ctx, GenericWatcherConfig[types.AppServer, readonly.AppServer]{
+		ResourceWatcherConfig: cfg.ResourceWatcherConfig,
+		ResourceKind:          types.KindAppServer,
+		// The app server watcher is a proxy only routing construct (see the
+		// reversetunnel server and initProxyEndpoint call sites); it must observe app
+		// servers in every scope, not just unscoped ones, so it watches with MODE_ALL.
+		ScopeFilter: types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build()),
+		ResourceKey: func(resource types.AppServer) string {
+			// host IDs are guaranteed to not contain "/"
+			return resource.GetHostID() + "/" + resource.GetName()
+		},
+		DeleteKey: func(r types.Resource) string {
+			// the host ID is stored in metadata.description in app server delete events
+			return r.GetMetadata().Description + "/" + r.GetName()
+		},
+		ResourceGetter: func(ctx context.Context) ([]types.AppServer, error) {
+			// TODO(fspmarshall/scopes): this list does not yet honor scope filters, so it
+			// currently returns app servers in every scope and happens to match the MODE_ALL watch
+			// above. Once the list API supports scope filters (and defaults unscoped callers to
+			// unscoped-only, like the watch API), this call must explicitly request MODE_ALL as well.
+			return cfg.AppServersGetter.GetApplicationServers(ctx, apidefaults.Namespace)
+		},
+		DisableUpdateBroadcast: true,
+		CloneFunc:              types.AppServer.Copy,
+		ReadOnlyFunc: func(resource types.AppServer) readonly.AppServer {
+			return resource
+		},
+	})
+
+	return w, trace.Wrap(err)
+}
+
 type DatabaseServerWatcherConfig struct {
 	DatabaseServersGetter
 	ResourceWatcherConfig
@@ -540,61 +605,6 @@ func NewDatabaseServerWatcher(ctx context.Context, cfg DatabaseServerWatcherConf
 		DisableUpdateBroadcast: true,
 		CloneFunc:              types.DatabaseServer.Copy,
 		ReadOnlyFunc:           readonly.NewDatabaseServer,
-	})
-
-	return w, trace.Wrap(err)
-}
-
-type AppServersWatcherConfig struct {
-	AppServersGetter
-	ResourceWatcherConfig
-}
-
-func (cfg *AppServersWatcherConfig) CheckAndSetDefaults() error {
-	if err := cfg.ResourceWatcherConfig.CheckAndSetDefaults(); err != nil {
-		return trace.Wrap(err)
-	}
-
-	if cfg.MaxStaleness == 0 {
-		const databaseServerMaxStaleness = time.Minute
-		cfg.MaxStaleness = databaseServerMaxStaleness
-	}
-
-	if cfg.AppServersGetter == nil {
-		getter, ok := cfg.Client.(AppServersGetter)
-		if !ok {
-			return trace.BadParameter("missing parameter AppServersGetter and Client not usable as AppServersGetter")
-		}
-		cfg.AppServersGetter = getter
-	}
-
-	return nil
-}
-
-func NewAppServersWatcher(ctx context.Context, cfg AppServersWatcherConfig) (*GenericWatcher[types.AppServer, readonly.AppServer], error) {
-	if err := cfg.CheckAndSetDefaults(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	w, err := NewGenericResourceWatcher(ctx, GenericWatcherConfig[types.AppServer, readonly.AppServer]{
-		ResourceWatcherConfig: cfg.ResourceWatcherConfig,
-		ResourceKind:          types.KindAppServer,
-		ResourceKey: func(r types.AppServer) string {
-			// the host ID is guaranteed not to contain "/"
-			return r.GetHostID() + "/" + r.GetName()
-		},
-		DeleteKey: func(r types.Resource) string {
-			// the host ID is stored in metadata.description in app server delete events
-			return r.GetMetadata().Description + "/" + r.GetName()
-		},
-		ResourceGetter: func(ctx context.Context) ([]types.AppServer, error) {
-			return cfg.AppServersGetter.GetApplicationServers(ctx, apidefaults.Namespace)
-		},
-		DisableUpdateBroadcast: true,
-		CloneFunc:              types.AppServer.Copy,
-		ReadOnlyFunc: func(resource types.AppServer) readonly.AppServer {
-			return resource
-		},
 	})
 
 	return w, trace.Wrap(err)
@@ -732,6 +742,14 @@ type GenericWatcherConfig[T any, R any] struct {
 	ResourceWatcherConfig
 	// ResourceKind specifies the kind of resource the watcher is monitoring.
 	ResourceKind string
+	// ScopeFilter is an optional scope filter applied to the watch. A nil filter
+	// yields the caller's default scope behavior (unscoped-only for unscoped
+	// callers, current-scope-only for scoped callers). Watchers that run on the
+	// teleport proxy and must observe every instance of an optionally-scoped kind
+	// (regardless of scope) should set this to MODE_ALL. Note that the paired
+	// ResourceGetter (the list seed) does not yet honor scope filters; see the
+	// TODO at each MODE_ALL call site.
+	ScopeFilter *types.ScopeFilter
 	// RequireResourcesForInitialBroadcast indicates whether an update should be
 	// performed if the initial set of resources is empty.
 	RequireResourcesForInitialBroadcast bool
@@ -877,6 +895,7 @@ func (g *genericCollector[T, R]) resourceKinds() []types.WatchKind {
 	return []types.WatchKind{{
 		Kind:        g.ResourceKind,
 		LoadSecrets: g.LoadSecrets,
+		ScopeFilter: g.ScopeFilter,
 	}}
 }
 
@@ -1574,6 +1593,11 @@ type NodeWatcherConfig struct {
 	// NodesGetter is used to directly fetch the list of active nodes.
 	NodesGetter
 	ResourceWatcherConfig
+	// ScopeFilter is an optional scope filter applied to the node watch. See
+	// GenericWatcherConfig.ScopeFilter for discussion of function. Node watchers
+	// that run on the teleport proxy need to see nodes in every scope for routing
+	// and should set this to MODE_ALL.
+	ScopeFilter *types.ScopeFilter
 }
 
 // NewNodeWatcher returns a new instance of NodeWatcher.
@@ -1585,7 +1609,12 @@ func NewNodeWatcher(ctx context.Context, cfg NodeWatcherConfig) (*GenericWatcher
 	w, err := NewGenericResourceWatcher(ctx, GenericWatcherConfig[types.Server, readonly.Server]{
 		ResourceWatcherConfig: cfg.ResourceWatcherConfig,
 		ResourceKind:          types.KindNode,
+		ScopeFilter:           cfg.ScopeFilter,
 		ResourceGetter: func(ctx context.Context) ([]types.Server, error) {
+			// TODO(fspmarshall/scopes): this list does not yet honor scope filters, so it
+			// currently returns nodes in every scope and happens to match a MODE_ALL watch.
+			// Once the list API supports scope filters (and defaults unscoped callers to
+			// unscoped-only, like the watch API), this call must honor cfg.ScopeFilter.
 			return cfg.NodesGetter.GetNodes(ctx, apidefaults.Namespace)
 		},
 		ResourceKey:            types.Server.GetName,


### PR DESCRIPTION
Backport #68605 to branch/v18.

## Manual Test Plan
### Test Environment

Local env

### Test Cases
- [x] Verify that unscoped teleport agents/services can start without cache errors.
- [x]  Verify scoped SSH access functions as intended (notably, that proxy routing functions as intended).
- [x] Verify unscoped SSH access to scoped and unscoped nodes functions as intended.
- [x] Verify manual CRUD of multiple scoped roles/assignments in different scopes with the same name.