### PR TITLE
Frontend for logging in to a scope

### DIFF
--- a/api/client/webclient/webconfig.go
+++ b/api/client/webclient/webconfig.go
@@ -27,19 +27,19 @@ const (
 	WebConfigAuthProviderOIDCType = "oidc"
 	// WebConfigAuthProviderOIDCURL is OIDC webapi endpoint.
 	// redirect_url MUST be the last query param, see the comment in parseSSORequestParams for an explanation.
-	WebConfigAuthProviderOIDCURL = "/v1/webapi/oidc/login/web?connector_id=:providerName&login_hint=:loginHint?&redirect_url=:redirect"
+	WebConfigAuthProviderOIDCURL = "/v1/webapi/oidc/login/web?connector_id=:providerName&login_hint=:loginHint?&scope=:scope?&redirect_url=:redirect"
 
 	// WebConfigAuthProviderSAMLType is SAML provider type
 	WebConfigAuthProviderSAMLType = "saml"
 	// WebConfigAuthProviderSAMLURL is SAML webapi endpoint.
 	// redirect_url MUST be the last query param, see the comment in parseSSORequestParams for an explanation.
-	WebConfigAuthProviderSAMLURL = "/v1/webapi/saml/sso?connector_id=:providerName&login_hint=:loginHint?&redirect_url=:redirect"
+	WebConfigAuthProviderSAMLURL = "/v1/webapi/saml/sso?connector_id=:providerName&login_hint=:loginHint?&scope=:scope?&redirect_url=:redirect"
 
 	// WebConfigAuthProviderGitHubType is GitHub provider type
 	WebConfigAuthProviderGitHubType = "github"
 	// WebConfigAuthProviderGitHubURL is GitHub webapi endpoint
 	// redirect_url MUST be the last query param, see the comment in parseSSORequestParams for an explanation.
-	WebConfigAuthProviderGitHubURL = "/v1/webapi/github/login/web?connector_id=:providerName&redirect_url=:redirect"
+	WebConfigAuthProviderGitHubURL = "/v1/webapi/github/login/web?connector_id=:providerName&scope=:scope?&redirect_url=:redirect"
 )
 
 // WebConfig is web application configuration served by the backend to be used in frontend apps.

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -3634,13 +3634,24 @@ func TestGenerateKubernetesUserCert(t *testing.T) {
 func TestNewWebSession(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	p := newAuthSuite(t)
+
+	p, err := newTestPack(ctx, testPackOptions{
+		DataDir:        t.TempDir(),
+		ScopesFeatures: scopes.Features{Enabled: true},
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if p.bk != nil {
+			p.bk.Close()
+		}
+	})
 
 	// Set a web idle timeout.
 	duration := time.Duration(5) * time.Minute
 	cfg := types.DefaultClusterNetworkingConfig()
 	cfg.SetWebIdleTimeout(duration)
-	_, err := p.a.UpsertClusterNetworkingConfig(ctx, cfg)
+	_, err = p.a.UpsertClusterNetworkingConfig(ctx, cfg)
 	require.NoError(t, err)
 
 	// Create a user.
@@ -3684,12 +3695,75 @@ func TestNewWebSession(t *testing.T) {
 			SessionTTL: apidefaults.CertDuration,
 		}
 
-		_, checker, err := p.a.NewWebSession(ctx, req, nil /* opts */)
+		_, checkerCtx, err := p.a.NewWebSession(ctx, req, nil /* opts */)
 		require.NoError(t, err)
 
-		logins, err := checker.CheckLoginDuration(0)
+		logins, err := checkerCtx.CertParams().GetSSHLoginsForTTL(ctx, 0)
 		require.NoError(t, err)
 		require.Contains(t, logins, user.GetName())
+	})
+
+	t.Run("scoped session", func(t *testing.T) {
+		scopedService := local.NewScopedAccessService(p.bk)
+		_, err := scopedService.CreateScopedRole(ctx, scopedaccessv1pb.CreateScopedRoleRequest_builder{
+			Role: scopedaccessv1pb.ScopedRole_builder{
+				Kind: "scoped_role",
+				Metadata: headerv1.Metadata_builder{
+					Name: "web-session",
+				}.Build(),
+				Scope: "/test",
+				Spec: scopedaccessv1pb.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/test"},
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+
+		_, err = scopedService.CreateScopedRoleAssignment(ctx, scopedaccessv1pb.CreateScopedRoleAssignmentRequest_builder{
+			Assignment: scopedaccessv1pb.ScopedRoleAssignment_builder{
+				Kind: "scoped_role_assignment",
+				Metadata: headerv1.Metadata_builder{
+					Name: uuid.NewString(),
+				}.Build(),
+				Scope:   "/test",
+				SubKind: "dynamic",
+				Spec: scopedaccessv1pb.ScopedRoleAssignmentSpec_builder{
+					User: user.GetName(),
+					Assignments: []*scopedaccessv1pb.Assignment{
+						scopedaccessv1pb.Assignment_builder{
+							Role:  "/test::web-session",
+							Scope: "/test",
+						}.Build(),
+					},
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+
+		// Wait for scoped access cache to see the assignment.
+		pin := scopesv1pb.Pin_builder{Kind: scopesv1pb.PinKind_PIN_KIND_USER, Scope: "/test"}.Build()
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			err := p.a.ScopedAccessCache.PopulatePinnedAssignmentsForUser(ctx, user.GetName(), pin)
+			assert.NoError(ct, err)
+			assert.NotNil(ct, pin.GetAssignmentTree())
+		}, 15*time.Second, 100*time.Millisecond)
+
+		req := auth.NewWebSessionRequest{
+			User:  user.GetName(),
+			Scope: "/test",
+		}
+
+		ws, _, err := p.a.NewWebSession(ctx, req, nil /* opts */)
+		require.NoError(t, err)
+		assert.Equal(t, user.GetName(), ws.GetUser())
+
+		_, identity := parseX509PEMAndIdentity(t, ws.GetTLSCert())
+		sp := identity.ScopePin
+		require.NotNil(t, sp)
+		assert.Equal(t, "/test", sp.GetScope())
+		assert.Equal(t, scopesv1pb.PinKind_PIN_KIND_USER, sp.GetKind())
 	})
 }
 

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -3682,6 +3682,7 @@ func TestNewWebSession(t *testing.T) {
 	require.NotEmpty(t, ws.GetTLSCert())
 
 	t.Run("expands user metadata name in logins", func(t *testing.T) {
+		ctx := t.Context()
 		user, _, err := authtest.CreateUserAndRole(p.a, "templated-web-user", nil, nil, authtest.WithRoleMutator(func(role types.Role) {
 			role.SetLogins(types.Allow, []string{"{{user.metadata.name}}"})
 		}))
@@ -3704,6 +3705,7 @@ func TestNewWebSession(t *testing.T) {
 	})
 
 	t.Run("scoped session", func(t *testing.T) {
+		ctx := t.Context()
 		scopedService := local.NewScopedAccessService(p.bk)
 		_, err := scopedService.CreateScopedRole(ctx, scopedaccessv1pb.CreateScopedRoleRequest_builder{
 			Role: scopedaccessv1pb.ScopedRole_builder{

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -3767,6 +3767,87 @@ func TestNewWebSession(t *testing.T) {
 	})
 }
 
+func TestNewWebSessionScopedTrustedDeviceRequirement(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	p, err := newTestPack(ctx, testPackOptions{
+		DataDir:        t.TempDir(),
+		Modules:        modulestest.EnterpriseModules(),
+		ScopesFeatures: scopes.Features{Enabled: true},
+	})
+	require.NoError(t, err)
+
+	authPref, err := p.a.GetAuthPreference(ctx)
+	require.NoError(t, err)
+	authPref.SetDeviceTrust(&types.DeviceTrust{
+		Mode: constants.DeviceTrustModeRequired,
+	})
+	_, err = p.a.UpsertAuthPreference(ctx, authPref)
+	require.NoError(t, err)
+
+	_, _, err = authtest.CreateUserAndRole(p.a, "test-user", []string{}, nil)
+	require.NoError(t, err)
+
+	scopedService := p.a.ScopedAccess()
+	_, err = scopedService.CreateScopedRole(ctx, scopedaccessv1pb.CreateScopedRoleRequest_builder{
+		Role: scopedaccessv1pb.ScopedRole_builder{
+			Kind: "scoped_role",
+			Metadata: headerv1.Metadata_builder{
+				Name: "some-scoped-role",
+			}.Build(),
+			Scope: "/foo",
+			Spec: scopedaccessv1pb.ScopedRoleSpec_builder{
+				AssignableScopes: []string{"/foo/bar"},
+			}.Build(),
+			Version: types.V1,
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	_, err = scopedService.CreateScopedRoleAssignment(ctx, scopedaccessv1pb.CreateScopedRoleAssignmentRequest_builder{
+		Assignment: scopedaccessv1pb.ScopedRoleAssignment_builder{
+			Kind: "scoped_role_assignment",
+			Metadata: headerv1.Metadata_builder{
+				Name: uuid.NewString(),
+			}.Build(),
+			Scope:   "/foo",
+			SubKind: "dynamic",
+			Spec: scopedaccessv1pb.ScopedRoleAssignmentSpec_builder{
+				User: "test-user",
+				Assignments: []*scopedaccessv1pb.Assignment{
+					scopedaccessv1pb.Assignment_builder{
+						Role:  "/foo::some-scoped-role",
+						Scope: "/foo/bar",
+					}.Build(),
+				},
+			}.Build(),
+			Version: types.V1,
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	// Wait for scoped access cache to see the assignment.
+	pin := scopesv1pb.Pin_builder{Kind: scopesv1pb.PinKind_PIN_KIND_USER, Scope: "/foo/bar"}.Build()
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		err := p.a.ScopedAccessCache.PopulatePinnedAssignmentsForUser(ctx, "test-user", pin)
+		assert.NoError(ct, err)
+		assert.NotNil(ct, pin.GetAssignmentTree())
+	}, 15*time.Second, 100*time.Millisecond)
+
+	ws, _, err := p.a.NewWebSession(ctx, auth.NewWebSessionRequest{
+		User:  "test-user",
+		Scope: "/foo/bar",
+	}, nil /* opts */)
+	require.NoError(t, err)
+
+	assert.Equal(t, types.TrustedDeviceRequirement_TRUSTED_DEVICE_REQUIREMENT_REQUIRED, ws.GetTrustedDeviceRequirement())
+
+	// Make sure this has actually created a scoped session.
+	_, identity := parseX509PEMAndIdentity(t, ws.GetTLSCert())
+	assert.NotNil(t, identity.ScopePin)
+}
+
 func TestDeleteMFADeviceSync(t *testing.T) {
 	t.Parallel()
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3640,6 +3640,30 @@ func (a *ServerWithRoles) SubmitAccessReview(ctx context.Context, submission typ
 	return a.authServer.submitAccessReview(ctx, submission, &identity)
 }
 
+func (a *ScopedServerWithRoles) GetAccessCapabilities(ctx context.Context, req types.AccessCapabilitiesRequest) (*types.AccessCapabilities, error) {
+	if unscoped, ok := a.UnscopedServerWithRoles(); ok {
+		return unscoped.GetAccessCapabilities(ctx, req)
+	}
+
+	if a.scopedContext.User == nil {
+		return nil, trace.AccessDenied(
+			"access capabilities can only be retrieved by scoped identities if they are users",
+		)
+	}
+
+	// default to checking the capabilities of the caller
+	if req.User == "" {
+		req.User = a.scopedContext.User.GetName()
+	}
+
+	// Scoped identities can only check their own capabilities
+	if err := a.scopedCurrentUserAction(req.User); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return a.authServer.GetAccessCapabilities(ctx, req)
+}
+
 func (a *ServerWithRoles) GetAccessCapabilities(ctx context.Context, req types.AccessCapabilitiesRequest) (*types.AccessCapabilities, error) {
 	// default to checking the capabilities of the caller
 	if req.User == "" {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3661,7 +3661,9 @@ func (a *ScopedServerWithRoles) GetAccessCapabilities(ctx context.Context, req t
 		return nil, trace.Wrap(err)
 	}
 
-	return a.authServer.GetAccessCapabilities(ctx, req)
+	// TODO(bl-nero): Implement once it's supported by the backend. Currently,
+	// there's no concept of scoped access requests.
+	return &types.AccessCapabilities{}, nil
 }
 
 func (a *ServerWithRoles) GetAccessCapabilities(ctx context.Context, req types.AccessCapabilitiesRequest) (*types.AccessCapabilities, error) {

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -14697,3 +14697,161 @@ func TestRoleWindowsDesktopLeastPrivilege(t *testing.T) {
 		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
 	})
 }
+
+func TestGetAccessCapabilitiesRBAC(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	srv, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, srv.Close()) })
+
+	targetUser, err := types.NewUser("target")
+	require.NoError(t, err)
+	_, err = srv.AuthServer.CreateUser(ctx, targetUser)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name             string
+		allowRules       []types.Rule
+		callerUser       string
+		queriedUser      string
+		wantAccessDenied bool
+	}{
+		{
+			name:        "querying for self doesn't require permissions is allowed",
+			callerUser:  "caller-self-default",
+			queriedUser: "",
+		},
+		{
+			name:        "querying for self doesn't require permissions is allowed (explicit user name)",
+			callerUser:  "caller-self-explicit",
+			queriedUser: "caller-self-explicit",
+		},
+		{
+			name:             "querying for other user without permissions is denied",
+			callerUser:       "caller-other-denied",
+			queriedUser:      "target",
+			wantAccessDenied: true,
+		},
+		{
+			name: "querying for other user with permissions is allowed",
+			allowRules: []types.Rule{
+				types.NewRule(types.KindUser, []string{types.VerbRead}),
+				types.NewRule(types.KindRole, []string{types.VerbList, types.VerbRead}),
+			},
+			callerUser:  "caller-other-allowed",
+			queriedUser: "target",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			callerRole, err := types.NewRole(tt.callerUser+"-role", types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					Rules: tt.allowRules,
+				},
+			})
+			require.NoError(t, err)
+			callerUser, err := authtest.CreateUser(ctx, srv.AuthServer, tt.callerUser, callerRole)
+			require.NoError(t, err)
+
+			callerIdentity := authz.LocalUser{
+				Username: tt.callerUser,
+				Identity: tlsca.Identity{
+					Username: tt.callerUser,
+					Groups:   callerUser.GetRoles(),
+				},
+			}
+			authCtx, err := authz.ContextForLocalUser(
+				ctx, callerIdentity, srv.AuthServer.Services, srv.ClusterName, true, /* disableDeviceAuthz */
+			)
+			require.NoError(t, err)
+			authCtx.AdminActionAuthState = authz.AdminActionAuthMFAVerified
+
+			server := auth.NewServerWithRoles(srv.AuthServer, srv.AuditLog, *authCtx)
+			_, err = server.GetAccessCapabilities(authz.ContextWithUser(ctx, callerIdentity), types.AccessCapabilitiesRequest{
+				User: tt.queriedUser,
+			})
+			if tt.wantAccessDenied {
+				require.True(t, trace.IsAccessDenied(err), "expected access denied, got %T: %v", err, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetAccessCapabilitiesScopedRBAC(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	srv, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, srv.Close()) })
+
+	targetUser, err := types.NewUser("target")
+	require.NoError(t, err)
+	_, err = srv.AuthServer.CreateUser(ctx, targetUser)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name             string
+		callerUser       string
+		queriedUser      string
+		wantAccessDenied bool
+	}{
+		{
+			name:        "querying for self is allowed",
+			callerUser:  "scoped-caller-self",
+			queriedUser: "",
+		},
+		{
+			name:             "querying for other user is denied",
+			callerUser:       "scoped-caller-other",
+			queriedUser:      "target",
+			wantAccessDenied: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			callerUser, err := types.NewUser(tt.callerUser)
+			require.NoError(t, err)
+			callerUser, err = srv.AuthServer.CreateUser(ctx, callerUser)
+			require.NoError(t, err)
+
+			callerIdentity := authz.LocalUser{
+				Username: tt.callerUser,
+				Identity: tlsca.Identity{
+					Username: tt.callerUser,
+					ScopePin: scopesv1.Pin_builder{
+						Kind:  scopesv1.PinKind_PIN_KIND_USER,
+						Scope: "/test",
+					}.Build(),
+				},
+			}
+
+			server := auth.NewScopedServerWithRoles(srv.AuthServer, srv.AuditLog, &authz.ScopedContext{
+				User:     callerUser,
+				Identity: callerIdentity,
+			})
+			t.Cleanup(func() { server.Close() })
+
+			_, err = server.GetAccessCapabilities(authz.ContextWithUser(ctx, callerIdentity), types.AccessCapabilitiesRequest{
+				User: tt.queriedUser,
+			})
+			if tt.wantAccessDenied {
+				require.True(t, trace.IsAccessDenied(err), "expected access denied, got %T: %v", err, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -14821,10 +14821,9 @@ func TestGetAccessCapabilitiesScopedRBAC(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := t.Context()
 			callerUser, err := types.NewUser(tt.callerUser)
 			require.NoError(t, err)
-			callerUser, err = srv.AuthServer.CreateUser(ctx, callerUser)
+			callerUser, err = srv.AuthServer.CreateUser(t.Context(), callerUser)
 			require.NoError(t, err)
 
 			callerIdentity := authz.LocalUser{
@@ -14844,7 +14843,7 @@ func TestGetAccessCapabilitiesScopedRBAC(t *testing.T) {
 			})
 			t.Cleanup(func() { server.Close() })
 
-			_, err = server.GetAccessCapabilities(authz.ContextWithUser(ctx, callerIdentity), types.AccessCapabilitiesRequest{
+			_, err = server.GetAccessCapabilities(authz.ContextWithUser(t.Context(), callerIdentity), types.AccessCapabilitiesRequest{
 				User: tt.queriedUser,
 			})
 			if tt.wantAccessDenied {

--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -166,7 +166,7 @@ func (a *Server) NewWebSession(
 	ctx context.Context,
 	req NewWebSessionRequest,
 	opts *newWebSessionOpts,
-) (types.WebSession, services.AccessChecker, error) {
+) (types.WebSession, *services.ScopedAccessCheckerContext, error) {
 	return a.newWebSession(ctx, req, opts)
 }
 

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -1289,11 +1289,11 @@ func (g *GRPCServer) GetAccessRequestAllowedPromotions(ctx context.Context, requ
 }
 
 func (g *GRPCServer) GetAccessCapabilities(ctx context.Context, req *types.AccessCapabilitiesRequest) (*types.AccessCapabilities, error) {
-	auth, err := g.authenticate(ctx)
+	auth, err := g.scopedAuthenticate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	caps, err := auth.ServerWithRoles.GetAccessCapabilities(ctx, *req)
+	caps, err := auth.ScopedServerWithRoles.GetAccessCapabilities(ctx, *req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -6487,7 +6487,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	// Initialize and register the user preferences service.
 	userPreferencesSrv, err := userpreferencesv1.NewService(&userpreferencesv1.ServiceConfig{
 		Backend:    cfg.AuthServer.Services,
-		Authorizer: cfg.Authorizer,
+		Authorizer: cfg.ScopedAuthorizer,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -55,11 +55,6 @@ import (
 type NewWebSessionRequest = sessionreq.NewWebSessionRequest
 
 func (a *Server) CreateWebSessionFromReq(ctx context.Context, req NewWebSessionRequest) (types.WebSession, error) {
-	if req.Scope != "" {
-		// TODO(fspmarshall/scopes): add scoping support for web sessions
-		return nil, trace.BadParameter("web sessions cannot be pinned to a scope")
-	}
-
 	session, _, err := a.newWebSession(ctx, req, nil /* opts */)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -153,7 +148,16 @@ func (a *Server) newWebSession(
 	ctx context.Context,
 	req NewWebSessionRequest,
 	opts *newWebSessionOpts,
-) (types.WebSession, services.AccessChecker, error) {
+) (types.WebSession, *services.ScopedAccessCheckerContext, error) {
+	if req.Scope != "" {
+		if req.DelegationSessionID != "" {
+			return nil, nil, trace.BadParameter("access delegation is only supported for unscoped sessions")
+		}
+		if err := a.scopesFeatures.AssertEnabled(); err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+	}
+
 	userState, err := a.GetUserOrLoginState(ctx, req.User)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
@@ -168,15 +172,25 @@ func (a *Server) newWebSession(
 		return nil, nil, trace.Wrap(err)
 	}
 
-	checker, err := services.NewAccessChecker(&services.AccessInfo{
-		Username:                 userState.GetName(),
-		Roles:                    req.Roles,
-		Traits:                   req.Traits,
-		AllowedResourceAccessIDs: req.RequestedResourceAccessIDs,
-		DelegationSessionID:      req.DelegationSessionID,
-	}, clusterName.GetClusterName(), a)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
+	var checkerCtx *services.ScopedAccessCheckerContext
+	var unscopedChecker services.AccessChecker
+	if req.Scope != "" {
+		checkerCtx, err = a.AccessCheckerForScope(ctx, req.Scope, userState, req.RequestedResourceAccessIDs)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+	} else {
+		unscopedChecker, err = services.NewAccessChecker(&services.AccessInfo{
+			Username:                 userState.GetName(),
+			Roles:                    req.Roles,
+			Traits:                   req.Traits,
+			AllowedResourceAccessIDs: req.RequestedResourceAccessIDs,
+			DelegationSessionID:      req.DelegationSessionID,
+		}, clusterName.GetClusterName(), a)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		checkerCtx = services.NewScopedAccessCheckerContextFromUnscoped(unscopedChecker)
 	}
 
 	idleTimeout, err := a.getWebIdleTimeout(ctx)
@@ -207,7 +221,7 @@ func (a *Server) newWebSession(
 
 	sessionTTL := req.SessionTTL
 	if sessionTTL == 0 {
-		sessionTTL = checker.AdjustSessionTTL(apidefaults.CertDuration)
+		sessionTTL = checkerCtx.CertParams().AdjustSessionTTL(apidefaults.CertDuration)
 	}
 
 	if req.AttestWebSession {
@@ -241,7 +255,7 @@ func (a *Server) newWebSession(
 		TTL:            sessionTTL,
 		SSHPublicKey:   sshAuthorizedKey,
 		TLSPublicKey:   tlsPublicKeyPEM,
-		CheckerContext: services.NewScopedAccessCheckerContextFromUnscoped(checker), // TODO(fspmarshall/scopes): add scoping support to newWebSession.
+		CheckerContext: checkerCtx,
 		Traits:         req.Traits,
 		ActiveRequests: req.AccessRequests,
 	}
@@ -321,22 +335,26 @@ func (a *Server) newWebSession(
 		return nil, nil, trace.Wrap(err)
 	}
 
-	if tdr, err := a.calculateTrustedDeviceMode(ctx, func() ([]types.Role, error) {
-		return checker.Roles(), nil
-	}); err != nil {
-		a.logger.WarnContext(ctx, "Failed to calculate trusted device mode for session", "error", err)
-	} else {
-		sess.SetTrustedDeviceRequirement(tdr)
+	// TODO(bl-nero): Implement this for scoped sessions after support for device
+	// trust is added.
+	if unscopedChecker != nil {
+		if tdr, err := a.calculateTrustedDeviceMode(ctx, func() ([]types.Role, error) {
+			return unscopedChecker.Roles(), nil
+		}); err != nil {
+			a.logger.WarnContext(ctx, "Failed to calculate trusted device mode for session", "error", err)
+		} else {
+			sess.SetTrustedDeviceRequirement(tdr)
 
-		if tdr != types.TrustedDeviceRequirement_TRUSTED_DEVICE_REQUIREMENT_UNSPECIFIED {
-			a.logger.DebugContext(ctx, "Calculated trusted device requirement for session",
-				"user", req.User,
-				"trusted_device_requirement", tdr,
-			)
+			if tdr != types.TrustedDeviceRequirement_TRUSTED_DEVICE_REQUIREMENT_UNSPECIFIED {
+				a.logger.DebugContext(ctx, "Calculated trusted device requirement for session",
+					"user", req.User,
+					"trusted_device_requirement", tdr,
+				)
+			}
 		}
 	}
 
-	return sess, checker, nil
+	return sess, checkerCtx, nil
 }
 
 func (a *Server) getWebIdleTimeout(ctx context.Context) (time.Duration, error) {

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -335,22 +335,25 @@ func (a *Server) newWebSession(
 		return nil, nil, trace.Wrap(err)
 	}
 
-	// TODO(bl-nero): Implement this for scoped sessions after support for device
-	// trust is added.
-	if unscopedChecker != nil {
-		if tdr, err := a.calculateTrustedDeviceMode(ctx, func() ([]types.Role, error) {
+	if tdr, err := a.calculateTrustedDeviceMode(ctx, func() ([]types.Role, error) {
+		if unscopedChecker != nil {
 			return unscopedChecker.Roles(), nil
-		}); err != nil {
-			a.logger.WarnContext(ctx, "Failed to calculate trusted device mode for session", "error", err)
-		} else {
-			sess.SetTrustedDeviceRequirement(tdr)
+		}
+		// For scoped sessions, no traditional roles apply, so let's only compute
+		// the trusted device mode from global cluster settings.
+		// TODO(bl-nero): Update this once there's actual support for device trust
+		// in scoped sessions.
+		return nil, nil
+	}); err != nil {
+		a.logger.WarnContext(ctx, "Failed to calculate trusted device mode for session", "error", err)
+	} else {
+		sess.SetTrustedDeviceRequirement(tdr)
 
-			if tdr != types.TrustedDeviceRequirement_TRUSTED_DEVICE_REQUIREMENT_UNSPECIFIED {
-				a.logger.DebugContext(ctx, "Calculated trusted device requirement for session",
-					"user", req.User,
-					"trusted_device_requirement", tdr,
-				)
-			}
+		if tdr != types.TrustedDeviceRequirement_TRUSTED_DEVICE_REQUIREMENT_UNSPECIFIED {
+			a.logger.DebugContext(ctx, "Calculated trusted device requirement for session",
+				"user", req.User,
+				"trusted_device_requirement", tdr,
+			)
 		}
 	}
 

--- a/lib/auth/userpreferences/userpreferencesv1/service.go
+++ b/lib/auth/userpreferences/userpreferencesv1/service.go
@@ -32,7 +32,7 @@ import (
 // ServiceConfig holds configuration options for the user preferences service.
 type ServiceConfig struct {
 	Backend    services.UserPreferences
-	Authorizer authz.Authorizer
+	Authorizer authz.ScopedAuthorizer
 }
 
 // Service implements the teleport.userpreferences.v1.UserPreferencesService RPC service.
@@ -40,7 +40,7 @@ type Service struct {
 	userpreferences.UnimplementedUserPreferencesServiceServer
 
 	backend    services.UserPreferences
-	authorizer authz.Authorizer
+	authorizer authz.ScopedAuthorizer
 }
 
 // NewService returns a new user preferences gRPC service.
@@ -60,11 +60,14 @@ func NewService(cfg *ServiceConfig) (*Service, error) {
 
 // GetUserPreferences returns the user preferences for a given user.
 func (a *Service) GetUserPreferences(ctx context.Context, _ *userpreferences.GetUserPreferencesRequest) (*userpreferences.GetUserPreferencesResponse, error) {
-	authCtx, err := a.authorizer.Authorize(ctx)
+	authCtx, err := a.authorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
+	if authCtx.User == nil {
+		return nil, trace.AccessDenied("user preferences are only available to users, not scoped agents")
+	}
 	username := authCtx.User.GetName()
 
 	prefs, err := a.backend.GetUserPreferences(ctx, username)
@@ -79,11 +82,14 @@ func (a *Service) GetUserPreferences(ctx context.Context, _ *userpreferences.Get
 
 // UpsertUserPreferences creates or updates user preferences for a given username.
 func (a *Service) UpsertUserPreferences(ctx context.Context, req *userpreferences.UpsertUserPreferencesRequest) (*emptypb.Empty, error) {
-	authCtx, err := a.authorizer.Authorize(ctx)
+	authCtx, err := a.authorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
+	if authCtx.User == nil {
+		return nil, trace.AccessDenied("user preferences are only available to users, not scoped agents")
+	}
 	username := authCtx.User.GetName()
 
 	return &emptypb.Empty{}, trace.Wrap(a.backend.UpsertUserPreferences(ctx, username, req.GetPreferences()))

--- a/lib/auth/userpreferences/userpreferencesv1/service_test.go
+++ b/lib/auth/userpreferences/userpreferencesv1/service_test.go
@@ -193,10 +193,11 @@ func initSvc(t *testing.T) (map[string]context.Context, *Service) {
 	})
 	require.NoError(t, err)
 
-	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
-		ClusterName: "test-cluster",
-		AccessPoint: accessPoint,
-		LockWatcher: lockWatcher,
+	authorizer, err := authz.NewScopedAuthorizer(authz.AuthorizerOpts{
+		ClusterName:      "test-cluster",
+		AccessPoint:      accessPoint,
+		LockWatcher:      lockWatcher,
+		ScopedRoleReader: local.NewScopedAccessService(backend),
 	})
 	require.NoError(t, err)
 

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -229,6 +229,8 @@ type AuthenticateWebUserRequest struct {
 	User string `json:"user"`
 	// WebauthnAssertionResponse is a signed WebAuthn credential assertion.
 	WebauthnAssertionResponse *wantypes.CredentialAssertionResponse `json:"webauthnAssertionResponse,omitempty"`
+	// Scope is a scope for with the user is authenticated. Empty means unscoped.
+	Scope string `json:"scope,omitempty"`
 }
 
 type HeadlessRequest struct {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -613,6 +613,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 	sessionCache, err := newSessionCache(h.cfg.Context, sessionCacheOptions{
 		proxyClient:               cfg.ProxyClient,
 		accessPoint:               cfg.AccessPoint,
+		scopedRoleReader:          cfg.AccessPoint.ScopedRoleReader(),
 		servers:                   []utils.NetAddr{cfg.AuthServers},
 		cipherSuites:              cfg.CipherSuites,
 		clock:                     h.clock,
@@ -855,7 +856,7 @@ func (h *Handler) authenticateWebSession(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		return webSession{}, trace.Wrap(err)
 	}
-	resp, err := newSessionResponse(ctx)
+	resp, err := newSessionResponse(r.Context(), ctx)
 	if err != nil {
 		return webSession{}, trace.Wrap(err)
 	}
@@ -2879,14 +2880,26 @@ type CreateSessionResponse struct {
 	TrustedDeviceRequirement int32 `json:"trustedDeviceRequirement,omitempty"`
 }
 
-func newSessionResponse(sctx *SessionContext) (*CreateSessionResponse, error) {
+func newSessionResponse(ctx context.Context, sctx *SessionContext) (*CreateSessionResponse, error) {
 	accessChecker, err := sctx.GetUserAccessChecker()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	_, err = accessChecker.CheckLoginDuration(0)
-	if err != nil {
-		return nil, trace.Wrap(err)
+
+	if accessChecker.AccessInfo().ScopePin == nil {
+		_, err = accessChecker.CheckLoginDuration(0)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	} else {
+		checkerContext, err := sctx.GetUserScopedAccessCheckerContext(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		_, err = checkerContext.CertParams().GetSSHLoginsForTTL(ctx, 0)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	token, err := sctx.getToken()
@@ -2967,7 +2980,7 @@ func (h *Handler) createWebSession(w http.ResponseWriter, r *http.Request, p htt
 		return nil, trace.AccessDenied("need auth")
 	}
 
-	res, err := newSessionResponse(ctx)
+	res, err := newSessionResponse(r.Context(), ctx)
 	return res, trace.Wrap(err)
 }
 
@@ -3096,7 +3109,7 @@ func (h *Handler) renewWebSession(w http.ResponseWriter, r *http.Request, params
 		return nil, trace.Wrap(err)
 	}
 
-	res, err := newSessionResponse(newContext)
+	res, err := newSessionResponse(r.Context(), newContext)
 	return res, trace.Wrap(err)
 }
 
@@ -3174,7 +3187,7 @@ func (h *Handler) changeUserAuthentication(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Checks for at least one valid login.
-	if _, err := newSessionResponse(ctx); err != nil {
+	if _, err := newSessionResponse(r.Context(), ctx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -3395,7 +3408,7 @@ func (h *Handler) mfaLoginFinishSession(w http.ResponseWriter, r *http.Request, 
 		return nil, trace.AccessDenied("need auth")
 	}
 
-	return newSessionResponse(ctx)
+	return newSessionResponse(r.Context(), ctx)
 }
 
 // getClusters returns a list of cluster and its data.

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1537,9 +1537,32 @@ func (h *Handler) getUserContext(w http.ResponseWriter, r *http.Request, p httpr
 		})
 
 		userContext.AvailableScopes = assignedScopes
+
+		userContext.Scope, err = scopeFromSessionContext(c)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	return userContext, nil
+}
+
+func scopeFromSessionContext(c *SessionContext) (string, error) {
+	id, err := c.GetIdentity()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	if id == nil {
+		return "", nil
+	}
+
+	pin := id.ScopePin
+	if pin == nil {
+		return "", nil
+	}
+
+	return pin.GetScope(), nil
 }
 
 // PublicProxyAddr returns the publicly advertised proxy address
@@ -2485,7 +2508,6 @@ func (h *Handler) githubLoginWeb(w http.ResponseWriter, r *http.Request, p httpr
 		logger.ErrorContext(r.Context(), "Failed to parse request remote address", "error", err)
 		return sso.LoginFailedRedirectURL
 	}
-
 	response, err := h.cfg.ProxyClient.CreateGithubAuthRequest(r.Context(), types.GithubAuthRequest{
 		CSRFToken:         req.CSRFToken,
 		ConnectorID:       req.ConnectorID,
@@ -2493,6 +2515,7 @@ func (h *Handler) githubLoginWeb(w http.ResponseWriter, r *http.Request, p httpr
 		ClientRedirectURL: req.ClientRedirectURL,
 		ClientLoginIP:     remoteAddr,
 		ClientUserAgent:   r.UserAgent(),
+		Scope:             req.Scope,
 	})
 	if err != nil {
 		logger.ErrorContext(r.Context(), "Error creating auth request", "error", err)
@@ -2818,6 +2841,9 @@ type CreateSessionReq struct {
 	Pass string `json:"pass"`
 	// SecondFactorToken is the OTP.
 	SecondFactorToken string `json:"second_factor_token"`
+	// Scope is the scope for which this session is created. Empty means
+	// unscoped.
+	Scope string `json:"scope"`
 }
 
 // String returns text description of this response
@@ -2916,7 +2942,7 @@ func (h *Handler) createWebSession(w http.ResponseWriter, r *http.Request, p htt
 	case req.SecondFactorToken == "" && !cap.IsSecondFactorEnforced():
 		webSession, err = h.auth.AuthWithoutOTP(r.Context(), req.User, req.Pass, clientMeta)
 	case cap.IsSecondFactorTOTPAllowed():
-		webSession, err = h.auth.AuthWithOTP(r.Context(), req.User, req.Pass, req.SecondFactorToken, clientMeta)
+		webSession, err = h.auth.AuthWithOTP(r.Context(), req.User, req.Pass, req.SecondFactorToken, req.Scope, clientMeta)
 	default:
 		return nil, trace.AccessDenied("direct login with password+otp not supported by this cluster")
 	}
@@ -3456,7 +3482,7 @@ func (h *Handler) getSiteNamespaces(w http.ResponseWriter, r *http.Request, _ ht
 	}, nil
 }
 
-func makeUnifiedResourceRequest(r *http.Request) (*proto.ListUnifiedResourcesRequest, error) {
+func makeUnifiedResourceRequest(r *http.Request, scopePin *scopesv1.Pin) (*proto.ListUnifiedResourcesRequest, error) {
 	values := r.URL.Query()
 
 	limit, err := QueryLimitAsInt32(values, "limit", defaults.MaxIterationLimit)
@@ -3480,16 +3506,23 @@ func makeUnifiedResourceRequest(r *http.Request) (*proto.ListUnifiedResourcesReq
 	}
 
 	// set default kinds to be requested if none exist in the request
+	scopedIdentity := scopePin.GetScope() != ""
 	if len(kinds) == 0 {
-		kinds = []string{
-			types.KindApp,
-			types.KindDatabase,
-			types.KindNode,
-			types.KindWindowsDesktop,
-			types.KindLinuxDesktop,
-			types.KindKubernetesCluster,
-			types.KindSAMLIdPServiceProvider,
-			types.KindGitServer,
+		if scopedIdentity {
+			// TODO(bl-nero): Support more resource kinds when they are supported for
+			// scoped sessions.
+			kinds = []string{types.KindNode}
+		} else {
+			kinds = []string{
+				types.KindApp,
+				types.KindDatabase,
+				types.KindNode,
+				types.KindWindowsDesktop,
+				types.KindLinuxDesktop,
+				types.KindKubernetesCluster,
+				types.KindSAMLIdPServiceProvider,
+				types.KindGitServer,
+			}
 		}
 	}
 
@@ -3506,7 +3539,7 @@ func makeUnifiedResourceRequest(r *http.Request) (*proto.ListUnifiedResourcesReq
 		PredicateExpression: values.Get("query"),
 		SearchKeywords:      client.ParseSearchKeywords(values.Get("search"), ' '),
 		UseSearchAsRoles:    useSearchAsRoles,
-		IncludeLogins:       true,
+		IncludeLogins:       !scopedIdentity,
 		IncludeRequestable:  includeRequestable,
 	}, nil
 }
@@ -3553,7 +3586,7 @@ func (h *Handler) clusterUnifiedResourcesGet(w http.ResponseWriter, request *htt
 		return nil, trace.Wrap(err)
 	}
 
-	req, err := makeUnifiedResourceRequest(request)
+	req, err := makeUnifiedResourceRequest(request, identity.ScopePin)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -5794,6 +5827,8 @@ type SSORequestParams struct {
 	CSRFToken string
 	// LoginHint is the user's identifier (email) for identifier-first login.
 	LoginHint string
+	// Scope is the scope that this session will be pinned to.
+	Scope string
 }
 
 // ParseSSORequestParams extracts the SSO request parameters from an http.Request,
@@ -5835,11 +5870,14 @@ func ParseSSORequestParams(r *http.Request) (*SSORequestParams, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	scope := query.Get("scope")
+
 	return &SSORequestParams{
 		ClientRedirectURL: clientRedirectURL,
 		ConnectorID:       connectorID,
 		CSRFToken:         csrfToken,
 		LoginHint:         loginHint,
+		Scope:             scope,
 	}, nil
 }
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3088,6 +3088,9 @@ type renewSessionRequest struct {
 //   - ReloadUser (opt): similar to default but updates user related data (e.g login traits) by retrieving it from the backend
 //   - default (none set): create new session with currently assigned roles
 func (h *Handler) renewWebSession(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (any, error) {
+	// TODO(bl-nero): Fix session renewal for scoped sessions. This endpoint
+	// doesn't work for scoped sessions, but currently, the web UI doesn't even
+	// call it in such scenario.
 	req := renewSessionRequest{}
 	if err := httplib.ReadResourceJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2951,9 +2951,9 @@ func (h *Handler) createWebSession(w http.ResponseWriter, r *http.Request, p htt
 	var webSession types.WebSession
 	switch {
 	case !cap.IsSecondFactorEnforced():
-		webSession, err = h.auth.AuthWithoutOTP(r.Context(), req.User, req.Pass, clientMeta)
+		webSession, err = h.auth.AuthWithoutOTP(r.Context(), req.User, req.Pass, req.Scope, clientMeta)
 	case req.SecondFactorToken == "" && !cap.IsSecondFactorEnforced():
-		webSession, err = h.auth.AuthWithoutOTP(r.Context(), req.User, req.Pass, clientMeta)
+		webSession, err = h.auth.AuthWithoutOTP(r.Context(), req.User, req.Pass, req.Scope, clientMeta)
 	case cap.IsSecondFactorTOTPAllowed():
 		webSession, err = h.auth.AuthWithOTP(r.Context(), req.User, req.Pass, req.SecondFactorToken, req.Scope, clientMeta)
 	default:

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -145,7 +145,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/scopes"
-	"github.com/gravitational/teleport/lib/scopes/access"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	scopedapp "github.com/gravitational/teleport/lib/scopes/app"
 	"github.com/gravitational/teleport/lib/secret"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -324,6 +324,9 @@ type webSuiteConfig struct {
 
 	// middleware adds optional middleware to the test handler.
 	middleware func(next http.Handler) http.Handler
+
+	// scopesFeatures controls scoped access feature flags.
+	scopesFeatures scopes.Features
 }
 
 func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
@@ -365,6 +368,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 			ClusterNetworkingConfig: networkingConfig,
 			AuthPreferenceSpec:      cfg.authPreferenceSpec,
 			Modules:                 cfg.modules,
+			ScopesFeatures:          cfg.scopesFeatures,
 		},
 	}
 
@@ -675,6 +679,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 			ProxySSHAddr:  "127.0.0.1",
 			AccessPoint:   s.server.Auth(),
 		},
+		ScopesFeatures: cfg.scopesFeatures,
 		SessionControl: SessionControllerFunc(func(ctx context.Context, sctx *SessionContext, login, localAddr, remoteAddr string) (context.Context, error) {
 			controller := srv.WebSessionController(proxySessionController)
 			ctx, err := controller(ctx, sctx, login, localAddr, remoteAddr)
@@ -3226,10 +3231,14 @@ func TestLogin_PrivateKeyEnabledError(t *testing.T) {
 
 func TestLogin(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+	ctx := t.Context()
+
+	s := newWebSuiteWithConfig(t, webSuiteConfig{
+		scopesFeatures: scopes.Features{Enabled: true},
+	})
 	ap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
 		Type:         constants.Local,
-		SecondFactor: constants.SecondFactorOff,
+		SecondFactor: constants.SecondFactorOTP,
 	})
 	require.NoError(t, err)
 	_, err = s.server.Auth().UpsertAuthPreference(s.ctx, ap)
@@ -3239,63 +3248,129 @@ func TestLogin(t *testing.T) {
 	const user = "user1"
 	const pass = "password1234"
 	s.createUser(t, user, "root", pass, "")
+	otpSecret := newOTPSharedSecret()
+	dev, err := services.NewTOTPDevice("otp-device", otpSecret, s.clock.Now())
+	require.NoError(t, err)
+	err = s.server.Auth().UpsertMFADevice(ctx, user, dev)
+	require.NoError(t, err)
+
+	_, err = s.server.Auth().ScopedAccess().CreateScopedRole(
+		ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+			Role: scopedaccessv1.ScopedRole_builder{
+				Kind:    scopedaccess.KindScopedRole,
+				Version: types.V1,
+				Metadata: headerv1.Metadata_builder{
+					Name: "prod-role",
+				}.Build(),
+				Scope: "/prod",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/prod/east"},
+				}.Build(),
+			}.Build(),
+		}.Build(),
+	)
+	require.NoError(t, err)
+
+	_, err = s.server.Auth().ScopedAccess().CreateScopedRoleAssignment(
+		ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
+			Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
+				Kind:    scopedaccess.KindScopedRoleAssignment,
+				SubKind: scopedaccess.SubKindDynamic,
+				Version: types.V1,
+				Metadata: headerv1.Metadata_builder{
+					Name: "prod-role-assignment",
+				}.Build(),
+				Scope: "/prod",
+				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+					User: "user1",
+					Assignments: []*scopedaccessv1.Assignment{
+						scopedaccessv1.Assignment_builder{
+							Role:  "/prod::prod-role",
+							Scope: "/prod/east",
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+		}.Build(),
+	)
+	require.NoError(t, err)
 
 	clt := s.client(t)
-	ctx := context.Background()
 
-	const ua = "test-ua"
-	sessionResp, httpResp := loginWebOTP(t, ctx, loginWebOTPParams{
-		webClient: clt,
-		user:      user,
-		password:  pass,
-		userAgent: ua,
-	})
+	cases := []struct {
+		name  string
+		scope string
+	}{
+		{name: "unscoped", scope: ""},
+		{name: "scoped", scope: "/prod/east"},
+	}
 
-	events, _, err := s.server.AuthServer.AuditLog.SearchEvents(ctx, events.SearchEventsRequest{
-		From:       s.clock.Now().Add(-time.Hour),
-		To:         s.clock.Now().Add(time.Hour),
-		EventTypes: []string{events.UserLoginEvent},
-		Limit:      1,
-		Order:      types.EventOrderDescending,
-	})
-	require.NoError(t, err)
-	event := events[0].(*apievents.UserLogin)
-	require.True(t, event.Success)
-	require.Equal(t, ua, event.UserAgent)
-	require.True(t, strings.HasPrefix(event.RemoteAddr, "127.0.0.1:"))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			const ua = "test-ua"
+			s.clock.Advance(time.Minute) // Prevent reusing old OTP
+			sessionResp, httpResp := loginWebOTP(t, ctx, loginWebOTPParams{
+				webClient: clt,
+				clock:     s.clock,
+				user:      user,
+				password:  pass,
+				otpSecret: otpSecret,
+				scope:     tc.scope,
+				userAgent: ua,
+			})
 
-	cookies := httpResp.Cookies()
-	require.Len(t, cookies, 1)
-	require.NotEmpty(t, sessionResp.SessionExpires)
+			events, _, err := s.server.AuthServer.AuditLog.SearchEvents(ctx, events.SearchEventsRequest{
+				From:       s.clock.Now().Add(-time.Hour),
+				To:         s.clock.Now().Add(time.Hour),
+				EventTypes: []string{events.UserLoginEvent},
+				Limit:      1,
+				Order:      types.EventOrderDescending,
+			})
+			require.NoError(t, err)
+			event := events[0].(*apievents.UserLogin)
+			require.True(t, event.Success)
+			require.Equal(t, ua, event.UserAgent)
+			require.True(t, strings.HasPrefix(event.RemoteAddr, "127.0.0.1:"))
 
-	// now make sure we are logged in by calling authenticated method
-	// we need to supply both session cookie and bearer token for
-	// request to succeed
-	jar, err := cookiejar.New(nil)
-	require.NoError(t, err)
+			cookies := httpResp.Cookies()
+			require.Len(t, cookies, 1)
+			require.NotEmpty(t, sessionResp.SessionExpires)
 
-	clt = s.client(t, roundtrip.BearerAuth(sessionResp.Token), roundtrip.CookieJar(jar))
-	jar.SetCookies(s.url(), cookies)
+			// now make sure we are logged in by calling authenticated method
+			// we need to supply both session cookie and bearer token for
+			// request to succeed
+			jar, err := cookiejar.New(nil)
+			require.NoError(t, err)
 
-	re, err := clt.Get(s.ctx, clt.Endpoint("webapi", "sites"), url.Values{})
-	require.NoError(t, err)
+			clt = s.client(t, roundtrip.BearerAuth(sessionResp.Token), roundtrip.CookieJar(jar))
+			jar.SetCookies(s.url(), cookies)
 
-	var clusters []webui.Cluster
-	require.NoError(t, json.Unmarshal(re.Bytes(), &clusters))
+			re, err := clt.Get(
+				s.ctx,
+				clt.Endpoint("webapi", "sites", s.server.ClusterName(), "context"),
+				url.Values{},
+			)
+			require.NoError(t, err)
 
-	// in absence of session cookie or bearer auth the same request fill fail
+			var userContext webui.UserContext
+			require.NoError(t, json.Unmarshal(re.Bytes(), &userContext))
+			assert.Equal(t, tc.scope, userContext.Scope)
 
-	// no session cookie:
-	clt = s.client(t, roundtrip.BearerAuth(sessionResp.Token))
-	_, err = clt.Get(s.ctx, clt.Endpoint("webapi", "sites"), url.Values{})
-	require.Error(t, err)
-	require.True(t, trace.IsAccessDenied(err))
+			// in absence of session cookie or bearer auth the same request fill fail
 
-	// no bearer token:
-	clt = s.client(t, roundtrip.CookieJar(jar))
-	_, err = clt.Get(s.ctx, clt.Endpoint("webapi", "sites"), url.Values{})
-	require.Error(t, err)
-	require.True(t, trace.IsAccessDenied(err))
+			// no session cookie:
+			clt = s.client(t, roundtrip.BearerAuth(sessionResp.Token))
+			_, err = clt.Get(s.ctx, clt.Endpoint("webapi", "sites"), url.Values{})
+			require.Error(t, err)
+			require.True(t, trace.IsAccessDenied(err))
+
+			// no bearer token:
+			clt = s.client(t, roundtrip.CookieJar(jar))
+			_, err = clt.Get(s.ctx, clt.Endpoint("webapi", "sites"), url.Values{})
+			require.Error(t, err)
+			require.True(t, trace.IsAccessDenied(err))
+		})
+	}
 }
 
 // TestEmptyMotD ensures that responses returned by both /webapi/ping and
@@ -9662,20 +9737,16 @@ type testProxy struct {
 	webURL  url.URL
 }
 
-// authPack returns new authenticated package consisting of created valid
-// user, otp token, created web session and authenticated client.
-func (r *testProxy) authPack(t *testing.T, teleportUser string, roles []types.Role) *authPack {
+// authPackWithLoginParams returns new authenticated package consisting of
+// created valid user, otp token, created web session and authenticated client
+// with given login params.
+func (r *testProxy) authPackWithLoginParams(
+	t *testing.T, teleportUser string, loginParams loginWebOTPParams, roles []types.Role,
+) *authPack {
 	ctx := context.Background()
-	const (
-		pass      = "abcdef123456"
-		rawSecret = "def456"
-	)
-
 	u, err := user.Current()
 	require.NoError(t, err)
 	loginUser := u.Username
-
-	otpSecret := newOTPSharedSecret()
 
 	ap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
 		Type:         constants.Local,
@@ -9686,15 +9757,11 @@ func (r *testProxy) authPack(t *testing.T, teleportUser string, roles []types.Ro
 	_, err = r.auth.Auth().UpsertAuthPreference(ctx, ap)
 	require.NoError(t, err)
 
-	r.createUser(context.Background(), t, teleportUser, loginUser, pass, otpSecret, roles)
+	r.createUser(
+		context.Background(), t, teleportUser, loginUser, loginParams.password, loginParams.otpSecret, roles,
+	)
 
-	sessionResp, httpResp := loginWebOTP(t, ctx, loginWebOTPParams{
-		webClient: r.newClient(t),
-		clock:     r.clock,
-		user:      teleportUser,
-		password:  pass,
-		otpSecret: otpSecret,
-	})
+	sessionResp, httpResp := loginWebOTP(t, ctx, loginParams)
 
 	jar, err := cookiejar.New(nil)
 	require.NoError(t, err)
@@ -9703,17 +9770,46 @@ func (r *testProxy) authPack(t *testing.T, teleportUser string, roles []types.Ro
 	jar.SetCookies(&r.webURL, httpResp.Cookies())
 
 	return &authPack{
-		otpSecret: otpSecret,
+		otpSecret: loginParams.otpSecret,
 		user:      teleportUser,
 		login:     loginUser,
 		session:   sessionResp,
 		clt:       clt,
 		cookies:   httpResp.Cookies(),
-		password:  pass,
+		password:  loginParams.password,
 		device: &authtest.Device{
-			TOTPSecret: otpSecret,
+			TOTPSecret: loginParams.otpSecret,
 		},
 	}
+}
+
+func (r *testProxy) authPack(t *testing.T, teleportUser string, roles []types.Role) *authPack {
+	return r.authPackWithLoginParams(
+		t, teleportUser,
+		loginWebOTPParams{
+			webClient: r.newClient(t),
+			clock:     r.clock,
+			user:      teleportUser,
+			password:  "abcdef123456",
+			otpSecret: newOTPSharedSecret(),
+		},
+		roles,
+	)
+}
+
+func (r *testProxy) scopedAuthPack(t *testing.T, teleportUser string, scope string, roles []types.Role) *authPack {
+	return r.authPackWithLoginParams(
+		t, teleportUser,
+		loginWebOTPParams{
+			webClient: r.newClient(t),
+			clock:     r.clock,
+			user:      teleportUser,
+			password:  "abcdef123456",
+			otpSecret: newOTPSharedSecret(),
+			scope:     scope,
+		},
+		roles,
+	)
 }
 
 func (r *testProxy) authPackFromPack(t *testing.T, pack *authPack) *authPack {
@@ -9931,7 +10027,7 @@ func TestUserContextWithAccessRequest(t *testing.T) {
 	require.Equal(t, accessRequestID, userContext.ConsumedAccessRequestID)
 }
 
-func TestUerContextWithScopesNoAssignments(t *testing.T) {
+func TestUserContextWithScopesNoAssignments(t *testing.T) {
 	t.Parallel()
 	env := newWebPack(t, 1, withScopesFeatures(scopes.Features{Enabled: true}))
 	proxy := env.proxies[0]
@@ -9954,7 +10050,7 @@ func TestUerContextWithScopesNoAssignments(t *testing.T) {
 	require.Empty(t, userContext.AvailableScopes)
 }
 
-func TestUerContextWithScopes(t *testing.T) {
+func TestUserContextWithScopes(t *testing.T) {
 	t.Parallel()
 	env := newWebPack(t, 1, withScopesFeatures(scopes.Features{Enabled: true}))
 	proxy := env.proxies[0]
@@ -9963,7 +10059,7 @@ func TestUerContextWithScopes(t *testing.T) {
 	// Create scoped roles.
 	_, err := env.server.Auth().ScopedAccess().CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
 		Role: scopedaccessv1.ScopedRole_builder{
-			Kind:    access.KindScopedRole,
+			Kind:    scopedaccess.KindScopedRole,
 			Version: types.V1,
 			Metadata: headerv1.Metadata_builder{
 				Name: "role-a",
@@ -9977,7 +10073,7 @@ func TestUerContextWithScopes(t *testing.T) {
 	require.NoError(t, err)
 	_, err = env.server.Auth().ScopedAccess().CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
 		Role: scopedaccessv1.ScopedRole_builder{
-			Kind:    access.KindScopedRole,
+			Kind:    scopedaccess.KindScopedRole,
 			Version: types.V1,
 			Metadata: headerv1.Metadata_builder{
 				Name: "role-b",
@@ -9994,8 +10090,8 @@ func TestUerContextWithScopes(t *testing.T) {
 	username := "dave"
 	assignment1, err := env.server.Auth().ScopedAccess().CreateScopedRoleAssignment(ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
 		Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
-			Kind:    access.KindScopedRoleAssignment,
-			SubKind: access.SubKindDynamic,
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			SubKind: scopedaccess.SubKindDynamic,
 			Version: types.V1,
 			Metadata: headerv1.Metadata_builder{
 				Name: "assignment-1",
@@ -10021,8 +10117,8 @@ func TestUerContextWithScopes(t *testing.T) {
 	require.NoError(t, err)
 	assignment2, err := env.server.Auth().ScopedAccess().CreateScopedRoleAssignment(ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
 		Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
-			Kind:    access.KindScopedRoleAssignment,
-			SubKind: access.SubKindDynamic,
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			SubKind: scopedaccess.SubKindDynamic,
 			Version: types.V1,
 			Metadata: headerv1.Metadata_builder{
 				Name: "assignment-2",
@@ -10048,7 +10144,7 @@ func TestUerContextWithScopes(t *testing.T) {
 	waitForSRACache(t, env.server.TLS, assignment1, assignment2)
 
 	// Create and authenticate the test user.
-	pack := proxy.authPack(t, username, []types.Role{})
+	pack := proxy.scopedAuthPack(t, username, "/test/a2", []types.Role{})
 
 	// Make a request to fetch the userContext.
 	endpoint := pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "context")
@@ -10061,7 +10157,8 @@ func TestUerContextWithScopes(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify that the userContext returned contains the assigned scopes.
-	require.Equal(t, []string{"/test/a1", "/test/a2", "/test/b1"}, userContext.AvailableScopes)
+	assert.Equal(t, []string{"/test/a1", "/test/a2", "/test/b1"}, userContext.AvailableScopes)
+	assert.Equal(t, "/test/a2", userContext.Scope)
 }
 
 func waitForSRACache(t *testing.T, srv *authtest.TLSServer, resps ...*scopedaccessv1.CreateScopedRoleAssignmentResponse) {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -3307,6 +3307,7 @@ func TestLogin(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
 			const ua = "test-ua"
 			s.clock.Advance(time.Minute) // Prevent reusing old OTP
 			sessionResp, httpResp := loginWebOTP(t, ctx, loginWebOTPParams{

--- a/lib/web/login_helper_test.go
+++ b/lib/web/login_helper_test.go
@@ -54,6 +54,7 @@ type loginWebOTPParams struct {
 	// If empty then no OTP is sent in the request.
 	otpSecret string
 
+	scope               string // Optional.
 	userAgent           string // Optional.
 	overrideContentType string // Optional.
 }
@@ -110,6 +111,7 @@ func rawLoginWebOTP(ctx context.Context, params loginWebOTPParams) (resp *Draine
 		User:              params.user,
 		Pass:              params.password,
 		SecondFactorToken: code,
+		Scope:             params.scope,
 	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err, "request marshal")

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -108,6 +108,14 @@ type SessionContextConfig struct {
 	// "GetNodes".
 	UnsafeCachedAuthClient authclient.ReadProxyAccessPoint
 
+	// UnsafeScoopedRoleReader is a scoped role reader. It's authenticated with
+	// the identity of the node, hence it's "unsafe".
+	//
+	// Only use it where the identity of the caller will not affect the result of
+	// the RPC. For example, never call it to get a list of roles and return it
+	// to the user, as it may return more than the user is allowed to see.
+	UnsafeScopedRoleReader services.ScopedRoleReader
+
 	Parent *sessionCache
 	// Resources is a persistent resource store this context is bound to.
 	// The store maintains a list of resources between session renewals
@@ -138,6 +146,10 @@ func (c *SessionContextConfig) CheckAndSetDefaults() error {
 
 	if c.Session == nil {
 		return trace.BadParameter("Session required")
+	}
+
+	if c.UnsafeCachedAuthClient == nil {
+		return trace.BadParameter("Scoped role reader required")
 	}
 
 	if c.Log == nil {
@@ -518,6 +530,37 @@ func (c *SessionContext) GetUserAccessChecker() (services.AccessChecker, error) 
 	return accessChecker, trace.Wrap(err)
 }
 
+func (c *SessionContext) GetUserScopedAccessCheckerContext(ctx context.Context) (*services.ScopedAccessCheckerContext, error) {
+	cert, err := c.GetSSHCertificate()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ident, err := sshca.DecodeIdentity(cert)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	accessInfo := services.AccessInfoFromLocalSSHIdentity(ident)
+
+	if accessInfo.ScopePin == nil {
+		checker, err := c.GetUserAccessChecker()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		return services.NewScopedAccessCheckerContextFromUnscoped(checker), nil
+	}
+
+	checkerCtx, err := services.NewScopedAccessCheckerContext(
+		ctx, accessInfo, c.cfg.RootClusterName, c.cfg.UnsafeScopedRoleReader,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return checkerCtx, err
+}
+
 // GetProxyListenerMode returns cluster proxy listener mode form cluster networking config.
 func (c *SessionContext) GetProxyListenerMode(ctx context.Context) (types.ProxyListenerMode, error) {
 	resp, err := c.cfg.UnsafeCachedAuthClient.GetClusterNetworkingConfig(ctx)
@@ -627,11 +670,12 @@ func (c *SessionContext) expired(ctx context.Context) bool {
 const cachedSessionLingeringThreshold = 2 * time.Minute
 
 type sessionCacheOptions struct {
-	proxyClient  authclient.ClientI
-	accessPoint  authclient.ReadProxyAccessPoint
-	servers      []utils.NetAddr
-	cipherSuites []uint16
-	clock        clockwork.Clock
+	proxyClient      authclient.ClientI
+	scopedRoleReader services.ScopedRoleReader
+	accessPoint      authclient.ReadProxyAccessPoint
+	servers          []utils.NetAddr
+	cipherSuites     []uint16
+	clock            clockwork.Clock
 	// sessionLingeringThreshold specifies the time the session will linger
 	// in the cache before getting purged after it has expired
 	sessionLingeringThreshold time.Duration
@@ -667,6 +711,7 @@ func newSessionCache(ctx context.Context, config sessionCacheOptions) (*sessionC
 	cache := &sessionCache{
 		clusterName:                      clusterName.GetClusterName(),
 		proxyClient:                      config.proxyClient,
+		scopedRoleReader:                 config.scopedRoleReader,
 		accessPoint:                      config.accessPoint,
 		sessions:                         make(map[string]*SessionContext),
 		resources:                        make(map[string]*sessionResources),
@@ -701,13 +746,14 @@ func newSessionCache(ctx context.Context, config sessionCacheOptions) (*sessionC
 // sessionCache handles web session authentication,
 // and holds in-memory contexts associated with each session
 type sessionCache struct {
-	log         *slog.Logger
-	proxyClient authclient.ClientI
-	authServers []utils.NetAddr
-	accessPoint authclient.ReadProxyAccessPoint
-	closer      *utils.CloseBroadcaster
-	clusterName string
-	clock       clockwork.Clock
+	log              *slog.Logger
+	proxyClient      authclient.ClientI
+	authServers      []utils.NetAddr
+	accessPoint      authclient.ReadProxyAccessPoint
+	scopedRoleReader services.ScopedRoleReader
+	closer           *utils.CloseBroadcaster
+	clusterName      string
+	clock            clockwork.Clock
 	// sessionLingeringThreshold specifies the time the session will linger
 	// in the cache before getting purged after it has expired
 	sessionLingeringThreshold time.Duration
@@ -1230,6 +1276,7 @@ func (s *sessionCache) newSessionContextFromSession(ctx context.Context, session
 		User:                   session.GetUser(),
 		RootClient:             userClient,
 		UnsafeCachedAuthClient: s.accessPoint,
+		UnsafeScopedRoleReader: s.scopedRoleReader,
 		Parent:                 s,
 		Resources:              s.upsertSessionContext(session.GetUser()),
 		Session:                session,

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -937,6 +937,7 @@ func (s *sessionCache) releaseResourcesIfNoDeviceExtensions(ctx context.Context,
 func (s *sessionCache) AuthWithOTP(
 	ctx context.Context,
 	user, pass, otpToken string,
+	scope string,
 	clientMeta *authclient.ForwardedClientMetadata,
 ) (types.WebSession, error) {
 	return s.proxyClient.AuthenticateWebUser(ctx, authclient.AuthenticateUserRequest{
@@ -947,6 +948,7 @@ func (s *sessionCache) AuthWithOTP(
 			Token:    otpToken,
 		},
 		ClientMetadata: clientMeta,
+		Scope:          scope,
 	})
 }
 
@@ -970,6 +972,7 @@ func (s *sessionCache) AuthenticateWebUser(
 	authReq := authclient.AuthenticateUserRequest{
 		Username:       req.User,
 		ClientMetadata: clientMeta,
+		Scope:          req.Scope,
 	}
 	if req.WebauthnAssertionResponse != nil {
 		authReq.Webauthn = req.WebauthnAssertionResponse

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -1001,7 +1001,7 @@ func (s *sessionCache) AuthWithOTP(
 // AuthWithoutOTP authenticates the specified user with the given password.
 // Returns a new web session if successful.
 func (s *sessionCache) AuthWithoutOTP(
-	ctx context.Context, user, pass string, clientMeta *authclient.ForwardedClientMetadata,
+	ctx context.Context, user, pass string, scope string, clientMeta *authclient.ForwardedClientMetadata,
 ) (types.WebSession, error) {
 	return s.proxyClient.AuthenticateWebUser(ctx, authclient.AuthenticateUserRequest{
 		Username: user,
@@ -1009,6 +1009,7 @@ func (s *sessionCache) AuthWithoutOTP(
 			Password: []byte(pass),
 		},
 		ClientMetadata: clientMeta,
+		Scope:          scope,
 	})
 }
 

--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -79,6 +79,9 @@ type UserContext struct {
 	// AvailableScopes is a list of scopes available to the user through their
 	// scoped role assignments.
 	AvailableScopes []string `json:"availableScopes"`
+	// Scope contains the scope pinned to the current session. An empty string
+	// indicates an unscoped session.
+	Scope string `json:"scope"`
 }
 
 func getAccessStrategy(roleset services.RoleSet) accessStrategy {

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -63,6 +63,7 @@ import { ListView } from './ListView/ListView';
 import { ResourceTab } from './ResourceTab';
 import { getResourceId } from './shared/StatusInfo';
 import { mapResourceToViewItem } from './shared/viewItemsFactory';
+import './unifiedStyles.css';
 import {
   IncludedResourceMode,
   PinningSupport,
@@ -74,7 +75,6 @@ import {
   VisibleFilterPanelFields,
   VisibleResourceItemFields,
 } from './types';
-import './unifiedStyles.css';
 
 // get 48 resources to start
 const INITIAL_FETCH_SIZE = 48;
@@ -911,8 +911,13 @@ const ListFooter = styled.div`
  */
 export function getResourceAvailabilityFilter(
   availableResourceMode: AvailableResourceMode,
-  canRequestAllResources: boolean
+  canRequestAllResources: boolean,
+  // TODO(bl-nero): This parameter should be mandatory once the enterprise code catches up.
+  scopedSession?: boolean
 ): ResourceAvailabilityFilter {
+  if (scopedSession) {
+    return { mode: 'accessible', canRequestAll: false };
+  }
   switch (availableResourceMode) {
     case AvailableResourceMode.NONE:
       if (!canRequestAllResources) {

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -912,8 +912,7 @@ const ListFooter = styled.div`
 export function getResourceAvailabilityFilter(
   availableResourceMode: AvailableResourceMode,
   canRequestAllResources: boolean,
-  // TODO(bl-nero): This parameter should be mandatory once the enterprise code catches up.
-  scopedSession?: boolean
+  scopedSession: boolean = false
 ): ResourceAvailabilityFilter {
   if (scopedSession) {
     return { mode: 'accessible', canRequestAll: false };

--- a/web/packages/teleport/src/Login/Login.story.tsx
+++ b/web/packages/teleport/src/Login/Login.story.tsx
@@ -50,6 +50,7 @@ export const Otp = () => <Login {...sample} auth2faType="otp" />;
 export const Webauthn = () => <Login {...sample} auth2faType="webauthn" />;
 export const Optional = () => <Login {...sample} auth2faType="optional" />;
 export const On = () => <Login {...sample} auth2faType="on" />;
+export const Scoped = () => <Login {...sample} scope="/prod/west" />;
 export const CommunityAcknowledgement = () => {
   cfg.edition = 'community';
   return <Login {...sample} licenseAcknowledged={false} />;
@@ -108,4 +109,5 @@ const sample: State = {
   acknowledgeMotd: () => null,
   licenseAcknowledged: true,
   setLicenseAcknowledged: () => {},
+  scope: '',
 };

--- a/web/packages/teleport/src/Login/Login.test.tsx
+++ b/web/packages/teleport/src/Login/Login.test.tsx
@@ -17,6 +17,7 @@
  */
 
 import { userEvent, UserEvent } from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
 import selectEvent from 'react-select-event';
 
 import { fireEvent, render, screen, waitFor } from 'design/utils/testing';
@@ -39,100 +40,128 @@ beforeEach(() => {
   user = userEvent.setup();
 });
 
+function LoginTest({ initialURL }: { initialURL?: string }) {
+  const initialEntries = initialURL ? [initialURL] : undefined;
+  return (
+    <MemoryRouter initialEntries={initialEntries}>
+      <Login />
+    </MemoryRouter>
+  );
+}
+
 test('basic rendering', () => {
-  render(<Login />);
+  render(<LoginTest />);
 
   // test rendering of logo and title
   expect(screen.getByRole('img')).toBeInTheDocument();
   expect(screen.getByText(/sign in to teleport/i)).toBeInTheDocument();
 });
 
-test('login with redirect', async () => {
-  jest.spyOn(auth, 'login').mockResolvedValue({});
+describe.each([
+  {
+    name: 'unscoped',
+    url: '/web/login',
+    scope: '',
+    ssoURL:
+      'http://localhost/v1/webapi/github/login/web?connector_id=github&redirect_url=http%3A%2F%2Flocalhost%2Fweb',
+  },
+  {
+    name: 'scoped',
+    url: '/web/login?scope=%2Fdev',
+    scope: '/dev',
+    ssoURL:
+      'http://localhost/v1/webapi/github/login/web?connector_id=github&scope=%2Fdev&redirect_url=http%3A%2F%2Flocalhost%2Fweb',
+  },
+])('$name', ({ url, scope, ssoURL }) => {
+  test('login with redirect', async () => {
+    jest.spyOn(auth, 'login').mockResolvedValue({});
 
-  render(<Login />);
+    render(<LoginTest initialURL={url} />);
 
-  // fill form
-  const username = screen.getByPlaceholderText(/username/i);
-  const password = screen.getByPlaceholderText(/password/i);
-  fireEvent.change(username, { target: { value: 'username' } });
-  fireEvent.change(password, { target: { value: '123' } });
+    // fill form
+    const username = screen.getByPlaceholderText(/username/i);
+    const password = screen.getByPlaceholderText(/password/i);
+    fireEvent.change(username, { target: { value: 'username' } });
+    fireEvent.change(password, { target: { value: '123' } });
 
-  // test login and redirect
-  fireEvent.click(screen.getByText('Sign In'));
-  await waitFor(() => {
-    expect(auth.login).toHaveBeenCalledWith('username', '123', '');
+    // test login and redirect
+    fireEvent.click(screen.getByText('Sign In'));
+    await waitFor(() => {
+      expect(auth.login).toHaveBeenCalledWith('username', '123', '', scope);
+    });
+    expect(history.push).toHaveBeenCalledWith('http://localhost/web', true);
   });
-  expect(history.push).toHaveBeenCalledWith('http://localhost/web', true);
-});
 
-test('login with MFA, changing method to OTP', async () => {
-  jest.spyOn(cfg, 'getAuth2faType').mockImplementation(() => 'optional');
-  jest.spyOn(auth, 'login').mockResolvedValue({});
+  test('login with MFA, changing method to OTP', async () => {
+    jest.spyOn(cfg, 'getAuth2faType').mockImplementation(() => 'optional');
+    jest.spyOn(auth, 'login').mockResolvedValue({});
 
-  render(<Login />);
+    render(<LoginTest initialURL={url} />);
 
-  // fill form
-  const username = screen.getByLabelText(/username/i);
-  const password = screen.getByLabelText(/password/i);
-  const mfaType = screen.getByLabelText(/multi-factor type/i);
-  await user.type(username, 'username');
-  await user.type(password, '123');
+    // fill form
+    const username = screen.getByLabelText(/username/i);
+    const password = screen.getByLabelText(/password/i);
+    const mfaType = screen.getByLabelText(/multi-factor type/i);
+    await user.type(username, 'username');
+    await user.type(password, '123');
 
-  expect(
-    screen.queryByLabelText(/authenticator code/i)
-  ).not.toBeInTheDocument();
-  await selectEvent.select(mfaType, 'Authenticator App');
-  const authCode = screen.getByLabelText(/authenticator code/i);
-  await user.type(authCode, '987654');
+    expect(
+      screen.queryByLabelText(/authenticator code/i)
+    ).not.toBeInTheDocument();
+    await selectEvent.select(mfaType, 'Authenticator App');
+    const authCode = screen.getByLabelText(/authenticator code/i);
+    await user.type(authCode, '987654');
 
-  // test login and redirect
-  fireEvent.click(screen.getByText('Sign In'));
-  await waitFor(() => {
-    expect(auth.login).toHaveBeenCalledWith('username', '123', '987654');
+    // test login and redirect
+    fireEvent.click(screen.getByText('Sign In'));
+    await waitFor(() => {
+      expect(auth.login).toHaveBeenCalledWith(
+        'username',
+        '123',
+        '987654',
+        scope
+      );
+    });
+    expect(history.push).toHaveBeenCalledWith('http://localhost/web', true);
   });
-  expect(history.push).toHaveBeenCalledWith('http://localhost/web', true);
-});
 
-test('login with SSO', () => {
-  jest.spyOn(cfg, 'getAuth2faType').mockImplementation(() => 'otp');
-  jest.spyOn(cfg, 'getPrimaryAuthType').mockImplementation(() => 'sso');
-  jest.spyOn(cfg, 'getAuthProviders').mockImplementation(() => [
-    {
-      displayName: 'With GitHub',
-      type: 'github',
-      name: 'github',
-      url: '/github/login/web?connector_id=:providerName&redirect_url=:redirect?',
-    },
-  ]);
+  test('login with SSO', () => {
+    jest.spyOn(cfg, 'getAuth2faType').mockImplementation(() => 'otp');
+    jest.spyOn(cfg, 'getPrimaryAuthType').mockImplementation(() => 'sso');
+    jest.spyOn(cfg, 'getAuthProviders').mockImplementation(() => [
+      {
+        displayName: 'With GitHub',
+        type: 'github',
+        name: 'github',
+        url: '/v1/webapi/github/login/web?connector_id=:providerName&scope=:scope?&redirect_url=:redirect',
+      },
+    ]);
 
-  render(<Login />);
+    render(<LoginTest initialURL={url} />);
 
-  // test login pathways
-  fireEvent.click(screen.getByText('With GitHub'));
-  expect(history.push).toHaveBeenCalledWith(
-    'http://localhost/github/login/web?connector_id=github&redirect_url=http%3A%2F%2Flocalhost%2Fweb',
-    true
-  );
-});
+    // test login pathways
+    fireEvent.click(screen.getByText('With GitHub'));
+    expect(history.push).toHaveBeenCalledWith(ssoURL, true);
+  });
 
-test('passwordless login', async () => {
-  jest.spyOn(cfg, 'getPrimaryAuthType').mockReturnValue('passwordless');
-  jest.spyOn(auth, 'loginWithWebauthn').mockResolvedValue({});
+  test('passwordless login', async () => {
+    jest.spyOn(cfg, 'getPrimaryAuthType').mockReturnValue('passwordless');
+    jest.spyOn(auth, 'loginWithWebauthn').mockResolvedValue({});
 
-  render(<Login />);
+    render(<LoginTest initialURL={url} />);
 
-  await user.click(
-    screen.getByRole('button', { name: 'Sign in with a Passkey' })
-  );
-  expect(auth.loginWithWebauthn).toHaveBeenCalledWith(undefined); // No credentials
-  expect(history.push).toHaveBeenCalledWith('http://localhost/web', true);
+    await user.click(
+      screen.getByRole('button', { name: 'Sign in with a Passkey' })
+    );
+    expect(auth.loginWithWebauthn).toHaveBeenCalledWith(undefined, scope); // No credentials
+    expect(history.push).toHaveBeenCalledWith('http://localhost/web', true);
+  });
 });
 
 describe('test MOTD', () => {
   test('show motd only if motd is set', async () => {
     // default login form
-    const { unmount } = render(<Login />);
+    const { unmount } = render(<LoginTest />);
     expect(screen.getByPlaceholderText(/username/i)).toBeInTheDocument();
     expect(
       screen.queryByText('Welcome to cluster, your activity will be recorded.')
@@ -146,7 +175,7 @@ describe('test MOTD', () => {
         () => 'Welcome to cluster, your activity will be recorded.'
       );
 
-    render(<Login />);
+    render(<LoginTest />);
 
     expect(
       screen.getByText('Welcome to cluster, your activity will be recorded.')
@@ -160,7 +189,7 @@ describe('test MOTD', () => {
       .mockImplementation(
         () => 'Welcome to cluster, your activity will be recorded.'
       );
-    render(<Login />);
+    render(<LoginTest />);
     expect(
       screen.getByText('Welcome to cluster, your activity will be recorded.')
     ).toBeInTheDocument();
@@ -181,7 +210,7 @@ describe('test MOTD', () => {
         'https://teleport.example.com/web/headless/5c5c1f73-ac5c-52ee-bc9e-0353094dcb4a'
       );
 
-    render(<Login />);
+    render(<LoginTest />);
 
     expect(
       screen.queryByText('Welcome to cluster, your activity will be recorded.')
@@ -191,7 +220,7 @@ describe('test MOTD', () => {
   test('access changed message renders when the URL param is set', () => {
     jest.spyOn(history, 'hasAccessChangedParam').mockImplementation(() => true);
 
-    render(<Login />);
+    render(<LoginTest />);
 
     expect(screen.getByText(/sign in to teleport/i)).toBeInTheDocument();
     expect(screen.getByText(/Your access has changed/i)).toBeInTheDocument();
@@ -205,7 +234,7 @@ test('redirect to root if session is valid and path is not "/enterprise/saml-idp
     .mockReturnValue(
       'http://localhost/web/login?redirect_url=http://localhost/web/cluster/localhost/resources'
     );
-  render(<Login />);
+  render(<LoginTest />);
 
   expect(history.replace).toHaveBeenCalledWith('/web');
 });
@@ -216,6 +245,6 @@ test('redirect if session is valid and path matches "/enterprise/saml-idp/sso"',
   jest
     .spyOn(history, 'getRedirectParam')
     .mockReturnValue(samlIdPPath.toString());
-  render(<Login />);
+  render(<LoginTest />);
   expect(history.push).toHaveBeenCalledWith(samlIdPPath.toString(), true);
 });

--- a/web/packages/teleport/src/Login/Login.test.tsx
+++ b/web/packages/teleport/src/Login/Login.test.tsx
@@ -79,13 +79,12 @@ describe.each([
     render(<LoginTest initialURL={url} />);
 
     // fill form
-    const username = screen.getByPlaceholderText(/username/i);
-    const password = screen.getByPlaceholderText(/password/i);
-    fireEvent.change(username, { target: { value: 'username' } });
-    fireEvent.change(password, { target: { value: '123' } });
+    const user = userEvent.setup();
+    await user.type(screen.getByPlaceholderText(/username/i), 'username');
+    await user.type(screen.getByPlaceholderText(/password/i), '123');
 
     // test login and redirect
-    fireEvent.click(screen.getByText('Sign In'));
+    await user.click(screen.getByText('Sign In'));
     await waitFor(() => {
       expect(auth.login).toHaveBeenCalledWith('username', '123', '', scope);
     });

--- a/web/packages/teleport/src/Login/Login.tsx
+++ b/web/packages/teleport/src/Login/Login.tsx
@@ -52,6 +52,7 @@ export function LoginComponent({
   motd,
   showMotd,
   acknowledgeMotd,
+  scope,
 }: State) {
   // while we are checking if a session is valid, we don't return anything
   // to prevent flickering. The check only happens for a frame or two so
@@ -89,6 +90,7 @@ export function LoginComponent({
           clearAttempt={clearAttempt}
           isPasswordlessEnabled={isPasswordlessEnabled}
           primaryAuthType={primaryAuthType}
+          scope={scope}
         />
       )}
     </>

--- a/web/packages/teleport/src/Login/useLogin.test.tsx
+++ b/web/packages/teleport/src/Login/useLogin.test.tsx
@@ -17,6 +17,8 @@
  */
 
 import { renderHook } from '@testing-library/react';
+import { PropsWithChildren } from 'react';
+import { MemoryRouter } from 'react-router';
 
 import cfg from 'teleport/config';
 import history from 'teleport/services/history';
@@ -45,15 +47,19 @@ afterEach(() => {
   jest.resetAllMocks();
 });
 
+function Wrapper({ children }: PropsWithChildren) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
 it('redirect to root on path not matching "/enterprise/saml-idp/sso"', () => {
   jest.spyOn(history, 'getRedirectParam').mockReturnValue('http://localhost');
-  renderHook(() => useLogin());
+  renderHook(() => useLogin(), { wrapper: Wrapper });
   expect(history.replace).toHaveBeenCalledWith('/web');
 
   jest
     .spyOn(history, 'getRedirectParam')
     .mockReturnValue('http://localhost/web/cluster/name/resources');
-  renderHook(() => useLogin());
+  renderHook(() => useLogin(), { wrapper: Wrapper });
   expect(history.replace).toHaveBeenCalledWith('/web');
 });
 
@@ -63,7 +69,7 @@ it('redirect to SAML SSO path on matching "/enterprise/saml-idp/sso"', () => {
   jest
     .spyOn(history, 'getRedirectParam')
     .mockReturnValue(samlIdpPath.toString());
-  renderHook(() => useLogin());
+  renderHook(() => useLogin(), { wrapper: Wrapper });
   expect(history.push).toHaveBeenCalledWith(samlIdpPath.toString(), true);
 });
 
@@ -72,7 +78,7 @@ it('non-base domain redirects with base domain for a matching "/enterprise/saml-
   jest
     .spyOn(history, 'getRedirectParam')
     .mockReturnValue(samlIdpPath.toString());
-  renderHook(() => useLogin());
+  renderHook(() => useLogin(), { wrapper: Wrapper });
   const expectedPath = new URL('http://localhost' + cfg.routes.samlIdpSso);
   expect(history.push).toHaveBeenCalledWith(expectedPath.toString(), true);
 });
@@ -82,7 +88,7 @@ it('base domain with different path is redirected to root', async () => {
   jest
     .spyOn(history, 'getRedirectParam')
     .mockReturnValue(nonSamlIdpPath.toString());
-  renderHook(() => useLogin());
+  renderHook(() => useLogin(), { wrapper: Wrapper });
   expect(history.replace).toHaveBeenCalledWith('/web');
 });
 
@@ -94,7 +100,7 @@ it('invalid session does nothing', async () => {
     .spyOn(history, 'getRedirectParam')
     .mockReturnValue(samlIdpPathWithDifferentBase.toString());
   jest.spyOn(session, 'isValid').mockImplementation(() => false);
-  renderHook(() => useLogin());
+  renderHook(() => useLogin(), { wrapper: Wrapper });
   expect(history.replace).not.toHaveBeenCalled();
   expect(history.push).not.toHaveBeenCalled();
 });

--- a/web/packages/teleport/src/Login/useLogin.ts
+++ b/web/packages/teleport/src/Login/useLogin.ts
@@ -17,7 +17,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import { matchPath } from 'react-router';
+import { matchPath, useLocation } from 'react-router';
 
 import { TrustedDeviceRequirement } from 'gen-proto-ts/teleport/legacy/types/trusted_device_requirement_pb';
 import { useAttempt } from 'shared/hooks';
@@ -55,6 +55,11 @@ export default function useLogin() {
     setShowMotd(false);
   }
 
+  const location = useLocation();
+  const scope: string | null = new URLSearchParams(location.search).get(
+    'scope'
+  );
+
   // onSuccess can receive a device webtoken. If so, it will
   // enable a prompt to allow users to authorize the current
   function onSuccess({
@@ -64,6 +69,7 @@ export default function useLogin() {
     // deviceWebToken will only exist on a login response
     // from enterprise but just in case there is a version mismatch
     // between the webclient and proxy
+    storageService.setScopeSelected(scope != null);
     if (trustedDeviceRequirement === TrustedDeviceRequirement.REQUIRED) {
       session.setDeviceTrustRequired();
     }
@@ -76,7 +82,7 @@ export default function useLogin() {
   useEffect(() => {
     if (session.isValid()) {
       try {
-        const redirectUrlWithBase = new URL(getEntryRoute());
+        const redirectUrlWithBase = new URL(history.getEntryRoute());
         const matched = matchPath(
           cfg.routes.samlIdpSso,
           redirectUrlWithBase.pathname
@@ -101,7 +107,7 @@ export default function useLogin() {
     attemptActions.start();
     storageService.clearLoginTime();
     auth
-      .login(email, password, token)
+      .login(email, password, token, scope || '')
       .then(onSuccess)
       .catch(err => {
         attemptActions.error(err);
@@ -112,7 +118,7 @@ export default function useLogin() {
     attemptActions.start();
     storageService.clearLoginTime();
     auth
-      .loginWithWebauthn(creds)
+      .loginWithWebauthn(creds, scope || '')
       .then(onSuccess)
       .catch(err => {
         attemptActions.error(err);
@@ -122,13 +128,15 @@ export default function useLogin() {
   function onLoginWithSso(provider: AuthProvider, loginHint?: string) {
     attemptActions.start();
     storageService.clearLoginTime();
-    const appStartRoute = getEntryRoute();
-    const ssoUri = cfg.getSsoUrl(
-      provider.url,
-      provider.name,
-      appStartRoute,
-      loginHint
-    );
+    const appStartRoute = history.getEntryRoute();
+    const ssoUri = cfg.getSsoUrl({
+      providerUrl: provider.url,
+      providerName: provider.name,
+      redirect: appStartRoute,
+      loginHint,
+      scope: scope || '',
+    });
+    storageService.setScopeSelected(scope !== null);
     history.push(ssoUri, true);
   }
 
@@ -156,6 +164,7 @@ export default function useLogin() {
     motd,
     showMotd,
     acknowledgeMotd,
+    scope,
   };
 }
 
@@ -180,25 +189,9 @@ function authorizeWithDeviceTrust(token: DeviceWebToken) {
 }
 
 function loginSuccess() {
-  const redirect = getEntryRoute();
+  const redirect = history.getEntryRoute();
   const withPageRefresh = true;
   history.push(redirect, withPageRefresh);
-}
-
-/**
- * getEntryRoute returns a base ensured redirect URL value that is safe
- * for redirect.
- * @returns base ensured URL string.
- */
-function getEntryRoute() {
-  let entryUrl = history.getRedirectParam();
-  if (entryUrl) {
-    entryUrl = history.ensureKnownRoute(entryUrl);
-  } else {
-    entryUrl = cfg.routes.root;
-  }
-
-  return history.ensureBaseUrl(entryUrl);
 }
 
 export type State = ReturnType<typeof useLogin> & {

--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -38,6 +38,7 @@ import {
 import { marginTransitionCss } from 'shared/components/SlidingSidePanel/InfoGuide/const';
 import { ToastNotifications } from 'shared/components/ToastNotification';
 import useAttempt from 'shared/hooks/useAttemptNext';
+import { useStore } from 'shared/libs/stores';
 
 import { BannerList } from 'teleport/components/BannerList';
 import type { BannerType } from 'teleport/components/BannerList/BannerList';
@@ -72,6 +73,7 @@ export interface MainProps {
 
 export function Main(props: MainProps) {
   const ctx = useTeleport();
+  const storeUser = useStore(ctx.storeUser);
   const location = useLocation();
 
   const { attempt, setAttempt, run } = useAttempt('processing');
@@ -89,15 +91,14 @@ export function Main(props: MainProps) {
 
   const featureFlags = ctx.getFeatureFlags();
 
-  const scopeSelected = storageService.getScopeSelected();
+  const scope = storeUser?.getScope();
   const features = useMemo(
     () =>
       props.features.filter(
         feature =>
-          feature.hasAccess(featureFlags) &&
-          (!scopeSelected || feature.supportsScopes)
+          feature.hasAccess(featureFlags) && (!scope || feature.supportsScopes)
       ),
-    [featureFlags, props.features, scopeSelected]
+    [featureFlags, props.features, scope]
   );
 
   const { alerts, dismissAlert } = useAlerts(props.initialAlerts);
@@ -137,7 +138,7 @@ export function Main(props: MainProps) {
       cfg.scopesEnabled &&
       availableScopes.length > 0 &&
       !isScopePickerRoute &&
-      !scopeSelected
+      !storageService.getScopeSelected()
     ) {
       return <Redirect to={history.getScopePickerUrl()} />;
     }

--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -89,9 +89,15 @@ export function Main(props: MainProps) {
 
   const featureFlags = ctx.getFeatureFlags();
 
+  const scopeSelected = storageService.getScopeSelected();
   const features = useMemo(
-    () => props.features.filter(feature => feature.hasAccess(featureFlags)),
-    [featureFlags, props.features]
+    () =>
+      props.features.filter(
+        feature =>
+          feature.hasAccess(featureFlags) &&
+          (!scopeSelected || feature.supportsScopes)
+      ),
+    [featureFlags, props.features, scopeSelected]
   );
 
   const { alerts, dismissAlert } = useAlerts(props.initialAlerts);
@@ -130,7 +136,8 @@ export function Main(props: MainProps) {
     if (
       cfg.scopesEnabled &&
       availableScopes.length > 0 &&
-      !isScopePickerRoute
+      !isScopePickerRoute &&
+      !scopeSelected
     ) {
       return <Redirect to={history.getScopePickerUrl()} />;
     }

--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -96,7 +96,8 @@ export function Main(props: MainProps) {
     () =>
       props.features.filter(
         feature =>
-          feature.hasAccess(featureFlags) && (!scope || feature.supportsScopes)
+          feature.hasAccess(featureFlags) &&
+          supportsCurrentScope(feature, scope)
       ),
     [featureFlags, props.features, scope]
   );
@@ -264,6 +265,13 @@ function renderRoutes(
   }
 
   return routes;
+}
+
+function supportsCurrentScope(
+  feature: TeleportFeature,
+  scope: string
+): boolean {
+  return !scope || feature.supportsScopes;
 }
 
 function FeatureRoutes({ lockedFeatures }: { lockedFeatures: LockedFeatures }) {

--- a/web/packages/teleport/src/Scopes/LoginScopePicker.tsx
+++ b/web/packages/teleport/src/Scopes/LoginScopePicker.tsx
@@ -26,6 +26,9 @@ import * as Icon from 'design/Icon';
 import { H1, H2 } from 'design/Text';
 import { useStore } from 'shared/libs/stores';
 
+import history from 'teleport/services/history/history';
+import { storageService } from 'teleport/services/storageService';
+import session from 'teleport/services/websession/websession';
 import useTeleport from 'teleport/useTeleport';
 
 /**
@@ -39,6 +42,17 @@ export function LoginScopePicker() {
   const ctx = useTeleport();
   const storeUser = useStore(ctx.storeUser);
 
+  function signInWithScope(scope: string) {
+    session.switchScope(scope);
+  }
+
+  function signInWithoutScope() {
+    storageService.setScopeSelected(true);
+    const redirect = history.getEntryRoute();
+    const withPageRefresh = true;
+    history.push(redirect, withPageRefresh);
+  }
+
   return (
     <Box px="5" width="100%" overflow="scroll">
       <Card my="5" mx="auto" width="100%" maxWidth={600} p={4}>
@@ -47,9 +61,28 @@ export function LoginScopePicker() {
           Choose a scope for your session:
         </H2>
         <Stack gap={2} as={Ul}>
+          <Li>
+            <ScopeButton
+              block
+              size="extra-large"
+              onClick={() => signInWithoutScope()}
+            >
+              <Icon.Home />
+              <Flex justifyContent="start" flex={1}>
+                Teleport Home
+              </Flex>
+              <SignInAffordance gap={2}>
+                Sign in <Icon.ArrowForward />
+              </SignInAffordance>
+            </ScopeButton>
+          </Li>
           {storeUser.getAvailableScopes().map(scope => (
             <Li key={scope}>
-              <ScopeButton key={scope} block size="extra-large">
+              <ScopeButton
+                block
+                size="extra-large"
+                onClick={() => signInWithScope(scope)}
+              >
                 <Icon.Contract />
                 <Flex justifyContent="start" flex={1}>
                   {scope}

--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -20,8 +20,10 @@ import React, { type JSX } from 'react';
 import { Link, matchPath, useLocation } from 'react-router';
 import styled, { css, useTheme } from 'styled-components';
 
-import { Box, breakpointsPx, Flex, Image, TopNav } from 'design';
+import { Box, breakpointsPx, Flex, Image, Text, TopNav } from 'design';
+import * as Icon from 'design/Icon';
 import { HoverTooltip } from 'design/Tooltip';
+import { useStore } from 'shared/libs/stores';
 
 import { logoSrc } from 'teleport/components/LogoHero/LogoHero';
 import { UserMenuNav } from 'teleport/components/UserMenuNav';
@@ -31,6 +33,7 @@ import { useFeatures } from 'teleport/FeaturesContext';
 import { useLayout } from 'teleport/Main/LayoutContext';
 import { zIndexMap } from 'teleport/Navigation/zIndexMap';
 import { Notifications } from 'teleport/Notifications';
+import useTeleport from 'teleport/useTeleport';
 
 export function TopBar({
   CustomLogo,
@@ -42,6 +45,9 @@ export function TopBar({
   const location = useLocation();
   const features = useFeatures();
   const { currentWidth } = useLayout();
+  const ctx = useTeleport();
+  const storeUser = useStore(ctx.storeUser);
+  const scope = storeUser.getScope();
 
   // find active feature
   const feature = features.find(
@@ -60,7 +66,17 @@ export function TopBar({
 
   return (
     <TopBarContainer>
-      <TeleportLogo CustomLogo={CustomLogo} withLink={!scopePickerMode} />
+      <Flex alignItems="center">
+        <TeleportLogo CustomLogo={CustomLogo} withLink={!scopePickerMode} />
+        {scope && !feature?.logoOnlyTopbar && (
+          <HoverTooltip tipContent="Current scope">
+            <Flex alignItems="center">
+              <Icon.Contract mr={1} aria-label="scope" />
+              <Text typography="body1">{scope}</Text>
+            </Flex>
+          </HoverTooltip>
+        )}
+      </Flex>
       {!feature?.logoOnlyTopbar && (
         <Flex height="100%" alignItems="center">
           <Notifications iconSize={iconSize} />
@@ -135,12 +151,6 @@ const commonLogoWrapperStyles = css`
   align-items: center;
   height: 100%;
   margin-right: 0px;
-  @media screen and (min-width: ${p => p.theme.breakpoints.medium}) {
-    margin-right: 76px;
-  }
-  @media screen and (min-width: ${p => p.theme.breakpoints.large}) {
-    margin-right: 67px;
-  }
 `;
 
 const BoxLogoWrapper = styled(Box)`

--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -70,8 +70,8 @@ export function TopBar({
         <TeleportLogo CustomLogo={CustomLogo} withLink={!scopePickerMode} />
         {scope && !feature?.logoOnlyTopbar && (
           <HoverTooltip tipContent="Current scope">
-            <Flex alignItems="center">
-              <Icon.Contract mr={1} aria-label="scope" />
+            <Flex alignItems="center" gap={1}>
+              <Icon.Contract aria-label="scope" />
               <Text typography="body1">{scope}</Text>
             </Flex>
           </HoverTooltip>
@@ -79,7 +79,7 @@ export function TopBar({
       </Flex>
       {!feature?.logoOnlyTopbar && (
         <Flex height="100%" alignItems="center">
-          <Notifications iconSize={iconSize} />
+          {!scope && <Notifications iconSize={iconSize} />}
           <UserMenuNav hideFeatures={feature instanceof FeatureScopes} />
         </Flex>
       )}

--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -79,7 +79,11 @@ export function TopBar({
       </Flex>
       {!feature?.logoOnlyTopbar && (
         <Flex height="100%" alignItems="center">
-          {!scope && <Notifications iconSize={iconSize} />}
+          {
+            // TODO(bl-nero): enable notifications once they're supported by
+            // scopes.
+            !scope && <Notifications iconSize={iconSize} />
+          }
           <UserMenuNav hideFeatures={feature instanceof FeatureScopes} />
         </Flex>
       )}

--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -45,6 +45,7 @@ import {
   getResourceId,
   openStatusInfoPanel,
 } from 'shared/components/UnifiedResources/shared/StatusInfo';
+import { useStore } from 'shared/libs/stores';
 
 import { useTeleport } from 'teleport';
 import AgentButtonAdd from 'teleport/components/AgentButtonAdd';
@@ -175,6 +176,7 @@ export function ClusterResources({
   }) => ReactNode;
 }) {
   const teleCtx = useTeleport();
+  const storeUser = useStore(teleCtx.storeUser);
   const flags = teleCtx.getFeatureFlags();
 
   useNoMinWidth();
@@ -334,11 +336,15 @@ export function ClusterResources({
         availableKinds={getAvailableKindsWithAccess(flags)}
         pinning={pinning}
         ClusterDropdown={
-          <ClusterDropdown
-            clusterLoader={teleCtx.clusterService}
-            clusterId={clusterId}
-            onError={setLoadClusterError}
-          />
+          // TODO(bl-nero): Enable cluster dropdown for scoped sessions once
+          // it's supported on the backend.
+          storeUser.getScope() ? undefined : (
+            <ClusterDropdown
+              clusterLoader={teleCtx.clusterService}
+              clusterId={clusterId}
+              onError={setLoadClusterError}
+            />
+          )
         }
         NoResources={
           <Empty

--- a/web/packages/teleport/src/components/FormLogin/FormLogin.story.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormLogin.story.tsx
@@ -39,6 +39,7 @@ const props: Props = {
   auth2faType: 'off',
   primaryAuthType: 'local',
   isPasswordlessEnabled: false,
+  scope: '',
 };
 
 export default {
@@ -82,6 +83,8 @@ export const Cloud = () => (
     onRecover={() => null}
   />
 );
+
+export const Scoped = () => <FormLogin {...props} scope="/dev/east" />;
 
 export const ServerError = () => {
   const attempt = {

--- a/web/packages/teleport/src/components/FormLogin/FormLogin.test.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormLogin.test.tsx
@@ -249,4 +249,5 @@ const props: Props = {
   onLoginWithWebauthn: null,
   isPasswordlessEnabled: false,
   primaryAuthType: 'local',
+  scope: '',
 };

--- a/web/packages/teleport/src/components/FormLogin/FormLogin.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormLogin.tsx
@@ -31,6 +31,7 @@ import {
   Text,
 } from 'design';
 import * as Alerts from 'design/Alert';
+import * as Icon from 'design/Icon';
 import { StepComponentProps, StepSlider } from 'design/StepSlider';
 import { P } from 'design/Text/Text';
 import FieldInput from 'shared/components/FieldInput';
@@ -68,6 +69,7 @@ export default function LoginForm(props: Props) {
     primaryAuthType,
     title = 'Sign in to Teleport',
     ssoTitle = 'Sign in to Teleport with SSO',
+    scope,
   } = props;
 
   const [showIdentifierFirstLogin, setShowIdentifierFirstLogin] = useState(
@@ -115,6 +117,12 @@ export default function LoginForm(props: Props) {
       <Text typography="h1" mb={4} textAlign="center">
         {title}
       </Text>
+      {scope && (
+        <Flex gap={2} alignItems="center" justifyContent="center">
+          <Icon.Contract aria-label="scope" />
+          <Text typography="body1">{scope}</Text>
+        </Flex>
+      )}
       {errorMessage && <Alerts.Danger m={4}>{errorMessage}</Alerts.Danger>}
       {showAccessChangedMessage && (
         <Alerts.Warning m={4}>
@@ -511,6 +519,7 @@ export type Props = {
   onLogin(username: string, password: string, token: string): void;
   autoFocus?: boolean;
   setShowIdentifierFirstLogin?: (value: boolean) => void;
+  scope: string;
 };
 
 type AttemptState = ReturnType<typeof useAttempt>[0];

--- a/web/packages/teleport/src/config.test.ts
+++ b/web/packages/teleport/src/config.test.ts
@@ -82,24 +82,34 @@ test('getIntegrationsEnroll without extra params', () => {
 
 test('getSsoUrl', () => {
   const providerUrl =
-    '/v1/webapi/oidc/login/web?connector_id=:providerName&login_hint=:loginHint?&redirect_url=:redirect';
+    '/v1/webapi/oidc/login/web?connector_id=:providerName&login_hint=:loginHint?&redirect_url=:redirect&scope=:scope?';
   expect(
-    cfg.getSsoUrl(providerUrl, 'keycloak', 'example.com', undefined)
+    cfg.getSsoUrl({
+      providerUrl,
+      providerName: 'keycloak',
+      redirect: 'example.com',
+    })
   ).toEqual(
     'http://localhost/v1/webapi/oidc/login/web?connector_id=keycloak&redirect_url=example.com'
   );
   expect(
-    cfg.getSsoUrl(providerUrl, 'keycloak', 'example.com', 'user@example.com')
+    cfg.getSsoUrl({
+      providerUrl,
+      providerName: 'keycloak',
+      redirect: 'example.com',
+      loginHint: 'user@example.com',
+      scope: '/foo/bar',
+    })
   ).toEqual(
-    'http://localhost/v1/webapi/oidc/login/web?connector_id=keycloak&login_hint=user%40example.com&redirect_url=example.com'
+    'http://localhost/v1/webapi/oidc/login/web?connector_id=keycloak&login_hint=user%40example.com&redirect_url=example.com&scope=%2Ffoo%2Fbar'
   );
   expect(
-    cfg.getSsoUrl(
+    cfg.getSsoUrl({
       providerUrl,
-      'keycloak',
-      'example.com?a=b&c=d',
-      'user@example.com'
-    )
+      providerName: 'keycloak',
+      redirect: 'example.com?a=b&c=d',
+      loginHint: 'user@example.com',
+    })
   ).toEqual(
     'http://localhost/v1/webapi/oidc/login/web?connector_id=keycloak&login_hint=user%40example.com&redirect_url=example.com%3Fa%3Db%26c%3Dd'
   );

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -830,18 +830,38 @@ const cfg = {
     return searchString ? `${path}?${searchString}` : path;
   },
 
-  getSsoUrl(providerUrl, providerName, redirect, loginHint) {
+  getSsoUrl({
+    providerUrl,
+    providerName,
+    redirect,
+    loginHint,
+    scope,
+  }: {
+    providerUrl: string;
+    providerName: string;
+    redirect: string;
+    loginHint?: string;
+    scope?: string;
+  }) {
     loginHint = loginHint === '' ? undefined : loginHint;
+    scope = scope === '' ? undefined : scope;
     let basePath =
       cfg.baseUrl +
-      generateFullPath(providerUrl, { redirect, providerName, loginHint });
+      generateFullPath(providerUrl, {
+        redirect,
+        providerName,
+        loginHint,
+        scope,
+      });
 
+    const url = new URL(basePath);
     if (!loginHint) {
-      const url = new URL(basePath);
       url.searchParams.delete('login_hint', '');
-      basePath = url.toString();
     }
-    return basePath;
+    if (!scope) {
+      url.searchParams.delete('scope', '');
+    }
+    return url.toString();
   },
 
   getAuditRoute(clusterId: string) {

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -141,6 +141,7 @@ export class FeatureUnifiedResources implements TeleportFeature {
   sideNavCategory = SideNavigationCategory.Resources;
   // TODO(rudream): Remove this once shortcuts to pinned/nodes/apps/dbs/desktops/kubes are implemented.
   standalone = true;
+  supportsScopes = true;
 
   route = {
     title: 'Resources',
@@ -918,6 +919,8 @@ export class FeatureAccount implements TeleportFeature {
       'change password',
     ],
   };
+
+  supportsScopes = true;
 }
 
 export class FeatureHelpAndSupport implements TeleportFeature {
@@ -948,6 +951,8 @@ export class FeatureHelpAndSupport implements TeleportFeature {
       'version',
     ],
   };
+
+  supportsScopes = true;
 }
 
 export class FeatureScopes implements TeleportFeature {
@@ -959,6 +964,7 @@ export class FeatureScopes implements TeleportFeature {
   };
 
   hideNavigation = true;
+  supportsScopes = true;
 
   hasAccess(): boolean {
     return cfg.scopesEnabled;

--- a/web/packages/teleport/src/services/auth/auth.test.ts
+++ b/web/packages/teleport/src/services/auth/auth.test.ts
@@ -32,7 +32,7 @@ describe('services/auth', () => {
   test('login()', async () => {
     jest.spyOn(api, 'postWithOptions').mockResolvedValue({});
 
-    await auth.login(email, password, '');
+    await auth.login(email, password, '' /*otp*/, '' /*scope*/);
     expect(api.postWithOptions).toHaveBeenCalledWith(
       cfg.api.webSessionPath,
       expect.objectContaining({
@@ -40,20 +40,22 @@ describe('services/auth', () => {
           user: email,
           pass: password,
           second_factor_token: '',
+          scope: '',
         },
       })
     );
   });
 
-  test('login() OTP', async () => {
+  test('login() OTP and scope', async () => {
     jest.spyOn(api, 'postWithOptions').mockResolvedValue({});
     const data = {
       user: email,
       pass: password,
       second_factor_token: 'xxx',
+      scope: '/prod/europe',
     };
 
-    await auth.login(email, password, 'xxx');
+    await auth.login(email, password, 'xxx', '/prod/europe');
     expect(api.postWithOptions).toHaveBeenCalledWith(
       cfg.api.webSessionPath,
       expect.objectContaining({ data })

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -116,11 +116,12 @@ const auth = {
       .then(parseMfaChallengeJson);
   },
 
-  login(userId: string, password: string, otpCode: string) {
+  login(userId: string, password: string, otpCode: string, scope: string) {
     const data = {
       user: userId,
       pass: password,
       second_factor_token: otpCode,
+      scope,
     };
 
     return api.postWithOptions(cfg.api.webSessionPath, {
@@ -132,7 +133,7 @@ const auth = {
     });
   },
 
-  loginWithWebauthn(creds?: UserCredentials) {
+  loginWithWebauthn(creds?: UserCredentials, scope: string = '') {
     return auth
       .checkWebauthnSupport()
       .then(() => auth.mfaLoginBegin(creds))
@@ -145,6 +146,7 @@ const auth = {
         const request = {
           user: creds?.username,
           webauthnAssertionResponse: makeWebauthnAssertionResponse(res),
+          scope,
         };
 
         return api.postWithOptions(cfg.api.mfaLoginFinish, {

--- a/web/packages/teleport/src/services/history/history.test.ts
+++ b/web/packages/teleport/src/services/history/history.test.ts
@@ -133,7 +133,7 @@ describe('services/history', () => {
       history.goToLogin({ rememberLocation: true });
 
       const expected =
-        '/web/login?redirect_uri=http://localhost/current-location';
+        '/web/login?redirect_uri=http%3A%2F%2Flocalhost%2Fcurrent-location';
       expect(history._pageRefresh).toHaveBeenCalledWith(expected);
     });
 
@@ -144,7 +144,7 @@ describe('services/history', () => {
       location.pathname = '/bogus-location';
       history.goToLogin({ rememberLocation: true });
 
-      const expected = '/web/login?redirect_uri=http://localhost/web';
+      const expected = '/web/login?redirect_uri=http%3A%2F%2Flocalhost%2Fweb';
       expect(history._pageRefresh).toHaveBeenCalledWith(expected);
     });
 
@@ -155,7 +155,7 @@ describe('services/history', () => {
       location.pathname = '/current-location';
       history.goToLogin({ withAccessChangedMessage: true });
 
-      const expected = '/web/login?access_changed';
+      const expected = '/web/login?access_changed=';
       expect(history._pageRefresh).toHaveBeenCalledWith(expected);
     });
 
@@ -170,7 +170,7 @@ describe('services/history', () => {
       });
 
       const expected =
-        '/web/login?access_changed&redirect_uri=http://localhost/current-location';
+        '/web/login?access_changed=&redirect_uri=http%3A%2F%2Flocalhost%2Fcurrent-location';
       expect(history._pageRefresh).toHaveBeenCalledWith(expected);
     });
 
@@ -197,7 +197,7 @@ describe('services/history', () => {
       });
 
       const expected =
-        '/web/login?access_changed&redirect_uri=http://localhost/current-location%3Ftest%3Dvalue';
+        '/web/login?access_changed=&redirect_uri=http%3A%2F%2Flocalhost%2Fcurrent-location%3Ftest%3Dvalue';
       expect(history._pageRefresh).toHaveBeenCalledWith(expected);
     });
 
@@ -215,7 +215,7 @@ describe('services/history', () => {
       });
 
       const expected =
-        '/web/login?access_changed&redirect_uri=http://localhost/current-location%3Ftest%3Dvalue';
+        '/web/login?access_changed=&redirect_uri=http%3A%2F%2Flocalhost%2Fcurrent-location%3Ftest%3Dvalue';
       expect(history._pageRefresh).toHaveBeenCalledWith(expected);
 
       window.history.replaceState({}, '', '/');
@@ -229,7 +229,7 @@ describe('services/history', () => {
         .mockReturnValue(['/web/login', '/current-location']);
       location.pathname = '/current-location';
       expect(history.getScopePickerUrl()).toBe(
-        '/web/scope_picker?redirect_uri=http://localhost/current-location'
+        '/web/scope_picker?redirect_uri=http%3A%2F%2Flocalhost%2Fcurrent-location'
       );
     });
   });
@@ -240,7 +240,7 @@ describe('services/history', () => {
       .mockReturnValue(['/web/login', '/another-location']);
     location.pathname = '/bogus-location';
     expect(history.getScopePickerUrl()).toBe(
-      '/web/scope_picker?redirect_uri=http://localhost/web'
+      '/web/scope_picker?redirect_uri=http%3A%2F%2Flocalhost%2Fweb'
     );
   });
 });

--- a/web/packages/teleport/src/services/history/history.ts
+++ b/web/packages/teleport/src/services/history/history.ts
@@ -27,6 +27,12 @@ interface NavigationFunctions {
 
 let _nav: NavigationFunctions | null = null;
 
+export type LoginOptions = {
+  rememberLocation?: boolean;
+  withAccessChangedMessage?: boolean;
+  scope?: string;
+};
+
 const history = {
   /**
    * Initialize with navigation functions from React Router.
@@ -62,7 +68,7 @@ const history = {
     rememberLocation = false,
     withAccessChangedMessage = false,
     scope = '',
-  } = {}) {
+  }: LoginOptions = {}) {
     const params: string[] = [];
 
     // withAccessChangedMessage determines whether the login page the user is redirected to should include a notice that

--- a/web/packages/teleport/src/services/history/history.ts
+++ b/web/packages/teleport/src/services/history/history.ts
@@ -61,6 +61,7 @@ const history = {
   goToLogin({
     rememberLocation = false,
     withAccessChangedMessage = false,
+    scope = '',
   } = {}) {
     const params: string[] = [];
 
@@ -76,6 +77,10 @@ const history = {
       const knownRedirect = this.ensureBaseUrl(knownRoute);
       const query = search ? encodeURIComponent(search) : '';
       params.push(`redirect_uri=${knownRedirect}${query}`);
+    }
+
+    if (scope) {
+      params.push(`scope=${encodeURIComponent(scope)}`);
     }
 
     const queryString = params.join('&');
@@ -173,6 +178,22 @@ const history = {
 
   _pageRefresh(route: string) {
     window.location.href = this.ensureBaseUrl(route);
+  },
+
+  /**
+   * getEntryRoute returns a base ensured redirect URL value that is safe
+   * for redirect.
+   * @returns base ensured URL string.
+   */
+  getEntryRoute() {
+    let entryUrl = this.getRedirectParam();
+    if (entryUrl) {
+      entryUrl = this.ensureKnownRoute(entryUrl);
+    } else {
+      entryUrl = cfg.routes.root;
+    }
+
+    return this.ensureBaseUrl(entryUrl);
   },
 };
 

--- a/web/packages/teleport/src/services/history/history.ts
+++ b/web/packages/teleport/src/services/history/history.ts
@@ -69,32 +69,31 @@ const history = {
     withAccessChangedMessage = false,
     scope = '',
   }: LoginOptions = {}) {
-    const params: string[] = [];
+    const params = new URLSearchParams();
 
     // withAccessChangedMessage determines whether the login page the user is redirected to should include a notice that
     // they were logged out due to their roles having changed.
     if (withAccessChangedMessage) {
-      params.push('access_changed');
+      params.set('access_changed', '');
     }
 
     if (rememberLocation) {
       const { search, pathname } = this.getLocation();
       const knownRoute = this.ensureKnownRoute(pathname);
       const knownRedirect = this.ensureBaseUrl(knownRoute);
-      const query = search ? encodeURIComponent(search) : '';
-      params.push(`redirect_uri=${knownRedirect}${query}`);
+      params.set('redirect_uri', knownRedirect + search);
     }
 
     if (scope) {
-      params.push(`scope=${encodeURIComponent(scope)}`);
+      params.set('scope', scope);
     }
 
-    const queryString = params.join('&');
+    const queryString = params.toString();
     const url = queryString
       ? `${cfg.routes.login}?${queryString}`
       : cfg.routes.login;
 
-    this._pageRefresh(url);
+    this._pageRefresh(url.toString());
   },
 
   /**
@@ -102,15 +101,14 @@ const history = {
    * the scope has been picked.
    */
   getScopePickerUrl() {
-    const params: string[] = [];
+    const params = new URLSearchParams();
 
     const { search, pathname } = this.getLocation();
     const knownRoute = this.ensureKnownRoute(pathname);
     const knownRedirect = this.ensureBaseUrl(knownRoute);
-    const query = search ? encodeURIComponent(search) : '';
-    params.push(`redirect_uri=${knownRedirect}${query}`);
+    params.set(`redirect_uri`, knownRedirect + search);
 
-    const queryString = params.join('&');
+    const queryString = params.toString();
     const url = queryString
       ? `${cfg.routes.scopePicker}?${queryString}`
       : cfg.routes.scopePicker;

--- a/web/packages/teleport/src/services/history/index.ts
+++ b/web/packages/teleport/src/services/history/index.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import service, { getUrlParameter } from './history';
+import service, { getUrlParameter, LoginOptions } from './history';
 
 export default service;
-export { getUrlParameter };
+export { getUrlParameter, type LoginOptions };

--- a/web/packages/teleport/src/services/storageService/storageService.ts
+++ b/web/packages/teleport/src/services/storageService/storageService.ts
@@ -383,4 +383,18 @@ export const storageService = {
   getUseLoginScopePicker(): boolean {
     return this.getParsedJSONValue(KeysEnum.USE_LOGIN_SCOPE_PICKER, false);
   },
+
+  // Returns true if the user has already picked a scope for this session or
+  // explicitly made the session unscoped. This allows us to tell the
+  // difference between a session that is "implicitly unscoped" (where the user
+  // has not yet interacted with the scope picker) and an "explicitly unscoped"
+  // one (where the user already made their choice). In both cases, the scope
+  // is an empty string, hence this additional flag.
+  getScopeSelected(): boolean {
+    return this.getParsedJSONValue(KeysEnum.SCOPE_SELECTED, false);
+  },
+
+  setScopeSelected(s: boolean) {
+    window.localStorage.setItem(KeysEnum.SCOPE_SELECTED, JSON.stringify(s));
+  },
 };

--- a/web/packages/teleport/src/services/storageService/types.ts
+++ b/web/packages/teleport/src/services/storageService/types.ts
@@ -71,6 +71,7 @@ export const KeysEnum = {
   DESKTOP_HIDPI: 'grv_teleport_desktop_hidpi',
   // TODO(bl-nero): Remove this once the login scope picker is operational.
   USE_LOGIN_SCOPE_PICKER: 'grv_teleport_use_login_scope_picker',
+  SCOPE_SELECTED: 'grv_teleport_scope_selected',
 };
 
 // SurveyRequest is the request for sending data to the back end

--- a/web/packages/teleport/src/services/user/makeUserContext.ts
+++ b/web/packages/teleport/src/services/user/makeUserContext.ts
@@ -34,6 +34,7 @@ export default function makeUserContext(json: any): UserContext {
   const passwordState =
     json.passwordState || PasswordState.PASSWORD_STATE_UNSPECIFIED;
   const availableScopes = json.availableScopes || [];
+  const scope = json.scope || '';
 
   return {
     username,
@@ -48,6 +49,7 @@ export default function makeUserContext(json: any): UserContext {
     allowedSearchAsRoles,
     passwordState,
     availableScopes,
+    scope,
   };
 }
 

--- a/web/packages/teleport/src/services/user/types.ts
+++ b/web/packages/teleport/src/services/user/types.ts
@@ -58,6 +58,8 @@ export interface UserContext {
    * scoped role assignments.
    */
   availableScopes: string[];
+  /** Scope is the scope of current session. Empty if unscoped. */
+  scope: string;
 }
 
 /**

--- a/web/packages/teleport/src/services/user/user.test.ts
+++ b/web/packages/teleport/src/services/user/user.test.ts
@@ -435,6 +435,7 @@ test('undefined values in context response gives proper default values', async (
     allowedSearchAsRoles: [],
     passwordState: PasswordState.PASSWORD_STATE_UNSPECIFIED,
     availableScopes: [],
+    scope: '',
   } as UserContext);
 });
 

--- a/web/packages/teleport/src/services/websession/websession.ts
+++ b/web/packages/teleport/src/services/websession/websession.ts
@@ -39,29 +39,37 @@ const session = {
   _isDeviceTrustRequired: false,
   _isDeviceTrusted: false,
 
-  logout(rememberLocation = false) {
+  async logout(rememberLocation = false) {
     let samlSloUrl = '';
+    try {
+      const response = await this._plainLogout();
+      samlSloUrl = response?.samlSloUrl;
+    } finally {
+      if (samlSloUrl) {
+        window.open(samlSloUrl, '_self');
+      } else {
+        history.goToLogin({ rememberLocation });
+      }
+    }
+  },
 
-    api
-      .delete(cfg.api.webSessionPath)
-      .then(response => {
-        samlSloUrl = response?.samlSloUrl;
-      })
-      .catch(err => {
-        // This request can fail if the session is already expired, which isn't an issue, but we should still catch the error.
-        logger.error(
-          'Failed to delete session. This can happen if the session has already expired.',
-          err
-        );
-      })
-      .finally(() => {
-        this.clear();
-        if (samlSloUrl) {
-          window.open(samlSloUrl, '_self');
-        } else {
-          history.goToLogin({ rememberLocation });
-        }
-      });
+  async _plainLogout(): Promise<{ samlSloUrl: string } | undefined> {
+    try {
+      return await api.deleteWithOptions(cfg.api.webSessionPath, {});
+    } catch (err) {
+      // This request can fail if the session is already expired, which isn't an issue, but we should still catch the error.
+      logger.error(
+        'Failed to delete session. This can happen if the session has already expired.',
+        err
+      );
+    } finally {
+      this.clear();
+    }
+  },
+
+  async switchScope(scope: string) {
+    await this._plainLogout();
+    history.goToLogin({ scope });
   },
 
   logoutWithoutSlo({

--- a/web/packages/teleport/src/stores/storeUserContext.ts
+++ b/web/packages/teleport/src/stores/storeUserContext.ts
@@ -332,6 +332,6 @@ export default class StoreUserContext extends Store<UserContext> {
   }
 
   getScope() {
-    return this.state.scope;
+    return this.state?.scope ?? '';
   }
 }

--- a/web/packages/teleport/src/stores/storeUserContext.ts
+++ b/web/packages/teleport/src/stores/storeUserContext.ts
@@ -330,4 +330,8 @@ export default class StoreUserContext extends Store<UserContext> {
   getAvailableScopes() {
     return this.state.availableScopes;
   }
+
+  getScope() {
+    return this.state.scope;
+  }
 }

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -164,6 +164,11 @@ export interface TeleportFeature {
   showInDashboard?: boolean;
   /** isHyperLink is whether this subsection is merely a hyperlink/shortcut to another subsection. */
   isHyperLink?: boolean;
+  /**
+   * supportsScopes indicates whether this feature should be enabled in scoped
+   * sessions.
+   */
+  supportsScopes?: boolean;
 }
 
 export type StickyCluster = {

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -156,7 +156,8 @@ export function UnifiedResources(props: {
       supported: 'yes',
       availabilityFilter: getResourceAvailabilityFilter(
         userPreferences.unifiedResourcePreferences.availableResourceMode,
-        rootCluster.showResources === ShowResources.REQUESTABLE
+        rootCluster.showResources === ShowResources.REQUESTABLE,
+        false /* scopedSession */
       ),
     };
   }, [


### PR DESCRIPTION
This change adds a web frontend that enables users to log in to a scope or make an explicitly unscoped session. Note that the UX is suboptimal and requires logging in twice. This will need to be later addressed by allowing narrowing down the current scope. The login UI changes will still be required, though, for the later implementation of an in-app scope switcher that will allow switching to a parent scope.

[Demo](https://goteleport.zoom.us/clips/share/amAYXtleR3Go0d7-usnvCA)
Note: the demo also includes the enterprise part (signing in using SAML and OIDC).

Depends on https://github.com/gravitational/teleport/pull/68884
Followed up by https://github.com/gravitational/teleport.e/pull/9194

Since this feature isn't fully operational yet (the user can't actually sign in to a scope), it needs to be turned on first (see the test environment section for testing instructions).

Figma mocks: https://www.figma.com/design/R0OFgXfdWfEyH5I4SgQQaR/DESIGN-Scoped-RBAC-3?node-id=409-44481&m=dev

## Manual Test Plan
### Test Environment
Any cluster with two users (Alice, Bob). Alice doesn't have scoped role assignments, Bob has multiple scoped role assignments. To turn on the feature:
- Turn on Scopes globally using `TELEPORT_UNSTABLE_SCOPES=yes` in the environment.
- Using Chrome dev tools, add `grv_teleport_use_login_scope_picker=true` to the application's local storage.

This test plan is common for the UI and the backend change. The follow-up enterprise PR is tested separately.

### Test Cases
- [x] Alice can sign in to Teleport just as she was before.
- [x] With the scope picker turned on, Bob is able to log in to a scope:
   - [x] Using a passkey
   - [x] Using OTP
   - [x] Using GitHub
- [x] With the scope picker turned on, Bob is able to log in to an unscoped session:
   - [x] Using a passkey
   - [x] Using OTP
   - [x] Using GitHub
- [x] With the scope picker turned off, Bob can sign in just as he was before.
  - [x] Turn off on the server side, using the environment variable
  - [x] Turn off on the client side, using Chrome dev tools
- [x] Neither Alice nor Bob can log in to an unassigned scope (e.g. by visiting `/web/login?scope=/not-assigned`).