### PR TITLE
[v18] Bump svgo from 4.0.1 to 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "playwright": "^1.61.1",
     "react-select-event": "^5.5.1",
     "storybook": "^10.4.6",
-    "svgo": "^4.0.1",
+    "svgo": "^4.0.2",
     "typescript": "^6.0.3",
     "vite": "^8.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,8 +213,8 @@ importers:
         specifier: ^10.4.6
         version: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.1.0)(@types/react@19.2.17)(react@19.2.7)
       svgo:
-        specifier: ^4.0.1
-        version: 4.0.1
+        specifier: ^4.0.2
+        version: 4.0.2
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -6574,8 +6574,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svgo@4.0.1:
-    resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
+  svgo@4.0.2:
+    resolution: {integrity: sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -13624,7 +13624,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svgo@4.0.1:
+  svgo@4.0.2:
     dependencies:
       commander: 11.1.0
       css-select: 5.2.2

--- a/svgo.config.mjs
+++ b/svgo.config.mjs
@@ -28,5 +28,6 @@ export default {
         },
       },
     },
+    'removeScripts',
   ],
 };


### PR DESCRIPTION
Backport: #68856.

## Manual Test Plan
### Test Environment

My laptop.

### Test Cases
- [x] `pnpm process-icons` produces no changes.
