### PR TITLE
Deflake TestLockInForce

### DIFF
--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -962,29 +962,38 @@ func TestLockInForce(t *testing.T) {
 	watcher := f.ssh.srv.GetLockWatcher()
 	sub, err := watcher.Subscribe(ctx, lock.Target())
 	require.NoError(t, err)
+	defer sub.Close()
+
+	waitForLockEvent := func(eventType types.OpType) {
+		t.Helper()
+
+		timeout := time.NewTimer(20 * time.Second)
+		defer timeout.Stop()
+		for {
+			select {
+			case evt := <-sub.Events():
+				if evt.Type != eventType || evt.Resource.GetName() != lock.GetName() {
+					continue
+				}
+
+				if eventType == types.OpPut {
+					eventLock, ok := evt.Resource.(types.Lock)
+					require.True(t, ok)
+					require.Empty(t, cmp.Diff(lock.Target(), eventLock.Target()))
+				}
+				return
+			case <-sub.Done():
+				t.Fatalf("lock subscription terminated unexpectedly %v", sub.Error())
+			case <-timeout.C:
+				t.Fatalf("timed out waiting for lock %s event", eventType)
+			}
+		}
+	}
 
 	require.NoError(t, f.testSrv.Auth().UpsertLock(ctx, lock))
 
 	// Wait for the lock to appear before proceeding.
-	timeout := time.After(20 * time.Second)
-	for wait := true; wait; {
-		select {
-		case evt := <-sub.Events():
-			if evt.Type != types.OpPut {
-				continue
-			}
-
-			eventLock, ok := evt.Resource.(types.Lock)
-			require.True(t, ok)
-			require.Empty(t, cmp.Diff(lock.Target(), eventLock.Target()))
-			wait = false
-		case <-sub.Done():
-			t.Fatalf("lock subscription terminated unexpectedly %v", sub.Error())
-		case <-timeout:
-			t.Fatal("timed out waiting for lock target event")
-		}
-	}
-	require.NoError(t, sub.Close())
+	waitForLockEvent(types.OpPut)
 
 	// Expect the session to eventually be terminated because of the lock.
 	select {
@@ -1002,17 +1011,14 @@ func TestLockInForce(t *testing.T) {
 	// As long as the lock is in force, new sessions cannot be opened.
 	newClient, err := apissh.Dial(ctx, "tcp", f.ssh.srvAddress, f.ssh.cltConfig)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		// The client is expected to be closed by the lock monitor therefore expect
-		// an error on this second attempt.
-		require.Error(t, newClient.Close())
-	})
+	t.Cleanup(func() { newClient.Close() })
 	_, err = newClient.NewSession(ctx)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), lockInForceMsg)
 
 	// Once the lock is lifted, new sessions should go through without error.
 	require.NoError(t, f.testSrv.Auth().DeleteLock(ctx, "test-lock"))
+	waitForLockEvent(types.OpDelete)
 	newClient2, err := apissh.Dial(ctx, "tcp", f.ssh.srvAddress, f.ssh.cltConfig)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, newClient2.Close()) })


### PR DESCRIPTION
Wait for lock creation and deletion before making assertions.

Additionally, stop requiring the rejected client's Close call to return an error, this races with the lock monitor asynchronously closing the connection.

Closes #13770
