### PR TITLE
Add property based testing for encode and decode cluster name utils

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -31,6 +31,7 @@ require (
 	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v2 v2.4.0
+	pgregory.net/rapid v1.3.0
 )
 
 require (

--- a/api/go.sum
+++ b/api/go.sum
@@ -142,3 +142,5 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
+pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=

--- a/api/utils/cluster_property_test.go
+++ b/api/utils/cluster_property_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"regexp"
+    "strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+
+	"github.com/gravitational/teleport/api/constants"
+)
+
+func TestProperty_ClusterNameRoundTrip(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		name := string(rapid.SliceOf(rapid.Byte()).Draw(t, "clusterName"))
+		decoded, err := DecodeClusterName(EncodeClusterName(name))
+		require.NoError(t, err)
+		require.Equal(t, name, decoded)
+	})
+}
+
+func TestProperty_DecodeClusterName_NeverPanics(t *testing.T) {
+	const suffix = "." + constants.APIDomain
+
+	serverNameGen := rapid.OneOf(
+		rapid.String(),
+		rapid.Map(rapid.String(), func(s string) string { return s + suffix }),
+		rapid.StringMatching(`[0-9a-fA-F]{0,65}`+regexp.QuoteMeta(suffix)),
+		rapid.Map(rapid.String(), EncodeClusterName),
+		rapid.Just(constants.APIDomain),
+	)
+
+	rapid.Check(t, func(t *rapid.T) {
+		_, _ = DecodeClusterName(serverNameGen.Draw(t, "serverName"))
+	})
+}
+
+func TestProperty_EncodeClusterName_OutputIsHexPlusSuffix(t *testing.T) {
+    const suffix = "." + constants.APIDomain
+    hexRegex := regexp.MustCompile(`^[0-9a-f]*$`)
+
+    rapid.Check(t, func(t *rapid.T) {
+        name := string(rapid.SliceOf(rapid.Byte()).Draw(t, "clusterName"))
+        encoded := EncodeClusterName(name)
+        subdomain, ok := strings.CutSuffix(encoded, suffix)
+        require.True(t, ok, "expected %q to end with %q", encoded, suffix)
+        require.Regexp(t, hexRegex, subdomain)
+    })
+}
+
+func TestProperty_EncodeClusterName_OutputIsCorrectLength(t *testing.T) {
+    const suffix = "." + constants.APIDomain
+
+    rapid.Check(t, func(t *rapid.T) {
+        name := string(rapid.SliceOf(rapid.Byte()).Draw(t, "clusterName"))
+        encoded := EncodeClusterName(name)
+        require.Len(t, encoded, 2*len(name) + len(suffix))
+    })
+}

--- a/api/utils/cluster_property_test.go
+++ b/api/utils/cluster_property_test.go
@@ -16,7 +16,7 @@ package utils
 
 import (
 	"regexp"
-    "strings"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -51,24 +51,24 @@ func TestProperty_DecodeClusterName_NeverPanics(t *testing.T) {
 }
 
 func TestProperty_EncodeClusterName_OutputIsHexPlusSuffix(t *testing.T) {
-    const suffix = "." + constants.APIDomain
-    hexRegex := regexp.MustCompile(`^[0-9a-f]*$`)
+	const suffix = "." + constants.APIDomain
+	hexRegex := regexp.MustCompile(`^[0-9a-f]*$`)
 
-    rapid.Check(t, func(t *rapid.T) {
-        name := string(rapid.SliceOf(rapid.Byte()).Draw(t, "clusterName"))
-        encoded := EncodeClusterName(name)
-        subdomain, ok := strings.CutSuffix(encoded, suffix)
-        require.True(t, ok, "expected %q to end with %q", encoded, suffix)
-        require.Regexp(t, hexRegex, subdomain)
-    })
+	rapid.Check(t, func(t *rapid.T) {
+		name := string(rapid.SliceOf(rapid.Byte()).Draw(t, "clusterName"))
+		encoded := EncodeClusterName(name)
+		subdomain, ok := strings.CutSuffix(encoded, suffix)
+		require.True(t, ok, "expected %q to end with %q", encoded, suffix)
+		require.Regexp(t, hexRegex, subdomain)
+	})
 }
 
 func TestProperty_EncodeClusterName_OutputIsCorrectLength(t *testing.T) {
-    const suffix = "." + constants.APIDomain
+	const suffix = "." + constants.APIDomain
 
-    rapid.Check(t, func(t *rapid.T) {
-        name := string(rapid.SliceOf(rapid.Byte()).Draw(t, "clusterName"))
-        encoded := EncodeClusterName(name)
-        require.Len(t, encoded, 2*len(name) + len(suffix))
-    })
+	rapid.Check(t, func(t *rapid.T) {
+		name := string(rapid.SliceOf(rapid.Byte()).Draw(t, "clusterName"))
+		encoded := EncodeClusterName(name)
+		require.Len(t, encoded, 2*len(name)+len(suffix))
+	})
 }


### PR DESCRIPTION
Adds a round-trip property test, as well as testing that the shape of the output of encode is hex plus the expected suffix, and that the length of the encoded output is 2x the cluster name length plus the length of the suffix
