### PR TITLE
app: Log expired app sessions at debug level

### DIFF
--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -420,8 +420,8 @@ func (h *Handler) getAppSession(r *http.Request) (ws types.WebSession, err error
 	}
 	if err != nil {
 		// Missing, expired, or invalid sessions are expected because clients
-		// replay stale cookies, so they are logged at debug level. Unexpected
-		// failures are logged as warnings.
+		// replay stale cookies, so they are logged at debug rather than
+		// warning level.
 		if trace.IsNotFound(err) || trace.IsAccessDenied(err) {
 			h.logger.DebugContext(r.Context(), "Failed to fetch application session", "error", err)
 		} else {

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -364,7 +364,6 @@ func (h *Handler) handleForwardError(w http.ResponseWriter, req *http.Request, e
 func (h *Handler) authenticate(ctx context.Context, r *http.Request) (*session, error) {
 	ws, err := h.getAppSession(r)
 	if err != nil {
-		h.logger.WarnContext(ctx, "Failed to fetch application session", "error", err)
 		return nil, trace.AccessDenied("invalid session")
 	}
 
@@ -385,7 +384,6 @@ func (h *Handler) authenticate(ctx context.Context, r *http.Request) (*session, 
 func (h *Handler) renewSession(r *http.Request) (*session, error) {
 	ws, err := h.getAppSession(r)
 	if err != nil {
-		h.logger.DebugContext(r.Context(), "Failed to fetch application session: not found")
 		return nil, trace.AccessDenied("invalid session")
 	}
 
@@ -421,7 +419,14 @@ func (h *Handler) getAppSession(r *http.Request) (ws types.WebSession, err error
 		ws, err = h.getAppSessionFromCookie(r)
 	}
 	if err != nil {
-		h.logger.WarnContext(r.Context(), "Failed to get session", "error", err)
+		// Missing, expired, or invalid sessions are expected because clients
+		// replay stale cookies, so they are logged at debug level. Unexpected
+		// failures are logged as warnings.
+		if trace.IsNotFound(err) || trace.IsAccessDenied(err) {
+			h.logger.DebugContext(r.Context(), "Failed to fetch application session", "error", err)
+		} else {
+			h.logger.WarnContext(r.Context(), "Failed to fetch application session", "error", err)
+		}
 		return nil, trace.AccessDenied("invalid session")
 	}
 	return ws, nil

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -622,10 +622,10 @@ func (h *Handler) getSession(ctx context.Context, ws types.WebSession) (*session
 func extractCookie(r *http.Request, cookieName string) (string, error) {
 	rawCookie, err := r.Cookie(cookieName)
 	if err != nil {
-		return "", trace.Wrap(err)
+		return "", trace.NotFound("cookie %q not found", cookieName)
 	}
 	if rawCookie != nil && rawCookie.Value == "" {
-		return "", trace.BadParameter("cookie missing")
+		return "", trace.NotFound("cookie %q is empty", cookieName)
 	}
 
 	return rawCookie.Value, nil

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -620,12 +620,12 @@ func (h *Handler) getSession(ctx context.Context, ws types.WebSession) (*session
 
 // extractCookie extracts the cookie from the *http.Request.
 func extractCookie(r *http.Request, cookieName string) (string, error) {
-	rawCookie, err := r.Cookie(cookieName)
-	if err != nil {
-		return "", trace.NotFound("cookie %q not found", cookieName)
+	rawCookie, _ := r.Cookie(cookieName)
+	if rawCookie == nil {
+		return "", trace.NotFound("cookie %+q not found", cookieName)
 	}
-	if rawCookie != nil && rawCookie.Value == "" {
-		return "", trace.NotFound("cookie %q is empty", cookieName)
+	if rawCookie.Value == "" {
+		return "", trace.NotFound("cookie %+q is empty", cookieName)
 	}
 
 	return rawCookie.Value, nil

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -28,7 +28,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -1103,17 +1102,6 @@ func startFakeAppServerOnCluster(t *testing.T, clusterName string, accessPoint a
 	return fakeCluster
 }
 
-// captureWarnLogs swaps the handler's logger for one that only records
-// warning-level and above into the returned buffer, then restores the
-// original logger when the test ends.
-func captureWarnLogs(t *testing.T, h *Handler) *bytes.Buffer {
-	orig := h.logger
-	t.Cleanup(func() { h.logger = orig })
-	var buf bytes.Buffer
-	h.logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	return &buf
-}
-
 func TestHandlerAuthenticate(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -1216,12 +1204,10 @@ func TestHandlerAuthenticate(t *testing.T) {
 	})
 
 	t.Run("without cookie or client cert", func(t *testing.T) {
-		logs := captureWarnLogs(t, appHandler)
 		request := httptest.NewRequest("GET", "https://"+publicAddr, nil)
 		_, err := appHandler.authenticate(ctx, request)
 		require.Error(t, err)
 		require.True(t, trace.IsAccessDenied(err))
-		require.Empty(t, logs.String(), "a missing cookie must not be logged above debug level")
 	})
 
 	t.Run("with cookie subject mismatch", func(t *testing.T) {
@@ -1246,24 +1232,9 @@ func TestHandlerAuthenticate(t *testing.T) {
 		request := httptest.NewRequest("GET", "https://"+publicAddr, nil)
 		addValidSessionCookiesToRequest(authClient.appSession, request)
 
-		logs := captureWarnLogs(t, appHandler)
 		_, err := appHandler.authenticate(ctx, request)
 		require.Error(t, err)
 		require.True(t, trace.IsAccessDenied(err))
-		require.Empty(t, logs.String(), "expired session must not be logged above debug level")
-	})
-
-	t.Run("backend error is logged at warning", func(t *testing.T) {
-		authClient.sessionError = trace.ConnectionProblem(nil, "backend unavailable")
-		t.Cleanup(func() { authClient.sessionError = nil })
-		request := httptest.NewRequest("GET", "https://"+publicAddr, nil)
-		addValidSessionCookiesToRequest(authClient.appSession, request)
-
-		logs := captureWarnLogs(t, appHandler)
-		_, err := appHandler.authenticate(ctx, request)
-		require.Error(t, err)
-		require.True(t, trace.IsAccessDenied(err))
-		require.NotEmpty(t, logs.String(), "an unexpected backend error must be logged at warning level")
 	})
 }
 

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -28,6 +28,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -1232,9 +1233,15 @@ func TestHandlerAuthenticate(t *testing.T) {
 		request := httptest.NewRequest("GET", "https://"+publicAddr, nil)
 		addValidSessionCookiesToRequest(authClient.appSession, request)
 
+		// An expired session must not be logged above debug, otherwise a
+		// client replaying the stale cookie floods the logs.
+		var logs bytes.Buffer
+		appHandler.logger = slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
 		_, err := appHandler.authenticate(ctx, request)
 		require.Error(t, err)
 		require.True(t, trace.IsAccessDenied(err))
+		require.Empty(t, logs.String(), "expired session must not be logged above debug level")
 	})
 }
 

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -1103,6 +1103,17 @@ func startFakeAppServerOnCluster(t *testing.T, clusterName string, accessPoint a
 	return fakeCluster
 }
 
+// captureWarnLogs swaps the handler's logger for one that only records
+// warning-level and above into the returned buffer, then restores the
+// original logger when the test ends.
+func captureWarnLogs(t *testing.T, h *Handler) *bytes.Buffer {
+	orig := h.logger
+	t.Cleanup(func() { h.logger = orig })
+	var buf bytes.Buffer
+	h.logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	return &buf
+}
+
 func TestHandlerAuthenticate(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -1205,10 +1216,12 @@ func TestHandlerAuthenticate(t *testing.T) {
 	})
 
 	t.Run("without cookie or client cert", func(t *testing.T) {
+		logs := captureWarnLogs(t, appHandler)
 		request := httptest.NewRequest("GET", "https://"+publicAddr, nil)
 		_, err := appHandler.authenticate(ctx, request)
 		require.Error(t, err)
 		require.True(t, trace.IsAccessDenied(err))
+		require.Empty(t, logs.String(), "a missing cookie must not be logged above debug level")
 	})
 
 	t.Run("with cookie subject mismatch", func(t *testing.T) {
@@ -1233,15 +1246,24 @@ func TestHandlerAuthenticate(t *testing.T) {
 		request := httptest.NewRequest("GET", "https://"+publicAddr, nil)
 		addValidSessionCookiesToRequest(authClient.appSession, request)
 
-		// An expired session must not be logged above debug, otherwise a
-		// client replaying the stale cookie floods the logs.
-		var logs bytes.Buffer
-		appHandler.logger = slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))
-
+		logs := captureWarnLogs(t, appHandler)
 		_, err := appHandler.authenticate(ctx, request)
 		require.Error(t, err)
 		require.True(t, trace.IsAccessDenied(err))
 		require.Empty(t, logs.String(), "expired session must not be logged above debug level")
+	})
+
+	t.Run("backend error is logged at warning", func(t *testing.T) {
+		authClient.sessionError = trace.ConnectionProblem(nil, "backend unavailable")
+		t.Cleanup(func() { authClient.sessionError = nil })
+		request := httptest.NewRequest("GET", "https://"+publicAddr, nil)
+		addValidSessionCookiesToRequest(authClient.appSession, request)
+
+		logs := captureWarnLogs(t, appHandler)
+		_, err := appHandler.authenticate(ctx, request)
+		require.Error(t, err)
+		require.True(t, trace.IsAccessDenied(err))
+		require.NotEmpty(t, logs.String(), "an unexpected backend error must be logged at warning level")
 	})
 }
 


### PR DESCRIPTION
Log a failed application session lookup at debug level, not warning, when the session is missing, expired, or invalid. Otherwise a client that keeps sending requests with a stale cookie, such as a browser tab polling after the session TTL elapses, floods the proxy logs with a full stack trace on every request.

Keep the warning for unexpected failures such as backend connection problems. Drop the duplicate log that `authenticate` and `renewSession` emitted on top of `getAppSession`, so a failed lookup logs at most once.

Issue: https://github.com/gravitational/teleport/issues/66138

Changelog: Reduced log spam from expired application sessions.

## Manual Test Plan

### Test Environment

macOS, single local Teleport process running auth, proxy, and app service, with one HTTP app registered and log severity set to `DEBUG`.

### Test Cases

#### Test 1: Invalid app session cookie logs at debug (with fix)

Send several requests to a proxied app carrying an invalid app session cookie, so each request fails the session lookup before forwarding. No login, user, or running backend app is required.

- [x] Each request logs `Failed to fetch application session` at debug level.
- [x] No warning is logged for that message.
- [x] The message is logged at most once per failed request, not twice.

#### Test 2: Valid session unaffected

Log in, launch the app, and confirm normal access still works and no session-fetch warnings appear during use.

- [x] After login, the app loads and authenticated requests forward with HTTP 200.
- [x] No warning is logged during normal app use; the single pre-auth miss from the launch redirect is logged at debug level.

#### Test 3: Regression baseline (without fix)

Build from master (before the fix) and repeat Test 1.

- [x] The master build logs the failed lookup at warning level (twice per request), confirming the pre-fix behaviour the PR changes.
