### PR TITLE
Fix Windows webassets build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1956,23 +1956,43 @@ ensure-js-deps:
 ifeq ($(WEBASSETS_SKIP_BUILD),1)
 ensure-wasm-deps:
 else
-ensure-wasm-deps: ensure-llvm-macos rustup-toolchain-warning ensure-wasm-bindgen ensure-wasm-opt
+ensure-wasm-deps: ensure-llvm rustup-toolchain-warning ensure-wasm-bindgen ensure-wasm-opt
 
-.PHONY: ensure-llvm-macos
-ifeq ("$(OS)-$(ARCH)","darwin-arm64")
+.PHONY: ensure-llvm
+ifeq ("$(OS)","darwin")
 BREW_DIR = $(shell brew --prefix)
 LLVM_PREFIX = $(shell brew list | grep llvm | head -n 1)
 LLVM_DIR = $(shell brew --prefix $(LLVM_PREFIX))
-CC = $(LLVM_DIR)/bin/clang
-AR = $(LLVM_DIR)/bin/llvm-ar
-ensure-llvm-macos:
-	@if [[ "${BREW_DIR}" = "${LLVM_DIR}" ]]; then \
+# Prevent these from being exported and expanded for every recipe.
+unexport BREW_DIR LLVM_PREFIX LLVM_DIR
+
+# The ironrdp WASM build needs clang/llvm-ar.
+# These are applied as target-specific variables so
+# brew is only invoked when necessary and so that
+# CC and AR are only overwritten for WASM compilation.
+build-ironrdp-wasm: CC = $(LLVM_DIR)/bin/clang
+build-ironrdp-wasm: AR = $(LLVM_DIR)/bin/llvm-ar
+
+ensure-llvm:
+	@if [[ "$(BREW_DIR)" = "$(LLVM_DIR)" ]]; then \
 		echo "llvm is required, please run 'brew install llvm' and add '/opt/homebrew/opt/llvm/bin' at the start of PATH variable"; \
 		exit 1; \
 	fi
 
+else ifeq ("$(OS)","windows")
+LLVM_DIR=$(shell vswhere.exe -latest -requires Microsoft.VisualStudio.Component.VC.Llvm.Clang -property installationPath)
+unexport LLVM_DIR
+build-ironrdp-wasm: CC = $(LLVM_DIR)/VC/Tools/Llvm/x64/bin/clang
+build-ironrdp-wasm: AR = $(LLVM_DIR)/VC/Tools/Llvm/x64/bin/llvm-ar
+
+ensure-llvm:
+	@if [[ "x" = "x$(LLVM_DIR)" ]]; then \
+		echo "llvm is required, please install Visual Studio with LLVM component"; \
+		exit 1; \
+	fi
+
 else
-ensure-llvm-macos:
+ensure-llvm:
 endif
 
 WASM_BINDGEN_VERSION = $(shell awk ' \

--- a/build.assets/Dockerfile-node
+++ b/build.assets/Dockerfile-node
@@ -36,10 +36,12 @@ RUN apt-get -y update && \
     apt-get install -q -y --no-install-recommends \
     build-essential \
     ca-certificates \
+    clang \
     git \
     golang \
     libc6-dev \
     libssl-dev \
+    llvm \
     locales \
     openssh-client \
     pkg-config \

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -45,7 +45,7 @@ reqwest = { version = "0.13", default-features = false }
 rustls = { version = "0.23.40", default-features = false, features = [
     "aws-lc-rs",
 ] }
-qoi  = { version = "0.4.1",  optional = true }
+qoi = { version = "0.4.1", optional = true }
 zstd = { version = "0.13.3", optional = true }
 
 [dev-dependencies]
@@ -58,5 +58,6 @@ cbindgen = "0.29.3"
 tempfile = "3.27.0"
 
 [features]
+default = ["desktop-encoder"]
 fips = ["tokio-boring/fips", "boring/fips"]
 desktop-encoder = ["dep:qoi", "dep:zstd", "ironrdp-session/qoiz"]

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -45,12 +45,13 @@ reqwest = { version = "0.13", default-features = false }
 rustls = { version = "0.23.40", default-features = false, features = [
     "aws-lc-rs",
 ] }
-qoi = { version = "0.4.1", optional = true }
-zstd = { version = "0.13.3", optional = true }
+qoi = "0.4.1"
+zstd = "0.13.3"
 
 [dev-dependencies]
 ironrdp-graphics.workspace = true
 ironrdp-session.workspace = true
+ironrdp-session.features = ["qoiz"]
 base64 = "0.22.1"
 
 [build-dependencies]
@@ -58,6 +59,4 @@ cbindgen = "0.29.3"
 tempfile = "3.27.0"
 
 [features]
-default = ["desktop-encoder"]
 fips = ["tokio-boring/fips", "boring/fips"]
-desktop-encoder = ["dep:qoi", "dep:zstd", "ironrdp-session/qoiz"]

--- a/lib/srv/desktop/rdp/rdpclient/client_qoiz.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_qoiz.go
@@ -1,4 +1,4 @@
-//go:build desktop_access_rdp && desktop_encoder
+//go:build desktop_access_rdp
 
 // Teleport
 // Copyright (C) 2026 Gravitational, Inc.

--- a/lib/srv/desktop/rdp/rdpclient/client_qoiz.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_qoiz.go
@@ -18,17 +18,18 @@
 
 package rdpclient
 
-import (
-	"unsafe"
-
-	"github.com/gravitational/teleport/lib/srv/desktop/tdp/protocol/tdpb"
-	"github.com/gravitational/trace"
-)
-
 /*
 #include <librdpclient.h>
 */
 import "C"
+
+import (
+	"unsafe"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/srv/desktop/tdp/protocol/tdpb"
+)
 
 // EncodeQOIZ encodes changed frame to series of FastPath SetSurface PDUs using QOIZ codec.
 // Resulting frames can be consumed directly by the FastPath processor from IronRDP if qoiz

--- a/lib/srv/desktop/rdp/rdpclient/client_qoiz_stub.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_qoiz_stub.go
@@ -1,4 +1,4 @@
-//go:build !(desktop_access_rdp && desktop_encoder)
+//go:build !desktop_access_rdp
 
 // Teleport
 // Copyright (C) 2026 Gravitational, Inc.

--- a/lib/srv/desktop/rdp/rdpclient/client_qoiz_test.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_qoiz_test.go
@@ -1,4 +1,4 @@
-//go:build desktop_access_rdp && desktop_encoder
+//go:build desktop_access_rdp
 
 /*
  * *

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -49,7 +49,6 @@ use util::{from_c_string, from_go_array};
 pub mod client;
 mod cliprdr;
 mod license;
-#[cfg(feature = "desktop-encoder")]
 mod linux_desktop_encoder;
 mod network_client;
 mod piv;

--- a/web/packages/shared/libs/ironrdp/Cargo.toml
+++ b/web/packages/shared/libs/ironrdp/Cargo.toml
@@ -29,5 +29,5 @@ wasm-bindgen = "0.2.95"
 web-sys = { version = "0.3.95", features = ["ImageData"] }
 
 [features]
-default = []
+default = ["qoiz"]
 qoiz = ["ironrdp-session/qoiz"]

--- a/web/packages/shared/libs/ironrdp/Cargo.toml
+++ b/web/packages/shared/libs/ironrdp/Cargo.toml
@@ -15,6 +15,7 @@ console_error_panic_hook = "0.1.7"
 getrandom1 = { package = "getrandom", version = "0.2", features = ["js"] }
 getrandom2 = { package = "getrandom", version = "0.4.2", features = ["wasm_js"] }
 ironrdp-session.workspace = true
+ironrdp-session.features = ["qoiz"]
 ironrdp-pdu.workspace = true
 ironrdp-core.workspace = true
 ironrdp-graphics.workspace = true
@@ -27,7 +28,3 @@ tracing-web = "0.1.2"
 uuid = { version = ">=1.16, <1.24", features = ["js"] } # Pinned below 1.21: uuid 1.21+ needs getrandom 0.4 -> rand_core 0.10 (stable), which conflicts with picky rc.22's pinned rand_core = "=0.10.0-rc-3". Remove this pin when picky ships with stable RustCrypto deps.
 wasm-bindgen = "0.2.95"
 web-sys = { version = "0.3.95", features = ["ImageData"] }
-
-[features]
-default = ["qoiz"]
-qoiz = ["ironrdp-session/qoiz"]


### PR DESCRIPTION
This PR fixes building webassets in node buildbox and on Windows machines. It also brings back `qoiz` in default build enabling Linux desktop.
It should also fix slow builds in GNU make on macOS using suggestion from https://github.com/gravitational/teleport/pull/68544#issuecomment-4938849982

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Tag build
### Test Cases
- [x] [tag build](https://github.com/gravitational/teleport.e/actions/runs/30123625898) succeeds
