### PR TITLE
Tweak the required/documented CreateCSR permissions

### DIFF
--- a/api/gen/proto/go/teleport/subca/v1/subca_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/subca/v1/subca_service_grpc.pb.go
@@ -83,7 +83,8 @@ type SubCAServiceClient interface {
 	// instead it will use local keys. In this case, each Auth server must be
 	// contacted independently to create their corresponding CSRs.
 	//
-	// CreateCSR requires cert_authority_override:create+update permissions.
+	// CreateCSR requires the cert_authority_override:create permission, which
+	// reflects its powers to write PendingCSRRequest resources to the backend.
 	CreateCSR(ctx context.Context, in *CreateCSRRequest, opts ...grpc.CallOption) (*CreateCSRResponse, error)
 	// CreateCertAuthorityOverride creates a CertAuthorityOverride resource.
 	//
@@ -292,7 +293,8 @@ type SubCAServiceServer interface {
 	// instead it will use local keys. In this case, each Auth server must be
 	// contacted independently to create their corresponding CSRs.
 	//
-	// CreateCSR requires cert_authority_override:create+update permissions.
+	// CreateCSR requires the cert_authority_override:create permission, which
+	// reflects its powers to write PendingCSRRequest resources to the backend.
 	CreateCSR(context.Context, *CreateCSRRequest) (*CreateCSRResponse, error)
 	// CreateCertAuthorityOverride creates a CertAuthorityOverride resource.
 	//

--- a/api/proto/teleport/subca/v1/subca_service.proto
+++ b/api/proto/teleport/subca/v1/subca_service.proto
@@ -61,7 +61,8 @@ service SubCAService {
   // instead it will use local keys. In this case, each Auth server must be
   // contacted independently to create their corresponding CSRs.
   //
-  // CreateCSR requires cert_authority_override:create+update permissions.
+  // CreateCSR requires the cert_authority_override:create permission, which
+  // reflects its powers to write PendingCSRRequest resources to the backend.
   rpc CreateCSR(CreateCSRRequest) returns (CreateCSRResponse);
 
   // CreateCertAuthorityOverride creates a CertAuthorityOverride resource.


### PR DESCRIPTION
Require only "cert_authority_override:create" for CreateCSR. The "create+update" requirement is a leftover from the initial implementation where it would watch CertAuthorityOverride instances; only "create" seem sufficient now.

https://github.com/gravitational/teleport.e/issues/7675