### PR TITLE
[v18] Enrich too-old connection failures on instance startup

### DIFF
--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -23,15 +23,12 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
-	"fmt"
 	"log/slog"
 	"path/filepath"
 	"slices"
 	"strings"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
 	"github.com/google/uuid"
 	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
@@ -43,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/breaker"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/client/webclient"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
@@ -97,10 +95,9 @@ func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*
 			return connector, nil
 		} else {
 			switch {
-			// Version incompatibilities (the client is too new or too old for
-			// the cluster) are fatal. Retrying is pointless until the client is
-			// up or downgraded, so surface the error and stop reconnecting.
-			case isVersionCompatibilityError(connectErr):
+			// A too-new instance is fatal. Retrying is pointless until this
+			// instance downgraded, so surface the error and stop reconnecting.
+			case isVersionIncompatible(connectErr):
 				return nil, trace.Wrap(connectErr)
 			case strings.Contains(connectErr.Error(), auth.TokenExpiredOrNotFound):
 				process.logger.ErrorContext(process.ExitContext(), "Can not join the cluster, the token is expired or not found. Regenerate the token and try again.")
@@ -131,20 +128,6 @@ func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*
 	}
 }
 
-type invalidVersionErr struct {
-	ClusterMajorVersion int64
-	LocalMajorVersion   int64
-}
-
-func (i invalidVersionErr) Error() string {
-	return fmt.Sprintf("Teleport instance is too new. This instance is running v%d. The auth server is running v%d and only supports instances on v%d or v%d. To connect anyway pass the --skip-version-check flag.", i.LocalMajorVersion, i.ClusterMajorVersion, i.ClusterMajorVersion, i.ClusterMajorVersion-1)
-}
-
-func isVersionCompatibilityError(err error) bool {
-	return errors.As(err, &invalidVersionErr{}) ||
-		isVersionIncompatible(err)
-}
-
 func (process *TeleportProcess) assertSystemRoles(rolesToAssert []types.SystemRole) (assertionID string, err error) {
 	assertionID = uuid.New().String()
 	irm := process.getInstanceRoleEventMapping()
@@ -170,32 +153,6 @@ func (process *TeleportProcess) assertSystemRoles(rolesToAssert []types.SystemRo
 	}
 
 	return assertionID, nil
-}
-
-func (process *TeleportProcess) authServerTooOld(resp *proto.PingResponse) error {
-	serverVersion, err := semver.NewVersion(resp.ServerVersion)
-	if err != nil {
-		return trace.BadParameter("failed to parse reported auth server version as semver: %v", err)
-	}
-
-	version := teleport.Version
-	if process.Config.Testing.TeleportVersion != "" {
-		version = process.Config.Testing.TeleportVersion
-	}
-	teleportVersion, err := semver.NewVersion(version)
-	if err != nil {
-		return trace.BadParameter("failed to parse local teleport version as semver: %v", err)
-	}
-
-	if serverVersion.Major < teleportVersion.Major {
-		if process.Config.SkipVersionCheck {
-			process.logger.WarnContext(process.ExitContext(), "This instance is too new. Using a newer major version than the Auth server is unsupported and may impair functionality.", "version", teleportVersion.Major, "auth_version", serverVersion.Major, "supported_versions", []int64{serverVersion.Major, serverVersion.Major - 1})
-			return nil
-		}
-		return trace.Wrap(invalidVersionErr{ClusterMajorVersion: serverVersion.Major, LocalMajorVersion: teleportVersion.Major})
-	}
-
-	return nil
 }
 
 // connectToAuthService attempts to login into the auth servers specified in the
@@ -1433,14 +1390,17 @@ func (process *TeleportProcess) getConnector(clientIdentity, serverIdentity *sta
 		}
 	}
 
+	// newClient enforces version compatibility (too-new is fatal, too-old is
+	// detected and surfaced) as part of establishing the connection.
 	clt, pingResponse, err := process.newClient(newConn)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	// Return a helpful message and don't retry if ping was successful,
-	// but the auth server is too old. Auth is not going to get any younger.
-	if err := process.authServerTooOld(pingResponse); err != nil {
+	// Refuse a too-new instance against the auth server's version. Too-old
+	// can't be checked here: the auth gRPC ping carries no minimum client
+	// version, and a too-old client is force-closed before Ping returns.
+	if err := process.enforceVersionPolicy(process.ExitContext(), joinclient.VersionInfo{ServerVersion: pingResponse.ServerVersion}); err != nil {
 		return nil, trace.NewAggregate(err, clt.Close())
 	}
 
@@ -1539,7 +1499,7 @@ func (process *TeleportProcess) newClient(connector *Connector) (*authclient.Cli
 			logger.DebugContext(process.ExitContext(), "Attempting to connect to Auth Server through tunnel.")
 			tunnelClient, pingResponse, err := process.newClientThroughTunnel(tlsConfig, sshClientConfig, connector.Role(), connector.ClientGetPool)
 			if err != nil {
-				return nil, nil, trace.Errorf("Failed to connect to Proxy Server through tunnel: %v", err)
+				return nil, nil, trace.Wrap(err, "Failed to connect to Proxy Server through tunnel")
 			}
 
 			logger.DebugContext(process.ExitContext(), "Connected to Auth Server through tunnel.")
@@ -1569,7 +1529,39 @@ func (process *TeleportProcess) breakerConfigForRole(role types.SystemRole) brea
 	return servicebreaker.InstrumentBreakerForConnector(role, process.Config.CircuitBreakerConfig)
 }
 
+// proxyVersionInfo fetches the proxy's advertised version information. It fails
+// open, returning a zero VersionInfo (and logging) when the address is unknown
+// or the fetch fails, so a transient error can't block connecting.
+func (process *TeleportProcess) proxyVersionInfo() joinclient.VersionInfo {
+	proxyAddr := process.Config.ProxyWebAddr()
+	if proxyAddr.IsEmpty() {
+		return joinclient.VersionInfo{}
+	}
+
+	findResp, err := webclient.Find(&webclient.Config{
+		Context:   process.ExitContext(),
+		ProxyAddr: proxyAddr.String(),
+		Insecure:  lib.IsInsecureDevMode(),
+	})
+	if err != nil {
+		process.logger.WarnContext(process.ExitContext(),
+			"Could not fetch version information from the proxy's web API, skipping the version compatibility check for this connection attempt.",
+			"proxy_addr", proxyAddr.String(),
+			"error", err,
+		)
+		return joinclient.VersionInfo{}
+	}
+	return joinclient.VersionInfo{
+		ServerVersion:    findResp.ServerVersion,
+		MinClientVersion: findResp.MinClientVersion,
+	}
+}
+
 func (process *TeleportProcess) newClientThroughTunnel(tlsConfig *tls.Config, sshConfig *ssh.ClientConfig, role types.SystemRole, getClusterCAs func() (*x509.CertPool, error)) (*authclient.Client, *proto.PingResponse, error) {
+	versionInfo := process.proxyVersionInfo()
+	if err := process.enforceVersionPolicy(process.ExitContext(), versionInfo); err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
 	dialer, err := reversetunnelclient.NewTunnelAuthDialer(reversetunnelclient.TunnelAuthDialerConfig{
 		Resolver:              process.resolver,
 		ClientConfig:          sshConfig,
@@ -1601,7 +1593,14 @@ func (process *TeleportProcess) newClientThroughTunnel(tlsConfig *tls.Config, ss
 	defer cancel()
 	resp, err := clt.Ping(ctx)
 	if err != nil {
-		return nil, nil, trace.NewAggregate(err, clt.Close())
+		return nil, nil, trace.NewAggregate(
+			err,
+			clt.Close(),
+			// A too-old instance is force-closed by the server with an opaque EOF.
+			// Include a too-old error (nil if not too old) so an operator knows
+			// that version compatibility is a potential cause of the failure.
+			clientTooOld(versionInfo.MinClientVersion),
+		)
 	}
 
 	return clt, &resp, nil

--- a/lib/service/connect_test.go
+++ b/lib/service/connect_test.go
@@ -19,7 +19,9 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -28,14 +30,19 @@ import (
 	"testing"
 
 	"github.com/coreos/go-semver/semver"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/storage"
 	"github.com/gravitational/teleport/lib/backend/memory"
@@ -47,7 +54,9 @@ import (
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
-func TestTeleportProcessClientVersionCheck(t *testing.T) {
+// TestTeleportProcessJoinVersionCheck covers version enforcement during a
+// fresh instance's join.
+func TestTeleportProcessJoinVersionCheck(t *testing.T) {
 	lib.SetInsecureDevMode(true)
 	t.Cleanup(func() { lib.SetInsecureDevMode(false) })
 
@@ -57,7 +66,7 @@ func TestTeleportProcessClientVersionCheck(t *testing.T) {
 	tooOldMinVersion := semver.Version{Major: teleport.SemVer().Major + 1}.String()
 	tooNewServerVersion := semver.Version{Major: teleport.SemVer().Major - 1}.String()
 
-	newConfig := func(t *testing.T, minClientVersion, serverVersion string) *servicecfg.Config {
+	newProcess := func(t *testing.T, findHandler http.HandlerFunc, skipVersionCheck bool) *TeleportProcess {
 		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// The skipped-check variant proceeds past the version check and hits
 			// join endpoints this stub doesn't implement before failing.
@@ -65,10 +74,7 @@ func TestTeleportProcessClientVersionCheck(t *testing.T) {
 				http.NotFound(w, r)
 				return
 			}
-			require.NoError(t, json.NewEncoder(w).Encode(webclient.PingResponse{
-				MinClientVersion: minClientVersion,
-				ServerVersion:    serverVersion,
-			}))
+			findHandler(w, r)
 		}))
 		t.Cleanup(srv.Close)
 
@@ -80,74 +86,231 @@ func TestTeleportProcessClientVersionCheck(t *testing.T) {
 		cfg.Auth.Enabled = false
 		cfg.Proxy.Enabled = false
 		cfg.SSH.Enabled = true
-		return cfg
+		cfg.SkipVersionCheck = skipVersionCheck
+
+		process, err := NewTeleport(cfg)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = process.Close() })
+		return process
 	}
 
-	t.Run("client too old stops reconnect retries", func(t *testing.T) {
-		cfg := newConfig(t, tooOldMinVersion, teleport.Version)
-		process, err := NewTeleport(cfg)
-		require.NoError(t, err)
-		t.Cleanup(func() { _ = process.Close() })
+	serveVersions := func(minClientVersion, serverVersion string) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, json.NewEncoder(w).Encode(webclient.PingResponse{
+				MinClientVersion: minClientVersion,
+				ServerVersion:    serverVersion,
+			}))
+		}
+	}
 
-		c, err := process.reconnectToAuthService(types.RoleInstance)
-		var tooOld *clientTooOldError
-		require.ErrorAs(t, err, &tooOld)
-		require.Nil(t, c)
-	})
-
-	t.Run("client too old with skip version check bypasses the failure", func(t *testing.T) {
-		cfg := newConfig(t, tooOldMinVersion, teleport.Version)
-		cfg.SkipVersionCheck = true
-
-		process, err := NewTeleport(cfg)
-		require.NoError(t, err)
-		t.Cleanup(func() { _ = process.Close() })
-
-		// Deliberately call connectToAuthService, not reconnectToAuthService.
-		// With the check skipped the join fails against the stub with an
-		// ordinary connection error, which reconnectToAuthService treats as
-		// retryable and would loop on forever. Failing with anything other
-		// than clientTooOldError proves SkipVersionCheck was plumbed through
-		// and bypassed the check.
-		c, err := process.connectToAuthService(types.RoleInstance)
-		require.Error(t, err)
-		var tooOld *clientTooOldError
-		require.NotErrorAs(t, err, &tooOld)
-		require.Nil(t, c)
-	})
+	const (
+		skipVersionCheckTrue  = true
+		skipVersionCheckFalse = false
+	)
 
 	t.Run("client too new stops reconnect retries", func(t *testing.T) {
-		cfg := newConfig(t, teleport.MinClientSemVer().String(), tooNewServerVersion)
-
-		process, err := NewTeleport(cfg)
-		require.NoError(t, err)
-		t.Cleanup(func() { _ = process.Close() })
-
+		process := newProcess(t, serveVersions(teleport.MinClientSemVer().String(), tooNewServerVersion), skipVersionCheckFalse)
 		c, err := process.reconnectToAuthService(types.RoleInstance)
-		var tooNew *clientTooNewError
-		require.ErrorAs(t, err, &tooNew)
+		requireClientTooNew(t, err)
 		require.Nil(t, c)
 	})
 
+	// The cases below call connectToAuthService, not reconnectToAuthService.
+	// Once past the version check the join fails against the stub with an
+	// ordinary error that reconnectToAuthService would retry forever.
+
 	t.Run("client too new with skip version check bypasses the failure", func(t *testing.T) {
-		cfg := newConfig(t, teleport.MinClientSemVer().String(), tooNewServerVersion)
-		cfg.SkipVersionCheck = true
-
-		process, err := NewTeleport(cfg)
-		require.NoError(t, err)
-		t.Cleanup(func() { _ = process.Close() })
-
-		// Deliberately call connectToAuthService, not reconnectToAuthService.
-		// With the check skipped the join fails against the stub with an
-		// ordinary connection error, which reconnectToAuthService treats as
-		// retryable and would loop on forever. Failing with anything other
-		// than clientTooNewError proves SkipVersionCheck was plumbed through
-		// and bypassed the check.
+		// A non-version error proves SkipVersionCheck was plumbed through.
+		process := newProcess(t, serveVersions(teleport.MinClientSemVer().String(), tooNewServerVersion), skipVersionCheckTrue)
 		c, err := process.connectToAuthService(types.RoleInstance)
 		require.Error(t, err)
 		var tooNew *clientTooNewError
 		require.NotErrorAs(t, err, &tooNew)
 		require.Nil(t, c)
+	})
+
+	t.Run("client too old is not blocked by the client", func(t *testing.T) {
+		// Too-old is the server's call, so the client-side join check must not
+		// block it. The join proceeds past the version check and fails against the
+		// stub with an ordinary (non-version) error. connectToAuthService is used
+		// (single attempt) rather than reconnectToAuthService, which would retry a
+		// non-version error forever.
+		process := newProcess(t, serveVersions(tooOldMinVersion, teleport.Version), skipVersionCheckFalse)
+		c, err := process.connectToAuthService(types.RoleInstance)
+		require.Error(t, err)
+		require.False(t, isVersionIncompatible(err), "too-old must not be a client-side version block, got %v", err)
+		var tooOld *clientTooOldError
+		require.NotErrorAs(t, err, &tooOld)
+		require.Nil(t, c)
+	})
+
+	t.Run("compatible version passes the check", func(t *testing.T) {
+		// Only too-new is enforced, so a non-version error proves the check
+		// didn't reject and the flow reached the join.
+		process := newProcess(t, serveVersions(teleport.MinClientSemVer().String(), teleport.Version), skipVersionCheckFalse)
+		c, err := process.connectToAuthService(types.RoleInstance)
+		require.Error(t, err)
+		require.False(t, isVersionIncompatible(err), "compatible version should pass the check, got %v", err)
+		require.Nil(t, c)
+	})
+
+	t.Run("find failure skips version check", func(t *testing.T) {
+		// A failed /webapi/find must fail open, not block the connection.
+		process := newProcess(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}, skipVersionCheckFalse)
+		c, err := process.connectToAuthService(types.RoleInstance)
+		require.Error(t, err)
+		require.False(t, isVersionIncompatible(err), "version check should have been skipped on find failure, got %v", err)
+		require.Nil(t, c)
+	})
+}
+
+// fakeAuthPingServer is a minimal AuthService gRPC server that only answers
+// Ping, letting tests advertise an arbitrary ServerVersion.
+type fakeAuthPingServer struct {
+	proto.UnimplementedAuthServiceServer
+	serverVersion string
+}
+
+func (f *fakeAuthPingServer) Ping(context.Context, *proto.PingRequest) (*proto.PingResponse, error) {
+	return &proto.PingResponse{ServerVersion: f.serverVersion, ServerFeatures: &proto.Features{}}, nil
+}
+
+// TestGetConnectorVersionCheck covers the startup too-new check for an
+// already-joined instance reconnecting. The fake gRPC server fakes its
+// version while presenting an authtest-issued cert so it passes the
+// connector's TLS check.
+func TestGetConnectorVersionCheck(t *testing.T) {
+	t.Parallel()
+
+	testAuthServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, testAuthServer.Close()) })
+
+	// nodeID is the connecting client. authID backs the fake server's cert: it
+	// plays the auth server, and an auth-role cert carries the
+	// "*.teleport.cluster.local" SAN the connector's TLS check requires (node
+	// certs don't). Both are issued by the same cluster CA the connector trusts.
+	nodeID, err := authtest.NewServerIdentity(testAuthServer.AuthServer, "test-host-id", types.RoleNode)
+	require.NoError(t, err)
+	authID, err := authtest.NewServerIdentity(testAuthServer.AuthServer, "test-auth-id", types.RoleAuth)
+	require.NoError(t, err)
+	serverTLSConfig, err := authID.TLSConfig(nil)
+	require.NoError(t, err)
+
+	// A server one major behind makes this instance too new.
+	tooNewServerVersion := semver.Version{Major: teleport.SemVer().Major - 1}.String()
+
+	for _, tt := range []struct {
+		name          string
+		serverVersion string
+		skipCheck     bool
+		assertError   require.ErrorAssertionFunc
+	}{
+		{
+			name:          "client too new stops connection",
+			serverVersion: tooNewServerVersion,
+			assertError:   requireClientTooNew,
+		},
+		{
+			// Skip must not just suppress the error but yield a working connector.
+			name:          "client too new with skip version check connects",
+			serverVersion: tooNewServerVersion,
+			skipCheck:     true,
+			assertError:   require.NoError,
+		},
+		{
+			name:          "compatible version connects",
+			serverVersion: teleport.Version,
+			assertError:   require.NoError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			lis, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = lis.Close() })
+
+			grpcServer := grpc.NewServer(grpc.Creds(credentials.NewTLS(serverTLSConfig)))
+			proto.RegisterAuthServiceServer(grpcServer, &fakeAuthPingServer{serverVersion: tt.serverVersion})
+			go grpcServer.Serve(lis)
+			t.Cleanup(grpcServer.Stop)
+
+			// V3 config with an auth address and no proxy routes newClient down
+			// the direct-to-auth path, straight to the fake gRPC server.
+			cfg := servicecfg.MakeDefaultConfig()
+			cfg.Version = defaults.TeleportConfigVersionV3
+			cfg.SkipVersionCheck = tt.skipCheck
+			cfg.SetAuthServerAddress(utils.NetAddr{AddrNetwork: "tcp", Addr: lis.Addr().String()})
+
+			process := &TeleportProcess{
+				Clock:      clockwork.NewRealClock(),
+				Supervisor: &LocalSupervisor{exitContext: t.Context()},
+				Config:     cfg,
+				logger:     logtest.NewLogger(),
+			}
+			// getConnector checks for a reusable instance client for non-instance
+			// roles. A closed ready channel makes that lookup return immediately
+			// instead of blocking, so it falls through to a fresh connection.
+			process.instanceConnectorReady = make(chan struct{})
+			close(process.instanceConnectorReady)
+
+			conn, err := process.getConnector(nodeID, nodeID)
+			if conn != nil {
+				t.Cleanup(func() { _ = conn.Close() })
+			}
+			tt.assertError(t, err)
+		})
+	}
+}
+
+// TestProxyVersionInfo covers the reconnect-path fetch of the proxy's advertised
+// version information, including the fail-open behavior that keeps a transient or
+// unreachable web API from blocking an otherwise-valid instance.
+func TestProxyVersionInfo(t *testing.T) {
+	lib.SetInsecureDevMode(true)
+	t.Cleanup(func() { lib.SetInsecureDevMode(false) })
+
+	newProcess := func(t *testing.T, handler http.HandlerFunc) *TeleportProcess {
+		srv := httptest.NewTLSServer(handler)
+		t.Cleanup(srv.Close)
+		return &TeleportProcess{
+			Supervisor: &LocalSupervisor{exitContext: t.Context()},
+			Config: &servicecfg.Config{
+				Version:     defaults.TeleportConfigVersionV3,
+				ProxyServer: utils.NetAddr{AddrNetwork: "tcp", Addr: strings.TrimPrefix(srv.URL, "https://")},
+			},
+			logger: logtest.NewLogger(),
+		}
+	}
+
+	t.Run("advertised versions are returned", func(t *testing.T) {
+		process := newProcess(t, func(w http.ResponseWriter, _ *http.Request) {
+			require.NoError(t, json.NewEncoder(w).Encode(webclient.PingResponse{
+				ServerVersion:    "1.2.3",
+				MinClientVersion: "1.0.0",
+			}))
+		})
+		require.Equal(t,
+			joinclient.VersionInfo{ServerVersion: "1.2.3", MinClientVersion: "1.0.0"},
+			process.proxyVersionInfo(),
+		)
+	})
+
+	t.Run("fetch failure fails open", func(t *testing.T) {
+		process := newProcess(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		require.Equal(t, joinclient.VersionInfo{}, process.proxyVersionInfo())
+	})
+
+	t.Run("no proxy address fails open", func(t *testing.T) {
+		process := &TeleportProcess{
+			Supervisor: &LocalSupervisor{exitContext: t.Context()},
+			Config:     &servicecfg.Config{},
+			logger:     logtest.NewLogger(),
+		}
+		require.Equal(t, joinclient.VersionInfo{}, process.proxyVersionInfo())
 	})
 }
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1374,12 +1374,7 @@ func NewTeleport(cfg *servicecfg.Config) (_ *TeleportProcess, err error) {
 		}
 	}
 
-	var resolverAddr utils.NetAddr
-	if cfg.Version == defaults.TeleportConfigVersionV3 && !cfg.ProxyServer.IsEmpty() {
-		resolverAddr = cfg.ProxyServer
-	} else {
-		resolverAddr = cfg.AuthServerAddresses()[0]
-	}
+	resolverAddr := cfg.ProxyWebAddr()
 
 	process.resolver, err = reversetunnelclient.CachingResolver(
 		process.ExitContext(),

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -35,7 +35,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
@@ -51,7 +50,6 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api"
 	"github.com/gravitational/teleport/api/breaker"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	autoupdatepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
@@ -64,7 +62,6 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/storage"
 	"github.com/gravitational/teleport/lib/backend"
-	"github.com/gravitational/teleport/lib/backend/lite"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/cloud/imds"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -1217,92 +1214,6 @@ func expectedSSHPrincipals(hostID, hostName, clusterName string) []string {
 		string(teleport.PrincipalLoopbackV6),
 	}
 
-}
-
-func TestTeleportProcessAuthVersionCheck(t *testing.T) {
-	t.Parallel()
-
-	lib.SetInsecureDevMode(true)
-	defer lib.SetInsecureDevMode(false)
-
-	listenAddr := utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
-	token := "join-token"
-
-	// Create Auth Service process.
-	staticTokens, err := types.NewStaticTokens(types.StaticTokensSpecV2{
-		StaticTokens: []types.ProvisionTokenV1{
-			{
-				Roles: []types.SystemRole{
-					types.RoleNode,
-				},
-				Token: token,
-			},
-		},
-	})
-	require.NoError(t, err)
-
-	authCfg := servicecfg.MakeDefaultConfig()
-	authCfg.SetAuthServerAddress(listenAddr)
-	authCfg.DataDir = makeTempDir(t)
-	authCfg.Auth.Enabled = true
-	authCfg.Auth.StaticTokens = staticTokens
-	authCfg.Auth.StorageConfig.Type = lite.GetName()
-	authCfg.Auth.StorageConfig.Params = backend.Params{defaults.BackendPath: filepath.Join(authCfg.DataDir, defaults.BackendDir)}
-	authCfg.Auth.ListenAddr = listenAddr
-	authCfg.Proxy.Enabled = false
-	authCfg.SSH.Enabled = false
-
-	authProc, err := NewTeleport(authCfg)
-	require.NoError(t, err)
-
-	err = authProc.Start()
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		authProc.Close()
-	})
-
-	// Create Node process, pointing at the auth server's local port
-	authListenAddr := authProc.Config.AuthServerAddresses()[0]
-	nodeCfg := servicecfg.MakeDefaultConfig()
-	nodeCfg.SetAuthServerAddress(authListenAddr)
-	nodeCfg.DataDir = makeTempDir(t)
-	nodeCfg.SetToken(token)
-	nodeCfg.Auth.Enabled = false
-	nodeCfg.Proxy.Enabled = false
-	nodeCfg.SSH.Enabled = true
-
-	// Set the Node's major version to be greater than the Auth Service's,
-	// which should make the version check fail.
-	currentVersion := semver.Version{Major: api.VersionMajor + 1}
-	nodeCfg.Testing.TeleportVersion = currentVersion.String()
-
-	t.Run("with version check", func(t *testing.T) {
-		testVersionCheck(t, nodeCfg, false)
-	})
-
-	t.Run("without version check", func(t *testing.T) {
-		testVersionCheck(t, nodeCfg, true)
-	})
-}
-
-func testVersionCheck(t *testing.T, nodeCfg *servicecfg.Config, skipVersionCheck bool) {
-	nodeCfg.SkipVersionCheck = skipVersionCheck
-
-	nodeProc, err := NewTeleport(nodeCfg)
-	require.NoError(t, err)
-
-	c, err := nodeProc.reconnectToAuthService(types.RoleInstance)
-	if skipVersionCheck {
-		require.NoError(t, err)
-		require.NotNil(t, c)
-	} else {
-		require.ErrorAs(t, err, &invalidVersionErr{})
-		require.Nil(t, c)
-	}
-
-	supervisor, ok := nodeProc.Supervisor.(*LocalSupervisor)
-	require.True(t, ok)
-	supervisor.signalExit()
 }
 
 func TestProxyGRPCServers(t *testing.T) {

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -319,9 +319,6 @@ type ConfigTesting struct {
 	// ShutdownTimeout is set to override default shutdown timeout.
 	ShutdownTimeout time.Duration
 
-	// TeleportVersion is used to control the Teleport version in tests.
-	TeleportVersion string
-
 	// KubeMultiplexerIgnoreSelfConnections signals that Proxy TLS server's listener should
 	// require PROXY header if 'proxyProtocolMode: true' even from self connections. Used in tests as all connections are self
 	// connections there.
@@ -597,6 +594,22 @@ func (cfg *Config) SetAuthServerAddresses(addrs []utils.NetAddr) error {
 // SetAuthServerAddress sets the value of authServers to a single value
 func (cfg *Config) SetAuthServerAddress(addr utils.NetAddr) {
 	cfg.authServers = []utils.NetAddr{addr}
+}
+
+// ProxyWebAddr returns the address used to reach the cluster's web API: the
+// configured proxy for v3 configs, otherwise the first address in auth_servers
+// (in v1/v2 configs, this could be either a proxy or an auth server).
+//
+// Config validation guarantees one of the two is set. Returns an empty NetAddr
+// if no addresses are configured, which is unreachable for a validated config.
+func (cfg *Config) ProxyWebAddr() utils.NetAddr {
+	if cfg.Version == defaults.TeleportConfigVersionV3 && !cfg.ProxyServer.IsEmpty() {
+		return cfg.ProxyServer
+	}
+	if authServers := cfg.AuthServerAddresses(); len(authServers) > 0 {
+		return authServers[0]
+	}
+	return utils.NetAddr{}
 }
 
 // Token returns token needed to join the auth server

--- a/lib/service/versioncompat.go
+++ b/lib/service/versioncompat.go
@@ -37,7 +37,7 @@ type clientTooOldError struct {
 }
 
 func (e *clientTooOldError) Error() string {
-	return fmt.Sprintf("Teleport instance is too old. This instance is running v%s. The server requires a minimum version of v%s. To connect anyway pass the --skip-version-check flag.", e.ClientVersion, e.MinVersion)
+	return fmt.Sprintf("This Teleport instance (v%s) is older than the minimum version supported by the cluster (v%s), which may be the cause of this connection failure.", e.ClientVersion, e.MinVersion)
 }
 
 // clientTooNewError indicates this client is a newer major version than the cluster.
@@ -50,47 +50,54 @@ func (e *clientTooNewError) Error() string {
 	return fmt.Sprintf("Teleport instance is too new. This instance is running v%d. The server is running v%d and only supports instances on v%d or v%d. To connect anyway pass the --skip-version-check flag.", e.LocalMajorVersion, e.ClusterMajorVersion, e.ClusterMajorVersion, e.ClusterMajorVersion-1)
 }
 
-// isVersionIncompatible reports whether err indicates this client's version is
-// incompatible with the cluster, either a [clientTooOldError] or [clientTooNewError].
+// isVersionIncompatible reports whether err is a fatal client-side version
+// incompatibility (a [clientTooNewError]).
 func isVersionIncompatible(err error) bool {
-	var tooOld *clientTooOldError
 	var tooNew *clientTooNewError
-	return errors.As(err, &tooOld) || errors.As(err, &tooNew)
+	return errors.As(err, &tooNew)
 }
 
-// enforceVersionPolicy implements this agent's policy for an incompatible cluster
-// version. Any version incompatibility is fatal unless the --skip-version-check
-// flag is provided. Parse errors fail open so malformed version information
-// advertised by the cluster can't block joining.
+// enforceVersionPolicy refuses an instance that is a newer major version than
+// the server. If --skip-version-check is provided, version incompatibility is
+// detected and logged but not enforced. Parse errors fail open to prevent
+// blocking a connection from an otherwise valid instance.
+//
+// Too-old is deliberately not checked here. The server is the authority and
+// will close connections unless it is running with TELEPORT_UNSTABLE_ALLOW_OLD_CLIENTS=yes.
 func (process *TeleportProcess) enforceVersionPolicy(ctx context.Context, info joinclient.VersionInfo) error {
-	for _, err := range []error{
-		checkClientMeetsMinVersion(teleport.Version, info.MinClientVersion),
-		checkClientMeetsMaxVersion(teleport.Version, info.ServerVersion),
-	} {
-		if err == nil {
-			continue
-		}
-		if !isVersionIncompatible(err) {
-			process.logger.WarnContext(ctx,
-				"Could not determine version compatibility with the cluster, skipping check.",
-				"error", err,
-				"min_client_version", info.MinClientVersion,
-				"server_version", info.ServerVersion,
-				"instance_version", teleport.Version,
-			)
-			continue
-		}
-		if process.Config.SkipVersionCheck {
-			process.logger.WarnContext(ctx,
-				"Instance version is incompatible with the cluster, continuing anyway because --skip-version-check flag was provided.",
-				"error", err,
-				"min_client_version", info.MinClientVersion,
-				"server_version", info.ServerVersion,
-				"instance_version", teleport.Version,
-			)
-			continue
-		}
-		return trace.Wrap(err)
+	err := checkClientMeetsMaxVersion(teleport.Version, info.ServerVersion)
+	if err == nil {
+		return nil
+	}
+	if !isVersionIncompatible(err) {
+		process.logger.WarnContext(ctx,
+			"Could not determine version compatibility with the cluster, skipping check.",
+			"error", err,
+			"server_version", info.ServerVersion,
+			"instance_version", teleport.Version,
+		)
+		return nil
+	}
+	if process.Config.SkipVersionCheck {
+		process.logger.WarnContext(ctx,
+			"Instance is a newer major version than the cluster, continuing anyway because --skip-version-check flag was provided.",
+			"error", err,
+			"server_version", info.ServerVersion,
+			"instance_version", teleport.Version,
+		)
+		return nil
+	}
+	return trace.Wrap(err)
+}
+
+// clientTooOld returns a [clientTooOldError] if this instance is older than the
+// server's advertised minimum client version, or nil if it is not (including an
+// empty or unparseable version). A parse error is treated as nil so uncertainty
+// never drives behavior.
+func clientTooOld(minClientVersion string) error {
+	var tooOld *clientTooOldError
+	if errors.As(checkClientMeetsMinVersion(teleport.Version, minClientVersion), &tooOld) {
+		return tooOld
 	}
 	return nil
 }

--- a/lib/service/versioncompat_test.go
+++ b/lib/service/versioncompat_test.go
@@ -61,7 +61,8 @@ func TestCheckClientMeetsMinVersion(t *testing.T) {
 			minVersion:    "2.0.0-aa",
 			assertErr: func(t require.TestingT, err error, _ ...any) {
 				requireClientTooOld(t, err)
-				require.Contains(t, err.Error(), "minimum version of v2.0.0.")
+				require.Contains(t, err.Error(), "v2.0.0")
+				require.NotContains(t, err.Error(), "2.0.0-aa")
 			},
 		},
 		{
@@ -181,20 +182,9 @@ func TestEnforceVersionPolicy(t *testing.T) {
 			assertErr:        require.NoError,
 		},
 		{
-			name:             "client too old",
-			minClientVersion: tooOldMinVersion,
-			assertErr:        requireClientTooOld,
-		},
-		{
 			name:          "client too new",
 			serverVersion: tooNewServerVersion,
 			assertErr:     requireClientTooNew,
-		},
-		{
-			name:             "client too old but skip version check",
-			minClientVersion: tooOldMinVersion,
-			skipVersionCheck: true,
-			assertErr:        require.NoError,
 		},
 		{
 			name:             "client too new but skip version check",
@@ -203,26 +193,27 @@ func TestEnforceVersionPolicy(t *testing.T) {
 			assertErr:        require.NoError,
 		},
 		{
-			// The min parse error must fail open without short-circuiting the
-			// loop before the independent server check produces its verdict.
-			name:             "malformed minimum does not mask client too new",
-			minClientVersion: "not-a-version",
+			// Too-old is only advisory on the client.
+			name:             "client too old is not enforced",
+			minClientVersion: tooOldMinVersion,
+			assertErr:        require.NoError,
+		},
+		{
+			// Too-old must not mask an independent too-new verdict.
+			name:             "client too old does not mask client too new",
+			minClientVersion: tooOldMinVersion,
 			serverVersion:    tooNewServerVersion,
 			assertErr:        requireClientTooNew,
 		},
 		{
-			// The bad server version fails open and must not suppress the
-			// client-too-old verdict from the min check.
-			name:             "client too old with malformed server version",
-			minClientVersion: tooOldMinVersion,
-			serverVersion:    "not-a-version",
-			assertErr:        requireClientTooOld,
+			name:          "malformed server version fails open",
+			serverVersion: "not-a-version",
+			assertErr:     require.NoError,
 		},
 		{
-			name:             "both versions malformed fail open",
-			minClientVersion: "not-a-version",
-			serverVersion:    "not-a-version",
-			assertErr:        require.NoError,
+			name:          "no server version fails open",
+			serverVersion: "",
+			assertErr:     require.NoError,
 		},
 	}
 
@@ -238,6 +229,52 @@ func TestEnforceVersionPolicy(t *testing.T) {
 				ServerVersion:    tc.serverVersion,
 			})
 			tc.assertErr(t, err)
+		})
+	}
+}
+
+func TestClientTooOld(t *testing.T) {
+	t.Parallel()
+
+	tooOldMinVersion := semver.Version{Major: teleport.SemVer().Major + 1}.String()
+
+	cases := []struct {
+		name             string
+		minClientVersion string
+		wantTooOld       bool
+	}{
+		{
+			name:             "instance below minimum",
+			minClientVersion: tooOldMinVersion,
+			wantTooOld:       true,
+		},
+		{
+			name:             "instance meets minimum",
+			minClientVersion: teleport.MinClientSemVer().String(),
+			wantTooOld:       false,
+		},
+		{
+			name:             "no minimum advertised fails open",
+			minClientVersion: "",
+			wantTooOld:       false,
+		},
+		{
+			name:             "malformed minimum fails open",
+			minClientVersion: "not-a-version",
+			wantTooOld:       false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := clientTooOld(tc.minClientVersion)
+			if tc.wantTooOld {
+				var tooOld *clientTooOldError
+				require.ErrorAs(t, err, &tooOld)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Backport #68461 to branch/v18

Changelog: Teleport instances connecting through a proxy that are running a version below the cluster's advertised minimum client version now log a clear version-compatibility error on startup instead of an opaque connection error.

## Manual Test Plan
### Test Environment
Local build. Three `teleport` binaries built at different major versions to induce skew (v18, v19, and v20). For most cases the instance joins once at a compatible version, then restarts against a cluster/version that puts it out of range. The proxy-lag case (instance newer than the proxy) uses a split auth/proxy deployment: a v19 auth with a v18 proxy, and a v19 instance.

### Test Cases
- [x] A compatible instance connects normally
- [x] Instance one major newer than auth is rejected on startup with a clear "too new" message (direct-to-auth)
- [x] Instance one major newer than auth is rejected on startup with a clear "too new" message (via-proxy)
- [x] A too-new rejected instance stops retrying and exits, rather than looping on reconnect
- [x] A too-old instance is not rejected; logs a clear error (with the too-old message) and retries
- [x] `--skip-version-check` lets a too-new instance connect
- [x] Instance newer than the proxy but not newer than auth is rejected on startup (proxy one major behind auth; too-new-vs-proxy check)