### PR TITLE
[v18] Display a list of scopes in the UI

### DIFF
--- a/api/client/webclient/webconfig.go
+++ b/api/client/webclient/webconfig.go
@@ -139,6 +139,8 @@ type WebConfig struct {
 	IdentitySecurity IdentitySecurity `json:"identitySecurity"`
 	// BeamsUI indicates whether the Beams lite-mode UI is enabled
 	BeamsUI bool `json:"beamsUi"`
+	// ScopesEnabled indicates whether authorization scopes are enabled.
+	ScopesEnabled bool `json:"scopesEnabled"`
 }
 
 // IdentitySecurity contains identity security features and settings.

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -5685,6 +5685,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			Context:                   process.GracefulExitContext(),
 			StaticFS:                  fs,
 			ClusterFeatures:           process.GetClusterFeatures(),
+			ScopesFeatures:            process.scopesFeatures,
 			GetProxyClientCertificate: conn.ClientGetCertificate,
 			UI:                        cfg.Proxy.UI,
 			ProxySettings:             proxySettings,

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -69,6 +69,8 @@ import (
 	linuxdesktopv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/linuxdesktop/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 	"github.com/gravitational/teleport/api/mfa"
 	apitracing "github.com/gravitational/teleport/api/observability/tracing"
@@ -95,6 +97,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/httplib/csrf"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
@@ -105,6 +108,7 @@ import (
 	"github.com/gravitational/teleport/lib/proxy"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/scopes"
+	scopedutils "github.com/gravitational/teleport/lib/scopes/utils"
 	"github.com/gravitational/teleport/lib/secret"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
@@ -270,6 +274,9 @@ type Config struct {
 
 	// ClusterFeatures contains flags for supported/unsupported features.
 	ClusterFeatures proto.Features
+
+	// ScopesFeatures dictates which scoped components are enabled for this server.
+	ScopesFeatures scopes.Features
 
 	// ProxySettings allows fetching the current proxy settings.
 	ProxySettings ProxySettingsGetter
@@ -1454,6 +1461,43 @@ func (h *Handler) getUserContext(w http.ResponseWriter, r *http.Request, p httpr
 
 	userContext.ConsumedAccessRequestID = c.cfg.Session.GetConsumedAccessRequestID()
 
+	if h.cfg.ScopesFeatures.Enabled {
+		assignments, err := stream.Collect(scopedutils.RangeScopedRoleAssignments(
+			r.Context(), clt.ScopedAccessServiceClient(), scopedaccessv1.ListScopedRoleAssignmentsRequest_builder{
+				// Note that we are using the AllCallerAssignments flag here rather
+				// than just looking for our assignments by username. This flag
+				// suppresses standard scope-pinning, which allows us to see
+				// assignments in parent/orthogonal scopes. Generally, scoped commands
+				// only show the subset of state subject to the currently pinned scope,
+				// but the purpose of this function is specifically to discover
+				// potential target scopes for logging in, so we want to see everything
+				// regardless of current scope.
+				AllCallerAssignments: true,
+				ScopeFilter: scopesv1.Filter_builder{
+					Mode: scopesv1.Mode_MODE_ALL,
+				}.Build(),
+			}.Build(),
+		))
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		var assignedScopes []string
+		for _, assignment := range assignments {
+			for _, subAssignment := range assignment.GetSpec().GetAssignments() {
+				assignedScopes = append(assignedScopes, subAssignment.GetScope())
+			}
+		}
+
+		// apply canonical sorting and deduplication
+		slices.SortFunc(assignedScopes, scopes.Sort)
+		assignedScopes = slices.CompactFunc(assignedScopes, func(a, b string) bool {
+			return scopes.Compare(a, b) == scopes.Equivalent
+		})
+
+		userContext.AvailableScopes = assignedScopes
+	}
+
 	return userContext, nil
 }
 
@@ -2105,7 +2149,8 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 			AccessGraphConfigSet:        rsp.GetEnabled() && rsp.GetAddress() != "",
 			SessionSummarizationEnabled: sessionSummarizerEnabled,
 		},
-		BeamsUI: clusterFeatures.GetBeamsUI(),
+		BeamsUI:       clusterFeatures.GetBeamsUI(),
+		ScopesEnabled: h.cfg.ScopesFeatures.Enabled,
 	}
 
 	// Set entitlements with backwards field compatibility

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -88,8 +88,10 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	transportpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/transport/v1"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
@@ -139,6 +141,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/scopes"
+	access "github.com/gravitational/teleport/lib/scopes/access"
 	scopedapp "github.com/gravitational/teleport/lib/scopes/app"
 	"github.com/gravitational/teleport/lib/secret"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -9314,6 +9317,7 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 			ProxySSHAddr:  "127.0.0.1",
 			AccessPoint:   client,
 		},
+		ScopesFeatures: scopesFeatures,
 		SessionControl: SessionControllerFunc(func(ctx context.Context, sctx *SessionContext, login, localAddr, remoteAddr string) (context.Context, error) {
 			controller := srv.WebSessionController(sessionController)
 			ctx, err := controller(ctx, sctx, login, localAddr, remoteAddr)
@@ -9670,6 +9674,154 @@ func TestUserContextWithAccessRequest(t *testing.T) {
 
 	// Verify that the userContext returned contains the correct Access Request ID.
 	require.Equal(t, accessRequestID, userContext.ConsumedAccessRequestID)
+}
+
+func TestUerContextWithScopesNoAssignments(t *testing.T) {
+	t.Parallel()
+	env := newWebPack(t, 1, withScopesFeatures(scopes.Features{Enabled: true}))
+	proxy := env.proxies[0]
+	ctx := t.Context()
+
+	// Create and authenticate the test user.
+	pack := proxy.authPack(t, "dave", []types.Role{})
+
+	// Make a request to fetch the userContext.
+	endpoint := pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "context")
+	response, err := pack.clt.Get(ctx, endpoint, url.Values{})
+	require.NoError(t, err)
+
+	// Process the JSON response of the request.
+	var userContext webui.UserContext
+	err = json.Unmarshal(response.Bytes(), &userContext)
+	require.NoError(t, err)
+
+	// Verify that the userContext returned contains no available scopes.
+	require.Empty(t, userContext.AvailableScopes)
+}
+
+func TestUerContextWithScopes(t *testing.T) {
+	t.Parallel()
+	env := newWebPack(t, 1, withScopesFeatures(scopes.Features{Enabled: true}))
+	proxy := env.proxies[0]
+	ctx := t.Context()
+
+	// Create scoped roles.
+	_, err := env.server.Auth().ScopedAccess().CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+		Role: scopedaccessv1.ScopedRole_builder{
+			Kind:    access.KindScopedRole,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: "role-a",
+			}.Build(),
+			Scope: "/test",
+			Spec: scopedaccessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{"/test/a1", "/test/a2", "/test/b1"},
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+	_, err = env.server.Auth().ScopedAccess().CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+		Role: scopedaccessv1.ScopedRole_builder{
+			Kind:    access.KindScopedRole,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: "role-b",
+			}.Build(),
+			Scope: "/test",
+			Spec: scopedaccessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{"/test/b1"},
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	// Create scoped role assignments.
+	username := "dave"
+	assignment1, err := env.server.Auth().ScopedAccess().CreateScopedRoleAssignment(ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
+		Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
+			Kind:    access.KindScopedRoleAssignment,
+			SubKind: access.SubKindDynamic,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: "assignment-1",
+			}.Build(),
+			Scope: "/test",
+			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+				User: username,
+				Assignments: []*scopedaccessv1.Assignment{
+					// Deliberately put these out of order to make sure that the result
+					// is sorted.
+					scopedaccessv1.Assignment_builder{
+						Role:  "/test::role-b",
+						Scope: "/test/b1",
+					}.Build(),
+					scopedaccessv1.Assignment_builder{
+						Role:  "/test::role-a",
+						Scope: "/test/a2",
+					}.Build(),
+				},
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+	assignment2, err := env.server.Auth().ScopedAccess().CreateScopedRoleAssignment(ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
+		Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
+			Kind:    access.KindScopedRoleAssignment,
+			SubKind: access.SubKindDynamic,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: "assignment-2",
+			}.Build(),
+			Scope: "/test",
+			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+				User: username,
+				Assignments: []*scopedaccessv1.Assignment{
+					scopedaccessv1.Assignment_builder{
+						Role:  "/test::role-a",
+						Scope: "/test/a1",
+					}.Build(),
+					// Add a duplicate to make sure that the result is deduplicated.
+					scopedaccessv1.Assignment_builder{
+						Role:  "/test::role-a",
+						Scope: "/test/a2",
+					}.Build(),
+				},
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+	waitForSRACache(t, env.server.TLS, assignment1, assignment2)
+
+	// Create and authenticate the test user.
+	pack := proxy.authPack(t, username, []types.Role{})
+
+	// Make a request to fetch the userContext.
+	endpoint := pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "context")
+	response, err := pack.clt.Get(ctx, endpoint, url.Values{})
+	require.NoError(t, err)
+
+	// Process the JSON response of the request.
+	var userContext webui.UserContext
+	err = json.Unmarshal(response.Bytes(), &userContext)
+	require.NoError(t, err)
+
+	// Verify that the userContext returned contains the assigned scopes.
+	require.Equal(t, []string{"/test/a1", "/test/a2", "/test/b1"}, userContext.AvailableScopes)
+}
+
+func waitForSRACache(t *testing.T, srv *authtest.TLSServer, resps ...*scopedaccessv1.CreateScopedRoleAssignmentResponse) {
+	t.Helper()
+	ctx := t.Context()
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		for _, resp := range resps {
+			_, err := srv.Auth().ScopedAccessCache.GetScopedRoleAssignment(ctx, scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
+				Name:    resp.GetAssignment().GetMetadata().GetName(),
+				SubKind: resp.GetAssignment().GetSubKind(),
+				Scope:   resp.GetAssignment().GetScope(),
+			}.Build())
+			require.NoError(t, err)
+		}
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 // TestIsMFARequired_AcceptedRequests mostly tests that requests

--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -72,6 +72,9 @@ type UserContext struct {
 	AllowedSearchAsRoles []string `json:"allowedSearchAsRoles"`
 	// PasswordState specifies whether the user has a password set or not.
 	PasswordSate types.PasswordState `json:"passwordState"`
+	// AvailableScopes is a list of scopes available to the user through their
+	// scoped role assignments.
+	AvailableScopes []string `json:"availableScopes"`
 }
 
 func getAccessStrategy(roleset services.RoleSet) accessStrategy {

--- a/web/packages/teleport/src/Main/Main.test.tsx
+++ b/web/packages/teleport/src/Main/Main.test.tsx
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { createMemoryHistory } from 'history';
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter } from 'react-router';
 
@@ -40,6 +41,7 @@ import { Context, ContextProvider } from 'teleport';
 import { apps } from 'teleport/Apps/fixtures';
 import { events } from 'teleport/Audit/fixtures';
 import { clusters } from 'teleport/Clusters/fixtures';
+import cfg from 'teleport/config';
 import { databases } from 'teleport/Databases/fixtures';
 import { desktops } from 'teleport/Desktops/fixtures';
 import { getOSSFeatures } from 'teleport/features';
@@ -49,6 +51,8 @@ import { LayoutContextProvider } from 'teleport/Main/LayoutContext';
 import { createTeleportContext } from 'teleport/mocks/contexts';
 import { NavigationCategory } from 'teleport/Navigation';
 import { nodes } from 'teleport/Nodes/fixtures';
+import history from 'teleport/services/history/history';
+import { KeysEnum } from 'teleport/services/storageService';
 import { sessions } from 'teleport/Sessions/fixtures';
 import TeleportContext from 'teleport/teleportContext';
 import { userEventCaptureSuccess } from 'teleport/test/helpers/userEvents';
@@ -61,7 +65,15 @@ import { Main, MainProps } from './Main';
 
 enableMswServer();
 
+const defaultScopesEnabled = cfg.scopesEnabled;
+
+afterEach(() => {
+  cfg.scopesEnabled = defaultScopesEnabled;
+  localStorage.removeItem(KeysEnum.USE_LOGIN_SCOPE_PICKER);
+});
+
 beforeEach(() => {
+  history.init(createMemoryHistory());
   server.use(
     userEventCaptureSuccess(),
     successGetUsersV2([]),
@@ -115,6 +127,35 @@ test('renders', () => {
 
   expect(screen.getByTestId('teleport-logo')).toBeInTheDocument();
   expect(screen.queryAllByTestId(/toast-note/i)).toHaveLength(0);
+});
+
+test('redirects users with available scopes to the scope picker before rendering the app', async () => {
+  cfg.scopesEnabled = true;
+  localStorage.setItem(KeysEnum.USE_LOGIN_SCOPE_PICKER, JSON.stringify(true));
+  mockUserContextProviderWith(makeTestUserContext());
+  const ctx = setupContext();
+  ctx.storeUser.setState({
+    ...ctx.storeUser.state,
+    availableScopes: ['/prod', '/staging'],
+  });
+
+  render(
+    <MemoryRouter>
+      <LayoutContextProvider>
+        <ContextProvider ctx={ctx}>
+          <ToastNotificationProvider>
+            <Main features={getOSSFeatures()} />
+          </ToastNotificationProvider>
+        </ContextProvider>
+      </LayoutContextProvider>
+    </MemoryRouter>
+  );
+
+  // No navigation expected.
+  expect(screen.queryAllByText('Zero Trust Access')).toHaveLength(0);
+  expect(
+    screen.getByRole('heading', { name: 'Choose a scope for your session:' })
+  ).toBeVisible();
 });
 
 test('toggle rendering of info guide panel', async () => {

--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -53,6 +53,8 @@ import {
   LINK_DESTINATION_LABEL,
   LINK_TEXT_LABEL,
 } from 'teleport/services/alerts/alerts';
+import historyService from 'teleport/services/history/history';
+import { storageService } from 'teleport/services/storageService';
 import { TopBar } from 'teleport/TopBar';
 import type { LockedFeatures, TeleportFeature } from 'teleport/types';
 import { useUser } from 'teleport/User/UserContext';
@@ -117,6 +119,25 @@ export function Main(props: MainProps) {
     );
   }
 
+  const availableScopes = ctx.storeUser.getAvailableScopes();
+  const isScopePickerRoute = !!matchPath(history.location.pathname, {
+    path: cfg.routes.scopePicker,
+    exact: true,
+  });
+
+  // TODO(bl-nero): Don't redirect once the user picks a scope.
+  // For now, as the scope picker is not fully operational, we only enable it
+  // if a local storage flag is on.
+  if (storageService.getUseLoginScopePicker()) {
+    if (
+      cfg.scopesEnabled &&
+      availableScopes.length > 0 &&
+      !isScopePickerRoute
+    ) {
+      return <Redirect to={historyService.getScopePickerUrl()} />;
+    }
+  }
+
   // redirect to the default feature when hitting the root /web URL
   if (
     matchPath(history.location.pathname, { path: cfg.routes.root, exact: true })
@@ -156,7 +177,10 @@ export function Main(props: MainProps) {
 
   return (
     <FeaturesContextProvider value={features}>
-      <TopBar CustomLogo={props.CustomLogo} />
+      <TopBar
+        CustomLogo={props.CustomLogo}
+        scopePickerMode={isScopePickerRoute}
+      />
       <Wrapper>
         <MainContainer>
           <Navigation showPoweredByLogo={!!props.CustomLogo} />

--- a/web/packages/teleport/src/Scopes/LoginScopePicker.story.tsx
+++ b/web/packages/teleport/src/Scopes/LoginScopePicker.story.tsx
@@ -1,0 +1,56 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { Meta } from '@storybook/react-vite';
+import type { ComponentProps } from 'react';
+
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import { TeleportProviderBasic } from 'teleport/mocks/providers';
+
+import { LoginScopePicker as Component } from './LoginScopePicker';
+
+type StoryProps = ComponentProps<typeof Component> & {
+  username: string;
+  availableScopes: string[];
+};
+
+const meta: Meta<StoryProps> = {
+  title: 'Teleport/Scopes',
+  args: {
+    username: 'alice',
+    availableScopes: ['/prod', '/staging/west', '/staging/west/team-a'],
+  },
+};
+
+export default meta;
+
+export function LoginScopePicker({ username, availableScopes }: StoryProps) {
+  const ctx = createTeleportContext();
+
+  ctx.storeUser.setState({
+    ...ctx.storeUser.state,
+    username,
+    availableScopes,
+  });
+
+  return (
+    <TeleportProviderBasic teleportCtx={ctx}>
+      <Component />
+    </TeleportProviderBasic>
+  );
+}

--- a/web/packages/teleport/src/Scopes/LoginScopePicker.tsx
+++ b/web/packages/teleport/src/Scopes/LoginScopePicker.tsx
@@ -1,0 +1,96 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled from 'styled-components';
+
+import Box from 'design/Box';
+import { ButtonBorder } from 'design/Button';
+import Card from 'design/Card';
+import Flex, { Stack } from 'design/Flex';
+import * as Icon from 'design/Icon';
+import { H1, H2 } from 'design/Text';
+import { useStore } from 'shared/libs/stores';
+
+import useTeleport from 'teleport/useTeleport';
+
+/**
+ * Renders a scope picker screen that is shown if necessary after the user
+ * signs in. The scope picker allows selecting a scope to be pinned to the
+ * session.
+ *
+ * TODO(bl-nero): Actually pick the scope and sign the user into it.
+ */
+export function LoginScopePicker() {
+  const ctx = useTeleport();
+  const storeUser = useStore(ctx.storeUser);
+
+  return (
+    <Box px="5" width="100%" overflow="scroll">
+      <Card my="5" mx="auto" width="100%" maxWidth={600} p={4}>
+        <H1>Welcome back, {storeUser.getUsername()}</H1>
+        <H2 mt={5} mb={3}>
+          Choose a scope for your session:
+        </H2>
+        <Stack gap={2} as={Ul}>
+          {storeUser.getAvailableScopes().map(scope => (
+            <Li key={scope}>
+              <ScopeButton key={scope} block size="extra-large">
+                <Icon.Contract />
+                <Flex justifyContent="start" flex={1}>
+                  {scope}
+                </Flex>
+                <SignInAffordance gap={2}>
+                  Sign in <Icon.ArrowForward />
+                </SignInAffordance>
+              </ScopeButton>
+            </Li>
+          ))}
+        </Stack>
+      </Card>
+    </Box>
+  );
+}
+
+const Ul = styled.ul`
+  list-style: none;
+  padding: 0;
+  margin: 0;
+`;
+
+const Li = styled.li`
+  display: block;
+  width: 100%;
+`;
+
+const ScopeButton = styled(ButtonBorder)`
+  justify-content: start;
+  gap: ${props => props.theme.space[3]}px;
+  font-weight: 400;
+  padding-left: ${props => props.theme.space[3]}px;
+  padding-right: ${props => props.theme.space[3]}px;
+`;
+
+const SignInAffordance = styled(Flex)`
+  color: ${props => props.theme.colors.text.muted};
+  opacity: 0;
+  transition: opacity 0.1s;
+
+  ${ScopeButton}:hover &, ${ScopeButton}:focus-visible & {
+    opacity: 100%;
+  }
+`;

--- a/web/packages/teleport/src/Scopes/index.ts
+++ b/web/packages/teleport/src/Scopes/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { LoginScopePicker } from './LoginScopePicker';

--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -19,14 +19,15 @@
 import React, { type JSX } from 'react';
 import { matchPath, useHistory } from 'react-router';
 import { Link } from 'react-router-dom';
-import styled, { useTheme } from 'styled-components';
+import styled, { css, useTheme } from 'styled-components';
 
-import { breakpointsPx, Flex, Image, TopNav } from 'design';
+import { Box, breakpointsPx, Flex, Image, TopNav } from 'design';
 import { HoverTooltip } from 'design/Tooltip';
 
 import { logoSrc } from 'teleport/components/LogoHero/LogoHero';
 import { UserMenuNav } from 'teleport/components/UserMenuNav';
 import cfg from 'teleport/config';
+import { FeatureScopes } from 'teleport/features';
 import { useFeatures } from 'teleport/FeaturesContext';
 import { useLayout } from 'teleport/Main/LayoutContext';
 import { zIndexMap } from 'teleport/Navigation/zIndexMap';
@@ -35,8 +36,10 @@ import useTeleport from 'teleport/useTeleport';
 
 export function TopBar({
   CustomLogo,
+  scopePickerMode,
 }: {
   CustomLogo?: () => React.ReactElement;
+  scopePickerMode?: boolean;
 }) {
   const ctx = useTeleport();
   const history = useHistory();
@@ -59,12 +62,15 @@ export function TopBar({
       : navigationIconSizeSmall;
 
   return (
-    <TopBarContainer navigationHidden={feature?.hideNavigation}>
-      <TeleportLogo CustomLogo={CustomLogo} />
+    <TopBarContainer>
+      <TeleportLogo CustomLogo={CustomLogo} withLink={!scopePickerMode} />
       {!feature?.logoOnlyTopbar && (
         <Flex height="100%" alignItems="center">
           <Notifications iconSize={iconSize} />
-          <UserMenuNav username={ctx.storeUser.state.username} />
+          <UserMenuNav
+            username={ctx.storeUser.state.username}
+            hideFeatures={feature instanceof FeatureScopes}
+          />
         </Flex>
       )}
     </TopBarContainer>
@@ -91,61 +97,71 @@ export const TopBarContainer = styled(TopNav)`
 
 const TeleportLogo = ({
   CustomLogo,
+  withLink,
 }: {
   CustomLogo?: () => React.ReactElement;
+  withLink: boolean;
 }) => {
   const theme = useTheme();
   const src = logoSrc(theme.type);
+  const logoContent = CustomLogo ? (
+    <CustomLogo />
+  ) : (
+    <Image
+      data-testid="teleport-logo"
+      src={src}
+      alt="Teleport logo"
+      css={`
+        padding-left: ${props => props.theme.space[3]}px;
+        padding-right: ${props => props.theme.space[3]}px;
+        height: 18px;
+        @media screen and (min-width: ${p => p.theme.breakpoints.small}) {
+          height: 28px;
+          padding-left: ${props => props.theme.space[4]}px;
+          padding-right: ${props => props.theme.space[4]}px;
+        }
+        @media screen and (min-width: ${p => p.theme.breakpoints.large}) {
+          height: 30px;
+        }
+      `}
+    />
+  );
 
-  return (
+  return withLink ? (
     <HoverTooltip placement="bottom" tipContent="Teleport Resources Home">
-      <Link
-        css={`
-          cursor: pointer;
-          display: flex;
-          transition: background-color 0.1s linear;
-          &:hover {
-            background-color: ${p =>
-              p.theme.colors.interactive.tonal.primary[0]};
-          }
-          align-items: center;
-          height: 100%;
-          margin-right: 0px;
-          @media screen and (min-width: ${p => p.theme.breakpoints.medium}) {
-            margin-right: 76px;
-          }
-          @media screen and (min-width: ${p => p.theme.breakpoints.large}) {
-            margin-right: 67px;
-          }
-        `}
-        to={cfg.routes.root}
-      >
-        {CustomLogo ? (
-          <CustomLogo />
-        ) : (
-          <Image
-            data-testid="teleport-logo"
-            src={src}
-            alt="Teleport logo"
-            css={`
-              padding-left: ${props => props.theme.space[3]}px;
-              padding-right: ${props => props.theme.space[3]}px;
-              height: 18px;
-              @media screen and (min-width: ${p => p.theme.breakpoints.small}) {
-                height: 28px;
-                padding-left: ${props => props.theme.space[4]}px;
-                padding-right: ${props => props.theme.space[4]}px;
-              }
-              @media screen and (min-width: ${p => p.theme.breakpoints.large}) {
-                height: 30px;
-              }
-            `}
-          />
-        )}
-      </Link>
+      <LinkLogoWrapper to={cfg.routes.root}>{logoContent}</LinkLogoWrapper>
     </HoverTooltip>
+  ) : (
+    <BoxLogoWrapper>{logoContent}</BoxLogoWrapper>
   );
 };
+
+const commonLogoWrapperStyles = css`
+  display: flex;
+  align-items: center;
+  height: 100%;
+  margin-right: 0px;
+  @media screen and (min-width: ${p => p.theme.breakpoints.medium}) {
+    margin-right: 76px;
+  }
+  @media screen and (min-width: ${p => p.theme.breakpoints.large}) {
+    margin-right: 67px;
+  }
+`;
+
+const BoxLogoWrapper = styled(Box)`
+  ${commonLogoWrapperStyles}
+`;
+
+const LinkLogoWrapper = styled(Link)`
+  ${commonLogoWrapperStyles}
+
+  cursor: pointer;
+  transition: background-color 0.1s linear;
+  &:hover {
+    background-color: ${p => p.theme.colors.interactive.tonal.primary[0]};
+  }
+`;
 
 export const navigationIconSizeSmall = 20;
 export const navigationIconSizeMedium = 24;

--- a/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.tsx
+++ b/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.tsx
@@ -42,10 +42,6 @@ import { getCurrentTheme, getNextTheme } from 'teleport/ThemeProvider';
 import { DeviceTrustStatus } from 'teleport/TopBar/DeviceTrustStatus';
 import { useUser } from 'teleport/User/UserContext';
 
-interface UserMenuNavProps {
-  username: string;
-}
-
 const USER_MENU_DROPDOWN_ID = 'tb-user-menu';
 
 const Container = styled.div`
@@ -117,7 +113,13 @@ const Arrow = styled.div<{ open?: boolean }>`
   }
 `;
 
-export function UserMenuNav({ username }: UserMenuNavProps) {
+export function UserMenuNav({
+  username,
+  hideFeatures,
+}: {
+  username: string;
+  hideFeatures?: boolean;
+}) {
   const [open, setOpen] = useState(false);
   const theme = useTheme();
 
@@ -140,9 +142,12 @@ export function UserMenuNav({ username }: UserMenuNavProps) {
   const initial =
     username && username.length ? username.trim().charAt(0).toUpperCase() : '';
 
-  const topMenuItems = features.filter(
-    feature => Boolean(feature.topMenuItem) && feature.category === undefined
-  );
+  const topMenuItems = hideFeatures
+    ? []
+    : features.filter(
+        feature =>
+          Boolean(feature.topMenuItem) && feature.category === undefined
+      );
 
   const items = [];
 
@@ -219,7 +224,7 @@ export function UserMenuNav({ username }: UserMenuNavProps) {
         <DeviceTrustStatus />
         {items}
 
-        <DropdownDivider />
+        {items.length > 0 && <DropdownDivider />}
 
         {/* Hide ability to switch themes if the theme is a custom theme */}
         {!theme.isCustomTheme && (

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -109,6 +109,9 @@ const cfg = {
   // beamsUI indicates whether the Beams lite-mode UI is enabled
   beamsUi: false,
 
+  // scopesEnabled indicates whether authorization scopes are enabled.
+  scopesEnabled: false,
+
   configDir: '$HOME/.config/teleport',
 
   baseUrl: window.location.origin,
@@ -233,6 +236,7 @@ const cfg = {
     loginErrorCallback: '/web/msg/error/login/callback',
     loginErrorUnauthorized: '/web/msg/error/login/auth',
     loginErrorEntraIDGroupsOverage: '/web/msg/error/login/entra_groups_overage',
+    scopePicker: '/web/scope_picker',
     samlSloFailed: '/web/msg/error/slo',
     userInvite: '/web/invite/:tokenId',
     userInviteContinue: '/web/invite/:tokenId/continue',

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -70,6 +70,7 @@ import { Locks } from './LocksV2/Locks';
 import { NewLockView } from './LocksV2/NewLock';
 import { ManagedUpdates } from './ManagedUpdates';
 import { RolesContainer as Roles } from './Roles';
+import { LoginScopePicker } from './Scopes';
 import { SessionsContainer as Sessions } from './Sessions';
 import { Support } from './Support';
 import { TrustedClusters } from './TrustedClusters';
@@ -950,6 +951,21 @@ export class FeatureHelpAndSupport implements TeleportFeature {
   };
 }
 
+export class FeatureScopes implements TeleportFeature {
+  route = {
+    title: 'Pick a Scope',
+    path: cfg.routes.scopePicker,
+    exact: true,
+    component: LoginScopePicker,
+  };
+
+  hideNavigation = true;
+
+  hasAccess(): boolean {
+    return cfg.scopesEnabled;
+  }
+}
+
 export function getOSSFeatures(): TeleportFeature[] {
   return [
     // Resources
@@ -993,5 +1009,6 @@ export function getOSSFeatures(): TeleportFeature[] {
     // Other
     new FeatureAccount(),
     new FeatureHelpAndSupport(),
+    new FeatureScopes(),
   ];
 }

--- a/web/packages/teleport/src/services/history/history.test.ts
+++ b/web/packages/teleport/src/services/history/history.test.ts
@@ -125,6 +125,17 @@ describe('services/history', () => {
       expect(history._pageRefresh).toHaveBeenCalledWith(expected);
     });
 
+    it('should not attempt to redirect from an unknown path', () => {
+      jest
+        .spyOn(history, 'getRoutes')
+        .mockReturnValue(['/web/login', '/another-location']);
+      history.original().location.pathname = '/bogus-location';
+      history.goToLogin({ rememberLocation: true });
+
+      const expected = '/web/login?redirect_uri=http://localhost/web';
+      expect(history._pageRefresh).toHaveBeenCalledWith(expected);
+    });
+
     it('should navigate to login with access_changed param and no redirect_uri', () => {
       jest
         .spyOn(history, 'getRoutes')
@@ -176,5 +187,27 @@ describe('services/history', () => {
         '/web/login?access_changed&redirect_uri=http://localhost/current-location?test=value';
       expect(history._pageRefresh).toHaveBeenCalledWith(expected);
     });
+  });
+
+  describe('getScopePickerUrl', () => {
+    it('should have a redirection to the current page', () => {
+      jest
+        .spyOn(history, 'getRoutes')
+        .mockReturnValue(['/web/login', '/current-location']);
+      history.original().location.pathname = '/current-location';
+      expect(history.getScopePickerUrl()).toBe(
+        '/web/scope_picker?redirect_uri=http://localhost/current-location'
+      );
+    });
+  });
+
+  it('should not attempt to redirect from an unknown path', () => {
+    jest
+      .spyOn(history, 'getRoutes')
+      .mockReturnValue(['/web/login', '/another-location']);
+    history.original().location.pathname = '/bogus-location';
+    expect(history.getScopePickerUrl()).toBe(
+      '/web/scope_picker?redirect_uri=http://localhost/web'
+    );
   });
 });

--- a/web/packages/teleport/src/services/history/history.ts
+++ b/web/packages/teleport/src/services/history/history.ts
@@ -78,6 +78,27 @@ const history = {
     this._pageRefresh(url);
   },
 
+  /**
+   * Returns an URL to a scope picker that redirects to the current URL once
+   * the scope has been picked.
+   */
+  getScopePickerUrl() {
+    const params: string[] = [];
+
+    const { search, pathname } = this.getLocation();
+    const knownRoute = this.ensureKnownRoute(pathname);
+    const knownRedirect = this.ensureBaseUrl(knownRoute);
+    const query = search ? encodeURIComponent(search) : '';
+    params.push(`redirect_uri=${knownRedirect}${query}`);
+
+    const queryString = params.join('&');
+    const url = queryString
+      ? `${cfg.routes.scopePicker}?${queryString}`
+      : cfg.routes.scopePicker;
+
+    return url;
+  },
+
   // TODO (avatus): make this return a path only if a full URI is present
   getRedirectParam() {
     return getUrlParameter('redirect_uri', this.original().location.search);

--- a/web/packages/teleport/src/services/storageService/storageService.ts
+++ b/web/packages/teleport/src/services/storageService/storageService.ts
@@ -48,6 +48,7 @@ const KEEP_LOCALSTORAGE_KEYS_ON_LOGOUT = [
   KeysEnum.SESSION_RECORDINGS_DISMISSED_CTA,
   KeysEnum.IDENTITY_SECURITY_RECOMMENDATIONS_UNIFIED_RESOURCES_CTA_SEEN,
   KeysEnum.DESKTOP_HIDPI,
+  KeysEnum.USE_LOGIN_SCOPE_PICKER,
 ];
 
 const RECENT_HISTORY_MAX_LENGTH = 10;
@@ -373,5 +374,9 @@ export const storageService = {
       return '';
     }
     return parsed.hash;
+  },
+
+  getUseLoginScopePicker(): boolean {
+    return this.getParsedJSONValue(KeysEnum.USE_LOGIN_SCOPE_PICKER, false);
   },
 };

--- a/web/packages/teleport/src/services/storageService/types.ts
+++ b/web/packages/teleport/src/services/storageService/types.ts
@@ -68,6 +68,8 @@ export const KeysEnum = {
     'grv_teleport_identity_security_recommendations_unified_resources_cta_seen',
   APP_LAUNCHER_FRAGMENT: 'grv_teleport_app_launcher_fragment',
   DESKTOP_HIDPI: 'grv_teleport_desktop_hidpi',
+  // TODO(bl-nero): Remove this once the login scope picker is operational.
+  USE_LOGIN_SCOPE_PICKER: 'grv_teleport_use_login_scope_picker',
 };
 
 // SurveyRequest is the request for sending data to the back end

--- a/web/packages/teleport/src/services/user/makeUserContext.ts
+++ b/web/packages/teleport/src/services/user/makeUserContext.ts
@@ -33,6 +33,7 @@ export default function makeUserContext(json: any): UserContext {
   const allowedSearchAsRoles = json.allowedSearchAsRoles || [];
   const passwordState =
     json.passwordState || PasswordState.PASSWORD_STATE_UNSPECIFIED;
+  const availableScopes = json.availableScopes || [];
 
   return {
     username,
@@ -44,6 +45,7 @@ export default function makeUserContext(json: any): UserContext {
     accessRequestId,
     allowedSearchAsRoles,
     passwordState,
+    availableScopes,
   };
 }
 

--- a/web/packages/teleport/src/services/user/types.ts
+++ b/web/packages/teleport/src/services/user/types.ts
@@ -49,6 +49,11 @@ export interface UserContext {
   allowedSearchAsRoles: string[];
   /** Indicates whether the user has a password set. */
   passwordState: PasswordState;
+  /**
+   * A list of scopes available to sign in for this user, based on user's
+   * scoped role assignments.
+   */
+  availableScopes: string[];
 }
 
 /**

--- a/web/packages/teleport/src/services/user/user.test.ts
+++ b/web/packages/teleport/src/services/user/user.test.ts
@@ -20,7 +20,13 @@ import cfg from 'teleport/config';
 import api from 'teleport/services/api';
 
 import { makeTraits } from './makeUser';
-import { Acl, ExcludeUserField, PasswordState, User } from './types';
+import {
+  Acl,
+  ExcludeUserField,
+  PasswordState,
+  User,
+  UserContext,
+} from './types';
 import user from './user';
 
 test('undefined values in context response gives proper default values', async () => {
@@ -414,7 +420,8 @@ test('undefined values in context response gives proper default values', async (
     },
     allowedSearchAsRoles: [],
     passwordState: PasswordState.PASSWORD_STATE_UNSPECIFIED,
-  });
+    availableScopes: [],
+  } as UserContext);
 });
 
 test('fetch users, null response values gives empty array', async () => {

--- a/web/packages/teleport/src/stores/storeUserContext.ts
+++ b/web/packages/teleport/src/stores/storeUserContext.ts
@@ -322,4 +322,8 @@ export default class StoreUserContext extends Store<UserContext> {
   getBeamAccess() {
     return this.state.acl.beam;
   }
+
+  getAvailableScopes() {
+    return this.state.availableScopes;
+  }
 }


### PR DESCRIPTION
Backport #68028 to branch/v18

https://github.com/gravitational/teleport.e/pull/9221 needs to be merged right after this one.

## Manual Test Plan
### Test Environment
Any cluster with two users (Alice, Bob). Alice doesn't have scoped role assignments, Bob has multiple scoped role assignments. To turn on the feature:
- Turn on Scopes globally using `TELEPORT_UNSTABLE_SCOPES=yes` in the environment.
- Using Chrome dev tools, add `grv_teleport_use_login_scope_picker=true` to the application's local storage.

### Test Cases
- [x] Alice can sign in and navigate through Teleport just as she was before.
  - [x] Teleport logo leads to the resources page, and all expected features are present in the user menu.
- [x] With the scope picker turned on, Bob sees a list of scopes available to him after he logs in.
  - [x] Teleport logo is not clickable and the user menu only contains theme switcher and the logout command.
- [x] With the scope picker turned off, Bob can sign in and navigate through Teleport just as he was before.
  - [x] Turn off on the server side, using the environment variable
  - [x] Turn off on the client side, using Chrome dev tools