### PR TITLE
[v18] scoped Terraform support

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -610,6 +610,10 @@ const (
 	// that contains the GitLab ID token. This can be used to authenticate to multiple Teleport clusters from a single
 	// GitLab CI job.
 	EnvVarGitlabIDTokenEnvVar = "TF_TELEPORT_GITLAB_ID_TOKEN_ENV_VAR"
+	// EnvVarTerraformScoped is the environment variable indicating that the Terraform Operator will join with a scoped token.
+	// This only takes effect when the operator performs native MachineID joining
+	// (i.e. join method and join token are specified). This must be set when using a scoped join token.
+	EnvVarTerraformScoped = "TF_TELEPORT_SCOPED"
 )
 
 // MaxPIVPINCacheTTL defines the maximum allowed TTL for PIV PIN client caches.

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -2728,6 +2728,7 @@ Flags:
 |`--bot-ttl`|`1h`|Time-to-live of the Bot resource. The bot will be removed after this period. Defaults to \[1h\]|
 |`--resource-prefix`|`tctl-terraform-env-`|Resource prefix to use when creating the Terraform role and bots. Defaults to \[tctl-terraform-env-\]|
 |`--role`|*no default*|Role used by Terraform. The role must already exist in Teleport. When not specified, uses the default role "terraform-provider"|
+|`--scope`|*no default*|Scope of the bot used by the Terraform provider. When empty, TF provider runs unscoped.|
 
 ## tctl tokens add
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/terraform-provider.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/terraform-provider.mdx
@@ -187,6 +187,7 @@ This auth method has the following limitations:
 - `join_token` (String) Name of the token used for the native MachineID joining. This value is not sensitive for [delegated join methods](../../deployment/join-methods.mdx#secret-vs-delegated). This can also be set with the environment variable `TF_TELEPORT_JOIN_TOKEN`.
 - `key_base64` (String, Sensitive) Base64 encoded TLS auth key. This can also be set with the environment variable `TF_TELEPORT_KEY_BASE64`.
 - `key_path` (String) Path to Teleport auth key file. This can also be set with the environment variable `TF_TELEPORT_KEY`.
+- `kubernetes_token_path` (String) KubernetesTokenPath configures the Kubernetes token location when joining using MachineID and the `kubernetes` join method. When unset, the join client will try the `KUBERNETES_TOKEN_PATH` env var, else it will use the standard location: `/var/run/secrets/kubernetes.io/serviceaccount/token`.
 - `profile_dir` (String) Teleport profile path. This can also be set with the environment variable `TF_TELEPORT_PROFILE_PATH`.
 - `profile_name` (String) Teleport profile name. This can also be set with the environment variable `TF_TELEPORT_PROFILE_NAME`.
 - `retry_base_duration` (String) Retry algorithm when the API returns 'not found': base duration between retries (https://pkg.go.dev/time#ParseDuration). This can also be set with the environment variable `TF_TELEPORT_RETRY_BASE_DURATION`.

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/terraform-provider.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/terraform-provider.mdx
@@ -195,4 +195,5 @@ This auth method has the following limitations:
 - `retry_max_tries` (String) Retry algorithm when the API returns 'not found': max tries. This can also be set with the environment variable `TF_TELEPORT_RETRY_MAX_TRIES`.
 - `root_ca_base64` (String) Base64 encoded Root CA. This can also be set with the environment variable `TF_TELEPORT_CA_BASE64`.
 - `root_ca_path` (String) Path to Teleport Root CA. This can also be set with the environment variable `TF_TELEPORT_ROOT_CA`.
+- `scoped` (Boolean) Scoped indicates that the Terraform Operator will join with a scoped token. This only takes effect when the operator performs native MachineID joining (i.e. join method and join token are specified). This must be set when using a scoped join token. This can also be set with the environment variable `TF_TELEPORT_SCOPED`
 

--- a/docs/pages/reference/machine-workload-identity/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/configuration.mdx
@@ -140,6 +140,14 @@ onboarding:
     # key.
     static_key_path: ./path/to/secret
 
+  # kubernetes holds parameters specific to the "kubernetes" join methods.
+  kubernetes:
+    # token_path is the optional path that used to lookup the Kubernetes service account token for joining.
+    # When unset, tbot will try the `KUBERNETES_TOKEN_PATH` env var, else it will use the standard location:
+    # "/var/run/secrets/kubernetes.io/serviceaccount/token".
+    #
+    # token_path: "./path/to/token"
+
 # storage specifies the destination that `tbot` should use to store its
 # internal state. This state is sensitive, and you should ensure that the
 # destination you specify here can only be accessed by `tbot`.

--- a/integration/tctl_terraform_env_test.go
+++ b/integration/tctl_terraform_env_test.go
@@ -35,16 +35,24 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/gravitational/teleport/api/breaker"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/wait"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/tool/tctl/common"
@@ -200,6 +208,141 @@ func TestTCTLTerraformCommand_AuthJoin(t *testing.T) {
 	connectWithCredentialsFromVars(t, vars, clt)
 }
 
+// TestTCTLTerraformCommand_ScopedProxyJoin validates that the command `tctl terraform env`
+// can run from an unscoped admin against a Teleport Proxy service and generates valid
+// scoped credentials Terraform can use to connect to Teleport.
+func TestTCTLTerraformCommand_ScopedProxyJoin(t *testing.T) {
+	// test is not Parallel because of the metrics black hole
+	testDir := t.TempDir()
+	prometheus.DefaultRegisterer = metricRegistryBlackHole{}
+
+	// Test setup: creating a teleport instance running auth and proxy
+	clusterName := "root.example.com"
+	cfg := helpers.InstanceConfig{
+		ClusterName: clusterName,
+		HostID:      uuid.New().String(),
+		NodeName:    helpers.Loopback,
+		Logger:      logtest.NewLogger(),
+	}
+	cfg.Listeners = helpers.SingleProxyPortSetup(t, &cfg.Fds)
+	rc := helpers.NewInstance(t, cfg)
+
+	rcConf := servicecfg.MakeDefaultConfig()
+	rcConf.DataDir = filepath.Join(testDir, "data")
+	rcConf.Auth.Enabled = true
+	rcConf.Proxy.Enabled = true
+	rcConf.SSH.Enabled = false
+	rcConf.Proxy.DisableWebInterface = true
+	rcConf.Version = "v3"
+	rcConf.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
+	rcConf.ScopesFeatures = scopes.Features{Enabled: true}
+
+	testUsername := "test-user"
+	createTCTLTerraformCrossScopeAdmin(t, testUsername, rc)
+
+	// Test setup: starting the Teleport instance
+	err := rc.CreateEx(t, nil, rcConf)
+	require.NoError(t, err)
+
+	err = rc.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, rc.StopAll())
+	})
+
+	// Test setup: obtaining and authclient connected via the proxy
+	clt := getAuthClientForProxy(t, rc, testUsername, time.Hour)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	_, err = clt.Ping(ctx)
+	require.NoError(t, err)
+
+	createDefaultTerraformScopedRole(t, ctx, clt)
+
+	addr, err := rc.Process.ProxyWebAddr()
+	require.NoError(t, err)
+
+	// Test execution, running the tctl command
+	tctlCfg := &servicecfg.Config{}
+	err = tctlCfg.SetAuthServerAddresses([]utils.NetAddr{*addr})
+	require.NoError(t, err)
+	tctlCommand := common.TerraformCommand{}
+
+	const testScope = "/test"
+	app := kingpin.New("test", "test")
+	tctlCommand.Initialize(app, nil, tctlCfg)
+	_, err = app.Parse([]string{"terraform", "env", "--scope", testScope})
+	require.NoError(t, err)
+	// Create io buffer writer
+	stdout := &bytes.Buffer{}
+
+	err = tctlCommand.RunEnvCommand(ctx, clt, stdout, os.Stderr)
+	require.NoError(t, err)
+
+	vars := parseExportedEnvVars(t, stdout)
+	require.Contains(t, vars, constants.EnvVarTerraformAddress)
+	require.Contains(t, vars, constants.EnvVarTerraformIdentityFileBase64)
+
+	// Test validation: connect with the credentials in env vars and do a ping
+	require.Equal(t, addr.String(), vars[constants.EnvVarTerraformAddress])
+
+	connectWithCredentialsFromVars(t, vars, clt)
+
+	// Test validation: make sure no role assignment is left. We don't know the assignment's name so we have to list them all initially.
+	resp, err := clt.ScopedAccessServiceClient().ListScopedRoleAssignments(ctx, scopedaccessv1.ListScopedRoleAssignmentsRequest_builder{
+		ScopeFilter: scopesv1.Filter_builder{
+			Scope: testScope,
+			Mode:  scopesv1.Mode_MODE_EXACT,
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+	switch len(resp.GetAssignments()) {
+	case 0:
+		// assignment already deleted
+		return
+	case 1:
+		// Assignment still exists, this might be a race against the cache.
+		// Will retry a few times.
+		_, err = wait.UntilNotFound(ctx, func(ctx context.Context) (*scopedaccessv1.GetScopedRoleAssignmentResponse, error) {
+			return clt.ScopedAccessServiceClient().GetScopedRoleAssignment(ctx, scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
+				Name:    resp.GetAssignments()[0].GetMetadata().GetName(),
+				SubKind: resp.GetAssignments()[0].GetSubKind(),
+				Scope:   resp.GetAssignments()[0].GetScope(),
+			}.Build())
+		})
+		require.NoError(t, err)
+	default:
+		require.Fail(t, "unexpected number of role assignments: %v", len(resp.GetAssignments()))
+	}
+}
+
+func createDefaultTerraformScopedRole(t *testing.T, ctx context.Context, clt *authclient.Client) {
+	reader, err := utils.OpenFileNoUnsafeLinks("../integrations/terraform/examples/provider/scoped-provider-role.yaml")
+	require.NoError(t, err)
+
+	decoder := kyaml.NewYAMLOrJSONDecoder(reader, defaults.LookaheadBufSize)
+	var raw services.UnknownResource
+	err = decoder.Decode(&raw)
+	require.NoError(t, err)
+	r, err := services.UnmarshalProtoResource[*scopedaccessv1.ScopedRole](raw.Raw, services.DisallowUnknown())
+	require.NoError(t, err)
+
+	_, err = clt.ScopedAccessServiceClient().CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+		Role: r,
+	}.Build())
+	require.NoError(t, err)
+
+	// Wait for the role to enter the cache, there is a race. If the test wins, tctl will fail to find the role.
+	_, err = wait.UntilFound(ctx, func(ctx context.Context) (*scopedaccessv1.GetScopedRoleResponse, error) {
+		return clt.ScopedAccessServiceClient().GetScopedRole(ctx,
+			scopedaccessv1.GetScopedRoleRequest_builder{
+				Name:  r.GetMetadata().GetName(),
+				Scope: r.GetScope(),
+			}.Build())
+	}, wait.WithMaxTries(7))
+	require.NoError(t, err)
+}
+
 func createTCTLTerraformUserAndRole(t *testing.T, username string, instance *helpers.TeleInstance) {
 	// Test setup: creating a test user and its role
 	role, err := types.NewRole("test-role", types.RoleSpecV6{
@@ -209,6 +352,32 @@ func createTCTLTerraformUserAndRole(t *testing.T, username string, instance *hel
 				{
 					Resources: []string{types.KindToken, types.KindRole, types.KindBot},
 					Verbs:     []string{types.VerbRead, types.VerbCreate, types.VerbList, types.VerbUpdate},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	instance.AddUserWithRole(username, role)
+}
+
+func createTCTLTerraformCrossScopeAdmin(t *testing.T, username string, instance *helpers.TeleInstance) {
+	// Test setup: creating a test user and its role
+	role, err := types.NewRole("test-role-full-admin", types.RoleSpecV6{
+		Options: types.RoleOptions{},
+		Allow: types.RoleConditions{
+			Rules: []types.Rule{
+				{
+					Resources: []string{types.KindScopedToken},
+					Verbs:     []string{types.VerbRead, types.VerbCreate, types.VerbList, types.VerbUpdate, types.VerbDelete},
+				},
+				{
+					Resources: []string{scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment},
+					Verbs:     []string{types.VerbReadNoSecrets, types.VerbCreate, types.VerbList, types.VerbUpdate, types.VerbDelete},
+				},
+				{
+					Resources: []string{types.KindBot},
+					Verbs:     []string{types.VerbRead, types.VerbCreate, types.VerbList, types.VerbUpdate, types.VerbDelete},
 				},
 			},
 		},

--- a/integrations/lib/embeddedtbot/bot.go
+++ b/integrations/lib/embeddedtbot/bot.go
@@ -74,6 +74,7 @@ func New(botConfig *BotConfig, log *slog.Logger) (*EmbeddedBot, error) {
 				botConfig.CredentialLifetime,
 			),
 		},
+		Scoped: botConfig.Scoped,
 	}
 
 	err := cfg.CheckAndSetDefaults()

--- a/integrations/lib/embeddedtbot/bot_test.go
+++ b/integrations/lib/embeddedtbot/bot_test.go
@@ -208,13 +208,12 @@ func createBotUser(
 }
 
 func TestScopedBotJoinAuth(t *testing.T) {
+	t.Parallel()
+
 	// Test setup: Configure and start Teleport server
 	clusterName := "root.example.com"
 	logger := logtest.NewLogger()
 	ctx := t.Context()
-
-	// We lose test parallelism, but there's currently no other way to enable scope support.
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 
 	teleportServer := helpers.NewInstance(t, helpers.InstanceConfig{
 		ClusterName: clusterName,
@@ -243,6 +242,7 @@ func TestScopedBotJoinAuth(t *testing.T) {
 	// Test setup: starting the Teleport instance
 	rcConf := servicecfg.MakeDefaultConfig()
 	rcConf.DataDir = t.TempDir()
+	rcConf.ScopesFeatures = scopes.Features{Enabled: true}
 	rcConf.Auth.Enabled = true
 	rcConf.Proxy.Enabled = true
 	rcConf.Proxy.DisableWebInterface = true
@@ -290,53 +290,53 @@ func TestScopedBotJoinAuth(t *testing.T) {
 	)
 
 	// Role impersonated by the bot.
-	botRole := &scopedaccessv1.ScopedRole{
+	botRole := scopedaccessv1.ScopedRole_builder{
 		Kind:    scopedaccess.KindScopedRole,
 		Version: types.V1,
-		Metadata: &headerv1.Metadata{
+		Metadata: headerv1.Metadata_builder{
 			Name: testBotRole,
-		},
+		}.Build(),
 		Scope: testRootScope,
-		Spec: &scopedaccessv1.ScopedRoleSpec{
+		Spec: scopedaccessv1.ScopedRoleSpec_builder{
 			AssignableScopes: []string{testRootScope},
 			Rules: []*scopedaccessv1.ScopedRule{
 				// The role can read scoped roles. We will use this to validate its permissions later.
-				{
+				scopedaccessv1.ScopedRule_builder{
 					Resources: []string{scopedaccess.KindScopedRole},
 					Verbs:     []string{types.VerbReadNoSecrets},
-				},
+				}.Build(),
 			},
-		},
-	}
+		}.Build(),
+	}.Build()
 	require.NoError(t, scopedaccess.StrongValidateRole(botRole), "malformed role, this is a bug in the test fixture")
-	_, err = adminClient.ScopedAccessServiceClient().CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+	_, err = adminClient.ScopedAccessServiceClient().CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
 		Role: botRole,
-	})
+	}.Build())
 	require.NoError(t, err)
 
 	// Create the bot.
-	botResource := &machineidv1.Bot{
+	botResource := machineidv1.Bot_builder{
 		Kind:    types.KindBot,
 		Version: types.V1,
-		Metadata: &headerv1.Metadata{
+		Metadata: headerv1.Metadata_builder{
 			Name: testBotName,
-		},
+		}.Build(),
 		Spec:  &machineidv1.BotSpec{},
 		Scope: testRootScope,
-	}
-	_, err = adminClient.BotServiceClient().CreateBot(ctx, &machineidv1.CreateBotRequest{
+	}.Build()
+	_, err = adminClient.BotServiceClient().CreateBot(ctx, machineidv1.CreateBotRequest_builder{
 		Bot: botResource,
-	})
+	}.Build())
 	require.NoError(t, err)
 
 	// Assign role to bot
-	roleAssignment := &scopedaccessv1.ScopedRoleAssignment{
+	roleAssignment := scopedaccessv1.ScopedRoleAssignment_builder{
 		Kind:    scopedaccess.KindScopedRoleAssignment,
 		SubKind: scopedaccess.SubKindDynamic,
 		Version: types.V1,
-		Metadata: &headerv1.Metadata{
+		Metadata: headerv1.Metadata_builder{
 			Name: testBotRole,
-		},
+		}.Build(),
 		Scope: testRootScope,
 		Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
 			Assignments: []*scopedaccessv1.Assignment{
@@ -350,12 +350,12 @@ func TestScopedBotJoinAuth(t *testing.T) {
 			},
 			Bot: scopes.QualifiedName{Scope: testRootScope, Name: testBotName}.String(),
 		}.Build(),
-	}
+	}.Build()
 	_, err = adminClient.ScopedAccessServiceClient().CreateScopedRoleAssignment(
 		ctx,
-		&scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
 			Assignment: roleAssignment,
-		})
+		}.Build())
 	require.NoError(t, err)
 
 	// Test setup: Wait for the role assignment to enter the auth server cache
@@ -363,14 +363,15 @@ func TestScopedBotJoinAuth(t *testing.T) {
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		resp, err := adminClient.ScopedAccessServiceClient().GetScopedRoleAssignment(
 			ctx,
-			&scopedaccessv1.GetScopedRoleAssignmentRequest{
+			scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
 				Name:    testBotRole,
+				Scope:   testRootScope,
 				SubKind: scopedaccess.SubKindDynamic,
-			},
+			}.Build(),
 		)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
-		require.NotNil(t, resp.Assignment)
+		require.NotNil(t, resp.GetAssignment())
 	}, 5*time.Second, 100*time.Millisecond, "expected role assignment to enter the auth cache")
 
 	// Test setup: Create a fake Kubernetes JWKS signer that will be used by the bot to join the cluster.
@@ -414,9 +415,9 @@ func TestScopedBotJoinAuth(t *testing.T) {
 	}.Build()
 	// Somehow the admin client interface doesn't expose CreateScopedToken ¯\_(ツ)_/¯
 	// We use the auth server directly to create the scoped token.
-	_, err = teleportServer.Process.GetAuthServer().CreateScopedToken(ctx, &scopedjoiningv1.CreateScopedTokenRequest{
+	scopedToken, err := teleportServer.Process.GetAuthServer().CreateScopedToken(ctx, scopedjoiningv1.CreateScopedTokenRequest_builder{
 		Token: token,
-	})
+	}.Build())
 	require.NoError(t, err)
 
 	// Test setup: Configure the bot to join the auth using the scoped join token and the JWT.
@@ -425,7 +426,7 @@ func TestScopedBotJoinAuth(t *testing.T) {
 	botConfig := &BotConfig{
 		AuthServer: authAddr.Addr,
 		Onboarding: onboarding.Config{
-			TokenValue: testTokenName,
+			TokenValue: scopedToken.GetToken().GetMetadata().GetName(),
 			JoinMethod: types.JoinMethodKubernetes,
 			Kubernetes: onboarding.KubernetesOnboardingConfig{
 				TokenPath: tokenPath,
@@ -453,8 +454,9 @@ func TestScopedBotJoinAuth(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, clusterName, botPong.ClusterName)
 
-	_, err = botClient.ScopedAccessServiceClient().GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
-		Name: testBotRole,
-	})
+	_, err = botClient.ScopedAccessServiceClient().GetScopedRole(ctx, scopedaccessv1.GetScopedRoleRequest_builder{
+		Name:  testBotRole,
+		Scope: testRootScope,
+	}.Build())
 	require.NoError(t, err)
 }

--- a/integrations/lib/embeddedtbot/bot_test.go
+++ b/integrations/lib/embeddedtbot/bot_test.go
@@ -19,19 +19,30 @@
 package embeddedtbot
 
 import (
-	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopedjoiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
+	"github.com/gravitational/teleport/lib/oidc/fakeissuer"
+	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	scopedjoining "github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
@@ -41,7 +52,7 @@ import (
 func TestBotJoinAuth(t *testing.T) {
 	// Configure and start Teleport server
 	clusterName := "root.example.com"
-	ctx := context.Background()
+	ctx := t.Context()
 	logger := logtest.NewLogger()
 	teleportServer := helpers.NewInstance(t, helpers.InstanceConfig{
 		ClusterName: clusterName,
@@ -163,7 +174,7 @@ func createBotRole(botName string, resourceName string, roleRequests []string) (
 	}
 
 	meta := role.GetMetadata()
-	meta.Description = fmt.Sprintf("Automatically generated role for bot %s", botName)
+	meta.Description = fmt.Sprintf("Role for bot %s", botName)
 	if meta.Labels == nil {
 		meta.Labels = map[string]string{}
 	}
@@ -194,4 +205,256 @@ func createBotUser(
 	user.SetMetadata(metadata)
 	user.SetTraits(traits)
 	return user, nil
+}
+
+func TestScopedBotJoinAuth(t *testing.T) {
+	// Test setup: Configure and start Teleport server
+	clusterName := "root.example.com"
+	logger := logtest.NewLogger()
+	ctx := t.Context()
+
+	// We lose test parallelism, but there's currently no other way to enable scope support.
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+
+	teleportServer := helpers.NewInstance(t, helpers.InstanceConfig{
+		ClusterName: clusterName,
+		HostID:      uuid.New().String(),
+		NodeName:    helpers.Loopback,
+		Logger:      logger,
+	})
+
+	// Test setup: building an admin user and role that will be used to create fixtures.
+	const adminUserName = "admin"
+	adminRole, err := types.NewRole("admin", types.RoleSpecV6{
+		Options: types.RoleOptions{},
+		Allow: types.RoleConditions{
+			Rules: []types.Rule{
+				{
+					Resources: []string{types.KindUser, types.KindRole, scopedaccess.KindScopedToken, scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment, types.KindBot},
+					Verbs:     []string{types.VerbRead, types.VerbCreate, types.VerbDelete, types.VerbList, types.VerbUpdate},
+				},
+			},
+		},
+		Deny: types.RoleConditions{},
+	})
+	require.NoError(t, err)
+	teleportServer.AddUserWithRole(adminUserName, adminRole)
+
+	// Test setup: starting the Teleport instance
+	rcConf := servicecfg.MakeDefaultConfig()
+	rcConf.DataDir = t.TempDir()
+	rcConf.Auth.Enabled = true
+	rcConf.Proxy.Enabled = true
+	rcConf.Proxy.DisableWebInterface = true
+	rcConf.SSH.Enabled = false
+	rcConf.Version = "v3"
+
+	require.NoError(t, teleportServer.CreateEx(t, nil, rcConf))
+
+	require.NoError(t, teleportServer.Start())
+	t.Cleanup(func() { _ = teleportServer.StopAll() })
+
+	// Test setup: Building an admin client.
+	// Note: this is very convoluted but the bot service is not stored in the auth server struct and cannot be accessed
+	// without a rpc client.
+	adminCreds, err := helpers.GenerateUserCreds(helpers.UserCredsRequest{
+		Process:  teleportServer.Process,
+		Username: "admin",
+	})
+	require.NoError(t, err)
+	clt, err := teleportServer.NewClientWithCreds(
+		helpers.ClientConfig{
+			TeleportUser: adminUserName,
+			Login:        adminUserName,
+			Cluster:      clusterName,
+		},
+		*adminCreds,
+	)
+	require.NoError(t, err)
+
+	clusterClient, err := clt.ConnectToCluster(ctx)
+	require.NoError(t, err)
+	adminClient, err := clusterClient.ConnectToCluster(ctx, clusterName)
+	require.NoError(t, err)
+	// Validate that the admin client works.
+	adminPong, err := adminClient.Ping(ctx)
+	require.NoError(t, err)
+	require.Equal(t, clusterName, adminPong.ClusterName)
+
+	// Test setup: Create all the scoped resources describing a scoped bot, and its RBAC.
+	const (
+		testRootScope = "/my-scope"
+		testBotRole   = "scoped-role"
+		testBotName   = "test-bot"
+		testTokenName = "test-token"
+	)
+
+	// Role impersonated by the bot.
+	botRole := &scopedaccessv1.ScopedRole{
+		Kind:    scopedaccess.KindScopedRole,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: testBotRole,
+		},
+		Scope: testRootScope,
+		Spec: &scopedaccessv1.ScopedRoleSpec{
+			AssignableScopes: []string{testRootScope},
+			Rules: []*scopedaccessv1.ScopedRule{
+				// The role can read scoped roles. We will use this to validate its permissions later.
+				{
+					Resources: []string{scopedaccess.KindScopedRole},
+					Verbs:     []string{types.VerbReadNoSecrets},
+				},
+			},
+		},
+	}
+	require.NoError(t, scopedaccess.StrongValidateRole(botRole), "malformed role, this is a bug in the test fixture")
+	_, err = adminClient.ScopedAccessServiceClient().CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: botRole,
+	})
+	require.NoError(t, err)
+
+	// Create the bot.
+	botResource := &machineidv1.Bot{
+		Kind:    types.KindBot,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: testBotName,
+		},
+		Spec:  &machineidv1.BotSpec{},
+		Scope: testRootScope,
+	}
+	_, err = adminClient.BotServiceClient().CreateBot(ctx, &machineidv1.CreateBotRequest{
+		Bot: botResource,
+	})
+	require.NoError(t, err)
+
+	// Assign role to bot
+	roleAssignment := &scopedaccessv1.ScopedRoleAssignment{
+		Kind:    scopedaccess.KindScopedRoleAssignment,
+		SubKind: scopedaccess.SubKindDynamic,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: testBotRole,
+		},
+		Scope: testRootScope,
+		Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+			Assignments: []*scopedaccessv1.Assignment{
+				scopedaccessv1.Assignment_builder{
+					Role: scopes.QualifiedName{
+						Scope: testRootScope,
+						Name:  testBotRole,
+					}.String(),
+					Scope: testRootScope,
+				}.Build(),
+			},
+			Bot: scopes.QualifiedName{Scope: testRootScope, Name: testBotName}.String(),
+		}.Build(),
+	}
+	_, err = adminClient.ScopedAccessServiceClient().CreateScopedRoleAssignment(
+		ctx,
+		&scopedaccessv1.CreateScopedRoleAssignmentRequest{
+			Assignment: roleAssignment,
+		})
+	require.NoError(t, err)
+
+	// Test setup: Wait for the role assignment to enter the auth server cache
+	// else the bot will race against the cache, joining will fail and the test wil be flaky.
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		resp, err := adminClient.ScopedAccessServiceClient().GetScopedRoleAssignment(
+			ctx,
+			&scopedaccessv1.GetScopedRoleAssignmentRequest{
+				Name:    testBotRole,
+				SubKind: scopedaccess.SubKindDynamic,
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.NotNil(t, resp.Assignment)
+	}, 5*time.Second, 100*time.Millisecond, "expected role assignment to enter the auth cache")
+
+	// Test setup: Create a fake Kubernetes JWKS signer that will be used by the bot to join the cluster.
+	const (
+		testPod            = "my-pod"
+		testNamespace      = "my-namespace"
+		testServiceAccount = "my-service-account"
+	)
+	signer, err := fakeissuer.NewKubernetesSigner(clockwork.NewRealClock())
+	require.NoError(t, err)
+	jwks, err := signer.GetMarshaledJWKS()
+	require.NoError(t, err)
+	jwt, err := signer.SignServiceAccountJWT(testPod, testNamespace, testServiceAccount, clusterName)
+	require.NoError(t, err)
+
+	tokenDir := t.TempDir()
+	tokenPath := filepath.Join(tokenDir, "token")
+	require.NoError(t, os.WriteFile(tokenPath, []byte(jwt), 0600))
+
+	// Test setup: Create the scoped token allowing the Bot to join with a JWT emitted by the Kube signer.
+	token := scopedjoiningv1.ScopedToken_builder{
+		Kind:     scopedaccess.KindScopedToken,
+		Version:  types.V1,
+		Metadata: headerv1.Metadata_builder{Name: testTokenName}.Build(),
+		Scope:    testRootScope,
+		Spec: scopedjoiningv1.ScopedTokenSpec_builder{
+			JoinMethod: string(types.JoinMethodKubernetes),
+			UsageMode:  scopedjoining.TokenUsageModeBot,
+			Kubernetes: scopedjoiningv1.Kubernetes_builder{
+				Allow: []*scopedjoiningv1.Kubernetes_Rule{
+					scopedjoiningv1.Kubernetes_Rule_builder{
+						ServiceAccount: testNamespace + ":" + testServiceAccount,
+					}.Build(),
+				},
+				Type:       string(types.KubernetesJoinTypeStaticJWKS),
+				StaticJwks: scopedjoiningv1.Kubernetes_StaticJWKSConfig_builder{Jwks: jwks}.Build(),
+			}.Build(),
+			Bot:   scopes.QualifiedName{Scope: testRootScope, Name: testBotName}.String(),
+			Roles: []string{string(types.RoleBot)},
+		}.Build(),
+	}.Build()
+	// Somehow the admin client interface doesn't expose CreateScopedToken ¯\_(ツ)_/¯
+	// We use the auth server directly to create the scoped token.
+	_, err = teleportServer.Process.GetAuthServer().CreateScopedToken(ctx, &scopedjoiningv1.CreateScopedTokenRequest{
+		Token: token,
+	})
+	require.NoError(t, err)
+
+	// Test setup: Configure the bot to join the auth using the scoped join token and the JWT.
+	authAddr, err := teleportServer.Process.AuthAddr()
+	require.NoError(t, err)
+	botConfig := &BotConfig{
+		AuthServer: authAddr.Addr,
+		Onboarding: onboarding.Config{
+			TokenValue: testTokenName,
+			JoinMethod: types.JoinMethodKubernetes,
+			Kubernetes: onboarding.KubernetesOnboardingConfig{
+				TokenPath: tokenPath,
+			},
+		},
+		CredentialLifetime: bot.CredentialLifetime{
+			TTL:             defaultCertificateTTL,
+			RenewalInterval: defaultRenewalInterval,
+		},
+		Scoped: true,
+	}
+
+	// Test execution: Run the bot, make it join the cluster and yield credentials.
+	embeddedBot, err := New(botConfig, logger)
+	require.NoError(t, err)
+	pong, err := embeddedBot.Preflight(ctx)
+	require.NoError(t, err)
+	require.Equal(t, clusterName, pong.ClusterName)
+
+	botClient, err := embeddedBot.StartAndWaitForClient(ctx, 10*time.Second)
+	require.NoError(t, err)
+
+	// Test validation: check if the bot produced a valid client.
+	botPong, err := botClient.Ping(ctx)
+	require.NoError(t, err)
+	require.Equal(t, clusterName, botPong.ClusterName)
+
+	_, err = botClient.ScopedAccessServiceClient().GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
+		Name: testBotRole,
+	})
+	require.NoError(t, err)
 }

--- a/integrations/lib/embeddedtbot/config.go
+++ b/integrations/lib/embeddedtbot/config.go
@@ -42,6 +42,8 @@ type BotConfig struct {
 	Onboarding         onboarding.Config
 	CredentialLifetime bot.CredentialLifetime
 	Insecure           bool
+	// Scoped represents if the bot uses a scoped token to join (and gets a scoped identity).
+	Scoped bool
 }
 
 // BindFlags binds BotConfig fields to CLI flags.

--- a/integrations/terraform/examples/provider/scoped-provider-role.yaml
+++ b/integrations/terraform/examples/provider/scoped-provider-role.yaml
@@ -1,0 +1,22 @@
+version: v1
+kind: scoped_role
+metadata:
+  name: terraform-provider
+scope: "/"
+spec:
+  assignable_scopes: ["/**"]
+  rules:
+    - resources: ["scoped_role", "scoped_role_assignment", "bot"]
+      verbs:
+        - list
+        - create
+        - readnosecrets
+        - update
+        - delete
+    - resources: ["scoped_token"]
+      verbs:
+        - list
+        - create
+        - read
+        - update
+        - delete

--- a/integrations/terraform/provider/credentials.go
+++ b/integrations/terraform/provider/credentials.go
@@ -528,6 +528,9 @@ See https://goteleport.com/docs/reference/join-methods for more details.`)
 			Gitlab: onboarding.GitlabOnboardingConfig{
 				TokenEnvVarName: gitlabIDTokenEnvVar,
 			},
+			Kubernetes: onboarding.KubernetesOnboardingConfig{
+				TokenPath: config.KubernetesTokenPath.Value,
+			},
 		},
 		CredentialLifetime: bot.CredentialLifetime{
 			TTL:             time.Hour,

--- a/integrations/terraform/provider/credentials.go
+++ b/integrations/terraform/provider/credentials.go
@@ -490,6 +490,7 @@ func (CredentialsFromNativeMachineID) Credentials(ctx context.Context, config pr
 	caPath := stringFromConfigOrEnv(config.RootCaPath, constants.EnvVarTerraformRootCertificates, "")
 	gitlabIDTokenEnvVar := stringFromConfigOrEnv(config.GitlabIDTokenEnvVar, constants.EnvVarGitlabIDTokenEnvVar, "")
 	insecure := boolFromConfigOrEnv(config.Insecure, constants.EnvVarTerraformInsecure)
+	scoped := boolFromConfigOrEnv(config.Scoped, constants.EnvVarTerraformScoped)
 
 	if joinMethod == "" {
 		return nil, trace.BadParameter("missing parameter %q or environment variable %q", attributeTerraformJoinMethod, constants.EnvVarTerraformJoinMethod)
@@ -537,6 +538,7 @@ See https://goteleport.com/docs/reference/join-methods for more details.`)
 			RenewalInterval: 20 * time.Minute,
 		},
 		Insecure: insecure,
+		Scoped:   scoped,
 	}
 	// slog default logger has been configured during the provider init.
 	bot, err := embeddedtbot.New(botConfig, slog.Default())

--- a/integrations/terraform/provider/provider.go
+++ b/integrations/terraform/provider/provider.go
@@ -104,6 +104,10 @@ const (
 	// When unset, the join client will try the `KUBERNETES_TOKEN_PATH` env var, else it will use the standard location:
 	// "/var/run/secrets/kubernetes.io/serviceaccount/token".
 	attributeKubernetesTokenPath = "kubernetes_token_path"
+	// attributeScoped indicates that the Terraform Operator will join with a scoped token.
+	// This only takes effect when the operator performs native MachineID joining
+	// (i.e. join method and join token are specified). This must be set when using a scoped join token.
+	attributeScoped = "scoped"
 )
 
 type RetryConfig struct {
@@ -171,6 +175,10 @@ type providerData struct {
 	// When unset, the join client will try the `KUBERNETES_TOKEN_PATH` env var, else it will use the standard location:
 	// "/var/run/secrets/kubernetes.io/serviceaccount/token".
 	KubernetesTokenPath types.String `tfsdk:"kubernetes_token_path"`
+	// Scoped indicates that the Terraform Operator will join with a scoped token.
+	// This only takes effect when the operator performs native MachineID joining
+	// (i.e. join method and join token are specified). This must be set when using a scoped join token.
+	Scoped types.Bool `tfsdk:"scoped"`
 }
 
 // New returns an empty provider struct
@@ -303,6 +311,12 @@ func (p *Provider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics)
 				Sensitive:   false,
 				Optional:    true,
 				Description: "KubernetesTokenPath configures the Kubernetes token location when joining using MachineID and the `kubernetes` join method. When unset, the join client will try the `KUBERNETES_TOKEN_PATH` env var, else it will use the standard location: `/var/run/secrets/kubernetes.io/serviceaccount/token`.",
+			},
+			attributeScoped: {
+				Type:        types.BoolType,
+				Sensitive:   false,
+				Optional:    true,
+				Description: fmt.Sprintf("Scoped indicates that the Terraform Operator will join with a scoped token. This only takes effect when the operator performs native MachineID joining (i.e. join method and join token are specified). This must be set when using a scoped join token. This can also be set with the environment variable `%s`", constants.EnvVarTerraformScoped),
 			},
 		},
 	}, nil

--- a/integrations/terraform/provider/provider.go
+++ b/integrations/terraform/provider/provider.go
@@ -100,6 +100,10 @@ const (
 	// attributeTerraformGitlabIDTokenEnvVar is the attribute configuring the environment variable used to fetch the ID
 	// token issued by GitLab for the `gitlab` join method. If unset, this defaults to `TBOT_GITLAB_JWT`.
 	attributeTerraformGitlabIDTokenEnvVar = "gitlab_id_token_env_var"
+	// attributeKubernetesTokenPath configures the Kubernetes token location when joining using MachineID and the `kubernetes` join method.
+	// When unset, the join client will try the `KUBERNETES_TOKEN_PATH` env var, else it will use the standard location:
+	// "/var/run/secrets/kubernetes.io/serviceaccount/token".
+	attributeKubernetesTokenPath = "kubernetes_token_path"
 )
 
 type RetryConfig struct {
@@ -163,6 +167,10 @@ type providerData struct {
 	// defaults to `TBOT_GITLAB_JWT`. Useful in cases where multiple Teleport
 	// clusters are managed by the same GitLab job.
 	GitlabIDTokenEnvVar types.String `tfsdk:"gitlab_id_token_env_var"`
+	// KubernetesTokenPath configures the Kubernetes token location when joining using MachineID and the `kubernetes` join method.
+	// When unset, the join client will try the `KUBERNETES_TOKEN_PATH` env var, else it will use the standard location:
+	// "/var/run/secrets/kubernetes.io/serviceaccount/token".
+	KubernetesTokenPath types.String `tfsdk:"kubernetes_token_path"`
 }
 
 // New returns an empty provider struct
@@ -289,6 +297,12 @@ func (p *Provider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics)
 				Sensitive:   false,
 				Optional:    true,
 				Description: fmt.Sprintf("Environment variable used to fetch the ID token issued by GitLab for the `gitlab` join method. If unset, this defaults to `TBOT_GITLAB_JWT`. This can also be set with the environment variable `%s`.", constants.EnvVarGitlabIDTokenEnvVar),
+			},
+			attributeKubernetesTokenPath: {
+				Type:        types.StringType,
+				Sensitive:   false,
+				Optional:    true,
+				Description: "KubernetesTokenPath configures the Kubernetes token location when joining using MachineID and the `kubernetes` join method. When unset, the join client will try the `KUBERNETES_TOKEN_PATH` env var, else it will use the standard location: `/var/run/secrets/kubernetes.io/serviceaccount/token`.",
 			},
 		},
 	}, nil

--- a/integrations/terraform/testlib/machineid_join_test.go
+++ b/integrations/terraform/testlib/machineid_join_test.go
@@ -35,7 +35,6 @@ import (
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integrations/lib/testing/integration"
-	kubetoken "github.com/gravitational/teleport/lib/kube/token"
 	"github.com/gravitational/teleport/lib/oidc/fakeissuer"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
@@ -119,7 +118,6 @@ func TestTerraformJoin(t *testing.T) {
 	tempDir := t.TempDir()
 	jwtPath := filepath.Join(tempDir, "token")
 	require.NoError(t, os.WriteFile(jwtPath, []byte(jwt), 0600))
-	require.NoError(t, os.Setenv(kubetoken.EnvVarCustomKubernetesTokenPath, jwtPath))
 
 	// Test setup: craft a Terraform provider configuration
 	terraformConfig := fmt.Sprintf(`
@@ -130,8 +128,9 @@ func TestTerraformJoin(t *testing.T) {
 			retry_base_duration = "900ms"
 			retry_cap_duration = "4s"
 			retry_max_tries = "12"
+			kubernetes_token_path = %q
 		}
-	`, authHelper.ServerAddr(), testTokenName, types.JoinMethodKubernetes)
+	`, authHelper.ServerAddr(), testTokenName, types.JoinMethodKubernetes, jwtPath)
 
 	terraformProvider := provider.New()
 	terraformProviders := make(map[string]func() (tfprotov6.ProviderServer, error))
@@ -247,7 +246,6 @@ func TestTerraformJoinViaProxy(t *testing.T) {
 	tempDir := t.TempDir()
 	jwtPath := filepath.Join(tempDir, "token")
 	require.NoError(t, os.WriteFile(jwtPath, []byte(jwt), 0600))
-	require.NoError(t, os.Setenv(kubetoken.EnvVarCustomKubernetesTokenPath, jwtPath))
 
 	// Test setup: craft a Terraform provider configuration
 	proxyAddr, err := process.ProxyTunnelAddr()
@@ -262,8 +260,9 @@ func TestTerraformJoinViaProxy(t *testing.T) {
 			retry_base_duration = "900ms"
 			retry_cap_duration = "4s"
 			retry_max_tries = "12"
+			kubernetes_token_path = %q
 		}
-	`, proxyAddr, testTokenName, types.JoinMethodKubernetes)
+	`, proxyAddr, testTokenName, types.JoinMethodKubernetes, jwtPath)
 
 	terraformProvider := provider.New()
 	terraformProviders := make(map[string]func() (tfprotov6.ProviderServer, error))

--- a/integrations/terraform/testlib/machineid_join_test.go
+++ b/integrations/terraform/testlib/machineid_join_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/jonboulle/clockwork"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
@@ -38,6 +37,7 @@ import (
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	scopedjoiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/wait"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/integrations/lib/testing/integration"
 	"github.com/gravitational/teleport/lib/oidc/fakeissuer"
@@ -460,8 +460,8 @@ func TestTerraformJoinScoped(t *testing.T) {
 
 	// Test setup: Wait for the role assignment to enter the auth server cache
 	// else the bot will race against the cache, joining will fail and the test wil be flaky.
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		resp, err := adminClient.ScopedAccessServiceClient().GetScopedRoleAssignment(
+	resp, err := wait.UntilFound(ctx, func(ctx context.Context) (*scopedaccessv1.GetScopedRoleAssignmentResponse, error) {
+		return adminClient.ScopedAccessServiceClient().GetScopedRoleAssignment(
 			ctx,
 			scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
 				Name:    testBotRole,
@@ -469,10 +469,10 @@ func TestTerraformJoinScoped(t *testing.T) {
 				SubKind: scopedaccess.SubKindDynamic,
 			}.Build(),
 		)
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		require.NotNil(t, resp.GetAssignment())
-	}, 5*time.Second, 100*time.Millisecond, "expected role assignment to enter the auth cache")
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.GetAssignment())
 
 	// Test setup: Create a fake Kubernetes JWKS signer that will be used by the bot to join the cluster.
 	const (

--- a/integrations/terraform/testlib/machineid_join_test.go
+++ b/integrations/terraform/testlib/machineid_join_test.go
@@ -24,19 +24,30 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopedjoiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/integrations/lib/testing/integration"
 	"github.com/gravitational/teleport/lib/oidc/fakeissuer"
+	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	scopedjoining "github.com/gravitational/teleport/lib/scopes/joining"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 
 	"github.com/gravitational/teleport/integrations/terraform/provider"
@@ -296,4 +307,286 @@ func TestTerraformJoinViaProxy(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestTerraformJoinScoped(t *testing.T) {
+	require.NoError(t, os.Setenv("TF_ACC", "true"))
+
+	t.Parallel()
+	// Test setup: Configure and start Teleport server
+	clusterName := "root.example.com"
+	logger := logtest.NewLogger()
+	ctx := t.Context()
+
+	teleportServer := helpers.NewInstance(t, helpers.InstanceConfig{
+		ClusterName: clusterName,
+		HostID:      uuid.New().String(),
+		NodeName:    helpers.Loopback,
+		Logger:      logger,
+	})
+
+	// Test setup: building an admin user and role that will be used to create fixtures.
+	const adminUserName = "admin"
+	adminRole, err := types.NewRole("admin", types.RoleSpecV6{
+		Options: types.RoleOptions{},
+		Allow: types.RoleConditions{
+			Rules: []types.Rule{
+				{
+					Resources: []string{types.KindUser, types.KindRole, scopedaccess.KindScopedToken, scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment, types.KindBot},
+					Verbs:     []string{types.VerbRead, types.VerbCreate, types.VerbDelete, types.VerbList, types.VerbUpdate},
+				},
+			},
+		},
+		Deny: types.RoleConditions{},
+	})
+	require.NoError(t, err)
+	teleportServer.AddUserWithRole(adminUserName, adminRole)
+
+	// Test setup: starting the Teleport instance
+	rcConf := servicecfg.MakeDefaultConfig()
+	rcConf.DataDir = t.TempDir()
+	rcConf.ScopesFeatures = scopes.Features{Enabled: true}
+	rcConf.Auth.Enabled = true
+	rcConf.Proxy.Enabled = true
+	rcConf.Proxy.DisableWebInterface = true
+	rcConf.SSH.Enabled = false
+	rcConf.Version = "v3"
+
+	require.NoError(t, teleportServer.CreateEx(t, nil, rcConf))
+
+	require.NoError(t, teleportServer.Start())
+	t.Cleanup(func() { _ = teleportServer.StopAll() })
+
+	// Test setup: Building an admin client.
+	// Note: this is very convoluted but the bot service is not stored in the auth server struct and cannot be accessed
+	// without a rpc client.
+	adminCreds, err := helpers.GenerateUserCreds(helpers.UserCredsRequest{
+		Process:  teleportServer.Process,
+		Username: "admin",
+	})
+	require.NoError(t, err)
+	clt, err := teleportServer.NewClientWithCreds(
+		helpers.ClientConfig{
+			TeleportUser: adminUserName,
+			Login:        adminUserName,
+			Cluster:      clusterName,
+		},
+		*adminCreds,
+	)
+	require.NoError(t, err)
+
+	clusterClient, err := clt.ConnectToCluster(ctx)
+	require.NoError(t, err)
+	adminClient, err := clusterClient.ConnectToCluster(ctx, clusterName)
+	require.NoError(t, err)
+	// Validate that the admin client works.
+	adminPong, err := adminClient.Ping(ctx)
+	require.NoError(t, err)
+	require.Equal(t, clusterName, adminPong.ClusterName)
+
+	// Test setup: Create all the scoped resources describing a scoped bot, and its RBAC.
+	const (
+		// must match the `scoped_token_0_create.tf` fixture's scope
+		testRootScope = "/staging"
+		testBotRole   = "scoped-role"
+		testBotName   = "test-bot"
+		testTokenName = "test-token"
+	)
+
+	// Role impersonated by the bot.
+	botRole := scopedaccessv1.ScopedRole_builder{
+		Kind:    scopedaccess.KindScopedRole,
+		Version: types.V1,
+		Metadata: headerv1.Metadata_builder{
+			Name: testBotRole,
+		}.Build(),
+		Scope: testRootScope,
+		Spec: scopedaccessv1.ScopedRoleSpec_builder{
+			AssignableScopes: []string{testRootScope},
+			Rules: []*scopedaccessv1.ScopedRule{
+				scopedaccessv1.ScopedRule_builder{
+					Resources: []string{scopedaccess.KindScopedToken},
+					Verbs:     []string{types.VerbReadNoSecrets, types.VerbList, types.VerbUpdate, types.VerbCreate, types.VerbDelete, types.VerbRead},
+				}.Build(),
+			},
+		}.Build(),
+	}.Build()
+	require.NoError(t, scopedaccess.StrongValidateRole(botRole), "malformed role, this is a bug in the test fixture")
+	_, err = adminClient.ScopedAccessServiceClient().CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+		Role: botRole,
+	}.Build())
+	require.NoError(t, err)
+
+	// Create the bot.
+	botResource := machineidv1.Bot_builder{
+		Kind:    types.KindBot,
+		Version: types.V1,
+		Metadata: headerv1.Metadata_builder{
+			Name: testBotName,
+		}.Build(),
+		Spec:  &machineidv1.BotSpec{},
+		Scope: testRootScope,
+	}.Build()
+	_, err = adminClient.BotServiceClient().CreateBot(ctx, machineidv1.CreateBotRequest_builder{
+		Bot: botResource,
+	}.Build())
+	require.NoError(t, err)
+
+	// Assign role to bot
+	roleAssignment := scopedaccessv1.ScopedRoleAssignment_builder{
+		Kind:    scopedaccess.KindScopedRoleAssignment,
+		SubKind: scopedaccess.SubKindDynamic,
+		Version: types.V1,
+		Metadata: headerv1.Metadata_builder{
+			Name: testBotRole,
+		}.Build(),
+		Scope: testRootScope,
+		Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+			Assignments: []*scopedaccessv1.Assignment{
+				scopedaccessv1.Assignment_builder{
+					Role:  scopes.QualifiedName{Name: testBotRole, Scope: testRootScope}.String(),
+					Scope: testRootScope,
+				}.Build(),
+			},
+			Bot: scopes.QualifiedName{Scope: testRootScope, Name: testBotName}.String(),
+		}.Build(),
+	}.Build()
+	_, err = adminClient.ScopedAccessServiceClient().CreateScopedRoleAssignment(
+		ctx,
+		scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
+			Assignment: roleAssignment,
+		}.Build())
+	require.NoError(t, err)
+
+	// Test setup: Wait for the role assignment to enter the auth server cache
+	// else the bot will race against the cache, joining will fail and the test wil be flaky.
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		resp, err := adminClient.ScopedAccessServiceClient().GetScopedRoleAssignment(
+			ctx,
+			scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
+				Name:    testBotRole,
+				Scope:   testRootScope,
+				SubKind: scopedaccess.SubKindDynamic,
+			}.Build(),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.NotNil(t, resp.GetAssignment())
+	}, 5*time.Second, 100*time.Millisecond, "expected role assignment to enter the auth cache")
+
+	// Test setup: Create a fake Kubernetes JWKS signer that will be used by the bot to join the cluster.
+	const (
+		testPod            = "my-pod"
+		testNamespace      = "my-namespace"
+		testServiceAccount = "my-service-account"
+	)
+	signer, err := fakeissuer.NewKubernetesSigner(clockwork.NewRealClock())
+	require.NoError(t, err)
+	jwks, err := signer.GetMarshaledJWKS()
+	require.NoError(t, err)
+	jwt, err := signer.SignServiceAccountJWT(testPod, testNamespace, testServiceAccount, clusterName)
+	require.NoError(t, err)
+
+	tokenDir := t.TempDir()
+	tokenPath := filepath.Join(tokenDir, "token")
+	require.NoError(t, os.WriteFile(tokenPath, []byte(jwt), 0600))
+
+	// Test setup: Create the scoped token allowing the Bot to join with a JWT emitted by the Kube signer.
+	token := scopedjoiningv1.ScopedToken_builder{
+		Kind:     scopedaccess.KindScopedToken,
+		Version:  types.V1,
+		Metadata: headerv1.Metadata_builder{Name: testTokenName}.Build(),
+		Scope:    testRootScope,
+		Spec: scopedjoiningv1.ScopedTokenSpec_builder{
+			JoinMethod: string(types.JoinMethodKubernetes),
+			UsageMode:  scopedjoining.TokenUsageModeBot,
+			Kubernetes: scopedjoiningv1.Kubernetes_builder{
+				Allow: []*scopedjoiningv1.Kubernetes_Rule{
+					scopedjoiningv1.Kubernetes_Rule_builder{
+						ServiceAccount: testNamespace + ":" + testServiceAccount,
+					}.Build(),
+				},
+				Type:       string(types.KubernetesJoinTypeStaticJWKS),
+				StaticJwks: scopedjoiningv1.Kubernetes_StaticJWKSConfig_builder{Jwks: jwks}.Build(),
+			}.Build(),
+			Bot:   scopes.QualifiedName{Scope: testRootScope, Name: testBotName}.String(),
+			Roles: []string{string(types.RoleBot)},
+		}.Build(),
+	}.Build()
+	// Somehow the admin client interface doesn't expose CreateScopedToken ¯\_(ツ)_/¯
+	// We use the auth server directly to create the scoped token.
+	_, err = teleportServer.Process.GetAuthServer().CreateScopedToken(ctx, scopedjoiningv1.CreateScopedTokenRequest_builder{
+		Token: token,
+	}.Build())
+	require.NoError(t, err)
+
+	authAddr, err := teleportServer.Process.AuthAddr()
+	require.NoError(t, err)
+	proxyAddr, err := teleportServer.Process.ProxyWebAddr()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		addr *utils.NetAddr
+	}{
+		{
+			name: "join via auth",
+			addr: authAddr,
+		},
+		{
+			name: "join via proxy",
+			addr: proxyAddr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			terraformConfig := fmt.Sprintf(`
+		provider "teleport" {
+			addr = %q
+			join_token = %q
+			join_method = %q
+			insecure = true
+			retry_base_duration = "900ms"
+			retry_cap_duration = "4s"
+			retry_max_tries = "12"
+			kubernetes_token_path = %q
+			scoped = true
+		}
+	`, tt.addr, testTokenName, types.JoinMethodKubernetes, tokenPath)
+
+			terraformProvider := provider.New()
+			terraformProviders := make(map[string]func() (tfprotov6.ProviderServer, error))
+			terraformProviders["teleport"] = func() (tfprotov6.ProviderServer, error) {
+				// Terraform configures provider on every test step, but does not clean up previous one, which produces
+				// to "too many open files" at some point.
+				//
+				// With this statement we try to forcefully close previously opened client, which stays cached in
+				// the provider variable.
+				p, ok := terraformProvider.(*provider.Provider)
+				require.True(t, ok)
+				require.NoError(t, p.Close())
+				return providerserver.NewProtocol6(terraformProvider)(), nil
+			}
+
+			// Test execution: apply a TF resource with the provider joining via MachineID
+			dummyResource, err := fixtures.ReadFile(filepath.Join("fixtures", "scoped_token_0_create.tf"))
+			require.NoError(t, err)
+			testConfig := terraformConfig + "\n" + string(dummyResource)
+			name := "teleport_scoped_token.test"
+
+			resource.Test(t, resource.TestCase{
+				ProtoV6ProviderFactories: terraformProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: testConfig,
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckResourceAttr(name, "kind", "scoped_token"),
+							resource.TestCheckResourceAttr(name, "spec.join_method", "token"),
+						),
+					},
+				},
+			})
+		})
+	}
 }

--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -203,6 +203,10 @@ type RegisterParams struct {
 	// Register method will not attempt to dial, and many other parameters
 	// may be ignored.
 	AuthClient AuthJoinClient
+	// KubernetesTokenPath is the optional path that used to lookup the Kubernetes service account token for joining.
+	// When unset, the join client will try the `KUBERNETES_TOKEN_PATH` env var, else it will use the standard location:
+	// "/var/run/secrets/kubernetes.io/serviceaccount/token".
+	KubernetesTokenPath string
 	// KubernetesReadFileFunc is a function used to read the Kubernetes token
 	// from disk. Used in tests, and set to `os.ReadFile` if unset.
 	KubernetesReadFileFunc func(name string) ([]byte, error)
@@ -397,7 +401,7 @@ func Register(ctx context.Context, params RegisterParams) (result *RegisterResul
 		}
 	case types.JoinMethodKubernetes:
 		if params.IDToken == "" {
-			params.IDToken, err = kubetoken.GetIDToken(os.Getenv, params.KubernetesReadFileFunc)
+			params.IDToken, err = kubetoken.GetIDToken(params.KubernetesTokenPath, os.Getenv, params.KubernetesReadFileFunc)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}

--- a/lib/join/joinclient/join.go
+++ b/lib/join/joinclient/join.go
@@ -465,7 +465,7 @@ func joinWithMethod(
 		return oidcJoin(stream, joinParams, clientParams)
 	case types.JoinMethodKubernetes:
 		if joinParams.IDToken == "" {
-			joinParams.IDToken, err = kubetoken.GetIDToken(os.Getenv, joinParams.KubernetesReadFileFunc)
+			joinParams.IDToken, err = kubetoken.GetIDToken(joinParams.KubernetesTokenPath, os.Getenv, joinParams.KubernetesReadFileFunc)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}

--- a/lib/kube/token/source.go
+++ b/lib/kube/token/source.go
@@ -32,12 +32,12 @@ const (
 type getEnvFunc func(key string) string
 type readFileFunc func(name string) ([]byte, error)
 
-func GetIDToken(getEnv getEnvFunc, readFile readFileFunc) (string, error) {
-	// We check if we should use a custom location instead of the default one. This env var is not standard.
-	// This is useful when the operator wants to use a custom projected token, or another service account.
+func GetIDToken(customPath string, getEnv getEnvFunc, readFile readFileFunc) (string, error) {
 	path := kubernetesDefaultTokenPath
-	if customPath := getEnv(EnvVarCustomKubernetesTokenPath); customPath != "" {
+	if customPath != "" {
 		path = customPath
+	} else if envPath := getEnv(EnvVarCustomKubernetesTokenPath); envPath != "" {
+		path = envPath
 	}
 
 	token, err := readFile(path)

--- a/lib/kube/token/source_test.go
+++ b/lib/kube/token/source_test.go
@@ -58,6 +58,7 @@ func TestGetIDToken(t *testing.T) {
 		name        string
 		getEnv      getEnvFunc
 		readFile    readFileFunc
+		customPath  string
 		wantString  string
 		assertError require.ErrorAssertionFunc
 	}{
@@ -91,11 +92,19 @@ func TestGetIDToken(t *testing.T) {
 				require.ErrorContains(t, err, "/custom: no such file")
 			},
 		},
+		{
+			name:        "custom-token-via-path",
+			getEnv:      nil, // should not be called
+			readFile:    fakeReadFile("foobarbizz", "/custom"),
+			customPath:  "/custom",
+			wantString:  "foobarbizz",
+			assertError: require.NoError,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(t.Name(), func(t *testing.T) {
-			str, err := GetIDToken(tt.getEnv, tt.readFile)
+			str, err := GetIDToken(tt.customPath, tt.getEnv, tt.readFile)
 			require.Equal(t, tt.wantString, str)
 			tt.assertError(t, err)
 		})

--- a/lib/tbot/bot/onboarding/config.go
+++ b/lib/tbot/bot/onboarding/config.go
@@ -191,6 +191,14 @@ func (c *BoundKeypairOnboardingConfig) StaticPrivateKeyBytes() ([]byte, error) {
 	return nil, nil
 }
 
+// KubernetesOnboardingConfig holds configuration relevant to the `kubernetes` join method.
+type KubernetesOnboardingConfig struct {
+	// TokenPath is the optional path that tbot uses to lookup the Kubernetes service account token used to join.
+	// When unset, the join client will try the `KUBERNETES_TOKEN_PATH` env var, else it will use the standard location:
+	// "/var/run/secrets/kubernetes.io/serviceaccount/token".
+	TokenPath string `yaml:"token_path,omitempty"`
+}
+
 // GenericOIDCOnboardingConfig contains configuration relevant to the
 // `generic_oidc` join method.
 type GenericOIDCOnboardingConfig struct {
@@ -238,12 +246,15 @@ type Config struct {
 	// Gitlab holds configuration relevant to the `gitlab` join method.
 	Gitlab GitlabOnboardingConfig `yaml:"gitlab,omitempty"`
 
-	// BoundKeypair holds configuration relevant to the `bound_keypair` join method
+	// BoundKeypair holds configuration relevant to the `bound_keypair` join method.
 	BoundKeypair BoundKeypairOnboardingConfig `yaml:"bound_keypair,omitempty"`
 
 	// GenericOIDC contains configuration relevant to the `generic_oidc` join
 	// method.
 	GenericOIDC GenericOIDCOnboardingConfig `yaml:"generic_oidc,omitempty"`
+
+	// Kubernetes holds the configuration relevant to the `kubernetes` join method.
+	Kubernetes KubernetesOnboardingConfig `yaml:"kubernetes,omitempty"`
 }
 
 // HasToken gives the ability to check if there has been a token value stored

--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -812,6 +812,8 @@ func botIdentityFromToken(
 		if err != nil {
 			return nil, trace.Wrap(err, "initializing bound keypair client state")
 		}
+	case types.JoinMethodKubernetes:
+		params.KubernetesTokenPath = cfg.Onboarding.Kubernetes.TokenPath
 	case types.JoinMethodGenericOIDC:
 		params.GenericOIDCParams = join.GenericOIDCParams{
 			EnvVarName: cfg.Onboarding.GenericOIDC.Env,

--- a/lib/tbot/services/clientcredentials/config.go
+++ b/lib/tbot/services/clientcredentials/config.go
@@ -152,8 +152,8 @@ func (o *UnstableConfig) SetOrUpdateFacade(id *identity.Identity) {
 
 // CheckAndSetDefaults checks and sets default values for the configuration.
 func (o *UnstableConfig) CheckAndSetDefaults(scoped bool) error {
-	if scoped {
-		return trace.BadParameter("service type %q is not supported in scoped mode", ServiceType)
+	if scoped && o.DelegationSessionID != "" {
+		return trace.BadParameter("Delegation session ID is not supported in scoped mode")
 	}
 	return nil
 }

--- a/lib/tbot/services/clientcredentials/service.go
+++ b/lib/tbot/services/clientcredentials/service.go
@@ -51,6 +51,7 @@ func ServiceBuilder(cfg *UnstableConfig, credentialLifetime bot.CredentialLifeti
 			identityGenerator:  deps.IdentityGenerator,
 			log:                deps.Logger,
 			statusReporter:     deps.GetStatusReporter(),
+			scoped:             deps.Scoped,
 		}
 		return svc, nil
 	}
@@ -87,6 +88,7 @@ type Service struct {
 	statusReporter     readyz.Reporter
 	reloadCh           <-chan struct{}
 	identityGenerator  *identity.Generator
+	scoped             bool
 }
 
 func (s *Service) String() string {
@@ -97,14 +99,21 @@ func (s *Service) String() string {
 }
 
 func (s *Service) OneShot(ctx context.Context) error {
+	if s.scoped {
+		return s.generateScoped(ctx)
+	}
 	return s.generate(ctx)
 }
 
 func (s *Service) Run(ctx context.Context) error {
+	f := s.generate
+	if s.scoped {
+		f = s.generateScoped
+	}
 	err := internal.RunOnInterval(ctx, internal.RunOnIntervalConfig{
 		Service:         s.String(),
 		Name:            "output-renewal",
-		F:               s.generate,
+		F:               f,
 		Interval:        s.credentialLifetime.RenewalInterval,
 		RetryLimit:      internal.RenewalRetryLimit,
 		Log:             s.log,
@@ -133,6 +142,23 @@ func (s *Service) generate(ctx context.Context) error {
 	id, err := s.identityGenerator.Generate(ctx, opts...)
 	if err != nil {
 		return trace.Wrap(err, "generating identity")
+	}
+
+	s.cfg.SetOrUpdateFacade(id)
+	return nil
+}
+
+func (s *Service) generateScoped(ctx context.Context) error {
+	ctx, span := tracer.Start(
+		ctx,
+		"Service/generateScoped",
+	)
+	defer span.End()
+	s.log.InfoContext(ctx, "Generating scoped output")
+
+	id, err := s.identityGenerator.GenerateScoped(ctx, s.credentialLifetime.TTL, s.credentialLifetime.RenewalInterval)
+	if err != nil {
+		return trace.Wrap(err, "generating scoped identity")
 	}
 
 	s.cfg.SetOrUpdateFacade(id)

--- a/tool/tctl/common/terraform_command.go
+++ b/tool/tctl/common/terraform_command.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -36,12 +37,18 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopedjoiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/identityfile"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/common"
+	"github.com/gravitational/teleport/api/utils/wait"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	scopedjoining "github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
@@ -57,6 +64,7 @@ import (
 )
 
 const (
+	terraformScopedRoleDefault           = "/::" + teleport.PresetTerraformProviderRoleName
 	terraformHelperDefaultResourcePrefix = "tctl-terraform-env-"
 	terraformHelperDefaultTTL            = "1h"
 
@@ -75,6 +83,7 @@ type TerraformCommand struct {
 	resourcePrefix string
 	existingRole   string
 	botTTL         time.Duration
+	scope          string
 
 	cfg *servicecfg.Config
 
@@ -105,6 +114,10 @@ func (c *TerraformCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 		"role",
 		fmt.Sprintf("Role used by Terraform. The role must already exist in Teleport. When not specified, uses the default role %q", teleport.PresetTerraformProviderRoleName),
 	).StringVar(&c.existingRole)
+	c.envCmd.Flag(
+		"scope",
+		"Scope of the bot used by the Terraform provider. When empty, TF provider runs unscoped.",
+	).StringVar(&c.scope)
 
 	// Save a pointer to the config to be able to recover the Debug config later
 	c.cfg = cfg
@@ -163,46 +176,93 @@ func (c *TerraformCommand) RunEnvCommand(ctx context.Context, client *authclient
 		return trace.Wrap(err)
 	}
 
-	// Checking Terraform role
-	roleName, err := c.checkIfRoleExists(ctx, client)
-	if err != nil {
-		switch {
-		case trace.IsNotFound(err) && c.existingRole == "":
-			return trace.Wrap(err, `The Terraform role %q does not exist in your Teleport cluster.
+	var onboard onboarding.Config
+	scoped := c.scope != ""
+
+	if scoped {
+		// We are running in a scope.
+		roleSQN, err := c.checkIfScopedRoleExists(ctx, client.ScopedAccessServiceClient())
+		if err != nil {
+			if !trace.IsAccessDenied(err) {
+				return trace.Wrap(err, "checking if scoped role exists")
+			}
+			// We currently have no way for a scoped user to look into the assignable roles from parent scopes.
+			// So this check is likely to fail, even if the role exists.
+			// This should be revisited once we have an API to list such assignable parent roles.
+		}
+
+		token, assignment, err := c.createTransientScopedBotAndToken(ctx, client, roleSQN)
+		if err != nil {
+			return trace.Wrap(err, "creating transient scoped bot, token, and assigning role")
+		}
+
+		defer func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if _, err := client.ScopedAccessServiceClient().DeleteScopedRoleAssignment(ctx, scopedaccessv1.DeleteScopedRoleAssignmentRequest_builder{
+				Name:     assignment.GetMetadata().GetName(),
+				Revision: assignment.GetMetadata().GetRevision(),
+				SubKind:  assignment.GetSubKind(),
+				Scope:    assignment.GetScope(),
+			}.Build()); err != nil {
+				c.showProgress(fmt.Sprintf("🚨 Failed to cleanup scoped role assignment %q", assignment.GetMetadata().GetName()))
+			}
+			cancel()
+		}()
+
+		onboard = onboarding.Config{
+			TokenValue: token.GetMetadata().GetName(),
+			JoinMethod: types.JoinMethodBoundKeypair,
+			BoundKeypair: onboarding.BoundKeypairOnboardingConfig{
+				RegistrationSecretValue: token.GetStatus().GetUsage().GetBoundKeypair().GetRegistrationSecret(),
+			},
+		}
+	} else {
+		// We are running unscoped.
+		// Checking Terraform role
+		roleName, err := c.checkIfRoleExists(ctx, client)
+		if err != nil {
+			switch {
+			case trace.IsNotFound(err) && c.existingRole == "":
+				return trace.Wrap(err, `The Terraform role %q does not exist in your Teleport cluster.
 This default role is included in Teleport clusters whose version is higher than v16.1 or v17.
 If you want to use "tctl terraform env" against an older Teleport cluster, you must create the Terraform role
 yourself and set the flag --role <your-terraform-role-name>.`, roleName)
-		case trace.IsNotFound(err) && c.existingRole != "":
-			return trace.Wrap(err, `The Terraform role %q specified with --role does not exist in your Teleport cluster.
+			case trace.IsNotFound(err) && c.existingRole != "":
+				return trace.Wrap(err, `The Terraform role %q specified with --role does not exist in your Teleport cluster.
 Please check that the role exists in the cluster.`, roleName)
-		case trace.IsAccessDenied(err):
-			return trace.Wrap(err, `Failed to validate if the role %q exists.
+			case trace.IsAccessDenied(err):
+				return trace.Wrap(err, `Failed to validate if the role %q exists.
 To use the "tctl terraform env" command you must have rights to list and read Teleport roles.
 If you got a role granted recently, you might have to run "tsh logout" and login again.`, roleName)
-		default:
-			return trace.Wrap(err, "Unexpected error while trying to validate if the role %q exists.", roleName)
+			default:
+				return trace.Wrap(err, "Unexpected error while trying to validate if the role %q exists.", roleName)
+			}
 		}
-	}
 
-	// Create temporary bot and token
-	tokenName, err := c.createTransientBotAndToken(ctx, client, roleName)
-	if trace.IsAccessDenied(err) {
-		return trace.Wrap(err, `Failed to create the temporary Terraform bot or its token.
+		// Create temporary bot and token
+		tokenName, err := c.createTransientBotAndToken(ctx, client, roleName)
+		if trace.IsAccessDenied(err) {
+			return trace.Wrap(err, `Failed to create the temporary Terraform bot or its token.
 To use the "tctl terraform env" command you must have rights to create Teleport bot  and token resources.
 If you got a role granted recently, you might have to run "tsh logout" and login again.`)
-	}
-	if err != nil {
-		return trace.Wrap(err, "bootstrapping bot")
+		}
+		if err != nil {
+			return trace.Wrap(err, "bootstrapping bot")
+		}
+		onboard = onboarding.Config{
+			TokenValue: tokenName,
+			JoinMethod: types.JoinMethodToken,
+		}
 	}
 
 	// Now run tbot
 	c.showProgress("🤖 Using the temporary bot to obtain certificates")
-	id, sshHostCACerts, err := c.useBotToObtainIdentity(ctx, addr, tokenName, client)
+	id, sshHostCACerts, err := c.useBotToObtainIdentity(ctx, addr, onboard, client, scoped)
 	if err != nil {
 		return trace.Wrap(err, "The temporary bot failed to connect to Teleport.")
 	}
 
-	envVars, err := identityToTerraformEnvVars(addr.String(), id, sshHostCACerts)
+	envVars, err := identityToTerraformEnvVars(addr.String(), id, sshHostCACerts, scoped)
 	if err != nil {
 		return trace.Wrap(err, "exporting identity into environment variables")
 	}
@@ -274,6 +334,104 @@ func (c *TerraformCommand) createTransientBotAndToken(ctx context.Context, clien
 	return tokenName, nil
 }
 
+// createTransientBotAndToken creates a Bot resource and a secret Token.
+// The token is single use (secret tokens are consumed on MachineID join)
+// and the bot expires after the given TTL.
+func (c *TerraformCommand) createTransientScopedBotAndToken(ctx context.Context, client *authclient.Client, roleName scopes.QualifiedName) (*scopedjoiningv1.ScopedToken, *scopedaccessv1.ScopedRoleAssignment, error) {
+	// Create token and bot name
+	suffix, err := utils.CryptoRandomHex(4)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	botName := c.resourcePrefix + suffix
+	c.showProgress(fmt.Sprintf("⚙️ Creating temporary bot %q and its token", botName))
+
+	token := scopedjoiningv1.ScopedToken_builder{
+		Kind:    scopedaccess.KindScopedToken,
+		Version: types.V1,
+		Metadata: headerv1.Metadata_builder{
+			Name:    botName,
+			Labels:  terraformEnvCommandLabels,
+			Expires: timestamppb.New(time.Now().Add(c.botTTL)),
+		}.Build(),
+		Scope: c.scope,
+		Spec: scopedjoiningv1.ScopedTokenSpec_builder{
+			JoinMethod:   string(types.JoinMethodBoundKeypair),
+			UsageMode:    scopedjoining.TokenUsageModeBot,
+			Bot:          scopes.QualifiedName{Scope: c.scope, Name: botName}.String(),
+			Roles:        []string{string(types.RoleBot)},
+			BoundKeypair: scopedjoiningv1.BoundKeypairSpec_builder{Onboarding: scopedjoiningv1.BoundKeypairSpec_OnboardingSpec_builder{}.Build()}.Build(),
+		}.Build(),
+	}.Build()
+
+	token, err = client.CreateScopedToken(ctx, token)
+	if err != nil {
+		return nil, nil, trace.Wrap(err, "creating scoped token")
+	}
+
+	// Create bot
+	bot := machineidv1pb.Bot_builder{
+		Kind:    types.KindBot,
+		Version: types.V1,
+		Metadata: headerv1.Metadata_builder{
+			Name:    botName,
+			Expires: timestamppb.New(time.Now().Add(c.botTTL)),
+			Labels:  terraformEnvCommandLabels,
+		}.Build(),
+		Scope: c.scope,
+		Spec:  machineidv1pb.BotSpec_builder{}.Build(),
+	}.Build()
+
+	_, err = client.BotServiceClient().CreateBot(ctx, machineidv1pb.CreateBotRequest_builder{
+		Bot: bot,
+	}.Build())
+	if err != nil {
+		return token, nil, trace.Wrap(err, "creating bot")
+	}
+
+	// Assign role to bot
+	roleAssignment := scopedaccessv1.ScopedRoleAssignment_builder{
+		Kind:    scopedaccess.KindScopedRoleAssignment,
+		SubKind: scopedaccess.SubKindDynamic,
+		Version: types.V1,
+		Metadata: headerv1.Metadata_builder{
+			Name: botName,
+		}.Build(),
+		Scope: c.scope,
+		Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+			Assignments: []*scopedaccessv1.Assignment{
+				scopedaccessv1.Assignment_builder{
+					Role:  roleName.String(),
+					Scope: c.scope,
+				}.Build(),
+			},
+			Bot: scopes.QualifiedName{Scope: c.scope, Name: botName}.String(),
+		}.Build(),
+	}.Build()
+	assignmentResponse, err := client.ScopedAccessServiceClient().CreateScopedRoleAssignment(
+		ctx,
+		scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
+			Assignment: roleAssignment,
+		}.Build())
+	if err != nil {
+		return token, nil, trace.Wrap(err, "creating scoped role assignment")
+	}
+
+	_, err = wait.UntilFound(ctx, func(ctx context.Context) (*scopedaccessv1.GetScopedRoleAssignmentResponse, error) {
+		return client.ScopedAccessServiceClient().GetScopedRoleAssignment(ctx,
+			scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
+				Name:    assignmentResponse.GetAssignment().GetMetadata().GetName(),
+				Scope:   assignmentResponse.GetAssignment().GetScope(),
+				SubKind: assignmentResponse.GetAssignment().GetSubKind(),
+			}.Build())
+	})
+	if err != nil {
+		return token, nil, trace.Wrap(err, "waiting for role assignment to be created")
+	}
+	return token, assignmentResponse.GetAssignment(), nil
+}
+
 // roleClient describes the minimal set of operations that the helper uses to
 // create the Terraform provider role.
 type roleClient interface {
@@ -294,13 +452,40 @@ func (c *TerraformCommand) checkIfRoleExists(ctx context.Context, client roleCli
 	return roleName, trace.Wrap(err)
 }
 
+type scopedRoleClient interface {
+	GetScopedRole(ctx context.Context, req *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error)
+}
+
+// createRoleIfNeeded checks if the terraform role exists.
+// Returns the Terraform role name even in case of error, so this can be used to craft nice error messages.
+func (c *TerraformCommand) checkIfScopedRoleExists(ctx context.Context, client scopedRoleClient) (scopes.QualifiedName, error) {
+	roleSQN := c.existingRole
+
+	if roleSQN == "" {
+		roleSQN = terraformScopedRoleDefault
+	}
+
+	sqn, err := scopes.ParseQualifiedName(roleSQN)
+	if err != nil {
+		return scopes.QualifiedName{}, trace.Wrap(err, "parsing role SQN %q", roleSQN)
+	}
+
+	req := scopedaccessv1.GetScopedRoleRequest_builder{
+		Name:  sqn.Name,
+		Scope: sqn.Scope,
+	}.Build()
+	_, err = client.GetScopedRole(ctx, req)
+
+	return sqn, trace.Wrap(err)
+}
+
 // useBotToObtainIdentity takes secret bot token and runs a one-shot in-process tbot to trade the token
 // against valid certificates. Those certs are then serialized into an identity file.
 // The output is a set of environment variables, one of them including the base64-encoded identity file.
 // Later, the Terraform provider will read those environment variables to build its Teleport client.
 // Note: the function also returns the SSH Host CA cert encoded in the known host format.
 // The identity.Identity uses a different format (authorized keys).
-func (c *TerraformCommand) useBotToObtainIdentity(ctx context.Context, addr utils.NetAddr, token string, clt *authclient.Client) (*identity.Identity, [][]byte, error) {
+func (c *TerraformCommand) useBotToObtainIdentity(ctx context.Context, addr utils.NetAddr, onboard onboarding.Config, clt *authclient.Client, scoped bool) (*identity.Identity, [][]byte, error) {
 	credential := &clientcredentials.UnstableConfig{}
 	credentialLifetime := bot.CredentialLifetime{
 		TTL:             c.botTTL,
@@ -318,16 +503,14 @@ func (c *TerraformCommand) useBotToObtainIdentity(ctx context.Context, addr util
 			// This does not truly disable TLS validation, only trusts the certificate on first connection.
 			Insecure: clt.Config().InsecureSkipVerify,
 		},
-		Onboarding: onboarding.Config{
-			TokenValue: token,
-			JoinMethod: types.JoinMethodToken,
-		},
+		Onboarding:         onboard,
 		InternalStorage:    destination.NewMemory(),
 		CredentialLifetime: credentialLifetime,
 		Services: []bot.ServiceBuilder{
 			clientcredentials.ServiceBuilder(credential, credentialLifetime),
 		},
 		Logger: c.log,
+		Scoped: scoped,
 	}
 
 	// Insecure joining is not compatible with CA pinning
@@ -390,7 +573,7 @@ func (c *TerraformCommand) showProgress(update string) {
 // identityToTerraformEnvVars takes an identity and builds environment variables
 // configuring the Terraform provider to use this identity.
 // The sshHostCACerts must be in the "known hosts" format.
-func identityToTerraformEnvVars(addr string, id *identity.Identity, sshHostCACerts [][]byte) (map[string]string, error) {
+func identityToTerraformEnvVars(addr string, id *identity.Identity, sshHostCACerts [][]byte, scoped bool) (map[string]string, error) {
 	idFile := &identityfile.IdentityFile{
 		PrivateKey: id.PrivateKeyBytes,
 		Certs: identityfile.Certs{
@@ -407,8 +590,14 @@ func identityToTerraformEnvVars(addr string, id *identity.Identity, sshHostCACer
 		return nil, trace.Wrap(err)
 	}
 	idBase64 := base64.StdEncoding.EncodeToString(idBytes)
-	return map[string]string{
+
+	envVars := map[string]string{
 		constants.EnvVarTerraformAddress:            addr,
 		constants.EnvVarTerraformIdentityFileBase64: idBase64,
-	}, nil
+	}
+
+	if scoped {
+		envVars[constants.EnvVarTerraformScoped] = strconv.FormatBool(scoped)
+	}
+	return envVars, nil
 }


### PR DESCRIPTION
Manual backport of:
- Add terraform kube token path https://github.com/gravitational/teleport/pull/64766
- Adds scoped Terraform support https://github.com/gravitational/teleport/pull/68581
- tctl terraform env --scope (TODO) https://github.com/gravitational/teleport/pull/68739
- embedded tbot support: https://github.com/gravitational/teleport/pull/66750

Depends on: https://github.com/gravitational/teleport/pull/68895

Changelog: Added the ability for tbot and the Terraform provider to receive a custom Kubernetes token path via the configuration.
Changelog: Added scoped token joining to Terraform provider.
Changelog: Added scope support to tctl terraform env


## Manual Test Plan
### Test Environment

Local build

### Test Cases
- [x] `tctl terraform env` + TF runs
- [x] `tctl terraform env --scope /test` + TF with `/test` resources runs