### PR TITLE
Tighten UpsertNode RBAC

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1106,6 +1106,17 @@ func (a *ScopedServerWithRoles) UpsertNode(ctx context.Context, s types.Server) 
 		}
 	}
 
+	// The below check upholds the following two invariants:
+	// - An agentless host cannot be created by an agent, it must be created by an end user
+	// - Only scoped agentless hosts can be created to prevent immutable label modifications
+	_, isAgent := a.scopedContext.LocalServerID()
+	switch {
+	case isAgent && s.IsOpenSSHNode():
+		return nil, trace.BadParameter("%s may not create agentless hosts", a.scopedContext.DisplayName())
+	case s.GetScope() != "" && !s.IsOpenSSHNode():
+		return nil, trace.BadParameter("scoped nodes may not be created via UpsertNode")
+	}
+
 	return a.authServer.UpsertNode(ctx, s)
 }
 

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -9588,69 +9588,94 @@ func TestUpsertScopedNode(t *testing.T) {
 	const nodeName = "test1"
 	const otherID = "test2"
 
-	makeNode := func(t *testing.T, name, scope string) types.Server {
+	makeNode := func(t *testing.T, name, scope, subKind string) types.Server {
+		t.Helper()
+		if subKind == "" {
+			subKind = types.SubKindTeleportNode
+		}
 		node := &types.ServerV2{
 			Kind:    types.KindNode,
-			SubKind: types.SubKindOpenSSHNode,
+			SubKind: subKind,
 			Metadata: types.Metadata{
 				Name: name,
 			},
 			Spec: types.ServerSpecV2{
-				Addr:     "someaddr.com:443",
 				Hostname: name,
 			},
 			Scope: scope,
+		}
+		if node.IsOpenSSHNode() {
+			node.Spec.Addr = "someaddr.com:443"
 		}
 		require.NoError(t, node.CheckAndSetDefaults())
 		return node
 	}
 
 	tests := []struct {
-		name      string
-		server    *auth.ScopedServerWithRoles
-		nodeName  string
-		nodeScope string
-		shouldErr bool
+		name        string
+		server      *auth.ScopedServerWithRoles
+		nodeName    string
+		nodeScope   string
+		nodeSubKind string
+		errCheck    func(error) bool
 	}{
 		{
-			name:      "agent scope - matching ID and scope allowed",
+			name:      "agent scope - matching ID and scope denied",
 			server:    newScopedTestServerForHost(t, authsrv, nodeName, "/staging", types.RoleNode).ScopedServerWithRoles(),
 			nodeName:  nodeName,
 			nodeScope: "/staging",
+			errCheck:  trace.IsBadParameter,
+		},
+		{
+			name:        "agent scope - agentless node denied",
+			server:      newScopedTestServerForHost(t, authsrv, nodeName, "/staging", types.RoleNode).ScopedServerWithRoles(),
+			nodeName:    nodeName,
+			nodeScope:   "/staging",
+			nodeSubKind: types.SubKindOpenSSHNode,
+			errCheck:    trace.IsBadParameter,
 		},
 		{
 			name:      "agent scope - mismatched scope denied",
 			server:    newScopedTestServerForHost(t, authsrv, nodeName, "/staging", types.RoleNode).ScopedServerWithRoles(),
 			nodeName:  nodeName,
 			nodeScope: "/prod",
-			shouldErr: true,
+			errCheck:  trace.IsAccessDenied,
 		},
 		{
 			name:      "agent scope - mismatched ID denied",
 			server:    newScopedTestServerForHost(t, authsrv, nodeName, "/staging", types.RoleNode).ScopedServerWithRoles(),
 			nodeName:  otherID,
 			nodeScope: "/staging",
-			shouldErr: true,
+			errCheck:  trace.IsAccessDenied,
 		},
 		{
-			name:      "agent pin - matching ID and scope allowed",
+			name:      "agent pin - matching ID and scope denied",
 			server:    newScopePinnedTestServerForHost(t, authsrv, nodeName, "/staging", types.RoleNode),
 			nodeName:  nodeName,
 			nodeScope: "/staging",
+			errCheck:  trace.IsBadParameter,
+		},
+		{
+			name:        "agent pin - agentless node denied",
+			server:      newScopePinnedTestServerForHost(t, authsrv, nodeName, "/staging", types.RoleNode),
+			nodeName:    nodeName,
+			nodeScope:   "/staging",
+			nodeSubKind: types.SubKindOpenSSHNode,
+			errCheck:    trace.IsBadParameter,
 		},
 		{
 			name:      "agent pin - node scope orthogonal to pinned scope denied",
 			server:    newScopePinnedTestServerForHost(t, authsrv, nodeName, "/staging", types.RoleNode),
 			nodeName:  nodeName,
 			nodeScope: "/prod",
-			shouldErr: true,
+			errCheck:  trace.IsAccessDenied,
 		},
 		{
 			name:      "agent pin - mismatched ID denied",
 			server:    newScopePinnedTestServerForHost(t, authsrv, nodeName, "/staging", types.RoleNode),
 			nodeName:  otherID,
 			nodeScope: "/staging",
-			shouldErr: true,
+			errCheck:  trace.IsAccessDenied,
 		},
 		{
 			name: "unscoped user with node rules allowed",
@@ -9659,10 +9684,18 @@ func TestUpsertScopedNode(t *testing.T) {
 			nodeName: otherID,
 		},
 		{
-			name:      "unscoped user without node rules denied",
-			server:    newScopedTestServerWithUnscopedUser(t, authsrv, "plain-user", nil),
-			nodeName:  otherID,
-			shouldErr: true,
+			name: "unscoped user with node rules can create scoped agentless node",
+			server: newScopedTestServerWithUnscopedUser(t, authsrv, "scoped-openssh-admin",
+				[]types.Rule{types.NewRule(types.KindNode, []string{types.VerbCreate, types.VerbUpdate})}),
+			nodeName:    "scoped-openssh-node",
+			nodeScope:   "/staging",
+			nodeSubKind: types.SubKindOpenSSHNode,
+		},
+		{
+			name:     "unscoped user without node rules denied",
+			server:   newScopedTestServerWithUnscopedUser(t, authsrv, "plain-user", nil),
+			nodeName: otherID,
+			errCheck: trace.IsAccessDenied,
 		},
 		{
 			// Scoped roles cannot be created with node write permissions, so a scoped
@@ -9676,16 +9709,16 @@ func TestUpsertScopedNode(t *testing.T) {
 				}.Build()),
 			nodeName:  otherID,
 			nodeScope: "/staging",
-			shouldErr: true,
+			errCheck:  trace.IsAccessDenied,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := tt.server.UpsertNode(t.Context(), makeNode(t, tt.nodeName, tt.nodeScope))
-			if tt.shouldErr {
-				require.Error(t, err)
-				require.True(t, trace.IsAccessDenied(err))
+			_, err := tt.server.UpsertNode(t.Context(), makeNode(t, tt.nodeName, tt.nodeScope, tt.nodeSubKind))
+			if tt.errCheck != nil {
+				assert.Error(t, err)
+				assert.True(t, tt.errCheck(err), "unexpected error: %v", err)
 				return
 			}
 			require.NoError(t, err)

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -2923,7 +2923,7 @@ func TestParseSubsystemRequest(t *testing.T) {
 				Hostname: "agentless",
 			},
 		}
-		_, err = nodeClient.UpsertNode(ctx, &agentlessSrv)
+		_, err = f.testSrv.AuthServer.AuthServer.UpsertNode(ctx, &agentlessSrv)
 		require.NoError(t, err)
 
 		router, err := libproxy.NewRouter(libproxy.RouterConfig{

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -893,9 +893,9 @@ func TestScopedAndUnscopedNodeResource(t *testing.T) {
 		Hostname: "scoped-host",
 		Addr:     "127.0.0.1:23",
 	})
-	require.NoError(t, err)
+
 	scopedNode.(*types.ServerV2).Scope = "/staging"
-	_, err = clt.UpsertNode(ctx, scopedNode)
+	_, err = auth.GetAuthServer().UpsertNode(ctx, scopedNode)
 	require.NoError(t, err)
 
 	// Poll until both nodes appear via the unified-resource list (cache propagation).
@@ -970,33 +970,6 @@ func TestScopedAndUnscopedNodeResource(t *testing.T) {
 			select {
 			case <-timeout:
 				require.FailNow(t, "timed out waiting for unscoped-node hostname edit")
-			case <-time.After(100 * time.Millisecond):
-			}
-		}
-	})
-
-	t.Run("edit via two-arg SQN form", func(t *testing.T) {
-		editor := func(name string) error {
-			data, err := os.ReadFile(name)
-			if err != nil {
-				return err
-			}
-			data = bytes.ReplaceAll(data, []byte("scoped-host"), []byte("scoped-host-edited"))
-			return os.WriteFile(name, data, 0600)
-		}
-		_, err := runEditCommand(t, clt, []string{"edit", "node", "/staging::scoped-node"}, withEditor(editor))
-		require.NoError(t, err)
-
-		timeout := time.After(30 * time.Second)
-		for {
-			node, err := clt.GetNode(ctx, apidefaults.Namespace, "scoped-node")
-			if err == nil && node.GetHostname() == "scoped-host-edited" {
-				break
-			}
-			require.NoError(t, err, "unexpected error waiting for scoped-node edit")
-			select {
-			case <-timeout:
-				require.FailNow(t, "timed out waiting for scoped-node hostname edit")
 			case <-time.After(100 * time.Millisecond):
 			}
 		}


### PR DESCRIPTION
RBAC now enforces the following invariants
- A teleport agent cannot create an agentless host
- Scoped teleport agents may not be created, only scoped agentless hosts.

Resolves https://github.com/gravitational/pressure-washing/issues/525.






<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
