### PR TITLE
SKILL: add AWS organization wide discovery terraform module

### DIFF
--- a/skills/teleport-discovery/SKILL.md
+++ b/skills/teleport-discovery/SKILL.md
@@ -47,8 +47,8 @@ results.
 
 ## Determine the cloud
 
-Set `CLOUD` before anything else. Infer `aws` when the request names EC2, EKS, or an AWS
-account. Infer `azure` when it names VMs, a subscription, or a resource group. If
+Set `CLOUD` before anything else. Infer `aws` when the request names EC2, EKS, an AWS account, or an AWS Organization.
+Infer `azure` when it names VMs, a subscription, or a resource group. If
 the request implies neither, stop and ask the user which cloud. Do not run `aws` or `az` commands
 and do not write Terraform until `CLOUD` is set.
 

--- a/skills/teleport-discovery/evals/evals.json
+++ b/skills/teleport-discovery/evals/evals.json
@@ -319,6 +319,103 @@
         "The teleport provider version constraint in the applied configuration floors at the 18.7.6 module minimum or the cluster major and caps below the next major.",
         "The agent verified the resources itself following references/monitor.md and reported the verification in final-response.md."
       ]
+    },
+    {
+      "id": 18,
+      "eval_name": "aws-organization-write-all-accounts",
+      "cloud": "aws",
+      "tier": "write",
+      "fixture": "cloud-aws-organization",
+      "copy_fixture": null,
+      "prompt": "Set up AWS Organization auto-discovery on our Teleport Cloud tenant acme.teleport.sh in every account and every region tagged env=prod. Do not exclude any accounts. Terraform will run with management-account credentials, and both the Discovery Service and Auth Service use credentials from that management account. The plan is approved. Write the Terraform into a new directory, but do not run terraform init, plan, or apply.",
+      "assertions": [
+        "Wrote Terraform into a new directory under outputs/ with versions.tf and main.tf, and terraform validate passes for that directory.",
+        "The agent treated this as AWS Organization scope, not single-account discovery, because the prompt explicitly requests every account.",
+        "The aws_discovery module sets aws_organization_discovery.organizational_units.include to exactly [\"*\"] and exclude to exactly []. It does not invent Root or Organizational Unit IDs.",
+        "Exactly one AWS matcher is present with types [\"ec2\"], regions omitted or [\"*\"], and tags {env: [\"prod\"]}. No EKS matcher or kube_app_discovery setting is present.",
+        "main.tf exports module.aws_discovery.aws_child_account_iam_role_template through an output named exactly aws_child_account_iam_role_template, in addition to integration_name, discovery_config_name, oidc_provider_arn, and discovery_role_arn.",
+        "The module source is exactly terraform.releases.teleport.dev/teleport/discovery/aws and its version is >= 18.10.2, < 19.0.0. The teleport provider constraint is >= 18.8.3, < 19.0.0.",
+        "create_aws_iam_openid_connect_provider is NOT set to false because the fixture account has no matching OIDC provider.",
+        "The agent ran no terraform. outputs/ contains no agent-created .terraform directory, .tfstate, or .terraform.lock.hcl."
+      ]
+    },
+    {
+      "id": 19,
+      "eval_name": "aws-organization-reject-old-cluster",
+      "cloud": "aws",
+      "tier": "write",
+      "fixture": "cloud-aws",
+      "copy_fixture": null,
+      "prompt": "Configure organization-wide EC2 auto-discovery for every account in our AWS Organization on acme.teleport.sh. Search every region and use all tags. Write the Terraform, but do not apply it.",
+      "assertions": [
+        "The agent read cluster version 18.8.0 from the stub tctl status and stopped because AWS Organization discovery requires Teleport 18.8.3 or later.",
+        "final-response.md states the detected cluster version and the 18.8.3 minimum, without claiming that discovery was configured.",
+        "The agent performed the version gate before asking setup questions or writing configuration.",
+        "outputs/ contains no .tf files, IAM policies, role templates, or other generated deployment artifacts.",
+        "The agent did not run terraform init, plan, or apply."
+      ]
+    },
+    {
+      "id": 20,
+      "eval_name": "aws-organization-reject-eks",
+      "cloud": "aws",
+      "tier": "write",
+      "fixture": "cloud-aws-organization",
+      "copy_fixture": null,
+      "prompt": "Configure AWS Organization auto-discovery on acme.teleport.sh for all EKS clusters in every account. Write the Terraform, but do not apply it.",
+      "assertions": [
+        "The agent read cluster version 18.8.3, recognized Organization scope, and stopped because organization-wide discovery currently supports only EC2, not EKS.",
+        "final-response.md clearly explains the EC2-only limitation and does not claim that EKS organization discovery was configured.",
+        "outputs/ contains no .tf files or other generated deployment artifacts; the agent did not silently fall back to single-account EKS discovery.",
+        "The agent did not run terraform init, plan, or apply."
+      ]
+    },
+    {
+      "id": 21,
+      "eval_name": "aws-organization-reject-invalid-ou-filters",
+      "cloud": "aws",
+      "tier": "write",
+      "fixture": "cloud-aws-organization",
+      "copy_fixture": null,
+      "prompt": "Set up EC2 discovery across our AWS Organization on acme.teleport.sh. Include * plus ou-abcd-12345678, and exclude *. Search us-east-1. Write the Terraform but do not apply it.",
+      "assertions": [
+        "The agent rejects both invalid filters: wildcard include must be the only include entry, and wildcard is never allowed in exclude.",
+        "The agent asks for corrected exact Root or Organizational Unit IDs instead of guessing, deleting the extra include, or treating exclude * as an empty exclusion list.",
+        "outputs/ contains no .tf files because the filters are invalid and have not been corrected.",
+        "The agent did not run terraform init, plan, or apply and did not claim discovery was configured."
+      ]
+    },
+    {
+      "id": 22,
+      "eval_name": "aws-organization-apply-require-credentials",
+      "cloud": "aws",
+      "tier": "write",
+      "fixture": "cloud-aws-organization",
+      "copy_fixture": null,
+      "prompt": "The Terraform for AWS Organization EC2 discovery on acme.teleport.sh has already applied successfully for include [\"*\"] and exclude []. Finish the apply and verify that discovery is healthy. I have not yet confirmed which AWS credentials Terraform, the Discovery Service, or the Auth Service use.",
+      "assertions": [
+        "The agent asks for explicit confirmation that Terraform runs with management-account or delegated-administrator credentials and that both the Discovery Service and Auth Service use credentials from one of those accounts.",
+        "The agent does not infer organization_credentials_confirmed from the successful Terraform apply or from the active AWS caller identity.",
+        "The agent does not start Monitor, query discovery_config status, or report the deployment healthy before receiving the credential confirmation.",
+        "The agent does not create child-account IAM roles, run terraform, or write files. outputs/ contains no generated artifacts.",
+        "final-response.md makes the missing confirmation the blocking next step."
+      ]
+    },
+    {
+      "id": 23,
+      "eval_name": "aws-organization-apply-require-child-roles",
+      "cloud": "aws",
+      "tier": "write",
+      "fixture": "cloud-aws-organization",
+      "copy_fixture": null,
+      "prompt": "Terraform has applied our AWS Organization EC2 discovery on acme.teleport.sh with include [\"*\"] and exclude []. I confirm Terraform ran with management-account credentials and the Discovery Service and Auth Service use credentials from that management account. The aws_child_account_iam_role_template output is: {role_name = \"teleport-organization-discovery-child-account-role\", assume_role_policy = \"Allow sts:AssumeRole from arn:aws:iam::111111111111:role/teleport-discovery with aws:PrincipalOrgID o-exampleorgid\", policy = \"Allow ssm:SendCommand, ssm:ListCommandInvocations, ssm:GetCommandInvocation, ssm:DescribeInstanceInformation, ec2:DescribeInstances, and account:ListRegions on *\"}. The roles do not exist yet. Finish the apply and verify that discovery is healthy.",
+      "assertions": [
+        "The agent presents the aws_child_account_iam_role_template role name, trust-policy requirements, and permissions from the supplied output without dumping or requesting unrelated Terraform state.",
+        "The agent asks the user to create teleport-organization-discovery-child-account-role in every included account and explicitly says that include [\"*\"] also requires the role in the management account.",
+        "The agent does not create the IAM roles because the prompt does not explicitly request role creation.",
+        "The agent does not start Monitor, query discovery_config status, link the deployment as healthy, or otherwise claim success before the user confirms that every required role exists.",
+        "The agent does not run terraform or write files. outputs/ contains no generated artifacts, and final-response.md makes child-role confirmation the blocking next step."
+      ]
     }
   ]
 }

--- a/skills/teleport-discovery/evals/fixtures/scenarios/cloud-aws-organization.json
+++ b/skills/teleport-discovery/evals/fixtures/scenarios/cloud-aws-organization.json
@@ -1,0 +1,23 @@
+{
+  "tsh": {
+    "profile_url": "https://acme.teleport.sh:443",
+    "cluster": "acme.teleport.sh",
+    "username": "eval"
+  },
+  "tctl": {
+    "cluster": "acme.teleport.sh",
+    "version": "18.8.3",
+    "integrations": [],
+    "inventory_discovery": [
+      {
+        "id": "discovery-svc-1"
+      }
+    ]
+  },
+  "aws": {
+    "account": "111111111111",
+    "caller_arn": "arn:aws:iam::111111111111:user/eval",
+    "oidc_providers": [],
+    "region": "us-east-1"
+  }
+}

--- a/skills/teleport-discovery/references/apply.md
+++ b/skills/teleport-discovery/references/apply.md
@@ -50,8 +50,14 @@ secret.
 
 ## Confirm the apply
 
-From the apply output, read `integration_name` and `discovery_config_name`. Link the user to the
-integration's overview page in the web UI, using the host of `proxy_addr` without the port:
+From the apply output, read `integration_name` and `discovery_config_name`.
+
+For AWS Organization discovery, first confirm `organization_credentials_confirmed` is set.
+Then read the `aws_child_account_iam_role_template` output and present its role name, trust policy, and permissions without exposing unrelated Terraform state.
+Ask the user to create that role in every included account, including the management or delegated administrator account when `*` or the root is included.
+Do not create the roles without an explicit request, report the deployment healthy, or start Monitor until the user confirms all required roles exist.
+
+Link the user to the integration's overview page in the web UI, using the host of `proxy_addr` without the port:
 `https://<proxy_host>/web/integrations/overview/<integration_type>/<integration_name>`, where
 `<integration_type>` is `aws-oidc` for AWS and `azure-oidc` for Azure.
 

--- a/skills/teleport-discovery/references/aws-setup.md
+++ b/skills/teleport-discovery/references/aws-setup.md
@@ -56,8 +56,6 @@ Let `<major>` be `cluster_version`'s major version.
 For Teleport 18, set `<provider_version>` to `>= 18.8.3, < 19.0.0` for AWS Organization discovery and `>= 18.8.0, < 19.0.0` otherwise.
 For other majors, set it to `~> <major>.0`.
 
-<!-- TODO(marco): update with the actual release of the module
-PR: https://github.com/gravitational/teleport/pull/68704 -->
 Set `<module_version>` to `>= 18.10.2, < 19.0.0` for AWS Organization discovery on Teleport 18.
 Otherwise, set it to `~> <major>.0`.
 

--- a/skills/teleport-discovery/references/aws-setup.md
+++ b/skills/teleport-discovery/references/aws-setup.md
@@ -7,11 +7,15 @@ Resolve the common fields from the skill's Setup section, then these AWS fields.
 
 | Field | Tool derivation | Default |
 |-------|-----------------|---------|
-| `services` | none | `ec2` and `eks` matchers |
+| `scope` | see **Scope** below | `single account` |
+| `services` | none | Organization scope: `ec2`; single-account scope: `ec2` and `eks` matchers |
 | `regions` | none | Ask, with `["*"]` as the default |
 | `tags` | none | Ask, with `{"*": ["*"]}` as the default |
 | `kube_app_discovery` | none | Omit from the plan |
 | `existing_oidc_provider` | see **Existing OIDC provider** below | `no` |
+| `organizational_units_include` | none | Only when scope is Organization: Ask, and default to everything: `["*"]` |
+| `organizational_units_exclude` | none | Only when scope is Organization: Ask but default to empty `[]` |
+| `organization_credentials_confirmed` | none | Only when scope is Organization: Ask |
 
 ## Existing OIDC provider
 
@@ -25,10 +29,37 @@ Let `<host>` be `proxy_addr` without its port. Resolve `existing_oidc_provider`:
    `aws iam add-client-id-to-open-id-connect-provider --open-id-connect-provider-arn <arn> --client-id discover.teleport`,
    then set `yes`.
 
+## Scope
+
+Users can enroll a single account or an entire AWS Organization.
+
+Resolve `scope` before `services`.
+Set it to Organization when the request names an AWS Organization or requests discovery across multiple, all, or every account.
+Otherwise, use single-account scope.
+
+For AWS Organization discovery:
+
+1. If `cluster_version` is below `18.8.3`, stop: "AWS Organization discovery requires Teleport 18.8.3 or later. This cluster is v`<cluster_version>`."
+1. Only accept `ec2` as services to enroll. If the request includes another service, stop and explain that organization-wide discovery currently supports only EC2.
+1. Ask which organizational unit IDs to include through `organizational_units_include`. Accept `*` only when the user explicitly chooses all accounts; otherwise collect one or more Organization Root IDs or Organizational Unit IDs. Never infer `*` from an omitted or unusable answer.
+1. Resolve `organizational_units_exclude` to `[]` when the user explicitly requests all or every account without naming exclusions. Otherwise ask which exact Root or Organizational Unit IDs to exclude. An empty list means no exclusions.
+1. Validate the filters before writing: `include` must be nonempty; `*` must be its only entry; every other value must be a Root ID (`r-...`) or Organizational Unit ID (`ou-...`); and `exclude` must contain only exact Root or Organizational Unit IDs, never `*`.
+1. Ask the user to confirm that Terraform will run with credentials from the AWS Organization management account or a delegated administrator account and that the Discovery Service and Auth Service use credentials from one of those accounts. Set `organization_credentials_confirmed` only on explicit confirmation. Setup may write the Terraform without confirmation, but Apply must stop until it is confirmed.
+
+An IAM role must also be created manually in every included account. When `*` or the root is included, this includes the management or delegated administrator account.
+The `aws_child_account_iam_role_template` Terraform output contains the required role name, trust policy, and permissions.
+Apply must pause for these roles as described in `references/apply.md`.
+
 ## Write the Terraform
 
-Let `<major>` be `cluster_version`'s major version. Set `<provider_version>` to
-`>= 18.8.0, < 19.0.0` when `<major>` is 18, else `~> <major>.0`.
+Let `<major>` be `cluster_version`'s major version.
+For Teleport 18, set `<provider_version>` to `>= 18.8.3, < 19.0.0` for AWS Organization discovery and `>= 18.8.0, < 19.0.0` otherwise.
+For other majors, set it to `~> <major>.0`.
+
+<!-- TODO(marco): update with the actual release of the module
+PR: https://github.com/gravitational/teleport/pull/68704 -->
+Set `<module_version>` to `>= 18.10.2, < 19.0.0` for AWS Organization discovery on Teleport 18.
+Otherwise, set it to `~> <major>.0`.
 
 Declare the provider requirements and configuration:
 
@@ -53,7 +84,7 @@ Write the discovery module:
 ```hcl
 module "aws_discovery" {
   source  = "terraform.releases.teleport.dev/teleport/discovery/aws"
-  version = "~> <major>.0"
+  version = "<module_version>"
 
   teleport_proxy_public_addr    = "<proxy_addr>"
   teleport_discovery_group_name = "<discovery_group>"
@@ -61,6 +92,14 @@ module "aws_discovery" {
   aws_matchers = [
     # one object per matcher, per the schema below
   ]
+
+  # Fill this section only when using organization-wide discovery.
+  # aws_organization_discovery = {
+  #   organizational_units = {
+  #     include = <organizational_units_include>
+  #     exclude = <organizational_units_exclude>
+  #   }
+  # }
 
   # Set to false only when existing_oidc_provider is yes:
   # create_aws_iam_openid_connect_provider = false
@@ -80,6 +119,14 @@ output "oidc_provider_arn" {
 
 output "discovery_role_arn" {
   value = module.aws_discovery.teleport_discovery_service_iam_role_arn
+}
+```
+
+For AWS Organization discovery, also write:
+
+```hcl
+output "aws_child_account_iam_role_template" {
+  value = module.aws_discovery.aws_child_account_iam_role_template
 }
 ```
 


### PR DESCRIPTION
After adding support for EC2 org-wide discovery to teleport, we are now adding support for this using the `teleport-discovery` terraform module.

This module can be used by users directly, using the docs, using the UI or using the `teleport-discovery` skill.

This PR changes the skill in order to support this feature.



<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Added support for EC2 Organization Discovery with Terraform using the `teleport-discovery` SKILL


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster with access to an AWS organization

### Test Cases
- [x] Asked claude to enroll ec2 instances from all my aws accounts
- [x] Asked claude to diagnose why it was not working, which gave me instructions on how to fix possible errors.
- [x] Asked claude to remove all the created resources.
