### PR TITLE
Add label_expression to kube and ssh blocks for scoped roles

### DIFF
--- a/api/gen/proto/go/teleport/scopes/access/v1/role_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role_protohybrid.pb.go
@@ -631,9 +631,12 @@ type ScopedRoleSSH struct {
 	DisconnectExpiredCert *bool `protobuf:"varint,14,opt,name=disconnect_expired_cert,json=disconnectExpiredCert,proto3,oneof" json:"disconnect_expired_cert,omitempty"`
 	// Lock configures the role's locking behavior for SSH sessions.
 	// If empty, the defaults block value (or global default) applies.
-	Lock          *Lock `protobuf:"bytes,15,opt,name=lock,proto3" json:"lock,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Lock *Lock `protobuf:"bytes,15,opt,name=lock,proto3" json:"lock,omitempty"`
+	// LabelExpression is an optional predicate expression evaluated against an
+	// ssh node's labels.
+	LabelExpression string `protobuf:"bytes,16,opt,name=label_expression,json=labelExpression,proto3" json:"label_expression,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *ScopedRoleSSH) Reset() {
@@ -759,6 +762,13 @@ func (x *ScopedRoleSSH) GetLock() *Lock {
 	return nil
 }
 
+func (x *ScopedRoleSSH) GetLabelExpression() string {
+	if x != nil {
+		return x.LabelExpression
+	}
+	return ""
+}
+
 func (x *ScopedRoleSSH) SetLogins(v []string) {
 	x.Logins = v
 }
@@ -813,6 +823,10 @@ func (x *ScopedRoleSSH) SetDisconnectExpiredCert(v bool) {
 
 func (x *ScopedRoleSSH) SetLock(v *Lock) {
 	x.Lock = v
+}
+
+func (x *ScopedRoleSSH) SetLabelExpression(v string) {
+	x.LabelExpression = v
 }
 
 func (x *ScopedRoleSSH) HasPermitX11Forwarding() bool {
@@ -964,6 +978,9 @@ type ScopedRoleSSH_builder struct {
 	// Lock configures the role's locking behavior for SSH sessions.
 	// If empty, the defaults block value (or global default) applies.
 	Lock *Lock
+	// LabelExpression is an optional predicate expression evaluated against an
+	// ssh node's labels.
+	LabelExpression string
 }
 
 func (b0 ScopedRoleSSH_builder) Build() *ScopedRoleSSH {
@@ -984,6 +1001,7 @@ func (b0 ScopedRoleSSH_builder) Build() *ScopedRoleSSH {
 	x.SessionRecording = b.SessionRecording
 	x.DisconnectExpiredCert = b.DisconnectExpiredCert
 	x.Lock = b.Lock
+	x.LabelExpression = b.LabelExpression
 	return m0
 }
 
@@ -1011,9 +1029,12 @@ type ScopedRoleKube struct {
 	DisconnectExpiredCert *bool `protobuf:"varint,6,opt,name=disconnect_expired_cert,json=disconnectExpiredCert,proto3,oneof" json:"disconnect_expired_cert,omitempty"`
 	// Lock configures the role's locking behavior for kubernetes sessions.
 	// If empty, the defaults block value (or global default) applies.
-	Lock          *Lock `protobuf:"bytes,7,opt,name=lock,proto3" json:"lock,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Lock *Lock `protobuf:"bytes,7,opt,name=lock,proto3" json:"lock,omitempty"`
+	// LabelExpression is an optional predicate expression evaluated against a
+	// kubernetes server's labels.
+	LabelExpression string `protobuf:"bytes,8,opt,name=label_expression,json=labelExpression,proto3" json:"label_expression,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *ScopedRoleKube) Reset() {
@@ -1090,6 +1111,13 @@ func (x *ScopedRoleKube) GetLock() *Lock {
 	return nil
 }
 
+func (x *ScopedRoleKube) GetLabelExpression() string {
+	if x != nil {
+		return x.LabelExpression
+	}
+	return ""
+}
+
 func (x *ScopedRoleKube) SetLabels(v []*v11.Label) {
 	x.Labels = v
 }
@@ -1116,6 +1144,10 @@ func (x *ScopedRoleKube) SetDisconnectExpiredCert(v bool) {
 
 func (x *ScopedRoleKube) SetLock(v *Lock) {
 	x.Lock = v
+}
+
+func (x *ScopedRoleKube) SetLabelExpression(v string) {
+	x.LabelExpression = v
 }
 
 func (x *ScopedRoleKube) HasDisconnectExpiredCert() bool {
@@ -1161,6 +1193,9 @@ type ScopedRoleKube_builder struct {
 	// Lock configures the role's locking behavior for kubernetes sessions.
 	// If empty, the defaults block value (or global default) applies.
 	Lock *Lock
+	// LabelExpression is an optional predicate expression evaluated against a
+	// kubernetes server's labels.
+	LabelExpression string
 }
 
 func (b0 ScopedRoleKube_builder) Build() *ScopedRoleKube {
@@ -1174,6 +1209,7 @@ func (b0 ScopedRoleKube_builder) Build() *ScopedRoleKube {
 	x.ClientIdleTimeout = b.ClientIdleTimeout
 	x.DisconnectExpiredCert = b.DisconnectExpiredCert
 	x.Lock = b.Lock
+	x.LabelExpression = b.LabelExpression
 	return m0
 }
 
@@ -2209,7 +2245,7 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x11session_recording\x18\x02 \x01(\v2+.teleport.scopes.access.v1.SessionRecordingR\x10sessionRecording\x12;\n" +
 	"\x17disconnect_expired_cert\x18\x03 \x01(\bH\x00R\x15disconnectExpiredCert\x88\x01\x01\x123\n" +
 	"\x04lock\x18\x04 \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x1a\n" +
-	"\x18_disconnect_expired_cert\"\x99\a\n" +
+	"\x18_disconnect_expired_cert\"\xc4\a\n" +
 	"\rScopedRoleSSH\x12\x16\n" +
 	"\x06logins\x18\x01 \x03(\tR\x06logins\x120\n" +
 	"\x06labels\x18\x02 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12.\n" +
@@ -2225,13 +2261,14 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x12enhanced_recording\x18\f \x01(\v2,.teleport.scopes.access.v1.EnhancedRecordingR\x11enhancedRecording\x12X\n" +
 	"\x11session_recording\x18\r \x01(\v2+.teleport.scopes.access.v1.SessionRecordingR\x10sessionRecording\x12;\n" +
 	"\x17disconnect_expired_cert\x18\x0e \x01(\bH\x04R\x15disconnectExpiredCert\x88\x01\x01\x123\n" +
-	"\x04lock\x18\x0f \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x18\n" +
+	"\x04lock\x18\x0f \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lock\x12)\n" +
+	"\x10label_expression\x18\x10 \x01(\tR\x0flabelExpressionB\x18\n" +
 	"\x16_permit_x11_forwardingB\x10\n" +
 	"\x0e_forward_agentB\x0f\n" +
 	"\r_max_sessionsB\f\n" +
 	"\n" +
 	"_file_copyB\x1a\n" +
-	"\x18_disconnect_expired_cert\"\xf5\x02\n" +
+	"\x18_disconnect_expired_cert\"\xa0\x03\n" +
 	"\x0eScopedRoleKube\x120\n" +
 	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12\x16\n" +
 	"\x06groups\x18\x02 \x03(\tR\x06groups\x12\x14\n" +
@@ -2239,7 +2276,8 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\tresources\x18\x04 \x03(\v2'.teleport.scopes.access.v1.KubeResourceR\tresources\x12.\n" +
 	"\x13client_idle_timeout\x18\x05 \x01(\tR\x11clientIdleTimeout\x12;\n" +
 	"\x17disconnect_expired_cert\x18\x06 \x01(\bH\x00R\x15disconnectExpiredCert\x88\x01\x01\x123\n" +
-	"\x04lock\x18\a \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x1a\n" +
+	"\x04lock\x18\a \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lock\x12)\n" +
+	"\x10label_expression\x18\b \x01(\tR\x0flabelExpressionB\x1a\n" +
 	"\x18_disconnect_expired_cert\"N\n" +
 	"\x1aScopedRoleWorkloadIdentity\x120\n" +
 	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\"\xaa\x02\n" +

--- a/api/gen/proto/go/teleport/scopes/access/v1/role_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role_protoopaque.pb.go
@@ -590,6 +590,7 @@ type ScopedRoleSSH struct {
 	xxx_hidden_SessionRecording      *SessionRecording      `protobuf:"bytes,13,opt,name=session_recording,json=sessionRecording,proto3"`
 	xxx_hidden_DisconnectExpiredCert bool                   `protobuf:"varint,14,opt,name=disconnect_expired_cert,json=disconnectExpiredCert,proto3,oneof"`
 	xxx_hidden_Lock                  *Lock                  `protobuf:"bytes,15,opt,name=lock,proto3"`
+	xxx_hidden_LabelExpression       string                 `protobuf:"bytes,16,opt,name=label_expression,json=labelExpression,proto3"`
 	XXX_raceDetectHookData           protoimpl.RaceDetectHookData
 	XXX_presence                     [1]uint32
 	unknownFields                    protoimpl.UnknownFields
@@ -721,6 +722,13 @@ func (x *ScopedRoleSSH) GetLock() *Lock {
 	return nil
 }
 
+func (x *ScopedRoleSSH) GetLabelExpression() string {
+	if x != nil {
+		return x.xxx_hidden_LabelExpression
+	}
+	return ""
+}
+
 func (x *ScopedRoleSSH) SetLogins(v []string) {
 	x.xxx_hidden_Logins = v
 }
@@ -735,12 +743,12 @@ func (x *ScopedRoleSSH) SetClientIdleTimeout(v string) {
 
 func (x *ScopedRoleSSH) SetPermitX11Forwarding(v bool) {
 	x.xxx_hidden_PermitX11Forwarding = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 3, 14)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 3, 15)
 }
 
 func (x *ScopedRoleSSH) SetForwardAgent(v bool) {
 	x.xxx_hidden_ForwardAgent = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 4, 14)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 4, 15)
 }
 
 func (x *ScopedRoleSSH) SetPortForwarding(v *SSHPortForwarding) {
@@ -753,7 +761,7 @@ func (x *ScopedRoleSSH) SetHostUserCreation(v *CreateHostUser) {
 
 func (x *ScopedRoleSSH) SetMaxSessions(v int64) {
 	x.xxx_hidden_MaxSessions = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 7, 14)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 7, 15)
 }
 
 func (x *ScopedRoleSSH) SetHostSudoers(v []string) {
@@ -762,7 +770,7 @@ func (x *ScopedRoleSSH) SetHostSudoers(v []string) {
 
 func (x *ScopedRoleSSH) SetFileCopy(v bool) {
 	x.xxx_hidden_FileCopy = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 9, 14)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 9, 15)
 }
 
 func (x *ScopedRoleSSH) SetEnhancedRecording(v *EnhancedRecording) {
@@ -775,11 +783,15 @@ func (x *ScopedRoleSSH) SetSessionRecording(v *SessionRecording) {
 
 func (x *ScopedRoleSSH) SetDisconnectExpiredCert(v bool) {
 	x.xxx_hidden_DisconnectExpiredCert = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 12, 14)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 12, 15)
 }
 
 func (x *ScopedRoleSSH) SetLock(v *Lock) {
 	x.xxx_hidden_Lock = v
+}
+
+func (x *ScopedRoleSSH) SetLabelExpression(v string) {
+	x.xxx_hidden_LabelExpression = v
 }
 
 func (x *ScopedRoleSSH) HasPermitX11Forwarding() bool {
@@ -936,6 +948,9 @@ type ScopedRoleSSH_builder struct {
 	// Lock configures the role's locking behavior for SSH sessions.
 	// If empty, the defaults block value (or global default) applies.
 	Lock *Lock
+	// LabelExpression is an optional predicate expression evaluated against an
+	// ssh node's labels.
+	LabelExpression string
 }
 
 func (b0 ScopedRoleSSH_builder) Build() *ScopedRoleSSH {
@@ -946,31 +961,32 @@ func (b0 ScopedRoleSSH_builder) Build() *ScopedRoleSSH {
 	x.xxx_hidden_Labels = &b.Labels
 	x.xxx_hidden_ClientIdleTimeout = b.ClientIdleTimeout
 	if b.PermitX11Forwarding != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 3, 14)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 3, 15)
 		x.xxx_hidden_PermitX11Forwarding = *b.PermitX11Forwarding
 	}
 	if b.ForwardAgent != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 4, 14)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 4, 15)
 		x.xxx_hidden_ForwardAgent = *b.ForwardAgent
 	}
 	x.xxx_hidden_PortForwarding = b.PortForwarding
 	x.xxx_hidden_HostUserCreation = b.HostUserCreation
 	if b.MaxSessions != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 7, 14)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 7, 15)
 		x.xxx_hidden_MaxSessions = *b.MaxSessions
 	}
 	x.xxx_hidden_HostSudoers = b.HostSudoers
 	if b.FileCopy != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 9, 14)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 9, 15)
 		x.xxx_hidden_FileCopy = *b.FileCopy
 	}
 	x.xxx_hidden_EnhancedRecording = b.EnhancedRecording
 	x.xxx_hidden_SessionRecording = b.SessionRecording
 	if b.DisconnectExpiredCert != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 12, 14)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 12, 15)
 		x.xxx_hidden_DisconnectExpiredCert = *b.DisconnectExpiredCert
 	}
 	x.xxx_hidden_Lock = b.Lock
+	x.xxx_hidden_LabelExpression = b.LabelExpression
 	return m0
 }
 
@@ -988,6 +1004,7 @@ type ScopedRoleKube struct {
 	xxx_hidden_ClientIdleTimeout     string                 `protobuf:"bytes,5,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3"`
 	xxx_hidden_DisconnectExpiredCert bool                   `protobuf:"varint,6,opt,name=disconnect_expired_cert,json=disconnectExpiredCert,proto3,oneof"`
 	xxx_hidden_Lock                  *Lock                  `protobuf:"bytes,7,opt,name=lock,proto3"`
+	xxx_hidden_LabelExpression       string                 `protobuf:"bytes,8,opt,name=label_expression,json=labelExpression,proto3"`
 	XXX_raceDetectHookData           protoimpl.RaceDetectHookData
 	XXX_presence                     [1]uint32
 	unknownFields                    protoimpl.UnknownFields
@@ -1072,6 +1089,13 @@ func (x *ScopedRoleKube) GetLock() *Lock {
 	return nil
 }
 
+func (x *ScopedRoleKube) GetLabelExpression() string {
+	if x != nil {
+		return x.xxx_hidden_LabelExpression
+	}
+	return ""
+}
+
 func (x *ScopedRoleKube) SetLabels(v []*v11.Label) {
 	x.xxx_hidden_Labels = &v
 }
@@ -1094,11 +1118,15 @@ func (x *ScopedRoleKube) SetClientIdleTimeout(v string) {
 
 func (x *ScopedRoleKube) SetDisconnectExpiredCert(v bool) {
 	x.xxx_hidden_DisconnectExpiredCert = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 5, 7)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 5, 8)
 }
 
 func (x *ScopedRoleKube) SetLock(v *Lock) {
 	x.xxx_hidden_Lock = v
+}
+
+func (x *ScopedRoleKube) SetLabelExpression(v string) {
+	x.xxx_hidden_LabelExpression = v
 }
 
 func (x *ScopedRoleKube) HasDisconnectExpiredCert() bool {
@@ -1145,6 +1173,9 @@ type ScopedRoleKube_builder struct {
 	// Lock configures the role's locking behavior for kubernetes sessions.
 	// If empty, the defaults block value (or global default) applies.
 	Lock *Lock
+	// LabelExpression is an optional predicate expression evaluated against a
+	// kubernetes server's labels.
+	LabelExpression string
 }
 
 func (b0 ScopedRoleKube_builder) Build() *ScopedRoleKube {
@@ -1157,10 +1188,11 @@ func (b0 ScopedRoleKube_builder) Build() *ScopedRoleKube {
 	x.xxx_hidden_Resources = &b.Resources
 	x.xxx_hidden_ClientIdleTimeout = b.ClientIdleTimeout
 	if b.DisconnectExpiredCert != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 5, 7)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 5, 8)
 		x.xxx_hidden_DisconnectExpiredCert = *b.DisconnectExpiredCert
 	}
 	x.xxx_hidden_Lock = b.Lock
+	x.xxx_hidden_LabelExpression = b.LabelExpression
 	return m0
 }
 
@@ -2205,7 +2237,7 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x11session_recording\x18\x02 \x01(\v2+.teleport.scopes.access.v1.SessionRecordingR\x10sessionRecording\x12;\n" +
 	"\x17disconnect_expired_cert\x18\x03 \x01(\bH\x00R\x15disconnectExpiredCert\x88\x01\x01\x123\n" +
 	"\x04lock\x18\x04 \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x1a\n" +
-	"\x18_disconnect_expired_cert\"\x99\a\n" +
+	"\x18_disconnect_expired_cert\"\xc4\a\n" +
 	"\rScopedRoleSSH\x12\x16\n" +
 	"\x06logins\x18\x01 \x03(\tR\x06logins\x120\n" +
 	"\x06labels\x18\x02 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12.\n" +
@@ -2221,13 +2253,14 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x12enhanced_recording\x18\f \x01(\v2,.teleport.scopes.access.v1.EnhancedRecordingR\x11enhancedRecording\x12X\n" +
 	"\x11session_recording\x18\r \x01(\v2+.teleport.scopes.access.v1.SessionRecordingR\x10sessionRecording\x12;\n" +
 	"\x17disconnect_expired_cert\x18\x0e \x01(\bH\x04R\x15disconnectExpiredCert\x88\x01\x01\x123\n" +
-	"\x04lock\x18\x0f \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x18\n" +
+	"\x04lock\x18\x0f \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lock\x12)\n" +
+	"\x10label_expression\x18\x10 \x01(\tR\x0flabelExpressionB\x18\n" +
 	"\x16_permit_x11_forwardingB\x10\n" +
 	"\x0e_forward_agentB\x0f\n" +
 	"\r_max_sessionsB\f\n" +
 	"\n" +
 	"_file_copyB\x1a\n" +
-	"\x18_disconnect_expired_cert\"\xf5\x02\n" +
+	"\x18_disconnect_expired_cert\"\xa0\x03\n" +
 	"\x0eScopedRoleKube\x120\n" +
 	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12\x16\n" +
 	"\x06groups\x18\x02 \x03(\tR\x06groups\x12\x14\n" +
@@ -2235,7 +2268,8 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\tresources\x18\x04 \x03(\v2'.teleport.scopes.access.v1.KubeResourceR\tresources\x12.\n" +
 	"\x13client_idle_timeout\x18\x05 \x01(\tR\x11clientIdleTimeout\x12;\n" +
 	"\x17disconnect_expired_cert\x18\x06 \x01(\bH\x00R\x15disconnectExpiredCert\x88\x01\x01\x123\n" +
-	"\x04lock\x18\a \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x1a\n" +
+	"\x04lock\x18\a \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lock\x12)\n" +
+	"\x10label_expression\x18\b \x01(\tR\x0flabelExpressionB\x1a\n" +
 	"\x18_disconnect_expired_cert\"N\n" +
 	"\x1aScopedRoleWorkloadIdentity\x120\n" +
 	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\"\xaa\x02\n" +

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -165,6 +165,10 @@ message ScopedRoleSSH {
   // Lock configures the role's locking behavior for SSH sessions.
   // If empty, the defaults block value (or global default) applies.
   Lock lock = 15;
+
+  // LabelExpression is an optional predicate expression evaluated against an
+  // ssh node's labels.
+  string label_expression = 16;
 }
 
 // The group of all scoped role fields relevant to kube access. Fields within the kube block
@@ -197,6 +201,10 @@ message ScopedRoleKube {
   // Lock configures the role's locking behavior for kubernetes sessions.
   // If empty, the defaults block value (or global default) applies.
   Lock lock = 7;
+
+  // LabelExpression is an optional predicate expression evaluated against a
+  // kubernetes server's labels.
+  string label_expression = 8;
 }
 
 // ScopedRoleWorkloadIdentity groups all scoped role fields relevant to issuing

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedrolesv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedrolesv1.mdx
@@ -89,6 +89,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |client_idle_timeout|string|Overrides the defaults block idle timeout specifically for kube sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.|
 |disconnect_expired_cert|boolean|DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires. If empty, the defaults block value (or global default) applies.|
 |groups|[]string|The list of kubernetes groups this role allows.|
+|label_expression|string|LabelExpression is an optional predicate expression evaluated against a kubernetes server's labels.|
 |labels|[][object](#speckubelabels-items)|The map of kubernetes cluster labels used for RBAC.|
 |lock|[object](#speckubelock)|Lock configures the role's locking behavior for kubernetes sessions. If empty, the defaults block value (or global default) applies.|
 |resources|[][object](#speckuberesources-items)|The kubernetes resources this role grants access to.|
@@ -135,6 +136,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |forward_agent|boolean|ForwardAgent enables SSH agent forwarding.|
 |host_sudoers|[]string|Sudoers is a list of entries to include in a users sudoer file|
 |host_user_creation|[object](#specsshhost_user_creation)|HostUserCreation configures the creation of host users.|
+|label_expression|string|LabelExpression is an optional predicate expression evaluated against an ssh node's labels.|
 |labels|[][object](#specsshlabels-items)|Labels is the set of node labels used to dynamically select which nodes this role applies to.|
 |lock|[object](#specsshlock)|Lock configures the role's locking behavior for SSH sessions. If empty, the defaults block value (or global default) applies.|
 |logins|[]string|Logins is the list of OS logins this role permits on matching nodes.|

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role.mdx
@@ -117,6 +117,7 @@ Optional:
 - `client_idle_timeout` (String) Overrides the defaults block idle timeout specifically for kube sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.
 - `disconnect_expired_cert` (Boolean) DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires. If empty, the defaults block value (or global default) applies.
 - `groups` (List of String) The list of kubernetes groups this role allows.
+- `label_expression` (String) LabelExpression is an optional predicate expression evaluated against a kubernetes server's labels.
 - `labels` (Attributes List) The map of kubernetes cluster labels used for RBAC. (see [below for nested schema](#nested-schema-for-speckubelabels))
 - `lock` (Attributes) Lock configures the role's locking behavior for kubernetes sessions. If empty, the defaults block value (or global default) applies. (see [below for nested schema](#nested-schema-for-speckubelock))
 - `resources` (Attributes List) The kubernetes resources this role grants access to. (see [below for nested schema](#nested-schema-for-speckuberesources))
@@ -168,6 +169,7 @@ Optional:
 - `forward_agent` (Boolean) ForwardAgent enables SSH agent forwarding.
 - `host_sudoers` (List of String) Sudoers is a list of entries to include in a users sudoer file
 - `host_user_creation` (Attributes) HostUserCreation configures the creation of host users. (see [below for nested schema](#nested-schema-for-specsshhost_user_creation))
+- `label_expression` (String) LabelExpression is an optional predicate expression evaluated against an ssh node's labels.
 - `labels` (Attributes List) Labels is the set of node labels used to dynamically select which nodes this role applies to. (see [below for nested schema](#nested-schema-for-specsshlabels))
 - `lock` (Attributes) Lock configures the role's locking behavior for SSH sessions. If empty, the defaults block value (or global default) applies. (see [below for nested schema](#nested-schema-for-specsshlock))
 - `logins` (List of String) Logins is the list of OS logins this role permits on matching nodes.

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role.mdx
@@ -146,6 +146,7 @@ Optional:
 - `client_idle_timeout` (String) Overrides the defaults block idle timeout specifically for kube sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.
 - `disconnect_expired_cert` (Boolean) DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires. If empty, the defaults block value (or global default) applies.
 - `groups` (List of String) The list of kubernetes groups this role allows.
+- `label_expression` (String) LabelExpression is an optional predicate expression evaluated against a kubernetes server's labels.
 - `labels` (Attributes List) The map of kubernetes cluster labels used for RBAC. (see [below for nested schema](#nested-schema-for-speckubelabels))
 - `lock` (Attributes) Lock configures the role's locking behavior for kubernetes sessions. If empty, the defaults block value (or global default) applies. (see [below for nested schema](#nested-schema-for-speckubelock))
 - `resources` (Attributes List) The kubernetes resources this role grants access to. (see [below for nested schema](#nested-schema-for-speckuberesources))
@@ -197,6 +198,7 @@ Optional:
 - `forward_agent` (Boolean) ForwardAgent enables SSH agent forwarding.
 - `host_sudoers` (List of String) Sudoers is a list of entries to include in a users sudoer file
 - `host_user_creation` (Attributes) HostUserCreation configures the creation of host users. (see [below for nested schema](#nested-schema-for-specsshhost_user_creation))
+- `label_expression` (String) LabelExpression is an optional predicate expression evaluated against an ssh node's labels.
 - `labels` (Attributes List) Labels is the set of node labels used to dynamically select which nodes this role applies to. (see [below for nested schema](#nested-schema-for-specsshlabels))
 - `lock` (Attributes) Lock configures the role's locking behavior for SSH sessions. If empty, the defaults block value (or global default) applies. (see [below for nested schema](#nested-schema-for-specsshlock))
 - `logins` (List of String) Logins is the list of OS logins this role permits on matching nodes.

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
@@ -172,6 +172,10 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                  label_expression:
+                    description: LabelExpression is an optional predicate expression
+                      evaluated against a kubernetes server's labels.
+                    type: string
                   labels:
                     description: The map of kubernetes cluster labels used for RBAC.
                     items:
@@ -321,6 +325,10 @@ spec:
                         description: Shell is the shell to set for the user.
                         type: string
                     type: object
+                  label_expression:
+                    description: LabelExpression is an optional predicate expression
+                      evaluated against an ssh node's labels.
+                    type: string
                   labels:
                     description: Labels is the set of node labels used to dynamically
                       select which nodes this role applies to.

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
@@ -172,6 +172,10 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                  label_expression:
+                    description: LabelExpression is an optional predicate expression
+                      evaluated against a kubernetes server's labels.
+                    type: string
                   labels:
                     description: The map of kubernetes cluster labels used for RBAC.
                     items:
@@ -321,6 +325,10 @@ spec:
                         description: Shell is the shell to set for the user.
                         type: string
                     type: object
+                  label_expression:
+                    description: LabelExpression is an optional predicate expression
+                      evaluated against an ssh node's labels.
+                    type: string
                   labels:
                     description: Labels is the set of node labels used to dynamically
                       select which nodes this role applies to.

--- a/integrations/terraform/tfschema/scopes/access/v1/role_terraform.go
+++ b/integrations/terraform/tfschema/scopes/access/v1/role_terraform.go
@@ -212,6 +212,11 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 						},
+						"label_expression": {
+							Description: "LabelExpression is an optional predicate expression evaluated against a kubernetes server's labels.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
 						"labels": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 								"name": {
@@ -361,6 +366,11 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 							}),
 							Description: "HostUserCreation configures the creation of host users.",
 							Optional:    true,
+						},
+						"label_expression": {
+							Description: "LabelExpression is an optional predicate expression evaluated against an ssh node's labels.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 						"labels": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
@@ -1473,6 +1483,23 @@ func CopyScopedRoleFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 											}
 										}
 									}
+									{
+										a, ok := tf.Attrs["label_expression"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.ssh.label_expression"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.ssh.label_expression", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.LabelExpression = t
+											}
+										}
+									}
 								}
 							}
 						}
@@ -1809,6 +1836,23 @@ func CopyScopedRoleFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 														}
 													}
 												}
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["label_expression"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.kube.label_expression"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.kube.label_expression", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.LabelExpression = t
 											}
 										}
 									}
@@ -3710,6 +3754,28 @@ func CopyScopedRoleToTerraform(ctx context.Context, obj *github_com_gravitationa
 											}
 										}
 									}
+									{
+										t, ok := tf.AttrTypes["label_expression"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.ssh.label_expression"})
+										} else {
+											v, ok := tf.Attrs["label_expression"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ScopedRole.spec.ssh.label_expression", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.ssh.label_expression", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.LabelExpression) == ""
+											}
+											v.Value = string(obj.LabelExpression)
+											v.Unknown = false
+											tf.Attrs["label_expression"] = v
+										}
+									}
 								}
 								v.Unknown = false
 								tf.Attrs["ssh"] = v
@@ -4280,6 +4346,28 @@ func CopyScopedRoleToTerraform(ctx context.Context, obj *github_com_gravitationa
 												v.Unknown = false
 												tf.Attrs["lock"] = v
 											}
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["label_expression"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.kube.label_expression"})
+										} else {
+											v, ok := tf.Attrs["label_expression"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ScopedRole.spec.kube.label_expression", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.kube.label_expression", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.LabelExpression) == ""
+											}
+											v.Value = string(obj.LabelExpression)
+											v.Unknown = false
+											tf.Attrs["label_expression"] = v
 										}
 									}
 								}

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/constants"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/scopes"
@@ -208,117 +209,24 @@ func StrongValidateRole(role *scopedaccessv1.ScopedRole) error {
 		}
 	}
 
-	// verify that ssh logins are well-formed
-	if login := validateDoesNotContain(role.GetSpec().GetSsh().GetLogins(), invalidChars); login != "" {
-		// we currently don't support any form of wildcard/regex/substitution in scoped role
-		// logins. we likely will support substitution in the future, but its best to disallow
-		// it until that has landed.
-		return trace.BadParameter("scoped role %q has invalid login %q", role.GetMetadata().GetName(), login)
+	if err := validateDefaultsBlock(role.GetSpec().GetDefaults()); err != nil {
+		return trace.BadParameter("scoped role %q's defaults %s", role.GetMetadata().GetName(), err)
 	}
 
-	// verify that at least one label entry is defined when SSH block is given - scoped roles are deny by default, so a wildcard entry for
-	// labels must be explicitly provided if the role is meant to grant full access
-	if role.GetSpec().GetSsh() != nil && len(role.GetSpec().GetSsh().GetLabels()) == 0 {
-		return trace.BadParameter("scoped role %q has no spec.ssh.labels defined, please add at least one entry", role.GetMetadata().GetName())
-	}
-
-	// verify that ssh node labels are well-formed
-	for _, label := range role.GetSpec().GetSsh().GetLabels() {
-		// we currently don't support any form of wildcard/regex/substitution in scoped role
-		// node labels. we likely will support such things in the future, but its best to disallow
-		// them until that has landed.
-
-		if strings.ContainsAny(label.GetName(), invalidLabelChars) {
-			return trace.BadParameter("scoped role %q has invalid node label name %q", role.GetMetadata().GetName(), label.GetName())
-		}
-		if value := validateDoesNotContain(label.GetValues(), invalidLabelChars); value != "" {
-			return trace.BadParameter("scoped role %q has invalid node label value %q for label %q", role.GetMetadata().GetName(), value, label.GetName())
-		}
-	}
-
-	// verify that client_idle_timeout fields are valid Go duration strings
-	if s := role.GetSpec().GetSsh().GetClientIdleTimeout(); s != "" {
-		if _, err := time.ParseDuration(s); err != nil {
-			return trace.BadParameter("scoped role %q has invalid ssh.client_idle_timeout %q: %v", role.GetMetadata().GetName(), s, err)
-		}
-	}
-	if s := role.GetSpec().GetKube().GetClientIdleTimeout(); s != "" {
-		if _, err := time.ParseDuration(s); err != nil {
-			return trace.BadParameter("scoped role %q has invalid kube.client_idle_timeout %q: %v", role.GetMetadata().GetName(), s, err)
-		}
-	}
-	if s := role.GetSpec().GetDefaults().GetClientIdleTimeout(); s != "" {
-		if _, err := time.ParseDuration(s); err != nil {
-			return trace.BadParameter("scoped role %q has invalid defaults.client_idle_timeout %q: %v", role.GetMetadata().GetName(), s, err)
-		}
-	}
-
-	// verify that create_host_user_mode is a recognized value
-	if mode := role.GetSpec().GetSsh().GetHostUserCreation().GetMode(); mode != "" {
-		var hostUserMode types.CreateHostUserMode
-		if err := hostUserMode.UnmarshalText([]byte(mode)); err != nil {
-			return trace.BadParameter("scoped role %q has invalid ssh.host_user_creation.create_host_user_mode %q", role.GetMetadata().GetName(), mode)
-		}
-	}
-
-	// verify that max_sessions is non-negative
-	if ms := role.GetSpec().GetSsh().GetMaxSessions(); ms < 0 {
-		return trace.BadParameter("scoped role %q has invalid ssh.max_sessions %d: must be non-negative", role.GetMetadata().GetName(), ms)
-	}
-
-	// verify that session_recording_mode fields are recognized values
-	if mode := role.GetSpec().GetSsh().GetSessionRecording().GetMode(); mode != "" {
-		switch constants.SessionRecordingMode(mode) {
-		case constants.SessionRecordingModeStrict, constants.SessionRecordingModeBestEffort:
-		default:
-			return trace.BadParameter("scoped role %q has invalid ssh.session_recording_mode. %q: must be %q or %q",
-				role.GetMetadata().GetName(), mode, constants.SessionRecordingModeStrict, constants.SessionRecordingModeBestEffort)
-		}
-	}
-
-	if mode := role.GetSpec().GetDefaults().GetSessionRecording().GetMode(); mode != "" {
-		switch constants.SessionRecordingMode(mode) {
-		case constants.SessionRecordingModeStrict, constants.SessionRecordingModeBestEffort:
-		default:
-			return trace.BadParameter("scoped role %q has invalid defaults.session_recording_mode %q: must be %q or %q",
-				role.GetMetadata().GetName(), mode, constants.SessionRecordingModeStrict, constants.SessionRecordingModeBestEffort)
-		}
-	}
-
-	// verify that the lock.Mode is a recognized value for Defaults
-	if lock := role.GetSpec().GetDefaults().GetLock(); lock != nil {
-		if err := validateLock(lock); err != nil {
-			return trace.BadParameter("scoped role %q has invalid defaults.lock.mode %q", role.GetMetadata().GetName(), lock.GetMode())
-		}
-	}
-	// verify that lock.Mode is a recognized value for SSH
-	if lock := role.GetSpec().GetSsh().GetLock(); lock != nil {
-		if err := validateLock(lock); err != nil {
-			return trace.BadParameter("scoped role %q has invalid ssh.lock.mode %q", role.GetMetadata().GetName(), lock.GetMode())
-		}
+	if err := validateSSHBlock(role.GetSpec().GetSsh()); err != nil {
+		return trace.BadParameter("scoped role %q's ssh %s", role.GetMetadata().GetName(), err)
 	}
 
 	if err := validateAppBlock(role.GetSpec().GetApp()); err != nil {
-		return trace.BadParameter("scoped role %q %s", role.GetMetadata().GetName(), err)
+		return trace.BadParameter("scoped role %q's app %s", role.GetMetadata().GetName(), err)
 	}
 
-	// verify that kube block is well-formed
 	if err := validateKubeBlock(role.GetSpec().GetKube()); err != nil {
-		return trace.BadParameter("scoped role %q has %s", role.GetMetadata().GetName(), err)
+		return trace.BadParameter("scoped role %q's kube %s", role.GetMetadata().GetName(), err)
 	}
 
-	// verify that workload_identity labels are well-formed
-	for _, label := range role.GetSpec().GetWorkloadIdentity().GetLabels() {
-		// we currently don't support any form of wildcard/regex/substitution in scoped role
-		// workload identity labels. we likely will support such things in the future, but its
-		// best to disallow them until that has landed.
-
-		if strings.ContainsAny(label.GetName(), invalidLabelChars) {
-			return trace.BadParameter("scoped role %q has invalid workload_identity label name %q", role.GetMetadata().GetName(), label.GetName())
-		}
-		if value := validateDoesNotContain(label.GetValues(), invalidLabelChars); value != "" {
-			return trace.BadParameter("scoped role %q has invalid workload_identity label value %q for label %q", role.GetMetadata().GetName(), value, label.GetName())
-		}
+	if err := validateLabels(role.GetSpec().GetWorkloadIdentity().GetLabels()); err != nil {
+		return trace.BadParameter("scoped role %q's workload_identity %s", role.GetMetadata().GetName(), err)
 	}
 
 	// verify that scoped role converts to a valid unscoped role
@@ -341,52 +249,40 @@ func validateDoesNotContain(values []string, invalidSet string) string {
 	return ""
 }
 
-func validateAppBlock(app *scopedaccessv1.ScopedRoleApp) error {
-	if app == nil {
-		return nil
+// validateLabelMatchers verifies the labels and label_expressions.
+func validateLabelMatchers(labels []*labelv1.Label, expr string) error {
+	if len(labels) == 0 && expr == "" {
+		return trace.BadParameter("must define at least one labels entry or label_expression")
 	}
 
-	labels := app.GetLabels()
-	if len(labels) == 0 && app.GetLabelExpression() == "" {
-		return trace.BadParameter("must define at least one app.labels entry or app.label expressions")
-	}
-
-	if expr := app.GetLabelExpression(); expr != "" {
+	if expr != "" {
 		if _, err := label.ParseExpression(expr); err != nil {
-			return trace.BadParameter("has invalid app.label_expression: %v", err)
+			return trace.BadParameter("has invalid label_expression: %v", err)
 		}
 	}
 
-	// verify that app labels are well formed
+	return trace.Wrap(validateLabels(labels))
+}
+
+// validateLabels verifies that label names and values are well-formed.
+func validateLabels(labels []*labelv1.Label) error {
 	for _, label := range labels {
 		// we currently don't support any form of wildcard/regex/substitution in scoped role
-		// app labels. we likely will support such things in the future, but its best to disallow
+		// labels. we likely will support such things in the future, but its best to disallow
 		// them until that has landed.
 
 		if strings.ContainsAny(label.GetName(), invalidLabelChars) {
-			return trace.BadParameter("has invalid app label name %q", label.GetName())
+			return trace.BadParameter("has invalid label name %q", label.GetName())
 		}
 		if value := validateDoesNotContain(label.GetValues(), invalidLabelChars); value != "" {
-			return trace.BadParameter("has invalid app label value %q for label %q", value, label.GetName())
-		}
-	}
-
-	// verify that lock.Mode is a recognized value for App
-	if lock := app.GetLock(); lock != nil {
-		if err := validateLock(lock); err != nil {
-			return trace.BadParameter("has invalid app.lock.mode %q", lock.GetMode())
-		}
-	}
-
-	if s := app.GetClientIdleTimeout(); s != "" {
-		if _, err := time.ParseDuration(s); err != nil {
-			return trace.BadParameter("has invalid app.client_idle_timeout %q: %v", s, err)
+			return trace.BadParameter("has invalid label value %q for label %q", value, label.GetName())
 		}
 	}
 	return nil
 }
 
-func validateLock(lock *scopedaccessv1.Lock) error {
+// validateLockMode verifies that lock.mode is a recognized value.
+func validateLockMode(lock *scopedaccessv1.Lock) error {
 	mode := lock.GetMode()
 	switch constants.LockingMode(mode) {
 	// Allow for empty string - we will fall back to the cluster defaults - or best_effort if not set.
@@ -394,7 +290,32 @@ func validateLock(lock *scopedaccessv1.Lock) error {
 	case "":
 	case constants.LockingModeBestEffort, constants.LockingModeStrict:
 	default:
-		return trace.Errorf("invalid lock mode")
+		return trace.BadParameter("has invalid lock.mode %q", mode)
+	}
+	return nil
+}
+
+// validateClientIdleTimeout verifies that client_idle_timeout is a valid Go duration string.
+func validateClientIdleTimeout(s string) error {
+	if s == "" {
+		return nil
+	}
+	if _, err := time.ParseDuration(s); err != nil {
+		return trace.BadParameter("has invalid client_idle_timeout %q: %v", s, err)
+	}
+	return nil
+}
+
+// validateSessionRecordingMode verifies that session_recording.mode is a recognized value.
+func validateSessionRecordingMode(mode string) error {
+	if mode == "" {
+		return nil
+	}
+	switch constants.SessionRecordingMode(mode) {
+	case constants.SessionRecordingModeStrict, constants.SessionRecordingModeBestEffort:
+	default:
+		return trace.BadParameter("has invalid session_recording.mode %q: must be %q or %q",
+			mode, constants.SessionRecordingModeStrict, constants.SessionRecordingModeBestEffort)
 	}
 	return nil
 }
@@ -690,7 +611,7 @@ func getNamespacedResourceAPIGroup(resource string) (string, bool) {
 func validateKubeResource(resource *scopedaccessv1.KubeResource) error {
 	// NOTE(eriktate): errors must start with the field name producing the error so the final reported error
 	// renders correctly.
-	// (e.g. `scoped role "/my/scope::my-role" has invalid kube resource: spec.kube.resources[0].kind is required`)
+	// (e.g. `scoped role "/my/scope::my-role"'s kube has invalid resource: resources[0].kind is required`)
 	for _, verb := range resource.GetVerbs() {
 		if !slices.Contains(types.KubernetesVerbs, verb) && verb != types.Wildcard {
 			return trace.BadParameter("verbs contain invalid or unsupported %q; Supported: %v", verb, types.KubernetesVerbs)
@@ -734,39 +655,24 @@ func validateKubeBlock(kube *scopedaccessv1.ScopedRoleKube) error {
 		return nil
 	}
 
-	// verify that lock.Mode is a recognized value for Kube
-	if lock := kube.GetLock(); lock != nil {
-		if err := validateLock(lock); err != nil {
-			return trace.BadParameter("invalid kube.lock.mode %q", lock.GetMode())
-		}
+	if err := validateLockMode(kube.GetLock()); err != nil {
+		return trace.Wrap(err)
 	}
 
-	// verify that at least one label entry is defined - scoped roles are deny by default, so a wildcard entry for
-	// labels must be explicitly provided if the role is meant to grant full access
-	if len(kube.GetLabels()) == 0 {
-		return trace.BadParameter("no spec.kube.labels defined, please add at least one entry")
-	}
-
-	// verify that kube labels are well-formed
-	for _, label := range kube.GetLabels() {
-		if strings.ContainsAny(label.GetName(), invalidLabelChars) {
-			return trace.BadParameter("invalid kube label name %q", label.GetName())
-		}
-		if value := validateDoesNotContain(label.GetValues(), invalidLabelChars); value != "" {
-			return trace.BadParameter("invalid kube label value %q for label %q", value, label.GetName())
-		}
+	if err := validateLabelMatchers(kube.GetLabels(), kube.GetLabelExpression()); err != nil {
+		return trace.Wrap(err)
 	}
 
 	// verify that at least one resource is defined - scoped roles are deny by default, so a wildcard entry for
 	// resources must be explicitly provided when resource-based RBAC is not desired
 	if len(kube.GetResources()) == 0 {
-		return trace.BadParameter("no spec.kube.resources defined, if resource-based RBAC is not required please configure explicit wildcard access")
+		return trace.BadParameter("must define at least one resources entry, if resource-based RBAC is not required please configure explicit wildcard access")
 	}
 
 	// verify that kube resources are well-formed
 	for idx, resource := range kube.GetResources() {
 		if err := validateKubeResource(resource); err != nil {
-			return trace.BadParameter("invalid kube resource: spec.kube.resources[%d].%s", idx, err)
+			return trace.BadParameter("has invalid resource: resources[%d].%s", idx, err)
 		}
 	}
 
@@ -775,7 +681,7 @@ func validateKubeBlock(kube *scopedaccessv1.ScopedRoleKube) error {
 		// we currently don't support any form of wildcard/regex/substitution in scoped role
 		// kube groups. we likely will support substitution in the future, but its best to disallow
 		// it until that has landed.
-		return trace.BadParameter("invalid kube group %q", group)
+		return trace.BadParameter("has invalid group %q", group)
 	}
 
 	// verify that kube users are well-formed
@@ -783,7 +689,99 @@ func validateKubeBlock(kube *scopedaccessv1.ScopedRoleKube) error {
 		// we currently don't support any form of wildcard/regex/substitution in scoped role
 		// kube users. we likely will support substitution in the future, but its best to disallow
 		// it until that has landed.
-		return trace.BadParameter("invalid kube user %q", user)
+		return trace.BadParameter("has invalid user %q", user)
+	}
+
+	if err := validateClientIdleTimeout(kube.GetClientIdleTimeout()); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// validateDefaultsBlock validates the given defaults configuration in a scoped role spec.
+func validateDefaultsBlock(defaults *scopedaccessv1.ScopedRoleDefaults) error {
+	if defaults == nil {
+		return nil
+	}
+
+	if err := validateClientIdleTimeout(defaults.GetClientIdleTimeout()); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := validateSessionRecordingMode(defaults.GetSessionRecording().GetMode()); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := validateLockMode(defaults.GetLock()); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// validateSSHBlock validates the given ssh configuration in a scoped role spec.
+func validateSSHBlock(ssh *scopedaccessv1.ScopedRoleSSH) error {
+	if ssh == nil {
+		return nil
+	}
+
+	if err := validateLabelMatchers(ssh.GetLabels(), ssh.GetLabelExpression()); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// verify that ssh logins are well-formed
+	if login := validateDoesNotContain(ssh.GetLogins(), invalidChars); login != "" {
+		// we currently don't support any form of wildcard/regex/substitution in scoped role
+		// logins. we likely will support substitution in the future, but its best to disallow
+		// it until that has landed.
+		return trace.BadParameter("has invalid login %q", login)
+	}
+
+	if err := validateClientIdleTimeout(ssh.GetClientIdleTimeout()); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// verify that create_host_user_mode is a recognized value
+	if mode := ssh.GetHostUserCreation().GetMode(); mode != "" {
+		var hostUserMode types.CreateHostUserMode
+		if err := hostUserMode.UnmarshalText([]byte(mode)); err != nil {
+			return trace.BadParameter("has invalid host_user_creation.create_host_user_mode %q", mode)
+		}
+	}
+
+	// verify that max_sessions is non-negative
+	if ms := ssh.GetMaxSessions(); ms < 0 {
+		return trace.BadParameter("has invalid max_sessions %d: must be non-negative", ms)
+	}
+
+	if err := validateSessionRecordingMode(ssh.GetSessionRecording().GetMode()); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := validateLockMode(ssh.GetLock()); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// validateAppBlock validates the given app configuration in a scoped role spec.
+func validateAppBlock(app *scopedaccessv1.ScopedRoleApp) error {
+	if app == nil {
+		return nil
+	}
+
+	if err := validateLabelMatchers(app.GetLabels(), app.GetLabelExpression()); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := validateLockMode(app.GetLock()); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := validateClientIdleTimeout(app.GetClientIdleTimeout()); err != nil {
+		return trace.Wrap(err)
 	}
 
 	return nil

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -590,6 +590,44 @@ func TestValidateRole(t *testing.T) {
 			weakOk:   true,
 		},
 		{
+			name: "ssh block with invalid label expression",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						LabelExpression: `labels["env"] ==`,
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "ssh block with label expression only",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						LabelExpression: `labels["env"] == "staging"`,
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
 			name: "invalid kube.lock.mode",
 			role: scopedaccessv1.ScopedRole_builder{
 				Kind: KindScopedRole,
@@ -719,6 +757,48 @@ func TestValidateRole(t *testing.T) {
 				Version: types.V1,
 			}.Build(),
 			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name: "kube block without labels or label_expression",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Lock: scopedaccessv1.Lock_builder{
+							Mode: string(constants.LockingModeStrict),
+						}.Build(),
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "ssh block without labels or label_expression",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Lock: scopedaccessv1.Lock_builder{
+							Mode: string(constants.LockingModeStrict),
+						}.Build(),
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
 			weakOk:   true,
 		},
 		{
@@ -1053,6 +1133,46 @@ func TestValidateRole(t *testing.T) {
 				Version: types.V1,
 			}.Build(),
 			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube block with invalid label expression",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						LabelExpression: `labels["env"] ==`,
+						Resources:       wildcardKubeResources,
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube block with label expression only",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						LabelExpression: `labels["env"] == "staging"`,
+						Resources:       wildcardKubeResources,
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: true,
 			weakOk:   true,
 		},
 		{
@@ -2152,6 +2272,7 @@ func TestStrongValidateRoleSpecAllFieldsValidated(t *testing.T) {
 			Labels: []*labelv1.Label{
 				labelv1.Label_builder{Name: "env", Values: []string{"prod"}}.Build(),
 			},
+			LabelExpression:     `contains(labels["env"], "prod")`,
 			ClientIdleTimeout:   "1h",
 			PermitX11Forwarding: proto.Bool(true),
 			FileCopy:            proto.Bool(true),
@@ -2186,6 +2307,7 @@ func TestStrongValidateRoleSpecAllFieldsValidated(t *testing.T) {
 			Labels: []*labelv1.Label{
 				labelv1.Label_builder{Name: "env", Values: []string{"prod"}}.Build(),
 			},
+			LabelExpression: `contains(labels["env"], "prod")`,
 			Resources: []*scopedaccessv1.KubeResource{
 				scopedaccessv1.KubeResource_builder{
 					Kind:      "pods",

--- a/lib/scopes/access/compat.go
+++ b/lib/scopes/access/compat.go
@@ -41,6 +41,10 @@ func applySSHBlock(src *scopedaccessv1.ScopedRoleSSH, dst *types.RoleConditions)
 		}
 		dst.NodeLabels[label.GetName()] = apiutils.Strings(label.GetValues())
 	}
+
+	if expr := src.GetLabelExpression(); expr != "" {
+		dst.NodeLabelsExpression = expr
+	}
 }
 
 // applyKubeBlock writes/converts the relevant subset of the scoped role's kube block into the provided
@@ -56,6 +60,10 @@ func applyKubeBlock(src *scopedaccessv1.ScopedRoleKube, dst *types.RoleCondition
 			dst.KubernetesLabels = make(types.Labels)
 		}
 		dst.KubernetesLabels[label.GetName()] = apiutils.Strings(label.GetValues())
+	}
+
+	if expr := src.GetLabelExpression(); expr != "" {
+		dst.KubernetesLabelsExpression = expr
 	}
 
 	for i, resource := range src.GetResources() {
@@ -149,7 +157,7 @@ func ScopedRoleToRole(sr *scopedaccessv1.ScopedRole, assignedScope string) (type
 	// role conversion applies unwanted wildcards for kube resources when left unassigned, so we
 	// explicitly validate the kube block as a sanity check
 	if err := validateKubeBlock(sr.GetSpec().GetKube()); err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.BadParameter("scoped role %q's kube %s", sr.GetMetadata().GetName(), err)
 	}
 
 	var conditions types.RoleConditions

--- a/lib/scopes/access/compat_test.go
+++ b/lib/scopes/access/compat_test.go
@@ -586,14 +586,17 @@ func TestKubeConversion(t *testing.T) {
 	}
 }
 
-// TestAppConversion verifies that the scoped role app block converts its labels and
+// TestLabelConversion verifies that the scoped role protocol blocks converts its labels and
 // label_expression into the classic role's AppLabels/AppLabelsExpression conditions.
-func TestAppConversion(t *testing.T) {
+func TestLabelConversion(t *testing.T) {
 	t.Parallel()
 
 	tts := []struct {
-		name   string
-		app    *scopedaccessv1.ScopedRoleApp
+		name string
+		app  *scopedaccessv1.ScopedRoleApp
+		kube *scopedaccessv1.ScopedRoleKube
+		ssh  *scopedaccessv1.ScopedRoleSSH
+
 		expect types.RoleConditions
 	}{
 		{
@@ -627,8 +630,34 @@ func TestAppConversion(t *testing.T) {
 			app: scopedaccessv1.ScopedRoleApp_builder{
 				LabelExpression: `contains(labels["env"], "prod")`,
 			}.Build(),
+			kube: scopedaccessv1.ScopedRoleKube_builder{
+				LabelExpression: `contains(labels["env"], "prod")`,
+				Resources: []*scopedaccessv1.KubeResource{
+					scopedaccessv1.KubeResource_builder{
+						Kind:      types.Wildcard,
+						Namespace: types.Wildcard,
+						Name:      types.Wildcard,
+						ApiGroup:  types.Wildcard,
+						Verbs:     []string{types.Wildcard},
+					}.Build(),
+				},
+			}.Build(),
+			ssh: scopedaccessv1.ScopedRoleSSH_builder{
+				LabelExpression: `contains(labels["env"], "prod")`,
+			}.Build(),
 			expect: types.RoleConditions{
-				AppLabelsExpression: `contains(labels["env"], "prod")`,
+				AppLabelsExpression:        `contains(labels["env"], "prod")`,
+				KubernetesLabelsExpression: `contains(labels["env"], "prod")`,
+				NodeLabelsExpression:       `contains(labels["env"], "prod")`,
+				KubernetesResources: []types.KubernetesResource{
+					{
+						Kind:      types.Wildcard,
+						Namespace: types.Wildcard,
+						Name:      types.Wildcard,
+						APIGroup:  types.Wildcard,
+						Verbs:     []string{types.Wildcard},
+					},
+				},
 			},
 		},
 		{
@@ -661,6 +690,8 @@ func TestAppConversion(t *testing.T) {
 				Scope: "/foo",
 				Spec: scopedaccessv1.ScopedRoleSpec_builder{
 					App:              tt.app,
+					Ssh:              tt.ssh,
+					Kube:             tt.kube,
 					AssignableScopes: []string{"/foo/bar"},
 				}.Build(),
 				Version: types.V1,


### PR DESCRIPTION
This PR adds label expressions to scoped role's kube and ssh blocks. 

I've also attempted to deduplicate some repetitiveness in access validation.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Scoped roles can now define label expressions for kube and ssh access


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan

### Test Environment
Local cluster, docker nodes, k3d cluster

### Test Cases
- [x] Ensure scoped roles can access nodes with label expressions defined
- [x] Ensure scoped roles can access kube with label expressions defined
- [x] Ensure invalid label expressions are surfaced when creating them
- [x] Ensure tsh ls or kube ls don't show resources when label expressions that won't match on resources 
