### PR TITLE
Antithesis: allow go-cmp for antithesis workloads

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,6 +108,7 @@ linters:
             - '!**/lib/auth/test/**'
             - '!**/lib/services/suite/**'
             - '!**/build.assets/tooling/**'
+            - '!**/e/tests/antithesis/workloads/**'
           deny:
             - pkg: github.com/google/go-cmp/cmp
               desc: '"github.com/google/go-cmp/cmp" should only be used in tests'


### PR DESCRIPTION
The Antithesis workloads are in thier own module and are only ran within the simulation tests.
go-cmp is used for proto resource diff operations in the CRUD workloads.
