### PR TITLE
Escape terminal control sequences in `tctl` access-changes and detections output

### DIFF
--- a/tool/tctl/common/accessgraph/access_changes_command.go
+++ b/tool/tctl/common/accessgraph/access_changes_command.go
@@ -36,6 +36,7 @@ import (
 	graphmodels "github.com/gravitational/teleport/lib/accessgraph/apiclient/models/graph"
 	diffmodels "github.com/gravitational/teleport/lib/accessgraph/apiclient/models/jsondiff"
 	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 type accessChangesArgs struct {
@@ -294,12 +295,12 @@ func displayAccessChangesText(out io.Writer, changes []accessgraph.AccessPathSum
 
 	for _, change := range changes {
 		table.AddRow([]string{
-			change.Id,
-			change.AffectedNode.Kind,
-			change.AffectedNode.Name,
-			change.AffectedNode.Source,
-			change.AffectedNode.OriginType,
-			change.AffectedNode.Alias,
+			utils.EscapeControl(change.Id),
+			utils.EscapeControl(change.AffectedNode.Kind),
+			utils.EscapeControl(change.AffectedNode.Name),
+			utils.EscapeControl(change.AffectedNode.Source),
+			utils.EscapeControl(change.AffectedNode.OriginType),
+			utils.EscapeControl(change.AffectedNode.Alias),
 			change.CreatedAt.Format(time.RFC3339),
 		})
 	}
@@ -314,17 +315,18 @@ func displayAccessChange(out io.Writer, change *accessgraph.AccessPathDiff, form
 }
 
 func displayAccessChangeText(out io.Writer, change *accessgraph.AccessPathDiff) error {
+	// UUID fields need no escaping; string fields below are escaped.
 	fmt.Fprintf(out, "Change ID: %s\n\n", change.ChangeId)
 
 	fmt.Fprintln(out, "Affected Node:")
 	nodeTable := asciitable.MakeTable([]string{"ID", "Kind", "Name", "Source", "Origin Type", "Alias"})
 	nodeTable.AddRow([]string{
 		change.AffectedNode.Id.String(),
-		change.AffectedNode.Kind,
-		change.AffectedNode.Name,
-		change.AffectedNode.Source,
-		change.AffectedNode.OriginType,
-		change.AffectedNode.Alias,
+		utils.EscapeControl(change.AffectedNode.Kind),
+		utils.EscapeControl(change.AffectedNode.Name),
+		utils.EscapeControl(change.AffectedNode.Source),
+		utils.EscapeControl(change.AffectedNode.OriginType),
+		utils.EscapeControl(change.AffectedNode.Alias),
 	})
 	fmt.Fprintln(out, nodeTable.AsBuffer().String())
 
@@ -390,7 +392,7 @@ func displayAccessChangeText(out io.Writer, change *accessgraph.AccessPathDiff) 
 		if name == "" {
 			name = id
 		}
-		rows = append(rows, []string{string(op.Op), entityType, name, kind, originType})
+		rows = append(rows, []string{string(op.Op), entityType, utils.EscapeControl(name), utils.EscapeControl(kind), utils.EscapeControl(originType)})
 	}
 	diffTable := asciitable.MakeTableWithTruncatedColumn([]string{"Operation", "Type", "Name", "Kind", "Origin Type"}, rows, "Name")
 	_, err := fmt.Fprintln(out, diffTable.AsBuffer().String())

--- a/tool/tctl/common/accessgraph/access_changes_command.go
+++ b/tool/tctl/common/accessgraph/access_changes_command.go
@@ -392,7 +392,7 @@ func displayAccessChangeText(out io.Writer, change *accessgraph.AccessPathDiff) 
 		if name == "" {
 			name = id
 		}
-		rows = append(rows, []string{string(op.Op), entityType, utils.EscapeControl(name), utils.EscapeControl(kind), utils.EscapeControl(originType)})
+		rows = append(rows, []string{utils.EscapeControl(string(op.Op)), entityType, utils.EscapeControl(name), utils.EscapeControl(kind), utils.EscapeControl(originType)})
 	}
 	diffTable := asciitable.MakeTableWithTruncatedColumn([]string{"Operation", "Type", "Name", "Kind", "Origin Type"}, rows, "Name")
 	_, err := fmt.Fprintln(out, diffTable.AsBuffer().String())

--- a/tool/tctl/common/accessgraph/access_changes_command_test.go
+++ b/tool/tctl/common/accessgraph/access_changes_command_test.go
@@ -632,3 +632,58 @@ func TestConstructAccessChangesListQuery(t *testing.T) {
 		}
 	})
 }
+
+func TestAccessChangesTextEscapesControlSequences(t *testing.T) {
+	// OSC 52 clipboard-write + screen clear.
+	const inject = "evil\x1b]52;c;AAAA\a\x1b[2Jspoofed"
+
+	assertEscaped := func(t *testing.T, out string) {
+		require.NotContains(t, out, "\x1b", "raw escape byte leaked to terminal")
+		require.NotContains(t, out, "\a", "raw BEL byte leaked to terminal")
+		require.Contains(t, out, `\x1b`, "control sequence should be rendered as a visible escape")
+	}
+
+	injectedNode := accessgraph.AccessPathSummaryItemNode{
+		Id:         fixtureAffectedID,
+		Kind:       inject,
+		Name:       inject,
+		Source:     inject,
+		OriginType: inject,
+		Alias:      inject,
+	}
+
+	t.Run("summary list", func(t *testing.T) {
+		item := accessgraph.AccessPathSummaryItem{
+			Id:           fixtureChangeUUID.String(),
+			CreatedAt:    fixtureChangeTime,
+			AffectedNode: injectedNode,
+		}
+		var buf bytes.Buffer
+		require.NoError(t, displayAccessChangesText(&buf, []accessgraph.AccessPathSummaryItem{item}))
+		assertEscaped(t, buf.String())
+	})
+
+	t.Run("detail with diff row", func(t *testing.T) {
+		strRef := func(s string) *string { return &s }
+		anyRef := func(v any) *any { return &v }
+		newNodeID := "dddddddd-4444-4444-4444-444444444444"
+		addNode := map[string]any{
+			"id":          newNodeID,
+			"kind":        inject,
+			"name":        inject,
+			"origin_type": inject,
+		}
+		// A clean AffectedNode keeps the injected payload confined to the diff
+		// row, so the escape assertions can only pass via the diff-row path.
+		change := &accessgraph.AccessPathDiff{
+			ChangeId:     fixtureChangeUUID,
+			AffectedNode: accessgraph.AccessPathSummaryItemNode{Id: fixtureAffectedID, Kind: "resource", Name: "prod-db"},
+			Diff: []diffmodels.Operation{
+				{Op: diffmodels.OperationOpAdd, Path: strRef("/nodes/" + newNodeID), Value: anyRef(addNode)},
+			},
+		}
+		var buf bytes.Buffer
+		require.NoError(t, displayAccessChangeText(&buf, change))
+		assertEscaped(t, buf.String())
+	})
+}

--- a/tool/tctl/common/accessgraph/access_changes_command_test.go
+++ b/tool/tctl/common/accessgraph/access_changes_command_test.go
@@ -674,12 +674,14 @@ func TestAccessChangesTextEscapesControlSequences(t *testing.T) {
 			"origin_type": inject,
 		}
 		// A clean AffectedNode keeps the injected payload confined to the diff
-		// row, so the escape assertions can only pass via the diff-row path.
+		// row, so the escape assertions can only pass via the diff-row path. The
+		// Op value is also injected to cover the Operation column, which is a
+		// bare string enum the API can return unvalidated.
 		change := &accessgraph.AccessPathDiff{
 			ChangeId:     fixtureChangeUUID,
 			AffectedNode: accessgraph.AccessPathSummaryItemNode{Id: fixtureAffectedID, Kind: "resource", Name: "prod-db"},
 			Diff: []diffmodels.Operation{
-				{Op: diffmodels.OperationOpAdd, Path: strRef("/nodes/" + newNodeID), Value: anyRef(addNode)},
+				{Op: diffmodels.OperationOp(inject), Path: strRef("/nodes/" + newNodeID), Value: anyRef(addNode)},
 			},
 		}
 		var buf bytes.Buffer

--- a/tool/tctl/common/accessgraph/access_review_command.go
+++ b/tool/tctl/common/accessgraph/access_review_command.go
@@ -122,7 +122,7 @@ func (c *AccessGraphCommand) AccessReview(ctx context.Context, client *accessgra
 		// The activity lookup couldn't run: hide the columns and surface the
 		// backend's message as a note.
 		showActivity = false
-		output.ActivityUnavailable = utils.EscapeControl(*resp.IacError)
+		output.ActivityUnavailable = utils.AllowWhitespace(*resp.IacError)
 	}
 	if truncated {
 		output.Warnings = append(output.Warnings, fmt.Sprintf("results truncated at %d identities; narrow --query for the full set", args.limit))

--- a/tool/tctl/common/accessgraph/detections_command.go
+++ b/tool/tctl/common/accessgraph/detections_command.go
@@ -382,19 +382,19 @@ func displayDetectionText(out io.Writer, a accessgraph.SecurityAlert, events []l
 		field("Updated", a.UpdatedAt.Format(time.RFC3339))
 	}
 	if a.Description != nil && *a.Description != "" {
-		fmt.Fprintf(out, "\nDescription:\n%s\n", utils.EscapeControl(*a.Description))
+		fmt.Fprintf(out, "\nDescription:\n%s\n", utils.AllowWhitespace(*a.Description))
 	}
 	if a.MitigationSteps != nil && len(*a.MitigationSteps) > 0 {
 		fmt.Fprintln(out, "\nMitigation Steps:")
 		for _, step := range *a.MitigationSteps {
-			fmt.Fprintf(out, "  - %s\n", utils.EscapeControl(step))
+			fmt.Fprintf(out, "  - %s\n", utils.AllowWhitespace(step))
 		}
 	}
 	if eventsErr != nil || len(events) > 0 || (a.LogEntries != nil && len(*a.LogEntries) > 0) {
 		fmt.Fprintln(out, "\nLog Entries:")
 		switch {
 		case eventsErr != nil:
-			fmt.Fprintln(out, warningStyle.Render(utils.EscapeControl(eventsErr.Error())))
+			fmt.Fprintln(out, warningStyle.Render(utils.AllowWhitespace(eventsErr.Error())))
 		case len(events) == 0:
 			fmt.Fprintln(out, "Not found.")
 		default:

--- a/tool/tctl/common/accessgraph/detections_command.go
+++ b/tool/tctl/common/accessgraph/detections_command.go
@@ -35,6 +35,7 @@ import (
 	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
 	logmodels "github.com/gravitational/teleport/lib/accessgraph/apiclient/models/logs"
 	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // descriptionTextMaxLen caps Description in the detailed text table so a long
@@ -220,11 +221,11 @@ func detectionRowHeaders(detailed bool) []string {
 func detectionRow(a accessgraph.SecurityAlert, detailed bool) []string {
 	row := []string{
 		a.Id.String(),
-		string(a.Status),
+		utils.EscapeControl(string(a.Status)),
 		a.CreatedAt.Format(time.RFC3339),
-		string(a.Source),
-		a.Title,
-		string(a.Severity),
+		utils.EscapeControl(string(a.Source)),
+		utils.EscapeControl(a.Title),
+		utils.EscapeControl(string(a.Severity)),
 	}
 	if !detailed {
 		return row
@@ -243,11 +244,11 @@ func detectionRow(a accessgraph.SecurityAlert, detailed bool) []string {
 		updated = a.UpdatedAt.Format(time.RFC3339)
 	}
 	row = append(row,
-		strPtrToStr(a.ReportedBy),
-		a.Type,
-		formatAffectedEntity(a),
-		tags,
-		description,
+		utils.EscapeControl(strPtrToStr(a.ReportedBy)),
+		utils.EscapeControl(a.Type),
+		utils.EscapeControl(formatAffectedEntity(a)),
+		utils.EscapeControl(tags),
+		utils.EscapeControl(description),
 		a.StartTime.Format(time.RFC3339),
 		a.EndTime.Format(time.RFC3339),
 		updated,
@@ -358,7 +359,7 @@ func fetchAlertEvents(ctx context.Context, client *accessgraph.ClientWithRespons
 // displayDetectionText renders the human-readable detail view for one alert.
 func displayDetectionText(out io.Writer, a accessgraph.SecurityAlert, events []logmodels.AccessgraphStorageV1alphaEvent, eventsErr error) error {
 	field := func(label, value string) {
-		fmt.Fprintf(out, "%-19s%s\n", label+":", value)
+		fmt.Fprintf(out, "%-19s%s\n", label+":", utils.EscapeControl(value))
 	}
 	field("ID", a.Id.String())
 	field("Title", a.Title)
@@ -381,19 +382,19 @@ func displayDetectionText(out io.Writer, a accessgraph.SecurityAlert, events []l
 		field("Updated", a.UpdatedAt.Format(time.RFC3339))
 	}
 	if a.Description != nil && *a.Description != "" {
-		fmt.Fprintf(out, "\nDescription:\n%s\n", *a.Description)
+		fmt.Fprintf(out, "\nDescription:\n%s\n", utils.EscapeControl(*a.Description))
 	}
 	if a.MitigationSteps != nil && len(*a.MitigationSteps) > 0 {
 		fmt.Fprintln(out, "\nMitigation Steps:")
 		for _, step := range *a.MitigationSteps {
-			fmt.Fprintf(out, "  - %s\n", step)
+			fmt.Fprintf(out, "  - %s\n", utils.EscapeControl(step))
 		}
 	}
 	if eventsErr != nil || len(events) > 0 || (a.LogEntries != nil && len(*a.LogEntries) > 0) {
 		fmt.Fprintln(out, "\nLog Entries:")
 		switch {
 		case eventsErr != nil:
-			fmt.Fprintln(out, warningStyle.Render(eventsErr.Error()))
+			fmt.Fprintln(out, warningStyle.Render(utils.EscapeControl(eventsErr.Error())))
 		case len(events) == 0:
 			fmt.Fprintln(out, "Not found.")
 		default:
@@ -410,7 +411,12 @@ func displayDetectionText(out io.Writer, a accessgraph.SecurityAlert, events []l
 			if log.Reason != nil {
 				reason = *log.Reason
 			}
-			changes.AddRow([]string{log.CreatedAt.Format(time.RFC3339), string(log.Status), log.User, reason})
+			changes.AddRow([]string{
+				log.CreatedAt.Format(time.RFC3339),
+				utils.EscapeControl(string(log.Status)),
+				utils.EscapeControl(log.User),
+				utils.EscapeControl(reason),
+			})
 		}
 		fmt.Fprintln(out, changes.String())
 	}

--- a/tool/tctl/common/accessgraph/detections_command_test.go
+++ b/tool/tctl/common/accessgraph/detections_command_test.go
@@ -564,6 +564,56 @@ func TestDisplayDetectionTextAffectedEntity(t *testing.T) {
 	}
 }
 
+func TestDetectionTextEscapesControlSequences(t *testing.T) {
+	// OSC 52 clipboard-write + screen clear
+	inject := "evil\x1b]52;c;AAAA\a\x1b[2Jspoofed"
+
+	assertEscaped := func(t *testing.T, out string) {
+		require.NotContains(t, out, "\x1b", "raw escape byte leaked to terminal")
+		require.NotContains(t, out, "\a", "raw BEL byte leaked to terminal")
+		require.Contains(t, out, `\x1b`, "control sequence should be rendered as a visible escape")
+	}
+
+	// Payload in every field detectionRow / displayDetectionText escapes.
+	alert := accessgraph.SecurityAlert{
+		Id:        fixtureAlertID,
+		Title:     inject,
+		Type:      inject,
+		Severity:  accessgraph.SecurityAlertSeverity(inject),
+		Status:    accessgraph.AlertStatus(inject),
+		Source:    logmodels.EventSource(inject),
+		StartTime: fixtureStart,
+		EndTime:   fixtureEnd,
+		CreatedAt: fixtureCreated,
+		AffectedEntity: &struct {
+			Name *string `json:"name,omitempty"`
+			Type *string `json:"type,omitempty"`
+		}{Name: &inject},
+		Tags:            &[]string{inject},
+		Description:     &inject,
+		ReportedBy:      &inject,
+		MitigationSteps: &[]string{inject},
+		StatusChangeLogs: []accessgraph.AlertStatusChangeLog{{
+			CreatedAt: fixtureCreated,
+			Status:    accessgraph.AlertStatus(inject),
+			User:      inject,
+			Reason:    &inject,
+		}},
+	}
+
+	t.Run("row detailed", func(t *testing.T) {
+		out := strings.Join(detectionRow(alert, true), "\n")
+		assertEscaped(t, out)
+	})
+
+	t.Run("detail view", func(t *testing.T) {
+		var buf bytes.Buffer
+		// Non-nil eventsErr covers the escaped-error branch.
+		require.NoError(t, displayDetectionText(&buf, alert, nil, trace.BadParameter("%s", inject)))
+		assertEscaped(t, buf.String())
+	})
+}
+
 // TestInitDetectionsFlags exercises the kingpin wiring (defaults, enum
 // validation, --from/--to via timeValue) without going through TryRun or
 // touching the network.


### PR DESCRIPTION
Issue: https://github.com/gravitational/access-graph/issues/1933

`tctl access-changes` and `tctl detections` wrote Access Graph-derived strings straight into their text tables. This wraps them in `utils.EscapeControl` before text rendering so control bytes are shown as visible escapes.

## What changed

- Escape all Access Graph-derived strings in the `access-changes` list, detail, and diff-row text output.
- Escape all alert-derived strings in the `detections` list and detail text output.
- Add tests asserting injected control bytes render as visible escapes and never leak raw.

## Why

The `investigate` and `access-review` renderers already escape these fields; the suggestion to escape them was made after `detections` and `access-changes` had landed, so those two commands were left as the gap. Codex flagged the missing escaping as two P2 findings on the v18 backport (https://github.com/gravitational/teleport/pull/68783) — this closes that gap on master so the fix can be backported consistently. JSON/YAML output is left untouched.

## Manual Test Plan
### Test Environment

- Local `tctl` build against a dev cluster with Access Graph configured.

### Test Cases
- [x] `tctl detections ls` / `--detailed` / `get` escape control characters correctly.
- [x] `tctl access-changes ls` / `get` escape control characters correctly, including diff rows.
- [x] `--format json` / `--format yaml` emit the raw values unchanged for both commands.
