### PR TITLE
[v18] Adding kube resources to scoped roles

### DIFF
--- a/api/gen/proto/go/teleport/scopes/access/v1/role_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role_protohybrid.pb.go
@@ -932,6 +932,8 @@ type ScopedRoleKube struct {
 	Groups []string `protobuf:"bytes,2,rep,name=groups,proto3" json:"groups,omitempty"`
 	// An optional list of impersonatable kubernetes users this role allows.
 	Users []string `protobuf:"bytes,3,rep,name=users,proto3" json:"users,omitempty"`
+	// The kubernetes resources this role grants access to.
+	Resources []*KubeResource `protobuf:"bytes,4,rep,name=resources,proto3" json:"resources,omitempty"`
 	// Overrides the defaults block idle timeout specifically for kube sessions.
 	// Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
 	// (or global default) applies.
@@ -990,6 +992,13 @@ func (x *ScopedRoleKube) GetUsers() []string {
 	return nil
 }
 
+func (x *ScopedRoleKube) GetResources() []*KubeResource {
+	if x != nil {
+		return x.Resources
+	}
+	return nil
+}
+
 func (x *ScopedRoleKube) GetClientIdleTimeout() string {
 	if x != nil {
 		return x.ClientIdleTimeout
@@ -1021,6 +1030,10 @@ func (x *ScopedRoleKube) SetGroups(v []string) {
 
 func (x *ScopedRoleKube) SetUsers(v []string) {
 	x.Users = v
+}
+
+func (x *ScopedRoleKube) SetResources(v []*KubeResource) {
+	x.Resources = v
 }
 
 func (x *ScopedRoleKube) SetClientIdleTimeout(v string) {
@@ -1066,6 +1079,8 @@ type ScopedRoleKube_builder struct {
 	Groups []string
 	// An optional list of impersonatable kubernetes users this role allows.
 	Users []string
+	// The kubernetes resources this role grants access to.
+	Resources []*KubeResource
 	// Overrides the defaults block idle timeout specifically for kube sessions.
 	// Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
 	// (or global default) applies.
@@ -1083,6 +1098,7 @@ func (b0 ScopedRoleKube_builder) Build() *ScopedRoleKube {
 	x.Labels = b.Labels
 	x.Groups = b.Groups
 	x.Users = b.Users
+	x.Resources = b.Resources
 	x.ClientIdleTimeout = b.ClientIdleTimeout
 	x.DisconnectExpiredCert = b.DisconnectExpiredCert
 	x.Lock = b.Lock
@@ -1742,6 +1758,130 @@ func (b0 Lock_builder) Build() *Lock {
 	return m0
 }
 
+// The kube resource identifier.
+type KubeResource struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The kube resource type.
+	Kind string `protobuf:"bytes,1,opt,name=kind,proto3" json:"kind,omitempty"`
+	// The kube resource namespace. It supports wildcards.
+	Namespace string `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	// The kube resource name. It supports wildcards.
+	Name string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
+	// The allowed kube verbs for interacting with the kube resource.
+	Verbs []string `protobuf:"bytes,4,rep,name=verbs,proto3" json:"verbs,omitempty"`
+	// The kube API group of the kube resource. It supports wildcards.
+	ApiGroup      string `protobuf:"bytes,5,opt,name=api_group,json=apiGroup,proto3" json:"api_group,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *KubeResource) Reset() {
+	*x = KubeResource{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *KubeResource) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*KubeResource) ProtoMessage() {}
+
+func (x *KubeResource) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *KubeResource) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *KubeResource) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *KubeResource) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *KubeResource) GetVerbs() []string {
+	if x != nil {
+		return x.Verbs
+	}
+	return nil
+}
+
+func (x *KubeResource) GetApiGroup() string {
+	if x != nil {
+		return x.ApiGroup
+	}
+	return ""
+}
+
+func (x *KubeResource) SetKind(v string) {
+	x.Kind = v
+}
+
+func (x *KubeResource) SetNamespace(v string) {
+	x.Namespace = v
+}
+
+func (x *KubeResource) SetName(v string) {
+	x.Name = v
+}
+
+func (x *KubeResource) SetVerbs(v []string) {
+	x.Verbs = v
+}
+
+func (x *KubeResource) SetApiGroup(v string) {
+	x.ApiGroup = v
+}
+
+type KubeResource_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The kube resource type.
+	Kind string
+	// The kube resource namespace. It supports wildcards.
+	Namespace string
+	// The kube resource name. It supports wildcards.
+	Name string
+	// The allowed kube verbs for interacting with the kube resource.
+	Verbs []string
+	// The kube API group of the kube resource. It supports wildcards.
+	ApiGroup string
+}
+
+func (b0 KubeResource_builder) Build() *KubeResource {
+	m0 := &KubeResource{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Kind = b.Kind
+	x.Namespace = b.Namespace
+	x.Name = b.Name
+	x.Verbs = b.Verbs
+	x.ApiGroup = b.ApiGroup
+	return m0
+}
+
 var File_teleport_scopes_access_v1_role_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
@@ -1788,15 +1928,16 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\r_max_sessionsB\f\n" +
 	"\n" +
 	"_file_copyB\x1a\n" +
-	"\x18_disconnect_expired_cert\"\xbf\x02\n" +
+	"\x18_disconnect_expired_cert\"\xf5\x02\n" +
 	"\x0eScopedRoleKube\x120\n" +
 	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12\x16\n" +
 	"\x06groups\x18\x02 \x03(\tR\x06groups\x12\x14\n" +
-	"\x05users\x18\x03 \x03(\tR\x05users\x12.\n" +
+	"\x05users\x18\x03 \x03(\tR\x05users\x12E\n" +
+	"\tresources\x18\x04 \x03(\v2'.teleport.scopes.access.v1.KubeResourceR\tresources\x12.\n" +
 	"\x13client_idle_timeout\x18\x05 \x01(\tR\x11clientIdleTimeout\x12;\n" +
 	"\x17disconnect_expired_cert\x18\x06 \x01(\bH\x00R\x15disconnectExpiredCert\x88\x01\x01\x123\n" +
 	"\x04lock\x18\a \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x1a\n" +
-	"\x18_disconnect_expired_certJ\x04\b\x04\x10\x05R\tresources\"@\n" +
+	"\x18_disconnect_expired_cert\"@\n" +
 	"\n" +
 	"ScopedRule\x12\x1c\n" +
 	"\tresources\x18\x01 \x03(\tR\tresources\x12\x14\n" +
@@ -1828,9 +1969,15 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x10SessionRecording\x12\x12\n" +
 	"\x04mode\x18\x01 \x01(\tR\x04mode\"\x1a\n" +
 	"\x04Lock\x12\x12\n" +
-	"\x04mode\x18\x01 \x01(\tR\x04modeBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
+	"\x04mode\x18\x01 \x01(\tR\x04mode\"\x87\x01\n" +
+	"\fKubeResource\x12\x12\n" +
+	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x1c\n" +
+	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x12\x12\n" +
+	"\x04name\x18\x03 \x01(\tR\x04name\x12\x14\n" +
+	"\x05verbs\x18\x04 \x03(\tR\x05verbs\x12\x1b\n" +
+	"\tapi_group\x18\x05 \x01(\tR\bapiGroupBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
 
-var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*ScopedRole)(nil),              // 0: teleport.scopes.access.v1.ScopedRole
 	(*ScopedRoleSpec)(nil),          // 1: teleport.scopes.access.v1.ScopedRoleSpec
@@ -1845,11 +1992,12 @@ var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*EnhancedRecording)(nil),       // 10: teleport.scopes.access.v1.EnhancedRecording
 	(*SessionRecording)(nil),        // 11: teleport.scopes.access.v1.SessionRecording
 	(*Lock)(nil),                    // 12: teleport.scopes.access.v1.Lock
-	(*v1.Metadata)(nil),             // 13: teleport.header.v1.Metadata
-	(*v11.Label)(nil),               // 14: teleport.label.v1.Label
+	(*KubeResource)(nil),            // 13: teleport.scopes.access.v1.KubeResource
+	(*v1.Metadata)(nil),             // 14: teleport.header.v1.Metadata
+	(*v11.Label)(nil),               // 15: teleport.label.v1.Label
 }
 var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
-	13, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
+	14, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
 	2,  // 2: teleport.scopes.access.v1.ScopedRoleSpec.defaults:type_name -> teleport.scopes.access.v1.ScopedRoleDefaults
 	5,  // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
@@ -1857,21 +2005,22 @@ var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
 	4,  // 5: teleport.scopes.access.v1.ScopedRoleSpec.kube:type_name -> teleport.scopes.access.v1.ScopedRoleKube
 	11, // 6: teleport.scopes.access.v1.ScopedRoleDefaults.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
 	12, // 7: teleport.scopes.access.v1.ScopedRoleDefaults.lock:type_name -> teleport.scopes.access.v1.Lock
-	14, // 8: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
+	15, // 8: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
 	6,  // 9: teleport.scopes.access.v1.ScopedRoleSSH.port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
 	9,  // 10: teleport.scopes.access.v1.ScopedRoleSSH.host_user_creation:type_name -> teleport.scopes.access.v1.CreateHostUser
 	10, // 11: teleport.scopes.access.v1.ScopedRoleSSH.enhanced_recording:type_name -> teleport.scopes.access.v1.EnhancedRecording
 	11, // 12: teleport.scopes.access.v1.ScopedRoleSSH.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
 	12, // 13: teleport.scopes.access.v1.ScopedRoleSSH.lock:type_name -> teleport.scopes.access.v1.Lock
-	14, // 14: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
-	12, // 15: teleport.scopes.access.v1.ScopedRoleKube.lock:type_name -> teleport.scopes.access.v1.Lock
-	7,  // 16: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
-	8,  // 17: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
-	18, // [18:18] is the sub-list for method output_type
-	18, // [18:18] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	15, // 14: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
+	13, // 15: teleport.scopes.access.v1.ScopedRoleKube.resources:type_name -> teleport.scopes.access.v1.KubeResource
+	12, // 16: teleport.scopes.access.v1.ScopedRoleKube.lock:type_name -> teleport.scopes.access.v1.Lock
+	7,  // 17: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
+	8,  // 18: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
+	19, // [19:19] is the sub-list for method output_type
+	19, // [19:19] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }
@@ -1891,7 +2040,7 @@ func file_teleport_scopes_access_v1_role_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_access_v1_role_proto_rawDesc), len(file_teleport_scopes_access_v1_role_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   13,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/scopes/access/v1/role_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role_protoopaque.pb.go
@@ -925,6 +925,7 @@ type ScopedRoleKube struct {
 	xxx_hidden_Labels                *[]*v11.Label          `protobuf:"bytes,1,rep,name=labels,proto3"`
 	xxx_hidden_Groups                []string               `protobuf:"bytes,2,rep,name=groups,proto3"`
 	xxx_hidden_Users                 []string               `protobuf:"bytes,3,rep,name=users,proto3"`
+	xxx_hidden_Resources             *[]*KubeResource       `protobuf:"bytes,4,rep,name=resources,proto3"`
 	xxx_hidden_ClientIdleTimeout     string                 `protobuf:"bytes,5,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3"`
 	xxx_hidden_DisconnectExpiredCert bool                   `protobuf:"varint,6,opt,name=disconnect_expired_cert,json=disconnectExpiredCert,proto3,oneof"`
 	xxx_hidden_Lock                  *Lock                  `protobuf:"bytes,7,opt,name=lock,proto3"`
@@ -982,6 +983,15 @@ func (x *ScopedRoleKube) GetUsers() []string {
 	return nil
 }
 
+func (x *ScopedRoleKube) GetResources() []*KubeResource {
+	if x != nil {
+		if x.xxx_hidden_Resources != nil {
+			return *x.xxx_hidden_Resources
+		}
+	}
+	return nil
+}
+
 func (x *ScopedRoleKube) GetClientIdleTimeout() string {
 	if x != nil {
 		return x.xxx_hidden_ClientIdleTimeout
@@ -1015,13 +1025,17 @@ func (x *ScopedRoleKube) SetUsers(v []string) {
 	x.xxx_hidden_Users = v
 }
 
+func (x *ScopedRoleKube) SetResources(v []*KubeResource) {
+	x.xxx_hidden_Resources = &v
+}
+
 func (x *ScopedRoleKube) SetClientIdleTimeout(v string) {
 	x.xxx_hidden_ClientIdleTimeout = v
 }
 
 func (x *ScopedRoleKube) SetDisconnectExpiredCert(v bool) {
 	x.xxx_hidden_DisconnectExpiredCert = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 4, 6)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 5, 7)
 }
 
 func (x *ScopedRoleKube) SetLock(v *Lock) {
@@ -1032,7 +1046,7 @@ func (x *ScopedRoleKube) HasDisconnectExpiredCert() bool {
 	if x == nil {
 		return false
 	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 4)
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 5)
 }
 
 func (x *ScopedRoleKube) HasLock() bool {
@@ -1043,7 +1057,7 @@ func (x *ScopedRoleKube) HasLock() bool {
 }
 
 func (x *ScopedRoleKube) ClearDisconnectExpiredCert() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 4)
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 5)
 	x.xxx_hidden_DisconnectExpiredCert = false
 }
 
@@ -1060,6 +1074,8 @@ type ScopedRoleKube_builder struct {
 	Groups []string
 	// An optional list of impersonatable kubernetes users this role allows.
 	Users []string
+	// The kubernetes resources this role grants access to.
+	Resources []*KubeResource
 	// Overrides the defaults block idle timeout specifically for kube sessions.
 	// Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
 	// (or global default) applies.
@@ -1077,9 +1093,10 @@ func (b0 ScopedRoleKube_builder) Build() *ScopedRoleKube {
 	x.xxx_hidden_Labels = &b.Labels
 	x.xxx_hidden_Groups = b.Groups
 	x.xxx_hidden_Users = b.Users
+	x.xxx_hidden_Resources = &b.Resources
 	x.xxx_hidden_ClientIdleTimeout = b.ClientIdleTimeout
 	if b.DisconnectExpiredCert != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 4, 6)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 5, 7)
 		x.xxx_hidden_DisconnectExpiredCert = *b.DisconnectExpiredCert
 	}
 	x.xxx_hidden_Lock = b.Lock
@@ -1757,6 +1774,125 @@ func (b0 Lock_builder) Build() *Lock {
 	return m0
 }
 
+// The kube resource identifier.
+type KubeResource struct {
+	state                protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Kind      string                 `protobuf:"bytes,1,opt,name=kind,proto3"`
+	xxx_hidden_Namespace string                 `protobuf:"bytes,2,opt,name=namespace,proto3"`
+	xxx_hidden_Name      string                 `protobuf:"bytes,3,opt,name=name,proto3"`
+	xxx_hidden_Verbs     []string               `protobuf:"bytes,4,rep,name=verbs,proto3"`
+	xxx_hidden_ApiGroup  string                 `protobuf:"bytes,5,opt,name=api_group,json=apiGroup,proto3"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *KubeResource) Reset() {
+	*x = KubeResource{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *KubeResource) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*KubeResource) ProtoMessage() {}
+
+func (x *KubeResource) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *KubeResource) GetKind() string {
+	if x != nil {
+		return x.xxx_hidden_Kind
+	}
+	return ""
+}
+
+func (x *KubeResource) GetNamespace() string {
+	if x != nil {
+		return x.xxx_hidden_Namespace
+	}
+	return ""
+}
+
+func (x *KubeResource) GetName() string {
+	if x != nil {
+		return x.xxx_hidden_Name
+	}
+	return ""
+}
+
+func (x *KubeResource) GetVerbs() []string {
+	if x != nil {
+		return x.xxx_hidden_Verbs
+	}
+	return nil
+}
+
+func (x *KubeResource) GetApiGroup() string {
+	if x != nil {
+		return x.xxx_hidden_ApiGroup
+	}
+	return ""
+}
+
+func (x *KubeResource) SetKind(v string) {
+	x.xxx_hidden_Kind = v
+}
+
+func (x *KubeResource) SetNamespace(v string) {
+	x.xxx_hidden_Namespace = v
+}
+
+func (x *KubeResource) SetName(v string) {
+	x.xxx_hidden_Name = v
+}
+
+func (x *KubeResource) SetVerbs(v []string) {
+	x.xxx_hidden_Verbs = v
+}
+
+func (x *KubeResource) SetApiGroup(v string) {
+	x.xxx_hidden_ApiGroup = v
+}
+
+type KubeResource_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The kube resource type.
+	Kind string
+	// The kube resource namespace. It supports wildcards.
+	Namespace string
+	// The kube resource name. It supports wildcards.
+	Name string
+	// The allowed kube verbs for interacting with the kube resource.
+	Verbs []string
+	// The kube API group of the kube resource. It supports wildcards.
+	ApiGroup string
+}
+
+func (b0 KubeResource_builder) Build() *KubeResource {
+	m0 := &KubeResource{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Kind = b.Kind
+	x.xxx_hidden_Namespace = b.Namespace
+	x.xxx_hidden_Name = b.Name
+	x.xxx_hidden_Verbs = b.Verbs
+	x.xxx_hidden_ApiGroup = b.ApiGroup
+	return m0
+}
+
 var File_teleport_scopes_access_v1_role_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
@@ -1803,15 +1939,16 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\r_max_sessionsB\f\n" +
 	"\n" +
 	"_file_copyB\x1a\n" +
-	"\x18_disconnect_expired_cert\"\xbf\x02\n" +
+	"\x18_disconnect_expired_cert\"\xf5\x02\n" +
 	"\x0eScopedRoleKube\x120\n" +
 	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12\x16\n" +
 	"\x06groups\x18\x02 \x03(\tR\x06groups\x12\x14\n" +
-	"\x05users\x18\x03 \x03(\tR\x05users\x12.\n" +
+	"\x05users\x18\x03 \x03(\tR\x05users\x12E\n" +
+	"\tresources\x18\x04 \x03(\v2'.teleport.scopes.access.v1.KubeResourceR\tresources\x12.\n" +
 	"\x13client_idle_timeout\x18\x05 \x01(\tR\x11clientIdleTimeout\x12;\n" +
 	"\x17disconnect_expired_cert\x18\x06 \x01(\bH\x00R\x15disconnectExpiredCert\x88\x01\x01\x123\n" +
 	"\x04lock\x18\a \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x1a\n" +
-	"\x18_disconnect_expired_certJ\x04\b\x04\x10\x05R\tresources\"@\n" +
+	"\x18_disconnect_expired_cert\"@\n" +
 	"\n" +
 	"ScopedRule\x12\x1c\n" +
 	"\tresources\x18\x01 \x03(\tR\tresources\x12\x14\n" +
@@ -1843,9 +1980,15 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x10SessionRecording\x12\x12\n" +
 	"\x04mode\x18\x01 \x01(\tR\x04mode\"\x1a\n" +
 	"\x04Lock\x12\x12\n" +
-	"\x04mode\x18\x01 \x01(\tR\x04modeBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
+	"\x04mode\x18\x01 \x01(\tR\x04mode\"\x87\x01\n" +
+	"\fKubeResource\x12\x12\n" +
+	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x1c\n" +
+	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x12\x12\n" +
+	"\x04name\x18\x03 \x01(\tR\x04name\x12\x14\n" +
+	"\x05verbs\x18\x04 \x03(\tR\x05verbs\x12\x1b\n" +
+	"\tapi_group\x18\x05 \x01(\tR\bapiGroupBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
 
-var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*ScopedRole)(nil),              // 0: teleport.scopes.access.v1.ScopedRole
 	(*ScopedRoleSpec)(nil),          // 1: teleport.scopes.access.v1.ScopedRoleSpec
@@ -1860,11 +2003,12 @@ var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*EnhancedRecording)(nil),       // 10: teleport.scopes.access.v1.EnhancedRecording
 	(*SessionRecording)(nil),        // 11: teleport.scopes.access.v1.SessionRecording
 	(*Lock)(nil),                    // 12: teleport.scopes.access.v1.Lock
-	(*v1.Metadata)(nil),             // 13: teleport.header.v1.Metadata
-	(*v11.Label)(nil),               // 14: teleport.label.v1.Label
+	(*KubeResource)(nil),            // 13: teleport.scopes.access.v1.KubeResource
+	(*v1.Metadata)(nil),             // 14: teleport.header.v1.Metadata
+	(*v11.Label)(nil),               // 15: teleport.label.v1.Label
 }
 var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
-	13, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
+	14, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
 	2,  // 2: teleport.scopes.access.v1.ScopedRoleSpec.defaults:type_name -> teleport.scopes.access.v1.ScopedRoleDefaults
 	5,  // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
@@ -1872,21 +2016,22 @@ var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
 	4,  // 5: teleport.scopes.access.v1.ScopedRoleSpec.kube:type_name -> teleport.scopes.access.v1.ScopedRoleKube
 	11, // 6: teleport.scopes.access.v1.ScopedRoleDefaults.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
 	12, // 7: teleport.scopes.access.v1.ScopedRoleDefaults.lock:type_name -> teleport.scopes.access.v1.Lock
-	14, // 8: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
+	15, // 8: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
 	6,  // 9: teleport.scopes.access.v1.ScopedRoleSSH.port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
 	9,  // 10: teleport.scopes.access.v1.ScopedRoleSSH.host_user_creation:type_name -> teleport.scopes.access.v1.CreateHostUser
 	10, // 11: teleport.scopes.access.v1.ScopedRoleSSH.enhanced_recording:type_name -> teleport.scopes.access.v1.EnhancedRecording
 	11, // 12: teleport.scopes.access.v1.ScopedRoleSSH.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
 	12, // 13: teleport.scopes.access.v1.ScopedRoleSSH.lock:type_name -> teleport.scopes.access.v1.Lock
-	14, // 14: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
-	12, // 15: teleport.scopes.access.v1.ScopedRoleKube.lock:type_name -> teleport.scopes.access.v1.Lock
-	7,  // 16: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
-	8,  // 17: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
-	18, // [18:18] is the sub-list for method output_type
-	18, // [18:18] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	15, // 14: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
+	13, // 15: teleport.scopes.access.v1.ScopedRoleKube.resources:type_name -> teleport.scopes.access.v1.KubeResource
+	12, // 16: teleport.scopes.access.v1.ScopedRoleKube.lock:type_name -> teleport.scopes.access.v1.Lock
+	7,  // 17: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
+	8,  // 18: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
+	19, // [19:19] is the sub-list for method output_type
+	19, // [19:19] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }
@@ -1906,7 +2051,7 @@ func file_teleport_scopes_access_v1_role_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_access_v1_role_proto_rawDesc), len(file_teleport_scopes_access_v1_role_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   13,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -169,8 +169,8 @@ message ScopedRoleKube {
   // An optional list of impersonatable kubernetes users this role allows.
   repeated string users = 3;
 
-  reserved 4; // saving for kube resources
-  reserved "resources"; // saving for kube resources
+  // The kubernetes resources this role grants access to.
+  repeated KubeResource resources = 4;
 
   // Overrides the defaults block idle timeout specifically for kube sessions.
   // Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
@@ -245,4 +245,22 @@ message Lock {
   // Allowed values: strict or best_effort.
   // Defaults to value cluster wide auth preference if not set.
   string mode = 1;
+}
+
+// The kube resource identifier.
+message KubeResource {
+  // The kube resource type.
+  string kind = 1;
+
+  // The kube resource namespace. It supports wildcards.
+  string namespace = 2;
+
+  // The kube resource name. It supports wildcards.
+  string name = 3;
+
+  // The allowed kube verbs for interacting with the kube resource.
+  repeated string verbs = 4;
+
+  // The kube API group of the kube resource. It supports wildcards.
+  string api_group = 5;
 }

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1761,8 +1761,9 @@ var KubernetesClusterWideResourceKinds = []string{
 	KindKubeCertificateSigningRequest,
 }
 
-// KubernetesNamespacedResourceKinds is the list of known Kubernetes resource kinds
-// that are namespaced.
+// kubernetesNamespacedResourceKinds is the list of known Kubernetes resource kinds
+// that are namespaced. This map has been duplicated in lib/scopes/access/access.go.
+// Any changes should also be made there.
 //
 // Generated from `kubectl api-resources --namespaced=true -o name --sort-by=name` (kind k8s v1.32.2).
 // The format is "<plural>.<apigroup>".

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -2061,6 +2061,8 @@ func setDefaultKubernetesVerbs(spec *RoleSpecV6) {
 // - Name is not empty
 // - Namespace is not empty
 // - APIGroup is empty for roles <=v7 and not empty for >=v8
+// This function is duplicated for scoped roles in lib/scopes/access/access.go. Any changes to role v8 behavior should
+// also be made there.
 func validateKubeResources(roleVersion string, kubeResources []KubernetesResource) error {
 	for _, kubeResource := range kubeResources {
 		for _, verb := range kubeResource.Verbs {

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedrolesv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedrolesv1.mdx
@@ -62,6 +62,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |groups|[]string|The list of kubernetes groups this role allows.|
 |labels|[][object](#speckubelabels-items)|The map of kubernetes cluster labels used for RBAC.|
 |lock|[object](#speckubelock)|Lock configures the role's locking behavior for kubernetes sessions.|
+|resources|[][object](#speckuberesources-items)|The kubernetes resources this role grants access to.|
 |users|[]string|An optional list of impersonatable kubernetes users this role allows.|
 
 ### spec.kube.labels items
@@ -76,6 +77,16 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |Field|Type|Description|
 |---|---|---|
 |mode|string|Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.|
+
+### spec.kube.resources items
+
+|Field|Type|Description|
+|---|---|---|
+|api_group|string|The kube API group of the kube resource. It supports wildcards.|
+|kind|string|The kube resource type.|
+|name|string|The kube resource name. It supports wildcards.|
+|namespace|string|The kube resource namespace. It supports wildcards.|
+|verbs|[]string|The allowed kube verbs for interacting with the kube resource.|
 
 ### spec.rules items
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role.mdx
@@ -87,6 +87,7 @@ Optional:
 - `groups` (List of String) The list of kubernetes groups this role allows.
 - `labels` (Attributes List) The map of kubernetes cluster labels used for RBAC. (see [below for nested schema](#nested-schema-for-speckubelabels))
 - `lock` (Attributes) Lock configures the role's locking behavior for kubernetes sessions. (see [below for nested schema](#nested-schema-for-speckubelock))
+- `resources` (Attributes List) The kubernetes resources this role grants access to. (see [below for nested schema](#nested-schema-for-speckuberesources))
 - `users` (List of String) An optional list of impersonatable kubernetes users this role allows.
 
 ### Nested Schema for `spec.kube.labels`
@@ -102,6 +103,17 @@ Optional:
 Optional:
 
 - `mode` (String) Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.
+
+
+### Nested Schema for `spec.kube.resources`
+
+Optional:
+
+- `api_group` (String) The kube API group of the kube resource. It supports wildcards.
+- `kind` (String) The kube resource type.
+- `name` (String) The kube resource name. It supports wildcards.
+- `namespace` (String) The kube resource namespace. It supports wildcards.
+- `verbs` (List of String) The allowed kube verbs for interacting with the kube resource.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role.mdx
@@ -116,6 +116,7 @@ Optional:
 - `groups` (List of String) The list of kubernetes groups this role allows.
 - `labels` (Attributes List) The map of kubernetes cluster labels used for RBAC. (see [below for nested schema](#nested-schema-for-speckubelabels))
 - `lock` (Attributes) Lock configures the role's locking behavior for kubernetes sessions. (see [below for nested schema](#nested-schema-for-speckubelock))
+- `resources` (Attributes List) The kubernetes resources this role grants access to. (see [below for nested schema](#nested-schema-for-speckuberesources))
 - `users` (List of String) An optional list of impersonatable kubernetes users this role allows.
 
 ### Nested Schema for `spec.kube.labels`
@@ -131,6 +132,17 @@ Optional:
 Optional:
 
 - `mode` (String) Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.
+
+
+### Nested Schema for `spec.kube.resources`
+
+Optional:
+
+- `api_group` (String) The kube API group of the kube resource. It supports wildcards.
+- `kind` (String) The kube resource type.
+- `name` (String) The kube resource name. It supports wildcards.
+- `namespace` (String) The kube resource namespace. It supports wildcards.
+- `verbs` (List of String) The allowed kube verbs for interacting with the kube resource.
 
 
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
@@ -135,6 +135,34 @@ spec:
                           to value cluster wide auth preference if not set.'
                         type: string
                     type: object
+                  resources:
+                    description: The kubernetes resources this role grants access
+                      to.
+                    items:
+                      properties:
+                        api_group:
+                          description: The kube API group of the kube resource. It
+                            supports wildcards.
+                          type: string
+                        kind:
+                          description: The kube resource type.
+                          type: string
+                        name:
+                          description: The kube resource name. It supports wildcards.
+                          type: string
+                        namespace:
+                          description: The kube resource namespace. It supports wildcards.
+                          type: string
+                        verbs:
+                          description: The allowed kube verbs for interacting with
+                            the kube resource.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    nullable: true
+                    type: array
                   users:
                     description: An optional list of impersonatable kubernetes users
                       this role allows.

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
@@ -135,6 +135,34 @@ spec:
                           to value cluster wide auth preference if not set.'
                         type: string
                     type: object
+                  resources:
+                    description: The kubernetes resources this role grants access
+                      to.
+                    items:
+                      properties:
+                        api_group:
+                          description: The kube API group of the kube resource. It
+                            supports wildcards.
+                          type: string
+                        kind:
+                          description: The kube resource type.
+                          type: string
+                        name:
+                          description: The kube resource name. It supports wildcards.
+                          type: string
+                        namespace:
+                          description: The kube resource namespace. It supports wildcards.
+                          type: string
+                        verbs:
+                          description: The allowed kube verbs for interacting with
+                            the kube resource.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    nullable: true
+                    type: array
                   users:
                     description: An optional list of impersonatable kubernetes users
                       this role allows.

--- a/integrations/operator/controllers/resources/scopedrole_controller_test.go
+++ b/integrations/operator/controllers/resources/scopedrole_controller_test.go
@@ -28,6 +28,7 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
@@ -135,9 +136,15 @@ func (g *scopedRoleTestingPrimitives) ModifyKubernetesResource(ctx context.Conte
 		return trace.Wrap(err)
 	}
 	role.Spec.AssignableScopes = []string{"/staging/aa", "/staging/bb"}
-	role.Spec.Ssh = &accessv1.ScopedRoleSSH{
+	role.Spec.Ssh = accessv1.ScopedRoleSSH_builder{
+		Labels: []*labelv1.Label{
+			labelv1.Label_builder{
+				Name:   "*",
+				Values: []string{"*"},
+			}.Build(),
+		},
 		HostSudoers: []string{"test"},
-	}
+	}.Build()
 	return trace.Wrap(g.setup.K8sClient.Update(ctx, role))
 }
 

--- a/integrations/terraform/testlib/fixtures/scoped_role_1_update.tf
+++ b/integrations/terraform/testlib/fixtures/scoped_role_1_update.tf
@@ -14,6 +14,10 @@ resource "teleport_scoped_role" "test" {
       verbs     = ["read", "list", "create"]
     }]
     ssh = {
+      labels = [{
+        name   = "*"
+        values = ["*"]
+      }]
       logins = ["root"]
     }
   }

--- a/integrations/terraform/tfschema/scopes/access/v1/role_terraform.go
+++ b/integrations/terraform/tfschema/scopes/access/v1/role_terraform.go
@@ -190,6 +190,37 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 							Description: "Lock configures the role's locking behavior for kubernetes sessions.",
 							Optional:    true,
 						},
+						"resources": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+								"api_group": {
+									Description: "The kube API group of the kube resource. It supports wildcards.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"kind": {
+									Description: "The kube resource type.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"name": {
+									Description: "The kube resource name. It supports wildcards.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"namespace": {
+									Description: "The kube resource namespace. It supports wildcards.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"verbs": {
+									Description: "The allowed kube verbs for interacting with the kube resource.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+								},
+							}),
+							Description: "The kubernetes resources this role grants access to.",
+							Optional:    true,
+						},
 						"users": {
 							Description: "An optional list of impersonatable kubernetes users this role allows.",
 							Optional:    true,
@@ -1514,6 +1545,130 @@ func CopyScopedRoleFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 																t = string(v.Value)
 															}
 															obj.Users[k] = t
+														}
+													}
+												}
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["resources"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.kube.resources"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.kube.resources", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+											} else {
+												obj.Resources = make([]*github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_access_v1.KubeResource, len(v.Elems))
+												if !v.Null && !v.Unknown {
+													for k, a := range v.Elems {
+														v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														if !ok {
+															diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.kube.resources", "github_com_hashicorp_terraform_plugin_framework_types.Object"})
+														} else {
+															var t *github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_access_v1.KubeResource
+															if !v.Null && !v.Unknown {
+																tf := v
+																t = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_access_v1.KubeResource{}
+																obj := t
+																{
+																	a, ok := tf.Attrs["kind"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedRole.spec.kube.resources.kind"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.kube.resources.kind", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Kind = t
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["namespace"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedRole.spec.kube.resources.namespace"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.kube.resources.namespace", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Namespace = t
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["name"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedRole.spec.kube.resources.name"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.kube.resources.name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Name = t
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["verbs"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedRole.spec.kube.resources.verbs"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.kube.resources.verbs", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+																		} else {
+																			obj.Verbs = make([]string, len(v.Elems))
+																			if !v.Null && !v.Unknown {
+																				for k, a := range v.Elems {
+																					v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																					if !ok {
+																						diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.kube.resources.verbs", "github_com_hashicorp_terraform_plugin_framework_types.String"})
+																					} else {
+																						var t string
+																						if !v.Null && !v.Unknown {
+																							t = string(v.Value)
+																						}
+																						obj.Verbs[k] = t
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["api_group"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedRole.spec.kube.resources.api_group"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.kube.resources.api_group", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.ApiGroup = t
+																		}
+																	}
+																}
+															}
+															obj.Resources[k] = t
 														}
 													}
 												}
@@ -3487,6 +3642,205 @@ func CopyScopedRoleToTerraform(ctx context.Context, obj *github_com_gravitationa
 												}
 												c.Unknown = false
 												tf.Attrs["users"] = c
+											}
+										}
+									}
+									{
+										a, ok := tf.AttrTypes["resources"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.kube.resources"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.kube.resources", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+											} else {
+												c, ok := tf.Attrs["resources"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+												if !ok {
+													c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+														ElemType: o.ElemType,
+														Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Resources)),
+														Null:     true,
+													}
+												} else {
+													if c.Elems == nil {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Resources))
+													}
+												}
+												if obj.Resources != nil {
+													o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+													if len(obj.Resources) != len(c.Elems) {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Resources))
+													}
+													for k, a := range obj.Resources {
+														v, ok := tf.Attrs["resources"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														if !ok {
+															v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+																AttrTypes: o.AttrTypes,
+																Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+															}
+														} else {
+															if v.Attrs == nil {
+																v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+															}
+														}
+														if a == nil {
+															v.Null = true
+														} else {
+															obj := a
+															tf := &v
+															{
+																t, ok := tf.AttrTypes["kind"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedRole.spec.kube.resources.kind"})
+																} else {
+																	v, ok := tf.Attrs["kind"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedRole.spec.kube.resources.kind", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.kube.resources.kind", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Kind) == ""
+																	}
+																	v.Value = string(obj.Kind)
+																	v.Unknown = false
+																	tf.Attrs["kind"] = v
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["namespace"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedRole.spec.kube.resources.namespace"})
+																} else {
+																	v, ok := tf.Attrs["namespace"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedRole.spec.kube.resources.namespace", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.kube.resources.namespace", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Namespace) == ""
+																	}
+																	v.Value = string(obj.Namespace)
+																	v.Unknown = false
+																	tf.Attrs["namespace"] = v
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["name"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedRole.spec.kube.resources.name"})
+																} else {
+																	v, ok := tf.Attrs["name"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedRole.spec.kube.resources.name", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.kube.resources.name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Name) == ""
+																	}
+																	v.Value = string(obj.Name)
+																	v.Unknown = false
+																	tf.Attrs["name"] = v
+																}
+															}
+															{
+																a, ok := tf.AttrTypes["verbs"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedRole.spec.kube.resources.verbs"})
+																} else {
+																	o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+																	if !ok {
+																		diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.kube.resources.verbs", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+																	} else {
+																		c, ok := tf.Attrs["verbs"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+																		if !ok {
+																			c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+																				ElemType: o.ElemType,
+																				Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Verbs)),
+																				Null:     true,
+																			}
+																		} else {
+																			if c.Elems == nil {
+																				c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Verbs))
+																			}
+																		}
+																		if obj.Verbs != nil {
+																			t := o.ElemType
+																			if len(obj.Verbs) != len(c.Elems) {
+																				c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Verbs))
+																			}
+																			for k, a := range obj.Verbs {
+																				v, ok := tf.Attrs["verbs"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																				if !ok {
+																					i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																					if err != nil {
+																						diags.Append(attrWriteGeneralError{"ScopedRole.spec.kube.resources.verbs", err})
+																					}
+																					v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																					if !ok {
+																						diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.kube.resources.verbs", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																					}
+																					v.Null = string(a) == ""
+																				}
+																				v.Value = string(a)
+																				v.Unknown = false
+																				c.Elems[k] = v
+																			}
+																			if len(obj.Verbs) > 0 {
+																				c.Null = false
+																			}
+																		}
+																		c.Unknown = false
+																		tf.Attrs["verbs"] = c
+																	}
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["api_group"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedRole.spec.kube.resources.api_group"})
+																} else {
+																	v, ok := tf.Attrs["api_group"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedRole.spec.kube.resources.api_group", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.kube.resources.api_group", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.ApiGroup) == ""
+																	}
+																	v.Value = string(obj.ApiGroup)
+																	v.Unknown = false
+																	tf.Attrs["api_group"] = v
+																}
+															}
+														}
+														v.Unknown = false
+														c.Elems[k] = v
+													}
+													if len(obj.Resources) > 0 {
+														c.Null = false
+													}
+												}
+												c.Unknown = false
+												tf.Attrs["resources"] = c
 											}
 										}
 									}

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
@@ -975,6 +976,12 @@ func TestBasicSSHScopedLogin(t *testing.T) {
 	})
 	require.Error(t, err)
 
+	wildcardLabels := []*labelv1.Label{
+		labelv1.Label_builder{
+			Name:   "*",
+			Values: []string{"*"},
+		}.Build(),
+	}
 	// set up some scoped roles
 	scopedRoles := []*scopedaccessv1.ScopedRole{
 		{
@@ -985,9 +992,10 @@ func TestBasicSSHScopedLogin(t *testing.T) {
 			Scope: "/aa",
 			Spec: &scopedaccessv1.ScopedRoleSpec{
 				AssignableScopes: []string{"/aa"},
-				Ssh: &scopedaccessv1.ScopedRoleSSH{
+				Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+					Labels: wildcardLabels,
 					Logins: []string{"login-a"},
-				},
+				}.Build(),
 			},
 			Version: types.V1,
 		},
@@ -999,9 +1007,10 @@ func TestBasicSSHScopedLogin(t *testing.T) {
 			Scope: "/aa/bb",
 			Spec: &scopedaccessv1.ScopedRoleSpec{
 				AssignableScopes: []string{"/aa/bb"},
-				Ssh: &scopedaccessv1.ScopedRoleSSH{
+				Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+					Labels: wildcardLabels,
 					Logins: []string{"login-b"},
-				},
+				}.Build(),
 			},
 			Version: types.V1,
 		},
@@ -1013,9 +1022,10 @@ func TestBasicSSHScopedLogin(t *testing.T) {
 			Scope: "/aa/bb/cc",
 			Spec: &scopedaccessv1.ScopedRoleSpec{
 				AssignableScopes: []string{"/aa/bb/cc"},
-				Ssh: &scopedaccessv1.ScopedRoleSSH{
+				Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+					Labels: wildcardLabels,
 					Logins: []string{"login-c"},
-				},
+				}.Build(),
 			},
 			Version: types.V1,
 		},
@@ -1027,9 +1037,10 @@ func TestBasicSSHScopedLogin(t *testing.T) {
 			Scope: "/xx",
 			Spec: &scopedaccessv1.ScopedRoleSpec{
 				AssignableScopes: []string{"/xx"},
-				Ssh: &scopedaccessv1.ScopedRoleSSH{
+				Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+					Labels: wildcardLabels,
 					Logins: []string{"login-x"},
-				},
+				}.Build(),
 			},
 			Version: types.V1,
 		},

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -1178,6 +1178,15 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 				Kube: &scopedaccessv1.ScopedRoleKube{
 					Users:  []string{"scoped_kube_user"},
 					Groups: []string{"scoped_kube_group"},
+					Resources: []*scopedaccessv1.KubeResource{
+						scopedaccessv1.KubeResource_builder{
+							Kind:      "*",
+							Namespace: "*",
+							Name:      "*",
+							ApiGroup:  "*",
+							Verbs:     []string{"*"},
+						}.Build(),
+					},
 					Labels: []*labelv1.Label{
 						{
 							Name:   types.Wildcard,
@@ -5617,6 +5626,15 @@ func TestListResources_KindKubernetesCluster(t *testing.T) {
 					Kube: &scopedaccessv1.ScopedRoleKube{
 						Users:  []string{"kube_user"},
 						Groups: []string{"kube_group"},
+						Resources: []*scopedaccessv1.KubeResource{
+							scopedaccessv1.KubeResource_builder{
+								Kind:      "*",
+								Namespace: "*",
+								Name:      "*",
+								ApiGroup:  "*",
+								Verbs:     []string{"*"},
+							}.Build(),
+						},
 						Labels: []*labelv1.Label{
 							{
 								Name:   types.Wildcard,
@@ -13396,6 +13414,15 @@ func TestScopedUserCertGeneration(t *testing.T) {
 				Kube: &scopedaccessv1.ScopedRoleKube{
 					Users:  []string{"kube_user"},
 					Groups: []string{"kube_group"},
+					Resources: []*scopedaccessv1.KubeResource{
+						scopedaccessv1.KubeResource_builder{
+							Kind:      "*",
+							Namespace: "*",
+							Name:      "*",
+							ApiGroup:  "*",
+							Verbs:     []string{"*"},
+						}.Build(),
+					},
 					Labels: []*labelv1.Label{
 						{
 							Name:   types.Wildcard,

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -1303,13 +1303,19 @@ func TestScopePinnedHost(clusterName, hostID, scope string, roles ...types.Syste
 
 // TestServerID returns a TestIdentity for a node with the passed in serverID.
 func TestServerID(role types.SystemRole, serverID string) TestIdentity {
+	return TestScopedServerID(role, serverID, "")
+}
+
+// TestScopedServerID returns a scoped TestIdentity for a node with the passed in serverID.
+func TestScopedServerID(role types.SystemRole, serverID, scope string) TestIdentity {
 	return TestIdentity{
 		I: authz.BuiltinRole{
 			Role:                  types.RoleInstance,
 			Username:              serverID,
 			AdditionalSystemRoles: types.SystemRoles{role},
 			Identity: tlsca.Identity{
-				Username: serverID,
+				Username:   serverID,
+				AgentScope: scope,
 			},
 		},
 	}
@@ -1584,6 +1590,49 @@ func NewServerIdentity(clt *auth.Server, hostID string, role types.SystemRole) (
 			PublicSSHKey: ssh.MarshalAuthorizedKey(sshPubKey),
 			PublicTLSKey: tlsPubKey,
 		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return state.ReadIdentityFromKeyPair(privateKeyPEM, certs)
+}
+
+// NewScopedServerIdentity generates new scoped server identity, used in tests
+func NewScopedServerIdentity(clt *auth.Server, hostID, scope string, role types.SystemRole) (*state.Identity, error) {
+	if scope == "" {
+		return NewServerIdentity(clt, hostID, role)
+	}
+
+	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	privateKeyPEM, err := keys.MarshalPrivateKey(key)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	sshPubKey, err := ssh.NewPublicKey(key.Public())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	tlsPubKey, err := keys.MarshalPublicKey(key.Public())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	certs, err := clt.GenerateHostCerts(context.Background(), auth.HostCertsParams{
+		Req: &proto.HostCertsRequest{
+			HostID:       hostID,
+			NodeName:     hostID,
+			Role:         role,
+			PublicSSHKey: ssh.MarshalAuthorizedKey(sshPubKey),
+			PublicTLSKey: tlsPubKey,
+		},
+		AgentScope: scope,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/kube/proxy/exec_test.go
+++ b/lib/kube/proxy/exec_test.go
@@ -33,6 +33,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -42,8 +43,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/kubectl/pkg/scheme"
-
-	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
 	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
@@ -72,6 +71,27 @@ var (
 	containerCommmandExecute = []string{"sh"}
 	stdinContent             = []byte("stdin_data")
 )
+
+func wildcardResource() []*accessv1.KubeResource {
+	return []*accessv1.KubeResource{
+		accessv1.KubeResource_builder{
+			Kind:      types.Wildcard,
+			Name:      types.Wildcard,
+			Namespace: types.Wildcard,
+			ApiGroup:  types.Wildcard,
+			Verbs:     []string{types.Wildcard},
+		}.Build(),
+	}
+}
+
+func wildcardLabel() []*labelv1.Label {
+	return []*labelv1.Label{
+		labelv1.Label_builder{
+			Name:   types.Wildcard,
+			Values: []string{types.Wildcard},
+		}.Build(),
+	}
+}
 
 func testExecKubeService(t *testing.T, testCtx *TestContext) {
 	kubeMock, err := testingkubemock.NewKubeAPIMock()
@@ -120,37 +140,29 @@ func testExecKubeService(t *testing.T, testCtx *TestContext) {
 		t,
 		"scoped-"+username,
 		scopedTestScope,
-		&accessv1.ScopedRoleSpec{
+		accessv1.ScopedRoleSpec_builder{
 			AssignableScopes: []string{scopedTestScope},
-			Kube: &accessv1.ScopedRoleKube{
-				Users:  roleKubeUsers,
-				Groups: roleKubeGroups,
-				Labels: []*labelv1.Label{
-					{
-						Name:   types.Wildcard,
-						Values: []string{types.Wildcard},
-					},
-				},
-			},
-		})
+			Kube: accessv1.ScopedRoleKube_builder{
+				Users:     roleKubeUsers,
+				Groups:    roleKubeGroups,
+				Resources: wildcardResource(),
+				Labels:    wildcardLabel(),
+			}.Build(),
+		}.Build())
 
 	scopedMultiKubeUsers, scopedMultiKubeUserRole := testCtx.CreateUserAndScopedRole(
 		t,
 		"scoped-"+usernameMultiUsers,
 		scopedTestScope,
-		&accessv1.ScopedRoleSpec{
+		accessv1.ScopedRoleSpec_builder{
 			AssignableScopes: []string{scopedTestScope},
-			Kube: &accessv1.ScopedRoleKube{
-				Users:  append(slices.Clone(roleKubeUsers), "admin"),
-				Groups: roleKubeGroups,
-				Labels: []*labelv1.Label{
-					{
-						Name:   types.Wildcard,
-						Values: []string{types.Wildcard},
-					},
-				},
-			},
-		},
+			Kube: accessv1.ScopedRoleKube_builder{
+				Users:     append(slices.Clone(roleKubeUsers), "admin"),
+				Groups:    roleKubeGroups,
+				Resources: wildcardResource(),
+				Labels:    wildcardLabel(),
+			}.Build(),
+		}.Build(),
 	)
 	waitForSRACache(t, testCtx.TLSServer, scopedSingleKubeUserRole, scopedMultiKubeUserRole)
 
@@ -694,19 +706,15 @@ func TestExecMissingGETPermissionError(t *testing.T) {
 					t,
 					"scoped-"+username,
 					scopedTestScope,
-					&accessv1.ScopedRoleSpec{
+					accessv1.ScopedRoleSpec_builder{
 						AssignableScopes: []string{scopedTestScope},
-						Kube: &accessv1.ScopedRoleKube{
-							Users:  roleKubeUsers,
-							Groups: roleKubeGroups,
-							Labels: []*labelv1.Label{
-								{
-									Name:   types.Wildcard,
-									Values: []string{types.Wildcard},
-								},
-							},
-						},
-					})
+						Kube: accessv1.ScopedRoleKube_builder{
+							Users:     roleKubeUsers,
+							Groups:    roleKubeGroups,
+							Resources: wildcardResource(),
+							Labels:    wildcardLabel(),
+						}.Build(),
+					}.Build())
 
 				waitForSRACache(t, testCtx.TLSServer, scopedUserRole)
 

--- a/lib/kube/proxy/exec_test.go
+++ b/lib/kube/proxy/exec_test.go
@@ -26,13 +26,13 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -43,13 +43,19 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/kubectl/pkg/scheme"
 
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
+	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/events"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 var (
@@ -68,6 +74,10 @@ var (
 )
 
 func testExecKubeService(t *testing.T, testCtx *TestContext) {
+	kubeMock, err := testingkubemock.NewKubeAPIMock()
+	require.NoError(t, err)
+	t.Cleanup(func() { kubeMock.Close() })
+
 	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
 	userWithSingleKubeUser, _ := testCtx.CreateUserAndRole(
 		testCtx.Context,
@@ -94,7 +104,7 @@ func testExecKubeService(t *testing.T, testCtx *TestContext) {
 		usernameMultiUsers,
 		RoleSpec{
 			Name:       roleNameMultiUsers,
-			KubeUsers:  append(roleKubeUsers, "admin"),
+			KubeUsers:  append(slices.Clone(roleKubeUsers), "admin"),
 			KubeGroups: roleKubeGroups,
 		})
 
@@ -106,6 +116,60 @@ func testExecKubeService(t *testing.T, testCtx *TestContext) {
 	)
 	require.NotNil(t, configMultiKubeUsers)
 
+	scopedWithSingleKubeUser, scopedSingleKubeUserRole := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+username,
+		scopedTestScope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scopedTestScope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  roleKubeUsers,
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		})
+
+	scopedMultiKubeUsers, scopedMultiKubeUserRole := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+usernameMultiUsers,
+		scopedTestScope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scopedTestScope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  append(slices.Clone(roleKubeUsers), "admin"),
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		},
+	)
+	waitForSRACache(t, testCtx.TLSServer, scopedSingleKubeUserRole, scopedMultiKubeUserRole)
+
+	_, scopedConfigWithSingleKubeUser := testCtx.GenTestKubeClientTLSCert(
+		t,
+		scopedWithSingleKubeUser.GetName(),
+		kubeCluster,
+		func(i *tlsca.Identity) {
+			i.ScopePin = testCtx.GetScopePinForUser(t, scopedWithSingleKubeUser.GetName(), scopedTestScope)
+		},
+	)
+	_, scopedConfigMultiKubeUsers := testCtx.GenTestKubeClientTLSCert(
+		t,
+		scopedMultiKubeUsers.GetName(),
+		kubeCluster,
+		func(i *tlsca.Identity) {
+			i.ScopePin = testCtx.GetScopePinForUser(t, scopedMultiKubeUsers.GetName(), scopedTestScope)
+		},
+	)
 	type args struct {
 		executorBuilder func(*rest.Config, string, *url.URL) (remotecommand.Executor, error)
 		impersonateUser string
@@ -124,6 +188,13 @@ func testExecKubeService(t *testing.T, testCtx *TestContext) {
 			},
 		},
 		{
+			name: "SPDY protocol - scoped",
+			args: args{
+				executorBuilder: remotecommand.NewSPDYExecutor,
+				config:          scopedConfigWithSingleKubeUser,
+			},
+		},
+		{
 			name: "Websocket protocol v4",
 			args: args{
 				// We can delete the dummy client once https://github.com/kubernetes/kubernetes/pull/110142
@@ -136,6 +207,18 @@ func testExecKubeService(t *testing.T, testCtx *TestContext) {
 			},
 		},
 		{
+			name: "Websocket protocol v4 - scoped",
+			args: args{
+				// We can delete the dummy client once https://github.com/kubernetes/kubernetes/pull/110142
+				// is merged into k8s go-client.
+				// For now go-client does not support connections over websockets.
+				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
+					return newWebSocketClient(c, s, u)
+				},
+				config: scopedConfigWithSingleKubeUser,
+			},
+		},
+		{
 			name: "Websocket protocol v5",
 			args: args{
 				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
@@ -145,10 +228,27 @@ func testExecKubeService(t *testing.T, testCtx *TestContext) {
 			},
 		},
 		{
+			name: "Websocket protocol v5 - scoped",
+			args: args{
+				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
+					return remotecommand.NewWebSocketExecutor(c, s, u.String())
+				},
+				config: scopedConfigWithSingleKubeUser,
+			},
+		},
+		{
 			name: "SPDY protocol for user with multiple kubernetes users",
 			args: args{
 				executorBuilder: remotecommand.NewSPDYExecutor,
 				config:          configMultiKubeUsers,
+				impersonateUser: "admin",
+			},
+		},
+		{
+			name: "SPDY protocol for user with multiple kubernetes users - scoped",
+			args: args{
+				executorBuilder: remotecommand.NewSPDYExecutor,
+				config:          scopedConfigMultiKubeUsers,
 				impersonateUser: "admin",
 			},
 		},
@@ -166,12 +266,35 @@ func testExecKubeService(t *testing.T, testCtx *TestContext) {
 			},
 		},
 		{
+			name: "Websocket protocol v4 for user with multiple kubernetes users - scoped",
+			args: args{
+				// We can delete the dummy client once https://github.com/kubernetes/kubernetes/pull/110142
+				// is merged into k8s go-client.
+				// For now go-client does not support connections over websockets.
+				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
+					return newWebSocketClient(c, s, u)
+				},
+				config:          scopedConfigMultiKubeUsers,
+				impersonateUser: "admin",
+			},
+		},
+		{
 			name: "Websocket protocol v5 for user with multiple kubernetes users",
 			args: args{
 				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
 					return remotecommand.NewWebSocketExecutor(c, s, u.String())
 				},
 				config:          configMultiKubeUsers,
+				impersonateUser: "admin",
+			},
+		},
+		{
+			name: "Websocket protocol v5 for user with multiple kubernetes users - scoped",
+			args: args{
+				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
+					return remotecommand.NewWebSocketExecutor(c, s, u.String())
+				},
+				config:          scopedConfigMultiKubeUsers,
 				impersonateUser: "admin",
 			},
 		},
@@ -184,12 +307,30 @@ func testExecKubeService(t *testing.T, testCtx *TestContext) {
 			wantErr: true,
 		},
 		{
+			name: "SPDY protocol for user with multiple kubernetes users without specifying impersonate user - scoped",
+			args: args{
+				executorBuilder: remotecommand.NewSPDYExecutor,
+				config:          scopedConfigMultiKubeUsers,
+			},
+			wantErr: true,
+		},
+		{
 			name: "Websocket protocol v5 for user with multiple kubernetes users without specifying impersonate user",
 			args: args{
 				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
 					return remotecommand.NewWebSocketExecutor(c, s, u.String())
 				},
 				config: configMultiKubeUsers,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Websocket protocol v5 for user with multiple kubernetes users without specifying impersonate user - scoped",
+			args: args{
+				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
+					return remotecommand.NewWebSocketExecutor(c, s, u.String())
+				},
+				config: scopedConfigMultiKubeUsers,
 			},
 			wantErr: true,
 		},
@@ -250,6 +391,7 @@ func TestExecKubeService(t *testing.T) {
 	// creates a Kubernetes service with a configured cluster pointing to mock api server
 	testCtx := SetupTestContext(t.Context(), t, TestConfig{
 		Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+		Scope:    scopedTestScope,
 		ScopesFeatures: scopes.Features{
 			Enabled:         true,
 			AgentPinEnabled: true,
@@ -367,6 +509,7 @@ func TestExecKubeServiceWithFaultyPrimary(t *testing.T) {
 			failingAccessPoint.ClientI = client
 			return failingAccessPoint
 		},
+		Scope: scopedTestScope,
 		ScopesFeatures: scopes.Features{
 			Enabled:         true,
 			AgentPinEnabled: true,
@@ -441,7 +584,6 @@ func generateExecRequest(cfg generateExecRequestConfig) (*rest.Request, error) {
 
 func TestExecMissingGETPermissionError(t *testing.T) {
 	t.Parallel()
-
 	const (
 		errorMessage = "pods \"api-1\" is forbidden: User \"bar\" cannot %s resource " +
 			"\"pods/exec\" in API group \"\" in the namespace \"ns\""
@@ -451,6 +593,7 @@ func TestExecMissingGETPermissionError(t *testing.T) {
 		errorMessage   string
 		errorInspector func(*testing.T, error)
 		interactive    bool
+		scope          string
 	}{
 		{
 			name:         "missing get permission",
@@ -484,111 +627,149 @@ func TestExecMissingGETPermissionError(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			const errorCode = http.StatusForbidden
+		for _, scope := range []string{"", scopedTestScope} {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				const errorCode = http.StatusForbidden
 
-			kubeMock, err := testingkubemock.NewKubeAPIMock(
-				testingkubemock.WithExecError(
-					metav1.Status{
-						Status:  metav1.StatusFailure,
-						Message: tt.errorMessage,
-						Reason:  metav1.StatusReasonForbidden,
-						Code:    errorCode,
+				kubeMock, err := testingkubemock.NewKubeAPIMock(
+					testingkubemock.WithExecError(
+						metav1.Status{
+							Status:  metav1.StatusFailure,
+							Message: tt.errorMessage,
+							Reason:  metav1.StatusReasonForbidden,
+							Code:    errorCode,
+						},
+					),
+				)
+				require.NoError(t, err)
+				t.Cleanup(func() { kubeMock.Close() })
+				var (
+					execEvent  *apievents.Exec
+					eventsLock sync.Mutex
+				)
+
+				// creates a Kubernetes service with a configured cluster pointing to mock api server
+				testCtx := SetupTestContext(
+					t.Context(),
+					t,
+					TestConfig{
+						Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+						OnEvent: func(evt apievents.AuditEvent) {
+							eventsLock.Lock()
+							defer eventsLock.Unlock()
+							if exec, ok := evt.(*apievents.Exec); ok {
+								execEvent = exec
+							}
+						},
+						Scope: scope,
+						ScopesFeatures: scopes.Features{
+							Enabled:         true,
+							AgentPinEnabled: true,
+						},
 					},
-				),
-			)
-			require.NoError(t, err)
-			t.Cleanup(func() { kubeMock.Close() })
-			var (
-				execEvent  *apievents.Exec
-				eventsLock sync.Mutex
-			)
+				)
 
-			// creates a Kubernetes service with a configured cluster pointing to mock api server
-			testCtx := SetupTestContext(
-				context.Background(),
-				t,
-				TestConfig{
-					Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
-					OnEvent: func(evt apievents.AuditEvent) {
-						eventsLock.Lock()
-						defer eventsLock.Unlock()
-						if exec, ok := evt.(*apievents.Exec); ok {
-							execEvent = exec
-						}
+				t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
+
+				// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
+				user, _ := testCtx.CreateUserAndRole(
+					testCtx.Context,
+					t,
+					username,
+					RoleSpec{
+						Name:       roleName,
+						KubeUsers:  roleKubeUsers,
+						KubeGroups: roleKubeGroups,
+					})
+
+				// generate a kube client with user certs for auth
+				_, userRestConfig := testCtx.GenTestKubeClientTLSCert(
+					t,
+					user.GetName(),
+					kubeCluster,
+				)
+
+				scopedUser, scopedUserRole := testCtx.CreateUserAndScopedRole(
+					t,
+					"scoped-"+username,
+					scopedTestScope,
+					&accessv1.ScopedRoleSpec{
+						AssignableScopes: []string{scopedTestScope},
+						Kube: &accessv1.ScopedRoleKube{
+							Users:  roleKubeUsers,
+							Groups: roleKubeGroups,
+							Labels: []*labelv1.Label{
+								{
+									Name:   types.Wildcard,
+									Values: []string{types.Wildcard},
+								},
+							},
+						},
+					})
+
+				waitForSRACache(t, testCtx.TLSServer, scopedUserRole)
+
+				_, scopedUserRestConfig := testCtx.GenTestKubeClientTLSCert(
+					t,
+					scopedUser.GetName(),
+					kubeCluster,
+					func(i *tlsca.Identity) {
+						i.ScopePin = testCtx.GetScopePinForUser(t, scopedUser.GetName(), scopedTestScope)
 					},
-				},
-			)
-
-			t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
-
-			// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
-			user, _ := testCtx.CreateUserAndRole(
-				testCtx.Context,
-				t,
-				username,
-				RoleSpec{
-					Name:       roleName,
-					KubeUsers:  roleKubeUsers,
-					KubeGroups: roleKubeGroups,
-				})
-
-			// generate a kube client with user certs for auth
-			_, userRestConfig := testCtx.GenTestKubeClientTLSCert(
-				t,
-				user.GetName(),
-				kubeCluster,
-			)
-			var streamOpts remotecommand.StreamOptions
-			if !tt.interactive {
-				streamOpts = remotecommand.StreamOptions{
-					Stdin:  nil,
-					Stdout: &bytes.Buffer{},
-					Stderr: &bytes.Buffer{},
-					Tty:    false,
+				)
+				var streamOpts remotecommand.StreamOptions
+				if !tt.interactive {
+					streamOpts = remotecommand.StreamOptions{
+						Stdin:  nil,
+						Stdout: &bytes.Buffer{},
+						Stderr: &bytes.Buffer{},
+						Tty:    false,
+					}
+				} else {
+					stdinReader, _ := io.Pipe()
+					t.Cleanup(func() { stdinReader.Close() })
+					streamOpts = remotecommand.StreamOptions{
+						Stdin:  stdinReader,
+						Stdout: &bytes.Buffer{},
+						Stderr: nil,
+						Tty:    true,
+					}
 				}
-			} else {
-				stdinReader, _ := io.Pipe()
-				t.Cleanup(func() { stdinReader.Close() })
-				streamOpts = remotecommand.StreamOptions{
-					Stdin:  stdinReader,
-					Stdout: &bytes.Buffer{},
-					Stderr: nil,
-					Tty:    true,
+				req, err := generateExecRequest(
+					generateExecRequestConfig{
+						addr:          testCtx.KubeProxyAddress(),
+						podName:       podName,
+						podNamespace:  podNamespace,
+						containerName: podContainerName,
+						cmd:           containerCommmandExecute, // placeholder for commands to execute in the dummy pod
+						options:       streamOpts,
+					},
+				)
+				require.NoError(t, err)
+				cfg := userRestConfig
+				if scope != "" {
+					cfg = scopedUserRestConfig
 				}
-			}
-			req, err := generateExecRequest(
-				generateExecRequestConfig{
-					addr:          testCtx.KubeProxyAddress(),
-					podName:       podName,
-					podNamespace:  podNamespace,
-					containerName: podContainerName,
-					cmd:           containerCommmandExecute, // placeholder for commands to execute in the dummy pod
-					options:       streamOpts,
-				},
-			)
-			require.NoError(t, err)
+				exec, err := remotecommand.NewSPDYExecutor(cfg, http.MethodPost, req.URL())
+				require.NoError(t, err)
+				err = exec.StreamWithContext(testCtx.Context, streamOpts)
+				require.Error(t, err)
+				tt.errorInspector(t, err)
 
-			exec, err := remotecommand.NewSPDYExecutor(userRestConfig, http.MethodPost, req.URL())
-			require.NoError(t, err)
-			err = exec.StreamWithContext(testCtx.Context, streamOpts)
-			require.Error(t, err)
-			tt.errorInspector(t, err)
+				require.Eventually(t, func() bool {
+					eventsLock.Lock()
+					defer eventsLock.Unlock()
+					return execEvent != nil
+				}, 5*time.Second, 100*time.Millisecond, "expected exec event to be recorded")
 
-			require.Eventually(t, func() bool {
 				eventsLock.Lock()
-				defer eventsLock.Unlock()
-				return execEvent != nil
-			}, 5*time.Second, 100*time.Millisecond, "expected exec event to be recorded")
-
-			eventsLock.Lock()
-			require.Equal(t, events.ExecFailureCode, execEvent.Code)
-			require.Equal(t, "403", execEvent.ExitCode)
-			require.NotEmpty(t, execEvent.Error)
-			eventsLock.Unlock()
-		})
+				require.Equal(t, events.ExecFailureCode, execEvent.Code)
+				require.Equal(t, "403", execEvent.ExitCode)
+				require.NotEmpty(t, execEvent.Error)
+				eventsLock.Unlock()
+			})
+		}
 	}
 }
 
@@ -598,9 +779,8 @@ func TestExecWebsocketEndToEndErrReturn(t *testing.T) {
 	const (
 		errorMessage = "pods \"api-1\" is forbidden: User \"bar\" cannot %s resource " +
 			"\"pods/exec\" in API group \"\" in the namespace \"ns\""
+		errorCode = http.StatusForbidden
 	)
-
-	const errorCode = http.StatusForbidden
 
 	kubeMock, err := testingkubemock.NewKubeAPIMock(
 		testingkubemock.WithExecError(
@@ -632,7 +812,7 @@ func TestExecWebsocketEndToEndErrReturn(t *testing.T) {
 
 	// creates a Kubernetes service with a configured cluster pointing to mock api server
 	testCtx := SetupTestContext(
-		context.Background(),
+		t.Context(),
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
@@ -642,6 +822,11 @@ func TestExecWebsocketEndToEndErrReturn(t *testing.T) {
 				if exec, ok := evt.(*apievents.Exec); ok {
 					execEvent = exec
 				}
+			},
+			Scope: scopedTestScope,
+			ScopesFeatures: scopes.Features{
+				Enabled:         true,
+				AgentPinEnabled: true,
 			},
 		},
 	)
@@ -715,7 +900,7 @@ func TestExecWebsocketEndToEndErrReturn(t *testing.T) {
 
 			exec, err := remotecommand.NewSPDYExecutor(userRestConfig, http.MethodPost, req.URL())
 			require.NoError(t, err)
-			err = exec.StreamWithContext(context.Background(), streamOpts)
+			err = exec.StreamWithContext(t.Context(), streamOpts)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), kubernetes130BreakingChangeHint)
 
@@ -732,4 +917,19 @@ func TestExecWebsocketEndToEndErrReturn(t *testing.T) {
 			eventsLock.Unlock()
 		})
 	}
+}
+
+func waitForSRACache(t *testing.T, srv *authtest.TLSServer, resps ...*accessv1.CreateScopedRoleAssignmentResponse) {
+	t.Helper()
+	ctx := t.Context()
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		for _, resp := range resps {
+			_, err := srv.Auth().ScopedAccessCache.GetScopedRoleAssignment(ctx, &accessv1.GetScopedRoleAssignmentRequest{
+				Name:    resp.GetAssignment().GetMetadata().GetName(),
+				Scope:   resp.GetAssignment().GetScope(),
+				SubKind: resp.GetAssignment().GetSubKind(),
+			})
+			require.NoError(t, err)
+		}
+	}, 10*time.Second, 100*time.Millisecond)
 }

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1364,7 +1364,7 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 	// If the user has active Access requests we need to validate that they allow
 	// the kubeResource.
 	// This is required because CheckAccess does not validate the subresource type.
-	// TODO(eriktate/scopes): scoped identities don't support resources or access requests, so we skip
+	// TODO(eriktate/scopes): scoped identities don't support access requests, so we skip
 	// these checks for now.
 	if !isScoped && !actx.metaResource.isList {
 		if rbacResource := actx.metaResource.rbacResource(); rbacResource != nil && len(unscopedCtx.Checker.GetAllowedResourceAccessIDs()) > 0 {

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -28,6 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -963,6 +964,170 @@ func TestAuthenticate(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:              "local scoped user and scoped cluster",
+			user:              authz.LocalUser{},
+			scoped:            true,
+			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:    "local",
+			kubernetesCluster: "local",
+			haveKubeCreds:     true,
+			tunnel:            tun,
+			kubeServers: newKubeServersFromKubeClusters(
+				t,
+				&types.KubernetesClusterV3{
+					Metadata: types.Metadata{
+						Name: "local",
+						Labels: map[string]string{
+							"static_label1": "static_value1",
+							"static_label2": "static_value2",
+						},
+					},
+					Spec: types.KubernetesClusterSpecV3{
+						DynamicLabels: map[string]types.CommandLabelV2{},
+					},
+					Scope: scopedTestScope,
+				},
+			),
+			wantCtx: &authContext{
+				kubeUsers:       set.New("user-a"),
+				kubeGroups:      set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
+				kubeClusterName: "local",
+				kubeClusterLabels: map[string]string{
+					"static_label1": "static_value1",
+					"static_label2": "static_value2",
+				},
+				certExpires: certExpiration,
+				teleportCluster: teleportClusterClient{
+					name:       "local",
+					remoteAddr: *utils.MustParseAddr(remoteAddr),
+				},
+				kubeServers: newKubeServersFromKubeClusters(
+					t,
+					&types.KubernetesClusterV3{
+						Scope: scopedTestScope,
+						Metadata: types.Metadata{
+							Name: "local",
+							Labels: map[string]string{
+								"static_label1": "static_value1",
+								"static_label2": "static_value2",
+							},
+						},
+						Spec: types.KubernetesClusterSpecV3{
+							DynamicLabels: map[string]types.CommandLabelV2{},
+						},
+					},
+				),
+			},
+		},
+		{
+			desc:              "local unscoped user and scoped cluster",
+			user:              authz.LocalUser{},
+			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:    "local",
+			kubernetesCluster: "local",
+			haveKubeCreds:     true,
+			tunnel:            tun,
+			kubeServers: newKubeServersFromKubeClusters(
+				t,
+				&types.KubernetesClusterV3{
+					Metadata: types.Metadata{
+						Name: "local",
+						Labels: map[string]string{
+							"static_label1": "static_value1",
+							"static_label2": "static_value2",
+						},
+					},
+					Spec: types.KubernetesClusterSpecV3{
+						DynamicLabels: map[string]types.CommandLabelV2{},
+					},
+					Scope: scopedTestScope,
+				},
+			),
+			wantCtx: &authContext{
+				kubeUsers:       set.New("user-a"),
+				kubeGroups:      set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
+				kubeClusterName: "local",
+				kubeClusterLabels: map[string]string{
+					"static_label1": "static_value1",
+					"static_label2": "static_value2",
+				},
+				certExpires: certExpiration,
+				teleportCluster: teleportClusterClient{
+					name:       "local",
+					remoteAddr: *utils.MustParseAddr(remoteAddr),
+				},
+				kubeServers: newKubeServersFromKubeClusters(
+					t,
+					&types.KubernetesClusterV3{
+						Scope: scopedTestScope,
+						Metadata: types.Metadata{
+							Name: "local",
+							Labels: map[string]string{
+								"static_label1": "static_value1",
+								"static_label2": "static_value2",
+							},
+						},
+						Spec: types.KubernetesClusterSpecV3{
+							DynamicLabels: map[string]types.CommandLabelV2{},
+						},
+					},
+				),
+			},
+		},
+		{
+			desc:              "local scoped user and scoped cluster - mismatched scope",
+			user:              authz.LocalUser{},
+			scoped:            true,
+			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:    "local",
+			kubernetesCluster: "local",
+			haveKubeCreds:     true,
+			tunnel:            tun,
+			kubeServers: newKubeServersFromKubeClusters(
+				t,
+				&types.KubernetesClusterV3{
+					Metadata: types.Metadata{
+						Name: "local",
+						Labels: map[string]string{
+							"static_label1": "static_value1",
+							"static_label2": "static_value2",
+						},
+					},
+					Spec: types.KubernetesClusterSpecV3{
+						DynamicLabels: map[string]types.CommandLabelV2{},
+					},
+					Scope: "/other",
+				},
+			),
+			wantAuthorizeErrContains: "[00] access denied",
+		},
+		{
+			desc:              "local scoped user and unscoped cluster",
+			user:              authz.LocalUser{},
+			scoped:            true,
+			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:    "local",
+			kubernetesCluster: "local",
+			haveKubeCreds:     true,
+			tunnel:            tun,
+			kubeServers: newKubeServersFromKubeClusters(
+				t,
+				&types.KubernetesClusterV3{
+					Metadata: types.Metadata{
+						Name: "local",
+						Labels: map[string]string{
+							"static_label1": "static_value1",
+							"static_label2": "static_value2",
+						},
+					},
+					Spec: types.KubernetesClusterSpecV3{
+						DynamicLabels: map[string]types.CommandLabelV2{},
+					},
+				},
+			),
+			wantAuthorizeErrContains: "[00] access denied",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
@@ -1046,7 +1211,7 @@ func TestAuthenticate(t *testing.T) {
 			}
 
 			gotCtx, err := f.authenticate(req)
-			if tt.wantErr {
+			if tt.wantErr || tt.wantAuthErr {
 				require.Error(t, err)
 				require.Equal(t, tt.wantAuthErr, trace.IsAccessDenied(err))
 				return
@@ -1548,6 +1713,7 @@ type mockAccessPoint struct {
 	authPref        types.AuthPreference
 	kubeServers     []types.KubeServer
 	cas             map[string]types.CertAuthority
+	scopedRoles     map[string]*scopedaccessv1.ScopedRole
 }
 
 func (ap mockAccessPoint) GetClusterNetworkingConfig(context.Context) (types.ClusterNetworkingConfig, error) {
@@ -1576,6 +1742,17 @@ func (ap mockAccessPoint) GetCertAuthorities(ctx context.Context, caType types.C
 
 func (ap mockAccessPoint) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error) {
 	return ap.cas[id.DomainName], nil
+}
+
+func (ap mockAccessPoint) GetScopedRole(ctx context.Context, req *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {
+	if role, ok := ap.scopedRoles[req.GetName()]; ok {
+		return &scopedaccessv1.GetScopedRoleResponse{Role: role}, nil
+	}
+	return nil, trace.NotFound("role %q not found", req.GetName())
+}
+
+func (ap mockAccessPoint) ListScopedRoles(ctx context.Context, req *scopedaccessv1.ListScopedRolesRequest) (*scopedaccessv1.ListScopedRolesResponse, error) {
+	return &scopedaccessv1.ListScopedRolesResponse{Roles: slices.Collect(maps.Values(ap.scopedRoles))}, nil
 }
 
 type mockRevTunnel struct {

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -60,7 +60,6 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
-	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -1815,15 +1814,14 @@ func newScopedKubeAuthorizer(t *testing.T, cfg scopedKubeAuthorizerConfig) mockA
 		Scope: "/",
 		Spec: &scopedaccessv1.ScopedRoleSpec{
 			AssignableScopes: []string{scopedTestScope},
-			Kube: &scopedaccessv1.ScopedRoleKube{
-				Labels: []*labelv1.Label{
-					{Name: types.Wildcard, Values: []string{types.Wildcard}},
-				},
+			Kube: scopedaccessv1.ScopedRoleKube_builder{
+				Labels:                wildcardLabel(),
+				Resources:             wildcardResource(),
 				Groups:                cfg.kubeGroups,
 				Users:                 cfg.kubeUsers,
 				Lock:                  lock,
 				DisconnectExpiredCert: cfg.kubeDisconnectExpired,
-			},
+			}.Build(),
 		},
 		Version: types.V1,
 	}

--- a/lib/kube/proxy/resource_rbac_test.go
+++ b/lib/kube/proxy/resource_rbac_test.go
@@ -52,13 +52,14 @@ import (
 	restclientwatch "k8s.io/client-go/rest/watch"
 	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
 	tkm "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
@@ -98,75 +99,88 @@ func TestListPodRBAC(t *testing.T) {
 	// close tests
 	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
 
-	// create a user with full access to kubernetes Pods.
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithFullAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithFullAccess,
-		RoleSpec{
-			Name:       usernameWithFullAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow, []types.KubernetesResource{
-					{
-						Kind:      "pods",
-						Name:      types.Wildcard,
-						Namespace: types.Wildcard,
-						Verbs:     []string{types.Wildcard},
-						APIGroup:  types.Wildcard,
-					},
-				})
+	kubeResourceDefs := map[string][]types.KubernetesResource{
+		usernameWithFullAccess: []types.KubernetesResource{
+			{
+				Kind:      "pods",
+				Name:      types.Wildcard,
+				Namespace: types.Wildcard,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  types.Wildcard,
 			},
 		},
-	)
+		usernameWithNamespaceAccess: []types.KubernetesResource{
+			{
+				Kind:      "pods",
+				Name:      types.Wildcard,
+				Namespace: metav1.NamespaceDefault,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  types.Wildcard,
+			},
+		},
+		usernameWithLimitedAccess: []types.KubernetesResource{
+			{
+				Kind:      "pods",
+				Name:      "nginx-*",
+				Namespace: metav1.NamespaceDefault,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  types.Wildcard,
+			},
+		},
+		usernameWithoutListVerbAccess: []types.KubernetesResource{
+			{
+				Kind:      "pods",
+				Name:      "*",
+				Namespace: metav1.NamespaceDefault,
+				Verbs:     []string{"get"},
+				APIGroup:  types.Wildcard,
+			},
+		},
+	}
 
-	scopedUserWithFullAccess, scopedRoleWithFullAccess := testCtx.CreateUserAndScopedRole(
-		t,
-		"scoped-"+usernameWithFullAccess,
-		scope,
-		&accessv1.ScopedRoleSpec{
-			AssignableScopes: []string{scope},
-			Kube: &accessv1.ScopedRoleKube{
-				Users:  roleKubeUsers,
-				Groups: roleKubeGroups,
-				Labels: []*labelv1.Label{
-					{
-						Name:   types.Wildcard,
-						Values: []string{types.Wildcard},
-					},
+	scopedAssignments := make([]*accessv1.CreateScopedRoleAssignmentResponse, 0, len(kubeResourceDefs))
+	users := make(map[string]types.User)
+	for username, kubeResources := range kubeResourceDefs {
+		// create unscoped user
+		unscopedUser, _ := testCtx.CreateUserAndRole(
+			testCtx.Context,
+			t,
+			username,
+			RoleSpec{
+				Name:       username,
+				KubeUsers:  roleKubeUsers,
+				KubeGroups: roleKubeGroups,
+				SetupRoleFunc: func(r types.Role) {
+					r.SetKubeResources(types.Allow, kubeResources)
 				},
 			},
-		})
-	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
+		)
+		users[unscopedUser.GetName()] = unscopedUser
 
-	// create a user with full access to kubernetes Pods.
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithNamespaceAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithNamespaceAccess,
-		RoleSpec{
-			Name:       usernameWithNamespaceAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow,
-					[]types.KubernetesResource{
-						{
-							Kind:      "pods",
-							Name:      types.Wildcard,
-							Namespace: metav1.NamespaceDefault,
-							Verbs:     []string{types.Wildcard},
-							APIGroup:  types.Wildcard,
-						},
-					})
-			},
-		},
-	)
+		// create scoped user
+		scopedResources := make([]*accessv1.KubeResource, len(kubeResources))
+		for idx, resource := range kubeResources {
+			scopedResources[idx] = toScopedKubeResource(resource)
+		}
+		scopedUser, scopedAssignment := testCtx.CreateUserAndScopedRole(
+			t,
+			scopedUsername(username),
+			scope,
+			accessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{scope},
+				Kube: accessv1.ScopedRoleKube_builder{
+					Users:     roleKubeUsers,
+					Groups:    roleKubeGroups,
+					Labels:    wildcardLabel(),
+					Resources: scopedResources,
+				}.Build(),
+			}.Build())
+		scopedAssignments = append(scopedAssignments, scopedAssignment)
+		users[scopedUser.GetName()] = scopedUser
+	}
+	waitForSRACache(t, testCtx.TLSServer, scopedAssignments...)
 
+	// create a user with traits
 	userWithTraits, _ := testCtx.CreateUserWithTraitsAndRole(
 		testCtx.Context,
 		t,
@@ -192,60 +206,7 @@ func TestListPodRBAC(t *testing.T) {
 			},
 		},
 	)
-
-	// create a moderator user with access to kubernetes
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithLimitedAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithLimitedAccess,
-		RoleSpec{
-			Name:       usernameWithLimitedAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow,
-					[]types.KubernetesResource{
-						{
-							Kind:      "pods",
-							Name:      "nginx-*",
-							Namespace: metav1.NamespaceDefault,
-							Verbs:     []string{types.Wildcard},
-							APIGroup:  types.Wildcard,
-						},
-					},
-				)
-			},
-		},
-	)
-	// create a moderator user with access to kubernetes
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithoutListVerb, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithoutListVerbAccess,
-		RoleSpec{
-			Name:       usernameWithoutListVerbAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow,
-					[]types.KubernetesResource{
-						{
-							Kind:      "pods",
-							Name:      "*",
-							Namespace: metav1.NamespaceDefault,
-							Verbs:     []string{"get"},
-							APIGroup:  types.Wildcard,
-						},
-					},
-				)
-			},
-		},
-	)
-
-	// create a user allowed to access all namespaces except the default namespace.
-	// (kubernetes_user and kubernetes_groups specified)
+	// create a user with deny rules
 	userWithDenyRule, _ := testCtx.CreateUserAndRole(
 		testCtx.Context,
 		t,
@@ -291,11 +252,6 @@ func TestListPodRBAC(t *testing.T) {
 		listPodErr       error
 		getTestPodResult error
 	}
-	scopedOpts := []GenTestKubeClientTLSCertOptions{
-		func(i *tlsca.Identity) {
-			i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
-		},
-	}
 	tests := []struct {
 		name string
 		args args
@@ -304,7 +260,7 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "list default namespace pods for user with full access",
 			args: args{
-				user:      userWithFullAccess,
+				user:      users[usernameWithFullAccess],
 				namespace: metav1.NamespaceDefault,
 			},
 			want: want{
@@ -318,9 +274,9 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "list default namespace pods for scoped user with full access",
 			args: args{
-				user:      scopedUserWithFullAccess,
+				user:      users[scopedUsername(usernameWithFullAccess)],
 				namespace: metav1.NamespaceDefault,
-				opts:      scopedOpts,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithFullAccess), scope),
 			},
 			want: want{
 				listPodsResult: []string{
@@ -333,7 +289,7 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "list pods in every namespace for user with full access",
 			args: args{
-				user:      userWithFullAccess,
+				user:      users[usernameWithFullAccess],
 				namespace: metav1.NamespaceAll,
 			},
 			want: want{
@@ -349,9 +305,9 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "list pods in every namespace for scoped user with full access",
 			args: args{
-				user:      scopedUserWithFullAccess,
+				user:      users[scopedUsername(usernameWithFullAccess)],
 				namespace: metav1.NamespaceAll,
-				opts:      scopedOpts,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithFullAccess), scope),
 			},
 			want: want{
 				listPodsResult: []string{
@@ -366,8 +322,23 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "list default namespace pods for user with default namespace",
 			args: args{
-				user:      userWithNamespaceAccess,
+				user:      users[usernameWithNamespaceAccess],
 				namespace: metav1.NamespaceDefault,
+			},
+			want: want{
+				listPodsResult: []string{
+					"default/nginx-1",
+					"default/nginx-2",
+					"default/test",
+				},
+			},
+		},
+		{
+			name: "list default namespace pods for scoped user with default namespace",
+			args: args{
+				user:      users[scopedUsername(usernameWithNamespaceAccess)],
+				namespace: metav1.NamespaceDefault,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithNamespaceAccess), scope),
 			},
 			want: want{
 				listPodsResult: []string{
@@ -380,8 +351,23 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "list pods in every namespace for user with default namespace",
 			args: args{
-				user:      userWithNamespaceAccess,
+				user:      users[usernameWithNamespaceAccess],
 				namespace: metav1.NamespaceAll,
+			},
+			want: want{
+				listPodsResult: []string{
+					"default/nginx-1",
+					"default/nginx-2",
+					"default/test",
+				},
+			},
+		},
+		{
+			name: "list pods in every namespace for scoped user with default namespace",
+			args: args{
+				user:      users[scopedUsername(usernameWithNamespaceAccess)],
+				namespace: metav1.NamespaceAll,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithNamespaceAccess), scope),
 			},
 			want: want{
 				listPodsResult: []string{
@@ -422,7 +408,7 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "list default namespace pods for user with limited access",
 			args: args{
-				user:      userWithLimitedAccess,
+				user:      users[usernameWithLimitedAccess],
 				namespace: metav1.NamespaceDefault,
 			},
 			want: want{
@@ -434,6 +420,28 @@ func TestListPodRBAC(t *testing.T) {
 					ErrStatus: metav1.Status{
 						Status:  "Failure",
 						Message: "pods \"test\" is forbidden: User \"limited_user\" cannot get resource \"pods\" in API group \"\" in the namespace \"default\"",
+						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
+					},
+				},
+			},
+		},
+		{
+			name: "list default namespace pods for scoped user with limited access",
+			args: args{
+				user:      users[scopedUsername(usernameWithLimitedAccess)],
+				namespace: metav1.NamespaceDefault,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithLimitedAccess), scope),
+			},
+			want: want{
+				listPodsResult: []string{
+					"default/nginx-1",
+					"default/nginx-2",
+				},
+				getTestPodResult: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  "Failure",
+						Message: "pods \"test\" is forbidden: User \"scoped-limited_user\" cannot get resource \"pods\" in API group \"\" in the namespace \"default\"",
 						Code:    403,
 						Reason:  metav1.StatusReasonForbidden,
 					},
@@ -463,7 +471,7 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "list default namespace pods for user with limited access and a resource access request",
 			args: args{
-				user:      userWithNamespaceAccess,
+				user:      users[usernameWithNamespaceAccess],
 				namespace: metav1.NamespaceDefault,
 				opts: []GenTestKubeClientTLSCertOptions{
 					WithResourceAccessRequests(
@@ -497,7 +505,7 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "user with legacy pod access request that no longer fullfills the role requirements",
 			args: args{
-				user:      userWithLimitedAccess,
+				user:      users[usernameWithLimitedAccess],
 				namespace: metav1.NamespaceDefault,
 				opts: []GenTestKubeClientTLSCertOptions{
 					WithResourceAccessRequests(
@@ -535,7 +543,7 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "user with pod access request that no longer fullfills the role requirements",
 			args: args{
-				user:      userWithLimitedAccess,
+				user:      users[usernameWithLimitedAccess],
 				namespace: metav1.NamespaceDefault,
 				opts: []GenTestKubeClientTLSCertOptions{
 					WithResourceAccessRequests(
@@ -573,7 +581,7 @@ func TestListPodRBAC(t *testing.T) {
 		{
 			name: "list default namespace pods for user with limited access",
 			args: args{
-				user:      userWithoutListVerb,
+				user:      users[usernameWithoutListVerbAccess],
 				namespace: metav1.NamespaceDefault,
 			},
 			want: want{
@@ -582,6 +590,25 @@ func TestListPodRBAC(t *testing.T) {
 					ErrStatus: metav1.Status{
 						Status:  "Failure",
 						Message: "pods is forbidden: User \"no_list_user\" cannot list resource \"pods\" in API group \"\" in the namespace \"default\"",
+						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
+					},
+				},
+			},
+		},
+		{
+			name: "list default namespace pods for scoped user with limited access",
+			args: args{
+				user:      users[scopedUsername(usernameWithoutListVerbAccess)],
+				namespace: metav1.NamespaceDefault,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithoutListVerbAccess), scope),
+			},
+			want: want{
+				listPodsResult: []string{},
+				listPodErr: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  "Failure",
+						Message: "pods is forbidden: User \"scoped-no_list_user\" cannot list resource \"pods\" in API group \"\" in the namespace \"default\"",
 						Code:    403,
 						Reason:  metav1.StatusReasonForbidden,
 					},
@@ -1158,110 +1185,80 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 	// close tests
 	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
 
-	// create a user with full access to kubernetes Pods.
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithFullAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithFullAccess,
-		RoleSpec{
-			Name:       usernameWithFullAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow, []types.KubernetesResource{
-					{
-						Kind:      "pods",
-						Name:      types.Wildcard,
-						Namespace: types.Wildcard,
-						Verbs:     []string{types.Wildcard},
-						APIGroup:  types.Wildcard,
-					},
-				})
+	kubeResourceDefs := map[string][]types.KubernetesResource{
+		usernameWithFullAccess: []types.KubernetesResource{
+			{
+				Kind:      "pods",
+				Name:      types.Wildcard,
+				Namespace: types.Wildcard,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  types.Wildcard,
 			},
 		},
-	)
+		usernameWithNamespaceAccess: []types.KubernetesResource{
+			{
+				Kind:      "pods",
+				Name:      types.Wildcard,
+				Namespace: metav1.NamespaceDefault,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  types.Wildcard,
+			},
+		},
+		usernameWithLimitedAccess: []types.KubernetesResource{
+			{
+				Kind:      "pods",
+				Name:      "nginx-*",
+				Namespace: metav1.NamespaceDefault,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  types.Wildcard,
+			},
+		},
+	}
 
-	scopedUserWithFullAccess, scopedRoleWithFullAccess := testCtx.CreateUserAndScopedRole(
-		t,
-		"scoped-"+usernameWithFullAccess,
-		scope,
-		&accessv1.ScopedRoleSpec{
-			AssignableScopes: []string{scope},
-			Kube: &accessv1.ScopedRoleKube{
-				Users:  roleKubeUsers,
-				Groups: roleKubeGroups,
-				Labels: []*labelv1.Label{
-					{
-						Name:   types.Wildcard,
-						Values: []string{types.Wildcard},
-					},
+	scopedAssignments := make([]*accessv1.CreateScopedRoleAssignmentResponse, 0, len(kubeResourceDefs))
+	users := make(map[string]types.User)
+	for username, kubeResources := range kubeResourceDefs {
+		unscopedUser, _ := testCtx.CreateUserAndRole(
+			testCtx.Context,
+			t,
+			username,
+			RoleSpec{
+				Name:       username,
+				KubeUsers:  roleKubeUsers,
+				KubeGroups: roleKubeGroups,
+				SetupRoleFunc: func(r types.Role) {
+					r.SetKubeResources(types.Allow, kubeResources)
 				},
 			},
-		})
-	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
+		)
+		users[unscopedUser.GetName()] = unscopedUser
 
-	// create a user with full access to kubernetes Pods.
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithNamespaceAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithNamespaceAccess,
-		RoleSpec{
-			Name:       usernameWithNamespaceAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow,
-					[]types.KubernetesResource{
-						{
-							Kind:      "pods",
-							Name:      types.Wildcard,
-							Namespace: metav1.NamespaceDefault,
-							Verbs:     []string{types.Wildcard},
-							APIGroup:  types.Wildcard,
-						},
-					})
-			},
-		},
-	)
-
-	// create a moderator user with access to kubernetes
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithLimitedAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithLimitedAccess,
-		RoleSpec{
-			Name:       usernameWithLimitedAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow,
-					[]types.KubernetesResource{
-						{
-							Kind:      "pods",
-							Name:      "nginx-*",
-							Namespace: metav1.NamespaceDefault,
-							Verbs:     []string{types.Wildcard},
-							APIGroup:  types.Wildcard,
-						},
-					},
-				)
-			},
-		},
-	)
+		scopedResources := make([]*accessv1.KubeResource, len(kubeResources))
+		for idx, resource := range kubeResources {
+			scopedResources[idx] = toScopedKubeResource(resource)
+		}
+		scopedUser, scopedAssignment := testCtx.CreateUserAndScopedRole(
+			t,
+			scopedUsername(username),
+			scope,
+			accessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{scope},
+				Kube: accessv1.ScopedRoleKube_builder{
+					Users:     roleKubeUsers,
+					Groups:    roleKubeGroups,
+					Labels:    wildcardLabel(),
+					Resources: scopedResources,
+				}.Build(),
+			}.Build())
+		scopedAssignments = append(scopedAssignments, scopedAssignment)
+		users[scopedUser.GetName()] = scopedUser
+	}
+	waitForSRACache(t, testCtx.TLSServer, scopedAssignments...)
 
 	type args struct {
 		user      types.User
 		namespace string
 		opts      []GenTestKubeClientTLSCertOptions
-	}
-	scopedOpts := []GenTestKubeClientTLSCertOptions{
-		func(i *tlsca.Identity) {
-			i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
-		},
 	}
 	tests := []struct {
 		name        string
@@ -1272,7 +1269,7 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 		{
 			name: "delete pods in default namespace for user with full access",
 			args: args{
-				user:      userWithFullAccess,
+				user:      users[usernameWithFullAccess],
 				namespace: metav1.NamespaceDefault,
 			},
 
@@ -1285,9 +1282,9 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 		{
 			name: "delete pods in default namespace for scoped user with full access",
 			args: args{
-				user:      scopedUserWithFullAccess,
+				user:      users[scopedUsername(usernameWithFullAccess)],
 				namespace: metav1.NamespaceDefault,
-				opts:      scopedOpts,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithFullAccess), scope),
 			},
 
 			deletedPods: []string{
@@ -1299,8 +1296,21 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 		{
 			name: "delete pods for user limited to default namespace",
 			args: args{
-				user:      userWithNamespaceAccess,
+				user:      users[usernameWithNamespaceAccess],
 				namespace: metav1.NamespaceDefault,
+			},
+			deletedPods: []string{
+				"default/nginx-1",
+				"default/nginx-2",
+				"default/test",
+			},
+		},
+		{
+			name: "delete pods for scoped user limited to default namespace",
+			args: args{
+				user:      users[scopedUsername(usernameWithNamespaceAccess)],
+				namespace: metav1.NamespaceDefault,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithNamespaceAccess), scope),
 			},
 			deletedPods: []string{
 				"default/nginx-1",
@@ -1311,8 +1321,18 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 		{
 			name: "delete pods in dev namespace for user limited to default",
 			args: args{
-				user:      userWithNamespaceAccess,
+				user:      users[usernameWithNamespaceAccess],
 				namespace: "dev",
+			},
+			wantErr:     true,
+			deletedPods: []string{},
+		},
+		{
+			name: "delete pods in dev namespace for scoped user limited to default",
+			args: args{
+				user:      users[scopedUsername(usernameWithNamespaceAccess)],
+				namespace: "dev",
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithNamespaceAccess), scope),
 			},
 			wantErr:     true,
 			deletedPods: []string{},
@@ -1320,8 +1340,21 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 		{
 			name: "delete pods in default namespace for user with limited access",
 			args: args{
-				user:      userWithLimitedAccess,
+				user:      users[usernameWithLimitedAccess],
 				namespace: metav1.NamespaceDefault,
+			},
+
+			deletedPods: []string{
+				"default/nginx-1",
+				"default/nginx-2",
+			},
+		},
+		{
+			name: "delete pods in default namespace for scoped user with limited access",
+			args: args{
+				user:      users[scopedUsername(usernameWithLimitedAccess)],
+				namespace: metav1.NamespaceDefault,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithLimitedAccess), scope),
 			},
 
 			deletedPods: []string{
@@ -1397,112 +1430,80 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 	// close tests
 	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
 
-	// create a user with full access to kubernetes Pods.
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithFullAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithFullAccess,
-		RoleSpec{
-			Name:       usernameWithFullAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow, []types.KubernetesResource{
-					{
-						Kind:      "teleportroles",
-						Name:      types.Wildcard,
-						Namespace: types.Wildcard,
-						Verbs:     []string{types.Wildcard},
-						APIGroup:  "resources.teleport.dev",
-					},
-				})
+	kubeResourceDefs := map[string][]types.KubernetesResource{
+		usernameWithFullAccess: []types.KubernetesResource{
+			{
+				Kind:      "teleportroles",
+				Name:      types.Wildcard,
+				Namespace: types.Wildcard,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  "resources.teleport.dev",
 			},
 		},
-	)
+		usernameWithNamespaceAccess: []types.KubernetesResource{
+			{
+				Kind:      "teleportroles",
+				Name:      types.Wildcard,
+				Namespace: metav1.NamespaceDefault,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  "resources.teleport.dev",
+			},
+		},
+		usernameWithLimitedAccess: []types.KubernetesResource{
+			{
+				Kind:      "teleportroles",
+				Name:      "*-test",
+				Namespace: metav1.NamespaceDefault,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  "resources.teleport.dev",
+			},
+		},
+	}
 
-	// create a scoped user with full access to kubernetes Pods.
-	// (kubernetes_user and kubernetes_groups specified)
-	scopedUserWithFullAccess, scopedRoleWithFullAccess := testCtx.CreateUserAndScopedRole(
-		t,
-		"scoped-"+usernameWithFullAccess,
-		scope,
-		&accessv1.ScopedRoleSpec{
-			AssignableScopes: []string{scope},
-			Kube: &accessv1.ScopedRoleKube{
-				Users:  roleKubeUsers,
-				Groups: roleKubeGroups,
-				Labels: []*labelv1.Label{
-					{
-						Name:   types.Wildcard,
-						Values: []string{types.Wildcard},
-					},
+	scopedAssignments := make([]*accessv1.CreateScopedRoleAssignmentResponse, 0, len(kubeResourceDefs))
+	users := make(map[string]types.User)
+	for username, kubeResources := range kubeResourceDefs {
+		unscopedUser, _ := testCtx.CreateUserAndRole(
+			testCtx.Context,
+			t,
+			username,
+			RoleSpec{
+				Name:       username,
+				KubeUsers:  roleKubeUsers,
+				KubeGroups: roleKubeGroups,
+				SetupRoleFunc: func(r types.Role) {
+					r.SetKubeResources(types.Allow, kubeResources)
 				},
 			},
-		})
-	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
+		)
+		users[unscopedUser.GetName()] = unscopedUser
 
-	// create a user with full access to kubernetes Pods.
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithNamespaceAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithNamespaceAccess,
-		RoleSpec{
-			Name:       usernameWithNamespaceAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow,
-					[]types.KubernetesResource{
-						{
-							Kind:      "teleportroles",
-							Name:      types.Wildcard,
-							Namespace: metav1.NamespaceDefault,
-							Verbs:     []string{types.Wildcard},
-							APIGroup:  "resources.teleport.dev",
-						},
-					})
-			},
-		},
-	)
-
-	// create a moderator user with access to kubernetes
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithLimitedAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithLimitedAccess,
-		RoleSpec{
-			Name:       usernameWithLimitedAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow,
-					[]types.KubernetesResource{
-						{
-							Kind:      "teleportroles",
-							Name:      "*-test",
-							Namespace: metav1.NamespaceDefault,
-							Verbs:     []string{types.Wildcard},
-							APIGroup:  "resources.teleport.dev",
-						},
-					},
-				)
-			},
-		},
-	)
+		scopedResources := make([]*accessv1.KubeResource, len(kubeResources))
+		for idx, resource := range kubeResources {
+			scopedResources[idx] = toScopedKubeResource(resource)
+		}
+		scopedUser, scopedAssignment := testCtx.CreateUserAndScopedRole(
+			t,
+			scopedUsername(username),
+			scope,
+			accessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{scope},
+				Kube: accessv1.ScopedRoleKube_builder{
+					Users:     roleKubeUsers,
+					Groups:    roleKubeGroups,
+					Labels:    wildcardLabel(),
+					Resources: scopedResources,
+				}.Build(),
+			}.Build())
+		scopedAssignments = append(scopedAssignments, scopedAssignment)
+		users[scopedUser.GetName()] = scopedUser
+	}
+	waitForSRACache(t, testCtx.TLSServer, scopedAssignments...)
 
 	type args struct {
 		user      types.User
 		namespace string
 		opts      []GenTestKubeClientTLSCertOptions
-	}
-	scopedOpts := []GenTestKubeClientTLSCertOptions{
-		func(i *tlsca.Identity) {
-			i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
-		},
 	}
 	tests := []struct {
 		name        string
@@ -1513,7 +1514,7 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 		{
 			name: "delete teleportroles in default namespace for user with full access",
 			args: args{
-				user:      userWithFullAccess,
+				user:      users[usernameWithFullAccess],
 				namespace: metav1.NamespaceDefault,
 			},
 
@@ -1527,9 +1528,9 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 		{
 			name: "delete teleportroles in default namespace for scoped user with full access",
 			args: args{
-				user:      scopedUserWithFullAccess,
+				user:      users[scopedUsername(usernameWithFullAccess)],
 				namespace: metav1.NamespaceDefault,
-				opts:      scopedOpts,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithFullAccess), scope),
 			},
 
 			deletedCRDs: []string{
@@ -1542,8 +1543,22 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 		{
 			name: "delete teleportroles for user limited to default namespace",
 			args: args{
-				user:      userWithNamespaceAccess,
+				user:      users[usernameWithNamespaceAccess],
 				namespace: metav1.NamespaceDefault,
+			},
+			deletedCRDs: []string{
+				"default/telerole-1",
+				"default/telerole-1",
+				"default/telerole-2",
+				"default/telerole-test",
+			},
+		},
+		{
+			name: "delete teleportroles for scoped user limited to default namespace",
+			args: args{
+				user:      users[scopedUsername(usernameWithNamespaceAccess)],
+				namespace: metav1.NamespaceDefault,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithNamespaceAccess), scope),
 			},
 			deletedCRDs: []string{
 				"default/telerole-1",
@@ -1555,8 +1570,18 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 		{
 			name: "delete teleportroles in dev namespace for user limited to default",
 			args: args{
-				user:      userWithNamespaceAccess,
+				user:      users[usernameWithNamespaceAccess],
 				namespace: "dev",
+			},
+			wantErr:     true,
+			deletedCRDs: []string{},
+		},
+		{
+			name: "delete teleportroles in dev namespace for scoped user limited to default",
+			args: args{
+				user:      users[scopedUsername(usernameWithNamespaceAccess)],
+				namespace: "dev",
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithNamespaceAccess), scope),
 			},
 			wantErr:     true,
 			deletedCRDs: []string{},
@@ -1564,8 +1589,20 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 		{
 			name: "delete teleportroles in default namespace for user with limited access",
 			args: args{
-				user:      userWithLimitedAccess,
+				user:      users[usernameWithLimitedAccess],
 				namespace: metav1.NamespaceDefault,
+			},
+
+			deletedCRDs: []string{
+				"default/telerole-test",
+			},
+		},
+		{
+			name: "delete teleportroles in default namespace for scoped user with limited access",
+			args: args{
+				user:      users[scopedUsername(usernameWithLimitedAccess)],
+				namespace: metav1.NamespaceDefault,
+				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithLimitedAccess), scope),
 			},
 
 			deletedCRDs: []string{
@@ -1643,84 +1680,68 @@ func TestListClusterRoleRBAC(t *testing.T) {
 	// close tests
 	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
 
-	// create a user with full access to kubernetes Pods.
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithFullAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithFullAccess,
-		RoleSpec{
-			Name:       usernameWithFullAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow, []types.KubernetesResource{
-					{
-						Kind:     "clusterroles",
-						Name:     types.Wildcard,
-						Verbs:    []string{types.Wildcard},
-						APIGroup: types.Wildcard,
-					},
-				})
+	kubeResourceDefs := map[string][]types.KubernetesResource{
+		usernameWithFullAccess: []types.KubernetesResource{
+			{
+				Kind:     "clusterroles",
+				Name:     types.Wildcard,
+				Verbs:    []string{types.Wildcard},
+				APIGroup: types.Wildcard,
 			},
 		},
-	)
+		usernameWithLimitedAccess: []types.KubernetesResource{
+			{
+				Kind:     "clusterroles",
+				Name:     "cr-nginx-*",
+				Verbs:    []string{types.Wildcard},
+				APIGroup: types.Wildcard,
+			},
+		},
+	}
 
-	// create a scoped user with full access to kubernetes Pods.
-	// (kubernetes_user and kubernetes_groups specified)
-	scopedUserWithFullAccess, scopedRoleWithFullAccess := testCtx.CreateUserAndScopedRole(
-		t,
-		"scoped-"+usernameWithFullAccess,
-		scope,
-		&accessv1.ScopedRoleSpec{
-			AssignableScopes: []string{scope},
-			Kube: &accessv1.ScopedRoleKube{
-				Users:  roleKubeUsers,
-				Groups: roleKubeGroups,
-				Labels: []*labelv1.Label{
-					{
-						Name:   types.Wildcard,
-						Values: []string{types.Wildcard},
-					},
+	scopedAssignments := make([]*accessv1.CreateScopedRoleAssignmentResponse, 0, len(kubeResourceDefs))
+	users := make(map[string]types.User)
+	for username, kubeResources := range kubeResourceDefs {
+		unscopedUser, _ := testCtx.CreateUserAndRole(
+			testCtx.Context,
+			t,
+			username,
+			RoleSpec{
+				Name:       username,
+				KubeUsers:  roleKubeUsers,
+				KubeGroups: roleKubeGroups,
+				SetupRoleFunc: func(r types.Role) {
+					r.SetKubeResources(types.Allow, kubeResources)
 				},
 			},
-		})
-	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
+		)
+		users[unscopedUser.GetName()] = unscopedUser
 
-	// Create a moderator user with access to kubernetes
-	// (kubernetes_user and kubernetes_groups specified).
-	userWithLimitedAccess, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameWithLimitedAccess,
-		RoleSpec{
-			Name:       usernameWithLimitedAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow,
-					[]types.KubernetesResource{
-						{
-							Kind:     "clusterroles",
-							Name:     "cr-nginx-*",
-							Verbs:    []string{types.Wildcard},
-							APIGroup: types.Wildcard,
-						},
-					},
-				)
-			},
-		},
-	)
+		scopedResources := make([]*accessv1.KubeResource, len(kubeResources))
+		for idx, resource := range kubeResources {
+			scopedResources[idx] = toScopedKubeResource(resource)
+		}
+		scopedUser, scopedAssignment := testCtx.CreateUserAndScopedRole(
+			t,
+			scopedUsername(username),
+			scope,
+			accessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{scope},
+				Kube: accessv1.ScopedRoleKube_builder{
+					Users:     roleKubeUsers,
+					Groups:    roleKubeGroups,
+					Labels:    wildcardLabel(),
+					Resources: scopedResources,
+				}.Build(),
+			}.Build())
+		scopedAssignments = append(scopedAssignments, scopedAssignment)
+		users[scopedUser.GetName()] = scopedUser
+	}
+	waitForSRACache(t, testCtx.TLSServer, scopedAssignments...)
 
 	type args struct {
 		user types.User
 		opts []GenTestKubeClientTLSCertOptions
-	}
-	scopedOpts := []GenTestKubeClientTLSCertOptions{
-		func(i *tlsca.Identity) {
-			i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
-		},
 	}
 	type want struct {
 		listClusterRolesResult []string
@@ -1735,7 +1756,7 @@ func TestListClusterRoleRBAC(t *testing.T) {
 		{
 			name: "list cluster roles for user with full access",
 			args: args{
-				user: userWithFullAccess,
+				user: users[usernameWithFullAccess],
 			},
 			want: want{
 				listClusterRolesResult: []string{
@@ -1748,8 +1769,8 @@ func TestListClusterRoleRBAC(t *testing.T) {
 		{
 			name: "list cluster roles for scoped user with full access",
 			args: args{
-				user: scopedUserWithFullAccess,
-				opts: scopedOpts,
+				user: users[scopedUsername(usernameWithFullAccess)],
+				opts: makeScopedOpts(t, testCtx, scopedUsername(usernameWithFullAccess), scope),
 			},
 			want: want{
 				listClusterRolesResult: []string{
@@ -1762,7 +1783,7 @@ func TestListClusterRoleRBAC(t *testing.T) {
 		{
 			name: "list cluster roles for user with limited access",
 			args: args{
-				user: userWithLimitedAccess,
+				user: users[usernameWithLimitedAccess],
 			},
 			want: want{
 				listClusterRolesResult: []string{
@@ -1779,11 +1800,31 @@ func TestListClusterRoleRBAC(t *testing.T) {
 				},
 			},
 		},
-
+		{
+			name: "list cluster roles for scoped user with limited access",
+			args: args{
+				user: users[scopedUsername(usernameWithLimitedAccess)],
+				opts: makeScopedOpts(t, testCtx, scopedUsername(usernameWithLimitedAccess), scope),
+			},
+			want: want{
+				listClusterRolesResult: []string{
+					"cr-nginx-1",
+					"cr-nginx-2",
+				},
+				getTestResult: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  "Failure",
+						Message: "clusterroles \"cr-test\" is forbidden: User \"scoped-limited_user\" cannot get resource \"clusterroles\" in API group \"rbac.authorization.k8s.io\"",
+						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
+					},
+				},
+			},
+		},
 		{
 			name: "user with cluster role access request that no longer fullfills the role requirements",
 			args: args{
-				user: userWithLimitedAccess,
+				user: users[usernameWithLimitedAccess],
 				opts: []GenTestKubeClientTLSCertOptions{
 					WithResourceAccessRequests(
 						types.ResourceAccessID{
@@ -1878,118 +1919,84 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 
 	kubeScheme, testCtx := newTestKubeCRDMock(t, scope, tkm.WithTeleportRoleCRD)
 
-	// create a user with full access to all namespaces.
-	// (kubernetes_user and kubernetes_groups specified)
-	userWithFullAccess, _ := testCtx.CreateUserAndRoleVersion(
-		testCtx.Context,
-		t,
-		usernameWithFullAccess,
-		types.V8,
-		RoleSpec{
-			Name:       usernameWithFullAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow, []types.KubernetesResource{
-					{
-						Kind:      types.Wildcard,
-						Name:      types.Wildcard,
-						Namespace: types.Wildcard,
-						Verbs:     []string{types.Wildcard},
-						APIGroup:  types.Wildcard,
-					},
-				})
+	kubeResourceDefs := map[string][]types.KubernetesResource{
+		usernameWithFullAccess: []types.KubernetesResource{
+			{
+				Kind:      types.Wildcard,
+				Name:      types.Wildcard,
+				Namespace: types.Wildcard,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  types.Wildcard,
 			},
 		},
-	)
+		usernameWithLimitedAccess: []types.KubernetesResource{
+			{
+				Kind:      types.Wildcard,
+				Name:      types.Wildcard,
+				Namespace: "dev",
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  types.Wildcard,
+			},
+			{
+				Kind:  "namespaces",
+				Name:  "dev",
+				Verbs: []string{types.Wildcard},
+			},
+		},
+		usernameWithSpecificAccess: []types.KubernetesResource{
+			{
+				Kind:      "teleportroles",
+				Name:      types.Wildcard,
+				Namespace: "dev",
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  "resources.teleport.dev",
+			},
+		},
+	}
 
-	// create a scoped user with full access to all namespaces.
-	// (kubernetes_user and kubernetes_groups specified)
-	scopedUserWithFullAccess, scopedRoleWithFullAccess := testCtx.CreateUserAndScopedRole(
-		t,
-		"scoped-"+usernameWithFullAccess,
-		scope,
-		&accessv1.ScopedRoleSpec{
-			AssignableScopes: []string{scope},
-			Kube: &accessv1.ScopedRoleKube{
-				Users:  roleKubeUsers,
-				Groups: roleKubeGroups,
-				Labels: []*labelv1.Label{
-					{
-						Name:   types.Wildcard,
-						Values: []string{types.Wildcard},
-					},
+	scopedAssignments := make([]*accessv1.CreateScopedRoleAssignmentResponse, 0, len(kubeResourceDefs))
+	users := make(map[string]types.User)
+	for username, kubeResources := range kubeResourceDefs {
+		unscopedUser, _ := testCtx.CreateUserAndRoleVersion(
+			testCtx.Context,
+			t,
+			username,
+			types.V8,
+			RoleSpec{
+				Name:       username,
+				KubeUsers:  roleKubeUsers,
+				KubeGroups: roleKubeGroups,
+				SetupRoleFunc: func(r types.Role) {
+					r.SetKubeResources(types.Allow, kubeResources)
 				},
 			},
-		})
-	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
+		)
+		users[unscopedUser.GetName()] = unscopedUser
 
-	// create a user with limited access to kubernetes namespaces.
-	userWithLimitedAccess, _ := testCtx.CreateUserAndRoleVersion(
-		testCtx.Context,
-		t,
-		usernameWithLimitedAccess,
-		types.V8,
-		RoleSpec{
-			Name:       usernameWithLimitedAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow,
-					[]types.KubernetesResource{
-						{
-							Kind:      types.Wildcard,
-							Name:      types.Wildcard,
-							Namespace: "dev",
-							Verbs:     []string{types.Wildcard},
-							APIGroup:  types.Wildcard,
-						},
-						{
-							Kind:  "namespaces",
-							Name:  "dev",
-							Verbs: []string{types.Wildcard},
-						},
-					},
-				)
-			},
-		},
-	)
-
-	// create a user with limited access to kubernetes namespaces.
-	userWithSpecificAccess, _ := testCtx.CreateUserAndRoleVersion(
-		testCtx.Context,
-		t,
-		usernameWithSpecificAccess,
-		types.V8,
-		RoleSpec{
-			Name:       usernameWithSpecificAccess,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow,
-					[]types.KubernetesResource{
-						{
-							Kind:      "teleportroles",
-							Name:      types.Wildcard,
-							Namespace: "dev",
-							Verbs:     []string{types.Wildcard},
-							APIGroup:  "resources.teleport.dev",
-						},
-					},
-				)
-			},
-		},
-	)
-
+		scopedResources := make([]*accessv1.KubeResource, len(kubeResources))
+		for idx, resource := range kubeResources {
+			scopedResources[idx] = toScopedKubeResource(resource)
+		}
+		scopedUser, scopedAssignment := testCtx.CreateUserAndScopedRole(
+			t,
+			scopedUsername(username),
+			scope,
+			accessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{scope},
+				Kube: accessv1.ScopedRoleKube_builder{
+					Users:     roleKubeUsers,
+					Groups:    roleKubeGroups,
+					Labels:    wildcardLabel(),
+					Resources: scopedResources,
+				}.Build(),
+			}.Build())
+		scopedAssignments = append(scopedAssignments, scopedAssignment)
+		users[scopedUser.GetName()] = scopedUser
+	}
+	waitForSRACache(t, testCtx.TLSServer, scopedAssignments...)
 	type args struct {
 		user types.User
 		opts []GenTestKubeClientTLSCertOptions
-	}
-	scopedOpts := []GenTestKubeClientTLSCertOptions{
-		func(i *tlsca.Identity) {
-			i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
-		},
 	}
 	type want struct {
 		listTeleportRolesResult []string
@@ -2005,7 +2012,7 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "list teleport roles for user with full access",
 			args: args{
-				user: userWithFullAccess,
+				user: users[usernameWithFullAccess],
 			},
 			want: want{
 				listTeleportRolesResult: []string{
@@ -2021,8 +2028,8 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "list teleport roles for scoped user with full access",
 			args: args{
-				user: scopedUserWithFullAccess,
-				opts: scopedOpts,
+				user: users[scopedUsername(usernameWithFullAccess)],
+				opts: makeScopedOpts(t, testCtx, scopedUsername(usernameWithFullAccess), scope),
 			},
 			want: want{
 				listTeleportRolesResult: []string{
@@ -2038,7 +2045,7 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "list teleport roles for user with specific crd access",
 			args: args{
-				user: userWithSpecificAccess,
+				user: users[usernameWithSpecificAccess],
 			},
 			want: want{
 				listTeleportRolesResult: []string{
@@ -2059,9 +2066,33 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 			},
 		},
 		{
+			name: "list teleport roles for scoped user with specific crd access",
+			args: args{
+				user: users[scopedUsername(usernameWithSpecificAccess)],
+				opts: makeScopedOpts(t, testCtx, scopedUsername(usernameWithSpecificAccess), scope),
+			},
+			want: want{
+				listTeleportRolesResult: []string{
+					"dev/telerole-1",
+					"dev/telerole-2",
+				},
+				getTestResult: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status: "Failure",
+						Message: fmt.Sprintf(
+							"teleportroles \"telerole-test\" is forbidden: User %q cannot get resource \"teleportroles\" in API group \"resources.teleport.dev\"",
+							"scoped-"+usernameWithSpecificAccess,
+						),
+						Code:   403,
+						Reason: metav1.StatusReasonForbidden,
+					},
+				},
+			},
+		},
+		{
 			name: "list teleport roles for user with limited access",
 			args: args{
-				user: userWithLimitedAccess,
+				user: users[usernameWithLimitedAccess],
 			},
 			want: want{
 				listTeleportRolesResult: []string{
@@ -2078,11 +2109,31 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 				},
 			},
 		},
-
+		{
+			name: "list teleport roles for scoped user with limited access",
+			args: args{
+				user: users[scopedUsername(usernameWithLimitedAccess)],
+				opts: makeScopedOpts(t, testCtx, scopedUsername(usernameWithLimitedAccess), scope),
+			},
+			want: want{
+				listTeleportRolesResult: []string{
+					"dev/telerole-1",
+					"dev/telerole-2",
+				},
+				getTestResult: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  "Failure",
+						Message: "teleportroles \"telerole-test\" is forbidden: User \"scoped-limited_user\" cannot get resource \"teleportroles\" in API group \"resources.teleport.dev\"",
+						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
+					},
+				},
+			},
+		},
 		{
 			name: "user with namespace access request that no longer fullfills the role requirements",
 			args: args{
-				user: userWithLimitedAccess,
+				user: users[usernameWithLimitedAccess],
 				opts: []GenTestKubeClientTLSCertOptions{
 					WithResourceAccessRequests(
 						types.ResourceAccessID{
@@ -2120,7 +2171,7 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "user with namespace access request that restricts the role requirements",
 			args: args{
-				user: userWithFullAccess,
+				user: users[usernameWithFullAccess],
 				opts: []GenTestKubeClientTLSCertOptions{
 					WithResourceAccessRequests(
 						types.ResourceAccessID{
@@ -2240,9 +2291,10 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 func TestV8JailedNamespaceListRBAC(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
+	const scope = "/test"
+	_, testCtx := newTestKubeCRDMock(t, scope, tkm.WithTeleportRoleCRD)
 
-	newTestUser := newTestUserFactory(t, testCtx, "", types.V8)
+	newTestUser := newTestUserFactoryWithScope(t, testCtx, "", types.V8, scope)
 
 	tests := []struct {
 		name string
@@ -2252,7 +2304,9 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 	}{
 		{
 			name: "full default access",
-			user: newTestUser(nil, nil),
+			// regnerate a factory without scopes because omitting kube resources
+			// is not allowed for scoped roles and newTestUser will fail
+			user: newTestUserFactory(t, testCtx, "", types.V8)(nil, nil),
 			ns:   "default",
 			want: []string{
 				// teleportroles.
@@ -2542,24 +2596,30 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+		// loop to run the test case against scoped and unscoped credentials
+		for _, scoped := range []bool{false, true} {
+			var opts []GenTestKubeClientTLSCertOptions
+			want := tt.want
+			if scoped {
+				opts = makeScopedOpts(t, testCtx, tt.user.GetName(), scope)
+			}
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 
-			// Generate a kube dynClient with user certs for auth.
-			_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), kubeCluster)
+				// Generate a kube dynClient with user certs for auth.
+				_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), kubeCluster, opts...)
+				// List TeleportRoles (namespaced), pods (namespaced), clusterroles (cluster wide) and namespaces (kind of cluster wide).
+				got := []string{}
+				got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("resources.teleport.dev/v6/teleportroles")).Namespace(tt.ns))...)
+				got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("v1/pods")).Namespace(tt.ns))...)
+				got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("rbac.authorization.k8s.io/v1/clusterroles")))...)
+				got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("v1/namespaces")))...)
 
-			// List TeleportRoles (namespaced), pods (namespaced), clusterroles (cluster wide) and namespaces (kind of cluster wide).
-			got := []string{}
-			got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("resources.teleport.dev/v6/teleportroles")).Namespace(tt.ns))...)
-			got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("v1/pods")).Namespace(tt.ns))...)
-			got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("rbac.authorization.k8s.io/v1/clusterroles")))...)
-			got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("v1/namespaces")))...)
-
-			require.Equal(t, tt.want, got)
-		})
+				require.Equal(t, want, got)
+			})
+		}
 	}
 }
-
 func TestV7JailedNamespaceListRBAC(t *testing.T) {
 	t.Parallel()
 
@@ -3148,9 +3208,10 @@ func TestV7V8Match(t *testing.T) {
 func TestNamespaceListRBAC(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
+	const scope = "/test"
+	_, testCtx := newTestKubeCRDMock(t, scope, tkm.WithTeleportRoleCRD)
 
-	newTestUser := newTestUserFactory(t, testCtx, "nslist", types.V8)
+	newTestUser := newTestUserFactoryWithScope(t, testCtx, "nslist", types.V8, scope)
 
 	commonResources := []types.KubernetesResource{
 		{
@@ -3176,9 +3237,10 @@ func TestNamespaceListRBAC(t *testing.T) {
 	}
 
 	tests := []struct {
-		name string
-		user types.User
-		want []string
+		name       string
+		user       types.User
+		want       []string
+		wantScoped []string
 	}{
 		{
 			name: "common resources",
@@ -3340,6 +3402,13 @@ func TestNamespaceListRBAC(t *testing.T) {
 				"test",
 				"prod",
 			},
+			// scoped roles do not support denials
+			wantScoped: []string{
+				"default",
+				"test",
+				"dev",
+				"prod",
+			},
 		},
 		{
 			name: "ns resource deny cluster-wide wildcard",
@@ -3359,6 +3428,12 @@ func TestNamespaceListRBAC(t *testing.T) {
 				},
 			}),
 			want: []string{},
+			wantScoped: []string{
+				"default",
+				"test",
+				"dev",
+				"prod",
+			},
 		},
 		{
 			name: "ns pods deny cluster-wide wildcard",
@@ -3386,6 +3461,13 @@ func TestNamespaceListRBAC(t *testing.T) {
 			// Even though the user has access to pods and still can get pods in all NSs, the list namespace is empty
 			// because of the deny rule.
 			want: []string{},
+			// scoped roles do not support denials
+			wantScoped: []string{
+				"default",
+				"test",
+				"dev",
+				"prod",
+			},
 		},
 		{
 			name: "ns pods deny ns wildcard",
@@ -3411,20 +3493,41 @@ func TestNamespaceListRBAC(t *testing.T) {
 			// Even though the user has access to pods and still can get pods in all NSs, the list namespace is empty
 			// because of the deny rule.
 			want: []string{},
+			// scoped roles do not support denials
+			wantScoped: []string{
+				"default",
+				"test",
+				"dev",
+				"prod",
+			},
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+		// loop to run the test case against scoped and unscoped credentials
+		for _, scoped := range []bool{false, true} {
+			var opts []GenTestKubeClientTLSCertOptions
+			want := tt.want
+			if scoped {
+				opts = makeScopedOpts(t, testCtx, tt.user.GetName(), scope)
+				// we only want to check tt.wantScoped if it was provided, otherwise a nil value means
+				// we should test scoped credentials against the same expectations
+				if tt.wantScoped != nil {
+					want = tt.wantScoped
+				}
+			}
 
-			// Generate a kube dynClient with user certs for auth.
-			_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), kubeCluster)
+			t.Run(fmt.Sprintf("%s scoped=%t", tt.name, scoped), func(t *testing.T) {
+				t.Parallel()
 
-			got := []string{}
-			got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("v1/namespaces")))...)
+				// Generate a kube dynClient with user certs for auth.
+				_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), kubeCluster, opts...)
 
-			require.Equal(t, tt.want, got)
-		})
+				got := []string{}
+				got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("v1/namespaces")))...)
+
+				require.Equal(t, want, got)
+			})
+		}
 	}
 }
 
@@ -3582,12 +3685,13 @@ func TestDenyClusterWideResources(t *testing.T) {
 	}
 }
 
-func TestDeleteNamespace(t *testing.T) {
+func TestDeleteNamespaceDenial(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
+	const scope = "/test"
+	_, testCtx := newTestKubeCRDMock(t, scope, tkm.WithTeleportRoleCRD)
 
-	newTestUser := newTestUserFactory(t, testCtx, "delete-ns", types.V8)
+	newTestUser := newTestUserFactoryWithScope(t, testCtx, "delete-ns", types.V8, scope)
 
 	fullAccess := []types.KubernetesResource{
 		{
@@ -3835,6 +3939,10 @@ func newTestKubeCRDMock(t *testing.T, scope string, opts ...tkm.Option) (*runtim
 }
 
 func newTestUserFactory(t *testing.T, testCtx *TestContext, prefix, roleVersion string) func(allow, deny []types.KubernetesResource) types.User {
+	return newTestUserFactoryWithScope(t, testCtx, prefix, roleVersion, "")
+}
+
+func newTestUserFactoryWithScope(t *testing.T, testCtx *TestContext, prefix, roleVersion, scope string) func(allow, deny []types.KubernetesResource) types.User {
 	count := 0
 	if prefix == "" {
 		prefix = "test"
@@ -3859,6 +3967,69 @@ func newTestUserFactory(t *testing.T, testCtx *TestContext, prefix, roleVersion 
 				},
 			},
 		)
+
+		// don't generate scoped roles if scope wasn't provided
+		if scope == "" {
+			return user
+		}
+
+		// don't generate scoped roles for legacy role kinds
+		if roleVersion != "" && roleVersion != types.V8 {
+			return user
+		}
+
+		// scoped roles are implicit deny and only provide allow rules
+		scopedResources := make([]*accessv1.KubeResource, len(allow))
+		for idx, res := range allow {
+			scopedResources[idx] = toScopedKubeResource(res)
+		}
+		scopedAccess := testCtx.TLSServer.Auth().ScopedAccess()
+		role, err := scopedAccess.CreateScopedRole(t.Context(), accessv1.CreateScopedRoleRequest_builder{
+			Role: accessv1.ScopedRole_builder{
+				Kind:    access.KindScopedRole,
+				Version: types.V1,
+				Metadata: headerv1.Metadata_builder{
+					Name: name,
+				}.Build(),
+				Scope: scope,
+				Spec: accessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{scope},
+					Kube: accessv1.ScopedRoleKube_builder{
+						Users:     roleKubeUsers,
+						Groups:    roleKubeGroups,
+						Labels:    wildcardLabel(),
+						Resources: scopedResources,
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+
+		assignment, err := scopedAccess.CreateScopedRoleAssignment(t.Context(), accessv1.CreateScopedRoleAssignmentRequest_builder{
+			Assignment: accessv1.ScopedRoleAssignment_builder{
+				Kind:    access.KindScopedRoleAssignment,
+				Version: types.V1,
+				SubKind: access.SubKindDynamic,
+				Scope:   scope,
+				Metadata: headerv1.Metadata_builder{
+					Name: uuid.New().String(),
+				}.Build(),
+				Spec: accessv1.ScopedRoleAssignmentSpec_builder{
+					User: name,
+					Assignments: []*accessv1.Assignment{
+						accessv1.Assignment_builder{
+							Role: scopes.QualifiedName{
+								Name:  role.GetRole().GetMetadata().GetName(),
+								Scope: role.GetRole().GetScope(),
+							}.String(),
+							Scope: scope,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		waitForSRACache(t, testCtx.TLSServer, assignment)
 		return user
 	}
 }
@@ -3920,8 +4091,9 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 	teleswagv1 := tkm.NewCRD("swag.teleport.dev", "v1", "teleswags", "TeleportSwag", "TeleportSwagList", true)
 	clusterswagv0 := tkm.NewCRD("resources.teleport.dev", "v0", "clusterswags", "ClusterSwag", "ClusterSwagList", false)
 
+	const scope = "/test"
 	kubeScheme, testCtx := newTestKubeCRDMock(t,
-		"",
+		scope,
 		tkm.WithTeleportRoleCRD,
 		tkm.WithCRD(telerolev8,
 			tkm.NewObject("default", "telerole-1"),
@@ -3940,20 +4112,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		),
 	)
 
-	newUser := func(name string, resources []types.KubernetesResource) types.User {
-		u, _ := testCtx.CreateUserAndRole(
-			testCtx.Context,
-			t,
-			name,
-			RoleSpec{
-				Name:          name,
-				KubeUsers:     roleKubeUsers,
-				KubeGroups:    roleKubeGroups,
-				SetupRoleFunc: func(r types.Role) { r.SetKubeResources(types.Allow, resources) },
-			},
-		)
-		return u
-	}
+	newUser := newTestUserFactoryWithScope(t, testCtx, "crd-rbac", types.V8, scope)
 
 	type args struct {
 		user types.User
@@ -3971,7 +4130,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "list crds on multiple versions",
 			args: args{
-				user: newUser("dev_access_two_versions", []types.KubernetesResource{
+				user: newUser([]types.KubernetesResource{
 					{
 						Kind:      tkm.NewTeleportRoleCRD().GetKindPlural(),
 						Name:      types.Wildcard,
@@ -3986,7 +4145,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  types.Wildcard,
 					},
-				}),
+				}, nil),
 				crds: []*tkm.CRD{tkm.NewTeleportRoleCRD(), telerolev8.Copy()},
 			},
 			want: want{
@@ -4005,7 +4164,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "access to multiple crds listing one without access",
 			args: args{
-				user: newUser("no_swag_access", []types.KubernetesResource{
+				user: newUser([]types.KubernetesResource{
 					{
 						Kind:      tkm.NewTeleportRoleCRD().GetKindPlural(),
 						Name:      types.Wildcard,
@@ -4020,7 +4179,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  types.Wildcard,
 					},
-				}),
+				}, nil),
 				crds: []*tkm.CRD{tkm.NewTeleportRoleCRD(), telerolev8.Copy(), teleswagv1.Copy()},
 			},
 			want: want{
@@ -4041,7 +4200,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "valid kind format",
 			args: args{
-				user: newUser("diff_fmt_ok", []types.KubernetesResource{
+				user: newUser([]types.KubernetesResource{
 					{
 						Kind:      "teleportroles",
 						Name:      types.Wildcard,
@@ -4056,7 +4215,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  "resources.teleport.dev",
 					},
-				}),
+				}, nil),
 				crds: []*tkm.CRD{telerolev8},
 			},
 			want: want{
@@ -4072,7 +4231,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "different invalid kind format",
 			args: args{
-				user: newUser("diff_fmt_ko", []types.KubernetesResource{
+				user: newUser([]types.KubernetesResource{
 					{
 						Kind:      "TeleportRole",
 						Name:      types.Wildcard,
@@ -4136,7 +4295,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  types.Wildcard,
 					},
-				}),
+				}, nil),
 				crds: []*tkm.CRD{telerolev8},
 			},
 			want: want{
@@ -4146,7 +4305,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "cluster wide crd",
 			args: args{
-				user: newUser("cluster_crd_ok", []types.KubernetesResource{
+				user: newUser([]types.KubernetesResource{
 					{
 						Kind:      clusterswagv0.GetKindPlural(),
 						Name:      "clusterswag-*",
@@ -4154,7 +4313,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  types.Wildcard,
 					},
-				}),
+				}, nil),
 				crds: []*tkm.CRD{clusterswagv0},
 			},
 			want: want{
@@ -4170,7 +4329,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "cluster wide crd no access",
 			args: args{
-				user: newUser("cluster_crd_ko", []types.KubernetesResource{
+				user: newUser([]types.KubernetesResource{
 					{
 						Kind:      telerolev8.GetKindPlural(),
 						Name:      types.Wildcard,
@@ -4178,7 +4337,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  types.Wildcard,
 					},
-				}),
+				}, nil),
 				crds: []*tkm.CRD{clusterswagv0},
 			},
 			want: want{
@@ -4188,7 +4347,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "cluster wide crd no acces wildcard",
 			args: args{
-				user: newUser("cluster_crd_ko", []types.KubernetesResource{
+				user: newUser([]types.KubernetesResource{
 					{
 						Kind:      telerolev8.GetKindPlural(),
 						Name:      types.Wildcard,
@@ -4196,7 +4355,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  types.Wildcard,
 					},
-				}),
+				}, nil),
 				crds: []*tkm.CRD{clusterswagv0},
 			},
 			want: want{
@@ -4206,45 +4365,51 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			// Generate a kube client with user certs for auth.
-			_, rest := testCtx.GenTestKubeClientTLSCert(t, tt.args.user.GetName(), kubeCluster)
-
-			client, err := controllerclient.New(rest, controllerclient.Options{
-				Scheme: kubeScheme,
-			})
-			require.NoError(t, err)
-
-			for i, list := range tt.args.crds {
-				list := list.Copy()
-				if err := client.List(context.Background(), list); tt.want.wantListErr[i] {
-					require.Error(t, err)
-					continue
-				} else {
-					require.NoError(t, err)
-				}
-				require.True(t, list.IsList())
-
-				// Iterate over the list of teleport roles and get the namespace and name
-				// of each role in the format <namespace>/<name>.
-				var retList []string
-				require.NoError(
-					t,
-					list.EachListItem(
-						func(itemI runtime.Object) error {
-							item, ok := itemI.(*unstructured.Unstructured)
-							if !ok {
-								return fmt.Errorf("invalid item type %T", itemI)
-							}
-							retList = append(retList, path.Join(item.GetNamespace(), item.GetName()))
-							return nil
-						},
-					),
-				)
-				require.ElementsMatch(t, tt.want.listTeleportRolesResult[i], retList)
+		for _, scoped := range []bool{false, true} {
+			var opts []GenTestKubeClientTLSCertOptions
+			if scoped {
+				opts = makeScopedOpts(t, testCtx, tt.args.user.GetName(), scope)
 			}
-		})
+			t.Run(fmt.Sprintf("%s scoped=%t", tt.name, scoped), func(t *testing.T) {
+				t.Parallel()
+				// Generate a kube client with user certs for auth.
+				_, rest := testCtx.GenTestKubeClientTLSCert(t, tt.args.user.GetName(), kubeCluster, opts...)
+
+				client, err := controllerclient.New(rest, controllerclient.Options{
+					Scheme: kubeScheme,
+				})
+				require.NoError(t, err)
+
+				for i, list := range tt.args.crds {
+					list := list.Copy()
+					if err := client.List(context.Background(), list); tt.want.wantListErr[i] {
+						require.Error(t, err)
+						continue
+					} else {
+						require.NoError(t, err)
+					}
+					require.True(t, list.IsList())
+
+					// Iterate over the list of teleport roles and get the namespace and name
+					// of each role in the format <namespace>/<name>.
+					var retList []string
+					require.NoError(
+						t,
+						list.EachListItem(
+							func(itemI runtime.Object) error {
+								item, ok := itemI.(*unstructured.Unstructured)
+								if !ok {
+									return fmt.Errorf("invalid item type %T", itemI)
+								}
+								retList = append(retList, path.Join(item.GetNamespace(), item.GetName()))
+								return nil
+							},
+						),
+					)
+					require.ElementsMatch(t, tt.want.listTeleportRolesResult[i], retList)
+				}
+			})
+		}
 	}
 }
 
@@ -4260,51 +4425,45 @@ func TestProxySubresourceRBAC(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { kubeMock.Close() })
 
+	const scope = "/test"
 	testCtx := SetupTestContext(
 		context.Background(),
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			Scope:    scope,
+			ScopesFeatures: scopes.Features{
+				Enabled: true,
+			},
 		},
 	)
 	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
 
-	roleSpec := func(name string, resources []types.KubernetesResource) RoleSpec {
-		return RoleSpec{
-			Name:       name,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-			SetupRoleFunc: func(r types.Role) {
-				r.SetKubeResources(types.Allow, resources)
-			},
-		}
-	}
+	newUser := newTestUserFactoryWithScope(t, testCtx, "subresource-rbac", types.V8, scope)
 
-	podGetUser, _ := testCtx.CreateUserAndRole(testCtx.Context, t, "pod-get",
-		roleSpec("pod-get-role", []types.KubernetesResource{{
-			Kind: "pods", Namespace: types.Wildcard, Name: types.Wildcard,
-			Verbs: []string{"get", "list"}, APIGroup: types.Wildcard,
-		}}))
-	serviceGetUser, _ := testCtx.CreateUserAndRole(testCtx.Context, t, "service-get",
-		roleSpec("service-get-role", []types.KubernetesResource{{
-			Kind: "services", Namespace: types.Wildcard, Name: types.Wildcard,
-			Verbs: []string{"get", "list"}, APIGroup: types.Wildcard,
-		}}))
-	nodeGetUser, _ := testCtx.CreateUserAndRole(testCtx.Context, t, "node-get",
-		roleSpec("node-get-role", []types.KubernetesResource{{
-			Kind: "nodes", Name: types.Wildcard,
-			Verbs: []string{"get", "list"}, APIGroup: types.Wildcard,
-		}}))
+	podGetUser := newUser([]types.KubernetesResource{{
+		Kind: "pods", Namespace: types.Wildcard, Name: types.Wildcard,
+		Verbs: []string{"get", "list"}, APIGroup: types.Wildcard,
+	}}, nil)
+
+	serviceGetUser := newUser([]types.KubernetesResource{{
+		Kind: "services", Namespace: types.Wildcard, Name: types.Wildcard,
+		Verbs: []string{"get", "list"}, APIGroup: types.Wildcard,
+	}}, nil)
+
+	nodeGetUser := newUser([]types.KubernetesResource{{
+		Kind: "nodes", Name: types.Wildcard,
+		Verbs: []string{"get", "list"}, APIGroup: types.Wildcard,
+	}}, nil)
 	// Negative control: configmaps allow rule, no pods/services/nodes match.
-	noMatchUser, _ := testCtx.CreateUserAndRole(testCtx.Context, t, "no-match",
-		roleSpec("no-match-role", []types.KubernetesResource{{
-			Kind: "configmaps", Namespace: types.Wildcard, Name: types.Wildcard,
-			Verbs: []string{"get"}, APIGroup: types.Wildcard,
-		}}))
+	noMatchUser := newUser([]types.KubernetesResource{{
+		Kind: "configmaps", Namespace: types.Wildcard, Name: types.Wildcard,
+		Verbs: []string{"get"}, APIGroup: types.Wildcard,
+	}}, nil)
 
-	sendGet := func(t *testing.T, user types.User, urlPath string) (int, string) {
+	sendGet := func(t *testing.T, user types.User, urlPath string, opts ...GenTestKubeClientTLSCertOptions) (int, string) {
 		t.Helper()
-		_, cfg := testCtx.GenTestKubeClientTLSCert(t, user.GetName(), kubeCluster)
+		_, cfg := testCtx.GenTestKubeClientTLSCert(t, user.GetName(), kubeCluster, opts...)
 		transport, err := rest.TransportFor(cfg)
 		require.NoError(t, err)
 		client := &http.Client{Transport: transport}
@@ -4364,14 +4523,43 @@ func TestProxySubresourceRBAC(t *testing.T) {
 			user:         noMatchUser,
 			urlPath:      "/api/v1/namespaces/default/pods/teleport/proxy/8080",
 			wantCode:     http.StatusForbidden,
-			bodyContains: `User \"no-match\" cannot proxy resource`,
+			bodyContains: fmt.Sprintf("User \\\"%s\\\" cannot proxy resource", noMatchUser.GetName()),
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			code, body := sendGet(t, tt.user, tt.urlPath)
-			require.Equal(t, tt.wantCode, code, "body: %s", body)
-			require.Contains(t, body, tt.bodyContains)
-		})
+		for _, scoped := range []bool{false, true} {
+			var opts []GenTestKubeClientTLSCertOptions
+			if scoped {
+				opts = makeScopedOpts(t, testCtx, tt.user.GetName(), scope)
+			}
+			t.Run(fmt.Sprintf("%s scoped=%t", tt.name, scoped), func(t *testing.T) {
+				code, body := sendGet(t, tt.user, tt.urlPath, opts...)
+				require.Equal(t, tt.wantCode, code, "body: %s", body)
+				require.Contains(t, body, tt.bodyContains)
+			})
+
+		}
 	}
+}
+
+func makeScopedOpts(t *testing.T, testCtx *TestContext, username, scope string) []GenTestKubeClientTLSCertOptions {
+	return []GenTestKubeClientTLSCertOptions{
+		func(i *tlsca.Identity) {
+			i.ScopePin = testCtx.GetScopePinForUser(t, username, scope)
+		},
+	}
+}
+
+func toScopedKubeResource(resource types.KubernetesResource) *accessv1.KubeResource {
+	return accessv1.KubeResource_builder{
+		Kind:      resource.Kind,
+		Name:      resource.Name,
+		Namespace: resource.Namespace,
+		Verbs:     resource.Verbs,
+		ApiGroup:  resource.APIGroup,
+	}.Build()
+}
+
+func scopedUsername(username string) string {
+	return "scoped-" + username
 }

--- a/lib/kube/proxy/resource_rbac_test.go
+++ b/lib/kube/proxy/resource_rbac_test.go
@@ -52,10 +52,14 @@ import (
 	restclientwatch "k8s.io/client-go/rest/watch"
 	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
+	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
 	tkm "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
@@ -68,6 +72,7 @@ func TestListPodRBAC(t *testing.T) {
 		usernameWithoutListVerbAccess = "no_list_user"
 		usernameWithTraits            = "trait_user"
 		testPodName                   = "test"
+		scope                         = "/test"
 	)
 	// kubeMock is a Kubernetes API mock for the session tests.
 	// Once a new session is created, this mock will write to
@@ -83,6 +88,11 @@ func TestListPodRBAC(t *testing.T) {
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			Scope:    scope,
+			ScopesFeatures: scopes.Features{
+				Enabled:         true,
+				AgentPinEnabled: true,
+			},
 		},
 	)
 	// close tests
@@ -112,6 +122,25 @@ func TestListPodRBAC(t *testing.T) {
 			},
 		},
 	)
+
+	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+usernameWithFullAccess,
+		scope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  roleKubeUsers,
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		})
+
 	// create a user with full access to kubernetes Pods.
 	// (kubernetes_user and kubernetes_groups specified)
 	userWithNamespaceAccess, _ := testCtx.CreateUserAndRole(
@@ -261,6 +290,11 @@ func TestListPodRBAC(t *testing.T) {
 		listPodErr       error
 		getTestPodResult error
 	}
+	scopedOpts := []GenTestKubeClientTLSCertOptions{
+		func(i *tlsca.Identity) {
+			i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
+		},
+	}
 	tests := []struct {
 		name string
 		args args
@@ -281,10 +315,42 @@ func TestListPodRBAC(t *testing.T) {
 			},
 		},
 		{
+			name: "list default namespace pods for scoped user with full access",
+			args: args{
+				user:      scopedUserWithFullAccess,
+				namespace: metav1.NamespaceDefault,
+				opts:      scopedOpts,
+			},
+			want: want{
+				listPodsResult: []string{
+					"default/nginx-1",
+					"default/nginx-2",
+					"default/test",
+				},
+			},
+		},
+		{
 			name: "list pods in every namespace for user with full access",
 			args: args{
 				user:      userWithFullAccess,
 				namespace: metav1.NamespaceAll,
+			},
+			want: want{
+				listPodsResult: []string{
+					"default/nginx-1",
+					"default/nginx-2",
+					"default/test",
+					"dev/nginx-1",
+					"dev/nginx-2",
+				},
+			},
+		},
+		{
+			name: "list pods in every namespace for scoped user with full access",
+			args: args{
+				user:      scopedUserWithFullAccess,
+				namespace: metav1.NamespaceAll,
+				opts:      scopedOpts,
 			},
 			want: want{
 				listPodsResult: []string{
@@ -1065,6 +1131,7 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 		usernameWithFullAccess      = "full_user"
 		usernameWithNamespaceAccess = "default_user"
 		usernameWithLimitedAccess   = "limited_user"
+		scope                       = "/test"
 	)
 	// kubeMock is a Kubernetes API mock for the session tests.
 	// Once a new session is created, this mock will write to
@@ -1080,6 +1147,11 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			Scope:    scope,
+			ScopesFeatures: scopes.Features{
+				Enabled:         true,
+				AgentPinEnabled: true,
+			},
 		},
 	)
 	// close tests
@@ -1109,6 +1181,25 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 			},
 		},
 	)
+
+	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+usernameWithFullAccess,
+		scope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  roleKubeUsers,
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		})
+
 	// create a user with full access to kubernetes Pods.
 	// (kubernetes_user and kubernetes_groups specified)
 	userWithNamespaceAccess, _ := testCtx.CreateUserAndRole(
@@ -1163,6 +1254,12 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 	type args struct {
 		user      types.User
 		namespace string
+		opts      []GenTestKubeClientTLSCertOptions
+	}
+	scopedOpts := []GenTestKubeClientTLSCertOptions{
+		func(i *tlsca.Identity) {
+			i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
+		},
 	}
 	tests := []struct {
 		name        string
@@ -1175,6 +1272,20 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 			args: args{
 				user:      userWithFullAccess,
 				namespace: metav1.NamespaceDefault,
+			},
+
+			deletedPods: []string{
+				"default/nginx-1",
+				"default/nginx-2",
+				"default/test",
+			},
+		},
+		{
+			name: "delete pods in default namespace for scoped user with full access",
+			args: args{
+				user:      scopedUserWithFullAccess,
+				namespace: metav1.NamespaceDefault,
+				opts:      scopedOpts,
 			},
 
 			deletedPods: []string{
@@ -1228,6 +1339,7 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 				t,
 				tt.args.user.GetName(),
 				kubeCluster,
+				tt.args.opts...,
 			)
 			err := client.CoreV1().Pods(tt.args.namespace).DeleteCollection(
 				testCtx.Context,
@@ -1257,6 +1369,7 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 		usernameWithFullAccess      = "full_user"
 		usernameWithNamespaceAccess = "default_user"
 		usernameWithLimitedAccess   = "limited_user"
+		scope                       = "/test"
 	)
 	// kubeMock is a Kubernetes API mock for the session tests.
 	// Once a new session is created, this mock will write to
@@ -1272,6 +1385,11 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			Scope:    scope,
+			ScopesFeatures: scopes.Features{
+				Enabled:         true,
+				AgentPinEnabled: true,
+			},
 		},
 	)
 	// close tests
@@ -1301,6 +1419,27 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 			},
 		},
 	)
+
+	// create a scoped user with full access to kubernetes Pods.
+	// (kubernetes_user and kubernetes_groups specified)
+	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+usernameWithFullAccess,
+		scope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  roleKubeUsers,
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		})
+
 	// create a user with full access to kubernetes Pods.
 	// (kubernetes_user and kubernetes_groups specified)
 	userWithNamespaceAccess, _ := testCtx.CreateUserAndRole(
@@ -1355,6 +1494,12 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 	type args struct {
 		user      types.User
 		namespace string
+		opts      []GenTestKubeClientTLSCertOptions
+	}
+	scopedOpts := []GenTestKubeClientTLSCertOptions{
+		func(i *tlsca.Identity) {
+			i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
+		},
 	}
 	tests := []struct {
 		name        string
@@ -1367,6 +1512,21 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 			args: args{
 				user:      userWithFullAccess,
 				namespace: metav1.NamespaceDefault,
+			},
+
+			deletedCRDs: []string{
+				"default/telerole-1",
+				"default/telerole-1",
+				"default/telerole-2",
+				"default/telerole-test",
+			},
+		},
+		{
+			name: "delete teleportroles in default namespace for scoped user with full access",
+			args: args{
+				user:      scopedUserWithFullAccess,
+				namespace: metav1.NamespaceDefault,
+				opts:      scopedOpts,
 			},
 
 			deletedCRDs: []string{
@@ -1420,6 +1580,7 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 				t,
 				tt.args.user.GetName(),
 				kubeCluster,
+				tt.args.opts...,
 			)
 			err := client.Resource(schema.GroupVersionResource{
 				Group:    "resources.teleport.dev",
@@ -1449,12 +1610,11 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 }
 
 func TestListClusterRoleRBAC(t *testing.T) {
-	t.Parallel()
-
 	const (
 		usernameWithFullAccess    = "full_user"
 		usernameWithLimitedAccess = "limited_user"
 		testClusterRoleName       = "cr-test"
+		scope                     = "/test"
 	)
 	// kubeMock is a Kubernetes API mock for the session tests.
 	// Once a new session is created, this mock will write to
@@ -1470,6 +1630,11 @@ func TestListClusterRoleRBAC(t *testing.T) {
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			Scope:    scope,
+			ScopesFeatures: scopes.Features{
+				Enabled:         true,
+				AgentPinEnabled: true,
+			},
 		},
 	)
 	// close tests
@@ -1498,6 +1663,26 @@ func TestListClusterRoleRBAC(t *testing.T) {
 			},
 		},
 	)
+
+	// create a scoped user with full access to kubernetes Pods.
+	// (kubernetes_user and kubernetes_groups specified)
+	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+usernameWithFullAccess,
+		scope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  roleKubeUsers,
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		})
 
 	// Create a moderator user with access to kubernetes
 	// (kubernetes_user and kubernetes_groups specified).
@@ -1528,6 +1713,11 @@ func TestListClusterRoleRBAC(t *testing.T) {
 		user types.User
 		opts []GenTestKubeClientTLSCertOptions
 	}
+	scopedOpts := []GenTestKubeClientTLSCertOptions{
+		func(i *tlsca.Identity) {
+			i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
+		},
+	}
 	type want struct {
 		listClusterRolesResult []string
 		listClusterErr         error
@@ -1542,6 +1732,20 @@ func TestListClusterRoleRBAC(t *testing.T) {
 			name: "list cluster roles for user with full access",
 			args: args{
 				user: userWithFullAccess,
+			},
+			want: want{
+				listClusterRolesResult: []string{
+					"cr-nginx-1",
+					"cr-nginx-2",
+					"cr-test",
+				},
+			},
+		},
+		{
+			name: "list cluster roles for scoped user with full access",
+			args: args{
+				user: scopedUserWithFullAccess,
+				opts: scopedOpts,
 			},
 			want: want{
 				listClusterRolesResult: []string{
@@ -1659,17 +1863,16 @@ func TestListClusterRoleRBAC(t *testing.T) {
 }
 
 func TestGenericCustomResourcesRBAC(t *testing.T) {
-	t.Parallel()
-
 	const (
 		usernameWithFullAccess     = "full_user"
 		usernameWithLimitedAccess  = "limited_user"
 		usernameWithSpecificAccess = "specific_user"
 		testTeleportRoleName       = "telerole-test"
 		testTeleportRoleNamespace  = "default"
+		scope                      = "/test"
 	)
 
-	kubeScheme, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	kubeScheme, testCtx := newTestKubeCRDMock(t, scope, tkm.WithTeleportRoleCRD)
 
 	// create a user with full access to all namespaces.
 	// (kubernetes_user and kubernetes_groups specified)
@@ -1696,6 +1899,26 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 			},
 		},
 	)
+
+	// create a scoped user with full access to all namespaces.
+	// (kubernetes_user and kubernetes_groups specified)
+	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+usernameWithFullAccess,
+		scope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  roleKubeUsers,
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		})
 
 	// create a user with limited access to kubernetes namespaces.
 	userWithLimitedAccess, _ := testCtx.CreateUserAndRoleVersion(
@@ -1758,6 +1981,11 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 		user types.User
 		opts []GenTestKubeClientTLSCertOptions
 	}
+	scopedOpts := []GenTestKubeClientTLSCertOptions{
+		func(i *tlsca.Identity) {
+			i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
+		},
+	}
 	type want struct {
 		listTeleportRolesResult []string
 		wantListErr             bool
@@ -1773,6 +2001,23 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 			name: "list teleport roles for user with full access",
 			args: args{
 				user: userWithFullAccess,
+			},
+			want: want{
+				listTeleportRolesResult: []string{
+					"default/telerole-1",
+					"default/telerole-1",
+					"default/telerole-2",
+					"default/telerole-test",
+					"dev/telerole-1",
+					"dev/telerole-2",
+				},
+			},
+		},
+		{
+			name: "list teleport roles for scoped user with full access",
+			args: args{
+				user: scopedUserWithFullAccess,
+				opts: scopedOpts,
 			},
 			want: want{
 				listTeleportRolesResult: []string{
@@ -1990,7 +2235,7 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 func TestV8JailedNamespaceListRBAC(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	newTestUser := newTestUserFactory(t, testCtx, "", types.V8)
 
@@ -2313,7 +2558,7 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 func TestV7JailedNamespaceListRBAC(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	newTestUser := newTestUserFactory(t, testCtx, "", types.V7)
 
@@ -2538,7 +2783,7 @@ func TestV7JailedNamespaceListRBAC(t *testing.T) {
 func TestV7V8Match(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	// Create a factory to generate users in various role versions.
 	newV7TestUser := newTestUserFactory(t, testCtx, "v7v8", types.V7)
@@ -2898,7 +3143,7 @@ func TestV7V8Match(t *testing.T) {
 func TestNamespaceListRBAC(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	newTestUser := newTestUserFactory(t, testCtx, "nslist", types.V8)
 
@@ -3181,7 +3426,7 @@ func TestNamespaceListRBAC(t *testing.T) {
 func TestDenyClusterWideResources(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	newTestUser := newTestUserFactory(t, testCtx, "deny-cw", types.V8)
 
@@ -3335,7 +3580,7 @@ func TestDenyClusterWideResources(t *testing.T) {
 func TestDeleteNamespace(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	newTestUser := newTestUserFactory(t, testCtx, "delete-ns", types.V8)
 
@@ -3444,7 +3689,7 @@ func TestDeleteNamespace(t *testing.T) {
 func TestFullNamespaceNoDeleteRBAC(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	newTestUser := newTestUserFactory(t, testCtx, "fullnsnodelete", types.V8)
 
@@ -3550,7 +3795,7 @@ func TestFullNamespaceNoDeleteRBAC(t *testing.T) {
 	}
 }
 
-func newTestKubeCRDMock(t *testing.T, opts ...tkm.Option) (*runtime.Scheme, *TestContext) {
+func newTestKubeCRDMock(t *testing.T, scope string, opts ...tkm.Option) (*runtime.Scheme, *TestContext) {
 	t.Helper()
 
 	// kubeMock is a Kubernetes API mock for the session tests.
@@ -3571,6 +3816,11 @@ func newTestKubeCRDMock(t *testing.T, opts ...tkm.Option) (*runtime.Scheme, *Tes
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			Scope:    scope,
+			ScopesFeatures: scopes.Features{
+				Enabled:         true,
+				AgentPinEnabled: true,
+			},
 		},
 	)
 	// Close tests.
@@ -3584,6 +3834,7 @@ func newTestUserFactory(t *testing.T, testCtx *TestContext, prefix, roleVersion 
 	if prefix == "" {
 		prefix = "test"
 	}
+
 	return func(allow, deny []types.KubernetesResource) types.User {
 		t.Helper()
 		count++
@@ -3665,6 +3916,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 	clusterswagv0 := tkm.NewCRD("resources.teleport.dev", "v0", "clusterswags", "ClusterSwag", "ClusterSwagList", false)
 
 	kubeScheme, testCtx := newTestKubeCRDMock(t,
+		"",
 		tkm.WithTeleportRoleCRD,
 		tkm.WithCRD(telerolev8,
 			tkm.NewObject("default", "telerole-1"),

--- a/lib/kube/proxy/resource_rbac_test.go
+++ b/lib/kube/proxy/resource_rbac_test.go
@@ -123,7 +123,7 @@ func TestListPodRBAC(t *testing.T) {
 		},
 	)
 
-	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+	scopedUserWithFullAccess, scopedRoleWithFullAccess := testCtx.CreateUserAndScopedRole(
 		t,
 		"scoped-"+usernameWithFullAccess,
 		scope,
@@ -140,6 +140,7 @@ func TestListPodRBAC(t *testing.T) {
 				},
 			},
 		})
+	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
 
 	// create a user with full access to kubernetes Pods.
 	// (kubernetes_user and kubernetes_groups specified)
@@ -1182,7 +1183,7 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 		},
 	)
 
-	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+	scopedUserWithFullAccess, scopedRoleWithFullAccess := testCtx.CreateUserAndScopedRole(
 		t,
 		"scoped-"+usernameWithFullAccess,
 		scope,
@@ -1199,6 +1200,7 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 				},
 			},
 		})
+	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
 
 	// create a user with full access to kubernetes Pods.
 	// (kubernetes_user and kubernetes_groups specified)
@@ -1422,7 +1424,7 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 
 	// create a scoped user with full access to kubernetes Pods.
 	// (kubernetes_user and kubernetes_groups specified)
-	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+	scopedUserWithFullAccess, scopedRoleWithFullAccess := testCtx.CreateUserAndScopedRole(
 		t,
 		"scoped-"+usernameWithFullAccess,
 		scope,
@@ -1439,6 +1441,7 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 				},
 			},
 		})
+	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
 
 	// create a user with full access to kubernetes Pods.
 	// (kubernetes_user and kubernetes_groups specified)
@@ -1666,7 +1669,7 @@ func TestListClusterRoleRBAC(t *testing.T) {
 
 	// create a scoped user with full access to kubernetes Pods.
 	// (kubernetes_user and kubernetes_groups specified)
-	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+	scopedUserWithFullAccess, scopedRoleWithFullAccess := testCtx.CreateUserAndScopedRole(
 		t,
 		"scoped-"+usernameWithFullAccess,
 		scope,
@@ -1683,6 +1686,7 @@ func TestListClusterRoleRBAC(t *testing.T) {
 				},
 			},
 		})
+	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
 
 	// Create a moderator user with access to kubernetes
 	// (kubernetes_user and kubernetes_groups specified).
@@ -1902,7 +1906,7 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 
 	// create a scoped user with full access to all namespaces.
 	// (kubernetes_user and kubernetes_groups specified)
-	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+	scopedUserWithFullAccess, scopedRoleWithFullAccess := testCtx.CreateUserAndScopedRole(
 		t,
 		"scoped-"+usernameWithFullAccess,
 		scope,
@@ -1919,6 +1923,7 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 				},
 			},
 		})
+	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
 
 	// create a user with limited access to kubernetes namespaces.
 	userWithLimitedAccess, _ := testCtx.CreateUserAndRoleVersion(

--- a/lib/kube/proxy/self_subject_reviews_test.go
+++ b/lib/kube/proxy/self_subject_reviews_test.go
@@ -437,7 +437,7 @@ func TestSelfSubjectAccessReviewsRBAC(t *testing.T) {
 func TestSelfSubjectAccessReviewsAllowed(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, testingkubemock.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", testingkubemock.WithTeleportRoleCRD)
 
 	newTestUserV7 := newTestUserFactory(t, testCtx, "", types.V7)
 	newTestUserV8 := newTestUserFactory(t, testCtx, "", types.V8)

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -47,6 +47,9 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/keys"
@@ -69,6 +72,7 @@ import (
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	sessPkg "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -113,6 +117,7 @@ type TestConfig struct {
 	CreateAuditStreamErr error
 	WrapAuthClient       func(authclient.ClientI) authclient.ClientI
 	ScopesFeatures       scopes.Features
+	Scope                string
 }
 
 // SetupTestContext creates a kube service with clusters configured.
@@ -179,7 +184,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	require.NoError(t, err)
 
 	// Auth client for Kube service.
-	testCtx.AuthClient, err = testCtx.TLSServer.NewClient(authtest.TestServerID(types.RoleKube, testCtx.HostID))
+	testCtx.AuthClient, err = testCtx.TLSServer.NewClient(authtest.TestScopedServerID(types.RoleKube, testCtx.HostID, cfg.Scope))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, testCtx.AuthClient.Close()) })
 
@@ -208,7 +213,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	require.NoError(t, err)
 
 	// TLS config for kube proxy and Kube service.
-	serverIdentity, err := authtest.NewServerIdentity(authServer.AuthServer, testCtx.HostID, types.RoleKube)
+	serverIdentity, err := authtest.NewScopedServerIdentity(authServer.AuthServer, testCtx.HostID, cfg.Scope, types.RoleKube)
 	require.NoError(t, err)
 	kubeServiceTLSConfig, err := serverIdentity.TLSConfig(nil)
 	require.NoError(t, err)
@@ -250,12 +255,13 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 
 	inventoryHandle, err := inventory.NewDownstreamHandle(client.InventoryControlStream,
 		func(_ context.Context) (*proto.UpstreamInventoryHello, error) {
-			return &proto.UpstreamInventoryHello{
+			return proto.UpstreamInventoryHello_builder{
 				ServerID: testCtx.HostID,
 				Version:  teleport.Version,
 				Services: types.SystemRoles{types.RoleKube}.StringSlice(),
 				Hostname: "test",
-			}, nil
+				Scope:    cfg.Scope,
+			}.Build(), nil
 		})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, inventoryHandle.Close()) })
@@ -314,6 +320,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 			},
 			Clock:           clockwork.NewRealClock(),
 			ClusterFeatures: features,
+			Scope:           cfg.Scope,
 		},
 		DynamicLabels: nil,
 		TLS:           kubeServiceTLSConfig.Clone(),
@@ -536,6 +543,54 @@ func (c *TestContext) CreateUserAndRoleVersion(ctx context.Context, t *testing.T
 	return c.CreateUserWithTraitsAndRoleVersion(ctx, t, username, nil, roleVersion, roleSpec)
 }
 
+// CreateUserScopedRole creates a Teleport user and a scoped role assigned
+// to them.
+func (c *TestContext) CreateUserAndScopedRole(t *testing.T, username, scope string, roleSpec *accessv1.ScopedRoleSpec) (types.User, *accessv1.CreateScopedRoleAssignmentResponse) {
+	user, err := authtest.CreateUser(t.Context(), c.TLSServer.Auth(), username)
+	require.NoError(t, err)
+
+	scopedAccess := c.TLSServer.Auth().ScopedAccess()
+	role, err := scopedAccess.CreateScopedRole(t.Context(), &accessv1.CreateScopedRoleRequest{
+		Role: &accessv1.ScopedRole{
+			Kind:    access.KindScopedRole,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: username,
+			},
+			Scope: scope,
+			Spec:  roleSpec,
+		},
+	})
+	require.NoError(t, err)
+
+	assignment, err := scopedAccess.CreateScopedRoleAssignment(t.Context(), &accessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: &accessv1.ScopedRoleAssignment{
+			Kind:    access.KindScopedRoleAssignment,
+			Version: types.V1,
+			SubKind: access.SubKindDynamic,
+			Scope:   scope,
+			Metadata: &headerv1.Metadata{
+				Name: uuid.New().String(),
+			},
+			Spec: &accessv1.ScopedRoleAssignmentSpec{
+				User: username,
+				Assignments: []*accessv1.Assignment{
+					{
+						Role: scopes.QualifiedName{
+							Name:  role.GetRole().GetMetadata().GetName(),
+							Scope: role.GetRole().GetScope(),
+						}.String(),
+						Scope: scope,
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	return user, assignment
+}
+
 func newKubeConfigFile(t *testing.T, clusters ...KubeClusterConfig) string {
 	tmpDir := t.TempDir()
 
@@ -747,4 +802,15 @@ func (f *fakeCluster) DialTCP(p reversetunnelclient.DialParams) (conn net.Conn, 
 		panic(err)
 	}
 	return conn, nil
+}
+
+func (c *TestContext) GetScopePinForUser(t *testing.T, username, scope string) *scopesv1.Pin {
+	pin := &scopesv1.Pin{
+		Kind:  scopesv1.PinKind_PIN_KIND_USER,
+		Scope: scope,
+	}
+	err := c.AuthServer.ScopedAccessCache.PopulatePinnedAssignmentsForUser(t.Context(), username, pin)
+	require.NoError(t, err)
+
+	return pin
 }

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -18,6 +18,7 @@ package access
 
 import (
 	"iter"
+	"slices"
 	"strings"
 	"time"
 
@@ -59,6 +60,8 @@ const (
 	// unlike MaxRolesPerAssignment, this is a fairly arbitrary limit and there isn't a strong reason to keep it low other than
 	// to avoid excess resource size and to keep our options open for the future.
 	maxAssignableScopes = 16
+	invalidChars        = "{}^$*"
+	invalidLabelChars   = "{}^$"
 )
 
 // RoleIsAssignableToScopeOfEffect checks if the given role is assignable to the given scope of effect. For example,
@@ -201,14 +204,18 @@ func StrongValidateRole(role *scopedaccessv1.ScopedRole) error {
 		}
 	}
 
-	const invalidChars = "{}^$*"
-	const invalidLabelChars = "{}^$"
 	// verify that ssh logins are well-formed
 	if login := validateDoesNotContain(role.GetSpec().GetSsh().GetLogins(), invalidChars); login != "" {
 		// we currently don't support any form of wildcard/regex/substitution in scoped role
 		// logins. we likely will support substitution in the future, but its best to disallow
 		// it until that has landed.
 		return trace.BadParameter("scoped role %q has invalid login %q", role.GetMetadata().GetName(), login)
+	}
+
+	// verify that at least one label entry is defined when SSH block is given - scoped roles are deny by default, so a wildcard entry for
+	// labels must be explicitly provided if the role is meant to grant full access
+	if role.GetSpec().GetSsh() != nil && len(role.GetSpec().GetSsh().GetLabels()) == 0 {
+		return trace.BadParameter("scoped role %q has no spec.ssh.labels defined, please add at least one entry", role.GetMetadata().GetName())
 	}
 
 	// verify that ssh node labels are well-formed
@@ -288,41 +295,9 @@ func StrongValidateRole(role *scopedaccessv1.ScopedRole) error {
 		}
 	}
 
-	// verify that lock.Mode is a recognized value for Kube
-	if lock := role.GetSpec().GetKube().GetLock(); lock != nil {
-		if err := validateLock(lock); err != nil {
-			return trace.BadParameter("scoped role %q has invalid kube.lock.mode %q", role.GetMetadata().GetName(), lock.GetMode())
-		}
-	}
-
-	// verify that kube labels are well-formed
-	for _, label := range role.GetSpec().GetKube().GetLabels() {
-		// we currently don't support any form of wildcard/regex/substitution in scoped role
-		// node labels. we likely will support such things in the future, but its best to disallow
-		// them until that has landed.
-
-		if strings.ContainsAny(label.GetName(), invalidLabelChars) {
-			return trace.BadParameter("scoped role %q has invalid kube label name %q", role.GetMetadata().GetName(), label.GetName())
-		}
-		if value := validateDoesNotContain(label.GetValues(), invalidLabelChars); value != "" {
-			return trace.BadParameter("scoped role %q has invalid kube label value %q for label %q", role.GetMetadata().GetName(), value, label.GetName())
-		}
-	}
-
-	// verify that kube groups are well-formed
-	if group := validateDoesNotContain(role.GetSpec().GetKube().GetGroups(), invalidChars); group != "" {
-		// we currently don't support any form of wildcard/regex/substitution in scoped role
-		// kube gruops. we likely will support substitution in the future, but its best to disallow
-		// it until that has landed.
-		return trace.BadParameter("scoped role %q has invalid kube group %q", role.GetMetadata().GetName(), group)
-	}
-
-	// verify that kube users are well-formed
-	if user := validateDoesNotContain(role.GetSpec().GetKube().GetUsers(), invalidChars); user != "" {
-		// we currently don't support any form of wildcard/regex/substitution in scoped role
-		// kube users. we likely will support substitution in the future, but its best to disallow
-		// it until that has landed.
-		return trace.BadParameter("scoped role %q has invalid kube user %q", role.GetMetadata().GetName(), user)
+	// verify that kube block is well-formed
+	if err := validateKubeBlock(role.GetSpec().GetKube()); err != nil {
+		return trace.BadParameter("scoped role %q has %s", role.GetMetadata().GetName(), err)
 	}
 
 	// verify that scoped role converts to a valid unscoped role
@@ -574,6 +549,175 @@ func commonValidateAssignment(assignment *scopedaccessv1.ScopedRoleAssignment) e
 
 	if assignment.GetSpec().GetUser() == "" && assignment.GetSpec().GetBot() == "" {
 		return trace.BadParameter("scoped role assignment %q is missing spec.user or spec.bot", assignment.GetMetadata().GetName())
+	}
+
+	return nil
+}
+
+// getNamespacedResourceAPIGroup maps the list of known Kubernetes resource kinds
+// that are namespaced to their respective API group. It is copied from the kubernetesNamespacesResourceKinds
+// map found in api/types/constants.go to prevent exporting it from the public API. Any changes should also be
+// made in the original.
+//
+// Generated from `kubectl api-resources --namespaced=true -o name --sort-by=name` (kind k8s v1.32.2).
+// The format is "<plural>.<apigroup>".
+//
+// Only used to validate the api_group field.
+// If we have a match, we know we need a namespaced value, if we don't
+// have a match, we don't know we don't. Best effort basis.
+//
+// Key: resource kind, value: api group.
+func getNamespacedResourceAPIGroup(resource string) (string, bool) {
+	switch resource {
+	case "bindings", "services", "serviceaccounts", "secrets", "resourcequotas",
+		"replicationcontrollers", "podtemplates", "pods", "limitranges", "endpoints",
+		"configmaps", "persistentvolumeclaims":
+		return "", true
+	case "controllerrevisions":
+		return "apps", true
+	case "cronjobs":
+		return "batch", true
+	case "csistoragecapacities":
+		return "storage.k8s.io", true
+	case "daemonsets":
+		return "apps", true
+	case "deployments":
+		return "apps", true
+	case "endpointslices":
+		return "discovery.k8s.io", true
+	case "events":
+		return "events.k8s.io", true
+	case "horizontalpodautoscalers":
+		return "autoscaling", true
+	case "ingresses":
+		return "networking.k8s.io", true
+	case "jobs":
+		return "batch", true
+	case "leases":
+		return "coordination.k8s.io", true
+	case "localsubjectaccessreviews":
+		return "authorization.k8s.io", true
+	case "networkpolicies":
+		return "networking.k8s.io", true
+	case "poddisruptionbudgets":
+		return "policy", true
+	case "replicasets":
+		return "apps", true
+	case "rolebindings":
+		return "rbac.authorization.k8s.io", true
+	case "roles":
+		return "rbac.authorization.k8s.io", true
+	case "statefulsets":
+		return "apps", true
+	default:
+		return "", false
+	}
+}
+
+// validateKubeResources validates the following rules for each spec.kube.resources entry:
+// - Kind doesn't map to an API group
+// - Name is not empty
+// - Namespace is not empty
+// - ApiGroup not empty
+// This validator is largely copied from the role v8 case of validateKubeResources found in api/types/role.go.
+// It is ported to support scoped roles and the original should considered as well when making any changes.
+func validateKubeResource(resource *scopedaccessv1.KubeResource) error {
+	// NOTE(eriktate): errors must start with the field name producing the error so the final reported error
+	// renders correctly.
+	// (e.g. `scoped role "/my/scope::my-role" has invalid kube resource: spec.kube.resources[0].kind is required`)
+	for _, verb := range resource.GetVerbs() {
+		if !slices.Contains(types.KubernetesVerbs, verb) && verb != types.Wildcard {
+			return trace.BadParameter("verbs contain invalid or unsupported %q; Supported: %v", verb, types.KubernetesVerbs)
+		}
+		if verb == types.Wildcard && len(resource.GetVerbs()) > 1 {
+			return trace.BadParameter("verbs contain %q which cannot be used with other verbs", verb)
+		}
+	}
+
+	if resource.GetKind() == "" {
+		return trace.BadParameter("kind is required")
+	}
+	// If we have a kind in singular form for a known resource kind, check the api group.
+	if slices.Contains(types.KubernetesResourcesKinds, resource.GetKind()) {
+		// If the api group is a wildcard or matches a legacy group, then it is most definitely a mistake. Reject the role.
+		if resource.GetApiGroup() == types.Wildcard || resource.GetApiGroup() == types.KubernetesResourcesV7KindGroups[resource.GetKind()] {
+			return trace.BadParameter("kind %q is invalid. Please use plural name", resource.GetKind())
+		}
+	}
+	// Only allow empty string for known core resources.
+	if resource.GetApiGroup() == "" {
+		if _, ok := types.KubernetesCoreResourceKinds[resource.GetKind()]; !ok {
+			return trace.BadParameter("api_group is required for resource %q", resource.GetKind())
+		}
+	}
+	// Best effort attempt to validate if the namespace field is needed.
+	if resource.GetNamespace() == "" {
+		if apiGroup, ok := getNamespacedResourceAPIGroup(resource.GetKind()); ok && apiGroup == resource.GetApiGroup() {
+			return trace.BadParameter("namespace must be included for kind %q", resource.GetKind())
+		}
+	}
+
+	return nil
+}
+
+// validateKubeBlock validates the given kube configuration in a scoped role spec.
+func validateKubeBlock(kube *scopedaccessv1.ScopedRoleKube) error {
+	// the kube block is not required for all scoped roles, so nil is
+	// not an error
+	if kube == nil {
+		return nil
+	}
+
+	// verify that lock.Mode is a recognized value for Kube
+	if lock := kube.GetLock(); lock != nil {
+		if err := validateLock(lock); err != nil {
+			return trace.BadParameter("invalid kube.lock.mode %q", lock.GetMode())
+		}
+	}
+
+	// verify that at least one label entry is defined - scoped roles are deny by default, so a wildcard entry for
+	// labels must be explicitly provided if the role is meant to grant full access
+	if len(kube.GetLabels()) == 0 {
+		return trace.BadParameter("no spec.kube.labels defined, please add at least one entry")
+	}
+
+	// verify that kube labels are well-formed
+	for _, label := range kube.GetLabels() {
+		if strings.ContainsAny(label.GetName(), invalidLabelChars) {
+			return trace.BadParameter("invalid kube label name %q", label.GetName())
+		}
+		if value := validateDoesNotContain(label.GetValues(), invalidLabelChars); value != "" {
+			return trace.BadParameter("invalid kube label value %q for label %q", value, label.GetName())
+		}
+	}
+
+	// verify that at least one resource is defined - scoped roles are deny by default, so a wildcard entry for
+	// resources must be explicitly provided when resource-based RBAC is not desired
+	if len(kube.GetResources()) == 0 {
+		return trace.BadParameter("no spec.kube.resources defined, if resource-based RBAC is not required please configure explicit wildcard access")
+	}
+
+	// verify that kube resources are well-formed
+	for idx, resource := range kube.GetResources() {
+		if err := validateKubeResource(resource); err != nil {
+			return trace.BadParameter("invalid kube resource: spec.kube.resources[%d].%s", idx, err)
+		}
+	}
+
+	// verify that kube groups are well-formed
+	if group := validateDoesNotContain(kube.GetGroups(), invalidChars); group != "" {
+		// we currently don't support any form of wildcard/regex/substitution in scoped role
+		// kube groups. we likely will support substitution in the future, but its best to disallow
+		// it until that has landed.
+		return trace.BadParameter("invalid kube group %q", group)
+	}
+
+	// verify that kube users are well-formed
+	if user := validateDoesNotContain(kube.GetUsers(), invalidChars); user != "" {
+		// we currently don't support any form of wildcard/regex/substitution in scoped role
+		// kube users. we likely will support substitution in the future, but its best to disallow
+		// it until that has landed.
+		return trace.BadParameter("invalid kube user %q", user)
 	}
 
 	return nil

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -37,6 +37,21 @@ import (
 func TestValidateRole(t *testing.T) {
 	t.Parallel()
 
+	wildcardKubeResources := []*scopedaccessv1.KubeResource{
+		scopedaccessv1.KubeResource_builder{
+			Kind:      "*",
+			Namespace: "*",
+			Name:      "*",
+			ApiGroup:  "*",
+			Verbs:     []string{"*"},
+		}.Build(),
+	}
+	wildcardLabels := []*labelv1.Label{
+		labelv1.Label_builder{
+			Name:   "*",
+			Values: []string{"*"},
+		}.Build(),
+	}
 	tts := []struct {
 		name     string
 		role     *scopedaccessv1.ScopedRole
@@ -287,9 +302,10 @@ func TestValidateRole(t *testing.T) {
 				Scope: "/",
 				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
-					Ssh: &scopedaccessv1.ScopedRoleSSH{
+					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Labels:            wildcardLabels,
 						ClientIdleTimeout: "not-a-duration",
-					},
+					}.Build(),
 				},
 				Version: types.V1,
 			},
@@ -325,11 +341,12 @@ func TestValidateRole(t *testing.T) {
 				Scope: "/",
 				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
-					Ssh: &scopedaccessv1.ScopedRoleSSH{
-						HostUserCreation: &scopedaccessv1.CreateHostUser{
+					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Labels: wildcardLabels,
+						HostUserCreation: scopedaccessv1.CreateHostUser_builder{
 							Mode: "invalid-mode",
-						},
-					},
+						}.Build(),
+					}.Build(),
 				},
 				Version: types.V1,
 			},
@@ -346,11 +363,12 @@ func TestValidateRole(t *testing.T) {
 				Scope: "/",
 				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
-					Ssh: &scopedaccessv1.ScopedRoleSSH{
-						HostUserCreation: &scopedaccessv1.CreateHostUser{
+					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Labels: wildcardLabels,
+						HostUserCreation: scopedaccessv1.CreateHostUser_builder{
 							Mode: "keep",
-						},
-					},
+						}.Build(),
+					}.Build(),
 				},
 				Version: types.V1,
 			},
@@ -367,9 +385,10 @@ func TestValidateRole(t *testing.T) {
 				Scope: "/",
 				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
-					Ssh: &scopedaccessv1.ScopedRoleSSH{
+					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Labels:      wildcardLabels,
 						MaxSessions: proto.Int64(-1),
-					},
+					}.Build(),
 				},
 				Version: types.V1,
 			},
@@ -386,9 +405,10 @@ func TestValidateRole(t *testing.T) {
 				Scope: "/",
 				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
-					Ssh: &scopedaccessv1.ScopedRoleSSH{
+					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Labels:      wildcardLabels,
 						MaxSessions: proto.Int64(1),
-					},
+					}.Build(),
 				},
 				Version: types.V1,
 			},
@@ -459,11 +479,12 @@ func TestValidateRole(t *testing.T) {
 				Scope:    "/",
 				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
-					Ssh: &scopedaccessv1.ScopedRoleSSH{
-						SessionRecording: &scopedaccessv1.SessionRecording{
+					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Labels: wildcardLabels,
+						SessionRecording: scopedaccessv1.SessionRecording_builder{
 							Mode: "blah",
-						},
-					},
+						}.Build(),
+					}.Build(),
 				},
 			},
 		},
@@ -477,14 +498,32 @@ func TestValidateRole(t *testing.T) {
 				Scope: "/",
 				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
-					Ssh: &scopedaccessv1.ScopedRoleSSH{
-						Lock: &scopedaccessv1.Lock{
+					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Labels: wildcardLabels,
+						Lock: scopedaccessv1.Lock_builder{
 							Mode: "invalid",
-						},
-					},
+						}.Build(),
+					}.Build(),
 				},
 				Version: types.V1,
 			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "ssh without labels",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Ssh:              scopedaccessv1.ScopedRoleSSH_builder{}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
 			strongOk: false,
 			weakOk:   true,
 		},
@@ -496,11 +535,12 @@ func TestValidateRole(t *testing.T) {
 				Scope:    "/",
 				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
-					Ssh: &scopedaccessv1.ScopedRoleSSH{
-						SessionRecording: &scopedaccessv1.SessionRecording{
+					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Labels: wildcardLabels,
+						SessionRecording: scopedaccessv1.SessionRecording_builder{
 							Mode: string(constants.SessionRecordingModeStrict),
-						},
-					},
+						}.Build(),
+					}.Build(),
 				},
 			},
 		},
@@ -514,11 +554,12 @@ func TestValidateRole(t *testing.T) {
 				Scope: "/",
 				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
-					Ssh: &scopedaccessv1.ScopedRoleSSH{
-						Lock: &scopedaccessv1.Lock{
+					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Labels: wildcardLabels,
+						Lock: scopedaccessv1.Lock_builder{
 							Mode: string(constants.LockingModeStrict),
-						},
-					},
+						}.Build(),
+					}.Build(),
 				},
 				Version: types.V1,
 			},
@@ -536,11 +577,12 @@ func TestValidateRole(t *testing.T) {
 				Scope: "/",
 				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
-					Ssh: &scopedaccessv1.ScopedRoleSSH{
-						Lock: &scopedaccessv1.Lock{
+					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Labels: wildcardLabels,
+						Lock: scopedaccessv1.Lock_builder{
 							Mode: "",
-						},
-					},
+						}.Build(),
+					}.Build(),
 				},
 				Version: types.V1,
 			},
@@ -557,11 +599,13 @@ func TestValidateRole(t *testing.T) {
 				Scope: "/",
 				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
-					Kube: &scopedaccessv1.ScopedRoleKube{
-						Lock: &scopedaccessv1.Lock{
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Labels:    wildcardLabels,
+						Resources: wildcardKubeResources,
+						Lock: scopedaccessv1.Lock_builder{
 							Mode: "invalid",
-						},
-					},
+						}.Build(),
+					}.Build(),
 				},
 				Version: types.V1,
 			},
@@ -578,11 +622,13 @@ func TestValidateRole(t *testing.T) {
 				Scope: "/",
 				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
-					Kube: &scopedaccessv1.ScopedRoleKube{
-						Lock: &scopedaccessv1.Lock{
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Labels:    wildcardLabels,
+						Resources: wildcardKubeResources,
+						Lock: scopedaccessv1.Lock_builder{
 							Mode: string(constants.LockingModeStrict),
-						},
-					},
+						}.Build(),
+					}.Build(),
 				},
 				Version: types.V1,
 			},
@@ -599,11 +645,13 @@ func TestValidateRole(t *testing.T) {
 				Scope: "/",
 				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
-					Kube: &scopedaccessv1.ScopedRoleKube{
-						Lock: &scopedaccessv1.Lock{
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Labels:    wildcardLabels,
+						Resources: wildcardKubeResources,
+						Lock: scopedaccessv1.Lock_builder{
 							Mode: "",
-						},
-					},
+						}.Build(),
+					}.Build(),
 				},
 				Version: types.V1,
 			},
@@ -671,6 +719,288 @@ func TestValidateRole(t *testing.T) {
 				Version: types.V1,
 			},
 			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name: "kube without labels",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Resources: wildcardKubeResources,
+						Groups:    []string{"cluster-admin"},
+						Users:     []string{"cluster-user"},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube without resources",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Labels: wildcardLabels,
+						Groups: []string{"cluster-admin"},
+						Users:  []string{"cluster-user"},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube with resource missing kind",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Resources: []*scopedaccessv1.KubeResource{
+							scopedaccessv1.KubeResource_builder{
+								Kind:      "",
+								Name:      "*",
+								Namespace: "*",
+								ApiGroup:  "*",
+								Verbs:     []string{"*"},
+							}.Build(),
+						},
+						Labels: wildcardLabels,
+						Groups: []string{"cluster-admin"},
+						Users:  []string{"cluster-user"},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube with resource setting wildcard api group for singular resource kind",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Resources: []*scopedaccessv1.KubeResource{
+							scopedaccessv1.KubeResource_builder{
+								Kind:      "pod",
+								Name:      "*",
+								Namespace: "*",
+								ApiGroup:  "*",
+								Verbs:     []string{"*"},
+							}.Build(),
+						},
+						Labels: wildcardLabels,
+						Groups: []string{"cluster-admin"},
+						Users:  []string{"cluster-user"},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube with resource setting legacy api group for singular resource kind",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Resources: []*scopedaccessv1.KubeResource{
+							scopedaccessv1.KubeResource_builder{
+								Kind:      types.KindKubeDeployment,
+								Name:      "*",
+								Namespace: "*",
+								ApiGroup:  "apps",
+								Verbs:     []string{"*"},
+							}.Build(),
+						},
+						Labels: wildcardLabels,
+						Groups: []string{"cluster-admin"},
+						Users:  []string{"cluster-user"},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube with resource setting empty api group for non-core resource",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Resources: []*scopedaccessv1.KubeResource{
+							scopedaccessv1.KubeResource_builder{
+								Kind:      "apps",
+								Name:      "*",
+								Namespace: "*",
+								ApiGroup:  "",
+								Verbs:     []string{"*"},
+							}.Build(),
+						},
+						Labels: wildcardLabels,
+						Groups: []string{"cluster-admin"},
+						Users:  []string{"cluster-user"},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube with resource setting empty namespace for namespaced kind/api_group combo",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Resources: []*scopedaccessv1.KubeResource{
+							scopedaccessv1.KubeResource_builder{
+								Kind:      "deployments",
+								Name:      "*",
+								Namespace: "",
+								ApiGroup:  "apps",
+								Verbs:     []string{"*"},
+							}.Build(),
+						},
+						Labels: wildcardLabels,
+						Groups: []string{"cluster-admin"},
+						Users:  []string{"cluster-user"},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube with resource setting wildcard verb with any other verb",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Resources: []*scopedaccessv1.KubeResource{
+							scopedaccessv1.KubeResource_builder{
+								Kind:      "*",
+								Name:      "*",
+								Namespace: "*",
+								ApiGroup:  "*",
+								Verbs:     []string{"*", "get"},
+							}.Build(),
+						},
+						Labels: wildcardLabels,
+						Groups: []string{"cluster-admin"},
+						Users:  []string{"cluster-user"},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube with resource setting unrecognized verb",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Resources: []*scopedaccessv1.KubeResource{
+							scopedaccessv1.KubeResource_builder{
+								Kind:      "*",
+								Name:      "*",
+								Namespace: "*",
+								ApiGroup:  "*",
+								Verbs:     []string{"scopify"},
+							}.Build(),
+						},
+						Labels: wildcardLabels,
+						Groups: []string{"cluster-admin"},
+						Users:  []string{"cluster-user"},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "kube with resource setting interpolated verb",
+			role: scopedaccessv1.ScopedRole_builder{
+				Kind: KindScopedRole,
+				Metadata: headerv1.Metadata_builder{
+					Name: "test",
+				}.Build(),
+				Scope: "/",
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{"/foo"},
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Resources: []*scopedaccessv1.KubeResource{
+							scopedaccessv1.KubeResource_builder{
+								Kind:      "*",
+								Name:      "*",
+								Namespace: "*",
+								ApiGroup:  "*",
+								Verbs:     []string{"{{internal.verb}}"},
+							}.Build(),
+						},
+						Labels: wildcardLabels,
+						Groups: []string{"cluster-admin"},
+						Users:  []string{"cluster-user"},
+					}.Build(),
+				}.Build(),
+				Version: types.V1,
+			}.Build(),
+			strongOk: false,
 			weakOk:   true,
 		},
 	}
@@ -1496,7 +1826,7 @@ func TestStrongValidateRoleSpecAllFieldsValidated(t *testing.T) {
 			Lock: &scopedaccessv1.Lock{
 				Mode: "strict",
 			},
-			DisconnectExpiredCert: ptr(true),
+			DisconnectExpiredCert: proto.Bool(true),
 		},
 		Rules: []*scopedaccessv1.ScopedRule{
 			{
@@ -1553,7 +1883,7 @@ func TestStrongValidateRoleSpecAllFieldsValidated(t *testing.T) {
 				}.Build(),
 			},
 			ClientIdleTimeout:     "1h",
-			DisconnectExpiredCert: ptr(true),
+			DisconnectExpiredCert: proto.Bool(true),
 			Lock: &scopedaccessv1.Lock{
 				Mode: "strict",
 			},

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -1543,6 +1543,15 @@ func TestStrongValidateRoleSpecAllFieldsValidated(t *testing.T) {
 			Labels: []*labelv1.Label{
 				{Name: "env", Values: []string{"prod"}},
 			},
+			Resources: []*scopedaccessv1.KubeResource{
+				scopedaccessv1.KubeResource_builder{
+					Kind:      "pods",
+					Namespace: "default",
+					Name:      "*",
+					ApiGroup:  "*",
+					Verbs:     []string{"get"},
+				}.Build(),
+			},
 			ClientIdleTimeout:     "1h",
 			DisconnectExpiredCert: ptr(true),
 			Lock: &scopedaccessv1.Lock{

--- a/lib/scopes/access/compat.go
+++ b/lib/scopes/access/compat.go
@@ -57,6 +57,19 @@ func applyKubeBlock(src *scopedaccessv1.ScopedRoleKube, dst *types.RoleCondition
 		}
 		dst.KubernetesLabels[label.GetName()] = apiutils.Strings(label.GetValues())
 	}
+
+	for i, resource := range src.GetResources() {
+		if dst.KubernetesResources == nil {
+			dst.KubernetesResources = make([]types.KubernetesResource, len(src.GetResources()))
+		}
+		dst.KubernetesResources[i] = types.KubernetesResource{
+			Kind:      resource.GetKind(),
+			Namespace: resource.GetNamespace(),
+			Name:      resource.GetName(),
+			Verbs:     resource.GetVerbs(),
+			APIGroup:  resource.GetApiGroup(),
+		}
+	}
 }
 
 // applyRules merges the rules of a scoped role into the provided classic role
@@ -99,10 +112,16 @@ func applyRules(src []*scopedaccessv1.ScopedRule, dst *types.RoleConditions) {
 
 // ScopedRoleToRole converts a scoped role to an equivalent classic role. Scoped roles do not implement their
 // own access-control logic for the most part, and instead rely on converting to classic roles for the final
-// step of evaluation. This functiona also accepts the assigned scope as a parameter because we conventionally
+// step of evaluation. This function also accepts the assigned scope as a parameter because we conventionally
 // format converted role names as "<role-name>@<assigned-scope>" to help ensure reasonable error messages from
 // role evaluation logic.
 func ScopedRoleToRole(sr *scopedaccessv1.ScopedRole, assignedScope string) (types.Role, error) {
+	// role conversion applies unwanted wildcards for kube resources when left unassigned, so we
+	// explicitly validate the kube block as a sanity check
+	if err := validateKubeBlock(sr.GetSpec().GetKube()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	var conditions types.RoleConditions
 	applySSHBlock(sr.GetSpec().GetSsh(), &conditions)
 	applyKubeBlock(sr.GetSpec().GetKube(), &conditions)

--- a/lib/scopes/access/compat_test.go
+++ b/lib/scopes/access/compat_test.go
@@ -228,11 +228,27 @@ func baseScopedRole() *scopedaccessv1.ScopedRole {
 		Kind:     KindScopedRole,
 		Metadata: &headerv1.Metadata{Name: "test"},
 		Scope:    "/foo",
-		Spec: &scopedaccessv1.ScopedRoleSpec{
+		Spec: scopedaccessv1.ScopedRoleSpec_builder{
 			AssignableScopes: []string{"/foo/bar"},
-			Ssh:              &scopedaccessv1.ScopedRoleSSH{},
-			Kube:             &scopedaccessv1.ScopedRoleKube{},
-		},
+			Ssh:              scopedaccessv1.ScopedRoleSSH_builder{}.Build(),
+			Kube: scopedaccessv1.ScopedRoleKube_builder{
+				Labels: []*labelv1.Label{
+					labelv1.Label_builder{
+						Name:   "*",
+						Values: []string{"*"},
+					}.Build(),
+				},
+				Resources: []*scopedaccessv1.KubeResource{
+					scopedaccessv1.KubeResource_builder{
+						Kind:      "*",
+						Namespace: "*",
+						Name:      "*",
+						ApiGroup:  "*",
+						Verbs:     []string{"*"},
+					}.Build(),
+				},
+			}.Build(),
+		}.Build(),
 		Version: types.V1,
 	}
 }
@@ -357,9 +373,24 @@ func TestKubeDisconnectExpiredCertNotInClassicRole(t *testing.T) {
 	t.Parallel()
 
 	sr := baseScopedRole()
-	sr.Spec.Kube = &scopedaccessv1.ScopedRoleKube{
+	sr.Spec.Kube = scopedaccessv1.ScopedRoleKube_builder{
 		DisconnectExpiredCert: ptr(true),
-	}
+		Labels: []*labelv1.Label{
+			labelv1.Label_builder{
+				Name:   "*",
+				Values: []string{"*"},
+			}.Build(),
+		},
+		Resources: []*scopedaccessv1.KubeResource{
+			scopedaccessv1.KubeResource_builder{
+				Kind:      types.Wildcard,
+				Namespace: types.Wildcard,
+				Name:      types.Wildcard,
+				ApiGroup:  types.Wildcard,
+				Verbs:     []string{types.Wildcard},
+			}.Build(),
+		},
+	}.Build()
 
 	role, err := ScopedRoleToRole(sr, "/foo/bar")
 	require.NoError(t, err)
@@ -431,12 +462,12 @@ func TestKubeConversion(t *testing.T) {
 	}{
 		{
 			name:   "empty conditions",
-			kube:   &scopedaccessv1.ScopedRoleKube{},
+			kube:   nil,
 			expect: types.RoleConditions{},
 		},
 		{
 			name: "sparse",
-			kube: &scopedaccessv1.ScopedRoleKube{
+			kube: scopedaccessv1.ScopedRoleKube_builder{
 				Users:  []string{"system:user"},
 				Groups: []string{"viewer"},
 				Labels: []*labelv1.Label{
@@ -445,7 +476,16 @@ func TestKubeConversion(t *testing.T) {
 						Values: []string{"red"},
 					},
 				},
-			},
+				Resources: []*scopedaccessv1.KubeResource{
+					scopedaccessv1.KubeResource_builder{
+						Kind:      types.Wildcard,
+						Namespace: types.Wildcard,
+						Name:      types.Wildcard,
+						ApiGroup:  types.Wildcard,
+						Verbs:     []string{types.Wildcard},
+					}.Build(),
+				},
+			}.Build(),
 			expect: types.RoleConditions{
 				KubeUsers:  []string{"system:user"},
 				KubeGroups: []string{"viewer"},
@@ -457,7 +497,7 @@ func TestKubeConversion(t *testing.T) {
 		},
 		{
 			name: "full",
-			kube: &scopedaccessv1.ScopedRoleKube{
+			kube: scopedaccessv1.ScopedRoleKube_builder{
 				Users:  []string{"system:user", "system:admin"},
 				Groups: []string{"viewer", "editor"},
 				Labels: []*labelv1.Label{
@@ -470,7 +510,21 @@ func TestKubeConversion(t *testing.T) {
 						Values: []string{"blue"},
 					},
 				},
-			},
+				Resources: []*scopedaccessv1.KubeResource{
+					scopedaccessv1.KubeResource_builder{
+						Kind:      "pods",
+						Namespace: "default",
+						Name:      "pod-name",
+						Verbs:     []string{"get", "list"},
+						ApiGroup:  "pod-group",
+					}.Build(),
+				},
+				ClientIdleTimeout:     "30m",
+				DisconnectExpiredCert: new(bool),
+				Lock: scopedaccessv1.Lock_builder{
+					Mode: "strict",
+				}.Build(),
+			}.Build(),
 			expect: types.RoleConditions{
 				KubeUsers:  []string{"system:user", "system:admin"},
 				KubeGroups: []string{"viewer", "editor"},
@@ -478,7 +532,15 @@ func TestKubeConversion(t *testing.T) {
 					"env":  apiutils.Strings{"prod", "staging"},
 					"team": apiutils.Strings{"blue"},
 				},
-				KubernetesResources: wildcardResources,
+				KubernetesResources: []types.KubernetesResource{
+					types.KubernetesResource{
+						Kind:      "pods",
+						Namespace: "default",
+						Name:      "pod-name",
+						Verbs:     []string{"get", "list"},
+						APIGroup:  "pod-group",
+					},
+				},
 			},
 		},
 	}

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -1706,6 +1706,15 @@ func TestScopedBotKubernetes(t *testing.T) {
 					Labels: []*labelv1.Label{
 						{Name: "*", Values: []string{"*"}},
 					},
+					Resources: []*scopedaccessv1.KubeResource{
+						scopedaccessv1.KubeResource_builder{
+							Kind:      types.Wildcard,
+							Name:      types.Wildcard,
+							Namespace: types.Wildcard,
+							ApiGroup:  types.Wildcard,
+							Verbs:     []string{types.Wildcard},
+						}.Build(),
+					},
 					Groups: []string{"system:masters"},
 				},
 			},


### PR DESCRIPTION
Backports #66384, #67856, #68263, #68273 to branch/v18 

## Manual Test Plan
### Test Environment
A local teleport cluster with `TELEPORT_UNSTABLE_SCOPES=yes` and `TELEPORT_UNSTABLE_AGENT_SCOPE_PIN=yes`
### Test Cases
- [x] Fail to create a scoped role with non-nil `spec.kube` that does not define `resources`
- [x] Fail to create a scoped role with non-nil `spec.kube` that does not define `labels`
- [x] Create a scoped role with valid `spec.kube.resources`
- [x] Access scoped kube cluster using scoped identity with wildcard access
- [x] Access scoped kube cluster using scoped identity with limited access
  - [x] Limit resources by kind
  - [x] Limit resources by name
  - [x] Limit resources by namespace
  - [x] Limit resources by API group
  - [x] Limit actions by verb
- [x] Fail to create a scoped role with non-nil `spec.ssh` that does not define `labels`