### PR TITLE
[v18] Preserve access list grants when dropping access requests

### DIFF
--- a/lib/auth/access_request_test.go
+++ b/lib/auth/access_request_test.go
@@ -41,6 +41,8 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -195,6 +197,7 @@ func TestAccessRequest(t *testing.T) {
 	t.Run("single", func(t *testing.T) { testSingleAccessRequests(t, testPack) })
 	t.Run("multi", func(t *testing.T) { testMultiAccessRequests(t, testPack) })
 	t.Run("role refresh with bogus request ID", func(t *testing.T) { testRoleRefreshWithBogusRequestID(t, testPack) })
+	t.Run("drop requests keeps access list grants", func(t *testing.T) { testDropRequestsKeepsAccessListGrants(t, testPack) })
 	t.Run("bot user approver", func(t *testing.T) { testBotAccessRequestReview(t, testPack) })
 	t.Run("deny", func(t *testing.T) { testAccessRequestDenyRules(t, testPack) })
 	t.Run("cert extension resource IDs", func(t *testing.T) { testCertExtensionResourceIDs(t, testPack) })
@@ -1360,6 +1363,123 @@ func testRoleRefreshWithBogusRequestID(t *testing.T, testPack *accessRequestTest
 
 	// Verify that the new certs issued for the old client have the new role.
 	checkCerts(t, certs, []string{"requesters", "operators"}, nil, nil, nil)
+}
+
+// testDropRequestsKeepsAccessListGrants verifies that dropping access requests
+// resets the certificate roles and traits to the user login state, which
+// includes roles and traits granted by access lists, rather than to the bare
+// backend user. See https://github.com/gravitational/teleport/issues/45797.
+func testDropRequestsKeepsAccessListGrants(t *testing.T, testPack *accessRequestTestPack) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	username := "requester-with-access-list"
+	authServer := testPack.tlsServer.Auth()
+
+	// Create a user with the base "requesters" role.
+	user, err := types.NewUser(username)
+	require.NoError(t, err)
+	user.AddRole("requesters")
+	_, err = authServer.UpsertUser(ctx, user)
+	require.NoError(t, err)
+
+	// Create a role that is granted only through an access list.
+	aclRole, err := types.NewRole("access-list-granted", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Logins: []string{"acl-login"},
+		},
+	})
+	require.NoError(t, err)
+	_, err = authServer.UpsertRole(ctx, aclRole)
+	require.NoError(t, err)
+
+	// Grant the role through a real access list. Dropping access requests
+	// regenerates the user login state from the backend user and access
+	// lists, so the grant must be backed by an actual list membership.
+	acl, err := accesslist.NewAccessList(
+		header.Metadata{
+			Name: "requester-acl",
+		},
+		accesslist.Spec{
+			Title:  "requester-acl",
+			Owners: []accesslist.Owner{{Name: "acl-owner"}},
+			Audit:  accesslist.Audit{NextAuditDate: time.Now().Add(24 * time.Hour).UTC()},
+			Grants: accesslist.Grants{
+				Roles: []string{aclRole.GetName()},
+			},
+		},
+	)
+	require.NoError(t, err)
+	_, err = authServer.UpsertAccessList(ctx, acl)
+	require.NoError(t, err)
+
+	member, err := accesslist.NewAccessListMember(
+		header.Metadata{
+			Name: username,
+		},
+		accesslist.AccessListMemberSpec{
+			AccessList: acl.GetName(),
+			Name:       username,
+			Joined:     time.Now().UTC(),
+			AddedBy:    "acl-owner",
+			Expires:    time.Now().Add(24 * time.Hour).UTC(),
+		},
+	)
+	require.NoError(t, err)
+	_, err = authServer.UpsertAccessListMember(ctx, member)
+	require.NoError(t, err)
+
+	// Create an approved access request for the "admins" role.
+	accessRequest, err := services.NewAccessRequest(username, "admins")
+	require.NoError(t, err)
+	accessRequest.SetState(types.RequestState_APPROVED)
+	accessRequest.SetAccessExpiry(time.Now().Add(time.Hour).UTC())
+	require.NoError(t, authServer.UpsertAccessRequest(ctx, accessRequest))
+
+	clt, err := testPack.tlsServer.NewClient(authtest.TestUser(username))
+	require.NoError(t, err)
+	defer clt.Close()
+
+	// Assume the access request.
+	certs, err := clt.GenerateUserCerts(ctx, proto.UserCertsRequest{
+		SSHPublicKey:   testPack.sshPubKey,
+		TLSPublicKey:   testPack.tlsPubKey,
+		Username:       username,
+		Expires:        time.Now().Add(time.Hour).UTC(),
+		AccessRequests: []string{accessRequest.GetName()},
+	})
+	require.NoError(t, err)
+
+	tlsCert, err := tls.X509KeyPair(certs.TLS, testPack.tlsPrivKey)
+	require.NoError(t, err)
+	elevatedClient, err := testPack.tlsServer.NewClientWithCert(tlsCert)
+	require.NoError(t, err)
+	defer elevatedClient.Close()
+
+	// Drop all access requests. The reissued certs must keep the roles and
+	// traits granted by access lists via the user login state.
+	certs, err = elevatedClient.GenerateUserCerts(ctx, proto.UserCertsRequest{
+		SSHPublicKey:       testPack.sshPubKey,
+		TLSPublicKey:       testPack.tlsPubKey,
+		Username:           username,
+		Expires:            time.Now().Add(time.Hour).UTC(),
+		DropAccessRequests: []string{"*"},
+	})
+	require.NoError(t, err)
+	checkCerts(t, certs, []string{"requesters", aclRole.GetName()}, []string{"acl-login"}, nil, nil)
+
+	// Dropping a single request by ID must behave the same way.
+	certs, err = elevatedClient.GenerateUserCerts(ctx, proto.UserCertsRequest{
+		SSHPublicKey:       testPack.sshPubKey,
+		TLSPublicKey:       testPack.tlsPubKey,
+		Username:           username,
+		Expires:            time.Now().Add(time.Hour).UTC(),
+		DropAccessRequests: []string{accessRequest.GetName()},
+	})
+	require.NoError(t, err)
+	checkCerts(t, certs, []string{"requesters", aclRole.GetName()}, []string{"acl-login"}, nil, nil)
 }
 
 // checkCerts checks that the ssh and tls certs include the given roles, logins,

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2924,6 +2924,28 @@ func (a *Server) GetUserOrLoginState(ctx context.Context, username string) (serv
 	return services.GetUserOrLoginState(ctx, a.Services, username)
 }
 
+// regenerateUserLoginState computes the user login state for the given user
+// from the current backend user and access lists, and returns it without
+// persisting it. Unlike GetUserOrLoginState, this does not trust the stored
+// login state, which is a snapshot from login time and may miss both role
+// changes on the backend user and access list membership changes. The stored
+// login state in backend is left untouched.
+func (a *Server) regenerateUserLoginState(ctx context.Context, username string) (services.UserState, error) {
+	// Use Services (real backend instead of cache) to pick up user changes
+	// that may not have propagated to the cache yet.
+	user, err := a.Services.GetUser(ctx, username, false)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if user.IsBot() {
+		// Bot user don't have ULS no  need to regenerate.
+		// See GetUserOrLoginState where IsBot is checked and the user is returned directly.
+		return user, nil
+	}
+	uls, err := a.ulsGenerator.GeneratePureULS(ctx, user)
+	return uls, trace.Wrap(err)
+}
+
 func (a *Server) GenerateOpenSSHCert(ctx context.Context, req *proto.OpenSSHCertRequest) (*proto.OpenSSHCert, error) {
 	if req.User == nil {
 		return nil, trace.BadParameter("user is empty")

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3849,10 +3849,18 @@ func (a *ScopedServerWithRoles) desiredAccessInfoForUser(ctx context.Context, re
 	}
 
 	if dropAnyRequests := len(req.DropAccessRequests) > 0; dropAnyRequests {
-		// Reset to the base roles and traits stored in the backend user,
-		// currently active requests (not being dropped) and new access requests
-		// will be filled in below.
-		accessInfo = services.AccessInfoFromUserState(user)
+		// When dropping access requests, reset to the base roles and traits
+		// from a freshly regenerated user login state, which extends user object
+		// by roles and traits granted through access lists. The login state is
+		// regenerated rather than read from the backend because the user may
+		// have been modified since it was last computed, leaving the stored
+		// user_login_state stale. Using the raw user object here instead
+		// would strip access list grants from the reissued certificate.
+		userState, err := a.authServer.regenerateUserLoginState(ctx, user.GetName())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		accessInfo = services.AccessInfoFromUserState(userState)
 
 		// Check for ["*"] as special case to drop all requests.
 		if len(req.DropAccessRequests) == 1 && req.DropAccessRequests[0] == "*" {


### PR DESCRIPTION
Backport #68871 to branch/v18

changelog: Fixed `tsh request drop` removing roles and traits granted through Access Lists from the reissued certificate.


## Manual Test Plan
### Test Environment
local cluster
### Test Cases
  Core fix  - Access List grants survive tsh request drop:
  - [x] `tsh login --user=alice` -> `tsh status` shows roles requester, acl-granted and login acl-login
  - [x] `tsh request create` --roles=access --nowait -> tctl request approve <id> -> tsh login --request-id=<id> -> tsh status shows the access role and the active request
  - [x] `tsh request drop` -> the access role and active request are gone, but acl-granted, login acl-login, and trait acl-trait are still present (before this fix, all Access List grants disappeared) 
  - [x] After `tsh request drop` verify that user have still access to resources granted by `acl-granted` role.

  Regressions:
  - [x] User with no Access List memberships: create -> assume -> drop returns the cert to base roles, same as before
  - [x] Expired Access List membership: after alice's membership expires, tsh request drop does not re-apply acl-granted to the reissued cert