### PR TITLE
client_ip_restriction: add new fields, update protos

### DIFF
--- a/api/gen/proto/go/teleport/clientiprestriction/v1/clientiprestriction_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/clientiprestriction/v1/clientiprestriction_protohybrid.pb.go
@@ -26,6 +26,7 @@ import (
 	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	unsafe "unsafe"
 )
@@ -216,7 +217,26 @@ type ClientIPRestrictionSpec struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// allowed_cidrs is the list of CIDR blocks permitted to connect to the cluster.
 	// An empty list disables restrictions and allows all traffic.
-	AllowedCidrs  []string `protobuf:"bytes,1,rep,name=allowed_cidrs,json=allowedCidrs,proto3" json:"allowed_cidrs,omitempty"`
+	AllowedCidrs []string `protobuf:"bytes,1,rep,name=allowed_cidrs,json=allowedCidrs,proto3" json:"allowed_cidrs,omitempty"`
+	// mode is the user-controlled operational mode of the restriction. It denotes
+	// intent; the actual enforcement state is reported by status.state.
+	// Possible values: "draft" (configured but not enforced) and "enforced"
+	// (should be enforced by Teleport Cloud). An empty value is treated as
+	// "enforced" for backward compatibility.
+	Mode string `protobuf:"bytes,2,opt,name=mode,proto3" json:"mode,omitempty"`
+	// expires is the time at which the restriction is disabled and mode reverts
+	// to "draft". An unset value means the restriction never expires. When set,
+	// it must be at least 20 minutes in the future.
+	//
+	// Note: we do not use the `metadata.expires` field for this, because that
+	// conventionally denotes that the resource should be deleted once it elapses.
+	// Here expiry only stops enforcement on the Cloud side; the resource itself
+	// keeps existing, reverting to a "draft" state rather than being removed.
+	//
+	// Writes fully replace the resource, so a client editing other fields must
+	// re-send a still-valid expiry or clear it. An expiry read earlier and passed
+	// back unchanged can be rejected once it is under 20 minutes away.
+	Expires       *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=expires,proto3" json:"expires,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -253,8 +273,41 @@ func (x *ClientIPRestrictionSpec) GetAllowedCidrs() []string {
 	return nil
 }
 
+func (x *ClientIPRestrictionSpec) GetMode() string {
+	if x != nil {
+		return x.Mode
+	}
+	return ""
+}
+
+func (x *ClientIPRestrictionSpec) GetExpires() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Expires
+	}
+	return nil
+}
+
 func (x *ClientIPRestrictionSpec) SetAllowedCidrs(v []string) {
 	x.AllowedCidrs = v
+}
+
+func (x *ClientIPRestrictionSpec) SetMode(v string) {
+	x.Mode = v
+}
+
+func (x *ClientIPRestrictionSpec) SetExpires(v *timestamppb.Timestamp) {
+	x.Expires = v
+}
+
+func (x *ClientIPRestrictionSpec) HasExpires() bool {
+	if x == nil {
+		return false
+	}
+	return x.Expires != nil
+}
+
+func (x *ClientIPRestrictionSpec) ClearExpires() {
+	x.Expires = nil
 }
 
 type ClientIPRestrictionSpec_builder struct {
@@ -263,6 +316,25 @@ type ClientIPRestrictionSpec_builder struct {
 	// allowed_cidrs is the list of CIDR blocks permitted to connect to the cluster.
 	// An empty list disables restrictions and allows all traffic.
 	AllowedCidrs []string
+	// mode is the user-controlled operational mode of the restriction. It denotes
+	// intent; the actual enforcement state is reported by status.state.
+	// Possible values: "draft" (configured but not enforced) and "enforced"
+	// (should be enforced by Teleport Cloud). An empty value is treated as
+	// "enforced" for backward compatibility.
+	Mode string
+	// expires is the time at which the restriction is disabled and mode reverts
+	// to "draft". An unset value means the restriction never expires. When set,
+	// it must be at least 20 minutes in the future.
+	//
+	// Note: we do not use the `metadata.expires` field for this, because that
+	// conventionally denotes that the resource should be deleted once it elapses.
+	// Here expiry only stops enforcement on the Cloud side; the resource itself
+	// keeps existing, reverting to a "draft" state rather than being removed.
+	//
+	// Writes fully replace the resource, so a client editing other fields must
+	// re-send a still-valid expiry or clear it. An expiry read earlier and passed
+	// back unchanged can be rejected once it is under 20 minutes away.
+	Expires *timestamppb.Timestamp
 }
 
 func (b0 ClientIPRestrictionSpec_builder) Build() *ClientIPRestrictionSpec {
@@ -270,6 +342,8 @@ func (b0 ClientIPRestrictionSpec_builder) Build() *ClientIPRestrictionSpec {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.AllowedCidrs = b.AllowedCidrs
+	x.Mode = b.Mode
+	x.Expires = b.Expires
 	return m0
 }
 
@@ -278,7 +352,8 @@ func (b0 ClientIPRestrictionSpec_builder) Build() *ClientIPRestrictionSpec {
 type ClientIPRestrictionStatus struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// state is the current enforcement state of the restrictions at the ingress layer.
-	// Possible values: "pending", "active".
+	// Possible values: "pending" (written but not yet applied), "active" (applied
+	// and enforced), and "draft" (saved but not enforced because mode is "draft").
 	State         string `protobuf:"bytes,1,opt,name=state,proto3" json:"state,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -324,7 +399,8 @@ type ClientIPRestrictionStatus_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
 	// state is the current enforcement state of the restrictions at the ingress layer.
-	// Possible values: "pending", "active".
+	// Possible values: "pending" (written but not yet applied), "active" (applied
+	// and enforced), and "draft" (saved but not enforced because mode is "draft").
 	State string
 }
 
@@ -340,16 +416,18 @@ var File_teleport_clientiprestriction_v1_clientiprestriction_proto protoreflect.
 
 const file_teleport_clientiprestriction_v1_clientiprestriction_proto_rawDesc = "" +
 	"\n" +
-	"9teleport/clientiprestriction/v1/clientiprestriction.proto\x12\x1fteleport.clientiprestriction.v1\x1a!teleport/header/v1/metadata.proto\"\xba\x02\n" +
+	"9teleport/clientiprestriction/v1/clientiprestriction.proto\x12\x1fteleport.clientiprestriction.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a!teleport/header/v1/metadata.proto\"\xba\x02\n" +
 	"\x13ClientIPRestriction\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12L\n" +
 	"\x04spec\x18\x05 \x01(\v28.teleport.clientiprestriction.v1.ClientIPRestrictionSpecR\x04spec\x12R\n" +
-	"\x06status\x18\x06 \x01(\v2:.teleport.clientiprestriction.v1.ClientIPRestrictionStatusR\x06status\">\n" +
+	"\x06status\x18\x06 \x01(\v2:.teleport.clientiprestriction.v1.ClientIPRestrictionStatusR\x06status\"\x88\x01\n" +
 	"\x17ClientIPRestrictionSpec\x12#\n" +
-	"\rallowed_cidrs\x18\x01 \x03(\tR\fallowedCidrs\"1\n" +
+	"\rallowed_cidrs\x18\x01 \x03(\tR\fallowedCidrs\x12\x12\n" +
+	"\x04mode\x18\x02 \x01(\tR\x04mode\x124\n" +
+	"\aexpires\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\aexpires\"1\n" +
 	"\x19ClientIPRestrictionStatus\x12\x14\n" +
 	"\x05state\x18\x01 \x01(\tR\x05stateBjZhgithub.com/gravitational/teleport/api/gen/proto/go/teleport/clientiprestriction/v1;clientiprestrictionv1b\x06proto3"
 
@@ -359,16 +437,18 @@ var file_teleport_clientiprestriction_v1_clientiprestriction_proto_goTypes = []a
 	(*ClientIPRestrictionSpec)(nil),   // 1: teleport.clientiprestriction.v1.ClientIPRestrictionSpec
 	(*ClientIPRestrictionStatus)(nil), // 2: teleport.clientiprestriction.v1.ClientIPRestrictionStatus
 	(*v1.Metadata)(nil),               // 3: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),     // 4: google.protobuf.Timestamp
 }
 var file_teleport_clientiprestriction_v1_clientiprestriction_proto_depIdxs = []int32{
 	3, // 0: teleport.clientiprestriction.v1.ClientIPRestriction.metadata:type_name -> teleport.header.v1.Metadata
 	1, // 1: teleport.clientiprestriction.v1.ClientIPRestriction.spec:type_name -> teleport.clientiprestriction.v1.ClientIPRestrictionSpec
 	2, // 2: teleport.clientiprestriction.v1.ClientIPRestriction.status:type_name -> teleport.clientiprestriction.v1.ClientIPRestrictionStatus
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	4, // 3: teleport.clientiprestriction.v1.ClientIPRestrictionSpec.expires:type_name -> google.protobuf.Timestamp
+	4, // [4:4] is the sub-list for method output_type
+	4, // [4:4] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_teleport_clientiprestriction_v1_clientiprestriction_proto_init() }

--- a/api/gen/proto/go/teleport/clientiprestriction/v1/clientiprestriction_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/clientiprestriction/v1/clientiprestriction_protoopaque.pb.go
@@ -26,6 +26,7 @@ import (
 	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	unsafe "unsafe"
 )
@@ -209,6 +210,8 @@ func (b0 ClientIPRestriction_builder) Build() *ClientIPRestriction {
 type ClientIPRestrictionSpec struct {
 	state                   protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_AllowedCidrs []string               `protobuf:"bytes,1,rep,name=allowed_cidrs,json=allowedCidrs,proto3"`
+	xxx_hidden_Mode         string                 `protobuf:"bytes,2,opt,name=mode,proto3"`
+	xxx_hidden_Expires      *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=expires,proto3"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }
@@ -245,8 +248,41 @@ func (x *ClientIPRestrictionSpec) GetAllowedCidrs() []string {
 	return nil
 }
 
+func (x *ClientIPRestrictionSpec) GetMode() string {
+	if x != nil {
+		return x.xxx_hidden_Mode
+	}
+	return ""
+}
+
+func (x *ClientIPRestrictionSpec) GetExpires() *timestamppb.Timestamp {
+	if x != nil {
+		return x.xxx_hidden_Expires
+	}
+	return nil
+}
+
 func (x *ClientIPRestrictionSpec) SetAllowedCidrs(v []string) {
 	x.xxx_hidden_AllowedCidrs = v
+}
+
+func (x *ClientIPRestrictionSpec) SetMode(v string) {
+	x.xxx_hidden_Mode = v
+}
+
+func (x *ClientIPRestrictionSpec) SetExpires(v *timestamppb.Timestamp) {
+	x.xxx_hidden_Expires = v
+}
+
+func (x *ClientIPRestrictionSpec) HasExpires() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Expires != nil
+}
+
+func (x *ClientIPRestrictionSpec) ClearExpires() {
+	x.xxx_hidden_Expires = nil
 }
 
 type ClientIPRestrictionSpec_builder struct {
@@ -255,6 +291,25 @@ type ClientIPRestrictionSpec_builder struct {
 	// allowed_cidrs is the list of CIDR blocks permitted to connect to the cluster.
 	// An empty list disables restrictions and allows all traffic.
 	AllowedCidrs []string
+	// mode is the user-controlled operational mode of the restriction. It denotes
+	// intent; the actual enforcement state is reported by status.state.
+	// Possible values: "draft" (configured but not enforced) and "enforced"
+	// (should be enforced by Teleport Cloud). An empty value is treated as
+	// "enforced" for backward compatibility.
+	Mode string
+	// expires is the time at which the restriction is disabled and mode reverts
+	// to "draft". An unset value means the restriction never expires. When set,
+	// it must be at least 20 minutes in the future.
+	//
+	// Note: we do not use the `metadata.expires` field for this, because that
+	// conventionally denotes that the resource should be deleted once it elapses.
+	// Here expiry only stops enforcement on the Cloud side; the resource itself
+	// keeps existing, reverting to a "draft" state rather than being removed.
+	//
+	// Writes fully replace the resource, so a client editing other fields must
+	// re-send a still-valid expiry or clear it. An expiry read earlier and passed
+	// back unchanged can be rejected once it is under 20 minutes away.
+	Expires *timestamppb.Timestamp
 }
 
 func (b0 ClientIPRestrictionSpec_builder) Build() *ClientIPRestrictionSpec {
@@ -262,6 +317,8 @@ func (b0 ClientIPRestrictionSpec_builder) Build() *ClientIPRestrictionSpec {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_AllowedCidrs = b.AllowedCidrs
+	x.xxx_hidden_Mode = b.Mode
+	x.xxx_hidden_Expires = b.Expires
 	return m0
 }
 
@@ -314,7 +371,8 @@ type ClientIPRestrictionStatus_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
 	// state is the current enforcement state of the restrictions at the ingress layer.
-	// Possible values: "pending", "active".
+	// Possible values: "pending" (written but not yet applied), "active" (applied
+	// and enforced), and "draft" (saved but not enforced because mode is "draft").
 	State string
 }
 
@@ -330,16 +388,18 @@ var File_teleport_clientiprestriction_v1_clientiprestriction_proto protoreflect.
 
 const file_teleport_clientiprestriction_v1_clientiprestriction_proto_rawDesc = "" +
 	"\n" +
-	"9teleport/clientiprestriction/v1/clientiprestriction.proto\x12\x1fteleport.clientiprestriction.v1\x1a!teleport/header/v1/metadata.proto\"\xba\x02\n" +
+	"9teleport/clientiprestriction/v1/clientiprestriction.proto\x12\x1fteleport.clientiprestriction.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a!teleport/header/v1/metadata.proto\"\xba\x02\n" +
 	"\x13ClientIPRestriction\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12L\n" +
 	"\x04spec\x18\x05 \x01(\v28.teleport.clientiprestriction.v1.ClientIPRestrictionSpecR\x04spec\x12R\n" +
-	"\x06status\x18\x06 \x01(\v2:.teleport.clientiprestriction.v1.ClientIPRestrictionStatusR\x06status\">\n" +
+	"\x06status\x18\x06 \x01(\v2:.teleport.clientiprestriction.v1.ClientIPRestrictionStatusR\x06status\"\x88\x01\n" +
 	"\x17ClientIPRestrictionSpec\x12#\n" +
-	"\rallowed_cidrs\x18\x01 \x03(\tR\fallowedCidrs\"1\n" +
+	"\rallowed_cidrs\x18\x01 \x03(\tR\fallowedCidrs\x12\x12\n" +
+	"\x04mode\x18\x02 \x01(\tR\x04mode\x124\n" +
+	"\aexpires\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\aexpires\"1\n" +
 	"\x19ClientIPRestrictionStatus\x12\x14\n" +
 	"\x05state\x18\x01 \x01(\tR\x05stateBjZhgithub.com/gravitational/teleport/api/gen/proto/go/teleport/clientiprestriction/v1;clientiprestrictionv1b\x06proto3"
 
@@ -349,16 +409,18 @@ var file_teleport_clientiprestriction_v1_clientiprestriction_proto_goTypes = []a
 	(*ClientIPRestrictionSpec)(nil),   // 1: teleport.clientiprestriction.v1.ClientIPRestrictionSpec
 	(*ClientIPRestrictionStatus)(nil), // 2: teleport.clientiprestriction.v1.ClientIPRestrictionStatus
 	(*v1.Metadata)(nil),               // 3: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),     // 4: google.protobuf.Timestamp
 }
 var file_teleport_clientiprestriction_v1_clientiprestriction_proto_depIdxs = []int32{
 	3, // 0: teleport.clientiprestriction.v1.ClientIPRestriction.metadata:type_name -> teleport.header.v1.Metadata
 	1, // 1: teleport.clientiprestriction.v1.ClientIPRestriction.spec:type_name -> teleport.clientiprestriction.v1.ClientIPRestrictionSpec
 	2, // 2: teleport.clientiprestriction.v1.ClientIPRestriction.status:type_name -> teleport.clientiprestriction.v1.ClientIPRestrictionStatus
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	4, // 3: teleport.clientiprestriction.v1.ClientIPRestrictionSpec.expires:type_name -> google.protobuf.Timestamp
+	4, // [4:4] is the sub-list for method output_type
+	4, // [4:4] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_teleport_clientiprestriction_v1_clientiprestriction_proto_init() }

--- a/api/proto/teleport/clientiprestriction/v1/clientiprestriction.proto
+++ b/api/proto/teleport/clientiprestriction/v1/clientiprestriction.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package teleport.clientiprestriction.v1;
 
+import "google/protobuf/timestamp.proto";
 import "teleport/header/v1/metadata.proto";
 
 option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport/clientiprestriction/v1;clientiprestrictionv1";
@@ -47,12 +48,34 @@ message ClientIPRestrictionSpec {
   // allowed_cidrs is the list of CIDR blocks permitted to connect to the cluster.
   // An empty list disables restrictions and allows all traffic.
   repeated string allowed_cidrs = 1;
+
+  // mode is the user-controlled operational mode of the restriction. It denotes
+  // intent; the actual enforcement state is reported by status.state.
+  // Possible values: "draft" (configured but not enforced) and "enforced"
+  // (should be enforced by Teleport Cloud). An empty value is treated as
+  // "enforced" for backward compatibility.
+  string mode = 2;
+
+  // expires is the time at which the restriction is disabled and mode reverts
+  // to "draft". An unset value means the restriction never expires. When set,
+  // it must be at least 20 minutes in the future.
+  //
+  // Note: we do not use the `metadata.expires` field for this, because that
+  // conventionally denotes that the resource should be deleted once it elapses.
+  // Here expiry only stops enforcement on the Cloud side; the resource itself
+  // keeps existing, reverting to a "draft" state rather than being removed.
+  //
+  // Writes fully replace the resource, so a client editing other fields must
+  // re-send a still-valid expiry or clear it. An expiry read earlier and passed
+  // back unchanged can be rejected once it is under 20 minutes away.
+  google.protobuf.Timestamp expires = 3;
 }
 
 // ClientIPRestrictionStatus contains dynamic properties of a ClientIPRestriction. These properties are
 // modified during runtime of a Teleport process. They should not be modified by users.
 message ClientIPRestrictionStatus {
   // state is the current enforcement state of the restrictions at the ingress layer.
-  // Possible values: "pending", "active".
+  // Possible values: "pending" (written but not yet applied), "active" (applied
+  // and enforced), and "draft" (saved but not enforced because mode is "draft").
   string state = 1;
 }

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -44,6 +44,7 @@ import (
 	accessgraphsecretsv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessgraph/v1"
 	auditlogpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
 	beamsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/beams/v1"
+	clientiprestrictionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/clientiprestriction/v1"
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	dbobjectimportrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
 	delegationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/delegation/v1"
@@ -617,6 +618,11 @@ func (c *Client) AccessListClient() services.AccessLists {
 // AccessMonitoringRuleClient returns the access monitoring rules client.
 func (c *Client) AccessMonitoringRuleClient() services.AccessMonitoringRules {
 	return c.APIClient.AccessMonitoringRulesClient()
+}
+
+// ClientIPRestrictionClient returns the client IP restriction client.
+func (c *Client) ClientIPRestrictionClient() clientiprestrictionv1.ClientIPRestrictionServiceClient {
+	return c.APIClient.ClientIPRestrictionClient()
 }
 
 func (c *Client) ExternalAuditStorageClient() *externalauditstorage.Client {
@@ -1831,6 +1837,12 @@ type ClientI interface {
 	// when calling this method, but all RPCs will return "not implemented" errors
 	// (as per the default gRPC behavior).
 	AccessMonitoringRuleClient() services.AccessMonitoringRules
+
+	// ClientIPRestrictionClient returns a client IP restriction client.
+	// Clients connecting to older Teleport versions still get a client when calling
+	// this method, but all RPCs will return "not implemented" errors (as per the
+	// default gRPC behavior).
+	ClientIPRestrictionClient() clientiprestrictionv1.ClientIPRestrictionServiceClient
 
 	// DatabaseObjectImportRuleClient returns a database object import rule client.
 	DatabaseObjectImportRuleClient() dbobjectimportrulev1.DatabaseObjectImportRuleServiceClient

--- a/tool/tctl/common/resources/clientiprestriction.go
+++ b/tool/tctl/common/resources/clientiprestriction.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/gravitational/trace"
 
@@ -113,10 +114,22 @@ func (c *clientIPRestrictionCollection) Resources() []types.Resource {
 }
 
 func (c *clientIPRestrictionCollection) WriteText(w io.Writer, verbose bool) error {
-	t := asciitable.MakeTable([]string{"Allowed CIDRs", "State"})
+	mode := c.cir.GetSpec().GetMode()
+	if mode == "" {
+		// An empty mode is treated as enforced for backward compatibility.
+		mode = "enforced"
+	}
+	expires := "never"
+	if e := c.cir.GetSpec().GetExpires(); e != nil {
+		expires = e.AsTime().Format(time.RFC3339)
+	}
+
+	t := asciitable.MakeTable([]string{"Allowed CIDRs", "Mode", "State", "Expires"})
 	t.AddRow([]string{
 		strings.Join(c.cir.GetSpec().GetAllowedCidrs(), ", "),
+		mode,
 		c.cir.GetStatus().GetState(),
+		expires,
 	})
 	_, err := t.AsBuffer().WriteTo(w)
 	return trace.Wrap(err)


### PR DESCRIPTION
## What

Adds new fields to the `client_ip_restriction` resource and updates the generated protos. Also exposes `ClientIPRestrictionClient` on `authclient.ClientI` so the web proxy can call the `client_ip_restriction` service.

## Commits
- Add new fields, update protos
- Expose ClientIPRestrictionClient on authclient.ClientI so the web proxy can call the client_ip_restriction service
