### PR TITLE
[v18] Return typed error for expired reusable SSO/browser MFA responses

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -4525,7 +4525,7 @@ func (a *Server) CreateAuthenticateChallenge(ctx context.Context, req *proto.Cre
 		}
 
 		var err error
-		browserMFAReq, err = a.GetMFASession(ctx, req.BrowserMFARequestID)
+		browserMFAReq, err = a.GetMFASessionData(ctx, req.BrowserMFARequestID)
 		if err != nil {
 			a.logger.WarnContext(ctx, "Failed to read MFA session for browser MFA request", "error", err)
 			return nil, trace.AccessDenied("invalid browser MFA request")
@@ -8599,16 +8599,8 @@ func (a *Server) validateMFAAuthResponseInternal(
 			loginData, err = webLogin.Finish(ctx, user, wantypes.CredentialAssertionResponseFromProto(res.Webauthn), requiredExtensions)
 		}
 		if err != nil {
-			if requiredExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES &&
-				trace.IsNotFound(err) {
-				// Do not add extra user messages to
-				// mfa.ErrExpiredReusableMFAResponse. Doing so will prevent
-				// client-side code from using errors.Is to reliably identify
-				// this specific error after it goes through gRPC. The original
-				// error isn't particularly useful to the user anyway, so just
-				// log it at debug level.
-				a.logger.DebugContext(ctx, "Reusable MFA response validation failed and possibly expired", "error", err)
-				return nil, trace.Wrap(&mfa.ErrExpiredReusableMFAResponse)
+			if reuseErr := a.convertToErrExpiredReusableMFAResponse(ctx, err, requiredExtensions); reuseErr != nil {
+				return nil, trace.Wrap(reuseErr)
 			}
 			return nil, trace.AccessDenied("MFA response validation failed: %v", err)
 		}
@@ -8641,6 +8633,50 @@ func (a *Server) validateMFAAuthResponseInternal(
 	default:
 		return nil, trace.BadParameter("unknown or missing MFAAuthenticateResponse type %T", resp.Response)
 	}
+}
+
+// convertToErrExpiredReusableMFAResponse converts err to
+// mfa.ErrExpiredReusableMFAResponse, if appropriate.
+// Returns nil if the conversion should not apply.
+func (a *Server) convertToErrExpiredReusableMFAResponse(ctx context.Context, err error, requiredExtensions *mfav1.ChallengeExtensions) error {
+	if requiredExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES && trace.IsNotFound(err) {
+		a.logger.DebugContext(ctx, "Reusable MFA response validation failed and possibly expired", "error", err)
+		return trace.Wrap(&mfa.ErrExpiredReusableMFAResponse)
+	}
+	return nil
+}
+
+// mfaSessionDataNotFoundMsg is the client-facing error for a missing, foreign, or wrong-flow MFA session.
+const mfaSessionDataNotFoundMsg = "mfa session data not found"
+
+// verifyMFASessionData validates the stored MFA session shared by the SSO and browser MFA verify flows.
+func (a *Server) verifyMFASessionData(
+	ctx context.Context,
+	sessionID,
+	username string,
+	requiredExtensions *mfav1.ChallengeExtensions,
+) (*services.MFASessionData, error) {
+	mfaSess, err := a.GetMFASessionData(ctx, sessionID)
+	if err != nil {
+		if reuseErr := a.convertToErrExpiredReusableMFAResponse(ctx, err, requiredExtensions); reuseErr != nil {
+			return nil, reuseErr
+		}
+		if trace.IsNotFound(err) {
+			return nil, trace.NotFound("%s", mfaSessionDataNotFoundMsg)
+		}
+		return nil, trace.Wrap(err)
+	}
+	if mfaSess.Username != username {
+		return nil, trace.NotFound("%s", mfaSessionDataNotFoundMsg)
+	}
+	if requiredExtensions.Scope != mfaSess.ChallengeExtensions.Scope {
+		return nil, trace.AccessDenied("required scope %q is not satisfied by the given MFA session with scope %q", requiredExtensions.Scope, mfaSess.ChallengeExtensions.Scope)
+	}
+	if requiredExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_NO &&
+		mfaSess.ChallengeExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES {
+		return nil, trace.AccessDenied("the given MFA session allows reuse, but reuse is not permitted in this context")
+	}
+	return mfaSess, nil
 }
 
 func mergeKeySets(a, b types.CAKeySet) types.CAKeySet {

--- a/lib/auth/browser_mfa.go
+++ b/lib/auth/browser_mfa.go
@@ -40,7 +40,7 @@ import (
 func (a *Server) CompleteBrowserMFAChallenge(ctx context.Context, requestID string, webauthnResponse *webauthnpb.CredentialAssertionResponse) (string, error) {
 	const notFoundErrMsg = "mfa session data not found"
 	// Retrieve the MFA session
-	mfaSession, err := a.GetMFASession(ctx, requestID)
+	mfaSession, err := a.GetMFASessionData(ctx, requestID)
 	if trace.IsNotFound(err) {
 		return "", trace.AccessDenied("%s", notFoundErrMsg)
 	} else if err != nil {
@@ -115,28 +115,22 @@ func (a *Server) VerifyBrowserMFASession(ctx context.Context, username, sessionI
 		return nil, trace.BadParameter("webauthn response must be supplied")
 	}
 
-	const notFoundErrMsg = "browser MFA session data not found"
-	mfaSess, err := a.GetMFASessionData(ctx, sessionID)
-	if trace.IsNotFound(err) {
-		return nil, trace.NotFound("%s", notFoundErrMsg)
-	} else if err != nil {
+	mfaSess, err := a.verifyMFASessionData(ctx, sessionID, username, requiredExtensions)
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	// Verify the user's name matches.
-	if mfaSess.Username != username {
-		return nil, trace.NotFound("%s", notFoundErrMsg)
-	}
-
-	// Verify this is a Browser MFA session and not an SSO MFA session.
-	if mfaSess.TSHRedirectURL == "" || mfaSess.ConnectorType != constants.BrowserMFA {
+	// Verify the session was created by the Browser MFA flow:
+	// Browser MFA sessions are created with the browser connector and a client redirect URL.
+	isBrowserMFASession := mfaSess.ConnectorType == constants.BrowserMFA && mfaSess.TSHRedirectURL != ""
+	if !isBrowserMFASession {
 		a.logger.WarnContext(ctx,
-			"The Browser MFA flow was used to access a SSO MFA session.",
+			"Rejecting an MFA session that was not created by the Browser MFA flow.",
 			"request_id", mfaSess.RequestID,
 			"connector_type", mfaSess.ConnectorType,
 			"username", username,
 		)
-		return nil, trace.NotFound("%s", notFoundErrMsg)
+		return nil, trace.NotFound("%s", mfaSessionDataNotFoundMsg)
 	}
 
 	// Check if the MFA session matches the user's Browser MFA settings.
@@ -155,22 +149,6 @@ func (a *Server) VerifyBrowserMFASession(ctx context.Context, username, sessionI
 			)
 		}
 		return nil, trace.AccessDenied("browser MFA not available")
-	}
-
-	// Check if the given scope is satisfied by the challenge scope.
-	if requiredExtensions.Scope != mfaSess.ChallengeExtensions.Scope {
-		return nil, trace.AccessDenied(
-			"required scope %q is not satisfied by the given browser MFA session with scope %q",
-			requiredExtensions.Scope,
-			mfaSess.ChallengeExtensions.Scope,
-		)
-	}
-
-	// If this session is reusable, but this context forbids reusable sessions, return an error.
-	reuseNotPermitted := requiredExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_NO
-	sessionAllowsReuse := mfaSess.ChallengeExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES
-	if reuseNotPermitted && sessionAllowsReuse {
-		return nil, trace.AccessDenied("the given browser MFA session allows reuse, but reuse is not permitted in this context")
 	}
 
 	// Convert from protobuf type to wantypes

--- a/lib/auth/browser_mfa_test.go
+++ b/lib/auth/browser_mfa_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
+	mfa "github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	webauthnpb "github.com/gravitational/teleport/api/types/webauthn"
 	"github.com/gravitational/teleport/lib/auth"
@@ -810,7 +811,7 @@ func TestVerifyBrowserMFASession(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	const notFoundErrMsg = "browser MFA session data not found"
+	const notFoundErrMsg = "mfa session data not found"
 	loginExt := &mfav1.ChallengeExtensions{
 		Scope: mfav1.ChallengeScope_CHALLENGE_SCOPE_LOGIN,
 	}
@@ -878,6 +879,18 @@ func TestVerifyBrowserMFASession(t *testing.T) {
 				require.EqualError(t, err, notFoundErrMsg)
 			})
 		}
+	})
+
+	t.Run("expired reusable MFA response when session is missing and reuse is allowed", func(t *testing.T) {
+		env := newBrowserMFATestEnv(t)
+		reuseExt := &mfav1.ChallengeExtensions{
+			Scope:      mfav1.ChallengeScope_CHALLENGE_SCOPE_USER_SESSION,
+			AllowReuse: mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES,
+		}
+
+		mad, err := env.auth.VerifyBrowserMFASession(ctx, env.webauthnUser.GetName(), "expired-session", &webauthnpb.CredentialAssertionResponse{}, reuseExt)
+		assert.ErrorIs(t, err, &mfa.ErrExpiredReusableMFAResponse)
+		assert.Nil(t, mad)
 	})
 
 	t.Run("access denied when user has no webauthn devices", func(t *testing.T) {

--- a/lib/auth/sso_mfa.go
+++ b/lib/auth/sso_mfa.go
@@ -19,6 +19,7 @@ package auth
 import (
 	"context"
 	"crypto/subtle"
+	"slices"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/oauth2"
@@ -94,28 +95,22 @@ func (a *Server) verifySSOMFASession(ctx context.Context, username, sessionID, t
 		return nil, trace.BadParameter("requested challenge extensions must be supplied.")
 	}
 
-	const notFoundErrMsg = "mfa sso session data not found"
-	mfaSess, err := a.GetMFASessionData(ctx, sessionID)
-	if trace.IsNotFound(err) {
-		return nil, trace.AccessDenied("%s", notFoundErrMsg)
-	} else if err != nil {
+	mfaSess, err := a.verifyMFASessionData(ctx, sessionID, username, requiredExtensions)
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	// Verify the user's name and sso device matches.
-	if mfaSess.Username != username {
-		return nil, trace.AccessDenied("%s", notFoundErrMsg)
-	}
-
-	// Verify this is an SSO MFA session and not a Browser MFA session.
-	if mfaSess.TSHRedirectURL != "" || mfaSess.ConnectorType == constants.BrowserMFA {
+	// Verify the session was created by the SSO MFA flow:
+	// SSO MFA sessions are created with an SSO connector and no client redirect URL.
+	isSSOMFASession := slices.Contains([]string{constants.SAML, constants.OIDC}, mfaSess.ConnectorType) && mfaSess.TSHRedirectURL == ""
+	if !isSSOMFASession {
 		a.logger.WarnContext(ctx,
-			"The SSO MFA flow was used to access a Browser MFA session.",
+			"Rejecting an MFA session that was not created by the SSO MFA flow.",
 			"request_id", mfaSess.RequestID,
 			"connector_type", mfaSess.ConnectorType,
 			"username", username,
 		)
-		return nil, trace.NotFound("%s", notFoundErrMsg)
+		return nil, trace.NotFound("%s", mfaSessionDataNotFoundMsg)
 	}
 
 	// Check if the MFA session matches the user's SSO MFA settings.
@@ -134,16 +129,6 @@ func (a *Server) verifySSOMFASession(ctx context.Context, username, sessionID, t
 	// Verify the token matches.
 	if subtle.ConstantTimeCompare([]byte(mfaSess.Token), []byte(token)) == 0 {
 		return nil, trace.AccessDenied("invalid SSO MFA challenge response")
-	}
-
-	// Check if the given scope is satisfied by the challenge scope.
-	if requiredExtensions.Scope != mfaSess.ChallengeExtensions.Scope {
-		return nil, trace.AccessDenied("required scope %q is not satisfied by the given sso mfa session with scope %q", requiredExtensions.Scope, mfaSess.ChallengeExtensions.Scope)
-	}
-
-	// If this session is reusable, but this context forbids reusable sessions, return an error.
-	if requiredExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_NO && mfaSess.ChallengeExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES {
-		return nil, trace.AccessDenied("the given sso mfa session allows reuse, but reuse is not permitted in this context")
 	}
 
 	if mfaSess.ChallengeExtensions.AllowReuse != mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES {
@@ -202,21 +187,11 @@ func (a *Server) UpsertMFASessionWithToken(ctx context.Context, sd *services.MFA
 	return sd.Token, nil
 }
 
-// GetMFASession returns the MFA session for the given username and sessionID.
-func (a *Server) GetMFASession(ctx context.Context, sessionID string) (*services.MFASessionData, error) {
-	sd, err := a.GetMFASessionData(ctx, sessionID)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return sd, nil
-}
-
 // TODO(danielashare): Remove these wrapper functions once `e` points to the renamed versions
 func (a *Server) UpsertSSOMFASessionWithToken(ctx context.Context, sd *services.MFASessionData) (token string, err error) {
 	return a.UpsertMFASessionWithToken(ctx, sd)
 }
 
 func (a *Server) GetSSOMFASession(ctx context.Context, sessionID string) (*services.MFASessionData, error) {
-	return a.GetMFASession(ctx, sessionID)
+	return a.GetMFASessionData(ctx, sessionID)
 }

--- a/lib/auth/sso_mfa_test.go
+++ b/lib/auth/sso_mfa_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
+	mfa "github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -479,7 +480,26 @@ func TestSSOMFAChallenge_Validation(t *testing.T) {
 			},
 			requiredExtensions: &mfav1.ChallengeExtensions{},
 			assertValidation: func(t *testing.T, mad *authz.MFAAuthData, err error) {
-				require.True(t, trace.IsAccessDenied(err), "expected access denied error but got %v", err)
+				require.True(t, trace.IsNotFound(err), "expected not found error but got %v", err)
+			},
+		},
+		{
+			// The session data backing a reusable response expires on its own TTL,
+			// so a missing session with reuse allowed is reported as an expired
+			// reusable response, not as a generic access denied error.
+			name:     "NOK no session data with reuse allowed",
+			username: samlUser.GetName(),
+			sd:       nil,
+			ssoResponse: &proto.SSOResponse{
+				RequestId: "unknown",
+				Token:     "token",
+			},
+			requiredExtensions: &mfav1.ChallengeExtensions{
+				Scope:      mfav1.ChallengeScope_CHALLENGE_SCOPE_USER_SESSION,
+				AllowReuse: mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES,
+			},
+			assertValidation: func(t *testing.T, mad *authz.MFAAuthData, err error) {
+				require.ErrorIs(t, err, &mfa.ErrExpiredReusableMFAResponse)
 			},
 		},
 		{
@@ -503,7 +523,7 @@ func TestSSOMFAChallenge_Validation(t *testing.T) {
 				Scope: mfav1.ChallengeScope_CHALLENGE_SCOPE_LOGIN,
 			},
 			assertValidation: func(t *testing.T, mad *authz.MFAAuthData, err error) {
-				require.True(t, trace.IsAccessDenied(err), "expected access denied error but got %v", err)
+				require.True(t, trace.IsNotFound(err), "expected not found error but got %v", err)
 			},
 		},
 		{


### PR DESCRIPTION
Backport of #68930 to `branch/v18`.

Clean cherry-pick. No conflicts.