### PR TITLE
[v18] Add page_type and outcome statements to 27 guides

### DIFF
--- a/docs/pages/configuration/teleport-operator/secret-lookup.mdx
+++ b/docs/pages/configuration/teleport-operator/secret-lookup.mdx
@@ -6,10 +6,11 @@ tags:
  - infrastructure-as-code
  - how-to
  - zero-trust
+page_type: how-to
 ---
 
-This guide describes how to store sensitive information in Kubernetes Secrets instead
-of the Teleport Kubernetes operator CRs.
+This guide shows you how to store sensitive information in Kubernetes Secrets
+instead of the Teleport Kubernetes operator CRs.
 
 ## How it works
 

--- a/docs/pages/configuration/teleport-operator/teleport-operator-helm.mdx
+++ b/docs/pages/configuration/teleport-operator/teleport-operator-helm.mdx
@@ -6,10 +6,11 @@ tags:
  - infrastructure-as-code
  - how-to
  - zero-trust
+page_type: how-to
 ---
 
-This guide explains how to run the Teleport Kubernetes Operator alongside a Teleport cluster
-deployed via the `teleport-cluster` Helm chart.
+In this guide, you will run the Teleport Kubernetes Operator alongside a
+Teleport cluster deployed via the `teleport-cluster` Helm chart.
 
 <Admonition type="warning">
 If your Teleport cluster is not deployed using the `teleport-cluster` Helm chart

--- a/docs/pages/core-concepts.mdx
+++ b/docs/pages/core-concepts.mdx
@@ -4,11 +4,12 @@ description: Learn the key components that make up Teleport.
 tags:
  - conceptual
  - platform-wide
+page_type: conceptual
 ---
 
-Here are the core concepts that describe a Teleport deployment. You will see
-these terms often when setting up and managing Teleport, so you should get
-familiar with them before following other pages in the documentation.
+This page describes the core concepts behind Teleport. You will see these terms
+often when setting up and managing Teleport, so you should get familiar with
+them before following other pages in the documentation.
 
 ## Teleport cluster
 

--- a/docs/pages/feature-matrix.mdx
+++ b/docs/pages/feature-matrix.mdx
@@ -2,14 +2,15 @@
 title: Teleport Feature Matrix
 description: Provides a comparison of features available in Teleport products.
 tags:
- - conceptual
+ - reference
  - platform-wide
+page_type: reference
 ---
 
 import Button from '@site/src/components/Button';
 import Icon from '@site/src/components/Icon'; 
 
-The Teleport feature matrix lists capabilities of the Teleport Infrastructure
+This page lists the capabilities of the Teleport Infrastructure
 Identity Platform, organized by product.
 
 {/*The Feature Matrix table has unique requirements, so include styling in an

--- a/docs/pages/identity-governance/access-lists/guide.mdx
+++ b/docs/pages/identity-governance/access-lists/guide.mdx
@@ -14,7 +14,7 @@ skills:
 
 {/* lint disable page-structure remark-lint */}
 
-This guide walks you through the Teleport Web UI to:
+In this guide, you will use the Teleport Web UI to:
 
 - Create an Access List
 - Assign a member to it

--- a/docs/pages/identity-governance/access-lists/nested-access-lists.mdx
+++ b/docs/pages/identity-governance/access-lists/nested-access-lists.mdx
@@ -6,13 +6,14 @@ tags:
  - identity-governance
  - privileged-access
 enterprise: Identity Governance
+page_type: how-to
 ---
 
 Nested Access Lists allow inclusion of an Access List as a member or owner of another Access List.
 This enables hierarchical permission structures where permissions can be inherited from multiple levels of
 parent Access Lists.
 
-This guide will help you:
+In this guide, you will:
 
 - Understand how nesting and inheritance work in Access Lists
 - Create a nested Access List

--- a/docs/pages/identity-governance/access-lists/standing-access-list.mdx
+++ b/docs/pages/identity-governance/access-lists/standing-access-list.mdx
@@ -8,19 +8,20 @@ tags:
  - identity-governance
  - privileged-access
 enterprise: Identity Governance
+page_type: how-to
 ---
-
-{/* lint disable page-structure remark-lint */}
 
 The **Standing Access Guide** creates an Access List whose members are automatically
 granted access to a defined set of resources when they log in. No Access Request
 is required.
 
-This guide will help you:
+In this guide, you will:
 
 - Decide when a Standing Access List is the right fit
 - Create one using the guided flow in the Teleport Web UI
 - Verify that members get access on login
+
+{/* lint ignore page-structure remark-lint */}
 
 ## When to use this flow
 

--- a/docs/pages/identity-governance/access-requests/plugins/mattermost.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/mattermost.mdx
@@ -8,11 +8,12 @@ tags:
  - identity-governance
  - privileged-access
 enterprise: Identity Governance
+page_type: how-to
 ---
 
 import BotLogo from "/static/avatar_logo.png";
 
-This guide explains how to integrate Access Requests with Mattermost, an open 
+This guide shows you how to integrate Access Requests with Mattermost, an open
 source messaging platform. 
 
 <details>

--- a/docs/pages/identity-governance/access-requests/plugins/pagerduty.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/pagerduty.mdx
@@ -8,11 +8,12 @@ tags:
  - identity-governance
  - privileged-access
 enterprise: Identity Governance
+page_type: how-to
 ---
 
 With Teleport's PagerDuty integration, engineers can access the infrastructure
 they need to resolve incidents quickly—without longstanding admin permissions
-that can become a vector for attacks. This guide explains how to set up
+that can become a vector for attacks. This guide shows you how to set up
 Teleport's Access Request plugin for PagerDuty.
 
 ## How it works

--- a/docs/pages/identity-governance/access-requests/resource-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/resource-requests.mdx
@@ -9,9 +9,8 @@ tags:
  - identity-governance
  - privileged-access
 enterprise: Identity Governance
+page_type: how-to
 ---
-
-{/* lint disable page-structure remark-lint */}
 
 With Teleport Resource Access Requests, users can request access to specific
 resources without needing to know anything about the roles or RBAC controls used
@@ -29,6 +28,11 @@ Teleport Community Edition users can get a preview of how Access Requests work b
 requesting a role via the Teleport CLI. Full Access Request functionality,
 including Resource Access Requests and an intuitive and searchable UI are
 available in Teleport Enterprise.
+
+In this guide, you will set up Resource Access Requests, search for resources to
+access, and request access to a resource.
+
+{/* lint ignore page-structure remark-lint */}
 
 ## Prerequisites
 

--- a/docs/pages/identity-governance/idps/saml-attribute-mapping.mdx
+++ b/docs/pages/identity-governance/idps/saml-attribute-mapping.mdx
@@ -8,6 +8,7 @@ tags:
  - identity-governance
  - privileged-access
 enterprise: Identity Governance
+page_type: conceptual
 ---
 
 Attribute mapping configures Teleport SAML Identity Provider to assert custom user attributes in SAML response.
@@ -39,6 +40,8 @@ spec:
     name_format: urn:oasis:names:tc:SAML:2.0:attrname-format:basic # optional, full urn format.
     value: user.spec.roles
 ```
+
+This page describes the configuration options available for attribute mapping.
 
 ## Prerequisites
 

--- a/docs/pages/identity-governance/idps/saml-guide.mdx
+++ b/docs/pages/identity-governance/idps/saml-guide.mdx
@@ -9,11 +9,12 @@ tags:
  - identity-governance
  - infrastructure-identity
 enterprise: Identity Governance
+page_type: how-to
 ---
 
-This guide details an example on how to use Teleport as a SAML identity provider
-(IdP). You can set up the Teleport SAML IdP to enable Teleport users to
-authenticate to external services through Teleport.
+In this guide, you will use Teleport as a SAML identity provider (IdP). You can
+set up the Teleport SAML IdP to enable Teleport users to authenticate to
+external services through Teleport.
 
 ## How it works
 

--- a/docs/pages/identity-governance/idps/usage/saml-microsoft-entra-external-id.mdx
+++ b/docs/pages/identity-governance/idps/usage/saml-microsoft-entra-external-id.mdx
@@ -8,12 +8,14 @@ tags:
  - azure
  - infrastructure-identity
 enterprise: Identity Governance
+page_type: how-to
 ---
 
 {/* lint disable page-structure remark-lint */}
 
-This guide explains how to integrate the Teleport SAML IdP with [Microsoft Entra External ID](https://learn.microsoft.com/en-us/entra/external-id/)
-so that users can access Azure Portal and the Azure CLI by authenticating with Teleport.
+This guide shows you how to integrate the Teleport SAML IdP with [Microsoft
+Entra External ID](https://learn.microsoft.com/en-us/entra/external-id/) so that
+users can access Azure Portal and the Azure CLI by authenticating with Teleport.
 
 ## How it works
 

--- a/docs/pages/identity-governance/idps/usage/usage.mdx
+++ b/docs/pages/identity-governance/idps/usage/usage.mdx
@@ -3,6 +3,7 @@ title: Using the Teleport SAML IdP
 sidebar_label: Usage
 description: Explains how to enable Teleport users to authenticate to external services using the Teleport SAML IdP.
 enterprise: Identity Governance
+page_type: landing
 ---
 
 The guides in this section explain how to set up the Teleport SAML IdP to enable

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/guide.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/guide.mdx
@@ -9,11 +9,14 @@ tags:
  - privileged-access
  - aws
 enterprise: Identity Governance
+page_type: how-to
 ---
 
-Teleport's integration with [AWS IAM Identity Center](https://aws.amazon.com/iam/identity-center/)
-allows you to organize and manage your users' short- and long-term access to AWS
-accounts and their permissions.
+Teleport's integration with [AWS IAM Identity
+Center](https://aws.amazon.com/iam/identity-center/) allows you to organize and
+manage your users' short- and long-term access to AWS accounts and their
+permissions. In this guide, you will set up the AWS IAM Identity Center
+integration to create Teleport resources automatically based on your AWS data.
 
 ## How it works
 

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
@@ -8,13 +8,14 @@ tags:
  - privileged-access
  - aws
 enterprise: Identity Governance
+page_type: how-to
 ---
 
-This guide describes how to introduce Teleport into an existing Okta-managed AWS
-IAM Identity Center configuration. It specifically describes two scenarios: one where 
-Teleport shares control of your Identity Center managed resources in conjunction
-with Okta, and another where Teleport replaces Okta as the Identity Center SSO
-Provider and user provisioner.
+This guide shows you how to introduce Teleport into an existing Okta-managed AWS
+IAM Identity Center configuration. It specifically describes two scenarios: one
+where Teleport shares control of your Identity Center managed resources in
+conjunction with Okta, and another where Teleport replaces Okta as the Identity
+Center SSO Provider and user provisioner.
 
 ## How it works
 

--- a/docs/pages/identity-governance/integrations/entra-id/setup/setup.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/setup/setup.mdx
@@ -3,6 +3,7 @@ title: Setting up the Microsoft Entra ID Integration
 sidebar_label: Setup
 description: Provides instructions for setting up the Microsoft Entra ID integration using various methods.
 enterprise: Identity Governance
+page_type: landing
 ---
 
 <DocCardList />

--- a/docs/pages/identity-governance/integrations/okta/app-and-group-sync.mdx
+++ b/docs/pages/identity-governance/integrations/okta/app-and-group-sync.mdx
@@ -8,6 +8,7 @@ tags:
  - identity-governance
  - privileged-access
 enterprise: Identity Governance
+page_type: how-to
 ---
 
 Okta has its own permissions system that doesn't directly map into Teleport. This
@@ -16,9 +17,9 @@ applications within Okta. To model this within Teleport, an administrator would 
 to carefully craft a labeling system to attach to various Okta apps and groups and a set of
 roles to go along with them.
 
-With the synchronization of Okta apps and groups as Teleport Access List feature in the Okta
-integration, this work is performed for you. This guide explains how to set up
-the Okta app and group sync.
+With the synchronization of Okta apps and groups as Teleport Access List feature
+in the Okta integration, this work is performed for you. This guide shows you
+how to set up the Okta app and group sync.
 
 ## How it works
 

--- a/docs/pages/installation/agents/agents.mdx
+++ b/docs/pages/installation/agents/agents.mdx
@@ -6,7 +6,10 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: conceptual
 ---
+
+This page describes the concept of a Teleport **join method**.
 
 You can use Teleport to protect infrastructure resources like servers and
 databases by deploying **Teleport Agents**. Teleport Agents run one or more

--- a/docs/pages/installation/agents/oracle.mdx
+++ b/docs/pages/installation/agents/oracle.mdx
@@ -6,9 +6,10 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
-This guide will explain how to use the **Oracle join method** to configure
+In this guide, you will use the **Oracle join method** to configure
 Teleport processes to join your Teleport cluster without sharing any secrets
 when they are running in an Oracle Cloud Infrastructure (OCI) Compute instance.
 

--- a/docs/pages/installation/self-hosted/private-keys/hsm.mdx
+++ b/docs/pages/installation/self-hosted/private-keys/hsm.mdx
@@ -6,10 +6,11 @@ tags:
  - how-to
  - platform-wide
 enterprise: Hardware security module support
+page_type: how-to
 ---
 
-This guide will show you how to set up the Teleport Auth Service to use a
-hardware security module (HSM) to store and handle private keys.
+This guide shows you how to set up the Teleport Auth Service to use a hardware
+security module (HSM) to store and handle private keys.
 
 ## How it works
 

--- a/docs/pages/zero-trust-access/compliance-frameworks/compliance-frameworks.mdx
+++ b/docs/pages/zero-trust-access/compliance-frameworks/compliance-frameworks.mdx
@@ -4,6 +4,7 @@ description: "How to use Teleport's access controls to streamline compliance wit
 tags:
  - zero-trust
  - audit
+page_type: landing
 ---
 
 Teleport makes it easier for your organization to achieve compliance with

--- a/docs/pages/zero-trust-access/export-audit-events/export-audit-events.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/export-audit-events.mdx
@@ -5,6 +5,7 @@ description: Learn how to export Teleport audit events to your log management so
 tags:
  - zero-trust
  - audit
+page_type: landing
 ---
 
 The Teleport Auth Service emits audit logs when users and services interact with

--- a/docs/pages/zero-trust-access/management/proxy-peering.mdx
+++ b/docs/pages/zero-trust-access/management/proxy-peering.mdx
@@ -4,6 +4,7 @@ description: How to upgrade an existing Teleport cluster to Proxy Peering mode.
 tags:
  - how-to
  - platform-wide
+page_type: how-to
 ---
 
 Proxy Peering enables Teleport Agents to be reachable without connecting to

--- a/docs/pages/zero-trust-access/management/security/proxy-protocol.mdx
+++ b/docs/pages/zero-trust-access/management/security/proxy-protocol.mdx
@@ -5,6 +5,7 @@ description: How to securely configure PROXY protocol usage with Teleport.
 tags:
  - how-to
  - platform-wide
+page_type: how-to
 ---
 
 This guide shows you how to configure the Teleport Auth Service and Proxy

--- a/docs/pages/zero-trust-access/management/tls-routing.mdx
+++ b/docs/pages/zero-trust-access/management/tls-routing.mdx
@@ -4,6 +4,7 @@ description: How to upgrade an existing Teleport cluster to single-port TLS rout
 tags:
  - how-to
  - platform-wide
+page_type: how-to
 ---
 
 {/* lint disable page-structure remark-lint */}
@@ -22,8 +23,8 @@ is served on a separate port:
   internal network like SSH.
 
 Upgrading Teleport will not enable TLS routing by default and the cluster will
-keep working in backwards-compatibility mode. Follow this guide to migrate your
-Teleport installation to TLS routing.
+keep working in backwards-compatibility mode. In this guide, you will migrate
+your Teleport installation to TLS routing.
 
 Teleport Enterprise Cloud manages the Proxy Service's networking configuration
 for you. Get started with a [free


### PR DESCRIPTION
Backports #68200

We are standardizing docs guides to add a `page_type` frontmatter field,
 with values for how-to guides, references, etc. We can then use this
 field to apply linting rules that ensure each guide type follows
 type-specific docs site conventions. The first convention is that each
 docs page must have an outcome statement, the structure of which depends
 on the guide's type. Human and AI agent readers can determine from the
 outcome statement whether to continue reading the guide or not.

 This change assigns the `page_type` frontmatter field to 47 guides.
 Where an outcome statement is missing or incorrect, this change adds or
 corrects it. Changes include:
 - Landing pages: added `page_type: landing`, with no outcome statement required
 - Guides with entirely new outcome statements
 - Already-compliant guides: intro paragraphs already matched the required pattern, so this adds `page_type` only
 - Editing outcome statements to use compliant phrasing: a sentence in the introduction mostly matched the expected pattern, but required a small phrasing change