### PR TITLE
Adding dynamic registration of scoped kube clusters

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -1538,11 +1538,29 @@ func (c *Client) GetKubernetesServers(ctx context.Context) ([]types.KubeServer, 
 }
 
 // DeleteKubernetesServer deletes a named kubernetes server.
+//
+// TODO (eriktate): remove in v20
 func (c *Client) DeleteKubernetesServer(ctx context.Context, hostID, name string) error {
-	_, err := c.grpc.DeleteKubernetesServer(ctx, &proto.DeleteKubernetesServerRequest{
-		HostID: hostID,
+	return c.DeleteKubeServer(ctx, presencepb.DeleteKubeServerRequest_builder{
+		HostId: hostID,
 		Name:   name,
-	})
+	}.Build())
+}
+
+// DeleteKubeServer deletes a named kubernetes server with respect to scopes.
+func (c *Client) DeleteKubeServer(ctx context.Context, req *presencepb.DeleteKubeServerRequest) error {
+	_, err := c.PresenceServiceClient().DeleteKubeServer(ctx, req)
+	if trace.IsNotImplemented(err) {
+		if req.GetScope() != "" {
+			return trace.BadParameter("requesting deletion of scoped kube server from an outdated Teleport control plane that does not support it")
+		}
+		//nolint:staticcheck // TODO(eriktate): deprecated, to be removed in v20
+		_, err := c.grpc.DeleteKubernetesServer(ctx, &proto.DeleteKubernetesServerRequest{
+			HostID: req.GetHostId(),
+			Name:   req.GetName(),
+		})
+		return trace.Wrap(err)
+	}
 	return trace.Wrap(err)
 }
 

--- a/api/gen/proto/go/teleport/presence/v1/service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/presence/v1/service_grpc.pb.go
@@ -52,6 +52,7 @@ const (
 	PresenceService_GetKubeCluster_FullMethodName      = "/teleport.presence.v1.PresenceService/GetKubeCluster"
 	PresenceService_ListKubeClusters_FullMethodName    = "/teleport.presence.v1.PresenceService/ListKubeClusters"
 	PresenceService_DeleteKubeCluster_FullMethodName   = "/teleport.presence.v1.PresenceService/DeleteKubeCluster"
+	PresenceService_DeleteKubeServer_FullMethodName    = "/teleport.presence.v1.PresenceService/DeleteKubeServer"
 	PresenceService_DeleteAppServer_FullMethodName     = "/teleport.presence.v1.PresenceService/DeleteAppServer"
 )
 
@@ -95,6 +96,8 @@ type PresenceServiceClient interface {
 	ListKubeClusters(ctx context.Context, in *ListKubeClustersRequest, opts ...grpc.CallOption) (*ListKubeClustersResponse, error)
 	// Deletes a kube cluster resource from the backend.
 	DeleteKubeCluster(ctx context.Context, in *DeleteKubeClusterRequest, opts ...grpc.CallOption) (*DeleteKubeClusterResponse, error)
+	// Deletes a specific scoped or unscoped kube server from the backend.
+	DeleteKubeServer(ctx context.Context, in *DeleteKubeServerRequest, opts ...grpc.CallOption) (*DeleteKubeServerResponse, error)
 	// Deletes a specific scoped or unscoped application server.
 	DeleteAppServer(ctx context.Context, in *DeleteAppServerRequest, opts ...grpc.CallOption) (*DeleteAppServerResponse, error)
 }
@@ -277,6 +280,16 @@ func (c *presenceServiceClient) DeleteKubeCluster(ctx context.Context, in *Delet
 	return out, nil
 }
 
+func (c *presenceServiceClient) DeleteKubeServer(ctx context.Context, in *DeleteKubeServerRequest, opts ...grpc.CallOption) (*DeleteKubeServerResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteKubeServerResponse)
+	err := c.cc.Invoke(ctx, PresenceService_DeleteKubeServer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *presenceServiceClient) DeleteAppServer(ctx context.Context, in *DeleteAppServerRequest, opts ...grpc.CallOption) (*DeleteAppServerResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(DeleteAppServerResponse)
@@ -327,6 +340,8 @@ type PresenceServiceServer interface {
 	ListKubeClusters(context.Context, *ListKubeClustersRequest) (*ListKubeClustersResponse, error)
 	// Deletes a kube cluster resource from the backend.
 	DeleteKubeCluster(context.Context, *DeleteKubeClusterRequest) (*DeleteKubeClusterResponse, error)
+	// Deletes a specific scoped or unscoped kube server from the backend.
+	DeleteKubeServer(context.Context, *DeleteKubeServerRequest) (*DeleteKubeServerResponse, error)
 	// Deletes a specific scoped or unscoped application server.
 	DeleteAppServer(context.Context, *DeleteAppServerRequest) (*DeleteAppServerResponse, error)
 	mustEmbedUnimplementedPresenceServiceServer()
@@ -389,6 +404,9 @@ func (UnimplementedPresenceServiceServer) ListKubeClusters(context.Context, *Lis
 }
 func (UnimplementedPresenceServiceServer) DeleteKubeCluster(context.Context, *DeleteKubeClusterRequest) (*DeleteKubeClusterResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteKubeCluster not implemented")
+}
+func (UnimplementedPresenceServiceServer) DeleteKubeServer(context.Context, *DeleteKubeServerRequest) (*DeleteKubeServerResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteKubeServer not implemented")
 }
 func (UnimplementedPresenceServiceServer) DeleteAppServer(context.Context, *DeleteAppServerRequest) (*DeleteAppServerResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteAppServer not implemented")
@@ -720,6 +738,24 @@ func _PresenceService_DeleteKubeCluster_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _PresenceService_DeleteKubeServer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteKubeServerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PresenceServiceServer).DeleteKubeServer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PresenceService_DeleteKubeServer_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PresenceServiceServer).DeleteKubeServer(ctx, req.(*DeleteKubeServerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _PresenceService_DeleteAppServer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(DeleteAppServerRequest)
 	if err := dec(in); err != nil {
@@ -812,6 +848,10 @@ var PresenceService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteKubeCluster",
 			Handler:    _PresenceService_DeleteKubeCluster_Handler,
+		},
+		{
+			MethodName: "DeleteKubeServer",
+			Handler:    _PresenceService_DeleteKubeServer_Handler,
 		},
 		{
 			MethodName: "DeleteAppServer",

--- a/api/gen/proto/go/teleport/presence/v1/service_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/presence/v1/service_protohybrid.pb.go
@@ -2098,6 +2098,144 @@ func (b0 DeleteKubeClusterResponse_builder) Build() *DeleteKubeClusterResponse {
 	return m0
 }
 
+// The request to delete a specific scoped or unscoped kube server.
+type DeleteKubeServerRequest struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The kube server host uuid.
+	HostId string `protobuf:"bytes,1,opt,name=host_id,json=hostId,proto3" json:"host_id,omitempty"`
+	// The name of the kube server to delete.
+	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	// The scope of the kube server to delete. Empty for unscoped
+	// servers.
+	Scope         string `protobuf:"bytes,3,opt,name=scope,proto3" json:"scope,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteKubeServerRequest) Reset() {
+	*x = DeleteKubeServerRequest{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteKubeServerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteKubeServerRequest) ProtoMessage() {}
+
+func (x *DeleteKubeServerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *DeleteKubeServerRequest) GetHostId() string {
+	if x != nil {
+		return x.HostId
+	}
+	return ""
+}
+
+func (x *DeleteKubeServerRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *DeleteKubeServerRequest) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
+func (x *DeleteKubeServerRequest) SetHostId(v string) {
+	x.HostId = v
+}
+
+func (x *DeleteKubeServerRequest) SetName(v string) {
+	x.Name = v
+}
+
+func (x *DeleteKubeServerRequest) SetScope(v string) {
+	x.Scope = v
+}
+
+type DeleteKubeServerRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The kube server host uuid.
+	HostId string
+	// The name of the kube server to delete.
+	Name string
+	// The scope of the kube server to delete. Empty for unscoped
+	// servers.
+	Scope string
+}
+
+func (b0 DeleteKubeServerRequest_builder) Build() *DeleteKubeServerRequest {
+	m0 := &DeleteKubeServerRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.HostId = b.HostId
+	x.Name = b.Name
+	x.Scope = b.Scope
+	return m0
+}
+
+// The response for deleting a kube server.
+type DeleteKubeServerResponse struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteKubeServerResponse) Reset() {
+	*x = DeleteKubeServerResponse{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteKubeServerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteKubeServerResponse) ProtoMessage() {}
+
+func (x *DeleteKubeServerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type DeleteKubeServerResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 DeleteKubeServerResponse_builder) Build() *DeleteKubeServerResponse {
+	m0 := &DeleteKubeServerResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
 // The request to delete a specific scoped or unscoped application server.
 type DeleteAppServerRequest struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
@@ -2114,7 +2252,7 @@ type DeleteAppServerRequest struct {
 
 func (x *DeleteAppServerRequest) Reset() {
 	*x = DeleteAppServerRequest{}
-	mi := &file_teleport_presence_v1_service_proto_msgTypes[29]
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2126,7 +2264,7 @@ func (x *DeleteAppServerRequest) String() string {
 func (*DeleteAppServerRequest) ProtoMessage() {}
 
 func (x *DeleteAppServerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_presence_v1_service_proto_msgTypes[29]
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2201,7 +2339,7 @@ type DeleteAppServerResponse struct {
 
 func (x *DeleteAppServerResponse) Reset() {
 	*x = DeleteAppServerResponse{}
-	mi := &file_teleport_presence_v1_service_proto_msgTypes[30]
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2213,7 +2351,7 @@ func (x *DeleteAppServerResponse) String() string {
 func (*DeleteAppServerResponse) ProtoMessage() {}
 
 func (x *DeleteAppServerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_presence_v1_service_proto_msgTypes[30]
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2318,12 +2456,17 @@ const file_teleport_presence_v1_service_proto_rawDesc = "" +
 	"\x18DeleteKubeClusterRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05scope\x18\x02 \x01(\tR\x05scope\"\x1b\n" +
-	"\x19DeleteKubeClusterResponse\"[\n" +
+	"\x19DeleteKubeClusterResponse\"\\\n" +
+	"\x17DeleteKubeServerRequest\x12\x17\n" +
+	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
+	"\x05scope\x18\x03 \x01(\tR\x05scope\"\x1a\n" +
+	"\x18DeleteKubeServerResponse\"[\n" +
 	"\x16DeleteAppServerRequest\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
 	"\x05scope\x18\x03 \x01(\tR\x05scope\"\x19\n" +
-	"\x17DeleteAppServerResponse2\xcd\x0f\n" +
+	"\x17DeleteAppServerResponse2\xc0\x10\n" +
 	"\x0fPresenceService\x12Y\n" +
 	"\x10GetRemoteCluster\x12-.teleport.presence.v1.GetRemoteClusterRequest\x1a\x16.types.RemoteClusterV3\x12w\n" +
 	"\x12ListRemoteClusters\x12/.teleport.presence.v1.ListRemoteClustersRequest\x1a0.teleport.presence.v1.ListRemoteClustersResponse\x12_\n" +
@@ -2341,10 +2484,11 @@ const file_teleport_presence_v1_service_proto_rawDesc = "" +
 	"\x11DeleteProxyServer\x12..teleport.presence.v1.DeleteProxyServerRequest\x1a/.teleport.presence.v1.DeleteProxyServerResponse\x12k\n" +
 	"\x0eGetKubeCluster\x12+.teleport.presence.v1.GetKubeClusterRequest\x1a,.teleport.presence.v1.GetKubeClusterResponse\x12q\n" +
 	"\x10ListKubeClusters\x12-.teleport.presence.v1.ListKubeClustersRequest\x1a..teleport.presence.v1.ListKubeClustersResponse\x12t\n" +
-	"\x11DeleteKubeCluster\x12..teleport.presence.v1.DeleteKubeClusterRequest\x1a/.teleport.presence.v1.DeleteKubeClusterResponse\x12n\n" +
+	"\x11DeleteKubeCluster\x12..teleport.presence.v1.DeleteKubeClusterRequest\x1a/.teleport.presence.v1.DeleteKubeClusterResponse\x12q\n" +
+	"\x10DeleteKubeServer\x12-.teleport.presence.v1.DeleteKubeServerRequest\x1a..teleport.presence.v1.DeleteKubeServerResponse\x12n\n" +
 	"\x0fDeleteAppServer\x12,.teleport.presence.v1.DeleteAppServerRequest\x1a-.teleport.presence.v1.DeleteAppServerResponseBTZRgithub.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1;presencev1b\x06proto3"
 
-var file_teleport_presence_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
+var file_teleport_presence_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_teleport_presence_v1_service_proto_goTypes = []any{
 	(*GetRemoteClusterRequest)(nil),    // 0: teleport.presence.v1.GetRemoteClusterRequest
 	(*ListRemoteClustersRequest)(nil),  // 1: teleport.presence.v1.ListRemoteClustersRequest
@@ -2375,32 +2519,34 @@ var file_teleport_presence_v1_service_proto_goTypes = []any{
 	(*ListKubeClustersResponse)(nil),   // 26: teleport.presence.v1.ListKubeClustersResponse
 	(*DeleteKubeClusterRequest)(nil),   // 27: teleport.presence.v1.DeleteKubeClusterRequest
 	(*DeleteKubeClusterResponse)(nil),  // 28: teleport.presence.v1.DeleteKubeClusterResponse
-	(*DeleteAppServerRequest)(nil),     // 29: teleport.presence.v1.DeleteAppServerRequest
-	(*DeleteAppServerResponse)(nil),    // 30: teleport.presence.v1.DeleteAppServerResponse
-	(*types.RemoteClusterV3)(nil),      // 31: types.RemoteClusterV3
-	(*fieldmaskpb.FieldMask)(nil),      // 32: google.protobuf.FieldMask
-	(*types.ReverseTunnelV2)(nil),      // 33: types.ReverseTunnelV2
-	(*RelayServer)(nil),                // 34: teleport.presence.v1.RelayServer
-	(*types.ServerV2)(nil),             // 35: types.ServerV2
-	(*types.KubernetesClusterV3)(nil),  // 36: types.KubernetesClusterV3
-	(*v1.Filter)(nil),                  // 37: teleport.scopes.v1.Filter
-	(*emptypb.Empty)(nil),              // 38: google.protobuf.Empty
+	(*DeleteKubeServerRequest)(nil),    // 29: teleport.presence.v1.DeleteKubeServerRequest
+	(*DeleteKubeServerResponse)(nil),   // 30: teleport.presence.v1.DeleteKubeServerResponse
+	(*DeleteAppServerRequest)(nil),     // 31: teleport.presence.v1.DeleteAppServerRequest
+	(*DeleteAppServerResponse)(nil),    // 32: teleport.presence.v1.DeleteAppServerResponse
+	(*types.RemoteClusterV3)(nil),      // 33: types.RemoteClusterV3
+	(*fieldmaskpb.FieldMask)(nil),      // 34: google.protobuf.FieldMask
+	(*types.ReverseTunnelV2)(nil),      // 35: types.ReverseTunnelV2
+	(*RelayServer)(nil),                // 36: teleport.presence.v1.RelayServer
+	(*types.ServerV2)(nil),             // 37: types.ServerV2
+	(*types.KubernetesClusterV3)(nil),  // 38: types.KubernetesClusterV3
+	(*v1.Filter)(nil),                  // 39: teleport.scopes.v1.Filter
+	(*emptypb.Empty)(nil),              // 40: google.protobuf.Empty
 }
 var file_teleport_presence_v1_service_proto_depIdxs = []int32{
-	31, // 0: teleport.presence.v1.ListRemoteClustersResponse.remote_clusters:type_name -> types.RemoteClusterV3
-	31, // 1: teleport.presence.v1.UpdateRemoteClusterRequest.remote_cluster:type_name -> types.RemoteClusterV3
-	32, // 2: teleport.presence.v1.UpdateRemoteClusterRequest.update_mask:type_name -> google.protobuf.FieldMask
-	33, // 3: teleport.presence.v1.ListReverseTunnelsResponse.reverse_tunnels:type_name -> types.ReverseTunnelV2
-	33, // 4: teleport.presence.v1.UpsertReverseTunnelRequest.reverse_tunnel:type_name -> types.ReverseTunnelV2
-	34, // 5: teleport.presence.v1.GetRelayServerResponse.relay_server:type_name -> teleport.presence.v1.RelayServer
-	34, // 6: teleport.presence.v1.ListRelayServersResponse.relays:type_name -> teleport.presence.v1.RelayServer
-	35, // 7: teleport.presence.v1.ListAuthServersResponse.servers:type_name -> types.ServerV2
-	35, // 8: teleport.presence.v1.ListProxyServersResponse.servers:type_name -> types.ServerV2
-	35, // 9: teleport.presence.v1.UpsertProxyServerRequest.server:type_name -> types.ServerV2
-	35, // 10: teleport.presence.v1.UpsertProxyServerResponse.server:type_name -> types.ServerV2
-	36, // 11: teleport.presence.v1.GetKubeClusterResponse.cluster:type_name -> types.KubernetesClusterV3
-	37, // 12: teleport.presence.v1.ListKubeClustersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
-	36, // 13: teleport.presence.v1.ListKubeClustersResponse.clusters:type_name -> types.KubernetesClusterV3
+	33, // 0: teleport.presence.v1.ListRemoteClustersResponse.remote_clusters:type_name -> types.RemoteClusterV3
+	33, // 1: teleport.presence.v1.UpdateRemoteClusterRequest.remote_cluster:type_name -> types.RemoteClusterV3
+	34, // 2: teleport.presence.v1.UpdateRemoteClusterRequest.update_mask:type_name -> google.protobuf.FieldMask
+	35, // 3: teleport.presence.v1.ListReverseTunnelsResponse.reverse_tunnels:type_name -> types.ReverseTunnelV2
+	35, // 4: teleport.presence.v1.UpsertReverseTunnelRequest.reverse_tunnel:type_name -> types.ReverseTunnelV2
+	36, // 5: teleport.presence.v1.GetRelayServerResponse.relay_server:type_name -> teleport.presence.v1.RelayServer
+	36, // 6: teleport.presence.v1.ListRelayServersResponse.relays:type_name -> teleport.presence.v1.RelayServer
+	37, // 7: teleport.presence.v1.ListAuthServersResponse.servers:type_name -> types.ServerV2
+	37, // 8: teleport.presence.v1.ListProxyServersResponse.servers:type_name -> types.ServerV2
+	37, // 9: teleport.presence.v1.UpsertProxyServerRequest.server:type_name -> types.ServerV2
+	37, // 10: teleport.presence.v1.UpsertProxyServerResponse.server:type_name -> types.ServerV2
+	38, // 11: teleport.presence.v1.GetKubeClusterResponse.cluster:type_name -> types.KubernetesClusterV3
+	39, // 12: teleport.presence.v1.ListKubeClustersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
+	38, // 13: teleport.presence.v1.ListKubeClustersResponse.clusters:type_name -> types.KubernetesClusterV3
 	0,  // 14: teleport.presence.v1.PresenceService.GetRemoteCluster:input_type -> teleport.presence.v1.GetRemoteClusterRequest
 	1,  // 15: teleport.presence.v1.PresenceService.ListRemoteClusters:input_type -> teleport.presence.v1.ListRemoteClustersRequest
 	3,  // 16: teleport.presence.v1.PresenceService.UpdateRemoteCluster:input_type -> teleport.presence.v1.UpdateRemoteClusterRequest
@@ -2418,27 +2564,29 @@ var file_teleport_presence_v1_service_proto_depIdxs = []int32{
 	23, // 28: teleport.presence.v1.PresenceService.GetKubeCluster:input_type -> teleport.presence.v1.GetKubeClusterRequest
 	25, // 29: teleport.presence.v1.PresenceService.ListKubeClusters:input_type -> teleport.presence.v1.ListKubeClustersRequest
 	27, // 30: teleport.presence.v1.PresenceService.DeleteKubeCluster:input_type -> teleport.presence.v1.DeleteKubeClusterRequest
-	29, // 31: teleport.presence.v1.PresenceService.DeleteAppServer:input_type -> teleport.presence.v1.DeleteAppServerRequest
-	31, // 32: teleport.presence.v1.PresenceService.GetRemoteCluster:output_type -> types.RemoteClusterV3
-	2,  // 33: teleport.presence.v1.PresenceService.ListRemoteClusters:output_type -> teleport.presence.v1.ListRemoteClustersResponse
-	31, // 34: teleport.presence.v1.PresenceService.UpdateRemoteCluster:output_type -> types.RemoteClusterV3
-	38, // 35: teleport.presence.v1.PresenceService.DeleteRemoteCluster:output_type -> google.protobuf.Empty
-	6,  // 36: teleport.presence.v1.PresenceService.ListReverseTunnels:output_type -> teleport.presence.v1.ListReverseTunnelsResponse
-	33, // 37: teleport.presence.v1.PresenceService.UpsertReverseTunnel:output_type -> types.ReverseTunnelV2
-	38, // 38: teleport.presence.v1.PresenceService.DeleteReverseTunnel:output_type -> google.protobuf.Empty
-	10, // 39: teleport.presence.v1.PresenceService.GetRelayServer:output_type -> teleport.presence.v1.GetRelayServerResponse
-	12, // 40: teleport.presence.v1.PresenceService.ListRelayServers:output_type -> teleport.presence.v1.ListRelayServersResponse
-	14, // 41: teleport.presence.v1.PresenceService.DeleteRelayServer:output_type -> teleport.presence.v1.DeleteRelayServerResponse
-	16, // 42: teleport.presence.v1.PresenceService.ListAuthServers:output_type -> teleport.presence.v1.ListAuthServersResponse
-	18, // 43: teleport.presence.v1.PresenceService.ListProxyServers:output_type -> teleport.presence.v1.ListProxyServersResponse
-	20, // 44: teleport.presence.v1.PresenceService.UpsertProxyServer:output_type -> teleport.presence.v1.UpsertProxyServerResponse
-	22, // 45: teleport.presence.v1.PresenceService.DeleteProxyServer:output_type -> teleport.presence.v1.DeleteProxyServerResponse
-	24, // 46: teleport.presence.v1.PresenceService.GetKubeCluster:output_type -> teleport.presence.v1.GetKubeClusterResponse
-	26, // 47: teleport.presence.v1.PresenceService.ListKubeClusters:output_type -> teleport.presence.v1.ListKubeClustersResponse
-	28, // 48: teleport.presence.v1.PresenceService.DeleteKubeCluster:output_type -> teleport.presence.v1.DeleteKubeClusterResponse
-	30, // 49: teleport.presence.v1.PresenceService.DeleteAppServer:output_type -> teleport.presence.v1.DeleteAppServerResponse
-	32, // [32:50] is the sub-list for method output_type
-	14, // [14:32] is the sub-list for method input_type
+	29, // 31: teleport.presence.v1.PresenceService.DeleteKubeServer:input_type -> teleport.presence.v1.DeleteKubeServerRequest
+	31, // 32: teleport.presence.v1.PresenceService.DeleteAppServer:input_type -> teleport.presence.v1.DeleteAppServerRequest
+	33, // 33: teleport.presence.v1.PresenceService.GetRemoteCluster:output_type -> types.RemoteClusterV3
+	2,  // 34: teleport.presence.v1.PresenceService.ListRemoteClusters:output_type -> teleport.presence.v1.ListRemoteClustersResponse
+	33, // 35: teleport.presence.v1.PresenceService.UpdateRemoteCluster:output_type -> types.RemoteClusterV3
+	40, // 36: teleport.presence.v1.PresenceService.DeleteRemoteCluster:output_type -> google.protobuf.Empty
+	6,  // 37: teleport.presence.v1.PresenceService.ListReverseTunnels:output_type -> teleport.presence.v1.ListReverseTunnelsResponse
+	35, // 38: teleport.presence.v1.PresenceService.UpsertReverseTunnel:output_type -> types.ReverseTunnelV2
+	40, // 39: teleport.presence.v1.PresenceService.DeleteReverseTunnel:output_type -> google.protobuf.Empty
+	10, // 40: teleport.presence.v1.PresenceService.GetRelayServer:output_type -> teleport.presence.v1.GetRelayServerResponse
+	12, // 41: teleport.presence.v1.PresenceService.ListRelayServers:output_type -> teleport.presence.v1.ListRelayServersResponse
+	14, // 42: teleport.presence.v1.PresenceService.DeleteRelayServer:output_type -> teleport.presence.v1.DeleteRelayServerResponse
+	16, // 43: teleport.presence.v1.PresenceService.ListAuthServers:output_type -> teleport.presence.v1.ListAuthServersResponse
+	18, // 44: teleport.presence.v1.PresenceService.ListProxyServers:output_type -> teleport.presence.v1.ListProxyServersResponse
+	20, // 45: teleport.presence.v1.PresenceService.UpsertProxyServer:output_type -> teleport.presence.v1.UpsertProxyServerResponse
+	22, // 46: teleport.presence.v1.PresenceService.DeleteProxyServer:output_type -> teleport.presence.v1.DeleteProxyServerResponse
+	24, // 47: teleport.presence.v1.PresenceService.GetKubeCluster:output_type -> teleport.presence.v1.GetKubeClusterResponse
+	26, // 48: teleport.presence.v1.PresenceService.ListKubeClusters:output_type -> teleport.presence.v1.ListKubeClustersResponse
+	28, // 49: teleport.presence.v1.PresenceService.DeleteKubeCluster:output_type -> teleport.presence.v1.DeleteKubeClusterResponse
+	30, // 50: teleport.presence.v1.PresenceService.DeleteKubeServer:output_type -> teleport.presence.v1.DeleteKubeServerResponse
+	32, // 51: teleport.presence.v1.PresenceService.DeleteAppServer:output_type -> teleport.presence.v1.DeleteAppServerResponse
+	33, // [33:52] is the sub-list for method output_type
+	14, // [14:33] is the sub-list for method input_type
 	14, // [14:14] is the sub-list for extension type_name
 	14, // [14:14] is the sub-list for extension extendee
 	0,  // [0:14] is the sub-list for field type_name
@@ -2456,7 +2604,7 @@ func file_teleport_presence_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_presence_v1_service_proto_rawDesc), len(file_teleport_presence_v1_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   31,
+			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/presence/v1/service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/presence/v1/service_protoopaque.pb.go
@@ -2057,6 +2057,140 @@ func (b0 DeleteKubeClusterResponse_builder) Build() *DeleteKubeClusterResponse {
 	return m0
 }
 
+// The request to delete a specific scoped or unscoped kube server.
+type DeleteKubeServerRequest struct {
+	state             protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_HostId string                 `protobuf:"bytes,1,opt,name=host_id,json=hostId,proto3"`
+	xxx_hidden_Name   string                 `protobuf:"bytes,2,opt,name=name,proto3"`
+	xxx_hidden_Scope  string                 `protobuf:"bytes,3,opt,name=scope,proto3"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *DeleteKubeServerRequest) Reset() {
+	*x = DeleteKubeServerRequest{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteKubeServerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteKubeServerRequest) ProtoMessage() {}
+
+func (x *DeleteKubeServerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *DeleteKubeServerRequest) GetHostId() string {
+	if x != nil {
+		return x.xxx_hidden_HostId
+	}
+	return ""
+}
+
+func (x *DeleteKubeServerRequest) GetName() string {
+	if x != nil {
+		return x.xxx_hidden_Name
+	}
+	return ""
+}
+
+func (x *DeleteKubeServerRequest) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
+func (x *DeleteKubeServerRequest) SetHostId(v string) {
+	x.xxx_hidden_HostId = v
+}
+
+func (x *DeleteKubeServerRequest) SetName(v string) {
+	x.xxx_hidden_Name = v
+}
+
+func (x *DeleteKubeServerRequest) SetScope(v string) {
+	x.xxx_hidden_Scope = v
+}
+
+type DeleteKubeServerRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The kube server host uuid.
+	HostId string
+	// The name of the kube server to delete.
+	Name string
+	// The scope of the kube server to delete. Empty for unscoped
+	// servers.
+	Scope string
+}
+
+func (b0 DeleteKubeServerRequest_builder) Build() *DeleteKubeServerRequest {
+	m0 := &DeleteKubeServerRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_HostId = b.HostId
+	x.xxx_hidden_Name = b.Name
+	x.xxx_hidden_Scope = b.Scope
+	return m0
+}
+
+// The response for deleting a kube server.
+type DeleteKubeServerResponse struct {
+	state         protoimpl.MessageState `protogen:"opaque.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteKubeServerResponse) Reset() {
+	*x = DeleteKubeServerResponse{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteKubeServerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteKubeServerResponse) ProtoMessage() {}
+
+func (x *DeleteKubeServerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type DeleteKubeServerResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 DeleteKubeServerResponse_builder) Build() *DeleteKubeServerResponse {
+	m0 := &DeleteKubeServerResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
 // The request to delete a specific scoped or unscoped application server.
 type DeleteAppServerRequest struct {
 	state             protoimpl.MessageState `protogen:"opaque.v1"`
@@ -2069,7 +2203,7 @@ type DeleteAppServerRequest struct {
 
 func (x *DeleteAppServerRequest) Reset() {
 	*x = DeleteAppServerRequest{}
-	mi := &file_teleport_presence_v1_service_proto_msgTypes[29]
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2081,7 +2215,7 @@ func (x *DeleteAppServerRequest) String() string {
 func (*DeleteAppServerRequest) ProtoMessage() {}
 
 func (x *DeleteAppServerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_presence_v1_service_proto_msgTypes[29]
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2156,7 +2290,7 @@ type DeleteAppServerResponse struct {
 
 func (x *DeleteAppServerResponse) Reset() {
 	*x = DeleteAppServerResponse{}
-	mi := &file_teleport_presence_v1_service_proto_msgTypes[30]
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2168,7 +2302,7 @@ func (x *DeleteAppServerResponse) String() string {
 func (*DeleteAppServerResponse) ProtoMessage() {}
 
 func (x *DeleteAppServerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_presence_v1_service_proto_msgTypes[30]
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2273,12 +2407,17 @@ const file_teleport_presence_v1_service_proto_rawDesc = "" +
 	"\x18DeleteKubeClusterRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05scope\x18\x02 \x01(\tR\x05scope\"\x1b\n" +
-	"\x19DeleteKubeClusterResponse\"[\n" +
+	"\x19DeleteKubeClusterResponse\"\\\n" +
+	"\x17DeleteKubeServerRequest\x12\x17\n" +
+	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
+	"\x05scope\x18\x03 \x01(\tR\x05scope\"\x1a\n" +
+	"\x18DeleteKubeServerResponse\"[\n" +
 	"\x16DeleteAppServerRequest\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
 	"\x05scope\x18\x03 \x01(\tR\x05scope\"\x19\n" +
-	"\x17DeleteAppServerResponse2\xcd\x0f\n" +
+	"\x17DeleteAppServerResponse2\xc0\x10\n" +
 	"\x0fPresenceService\x12Y\n" +
 	"\x10GetRemoteCluster\x12-.teleport.presence.v1.GetRemoteClusterRequest\x1a\x16.types.RemoteClusterV3\x12w\n" +
 	"\x12ListRemoteClusters\x12/.teleport.presence.v1.ListRemoteClustersRequest\x1a0.teleport.presence.v1.ListRemoteClustersResponse\x12_\n" +
@@ -2296,10 +2435,11 @@ const file_teleport_presence_v1_service_proto_rawDesc = "" +
 	"\x11DeleteProxyServer\x12..teleport.presence.v1.DeleteProxyServerRequest\x1a/.teleport.presence.v1.DeleteProxyServerResponse\x12k\n" +
 	"\x0eGetKubeCluster\x12+.teleport.presence.v1.GetKubeClusterRequest\x1a,.teleport.presence.v1.GetKubeClusterResponse\x12q\n" +
 	"\x10ListKubeClusters\x12-.teleport.presence.v1.ListKubeClustersRequest\x1a..teleport.presence.v1.ListKubeClustersResponse\x12t\n" +
-	"\x11DeleteKubeCluster\x12..teleport.presence.v1.DeleteKubeClusterRequest\x1a/.teleport.presence.v1.DeleteKubeClusterResponse\x12n\n" +
+	"\x11DeleteKubeCluster\x12..teleport.presence.v1.DeleteKubeClusterRequest\x1a/.teleport.presence.v1.DeleteKubeClusterResponse\x12q\n" +
+	"\x10DeleteKubeServer\x12-.teleport.presence.v1.DeleteKubeServerRequest\x1a..teleport.presence.v1.DeleteKubeServerResponse\x12n\n" +
 	"\x0fDeleteAppServer\x12,.teleport.presence.v1.DeleteAppServerRequest\x1a-.teleport.presence.v1.DeleteAppServerResponseBTZRgithub.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1;presencev1b\x06proto3"
 
-var file_teleport_presence_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
+var file_teleport_presence_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_teleport_presence_v1_service_proto_goTypes = []any{
 	(*GetRemoteClusterRequest)(nil),    // 0: teleport.presence.v1.GetRemoteClusterRequest
 	(*ListRemoteClustersRequest)(nil),  // 1: teleport.presence.v1.ListRemoteClustersRequest
@@ -2330,32 +2470,34 @@ var file_teleport_presence_v1_service_proto_goTypes = []any{
 	(*ListKubeClustersResponse)(nil),   // 26: teleport.presence.v1.ListKubeClustersResponse
 	(*DeleteKubeClusterRequest)(nil),   // 27: teleport.presence.v1.DeleteKubeClusterRequest
 	(*DeleteKubeClusterResponse)(nil),  // 28: teleport.presence.v1.DeleteKubeClusterResponse
-	(*DeleteAppServerRequest)(nil),     // 29: teleport.presence.v1.DeleteAppServerRequest
-	(*DeleteAppServerResponse)(nil),    // 30: teleport.presence.v1.DeleteAppServerResponse
-	(*types.RemoteClusterV3)(nil),      // 31: types.RemoteClusterV3
-	(*fieldmaskpb.FieldMask)(nil),      // 32: google.protobuf.FieldMask
-	(*types.ReverseTunnelV2)(nil),      // 33: types.ReverseTunnelV2
-	(*RelayServer)(nil),                // 34: teleport.presence.v1.RelayServer
-	(*types.ServerV2)(nil),             // 35: types.ServerV2
-	(*types.KubernetesClusterV3)(nil),  // 36: types.KubernetesClusterV3
-	(*v1.Filter)(nil),                  // 37: teleport.scopes.v1.Filter
-	(*emptypb.Empty)(nil),              // 38: google.protobuf.Empty
+	(*DeleteKubeServerRequest)(nil),    // 29: teleport.presence.v1.DeleteKubeServerRequest
+	(*DeleteKubeServerResponse)(nil),   // 30: teleport.presence.v1.DeleteKubeServerResponse
+	(*DeleteAppServerRequest)(nil),     // 31: teleport.presence.v1.DeleteAppServerRequest
+	(*DeleteAppServerResponse)(nil),    // 32: teleport.presence.v1.DeleteAppServerResponse
+	(*types.RemoteClusterV3)(nil),      // 33: types.RemoteClusterV3
+	(*fieldmaskpb.FieldMask)(nil),      // 34: google.protobuf.FieldMask
+	(*types.ReverseTunnelV2)(nil),      // 35: types.ReverseTunnelV2
+	(*RelayServer)(nil),                // 36: teleport.presence.v1.RelayServer
+	(*types.ServerV2)(nil),             // 37: types.ServerV2
+	(*types.KubernetesClusterV3)(nil),  // 38: types.KubernetesClusterV3
+	(*v1.Filter)(nil),                  // 39: teleport.scopes.v1.Filter
+	(*emptypb.Empty)(nil),              // 40: google.protobuf.Empty
 }
 var file_teleport_presence_v1_service_proto_depIdxs = []int32{
-	31, // 0: teleport.presence.v1.ListRemoteClustersResponse.remote_clusters:type_name -> types.RemoteClusterV3
-	31, // 1: teleport.presence.v1.UpdateRemoteClusterRequest.remote_cluster:type_name -> types.RemoteClusterV3
-	32, // 2: teleport.presence.v1.UpdateRemoteClusterRequest.update_mask:type_name -> google.protobuf.FieldMask
-	33, // 3: teleport.presence.v1.ListReverseTunnelsResponse.reverse_tunnels:type_name -> types.ReverseTunnelV2
-	33, // 4: teleport.presence.v1.UpsertReverseTunnelRequest.reverse_tunnel:type_name -> types.ReverseTunnelV2
-	34, // 5: teleport.presence.v1.GetRelayServerResponse.relay_server:type_name -> teleport.presence.v1.RelayServer
-	34, // 6: teleport.presence.v1.ListRelayServersResponse.relays:type_name -> teleport.presence.v1.RelayServer
-	35, // 7: teleport.presence.v1.ListAuthServersResponse.servers:type_name -> types.ServerV2
-	35, // 8: teleport.presence.v1.ListProxyServersResponse.servers:type_name -> types.ServerV2
-	35, // 9: teleport.presence.v1.UpsertProxyServerRequest.server:type_name -> types.ServerV2
-	35, // 10: teleport.presence.v1.UpsertProxyServerResponse.server:type_name -> types.ServerV2
-	36, // 11: teleport.presence.v1.GetKubeClusterResponse.cluster:type_name -> types.KubernetesClusterV3
-	37, // 12: teleport.presence.v1.ListKubeClustersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
-	36, // 13: teleport.presence.v1.ListKubeClustersResponse.clusters:type_name -> types.KubernetesClusterV3
+	33, // 0: teleport.presence.v1.ListRemoteClustersResponse.remote_clusters:type_name -> types.RemoteClusterV3
+	33, // 1: teleport.presence.v1.UpdateRemoteClusterRequest.remote_cluster:type_name -> types.RemoteClusterV3
+	34, // 2: teleport.presence.v1.UpdateRemoteClusterRequest.update_mask:type_name -> google.protobuf.FieldMask
+	35, // 3: teleport.presence.v1.ListReverseTunnelsResponse.reverse_tunnels:type_name -> types.ReverseTunnelV2
+	35, // 4: teleport.presence.v1.UpsertReverseTunnelRequest.reverse_tunnel:type_name -> types.ReverseTunnelV2
+	36, // 5: teleport.presence.v1.GetRelayServerResponse.relay_server:type_name -> teleport.presence.v1.RelayServer
+	36, // 6: teleport.presence.v1.ListRelayServersResponse.relays:type_name -> teleport.presence.v1.RelayServer
+	37, // 7: teleport.presence.v1.ListAuthServersResponse.servers:type_name -> types.ServerV2
+	37, // 8: teleport.presence.v1.ListProxyServersResponse.servers:type_name -> types.ServerV2
+	37, // 9: teleport.presence.v1.UpsertProxyServerRequest.server:type_name -> types.ServerV2
+	37, // 10: teleport.presence.v1.UpsertProxyServerResponse.server:type_name -> types.ServerV2
+	38, // 11: teleport.presence.v1.GetKubeClusterResponse.cluster:type_name -> types.KubernetesClusterV3
+	39, // 12: teleport.presence.v1.ListKubeClustersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
+	38, // 13: teleport.presence.v1.ListKubeClustersResponse.clusters:type_name -> types.KubernetesClusterV3
 	0,  // 14: teleport.presence.v1.PresenceService.GetRemoteCluster:input_type -> teleport.presence.v1.GetRemoteClusterRequest
 	1,  // 15: teleport.presence.v1.PresenceService.ListRemoteClusters:input_type -> teleport.presence.v1.ListRemoteClustersRequest
 	3,  // 16: teleport.presence.v1.PresenceService.UpdateRemoteCluster:input_type -> teleport.presence.v1.UpdateRemoteClusterRequest
@@ -2373,27 +2515,29 @@ var file_teleport_presence_v1_service_proto_depIdxs = []int32{
 	23, // 28: teleport.presence.v1.PresenceService.GetKubeCluster:input_type -> teleport.presence.v1.GetKubeClusterRequest
 	25, // 29: teleport.presence.v1.PresenceService.ListKubeClusters:input_type -> teleport.presence.v1.ListKubeClustersRequest
 	27, // 30: teleport.presence.v1.PresenceService.DeleteKubeCluster:input_type -> teleport.presence.v1.DeleteKubeClusterRequest
-	29, // 31: teleport.presence.v1.PresenceService.DeleteAppServer:input_type -> teleport.presence.v1.DeleteAppServerRequest
-	31, // 32: teleport.presence.v1.PresenceService.GetRemoteCluster:output_type -> types.RemoteClusterV3
-	2,  // 33: teleport.presence.v1.PresenceService.ListRemoteClusters:output_type -> teleport.presence.v1.ListRemoteClustersResponse
-	31, // 34: teleport.presence.v1.PresenceService.UpdateRemoteCluster:output_type -> types.RemoteClusterV3
-	38, // 35: teleport.presence.v1.PresenceService.DeleteRemoteCluster:output_type -> google.protobuf.Empty
-	6,  // 36: teleport.presence.v1.PresenceService.ListReverseTunnels:output_type -> teleport.presence.v1.ListReverseTunnelsResponse
-	33, // 37: teleport.presence.v1.PresenceService.UpsertReverseTunnel:output_type -> types.ReverseTunnelV2
-	38, // 38: teleport.presence.v1.PresenceService.DeleteReverseTunnel:output_type -> google.protobuf.Empty
-	10, // 39: teleport.presence.v1.PresenceService.GetRelayServer:output_type -> teleport.presence.v1.GetRelayServerResponse
-	12, // 40: teleport.presence.v1.PresenceService.ListRelayServers:output_type -> teleport.presence.v1.ListRelayServersResponse
-	14, // 41: teleport.presence.v1.PresenceService.DeleteRelayServer:output_type -> teleport.presence.v1.DeleteRelayServerResponse
-	16, // 42: teleport.presence.v1.PresenceService.ListAuthServers:output_type -> teleport.presence.v1.ListAuthServersResponse
-	18, // 43: teleport.presence.v1.PresenceService.ListProxyServers:output_type -> teleport.presence.v1.ListProxyServersResponse
-	20, // 44: teleport.presence.v1.PresenceService.UpsertProxyServer:output_type -> teleport.presence.v1.UpsertProxyServerResponse
-	22, // 45: teleport.presence.v1.PresenceService.DeleteProxyServer:output_type -> teleport.presence.v1.DeleteProxyServerResponse
-	24, // 46: teleport.presence.v1.PresenceService.GetKubeCluster:output_type -> teleport.presence.v1.GetKubeClusterResponse
-	26, // 47: teleport.presence.v1.PresenceService.ListKubeClusters:output_type -> teleport.presence.v1.ListKubeClustersResponse
-	28, // 48: teleport.presence.v1.PresenceService.DeleteKubeCluster:output_type -> teleport.presence.v1.DeleteKubeClusterResponse
-	30, // 49: teleport.presence.v1.PresenceService.DeleteAppServer:output_type -> teleport.presence.v1.DeleteAppServerResponse
-	32, // [32:50] is the sub-list for method output_type
-	14, // [14:32] is the sub-list for method input_type
+	29, // 31: teleport.presence.v1.PresenceService.DeleteKubeServer:input_type -> teleport.presence.v1.DeleteKubeServerRequest
+	31, // 32: teleport.presence.v1.PresenceService.DeleteAppServer:input_type -> teleport.presence.v1.DeleteAppServerRequest
+	33, // 33: teleport.presence.v1.PresenceService.GetRemoteCluster:output_type -> types.RemoteClusterV3
+	2,  // 34: teleport.presence.v1.PresenceService.ListRemoteClusters:output_type -> teleport.presence.v1.ListRemoteClustersResponse
+	33, // 35: teleport.presence.v1.PresenceService.UpdateRemoteCluster:output_type -> types.RemoteClusterV3
+	40, // 36: teleport.presence.v1.PresenceService.DeleteRemoteCluster:output_type -> google.protobuf.Empty
+	6,  // 37: teleport.presence.v1.PresenceService.ListReverseTunnels:output_type -> teleport.presence.v1.ListReverseTunnelsResponse
+	35, // 38: teleport.presence.v1.PresenceService.UpsertReverseTunnel:output_type -> types.ReverseTunnelV2
+	40, // 39: teleport.presence.v1.PresenceService.DeleteReverseTunnel:output_type -> google.protobuf.Empty
+	10, // 40: teleport.presence.v1.PresenceService.GetRelayServer:output_type -> teleport.presence.v1.GetRelayServerResponse
+	12, // 41: teleport.presence.v1.PresenceService.ListRelayServers:output_type -> teleport.presence.v1.ListRelayServersResponse
+	14, // 42: teleport.presence.v1.PresenceService.DeleteRelayServer:output_type -> teleport.presence.v1.DeleteRelayServerResponse
+	16, // 43: teleport.presence.v1.PresenceService.ListAuthServers:output_type -> teleport.presence.v1.ListAuthServersResponse
+	18, // 44: teleport.presence.v1.PresenceService.ListProxyServers:output_type -> teleport.presence.v1.ListProxyServersResponse
+	20, // 45: teleport.presence.v1.PresenceService.UpsertProxyServer:output_type -> teleport.presence.v1.UpsertProxyServerResponse
+	22, // 46: teleport.presence.v1.PresenceService.DeleteProxyServer:output_type -> teleport.presence.v1.DeleteProxyServerResponse
+	24, // 47: teleport.presence.v1.PresenceService.GetKubeCluster:output_type -> teleport.presence.v1.GetKubeClusterResponse
+	26, // 48: teleport.presence.v1.PresenceService.ListKubeClusters:output_type -> teleport.presence.v1.ListKubeClustersResponse
+	28, // 49: teleport.presence.v1.PresenceService.DeleteKubeCluster:output_type -> teleport.presence.v1.DeleteKubeClusterResponse
+	30, // 50: teleport.presence.v1.PresenceService.DeleteKubeServer:output_type -> teleport.presence.v1.DeleteKubeServerResponse
+	32, // 51: teleport.presence.v1.PresenceService.DeleteAppServer:output_type -> teleport.presence.v1.DeleteAppServerResponse
+	33, // [33:52] is the sub-list for method output_type
+	14, // [14:33] is the sub-list for method input_type
 	14, // [14:14] is the sub-list for extension type_name
 	14, // [14:14] is the sub-list for extension extendee
 	0,  // [0:14] is the sub-list for field type_name
@@ -2411,7 +2555,7 @@ func file_teleport_presence_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_presence_v1_service_proto_rawDesc), len(file_teleport_presence_v1_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   31,
+			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/proto/teleport/presence/v1/service.proto
+++ b/api/proto/teleport/presence/v1/service.proto
@@ -66,6 +66,9 @@ service PresenceService {
   // Deletes a kube cluster resource from the backend.
   rpc DeleteKubeCluster(DeleteKubeClusterRequest) returns (DeleteKubeClusterResponse);
 
+  // Deletes a specific scoped or unscoped kube server from the backend.
+  rpc DeleteKubeServer(DeleteKubeServerRequest) returns (DeleteKubeServerResponse);
+
   // Deletes a specific scoped or unscoped application server.
   rpc DeleteAppServer(DeleteAppServerRequest) returns (DeleteAppServerResponse);
 }
@@ -285,6 +288,20 @@ message DeleteKubeClusterRequest {
 
 // The response for deleting a specific scoped or unscoped kube cluster resource.
 message DeleteKubeClusterResponse {}
+
+// The request to delete a specific scoped or unscoped kube server.
+message DeleteKubeServerRequest {
+  // The kube server host uuid.
+  string host_id = 1;
+  // The name of the kube server to delete.
+  string name = 2;
+  // The scope of the kube server to delete. Empty for unscoped
+  // servers.
+  string scope = 3;
+}
+
+// The response for deleting a kube server.
+message DeleteKubeServerResponse {}
 
 // The request to delete a specific scoped or unscoped application server.
 message DeleteAppServerRequest {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1279,7 +1279,8 @@ func supportedScopedWatchKind(kind string) bool {
 		types.KindAccessListMember,
 		types.KindAccessListReview,
 		scopedaccess.KindScopedRole,
-		scopedaccess.KindScopedRoleAssignment:
+		scopedaccess.KindScopedRoleAssignment,
+		types.KindKubernetesCluster:
 		return true
 	default:
 		return false
@@ -7003,13 +7004,37 @@ func (a *ServerWithRoles) UpsertKubernetesServer(ctx context.Context, s types.Ku
 }
 
 // DeleteKubernetesServer deletes specified kubernetes server.
-func (a *ServerWithRoles) DeleteKubernetesServer(ctx context.Context, hostID, name string) error {
-	if err := a.ScopedServerWithRoles().scopedContext.AgentOwnedResourceAction("", hostID, types.RoleKube); err != nil {
-		if err := a.authorizeAction(types.KindKubeServer, types.VerbDelete); err != nil {
+//
+// Deprecated: Use DeleteKubeServer in the presence service instead.
+// TODO (eriktate): remove in v20
+func (a *ScopedServerWithRoles) DeleteKubernetesServer(ctx context.Context, req *proto.DeleteKubernetesServerRequest) error {
+	var existingServer types.KubeServer
+	for server, err := range a.authServer.RangeKubernetesServersWithName(ctx, req.GetName()) {
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		// only allow unscoped kube servers to be deleted using this deprecated DeleteKubernetesServer method
+		if server.GetScope() == "" && server.GetHostID() == req.GetHostID() {
+			existingServer = server
+			break
+		}
+	}
+	if existingServer == nil {
+		return trace.NotFound("%s %q doesn't exist", types.KindKubeServer, req.GetName())
+	}
+	if err := a.scopedContext.AgentOwnedResourceAction(existingServer.GetScope(), existingServer.GetHostID(), types.RoleKube); err != nil {
+		ruleCtx := a.scopedContext.RuleContext()
+		if err := a.scopedContext.CheckerContext.Decision(ctx, existingServer.GetScope(), func(checker *services.ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(&ruleCtx, types.KindKubeServer, types.VerbDelete)
+		}); err != nil {
 			return trace.Wrap(err)
 		}
 	}
-	return a.authServer.DeleteKubernetesServer(ctx, hostID, name)
+	return a.authServer.DeleteKubeServer(ctx, presencev1.DeleteKubeServerRequest_builder{
+		Scope:  existingServer.GetScope(),
+		Name:   req.GetName(),
+		HostId: req.GetHostID(),
+	}.Build())
 }
 
 // DeleteAllKubernetesServers deletes all registered kubernetes servers.

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -3552,11 +3552,12 @@ func TestKubeCRUDFromKubeService(t *testing.T) {
 	}))
 
 	const scope = "/test"
+	const hostID = "host-id"
 	scopedIdent := authtest.TestScopePinnedHost(srv.ClusterName(), "scoped-host", scope, types.RoleKube)
 	scopedKubeClient, err := srv.NewClient(scopedIdent)
 	require.NoError(t, err)
 
-	unscopedKubeClient, err := srv.NewClient(authtest.TestServerID(types.RoleKube, "host-id"))
+	unscopedKubeClient, err := srv.NewClient(authtest.TestServerID(types.RoleKube, hostID))
 	require.NoError(t, err)
 
 	// create an admin client to create resources and setup for test cases
@@ -3593,7 +3594,7 @@ func TestKubeCRUDFromKubeService(t *testing.T) {
 	err = adminClient.CreateKubernetesCluster(ctx, scopedKubeCluster)
 	require.NoError(t, err)
 
-	kubeServer, err := types.NewKubernetesServerV3FromCluster(kubeCluster, "hostname", "host-id")
+	kubeServer, err := types.NewKubernetesServerV3FromCluster(kubeCluster, "hostname", hostID)
 	require.NoError(t, err)
 	_, err = adminClient.UpsertKubernetesServer(ctx, kubeServer)
 	require.NoError(t, err)
@@ -3747,12 +3748,16 @@ func TestKubeCRUDFromKubeService(t *testing.T) {
 		_, err := adminClient.UpsertKubernetesServer(ctx, ks)
 		require.NoError(t, err)
 
-		// unscoped kube clients SHOULD be able to delete a kube server
-		err = unscopedKubeClient.DeleteKubernetesServer(ctx, "host-id", ks.GetName())
+		// unscoped kube clients SHOULD be able to delete their own kube server
+		// TODO (eriktate): remove in v20
+		//nolint:staticcheck // SA1019
+		err = unscopedKubeClient.DeleteKubernetesServer(ctx, hostID, ks.GetName())
 		require.NoError(t, err)
 
 		// scoped kube clients SHOULD NOT be able to delete a kube server
-		err = scopedKubeClient.DeleteKubernetesServer(ctx, "hostname", "host-id")
+		// TODO (eriktate): remove in v20
+		//nolint:staticcheck // SA1019
+		err = scopedKubeClient.DeleteKubernetesServer(ctx, "hostname", hostID)
 		require.Error(t, err)
 		require.True(t, trace.IsAccessDenied(err), "expected access denied error")
 	})
@@ -14701,11 +14706,21 @@ func TestRoleKubeLeastPrivilege(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("delete own kube server allowed", func(t *testing.T) {
-		require.NoError(t, kube.DeleteKubernetesServer(ctx, ownID, "kube"))
+		// TODO (eriktate): remove in v20
+		//nolint:staticcheck // SA1019
+		require.NoError(t, kube.ScopedServerWithRoles().DeleteKubernetesServer(ctx, &proto.DeleteKubernetesServerRequest{
+			HostID: ownID,
+			Name:   "kube",
+		}))
 	})
 
 	t.Run("delete other kube server denied", func(t *testing.T) {
-		err := kube.DeleteKubernetesServer(ctx, otherID, "kube")
+		// TODO (eriktate): remove in v20
+		//nolint:staticcheck // SA1019
+		err := kube.ScopedServerWithRoles().DeleteKubernetesServer(ctx, &proto.DeleteKubernetesServerRequest{
+			HostID: otherID,
+			Name:   "kube",
+		})
 		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
 	})
 

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -2264,12 +2264,15 @@ func (g *GRPCServer) UpsertKubernetesServer(ctx context.Context, req *authpb.Ups
 }
 
 // DeleteKubernetesServer deletes a kubernetes server.
+//
+// Deprecated: Use DeleteKubeServer in the presence service instead.
+// TODO (eriktate): remove in v20
 func (g *GRPCServer) DeleteKubernetesServer(ctx context.Context, req *authpb.DeleteKubernetesServerRequest) (*emptypb.Empty, error) {
-	auth, err := g.authenticate(ctx)
+	auth, err := g.scopedAuthenticate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	err = auth.DeleteKubernetesServer(ctx, req.GetHostID(), req.GetName())
+	err = auth.DeleteKubernetesServer(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/presence/presencev1/service.go
+++ b/lib/auth/presence/presencev1/service.go
@@ -62,6 +62,8 @@ type Backend interface {
 	GetKubeCluster(ctx context.Context, req *presencepb.GetKubeClusterRequest) (types.KubeCluster, error)
 	RangeKubeClusters(ctx context.Context, req *presencepb.ListKubeClustersRequest) iter.Seq2[types.KubeCluster, error]
 	DeleteKubeCluster(ctx context.Context, req *presencepb.DeleteKubeClusterRequest) error
+
+	DeleteKubeServer(ctx context.Context, req *presencepb.DeleteKubeServerRequest) error
 }
 
 type Cache interface {
@@ -812,4 +814,39 @@ func (s *Service) DeleteKubeCluster(ctx context.Context, req *presencepb.DeleteK
 		s.logger.WarnContext(ctx, "Failed to emit kube cluster delete event", "error", err)
 	}
 	return presencepb.DeleteKubeClusterResponse_builder{}.Build(), nil
+}
+
+// DeleteKubeServer deletes a scoped or unscoped kube server.
+func (s *Service) DeleteKubeServer(
+	ctx context.Context, req *presencepb.DeleteKubeServerRequest,
+) (*presencepb.DeleteKubeServerResponse, error) {
+	authzCtx, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	switch {
+	case req.GetHostId() == "":
+		return nil, trace.BadParameter("host_id: must be specified")
+	case req.GetName() == "":
+		return nil, trace.BadParameter("name: must be specified")
+	}
+
+	ruleCtx := authzCtx.RuleContext()
+	if err := authzCtx.CheckerContext.Decision(ctx, req.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		// Kube agents can delete their own kube servers
+		// (builtin RoleKube only grants read on kube_server rules); anyone else
+		// needs an app_server delete rule granted in the target scope.
+		if err := authzCtx.AgentOwnedResourceAction(req.GetScope(), req.GetHostId(), types.RoleKube); err == nil {
+			return nil
+		}
+		return checker.CheckAccessToRules(&ruleCtx, types.KindKubeServer, types.VerbDelete)
+	}); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := s.backend.DeleteKubeServer(ctx, req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return presencepb.DeleteKubeServerResponse_builder{}.Build(), nil
 }

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -383,7 +383,6 @@ func ForNode(cfg Config) Config {
 // ForKubernetes sets up watch configuration for a kubernetes service.
 func ForKubernetes(cfg Config) Config {
 	cfg.target = "kube"
-	unscoped := types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build())
 	cfg.Watches = []types.WatchKind{
 		{Kind: types.KindCertAuthority, LoadSecrets: false, Filter: makeAllKnownCAsFilter().IntoMap()},
 		{Kind: types.KindClusterName},
@@ -394,7 +393,7 @@ func ForKubernetes(cfg Config) Config {
 		{Kind: types.KindUser},
 		{Kind: types.KindRole},
 		{Kind: types.KindKubeServer},
-		{Kind: types.KindKubernetesCluster, ScopeFilter: unscoped},
+		{Kind: types.KindKubernetesCluster},
 		{Kind: types.KindKubeWaitingContainer},
 		{Kind: types.KindHealthCheckConfig},
 	}

--- a/lib/cache/kube.go
+++ b/lib/cache/kube.go
@@ -19,7 +19,6 @@ package cache
 import (
 	"context"
 	"iter"
-	"strings"
 
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/proto"
@@ -29,10 +28,8 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	kubewaitingcontainerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
-	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
-	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
@@ -52,7 +49,11 @@ func kubeServerByClusterNameKey(s types.KubeServer) string {
 	if cluster == nil {
 		return ""
 	}
-	return string(ordered.Encode(cluster.GetName(), s.GetHostID(), s.GetName()))
+	// The second component is the scope-aware resource cursor, so within each
+	// kube cluster name the in-memory ordering matches the backend listing order
+	// (unscoped first, then scoped) and index keys are interchangeable with
+	// the fallback pagination tokens.
+	return string(ordered.Encode(cluster.GetName(), services.GetCursorForKubeServer(s)))
 }
 
 func newKubernetesServerCollection(p services.Presence, w types.WatchKind) (*collection[types.KubeServer, kubeServerIndex], error) {
@@ -65,9 +66,7 @@ func newKubernetesServerCollection(p services.Presence, w types.WatchKind) (*col
 			types.KindKubeServer,
 			types.KubeServer.Copy,
 			map[kubeServerIndex]func(types.KubeServer) string{
-				kubeServerNameIndex: func(u types.KubeServer) string {
-					return u.GetHostID() + "/" + u.GetName()
-				},
+				kubeServerNameIndex:        services.GetCursorForKubeServer,
 				kubeServerClusterNameIndex: kubeServerByClusterNameKey,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.KubeServer, error) {
@@ -137,20 +136,19 @@ func (c *Cache) RangeKubernetesServersWithName(ctx context.Context, clusterName 
 				return nil, "", trace.BadParameter("pagination token does not match the requested kubernetes cluster name")
 			}
 
-			backendKey := ""
+			// The remainder of the token is the scope aware resource
+			startKey := ""
 			if len(rest) > 0 {
-				var hostID, serverName string
-				if err := ordered.Decode(rest, &hostID, &serverName); err != nil {
+				if err := ordered.Decode(rest, &startKey); err != nil {
 					return nil, "", trace.Wrap(err)
 				}
-				backendKey = hostID + "/" + serverName
 			}
 
 			resp, err := c.Config.Presence.ListResources(ctx, clientproto.ListResourcesRequest{
 				ResourceType: types.KindKubeServer,
 				Namespace:    defaults.Namespace,
 				Limit:        int32(pageSize),
-				StartKey:     backendKey,
+				StartKey:     startKey,
 			})
 			if err != nil {
 				return nil, "", trace.Wrap(err)
@@ -170,11 +168,7 @@ func (c *Cache) RangeKubernetesServersWithName(ctx context.Context, clusterName 
 
 			next := ""
 			if resp.NextKey != "" {
-				hostID, serverName, ok := strings.Cut(resp.NextKey, backend.SeparatorString)
-				if !ok {
-					return nil, "", trace.BadParameter("invalid pagination token: %q", resp.NextKey)
-				}
-				next = string(ordered.Encode(clusterName, hostID, serverName))
+				next = string(ordered.Encode(clusterName, resp.NextKey))
 			}
 			return page, next, nil
 		}
@@ -213,17 +207,6 @@ func newKubernetesClusterCollection(upstream KubeClusterUpstream, w types.WatchK
 		return nil, trace.BadParameter("missing parameter KubeClusterUpstream")
 	}
 
-	var scopeFilter *scopesv1.Filter
-	if filter := w.ScopeFilter; filter != nil {
-		scopeFilter = scopesv1.Filter_builder{
-			Scope: filter.Scope,
-			Mode:  filter.Mode,
-		}.Build()
-	} else {
-		scopeFilter = scopesv1.Filter_builder{
-			Mode: scopesv1.Mode_MODE_UNSCOPED,
-		}.Build()
-	}
 	return &collection[types.KubeCluster, kubeClusterIndex]{
 		store: newStore(
 			types.KindKubernetesCluster,
@@ -236,7 +219,7 @@ func newKubernetesClusterCollection(upstream KubeClusterUpstream, w types.WatchK
 				return upstream.ListKubeClusters(ctx, presencev1.ListKubeClustersRequest_builder{
 					PageSize:    int32(pageSize),
 					PageToken:   pageToken,
-					ScopeFilter: scopeFilter,
+					ScopeFilter: w.ScopeFilter.ToProto(),
 				}.Build())
 			}))
 		},

--- a/lib/cache/kube_test.go
+++ b/lib/cache/kube_test.go
@@ -20,16 +20,20 @@ import (
 	"context"
 	"iter"
 	"testing"
+	"testing/synctest"
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/client/proto"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	kubewaitingcontainerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/kubewaitingcontainer"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -227,7 +231,93 @@ func TestKubernetesServers(t *testing.T) {
 			},
 		})
 	})
+}
 
+// TestListResourcesKubeServerScopedPagination verifies that ListResources
+// pagination spanning unscoped and scoped kube servers returns every server
+func TestListResourcesKubeServerScopedPagination(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name    string
+		neverOK bool
+	}{
+		{name: "HealthyCache", neverOK: false},
+		{name: "Fallback", neverOK: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx := t.Context()
+
+				p := newTestPack(t, func(cfg Config) Config {
+					cfg = ForAuth(cfg)
+					cfg.neverOK = tt.neverOK
+					return cfg
+				})
+				t.Cleanup(p.Close)
+
+				go func() {
+					for {
+						select {
+						case <-ctx.Done():
+							return
+						case <-p.eventsC:
+							// Discard events to avoid blocking the test.
+						}
+					}
+				}()
+
+				key := func(s types.KubeServer) string {
+					return s.GetScope() + "/" + s.GetHostID() + "/" + s.GetName()
+				}
+
+				var expectedKeys []string
+				for _, scope := range []string{"", "", "", "/prod", "/prod", "/staging"} {
+					server := mustCreateKubeServer(t, uuid.New().String(), "testcluster").(*types.KubernetesServerV3)
+					server.Scope = scope
+					server.Spec.Cluster.Scope = scope
+					_, err := p.presenceS.UpsertKubernetesServer(ctx, server)
+					require.NoError(t, err)
+					expectedKeys = append(expectedKeys, key(server))
+				}
+
+				// Wait for the cache to replicate all servers.
+				synctest.Wait()
+
+				var actualKeys []string
+				startKey := ""
+				for {
+					resp, err := p.cache.ListResources(ctx, proto.ListResourcesRequest{
+						ResourceType: types.KindKubeServer,
+						Namespace:    apidefaults.Namespace,
+						Limit:        1,
+						StartKey:     startKey,
+					})
+					require.NoError(t, err)
+					r := resp.Resources[0]
+					server, ok := r.(types.KubeServer)
+					require.True(t, ok)
+					if startKey != "" { // first entry
+						if startKey == scopes.ResourceCursorScopedStart() {
+							// The unscoped range ended exactly at a page boundary;
+							// next entry should be scoped
+							require.NotEmpty(t, server.GetScope())
+						} else {
+							require.Equal(t, startKey, services.GetCursorForKubeServer(server))
+						}
+					}
+					actualKeys = append(actualKeys, key(server))
+
+					if resp.NextKey == "" {
+						break
+					}
+					startKey = resp.NextKey
+				}
+
+				require.ElementsMatch(t, expectedKeys, actualKeys)
+			})
+		})
+	}
 }
 
 func mustCreateKubeServer(t testing.TB, hostID, clusterName string) types.KubeServer {
@@ -250,7 +340,11 @@ var kubeServerRangeFuncs = rangeServersWithTargetNameFuncs[types.KubeServer]{
 		return err
 	},
 	delete: func(ctx context.Context, presence services.Presence, s types.KubeServer) error {
-		return presence.DeleteKubernetesServer(ctx, s.GetHostID(), s.GetName())
+		return presence.DeleteKubeServer(ctx, presencev1.DeleteKubeServerRequest_builder{
+			HostId: s.GetHostID(),
+			Name:   s.GetName(),
+			Scope:  s.GetScope(),
+		}.Build())
 	},
 	rangeByName: (*Cache).RangeKubernetesServersWithName,
 }

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -66,7 +66,7 @@ type Auth interface {
 	DeleteDatabaseServer(ctx context.Context, namespace, hostID, name string) error
 
 	UpsertKubernetesServer(context.Context, types.KubeServer) (*types.KeepAlive, error)
-	DeleteKubernetesServer(ctx context.Context, hostID, name string) error
+	DeleteKubeServer(ctx context.Context, req *presencev1.DeleteKubeServerRequest) error
 
 	UpsertRelayServer(ctx context.Context, relayServer *presencev1.RelayServer) (*presencev1.RelayServer, error)
 	DeleteRelayServer(ctx context.Context, name string) error
@@ -831,7 +831,11 @@ func (c *Controller) doResourceCleanup(handle *upstreamHandle) {
 			return
 		}
 
-		if err := c.auth.DeleteKubernetesServer(c.closeContext, kube.resource.GetHostID(), kube.resource.GetName()); err != nil && !trace.IsNotFound(err) {
+		if err := c.auth.DeleteKubeServer(c.closeContext, presencev1.DeleteKubeServerRequest_builder{
+			Scope:  kube.resource.GetScope(),
+			HostId: kube.resource.GetHostID(),
+			Name:   kube.resource.GetName(),
+		}.Build()); err != nil && !trace.IsNotFound(err) {
 			if cleanupCtx.Err() != nil {
 				slog.WarnContext(c.closeContext, "halting remaining resource cleanup", "instance_id", handle.Hello().GetServerID(), "error", err)
 				return

--- a/lib/inventory/controller_test.go
+++ b/lib/inventory/controller_test.go
@@ -182,7 +182,7 @@ func (a *fakeAuth) UpsertKubernetesServer(_ context.Context, server types.KubeSe
 	}, a.err
 }
 
-func (a *fakeAuth) DeleteKubernetesServer(ctx context.Context, hostID, name string) error {
+func (a *fakeAuth) DeleteKubeServer(ctx context.Context, req *presencev1.DeleteKubeServerRequest) error {
 	return nil
 }
 

--- a/lib/join/join_ec2_test.go
+++ b/lib/join/join_ec2_test.go
@@ -676,7 +676,10 @@ func TestHostUniqueCheck(t *testing.T) {
 				require.NoError(t, err)
 			},
 			deleter: func(t *testing.T, hostID string) {
-				require.NoError(t, a.DeleteKubernetesServer(t.Context(), hostID, "test-kube-cluster"))
+				require.NoError(t, a.DeleteKubeServer(t.Context(), presencev1.DeleteKubeServerRequest_builder{
+					HostId: hostID,
+					Name:   "test-kube-cluster",
+				}.Build()))
 			},
 		},
 		{

--- a/lib/kube/proxy/exec_test.go
+++ b/lib/kube/proxy/exec_test.go
@@ -513,7 +513,7 @@ func TestExecKubeServiceWithFaultyPrimary(t *testing.T) {
 	// creates a Kubernetes service with a configured cluster pointing to mock api server
 	testCtx := SetupTestContext(t.Context(), t, TestConfig{
 		Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
-		WrapAuthClient: func(client authclient.ClientI) authclient.ClientI {
+		WrapProxyAccessPoint: func(client authclient.ClientI) authclient.ClientI {
 			failingAccessPoint.ClientI = client
 			return failingAccessPoint
 		},

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -243,10 +243,6 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	// TODO(eriktate/scopes): remove this validation once dynamic cluster registration supports scopes
-	if cfg.GetScope() != "" && len(cfg.ResourceMatchers) > 0 {
-		return nil, trace.BadParameter("dynamic cluster registration not supported for scoped kube_service, resource matchers must be empty")
-	}
 	cfg.ForwarderConfig.log = log
 	fwd, err := NewForwarder(cfg.ForwarderConfig)
 	if err != nil {

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -120,6 +120,7 @@ type TestConfig struct {
 	ClusterFeatures      func() proto.Features
 	CreateAuditStreamErr error
 	WrapAuthClient       func(authclient.ClientI) authclient.ClientI
+	WrapProxyAccessPoint func(authclient.ClientI) authclient.ClientI
 	ScopesFeatures       scopes.Features
 	Scope                string
 }
@@ -150,12 +151,13 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 
 	// Create and start test auth server.
 	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
-		Clock:         clockwork.NewFakeClockAt(time.Now()),
-		ClusterName:   testCtx.ClusterName,
-		Streamer:      streamer,
-		UploadHandler: testCtx.UploadHandler,
-		Dir:           t.TempDir(),
-		Modules:       cmp.Or(cfg.Modules, modulestest.OSSModules()),
+		Clock:          clockwork.NewFakeClockAt(time.Now()),
+		ClusterName:    testCtx.ClusterName,
+		Streamer:       streamer,
+		UploadHandler:  testCtx.UploadHandler,
+		Dir:            t.TempDir(),
+		Modules:        cmp.Or(cfg.Modules, modulestest.OSSModules()),
+		ScopesFeatures: cfg.ScopesFeatures,
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
@@ -280,9 +282,11 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		},
 	)
 	require.NoError(t, err)
-	err = healthCheckManager.Start(testCtx.Context)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, healthCheckManager.Close()) })
+	if cfg.Scope == "" {
+		err = healthCheckManager.Start(testCtx.Context)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, healthCheckManager.Close()) })
+	}
 
 	var authClient authclient.ClientI = client
 	if cfg.WrapAuthClient != nil {
@@ -292,6 +296,15 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	var accessPoint authclient.ClientI = client
 	if cfg.WrapAuthClient != nil {
 		accessPoint = cfg.WrapAuthClient(client)
+	}
+	// The kube service must use its scoped identity to watch kube_cluster
+	// resources. The proxy, however, watches kube_servers in every scope.
+	proxyAccessPoint := accessPoint
+	if cfg.Scope != "" {
+		proxyAccessPoint = proxyAuthClient
+	}
+	if cfg.WrapProxyAccessPoint != nil {
+		proxyAccessPoint = cfg.WrapProxyAccessPoint(proxyAccessPoint)
 	}
 
 	// Create kubernetes service server.
@@ -352,7 +365,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		testCtx.Context,
 		kubewatcher.ProxyKubeServerWatcherConfig{
 			Logger:           logtest.NewLogger(),
-			AccessPoint:      accessPoint,
+			AccessPoint:      proxyAccessPoint,
 			FallbackGetter:   proxyAuthClient,
 			PrimaryTimeout:   time.Second,
 			FallbackInterval: time.Second,
@@ -415,7 +428,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 			PROXYSigner: &multiplexer.PROXYSigner{},
 		},
 		TLS:                      proxyTLSConfig.Clone(),
-		AccessPoint:              accessPoint,
+		AccessPoint:              proxyAccessPoint,
 		KubernetesServersWatcher: kubeServersWatcher,
 		LimiterConfig: limiter.Config{
 			MaxConnections: 1000,

--- a/lib/kube/proxy/watcher.go
+++ b/lib/kube/proxy/watcher.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
@@ -93,7 +94,7 @@ func (s *TLSServer) startReconciler(ctx context.Context) (err error) {
 // startKubeClusterResourceWatcher starts watching changes to Kube Clusters resources and
 // registers/unregisters the proxied Kube Cluster accordingly.
 func (s *TLSServer) startKubeClusterResourceWatcher(ctx context.Context) (*services.GenericWatcher[types.KubeCluster, readonly.KubeCluster], error) {
-	if len(s.ResourceMatchers) == 0 || s.KubeServiceType != KubeService || s.GetScope() != "" {
+	if len(s.ResourceMatchers) == 0 || s.KubeServiceType != KubeService {
 		s.log.DebugContext(ctx, "Not initializing Kube Cluster resource watcher")
 		return nil, nil
 	}
@@ -264,7 +265,11 @@ func (s *TLSServer) unregisterKubeCluster(ctx context.Context, cluster types.Kub
 
 // deleteKubernetesServer deletes kubernetes server for the specified cluster.
 func (s *TLSServer) deleteKubernetesServer(ctx context.Context, name string) error {
-	err := s.AuthClient.DeleteKubernetesServer(ctx, s.HostID, name)
+	err := s.AuthClient.DeleteKubeServer(ctx, presencev1.DeleteKubeServerRequest_builder{
+		Scope:  s.GetScope(),
+		HostId: s.HostID,
+		Name:   name,
+	}.Build())
 	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}

--- a/lib/kube/proxy/watcher_test.go
+++ b/lib/kube/proxy/watcher_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -51,13 +52,13 @@ func newMockAuthClient() *mockAuthClient {
 	}
 }
 
-func (m *mockAuthClient) DeleteKubernetesServer(ctx context.Context, hostID, name string) error {
+func (m *mockAuthClient) DeleteKubeServer(ctx context.Context, req *presencev1.DeleteKubeServerRequest) error {
 	select {
-	case m.deleteCh <- name:
+	case m.deleteCh <- scopes.MakeResourceCursor(req.GetScope(), req.GetName()):
 	case <-time.After(5 * time.Second):
 		return fmt.Errorf("failed to signal kube server deletion")
 	}
-	return m.ClientI.DeleteKubernetesServer(ctx, hostID, name)
+	return m.ClientI.DeleteKubeServer(ctx, req)
 }
 
 // TestWatcher verifies that kubernetes agent properly detects and applies
@@ -211,7 +212,7 @@ func TestWatcher(t *testing.T) {
 	}
 	select {
 	case deleted := <-authClient.deleteCh:
-		require.Equal(t, kube1.GetName(), deleted)
+		require.Equal(t, services.GetCursorForKubeCluster(kube1), deleted)
 	case <-time.After(time.Second):
 		t.Fatal("Kube server wasn't deleted after 1s.")
 	}
@@ -234,7 +235,153 @@ func TestWatcher(t *testing.T) {
 	}
 	select {
 	case deleted := <-authClient.deleteCh:
-		require.Equal(t, kube2.GetName(), deleted)
+		require.Equal(t, services.GetCursorForKubeCluster(kube2), deleted)
+	case <-time.After(time.Second):
+		t.Fatal("Kube server wasn't deleted after 1s.")
+	}
+}
+
+// TestScopedWatcher verifies that kubernetes agent properly detects and applies
+// changes to scoped kube_cluster resources.
+func TestScopedWatcher(t *testing.T) {
+	kubeMock, err := testingkubemock.NewKubeAPIMock()
+	require.NoError(t, err)
+	t.Cleanup(func() { kubeMock.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	reconcileCh := make(chan types.KubeClusters)
+
+	const scope = "/aa"
+	authClient := newMockAuthClient()
+	// Setup kubernetes server that proxies one static kube cluster and
+	// watches for kube_clusters with label group=a.
+	testCtx := SetupTestContext(ctx, t, TestConfig{
+		Clusters: []KubeClusterConfig{{"kube0", kubeMock.URL}},
+		ResourceMatchers: []services.ResourceMatcher{
+			{Labels: types.Labels{
+				"group": []string{"a"},
+			}},
+		},
+		OnReconcile: func(kcs types.KubeClusters) {
+			select {
+			case reconcileCh <- kcs:
+			case <-ctx.Done():
+				return
+			}
+		},
+		WrapAuthClient: func(client authclient.ClientI) authclient.ClientI {
+			authClient.ClientI = client
+			return authClient
+		},
+		Scope: scope,
+		ScopesFeatures: scopes.Features{
+			Enabled:         true,
+			AgentPinEnabled: true,
+		},
+	})
+
+	require.Len(t, testCtx.KubeServer.fwd.kubeClusters(), 1)
+	kube0 := testCtx.KubeServer.fwd.kubeClusters()[0]
+
+	// Only kube0 should be registered initially.
+	select {
+	case a := <-reconcileCh:
+		sort.Sort(a)
+		require.Empty(t, cmp.Diff(types.KubeClusters{kube0}, a,
+			cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+		))
+	case <-time.After(time.Second):
+		t.Fatal("Didn't receive reconcile event after 1s.")
+	}
+
+	// Create an unscoped kube1 with label group=a
+	kube1, err := makeDynamicKubeCluster(t, "kube1", kubeMock.URL, map[string]string{"group": "a"})
+	require.NoError(t, err)
+	err = testCtx.AuthServer.CreateKubernetesCluster(ctx, kube1)
+	require.NoError(t, err)
+
+	// It should NOT be registered due to scope mismatch
+	select {
+	case <-reconcileCh:
+		require.FailNow(t, "unexpected reconcile event for an unscoped kube cluster")
+	case <-time.After(time.Second):
+	}
+
+	// Create kube_cluster with label group=a and scope=/aa
+	kube2, err := makeDynamicKubeCluster(t, "kube2", kubeMock.URL, map[string]string{"group": "a"})
+	require.NoError(t, err)
+	kube2.Scope = scope
+	err = testCtx.AuthServer.CreateKubernetesCluster(ctx, kube2)
+	require.NoError(t, err)
+
+	// It should be registered.
+	select {
+	case a := <-reconcileCh:
+		sort.Sort(a)
+		require.Empty(t, cmp.Diff(types.KubeClusters{kube0, kube2}, a,
+			cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+		))
+	case <-time.After(time.Second):
+		t.Fatal("Didn't receive reconcile event after 1s.")
+	}
+
+	// Create kube_cluster with label group=b in scope=/aa
+	kube3, err := makeDynamicKubeCluster(t, "kube3", kubeMock.URL, map[string]string{"group": "b"})
+	require.NoError(t, err)
+	kube3.Scope = scope
+	err = testCtx.AuthServer.CreateKubernetesCluster(ctx, kube3)
+	require.NoError(t, err)
+
+	// It shouldn't be registered.
+	select {
+	case a := <-reconcileCh:
+		sort.Sort(a)
+		require.Empty(t, cmp.Diff(types.KubeClusters{kube0, kube2}, a,
+			cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+		))
+	case <-time.After(time.Second):
+		t.Fatal("Didn't receive reconcile event after 1s.")
+	}
+
+	// Update kube3 labels so it matches.
+	kube3.SetStaticLabels(map[string]string{"group": "a", types.OriginLabel: types.OriginDynamic})
+	err = testCtx.AuthServer.UpdateKubernetesCluster(ctx, kube3)
+	require.NoError(t, err)
+
+	// kube0, kube2, and kube3 should be registered now.
+	select {
+	case a := <-reconcileCh:
+		sort.Sort(a)
+		require.Empty(t, cmp.Diff(types.KubeClusters{kube0, kube2, kube3}, a,
+			cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+		))
+	case <-time.After(time.Second):
+		t.Fatal("Didn't receive reconcile event after 1s.")
+	}
+
+	// Remove kube2.
+	err = testCtx.AuthServer.DeleteKubeCluster(ctx, presencev1.DeleteKubeClusterRequest_builder{
+		Name:  kube2.GetName(),
+		Scope: kube2.GetScope(),
+	}.Build())
+	require.NoError(t, err)
+
+	// Only kube0 and kube3 should remain.
+	select {
+	case a := <-reconcileCh:
+		sort.Sort(a)
+		require.Empty(t, cmp.Diff(types.KubeClusters{kube0, kube3}, a,
+			cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+		))
+	case <-time.After(time.Second):
+		t.Fatal("Didn't receive reconcile event after 1s.")
+	}
+
+	// Confirm delete event is received
+	select {
+	case deleted := <-authClient.deleteCh:
+		require.Equal(t, services.GetCursorForKubeCluster(kube2), deleted)
 	case <-time.After(time.Second):
 		t.Fatal("Kube server wasn't deleted after 1s.")
 	}

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -347,8 +347,11 @@ func GetCursorForAppServer(server types.AppServer) string {
 // GetCursorForResource returns the pagination cursor for a
 // resource used in ListResources.
 func GetCursorForResource(r types.ResourceWithLabels) string {
-	if s, ok := r.(types.AppServer); ok {
-		return GetCursorForAppServer(s)
+	switch res := r.(type) {
+	case types.AppServer:
+		return GetCursorForAppServer(res)
+	case types.KubeServer:
+		return GetCursorForKubeServer(res)
 	}
 	return backend.GetPaginationKey(r)
 }

--- a/lib/services/kubernetes.go
+++ b/lib/services/kubernetes.go
@@ -178,3 +178,10 @@ func UnmarshalKubeCluster(data []byte, opts ...MarshalOption) (types.KubeCluster
 func GetCursorForKubeCluster(cluster types.KubeCluster) string {
 	return scopes.MakeResourceCursor(cluster.GetScope(), cluster.GetName())
 }
+
+// GetCursorForKubeServer returns the resource cursor identifying a kube server
+// in the logical resource stream: "<host-id>/<cluster-name>" for unscoped kube servers
+// and "~scoped/<encoded-scope>/<host-id>/<cluster-name>" for scoped kube servers.
+func GetCursorForKubeServer(server types.KubeServer) string {
+	return scopes.MakeResourceCursorWithHost(server.GetScope(), server.GetHostID(), server.GetName())
+}

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -1693,7 +1693,7 @@ func (p *webTokenParser) parse(event backend.Event) (types.Resource, error) {
 
 func newKubeServerParser() *kubeServerParser {
 	return &kubeServerParser{
-		baseParser: newBaseParser(backend.NewKey(kubeServersPrefix)),
+		baseParser: newBaseParser(kubeServersUnscopedPrefix(), kubeServersScopedPrefix()),
 	}
 }
 
@@ -1704,18 +1704,24 @@ type kubeServerParser struct {
 func (p *kubeServerParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		components := event.Item.Key.Components()
-		if len(components) != 3 {
-			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		// Scoped kube servers live under
+		// /scoped/kubeServers/<encoded-scope>/<host-id>/<name>.
+		sqn, hostID, err := kubeServerNameFromKey(event.Item.Key)
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 
-		return &types.ResourceHeader{
+		return &types.KubernetesServerV3{
 			Kind:    types.KindKubeServer,
 			Version: types.V3,
 			Metadata: types.Metadata{
-				Name:        components[2],
+				Name:        sqn.Name,
 				Namespace:   apidefaults.Namespace,
-				Description: components[1],
+				Description: hostID,
+			},
+			Scope: sqn.Scope,
+			Spec: types.KubernetesServerSpecV3{
+				HostID: hostID,
 			},
 		}, nil
 	case types.OpPut:
@@ -1869,6 +1875,35 @@ func kubeNameFromKey(key backend.Key) (scopes.QualifiedName, error) {
 		}, nil
 	default:
 		return scopes.QualifiedName{}, trace.NotFound("failed parsing %v", key.String())
+	}
+}
+
+func kubeServerNameFromKey(key backend.Key) (scopes.QualifiedName, string, error) {
+	switch {
+	case key.HasPrefix(kubeServersScopedPrefix()):
+		components := key.TrimPrefix(kubeServersScopedPrefix()).Components()
+		if len(components) != 3 {
+			return scopes.QualifiedName{}, "", trace.NotFound("failed parsing %v", key.String())
+		}
+		encodedScope, hostID, name := components[0], components[1], components[2]
+		scope, err := scopes.DecodeFromKey(encodedScope)
+		if err != nil {
+			return scopes.QualifiedName{}, "", trace.Wrap(err)
+		}
+		return scopes.QualifiedName{
+			Scope: scope,
+			Name:  name,
+		}, hostID, nil
+	case key.HasPrefix(kubeServersUnscopedPrefix()):
+		components := key.TrimPrefix(kubeServersUnscopedPrefix()).Components()
+		if len(components) != 2 {
+			return scopes.QualifiedName{}, "", trace.NotFound("failed parsing %v", key.String())
+		}
+		return scopes.QualifiedName{
+			Name: components[1],
+		}, components[0], nil
+	default:
+		return scopes.QualifiedName{}, "", trace.NotFound("failed parsing %v", key.String())
 	}
 }
 

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopecache "github.com/gravitational/teleport/lib/scopes/cache"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
@@ -57,6 +58,7 @@ type PresenceService struct {
 
 	relayServers *generic.ServiceWrapper[*presencev1.RelayServer]
 	appServers   *generic.ScopeAwareService[types.AppServer]
+	kubeServers  *generic.ScopeAwareService[types.KubeServer]
 }
 
 type appServerServiceParams struct {
@@ -83,6 +85,25 @@ func appServerServiceForHost(
 	}
 
 	return service.WithPrefix(params.Host), nil
+}
+
+// kubeServerServiceForHost returns a [*generic.Service] prefixed for the kube
+// servers of a single host:
+//   - unscoped: /kubeServers/default/<host-id>/<name>
+//   - scoped:   /scoped/kubeServers/<encoded-scope>/<host-id>/<name>
+//
+// Since a kube server represents a single forwarded kube cluster, there may be
+// multiple kube clusters on a single host, so the hostID prefix is needed.
+func kubeServerServiceForHost(
+	kubeServers *generic.ScopeAwareService[types.KubeServer],
+	sqn scopes.QualifiedName,
+) (*generic.Service[types.KubeServer], error) {
+	service, err := kubeServers.WithScopePrefix(sqn.Scope)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return service.WithPrefix(sqn.Name), nil
 }
 
 var _ services.PresenceInternal = (*PresenceService)(nil)
@@ -117,6 +138,22 @@ func NewPresenceService(b backend.Backend) *PresenceService {
 		panic("impossible: failed to construct app_server service wrapper")
 	}
 
+	kubeServers, err := generic.NewScopeAwareService(&generic.ScopeAwareServiceConfig[types.KubeServer]{
+		Backend:               b,
+		ResourceKind:          types.KindKubeServer,
+		UnscopedBackendPrefix: kubeServersUnscopedPrefix(),
+		ScopedBackendPrefix:   kubeServersScopedPrefix(),
+		MarshalFunc: func(server types.KubeServer, option ...services.MarshalOption) ([]byte, error) {
+			return services.MarshalKubeServer(server, option...)
+		},
+		UnmarshalFunc: func(bytes []byte, option ...services.MarshalOption) (types.KubeServer, error) {
+			server, err := services.UnmarshalKubeServer(bytes, option...)
+			return server, trace.Wrap(err)
+		},
+	})
+	if err != nil {
+		panic("impossible: failed to construct kube_server service wrapper")
+	}
 	return &PresenceService{
 		logger:  slog.With(teleport.ComponentKey, "Presence"),
 		jitter:  retryutils.FullJitter,
@@ -124,6 +161,7 @@ func NewPresenceService(b backend.Backend) *PresenceService {
 
 		relayServers: relayServers,
 		appServers:   appServers,
+		kubeServers:  kubeServers,
 	}
 }
 
@@ -1006,30 +1044,19 @@ func (s *PresenceService) DeleteSemaphore(ctx context.Context, filter types.Sema
 
 // UpsertKubernetesServer registers an kubernetes server.
 func (s *PresenceService) UpsertKubernetesServer(ctx context.Context, server types.KubeServer) (*types.KeepAlive, error) {
-	if err := services.CheckAndSetDefaults(server); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	rev := server.GetRevision()
-	value, err := services.MarshalKubeServer(server)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	// Since a kube server represents a single proxied cluster, there may
-	// be multiple kubernetes servers on a single host, so they are stored under
-	// the following path in the backend:
-	//   /kubeServers/<host-uuid>/<name>
-	_, err = s.Put(ctx, backend.Item{
-		Key: backend.NewKey(kubeServersPrefix,
-			server.GetHostID(),
-			server.GetName()),
-		Value:    value,
-		Expires:  server.Expiry(),
-		Revision: rev,
+	svc, err := s.kubeServers.WithScopedResourcePrefix(scopes.QualifiedName{
+		Scope: server.GetScope(),
+		Name:  server.GetHostID(),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if server.Expiry().IsZero() {
+
+	upserted, err := svc.UpsertResource(ctx, server)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if upserted.Expiry().IsZero() {
 		return &types.KeepAlive{}, nil
 	}
 	return &types.KeepAlive{
@@ -1037,33 +1064,38 @@ func (s *PresenceService) UpsertKubernetesServer(ctx context.Context, server typ
 		Name:      server.GetName(),
 		Namespace: server.GetNamespace(),
 		HostID:    server.GetHostID(),
-		Expires:   server.Expiry(),
+		Expires:   upserted.Expiry(),
 		Scope:     server.GetScope(),
 	}, nil
 }
 
-// DeleteKubernetesServer removes specified kubernetes server.
-func (s *PresenceService) DeleteKubernetesServer(ctx context.Context, hostID, name string) error {
-	if name == "" {
+// DeleteKubeServer removes specified kubernetes server.
+func (s *PresenceService) DeleteKubeServer(ctx context.Context, req *presencev1.DeleteKubeServerRequest) error {
+	if req.GetName() == "" {
 		return trace.BadParameter("no name specified for kubernetes server deletion")
 	}
-	if hostID == "" {
+	if req.GetHostId() == "" {
 		return trace.BadParameter("no hostID specified for kubernetes server deletion")
 	}
-	key := backend.NewKey(kubeServersPrefix, hostID, name)
-	return s.Delete(ctx, key)
+
+	svc, err := kubeServerServiceForHost(s.kubeServers, scopes.QualifiedName{
+		Scope: req.GetScope(),
+		Name:  req.GetHostId(),
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return svc.DeleteResource(ctx, req.GetName())
 }
 
 // DeleteAllKubernetesServers removes all registered kubernetes servers.
 func (s *PresenceService) DeleteAllKubernetesServers(ctx context.Context) error {
-	startKey := backend.ExactKey(kubeServersPrefix)
-	return s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
+	return s.kubeServers.DeleteAllResources(ctx)
 }
 
 // GetKubernetesServers returns all registered kubernetes servers.
 func (s *PresenceService) GetKubernetesServers(ctx context.Context) ([]types.KubeServer, error) {
-	servers, err := s.getKubernetesServers(ctx)
-	return servers, trace.Wrap(err)
+	return stream.Collect(s.kubeServers.Resources(ctx, "", ""))
 }
 
 // RangeKubernetesServersWithName returns an iterator over kubernetes servers for a given cluster name.
@@ -1076,44 +1108,12 @@ func (s *PresenceService) RangeKubernetesServersWithName(ctx context.Context, cl
 	// CheckAndSetDefaults invariant, this filter could check against the backend
 	// key's trailing component before unmarshalling. Currently no such invariant
 	// exists, so we unmarshal every item to read the embedded cluster name.
-	mapFn := func(item backend.Item) (types.KubeServer, bool) {
-		server, err := services.UnmarshalKubeServer(
-			item.Value,
-			services.WithExpires(item.Expires),
-			services.WithRevision(item.Revision),
-		)
-		if err != nil {
-			s.logger.WarnContext(ctx, "Failed to unmarshal kubernetes server", "key", item.Key, "error", err)
-			return nil, false
-		}
+	mapFn := func(server types.KubeServer) (types.KubeServer, bool) {
 		cluster := server.GetCluster()
 		return server, cluster != nil && cluster.GetName() == clusterName
 	}
 
-	startKey := backend.ExactKey(kubeServersPrefix)
-	endKey := backend.RangeEnd(startKey)
-
-	return stream.FilterMap(s.Backend.Items(ctx, backend.ItemsParams{StartKey: startKey, EndKey: endKey}), mapFn)
-}
-
-func (s *PresenceService) getKubernetesServers(ctx context.Context) ([]types.KubeServer, error) {
-	startKey := backend.ExactKey(kubeServersPrefix)
-	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	servers := make([]types.KubeServer, len(result.Items))
-	for i, item := range result.Items {
-		server, err := services.UnmarshalKubeServer(
-			item.Value,
-			services.WithExpires(item.Expires),
-			services.WithRevision(item.Revision))
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		servers[i] = server
-	}
-	return servers, nil
+	return stream.FilterMap(s.kubeServers.Resources(ctx, "", ""), mapFn)
 }
 
 // GetDatabaseServers returns all registered database proxy servers.
@@ -1345,6 +1345,14 @@ func (s *PresenceService) KeepAliveServer(ctx context.Context, h types.KeepAlive
 		return trace.Wrap(err)
 	}
 
+	var encodedScope string
+	if h.Scope != "" {
+		var err error
+		encodedScope, err = scopes.EncodeForKey(h.Scope)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
 	// Update the prefix off the type information in the keep alive.
 	var key backend.Key
 	switch h.GetType() {
@@ -1361,7 +1369,11 @@ func (s *PresenceService) KeepAliveServer(ctx context.Context, h types.KeepAlive
 	case constants.KeepAliveWindowsDesktopService:
 		key = backend.NewKey(windowsDesktopServicesPrefix, h.Name)
 	case constants.KeepAliveKube:
-		key = backend.NewKey(kubeServersPrefix, h.HostID, h.Name)
+		if encodedScope == "" {
+			key = kubeServersUnscopedPrefix().AppendKey(backend.NewKey(h.HostID, h.Name))
+		} else {
+			key = kubeServersScopedPrefix().AppendKey(backend.NewKey(encodedScope, h.HostID, h.Name))
+		}
 	case constants.KeepAliveDatabaseService:
 		key = backend.NewKey(databaseServicePrefix, h.Name)
 	default:
@@ -1586,8 +1598,7 @@ func (s *PresenceService) listResources(ctx context.Context, req proto.ListResou
 		keyPrefix = []string{windowsDesktopsPrefix}
 		unmarshalItemFunc = backendItemToWindowsDesktop
 	case types.KindKubeServer:
-		keyPrefix = []string{kubeServersPrefix}
-		unmarshalItemFunc = backendItemToKubernetesServer
+		return s.listKubeServers(ctx, req)
 	case types.KindUserGroup:
 		keyPrefix = []string{userGroupPrefix}
 		unmarshalItemFunc = backendItemToUserGroup
@@ -1688,6 +1699,47 @@ func (s *PresenceService) listAppServers(ctx context.Context, req proto.ListReso
 
 	return &types.ListResourcesResponse{
 		Resources: types.AppServers(servers).AsResources(),
+		NextKey:   nextKey,
+	}, nil
+}
+
+// listKubeServers returns a page of kube servers retrieving both the
+// unscoped and the scoped backend entries.
+func (s *PresenceService) listKubeServers(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
+	filter := services.MatchResourceFilter{
+		ResourceKind:   req.ResourceType,
+		Labels:         req.Labels,
+		SearchKeywords: req.SearchKeywords,
+	}
+	if req.PredicateExpression != "" {
+		expression, err := services.NewResourceExpression(req.PredicateExpression)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		filter.PredicateExpression = expression
+	}
+
+	var matchErr error
+	servers, nextKey, err := s.kubeServers.ListResourcesWithFilter(ctx, int(req.Limit), req.StartKey, func(server types.KubeServer) bool {
+		if matchErr != nil {
+			return false
+		}
+		match, err := services.MatchResourceByFilters(server, filter, nil /* ignore dup matches */)
+		if err != nil {
+			matchErr = err
+			return false
+		}
+		return match
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if matchErr != nil {
+		return nil, trace.Wrap(matchErr)
+	}
+
+	return &types.ListResourcesResponse{
+		Resources: types.KubeServers(servers).AsResources(),
 		NextKey:   nextKey,
 	}, nil
 }
@@ -1976,16 +2028,6 @@ func backendItemToDatabaseService(item backend.Item) (types.ResourceWithLabels, 
 	)
 }
 
-// backendItemToKubernetesServer unmarshals `backend.Item` into a
-// `types.KubeServer`, returning it as a `types.ResourceWithLabels`.
-func backendItemToKubernetesServer(item backend.Item) (types.ResourceWithLabels, error) {
-	return services.UnmarshalKubeServer(
-		item.Value,
-		services.WithExpires(item.Expires),
-		services.WithRevision(item.Revision),
-	)
-}
-
 // backendItemToServer returns `backendItemToResourceFunc` to unmarshal a
 // `backend.Item` into a `types.ServerV2` with a specific `kind`, returning it
 // as a `types.ResourceWithLabels`.
@@ -2101,6 +2143,14 @@ func (relayServerParser) prefixes() []backend.Key {
 	return []backend.Key{backend.ExactKey(relayServersPrefix)}
 }
 
+func kubeServersUnscopedPrefix() backend.Key {
+	return backend.NewKey("kubeServers")
+}
+
+func kubeServersScopedPrefix() backend.Key {
+	return backend.NewKey("scoped", "kubeServers")
+}
+
 const (
 	reverseTunnelsPrefix         = "reverseTunnels"
 	tunnelConnectionsPrefix      = "tunnelConnections"
@@ -2113,7 +2163,6 @@ const (
 	serversPrefix                = "servers"
 	dbServersPrefix              = "databaseServers"
 	appServersPrefix             = "appServers"
-	kubeServersPrefix            = "kubeServers"
 	namespacesPrefix             = "namespaces"
 	authServersPrefix            = "authservers"
 	proxiesPrefix                = "proxies"

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -562,7 +562,7 @@ func mustCreateKubernetesServer(t *testing.T, clusterName string) types.KubeServ
 	return server
 }
 
-func TestRangeKubernetesServersWithName(t *testing.T) {
+func TestKubeServersCRUD(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 
@@ -570,18 +570,22 @@ func TestRangeKubernetesServersWithName(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = bk.Close() })
 
-	presence := NewPresenceService(bk)
+	presence := NewPresenceService(backend.NewSanitizer(bk))
 
 	t.Run("ParameterValidation", func(t *testing.T) {
 		_, err = iterstream.Collect(presence.RangeKubernetesServersWithName(ctx, ""))
 		require.ErrorAs(t, err, new(*trace.BadParameterError))
 	})
 
+	const scope = "/aa"
 	server1 := mustCreateKubernetesServer(t, "shared-cluster")
 	server2 := mustCreateKubernetesServer(t, "shared-cluster")
 	server3 := mustCreateKubernetesServer(t, "standalone-cluster")
+	server4, ok := server2.Copy().(*types.KubernetesServerV3)
+	require.True(t, ok, "expected types.KubernetesServerV3")
+	server4.Scope = scope
 
-	for _, s := range []types.KubeServer{server1, server2, server3} {
+	for _, s := range []types.KubeServer{server1, server2, server3, server4} {
 		_, err := presence.UpsertKubernetesServer(ctx, s)
 		require.NoError(t, err)
 	}
@@ -589,7 +593,7 @@ func TestRangeKubernetesServersWithName(t *testing.T) {
 	t.Run("MultipleServersSameCluster", func(t *testing.T) {
 		servers, err := iterstream.Collect(presence.RangeKubernetesServersWithName(ctx, "shared-cluster"))
 		require.NoError(t, err)
-		require.Len(t, servers, 2)
+		require.Len(t, servers, 3)
 		for _, s := range servers {
 			require.Equal(t, "shared-cluster", s.GetCluster().GetName())
 		}
@@ -608,8 +612,27 @@ func TestRangeKubernetesServersWithName(t *testing.T) {
 		require.Empty(t, servers)
 	})
 
+	t.Run("DeletedServerWithScope", func(t *testing.T) {
+		err := presence.DeleteKubeServer(ctx, presencev1.DeleteKubeServerRequest_builder{
+			Scope:  scope,
+			HostId: server2.GetHostID(),
+			Name:   server2.GetName(),
+		}.Build())
+		require.NoError(t, err)
+
+		servers, err := iterstream.Collect(presence.RangeKubernetesServersWithName(ctx, "shared-cluster"))
+		require.NoError(t, err)
+		require.Len(t, servers, 2)
+		for _, server := range servers {
+			require.Empty(t, server.GetScope())
+		}
+	})
+
 	t.Run("DeletedServersNotReturned", func(t *testing.T) {
-		err := presence.DeleteKubernetesServer(ctx, server1.GetHostID(), server1.GetName())
+		err := presence.DeleteKubeServer(ctx, presencev1.DeleteKubeServerRequest_builder{
+			HostId: server1.GetHostID(),
+			Name:   server1.GetName(),
+		}.Build())
 		require.NoError(t, err)
 
 		servers, err := iterstream.Collect(presence.RangeKubernetesServersWithName(ctx, "shared-cluster"))
@@ -2263,14 +2286,18 @@ func TestScopedLease(t *testing.T) {
 			Scope: scope,
 		}
 
-		// Create servers and check lease scopes
+		// Create servers, check lease scopes, and try a keepalive
 		lease, err := presence.UpsertKubernetesServer(ctx, unscoped)
 		require.NoError(t, err)
 		require.Empty(t, lease.Scope)
+		err = presence.KeepAliveServer(ctx, *lease)
+		require.NoError(t, err)
 
 		lease, err = presence.UpsertKubernetesServer(ctx, scoped)
 		require.NoError(t, err)
 		require.Equal(t, scope, lease.Scope)
+		err = presence.KeepAliveServer(ctx, *lease)
+		require.NoError(t, err)
 	})
 
 	t.Run("nodes", func(t *testing.T) {

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -172,8 +172,8 @@ type Presence interface {
 	// GetKubernetesServers returns a list of registered kubernetes servers.
 	GetKubernetesServers(context.Context) ([]types.KubeServer, error)
 
-	// DeleteKubernetesServer deletes a named kubernetes servers.
-	DeleteKubernetesServer(ctx context.Context, hostID, name string) error
+	// DeleteKubeServer deletes a named kubernetes servers.
+	DeleteKubeServer(ctx context.Context, req *presencev1.DeleteKubeServerRequest) error
 
 	// DeleteAllKubernetesServers deletes all registered kubernetes servers.
 	DeleteAllKubernetesServers(context.Context) error

--- a/lib/services/unified_resource_test.go
+++ b/lib/services/unified_resource_test.go
@@ -1208,7 +1208,11 @@ func TestUnifiedResourceWatcher_DeleteEvent(t *testing.T) {
 	err = clt.DeleteWindowsDesktop(ctx, desktops[0].Spec.HostID, desktops[0].GetName())
 	require.NoError(t, err)
 	desktops = desktops[1:]
-	err = clt.DeleteKubernetesServer(ctx, kubeServers[0].Spec.HostID, kubeServers[0].GetName())
+	err = clt.DeleteKubeServer(ctx, presencev1.DeleteKubeServerRequest_builder{
+		Scope:  kubeServers[0].GetScope(),
+		HostId: kubeServers[0].Spec.HostID,
+		Name:   kubeServers[0].GetName(),
+	}.Build())
 	require.NoError(t, err)
 	kubeServers = kubeServers[1:]
 
@@ -1252,7 +1256,11 @@ func TestUnifiedResourceWatcher_DeleteEvent(t *testing.T) {
 		require.NoError(t, err)
 	}
 	for _, kubeServer := range kubeServers {
-		err = clt.DeleteKubernetesServer(ctx, kubeServer.Spec.HostID, kubeServer.GetName())
+		err = clt.DeleteKubeServer(ctx, presencev1.DeleteKubeServerRequest_builder{
+			Scope:  kubeServer.GetScope(),
+			HostId: kubeServer.GetHostID(),
+			Name:   kubeServer.GetName(),
+		}.Build())
 		require.NoError(t, err)
 	}
 

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -662,8 +662,15 @@ func NewKubeClusterWatcher(ctx context.Context, cfg KubeClusterWatcherConfig) (*
 		ResourceGetter: func(ctx context.Context) ([]types.KubeCluster, error) {
 			return iterstream.Collect(getter.RangeKubeClusters(ctx, nil))
 		},
-		ResourceKey: types.KubeCluster.GetName,
-		ResourcesC:  cfg.KubeClustersC,
+		ResourceKey: GetCursorForKubeCluster,
+		DeleteKey: func(res types.Resource) string {
+			cluster, ok := res.(types.KubeCluster)
+			if !ok {
+				return ""
+			}
+			return GetCursorForKubeCluster(cluster)
+		},
+		ResourcesC: cfg.KubeClustersC,
 		CloneFunc: func(resource types.KubeCluster) types.KubeCluster {
 			return resource.Copy()
 		},

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -1281,7 +1281,11 @@ func TestKubeServerWatcher(t *testing.T) {
 	require.Len(t, filtered, 1)
 
 	// Test Deleting a kube server.
-	require.NoError(t, presence.DeleteKubernetesServer(ctx, kubeServers[0].GetHostID(), kubeServers[0].GetName()))
+	require.NoError(t, presence.DeleteKubeServer(ctx, presencev1.DeleteKubeServerRequest_builder{
+		Scope:  kubeServers[0].GetScope(),
+		HostId: kubeServers[0].GetHostID(),
+		Name:   kubeServers[0].GetName(),
+	}.Build()))
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		kube, err := w.CurrentResources(context.Background())
 		require.NoError(t, err)
@@ -1312,7 +1316,11 @@ func TestKubeServerWatcher(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	for _, server := range filtered {
-		require.NoError(t, presence.DeleteKubernetesServer(ctx, server.GetHostID(), server.GetName()))
+		require.NoError(t, presence.DeleteKubeServer(ctx, presencev1.DeleteKubeServerRequest_builder{
+			Scope:  server.GetScope(),
+			HostId: server.GetHostID(),
+			Name:   server.GetName(),
+		}.Build()))
 	}
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		filtered, err := w.CurrentResourcesWithFilter(context.Background(), func(ks readonly.KubeServer) bool {

--- a/tool/tctl/common/resources/kube_server.go
+++ b/tool/tctl/common/resources/kube_server.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -112,7 +113,11 @@ func deleteKubeServer(ctx context.Context, client *authclient.Client, ref servic
 		return trace.Wrap(err)
 	}
 	for _, s := range servers {
-		err := client.DeleteKubernetesServer(ctx, s.GetHostID(), name)
+		err := client.DeleteKubeServer(ctx, presencev1.DeleteKubeServerRequest_builder{
+			Scope:  s.GetScope(),
+			HostId: s.GetHostID(),
+			Name:   name,
+		}.Build())
 		if err != nil {
 			return trace.Wrap(err)
 		}


### PR DESCRIPTION
Reenables dynamic kube cluster registration for kube agents and updates kube server backend  to be scope aware.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local teleport clusters with `TELEPORT_UNSTABLE_SCOPES=yes` and `TELEPORT_UNSTABLE_AGENT_SCOPE_PIN=yes`
### Test Cases
- [x] Join a scoped kube agent with `resources` block configured to dynamically register kube clusters
- [x] Join a duplicate kube agent under an orthogonal scope
- [x] Create duplicate kube clusters using `tctl create` under the same scopes as the kube agents
- [x] Confirm two kube servers are generated with different host IDs (`tsh kube ls` and/or `tctl get kube_server`)
- [x] Confirm kubectl commands can be executed against dynamic cluster using scoped credentials
- [x] Delete dynamic clusters and confirm correct kube servers are cleaned up
- [x] Keepalives are successful for scoped kube servers
