### PR TITLE
[v18] Antithesis: allow go-cmp for antithesis workloads

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -115,6 +115,7 @@ linters:
             - '!**/lib/services/local/users.go'
             - '!**/lib/services/user.go'
             - '!**/build.assets/tooling/**'
+            - '!**/e/tests/antithesis/workloads/**'
           deny:
             - pkg: github.com/google/go-cmp/cmp
               desc: '"github.com/google/go-cmp/cmp" should only be used in tests'


### PR DESCRIPTION
Backport #68970 to branch/v18