### PR TITLE
Return typed error for expired reusable SSO/browser MFA responses

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -8634,7 +8634,7 @@ func (a *Server) validateMFAAuthResponseInternal(
 			loginData, err = webLogin.Finish(ctx, user, wantypes.CredentialAssertionResponseFromProto(res.Webauthn), requiredExtensions)
 		}
 		if err != nil {
-			if reuseErr := a.expiredReusableMFAError(ctx, err, requiredExtensions); reuseErr != nil {
+			if reuseErr := a.convertToErrExpiredReusableMFAResponse(ctx, err, requiredExtensions); reuseErr != nil {
 				return nil, trace.Wrap(reuseErr)
 			}
 			return nil, trace.AccessDenied("MFA response validation failed: %v", err)
@@ -8687,21 +8687,20 @@ func (a *Server) verifyMFASessionData(
 	sessionID,
 	username string,
 	requiredExtensions *mfav1.ChallengeExtensions,
-	wrapNotFoundError func(error) error,
+	notFoundErr error,
 ) (*services.MFASessionData, error) {
 	mfaSess, err := a.GetMFASessionData(ctx, sessionID)
 	if err != nil {
-		if reuseErr := a.expiredReusableMFAError(ctx, err, requiredExtensions); reuseErr != nil {
+		if reuseErr := a.convertToErrExpiredReusableMFAResponse(ctx, err, requiredExtensions); reuseErr != nil {
 			return nil, reuseErr
 		}
 		if trace.IsNotFound(err) {
-			return nil, trace.Wrap(notFoundErr)
+			return nil, notFoundErr
 		}
 		return nil, trace.Wrap(err)
 	}
 	if mfaSess.Username != username {
-		return nil, trace.Wrap(notFoundErr)
-
+		return nil, notFoundErr
 	}
 	if requiredExtensions.Scope != mfaSess.ChallengeExtensions.Scope {
 		return nil, trace.AccessDenied("required scope %q is not satisfied by the given MFA session with scope %q", requiredExtensions.Scope, mfaSess.ChallengeExtensions.Scope)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -8671,7 +8671,7 @@ func (a *Server) validateMFAAuthResponseInternal(
 }
 
 func (a *Server) expiredReusableMFAError(ctx context.Context, err error, requiredExtensions *mfav1.ChallengeExtensions) error {
-	if trace.IsNotFound(err) && requiredExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES {
+	if requiredExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES && trace.IsNotFound(err) {
 		a.logger.DebugContext(ctx, "Reusable MFA response validation failed and possibly expired", "error", err)
 		return trace.Wrap(&mfa.ErrExpiredReusableMFAResponse)
 	}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -8691,7 +8691,8 @@ func (a *Server) verifyMFASessionData(ctx context.Context, sessionID, username s
 		return nil, trace.Wrap(err)
 	}
 	if mfaSess.Username != username {
-		return nil, notFoundErr
+		return nil, trace.Wrap(notFoundErr)
+
 	}
 	if requiredExtensions.Scope != mfaSess.ChallengeExtensions.Scope {
 		return nil, trace.AccessDenied("required scope %q is not satisfied by the given MFA session with scope %q", requiredExtensions.Scope, mfaSess.ChallengeExtensions.Scope)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -8635,7 +8635,7 @@ func (a *Server) validateMFAAuthResponseInternal(
 		}
 		if err != nil {
 			if reuseErr := a.expiredReusableMFAError(ctx, err, requiredExtensions); reuseErr != nil {
-				return nil, reuseErr
+				return nil, trace.Wrap(reuseErr)
 			}
 			return nil, trace.AccessDenied("MFA response validation failed: %v", err)
 		}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -8686,7 +8686,7 @@ func (a *Server) verifyMFASessionData(ctx context.Context, sessionID, username s
 			return nil, reuseErr
 		}
 		if trace.IsNotFound(err) {
-			return nil, notFoundErr
+			return nil, trace.Wrap(notFoundErr)
 		}
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -8679,7 +8679,13 @@ func (a *Server) expiredReusableMFAError(ctx context.Context, err error, require
 }
 
 // verifyMFASessionData validates the stored MFA session shared by the SSO and browser MFA verify flows.
-func (a *Server) verifyMFASessionData(ctx context.Context, sessionID, username string, requiredExtensions *mfav1.ChallengeExtensions, notFoundErr error) (*services.MFASessionData, error) {
+func (a *Server) verifyMFASessionData(
+	ctx context.Context,
+	sessionID,
+	username string,
+	requiredExtensions *mfav1.ChallengeExtensions,
+	wrapNotFoundError func(error) error,
+) (*services.MFASessionData, error) {
 	mfaSess, err := a.GetMFASessionData(ctx, sessionID)
 	if err != nil {
 		if reuseErr := a.expiredReusableMFAError(ctx, err, requiredExtensions); reuseErr != nil {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -4481,7 +4481,7 @@ func (a *Server) CreateAuthenticateChallenge(ctx context.Context, req *proto.Cre
 		}
 
 		var err error
-		browserMFAReq, err = a.GetMFASession(ctx, req.BrowserMFARequestID)
+		browserMFAReq, err = a.GetMFASessionData(ctx, req.BrowserMFARequestID)
 		if err != nil {
 			a.logger.WarnContext(ctx, "Failed to read MFA session for browser MFA request", "error", err)
 			return nil, trace.AccessDenied("invalid browser MFA request")

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -8681,13 +8681,15 @@ func (a *Server) convertToErrExpiredReusableMFAResponse(ctx context.Context, err
 	return nil
 }
 
+// mfaSessionDataNotFoundMsg is the client-facing error for a missing, foreign, or wrong-flow MFA session.
+const mfaSessionDataNotFoundMsg = "mfa session data not found"
+
 // verifyMFASessionData validates the stored MFA session shared by the SSO and browser MFA verify flows.
 func (a *Server) verifyMFASessionData(
 	ctx context.Context,
 	sessionID,
 	username string,
 	requiredExtensions *mfav1.ChallengeExtensions,
-	notFoundErr error,
 ) (*services.MFASessionData, error) {
 	mfaSess, err := a.GetMFASessionData(ctx, sessionID)
 	if err != nil {
@@ -8695,12 +8697,12 @@ func (a *Server) verifyMFASessionData(
 			return nil, reuseErr
 		}
 		if trace.IsNotFound(err) {
-			return nil, notFoundErr
+			return nil, trace.AccessDenied("%s", mfaSessionDataNotFoundMsg)
 		}
 		return nil, trace.Wrap(err)
 	}
 	if mfaSess.Username != username {
-		return nil, notFoundErr
+		return nil, trace.AccessDenied("%s", mfaSessionDataNotFoundMsg)
 	}
 	if requiredExtensions.Scope != mfaSess.ChallengeExtensions.Scope {
 		return nil, trace.AccessDenied("required scope %q is not satisfied by the given MFA session with scope %q", requiredExtensions.Scope, mfaSess.ChallengeExtensions.Scope)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -8634,16 +8634,8 @@ func (a *Server) validateMFAAuthResponseInternal(
 			loginData, err = webLogin.Finish(ctx, user, wantypes.CredentialAssertionResponseFromProto(res.Webauthn), requiredExtensions)
 		}
 		if err != nil {
-			if requiredExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES &&
-				trace.IsNotFound(err) {
-				// Do not add extra user messages to
-				// mfa.ErrExpiredReusableMFAResponse. Doing so will prevent
-				// client-side code from using errors.Is to reliably identify
-				// this specific error after it goes through gRPC. The original
-				// error isn't particularly useful to the user anyway, so just
-				// log it at debug level.
-				a.logger.DebugContext(ctx, "Reusable MFA response validation failed and possibly expired", "error", err)
-				return nil, trace.Wrap(&mfa.ErrExpiredReusableMFAResponse)
+			if reuseErr := a.expiredReusableMFAError(ctx, err, requiredExtensions); reuseErr != nil {
+				return nil, reuseErr
 			}
 			return nil, trace.AccessDenied("MFA response validation failed: %v", err)
 		}
@@ -8676,6 +8668,38 @@ func (a *Server) validateMFAAuthResponseInternal(
 	default:
 		return nil, trace.BadParameter("unknown or missing MFAAuthenticateResponse type %T", resp.Response)
 	}
+}
+
+func (a *Server) expiredReusableMFAError(ctx context.Context, err error, requiredExtensions *mfav1.ChallengeExtensions) error {
+	if trace.IsNotFound(err) && requiredExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES {
+		a.logger.DebugContext(ctx, "Reusable MFA response validation failed and possibly expired", "error", err)
+		return trace.Wrap(&mfa.ErrExpiredReusableMFAResponse)
+	}
+	return nil
+}
+
+// verifyMFASessionData validates the stored MFA session shared by the SSO and browser MFA verify flows.
+func (a *Server) verifyMFASessionData(ctx context.Context, sessionID, username string, requiredExtensions *mfav1.ChallengeExtensions, notFoundErr error) (*services.MFASessionData, error) {
+	mfaSess, err := a.GetMFASessionData(ctx, sessionID)
+	if err != nil {
+		if reuseErr := a.expiredReusableMFAError(ctx, err, requiredExtensions); reuseErr != nil {
+			return nil, reuseErr
+		}
+		if trace.IsNotFound(err) {
+			return nil, notFoundErr
+		}
+		return nil, trace.Wrap(err)
+	}
+	if mfaSess.Username != username {
+		return nil, notFoundErr
+	}
+	if requiredExtensions.Scope != mfaSess.ChallengeExtensions.Scope {
+		return nil, trace.AccessDenied("required scope %q is not satisfied by the given MFA session with scope %q", requiredExtensions.Scope, mfaSess.ChallengeExtensions.Scope)
+	}
+	if requiredExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_NO && mfaSess.ChallengeExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES {
+		return nil, trace.AccessDenied("the given MFA session allows reuse, but reuse is not permitted in this context")
+	}
+	return mfaSess, nil
 }
 
 func mergeKeySets(a, b types.CAKeySet) types.CAKeySet {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -8670,7 +8670,10 @@ func (a *Server) validateMFAAuthResponseInternal(
 	}
 }
 
-func (a *Server) expiredReusableMFAError(ctx context.Context, err error, requiredExtensions *mfav1.ChallengeExtensions) error {
+// convertToErrExpiredReusableMFAResponse converts err to
+// mfa.ErrExpiredReusableMFAResponse, if appropriate.
+// Returns nil if the conversion should not apply.
+func (a *Server) convertToErrExpiredReusableMFAResponse(ctx context.Context, err error, requiredExtensions *mfav1.ChallengeExtensions) error {
 	if requiredExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES && trace.IsNotFound(err) {
 		a.logger.DebugContext(ctx, "Reusable MFA response validation failed and possibly expired", "error", err)
 		return trace.Wrap(&mfa.ErrExpiredReusableMFAResponse)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -8697,12 +8697,12 @@ func (a *Server) verifyMFASessionData(
 			return nil, reuseErr
 		}
 		if trace.IsNotFound(err) {
-			return nil, trace.AccessDenied("%s", mfaSessionDataNotFoundMsg)
+			return nil, trace.NotFound("%s", mfaSessionDataNotFoundMsg)
 		}
 		return nil, trace.Wrap(err)
 	}
 	if mfaSess.Username != username {
-		return nil, trace.AccessDenied("%s", mfaSessionDataNotFoundMsg)
+		return nil, trace.NotFound("%s", mfaSessionDataNotFoundMsg)
 	}
 	if requiredExtensions.Scope != mfaSess.ChallengeExtensions.Scope {
 		return nil, trace.AccessDenied("required scope %q is not satisfied by the given MFA session with scope %q", requiredExtensions.Scope, mfaSess.ChallengeExtensions.Scope)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -8697,7 +8697,8 @@ func (a *Server) verifyMFASessionData(ctx context.Context, sessionID, username s
 	if requiredExtensions.Scope != mfaSess.ChallengeExtensions.Scope {
 		return nil, trace.AccessDenied("required scope %q is not satisfied by the given MFA session with scope %q", requiredExtensions.Scope, mfaSess.ChallengeExtensions.Scope)
 	}
-	if requiredExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_NO && mfaSess.ChallengeExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES {
+	if requiredExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_NO &&
+		mfaSess.ChallengeExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES {
 		return nil, trace.AccessDenied("the given MFA session allows reuse, but reuse is not permitted in this context")
 	}
 	return mfaSess, nil

--- a/lib/auth/browser_mfa.go
+++ b/lib/auth/browser_mfa.go
@@ -128,7 +128,8 @@ func (a *Server) VerifyBrowserMFASession(ctx context.Context, username, sessionI
 
 	// Verify the session was created by the Browser MFA flow:
 	// Browser MFA sessions are created with the browser connector and a client redirect URL.
-	if !(mfaSess.ConnectorType == constants.BrowserMFA && mfaSess.TSHRedirectURL != "") {
+	isBrowserMFASession := mfaSess.ConnectorType == constants.BrowserMFA && mfaSess.TSHRedirectURL != ""
+	if !isBrowserMFASession {
 		a.logger.WarnContext(ctx,
 			"Rejecting an MFA session that was not created by the Browser MFA flow.",
 			"request_id", mfaSess.RequestID,

--- a/lib/auth/browser_mfa.go
+++ b/lib/auth/browser_mfa.go
@@ -120,8 +120,7 @@ func (a *Server) VerifyBrowserMFASession(ctx context.Context, username, sessionI
 		return nil, trace.BadParameter("webauthn response must be supplied")
 	}
 
-	const notFoundErrMsg = "browser MFA session data not found"
-	mfaSess, err := a.verifyMFASessionData(ctx, sessionID, username, requiredExtensions, trace.NotFound("%s", notFoundErrMsg))
+	mfaSess, err := a.verifyMFASessionData(ctx, sessionID, username, requiredExtensions)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -136,7 +135,7 @@ func (a *Server) VerifyBrowserMFASession(ctx context.Context, username, sessionI
 			"connector_type", mfaSess.ConnectorType,
 			"username", username,
 		)
-		return nil, trace.NotFound("%s", notFoundErrMsg)
+		return nil, trace.AccessDenied("%s", mfaSessionDataNotFoundMsg)
 	}
 
 	// Check if the MFA session matches the user's Browser MFA settings.

--- a/lib/auth/browser_mfa.go
+++ b/lib/auth/browser_mfa.go
@@ -41,7 +41,7 @@ import (
 func (a *Server) CompleteBrowserMFAChallenge(ctx context.Context, requestID string, webauthnResponse *webauthnpb.CredentialAssertionResponse) (string, error) {
 	const notFoundErrMsg = "mfa session data not found"
 	// Retrieve the MFA session
-	mfaSession, err := a.GetMFASession(ctx, requestID)
+	mfaSession, err := a.GetMFASessionData(ctx, requestID)
 	if trace.IsNotFound(err) {
 		return "", trace.AccessDenied("%s", notFoundErrMsg)
 	} else if err != nil {

--- a/lib/auth/browser_mfa.go
+++ b/lib/auth/browser_mfa.go
@@ -135,7 +135,7 @@ func (a *Server) VerifyBrowserMFASession(ctx context.Context, username, sessionI
 			"connector_type", mfaSess.ConnectorType,
 			"username", username,
 		)
-		return nil, trace.AccessDenied("%s", mfaSessionDataNotFoundMsg)
+		return nil, trace.NotFound("%s", mfaSessionDataNotFoundMsg)
 	}
 
 	// Check if the MFA session matches the user's Browser MFA settings.

--- a/lib/auth/browser_mfa.go
+++ b/lib/auth/browser_mfa.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
+	mfa "github.com/gravitational/teleport/api/mfa"
 	webauthnpb "github.com/gravitational/teleport/api/types/webauthn"
 	"github.com/gravitational/teleport/lib/auth/internal/browsermfa"
 	"github.com/gravitational/teleport/lib/auth/mfatypes"
@@ -123,6 +124,13 @@ func (a *Server) VerifyBrowserMFASession(ctx context.Context, username, sessionI
 	const notFoundErrMsg = "browser MFA session data not found"
 	mfaSess, err := a.GetMFASessionData(ctx, sessionID)
 	if trace.IsNotFound(err) {
+		if requiredExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES {
+			// The session data backing a reusable response expires on its own TTL.
+			// Return the typed error so clients replaying the response refresh it
+			// instead of failing, like the WebAuthn flow does.
+			a.logger.DebugContext(ctx, "Reusable browser MFA session data not found and possibly expired", "error", err)
+			return nil, trace.Wrap(&mfa.ErrExpiredReusableMFAResponse)
+		}
 		return nil, trace.NotFound("%s", notFoundErrMsg)
 	} else if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/browser_mfa.go
+++ b/lib/auth/browser_mfa.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
-	mfa "github.com/gravitational/teleport/api/mfa"
 	webauthnpb "github.com/gravitational/teleport/api/types/webauthn"
 	"github.com/gravitational/teleport/lib/auth/internal/browsermfa"
 	"github.com/gravitational/teleport/lib/auth/mfatypes"
@@ -122,29 +121,16 @@ func (a *Server) VerifyBrowserMFASession(ctx context.Context, username, sessionI
 	}
 
 	const notFoundErrMsg = "browser MFA session data not found"
-	mfaSess, err := a.GetMFASessionData(ctx, sessionID)
-	if trace.IsNotFound(err) {
-		if requiredExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES {
-			// The session data backing a reusable response expires on its own TTL.
-			// Return the typed error so clients replaying the response refresh it
-			// instead of failing, like the WebAuthn flow does.
-			a.logger.DebugContext(ctx, "Reusable browser MFA session data not found and possibly expired", "error", err)
-			return nil, trace.Wrap(&mfa.ErrExpiredReusableMFAResponse)
-		}
-		return nil, trace.NotFound("%s", notFoundErrMsg)
-	} else if err != nil {
+	mfaSess, err := a.verifyMFASessionData(ctx, sessionID, username, requiredExtensions, trace.NotFound("%s", notFoundErrMsg))
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	// Verify the user's name matches.
-	if mfaSess.Username != username {
-		return nil, trace.NotFound("%s", notFoundErrMsg)
-	}
-
-	// Verify this is a Browser MFA session and not an SSO MFA session.
-	if mfaSess.TSHRedirectURL == "" || mfaSess.ConnectorType != constants.BrowserMFA {
+	// Verify the session was created by the Browser MFA flow:
+	// Browser MFA sessions are created with the browser connector and a client redirect URL.
+	if !(mfaSess.ConnectorType == constants.BrowserMFA && mfaSess.TSHRedirectURL != "") {
 		a.logger.WarnContext(ctx,
-			"The Browser MFA flow was used to access a SSO MFA session.",
+			"Rejecting an MFA session that was not created by the Browser MFA flow.",
 			"request_id", mfaSess.RequestID,
 			"connector_type", mfaSess.ConnectorType,
 			"username", username,
@@ -168,22 +154,6 @@ func (a *Server) VerifyBrowserMFASession(ctx context.Context, username, sessionI
 			)
 		}
 		return nil, trace.AccessDenied("browser MFA not available")
-	}
-
-	// Check if the given scope is satisfied by the challenge scope.
-	if requiredExtensions.Scope != mfaSess.ChallengeExtensions.Scope {
-		return nil, trace.AccessDenied(
-			"required scope %q is not satisfied by the given browser MFA session with scope %q",
-			requiredExtensions.Scope,
-			mfaSess.ChallengeExtensions.Scope,
-		)
-	}
-
-	// If this session is reusable, but this context forbids reusable sessions, return an error.
-	reuseNotPermitted := requiredExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_NO
-	sessionAllowsReuse := mfaSess.ChallengeExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES
-	if reuseNotPermitted && sessionAllowsReuse {
-		return nil, trace.AccessDenied("the given browser MFA session allows reuse, but reuse is not permitted in this context")
 	}
 
 	// Convert from protobuf type to wantypes

--- a/lib/auth/browser_mfa_test.go
+++ b/lib/auth/browser_mfa_test.go
@@ -855,7 +855,7 @@ func TestVerifyBrowserMFASession(t *testing.T) {
 		}
 	})
 
-	t.Run("same access denied error for missing session and username mismatch", func(t *testing.T) {
+	t.Run("same not found error for missing session and username mismatch", func(t *testing.T) {
 		env := newBrowserMFATestEnv(t)
 
 		for _, tt := range []struct {
@@ -880,7 +880,7 @@ func TestVerifyBrowserMFASession(t *testing.T) {
 
 				mad, err := env.auth.VerifyBrowserMFASession(ctx, env.webauthnUser.GetName(), "session-id", &webauthnpb.CredentialAssertionResponse{}, loginExt)
 				require.Nil(t, mad)
-				require.True(t, trace.IsAccessDenied(err), "expected access denied error but got %v", err)
+				require.True(t, trace.IsNotFound(err), "expected not found error but got %v", err)
 				require.EqualError(t, err, notFoundErrMsg)
 			})
 		}

--- a/lib/auth/browser_mfa_test.go
+++ b/lib/auth/browser_mfa_test.go
@@ -816,7 +816,7 @@ func TestVerifyBrowserMFASession(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	const notFoundErrMsg = "browser MFA session data not found"
+	const notFoundErrMsg = "mfa session data not found"
 	loginExt := &mfav1.ChallengeExtensions{
 		Scope: mfav1.ChallengeScope_CHALLENGE_SCOPE_LOGIN,
 	}
@@ -855,7 +855,7 @@ func TestVerifyBrowserMFASession(t *testing.T) {
 		}
 	})
 
-	t.Run("same not found error for missing session and username mismatch", func(t *testing.T) {
+	t.Run("same access denied error for missing session and username mismatch", func(t *testing.T) {
 		env := newBrowserMFATestEnv(t)
 
 		for _, tt := range []struct {
@@ -880,7 +880,7 @@ func TestVerifyBrowserMFASession(t *testing.T) {
 
 				mad, err := env.auth.VerifyBrowserMFASession(ctx, env.webauthnUser.GetName(), "session-id", &webauthnpb.CredentialAssertionResponse{}, loginExt)
 				require.Nil(t, mad)
-				require.True(t, trace.IsNotFound(err), "expected not found error but got %v", err)
+				require.True(t, trace.IsAccessDenied(err), "expected access denied error but got %v", err)
 				require.EqualError(t, err, notFoundErrMsg)
 			})
 		}

--- a/lib/auth/browser_mfa_test.go
+++ b/lib/auth/browser_mfa_test.go
@@ -894,8 +894,8 @@ func TestVerifyBrowserMFASession(t *testing.T) {
 		}
 
 		mad, err := env.auth.VerifyBrowserMFASession(ctx, env.webauthnUser.GetName(), "expired-session", &webauthnpb.CredentialAssertionResponse{}, reuseExt)
-		require.Nil(t, mad)
-		require.ErrorIs(t, err, &mfa.ErrExpiredReusableMFAResponse)
+		assert.ErrorIs(t, err, &mfa.ErrExpiredReusableMFAResponse)
+		assert.Nil(t, mad)
 	})
 
 	t.Run("access denied when user has no webauthn devices", func(t *testing.T) {

--- a/lib/auth/browser_mfa_test.go
+++ b/lib/auth/browser_mfa_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
+	mfa "github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	webauthnpb "github.com/gravitational/teleport/api/types/webauthn"
 	"github.com/gravitational/teleport/lib/auth"
@@ -883,6 +884,18 @@ func TestVerifyBrowserMFASession(t *testing.T) {
 				require.EqualError(t, err, notFoundErrMsg)
 			})
 		}
+	})
+
+	t.Run("expired reusable MFA response when session is missing and reuse is allowed", func(t *testing.T) {
+		env := newBrowserMFATestEnv(t)
+		reuseExt := &mfav1.ChallengeExtensions{
+			Scope:      mfav1.ChallengeScope_CHALLENGE_SCOPE_USER_SESSION,
+			AllowReuse: mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES,
+		}
+
+		mad, err := env.auth.VerifyBrowserMFASession(ctx, env.webauthnUser.GetName(), "expired-session", &webauthnpb.CredentialAssertionResponse{}, reuseExt)
+		require.Nil(t, mad)
+		require.ErrorIs(t, err, &mfa.ErrExpiredReusableMFAResponse)
 	})
 
 	t.Run("access denied when user has no webauthn devices", func(t *testing.T) {

--- a/lib/auth/sso_mfa.go
+++ b/lib/auth/sso_mfa.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	mfav2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v2"
+	mfa "github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/mfatypes"
 	"github.com/gravitational/teleport/lib/authz"
@@ -103,6 +104,13 @@ func (a *Server) VerifySSOMFASession(ctx context.Context, username, sessionID, t
 	const notFoundErrMsg = "mfa sso session data not found"
 	mfaSess, err := a.GetMFASessionData(ctx, sessionID)
 	if trace.IsNotFound(err) {
+		if requiredExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES {
+			// The session data backing a reusable response expires on its own TTL.
+			// Return the typed error so clients replaying the response refresh it
+			// instead of failing, like the WebAuthn flow does.
+			a.logger.DebugContext(ctx, "Reusable SSO MFA session data not found and possibly expired", "error", err)
+			return nil, trace.Wrap(&mfa.ErrExpiredReusableMFAResponse)
+		}
 		return nil, trace.AccessDenied("%s", notFoundErrMsg)
 	} else if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/sso_mfa.go
+++ b/lib/auth/sso_mfa.go
@@ -109,7 +109,8 @@ func (a *Server) VerifySSOMFASession(ctx context.Context, username, sessionID, t
 
 	// Verify the session was created by the SSO MFA flow:
 	// SSO MFA sessions are created with an SSO connector and no client redirect URL.
-	if !(slices.Contains([]string{constants.SAML, constants.OIDC}, mfaSess.ConnectorType) && mfaSess.TSHRedirectURL == "") {
+	isSSOMFASession := slices.Contains([]string{constants.SAML, constants.OIDC}, mfaSess.ConnectorType) && mfaSess.TSHRedirectURL == ""
+	if !isSSOMFASession {
 		a.logger.WarnContext(ctx,
 			"Rejecting an MFA session that was not created by the SSO MFA flow.",
 			"request_id", mfaSess.RequestID,

--- a/lib/auth/sso_mfa.go
+++ b/lib/auth/sso_mfa.go
@@ -116,7 +116,7 @@ func (a *Server) VerifySSOMFASession(ctx context.Context, username, sessionID, t
 			"connector_type", mfaSess.ConnectorType,
 			"username", username,
 		)
-		return nil, trace.AccessDenied("%s", mfaSessionDataNotFoundMsg)
+		return nil, trace.NotFound("%s", mfaSessionDataNotFoundMsg)
 	}
 
 	// Check if the MFA session matches the user's SSO MFA settings.

--- a/lib/auth/sso_mfa.go
+++ b/lib/auth/sso_mfa.go
@@ -19,6 +19,7 @@ package auth
 import (
 	"context"
 	"crypto/subtle"
+	"slices"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/oauth2"
@@ -27,7 +28,6 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	mfav2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v2"
-	mfa "github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/mfatypes"
 	"github.com/gravitational/teleport/lib/authz"
@@ -102,29 +102,16 @@ func (a *Server) VerifySSOMFASession(ctx context.Context, username, sessionID, t
 	}
 
 	const notFoundErrMsg = "mfa sso session data not found"
-	mfaSess, err := a.GetMFASessionData(ctx, sessionID)
-	if trace.IsNotFound(err) {
-		if requiredExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES {
-			// The session data backing a reusable response expires on its own TTL.
-			// Return the typed error so clients replaying the response refresh it
-			// instead of failing, like the WebAuthn flow does.
-			a.logger.DebugContext(ctx, "Reusable SSO MFA session data not found and possibly expired", "error", err)
-			return nil, trace.Wrap(&mfa.ErrExpiredReusableMFAResponse)
-		}
-		return nil, trace.AccessDenied("%s", notFoundErrMsg)
-	} else if err != nil {
+	mfaSess, err := a.verifyMFASessionData(ctx, sessionID, username, requiredExtensions, trace.AccessDenied("%s", notFoundErrMsg))
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	// Verify the user's name and sso device matches.
-	if mfaSess.Username != username {
-		return nil, trace.AccessDenied("%s", notFoundErrMsg)
-	}
-
-	// Verify this is an SSO MFA session and not a Browser MFA session.
-	if mfaSess.TSHRedirectURL != "" || mfaSess.ConnectorType == constants.BrowserMFA {
+	// Verify the session was created by the SSO MFA flow:
+	// SSO MFA sessions are created with an SSO connector and no client redirect URL.
+	if !(slices.Contains([]string{constants.SAML, constants.OIDC}, mfaSess.ConnectorType) && mfaSess.TSHRedirectURL == "") {
 		a.logger.WarnContext(ctx,
-			"The SSO MFA flow was used to access a Browser MFA session.",
+			"Rejecting an MFA session that was not created by the SSO MFA flow.",
 			"request_id", mfaSess.RequestID,
 			"connector_type", mfaSess.ConnectorType,
 			"username", username,
@@ -148,16 +135,6 @@ func (a *Server) VerifySSOMFASession(ctx context.Context, username, sessionID, t
 	// Verify the token matches.
 	if subtle.ConstantTimeCompare([]byte(mfaSess.Token), []byte(token)) == 0 {
 		return nil, trace.AccessDenied("invalid SSO MFA challenge response")
-	}
-
-	// Check if the given scope is satisfied by the challenge scope.
-	if requiredExtensions.Scope != mfaSess.ChallengeExtensions.Scope {
-		return nil, trace.AccessDenied("required scope %q is not satisfied by the given sso mfa session with scope %q", requiredExtensions.Scope, mfaSess.ChallengeExtensions.Scope)
-	}
-
-	// If this session is reusable, but this context forbids reusable sessions, return an error.
-	if requiredExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_NO && mfaSess.ChallengeExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES {
-		return nil, trace.AccessDenied("the given sso mfa session allows reuse, but reuse is not permitted in this context")
 	}
 
 	if mfaSess.ChallengeExtensions.AllowReuse != mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES {

--- a/lib/auth/sso_mfa.go
+++ b/lib/auth/sso_mfa.go
@@ -231,21 +231,11 @@ func (a *Server) UpsertMFASessionWithToken(ctx context.Context, sd *services.MFA
 	return sd.Token, nil
 }
 
-// GetMFASession returns the MFA session for the given username and sessionID.
-func (a *Server) GetMFASession(ctx context.Context, sessionID string) (*services.MFASessionData, error) {
-	sd, err := a.GetMFASessionData(ctx, sessionID)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return sd, nil
-}
-
 // TODO(danielashare): Remove these wrapper functions once `e` points to the renamed versions
 func (a *Server) UpsertSSOMFASessionWithToken(ctx context.Context, sd *services.MFASessionData) (token string, err error) {
 	return a.UpsertMFASessionWithToken(ctx, sd)
 }
 
 func (a *Server) GetSSOMFASession(ctx context.Context, sessionID string) (*services.MFASessionData, error) {
-	return a.GetMFASession(ctx, sessionID)
+	return a.GetMFASessionData(ctx, sessionID)
 }

--- a/lib/auth/sso_mfa.go
+++ b/lib/auth/sso_mfa.go
@@ -101,8 +101,7 @@ func (a *Server) VerifySSOMFASession(ctx context.Context, username, sessionID, t
 		return nil, trace.BadParameter("requested challenge extensions must be supplied.")
 	}
 
-	const notFoundErrMsg = "mfa sso session data not found"
-	mfaSess, err := a.verifyMFASessionData(ctx, sessionID, username, requiredExtensions, trace.AccessDenied("%s", notFoundErrMsg))
+	mfaSess, err := a.verifyMFASessionData(ctx, sessionID, username, requiredExtensions)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -117,7 +116,7 @@ func (a *Server) VerifySSOMFASession(ctx context.Context, username, sessionID, t
 			"connector_type", mfaSess.ConnectorType,
 			"username", username,
 		)
-		return nil, trace.NotFound("%s", notFoundErrMsg)
+		return nil, trace.AccessDenied("%s", mfaSessionDataNotFoundMsg)
 	}
 
 	// Check if the MFA session matches the user's SSO MFA settings.

--- a/lib/auth/sso_mfa_test.go
+++ b/lib/auth/sso_mfa_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
+	mfa "github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -480,6 +481,25 @@ func TestSSOMFAChallenge_Validation(t *testing.T) {
 			requiredExtensions: &mfav1.ChallengeExtensions{},
 			assertValidation: func(t *testing.T, mad *authz.MFAAuthData, err error) {
 				require.True(t, trace.IsAccessDenied(err), "expected access denied error but got %v", err)
+			},
+		},
+		{
+			// The session data backing a reusable response expires on its own TTL,
+			// so a missing session with reuse allowed is reported as an expired
+			// reusable response, not as a generic access denied error.
+			name:     "NOK no session data with reuse allowed",
+			username: samlUser.GetName(),
+			sd:       nil,
+			ssoResponse: &proto.SSOResponse{
+				RequestId: "unknown",
+				Token:     "token",
+			},
+			requiredExtensions: &mfav1.ChallengeExtensions{
+				Scope:      mfav1.ChallengeScope_CHALLENGE_SCOPE_USER_SESSION,
+				AllowReuse: mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES,
+			},
+			assertValidation: func(t *testing.T, mad *authz.MFAAuthData, err error) {
+				require.ErrorIs(t, err, &mfa.ErrExpiredReusableMFAResponse)
 			},
 		},
 		{

--- a/lib/auth/sso_mfa_test.go
+++ b/lib/auth/sso_mfa_test.go
@@ -480,7 +480,7 @@ func TestSSOMFAChallenge_Validation(t *testing.T) {
 			},
 			requiredExtensions: &mfav1.ChallengeExtensions{},
 			assertValidation: func(t *testing.T, mad *authz.MFAAuthData, err error) {
-				require.True(t, trace.IsAccessDenied(err), "expected access denied error but got %v", err)
+				require.True(t, trace.IsNotFound(err), "expected not found error but got %v", err)
 			},
 		},
 		{
@@ -523,7 +523,7 @@ func TestSSOMFAChallenge_Validation(t *testing.T) {
 				Scope: mfav1.ChallengeScope_CHALLENGE_SCOPE_LOGIN,
 			},
 			assertValidation: func(t *testing.T, mad *authz.MFAAuthData, err error) {
-				require.True(t, trace.IsAccessDenied(err), "expected access denied error but got %v", err)
+				require.True(t, trace.IsNotFound(err), "expected not found error but got %v", err)
 			},
 		},
 		{


### PR DESCRIPTION
Expired reusable SSO and browser MFA responses surfaced as generic AccessDenied/NotFound errors instead of `mfa.ErrExpiredReusableMFAResponse`, so clients replaying a reusable response (`tsh db exec` today, `tsh proxy kube` after #68522) failed instead of running a fresh MFA ceremony. `VerifySSOMFASession` and `VerifyBrowserMFASession` now map missing session data to the typed error when reuse is allowed, mirroring the WebAuthn branch of `validateMFAAuthResponse`.

Fixes #68929