### PR TITLE
`EnrollDevice` RPC proof of concept

### DIFF
--- a/api/gen/proto/go/teleport/devicetrust/public/v1/devicetrust_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/devicetrust/public/v1/devicetrust_service_grpc.pb.go
@@ -34,6 +34,7 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	DeviceTrustService_CreatePairedDeviceEnrollToken_FullMethodName = "/teleport.devicetrust.public.v1.DeviceTrustService/CreatePairedDeviceEnrollToken"
+	DeviceTrustService_EnrollDevice_FullMethodName                  = "/teleport.devicetrust.public.v1.DeviceTrustService/EnrollDevice"
 )
 
 // DeviceTrustServiceClient is the client API for DeviceTrustService service.
@@ -64,6 +65,19 @@ type DeviceTrustServiceClient interface {
 	// calls with the same enroll pairing token are allowed only if os_type and
 	// serial_number from device_data match those from the initial call.
 	CreatePairedDeviceEnrollToken(ctx context.Context, in *CreatePairedDeviceEnrollTokenRequest, opts ...grpc.CallOption) (*CreatePairedDeviceEnrollTokenResponse, error)
+	// EnrollDevice performs the device enrollment ceremony for a mobile device.
+	//
+	// It is the publicly-accessible counterpart to
+	// teleport.devicetrust.v1.DeviceTrustService.EnrollDevice. It uses the
+	// enrollment token returned by CreatePairedDeviceEnrollToken instead of a
+	// user certificate.
+	//
+	// iOS and iPadOS enrollment flow:
+	// -> EnrollDeviceInit (client)
+	// <- IOSEnrollChallenge (server)
+	// -> IOSEnrollChallengeResponse (client)
+	// <- EnrollDeviceSuccess (server)
+	EnrollDevice(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[EnrollDeviceRequest, EnrollDeviceResponse], error)
 }
 
 type deviceTrustServiceClient struct {
@@ -83,6 +97,19 @@ func (c *deviceTrustServiceClient) CreatePairedDeviceEnrollToken(ctx context.Con
 	}
 	return out, nil
 }
+
+func (c *deviceTrustServiceClient) EnrollDevice(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[EnrollDeviceRequest, EnrollDeviceResponse], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &DeviceTrustService_ServiceDesc.Streams[0], DeviceTrustService_EnrollDevice_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[EnrollDeviceRequest, EnrollDeviceResponse]{ClientStream: stream}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type DeviceTrustService_EnrollDeviceClient = grpc.BidiStreamingClient[EnrollDeviceRequest, EnrollDeviceResponse]
 
 // DeviceTrustServiceServer is the server API for DeviceTrustService service.
 // All implementations must embed UnimplementedDeviceTrustServiceServer
@@ -112,6 +139,19 @@ type DeviceTrustServiceServer interface {
 	// calls with the same enroll pairing token are allowed only if os_type and
 	// serial_number from device_data match those from the initial call.
 	CreatePairedDeviceEnrollToken(context.Context, *CreatePairedDeviceEnrollTokenRequest) (*CreatePairedDeviceEnrollTokenResponse, error)
+	// EnrollDevice performs the device enrollment ceremony for a mobile device.
+	//
+	// It is the publicly-accessible counterpart to
+	// teleport.devicetrust.v1.DeviceTrustService.EnrollDevice. It uses the
+	// enrollment token returned by CreatePairedDeviceEnrollToken instead of a
+	// user certificate.
+	//
+	// iOS and iPadOS enrollment flow:
+	// -> EnrollDeviceInit (client)
+	// <- IOSEnrollChallenge (server)
+	// -> IOSEnrollChallengeResponse (client)
+	// <- EnrollDeviceSuccess (server)
+	EnrollDevice(grpc.BidiStreamingServer[EnrollDeviceRequest, EnrollDeviceResponse]) error
 	mustEmbedUnimplementedDeviceTrustServiceServer()
 }
 
@@ -124,6 +164,9 @@ type UnimplementedDeviceTrustServiceServer struct{}
 
 func (UnimplementedDeviceTrustServiceServer) CreatePairedDeviceEnrollToken(context.Context, *CreatePairedDeviceEnrollTokenRequest) (*CreatePairedDeviceEnrollTokenResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreatePairedDeviceEnrollToken not implemented")
+}
+func (UnimplementedDeviceTrustServiceServer) EnrollDevice(grpc.BidiStreamingServer[EnrollDeviceRequest, EnrollDeviceResponse]) error {
+	return status.Error(codes.Unimplemented, "method EnrollDevice not implemented")
 }
 func (UnimplementedDeviceTrustServiceServer) mustEmbedUnimplementedDeviceTrustServiceServer() {}
 func (UnimplementedDeviceTrustServiceServer) testEmbeddedByValue()                            {}
@@ -164,6 +207,13 @@ func _DeviceTrustService_CreatePairedDeviceEnrollToken_Handler(srv interface{}, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _DeviceTrustService_EnrollDevice_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(DeviceTrustServiceServer).EnrollDevice(&grpc.GenericServerStream[EnrollDeviceRequest, EnrollDeviceResponse]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type DeviceTrustService_EnrollDeviceServer = grpc.BidiStreamingServer[EnrollDeviceRequest, EnrollDeviceResponse]
+
 // DeviceTrustService_ServiceDesc is the grpc.ServiceDesc for DeviceTrustService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -176,6 +226,13 @@ var DeviceTrustService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _DeviceTrustService_CreatePairedDeviceEnrollToken_Handler,
 		},
 	},
-	Streams:  []grpc.StreamDesc{},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "EnrollDevice",
+			Handler:       _DeviceTrustService_EnrollDevice_Handler,
+			ServerStreams: true,
+			ClientStreams: true,
+		},
+	},
 	Metadata: "teleport/devicetrust/public/v1/devicetrust_service.proto",
 }

--- a/api/gen/proto/go/teleport/devicetrust/public/v1/devicetrust_service_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/devicetrust/public/v1/devicetrust_service_protohybrid.pb.go
@@ -195,37 +195,839 @@ func (b0 CreatePairedDeviceEnrollTokenResponse_builder) Build() *CreatePairedDev
 	return m0
 }
 
+// Request for EnrollDevice.
+type EnrollDeviceRequest struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// Types that are valid to be assigned to Payload:
+	//
+	//	*EnrollDeviceRequest_Init
+	//	*EnrollDeviceRequest_IosChallengeResponse
+	Payload       isEnrollDeviceRequest_Payload `protobuf_oneof:"payload"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EnrollDeviceRequest) Reset() {
+	*x = EnrollDeviceRequest{}
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnrollDeviceRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnrollDeviceRequest) ProtoMessage() {}
+
+func (x *EnrollDeviceRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *EnrollDeviceRequest) GetPayload() isEnrollDeviceRequest_Payload {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
+func (x *EnrollDeviceRequest) GetInit() *EnrollDeviceInit {
+	if x != nil {
+		if x, ok := x.Payload.(*EnrollDeviceRequest_Init); ok {
+			return x.Init
+		}
+	}
+	return nil
+}
+
+func (x *EnrollDeviceRequest) GetIosChallengeResponse() *IOSEnrollChallengeResponse {
+	if x != nil {
+		if x, ok := x.Payload.(*EnrollDeviceRequest_IosChallengeResponse); ok {
+			return x.IosChallengeResponse
+		}
+	}
+	return nil
+}
+
+func (x *EnrollDeviceRequest) SetInit(v *EnrollDeviceInit) {
+	if v == nil {
+		x.Payload = nil
+		return
+	}
+	x.Payload = &EnrollDeviceRequest_Init{v}
+}
+
+func (x *EnrollDeviceRequest) SetIosChallengeResponse(v *IOSEnrollChallengeResponse) {
+	if v == nil {
+		x.Payload = nil
+		return
+	}
+	x.Payload = &EnrollDeviceRequest_IosChallengeResponse{v}
+}
+
+func (x *EnrollDeviceRequest) HasPayload() bool {
+	if x == nil {
+		return false
+	}
+	return x.Payload != nil
+}
+
+func (x *EnrollDeviceRequest) HasInit() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.Payload.(*EnrollDeviceRequest_Init)
+	return ok
+}
+
+func (x *EnrollDeviceRequest) HasIosChallengeResponse() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.Payload.(*EnrollDeviceRequest_IosChallengeResponse)
+	return ok
+}
+
+func (x *EnrollDeviceRequest) ClearPayload() {
+	x.Payload = nil
+}
+
+func (x *EnrollDeviceRequest) ClearInit() {
+	if _, ok := x.Payload.(*EnrollDeviceRequest_Init); ok {
+		x.Payload = nil
+	}
+}
+
+func (x *EnrollDeviceRequest) ClearIosChallengeResponse() {
+	if _, ok := x.Payload.(*EnrollDeviceRequest_IosChallengeResponse); ok {
+		x.Payload = nil
+	}
+}
+
+const EnrollDeviceRequest_Payload_not_set_case case_EnrollDeviceRequest_Payload = 0
+const EnrollDeviceRequest_Init_case case_EnrollDeviceRequest_Payload = 1
+const EnrollDeviceRequest_IosChallengeResponse_case case_EnrollDeviceRequest_Payload = 2
+
+func (x *EnrollDeviceRequest) WhichPayload() case_EnrollDeviceRequest_Payload {
+	if x == nil {
+		return EnrollDeviceRequest_Payload_not_set_case
+	}
+	switch x.Payload.(type) {
+	case *EnrollDeviceRequest_Init:
+		return EnrollDeviceRequest_Init_case
+	case *EnrollDeviceRequest_IosChallengeResponse:
+		return EnrollDeviceRequest_IosChallengeResponse_case
+	default:
+		return EnrollDeviceRequest_Payload_not_set_case
+	}
+}
+
+type EnrollDeviceRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Fields of oneof Payload:
+	Init                 *EnrollDeviceInit
+	IosChallengeResponse *IOSEnrollChallengeResponse
+	// -- end of Payload
+}
+
+func (b0 EnrollDeviceRequest_builder) Build() *EnrollDeviceRequest {
+	m0 := &EnrollDeviceRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	if b.Init != nil {
+		x.Payload = &EnrollDeviceRequest_Init{b.Init}
+	}
+	if b.IosChallengeResponse != nil {
+		x.Payload = &EnrollDeviceRequest_IosChallengeResponse{b.IosChallengeResponse}
+	}
+	return m0
+}
+
+type case_EnrollDeviceRequest_Payload protoreflect.FieldNumber
+
+func (x case_EnrollDeviceRequest_Payload) String() string {
+	md := file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[2].Descriptor()
+	if x == 0 {
+		return "not set"
+	}
+	return protoimpl.X.MessageFieldStringOf(md, protoreflect.FieldNumber(x))
+}
+
+type isEnrollDeviceRequest_Payload interface {
+	isEnrollDeviceRequest_Payload()
+}
+
+type EnrollDeviceRequest_Init struct {
+	Init *EnrollDeviceInit `protobuf:"bytes,1,opt,name=init,proto3,oneof"`
+}
+
+type EnrollDeviceRequest_IosChallengeResponse struct {
+	IosChallengeResponse *IOSEnrollChallengeResponse `protobuf:"bytes,2,opt,name=ios_challenge_response,json=iosChallengeResponse,proto3,oneof"`
+}
+
+func (*EnrollDeviceRequest_Init) isEnrollDeviceRequest_Payload() {}
+
+func (*EnrollDeviceRequest_IosChallengeResponse) isEnrollDeviceRequest_Payload() {}
+
+// EnrollDeviceInit initiates the enrollment ceremony.
+type EnrollDeviceInit struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// Device enrollment token.
+	// See CreatePairedDeviceEnrollToken.
+	Token string `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`
+	// ID of the device credential.
+	CredentialId string `protobuf:"bytes,2,opt,name=credential_id,json=credentialId,proto3" json:"credential_id,omitempty"`
+	// Device collected data.
+	// Matched against the device registration information and any previously
+	// collected data.
+	DeviceData *v1.DeviceCollectedData `protobuf:"bytes,3,opt,name=device_data,json=deviceData,proto3" json:"device_data,omitempty"`
+	// Payload for data specific to iOS and iPadOS.
+	Ios           *IOSEnrollPayload `protobuf:"bytes,4,opt,name=ios,proto3" json:"ios,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EnrollDeviceInit) Reset() {
+	*x = EnrollDeviceInit{}
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnrollDeviceInit) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnrollDeviceInit) ProtoMessage() {}
+
+func (x *EnrollDeviceInit) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *EnrollDeviceInit) GetToken() string {
+	if x != nil {
+		return x.Token
+	}
+	return ""
+}
+
+func (x *EnrollDeviceInit) GetCredentialId() string {
+	if x != nil {
+		return x.CredentialId
+	}
+	return ""
+}
+
+func (x *EnrollDeviceInit) GetDeviceData() *v1.DeviceCollectedData {
+	if x != nil {
+		return x.DeviceData
+	}
+	return nil
+}
+
+func (x *EnrollDeviceInit) GetIos() *IOSEnrollPayload {
+	if x != nil {
+		return x.Ios
+	}
+	return nil
+}
+
+func (x *EnrollDeviceInit) SetToken(v string) {
+	x.Token = v
+}
+
+func (x *EnrollDeviceInit) SetCredentialId(v string) {
+	x.CredentialId = v
+}
+
+func (x *EnrollDeviceInit) SetDeviceData(v *v1.DeviceCollectedData) {
+	x.DeviceData = v
+}
+
+func (x *EnrollDeviceInit) SetIos(v *IOSEnrollPayload) {
+	x.Ios = v
+}
+
+func (x *EnrollDeviceInit) HasDeviceData() bool {
+	if x == nil {
+		return false
+	}
+	return x.DeviceData != nil
+}
+
+func (x *EnrollDeviceInit) HasIos() bool {
+	if x == nil {
+		return false
+	}
+	return x.Ios != nil
+}
+
+func (x *EnrollDeviceInit) ClearDeviceData() {
+	x.DeviceData = nil
+}
+
+func (x *EnrollDeviceInit) ClearIos() {
+	x.Ios = nil
+}
+
+type EnrollDeviceInit_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Device enrollment token.
+	// See CreatePairedDeviceEnrollToken.
+	Token string
+	// ID of the device credential.
+	CredentialId string
+	// Device collected data.
+	// Matched against the device registration information and any previously
+	// collected data.
+	DeviceData *v1.DeviceCollectedData
+	// Payload for data specific to iOS and iPadOS.
+	Ios *IOSEnrollPayload
+}
+
+func (b0 EnrollDeviceInit_builder) Build() *EnrollDeviceInit {
+	m0 := &EnrollDeviceInit{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Token = b.Token
+	x.CredentialId = b.CredentialId
+	x.DeviceData = b.DeviceData
+	x.Ios = b.Ios
+	return m0
+}
+
+// IOSEnrollPayload is the iOS- and iPadOS-specific enrollment payload.
+type IOSEnrollPayload struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// Device public key marshaled as a PKIX, ASN.1 DER.
+	PublicKeyDer  []byte `protobuf:"bytes,1,opt,name=public_key_der,json=publicKeyDer,proto3" json:"public_key_der,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IOSEnrollPayload) Reset() {
+	*x = IOSEnrollPayload{}
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IOSEnrollPayload) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IOSEnrollPayload) ProtoMessage() {}
+
+func (x *IOSEnrollPayload) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *IOSEnrollPayload) GetPublicKeyDer() []byte {
+	if x != nil {
+		return x.PublicKeyDer
+	}
+	return nil
+}
+
+func (x *IOSEnrollPayload) SetPublicKeyDer(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.PublicKeyDer = v
+}
+
+type IOSEnrollPayload_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Device public key marshaled as a PKIX, ASN.1 DER.
+	PublicKeyDer []byte
+}
+
+func (b0 IOSEnrollPayload_builder) Build() *IOSEnrollPayload {
+	m0 := &IOSEnrollPayload{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.PublicKeyDer = b.PublicKeyDer
+	return m0
+}
+
+// IOSEnrollChallengeResponse is an iOS and iPadOS enrollment challenge response.
+type IOSEnrollChallengeResponse struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// Signature over the challenge, using the device key.
+	Signature     []byte `protobuf:"bytes,1,opt,name=signature,proto3" json:"signature,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IOSEnrollChallengeResponse) Reset() {
+	*x = IOSEnrollChallengeResponse{}
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IOSEnrollChallengeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IOSEnrollChallengeResponse) ProtoMessage() {}
+
+func (x *IOSEnrollChallengeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *IOSEnrollChallengeResponse) GetSignature() []byte {
+	if x != nil {
+		return x.Signature
+	}
+	return nil
+}
+
+func (x *IOSEnrollChallengeResponse) SetSignature(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.Signature = v
+}
+
+type IOSEnrollChallengeResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Signature over the challenge, using the device key.
+	Signature []byte
+}
+
+func (b0 IOSEnrollChallengeResponse_builder) Build() *IOSEnrollChallengeResponse {
+	m0 := &IOSEnrollChallengeResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Signature = b.Signature
+	return m0
+}
+
+// Response for EnrollDevice.
+type EnrollDeviceResponse struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// Types that are valid to be assigned to Payload:
+	//
+	//	*EnrollDeviceResponse_Success
+	//	*EnrollDeviceResponse_IosChallenge
+	Payload       isEnrollDeviceResponse_Payload `protobuf_oneof:"payload"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EnrollDeviceResponse) Reset() {
+	*x = EnrollDeviceResponse{}
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnrollDeviceResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnrollDeviceResponse) ProtoMessage() {}
+
+func (x *EnrollDeviceResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *EnrollDeviceResponse) GetPayload() isEnrollDeviceResponse_Payload {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
+func (x *EnrollDeviceResponse) GetSuccess() *EnrollDeviceSuccess {
+	if x != nil {
+		if x, ok := x.Payload.(*EnrollDeviceResponse_Success); ok {
+			return x.Success
+		}
+	}
+	return nil
+}
+
+func (x *EnrollDeviceResponse) GetIosChallenge() *IOSEnrollChallenge {
+	if x != nil {
+		if x, ok := x.Payload.(*EnrollDeviceResponse_IosChallenge); ok {
+			return x.IosChallenge
+		}
+	}
+	return nil
+}
+
+func (x *EnrollDeviceResponse) SetSuccess(v *EnrollDeviceSuccess) {
+	if v == nil {
+		x.Payload = nil
+		return
+	}
+	x.Payload = &EnrollDeviceResponse_Success{v}
+}
+
+func (x *EnrollDeviceResponse) SetIosChallenge(v *IOSEnrollChallenge) {
+	if v == nil {
+		x.Payload = nil
+		return
+	}
+	x.Payload = &EnrollDeviceResponse_IosChallenge{v}
+}
+
+func (x *EnrollDeviceResponse) HasPayload() bool {
+	if x == nil {
+		return false
+	}
+	return x.Payload != nil
+}
+
+func (x *EnrollDeviceResponse) HasSuccess() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.Payload.(*EnrollDeviceResponse_Success)
+	return ok
+}
+
+func (x *EnrollDeviceResponse) HasIosChallenge() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.Payload.(*EnrollDeviceResponse_IosChallenge)
+	return ok
+}
+
+func (x *EnrollDeviceResponse) ClearPayload() {
+	x.Payload = nil
+}
+
+func (x *EnrollDeviceResponse) ClearSuccess() {
+	if _, ok := x.Payload.(*EnrollDeviceResponse_Success); ok {
+		x.Payload = nil
+	}
+}
+
+func (x *EnrollDeviceResponse) ClearIosChallenge() {
+	if _, ok := x.Payload.(*EnrollDeviceResponse_IosChallenge); ok {
+		x.Payload = nil
+	}
+}
+
+const EnrollDeviceResponse_Payload_not_set_case case_EnrollDeviceResponse_Payload = 0
+const EnrollDeviceResponse_Success_case case_EnrollDeviceResponse_Payload = 1
+const EnrollDeviceResponse_IosChallenge_case case_EnrollDeviceResponse_Payload = 2
+
+func (x *EnrollDeviceResponse) WhichPayload() case_EnrollDeviceResponse_Payload {
+	if x == nil {
+		return EnrollDeviceResponse_Payload_not_set_case
+	}
+	switch x.Payload.(type) {
+	case *EnrollDeviceResponse_Success:
+		return EnrollDeviceResponse_Success_case
+	case *EnrollDeviceResponse_IosChallenge:
+		return EnrollDeviceResponse_IosChallenge_case
+	default:
+		return EnrollDeviceResponse_Payload_not_set_case
+	}
+}
+
+type EnrollDeviceResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Fields of oneof Payload:
+	Success      *EnrollDeviceSuccess
+	IosChallenge *IOSEnrollChallenge
+	// -- end of Payload
+}
+
+func (b0 EnrollDeviceResponse_builder) Build() *EnrollDeviceResponse {
+	m0 := &EnrollDeviceResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	if b.Success != nil {
+		x.Payload = &EnrollDeviceResponse_Success{b.Success}
+	}
+	if b.IosChallenge != nil {
+		x.Payload = &EnrollDeviceResponse_IosChallenge{b.IosChallenge}
+	}
+	return m0
+}
+
+type case_EnrollDeviceResponse_Payload protoreflect.FieldNumber
+
+func (x case_EnrollDeviceResponse_Payload) String() string {
+	md := file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[6].Descriptor()
+	if x == 0 {
+		return "not set"
+	}
+	return protoimpl.X.MessageFieldStringOf(md, protoreflect.FieldNumber(x))
+}
+
+type isEnrollDeviceResponse_Payload interface {
+	isEnrollDeviceResponse_Payload()
+}
+
+type EnrollDeviceResponse_Success struct {
+	Success *EnrollDeviceSuccess `protobuf:"bytes,1,opt,name=success,proto3,oneof"`
+}
+
+type EnrollDeviceResponse_IosChallenge struct {
+	IosChallenge *IOSEnrollChallenge `protobuf:"bytes,2,opt,name=ios_challenge,json=iosChallenge,proto3,oneof"`
+}
+
+func (*EnrollDeviceResponse_Success) isEnrollDeviceResponse_Payload() {}
+
+func (*EnrollDeviceResponse_IosChallenge) isEnrollDeviceResponse_Payload() {}
+
+// EnrollDeviceSuccess marks a successful device enrollment ceremony.
+type EnrollDeviceSuccess struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The enrolled device.
+	Device        *v1.Device `protobuf:"bytes,1,opt,name=device,proto3" json:"device,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EnrollDeviceSuccess) Reset() {
+	*x = EnrollDeviceSuccess{}
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnrollDeviceSuccess) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnrollDeviceSuccess) ProtoMessage() {}
+
+func (x *EnrollDeviceSuccess) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *EnrollDeviceSuccess) GetDevice() *v1.Device {
+	if x != nil {
+		return x.Device
+	}
+	return nil
+}
+
+func (x *EnrollDeviceSuccess) SetDevice(v *v1.Device) {
+	x.Device = v
+}
+
+func (x *EnrollDeviceSuccess) HasDevice() bool {
+	if x == nil {
+		return false
+	}
+	return x.Device != nil
+}
+
+func (x *EnrollDeviceSuccess) ClearDevice() {
+	x.Device = nil
+}
+
+type EnrollDeviceSuccess_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The enrolled device.
+	Device *v1.Device
+}
+
+func (b0 EnrollDeviceSuccess_builder) Build() *EnrollDeviceSuccess {
+	m0 := &EnrollDeviceSuccess{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Device = b.Device
+	return m0
+}
+
+// IOSEnrollChallenge is a iOS and iPadOS enrollment challenge.
+type IOSEnrollChallenge struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// Randomly-generated, opaque challenge to be signed using the device key.
+	Challenge     []byte `protobuf:"bytes,1,opt,name=challenge,proto3" json:"challenge,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IOSEnrollChallenge) Reset() {
+	*x = IOSEnrollChallenge{}
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IOSEnrollChallenge) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IOSEnrollChallenge) ProtoMessage() {}
+
+func (x *IOSEnrollChallenge) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *IOSEnrollChallenge) GetChallenge() []byte {
+	if x != nil {
+		return x.Challenge
+	}
+	return nil
+}
+
+func (x *IOSEnrollChallenge) SetChallenge(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.Challenge = v
+}
+
+type IOSEnrollChallenge_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Randomly-generated, opaque challenge to be signed using the device key.
+	Challenge []byte
+}
+
+func (b0 IOSEnrollChallenge_builder) Build() *IOSEnrollChallenge {
+	m0 := &IOSEnrollChallenge{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Challenge = b.Challenge
+	return m0
+}
+
 var File_teleport_devicetrust_public_v1_devicetrust_service_proto protoreflect.FileDescriptor
 
 const file_teleport_devicetrust_public_v1_devicetrust_service_proto_rawDesc = "" +
 	"\n" +
-	"8teleport/devicetrust/public/v1/devicetrust_service.proto\x12\x1eteleport.devicetrust.public.v1\x1a3teleport/devicetrust/v1/device_collected_data.proto\x1a1teleport/devicetrust/v1/device_enroll_token.proto\"\xa7\x01\n" +
+	"8teleport/devicetrust/public/v1/devicetrust_service.proto\x12\x1eteleport.devicetrust.public.v1\x1a$teleport/devicetrust/v1/device.proto\x1a3teleport/devicetrust/v1/device_collected_data.proto\x1a1teleport/devicetrust/v1/device_enroll_token.proto\"\xa7\x01\n" +
 	"$CreatePairedDeviceEnrollTokenRequest\x120\n" +
 	"\x14enroll_pairing_token\x18\x01 \x01(\tR\x12enrollPairingToken\x12M\n" +
 	"\vdevice_data\x18\x02 \x01(\v2,.teleport.devicetrust.v1.DeviceCollectedDataR\n" +
 	"deviceData\"\x83\x01\n" +
 	"%CreatePairedDeviceEnrollTokenResponse\x12Z\n" +
-	"\x13device_enroll_token\x18\x01 \x01(\v2*.teleport.devicetrust.v1.DeviceEnrollTokenR\x11deviceEnrollToken2\xc3\x01\n" +
+	"\x13device_enroll_token\x18\x01 \x01(\v2*.teleport.devicetrust.v1.DeviceEnrollTokenR\x11deviceEnrollToken\"\xdc\x01\n" +
+	"\x13EnrollDeviceRequest\x12F\n" +
+	"\x04init\x18\x01 \x01(\v20.teleport.devicetrust.public.v1.EnrollDeviceInitH\x00R\x04init\x12r\n" +
+	"\x16ios_challenge_response\x18\x02 \x01(\v2:.teleport.devicetrust.public.v1.IOSEnrollChallengeResponseH\x00R\x14iosChallengeResponseB\t\n" +
+	"\apayload\"\xe0\x01\n" +
+	"\x10EnrollDeviceInit\x12\x14\n" +
+	"\x05token\x18\x01 \x01(\tR\x05token\x12#\n" +
+	"\rcredential_id\x18\x02 \x01(\tR\fcredentialId\x12M\n" +
+	"\vdevice_data\x18\x03 \x01(\v2,.teleport.devicetrust.v1.DeviceCollectedDataR\n" +
+	"deviceData\x12B\n" +
+	"\x03ios\x18\x04 \x01(\v20.teleport.devicetrust.public.v1.IOSEnrollPayloadR\x03ios\"8\n" +
+	"\x10IOSEnrollPayload\x12$\n" +
+	"\x0epublic_key_der\x18\x01 \x01(\fR\fpublicKeyDer\":\n" +
+	"\x1aIOSEnrollChallengeResponse\x12\x1c\n" +
+	"\tsignature\x18\x01 \x01(\fR\tsignature\"\xcd\x01\n" +
+	"\x14EnrollDeviceResponse\x12O\n" +
+	"\asuccess\x18\x01 \x01(\v23.teleport.devicetrust.public.v1.EnrollDeviceSuccessH\x00R\asuccess\x12Y\n" +
+	"\rios_challenge\x18\x02 \x01(\v22.teleport.devicetrust.public.v1.IOSEnrollChallengeH\x00R\fiosChallengeB\t\n" +
+	"\apayload\"N\n" +
+	"\x13EnrollDeviceSuccess\x127\n" +
+	"\x06device\x18\x01 \x01(\v2\x1f.teleport.devicetrust.v1.DeviceR\x06device\"2\n" +
+	"\x12IOSEnrollChallenge\x12\x1c\n" +
+	"\tchallenge\x18\x01 \x01(\fR\tchallenge2\xc2\x02\n" +
 	"\x12DeviceTrustService\x12\xac\x01\n" +
-	"\x1dCreatePairedDeviceEnrollToken\x12D.teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenRequest\x1aE.teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenResponseBgZegithub.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/public/v1;devicetrustpublicv1b\x06proto3"
+	"\x1dCreatePairedDeviceEnrollToken\x12D.teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenRequest\x1aE.teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenResponse\x12}\n" +
+	"\fEnrollDevice\x123.teleport.devicetrust.public.v1.EnrollDeviceRequest\x1a4.teleport.devicetrust.public.v1.EnrollDeviceResponse(\x010\x01BgZegithub.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/public/v1;devicetrustpublicv1b\x06proto3"
 
-var file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_teleport_devicetrust_public_v1_devicetrust_service_proto_goTypes = []any{
 	(*CreatePairedDeviceEnrollTokenRequest)(nil),  // 0: teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenRequest
 	(*CreatePairedDeviceEnrollTokenResponse)(nil), // 1: teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenResponse
-	(*v1.DeviceCollectedData)(nil),                // 2: teleport.devicetrust.v1.DeviceCollectedData
-	(*v1.DeviceEnrollToken)(nil),                  // 3: teleport.devicetrust.v1.DeviceEnrollToken
+	(*EnrollDeviceRequest)(nil),                   // 2: teleport.devicetrust.public.v1.EnrollDeviceRequest
+	(*EnrollDeviceInit)(nil),                      // 3: teleport.devicetrust.public.v1.EnrollDeviceInit
+	(*IOSEnrollPayload)(nil),                      // 4: teleport.devicetrust.public.v1.IOSEnrollPayload
+	(*IOSEnrollChallengeResponse)(nil),            // 5: teleport.devicetrust.public.v1.IOSEnrollChallengeResponse
+	(*EnrollDeviceResponse)(nil),                  // 6: teleport.devicetrust.public.v1.EnrollDeviceResponse
+	(*EnrollDeviceSuccess)(nil),                   // 7: teleport.devicetrust.public.v1.EnrollDeviceSuccess
+	(*IOSEnrollChallenge)(nil),                    // 8: teleport.devicetrust.public.v1.IOSEnrollChallenge
+	(*v1.DeviceCollectedData)(nil),                // 9: teleport.devicetrust.v1.DeviceCollectedData
+	(*v1.DeviceEnrollToken)(nil),                  // 10: teleport.devicetrust.v1.DeviceEnrollToken
+	(*v1.Device)(nil),                             // 11: teleport.devicetrust.v1.Device
 }
 var file_teleport_devicetrust_public_v1_devicetrust_service_proto_depIdxs = []int32{
-	2, // 0: teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenRequest.device_data:type_name -> teleport.devicetrust.v1.DeviceCollectedData
-	3, // 1: teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenResponse.device_enroll_token:type_name -> teleport.devicetrust.v1.DeviceEnrollToken
-	0, // 2: teleport.devicetrust.public.v1.DeviceTrustService.CreatePairedDeviceEnrollToken:input_type -> teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenRequest
-	1, // 3: teleport.devicetrust.public.v1.DeviceTrustService.CreatePairedDeviceEnrollToken:output_type -> teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenResponse
-	3, // [3:4] is the sub-list for method output_type
-	2, // [2:3] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	9,  // 0: teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenRequest.device_data:type_name -> teleport.devicetrust.v1.DeviceCollectedData
+	10, // 1: teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenResponse.device_enroll_token:type_name -> teleport.devicetrust.v1.DeviceEnrollToken
+	3,  // 2: teleport.devicetrust.public.v1.EnrollDeviceRequest.init:type_name -> teleport.devicetrust.public.v1.EnrollDeviceInit
+	5,  // 3: teleport.devicetrust.public.v1.EnrollDeviceRequest.ios_challenge_response:type_name -> teleport.devicetrust.public.v1.IOSEnrollChallengeResponse
+	9,  // 4: teleport.devicetrust.public.v1.EnrollDeviceInit.device_data:type_name -> teleport.devicetrust.v1.DeviceCollectedData
+	4,  // 5: teleport.devicetrust.public.v1.EnrollDeviceInit.ios:type_name -> teleport.devicetrust.public.v1.IOSEnrollPayload
+	7,  // 6: teleport.devicetrust.public.v1.EnrollDeviceResponse.success:type_name -> teleport.devicetrust.public.v1.EnrollDeviceSuccess
+	8,  // 7: teleport.devicetrust.public.v1.EnrollDeviceResponse.ios_challenge:type_name -> teleport.devicetrust.public.v1.IOSEnrollChallenge
+	11, // 8: teleport.devicetrust.public.v1.EnrollDeviceSuccess.device:type_name -> teleport.devicetrust.v1.Device
+	0,  // 9: teleport.devicetrust.public.v1.DeviceTrustService.CreatePairedDeviceEnrollToken:input_type -> teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenRequest
+	2,  // 10: teleport.devicetrust.public.v1.DeviceTrustService.EnrollDevice:input_type -> teleport.devicetrust.public.v1.EnrollDeviceRequest
+	1,  // 11: teleport.devicetrust.public.v1.DeviceTrustService.CreatePairedDeviceEnrollToken:output_type -> teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenResponse
+	6,  // 12: teleport.devicetrust.public.v1.DeviceTrustService.EnrollDevice:output_type -> teleport.devicetrust.public.v1.EnrollDeviceResponse
+	11, // [11:13] is the sub-list for method output_type
+	9,  // [9:11] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_teleport_devicetrust_public_v1_devicetrust_service_proto_init() }
@@ -233,13 +1035,21 @@ func file_teleport_devicetrust_public_v1_devicetrust_service_proto_init() {
 	if File_teleport_devicetrust_public_v1_devicetrust_service_proto != nil {
 		return
 	}
+	file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[2].OneofWrappers = []any{
+		(*EnrollDeviceRequest_Init)(nil),
+		(*EnrollDeviceRequest_IosChallengeResponse)(nil),
+	}
+	file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[6].OneofWrappers = []any{
+		(*EnrollDeviceResponse_Success)(nil),
+		(*EnrollDeviceResponse_IosChallenge)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_devicetrust_public_v1_devicetrust_service_proto_rawDesc), len(file_teleport_devicetrust_public_v1_devicetrust_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/devicetrust/public/v1/devicetrust_service_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/devicetrust/public/v1/devicetrust_service_protohybrid.pb.go
@@ -391,7 +391,13 @@ type EnrollDeviceInit struct {
 	// collected data.
 	DeviceData *v1.DeviceCollectedData `protobuf:"bytes,3,opt,name=device_data,json=deviceData,proto3" json:"device_data,omitempty"`
 	// Payload for data specific to iOS and iPadOS.
-	Ios           *IOSEnrollPayload `protobuf:"bytes,4,opt,name=ios,proto3" json:"ios,omitempty"`
+	Ios *IOSEnrollPayload `protobuf:"bytes,4,opt,name=ios,proto3" json:"ios,omitempty"`
+	// User that owns the device being enrolled.
+	//
+	// Temporary: ownership should be derived from the enrollment token issued by
+	// CreatePairedDeviceEnrollToken, not supplied by the client. This field lets
+	// the ceremony assign an owner until the token carries the user.
+	User          string `protobuf:"bytes,5,opt,name=user,proto3" json:"user,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -449,6 +455,13 @@ func (x *EnrollDeviceInit) GetIos() *IOSEnrollPayload {
 	return nil
 }
 
+func (x *EnrollDeviceInit) GetUser() string {
+	if x != nil {
+		return x.User
+	}
+	return ""
+}
+
 func (x *EnrollDeviceInit) SetToken(v string) {
 	x.Token = v
 }
@@ -463,6 +476,10 @@ func (x *EnrollDeviceInit) SetDeviceData(v *v1.DeviceCollectedData) {
 
 func (x *EnrollDeviceInit) SetIos(v *IOSEnrollPayload) {
 	x.Ios = v
+}
+
+func (x *EnrollDeviceInit) SetUser(v string) {
+	x.User = v
 }
 
 func (x *EnrollDeviceInit) HasDeviceData() bool {
@@ -501,6 +518,12 @@ type EnrollDeviceInit_builder struct {
 	DeviceData *v1.DeviceCollectedData
 	// Payload for data specific to iOS and iPadOS.
 	Ios *IOSEnrollPayload
+	// User that owns the device being enrolled.
+	//
+	// Temporary: ownership should be derived from the enrollment token issued by
+	// CreatePairedDeviceEnrollToken, not supplied by the client. This field lets
+	// the ceremony assign an owner until the token carries the user.
+	User string
 }
 
 func (b0 EnrollDeviceInit_builder) Build() *EnrollDeviceInit {
@@ -511,6 +534,7 @@ func (b0 EnrollDeviceInit_builder) Build() *EnrollDeviceInit {
 	x.CredentialId = b.CredentialId
 	x.DeviceData = b.DeviceData
 	x.Ios = b.Ios
+	x.User = b.User
 	return m0
 }
 
@@ -971,13 +995,14 @@ const file_teleport_devicetrust_public_v1_devicetrust_service_proto_rawDesc = ""
 	"\x13EnrollDeviceRequest\x12F\n" +
 	"\x04init\x18\x01 \x01(\v20.teleport.devicetrust.public.v1.EnrollDeviceInitH\x00R\x04init\x12r\n" +
 	"\x16ios_challenge_response\x18\x02 \x01(\v2:.teleport.devicetrust.public.v1.IOSEnrollChallengeResponseH\x00R\x14iosChallengeResponseB\t\n" +
-	"\apayload\"\xe0\x01\n" +
+	"\apayload\"\xf4\x01\n" +
 	"\x10EnrollDeviceInit\x12\x14\n" +
 	"\x05token\x18\x01 \x01(\tR\x05token\x12#\n" +
 	"\rcredential_id\x18\x02 \x01(\tR\fcredentialId\x12M\n" +
 	"\vdevice_data\x18\x03 \x01(\v2,.teleport.devicetrust.v1.DeviceCollectedDataR\n" +
 	"deviceData\x12B\n" +
-	"\x03ios\x18\x04 \x01(\v20.teleport.devicetrust.public.v1.IOSEnrollPayloadR\x03ios\"8\n" +
+	"\x03ios\x18\x04 \x01(\v20.teleport.devicetrust.public.v1.IOSEnrollPayloadR\x03ios\x12\x12\n" +
+	"\x04user\x18\x05 \x01(\tR\x04user\"8\n" +
 	"\x10IOSEnrollPayload\x12$\n" +
 	"\x0epublic_key_der\x18\x01 \x01(\fR\fpublicKeyDer\":\n" +
 	"\x1aIOSEnrollChallengeResponse\x12\x1c\n" +

--- a/api/gen/proto/go/teleport/devicetrust/public/v1/devicetrust_service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/devicetrust/public/v1/devicetrust_service_protoopaque.pb.go
@@ -371,6 +371,7 @@ type EnrollDeviceInit struct {
 	xxx_hidden_CredentialId string                  `protobuf:"bytes,2,opt,name=credential_id,json=credentialId,proto3"`
 	xxx_hidden_DeviceData   *v1.DeviceCollectedData `protobuf:"bytes,3,opt,name=device_data,json=deviceData,proto3"`
 	xxx_hidden_Ios          *IOSEnrollPayload       `protobuf:"bytes,4,opt,name=ios,proto3"`
+	xxx_hidden_User         string                  `protobuf:"bytes,5,opt,name=user,proto3"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }
@@ -428,6 +429,13 @@ func (x *EnrollDeviceInit) GetIos() *IOSEnrollPayload {
 	return nil
 }
 
+func (x *EnrollDeviceInit) GetUser() string {
+	if x != nil {
+		return x.xxx_hidden_User
+	}
+	return ""
+}
+
 func (x *EnrollDeviceInit) SetToken(v string) {
 	x.xxx_hidden_Token = v
 }
@@ -442,6 +450,10 @@ func (x *EnrollDeviceInit) SetDeviceData(v *v1.DeviceCollectedData) {
 
 func (x *EnrollDeviceInit) SetIos(v *IOSEnrollPayload) {
 	x.xxx_hidden_Ios = v
+}
+
+func (x *EnrollDeviceInit) SetUser(v string) {
+	x.xxx_hidden_User = v
 }
 
 func (x *EnrollDeviceInit) HasDeviceData() bool {
@@ -480,6 +492,12 @@ type EnrollDeviceInit_builder struct {
 	DeviceData *v1.DeviceCollectedData
 	// Payload for data specific to iOS and iPadOS.
 	Ios *IOSEnrollPayload
+	// User that owns the device being enrolled.
+	//
+	// Temporary: ownership should be derived from the enrollment token issued by
+	// CreatePairedDeviceEnrollToken, not supplied by the client. This field lets
+	// the ceremony assign an owner until the token carries the user.
+	User string
 }
 
 func (b0 EnrollDeviceInit_builder) Build() *EnrollDeviceInit {
@@ -490,6 +508,7 @@ func (b0 EnrollDeviceInit_builder) Build() *EnrollDeviceInit {
 	x.xxx_hidden_CredentialId = b.CredentialId
 	x.xxx_hidden_DeviceData = b.DeviceData
 	x.xxx_hidden_Ios = b.Ios
+	x.xxx_hidden_User = b.User
 	return m0
 }
 
@@ -935,13 +954,14 @@ const file_teleport_devicetrust_public_v1_devicetrust_service_proto_rawDesc = ""
 	"\x13EnrollDeviceRequest\x12F\n" +
 	"\x04init\x18\x01 \x01(\v20.teleport.devicetrust.public.v1.EnrollDeviceInitH\x00R\x04init\x12r\n" +
 	"\x16ios_challenge_response\x18\x02 \x01(\v2:.teleport.devicetrust.public.v1.IOSEnrollChallengeResponseH\x00R\x14iosChallengeResponseB\t\n" +
-	"\apayload\"\xe0\x01\n" +
+	"\apayload\"\xf4\x01\n" +
 	"\x10EnrollDeviceInit\x12\x14\n" +
 	"\x05token\x18\x01 \x01(\tR\x05token\x12#\n" +
 	"\rcredential_id\x18\x02 \x01(\tR\fcredentialId\x12M\n" +
 	"\vdevice_data\x18\x03 \x01(\v2,.teleport.devicetrust.v1.DeviceCollectedDataR\n" +
 	"deviceData\x12B\n" +
-	"\x03ios\x18\x04 \x01(\v20.teleport.devicetrust.public.v1.IOSEnrollPayloadR\x03ios\"8\n" +
+	"\x03ios\x18\x04 \x01(\v20.teleport.devicetrust.public.v1.IOSEnrollPayloadR\x03ios\x12\x12\n" +
+	"\x04user\x18\x05 \x01(\tR\x04user\"8\n" +
 	"\x10IOSEnrollPayload\x12$\n" +
 	"\x0epublic_key_der\x18\x01 \x01(\fR\fpublicKeyDer\":\n" +
 	"\x1aIOSEnrollChallengeResponse\x12\x1c\n" +

--- a/api/gen/proto/go/teleport/devicetrust/public/v1/devicetrust_service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/devicetrust/public/v1/devicetrust_service_protoopaque.pb.go
@@ -192,37 +192,806 @@ func (b0 CreatePairedDeviceEnrollTokenResponse_builder) Build() *CreatePairedDev
 	return m0
 }
 
+// Request for EnrollDevice.
+type EnrollDeviceRequest struct {
+	state              protoimpl.MessageState        `protogen:"opaque.v1"`
+	xxx_hidden_Payload isEnrollDeviceRequest_Payload `protobuf_oneof:"payload"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *EnrollDeviceRequest) Reset() {
+	*x = EnrollDeviceRequest{}
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnrollDeviceRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnrollDeviceRequest) ProtoMessage() {}
+
+func (x *EnrollDeviceRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *EnrollDeviceRequest) GetInit() *EnrollDeviceInit {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Payload.(*enrollDeviceRequest_Init); ok {
+			return x.Init
+		}
+	}
+	return nil
+}
+
+func (x *EnrollDeviceRequest) GetIosChallengeResponse() *IOSEnrollChallengeResponse {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Payload.(*enrollDeviceRequest_IosChallengeResponse); ok {
+			return x.IosChallengeResponse
+		}
+	}
+	return nil
+}
+
+func (x *EnrollDeviceRequest) SetInit(v *EnrollDeviceInit) {
+	if v == nil {
+		x.xxx_hidden_Payload = nil
+		return
+	}
+	x.xxx_hidden_Payload = &enrollDeviceRequest_Init{v}
+}
+
+func (x *EnrollDeviceRequest) SetIosChallengeResponse(v *IOSEnrollChallengeResponse) {
+	if v == nil {
+		x.xxx_hidden_Payload = nil
+		return
+	}
+	x.xxx_hidden_Payload = &enrollDeviceRequest_IosChallengeResponse{v}
+}
+
+func (x *EnrollDeviceRequest) HasPayload() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Payload != nil
+}
+
+func (x *EnrollDeviceRequest) HasInit() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Payload.(*enrollDeviceRequest_Init)
+	return ok
+}
+
+func (x *EnrollDeviceRequest) HasIosChallengeResponse() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Payload.(*enrollDeviceRequest_IosChallengeResponse)
+	return ok
+}
+
+func (x *EnrollDeviceRequest) ClearPayload() {
+	x.xxx_hidden_Payload = nil
+}
+
+func (x *EnrollDeviceRequest) ClearInit() {
+	if _, ok := x.xxx_hidden_Payload.(*enrollDeviceRequest_Init); ok {
+		x.xxx_hidden_Payload = nil
+	}
+}
+
+func (x *EnrollDeviceRequest) ClearIosChallengeResponse() {
+	if _, ok := x.xxx_hidden_Payload.(*enrollDeviceRequest_IosChallengeResponse); ok {
+		x.xxx_hidden_Payload = nil
+	}
+}
+
+const EnrollDeviceRequest_Payload_not_set_case case_EnrollDeviceRequest_Payload = 0
+const EnrollDeviceRequest_Init_case case_EnrollDeviceRequest_Payload = 1
+const EnrollDeviceRequest_IosChallengeResponse_case case_EnrollDeviceRequest_Payload = 2
+
+func (x *EnrollDeviceRequest) WhichPayload() case_EnrollDeviceRequest_Payload {
+	if x == nil {
+		return EnrollDeviceRequest_Payload_not_set_case
+	}
+	switch x.xxx_hidden_Payload.(type) {
+	case *enrollDeviceRequest_Init:
+		return EnrollDeviceRequest_Init_case
+	case *enrollDeviceRequest_IosChallengeResponse:
+		return EnrollDeviceRequest_IosChallengeResponse_case
+	default:
+		return EnrollDeviceRequest_Payload_not_set_case
+	}
+}
+
+type EnrollDeviceRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Fields of oneof xxx_hidden_Payload:
+	Init                 *EnrollDeviceInit
+	IosChallengeResponse *IOSEnrollChallengeResponse
+	// -- end of xxx_hidden_Payload
+}
+
+func (b0 EnrollDeviceRequest_builder) Build() *EnrollDeviceRequest {
+	m0 := &EnrollDeviceRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	if b.Init != nil {
+		x.xxx_hidden_Payload = &enrollDeviceRequest_Init{b.Init}
+	}
+	if b.IosChallengeResponse != nil {
+		x.xxx_hidden_Payload = &enrollDeviceRequest_IosChallengeResponse{b.IosChallengeResponse}
+	}
+	return m0
+}
+
+type case_EnrollDeviceRequest_Payload protoreflect.FieldNumber
+
+func (x case_EnrollDeviceRequest_Payload) String() string {
+	md := file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[2].Descriptor()
+	if x == 0 {
+		return "not set"
+	}
+	return protoimpl.X.MessageFieldStringOf(md, protoreflect.FieldNumber(x))
+}
+
+type isEnrollDeviceRequest_Payload interface {
+	isEnrollDeviceRequest_Payload()
+}
+
+type enrollDeviceRequest_Init struct {
+	Init *EnrollDeviceInit `protobuf:"bytes,1,opt,name=init,proto3,oneof"`
+}
+
+type enrollDeviceRequest_IosChallengeResponse struct {
+	IosChallengeResponse *IOSEnrollChallengeResponse `protobuf:"bytes,2,opt,name=ios_challenge_response,json=iosChallengeResponse,proto3,oneof"`
+}
+
+func (*enrollDeviceRequest_Init) isEnrollDeviceRequest_Payload() {}
+
+func (*enrollDeviceRequest_IosChallengeResponse) isEnrollDeviceRequest_Payload() {}
+
+// EnrollDeviceInit initiates the enrollment ceremony.
+type EnrollDeviceInit struct {
+	state                   protoimpl.MessageState  `protogen:"opaque.v1"`
+	xxx_hidden_Token        string                  `protobuf:"bytes,1,opt,name=token,proto3"`
+	xxx_hidden_CredentialId string                  `protobuf:"bytes,2,opt,name=credential_id,json=credentialId,proto3"`
+	xxx_hidden_DeviceData   *v1.DeviceCollectedData `protobuf:"bytes,3,opt,name=device_data,json=deviceData,proto3"`
+	xxx_hidden_Ios          *IOSEnrollPayload       `protobuf:"bytes,4,opt,name=ios,proto3"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
+}
+
+func (x *EnrollDeviceInit) Reset() {
+	*x = EnrollDeviceInit{}
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnrollDeviceInit) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnrollDeviceInit) ProtoMessage() {}
+
+func (x *EnrollDeviceInit) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *EnrollDeviceInit) GetToken() string {
+	if x != nil {
+		return x.xxx_hidden_Token
+	}
+	return ""
+}
+
+func (x *EnrollDeviceInit) GetCredentialId() string {
+	if x != nil {
+		return x.xxx_hidden_CredentialId
+	}
+	return ""
+}
+
+func (x *EnrollDeviceInit) GetDeviceData() *v1.DeviceCollectedData {
+	if x != nil {
+		return x.xxx_hidden_DeviceData
+	}
+	return nil
+}
+
+func (x *EnrollDeviceInit) GetIos() *IOSEnrollPayload {
+	if x != nil {
+		return x.xxx_hidden_Ios
+	}
+	return nil
+}
+
+func (x *EnrollDeviceInit) SetToken(v string) {
+	x.xxx_hidden_Token = v
+}
+
+func (x *EnrollDeviceInit) SetCredentialId(v string) {
+	x.xxx_hidden_CredentialId = v
+}
+
+func (x *EnrollDeviceInit) SetDeviceData(v *v1.DeviceCollectedData) {
+	x.xxx_hidden_DeviceData = v
+}
+
+func (x *EnrollDeviceInit) SetIos(v *IOSEnrollPayload) {
+	x.xxx_hidden_Ios = v
+}
+
+func (x *EnrollDeviceInit) HasDeviceData() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_DeviceData != nil
+}
+
+func (x *EnrollDeviceInit) HasIos() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Ios != nil
+}
+
+func (x *EnrollDeviceInit) ClearDeviceData() {
+	x.xxx_hidden_DeviceData = nil
+}
+
+func (x *EnrollDeviceInit) ClearIos() {
+	x.xxx_hidden_Ios = nil
+}
+
+type EnrollDeviceInit_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Device enrollment token.
+	// See CreatePairedDeviceEnrollToken.
+	Token string
+	// ID of the device credential.
+	CredentialId string
+	// Device collected data.
+	// Matched against the device registration information and any previously
+	// collected data.
+	DeviceData *v1.DeviceCollectedData
+	// Payload for data specific to iOS and iPadOS.
+	Ios *IOSEnrollPayload
+}
+
+func (b0 EnrollDeviceInit_builder) Build() *EnrollDeviceInit {
+	m0 := &EnrollDeviceInit{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Token = b.Token
+	x.xxx_hidden_CredentialId = b.CredentialId
+	x.xxx_hidden_DeviceData = b.DeviceData
+	x.xxx_hidden_Ios = b.Ios
+	return m0
+}
+
+// IOSEnrollPayload is the iOS- and iPadOS-specific enrollment payload.
+type IOSEnrollPayload struct {
+	state                   protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_PublicKeyDer []byte                 `protobuf:"bytes,1,opt,name=public_key_der,json=publicKeyDer,proto3"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
+}
+
+func (x *IOSEnrollPayload) Reset() {
+	*x = IOSEnrollPayload{}
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IOSEnrollPayload) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IOSEnrollPayload) ProtoMessage() {}
+
+func (x *IOSEnrollPayload) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *IOSEnrollPayload) GetPublicKeyDer() []byte {
+	if x != nil {
+		return x.xxx_hidden_PublicKeyDer
+	}
+	return nil
+}
+
+func (x *IOSEnrollPayload) SetPublicKeyDer(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.xxx_hidden_PublicKeyDer = v
+}
+
+type IOSEnrollPayload_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Device public key marshaled as a PKIX, ASN.1 DER.
+	PublicKeyDer []byte
+}
+
+func (b0 IOSEnrollPayload_builder) Build() *IOSEnrollPayload {
+	m0 := &IOSEnrollPayload{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_PublicKeyDer = b.PublicKeyDer
+	return m0
+}
+
+// IOSEnrollChallengeResponse is an iOS and iPadOS enrollment challenge response.
+type IOSEnrollChallengeResponse struct {
+	state                protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Signature []byte                 `protobuf:"bytes,1,opt,name=signature,proto3"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *IOSEnrollChallengeResponse) Reset() {
+	*x = IOSEnrollChallengeResponse{}
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IOSEnrollChallengeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IOSEnrollChallengeResponse) ProtoMessage() {}
+
+func (x *IOSEnrollChallengeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *IOSEnrollChallengeResponse) GetSignature() []byte {
+	if x != nil {
+		return x.xxx_hidden_Signature
+	}
+	return nil
+}
+
+func (x *IOSEnrollChallengeResponse) SetSignature(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.xxx_hidden_Signature = v
+}
+
+type IOSEnrollChallengeResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Signature over the challenge, using the device key.
+	Signature []byte
+}
+
+func (b0 IOSEnrollChallengeResponse_builder) Build() *IOSEnrollChallengeResponse {
+	m0 := &IOSEnrollChallengeResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Signature = b.Signature
+	return m0
+}
+
+// Response for EnrollDevice.
+type EnrollDeviceResponse struct {
+	state              protoimpl.MessageState         `protogen:"opaque.v1"`
+	xxx_hidden_Payload isEnrollDeviceResponse_Payload `protobuf_oneof:"payload"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *EnrollDeviceResponse) Reset() {
+	*x = EnrollDeviceResponse{}
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnrollDeviceResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnrollDeviceResponse) ProtoMessage() {}
+
+func (x *EnrollDeviceResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *EnrollDeviceResponse) GetSuccess() *EnrollDeviceSuccess {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Payload.(*enrollDeviceResponse_Success); ok {
+			return x.Success
+		}
+	}
+	return nil
+}
+
+func (x *EnrollDeviceResponse) GetIosChallenge() *IOSEnrollChallenge {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Payload.(*enrollDeviceResponse_IosChallenge); ok {
+			return x.IosChallenge
+		}
+	}
+	return nil
+}
+
+func (x *EnrollDeviceResponse) SetSuccess(v *EnrollDeviceSuccess) {
+	if v == nil {
+		x.xxx_hidden_Payload = nil
+		return
+	}
+	x.xxx_hidden_Payload = &enrollDeviceResponse_Success{v}
+}
+
+func (x *EnrollDeviceResponse) SetIosChallenge(v *IOSEnrollChallenge) {
+	if v == nil {
+		x.xxx_hidden_Payload = nil
+		return
+	}
+	x.xxx_hidden_Payload = &enrollDeviceResponse_IosChallenge{v}
+}
+
+func (x *EnrollDeviceResponse) HasPayload() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Payload != nil
+}
+
+func (x *EnrollDeviceResponse) HasSuccess() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Payload.(*enrollDeviceResponse_Success)
+	return ok
+}
+
+func (x *EnrollDeviceResponse) HasIosChallenge() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Payload.(*enrollDeviceResponse_IosChallenge)
+	return ok
+}
+
+func (x *EnrollDeviceResponse) ClearPayload() {
+	x.xxx_hidden_Payload = nil
+}
+
+func (x *EnrollDeviceResponse) ClearSuccess() {
+	if _, ok := x.xxx_hidden_Payload.(*enrollDeviceResponse_Success); ok {
+		x.xxx_hidden_Payload = nil
+	}
+}
+
+func (x *EnrollDeviceResponse) ClearIosChallenge() {
+	if _, ok := x.xxx_hidden_Payload.(*enrollDeviceResponse_IosChallenge); ok {
+		x.xxx_hidden_Payload = nil
+	}
+}
+
+const EnrollDeviceResponse_Payload_not_set_case case_EnrollDeviceResponse_Payload = 0
+const EnrollDeviceResponse_Success_case case_EnrollDeviceResponse_Payload = 1
+const EnrollDeviceResponse_IosChallenge_case case_EnrollDeviceResponse_Payload = 2
+
+func (x *EnrollDeviceResponse) WhichPayload() case_EnrollDeviceResponse_Payload {
+	if x == nil {
+		return EnrollDeviceResponse_Payload_not_set_case
+	}
+	switch x.xxx_hidden_Payload.(type) {
+	case *enrollDeviceResponse_Success:
+		return EnrollDeviceResponse_Success_case
+	case *enrollDeviceResponse_IosChallenge:
+		return EnrollDeviceResponse_IosChallenge_case
+	default:
+		return EnrollDeviceResponse_Payload_not_set_case
+	}
+}
+
+type EnrollDeviceResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Fields of oneof xxx_hidden_Payload:
+	Success      *EnrollDeviceSuccess
+	IosChallenge *IOSEnrollChallenge
+	// -- end of xxx_hidden_Payload
+}
+
+func (b0 EnrollDeviceResponse_builder) Build() *EnrollDeviceResponse {
+	m0 := &EnrollDeviceResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	if b.Success != nil {
+		x.xxx_hidden_Payload = &enrollDeviceResponse_Success{b.Success}
+	}
+	if b.IosChallenge != nil {
+		x.xxx_hidden_Payload = &enrollDeviceResponse_IosChallenge{b.IosChallenge}
+	}
+	return m0
+}
+
+type case_EnrollDeviceResponse_Payload protoreflect.FieldNumber
+
+func (x case_EnrollDeviceResponse_Payload) String() string {
+	md := file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[6].Descriptor()
+	if x == 0 {
+		return "not set"
+	}
+	return protoimpl.X.MessageFieldStringOf(md, protoreflect.FieldNumber(x))
+}
+
+type isEnrollDeviceResponse_Payload interface {
+	isEnrollDeviceResponse_Payload()
+}
+
+type enrollDeviceResponse_Success struct {
+	Success *EnrollDeviceSuccess `protobuf:"bytes,1,opt,name=success,proto3,oneof"`
+}
+
+type enrollDeviceResponse_IosChallenge struct {
+	IosChallenge *IOSEnrollChallenge `protobuf:"bytes,2,opt,name=ios_challenge,json=iosChallenge,proto3,oneof"`
+}
+
+func (*enrollDeviceResponse_Success) isEnrollDeviceResponse_Payload() {}
+
+func (*enrollDeviceResponse_IosChallenge) isEnrollDeviceResponse_Payload() {}
+
+// EnrollDeviceSuccess marks a successful device enrollment ceremony.
+type EnrollDeviceSuccess struct {
+	state             protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Device *v1.Device             `protobuf:"bytes,1,opt,name=device,proto3"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *EnrollDeviceSuccess) Reset() {
+	*x = EnrollDeviceSuccess{}
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnrollDeviceSuccess) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnrollDeviceSuccess) ProtoMessage() {}
+
+func (x *EnrollDeviceSuccess) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *EnrollDeviceSuccess) GetDevice() *v1.Device {
+	if x != nil {
+		return x.xxx_hidden_Device
+	}
+	return nil
+}
+
+func (x *EnrollDeviceSuccess) SetDevice(v *v1.Device) {
+	x.xxx_hidden_Device = v
+}
+
+func (x *EnrollDeviceSuccess) HasDevice() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Device != nil
+}
+
+func (x *EnrollDeviceSuccess) ClearDevice() {
+	x.xxx_hidden_Device = nil
+}
+
+type EnrollDeviceSuccess_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The enrolled device.
+	Device *v1.Device
+}
+
+func (b0 EnrollDeviceSuccess_builder) Build() *EnrollDeviceSuccess {
+	m0 := &EnrollDeviceSuccess{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Device = b.Device
+	return m0
+}
+
+// IOSEnrollChallenge is a iOS and iPadOS enrollment challenge.
+type IOSEnrollChallenge struct {
+	state                protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Challenge []byte                 `protobuf:"bytes,1,opt,name=challenge,proto3"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *IOSEnrollChallenge) Reset() {
+	*x = IOSEnrollChallenge{}
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IOSEnrollChallenge) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IOSEnrollChallenge) ProtoMessage() {}
+
+func (x *IOSEnrollChallenge) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *IOSEnrollChallenge) GetChallenge() []byte {
+	if x != nil {
+		return x.xxx_hidden_Challenge
+	}
+	return nil
+}
+
+func (x *IOSEnrollChallenge) SetChallenge(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.xxx_hidden_Challenge = v
+}
+
+type IOSEnrollChallenge_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Randomly-generated, opaque challenge to be signed using the device key.
+	Challenge []byte
+}
+
+func (b0 IOSEnrollChallenge_builder) Build() *IOSEnrollChallenge {
+	m0 := &IOSEnrollChallenge{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Challenge = b.Challenge
+	return m0
+}
+
 var File_teleport_devicetrust_public_v1_devicetrust_service_proto protoreflect.FileDescriptor
 
 const file_teleport_devicetrust_public_v1_devicetrust_service_proto_rawDesc = "" +
 	"\n" +
-	"8teleport/devicetrust/public/v1/devicetrust_service.proto\x12\x1eteleport.devicetrust.public.v1\x1a3teleport/devicetrust/v1/device_collected_data.proto\x1a1teleport/devicetrust/v1/device_enroll_token.proto\"\xa7\x01\n" +
+	"8teleport/devicetrust/public/v1/devicetrust_service.proto\x12\x1eteleport.devicetrust.public.v1\x1a$teleport/devicetrust/v1/device.proto\x1a3teleport/devicetrust/v1/device_collected_data.proto\x1a1teleport/devicetrust/v1/device_enroll_token.proto\"\xa7\x01\n" +
 	"$CreatePairedDeviceEnrollTokenRequest\x120\n" +
 	"\x14enroll_pairing_token\x18\x01 \x01(\tR\x12enrollPairingToken\x12M\n" +
 	"\vdevice_data\x18\x02 \x01(\v2,.teleport.devicetrust.v1.DeviceCollectedDataR\n" +
 	"deviceData\"\x83\x01\n" +
 	"%CreatePairedDeviceEnrollTokenResponse\x12Z\n" +
-	"\x13device_enroll_token\x18\x01 \x01(\v2*.teleport.devicetrust.v1.DeviceEnrollTokenR\x11deviceEnrollToken2\xc3\x01\n" +
+	"\x13device_enroll_token\x18\x01 \x01(\v2*.teleport.devicetrust.v1.DeviceEnrollTokenR\x11deviceEnrollToken\"\xdc\x01\n" +
+	"\x13EnrollDeviceRequest\x12F\n" +
+	"\x04init\x18\x01 \x01(\v20.teleport.devicetrust.public.v1.EnrollDeviceInitH\x00R\x04init\x12r\n" +
+	"\x16ios_challenge_response\x18\x02 \x01(\v2:.teleport.devicetrust.public.v1.IOSEnrollChallengeResponseH\x00R\x14iosChallengeResponseB\t\n" +
+	"\apayload\"\xe0\x01\n" +
+	"\x10EnrollDeviceInit\x12\x14\n" +
+	"\x05token\x18\x01 \x01(\tR\x05token\x12#\n" +
+	"\rcredential_id\x18\x02 \x01(\tR\fcredentialId\x12M\n" +
+	"\vdevice_data\x18\x03 \x01(\v2,.teleport.devicetrust.v1.DeviceCollectedDataR\n" +
+	"deviceData\x12B\n" +
+	"\x03ios\x18\x04 \x01(\v20.teleport.devicetrust.public.v1.IOSEnrollPayloadR\x03ios\"8\n" +
+	"\x10IOSEnrollPayload\x12$\n" +
+	"\x0epublic_key_der\x18\x01 \x01(\fR\fpublicKeyDer\":\n" +
+	"\x1aIOSEnrollChallengeResponse\x12\x1c\n" +
+	"\tsignature\x18\x01 \x01(\fR\tsignature\"\xcd\x01\n" +
+	"\x14EnrollDeviceResponse\x12O\n" +
+	"\asuccess\x18\x01 \x01(\v23.teleport.devicetrust.public.v1.EnrollDeviceSuccessH\x00R\asuccess\x12Y\n" +
+	"\rios_challenge\x18\x02 \x01(\v22.teleport.devicetrust.public.v1.IOSEnrollChallengeH\x00R\fiosChallengeB\t\n" +
+	"\apayload\"N\n" +
+	"\x13EnrollDeviceSuccess\x127\n" +
+	"\x06device\x18\x01 \x01(\v2\x1f.teleport.devicetrust.v1.DeviceR\x06device\"2\n" +
+	"\x12IOSEnrollChallenge\x12\x1c\n" +
+	"\tchallenge\x18\x01 \x01(\fR\tchallenge2\xc2\x02\n" +
 	"\x12DeviceTrustService\x12\xac\x01\n" +
-	"\x1dCreatePairedDeviceEnrollToken\x12D.teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenRequest\x1aE.teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenResponseBgZegithub.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/public/v1;devicetrustpublicv1b\x06proto3"
+	"\x1dCreatePairedDeviceEnrollToken\x12D.teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenRequest\x1aE.teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenResponse\x12}\n" +
+	"\fEnrollDevice\x123.teleport.devicetrust.public.v1.EnrollDeviceRequest\x1a4.teleport.devicetrust.public.v1.EnrollDeviceResponse(\x010\x01BgZegithub.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/public/v1;devicetrustpublicv1b\x06proto3"
 
-var file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_teleport_devicetrust_public_v1_devicetrust_service_proto_goTypes = []any{
 	(*CreatePairedDeviceEnrollTokenRequest)(nil),  // 0: teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenRequest
 	(*CreatePairedDeviceEnrollTokenResponse)(nil), // 1: teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenResponse
-	(*v1.DeviceCollectedData)(nil),                // 2: teleport.devicetrust.v1.DeviceCollectedData
-	(*v1.DeviceEnrollToken)(nil),                  // 3: teleport.devicetrust.v1.DeviceEnrollToken
+	(*EnrollDeviceRequest)(nil),                   // 2: teleport.devicetrust.public.v1.EnrollDeviceRequest
+	(*EnrollDeviceInit)(nil),                      // 3: teleport.devicetrust.public.v1.EnrollDeviceInit
+	(*IOSEnrollPayload)(nil),                      // 4: teleport.devicetrust.public.v1.IOSEnrollPayload
+	(*IOSEnrollChallengeResponse)(nil),            // 5: teleport.devicetrust.public.v1.IOSEnrollChallengeResponse
+	(*EnrollDeviceResponse)(nil),                  // 6: teleport.devicetrust.public.v1.EnrollDeviceResponse
+	(*EnrollDeviceSuccess)(nil),                   // 7: teleport.devicetrust.public.v1.EnrollDeviceSuccess
+	(*IOSEnrollChallenge)(nil),                    // 8: teleport.devicetrust.public.v1.IOSEnrollChallenge
+	(*v1.DeviceCollectedData)(nil),                // 9: teleport.devicetrust.v1.DeviceCollectedData
+	(*v1.DeviceEnrollToken)(nil),                  // 10: teleport.devicetrust.v1.DeviceEnrollToken
+	(*v1.Device)(nil),                             // 11: teleport.devicetrust.v1.Device
 }
 var file_teleport_devicetrust_public_v1_devicetrust_service_proto_depIdxs = []int32{
-	2, // 0: teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenRequest.device_data:type_name -> teleport.devicetrust.v1.DeviceCollectedData
-	3, // 1: teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenResponse.device_enroll_token:type_name -> teleport.devicetrust.v1.DeviceEnrollToken
-	0, // 2: teleport.devicetrust.public.v1.DeviceTrustService.CreatePairedDeviceEnrollToken:input_type -> teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenRequest
-	1, // 3: teleport.devicetrust.public.v1.DeviceTrustService.CreatePairedDeviceEnrollToken:output_type -> teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenResponse
-	3, // [3:4] is the sub-list for method output_type
-	2, // [2:3] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	9,  // 0: teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenRequest.device_data:type_name -> teleport.devicetrust.v1.DeviceCollectedData
+	10, // 1: teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenResponse.device_enroll_token:type_name -> teleport.devicetrust.v1.DeviceEnrollToken
+	3,  // 2: teleport.devicetrust.public.v1.EnrollDeviceRequest.init:type_name -> teleport.devicetrust.public.v1.EnrollDeviceInit
+	5,  // 3: teleport.devicetrust.public.v1.EnrollDeviceRequest.ios_challenge_response:type_name -> teleport.devicetrust.public.v1.IOSEnrollChallengeResponse
+	9,  // 4: teleport.devicetrust.public.v1.EnrollDeviceInit.device_data:type_name -> teleport.devicetrust.v1.DeviceCollectedData
+	4,  // 5: teleport.devicetrust.public.v1.EnrollDeviceInit.ios:type_name -> teleport.devicetrust.public.v1.IOSEnrollPayload
+	7,  // 6: teleport.devicetrust.public.v1.EnrollDeviceResponse.success:type_name -> teleport.devicetrust.public.v1.EnrollDeviceSuccess
+	8,  // 7: teleport.devicetrust.public.v1.EnrollDeviceResponse.ios_challenge:type_name -> teleport.devicetrust.public.v1.IOSEnrollChallenge
+	11, // 8: teleport.devicetrust.public.v1.EnrollDeviceSuccess.device:type_name -> teleport.devicetrust.v1.Device
+	0,  // 9: teleport.devicetrust.public.v1.DeviceTrustService.CreatePairedDeviceEnrollToken:input_type -> teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenRequest
+	2,  // 10: teleport.devicetrust.public.v1.DeviceTrustService.EnrollDevice:input_type -> teleport.devicetrust.public.v1.EnrollDeviceRequest
+	1,  // 11: teleport.devicetrust.public.v1.DeviceTrustService.CreatePairedDeviceEnrollToken:output_type -> teleport.devicetrust.public.v1.CreatePairedDeviceEnrollTokenResponse
+	6,  // 12: teleport.devicetrust.public.v1.DeviceTrustService.EnrollDevice:output_type -> teleport.devicetrust.public.v1.EnrollDeviceResponse
+	11, // [11:13] is the sub-list for method output_type
+	9,  // [9:11] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_teleport_devicetrust_public_v1_devicetrust_service_proto_init() }
@@ -230,13 +999,21 @@ func file_teleport_devicetrust_public_v1_devicetrust_service_proto_init() {
 	if File_teleport_devicetrust_public_v1_devicetrust_service_proto != nil {
 		return
 	}
+	file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[2].OneofWrappers = []any{
+		(*enrollDeviceRequest_Init)(nil),
+		(*enrollDeviceRequest_IosChallengeResponse)(nil),
+	}
+	file_teleport_devicetrust_public_v1_devicetrust_service_proto_msgTypes[6].OneofWrappers = []any{
+		(*enrollDeviceResponse_Success)(nil),
+		(*enrollDeviceResponse_IosChallenge)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_devicetrust_public_v1_devicetrust_service_proto_rawDesc), len(file_teleport_devicetrust_public_v1_devicetrust_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/proto/teleport/devicetrust/public/v1/devicetrust_service.proto
+++ b/api/proto/teleport/devicetrust/public/v1/devicetrust_service.proto
@@ -101,6 +101,13 @@ message EnrollDeviceInit {
 
   // Payload for data specific to iOS and iPadOS.
   IOSEnrollPayload ios = 4;
+
+  // User that owns the device being enrolled.
+  //
+  // Temporary: ownership should be derived from the enrollment token issued by
+  // CreatePairedDeviceEnrollToken, not supplied by the client. This field lets
+  // the ceremony assign an owner until the token carries the user.
+  string user = 5;
 }
 
 // IOSEnrollPayload is the iOS- and iPadOS-specific enrollment payload.

--- a/api/proto/teleport/devicetrust/public/v1/devicetrust_service.proto
+++ b/api/proto/teleport/devicetrust/public/v1/devicetrust_service.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package teleport.devicetrust.public.v1;
 
+import "teleport/devicetrust/v1/device.proto";
 import "teleport/devicetrust/v1/device_collected_data.proto";
 import "teleport/devicetrust/v1/device_enroll_token.proto";
 
@@ -45,6 +46,20 @@ service DeviceTrustService {
   // calls with the same enroll pairing token are allowed only if os_type and
   // serial_number from device_data match those from the initial call.
   rpc CreatePairedDeviceEnrollToken(CreatePairedDeviceEnrollTokenRequest) returns (CreatePairedDeviceEnrollTokenResponse);
+
+  // EnrollDevice performs the device enrollment ceremony for a mobile device.
+  //
+  // It is the publicly-accessible counterpart to
+  // teleport.devicetrust.v1.DeviceTrustService.EnrollDevice. It uses the
+  // enrollment token returned by CreatePairedDeviceEnrollToken instead of a
+  // user certificate.
+  //
+  // iOS and iPadOS enrollment flow:
+  // -> EnrollDeviceInit (client)
+  // <- IOSEnrollChallenge (server)
+  // -> IOSEnrollChallengeResponse (client)
+  // <- EnrollDeviceSuccess (server)
+  rpc EnrollDevice(stream EnrollDeviceRequest) returns (stream EnrollDeviceResponse);
 }
 
 // Request for CreatePairedDeviceEnrollToken.
@@ -60,4 +75,62 @@ message CreatePairedDeviceEnrollTokenRequest {
 // Response for CreatePairedDeviceEnrollToken.
 message CreatePairedDeviceEnrollTokenResponse {
   teleport.devicetrust.v1.DeviceEnrollToken device_enroll_token = 1;
+}
+
+// Request for EnrollDevice.
+message EnrollDeviceRequest {
+  oneof payload {
+    EnrollDeviceInit init = 1;
+    IOSEnrollChallengeResponse ios_challenge_response = 2;
+  }
+}
+
+// EnrollDeviceInit initiates the enrollment ceremony.
+message EnrollDeviceInit {
+  // Device enrollment token.
+  // See CreatePairedDeviceEnrollToken.
+  string token = 1;
+
+  // ID of the device credential.
+  string credential_id = 2;
+
+  // Device collected data.
+  // Matched against the device registration information and any previously
+  // collected data.
+  teleport.devicetrust.v1.DeviceCollectedData device_data = 3;
+
+  // Payload for data specific to iOS and iPadOS.
+  IOSEnrollPayload ios = 4;
+}
+
+// IOSEnrollPayload is the iOS- and iPadOS-specific enrollment payload.
+message IOSEnrollPayload {
+  // Device public key marshaled as a PKIX, ASN.1 DER.
+  bytes public_key_der = 1;
+}
+
+// IOSEnrollChallengeResponse is an iOS and iPadOS enrollment challenge response.
+message IOSEnrollChallengeResponse {
+  // Signature over the challenge, using the device key.
+  bytes signature = 1;
+}
+
+// Response for EnrollDevice.
+message EnrollDeviceResponse {
+  oneof payload {
+    EnrollDeviceSuccess success = 1;
+    IOSEnrollChallenge ios_challenge = 2;
+  }
+}
+
+// EnrollDeviceSuccess marks a successful device enrollment ceremony.
+message EnrollDeviceSuccess {
+  // The enrolled device.
+  teleport.devicetrust.v1.Device device = 1;
+}
+
+// IOSEnrollChallenge is a iOS and iPadOS enrollment challenge.
+message IOSEnrollChallenge {
+  // Randomly-generated, opaque challenge to be signed using the device key.
+  bytes challenge = 1;
 }

--- a/buf.yaml
+++ b/buf.yaml
@@ -75,6 +75,7 @@ lint:
     UNARY_RPC:
       - api/proto/teleport/auditlog/v1/auditlog.proto
       - api/proto/teleport/devicetrust/v1/devicetrust_service.proto
+      - api/proto/teleport/devicetrust/public/v1/devicetrust_service.proto
       - api/proto/teleport/legacy/client/proto/joinservice.proto
       - api/proto/teleport/transport/v1/transport_service.proto
       - api/proto/teleport/access_graph/v1/secrets_service.proto

--- a/lib/devicetrust/grpcproxy/grpcproxy.go
+++ b/lib/devicetrust/grpcproxy/grpcproxy.go
@@ -21,8 +21,10 @@ import (
 	"log/slog"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/grpc"
 
 	publicdevicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/public/v1"
+	grpcutils "github.com/gravitational/teleport/lib/utils/grpc"
 )
 
 // AuthClient is a subset of the full Auth API that must be connected.
@@ -64,4 +66,13 @@ type Service struct {
 func (s *Service) CreatePairedDeviceEnrollToken(ctx context.Context, req *publicdevicepb.CreatePairedDeviceEnrollTokenRequest) (*publicdevicepb.CreatePairedDeviceEnrollTokenResponse, error) {
 	res, err := s.authClient.PublicDevicesClient().CreatePairedDeviceEnrollToken(ctx, req)
 	return res, trace.Wrap(err)
+}
+
+// EnrollDevice proxies the bidi enrollment stream to the same RPC in the Auth
+// Service.
+func (s *Service) EnrollDevice(stream publicdevicepb.DeviceTrustService_EnrollDeviceServer) error {
+	return trace.Wrap(grpcutils.ProxyBidiStream(s.log, stream,
+		func(ctx context.Context) (grpc.BidiStreamingClient[publicdevicepb.EnrollDeviceRequest, publicdevicepb.EnrollDeviceResponse], error) {
+			return s.authClient.PublicDevicesClient().EnrollDevice(ctx)
+		}))
 }

--- a/lib/mobile/verify/enroll/enroll.go
+++ b/lib/mobile/verify/enroll/enroll.go
@@ -116,12 +116,14 @@ func (c *Client) CreatePairedDeviceEnrollToken(pairingToken string, deviceData *
 }
 
 // EnrollDevice runs the enrollment ceremony against the public Device Trust
-// service using the enrollment token from CreatePairedDeviceEnrollToken.
+// service using the enrollment token from CreatePairedDeviceEnrollToken. user
+// is the owner to assign to the device, carried on the request temporarily
+// until the enrollment token can supply it.
 //
 // This is a simplified stand-in for the real iOS ceremony: instead of a Secure
 // Enclave key it generates an ephemeral P-256 key in-process, signs the
 // server's challenge with it, and returns the enrolled device.
-func (c *Client) EnrollDevice(enrollToken string, deviceData *DeviceCollectedData) (*EnrolledDevice, error) {
+func (c *Client) EnrollDevice(enrollToken, user string, deviceData *DeviceCollectedData) (*EnrolledDevice, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -163,6 +165,7 @@ func (c *Client) EnrollDevice(enrollToken string, deviceData *DeviceCollectedDat
 			Ios: devicetrustpublicv1pb.IOSEnrollPayload_builder{
 				PublicKeyDer: pubDER,
 			}.Build(),
+			User: user,
 		}.Build(),
 	}.Build()); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/mobile/verify/enroll/enroll.go
+++ b/lib/mobile/verify/enroll/enroll.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	devicetrustpublicv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/public/v1"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	proxyinsecureclient "github.com/gravitational/teleport/lib/client/proxy/insecure"
 )
@@ -64,9 +65,10 @@ type DeviceEnrollToken struct {
 	Token string
 }
 
-// CreateMobileEnrollToken calls CreateMobileDeviceEnrollToken on the public
-// Device Trust service. Populated fields of deviceData are forwarded as-is.
-func (c *Client) CreateMobileEnrollToken(pairingToken string, deviceData *DeviceCollectedData) (*DeviceEnrollToken, error) {
+// CreatePairedDeviceEnrollToken calls CreatePairedDeviceEnrollToken on the
+// public Device Trust service. Populated fields of deviceData are forwarded
+// as-is.
+func (c *Client) CreatePairedDeviceEnrollToken(pairingToken string, deviceData *DeviceCollectedData) (*DeviceEnrollToken, error) {
 	// TODO(ravicious): Integrate Go's context with Swift's task cancellation
 	// See https://github.com/gravitational/teleport/pull/61278/changes/8980e91f611264bd760890316d49a842ded2aebb
 	ctx, cancel := context.WithCancel(context.Background())
@@ -86,29 +88,29 @@ func (c *Client) CreateMobileEnrollToken(pairingToken string, deviceData *Device
 	}
 	defer grpcConn.Close()
 
-	// TODO(ravicious): Replace this with a call to the public gRPC service.
-	client := devicepb.NewDeviceTrustServiceClient(grpcConn)
-	resp, err := client.CreateDeviceEnrollToken(ctx,
-		devicepb.CreateDeviceEnrollTokenRequest_builder{
-			DeviceData: toPBDeviceData(deviceData),
+	client := devicetrustpublicv1pb.NewDeviceTrustServiceClient(grpcConn)
+	resp, err := client.CreatePairedDeviceEnrollToken(ctx,
+		devicetrustpublicv1pb.CreatePairedDeviceEnrollTokenRequest_builder{
+			EnrollPairingToken: pairingToken,
+			DeviceData:         toPBDeviceData(deviceData),
 		}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &DeviceEnrollToken{
-		Token: resp.GetToken(),
+		Token: resp.GetDeviceEnrollToken().GetToken(),
 	}, nil
 }
 
-// toPBDeviceData translates DeviceCollectedData into the proto type.
-// OsType stays UNSPECIFIED until OS_TYPE_IOS lands in
-// teleport.devicetrust.v1.OSType (see RFD 32e).
+// toPBDeviceData translates DeviceCollectedData into the proto type. OsType is
+// hardcoded to iOS.
 func toPBDeviceData(d *DeviceCollectedData) *devicepb.DeviceCollectedData {
 	if d == nil {
 		d = &DeviceCollectedData{}
 	}
 	return devicepb.DeviceCollectedData_builder{
 		CollectTime:        timestamppb.Now(),
+		OsType:             devicepb.OSType_OS_TYPE_IOS,
 		SerialNumber:       d.SerialNumber,
 		ModelIdentifier:    d.ModelIdentifier,
 		OsVersion:          d.VersionOS,

--- a/lib/mobile/verify/enroll/enroll.go
+++ b/lib/mobile/verify/enroll/enroll.go
@@ -18,8 +18,13 @@ package enroll
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
 	"log/slog"
 
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -27,6 +32,7 @@ import (
 	devicetrustpublicv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/public/v1"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	proxyinsecureclient "github.com/gravitational/teleport/lib/client/proxy/insecure"
+	"github.com/gravitational/teleport/lib/devicetrust/challenge"
 )
 
 type Client struct {
@@ -65,6 +71,13 @@ type DeviceEnrollToken struct {
 	Token string
 }
 
+// EnrolledDevice is the iOS-relevant subset of the enrolled
+// teleport.devicetrust.v1.Device returned by EnrollDevice.
+type EnrolledDevice struct {
+	DeviceID string
+	AssetTag string
+}
+
 // CreatePairedDeviceEnrollToken calls CreatePairedDeviceEnrollToken on the
 // public Device Trust service. Populated fields of deviceData are forwarded
 // as-is.
@@ -99,6 +112,97 @@ func (c *Client) CreatePairedDeviceEnrollToken(pairingToken string, deviceData *
 	}
 	return &DeviceEnrollToken{
 		Token: resp.GetDeviceEnrollToken().GetToken(),
+	}, nil
+}
+
+// EnrollDevice runs the enrollment ceremony against the public Device Trust
+// service using the enrollment token from CreatePairedDeviceEnrollToken.
+//
+// This is a simplified stand-in for the real iOS ceremony: instead of a Secure
+// Enclave key it generates an ephemeral P-256 key in-process, signs the
+// server's challenge with it, and returns the enrolled device.
+func (c *Client) EnrollDevice(enrollToken string, deviceData *DeviceCollectedData) (*EnrolledDevice, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	pubDER, err := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	grpcConn, err := proxyinsecureclient.NewConnection(
+		ctx,
+		proxyinsecureclient.ConnectionConfig{
+			ProxyServer: c.proxyServer,
+			Clock:       clockwork.NewRealClock(),
+			Insecure:    c.insecure,
+			Log:         slog.Default(),
+		},
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer grpcConn.Close()
+
+	client := devicetrustpublicv1pb.NewDeviceTrustServiceClient(grpcConn)
+	stream, err := client.EnrollDevice(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// 1. Init.
+	if err := stream.Send(devicetrustpublicv1pb.EnrollDeviceRequest_builder{
+		Init: devicetrustpublicv1pb.EnrollDeviceInit_builder{
+			Token:        enrollToken,
+			CredentialId: uuid.NewString(),
+			DeviceData:   toPBDeviceData(deviceData),
+			Ios: devicetrustpublicv1pb.IOSEnrollPayload_builder{
+				PublicKeyDer: pubDER,
+			}.Build(),
+		}.Build(),
+	}.Build()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// 2. Challenge.
+	resp, err := stream.Recv()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	chal := resp.GetIosChallenge().GetChallenge()
+	if len(chal) == 0 {
+		return nil, trace.BadParameter("expected iOS enroll challenge")
+	}
+
+	// 3. Challenge response.
+	sig, err := challenge.Sign(chal, priv)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := stream.Send(devicetrustpublicv1pb.EnrollDeviceRequest_builder{
+		IosChallengeResponse: devicetrustpublicv1pb.IOSEnrollChallengeResponse_builder{
+			Signature: sig,
+		}.Build(),
+	}.Build()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// 4. Success.
+	resp, err = stream.Recv()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	dev := resp.GetSuccess().GetDevice()
+	if dev == nil {
+		return nil, trace.BadParameter("expected enroll device success")
+	}
+	return &EnrolledDevice{
+		DeviceID: dev.GetId(),
+		AssetTag: dev.GetAssetTag(),
 	}, nil
 }
 

--- a/tool/enroll/main.go
+++ b/tool/enroll/main.go
@@ -39,6 +39,7 @@ func main() {
 	proxyServer := flag.String("proxy", "", "proxy server address (host:port)")
 	rpc := flag.String("rpc", "create-token", "RPC to call: create-token or enroll")
 	token := flag.String("token", "", "enroll pairing token for create-token, device enrollment token for enroll")
+	user := flag.String("user", "", "owner to assign to the device (enroll only)")
 	flag.Parse()
 
 	if *proxyServer == "" || *token == "" {
@@ -57,7 +58,11 @@ func main() {
 		}
 		fmt.Println(enrollToken.Token)
 	case "enroll":
-		device, err := client.EnrollDevice(*token, &fakeDeviceData)
+		if *user == "" {
+			fmt.Fprintln(os.Stderr, "-user is required for enroll")
+			os.Exit(1)
+		}
+		device, err := client.EnrollDevice(*token, *user, &fakeDeviceData)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)

--- a/tool/enroll/main.go
+++ b/tool/enroll/main.go
@@ -15,8 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // Command enroll is a throwaway tool that calls the public Device Trust
-// CreatePairedDeviceEnrollToken RPC against a proxy server with a given
-// pairing token and constant fake device data.
+// CreatePairedDeviceEnrollToken and EnrollDevice RPCs against a proxy server
+// with a given token and constant fake device data.
 package main
 
 import (
@@ -37,7 +37,8 @@ var fakeDeviceData = enroll.DeviceCollectedData{
 
 func main() {
 	proxyServer := flag.String("proxy", "", "proxy server address (host:port)")
-	token := flag.String("token", "", "enroll pairing token")
+	rpc := flag.String("rpc", "create-token", "RPC to call: create-token or enroll")
+	token := flag.String("token", "", "enroll pairing token for create-token, device enrollment token for enroll")
 	flag.Parse()
 
 	if *proxyServer == "" || *token == "" {
@@ -46,10 +47,25 @@ func main() {
 	}
 
 	client := enroll.NewClient(*proxyServer, false)
-	enrollToken, err := client.CreatePairedDeviceEnrollToken(*token, &fakeDeviceData)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+
+	switch *rpc {
+	case "create-token":
+		enrollToken, err := client.CreatePairedDeviceEnrollToken(*token, &fakeDeviceData)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		fmt.Println(enrollToken.Token)
+	case "enroll":
+		device, err := client.EnrollDevice(*token, &fakeDeviceData)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		fmt.Printf("enrolled device %s (asset tag %s)\n", device.DeviceID, device.AssetTag)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown rpc %q\n", *rpc)
+		flag.Usage()
 		os.Exit(1)
 	}
-	fmt.Println(enrollToken.Token)
 }

--- a/tool/enroll/main.go
+++ b/tool/enroll/main.go
@@ -1,0 +1,55 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Command enroll is a throwaway tool that calls the public Device Trust
+// CreatePairedDeviceEnrollToken RPC against a proxy server with a given
+// pairing token and constant fake device data.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/gravitational/teleport/lib/mobile/verify/enroll"
+)
+
+// fakeDeviceData is constant stand-in device data for manual testing.
+var fakeDeviceData = enroll.DeviceCollectedData{
+	SerialNumber:    "FAKE000SERIAL",
+	ModelIdentifier: "iPhone16,1",
+	VersionOS:       "18.0",
+	BuildOS:         "22A000",
+}
+
+func main() {
+	proxyServer := flag.String("proxy", "", "proxy server address (host:port)")
+	token := flag.String("token", "", "enroll pairing token")
+	flag.Parse()
+
+	if *proxyServer == "" || *token == "" {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	client := enroll.NewClient(*proxyServer, false)
+	enrollToken, err := client.CreatePairedDeviceEnrollToken(*token, &fakeDeviceData)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Println(enrollToken.Token)
+}

--- a/tool/tctl/common/devices.go
+++ b/tool/tctl/common/devices.go
@@ -27,6 +27,7 @@ import (
 	"log/slog"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -64,19 +65,23 @@ type DevicesCommand struct {
 
 type osType = string
 
-const (
-	linuxType   osType = "linux"
-	macosType   osType = "macos"
-	windowsType osType = "windows"
-)
-
-var osTypes = []string{linuxType, macosType, windowsType}
-
-var osTypeToEnum = map[osType]devicepb.OSType{
-	linuxType:   devicepb.OSType_OS_TYPE_LINUX,
-	macosType:   devicepb.OSType_OS_TYPE_MACOS,
-	windowsType: devicepb.OSType_OS_TYPE_WINDOWS,
-}
+// osTypes (accepted --os values) and osTypeToEnum are derived from
+// devicepb.OSType, minus UNSPECIFIED.
+var osTypes, osTypeToEnum = func() ([]osType, map[osType]devicepb.OSType) {
+	m := make(map[osType]devicepb.OSType, len(devicepb.OSType_value)-1)
+	var names []osType
+	for name, v := range devicepb.OSType_value {
+		ot := devicepb.OSType(v)
+		if ot == devicepb.OSType_OS_TYPE_UNSPECIFIED {
+			continue
+		}
+		s := strings.ToLower(strings.TrimPrefix(name, "OS_TYPE_"))
+		m[s] = ot
+		names = append(names, s)
+	}
+	sort.Strings(names)
+	return names, m
+}()
 
 func (c *DevicesCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, cfg *servicecfg.Config) {
 	devicesCmd := app.Command("devices", "Register and manage trusted devices").Hidden()


### PR DESCRIPTION
@gmedori Here's a proof of concept of `EnrollDevice`. It does not perform any auth checks and the user comes from the `user` field temporarily added to `EnrollDeviceInit`. The proto definitions in the final version should stay pretty much the same.

1. Check out `maja/poc/enroll-device` in OSS and e.
2. `make build/tctl`
3. `make -C e build/teleport`
4. `tctl devices add --os ios --asset-tag FAKE000SERIAL`
5. `tctl devices enroll --asset-tag FAKE000SERIAL` and copy the resulting enrollment token.
6. `go run ./tool/enroll -proxy <proxy hostname and port> -rpc enroll -user <your user> -token <enrollment token>`
7. Go to Account Settings in the Web UI, the device should be under Trusted Devices.
   * Alternatively, just `tctl devices ls` and it should list the correct owner. 

To unenroll the device and remove it from the inventory, `tctl devices rm --asset-tag FAKE000SERIAL`.

The serial number can be arbitrary, but it must be the same across step 4, 5 and 6. See `fakeDeviceData` in `tool/enroll/main.go`.

https://goteleport.com/docs/zero-trust-access/device-trust/device-management/

TODO for @gmedori:

- [ ] Complete `EnrollDevice` ceremony using the mobile app with a device registered manually with `tctl devices add`.
- [ ] Same as above, but the device comes from Jamf.
  - See [Enroll a mobile device into an MDM](https://app.notion.com/p/goteleport/Device-Trust-development-c8537ac975e44c18b033cd627123a457?source=copy_link#27afdd3830be80d4b59cd1f0783ce66e).
- [ ] Same as above, but the device comes from Intune.