### PR TITLE
Fix race condition in TestAgentPoolConnectionCount

### DIFF
--- a/lib/reversetunnel/agentpool_test.go
+++ b/lib/reversetunnel/agentpool_test.go
@@ -48,6 +48,8 @@ type mockAgent struct {
 	mockStart    func(ctx context.Context) error
 	mockStop     func() error
 	mockGetState func() AgentState
+	// mu protects access to the mockGetState field.
+	mu sync.RWMutex
 }
 
 func (m *mockAgent) Start(ctx context.Context) error {
@@ -58,6 +60,8 @@ func (m *mockAgent) Start(ctx context.Context) error {
 }
 
 func (m *mockAgent) GetState() AgentState {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	if m.mockGetState != nil {
 		return m.mockGetState()
 	}
@@ -138,9 +142,11 @@ func setupTestAgentPool(t *testing.T) (*AgentPool, *mockClient) {
 
 		go func() {
 			<-pool.ctx.Done()
+			agent.mu.Lock()
 			agent.mockGetState = func() AgentState {
 				return AgentClosed
 			}
+			agent.mu.Unlock()
 			callback := pool.getStateCallback(agent)
 			callback(AgentClosed)
 		}()


### PR DESCRIPTION
`mockGetState` was mutated in the per-agent goroutine while the pool's run loop was reading it, via `addActiveAgent`. This adds a mutex to guard the field, matching the real agent implementation.

Closes #68842