### PR TITLE
Apply new docs standard to operator/TF module docs

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportAccessList
 description: Provides a comprehensive list of fields in the TeleportAccessList resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportAccessList r
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportAccessList`
+This guide lists the fields in the `TeleportAccessList`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accessmonitoringrulesv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accessmonitoringrulesv1.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportAccessMonitoringRuleV1
 description: Provides a comprehensive list of fields in the TeleportAccessMonitoringRuleV1 resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportAccessMonito
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportAccessMonitoringRuleV1`
+This guide lists the fields in the `TeleportAccessMonitoringRuleV1`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-appsv3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-appsv3.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportAppV3
 description: Provides a comprehensive list of fields in the TeleportAppV3 resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportAppV3 resour
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportAppV3`
+This guide lists the fields in the `TeleportAppV3`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateconfigsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateconfigsv1.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportAutoupdateConfigV1
 description: Provides a comprehensive list of fields in the TeleportAutoupdateConfigV1 resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportAutoupdateCo
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportAutoupdateConfigV1`
+This guide lists the fields in the `TeleportAutoupdateConfigV1`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateversionsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateversionsv1.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportAutoupdateVersionV1
 description: Provides a comprehensive list of fields in the TeleportAutoupdateVersionV1 resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportAutoupdateVe
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportAutoupdateVersionV1`
+This guide lists the fields in the `TeleportAutoupdateVersionV1`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-botsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-botsv1.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportBotV1
 description: Provides a comprehensive list of fields in the TeleportBotV1 resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportBotV1 resour
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportBotV1`
+This guide lists the fields in the `TeleportBotV1`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-databasesv3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-databasesv3.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportDatabaseV3
 description: Provides a comprehensive list of fields in the TeleportDatabaseV3 resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportDatabaseV3 r
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportDatabaseV3`
+This guide lists the fields in the `TeleportDatabaseV3`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-githubconnectors.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-githubconnectors.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportGithubConnector
 description: Provides a comprehensive list of fields in the TeleportGithubConnector resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportGithubConnec
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportGithubConnector`
+This guide lists the fields in the `TeleportGithubConnector`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-inferencemodels.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-inferencemodels.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportInferenceModel
 description: Provides a comprehensive list of fields in the TeleportInferenceModel resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportInferenceMod
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportInferenceModel`
+This guide lists the fields in the `TeleportInferenceModel`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-inferencepolicies.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-inferencepolicies.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportInferencePolicy
 description: Provides a comprehensive list of fields in the TeleportInferencePolicy resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportInferencePol
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportInferencePolicy`
+This guide lists the fields in the `TeleportInferencePolicy`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-inferencesecrets.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-inferencesecrets.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportInferenceSecret
 description: Provides a comprehensive list of fields in the TeleportInferenceSecret resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportInferenceSec
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportInferenceSecret`
+This guide lists the fields in the `TeleportInferenceSecret`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-locksv2.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-locksv2.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportLockV2
 description: Provides a comprehensive list of fields in the TeleportLockV2 resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportLockV2 resou
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportLockV2`
+This guide lists the fields in the `TeleportLockV2`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-loginrules.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-loginrules.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportLoginRule
 description: Provides a comprehensive list of fields in the TeleportLoginRule resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportLoginRule re
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportLoginRule`
+This guide lists the fields in the `TeleportLoginRule`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-oidcconnectors.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-oidcconnectors.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportOIDCConnector
 description: Provides a comprehensive list of fields in the TeleportOIDCConnector resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportOIDCConnecto
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportOIDCConnector`
+This guide lists the fields in the `TeleportOIDCConnector`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-oktaimportrules.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-oktaimportrules.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportOktaImportRule
 description: Provides a comprehensive list of fields in the TeleportOktaImportRule resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportOktaImportRu
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportOktaImportRule`
+This guide lists the fields in the `TeleportOktaImportRule`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-openssheiceserversv2.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-openssheiceserversv2.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportOpenSSHEICEServerV2
 description: Provides a comprehensive list of fields in the TeleportOpenSSHEICEServerV2 resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportOpenSSHEICES
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportOpenSSHEICEServerV2`
+This guide lists the fields in the `TeleportOpenSSHEICEServerV2`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-opensshserversv2.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-opensshserversv2.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportOpenSSHServerV2
 description: Provides a comprehensive list of fields in the TeleportOpenSSHServerV2 resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportOpenSSHServe
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportOpenSSHServerV2`
+This guide lists the fields in the `TeleportOpenSSHServerV2`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-provisiontokens.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-provisiontokens.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportProvisionToken
 description: Provides a comprehensive list of fields in the TeleportProvisionToken resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportProvisionTok
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportProvisionToken`
+This guide lists the fields in the `TeleportProvisionToken`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-retrievalmodelsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-retrievalmodelsv1.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportRetrievalModelV1
 description: Provides a comprehensive list of fields in the TeleportRetrievalModelV1 resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportRetrievalMod
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportRetrievalModelV1`
+This guide lists the fields in the `TeleportRetrievalModelV1`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-roles.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-roles.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportRole
 description: Provides a comprehensive list of fields in the TeleportRole resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportRole resourc
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportRole`
+This guide lists the fields in the `TeleportRole`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv6.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv6.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportRoleV6
 description: Provides a comprehensive list of fields in the TeleportRoleV6 resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportRoleV6 resou
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportRoleV6`
+This guide lists the fields in the `TeleportRoleV6`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv7.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv7.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportRoleV7
 description: Provides a comprehensive list of fields in the TeleportRoleV7 resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportRoleV7 resou
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportRoleV7`
+This guide lists the fields in the `TeleportRoleV7`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv8.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv8.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportRoleV8
 description: Provides a comprehensive list of fields in the TeleportRoleV8 resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportRoleV8 resou
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportRoleV8`
+This guide lists the fields in the `TeleportRoleV8`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-samlconnectors.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-samlconnectors.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportSAMLConnector
 description: Provides a comprehensive list of fields in the TeleportSAMLConnector resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportSAMLConnecto
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportSAMLConnector`
+This guide lists the fields in the `TeleportSAMLConnector`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-samlidpserviceprovidersv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-samlidpserviceprovidersv1.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportSAMLIdPServiceProviderV1
 description: Provides a comprehensive list of fields in the TeleportSAMLIdPServiceProviderV1 resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportSAMLIdPServi
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportSAMLIdPServiceProviderV1`
+This guide lists the fields in the `TeleportSAMLIdPServiceProviderV1`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedroleassignmentsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedroleassignmentsv1.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportScopedRoleAssignmentV1
 description: Provides a comprehensive list of fields in the TeleportScopedRoleAssignmentV1 resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportScopedRoleAs
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportScopedRoleAssignmentV1`
+This guide lists the fields in the `TeleportScopedRoleAssignmentV1`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedrolesv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedrolesv1.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportScopedRoleV1
 description: Provides a comprehensive list of fields in the TeleportScopedRoleV1 resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportScopedRoleV1
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportScopedRoleV1`
+This guide lists the fields in the `TeleportScopedRoleV1`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedtokensv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedtokensv1.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportScopedTokenV1
 description: Provides a comprehensive list of fields in the TeleportScopedTokenV1 resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportScopedTokenV
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportScopedTokenV1`
+This guide lists the fields in the `TeleportScopedTokenV1`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-trustedclustersv2.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-trustedclustersv2.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportTrustedClusterV2
 description: Provides a comprehensive list of fields in the TeleportTrustedClusterV2 resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportTrustedClust
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportTrustedClusterV2`
+This guide lists the fields in the `TeleportTrustedClusterV2`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-users.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-users.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportUser
 description: Provides a comprehensive list of fields in the TeleportUser resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportUser resourc
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportUser`
+This guide lists the fields in the `TeleportUser`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-workloadidentitiesv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-workloadidentitiesv1.mdx
@@ -1,6 +1,7 @@
 ---
 title: TeleportWorkloadIdentityV1
 description: Provides a comprehensive list of fields in the TeleportWorkloadIdentityV1 resource available through the Teleport Kubernetes operator
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -10,7 +11,7 @@ description: Provides a comprehensive list of fields in the TeleportWorkloadIden
 need to refer to these. */}
 {/* vale 3rd-party-products.former-names = NO */}
 
-This guide is a comprehensive reference to the fields in the `TeleportWorkloadIdentityV1`
+This guide lists the fields in the `TeleportWorkloadIdentityV1`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/examples.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/examples.mdx
@@ -2,6 +2,7 @@
 title: Terraform Module teleport-discovery-aws Examples
 sidebar_label: examples
 description: Index of all the examples for the teleport-discovery-aws Terraform module.
+page_type: landing
 ---
 
 {/*

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/organization.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/organization.mdx
@@ -2,6 +2,7 @@
 title: Example for discovering AWS resources in all accounts under an organization
 sidebar_label: organization
 description: Configure Teleport to discover resources in accounts within an AWS organization.
+page_type: reference
 ---
 
 {/*
@@ -10,6 +11,9 @@ description: Configure Teleport to discover resources in accounts within an AWS 
     Instead, edit teleport/discovery/aws/examples/organization/README.md
     Then, regenerate the docs with `make -C integrations/terraform-modules docs`.
 */}
+
+This page lists the configuration fields in a usage example of the
+teleport-discovery-aws Terraform module: organization.
 
 Source Code: [github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws/examples/organization](https://github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws/examples/organization)
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/single-account-legacy.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/single-account-legacy.mdx
@@ -2,6 +2,7 @@
 title: AWS Discovery in a Single Account
 sidebar_label: single-account-legacy
 description: Configure Teleport to discover resources in an AWS account.
+page_type: reference
 ---
 
 {/*
@@ -10,6 +11,9 @@ description: Configure Teleport to discover resources in an AWS account.
     Instead, edit teleport/discovery/aws/examples/single-account-legacy/README.md
     Then, regenerate the docs with `make -C integrations/terraform-modules docs`.
 */}
+
+This page lists the configuration fields in a usage example of the
+teleport-discovery-aws Terraform module: single-account-legacy.
 
 Source Code: [github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws/examples/single-account-legacy](https://github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws/examples/single-account-legacy)
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/single-account.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/single-account.mdx
@@ -2,6 +2,7 @@
 title: Discover AWS Resources in a Single Account
 sidebar_label: single-account
 description: Configure Teleport to discover resources in an AWS account.
+page_type: reference
 ---
 
 {/*
@@ -10,6 +11,9 @@ description: Configure Teleport to discover resources in an AWS account.
     Instead, edit teleport/discovery/aws/examples/single-account/README.md
     Then, regenerate the docs with `make -C integrations/terraform-modules docs`.
 */}
+
+This page lists the configuration fields in a usage example of the
+teleport-discovery-aws Terraform module: single-account.
 
 Source Code: [github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws/examples/single-account](https://github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws/examples/single-account)
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
@@ -2,6 +2,7 @@
 title: Reference for the teleport-discovery-aws Terraform module
 sidebar_label: teleport-discovery-aws
 description: This page describes the teleport-discovery-aws Terraform module.
+page_type: reference
 ---
 
 {/*
@@ -10,6 +11,9 @@ description: This page describes the teleport-discovery-aws Terraform module.
     Instead, edit integrations/terraform-modules/teleport/discovery/aws/README.md
     Then, regenerate the docs with `make -C integrations/terraform-modules docs`.
 */}
+
+This page lists the input fields and output values of the teleport-discovery-aws
+Terraform module.
 
 Source Code: [github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws](https://github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws)
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-azure/examples/examples.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-azure/examples/examples.mdx
@@ -2,6 +2,7 @@
 title: Terraform Module teleport-discovery-azure Examples
 sidebar_label: examples
 description: Index of all the examples for the teleport-discovery-azure Terraform module.
+page_type: landing
 ---
 
 {/*

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-azure/examples/management-group.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-azure/examples/management-group.mdx
@@ -2,6 +2,7 @@
 title: Discover Azure Resources in a Management Group
 sidebar_label: management-group
 description: Configure Teleport to discover resources in an Azure management group.
+page_type: reference
 ---
 
 {/*
@@ -10,6 +11,9 @@ description: Configure Teleport to discover resources in an Azure management gro
     Instead, edit teleport/discovery/azure/examples/management-group/README.md
     Then, regenerate the docs with `make -C integrations/terraform-modules docs`.
 */}
+
+This page lists the configuration fields in a usage example of the
+teleport-discovery-azure Terraform module: management-group.
 
 Source Code: [github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/azure/examples/management-group](https://github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/azure/examples/management-group)
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-azure/examples/single-subscription.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-azure/examples/single-subscription.mdx
@@ -2,6 +2,7 @@
 title: Discover Azure Resources in a Single Subscription
 sidebar_label: single-subscription
 description: Configure Teleport to discover resources in an Azure subscription.
+page_type: reference
 ---
 
 {/*
@@ -10,6 +11,9 @@ description: Configure Teleport to discover resources in an Azure subscription.
     Instead, edit teleport/discovery/azure/examples/single-subscription/README.md
     Then, regenerate the docs with `make -C integrations/terraform-modules docs`.
 */}
+
+This page lists the configuration fields in a usage example of the
+teleport-discovery-azure Terraform module: single-subscription.
 
 Source Code: [github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/azure/examples/single-subscription](https://github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/azure/examples/single-subscription)
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-azure/teleport-discovery-azure.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-azure/teleport-discovery-azure.mdx
@@ -2,6 +2,7 @@
 title: Reference for the teleport-discovery-azure Terraform module
 sidebar_label: teleport-discovery-azure
 description: This page describes the teleport-discovery-azure Terraform module.
+page_type: reference
 ---
 
 {/*
@@ -10,6 +11,9 @@ description: This page describes the teleport-discovery-azure Terraform module.
     Instead, edit integrations/terraform-modules/teleport/discovery/azure/README.md
     Then, regenerate the docs with `make -C integrations/terraform-modules docs`.
 */}
+
+This page lists the input fields and output values of the teleport-discovery-azure
+Terraform module.
 
 Source Code: [github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/azure](https://github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/azure)
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/terraform-modules.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/terraform-modules.mdx
@@ -2,6 +2,7 @@
 title: Teleport Terraform Modules Reference
 sidebar_label: Terraform Modules
 description: Reference documentation for the Teleport Terraform modules.
+page_type: landing
 tags:
  - infrastructure-as-code
  - reference

--- a/integrations/operator/crdgen/format.go
+++ b/integrations/operator/crdgen/format.go
@@ -47,6 +47,7 @@ func formatAsCRD(crd apiextv1.CustomResourceDefinition, groupName, pluralName st
 var crdDocTmpl string = `---
 title: {{.Title}}
 description: {{.Description}}
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
@@ -273,7 +274,7 @@ func formatAsDocsPage(crd apiextv1.CustomResourceDefinition, groupName, pluralNa
 		Title:       crd.Spec.Names.Kind,
 		Description: fmt.Sprintf("Provides a comprehensive list of fields in the %v resource available through the Teleport Kubernetes operator", crd.Spec.Names.Kind),
 		Intro: strings.ReplaceAll(fmt.Sprintf(
-			`This guide is a comprehensive reference to the fields in the BACKTICK%vBACKTICK
+			`This guide lists the fields in the BACKTICK%vBACKTICK
 resource, which you can apply after installing the Teleport Kubernetes operator.`,
 			crd.Spec.Names.Kind), "BACKTICK", "`"),
 	}

--- a/integrations/terraform-modules/gen/docs.sh
+++ b/integrations/terraform-modules/gen/docs.sh
@@ -54,6 +54,7 @@ cat <<EOF > "${MODULES_DOC_INDEX}"
 title: Teleport Terraform Modules Reference
 sidebar_label: Terraform Modules
 description: Reference documentation for the Teleport Terraform modules.
+page_type: landing
 tags:
  - infrastructure-as-code
  - reference
@@ -97,6 +98,7 @@ EOF
 title: Reference for the ${module_name} Terraform module
 sidebar_label: ${module_name}
 description: This page describes the ${module_name} Terraform module.
+page_type: reference
 ---
 
 {/*
@@ -105,6 +107,9 @@ description: This page describes the ${module_name} Terraform module.
     Instead, edit ${MODULES_ROOT_DIR}/${module}/README.md
     Then, regenerate the docs with \`make -C ${MODULES_ROOT_DIR} docs\`.
 */}
+
+This page lists the input fields and output values of the ${module_name}
+Terraform module.
 
 Source Code: [${SOURCE_URI}/${module}](https://${SOURCE_URI}/${module})
 
@@ -123,6 +128,7 @@ EOF
 title: Terraform Module ${module_name} Examples
 sidebar_label: examples
 description: Index of all the examples for the ${module_name} Terraform module.
+page_type: landing
 ---
 
 {/*
@@ -160,6 +166,7 @@ EOF
 title: ${example_title}
 sidebar_label: ${example_name}
 description: ${example_description}
+page_type: reference
 ---
 
 {/*
@@ -168,6 +175,9 @@ description: ${example_description}
     Instead, edit ${example}/README.md
     Then, regenerate the docs with \`make -C ${MODULES_ROOT_DIR} docs\`.
 */}
+
+This page lists the configuration fields in a usage example of the
+${module_name} Terraform module: ${example_name}.
 
 Source Code: [${SOURCE_URI}/${example}](https://${SOURCE_URI}/${example})
 


### PR DESCRIPTION
The docs are moving towards expecting a standard set of outcome statements. This allows us to ensure that each page includes a succinct summary of its purpose for human and agent readers, depending on the type of page, without requiring the reader to traverse more of the document than necessary.

This change edits the templates for the Terraform modules and Kubernetes operator reference pages to:
- Add the `page_type` frontmatter field, which is used to enforce standards for different types of pages.
- Ensure each page includes a compliant outcome statement.