### PR TITLE
appresource: Add rule and decision types

### DIFF
--- a/lib/appresource/audit.go
+++ b/lib/appresource/audit.go
@@ -1,0 +1,123 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package appresource
+
+import (
+	"go/ast"
+	goparser "go/parser"
+	"go/token"
+	"strconv"
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// Hint is a near-miss reason recorded by deny_hint: the code and
+// reason of a wrapped condition that was reached and evaluated to
+// false. Under &&, that is the near-miss where the checks to its left
+// passed but this one did not.
+type Hint struct {
+	Code   string
+	Reason string
+}
+
+// validateAuditCode checks an allow or deny code. A valid code is 1 to
+// 256 bytes of [a-z0-9_] and does not start with the reserved
+// teleport_ prefix.
+func validateAuditCode(code string) error {
+	for _, r := range code {
+		legal := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_'
+		if !legal {
+			return trace.BadParameter("code %q must contain only [a-z0-9_]", code)
+		}
+	}
+	if len(code) < 1 || len(code) > 256 {
+		return trace.BadParameter("code %q must be 1 to 256 characters", code)
+	}
+	if strings.HasPrefix(code, "teleport_") {
+		return trace.BadParameter("code %q must not start with the reserved teleport_ prefix", code)
+	}
+	return nil
+}
+
+// validateAuditCodes rejects an illegal code in an allow_code("...",
+// ...) or deny_hint("...", ...) call whose code is a string constant,
+// so an illegal constant code fails at compile time rather than per
+// request. A dynamic code is validated at evaluation instead. Both
+// wrappers return the value of the expression they wrap, so a
+// misplaced call can record a stray code or hint but can never flip
+// the boolean result, and no placement check is needed.
+//
+// It also rejects a constant reason over the reason byte cap, so the
+// expression surface bounds a reason the same way the sugared
+// allow_reason and deny_reason_hint fields do. A dynamic reason is not
+// length-checked.
+//
+// The predicate uses the same Go expression syntax the engine parses,
+// so this reuses go/parser to walk the AST. An expression that does
+// not parse is left to the engine, which reports the parse error.
+func validateAuditCodes(expr string) error {
+	parsed, err := goparser.ParseExpr(expr)
+	if err != nil {
+		return nil
+	}
+	var bad error
+	ast.Inspect(parsed, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || len(call.Args) == 0 {
+			return true
+		}
+		if !isIdentCall(call, "allow_code") && !isIdentCall(call, "deny_hint") {
+			return true
+		}
+		if code, ok := stringLiteral(call.Args[0]); ok {
+			if err := validateAuditCode(code); err != nil && bad == nil {
+				bad = err
+			}
+		}
+		if len(call.Args) < 2 {
+			return true
+		}
+		if reason, ok := stringLiteral(call.Args[1]); ok && len(reason) > maxReasonBytes && bad == nil {
+			bad = trace.BadParameter("reason is %d bytes, over the %d byte cap", len(reason), maxReasonBytes)
+		}
+		return true
+	})
+	return trace.Wrap(bad)
+}
+
+// stringLiteral returns the value of a string-constant argument.
+func stringLiteral(arg ast.Expr) (string, bool) {
+	lit, ok := ast.Unparen(arg).(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	s, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return s, true
+}
+
+// isIdentCall reports whether call is a bare name(...) call, such as
+// allow_code(...). It does not match a selector call like path.match(...).
+func isIdentCall(call *ast.CallExpr, name string) bool {
+	id, ok := call.Fun.(*ast.Ident)
+	return ok && id.Name == name
+}

--- a/lib/appresource/audit.go
+++ b/lib/appresource/audit.go
@@ -20,7 +20,7 @@ package appresource
 
 import (
 	"go/ast"
-	goparser "go/parser"
+	"go/parser"
 	"go/token"
 	"strconv"
 	"strings"
@@ -28,10 +28,9 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// Hint is a near-miss reason recorded by deny_hint: the code and
-// reason of a wrapped condition that was reached and evaluated to
-// false. Under &&, that is the near-miss where the checks to its left
-// passed but this one did not.
+// Hint conveys why a request to an HTTP application was denied. A rule
+// records one through deny_hint, carrying the code and reason of a
+// condition that was reached and evaluated to false.
 type Hint struct {
 	Code   string
 	Reason string
@@ -69,11 +68,12 @@ func validateAuditCode(code string) error {
 // allow_reason and deny_reason_hint fields do. A dynamic reason is not
 // length-checked.
 //
-// The predicate uses the same Go expression syntax the engine parses,
-// so this reuses go/parser to walk the AST. An expression that does
-// not parse is left to the engine, which reports the parse error.
+// The engine parses a predicate with go/parser, through typical and
+// vulcand/predicate, so the walk here reads the same AST from the same
+// parser. An expression that does not parse is left to the engine, which
+// reports the parse error.
 func validateAuditCodes(expr string) error {
-	parsed, err := goparser.ParseExpr(expr)
+	parsed, err := parser.ParseExpr(expr)
 	if err != nil {
 		return nil
 	}

--- a/lib/appresource/audit_test.go
+++ b/lib/appresource/audit_test.go
@@ -1,0 +1,194 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package appresource
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// evaluateState compiles expr and evaluates it against request and
+// identity, returning the boolean result and the state the audit
+// wrappers recorded.
+func evaluateState(t *testing.T, expr string, request Request, identity Identity) (bool, *evalState) {
+	t.Helper()
+	pred, err := compilePredicate(expr)
+	require.NoError(t, err)
+	e := Env{Request: request, Identity: identity}.withAuditState()
+	got, err := pred.Evaluate(e)
+	require.NoError(t, err)
+	return got, e.state
+}
+
+// TestAllowCode pins that allow_code records its code and reason only when
+// the wrapped expression is true, and is transparent to the boolean result.
+func TestAllowCode(t *testing.T) {
+	const expr = `allow_code("project_read", "User has access to project.", ` +
+		`contains(user.traits["allowed_projects"], "acme") && request.method == "GET")`
+	identity := Identity{Traits: map[string][]string{"allowed_projects": {"acme"}}}
+
+	got, state := evaluateState(t, expr, Request{Method: "GET"}, identity)
+	require.True(t, got)
+	require.Equal(t, "project_read", state.allowCode)
+	require.Equal(t, "User has access to project.", state.allowReason)
+
+	got, state = evaluateState(t, expr, Request{Method: "POST"}, identity)
+	require.False(t, got)
+	require.Empty(t, state.allowCode)
+	require.Empty(t, state.allowReason)
+}
+
+func TestAllowCodeBranchSpecific(t *testing.T) {
+	const expr = `allow_code("read", "Read.", request.method == "GET") || ` +
+		`allow_code("write", "Write.", request.method == "POST")`
+
+	got, state := evaluateState(t, expr, Request{Method: "GET"}, Identity{})
+	require.True(t, got)
+	require.Equal(t, "read", state.allowCode)
+
+	got, state = evaluateState(t, expr, Request{Method: "POST"}, Identity{})
+	require.True(t, got)
+	require.Equal(t, "write", state.allowCode)
+}
+
+func TestAllowCodeLastWins(t *testing.T) {
+	const expr = `allow_code("first", "First.", true) && allow_code("second", "Second.", true)`
+
+	got, state := evaluateState(t, expr, Request{}, Identity{})
+	require.True(t, got)
+	require.Equal(t, "second", state.allowCode)
+	require.Equal(t, "Second.", state.allowReason)
+}
+
+// TestAllowCodeOnDeny pins that allowCode stays set when an allow_code
+// fired true but a later condition made the whole predicate false. The
+// caller reads allowCode only on an allow.
+func TestAllowCodeOnDeny(t *testing.T) {
+	const expr = `allow_code("read", "Read.", true) && request.method == "POST"`
+
+	got, state := evaluateState(t, expr, Request{Method: "GET"}, Identity{})
+	require.False(t, got)
+	require.Equal(t, "read", state.allowCode)
+}
+
+// TestDenyHint pins that deny_hint records a hint exactly on the near-miss,
+// when the conditions on its left matched but the wrapped condition failed.
+func TestDenyHint(t *testing.T) {
+	const expr = `request.method == "GET" && deny_hint("not_in_allowlist", ` +
+		`"Project is not in your allowlist.", contains(user.traits["allowed_projects"], "acme"))`
+	allowed := Identity{Traits: map[string][]string{"allowed_projects": {"acme"}}}
+
+	// The wrapped condition holds: allow, no hint.
+	got, state := evaluateState(t, expr, Request{Method: "GET"}, allowed)
+	require.True(t, got)
+	require.Empty(t, state.denyHints)
+
+	// Near miss: the method matches, the wrapped condition fails.
+	got, state = evaluateState(t, expr, Request{Method: "GET"}, Identity{})
+	require.False(t, got)
+	require.Equal(t, []Hint{{Code: "not_in_allowlist", Reason: "Project is not in your allowlist."}}, state.denyHints)
+
+	// Method miss: the left of && fails first, so deny_hint never runs and
+	// no hint fires.
+	got, state = evaluateState(t, expr, Request{Method: "POST"}, Identity{})
+	require.False(t, got)
+	require.Empty(t, state.denyHints)
+}
+
+// TestDenyHintOrder pins that several fired hints are recorded in evaluation
+// order, and that a hint recorded on a branch that lost to a later match is
+// still present.
+func TestDenyHintOrder(t *testing.T) {
+	const expr = `deny_hint("needs_dev", "You need the dev role.", contains(user.roles, "dev")) || ` +
+		`deny_hint("needs_admin", "You need the admin role.", contains(user.roles, "admin"))`
+
+	got, state := evaluateState(t, expr, Request{}, Identity{})
+	require.False(t, got)
+	require.Equal(t, []Hint{
+		{Code: "needs_dev", Reason: "You need the dev role."},
+		{Code: "needs_admin", Reason: "You need the admin role."},
+	}, state.denyHints)
+
+	got, state = evaluateState(t, expr, Request{}, Identity{Roles: []string{"admin"}})
+	require.True(t, got)
+	require.Equal(t, []Hint{{Code: "needs_dev", Reason: "You need the dev role."}}, state.denyHints)
+}
+
+// TestCodeValidationAtCompile pins that an illegal literal code in either
+// wrapper fails at compile, not per request.
+func TestCodeValidationAtCompile(t *testing.T) {
+	valid := []string{
+		`allow_code("a", "", true)`,
+		`allow_code("` + strings.Repeat("a", 256) + `", "reason", true)`,
+		`deny_hint("not_in_allowlist", "reason", true)`,
+	}
+	for _, expr := range valid {
+		t.Run(expr, func(t *testing.T) {
+			_, err := compilePredicate(expr)
+			require.NoError(t, err)
+		})
+	}
+
+	invalid := []struct {
+		expr    string
+		wantErr string
+	}{
+		{`allow_code("Project_Read", "reason", true)`, "must contain only"},
+		{`allow_code(("Bad Code"), "reason", true)`, "must contain only"},
+		{`deny_hint("Bad Code", "reason", true)`, "must contain only"},
+		{`deny_hint("teleport_x", "reason", true)`, "reserved teleport_ prefix"},
+		{`request.method == "GET" && deny_hint("Bad Code", "reason", true)`, "must contain only"},
+	}
+	for _, tt := range invalid {
+		t.Run(tt.expr, func(t *testing.T) {
+			_, err := compilePredicate(tt.expr)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+// TestCodeValidationAtEvaluation pins that a code built at evaluation, which
+// the compile-time walk cannot see, is still rejected by the function.
+func TestCodeValidationAtEvaluation(t *testing.T) {
+	for _, expr := range []string{
+		`allow_code(lower("BAD CODE"), "reason", true)`,
+		`deny_hint(upper("bad_code"), "reason", true)`,
+	} {
+		t.Run(expr, func(t *testing.T) {
+			pred, err := compilePredicate(expr)
+			require.NoError(t, err)
+			_, err = pred.Evaluate(Env{}.withAuditState())
+			require.ErrorContains(t, err, "must contain only")
+		})
+	}
+}
+
+func TestValidateAuditCode(t *testing.T) {
+	valid := []string{"a", "0", "_", "project_read", "a1_b2", strings.Repeat("a", 256)}
+	for _, code := range valid {
+		require.NoError(t, validateAuditCode(code), code)
+	}
+
+	invalid := []string{"", "A", "Project_Read", "has space", "a-b", "teleport_", "teleport_x", "ümlaut", strings.Repeat("a", 257)}
+	for _, code := range invalid {
+		require.Error(t, validateAuditCode(code), code)
+	}
+}

--- a/lib/appresource/decision.go
+++ b/lib/appresource/decision.go
@@ -1,0 +1,120 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package appresource
+
+import "encoding/json"
+
+// DenyKind is the structured reason a request was denied. Its values are
+// the deny_kind emitted on the app.session.request.denied audit event, so
+// the type reads as a category in Go while it serializes straight to the
+// audit string in JSON.
+type DenyKind string
+
+const (
+	// DenyNotAllowed is the kind for a well-formed request that no allow
+	// rule matched. A fired hint explains the near-miss.
+	DenyNotAllowed DenyKind = "teleport_request_not_allowed"
+	// DenyInvalidRequest is the kind for a request denied before any rule
+	// evaluated, because its path was rejected as malformed or unsafe,
+	// such as a "." or ".." segment, consecutive slashes, an illegal
+	// byte, or a percent-escape other than the encoded separator %2F.
+	DenyInvalidRequest DenyKind = "teleport_invalid_request"
+)
+
+// Decision is the outcome of evaluating a rule or role set against a
+// request. Allowed is the verdict. Exactly one of Allow or Deny carries
+// the matching detail, so allow-only and deny-only fields cannot be read
+// on the wrong outcome. EvaluatedRoles rides both, since the audit event
+// emits it either way.
+type Decision struct {
+	// Allowed reports whether any rule matched.
+	Allowed bool
+	// Allow carries the captures and codes of the matching rule. It is
+	// non-nil if and only if Allowed.
+	Allow *AllowDetails
+	// Deny carries the deny kind and any fired hints. It is non-nil if
+	// and only if not Allowed.
+	Deny *DenyDetails
+	// EvaluatedRoles lists the roles that carried app_resources for the
+	// app, in the order they were evaluated. An empty list on a deny
+	// marks a misconfigured default-deny, where no role granted any
+	// app_resources, as opposed to a request that a granting role did not
+	// match.
+	EvaluatedRoles []string
+}
+
+// AllowDetails carries the detail of an allow.
+type AllowDetails struct {
+	// Vars holds the segments the matching rule's captures bound.
+	Vars map[string]string
+	// Code is the matching rule's allow_code.
+	Code string
+	// Reason is the matching rule's allow_reason.
+	Reason string
+}
+
+// DenyDetails carries the detail of a deny.
+type DenyDetails struct {
+	// Kind is the structured reason for the deny.
+	Kind DenyKind
+	// Hints lists every hint that fired, in rule order.
+	Hints []Hint
+}
+
+// decisionJSON is the flat wire form of a Decision: the Allow and Deny
+// details become top-level keys, matching the payload the audit event
+// and the tctl evaluate output carry.
+type decisionJSON struct {
+	Allowed        bool              `json:"allowed"`
+	EvaluatedRoles []string          `json:"evaluated_roles,omitempty"`
+	Vars           map[string]string `json:"vars,omitempty"`
+	AllowCode      string            `json:"allow_code,omitempty"`
+	AllowReason    string            `json:"allow_reason,omitempty"`
+	DenyKind       DenyKind          `json:"deny_kind,omitempty"`
+	Hints          []hintJSON        `json:"hints,omitempty"`
+}
+
+// hintJSON is the wire form of one fired deny hint.
+type hintJSON struct {
+	Code   string `json:"code"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// MarshalJSON encodes the decision in its flat wire form, with unset
+// fields omitted. It reads the detail matching the verdict, so a
+// malformed decision that sets the wrong side cannot emit allow keys on
+// a deny or deny keys on an allow.
+func (d Decision) MarshalJSON() ([]byte, error) {
+	out := decisionJSON{
+		Allowed:        d.Allowed,
+		EvaluatedRoles: d.EvaluatedRoles,
+	}
+	if d.Allowed && d.Allow != nil {
+		out.Vars = d.Allow.Vars
+		out.AllowCode = d.Allow.Code
+		out.AllowReason = d.Allow.Reason
+	}
+	if !d.Allowed && d.Deny != nil {
+		out.DenyKind = d.Deny.Kind
+		for _, h := range d.Deny.Hints {
+			out.Hints = append(out.Hints, hintJSON(h))
+		}
+	}
+	return json.Marshal(out)
+}

--- a/lib/appresource/decision.go
+++ b/lib/appresource/decision.go
@@ -77,9 +77,7 @@ type DenyDetails struct {
 	Hints []Hint
 }
 
-// decisionJSON is the flat wire form of a Decision: the Allow and Deny
-// details become top-level keys, matching the payload the audit event
-// and the tctl evaluate output carry.
+// decisionJSON is the flat wire form of a Decision.
 type decisionJSON struct {
 	Allowed        bool              `json:"allowed"`
 	EvaluatedRoles []string          `json:"evaluated_roles,omitempty"`

--- a/lib/appresource/decision_test.go
+++ b/lib/appresource/decision_test.go
@@ -1,0 +1,124 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package appresource
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDecisionJSON pins the flat wire form of a decision, the payload
+// the audit event and the tctl evaluate output carry.
+func TestDecisionJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		decision Decision
+		want     string
+	}{
+		{
+			name: "allow with vars and code",
+			decision: Decision{
+				Allowed: true,
+				Allow: &AllowDetails{
+					Vars:   map[string]string{"project": "42"},
+					Code:   "repo_read",
+					Reason: "Read access to the repository API",
+				},
+				EvaluatedRoles: []string{"developer"},
+			},
+			want: `{
+				"allowed": true,
+				"evaluated_roles": ["developer"],
+				"vars": {"project": "42"},
+				"allow_code": "repo_read",
+				"allow_reason": "Read access to the repository API"
+			}`,
+		},
+		{
+			name: "bare allow omits unset fields",
+			decision: Decision{
+				Allowed:        true,
+				Allow:          &AllowDetails{},
+				EvaluatedRoles: []string{"developer"},
+			},
+			want: `{"allowed": true, "evaluated_roles": ["developer"]}`,
+		},
+		{
+			name: "deny with hints",
+			decision: Decision{
+				Deny: &DenyDetails{
+					Kind: DenyNotAllowed,
+					Hints: []Hint{
+						{Code: "project_not_allowed", Reason: "Project is not in the caller's allowlist"},
+						{Code: "needs_dev"},
+					},
+				},
+				EvaluatedRoles: []string{"developer", "reader"},
+			},
+			want: `{
+				"allowed": false,
+				"evaluated_roles": ["developer", "reader"],
+				"deny_kind": "teleport_request_not_allowed",
+				"hints": [
+					{"code": "project_not_allowed", "reason": "Project is not in the caller's allowlist"},
+					{"code": "needs_dev"}
+				]
+			}`,
+		},
+		{
+			name: "invalid request deny",
+			decision: Decision{
+				Deny:           &DenyDetails{Kind: DenyInvalidRequest},
+				EvaluatedRoles: []string{"developer"},
+			},
+			want: `{
+				"allowed": false,
+				"evaluated_roles": ["developer"],
+				"deny_kind": "teleport_invalid_request"
+			}`,
+		},
+		{
+			name: "misconfigured default-deny omits evaluated_roles",
+			decision: Decision{
+				Deny: &DenyDetails{Kind: DenyNotAllowed},
+			},
+			want: `{"allowed": false, "deny_kind": "teleport_request_not_allowed"}`,
+		},
+		{
+			// A decision whose detail contradicts the verdict projects the
+			// verdict side only, so a malformed value cannot emit deny keys
+			// on an allow.
+			name: "mismatched detail is dropped",
+			decision: Decision{
+				Allowed: true,
+				Deny:    &DenyDetails{Kind: DenyNotAllowed},
+			},
+			want: `{"allowed": true}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := json.Marshal(tt.decision)
+			require.NoError(t, err)
+			require.JSONEq(t, tt.want, string(got))
+		})
+	}
+}

--- a/lib/appresource/rule.go
+++ b/lib/appresource/rule.go
@@ -1,0 +1,303 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package appresource
+
+import (
+	"fmt"
+	"go/ast"
+	goparser "go/parser"
+	"strconv"
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// maxWhereBytes caps a sugared rule's where clause. The where compiles to
+// one predicate evaluated per request, so an unbounded clause is both a
+// parse cost and an audit-log hazard. The cap keeps an authored condition
+// to a reviewable size.
+const maxWhereBytes = 1 << 10 // 1 KiB
+
+// maxExpressionBytes caps one app_resources_expressions entry, the bare
+// predicate surface. It is wider than the where cap because an expression
+// carries the whole rule, path match included, where the sugared where
+// carries only the identity and request condition.
+const maxExpressionBytes = 4 << 10 // 4 KiB
+
+// maxReasonBytes caps an allow_reason or deny_reason_hint. A reason rides
+// on every matching audit event, so the cap bounds the per-event payload.
+const maxReasonBytes = 1 << 10 // 1 KiB
+
+// Rule is one app_resources entry, the sugared declarative authoring
+// surface. It reads compactly for the common HTTP case and lowers to one
+// predicate: Paths matches the request path, Methods the request method,
+// and Where the caller identity and request. Where holds conditions over
+// the caller identity, the request, and the rule's captures, and may not
+// call path.match, so all path matching flows through Paths. A full
+// predicate that needs the matcher language directly is the separate
+// app_resources_expressions field, a list of predicate strings.
+//
+// AllowCode and AllowReason lower to an allow_code call wrapping the
+// rule, and DenyCodeHint and DenyReasonHint to a deny_hint call wrapping
+// the where, so each sugared field and its expression primitive share one
+// representation. A deny hint explains a near-miss, when the rule's path
+// and method matched but it did not allow.
+type Rule struct {
+	// Paths are declarative path patterns, OR-ed. A request matches on
+	// path if any pattern matches. A rule must set either Paths or
+	// UnsafeAllowAll, since a rule that scopes nothing by path would
+	// grant unrestricted access by accident. UnsafeAllowAll is the
+	// explicit way to ask for that.
+	Paths []string `yaml:"paths,omitempty"`
+	// Methods are HTTP methods that further scope a Paths rule, OR-ed. If
+	// Methods is empty, any method is permitted. Otherwise the request
+	// method must appear in the list, matched case-insensitively: both the
+	// listed names and the request method are folded to upper case before
+	// the membership test, so a request sent as "get" matches a rule
+	// listing "GET". Names are validated against the standard HTTP methods
+	// (GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE). An unknown
+	// method is a load error, so a typo fails loudly rather than silently
+	// never matching. CONNECT is not a member: a CONNECT request targets
+	// an authority, not a slash-path, so the tokenizer rejects it and a
+	// rule listing CONNECT could never match.
+	Methods []string `yaml:"methods,omitempty"`
+	// Where is a condition over the caller identity, the request, and this
+	// rule's captures. It does not match paths and may not call path.match.
+	Where string `yaml:"where,omitempty"`
+	// AllowEncoded opts the rule's path match into the named encoded
+	// chars, lowering to the allow_encoded option on path.match. In this
+	// version only the separator "/" is admitted, so it is written
+	// allow_encoded: ["/"]. It applies to the whole match and pairs with
+	// an encoded node in a path, such as "{name:/}" or "{:/}". Without it
+	// an encoded node never matches.
+	AllowEncoded []string `yaml:"allow_encoded,omitempty"`
+	// AllowCode is the structured code emitted on the allow audit event
+	// when this rule matches. Without it, an allow emits no code.
+	AllowCode string `yaml:"allow_code,omitempty"`
+	// AllowReason is the human-readable explanation emitted alongside
+	// AllowCode on an allow.
+	AllowReason string `yaml:"allow_reason,omitempty"`
+	// DenyCodeHint is the structured code emitted on the deny audit event
+	// when the rule's path and method matched but the rule did not allow.
+	// It explains the near-miss within the rule's path-and-method scope.
+	DenyCodeHint string `yaml:"deny_code_hint,omitempty"`
+	// DenyReasonHint is the human-readable explanation emitted alongside
+	// DenyCodeHint.
+	DenyReasonHint string `yaml:"deny_reason_hint,omitempty"`
+	// UnsafeAllowAll grants unrestricted access to every path and method,
+	// restoring the pre-v9 behavior where a role that granted an app
+	// granted all of it. It is the deliberate opt-out for when the safe
+	// path surface is too restrictive, such as traffic that carries
+	// percent-encoding the matcher would otherwise reject. It bypasses
+	// every safety layer, including the request tokenizer, so a path that
+	// would be rejected as malformed or unsafe is forwarded as-is. Because
+	// it is all-or-nothing, it cannot be combined with any other field.
+	// Setting it alongside one is a load error.
+	UnsafeAllowAll bool `yaml:"unsafe_allow_all,omitempty"`
+}
+
+// validate checks a rule's structural constraints, the ones that decide
+// whether the rule may be lowered at all: field presence and combination
+// rules, method names, the where clause, byte caps, and audit codes.
+// Value-level checks that the lowered predicate would itself reject, such
+// as a malformed path pattern, are left to compilation.
+func (r Rule) validate() error {
+	if r.UnsafeAllowAll {
+		return r.validateUnsafeAllowAllStandsAlone()
+	}
+	if len(r.Paths) == 0 {
+		// A present-but-empty list (paths: []) is treated as unset rather
+		// than silently allowed, so an author who clears the list gets a
+		// load error instead of an accidental unrestricted grant.
+		return trace.BadParameter("a rule must set paths or unsafe_allow_all")
+	}
+	if err := validateMethods(r.Methods); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := validateWhere(r.Where); err != nil {
+		return trace.Wrap(err)
+	}
+	for _, e := range r.AllowEncoded {
+		if e != "/" {
+			return trace.BadParameter("allow_encoded admits only the separator %q, got %q", "/", e)
+		}
+	}
+	if r.AllowReason != "" && r.AllowCode == "" {
+		// A reason explains a code, so a reason with no code has nothing
+		// to qualify and would be silently dropped by the lowering.
+		// Reject it at load.
+		return trace.BadParameter("allow_reason set without allow_code")
+	}
+	if r.AllowCode != "" {
+		if err := validateAuditCode(r.AllowCode); err != nil {
+			return trace.Wrap(err, "invalid allow_code")
+		}
+	}
+	if len(r.AllowReason) > maxReasonBytes {
+		return trace.BadParameter("allow_reason is %d bytes, over the %d byte cap", len(r.AllowReason), maxReasonBytes)
+	}
+	if r.DenyReasonHint != "" && r.DenyCodeHint == "" {
+		return trace.BadParameter("deny_reason_hint set without deny_code_hint")
+	}
+	if r.DenyCodeHint != "" {
+		if err := validateAuditCode(r.DenyCodeHint); err != nil {
+			return trace.Wrap(err, "invalid deny_code_hint")
+		}
+		// A deny hint qualifies the where condition. With no where there
+		// is no near-miss to explain and the hint could never fire, so
+		// reject it at load rather than silently dropping it.
+		if r.Where == "" {
+			return trace.BadParameter("deny_code_hint set without a where clause for the hint to qualify")
+		}
+	}
+	if len(r.DenyReasonHint) > maxReasonBytes {
+		return trace.BadParameter("deny_reason_hint is %d bytes, over the %d byte cap", len(r.DenyReasonHint), maxReasonBytes)
+	}
+	return nil
+}
+
+// validateUnsafeAllowAllStandsAlone rejects an unsafe_allow_all rule that
+// also sets another field. unsafe_allow_all grants everything, so any
+// companion field is either redundant or a contradiction, and silently
+// ignoring it would hide an authoring mistake.
+func (r Rule) validateUnsafeAllowAllStandsAlone() error {
+	if len(r.Paths) > 0 || len(r.Methods) > 0 || r.Where != "" ||
+		len(r.AllowEncoded) > 0 || r.AllowCode != "" || r.AllowReason != "" ||
+		r.DenyCodeHint != "" || r.DenyReasonHint != "" {
+		return trace.BadParameter("unsafe_allow_all cannot be combined with any other field")
+	}
+	return nil
+}
+
+// standardMethods is the set of HTTP methods a rule may name, the request
+// methods defined by RFC 9110 less CONNECT. CONNECT is excluded
+// deliberately: it targets an authority rather than a slash-path, so the
+// tokenizer rejects a CONNECT request and a rule listing it could only
+// ever be a dead rule.
+var standardMethods = map[string]struct{}{
+	"GET":     {},
+	"HEAD":    {},
+	"POST":    {},
+	"PUT":     {},
+	"PATCH":   {},
+	"DELETE":  {},
+	"OPTIONS": {},
+	"TRACE":   {},
+}
+
+// validateMethods rejects a method that is not a standard HTTP method.
+// The comparison folds to upper case, matching methodClause, so "get" and
+// "GET" are the same method and a typo such as "GTE" fails at load rather
+// than compiling a rule that never matches.
+func validateMethods(methods []string) error {
+	for _, m := range methods {
+		if _, ok := standardMethods[strings.ToUpper(m)]; !ok {
+			return trace.BadParameter("method %q is not a standard HTTP method (GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE)", m)
+		}
+	}
+	return nil
+}
+
+// methodClause renders the Methods as a membership test against the
+// request method. It is empty when no methods are set, so an empty
+// Methods list constrains nothing and any method is permitted. The listed
+// methods are upper-cased and the request method is folded with upper()
+// before the membership test, so matching is case-insensitive on both
+// sides. Callers must validate the rule first: an unvalidated method
+// renders a clause that never matches.
+func (r Rule) methodClause() string {
+	if len(r.Methods) == 0 {
+		return ""
+	}
+	quoted := make([]string, 0, len(r.Methods))
+	for _, m := range r.Methods {
+		quoted = append(quoted, strconv.Quote(strings.ToUpper(m)))
+	}
+	return fmt.Sprintf("contains(set(%s), upper(request.method))", strings.Join(quoted, ", "))
+}
+
+// validateWhere checks a sugared rule's where clause: the byte cap, that
+// the clause parses as one self-contained expression, and that it does
+// not call path.match.
+//
+// The where uses the same Go expression syntax the engine parses, so this
+// reuses go/parser to walk the AST. A clause that does not parse on its
+// own is rejected rather than left to the engine, because the lowering
+// splices the clause into a larger predicate string, and an unbalanced
+// fragment that fails alone can parse inside the composite and change the
+// rule's structure.
+//
+// Path matching in the sugared form flows through paths, so the where
+// holds identity, request, and capture conditions only. A predicate that
+// needs to call path.match directly belongs in
+// app_resources_expressions.
+func validateWhere(where string) error {
+	if where == "" {
+		return nil
+	}
+	if len(where) > maxWhereBytes {
+		return trace.BadParameter("where clause is %d bytes, over the %d byte cap", len(where), maxWhereBytes)
+	}
+	parsed, err := goparser.ParseExpr(where)
+	if err != nil {
+		return trace.BadParameter("where clause does not parse: %v", err)
+	}
+	var bad bool
+	ast.Inspect(parsed, func(n ast.Node) bool {
+		if call, ok := n.(*ast.CallExpr); ok && isPathMatch(call) {
+			bad = true
+		}
+		return true
+	})
+	if bad {
+		const msg = "where may not call path.match: express path matching through paths, or move the whole rule to app_resources_expressions"
+		return trace.BadParameter(msg)
+	}
+	return nil
+}
+
+// isPathMatch reports whether call is a path.match(...) call.
+func isPathMatch(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "match" {
+		return false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	return ok && id.Name == "path"
+}
+
+// compileExpression compiles one app_resources_expressions entry, a bare
+// predicate string. Unlike a sugared rule's where clause, it may use the
+// full predicate language directly. It may also wrap an inner condition
+// in deny_hint to contribute a near-miss hint, the same primitive the
+// sugared deny_code_hint lowers to, so an expression rule and a sugared
+// rule share one deny mechanism.
+func compileExpression(expr string) (predicate, error) {
+	if strings.TrimSpace(expr) == "" {
+		return nil, trace.BadParameter("an app_resources_expressions entry cannot be empty")
+	}
+	if len(expr) > maxExpressionBytes {
+		return nil, trace.BadParameter("app_resources_expressions entry is %d bytes, over the %d byte cap", len(expr), maxExpressionBytes)
+	}
+	pred, err := compilePredicate(expr)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return pred, nil
+}

--- a/lib/appresource/rule.go
+++ b/lib/appresource/rule.go
@@ -21,11 +21,14 @@ package appresource
 import (
 	"fmt"
 	"go/ast"
-	goparser "go/parser"
+	"go/parser"
+	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/utils/typical"
 )
 
 // maxWhereBytes caps a sugared rule's where clause. The where compiles to
@@ -44,38 +47,27 @@ const maxExpressionBytes = 4 << 10 // 4 KiB
 // on every matching audit event, so the cap bounds the per-event payload.
 const maxReasonBytes = 1 << 10 // 1 KiB
 
-// Rule is one app_resources entry, the sugared declarative authoring
-// surface. It reads compactly for the common HTTP case and lowers to one
-// predicate: Paths matches the request path, Methods the request method,
-// and Where the caller identity and request. Where holds conditions over
-// the caller identity, the request, and the rule's captures, and may not
-// call path.match, so all path matching flows through Paths. A full
-// predicate that needs the matcher language directly is the separate
-// app_resources_expressions field, a list of predicate strings.
-//
-// AllowCode and AllowReason lower to an allow_code call wrapping the
-// rule, and DenyCodeHint and DenyReasonHint to a deny_hint call wrapping
-// the where, so each sugared field and its expression primitive share one
-// representation. A deny hint explains a near-miss, when the rule's path
-// and method matched but it did not allow.
+// Rule is one app_resources entry, the sugared authoring surface for
+// allowing HTTP requests to an app. A request matches a rule when its
+// path matches Paths, its method matches Methods, and Where holds. A rule
+// that needs the predicate language itself belongs in the separate
+// app_resources_expressions field.
 type Rule struct {
 	// Paths are declarative path patterns, OR-ed. A request matches on
 	// path if any pattern matches. A rule must set either Paths or
-	// UnsafeAllowAll, since a rule that scopes nothing by path would
-	// grant unrestricted access by accident. UnsafeAllowAll is the
-	// explicit way to ask for that.
+	// AllowAll, since a rule that scopes nothing by path would grant
+	// unrestricted access by accident. AllowAll is the explicit way to ask
+	// for that.
 	Paths []string `yaml:"paths,omitempty"`
 	// Methods are HTTP methods that further scope a Paths rule, OR-ed. If
 	// Methods is empty, any method is permitted. Otherwise the request
 	// method must appear in the list, matched case-insensitively: both the
 	// listed names and the request method are folded to upper case before
 	// the membership test, so a request sent as "get" matches a rule
-	// listing "GET". Names are validated against the standard HTTP methods
-	// (GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE). An unknown
-	// method is a load error, so a typo fails loudly rather than silently
-	// never matching. CONNECT is not a member: a CONNECT request targets
-	// an authority, not a slash-path, so the tokenizer rejects it and a
-	// rule listing CONNECT could never match.
+	// listing "GET". Names are validated against validMethods (GET, HEAD,
+	// POST, PUT, PATCH, DELETE, OPTIONS, TRACE). A name outside that list is
+	// a load error, so a typo fails loudly rather than silently never
+	// matching.
 	Methods []string `yaml:"methods,omitempty"`
 	// Where is a condition over the caller identity, the request, and this
 	// rule's captures. It does not match paths and may not call path.match.
@@ -100,7 +92,7 @@ type Rule struct {
 	// DenyReasonHint is the human-readable explanation emitted alongside
 	// DenyCodeHint.
 	DenyReasonHint string `yaml:"deny_reason_hint,omitempty"`
-	// UnsafeAllowAll grants unrestricted access to every path and method,
+	// AllowAll grants unrestricted access to every path and method,
 	// restoring the pre-v9 behavior where a role that granted an app
 	// granted all of it. It is the deliberate opt-out for when the safe
 	// path surface is too restrictive, such as traffic that carries
@@ -109,7 +101,7 @@ type Rule struct {
 	// would be rejected as malformed or unsafe is forwarded as-is. Because
 	// it is all-or-nothing, it cannot be combined with any other field.
 	// Setting it alongside one is a load error.
-	UnsafeAllowAll bool `yaml:"unsafe_allow_all,omitempty"`
+	AllowAll bool `yaml:"allow_all,omitempty"`
 }
 
 // validate checks a rule's structural constraints, the ones that decide
@@ -118,14 +110,14 @@ type Rule struct {
 // Value-level checks that the lowered predicate would itself reject, such
 // as a malformed path pattern, are left to compilation.
 func (r Rule) validate() error {
-	if r.UnsafeAllowAll {
-		return r.validateUnsafeAllowAllStandsAlone()
+	if r.AllowAll {
+		return r.validateAllowAllStandsAlone()
 	}
 	if len(r.Paths) == 0 {
 		// A present-but-empty list (paths: []) is treated as unset rather
 		// than silently allowed, so an author who clears the list gets a
 		// load error instead of an accidental unrestricted grant.
-		return trace.BadParameter("a rule must set paths or unsafe_allow_all")
+		return trace.BadParameter("a rule must set paths or allow_all")
 	}
 	if err := validateMethods(r.Methods); err != nil {
 		return trace.Wrap(err)
@@ -172,43 +164,28 @@ func (r Rule) validate() error {
 	return nil
 }
 
-// validateUnsafeAllowAllStandsAlone rejects an unsafe_allow_all rule that
-// also sets another field. unsafe_allow_all grants everything, so any
-// companion field is either redundant or a contradiction, and silently
-// ignoring it would hide an authoring mistake.
-func (r Rule) validateUnsafeAllowAllStandsAlone() error {
+// validateAllowAllStandsAlone rejects an allow_all rule that also sets
+// another field. allow_all grants everything, so any companion field is
+// either redundant or a contradiction, and silently ignoring it would hide
+// an authoring mistake.
+func (r Rule) validateAllowAllStandsAlone() error {
 	if len(r.Paths) > 0 || len(r.Methods) > 0 || r.Where != "" ||
 		len(r.AllowEncoded) > 0 || r.AllowCode != "" || r.AllowReason != "" ||
 		r.DenyCodeHint != "" || r.DenyReasonHint != "" {
-		return trace.BadParameter("unsafe_allow_all cannot be combined with any other field")
+		return trace.BadParameter("allow_all cannot be combined with any other field")
 	}
 	return nil
 }
 
-// standardMethods is the set of HTTP methods a rule may name, the request
-// methods defined by RFC 9110 less CONNECT. CONNECT is excluded
-// deliberately: it targets an authority rather than a slash-path, so the
-// tokenizer rejects a CONNECT request and a rule listing it could only
-// ever be a dead rule.
-var standardMethods = map[string]struct{}{
-	"GET":     {},
-	"HEAD":    {},
-	"POST":    {},
-	"PUT":     {},
-	"PATCH":   {},
-	"DELETE":  {},
-	"OPTIONS": {},
-	"TRACE":   {},
-}
-
-// validateMethods rejects a method that is not a standard HTTP method.
-// The comparison folds to upper case, matching methodClause, so "get" and
-// "GET" are the same method and a typo such as "GTE" fails at load rather
-// than compiling a rule that never matches.
+// validateMethods rejects a method a request can never carry, checked
+// against the same validMethods an evaluation accepts. The comparison
+// folds to upper case, matching methodClause, so "get" and "GET" are the
+// same method and a typo such as "GTE" fails at load rather than
+// compiling a rule that never matches.
 func validateMethods(methods []string) error {
 	for _, m := range methods {
-		if _, ok := standardMethods[strings.ToUpper(m)]; !ok {
-			return trace.BadParameter("method %q is not a standard HTTP method (GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE)", m)
+		if !slices.Contains(validMethods, strings.ToUpper(m)) {
+			return trace.BadParameter("method %q is not one of %s", m, strings.Join(validMethods, ", "))
 		}
 	}
 	return nil
@@ -236,12 +213,12 @@ func (r Rule) methodClause() string {
 // the clause parses as one self-contained expression, and that it does
 // not call path.match.
 //
-// The where uses the same Go expression syntax the engine parses, so this
-// reuses go/parser to walk the AST. A clause that does not parse on its
-// own is rejected rather than left to the engine, because the lowering
-// splices the clause into a larger predicate string, and an unbalanced
-// fragment that fails alone can parse inside the composite and change the
-// rule's structure.
+// The engine parses a predicate with go/parser, through typical and
+// vulcand/predicate, so the walk here reads the same AST from the same
+// parser. A clause that does not parse on its own is rejected rather than
+// left to the engine, because the lowering splices the clause into a
+// larger predicate string, and an unbalanced fragment that fails alone can
+// parse inside the composite and change the rule's structure.
 //
 // Path matching in the sugared form flows through paths, so the where
 // holds identity, request, and capture conditions only. A predicate that
@@ -254,7 +231,7 @@ func validateWhere(where string) error {
 	if len(where) > maxWhereBytes {
 		return trace.BadParameter("where clause is %d bytes, over the %d byte cap", len(where), maxWhereBytes)
 	}
-	parsed, err := goparser.ParseExpr(where)
+	parsed, err := parser.ParseExpr(where)
 	if err != nil {
 		return trace.BadParameter("where clause does not parse: %v", err)
 	}
@@ -288,7 +265,7 @@ func isPathMatch(call *ast.CallExpr) bool {
 // in deny_hint to contribute a near-miss hint, the same primitive the
 // sugared deny_code_hint lowers to, so an expression rule and a sugared
 // rule share one deny mechanism.
-func compileExpression(expr string) (predicate, error) {
+func compileExpression(expr string) (typical.Expression[Env, bool], error) {
 	if strings.TrimSpace(expr) == "" {
 		return nil, trace.BadParameter("an app_resources_expressions entry cannot be empty")
 	}

--- a/lib/appresource/rule_test.go
+++ b/lib/appresource/rule_test.go
@@ -1,0 +1,370 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package appresource
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestRuleValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		rule    Rule
+		wantErr string
+	}{
+		{
+			name:    "empty rule",
+			rule:    Rule{},
+			wantErr: "must set paths or unsafe_allow_all",
+		},
+		{
+			name:    "present but empty paths",
+			rule:    Rule{Paths: []string{}},
+			wantErr: "must set paths or unsafe_allow_all",
+		},
+		{
+			name: "paths alone",
+			rule: Rule{Paths: []string{"/api/**"}},
+		},
+		{
+			name: "unsafe_allow_all alone",
+			rule: Rule{UnsafeAllowAll: true},
+		},
+		{
+			name:    "unsafe_allow_all with paths",
+			rule:    Rule{UnsafeAllowAll: true, Paths: []string{"/api/**"}},
+			wantErr: "cannot be combined",
+		},
+		{
+			name:    "unsafe_allow_all with methods",
+			rule:    Rule{UnsafeAllowAll: true, Methods: []string{"GET"}},
+			wantErr: "cannot be combined",
+		},
+		{
+			name:    "unsafe_allow_all with where",
+			rule:    Rule{UnsafeAllowAll: true, Where: "true"},
+			wantErr: "cannot be combined",
+		},
+		{
+			name:    "unsafe_allow_all with allow_encoded",
+			rule:    Rule{UnsafeAllowAll: true, AllowEncoded: []string{"/"}},
+			wantErr: "cannot be combined",
+		},
+		{
+			name:    "unsafe_allow_all with allow_code",
+			rule:    Rule{UnsafeAllowAll: true, AllowCode: "all"},
+			wantErr: "cannot be combined",
+		},
+		{
+			name:    "unsafe_allow_all with allow_reason",
+			rule:    Rule{UnsafeAllowAll: true, AllowReason: "all"},
+			wantErr: "cannot be combined",
+		},
+		{
+			name:    "unsafe_allow_all with deny_code_hint",
+			rule:    Rule{UnsafeAllowAll: true, DenyCodeHint: "no"},
+			wantErr: "cannot be combined",
+		},
+		{
+			name:    "unsafe_allow_all with deny_reason_hint",
+			rule:    Rule{UnsafeAllowAll: true, DenyReasonHint: "no"},
+			wantErr: "cannot be combined",
+		},
+		{
+			name: "valid methods",
+			rule: Rule{Paths: []string{"/api/**"}, Methods: []string{"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "TRACE"}},
+		},
+		{
+			name: "lowercase method",
+			rule: Rule{Paths: []string{"/api/**"}, Methods: []string{"get"}},
+		},
+		{
+			name:    "typoed method",
+			rule:    Rule{Paths: []string{"/api/**"}, Methods: []string{"GTE"}},
+			wantErr: "not a standard HTTP method",
+		},
+		{
+			name:    "connect method",
+			rule:    Rule{Paths: []string{"/api/**"}, Methods: []string{"CONNECT"}},
+			wantErr: "not a standard HTTP method",
+		},
+		{
+			name:    "empty method name",
+			rule:    Rule{Paths: []string{"/api/**"}, Methods: []string{""}},
+			wantErr: "not a standard HTTP method",
+		},
+		{
+			name: "allow code and reason",
+			rule: Rule{Paths: []string{"/api/**"}, AllowCode: "public_api", AllowReason: "Public API."},
+		},
+		{
+			name:    "allow_reason without allow_code",
+			rule:    Rule{Paths: []string{"/api/**"}, AllowReason: "Public API."},
+			wantErr: "allow_reason set without allow_code",
+		},
+		{
+			name:    "allow_code with illegal chars",
+			rule:    Rule{Paths: []string{"/api/**"}, AllowCode: "Public-API"},
+			wantErr: "invalid allow_code",
+		},
+		{
+			name:    "allow_code with reserved prefix",
+			rule:    Rule{Paths: []string{"/api/**"}, AllowCode: "teleport_mine"},
+			wantErr: "invalid allow_code",
+		},
+		{
+			name: "deny hint with where",
+			rule: Rule{Paths: []string{"/api/**"}, Where: `contains(user.roles, "dev")`, DenyCodeHint: "needs_dev", DenyReasonHint: "Needs the dev role."},
+		},
+		{
+			name:    "deny_reason_hint without deny_code_hint",
+			rule:    Rule{Paths: []string{"/api/**"}, Where: "true", DenyReasonHint: "Needs the dev role."},
+			wantErr: "deny_reason_hint set without deny_code_hint",
+		},
+		{
+			name:    "deny_code_hint without where",
+			rule:    Rule{Paths: []string{"/api/**"}, DenyCodeHint: "needs_dev"},
+			wantErr: "deny_code_hint set without a where clause",
+		},
+		{
+			name:    "deny_code_hint with reserved prefix",
+			rule:    Rule{Paths: []string{"/api/**"}, Where: "true", DenyCodeHint: "teleport_no"},
+			wantErr: "invalid deny_code_hint",
+		},
+		{
+			name:    "where calls path.match",
+			rule:    Rule{Paths: []string{"/api/**"}, Where: `path.match(literal("api"))`},
+			wantErr: "where may not call path.match",
+		},
+		{
+			name: "path.match inside a string literal",
+			rule: Rule{Paths: []string{"/api/**"}, Where: `user.name == "path.match(x)"`},
+		},
+		{
+			name: "match call on another receiver",
+			rule: Rule{Paths: []string{"/api/**"}, Where: `foo.match("x")`},
+		},
+		{
+			name:    "unparseable where",
+			rule:    Rule{Paths: []string{"/api/**"}, Where: `user.name ==`},
+			wantErr: "does not parse",
+		},
+		{
+			name:    "unbalanced where fragment",
+			rule:    Rule{Paths: []string{"/api/**"}, Where: `false) || (true`},
+			wantErr: "does not parse",
+		},
+		{
+			name: "allow_encoded slash",
+			rule: Rule{Paths: []string{"/api/**"}, AllowEncoded: []string{"/"}},
+		},
+		{
+			name:    "allow_encoded other char",
+			rule:    Rule{Paths: []string{"/api/**"}, AllowEncoded: []string{"%"}},
+			wantErr: "allow_encoded admits only",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.rule.validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+// TestRuleFromYAML pins the YAML field names of the sugared authoring
+// surface, written in the exact form an author would put under
+// app_resources.
+func TestRuleFromYAML(t *testing.T) {
+	const doc = `
+paths: ["/api/v4/projects/{project}/**"]
+methods: [GET, HEAD]
+where: contains(user.traits["allowed_projects"], vars.project)
+allow_encoded: ["/"]
+allow_code: repo_read
+allow_reason: "Read access to the repository API"
+deny_code_hint: project_not_allowed
+deny_reason_hint: "Project is not in the caller's allowlist"
+`
+	var r Rule
+	require.NoError(t, yaml.Unmarshal([]byte(doc), &r))
+	want := Rule{
+		Paths:          []string{"/api/v4/projects/{project}/**"},
+		Methods:        []string{"GET", "HEAD"},
+		Where:          `contains(user.traits["allowed_projects"], vars.project)`,
+		AllowEncoded:   []string{"/"},
+		AllowCode:      "repo_read",
+		AllowReason:    "Read access to the repository API",
+		DenyCodeHint:   "project_not_allowed",
+		DenyReasonHint: "Project is not in the caller's allowlist",
+	}
+	require.Equal(t, want, r)
+	require.NoError(t, r.validate())
+
+	var unsafeRule Rule
+	require.NoError(t, yaml.Unmarshal([]byte(`unsafe_allow_all: true`), &unsafeRule))
+	require.Equal(t, Rule{UnsafeAllowAll: true}, unsafeRule)
+	require.NoError(t, unsafeRule.validate())
+}
+
+// TestMethodClause pins the rendered membership test and the one side
+// the fold applies to. A configured method is folded, so methods written
+// as "head" in YAML still match, but a request method is not: only the
+// canonical HTTP methods reach a clause, because the app service
+// forwards the method unchanged and an upstream may route "get" and
+// "GET" differently.
+func TestMethodClause(t *testing.T) {
+	rule := Rule{Methods: []string{"GET", "head"}}
+	clause := rule.methodClause()
+	require.Equal(t, `contains(set("GET", "HEAD"), upper(request.method))`, clause)
+
+	tests := []struct {
+		method string
+		want   bool
+	}{
+		{http.MethodGet, true},
+		{http.MethodHead, true},
+		{http.MethodPost, false},
+		{http.MethodDelete, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			require.Equal(t, tt.want, evaluate(t, clause, Request{Method: tt.method}, Identity{}))
+		})
+	}
+}
+
+// TestMethodClauseRejectsNonCanonicalRequestMethod pins that a request
+// method outside the canonical set is rejected before a clause decides,
+// rather than folded into one that matches.
+func TestMethodClauseRejectsNonCanonicalRequestMethod(t *testing.T) {
+	where, err := CompileWhere(Rule{Methods: []string{"GET"}}.methodClause())
+	require.NoError(t, err)
+
+	for _, method := range []string{"get", "GeT", "head"} {
+		t.Run(method, func(t *testing.T) {
+			_, err := where.Evaluate(Env{Request: Request{Method: method}})
+			require.ErrorContains(t, err, "unsupported HTTP method")
+		})
+	}
+}
+
+// TestMethodClauseEmpty pins that an empty Methods list renders no
+// clause, so it constrains nothing and any method is permitted.
+func TestMethodClauseEmpty(t *testing.T) {
+	require.Empty(t, Rule{}.methodClause())
+}
+
+// TestWhereByteCap pins the 1 KiB cap on a sugared where clause. A
+// clause at the cap validates. One byte over is a load error, so an
+// unbounded condition cannot ride into the evaluator or the audit log.
+func TestWhereByteCap(t *testing.T) {
+	atCap := `user.name == "x"` + strings.Repeat(" ", maxWhereBytes-len(`user.name == "x"`))
+	require.Len(t, atCap, maxWhereBytes)
+	require.NoError(t, Rule{Paths: []string{"/api/**"}, Where: atCap}.validate())
+
+	err := Rule{Paths: []string{"/api/**"}, Where: atCap + " "}.validate()
+	require.ErrorContains(t, err, "over the")
+}
+
+// TestReasonByteCap pins the 1 KiB cap on allow_reason and
+// deny_reason_hint. A reason rides on every matching audit event, so an
+// unbounded reason is rejected at load.
+func TestReasonByteCap(t *testing.T) {
+	atCap := strings.Repeat("x", maxReasonBytes)
+
+	require.NoError(t, Rule{Paths: []string{"/api/**"}, AllowCode: "ok", AllowReason: atCap}.validate())
+	err := Rule{Paths: []string{"/api/**"}, AllowCode: "ok", AllowReason: atCap + "x"}.validate()
+	require.ErrorContains(t, err, "over the")
+
+	require.NoError(t, Rule{Paths: []string{"/api/**"}, Where: "true", DenyCodeHint: "no", DenyReasonHint: atCap}.validate())
+	err = Rule{Paths: []string{"/api/**"}, Where: "true", DenyCodeHint: "no", DenyReasonHint: atCap + "x"}.validate()
+	require.ErrorContains(t, err, "over the")
+}
+
+// TestExpressionReasonByteCap pins that a constant reason in an
+// expression entry's allow_code or deny_hint call is held to the same
+// 1 KiB cap as the sugared reason fields, so the two surfaces bound a
+// reason identically.
+func TestExpressionReasonByteCap(t *testing.T) {
+	atCap := strings.Repeat("x", maxReasonBytes)
+
+	_, err := compileExpression(fmt.Sprintf("deny_hint(%q, %q, true)", "no", atCap))
+	require.NoError(t, err)
+	_, err = compileExpression(fmt.Sprintf("deny_hint(%q, %q, true)", "no", atCap+"x"))
+	require.ErrorContains(t, err, "over the")
+
+	_, err = compileExpression(fmt.Sprintf("allow_code(%q, %q, true)", "ok", atCap))
+	require.NoError(t, err)
+	_, err = compileExpression(fmt.Sprintf("allow_code(%q, %q, true)", "ok", atCap+"x"))
+	require.ErrorContains(t, err, "over the")
+}
+
+// TestExpressionByteCap pins the 4 KiB cap on one
+// app_resources_expressions entry. An entry at the cap compiles. One
+// byte over is a load error.
+func TestExpressionByteCap(t *testing.T) {
+	atCap := `contains(user.roles, "dev")`
+	atCap += strings.Repeat(" ", maxExpressionBytes-len(atCap))
+	require.Len(t, atCap, maxExpressionBytes)
+	_, err := compileExpression(atCap)
+	require.NoError(t, err, "an expression at the cap compiles")
+
+	_, err = compileExpression(atCap + " ")
+	require.ErrorContains(t, err, "over the")
+}
+
+// TestCompileExpression pins the load path of one
+// app_resources_expressions entry: an empty or blank entry is a load
+// error, and a valid entry compiles to a predicate that evaluates.
+func TestCompileExpression(t *testing.T) {
+	_, err := compileExpression("")
+	require.ErrorContains(t, err, "cannot be empty")
+	_, err = compileExpression("   ")
+	require.ErrorContains(t, err, "cannot be empty")
+
+	pred, err := compileExpression(`contains(user.roles, "dev") && request.method == "GET"`)
+	require.NoError(t, err)
+
+	got, err := pred.Evaluate(Env{Request: Request{Method: "GET"}, Identity: Identity{Roles: []string{"dev"}}}.withAuditState())
+	require.NoError(t, err)
+	require.True(t, got)
+
+	got, err = pred.Evaluate(Env{Request: Request{Method: "POST"}, Identity: Identity{Roles: []string{"dev"}}}.withAuditState())
+	require.NoError(t, err)
+	require.False(t, got)
+}
+
+// TestCompileExpressionRejectsBadCode pins that an illegal constant
+// audit code in an expression entry fails at compile, through the same
+// AST walk a sugared rule's codes go through.
+func TestCompileExpressionRejectsBadCode(t *testing.T) {
+	_, err := compileExpression(`allow_code("teleport_mine", "Reserved.", true)`)
+	require.ErrorContains(t, err, "teleport_")
+}

--- a/lib/appresource/rule_test.go
+++ b/lib/appresource/rule_test.go
@@ -37,59 +37,59 @@ func TestRuleValidate(t *testing.T) {
 		{
 			name:    "empty rule",
 			rule:    Rule{},
-			wantErr: "must set paths or unsafe_allow_all",
+			wantErr: "must set paths or allow_all",
 		},
 		{
 			name:    "present but empty paths",
 			rule:    Rule{Paths: []string{}},
-			wantErr: "must set paths or unsafe_allow_all",
+			wantErr: "must set paths or allow_all",
 		},
 		{
 			name: "paths alone",
 			rule: Rule{Paths: []string{"/api/**"}},
 		},
 		{
-			name: "unsafe_allow_all alone",
-			rule: Rule{UnsafeAllowAll: true},
+			name: "allow_all alone",
+			rule: Rule{AllowAll: true},
 		},
 		{
-			name:    "unsafe_allow_all with paths",
-			rule:    Rule{UnsafeAllowAll: true, Paths: []string{"/api/**"}},
+			name:    "allow_all with paths",
+			rule:    Rule{AllowAll: true, Paths: []string{"/api/**"}},
 			wantErr: "cannot be combined",
 		},
 		{
-			name:    "unsafe_allow_all with methods",
-			rule:    Rule{UnsafeAllowAll: true, Methods: []string{"GET"}},
+			name:    "allow_all with methods",
+			rule:    Rule{AllowAll: true, Methods: []string{"GET"}},
 			wantErr: "cannot be combined",
 		},
 		{
-			name:    "unsafe_allow_all with where",
-			rule:    Rule{UnsafeAllowAll: true, Where: "true"},
+			name:    "allow_all with where",
+			rule:    Rule{AllowAll: true, Where: "true"},
 			wantErr: "cannot be combined",
 		},
 		{
-			name:    "unsafe_allow_all with allow_encoded",
-			rule:    Rule{UnsafeAllowAll: true, AllowEncoded: []string{"/"}},
+			name:    "allow_all with allow_encoded",
+			rule:    Rule{AllowAll: true, AllowEncoded: []string{"/"}},
 			wantErr: "cannot be combined",
 		},
 		{
-			name:    "unsafe_allow_all with allow_code",
-			rule:    Rule{UnsafeAllowAll: true, AllowCode: "all"},
+			name:    "allow_all with allow_code",
+			rule:    Rule{AllowAll: true, AllowCode: "all"},
 			wantErr: "cannot be combined",
 		},
 		{
-			name:    "unsafe_allow_all with allow_reason",
-			rule:    Rule{UnsafeAllowAll: true, AllowReason: "all"},
+			name:    "allow_all with allow_reason",
+			rule:    Rule{AllowAll: true, AllowReason: "all"},
 			wantErr: "cannot be combined",
 		},
 		{
-			name:    "unsafe_allow_all with deny_code_hint",
-			rule:    Rule{UnsafeAllowAll: true, DenyCodeHint: "no"},
+			name:    "allow_all with deny_code_hint",
+			rule:    Rule{AllowAll: true, DenyCodeHint: "no"},
 			wantErr: "cannot be combined",
 		},
 		{
-			name:    "unsafe_allow_all with deny_reason_hint",
-			rule:    Rule{UnsafeAllowAll: true, DenyReasonHint: "no"},
+			name:    "allow_all with deny_reason_hint",
+			rule:    Rule{AllowAll: true, DenyReasonHint: "no"},
 			wantErr: "cannot be combined",
 		},
 		{
@@ -103,17 +103,17 @@ func TestRuleValidate(t *testing.T) {
 		{
 			name:    "typoed method",
 			rule:    Rule{Paths: []string{"/api/**"}, Methods: []string{"GTE"}},
-			wantErr: "not a standard HTTP method",
+			wantErr: "is not one of",
 		},
 		{
 			name:    "connect method",
 			rule:    Rule{Paths: []string{"/api/**"}, Methods: []string{"CONNECT"}},
-			wantErr: "not a standard HTTP method",
+			wantErr: "is not one of",
 		},
 		{
 			name:    "empty method name",
 			rule:    Rule{Paths: []string{"/api/**"}, Methods: []string{""}},
-			wantErr: "not a standard HTTP method",
+			wantErr: "is not one of",
 		},
 		{
 			name: "allow code and reason",
@@ -228,8 +228,8 @@ deny_reason_hint: "Project is not in the caller's allowlist"
 	require.NoError(t, r.validate())
 
 	var unsafeRule Rule
-	require.NoError(t, yaml.Unmarshal([]byte(`unsafe_allow_all: true`), &unsafeRule))
-	require.Equal(t, Rule{UnsafeAllowAll: true}, unsafeRule)
+	require.NoError(t, yaml.Unmarshal([]byte(`allow_all: true`), &unsafeRule))
+	require.Equal(t, Rule{AllowAll: true}, unsafeRule)
 	require.NoError(t, unsafeRule.validate())
 }
 

--- a/lib/appresource/where.go
+++ b/lib/appresource/where.go
@@ -28,7 +28,12 @@ import (
 	"github.com/gravitational/teleport/lib/utils/typical"
 )
 
-// validMethods are the HTTP methods a where clause evaluation accepts.
+// validMethods are the HTTP methods app access authorizes, in upper case:
+// the methods a rule may name and the methods an evaluation accepts on a
+// request. They are the request methods of RFC 9110 plus PATCH (RFC 5789)
+// and less CONNECT. A CONNECT request targets an authority rather than a
+// slash-path, so the tokenizer rejects it and a rule naming it could only
+// ever be a dead rule.
 var validMethods = []string{
 	http.MethodGet,
 	http.MethodHead,
@@ -233,15 +238,10 @@ func mustNewWhereParser() *typical.CachedParser[Env, bool] {
 	return p
 }
 
-// predicate is a parsed, type-checked app-access predicate ready to
-// evaluate. A rule lowers to one predicate, and an
-// app_resources_expressions entry compiles to one directly.
-type predicate = typical.Expression[Env, bool]
-
 // compilePredicate parses and type-checks a predicate, and runs the
 // compile-time audit code validation. Unlike CompileWhere it accepts the
 // full predicate language, including the audit wrappers.
-func compilePredicate(expr string) (predicate, error) {
+func compilePredicate(expr string) (typical.Expression[Env, bool], error) {
 	pred, err := whereParser.Parse(expr)
 	if err != nil {
 		return nil, trace.BadParameter("compiling predicate %q: %v", expr, err)

--- a/lib/appresource/where.go
+++ b/lib/appresource/where.go
@@ -56,12 +56,41 @@ type Identity struct {
 	Traits map[string][]string
 }
 
-// Env holds the values one where clause evaluation reads. Request and
-// Identity are deliberately not [http.Request] and tlsca.Identity, to make
-// clear which fields matter for evaluation.
+// Env holds the values one where clause evaluation reads, and the state
+// the audit wrappers record into. Request and Identity are deliberately
+// not [http.Request] and tlsca.Identity, to make clear which fields
+// matter for evaluation.
 type Env struct {
 	Request  Request
 	Identity Identity
+	// state collects what the audit wrappers record. It is unexported
+	// because only an evaluation that intends to read the record back
+	// needs it, and it is nil for an Env a caller built itself. The
+	// wrappers tolerate a nil state, so a where clause that calls one
+	// still evaluates.
+	state *evalState
+}
+
+// evalState holds the side effects of one evaluation for the caller. It
+// is held by pointer so the same instance is observed across the whole
+// expression tree, even though Env is passed by value. On error the
+// state may be partially populated and must be discarded. allowCode is
+// meaningful only when the evaluation returned true, and denyHints only
+// when it returned false.
+type evalState struct {
+	// allowCode and allowReason hold the last successful allow_code call.
+	allowCode   string
+	allowReason string
+	// denyHints records deny_hint calls in evaluation order.
+	denyHints []Hint
+}
+
+// withAuditState returns a copy of the environment carrying a fresh
+// audit state, so concurrent evaluations never share recorded codes or
+// hints. The rule layer builds one per evaluation.
+func (e Env) withAuditState() Env {
+	e.state = &evalState{}
+	return e
 }
 
 // Where is a compiled where clause. Only CompileWhere returns a usable
@@ -144,6 +173,35 @@ func mustNewWhereParser() *typical.CachedParser[Env, bool] {
 			}),
 		},
 		Functions: map[string]typical.Function{
+			// allow_code records an audit code and reason and returns the
+			// wrapped boolean, so it never flips the result. The record is
+			// committed only when the wrapped expression is true. When
+			// several allow_code calls fire on one evaluation, the last one
+			// wins.
+			"allow_code": typical.TernaryFunctionWithEnv(func(e Env, code, reason string, expr bool) (bool, error) {
+				if err := validateAuditCode(code); err != nil {
+					return false, trace.Wrap(err)
+				}
+				if expr && e.state != nil {
+					e.state.allowCode = code
+					e.state.allowReason = reason
+				}
+				return expr, nil
+			}),
+			// deny_hint records a near-miss hint and returns the wrapped
+			// boolean, so it never flips the result. The hint is committed
+			// only when the call is reached and the wrapped expression is
+			// false. Under &&, that is the near-miss where the conditions on
+			// its left matched but this one did not.
+			"deny_hint": typical.TernaryFunctionWithEnv(func(e Env, code, reason string, expr bool) (bool, error) {
+				if err := validateAuditCode(code); err != nil {
+					return false, trace.Wrap(err)
+				}
+				if !expr && e.state != nil {
+					e.state.denyHints = append(e.state.denyHints, Hint{Code: code, Reason: reason})
+				}
+				return expr, nil
+			}),
 			// set and contains are named after the functions in the role
 			// where-clause language, services.NewWhereParser.
 			"set": typical.UnaryVariadicFunction[Env](func(args ...string) ([]string, error) {
@@ -173,4 +231,23 @@ func mustNewWhereParser() *typical.CachedParser[Env, bool] {
 		panic(trace.Wrap(err, "building the where clause parser (this is a bug)"))
 	}
 	return p
+}
+
+// predicate is a parsed, type-checked app-access predicate ready to
+// evaluate. A rule lowers to one predicate, and an
+// app_resources_expressions entry compiles to one directly.
+type predicate = typical.Expression[Env, bool]
+
+// compilePredicate parses and type-checks a predicate, and runs the
+// compile-time audit code validation. Unlike CompileWhere it accepts the
+// full predicate language, including the audit wrappers.
+func compilePredicate(expr string) (predicate, error) {
+	pred, err := whereParser.Parse(expr)
+	if err != nil {
+		return nil, trace.BadParameter("compiling predicate %q: %v", expr, err)
+	}
+	if err := validateAuditCodes(expr); err != nil {
+		return nil, trace.Wrap(err, "compiling predicate %q", expr)
+	}
+	return pred, nil
 }


### PR DESCRIPTION
Add the rule and decision types for fine-grained HTTP app access.

`Rule` is one `app_resources` entry, the sugared form written in a role. Its fields are those of the `AppResource` proto message. Example role showing how a rule will be written:

```yaml
kind: role
version: v9
metadata:
  name: gitlab-dev
spec:
  allow:
    app_labels:
      vendor: [gitlab]
    app_resources:
      - paths: ["/api/v4/projects/{project}/**"]
        methods: ["GET", "POST"]
        where: contains(user.traits["allowed_projects"], vars.project)
        deny_code_hint: project_not_allowed
        deny_reason_hint: Project is not in the caller's allowlist
```

`Rule` validation covers the following.

- A rule sets either `paths` or `allow_all`, and `allow_all` cannot be combined with any other field.
- A method name must be one of `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`, or `TRACE`, matched case-insensitively.
- A `where` clause must parse on its own and must not call `path.match`.
- An `allow_reason` needs an `allow_code`, a `deny_reason_hint` needs a `deny_code_hint`, and a `deny_code_hint` needs a `where` clause.
- An audit code is 1 to 256 bytes of `[a-z0-9_]` and must not use the reserved `teleport_` prefix. A constant code inside an `allow_code` or `deny_hint` call is checked the same way.
- A `where` clause is capped at 1 KiB, an `app_resources_expressions` entry at 4 KiB, and a reason at 1 KiB.

`Decision`, `DenyKind`, `AllowDetails`, and `DenyDetails` are the result of an evaluation. They marshal into one flat JSON object, the form the deny audit event and the `tctl apps evaluate` output will use.

For the role above, a `GET` of `/api/v4/projects/42/issues` by a member of project `42`, whose `allowed_projects` trait contains `42`, is allowed. The captured segment is returned in `vars`:

```json
{
  "allowed": true,
  "evaluated_roles": ["gitlab-dev"],
  "vars": {"project": "42"}
}
```

The same request by a non-member is denied. The rule's `deny_code_hint` and `deny_reason_hint` are returned as a hint:

```json
{
  "allowed": false,
  "evaluated_roles": ["gitlab-dev"],
  "deny_kind": "teleport_request_not_allowed",
  "hints": [
    {
      "code": "project_not_allowed",
      "reason": "Project is not in the caller's allowlist"
    }
  ]
}
```

Related-RFD: https://github.com/gravitational/rfd/blob/main/rfd/0303-policy-based-app-access.md
