### PR TITLE
[v18] Add a multi value label parser (#67280)

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -5080,6 +5080,44 @@ func (tc *TeleportClient) LoadTLSConfigForClusters(clusters []string) (*tls.Conf
 // ParseLabelSpec parses a string like 'name=value,"long name"="quoted value"` into a map like
 // { "name" -> "value", "long name" -> "quoted value" }
 func ParseLabelSpec(spec string) (map[string]string, error) {
+	tokens, err := tokenizeLabelSpec(spec)
+	if err != nil {
+		return nil, err
+	}
+	// break tokens in pairs and put into a map:
+	labels := make(map[string]string)
+	for i := 0; i < len(tokens); i += 2 {
+		labels[tokens[i]] = tokens[i+1]
+	}
+	return labels, nil
+}
+
+// MultiValueLabelSelectorSpec parses a string like 'name=value,name=other,"long name"="quoted value"`
+// into a map like { "name" -> ["value", "other"], "long name" -> ["quoted value"] }.
+// Similar to LabelSelectorSpec but allows repeated key values stored into a slice.
+// Duplicate values for the same key are dropped.
+//
+// Multi valued labels are supported for role resources e.g. node_labels.
+func MultiValueLabelSelectorSpec(spec string) (map[string][]string, error) {
+	tokens, err := tokenizeLabelSpec(spec)
+	if err != nil {
+		return nil, err
+	}
+	// break tokens in pairs and put into a map, appending repeated keys:
+	labels := make(map[string][]string)
+	for i := 0; i < len(tokens); i += 2 {
+		key := tokens[i]
+		val := tokens[i+1]
+		if !slices.Contains(labels[key], val) {
+			labels[key] = append(labels[key], val)
+		}
+	}
+	return labels, nil
+}
+
+// tokenizeLabelSpec breaks a label spec like 'name=value,"long name"="quoted value"'
+// into a list of key/value tokens (name, value, long name, quoted value...).
+func tokenizeLabelSpec(spec string) ([]string, error) {
 	var tokens []string
 	openQuotes := false
 	var tokenStart, assignCount int
@@ -5113,12 +5151,7 @@ func ParseLabelSpec(spec string) (map[string]string, error) {
 	if len(tokens)%2 != 0 || assignCount != len(tokens)/2 {
 		return nil, fmt.Errorf("invalid label spec: '%s', should be 'key=value'", spec)
 	}
-	// break tokens in pairs and put into a map:
-	labels := make(map[string]string)
-	for i := 0; i < len(tokens); i += 2 {
-		labels[tokens[i]] = tokens[i+1]
-	}
-	return labels, nil
+	return tokens, nil
 }
 
 // ParseSearchKeywords parses a string ie: foo,bar,"quoted value"` into a slice of

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -261,6 +261,56 @@ func TestParseLabels(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestMultiValueLabelSelectorSpec(t *testing.T) {
+	// empty:
+	m, err := MultiValueLabelSelectorSpec("")
+	require.NoError(t, err)
+	require.Empty(t, m)
+
+	// simplest case:
+	m, err = MultiValueLabelSelectorSpec("key=value")
+	require.NotNil(t, m)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(m, map[string][]string{
+		"key": {"value"},
+	}))
+
+	// repeated keys, same values de-dupped:
+	m, err = MultiValueLabelSelectorSpec("env=staging,region=west,region=east,env=prod,fruit=apple,fruit=apple,region=east")
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(m, map[string][]string{
+		"env":    {"staging", "prod"},
+		"region": {"west", "east"},
+		"fruit":  {"apple"},
+	}))
+
+	// unicode, same value unicode de-dupped:
+	m, err = MultiValueLabelSelectorSpec(`服务器环境=测试,操作系统类别=Linux,机房=华北,服务器环境=something,服务器环境=测试`)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(m, map[string][]string{
+		"服务器环境":  {"测试", "something"},
+		"操作系统类别": {"Linux"},
+		"机房":     {"华北"},
+	}))
+
+	// quoting and separators inside quotes:
+	m, err = MultiValueLabelSelectorSpec(`type="database";" role"=master,ver="mongoDB v1,2", type=db2`)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(m, map[string][]string{
+		"type": {"database", "db2"},
+		"role": {"master"},
+		"ver":  {"mongoDB v1,2"},
+	}))
+
+	// invalid specs
+	m, err = MultiValueLabelSelectorSpec(`type="database,"role"=master,ver="mongoDB v1,2"`)
+	require.Nil(t, m)
+	require.Error(t, err)
+	m, err = MultiValueLabelSelectorSpec(`type="database",role,master`)
+	require.Nil(t, m)
+	require.Error(t, err)
+}
+
 func TestPortsParsing(t *testing.T) {
 	// empty:
 	ports, err := ParsePortForwardSpec(nil)


### PR DESCRIPTION
backports https://github.com/gravitational/teleport/pull/67280 to branch/v18

This had conflict b/c https://github.com/gravitational/teleport/pull/67257 didn't get backported which moved the original parser to a new file. I just moved my changes to the file where the parser was originally. 

No test plan b/c it's not used yet, and unit test should suffice (both parser test passes)




