### PR TITLE
[v18] Adapt `tctl auth create-override-csr` to recent RPC changes

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -719,6 +719,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
+|`--[no-]local-only`|`false`|If true only private keys local to the replying Auth server are used.|
 |`--out`|*no default*|If set writes CSRs to files using --out as the path prefix|
 |`--public-key`|*no default*|Public key hash of CA certificate to be targeted|
 |`--subject`|*no default*|Customized certificate subject. Example: "O=MyClusterName,OU=MyOrgUnit,CN=MyCommonName"|

--- a/tool/tctl/common/subca/subca_command.go
+++ b/tool/tctl/common/subca/subca_command.go
@@ -175,6 +175,9 @@ func (c *Command) Initialize(
 	c.createOverrideCSR.
 		Flag("subject", `Customized certificate subject. Example: "O=MyClusterName,OU=MyOrgUnit,CN=MyCommonName"`).
 		StringVar(&c.createOverrideCSR.subject)
+	c.createOverrideCSR.
+		Flag("local-only", "If true only private keys local to the replying Auth server are used.").
+		BoolVar(&c.createOverrideCSR.localOnly)
 
 	c.createOverride.CmdClause = parent.Command("create-override", "Add a single certificate override to a CA override resource")
 	c.createOverride.Flag("type", caTypesHelp).
@@ -272,6 +275,7 @@ type createOverrideCSRCommand struct {
 	out       string // Output path prefix.
 	publicKey string
 	subject   string
+	localOnly bool
 }
 
 func (c *createOverrideCSRCommand) Run(
@@ -317,6 +321,7 @@ func (c *createOverrideCSRCommand) Run(
 		CaType:        caType,
 		PublicKeyHash: pubKey,
 		CustomSubject: customSubject,
+		LocalOnly:     c.localOnly,
 	}.Build())
 	if err != nil {
 		return trace.Wrap(err, "create CSRs")
@@ -324,6 +329,15 @@ func (c *createOverrideCSRCommand) Run(
 	// Defensive. Should fail server-side if that's the case.
 	if len(resp.GetCsrs()) == 0 {
 		return trace.BadParameter("no CSRs created")
+	}
+
+	// Print warnings to stderr.
+	for _, warn := range resp.GetWarnings() {
+		if pkh := warn.GetPublicKeyHash(); pkh != "" {
+			fmt.Fprintf(s.Stderr, "public key %q: %s\n", pkh, warn.GetUserMessage())
+		} else {
+			fmt.Fprintln(s.Stderr, warn.GetUserMessage())
+		}
 	}
 
 	// If writing to stdout there's no need to parse the PEMs or form filenames.

--- a/tool/tctl/common/subca/subca_command_test.go
+++ b/tool/tctl/common/subca/subca_command_test.go
@@ -56,10 +56,12 @@ func TestCommand_CreateOverrideCSR(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		flags      []string // flags after "tctl auth create-override-csr"
-		csrPEMs    []string // as returned by the server
+		flags      []string                    // flags after "tctl auth create-override-csr"
+		csrPEMs    []string                    // as returned by the server
+		csrWarns   []*subcav1.CreateCSRWarning // as returned by the server
 		wantReq    *subcav1.CreateCSRRequest
 		wantStdout string
+		wantStderr string
 		wantFiles  map[string]string // filepath to content
 	}{
 		{
@@ -152,13 +154,38 @@ func TestCommand_CreateOverrideCSR(t *testing.T) {
 				wantWindows2File: windowsCSRPEM2,
 			},
 		},
+		{
+			name: "local only",
+			flags: []string{
+				"--type", string(types.WindowsCA),
+				"--local-only",
+			},
+			csrPEMs: []string{
+				windowsCSRPEM,
+			},
+			// Simulates "windowsCSRPEM2" not being accessible.
+			csrWarns: []*subcav1.CreateCSRWarning{
+				subcav1.CreateCSRWarning_builder{
+					UserMessage:   "private key inaccessible",
+					PublicKeyHash: "11b52b511de1f0d8c4b5e5a3beb053fb5497727d696de6dae338560e4e2f8e0c",
+				}.Build(),
+			},
+			wantReq: subcav1.CreateCSRRequest_builder{
+				CaType:    string(types.WindowsCA),
+				LocalOnly: true,
+			}.Build(),
+			wantStdout: windowsCSRPEM + "\n",
+			wantStderr: `public key "11b52b511de1f0d8c4b5e5a3beb053fb5497727d696de6dae338560e4e2f8e0c": private key inaccessible
+`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
 			fakeClient := &fakeAuthClient{
-				csrPEMs: test.csrPEMs,
+				csrPEMs:  test.csrPEMs,
+				csrWarns: test.csrWarns,
 			}
 			clientFunc := func(ctx context.Context) (_ subca.SubCAClientSource, closeFn func(context.Context), _ error) {
 				return fakeClient, func(ctx context.Context) {}, nil
@@ -179,8 +206,9 @@ func TestCommand_CreateOverrideCSR(t *testing.T) {
 				t.Errorf("CreateCSRRequest mismatch (-want +got)\n%s", diff)
 			}
 
-			// Verify stdout.
+			// Verify stdout/stderr.
 			assert.Equal(t, test.wantStdout, env.Stdout.String(), "stdout mismatch")
+			assert.Equal(t, test.wantStderr, env.Stderr.String(), "stderr mismatch")
 
 			// Verify side effects.
 			for filePath, wantContent := range test.wantFiles {
@@ -776,6 +804,7 @@ type fakeAuthClient struct {
 	subcav1.SubCAServiceClient
 
 	csrPEMs                      []string
+	csrWarns                     []*subcav1.CreateCSRWarning
 	lastCSRRequest               *subcav1.CreateCSRRequest
 	lastAddCertificateRequest    *subcav1.AddCertificateOverrideRequest
 	lastUpdateCertificateRequest *subcav1.UpdateCertificateOverrideRequest
@@ -795,7 +824,8 @@ func (f *fakeAuthClient) CreateCSR(
 	}
 
 	resp := subcav1.CreateCSRResponse_builder{
-		Csrs: make([]*subcav1.CertificateSigningRequest, len(f.csrPEMs)),
+		Csrs:     make([]*subcav1.CertificateSigningRequest, len(f.csrPEMs)),
+		Warnings: f.csrWarns,
 	}.Build()
 	for i, pem := range f.csrPEMs {
 		resp.GetCsrs()[i] = subcav1.CertificateSigningRequest_builder{


### PR DESCRIPTION
Backport #69018 to branch/v18.

https://github.com/gravitational/teleport.e/issues/7675

## Manual Test Plan
### Test Environment

Local HA cluster built with https://github.com/gravitational/teleport.e/pull/9228.

### Test Cases
- [x] `tctl auth create-override-csr --local-only` only issues CSRs that can be signed by the local Auth
- [x] `tctl auth create-override-csr` prints response warnings.