### PR TITLE
Add page_type and outcome statements to 51 files

### DIFF
--- a/docs/pages/configuration/terraform-provider/ci-or-cloud.mdx
+++ b/docs/pages/configuration/terraform-provider/ci-or-cloud.mdx
@@ -7,9 +7,10 @@ tags:
  - infrastructure-as-code
  - how-to
  - zero-trust
+page_type: how-to
 ---
 
-This guide covers how to run the Teleport Terraform Provider from:
+In this guide, you will run the Teleport Terraform Provider from:
 
 - your CI/CD pipelines on:
   - GitHub Actions (we'll use the `github` join method)

--- a/docs/pages/configuration/terraform-provider/env0.mdx
+++ b/docs/pages/configuration/terraform-provider/env0.mdx
@@ -7,10 +7,11 @@ tags:
  - infrastructure-as-code
  - how-to
  - zero-trust
+page_type: how-to
 ---
 
-This guide demonstrates how to use the Terraform provider for Teleport in jobs
-running on [env zero].
+In this guide, you will use the Terraform provider for Teleport in jobs running
+on [env zero].
 
 This guide does not cover running the Terraform provider locally, in other CI/CD
 environments, or in short-lived cloud VMs. In any of these cases, refer to a

--- a/docs/pages/configuration/terraform-provider/local.mdx
+++ b/docs/pages/configuration/terraform-provider/local.mdx
@@ -6,10 +6,11 @@ tags:
  - infrastructure-as-code
  - how-to
  - zero-trust
+page_type: how-to
 ---
 
-This guide covers how to run the Teleport Terraform provider from your local computer,
-where you are already logged in Teleport as yourself.
+In this guide, you will run the Teleport Terraform provider from your local
+computer, where you are already logged in Teleport as yourself.
 
 This guide does not cover running Teleport in remote environments such as a cloud VM, an on-prem server,
 or CI/CD pipelines. If you are in one of those cases, please follow the dedicated guides:

--- a/docs/pages/configuration/terraform-provider/long-lived-credentials.mdx
+++ b/docs/pages/configuration/terraform-provider/long-lived-credentials.mdx
@@ -6,10 +6,12 @@ tags:
  - infrastructure-as-code
  - how-to
  - zero-trust
+page_type: how-to
 ---
 
-This guide explains how to create a Terraform user and have the Teleport Auth Service sign long-lived credentials
-for it. The Teleport Terraform Provider can then use those credentials to interact with Teleport.
+In this guide, you will create a Terraform user and have the Teleport Auth
+Service sign long-lived credentials for it. The Teleport Terraform Provider can
+then use those credentials to interact with Teleport.
 
 ## How it works
 

--- a/docs/pages/configuration/using-tctl.mdx
+++ b/docs/pages/configuration/using-tctl.mdx
@@ -6,10 +6,11 @@ sidebar_position: 1
 tags:
 - conceptual
 - platform-wide
+page_type: conceptual
 ---
 
-This guide provides an overview of `tctl`, a command-line tool for managing
-Teleport dynamic resources.
+This guide describes the basic operations you can perform with `tctl`, a
+command-line tool for managing Teleport dynamic resources.
 
 For an overview of what a dynamic resource is, see [Infrastructure as
 Code](configuration.mdx).

--- a/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 Teleport's SSH Service can automatically create local Unix users on a server,
@@ -23,6 +24,9 @@ member of your organization and gives you fine-grained, per-host control of
 permissions. As a security best practice, Teleport provisions these users and 
 keeps them on the host for auditability, though they can be configured to be 
 deleted at the end of an SSH session if required by your environment.
+
+In this guide, you will configure host user creation and host sudoers for
+Teleport-protected servers.
 
 ## How it works
 

--- a/docs/pages/identity-governance/access-lists/custom-access-list.mdx
+++ b/docs/pages/identity-governance/access-lists/custom-access-list.mdx
@@ -8,9 +8,8 @@ tags:
  - identity-governance
  - privileged-access
 enterprise: Identity Governance
+page_type: how-to
 ---
-
-{/* lint disable page-structure remark-lint */}
 
 The web UI's **Custom Form** creates an Access List by directly assigning
 existing roles to members and owners. Unlike the guided flows
@@ -18,11 +17,13 @@ existing roles to members and owners. Unlike the guided flows
 [Just-in-Time](./jit-access-list.mdx)), it does not generate roles for you —
 you pick from roles that already exist in the cluster.
 
-This guide will help you:
+In this guide, you will:
 
 - Decide when the Custom Form is the right fit
 - Create an Access List using the Custom Form in the Teleport Web UI
 - Verify that members get access on login
+
+{/* lint ignore page-structure remark-lint */}
 
 ## When to use this flow
 

--- a/docs/pages/identity-governance/access-requests/oss-role-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/oss-role-requests.mdx
@@ -8,6 +8,7 @@ tags:
  - conceptual
  - identity-governance
  - privileged-access
+page_type: conceptual
 ---
 
 Just-in-time Access Requests are a feature of Teleport Enterprise.
@@ -17,11 +18,11 @@ requesting a role using the Teleport CLI. Full Access Request functionality,
 including Resource Access Requests and an intuitive and searchable UI are
 available in Teleport Enterprise.
 
-This guide describes CLI workflows that are available in all Teleport editions,
-but are the only available option for Teleport Community Edition users. For
-Teleport Enterprise, we recommend using an Access Request plugin so reviewers
-receive notifications via the communication tools your organization already
-uses. See [Access Request plugins](./plugins/plugins.mdx) for guidance.
+This guide describes the CLI workflows that are available in all Teleport
+editions, but are the only available option for Teleport Community Edition
+users. For Teleport Enterprise, we recommend using an Access Request plugin so
+reviewers receive notifications via the communication tools your organization
+already uses. See [Access Request plugins](./plugins/plugins.mdx) for guidance.
 
 ## RBAC security setup
 

--- a/docs/pages/identity-governance/access-requests/plugins/opsgenie.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/opsgenie.mdx
@@ -8,9 +8,8 @@ tags:
  - identity-governance
  - privileged-access
 enterprise: Identity Governance
+page_type: how-to
 ---
-
-{/* lint disable page-structure remark-lint */}
 
 With Teleport's Opsgenie integration, engineers can access the infrastructure
 they need to resolve alerts quickly, without longstanding admin permissions
@@ -22,8 +21,9 @@ approve or deny the requests via Teleport. You can also configure the plugin to
 approve Role Access Requests automatically if the user making the request is on
 the on-call team for a service affected by an alert.
 
-This guide will explain how to set up Teleport's Access Request plugin for
-Opsgenie.
+In this guide, you will set up the Teleport Access Request plugin for Opsgenie.
+
+{/* lint ignore page-structure remark-lint */}
 
 ## Prerequisites
 

--- a/docs/pages/identity-governance/access-requests/plugins/plugins.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/plugins.mdx
@@ -10,6 +10,7 @@ tags:
  - identity-governance
  - privileged-access
 enterprise: Identity Governance
+page_type: landing
 ---
 
 Teleport Just-in-Time Access Requests allow users to receive temporary elevated

--- a/docs/pages/identity-governance/identity-gov-use-cases.mdx
+++ b/docs/pages/identity-governance/identity-gov-use-cases.mdx
@@ -6,6 +6,7 @@ sidebar_position: 1
 tags:
  - identity-governance
 enterprise: Identity Governance
+page_type: landing
 ---
 
 Teleport Identity Governance helps organizations strengthen security and compliance by centralizing 

--- a/docs/pages/identity-governance/idps/usage/saml-gcp-workforce-identity-federation.mdx
+++ b/docs/pages/identity-governance/idps/usage/saml-gcp-workforce-identity-federation.mdx
@@ -9,9 +9,8 @@ tags:
  - google-cloud
  - infrastructure-identity
 enterprise: Identity Governance
+page_type: how-to
 ---
-
-{/* lint disable page-structure remark-lint */}
 
 GCP Workforce Identity Federation enables provisioning access to GCP web console and APIs
 for identities that are not managed within Google Workspace Admin or GCP Cloud Identity.
@@ -22,9 +21,11 @@ Once a pool identity provider is configured, users can sign into the GCP web con
 long as their identity is signed by the identity provider in a federated authentication
 process.
 
+In this guide, you will integrate GCP workforce Identity Federation with
+Teleport SAML IdP, so users can sign in into GCP web console by authenticating
+with Teleport.
 
-This guide details how to integrate GCP workforce Identity Federation service with Teleport
-SAML IdP, so users can sign in into GCP web console by authenticating with Teleport.
+{/* lint ignore page-structure remark-lint */}
 
 ## Prerequisites
 
@@ -54,7 +55,7 @@ integration tile. Click the tile.
 
 Now follow the steps listed below.
 
-## Step 1/3. Configure workforce pool
+### Step 1/3. Configure workforce pool
 As a first step, provide the following information to the script generator.
 
 ![Test the IdP](../../../../img/access-controls/saml-idp/gcp-workforce/generate-command.png)
@@ -87,7 +88,7 @@ resource ID for workforce pool and workforce pool provider, respectively.
 </Admonition>
 
 
-## Step 2/3. Add workforce pool To Teleport
+### Step 2/3. Add workforce pool To Teleport
 
 Proceed to the next step in the UI by clicking the **Next** button.
 
@@ -103,7 +104,7 @@ values or attribute mapping in GCP, you must also updated the respective SAML se
 </Admonition>
 
 
-## Step 3/3. Create GCP IAM policy
+### Step 3/3. Create GCP IAM policy
 
 Once a pool and pool provider is configured in the GCP, and its respective configuration is added
 to Teleport as a SAML service provider resource, users can sign in into the GCP web console, as
@@ -247,7 +248,7 @@ While the guided integration makes it easy to get started, advance configuration
 should follow a manual integration. Both the Web UI and Teleport `tctl` client can be used for
 manual configuration. The following steps shows configuration with Teleport `tctl` admin client.
 
-## Step 1/3. Create workforce pool and pool provider
+### Step 1/3. Create workforce pool and pool provider
 
 First, create a workforce pool.
 ```
@@ -276,7 +277,7 @@ gcloud iam workforce-pools providers create-saml <pool_provider_name> \
 
 Please refer to the GCP [Workforce Identity Federation docs](https://cloud.google.com/iam/docs/configuring-workforce-identity-federation) as a canonical reference.
 
-## Step 2/3. Add workforce pool to Teleport
+### Step 2/3. Add workforce pool to Teleport
 
 After you create a workforce pool and workforce pool provider, you will need to add workforce
 pool provider configuration as a SAML service provider resource in Teleport.
@@ -305,7 +306,7 @@ Save the spec as **pool_provider_name.yaml** file. And create the saml service p
 $ tctl create pool_provider_name.yaml
 ```
 
-## Step 3/3. Create GCP IAM policy
+### Step 3/3. Create GCP IAM policy
 
 This step is similar to Step 3 in the guided configuration flow.
 You will need to create a GCP IAM policy representing the workforce principal.

--- a/docs/pages/identity-governance/integrations/integrations.mdx
+++ b/docs/pages/identity-governance/integrations/integrations.mdx
@@ -6,6 +6,7 @@ tags:
  - identity-governance
  - privileged-access
 enterprise: Identity Governance
+page_type: landing
 ---
 
 You can configure Teleport to sync role-based access control (RBAC) configurations with

--- a/docs/pages/identity-governance/integrations/okta/guided-sso.mdx
+++ b/docs/pages/identity-governance/integrations/okta/guided-sso.mdx
@@ -8,21 +8,22 @@ tags:
  - identity-governance
  - privileged-access
 enterprise: Identity Governance
+page_type: how-to
 ---
 
-{/* lint disable page-structure remark-lint */}
-
 The Teleport Okta SSO integration allows Teleport users to authenticate using
-Okta as an identity provider. The guided enrollment flow for the Okta
-SSO integration is part of the [guided Okta integration](./okta.mdx). This
-guide is a companion to the guided Okta SSO integration, showing you how to
-perform required actions within Okta.
+Okta as an identity provider. The guided enrollment flow for the Okta SSO
+integration is part of the [guided Okta integration](./okta.mdx). In this guide,
+you will complete setup steps for the guided Okta SSO integration that you must
+perform within Okta.
 
 If you do not plan to enroll additional components of the guided Okta
 integration, you can set up only the Okta SSO integration - called an
 authentication connector - by following [Authentication With Okta as an SSO
 Provider](../../../zero-trust-access/sso/integrate-idp/okta.mdx).
- 
+
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise"!)

--- a/docs/pages/installation/agents/add-service-to-agent.mdx
+++ b/docs/pages/installation/agents/add-service-to-agent.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 A single Teleport Agent can run multiple services. This guide shows you how to

--- a/docs/pages/installation/agents/argocd-helm.mdx
+++ b/docs/pages/installation/agents/argocd-helm.mdx
@@ -6,11 +6,12 @@ tags:
  - ci-cd
  - platform-wide
  - how-to
+page_type: how-to
 ---
 
-Teleport can provide secure, unified access to your Kubernetes clusters. This
-guide will show you how to deploy Teleport Kubernetes agent on a Kubernetes cluster using Helm
-and ArgoCD.
+Teleport can provide secure, unified access to your Kubernetes clusters. In this
+guide, you will deploy Teleport Kubernetes agent on a Kubernetes cluster using
+Helm and ArgoCD.
 
 ## How it works
 

--- a/docs/pages/installation/agents/bound-keypair-static-keys.mdx
+++ b/docs/pages/installation/agents/bound-keypair-static-keys.mdx
@@ -6,9 +6,10 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
-This guide explains how to use the **Bound Keypair join method** to configure
+In this guide, you will use the **Bound Keypair join method** to configure
 Teleport processes to join your Teleport cluster.
 
 The Bound Keypair join method supports two modes of operation for Teleport

--- a/docs/pages/installation/installation.mdx
+++ b/docs/pages/installation/installation.mdx
@@ -1,6 +1,7 @@
 ---
 title: Install Teleport
 description: Provides guidance on installing Teleport cluster components.
+page_type: landing
 ---
 
 The guides in this section show you how to install Teleport on your system. As

--- a/docs/pages/installation/self-hosted/deployments/aws-starter-cluster-terraform.mdx
+++ b/docs/pages/installation/self-hosted/deployments/aws-starter-cluster-terraform.mdx
@@ -7,10 +7,12 @@ tags:
  - how-to
  - platform-wide
  - aws
+page_type: how-to
 ---
 
-This guide is designed to accompany our [reference starter-cluster Terraform code](https://github.com/gravitational/teleport/tree/branch/v(=teleport.major_version=)/examples/aws/terraform/starter-cluster#teleport-terraform-aws-ami-simple-example)
-and describe how to manage the resulting Teleport deployment.
+In this guide, you will configure our [reference starter-cluster Terraform
+module](https://github.com/gravitational/teleport/tree/branch/v(=teleport.major_version=)/examples/aws/terraform/starter-cluster#teleport-terraform-aws-ami-simple-example)
+and manage the resulting Teleport deployment.
 
 This module will deploy the following components:
 - One AWS EC2 instance running the Teleport Auth Service, Proxy Service and SSH Service components

--- a/docs/pages/installation/self-hosted/deployments/deployments.mdx
+++ b/docs/pages/installation/self-hosted/deployments/deployments.mdx
@@ -4,6 +4,7 @@ description: Teleport Installation and Configuration Reference Deployment Guides
 template: "no-toc"
 tags:
  - platform-wide
+page_type: landing
 ---
 
 These guides show you how to set up a full self-hosted Teleport deployment on

--- a/docs/pages/installation/self-hosted/helm-deployments/custom.mdx
+++ b/docs/pages/installation/self-hosted/helm-deployments/custom.mdx
@@ -6,9 +6,10 @@ description: Install and configure a Teleport cluster with a custom configuratio
 tags:
  - how-to
  - platform-wide
+page_type: how-to
 ---
 
-In this guide, we'll explain how to set up a Teleport cluster in Kubernetes
+In this guide, you will set up a Teleport cluster in Kubernetes
 with custom [`teleport.yaml`](../../../reference/deployment/config.mdx) config file elements
 using Teleport Helm charts.
 

--- a/docs/pages/installation/self-hosted/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/installation/self-hosted/helm-deployments/kubernetes-cluster.mdx
@@ -5,10 +5,11 @@ description: This guide shows you how to deploy Teleport on a Kubernetes cluster
 tags:
  - how-to
  - platform-wide
+page_type: how-to
 ---
 
 Teleport can provide secure, unified access to your Kubernetes clusters. This
-guide will show you how to deploy Teleport on a Kubernetes cluster using Helm.
+guide shows you how to deploy Teleport on a Kubernetes cluster using Helm.
 
 ## How it works
 

--- a/docs/pages/installation/self-hosted/private-keys/gcp-kms.mdx
+++ b/docs/pages/installation/self-hosted/private-keys/gcp-kms.mdx
@@ -6,11 +6,12 @@ tags:
  - how-to
  - platform-wide
  - google-cloud
+page_type: how-to
 ---
 
-This guide will show you how to set up your Teleport Cluster to use the Google
-Cloud Key Management Service (KMS) to store and handle the CA private key
-material used to sign all certificates issued by your Teleport cluster.
+In this guide, you will set up your Teleport cluster to use the Google Cloud Key
+Management Service (KMS) to store and handle the CA private key material used to
+sign all certificates issued by your Teleport cluster.
 
 ## How it works
 

--- a/docs/pages/installation/single-machine/linux.mdx
+++ b/docs/pages/installation/single-machine/linux.mdx
@@ -6,10 +6,11 @@ description: How to install Teleport on Linux using our package repositories, TA
 tags:
 - reference
 - platform-wide
+page_type: conceptual
 ---
 
-This guide explains how to install the `teleport` binary on a single Linux
-machine. 
+This guide describes the methods you can use to install Teleport on a single
+Linux machine. 
 
 If you are starting out with Teleport, we recommend beginning with a [Teleport
 Cloud](https://goteleport.com/signup/) account. From there, the only Teleport

--- a/docs/pages/installation/single-machine/single-machine.mdx
+++ b/docs/pages/installation/single-machine/single-machine.mdx
@@ -6,6 +6,7 @@ videoBanner: fjk29wqXm1A
 tags:
 - reference
 - platform-wide
+page_type: landing
 ---
 
 The guides in this section explain how to install Teleport on a single machine.

--- a/docs/pages/reference/access-controls/access-monitoring-events.mdx
+++ b/docs/pages/reference/access-controls/access-monitoring-events.mdx
@@ -2,11 +2,11 @@
 title: Access Monitoring Event Reference
 sidebar_label: Access Monitoring Events
 description: Provides a comprehensive list of Access Monitoring events, their fields, and their types.
+page_type: reference
 ---
 
-The Access Monitoring event reference includes a list of Access Monitoring
-events that you can query and view in reports, along with examples of `tctl`
-commands you can run to query each event.
+This page lists the Access Monitoring events that you can query and view in
+reports, along with examples of `tctl` commands you can run to query each event.
 
 Access Monitoring tracks a subset of Teleport audit events that are relevant to
 identifying unusual access patterns. To view a comprehensive set of events,

--- a/docs/pages/reference/access-controls/authentication.mdx
+++ b/docs/pages/reference/access-controls/authentication.mdx
@@ -5,10 +5,12 @@ tags:
  - reference
  - zero-trust
  - privileged-access
+page_type: conceptual
 ---
 
 Teleport authenticates users either via the Proxy Service or with an identity
-provider via **authentication connectors**.
+provider via **authentication connectors**. This page describes the available
+authentication connectors you can use with Teleport.
 
 <Admonition type="tip">
 

--- a/docs/pages/reference/access-controls/user-display-names.mdx
+++ b/docs/pages/reference/access-controls/user-display-names.mdx
@@ -5,6 +5,7 @@ keywords: [user,display name,idp,sso,scim]
 tags:
  - reference
  - zero-trust
+page_type: conceptual
 ---
 
 A *display name* is a human-readable name that Teleport derives for a user at
@@ -13,6 +14,8 @@ attributes or a local user's traits.
 Display names are presentation only: the Teleport **username** remains the
 stable identifier and is always shown alongside the display name, so a user is
 never shown by a name alone.
+
+This page describes how Teleport determines which user display name to render.
 
 ## How Teleport derives a display name
 

--- a/docs/pages/reference/architecture/api-architecture.mdx
+++ b/docs/pages/reference/architecture/api-architecture.mdx
@@ -5,6 +5,7 @@ description: Architectural overview of the Teleport gRPC API.
 tags:
  - conceptual
  - platform-wide
+page_type: conceptual
 ---
 
 This guide describes the architecture of the Teleport gRPC API, which enables

--- a/docs/pages/reference/architecture/authorization.mdx
+++ b/docs/pages/reference/architecture/authorization.mdx
@@ -6,6 +6,7 @@ tags:
  - conceptual
  - platform-wide
  - privileged-access
+page_type: conceptual
 ---
 
 Teleport handles both authentication and authorization.
@@ -13,7 +14,8 @@ Teleport handles both authentication and authorization.
 - Authentication is about proving the identity of a user or a service.
 - Authorization is about proving access rights to something.
 
-This article explains authorization of users and services with RBAC.
+This page describes how authorization works for users and services with Teleport
+RBAC.
 
 ## Users and Roles
 

--- a/docs/pages/reference/architecture/proxy.mdx
+++ b/docs/pages/reference/architecture/proxy.mdx
@@ -5,7 +5,10 @@ description: Architecture of Teleport's identity-aware proxy service
 tags:
  - conceptual
  - platform-wide
+page_type: conceptual
 ---
+
+This page describes the architecture of the Teleport Proxy Service.
 
 The Teleport Proxy Service is an identity-aware proxy with a web UI. The Teleport Proxy Service 
 provides the following key features:

--- a/docs/pages/reference/architecture/relay.mdx
+++ b/docs/pages/reference/architecture/relay.mdx
@@ -5,7 +5,11 @@ description: Architecture of Teleport's Relay service
 tags:
  - conceptual
  - platform-wide
+page_type: conceptual
 ---
+
+This page describes the architecture and configuration of the Teleport Relay
+Service.
 
 <Admonition type="info">
 

--- a/docs/pages/reference/cli/cli.mdx
+++ b/docs/pages/reference/cli/cli.mdx
@@ -5,6 +5,7 @@ description: Detailed guide and reference documentation for Teleport's command l
 tags:
  - reference
  - platform-wide
+page_type: landing
 ---
 
 Teleport is made up of six CLI tools.

--- a/docs/pages/reference/deployment/backends.mdx
+++ b/docs/pages/reference/deployment/backends.mdx
@@ -4,7 +4,11 @@ description: How to configure Teleport deployment for high-availability using st
 tags:
  - conceptual
  - platform-wide
+page_type: conceptual
 ---
+
+This page describes the data that a Teleport cluster stores on its backends and
+different options you can configure for Teleport storage backends.
 
 A Teleport cluster stores different types of data in different locations. By
 default everything is stored in a local directory on the Auth Service host.

--- a/docs/pages/reference/deployment/identity-security-config.mdx
+++ b/docs/pages/reference/deployment/identity-security-config.mdx
@@ -5,11 +5,14 @@ description: The detailed guide and reference documentation for configuring Tele
 keywords: [config, file, reference, yaml, etc]
 tags:
  - identity-security
+page_type: reference
 ---
 
 Teleport Identity Security uses the YAML file format for configuration. A full configuration
 reference file is shown below. This provides comments and all available options
 for `identity-security.yaml`.
+
+This page lists the configuration fields for Teleport Identity Security.
 
 ## Before using this reference
 

--- a/docs/pages/reference/deployment/monitoring/event-handler.mdx
+++ b/docs/pages/reference/deployment/monitoring/event-handler.mdx
@@ -10,6 +10,7 @@ keywords:
 tags:
   - reference
   - audit
+page_type: reference
 ---
 
 The **Event Handler** plugin exports Teleport audit events to a Fluentd
@@ -17,6 +18,9 @@ service. The plugin retrieves events in configurable batches, forwards each
 event to Fluentd over mTLS, and persists the ID of each successfully sent event
 to local storage. If the plugin crashes or restarts, it resumes from the last
 confirmed event. By default, the plugin polls for new events every 10 seconds.
+
+This page lists the configuration fields for the Teleport Event Handler and
+provides instructions for generating credentials for mTLS with Fluentd.
 
 To learn more about exporting Teleport audit events with the Event Handler,
 see the [Audit Event Export guides

--- a/docs/pages/reference/deployment/monitoring/metrics.mdx
+++ b/docs/pages/reference/deployment/monitoring/metrics.mdx
@@ -4,7 +4,11 @@ description: Comprehensive list of all metrics exposed by Teleport.
 tags:
  - reference
  - platform-wide
+page_type: reference
 ---
+
+This page lists the metrics that are available for monitoring your Teleport
+cluster.
 
 <Admonition scope={["cloud"]} type="tip">
 

--- a/docs/pages/reference/deployment/monitoring/tracing-service-configuration.mdx
+++ b/docs/pages/reference/deployment/monitoring/tracing-service-configuration.mdx
@@ -4,9 +4,10 @@ description: Configuration reference for Distributed Tracing.
 tags:
  - reference
  - platform-wide
+page_type: reference
 ---
 
-This guide lays out the configuration fields that are related to distributed
+This guide lists the configuration fields that are related to distributed
 tracing in Teleport. You can find these fields in the Teleport configuration
 file, which is `teleport.yaml` by default:
 

--- a/docs/pages/reference/helm-reference/helm-reference.mdx
+++ b/docs/pages/reference/helm-reference/helm-reference.mdx
@@ -5,6 +5,7 @@ description: Comprehensive lists of configuration values in Teleport's Helm char
 template: "no-toc"
 tags:
  - platform-wide
+page_type: landing
 ---
 
 - [teleport-cluster](teleport-cluster.mdx): Deploy the

--- a/docs/pages/reference/helm-reference/teleport-plugin-email.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-email.mdx
@@ -7,13 +7,14 @@ tags:
  - reference
  - zero-trust
  - privileged-access
+page_type: reference
 ---
 
 The `teleport-plugin-email` Helm chart is used to configure the email Teleport plugin, which allows users to receive Access Requests via emails.
 
 You can [browse the source on GitHub](https://github.com/gravitational/teleport/tree/v(=teleport.version=)/examples/chart/access/email).
 
-This reference details available values for the `teleport-plugin-email` chart.
+This page lists the available values for the `teleport-plugin-email` chart.
 
 (!docs/pages/includes/backup-warning.mdx!)
 

--- a/docs/pages/reference/machine-workload-identity/bound-keypair/getting-started.mdx
+++ b/docs/pages/reference/machine-workload-identity/bound-keypair/getting-started.mdx
@@ -5,6 +5,7 @@ tags:
  - mwi
  - how-to
  - infrastructure-identity
+page_type: how-to
 ---
 
 In this guide, you will install Machine & Workload Identity's agent, `tbot`, on

--- a/docs/pages/reference/machine-workload-identity/telemetry.mdx
+++ b/docs/pages/reference/machine-workload-identity/telemetry.mdx
@@ -4,9 +4,10 @@ description: An explanation of the telemetry collected by Machine & Workload Ide
 tags:
  - conceptual
  - mwi
+page_type: conceptual
 ---
 
-This document explains what telemetry is collected by the `tbot` agent, why we
+This page describes what telemetry is collected by the `tbot` agent, why we
 want to collect this telemetry and, how to opt in or out.
 
 ## Why?

--- a/docs/pages/reference/public-certificates.mdx
+++ b/docs/pages/reference/public-certificates.mdx
@@ -1,11 +1,13 @@
 ---
 title: "Public Certificates & Encryption Keys"
 description: "Provides certificates and public keys used to sign Teleport software."
+page_type: reference
 ---
 
-We use the following certificates and public keys to sign our software. Many of
-these keys and certificates use our legal business name Gravitational, Inc. and
-our former domain gravitational.com. Don’t worry – [Gravitational is
+This page lists the certificates and public keys the Teleport team uses to sign
+our software. Many of these keys and certificates use our legal business name
+Gravitational, Inc. and our former domain gravitational.com. Don’t worry –
+[Gravitational is
 Teleport](https://goteleport.com/blog/gravitational-is-teleport/).
 
 ## APT, YUM, & Zypper signing keys

--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -4,6 +4,7 @@ description: Provides a detailed breakdown of Teleport usage reporting.
 tags:
  - conceptual
  - platform-wide
+page_type: conceptual
 ---
 
 Commercial editions of Teleport send anonymized usage data to Teleport so we can

--- a/docs/pages/zero-trust-access/export-audit-events/splunk.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/splunk.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - audit
+page_type: how-to
 ---
 
 Teleport's Event Handler plugin receives audit events from the Teleport Auth
@@ -13,8 +14,8 @@ Service and forwards them to your log management solution, letting you perform
 historical analysis, detect unusual behavior, and form a better understanding of
 how users interact with your Teleport cluster.
 
-In this guide, we will show you how to configure the Teleport Event Handler
-plugin to send your Teleport audit events to Splunk. 
+In this guide, you will configure the Teleport Event Handler plugin to send your
+Teleport audit events to Splunk. 
 
 ## How it works
 

--- a/docs/pages/zero-trust-access/management/breakglass-access.mdx
+++ b/docs/pages/zero-trust-access/management/breakglass-access.mdx
@@ -2,9 +2,10 @@
 title: Configuring Break-Glass SSH Access for Disaster Recovery
 sidebar_label: Break-Glass Access
 description: Guide to set up break-glass emergency SSH access for critical systems if Teleport becomes unavailable.
+page_type: how-to
 ---
 
-This guide will walk you through the steps required to configure emergency "break-glass" access for critical agents and servers via OpenSSH
+In this guide, you will configure emergency "break-glass" access for critical agents and servers via OpenSSH
 using Teleport-issued certificates, in the following scenarios:
 
 1. The Teleport Agent on a server has crashed, gone offline, or become unusable.

--- a/docs/pages/zero-trust-access/management/diagnostics/datadog.mdx
+++ b/docs/pages/zero-trust-access/management/diagnostics/datadog.mdx
@@ -4,7 +4,10 @@ description: How to export Teleport metrics and logs to Datadog
 tags:
  - conceptual
  - platform-wide
+page_type: conceptual
 ---
+
+This page describes the Teleport Datadog integration.
 
 Datadog has an [officially maintained integration](https://docs.datadoghq.com/integrations/teleport/) for Teleport.
 

--- a/docs/pages/zero-trust-access/management/diagnostics/metrics.mdx
+++ b/docs/pages/zero-trust-access/management/diagnostics/metrics.mdx
@@ -5,9 +5,10 @@ description: Describes important metrics to monitor if you are self-hosting Tele
 tags:
  - conceptual
  - platform-wide
+page_type: conceptual
 ---
 
-This guide explains the metrics you should use to get started monitoring your
+This guide describes the metrics you should use to get started monitoring your
 self-hosted Teleport cluster, focusing on metrics reported by the Auth Service
 and Proxy Service. If you use Teleport Enterprise (Cloud), the Teleport team
 monitors and responds to these metrics for you.

--- a/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
@@ -6,12 +6,16 @@ tags:
  - platform-wide
  - resiliency
 enterprise: Certificate Authority Overrides
+page_type: how-to
 ---
 
 Certificate Authority Overrides let a cluster administrator override a
 self-signed Teleport CA certificate with a certificate signed by an external
 certificate authority. In practice, that Teleport CA becomes a subordinate CA in
 an external trust chain.
+
+In this guide, you will complete a Certificate Authority Override in your
+Teleport cluster.
 
 <Admonition type="info">
 Certificate Authority Overrides are currently in active development. The

--- a/docs/pages/zero-trust-access/management/workload-clusters.mdx
+++ b/docs/pages/zero-trust-access/management/workload-clusters.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - mwi
  - infrastructure-identity
+page_type: how-to
 ---
 
 `workload_cluster` resources can be used to automatically provision and
@@ -14,7 +15,7 @@ Teleport Cloud also creates a Bot, token, and role in the provisioned Teleport
 Cloud cluster so that automation can create, read, and update users and roles
 in that cluster.
 
-This guide covers how to:
+In this guide, you will:
 
 - Create a `workload_cluster` resource in a parent Teleport Cloud cluster.
 - Wait for the child Teleport Cloud cluster to become active.

--- a/docs/pages/zero-trust-access/zero-trust-access.mdx
+++ b/docs/pages/zero-trust-access/zero-trust-access.mdx
@@ -2,6 +2,7 @@
 title: Teleport Zero Trust Access
 description: Provides guides for the Teleport Zero Trust Access product.
 template: "landing-page"
+page_type: landing
 ---
 
 import LandingHero, { LandingHeroProps } from '@site/src/components/Pages/Landing/LandingHero';


### PR DESCRIPTION
The docs are moving towards expecting a standard set of outcome statements. This allows us to ensure that each page includes a succinct summary of its purpose for human and agent readers, depending on the type of page, without requiring the reader to traverse more of the document than necessary.

Add the page_type frontmatter field, which is used to enforce standards for different types of pages. Ensure each page includes a compliant outcome statement.