### PR TITLE
[v18] fix: include user's SSO MFA device in weakest MFA device resolution

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -4741,6 +4741,8 @@ enum MFADeviceKind {
   MFA_DEVICE_KIND_TOTP = 2;
   // MFA device is known to be configured using WebAuthn as the weakest form of MFA.
   MFA_DEVICE_KIND_WEBAUTHN = 3;
+  // MFA device is known to be configured using SSO as the weakest form of MFA.
+  MFA_DEVICE_KIND_SSO = 4;
 }
 
 // UserSpecV2 is a specification for V2 user

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -1331,7 +1331,7 @@ func (s *IdentityService) buildAndSetWeakestMFADeviceKind(ctx context.Context, u
 	if localAuthSecrets != nil {
 		upsertingMFA = localAuthSecrets.MFA
 	}
-	state, err := s.buildWeakestMFADeviceKind(ctx, user.GetName(), upsertingMFA...)
+	state, err := s.buildWeakestMFADeviceKind(ctx, user, upsertingMFA...)
 	if err != nil {
 		s.logger.WarnContext(ctx, "Failed to determine weakest mfa device kind for user", "error", err)
 		return
@@ -1339,24 +1339,30 @@ func (s *IdentityService) buildAndSetWeakestMFADeviceKind(ctx context.Context, u
 	user.SetWeakestDevice(state)
 }
 
-func (s *IdentityService) buildWeakestMFADeviceKind(ctx context.Context, user string, upsertingMFA ...*types.MFADevice) (types.MFADeviceKind, error) {
-	devs, err := s.GetMFADevices(ctx, user, false)
+func (s *IdentityService) buildWeakestMFADeviceKind(ctx context.Context, user types.User, upsertingMFA ...*types.MFADevice) (types.MFADeviceKind, error) {
+	devs, err := s.getMFADevices(ctx, user.GetName(), false /* MFA secrets not needed */, func() (types.CreatedBy, error) {
+		return user.GetCreatedBy(), nil
+	})
 	if err != nil {
 		return types.MFADeviceKind_MFA_DEVICE_KIND_UNSET, trace.Wrap(err)
 	}
 	return GetWeakestMFADeviceKind(append(devs, upsertingMFA...)), nil
 }
 
-// GetWeakestMFADeviceKind returns the weakest MFA state based on the devices the user
-// has.
-// When a user has no MFA device, it's set to `MFADeviceKind_MFA_DEVICE_KIND_UNSET`.
-// When a user has at least one TOTP device, it's set to `MFADeviceKind_MFA_DEVICE_KIND_TOTP`.
-// When a user ONLY has webauthn devices, it's set to `MFADeviceKind_MFA_DEVICE_KIND_WEBAUTHN`.
-func GetWeakestMFADeviceKind(devs []*types.MFADevice) types.MFADeviceKind {
+// GetWeakestMFADeviceKind returns the weakest MFA device kind.
+// Device ranking, from weakest to strongest: TOTP < SSO MFA < WebAuthn/U2F.
+//   - If `in` has zero MFA devices, it returns `MFADeviceKind_MFA_DEVICE_KIND_UNSET`.
+//   - If `in` has at least one TOTP device, it returns `MFADeviceKind_MFA_DEVICE_KIND_TOTP`.
+//   - If `in` has at least one SSO MFA device and no TOTP devices, it returns `MFADeviceKind_MFA_DEVICE_KIND_SSO`.
+//   - If `in` has only WebAuthn/U2F devices, it returns `MFADeviceKind_MFA_DEVICE_KIND_WEBAUTHN`.
+func GetWeakestMFADeviceKind(in []*types.MFADevice) types.MFADeviceKind {
 	mfaState := types.MFADeviceKind_MFA_DEVICE_KIND_UNSET
-	for _, d := range devs {
+	for _, d := range in {
 		if (d.GetWebauthn() != nil || d.GetU2F() != nil) && mfaState == types.MFADeviceKind_MFA_DEVICE_KIND_UNSET {
 			mfaState = types.MFADeviceKind_MFA_DEVICE_KIND_WEBAUTHN
+		}
+		if d.GetSso() != nil && mfaState != types.MFADeviceKind_MFA_DEVICE_KIND_TOTP {
+			mfaState = types.MFADeviceKind_MFA_DEVICE_KIND_SSO
 		}
 		if d.GetTotp() != nil {
 			mfaState = types.MFADeviceKind_MFA_DEVICE_KIND_TOTP
@@ -1386,7 +1392,13 @@ func (s *IdentityService) DeleteMFADevice(ctx context.Context, user, id string) 
 
 	err := s.Delete(ctx, backend.NewKey(webPrefix, usersPrefix, user, mfaDevicePrefix, id))
 	if trace.IsNotFound(err) {
-		if _, err := s.getSSOMFADevice(ctx, user); err == nil {
+		if _, err := s.getSSOMFADevice(ctx, func() (types.CreatedBy, error) {
+			user, err := s.GetUser(ctx, user, false /* user secrets not required */)
+			if err != nil {
+				return types.CreatedBy{}, trace.Wrap(err)
+			}
+			return user.GetCreatedBy(), nil
+		}); err == nil {
 			return trace.BadParameter("cannot delete ephemeral SSO MFA device")
 		}
 		return trace.Wrap(err)
@@ -1405,20 +1417,36 @@ func (s *IdentityService) GetMFADevices(ctx context.Context, user string, withSe
 		return nil, trace.BadParameter("missing parameter user")
 	}
 
+	devices, err := s.getMFADevices(ctx, user, withSecrets, func() (types.CreatedBy, error) {
+		user, err := s.GetUser(ctx, user, false /* user secrets not required */)
+		if err != nil {
+			return types.CreatedBy{}, trace.Wrap(err)
+		}
+		return user.GetCreatedBy(), nil
+	})
+
+	return devices, trace.Wrap(err)
+}
+
+func (s *IdentityService) getMFADevices(ctx context.Context, user string, withMFASecrets bool, userCreatedByFn func() (types.CreatedBy, error)) ([]*types.MFADevice, error) {
+	if user == "" {
+		return nil, trace.BadParameter("missing parameter user")
+	}
+
 	// get normal MFA devices and SSO mfa device concurrently, returning the first error we get.
 	eg, egCtx := errgroup.WithContext(ctx)
 
 	var devices []*types.MFADevice
 	eg.Go(func() error {
 		var err error
-		devices, err = s.getMFADevices(egCtx, user, withSecrets)
+		devices, err = s.getPersistedMFADevices(egCtx, user, withMFASecrets)
 		return trace.Wrap(err)
 	})
 
 	var ssoDev *types.MFADevice
 	eg.Go(func() error {
 		var err error
-		ssoDev, err = s.getSSOMFADevice(egCtx, user)
+		ssoDev, err = s.getSSOMFADevice(egCtx, userCreatedByFn)
 		if trace.IsNotFound(err) {
 			return nil // OK, SSO device may not exist.
 		}
@@ -1436,10 +1464,10 @@ func (s *IdentityService) GetMFADevices(ctx context.Context, user string, withSe
 	return devices, nil
 }
 
-// getMFADevices reads devices from storage. Devices from other sources, such as
+// getPersistedMFADevices reads devices from storage. Devices from other sources, such as
 // the ephemeral SSO devices, are not returned by it.
 // See getSSOMFADevice and GetMFADevices (which returns all devices).
-func (s *IdentityService) getMFADevices(ctx context.Context, user string, withSecrets bool) ([]*types.MFADevice, error) {
+func (s *IdentityService) getPersistedMFADevices(ctx context.Context, user string, withSecrets bool) ([]*types.MFADevice, error) {
 	startKey := backend.ExactKey(webPrefix, usersPrefix, user, mfaDevicePrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
@@ -1466,18 +1494,14 @@ func (s *IdentityService) getMFADevices(ctx context.Context, user string, withSe
 // getSSOMFADevice returns the user's SSO MFA device. This device is ephemeral, meaning it
 // does not actually appear in the backend under the user's mfa key. Instead it is fetched
 // by checking related user and cluster configuration settings.
-func (s *IdentityService) getSSOMFADevice(ctx context.Context, user string) (*types.MFADevice, error) {
-	if user == "" {
-		return nil, trace.BadParameter("missing parameter user")
+func (s *IdentityService) getSSOMFADevice(ctx context.Context, userCreatedByFn func() (types.CreatedBy, error)) (*types.MFADevice, error) {
+	if userCreatedByFn == nil {
+		return nil, trace.BadParameter("missing parameter userCreatedByFn")
 	}
-
-	const withSecrets = false
-	u, err := s.GetUser(ctx, user, withSecrets)
+	cb, err := userCreatedByFn()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	cb := u.GetCreatedBy()
 	if cb.Connector == nil {
 		return nil, trace.NotFound("no SSO MFA device found; user was not created by an auth connector")
 	}
@@ -1487,6 +1511,7 @@ func (s *IdentityService) getSSOMFADevice(ctx context.Context, user string) (*ty
 		GetDisplay() string
 	}
 
+	const withSecrets = false
 	const ssoMFADisabledErr = "no SSO MFA device found; user's auth connector does not have MFA enabled"
 	switch cb.Connector.Type {
 	case constants.SAML:

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 
+	"github.com/gravitational/teleport/api/constants"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
 	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
@@ -1786,6 +1787,69 @@ func TestWeakestMFADeviceKind(t *testing.T) {
 	got, err = identity.GetUser(ctx, "bob", false)
 	require.NoError(t, err)
 	require.Equal(t, types.MFADeviceKind_MFA_DEVICE_KIND_TOTP, got.GetWeakestDevice())
+
+	// An SSO MFA device cannot be created. Instead it is deduced based on the MFA settings being
+	// enabled in the SSO connector spec. It is simulated by creating a SAML connector below.
+	samlConnectorWithSSOMFA, err := types.NewSAMLConnector("saml", types.SAMLConnectorSpecV2{
+		AssertionConsumerService: "http://localhost:65535/acs", // not called
+		Issuer:                   "test",
+		SSO:                      "https://localhost:65535/sso", // not called
+		AttributesToRoles: []types.AttributeMapping{
+			// not used. can be any name, value but role must exist
+			{Name: "groups", Value: "admin", Roles: []string{"access"}},
+		},
+		MFASettings: &types.SAMLConnectorMFASettings{
+			Enabled: true,
+			Issuer:  "test",
+			Sso:     "https://localhost:65535/sso", // not called
+		},
+	})
+	require.NoError(t, err)
+	_, err = identity.UpsertSAMLConnector(ctx, samlConnectorWithSSOMFA)
+	require.NoError(t, err)
+
+	// Update bob to be an SSO user by setting CreatedBy matching with samlConnectorWithSSOMFA.
+	// This will start resolving bob's SSO MFA device.
+	bob1, err = identity.GetUser(ctx, "bob", false /* withSecrets */)
+	require.NoError(t, err)
+	bob1.SetCreatedBy(types.CreatedBy{
+		Connector: &types.ConnectorRef{
+			Type:     constants.SAML,
+			ID:       samlConnectorWithSSOMFA.GetName(),
+			Identity: bob1.GetName(),
+		},
+		Time: clock.Now().UTC(),
+	})
+	got, err = identity.UpdateUser(ctx, bob1)
+	require.NoError(t, err)
+
+	// Weakest device still remains the TOTP.
+	require.Equal(t, types.MFADeviceKind_MFA_DEVICE_KIND_TOTP, got.GetWeakestDevice())
+
+	// Delete TOTP device
+	err = identity.DeleteMFADevice(ctx, "bob", totpDevice.Id)
+	require.NoError(t, err)
+
+	// Expect the new weakest device to be SSO MFA.
+	got, err = identity.GetUser(ctx, "bob", false /* withSecrets */)
+	require.NoError(t, err)
+	require.Equal(t, types.MFADeviceKind_MFA_DEVICE_KIND_SSO, got.GetWeakestDevice())
+
+	// New SAML user that has a referenced connector with MFA settings enabled should
+	// get the MFADeviceKind_MFA_DEVICE_KIND_SSO at the time of resource creation.
+	alice, err := types.NewUser("alice")
+	require.NoError(t, err)
+	alice.SetCreatedBy(types.CreatedBy{
+		Connector: &types.ConnectorRef{
+			Type:     constants.SAML,
+			ID:       samlConnectorWithSSOMFA.GetName(),
+			Identity: alice.GetName(),
+		},
+		Time: clock.Now().UTC(),
+	})
+	got, err = identity.CreateUser(ctx, alice)
+	require.NoError(t, err)
+	require.Equal(t, types.MFADeviceKind_MFA_DEVICE_KIND_SSO, got.GetWeakestDevice())
 }
 
 func TestIdentityService_SSOMFASessionDataCRUD(t *testing.T) {


### PR DESCRIPTION

Backports https://github.com/gravitational/teleport/pull/68738 to branch/v18

Changelog: User's weakest MFA device checker now accounts for user's SSO MFA device.

https://github.com/gravitational/teleport.e/issues/9100

## Manual Test Plan
### Test Environment
Teleport cluster with SAML connector set up and SSO MFA enabled.

### Test Cases
- [x] Check SSO MFA device is computed for user's weakest MFA device
- [x] Regression test: Check `tsh mfa ls` works.
- [x] Regression test: Check user can add new MFA device from Web UI and `tsh`.
