### PR TITLE
discovery: include Azure identity in subscription failure UserTasks

### DIFF
--- a/api/gen/proto/go/teleport/usertasks/v1/user_tasks_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/usertasks/v1/user_tasks_protohybrid.pb.go
@@ -1293,7 +1293,11 @@ type DiscoverAzureVM struct {
 	// ResourceGroup is the Azure Resource Group where VMs are located.
 	ResourceGroup string `protobuf:"bytes,3,opt,name=resource_group,json=resourceGroup,proto3" json:"resource_group,omitempty"`
 	// Region is the Azure Region where Teleport failed to enroll VMs.
-	Region        string `protobuf:"bytes,4,opt,name=region,proto3" json:"region,omitempty"`
+	Region string `protobuf:"bytes,4,opt,name=region,proto3" json:"region,omitempty"`
+	// TenantID is the Microsoft Entra tenant ID used by the Azure integration.
+	TenantId string `protobuf:"bytes,5,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	// ClientID is the client ID of the Azure integration's managed identity or service principal.
+	ClientId      string `protobuf:"bytes,6,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1351,6 +1355,20 @@ func (x *DiscoverAzureVM) GetRegion() string {
 	return ""
 }
 
+func (x *DiscoverAzureVM) GetTenantId() string {
+	if x != nil {
+		return x.TenantId
+	}
+	return ""
+}
+
+func (x *DiscoverAzureVM) GetClientId() string {
+	if x != nil {
+		return x.ClientId
+	}
+	return ""
+}
+
 func (x *DiscoverAzureVM) SetInstances(v map[string]*DiscoverAzureVMInstance) {
 	x.Instances = v
 }
@@ -1367,6 +1385,14 @@ func (x *DiscoverAzureVM) SetRegion(v string) {
 	x.Region = v
 }
 
+func (x *DiscoverAzureVM) SetTenantId(v string) {
+	x.TenantId = v
+}
+
+func (x *DiscoverAzureVM) SetClientId(v string) {
+	x.ClientId = v
+}
+
 type DiscoverAzureVM_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -1378,6 +1404,10 @@ type DiscoverAzureVM_builder struct {
 	ResourceGroup string
 	// Region is the Azure Region where Teleport failed to enroll VMs.
 	Region string
+	// TenantID is the Microsoft Entra tenant ID used by the Azure integration.
+	TenantId string
+	// ClientID is the client ID of the Azure integration's managed identity or service principal.
+	ClientId string
 }
 
 func (b0 DiscoverAzureVM_builder) Build() *DiscoverAzureVM {
@@ -1388,6 +1418,8 @@ func (b0 DiscoverAzureVM_builder) Build() *DiscoverAzureVM {
 	x.SubscriptionId = b.SubscriptionId
 	x.ResourceGroup = b.ResourceGroup
 	x.Region = b.Region
+	x.TenantId = b.TenantId
+	x.ClientId = b.ClientId
 	return m0
 }
 
@@ -1684,12 +1716,14 @@ const file_teleport_usertasks_v1_user_tasks_proto_rawDesc = "" +
 	"\x06engine\x18\x03 \x01(\tR\x06engine\x12)\n" +
 	"\x10discovery_config\x18\x04 \x01(\tR\x0fdiscoveryConfig\x12'\n" +
 	"\x0fdiscovery_group\x18\x05 \x01(\tR\x0ediscoveryGroup\x127\n" +
-	"\tsync_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\bsyncTime\"\xbc\x02\n" +
+	"\tsync_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\bsyncTime\"\xf6\x02\n" +
 	"\x0fDiscoverAzureVM\x12S\n" +
 	"\tinstances\x18\x01 \x03(\v25.teleport.usertasks.v1.DiscoverAzureVM.InstancesEntryR\tinstances\x12'\n" +
 	"\x0fsubscription_id\x18\x02 \x01(\tR\x0esubscriptionId\x12%\n" +
 	"\x0eresource_group\x18\x03 \x01(\tR\rresourceGroup\x12\x16\n" +
-	"\x06region\x18\x04 \x01(\tR\x06region\x1al\n" +
+	"\x06region\x18\x04 \x01(\tR\x06region\x12\x1b\n" +
+	"\ttenant_id\x18\x05 \x01(\tR\btenantId\x12\x1b\n" +
+	"\tclient_id\x18\x06 \x01(\tR\bclientId\x1al\n" +
 	"\x0eInstancesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12D\n" +
 	"\x05value\x18\x02 \x01(\v2..teleport.usertasks.v1.DiscoverAzureVMInstanceR\x05value:\x028\x01\"\x9a\x03\n" +

--- a/api/gen/proto/go/teleport/usertasks/v1/user_tasks_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/usertasks/v1/user_tasks_protoopaque.pb.go
@@ -1229,6 +1229,8 @@ type DiscoverAzureVM struct {
 	xxx_hidden_SubscriptionId string                              `protobuf:"bytes,2,opt,name=subscription_id,json=subscriptionId,proto3"`
 	xxx_hidden_ResourceGroup  string                              `protobuf:"bytes,3,opt,name=resource_group,json=resourceGroup,proto3"`
 	xxx_hidden_Region         string                              `protobuf:"bytes,4,opt,name=region,proto3"`
+	xxx_hidden_TenantId       string                              `protobuf:"bytes,5,opt,name=tenant_id,json=tenantId,proto3"`
+	xxx_hidden_ClientId       string                              `protobuf:"bytes,6,opt,name=client_id,json=clientId,proto3"`
 	unknownFields             protoimpl.UnknownFields
 	sizeCache                 protoimpl.SizeCache
 }
@@ -1286,6 +1288,20 @@ func (x *DiscoverAzureVM) GetRegion() string {
 	return ""
 }
 
+func (x *DiscoverAzureVM) GetTenantId() string {
+	if x != nil {
+		return x.xxx_hidden_TenantId
+	}
+	return ""
+}
+
+func (x *DiscoverAzureVM) GetClientId() string {
+	if x != nil {
+		return x.xxx_hidden_ClientId
+	}
+	return ""
+}
+
 func (x *DiscoverAzureVM) SetInstances(v map[string]*DiscoverAzureVMInstance) {
 	x.xxx_hidden_Instances = v
 }
@@ -1302,6 +1318,14 @@ func (x *DiscoverAzureVM) SetRegion(v string) {
 	x.xxx_hidden_Region = v
 }
 
+func (x *DiscoverAzureVM) SetTenantId(v string) {
+	x.xxx_hidden_TenantId = v
+}
+
+func (x *DiscoverAzureVM) SetClientId(v string) {
+	x.xxx_hidden_ClientId = v
+}
+
 type DiscoverAzureVM_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -1313,6 +1337,10 @@ type DiscoverAzureVM_builder struct {
 	ResourceGroup string
 	// Region is the Azure Region where Teleport failed to enroll VMs.
 	Region string
+	// TenantID is the Microsoft Entra tenant ID used by the Azure integration.
+	TenantId string
+	// ClientID is the client ID of the Azure integration's managed identity or service principal.
+	ClientId string
 }
 
 func (b0 DiscoverAzureVM_builder) Build() *DiscoverAzureVM {
@@ -1323,6 +1351,8 @@ func (b0 DiscoverAzureVM_builder) Build() *DiscoverAzureVM {
 	x.xxx_hidden_SubscriptionId = b.SubscriptionId
 	x.xxx_hidden_ResourceGroup = b.ResourceGroup
 	x.xxx_hidden_Region = b.Region
+	x.xxx_hidden_TenantId = b.TenantId
+	x.xxx_hidden_ClientId = b.ClientId
 	return m0
 }
 
@@ -1610,12 +1640,14 @@ const file_teleport_usertasks_v1_user_tasks_proto_rawDesc = "" +
 	"\x06engine\x18\x03 \x01(\tR\x06engine\x12)\n" +
 	"\x10discovery_config\x18\x04 \x01(\tR\x0fdiscoveryConfig\x12'\n" +
 	"\x0fdiscovery_group\x18\x05 \x01(\tR\x0ediscoveryGroup\x127\n" +
-	"\tsync_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\bsyncTime\"\xbc\x02\n" +
+	"\tsync_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\bsyncTime\"\xf6\x02\n" +
 	"\x0fDiscoverAzureVM\x12S\n" +
 	"\tinstances\x18\x01 \x03(\v25.teleport.usertasks.v1.DiscoverAzureVM.InstancesEntryR\tinstances\x12'\n" +
 	"\x0fsubscription_id\x18\x02 \x01(\tR\x0esubscriptionId\x12%\n" +
 	"\x0eresource_group\x18\x03 \x01(\tR\rresourceGroup\x12\x16\n" +
-	"\x06region\x18\x04 \x01(\tR\x06region\x1al\n" +
+	"\x06region\x18\x04 \x01(\tR\x06region\x12\x1b\n" +
+	"\ttenant_id\x18\x05 \x01(\tR\btenantId\x12\x1b\n" +
+	"\tclient_id\x18\x06 \x01(\tR\bclientId\x1al\n" +
 	"\x0eInstancesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12D\n" +
 	"\x05value\x18\x02 \x01(\v2..teleport.usertasks.v1.DiscoverAzureVMInstanceR\x05value:\x028\x01\"\x9a\x03\n" +

--- a/api/proto/teleport/usertasks/v1/user_tasks.proto
+++ b/api/proto/teleport/usertasks/v1/user_tasks.proto
@@ -179,6 +179,10 @@ message DiscoverAzureVM {
   string resource_group = 3;
   // Region is the Azure Region where Teleport failed to enroll VMs.
   string region = 4;
+  // TenantID is the Microsoft Entra tenant ID used by the Azure integration.
+  string tenant_id = 5;
+  // ClientID is the client ID of the Azure integration's managed identity or service principal.
+  string client_id = 6;
 }
 
 // DiscoverAzureVMInstance contains the result of enrolling an Azure VM.

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -885,7 +885,19 @@ func (s *Server) handleAzureSubscriptionListError(integration string, err error)
 		return
 	}
 
-	if err := s.taskUpdater().upsertAzureSubscriptionListTask(integration, issueType); err != nil {
+	var tenantID, clientID string
+	integrationResource, err := s.Config.AccessPoint.GetIntegration(s.ctx, integration)
+	if err != nil {
+		s.Log.WarnContext(s.ctx, "Failed to get Azure integration identity for User Task",
+			"integration", integration,
+			"error", err,
+		)
+	} else if azureOIDCSpec := integrationResource.GetAzureOIDCIntegrationSpec(); azureOIDCSpec != nil {
+		tenantID = azureOIDCSpec.TenantID
+		clientID = azureOIDCSpec.ClientID
+	}
+
+	if err := s.taskUpdater().upsertAzureSubscriptionListTask(integration, issueType, tenantID, clientID); err != nil {
 		s.Log.WarnContext(s.ctx, "Failed to upsert Azure subscription list permission User Task",
 			"integration", integration,
 			"error", err,

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -1049,7 +1049,7 @@ type taskUpdater struct {
 	Log            *slog.Logger
 }
 
-func (s *taskUpdater) upsertAzureSubscriptionListTask(integration, issueType string) error {
+func (s *taskUpdater) upsertAzureSubscriptionListTask(integration, issueType, tenantID, clientID string) error {
 	task, err := usertasks.NewDiscoverAzureVMUserTask(
 		usertasks.TaskGroup{
 			Integration: integration,
@@ -1058,6 +1058,8 @@ func (s *taskUpdater) upsertAzureSubscriptionListTask(integration, issueType str
 		s.clock.Now().Add(2*s.PollInterval),
 		usertasksv1.DiscoverAzureVM_builder{
 			Instances: map[string]*usertasksv1.DiscoverAzureVMInstance{},
+			TenantId:  tenantID,
+			ClientId:  clientID,
 		}.Build(),
 	)
 	if err != nil {
@@ -1105,6 +1107,12 @@ func (s *taskUpdater) mergeAzure(oldSpec *usertasksv1.UserTaskSpec, newSpec *use
 	}
 	if newSpec.GetDiscoverAzureVm().GetInstances() == nil {
 		newSpec.GetDiscoverAzureVm().SetInstances(make(map[string]*usertasksv1.DiscoverAzureVMInstance))
+	}
+	if newSpec.GetDiscoverAzureVm().GetTenantId() == "" {
+		newSpec.GetDiscoverAzureVm().SetTenantId(oldSpec.GetDiscoverAzureVm().GetTenantId())
+	}
+	if newSpec.GetDiscoverAzureVm().GetClientId() == "" {
+		newSpec.GetDiscoverAzureVm().SetClientId(oldSpec.GetDiscoverAzureVm().GetClientId())
 	}
 	mergeExistingInstances(s, oldSpec.GetDiscoverAzureVm().GetInstances(), newSpec.GetDiscoverAzureVm().GetInstances())
 }

--- a/lib/srv/discovery/status_test.go
+++ b/lib/srv/discovery/status_test.go
@@ -346,6 +346,8 @@ func TestUpsertAzureSubscriptionListTask(t *testing.T) {
 	require.NoError(t, updater.upsertAzureSubscriptionListTask(
 		"azure-integration",
 		usertasks.AutoDiscoverAzureVMIssueSubscriptionListDenied,
+		"azure-tenant-id",
+		"azure-client-id",
 	))
 	require.Len(t, ap.tasks, 1)
 
@@ -355,8 +357,43 @@ func TestUpsertAzureSubscriptionListTask(t *testing.T) {
 		require.Equal(t, "azure-integration", task.GetSpec().GetIntegration())
 		require.Empty(t, task.GetSpec().GetDiscoverAzureVm().GetSubscriptionId())
 		require.Empty(t, task.GetSpec().GetDiscoverAzureVm().GetInstances())
+		require.Equal(t, "azure-tenant-id", task.GetSpec().GetDiscoverAzureVm().GetTenantId())
+		require.Equal(t, "azure-client-id", task.GetSpec().GetDiscoverAzureVm().GetClientId())
 		require.True(t, updater.clock.Now().Add(2*updater.PollInterval).Equal(task.GetMetadata().GetExpires().AsTime()))
 	}
+}
+
+func TestUpsertAzureSubscriptionListTaskPreservesIdentity(t *testing.T) {
+	t.Parallel()
+
+	const (
+		integration = "azure-integration"
+		issueType   = usertasks.AutoDiscoverAzureVMIssueSubscriptionListDenied
+		tenantID    = "azure-tenant-id"
+		clientID    = "azure-client-id"
+	)
+
+	existingTask, err := usertasks.NewDiscoverAzureVMUserTask(
+		usertasks.TaskGroup{
+			Integration: integration,
+			IssueType:   issueType,
+		},
+		time.Now().Add(time.Hour),
+		usertasksv1.DiscoverAzureVM_builder{
+			Instances: map[string]*usertasksv1.DiscoverAzureVMInstance{},
+			TenantId:  tenantID,
+			ClientId:  clientID,
+		}.Build(),
+	)
+	require.NoError(t, err)
+
+	updater, ap := newTaskUpdater(t, existingTask)
+	require.NoError(t, updater.upsertAzureSubscriptionListTask(integration, issueType, "", ""))
+
+	task, err := ap.GetUserTask(t.Context(), existingTask.GetMetadata().GetName())
+	require.NoError(t, err)
+	require.Equal(t, tenantID, task.GetSpec().GetDiscoverAzureVm().GetTenantId())
+	require.Equal(t, clientID, task.GetSpec().GetDiscoverAzureVm().GetClientId())
 }
 
 func TestAWSEC2Tasks_AddFailedEnrollment(t *testing.T) {

--- a/lib/usertasks/descriptions/azure-vm-subscription-list-denied.md
+++ b/lib/usertasks/descriptions/azure-vm-subscription-list-denied.md
@@ -2,7 +2,7 @@
 
 Teleport could not resolve the wildcard subscription matcher because the Azure integration cannot access any subscriptions.
 
-Verify that the integration uses the intended Azure tenant and managed identity or service principal. Grant that identity a role with the following actions at the management group or subscription scope that Teleport should discover:
+The UserTask's `tenant_id` and `client_id` fields identify the Microsoft Entra tenant and managed identity or service principal used by the integration. Verify that these identifiers are correct, then grant that identity a role with the following actions at the management group or subscription scope that Teleport should discover:
 
 - `Microsoft.Compute/virtualMachines/read`
 - `Microsoft.Compute/virtualMachines/runCommands/write`

--- a/lib/usertasks/descriptions/azure-vm-subscription-list-denied.md
+++ b/lib/usertasks/descriptions/azure-vm-subscription-list-denied.md
@@ -2,7 +2,7 @@
 
 Teleport could not resolve the wildcard subscription matcher because the Azure integration cannot access any subscriptions.
 
-The UserTask's `tenant_id` and `client_id` fields identify the Microsoft Entra tenant and managed identity or service principal used by the integration. Verify that these identifiers are correct, then grant that identity a role with the following actions at the management group or subscription scope that Teleport should discover:
+This task's Tenant ID and Client ID fields identify the Microsoft Entra tenant and managed identity or service principal used by the integration. Verify that these identifiers are correct, then grant that identity a role with the following actions at the management group or subscription scope that Teleport should discover:
 
 - `Microsoft.Compute/virtualMachines/read`
 - `Microsoft.Compute/virtualMachines/runCommands/write`

--- a/web/packages/teleport/src/Discover/Overview/ActivityTab.test.tsx
+++ b/web/packages/teleport/src/Discover/Overview/ActivityTab.test.tsx
@@ -121,6 +121,62 @@ test('opens issue drawer and resolves a task', async () => {
   );
 });
 
+test('shows Azure integration identity in the issue drawer', async () => {
+  (useToastNotifications as jest.Mock).mockReturnValue({
+    add: jest.fn(),
+  });
+
+  jest.spyOn(integrationService, 'fetchUserTask').mockResolvedValueOnce({
+    name: 'task-azure',
+    taskType: 'discover-azure-vm',
+    state: 'OPEN',
+    issueType: 'azure-vm-subscription-list-denied',
+    title: 'Cannot access Azure subscriptions',
+    integration: 'azure-integration',
+    lastStateChange: '2025-10-24T12:30:00Z',
+    description: 'Details',
+    discoverAzureVm: {
+      instances: {},
+      subscription_id: '',
+      resource_group: '',
+      region: '',
+      tenant_id: 'azure-tenant-id',
+      client_id: 'azure-client-id',
+    },
+  });
+
+  render(
+    <QueryClientProvider client={testQueryClient}>
+      <ActivityTab
+        stats={{
+          name: 'azure-integration',
+          userTasks: [
+            {
+              name: 'task-azure',
+              taskType: 'discover-azure-vm',
+              state: 'OPEN',
+              issueType: 'azure-vm-subscription-list-denied',
+              title: 'Cannot access Azure subscriptions',
+              integration: 'azure-integration',
+              lastStateChange: '2025-10-24T12:30:00Z',
+            },
+          ],
+        }}
+      />
+    </QueryClientProvider>
+  );
+
+  await userEvent.click(screen.getByText('Details'));
+  await screen.findByRole('heading', {
+    name: 'Cannot access Azure subscriptions',
+  });
+
+  expect(screen.getByText('Tenant ID:')).toBeVisible();
+  expect(screen.getByText('azure-tenant-id')).toBeVisible();
+  expect(screen.getByText('Client ID:')).toBeVisible();
+  expect(screen.getByText('azure-client-id')).toBeVisible();
+});
+
 test('keeps failed tasks selected when bulk resolve partially fails', async () => {
   const addToast = jest.fn();
   (useToastNotifications as jest.Mock).mockReturnValue({

--- a/web/packages/teleport/src/Discover/Overview/UserTaskDrawer.tsx
+++ b/web/packages/teleport/src/Discover/Overview/UserTaskDrawer.tsx
@@ -197,6 +197,8 @@ function DetailsTab({ task }: { task: UserTaskDetail }) {
       <InfoRow label="Resource Type" value={info.resourceType} />
       <InfoRow label="Region" value={info.region} />
       <InfoRow label="Account" value={info.account} />
+      {info.tenantId && <InfoRow label="Tenant ID" value={info.tenantId} />}
+      {info.clientId && <InfoRow label="Client ID" value={info.clientId} />}
       <InfoRow label="Last updated" value={formatDate(task.lastStateChange)} />
       <Divider />
 
@@ -254,6 +256,8 @@ function getTaskInfo(task: UserTaskDetail): {
   resourceType: string;
   region?: string;
   account?: string;
+  tenantId?: string;
+  clientId?: string;
 } {
   const taskType = (task.taskType || '').toLowerCase();
   if (taskType.includes('ec2')) {
@@ -282,6 +286,8 @@ function getTaskInfo(task: UserTaskDetail): {
       resourceType: 'Azure VM',
       region: task.discoverAzureVm?.region,
       account: task.discoverAzureVm?.subscription_id,
+      tenantId: task.discoverAzureVm?.tenant_id,
+      clientId: task.discoverAzureVm?.client_id,
     };
   }
   return { resourceType: '', region: undefined, account: undefined };

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -550,6 +550,8 @@ export const integrationService = {
           subscription_id: resp.discoverAzureVm?.subscription_id,
           resource_group: resp.discoverAzureVm?.resource_group,
           region: resp.discoverAzureVm?.region,
+          tenant_id: resp.discoverAzureVm?.tenant_id,
+          client_id: resp.discoverAzureVm?.client_id,
         },
       };
     });

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -794,6 +794,10 @@ export type DiscoverAzureVm = {
   resource_group: string;
   // region is the Azure Region where Teleport failed to enroll VMs.
   region: string;
+  // tenant_id is the Microsoft Entra tenant ID used by the Azure integration.
+  tenant_id?: string;
+  // client_id is the client ID of the Azure integration's managed identity or service principal.
+  client_id?: string;
 };
 
 // DiscoverAzureVmInstance contains the result of enrolling an Azure VM.


### PR DESCRIPTION
Depends on #68814.

Changelog: Include Azure tenant and client IDs in Azure VM discovery subscription failure UserTasks.

## Summary

#68814 surfaces Azure wildcard subscription resolution failures as UserTasks. However, the task currently identifies only the Teleport integration, requiring users to inspect that integration separately to determine which Azure identity needs additional permissions.

This PR adds the Azure OIDC integration identity to the UserTask:

- `tenant_id`: the Microsoft Entra tenant used by the integration.
- `client_id`: the managed identity or service principal used by the integration.

These are non-secret identifiers.

The fields are:

- Added to the `DiscoverAzureVM` UserTask payload.
- Populated when creating a subscription resolution failure task.
- Preserved when tasks are merged across Discovery Service replicas or mixed-version deployments.
- Passed through the Web UI adapter.
- Displayed in the UserTask drawer.

If the integration cannot be read, the UserTask is still created without the identity fields.

## Manual Test Plan

### Test Environment

Tested against https://mpmonboarding.cloud.gravitational.io/

Use an Azure OIDC integration with a wildcard Azure VM DiscoveryConfig:

```yaml
subscriptions: ["*"]
```

### Test Cases

- [x] Remove the integration identity’s subscription access.
- [x] Confirm an azure-vm-subscription-list-denied UserTask is created.
- [x] Confirm the task contains the integration’s expected `tenant_id` and `client_id`.
- [x] Confirm Tenant ID and Client ID are displayed in the Web UI task drawer.
<img width="566" height="1077" alt="Screenshot 2026-07-27 at 17 38 18" src="https://github.com/user-attachments/assets/f6c6fbff-b8a8-478f-bcb8-ef58fe9ac3ac" />

- [x] Restore the Azure role assignment and verify discovery recovers after reconciliation.