### PR TITLE
app: Log expired app sessions at debug level

### DIFF
--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -364,7 +364,6 @@ func (h *Handler) handleForwardError(w http.ResponseWriter, req *http.Request, e
 func (h *Handler) authenticate(ctx context.Context, r *http.Request) (*session, error) {
 	ws, err := h.getAppSession(r)
 	if err != nil {
-		h.logger.WarnContext(ctx, "Failed to fetch application session", "error", err)
 		return nil, trace.AccessDenied("invalid session")
 	}
 
@@ -385,7 +384,6 @@ func (h *Handler) authenticate(ctx context.Context, r *http.Request) (*session, 
 func (h *Handler) renewSession(r *http.Request) (*session, error) {
 	ws, err := h.getAppSession(r)
 	if err != nil {
-		h.logger.DebugContext(r.Context(), "Failed to fetch application session: not found")
 		return nil, trace.AccessDenied("invalid session")
 	}
 
@@ -421,7 +419,14 @@ func (h *Handler) getAppSession(r *http.Request) (ws types.WebSession, err error
 		ws, err = h.getAppSessionFromCookie(r)
 	}
 	if err != nil {
-		h.logger.WarnContext(r.Context(), "Failed to get session", "error", err)
+		// Missing, expired, or invalid sessions are expected because clients
+		// replay stale cookies, so they are logged at debug level. Unexpected
+		// failures are logged as warnings.
+		if trace.IsNotFound(err) || trace.IsAccessDenied(err) {
+			h.logger.DebugContext(r.Context(), "Failed to fetch application session", "error", err)
+		} else {
+			h.logger.WarnContext(r.Context(), "Failed to fetch application session", "error", err)
+		}
 		return nil, trace.AccessDenied("invalid session")
 	}
 	return ws, nil

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -28,6 +28,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -1232,9 +1233,15 @@ func TestHandlerAuthenticate(t *testing.T) {
 		request := httptest.NewRequest("GET", "https://"+publicAddr, nil)
 		addValidSessionCookiesToRequest(authClient.appSession, request)
 
+		// An expired session must not be logged above debug, otherwise a
+		// client replaying the stale cookie floods the logs.
+		var logs bytes.Buffer
+		appHandler.logger = slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
 		_, err := appHandler.authenticate(ctx, request)
 		require.Error(t, err)
 		require.True(t, trace.IsAccessDenied(err))
+		require.Empty(t, logs.String(), "expired session must not be logged above debug level")
 	})
 }
 


### PR DESCRIPTION
The web application proxy logs a warning with a full stack trace whenever it cannot fetch an application session. When a session reaches its TTL, a client that keeps replaying the stale cookie, such as a browser tab polling in the background, triggers that warning on every request and floods the proxy logs.

This downgrades the log to debug level for the expected cases where the session is missing, expired, or invalid, and keeps the warning for unexpected failures such as backend connection problems. It also removes the duplicate log that `authenticate` and `renewSession` emitted on top of the one in `getAppSession`, so a failed lookup is logged at most once.

Issue: https://github.com/gravitational/teleport/issues/66138

Changelog: Fixed excessive warnings logged when a client replays an expired application session cookie.