### PR TITLE
Prevent demo cluster missteps for AI agents

### DIFF
--- a/docs/pages/get-started/deploy-community.mdx
+++ b/docs/pages/get-started/deploy-community.mdx
@@ -58,36 +58,31 @@ instance approach** for simplicity. Once you have completed this guide, having a
 dedicated host for your self-hosted Teleport cluster reduces the complexity of
 following other guides in the Teleport documentation.
 
-Make sure you have met the
-following requirements for your platform:
+Make sure you have met the following requirements for your platform:
 
 <Tabs>
 <TabItem label="Remote virtual machine">
 
 - A Linux host with only port `443` open to ingress traffic, and no existing
-  Teleport installation. You must be able to install and run software on the
-  host. Either configure access to the host via SSH for the initial setup (and
-  open an SSH port in addition to port `443`) or enter the commands in this
-  guide into an Amazon EC2 [user data
-  script](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html),
-  Google Compute Engine [startup
-  script](https://cloud.google.com/compute/docs/instances/startup-scripts), or
-  similar.
-
+  Teleport installation.
+  - You must be able to install and run software on the host. Either configure
+    access to the host via SSH for the initial setup (and open an SSH port in
+    addition to port `443`) or enter the commands in this guide into an Amazon
+    EC2 [user data
+    script](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html),
+    Google Compute Engine [startup
+    script](https://cloud.google.com/compute/docs/instances/startup-scripts), or
+    similar.
+  - The host can start with 2 vCPU and 1GB RAM for testing, though for
+    additional users and resources, we recommend a larger instance size. For the
+    most scalable performance, run Teleport-protected resources on separate
+    hosts from the Teleport cluster.
 - **One** of the following:
   - A registered domain name or access to a service like Amazon Route53 that
     allows you to register domain names.
   - An authoritative DNS nameserver managed by your organization, plus an
     existing certificate authority. If using this approach, ensure that your
     browser is configured to use your organization's nameserver.
-
-- Two DNS `A` records, each pointing to the IP address of your Linux host.
-  Assuming `teleport.example.com` is your domain name, set up records for:
-
-  |Domain|Reason|
-  |---|---|
-  |`teleport.example.com`|Traffic to the Proxy Service from users and services.|
-  |`*.teleport.example.com`|Traffic to web applications registered with Teleport. Teleport issues a subdomain of your cluster's domain name to each application.|
 
 </TabItem>
 <TabItem label="Local Docker container">
@@ -154,14 +149,118 @@ Authenticator](https://www.google.com/landing/2step/), or
 
 <Admonition type="danger">
 
-While it is possible to configure the Teleport Auth Service to use a self-signed
-certificate, this adds significant complexity and is not recommended. See
-[Self-Signed Certificates](../installation/self-hosted/self-signed-certs.mdx)
-for how to run a Teleport cluster with self-signed certificates. 
+For your Teleport cluster to be functional, the Proxy Service must be
+addressable from outside the cluster with a valid TLS certificate. In most
+cases, this requires a domain name. Only run your Teleport cluster with
+self-signed certificates if you understand the implications. Other guides in the
+documentation assume that your cluster has a domain name.
+
+See [Self-Signed
+Certificates](../installation/self-hosted/self-signed-certs.mdx) for how to run
+a Teleport cluster with self-signed certificates.
 
 </Admonition>
 
-## Step 1/3. Set up Teleport on your Linux host
+## Step 1/4. Create DNS records
+
+If you are following this guide with a local Docker container for testing, skip
+to Step 2.
+
+Create two DNS `A` records, each pointing to the IP address of your Linux host.
+Assuming `teleport.example.com` is your domain name, set up records for:
+
+|Domain|Reason|
+|---|---|
+|`teleport.example.com`|Traffic to the Proxy Service from users and services.|
+|`*.teleport.example.com`|Traffic to web applications registered with Teleport. Teleport issues a subdomain of your cluster's domain name to each application.|
+
+Here are example commands for creating these records on AWS and Google Cloud. If
+you are using a DNS name server managed by your organization, use your internal
+tooling to create the two records and skip to Step 2.
+
+1. Assign the following variables:
+   - <Var name="instance-ip" />: An IP address for the instance where you want to
+     run Teleport (mentioned in the Prerequisites). It must be reachable by cluster
+     users as well as any infrastructure resources you want to protect.
+   - <Var name="teleport.example.com"/>: The subdomain for your Teleport cluster.
+
+1. Run the appropriate commands for your cloud provider:
+
+   <Tabs>
+   <TabItem label="AWS Route 53">
+
+   Assign <Var name="myzone" /> to the ID of your Route 53 hosted zone and run
+   the following command:
+
+   ```code
+   $ MYDNS='<Var name="teleport.example.com" />'
+   $ MYIP='<Var name="instance-ip" />'
+   $ MYZONE='<Var name="myzone" />'
+   
+   # Create a JSON file changeset for AWS.
+   $ jq -n --arg dns "${MYDNS?}" --arg ip "${MYIP?}" \
+       '{
+           "Comment": "Create records",
+           "Changes": [
+             {
+               "Action": "CREATE",
+               "ResourceRecordSet": {
+                 "Name": $dns,
+                 "Type": "A",
+                 "TTL": 300,
+                 "ResourceRecords": [
+                   { "Value": $ip }
+                 ]
+               }
+             },
+             {
+               "Action": "CREATE",
+               "ResourceRecordSet": {
+                 "Name": ("*." + $dns),
+                 "Type": "A",
+                 "TTL": 300,
+                 "ResourceRecords": [
+                   { "Value": $ip }
+                 ]
+               }
+             }
+         ]
+       }' > myrecords.json
+   
+   # Review records before applying.
+   $ cat myrecords.json | jq
+   # Apply the records and capture change id
+   $ CHANGEID="$(aws route53 change-resource-record-sets --hosted-zone-id "${MYZONE?}" --change-batch file://myrecords.json | jq -r '.ChangeInfo.Id')"
+   
+   # Verify that change has been applied
+   $ aws route53 get-change --id "${CHANGEID?}" | jq '.ChangeInfo.Status'
+   # "INSYNC"
+   ```
+
+   </TabItem>
+   <TabItem label="Google Cloud DNS">
+
+   Assign <Var name="myzone" /> to the name of the Cloud DNS zone in which you will
+   create records.
+
+   Run the following commands:
+
+   ```code
+   $ MYZONE='<Var name="myzone" />'
+   $ MYIP='<Var name="instance-ip" />'
+   $ MYDNS='<Var name="teleport.example.com" />'
+   
+   $ gcloud dns record-sets transaction start --zone="${MYZONE?}"
+   $ gcloud dns record-sets transaction add ${MYIP?} --name="${MYDNS?}" --ttl="300" --type="A" --zone="${MYZONE?}"
+   $ gcloud dns record-sets transaction add ${MYIP?} --name="*.${MYDNS?}" --ttl="300" --type="A" --zone="${MYZONE?}"
+   $ gcloud dns record-sets transaction describe --zone="${MYZONE?}"
+   $ gcloud dns record-sets transaction execute --zone="${MYZONE?}"
+   ```
+
+   </TabItem>
+   </Tabs>
+
+## Step 2/4. Set up Teleport on your Linux host
 
 In this step, you will log into your Linux host, download the Teleport binary,
 generate a Teleport configuration file, and start the Teleport Auth Service,
@@ -228,24 +327,6 @@ infrastructure in your cluster.
       --key-file=/etc/teleport-tls/localhost-key.pem
   ```
   </TabItem>
-  <TabItem label="Private network deployment">
-  On your Teleport host, place a valid private key and a certificate chain in `/var/lib/teleport/privkey.pem`
-  and `/var/lib/teleport/fullchain.pem` respectively.
-
-  The leaf certificate must have a subject that corresponds to the domain of your Teleport host, e.g., `*.teleport.example.com`.
-
-  On the host where you will start the Teleport Auth Service and Proxy Service,
-  run the following `teleport configure` command. Assign <Var
-  name="teleport.example.com" /> to the domain name of your Teleport cluster.
-
-  ```code
-  $ sudo teleport configure -o file \
-      --cluster-name=<Var name="teleport.example.com" /> \
-      --public-addr=<Var name="teleport.example.com" />:443 \
-      --cert-file=/var/lib/teleport/fullchain.pem \
-      --key-file=/var/lib/teleport/privkey.pem
-  ```
-  </TabItem>
 </Tabs>
 
 ### Start Teleport
@@ -296,7 +377,7 @@ infrastructure in your cluster.
   - Check the Teleport logs for errors: `sudo journalctl -u teleport` on a VM, or review the terminal output in your container.
 </Checkpoint>
 
-## Step 2/3. Create a Teleport user and set up multi-factor authentication
+## Step 3/4. Create a Teleport user and set up multi-factor authentication
 
 In this step, we'll create a new Teleport user, `teleport-admin`, which is
 allowed to log into SSH hosts as any of the principals `root`, `ubuntu`, or
@@ -402,7 +483,7 @@ $ tsh login --proxy=<Var name="teleport.example.com" /> --user=teleport-admin
 
 </details>
 
-## Step 3/3. Access your server with Teleport
+## Step 4/4. Access your server with Teleport
 
 Now that you have Teleport running and a user configured, you can access your Linux server through the Teleport Web UI (it will be automatically enrolled since Teleport is running on it).
 
@@ -432,3 +513,32 @@ At this point, you've launched your own Teleport Community Edition cluster and c
 <Button style={{ padding: '0 var(--m-2)' }} as="link" href="../connect/" variant="primary" shape="lg">Step 2 - Connect infrastructure <Icon name="arrowRight" inline size="sm"/> </Button>
 </div>
 
+## Advanced: Bring your own certificate
+
+It is possible to deploy Teleport Community Edition in environments that are
+air-gapped or require a private certificate authority. You can configure the
+Teleport Proxy Service to present a custom certificate and CA.
+
+On your Teleport host, place a valid private key and a certificate chain in
+`/var/lib/teleport/privkey.pem` and `/var/lib/teleport/fullchain.pem`
+respectively.
+
+The leaf certificate must have a subject that corresponds to the domain of your
+Teleport host, e.g., `*.teleport.example.com`.
+
+On the host where you will start the Teleport Auth Service and Proxy Service,
+run the following `teleport configure` command. Assign
+<Var name="teleport.example.com" /> to the domain name of your Teleport cluster.
+
+```code
+$ sudo teleport configure -o file \
+    --cluster-name=<Var name="teleport.example.com" /> \
+    --public-addr=<Var name="teleport.example.com" />:443 \
+    --cert-file=/var/lib/teleport/fullchain.pem \
+    --key-file=/var/lib/teleport/privkey.pem
+```
+
+All clients and Teleport Agents connecting to this cluster must trust the
+certificate authority that signed `fullchain.pem`. See [Running Teleport with
+Self-Signed Certificates]( ../installation/self-hosted/self-signed-certs.mdx)
+for details.

--- a/docs/pages/includes/add-role-to-user.mdx
+++ b/docs/pages/includes/add-role-to-user.mdx
@@ -1,6 +1,7 @@
 {{ role="myrole" user="your Teleport user" }}
-Assign the `{{ role }}` role to {{ user }} by running the appropriate
-commands for your authentication provider:
+Assign the `{{ role }}` role to {{ user }}. The commands to run depend on how
+you authenticate to Teleport, that is, whether you have a local Teleport user, a
+single sign-on authentication connector, or a non-interactive user:
 
 <Tabs>
 <TabItem label="Local User">
@@ -102,13 +103,13 @@ commands for your authentication provider:
    oidc.yaml file immediately after updating the resource.
 
 1. Edit `oidc.yaml`, adding `{{ role }}` to the `claims_to_roles` section. 
-   
+
    The claim you should map to this role depends on how you have designed your organization's 
    role-based access controls (RBAC). However, the group must include your user account and
    should be the smallest group possible within your organization.
-   
+
    Here is an example:
-   
+
    ```diff
      claims_to_roles:
        - name: "groups"
@@ -119,12 +120,63 @@ commands for your authentication provider:
    ```
 
 1. Apply your changes:
-   
+
    ```code
    $ tctl create -f oidc.yaml
    ```
 
 1. Sign out of the Teleport cluster and sign in again to assume the new role.
+
+</TabItem>
+<TabItem label="Non-Interactive">
+
+For non-interactive users such as AI agents and CI/CD runners, follow these
+steps.
+
+If you are using Machine ID to issue identity files to your user:
+
+1. Add the new role to your bot. Assign <Var name="mybot" /> to the name of the
+   Machine ID bot that issues your certificate:
+
+   ```code
+   $ tctl bots update <Var name="mybot" /> --add-roles {{ role }}
+   ```
+
+1. Force `tbot` to regenerate the certificate:
+
+   ```code
+   $ pkill -HUP tbot
+   ```
+
+   The bot will also generate a certificate with the new role on its next
+   renewal.
+
+Otherwise, update your user and regenerate your identity file:
+
+1. Retrieve your local user's roles as a comma-separated list. Make sure
+   <Var name="username" /> is the Teleport user you want to assign the new role
+   to.
+
+   ```code
+   $ ROLES=$(tctl get user/<Var name="username" /> --format=json | jq -r '.[].spec.roles | join(",")')
+   ```
+
+1. Edit your local user to add the new role:
+
+   ```code
+   $ tctl users update <Var name="username" /> \
+     --set-roles "${ROLES?},{{ role }}"
+   ```
+
+1. Regenerate the identity file. Make sure <Var name="path/to/identity/file" />
+   corresponds to the correct output path:
+
+   ```code
+   $ tctl auth sign \
+     --user=<Var name="username" /> \
+     --out=<Var name="path/to/identity/file" /> \
+     --overwrite
+   ```
 
 </TabItem>
 </Tabs>

--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -1,8 +1,9 @@
 {{ edition="Teleport" clients="`tctl` and `tsh` clients" optionalClientNote="" }}
 
-- A running {{ edition }} cluster. If you want to get started with Teleport,
-  [sign up](https://goteleport.com/signup) for a free trial or [set up a demo
-  environment](../get-started/deploy-community.mdx).
+- A running {{ edition }} cluster accessible at a hostname with a valid TLS
+  certificate. If you want to get started with Teleport,
+  [sign up](https://goteleport.com/signup) for a free trial or
+  [set up a demo environment](../get-started/deploy-community.mdx).
 
 - The {{ clients }}{{ optionalClientNote }}.
 


### PR DESCRIPTION
Fix issues that hinder AI agents that attempt to set up a demo cluster in order to follow other docs guides.

- **Add resource guidelines to the Deploy Community guide:** An agent failed to follow many of our how-to guides because it ran all demo infrastructure resources on the same host as the Teleport cluster.  This caused OOMs. Sizing guidance is based on the single-instance Terraform guide, `installation/self-hosted/deployments/aws-starter-cluster-terraform.mdx`.

- **Edit the Community Edition guide to add further preventions against using self-signed certificates:** Agents see the Prerequisites requirement for DNS records as a blocker. If records don't exist, the agent doesn't try to create them. Instead, add a "Step" section with instructions to create DNS records. While an earlier change removed an existing "Step" section for creating records, this change includes commands in the section to reduce the context needed to follow the guide and give agents an easy course of action to reach for. (If it's not easy, they'll reach for self-signed certificates instead.)

  Also strengthen the Admonition against using self-signed certificates, which tends to be an AI agent's first choice.

- **Mark the private CA alternative as advanced in the Deploy Community guide:** This way, it's not presented as equally viable for a demo environment, and agents won't be as tempted to follow it.

- **Require a valid TLS certificate** in the partial we use in Prerequisites sections throughout our how-to guides, `edition-prereqs-tabs.mdx`. While agents tend to set up demo clusters successully, they often use self-signed certificates and fail to connect Teleport Agents to it, and for `tctl` commands, end up running the commands over a direct SSH connection to the Auth Service. Include a persistent reminder in how-to guides that we expect the Proxy Service to be reachable with a valid TLS certificate.

- **Edit add-role-to-user.mdx:** Add a `TabItem` in this partial for non-interactive users, since agents had difficulty with `tsh login`