### PR TITLE
[v17] Enrich too-old connection failures on instance startup

### DIFF
--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -23,15 +23,12 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
-	"fmt"
 	"log/slog"
 	"path/filepath"
 	"slices"
 	"strings"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
 	"github.com/google/uuid"
 	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
@@ -43,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/breaker"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/client/webclient"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
@@ -94,7 +92,9 @@ func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*
 			return connector, nil
 		} else {
 			switch {
-			case errors.As(connectErr, &invalidVersionErr{}):
+			// A too-new instance is fatal. Retrying is pointless until this
+			// instance downgraded, so surface the error and stop reconnecting.
+			case isVersionIncompatible(connectErr):
 				return nil, trace.Wrap(connectErr)
 			case role == types.RoleNode && strings.Contains(connectErr.Error(), auth.TokenExpiredOrNotFound):
 				process.logger.ErrorContext(process.ExitContext(), "Can not join the cluster as node, the token expired or not found. Regenerate the token and try again.")
@@ -125,15 +125,6 @@ func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*
 	}
 }
 
-type invalidVersionErr struct {
-	ClusterMajorVersion int64
-	LocalMajorVersion   int64
-}
-
-func (i invalidVersionErr) Error() string {
-	return fmt.Sprintf("Teleport instance is too new. This instance is running v%d. The auth server is running v%d and only supports instances on v%d or v%d. To connect anyway pass the --skip-version-check flag.", i.LocalMajorVersion, i.ClusterMajorVersion, i.ClusterMajorVersion, i.ClusterMajorVersion-1)
-}
-
 func (process *TeleportProcess) assertSystemRoles(rolesToAssert []types.SystemRole) (assertionID string, err error) {
 	assertionID = uuid.New().String()
 	irm := process.getInstanceRoleEventMapping()
@@ -159,32 +150,6 @@ func (process *TeleportProcess) assertSystemRoles(rolesToAssert []types.SystemRo
 	}
 
 	return assertionID, nil
-}
-
-func (process *TeleportProcess) authServerTooOld(resp *proto.PingResponse) error {
-	serverVersion, err := semver.NewVersion(resp.ServerVersion)
-	if err != nil {
-		return trace.BadParameter("failed to parse reported auth server version as semver: %v", err)
-	}
-
-	version := teleport.Version
-	if process.Config.Testing.TeleportVersion != "" {
-		version = process.Config.Testing.TeleportVersion
-	}
-	teleportVersion, err := semver.NewVersion(version)
-	if err != nil {
-		return trace.BadParameter("failed to parse local teleport version as semver: %v", err)
-	}
-
-	if serverVersion.Major < teleportVersion.Major {
-		if process.Config.SkipVersionCheck {
-			process.logger.WarnContext(process.ExitContext(), "This instance is too new. Using a newer major version than the Auth server is unsupported and may impair functionality.", "version", teleportVersion.Major, "auth_version", serverVersion.Major, "supported_versions", []int64{serverVersion.Major, serverVersion.Major - 1})
-			return nil
-		}
-		return trace.Wrap(invalidVersionErr{ClusterMajorVersion: serverVersion.Major, LocalMajorVersion: teleportVersion.Major})
-	}
-
-	return nil
 }
 
 // connectToAuthService attempts to login into the auth servers specified in the
@@ -1077,14 +1042,17 @@ func (process *TeleportProcess) getConnector(clientIdentity, serverIdentity *sta
 		}
 	}
 
+	// newClient enforces version compatibility (too-new is fatal, too-old is
+	// detected and surfaced) as part of establishing the connection.
 	clt, pingResponse, err := process.newClient(newConn)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	// Return a helpful message and don't retry if ping was successful,
-	// but the auth server is too old. Auth is not going to get any younger.
-	if err := process.authServerTooOld(pingResponse); err != nil {
+	// Refuse a too-new instance against the auth server's version. Too-old
+	// can't be checked here: the auth gRPC ping carries no minimum client
+	// version, and a too-old client is force-closed before Ping returns.
+	if err := process.enforceVersionPolicy(process.ExitContext(), versionInfo{ServerVersion: pingResponse.ServerVersion}); err != nil {
 		return nil, trace.NewAggregate(err, clt.Close())
 	}
 
@@ -1183,7 +1151,7 @@ func (process *TeleportProcess) newClient(connector *Connector) (*authclient.Cli
 			logger.DebugContext(process.ExitContext(), "Attempting to connect to Auth Server through tunnel.")
 			tunnelClient, pingResponse, err := process.newClientThroughTunnel(tlsConfig, sshClientConfig, connector.Role(), connector.ClientGetPool)
 			if err != nil {
-				return nil, nil, trace.Errorf("Failed to connect to Proxy Server through tunnel: %v", err)
+				return nil, nil, trace.Wrap(err, "Failed to connect to Proxy Server through tunnel")
 			}
 
 			logger.DebugContext(process.ExitContext(), "Connected to Auth Server through tunnel.")
@@ -1213,7 +1181,39 @@ func (process *TeleportProcess) breakerConfigForRole(role types.SystemRole) brea
 	return servicebreaker.InstrumentBreakerForConnector(role, process.Config.CircuitBreakerConfig)
 }
 
+// proxyVersionInfo fetches the proxy's advertised version information. It fails
+// open, returning a zero VersionInfo (and logging) when the address is unknown
+// or the fetch fails, so a transient error can't block connecting.
+func (process *TeleportProcess) proxyVersionInfo() versionInfo {
+	proxyAddr := process.Config.ProxyWebAddr()
+	if proxyAddr.IsEmpty() {
+		return versionInfo{}
+	}
+
+	findResp, err := webclient.Find(&webclient.Config{
+		Context:   process.ExitContext(),
+		ProxyAddr: proxyAddr.String(),
+		Insecure:  lib.IsInsecureDevMode(),
+	})
+	if err != nil {
+		process.logger.WarnContext(process.ExitContext(),
+			"Could not fetch version information from the proxy's web API, skipping the version compatibility check for this connection attempt.",
+			"proxy_addr", proxyAddr.String(),
+			"error", err,
+		)
+		return versionInfo{}
+	}
+	return versionInfo{
+		ServerVersion:    findResp.ServerVersion,
+		MinClientVersion: findResp.MinClientVersion,
+	}
+}
+
 func (process *TeleportProcess) newClientThroughTunnel(tlsConfig *tls.Config, sshConfig *ssh.ClientConfig, role types.SystemRole, getClusterCAs func() (*x509.CertPool, error)) (*authclient.Client, *proto.PingResponse, error) {
+	versionInfo := process.proxyVersionInfo()
+	if err := process.enforceVersionPolicy(process.ExitContext(), versionInfo); err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
 	dialer, err := reversetunnelclient.NewTunnelAuthDialer(reversetunnelclient.TunnelAuthDialerConfig{
 		Resolver:              process.resolver,
 		ClientConfig:          sshConfig,
@@ -1245,7 +1245,14 @@ func (process *TeleportProcess) newClientThroughTunnel(tlsConfig *tls.Config, ss
 	defer cancel()
 	resp, err := clt.Ping(ctx)
 	if err != nil {
-		return nil, nil, trace.NewAggregate(err, clt.Close())
+		return nil, nil, trace.NewAggregate(
+			err,
+			clt.Close(),
+			// A too-old instance is force-closed by the server with an opaque EOF.
+			// Include a too-old error (nil if not too old) so an operator knows
+			// that version compatibility is a potential cause of the failure.
+			clientTooOld(versionInfo.MinClientVersion),
+		)
 	}
 
 	return clt, &resp, nil

--- a/lib/service/connect_test.go
+++ b/lib/service/connect_test.go
@@ -1,0 +1,194 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/client/webclient"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib"
+	"github.com/gravitational/teleport/lib/auth/authtest"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// fakeAuthPingServer is a minimal AuthService gRPC server that only answers
+// Ping, letting tests advertise an arbitrary ServerVersion.
+type fakeAuthPingServer struct {
+	proto.UnimplementedAuthServiceServer
+	serverVersion string
+}
+
+func (f *fakeAuthPingServer) Ping(context.Context, *proto.PingRequest) (*proto.PingResponse, error) {
+	return &proto.PingResponse{ServerVersion: f.serverVersion, ServerFeatures: &proto.Features{}}, nil
+}
+
+// TestGetConnectorVersionCheck covers the startup too-new check for an
+// already-joined instance reconnecting. The fake gRPC server fakes its
+// version while presenting an authtest-issued cert so it passes the
+// connector's TLS check.
+func TestGetConnectorVersionCheck(t *testing.T) {
+	lib.SetInsecureDevMode(true)
+	t.Cleanup(func() { lib.SetInsecureDevMode(false) })
+
+	testAuthServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, testAuthServer.Close()) })
+
+	// nodeID is the connecting client. authID backs the fake server's cert: it
+	// plays the auth server, and an auth-role cert carries the
+	// "*.teleport.cluster.local" SAN the connector's TLS check requires (node
+	// certs don't). Both are issued by the same cluster CA the connector trusts.
+	nodeID, err := authtest.NewServerIdentity(testAuthServer.AuthServer, "test-host-id", types.RoleNode)
+	require.NoError(t, err)
+	authID, err := authtest.NewServerIdentity(testAuthServer.AuthServer, "test-auth-id", types.RoleAuth)
+	require.NoError(t, err)
+	serverTLSConfig, err := authID.TLSConfig(nil)
+	require.NoError(t, err)
+
+	// A server one major behind makes this instance too new.
+	tooNewServerVersion := semver.Version{Major: teleport.SemVer().Major - 1}.String()
+
+	for _, tt := range []struct {
+		name          string
+		serverVersion string
+		skipCheck     bool
+		assertError   require.ErrorAssertionFunc
+	}{
+		{
+			name:          "client too new stops connection",
+			serverVersion: tooNewServerVersion,
+			assertError:   requireClientTooNew,
+		},
+		{
+			// Skip must not just suppress the error but yield a working connector.
+			name:          "client too new with skip version check connects",
+			serverVersion: tooNewServerVersion,
+			skipCheck:     true,
+			assertError:   require.NoError,
+		},
+		{
+			name:          "compatible version connects",
+			serverVersion: teleport.Version,
+			assertError:   require.NoError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			lis, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = lis.Close() })
+
+			grpcServer := grpc.NewServer(grpc.Creds(credentials.NewTLS(serverTLSConfig)))
+			proto.RegisterAuthServiceServer(grpcServer, &fakeAuthPingServer{serverVersion: tt.serverVersion})
+			go grpcServer.Serve(lis)
+			t.Cleanup(grpcServer.Stop)
+
+			// V3 config with an auth address and no proxy routes newClient down
+			// the direct-to-auth path, straight to the fake gRPC server.
+			cfg := servicecfg.MakeDefaultConfig()
+			cfg.Version = defaults.TeleportConfigVersionV3
+			cfg.SkipVersionCheck = tt.skipCheck
+			cfg.SetAuthServerAddress(utils.NetAddr{AddrNetwork: "tcp", Addr: lis.Addr().String()})
+
+			process := &TeleportProcess{
+				Clock:      clockwork.NewRealClock(),
+				Supervisor: &LocalSupervisor{exitContext: t.Context()},
+				Config:     cfg,
+				logger:     utils.NewSlogLoggerForTests(),
+			}
+			// getConnector checks for a reusable instance client for non-instance
+			// roles. A closed ready channel makes that lookup return immediately
+			// instead of blocking, so it falls through to a fresh connection.
+			process.instanceConnectorReady = make(chan struct{})
+			close(process.instanceConnectorReady)
+
+			conn, err := process.getConnector(nodeID, nodeID)
+			if conn != nil {
+				t.Cleanup(func() { _ = conn.Close() })
+			}
+			tt.assertError(t, err)
+		})
+	}
+}
+
+// TestProxyVersionInfo covers the reconnect-path fetch of the proxy's advertised
+// version information, including the fail-open behavior that keeps a transient or
+// unreachable web API from blocking an otherwise-valid instance.
+func TestProxyVersionInfo(t *testing.T) {
+	lib.SetInsecureDevMode(true)
+	t.Cleanup(func() { lib.SetInsecureDevMode(false) })
+
+	newProcess := func(t *testing.T, handler http.HandlerFunc) *TeleportProcess {
+		srv := httptest.NewTLSServer(handler)
+		t.Cleanup(srv.Close)
+		return &TeleportProcess{
+			Supervisor: &LocalSupervisor{exitContext: t.Context()},
+			Config: &servicecfg.Config{
+				Version:     defaults.TeleportConfigVersionV3,
+				ProxyServer: utils.NetAddr{AddrNetwork: "tcp", Addr: strings.TrimPrefix(srv.URL, "https://")},
+			},
+			logger: utils.NewSlogLoggerForTests(),
+		}
+	}
+
+	t.Run("advertised versions are returned", func(t *testing.T) {
+		process := newProcess(t, func(w http.ResponseWriter, _ *http.Request) {
+			require.NoError(t, json.NewEncoder(w).Encode(webclient.PingResponse{
+				ServerVersion:    "1.2.3",
+				MinClientVersion: "1.0.0",
+			}))
+		})
+		require.Equal(t,
+			versionInfo{ServerVersion: "1.2.3", MinClientVersion: "1.0.0"},
+			process.proxyVersionInfo(),
+		)
+	})
+
+	t.Run("fetch failure fails open", func(t *testing.T) {
+		process := newProcess(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		require.Equal(t, versionInfo{}, process.proxyVersionInfo())
+	})
+
+	t.Run("no proxy address fails open", func(t *testing.T) {
+		process := &TeleportProcess{
+			Supervisor: &LocalSupervisor{exitContext: t.Context()},
+			Config:     &servicecfg.Config{},
+			logger:     utils.NewSlogLoggerForTests(),
+		}
+		require.Equal(t, versionInfo{}, process.proxyVersionInfo())
+	})
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1247,12 +1247,7 @@ func NewTeleport(cfg *servicecfg.Config) (_ *TeleportProcess, err error) {
 		}
 	}
 
-	var resolverAddr utils.NetAddr
-	if cfg.Version == defaults.TeleportConfigVersionV3 && !cfg.ProxyServer.IsEmpty() {
-		resolverAddr = cfg.ProxyServer
-	} else {
-		resolverAddr = cfg.AuthServerAddresses()[0]
-	}
+	resolverAddr := cfg.ProxyWebAddr()
 
 	process.resolver, err = reversetunnelclient.CachingResolver(
 		process.ExitContext(),

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -35,7 +35,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
@@ -51,7 +50,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api"
 	"github.com/gravitational/teleport/api/breaker"
 	autoupdatepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -63,7 +61,6 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/storage"
 	"github.com/gravitational/teleport/lib/backend"
-	"github.com/gravitational/teleport/lib/backend/lite"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/cloud/imds"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -984,92 +981,6 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 	require.True(t, ok)
 	supervisor.signalExit()
 	wg.Wait()
-}
-
-func TestTeleportProcessAuthVersionCheck(t *testing.T) {
-	t.Parallel()
-
-	lib.SetInsecureDevMode(true)
-	defer lib.SetInsecureDevMode(false)
-
-	listenAddr := utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
-	token := "join-token"
-
-	// Create Auth Service process.
-	staticTokens, err := types.NewStaticTokens(types.StaticTokensSpecV2{
-		StaticTokens: []types.ProvisionTokenV1{
-			{
-				Roles: []types.SystemRole{
-					types.RoleNode,
-				},
-				Token: token,
-			},
-		},
-	})
-	require.NoError(t, err)
-
-	authCfg := servicecfg.MakeDefaultConfig()
-	authCfg.SetAuthServerAddress(listenAddr)
-	authCfg.DataDir = makeTempDir(t)
-	authCfg.Auth.Enabled = true
-	authCfg.Auth.StaticTokens = staticTokens
-	authCfg.Auth.StorageConfig.Type = lite.GetName()
-	authCfg.Auth.StorageConfig.Params = backend.Params{defaults.BackendPath: filepath.Join(authCfg.DataDir, defaults.BackendDir)}
-	authCfg.Auth.ListenAddr = listenAddr
-	authCfg.Proxy.Enabled = false
-	authCfg.SSH.Enabled = false
-
-	authProc, err := NewTeleport(authCfg)
-	require.NoError(t, err)
-
-	err = authProc.Start()
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		authProc.Close()
-	})
-
-	// Create Node process, pointing at the auth server's local port
-	authListenAddr := authProc.Config.AuthServerAddresses()[0]
-	nodeCfg := servicecfg.MakeDefaultConfig()
-	nodeCfg.SetAuthServerAddress(authListenAddr)
-	nodeCfg.DataDir = makeTempDir(t)
-	nodeCfg.SetToken(token)
-	nodeCfg.Auth.Enabled = false
-	nodeCfg.Proxy.Enabled = false
-	nodeCfg.SSH.Enabled = true
-
-	// Set the Node's major version to be greater than the Auth Service's,
-	// which should make the version check fail.
-	currentVersion := semver.Version{Major: api.VersionMajor + 1}
-	nodeCfg.Testing.TeleportVersion = currentVersion.String()
-
-	t.Run("with version check", func(t *testing.T) {
-		testVersionCheck(t, nodeCfg, false)
-	})
-
-	t.Run("without version check", func(t *testing.T) {
-		testVersionCheck(t, nodeCfg, true)
-	})
-}
-
-func testVersionCheck(t *testing.T, nodeCfg *servicecfg.Config, skipVersionCheck bool) {
-	nodeCfg.SkipVersionCheck = skipVersionCheck
-
-	nodeProc, err := NewTeleport(nodeCfg)
-	require.NoError(t, err)
-
-	c, err := nodeProc.reconnectToAuthService(types.RoleInstance)
-	if skipVersionCheck {
-		require.NoError(t, err)
-		require.NotNil(t, c)
-	} else {
-		require.ErrorAs(t, err, &invalidVersionErr{})
-		require.Nil(t, c)
-	}
-
-	supervisor, ok := nodeProc.Supervisor.(*LocalSupervisor)
-	require.True(t, ok)
-	supervisor.signalExit()
 }
 
 func TestProxyGRPCServers(t *testing.T) {

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -315,9 +315,6 @@ type ConfigTesting struct {
 	// ShutdownTimeout is set to override default shutdown timeout.
 	ShutdownTimeout time.Duration
 
-	// TeleportVersion is used to control the Teleport version in tests.
-	TeleportVersion string
-
 	// KubeMultiplexerIgnoreSelfConnections signals that Proxy TLS server's listener should
 	// require PROXY header if 'proxyProtocolMode: true' even from self connections. Used in tests as all connections are self
 	// connections there.
@@ -433,6 +430,22 @@ func (cfg *Config) SetAuthServerAddresses(addrs []utils.NetAddr) error {
 // SetAuthServerAddress sets the value of authServers to a single value
 func (cfg *Config) SetAuthServerAddress(addr utils.NetAddr) {
 	cfg.authServers = []utils.NetAddr{addr}
+}
+
+// ProxyWebAddr returns the address used to reach the cluster's web API: the
+// configured proxy for v3 configs, otherwise the first address in auth_servers
+// (in v1/v2 configs, this could be either a proxy or an auth server).
+//
+// Config validation guarantees one of the two is set. Returns an empty NetAddr
+// if no addresses are configured, which is unreachable for a validated config.
+func (cfg *Config) ProxyWebAddr() utils.NetAddr {
+	if cfg.Version == defaults.TeleportConfigVersionV3 && !cfg.ProxyServer.IsEmpty() {
+		return cfg.ProxyServer
+	}
+	if authServers := cfg.AuthServerAddresses(); len(authServers) > 0 {
+		return authServers[0]
+	}
+	return utils.NetAddr{}
 }
 
 // Token returns token needed to join the auth server

--- a/lib/service/versioncompat.go
+++ b/lib/service/versioncompat.go
@@ -1,0 +1,143 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// clientTooOldError indicates this client is older than the cluster's minimum
+// client version.
+type clientTooOldError struct {
+	ClientVersion string
+	MinVersion    string
+}
+
+func (e *clientTooOldError) Error() string {
+	return fmt.Sprintf("This Teleport instance (v%s) is older than the minimum version supported by the cluster (v%s), which may be the cause of this connection failure.", e.ClientVersion, e.MinVersion)
+}
+
+// clientTooNewError indicates this client is a newer major version than the cluster.
+type clientTooNewError struct {
+	LocalMajorVersion   int64
+	ClusterMajorVersion int64
+}
+
+func (e *clientTooNewError) Error() string {
+	return fmt.Sprintf("Teleport instance is too new. This instance is running v%d. The server is running v%d and only supports instances on v%d or v%d. To connect anyway pass the --skip-version-check flag.", e.LocalMajorVersion, e.ClusterMajorVersion, e.ClusterMajorVersion, e.ClusterMajorVersion-1)
+}
+
+type versionInfo struct {
+	// ServerVersion is the version of the server.
+	ServerVersion string
+	// MinClientVersion is the minimum client version supported by the server.
+	MinClientVersion string
+}
+
+// isVersionIncompatible reports whether err is a fatal client-side version
+// incompatibility (a [clientTooNewError]).
+func isVersionIncompatible(err error) bool {
+	var tooNew *clientTooNewError
+	return errors.As(err, &tooNew)
+}
+
+// enforceVersionPolicy refuses an instance that is a newer major version than
+// the server. If --skip-version-check is provided, version incompatibility is
+// detected and logged but not enforced. Parse errors fail open to prevent
+// blocking a connection from an otherwise valid instance.
+//
+// Too-old is deliberately not checked here. The server is the authority and
+// will close connections unless it is running with TELEPORT_UNSTABLE_ALLOW_OLD_CLIENTS=yes.
+func (process *TeleportProcess) enforceVersionPolicy(ctx context.Context, info versionInfo) error {
+	err := checkClientMeetsMaxVersion(teleport.Version, info.ServerVersion)
+	if err == nil {
+		return nil
+	}
+	if !isVersionIncompatible(err) {
+		process.logger.WarnContext(ctx,
+			"Could not determine version compatibility with the cluster, skipping check.",
+			"error", err,
+			"server_version", info.ServerVersion,
+			"instance_version", teleport.Version,
+		)
+		return nil
+	}
+	if process.Config.SkipVersionCheck {
+		process.logger.WarnContext(ctx,
+			"Instance is a newer major version than the cluster, continuing anyway because --skip-version-check flag was provided.",
+			"error", err,
+			"server_version", info.ServerVersion,
+			"instance_version", teleport.Version,
+		)
+		return nil
+	}
+	return trace.Wrap(err)
+}
+
+// clientTooOld returns a [clientTooOldError] if this instance is older than the
+// server's advertised minimum client version, or nil if it is not (including an
+// empty or unparseable version). A parse error is treated as nil so uncertainty
+// never drives behavior.
+func clientTooOld(minClientVersion string) error {
+	var tooOld *clientTooOldError
+	if errors.As(checkClientMeetsMinVersion(teleport.Version, minClientVersion), &tooOld) {
+		return tooOld
+	}
+	return nil
+}
+
+func checkClientMeetsMinVersion(clientVersion, minVersion string) error {
+	if minVersion == "" {
+		return nil
+	}
+	// Stripping the pre-release both validates the advertised minimum and yields a
+	// clean version for the user-facing error message.
+	minWithoutPreRelease, err := utils.VersionWithoutPreRelease(minVersion)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if !utils.MeetsMinVersion(clientVersion, minVersion) {
+		return &clientTooOldError{ClientVersion: clientVersion, MinVersion: minWithoutPreRelease}
+	}
+	return nil
+}
+
+func checkClientMeetsMaxVersion(clientVersion, serverVersion string) error {
+	if serverVersion == "" {
+		return nil
+	}
+	client, err := semver.NewVersion(clientVersion)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	server, err := semver.NewVersion(serverVersion)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if server.Major < client.Major {
+		return &clientTooNewError{LocalMajorVersion: client.Major, ClusterMajorVersion: server.Major}
+	}
+	return nil
+}

--- a/lib/service/versioncompat_test.go
+++ b/lib/service/versioncompat_test.go
@@ -1,0 +1,279 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"testing"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func requireClientTooOld(t require.TestingT, err error, _ ...any) {
+	var target *clientTooOldError
+	require.ErrorAs(t, err, &target)
+}
+
+func requireClientTooNew(t require.TestingT, err error, _ ...any) {
+	var target *clientTooNewError
+	require.ErrorAs(t, err, &target)
+}
+
+func TestCheckClientMeetsMinVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		clientVersion string
+		minVersion    string
+		assertErr     require.ErrorAssertionFunc
+	}{
+		{
+			name:          "client too old",
+			clientVersion: "1.0.0",
+			minVersion:    "2.0.0",
+			assertErr:     requireClientTooOld,
+		},
+		{
+			// The pre-release suffix is stripped from the minimum reported in
+			// the error so the user-facing message shows a clean version.
+			name:          "client too old with pre-release minimum",
+			clientVersion: "1.0.0",
+			minVersion:    "2.0.0-aa",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				requireClientTooOld(t, err)
+				require.Contains(t, err.Error(), "v2.0.0")
+				require.NotContains(t, err.Error(), "2.0.0-aa")
+			},
+		},
+		{
+			name:          "pre-release client too old for release minimum",
+			clientVersion: "2.0.0-dev",
+			minVersion:    "2.0.0",
+			assertErr:     requireClientTooOld,
+		},
+		{
+			// The proxy advertises "<major>.0.0-aa" so that pre-release builds
+			// of the minimum version are permitted. This case fails if the
+			// comparison ever switches to the stripped minimum (2.0.0-dev is
+			// below 2.0.0 but above 2.0.0-aa).
+			name:          "pre-release client meets pre-release minimum",
+			clientVersion: "2.0.0-dev",
+			minVersion:    "2.0.0-aa",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "client meets minimum",
+			clientVersion: "2.0.0",
+			minVersion:    "1.0.0",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "client exactly meets minimum",
+			clientVersion: "1.0.0",
+			minVersion:    "1.0.0",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "no minimum advertised",
+			clientVersion: "1.0.0",
+			minVersion:    "",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "malformed minimum returns parse error",
+			clientVersion: "1.0.0",
+			minVersion:    "not-a-version",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				var target *clientTooOldError
+				require.NotErrorAs(t, err, &target)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.assertErr(t, checkClientMeetsMinVersion(tc.clientVersion, tc.minVersion))
+		})
+	}
+}
+
+func TestCheckClientMeetsMaxVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		clientVersion string
+		serverVersion string
+		assertErr     require.ErrorAssertionFunc
+	}{
+		{
+			name:          "client is newer than server",
+			clientVersion: "3.0.0",
+			serverVersion: "2.0.0",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				requireClientTooNew(t, err)
+				require.Contains(t, err.Error(), "supports instances on v2 or v1")
+			},
+		},
+		{
+			name:          "client is older than server",
+			clientVersion: "1.0.0",
+			serverVersion: "2.0.0",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "client and server are the same version",
+			clientVersion: "1.0.0",
+			serverVersion: "1.0.0",
+			assertErr:     require.NoError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.assertErr(t, checkClientMeetsMaxVersion(tc.clientVersion, tc.serverVersion))
+		})
+	}
+}
+
+func TestEnforceVersionPolicy(t *testing.T) {
+	t.Parallel()
+
+	// The skew is induced from the server side: advertise requirements the
+	// running build can't satisfy, so the check trips against the real
+	// teleport.Version without overriding the local version.
+	tooOldMinVersion := semver.Version{Major: teleport.SemVer().Major + 1}.String()
+	tooNewServerVersion := semver.Version{Major: teleport.SemVer().Major - 1}.String()
+
+	cases := []struct {
+		name             string
+		minClientVersion string
+		serverVersion    string
+		skipVersionCheck bool
+		assertErr        require.ErrorAssertionFunc
+	}{
+		{
+			name:             "compatible",
+			minClientVersion: teleport.MinClientSemVer().String(),
+			serverVersion:    teleport.Version,
+			assertErr:        require.NoError,
+		},
+		{
+			name:          "client too new",
+			serverVersion: tooNewServerVersion,
+			assertErr:     requireClientTooNew,
+		},
+		{
+			name:             "client too new but skip version check",
+			serverVersion:    tooNewServerVersion,
+			skipVersionCheck: true,
+			assertErr:        require.NoError,
+		},
+		{
+			// Too-old is only advisory on the client.
+			name:             "client too old is not enforced",
+			minClientVersion: tooOldMinVersion,
+			assertErr:        require.NoError,
+		},
+		{
+			// Too-old must not mask an independent too-new verdict.
+			name:             "client too old does not mask client too new",
+			minClientVersion: tooOldMinVersion,
+			serverVersion:    tooNewServerVersion,
+			assertErr:        requireClientTooNew,
+		},
+		{
+			name:          "malformed server version fails open",
+			serverVersion: "not-a-version",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "no server version fails open",
+			serverVersion: "",
+			assertErr:     require.NoError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			process := &TeleportProcess{
+				Config: &servicecfg.Config{SkipVersionCheck: tc.skipVersionCheck},
+				logger: utils.NewSlogLoggerForTests(),
+			}
+			err := process.enforceVersionPolicy(t.Context(), versionInfo{
+				MinClientVersion: tc.minClientVersion,
+				ServerVersion:    tc.serverVersion,
+			})
+			tc.assertErr(t, err)
+		})
+	}
+}
+
+func TestClientTooOld(t *testing.T) {
+	t.Parallel()
+
+	tooOldMinVersion := semver.Version{Major: teleport.SemVer().Major + 1}.String()
+
+	cases := []struct {
+		name             string
+		minClientVersion string
+		wantTooOld       bool
+	}{
+		{
+			name:             "instance below minimum",
+			minClientVersion: tooOldMinVersion,
+			wantTooOld:       true,
+		},
+		{
+			name:             "instance meets minimum",
+			minClientVersion: teleport.MinClientSemVer().String(),
+			wantTooOld:       false,
+		},
+		{
+			name:             "no minimum advertised fails open",
+			minClientVersion: "",
+			wantTooOld:       false,
+		},
+		{
+			name:             "malformed minimum fails open",
+			minClientVersion: "not-a-version",
+			wantTooOld:       false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := clientTooOld(tc.minClientVersion)
+			if tc.wantTooOld {
+				var tooOld *clientTooOldError
+				require.ErrorAs(t, err, &tooOld)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Backport #68461 to branch/v17

Changelog: Teleport instances connecting through a proxy that are running a version below the cluster's advertised minimum client version now log a clear version-compatibility error on startup instead of an opaque connection error.

## Manual Test Plan
### Test Environment
Local build. Three `teleport` binaries built at different major versions to induce skew (v17, v18, and v19). For most cases the instance joins once at a compatible version, then restarts against a cluster/version that puts it out of range. The proxy-lag case (instance newer than the proxy) uses a split auth/proxy deployment: a v18 auth with a v17 proxy, and a v18 instance.

### Test Cases
- [x] A compatible instance connects normally
- [x] Instance one major newer than auth is rejected on startup with a clear "too new" message (direct-to-auth)
- [x] Instance one major newer than auth is rejected on startup with a clear "too new" message (via-proxy)
- [x] A too-new rejected instance stops retrying and exits, rather than looping on reconnect
- [x] A too-old instance is not rejected; logs a clear error (with the too-old message) and retries
- [x] `--skip-version-check` lets a too-new instance connect
- [x] Instance newer than the proxy but not newer than auth is rejected on startup (proxy one major behind auth; too-new-vs-proxy check)