### PR TITLE
[v18] Fix Azure workload identity access

### DIFF
--- a/lib/srv/app/azure/credential.go
+++ b/lib/srv/app/azure/credential.go
@@ -21,6 +21,8 @@ package azure
 import (
 	"context"
 	"log/slog"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -33,6 +35,8 @@ import (
 	cloudazure "github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/utils"
 )
+
+const defaultScopeSuffix = "/.default"
 
 // credentialProvider defines an interface that manages a particular type of
 // credential.
@@ -178,16 +182,41 @@ func (w *workloadIdentityCredentialProvider) MakeCredential(ctx context.Context,
 	return credential, trace.Wrap(err)
 }
 
+// MapScope maps a single resource audience to the workload identity scope
+// format expected by Microsoft identity platform.
+//
+// Azure CLI may send resource-style audiences such as "https://vault.azure.net".
+// Workload identity uses OAuth scopes, so a bare resource audience must be
+// converted to "{resource}/.default". Do not normalize multi-token scope lists
+// here; .default is not compatible with dynamic or OIDC scopes in the same
+// token request.
 func (w *workloadIdentityCredentialProvider) MapScope(scope string) string {
-	// This scope ("https://management.core.windows.net/") from `az` CLI tool
-	// will fail for workload identity as workload identity is only expected to
-	// be used with compatible SDKs, whereas the SDK adds ".default" to the
-	// audience:
-	//
-	// https://github.com/Azure/azure-sdk-for-go/blob/9e78ee2b86f0f4989098dd7e545b73841fc8df47/sdk/azcore/arm/runtime/pipeline.go#L35
-	if scope == "https://management.core.windows.net/" {
-		return scope + ".default"
+	if strings.HasSuffix(scope, defaultScopeSuffix) {
+		return scope
 	}
+
+	// If the input contains multiple scope tokens, for example
+	// https://graph.microsoft.com/User.Read openid profile, leave it
+	// unchanged.
+	tokens := strings.Fields(scope)
+	if len(tokens) > 1 {
+		return scope
+	}
+
+	parsed, err := url.Parse(scope)
+	// Bare delegated scopes such as User.Read are interpreted by Microsoft
+	// identity platform as Microsoft Graph scopes; leave them unchanged.
+	// https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#admin-restricted-permissions
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return scope
+	}
+
+	if parsed.Path == "" || parsed.Path == "/" {
+		// Specifically do not strip the trailing slash as required by Microsoft documentation:
+		// https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#trailing-slash-and-default
+		return scope + defaultScopeSuffix
+	}
+
 	return scope
 }
 

--- a/lib/srv/app/azure/credential_test.go
+++ b/lib/srv/app/azure/credential_test.go
@@ -74,6 +74,46 @@ func Test_getAccessTokenFromCredentialProvider(t *testing.T) {
 	require.Equal(t, "test-scope.mapped", fakeCredProvider.cred.lastSeenScope)
 }
 
+func Test_managedIdentityCredentialProvider_MapScope(t *testing.T) {
+	t.Parallel()
+
+	credProvider := managedIdentityCredentialProvider{}
+
+	tests := []struct {
+		name       string
+		inputScope string
+		wantScope  string
+	}{
+		{
+			name:       "resource with trailing slash unchanged",
+			inputScope: "https://vault.azure.net/",
+			wantScope:  "https://vault.azure.net/",
+		},
+		{
+			name:       "resource without trailing slash unchanged",
+			inputScope: "https://vault.azure.net",
+			wantScope:  "https://vault.azure.net",
+		},
+		{
+			name:       "default scope unchanged",
+			inputScope: "https://vault.azure.net/.default",
+			wantScope:  "https://vault.azure.net/.default",
+		},
+		{
+			name:       "dynamic scope list unchanged",
+			inputScope: "https://graph.microsoft.com/User.Read openid profile offline_access",
+			wantScope:  "https://graph.microsoft.com/User.Read openid profile offline_access",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotScope := credProvider.MapScope(tt.inputScope)
+			require.Equal(t, tt.wantScope, gotScope)
+		})
+	}
+}
+
 func Test_workloadIdentityCredentialProvider(t *testing.T) {
 	ctx := context.Background()
 	fakeAgentIdentity := &fakeTokenCredential{}
@@ -109,21 +149,81 @@ func Test_workloadIdentityCredentialProvider(t *testing.T) {
 
 	t.Run("MapScope", func(t *testing.T) {
 		tests := []struct {
-			inputScope  string
-			outputScope string
+			name       string
+			inputScope string
+			wantScope  string
 		}{
 			{
-				inputScope:  "https://management.core.windows.net/",
-				outputScope: "https://management.core.windows.net/.default",
+				name:       "management resource preserves trailing slash",
+				inputScope: "https://management.core.windows.net/",
+				wantScope:  "https://management.core.windows.net//.default",
 			},
 			{
-				inputScope:  "some-other-scope",
-				outputScope: "some-other-scope",
+				name:       "management resource without trailing slash",
+				inputScope: "https://management.azure.com",
+				wantScope:  "https://management.azure.com/.default",
+			},
+			{
+				name:       "resource without trailing slash",
+				inputScope: "https://vault.azure.net",
+				wantScope:  "https://vault.azure.net/.default",
+			},
+			{
+				name:       "resource with trailing slash",
+				inputScope: "https://vault.azure.net/",
+				wantScope:  "https://vault.azure.net//.default",
+			},
+			{
+				name:       "default scope unchanged",
+				inputScope: "https://vault.azure.net/.default",
+				wantScope:  "https://vault.azure.net/.default",
+			},
+			{
+				name:       "storage resource preserves trailing slash",
+				inputScope: "https://storage.azure.com/",
+				wantScope:  "https://storage.azure.com//.default",
+			},
+			{
+				name:       "database resource preserves trailing slash",
+				inputScope: "https://database.windows.net/",
+				wantScope:  "https://database.windows.net//.default",
+			},
+			{
+				name:       "only global OIDC scopes",
+				inputScope: "openid profile offline_access",
+				wantScope:  "openid profile offline_access",
+			},
+			{
+				name:       "dynamic delegated scope",
+				inputScope: "User.Read",
+				wantScope:  "User.Read",
+			},
+			{
+				name:       "fully qualified dynamic delegated scope",
+				inputScope: "https://graph.microsoft.com/User.Read",
+				wantScope:  "https://graph.microsoft.com/User.Read",
+			},
+			{
+				name:       "dynamic delegated scope with global OIDC scopes",
+				inputScope: "https://graph.microsoft.com/User.Read openid profile offline_access",
+				wantScope:  "https://graph.microsoft.com/User.Read openid profile offline_access",
+			},
+			{
+				name:       "multiple dynamic delegated scopes",
+				inputScope: "User.Read Files.Read.All",
+				wantScope:  "User.Read Files.Read.All",
+			},
+			{
+				name:       "custom API dynamic delegated scope",
+				inputScope: "api://00000000-0000-0000-0000-000000000000/access_as_user",
+				wantScope:  "api://00000000-0000-0000-0000-000000000000/access_as_user",
 			},
 		}
-		for _, test := range tests {
-			t.Run(test.inputScope, func(t *testing.T) {
-				require.Equal(t, test.outputScope, credProvider.MapScope(test.inputScope))
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				gotScope := credProvider.MapScope(tt.inputScope)
+				require.Equal(t, tt.wantScope, gotScope)
 			})
 		}
 	})


### PR DESCRIPTION
Backport #68938 to branch/v18

No changes on top of the orginal commit.

issue: https://github.com/gravitational/teleport/issues/63718
issue: https://github.com/gravitational/teleport/issues/64250
issue: https://github.com/gravitational/teleport/issues/61056

## What
Access to resources using Azure CLI through Teleport is broken if using the workload identity (the method used in GH actions and AKS clusters).

## Why
The problem only occurs when `app_service` uses workload identity as Azure credentials. in this mode `scope` is used to set the requested resource. This `scope` field requires a `/.default` suffix and standard azure CLI tools add it. Teleport however was only adding it if the scope's was `https://management.core.windows.net/`, rendering other scopes malformed and resulting in 400 (bad request) response from Azure.

When teleport issues requests using `tsh az` it always uses `--identity --resource=xxx` (managed identity style), so that the requests do not include the required `/.default` suffix. In addition, it may include other OIDC-related scopes.

The fix in this PR is to always append `/.default` suffix to scopes unless there is already a dynamic scope or global OIDC-related scopes included.

## Manual Test Plan
- [x] Updated the fixed version and confirm the `tsh az keyvault secret show` command works and correct scope with .default suffix is sent.
```
cli.azure.cli.core.sdk.policies: Response content:
cli.azure.cli.core.sdk.policies: {"error":{"code":"Unauthorized","message":"AKV10000: Request is missing a Bearer, PoP, or MTLS_POP token."}}
cli.azure.cli.core.auth.credential_adaptor: CredentialAdaptor.get_token_info: scopes=('https://vault.azure.net/.default',), options={'tenant_id': 'ff882432-09b0-437b-bd22-ca13c0037ded'}
cli.azure.cli.core.auth.msal_credentials: ManagedIdentityCredential.acquire_token: scopes=['https://vault.azure.net/.default'], kwargs={}
msal.managed_identity: Obtaining token via managed identity on Azure App Service
```

### Test Environment
- Build an Azure console acceess in AKS - https://goteleport.com/docs/enroll-resources/application-access/cloud-apis/azure-aks-workload-id/

### Test Cases
- [x] Validate that the test cases that were known to fail are succeeding now.
      - Setup ASK Azure console application and also a secret vault with a dummy secret (running the fixed teleport on the AKS agent).
      - Login to the azure console app with the following command:
         `tsh apps login azure-cli --azure-identity <azure-identity>`
      - `tsh -d az keyvault secret show --vault-name kv-kozadaevtelepor-lr73 --name dummy-password --debug`
          This command used to fail with teleport getting 400 (bad-request) from the Azure. Additionally commands that access blob storage were broken as well and can also be used.

    ```
    2026-07-23T16:37:42.683+01:00 WARN [LOCALPROX] Server response contained an error header error_header:"ERROR REPORT: Original Error: *azidentity.AuthenticationFailedError WorkloadIdentityCredential authentication failed.  POST https://login.microsoftonline.com/ff882432-09b0-437b-bd22-ca13c0037ded/oauth2/v2.0/token ---
    ----------------------------------------------------------------------------- RESPONSE 400: 400 Bad Request -------------------------------------------------------------------------------- {   &#34;error&#34;: &#34;invalid_scope&#34;,   &#34;error_description&#34;: &#34;AADSTS70011: The provided request must include a
     &#39;scope&#39; input parameter. The provided value for the input parameter &#39;scope&#39; is not valid. The scope https://vault.azure.net openid offline_access profile is not valid. Trace ID: dc04ff2b-146c-4d3f-8967-05beea226000 Correlation ID: 27fb4e9f-65f4-4cfc-8b5f-b9f8ae640b7d Timestamp: 2026-07-23 15:37:42Z&#3
    4;,   &#34;error_codes&#34;: [     70011   ],   &#34;timestamp&#34;: &#34;2026-07-23 15:37:42Z&#34;,   &#34;trace_id&#34;: &#34;dc04ff2b-146c-4d3f-8967-05beea226000&#34;,   &#34;correlation_id&#34;: &#34;27fb4e9f-65f4-4cfc-8b5f-b9f8ae640b7d&#34; } -----------------------------------------------------------------------
    --------- To troubleshoot, visit https://aka.ms/azsdk/go/identity/troubleshoot#workload Stack Trace:\n\tgithub.com/gravitational/teleport/lib/srv/app/azure/credential.go:79 github.com/gravitational/teleport/lib/srv/app/azure.getAccessTokenFromCredentialProvider.func1\n\tgithub.com/gravitational/teleport/lib/srv/app/az
    ure/credential.go:63 github.com/gravitational/teleport/lib/srv/app/azure.(*HandlerConfig).CheckAndSetDefaults.lazyGetAccessTokenFromDefaultCredentialProvider.func1\n\tgithub.com/gravitational/teleport/lib/srv/app/azure/handler.go:293 github.com/gravitational/teleport/lib/srv/app/azure.(*handler).getToken.func1.1\n\tgi
    thub.com/gravitational/teleport/lib/utils/fncache.go:278 github.com/gravitational/teleport/lib/utils.FnCacheGetWithTTL[...].func1\n\tgithub.com/gravitational/teleport/lib/utils/fncache.go:357 github.com/gravitational/teleport/lib/utils.(*FnCache).get.func1\n\truntime/asm_amd64.s:1771 runtime.goexit\n\n\tUser Message:
    WorkloadIdentityCredential authentication failed.  POST https://login.microsoftonline.com/ff882432-09b0-437b-bd22-ca13c0037ded/oauth2/v2.0/token -------------------------------------------------------------------------------- RESPONSE 400: 400 Bad Request ---------------------------------------------------------------
    ----------------- {   &#34;error&#34;: &#34;invalid_scope&#34;,   &#34;error_description&#34;: &#34;AADSTS70011: The provided request must include a &#39;scope&#39; input parameter. The provided value for the input parameter &#39;scope&#39; is not valid. The scope https://vault.azure.net openid offline_access profile
    is not valid. Trace ID: dc04ff2b-146c-4d3f-8967-05beea226000 Correlation ID: 27fb4e9f-65f4-4cfc-8b5f-b9f8ae640b7d Timestamp: 2026-07-23 15:37:42Z&#34;,   &#34;error_codes&#34;: [     70011   ],   &#34;timestamp&#34;: &#34;2026-07-23 15:37:42Z&#34;,   &#34;trace_id&#34;: &#34;dc04ff2b-146c-4d3f-8967-05beea226000&#34;,
      &#34;correlation_id&#34;: &#34;27fb4e9f-65f4-4cfc-8b5f-b9f8ae640b7d&#34; } -------------------------------------------------------------------------------- To troubleshoot, visit https://aka.ms/azsdk/go/identity/troubleshoot#workload" alpnproxy/local_proxy.go:328
    ```

      - Observe the command succeeds and passes the correct scope to the Azure. 
    ```
    cli.azure.cli.core.sdk.policies: Response content:
    cli.azure.cli.core.sdk.policies: {"error":{"code":"Unauthorized","message":"AKV10000: Request is missing a Bearer, PoP, or MTLS_POP token."}}
    cli.azure.cli.core.auth.credential_adaptor: CredentialAdaptor.get_token_info: scopes=('https://vault.azure.net/.default',), options={'tenant_id': 'ff882432-09b0-437b-bd22-ca13c0037ded'}
    cli.azure.cli.core.auth.msal_credentials: ManagedIdentityCredential.acquire_token: scopes=['https://vault.azure.net/.default'], kwargs={}
    msal.managed_identity: Obtaining token via managed identity on Azure App Service
    ```

- [x] Validate that the test cases that were working properly - continue to work.
      - Setup ASK Azure console application and also a secret vault with a dummy secret (running the master teleport).
      - Login to the azure console app with the following command:
         `tsh apps login azure-cli --azure-identity <azure-identity>`
      - `tsh az -d account get-access-token --resource https://management.azure.com/ --debug`
          This command should succeed because it's using management scope handled by the current code.
    ```
    cli.knack.cli: Event: CommandInvoker.OnCommandTableLoaded []
    cli.knack.cli: Event: CommandInvoker.OnPreParseArgs []
    cli.knack.cli: Event: CommandInvoker.OnPostParseArgs [<function OutputProducer.handle_output_argument at 0x1058c2da0>, <function CLIQuery.handle_query_parameter at 0x105945590>, <function register_ids_argument.<locals>.parse_ids_arguments at 0x105c25f30>]
    cli.azure.cli.core.auth.msal_credentials: ManagedIdentityCredential.acquire_token: scopes=['https://management.azure.com//.default'], kwargs={}
    msal.managed_identity: Obtaining token via managed identity on Azure App Service
    urllib3.connectionpool: Starting new HTTPS connection (1): azure-identity.teleport.dev:443
    ```
      - Upgrade to fix version and observe the command is still working.
- [x] Verify `tsh az proxy` works as well (https://github.com/gravitational/teleport/issues/64250)
   Same setup as above.
   - run `tsh proxy azure --port 8080 --debug`
   - export the provided env variables in another terminal.
   - use the az vault/store command from above tests (without tsh) and observe they are working on fixed version. They used to fail with the same error as the above.