### PR TITLE
[v18] OpenAI LLM access

### DIFF
--- a/lib/httplib/compress/compress.go
+++ b/lib/httplib/compress/compress.go
@@ -1,0 +1,137 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package compress provides HTTP middleware for transparently decompressing
+// request bodies based on the Content-Encoding header.
+package compress
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gravitational/trace"
+	"github.com/klauspost/compress/zstd"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+type config struct {
+	writeErrorFunc func(*http.Request, http.ResponseWriter, error)
+}
+
+// Option configures the behavior of [Middleware].
+type Option func(*config)
+
+// WithWriteError sets the function used to write middleware errors to the
+// client, allowing callers to render errors in a protocol-specific format.
+func WithWriteError(f func(*http.Request, http.ResponseWriter, error)) Option {
+	return func(c *config) {
+		c.writeErrorFunc = f
+	}
+}
+
+// Middleware wraps next so that compressed request bodies are transparently
+// decompressed before being served. Requests without a Content-Encoding
+// header pass through untouched.
+// Unsupported encodings are rejected without calling next.
+func Middleware(next http.Handler, opts ...Option) http.Handler {
+	cfg := &config{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	errorFunc := func(r *http.Request, w http.ResponseWriter, err error) {
+		if cfg.writeErrorFunc != nil {
+			cfg.writeErrorFunc(r, w, err)
+			return
+		}
+
+		trace.WriteError(w, err)
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// By definition the encoding header can contain the "chain" of compression,
+		// however we're not supporting them at the moment, so it is safe to
+		// directly assert the encoding.
+		//
+		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Encoding
+		switch encoding := strings.ToLower(strings.TrimSpace(r.Header.Get("Content-Encoding"))); encoding {
+		case "zstd":
+			downstreamReader, err := newZstdReader(
+				// We also need to enforce the limited reader here because the internal
+				// zstd limits apply only to effectively decoded bytes (not actual
+				// bytes read).
+				utils.LimitReader(r.Body, teleport.MaxHTTPRequestSize),
+				r.Body,
+			)
+			if err != nil {
+				errorFunc(r, w, err)
+				return
+			}
+			r.Body = downstreamReader
+			// The body is no longer compressed, and its decompressed size is
+			// unknown, so drop the encoding/length headers to keep the request
+			// consistent for handlers that forward it.
+			r.Header.Del("Content-Encoding")
+			r.Header.Del("Content-Length")
+			r.ContentLength = -1
+		case "":
+			// Default non compressed body, nothing to do here.
+		default:
+			errorFunc(r, w, trace.NotImplemented("encoding format %q not supported, currently only non-compressed or 'zstd' is supported", encoding))
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+type zstdReader struct {
+	decoder *zstd.Decoder
+	closer  io.Closer
+}
+
+// Close implements [io.ReadCloser].
+func (z *zstdReader) Close() error {
+	z.decoder.Close()
+	// Just be sure the original buffer is also closed.
+	return trace.Wrap(z.closer.Close())
+}
+
+// Read implements [io.ReadCloser].
+func (z *zstdReader) Read(p []byte) (n int, err error) {
+	return z.decoder.Read(p)
+}
+
+func newZstdReader(orig io.Reader, closer io.Closer) (io.ReadCloser, error) {
+	dec, err := zstd.NewReader(
+		orig,
+		zstd.WithDecoderLowmem(true),
+		// This setting works more like a limit of how much memory it can hold
+		// while decompressing the requests.
+		zstd.WithDecoderMaxWindow(teleport.MaxHTTPRequestSize),
+		zstd.WithDecoderConcurrency(1),
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &zstdReader{
+		decoder: dec,
+		closer:  closer,
+	}, nil
+}

--- a/lib/httplib/compress/compress_test.go
+++ b/lib/httplib/compress/compress_test.go
@@ -1,0 +1,204 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package compress
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func TestMiddleware(t *testing.T) {
+	const (
+		defaultReply      = "REPLY"
+		defaultStatusCode = http.StatusOK
+	)
+	expectUnchangedResponse := func(tt require.TestingT, i1 any, i2 ...any) {
+		require.NotNil(tt, i1, i2...)
+		rec, _ := i1.(*httptest.ResponseRecorder)
+		res := rec.Result()
+		body, err := io.ReadAll(res.Body)
+		require.NoError(tt, err, i2...)
+		require.Equal(tt, defaultReply, string(body), i2...)
+		require.Equal(tt, defaultStatusCode, res.StatusCode)
+	}
+
+	for name, tc := range map[string]struct {
+		newRequestFunc func() *http.Request
+		writeErrorFunc func(*http.Request, http.ResponseWriter, error)
+		expectRequest  require.ValueAssertionFunc
+		expectResponse require.ValueAssertionFunc
+	}{
+		"compressed request is received decompressed by next handler": {
+			newRequestFunc: func() *http.Request {
+				encoded := zstd.EncodeTo([]byte{}, []byte("non compressed req"))
+				req, _ := http.NewRequest(
+					http.MethodPost,
+					"",
+					bytes.NewReader(encoded),
+				)
+				req.Header.Add("Content-Encoding", "zstd")
+				return req
+			},
+			expectRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.NotNil(tt, i1, i2...)
+				req, _ := i1.(*http.Request)
+				body, err := io.ReadAll(req.Body)
+				require.NoError(tt, err, i2...)
+				require.Equal(tt, []byte("non compressed req"), body, i2...)
+				// Since the body is no longer compressed, the encoding/length
+				// headers must be reset.
+				require.Empty(tt, req.Header.Get("Content-Encoding"), i2...)
+				require.Empty(tt, req.Header.Get("Content-Length"), i2...)
+				require.EqualValues(tt, -1, req.ContentLength, i2...)
+			},
+			expectResponse: expectUnchangedResponse,
+		},
+		"compressed request exceeds max size": {
+			newRequestFunc: func() *http.Request {
+				gen := rand.New(rand.NewPCG(uint64(1), uint64(1)))
+				raw := make([]byte, teleport.MaxHTTPRequestSize+1024*1024)
+				for offset := 0; offset+8 <= len(raw); offset += 8 {
+					binary.LittleEndian.PutUint64(raw[offset:offset+8], gen.Uint64())
+				}
+				req, _ := http.NewRequest(
+					http.MethodPost,
+					"",
+					bytes.NewReader(zstd.EncodeTo([]byte{}, raw)),
+				)
+				req.Header.Add("Content-Encoding", "zstd")
+				return req
+			},
+			expectRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.NotNil(tt, i1, i2...)
+				req, _ := i1.(*http.Request)
+				// Since the compressed version exceeds the size, we expect an
+				// error while reading it.
+				_, err := io.ReadAll(req.Body)
+				require.Error(tt, err, i2...)
+			},
+			// Next handler will still be called, it is where the limit exceeded
+			// error will be raised.
+			expectResponse: expectUnchangedResponse,
+		},
+		"compressed request does not exceed max but decompressed does": {
+			newRequestFunc: func() *http.Request {
+				// Generate a "very compressible" body.
+				gen := "body " + strings.Repeat("a", teleport.MaxHTTPRequestSize)
+				req, _ := http.NewRequest(
+					http.MethodPost,
+					"",
+					bytes.NewReader(zstd.EncodeTo([]byte{}, []byte(gen))),
+				)
+				req.Header.Add("Content-Encoding", "zstd")
+				return req
+			},
+			expectRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.NotNil(tt, i1, i2...)
+				req, _ := i1.(*http.Request)
+				// The full body will still be available on the next handler,
+				// but it should itself force the request limits.
+				_, err := io.ReadAll(utils.LimitReader(req.Body, teleport.MaxHTTPRequestSize))
+				require.Error(tt, err, i2...)
+			},
+			// Next handler will still be called even when the body is empty,
+			// it is up to the handler to gracefully handle this case.
+			expectResponse: expectUnchangedResponse,
+		},
+		"unsupported encoding format": {
+			newRequestFunc: func() *http.Request {
+				req, _ := http.NewRequest(
+					http.MethodPost,
+					"",
+					strings.NewReader("random data"),
+				)
+				req.Header.Add("Content-Encoding", "random")
+				return req
+			},
+			// Next handler won't be called, so we expect no request, and error
+			// message written into the recorder.
+			expectRequest: require.Nil,
+			expectResponse: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.NotNil(tt, i1, i2...)
+				rec, _ := i1.(*httptest.ResponseRecorder)
+				res := rec.Result()
+				body, err := io.ReadAll(res.Body)
+				require.NoError(tt, err, i2...)
+
+				middlewareErr := trace.ReadError(res.StatusCode, body)
+				require.Error(tt, middlewareErr, i2...)
+				require.True(tt, trace.IsNotImplemented(middlewareErr), "expected NotImplementedError but got %T", middlewareErr)
+			},
+		},
+		"custom write error function": {
+			newRequestFunc: func() *http.Request {
+				req, _ := http.NewRequest(
+					http.MethodPost,
+					"",
+					strings.NewReader("random data"),
+				)
+				req.Header.Add("Content-Encoding", "random")
+				return req
+			},
+			writeErrorFunc: func(_ *http.Request, w http.ResponseWriter, err error) {
+				w.WriteHeader(http.StatusInternalServerError)
+				io.WriteString(w, "my custom error")
+			},
+			// Next handler won't be called, so we expect no request, and error
+			// message written into the recorder.
+			expectRequest: require.Nil,
+			expectResponse: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.NotNil(tt, i1, i2...)
+				rec, _ := i1.(*httptest.ResponseRecorder)
+				res := rec.Result()
+				body, err := io.ReadAll(res.Body)
+				require.NoError(tt, err, i2...)
+
+				require.Equal(tt, http.StatusInternalServerError, res.StatusCode, i2...)
+				require.Equal(tt, "my custom error", string(body), i2...)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			writer := httptest.NewRecorder()
+			var (
+				nextReq *http.Request
+			)
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextReq = r
+				w.WriteHeader(defaultStatusCode)
+				io.WriteString(w, defaultReply)
+			})
+
+			Middleware(next, WithWriteError(tc.writeErrorFunc)).ServeHTTP(writer, tc.newRequestFunc())
+			tc.expectRequest(t, nextReq)
+			tc.expectResponse(t, writer)
+		})
+	}
+}

--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -201,7 +201,7 @@ type ConnectionsHandler struct {
 	awsHandler   http.Handler
 	azureHandler http.Handler
 	gcpHandler   http.Handler
-	llmHandler   http.Handler
+	llmHandler   *appllm.Handler
 
 	// authMiddleware allows wrapping connections with identity information.
 	authMiddleware *auth.Middleware

--- a/lib/srv/app/llm/anthropic/anthropic.go
+++ b/lib/srv/app/llm/anthropic/anthropic.go
@@ -89,12 +89,7 @@ func NewRequest(cfg *llmrequest.Config) (*http.Request, llmrequest.RequestInfo, 
 			return nil, info, trace.NotFound("unsupported endpoint")
 		}
 	case types.LLMProviderAWSBedrock:
-		var err error
-		cfg.ProviderURL, err = bedrock.BuildURL(cfg.Logger, cfg.App)
-		if err != nil {
-			return nil, info, trace.Wrap(err)
-		}
-
+		cfg.ProviderURL = bedrock.BuildAnthropicURL(cfg.Logger, cfg.App)
 		switch strings.TrimPrefix(cfg.DownstreamRequest.URL.Path, "/v1") {
 		case "/messages":
 			if cfg.DownstreamRequest.Method != http.MethodPost {

--- a/lib/srv/app/llm/anthropic/anthropic.go
+++ b/lib/srv/app/llm/anthropic/anthropic.go
@@ -37,7 +37,7 @@ import (
 
 // NewRequest creates a new provider request based on the downstream request,
 // and inference endpoint configuration.
-func NewRequest(cfg *llmrequest.Config) (*http.Request, *RequestInfo, error) {
+func NewRequest(cfg *llmrequest.Config) (*http.Request, llmrequest.RequestInfo, error) {
 	var (
 		info            = &RequestInfo{}
 		providerPath    string
@@ -189,7 +189,7 @@ func marshalError(apiErr *errorEnvelope) []byte {
 	enc, err := utils.FastMarshal(apiErr)
 	if err != nil {
 		return []byte(
-			`{"type": "error", "error": {"type": "api_error", "message": "` + llmerrors.ErrUnknown.Error() + `"}}`,
+			`{"type": "error", "error": {"type": "api_error", "message": ` + llmerrors.MarshalMessage(llmerrors.ErrUnknown) + `}}`,
 		)
 	}
 	return enc

--- a/lib/srv/app/llm/anthropic/anthropic.go
+++ b/lib/srv/app/llm/anthropic/anthropic.go
@@ -116,6 +116,9 @@ func NewRequest(cfg *llmrequest.Config) (*http.Request, llmrequest.RequestInfo, 
 	}
 
 	body, err := utils.ReadAtMost(cfg.DownstreamRequest.Body, teleport.MaxHTTPRequestSize)
+	if closeErr := cfg.DownstreamRequest.Body.Close(); closeErr != nil {
+		cfg.Logger.WarnContext(cfg.DownstreamRequest.Context(), "failed to close downstream body", "error", closeErr)
+	}
 	if err != nil {
 		return nil, info, trace.Wrap(err)
 	}

--- a/lib/srv/app/llm/bedrock/bedrock.go
+++ b/lib/srv/app/llm/bedrock/bedrock.go
@@ -98,32 +98,43 @@ func SignRequest(ctx context.Context, opts SignRequestOptions) error {
 	return nil
 }
 
-// BuildURL builds the Bedrock URL address.
-func BuildURL(log *slog.Logger, app types.Application) (*url.URL, error) {
-	format := app.GetLLM().Format
-	region := resolveRegion(context.Background(), log, app)
-	// https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html
-	host := "bedrock-mantle." + region + ".api.aws"
-
-	switch format {
-	case types.LLMFormatAnthropic:
-		// Messages API: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-messages-api.html
-		return &url.URL{
-			Scheme: "https",
-			Host:   host,
-			Path:   "/anthropic/v1",
-		}, nil
-	case types.LLMFormatOpenAI:
-		// Responses API: https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html
-		// Chat completions API: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-chat-completions-mantle.html
-		return &url.URL{
-			Scheme: "https",
-			Host:   host,
-			Path:   "/v1",
-		}, nil
-	default:
-		return nil, trace.BadParameter("format %q not supported on AWS Bedrock", format)
+// BuildAnthropicURL builds the Anthropic-compatible Bedrock URL address.
+//
+// Messages API: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-messages-api.html
+func BuildAnthropicURL(log *slog.Logger, app types.Application) *url.URL {
+	return &url.URL{
+		Scheme: "https",
+		Host:   buildMantleEndpoint(log, app),
+		Path:   "/anthropic/v1",
 	}
+}
+
+// BuildOpenAIURL builds the OpenAI-compatible Bedrock URL address.
+//
+// Responses API: https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html
+// Chat completions API: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-chat-completions-mantle.html
+func BuildOpenAIURL(log *slog.Logger, app types.Application, isResponses bool) *url.URL {
+	if isResponses {
+		return &url.URL{
+			Scheme: "https",
+			Host:   buildMantleEndpoint(log, app),
+			Path:   "/openai/v1",
+		}
+	}
+
+	return &url.URL{
+		Scheme: "https",
+		Host:   buildMantleEndpoint(log, app),
+		Path:   "/v1",
+	}
+}
+
+// buildMantleEndpoint builds Bedrock mantle address.
+//
+// https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html
+func buildMantleEndpoint(log *slog.Logger, app types.Application) string {
+	region := resolveRegion(context.Background(), log, app)
+	return "bedrock-mantle." + region + ".api.aws"
 }
 
 // resolveRegion resolves which AWS region to use.

--- a/lib/srv/app/llm/bedrock/bedrock_test.go
+++ b/lib/srv/app/llm/bedrock/bedrock_test.go
@@ -32,18 +32,16 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 )
 
-func TestBuildURL(t *testing.T) {
+func TestBuildAnthropicURL(t *testing.T) {
 	for name, tc := range map[string]struct {
-		app           types.Application
-		expectedError require.ErrorAssertionFunc
-		expectedURL   require.ValueAssertionFunc
+		app         types.Application
+		expectedURL require.ValueAssertionFunc
 	}{
-		"anthropic format": {
+		"messages": {
 			app: newApp(t, &types.LLM{
 				Format:   types.LLMFormatAnthropic,
 				Provider: types.LLMProviderAWSBedrock,
 			}, &types.AppAWS{Region: "us-east-2"}),
-			expectedError: require.NoError,
 			expectedURL: func(tt require.TestingT, i1 any, i2 ...any) {
 				u, _ := i1.(*url.URL)
 				require.Equal(tt, "https", u.Scheme)
@@ -51,12 +49,50 @@ func TestBuildURL(t *testing.T) {
 				require.Equal(tt, "/anthropic/v1", u.Path)
 			},
 		},
-		"openai format": {
+		"default region": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatAnthropic,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{}),
+			expectedURL: func(tt require.TestingT, i1 any, i2 ...any) {
+				u, _ := i1.(*url.URL)
+				require.Equal(tt, "https", u.Scheme)
+				require.Equal(tt, "bedrock-mantle."+defaultRegion+".api.aws", u.Host)
+				require.Equal(tt, "/anthropic/v1", u.Path)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			tc.expectedURL(t, BuildAnthropicURL(slog.Default(), tc.app))
+		})
+	}
+}
+
+func TestBuildOpenAIURL(t *testing.T) {
+	for name, tc := range map[string]struct {
+		app         types.Application
+		isResponses bool
+		expectedURL require.ValueAssertionFunc
+	}{
+		"responses": {
 			app: newApp(t, &types.LLM{
 				Format:   types.LLMFormatOpenAI,
 				Provider: types.LLMProviderAWSBedrock,
 			}, &types.AppAWS{Region: "eu-central-1"}),
-			expectedError: require.NoError,
+			isResponses: true,
+			expectedURL: func(tt require.TestingT, i1 any, i2 ...any) {
+				u, _ := i1.(*url.URL)
+				require.Equal(tt, "https", u.Scheme)
+				require.Equal(tt, "bedrock-mantle.eu-central-1.api.aws", u.Host)
+				require.Equal(tt, "/openai/v1", u.Path)
+			},
+		},
+		"chat completions": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{Region: "eu-central-1"}),
+			isResponses: false,
 			expectedURL: func(tt require.TestingT, i1 any, i2 ...any) {
 				u, _ := i1.(*url.URL)
 				require.Equal(tt, "https", u.Scheme)
@@ -69,19 +105,17 @@ func TestBuildURL(t *testing.T) {
 				Format:   types.LLMFormatOpenAI,
 				Provider: types.LLMProviderAWSBedrock,
 			}, &types.AppAWS{}),
-			expectedError: require.NoError,
+			isResponses: true,
 			expectedURL: func(tt require.TestingT, i1 any, i2 ...any) {
 				u, _ := i1.(*url.URL)
 				require.Equal(tt, "https", u.Scheme)
 				require.Equal(tt, "bedrock-mantle."+defaultRegion+".api.aws", u.Host)
-				require.Equal(tt, "/v1", u.Path)
+				require.Equal(tt, "/openai/v1", u.Path)
 			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			u, err := BuildURL(slog.Default(), tc.app)
-			tc.expectedError(t, err)
-			tc.expectedURL(t, u)
+			tc.expectedURL(t, BuildOpenAIURL(slog.Default(), tc.app, tc.isResponses))
 		})
 	}
 }

--- a/lib/srv/app/llm/errors/errors.go
+++ b/lib/srv/app/llm/errors/errors.go
@@ -43,6 +43,8 @@ var (
 	ErrBadResponse = errors.New("the inference provider returned an unexpected response. Contact your Teleport administrator")
 	// ErrConfig returned when the app or app service are misconfigured, requiring admin intervention.
 	ErrConfig = errors.New("unable to serve request due to an app configuration error. Contact your Teleport administrator")
+	// ErrInternal returned when there is a Teleport processing error (nothing to do with the inference provider).
+	ErrInternal = errors.New("unable to serve the request due to an internal error. Contact your Teleport administrator")
 	// ErrUnknown returned when the handler could not identify the error.
 	ErrUnknown = errors.New("the inference provider returned an unexpected error. Contact your Teleport administrator")
 )
@@ -92,6 +94,8 @@ func StatusCodeFromErr(err error) int {
 		return http.StatusTooManyRequests
 	case errors.Is(err, ErrUnsupported):
 		return http.StatusNotFound
+	case errors.Is(err, ErrInternal):
+		return http.StatusInternalServerError
 	default:
 		return trace.ErrorToCode(err)
 	}

--- a/lib/srv/app/llm/errors/errors.go
+++ b/lib/srv/app/llm/errors/errors.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 var (
@@ -93,4 +95,20 @@ func StatusCodeFromErr(err error) int {
 	default:
 		return trace.ErrorToCode(err)
 	}
+}
+
+// MarshalMessage marshals an error into JSON format. This function might return
+// empty.
+//
+// Callers can safely interpolate the result of this function with JSON strings.
+func MarshalMessage(err error) string {
+	if err == nil {
+		return `""`
+	}
+
+	if enc, err := utils.FastMarshal(err.Error()); err == nil {
+		return string(enc)
+	}
+
+	return `""`
 }

--- a/lib/srv/app/llm/errors/errors_test.go
+++ b/lib/srv/app/llm/errors/errors_test.go
@@ -1,0 +1,52 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package errors
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func TestMarshalMessage(t *testing.T) {
+	for name, tc := range map[string]struct {
+		in       error
+		expected string
+	}{
+		"error message": {
+			in:       ErrUnknown,
+			expected: ErrUnknown.Error(),
+		},
+		"nil error": {
+			in:       nil,
+			expected: "",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			res := MarshalMessage(tc.in)
+			require.True(t, strings.HasPrefix(res, "\""), "expected result to include surrounding \"")
+			require.True(t, strings.HasSuffix(res, "\""), "expected result to include surrounding \"")
+
+			var decRes string
+			require.NoError(t, utils.FastUnmarshal([]byte(res), &decRes))
+			require.Equal(t, tc.expected, decRes)
+		})
+	}
+}

--- a/lib/srv/app/llm/handler.go
+++ b/lib/srv/app/llm/handler.go
@@ -144,6 +144,64 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// HandleError handles an error and forwards LLM compatible results to the
+// client.
+func (h *Handler) HandleError(r *http.Request, w http.ResponseWriter, err error) {
+	if err == nil {
+		return
+	}
+
+	sessionCtx, sessionCtxErr := common.GetSessionContext(r)
+	if sessionCtxErr != nil {
+		trace.WriteError(w, err)
+		return
+	}
+
+	llm := sessionCtx.App.GetLLM()
+	log := h.cfg.Log.With(
+		"app", sessionCtx.App.GetName(),
+		"format", llm.Format,
+		"provider", llm.Provider,
+	)
+
+	var formattedErr error
+	switch {
+	case trace.IsNotImplemented(err):
+		formattedErr = llmerrors.NewProviderError(llmerrors.ErrUnsupported, err.Error())
+	default:
+		// Other errors are most likely related to Teleport processing the
+		// request which is not valuable for callers, so log the error and
+		// return a generic one for the downstream.
+		log.ErrorContext(h.closeContext, "failed to process llm request due to error", "err", err)
+		formattedErr = llmerrors.ErrInternal
+	}
+
+	defer func() {
+		if auditErr := sessionCtx.Audit.OnLLMRequest(
+			h.closeContext,
+			sessionCtx,
+			r,
+			common.LLMRequest{Format: llm.Format, Provider: llm.Provider},
+			common.LLMResponse{Error: formattedErr},
+		); auditErr != nil {
+			log.ErrorContext(h.closeContext, "failed to emit audit event for failed request", "error", auditErr)
+		}
+	}()
+
+	switch llm.Format {
+	case types.LLMFormatAnthropic:
+		if werr := anthropic.WriteError(w, formattedErr); werr != nil {
+			log.ErrorContext(h.closeContext, "failed to write error", "error", werr)
+		}
+	case types.LLMFormatOpenAI:
+		if werr := openai.WriteError(w, formattedErr); werr != nil {
+			log.ErrorContext(h.closeContext, "failed to write error", "error", werr)
+		}
+	default:
+		trace.WriteError(w, formattedErr)
+	}
+}
+
 // serveHTTP routes requests to the configured LLM provider handler.
 func (h *Handler) serveHTTP(w http.ResponseWriter, r *http.Request) error {
 	sessionCtx, err := common.GetSessionContext(r)
@@ -161,7 +219,6 @@ func (h *Handler) serveHTTP(w http.ResponseWriter, r *http.Request) error {
 		).Observe(time.Since(start).Seconds())
 	}()
 
-	// TODO(gabrielcorado): implement OpenAI handler.
 	switch llm.Format {
 	case types.LLMFormatAnthropic:
 		h.handleRequest(

--- a/lib/srv/app/llm/handler.go
+++ b/lib/srv/app/llm/handler.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/app/llm/anthropic"
 	"github.com/gravitational/teleport/lib/srv/app/llm/bedrock"
 	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+	"github.com/gravitational/teleport/lib/srv/app/llm/openai"
 	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
 )
 
@@ -47,7 +48,9 @@ type Handler struct {
 	metrics      *llmMetrics
 
 	anthropicProviderURL *url.URL
-	anthropicApiKey      string
+	anthropicAPIKey      string
+	openAIProviderURL    *url.URL
+	openAIAPIKey         string
 }
 
 // HandlerConfig configures dependencies for the LLM proxy handler.
@@ -105,7 +108,8 @@ func NewHandler(ctx context.Context, cfg HandlerConfig) (*Handler, error) {
 		metrics:      m,
 		// Not much validation can be applied here since some providers might
 		// not require an actual API key.
-		anthropicApiKey: os.Getenv(anthropicApiKeyEnvVarName),
+		anthropicAPIKey: os.Getenv(anthropicAPIKeyEnvVarName),
+		openAIAPIKey:    os.Getenv(openAIAPIKeyEnvVarName),
 	}
 
 	// It ok to leave this value as `nil`, the value receivers must implement a
@@ -117,6 +121,16 @@ func NewHandler(ctx context.Context, cfg HandlerConfig) (*Handler, error) {
 			// Hard failure.
 			return nil, trace.Wrap(err)
 		}
+		h.cfg.Log.InfoContext(ctx, "using anthropic provider address from environment", "host", h.anthropicProviderURL.Host)
+	}
+	if rawOpenAIURL := os.Getenv(openAIAddressEnvVarName); rawOpenAIURL != "" {
+		var err error
+		h.openAIProviderURL, err = url.Parse(rawOpenAIURL)
+		if err != nil {
+			// Hard failure.
+			return nil, trace.Wrap(err)
+		}
+		h.cfg.Log.InfoContext(ctx, "using openai provider address from environment", "host", h.openAIProviderURL.Host)
 	}
 
 	return h, nil
@@ -152,21 +166,39 @@ func (h *Handler) serveHTTP(w http.ResponseWriter, r *http.Request) error {
 	case types.LLMFormatAnthropic:
 		h.handleRequest(
 			sessionCtx, w, r,
-			func(app types.Application, r *http.Request) (*http.Request, RequestInfo, error) {
+			func(app types.Application, r *http.Request) (*http.Request, llmrequest.RequestInfo, error) {
 				return anthropic.NewRequest(&llmrequest.Config{
 					App:               app,
 					DownstreamRequest: r,
 					ProviderURL:       h.anthropicProviderURL,
 					GetAPIKeyFunc: func() string {
-						return h.anthropicApiKey
+						return h.anthropicAPIKey
 					},
 					SignBedrockRequest: h.signBedrockRequest,
 				})
 			},
-			func(l *slog.Logger, w http.ResponseWriter) (UpstreamRecorder, error) {
+			func(l *slog.Logger, _ llmrequest.RequestInfo, w http.ResponseWriter) (UpstreamRecorder, error) {
 				return anthropic.NewResponseRecorder(l, w)
 			},
 			anthropic.WriteError,
+		)
+	case types.LLMFormatOpenAI:
+		h.handleRequest(
+			sessionCtx, w, r,
+			func(app types.Application, r *http.Request) (*http.Request, llmrequest.RequestInfo, error) {
+				return openai.NewRequest(&llmrequest.Config{
+					App:               app,
+					DownstreamRequest: r,
+					ProviderURL:       h.openAIProviderURL,
+					GetAPIKeyFunc: func() string {
+						return h.openAIAPIKey
+					},
+				})
+			},
+			func(l *slog.Logger, info llmrequest.RequestInfo, w http.ResponseWriter) (UpstreamRecorder, error) {
+				return openai.NewResponseRecorder(l, info, w)
+			},
+			openai.WriteError,
 		)
 	default:
 		return trace.NotImplemented("llm format %q not supported", llm.Format)
@@ -187,24 +219,12 @@ func (h *Handler) signBedrockRequest(ctx context.Context, app types.Application,
 // WriteErrorFunc is function used to write an error into the downstream request.
 type WriteErrorFunc func(http.ResponseWriter, error) error
 
-// RequestInfo interface that contains the request information.
-type RequestInfo interface {
-	// RequestedModel returns the requested model name.
-	RequestedModel() string
-	// ProviderModel returns the model name sent to the provider.
-	ProviderModel() string
-	// IsStream indicates if the request uses streaming.
-	IsStream() bool
-	// RequestSize contains the total request size in bytes.
-	RequestSize() int
-}
-
 // NewUpstreamRequestFunc function used to create a new upstream request.
-type NewUpstreamRequestFunc func(app types.Application, r *http.Request) (*http.Request, RequestInfo, error)
+type NewUpstreamRequestFunc func(app types.Application, r *http.Request) (*http.Request, llmrequest.RequestInfo, error)
 
 // NewUpstreamRecoderFunc function used to initialize a upstream response
 // recorder.
-type NewUpstreamRecoderFunc func(*slog.Logger, http.ResponseWriter) (UpstreamRecorder, error)
+type NewUpstreamRecoderFunc func(*slog.Logger, llmrequest.RequestInfo, http.ResponseWriter) (UpstreamRecorder, error)
 
 // UpstreamRecorder records upstream results.
 type UpstreamRecorder interface {
@@ -242,7 +262,7 @@ func (h *Handler) handleRequest(
 
 	var (
 		err  error
-		info RequestInfo
+		info llmrequest.RequestInfo
 		rec  UpstreamRecorder
 	)
 
@@ -272,7 +292,7 @@ func (h *Handler) handleRequest(
 		return
 	}
 
-	rec, err = newRecorderFunc(log, w)
+	rec, err = newRecorderFunc(log, info, w)
 	if err != nil {
 		log.ErrorContext(r.Context(), "failed to initialize recorder", "error", err)
 		// This is considered an "internal" error. For downstream connections,
@@ -352,9 +372,15 @@ const (
 	//
 	// https://code.claude.com/docs/en/env-vars#variables
 	anthropicAddressEnvVarName = "ANTHROPIC_BASE_URL"
-	// anthropicApiKeyEnvVarName is the Anthropic's default environment variable
+	// anthropicAPIKeyEnvVarName is the Anthropic's default environment variable
 	// used to set API keys.
 	//
 	// https://code.claude.com/docs/en/env-vars#variables
-	anthropicApiKeyEnvVarName = "ANTHROPIC_API_KEY"
+	anthropicAPIKeyEnvVarName = "ANTHROPIC_API_KEY"
+	// openAIAddressEnvVarName is the OpenAI's environment variable used to set
+	// base API address.
+	openAIAddressEnvVarName = "OPENAI_BASE_URL"
+	// openAIAPIKeyEnvVarName is the OpenAI's environment variable used to
+	// set API keys.
+	openAIAPIKeyEnvVarName = "OPENAI_API_KEY"
 )

--- a/lib/srv/app/llm/handler.go
+++ b/lib/srv/app/llm/handler.go
@@ -193,6 +193,7 @@ func (h *Handler) serveHTTP(w http.ResponseWriter, r *http.Request) error {
 					GetAPIKeyFunc: func() string {
 						return h.openAIAPIKey
 					},
+					SignBedrockRequest: h.signBedrockRequest,
 				})
 			},
 			func(l *slog.Logger, info llmrequest.RequestInfo, w http.ResponseWriter) (UpstreamRecorder, error) {

--- a/lib/srv/app/llm/handler_test.go
+++ b/lib/srv/app/llm/handler_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv/app/common"
+	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
 )
 
 // TestHandleRequest covers `handleRequest` function which is responsible for
@@ -60,7 +61,7 @@ func TestHandleRequest(t *testing.T) {
 	}{
 		"success request": {
 			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
-				return func(_ types.Application, _ *http.Request) (*http.Request, RequestInfo, error) {
+				return func(_ types.Application, _ *http.Request) (*http.Request, llmrequest.RequestInfo, error) {
 					req, err := http.NewRequest(http.MethodPost, s.URL, nil)
 					if err != nil {
 						return nil, nil, trace.Wrap(err)
@@ -95,7 +96,7 @@ func TestHandleRequest(t *testing.T) {
 		},
 		"new request error": {
 			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
-				return func(_ types.Application, _ *http.Request) (*http.Request, RequestInfo, error) {
+				return func(_ types.Application, _ *http.Request) (*http.Request, llmrequest.RequestInfo, error) {
 					return nil, nil, trace.BadParameter("invalid request")
 				}
 			},
@@ -117,7 +118,7 @@ func TestHandleRequest(t *testing.T) {
 		},
 		"new request error with partial info": {
 			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
-				return func(_ types.Application, _ *http.Request) (*http.Request, RequestInfo, error) {
+				return func(_ types.Application, _ *http.Request) (*http.Request, llmrequest.RequestInfo, error) {
 					return nil, &mockRequestInfo{
 						requestedModel: "requested",
 						providerModel:  "provider",
@@ -142,7 +143,7 @@ func TestHandleRequest(t *testing.T) {
 		},
 		"successful request with recorder error": {
 			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
-				return func(_ types.Application, _ *http.Request) (*http.Request, RequestInfo, error) {
+				return func(_ types.Application, _ *http.Request) (*http.Request, llmrequest.RequestInfo, error) {
 					req, err := http.NewRequest(http.MethodPost, s.URL, nil)
 					if err != nil {
 						return nil, nil, trace.Wrap(err)
@@ -176,7 +177,7 @@ func TestHandleRequest(t *testing.T) {
 		// This case covers scenarios where upstream is not reachable.
 		"upstream forward error": {
 			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
-				return func(_ types.Application, _ *http.Request) (*http.Request, RequestInfo, error) {
+				return func(_ types.Application, _ *http.Request) (*http.Request, llmrequest.RequestInfo, error) {
 					req, err := http.NewRequest(http.MethodPost, s.URL, nil)
 					if err != nil {
 						return nil, nil, trace.Wrap(err)
@@ -249,7 +250,7 @@ func TestHandleRequest(t *testing.T) {
 				w,
 				req,
 				tc.newRequestFunc(w, mockServer),
-				func(_ *slog.Logger, w http.ResponseWriter) (UpstreamRecorder, error) {
+				func(_ *slog.Logger, _ llmrequest.RequestInfo, w http.ResponseWriter) (UpstreamRecorder, error) {
 					rec := &mockUpstreamRecorder{ResponseWriter: w}
 					tc.modifyRecorderFunc(rec)
 					return rec, nil
@@ -299,7 +300,7 @@ func (m *mockUpstreamRecorder) Written() int {
 }
 
 type mockRequestInfo struct {
-	RequestInfo
+	llmrequest.RequestInfo
 
 	requestedModel string
 	providerModel  string

--- a/lib/srv/app/llm/handler_test.go
+++ b/lib/srv/app/llm/handler_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv/app/common"
+	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
 	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
 )
 
@@ -263,6 +264,84 @@ func TestHandleRequest(t *testing.T) {
 			tc.expectedResponse(t, w.Body.String())
 		})
 	}
+}
+
+func TestHandleError(t *testing.T) {
+	for name, tc := range map[string]struct {
+		llm              *types.LLM
+		err              error
+		expectResponse   require.ValueAssertionFunc
+		expectAuditEvent require.ValueAssertionFunc
+	}{
+		"supported format renders error and audit error": {
+			llm: &types.LLM{
+				Format: types.LLMFormatAnthropic,
+			},
+			err: trace.BadParameter("not supported value"),
+			expectResponse: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.NotNil(tt, i1, i2...)
+				rec, _ := i1.(*httptest.ResponseRecorder)
+				res := rec.Result()
+				body, err := io.ReadAll(res.Body)
+				require.NoError(tt, err, i2...)
+				require.Contains(tt, string(body), llmerrors.ErrInternal.Error(), i2...)
+			},
+			expectAuditEvent: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.NotNil(tt, i1, i2...)
+				evt := i1.(*apievents.AppSessionLLMRequest)
+				require.False(tt, evt.Status.Success, i2...)
+			},
+		},
+		"unsupported format renders error and audit error": {
+			llm: &types.LLM{
+				Format: "unsupported-format",
+			},
+			err: trace.BadParameter("not supported value"),
+			expectResponse: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.NotNil(tt, i1, i2...)
+				rec, _ := i1.(*httptest.ResponseRecorder)
+				res := rec.Result()
+				body, err := io.ReadAll(res.Body)
+				require.NoError(tt, err, i2...)
+				require.Contains(tt, string(body), llmerrors.ErrInternal.Error(), i2...)
+			},
+			expectAuditEvent: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.NotNil(tt, i1, i2...)
+				evt := i1.(*apievents.AppSessionLLMRequest)
+				require.False(tt, evt.Status.Success, i2...)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var auditEvent *apievents.AppSessionLLMRequest
+			h := newTestHandler(t, nil)
+			req := newTestSessionRequest(
+				t,
+				http.MethodPost,
+				"",
+				"/",
+				nil,
+				&common.SessionContext{
+					App: &types.AppV3{
+						Spec: types.AppSpecV3{
+							LLM: tc.llm,
+						},
+					},
+					Audit: newTestAudit(t, func(pe apievents.PreparedSessionEvent) {
+						if evt, ok := pe.GetAuditEvent().(*apievents.AppSessionLLMRequest); ok {
+							auditEvent = evt
+						}
+					}),
+				},
+			)
+
+			w := httptest.NewRecorder()
+			h.HandleError(req, w, tc.err)
+			tc.expectResponse(t, w)
+			tc.expectAuditEvent(t, auditEvent)
+		})
+	}
+
 }
 
 type mockUpstreamRecorder struct {

--- a/lib/srv/app/llm/openai/errors.go
+++ b/lib/srv/app/llm/openai/errors.go
@@ -1,0 +1,168 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package openai
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gravitational/trace"
+
+	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// WriteError writes an error in OpenAI format.
+func WriteError(w http.ResponseWriter, err error) error {
+	w.WriteHeader(llmerrors.StatusCodeFromErr(err))
+	_, werr := w.Write(marshalError(newErrorEnvelope(err)))
+	return trace.Wrap(werr)
+}
+
+// marshalError marshals an error into OpenAI format.
+func marshalError(apiErr *errorEnvelope) []byte {
+	enc, err := utils.FastMarshal(apiErr)
+	if err != nil {
+		return []byte(
+			`{"error": {"type": "server_error", "message": ` + llmerrors.MarshalMessage(llmerrors.ErrUnknown) + `}}`,
+		)
+	}
+	return enc
+}
+
+// marshalResponsesErrorEvent marshals an OpenAI error message.
+func marshalResponsesErrorEvent(evt *responsesErrorSSEEvent) []byte {
+	enc, err := utils.FastMarshal(evt)
+	if err != nil {
+		return []byte(
+			// Ignore SequenceNumber to avoid having to deal with number
+			// conversions in this failure scenario.
+			`{"type": "error", "message": ` + llmerrors.MarshalMessage(llmerrors.ErrUnknown) + `}`,
+		)
+	}
+	return enc
+}
+
+// marshalResponsesFailedError marshals an OpenAI `response.failed` error
+// message.
+func marshalResponsesFailedError(evt *responsesFailedSSEEvent) []byte {
+	enc, err := utils.FastMarshal(evt)
+	if err != nil {
+		return []byte(
+			// Ignore SequenceNumber to avoid having to deal with number
+			// conversions in this failure scenario.
+			`{"type": "` + responsesFailedEventName + `", "response": {"type": "server_error", "message": ` + llmerrors.MarshalMessage(llmerrors.ErrUnknown) + `}}`,
+		)
+	}
+	return enc
+}
+
+// newErrorEnvelope creates a new error envelope.
+func newErrorEnvelope(err error) *errorEnvelope {
+	if err == nil {
+		return nil
+	}
+
+	return &errorEnvelope{
+		Type:  "error",
+		Error: newErrorMessage(err),
+	}
+}
+
+// newResponsesFailedError creates a new error in the `response.failed` event
+// format.
+func newResponsesFailedError(seqNumber int, err error) *responsesFailedSSEEvent {
+	return &responsesFailedSSEEvent{
+		Type:           responsesFailedEventName,
+		SequenceNumber: seqNumber,
+		// `responses.failed` contents needed is only the `error` key.
+		// Instead of defining a dedicated struct for this we reuse the
+		// `errorEvenlope`, but since the response doesn't have the `type` field
+		// we must not define here (and cannot use the `newErrorEnvelope`
+		// function).
+		Response: errorEnvelope{
+			Error: newErrorMessage(err),
+		},
+	}
+}
+
+// newErrorMessage creates a new error message.
+func newErrorMessage(err error) errorMessage {
+	msg := errorMessage{
+		Type:    errorTypeServerError,
+		Message: err.Error(),
+	}
+	switch {
+	case errors.Is(err, llmerrors.ErrRejected):
+		msg.Type = errorTypeRateLimitExceeded
+	case errors.Is(err, llmerrors.ErrBadRequest),
+		errors.Is(err, llmerrors.ErrUnauthorized),
+		errors.Is(err, llmerrors.ErrUnsupported),
+		trace.IsBadParameter(err),
+		trace.IsNotFound(err):
+		msg.Type = errorTypeInvalidRequest
+	}
+
+	return msg
+}
+
+// parseProviderError parses errors that come from OpenAI API.
+func parseProviderError(statusCode int, body []byte) (*llmerrors.ProviderError, error) {
+	var r errorEnvelope
+	if err := utils.FastUnmarshal(body, &r); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Prefer setting the LLM error on status code since it provides more
+	// granularity.
+	//
+	// https://developers.openai.com/api/docs/guides/error-codes#api-errors
+	switch statusCode {
+	case http.StatusBadRequest:
+		return llmerrors.NewProviderError(llmerrors.ErrBadRequest, r.Error.Message), nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return llmerrors.NewProviderError(llmerrors.ErrUnauthorized, ""), nil
+	case http.StatusTooManyRequests, http.StatusServiceUnavailable:
+		return llmerrors.NewProviderError(llmerrors.ErrRejected, r.Error.Message), nil
+	}
+
+	switch r.Error.Type {
+	case errorTypeInvalidRequest:
+		return llmerrors.NewProviderError(llmerrors.ErrBadRequest, r.Error.Message), nil
+	case errorTypeRateLimitExceeded:
+		return llmerrors.NewProviderError(llmerrors.ErrRejected, r.Error.Message), nil
+	default:
+		return llmerrors.NewProviderError(llmerrors.ErrUnknown, r.Error.Message), nil
+	}
+}
+
+type errorMessage struct {
+	Type    string `json:"type,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// errorEnvelope wraps the error message from OpenAI's API.
+type errorEnvelope struct {
+	Type  string       `json:"type,omitempty"`
+	Error errorMessage `json:"error"`
+}
+
+const (
+	errorTypeServerError       = "server_error"
+	errorTypeRateLimitExceeded = "rate_limit_exceeded"
+	errorTypeInvalidRequest    = "invalid_request_error"
+)

--- a/lib/srv/app/llm/openai/openai.go
+++ b/lib/srv/app/llm/openai/openai.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/srv/app/llm/bedrock"
+	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
 	"github.com/gravitational/teleport/lib/srv/app/llm/models"
 	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
 	"github.com/gravitational/teleport/lib/utils"
@@ -57,49 +59,56 @@ func NewRequest(cfg *llmrequest.Config) (*http.Request, llmrequest.RequestInfo, 
 		Path:   "/v1",
 	})
 
+	// All endpoints use JSON content-type.
+	providerHeaders.Set("Content-Type", "application/json")
 	llm := cfg.App.GetLLM()
-	// TODO(gabrielcorado): add support for bedrock provider.
-	switch llm.Provider {
-	case types.LLMProviderOpenAI:
-		switch strings.TrimPrefix(cfg.DownstreamRequest.URL.Path, "/v1") {
-		// https://developers.openai.com/api/reference/resources/responses/methods/create
-		case "/responses":
-			if cfg.DownstreamRequest.Method != http.MethodPost {
-				// We're ok with returning 404 back to clients instead 405 status.
-				return nil, info, trace.NotFound("responses API supports only POST requests")
-			}
 
-			// Currently, websocket mode is not supported.
-			//
-			// https://developers.openai.com/api/docs/guides/websocket-mode
-			if websocket.IsWebSocketUpgrade(cfg.DownstreamRequest) {
-				return nil, info, trace.NotFound("websocket mode is not supported")
-			}
-
-			info.endpointType = endpointTypeResponses
-			providerPath = "/responses"
-			providerMethod = http.MethodPost
-			req = &responsesAPIRequest{}
-		// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
-		case "/chat/completions":
-			if cfg.DownstreamRequest.Method != http.MethodPost {
-				// We're ok with returning 404 back to clients instead 405 status.
-				return nil, info, trace.NotFound("chat completions API supports only POST requests")
-			}
-
-			info.endpointType = endpointTypeChatCompletions
-			providerPath = "/chat/completions"
-			providerMethod = http.MethodPost
-			req = &chatCompletionsAPIRequest{}
-		default:
-			return nil, info, trace.NotFound("unsupported endpoint")
+	// Both `openai` and `bedrock` providers support responses and chat
+	// completions endpoints.
+	//
+	// https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html
+	switch strings.TrimPrefix(cfg.DownstreamRequest.URL.Path, "/v1") {
+	// https://developers.openai.com/api/reference/resources/responses/methods/create
+	case "/responses":
+		if cfg.DownstreamRequest.Method != http.MethodPost {
+			// We're ok with returning 404 back to clients instead 405 status.
+			return nil, info, trace.NotFound("responses API supports only POST requests")
 		}
 
+		// Teleport and Bedrock don't support WebSocket mode.
+		//
+		// https://developers.openai.com/api/docs/guides/websocket-mode
+		// https://developers.openai.com/api/docs/guides/amazon-bedrock#responses-api-feature-availability
+		if websocket.IsWebSocketUpgrade(cfg.DownstreamRequest) {
+			return nil, info, trace.NotFound("websocket mode is not supported")
+		}
+
+		info.endpointType = endpointTypeResponses
+		providerPath = "/responses"
+		providerMethod = http.MethodPost
+		req = &responsesAPIRequest{}
+	case "/chat/completions":
+		if cfg.DownstreamRequest.Method != http.MethodPost {
+			// We're ok with returning 404 back to clients instead 405 status.
+			return nil, info, trace.NotFound("chat completions API supports only POST requests")
+		}
+
+		info.endpointType = endpointTypeChatCompletions
+		providerPath = "/chat/completions"
+		providerMethod = http.MethodPost
+		req = &chatCompletionsAPIRequest{}
+	default:
+		return nil, info, trace.NotFound("unsupported endpoint")
+	}
+
+	switch llm.Provider {
+	case types.LLMProviderOpenAI:
 		// OpenAI API requires only `Authorization` header carrying the API key.
 		//
 		// https://developers.openai.com/api/reference/overview#authentication
 		providerHeaders.Set("Authorization", "Bearer "+cfg.GetAPIKeyFunc())
-		providerHeaders.Set("Content-Type", "application/json")
+	case types.LLMProviderAWSBedrock:
+		cfg.ProviderURL = bedrock.BuildOpenAIURL(cfg.Logger, cfg.App, info.endpointType == endpointTypeResponses)
 	default:
 		return nil, info, trace.NotImplemented("provider %q is not supported", llm.Provider)
 	}
@@ -157,5 +166,16 @@ func NewRequest(cfg *llmrequest.Config) (*http.Request, llmrequest.RequestInfo, 
 		return nil, info, trace.Wrap(err)
 	}
 	providerReq.Header = providerHeaders
+
+	if llm.Provider == types.LLMProviderAWSBedrock {
+		if err := cfg.SignBedrockRequest(providerReq.Context(), cfg.App, providerReq, providerBody); err != nil {
+			// The signing failure cause can carry AWS credentials/config
+			// details, so it is only logged, and clients receive a generic
+			// internal error message.
+			cfg.Logger.ErrorContext(providerReq.Context(), "failed to sign provider request", "error", err)
+			return nil, info, llmerrors.ErrConfig
+		}
+	}
+
 	return providerReq, info, nil
 }

--- a/lib/srv/app/llm/openai/openai.go
+++ b/lib/srv/app/llm/openai/openai.go
@@ -80,6 +80,17 @@ func NewRequest(cfg *llmrequest.Config) (*http.Request, llmrequest.RequestInfo, 
 			providerPath = "/responses"
 			providerMethod = http.MethodPost
 			req = &responsesAPIRequest{}
+		// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
+		case "/chat/completions":
+			if cfg.DownstreamRequest.Method != http.MethodPost {
+				// We're ok with returning 404 back to clients instead 405 status.
+				return nil, info, trace.NotFound("chat completions API supports only POST requests")
+			}
+
+			info.endpointType = endpointTypeChatCompletions
+			providerPath = "/chat/completions"
+			providerMethod = http.MethodPost
+			req = &chatCompletionsAPIRequest{}
 		default:
 			return nil, info, trace.NotFound("unsupported endpoint")
 		}
@@ -125,6 +136,7 @@ func NewRequest(cfg *llmrequest.Config) (*http.Request, llmrequest.RequestInfo, 
 	info.providerModel = providerModel
 	req.SetModel(providerModel)
 	req.EnableReportUsage()
+	req.DisableDataRetention()
 
 	providerBody, err := utils.FastMarshal(req)
 	if err != nil {

--- a/lib/srv/app/llm/openai/openai.go
+++ b/lib/srv/app/llm/openai/openai.go
@@ -114,10 +114,12 @@ func NewRequest(cfg *llmrequest.Config) (*http.Request, llmrequest.RequestInfo, 
 	}
 
 	body, err := utils.ReadAtMost(cfg.DownstreamRequest.Body, teleport.MaxHTTPRequestSize)
+	if closeErr := cfg.DownstreamRequest.Body.Close(); closeErr != nil {
+		cfg.Logger.WarnContext(cfg.DownstreamRequest.Context(), "failed to close downstream body", "error", closeErr)
+	}
 	if err != nil {
 		return nil, info, trace.Wrap(err)
 	}
-	defer cfg.DownstreamRequest.Body.Close()
 
 	if err := utils.FastUnmarshal(body, &req); err != nil {
 		return nil, info, trace.BadParameter("unable to parse request body")

--- a/lib/srv/app/llm/openai/openai.go
+++ b/lib/srv/app/llm/openai/openai.go
@@ -1,0 +1,149 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package openai
+
+import (
+	"bytes"
+	"cmp"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gorilla/websocket"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/srv/app/llm/models"
+	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// NewRequest creates a new provider request based on the downstream request,
+// and inference endpoint configuration.
+func NewRequest(cfg *llmrequest.Config) (*http.Request, llmrequest.RequestInfo, error) {
+	var (
+		info            = &RequestInfo{}
+		providerPath    string
+		providerMethod  string
+		providerHeaders = http.Header{}
+		req             apiRequest
+	)
+
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, info, trace.Wrap(err)
+	}
+
+	// Default URL address.
+	//
+	// https://developers.openai.com/api/reference/overview
+	cfg.ProviderURL = cmp.Or(cfg.ProviderURL, &url.URL{
+		Scheme: "https",
+		Host:   "api.openai.com",
+		Path:   "/v1",
+	})
+
+	llm := cfg.App.GetLLM()
+	// TODO(gabrielcorado): add support for bedrock provider.
+	switch llm.Provider {
+	case types.LLMProviderOpenAI:
+		switch strings.TrimPrefix(cfg.DownstreamRequest.URL.Path, "/v1") {
+		// https://developers.openai.com/api/reference/resources/responses/methods/create
+		case "/responses":
+			if cfg.DownstreamRequest.Method != http.MethodPost {
+				// We're ok with returning 404 back to clients instead 405 status.
+				return nil, info, trace.NotFound("responses API supports only POST requests")
+			}
+
+			// Currently, websocket mode is not supported.
+			//
+			// https://developers.openai.com/api/docs/guides/websocket-mode
+			if websocket.IsWebSocketUpgrade(cfg.DownstreamRequest) {
+				return nil, info, trace.NotFound("websocket mode is not supported")
+			}
+
+			info.endpointType = endpointTypeResponses
+			providerPath = "/responses"
+			providerMethod = http.MethodPost
+			req = &responsesAPIRequest{}
+		default:
+			return nil, info, trace.NotFound("unsupported endpoint")
+		}
+
+		// OpenAI API requires only `Authorization` header carrying the API key.
+		//
+		// https://developers.openai.com/api/reference/overview#authentication
+		providerHeaders.Set("Authorization", "Bearer "+cfg.GetAPIKeyFunc())
+		providerHeaders.Set("Content-Type", "application/json")
+	default:
+		return nil, info, trace.NotImplemented("provider %q is not supported", llm.Provider)
+	}
+
+	body, err := utils.ReadAtMost(cfg.DownstreamRequest.Body, teleport.MaxHTTPRequestSize)
+	if err != nil {
+		return nil, info, trace.Wrap(err)
+	}
+	defer cfg.DownstreamRequest.Body.Close()
+
+	if err := utils.FastUnmarshal(body, &req); err != nil {
+		return nil, info, trace.BadParameter("unable to parse request body")
+	}
+
+	// Clients can send `null` JSON values, and since we're decoding into an
+	// interface (which can hold a `nil` reference), decoding `null` into the
+	// interface causes it to be `nil`. This condition guards against this case
+	// avoiding a nil pointer exception.
+	if req == nil {
+		return nil, info, trace.BadParameter("invalid request body")
+	}
+
+	if err := req.Validate(); err != nil {
+		return nil, info, trace.Wrap(err)
+	}
+
+	info.requestedModel = req.GetModel()
+	info.stream = req.GetStream()
+
+	providerModel, found := models.ConvertName(llm.Models, llm.FallbackModel, req.GetModel())
+	if !found {
+		return nil, info, trace.BadParameter("requested model %q is not supported", req.GetModel())
+	}
+	info.providerModel = providerModel
+	req.SetModel(providerModel)
+	req.EnableReportUsage()
+
+	providerBody, err := utils.FastMarshal(req)
+	if err != nil {
+		return nil, info, trace.ConnectionProblem(err, "failed to generate provider request")
+	}
+	info.requestSize = len(providerBody)
+
+	// Since we're doing a complete rewrite of the downstream request, it is
+	// easier to use a "fresh" request, and copy what is used from downstream
+	// request.
+	providerReq, err := http.NewRequestWithContext(
+		cfg.DownstreamRequest.Context(), // Keep original context so cancelation propagates.
+		providerMethod,
+		cfg.ProviderURL.JoinPath(providerPath).String(),
+		bytes.NewBuffer(providerBody),
+	)
+	if err != nil {
+		return nil, info, trace.Wrap(err)
+	}
+	providerReq.Header = providerHeaders
+	return providerReq, info, nil
+}

--- a/lib/srv/app/llm/openai/openai_test.go
+++ b/lib/srv/app/llm/openai/openai_test.go
@@ -1,0 +1,383 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package openai
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
+)
+
+func TestNewRequest(t *testing.T) {
+	apiKey := "random-api-key"
+
+	for name, tc := range map[string]struct {
+		app             types.Application
+		request         func() *http.Request
+		expectedError   require.ErrorAssertionFunc
+		expectedRequest require.ValueAssertionFunc
+		expectedInfo    require.ValueAssertionFunc
+	}{
+		"successful responses": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`{"model":"gpt-5","input":"Hello"}`),
+				)
+				return r
+			},
+			expectedError: require.NoError,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				require.Equal(tt, "/v1/responses", req.URL.Path)
+				require.Equal(tt, http.MethodPost, req.Method)
+				require.Equal(tt, "Bearer "+apiKey, req.Header.Get("Authorization"))
+				require.NotEmpty(tt, req.Header.Get("content-type"))
+			},
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Equal(tt, "gpt-5", info.RequestedModel())
+				require.Equal(tt, "gpt-5", info.ProviderModel())
+			},
+		},
+		"includes single /v1 prefix": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/v1/responses",
+					strings.NewReader(`{"model":"gpt-5","input":"Hello"}`),
+				)
+				return r
+			},
+			expectedError: require.NoError,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				require.Equal(tt, "/v1/responses", req.URL.Path)
+			},
+			expectedInfo: require.NotNil,
+		},
+		"convert model name": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+				Models: []*types.LLM_Model{
+					{ProviderName: "gpt-5", Name: "gpt-4o"},
+				},
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`{"model":"gpt-4o","input":"Hello"}`),
+				)
+				return r
+			},
+			expectedError: require.NoError,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				body, err := io.ReadAll(req.Body)
+				require.NoError(tt, err)
+				require.Contains(tt, string(body), "gpt-5")
+			},
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Equal(tt, "gpt-4o", info.RequestedModel())
+				require.Equal(tt, "gpt-5", info.ProviderModel())
+			},
+		},
+		"fallback model name": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+				Models: []*types.LLM_Model{
+					{ProviderName: "gpt-5", Name: "gpt-4o"},
+				},
+				FallbackModel: "gpt-4o",
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`{"model":"gpt-4o-mini","input":"Hello"}`),
+				)
+				return r
+			},
+			expectedError: require.NoError,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				body, err := io.ReadAll(req.Body)
+				require.NoError(tt, err)
+				require.Contains(tt, string(body), "gpt-5")
+			},
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Equal(tt, "gpt-4o-mini", info.RequestedModel())
+				require.Equal(tt, "gpt-5", info.ProviderModel())
+			},
+		},
+		"unsupported model name": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+				Models: []*types.LLM_Model{
+					{ProviderName: "gpt-5", Name: "gpt-4o"},
+				},
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`{"model":"gpt-4o-mini","input":"Hello"}`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Equal(tt, "gpt-4o-mini", info.RequestedModel())
+				require.Empty(tt, info.ProviderModel())
+			},
+		},
+		"request exceeds max size": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(
+						`{"model":"gpt-5","input":"`+strings.Repeat("a", teleport.MaxHTTPRequestSize)+`"}`,
+					),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Empty(tt, info.RequestedModel())
+				require.Empty(tt, info.ProviderModel())
+			},
+		},
+		"unsupported endpoint": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/embeddings",
+					strings.NewReader(`{"model":"gpt-5","input":"Hello"}`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"unsupported method on responses": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodGet,
+					"/responses",
+					nil,
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"websocket mode is not supported": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`{"model":"gpt-5","input":"Hello"}`),
+				)
+				r.Header.Set("Connection", "upgrade")
+				r.Header.Set("Upgrade", "websocket")
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"responses background requests is not supported": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`{"model":"gpt-5","input":"Hello", "background": true}`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"responses store requests is not supported": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`{"model":"gpt-5","input":"Hello", "store": true}`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"null requests is rejected": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`null`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			req, info, err := NewRequest(&llmrequest.Config{
+				App:               tc.app,
+				DownstreamRequest: tc.request(),
+				GetAPIKeyFunc: func() string {
+					return apiKey
+				},
+			})
+			tc.expectedError(t, err)
+			tc.expectedRequest(t, req)
+			tc.expectedInfo(t, info)
+		})
+	}
+}
+
+func newApp(t *testing.T, llm *types.LLM, appAWS *types.AppAWS) types.Application {
+	app, err := types.NewAppV3(types.Metadata{Name: "llm-app"}, types.AppSpecV3{
+		LLM: llm,
+		AWS: appAWS,
+	})
+	require.NoError(t, err)
+	return app
+}
+
+// buildRequestBody returns a valid responses API request body whose total size
+// is roughly fillerBytes.
+func buildRequestBody(fillerBytes int) []byte {
+	content := strings.Repeat("A", fillerBytes)
+	return fmt.Appendf(nil,
+		`{"model":"gpt-4o","max_output_tokens":1024,"stream":false,"input":%q}`,
+		content,
+	)
+}
+
+// BenchmarkNewRequest tracks the cost of the downstream request "parsing" and
+// generation of the provider request, across different body sizes.
+//
+//	go test ./lib/srv/app/llm/openai/ -run '^$' -bench BenchmarkNewRequest -benchmem
+func BenchmarkNewRequest(b *testing.B) {
+	// Maps the requested model to a provider model so the conversion path
+	// (the common case in production) is exercised.
+	app, err := types.NewAppV3(types.Metadata{Name: "benchmark-app"}, types.AppSpecV3{
+		LLM: &types.LLM{
+			Provider: types.LLMProviderOpenAI,
+			Format:   types.LLMFormatOpenAI,
+			Models: []*types.LLM_Model{
+				{ProviderName: "gpt-5", Name: "gpt-4o"},
+			},
+		},
+	})
+	require.NoError(b, err)
+
+	for _, bc := range []struct {
+		name string
+		body []byte
+	}{
+		{"small_chat", buildRequestBody(16)},
+		{"medium_32KB", buildRequestBody(32 * 1024)},
+		{"large_1MB", buildRequestBody(1024 * 1024)},
+		{"xlarge_8MB", buildRequestBody(8 * 1024 * 1024)},
+	} {
+		b.Run(bc.name, func(b *testing.B) {
+			// Reuse a single request and only reset the body each iteration.
+			r, err := http.NewRequest(http.MethodPost, "/responses", nil)
+			require.NoError(b, err)
+
+			b.SetBytes(int64(len(bc.body)))
+			b.ReportAllocs()
+
+			for b.Loop() {
+				r.Body = io.NopCloser(bytes.NewReader(bc.body))
+				if _, _, err := NewRequest(&llmrequest.Config{
+					App:               app,
+					DownstreamRequest: r,
+					GetAPIKeyFunc:     func() string { return "" },
+				}); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/lib/srv/app/llm/openai/openai_test.go
+++ b/lib/srv/app/llm/openai/openai_test.go
@@ -298,6 +298,71 @@ func TestNewRequest(t *testing.T) {
 			expectedRequest: require.Nil,
 			expectedInfo:    require.NotNil,
 		},
+		"successful chat completions": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/chat/completions",
+					strings.NewReader(`{"model":"gpt-5","stream": true,"messages":[{"role":"user","content":"Hello"}]}`),
+				)
+				return r
+			},
+			expectedError: require.NoError,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				require.Equal(tt, "/v1/chat/completions", req.URL.Path)
+				require.Equal(tt, http.MethodPost, req.Method)
+				require.Equal(tt, "Bearer "+apiKey, req.Header.Get("Authorization"))
+				require.NotEmpty(tt, req.Header.Get("content-type"))
+				// Usage reporting is enabled on chat completions requests.
+				body, err := io.ReadAll(req.Body)
+				require.NoError(tt, err)
+				require.Contains(tt, string(body), `"include_usage":true`)
+			},
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Equal(tt, "gpt-5", info.RequestedModel())
+				require.Equal(tt, "gpt-5", info.ProviderModel())
+			},
+		},
+		"chat completions store is not supported": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/chat/completions",
+					strings.NewReader(`{"model":"gpt-5","stream": true,"store":true,"messages":[{"role":"user","content":"Hello"}]}`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"unsupported method on chat completions": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderOpenAI,
+			}, nil /* appAWS */),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodGet,
+					"/chat/completions",
+					nil,
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			req, info, err := NewRequest(&llmrequest.Config{

--- a/lib/srv/app/llm/openai/openai_test.go
+++ b/lib/srv/app/llm/openai/openai_test.go
@@ -18,6 +18,10 @@ package openai
 
 import (
 	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -34,9 +38,18 @@ import (
 func TestNewRequest(t *testing.T) {
 	apiKey := "random-api-key"
 
+	signAWSRequest := func(_ context.Context, _ types.Application, req *http.Request, reqBody []byte) error {
+		hash := sha256.New()
+		hash.Write(reqBody)
+		req.Header.Set("X-Amz-Content-Sha256", hex.EncodeToString(hash.Sum(nil)))
+		req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=test")
+		return nil
+	}
+
 	for name, tc := range map[string]struct {
 		app             types.Application
 		request         func() *http.Request
+		signAWSRequest  func(context.Context, types.Application, *http.Request, []byte) error
 		expectedError   require.ErrorAssertionFunc
 		expectedRequest require.ValueAssertionFunc
 		expectedInfo    require.ValueAssertionFunc
@@ -363,6 +376,169 @@ func TestNewRequest(t *testing.T) {
 			expectedRequest: require.Nil,
 			expectedInfo:    require.NotNil,
 		},
+		"bedrock responses successful messages": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderAWSBedrock,
+				Models: []*types.LLM_Model{
+					{ProviderName: "openai.gpt-5.6-terra", Name: "gpt-5.6-terra"},
+				},
+			}, &types.AppAWS{
+				Region: "us-east-2",
+			}),
+			signAWSRequest: signAWSRequest,
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`{"model":"gpt-5.6-terra","input":"Hello"}`),
+				)
+				return r
+			},
+			expectedError: require.NoError,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				require.Equal(tt, "bedrock-mantle.us-east-2.api.aws", req.URL.Host)
+				require.Equal(tt, "/openai/v1/responses", req.URL.Path)
+				require.NotEmpty(tt, req.Header.Get("content-type"))
+				require.NotEmpty(tt, req.Header.Get("Authorization"))
+
+				body, err := io.ReadAll(req.Body)
+				require.NoError(tt, err)
+				require.Contains(tt, string(body), "openai.gpt-5.6-terra")
+				bodyHash := sha256.Sum256(body)
+				require.Equal(tt, hex.EncodeToString(bodyHash[:]), req.Header.Get("X-Amz-Content-Sha256"))
+			},
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Equal(tt, "gpt-5.6-terra", info.RequestedModel())
+				require.Equal(tt, "openai.gpt-5.6-terra", info.ProviderModel())
+			},
+		},
+		"bedrock chat completions successful messages": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderAWSBedrock,
+				Models: []*types.LLM_Model{
+					{ProviderName: "openai.gpt-5.6-terra", Name: "gpt-5.6-terra"},
+				},
+			}, &types.AppAWS{
+				Region: "us-east-2",
+			}),
+			signAWSRequest: signAWSRequest,
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/chat/completions",
+					strings.NewReader(`{"model":"gpt-5.6-terra","stream": true,"messages":[{"role":"user","content":"Hello"}]}`),
+				)
+				return r
+			},
+			expectedError: require.NoError,
+			expectedRequest: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, _ := i1.(*http.Request)
+				require.Equal(tt, "bedrock-mantle.us-east-2.api.aws", req.URL.Host)
+				require.Equal(tt, "/v1/chat/completions", req.URL.Path)
+				require.NotEmpty(tt, req.Header.Get("content-type"))
+				require.NotEmpty(tt, req.Header.Get("Authorization"))
+
+				body, err := io.ReadAll(req.Body)
+				require.NoError(tt, err)
+				require.Contains(tt, string(body), "openai.gpt-5.6-terra")
+				bodyHash := sha256.Sum256(body)
+				require.Equal(tt, hex.EncodeToString(bodyHash[:]), req.Header.Get("X-Amz-Content-Sha256"))
+			},
+			expectedInfo: func(tt require.TestingT, i1 any, i2 ...any) {
+				info, _ := i1.(*RequestInfo)
+				require.Equal(tt, "gpt-5.6-terra", info.RequestedModel())
+				require.Equal(tt, "openai.gpt-5.6-terra", info.ProviderModel())
+			},
+		},
+		"bedrock signer failure": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{
+				Region: "us-east-2",
+			}),
+			signAWSRequest: func(ctx context.Context, a types.Application, r *http.Request, b []byte) error {
+				return errors.New("signing failed")
+			},
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`{"model":"gpt-5.6-terra","input":"Hello"}`),
+				)
+				return r
+			},
+			expectedError: func(tt require.TestingT, err error, i ...any) {
+				require.Error(tt, err)
+				// The signing failure cause must not reach clients.
+				require.NotContains(tt, err.Error(), "signing failed")
+			},
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"bedrock missing signer": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{
+				Region: "us-east-2",
+			}),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/responses",
+					strings.NewReader(`{"model":"gpt-5.6-terra","input":"Hello"}`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"bedrock unsupported endpoint": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{
+				Region: "us-east-2",
+			}),
+			signAWSRequest: signAWSRequest,
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodPost,
+					"/complete",
+					strings.NewReader(`{"model":"gpt-5.6-terra","input":"Hello"}`),
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
+		"bedrock unsupported method": {
+			app: newApp(t, &types.LLM{
+				Format:   types.LLMFormatOpenAI,
+				Provider: types.LLMProviderAWSBedrock,
+			}, &types.AppAWS{
+				Region: "us-east-2",
+			}),
+			signAWSRequest: signAWSRequest,
+			request: func() *http.Request {
+				r, _ := http.NewRequest(
+					http.MethodGet,
+					"/responses",
+					nil,
+				)
+				return r
+			},
+			expectedError:   require.Error,
+			expectedRequest: require.Nil,
+			expectedInfo:    require.NotNil,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			req, info, err := NewRequest(&llmrequest.Config{
@@ -371,6 +547,7 @@ func TestNewRequest(t *testing.T) {
 				GetAPIKeyFunc: func() string {
 					return apiKey
 				},
+				SignBedrockRequest: tc.signAWSRequest,
 			})
 			tc.expectedError(t, err)
 			tc.expectedRequest(t, req)

--- a/lib/srv/app/llm/openai/recorder.go
+++ b/lib/srv/app/llm/openai/recorder.go
@@ -1,0 +1,210 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package openai
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/httplib/sse"
+	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+	llmrecorder "github.com/gravitational/teleport/lib/srv/app/llm/recorder"
+	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// NewResponseRecorder creates a new OpenAI response recorder.
+func NewResponseRecorder(log *slog.Logger, info llmrequest.RequestInfo, w http.ResponseWriter) (*llmrecorder.ResponseRecorder, error) {
+	oaiInfo, ok := info.(*RequestInfo)
+	if !ok {
+		return nil, trace.BadParameter("expected openai.RequestInfo but got %T", info)
+	}
+
+	return llmrecorder.NewResponseRecorder(log, w, Endpoint{
+		endpointType: oaiInfo.endpointType,
+	})
+}
+
+// Endpoint implements [llmrecorder.Endpoint] for the OpenAI API.
+type Endpoint struct {
+	endpointType endpointType
+}
+
+// MarshalError implements [recorder.Endpoint].
+func (e Endpoint) MarshalError(err error) []byte {
+	return marshalError(newErrorEnvelope(err))
+}
+
+// ParseError implements [recorder.Endpoint].
+func (e Endpoint) ParseError(statusCode int, body []byte) (providerError *llmerrors.ProviderError, err error) {
+	return parseProviderError(statusCode, body)
+}
+
+// ParseUsage implements [recorder.Endpoint].
+func (e Endpoint) ParseUsage(body []byte) (inputTokens int, outputTokens int, err error) {
+	switch e.endpointType {
+	case endpointTypeResponses:
+		var result responsesAPIUsage
+		if err := utils.FastUnmarshal(body, &result); err != nil {
+			return 0, 0, trace.Wrap(err)
+		}
+		return result.Usage.InputTokens, result.Usage.OutputTokens, nil
+	default:
+		return 0, 0, trace.BadParameter("endpoint type not supported")
+	}
+}
+
+// ProcessSSE implements [recorder.Endpoint].
+func (e Endpoint) ProcessSSE(ctx context.Context, log *slog.Logger, reader io.ReadCloser, writer io.Writer) (inputTokens int, outputTokens int, err error) {
+	switch e.endpointType {
+	case endpointTypeResponses:
+		return processResponsesSSEEvents(ctx, log, reader, writer)
+	default:
+		return 0, 0, trace.BadParameter("endpoint type not supported")
+	}
+}
+
+// processResponsesSSEEvents processes responses API streaming (SSE) events.
+//
+// Usage information is read only from the terminal `response.completed` and
+// `response.incomplete` events.
+//
+// This means that if the request is canceled before any of those "final events"
+// arrives, we cannot track the usage of the request. This is a known limitation
+// and will be addressed in the future when we introduce token budgeting.
+//
+// For error events, OpenAI specifies `response.failed` and `error` events.
+// There isn't much information about what we can expect from both, so we treat
+// them the same way for now.
+//
+// Other events don't contain relevant information for the recorder, so we
+// forward them as is.
+func processResponsesSSEEvents(ctx context.Context, log *slog.Logger, r io.ReadCloser, w io.Writer) (int, int, error) {
+	defer r.Close()
+
+	var (
+		done              bool
+		inputTokensCount  int
+		outputTokensCount int
+	)
+	for event, err := range sse.ReadEvents(r) {
+		if err != nil {
+			return inputTokensCount, outputTokensCount, trace.Wrap(err)
+		}
+
+		switch event.Event {
+		case responsesFailedEventName:
+			var streamEventPayload responsesFailedSSEEvent
+			if err := utils.FastUnmarshal(event.Data, &streamEventPayload); err != nil {
+				log.ErrorContext(ctx, "failed to parse error event", "error", err)
+				if _, err := sse.WriteEvent(w, sse.Event{
+					Event: responsesFailedEventName,
+					Data:  marshalResponsesFailedError(newResponsesFailedError(0 /* seqNumber */, llmerrors.ErrBadResponse)),
+				}); err != nil {
+					// Preserve the provider response for recorder Err().
+					// Downstream delivery failure is a secondary transport
+					// condition here.
+					log.ErrorContext(ctx, "failed to write error event", "error", err)
+				}
+				return inputTokensCount, outputTokensCount, llmerrors.ErrBadResponse
+			}
+
+			apiErr := llmerrors.NewProviderError(llmerrors.ErrUnknown, streamEventPayload.Response.Error.Message)
+			if _, err := sse.WriteEvent(w, sse.Event{
+				Event: responsesFailedEventName,
+				Data:  marshalResponsesFailedError(newResponsesFailedError(streamEventPayload.SequenceNumber, apiErr)),
+			}); err != nil {
+				// Preserve the provider error for recorder Err(). A failed
+				// downstream write here often means the client canceled or
+				// timed out after the provider had already rejected the
+				// request.
+				log.ErrorContext(ctx, "failed to write error event", "error", err)
+			}
+			return inputTokensCount, outputTokensCount, apiErr
+		case responsesErrorEventName:
+			var streamEventPayload responsesErrorSSEEvent
+			if err := utils.FastUnmarshal(event.Data, &streamEventPayload); err != nil {
+				log.ErrorContext(ctx, "failed to parse error event", "error", err)
+				if _, err := sse.WriteEvent(w, sse.Event{
+					Event: responsesErrorEventName,
+					// We use error message directly since we don't need specific
+					// error type set (it must always default to the event name).
+					Data: marshalResponsesErrorEvent(&responsesErrorSSEEvent{Type: responsesErrorEventName, Message: llmerrors.ErrBadResponse.Error()}),
+				}); err != nil {
+					// Preserve the provider response for recorder Err().
+					// Downstream delivery failure is a secondary transport
+					// condition here.
+					log.ErrorContext(ctx, "failed to write error event", "error", err)
+				}
+				return inputTokensCount, outputTokensCount, llmerrors.ErrBadResponse
+			}
+
+			apiErr := llmerrors.NewProviderError(llmerrors.ErrUnknown, streamEventPayload.Message)
+			if _, err := sse.WriteEvent(w, sse.Event{
+				Event: responsesErrorEventName,
+				Data: marshalResponsesErrorEvent(&responsesErrorSSEEvent{
+					Type:           responsesErrorEventName,
+					Message:        apiErr.Error(),
+					SequenceNumber: streamEventPayload.SequenceNumber,
+				}),
+			}); err != nil {
+				// Preserve the provider error for recorder Err(). A failed
+				// downstream write here often means the client canceled or
+				// timed out after the provider had already rejected the
+				// request.
+				log.ErrorContext(ctx, "failed to write error event", "error", err)
+			}
+			return inputTokensCount, outputTokensCount, apiErr
+		case responsesCompletedEventName, responsesIncompleteEventName:
+			var streamEventPayload responsesSSEEventWithUsage
+			if err := utils.FastUnmarshal(event.Data, &streamEventPayload); err != nil {
+				log.ErrorContext(ctx, "failed to parse response.completed event", "error", err)
+				return 0, 0, llmerrors.ErrBadResponse
+			}
+			inputTokensCount = streamEventPayload.Response.Usage.InputTokens
+			outputTokensCount = streamEventPayload.Response.Usage.OutputTokens
+			done = true
+		}
+
+		if _, err := sse.WriteEvent(w, event); err != nil {
+			return inputTokensCount, outputTokensCount, trace.Wrap(err)
+		}
+	}
+
+	// This would mean the stream did not work correctly (due to missing final
+	// event).
+	if !done {
+		return 0, 0, llmerrors.NewProviderError(llmerrors.ErrBadResponse, "provider did not send final event")
+	}
+
+	return inputTokensCount, outputTokensCount, nil
+}
+
+const (
+	// responsesFailedEventName is the SSE event of a failed response.
+	responsesFailedEventName = "response.failed"
+	// responsesCompletedEventName is the SSE event of a completed response.
+	responsesCompletedEventName = "response.completed"
+	// responsesIncompleteEventName is the SSE event of a incomplete response.
+	responsesIncompleteEventName = "response.incomplete"
+	// responsesErrorEventName is the SSE event of an error.
+	responsesErrorEventName = "error"
+)

--- a/lib/srv/app/llm/openai/recorder.go
+++ b/lib/srv/app/llm/openai/recorder.go
@@ -17,6 +17,7 @@
 package openai
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
@@ -67,6 +68,15 @@ func (e Endpoint) ParseUsage(body []byte) (inputTokens int, outputTokens int, er
 			return 0, 0, trace.Wrap(err)
 		}
 		return result.Usage.InputTokens, result.Usage.OutputTokens, nil
+	case endpointTypeChatCompletions:
+		var result chatCompletionsResponse
+		if err := utils.FastUnmarshal(body, &result); err != nil {
+			return 0, 0, trace.Wrap(err)
+		}
+		if result.Usage == nil {
+			return 0, 0, llmerrors.NewProviderError(llmerrors.ErrBadResponse, "missing usage information")
+		}
+		return result.Usage.PromptTokens, result.Usage.CompletionTokens, nil
 	default:
 		return 0, 0, trace.BadParameter("endpoint type not supported")
 	}
@@ -77,6 +87,8 @@ func (e Endpoint) ProcessSSE(ctx context.Context, log *slog.Logger, reader io.Re
 	switch e.endpointType {
 	case endpointTypeResponses:
 		return processResponsesSSEEvents(ctx, log, reader, writer)
+	case endpointTypeChatCompletions:
+		return processChatCompletionsSSEEvents(ctx, log, reader, writer)
 	default:
 		return 0, 0, trace.BadParameter("endpoint type not supported")
 	}
@@ -196,6 +208,80 @@ func processResponsesSSEEvents(ctx context.Context, log *slog.Logger, r io.ReadC
 	}
 
 	return inputTokensCount, outputTokensCount, nil
+}
+
+// processChatCompletionsSSEEvents process chat completions API streaming (SSE)
+// events.
+//
+// This streaming has only one type of event, and they have roughly the same
+// shape as the non-stream chat completions responses, with only a subset of
+// fields available in the events.
+//
+// Usage information will be available on the last JSON event of the stream, and
+// similarly to responses API streaming, if the request is canceled before the
+// event arrives we cannot determine the token usage. This is a known limitation
+// and will be addressed in the future when we introduce token budgeting.
+func processChatCompletionsSSEEvents(ctx context.Context, log *slog.Logger, r io.ReadCloser, w io.Writer) (int, int, error) {
+	defer r.Close()
+
+	// Instead of trying to unmarshal every chunk to check if usage is
+	// available, we'll do that only on the last JSON event which is the only
+	// event that contains usage information.
+	//
+	// Chat completions always send a `[DONE]` event when streaming is done, and
+	// when usage is enabled the chunk before that will contain the usage
+	// information. We can use that as differentiator of "non-data" event,
+	// but not a requirement. If the last event contains the usage information
+	// we should be good to go.
+	//
+	// Note usage information needs to be enabled in the request using
+	// `stream_options`. Note from OpenAI docs:
+	//
+	//	> If set, an additional chunk will be streamed before the data: [DONE] message.
+	//	> The usage field on this chunk shows the token usage statistics for the
+	//	> entire request, and the choices field will always be an empty array.
+	//	> All other chunks will also include a usage field, but with a null value.
+	//	> NOTE: If the stream is interrupted, you may not receive the final usage
+	//	> chunk which contains the total token usage for the request.
+
+	var lastEventPayload []byte
+	for event, err := range sse.ReadEvents(r) {
+		if err != nil {
+			return 0, 0, trace.Wrap(err)
+		}
+
+		if !bytes.Equal(event.Data, []byte("[DONE]")) {
+			lastEventPayload = event.Data
+		}
+
+		if _, err := sse.WriteEvent(w, event); err != nil {
+			return 0, 0, trace.Wrap(err)
+		}
+	}
+
+	if len(lastEventPayload) == 0 {
+		log.ErrorContext(ctx, "empty chat completion response")
+		return 0, 0, llmerrors.ErrBadResponse
+	}
+
+	var completionResp chatCompletionsResponse
+	if err := utils.FastUnmarshal(lastEventPayload, &completionResp); err != nil {
+		log.ErrorContext(ctx, "failed to parse chat completion event", "error", err)
+		return 0, 0, llmerrors.ErrBadResponse
+	}
+
+	// This behavior is not documented, but the SDKs do handle it. So here we're
+	// being defensive, otherwise an error event would be seen as success with
+	// empty usage.
+	if completionResp.Error != nil {
+		return 0, 0, llmerrors.NewProviderError(llmerrors.ErrUnknown, completionResp.Error.Message)
+	}
+
+	if completionResp.Usage == nil {
+		return 0, 0, llmerrors.NewProviderError(llmerrors.ErrBadResponse, "provider did not send final event")
+	}
+
+	return completionResp.Usage.PromptTokens, completionResp.Usage.CompletionTokens, nil
 }
 
 const (

--- a/lib/srv/app/llm/openai/recorder_test.go
+++ b/lib/srv/app/llm/openai/recorder_test.go
@@ -44,6 +44,16 @@ var responsesSuccessStream = strings.Join([]string{
 var responsesIncompleteStream = "event: response.incomplete\n" +
 	`data: {"type":"response.incomplete","response":{"status":"incomplete","incomplete_details":{"reason":"max_tokens"},"usage":{"input_tokens":15,"output_tokens":60,"total_tokens":75},"sequence_number":1}}`
 
+// chatCompletionsSuccessStream is a valid chat completions API SSE stream. When
+// stream_options.include_usage is set, the usage is reported on the chunk right
+// before the terminal `[DONE]` event.
+var chatCompletionsSuccessStream = strings.Join([]string{
+	`data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"}}],"usage":null}`,
+	`data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"World"}}],"usage":null}`,
+	`data: {"id":"c1","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":15,"completion_tokens":60,"total_tokens":75}}`,
+	`data: [DONE]`,
+}, "\n\n")
+
 // TestParseProviderError covers the OpenAI status-code to Teleport error
 // mapping.
 func TestParseProviderError(t *testing.T) {
@@ -122,6 +132,18 @@ func TestEndpointParseUsage(t *testing.T) {
 		"responses malformed body": {
 			endpointType: endpointTypeResponses,
 			body:         `{"usage":`,
+			expectedErr:  require.Error,
+		},
+		"chat completions success": {
+			endpointType:         endpointTypeChatCompletions,
+			body:                 `{"id":"chatcmpl_123","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Hello"}}],"usage":{"prompt_tokens":15,"completion_tokens":20,"total_tokens":35}}`,
+			expectedInputTokens:  15,
+			expectedOutputTokens: 20,
+			expectedErr:          require.NoError,
+		},
+		"chat malformed body": {
+			endpointType: endpointTypeChatCompletions,
+			body:         `{"usage":{`,
 			expectedErr:  require.Error,
 		},
 	} {
@@ -223,6 +245,69 @@ func TestEndpointProcessSSE(t *testing.T) {
 				require.Empty(t, body)
 			},
 		},
+		"chat completions success extracts usage and forwards events": {
+			endpointType:        endpointTypeChatCompletions,
+			stream:              chatCompletionsSuccessStream,
+			expectedInputTokens: 15,
+			expectedOutput:      60,
+			expectedErr:         require.NoError,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Equal(t, chatCompletionsSuccessStream+"\n\n", body)
+			},
+		},
+		"chat completions empty stream reports no usage": {
+			endpointType:        endpointTypeChatCompletions,
+			stream:              "",
+			expectedInputTokens: 0,
+			expectedOutput:      0,
+			expectedErr:         require.Error,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Empty(t, body)
+			},
+		},
+		"chat completions returns error": {
+			endpointType:        endpointTypeChatCompletions,
+			stream:              "event: data\n" + `data: {"error":{"message":"chat completion failure"}}`,
+			expectedInputTokens: 0,
+			expectedOutput:      0,
+			expectedErr: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorContains(tt, err, "chat completion failure", i...)
+			},
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Equal(
+					t,
+					"event: data\n"+`data: {"error":{"message":"chat completion failure"}}`+"\n\n",
+					body,
+					"expected the exact same SSE event, but got a different result",
+				)
+			},
+		},
+		"chat completions missing usage event": {
+			endpointType: endpointTypeChatCompletions,
+			stream: strings.Join([]string{
+				`data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello World"}}],"usage":null}`,
+				`data: [DONE]`,
+			}, "\n\n"),
+			expectedInputTokens: 0,
+			expectedOutput:      0,
+			expectedErr:         require.Error,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.NotEmpty(t, body)
+			},
+		},
+		"chat completions never sends DONE": {
+			endpointType: endpointTypeChatCompletions,
+			stream: strings.Join([]string{
+				`data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello World"}}],"usage":null}`,
+				`data: {"id":"c1","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":15,"completion_tokens":60,"total_tokens":75}}`,
+			}, "\n\n"),
+			expectedInputTokens: 15,
+			expectedOutput:      60,
+			expectedErr:         require.NoError,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.NotEmpty(t, body)
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -301,6 +386,16 @@ func buildResponsesBody(fillerBytes int) []byte {
 	)
 }
 
+// buildChatCompletionsBody returns a valid non-streaming chat completions API
+// response whose total size is roughly fillerBytes.
+func buildChatCompletionsBody(fillerBytes int) []byte {
+	text := strings.Repeat("A", fillerBytes)
+	return fmt.Appendf(nil,
+		`{"id":"chatcmpl_123","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":%q}}],"usage":{"prompt_tokens":15,"completion_tokens":20,"total_tokens":35}}`,
+		text,
+	)
+}
+
 // buildResponsesStreamEvents returns valid responses API SSE events.
 func buildResponsesStreamEvents(numEvents int) [][]byte {
 	events := make([][]byte, 0, numEvents+2)
@@ -312,8 +407,20 @@ func buildResponsesStreamEvents(numEvents int) [][]byte {
 	return events
 }
 
-// BenchmarkResponseRecorderJSON tracks the non-streaming path for each API
-// endpoint format.
+// buildChatCompletionsStreamEvents returns valid chat completions API SSE
+// events.
+func buildChatCompletionsStreamEvents(numEvents int) [][]byte {
+	events := make([][]byte, 0, numEvents+2)
+	for range numEvents {
+		events = append(events, []byte(`data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"Hello world"}}],"usage":null}`+"\n\n"))
+	}
+	events = append(events, []byte(`data: {"id":"c1","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":15,"completion_tokens":60,"total_tokens":75}}`+"\n\n"))
+	events = append(events, []byte(`data: [DONE]`+"\n\n"))
+	return events
+}
+
+// BenchmarkResponseRecorderJSON tracks the non-streaming path for both API
+// formats.
 //
 //	go test ./lib/srv/app/llm/openai/ -run '^$' -bench BenchmarkResponseRecorderJSON -benchmem
 func BenchmarkResponseRecorderJSON(b *testing.B) {
@@ -326,6 +433,9 @@ func BenchmarkResponseRecorderJSON(b *testing.B) {
 		{"responses/small", endpointTypeResponses, buildResponsesBody(16)},
 		{"responses/medium_32KB", endpointTypeResponses, buildResponsesBody(32 * 1024)},
 		{"responses/large_1MB", endpointTypeResponses, buildResponsesBody(1024 * 1024)},
+		{"chat/small", endpointTypeChatCompletions, buildChatCompletionsBody(16)},
+		{"chat/medium_32KB", endpointTypeChatCompletions, buildChatCompletionsBody(32 * 1024)},
+		{"chat/large_1MB", endpointTypeChatCompletions, buildChatCompletionsBody(1024 * 1024)},
 	} {
 		b.Run(bc.name, func(b *testing.B) {
 			b.SetBytes(int64(len(bc.body)))
@@ -358,6 +468,9 @@ func BenchmarkResponseRecorderStream(b *testing.B) {
 		{"responses/32_events", endpointTypeResponses, buildResponsesStreamEvents(32)},
 		{"responses/256_events", endpointTypeResponses, buildResponsesStreamEvents(256)},
 		{"responses/1024_events", endpointTypeResponses, buildResponsesStreamEvents(1024)},
+		{"chat/32_events", endpointTypeChatCompletions, buildChatCompletionsStreamEvents(32)},
+		{"chat/256_events", endpointTypeChatCompletions, buildChatCompletionsStreamEvents(256)},
+		{"chat/1024_events", endpointTypeChatCompletions, buildChatCompletionsStreamEvents(1024)},
 	} {
 		var total int
 		for _, e := range bc.events {

--- a/lib/srv/app/llm/openai/recorder_test.go
+++ b/lib/srv/app/llm/openai/recorder_test.go
@@ -1,0 +1,384 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package openai
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+	llmtesting "github.com/gravitational/teleport/lib/srv/app/llm/testing"
+)
+
+// responsesSuccessStream is a valid responses API SSE stream. Usage is only
+// reported on the terminal response.completed event.
+var responsesSuccessStream = strings.Join([]string{
+	"event: response.created\n" + `data: {"type":"response.created","response":{"id":"resp_123","object":"response"},"sequence_number":0}`,
+	"event: response.output_text.delta\n" + `data: {"type":"response.output_text.delta","delta":"Hello","sequence_number":1}`,
+	"event: response.output_text.delta\n" + `data: {"type":"response.output_text.delta","delta":"World","sequence_number":2}`,
+	"event: response.completed\n" + `data: {"type":"response.completed","response":{"usage":{"input_tokens":15,"output_tokens":60,"total_tokens":75}},"sequence_number":3}`,
+}, "\n\n")
+
+// responsesIncompleteStream matches the documented incomplete response shape.
+var responsesIncompleteStream = "event: response.incomplete\n" +
+	`data: {"type":"response.incomplete","response":{"status":"incomplete","incomplete_details":{"reason":"max_tokens"},"usage":{"input_tokens":15,"output_tokens":60,"total_tokens":75},"sequence_number":1}}`
+
+// TestParseProviderError covers the OpenAI status-code to Teleport error
+// mapping.
+func TestParseProviderError(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		statusCode  int
+		body        string
+		expectedErr error
+	}{
+		"bad request":         {http.StatusBadRequest, `{"error":{"type":"invalid_request_error","message":"bad"}}`, llmerrors.ErrBadRequest},
+		"unauthorized":        {http.StatusUnauthorized, `{"error":{"type":"authentication_error","message":"nope"}}`, llmerrors.ErrUnauthorized},
+		"forbidden":           {http.StatusForbidden, `{"error":{"type":"permission_error","message":"nope"}}`, llmerrors.ErrUnauthorized},
+		"rate limit":          {http.StatusTooManyRequests, `{"error":{"type":"rate_limit_exceeded","message":"slow down"}}`, llmerrors.ErrRejected},
+		"service unavailable": {http.StatusServiceUnavailable, `{"error":{"type":"server_error","message":"busy"}}`, llmerrors.ErrRejected},
+		"unknown status":      {http.StatusInternalServerError, `{"error":{"type":"server_error","message":"?"}}`, llmerrors.ErrUnknown},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			apiErr, err := parseProviderError(tc.statusCode, []byte(tc.body))
+			require.NoError(t, err)
+			require.ErrorIs(t, apiErr, tc.expectedErr)
+		})
+	}
+
+	t.Run("malformed body returns parse error", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseProviderError(http.StatusBadRequest, []byte(`{"error":`))
+		require.Error(t, err)
+	})
+}
+
+// TestNewErrorMessage covers the Teleport error to OpenAI error type mapping.
+func TestNewErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		err          error
+		expectedType string
+	}{
+		"bad request":  {llmerrors.ErrBadRequest, errorTypeInvalidRequest},
+		"unauthorized": {llmerrors.ErrUnauthorized, errorTypeInvalidRequest},
+		"unsupported":  {llmerrors.ErrUnsupported, errorTypeInvalidRequest},
+		"rejected":     {llmerrors.ErrRejected, errorTypeRateLimitExceeded},
+		"timeout":      {llmerrors.ErrTimeout, errorTypeServerError},
+		"unknown":      {llmerrors.ErrUnknown, errorTypeServerError},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			msg := newErrorEnvelope(tc.err)
+			require.Equal(t, tc.expectedType, msg.Error.Type)
+			require.Contains(t, msg.Error.Message, tc.err.Error())
+		})
+	}
+
+	require.Nil(t, newErrorEnvelope(nil))
+}
+
+func TestEndpointParseUsage(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		endpointType         endpointType
+		body                 string
+		expectedInputTokens  int
+		expectedOutputTokens int
+		expectedErr          require.ErrorAssertionFunc
+	}{
+		"responses success": {
+			endpointType:         endpointTypeResponses,
+			body:                 `{"usage":{"input_tokens":15,"output_tokens":20,"total_tokens":35}}`,
+			expectedInputTokens:  15,
+			expectedOutputTokens: 20,
+			expectedErr:          require.NoError,
+		},
+		"responses malformed body": {
+			endpointType: endpointTypeResponses,
+			body:         `{"usage":`,
+			expectedErr:  require.Error,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			in, out, err := Endpoint{endpointType: tc.endpointType}.ParseUsage([]byte(tc.body))
+			tc.expectedErr(t, err)
+			require.Equal(t, tc.expectedInputTokens, in)
+			require.Equal(t, tc.expectedOutputTokens, out)
+		})
+	}
+}
+
+func TestEndpointProcessSSE(t *testing.T) {
+	t.Parallel()
+
+	log := slog.New(slog.DiscardHandler)
+
+	for name, tc := range map[string]struct {
+		endpointType        endpointType
+		stream              string
+		expectedInputTokens int
+		expectedOutput      int
+		expectedErr         require.ErrorAssertionFunc
+		expectedDownstream  func(t *testing.T, body string)
+	}{
+		"responses success extracts usage and forwards events": {
+			endpointType:        endpointTypeResponses,
+			stream:              responsesSuccessStream,
+			expectedInputTokens: 15,
+			expectedOutput:      60,
+			expectedErr:         require.NoError,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Equal(t, responsesSuccessStream+"\n\n", body)
+			},
+		},
+		"responses missing end event forwards events and reports error": {
+			endpointType: endpointTypeResponses,
+			stream: strings.Join([]string{
+				"event: response.created\n" + `data: {"type":"response.created","response":{"id":"resp_123","object":"response"},"sequence_number":0}`,
+				"event: response.output_text.delta\n" + `data: {"type":"response.output_text.delta","delta":"Hello","sequence_number":1}`,
+			}, "\n\n"),
+			expectedErr: require.Error,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.NotEmpty(t, body)
+			},
+		},
+		"responses incomplete event extracts usage and forwards events": {
+			endpointType:        endpointTypeResponses,
+			stream:              responsesIncompleteStream,
+			expectedInputTokens: 15,
+			expectedOutput:      60,
+			expectedErr:         require.NoError,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Equal(t, responsesIncompleteStream+"\n\n", body)
+			},
+		},
+		"responses response.failed surfaces provider error": {
+			endpointType: endpointTypeResponses,
+			stream:       "event: response.failed\n" + `data: {"type":"response.failed","response":{"error":{"type":"server_error","message":"the model failed"}},"sequence_number":5}`,
+			expectedErr:  require.Error,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Equal(
+					t,
+					"event: response.failed\n"+`data: {"type":"response.failed","response":{"error":{"type":"server_error","message":"`+llmerrors.ErrUnknown.Error()+`: the model failed"}},"sequence_number":5}`+"\n\n",
+					body,
+					"expected the exact same SSE event shape with Teleport error, but got a different result",
+				)
+			},
+		},
+		"responses error surfaces provider error": {
+			endpointType: endpointTypeResponses,
+			stream:       "event: error\n" + `data: {"type":"error","message":"the model failed","sequence_number":5}`,
+			expectedErr:  require.Error,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Equal(
+					t,
+					"event: error\n"+`data: {"type":"error","message":"`+llmerrors.ErrUnknown.Error()+`: the model failed","sequence_number":5}`+"\n\n",
+					body,
+					"expected the exact same SSE event shape with Teleport error, but got a different result",
+				)
+			},
+		},
+		"responses invalid response.failed surfaces bad response": {
+			endpointType: endpointTypeResponses,
+			stream:       "event: response.failed\n" + `data: {"type":"response.failed","response":`,
+			expectedErr: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorIs(tt, err, llmerrors.ErrBadResponse, i...)
+			},
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Contains(t, body, llmerrors.ErrBadResponse.Error())
+			},
+		},
+		"responses malformed completed event surfaces bad response": {
+			endpointType: endpointTypeResponses,
+			stream:       "event: response.completed\n" + `data: {"type":"response.completed","response":`,
+			expectedErr:  require.Error,
+			expectedDownstream: func(t *testing.T, body string) {
+				require.Empty(t, body)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var out strings.Builder
+			in, out2, err := Endpoint{endpointType: tc.endpointType}.ProcessSSE(
+				context.Background(),
+				log,
+				io.NopCloser(strings.NewReader(tc.stream)),
+				&out,
+			)
+			tc.expectedErr(t, err)
+			require.Equal(t, tc.expectedInputTokens, in)
+			require.Equal(t, tc.expectedOutput, out2)
+			tc.expectedDownstream(t, out.String())
+		})
+	}
+}
+
+// TestEndpointProcessSSEWriteFailure covers the error-event branch when the
+// downstream write fails: the recorder must still surface the semantic error.
+func TestEndpointProcessSSEWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	log := slog.New(slog.DiscardHandler)
+
+	for name, tc := range map[string]struct {
+		endpointType endpointType
+		stream       string
+		expectedErr  require.ErrorAssertionFunc
+	}{
+		"responses.failed event error surfaces to downstream": {
+			endpointType: endpointTypeResponses,
+			stream:       "event: response.failed\n" + `data: {"type":"response.failed","response":{"error":{"type":"server_error","message":"the model failed"}}}`,
+			expectedErr: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorContains(tt, err, "the model failed")
+			},
+		},
+		"responses.failed error event surfaces to downstream as bad response": {
+			endpointType: endpointTypeResponses,
+			stream:       "event: response.failed\n" + `data: {"type":"response.failed","response":`,
+			expectedErr: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorIs(tt, err, llmerrors.ErrBadResponse, i...)
+			},
+		},
+		"responses error event surfaces to downstream": {
+			endpointType: endpointTypeResponses,
+			stream:       "event: error\n" + `data: {"type":"server_error","message":"the model failed"}`,
+			expectedErr: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorContains(tt, err, "the model failed")
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			w := llmtesting.NewFailingResponseWriter("text/event-stream")
+			_, _, err := Endpoint{endpointType: tc.endpointType}.ProcessSSE(
+				context.Background(),
+				log,
+				io.NopCloser(strings.NewReader(tc.stream)),
+				w,
+			)
+			tc.expectedErr(t, err)
+		})
+	}
+}
+
+// buildResponsesBody returns a valid non-streaming responses API response whose
+// total size is roughly fillerBytes.
+func buildResponsesBody(fillerBytes int) []byte {
+	text := strings.Repeat("A", fillerBytes)
+	return fmt.Appendf(nil,
+		`{"id":"resp_123","object":"response","output":[{"type":"message","content":[{"type":"output_text","text":%q}]}],"usage":{"input_tokens":15,"output_tokens":20,"total_tokens":35}}`,
+		text,
+	)
+}
+
+// buildResponsesStreamEvents returns valid responses API SSE events.
+func buildResponsesStreamEvents(numEvents int) [][]byte {
+	events := make([][]byte, 0, numEvents+2)
+	events = append(events, []byte("event: response.created\n"+`data: {"type":"response.created","response":{"id":"resp_123","object":"response"}}`+"\n\n"))
+	for range numEvents {
+		events = append(events, []byte("event: response.output_text.delta\n"+`data: {"type":"response.output_text.delta","delta":"Hello world"}`+"\n\n"))
+	}
+	events = append(events, []byte("event: response.completed\n"+`data: {"type":"response.completed","response":{"usage":{"input_tokens":15,"output_tokens":60,"total_tokens":75}}}`+"\n\n"))
+	return events
+}
+
+// BenchmarkResponseRecorderJSON tracks the non-streaming path for each API
+// endpoint format.
+//
+//	go test ./lib/srv/app/llm/openai/ -run '^$' -bench BenchmarkResponseRecorderJSON -benchmem
+func BenchmarkResponseRecorderJSON(b *testing.B) {
+	log := slog.New(slog.DiscardHandler)
+	for _, bc := range []struct {
+		name string
+		ep   endpointType
+		body []byte
+	}{
+		{"responses/small", endpointTypeResponses, buildResponsesBody(16)},
+		{"responses/medium_32KB", endpointTypeResponses, buildResponsesBody(32 * 1024)},
+		{"responses/large_1MB", endpointTypeResponses, buildResponsesBody(1024 * 1024)},
+	} {
+		b.Run(bc.name, func(b *testing.B) {
+			b.SetBytes(int64(len(bc.body)))
+			b.ReportAllocs()
+
+			for b.Loop() {
+				w := llmtesting.NewDiscardResponseWriter("application/json")
+				rec, err := NewResponseRecorder(log, &RequestInfo{endpointType: bc.ep}, w)
+				require.NoError(b, err)
+				rec.WriteHeader(http.StatusOK)
+				_, err = rec.Write(bc.body)
+				require.NoError(b, err)
+				require.NoError(b, rec.Close())
+			}
+		})
+	}
+}
+
+// BenchmarkResponseRecorderStream issues one Write per SSE event for each API
+// endpoint format.
+//
+//	go test ./lib/srv/app/llm/openai/ -run '^$' -bench BenchmarkResponseRecorderStream -benchmem
+func BenchmarkResponseRecorderStream(b *testing.B) {
+	log := slog.New(slog.DiscardHandler)
+	for _, bc := range []struct {
+		name   string
+		ep     endpointType
+		events [][]byte
+	}{
+		{"responses/32_events", endpointTypeResponses, buildResponsesStreamEvents(32)},
+		{"responses/256_events", endpointTypeResponses, buildResponsesStreamEvents(256)},
+		{"responses/1024_events", endpointTypeResponses, buildResponsesStreamEvents(1024)},
+	} {
+		var total int
+		for _, e := range bc.events {
+			total += len(e)
+		}
+		b.Run(bc.name, func(b *testing.B) {
+			b.SetBytes(int64(total))
+			b.ReportAllocs()
+
+			for b.Loop() {
+				w := llmtesting.NewDiscardResponseWriter("text/event-stream")
+				rec, err := NewResponseRecorder(log, &RequestInfo{endpointType: bc.ep}, w)
+				require.NoError(b, err)
+				rec.WriteHeader(http.StatusOK)
+				for _, e := range bc.events {
+					_, err := rec.Write(e)
+					require.NoError(b, err)
+				}
+				// Close waits for the SSE-processing goroutine to drain.
+				require.NoError(b, rec.Close())
+			}
+		})
+	}
+}

--- a/lib/srv/app/llm/openai/types.go
+++ b/lib/srv/app/llm/openai/types.go
@@ -32,7 +32,8 @@ import (
 type endpointType string
 
 const (
-	endpointTypeResponses endpointType = "responses"
+	endpointTypeResponses       endpointType = "responses"
+	endpointTypeChatCompletions endpointType = "chat_completions"
 )
 
 // RequestInfo contains the request information.
@@ -54,6 +55,7 @@ type apiRequest interface {
 	SetModel(string)
 	GetStream() bool
 	EnableReportUsage()
+	DisableDataRetention()
 	Validate() error
 }
 
@@ -68,6 +70,11 @@ type responsesAPIRequest struct {
 	Store      bool   `json:"store"`
 
 	raw map[string]json.RawMessage `json:"-"`
+}
+
+func (r *responsesAPIRequest) DisableDataRetention() {
+	r.Store = false
+	r.Background = false
 }
 
 // Nothing to do, usage is always reported on responses API.
@@ -86,6 +93,11 @@ func (r *responsesAPIRequest) Validate() error {
 	return nil
 }
 
+var (
+	_ (apiRequest) = (*responsesAPIRequest)(nil)
+	_ (apiRequest) = (*chatCompletionsAPIRequest)(nil)
+)
+
 func (r *responsesAPIRequest) UnmarshalJSON(data []byte) error {
 	type Alias responsesAPIRequest
 	aux := &struct{ *Alias }{Alias: (*Alias)(r)}
@@ -100,7 +112,7 @@ func (r *responsesAPIRequest) UnmarshalJSON(data []byte) error {
 
 	for key := range raw {
 		switch strings.ToLower(key) {
-		case "model", "stream", "background":
+		case "model", "stream", "store", "background":
 			delete(raw, key)
 		default:
 		}
@@ -121,8 +133,100 @@ func (r responsesAPIRequest) MarshalJSON() ([]byte, error) {
 			return nil, trace.Wrap(err)
 		}
 	}
-	// [Background] and [Store] are expected to always be set `false`, so no
-	// need to marshal it.
+	if err := marshalField(final, "background", r.Background); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := marshalField(final, "store", r.Store); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	res, err := utils.FastMarshal(final)
+	return res, trace.Wrap(err)
+}
+
+// chatCompletionsAPIRequestStreamOptions contains `stream_options` fields from
+// chat completions API.
+type chatCompletionsAPIRequestStreamOptions struct {
+	// `include_obfuscation` defaults to `true` when not set in OpenAI spec,
+	// meaning that we must avoid emitting the value when it is not set to
+	// comply with the default behavior.
+	IncludeObfuscation *bool `json:"include_obfuscation,omitempty"`
+	IncludeUsage       bool  `json:"include_usage"`
+}
+
+// chatCompletionsAPIRequest contains part of the fields from chat completions
+// API request body.
+//
+// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
+type chatCompletionsAPIRequest struct {
+	Model         string                                 `json:"model"`
+	Stream        bool                                   `json:"stream"`
+	StreamOptions chatCompletionsAPIRequestStreamOptions `json:"stream_options"`
+	Store         bool                                   `json:"store"`
+
+	raw map[string]json.RawMessage `json:"-"`
+}
+
+func (r *chatCompletionsAPIRequest) DisableDataRetention() {
+	r.Store = false
+}
+
+func (r *chatCompletionsAPIRequest) EnableReportUsage() {
+	r.StreamOptions.IncludeUsage = true
+}
+func (r *chatCompletionsAPIRequest) GetModel() string      { return r.Model }
+func (r *chatCompletionsAPIRequest) GetStream() bool       { return r.Stream }
+func (r *chatCompletionsAPIRequest) SetModel(model string) { r.Model = model }
+func (r *chatCompletionsAPIRequest) Validate() error {
+	if r.Store {
+		return llmerrors.NewProviderError(llmerrors.ErrUnsupported, "storing chat completions not supported")
+	}
+
+	return nil
+}
+
+func (r *chatCompletionsAPIRequest) UnmarshalJSON(data []byte) error {
+	type Alias chatCompletionsAPIRequest
+	aux := &struct{ *Alias }{Alias: (*Alias)(r)}
+	if err := caseSensitiveJSONConfig.Unmarshal(data, aux); err != nil {
+		return trace.Wrap(err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := utils.FastUnmarshal(data, &raw); err != nil {
+		return trace.Wrap(err)
+	}
+
+	for key := range raw {
+		switch strings.ToLower(key) {
+		case "model", "stream", "stream_options", "store":
+			delete(raw, key)
+		default:
+		}
+	}
+
+	r.raw = raw
+	return nil
+}
+
+func (r chatCompletionsAPIRequest) MarshalJSON() ([]byte, error) {
+	final := make(map[string]json.RawMessage, len(r.raw)+4) // Current len + taken fields.
+	maps.Copy(final, r.raw)
+	if err := marshalField(final, "model", r.Model); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := marshalField(final, "stream", r.Stream); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := marshalField(final, "store", r.Store); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// We must include `stream_options` only for streaming requests, as some
+	// providers might reject it as bad request.
+	if r.Stream {
+		if err := marshalField(final, "stream_options", r.StreamOptions); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
 	res, err := utils.FastMarshal(final)
 	return res, trace.Wrap(err)
 }
@@ -171,6 +275,18 @@ type responsesErrorSSEEvent struct {
 	Type           string `json:"type"`
 	Message        string `json:"message"`
 	SequenceNumber int    `json:"sequence_number"`
+}
+
+// chatCompletionsResponse contains part of the fields from chat completions API
+// response body.
+//
+// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create#(resource)%20chat.completions%20%3E%20(model)%20chat_completion%20%3E%20(schema)
+type chatCompletionsResponse struct {
+	Usage *struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+	} `json:"usage"`
+	Error *errorMessage `json:"error"`
 }
 
 // caseSensitiveJSONConfig is used to decode JSON messages. The config is

--- a/lib/srv/app/llm/openai/types.go
+++ b/lib/srv/app/llm/openai/types.go
@@ -1,0 +1,185 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package openai
+
+import (
+	"encoding/json"
+	"maps"
+	"strings"
+
+	"github.com/gravitational/trace"
+	jsoniter "github.com/json-iterator/go"
+
+	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// endpointType is the OpenAI API endpoint format.
+type endpointType string
+
+const (
+	endpointTypeResponses endpointType = "responses"
+)
+
+// RequestInfo contains the request information.
+type RequestInfo struct {
+	requestedModel string
+	providerModel  string
+	stream         bool
+	requestSize    int
+	endpointType   endpointType
+}
+
+func (r *RequestInfo) RequestedModel() string { return r.requestedModel }
+func (r *RequestInfo) ProviderModel() string  { return r.providerModel }
+func (r *RequestInfo) IsStream() bool         { return r.stream }
+func (r *RequestInfo) RequestSize() int       { return r.requestSize }
+
+type apiRequest interface {
+	GetModel() string
+	SetModel(string)
+	GetStream() bool
+	EnableReportUsage()
+	Validate() error
+}
+
+// responsesAPIRequest contains part of the fields from responses API request
+// body.
+//
+// https://developers.openai.com/api/reference/resources/responses/methods/create
+type responsesAPIRequest struct {
+	Model      string `json:"model"`
+	Stream     bool   `json:"stream"`
+	Background bool   `json:"background"`
+	Store      bool   `json:"store"`
+
+	raw map[string]json.RawMessage `json:"-"`
+}
+
+// Nothing to do, usage is always reported on responses API.
+func (r *responsesAPIRequest) EnableReportUsage()    {}
+func (r *responsesAPIRequest) GetModel() string      { return r.Model }
+func (r *responsesAPIRequest) GetStream() bool       { return r.Stream }
+func (r *responsesAPIRequest) SetModel(model string) { r.Model = model }
+func (r *responsesAPIRequest) Validate() error {
+	if r.Background {
+		return llmerrors.NewProviderError(llmerrors.ErrUnsupported, "background responses not supported")
+	}
+	if r.Store {
+		return llmerrors.NewProviderError(llmerrors.ErrUnsupported, "storing responses not supported")
+	}
+
+	return nil
+}
+
+func (r *responsesAPIRequest) UnmarshalJSON(data []byte) error {
+	type Alias responsesAPIRequest
+	aux := &struct{ *Alias }{Alias: (*Alias)(r)}
+	if err := caseSensitiveJSONConfig.Unmarshal(data, aux); err != nil {
+		return trace.Wrap(err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := utils.FastUnmarshal(data, &raw); err != nil {
+		return trace.Wrap(err)
+	}
+
+	for key := range raw {
+		switch strings.ToLower(key) {
+		case "model", "stream", "background":
+			delete(raw, key)
+		default:
+		}
+	}
+
+	r.raw = raw
+	return nil
+}
+
+func (r responsesAPIRequest) MarshalJSON() ([]byte, error) {
+	final := make(map[string]json.RawMessage, len(r.raw)+2) // Current len + taken fields.
+	maps.Copy(final, r.raw)
+	if err := marshalField(final, "model", r.Model); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if r.Stream {
+		if err := marshalField(final, "stream", r.Stream); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	// [Background] and [Store] are expected to always be set `false`, so no
+	// need to marshal it.
+	res, err := utils.FastMarshal(final)
+	return res, trace.Wrap(err)
+}
+
+func marshalField(raw map[string]json.RawMessage, fieldName string, value any) error {
+	field, err := json.Marshal(value)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	raw[fieldName] = field
+	return nil
+}
+
+// responsesAPIUsage contains part of the fields from responses API response
+// body.
+//
+// https://developers.openai.com/api/reference/resources/responses/methods/create#(resource)%20responses%20%3E%20(model)%20response%20%3E%20(schema)
+type responsesAPIUsage struct {
+	Usage struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+	} `json:"usage"`
+}
+
+// responsesSSEEventWithUsage contains part of responses SSE event that contains
+// `usage` information.
+type responsesSSEEventWithUsage struct {
+	Response responsesAPIUsage `json:"response"`
+}
+
+// responsesFailedSSEEvent contains part of the fields from responses API
+// `response.failed` SSE event.
+//
+// https://developers.openai.com/api/reference/resources/responses/streaming-events#response.failed
+type responsesFailedSSEEvent struct {
+	Type           string        `json:"type"`
+	Response       errorEnvelope `json:"response"`
+	SequenceNumber int           `json:"sequence_number"`
+}
+
+// responsesErrorSSEEvent contains part of the fields from responses API `error`
+// SSE event.
+//
+// https://developers.openai.com/api/reference/resources/responses/streaming-events#error
+type responsesErrorSSEEvent struct {
+	Type           string `json:"type"`
+	Message        string `json:"message"`
+	SequenceNumber int    `json:"sequence_number"`
+}
+
+// caseSensitiveJSONConfig is used to decode JSON messages. The config is
+// based on jsoniter.ConfigCompatibleWithStandardLibrary with the addition of
+// CaseSensitive enabled.
+// TODO(gabrielcorado): Migrate to encoding/json/v2 once it's out of experimentation.
+var caseSensitiveJSONConfig = jsoniter.Config{
+	EscapeHTML:             true,
+	SortMapKeys:            true,
+	ValidateJsonRawMessage: true,
+	CaseSensitive:          true,
+}.Froze()

--- a/lib/srv/app/llm/openai/types_test.go
+++ b/lib/srv/app/llm/openai/types_test.go
@@ -169,7 +169,7 @@ func TestEncodeResponsesRequest(t *testing.T) {
 			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
 				resp, ok := i1.(string)
 				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
-				require.JSONEq(tt, `{"model": "gpt-5", "stream": true, "max_output_tokens": 1024, "input":"Hello"}`, resp)
+				require.JSONEq(tt, `{"model": "gpt-5", "stream": true, "max_output_tokens": 1024, "input":"Hello","store":false,"background":false}`, resp)
 			},
 		},
 		"modified fields": {
@@ -182,7 +182,7 @@ func TestEncodeResponsesRequest(t *testing.T) {
 			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
 				resp, ok := i1.(string)
 				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
-				require.JSONEq(tt, `{"model": "gpt-5-mini", "max_output_tokens": 1024, "input":"Hello"}`, resp)
+				require.JSONEq(tt, `{"model": "gpt-5-mini", "max_output_tokens": 1024, "input":"Hello","store":false,"background":false}`, resp)
 			},
 		},
 		"set model via SetModel": {
@@ -194,7 +194,7 @@ func TestEncodeResponsesRequest(t *testing.T) {
 			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
 				resp, ok := i1.(string)
 				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
-				require.JSONEq(tt, `{"model": "gpt-4o", "stream": true, "max_output_tokens": 1024, "input":"Hello"}`, resp)
+				require.JSONEq(tt, `{"model": "gpt-4o", "stream": true, "max_output_tokens": 1024, "input":"Hello","store":false,"background":false}`, resp)
 			},
 		},
 		"duplicate fields": {
@@ -204,7 +204,7 @@ func TestEncodeResponsesRequest(t *testing.T) {
 			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
 				resp, ok := i1.(string)
 				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
-				require.JSONEq(tt, `{"model": "gpt-5-mini", "max_output_tokens": 5555, "input":"Hello"}`, resp)
+				require.JSONEq(tt, `{"model": "gpt-5-mini", "max_output_tokens": 5555, "input":"Hello","store":false,"background":false}`, resp)
 			},
 		},
 		"duplicate fields different casing": {
@@ -215,7 +215,7 @@ func TestEncodeResponsesRequest(t *testing.T) {
 				resp, ok := i1.(string)
 				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
 				// Expect values from lowercase keys.
-				require.JSONEq(tt, `{"model": "gpt-5", "stream": true, "input":"Hello"}`, resp)
+				require.JSONEq(tt, `{"model": "gpt-5", "stream": true, "input":"Hello","store":false,"background":false}`, resp)
 			},
 		},
 		"full uppercase keys": {
@@ -225,7 +225,7 @@ func TestEncodeResponsesRequest(t *testing.T) {
 			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
 				resp, ok := i1.(string)
 				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
-				require.JSONEq(tt, `{"model": "", "input":"Hello"}`, resp)
+				require.JSONEq(tt, `{"model": "", "input":"Hello","store":false,"background":false}`, resp)
 			},
 		},
 		"valid json missing fields": {
@@ -235,12 +235,254 @@ func TestEncodeResponsesRequest(t *testing.T) {
 			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
 				resp, ok := i1.(string)
 				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
-				require.JSONEq(tt, `{"model": "", "input":"Hello"}`, resp)
+				require.JSONEq(tt, `{"model": "", "input":"Hello","store":false,"background":false}`, resp)
 			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			var r responsesAPIRequest
+			require.NoError(t, utils.FastUnmarshal([]byte(tc.input), &r))
+			tc.modifyRequest(&r)
+
+			res, err := utils.FastMarshal(r)
+			tc.expectError(t, err)
+			tc.expectValue(t, string(res))
+		})
+	}
+}
+
+func TestParseChatCompletionsRequest(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input       string
+		expectError require.ErrorAssertionFunc
+		expectValue require.ValueAssertionFunc
+	}{
+		"valid json with fields": {
+			input:       `{"model": "gpt-5", "stream": true, "max_completion_tokens": 1024, "stream_options": {"include_usage": true}, "messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(chatCompletionsAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Equal(tt, "gpt-5", req.Model, i2...)
+				require.True(tt, req.Stream, i2...)
+				require.True(tt, req.StreamOptions.IncludeUsage, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"valid json missing fields": {
+			input:       `{"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(chatCompletionsAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Empty(tt, req.Model, i2...)
+				require.False(tt, req.Stream, i2...)
+				require.False(tt, req.StreamOptions.IncludeUsage, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"model duplicates": {
+			input:       `{"model":"gpt-5","model":"gpt-5-mini","MODEL":"gpt-4o","max_completion_tokens":1024,"stream":true,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(chatCompletionsAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Equal(tt, "gpt-5-mini", req.Model, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"model duplicates different casing": {
+			input:       `{"model":"gpt-5","MODEL":"gpt-4o","max_completion_tokens":1024,"stream":true,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(chatCompletionsAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Equal(tt, "gpt-5", req.Model, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"stream duplicates": {
+			input:       `{"model":"gpt-5","stream":true,"stream":false,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(chatCompletionsAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.False(tt, req.Stream, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"stream duplicates different casing": {
+			input:       `{"model":"gpt-5","stream":true,"STREAM":false,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(chatCompletionsAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.True(tt, req.Stream, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"max completion tokens duplicates": {
+			input:       `{"model":"gpt-5","max_completion_tokens":1024,"max_completion_tokens":5555,"stream":true,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(chatCompletionsAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"max completion tokens duplicates different casing": {
+			input:       `{"model":"gpt-5","max_completion_tokens":1024,"MAX_COMPLETION_TOKENS":9999,"stream":true,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(chatCompletionsAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"fields in uppercase": {
+			input:       `{"MODEL":"gpt-5","MAX_COMPLETION_TOKENS":1024,"STREAM":true,"messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(chatCompletionsAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Empty(tt, req.Model, i2...)
+				require.False(tt, req.Stream, i2...)
+				require.Contains(tt, req.raw, "messages")
+			},
+		},
+		"stream invalid format": {
+			input:       `{"model":"gpt-5","stream":"yes","messages":[{"role":"user","content":"Hello"}]}`,
+			expectError: require.Error,
+			expectValue: require.NotEmpty,
+		},
+		"duplicated other fields no error": {
+			input:       `{"model": "gpt-5", "stream": true, "max_completion_tokens": 1024, "messages":[{"role":"user","content":"Hello"}], "reasoning_effort": "low", "reasoning_effort": "high"}`,
+			expectError: require.NoError,
+			expectValue: require.NotEmpty,
+		},
+		"invalid json": {
+			input:       `{random}`,
+			expectError: require.Error,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(chatCompletionsAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Empty(tt, req.Model, i2...)
+				require.False(tt, req.Stream, i2...)
+				require.Empty(tt, req.raw, i2...)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var r chatCompletionsAPIRequest
+			tc.expectError(t, utils.FastUnmarshal([]byte(tc.input), &r))
+			tc.expectValue(t, r)
+		})
+	}
+}
+
+func TestEncodeChatCompletionsRequest(t *testing.T) {
+	// For this test we use the value generated from a raw chat completions API
+	// request, so effectively we're also testing the parsing/decoding part as
+	// well.
+
+	for name, tc := range map[string]struct {
+		input         string
+		modifyRequest func(*chatCompletionsAPIRequest)
+		output        string
+		expectError   require.ErrorAssertionFunc
+		expectValue   require.ValueAssertionFunc
+	}{
+		"unmodified fields": {
+			input:         `{"model": "gpt-5", "stream": true, "max_completion_tokens": 1024, "stream_options": {"include_obfuscation": false, "include_usage": false}, "messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *chatCompletionsAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "gpt-5", "stream": true, "max_completion_tokens": 1024, "stream_options": {"include_obfuscation": false, "include_usage": false}, "messages":[{"role":"user","content":"Hello"}],"store":false}`, resp)
+			},
+		},
+		"modified fields": {
+			input: `{"model": "gpt-5", "stream": true, "max_completion_tokens": 1024, "messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *chatCompletionsAPIRequest) {
+				r.Model = "gpt-5-mini"
+				r.Stream = false
+			},
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "gpt-5-mini", "stream": false, "max_completion_tokens": 1024, "messages":[{"role":"user","content":"Hello"}],"store":false}`, resp)
+			},
+		},
+		"enable report usage": {
+			input: `{"model": "gpt-5", "stream": true, "max_completion_tokens": 1024, "messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *chatCompletionsAPIRequest) {
+				r.EnableReportUsage()
+			},
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "gpt-5", "stream": true, "max_completion_tokens": 1024, "stream_options": {"include_usage": true}, "messages":[{"role":"user","content":"Hello"}],"store":false}`, resp)
+			},
+		},
+		"enable report usage with obfuscation": {
+			input: `{"model": "gpt-5", "stream": true, "stream_options": {"include_obfuscation": false}, "max_completion_tokens": 1024, "messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *chatCompletionsAPIRequest) {
+				r.EnableReportUsage()
+			},
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "gpt-5", "stream": true, "max_completion_tokens": 1024, "stream_options": {"include_obfuscation": false, "include_usage": true}, "messages":[{"role":"user","content":"Hello"}],"store":false}`, resp)
+			},
+		},
+		"duplicate fields": {
+			input:         `{"model": "gpt-5", "model": "gpt-5-mini", "stream": true, "stream": false, "max_completion_tokens": 1024, "max_completion_tokens": 5555, "messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *chatCompletionsAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "gpt-5-mini", "stream": false, "max_completion_tokens": 5555, "messages":[{"role":"user","content":"Hello"}],"store":false}`, resp)
+			},
+		},
+		"duplicate fields different casing": {
+			input:         `{"model": "gpt-5", "MODEL": "gpt-5-mini", "stream": true, "STREAM": false, "messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *chatCompletionsAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				// Expect values from lowercase keys.
+				require.JSONEq(tt, `{"model": "gpt-5", "stream": true, "stream_options": {"include_usage": false}, "messages":[{"role":"user","content":"Hello"}],"store":false}`, resp)
+			},
+		},
+		"full uppercase keys": {
+			input:         `{"MODEL": "gpt-5", "STREAM": true, "messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *chatCompletionsAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "", "stream": false, "messages":[{"role":"user","content":"Hello"}],"store":false}`, resp)
+			},
+		},
+		"valid json missing fields": {
+			input:         `{"messages":[{"role":"user","content":"Hello"}]}`,
+			modifyRequest: func(r *chatCompletionsAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "", "stream": false, "messages":[{"role":"user","content":"Hello"}],"store":false}`, resp)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var r chatCompletionsAPIRequest
 			require.NoError(t, utils.FastUnmarshal([]byte(tc.input), &r))
 			tc.modifyRequest(&r)
 

--- a/lib/srv/app/llm/openai/types_test.go
+++ b/lib/srv/app/llm/openai/types_test.go
@@ -1,0 +1,252 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package openai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func TestParseResponsesRequest(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input       string
+		expectError require.ErrorAssertionFunc
+		expectValue require.ValueAssertionFunc
+	}{
+		"valid json with fields": {
+			input:       `{"model": "gpt-5", "stream": true, "max_output_tokens": 1024, "input":"Hello"}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(responsesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Equal(tt, "gpt-5", req.Model, i2...)
+				require.True(tt, req.Stream, i2...)
+				require.Contains(tt, req.raw, "input")
+			},
+		},
+		"valid json missing fields": {
+			input:       `{"input":"Hello"}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(responsesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Empty(tt, req.Model, i2...)
+				require.False(tt, req.Stream, i2...)
+				require.Contains(tt, req.raw, "input")
+			},
+		},
+		"model duplicates": {
+			input:       `{"model":"gpt-5","model":"gpt-5-mini","MODEL":"gpt-4o","max_output_tokens":1024,"stream":true,"input":"Hello"}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(responsesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Equal(tt, "gpt-5-mini", req.Model, i2...)
+				require.Contains(tt, req.raw, "input")
+			},
+		},
+		"model duplicates different casing": {
+			input:       `{"model":"gpt-5","MODEL":"gpt-4o","max_output_tokens":1024,"stream":true,"input":"Hello"}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(responsesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Equal(tt, "gpt-5", req.Model, i2...)
+				require.Contains(tt, req.raw, "input")
+			},
+		},
+		"stream duplicates": {
+			input:       `{"model":"gpt-5","stream":true,"stream":false,"input":"Hello"}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(responsesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.False(tt, req.Stream, i2...)
+				require.Contains(tt, req.raw, "input")
+			},
+		},
+		"stream duplicates different casing": {
+			input:       `{"model":"gpt-5","stream":true,"STREAM":false,"input":"Hello"}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(responsesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.True(tt, req.Stream, i2...)
+				require.Contains(tt, req.raw, "input")
+			},
+		},
+		"max output tokens duplicates": {
+			input:       `{"model":"gpt-5","max_output_tokens":1024,"max_output_tokens":5555,"stream":true,"input":"Hello"}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(responsesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Contains(tt, req.raw, "input")
+			},
+		},
+		"max output tokens duplicates different casing": {
+			input:       `{"model":"gpt-5","max_output_tokens":1024,"MAX_OUTPUT_TOKENS":9999,"stream":true,"input":"Hello"}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(responsesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Contains(tt, req.raw, "input")
+			},
+		},
+		"fields in uppercase": {
+			input:       `{"MODEL":"gpt-5","MAX_OUTPUT_TOKENS":1024,"STREAM":true,"input":"Hello"}`,
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(responsesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Empty(tt, req.Model, i2...)
+				require.False(tt, req.Stream, i2...)
+				require.Contains(tt, req.raw, "input")
+			},
+		},
+		"stream invalid format": {
+			input:       `{"model":"gpt-5","stream":"yes","input":"Hello"}`,
+			expectError: require.Error,
+			expectValue: require.NotEmpty,
+		},
+		"duplicated other fields no error": {
+			input:       `{"model": "gpt-5", "stream": true, "max_output_tokens": 1024, "input":"Hello", "reasoning": {"effort": "low"}, "reasoning": {"effort": "high"}}`,
+			expectError: require.NoError,
+			expectValue: require.NotEmpty,
+		},
+		"invalid json": {
+			input:       `{random}`,
+			expectError: require.Error,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				req, ok := i1.(responsesAPIRequest)
+				require.True(tt, ok, "expect type to be %T but got %T", req, i1)
+				require.Empty(tt, req.Model, i2...)
+				require.False(tt, req.Stream, i2...)
+				require.Empty(tt, req.raw, i2...)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var r responsesAPIRequest
+			tc.expectError(t, utils.FastUnmarshal([]byte(tc.input), &r))
+			tc.expectValue(t, r)
+		})
+	}
+}
+
+func TestEncodeResponsesRequest(t *testing.T) {
+	// For this test we use the value generated from a raw responses API request,
+	// so effectively we're also testing the parsing/decoding part as well.
+
+	for name, tc := range map[string]struct {
+		input         string
+		modifyRequest func(*responsesAPIRequest)
+		output        string
+		expectError   require.ErrorAssertionFunc
+		expectValue   require.ValueAssertionFunc
+	}{
+		"unmodified fields": {
+			input:         `{"model": "gpt-5", "stream": true, "max_output_tokens": 1024, "input":"Hello"}`,
+			modifyRequest: func(r *responsesAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "gpt-5", "stream": true, "max_output_tokens": 1024, "input":"Hello"}`, resp)
+			},
+		},
+		"modified fields": {
+			input: `{"model": "gpt-5", "stream": true, "max_output_tokens": 1024, "input":"Hello"}`,
+			modifyRequest: func(r *responsesAPIRequest) {
+				r.Model = "gpt-5-mini"
+				r.Stream = false
+			},
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "gpt-5-mini", "max_output_tokens": 1024, "input":"Hello"}`, resp)
+			},
+		},
+		"set model via SetModel": {
+			input: `{"model": "gpt-5", "stream": true, "max_output_tokens": 1024, "input":"Hello"}`,
+			modifyRequest: func(r *responsesAPIRequest) {
+				r.SetModel("gpt-4o")
+			},
+			expectError: require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "gpt-4o", "stream": true, "max_output_tokens": 1024, "input":"Hello"}`, resp)
+			},
+		},
+		"duplicate fields": {
+			input:         `{"model": "gpt-5", "model": "gpt-5-mini", "stream": true, "stream": false, "max_output_tokens": 1024, "max_output_tokens": 5555, "input":"Hello"}`,
+			modifyRequest: func(r *responsesAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "gpt-5-mini", "max_output_tokens": 5555, "input":"Hello"}`, resp)
+			},
+		},
+		"duplicate fields different casing": {
+			input:         `{"model": "gpt-5", "MODEL": "gpt-5-mini", "stream": true, "STREAM": false, "input":"Hello"}`,
+			modifyRequest: func(r *responsesAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				// Expect values from lowercase keys.
+				require.JSONEq(tt, `{"model": "gpt-5", "stream": true, "input":"Hello"}`, resp)
+			},
+		},
+		"full uppercase keys": {
+			input:         `{"MODEL": "gpt-5", "STREAM": true, "input":"Hello"}`,
+			modifyRequest: func(r *responsesAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "", "input":"Hello"}`, resp)
+			},
+		},
+		"valid json missing fields": {
+			input:         `{"input":"Hello"}`,
+			modifyRequest: func(r *responsesAPIRequest) {},
+			expectError:   require.NoError,
+			expectValue: func(tt require.TestingT, i1 any, i2 ...any) {
+				resp, ok := i1.(string)
+				require.True(tt, ok, "expect type to be %T but got %T", resp, i1)
+				require.JSONEq(tt, `{"model": "", "input":"Hello"}`, resp)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var r responsesAPIRequest
+			require.NoError(t, utils.FastUnmarshal([]byte(tc.input), &r))
+			tc.modifyRequest(&r)
+
+			res, err := utils.FastMarshal(r)
+			tc.expectError(t, err)
+			tc.expectValue(t, string(res))
+		})
+	}
+}

--- a/lib/srv/app/llm/request/request.go
+++ b/lib/srv/app/llm/request/request.go
@@ -68,3 +68,15 @@ func (c *Config) CheckAndSetDefaults() error {
 
 	return nil
 }
+
+// RequestInfo interface that contains the request information.
+type RequestInfo interface {
+	// RequestedModel returns the requested model name.
+	RequestedModel() string
+	// ProviderModel returns the model name sent to the provider.
+	ProviderModel() string
+	// IsStream indicates if the request uses streaming.
+	IsStream() bool
+	// RequestSize contains the total request size in bytes.
+	RequestSize() int
+}

--- a/lib/srv/app/session.go
+++ b/lib/srv/app/session.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/recorder"
+	"github.com/gravitational/teleport/lib/httplib/compress"
 	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
 	rsession "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv"
@@ -215,7 +216,7 @@ func (c *ConnectionsHandler) withGCPHandler(ctx context.Context, sess *sessionCh
 }
 
 func (c *ConnectionsHandler) withLLMHandler(ctx context.Context, sess *sessionChunk, identity *tlsca.Identity, app types.Application) error {
-	sess.handler = c.llmHandler
+	sess.handler = compress.Middleware(c.llmHandler, compress.WithWriteError(c.llmHandler.HandleError))
 	return nil
 }
 


### PR DESCRIPTION
This PR backports LLM access for OpenAI (`openai` and `bedrock` providers). It includes the following:

- #68521
- #68698
- #68818
- #68859

## Manual Test Plan
### Test Environment
Local environment with a dedicated app service instance.

<details>
<summary>App configuration</summary>

```yaml
kind: app
version: v3
metadata:
  name: openai
  description: "OpenAI API"
spec:
  inference:
    format: "openai"
    provider: "openai"
    models:
    - name: gpt-5.6-terra
      provider_name: gpt-5.6-terra
    fallback_model: gpt-5.6-terra
---
kind: app
version: v3
metadata:
  name: openai-bedrock
  description: "OpenAI Bedrock API"
spec:
  inference:
    format: "openai"
    provider: "bedrock"
    models:
    - name: gpt-5.6-terra
      provider_name: openai.gpt-5.6-terra
    fallback_model: gpt-5.6-terra
  aws:
    region: us-east-1
```
</details>

### Test Cases
- [x] Access using `curl` and `codex` (provider: `openai`)


  - [x] Mapped model.
  - [x] Streaming requests.
  - [x] Fallback model.
  - [x] Invalid messages/errors returned are from Teleport.
  - [x] Audit events are included in the app session recording. `tsh play -f json <chunk-id>`
  - [x] Prometheus metrics generated.

- [x] Access using `curl` and `codex` (provider: `bedrock`)
  <details>
  <summary>App configuration</summary>

  ```yaml
  kind: app
  version: v3
  metadata:
    name: anthropic
    description: "Anthropic API"
    labels:
      env: local
  spec:
    integration: aws-oidc-integration
    inference:
      format: "anthropic"
      provider: "bedrock"
      models:
      - name: claude-opus-4-7
        provider_name: anthropic.claude-opus-4-7
      fallback_model: claude-opus-4-7
    aws:
      region: us-east-1
  ```
  </details>

  - [x] Mapped model.
  - [x] Streaming requests.
  - [x] Fallback model.
  - [x] Invalid messages/errors returned are from Teleport.
  - [x] Audit events are included in the app session recording. `tsh play -f json <chunk-id>`
  - [x] Prometheus metrics generated.