### PR TITLE
[web ui] feat(Discovery): add Organization support for EC2 Discovery

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -940,6 +940,12 @@ const (
 	// AzureManagementGroupIDLabel is the label key for the Azure management group ID
 	// used for tenant-wide discovery scoping.
 	AzureManagementGroupIDLabel = TeleportNamespace + "/azure-management-group-id"
+	// AWSOrganizationalUnitsIncludeLabel is the label key for the comma-separated
+	// list of AWS Organizational Unit IDs to include for organization-wide discovery.
+	AWSOrganizationalUnitsIncludeLabel = TeleportNamespace + "/aws-organizational-units-include"
+	// AWSOrganizationalUnitsExcludeLabel is the label key for the comma-separated
+	// list of AWS Organizational Unit IDs to exclude from organization-wide discovery.
+	AWSOrganizationalUnitsExcludeLabel = TeleportNamespace + "/aws-organizational-units-exclude"
 	// ZoneLabelDiscovery is used to identify virtual machines by GCP zone
 	// found via automatic discovery, to avoid re-running installation
 	// commands on the node.

--- a/integrations/terraform-modules/teleport/discovery/aws/main.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/main.tf
@@ -5,7 +5,14 @@ locals {
     "teleport.dev/integration" = local.teleport_integration_name
     "teleport.dev/iac-tool"    = "terraform"
   })
-  apply_teleport_resource_labels = merge(var.apply_teleport_resource_labels, {
+  apply_teleport_org_labels = var.aws_organization_discovery != null ? {
+    "teleport.dev/aws-organizational-units-include" = join(",",
+    sort(var.aws_organization_discovery.organizational_units.include))
+    "teleport.dev/aws-organizational-units-exclude" = join(",",
+    sort(coalesce(var.aws_organization_discovery.organizational_units.exclude, [])))
+  } : {}
+
+  apply_teleport_resource_labels = merge(var.apply_teleport_resource_labels, local.apply_teleport_org_labels, {
     "teleport.dev/iac-tool" = "terraform",
   })
 

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -47,6 +47,17 @@ type IntegrationAWSOIDCSpec struct {
 	// such as preventing integration from update or deletion. Empty audience value
 	// should be treated as a default and backward-compatible behavior of the integration.
 	Audience string `json:"audience,omitempty"`
+
+	// Organization contains the AWS Organization discovery configuration.
+	Organization *IntegrationAWSOrganizationSpec `json:"organization,omitempty"`
+}
+
+// IntegrationAWSOrganizationSpec contains the AWS Organization discovery details.
+type IntegrationAWSOrganizationSpec struct {
+	// IncludeUnits is the list of Organizational Unit IDs to include.
+	IncludeUnits []string `json:"includeUnits,omitempty"`
+	// ExcludeUnits is the list of Organizational Unit IDs to exclude.
+	ExcludeUnits []string `json:"excludeUnits,omitempty"`
 }
 
 // IntegrationAWSRASpec contain the specific fields for the `aws-ra` subkind integration.
@@ -446,6 +457,17 @@ func MakeIntegration(ig types.Integration) (*Integration, error) {
 			IssuerS3Bucket: s3Bucket,
 			IssuerS3Prefix: s3Prefix,
 			Audience:       ig.GetAWSOIDCIntegrationSpec().Audience,
+		}
+		includeUnits, _ := ig.GetLabel(types.AWSOrganizationalUnitsIncludeLabel)
+		excludeUnits, _ := ig.GetLabel(types.AWSOrganizationalUnitsExcludeLabel)
+		if includeUnits != "" || excludeUnits != "" {
+			ret.AWSOIDC.Organization = &IntegrationAWSOrganizationSpec{}
+			if includeUnits != "" {
+				ret.AWSOIDC.Organization.IncludeUnits = strings.Split(includeUnits, ",")
+			}
+			if excludeUnits != "" {
+				ret.AWSOIDC.Organization.ExcludeUnits = strings.Split(excludeUnits, ",")
+			}
 		}
 	case types.IntegrationSubKindAzureOIDC:
 		spec := ig.GetAzureOIDCIntegrationSpec()

--- a/lib/web/ui/integration_test.go
+++ b/lib/web/ui/integration_test.go
@@ -77,6 +77,21 @@ func TestMakeIntegration(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	terraformManagedAwsOrgIntegration, err := types.NewIntegrationAWSOIDC(
+		types.Metadata{
+			Name: "terraform-managed-aws-org",
+			Labels: map[string]string{
+				types.CreatedByIaCLabel:                  IaCTerraformLabel,
+				types.AWSOrganizationalUnitsIncludeLabel: "ou-1,ou-2",
+				types.AWSOrganizationalUnitsExcludeLabel: "ou-3",
+			},
+		},
+		&types.AWSOIDCIntegrationSpecV1{
+			RoleARN: "arn:aws:iam::123456789012:role/example",
+		},
+	)
+	require.NoError(t, err)
+
 	testCases := []struct {
 		integration types.Integration
 		want        Integration
@@ -124,6 +139,21 @@ func TestMakeIntegration(t *testing.T) {
 						Region:            "eastus",
 						ResourceGroup:     "my-azure-resource-group",
 						ManagementGroupID: "my-management-group",
+					},
+				},
+				IsManagedByTerraform: true,
+			},
+		},
+		{
+			integration: terraformManagedAwsOrgIntegration,
+			want: Integration{
+				Name:    "terraform-managed-aws-org",
+				SubKind: types.IntegrationSubKindAWSOIDC,
+				AWSOIDC: &IntegrationAWSOIDCSpec{
+					RoleARN: "arn:aws:iam::123456789012:role/example",
+					Organization: &IntegrationAWSOrganizationSpec{
+						IncludeUnits: []string{"ou-1", "ou-2"},
+						ExcludeUnits: []string{"ou-3"},
 					},
 				},
 				IsManagedByTerraform: true,

--- a/web/packages/teleport/src/Discover/Overview/Aws/SettingsTab.test.tsx
+++ b/web/packages/teleport/src/Discover/Overview/Aws/SettingsTab.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { QueryClientProvider } from '@tanstack/react-query';
+
+import {
+  render,
+  screen,
+  testQueryClient,
+  waitFor,
+  within,
+} from 'design/utils/testing';
+import 'shared/components/TextEditor/TextEditor.mock';
+
+import { ContextProvider } from 'teleport';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import {
+  IntegrationAwsOidc,
+  IntegrationKind,
+  IntegrationWithSummary,
+  integrationService,
+} from 'teleport/services/integrations';
+
+import { SettingsTab } from './SettingsTab';
+
+const baseStats: IntegrationWithSummary = {
+  name: 'my-aws-integration',
+  subKind: IntegrationKind.AwsOidc,
+  unresolvedUserTasks: 0,
+  userTasks: [],
+  awsra: {} as any,
+  awsoidc: {} as any,
+  awsec2: {} as any,
+  awsrds: {} as any,
+  awseks: {} as any,
+  azurevm: {} as any,
+  rolesAnywhereProfileSync: {} as any,
+};
+
+const baseIntegration: IntegrationAwsOidc = {
+  resourceType: 'integration',
+  kind: IntegrationKind.AwsOidc,
+  name: 'my-aws-integration',
+  spec: {
+    roleArn: 'arn:aws:iam::123456789012:role/example',
+  },
+  statusCode: 1,
+};
+
+function setupMocks(integration: IntegrationAwsOidc = baseIntegration) {
+  jest
+    .spyOn(integrationService, 'fetchIntegration')
+    .mockResolvedValue(integration);
+  jest.spyOn(integrationService, 'fetchIntegrationRules').mockResolvedValue({
+    rules: [],
+    nextKey: '',
+  });
+}
+
+function renderSettingsTab() {
+  const ctx = createTeleportContext();
+  ctx.storeUser.state.cluster.authVersion = '1.0.0';
+
+  return render(
+    <ContextProvider ctx={ctx}>
+      <QueryClientProvider client={testQueryClient}>
+        <SettingsTab
+          stats={baseStats}
+          activeInfoGuideTab={null}
+          onInfoGuideTabChange={() => {}}
+        />
+      </QueryClientProvider>
+    </ContextProvider>
+  );
+}
+
+describe('SettingsTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    testQueryClient.clear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('organization scope', () => {
+    test('does not render for single account', async () => {
+      setupMocks();
+      renderSettingsTab();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('radio', { name: 'Single Account' })
+        ).toBeChecked();
+      });
+      expect(
+        screen.queryByText(/Include Organizational Units/i)
+      ).not.toBeInTheDocument();
+    });
+
+    test('renders with organization scope', async () => {
+      setupMocks({
+        ...baseIntegration,
+        spec: {
+          ...baseIntegration.spec,
+          organization: {
+            includeUnits: ['ou-1', 'ou-2'],
+            excludeUnits: ['ou-3'],
+          },
+        },
+      });
+      renderSettingsTab();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('radio', { name: 'Organization' })
+        ).toBeChecked();
+      });
+
+      const includeGroup = screen.getByRole('group', {
+        name: /Include Organizational Units/i,
+      });
+      expect(
+        within(includeGroup).getByDisplayValue('ou-1')
+      ).toBeInTheDocument();
+      expect(
+        within(includeGroup).getByDisplayValue('ou-2')
+      ).toBeInTheDocument();
+
+      const excludeGroup = screen.getByRole('group', {
+        name: /Exclude Organizational Units/i,
+      });
+      expect(
+        within(excludeGroup).getByDisplayValue('ou-3')
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/web/packages/teleport/src/Discover/Overview/Aws/SettingsTab.tsx
+++ b/web/packages/teleport/src/Discover/Overview/Aws/SettingsTab.tsx
@@ -25,11 +25,16 @@ import { copyToClipboard } from 'design/utils/copyToClipboard';
 import Validation from 'shared/components/Validation';
 
 import { DeploymentMethodSection } from 'teleport/Integrations/Enroll/Cloud/Aws/DeploymentMethodSection';
-import { IntegrationSection } from 'teleport/Integrations/Enroll/Cloud/Aws/EnrollAws';
+import {
+  ScopeSection,
+  IntegrationSection,
+} from 'teleport/Integrations/Enroll/Cloud/Aws/EnrollAws';
 import { InfoGuideContent } from 'teleport/Integrations/Enroll/Cloud/Aws/InfoGuide';
 import { ResourcesSection } from 'teleport/Integrations/Enroll/Cloud/Aws/ResourcesSection';
 import { buildTerraformConfig } from 'teleport/Integrations/Enroll/Cloud/Aws/tf_module';
 import {
+  AwsOrganizationalUnits,
+  AwsScope,
   buildMatchers,
   ServiceConfig,
   ServiceConfigs,
@@ -43,6 +48,7 @@ import {
 } from 'teleport/Integrations/Enroll/Cloud/Shared/InfoGuide';
 import { AwsResource } from 'teleport/Integrations/status/AwsOidc/Cards/StatCard';
 import {
+  IntegrationAwsOidc,
   IntegrationDiscoveryRule,
   IntegrationKind,
   integrationService,
@@ -52,6 +58,19 @@ import {
 import { useClusterVersion } from 'teleport/useClusterVersion';
 
 import { DeleteIntegrationSection } from '../DeleteIntegrationSection';
+
+const organizationFromIntegration = (
+  integration?: IntegrationAwsOidc
+): AwsOrganizationalUnits | null => {
+  const org = integration?.spec?.organization;
+  if (org && org.includeUnits?.length > 0) {
+    return {
+      include: org.includeUnits,
+      exclude: org.excludeUnits || [],
+    };
+  }
+  return null;
+};
 
 const configFromRules = (rules: IntegrationDiscoveryRule[]): ServiceConfig => {
   const regions = rules.map(r => r.region);
@@ -84,6 +103,16 @@ export function SettingsTab({
   const { clusterVersion } = useClusterVersion();
 
   const {
+    data: integration,
+    isLoading: isIntegrationLoading,
+    isError: isIntegrationError,
+  } = useQuery({
+    queryKey: ['integration', integrationName],
+    queryFn: () =>
+      integrationService.fetchIntegration<IntegrationAwsOidc>(integrationName),
+  });
+
+  const {
     data: ec2Rules,
     isLoading: isLoadingEc2,
     isError: isEc2Error,
@@ -112,8 +141,11 @@ export function SettingsTab({
   const [updatedConfigs, setUpdatedConfigs] = useState<Partial<ServiceConfigs>>(
     {}
   );
+  const [updatedScope, setScope] = useState<AwsScope | null>(null);
+  const [updatedOrgUnits, setOrgUnits] =
+    useState<AwsOrganizationalUnits | null>(null);
 
-  if (isLoadingEc2 || isLoadingEks) {
+  if (isLoadingEc2 || isLoadingEks || isIntegrationLoading) {
     return (
       <Flex justifyContent="center" mt={6}>
         <Indicator />
@@ -121,9 +153,16 @@ export function SettingsTab({
     );
   }
 
-  if (isEc2Error || isEksError) {
+  if (isEc2Error || isEksError || isIntegrationError) {
     return <Danger>Failed to load the integration settings.</Danger>;
   }
+
+  const initialOrgUnits = organizationFromIntegration(integration);
+  const initialScope: AwsScope = initialOrgUnits ? 'organization' : 'account';
+  const scope = updatedScope ?? initialScope;
+  const isOrganization = scope === 'organization';
+  const orgUnits = updatedOrgUnits ??
+    initialOrgUnits ?? { include: ['*'], exclude: [] };
 
   const configs: ServiceConfigs = {
     ec2: updatedConfigs.ec2 ?? configFromRules(ec2Rules.rules),
@@ -137,10 +176,16 @@ export function SettingsTab({
     }));
   };
 
+  // TF module currently supports EC2 only
+  const supportedConfigs: ServiceConfigs = isOrganization
+    ? { ...configs, eks: { ...configs.eks, enabled: false } }
+    : configs;
+
   const terraformConfig = buildTerraformConfig({
     integrationName,
-    matchers: buildMatchers(configs),
+    matchers: buildMatchers(supportedConfigs),
     version: clusterVersion,
+    orgUnits: isOrganization ? orgUnits : null,
   });
 
   return (
@@ -157,12 +202,21 @@ export function SettingsTab({
                 />
               </Box>
               <Divider />
+              <ScopeSection
+                scope={scope}
+                onScopeChange={setScope}
+                orgUnits={orgUnits}
+                onOrgUnitsChange={setOrgUnits}
+              />
+              <Divider />
               <ResourcesSection
-                configs={configs}
+                configs={supportedConfigs}
                 onConfigChange={updateConfig}
+                isOrganization={isOrganization}
               />
               <Divider />
               <DeploymentMethodSection
+                isOrganization={isOrganization}
                 terraformConfig={terraformConfig}
                 handleCopy={() => {
                   if (validator.validate() && terraformConfig) {

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/DeploymentMethodSection.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/DeploymentMethodSection.tsx
@@ -40,6 +40,7 @@ type DeploymentMethodSectionProps = {
   checkIntegrationError?: boolean;
   isCheckingIntegration?: boolean;
   showVerificationStep?: boolean;
+  isOrganization?: boolean;
 };
 
 export function DeploymentMethodSection({
@@ -51,13 +52,14 @@ export function DeploymentMethodSection({
   checkIntegrationError,
   handleCancelCheckIntegration,
   showVerificationStep = true,
+  isOrganization = false,
 }: DeploymentMethodSectionProps) {
   const validator = useValidation();
 
   return (
     <>
       <Flex alignItems="center" fontSize={4} fontWeight="medium" mb={2}>
-        <CircleNumber>3</CircleNumber>
+        <CircleNumber>4</CircleNumber>
         Apply Terraform
       </Flex>
 
@@ -133,6 +135,26 @@ export function DeploymentMethodSection({
               lines={[{ text: `terraform init` }, { text: `terraform apply` }]}
             />
           </Box>
+          {isOrganization && (
+            <Box mt={4}>
+              <Text bold={true} fontSize="14px" mb={2}>
+                4. Create IAM role in each target account
+              </Text>
+              <Text color="text.slightlyMuted" fontSize={1} mb={2}>
+                Create an IAM role in each target account using the role name,
+                trust policy, and permissions from the module output. This role
+                allows the Discovery Service to assume credentials in child
+                accounts to discover resources.
+              </Text>
+              <TextSelectCopyMulti
+                lines={[
+                  {
+                    text: 'terraform output aws_child_account_iam_role_template',
+                  },
+                ]}
+              />
+            </Box>
+          )}
         </Flex>
       </Box>
 
@@ -140,7 +162,7 @@ export function DeploymentMethodSection({
         <>
           <Divider />
           <Flex alignItems="center" fontSize={4} fontWeight="medium" mb={2}>
-            <CircleNumber>4</CircleNumber>
+            <CircleNumber>5</CircleNumber>
             Verify the Integration
           </Flex>
 

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.tsx
@@ -317,7 +317,7 @@ export function ScopeSection({
                 </>
               }
               value={orgUnits.include}
-              placeholder="r-xy"
+              placeholder="r-abcd"
               onChange={include => onOrgUnitsChange({ ...orgUnits, include })}
             />
             {!includeValidationResult.valid && (
@@ -335,7 +335,7 @@ export function ScopeSection({
               label="Exclude Organizational Units"
               tooltipContent="Accounts under an excluded organizational unit will be ignored."
               value={orgUnits.exclude}
-              placeholder="ou-xy-abcdefgh"
+              placeholder="ou-abcd-xyz12345"
               onChange={exclude => onOrgUnitsChange({ ...orgUnits, exclude })}
             />
           </Box>

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.tsx
@@ -20,7 +20,10 @@ import { useMemo, useState } from 'react';
 import { Link as InternalLink } from 'react-router';
 
 import { Box, ButtonSecondary, Flex, Subtitle1, Text } from 'design';
+import { MarkInverse } from 'design/Mark';
+import { RadioGroup } from 'design/RadioGroup';
 import FieldInput from 'shared/components/FieldInput';
+import { FieldMultiInput } from 'shared/components/FieldMultiInput/FieldMultiInput';
 import Validation from 'shared/components/Validation';
 import { requiredIntegrationName } from 'shared/components/Validation/rules';
 
@@ -50,6 +53,8 @@ import { InfoGuideContent } from './InfoGuide';
 import { ResourcesSection } from './ResourcesSection';
 import { buildTerraformConfig } from './tf_module';
 import {
+  AwsOrganizationalUnits,
+  AwsScope,
   buildMatchers,
   ServiceConfig,
   ServiceConfigs,
@@ -72,6 +77,12 @@ export function EnrollAws() {
     cancelCheckIntegration,
   } = useEnrollCloudIntegration(IntegrationEnrollKind.AwsCloud);
 
+  const [scope, setScope] = useState<AwsScope>('account');
+  const [orgUnits, setOrgUnits] = useState<AwsOrganizationalUnits>({
+    include: ['*'],
+    exclude: [],
+  });
+
   const [configs, setConfigs] = useState<ServiceConfigs>({
     ec2: { enabled: true, regions: [], tags: [] },
     eks: { enabled: false, regions: [], tags: [], kubeAppDiscovery: true },
@@ -84,14 +95,28 @@ export function EnrollAws() {
     }));
   };
 
+  const isOrganization = scope === 'organization';
+
+  // TF module currently supports EC2 only
+  const supportedConfigs: ServiceConfigs = isOrganization
+    ? { ...configs, eks: { ...configs.eks, enabled: false } }
+    : configs;
+
   const terraformConfig = useMemo(
     () =>
       buildTerraformConfig({
         integrationName,
-        matchers: buildMatchers(configs),
+        matchers: buildMatchers(supportedConfigs),
         version: clusterVersion,
+        orgUnits: isOrganization ? orgUnits : null,
       }),
-    [integrationName, configs, clusterVersion]
+    [
+      integrationName,
+      supportedConfigs,
+      clusterVersion,
+      isOrganization,
+      orgUnits,
+    ]
   );
 
   const {
@@ -125,12 +150,21 @@ export function EnrollAws() {
                 disabled={isFetching}
               />
               <Divider />
+              <ScopeSection
+                scope={scope}
+                onScopeChange={setScope}
+                orgUnits={orgUnits}
+                onOrgUnitsChange={setOrgUnits}
+              />
+              <Divider />
               <ResourcesSection
-                configs={configs}
+                configs={supportedConfigs}
                 onConfigChange={updateConfig}
+                isOrganization={isOrganization}
               />
               <Divider />
               <DeploymentMethodSection
+                isOrganization={isOrganization}
                 terraformConfig={terraformConfig}
                 handleCopy={() => {
                   if (validator.validate() && terraformConfig) {
@@ -218,6 +252,75 @@ export function IntegrationSection({
         disabled={disabled}
         onChange={e => onChange(e.target.value.trim())}
       />
+    </>
+  );
+}
+
+type ScopeSectionProps = {
+  scope: AwsScope;
+  onScopeChange: (scope: AwsScope) => void;
+  orgUnits: AwsOrganizationalUnits;
+  onOrgUnitsChange: (config: AwsOrganizationalUnits) => void;
+};
+
+export function ScopeSection({
+  scope,
+  onScopeChange,
+  orgUnits,
+  onOrgUnitsChange,
+}: ScopeSectionProps) {
+  const isOrganization = scope === 'organization';
+
+  return (
+    <>
+      <Flex alignItems="center" fontSize={4} fontWeight="medium" mb={1}>
+        <CircleNumber>2</CircleNumber>
+        Scope
+      </Flex>
+      <Text ml={4} mb={3}>
+        Discover resources in a single AWS account or across multiple accounts
+        using AWS Organizations.
+      </Text>
+      <Box ml={4} mb={3}>
+        <RadioGroup
+          name="awsScope"
+          options={[
+            { value: 'account', label: 'Single Account' },
+            { value: 'organization', label: 'Organization' },
+          ]}
+          value={scope}
+          size="small"
+          onChange={value => onScopeChange(value as AwsScope)}
+        />
+      </Box>
+      {isOrganization && (
+        <>
+          <Box ml={4} mb={3} maxWidth={432}>
+            <FieldMultiInput
+              label="Include Organizational Units"
+              tooltipContent={
+                <>
+                  Use <MarkInverse>*</MarkInverse> or the root organizational
+                  unit <MarkInverse>r-&#60;ID&#62;</MarkInverse> to include
+                  every account in the organization.
+                </>
+              }
+              value={orgUnits.include}
+              placeholder="r-xy"
+              onChange={include => onOrgUnitsChange({ ...orgUnits, include })}
+            />
+          </Box>
+          <Box ml={4} mb={3} maxWidth={432}>
+            <FieldMultiInput
+              label="Exclude Organizational Units"
+              tooltipContent="Accounts under an excluded organizational unit will be ignored."
+              value={orgUnits.exclude}
+              placeholder="ou-xy-abcdefgh"
+              onChange={exclude => onOrgUnitsChange({ ...orgUnits, exclude })}
+            />
+          </Box>
+        </>
+      )}
     </>
   );
 }

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.tsx
@@ -24,8 +24,11 @@ import { MarkInverse } from 'design/Mark';
 import { RadioGroup } from 'design/RadioGroup';
 import FieldInput from 'shared/components/FieldInput';
 import { FieldMultiInput } from 'shared/components/FieldMultiInput/FieldMultiInput';
-import Validation from 'shared/components/Validation';
-import { requiredIntegrationName } from 'shared/components/Validation/rules';
+import Validation, { useRule } from 'shared/components/Validation';
+import {
+  requiredField,
+  requiredIntegrationName,
+} from 'shared/components/Validation/rules';
 
 import cfg from 'teleport/config';
 import { Header } from 'teleport/Discover/Shared';
@@ -263,6 +266,10 @@ type ScopeSectionProps = {
   onOrgUnitsChange: (config: AwsOrganizationalUnits) => void;
 };
 
+const includeOrgUnitsRule = requiredField(
+  'At least one organizational unit is required.'
+);
+
 export function ScopeSection({
   scope,
   onScopeChange,
@@ -270,6 +277,9 @@ export function ScopeSection({
   onOrgUnitsChange,
 }: ScopeSectionProps) {
   const isOrganization = scope === 'organization';
+  const includeValidationResult = useRule(
+    includeOrgUnitsRule(orgUnits.include)
+  );
 
   return (
     <>
@@ -298,6 +308,7 @@ export function ScopeSection({
           <Box ml={4} mb={3} maxWidth={432}>
             <FieldMultiInput
               label="Include Organizational Units"
+              required
               tooltipContent={
                 <>
                   Use <MarkInverse>*</MarkInverse> or the root organizational
@@ -309,6 +320,15 @@ export function ScopeSection({
               placeholder="r-xy"
               onChange={include => onOrgUnitsChange({ ...orgUnits, include })}
             />
+            {!includeValidationResult.valid && (
+              <Text
+                color="interactive.solid.danger.default"
+                fontSize={1}
+                mt={1}
+              >
+                {includeValidationResult.message}
+              </Text>
+            )}
           </Box>
           <Box ml={4} mb={3} maxWidth={432}>
             <FieldMultiInput

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/ResourcesSection.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/ResourcesSection.tsx
@@ -70,11 +70,13 @@ const tagsWidth = fieldWidth + 32;
 type ResourcesSectionProps = {
   configs: ServiceConfigs;
   onConfigChange: (type: ServiceType, patch: Partial<ServiceConfig>) => void;
+  isOrganization?: boolean;
 };
 
 export function ResourcesSection({
   configs,
   onConfigChange,
+  isOrganization = false,
 }: ResourcesSectionProps) {
   const { valid, message } = useRule(requiredResourceType(configs));
   const hasError = !valid;
@@ -82,7 +84,7 @@ export function ResourcesSection({
   return (
     <>
       <Flex alignItems="center" fontSize={4} fontWeight="medium" mb={1}>
-        <CircleNumber>2</CircleNumber>
+        <CircleNumber>3</CircleNumber>
         Resource Types
       </Flex>
       <Text ml={4} mb={3}>
@@ -113,6 +115,8 @@ export function ResourcesSection({
           config={configs.eks}
           onUpdate={patch => onConfigChange('eks', patch)}
           tagTooltip="Match EKS clusters by their tags. If no tags are added, Teleport will match and enroll all EKS clusters."
+          disabled={isOrganization}
+          disabledTooltip="Teleport Discovery Terraform module currently does not support EKS Discovery with AWS Organizations. Select Single Account scope to enable EKS discovery."
         >
           <Box mt={2}>
             <Toggle
@@ -146,12 +150,16 @@ function AwsService({
   config,
   onUpdate,
   tagTooltip,
+  disabled = false,
+  disabledTooltip,
   children,
 }: {
   label: string;
   config: ServiceConfig;
   onUpdate: (update: Partial<ServiceConfig>) => void;
   tagTooltip: string;
+  disabled?: boolean;
+  disabledTooltip?: string;
   children?: React.ReactNode;
 }) {
   const [tagsExpanded, setTagsExpanded] = useState(config.tags.length > 0);
@@ -161,16 +169,28 @@ function AwsService({
     [config.regions]
   );
 
+  const checkboxLabel = disabled ? (
+    <Flex alignItems="center" gap={1}>
+      {label}
+      <IconTooltip kind="info">
+        <Text>{disabledTooltip}</Text>
+      </IconTooltip>
+    </Flex>
+  ) : (
+    label
+  );
+
   return (
     <>
       <FieldCheckbox
         mb={2}
         size="small"
-        label={label}
-        checked={config.enabled}
+        label={checkboxLabel}
+        checked={config.enabled && !disabled}
+        disabled={disabled}
         onChange={() => onUpdate({ enabled: !config.enabled })}
       />
-      {config.enabled && (
+      {config.enabled && !disabled && (
         <Box ml={4}>
           <Box mb={3} width={fieldWidth}>
             <RegionSelect

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/tf_module.test.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/tf_module.test.ts
@@ -236,4 +236,38 @@ describe('buildTerraformConfig', () => {
       'regions = ["eu-west-1", "us-east-1", "us-west-2"]'
     );
   });
+
+  describe('organization scope', () => {
+    test('disabled', () => {
+      const result = buildTerraformConfig(baseConfig);
+
+      expect(result).not.toContain('aws_organization_discovery');
+      expect(result).not.toContain('aws_child_account_iam_role_template');
+    });
+
+    test('enabled, includes wildcard by default', () => {
+      const result = buildTerraformConfig({
+        ...baseConfig,
+        orgUnits: { include: [], exclude: [] },
+      });
+
+      expect(result).toContain('include = ["*"]');
+      expect(result).not.toContain('exclude');
+      expect(result).toContain('output "aws_child_account_iam_role_template"');
+    });
+
+    test('with values', () => {
+      const result = buildTerraformConfig({
+        ...baseConfig,
+        orgUnits: { include: ['ou-1', 'ou-2'], exclude: ['ou-3'] },
+      });
+
+      expect(result).toContain('aws_organization_discovery');
+      expect(result).toContain('include = ["ou-1", "ou-2"]');
+      expect(result).toContain('exclude = ["ou-3"]');
+      expect(result).toContain(
+        'module.aws_discovery.aws_child_account_iam_role_template'
+      );
+    });
+  });
 });

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/tf_module.test.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/tf_module.test.ts
@@ -245,13 +245,13 @@ describe('buildTerraformConfig', () => {
       expect(result).not.toContain('aws_child_account_iam_role_template');
     });
 
-    test('enabled, includes wildcard by default', () => {
+    test('enabled', () => {
       const result = buildTerraformConfig({
         ...baseConfig,
         orgUnits: { include: [], exclude: [] },
       });
 
-      expect(result).toContain('include = ["*"]');
+      expect(result).toContain('include = []');
       expect(result).not.toContain('exclude');
       expect(result).toContain('output "aws_child_account_iam_role_template"');
     });

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/tf_module.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/tf_module.ts
@@ -84,8 +84,9 @@ const buildOrgDiscovery = (
   const exclude = orgUnits.exclude.filter(s => s.trim());
 
   const organizationalUnits: TFObject = {
-    include: include.length > 0 ? include : ['*'],
+    include,
   };
+
   if (exclude.length > 0) {
     organizationalUnits.exclude = exclude;
   }

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/tf_module.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/tf_module.ts
@@ -21,12 +21,13 @@ import { parse as parseVersion } from 'shared/utils/semVer';
 import cfg from 'teleport/config';
 
 import { hcl, TFObject } from '../terraform';
-import { AwsLabel, AwsMatcher } from './types';
+import { AwsLabel, AwsMatcher, AwsOrganizationalUnits } from './types';
 
 export type AwsDiscoverTerraformModuleConfig = {
   integrationName: string;
   matchers: AwsMatcher[];
   version: string;
+  orgUnits?: AwsOrganizationalUnits | null;
 };
 
 const TF_MODULE = '/teleport/discovery/aws';
@@ -74,10 +75,29 @@ const buildTfMatcher = (matcher: AwsMatcher): TFObject => {
   return obj;
 };
 
+const buildOrgDiscovery = (
+  orgUnits?: AwsOrganizationalUnits | null
+): TFObject | null => {
+  if (!orgUnits) return null;
+
+  const include = orgUnits.include.filter(s => s.trim());
+  const exclude = orgUnits.exclude.filter(s => s.trim());
+
+  const organizationalUnits: TFObject = {
+    include: include.length > 0 ? include : ['*'],
+  };
+  if (exclude.length > 0) {
+    organizationalUnits.exclude = exclude;
+  }
+
+  return { organizational_units: organizationalUnits };
+};
+
 export const buildTerraformConfig = ({
   integrationName,
   matchers,
   version,
+  orgUnits,
 }: AwsDiscoverTerraformModuleConfig): string => {
   const tfRegistry = isStaging(version)
     ? cfg.terraform.stagingRegistry
@@ -88,6 +108,16 @@ export const buildTerraformConfig = ({
   const integrationNameOrNull = integrationName.trim() || null;
 
   const awsMatchers = matchers.length > 0 ? matchers.map(buildTfMatcher) : null;
+
+  const awsOrgDiscovery = buildOrgDiscovery(orgUnits);
+
+  const orgOutput = awsOrgDiscovery
+    ? hcl`
+output "aws_child_account_iam_role_template" {
+  value = module.aws_discovery.aws_child_account_iam_role_template
+}
+`
+    : '';
 
   const tfModule = hcl`# Terraform Module
 module "aws_discovery" {
@@ -100,9 +130,13 @@ module "aws_discovery" {
   teleport_discovery_group_name = "cloud-discovery-group"
   teleport_integration_name	    = ${integrationNameOrNull}
 
+  # Discover resources across all accounts in the AWS Organization,
+  # filtered by Organizational Units.
+  aws_organization_discovery = ${awsOrgDiscovery}
+
   aws_matchers = ${awsMatchers}
 }
 `;
 
-  return tfModule;
+  return tfModule + orgOutput;
 };

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/types.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/types.ts
@@ -43,6 +43,13 @@ export type AwsMatcher = {
   kubeAppDiscovery?: boolean;
 };
 
+export type AwsScope = 'account' | 'organization';
+
+export type AwsOrganizationalUnits = {
+  include: string[];
+  exclude: string[];
+};
+
 export const buildMatchers = (configs: ServiceConfigs): AwsMatcher[] =>
   serviceTypes
     .filter(t => configs[t].enabled)

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -680,6 +680,7 @@ function makeIntegration(json: any): Integration {
         issuerS3Bucket: awsoidc?.issuerS3Bucket,
         issuerS3Prefix: awsoidc?.issuerS3Prefix,
         audience: awsoidc?.audience,
+        organization: awsoidc?.organization,
       },
     };
   }

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -175,6 +175,10 @@ export type IntegrationSpecAwsOidc = {
    * that depends on this integration.
    */
   audience?: IntegrationAudience;
+  organization?: {
+    includeUnits: string[];
+    excludeUnits: string[];
+  };
 };
 
 // IntegrationSpecAwsRa contain the specific fields for the `aws-ra` subkind integration. [go struct ui.IntegrationAWSRASpec]


### PR DESCRIPTION
Issue: https://github.com/gravitational/teleport/issues/66122

Changelog: Added AWS Organization Discovery support in Web UI

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

cloud

### Test Cases
- [x] Verify 'single account' / 'organization' scope selectable in AWS Integration IaC form
- [x] Verify the generated terraform snippet works
- [x] Verify `SettingsTab for an integration created w/ IaC module includes organization config
