### PR TITLE
[vnet] Increase tun mtu to 16 KiB

### DIFF
--- a/lib/vnet/admin_process_unix.go
+++ b/lib/vnet/admin_process_unix.go
@@ -120,7 +120,7 @@ func runUnixAdminProcess(ctx context.Context, clt *clientApplicationServiceClien
 
 func createTUNDevice(ctx context.Context, interfaceName string) (tun.Device, string, error) {
 	log.DebugContext(ctx, "Creating TUN device.")
-	dev, err := tun.CreateTUN(interfaceName, mtu)
+	dev, err := tun.CreateTUN(interfaceName, vnetTUNMTU)
 	if err != nil {
 		return nil, "", trace.Wrap(err, "creating TUN device")
 	}

--- a/lib/vnet/admin_process_unix.go
+++ b/lib/vnet/admin_process_unix.go
@@ -120,7 +120,7 @@ func runUnixAdminProcess(ctx context.Context, clt *clientApplicationServiceClien
 
 func createTUNDevice(ctx context.Context, interfaceName string) (tun.Device, string, error) {
 	log.DebugContext(ctx, "Creating TUN device.")
-	dev, err := tun.CreateTUN(interfaceName, vnetTUNMTU)
+	dev, err := tun.CreateTUN(interfaceName, tunMTU(ctx))
 	if err != nil {
 		return nil, "", trace.Wrap(err, "creating TUN device")
 	}

--- a/lib/vnet/admin_process_windows.go
+++ b/lib/vnet/admin_process_windows.go
@@ -33,6 +33,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/windows"
 	"golang.zx2c4.com/wireguard/tun"
+	"golang.zx2c4.com/wireguard/windows/tunnel/winipcfg"
 
 	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
 )
@@ -89,16 +90,33 @@ func runWindowsAdminProcess(ctx context.Context, cfg *windowsAdminProcessConfig)
 		return trace.Wrap(err, "authenticating user process")
 	}
 
-	device, err := tun.CreateTUN(tunInterfaceName, mtu)
+	// wireguard-go's Windows TUN implementation only stores and reports this MTU;
+	// it does not configure the Windows IP interfaces. Configure the MTU for each
+	// enabled address family separately below.
+	device, err := tun.CreateTUN(tunInterfaceName, vnetTUNMTU)
 	if err != nil {
 		return trace.Wrap(err, "creating TUN device")
 	}
 	defer device.Close()
+	nativeTUN, ok := device.(*tun.NativeTun)
+	if !ok {
+		return trace.BadParameter("unexpected Windows TUN device type %T", device)
+	}
+	ipv6Disabled, err := hostIPv6Disabled(tunInterfaceName)
+	if err != nil {
+		// Could not determine, assume IPv6 is enabled. If it is actually
+		// disabled, setting the IPv6 interface MTU will surface the error.
+		log.WarnContext(ctx, "Failed to check whether IPv6 is disabled while configuring the TUN device, assuming IPv6 is enabled.",
+			"error", err)
+	}
+	if err := setWindowsTUNDeviceMTU(nativeTUN, vnetTUNMTU, ipv6Disabled); err != nil {
+		return trace.Wrap(err, "setting TUN device MTU")
+	}
 	tunName, err := device.Name()
 	if err != nil {
 		return trace.Wrap(err, "getting TUN device name")
 	}
-	log.InfoContext(ctx, "Created TUN interface", "tun", tunName)
+	log.InfoContext(ctx, "Created TUN interface", "tun", tunName, "mtu", vnetTUNMTU)
 
 	networkStackConfig, err := newNetworkStackConfig(ctx, device, clt)
 	if err != nil {
@@ -155,6 +173,29 @@ func runWindowsAdminProcess(ctx context.Context, cfg *windowsAdminProcessConfig)
 		}
 	})
 	return trace.Wrap(g.Wait(), "running VNet admin process")
+}
+
+func setWindowsTUNDeviceMTU(device *tun.NativeTun, mtu int, ipv6Disabled bool) error {
+	luid := winipcfg.LUID(device.LUID())
+	if luid == 0 {
+		return trace.NotFound("TUN interface LUID is unavailable")
+	}
+
+	families := []winipcfg.AddressFamily{windows.AF_INET}
+	if !ipv6Disabled {
+		families = append(families, windows.AF_INET6)
+	}
+	for _, family := range families {
+		row, err := luid.IPInterface(family)
+		if err != nil {
+			return trace.Wrap(err, "getting Windows IP interface for address family %d", family)
+		}
+		row.NLMTU = uint32(mtu)
+		if err := row.Set(); err != nil {
+			return trace.Wrap(err, "setting Windows IP interface MTU for address family %d", family)
+		}
+	}
+	return nil
 }
 
 func authenticateUserProcess(ctx context.Context, clt *clientApplicationServiceClient, userSID string) error {

--- a/lib/vnet/admin_process_windows.go
+++ b/lib/vnet/admin_process_windows.go
@@ -93,7 +93,8 @@ func runWindowsAdminProcess(ctx context.Context, cfg *windowsAdminProcessConfig)
 	// wireguard-go's Windows TUN implementation only stores and reports this MTU;
 	// it does not configure the Windows IP interfaces. Configure the MTU for each
 	// enabled address family separately below.
-	device, err := tun.CreateTUN(tunInterfaceName, vnetTUNMTU)
+	mtu := tunMTU(ctx)
+	device, err := tun.CreateTUN(tunInterfaceName, mtu)
 	if err != nil {
 		return trace.Wrap(err, "creating TUN device")
 	}
@@ -109,14 +110,14 @@ func runWindowsAdminProcess(ctx context.Context, cfg *windowsAdminProcessConfig)
 		log.WarnContext(ctx, "Failed to check whether IPv6 is disabled while configuring the TUN device, assuming IPv6 is enabled.",
 			"error", err)
 	}
-	if err := setWindowsTUNDeviceMTU(nativeTUN, vnetTUNMTU, ipv6Disabled); err != nil {
+	if err := setWindowsTUNDeviceMTU(nativeTUN, mtu, ipv6Disabled); err != nil {
 		return trace.Wrap(err, "setting TUN device MTU")
 	}
 	tunName, err := device.Name()
 	if err != nil {
 		return trace.Wrap(err, "getting TUN device name")
 	}
-	log.InfoContext(ctx, "Created TUN interface", "tun", tunName, "mtu", vnetTUNMTU)
+	log.InfoContext(ctx, "Created TUN interface", "tun", tunName, "mtu", mtu)
 
 	networkStackConfig, err := newNetworkStackConfig(ctx, device, clt)
 	if err != nil {

--- a/lib/vnet/fake_host_network.go
+++ b/lib/vnet/fake_host_network.go
@@ -39,7 +39,7 @@ import (
 // for use in tests, backed by the gVisor network stack. Users must call Close on
 // the network to clean up its resources.
 func NewFakeHostNetwork() (*FakeHostNetwork, error) {
-	stack, nic, err := createStack()
+	stack, nic, err := createStack(vnetTUNMTU)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -298,7 +298,7 @@ var errFakeTUNClosed = errors.New("TUN closed")
 // its own allocations to benchmarks.
 var fakeTUNPacketPool = sync.Pool{
 	New: func() any {
-		b := make([]byte, 0, 2048) // a bit above the 1500 MTU so the buffer never needs to grow
+		b := make([]byte, 0, vnetTUNMTU+2*1024) // a bit above vnetTUNMTU so the buffer never needs to grow
 		return &b
 	},
 }
@@ -312,6 +312,10 @@ type fakeTUN struct {
 
 func (f *fakeTUN) Name() (string, error) {
 	return f.name, nil
+}
+
+func (f *fakeTUN) MTU() (int, error) {
+	return vnetTUNMTU, nil
 }
 
 func (f *fakeTUN) BatchSize() int {

--- a/lib/vnet/network_stack.go
+++ b/lib/vnet/network_stack.go
@@ -53,7 +53,7 @@ const (
 	logComponent                     = "vnet"
 	dnsLogComponent                  = "dns"
 	nicID                            = 1
-	mtu                              = 1500
+	vnetTUNMTU                       = 16 * 1024
 	tcpReceiveBufferSize             = 0 // 0 means a default will be used.
 	maxInFlightTCPConnectionAttempts = 1024
 )
@@ -122,6 +122,11 @@ type udpHandler interface {
 type TUNDevice interface {
 	// Name returns the current name of the Device.
 	Name() (string, error)
+
+	// MTU returns the MTU of the Device. The network stack sizes its link
+	// endpoint and packet buffers from this value, so it must not change over
+	// the lifetime of a Device.
+	MTU() (int, error)
 
 	// Write one or more packets to the device (without any additional headers).
 	// On a successful write it returns the number of packets written. A nonzero
@@ -285,7 +290,11 @@ func newNetworkStack(cfg *networkStackConfig) (*networkStack, error) {
 	logger := slog.With(teleport.ComponentKey, logComponent)
 	dnsLogger := slog.With(teleport.ComponentKey, teleport.Component(logComponent, dnsLogComponent))
 
-	stack, linkEndpoint, err := createStack()
+	mtu, err := cfg.tunDevice.MTU()
+	if err != nil {
+		return nil, trace.Wrap(err, "getting TUN device MTU")
+	}
+	stack, linkEndpoint, err := createStack(uint32(mtu))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -349,7 +358,7 @@ func newNetworkStack(cfg *networkStackConfig) (*networkStack, error) {
 	return ns, nil
 }
 
-func createStack() (*stack.Stack, *channel.Endpoint, error) {
+func createStack(mtu uint32) (*stack.Stack, *channel.Endpoint, error) {
 	netStack := stack.New(stack.Options{
 		NetworkProtocols:   []stack.NetworkProtocolFactory{ipv4network.NewProtocol, ipv6network.NewProtocol},
 		TransportProtocols: []stack.TransportProtocolFactory{tcp.NewProtocol, udp.NewProtocol},
@@ -742,6 +751,10 @@ func forwardBetweenTunAndNetstack(ctx context.Context, tun TUNDevice, linkEndpoi
 }
 
 func forwardNetstackToTUN(ctx context.Context, linkEndpoint *channel.Endpoint, tun TUNDevice) error {
+	mtu, err := tun.MTU()
+	if err != nil {
+		return trace.Wrap(err, "getting TUN device MTU")
+	}
 	bufs := [][]byte{make([]byte, device.MessageTransportHeaderSize+mtu)}
 	for {
 		packet := linkEndpoint.ReadContext(ctx)
@@ -773,6 +786,10 @@ func forwardNetstackToTUN(ctx context.Context, linkEndpoint *channel.Endpoint, t
 // returning os.ErrClosed from tun.Read.
 func forwardTUNtoNetstack(ctx context.Context, tun TUNDevice, linkEndpoint *channel.Endpoint) error {
 	const readOffset = device.MessageTransportHeaderSize
+	mtu, err := tun.MTU()
+	if err != nil {
+		return trace.Wrap(err, "getting TUN device MTU")
+	}
 	bufs := make([][]byte, tun.BatchSize())
 	for i := range bufs {
 		bufs[i] = make([]byte, device.MessageTransportHeaderSize+mtu)

--- a/lib/vnet/network_stack.go
+++ b/lib/vnet/network_stack.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"net/netip"
 	"os"
+	"strconv"
 	"sync"
 	"sync/atomic"
 
@@ -50,13 +51,41 @@ import (
 var log = logutils.NewPackageLogger(teleport.ComponentKey, logComponent)
 
 const (
-	logComponent                     = "vnet"
-	dnsLogComponent                  = "dns"
-	nicID                            = 1
-	vnetTUNMTU                       = 16 * 1024
+	logComponent    = "vnet"
+	dnsLogComponent = "dns"
+	nicID           = 1
+	// vnetTUNMTU is the default MTU for the TUN device. It can be overridden
+	// with the TELEPORT_UNSTABLE_VNET_TUN_MTU environment variable.
+	vnetTUNMTU = 16 * 1024
+	// vnetTUNMTUEnvVar overrides the default TUN device MTU. It must be set in
+	// the environment of the VNet admin process.
+	vnetTUNMTUEnvVar = "TELEPORT_UNSTABLE_VNET_TUN_MTU"
+	// minTUNMTU is the lowest accepted MTU override, chosen because IPv6
+	// requires a minimum link MTU of 1280 bytes (RFC 8200).
+	minTUNMTU = 1280
+	// maxTUNMTU is the largest possible IP packet size, the 16-bit total
+	// length field limit shared by IPv4 (RFC 791) and IPv6 (RFC 8200).
+	maxTUNMTU                        = 65535
 	tcpReceiveBufferSize             = 0 // 0 means a default will be used.
 	maxInFlightTCPConnectionAttempts = 1024
 )
+
+// tunMTU returns the MTU to use for the TUN device.
+func tunMTU(ctx context.Context) int {
+	env := os.Getenv(vnetTUNMTUEnvVar)
+	if env == "" {
+		return vnetTUNMTU
+	}
+	mtu, err := strconv.Atoi(env)
+	if err != nil || mtu < minTUNMTU || mtu > maxTUNMTU {
+		log.WarnContext(ctx, "Ignoring invalid TUN MTU override.",
+			"env_var", vnetTUNMTUEnvVar, "value", env, "min", minTUNMTU, "max", maxTUNMTU)
+		return vnetTUNMTU
+	}
+	log.InfoContext(ctx, "Using TUN MTU override from environment.",
+		"env_var", vnetTUNMTUEnvVar, "mtu", mtu)
+	return mtu
+}
 
 // networkStackConfig holds configuration parameters for the VNet network stack.
 type networkStackConfig struct {

--- a/lib/vnet/network_stack_test.go
+++ b/lib/vnet/network_stack_test.go
@@ -106,3 +106,27 @@ func TestResolveAAAADiagProbeCaseInsensitive(t *testing.T) {
 	}
 	require.Empty(t, ns.state.assignedIPs)
 }
+
+// TestTunMTU verifies that the TELEPORT_UNSTABLE_VNET_TUN_MTU override is
+// applied when valid and ignored otherwise.
+func TestTunMTU(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		env  string
+		want int
+	}{
+		{name: "unset", env: "", want: vnetTUNMTU},
+		{name: "valid override", env: "1500", want: 1500},
+		{name: "not a number", env: "16k", want: vnetTUNMTU},
+		{name: "below IPv6 minimum", env: "1279", want: vnetTUNMTU},
+		{name: "at minimum", env: "1280", want: 1280},
+		{name: "at maximum", env: "65535", want: 65535},
+		{name: "above maximum", env: "65536", want: vnetTUNMTU},
+		{name: "negative", env: "-1500", want: vnetTUNMTU},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(vnetTUNMTUEnvVar, tc.env)
+			require.Equal(t, tc.want, tunMTU(t.Context()))
+		})
+	}
+}

--- a/lib/vnet/vnet_bench_test.go
+++ b/lib/vnet/vnet_bench_test.go
@@ -36,11 +36,11 @@ import (
 // goarch: arm64
 // pkg: github.com/gravitational/teleport/lib/vnet
 // cpu: Apple M4 Pro
-// BenchmarkNetstackThroughput/smallChunks-14                 27142             46054 ns/op                64.08 allocs/KiB            1291 B/op         32 allocs/op
-// BenchmarkNetstackThroughput/mediumChunks-14                18118             65857 ns/op                14.67 allocs/KiB            2234 B/op         58 allocs/op
-// BenchmarkNetstackThroughput/largeChunks-14                   288           4143273 ns/op                 8.790 allocs/KiB         390954 B/op       9001 allocs/op
+// BenchmarkNetstackThroughput/smallChunks-14                 24586             45680 ns/op                64.08 allocs/KiB            1305 B/op         32 allocs/op
+// BenchmarkNetstackThroughput/mediumChunks-14                24510             48722 ns/op                 8.009 allocs/KiB           1315 B/op         32 allocs/op
+// BenchmarkNetstackThroughput/largeChunks-14                  1003           1159479 ns/op                 1.844 allocs/KiB          81370 B/op       1888 allocs/op
 // PASS
-// ok      github.com/gravitational/teleport/lib/vnet      4.967s
+// ok      github.com/gravitational/teleport/lib/vnet      4.802s
 func BenchmarkNetstackThroughput(b *testing.B) {
 	utils.InitLogger(utils.LoggingForCLI, slog.LevelError)
 	b.Cleanup(func() { utils.InitLogger(utils.LoggingForCLI, slog.LevelDebug) })


### PR DESCRIPTION
Changelog: Improved VNet throughput by increasing the TUN MTU to 16 KiB.

VNet's TUN device used a 1500-byte MTU (the standard default for physical ethernet). But the TUN link is virtual, VNet terminates the application's TCP connection in its gVisor network stack and forwards the byte stream over a separate connection to the Teleport proxy

`application -> TUN -> gVisor network stack-> teleport proxy connection`

The proxy connection still uses the MTU of the real network path, so raising the TUN MTU is safe.

This PR increases the TUN MTU to 16 KiB and sizes the gVisor link endpoint and forwarding buffers from the MTU reported by the TUN device. On macOS and Linux wireguard-go applies the requested MTU to the interface directly, so nothing else is needed. On Windows it only stores and reports the value, so VNet also configures the IPv4 and IPv6 interface MTUs.

### Choosing 16 KiB

I tested several MTU values with iperf3 on a local Apple M4 Pro Mac, a local Teleport cluster with the iperf3 server registered as a TCP app, and the client connecting through VNet. Everything runs on one machine, so this basically measures bulk data transfer over the VNet itself.

| TUN MTU | `-R`, server to client | `--bidir`, client to server | `--bidir`, server to client |
|---:|---:|---:|---:|
| 1,500 B | 3.09 Gbit/s | 0.35 Gbit/s | 3.01 Gbit/s |
| 9 KiB | 6.23 Gbit/s | 3.40 Gbit/s | 3.06 Gbit/s |
| 16 KiB | 6.28 Gbit/s | 4.78 Gbit/s | 3.14 Gbit/s |
| 32 KiB | 6.40 Gbit/s | 4.76 Gbit/s | 3.15 Gbit/s |
| 65,535 B | 6.41 Gbit/s | 4.76 Gbit/s | 3.13 Gbit/s |

I stopped at 16 KiB because throughput saturates at that point

### Benchmark

I also updated the results for the network stack benchmark. smallChunks isn't affected because 512-byte chunks already fit into the previous 1500-byte MTU, larger chunks now show less time and fewer allocations per op.


```
goos: darwin
goarch: arm64
pkg: github.com/gravitational/teleport/lib/vnet
cpu: Apple M4 Pro
                                   │    sec/op    │    sec/op     vs base                 │
NetstackThroughput/smallChunks-14    46.05µ ± ∞ ¹   45.68µ ± ∞ ¹        ~ (p=1.000 n=1) ²
NetstackThroughput/mediumChunks-14   65.86µ ± ∞ ¹   48.72µ ± ∞ ¹        ~ (p=1.000 n=1) ²
NetstackThroughput/largeChunks-14    4.143m ± ∞ ¹   1.159m ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                              232.5µ         137.2µ        -41.00%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                   │  allocs/KiB  │ allocs/KiB   vs base                 │
NetstackThroughput/smallChunks-14     64.08 ± ∞ ¹   64.08 ± ∞ ¹        ~ (p=1.000 n=1) ²
NetstackThroughput/mediumChunks-14   14.670 ± ∞ ¹   8.009 ± ∞ ¹        ~ (p=1.000 n=1) ³
NetstackThroughput/largeChunks-14     8.790 ± ∞ ¹   1.844 ± ∞ ¹        ~ (p=1.000 n=1) ³
geomean                               20.22         9.818        -51.44%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ need >= 4 samples to detect a difference at alpha level 0.05

                                   │      B/op      │     B/op       vs base                 │
NetstackThroughput/smallChunks-14     1.261Ki ± ∞ ¹   1.274Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
NetstackThroughput/mediumChunks-14    2.182Ki ± ∞ ¹   1.284Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
NetstackThroughput/largeChunks-14    381.79Ki ± ∞ ¹   79.46Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                               10.16Ki         5.066Ki        -50.15%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                   │  allocs/op   │  allocs/op    vs base                 │
NetstackThroughput/smallChunks-14     32.00 ± ∞ ¹    32.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
NetstackThroughput/mediumChunks-14    58.00 ± ∞ ¹    32.00 ± ∞ ¹        ~ (p=1.000 n=1) ³
NetstackThroughput/largeChunks-14    9.001k ± ∞ ¹   1.888k ± ∞ ¹        ~ (p=1.000 n=1) ³
geomean                               255.6          124.6        -51.27%
```

## Manual Test Plan
### Test Cases
- [x] macOS: VNet starts, apps are reachable, `ifconfig <utunN>` shows `mtu 16384`.
- [x] Linux: VNet starts, apps are reachable, `ip link show <tun>` shows `mtu 16384`.
- [x] Windows: VNet starts, apps are reachable, `netsh interface ipv4 show subinterfaces`
      and `netsh interface ipv6 show subinterfaces` show `mtu 16384` for the TUN interface.
