### PR TITLE
tbot helm chart: Add dnsConfig support

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
@@ -605,3 +605,15 @@ See [the Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-po
 for more details.
 
 By default, this is unset.
+
+## `dnsConfig`
+
+| Type | Default |
+|------|---------|
+| `object` | `null` |
+
+`dnsConfig` sets the pod DNS configuration for any pods created by the chart.
+See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config)
+for more details.
+
+By default, this is unset.

--- a/examples/chart/tbot/.lint/full.yaml
+++ b/examples/chart/tbot/.lint/full.yaml
@@ -113,3 +113,8 @@ securityContext:
 podSecurityContext:
   runAsUser: 1000
   runAsGroup: 3000
+
+dnsConfig:
+  options:
+    - name: ndots
+      value: "2"

--- a/examples/chart/tbot/templates/deployment.yaml
+++ b/examples/chart/tbot/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
     {{- if .Values.podSecurityContext }}
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
     {{- end }}
+    {{- if .Values.dnsConfig }}
+      dnsConfig: {{- toYaml .Values.dnsConfig | nindent 8 }}
+    {{- end }}
       containers:
         - name: tbot
           image: {{ .Values.image }}:{{ template "tbot.version" . }}

--- a/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
@@ -115,6 +115,10 @@ should match the snapshot (full):
                   name: join-sa-token
                 - mountPath: /test/path
                   name: test-volume
+          dnsConfig:
+            options:
+              - name: ndots
+                value: "2"
           imagePullSecrets:
             - name: test-pull-secret
           nodeSelector:

--- a/examples/chart/tbot/tests/deployment_test.yaml
+++ b/examples/chart/tbot/tests/deployment_test.yaml
@@ -15,3 +15,26 @@ tests:
       - ../.lint/full.yaml
     asserts:
       - matchSnapshot: {}
+  - it: should not contain dnsConfig when not set
+    template: deployment.yaml
+    values:
+      - ../.lint/simple.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.dnsConfig
+  - it: should contain dnsConfig when set
+    template: deployment.yaml
+    values:
+      - ../.lint/simple.yaml
+    set:
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "2"
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsConfig
+          value:
+            options:
+              - name: ndots
+                value: "2"

--- a/examples/chart/tbot/values.yaml
+++ b/examples/chart/tbot/values.yaml
@@ -319,3 +319,10 @@ securityContext: null
 #
 # By default, this is unset.
 podSecurityContext: null
+
+# dnsConfig(object) -- sets the pod DNS configuration for any pods created by the chart.
+# See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config)
+# for more details.
+#
+# By default, this is unset.
+dnsConfig: null


### PR DESCRIPTION
## Description

Adds support for the Kubernetes `dnsConfig` pod spec field in the tbot Helm chart, following the same pattern used for `podSecurityContext`.

Fixes #68912

## Changes

- `examples/chart/tbot/values.yaml`: Added `dnsConfig: null` value with documentation comment
- `examples/chart/tbot/templates/deployment.yaml`: Added conditional rendering of `dnsConfig` in the pod spec
- `examples/chart/tbot/.lint/full.yaml`: Added `dnsConfig` with `ndots: "2"` to exercise the value in lint/tests
- `examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap`: Updated snapshot
- `docs/pages/includes/helm-reference/zz_generated.tbot.mdx`: Regenerated reference docs

## Motivation

In EKS clusters using Cilium as the CNI with FQDN-based network policies and CoreDNS autopath, the default `ndots: 5` causes external FQDNs to be tried with cluster search domains first. This triggers a known Cilium DNS proxy caching issue (cilium/cilium#20191) where resolved IPs are associated with the wrong FQDN identity, permanently blocking egress traffic.

Setting `dnsConfig.options: [{name: ndots, value: "2"}]` prevents search domain expansion for external FQDNs and avoids the issue entirely.

## Usage

```yaml
dnsConfig:
  options:
    - name: ndots
      value: "2"
```

## Tests

- `helm lint` passes with both simple and full values
- `helm unittest` passes (16 tests, 13 snapshots)
- `helm-janitor reference --check` passes
- `helm-janitor lint` passes (includes yamllint)