### PR TITLE
Add `tctl detections triage|resolve|close` commands to update Identity Security Alerts

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -1402,6 +1402,29 @@ Flags:
 |`--format`|`text`|Output format, 'text', 'json' or 'yaml'|
 |`-v`, `--[no-]verbose`|`false`|Verbose table output, shows full label output|
 
+## tctl detections close
+
+Mark a detection as closed.
+
+Usage:
+
+```code
+$ tctl detections close [<flags>] <id>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--[no-]allow-empty`|`false`|Change the status without a reason instead of prompting for one.|
+|`-r`, `--reason`|*no default*|Reason for the status change. If omitted, an editor is opened to collect one.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|id|*no default* (required)|The detection ID to update.|
+
 ## tctl detections get
 
 Get Identity Security detection details.
@@ -1417,8 +1440,6 @@ Flags:
 |Flag|Default|Description|
 |---|---|---|
 |`--format`|`text` (one of: `text`, `json`, `yaml`)|Output format. (Values: text, json, yaml)|
-|`--from`|`30d`|Include activity at or after this time. (Examples: 2006-01-02T15:04:05Z07:00, 2006-01-02, 24h, 7d; negative durations like -1h are future-relative. Default: 30d)|
-|`--to`|`now`|Include activity at or before this time. (Examples: 2006-01-02T15:04:05Z07:00, 2006-01-02, 24h, 7d; negative durations like -1h are future-relative. Default: now)|
 
 Arguments:
 
@@ -1449,6 +1470,52 @@ Flags:
 |`--status`|`in_progress`,`triaged` (any of (repeatable): `in_progress`, `triaged`, `resolved`, `closed`)|Filter detections by status (Values: in_progress, triaged, resolved, closed). Default: in_progress, triaged.|
 |`--to`|`now`|Include activity at or before this time. (Examples: 2006-01-02T15:04:05Z07:00, 2006-01-02, 24h, 7d; negative durations like -1h are future-relative. Default: now)|
 |`--type`|*no default*|Filter detections by type.|
+
+## tctl detections resolve
+
+Mark a detection as resolved.
+
+Usage:
+
+```code
+$ tctl detections resolve [<flags>] <id>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--[no-]allow-empty`|`false`|Change the status without a reason instead of prompting for one.|
+|`-r`, `--reason`|*no default*|Reason for the status change. If omitted, an editor is opened to collect one.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|id|*no default* (required)|The detection ID to update.|
+
+## tctl detections triage
+
+Mark a detection as triaged.
+
+Usage:
+
+```code
+$ tctl detections triage [<flags>] <id>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--[no-]allow-empty`|`false`|Change the status without a reason instead of prompting for one.|
+|`-r`, `--reason`|*no default*|Reason for the status change. If omitted, an editor is opened to collect one.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|id|*no default* (required)|The detection ID to update.|
 
 ## tctl devices add
 

--- a/tool/tctl/common/accessgraph/command.go
+++ b/tool/tctl/common/accessgraph/command.go
@@ -76,6 +76,12 @@ func (c *AccessGraphCommand) TryRun(ctx context.Context, cmd string, clientFunc 
 		commandFunc = c.DetectionsList
 	case c.detections.get.cmd.FullCommand():
 		commandFunc = c.DetectionsGet
+	case c.detections.triage.cmd.FullCommand():
+		commandFunc = c.DetectionsTriage
+	case c.detections.resolve.cmd.FullCommand():
+		commandFunc = c.DetectionsResolve
+	case c.detections.close.cmd.FullCommand():
+		commandFunc = c.DetectionsClose
 	case c.investigate.cmd.FullCommand():
 		commandFunc = c.Investigate
 	case c.accessChanges.ls.cmd.FullCommand():

--- a/tool/tctl/common/accessgraph/detections_command.go
+++ b/tool/tctl/common/accessgraph/detections_command.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"strings"
 	"time"
 
@@ -30,12 +31,14 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
+	"golang.org/x/term"
 
 	"github.com/gravitational/teleport"
 	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
 	logmodels "github.com/gravitational/teleport/lib/accessgraph/apiclient/models/logs"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/tool/tctl/common/editor"
 )
 
 // descriptionTextMaxLen caps Description in the detailed text table so a long
@@ -47,16 +50,22 @@ type detectionsArgs struct {
 	ls  detectionsListArgs
 	get detectionsGetArgs
 
-	// Date filters
-	from time.Time
-	to   time.Time
+	// Status-change subcommands, one per lifecycle verb.
+	triage  detectionSetStatusArgs
+	resolve detectionSetStatusArgs
+	close   detectionSetStatusArgs
 
-	// Output format
-	format string
+	// editor is used by tests to inject the editing mechanism so that
+	// different scenarios can be asserted.
+	editor func(ctx context.Context, filename string) error
 }
 
 type detectionsListArgs struct {
 	cmd *kingpin.CmdClause
+
+	// Date filters
+	from time.Time
+	to   time.Time
 
 	// General filters
 	status   []string
@@ -69,28 +78,36 @@ type detectionsListArgs struct {
 
 	// detailed expands the ls command to carry extra columns
 	detailed bool
+
+	// Output format
+	format string
 }
 
+// Output and time-window flags are declared per subcommand rather than on the
+// `detections` parent so the status verbs don't advertise options they ignore.
 func (c *AccessGraphCommand) initDetections(app *kingpin.Application) {
 	detectionsCmd := app.Command("detections", "Investigate security detections and anomalies.")
-	detectionsCmd.Flag("from", fmt.Sprintf("Include activity at or after this time. (Examples: %s, %s, 24h, 7d; negative durations like -1h are future-relative. Default: 30d)", time.RFC3339, time.DateOnly)).
-		Default("30d").
-		SetValue(timeValue{target: &c.detections.from})
-	detectionsCmd.Flag("to", fmt.Sprintf("Include activity at or before this time. (Examples: %s, %s, 24h, 7d; negative durations like -1h are future-relative. Default: now)", time.RFC3339, time.DateOnly)).
-		Default("now").
-		SetValue(timeValue{target: &c.detections.to})
-	detectionsCmd.Flag("format", "Output format. (Values: text, json, yaml)").
-		Default(teleport.Text).
-		EnumVar(&c.detections.format, teleport.Text, teleport.JSON, teleport.YAML)
 	c.detections.cmd = detectionsCmd
 
-	c.initDetectionsList(c.detections.cmd)
-	c.initDetectionsGet(c.detections.cmd)
+	c.initDetectionsList(detectionsCmd)
+	c.initDetectionsGet(detectionsCmd)
+	c.initDetectionsSetStatus(detectionsCmd, "triage", "Mark a detection as triaged.", &c.detections.triage)
+	c.initDetectionsSetStatus(detectionsCmd, "resolve", "Mark a detection as resolved.", &c.detections.resolve)
+	c.initDetectionsSetStatus(detectionsCmd, "close", "Mark a detection as closed.", &c.detections.close)
 }
 
 func (c *AccessGraphCommand) initDetectionsList(parent *kingpin.CmdClause) {
 	lsCmd := parent.Command("ls", "List Identity Security detections.")
 
+	lsCmd.Flag("from", fmt.Sprintf("Include activity at or after this time. (Examples: %s, %s, 24h, 7d; negative durations like -1h are future-relative. Default: 30d)", time.RFC3339, time.DateOnly)).
+		Default("30d").
+		SetValue(timeValue{target: &c.detections.ls.from})
+	lsCmd.Flag("to", fmt.Sprintf("Include activity at or before this time. (Examples: %s, %s, 24h, 7d; negative durations like -1h are future-relative. Default: now)", time.RFC3339, time.DateOnly)).
+		Default("now").
+		SetValue(timeValue{target: &c.detections.ls.to})
+	lsCmd.Flag("format", "Output format. (Values: text, json, yaml)").
+		Default(teleport.Text).
+		EnumVar(&c.detections.ls.format, teleport.Text, teleport.JSON, teleport.YAML)
 	lsCmd.Flag("status", "Filter detections by status (Values: in_progress, triaged, resolved, closed). Default: in_progress, triaged.").
 		AllowDuplicate().
 		Default("in_progress", "triaged").
@@ -114,15 +131,15 @@ func (c *AccessGraphCommand) initDetectionsList(parent *kingpin.CmdClause) {
 
 // DetectionsList executes `tctl detections ls`.
 func (c *AccessGraphCommand) DetectionsList(ctx context.Context, client *accessgraph.ClientWithResponses) error {
-	if err := validateTimeWindow(c.detections.from, c.detections.to); err != nil {
+	if err := validateTimeWindow(c.detections.ls.from, c.detections.ls.to); err != nil {
 		return trace.Wrap(err)
 	}
-	params := constructAlertsListQuery(c.detections)
+	params := constructAlertsListQuery(c.detections.ls)
 	alerts, err := fetchAlerts(ctx, client, params, c.detections.ls.limit)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return displayDetections(c.stdout, alerts, c.detections.format, c.detections.ls.detailed)
+	return displayDetections(c.stdout, alerts, c.detections.ls.format, c.detections.ls.detailed)
 }
 
 // fetchAlerts paginates ListAlertsV1 until limit alerts have been collected or
@@ -162,13 +179,13 @@ func fetchAlerts(
 	}
 }
 
-func constructAlertsListQuery(args detectionsArgs) accessgraph.ListAlertsV1Params {
+func constructAlertsListQuery(args detectionsListArgs) accessgraph.ListAlertsV1Params {
 	var queryParts []string
 	for field, values := range map[string][]string{
-		"status":   args.ls.status,
-		"source":   args.ls.source,
-		"type":     args.ls.typ,
-		"severity": args.ls.severity,
+		"status":   args.status,
+		"source":   args.source,
+		"type":     args.typ,
+		"severity": args.severity,
 	} {
 		if clause := dslClause(field, values); clause != "" {
 			queryParts = append(queryParts, clause)
@@ -293,11 +310,17 @@ func displayDetectionsText(out io.Writer, alerts []accessgraph.SecurityAlert, de
 type detectionsGetArgs struct {
 	cmd *kingpin.CmdClause
 	id  string
+
+	// Output format
+	format string
 }
 
 func (c *AccessGraphCommand) initDetectionsGet(parent *kingpin.CmdClause) {
 	getCmd := parent.Command("get", "Get Identity Security detection details.")
 	getCmd.Arg("id", "The detection ID to retrieve.").Required().StringVar(&c.detections.get.id)
+	getCmd.Flag("format", "Output format. (Values: text, json, yaml)").
+		Default(teleport.Text).
+		EnumVar(&c.detections.get.format, teleport.Text, teleport.JSON, teleport.YAML)
 	c.detections.get.cmd = getCmd
 }
 
@@ -332,7 +355,7 @@ func (c *AccessGraphCommand) DetectionsGet(ctx context.Context, client *accessgr
 	if eventsErr != nil {
 		out.EventsError = eventsErr.Error()
 	}
-	return writeOutput(c.stdout, out, c.detections.format, func(w io.Writer) error {
+	return writeOutput(c.stdout, out, c.detections.get.format, func(w io.Writer) error {
 		return displayDetectionText(w, alert, events, eventsErr)
 	})
 }
@@ -421,4 +444,140 @@ func displayDetectionText(out io.Writer, a accessgraph.SecurityAlert, events []l
 		fmt.Fprintln(out, changes.String())
 	}
 	return nil
+}
+
+// detectionSetStatusArgs backs the triage/resolve/close subcommands.
+type detectionSetStatusArgs struct {
+	cmd        *kingpin.CmdClause
+	id         string
+	reason     string
+	allowEmpty bool
+}
+
+func (c *AccessGraphCommand) initDetectionsSetStatus(parent *kingpin.CmdClause, verb, help string, target *detectionSetStatusArgs) {
+	cmd := parent.Command(verb, help)
+	cmd.Arg("id", "The detection ID to update.").Required().StringVar(&target.id)
+	cmd.Flag("reason", "Reason for the status change. If omitted, an editor is opened to collect one.").
+		Short('r').
+		StringVar(&target.reason)
+	cmd.Flag("allow-empty", "Change the status without a reason instead of prompting for one.").
+		BoolVar(&target.allowEmpty)
+	target.cmd = cmd
+}
+
+// DetectionsTriage executes `tctl detections triage <id>`.
+func (c *AccessGraphCommand) DetectionsTriage(ctx context.Context, client *accessgraph.ClientWithResponses) error {
+	return c.detectionsSetStatus(ctx, client, c.detections.triage, accessgraph.Triaged)
+}
+
+// DetectionsResolve executes `tctl detections resolve <id>`.
+func (c *AccessGraphCommand) DetectionsResolve(ctx context.Context, client *accessgraph.ClientWithResponses) error {
+	return c.detectionsSetStatus(ctx, client, c.detections.resolve, accessgraph.Resolved)
+}
+
+// DetectionsClose executes `tctl detections close <id>`.
+func (c *AccessGraphCommand) DetectionsClose(ctx context.Context, client *accessgraph.ClientWithResponses) error {
+	return c.detectionsSetStatus(ctx, client, c.detections.close, accessgraph.Closed)
+}
+
+// detectionsSetStatus writes status to the detection identified by args.id.
+func (c *AccessGraphCommand) detectionsSetStatus(ctx context.Context, client *accessgraph.ClientWithResponses, args detectionSetStatusArgs, status accessgraph.AlertStatus) error {
+	id, err := uuid.Parse(args.id)
+	if err != nil {
+		return trace.BadParameter("invalid detection id %q: %v", args.id, err)
+	}
+
+	reason, err := c.resolveReason(ctx, args, status)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	body := accessgraph.PutAlertStatusRequest{Status: status}
+	if reason != "" {
+		body.Reason = &reason
+	}
+
+	// UpdateAlertStatusV1Response has no success body; doRequest's status check is the only success signal.
+	if _, err := doRequest(client.UpdateAlertStatusV1WithResponse(ctx, id, body)); err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = fmt.Fprintf(c.stdout, "Detection %s set to %s.\n", id, status)
+	return trace.Wrap(err)
+}
+
+// resolveReason returns the --reason flag, "" when --allow-empty is set, or an interactively collected reason.
+func (c *AccessGraphCommand) resolveReason(ctx context.Context, args detectionSetStatusArgs, status accessgraph.AlertStatus) (string, error) {
+	if reason := strings.TrimSpace(args.reason); reason != "" {
+		return reason, nil
+	}
+	if args.allowEmpty {
+		return "", nil
+	}
+
+	reason, err := c.collectReason(ctx, args.id, status)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	if reason == "" {
+		return "", trace.BadParameter("empty reason, aborting; pass --allow-empty to change the status without one")
+	}
+	return reason, nil
+}
+
+// reasonTemplate seeds the editor buffer, leaving the cursor on a blank first line.
+const reasonTemplate = `
+# Please enter a reason for setting detection %s to %q.
+# Lines starting with '#' are ignored, and an empty reason aborts the change.
+`
+
+// collectReason opens the editor on a seeded temporary file and returns what
+// the user typed, minus the seeded comments.
+func (c *AccessGraphCommand) collectReason(ctx context.Context, id string, status accessgraph.AlertStatus) (string, error) {
+	f, err := os.CreateTemp("", "teleport-detection-reason*.txt")
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	defer os.Remove(f.Name())
+
+	if _, err := fmt.Fprintf(f, reasonTemplate, id, status); err != nil {
+		_ = f.Close()
+		return "", trace.Wrap(err)
+	}
+	if err := f.Close(); err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	if err := c.runReasonEditor(ctx, f.Name()); err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	edited, err := os.ReadFile(f.Name())
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return stripComments(string(edited)), nil
+}
+
+// runReasonEditor opens filename in the user's editor, which requires a terminal.
+func (c *AccessGraphCommand) runReasonEditor(ctx context.Context, filename string) error {
+	if c.detections.editor != nil {
+		return trace.Wrap(c.detections.editor(ctx, filename))
+	}
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return trace.BadParameter("no terminal available to prompt for a reason; pass --reason/-r or --allow-empty")
+	}
+	return trace.Wrap(editor.Run(ctx, filename))
+}
+
+// stripComments drops whole-line '#' comments and trims the result.
+func stripComments(s string) string {
+	var kept []string
+	for line := range strings.SplitSeq(s, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.TrimSpace(strings.Join(kept, "\n"))
 }

--- a/tool/tctl/common/accessgraph/detections_command_test.go
+++ b/tool/tctl/common/accessgraph/detections_command_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -237,9 +238,12 @@ func newDetectionsCommand(t *testing.T, format string) (*AccessGraphCommand, *by
 	c := &AccessGraphCommand{
 		stdout: &buf,
 		detections: detectionsArgs{
-			format: format,
-			from:   fixtureFromArg,
-			to:     fixtureToArg,
+			ls: detectionsListArgs{
+				format: format,
+				from:   fixtureFromArg,
+				to:     fixtureToArg,
+			},
+			get: detectionsGetArgs{format: format},
 		},
 	}
 	return c, &buf
@@ -254,12 +258,11 @@ func TestDetectionsList(t *testing.T) {
 			[]accessgraph.SecurityAlert{alertFixture(t)}, &got, 0, ""))
 
 		c, _ := newDetectionsCommand(t, teleport.JSON)
-		c.detections.ls = detectionsListArgs{
-			status:   []string{"in_progress", "triaged"},
-			source:   []string{"aws"},
-			typ:      []string{"privilege_escalation"},
-			severity: []string{"high", "critical"},
-		}
+		// Set fields individually so the helper's from/to window survives.
+		c.detections.ls.status = []string{"in_progress", "triaged"}
+		c.detections.ls.source = []string{"aws"}
+		c.detections.ls.typ = []string{"privilege_escalation"}
+		c.detections.ls.severity = []string{"high", "critical"}
 		require.NoError(t, c.DetectionsList(context.Background(), ag))
 
 		// The DSL is assembled by ranging over a map, so the AND-joined
@@ -382,9 +385,9 @@ func TestDetectionsList(t *testing.T) {
 func TestDetectionsGet(t *testing.T) {
 	t.Run("invalid uuid returns BadParameter without hitting the server", func(t *testing.T) {
 		// Handler fails on any request — the uuid guard must trip first.
-		var called atomic.Int64
+		var calls atomic.Int64
 		ag := newAccessGraphTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			called.Add(1)
+			calls.Add(1)
 			t.Errorf("server reached despite invalid uuid: %s", r.URL.Path)
 		}))
 
@@ -392,7 +395,7 @@ func TestDetectionsGet(t *testing.T) {
 		c.detections.get.id = "not-a-uuid"
 		err := c.DetectionsGet(context.Background(), ag)
 		require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
-		require.EqualValues(t, 0, called.Load())
+		require.EqualValues(t, 0, calls.Load())
 	})
 
 	t.Run("alert with log entries walks the logs cursor across pages", func(t *testing.T) {
@@ -529,6 +532,203 @@ func TestDetectionsGet(t *testing.T) {
 	})
 }
 
+// updateStatusRequest captures the wire-level PUT that detectionsSetStatus drove.
+type updateStatusRequest struct {
+	method string
+	path   string
+	body   accessgraph.PutAlertStatusRequest
+}
+
+// newUpdateAlertStatusHandler serves the status-update route, recording the
+// inbound request. Pass statusCode != 0 to drive the error paths.
+func newUpdateAlertStatusHandler(t *testing.T, captured *updateStatusRequest, statusCode int, errBody string) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body accessgraph.PutAlertStatusRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		if captured != nil {
+			*captured = updateStatusRequest{method: r.Method, path: r.URL.Path, body: body}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if statusCode != 0 && statusCode != http.StatusOK {
+			w.WriteHeader(statusCode)
+			_, _ = w.Write([]byte(errBody))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestDetectionsSetStatus(t *testing.T) {
+	// The route detectionsSetStatus PUTs to for the fixture id.
+	updateStatusPath := getAlertPath + fixtureAlertID.String() + "/status"
+
+	t.Run("each verb maps to its status and sends the reason", func(t *testing.T) {
+		cases := []struct {
+			verb   string
+			status accessgraph.AlertStatus
+			set    func(c *AccessGraphCommand, args detectionSetStatusArgs)
+			run    func(c *AccessGraphCommand, ctx context.Context, ag *accessgraph.ClientWithResponses) error
+		}{
+			{"triage", accessgraph.Triaged,
+				func(c *AccessGraphCommand, a detectionSetStatusArgs) { c.detections.triage = a },
+				(*AccessGraphCommand).DetectionsTriage},
+			{"resolve", accessgraph.Resolved,
+				func(c *AccessGraphCommand, a detectionSetStatusArgs) { c.detections.resolve = a },
+				(*AccessGraphCommand).DetectionsResolve},
+			{"close", accessgraph.Closed,
+				func(c *AccessGraphCommand, a detectionSetStatusArgs) { c.detections.close = a },
+				(*AccessGraphCommand).DetectionsClose},
+		}
+		for _, tc := range cases {
+			t.Run(tc.verb, func(t *testing.T) {
+				var got updateStatusRequest
+				ag := newAccessGraphTestClient(t, newUpdateAlertStatusHandler(t, &got, 0, ""))
+
+				c, buf := newDetectionsCommand(t, teleport.Text)
+				tc.set(c, detectionSetStatusArgs{id: fixtureAlertID.String(), reason: "looking into it"})
+				require.NoError(t, tc.run(c, context.Background(), ag))
+
+				require.Equal(t, http.MethodPut, got.method)
+				require.Equal(t, updateStatusPath, got.path)
+				require.Equal(t, tc.status, got.body.Status)
+				require.NotNil(t, got.body.Reason)
+				require.Equal(t, "looking into it", *got.body.Reason)
+				require.Equal(t, "Detection "+fixtureAlertID.String()+" set to "+string(tc.status)+".\n", buf.String())
+			})
+		}
+	})
+
+	t.Run("allow-empty omits the reason", func(t *testing.T) {
+		var got updateStatusRequest
+		ag := newAccessGraphTestClient(t, newUpdateAlertStatusHandler(t, &got, 0, ""))
+
+		c, _ := newDetectionsCommand(t, teleport.Text)
+		c.detections.triage = detectionSetStatusArgs{id: fixtureAlertID.String(), allowEmpty: true}
+		require.NoError(t, c.DetectionsTriage(context.Background(), ag))
+
+		require.Equal(t, accessgraph.Triaged, got.body.Status)
+		require.Nil(t, got.body.Reason)
+	})
+
+	t.Run("reason is trimmed and wins over allow-empty", func(t *testing.T) {
+		var got updateStatusRequest
+		ag := newAccessGraphTestClient(t, newUpdateAlertStatusHandler(t, &got, 0, ""))
+
+		c, _ := newDetectionsCommand(t, teleport.Text)
+		c.detections.triage = detectionSetStatusArgs{id: fixtureAlertID.String(), reason: "  spot checked  ", allowEmpty: true}
+		require.NoError(t, c.DetectionsTriage(context.Background(), ag))
+
+		require.NotNil(t, got.body.Reason)
+		require.Equal(t, "spot checked", *got.body.Reason)
+	})
+
+	t.Run("whitespace-only reason is treated as unset", func(t *testing.T) {
+		var got updateStatusRequest
+		ag := newAccessGraphTestClient(t, newUpdateAlertStatusHandler(t, &got, 0, ""))
+
+		c, _ := newDetectionsCommand(t, teleport.Text)
+		c.detections.triage = detectionSetStatusArgs{id: fixtureAlertID.String(), reason: "   ", allowEmpty: true}
+		require.NoError(t, c.DetectionsTriage(context.Background(), ag))
+
+		require.Nil(t, got.body.Reason)
+	})
+
+	t.Run("reason from editor has comments stripped", func(t *testing.T) {
+		var got updateStatusRequest
+		ag := newAccessGraphTestClient(t, newUpdateAlertStatusHandler(t, &got, 0, ""))
+
+		c, _ := newDetectionsCommand(t, teleport.Text)
+		c.detections.resolve = detectionSetStatusArgs{id: fixtureAlertID.String()}
+		// Whole-line comments are dropped; a '#' mid-line is kept.
+		c.detections.editor = func(_ context.Context, filename string) error {
+			return os.WriteFile(filename, []byte("# header comment\nrotated the key for incident #42\n   # indented comment\n"), 0o600)
+		}
+		require.NoError(t, c.DetectionsResolve(context.Background(), ag))
+
+		require.NotNil(t, got.body.Reason)
+		require.Equal(t, "rotated the key for incident #42", *got.body.Reason)
+	})
+
+	t.Run("empty editor reason aborts without a request", func(t *testing.T) {
+		var calls atomic.Int64
+		ag := newAccessGraphTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			t.Errorf("server reached despite empty reason: %s", r.URL.Path)
+		}))
+
+		c, _ := newDetectionsCommand(t, teleport.Text)
+		c.detections.close = detectionSetStatusArgs{id: fixtureAlertID.String()}
+		c.detections.editor = func(_ context.Context, filename string) error {
+			return os.WriteFile(filename, []byte("# only comments\n\n"), 0o600)
+		}
+		err := c.DetectionsClose(context.Background(), ag)
+		require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
+		require.EqualValues(t, 0, calls.Load())
+	})
+
+	t.Run("editor failure aborts without a request", func(t *testing.T) {
+		var calls atomic.Int64
+		ag := newAccessGraphTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			t.Errorf("server reached despite editor failure: %s", r.URL.Path)
+		}))
+
+		c, _ := newDetectionsCommand(t, teleport.Text)
+		c.detections.close = detectionSetStatusArgs{id: fixtureAlertID.String()}
+		c.detections.editor = func(context.Context, string) error {
+			return trace.BadParameter("editor exploded")
+		}
+		err := c.DetectionsClose(context.Background(), ag)
+		// Match the message, not just BadParameter: the empty-reason fallthrough is one too.
+		require.ErrorContains(t, err, "editor exploded")
+		require.EqualValues(t, 0, calls.Load())
+	})
+
+	t.Run("no terminal without a reason flag errors without a request", func(t *testing.T) {
+		// Tests run without a terminal and inject no editor, so the reason
+		// cannot be collected: the command must require an explicit flag.
+		var calls atomic.Int64
+		ag := newAccessGraphTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			t.Errorf("server reached despite no way to collect a reason: %s", r.URL.Path)
+		}))
+
+		c, _ := newDetectionsCommand(t, teleport.Text)
+		c.detections.triage = detectionSetStatusArgs{id: fixtureAlertID.String()}
+		err := c.DetectionsTriage(context.Background(), ag)
+		require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
+		require.EqualValues(t, 0, calls.Load())
+	})
+
+	t.Run("invalid uuid returns BadParameter without hitting the server", func(t *testing.T) {
+		var calls atomic.Int64
+		ag := newAccessGraphTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			t.Errorf("server reached despite invalid uuid: %s", r.URL.Path)
+		}))
+
+		c, _ := newDetectionsCommand(t, teleport.Text)
+		c.detections.triage = detectionSetStatusArgs{id: "not-a-uuid", allowEmpty: true}
+		err := c.DetectionsTriage(context.Background(), ag)
+		require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
+		require.EqualValues(t, 0, calls.Load())
+	})
+
+	t.Run("HTTP 404 surfaces as apiResponseError", func(t *testing.T) {
+		ag := newAccessGraphTestClient(t, newUpdateAlertStatusHandler(t, nil,
+			http.StatusNotFound, `{"message":"no such alert"}`))
+
+		c, _ := newDetectionsCommand(t, teleport.Text)
+		c.detections.resolve = detectionSetStatusArgs{id: fixtureAlertID.String(), allowEmpty: true}
+		err := c.DetectionsResolve(context.Background(), ag)
+		var agErr *apiResponseError
+		require.ErrorAs(t, err, &agErr)
+		require.Equal(t, http.StatusNotFound, agErr.StatusCode)
+		require.Equal(t, "no such alert", agErr.Message)
+	})
+}
+
 func TestDisplayDetectionTextAffectedEntity(t *testing.T) {
 
 	cases := []struct {
@@ -636,7 +836,7 @@ func TestInitDetectionsFlags(t *testing.T) {
 		after := time.Now()
 		require.NoError(t, err)
 
-		require.Equal(t, teleport.Text, got.format)
+		require.Equal(t, teleport.Text, got.ls.format)
 		require.Equal(t, []string{"in_progress", "triaged"}, got.ls.status)
 		require.Empty(t, got.ls.severity, "no default severity filter — unset means all")
 		require.False(t, got.ls.detailed)
@@ -644,8 +844,8 @@ func TestInitDetectionsFlags(t *testing.T) {
 
 		// --from defaults to "30d" → ~30d before parse time. Allow the
 		// parse window (before..after) to absorb any clock drift.
-		require.WithinRange(t, got.from, before.Add(-30*24*time.Hour-time.Second), after.Add(-30*24*time.Hour+time.Second))
-		require.WithinRange(t, got.to, before, after.Add(time.Second))
+		require.WithinRange(t, got.ls.from, before.Add(-30*24*time.Hour-time.Second), after.Add(-30*24*time.Hour+time.Second))
+		require.WithinRange(t, got.ls.to, before, after.Add(time.Second))
 	})
 
 	t.Run("ls rejects unknown status enum", func(t *testing.T) {
@@ -672,8 +872,14 @@ func TestInitDetectionsFlags(t *testing.T) {
 		got, err := parse(t, "detections", "ls", "--detailed", "--format", teleport.JSON, "--limit", "250")
 		require.NoError(t, err)
 		require.True(t, got.ls.detailed)
-		require.Equal(t, teleport.JSON, got.format)
+		require.Equal(t, teleport.JSON, got.ls.format)
 		require.Equal(t, 250, got.ls.limit)
+	})
+
+	t.Run("get accepts --format", func(t *testing.T) {
+		got, err := parse(t, "detections", "get", fixtureAlertID.String(), "--format", teleport.YAML)
+		require.NoError(t, err)
+		require.Equal(t, teleport.YAML, got.get.format)
 	})
 
 	t.Run("get requires id argument", func(t *testing.T) {
@@ -685,6 +891,37 @@ func TestInitDetectionsFlags(t *testing.T) {
 		got, err := parse(t, "detections", "get", fixtureAlertID.String())
 		require.NoError(t, err)
 		require.Equal(t, fixtureAlertID.String(), got.get.id)
+	})
+
+	t.Run("status verbs require id argument", func(t *testing.T) {
+		for _, verb := range []string{"triage", "resolve", "close"} {
+			t.Run(verb, func(t *testing.T) {
+				_, err := parse(t, "detections", verb)
+				require.Error(t, err)
+			})
+		}
+	})
+
+	t.Run("status verbs capture id, reason, and allow-empty", func(t *testing.T) {
+		cases := []struct {
+			verb string
+			pick func(detectionsArgs) detectionSetStatusArgs
+		}{
+			{"triage", func(a detectionsArgs) detectionSetStatusArgs { return a.triage }},
+			{"resolve", func(a detectionsArgs) detectionSetStatusArgs { return a.resolve }},
+			{"close", func(a detectionsArgs) detectionSetStatusArgs { return a.close }},
+		}
+		for _, tc := range cases {
+			t.Run(tc.verb, func(t *testing.T) {
+				// -r is the short form of --reason.
+				got, err := parse(t, "detections", tc.verb, fixtureAlertID.String(), "-r", "because", "--allow-empty")
+				require.NoError(t, err)
+				args := tc.pick(got)
+				require.Equal(t, fixtureAlertID.String(), args.id)
+				require.Equal(t, "because", args.reason)
+				require.True(t, args.allowEmpty)
+			})
+		}
 	})
 }
 

--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -28,8 +28,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"os/exec"
-	"strings"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
@@ -44,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
+	"github.com/gravitational/teleport/tool/tctl/common/editor"
 	"github.com/gravitational/teleport/tool/tctl/common/resources"
 )
 
@@ -88,21 +87,7 @@ func (e *EditCommand) runEditor(ctx context.Context, name string) error {
 	if e.Editor != nil {
 		return trace.Wrap(e.Editor(name))
 	}
-
-	textEditor := getTextEditor()
-	args := strings.Fields(textEditor)
-	editorCmd := exec.CommandContext(ctx, args[0], append(args[1:], name)...)
-	editorCmd.Stdin = os.Stdin
-	editorCmd.Stdout = os.Stdout
-	editorCmd.Stderr = os.Stderr
-	if err := editorCmd.Start(); err != nil {
-		return trace.BadParameter("could not start editor %v: %v", textEditor, err)
-	}
-	if err := editorCmd.Wait(); err != nil {
-		return trace.BadParameter("skipping resource update, editor did not complete successfully: %v", err)
-	}
-
-	return nil
+	return trace.Wrap(editor.Run(ctx, name), "skipping resource update")
 }
 
 func (e *EditCommand) editResource(ctx context.Context, client *authclient.Client) error {
@@ -314,16 +299,6 @@ func editUpdateWithFallbackScoped(
 	} else {
 		return trace.Wrap(err)
 	}
-}
-
-// getTextEditor returns the text editor to be used for editing the resource.
-func getTextEditor() string {
-	for _, v := range []string{"TELEPORT_EDITOR", "VISUAL", "EDITOR"} {
-		if value := os.Getenv(v); value != "" {
-			return value
-		}
-	}
-	return "vi"
 }
 
 func checksum(filename string) (string, error) {

--- a/tool/tctl/common/editor/editor.go
+++ b/tool/tctl/common/editor/editor.go
@@ -1,0 +1,54 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Package editor launches the user's configured text editor against a file,
+// the mechanism shared by tctl commands that collect free-form input (resource
+// edits, detection status-change reasons).
+package editor
+
+import (
+	"cmp"
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// command returns the editor command line from TELEPORT_EDITOR, VISUAL, or EDITOR, defaulting to vi.
+func command() string {
+	return cmp.Or(os.Getenv("TELEPORT_EDITOR"), os.Getenv("VISUAL"), os.Getenv("EDITOR"), "vi")
+}
+
+// Run opens filename in the user's configured editor and blocks until it exits.
+func Run(ctx context.Context, filename string) error {
+	editor := command()
+	args := strings.Fields(editor)
+	cmd := exec.CommandContext(ctx, args[0], append(args[1:], filename)...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return trace.BadParameter("could not start editor %v: %v", editor, err)
+	}
+	if err := cmd.Wait(); err != nil {
+		return trace.BadParameter("editor did not complete successfully: %v", err)
+	}
+	return nil
+}

--- a/tool/tctl/common/editor/editor_test.go
+++ b/tool/tctl/common/editor/editor_test.go
@@ -1,0 +1,55 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package editor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommand(t *testing.T) {
+	t.Run("defaults to vi when nothing is set", func(t *testing.T) {
+		t.Setenv("TELEPORT_EDITOR", "")
+		t.Setenv("VISUAL", "")
+		t.Setenv("EDITOR", "")
+		require.Equal(t, "vi", command())
+	})
+
+	t.Run("TELEPORT_EDITOR takes precedence", func(t *testing.T) {
+		t.Setenv("TELEPORT_EDITOR", "tele-ed")
+		t.Setenv("VISUAL", "visual-ed")
+		t.Setenv("EDITOR", "editor-ed")
+		require.Equal(t, "tele-ed", command())
+	})
+
+	t.Run("VISUAL beats EDITOR", func(t *testing.T) {
+		t.Setenv("TELEPORT_EDITOR", "")
+		t.Setenv("VISUAL", "visual-ed")
+		t.Setenv("EDITOR", "editor-ed")
+		require.Equal(t, "visual-ed", command())
+	})
+
+	t.Run("EDITOR is the last resort before vi", func(t *testing.T) {
+		t.Setenv("TELEPORT_EDITOR", "")
+		t.Setenv("VISUAL", "")
+		t.Setenv("EDITOR", "editor-ed")
+		require.Equal(t, "editor-ed", command())
+	})
+}


### PR DESCRIPTION

Issue: https://github.com/gravitational/access-graph/issues/1933

This PR adds `tctl detections triage|resolve|close <id>` — the first _write_ operations in the Access Graph (AG) `tctl` surface. Each verb PUTs the corresponding status to AG's `UpdateAlertStatusV1` along with an optional reason.

## What changed

- Add the three status verbs, each taking a detection `<id>` plus `--reason/-r` and `--allow-empty`. With neither flag an editor opens on a seeded temp file; whole-line `#` comments are stripped and an empty result aborts.
- Extract the editor-launching logic out of `edit_command.go` into a new `tool/tctl/common/editor` package, now shared by `tctl edit` and the status verbs.
- Move `--format`, `--from`, and `--to` off the `detections` parent onto `ls` and `get`.
- Regenerate `docs/pages/reference/cli/tctl.mdx`.

## Why

This continues [access-graph#1933](https://github.com/gravitational/access-graph/issues/1933). The read side has landed — `detections ls`/`get`, `investigate`, `access-changes`, `access-review` — so operators can find and inspect a detection from the CLI but must switch to the web UI to act on it. These verbs close that loop.

Detections are the highest-value place to start on writes because read plus write makes the whole triage loop scriptable, and in particular agent-driven: an LLM with `tctl` access can already pull a detection report and investigate the surrounding identity activity, and with these verbs it can record the outcome itself once it has done so, with the reason captured as an audit trail.

A few notes worth flagging:

- **Output and time-window flags are now per subcommand.** On the parent, kingpin offered them on every child including the status verbs, which ignore them. Duplicating the declaration on `ls` and `get` is deliberate and matches `acl_command.go`. Side effect: `tctl detections get <id> --from 1d` used to parse and be silently ignored, and now errors.
- **The editor extraction reshapes one `tctl edit` error.** `runEditor` now returns `trace.Wrap(editor.Run(ctx, name), "skipping resource update")`, so an editor exiting non-zero keeps the same `skipping resource update` prefix but renders as two lines via `TraceErr`'s message tree instead of one. It is still a `BadParameter`.

Changelog: Added `tctl detections triage`, `tctl detections resolve`, and `tctl detections close` to update the status of Access Graph security detections.

## Manual Test Plan

### Test Environment

- Local dev cluster (current branch for `teleport` + local Access Graph).

### Test Cases

- [x] Each of `triage`, `resolve`, and `close` sets the expected status, confirmed by a follow-up `tctl detections get <id>`.
- [x] `--reason`/`-r` records the reason; `--allow-empty` sets the status without one.
- [x] With neither flag the editor opens on the seeded template; the reason is saved and `#` comment lines are stripped. An empty buffer aborts without a request.
- [x] Non-terminal stdin with neither flag errors instead of spawning an editor; a malformed `<id>` is rejected before the network call.
- [x] `tctl detections ls` and `get` still work, including `--format` and `ls --from/--to`.
- [x] `tctl edit <resource>` still opens the editor, saves changes, and reports the "skipping resource update" error when the editor exits non-zero.