### PR TITLE
[v18] Add set conversion helper for generic_oidc predicate expressions

### DIFF
--- a/lib/expression/set.go
+++ b/lib/expression/set.go
@@ -19,8 +19,9 @@
 package expression
 
 import (
-	"github.com/gravitational/teleport/lib/utils/set"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/utils/set"
 )
 
 // Set is a map of type string key and struct values. Set is a thin wrapper over

--- a/lib/expression/set.go
+++ b/lib/expression/set.go
@@ -20,6 +20,7 @@ package expression
 
 import (
 	"github.com/gravitational/teleport/lib/utils/set"
+	"github.com/gravitational/trace"
 )
 
 // Set is a map of type string key and struct values. Set is a thin wrapper over
@@ -34,6 +35,45 @@ type Set struct {
 // NewSet constructs a new set from an arbitrary collection of elements
 func NewSet(values ...string) Set {
 	return Set{set.New(values...)}
+}
+
+// NewFlattenedSet constructs a new string set from `any` elements. It supports
+// plain strings, string arrays, []any containing only strings, and other Sets
+// containing strings, and returns the flattened union of all strings across all
+// provided values. If any unsupported types are provided, an error is returned.
+//
+// Library users use this implementation to override the default `set()`
+// behavior if they need to handle lists, e.g. from JSON.
+func NewFlattenedSet(values ...any) (Set, error) {
+	var elements []string
+
+	for _, e := range values {
+		switch element := e.(type) {
+		case string:
+			elements = append(elements, element)
+		case []string:
+			// Unlikely for data parsed via JSON, but other callers might pass
+			// a []string and it's easy to support.
+			elements = append(elements, element...)
+		case []any:
+			// Flatten []any to strings if possible. We won't bother recursing
+			// further unless an actual use case for doing so presents itself;
+			// for now, just expect strings.
+			for _, item := range element {
+				s, ok := item.(string)
+				if !ok {
+					return Set{}, trace.BadParameter("unsupported set element type, got %T", item)
+				}
+				elements = append(elements, s)
+			}
+		case Set:
+			elements = append(elements, element.items()...)
+		default:
+			return Set{}, trace.BadParameter("unsupported set element type, got: %T", e)
+		}
+	}
+
+	return Set{set.New(elements...)}, nil
 }
 
 // add creates a new Set containing all values in the receiver Set and adds

--- a/lib/join/genericoidc/expression.go
+++ b/lib/join/genericoidc/expression.go
@@ -35,7 +35,7 @@ type Environment struct {
 	Claims map[string]any
 }
 
-var booleanExpressionParser = func() *typical.Parser[*Environment, any] {
+var booleanExpressionParser = func() *typical.Parser[*Environment, bool] {
 	spec := expression.DefaultParserSpec[*Environment]()
 	spec.GetUnknownIdentifier = func(env *Environment, fields []string) (any, error) {
 		if len(fields) == 0 {
@@ -67,7 +67,7 @@ var booleanExpressionParser = func() *typical.Parser[*Environment, any] {
 			}),
 	})
 
-	parser, err := typical.NewParser[*Environment, any](spec)
+	parser, err := typical.NewParser[*Environment, bool](spec)
 	if err != nil {
 		panic(fmt.Sprintf("failed to construct parser: %v", err))
 	}
@@ -114,9 +114,5 @@ func evaluateExpression(expr string, env *Environment) (bool, error) {
 		return false, trace.Wrap(err, "evaluating expression: %s", expr)
 	}
 
-	if result, ok := rsp.(bool); ok {
-		return result, nil
-	}
-
-	return false, trace.Errorf("expression evaluated to %T instead of boolean: %s", rsp, expr)
+	return rsp, nil
 }

--- a/lib/join/genericoidc/expression.go
+++ b/lib/join/genericoidc/expression.go
@@ -20,6 +20,7 @@ package genericoidc
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -47,6 +48,24 @@ var booleanExpressionParser = func() *typical.Parser[*Environment, any] {
 
 		return getByFields(env.Claims, fields[1:])
 	}
+
+	// Add (overwrite) `set()` with an enhanced variant that can ingest and
+	// flatten []string. The built-in `set()` only supports `string` values as
+	// variadic args and there's no "foo..." operator equivalent, meaning it
+	// can't convert []string -> Set, and unfortunately, essentially all
+	// built-in predicate functions operate on Sets and not lists, with no
+	// coercion.
+	// This enhanced variant can wrap list variables (e.g. parsed lists in
+	// claims documents) in addition to plain strings, or other sets. It's a
+	// simple opt-in override (just changes the underlying impl from
+	// `expression.NewSet()`) to avoid changing behavior for other predicate
+	// uses.
+	maps.Copy(spec.Functions, map[string]typical.Function{
+		"set": typical.UnaryVariadicFunction[*Environment](
+			func(args ...any) (expression.Set, error) {
+				return expression.NewFlattenedSet(args...)
+			}),
+	})
 
 	parser, err := typical.NewParser[*Environment, any](spec)
 	if err != nil {

--- a/lib/join/genericoidc/expression_test.go
+++ b/lib/join/genericoidc/expression_test.go
@@ -115,6 +115,42 @@ func TestEvaluateExpression(t *testing.T) {
 				require.ErrorContains(t, err, "operator (==) not supported for type: float64")
 			},
 		},
+		{
+			name: "set helper enables regex with single string",
+			claims: claims(t, `{
+				"user": "alice@example.com"
+			}`),
+			expression:  `regexp.match(set(claims.user), "^.+@example.com$")`,
+			expect:      true,
+			expectError: require.NoError,
+		},
+		{
+			name: "set helper denies via regex with single string",
+			claims: claims(t, `{
+				"user": "alice@example.com"
+			}`),
+			expression:  `regexp.match(set(claims.user), "^.+@nope.com$")`,
+			expect:      false,
+			expectError: require.NoError,
+		},
+		{
+			name: "set helper enables contains_all with array of strings",
+			claims: claims(t, `{
+				"groups": ["foo", "bar", "baz"]
+			}`),
+			expression:  `contains_all(set(claims.groups), set("foo", "bar", "baz"))`,
+			expect:      true,
+			expectError: require.NoError,
+		},
+		{
+			name: "set helper denies contains_all with array of strings",
+			claims: claims(t, `{
+				"groups": ["foo", "bar", "baz"]
+			}`),
+			expression:  `contains_all(set(claims.groups), set("foo", "bar", "baz", "qux"))`,
+			expect:      true,
+			expectError: require.NoError,
+		},
 	}
 
 	for _, tt := range tests {

--- a/lib/join/genericoidc/expression_test.go
+++ b/lib/join/genericoidc/expression_test.go
@@ -148,7 +148,7 @@ func TestEvaluateExpression(t *testing.T) {
 				"groups": ["foo", "bar", "baz"]
 			}`),
 			expression:  `contains_all(set(claims.groups), set("foo", "bar", "baz", "qux"))`,
-			expect:      true,
+			expect:      false,
 			expectError: require.NoError,
 		},
 	}


### PR DESCRIPTION
Backport #68699 to branch/v18

---

This adds a small enhanced version of `set()` for `generic_oidc` that can convert lists to sets.

This is needed because almost all interesting functions in the predicate language operate on sets, not lists. So, when given `[]any` parsed from JSON claims, they fail. This limitation affects:
- `contains()`, `contains_any()`, `contains_all()`
- `regexp.match()`
- `is_empty()`
- ...and every other function that claims to operate on `[]string` according to the public docs but actually operates on sets.

(It should also be noted that the type of JSON arrays parsed from claims without a schema is actually `[]any`, so even  if the built-in `set()`/other functions handled `[]string`, they still wouldn't be able to inspect fields from parsed JWTs.)

To work around this limitation, this tiny override for `set()` defers to a new `expression.NewFlattenedSet()` constructor. It lets us (or others) easily override the built-in `set()` impl that only accepts variadic `string...` with this more flexible variant that accepts variadic `any...` and casts/flattens to `[]string` (or errors).

I explicitly did not apply this change to the default `set()` implementation, as doing so could potentially cause unexpected changes that might, for example, cause expressions to allow access that were previously broken due to this limitation.

No changelog, I plan to get this merged along with the initial generic_oidc changes (v18.11.0).

## Manual Test Plan
### Test Environment

In addition to unit tests here, I added some test cases to my `generic_oidc` test suite: https://github.com/timothyb89/teleport-harness/commit/7dcc22c53b23fe5b99c60e3cb377ad8bfad8c181

Detailed results can be found here: https://gist.github.com/timothyb89/75724b2471c9b916158f9019386db8b8. Note that this branch needed to be combined with https://github.com/gravitational/teleport/pull/68566 which is still pending review to be tested, but it otherwise has no merge order dependency.

### Test Cases
 - [x] Generic OIDC can now join using `regexp.match()` and `contains_all()` in `allow_any` expressions
