### PR TITLE
operator: Support namespaced scoped roles and role assignments

### DIFF
--- a/integrations/operator/controllers/resources/scopedrole_controller.go
+++ b/integrations/operator/controllers/resources/scopedrole_controller.go
@@ -42,14 +42,16 @@ func (s *scopedRoleClient) Create(ctx context.Context, role *accessv1.ScopedRole
 
 func (s *scopedRoleClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
 	_, err := s.teleportClient.ScopedAccessServiceClient().DeleteScopedRole(ctx, accessv1.DeleteScopedRoleRequest_builder{
-		Name: key.String(),
+		Name:  key.Name,
+		Scope: key.Scope,
 	}.Build())
 	return trace.Wrap(err)
 }
 
 func (s *scopedRoleClient) Get(ctx context.Context, key reconcilers.ResourceKey) (*accessv1.ScopedRole, error) {
 	resp, err := s.teleportClient.ScopedAccessServiceClient().GetScopedRole(ctx, accessv1.GetScopedRoleRequest_builder{
-		Name: key.String(),
+		Name:  key.Name,
+		Scope: key.Scope,
 	}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -65,7 +67,7 @@ func (s *scopedRoleClient) Update(ctx context.Context, role *accessv1.ScopedRole
 }
 
 func NewScopedRoleV1Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
-	return reconcilers.NewTeleportResource153Reconciler[*accessv1.ScopedRole, *resourcesv1.TeleportScopedRoleV1](
+	return reconcilers.NewTeleportScopedResource153Reconciler[*accessv1.ScopedRole, *resourcesv1.TeleportScopedRoleV1](
 		client,
 		&scopedRoleClient{
 			teleportClient: tClient,

--- a/integrations/operator/controllers/resources/scopedroleassignment_controller.go
+++ b/integrations/operator/controllers/resources/scopedroleassignment_controller.go
@@ -43,7 +43,8 @@ func (s *scopedRoleAssignmentClient) Create(ctx context.Context, assignment *acc
 
 func (s *scopedRoleAssignmentClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
 	_, err := s.teleportClient.ScopedAccessServiceClient().DeleteScopedRoleAssignment(ctx, accessv1.DeleteScopedRoleAssignmentRequest_builder{
-		Name:    key.String(),
+		Name:    key.Name,
+		Scope:   key.Scope,
 		SubKind: scopedaccess.SubKindDynamic,
 	}.Build())
 	return trace.Wrap(err)
@@ -51,7 +52,8 @@ func (s *scopedRoleAssignmentClient) Delete(ctx context.Context, key reconcilers
 
 func (s *scopedRoleAssignmentClient) Get(ctx context.Context, key reconcilers.ResourceKey) (*accessv1.ScopedRoleAssignment, error) {
 	resp, err := s.teleportClient.ScopedAccessServiceClient().GetScopedRoleAssignment(ctx, accessv1.GetScopedRoleAssignmentRequest_builder{
-		Name:    key.String(),
+		Name:    key.Name,
+		Scope:   key.Scope,
 		SubKind: scopedaccess.SubKindDynamic,
 	}.Build())
 	if err != nil {
@@ -68,7 +70,7 @@ func (s *scopedRoleAssignmentClient) Update(ctx context.Context, assignment *acc
 }
 
 func NewScopedRoleAssignmentV1Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
-	return reconcilers.NewTeleportResource153Reconciler[*accessv1.ScopedRoleAssignment, *resourcesv1.TeleportScopedRoleAssignmentV1](
+	return reconcilers.NewTeleportScopedResource153Reconciler[*accessv1.ScopedRoleAssignment, *resourcesv1.TeleportScopedRoleAssignmentV1](
 		client,
 		&scopedRoleAssignmentClient{
 			teleportClient: tClient,


### PR DESCRIPTION



<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local k3s cluster with the CRDs from this branch loaded. Local Teleport cluster with the k3s cluster enrolled as a Kubernetes resource.

### Test Cases
- [x] scoped role CRUD works via operator in the appropriate namespace
- [x] scoped role assignment CRUD works via operator in the appropriate namespace