### PR TITLE
[v18] Record node name on early join rejection audit events

### DIFF
--- a/api/gen/proto/go/teleport/join/v1/joinservice_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/join/v1/joinservice_protohybrid.pb.go
@@ -114,8 +114,13 @@ type ClientInit struct {
 	// accepting ProxySuppliedParams.
 	ForwardedByProxy        bool                            `protobuf:"varint,4,opt,name=forwarded_by_proxy,json=forwardedByProxy,proto3" json:"forwarded_by_proxy,omitempty"`
 	ProxySuppliedParameters *ClientInit_ProxySuppliedParams `protobuf:"bytes,5,opt,name=proxy_supplied_parameters,json=proxySuppliedParameters,proto3,oneof" json:"proxy_supplied_parameters,omitempty"`
-	unknownFields           protoimpl.UnknownFields
-	sizeCache               protoimpl.SizeCache
+	// HostName is the user-friendly node name of a joining host, sent early so it
+	// can be recorded on the join audit event even when the join is rejected
+	// before the host params are received. It is advisory; the host name used for
+	// issued certificates is carried in HostParams.
+	HostName      string `protobuf:"bytes,6,opt,name=host_name,json=hostName,proto3" json:"host_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ClientInit) Reset() {
@@ -178,6 +183,13 @@ func (x *ClientInit) GetProxySuppliedParameters() *ClientInit_ProxySuppliedParam
 	return nil
 }
 
+func (x *ClientInit) GetHostName() string {
+	if x != nil {
+		return x.HostName
+	}
+	return ""
+}
+
 func (x *ClientInit) SetJoinMethod(v string) {
 	x.JoinMethod = &v
 }
@@ -196,6 +208,10 @@ func (x *ClientInit) SetForwardedByProxy(v bool) {
 
 func (x *ClientInit) SetProxySuppliedParameters(v *ClientInit_ProxySuppliedParams) {
 	x.ProxySuppliedParameters = v
+}
+
+func (x *ClientInit) SetHostName(v string) {
+	x.HostName = v
 }
 
 func (x *ClientInit) HasJoinMethod() bool {
@@ -240,6 +256,11 @@ type ClientInit_builder struct {
 	// accepting ProxySuppliedParams.
 	ForwardedByProxy        bool
 	ProxySuppliedParameters *ClientInit_ProxySuppliedParams
+	// HostName is the user-friendly node name of a joining host, sent early so it
+	// can be recorded on the join audit event even when the join is rejected
+	// before the host params are received. It is advisory; the host name used for
+	// issued certificates is carried in HostParams.
+	HostName string
 }
 
 func (b0 ClientInit_builder) Build() *ClientInit {
@@ -251,6 +272,7 @@ func (b0 ClientInit_builder) Build() *ClientInit {
 	x.SystemRole = b.SystemRole
 	x.ForwardedByProxy = b.ForwardedByProxy
 	x.ProxySuppliedParameters = b.ProxySuppliedParameters
+	x.HostName = b.HostName
 	return m0
 }
 
@@ -5076,7 +5098,7 @@ var File_teleport_join_v1_joinservice_proto protoreflect.FileDescriptor
 
 const file_teleport_join_v1_joinservice_proto_rawDesc = "" +
 	"\n" +
-	"\"teleport/join/v1/joinservice.proto\x12\x10teleport.join.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&teleport/scopes/joining/v1/token.proto\"\xa0\x03\n" +
+	"\"teleport/join/v1/joinservice.proto\x12\x10teleport.join.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&teleport/scopes/joining/v1/token.proto\"\xbd\x03\n" +
 	"\n" +
 	"ClientInit\x12$\n" +
 	"\vjoin_method\x18\x01 \x01(\tH\x00R\n" +
@@ -5086,7 +5108,8 @@ const file_teleport_join_v1_joinservice_proto_rawDesc = "" +
 	"\vsystem_role\x18\x03 \x01(\tR\n" +
 	"systemRole\x12,\n" +
 	"\x12forwarded_by_proxy\x18\x04 \x01(\bR\x10forwardedByProxy\x12q\n" +
-	"\x19proxy_supplied_parameters\x18\x05 \x01(\v20.teleport.join.v1.ClientInit.ProxySuppliedParamsH\x01R\x17proxySuppliedParameters\x88\x01\x01\x1a]\n" +
+	"\x19proxy_supplied_parameters\x18\x05 \x01(\v20.teleport.join.v1.ClientInit.ProxySuppliedParamsH\x01R\x17proxySuppliedParameters\x88\x01\x01\x12\x1b\n" +
+	"\thost_name\x18\x06 \x01(\tR\bhostName\x1a]\n" +
 	"\x13ProxySuppliedParams\x12\x1f\n" +
 	"\vremote_addr\x18\x01 \x01(\tR\n" +
 	"remoteAddr\x12%\n" +

--- a/api/gen/proto/go/teleport/join/v1/joinservice_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/join/v1/joinservice_protoopaque.pb.go
@@ -102,6 +102,7 @@ type ClientInit struct {
 	xxx_hidden_SystemRole              string                          `protobuf:"bytes,3,opt,name=system_role,json=systemRole,proto3"`
 	xxx_hidden_ForwardedByProxy        bool                            `protobuf:"varint,4,opt,name=forwarded_by_proxy,json=forwardedByProxy,proto3"`
 	xxx_hidden_ProxySuppliedParameters *ClientInit_ProxySuppliedParams `protobuf:"bytes,5,opt,name=proxy_supplied_parameters,json=proxySuppliedParameters,proto3,oneof"`
+	xxx_hidden_HostName                string                          `protobuf:"bytes,6,opt,name=host_name,json=hostName,proto3"`
 	XXX_raceDetectHookData             protoimpl.RaceDetectHookData
 	XXX_presence                       [1]uint32
 	unknownFields                      protoimpl.UnknownFields
@@ -171,9 +172,16 @@ func (x *ClientInit) GetProxySuppliedParameters() *ClientInit_ProxySuppliedParam
 	return nil
 }
 
+func (x *ClientInit) GetHostName() string {
+	if x != nil {
+		return x.xxx_hidden_HostName
+	}
+	return ""
+}
+
 func (x *ClientInit) SetJoinMethod(v string) {
 	x.xxx_hidden_JoinMethod = &v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 5)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 6)
 }
 
 func (x *ClientInit) SetTokenName(v string) {
@@ -190,6 +198,10 @@ func (x *ClientInit) SetForwardedByProxy(v bool) {
 
 func (x *ClientInit) SetProxySuppliedParameters(v *ClientInit_ProxySuppliedParams) {
 	x.xxx_hidden_ProxySuppliedParameters = v
+}
+
+func (x *ClientInit) SetHostName(v string) {
+	x.xxx_hidden_HostName = v
 }
 
 func (x *ClientInit) HasJoinMethod() bool {
@@ -235,6 +247,11 @@ type ClientInit_builder struct {
 	// accepting ProxySuppliedParams.
 	ForwardedByProxy        bool
 	ProxySuppliedParameters *ClientInit_ProxySuppliedParams
+	// HostName is the user-friendly node name of a joining host, sent early so it
+	// can be recorded on the join audit event even when the join is rejected
+	// before the host params are received. It is advisory; the host name used for
+	// issued certificates is carried in HostParams.
+	HostName string
 }
 
 func (b0 ClientInit_builder) Build() *ClientInit {
@@ -242,13 +259,14 @@ func (b0 ClientInit_builder) Build() *ClientInit {
 	b, x := &b0, m0
 	_, _ = b, x
 	if b.JoinMethod != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 5)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 6)
 		x.xxx_hidden_JoinMethod = b.JoinMethod
 	}
 	x.xxx_hidden_TokenName = b.TokenName
 	x.xxx_hidden_SystemRole = b.SystemRole
 	x.xxx_hidden_ForwardedByProxy = b.ForwardedByProxy
 	x.xxx_hidden_ProxySuppliedParameters = b.ProxySuppliedParameters
+	x.xxx_hidden_HostName = b.HostName
 	return m0
 }
 
@@ -4877,7 +4895,7 @@ var File_teleport_join_v1_joinservice_proto protoreflect.FileDescriptor
 
 const file_teleport_join_v1_joinservice_proto_rawDesc = "" +
 	"\n" +
-	"\"teleport/join/v1/joinservice.proto\x12\x10teleport.join.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&teleport/scopes/joining/v1/token.proto\"\xa0\x03\n" +
+	"\"teleport/join/v1/joinservice.proto\x12\x10teleport.join.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&teleport/scopes/joining/v1/token.proto\"\xbd\x03\n" +
 	"\n" +
 	"ClientInit\x12$\n" +
 	"\vjoin_method\x18\x01 \x01(\tH\x00R\n" +
@@ -4887,7 +4905,8 @@ const file_teleport_join_v1_joinservice_proto_rawDesc = "" +
 	"\vsystem_role\x18\x03 \x01(\tR\n" +
 	"systemRole\x12,\n" +
 	"\x12forwarded_by_proxy\x18\x04 \x01(\bR\x10forwardedByProxy\x12q\n" +
-	"\x19proxy_supplied_parameters\x18\x05 \x01(\v20.teleport.join.v1.ClientInit.ProxySuppliedParamsH\x01R\x17proxySuppliedParameters\x88\x01\x01\x1a]\n" +
+	"\x19proxy_supplied_parameters\x18\x05 \x01(\v20.teleport.join.v1.ClientInit.ProxySuppliedParamsH\x01R\x17proxySuppliedParameters\x88\x01\x01\x12\x1b\n" +
+	"\thost_name\x18\x06 \x01(\tR\bhostName\x1a]\n" +
 	"\x13ProxySuppliedParams\x12\x1f\n" +
 	"\vremote_addr\x18\x01 \x01(\tR\n" +
 	"remoteAddr\x12%\n" +

--- a/api/proto/teleport/join/v1/joinservice.proto
+++ b/api/proto/teleport/join/v1/joinservice.proto
@@ -52,6 +52,12 @@ message ClientInit {
     string client_version = 2;
   }
   optional ProxySuppliedParams proxy_supplied_parameters = 5;
+
+  // HostName is the user-friendly node name of a joining host, sent early so it
+  // can be recorded on the join audit event even when the join is rejected
+  // before the host params are received. It is advisory; the host name used for
+  // issued certificates is carried in HostParams.
+  string host_name = 6;
 }
 
 // PublicKeys holds public keys sent by the client requested subject keys for

--- a/lib/join/internal/messages/messages.go
+++ b/lib/join/internal/messages/messages.go
@@ -65,6 +65,11 @@ type ClientInit struct {
 	// nodes join via the proxy address. They must only be trusted if the
 	// incoming join request is authenticated as the Proxy.
 	ProxySuppliedParams *ProxySuppliedParams
+	// HostName is the user-friendly node name of a joining host, sent early so it
+	// can be recorded on the join audit event even when the join is rejected
+	// before the host params are received. It is advisory; the host name used for
+	// issued certificates is carried in HostParams.
+	HostName string
 }
 
 func (i *ClientInit) Check() error {

--- a/lib/join/join_test.go
+++ b/lib/join/join_test.go
@@ -172,7 +172,8 @@ func TestJoinToken(t *testing.T) {
 					ConnectionMetadata: apievents.ConnectionMetadata{
 						RemoteAddr: "127.0.0.1",
 					},
-					Role: "Instance",
+					Role:     "Instance",
+					NodeName: "node",
 				},
 				evt,
 				protocmp.Transform(),
@@ -385,9 +386,10 @@ func TestJoinToken(t *testing.T) {
 					ConnectionMetadata: apievents.ConnectionMetadata{
 						RemoteAddr: "127.0.0.1",
 					},
-					HostID: identity.ID.HostID(),
-					Role:   "Instance",
-					Roles:  slices.DeleteFunc(token1.GetRoles().StringSlice(), func(role string) bool { return role == types.RoleInstance.String() }),
+					HostID:   identity.ID.HostID(),
+					Role:     "Instance",
+					NodeName: "node",
+					Roles:    slices.DeleteFunc(token1.GetRoles().StringSlice(), func(role string) bool { return role == types.RoleInstance.String() }),
 				},
 				evt,
 				protocmp.Transform(),
@@ -553,6 +555,53 @@ func TestJoinToken(t *testing.T) {
 			tc.assertRejoinExpectation(t, newIdentity, err)
 		})
 	}
+
+	t.Run("rejected join records sanitized node name", func(t *testing.T) {
+		ctx := t.Context()
+		// The join is rejected before host params are received, so the node name
+		// on the audit event comes from the advisory (untrusted) ClientInit
+		// value and must be sanitized. \x00 is stripped to '_'.
+		_, err := joinclient.Join(ctx, joinclient.JoinParams{
+			Token: "invalidtoken",
+			ID: state.IdentityID{
+				Role:     types.RoleInstance,
+				NodeName: "node\x00name",
+			},
+			ProxyServer: utils.NetAddr{
+				AddrNetwork: proxyListener.Addr().Network(),
+				Addr:        proxyListener.Addr().String(),
+			},
+			// The proxy's TLS cert for the test is not trusted.
+			Insecure: true,
+		})
+		require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			evt, err := authService.lastEvent(ctx, "instance.join")
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(
+				&apievents.InstanceJoin{
+					Metadata: apievents.Metadata{
+						Type: "instance.join",
+						Code: events.InstanceJoinFailureCode,
+					},
+					Status: apievents.Status{
+						Success: false,
+						Error:   "token expired or not found",
+					},
+					ConnectionMetadata: apievents.ConnectionMetadata{
+						RemoteAddr: "127.0.0.1",
+					},
+					Role:     "Instance",
+					NodeName: "node_name",
+				},
+				evt,
+				protocmp.Transform(),
+				cmpopts.IgnoreMapEntries(func(key string, val any) bool {
+					return key == "Time" || key == "ID"
+				}),
+			))
+		}, 15*time.Second, 100*time.Millisecond, "expected instance.join failed event not found")
+	})
 }
 
 // TestJoinError asserts that attempts to join with an invalid token return an

--- a/lib/join/joinclient/join.go
+++ b/lib/join/joinclient/join.go
@@ -282,11 +282,12 @@ func joinWithClient(ctx context.Context, params JoinParams, client *joinv1.Clien
 	defer stream.CloseSend()
 
 	// Send the ClientInit message with the intended join method, token name,
-	// and system role.
+	// system role, and host name.
 	if err := stream.Send(&messages.ClientInit{
 		JoinMethod: joinMethodPtr,
 		TokenName:  params.Token,
 		SystemRole: params.ID.Role.String(),
+		HostName:   params.ID.NodeName,
 	}); err != nil {
 		// Failing to send the first message on the stream is always a connection error.
 		return nil, &connectionError{trace.Wrap(err, "sending ClientInit message")}

--- a/lib/join/joinv1/messages.go
+++ b/lib/join/joinv1/messages.go
@@ -176,6 +176,7 @@ func clientInitToMessage(req *joinv1.ClientInit) *messages.ClientInit {
 		TokenName:        req.GetTokenName(),
 		SystemRole:       req.GetSystemRole(),
 		ForwardedByProxy: req.GetForwardedByProxy(),
+		HostName:         req.GetHostName(),
 	}
 	if joinMethod := req.GetJoinMethod(); joinMethod != "" {
 		msg.JoinMethod = &joinMethod
@@ -195,6 +196,7 @@ func clientInitFromMessage(msg *messages.ClientInit) *joinv1.ClientInit {
 		TokenName:        msg.TokenName,
 		SystemRole:       msg.SystemRole,
 		ForwardedByProxy: msg.ForwardedByProxy,
+		HostName:         msg.HostName,
 	}
 	if proxySuppliedParams := msg.ProxySuppliedParams; proxySuppliedParams != nil {
 		req.ProxySuppliedParameters = &joinv1.ClientInit_ProxySuppliedParams{

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -267,6 +267,12 @@ func (s *Server) Join(stream messages.ServerStream) (err error) {
 		if clientInit.JoinMethod != nil {
 			i.RequestedJoinMethod = joinutils.SanitizeUntrustedString(*clientInit.JoinMethod)
 		}
+		if clientInit.HostName != "" {
+			// Sanitizing won't prevent an invalid hostname from being used
+			// but we don't care about that because the ClientInit.HostName
+			// is only used for diagnostic purposes.
+			i.NodeName = joinutils.SanitizeUntrustedString(clientInit.HostName)
+		}
 	})
 	if err := clientInit.Check(); err != nil {
 		return trace.Wrap(err, "validating ClientInit message")


### PR DESCRIPTION
Backport #68787 to branch/v18

Changelog: Rejected host join attempts now include the node name in the instance.join audit event, making rejected instances easier to identify.

## Manual Test Plan
### Test Environment
Cloud tenant, plus a joining node and tbot.

### Test Cases
- [x] Node join with a bad token records the node name on the `instance.join` failure event
- [x] Successful node join records the node name
- [x] Bot join is unaffected (joins, normal `bot.join` event, no node name)