### PR TITLE
Use split Identity Security entitlements

### DIFF
--- a/api/client/webclient/webconfig.go
+++ b/api/client/webclient/webconfig.go
@@ -96,8 +96,8 @@ type WebConfig struct {
 	// IdentitySecurity contains identity security features and settings.
 	// The individual identity security entitlements should be read from the Entitlements field.
 	IdentitySecurity IdentitySecurity `json:"identitySecurity"`
-	// IsPolicyEnabled is true if [Features.Policy] = true
-	// Deprecated, use entitlements
+	// IsPolicyEnabled is true if [Features.Policy] = true.
+	// Deprecated; use the feature-specific identity security entitlements.
 	IsPolicyEnabled bool `json:"isPolicyEnabled"`
 	// BeamsUI indicates whether the Beams lite-mode UI is enabled
 	BeamsUI bool `json:"beamsUi"`
@@ -107,8 +107,8 @@ type WebConfig struct {
 
 // IdentitySecurity contains identity security features and settings.
 type IdentitySecurity struct {
-	// IsClusterLicensed indicates whether identity security features are licensed
-	// for this cluster.
+	// IsClusterLicensed indicates whether any identity security feature is
+	// licensed for this cluster. Deprecated; use the individual entitlements.
 	IsClusterLicensed bool `json:"licensed"`
 	// AccessGraphConfigSet indicates whether access graph configuration is set in
 	// Auth and/or Proxy.

--- a/integrations/operator/controllers/reconciler.go
+++ b/integrations/operator/controllers/reconciler.go
@@ -52,6 +52,6 @@ func RequireEnterprise(features *proto.Features) bool {
 	return features.GetAdvancedAccessWorkflows()
 }
 
-func RequirePolicy(features *proto.Features) bool {
-	return modules.GetProtoEntitlement(features, entitlements.Policy).Enabled
+func RequireSessionSummaries(features *proto.Features) bool {
+	return modules.GetProtoEntitlement(features, entitlements.SessionSummaries).Enabled
 }

--- a/integrations/operator/controllers/resources/inference_model_controller.go
+++ b/integrations/operator/controllers/resources/inference_model_controller.go
@@ -92,7 +92,7 @@ func NewInferenceModelReconciler(
 		client,
 		inferenceModelClient,
 		reconcilers.Config{
-			CheckFeatures: controllers.RequirePolicy,
+			CheckFeatures: controllers.RequireSessionSummaries,
 		},
 	)
 

--- a/integrations/operator/controllers/resources/inference_policy_controller.go
+++ b/integrations/operator/controllers/resources/inference_policy_controller.go
@@ -92,7 +92,7 @@ func NewInferencePolicyReconciler(
 		client,
 		inferencePolicyClient,
 		reconcilers.Config{
-			CheckFeatures: controllers.RequirePolicy,
+			CheckFeatures: controllers.RequireSessionSummaries,
 		},
 	)
 

--- a/integrations/operator/controllers/resources/inference_secret_controller.go
+++ b/integrations/operator/controllers/resources/inference_secret_controller.go
@@ -102,7 +102,7 @@ func NewInferenceSecretReconciler(
 		client,
 		secretClient,
 		reconcilers.Config{
-			CheckFeatures: controllers.RequirePolicy,
+			CheckFeatures: controllers.RequireSessionSummaries,
 		},
 	)
 

--- a/integrations/operator/controllers/resources/retrieval_model_controller.go
+++ b/integrations/operator/controllers/resources/retrieval_model_controller.go
@@ -94,7 +94,7 @@ func NewRetrievalModelV1Reconciler(client kclient.Client, tClient *client.Client
 		client,
 		rmClient,
 		reconcilers.Config{
-			CheckFeatures: controllers.RequirePolicy,
+			CheckFeatures: controllers.RequireSessionSummaries,
 		},
 	)
 

--- a/integrations/operator/controllers/resources/setup_test.go
+++ b/integrations/operator/controllers/resources/setup_test.go
@@ -31,9 +31,31 @@ import (
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
+
+func TestRequireSessionSummaries(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, controllers.RequireSessionSummaries(&proto.Features{
+		Entitlements: map[string]*proto.EntitlementInfo{
+			string(entitlements.Policy): {Enabled: true},
+		},
+	}))
+	require.False(t, controllers.RequireSessionSummaries(&proto.Features{
+		Entitlements: map[string]*proto.EntitlementInfo{
+			string(entitlements.Policy):           {Enabled: true},
+			string(entitlements.SessionSummaries): {Enabled: false},
+		},
+	}))
+	require.True(t, controllers.RequireSessionSummaries(&proto.Features{
+		Entitlements: map[string]*proto.EntitlementInfo{
+			string(entitlements.SessionSummaries): {Enabled: true},
+		},
+	}))
+}
 
 type fakeReconciler struct {
 	reconcile.Reconciler

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4288,8 +4288,8 @@ func (a *ScopedServerWithRoles) generateUserCerts(ctx context.Context, req proto
 	}
 
 	if req.Usage == proto.UserCertsRequest_AccessGraphAPI {
-		if !a.authServer.modules.Features().GetEntitlement(entitlements.Policy).Enabled {
-			return nil, trace.AccessDenied("access graph requires a Teleport Policy license")
+		if !a.authServer.modules.Features().GetEntitlement(entitlements.AccessGraph).Enabled {
+			return nil, trace.AccessDenied("access graph requires a Teleport Access Graph license")
 		}
 		if isScoped {
 			return nil, trace.Wrap(services.ErrScopedIdentity, "access graph is not permitted")

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -14001,9 +14001,9 @@ func TestScopedUserCertGeneration(t *testing.T) {
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
-				entitlements.Policy: {Enabled: true},
-				entitlements.K8s:    {Enabled: true},
-				entitlements.App:    {Enabled: true},
+				entitlements.AccessGraph: {Enabled: true},
+				entitlements.K8s:         {Enabled: true},
+				entitlements.App:         {Enabled: true},
 			},
 		},
 	}), withClock(clock))

--- a/lib/auth/clusterconfig/clusterconfigv1/service.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service.go
@@ -982,8 +982,9 @@ func (s *Service) GetClusterAccessGraphConfig(ctx context.Context, _ *clustercon
 		return nil, trace.AccessDenied("this request can be only executed by a Teleport service")
 	}
 
-	// If the policy feature is disabled in the license, return a disabled response. if cloud, return the response to allow demo mode enabling
-	if !s.modules.Features().GetEntitlement(entitlements.Policy).Enabled && !s.modules.Features().AccessGraph && !s.modules.Features().Cloud {
+	// If Access Graph is disabled in the license, return a disabled response. If
+	// this is a Cloud cluster, return the response to allow demo mode enabling.
+	if !s.modules.Features().GetEntitlement(entitlements.AccessGraph).Enabled && !s.modules.Features().AccessGraph && !s.modules.Features().Cloud {
 		return clusterconfigpb.GetClusterAccessGraphConfigResponse_builder{
 			AccessGraph: clusterconfigpb.AccessGraphConfig_builder{
 				Enabled: false,
@@ -1084,8 +1085,8 @@ func (s *Service) UpdateAccessGraphSettings(ctx context.Context, req *clustercon
 		return nil, trace.Wrap(err)
 	}
 
-	if !s.modules.Features().GetEntitlement(entitlements.Policy).Enabled && !s.modules.Features().AccessGraph && !s.modules.Features().Cloud {
-		return nil, trace.AccessDenied("access graph is feature isn't enabled")
+	if !s.modules.Features().GetEntitlement(entitlements.AccessGraph).Enabled && !s.modules.Features().AccessGraph && !s.modules.Features().Cloud {
+		return nil, trace.AccessDenied("access graph feature isn't enabled")
 	}
 
 	cfg := req.GetAccessGraphSettings()
@@ -1128,8 +1129,8 @@ func (s *Service) UpsertAccessGraphSettings(ctx context.Context, req *clustercon
 		return nil, trace.Wrap(err)
 	}
 
-	if !s.modules.Features().GetEntitlement(entitlements.Policy).Enabled && !s.modules.Features().AccessGraph {
-		return nil, trace.AccessDenied("access graph is feature isn't enabled")
+	if !s.modules.Features().GetEntitlement(entitlements.AccessGraph).Enabled && !s.modules.Features().AccessGraph {
+		return nil, trace.AccessDenied("access graph feature isn't enabled")
 	}
 
 	cfg := req.GetAccessGraphSettings()
@@ -1172,8 +1173,8 @@ func (s *Service) ResetAccessGraphSettings(ctx context.Context, _ *clusterconfig
 		return nil, trace.Wrap(err)
 	}
 
-	if !s.modules.Features().GetEntitlement(entitlements.Policy).Enabled && !s.modules.Features().AccessGraph {
-		return nil, trace.AccessDenied("access graph is feature isn't enabled")
+	if !s.modules.Features().GetEntitlement(entitlements.AccessGraph).Enabled && !s.modules.Features().AccessGraph {
+		return nil, trace.AccessDenied("access graph feature isn't enabled")
 	}
 
 	obj, err := clusterconfig.NewAccessGraphSettings(clusterconfigpb.AccessGraphSettingsSpec_builder{

--- a/lib/auth/clusterconfig/clusterconfigv1/service_test.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service_test.go
@@ -2004,7 +2004,7 @@ func TestGetAccessGraphConfig(t *testing.T) {
 		accessGraphSettings *clusterconfigpb.AccessGraphSettings
 	}{
 		{
-			name:              "authorized proxy with non empty access graph config; Policy module is disabled",
+			name:              "authorized proxy with non empty access graph config; Access Graph entitlement is disabled",
 			role:              types.RoleProxy,
 			accessGraphConfig: cfgEnabled,
 			errorAssertion:    require.NoError,
@@ -2015,12 +2015,12 @@ func TestGetAccessGraphConfig(t *testing.T) {
 			}.Build(),
 		},
 		{
-			name: "authorized proxy with non empty access graph config; Policy module is enabled",
+			name: "authorized proxy with non empty access graph config; Access Graph entitlement is enabled",
 			role: types.RoleProxy,
 			modules: &modulestest.Modules{
 				TestFeatures: modules.Features{
 					Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
-						entitlements.Policy: {Enabled: true},
+						entitlements.AccessGraph: {Enabled: true},
 					},
 				},
 			},
@@ -2037,12 +2037,12 @@ func TestGetAccessGraphConfig(t *testing.T) {
 			}.Build(),
 		},
 		{
-			name: "authorized discovery with non empty access graph config; Policy module is enabled",
+			name: "authorized discovery with non empty access graph config; Access Graph entitlement is enabled",
 			role: types.RoleDiscovery,
 			modules: &modulestest.Modules{
 				TestFeatures: modules.Features{
 					Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
-						entitlements.Policy: {Enabled: true},
+						entitlements.AccessGraph: {Enabled: true},
 					},
 				},
 			},
@@ -2059,12 +2059,12 @@ func TestGetAccessGraphConfig(t *testing.T) {
 			}.Build(),
 		},
 		{
-			name: "Policy module is enabled with secrets scan option",
+			name: "Access Graph entitlement is enabled with secrets scan option",
 			role: types.RoleDiscovery,
 			modules: &modulestest.Modules{
 				TestFeatures: modules.Features{
 					Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
-						entitlements.Policy: {Enabled: true},
+						entitlements.AccessGraph: {Enabled: true},
 					},
 				},
 			},
@@ -2222,7 +2222,7 @@ func TestUpdateAccessGraphSettings(t *testing.T) {
 			modules: &modulestest.Modules{
 				TestFeatures: modules.Features{
 					Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
-						entitlements.Policy: {Enabled: true},
+						entitlements.AccessGraph: {Enabled: true},
 					},
 				},
 			},
@@ -2345,7 +2345,7 @@ func TestUpsertAccessGraphSettings(t *testing.T) {
 			modules: &modulestest.Modules{
 				TestFeatures: modules.Features{
 					Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
-						entitlements.Policy: {Enabled: true},
+						entitlements.AccessGraph: {Enabled: true},
 					},
 				},
 			},
@@ -2437,7 +2437,7 @@ func TestResetAccessGraphSettings(t *testing.T) {
 			modules: &modulestest.Modules{
 				TestFeatures: modules.Features{
 					Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
-						entitlements.Policy: {Enabled: true},
+						entitlements.AccessGraph: {Enabled: true},
 					},
 				},
 			},

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -6131,7 +6131,7 @@ func TestGetAccessGraphConfig(t *testing.T) {
 		withModules(&modulestest.Modules{
 			TestFeatures: modules.Features{
 				Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
-					entitlements.Policy: {Enabled: true},
+					entitlements.AccessGraph: {Enabled: true},
 				},
 			},
 		}),
@@ -7089,7 +7089,7 @@ func TestGenerateUserCerts_accessGraphUsage(t *testing.T) {
 		TestBuildType: modules.BuildEnterprise, // required for Device Trust.
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
-				entitlements.Policy: {Enabled: true},
+				entitlements.AccessGraph: {Enabled: true},
 			},
 		},
 	}))
@@ -7213,7 +7213,7 @@ func TestGenerateUserCertsScopedBot(t *testing.T) {
 		TestBuildType: modules.BuildEnterprise, // required for Device Trust.
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
-				entitlements.Policy: {Enabled: true},
+				entitlements.AccessGraph: {Enabled: true},
 			},
 		},
 	}))

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -81,7 +81,7 @@ type Features struct {
 	// AccessGraph enables the usage of access graph.
 	// NOTE: this is a legacy flag that is currently used to signal
 	// that Access Graph integration is *enabled* on a cluster.
-	// *Access* to the feature is gated on the `Policy` flag.
+	// *Access* to the feature is gated on the `AccessGraph` entitlement.
 	// TODO(justinas): remove this field once "TAG enabled" status is moved to a resource in the backend.
 	AccessGraph bool
 	// AccessMonitoringConfigured contributes to the enablement of access monitoring.
@@ -147,19 +147,15 @@ func (f Features) ToProto() *proto.Features {
 	}
 }
 
-// EntitlementsToProto takes the features.Entitlements object and returns a proto version. If not present on Features, the
-// proto entitlement will default to false
+// EntitlementsToProto takes the features.Entitlements object and returns a
+// proto version. Missing split identity security entitlements fall back to the
+// legacy Policy entitlement.
 func (f Features) EntitlementsToProto() map[string]*proto.EntitlementInfo {
 	all := entitlements.AllEntitlements
 	result := make(map[string]*proto.EntitlementInfo, len(all))
 
 	for _, e := range all {
-		al, ok := f.Entitlements[e]
-		if !ok {
-			result[string(e)] = &proto.EntitlementInfo{}
-			continue
-		}
-
+		al := f.GetEntitlement(e)
 		result[string(e)] = &proto.EntitlementInfo{
 			Enabled: al.Enabled,
 			Limit:   al.Limit,
@@ -169,31 +165,56 @@ func (f Features) EntitlementsToProto() map[string]*proto.EntitlementInfo {
 	return result
 }
 
-// GetEntitlement takes an entitlement and returns either the Features entitlement, or if not present, a false entitlement
+// GetEntitlement returns the requested entitlement. For compatibility with
+// licenses that predate the identity security entitlement split, a missing
+// AccessGraph, ActivityCenter, or SessionSummaries entitlement falls back to an
+// enabled legacy Policy entitlement.
 func (f Features) GetEntitlement(e entitlements.EntitlementKind) EntitlementInfo {
 	al, ok := f.Entitlements[e]
-	if !ok {
-		return EntitlementInfo{}
+	if ok {
+		return EntitlementInfo{
+			Enabled: al.Enabled,
+			Limit:   al.Limit,
+		}
 	}
 
-	return EntitlementInfo{
-		Enabled: al.Enabled,
-		Limit:   al.Limit,
+	if isLegacyPolicyFallbackEntitlement(e) && f.Entitlements[entitlements.Policy].Enabled {
+		return EntitlementInfo{Enabled: true}
 	}
+
+	return EntitlementInfo{}
 }
 
-// GetProtoEntitlement takes a proto features set and an entitlement and returns either the proto features entitlement,
-// or if not present, a false entitlement
+// GetProtoEntitlement returns the requested proto entitlement. For
+// compatibility with clusters that predate the identity security entitlement
+// split, a missing AccessGraph, ActivityCenter, or SessionSummaries entitlement
+// falls back to an enabled legacy Policy entitlement or Policy proto field.
 func GetProtoEntitlement(f *proto.Features, e entitlements.EntitlementKind) *proto.EntitlementInfo {
 	fE := f.GetEntitlements()
 	al, ok := fE[string(e)]
-	if !ok {
-		return &proto.EntitlementInfo{}
+	if ok {
+		return &proto.EntitlementInfo{
+			Enabled: al.Enabled,
+			Limit:   al.Limit,
+		}
 	}
 
-	return &proto.EntitlementInfo{
-		Enabled: al.Enabled,
-		Limit:   al.Limit,
+	if isLegacyPolicyFallbackEntitlement(e) {
+		policy, hasPolicyEntitlement := fE[string(entitlements.Policy)]
+		if policy.GetEnabled() || !hasPolicyEntitlement && f.GetPolicy().GetEnabled() {
+			return &proto.EntitlementInfo{Enabled: true}
+		}
+	}
+
+	return &proto.EntitlementInfo{}
+}
+
+func isLegacyPolicyFallbackEntitlement(e entitlements.EntitlementKind) bool {
+	switch e {
+	case entitlements.AccessGraph, entitlements.ActivityCenter, entitlements.SessionSummaries:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/lib/modules/modules_test.go
+++ b/lib/modules/modules_test.go
@@ -244,6 +244,7 @@ func TestFeatures_GetEntitlement(t *testing.T) {
 		Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
 			entitlements.AccessLists: {Enabled: true, Limit: 111},
 			entitlements.K8s:         {Enabled: false},
+			entitlements.Policy:      {Enabled: true},
 			entitlements.SAML:        {},
 		},
 	}
@@ -259,6 +260,50 @@ func TestFeatures_GetEntitlement(t *testing.T) {
 
 	actual = f.GetEntitlement(entitlements.UsageReporting)
 	require.Equal(t, modules.EntitlementInfo{}, actual)
+
+	actual = f.GetEntitlement(entitlements.AccessGraph)
+	require.Equal(t, modules.EntitlementInfo{Enabled: true}, actual)
+
+	actual = f.GetEntitlement(entitlements.ActivityCenter)
+	require.Equal(t, modules.EntitlementInfo{Enabled: true}, actual)
+
+	actual = f.GetEntitlement(entitlements.SessionSummaries)
+	require.Equal(t, modules.EntitlementInfo{Enabled: true}, actual)
+
+	f.Entitlements[entitlements.AccessGraph] = modules.EntitlementInfo{Enabled: false}
+	actual = f.GetEntitlement(entitlements.AccessGraph)
+	require.Equal(t, modules.EntitlementInfo{Enabled: false}, actual)
+}
+
+func TestGetProtoEntitlementLegacyPolicyFallback(t *testing.T) {
+	features := &proto.Features{
+		Entitlements: map[string]*proto.EntitlementInfo{
+			string(entitlements.Policy):      {Enabled: true},
+			string(entitlements.AccessGraph): {Enabled: false},
+		},
+	}
+
+	require.False(t, modules.GetProtoEntitlement(features, entitlements.AccessGraph).Enabled)
+	require.True(t, modules.GetProtoEntitlement(features, entitlements.ActivityCenter).Enabled)
+	require.True(t, modules.GetProtoEntitlement(features, entitlements.SessionSummaries).Enabled)
+	require.False(t, modules.GetProtoEntitlement(features, entitlements.AccessLists).Enabled)
+
+	protoFeatures := modules.Features{
+		Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+			entitlements.Policy:      {Enabled: true},
+			entitlements.AccessGraph: {Enabled: false},
+		},
+	}.ToProto()
+	require.False(t, protoFeatures.Entitlements[string(entitlements.AccessGraph)].Enabled)
+	require.True(t, protoFeatures.Entitlements[string(entitlements.ActivityCenter)].Enabled)
+	require.True(t, protoFeatures.Entitlements[string(entitlements.SessionSummaries)].Enabled)
+
+	legacyFeatures := &proto.Features{
+		Policy: &proto.PolicyFeature{Enabled: true},
+	}
+	require.True(t, modules.GetProtoEntitlement(legacyFeatures, entitlements.AccessGraph).Enabled)
+	require.True(t, modules.GetProtoEntitlement(legacyFeatures, entitlements.ActivityCenter).Enabled)
+	require.True(t, modules.GetProtoEntitlement(legacyFeatures, entitlements.SessionSummaries).Enabled)
 }
 
 func TestEntitlementInfo_UnderLimit(t *testing.T) {

--- a/lib/srv/discovery/access_graph_aws.go
+++ b/lib/srv/discovery/access_graph_aws.go
@@ -333,6 +333,15 @@ func newAccessGraphClient(ctx context.Context, getCert func() (*tls.Certificate,
 // in the cluster features.
 var errTAGFeatureNotEnabled = errors.New("TAG feature is not enabled")
 
+func accessGraphEntitlementEnabled(features *proto.Features) bool {
+	return features.GetAccessGraph() ||
+		modules.GetProtoEntitlement(features, entitlements.AccessGraph).Enabled
+}
+
+func activityCenterEntitlementEnabled(features *proto.Features) bool {
+	return modules.GetProtoEntitlement(features, entitlements.ActivityCenter).Enabled
+}
+
 // initializeAndWatchAccessGraph creates a new access graph service client and
 // watches the connection state. If the connection is closed, it will
 // automatically try to reconnect.
@@ -343,8 +352,7 @@ func (s *Server) initializeAndWatchAccessGraph(ctx context.Context, reloadCh <-c
 	)
 
 	clusterFeatures := s.Config.ClusterFeatures()
-	policy := modules.GetProtoEntitlement(&clusterFeatures, entitlements.Policy)
-	if !clusterFeatures.AccessGraph && !policy.Enabled {
+	if !accessGraphEntitlementEnabled(&clusterFeatures) {
 		return trace.Wrap(errTAGFeatureNotEnabled)
 	}
 
@@ -645,8 +653,7 @@ func (s *Server) startCloudtrailPoller(ctx context.Context, reloadCh <-chan stru
 	const semaphoreName = "access_graph_aws_cloudtrail_sync"
 
 	clusterFeatures := s.Config.ClusterFeatures()
-	policy := modules.GetProtoEntitlement(&clusterFeatures, entitlements.Policy)
-	if !clusterFeatures.AccessGraph && !policy.Enabled {
+	if !activityCenterEntitlementEnabled(&clusterFeatures) {
 		return trace.Wrap(errTAGFeatureNotEnabled)
 	}
 

--- a/lib/srv/discovery/access_graph_aws_test.go
+++ b/lib/srv/discovery/access_graph_aws_test.go
@@ -39,8 +39,75 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/entitlements"
 )
+
+func TestIdentitySecurityEntitlementGates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		features           *proto.Features
+		wantAccessGraph    bool
+		wantActivityCenter bool
+	}{
+		{
+			name: "legacy AccessGraph enabled signal",
+			features: &proto.Features{
+				AccessGraph: true,
+			},
+			wantAccessGraph: true,
+		},
+		{
+			name: "legacy Policy entitlement enables missing split features",
+			features: &proto.Features{
+				Entitlements: map[string]*proto.EntitlementInfo{
+					string(entitlements.Policy): {Enabled: true},
+				},
+			},
+			wantAccessGraph:    true,
+			wantActivityCenter: true,
+		},
+		{
+			name: "explicit split entitlements override legacy Policy fallback",
+			features: &proto.Features{
+				Entitlements: map[string]*proto.EntitlementInfo{
+					string(entitlements.Policy):         {Enabled: true},
+					string(entitlements.AccessGraph):    {Enabled: false},
+					string(entitlements.ActivityCenter): {Enabled: false},
+				},
+			},
+		},
+		{
+			name: "Access Graph entitlement",
+			features: &proto.Features{
+				Entitlements: map[string]*proto.EntitlementInfo{
+					string(entitlements.AccessGraph): {Enabled: true},
+				},
+			},
+			wantAccessGraph: true,
+		},
+		{
+			name: "Activity Center entitlement",
+			features: &proto.Features{
+				Entitlements: map[string]*proto.EntitlementInfo{
+					string(entitlements.ActivityCenter): {Enabled: true},
+				},
+			},
+			wantActivityCenter: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.wantAccessGraph, accessGraphEntitlementEnabled(tt.features))
+			require.Equal(t, tt.wantActivityCenter, activityCenterEntitlementEnabled(tt.features))
+		})
+	}
+}
 
 func TestSQSPollEvents(t *testing.T) {
 	t.Parallel()

--- a/lib/srv/discovery/access_graph_azure.go
+++ b/lib/srv/discovery/access_graph_azure.go
@@ -31,9 +31,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
-	"github.com/gravitational/teleport/entitlements"
 	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/discovery/fetchers/azuresync"
 )
@@ -212,8 +210,7 @@ func (s *Server) getAllTAGSyncAzureFetchers() []*azuresync.Fetcher {
 func (s *Server) initializeAndWatchAzureAccessGraph(ctx context.Context, reloadCh chan struct{}) error {
 	// Check if the access graph is enabled
 	clusterFeatures := s.Config.ClusterFeatures()
-	policy := modules.GetProtoEntitlement(&clusterFeatures, entitlements.Policy)
-	if !clusterFeatures.AccessGraph && !policy.Enabled {
+	if !accessGraphEntitlementEnabled(&clusterFeatures) {
 		return trace.Wrap(errTAGFeatureNotEnabled)
 	}
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2270,9 +2270,11 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 		IsPolicyEnabled:                modules.GetProtoEntitlement(&clusterFeatures, entitlements.Policy).Enabled,
 		// if Entitlements are not present, GetWebCfgEntitlements will return a map of entitlement to {enabled:false}
 		// if Entitlements are present, GetWebCfgEntitlements will populate the fields appropriately
-		Entitlements: GetWebCfgEntitlements(clusterFeatures.GetEntitlements()),
+		Entitlements: getWebCfgEntitlements(&clusterFeatures),
 		IdentitySecurity: webclient.IdentitySecurity{
-			IsClusterLicensed:           modules.GetProtoEntitlement(&clusterFeatures, entitlements.Policy).Enabled,
+			IsClusterLicensed: modules.GetProtoEntitlement(&clusterFeatures, entitlements.AccessGraph).Enabled ||
+				modules.GetProtoEntitlement(&clusterFeatures, entitlements.ActivityCenter).Enabled ||
+				modules.GetProtoEntitlement(&clusterFeatures, entitlements.SessionSummaries).Enabled,
 			AccessGraphConfigSet:        accessGraphConfigSet,
 			SessionSummarizationEnabled: sessionSummarizerEnabled,
 		},
@@ -2441,18 +2443,18 @@ func (h *Handler) getUserMatchedAuthConnectors(w http.ResponseWriter, r *http.Re
 	}, nil
 }
 
-// GetWebCfgEntitlements takes a cloud entitlement set and returns a modules Entitlement set
+// GetWebCfgEntitlements converts a proto entitlement map into the Web UI
+// representation, including the legacy Policy fallback.
 func GetWebCfgEntitlements(protoEntitlements map[string]*proto.EntitlementInfo) map[string]webclient.EntitlementInfo {
+	return getWebCfgEntitlements(&proto.Features{Entitlements: protoEntitlements})
+}
+
+func getWebCfgEntitlements(features *proto.Features) map[string]webclient.EntitlementInfo {
 	all := entitlements.AllEntitlements
 	result := make(map[string]webclient.EntitlementInfo, len(all))
 
 	for _, e := range all {
-		al, ok := protoEntitlements[string(e)]
-		if !ok {
-			result[string(e)] = webclient.EntitlementInfo{}
-			continue
-		}
-
+		al := modules.GetProtoEntitlement(features, e)
 		result[string(e)] = webclient.EntitlementInfo{
 			Enabled: al.Enabled,
 			Limit:   al.Limit,

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -5370,6 +5370,34 @@ func (s *safeModules) SetFeatures(f modules.Features) {
 	s.Modules.TestFeatures = f
 }
 
+func TestGetWebCfgEntitlementsLegacyPolicyFallback(t *testing.T) {
+	t.Parallel()
+
+	got := GetWebCfgEntitlements(map[string]*authproto.EntitlementInfo{
+		string(entitlements.Policy): {Enabled: true},
+	})
+	require.True(t, got[string(entitlements.AccessGraph)].Enabled)
+	require.True(t, got[string(entitlements.ActivityCenter)].Enabled)
+	require.True(t, got[string(entitlements.SessionSummaries)].Enabled)
+
+	got = GetWebCfgEntitlements(map[string]*authproto.EntitlementInfo{
+		string(entitlements.Policy):           {Enabled: true},
+		string(entitlements.AccessGraph):      {Enabled: false},
+		string(entitlements.ActivityCenter):   {Enabled: false},
+		string(entitlements.SessionSummaries): {Enabled: false},
+	})
+	require.False(t, got[string(entitlements.AccessGraph)].Enabled)
+	require.False(t, got[string(entitlements.ActivityCenter)].Enabled)
+	require.False(t, got[string(entitlements.SessionSummaries)].Enabled)
+
+	got = getWebCfgEntitlements(&authproto.Features{
+		Policy: &authproto.PolicyFeature{Enabled: true},
+	})
+	require.True(t, got[string(entitlements.AccessGraph)].Enabled)
+	require.True(t, got[string(entitlements.ActivityCenter)].Enabled)
+	require.True(t, got[string(entitlements.SessionSummaries)].Enabled)
+}
+
 func TestGetWebConfig_WithEntitlements(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx := t.Context()
@@ -5572,6 +5600,7 @@ func TestGetWebConfig_WithEntitlements(t *testing.T) {
 				entitlements.DB:          {Enabled: true, Limit: 22},
 				entitlements.DeviceTrust: {Enabled: true, Limit: 33},
 				entitlements.Desktop:     {Enabled: true, Limit: 44},
+				entitlements.Policy:      {Enabled: true},
 			},
 		})
 
@@ -5590,12 +5619,18 @@ func TestGetWebConfig_WithEntitlements(t *testing.T) {
 		expectedCfg.AutomaticUpgrades = true
 		expectedCfg.AutomaticUpgradesTargetVersion = "v" + teleport.Version
 		expectedCfg.Edition = testModules.BuildType()
+		expectedCfg.Entitlements[string(entitlements.AccessGraph)] = webclient.EntitlementInfo{Enabled: true}
+		expectedCfg.Entitlements[string(entitlements.ActivityCenter)] = webclient.EntitlementInfo{Enabled: true}
 		expectedCfg.Entitlements[string(entitlements.App)] = webclient.EntitlementInfo{Enabled: false}
 		expectedCfg.Entitlements[string(entitlements.DB)] = webclient.EntitlementInfo{Enabled: true, Limit: 22}
 		expectedCfg.Entitlements[string(entitlements.DeviceTrust)] = webclient.EntitlementInfo{Enabled: true, Limit: 33}
 		expectedCfg.Entitlements[string(entitlements.Desktop)] = webclient.EntitlementInfo{Enabled: true, Limit: 44}
 		expectedCfg.Entitlements[string(entitlements.JoinActiveSessions)] = webclient.EntitlementInfo{Enabled: false}
 		expectedCfg.Entitlements[string(entitlements.K8s)] = webclient.EntitlementInfo{Enabled: false}
+		expectedCfg.Entitlements[string(entitlements.Policy)] = webclient.EntitlementInfo{Enabled: true}
+		expectedCfg.Entitlements[string(entitlements.SessionSummaries)] = webclient.EntitlementInfo{Enabled: true}
+		expectedCfg.IdentitySecurity.IsClusterLicensed = true
+		expectedCfg.IsPolicyEnabled = true
 
 		// Advance time to unblock the feature watcher. Wait until
 		// the features have been retrieved and the feature watcher is blocked

--- a/skills/teleport-session-review/SKILL.md
+++ b/skills/teleport-session-review/SKILL.md
@@ -109,7 +109,8 @@ answer instead of a raw error:
    curl -s https://<proxy>/web/config.js \
      | sed -E 's/^[^{]*//; s/;[[:space:]]*$//' \
      | jq '{edition,
-            identitySecurityLicensed: .identitySecurity.licensed,
+            sessionSummariesLicensed: .entitlements.SessionSummaries.enabled,
+            accessGraphLicensed: .entitlements.AccessGraph.enabled,
             sessionSummarization: .identitySecurity.sessionSummarizationEnabled,
             accessGraphConfigSet: .identitySecurity.accessGraphConfigSet}'
    ```
@@ -117,9 +118,10 @@ answer instead of a raw error:
    Interpret (treat `null`/absent the same as `false` — on some clusters,
    including Enterprise **Cloud** tenants, the whole `identitySecurity` block is
    missing from `config.js` even when Identity Security is entitled):
-   - `edition` is `oss`/`community` **or** `identitySecurityLicensed` is not true →
-     this cluster cannot do summaries/search. Tell the user it requires
-     Enterprise + Identity Security, and use `recordings ls` instead.
+   - `edition` is `oss`/`community`, `sessionSummariesLicensed` is not true, or
+     `accessGraphLicensed` is not true → this cluster cannot do
+     summaries/search. Tell the user it requires Enterprise with the Session
+     Summaries and Access Graph entitlements, and use `recordings ls` instead.
    - `sessionSummarization` (i.e. `identitySecurity.sessionSummarizationEnabled`,
      the gate the user asked about) is not true, or `accessGraphConfigSet` is not
      true → licensed but not turned on; tell them to enable session summarization

--- a/skills/teleport-session-review/references/SCHEMA.md
+++ b/skills/teleport-session-review/references/SCHEMA.md
@@ -155,7 +155,8 @@ Relevant fields (observed on a live v18.8 Enterprise cluster):
 | Field | Meaning |
 |---|---|
 | `edition` | `ent` = Enterprise; `oss`/`community` = no summaries/search. |
-| `identitySecurity.licensed` | Identity Security is licensed. |
+| `entitlements.SessionSummaries.enabled` | Session Summaries is licensed. |
+| `entitlements.AccessGraph.enabled` | Access Graph is licensed. |
 | `identitySecurity.sessionSummarizationEnabled` | **The session-summarization gate.** Must be `true` for search/summaries. |
 | `identitySecurity.accessGraphConfigSet` | Access Graph is configured. |
 | `sessionSummarizerEnabled` | Top-level mirror of the summarization gate. |
@@ -167,7 +168,8 @@ requires 18.8.0+).
 
 Capability summary: `recordings ls` / `download` and `tsh play` work on **every
 edition**; `recordings search` (+ AI summaries) needs `edition=ent` **and**
-`identitySecurity.licensed=true` **and**
+`entitlements.SessionSummaries.enabled=true` **and**
+`entitlements.AccessGraph.enabled=true` **and**
 `identitySecurity.sessionSummarizationEnabled=true` on a **v18.8.0+** proxy.
 
 ---

--- a/tool/tctl/common/accessgraph/credentials.go
+++ b/tool/tctl/common/accessgraph/credentials.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/modules"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 )
@@ -198,18 +199,12 @@ func ensureAccessGraphCert(ctx context.Context, creds *accessGraphCredentials, c
 	return trace.Wrap(issueAndStoreAccessGraphCert(ctx, creds, authClient))
 }
 
-// checkAccessGraphSupported gates on the `Policy` entitlement.
+// checkAccessGraphSupported gates on the `AccessGraph` entitlement.
 // Endpoint reachability is checked at AG call time, not here.
 func checkAccessGraphSupported(ctx context.Context, ping proto.PingResponse) error {
 	features := ping.GetServerFeatures()
 
-	// This gate routes the "not licensed" error message and accepts the legacy
-	// `Policy` submessage from older clusters that predate the entitlements map.
-	//
-	// TODO(ghassan): when #66571's follow-ups split Identity Security out of Policy,
-	//  gate on the more specific entitlement here and keep Policy as the legacy fallback.
-	policy := features.GetEntitlements()[string(entitlements.Policy)]
-	licensed := policy.GetEnabled() || features.GetPolicy().GetEnabled()
+	licensed := modules.GetProtoEntitlement(features, entitlements.AccessGraph).Enabled
 	if !licensed {
 		return trace.AccessDenied(unlicensedAccessGraphMessage)
 	}

--- a/tool/tctl/common/accessgraph/credentials_test.go
+++ b/tool/tctl/common/accessgraph/credentials_test.go
@@ -150,7 +150,7 @@ func pingResponseAccessGraphReady() proto.PingResponse {
 		ServerFeatures: &proto.Features{
 			AccessGraph: true,
 			Entitlements: map[string]*proto.EntitlementInfo{
-				string(entitlements.Policy): {Enabled: true},
+				string(entitlements.AccessGraph): {Enabled: true},
 			},
 		},
 	}
@@ -658,11 +658,25 @@ func TestCheckAccessGraphSupported(t *testing.T) {
 		wantSubstr []string // every substring must appear in err.Error()
 	}{
 		{
-			name: "Policy entitlement enabled → no error",
+			name: "AccessGraph entitlement enabled → no error",
 			ping: pingResponseAccessGraphReady(),
 			wantErr: func(err error) bool {
 				return err == nil
 			},
+		},
+		{
+			// Older clusters have an entitlements map but no dedicated
+			// AccessGraph key.
+			name: "legacy Policy entitlement enabled → no error",
+			ping: proto.PingResponse{
+				ServerFeatures: &proto.Features{
+					AccessGraph: true,
+					Entitlements: map[string]*proto.EntitlementInfo{
+						string(entitlements.Policy): {Enabled: true},
+					},
+				},
+			},
+			wantErr: func(err error) bool { return err == nil },
 		},
 		{
 			// Older clusters set only the legacy Policy submessage.
@@ -681,7 +695,7 @@ func TestCheckAccessGraphSupported(t *testing.T) {
 				ServerFeatures: &proto.Features{
 					AccessGraph: false,
 					Entitlements: map[string]*proto.EntitlementInfo{
-						string(entitlements.Policy): {Enabled: true},
+						string(entitlements.AccessGraph): {Enabled: true},
 					},
 				},
 			},
@@ -694,12 +708,13 @@ func TestCheckAccessGraphSupported(t *testing.T) {
 			},
 		},
 		{
-			name: "Policy entitlement explicitly disabled → AccessDenied",
+			name: "AccessGraph entitlement explicitly disabled does not fall back to Policy → AccessDenied",
 			ping: proto.PingResponse{
 				ServerFeatures: &proto.Features{
 					AccessGraph: true,
 					Entitlements: map[string]*proto.EntitlementInfo{
-						string(entitlements.Policy): {Enabled: false},
+						string(entitlements.AccessGraph): {Enabled: false},
+						string(entitlements.Policy):      {Enabled: true},
 					},
 				},
 			},
@@ -719,9 +734,7 @@ func TestCheckAccessGraphSupported(t *testing.T) {
 			},
 		},
 		{
-			// Regression guard: the `AccessGraph` entitlement key is
-			// never populated by the modules code — only `Policy` is.
-			name: "AccessGraph-key entitlement on its own is NOT sufficient — Policy is the gate",
+			name: "AccessGraph entitlement on its own is sufficient",
 			ping: proto.PingResponse{
 				ServerFeatures: &proto.Features{
 					AccessGraph: true,
@@ -730,9 +743,8 @@ func TestCheckAccessGraphSupported(t *testing.T) {
 					},
 				},
 			},
-			wantErr: trace.IsAccessDenied,
-			wantSubstr: []string{
-				"Identity Security",
+			wantErr: func(err error) bool {
+				return err == nil
 			},
 		},
 	}

--- a/web/packages/teleport/src/Roles/PolicyPlaceholder.tsx
+++ b/web/packages/teleport/src/Roles/PolicyPlaceholder.tsx
@@ -72,7 +72,8 @@ export function PolicyPlaceholder({
 
   // roleDiffProps can be undefined if not cloud and not role tester
   // enabled.
-  const hideSalesButton = (cfg.isPolicyEnabled || cfg.isCloud) && roleDiffProps;
+  const hideSalesButton =
+    (cfg.entitlements.AccessGraph.enabled || cfg.isCloud) && roleDiffProps;
 
   return (
     <Box maxWidth={promoImageWidth + 2 * 2} minWidth={300}>
@@ -90,7 +91,7 @@ export function PolicyPlaceholder({
         </Box>
         <Flex flex="0 0 auto" alignItems="start">
           {canUpdateAccessGraphSettings &&
-            !cfg.isPolicyEnabled &&
+            !cfg.entitlements.AccessGraph.enabled &&
             cfg.isCloud &&
             enableDemoMode && ( // cloud can enable a demo mode so show that button
               <ButtonPrimary

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.story.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.story.tsx
@@ -43,7 +43,7 @@ import { RoleEditorDialog } from './RoleEditorDialog';
 import { unableToUpdatePreviewMessage } from './Shared';
 import { withDefaults } from './StandardEditor/withDefaults';
 
-const defaultIsPolicyEnabled = cfg.isPolicyEnabled;
+const defaultAccessGraphEntitlement = cfg.entitlements.AccessGraph;
 const defaultGetAccessGraphRoleTesterEnabled =
   storageService.getAccessGraphRoleTesterEnabled;
 
@@ -56,13 +56,13 @@ export default {
         ctx.storeUser.getRoleAccess = () => parameters.acl;
       }
       if (args.roleDiffEnabled) {
-        cfg.isPolicyEnabled = true;
+        cfg.entitlements.AccessGraph = { enabled: true, limit: 0 };
         storageService.getAccessGraphRoleTesterEnabled = () => true;
       }
       useEffect(() => {
         // Clean up
         return () => {
-          cfg.isPolicyEnabled = defaultIsPolicyEnabled;
+          cfg.entitlements.AccessGraph = defaultAccessGraphEntitlement;
           storageService.getAccessGraphRoleTesterEnabled =
             defaultGetAccessGraphRoleTesterEnabled;
         };

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
@@ -48,7 +48,7 @@ import { defaultRoleVersion, newRole } from './StandardEditor/standardmodel';
 import * as StandardModelModule from './StandardEditor/standardmodel';
 import { defaultOptions, withDefaults } from './StandardEditor/withDefaults';
 
-const defaultIsPolicyEnabled = cfg.isPolicyEnabled;
+const defaultAccessGraphEntitlement = cfg.entitlements.AccessGraph;
 
 let user: UserEvent;
 
@@ -85,7 +85,7 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.restoreAllMocks();
-  cfg.isPolicyEnabled = defaultIsPolicyEnabled;
+  cfg.entitlements.AccessGraph = defaultAccessGraphEntitlement;
 });
 
 test('rendering and switching tabs for new role', async () => {
@@ -192,7 +192,7 @@ test('rendering and switching tabs for a non-standard role', async () => {
 });
 
 it('calls onRoleUpdate on each modification in the standard editor', async () => {
-  cfg.isPolicyEnabled = true;
+  cfg.entitlements.AccessGraph = { enabled: true, limit: 0 };
   const onRoleUpdate = jest.fn();
   render(<TestRoleEditor demoMode onRoleUpdate={onRoleUpdate} />);
   expect(onRoleUpdate).toHaveBeenLastCalledWith(
@@ -208,7 +208,7 @@ it('calls onRoleUpdate on each modification in the standard editor', async () =>
 });
 
 it('calls onRoleUpdate after the first rendering of a non-standard role', async () => {
-  cfg.isPolicyEnabled = true;
+  cfg.entitlements.AccessGraph = { enabled: true, limit: 0 };
   const onRoleUpdate = jest.fn();
   const nonStandardRole = withDefaults({
     unsupportedField: true,
@@ -423,7 +423,7 @@ test('saving a new role', async () => {
 });
 
 describe('saving a new role after editing as YAML', () => {
-  test('with Policy disabled', async () => {
+  test('with Access Graph disabled', async () => {
     const onSave = jest.fn();
     render(<TestRoleEditor onSave={onSave} />);
 
@@ -455,8 +455,8 @@ describe('saving a new role after editing as YAML', () => {
     } as CreateNewRoleSaveClickEventData);
   });
 
-  test('with Policy enabled', async () => {
-    cfg.isPolicyEnabled = true;
+  test('with Access Graph enabled', async () => {
+    cfg.entitlements.AccessGraph = { enabled: true, limit: 0 };
     jest
       .spyOn(storageService, 'getAccessGraphRoleTesterEnabled')
       .mockReturnValue(true);

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx
@@ -90,7 +90,8 @@ export const RoleEditor = ({
   onMinimizedChange,
 }: RoleEditorProps) => {
   const roleTesterEnabled =
-    (cfg.isPolicyEnabled && storageService.getAccessGraphRoleTesterEnabled()) ||
+    (cfg.entitlements.AccessGraph.enabled &&
+      storageService.getAccessGraphRoleTesterEnabled()) ||
     demoMode;
   const idPrefix = useId();
   // These IDs are needed to connect accessibility attributes between the

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditorVisualizer.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditorVisualizer.test.tsx
@@ -31,11 +31,11 @@ import { RoleDiffProps, RoleDiffState } from '../Roles';
 import { RoleEditorVisualizer } from './RoleEditorVisualizer';
 
 const defaultDemoMode = cfg.entitlements.AccessGraphDemoMode;
-const defaultIsPolicyEnabled = cfg.isPolicyEnabled;
+const defaultAccessGraphEntitlement = cfg.entitlements.AccessGraph;
 const defaultIsCloud = cfg.isCloud;
 afterEach(() => {
   cfg.entitlements.AccessGraphDemoMode = defaultDemoMode;
-  cfg.isPolicyEnabled = defaultIsPolicyEnabled;
+  cfg.entitlements.AccessGraph = defaultAccessGraphEntitlement;
   cfg.isCloud = defaultIsCloud;
 });
 

--- a/web/packages/teleport/src/config.test.ts
+++ b/web/packages/teleport/src/config.test.ts
@@ -25,6 +25,73 @@ import cfg, {
 } from './config';
 import { IntegrationTag } from './Integrations/Enroll/Shared';
 
+describe('legacy Policy entitlement fallback', () => {
+  const original = {
+    isPolicyEnabled: cfg.isPolicyEnabled,
+    Policy: { ...cfg.entitlements.Policy },
+    AccessGraph: { ...cfg.entitlements.AccessGraph },
+    ActivityCenter: { ...cfg.entitlements.ActivityCenter },
+    SessionSummaries: { ...cfg.entitlements.SessionSummaries },
+  };
+
+  afterEach(() => {
+    cfg.isPolicyEnabled = original.isPolicyEnabled;
+    cfg.entitlements.Policy = { ...original.Policy };
+    cfg.entitlements.AccessGraph = { ...original.AccessGraph };
+    cfg.entitlements.ActivityCenter = { ...original.ActivityCenter };
+    cfg.entitlements.SessionSummaries = { ...original.SessionSummaries };
+  });
+
+  test('enables missing split entitlements from the Policy entitlement', () => {
+    cfg.init({
+      entitlements: {
+        Policy: { enabled: true, limit: 0 },
+      },
+    });
+
+    expect(cfg.entitlements.AccessGraph.enabled).toBe(true);
+    expect(cfg.entitlements.ActivityCenter.enabled).toBe(true);
+    expect(cfg.entitlements.SessionSummaries.enabled).toBe(true);
+  });
+
+  test('uses the old isPolicyEnabled flag when entitlements are absent', () => {
+    cfg.init({
+      isPolicyEnabled: true,
+    });
+
+    expect(cfg.entitlements.Policy.enabled).toBe(true);
+    expect(cfg.entitlements.AccessGraph.enabled).toBe(true);
+    expect(cfg.entitlements.ActivityCenter.enabled).toBe(true);
+    expect(cfg.entitlements.SessionSummaries.enabled).toBe(true);
+  });
+
+  test('does not apply fallback when any split entitlement is present', () => {
+    cfg.init({
+      isPolicyEnabled: true,
+      entitlements: {
+        AccessGraph: { enabled: false, limit: 0 },
+      },
+    });
+
+    expect(cfg.entitlements.AccessGraph.enabled).toBe(false);
+    expect(cfg.entitlements.ActivityCenter.enabled).toBe(false);
+    expect(cfg.entitlements.SessionSummaries.enabled).toBe(false);
+  });
+
+  test('an explicit Policy entitlement overrides the deprecated flag', () => {
+    cfg.init({
+      isPolicyEnabled: true,
+      entitlements: {
+        Policy: { enabled: false, limit: 0 },
+      },
+    });
+
+    expect(cfg.entitlements.AccessGraph.enabled).toBe(false);
+    expect(cfg.entitlements.ActivityCenter.enabled).toBe(false);
+    expect(cfg.entitlements.SessionSummaries.enabled).toBe(false);
+  });
+});
+
 test('getDeployServiceIamConfigureScriptPath formatting', () => {
   const params: UrlDeployServiceIamConfigureScriptParams = {
     integrationName: 'int-name',

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -50,7 +50,10 @@ import type { RecordingType } from 'teleport/services/recordings';
 import type { ParticipantMode } from 'teleport/services/session';
 import type { YamlSupportedResourceKind } from 'teleport/services/yaml/types';
 
-import { defaultEntitlements } from './entitlement';
+import {
+  applyLegacyPolicyEntitlementFallback,
+  defaultEntitlements,
+} from './entitlement';
 import generateResourcePath from './generateResourcePath';
 import { IntegrationTag } from './Integrations/Enroll/Shared';
 import type { MfaChallengeResponse } from './services/mfa';
@@ -283,8 +286,8 @@ const cfg = {
   oidc: false,
   /** @deprecated Use entitlements instead; remove in v20 */
   saml: false,
-  // isPolicyEnabled refers to the Teleport Policy product
-  /** @deprecated Use entitlements.Policy.enabled instead;*/
+  // isPolicyEnabled refers to the legacy Teleport Policy product.
+  /** @deprecated Use the feature-specific identity security entitlements instead. */
   isPolicyEnabled: false,
 
   ui: {
@@ -2078,7 +2081,7 @@ const cfg = {
   },
 
   init(backendConfig = {}) {
-    mergeDeep(this, backendConfig);
+    mergeDeep(this, applyLegacyPolicyEntitlementFallback(backendConfig));
   },
 };
 

--- a/web/packages/teleport/src/entitlement.ts
+++ b/web/packages/teleport/src/entitlement.ts
@@ -49,10 +49,19 @@ type entitlement =
   | 'UpsellAlert'
   | 'UsageReporting';
 
-export const defaultEntitlements: Record<
-  entitlement,
-  { enabled: boolean; limit: number }
-> = {
+type EntitlementInfo = { enabled: boolean; limit: number };
+type LegacyPolicyConfig = {
+  isPolicyEnabled?: boolean;
+  entitlements?: Partial<Record<entitlement, EntitlementInfo>>;
+};
+
+const legacyPolicyFallbackEntitlements = [
+  'AccessGraph',
+  'ActivityCenter',
+  'SessionSummaries',
+] as const satisfies readonly entitlement[];
+
+export const defaultEntitlements: Record<entitlement, EntitlementInfo> = {
   AccessGraph: { enabled: false, limit: 0 },
   AccessGraphDemoMode: { enabled: false, limit: 0 },
   AccessLists: { enabled: false, limit: 0 },
@@ -84,3 +93,40 @@ export const defaultEntitlements: Record<
   UpsellAlert: { enabled: false, limit: 0 },
   UsageReporting: { enabled: false, limit: 0 },
 };
+
+/**
+ * Applies the Identity Security entitlement split for config payloads from
+ * older proxies. The fallback is applied only if all split entitlements are
+ * absent.
+ */
+export function applyLegacyPolicyEntitlementFallback<
+  T extends LegacyPolicyConfig,
+>(config: T): T {
+  const incomingEntitlements = config.entitlements ?? {};
+  const hasPolicyEntitlement = Object.prototype.hasOwnProperty.call(
+    incomingEntitlements,
+    'Policy'
+  );
+  const policyEnabled = hasPolicyEntitlement
+    ? incomingEntitlements?.Policy?.enabled === true
+    : config.isPolicyEnabled === true;
+  const hasSplitEntitlement = legacyPolicyFallbackEntitlements.some(
+    entitlement =>
+      Object.prototype.hasOwnProperty.call(incomingEntitlements, entitlement)
+  );
+
+  if (!policyEnabled || hasSplitEntitlement) {
+    return config;
+  }
+
+  const entitlements = { ...incomingEntitlements };
+  if (!hasPolicyEntitlement) {
+    entitlements.Policy = { enabled: true, limit: 0 };
+  }
+
+  for (const entitlement of legacyPolicyFallbackEntitlements) {
+    entitlements[entitlement] = { enabled: true, limit: 0 };
+  }
+
+  return { ...config, entitlements };
+}


### PR DESCRIPTION
Gate Access Graph, Activity Center, and Session Summaries consumers on their dedicated entitlements.

Treat legacy Policy as a fallback for missing split entitlements across module, proto, web config, tctl, and UI config paths so newer clients remain compatible with older clusters and proxies.

Continues
- https://github.com/gravitational/teleport/pull/66571
- https://github.com/gravitational/teleport/pull/64340
- https://github.com/gravitational/teleport.e/pull/8722
- https://github.com/gravitational/teleport.e/pull/8725
- https://github.com/gravitational/teleport.e/pull/8791
- https://github.com/gravitational/teleport.e/pull/8792






<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
