### PR TITLE
[v18] chore: updated the beams sidebar title to be Beams

### DIFF
--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -119,7 +119,7 @@ export enum NavTitle {
   // Beams
   BeamsQuickstart = 'Quickstart',
   BeamsFeedback = 'Feedback',
-  BeamsList = 'My Beams',
+  BeamsList = 'Beams',
 }
 
 export interface TeleportFeatureRoute {


### PR DESCRIPTION
Backport #68902 to branch/v18

## Changes
- This updates beams sidebar sub menu to be called `Beams` instead of `My Beams`. This is because in the beams list view we show both beams created by all users and also beams created by the logged user, so from that standpoint `My Beams` is incorrect.

Note: The change in this PR is going to be used by this PR:  https://github.com/gravitational/teleport.e/pull/9203

<!-- Provide a descriptive entry for the changelog of the next release. -->



<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->