### PR TITLE
[e2e] Add `no-resource-setup` flag to e2e runner

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -42,6 +42,7 @@ By default, the runner runs in test mode. Use one of the following flags to chan
 |------------------------|------------------|-----------------------------------------------------------------------------------------|
 | `-v`                   | `false`          | Enable debug logging                                                                    |
 | `--no-build`           | `false`          | Skip `make` binaries (useful during development)                                        |
+| `--no-resource-setup`  | `false`          | Skip pre-test resource setup                                                            |
 | `--quiet`              | `false`          | Redirect Teleport logs to file instead of stdout                                        |
 | `--replace-certs`      | `false`          | Generate new self-signed certificates                                                   |
 | `--update-snapshots`   | `false`          | Update Playwright snapshot baselines                                                    |
@@ -231,6 +232,9 @@ Connect is built automatically when running `tests/connect` paths or when using 
 ```bash
 # Run a specific test, skip rebuilding (fastest iteration loop)
 ./e2e/run.sh --no-build e2e/tests/web/authenticated/roles.spec.ts
+
+# Skip applying pre-test resources
+./e2e/run.sh --no-build --no-resource-setup e2e/tests/web/authenticated/roles.spec.ts
 
 # Run only Connect tests, skip rebuilding of both Teleport and Connect
 ./e2e/run.sh --no-build e2e/tests/connect

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -42,6 +42,7 @@ By default, the runner runs in test mode. Use one of the following flags to chan
 |------------------------|------------------|-----------------------------------------------------------------------------------------|
 | `-v`                   | `false`          | Enable debug logging                                                                    |
 | `--no-build`           | `false`          | Skip `make` binaries (useful during development)                                        |
+| `--no-resource-setup`  | `false`          | Skip pre-test resource setup                                                            |
 | `--quiet`              | `false`          | Redirect Teleport logs to file instead of stdout                                        |
 | `--replace-certs`      | `false`          | Generate new self-signed certificates                                                   |
 | `--update-snapshots`   | `false`          | Update Playwright snapshot baselines                                                    |
@@ -254,6 +255,9 @@ Connect is built automatically when running `tests/connect` paths or when using 
 ```bash
 # Run a specific test, skip rebuilding (fastest iteration loop)
 ./e2e/run.sh --no-build e2e/tests/web/authenticated/roles.spec.ts
+
+# Skip applying pre-test resources
+./e2e/run.sh --no-build --no-resource-setup e2e/tests/web/authenticated/roles.spec.ts
 
 # Run only Connect tests, skip rebuilding of both Teleport and Connect
 ./e2e/run.sh --no-build e2e/tests/connect

--- a/e2e/runner/flags.go
+++ b/e2e/runner/flags.go
@@ -34,6 +34,7 @@ var validBrowsers = []string{"chromium", "firefox", "webkit"}
 
 type e2eFlags struct {
 	noBuild          bool
+	noResourceSetup  bool
 	quiet            bool
 	verbose          bool
 	replaceCerts     bool
@@ -73,7 +74,8 @@ func parseFlags(repoRoot string) (*e2eFlags, runMode, error) {
 	flag.IntVar(&testResultsPR, "test-results", 0, "download test results and open a trace for a given PR number (pass trace path as argument)")
 
 	flag.BoolVar(&f.verbose, "v", false, "enable debug logging")
-	flag.BoolVar(&f.noBuild, "no-build", false, "skip make binaries")                          // useful for running during development to avoid rebuilding Teleport every time
+	flag.BoolVar(&f.noBuild, "no-build", false, "skip make binaries") // useful for running during development to avoid rebuilding Teleport every time
+	flag.BoolVar(&f.noResourceSetup, "no-resource-setup", false, "skip applying resources to Teleport instance in advance of tests")
 	flag.BoolVar(&f.quiet, "quiet", false, "redirect Teleport logs to file instead of stdout") // used in CI to avoid flooding logs with Teleport logs
 	flag.BoolVar(&f.replaceCerts, "replace-certs", false, "generate new self-signed certificates")
 	flag.BoolVar(&f.updateSnapshots, "update-snapshots", false, "update Playwright snapshot baselines")

--- a/e2e/runner/instance.go
+++ b/e2e/runner/instance.go
@@ -34,6 +34,7 @@ type testInstance struct {
 	e2eDir             string
 	dataDir            string
 	tctlBin            string
+	noResourceSetup    bool
 	teleportConfigPath string
 	teleport           *teleportInstance
 	node               *dockerNode
@@ -60,8 +61,10 @@ func (inst *testInstance) start(ctx context.Context) error {
 		if err = inst.teleport.seedRecordings(ctx, inst.e2eDir, inst.dataDir); err != nil {
 			return fmt.Errorf("failed to seed session recordings for %s: %w", inst.browser, err)
 		}
-		if err = applyResources(ctx, inst.e2eDir, inst.tctlBin, inst.teleportConfigPath); err != nil {
-			return fmt.Errorf("failed to apply resources for %s: %w", inst.browser, err)
+		if !inst.noResourceSetup {
+			if err = applyResources(ctx, inst.e2eDir, inst.tctlBin, inst.teleportConfigPath); err != nil {
+				return fmt.Errorf("failed to apply resources for %s: %w", inst.browser, err)
+			}
 		}
 	}
 

--- a/e2e/runner/main.go
+++ b/e2e/runner/main.go
@@ -205,22 +205,24 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 
 	for _, browser := range config.browsers {
 		inst := &testInstance{
-			browser: browser,
-			log:     newBrowserLogger(browser),
-			e2eDir:  e2eDir,
-			dataDir: filepath.Join(e2eDir, "data", browser),
-			tctlBin: flags.tctlBin,
+			browser:         browser,
+			log:             newBrowserLogger(browser),
+			e2eDir:          e2eDir,
+			dataDir:         filepath.Join(e2eDir, "data", browser),
+			tctlBin:         flags.tctlBin,
+			noResourceSetup: flags.noResourceSetup,
 		}
 		config.instances = append(config.instances, inst)
 	}
 
 	if fixtures.Connect.Enabled {
 		config.connectInstance = &testInstance{
-			browser: "connect",
-			log:     newBrowserLogger("connect"),
-			e2eDir:  e2eDir,
-			dataDir: filepath.Join(e2eDir, "data", "connect"),
-			tctlBin: flags.tctlBin,
+			browser:         "connect",
+			log:             newBrowserLogger("connect"),
+			e2eDir:          e2eDir,
+			dataDir:         filepath.Join(e2eDir, "data", "connect"),
+			tctlBin:         flags.tctlBin,
+			noResourceSetup: flags.noResourceSetup,
 		}
 	}
 

--- a/e2e/runner/main.go
+++ b/e2e/runner/main.go
@@ -210,22 +210,24 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 
 	for _, browser := range config.browsers {
 		inst := &testInstance{
-			browser: browser,
-			log:     newBrowserLogger(browser),
-			e2eDir:  e2eDir,
-			dataDir: filepath.Join(e2eDir, "data", browser),
-			tctlBin: flags.tctlBin,
+			browser:         browser,
+			log:             newBrowserLogger(browser),
+			e2eDir:          e2eDir,
+			dataDir:         filepath.Join(e2eDir, "data", browser),
+			tctlBin:         flags.tctlBin,
+			noResourceSetup: flags.noResourceSetup,
 		}
 		config.instances = append(config.instances, inst)
 	}
 
 	if fixtures.Connect.Enabled {
 		config.connectInstance = &testInstance{
-			browser: "connect",
-			log:     newBrowserLogger("connect"),
-			e2eDir:  e2eDir,
-			dataDir: filepath.Join(e2eDir, "data", "connect"),
-			tctlBin: flags.tctlBin,
+			browser:         "connect",
+			log:             newBrowserLogger("connect"),
+			e2eDir:          e2eDir,
+			dataDir:         filepath.Join(e2eDir, "data", "connect"),
+			tctlBin:         flags.tctlBin,
+			noResourceSetup: flags.noResourceSetup,
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR implements a `--no-resource-setup` flag to skip the advance resource setup in the e2e test runner. Today, for an enterprise E2E test, the e2e runner initializes a Teleport instance and automatically sets up all resources defined in `e/e2e/config/resources`. However, we don't always want or need these resources, especially for the incoming cloud panel e2e test (see [PR](https://github.com/gravitational/teleport.e/pull/9186) and context below) which uses an enterprise cloud license with a smaller set of features than the self-hosted all-features license that the existing enterprise e2e tests use.

## Context

Contributes to https://github.com/gravitational/cloud/issues/17873

This is the first PR in a chain to add an e2e test to the enterprise repo that starts a Teleport tenant with a cloud license and navigates to the Usage Reporting page (`/web/cloud/summary`) to assert that it loads. The Usage Summary page displays a bundled react app (aka cloud panel) sent across the wire from the Cloud API (see [orginal goal](https://github.com/gravitational/cloud/issues/16174)) and we want to assert that Teleport is still able to render it.

<details><summary>PR chain</summary>

<pre>
Chain: Cloud Panel E2E Testing
└── <b><a href="https://github.com/gravitational/teleport/pull/68865">teleport: Add no-resource-setup flag to e2e runner</a> </b>  ← current branch
    └── <a href="https://github.com/gravitational/teleport.e/pull/9186">e: Add cloud panel e2e test</a>
        └── <a href="https://github.com/gravitational/teleport/pull/69441">teleport: Allow e2e tests to declare custom env variables</a>
            └── <a href="https://github.com/gravitational/teleport.e/pull/9377">e: Enable Cloud Panel Test in CI</a>

* Note that depending on timing, I may add the last two CI PRs directly to the new monorepo instead.
</pre>

</details>

<!-- Provide a descriptive entry for the changelog of the next release. -->

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local

### Test Cases
- [x] Run enterprise E2E tests w/ flag and confirm the runner skips resource setup (no `applying resource` output) and that the tests fail
- [x] Run enterprise E2E tests w/o flag and confirm that the tests still pass 
