### PR TITLE
Retry on YubiKey `rx` errors

### DIFF
--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -986,6 +986,7 @@ func withRetries(callback deviceCallbackFunc) deviceCallbackFunc {
 		const maxRetries = 3
 		var err error
 		for i := 0; i < maxRetries; i++ {
+			start := time.Now()
 			err = callback(dev, info, pin)
 			if err == nil {
 				return nil
@@ -996,6 +997,15 @@ func withRetries(callback deviceCallbackFunc) deviceCallbackFunc {
 			if errors.Is(err, libfido2.ErrOperationDenied) {
 				fmt.Println("Gesture validation failed, make sure you use a registered fingerprint")
 				fidoLog.DebugContext(context.Background(), "Retrying libfido2 error 'operation denied'")
+				continue
+			}
+
+			// A security key may be temporarily busy, so we retry on "rx" errors.
+			// The ErrRX error can also be thrown on a touch timeout, so we only retry
+			// if we are within half of the device timeout.
+			if errors.Is(err, libfido2.ErrRX) && time.Since(start) < fido2DeviceTimeout/2 {
+				fidoLog.DebugContext(context.Background(), "Retrying libfido2 error 'rx' (device was temporarily busy)")
+				time.Sleep(fido2RetryInterval)
 				continue
 			}
 

--- a/lib/auth/webauthncli/fido2_test.go
+++ b/lib/auth/webauthncli/fido2_test.go
@@ -1173,6 +1173,14 @@ func TestFIDO2Login_bioErrorHandling(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "retry on rx error from busy device",
+			setAssertionErrors: func() {
+				bio.assertionErrors = []error{
+					libfido2.ErrRX,
+				}
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Intermittently, a `tsh` or `tctl` command that requires MFA will fail to access the user's YubiKey (and fallback to other MFA methods) because it is being used by another process. I've not been able to reproduce this locally and users report that this happens randomly so it is unlikely that an application like Chrome has an unmissable, front-and-centre MFA prompt waiting whilst a `tsh`/`tctl` MFA command is launched. According to Claude, there are other processes that could keep a YubiKey busy for a fraction of a second though:

1. Browser/OS WebAuthn Probes: Browsers, password managers, OS passkey machinery enumerate connected authenticators, which could light up the YubiKey.
2. Maybe MacOS's CTAP handling: The system services that handle security keys might hold the HID device briefly, less sure on this one.

These could be responsible so I've added a retry for the `libfido2.ErrRX` error case that will wait 500ms before trying again, hopefully giving enough time for whatever else is holding the security key to get out of the way.

## Manual Test Plan
As I said, this is very tough to replicate locally. I added a test to `fido2_test.go` that checks that auth attempt is retried on the `libfido2.ErrRX` error.
### Test Environment
Cluster running locally
### Test Cases
- [x] A non-busy YubiKey can be used by `tsh login`
- [x] Tests pass to show the error is retried
