### PR TITLE
docs: mwi guides - friction points found during agent testing

### DIFF
--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -1,6 +1,7 @@
 To install Teleport binaries on your Linux server, the recommended installation
-method is the cluster install script. It will select the correct version,
-edition, and installation mode for your cluster.
+method is the cluster install script. This script is served by your Teleport
+cluster's Proxy Service and automatically selects the correct version, edition,
+and installation mode to match your cluster.
 
 1. Remove any existing Teleport binaries on your system:
 

--- a/docs/pages/includes/machine-id/daemon-or-oneshot.mdx
+++ b/docs/pages/includes/machine-id/daemon-or-oneshot.mdx
@@ -1,3 +1,11 @@
+<Admonition type="note">
+If your Teleport Proxy Service uses a self-signed TLS certificate, `tbot`
+output services that contact the proxy (such as the `identity` service) will
+fail to generate some files (for example, `ssh_config` and `known_hosts`).
+Add the proxy certificate to the system CA trust store, or configure ACME or
+a valid TLS certificate for your Proxy Service.
+</Admonition>
+
 Now, you must decide if you want to run `tbot` as a daemon or in one-shot mode.
 
 In daemon mode, `tbot` runs continually, renewing the short-lived credentials

--- a/docs/pages/includes/machine-id/daemon-or-oneshot.mdx
+++ b/docs/pages/includes/machine-id/daemon-or-oneshot.mdx
@@ -1,4 +1,4 @@
-<Admonition type="note">
+<Admonition type="warning">
 If your Teleport Proxy Service uses a self-signed TLS certificate, `tbot`
 output services that contact the proxy (such as the `identity` service) will
 fail to generate some files (for example, `ssh_config` and `known_hosts`).

--- a/docs/pages/machine-workload-identity/access-guides/tctl.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/tctl.mdx
@@ -140,6 +140,17 @@ the generated identity file if you have modified this:
 $ tctl --auth-server example.teleport.sh:443 -i /opt/machine-id/identity create -f roles/*.yaml
 ```
 
+<Admonition type="note">
+If you run `tctl` on a host that also runs a Teleport service (with
+`/etc/teleport.yaml` present), the local configuration may conflict with the
+`--auth-server` flag. Set `TELEPORT_CONFIG_FILE=""` to bypass the local
+configuration:
+
+```code
+$ TELEPORT_CONFIG_FILE="" tctl --auth-server example.teleport.sh:443 -i /opt/machine-id/identity create -f roles/*.yaml
+```
+</Admonition>
+
 Check your Teleport cluster, ensuring the role has been created.
 
 ```code

--- a/docs/pages/machine-workload-identity/access-guides/tctl.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/tctl.mdx
@@ -140,7 +140,6 @@ the generated identity file if you have modified this:
 $ tctl --auth-server example.teleport.sh:443 -i /opt/machine-id/identity create -f roles/*.yaml
 ```
 
-<Admonition type="note">
 If you run `tctl` on a host that also runs a Teleport service (with
 `/etc/teleport.yaml` present), the local configuration may conflict with the
 `--auth-server` flag. Set `TELEPORT_CONFIG_FILE=""` to bypass the local
@@ -149,7 +148,6 @@ configuration:
 ```code
 $ TELEPORT_CONFIG_FILE="" tctl --auth-server example.teleport.sh:443 -i /opt/machine-id/identity create -f roles/*.yaml
 ```
-</Admonition>
 
 Check your Teleport cluster, ensuring the role has been created.
 

--- a/docs/pages/machine-workload-identity/deployment/kubernetes-oidc.mdx
+++ b/docs/pages/machine-workload-identity/deployment/kubernetes-oidc.mdx
@@ -298,6 +298,13 @@ type of service using the `services` value of the Helm chart and setting
 Follow one of the [access guides](../access-guides/access-guides.mdx) to find
 out more about how to configure `tbot` for your use case.
 
+## Manual deployment without Helm
+
+If you deploy `tbot` without the Helm chart, see 
+[Requirements for deployments without Helm](./kubernetes.mdx#requirements-for-deployments-without-helm)
+in the static JWKS guide for the additional configuration Helm normally handles for you: token audience projection 
+via `KUBERNETES_TOKEN_PATH`, the `POD_NAMESPACE` environment variable, and service account RBAC for secret writing.
+
 ## Further reading
 
 - Explore the [Helm chart configuration reference](../../reference/helm-reference/tbot.mdx).

--- a/docs/pages/machine-workload-identity/deployment/kubernetes.mdx
+++ b/docs/pages/machine-workload-identity/deployment/kubernetes.mdx
@@ -226,6 +226,95 @@ type of output using the `services` value of the Helm chart and setting
 Follow one of the [access guides](../access-guides/access-guides.mdx) to find
 out more about how to configure `tbot` for your use case.
 
+## Requirements for deployments without Helm
+
+The Helm chart handles several requirements for `tbot` automatically. If you
+deploy `tbot` yourself — with your own Deployment, ServiceAccount, and `tbot`
+configuration — you must configure the following in addition to the standard
+`tbot` setup.
+
+### Token audience projection
+
+The Kubernetes join method requires that the service account JWT presented to
+Teleport has an audience matching the Teleport cluster name. The service
+account token mounted in a Pod by default is not issued with the Teleport
+cluster name as its audience.
+
+You must project a service account token volume with the correct audience and
+tell `tbot` where to find it via the `KUBERNETES_TOKEN_PATH` environment
+variable:
+
+```yaml
+spec:
+  containers:
+  - name: tbot
+    env:
+    - name: KUBERNETES_TOKEN_PATH
+      value: "/var/run/secrets/teleport/token"
+    volumeMounts:
+    - name: teleport-token
+      mountPath: /var/run/secrets/teleport
+  volumes:
+  - name: teleport-token
+    projected:
+      sources:
+      - serviceAccountToken:
+          path: token
+          audience: example.teleport.sh
+          expirationSeconds: 600
+```
+
+Replace `example.teleport.sh` with the name of your Teleport cluster (the
+value of `clusterName`, not the proxy address).
+
+### Writing credentials to a Kubernetes secret
+
+When using `destination.type: kubernetes_secret` in the `tbot` configuration,
+the following additional setup is required:
+
+- Set the `POD_NAMESPACE` environment variable so `tbot` knows which namespace
+  to write the secret to. Use the Kubernetes downward API:
+
+  ```yaml
+  env:
+  - name: POD_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+  ```
+
+- Grant the `tbot` service account permission to manage secrets in its
+  namespace. The `create` verb is required because `tbot` creates the
+  destination secret automatically if it does not already exist:
+
+  ```yaml
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: tbot-secret-writer
+    namespace: default
+  rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update", "patch"]
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: tbot-secret-writer
+    namespace: default
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: tbot-secret-writer
+  subjects:
+  - kind: ServiceAccount
+    name: tbot
+    namespace: default
+  ```
+
+  Replace `default` with the namespace `tbot` runs in.
+
 ## Further reading
 
 - Explore the [Helm chart configuration reference](../../reference/helm-reference/tbot.mdx).

--- a/docs/pages/machine-workload-identity/deployment/linux.mdx
+++ b/docs/pages/machine-workload-identity/deployment/linux.mdx
@@ -90,9 +90,8 @@ the join URI (shown as `secret` in the example token) in your configuration file
 after the first run has completed, but there is no tangible security benefit to
 doing so.
 
-If the initial join fails (for example, due to a network or TLS error), the
-secret may already be consumed. Run `tctl bots add` again to generate a new
-join URI before retrying.
+If the initial join fails (for example, due to a network or TLS error), the secret may already be consumed. Use `tctl bots instances add example` to
++generate a new join URI for the bot before retrying.
 </Admonition>
 
 ### Prepare the storage directory

--- a/docs/pages/machine-workload-identity/deployment/linux.mdx
+++ b/docs/pages/machine-workload-identity/deployment/linux.mdx
@@ -89,6 +89,10 @@ successful join, the registration secret is invalidated. You may remove it from
 the join URI (shown as `secret` in the example token) in your configuration file
 after the first run has completed, but there is no tangible security benefit to
 doing so.
+
+If the initial join fails (for example, due to a network or TLS error), the
+secret may already be consumed. Run `tctl bots add` again to generate a new
+join URI before retrying.
 </Admonition>
 
 ### Prepare the storage directory

--- a/docs/pages/machine-workload-identity/deployment/linux.mdx
+++ b/docs/pages/machine-workload-identity/deployment/linux.mdx
@@ -82,7 +82,6 @@ services: []
 Replace:
 - The `join_uri` field value with the joining URI printed by `tctl` in step 2.
 
-<Admonition type="note">
 The first time that `tbot` runs, the registration secret contained within the
 joining URI will be used to authenticate the first connection. After the first
 successful join, the registration secret is invalidated. You may remove it from
@@ -92,7 +91,6 @@ doing so.
 
 If the initial join fails (for example, due to a network or TLS error), the secret may already be consumed. Use `tctl bots instances add example` to
 +generate a new join URI for the bot before retrying.
-</Admonition>
 
 ### Prepare the storage directory
 


### PR DESCRIPTION
Resolves https://github.com/gravitational/teleport/issues/68868

Addresses the higher-friction documentation issues identified during a live audit/agent run through the guides under `machine-workload-identity/` via Claude Code running on Beams, using AWS test account.

Set up demo K8s cluster as well as nip.io + ACME approach to get a valid TLS cluster from the start, avoiding the self-signed cert friction that blocked several guides earlier.


Files included: 

includes/install-linux.mdx
includes/machine-id/daemon-or-oneshot.mdx
machine-workload-identity/deployment/linux.mdx
machine-workload-identity/access-guides/tctl.mdx
machine-workload-identity/deployment/kubernetes-oidc.mdx
machine-workload-identity/deployment/kubernetes.mdx