### PR TITLE
Populate per-dimension principal sets in unified resources listings

### DIFF
--- a/api/accessrequest/access_request.go
+++ b/api/accessrequest/access_request.go
@@ -44,7 +44,7 @@ func GetResourcesByKind(ctx context.Context, clt client.ListResourcesClient, req
 	}
 	resources := make([]types.ResourceWithLabels, 0, len(results))
 	for _, result := range results {
-		leafResource, err := mapListResourcesResultToLeafResource(result, kind)
+		leafResource, err := MapListResourcesResultToLeafResource(result, kind)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -182,12 +182,13 @@ func mapResourceKindToListResourcesType(kind string) string {
 	}
 }
 
-// mapListResourcesResultToLeafResource is the inverse of
-// MapResourceKindToListResourcesType, after the ListResources call it maps the
-// result back to the kind we really want. `hint` should be the name of the
-// desired resource kind, used to disambiguate normal SSH nodes and kubernetes
-// services which are both returned as `types.Server`.
-func mapListResourcesResultToLeafResource(resource types.ResourceWithLabels, hint string) (types.ResourceWithLabels, error) {
+// MapListResourcesResultToLeafResource is the inverse of
+// mapResourceKindToListResourcesType; after the ListResources call it maps the
+// result back to the kind we really want, unwrapping server wrappers
+// (AppServer to App, DatabaseServer to Database, KubeServer to KubeCluster).
+// hint should be the name of the desired resource kind, used to disambiguate
+// SSH nodes from kubernetes services which are both returned as types.Server.
+func MapListResourcesResultToLeafResource(resource types.ResourceWithLabels, hint string) (types.ResourceWithLabels, error) {
 	switch r := resource.(type) {
 	case types.AppServer:
 		return r.GetApp(), nil

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -4731,17 +4731,43 @@ type ResourcePage[T types.ResourceWithLabels] struct {
 	NextKey string
 }
 
+// resourcePrincipalSets converts proto principal sets to their api/types form.
+func resourcePrincipalSets(sets []*proto.ResourcePrincipalSet) []types.ResourcePrincipalSet {
+	if len(sets) == 0 {
+		return nil
+	}
+	out := make([]types.ResourcePrincipalSet, 0, len(sets))
+	for _, s := range sets {
+		if s == nil {
+			continue
+		}
+		rps := types.ResourcePrincipalSet{PrincipalType: s.PrincipalType, Granted: s.Granted, Requestable: s.Requestable}
+		for _, br := range s.ByRole {
+			if br == nil {
+				continue
+			}
+			rps.ByRole = append(rps.ByRole, types.RolePrincipalValues{
+				Role:            br.Role,
+				RequiresRequest: br.RequiresRequest,
+				Values:          br.Values,
+			})
+		}
+		out = append(out, rps)
+	}
+	return out
+}
+
 // convertEnrichedResource extracts the resource and any enriched information from the
 // PaginatedResource returned from the rpc ListUnifiedResources.
 func convertEnrichedResource(resource *proto.PaginatedResource) (*types.EnrichedResource, error) {
 	if r := resource.GetNode(); r != nil {
-		return &types.EnrichedResource{ResourceWithLabels: r, Logins: resource.Logins, RequiresRequest: resource.RequiresRequest}, nil
+		return &types.EnrichedResource{ResourceWithLabels: r, Logins: resource.Logins, Principals: resourcePrincipalSets(resource.Principals), RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetDatabaseServer(); r != nil {
 		return &types.EnrichedResource{ResourceWithLabels: r, RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetDatabaseService(); r != nil {
 		return &types.EnrichedResource{ResourceWithLabels: r, RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetWindowsDesktop(); r != nil {
-		return &types.EnrichedResource{ResourceWithLabels: r, Logins: resource.Logins, RequiresRequest: resource.RequiresRequest}, nil
+		return &types.EnrichedResource{ResourceWithLabels: r, Logins: resource.Logins, Principals: resourcePrincipalSets(resource.Principals), RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetWindowsDesktopService(); r != nil {
 		return &types.EnrichedResource{ResourceWithLabels: r, RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetKubeCluster(); r != nil {
@@ -4751,14 +4777,14 @@ func convertEnrichedResource(resource *proto.PaginatedResource) (*types.Enriched
 	} else if r := resource.GetUserGroup(); r != nil {
 		return &types.EnrichedResource{ResourceWithLabels: r, RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetAppServer(); r != nil {
-		return &types.EnrichedResource{ResourceWithLabels: r, Logins: resource.Logins, RequiresRequest: resource.RequiresRequest}, nil
+		return &types.EnrichedResource{ResourceWithLabels: r, Logins: resource.Logins, Principals: resourcePrincipalSets(resource.Principals), RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetSAMLIdPServiceProvider(); r != nil {
 		return &types.EnrichedResource{ResourceWithLabels: r, RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetGitServer(); r != nil {
 		return &types.EnrichedResource{ResourceWithLabels: r, RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetLinuxDesktop(); r != nil {
 		desktop := proto.UnpackLinuxDesktop(r)
-		return &types.EnrichedResource{ResourceWithLabels: desktop, Logins: resource.Logins, RequiresRequest: resource.RequiresRequest}, nil
+		return &types.EnrichedResource{ResourceWithLabels: desktop, Logins: resource.Logins, Principals: resourcePrincipalSets(resource.Principals), RequiresRequest: resource.RequiresRequest}, nil
 	} else {
 		return nil, trace.BadParameter("received unsupported resource %T", resource.Resource)
 	}
@@ -4885,7 +4911,7 @@ func GetEnrichedResourcePage(ctx context.Context, clt GetResourcesClient, req *p
 				return out, trace.NotImplemented("resource type %s does not support pagination", req.ResourceType)
 			}
 
-			out.Resources = append(out.Resources, &types.EnrichedResource{ResourceWithLabels: resource, Logins: respResource.Logins})
+			out.Resources = append(out.Resources, &types.EnrichedResource{ResourceWithLabels: resource, Logins: respResource.Logins, Principals: resourcePrincipalSets(respResource.Principals)})
 		}
 
 		out.NextKey = resp.NextKey

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -4754,8 +4754,8 @@ type ResourcePage[T types.ResourceWithLabels] struct {
 	NextKey string
 }
 
-// resourcePrincipalSets converts proto principal sets to their api/types form.
-func resourcePrincipalSets(sets []*proto.ResourcePrincipalSet) []types.ResourcePrincipalSet {
+// convertResourcePrincipalSets converts proto principal sets to their api/types form.
+func convertResourcePrincipalSets(sets []*proto.ResourcePrincipalSet) []types.ResourcePrincipalSet {
 	if len(sets) == 0 {
 		return nil
 	}
@@ -4784,13 +4784,13 @@ func resourcePrincipalSets(sets []*proto.ResourcePrincipalSet) []types.ResourceP
 // PaginatedResource returned from the rpc ListUnifiedResources.
 func convertEnrichedResource(resource *proto.PaginatedResource) (*types.EnrichedResource, error) {
 	if r := resource.GetNode(); r != nil {
-		return &types.EnrichedResource{ResourceWithLabels: r, Logins: resource.Logins, Principals: resourcePrincipalSets(resource.Principals), RequiresRequest: resource.RequiresRequest}, nil
+		return &types.EnrichedResource{ResourceWithLabels: r, Logins: resource.Logins, Principals: convertResourcePrincipalSets(resource.Principals), RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetDatabaseServer(); r != nil {
 		return &types.EnrichedResource{ResourceWithLabels: r, RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetDatabaseService(); r != nil {
 		return &types.EnrichedResource{ResourceWithLabels: r, RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetWindowsDesktop(); r != nil {
-		return &types.EnrichedResource{ResourceWithLabels: r, Logins: resource.Logins, Principals: resourcePrincipalSets(resource.Principals), RequiresRequest: resource.RequiresRequest}, nil
+		return &types.EnrichedResource{ResourceWithLabels: r, Logins: resource.Logins, Principals: convertResourcePrincipalSets(resource.Principals), RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetWindowsDesktopService(); r != nil {
 		return &types.EnrichedResource{ResourceWithLabels: r, RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetKubeCluster(); r != nil {
@@ -4800,14 +4800,14 @@ func convertEnrichedResource(resource *proto.PaginatedResource) (*types.Enriched
 	} else if r := resource.GetUserGroup(); r != nil {
 		return &types.EnrichedResource{ResourceWithLabels: r, RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetAppServer(); r != nil {
-		return &types.EnrichedResource{ResourceWithLabels: r, Logins: resource.Logins, Principals: resourcePrincipalSets(resource.Principals), RequiresRequest: resource.RequiresRequest}, nil
+		return &types.EnrichedResource{ResourceWithLabels: r, Logins: resource.Logins, Principals: convertResourcePrincipalSets(resource.Principals), RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetSAMLIdPServiceProvider(); r != nil {
 		return &types.EnrichedResource{ResourceWithLabels: r, RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetGitServer(); r != nil {
 		return &types.EnrichedResource{ResourceWithLabels: r, RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetLinuxDesktop(); r != nil {
 		desktop := proto.UnpackLinuxDesktop(r)
-		return &types.EnrichedResource{ResourceWithLabels: desktop, Logins: resource.Logins, Principals: resourcePrincipalSets(resource.Principals), RequiresRequest: resource.RequiresRequest}, nil
+		return &types.EnrichedResource{ResourceWithLabels: desktop, Logins: resource.Logins, Principals: convertResourcePrincipalSets(resource.Principals), RequiresRequest: resource.RequiresRequest}, nil
 	} else {
 		return nil, trace.BadParameter("received unsupported resource %T", resource.Resource)
 	}
@@ -4934,7 +4934,7 @@ func GetEnrichedResourcePage(ctx context.Context, clt GetResourcesClient, req *p
 				return out, trace.NotImplemented("resource type %s does not support pagination", req.ResourceType)
 			}
 
-			out.Resources = append(out.Resources, &types.EnrichedResource{ResourceWithLabels: resource, Logins: respResource.Logins, Principals: resourcePrincipalSets(respResource.Principals)})
+			out.Resources = append(out.Resources, &types.EnrichedResource{ResourceWithLabels: resource, Logins: respResource.Logins, Principals: convertResourcePrincipalSets(respResource.Principals)})
 		}
 
 		out.NextKey = resp.NextKey

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -4754,17 +4754,43 @@ type ResourcePage[T types.ResourceWithLabels] struct {
 	NextKey string
 }
 
+// resourcePrincipalSets converts proto principal sets to their api/types form.
+func resourcePrincipalSets(sets []*proto.ResourcePrincipalSet) []types.ResourcePrincipalSet {
+	if len(sets) == 0 {
+		return nil
+	}
+	out := make([]types.ResourcePrincipalSet, 0, len(sets))
+	for _, s := range sets {
+		if s == nil {
+			continue
+		}
+		rps := types.ResourcePrincipalSet{PrincipalType: s.PrincipalType, Granted: s.Granted, Requestable: s.Requestable}
+		for _, br := range s.ByRole {
+			if br == nil {
+				continue
+			}
+			rps.ByRole = append(rps.ByRole, types.RolePrincipalValues{
+				Role:            br.Role,
+				RequiresRequest: br.RequiresRequest,
+				Values:          br.Values,
+			})
+		}
+		out = append(out, rps)
+	}
+	return out
+}
+
 // convertEnrichedResource extracts the resource and any enriched information from the
 // PaginatedResource returned from the rpc ListUnifiedResources.
 func convertEnrichedResource(resource *proto.PaginatedResource) (*types.EnrichedResource, error) {
 	if r := resource.GetNode(); r != nil {
-		return &types.EnrichedResource{ResourceWithLabels: r, Logins: resource.Logins, RequiresRequest: resource.RequiresRequest}, nil
+		return &types.EnrichedResource{ResourceWithLabels: r, Logins: resource.Logins, Principals: resourcePrincipalSets(resource.Principals), RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetDatabaseServer(); r != nil {
 		return &types.EnrichedResource{ResourceWithLabels: r, RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetDatabaseService(); r != nil {
 		return &types.EnrichedResource{ResourceWithLabels: r, RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetWindowsDesktop(); r != nil {
-		return &types.EnrichedResource{ResourceWithLabels: r, Logins: resource.Logins, RequiresRequest: resource.RequiresRequest}, nil
+		return &types.EnrichedResource{ResourceWithLabels: r, Logins: resource.Logins, Principals: resourcePrincipalSets(resource.Principals), RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetWindowsDesktopService(); r != nil {
 		return &types.EnrichedResource{ResourceWithLabels: r, RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetKubeCluster(); r != nil {
@@ -4774,14 +4800,14 @@ func convertEnrichedResource(resource *proto.PaginatedResource) (*types.Enriched
 	} else if r := resource.GetUserGroup(); r != nil {
 		return &types.EnrichedResource{ResourceWithLabels: r, RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetAppServer(); r != nil {
-		return &types.EnrichedResource{ResourceWithLabels: r, Logins: resource.Logins, RequiresRequest: resource.RequiresRequest}, nil
+		return &types.EnrichedResource{ResourceWithLabels: r, Logins: resource.Logins, Principals: resourcePrincipalSets(resource.Principals), RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetSAMLIdPServiceProvider(); r != nil {
 		return &types.EnrichedResource{ResourceWithLabels: r, RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetGitServer(); r != nil {
 		return &types.EnrichedResource{ResourceWithLabels: r, RequiresRequest: resource.RequiresRequest}, nil
 	} else if r := resource.GetLinuxDesktop(); r != nil {
 		desktop := proto.UnpackLinuxDesktop(r)
-		return &types.EnrichedResource{ResourceWithLabels: desktop, Logins: resource.Logins, RequiresRequest: resource.RequiresRequest}, nil
+		return &types.EnrichedResource{ResourceWithLabels: desktop, Logins: resource.Logins, Principals: resourcePrincipalSets(resource.Principals), RequiresRequest: resource.RequiresRequest}, nil
 	} else {
 		return nil, trace.BadParameter("received unsupported resource %T", resource.Resource)
 	}
@@ -4908,7 +4934,7 @@ func GetEnrichedResourcePage(ctx context.Context, clt GetResourcesClient, req *p
 				return out, trace.NotImplemented("resource type %s does not support pagination", req.ResourceType)
 			}
 
-			out.Resources = append(out.Resources, &types.EnrichedResource{ResourceWithLabels: resource, Logins: respResource.Logins})
+			out.Resources = append(out.Resources, &types.EnrichedResource{ResourceWithLabels: resource, Logins: respResource.Logins, Principals: resourcePrincipalSets(respResource.Principals)})
 		}
 
 		out.NextKey = resp.NextKey

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -749,6 +749,17 @@ func TestGetUnifiedResourcesWithLogins(t *testing.T) {
 				{
 					Resource: &proto.PaginatedResource_Node{Node: &types.ServerV2{}},
 					Logins:   []string{"alice", "bob"},
+					Principals: []*proto.ResourcePrincipalSet{
+						{
+							PrincipalType: types.PrincipalTypeLogins,
+							Granted:       []string{"alice"},
+							Requestable:   []string{"bob"},
+							ByRole: []*proto.RolePrincipalValues{
+								{Role: "access", Values: []string{"alice"}},
+								{Role: "editor", RequiresRequest: true, Values: []string{"bob"}},
+							},
+						},
+					},
 				},
 				{
 					Resource: &proto.PaginatedResource_WindowsDesktop{WindowsDesktop: &types.WindowsDesktopV3{}},
@@ -757,6 +768,9 @@ func TestGetUnifiedResourcesWithLogins(t *testing.T) {
 				{
 					Resource: &proto.PaginatedResource_AppServer{AppServer: &types.AppServerV3{}},
 					Logins:   []string{"llama"},
+					Principals: []*proto.ResourcePrincipalSet{
+						{PrincipalType: types.PrincipalTypeRoleARNs, Granted: []string{"llama"}},
+					},
 				},
 			},
 		},
@@ -773,14 +787,35 @@ func TestGetUnifiedResourcesWithLogins(t *testing.T) {
 
 	require.Len(t, resources, len(clt.resp.Resources))
 
+	principalTypes := func(sets []types.ResourcePrincipalSet) []*proto.ResourcePrincipalSet {
+		if len(sets) == 0 {
+			return nil
+		}
+		out := make([]*proto.ResourcePrincipalSet, 0, len(sets))
+		for _, s := range sets {
+			ps := &proto.ResourcePrincipalSet{PrincipalType: s.PrincipalType, Granted: s.Granted, Requestable: s.Requestable}
+			for _, br := range s.ByRole {
+				ps.ByRole = append(ps.ByRole, &proto.RolePrincipalValues{
+					Role:            br.Role,
+					RequiresRequest: br.RequiresRequest,
+					Values:          br.Values,
+				})
+			}
+			out = append(out, ps)
+		}
+		return out
+	}
 	for _, enriched := range resources {
 		switch enriched.ResourceWithLabels.(type) {
 		case *types.ServerV2:
 			assert.Equal(t, enriched.Logins, clt.resp.Resources[0].Logins)
+			assert.Equal(t, principalTypes(enriched.Principals), clt.resp.Resources[0].Principals)
 		case *types.WindowsDesktopV3:
 			assert.Equal(t, enriched.Logins, clt.resp.Resources[1].Logins)
+			assert.Equal(t, principalTypes(enriched.Principals), clt.resp.Resources[1].Principals)
 		case *types.AppServerV3:
 			assert.Equal(t, enriched.Logins, clt.resp.Resources[2].Logins)
+			assert.Equal(t, principalTypes(enriched.Principals), clt.resp.Resources[2].Principals)
 		}
 	}
 }

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -787,37 +787,60 @@ func TestGetUnifiedResourcesWithLogins(t *testing.T) {
 
 	require.Len(t, resources, len(clt.resp.Resources))
 
-	principalTypes := func(sets []types.ResourcePrincipalSet) []*proto.ResourcePrincipalSet {
-		if len(sets) == 0 {
-			return nil
-		}
-		out := make([]*proto.ResourcePrincipalSet, 0, len(sets))
-		for _, s := range sets {
-			ps := &proto.ResourcePrincipalSet{PrincipalType: s.PrincipalType, Granted: s.Granted, Requestable: s.Requestable}
-			for _, br := range s.ByRole {
-				ps.ByRole = append(ps.ByRole, &proto.RolePrincipalValues{
-					Role:            br.Role,
-					RequiresRequest: br.RequiresRequest,
-					Values:          br.Values,
-				})
-			}
-			out = append(out, ps)
-		}
-		return out
-	}
 	for _, enriched := range resources {
 		switch enriched.ResourceWithLabels.(type) {
 		case *types.ServerV2:
-			assert.Equal(t, enriched.Logins, clt.resp.Resources[0].Logins)
-			assert.Equal(t, principalTypes(enriched.Principals), clt.resp.Resources[0].Principals)
+			assert.Equal(t, clt.resp.Resources[0].Logins, enriched.Logins)
+			assert.Equal(t, []types.ResourcePrincipalSet{{
+				PrincipalType: types.PrincipalTypeLogins,
+				Granted:       []string{"alice"},
+				Requestable:   []string{"bob"},
+				ByRole: []types.RolePrincipalValues{
+					{Role: "access", Values: []string{"alice"}},
+					{Role: "editor", RequiresRequest: true, Values: []string{"bob"}},
+				},
+			}}, enriched.Principals)
 		case *types.WindowsDesktopV3:
-			assert.Equal(t, enriched.Logins, clt.resp.Resources[1].Logins)
-			assert.Equal(t, principalTypes(enriched.Principals), clt.resp.Resources[1].Principals)
+			assert.Equal(t, clt.resp.Resources[1].Logins, enriched.Logins)
+			assert.Empty(t, enriched.Principals)
 		case *types.AppServerV3:
-			assert.Equal(t, enriched.Logins, clt.resp.Resources[2].Logins)
-			assert.Equal(t, principalTypes(enriched.Principals), clt.resp.Resources[2].Principals)
+			assert.Equal(t, clt.resp.Resources[2].Logins, enriched.Logins)
+			assert.Equal(t, []types.ResourcePrincipalSet{{
+				PrincipalType: types.PrincipalTypeRoleARNs,
+				Granted:       []string{"llama"},
+			}}, enriched.Principals)
 		}
 	}
+}
+
+// TestConvertResourcePrincipalSets validates the conversion of proto principal
+// sets to their api/types form, including per-role attribution and nil entries.
+func TestConvertResourcePrincipalSets(t *testing.T) {
+	require.Nil(t, convertResourcePrincipalSets(nil))
+	require.Nil(t, convertResourcePrincipalSets([]*proto.ResourcePrincipalSet{}))
+
+	converted := convertResourcePrincipalSets([]*proto.ResourcePrincipalSet{
+		nil,
+		{
+			PrincipalType: types.PrincipalTypeLogins,
+			Granted:       []string{"alice"},
+			Requestable:   []string{"bob"},
+			ByRole: []*proto.RolePrincipalValues{
+				nil,
+				{Role: "access", Values: []string{"alice"}},
+				{Role: "editor", RequiresRequest: true, Values: []string{"bob"}},
+			},
+		},
+	})
+	require.Equal(t, []types.ResourcePrincipalSet{{
+		PrincipalType: types.PrincipalTypeLogins,
+		Granted:       []string{"alice"},
+		Requestable:   []string{"bob"},
+		ByRole: []types.RolePrincipalValues{
+			{Role: "access", Values: []string{"alice"}},
+			{Role: "editor", RequiresRequest: true, Values: []string{"bob"}},
+		},
+	}}, converted)
 }
 
 func TestUploadEncryptedRecording(t *testing.T) {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1590,6 +1590,25 @@ func (l *unifiedResourceLister) getAllowedLogins(resource services.AccessCheckab
 	}
 }
 
+// getLogins returns the principals allowed on a resource. `all` is the full set
+// from the lister's checker; `granted`, only computed when withGranted is set,
+// is the subset allowed by the user's current roles. When no search_as_roles
+// widen the listing, both sets are equal and no extra computation is performed.
+func (l *unifiedResourceLister) getLogins(withGranted bool, resource services.AccessCheckable) (all, granted []string, err error) {
+	all, err = l.getAllowedLogins(resource)
+	if err != nil || !withGranted {
+		return all, nil, trace.Wrap(err)
+	}
+	if l.requestableAccessChecker == nil {
+		return all, all, nil
+	}
+	granted, err = l.accessChecker.GetAllowedLoginsForResource(resource)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return all, granted, nil
+}
+
 func (a *ServerWithRoles) checkAction(namespace, resourceKind string, verb string, extraVerbs ...string) error {
 	switch resourceKind {
 	case types.KindIdentityCenterAccount, types.KindIdentityCenterAccountAssignment:
@@ -1770,61 +1789,63 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 	}
 
 	if req.IncludeLogins {
+		populatePrincipals := req.IncludeRequestable || resourceLister.requestableAccessChecker == nil
 		for _, r := range paginatedResources {
-			if n := r.GetNode(); n != nil {
-				logins, err := resourceLister.getAllowedLogins(n)
-				if err != nil {
-					a.authServer.logger.WarnContext(ctx, "Unable to determine logins for node",
-						"error", err,
-						"resource", n.GetName(),
-					)
-					continue
-				}
-				r.Logins = logins
-			} else if d := r.GetWindowsDesktop(); d != nil {
-				logins, err := resourceLister.getAllowedLogins(d)
-				if err != nil {
-					a.authServer.logger.WarnContext(ctx, "Unable to determine logins for desktop",
-						"error", err,
-						"resource", d.GetName(),
-					)
-					continue
-				}
-				r.Logins = logins
-			} else if d := r.GetLinuxDesktop(); d != nil {
-				desktop := proto.UnpackLinuxDesktop(d)
-				logins, err := resourceLister.getAllowedLogins(desktop)
-				if err != nil {
-					a.authServer.logger.WarnContext(ctx, "Unable to determine logins for Linux desktop",
-						"error", err,
-						"resource", desktop.GetName(),
-					)
-					continue
-				}
-				r.Logins = logins
-			} else if d := r.GetAppServer(); d != nil {
+			var checkable services.AccessCheckable
+			var principalType string
+			switch {
+			case r.GetNode() != nil:
+				checkable = r.GetNode()
+				principalType = types.PrincipalTypeLogins
+			case r.GetWindowsDesktop() != nil:
+				checkable = r.GetWindowsDesktop()
+			case r.GetLinuxDesktop() != nil:
+				checkable = proto.UnpackLinuxDesktop(r.GetLinuxDesktop())
+			case r.GetAppServer() != nil:
+				app := r.GetAppServer().GetApp()
 				// Apps representing an Identity Center Account have a collection of Permission Sets
 				// that can be thought of as individually-addressable sub-resources. To present a consitent
 				// view of the account we check access for each Permission Set, filter out those that have
 				// no access and treat the whole app as requiring an access request if _any_ of the contained
 				// permission sets require one.
-				if err := a.filterICPermissionSets(r, d.GetApp(), resourceLister); err != nil {
+				if err := a.filterICPermissionSets(r, app, resourceLister); err != nil {
 					a.authServer.logger.WarnContext(ctx, "Unable to filter",
 						"error", err,
-						"resource", d.GetApp().GetName(),
+						"resource", app.GetName(),
 					)
 					continue
 				}
+				checkable = app
+				principalType = types.PrincipalTypeRoleARNs
+			default:
+				continue
+			}
 
-				logins, err := resourceLister.getAllowedLogins(d.GetApp())
-				if err != nil {
-					a.authServer.logger.WarnContext(ctx, "Unable to determine logins for app",
-						"error", err,
-						"resource", d.GetApp().GetName(),
-					)
-					continue
+			all, granted, err := resourceLister.getLogins(populatePrincipals && principalType != "", checkable)
+			if err != nil {
+				a.authServer.logger.WarnContext(ctx, "Unable to determine logins for resource",
+					"error", err,
+					"resource", checkable.GetName(),
+				)
+				continue
+			}
+			r.Logins = all
+			if principalType != "" && populatePrincipals && len(all) > 0 {
+				grantedSet := make(map[string]struct{}, len(granted))
+				for _, v := range granted {
+					grantedSet[v] = struct{}{}
 				}
-				r.Logins = logins
+				var requestable []string
+				for _, v := range all {
+					if _, ok := grantedSet[v]; !ok {
+						requestable = append(requestable, v)
+					}
+				}
+				r.Principals = []*proto.ResourcePrincipalSet{{
+					PrincipalType: principalType,
+					Granted:       granted,
+					Requestable:   requestable,
+				}}
 			}
 		}
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1627,6 +1627,25 @@ func (l *unifiedResourceLister) getAllowedLogins(resource services.AccessCheckab
 	}
 }
 
+// getLogins returns the principals allowed on a resource. `all` is the full set
+// from the lister's checker; `granted`, only computed when withGranted is set,
+// is the subset allowed by the user's current roles. When no search_as_roles
+// widen the listing, both sets are equal and no extra computation is performed.
+func (l *unifiedResourceLister) getLogins(withGranted bool, resource services.AccessCheckable) (all, granted []string, err error) {
+	all, err = l.getAllowedLogins(resource)
+	if err != nil || !withGranted {
+		return all, nil, trace.Wrap(err)
+	}
+	if l.requestableAccessChecker == nil {
+		return all, all, nil
+	}
+	granted, err = l.accessChecker.GetAllowedLoginsForResource(resource)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return all, granted, nil
+}
+
 func (a *ServerWithRoles) checkAction(namespace, resourceKind string, verb string, extraVerbs ...string) error {
 	switch resourceKind {
 	case types.KindIdentityCenterAccount, types.KindIdentityCenterAccountAssignment:
@@ -1807,61 +1826,63 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 	}
 
 	if req.IncludeLogins {
+		populatePrincipals := req.IncludeRequestable || resourceLister.requestableAccessChecker == nil
 		for _, r := range paginatedResources {
-			if n := r.GetNode(); n != nil {
-				logins, err := resourceLister.getAllowedLogins(n)
-				if err != nil {
-					a.authServer.logger.WarnContext(ctx, "Unable to determine logins for node",
-						"error", err,
-						"resource", n.GetName(),
-					)
-					continue
-				}
-				r.Logins = logins
-			} else if d := r.GetWindowsDesktop(); d != nil {
-				logins, err := resourceLister.getAllowedLogins(d)
-				if err != nil {
-					a.authServer.logger.WarnContext(ctx, "Unable to determine logins for desktop",
-						"error", err,
-						"resource", d.GetName(),
-					)
-					continue
-				}
-				r.Logins = logins
-			} else if d := r.GetLinuxDesktop(); d != nil {
-				desktop := proto.UnpackLinuxDesktop(d)
-				logins, err := resourceLister.getAllowedLogins(desktop)
-				if err != nil {
-					a.authServer.logger.WarnContext(ctx, "Unable to determine logins for Linux desktop",
-						"error", err,
-						"resource", desktop.GetName(),
-					)
-					continue
-				}
-				r.Logins = logins
-			} else if d := r.GetAppServer(); d != nil {
+			var checkable services.AccessCheckable
+			var principalType string
+			switch {
+			case r.GetNode() != nil:
+				checkable = r.GetNode()
+				principalType = types.PrincipalTypeLogins
+			case r.GetWindowsDesktop() != nil:
+				checkable = r.GetWindowsDesktop()
+			case r.GetLinuxDesktop() != nil:
+				checkable = proto.UnpackLinuxDesktop(r.GetLinuxDesktop())
+			case r.GetAppServer() != nil:
+				app := r.GetAppServer().GetApp()
 				// Apps representing an Identity Center Account have a collection of Permission Sets
 				// that can be thought of as individually-addressable sub-resources. To present a consitent
 				// view of the account we check access for each Permission Set, filter out those that have
 				// no access and treat the whole app as requiring an access request if _any_ of the contained
 				// permission sets require one.
-				if err := a.filterICPermissionSets(r, d.GetApp(), resourceLister); err != nil {
+				if err := a.filterICPermissionSets(r, app, resourceLister); err != nil {
 					a.authServer.logger.WarnContext(ctx, "Unable to filter",
 						"error", err,
-						"resource", d.GetApp().GetName(),
+						"resource", app.GetName(),
 					)
 					continue
 				}
+				checkable = app
+				principalType = types.PrincipalTypeRoleARNs
+			default:
+				continue
+			}
 
-				logins, err := resourceLister.getAllowedLogins(d.GetApp())
-				if err != nil {
-					a.authServer.logger.WarnContext(ctx, "Unable to determine logins for app",
-						"error", err,
-						"resource", d.GetApp().GetName(),
-					)
-					continue
+			all, granted, err := resourceLister.getLogins(populatePrincipals && principalType != "", checkable)
+			if err != nil {
+				a.authServer.logger.WarnContext(ctx, "Unable to determine logins for resource",
+					"error", err,
+					"resource", checkable.GetName(),
+				)
+				continue
+			}
+			r.Logins = all
+			if principalType != "" && populatePrincipals && len(all) > 0 {
+				grantedSet := make(map[string]struct{}, len(granted))
+				for _, v := range granted {
+					grantedSet[v] = struct{}{}
 				}
-				r.Logins = logins
+				var requestable []string
+				for _, v := range all {
+					if _, ok := grantedSet[v]; !ok {
+						requestable = append(requestable, v)
+					}
+				}
+				r.Principals = []*proto.ResourcePrincipalSet{{
+					PrincipalType: principalType,
+					Granted:       granted,
+					Requestable:   requestable,
+				}}
 			}
 		}
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1630,20 +1630,43 @@ func (l *unifiedResourceLister) getAllowedLogins(resource services.AccessCheckab
 // getLogins returns the principals allowed on a resource. `all` is the full set
 // from the lister's checker; `granted`, only computed when withGranted is set,
 // is the subset allowed by the user's current roles. When no search_as_roles
-// widen the listing, both sets are equal and no extra computation is performed.
+// widen the listing, granted is a copy of all.
 func (l *unifiedResourceLister) getLogins(withGranted bool, resource services.AccessCheckable) (all, granted []string, err error) {
 	all, err = l.getAllowedLogins(resource)
-	if err != nil || !withGranted {
-		return all, nil, trace.Wrap(err)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	if !withGranted {
+		return all, nil, nil
 	}
 	if l.requestableAccessChecker == nil {
-		return all, all, nil
+		return all, slices.Clone(all), nil
 	}
 	granted, err = l.accessChecker.GetAllowedLoginsForResource(resource)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 	return all, granted, nil
+}
+
+// makeResourcePrincipalSet builds a principal set for one dimension of a
+// resource, splitting the full list into granted and requestable subsets.
+func makeResourcePrincipalSet(principalType string, all, granted []string) *proto.ResourcePrincipalSet {
+	grantedSet := make(map[string]struct{}, len(granted))
+	for _, v := range granted {
+		grantedSet[v] = struct{}{}
+	}
+	var requestable []string
+	for _, v := range all {
+		if _, ok := grantedSet[v]; !ok {
+			requestable = append(requestable, v)
+		}
+	}
+	return &proto.ResourcePrincipalSet{
+		PrincipalType: principalType,
+		Granted:       granted,
+		Requestable:   requestable,
+	}
 }
 
 func (a *ServerWithRoles) checkAction(namespace, resourceKind string, verb string, extraVerbs ...string) error {
@@ -1826,6 +1849,9 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 	}
 
 	if req.IncludeLogins {
+		// Splitting granted from requestable requires the caller to have specified
+		// IncludeRequestable, or no search_as_roles to have widened listing, otherwise
+		// every value would be reported as granted.
 		populatePrincipals := req.IncludeRequestable || resourceLister.requestableAccessChecker == nil
 		for _, r := range paginatedResources {
 			var checkable services.AccessCheckable
@@ -1867,22 +1893,11 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 				continue
 			}
 			r.Logins = all
+			// Resources with no allowed principals carry no dimensions, except
+			// for kinds whose dimensions' empty states are meaningful, e.g.,
+			// databases with auto-user provisioning.
 			if principalType != "" && populatePrincipals && len(all) > 0 {
-				grantedSet := make(map[string]struct{}, len(granted))
-				for _, v := range granted {
-					grantedSet[v] = struct{}{}
-				}
-				var requestable []string
-				for _, v := range all {
-					if _, ok := grantedSet[v]; !ok {
-						requestable = append(requestable, v)
-					}
-				}
-				r.Principals = []*proto.ResourcePrincipalSet{{
-					PrincipalType: principalType,
-					Granted:       granted,
-					Requestable:   requestable,
-				}}
+				r.Principals = []*proto.ResourcePrincipalSet{makeResourcePrincipalSet(principalType, all, granted)}
 			}
 		}
 	}

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -7801,11 +7801,13 @@ func TestListUnifiedResources_IncludeRequestable(t *testing.T) {
 	// only allow user to see first node
 	role.SetNodeLabels(types.Allow, types.Labels{"name": {testNodes[0].GetName()}})
 
-	// create a new role which can see second node
+	// create a new role which can see both nodes with a login ("admin")
+	// distinct from the base role's ("requester"). on node0 "admin" is
+	// requestable and "requester" granted, on node1 everything is requestable.
 	searchAsRole := services.RoleForUser(requester)
 	searchAsRole.SetName("test_search_role")
-	searchAsRole.SetNodeLabels(types.Allow, types.Labels{"name": {testNodes[1].GetName()}})
-	searchAsRole.SetLogins(types.Allow, []string{"requester"})
+	searchAsRole.SetNodeLabels(types.Allow, types.Labels{"name": {testNodes[0].GetName(), testNodes[1].GetName()}})
+	searchAsRole.SetLogins(types.Allow, []string{"admin"})
 	_, err = srv.Auth().UpsertRole(ctx, searchAsRole)
 	require.NoError(t, err)
 
@@ -7817,14 +7819,18 @@ func TestListUnifiedResources_IncludeRequestable(t *testing.T) {
 	require.NoError(t, err)
 
 	type expected struct {
-		name        string
-		requestable bool
+		name              string
+		requestable       bool
+		allLogins         []string
+		grantedLogins     []string
+		requestableLogins []string
 	}
 
 	for _, tc := range []struct {
 		desc              string
 		clt               *authclient.Client
 		requestOpt        func(*proto.ListUnifiedResourcesRequest)
+		checkLogins       bool
 		expectedResources []expected
 	}{
 		{
@@ -7849,10 +7855,24 @@ func TestListUnifiedResources_IncludeRequestable(t *testing.T) {
 			requestOpt: func(req *proto.ListUnifiedResourcesRequest) {
 				req.IncludeRequestable = true
 				req.UseSearchAsRoles = true
+				req.IncludeLogins = true
 			},
+			checkLogins: true,
 			expectedResources: []expected{
-				{name: testNodes[0].GetName(), requestable: false},
-				{name: testNodes[1].GetName(), requestable: true},
+				{
+					name:              testNodes[0].GetName(),
+					requestable:       false,
+					allLogins:         []string{"requester", "admin"},
+					grantedLogins:     []string{"requester"},
+					requestableLogins: []string{"admin"},
+				},
+				{
+					name:              testNodes[1].GetName(),
+					requestable:       true,
+					allLogins:         []string{"admin"},
+					grantedLogins:     nil,
+					requestableLogins: []string{"admin"},
+				},
 			},
 		},
 	} {
@@ -7867,13 +7887,123 @@ func TestListUnifiedResources_IncludeRequestable(t *testing.T) {
 			resp, err := tc.clt.ListUnifiedResources(ctx, &req)
 			require.NoError(t, err)
 			require.Len(t, resp.Resources, len(tc.expectedResources))
-			var resources []expected
+
+			byName := make(map[string]*proto.PaginatedResource)
+			var flags, wantFlags []expected
 			for _, resource := range resp.Resources {
-				resources = append(resources, expected{name: resource.GetNode().GetName(), requestable: resource.RequiresRequest})
+				name := resource.GetNode().GetName()
+				byName[name] = resource
+				flags = append(flags, expected{name: name, requestable: resource.RequiresRequest})
 			}
-			require.ElementsMatch(t, tc.expectedResources, resources)
+			for _, e := range tc.expectedResources {
+				wantFlags = append(wantFlags, expected{name: e.name, requestable: e.requestable})
+			}
+			require.ElementsMatch(t, wantFlags, flags)
+
+			if !tc.checkLogins {
+				return
+			}
+			for _, e := range tc.expectedResources {
+				r := byName[e.name]
+				require.NotNil(t, r, "resource %q missing from response", e.name)
+				require.ElementsMatch(t, e.allLogins, r.Logins, "Logins for %q", e.name)
+				require.Len(t, r.Principals, 1, "Principals for %q", e.name)
+				require.Equal(t, types.PrincipalTypeLogins, r.Principals[0].PrincipalType, "principal kind for %q", e.name)
+				require.ElementsMatch(t, e.grantedLogins, r.Principals[0].Granted, "granted principals for %q", e.name)
+				require.ElementsMatch(t, e.requestableLogins, r.Principals[0].Requestable, "requestable principals for %q", e.name)
+			}
 		})
 	}
+}
+
+// TestListUnifiedResources_AppPrincipalSets verifies the role_arns principal
+// dimension for AWS console apps.
+func TestListUnifiedResources_AppPrincipalSets(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	srv := newTestTLSServer(t)
+
+	const (
+		grantedARN     = "arn:aws:iam::123456789012:role/granted"
+		requestableARN = "arn:aws:iam::123456789012:role/requestable"
+	)
+
+	app, err := types.NewAppV3(types.Metadata{Name: "aws-console"}, types.AppSpecV3{
+		URI: constants.AWSConsoleURL,
+	})
+	require.NoError(t, err)
+	appServer, err := types.NewAppServerV3FromApp(app, "host", "host-id")
+	require.NoError(t, err)
+	_, err = srv.Auth().UpsertApplicationServer(ctx, appServer)
+	require.NoError(t, err)
+
+	requester, role, err := authtest.CreateUserAndRole(srv.Auth(), "app-requester", []string{"app-requester"}, nil)
+	require.NoError(t, err)
+	role.SetAppLabels(types.Allow, types.Labels{types.Wildcard: {types.Wildcard}})
+	role.SetAWSRoleARNs(types.Allow, []string{grantedARN})
+
+	searchAsRole := services.RoleForUser(requester)
+	searchAsRole.SetName("app_search_role")
+	searchAsRole.SetAppLabels(types.Allow, types.Labels{types.Wildcard: {types.Wildcard}})
+	searchAsRole.SetAWSRoleARNs(types.Allow, []string{requestableARN})
+	_, err = srv.Auth().UpsertRole(ctx, searchAsRole)
+	require.NoError(t, err)
+
+	role.SetSearchAsRoles(types.Allow, []string{searchAsRole.GetName()})
+	_, err = srv.Auth().UpsertRole(ctx, role)
+	require.NoError(t, err)
+
+	clt, err := srv.NewClient(authtest.TestUser(requester.GetName()))
+	require.NoError(t, err)
+
+	resp, err := clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
+		Kinds:              []string{types.KindApp},
+		SortBy:             types.SortBy{Field: "name"},
+		Limit:              5,
+		IncludeLogins:      true,
+		IncludeRequestable: true,
+		UseSearchAsRoles:   true,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Resources, 1)
+	r := resp.Resources[0]
+	require.ElementsMatch(t, []string{grantedARN, requestableARN}, r.Logins)
+	require.Len(t, r.Principals, 1)
+	require.Equal(t, types.PrincipalTypeRoleARNs, r.Principals[0].PrincipalType)
+	require.ElementsMatch(t, []string{grantedARN}, r.Principals[0].Granted)
+	require.ElementsMatch(t, []string{requestableARN}, r.Principals[0].Requestable)
+
+	// Without search flags, Logins comes from the base checker and Principals
+	// mirrors it with everything granted.
+	resp, err = clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
+		Kinds:         []string{types.KindApp},
+		SortBy:        types.SortBy{Field: "name"},
+		Limit:         5,
+		IncludeLogins: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Resources, 1)
+	r = resp.Resources[0]
+	require.ElementsMatch(t, []string{grantedARN}, r.Logins)
+	require.Len(t, r.Principals, 1)
+	require.Equal(t, types.PrincipalTypeRoleARNs, r.Principals[0].PrincipalType)
+	require.ElementsMatch(t, []string{grantedARN}, r.Principals[0].Granted)
+	require.Empty(t, r.Principals[0].Requestable)
+
+	// UseSearchAsRoles alone keeps its legacy response: the flat union in
+	// Logins and no Principals.
+	resp, err = clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
+		Kinds:            []string{types.KindApp},
+		SortBy:           types.SortBy{Field: "name"},
+		Limit:            5,
+		IncludeLogins:    true,
+		UseSearchAsRoles: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Resources, 1)
+	r = resp.Resources[0]
+	require.ElementsMatch(t, []string{grantedARN, requestableARN}, r.Logins)
+	require.Empty(t, r.Principals)
 }
 
 func TestCreateAccessRequestV2_oktaReadOnly(t *testing.T) {

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -7827,11 +7827,13 @@ func TestListUnifiedResources_IncludeRequestable(t *testing.T) {
 	// only allow user to see first node
 	role.SetNodeLabels(types.Allow, types.Labels{"name": {testNodes[0].GetName()}})
 
-	// create a new role which can see second node
+	// create a new role which can see both nodes with a login ("admin")
+	// distinct from the base role's ("requester"). on node0 "admin" is
+	// requestable and "requester" granted, on node1 everything is requestable.
 	searchAsRole := services.RoleForUser(requester)
 	searchAsRole.SetName("test_search_role")
-	searchAsRole.SetNodeLabels(types.Allow, types.Labels{"name": {testNodes[1].GetName()}})
-	searchAsRole.SetLogins(types.Allow, []string{"requester"})
+	searchAsRole.SetNodeLabels(types.Allow, types.Labels{"name": {testNodes[0].GetName(), testNodes[1].GetName()}})
+	searchAsRole.SetLogins(types.Allow, []string{"admin"})
 	_, err = srv.Auth().UpsertRole(ctx, searchAsRole)
 	require.NoError(t, err)
 
@@ -7843,14 +7845,18 @@ func TestListUnifiedResources_IncludeRequestable(t *testing.T) {
 	require.NoError(t, err)
 
 	type expected struct {
-		name        string
-		requestable bool
+		name              string
+		requestable       bool
+		allLogins         []string
+		grantedLogins     []string
+		requestableLogins []string
 	}
 
 	for _, tc := range []struct {
 		desc              string
 		clt               *authclient.Client
 		requestOpt        func(*proto.ListUnifiedResourcesRequest)
+		checkLogins       bool
 		expectedResources []expected
 	}{
 		{
@@ -7875,10 +7881,24 @@ func TestListUnifiedResources_IncludeRequestable(t *testing.T) {
 			requestOpt: func(req *proto.ListUnifiedResourcesRequest) {
 				req.IncludeRequestable = true
 				req.UseSearchAsRoles = true
+				req.IncludeLogins = true
 			},
+			checkLogins: true,
 			expectedResources: []expected{
-				{name: testNodes[0].GetName(), requestable: false},
-				{name: testNodes[1].GetName(), requestable: true},
+				{
+					name:              testNodes[0].GetName(),
+					requestable:       false,
+					allLogins:         []string{"requester", "admin"},
+					grantedLogins:     []string{"requester"},
+					requestableLogins: []string{"admin"},
+				},
+				{
+					name:              testNodes[1].GetName(),
+					requestable:       true,
+					allLogins:         []string{"admin"},
+					grantedLogins:     nil,
+					requestableLogins: []string{"admin"},
+				},
 			},
 		},
 	} {
@@ -7893,13 +7913,123 @@ func TestListUnifiedResources_IncludeRequestable(t *testing.T) {
 			resp, err := tc.clt.ListUnifiedResources(ctx, &req)
 			require.NoError(t, err)
 			require.Len(t, resp.Resources, len(tc.expectedResources))
-			var resources []expected
+
+			byName := make(map[string]*proto.PaginatedResource)
+			var flags, wantFlags []expected
 			for _, resource := range resp.Resources {
-				resources = append(resources, expected{name: resource.GetNode().GetName(), requestable: resource.RequiresRequest})
+				name := resource.GetNode().GetName()
+				byName[name] = resource
+				flags = append(flags, expected{name: name, requestable: resource.RequiresRequest})
 			}
-			require.ElementsMatch(t, tc.expectedResources, resources)
+			for _, e := range tc.expectedResources {
+				wantFlags = append(wantFlags, expected{name: e.name, requestable: e.requestable})
+			}
+			require.ElementsMatch(t, wantFlags, flags)
+
+			if !tc.checkLogins {
+				return
+			}
+			for _, e := range tc.expectedResources {
+				r := byName[e.name]
+				require.NotNil(t, r, "resource %q missing from response", e.name)
+				require.ElementsMatch(t, e.allLogins, r.Logins, "Logins for %q", e.name)
+				require.Len(t, r.Principals, 1, "Principals for %q", e.name)
+				require.Equal(t, types.PrincipalTypeLogins, r.Principals[0].PrincipalType, "principal kind for %q", e.name)
+				require.ElementsMatch(t, e.grantedLogins, r.Principals[0].Granted, "granted principals for %q", e.name)
+				require.ElementsMatch(t, e.requestableLogins, r.Principals[0].Requestable, "requestable principals for %q", e.name)
+			}
 		})
 	}
+}
+
+// TestListUnifiedResources_AppPrincipalSets verifies the role_arns principal
+// dimension for AWS console apps.
+func TestListUnifiedResources_AppPrincipalSets(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	srv := newTestTLSServer(t)
+
+	const (
+		grantedARN     = "arn:aws:iam::123456789012:role/granted"
+		requestableARN = "arn:aws:iam::123456789012:role/requestable"
+	)
+
+	app, err := types.NewAppV3(types.Metadata{Name: "aws-console"}, types.AppSpecV3{
+		URI: constants.AWSConsoleURL,
+	})
+	require.NoError(t, err)
+	appServer, err := types.NewAppServerV3FromApp(app, "host", "host-id")
+	require.NoError(t, err)
+	_, err = srv.Auth().UpsertApplicationServer(ctx, appServer)
+	require.NoError(t, err)
+
+	requester, role, err := authtest.CreateUserAndRole(srv.Auth(), "app-requester", []string{"app-requester"}, nil)
+	require.NoError(t, err)
+	role.SetAppLabels(types.Allow, types.Labels{types.Wildcard: {types.Wildcard}})
+	role.SetAWSRoleARNs(types.Allow, []string{grantedARN})
+
+	searchAsRole := services.RoleForUser(requester)
+	searchAsRole.SetName("app_search_role")
+	searchAsRole.SetAppLabels(types.Allow, types.Labels{types.Wildcard: {types.Wildcard}})
+	searchAsRole.SetAWSRoleARNs(types.Allow, []string{requestableARN})
+	_, err = srv.Auth().UpsertRole(ctx, searchAsRole)
+	require.NoError(t, err)
+
+	role.SetSearchAsRoles(types.Allow, []string{searchAsRole.GetName()})
+	_, err = srv.Auth().UpsertRole(ctx, role)
+	require.NoError(t, err)
+
+	clt, err := srv.NewClient(authtest.TestUser(requester.GetName()))
+	require.NoError(t, err)
+
+	resp, err := clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
+		Kinds:              []string{types.KindApp},
+		SortBy:             types.SortBy{Field: "name"},
+		Limit:              5,
+		IncludeLogins:      true,
+		IncludeRequestable: true,
+		UseSearchAsRoles:   true,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Resources, 1)
+	r := resp.Resources[0]
+	require.ElementsMatch(t, []string{grantedARN, requestableARN}, r.Logins)
+	require.Len(t, r.Principals, 1)
+	require.Equal(t, types.PrincipalTypeRoleARNs, r.Principals[0].PrincipalType)
+	require.ElementsMatch(t, []string{grantedARN}, r.Principals[0].Granted)
+	require.ElementsMatch(t, []string{requestableARN}, r.Principals[0].Requestable)
+
+	// Without search flags, Logins comes from the base checker and Principals
+	// mirrors it with everything granted.
+	resp, err = clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
+		Kinds:         []string{types.KindApp},
+		SortBy:        types.SortBy{Field: "name"},
+		Limit:         5,
+		IncludeLogins: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Resources, 1)
+	r = resp.Resources[0]
+	require.ElementsMatch(t, []string{grantedARN}, r.Logins)
+	require.Len(t, r.Principals, 1)
+	require.Equal(t, types.PrincipalTypeRoleARNs, r.Principals[0].PrincipalType)
+	require.ElementsMatch(t, []string{grantedARN}, r.Principals[0].Granted)
+	require.Empty(t, r.Principals[0].Requestable)
+
+	// UseSearchAsRoles alone keeps its legacy response: the flat union in
+	// Logins and no Principals.
+	resp, err = clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
+		Kinds:            []string{types.KindApp},
+		SortBy:           types.SortBy{Field: "name"},
+		Limit:            5,
+		IncludeLogins:    true,
+		UseSearchAsRoles: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Resources, 1)
+	r = resp.Resources[0]
+	require.ElementsMatch(t, []string{grantedARN, requestableARN}, r.Logins)
+	require.Empty(t, r.Principals)
 }
 
 func TestCreateAccessRequestV2_oktaReadOnly(t *testing.T) {

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -7938,6 +7938,24 @@ func TestListUnifiedResources_IncludeRequestable(t *testing.T) {
 				require.ElementsMatch(t, e.grantedLogins, r.Principals[0].Granted, "granted principals for %q", e.name)
 				require.ElementsMatch(t, e.requestableLogins, r.Principals[0].Requestable, "requestable principals for %q", e.name)
 			}
+
+			// Fetch the same page through the typed client helper to cover the
+			// conversion into EnrichedResource end to end.
+			enriched, _, err := apiclient.GetUnifiedResourcePage(ctx, tc.clt, &req)
+			require.NoError(t, err)
+			require.Len(t, enriched, len(tc.expectedResources))
+			for _, e := range tc.expectedResources {
+				idx := slices.IndexFunc(enriched, func(r *types.EnrichedResource) bool {
+					return r.GetName() == e.name
+				})
+				require.GreaterOrEqual(t, idx, 0, "resource %q missing from enriched page", e.name)
+				r := enriched[idx]
+				require.ElementsMatch(t, e.allLogins, r.Logins, "enriched logins for %q", e.name)
+				require.Len(t, r.Principals, 1, "enriched principals for %q", e.name)
+				require.Equal(t, types.PrincipalTypeLogins, r.Principals[0].PrincipalType, "enriched principal kind for %q", e.name)
+				require.ElementsMatch(t, e.grantedLogins, r.Principals[0].Granted, "enriched granted principals for %q", e.name)
+				require.ElementsMatch(t, e.requestableLogins, r.Principals[0].Requestable, "enriched requestable principals for %q", e.name)
+			}
 		})
 	}
 }

--- a/lib/web/unified_resource_principals.go
+++ b/lib/web/unified_resource_principals.go
@@ -83,8 +83,9 @@ func PrincipalsForUnifiedResource(opts PrincipalsForUnifiedResourceOpts) (*Unifi
 // These are returned as-is since they're for display or access-request
 // purposes, not direct SSH connections.
 //
-// When IncludeRequestable is set, granted logins are additionally computed
-// using the base access checker and filtered to cert principals.
+// When IncludeRequestable is set, granted logins come from Auth's principal
+// sets when present, else the base access checker, filtered to cert
+// principals.
 //
 // In the default mode (neither flag set), all logins are filtered to cert
 // principals so the connect menu only offers logins that will work.
@@ -93,7 +94,7 @@ func sshPrincipals(opts PrincipalsForUnifiedResourceOpts, server types.Server) (
 		all := set.New(opts.Resource.Logins...)
 		ps := &webui.PrincipalSet{All: all}
 		if opts.IncludeRequestable {
-			granted, err := opts.AccessChecker.GetAllowedLoginsForResource(server)
+			granted, err := grantedLoginsForResource(opts, types.PrincipalTypeLogins, server)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -127,7 +128,7 @@ func appPrincipals(opts PrincipalsForUnifiedResourceOpts, appServer types.AppSer
 	ps := &webui.PrincipalSet{All: allSet}
 
 	if opts.IncludeRequestable {
-		granted, err := opts.AccessChecker.GetAllowedLoginsForResource(appServer.GetApp())
+		granted, err := grantedLoginsForResource(opts, types.PrincipalTypeRoleARNs, appServer.GetApp())
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -137,6 +138,21 @@ func appPrincipals(opts PrincipalsForUnifiedResourceOpts, appServer types.AppSer
 	}
 
 	return ps, nil
+}
+
+// grantedLoginsForResource returns the logins usable without an access
+// request, preferring Auth's precomputed granted set when present,
+// else, computing locally using the base access checker.
+//
+// TODO(kiosion): DELETE IN 20.0.0
+func grantedLoginsForResource(opts PrincipalsForUnifiedResourceOpts, kind string, resource services.AccessCheckable) ([]string, error) {
+	for _, ps := range opts.Resource.Principals {
+		if ps.PrincipalType == kind {
+			return ps.Granted, nil
+		}
+	}
+	granted, err := opts.AccessChecker.GetAllowedLoginsForResource(resource)
+	return granted, trace.Wrap(err)
 }
 
 // filterByIdentityPrincipals returns the intersection of allowedLogins with

--- a/lib/web/unified_resource_principals.go
+++ b/lib/web/unified_resource_principals.go
@@ -144,6 +144,10 @@ func appPrincipals(opts PrincipalsForUnifiedResourceOpts, appServer types.AppSer
 // request, preferring Auth's precomputed granted set when present,
 // else, computing locally using the base access checker.
 //
+// The local path covers a Proxy reading from an Auth that predates the
+// principal sets, which happens while a cluster is part way through an
+// upgrade.
+//
 // TODO(kiosion): DELETE IN 20.0.0
 func grantedLoginsForResource(opts PrincipalsForUnifiedResourceOpts, kind string, resource services.AccessCheckable) ([]string, error) {
 	for _, ps := range opts.Resource.Principals {

--- a/lib/web/unified_resource_principals_test.go
+++ b/lib/web/unified_resource_principals_test.go
@@ -19,6 +19,7 @@
 package web
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -28,7 +29,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils/set"
 )
 
-// mockLoginGetter implements the GetAllowedLoginsForResource method for testing.
 type mockLoginGetter struct {
 	services.AccessChecker
 	logins []string
@@ -104,6 +104,52 @@ func TestPrincipalsForUnifiedResource_SSH(t *testing.T) {
 		// Granted is the intersection of AccessChecker result and cert principals.
 		require.Equal(t, set.New("ubuntu"), result.Logins.Granted)
 	})
+
+	t.Run("IncludeRequestable prefers Auth principal sets over local checker", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := PrincipalsForUnifiedResource(PrincipalsForUnifiedResourceOpts{
+			Resource: &types.EnrichedResource{
+				ResourceWithLabels: server,
+				Logins:             []string{"root", "ubuntu", "admin"},
+				Principals: []types.ResourcePrincipalSet{{
+					PrincipalType: types.PrincipalTypeLogins,
+					Granted:       []string{"ubuntu", "admin"},
+					Requestable:   []string{"root"},
+				}},
+			},
+			CertPrincipals:     []string{"ubuntu", "root"},
+			AccessChecker:      &mockLoginGetter{err: errors.New("must not be called")},
+			IncludeRequestable: true,
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, set.New("root", "ubuntu", "admin"), result.Logins.All)
+		// Granted is Auth's granted principal set filtered to cert principals.
+		require.Equal(t, set.New("ubuntu"), result.Logins.Granted)
+	})
+
+	t.Run("IncludeRequestable trusts an Auth principal set with nothing granted", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := PrincipalsForUnifiedResource(PrincipalsForUnifiedResourceOpts{
+			Resource: &types.EnrichedResource{
+				ResourceWithLabels: server,
+				Logins:             []string{"root", "ubuntu"},
+				Principals: []types.ResourcePrincipalSet{{
+					PrincipalType: types.PrincipalTypeLogins,
+					Requestable:   []string{"root", "ubuntu"},
+				}},
+			},
+			CertPrincipals:     []string{"ubuntu", "root"},
+			AccessChecker:      &mockLoginGetter{err: errors.New("must not be called")},
+			IncludeRequestable: true,
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, set.New("root", "ubuntu"), result.Logins.All)
+		require.Empty(t, result.Logins.Granted)
+	})
 }
 
 func TestPrincipalsForUnifiedResource_App(t *testing.T) {
@@ -174,6 +220,34 @@ func TestPrincipalsForUnifiedResource_App(t *testing.T) {
 				Logins:             []string{"arn:aws:iam::111:role/Admin", "arn:aws:iam::111:role/ReadOnly"},
 			},
 			AccessChecker:      &mockLoginGetter{logins: []string{"arn:aws:iam::111:role/ReadOnly"}},
+			IncludeRequestable: true,
+		})
+		require.NoError(t, err)
+
+		require.Equal(t,
+			set.New("arn:aws:iam::111:role/Admin", "arn:aws:iam::111:role/ReadOnly"),
+			result.AWSRoleARNs.All,
+		)
+		require.Equal(t,
+			set.New("arn:aws:iam::111:role/ReadOnly"),
+			result.AWSRoleARNs.Granted,
+		)
+	})
+
+	t.Run("IncludeRequestable prefers Auth principal sets over local checker", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := PrincipalsForUnifiedResource(PrincipalsForUnifiedResourceOpts{
+			Resource: &types.EnrichedResource{
+				ResourceWithLabels: appServer,
+				Logins:             []string{"arn:aws:iam::111:role/Admin", "arn:aws:iam::111:role/ReadOnly"},
+				Principals: []types.ResourcePrincipalSet{{
+					PrincipalType: types.PrincipalTypeRoleARNs,
+					Granted:       []string{"arn:aws:iam::111:role/ReadOnly"},
+					Requestable:   []string{"arn:aws:iam::111:role/Admin"},
+				}},
+			},
+			AccessChecker:      &mockLoginGetter{err: errors.New("must not be called")},
 			IncludeRequestable: true,
 		})
 		require.NoError(t, err)


### PR DESCRIPTION
## Context
This PR move the current granted-vs-requestable resource principal computation from Proxy's web handler into Auth, enabling clients beyond the web UI to consume it without duplicating the same computation. User-visible behavior remains unchanged.

## Related material
- [RFD 0228](https://github.com/gravitational/rfd/blob/main/rfd/0228-resource-scoped-constraints-in-access-requests.md)
- Requires gravitational/teleport#68879
- Required for follow-up https://github.com/gravitational/teleport/pull/69245

## Manual Test Plan
### Test Environment
- Single-node cluster (Auth, Proxy) built from this branch, one SSH node and one AWS console app
- Requester role whose `search_as_roles` grant additional logins and role ARNs beyond the base role

### Test Cases
- [ ] Validate with a new Proxy against a pre-change Auth, listing output is unchanged.
- [ ] Validate with an old tsh and Connect against a new Auth, resources list normally.
- [ ] Validate with a root Proxy listing a leaf cluster running an older Auth, per-resource principals for leaf resources are correct.
