### PR TITLE
Change tctl acl create --access-type values

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -119,8 +119,8 @@ Use --access-type to have Teleport create the access list's supporting roles
 for you. The --access-type value controls how members are granted access.
 Possible values are:
 
-  standing       members receive persistent access to the resources set below.
-  request-based  members must request that access; owners approve.
+  standing        members receive persistent access to the resources set below.
+  access-request  members must request that access; owners approve.
 
 The supporting roles are built from the resource flags you set. The available
 resource flags (grouped by target) are:
@@ -148,7 +148,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`--access-type`|*no default* (one of: `standing`, `request-based`)|How members are granted access: 'standing' (members receive persistent access to the resources described by the resource flags) or 'request-based' (members must request access; owners review). When omitted, a plain access list is created with no auto-generated roles.|
+|`--access-type`|*no default* (one of: `standing`, `access-request`)|How members are granted access: 'standing' (members receive persistent access to the resources described by the resource flags) or 'access-request' (members must request access; owners review). When omitted, a plain access list is created with no auto-generated roles.|
 |`--app-labels`|*no default*|Selects web apps members may access by label match. For AWS Identity Center apps, use --aws-ic-assignments instead.|
 |`--audit-day`|`1`|Day of month for audit (1, 15, or 31).|
 |`--audit-frequency`|`6`|Audit recurrence in months (1, 3, 6, or 12).|

--- a/tool/tctl/common/accesslist/command.go
+++ b/tool/tctl/common/accesslist/command.go
@@ -191,8 +191,8 @@ Use --access-type to have Teleport create the access list's supporting
 roles for you. The --access-type value controls how members are granted
 access. Possible values are:
 
-  standing       members receive persistent access to the resources set below.
-  request-based  members must request that access; owners approve.
+  standing        members receive persistent access to the resources set below.
+  access-request  members must request that access; owners approve.
 
 The supporting roles are built from the resource flags you set. The available
 resource flags (grouped by target) are:
@@ -278,7 +278,7 @@ func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags
 	c.update.Flag("remove-access", "Remove resource access from an access-typed list. Detaches the resource-access roles from the list's grants and from the supporting reviewer/requester roles.").BoolVar(&c.removeAccess)
 
 	c.create = acl.Command("create", createHelpText)
-	c.create.Flag("access-type", "How members are granted access: 'standing' (members receive persistent access to the resources described by the resource flags) or 'request-based' (members must request access; owners review). When omitted, a plain access list is created with no auto-generated roles.").EnumVar(&c.accessType, accessTypeLongTerm, accessTypeShortTerm)
+	c.create.Flag("access-type", "How members are granted access: 'standing' (members receive persistent access to the resources described by the resource flags) or 'access-request' (members must request access; owners review). When omitted, a plain access list is created with no auto-generated roles.").EnumVar(&c.accessType, accessTypeLongTerm, accessTypeShortTerm)
 	c.create.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
 	c.create.Flag("title", "Display name for the access list.").IsSetByUser(&c.titleSet).StringVar(&c.title)
 	c.create.Flag("audit-frequency", auditFrequencyText).Default("6").PlaceHolder("6").IntVar(&c.auditFrequency)

--- a/tool/tctl/common/accesslist/preset.go
+++ b/tool/tctl/common/accesslist/preset.go
@@ -32,7 +32,7 @@ const (
 	// CLI-facing access type values (what the user sees and uses,
 	// which aligns with terms used in docs).
 	accessTypeLongTerm  = "standing"
-	accessTypeShortTerm = "request-based"
+	accessTypeShortTerm = "access-request"
 
 	standardRolePrefixName = "access-standard"
 	awsicRolePrefixName    = "access-awsic"


### PR DESCRIPTION
Change the tctl acl create --access-type values from `request-based` to `access-request`. The term `access-request` is more familiar and official

So instead of using `--access-type=request-based`, you now have to specify `--access-type=access-request`

This is a safe change, none of the new `acl` commands have been backported yet.


```bash
$ tctl acl create --help
usage: tctl acl create [<flags>]

Create an access list.

Use --access-type to have Teleport create the access list's supporting roles for you. The --access-type
value controls how members are granted access. Possible values are:

  standing        members receive persistent access to the resources set below.
  access-request  members must request that access; owners approve.

<... etc>
Flags:
<... etc>
      --access-type=ACCESS-TYPE  How members are granted access: 'standing' (members receive
                                 persistent access to the resources described by the resource flags)
                                 or 'access-request' (members must request access; owners review).
                                 When omitted, a plain access list is created with no auto-generated roles.
                                 (one of: standing, access-request)
<... etc>
```

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

cloud staging

### Test Cases
- [x] tctl --help does not use `request-based` value anymore
- [x] tctl acl create with `--access-type=access-request`  
