### PR TITLE
[v18] Move access list related files

### DIFF
--- a/api/types/accesslist/preset.go
+++ b/api/types/accesslist/preset.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package accesslist
+
+import (
+	"strings"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+const (
+	// AccessListPresetLabel marks an access list resource (with a label) that
+	// is was created using a preset. The label value identifies the preset.
+	AccessListPresetLabel = types.TeleportInternalLabelPrefix + "access-list-preset"
+
+	// AccessListPresetRolesLabel is set on a preset-created access list and
+	// holds a comma-separated list of the role names created for the list.
+	// This is used to track which roles should be deleted when they're removed
+	// from the configuration.
+	AccessListPresetRolesLabel = types.TeleportInternalLabelPrefix + "access-list-preset-roles"
+)
+
+// PresetRoleNames returns the role names recorded on this access list's
+// label or nil if the label is unset.
+func (a *AccessList) PresetRoleNames() []string {
+	rolesStr, ok := a.GetAllLabels()[AccessListPresetRolesLabel]
+	if !ok || rolesStr == "" {
+		return nil
+	}
+	return strings.Split(rolesStr, ",")
+}
+
+// IsPreset returns true if the access list was created via a preset, identified
+// by the preset label the backend sets at create time.
+func (a *AccessList) IsPreset() bool {
+	return a.GetAllLabels()[AccessListPresetLabel] != ""
+}

--- a/lib/accesslists/preset/builder.go
+++ b/lib/accesslists/preset/builder.go
@@ -1,0 +1,480 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package preset
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+)
+
+const (
+	// AccessListPresetRoleInfix is the infix used in the names of roles
+	// auto-created for a preset-backed access list. The full role name
+	// format is "{prefix}-{AccessListPresetRoleInfix}-{accessListUUID}".
+	AccessListPresetRoleInfix = "acl-preset"
+
+	// RoleRequesterPrefix describes a role that allows to make access requests
+	// to some resources.
+	RoleRequesterPrefix = "requester"
+	// RoleReviewerPrefix describes a role that allows reviewing access requests.
+	RoleReviewerPrefix = "reviewer"
+
+	// RoleDesc indicating that resources was created by internal flow and should not be manage by users.
+	RoleDesc = "Role created by Teleport. Do not edit."
+)
+
+// PresetType defines the type of access list preset.
+type PresetType string
+
+// LongTermPresetType grants members access roles directly.
+// Owners receive the reviewer role.
+const LongTermPresetType PresetType = "long-term"
+
+// ShortTermPresetType grants members a requester role for on-demand access.
+// Members receive the requester role to request access, owners receive the reviewer role.
+const ShortTermPresetType PresetType = "short-term"
+
+// AccessListRolesBuilderConfig contains the configuration for building
+// access list and roles. The config is validated during builder creation.
+type AccessListRolesBuilderConfig struct {
+	// PresetName is the name of the preset access list.
+	PresetName string
+	// AccessListSpec is the access list specification to build from.
+	AccessListSpec *accesslist.AccessList
+	// PresetType determines the grant behavior (long-term or short-term).
+	PresetType PresetType
+	// AccessRoles are the roles that will be granted based on the preset type.
+	AccessRoles []types.Role
+
+	// SkipRoleDescriptions when true, omits adding role descriptions
+	SkipRoleDescriptions bool
+	// ManagedByIAC when not empty, adds a label to roles and access list that
+	// the resource is being managed by a IAC tool (e.g. terraform)
+	ManagedByIAC string
+}
+
+// CheckAndSetDefaults validates the config and sets default values.
+// It ensures that the access list name, preset name, and preset type are valid.
+//
+// Note: this function is not called by NewPresetAccessListRolesBuilderForTerraform.
+func (c *AccessListRolesBuilderConfig) CheckAndSetDefaults() error {
+	if c.AccessListSpec == nil {
+		return trace.BadParameter("access list is required")
+	}
+	if err := c.validateAccessListName(); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := c.validatePreset(); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// validatePreset validates the preset type in the config.
+func (c *AccessListRolesBuilderConfig) validatePreset() error {
+	if c.PresetType != LongTermPresetType && c.PresetType != ShortTermPresetType {
+		return trace.BadParameter("preset type is required")
+	}
+	return nil
+}
+
+// validateAccessListName validates the access list name in the config
+// and ensures name matches if both are provided.
+func (c *AccessListRolesBuilderConfig) validateAccessListName() error {
+	aclName := c.AccessListSpec.GetName()
+	if aclName == "" {
+		return trace.BadParameter("access list name is required")
+	}
+	if c.PresetName != "" && c.PresetName != aclName {
+		return trace.BadParameter("access list name is invalid")
+	}
+	return nil
+}
+
+// AccessListRolesBuilder is a standalone builder that constructs access lists
+// and roles in-memory WITHOUT any backend operations.
+// It is completely decoupled from persistence and can be used independently.
+type AccessListRolesBuilder struct {
+	cfg AccessListRolesBuilderConfig
+}
+
+type RolesBuildResult struct {
+	// ReviewerRole allows reviewing access requests for the access roles.
+	ReviewerRole types.Role
+	// RequesterRole allows requesting access to the access roles.
+	RequesterRole types.Role
+	// AccessRoles are the roles that grant actual permissions (e.g., app access, database access).
+	AccessRoles []types.Role
+}
+
+type AccessListBuildResult struct {
+	// AccessList is the constructed access list with grants configured based on preset type.
+	AccessList *accesslist.AccessList
+	// RolesToBeDeleted are role names that should be deleted (removed from previous access list configuration).
+	RolesToBeDeleted []string
+}
+
+// BuildResult contains all constructed objects (access list + roles).
+type BuildResult struct {
+	RolesBuildResult
+	AccessListBuildResult
+}
+
+// NewPresetAccessListRolesBuilder creates a new standalone builder
+// that constructs access list and roles in-memory (no backend operations).
+// The config is validated during builder creation.
+func NewPresetAccessListRolesBuilder(cfg AccessListRolesBuilderConfig) (*AccessListRolesBuilder, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &AccessListRolesBuilder{cfg: cfg}, nil
+}
+
+// NewPresetAccessListRolesBuilderForTerraform is similar to NewPresetAccessListRolesBuilder but allows for more
+// flexible validation rules to accommodate Terraform's workflow where certain resources (e.g access list) may
+// not exist yet.
+//
+// Note: this constructor does not call CheckAndSetDefaults.
+func NewPresetAccessListRolesBuilderForTerraform(cfg AccessListRolesBuilderConfig) (*AccessListRolesBuilder, error) {
+	if err := cfg.validatePreset(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if cfg.AccessListSpec != nil {
+		if err := cfg.validateAccessListName(); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	cfg.ManagedByIAC = types.IACToolTerraform
+	cfg.SkipRoleDescriptions = true
+	return &AccessListRolesBuilder{cfg: cfg}, nil
+}
+
+func collectRolesName(roles []types.Role) []string {
+	out := make([]string, 0, len(roles))
+	for _, role := range roles {
+		out = append(out, role.GetName())
+	}
+	return out
+}
+
+// Build constructs the access list and all roles in-memory.
+// It creates the access list, reviewer role, requester role, and access roles
+// based on the preset type. Returns BuildResult with all constructed objects.
+func (b *AccessListRolesBuilder) Build() (*BuildResult, error) {
+	builtRoles, err := b.BuildRoles()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	builtAccessList, err := b.BuildAccessList(builtRoles)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &BuildResult{
+		RolesBuildResult:      *builtRoles,
+		AccessListBuildResult: *builtAccessList,
+	}, nil
+}
+
+// BuildRoles only constructs the roles: access roles, reviewer role, and requester role.
+// Reviewer and requester roles are still constructed even if access roles are not provided.
+func (b *AccessListRolesBuilder) BuildRoles() (*RolesBuildResult, error) {
+	accessRoles, err := b.constructAccessRoles()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	accessRoleNames := collectRolesName(accessRoles)
+	reviewerRole, err := b.constructReviewerRole(accessRoleNames)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	requesterRole, err := b.constructRequesterRole(accessRoleNames)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &RolesBuildResult{
+		AccessRoles:   accessRoles,
+		ReviewerRole:  reviewerRole,
+		RequesterRole: requesterRole,
+	}, nil
+}
+
+// BuildAccessList only constructs the access list with the appropriate grants based on preset type.
+// If builtRoles is nil, access list grants will be empty.
+func (b *AccessListRolesBuilder) BuildAccessList(builtRoles *RolesBuildResult) (*AccessListBuildResult, error) {
+	if b.cfg.AccessListSpec == nil {
+		return nil, trace.BadParameter("access list spec is required to build access list")
+	}
+
+	reviewerRoleName := ""
+	requesterRoleName := ""
+	accessRoleNames := []string{}
+	if builtRoles != nil {
+		if builtRoles.ReviewerRole != nil {
+			reviewerRoleName = builtRoles.ReviewerRole.GetName()
+		}
+		if builtRoles.RequesterRole != nil {
+			requesterRoleName = builtRoles.RequesterRole.GetName()
+		}
+		accessRoleNames = collectRolesName(builtRoles.AccessRoles)
+	}
+
+	accessList, err := b.constructAccessList(reviewerRoleName, requesterRoleName, accessRoleNames)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Compute roles to be deleted by comparing old and new access lists
+	rolesToBeDeleted := b.computeRolesToBeDeleted(b.cfg.AccessListSpec, accessList)
+
+	return &AccessListBuildResult{
+		AccessList:       accessList,
+		RolesToBeDeleted: rolesToBeDeleted,
+	}, nil
+}
+
+// constructAccessRoles constructs the access roles from the provided role specs
+//
+// Note: This function modifies the input roles in cfg.AccessRoles
+// (renames them and adds labels). Callers should not reuse these role objects.
+func (b *AccessListRolesBuilder) constructAccessRoles() ([]types.Role, error) {
+	roles := make([]types.Role, 0, len(b.cfg.AccessRoles))
+	for _, roleSpec := range b.cfg.AccessRoles {
+		role := b.prepareAccessRole(roleSpec)
+		roles = append(roles, role)
+	}
+	return roles, nil
+}
+
+// prepareAccessRole clones and configures a role for the preset access list.
+// It ensures the role has the correct preset name (without double-suffixing),
+// labels, and description.
+func (b *AccessListRolesBuilder) prepareAccessRole(roleSpec types.Role) types.Role {
+	role := roleSpec.Clone()
+
+	labels := map[string]string{
+		accesslist.AccessListPresetLabel: b.cfg.PresetName,
+	}
+	if b.cfg.ManagedByIAC != "" {
+		labels[types.IACToolLabel] = b.cfg.ManagedByIAC
+	}
+
+	if _, ok := role.GetLabel(accesslist.AccessListPresetLabel); !ok {
+		role.SetName(b.generateRoleName(roleSpec.GetName()))
+		role.SetStaticLabels(labels)
+	} else if b.cfg.ManagedByIAC != "" {
+		existing := role.GetStaticLabels()
+		if existing == nil {
+			existing = map[string]string{}
+		}
+		existing[types.IACToolLabel] = b.cfg.ManagedByIAC
+		role.SetStaticLabels(existing)
+	}
+	if !b.cfg.SkipRoleDescriptions {
+		setRoleDesc(role, RoleDesc)
+	}
+
+	return role
+}
+
+// constructReviewerRole constructs the reviewer role that allows reviewing access requests
+func (b *AccessListRolesBuilder) constructReviewerRole(accessRoleNames []string) (types.Role, error) {
+	spec := types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			ReviewRequests: &types.AccessReviewConditions{
+				PreviewAsRoles: accessRoleNames,
+				Roles:          accessRoleNames,
+			},
+		},
+	}
+	labels := map[string]string{
+		accesslist.AccessListPresetLabel: b.cfg.PresetName,
+	}
+	if b.cfg.ManagedByIAC != "" {
+		labels[types.IACToolLabel] = b.cfg.ManagedByIAC
+	}
+
+	role, err := types.NewRole(b.generateRoleName(RoleReviewerPrefix), spec)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !b.cfg.SkipRoleDescriptions {
+		setRoleDesc(role, RoleDesc)
+	}
+	role.SetStaticLabels(labels)
+	return role, nil
+}
+
+// constructRequesterRole constructs the requester role that allows requesting access
+func (b *AccessListRolesBuilder) constructRequesterRole(accessRoleNames []string) (types.Role, error) {
+	roleName := b.generateRoleName(RoleRequesterPrefix)
+
+	spec := types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Request: &types.AccessRequestConditions{
+				SearchAsRoles: accessRoleNames,
+			},
+		},
+	}
+	labels := map[string]string{
+		accesslist.AccessListPresetLabel: b.cfg.PresetName,
+	}
+	if b.cfg.ManagedByIAC != "" {
+		labels[types.IACToolLabel] = b.cfg.ManagedByIAC
+	}
+
+	role, err := types.NewRole(roleName, spec)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if !b.cfg.SkipRoleDescriptions {
+		setRoleDesc(role, RoleDesc)
+	}
+	role.SetStaticLabels(labels)
+	return role, nil
+}
+
+func setRoleDesc(r types.Role, desc string) {
+	meta := r.GetMetadata()
+	meta.Description = desc
+	r.SetMetadata(meta)
+}
+
+// constructAccessList constructs the access list with the appropriate grants based on preset type
+func (b *AccessListRolesBuilder) constructAccessList(reviewerRoleName, requesterRoleName string, accessRoleNames []string) (*accesslist.AccessList, error) {
+	labels := map[string]string{
+		accesslist.AccessListPresetLabel: string(b.cfg.PresetType),
+	}
+
+	presetRoles := []string{}
+	if reviewerRoleName != "" {
+		presetRoles = append(presetRoles, reviewerRoleName)
+	}
+	if requesterRoleName != "" {
+		presetRoles = append(presetRoles, requesterRoleName)
+	}
+	presetRoles = append(presetRoles, accessRoleNames...)
+
+	if len(presetRoles) > 0 {
+		labels[accesslist.AccessListPresetRolesLabel] = strings.Join(presetRoles, ",")
+	}
+
+	if b.cfg.ManagedByIAC != "" {
+		labels[types.IACToolLabel] = b.cfg.ManagedByIAC
+	}
+
+	al, err := accesslist.NewAccessList(b.cfg.AccessListSpec.Metadata, b.cfg.AccessListSpec.Spec)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	al.Metadata.Name = b.cfg.PresetName
+	al.Metadata.Labels = labels
+
+	// Apply grants based on preset type
+	switch b.cfg.PresetType {
+	case LongTermPresetType:
+		memberGrants := accesslist.Grants{}
+		ownerGrants := accesslist.Grants{}
+
+		// long-term: Members get access roles directly, owners get reviewer role
+		if len(accessRoleNames) > 0 {
+			memberGrants = accesslist.Grants{
+				Roles: accessRoleNames,
+			}
+		}
+		if reviewerRoleName != "" {
+			ownerGrants = accesslist.Grants{
+				Roles: []string{reviewerRoleName},
+			}
+		}
+
+		al.Spec.Grants = memberGrants
+		al.Spec.OwnerGrants = ownerGrants
+
+	case ShortTermPresetType:
+		memberGrants := accesslist.Grants{}
+		ownerGrants := accesslist.Grants{}
+
+		// Short-term: Members get requester role, owners get reviewer role
+		if requesterRoleName != "" {
+			memberGrants = accesslist.Grants{
+				Roles: []string{requesterRoleName},
+			}
+		}
+		if reviewerRoleName != "" {
+			ownerGrants = accesslist.Grants{
+				Roles: []string{reviewerRoleName},
+			}
+		}
+
+		al.Spec.Grants = memberGrants
+		al.Spec.OwnerGrants = ownerGrants
+
+	default:
+		return nil, trace.BadParameter("unknown preset type %v", b.cfg.PresetType)
+	}
+
+	return al, nil
+}
+
+// computeRolesToBeDeleted identifies roles that were in the previous access list
+// but are not in the new configuration and should be deleted.
+func (b *AccessListRolesBuilder) computeRolesToBeDeleted(old, new *accesslist.AccessList) []string {
+	return b.findRolesToDelete(old.PresetRoleNames(), new.PresetRoleNames())
+}
+
+// findRolesToDelete compares old roles with new roles and returns
+// a list of roles that should be deleted.
+func (b *AccessListRolesBuilder) findRolesToDelete(existingRoles, newRoleNames []string) []string {
+	newRoleSet := make(map[string]struct{}, len(newRoleNames))
+	for _, name := range newRoleNames {
+		newRoleSet[name] = struct{}{}
+	}
+
+	var rolesToDelete []string
+	for _, existingRole := range existingRoles {
+		if _, exists := newRoleSet[existingRole]; !exists {
+			rolesToDelete = append(rolesToDelete, existingRole)
+		}
+	}
+	return rolesToDelete
+}
+
+func (b *AccessListRolesBuilder) generateRoleName(prefix string) string {
+	return RoleName(prefix, b.cfg.PresetName)
+}
+
+// GetAllRoles returns access, access request, reviewer roles.
+func (r BuildResult) GetAllRoles() []types.Role {
+	return append([]types.Role{r.ReviewerRole, r.RequesterRole}, r.AccessRoles...)
+}
+
+// RoleName generates a role name for preset access list roles.
+// The format is: {prefix}-acl-preset-{accessListName}.
+// For example: "reviewer-acl-preset-my-access-list".
+func RoleName(prefix, accessListName string) string {
+	return fmt.Sprintf("%s-%s-%s", prefix, AccessListPresetRoleInfix, accessListName)
+}

--- a/lib/accesslists/preset/builder_test.go
+++ b/lib/accesslists/preset/builder_test.go
@@ -1,0 +1,580 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package preset_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/lib/accesslists/preset"
+)
+
+func TestPresetAccessListRolesBuilder(t *testing.T) {
+	type check func(t *testing.T, result *preset.BuildResult)
+
+	accessListName := "test-access-list"
+	appRoleName := "app-access-acl-preset-test-access-list"
+	dbRoleName := "db-access-acl-preset-test-access-list"
+	reviewerRoleName := "reviewer-acl-preset-test-access-list"
+	requesterRoleName := "requester-acl-preset-test-access-list"
+
+	appRole, err := types.NewRole("app-access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: types.Labels{"env": []string{"production"}},
+		},
+	})
+	require.NoError(t, err)
+
+	dbRole, err := types.NewRole("db-access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			DatabaseLabels: types.Labels{"env": []string{"production"}},
+		},
+	})
+	require.NoError(t, err)
+
+	al, err := accesslist.NewAccessList(
+		header.Metadata{Name: accessListName},
+		accesslist.Spec{Title: "Test Access List"},
+	)
+	require.NoError(t, err)
+
+	checkAccessListMetadata := func(presetTypeLabel string) check {
+		return func(t *testing.T, result *preset.BuildResult) {
+			require.Equal(t, accessListName, result.AccessList.GetName())
+			require.Equal(t, presetTypeLabel, result.AccessList.GetMetadata().Labels[accesslist.AccessListPresetLabel])
+			require.Equal(t, "Test Access List", result.AccessList.Spec.Title)
+		}
+	}
+
+	checkAccessListGrants := func(memberRoles, ownerRoles []string) check {
+		return func(t *testing.T, result *preset.BuildResult) {
+			require.ElementsMatch(t, memberRoles, result.AccessList.Spec.Grants.Roles)
+			require.Equal(t, ownerRoles, result.AccessList.Spec.OwnerGrants.Roles)
+		}
+	}
+
+	checkAccessRole := func(index int, name string, appLabels, dbLabels types.Labels) check {
+		return func(t *testing.T, result *preset.BuildResult) {
+			require.Greater(t, len(result.AccessRoles), index, "role index out of bounds")
+
+			role := result.AccessRoles[index]
+			require.Equal(t, name, role.GetName())
+			require.Equal(t, accessListName, role.GetMetadata().Labels[accesslist.AccessListPresetLabel])
+			require.Equal(t, preset.RoleDesc, role.GetMetadata().Description)
+
+			// Check app labels if specified
+			if appLabels != nil {
+				require.Equal(t, appLabels, role.GetAppLabels(types.Allow))
+			}
+
+			// Check database labels if specified
+			if dbLabels != nil {
+				require.Equal(t, dbLabels, role.GetDatabaseLabels(types.Allow))
+			}
+		}
+	}
+
+	checkReviewerRoleCanReviewRoles := func(roles []string) check {
+		return func(t *testing.T, result *preset.BuildResult) {
+			require.Equal(t, reviewerRoleName, result.ReviewerRole.GetName())
+			require.Equal(t, accessListName, result.ReviewerRole.GetMetadata().Labels[accesslist.AccessListPresetLabel])
+			require.Equal(t, preset.RoleDesc, result.ReviewerRole.GetMetadata().Description)
+
+			reviewCond := result.ReviewerRole.GetAccessReviewConditions(types.Allow)
+			require.ElementsMatch(t, roles, reviewCond.Roles)
+			require.ElementsMatch(t, roles, reviewCond.PreviewAsRoles)
+		}
+	}
+
+	checkRequesterRoleCanSearchAsRoles := func(roles []string) check {
+		return func(t *testing.T, result *preset.BuildResult) {
+			require.Equal(t, requesterRoleName, result.RequesterRole.GetName())
+			require.Equal(t, accessListName, result.RequesterRole.GetMetadata().Labels[accesslist.AccessListPresetLabel])
+			require.Equal(t, preset.RoleDesc, result.RequesterRole.GetMetadata().Description)
+
+			requestCond := result.RequesterRole.GetAccessRequestConditions(types.Allow)
+			require.ElementsMatch(t, roles, requestCond.SearchAsRoles)
+		}
+	}
+
+	checkNoRolesToDelete := func() check {
+		return func(t *testing.T, result *preset.BuildResult) {
+			require.Nil(t, result.RolesToBeDeleted)
+		}
+	}
+
+	tests := []struct {
+		name       string
+		presetType preset.PresetType
+		checks     []check
+	}{
+		{
+			name:       "LongTerm",
+			presetType: preset.LongTermPresetType,
+			checks: []check{
+				checkAccessListMetadata("long-term"),
+				checkAccessListGrants(
+					[]string{appRoleName, dbRoleName}, // Members get access roles directly
+					[]string{reviewerRoleName},        // Owners get reviewer role
+				),
+				checkAccessRole(0, appRoleName, types.Labels{"env": []string{"production"}}, nil),
+				checkAccessRole(1, dbRoleName, nil, types.Labels{"env": []string{"production"}}),
+				checkReviewerRoleCanReviewRoles([]string{appRoleName, dbRoleName}),
+				checkRequesterRoleCanSearchAsRoles([]string{appRoleName, dbRoleName}),
+				checkNoRolesToDelete(),
+			},
+		},
+		{
+			name:       "ShortTerm",
+			presetType: preset.ShortTermPresetType,
+			checks: []check{
+				checkAccessListMetadata("short-term"),
+				checkAccessListGrants(
+					[]string{requesterRoleName}, // Members get requester role (to request access)
+					[]string{reviewerRoleName},  // Owners get reviewer role
+				),
+				checkAccessRole(0, appRoleName, types.Labels{"env": []string{"production"}}, nil),
+				checkAccessRole(1, dbRoleName, nil, types.Labels{"env": []string{"production"}}),
+				checkReviewerRoleCanReviewRoles([]string{appRoleName, dbRoleName}),
+				checkRequesterRoleCanSearchAsRoles([]string{appRoleName, dbRoleName}),
+				checkNoRolesToDelete(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder, err := preset.NewPresetAccessListRolesBuilder(preset.AccessListRolesBuilderConfig{
+				PresetName:     accessListName,
+				PresetType:     tt.presetType,
+				AccessRoles:    []types.Role{appRole, dbRole},
+				AccessListSpec: al,
+			})
+			require.NoError(t, err)
+
+			result, err := builder.Build()
+			require.NoError(t, err)
+
+			for _, check := range tt.checks {
+				check(t, result)
+			}
+		})
+	}
+
+	t.Run("nil builtRoles leaves grants empty", func(t *testing.T) {
+		builder, err := preset.NewPresetAccessListRolesBuilder(preset.AccessListRolesBuilderConfig{
+			PresetName:     accessListName,
+			PresetType:     preset.LongTermPresetType,
+			AccessRoles:    []types.Role{appRole},
+			AccessListSpec: al,
+		})
+		require.NoError(t, err)
+
+		result, err := builder.BuildAccessList(nil)
+		require.NoError(t, err)
+
+		require.Empty(t, result.AccessList.Spec.Grants.Roles)
+		require.Empty(t, result.AccessList.Spec.OwnerGrants.Roles)
+		require.NotContains(t, result.AccessList.GetStaticLabels(), accesslist.AccessListPresetRolesLabel)
+	})
+
+	t.Run("nil access list spec returns error", func(t *testing.T) {
+		_, err := preset.NewPresetAccessListRolesBuilder(preset.AccessListRolesBuilderConfig{
+			PresetName: accessListName,
+			PresetType: preset.LongTermPresetType,
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("preset name mismatch", func(t *testing.T) {
+		otherAccessList, err := accesslist.NewAccessList(
+			header.Metadata{Name: "different-name"},
+			accesslist.Spec{Title: "Other Access List"},
+		)
+		require.NoError(t, err)
+		_, err = preset.NewPresetAccessListRolesBuilder(preset.AccessListRolesBuilderConfig{
+			PresetName:     accessListName,
+			PresetType:     preset.LongTermPresetType,
+			AccessListSpec: otherAccessList,
+		})
+		require.ErrorContains(t, err, "access list name is invalid")
+	})
+}
+
+func TestPresetAccessListRolesBuilder_RolesToBeDeleted(t *testing.T) {
+	accessListName := "test-access-list"
+
+	existingAL, err := accesslist.NewAccessList(
+		header.Metadata{
+			Name: accessListName,
+		},
+		accesslist.Spec{
+			Title:       "Test Access List",
+			Description: "Test description",
+			Grants: accesslist.Grants{
+				Roles: []string{
+					"old-role-1-acl-preset-test-access-list",
+					"old-role-2-acl-preset-test-access-list",
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	newRole, err := types.NewRole("new-role", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: types.Labels{"env": []string{"production"}},
+		},
+	})
+	require.NoError(t, err)
+
+	builder, err := preset.NewPresetAccessListRolesBuilder(preset.AccessListRolesBuilderConfig{
+		PresetName:     accessListName,
+		PresetType:     preset.LongTermPresetType,
+		AccessRoles:    []types.Role{newRole},
+		AccessListSpec: existingAL,
+	})
+	require.NoError(t, err)
+
+	result, err := builder.Build()
+	require.NoError(t, err)
+
+	require.Len(t, result.AccessRoles, 1)
+	require.Equal(t, "new-role-acl-preset-test-access-list", result.AccessRoles[0].GetName())
+}
+
+func TestPresetAccessListRolesBuilderForTerraform(t *testing.T) {
+	accessListName := "test-access-list"
+	accessRole1Name := "accessRole1-acl-preset-test-access-list"
+	accessRole2Name := "accessRole2-acl-preset-test-access-list"
+	reviewerRoleName := "reviewer-acl-preset-test-access-list"
+	requesterRoleName := "requester-acl-preset-test-access-list"
+
+	rolesLabelValue := strings.Join([]string{reviewerRoleName, requesterRoleName, accessRole1Name, accessRole2Name}, ",")
+
+	accessList, err := accesslist.NewAccessList(
+		header.Metadata{Name: accessListName},
+		accesslist.Spec{Title: "Test Access List"},
+	)
+	require.NoError(t, err)
+
+	accessRole1, err := types.NewRole("accessRole1", types.RoleSpecV6{})
+	require.NoError(t, err)
+
+	accessRole2, err := types.NewRole("accessRole2", types.RoleSpecV6{})
+	require.NoError(t, err)
+
+	checkCommonLabelsAndRoles := func(result *preset.BuildResult) {
+		require.Equal(t, []string{reviewerRoleName}, result.AccessList.Spec.OwnerGrants.Roles)
+
+		staticLabels := result.AccessList.GetStaticLabels()
+		require.Len(t, result.AccessRoles, 2)
+		require.Equal(t, types.IACToolTerraform, staticLabels[types.IACToolLabel])
+		require.Equal(t, rolesLabelValue, staticLabels[accesslist.AccessListPresetRolesLabel])
+
+		require.Len(t, result.GetAllRoles(), 4) // 2 access roles + reviewer + requester
+		for _, role := range result.GetAllRoles() {
+			labels := role.GetStaticLabels()
+			require.Equal(t, types.IACToolTerraform, labels[types.IACToolLabel], "role %s missing terraform label", role.GetName())
+			require.Equal(t, accessListName, labels[accesslist.AccessListPresetLabel], "role %s missing access list preset label", role.GetName())
+			require.Empty(t, role.GetMetadata().Description, "role %s should have no description", role.GetName())
+		}
+	}
+
+	tests := []struct {
+		name        string
+		presetType  preset.PresetType
+		accessList  *accesslist.AccessList
+		accessRoles []types.Role
+		validate    func(t *testing.T, result *preset.BuildResult)
+	}{
+		{
+			name:        "long term build",
+			presetType:  preset.LongTermPresetType,
+			accessList:  accessList,
+			accessRoles: []types.Role{accessRole1, accessRole2},
+			validate: func(t *testing.T, result *preset.BuildResult) {
+				checkCommonLabelsAndRoles(result)
+				require.Equal(t, string(preset.LongTermPresetType), result.AccessList.GetMetadata().Labels[accesslist.AccessListPresetLabel])
+				require.ElementsMatch(t, []string{accessRole1Name, accessRole2Name}, result.AccessList.Spec.Grants.Roles)
+			},
+		},
+		{
+			name:        "short term build",
+			presetType:  preset.ShortTermPresetType,
+			accessList:  accessList,
+			accessRoles: []types.Role{accessRole1, accessRole2},
+			validate: func(t *testing.T, result *preset.BuildResult) {
+				checkCommonLabelsAndRoles(result)
+				require.Equal(t, string(preset.ShortTermPresetType), result.AccessList.GetMetadata().Labels[accesslist.AccessListPresetLabel])
+				require.ElementsMatch(t, []string{requesterRoleName}, result.AccessList.Spec.Grants.Roles)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			builder, err := preset.NewPresetAccessListRolesBuilderForTerraform(preset.AccessListRolesBuilderConfig{
+				PresetName:     accessListName,
+				PresetType:     tc.presetType,
+				AccessRoles:    tc.accessRoles,
+				AccessListSpec: tc.accessList,
+			})
+			require.NoError(t, err)
+
+			result, err := builder.Build()
+			require.NoError(t, err)
+
+			tc.validate(t, result)
+		})
+	}
+
+	t.Run("nil builtRoles leaves grants empty", func(t *testing.T) {
+		builder, err := preset.NewPresetAccessListRolesBuilderForTerraform(preset.AccessListRolesBuilderConfig{
+			PresetName:     accessListName,
+			PresetType:     preset.ShortTermPresetType,
+			AccessListSpec: accessList,
+		})
+		require.NoError(t, err)
+
+		builtRoles, err := builder.BuildRoles()
+		require.NoError(t, err)
+		require.Empty(t, builtRoles.AccessRoles)
+
+		builtAl, err := builder.BuildAccessList(nil)
+		require.NoError(t, err)
+		require.NotNil(t, builtAl.AccessList)
+		require.Empty(t, builtAl.AccessList.Spec.Grants.Roles)
+		require.Empty(t, builtAl.AccessList.Spec.OwnerGrants.Roles)
+		require.NotContains(t, builtAl.AccessList.GetStaticLabels(), accesslist.AccessListPresetRolesLabel)
+	})
+
+	t.Run("invalid preset type", func(t *testing.T) {
+		_, err := preset.NewPresetAccessListRolesBuilderForTerraform(preset.AccessListRolesBuilderConfig{
+			PresetName:     accessListName,
+			PresetType:     "unknown",
+			AccessListSpec: accessList,
+		})
+		require.ErrorContains(t, err, "preset type is required")
+	})
+
+	t.Run("preset name mismatch", func(t *testing.T) {
+		otherAccessList, err := accesslist.NewAccessList(
+			header.Metadata{Name: "different-name"},
+			accesslist.Spec{Title: "Other Access List"},
+		)
+		require.NoError(t, err)
+		_, err = preset.NewPresetAccessListRolesBuilderForTerraform(preset.AccessListRolesBuilderConfig{
+			PresetName:     accessListName,
+			PresetType:     preset.LongTermPresetType,
+			AccessListSpec: otherAccessList,
+		})
+		require.ErrorContains(t, err, "access list name is invalid")
+	})
+}
+
+func TestPresetAccessListRolesBuilder_Added(t *testing.T) {
+	accessListName := "test-access-list"
+
+	al, err := accesslist.NewAccessList(
+		header.Metadata{Name: accessListName},
+		accesslist.Spec{Title: "Test Access List"},
+	)
+	require.NoError(t, err)
+
+	devRole, err := types.NewRole("dev", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: types.Labels{"env": []string{"dev"}},
+		},
+	})
+	require.NoError(t, err)
+
+	prodRole, err := types.NewRole("prod", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: types.Labels{"env": []string{"prod"}},
+		},
+	})
+	require.NoError(t, err)
+
+	builder, err := preset.NewPresetAccessListRolesBuilder(preset.AccessListRolesBuilderConfig{
+		PresetName:     accessListName,
+		PresetType:     preset.LongTermPresetType,
+		AccessRoles:    []types.Role{devRole},
+		AccessListSpec: al,
+	})
+	require.NoError(t, err)
+
+	result, err := builder.Build()
+	require.NoError(t, err)
+
+	require.NotNil(t, result.AccessList)
+	require.Empty(t, result.RolesToBeDeleted)
+	require.Len(t, result.AccessRoles, 1)
+	require.Equal(t, result.AccessRoles[0].GetName(), preset.RoleName(devRole.GetName(), accessListName))
+
+	builder, err = preset.NewPresetAccessListRolesBuilder(preset.AccessListRolesBuilderConfig{
+		PresetName:     accessListName,
+		PresetType:     preset.ShortTermPresetType,
+		AccessRoles:    []types.Role{result.AccessRoles[0], prodRole},
+		AccessListSpec: result.AccessList,
+	})
+	require.NoError(t, err)
+
+	result, err = builder.Build()
+	require.NoError(t, err)
+
+	require.NotNil(t, result.AccessList)
+	require.Empty(t, result.RolesToBeDeleted)
+	require.Len(t, result.AccessRoles, 2)
+	require.Equal(t, result.AccessRoles[0].GetName(), preset.RoleName(devRole.GetName(), accessListName))
+	require.Equal(t, result.AccessRoles[1].GetName(), preset.RoleName(prodRole.GetName(), accessListName))
+
+	builder, err = preset.NewPresetAccessListRolesBuilder(preset.AccessListRolesBuilderConfig{
+		PresetName:     accessListName,
+		PresetType:     preset.ShortTermPresetType,
+		AccessRoles:    []types.Role{result.AccessRoles[0]},
+		AccessListSpec: result.AccessList,
+	})
+	require.NoError(t, err)
+
+	result, err = builder.Build()
+	require.NoError(t, err)
+
+	require.NotNil(t, result.AccessList)
+	require.Len(t, result.RolesToBeDeleted, 1)
+	require.Equal(t, result.AccessRoles[0].GetName(), preset.RoleName(devRole.GetName(), accessListName))
+}
+
+func TestPresetAccessListRolesBuilder_PreservesExistingRoleLabels(t *testing.T) {
+	accessListName := "test-access-list"
+
+	al, err := accesslist.NewAccessList(
+		header.Metadata{Name: accessListName},
+		accesslist.Spec{Title: "Test Access List"},
+	)
+	require.NoError(t, err)
+
+	existingRole, err := types.NewRole(
+		preset.RoleName("app-access", accessListName),
+		types.RoleSpecV6{
+			Allow: types.RoleConditions{
+				AppLabels: types.Labels{"env": []string{"production"}},
+			},
+		},
+	)
+	require.NoError(t, err)
+	existingRole.SetStaticLabels(map[string]string{
+		accesslist.AccessListPresetLabel: accessListName,
+		"owner":                          "team-foo",
+		"env":                            "dev",
+	})
+
+	t.Run("non-IAC update preserves all existing labels", func(t *testing.T) {
+		builder, err := preset.NewPresetAccessListRolesBuilder(preset.AccessListRolesBuilderConfig{
+			PresetName:     accessListName,
+			PresetType:     preset.LongTermPresetType,
+			AccessRoles:    []types.Role{existingRole.Clone()},
+			AccessListSpec: al,
+		})
+		require.NoError(t, err)
+
+		result, err := builder.Build()
+		require.NoError(t, err)
+
+		require.Len(t, result.AccessRoles, 1)
+		labels := result.AccessRoles[0].GetStaticLabels()
+		require.Equal(t, accessListName, labels[accesslist.AccessListPresetLabel])
+		require.Equal(t, "team-foo", labels["owner"])
+		require.Equal(t, "dev", labels["env"])
+	})
+
+	t.Run("IAC update preserves unrelated labels and adds IAC label", func(t *testing.T) {
+		builder, err := preset.NewPresetAccessListRolesBuilderForTerraform(preset.AccessListRolesBuilderConfig{
+			PresetName:     accessListName,
+			PresetType:     preset.LongTermPresetType,
+			AccessRoles:    []types.Role{existingRole.Clone()},
+			AccessListSpec: al,
+		})
+		require.NoError(t, err)
+
+		result, err := builder.Build()
+		require.NoError(t, err)
+
+		require.Len(t, result.AccessRoles, 1)
+		labels := result.AccessRoles[0].GetStaticLabels()
+		require.Equal(t, accessListName, labels[accesslist.AccessListPresetLabel])
+		require.Equal(t, types.IACToolTerraform, labels[types.IACToolLabel])
+		require.Equal(t, "team-foo", labels["owner"])
+		require.Equal(t, "dev", labels["env"])
+	})
+}
+
+func TestNewPresetAccessListRolesBuilder_Validation(t *testing.T) {
+	accessListName := "test-access-list"
+
+	al, err := accesslist.NewAccessList(
+		header.Metadata{Name: accessListName},
+		accesslist.Spec{Title: "Test Access List"},
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		cfg     preset.AccessListRolesBuilderConfig
+		wantErr string
+	}{
+		{
+			name: "nil access list spec",
+			cfg: preset.AccessListRolesBuilderConfig{
+				PresetName:     accessListName,
+				PresetType:     preset.LongTermPresetType,
+				AccessListSpec: nil,
+			},
+			wantErr: "access list is required",
+		},
+		{
+			name: "invalid preset type",
+			cfg: preset.AccessListRolesBuilderConfig{
+				PresetName:     accessListName,
+				PresetType:     "unknown",
+				AccessListSpec: al,
+			},
+			wantErr: "preset type is required",
+		},
+		{
+			name: "preset name mismatch",
+			cfg: preset.AccessListRolesBuilderConfig{
+				PresetName:     "different-name",
+				PresetType:     preset.LongTermPresetType,
+				AccessListSpec: al,
+			},
+			wantErr: "access list name is invalid",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := preset.NewPresetAccessListRolesBuilder(tc.cfg)
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}

--- a/tool/tctl/common/accesslist/command.go
+++ b/tool/tctl/common/accesslist/command.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package common
+package accesslist
 
 import (
 	"context"
@@ -48,8 +48,8 @@ import (
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 )
 
-// ACLCommand implements the `tctl acl` family of commands.
-type ACLCommand struct {
+// Command implements the `tctl acl` family of commands.
+type Command struct {
 	format string
 
 	ls            *kingpin.CmdClause
@@ -86,8 +86,8 @@ const (
 	memberKindList = "list"
 )
 
-// Initialize allows ACLCommand to plug itself into the CLI parser
-func (c *ACLCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, _ *servicecfg.Config) {
+// Initialize allows Command to plug itself into the CLI parser
+func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, _ *servicecfg.Config) {
 	acl := app.Command("acl", "Manage Access Lists.").Alias("access-lists")
 
 	c.ls = acl.Command("ls", "List cluster Access Lists.")
@@ -132,7 +132,7 @@ func (c *ACLCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFl
 }
 
 // TryRun takes the CLI command as an argument (like "acl ls") and executes it.
-func (c *ACLCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
+func (c *Command) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
 	var commandFunc func(ctx context.Context, client *authclient.Client) error
 	switch cmd {
 	case c.ls.FullCommand():
@@ -163,7 +163,7 @@ func (c *ACLCommand) TryRun(ctx context.Context, cmd string, clientFunc commoncl
 }
 
 // List will list access lists visible to the user.
-func (c *ACLCommand) List(ctx context.Context, client *authclient.Client) error {
+func (c *Command) List(ctx context.Context, client *authclient.Client) error {
 	var accessLists []*accesslist.AccessList
 	var err error
 
@@ -214,12 +214,12 @@ func parseACLQualifiedName(name string) (scopes.QualifiedName, error) {
 	return scopes.QualifiedName{Name: name}, nil
 }
 
-func (c *ACLCommand) accessListQualifiedName() (scopes.QualifiedName, error) {
+func (c *Command) accessListQualifiedName() (scopes.QualifiedName, error) {
 	sqn, err := parseACLQualifiedName(c.accessListName)
 	return sqn, trace.Wrap(err, "validating access list name as a scope-qualified name")
 }
 
-func (c *ACLCommand) memberQualifiedName() (scopes.QualifiedName, error) {
+func (c *Command) memberQualifiedName() (scopes.QualifiedName, error) {
 	sqn, err := parseACLQualifiedName(c.memberName)
 	return sqn, trace.Wrap(err, "validating member name as a scope-qualified name")
 }
@@ -237,7 +237,7 @@ func splitACLQualifiedNames(names string) ([]scopes.QualifiedName, error) {
 }
 
 // Get will display information about an access list visible to the user.
-func (c *ACLCommand) Get(ctx context.Context, client *authclient.Client) error {
+func (c *Command) Get(ctx context.Context, client *authclient.Client) error {
 	aclName, err := c.accessListQualifiedName()
 	if err != nil {
 		return trace.Wrap(err)
@@ -254,7 +254,7 @@ func (c *ACLCommand) Get(ctx context.Context, client *authclient.Client) error {
 }
 
 // UsersAdd will add a user to an access list.
-func (c *ACLCommand) UsersAdd(ctx context.Context, client *authclient.Client) error {
+func (c *Command) UsersAdd(ctx context.Context, client *authclient.Client) error {
 	var expires time.Time
 	if c.expires != "" {
 		var err error
@@ -314,7 +314,7 @@ func (c *ACLCommand) UsersAdd(ctx context.Context, client *authclient.Client) er
 }
 
 // UsersRemove will remove a user to an access list.
-func (c *ACLCommand) UsersRemove(ctx context.Context, client *authclient.Client) error {
+func (c *Command) UsersRemove(ctx context.Context, client *authclient.Client) error {
 	aclName, err := c.accessListQualifiedName()
 	if err != nil {
 		return trace.Wrap(err)
@@ -339,7 +339,7 @@ func (c *ACLCommand) UsersRemove(ctx context.Context, client *authclient.Client)
 }
 
 // UsersList will list the users in an access list.
-func (c *ACLCommand) UsersList(ctx context.Context, client *authclient.Client) error {
+func (c *Command) UsersList(ctx context.Context, client *authclient.Client) error {
 	aclName, err := c.accessListQualifiedName()
 	if err != nil {
 		return trace.Wrap(err)
@@ -392,7 +392,7 @@ func (c *ACLCommand) UsersList(ctx context.Context, client *authclient.Client) e
 	}
 }
 
-func (c *ACLCommand) ReviewsCreate(ctx context.Context, client *authclient.Client) error {
+func (c *Command) ReviewsCreate(ctx context.Context, client *authclient.Client) error {
 	review, err := c.makeReview()
 	if err != nil {
 		return trace.Wrap(err)
@@ -408,7 +408,7 @@ func (c *ACLCommand) ReviewsCreate(ctx context.Context, client *authclient.Clien
 	return nil
 }
 
-func (c *ACLCommand) makeReview() (*accesslist.Review, error) {
+func (c *Command) makeReview() (*accesslist.Review, error) {
 	aclName, err := c.accessListQualifiedName()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -443,7 +443,7 @@ func (c *ACLCommand) makeReview() (*accesslist.Review, error) {
 		aclName.Scope)
 }
 
-func (c *ACLCommand) ReviewsList(ctx context.Context, client *authclient.Client) error {
+func (c *Command) ReviewsList(ctx context.Context, client *authclient.Client) error {
 	aclName, err := c.accessListQualifiedName()
 	if err != nil {
 		return trace.Wrap(err)
@@ -466,7 +466,7 @@ func (c *ACLCommand) ReviewsList(ctx context.Context, client *authclient.Client)
 	return trace.Wrap(c.displayAccessListReviews(reviews))
 }
 
-func (c *ACLCommand) displayAccessListReviews(reviews []*accesslist.Review) error {
+func (c *Command) displayAccessListReviews(reviews []*accesslist.Review) error {
 	switch c.format {
 	case teleport.YAML:
 		return trace.Wrap(utils.WriteYAML(c.Stdout, reviews))
@@ -478,7 +478,7 @@ func (c *ACLCommand) displayAccessListReviews(reviews []*accesslist.Review) erro
 	return trace.BadParameter("invalid format %q", c.format)
 }
 
-func (c *ACLCommand) displayAccessListReviewsText(reviews []*accesslist.Review) error {
+func (c *Command) displayAccessListReviewsText(reviews []*accesslist.Review) error {
 	table := asciitable.MakeTable([]string{"ID", "Reviewer", "Review Date", "Removed Members", "Notes"})
 	for _, review := range reviews {
 		table.AddRow([]string{
@@ -493,7 +493,7 @@ func (c *ACLCommand) displayAccessListReviewsText(reviews []*accesslist.Review) 
 	return trace.Wrap(err)
 }
 
-func (c *ACLCommand) displayAccessLists(accessLists ...*accesslist.AccessList) error {
+func (c *Command) displayAccessLists(accessLists ...*accesslist.AccessList) error {
 	switch c.format {
 	case teleport.YAML:
 		return trace.Wrap(utils.WriteYAML(c.Stdout, accessLists))
@@ -507,7 +507,7 @@ func (c *ACLCommand) displayAccessLists(accessLists ...*accesslist.AccessList) e
 	return trace.BadParameter("invalid format %q", c.format)
 }
 
-func (c *ACLCommand) displayAccessListsText(accessLists ...*accesslist.AccessList) error {
+func (c *Command) displayAccessListsText(accessLists ...*accesslist.AccessList) error {
 	table := asciitable.MakeTable([]string{"ID", "Title", "Next Audit", "Granted Roles", "Granted Traits"})
 	for _, accessList := range accessLists {
 		grantedRoles := append([]string(nil), accessList.GetGrants().Roles...)

--- a/tool/tctl/common/acl_command.go
+++ b/tool/tctl/common/acl_command.go
@@ -1,0 +1,533 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/accesslists"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/utils"
+	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
+	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
+)
+
+// ACLCommand implements the `tctl acl` family of commands.
+type ACLCommand struct {
+	format string
+
+	ls            *kingpin.CmdClause
+	get           *kingpin.CmdClause
+	usersAdd      *kingpin.CmdClause
+	usersRemove   *kingpin.CmdClause
+	usersList     *kingpin.CmdClause
+	reviewsCreate *kingpin.CmdClause
+	reviewsList   *kingpin.CmdClause
+
+	// Used for managing a particular access list.
+	accessListName string
+	// Used to add an access list to another one
+	memberKind string
+
+	// Used for managing membership to an access list.
+	memberName string
+	expires    string
+	reason     string
+
+	// Used for creating reviews.
+	notes         string
+	removeMembers string
+
+	// Some extra options that control output.
+	reviewOnly bool // lists only access lists due for review
+
+	// Stdout allows to switch the standard output source. Used in tests.
+	Stdout io.Writer
+}
+
+const (
+	memberKindUser = "user"
+	memberKindList = "list"
+)
+
+// Initialize allows ACLCommand to plug itself into the CLI parser
+func (c *ACLCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, _ *servicecfg.Config) {
+	acl := app.Command("acl", "Manage Access Lists.").Alias("access-lists")
+
+	c.ls = acl.Command("ls", "List cluster Access Lists.")
+	c.ls.Flag("format", "Output format.").Default(teleport.YAML).EnumVar(&c.format, teleport.YAML, teleport.JSON, teleport.Text)
+	c.ls.Flag("review-only", "List only access lists that are due for review within the next 2 weeks or past due").BoolVar(&c.reviewOnly)
+
+	c.get = acl.Command("get", "Get detailed information for an Access List.")
+	c.get.Arg("access-list-name", "The Access List name.").Required().StringVar(&c.accessListName)
+	c.get.Flag("format", "Output format.").Default(teleport.YAML).EnumVar(&c.format, teleport.YAML, teleport.JSON, teleport.Text)
+
+	users := acl.Command("users", "Manage user membership to Access Lists.")
+
+	c.usersAdd = users.Command("add", "Add a user to an Access List.")
+	c.usersAdd.Flag("kind", "Access list member kind.").Default(memberKindUser).EnumVar(&c.memberKind, memberKindUser, memberKindList)
+	c.usersAdd.Arg("access-list-name", "The Access List name.").Required().StringVar(&c.accessListName)
+	c.usersAdd.Arg("user", "The member to add to the Access List.").Required().StringVar(&c.memberName)
+	c.usersAdd.Arg("expires", "When the user's access expires (must be in RFC3339). Defaults to the expiration time of the Access List.").StringVar(&c.expires)
+	c.usersAdd.Arg("reason", "The reason the user has been added to the Access List. Defaults to empty.").StringVar(&c.reason)
+
+	c.usersRemove = users.Command("rm", "Remove a user from an Access List.")
+	c.usersRemove.Arg("access-list-name", "The Access List name.").Required().StringVar(&c.accessListName)
+	c.usersRemove.Arg("user", "The member to remove from the Access List.").Required().StringVar(&c.memberName)
+
+	c.usersList = users.Command("ls", "List users that are members of an Access List.")
+	c.usersList.Arg("access-list-name", "The Access List name.").Required().StringVar(&c.accessListName)
+	c.usersList.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.JSON, teleport.Text)
+
+	reviews := acl.Command("reviews", "Manage access list reviews.")
+
+	c.reviewsCreate = reviews.Command("create", "Submit a new review for a given access list.")
+	c.reviewsCreate.Arg("access-list-name", "The access list name to submit review for.").Required().StringVar(&c.accessListName)
+	c.reviewsCreate.Flag("notes", "Optional review notes.").StringVar(&c.notes)
+	c.reviewsCreate.Flag("remove-members", "Comma-separated list of members to remove as part of this review.").StringVar(&c.removeMembers)
+
+	c.reviewsList = reviews.Command("ls", "List past audit history for a given access list.")
+	c.reviewsList.Arg("access-list-name", "The access list name to fetch review history for.").Required().StringVar(&c.accessListName)
+	c.reviewsList.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.YAML, teleport.JSON, teleport.Text)
+
+	if c.Stdout == nil {
+		c.Stdout = os.Stdout
+	}
+}
+
+// TryRun takes the CLI command as an argument (like "acl ls") and executes it.
+func (c *ACLCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
+	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	switch cmd {
+	case c.ls.FullCommand():
+		commandFunc = c.List
+	case c.get.FullCommand():
+		commandFunc = c.Get
+	case c.usersAdd.FullCommand():
+		commandFunc = c.UsersAdd
+	case c.usersRemove.FullCommand():
+		commandFunc = c.UsersRemove
+	case c.usersList.FullCommand():
+		commandFunc = c.UsersList
+	case c.reviewsCreate.FullCommand():
+		commandFunc = c.ReviewsCreate
+	case c.reviewsList.FullCommand():
+		commandFunc = c.ReviewsList
+	default:
+		return false, nil
+	}
+	client, closeFn, err := clientFunc(ctx)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	err = commandFunc(ctx, client)
+	closeFn(ctx)
+
+	return true, trace.Wrap(err)
+}
+
+// List will list access lists visible to the user.
+func (c *ACLCommand) List(ctx context.Context, client *authclient.Client) error {
+	var accessLists []*accesslist.AccessList
+	var err error
+
+	if c.reviewOnly {
+		accessLists, err = client.AccessListClient().GetAccessListsToReview(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	} else {
+		accessLists, err = stream.Collect(clientutils.Resources(ctx,
+			func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessList, string, error) {
+				return client.AccessListClient().ListAccessListsV2(ctx, accesslistv1.ListAccessListsV2Request_builder{
+					PageSize:  int32(pageSize),
+					PageToken: pageToken,
+					ScopeFilter: scopesv1.Filter_builder{
+						Mode: scopesv1.Mode_MODE_ALL,
+					}.Build(),
+				}.Build())
+			}))
+		if trace.IsNotImplemented(err) {
+			accessLists, err = stream.Collect(clientutils.Resources(ctx, client.AccessListClient().ListAccessLists))
+		}
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	if len(accessLists) == 0 && c.format == teleport.Text {
+		fmt.Fprintln(c.Stdout, "no access lists")
+		return nil
+	}
+
+	return trace.Wrap(c.displayAccessLists(accessLists...))
+}
+
+func parseACLQualifiedName(name string) (scopes.QualifiedName, error) {
+	// For backward compatibility, an argument is considered a scope-qualified
+	// name only if it:
+	// 1. parses as a qualified name (contains :: somewhere in the middle)
+	// 2. contains /
+	// otherwise it is considered a plain unscoped name. This allows access
+	// lists with names like 'example::list' to continue to be referenced in
+	// CLI commands as unscoped lists, only params like '/example::list' will
+	// be considered scoped.
+	if sqn, err := scopes.ParseQualifiedName(name); err == nil && strings.Contains(name, "/") {
+		return sqn, sqn.StrongValidate()
+	}
+	return scopes.QualifiedName{Name: name}, nil
+}
+
+func (c *ACLCommand) accessListQualifiedName() (scopes.QualifiedName, error) {
+	sqn, err := parseACLQualifiedName(c.accessListName)
+	return sqn, trace.Wrap(err, "validating access list name as a scope-qualified name")
+}
+
+func (c *ACLCommand) memberQualifiedName() (scopes.QualifiedName, error) {
+	sqn, err := parseACLQualifiedName(c.memberName)
+	return sqn, trace.Wrap(err, "validating member name as a scope-qualified name")
+}
+
+func splitACLQualifiedNames(names string) ([]scopes.QualifiedName, error) {
+	var sqns []scopes.QualifiedName
+	for _, name := range utils.SplitIdentifiers(names) {
+		sqn, err := parseACLQualifiedName(strings.TrimSpace(name))
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		sqns = append(sqns, sqn)
+	}
+	return sqns, nil
+}
+
+// Get will display information about an access list visible to the user.
+func (c *ACLCommand) Get(ctx context.Context, client *authclient.Client) error {
+	aclName, err := c.accessListQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	accessList, err := client.AccessListClient().GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Scope: aclName.Scope,
+		Name:  aclName.Name,
+	}.Build())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return trace.Wrap(c.displayAccessLists(accessList))
+}
+
+// UsersAdd will add a user to an access list.
+func (c *ACLCommand) UsersAdd(ctx context.Context, client *authclient.Client) error {
+	var expires time.Time
+	if c.expires != "" {
+		var err error
+		expires, err = time.Parse(time.RFC3339, c.expires)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	aclName, err := c.accessListQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	memberName, err := c.memberQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var membershipKind string
+	switch c.memberKind {
+	case memberKindList:
+		membershipKind = accesslist.MembershipKindList
+		if memberName.Scope != "" {
+			membershipKind = accesslist.MembershipKindScopedList
+		}
+	case "", memberKindUser:
+		if memberName.Scope != "" {
+			return trace.BadParameter("user members cannot be scoped, got %q", c.memberName)
+		}
+		membershipKind = accesslist.MembershipKindUser
+	}
+
+	member, err := accesslist.NewAccessListMemberWithScope(header.Metadata{
+		Name: memberName.String(),
+	}, accesslist.AccessListMemberSpec{
+		AccessList: aclName.String(),
+		Name:       memberName.String(),
+		Reason:     c.reason,
+		Expires:    expires,
+
+		// The following fields will be updated in the backend, so their values here don't matter.
+		Joined:         time.Now(),
+		AddedBy:        "dummy",
+		MembershipKind: membershipKind,
+	}, aclName.Scope)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = client.AccessListClient().UpsertAccessListMember(ctx, member)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Fprintf(c.Stdout, "successfully added member %s to access list %s", memberName.String(), aclName.String())
+
+	return nil
+}
+
+// UsersRemove will remove a user to an access list.
+func (c *ACLCommand) UsersRemove(ctx context.Context, client *authclient.Client) error {
+	aclName, err := c.accessListQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	memberName, err := c.memberQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = client.AccessListClient().DeleteAccessListMemberV2(ctx, accesslistv1.DeleteAccessListMemberRequest_builder{
+		AccessListScope: aclName.Scope,
+		AccessList:      aclName.Name,
+		MemberScope:     memberName.Scope,
+		MemberName:      memberName.Name,
+	}.Build())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Fprintf(c.Stdout, "successfully removed member %s from access list %s\n", memberName.String(), aclName.String())
+
+	return nil
+}
+
+// UsersList will list the users in an access list.
+func (c *ACLCommand) UsersList(ctx context.Context, client *authclient.Client) error {
+	aclName, err := c.accessListQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	var (
+		allMembers []*accesslist.AccessListMember
+		nextToken  string
+		listErr    error
+		members    []*accesslist.AccessListMember
+	)
+
+	for {
+		members, nextToken, listErr = client.AccessListClient().ListAccessListMembersV2(ctx, accesslistv1.ListAccessListMembersRequest_builder{
+			PageToken:       nextToken,
+			AccessListScope: aclName.Scope,
+			AccessList:      aclName.Name,
+		}.Build())
+		if listErr != nil {
+			return trace.Wrap(listErr)
+		}
+		allMembers = append(allMembers, members...)
+		if nextToken == "" {
+			break
+		}
+	}
+
+	switch c.format {
+	case teleport.JSON:
+		return trace.Wrap(utils.WriteJSONArray(c.Stdout, allMembers))
+	case teleport.Text:
+		if len(allMembers) == 0 {
+			fmt.Fprintf(c.Stdout, "No members found for access list %s.\nYou may not have access to see the members for this list.\n", aclName.String())
+			return nil
+		}
+		fmt.Fprintf(c.Stdout, "Members of %s:\n", aclName.String())
+		for _, member := range allMembers {
+			memberName, err := accesslists.MemberScopeQualifiedName(member)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if member.IsList() {
+				fmt.Fprintf(c.Stdout, "- (Access List) %s \n", memberName.String())
+			} else {
+				fmt.Fprintf(c.Stdout, "- %s\n", memberName.String())
+			}
+		}
+		return nil
+	default:
+		return trace.BadParameter("unsupported output format %q", c.format)
+	}
+}
+
+func (c *ACLCommand) ReviewsCreate(ctx context.Context, client *authclient.Client) error {
+	review, err := c.makeReview()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, nextAuditDate, err := client.AccessListClient().CreateAccessListReview(ctx, review)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Fprintf(c.Stdout, "Successfully submitted review for access list %s\n", c.accessListName)
+	fmt.Fprintf(c.Stdout, "Next audit date: %s\n", nextAuditDate.Format(time.DateOnly))
+	return nil
+}
+
+func (c *ACLCommand) makeReview() (*accesslist.Review, error) {
+	aclName, err := c.accessListQualifiedName()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var removeMembers []string
+	var removeScopedMembers []string
+	removedMemberNames, err := splitACLQualifiedNames(c.removeMembers)
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing removed member name")
+	}
+	for _, member := range removedMemberNames {
+		if member.Scope == "" {
+			removeMembers = append(removeMembers, member.String())
+		} else {
+			removeScopedMembers = append(removeScopedMembers, member.String())
+		}
+	}
+	return accesslist.NewReviewWithScope(
+		header.Metadata{
+			Name: uuid.NewString(),
+		},
+		accesslist.ReviewSpec{
+			AccessList: aclName.String(),
+			Reviewers:  []string{"placeholder"}, // Reviewers is set server-side but API requires it.
+			ReviewDate: time.Now(),              // Review date will be set server-side as well.
+			Notes:      c.notes,
+			Changes: accesslist.ReviewChanges{
+				RemovedMembers:       removeMembers,
+				ScopedRemovedMembers: removeScopedMembers,
+			},
+		},
+		aclName.Scope)
+}
+
+func (c *ACLCommand) ReviewsList(ctx context.Context, client *authclient.Client) error {
+	aclName, err := c.accessListQualifiedName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	reviews, err := stream.Collect(clientutils.Resources(ctx,
+		func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.Review, string, error) {
+			return client.AccessListClient().ListAccessListReviewsV2(ctx, accesslistv1.ListAccessListReviewsRequest_builder{
+				PageSize:        int32(pageSize),
+				NextToken:       pageToken,
+				AccessListScope: aclName.Scope,
+				AccessList:      aclName.Name,
+			}.Build())
+		}))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	sort.Slice(reviews, func(i, j int) bool {
+		return reviews[i].Spec.ReviewDate.After(reviews[j].Spec.ReviewDate)
+	})
+	return trace.Wrap(c.displayAccessListReviews(reviews))
+}
+
+func (c *ACLCommand) displayAccessListReviews(reviews []*accesslist.Review) error {
+	switch c.format {
+	case teleport.YAML:
+		return trace.Wrap(utils.WriteYAML(c.Stdout, reviews))
+	case teleport.JSON:
+		return trace.Wrap(utils.WriteJSONArray(c.Stdout, reviews))
+	case teleport.Text:
+		return trace.Wrap(c.displayAccessListReviewsText(reviews))
+	}
+	return trace.BadParameter("invalid format %q", c.format)
+}
+
+func (c *ACLCommand) displayAccessListReviewsText(reviews []*accesslist.Review) error {
+	table := asciitable.MakeTable([]string{"ID", "Reviewer", "Review Date", "Removed Members", "Notes"})
+	for _, review := range reviews {
+		table.AddRow([]string{
+			review.GetName(),
+			strings.Join(review.Spec.Reviewers, ","),
+			review.Spec.ReviewDate.Format(time.DateOnly),
+			strings.Join(append(review.Spec.Changes.RemovedMembers, review.Spec.Changes.ScopedRemovedMembers...), ","),
+			review.Spec.Notes,
+		})
+	}
+	_, err := fmt.Fprintln(c.Stdout, table.AsBuffer().String())
+	return trace.Wrap(err)
+}
+
+func (c *ACLCommand) displayAccessLists(accessLists ...*accesslist.AccessList) error {
+	switch c.format {
+	case teleport.YAML:
+		return trace.Wrap(utils.WriteYAML(c.Stdout, accessLists))
+	case teleport.JSON:
+		return trace.Wrap(utils.WriteJSONArray(c.Stdout, accessLists))
+	case teleport.Text:
+		return trace.Wrap(c.displayAccessListsText(accessLists...))
+	}
+
+	// technically unreachable since kingpin validates the EnumVar
+	return trace.BadParameter("invalid format %q", c.format)
+}
+
+func (c *ACLCommand) displayAccessListsText(accessLists ...*accesslist.AccessList) error {
+	table := asciitable.MakeTable([]string{"ID", "Title", "Next Audit", "Granted Roles", "Granted Traits"})
+	for _, accessList := range accessLists {
+		grantedRoles := append([]string(nil), accessList.GetGrants().Roles...)
+		for _, grant := range accessList.GetGrants().ScopedRoles {
+			grantedRoles = append(grantedRoles, grant.Role)
+		}
+		traitStrings := make([]string, 0, len(accessList.GetGrants().Traits))
+		for k, values := range accessList.GetGrants().Traits {
+			traitStrings = append(traitStrings, fmt.Sprintf("%s:{%s}", k, strings.Join(values, ",")))
+		}
+
+		grantedTraits := strings.Join(traitStrings, ",")
+		table.AddRow([]string{
+			accesslists.ScopeQualifiedName(accessList).String(),
+			accessList.Spec.Title,
+			accessList.Spec.Audit.NextAuditDate.Format(time.DateOnly),
+			strings.Join(grantedRoles, ","),
+			grantedTraits,
+		})
+	}
+	_, err := fmt.Fprintln(c.Stdout, table.AsBuffer().String())
+	return trace.Wrap(err)
+}

--- a/tool/tctl/common/cmds.go
+++ b/tool/tctl/common/cmds.go
@@ -19,6 +19,7 @@
 package common
 
 import (
+	"github.com/gravitational/teleport/tool/tctl/common/accesslist"
 	"github.com/gravitational/teleport/tool/tctl/common/accessmonitoring"
 	"github.com/gravitational/teleport/tool/tctl/common/decision"
 	"github.com/gravitational/teleport/tool/tctl/common/discovery"
@@ -60,7 +61,7 @@ func Commands() []CLICommand {
 		&LoadtestCommand{},
 		&DevicesCommand{},
 		&SAMLCommand{},
-		&ACLCommand{},
+		&accesslist.Command{},
 		&loginrule.Command{},
 		&IdPCommand{},
 		&accessmonitoring.Command{},


### PR DESCRIPTION
this is a similar backport (not exact) of 
- https://github.com/gravitational/teleport/pull/67334: moves `acl_command.go` into its own `accesslist` directory -- more files will be added to this directory -- original copy was kept b/c enterprise tests references them
- https://github.com/gravitational/teleport/pull/68452: moves the accesslist preset builder from enterprise -- this is just literally copy and pasta, files are not used yet

This PR is just moving things around + renames -- no new logic is introduced

next steps:
- update imports + delete the preset builder in enterprise
- come back to OSS and remove duplicated files that were kept to prevent e from breaking


## Manual Test Plan
### Test Environment

local

### Test Cases
- [x] build teleport/tctl
