### PR TITLE
[v18] Add page_type and outcome statements to 49 guides

### DIFF
--- a/docs/pages/configuration/configuration.mdx
+++ b/docs/pages/configuration/configuration.mdx
@@ -7,6 +7,7 @@ tags:
  - infrastructure-as-code
  - conceptual
  - zero-trust
+page_type: landing
 ---
 import Resources from "@site/src/components/Pages/Homepage/Resources";
 

--- a/docs/pages/configuration/resource-guides/agentless-ssh-servers.mdx
+++ b/docs/pages/configuration/resource-guides/agentless-ssh-servers.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 In this guide, you will see how to register in Teleport your OpenSSH nodes
@@ -36,7 +37,7 @@ agentless SSH servers. The Teleport Kubernetes Operator and Terraform provider,
 along with the `tctl` command-line tool, can manage agentless SSH services by
 authenticating to the Teleport Auth Service and interacting with its gRPC API.
 
-# Prerequisites
+## Prerequisites
 
 To follow this guide, you must have:
 

--- a/docs/pages/configuration/resource-guides/user-and-role.mdx
+++ b/docs/pages/configuration/resource-guides/user-and-role.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - zero-trust
  - privileged-access
+page_type: how-to
 ---
 
 In this guide, you will see how to create users and grant them roles through

--- a/docs/pages/configuration/terraform-provider/terraform-cloud.mdx
+++ b/docs/pages/configuration/terraform-provider/terraform-cloud.mdx
@@ -7,9 +7,10 @@ tags:
  - infrastructure-as-code
  - how-to
  - zero-trust
+page_type: how-to
 ---
 
-This guide demonstrates how to use the Terraform provider for Teleport using
+In this guide, you will use the Terraform provider for Teleport using
 HCP Terraform or Terraform Enterprise.
 
 This guide does not cover running the Terraform provider locally, in other CI/CD

--- a/docs/pages/configuration/terraform-provider/terraform-provider.mdx
+++ b/docs/pages/configuration/terraform-provider/terraform-provider.mdx
@@ -8,10 +8,12 @@ tags:
  - infrastructure-as-code
  - conceptual
  - zero-trust
+page_type: conceptual
 ---
 
 The Teleport Terraform provider allows Teleport administrators to use Terraform to configure Teleport via
-dynamic resources.
+dynamic resources. This page describes the essential operations for using the
+Teleport Terraform provider.
 
 ## Get started
 

--- a/docs/pages/identity-governance/access-lists/jit-access-list.mdx
+++ b/docs/pages/identity-governance/access-lists/jit-access-list.mdx
@@ -9,9 +9,8 @@ tags:
  - privileged-access
  - access-requests
 enterprise: Identity Governance
+page_type: how-to
 ---
-
-{/* lint disable page-structure remark-lint */}
 
 The **Just-in-Time Access Guide** creates an Access List whose members are required
 to request access to a defined set of resources, rather than being granted that
@@ -21,11 +20,13 @@ review and approve or deny it. Once approved, the member receives temporary
 access bounded by the request's TTL, capped by the member's remaining Teleport
 session.
 
-This guide will help you:
+In this guide, you will:
 
 - Decide when a Just-in-Time Access List is the right fit
 - Create one using the guided flow
 - Verify the request-and-approval experience as a member
+
+{/* lint ignore page-structure remark-lint */}
 
 ## When to use this flow
 

--- a/docs/pages/identity-governance/access-lists/reviewing-access-requests.mdx
+++ b/docs/pages/identity-governance/access-lists/reviewing-access-requests.mdx
@@ -7,9 +7,11 @@ tags:
  - privileged-access
  - access-requests
 enterprise: Identity Governance
+page_type: how-to
 ---
 
-In this guide we will walk through two Access List-related Access Request use-cases.
+In this guide, you will walk through two workflows for reviewing Access Requests
+for resources related to an Access List:
 
  - [Access Requests for resources granted by an Access List](#access-requests-for-resources-granted-by-an-access-list)
  - [Access Requests for resources requested by an Access List member](#access-requests-for-resources-requested-by-an-access-list-member)

--- a/docs/pages/identity-governance/access-requests/access-request-configuration.mdx
+++ b/docs/pages/identity-governance/access-requests/access-request-configuration.mdx
@@ -5,13 +5,14 @@ sidebar_position: 6
 description: Describes the options available for configuring just-in-time access to roles and resources in your Teleport cluster.
 tags:
  - access-requests
- - how-to
+ - conceptual
  - identity-governance
  - privileged-access
 enterprise: Identity Governance
+page_type: conceptual
 ---
 
-This guide explains the considerations you should make when configuring Teleport
+This guide describes the considerations you should make when configuring Teleport
 Access Requests, which enable a Teleport user to obtain elevated permissions by
 getting approval from one or more users in the same Teleport cluster.
 

--- a/docs/pages/identity-governance/access-requests/plugins/discord.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/discord.mdx
@@ -8,12 +8,13 @@ tags:
  - identity-governance
  - privileged-access
 enterprise: Identity Governance
+page_type: how-to
 ---
 
 import BotLogo from "/static/avatar_logo.png";
 import AppIcon from "@version/docs/img/sso/onelogin/teleport.png";
 
-This guide will explain how to set up Discord to receive Access Request messages
+In this guide, you will set up Discord to receive Access Request messages
 from Teleport. Teleport's Discord integration notifies individuals and channels of
 Access Requests. Users can then approve and deny Access Requests from within
 Discord, making it easier to implement security best practices without

--- a/docs/pages/identity-governance/access-requests/plugins/email.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/email.mdx
@@ -8,13 +8,14 @@ tags:
  - identity-governance
  - privileged-access
 enterprise: Identity Governance
+page_type: how-to
 ---
 
-This guide will explain how to set up Teleport to send Just-in-Time Access
-Request notifications to users via email. Since all organizations use email for
-at least some of their communications, Teleport's email plugin makes it
-straightforward to integrate Access Requests into your existing workflows,
-letting you implement security best practices without compromising productivity.
+In this guide, you will set up Teleport to send Just-in-Time Access Request
+notifications to users via email. Since all organizations use email for at least
+some of their communications, Teleport's email plugin makes it straightforward
+to integrate Access Requests into your existing workflows, letting you implement
+security best practices without compromising productivity.
 
 ![The email Access Request plugin](../../../../img/enterprise/plugins/email.png)
 

--- a/docs/pages/identity-governance/access-requests/plugins/msteams.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/msteams.mdx
@@ -8,10 +8,11 @@ tags:
  - identity-governance
  - privileged-access
 enterprise: Identity Governance
+page_type: how-to
 ---
 
-This guide will explain how to set up Microsoft Teams to receive Access Request messages
-from Teleport.
+In this guide, you will set up Microsoft Teams to receive Access Request
+messages from Teleport.
 
 <details>
 <summary>This integration is hosted on Teleport Enterprise (Cloud)</summary>

--- a/docs/pages/identity-governance/access-requests/plugins/servicenow.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/servicenow.mdx
@@ -8,9 +8,8 @@ tags:
  - identity-governance
  - privileged-access
 enterprise: Identity Governance
+page_type: how-to
 ---
-
-{/* lint disable page-structure remark-lint */}
 
 With Teleport's ServiceNow integration, engineers can access the infrastructure
 they need to resolve incidents quickly, without granting longstanding admin permissions
@@ -22,9 +21,9 @@ approve or deny the requests via Teleport. You can also configure the plugin to
 approve Access Requests automatically if the user making the request is in
 a specific on-call rotation.
 
-This guide will explain how to set up Teleport's Access Request plugin for
-ServiceNow.
+In this guide, you will set up Teleport's Access Request plugin for ServiceNow.
 
+{/* lint ignore page-structure remark-lint */}
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise"!)

--- a/docs/pages/identity-governance/access-requests/plugins/slack.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/slack.mdx
@@ -8,13 +8,14 @@ tags:
  - identity-governance
  - privileged-access
 enterprise: Identity Governance
+page_type: how-to
 ---
 
 import SlackVideoMp4 from "@version/docs/img/enterprise/plugins/slack/slack.mp4"
 import SlackVideoWebm from "@version/docs/img/enterprise/plugins/slack/slack.webm"
 
-This guide will explain how to set up Slack to receive Access Request messages
-from Teleport. 
+In this guide, you will set up Slack to receive Access Request messages from
+Teleport. 
 
 <details>
 <summary>This integration is hosted on Teleport Cloud</summary>

--- a/docs/pages/identity-governance/identity-governance.mdx
+++ b/docs/pages/identity-governance/identity-governance.mdx
@@ -5,6 +5,7 @@ template: "landing-page"
 tags:
  - identity-governance
 enterprise: Identity Governance
+page_type: landing
 ---
 
 import LandingHero from '@site/src/components/Pages/Landing/LandingHero';

--- a/docs/pages/identity-governance/idps/usage/saml-grafana.mdx
+++ b/docs/pages/identity-governance/idps/usage/saml-grafana.mdx
@@ -8,10 +8,11 @@ tags:
  - identity-governance
  - infrastructure-identity
 enterprise: Identity Governance
+page_type: how-to
 ---
 
 Grafana is an open source observability platform. Their enterprise version supports
-SAML authentication. This guide will help you configure Teleport as a SAML provider,
+SAML authentication. In this guide, you will configure Teleport as a SAML provider,
 and Grafana to accept the identities it provides.
 
 Note that Teleport can act as an identity provider to any SAML-compatible service,

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/advanced-options.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/advanced-options.mdx
@@ -6,11 +6,12 @@ tags:
  - conceptual
  - identity-governance
 enterprise: Identity Governance
+page_type: conceptual
 ---
 
 The Identity Center Integration can be configured to handle various advanced use
 cases that are not necessarily supported by the default installation flow. This
-guide describes these advanced options and use cases.
+page describes the options you can configure in advanced use cases.
 
 ## AWS authentication methods
 

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/using-aws-cli.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/using-aws-cli.mdx
@@ -8,10 +8,11 @@ tags:
   - privileged-access
   - aws
 enterprise: Identity Governance
+page_type: how-to
 ---
 
-This guide will show you how to configure the `aws` command-line tool to use
-access granted via Teleport and AWS Identity Center.
+In this guide, you will configure the `aws` command-line tool to use access
+granted via Teleport and AWS Identity Center.
 
 ## How it works
 

--- a/docs/pages/identity-governance/integrations/entra-id/advanced-options.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/advanced-options.mdx
@@ -8,9 +8,10 @@ tags:
  - azure
  - privileged-access
 enterprise: Identity Governance
+page_type:  conceptual
 ---
 
-This page lists advanced configuration options related to the
+This page describes the advanced configuration options related to the
 Teleport Entra ID integration. 
 
 ## Sync mode and intervals 

--- a/docs/pages/identity-governance/integrations/entra-id/setup/manual-installation.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/setup/manual-installation.mdx
@@ -8,9 +8,10 @@ tags:
  - azure
  - privileged-access
 enterprise: Identity Governance
+page_type: how-to
 ---
 
-This guide shows manual Entra ID configuration steps to set up Teleport Entra ID integration.
+In this guide, you will use the manual method to set up the Teleport Entra ID integration.
 See [getting started with Entra ID integration](../getting-started.mdx) for a guided Entra ID configuration. 
 
 The set up is based on the [OIDC IdP authentication method](../entra-id.mdx#choosing-the-microsoft-graph-api-authentication-method).

--- a/docs/pages/identity-governance/integrations/entra-id/setup/terraform.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/setup/terraform.mdx
@@ -10,11 +10,12 @@ tags:
  - azure
  - privileged-access
 enterprise: Identity Governance
+page_type: how-to
 ---
 
-This guide shows you how to integrate Teleport with Microsoft Entra ID using Terraform and `tctl`.
-You will configure the Entra ID side of the configuration using Terraform and install the Entra ID 
-plugin in Teleport using `tctl`. 
+In this guide, you will integrate Teleport with Microsoft Entra ID using
+Terraform and `tctl`. You will configure the Entra ID side of the configuration
+using Terraform and install the Entra ID plugin in Teleport using `tctl`. 
 
 For other supported configuration methods, see the following guides:
 - [Getting Started with the Entra ID Integration](../getting-started.mdx)

--- a/docs/pages/identity-governance/integrations/okta/reference.mdx
+++ b/docs/pages/identity-governance/integrations/okta/reference.mdx
@@ -4,13 +4,14 @@ sidebar_label: Reference
 description: Configuration and CLI reference documentation for Teleport Okta service.
 sidebar_position: 5
 tags:
- - reference
+ - conceptual
  - zero-trust
  - infrastructure-identity
 enterprise: Identity Governance
+page_type: conceptual
 ---
 
-This guide describes interfaces and options for configuring the Teleport Okta
+This page describes the interfaces and options for configuring the Teleport Okta
 Service, including Okta import rules, Okta assignments, and `tctl` commands. It
 also includes troubleshooting instructions.
 

--- a/docs/pages/identity-governance/integrations/okta/user-sync.mdx
+++ b/docs/pages/identity-governance/integrations/okta/user-sync.mdx
@@ -8,9 +8,8 @@ tags:
  - identity-governance
  - privileged-access
 enterprise: Identity Governance
+page_type: how-to
 ---
-
-{/* lint disable page-structure remark-lint */}
 
 Okta user sync imports Okta users as Teleport users via a continuous
 reconciliation loop. User sync works in tandem with the Teleport [SCIM
@@ -23,8 +22,10 @@ SCIM request does not reach your Teleport cluster, and works with Teleport
 clusters that are inaccessible over the public internet. User sync is required
 for application and group sync.
 
-This guide shows you how to set up Okta user sync with the guided Okta
-integration enrollment flow.
+In this guide, you will set up Okta user sync with the guided Okta integration
+enrollment flow.
+
+{/* lint ignore page-structure remark-lint */}
 
 ## Prerequisites
 

--- a/docs/pages/identity-governance/integrations/scim/sailpoint.mdx
+++ b/docs/pages/identity-governance/integrations/scim/sailpoint.mdx
@@ -7,11 +7,14 @@ tags:
 - identity-governance
 - privileged-access
 enterprise: Identity Governance
+page_type: how-to
 ---
 
 
 SailPoint provides a SCIM identity management connector that allows you to manage Teleport Access List membership
-through SailPoint IdentityNow or SailPoint IdentityIQ.
+through SailPoint IdentityNow or SailPoint IdentityIQ. In this guide, you will
+configure Teleport Access List membership via your SailPoint account, and
+optionally submit Access Requests via SailPoint.
 
 {/* lint ignore page-structure remark-lint */}
 

--- a/docs/pages/identity-security/usage/sql-editor.mdx
+++ b/docs/pages/identity-security/usage/sql-editor.mdx
@@ -7,13 +7,15 @@ tags:
  - access-risks
  - conceptual
 enterprise: Identity Security
+page_type: reference
 ---
 
 The Access Graph SQL Editor allows you to view nodes and edges within Access
 Graph that satisfy specific criteria. This helps you make sense of the access
 paths between identities and resources in your infrastructure so you can
 pinpoint and remediate access control issues. In the SQL Editor, you can enter
-SQL-like queries to explore selected nodes and edges within the graph.
+SQL-like queries to explore selected nodes and edges within the graph. This page
+lists example queries you can use in the SQL Editor.
 
 ![SQL Editor](../../../img/access-graph/sql-editor.png)
 

--- a/docs/pages/installation/self-hosted/deployments/aws-gslb-proxy-peering-ha-deployment.mdx
+++ b/docs/pages/installation/self-hosted/deployments/aws-gslb-proxy-peering-ha-deployment.mdx
@@ -6,10 +6,13 @@ tags:
  - conceptual
  - platform-wide
  - aws
+page_type: conceptual
 ---
 
-This deployment architecture features two important design decisions:
+This page describes how to deploy a Teleport cluster with Proxy Service instances
+spread across multiple AWS regions.
 
+This deployment architecture features two important design decisions:
 - Amazon Route 53 latency-based routing is used to ensure that users and agents connect to the closest available proxy.
 - Teleport's [Proxy Peering](../../../zero-trust-access/management/proxy-peering.mdx) is used to reduce the total number of tunnel connections in the Teleport cluster.
 

--- a/docs/pages/installation/self-hosted/deployments/aws-ha-autoscale-cluster-terraform.mdx
+++ b/docs/pages/installation/self-hosted/deployments/aws-ha-autoscale-cluster-terraform.mdx
@@ -7,9 +7,13 @@ tags:
  - how-to
  - platform-wide
  - aws
+page_type: how-to
 ---
 
-This guide is designed to accompany our [reference Terraform code](https://github.com/gravitational/teleport/tree/branch/v(=teleport.major_version=)/examples/aws/terraform/ha-autoscale-cluster#terraform-based-provisioning-example-amazon-single-ami)
+In this guide, you will deploy a high availability, self-hosted Teleport cluster
+on AWS using a Terraform module.  This guide is designed to accompany our
+[reference Terraform
+code](https://github.com/gravitational/teleport/tree/branch/v(=teleport.major_version=)/examples/aws/terraform/ha-autoscale-cluster#terraform-based-provisioning-example-amazon-single-ami)
 and describe how to manage the resulting Teleport deployment.
 
 (!docs/pages/includes/cloud/call-to-action.mdx!)

--- a/docs/pages/installation/self-hosted/deployments/multi-region-blueprint.mdx
+++ b/docs/pages/installation/self-hosted/deployments/multi-region-blueprint.mdx
@@ -6,10 +6,12 @@ tags:
  - conceptual
  - platform-wide
 enterprise: Support for multi-region deployments
+page_type: conceptual
 ---
 
-This page describes how to deploy a Teleport cluster in multiple regions to
-improve resiliency and sustain regional failure.
+This page describes the technical prerequisites you must follow for deploying a
+Teleport cluster in multiple regions to improve resiliency and sustain regional
+failure.
 
 <Admonition type="warning">
 Multi-region resilience drastically increases complexity and costs. Do not use

--- a/docs/pages/installation/self-hosted/helm-deployments/disaster-recovery.mdx
+++ b/docs/pages/installation/self-hosted/helm-deployments/disaster-recovery.mdx
@@ -6,11 +6,12 @@ tags:
  - how-to
  - platform-wide
  - aws
+page_type: how-to
 ---
 
 In case of an outage in your cloud provider region, you need to ensure that you
-can restore your Teleport cluster to working order. This guide provides an
-overview of a disaster recovery approach for self-hosted Teleport clusters.
+can restore your Teleport cluster to working order. In this guide, you will
+design a plan for disaster recovery in your self-hosted Teleport clusters.
 
 The guide assumes that your self-hosted Teleport cluster runs on Amazon Elastic
 Kubernetes Service and uses the `teleport-cluster` Helm chart. The

--- a/docs/pages/installation/self-hosted/helm-deployments/gcp.mdx
+++ b/docs/pages/installation/self-hosted/helm-deployments/gcp.mdx
@@ -6,9 +6,10 @@ tags:
  - how-to
  - platform-wide
  - google-cloud
+page_type: how-to
 ---
 
-In this guide, we'll go through how to set up a High Availability Teleport cluster with multiple replicas in Kubernetes
+In this guide, you will set up a High Availability Teleport cluster with multiple replicas in Kubernetes
 using Teleport Helm charts and Google Cloud Platform products (Firestore and Google Cloud Storage).
 
 If you are already running Teleport on another platform, you can use your

--- a/docs/pages/installation/self-hosted/helm-deployments/helm-deployments.mdx
+++ b/docs/pages/installation/self-hosted/helm-deployments/helm-deployments.mdx
@@ -6,6 +6,7 @@ description: How to install and configure Teleport in Kubernetes using Helm
 template: "no-toc"
 tags:
  - platform-wide
+page_type: landing
 ---
 
 The `teleport-cluster` Helm chart enables you deploy and manage a self-hosted,

--- a/docs/pages/installation/self-hosted/private-keys/aws-kms.mdx
+++ b/docs/pages/installation/self-hosted/private-keys/aws-kms.mdx
@@ -6,9 +6,10 @@ tags:
  - how-to
  - platform-wide
  - aws
+page_type: how-to
 ---
 
-This guide will show you how to set up your Teleport cluster to use the AWS Key
+In this guide, you will set up your Teleport cluster to use the AWS Key
 Management Service (KMS) to store and handle the CA private key material used to
 sign all certificates issued by your cluster.
 

--- a/docs/pages/installation/self-hosted/private-keys/private-keys.mdx
+++ b/docs/pages/installation/self-hosted/private-keys/private-keys.mdx
@@ -2,6 +2,7 @@
 title: Custom Private Key Management 
 sidebar_label: Key Management
 description: Provides information on managing Teleport private keys with a third-party service.
+page_type: landing
 ---
 
 You can configure a third-party service or hardware security module to manage

--- a/docs/pages/installation/self-hosted/self-signed-certs.mdx
+++ b/docs/pages/installation/self-hosted/self-signed-certs.mdx
@@ -5,9 +5,10 @@ description: This guide shows you how to run Teleport using self-signed certific
 tags:
  - conceptual
  - platform-wide
+page_type: conceptual
 ---
 
-This guide explains how to evaluate Teleport in a
+This guide describes the possibilities and limitations for evaluating Teleport in a
 non-production environment without having to configure TLS certificates.
 We will show you how to run Teleport with self-signed certificates and address
 problems caused by this configuration.

--- a/docs/pages/reference/access-controls/access-controls.mdx
+++ b/docs/pages/reference/access-controls/access-controls.mdx
@@ -5,6 +5,7 @@ description: Contains guides to configuring authentication and authorization in 
 tags:
  - zero-trust
  - privileged-access
+page_type: landing
 ---
 
 The Teleport access controls reference guides provide comprehensive information

--- a/docs/pages/reference/access-controls/saml-idp.mdx
+++ b/docs/pages/reference/access-controls/saml-idp.mdx
@@ -6,10 +6,12 @@ tags:
  - conceptual
  - identity-governance
  - infrastructure-identity
+page_type: conceptual
 ---
 
-This page provides details on the SAML identity provider available
-in Teleport.
+This page describes the key concepts for understanding the Teleport SAML
+identity provider, and provides reference information for designing service
+providers to work with the Teleport IdP. 
 
 ## What is the SAML identity provider?
 

--- a/docs/pages/reference/architecture/trustedclusters.mdx
+++ b/docs/pages/reference/architecture/trustedclusters.mdx
@@ -6,6 +6,7 @@ tags:
  - conceptual
  - zero-trust
  - infrastructure-identity
+page_type: conceptual
 ---
 
 <Admonition type="note">
@@ -14,7 +15,8 @@ Trusted clusters are only available for self-hosted Teleport clusters.
 
 Teleport can partition compute infrastructure into multiple clusters. A cluster
 is a group of Teleport connected resources. Each cluster
-manages a set of certificate authorities (CAs) for its users and resources.
+manages a set of certificate authorities (CAs) for its users and resources. This
+page describes the architecture of Teleport Trusted Clusters.
 
 Trusted Clusters allow the users of one cluster, the **root cluster**, to
 access resources registered with another cluster, the **leaf cluster**, while

--- a/docs/pages/reference/machine-workload-identity/workload-identity/configuration-resource-migration.mdx
+++ b/docs/pages/reference/machine-workload-identity/workload-identity/configuration-resource-migration.mdx
@@ -5,12 +5,16 @@ tags:
  - conceptual
  - mwi
  - infrastructure-identity
+page_type: conceptual
 ---
 
 The way that you configure Teleport Workload Identity is changing. If you are
 currently using Workload Identity, you will need to migrate to the new
 configuration experience by V19.0.0 when support for the old configuration
 will be removed.
+
+This page describes the benefits of the updated Workload Identity configuration
+model, and lists the changes it introduces to CLI commands and service types.
 
 ## Overview
 

--- a/docs/pages/zero-trust-access/api/api.mdx
+++ b/docs/pages/zero-trust-access/api/api.mdx
@@ -4,6 +4,7 @@ description: Guides to writing a client application for the Teleport gRPC API, w
 template: "no-toc"
 tags:
  - zero-trust
+page_type: landing
 ---
 
 The Teleport Auth Service provides a gRPC API for remotely interacting with your

--- a/docs/pages/zero-trust-access/api/rbac.mdx
+++ b/docs/pages/zero-trust-access/api/rbac.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - privileged-access
+page_type: how-to
 ---
 
 You can use the Teleport gRPC API to generate roles automatically based on an
@@ -22,13 +23,13 @@ This is especially useful for:
   unexpectedly gain or lose permissions if your teams reconfigure your external
   RBAC systems.
 
-## How it works
-
-In this guide, we will build a small demo application to show you how to
+In this guide, you will build a small demo application to show you how to
 generate Teleport roles using Teleport's API client library. 
 
-The application authenticates to the Teleport Auth Service gRPC API as well as
-your Kubernetes API server, and loads the role bindings and cluster role
+## How it works
+
+The demo application authenticates to the Teleport Auth Service gRPC API as well
+as your Kubernetes API server, and loads the role bindings and cluster role
 bindings from the Kubernetes API server. For each role binding and cluster role
 binding, the application generates a Teleport role using logic that maps the
 fields in the former to the fields in the latter.

--- a/docs/pages/zero-trust-access/authentication/ip-pinning.mdx
+++ b/docs/pages/zero-trust-access/authentication/ip-pinning.mdx
@@ -6,6 +6,7 @@ tags:
  - zero-trust
  - privileged-access
 enterprise: IP pinning
+page_type: conceptual
 ---
 
 <Admonition type="warning">
@@ -14,7 +15,9 @@ IP Pinning requires Teleport Enterprise.
 
 IP Pinning is a security feature that helps protect against unauthorized access by ensuring that
 Teleport users can only access resources from the IP address they used during the login process.
-This helps minimize the risk of compromised credentials being used from different locations.
+This helps minimize the risk of compromised credentials being used from
+different locations. This page describes the architecture of IP Pinning and
+provides configuration examples.
 
 ## How it works
 <Admonition type="note">

--- a/docs/pages/zero-trust-access/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/zero-trust-access/compliance-frameworks/fedramp.mdx
@@ -7,11 +7,12 @@ tags:
  - zero-trust
  - audit
 enterprise: FedRAMP compliance
+page_type: conceptual
 ---
 
 Teleport provides the foundation to meet FedRAMP requirements for the purposes of accessing infrastructure.
 This includes support for the [Federal Information Processing Standard FIPS 140](https://en.wikipedia.org/wiki/FIPS_140).
-This standard is the US government approved standard for cryptographic modules. This document explains how
+This standard is the US government approved standard for cryptographic modules. This page describes how
 Teleport FIPS mode works and how it can help your company to become FedRAMP authorized.
 
 ## FIPS Module

--- a/docs/pages/zero-trust-access/device-trust/enforcing-device-trust.mdx
+++ b/docs/pages/zero-trust-access/device-trust/enforcing-device-trust.mdx
@@ -8,7 +8,11 @@ tags:
  - zero-trust
  - resiliency
 enterprise: Device Trust
+page_type: conceptual
 ---
+
+This page describes the configuration options you can use to enforce Teleport
+Device Trust.
 
 <Admonition type="note" title="Supported Resources">
 Device Trust fully supports SSH, database and Kubernetes resources using

--- a/docs/pages/zero-trust-access/device-trust/intune-integration.mdx
+++ b/docs/pages/zero-trust-access/device-trust/intune-integration.mdx
@@ -10,10 +10,12 @@ tags:
  - azure
  - resiliency
 enterprise: Device Trust
+page_type: how-to
 ---
 
-The Device Trust Microsoft Intune integration lets you automatically sync your managed devices from
-Intune into Teleport. This guide explains how to set up the integration.
+The Device Trust Microsoft Intune integration lets you automatically sync your
+managed devices from Intune into Teleport. In this guide, you will set up the
+Microsoft Intune integration.
 
 ## How it works
 

--- a/docs/pages/zero-trust-access/management/diagnostics/logging.mdx
+++ b/docs/pages/zero-trust-access/management/diagnostics/logging.mdx
@@ -4,7 +4,11 @@ description: Explains how to configure the logger on a Teleport instance.
 tags:
  - conceptual
  - platform-wide
+page_type: conceptual
 ---
+
+This page describes the configuration fields you can use for adjusting the
+behavior of the logger on a running Teleport process.
 
 In the configuration file of a Teleport instance, you can configure the logger's behavior by defining the output
 destination, severity level, and output format.

--- a/docs/pages/zero-trust-access/management/security/ca-rotation.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-rotation.mdx
@@ -5,13 +5,14 @@ tags:
  - how-to
  - platform-wide
  - resiliency
+page_type: how-to
 ---
 
 Components of a Teleport cluster authenticate to one another using either X.509
 or SSH certificates. To issue certificates, Teleport maintains several
 certificate authorities. You can rotate Teleport CAs to prevent malicious actors
-from impersonating part of your Teleport cluster. This guide explains the CAs
-that Teleport maintains and how to rotate them.
+from impersonating part of your Teleport cluster. In this guide, you will choose
+a CA to rotate and perform a rotation.
 
 We recommend becoming familiar with the entire guide before following the steps,
 as you should be ready to roll back the CA rotation if it does not proceed as

--- a/docs/pages/zero-trust-access/management/security/client-timeout.mdx
+++ b/docs/pages/zero-trust-access/management/security/client-timeout.mdx
@@ -6,7 +6,11 @@ tags:
  - conceptual
  - zero-trust
  - privileged-access
+page_type: conceptual
 ---
+
+This page describes the options for configuring client idle timeout in your
+Teleport clusters.
 
 The `client_idle_timeout` in Teleport is a configurable setting that helps improve security by terminating inactive sessions after a specified period. It can be applied globally or per role, 
 allowing for flexibility based on your organization's security policies. The `client_idle_timeout` configuration ensures that SSH sessions, desktop sessions, kubectl exec or database 

--- a/docs/pages/zero-trust-access/management/security/restrict-privileges.mdx
+++ b/docs/pages/zero-trust-access/management/security/restrict-privileges.mdx
@@ -6,12 +6,15 @@ tags:
  - conceptual
  - zero-trust
  - privileged-access
+page_type: conceptual
 ---
 
 As an administrator, you need to make informed decisions about when and how to grant
 privileged access to the resources in your infrastructure, including the Teleport services
 that protect those resources. You also need to manage access to the cluster storage backend
-and determine whether to apply network-level restrictions.
+and determine whether to apply network-level restrictions. This page describes
+the precautions you must take to restrict access to resources by
+privileged accounts on Teleport-protected infrastructure.
 
 ## Labels and label expressions
 

--- a/docs/pages/zero-trust-access/rbac-get-started/labels.mdx
+++ b/docs/pages/zero-trust-access/rbac-get-started/labels.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 Teleport allows you to add arbitrary key-value pairs to applications, servers,
@@ -15,8 +16,8 @@ the following:
 - Filter the resources returned when running `tctl` and `tsh` commands.
 - Define roles that limit the resources Teleport users can access.
 
-This guide demonstrates how to add labels to enrolled server resources.
-However, you can follow similar steps to add labels to other types of resources.
+In this guide, you will add labels to enrolled server resources. You can follow
+similar steps to add labels to other types of resources.
 
 ## How it works
 

--- a/docs/pages/zero-trust-access/rbac-get-started/role-demo.mdx
+++ b/docs/pages/zero-trust-access/rbac-get-started/role-demo.mdx
@@ -6,6 +6,7 @@ tags:
  - privileged-access
  - how-to
  - zero-trust
+page_type: how-to
 ---
 
 Teleport Role-Based Access Control (RBAC) is a system for managing who can
@@ -13,9 +14,9 @@ access what within your infrastructure. Instead of assigning permissions
 directly to users, you create roles that define sets of permissions, then assign
 those roles to users.
 
-This guide helps you understand RBAC in Teleport by walking you through the
-process of applying labels to resources, setting up minimal roles, and accessing
-resources available to a particular role.
+In this guide, you will walk through the process of applying labels to
+resources, setting up minimal roles, and accessing resources available to a
+particular role.
 
 ## How it works
 


### PR DESCRIPTION
Backports #68950

We are standardizing docs guides to add a `page_type` frontmatter field, with values for how-to guides, references, etc. We can then use this field to apply linting rules that ensure each guide type follows type-specific docs site conventions. The first convention is that each docs page must have an outcome statement, the structure of which depends on the guide's type. Human and AI agent readers can determine from the outcome statement whether to continue reading the guide or not.

This change assigns the `page_type` frontmatter field to 49 guides. Where an outcome statement is missing or incorrect, this change adds or corrects it. Changes include:
- Landing pages: added `page_type: landing`, with no outcome statement required
- Guides with entirely new outcome statements
- Already-compliant guides: intro paragraphs already matched the required pattern, so this adds `page_type` only
- Editing outcome statements to use compliant phrasing: a sentence in the introduction mostly matched the expected pattern, but required a small phrasing change