### PR TITLE
[v18] Validate join ClientParams against SystemRole

### DIFF
--- a/lib/join/internal/messages/messages.go
+++ b/lib/join/internal/messages/messages.go
@@ -132,6 +132,24 @@ func (p *ClientParams) check() error {
 	return nil
 }
 
+// CheckForRole validates that the payload matches the requested SystemRole:
+// an Instance join must carry HostParams, a Bot join must carry BotParams.
+func (p *ClientParams) CheckForRole(role types.SystemRole) error {
+	switch role {
+	case types.RoleInstance:
+		if p.HostParams == nil {
+			return trace.BadParameter("HostParams is required to join as %s", role)
+		}
+	case types.RoleBot:
+		if p.BotParams == nil {
+			return trace.BadParameter("BotParams is required to join as %s", role)
+		}
+	default:
+		return trace.NotImplemented("new join service only supports Instance and Bot system roles, client requested %s", role)
+	}
+	return nil
+}
+
 // HostParams holds parameters that are specific to host joining and
 // irrelevant to bot joining.
 type HostParams struct {

--- a/lib/join/internal/messages/messages_test.go
+++ b/lib/join/internal/messages/messages_test.go
@@ -1,0 +1,115 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package messages
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// TestClientParamsCheckForRole verifies that the payload matches the requested
+// SystemRole. A wrong-typed or missing payload must be rejected with an error.
+func TestClientParamsCheckForRole(t *testing.T) {
+	t.Parallel()
+
+	validExpires := time.Now().Add(time.Hour)
+	validKeys := PublicKeys{
+		PublicTLSKey: []byte("tls-key"),
+		PublicSSHKey: []byte("ssh-key"),
+	}
+	validHostParams := func() *HostParams {
+		return &HostParams{PublicKeys: validKeys, HostName: "node"}
+	}
+	validBotParams := func() *BotParams {
+		return &BotParams{PublicKeys: validKeys, Expires: &validExpires}
+	}
+
+	tests := []struct {
+		name   string
+		role   types.SystemRole
+		params ClientParams
+		want   func(error) bool
+	}{
+		{
+			name:   "instance with host params is valid",
+			role:   types.RoleInstance,
+			params: ClientParams{HostParams: validHostParams()},
+			want:   nil,
+		},
+		{
+			name:   "instance with bot params is rejected",
+			role:   types.RoleInstance,
+			params: ClientParams{BotParams: validBotParams()},
+			want:   trace.IsBadParameter,
+		},
+		{
+			name:   "instance with no payload is rejected",
+			role:   types.RoleInstance,
+			params: ClientParams{},
+			want:   trace.IsBadParameter,
+		},
+		{
+			name:   "bot with bot params is valid",
+			role:   types.RoleBot,
+			params: ClientParams{BotParams: validBotParams()},
+			want:   nil,
+		},
+		{
+			name:   "bot with host params is rejected",
+			role:   types.RoleBot,
+			params: ClientParams{HostParams: validHostParams()},
+			want:   trace.IsBadParameter,
+		},
+		{
+			name:   "bot with no payload is rejected",
+			role:   types.RoleBot,
+			params: ClientParams{},
+			want:   trace.IsBadParameter,
+		},
+		{
+			// Param contents are method-dependent (bound keypair omits HostName),
+			// so CheckForRole must not reject a host payload for missing content.
+			name:   "instance with minimal host params is accepted",
+			role:   types.RoleInstance,
+			params: ClientParams{HostParams: &HostParams{}},
+			want:   nil,
+		},
+		{
+			name:   "unsupported role is not implemented",
+			role:   types.RoleProxy,
+			params: ClientParams{HostParams: validHostParams()},
+			want:   trace.IsNotImplemented,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.params.CheckForRole(tc.role)
+			if tc.want == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.True(t, tc.want(err), "unexpected error: %v", err)
+		})
+	}
+}

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -534,6 +534,10 @@ func (s *Server) makeResult(
 	rawClaims any,
 	attrs *workloadidentityv1pb.JoinAttrs,
 ) (messages.Response, error) {
+	// Validate the requested SystemRole with the payload the client sent.
+	if err := clientParams.CheckForRole(types.SystemRole(clientInit.SystemRole)); err != nil {
+		return nil, trace.Wrap(err, "validating client parameters")
+	}
 	switch types.SystemRole(clientInit.SystemRole) {
 	case types.RoleInstance:
 		return s.makeHostResult(ctx, diag, authCtx, clientParams.HostParams, token, rawClaims)
@@ -585,6 +589,9 @@ func makeHostCertsParams(
 	joinMethod types.JoinMethod,
 	rawClaims any,
 ) (*HostCertsParams, error) {
+	if hostParams == nil {
+		return nil, trace.BadParameter("HostParams is required to join as an Instance")
+	}
 	// GenerateHostCertsForJoin requires the TLS key to be PEM-encoded.
 	tlsPub, err := x509.ParsePKIXPublicKey(hostParams.PublicKeys.PublicTLSKey)
 	if err != nil {
@@ -673,6 +680,9 @@ func makeBotCertsParams(
 	rawClaims any,
 	attrs *workloadidentityv1pb.JoinAttrs,
 ) (*BotCertsParams, error) {
+	if botParams == nil {
+		return nil, trace.BadParameter("BotParams is required to join as a Bot")
+	}
 	// GenerateBotCertsForJoin requires the TLS key to be PEM-encoded.
 	tlsPub, err := x509.ParsePKIXPublicKey(botParams.PublicKeys.PublicTLSKey)
 	if err != nil {

--- a/lib/join/server_boundkeypair.go
+++ b/lib/join/server_boundkeypair.go
@@ -68,6 +68,10 @@ func (s *Server) handleBoundKeypairJoin(
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	// Validate the requested SystemRole with the payload the client sent.
+	if err := boundKeypairInit.ClientParams.CheckForRole(types.SystemRole(clientInit.SystemRole)); err != nil {
+		return nil, trace.Wrap(err, "validating client parameters")
+	}
 	setDiagnosticClientParams(stream.Diagnostic(), &boundKeypairInit.ClientParams)
 
 	issueChallenge := func(challenge *messages.BoundKeypairChallenge) (*messages.BoundKeypairChallengeSolution, error) {

--- a/lib/join/server_token.go
+++ b/lib/join/server_token.go
@@ -67,6 +67,9 @@ func (s *Server) handleTokenJoin(
 	// be generated we need to attempt to consume the token. Any error should be
 	// considered a join failure.
 	if scopedToken, ok := joining.GetScopedToken(token); ok {
+		if tokenInit.ClientParams.HostParams == nil {
+			return nil, trace.BadParameter("HostParams is required for a scoped token join")
+		}
 		publicKey := tokenInit.ClientParams.HostParams.PublicKeys.PublicTLSKey
 
 		if _, err := s.cfg.ScopedTokenService.UseScopedToken(stream.Context(), scopedToken, publicKey); err != nil {


### PR DESCRIPTION
Reject join requests where the requested `SystemRole` doesn't match the `ClientParams` payload the client sent

Backports https://github.com/gravitational/teleport/pull/68653

## Manual Test Plan
### Test Environment
Tested locally

### Test Cases
- [ ] happy path
  - [ ] Node join ( `tctl tokens add --type=node` )
  - [ ] Bot join (loosely following steps from Deploying tbot with Bound Keypair Joining)
  - [ ] Bound keypair join (loosely following steps from Deploying tbot with Bound Keypair Joining)
```
// Bot join example setup
tctl create bot.yaml           # kind: bot, name: testbot
tctl create token-token.yaml   # join_method: token, roles: [Bot], bot_name: testbot
sudo tbot start identity \
  --token=testbot-token --join-method=token \
  --auth-server=<auth>:3025 --ca-pin=sha256:... \
  --destination=file:///tmp/tbot-token
```
```
// Bound keypair join example setup
tctl create token-bk.yaml      # join_method: bound_keypair, roles: [Bot], bot_name: testbot
tctl get token/testbot-bk --format=json | jq -r '.[0].status.bound_keypair.registration_secret'
sudo tbot start identity \
  --token=testbot-bk --join-method=bound_keypair --registration-secret=<secret> \
  --auth-server=<auth>:3025 --ca-pin=sha256:... \
  --destination=file:///tmp/tbot-bk
```
- [ ] Error path;`SystemRole`/payload mismatch for any of above scenarios should return error; reproduced by setting `params.ID.Role != types.RoleBot` in `lib/join/joinclient/join.go/makeClientParams`
