### PR TITLE
[v17] app: Log expired app sessions at debug level

### DIFF
--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -332,7 +332,6 @@ func (h *Handler) handleForwardError(w http.ResponseWriter, req *http.Request, e
 func (h *Handler) authenticate(ctx context.Context, r *http.Request) (*session, error) {
 	ws, err := h.getAppSession(r)
 	if err != nil {
-		h.log.Warnf("Failed to fetch application session: %v.", err)
 		return nil, trace.AccessDenied("invalid session")
 	}
 
@@ -353,7 +352,6 @@ func (h *Handler) authenticate(ctx context.Context, r *http.Request) (*session, 
 func (h *Handler) renewSession(r *http.Request) (*session, error) {
 	ws, err := h.getAppSession(r)
 	if err != nil {
-		h.log.Debugf("Failed to fetch application session: not found.")
 		return nil, trace.AccessDenied("invalid session")
 	}
 
@@ -383,7 +381,14 @@ func (h *Handler) getAppSession(r *http.Request) (ws types.WebSession, err error
 		ws, err = h.getAppSessionFromCookie(r)
 	}
 	if err != nil {
-		h.log.Warnf("Failed to get session: %v.", err)
+		// Missing, expired, or invalid sessions are expected because clients
+		// replay stale cookies, so they are logged at debug rather than
+		// warning level.
+		if trace.IsNotFound(err) || trace.IsAccessDenied(err) {
+			h.log.Debugf("Failed to fetch application session: %v.", err)
+		} else {
+			h.log.Warnf("Failed to fetch application session: %v.", err)
+		}
 		return nil, trace.AccessDenied("invalid session")
 	}
 	return ws, nil
@@ -501,12 +506,12 @@ func (h *Handler) getSession(ctx context.Context, ws types.WebSession) (*session
 
 // extractCookie extracts the cookie from the *http.Request.
 func extractCookie(r *http.Request, cookieName string) (string, error) {
-	rawCookie, err := r.Cookie(cookieName)
-	if err != nil {
-		return "", trace.Wrap(err)
+	rawCookie, _ := r.Cookie(cookieName)
+	if rawCookie == nil {
+		return "", trace.NotFound("cookie %+q not found", cookieName)
 	}
-	if rawCookie != nil && rawCookie.Value == "" {
-		return "", trace.BadParameter("cookie missing")
+	if rawCookie.Value == "" {
+		return "", trace.NotFound("cookie %+q is empty", cookieName)
 	}
 
 	return rawCookie.Value, nil


### PR DESCRIPTION
Log a failed application session lookup at debug level, not warning, when the session is missing, expired, or invalid. Otherwise a client that keeps sending requests with a stale cookie, such as a browser tab polling after the session TTL elapses, floods the proxy logs with a full stack trace on every request.

Keep the warning for unexpected failures such as backend connection problems. Drop the duplicate log that `authenticate` and `renewSession` emitted on top of `getAppSession`, so a failed lookup logs at most once.

Issue: https://github.com/gravitational/teleport/issues/66138
Backport: https://github.com/gravitational/teleport/pull/68918

Changelog: Reduced log spam from expired application sessions.

## Manual Test Plan

### Test Environment

macOS, single local Teleport process running auth, proxy, and app service, with one HTTP app registered and log severity set to `DEBUG`.

### Test Cases

#### Test 1: Invalid app session cookie logs at debug (with fix)

Send several requests to a proxied app carrying an invalid app session cookie, so each request fails the session lookup before forwarding. No login, user, or running backend app is required.

- [x] Each request logs `Failed to fetch application session` at debug level.
- [x] No warning is logged for that message.
- [x] The message is logged at most once per failed request, not twice.

#### Test 2: Valid session unaffected

Log in, launch the app, and confirm normal access still works and no session-fetch warnings appear during use.

- [x] After login, the app loads and authenticated requests forward with HTTP 200.
- [x] No warning is logged during normal app use; the pre-auth misses from the launch redirect are logged at debug level.

#### Test 3: Regression baseline (without fix)

Build the `branch/v17` commit before the fix and repeat Test 1.

- [x] The pre-fix build logs the failed lookup at warning level (twice per request), confirming the pre-fix behaviour the PR changes.


