### PR TITLE
Fix pagination bug with ListUserGroups resulting in excess items

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -8785,7 +8785,7 @@ func (a *ServerWithRoles) ListUserGroups(ctx context.Context, pageSize int, next
 		return filteredUserGroups, "", nil
 	}
 
-	return filteredUserGroups[:pageSize], filteredUserGroups[pageSize-1].GetName(), nil
+	return filteredUserGroups[:pageSize], filteredUserGroups[pageSize].GetName(), nil
 }
 
 // GetUserGroup returns the specified user group resources.

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -6668,6 +6668,36 @@ func TestListResources_KindUserGroup(t *testing.T) {
 		}
 		require.IsDecreasing(t, names)
 	})
+
+	t.Run("pagination does not duplicate the boundary item", func(t *testing.T) {
+		t.Parallel()
+
+		page1, nextKey, err := s.ListUserGroups(ctx, 2, "")
+		require.NoError(t, err)
+		require.Len(t, page1, 2)
+		require.Equal(t, testUg2.GetName(), page1[0].GetName())
+		require.Equal(t, testUg3.GetName(), page1[1].GetName())
+
+		// nextKey must point at the next UNFETCHED item
+		require.Equal(t, testUg1.GetName(), nextKey,
+			"nextKey should be the name of the next item to fetch, not the last item already returned")
+
+		page2, nextKey2, err := s.ListUserGroups(ctx, 2, nextKey)
+		require.NoError(t, err)
+		require.Empty(t, nextKey2)
+		require.Len(t, page2, 1)
+		require.Equal(t, testUg1.GetName(), page2[0].GetName())
+
+		// No group should be served on both pages.
+		seen := make(map[string]bool, len(page1))
+		for _, ug := range page1 {
+			seen[ug.GetName()] = true
+		}
+		for _, ug := range page2 {
+			require.Falsef(t, seen[ug.GetName()], "user group %q was returned on both pages", ug.GetName())
+		}
+	})
+
 }
 
 func createUserGroup(t *testing.T, s *auth.Server, name string, labels map[string]string) types.UserGroup {


### PR DESCRIPTION
I have found this bug when working on the auth/backend consistency property checker in https://github.com/gravitational/teleport.e/pull/9183

The next key is inclusive and should point to the item outside of the current result. This results in the boundary item being returned twice.

Cache and Backend have generic tests that test pagination but auth with roles has need for filtering pages, generally it is preferred to use the range based APIs with `generic.CollectPageAndCursor` if present to avoid page trimming.


<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed pagination bug in ListUserGroups potentially resulting in duplicate items. 


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local & Antithesis

### Test Cases
- [x] Run the antithesis auth consistency checker workload locally and on Antithesis. Verify no duplicate property has been violated. 
