### PR TITLE
tsh recordings export: support Linux desktop recordings

### DIFF
--- a/lib/srv/desktop/rdp/decoder/Cargo.toml
+++ b/lib/srv/desktop/rdp/decoder/Cargo.toml
@@ -14,6 +14,9 @@ ironrdp-core.workspace = true
 ironrdp-graphics.workspace = true
 ironrdp-pdu.workspace = true
 ironrdp-session.workspace = true
+# Linux desktop sessions are encoded with the QOIZ codec,
+# so the decoder must be able to decode them.
+ironrdp-session.features = ["qoiz"]
 
 [features]
 image-resize = ["dep:fast_image_resize"]

--- a/tool/tsh/common/recording_export.go
+++ b/tool/tsh/common/recording_export.go
@@ -252,13 +252,17 @@ loop:
 			d.progress.Add(1)
 
 			switch evt := evt.(type) {
-			case *apievents.WindowsDesktopSessionStart:
+			case *apievents.WindowsDesktopSessionStart, *apievents.LinuxDesktopSessionStart:
 			case *apievents.WindowsDesktopSessionEnd:
 				if !evt.StartTime.IsZero() && !evt.EndTime.IsZero() {
 					endMillis = max(endMillis, evt.EndTime.Sub(evt.StartTime).Milliseconds())
 				}
 				break loop
-
+			case *apievents.LinuxDesktopSessionEnd:
+				if !evt.StartTime.IsZero() && !evt.EndTime.IsZero() {
+					endMillis = max(endMillis, evt.EndTime.Sub(evt.StartTime).Milliseconds())
+				}
+				break loop
 			case *apievents.DesktopRecording:
 				screenData, err := decoder.UpdateScreen(evt)
 				if err != nil {


### PR DESCRIPTION
<img width="1624" height="934" alt="image" src="https://github.com/user-attachments/assets/7b1ba488-310c-4c21-891d-7f95d01b3e6b" />

Wait for #69072 to merge first.

## Manual Test Plan

### Test Environment

Local cluster

### Test Cases
- [x] `tsh recordings export` produces a playable video file on a Linux desktop recording 
