### PR TITLE
Don't fetch the role list twice for Kubernetes connection locks

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -669,13 +669,18 @@ func (f *Forwarder) acquireConnectionLockWithIdentity(ctx context.Context, ident
 		),
 	)
 	defer span.End()
-	user := identity.Identity.GetIdentity().Username
-	roles, err := getRolesByName(ctx, f, identity.Identity.GetIdentity().Groups)
-	if err != nil {
-		return trace.Wrap(err)
-	}
 
-	if err := f.acquireConnectionLock(ctx, user, roles); err != nil {
+	unscopedContext, isUnscoped := identity.UnscopedContext()
+	if !isUnscoped {
+		// scoped roles don't have max_kubernetes_connections
+		return nil
+	}
+	maxConnections := unscopedContext.Checker.MaxKubernetesConnections()
+	if maxConnections == 0 {
+		return nil
+	}
+	user := unscopedContext.Identity.GetIdentity().Username
+	if err := f.acquireConnectionLock(ctx, user, maxConnections); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -1681,8 +1686,7 @@ func wsProxy(ctx context.Context, log *slog.Logger, wsSource *gwebsocket.Conn, w
 // acquireConnectionLock acquires a semaphore used to limit connections to the Kubernetes agent.
 // The semaphore is releasted when the request is returned/connection is closed.
 // Returns an error if a semaphore could not be acquired.
-func (f *Forwarder) acquireConnectionLock(ctx context.Context, user string, roles services.RoleSet) error {
-	maxConnections := roles.MaxKubernetesConnections()
+func (f *Forwarder) acquireConnectionLock(ctx context.Context, user string, maxConnections int64) error {
 	if maxConnections == 0 {
 		return nil
 	}

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -659,17 +659,6 @@ func (f *Forwarder) withAuthStd(handler handlerWithAuthFuncStd) http.HandlerFunc
 
 // acquireConnectionLockWithIdentity acquires a connection lock under a given identity.
 func (f *Forwarder) acquireConnectionLockWithIdentity(ctx context.Context, identity *authContext) error {
-	ctx, span := f.cfg.tracer.Start(
-		ctx,
-		"kube.Forwarder/acquireConnectionLockWithIdentity",
-		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
-		oteltrace.WithAttributes(
-			semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
-			semconv.RPCSystemKey.String("kube"),
-		),
-	)
-	defer span.End()
-
 	unscopedContext, isUnscoped := identity.UnscopedContext()
 	if !isUnscoped {
 		// scoped roles don't have max_kubernetes_connections
@@ -1687,6 +1676,17 @@ func wsProxy(ctx context.Context, log *slog.Logger, wsSource *gwebsocket.Conn, w
 // The semaphore is releasted when the request is returned/connection is closed.
 // Returns an error if a semaphore could not be acquired.
 func (f *Forwarder) acquireConnectionLock(ctx context.Context, user string, maxConnections int64) error {
+	ctx, span := f.cfg.tracer.Start(
+		ctx,
+		"kube.Forwarder/acquireConnectionLock",
+		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
+		oteltrace.WithAttributes(
+			semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+			semconv.RPCSystemKey.String("kube"),
+		),
+	)
+	defer span.End()
+
 	if maxConnections == 0 {
 		return nil
 	}

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -661,7 +661,9 @@ func (f *Forwarder) withAuthStd(handler handlerWithAuthFuncStd) http.HandlerFunc
 func (f *Forwarder) acquireConnectionLockWithIdentity(ctx context.Context, identity *authContext) error {
 	unscopedContext, isUnscoped := identity.UnscopedContext()
 	if !isUnscoped {
-		// scoped roles don't have max_kubernetes_connections
+		// TODO(espadolini) TODO(eriktate): scoped identities don't currently
+		// support max_kubernetes_connections, this should be updated when they
+		// do
 		return nil
 	}
 	maxConnections := unscopedContext.Checker.MaxKubernetesConnections()

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -2004,6 +2004,13 @@ func TestKubernetesConnectionLimit(t *testing.T) {
 						Username: user.GetName(),
 						Groups:   []string{testCase.role.GetName()},
 					}),
+					Checker: services.NewAccessCheckerWithRoleSet(
+						&services.AccessInfo{
+							Roles: []string{testCase.role.GetName()},
+						},
+						"clustername",
+						services.NewRoleSet(testCase.role),
+					),
 				}),
 			}
 

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -309,6 +309,12 @@ type AccessChecker interface {
 
 	// DelegationSessionID returns the ID of the current Delegation Session.
 	DelegationSessionID() string
+
+	// MaxKubernetesConnections returns the maximum number of concurrent
+	// Kubernetes connections allowed. If MaxKubernetesConnections is zero then
+	// no maximum was defined and the number of concurrent connections is
+	// unconstrained.
+	MaxKubernetesConnections() int64
 }
 
 // AccessInfo hold information about an identity necessary to check whether that

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1599,9 +1599,7 @@ func (set RoleSet) MaxSessions() int64 {
 	return ms
 }
 
-// MaxConnections returns the maximum number of concurrent Kubernetes connections
-// allowed.  If MaxConnections is zero then no maximum was defined
-// and the number of concurrent connections is unconstrained.
+// MaxKubernetesConnections implements [AccessChecker].
 func (set RoleSet) MaxKubernetesConnections() int64 {
 	var mcs int64
 	for _, role := range set {


### PR DESCRIPTION
This PR exposes `max_kubernetes_connections` in the `AccessChecker` interface (we get it for free as part of the embedding of `RoleSet`) and uses it in lieu of loading the role list again from scratch as part of the logic to decide if we have to acquire a semaphore for long-running connections for Kube access (used for exec and port-forward).

Fixes #68625

## Manual Test Plan
### Test Environment

Cloud staging tenant, local kube agent, local `tsh proxy kube` to use `kubectl exec` repeatedly.

### Test Cases
- [x] `(*lib/kube/proxy.Forwarder).acquireConnectionLock` no longer appears prominently in profiles that contain a lot of `kubectl exec` handling, if no role specifies a max connection count
