### PR TITLE
[v17] Bump svgo from 4.0.1 to 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "playwright": "^1.60.0",
     "react-select-event": "^5.5.1",
     "storybook": "^10.2.14",
-    "svgo": "^4.0.1",
+    "svgo": "^4.0.2",
     "typescript": "^5.7.2",
     "vite": "6.3.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,8 +201,8 @@ importers:
         specifier: ^10.2.14
         version: 10.2.14(@testing-library/dom@10.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       svgo:
-        specifier: ^4.0.1
-        version: 4.0.1
+        specifier: ^4.0.2
+        version: 4.0.2
       typescript:
         specifier: ^5.7.2
         version: 5.7.2
@@ -5708,8 +5708,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svgo@4.0.1:
-    resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
+  svgo@4.0.2:
+    resolution: {integrity: sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -12181,7 +12181,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svgo@4.0.1:
+  svgo@4.0.2:
     dependencies:
       commander: 11.1.0
       css-select: 5.2.2

--- a/svgo.config.mjs
+++ b/svgo.config.mjs
@@ -28,5 +28,6 @@ export default {
         },
       },
     },
+    'removeScripts',
   ],
 };


### PR DESCRIPTION
Backport: #68856.

## Manual Test Plan
### Test Environment

My laptop.

### Test Cases
- [x] `pnpm process-icons` produces no changes.
