### PR TITLE
Keep ComponentFeatures server-managed on client write paths

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1157,6 +1157,11 @@ func (a *ScopedServerWithRoles) UpsertNode(ctx context.Context, s types.Server) 
 		}
 	}
 
+	// ComponentFeatures is server-managed. SSH agents advertise it over the inventory
+	// control stream, which never routes through this wrapper. Anything arriving here
+	// is a client write; drop it so clients can't over-report support.
+	s.SetComponentFeatures(nil)
+
 	return a.authServer.UpsertNode(ctx, s)
 }
 
@@ -2934,6 +2939,12 @@ func (a *ServerWithRoles) DeleteAuthServer(name string) error {
 func (a *ServerWithRoles) UpsertProxyServer(ctx context.Context, s types.Server) (types.Server, error) {
 	if err := a.authorizeAction(types.KindProxy, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
+	}
+	// ComponentFeatures is server-managed. This API is Proxy's own heartbeat; the
+	// field survives only for the builtin Proxy identity. Any other caller is a
+	// client write and can't claim support the component doesn't have.
+	if !a.hasBuiltinRole(types.RoleProxy) {
+		s.SetComponentFeatures(nil)
 	}
 	return a.authServer.UpsertProxyServer(ctx, s)
 }
@@ -6554,6 +6565,10 @@ func (a *ServerWithRoles) UpsertApplicationServer(ctx context.Context, server ty
 	if server.GetScope() != "" {
 		return nil, trace.BadParameter("scoped app server must register a control stream")
 	}
+	// ComponentFeatures is server-managed. App agents advertise over the inventory
+	// control stream which never routes through this wrapper. Anything arriving here
+	// is a client write; drop it so clients can't over-report support.
+	server.SetComponentFeatures(nil)
 	return a.authServer.UpsertApplicationServer(ctx, server)
 }
 

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -84,6 +84,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/cache"
+	"github.com/gravitational/teleport/lib/componentfeatures"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
@@ -9522,6 +9523,114 @@ func TestUpsertScopedNode(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// TestUpsertStripsComponentFeatures verifies that ComponentFeatures is server-managed.
+// Serving agents advertise over the inventory control stream which reaches
+// auth.Server directly. Client writes through authorized API must never be able
+// to claim feature support.
+func TestUpsertStripsComponentFeatures(t *testing.T) {
+	t.Parallel()
+	authsrv, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir:            t.TempDir(),
+		ScopesFeatures: scopes.Features{Enabled: true},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, authsrv.Close()) })
+
+	rcv1 := componentfeatures.New(componentfeatures.FeatureResourceConstraintsV1)
+
+	t.Run("node", func(t *testing.T) {
+		scoped := newScopedTestServerWithUnscopedUser(t, authsrv, "node-admin",
+			[]types.Rule{types.NewRule(types.KindNode, []string{types.VerbCreate, types.VerbUpdate, types.VerbRead})})
+
+		node, err := types.NewNode("client-written-node", types.SubKindOpenSSHNode, types.ServerSpecV2{
+			Addr:     "someaddr.com:443",
+			Hostname: "client-written-node",
+		}, nil)
+		require.NoError(t, err)
+		node.SetComponentFeatures(rcv1)
+
+		_, err = scoped.UpsertNode(t.Context(), node)
+		require.NoError(t, err)
+
+		unscoped, ok := scoped.UnscopedServerWithRoles()
+		require.True(t, ok)
+		got, err := unscoped.GetNode(t.Context(), apidefaults.Namespace, "client-written-node")
+		require.NoError(t, err)
+		require.Nil(t, got.GetComponentFeatures(), "client-set ComponentFeatures must not be persisted on a node")
+	})
+
+	t.Run("app server", func(t *testing.T) {
+		unscoped := serverWithAllowRules(t, authsrv,
+			[]types.Rule{types.NewRule(types.KindAppServer, []string{types.VerbCreate, types.VerbUpdate, types.VerbRead})})
+
+		app, err := types.NewAppV3(types.Metadata{Name: "client-written-app"},
+			types.AppSpecV3{URI: "https://console.aws.amazon.com"})
+		require.NoError(t, err)
+		appServer, err := types.NewAppServerV3FromApp(app, "host", "host-id")
+		require.NoError(t, err)
+		appServer.SetComponentFeatures(rcv1)
+
+		_, err = unscoped.UpsertApplicationServer(t.Context(), appServer)
+		require.NoError(t, err)
+
+		got, err := unscoped.GetApplicationServers(t.Context(), apidefaults.Namespace)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Nil(t, got[0].GetComponentFeatures(), "client-set ComponentFeatures must not be persisted on an app server")
+	})
+
+	// Proxy record is the one node/app-adjacent kind whose own heartbeat uses
+	// this API rather than the inventory control stream; its strip is identity-gated.
+	t.Run("proxy server client write strips", func(t *testing.T) {
+		unscoped := serverWithAllowRules(t, authsrv,
+			[]types.Rule{types.NewRule(types.KindProxy, []string{types.VerbCreate, types.VerbUpdate, types.VerbRead})})
+
+		proxy, err := types.NewServer("client-written-proxy", types.KindProxy, types.ServerSpecV2{
+			Addr: "proxy.example.com:3080",
+		})
+		require.NoError(t, err)
+		proxy.SetComponentFeatures(rcv1)
+
+		_, err = unscoped.UpsertProxyServer(t.Context(), proxy)
+		require.NoError(t, err)
+
+		got, err := authsrv.AuthServer.GetProxies()
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Nil(t, got[0].GetComponentFeatures(), "client-set ComponentFeatures must not be persisted on a proxy server")
+
+		require.NoError(t, authsrv.AuthServer.DeleteProxyServer(t.Context(), "client-written-proxy"))
+	})
+
+	t.Run("proxy server own heartbeat preserves", func(t *testing.T) {
+		authContext, err := authz.ContextForBuiltinRole(
+			authz.BuiltinRole{
+				Role:     types.RoleProxy,
+				Username: "proxy.example.com",
+			},
+			types.DefaultSessionRecordingConfig(),
+		)
+		require.NoError(t, err)
+		srv := auth.NewServerWithRoles(authsrv.AuthServer, events.NewDiscardAuditLog(), *authContext)
+
+		proxy, err := types.NewServer("heartbeat-proxy", types.KindProxy, types.ServerSpecV2{
+			Addr: "proxy.example.com:3080",
+		})
+		require.NoError(t, err)
+		proxy.SetComponentFeatures(rcv1)
+
+		_, err = srv.UpsertProxyServer(t.Context(), proxy)
+		require.NoError(t, err)
+
+		got, err := authsrv.AuthServer.GetProxies()
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.NotNil(t, got[0].GetComponentFeatures(), "the proxy's own heartbeat must keep ComponentFeatures")
+
+		require.NoError(t, authsrv.AuthServer.DeleteProxyServer(t.Context(), "heartbeat-proxy"))
+	})
 }
 
 // TestGenerateHostCertsAgentScopePin verifies that GenerateHostCerts handles agent scope pins

--- a/lib/auth/presence/presencev1/service.go
+++ b/lib/auth/presence/presencev1/service.go
@@ -592,6 +592,13 @@ func (s *Service) UpsertProxyServer(
 		return nil, trace.Wrap(err)
 	}
 
+	// ComponentFeatures is server-managed. This API is Proxy's own heartbeat; the
+	// field survives only for the builtin Proxy identity. Any other caller is a
+	// client write and can't claim support the component doesn't have.
+	if !authz.HasBuiltinRole(*authCtx, string(types.RoleProxy)) {
+		srv.SetComponentFeatures(nil)
+	}
+
 	// If the proxy advertised a local/unspecified address, replace the host
 	// component with the peer address observed on the socket.
 	if p, ok := peer.FromContext(ctx); ok {

--- a/lib/auth/presence/presencev1/service_test.go
+++ b/lib/auth/presence/presencev1/service_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/auth/authtest"
+	"github.com/gravitational/teleport/lib/componentfeatures"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/modules"
 )
@@ -1335,6 +1336,42 @@ func TestUpsertProxyServer(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("component features stripped on client write", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestUser(user.GetName()))
+		require.NoError(t, err)
+
+		clientProxy, err := types.NewServer("proxy-client-written", types.KindProxy, types.ServerSpecV2{
+			Addr: "127.0.0.1:2024",
+		})
+		require.NoError(t, err)
+		clientProxy.SetComponentFeatures(componentfeatures.New(componentfeatures.FeatureResourceConstraintsV1))
+
+		resp, err := client.PresenceServiceClient().UpsertProxyServer(ctx, presencev1pb.UpsertProxyServerRequest_builder{
+			Server: clientProxy.(*types.ServerV2),
+		}.Build())
+		require.NoError(t, err)
+		require.Nil(t, resp.GetServer().GetComponentFeatures(),
+			"client-set ComponentFeatures must not be persisted on a proxy server")
+	})
+
+	t.Run("component features preserved on own heartbeat", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestBuiltin(types.RoleProxy))
+		require.NoError(t, err)
+
+		hbProxy, err := types.NewServer("proxy-heartbeat", types.KindProxy, types.ServerSpecV2{
+			Addr: "127.0.0.1:2025",
+		})
+		require.NoError(t, err)
+		hbProxy.SetComponentFeatures(componentfeatures.New(componentfeatures.FeatureResourceConstraintsV1))
+
+		resp, err := client.PresenceServiceClient().UpsertProxyServer(ctx, presencev1pb.UpsertProxyServerRequest_builder{
+			Server: hbProxy.(*types.ServerV2),
+		}.Build())
+		require.NoError(t, err)
+		require.NotNil(t, resp.GetServer().GetComponentFeatures(),
+			"the proxy's own heartbeat must keep ComponentFeatures")
+	})
 }
 
 func TestUpsertReverseTunnel(t *testing.T) {


### PR DESCRIPTION
## Context
The `ComponentFeatures` field on presence records is meant to be server-managed the same way `status` and `revision` are; currently nothing enforces that.

This PR clears client-set `ComponentFeatures` on authorized write paths, split by how each kind's advertisement is set:
- SSH and app agents heartbeat over the inventory control stream; this reaches `auth.Server` directly and doesn't pass through the authorized API. Writes arriving at `UpsertNode` and `UpsertApplicationServer` are therefore client writes and the field is cleared unconditionally.
- Proxy records announce through the authorized API. `UpsertProxyServer` is Proxy's own heartbeat so stripping there is identity-gated instead, based on the builtin Proxy role.
- Auth records don't require handling as Auth writes its own record directly.

Database and Kubernetes servers will get the same strip on the WIP branches that introduce their `ComponentFeatures` fields.

### Why
`ComponentFeatures` is a component's claim about what its **code** supports; consumers use it to decide cluster-wide behavior. Today the Web UI computes a resource's effective features as the intersection of the resource's advertisement with `GetClusterAuthProxyServerFeatures` (all Auth + Proxy records), and `RESOURCE_CONSTRAINTS_V1` in that intersection changes what the UI offers (e.g. for AWS console apps it switches from showing only granted AWS roles to showing all account roles as requestable). Upcoming enforcement-class features will lean on the same advertisements to decide whether it is safe to issue resource-constrained credentials — an over-reported claim would mean a constraint silently not enforced somewhere along the serving path.

RBAC is not sufficient to protect the field, because RBAC controls **who may write a presence record**, not **which fields they may set**. After the builtin-identity gating in this PR, the remaining principals that can reach these endpoints are `tctl`/API callers holding `create`/`update` on `node`, `app_server`, or `proxy` — cluster admins and any automation granted those verbs through a custom role. Without the strip, that resource-level grant transitively includes the ability to spoof feature negotiation, which is a strictly stronger privilege than the grant implies.

"The next heartbeat fixes it" is self-healing, not a security boundary:
- a writer can simply re-upsert in a loop and win the race against a heartbeat that fires every few minutes, keeping a spoofed claim in place effectively permanently;
- agentless records (OpenSSH nodes, integration app servers) have no heartbeat at all, so a spoofed claim on them is never corrected;
- the version-gating applied on read is no defense either, since `TeleportVersion` lives in the same client-writable spec.

Stripping on the write path makes the field trustworthy by construction, consistent with how `status` and `rotation` are treated, at zero cost to legitimate writers (no current client-path writer sets the field; real advertisements flow over the inventory control stream or the identity-gated Proxy heartbeat).

## Manual Test Plan
### Test Environment
- Single-node cluster (Auth, Proxy, SSH agent, app agent serving an AWS console app) built from this branch
- User role granting create/update on `node`, `app_server`, and `proxy`

### Test Cases
- [x] Validate a client node write drops the field: `tctl create` an OpenSSH node whose spec carries `component_features`; the stored record's field is empty.
- [x] Validate a client app server write drops the field: Upsert an app server carrying `component_features` through the API; the stored record's field is empty.
- [x] Validate a client proxy write drops the field: Upsert a proxy record carrying `component_features`; the stored record's field is empty, and the real Proxy heartbeat restores its own advertisement on the next announce.
- [x] Validate advertisement still flows end-to-end: with all components from this branch, verify the AWS console app still exposes `RESOURCE_CONSTRAINTS_V1` in `supportedFeatureIds` and the Web UI still receives its list of feature IDs.

