### PR TITLE
[v18] Introduce `scopes.StrongValidateResourceName` (#68489)

### DIFF
--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -157,8 +157,8 @@ func StrongValidateRole(role *scopedaccessv1.ScopedRole) error {
 		return trace.Wrap(err)
 	}
 
-	if err := validateRoleName(role.GetMetadata().GetName()); err != nil {
-		return trace.BadParameter("scoped role name %q does not conform to segment naming rules: %v", role.GetMetadata().GetName(), err)
+	if err := scopes.StrongValidateResourceName(role.GetMetadata().GetName()); err != nil {
+		return trace.BadParameter("scoped role name %q does not conform to resource naming rules: %v", role.GetMetadata().GetName(), err)
 	}
 
 	if err := scopes.StrongValidate(role.GetScope()); err != nil {
@@ -358,13 +358,6 @@ func validateLock(lock *scopedaccessv1.Lock) error {
 	return nil
 }
 
-func validateRoleName(name string) error {
-	// note: having the scope name be validated as a segment name is a bit of an arbitrary choice, but its basically
-	// equivalent to what we would want from a standalone name requirement, and there may even be some future benefit
-	// if we ever need to encode a role assignment as a scope-like name.
-	return trace.Wrap(scopes.StrongValidateSegment(name))
-}
-
 // commonValidateRole performs the subset of role validation common to both weak and strong validation.
 func commonValidateRole(role *scopedaccessv1.ScopedRole) error {
 	if role.GetMetadata().GetName() == "" {
@@ -464,8 +457,8 @@ func StrongValidateAssignment(assignment *scopedaccessv1.ScopedRoleAssignment) e
 		return trace.BadParameter("scoped role assignment %q has invalid sub_kind %q", assignment.GetMetadata().GetName(), assignment.GetSubKind())
 	}
 
-	if err := scopes.StrongValidateSegment(assignment.GetMetadata().GetName()); err != nil {
-		return trace.BadParameter("scoped role assignment name %q does not conform to segment naming rules: %v", assignment.GetMetadata().GetName(), err)
+	if err := scopes.StrongValidateResourceName(assignment.GetMetadata().GetName()); err != nil {
+		return trace.BadParameter("scoped role assignment name %q does not conform to resource naming rules: %v", assignment.GetMetadata().GetName(), err)
 	}
 
 	if err := scopes.StrongValidate(assignment.GetScope()); err != nil {

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -856,12 +856,12 @@ func TestValidateAsssignment(t *testing.T) {
 			weakOk:   false,
 		},
 		{
-			name: "malformed name - long name",
+			name: "name longer than max segment size",
 			assignment: &scopedaccessv1.ScopedRoleAssignment{
 				Kind:    KindScopedRoleAssignment,
 				SubKind: SubKindDynamic,
 				Metadata: &headerv1.Metadata{
-					Name: "thisiswaytoolongofanameaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					Name: "thisisaverylongnameaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				},
 				Scope: "/",
 				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
@@ -875,7 +875,7 @@ func TestValidateAsssignment(t *testing.T) {
 				},
 				Version: types.V1,
 			},
-			strongOk: false,
+			strongOk: true,
 			weakOk:   true,
 		},
 		{

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -485,10 +485,8 @@ func StrongValidateToken(token *joiningv1.ScopedToken) error {
 	if expected, actual := "", token.GetSubKind(); expected != actual {
 		return trace.BadParameter("expected sub_kind %v, got %q", expected, actual)
 	}
-	if name := token.GetMetadata().GetName(); name == "" {
-		return trace.BadParameter("missing name")
-	} else if strings.Contains(name, ":") {
-		return trace.BadParameter("scoped token names cannot contain colons")
+	if err := scopes.StrongValidateResourceName(token.GetMetadata().GetName()); err != nil {
+		return trace.Wrap(err, "validating scoped token name")
 	}
 
 	if token.GetScope() == "" {

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -124,7 +124,7 @@ func TestValidateScopedToken(t *testing.T) {
 			modFn: func(tok *joiningv1.ScopedToken) {
 				tok.Metadata.Name = ""
 			},
-			expectedStrongErr: "missing name",
+			expectedStrongErr: "name is empty",
 		},
 		{
 			name: "missing spec",
@@ -1240,7 +1240,7 @@ func TestValidateScopedToken(t *testing.T) {
 			modFn: func(st *joiningv1.ScopedToken) {
 				st.GetMetadata().SetName("testing:testing")
 			},
-			expectedStrongErr: "scoped token names cannot contain colons",
+			expectedStrongErr: `name "testing:testing" is malformed`,
 		},
 	}
 

--- a/lib/scopes/qualified.go
+++ b/lib/scopes/qualified.go
@@ -19,7 +19,6 @@
 package scopes
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -65,7 +64,7 @@ func (q QualifiedName) StrongValidate() error {
 		return trace.BadParameter("scope-qualified name %q has invalid scope: %v", q, err)
 	}
 
-	if err := strongValidateName(q.Name); err != nil {
+	if err := StrongValidateResourceName(q.Name); err != nil {
 		return trace.BadParameter("scope-qualified name %q has invalid name: %v", q, err)
 	}
 
@@ -92,20 +91,6 @@ func (q QualifiedName) WeakValidate() error {
 	}
 
 	return nil
-}
-
-// nameRegexp is the regular expression used to validate scoped resource names. It enforces
-// the same character rules as segmentRegexp, but allows for single character names.
-var nameRegexp = regexp.MustCompile(`^[a-z0-9]([a-z0-9\-\_\.]*[a-z0-9])?$`)
-
-// strongValidateName checks if a scoped resource name is valid according to scope character
-// formatting rules. Unlike scope segments, names carry no length constraints.
-func strongValidateName(name string) error {
-	if name == "" {
-		return trace.BadParameter("name is empty")
-	}
-
-	return trace.Wrap(strongValidateFormat(name, nameRegexp))
 }
 
 // ParseQualifiedName parses a scope-qualified name string into its scope and name

--- a/lib/scopes/qualified.go
+++ b/lib/scopes/qualified.go
@@ -19,6 +19,7 @@
 package scopes
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -64,7 +65,7 @@ func (q QualifiedName) StrongValidate() error {
 		return trace.BadParameter("scope-qualified name %q has invalid scope: %v", q, err)
 	}
 
-	if err := StrongValidateSegment(q.Name); err != nil {
+	if err := strongValidateName(q.Name); err != nil {
 		return trace.BadParameter("scope-qualified name %q has invalid name: %v", q, err)
 	}
 
@@ -91,6 +92,20 @@ func (q QualifiedName) WeakValidate() error {
 	}
 
 	return nil
+}
+
+// nameRegexp is the regular expression used to validate scoped resource names. It enforces
+// the same character rules as segmentRegexp, but allows for single character names.
+var nameRegexp = regexp.MustCompile(`^[a-z0-9]([a-z0-9\-\_\.]*[a-z0-9])?$`)
+
+// strongValidateName checks if a scoped resource name is valid according to scope character
+// formatting rules. Unlike scope segments, names carry no length constraints.
+func strongValidateName(name string) error {
+	if name == "" {
+		return trace.BadParameter("name is empty")
+	}
+
+	return trace.Wrap(strongValidateFormat(name, nameRegexp))
 }
 
 // ParseQualifiedName parses a scope-qualified name string into its scope and name

--- a/lib/scopes/qualified_test.go
+++ b/lib/scopes/qualified_test.go
@@ -198,6 +198,12 @@ func TestValidateQualifiedName(t *testing.T) {
 			weakOk:   true,
 		},
 		{
+			name:     "name longer than max segment size",
+			sqn:      "/staging::aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
 			name:     "scope with breaking char",
 			sqn:      "/stag@ing::myrole",
 			strongOk: false,

--- a/lib/scopes/qualified_test.go
+++ b/lib/scopes/qualified_test.go
@@ -252,9 +252,9 @@ func TestValidateQualifiedName(t *testing.T) {
 			weakOk:   true,
 		},
 		{
-			name:     "name too short",
+			name:     "single-character name",
 			sqn:      "/staging::x",
-			strongOk: false,
+			strongOk: true,
 			weakOk:   true,
 		},
 		{

--- a/lib/scopes/scopes.go
+++ b/lib/scopes/scopes.go
@@ -144,6 +144,22 @@ func StrongValidateSegment(segment string) error {
 		return trace.BadParameter("segment %q is too short (min characters %d)", segment, minSegmentSize)
 	}
 
+	if err := strongValidateFormat(segment, segmentRegexp); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if len(segment) > maxSegmentSize {
+		return trace.BadParameter("segment %q is too long (max characters %d)", segment, maxSegmentSize)
+	}
+
+	return nil
+}
+
+// strongValidateFormat applies the strong formatting checks:
+// - no uppercase characters
+// - the provided shape regexp
+// - weak checks as a defensive backstop
+func strongValidateFormat(segment string, shape *regexp.Regexp) error {
 	// check for uppercase characters separately. this would be caught by the regex, but its better
 	// UX to call out uppercase characters specifically since its a common mistake.
 	for _, r := range segment {
@@ -152,12 +168,8 @@ func StrongValidateSegment(segment string) error {
 		}
 	}
 
-	if !segmentRegexp.MatchString(segment) {
+	if !shape.MatchString(segment) {
 		return trace.BadParameter("segment %q is malformed", segment)
-	}
-
-	if len(segment) > maxSegmentSize {
-		return trace.BadParameter("segment %q is too long (max characters %d)", segment, maxSegmentSize)
 	}
 
 	// as an extra precaution, also run all weak checks just to be certain we didn't accidentally

--- a/lib/scopes/scopes.go
+++ b/lib/scopes/scopes.go
@@ -144,7 +144,7 @@ func StrongValidateSegment(segment string) error {
 		return trace.BadParameter("segment %q is too short (min characters %d)", segment, minSegmentSize)
 	}
 
-	if err := strongValidateFormat(segment, segmentRegexp); err != nil {
+	if err := strongValidateFormat("segment", segment, segmentRegexp); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -155,29 +155,30 @@ func StrongValidateSegment(segment string) error {
 	return nil
 }
 
-// strongValidateFormat applies the strong formatting checks:
+// strongValidateFormat applies the strong formatting checks to value, describing it as noun
+// (e.g. "segment" or "name") in any error it returns:
 // - no uppercase characters
 // - the provided shape regexp
 // - weak checks as a defensive backstop
-func strongValidateFormat(segment string, shape *regexp.Regexp) error {
+func strongValidateFormat(noun, value string, shape *regexp.Regexp) error {
 	// check for uppercase characters separately. this would be caught by the regex, but its better
 	// UX to call out uppercase characters specifically since its a common mistake.
-	for _, r := range segment {
+	for _, r := range value {
 		if unicode.IsUpper(r) {
-			return trace.BadParameter("segment %q contains uppercase character(s)", segment)
+			return trace.BadParameter("%s %q contains uppercase character(s)", noun, value)
 		}
 	}
 
-	if !shape.MatchString(segment) {
-		return trace.BadParameter("segment %q is malformed", segment)
+	if !shape.MatchString(value) {
+		return trace.BadParameter("%s %q is malformed", noun, value)
 	}
 
 	// as an extra precaution, also run all weak checks just to be certain we didn't accidentally
 	// construct a weak check that rejects something that would otherwise pass a strong check. strong
 	// validation is not used in perf-critical paths, so there isn't any real downside to a little
 	// defensiveness here.
-	if err := WeakValidateSegment(segment); err != nil {
-		return trace.BadParameter("segment would not pass weak validation: %v", err)
+	if err := WeakValidateSegment(value); err != nil {
+		return trace.BadParameter("%s would not pass weak validation: %v", noun, err)
 	}
 
 	return nil
@@ -203,6 +204,10 @@ func WeakValidateSegment(segment string) error {
 	return nil
 }
 
+// nameRegexp is the regular expression used to validate scoped resource names. It enforces
+// the same character rules as segmentRegexp, but allows for single character names.
+var nameRegexp = regexp.MustCompile(`^[a-z0-9]([a-z0-9\-\_\.]*[a-z0-9])?$`)
+
 // StrongValidateResourceName checks if a scoped resource name is valid according to all resource name
 // formatting rules. Scoped resource names follow the same character restrictions as scope segments, but
 // are not subject to the maximum segment length limit. This function *must* be called on all scoped
@@ -214,19 +219,7 @@ func StrongValidateResourceName(name string) error {
 		return trace.BadParameter("name is empty")
 	}
 
-	// check for uppercase characters separately. this would be caught by the regex, but its better
-	// UX to call out uppercase characters specifically since its a common mistake.
-	for _, r := range name {
-		if unicode.IsUpper(r) {
-			return trace.BadParameter("name %q contains uppercase character(s)", name)
-		}
-	}
-
-	if !nameRegexp.MatchString(name) {
-		return trace.BadParameter("name %q is malformed", name)
-	}
-
-	return nil
+	return trace.Wrap(strongValidateFormat("name", name, nameRegexp))
 }
 
 // isNonSpacePrintableASCII checks if a byte is a non-space printable ASCII character (i.e. a byte in the range

--- a/lib/scopes/scopes.go
+++ b/lib/scopes/scopes.go
@@ -203,6 +203,32 @@ func WeakValidateSegment(segment string) error {
 	return nil
 }
 
+// StrongValidateResourceName checks if a scoped resource name is valid according to all resource name
+// formatting rules. Scoped resource names follow the same character restrictions as scope segments, but
+// are not subject to the maximum segment length limit. This function *must* be called on all scoped
+// resource name values received from user input and/or cluster-external sources. Use of this function
+// should be avoided when checking the validity of names from the control-plane in logic that may be run
+// agent-side.
+func StrongValidateResourceName(name string) error {
+	if name == "" {
+		return trace.BadParameter("name is empty")
+	}
+
+	// check for uppercase characters separately. this would be caught by the regex, but its better
+	// UX to call out uppercase characters specifically since its a common mistake.
+	for _, r := range name {
+		if unicode.IsUpper(r) {
+			return trace.BadParameter("name %q contains uppercase character(s)", name)
+		}
+	}
+
+	if !nameRegexp.MatchString(name) {
+		return trace.BadParameter("name %q is malformed", name)
+	}
+
+	return nil
+}
+
 // isNonSpacePrintableASCII checks if a byte is a non-space printable ASCII character (i.e. a byte in the range
 // [33, 126] inclusive). This is used for weak validation of scope segments and globs.
 func isNonSpacePrintableASCII(b byte) bool {

--- a/lib/scopes/scopes_test.go
+++ b/lib/scopes/scopes_test.go
@@ -135,6 +135,80 @@ func TestValidateSegment(t *testing.T) {
 	}
 }
 
+// TestStrongValidateResourceName tests the StrongValidateResourceName function. Resource names follow
+// the same character restrictions as scope segments, but are not subject to the maximum segment length.
+func TestStrongValidateResourceName(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name  string
+		rname string
+		ok    bool
+	}{
+		{
+			name:  "valid name",
+			rname: "aa",
+			ok:    true,
+		},
+		{
+			name:  "valid name with symbols",
+			rname: "aa-bb_cc.dd",
+			ok:    true,
+		},
+		{
+			name:  "valid name longer than max segment size",
+			rname: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			ok:    true,
+		},
+		{
+			name:  "empty name",
+			rname: "",
+			ok:    false,
+		},
+		{
+			name:  "name with leading symbol",
+			rname: ".aa",
+			ok:    false,
+		},
+		{
+			name:  "name with trailing symbol",
+			rname: "aa_",
+			ok:    false,
+		},
+		{
+			name:  "name with reserved symbol",
+			rname: "aa@bb",
+			ok:    false,
+		},
+		{
+			name:  "name with whitespace",
+			rname: "aa bb",
+			ok:    false,
+		},
+		{
+			name:  "name with separator",
+			rname: "aa/bb",
+			ok:    false,
+		},
+		{
+			name:  "name with uppercase",
+			rname: "aAa",
+			ok:    false,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			err := StrongValidateResourceName(tt.rname)
+			if tt.ok {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
 // TestStrongValidate tests the StrongValidate function for various combinations of scopes.
 func TestStrongValidate(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Backports #68489 and #69053

#69053 is the follow-up cleanup that dedupes the two overlapping name validation
implementations, so it is included here to keep `lib/scopes` aligned with master.

## Test Plan

### Environment

Local

### Test Cases

- [x] Regression: Create ScopedToken with valid name
- [x] Regression: Create ScopedRole with valid name
- [x] Regression: Create ScopedRoleAssignment with valid name