### PR TITLE
SAML: Add unstable env var to disable descriptor redirect check

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -642,6 +642,10 @@ const (
 	UnstableEnableEICEEnvVar = "TELEPORT_UNSTABLE_ENABLE_EICE"
 	// EICEDisabledMessage is the message that gets returned to the user when they try to use this functionality.
 	EICEDisabledMessage = "support for accessing EC2 instances using EC2 Instance Connect Endpoint was removed"
+	// UnstableDisableSAMLRedirectDowngradeCheckEnvVar allows disabling saml_connector
+	// entity_descriptor_url check preventing following redirects via HTTP originating from
+	// HTTPS route.
+	UnstableDisableSAMLRedirectDowngradeCheckEnvVar = "TELEPORT_UNSTABLE_DISABLE_SAML_REDIRECT_DOWNGRADE_CHECK"
 )
 
 const (

--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -642,10 +642,6 @@ const (
 	UnstableEnableEICEEnvVar = "TELEPORT_UNSTABLE_ENABLE_EICE"
 	// EICEDisabledMessage is the message that gets returned to the user when they try to use this functionality.
 	EICEDisabledMessage = "support for accessing EC2 instances using EC2 Instance Connect Endpoint was removed"
-	// UnstableDisableSAMLRedirectDowngradeCheckEnvVar allows disabling saml_connector
-	// entity_descriptor_url check preventing following redirects via HTTP originating from
-	// HTTPS route.
-	UnstableDisableSAMLRedirectDowngradeCheckEnvVar = "TELEPORT_UNSTABLE_DISABLE_SAML_REDIRECT_DOWNGRADE_CHECK"
 )
 
 const (

--- a/constants.go
+++ b/constants.go
@@ -1076,3 +1076,10 @@ const (
 	// OktaReviewerRoleContext  is the context used to name Okta Reviewer role created by Okta Access List sync
 	OktaReviewerRoleContext = "reviewer-okta-acl-role"
 )
+
+const (
+	// EnvVarUnstableDisableSAMLRedirectDowngradeCheck allows disabling saml_connector
+	// entity_descriptor_url check preventing following redirects via HTTP originating from
+	// HTTPS route.
+	EnvVarUnstableDisableSAMLRedirectDowngradeCheck = "TELEPORT_UNSTABLE_DISABLE_SAML_REDIRECT_DOWNGRADE_CHECK"
+)

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -39,8 +40,10 @@ import (
 	dsig "github.com/russellhaering/goxmldsig"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -256,8 +259,11 @@ func getEntityDescriptor(ctx context.Context, params getEntityDescriptorParams) 
 	}()
 
 	if url != "" && !params.Options.NoFollowURLs {
-		httpClient := &http.Client{
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		var checkRedirect func(req *http.Request, via []*http.Request) error
+		if disableCheckRedirect, _ := apiutils.ParseBool(os.Getenv(constants.UnstableDisableSAMLRedirectDowngradeCheckEnvVar)); disableCheckRedirect {
+			log.DebugContext(ctx, "Redirect HTTPS downgrade check disabled with the unstable environment variable")
+		} else {
+			checkRedirect = func(req *http.Request, via []*http.Request) error {
 				if len(via) != 0 && strings.EqualFold(via[len(via)-1].URL.Scheme, "https") && !strings.EqualFold(req.URL.Scheme, "https") {
 					return errors.New("connection downgrade not allowed for URL: " + req.URL.String())
 				}
@@ -265,8 +271,12 @@ func getEntityDescriptor(ctx context.Context, params getEntityDescriptorParams) 
 					return errors.New("stopped after 10 redirects")
 				}
 				return nil
-			},
-			Transport: params.Options.Transport,
+			}
+		}
+
+		httpClient := &http.Client{
+			CheckRedirect: checkRedirect,
+			Transport:     params.Options.Transport,
 		}
 
 		ctx, cancel := context.WithTimeout(ctx, defaults.DefaultIOTimeout)

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -259,6 +259,7 @@ func getEntityDescriptor(ctx context.Context, params getEntityDescriptorParams) 
 
 	if url != "" && !params.Options.NoFollowURLs {
 		var checkRedirect func(req *http.Request, via []*http.Request) error
+		// TODO(kopiczko): Remove this env var after Jul 2027 (one year since introduced) if no issue is reported.
 		if disableCheckRedirect, _ := apiutils.ParseBool(os.Getenv("TELEPORT_UNSTABLE_DISABLE_SAML_REDIRECT_DOWNGRADE_CHECK")); disableCheckRedirect {
 			log.DebugContext(ctx, "Redirect HTTPS downgrade check disabled with the unstable environment variable")
 		} else {

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -40,7 +40,6 @@ import (
 	dsig "github.com/russellhaering/goxmldsig"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
@@ -260,7 +259,7 @@ func getEntityDescriptor(ctx context.Context, params getEntityDescriptorParams) 
 
 	if url != "" && !params.Options.NoFollowURLs {
 		var checkRedirect func(req *http.Request, via []*http.Request) error
-		if disableCheckRedirect, _ := apiutils.ParseBool(os.Getenv(constants.UnstableDisableSAMLRedirectDowngradeCheckEnvVar)); disableCheckRedirect {
+		if disableCheckRedirect, _ := apiutils.ParseBool(os.Getenv("TELEPORT_UNSTABLE_DISABLE_SAML_REDIRECT_DOWNGRADE_CHECK")); disableCheckRedirect {
 			log.DebugContext(ctx, "Redirect HTTPS downgrade check disabled with the unstable environment variable")
 		} else {
 			checkRedirect = func(req *http.Request, via []*http.Request) error {

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -259,7 +260,7 @@ func getEntityDescriptor(ctx context.Context, params getEntityDescriptorParams) 
 	if url != "" && !params.Options.NoFollowURLs {
 		var checkRedirect func(req *http.Request, via []*http.Request) error
 		// TODO(kopiczko): Remove this env var after Jul 2027 (one year since introduced) if no issue is reported.
-		if disableCheckRedirect, _ := apiutils.ParseBool(teleport.EnvVarUnstableDisableSAMLRedirectDowngradeCheck); disableCheckRedirect {
+		if disableCheckRedirect, _ := apiutils.ParseBool(os.Getenv(teleport.EnvVarUnstableDisableSAMLRedirectDowngradeCheck)); disableCheckRedirect {
 			log.DebugContext(ctx, "Redirect HTTPS downgrade check disabled with the unstable environment variable")
 		} else {
 			checkRedirect = func(req *http.Request, via []*http.Request) error {

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -27,7 +27,6 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
-	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -260,7 +259,7 @@ func getEntityDescriptor(ctx context.Context, params getEntityDescriptorParams) 
 	if url != "" && !params.Options.NoFollowURLs {
 		var checkRedirect func(req *http.Request, via []*http.Request) error
 		// TODO(kopiczko): Remove this env var after Jul 2027 (one year since introduced) if no issue is reported.
-		if disableCheckRedirect, _ := apiutils.ParseBool(os.Getenv("TELEPORT_UNSTABLE_DISABLE_SAML_REDIRECT_DOWNGRADE_CHECK")); disableCheckRedirect {
+		if disableCheckRedirect, _ := apiutils.ParseBool(teleport.EnvVarUnstableDisableSAMLRedirectDowngradeCheck); disableCheckRedirect {
 			log.DebugContext(ctx, "Redirect HTTPS downgrade check disabled with the unstable environment variable")
 		} else {
 			checkRedirect = func(req *http.Request, via []*http.Request) error {


### PR DESCRIPTION
Followup of https://github.com/gravitational/teleport/pull/68371.
Adding `TELEPORT_UNSTABLE_DISABLE_SAML_REDIRECT_DOWNGRADE_CHECK` just in case.

## Backports

- https://github.com/gravitational/teleport/pull/69120

## Manual Test Plan

### Test Environment

Prepare http server with a handler:

```go
const (
	HTTPServerEndpointRedirectDowngrade = "/redirect-downgrade"
)

func _httpServerHandlerRedirectDowngrade(w http.ResponseWriter, r *http.Request) {
	http.Redirect(w, r, "http://plan.http.test", http.StatusMovedPermanently)
}
```

### Test Cases

- [x] Verify creating a SAML connector with `entity_descriptor_url` works.
- [x] Verify creating a SAML connector with `entity_descriptor_url` and `export TELEPORT_UNSTABLE_DISABLE_SAML_REDIRECT_DOWNGRADE_CHECK=1` works.
- [x] Verify setting `https://127.0.0.1:9000/redirect-downgrade` for `entity_descriptor_url` fails with "connection downgrade not allowed for URL: http://plan.http.test"
- [x] Verify setting `https://127.0.0.1:9000/redirect-downgrade` for `entity_descriptor_url` and `export TELEPORT_UNSTABLE_DISABLE_SAML_REDIRECT_DOWNGRADE_CHECK=1` fails with "dial tcp: lookup plan.http.test: no such host"
