### PR TITLE
[v18] Fix dbsc app handler and remove aud/sub from claim verification (#68354)

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -450,11 +450,11 @@ func (h *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handler.accessGraphHandler.ServeHTTP(w, r)
 		return
 	}
-	// If the request is either to the fragment authentication endpoint or if the
-	// request has a session cookie or a client cert, forward to
-	// application handlers. If the request is requesting a
-	// FQDN that is not of the proxy, redirect to application launcher.
-	if h.appHandler != nil && (app.HasFragment(r) || app.HasSessionCookie(r) || app.HasClientCert(r) || app.IsHTTPSTunnelConn(r)) {
+	// If the request is either to the fragment authentication endpoint, a DBSC
+	// endpoint, or if the request has a session cookie or a client cert, forward
+	// to application handlers. If the request is requesting a FQDN that is not of
+	// the proxy, redirect to application launcher.
+	if h.appHandler != nil && shouldForwardToAppHandler(r) {
 		h.appHandler.ServeHTTP(w, r)
 		return
 	}
@@ -489,6 +489,14 @@ func (h *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Serve the Web UI.
 	h.handler.ServeHTTP(w, r)
+}
+
+func shouldForwardToAppHandler(r *http.Request) bool {
+	return app.HasFragment(r) ||
+		app.IsDBSCRequest(r) ||
+		app.HasSessionCookie(r) ||
+		app.HasClientCert(r) ||
+		app.IsHTTPSTunnelConn(r)
 }
 
 // SetAccessGraphHandler sets the handler used to serve Access Graph API

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -201,6 +201,48 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+func TestShouldForwardToAppHandler(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		req  *http.Request
+		want bool
+	}{
+		{
+			name: "DBSC refresh without app cookies",
+			req:  httptest.NewRequest(http.MethodPost, "https://app.example.com/x-teleport-dbsc/refresh", nil),
+			want: true,
+		},
+		{
+			name: "DBSC registration without app cookies",
+			req:  httptest.NewRequest(http.MethodPost, "https://app.example.com/x-teleport-dbsc", nil),
+			want: true,
+		},
+		{
+			name: "normal app request without app cookies",
+			req:  httptest.NewRequest(http.MethodGet, "https://app.example.com/", nil),
+			want: false,
+		},
+		{
+			name: "normal app request with app cookie",
+			req: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "https://app.example.com/", nil)
+				req.AddCookie(&http.Cookie{Name: app.CookieName, Value: "session-id"})
+				return req
+			}(),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, shouldForwardToAppHandler(tt.req))
+		})
+	}
+}
+
 //go:embed testdata/no-history-shell.sh
 var noHistoryShellScript []byte
 

--- a/lib/web/app/auth.go
+++ b/lib/web/app/auth.go
@@ -234,12 +234,11 @@ func (h *Handler) completeAppAuthExchange(w http.ResponseWriter, r *http.Request
 		SameSite: http.SameSiteNoneMode,
 	})
 
-	// TODO (avatus) re-enable dbsc after spec change is in https://github.com/gravitational/teleport/pull/68354
 	// Set DBSC registration header to trigger device-bound session credentials.
 	// The browser will generate a key pair and POST to the registration endpoint.
-	// if err := h.setDBSCRegistrationHeader(r.Context(), w, req.CookieValue); err != nil {
-	// 	h.logger.DebugContext(r.Context(), "Failed to set DBSC registration header", "error", err)
-	// }
+	if err := h.setDBSCRegistrationHeader(r.Context(), w, req.CookieValue); err != nil {
+		h.logger.DebugContext(r.Context(), "Failed to set DBSC registration header", "error", err)
+	}
 
 	requiredApps := strings.Split(req.RequiredApps, ",")
 	if len(requiredApps) <= 1 {

--- a/lib/web/app/dbsc.go
+++ b/lib/web/app/dbsc.go
@@ -21,8 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -38,7 +36,7 @@ import (
 
 const (
 	// secureSessionRegistrationHeader is the header that triggers DBSC registration in the browser.
-	secureSessionRegistrationHeader = "Secure-Session-Registration" //nolint:unused // TODO(avatus) re-enable after spec change
+	secureSessionRegistrationHeader = "Secure-Session-Registration"
 	// secureSessionResponseHeader is the header containing the browser's signed JWT.
 	secureSessionResponseHeader = "Secure-Session-Response"
 	// secureSessionIDHeader is the header containing the session ID for refresh requests.
@@ -51,7 +49,18 @@ const (
 	dbscRegistrationPath = "/x-teleport-dbsc"
 	// dbscRefreshPath is the DBSC refresh endpoint.
 	dbscRefreshPath = "/x-teleport-dbsc/refresh"
+	// dbscDisabledEnv is the environment variable that disables DBSC entirely
+	// when set to any non-empty value.
+	dbscDisabledEnv = "TELEPORT_UNSTABLE_DISABLE_DBSC"
 )
+
+// IsDBSCRequest reports whether the request targets one of the DBSC endpoints.
+// DBSC refresh requests intentionally do not carry app cookies, so callers must
+// not rely on cookie presence to route them to the app handler.
+func IsDBSCRequest(r *http.Request) bool {
+	return r.Method == http.MethodPost &&
+		(r.URL.Path == dbscRegistrationPath || r.URL.Path == dbscRefreshPath)
+}
 
 // dbscSessionConfig is the JSON response returned after successful DBSC registration.
 type dbscSessionConfig struct {
@@ -76,6 +85,10 @@ type dbscCredential struct {
 // handleDBSCRegistration handles DBSC registration from the browser.
 // The browser POSTs a signed JWT proving possession of the private key.
 func (h *Handler) handleDBSCRegistration(w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
+	if h.dbscDisabled {
+		return trace.NotFound("DBSC support is disabled")
+	}
+
 	ctx := r.Context()
 
 	cookie, err := r.Cookie(CookieName)
@@ -120,6 +133,10 @@ func (h *Handler) handleDBSCRegistration(w http.ResponseWriter, r *http.Request,
 // 1. Browser POSTs with Secure-Session-Id but no response -> return 403 with challenge
 // 2. Browser POSTs with Secure-Session-Response -> verify and re-issue cookies
 func (h *Handler) handleDBSCRefresh(w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
+	if h.dbscDisabled {
+		return trace.NotFound("DBSC support is disabled")
+	}
+
 	ctx := r.Context()
 
 	sessionID, ok, err := getDBSCHeaderString(r, secureSessionIDHeader)
@@ -154,7 +171,7 @@ func (h *Handler) handleDBSCRefresh(w http.ResponseWriter, r *http.Request, p ht
 		return nil
 	}
 
-	if err := h.verifyDBSCRefreshResponse(ctx, responseJWT, sessionID, dbscRequestURL(r), storedPublicKey); err != nil {
+	if err := h.verifyDBSCRefreshResponse(ctx, responseJWT, sessionID, storedPublicKey); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -195,7 +212,7 @@ func (h *Handler) writeDBSCSessionConfig(w http.ResponseWriter, sessionID string
 }
 
 // verifyDBSCRefreshResponse verifies the browser's DBSC refresh JWT using the stored public key.
-func (h *Handler) verifyDBSCRefreshResponse(ctx context.Context, rawJWT string, sessionID string, audience string, storedPublicKey []byte) error {
+func (h *Handler) verifyDBSCRefreshResponse(ctx context.Context, rawJWT string, sessionID string, storedPublicKey []byte) error {
 	var jwk jose.JSONWebKey
 	if err := json.Unmarshal(storedPublicKey, &jwk); err != nil {
 		return trace.Wrap(err, "parsing stored DBSC public key")
@@ -208,40 +225,13 @@ func (h *Handler) verifyDBSCRefreshResponse(ctx context.Context, rawJWT string, 
 	if claims.ID == "" {
 		return trace.BadParameter("missing jti claim (challenge) in DBSC refresh")
 	}
-	if len(claims.Audience) == 0 {
-		return trace.BadParameter("missing aud claim in DBSC refresh")
-	}
-	if claims.Subject == "" {
-		return trace.BadParameter("missing sub claim in DBSC refresh")
-	}
-	if claims.Subject != sessionID {
-		return trace.BadParameter("invalid sub claim %q in DBSC refresh", claims.Subject)
-	}
-	validAudience := slices.Contains(claims.Audience, audience)
-	if !validAudience {
-		return trace.BadParameter("invalid aud claim %q in DBSC refresh", []string(claims.Audience))
-	}
 
+	// The DBSC proof is bound to the app session by the signed challenge in jti.
 	if err := h.verifyDBSCChallenge(ctx, claims.ID, sessionID); err != nil {
 		return trace.Wrap(err, "verifying DBSC challenge")
 	}
 
 	return nil
-}
-
-func dbscRequestURL(r *http.Request) string {
-	host := r.Host
-	if host == "" {
-		host = r.URL.Host
-	}
-
-	return (&url.URL{
-		Scheme:   "https",
-		Host:     host,
-		Path:     r.URL.Path,
-		RawPath:  r.URL.RawPath,
-		RawQuery: r.URL.RawQuery,
-	}).String()
 }
 
 // verifyDBSCChallenge verifies that the challenge was signed by this cluster.
@@ -265,9 +255,11 @@ func (h *Handler) verifyDBSCChallenge(ctx context.Context, challenge string, ses
 
 // setDBSCRegistrationHeader sets the Secure-Session-Registration header to trigger
 // DBSC registration in the browser.
-//
-//nolint:unused // TODO(avatus) re-enable after spec change
 func (h *Handler) setDBSCRegistrationHeader(ctx context.Context, w http.ResponseWriter, sessionID string) error {
+	if h.dbscDisabled {
+		return nil
+	}
+
 	challenge, err := h.c.AuthClient.SignDBSCChallenge(ctx, sessionID)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -110,6 +110,10 @@ type Handler struct {
 	// upgrade, configured via TELEPORT_UNSTABLE_APP_CSWSH_ACTION. Defaults to
 	// no-op.
 	cswshAction cswshAction
+
+	// dbscDisabled disables all DBSC handling, configured via
+	// TELEPORT_UNSTABLE_DISABLE_DBSC.
+	dbscDisabled bool
 }
 
 // NewHandler returns a new application handler.
@@ -124,10 +128,14 @@ func NewHandler(ctx context.Context, c *HandlerConfig) (*Handler, error) {
 		closeContext: ctx,
 		logger:       slog.With(teleport.ComponentKey, teleport.ComponentAppProxy),
 		cswshAction:  parseCSWSHAction(os.Getenv(cswshActionEnv)),
+		dbscDisabled: os.Getenv(dbscDisabledEnv) != "",
 	}
 	if h.cswshAction.enabled() {
 		h.logger.InfoContext(ctx, "Application access cross-site WebSocket (CSWSH) guard enabled",
 			"report", h.cswshAction.report, "block", h.cswshAction.block)
+	}
+	if h.dbscDisabled {
+		h.logger.InfoContext(ctx, "Application access DBSC support disabled via TELEPORT_UNSTABLE_DISABLE_DBSC")
 	}
 
 	// Create a new session cache, this holds sessions that can be used to

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -1127,50 +1127,8 @@ func TestDBSCRefresh(t *testing.T) {
 	challenge, err := strconv.Unquote(challengeValue)
 	require.NoError(t, err)
 
-	refreshAudience := (&url.URL{
-		Scheme: p.serverURL.Scheme,
-		Host:   p.serverURL.Host,
-		Path:   dbscRefreshPath,
-	}).String()
-	registrationAudience := (&url.URL{
-		Scheme: p.serverURL.Scheme,
-		Host:   p.serverURL.Host,
-		Path:   dbscRegistrationPath,
-	}).String()
-
-	registrationProofJWT, err := makeDBSCProofJWT(deviceKey, dbscProofJWTParams{
-		challenge: challenge,
-		audience:  registrationAudience,
-	})
-	require.NoError(t, err)
-	headers[secureSessionResponseHeader] = registrationProofJWT
-	status, _, _ = p.makeRequestWithHeaders(t, http.MethodPost, dbscRefreshPath, nil, nil, headers)
-	require.Equal(t, http.StatusBadRequest, status)
-
-	wrongAudienceProofJWT, err := makeDBSCProofJWT(deviceKey, dbscProofJWTParams{
-		challenge: challenge,
-		audience:  registrationAudience,
-		sessionID: session.GetName(),
-	})
-	require.NoError(t, err)
-	headers[secureSessionResponseHeader] = wrongAudienceProofJWT
-	status, _, _ = p.makeRequestWithHeaders(t, http.MethodPost, dbscRefreshPath, nil, nil, headers)
-	require.Equal(t, http.StatusBadRequest, status)
-
-	wrongSubjectProofJWT, err := makeDBSCProofJWT(deviceKey, dbscProofJWTParams{
-		challenge: challenge,
-		audience:  refreshAudience,
-		sessionID: "other-session",
-	})
-	require.NoError(t, err)
-	headers[secureSessionResponseHeader] = wrongSubjectProofJWT
-	status, _, _ = p.makeRequestWithHeaders(t, http.MethodPost, dbscRefreshPath, nil, nil, headers)
-	require.Equal(t, http.StatusBadRequest, status)
-
 	proofJWT, err := makeDBSCProofJWT(deviceKey, dbscProofJWTParams{
 		challenge: challenge,
-		audience:  refreshAudience,
-		sessionID: session.GetName(),
 	})
 	require.NoError(t, err)
 
@@ -1223,18 +1181,11 @@ func TestDBSCRegistration(t *testing.T) {
 	}
 	p := setup(t, fakeClock, authClient, nil)
 
-	registrationAudience := (&url.URL{
-		Scheme: p.serverURL.Scheme,
-		Host:   p.serverURL.Host,
-		Path:   dbscRegistrationPath,
-	}).String()
-
 	challenge, err := authClient.SignDBSCChallenge(t.Context(), session.GetName())
 	require.NoError(t, err)
 
 	proofJWT, err := makeDBSCProofJWT(deviceKey, dbscProofJWTParams{
 		challenge: challenge,
-		audience:  registrationAudience,
 		sessionID: session.GetName(),
 	})
 	require.NoError(t, err)
@@ -1291,9 +1242,77 @@ func TestDBSCRegistration(t *testing.T) {
 	})
 }
 
+func TestDBSCDisabled(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_DISABLE_DBSC", "1")
+
+	fakeClock := clockwork.NewFakeClock()
+	clusterName := "test-cluster"
+	publicAddr := "app.example.com"
+
+	tlsCAKey, tlsCACert, err := tlsca.GenerateSelfSignedCA(
+		pkix.Name{CommonName: clusterName},
+		[]string{publicAddr, apiutils.EncodeClusterName(clusterName)},
+		defaults.CATTL,
+	)
+	require.NoError(t, err)
+
+	session := createAppSession(t, fakeClock, tlsCAKey, tlsCACert, clusterName, publicAddr, "testapp")
+	deviceKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+	deviceJWK := jose.JSONWebKey{Key: deviceKey.Public()}
+	deviceJWKJSON, err := deviceJWK.Public().MarshalJSON()
+	require.NoError(t, err)
+	session.SetDBSCPublicKey(deviceJWKJSON)
+
+	jwtSigner, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+
+	authClient := &mockAuthClient{
+		clusterName: clusterName,
+		appSession:  session,
+		jwtSigner:   jwtSigner,
+	}
+	p := setup(t, fakeClock, authClient, nil)
+
+	t.Run("registration returns not found", func(t *testing.T) {
+		cookies := []http.Cookie{
+			{Name: CookieName, Value: session.GetName()},
+			{Name: SubjectCookieName, Value: session.GetBearerToken()},
+		}
+		headers := map[string]string{
+			secureSessionResponseHeader: "proof",
+		}
+		status, _, _ := p.makeRequestWithHeaders(t, http.MethodPost, dbscRegistrationPath, nil, cookies, headers)
+		require.Equal(t, http.StatusNotFound, status)
+	})
+
+	t.Run("refresh returns not found", func(t *testing.T) {
+		headers := map[string]string{
+			secureSessionIDHeader: session.GetName(),
+		}
+		status, _, responseHeaders := p.makeRequestWithHeaders(t, http.MethodPost, dbscRefreshPath, nil, nil, headers)
+		require.Equal(t, http.StatusNotFound, status)
+		require.Empty(t, responseHeaders.Get(secureSessionChallengeHeader))
+	})
+
+	t.Run("registration header not set", func(t *testing.T) {
+		handler, err := NewHandler(t.Context(), &HandlerConfig{
+			Clock:                 fakeClock,
+			AuthClient:            authClient,
+			AccessPoint:           authClient,
+			CipherSuites:          utils.DefaultCipherSuites(),
+			IntegrationAppHandler: &mockIntegrationAppHandler{},
+		})
+		require.NoError(t, err)
+
+		rec := httptest.NewRecorder()
+		require.NoError(t, handler.setDBSCRegistrationHeader(t.Context(), rec, session.GetName()))
+		require.Empty(t, rec.Header().Get(secureSessionRegistrationHeader))
+	})
+}
+
 type dbscProofJWTParams struct {
 	challenge string
-	audience  string
 	sessionID string
 }
 
@@ -1312,9 +1331,8 @@ func makeDBSCProofJWT(deviceKey crypto.Signer, params dbscProofJWTParams) (strin
 		Key jose.JSONWebKey `json:"key"`
 	}{
 		Claims: josejwt.Claims{
-			Audience: josejwt.Audience{params.audience},
-			ID:       params.challenge,
-			Subject:  params.sessionID,
+			ID:      params.challenge,
+			Subject: params.sessionID,
 		},
 		Key: jwk.Public(),
 	}).CompactSerialize()


### PR DESCRIPTION
Backport #68354 

## Manual Test Plan
### Test Environment
local and cloud

### Test Cases
- [x] (using 10 minutes as arbitrary time, but tested with 10 minutes and 30 seconds) Start an app session and check Dev Tools -> Application -> Device Bound Sessions and ensure that a session has been created for the app session.
- [x] Wait 9 minutes and refresh the page (do not click launch again, just refresh the app). notice that the session has been extended and no reauth has happened.
- [x] Wait 10 minutes and refresh the page. Same checks as above
- [x] Wait 11 minutes and refresh the page. Same checks as above

These can all be done in any order and the outcome should be intuitive. The user should have no visible reauthing happen during credential refresh (it does not show in the browser network tab either, but you can see the session updated in the dev tools).


Changelog: Fixed an issue where some DBSC sessions would timeout after 10 minutes. 