### PR TITLE
Fix formatting issues due to linter upgrade

### DIFF
--- a/docs/pages/enroll-resources/database-access/enrollment/aws/aws-docdb.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/aws-docdb.mdx
@@ -33,6 +33,7 @@ page_type: how-to
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - AWS account with a DocumentDB cluster.
+
   <Admonition type="warning" title="IAM authentication and TLS">
   Teleport uses IAM authentication to connect users to DocumentDB, which is
   only supported for DocumentDB 5.0 or higher.
@@ -40,10 +41,13 @@ page_type: how-to
   In addition, the DocumentDB cluster must have Transport Layer Security (TLS)
   enabled. TLS is enabled by default when using the default parameter group.
   </Admonition>
+
 - Command-line client `mongosh` or `mongo` installed and added to your
   system's `PATH` environment variable.
+
 - A host, e.g., an EC2 instance, where you will run the Teleport Database
   Service.
+
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/6. Create a Teleport user

--- a/docs/pages/enroll-resources/kubernetes-access/controls.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/controls.mdx
@@ -595,7 +595,6 @@ spec:
   Any other value, like `^.+$` will only match namespaced resources and exclude cluster-wide resources.
   </Admonition>
 
-
 - `name`: The name of the pod to allow access to. In `kube-access`, this is
   the `webapp` pod.
 

--- a/docs/pages/enroll-resources/mcp-access/enrolling-mcp-servers/stdio.mdx
+++ b/docs/pages/enroll-resources/mcp-access/enrolling-mcp-servers/stdio.mdx
@@ -44,12 +44,11 @@ providing visibility into user activity.
 You can update an existing Application Service or create a new one to enable the
 the MCP server.
 
-<Tabs>
-
-<TabItem label="Update an existing service">
+### Update an existing service
 
 If you already have an existing Application Service running, you can add a MCP
 server in your YAML configuration:
+
 ```yaml
 app_service:
   enabled: true
@@ -71,10 +70,13 @@ app_service:
 
 Replace the MCP details with the MCP server you desire to run then restart the Application Service.
 
-</TabItem>
-<TabItem label="Create a new service">
+Continue to Step 2.
 
-{/* lint ignore heading-increment remark-lint */}
+### Create a new service
+
+Install the Teleport Application Service on the host your prepared before
+following this guide.
+
 #### Get a join token
 (!docs/pages/includes/tctl-token.mdx serviceName="Application" tokenType="app" tokenFile="/tmp/token"!)
 
@@ -126,9 +128,6 @@ server you desire to run.
 #### Start the Teleport Application Service
 
 (!docs/pages/includes/start-teleport.mdx service="the Application Service"!)
-
-</TabItem>
-</Tabs>
 
 ## Step 2/3. Configure your Teleport user
 

--- a/docs/pages/enroll-resources/mcp-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/mcp-access/getting-started.mdx
@@ -48,12 +48,11 @@ activity.
 You can update an existing Application Service or create a new one to enable the
 demo MCP server.
 
-<Tabs>
+### Update an existing service
 
-<TabItem label="Update an existing service">
+If you already have an existing Application Service instance running, you can
+enable the demo MCP server by adding the following in your YAML configuration:
 
-If you already have an existing Application Service running, you can enable the
-demo MCP server by adding the following in your YAML configuration:
 ```diff
 app_service:
   enabled: true
@@ -61,12 +60,13 @@ app_service:
 ...
 ```
 
-Now restart the Application Service.
+Now restart the Application Service and skip to Step 2.
 
-</TabItem>
-<TabItem label="Create a new service">
+### Create a new service
 
-{/* lint ignore heading-increment remark-lint */}
+If you have not deployed the Teleport Application Service, you will need to run
+it on the host you prepared before following this guide.
+
 #### Get a join token
 (!docs/pages/includes/tctl-token.mdx serviceName="Application" tokenType="app" tokenFile="/tmp/token"!)
 
@@ -96,8 +96,6 @@ MCP server and save the configuration to `/etc/teleport.yaml`.
 #### Start the Teleport Application Service
 
 (!docs/pages/includes/start-teleport.mdx service="the Application Service"!)
-</TabItem>
-</Tabs>
 
 ## Step 2/3. Configure your Teleport user
 

--- a/docs/pages/machine-workload-identity/getting-started.mdx
+++ b/docs/pages/machine-workload-identity/getting-started.mdx
@@ -38,6 +38,7 @@ or Kubernetes cluster to Teleport. If you haven't done so, refer to the
 [guides on enrolling resources](../enroll-resources/enroll-resources.mdx).
 
 - A GitHub repository where you have permissions to create GitHub Actions workflows.
+
   <details>
   <summary>Using GitHub Enterprise?</summary>
 
@@ -54,6 +55,7 @@ or Kubernetes cluster to Teleport. If you haven't done so, refer to the
   <br/>
   The join token fields are available and commented out in the example join token file.
   </details>
+
 - A target resource enrolled in Teleport, either:
   - A Linux server
   - A Kubernetes cluster

--- a/docs/pages/migrate-plans.mdx
+++ b/docs/pages/migrate-plans.mdx
@@ -240,15 +240,12 @@ To migrate Teleport Agents:
    `stable/v(=teleport.major_version=)` or if you are using automatic
    upgrades the `stable/rolling` channel has all released versions.
 
-
 1. If you are using Teleport Community Edition, [uninstall Teleport](installation/uninstall-teleport.mdx)
    and install the enterprise edition of the `teleport` binary. You can confirm if the binary
    is correct by running `teleport version`. The output will contain the words
    `Teleport Enterprise`. The enterprise edition of the `teleport`
    binary should be used when connecting to Teleport Enterprise (Cloud) or
    Teleport Enterprise (Self-Hosted).
-
-
 
 1. Update the `proxy_server` or `auth_servers` field in each Agent configuration
    file to point to the address of your new Teleport Enterprise cluster. By

--- a/docs/pages/zero-trust-access/management/trustedclusters.mdx
+++ b/docs/pages/zero-trust-access/management/trustedclusters.mdx
@@ -578,7 +578,6 @@ running the following command:
    tsh status
    ```
 
-
 1. Confirm that the server running the Teleport Agent is joined to the leaf cluster by
 running a command similar to the following:
 


### PR DESCRIPTION
We are upgrading our `remark` linter for the docs. To accommodate the upgrade, adjust formatting to fix issues caught by the linter.

- **MCP Access and stdio guides:** Replace an outer Tabs component, which contains an inner Tabs and thus introduces unnecessary complexity, with H3s. These guides introduced H4 headings without a preceding H3, which violate the linter.

- **Remove extra newlines** from lists in `trustedclusters.mdx`, `migrate-plans.mdx`, and `controls.mdx`.

- **Add required blank lines** to `aws-docdb.mdx` and the MWI getting started guide.