### PR TITLE
[v18] Fix fail-open in CheckSPKI and harden ParseCertificatePEMs

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2383,9 +2383,6 @@ func applyWindowsDesktopConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		if err != nil {
 			return trace.WrapWithMessage(err, "parsing the LDAP root CA PEM cert(s)")
 		}
-		if len(pemCerts) == 0 {
-			return trace.BadParameter("ldap_ca_cert is set, but no certificates were parsed")
-		}
 		certs = pemCerts
 	}
 

--- a/lib/tlsca/parsegen.go
+++ b/lib/tlsca/parsegen.go
@@ -222,6 +222,7 @@ func ParseCertificatePEM(bytes []byte) (*x509.Certificate, error) {
 }
 
 // ParseCertificatePEM parses multiple PEM-encoded certificates
+// It returns an error if bytes doesn't contain at least one certificate.
 func ParseCertificatePEMs(bytes []byte) ([]*x509.Certificate, error) {
 	if len(bytes) == 0 {
 		return nil, trace.BadParameter("missing PEM encoded block")
@@ -239,6 +240,9 @@ func ParseCertificatePEMs(bytes []byte) ([]*x509.Certificate, error) {
 			return nil, trace.BadParameter("%s", err)
 		}
 		certs = append(certs, cert)
+	}
+	if len(certs) == 0 {
+		return nil, trace.BadParameter("no PEM-encoded certificate found")
 	}
 	return certs, nil
 }

--- a/lib/tlsca/parsegen_test.go
+++ b/lib/tlsca/parsegen_test.go
@@ -18,11 +18,14 @@ package tlsca_test
 
 import (
 	"crypto/x509/pkix"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/tlscatest"
 )
 
 func TestClusterName(t *testing.T) {
@@ -102,6 +105,54 @@ func TestClusterName(t *testing.T) {
 				return
 			}
 			assert.Equal(t, test.want, got, "Cluster name mismatch")
+		})
+	}
+}
+
+func TestParseCertificatePEMs(t *testing.T) {
+	t.Parallel()
+
+	_, validCAPEM, err := tlscatest.GenerateSelfSignedCA(tlscatest.GenerateCAConfig{ClusterName: "example.com"})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		input     []byte
+		wantErr   string
+		wantCerts int
+	}{
+		{
+			name:      "valid single certificate",
+			input:     validCAPEM,
+			wantCerts: 1,
+		},
+		{
+			name:      "valid multiple certificates",
+			input:     slices.Concat(validCAPEM, validCAPEM),
+			wantCerts: 2,
+		},
+		{
+			name:    "empty input",
+			input:   nil,
+			wantErr: "missing PEM encoded block",
+		},
+		{
+			// non-empty input containing no PEM block must fail with an error
+			name:    "non-empty input with no PEM block",
+			input:   []byte("this is not a PEM-encoded certificate"),
+			wantErr: "no PEM-encoded certificate found",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			certs, err := tlsca.ParseCertificatePEMs(test.input)
+			if test.wantErr != "" {
+				assert.ErrorContains(t, err, test.wantErr)
+				assert.Empty(t, certs)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Len(t, certs, test.wantCerts)
 		})
 	}
 }

--- a/tool/tctl/common/workload_identity_command.go
+++ b/tool/tctl/common/workload_identity_command.go
@@ -523,10 +523,7 @@ func (c *WorkloadIdentityCommand) runOverridesCreate(ctx context.Context, client
 		}
 		certs, err := tlsca.ParseCertificatePEMs(f)
 		if err != nil {
-			return trace.Wrap(err)
-		}
-		if len(certs) < 1 {
-			return trace.BadParameter("got no certificates from fullchain PEM file %q", p)
+			return trace.Wrap(err, "parsing fullchain PEM file %q", p)
 		}
 		overrides = append(overrides, certs)
 	}


### PR DESCRIPTION
Harden `ParseCertificatePEMs` to return error when there is no PEM-encoded certificate found.

Backports https://github.com/gravitational/teleport/pull/68589