### PR TITLE
Implement RFD 343: scoped operator

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.teleport-operator.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-operator.mdx
@@ -85,17 +85,36 @@ Setting this value is required when joining via the
 
 `token` is the name of the token used by the operator to join the Teleport cluster.
 
-## `scoped`
+## `scope`
 
 | Type | Default |
 |------|---------|
-| `bool` | `false` |
+| `string` | `""` |
 
-`scoped` makes the operator run in scoped mode.
+`scope` makes the operator run in scoped mode and specified the reconciled scope.
 In scoped mode, the operator can only reconcile scoped resource such as
 `TeleportScopedTokenV1`, `TeleportScopedRoleV1`, or `TeleportScopedRoleAssignmentV1`.
 Scoped mode requires the operator to join using a scoped token and the experimental scope
 feature to be enabled on both Teleport Auth Service instances and Proxy Service instances.
+
+The operator can only reconcile resources whose scope matches exactly `scope`.
+Resources in nested scopes are not reconciled.
+
+When running in scoped mode, `ownerEmail` must be set.
+When running in scoped mode, the operator generates a UUID and stores it in Kubernetes.
+This UUID is used to tag the operator-created resources and detect conflicts.
+
+## `ownerEmail`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`ownerEmail` is the name of the owner of the operator.
+This is used to tag the operator-created resources and know who created them.
+
+This is required when `scope` is specified..
+This currently has no effect when `scope` is empty.
 
 ## `teleportVersionOverride`
 

--- a/docs/pages/includes/helm-reference/zz_generated.teleport-operator.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-operator.mdx
@@ -85,17 +85,36 @@ Setting this value is required when joining via the
 
 `token` is the name of the token used by the operator to join the Teleport cluster.
 
-## `scoped`
+## `scope`
 
 | Type | Default |
 |------|---------|
-| `bool` | `false` |
+| `string` | `""` |
 
-`scoped` makes the operator run in scoped mode.
+`scope` makes the operator run in scoped mode and specified the reocnciled scope.
 In scoped mode, the operator can only reconcile scoped resource such as
 `TeleportScopedTokenV1`, `TeleportScopedRoleV1`, or `TeleportScopedRoleAssignmentV1`.
 Scoped mode requires the operator to join using a scoped token and the experimental scope
 feature to be enabled on both Teleport Auth Service instances and Proxy Service instances.
+
+The operator can only reconcile resources whose scope matches exactly `scope`.
+Resources in nested scopes are not reconciled.
+
+When running in scoped mode, `ownerEmail` must be set.
+When running in scoped mode, the operator generates a UUID and stores it in Kubernetes.
+This UUID is used to tag the operator-created resources and detect conflicts.
+
+## `ownerEmail`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`ownerEmail` is the name of the owner of the operator.
+This is used to tag the operator-created resources and know who created them.
+
+This is required when `scoped` is set to `true`.
+This currently has no effect when `scoped` is set to `false`.
 
 ## `teleportVersionOverride`
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
@@ -24,6 +24,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |apiVersion|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
 |kind|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
 |metadata|object||
+|scope|string|scope is the scope of the Access List.|
 |spec|[object](#spec)|AccessList resource definition v1 from Teleport|
 
 ### spec

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accesslists.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accesslists.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    resources.teleport.dev/scoped: "false"
+    resources.teleport.dev/scoped: "true"
   name: teleportaccesslists.resources.teleport.dev
 spec:
   group: resources.teleport.dev
@@ -16,7 +16,16 @@ spec:
     singular: teleportaccesslist
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Resource's scope.
+      jsonPath: .scope
+      name: scope
+      type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: AccessList is the Schema for the accesslists API
@@ -33,6 +42,13 @@ spec:
             type: string
           metadata:
             type: object
+          scope:
+            description: scope is the scope of the Access List.
+            type: string
+            x-kubernetes-validations:
+            - message: Scope is immutable. To create the resource in a different scope
+                you must delete it first.
+              rule: self == oldSelf
           spec:
             description: AccessList resource definition v1 from Teleport
             properties:
@@ -293,6 +309,10 @@ spec:
                 type: integer
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: Scope is immutable. To create the resource in a different scope
+            you must delete it first.
+          rule: has(self.scope) == has(oldSelf.scope)
     served: true
     storage: true
     subresources:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/_helpers.tpl
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/_helpers.tpl
@@ -27,6 +27,10 @@ This is done to avoid naming conflicts when including th chart in `teleport-clus
     {{- end }}
 {{- end }}
 
+{{- define "teleport-cluster.operator.shared-state-name" }}
+{{- printf "%s-shared-state" (include "teleport-cluster.operator.fullname" .) }}
+{{- end }}
+
 {{/*
 Create the name of the service account to use
 if serviceAccount is not defined or serviceAccount.name is empty, use .Release.Name
@@ -105,7 +109,7 @@ So we check if there's a CRD already deployed, it that's the case, we keep the C
 the release. As CRDs are not namespaced, we must use a custom annotation to avoid
 a conflict when two releases are deployed with the same name in different namespaces. */ -}}
 {{- define "teleport-cluster.operator.checkExistingCRDs" -}}
-  {{ $sentinelCRD := ternary  "teleportscopedrolesv1.resources.teleport.dev" "teleportrolesv7.resources.teleport.dev" .Values.scoped }}
+  {{ $sentinelCRD := ternary  "teleportscopedrolesv1.resources.teleport.dev" "teleportrolesv7.resources.teleport.dev" (not (empty .Values.scope)) }}
   {{ $existingCRD := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" $sentinelCRD}}
   {{- if not $existingCRD -}}
     false

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/crd-resources.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/crd-resources.yaml
@@ -37,7 +37,7 @@ shouldInstallCRDs in _helpers.yaml for more details). */ -}}
          This makes sure we don't deploy unscoped CRDs on a scoped operator.
          Note: scopedCRD is a string. */}}
     {{- $scopedCRD := (dig "metadata" "annotations" "resources.teleport.dev/scoped" "unknown" $raw) -}}
-    {{- if or (not .Values.scoped) (eq $scopedCRD "true") -}}
+    {{- if or (not .Values.scope) (eq $scopedCRD "true") -}}
       {{- toYaml $injectedCRD }}
 ---
     {{- end }}

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/deployment.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/deployment.yaml
@@ -56,8 +56,11 @@ spec:
             - '{{ .Values.joinMethod }}'
             - -token
             - '{{ .Values.token }}'
-  {{- if .Values.scoped }}
-            - -scoped
+  {{- if .Values.scope }}
+            - -scope
+            - {{ .Values.scope | quote }}
+            - -owner-email
+            - {{ required "ownerEmail must be set when running in scoped mode" .Values.ownerEmail | quote }}
   {{- end }}
   {{- if .Values.caPins }}
             - -ca-pin
@@ -66,7 +69,7 @@ spec:
   {{- if .Values.extraArgs }}
             {{- toYaml .Values.extraArgs | nindent 12 }}
   {{- end }}
-  {{- if or (.Values.tls.existingCASecretName) (.Values.teleportClusterName) (.Values.extraEnv)  }}
+  {{- if or (.Values.tls.existingCASecretName) (.Values.teleportClusterName) (.Values.extraEnv) (.Values.scope) }}
           env:
     {{- if .Values.extraEnv }}
           {{- toYaml .Values.extraEnv | nindent 12 }}
@@ -78,6 +81,14 @@ spec:
     {{- if .Values.teleportClusterName }}
             - name: KUBERNETES_TOKEN_PATH
               value: /var/run/secrets/teleport/serviceaccount/token
+    {{- end }}
+    {{- if .Values.scope }}
+            - name: KUBE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: RELEASE_NAME
+              value: {{ include "teleport-cluster.operator.fullname" . | quote}}
     {{- end }}
   {{- end }}
           livenessProbe:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/role.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/role.yaml
@@ -42,5 +42,19 @@ rules:
       - "get"
       - "list"
       - "watch"
+  {{- if .Values.scope }}
+  # ability to store its state in Kubernetes when running in scoped mode.
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+    verbs:
+      - "get"
+      - "update"
+      - "patch"
+      - "delete"
+    resourceNames:
+      - {{ include "teleport-cluster.operator.shared-state-name" . | quote }}
+  {{- end }}
 {{- end -}}
 {{- end -}}

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/state-secret.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/state-secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.enabled }}
+{{ if .Values.scope }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "teleport-cluster.operator.shared-state-name" . | quote }}
+  namespace: {{ .Release.Namespace }}
+data: {}
+  # data is empty on purpose, it will be filled by the operator
+type: Opaque
+{{- end }}
+{{- end }}

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/state_secret_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/state_secret_test.yaml
@@ -1,0 +1,27 @@
+suite: Operator State Secret
+templates:
+  - state-secret.yaml
+tests:
+  - it: creates no Secret when operator is not enabled
+    values:
+      - ../.lint/disabled.yaml
+    set:
+      scope: "/test"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: creates no RoleBinding when no scope is set
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: creates a Secret when scope is set
+    set:
+      scope: "/test"
+    asserts:
+      - containsDocument:
+          any: true
+          kind: Secret
+          apiVersion: v1
+          name: RELEASE-NAME-teleport-operator-shared-state

--- a/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
@@ -47,12 +47,26 @@ teleportClusterName: ""
 # token(string) -- is the name of the token used by the operator to join the Teleport cluster.
 token: ""
 
-# scoped(bool) -- makes the operator run in scoped mode.
+# scope(string) -- makes the operator run in scoped mode and specified the reconciled scope.
 # In scoped mode, the operator can only reconcile scoped resource such as
 # `TeleportScopedTokenV1`, `TeleportScopedRoleV1`, or `TeleportScopedRoleAssignmentV1`.
 # Scoped mode requires the operator to join using a scoped token and the experimental scope
 # feature to be enabled on both Teleport Auth Service instances and Proxy Service instances.
-scoped: false
+#
+# The operator can only reconcile resources whose scope matches exactly `scope`.
+# Resources in nested scopes are not reconciled.
+#
+# When running in scoped mode, `ownerEmail` must be set.
+# When running in scoped mode, the operator generates a UUID and stores it in Kubernetes.
+# This UUID is used to tag the operator-created resources and detect conflicts.
+scope: ""
+
+# ownerEmail(string) -- is the name of the owner of the operator.
+# This is used to tag the operator-created resources and know who created them.
+#
+# This is required when `scope` is specified..
+# This currently has no effect when `scope` is empty.
+ownerEmail: ""
 
 # teleportVersionOverride(string) -- controls the Teleport Kubernetes Operator
 # image version deployed by the chart.

--- a/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
@@ -47,12 +47,26 @@ teleportClusterName: ""
 # token(string) -- is the name of the token used by the operator to join the Teleport cluster.
 token: ""
 
-# scoped(bool) -- makes the operator run in scoped mode.
+# scope(string) -- makes the operator run in scoped mode and specified the reocnciled scope.
 # In scoped mode, the operator can only reconcile scoped resource such as
 # `TeleportScopedTokenV1`, `TeleportScopedRoleV1`, or `TeleportScopedRoleAssignmentV1`.
 # Scoped mode requires the operator to join using a scoped token and the experimental scope
 # feature to be enabled on both Teleport Auth Service instances and Proxy Service instances.
-scoped: false
+#
+# The operator can only reconcile resources whose scope matches exactly `scope`.
+# Resources in nested scopes are not reconciled.
+#
+# When running in scoped mode, `ownerEmail` must be set.
+# When running in scoped mode, the operator generates a UUID and stores it in Kubernetes.
+# This UUID is used to tag the operator-created resources and detect conflicts.
+scope: ""
+
+# ownerEmail(string) -- is the name of the owner of the operator.
+# This is used to tag the operator-created resources and know who created them.
+#
+# This is required when `scoped` is set to `true`.
+# This currently has no effect when `scoped` is set to `false`.
+ownerEmail: ""
 
 # teleportVersionOverride(string) -- controls the Teleport Kubernetes Operator
 # image version deployed by the chart.

--- a/integrations/operator/Dockerfile
+++ b/integrations/operator/Dockerfile
@@ -66,6 +66,7 @@ COPY integrations/operator/controllers/ integrations/operator/controllers/
 COPY integrations/operator/main.go integrations/operator/main.go
 COPY integrations/operator/namespace.go integrations/operator/namespace.go
 COPY integrations/operator/config.go integrations/operator/config.go
+COPY integrations/operator/state/ integrations/operator/state/
 
 # Compiler package should use host-triplet-agnostic name (i.e. "x86-64-linux-gnu-gcc" instead of "gcc")
 #  in most cases, to avoid issues on systems with multiple versions of gcc (i.e. buildboxes)

--- a/integrations/operator/Dockerfile.gha
+++ b/integrations/operator/Dockerfile.gha
@@ -83,6 +83,7 @@ COPY integrations/operator/controllers/ integrations/operator/controllers/
 COPY integrations/operator/main.go integrations/operator/main.go
 COPY integrations/operator/namespace.go integrations/operator/namespace.go
 COPY integrations/operator/config.go integrations/operator/config.go
+COPY integrations/operator/state/ integrations/operator/state/
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/integrations/operator/apis/resources/v1/accesslist_types.go
+++ b/integrations/operator/apis/resources/v1/accesslist_types.go
@@ -37,6 +37,7 @@ type TeleportAccessList struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	Scope  string                 `json:"scope"`
 	Spec   TeleportAccessListSpec `json:"spec"`
 	Status teleportcr.Status      `json:"status"`
 }
@@ -67,7 +68,8 @@ func (l TeleportAccessList) ToTeleport() *accesslist.AccessList {
 				Labels:      l.Labels,
 			},
 		},
-		Spec: accesslist.Spec(l.Spec),
+		Spec:  accesslist.Spec(l.Spec),
+		Scope: l.Scope,
 	}
 	return resource
 }

--- a/integrations/operator/config.go
+++ b/integrations/operator/config.go
@@ -36,7 +36,8 @@ type operatorConfig struct {
 	syncPeriod       time.Duration
 	namespace        string
 	logLevel         string
-	scoped           bool
+	scope            string
+	ownerEmail       string
 }
 
 // BindFlags binds operatorConfig fields to CLI flags.
@@ -53,7 +54,8 @@ func (c *operatorConfig) BindFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.namespace, "namespace", "", "The namespace containing the Teleport CRs.")
 	fs.DurationVar(&c.syncPeriod, "sync-period", defaultSyncPeriod, "Operator sync period (format: https://pkg.go.dev/time#ParseDuration)")
 	fs.StringVar(&c.logLevel, "log-level", "INFO", "Log level (DEBUG, INFO, WARN, ERROR).")
-	fs.BoolVar(&c.scoped, "scoped", false, "Run operator in scoped mode. Only scoped resources will be reconciled.")
+	fs.StringVar(&c.scope, "scope", "", "Configures the operator target scope. When unset, the operator runs unscoped. When set, the operator can only reconcile resources with this exact scope.")
+	fs.StringVar(&c.ownerEmail, "owner-email", "", "Email of the owner of the Teleport cluster. Required when running in scoped mode.")
 }
 
 // CheckAndSetDefaults checks the operatorConfig and populates unspecified
@@ -68,6 +70,9 @@ func (c *operatorConfig) CheckAndSetDefaults() error {
 				namespaceEnvVar, namespacePath,
 			)
 		}
+	}
+	if c.scope != "" && c.ownerEmail == "" {
+		return trace.BadParameter("Specifying owner-email is required when running in scoped mode.")
 	}
 	return nil
 }

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_accesslists.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_accesslists.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    resources.teleport.dev/scoped: "false"
+    resources.teleport.dev/scoped: "true"
   name: teleportaccesslists.resources.teleport.dev
 spec:
   group: resources.teleport.dev
@@ -16,7 +16,16 @@ spec:
     singular: teleportaccesslist
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Resource's scope.
+      jsonPath: .scope
+      name: scope
+      type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: AccessList is the Schema for the accesslists API
@@ -33,6 +42,13 @@ spec:
             type: string
           metadata:
             type: object
+          scope:
+            description: scope is the scope of the Access List.
+            type: string
+            x-kubernetes-validations:
+            - message: Scope is immutable. To create the resource in a different scope
+                you must delete it first.
+              rule: self == oldSelf
           spec:
             description: AccessList resource definition v1 from Teleport
             properties:
@@ -293,6 +309,10 @@ spec:
                 type: integer
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: Scope is immutable. To create the resource in a different scope
+            you must delete it first.
+          rule: has(self.scope) == has(oldSelf.scope)
     served: true
     storage: true
     subresources:

--- a/integrations/operator/controllers/reconcilers/generic.go
+++ b/integrations/operator/controllers/reconcilers/generic.go
@@ -359,6 +359,20 @@ func (r resourceReconciler[T, K]) Delete(ctx context.Context, obj kclient.Object
 		key.Scope = scope
 	}
 
+	if condition, ok := r.checkScope(key, r.operatorMetadata); !ok {
+		// If the scope doesn't match, we must not delete the resource on the Teleport side.
+		// Then we have 2 choices:
+		// - error continually until the user manually adds the "keep" label.
+		// - silently skp the deletion to let the CR be removed.
+		// As it's unlikely that the operator was managing the resource to begin with, the second option seems saner.
+		// There's a small risk of an operator changing scope, the leaving leftovers. Today we cannot detect this edge
+		// case, a potential workaround would be to introduce something in the CR status to track if it was reconciled
+		// once, and keep the last known SQN.
+		log := ctrllog.FromContext(ctx).V(0)
+		log.Info("Scope mismatch, skipping deletion", "reason", condition.Reason, "operatorScope", r.operatorMetadata.Scope, "resourceScope", key.Scope, "resourceName", key.Name, "resourceNamespace", obj.GetNamespace())
+		return nil
+	}
+
 	// This call catches non-existing resources or subkind mismatch (e.g. openssh nodes)
 	// We can then check that we own the Resource before deleting it.
 	resource, err := r.resourceClient.Get(ctx, key)
@@ -530,14 +544,14 @@ func (r resourceReconciler[T, K]) checkScope(key ResourceKey, metadata OperatorM
 			Reason:  ConditionTypeUnscoped,
 			Message: "Neither resource or operator are scoped",
 		}, true
-	case key.Scope == "" && metadata.Scope != "":
+	case key.Scope != "" && metadata.Scope == "":
 		return metav1.Condition{
 			Type:    ConditionTypeValidScope,
 			Status:  metav1.ConditionFalse,
 			Reason:  ConditionReasonNonMatchingScope,
 			Message: "Resource is scoped but operator is not. Refusing to reconcile.",
 		}, false
-	case key.Scope != "" && metadata.Scope == "":
+	case key.Scope == "" && metadata.Scope != "":
 		return metav1.Condition{
 			Type:    ConditionTypeValidScope,
 			Status:  metav1.ConditionFalse,

--- a/integrations/operator/controllers/reconcilers/generic.go
+++ b/integrations/operator/controllers/reconcilers/generic.go
@@ -36,7 +36,7 @@ import (
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/common"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
 	"github.com/gravitational/teleport/lib/scopes"
 )
@@ -54,6 +54,21 @@ const (
 	AnnotationFlagKeep = "teleport.dev/keep"
 )
 
+const (
+	OperatorIDLabel              = "resources.teleport.dev/operator-id"
+	operatorOwnerLabel           = "resources.teleport.dev/owner-email"
+	operatorTokenNameLabel       = "resources.teleport.dev/token-name"
+	operatorNamespaceLabel       = "resources.teleport.dev/namespace"
+	customResourceNameLabel      = "resources.teleport.dev/custom-resource-name"
+	customResourceNamespaceLabel = "resources.teleport.dev/custom-resource-namespace"
+	customResourceGVKLabel       = "resources.teleport.dev/custom-resource-gvk"
+
+	ownershipIssueMissingOriginLabel  = "teleport resource doesn't have the " + common.OriginLabel + "label"
+	ownershipIssueMismatchOriginLabel = "teleport resource has the " + common.OriginLabel + "label set to %q instead of \"" + common.OriginKubernetes + "\""
+	ownershipIssueMissingOperatorID   = "teleport resource doesn't have the " + OperatorIDLabel + "label"
+	ownershipIssueMismatchOperatorID  = "teleport resource has the " + OperatorIDLabel + "label set to %q instead of %q. Resource is owned by another operator. The resource label contain more info on the original operator."
+)
+
 // Resource is any Teleport Resource the controller manages.
 type Resource any
 
@@ -64,24 +79,9 @@ type Resource any
 type Adapter[T Resource] interface {
 	GetResourceName(T) string
 	GetResourceRevision(T) string
-	GetResourceOrigin(T) string
 	SetResourceRevision(T, string)
-	SetResourceLabels(T, map[string]string)
-}
-
-// ScopedResource153 extends [types.Resource153] for Teleport
-// resources that are scoped.
-type ScopedResource153 interface {
-	types.Resource153
-	GetScope() string
-}
-
-type ScopedResource153Adapter[T ScopedResource153] struct {
-	Resource153Adapter[T]
-}
-
-func (a ScopedResource153Adapter[T]) GetResourceScope(res T) string {
-	return res.GetScope()
+	SetResourceLabels(T, map[string]string, OperatorMetadata, customResourceMetadata)
+	CheckOwnership(T, OperatorMetadata) (bool, string)
 }
 
 // KubernetesCR is a Kubernetes CustomResource representing a Teleport Resource.
@@ -139,15 +139,37 @@ type Config struct {
 	CheckFeatures controllers.CheckFeaturesFunc
 }
 
+// OperatorMetadata contains the metadata about the operator runtime and configuration.
+// This is used to label resources and validate them (check their scope and provenance)
+type OperatorMetadata struct {
+	// Namespace is the operator namespace.
+	Namespace string
+	// ID is the operator ID.
+	ID string
+	// TokenName is the name of the token used by the operator to join.
+	TokenName string
+	// Scope is the operator scope. Set to `/` if the operator is unscoped.
+	Scope string
+	// Owner is the email of the operator owner. Specified by the user when deploying.
+	Owner string
+}
+
+type customResourceMetadata struct {
+	name      string
+	namespace string
+	gvk       string
+}
+
 // resourceReconciler is a Teleport generic reconciler.
 type resourceReconciler[T any, K KubernetesCR[T]] struct {
-	kubeClient     kclient.Client
-	resourceClient resourceClient[T]
-	gvk            schema.GroupVersionKind
-	adapter        Adapter[T]
-	scoped         bool
-	teleportKind   string
-	checkFeatures  controllers.CheckFeaturesFunc
+	kubeClient       kclient.Client
+	resourceClient   resourceClient[T]
+	gvk              schema.GroupVersionKind
+	adapter          Adapter[T]
+	scoped           bool
+	teleportKind     string
+	operatorMetadata OperatorMetadata
+	checkFeatures    controllers.CheckFeaturesFunc
 }
 
 func (r resourceReconciler[T, K]) GVK() schema.GroupVersionKind {
@@ -184,6 +206,8 @@ func (r resourceReconciler[T, K]) Upsert(ctx context.Context, obj kclient.Object
 		k8sResource,
 		true, /* returnUnknownFields */
 	)
+
+	// TODO(hugoShaka): optimize the updateStatus logic so we batch status updates
 	updateErr := updateStatus(updateStatusConfig{
 		ctx:         ctx,
 		client:      r.kubeClient,
@@ -198,6 +222,21 @@ func (r resourceReconciler[T, K]) Upsert(ctx context.Context, obj kclient.Object
 
 	debugLog.Info("Converting resource to teleport")
 	key := r.resourceKey(teleportResource)
+
+	scopeCondition, scopeOK := r.checkScope(key, r.operatorMetadata)
+	updateErr = updateStatus(updateStatusConfig{
+		ctx:         ctx,
+		client:      r.kubeClient,
+		k8sResource: k8sResource,
+		condition:   scopeCondition,
+	})
+	if updateErr != nil {
+		return trace.Wrap(updateErr, "updating status scope condition")
+	}
+	if !scopeOK {
+		return trace.CompareFailed("%s", scopeCondition.Message)
+	}
+
 	existingResource, err := r.resourceClient.Get(ctx, key)
 	updateErr = updateStatus(updateStatusConfig{
 		ctx:         ctx,
@@ -214,7 +253,7 @@ func (r resourceReconciler[T, K]) Upsert(ctx context.Context, obj kclient.Object
 
 	if exists {
 		debugLog.Info("Resource already exists")
-		newOwnershipCondition, isOwned := r.checkOwnership(existingResource)
+		newOwnershipCondition, isOwned := r.checkOwnership(existingResource, r.operatorMetadata)
 		debugLog.Info("Resource is owned")
 		if updateErr = updateStatus(updateStatusConfig{
 			ctx:         ctx,
@@ -240,10 +279,14 @@ func (r resourceReconciler[T, K]) Upsert(ctx context.Context, obj kclient.Object
 	}
 
 	kubeLabels := obj.GetLabels()
-	teleportLabels := make(map[string]string, len(kubeLabels)+1) // +1 because we'll add the origin label
+	teleportLabels := make(map[string]string)
 	maps.Copy(teleportLabels, kubeLabels)
-	teleportLabels[types.OriginLabel] = types.OriginKubernetes
-	r.adapter.SetResourceLabels(teleportResource, teleportLabels)
+	r.adapter.SetResourceLabels(
+		teleportResource,
+		teleportLabels,
+		r.operatorMetadata,
+		customResourceMetadata{name: obj.GetName(), namespace: obj.GetNamespace(), gvk: r.gvk.String()},
+	)
 	debugLog.Info("Propagating labels from kube resource", "kubeLabels", kubeLabels, "teleportLabels", teleportLabels)
 
 	if mutator, ok := r.resourceClient.(resourceMutator[T]); ok {
@@ -323,7 +366,7 @@ func (r resourceReconciler[T, K]) Delete(ctx context.Context, obj kclient.Object
 		return trace.Wrap(err)
 	}
 
-	_, isOwned := r.checkOwnership(resource)
+	_, isOwned := r.checkOwnership(resource, r.operatorMetadata)
 	if !isOwned {
 		// The Resource doesn't belong to us, we bail out but unblock the CR deletion
 		return nil
@@ -450,25 +493,18 @@ func isKept(obj kclient.Object) bool {
 	return checkAnnotationFlag(obj, AnnotationFlagKeep, false /* defaults to false */)
 }
 
-// isResourceOriginKubernetes reads a teleport Resource metadata, searches for the origin label and checks its
-// value is kubernetes.
-func (r resourceReconciler[T, K]) isResourceOriginKubernetes(resource T) bool {
-	origin := r.adapter.GetResourceOrigin(resource)
-	return origin == types.OriginKubernetes
-}
-
 // checkOwnership takes an existing Resource and validates the operator owns it.
 // It returns an ownership condition and a boolean representing if the Resource is
 // owned by the operator. The ownedResource must be non-nil.
-func (r resourceReconciler[T, K]) checkOwnership(existingResource T) (metav1.Condition, bool) {
-	if !r.isResourceOriginKubernetes(existingResource) {
+func (r resourceReconciler[T, K]) checkOwnership(existingResource T, metadata OperatorMetadata) (metav1.Condition, bool) {
+	if ok, reason := r.adapter.CheckOwnership(existingResource, metadata); !ok {
 		// Existing Teleport Resource does not belong to us, bailing out
 
 		condition := metav1.Condition{
 			Type:    ConditionTypeTeleportResourceOwned,
 			Status:  metav1.ConditionFalse,
 			Reason:  ConditionReasonOriginLabelNotMatching,
-			Message: "A Resource with the same name already exists in Teleport and does not have the Kubernetes origin label. Refusing to reconcile.",
+			Message: fmt.Sprintf("A resource with the same name already exists in Teleport and is not owned by the operator (%s). Refusing to reconcile.", reason),
 		}
 		return condition, false
 	}
@@ -477,9 +513,52 @@ func (r resourceReconciler[T, K]) checkOwnership(existingResource T) (metav1.Con
 		Type:    ConditionTypeTeleportResourceOwned,
 		Status:  metav1.ConditionTrue,
 		Reason:  ConditionReasonOriginLabelMatching,
-		Message: "Teleport Resource has the Kubernetes origin label.",
+		Message: "Teleport resource is owned by the operator.",
 	}
 	return condition, true
+}
+
+// checkOwnership takes an existing Resource and validates the operator owns it.
+// It returns an ownership condition and a boolean representing if the Resource is
+// owned by the operator. The ownedResource must be non-nil.
+func (r resourceReconciler[T, K]) checkScope(key ResourceKey, metadata OperatorMetadata) (metav1.Condition, bool) {
+	switch {
+	case key.Scope == "" && metadata.Scope == "":
+		return metav1.Condition{
+			Type:    ConditionTypeValidScope,
+			Status:  metav1.ConditionTrue,
+			Reason:  ConditionTypeUnscoped,
+			Message: "Neither resource or operator are scoped",
+		}, true
+	case key.Scope == "" && metadata.Scope != "":
+		return metav1.Condition{
+			Type:    ConditionTypeValidScope,
+			Status:  metav1.ConditionFalse,
+			Reason:  ConditionReasonNonMatchingScope,
+			Message: "Resource is scoped but operator is not. Refusing to reconcile.",
+		}, false
+	case key.Scope != "" && metadata.Scope == "":
+		return metav1.Condition{
+			Type:    ConditionTypeValidScope,
+			Status:  metav1.ConditionFalse,
+			Reason:  ConditionReasonNonMatchingScope,
+			Message: "Operator is scoped but resource is not. Refusing to reconcile.",
+		}, false
+	case metadata.Scope == key.Scope:
+		return metav1.Condition{
+			Type:    ConditionTypeValidScope,
+			Status:  metav1.ConditionTrue,
+			Reason:  ConditionReasonMatchingScope,
+			Message: "Resource scope matches the operator scope.",
+		}, true
+	default:
+		return metav1.Condition{
+			Type:    ConditionTypeValidScope,
+			Status:  metav1.ConditionFalse,
+			Reason:  ConditionReasonNonMatchingScope,
+			Message: fmt.Sprintf("Resource scope %q does not match the operator scope %q.", key.Scope, metadata.Scope),
+		}, false
+	}
 }
 
 var newResourceCondition = metav1.Condition{

--- a/integrations/operator/controllers/reconcilers/generic.go
+++ b/integrations/operator/controllers/reconcilers/generic.go
@@ -36,7 +36,7 @@ import (
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/common"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
 	"github.com/gravitational/teleport/lib/scopes"
 )
@@ -54,6 +54,21 @@ const (
 	AnnotationFlagKeep = "teleport.dev/keep"
 )
 
+const (
+	OperatorIDLabel              = "resources.teleport.dev/operator-id"
+	operatorOwnerLabel           = "resources.teleport.dev/owner-email"
+	operatorTokenNameLabel       = "resources.teleport.dev/token-name"
+	operatorNamespaceLabel       = "resources.teleport.dev/namespace"
+	customResourceNameLabel      = "resources.teleport.dev/custom-resource-name"
+	customResourceNamespaceLabel = "resources.teleport.dev/custom-resource-namespace"
+	customResourceGVKLabel       = "resources.teleport.dev/custom-resource-gvk"
+
+	ownershipIssueMissingOriginLabel  = "teleport resource doesn't have the " + common.OriginLabel + "label"
+	ownershipIssueMismatchOriginLabel = "teleport resource has the " + common.OriginLabel + "label set to %q instead of \"" + common.OriginKubernetes + "\""
+	ownershipIssueMissingOperatorID   = "teleport resource doesn't have the " + OperatorIDLabel + "label"
+	ownershipIssueMismatchOperatorID  = "teleport resource has the " + OperatorIDLabel + "label set to %q instead of %q. Resource is owned by another operator. The resource label contain more info on the original operator."
+)
+
 // Resource is any Teleport Resource the controller manages.
 type Resource any
 
@@ -64,24 +79,9 @@ type Resource any
 type Adapter[T Resource] interface {
 	GetResourceName(T) string
 	GetResourceRevision(T) string
-	GetResourceOrigin(T) string
 	SetResourceRevision(T, string)
-	SetResourceLabels(T, map[string]string)
-}
-
-// ScopedResource153 extends [types.Resource153] for Teleport
-// resources that are scoped.
-type ScopedResource153 interface {
-	types.Resource153
-	GetScope() string
-}
-
-type ScopedResource153Adapter[T ScopedResource153] struct {
-	Resource153Adapter[T]
-}
-
-func (a ScopedResource153Adapter[T]) GetResourceScope(res T) string {
-	return res.GetScope()
+	SetResourceLabels(T, map[string]string, OperatorMetadata, customResourceMetadata)
+	CheckOwnership(T, OperatorMetadata) (bool, string)
 }
 
 // KubernetesCR is a Kubernetes CustomResource representing a Teleport Resource.
@@ -139,15 +139,37 @@ type Config struct {
 	CheckFeatures controllers.CheckFeaturesFunc
 }
 
+// OperatorMetadata contains the metadata about the operator runtime and configuration.
+// This is used to label resources and validate them (check their scope and provenance)
+type OperatorMetadata struct {
+	// Namespace is the operator namespace.
+	Namespace string
+	// ID is the operator ID.
+	ID string
+	// TokenName is the name of the token used by the operator to join.
+	TokenName string
+	// Scope is the operator scope. Set to `/` if the operator is unscoped.
+	Scope string
+	// Owner is the email of the operator owner. Specified by the user when deploying.
+	Owner string
+}
+
+type customResourceMetadata struct {
+	name      string
+	namespace string
+	gvk       string
+}
+
 // resourceReconciler is a Teleport generic reconciler.
 type resourceReconciler[T any, K KubernetesCR[T]] struct {
-	kubeClient     kclient.Client
-	resourceClient resourceClient[T]
-	gvk            schema.GroupVersionKind
-	adapter        Adapter[T]
-	scoped         bool
-	teleportKind   string
-	checkFeatures  controllers.CheckFeaturesFunc
+	kubeClient       kclient.Client
+	resourceClient   resourceClient[T]
+	gvk              schema.GroupVersionKind
+	adapter          Adapter[T]
+	scoped           bool
+	teleportKind     string
+	operatorMetadata OperatorMetadata
+	checkFeatures    controllers.CheckFeaturesFunc
 }
 
 func (r resourceReconciler[T, K]) GVK() schema.GroupVersionKind {
@@ -184,6 +206,8 @@ func (r resourceReconciler[T, K]) Upsert(ctx context.Context, obj kclient.Object
 		k8sResource,
 		true, /* returnUnknownFields */
 	)
+
+	// TODO(hugoShaka): optimize the updateStatus logic so we batch status updates
 	updateErr := updateStatus(updateStatusConfig{
 		ctx:         ctx,
 		client:      r.kubeClient,
@@ -198,6 +222,21 @@ func (r resourceReconciler[T, K]) Upsert(ctx context.Context, obj kclient.Object
 
 	debugLog.Info("Converting resource to teleport")
 	key := r.resourceKey(teleportResource)
+
+	scopeCondition, scopeOK := r.checkScope(key, r.operatorMetadata)
+	updateErr = updateStatus(updateStatusConfig{
+		ctx:         ctx,
+		client:      r.kubeClient,
+		k8sResource: k8sResource,
+		condition:   scopeCondition,
+	})
+	if updateErr != nil {
+		return trace.Wrap(updateErr, "updating status scope condition")
+	}
+	if !scopeOK {
+		return trace.CompareFailed("%s", scopeCondition.Message)
+	}
+
 	existingResource, err := r.resourceClient.Get(ctx, key)
 	updateErr = updateStatus(updateStatusConfig{
 		ctx:         ctx,
@@ -214,7 +253,7 @@ func (r resourceReconciler[T, K]) Upsert(ctx context.Context, obj kclient.Object
 
 	if exists {
 		debugLog.Info("Resource already exists")
-		newOwnershipCondition, isOwned := r.checkOwnership(existingResource)
+		newOwnershipCondition, isOwned := r.checkOwnership(existingResource, r.operatorMetadata)
 		debugLog.Info("Resource is owned")
 		if updateErr = updateStatus(updateStatusConfig{
 			ctx:         ctx,
@@ -240,10 +279,14 @@ func (r resourceReconciler[T, K]) Upsert(ctx context.Context, obj kclient.Object
 	}
 
 	kubeLabels := obj.GetLabels()
-	teleportLabels := make(map[string]string, len(kubeLabels)+1) // +1 because we'll add the origin label
+	teleportLabels := make(map[string]string)
 	maps.Copy(teleportLabels, kubeLabels)
-	teleportLabels[types.OriginLabel] = types.OriginKubernetes
-	r.adapter.SetResourceLabels(teleportResource, teleportLabels)
+	r.adapter.SetResourceLabels(
+		teleportResource,
+		teleportLabels,
+		r.operatorMetadata,
+		customResourceMetadata{name: obj.GetName(), namespace: obj.GetNamespace(), gvk: r.gvk.String()},
+	)
 	debugLog.Info("Propagating labels from kube resource", "kubeLabels", kubeLabels, "teleportLabels", teleportLabels)
 
 	if mutator, ok := r.resourceClient.(resourceMutator[T]); ok {
@@ -316,6 +359,20 @@ func (r resourceReconciler[T, K]) Delete(ctx context.Context, obj kclient.Object
 		key.Scope = scope
 	}
 
+	if condition, ok := r.checkScope(key, r.operatorMetadata); !ok {
+		// If the scope doesn't match, we must not delete the resource on the Teleport side.
+		// Then we have 2 choices:
+		// - error continually until the user manually adds the "keep" label.
+		// - silently skp the deletion to let the CR be removed.
+		// As it's unlikely that the operator was managing the resource to begin with, the second option seems saner.
+		// There's a small risk of an operator changing scope, then leaving leftovers. Today we cannot detect this edge
+		// case, a potential workaround would be to introduce something in the CR status to track if it was reconciled
+		// once, and keep the last known SQN.
+		log := ctrllog.FromContext(ctx).V(0)
+		log.Info("Scope mismatch, skipping deletion", "reason", condition.Reason, "operatorScope", r.operatorMetadata.Scope, "resourceScope", key.Scope, "resourceName", key.Name, "resourceNamespace", obj.GetNamespace())
+		return nil
+	}
+
 	// This call catches non-existing resources or subkind mismatch (e.g. openssh nodes)
 	// We can then check that we own the Resource before deleting it.
 	resource, err := r.resourceClient.Get(ctx, key)
@@ -323,7 +380,7 @@ func (r resourceReconciler[T, K]) Delete(ctx context.Context, obj kclient.Object
 		return trace.Wrap(err)
 	}
 
-	_, isOwned := r.checkOwnership(resource)
+	_, isOwned := r.checkOwnership(resource, r.operatorMetadata)
 	if !isOwned {
 		// The Resource doesn't belong to us, we bail out but unblock the CR deletion
 		return nil
@@ -450,25 +507,18 @@ func isKept(obj kclient.Object) bool {
 	return checkAnnotationFlag(obj, AnnotationFlagKeep, false /* defaults to false */)
 }
 
-// isResourceOriginKubernetes reads a teleport Resource metadata, searches for the origin label and checks its
-// value is kubernetes.
-func (r resourceReconciler[T, K]) isResourceOriginKubernetes(resource T) bool {
-	origin := r.adapter.GetResourceOrigin(resource)
-	return origin == types.OriginKubernetes
-}
-
 // checkOwnership takes an existing Resource and validates the operator owns it.
 // It returns an ownership condition and a boolean representing if the Resource is
 // owned by the operator. The ownedResource must be non-nil.
-func (r resourceReconciler[T, K]) checkOwnership(existingResource T) (metav1.Condition, bool) {
-	if !r.isResourceOriginKubernetes(existingResource) {
+func (r resourceReconciler[T, K]) checkOwnership(existingResource T, metadata OperatorMetadata) (metav1.Condition, bool) {
+	if ok, reason := r.adapter.CheckOwnership(existingResource, metadata); !ok {
 		// Existing Teleport Resource does not belong to us, bailing out
 
 		condition := metav1.Condition{
 			Type:    ConditionTypeTeleportResourceOwned,
 			Status:  metav1.ConditionFalse,
 			Reason:  ConditionReasonOriginLabelNotMatching,
-			Message: "A Resource with the same name already exists in Teleport and does not have the Kubernetes origin label. Refusing to reconcile.",
+			Message: fmt.Sprintf("A resource with the same name already exists in Teleport and is not owned by the operator (%s). Refusing to reconcile.", reason),
 		}
 		return condition, false
 	}
@@ -477,9 +527,52 @@ func (r resourceReconciler[T, K]) checkOwnership(existingResource T) (metav1.Con
 		Type:    ConditionTypeTeleportResourceOwned,
 		Status:  metav1.ConditionTrue,
 		Reason:  ConditionReasonOriginLabelMatching,
-		Message: "Teleport Resource has the Kubernetes origin label.",
+		Message: "Teleport resource is owned by the operator.",
 	}
 	return condition, true
+}
+
+// checkOwnership takes an existing Resource and validates the operator owns it.
+// It returns an ownership condition and a boolean representing if the Resource is
+// owned by the operator. The ownedResource must be non-nil.
+func (r resourceReconciler[T, K]) checkScope(key ResourceKey, metadata OperatorMetadata) (metav1.Condition, bool) {
+	switch {
+	case key.Scope == "" && metadata.Scope == "":
+		return metav1.Condition{
+			Type:    ConditionTypeValidScope,
+			Status:  metav1.ConditionTrue,
+			Reason:  ConditionTypeUnscoped,
+			Message: "Neither resource or operator are scoped",
+		}, true
+	case key.Scope != "" && metadata.Scope == "":
+		return metav1.Condition{
+			Type:    ConditionTypeValidScope,
+			Status:  metav1.ConditionFalse,
+			Reason:  ConditionReasonNonMatchingScope,
+			Message: "Resource is scoped but operator is not. Refusing to reconcile.",
+		}, false
+	case key.Scope == "" && metadata.Scope != "":
+		return metav1.Condition{
+			Type:    ConditionTypeValidScope,
+			Status:  metav1.ConditionFalse,
+			Reason:  ConditionReasonNonMatchingScope,
+			Message: "Operator is scoped but resource is not. Refusing to reconcile.",
+		}, false
+	case metadata.Scope == key.Scope:
+		return metav1.Condition{
+			Type:    ConditionTypeValidScope,
+			Status:  metav1.ConditionTrue,
+			Reason:  ConditionReasonMatchingScope,
+			Message: "Resource scope matches the operator scope.",
+		}, true
+	default:
+		return metav1.Condition{
+			Type:    ConditionTypeValidScope,
+			Status:  metav1.ConditionFalse,
+			Reason:  ConditionReasonNonMatchingScope,
+			Message: fmt.Sprintf("Resource scope %q does not match the operator scope %q.", key.Scope, metadata.Scope),
+		}, false
+	}
 }
 
 var newResourceCondition = metav1.Condition{

--- a/integrations/operator/controllers/reconcilers/generic_test.go
+++ b/integrations/operator/controllers/reconcilers/generic_test.go
@@ -107,7 +107,7 @@ func (f *fakeTeleportResourceClient) Delete(_ context.Context, id ResourceKey) e
 }
 
 // resourceExists checks if a Resource is in the store.
-// This is use fr testing purposes.
+// This is use for testing purposes.
 func (f *fakeTeleportResourceClient) resourceExists(name string) bool {
 	_, ok := f.store[name]
 	return ok
@@ -152,15 +152,18 @@ func (f fakeResourceAdapter[T]) GetResourceRevision(res T) string {
 	return res.GetMetadata().Revision
 }
 
-func (f fakeResourceAdapter[T]) GetResourceOrigin(res T) string {
+func (f fakeResourceAdapter[T]) CheckOwnership(res T, _ OperatorMetadata) (bool, string) {
 	labels := res.GetMetadata().Labels
 	if len(labels) == 0 {
-		return ""
+		return false, ownershipIssueMissingOriginLabel
 	}
 	if origin, ok := labels[types.OriginLabel]; ok {
-		return origin
+		if origin == types.OriginKubernetes {
+			return true, ""
+		}
+		return false, ownershipIssueMismatchOriginLabel
 	}
-	return ""
+	return false, ownershipIssueMissingOriginLabel
 }
 
 func (f fakeResourceAdapter[T]) SetResourceRevision(res T, rev string) {
@@ -169,7 +172,8 @@ func (f fakeResourceAdapter[T]) SetResourceRevision(res T, rev string) {
 	res.SetMetadata(metadata)
 }
 
-func (f fakeResourceAdapter[T]) SetResourceLabels(res T, labels map[string]string) {
+func (f fakeResourceAdapter[T]) SetResourceLabels(res T, labels map[string]string, _ OperatorMetadata, _ customResourceMetadata) {
+	labels[types.OriginLabel] = types.OriginKubernetes
 	metadata := res.GetMetadata()
 	metadata.Labels = labels
 	res.SetMetadata(metadata)
@@ -296,7 +300,7 @@ func TestCheckOwnership(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 
-			condition, isOwned := reconciler.checkOwnership(tc.existingResource)
+			condition, isOwned := reconciler.checkOwnership(tc.existingResource, OperatorMetadata{})
 
 			require.Equal(t, tc.isOwned, isOwned)
 			require.Equal(t, ConditionTypeTeleportResourceOwned, condition.Type)

--- a/integrations/operator/controllers/reconcilers/legacy_resource_with_labels.go
+++ b/integrations/operator/controllers/reconcilers/legacy_resource_with_labels.go
@@ -149,6 +149,7 @@ func NewTeleportScopedResourceWithLabelsReconciler[T ScopedResourceWithLabels, K
 	kubeClient kclient.Client,
 	resourceClient resourceClient[T],
 	config Config,
+	metadata OperatorMetadata,
 ) (controllers.Reconciler, error) {
 	checkFeatures := controllers.AlwaysEnabled
 	if config.CheckFeatures != nil {
@@ -166,13 +167,14 @@ func NewTeleportScopedResourceWithLabelsReconciler[T ScopedResourceWithLabels, K
 	}
 
 	reconciler := &resourceReconciler[T, K]{
-		kubeClient:     kubeClient,
-		resourceClient: resourceClient,
-		gvk:            gvk,
-		adapter:        ScopedResourceWithLabelsAdapter[T]{},
-		scoped:         true,
-		teleportKind:   teleportKind,
-		checkFeatures:  checkFeatures,
+		kubeClient:       kubeClient,
+		resourceClient:   resourceClient,
+		gvk:              gvk,
+		adapter:          ScopedResourceWithLabelsAdapter[T]{},
+		scoped:           true,
+		teleportKind:     teleportKind,
+		checkFeatures:    checkFeatures,
+		operatorMetadata: metadata,
 	}
 	return reconciler, nil
 }

--- a/integrations/operator/controllers/reconcilers/legacy_resource_with_labels.go
+++ b/integrations/operator/controllers/reconcilers/legacy_resource_with_labels.go
@@ -19,6 +19,8 @@
 package reconcilers
 
 import (
+	"fmt"
+
 	"github.com/gravitational/trace"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -41,10 +43,17 @@ func (a ResourceWithLabelsAdapter[T]) GetResourceRevision(res T) string {
 	return res.GetRevision()
 }
 
-// GetResourceOrigin implements the Adapter interface.
-func (a ResourceWithLabelsAdapter[T]) GetResourceOrigin(res T) string {
+// CheckOwnership implements the Adapter interface.
+func (a ResourceWithLabelsAdapter[T]) CheckOwnership(res T, _ OperatorMetadata) (bool, string) {
 	origin, _ := res.GetLabel(types.OriginLabel)
-	return origin
+	switch origin {
+	case types.OriginKubernetes:
+		return true, ""
+	case "":
+		return false, ownershipIssueMissingOriginLabel
+	default:
+		return false, fmt.Sprintf(ownershipIssueMismatchOriginLabel, origin)
+	}
 }
 
 // SetResourceRevision implements the Adapter interface.
@@ -53,7 +62,8 @@ func (a ResourceWithLabelsAdapter[T]) SetResourceRevision(res T, revision string
 }
 
 // SetResourceLabels implements the Adapter interface.
-func (a ResourceWithLabelsAdapter[T]) SetResourceLabels(res T, labels map[string]string) {
+func (a ResourceWithLabelsAdapter[T]) SetResourceLabels(res T, labels map[string]string, _ OperatorMetadata, _ customResourceMetadata) {
+	labels[types.OriginLabel] = types.OriginKubernetes
 	res.SetStaticLabels(labels)
 }
 
@@ -87,6 +97,84 @@ func NewTeleportResourceWithLabelsReconciler[T types.ResourceWithLabels, K Kuber
 		scoped:         config.Scoped,
 		teleportKind:   teleportKind,
 		checkFeatures:  checkFeatures,
+	}
+	return reconciler, nil
+}
+
+// ScopedResourceWithLabels extends [types.ResourceWithLabels] for Teleport
+// resources that are scoped.
+type ScopedResourceWithLabels interface {
+	types.ResourceWithLabels
+	GetScope() string
+}
+
+type ScopedResourceWithLabelsAdapter[T ScopedResourceWithLabels] struct {
+	ResourceWithLabelsAdapter[T]
+}
+
+func (a ScopedResourceWithLabelsAdapter[T]) GetResourceScope(res T) string {
+	return res.GetScope()
+}
+
+func (a ScopedResourceWithLabelsAdapter[T]) CheckOwnership(res T, metadata OperatorMetadata) (bool, string) {
+	// Do the base tests.
+	if ok, reason := a.ResourceWithLabelsAdapter.CheckOwnership(res, metadata); !ok {
+		return ok, reason
+	}
+
+	// For scoped resources, also check the operator ID.
+	if res.GetScope() == "" {
+		return true, ""
+	}
+	if id, ok := res.GetLabel(OperatorIDLabel); ok {
+		if id != metadata.ID {
+			return false, fmt.Sprintf(ownershipIssueMismatchOperatorID, id, metadata.ID)
+		}
+		return true, ""
+	}
+
+	return false, ownershipIssueMissingOperatorID
+}
+
+func (a ScopedResourceWithLabelsAdapter[T]) SetResourceLabels(res T, labels map[string]string, metadata OperatorMetadata, customResourceMetadata customResourceMetadata) {
+	if res.GetScope() == "" {
+		a.ResourceWithLabelsAdapter.SetResourceLabels(res, labels, metadata, customResourceMetadata)
+		return
+	}
+	updateScopedLabels(labels, metadata, customResourceMetadata)
+	res.SetStaticLabels(labels)
+}
+
+func NewTeleportScopedResourceWithLabelsReconciler[T ScopedResourceWithLabels, K KubernetesCR[T]](
+	kubeClient kclient.Client,
+	resourceClient resourceClient[T],
+	config Config,
+	metadata OperatorMetadata,
+) (controllers.Reconciler, error) {
+	checkFeatures := controllers.AlwaysEnabled
+	if config.CheckFeatures != nil {
+		checkFeatures = config.CheckFeatures
+	}
+
+	gvk, err := gvkFromScheme[K](controllers.Scheme)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	teleportKind := newKubeResource[K]().ToTeleport().GetKind()
+	if teleportKind == "" {
+		return nil, trace.BadParameter("teleport kind is required, this is a bug")
+	}
+
+	reconciler := &resourceReconciler[T, K]{
+		kubeClient:       kubeClient,
+		resourceClient:   resourceClient,
+		gvk:              gvk,
+		adapter:          ScopedResourceWithLabelsAdapter[T]{},
+		scoped:           true,
+		teleportKind:     teleportKind,
+		checkFeatures:    checkFeatures,
+		operatorMetadata: metadata,
 	}
 	return reconciler, nil
 }

--- a/integrations/operator/controllers/reconcilers/legacy_resource_with_labels.go
+++ b/integrations/operator/controllers/reconcilers/legacy_resource_with_labels.go
@@ -19,6 +19,8 @@
 package reconcilers
 
 import (
+	"fmt"
+
 	"github.com/gravitational/trace"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -41,10 +43,17 @@ func (a ResourceWithLabelsAdapter[T]) GetResourceRevision(res T) string {
 	return res.GetRevision()
 }
 
-// GetResourceOrigin implements the Adapter interface.
-func (a ResourceWithLabelsAdapter[T]) GetResourceOrigin(res T) string {
+// CheckOwnership implements the Adapter interface.
+func (a ResourceWithLabelsAdapter[T]) CheckOwnership(res T, _ OperatorMetadata) (bool, string) {
 	origin, _ := res.GetLabel(types.OriginLabel)
-	return origin
+	switch origin {
+	case types.OriginKubernetes:
+		return true, ""
+	case "":
+		return false, ownershipIssueMissingOriginLabel
+	default:
+		return false, fmt.Sprintf(ownershipIssueMismatchOriginLabel, origin)
+	}
 }
 
 // SetResourceRevision implements the Adapter interface.
@@ -53,7 +62,8 @@ func (a ResourceWithLabelsAdapter[T]) SetResourceRevision(res T, revision string
 }
 
 // SetResourceLabels implements the Adapter interface.
-func (a ResourceWithLabelsAdapter[T]) SetResourceLabels(res T, labels map[string]string) {
+func (a ResourceWithLabelsAdapter[T]) SetResourceLabels(res T, labels map[string]string, _ OperatorMetadata, _ customResourceMetadata) {
+	labels[types.OriginLabel] = types.OriginKubernetes
 	res.SetStaticLabels(labels)
 }
 
@@ -85,6 +95,82 @@ func NewTeleportResourceWithLabelsReconciler[T types.ResourceWithLabels, K Kuber
 		gvk:            gvk,
 		adapter:        ResourceWithLabelsAdapter[T]{},
 		scoped:         config.Scoped,
+		teleportKind:   teleportKind,
+		checkFeatures:  checkFeatures,
+	}
+	return reconciler, nil
+}
+
+// ScopedResourceWithLabels extends [types.ResourceWithLabels] for Teleport
+// resources that are scoped.
+type ScopedResourceWithLabels interface {
+	types.ResourceWithLabels
+	GetScope() string
+}
+
+type ScopedResourceWithLabelsAdapter[T ScopedResourceWithLabels] struct {
+	ResourceWithLabelsAdapter[T]
+}
+
+func (a ScopedResourceWithLabelsAdapter[T]) GetResourceScope(res T) string {
+	return res.GetScope()
+}
+
+func (a ScopedResourceWithLabelsAdapter[T]) CheckOwnership(res T, metadata OperatorMetadata) (bool, string) {
+	// Do the base tests.
+	if ok, reason := a.ResourceWithLabelsAdapter.CheckOwnership(res, metadata); !ok {
+		return ok, reason
+	}
+
+	// For scoped resources, also check the operator ID.
+	if res.GetScope() == "" {
+		return true, ""
+	}
+	if id, ok := res.GetLabel(OperatorIDLabel); ok {
+		if id != metadata.ID {
+			return false, fmt.Sprintf(ownershipIssueMismatchOperatorID, id, metadata.ID)
+		}
+		return true, ""
+	}
+
+	return false, ownershipIssueMissingOperatorID
+}
+
+func (a ScopedResourceWithLabelsAdapter[T]) SetResourceLabels(res T, labels map[string]string, metadata OperatorMetadata, customResourceMetadata customResourceMetadata) {
+	if res.GetScope() == "" {
+		a.ResourceWithLabelsAdapter.SetResourceLabels(res, labels, metadata, customResourceMetadata)
+		return
+	}
+	updateScopedLabels(labels, metadata, customResourceMetadata)
+	res.SetStaticLabels(labels)
+}
+
+func NewTeleportScopedResourceWithLabelsReconciler[T ScopedResourceWithLabels, K KubernetesCR[T]](
+	kubeClient kclient.Client,
+	resourceClient resourceClient[T],
+	config Config,
+) (controllers.Reconciler, error) {
+	checkFeatures := controllers.AlwaysEnabled
+	if config.CheckFeatures != nil {
+		checkFeatures = config.CheckFeatures
+	}
+
+	gvk, err := gvkFromScheme[K](controllers.Scheme)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	teleportKind := newKubeResource[K]().ToTeleport().GetKind()
+	if teleportKind == "" {
+		return nil, trace.BadParameter("teleport kind is required, this is a bug")
+	}
+
+	reconciler := &resourceReconciler[T, K]{
+		kubeClient:     kubeClient,
+		resourceClient: resourceClient,
+		gvk:            gvk,
+		adapter:        ScopedResourceWithLabelsAdapter[T]{},
+		scoped:         true,
 		teleportKind:   teleportKind,
 		checkFeatures:  checkFeatures,
 	}

--- a/integrations/operator/controllers/reconcilers/legacy_resource_with_labels_test.go
+++ b/integrations/operator/controllers/reconcilers/legacy_resource_with_labels_test.go
@@ -1,0 +1,268 @@
+package reconcilers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+type fakeResourceWithLabels struct {
+	types.ResourceWithLabels
+	labels map[string]string
+	scope  string
+}
+
+func (r *fakeResourceWithLabels) GetLabel(key string) (string, bool) {
+	value, ok := r.labels[key]
+	return value, ok
+}
+
+func (r *fakeResourceWithLabels) SetStaticLabels(labels map[string]string) {
+	r.labels = labels
+}
+
+func (r *fakeResourceWithLabels) GetScope() string {
+	return r.scope
+}
+
+func TestResourceWithLabelsAdapter_CheckOwnership(t *testing.T) {
+	tests := []struct {
+		name           string
+		resource       *fakeResourceWithLabels
+		expected       bool
+		expectedReason string
+	}{
+		{
+			name:           "no labels",
+			resource:       &fakeResourceWithLabels{labels: map[string]string{}},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name:           "labels but no origin",
+			resource:       &fakeResourceWithLabels{labels: map[string]string{"foo": "bar"}},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name:           "origin label mismatch",
+			resource:       &fakeResourceWithLabels{labels: map[string]string{types.OriginLabel: types.OriginDefaults}},
+			expected:       false,
+			expectedReason: fmt.Sprintf(ownershipIssueMismatchOriginLabel, types.OriginDefaults),
+		},
+		{
+			name:     "origin label match",
+			resource: &fakeResourceWithLabels{labels: map[string]string{types.OriginLabel: types.OriginKubernetes}},
+			expected: true,
+		},
+	}
+
+	adapter := ResourceWithLabelsAdapter[*fakeResourceWithLabels]{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owned, reason := adapter.CheckOwnership(tt.resource, OperatorMetadata{})
+			require.Equal(t, tt.expected, owned)
+			require.Equal(t, tt.expectedReason, reason)
+		})
+	}
+}
+
+func TestResourceWithLabelsAdapter_SetResourceLabels(t *testing.T) {
+	adapter := ResourceWithLabelsAdapter[*fakeResourceWithLabels]{}
+	resource := &fakeResourceWithLabels{labels: map[string]string{}}
+	adapter.SetResourceLabels(resource, map[string]string{
+		"foo": "bar",
+	}, OperatorMetadata{
+		Namespace: "unused",
+		ID:        "unused",
+		TokenName: "unused",
+		Scope:     "unused",
+		Owner:     "unused",
+	}, customResourceMetadata{
+		name:      "unused",
+		namespace: "unused",
+		gvk:       "unused",
+	})
+	require.Equal(t, map[string]string{types.OriginLabel: types.OriginKubernetes, "foo": "bar"}, resource.labels)
+}
+
+func TestScopedResourceWithLabelsAdapter_CheckOwnership(t *testing.T) {
+	const (
+		testID        = "test-id"
+		conflictingID = "conflicting-id"
+		testScope     = "/team/a"
+	)
+	tests := []struct {
+		name           string
+		resource       *fakeResourceWithLabels
+		expected       bool
+		expectedReason string
+	}{
+		{
+			name:           "unscoped - no labels",
+			resource:       &fakeResourceWithLabels{labels: map[string]string{}},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name:           "uncscope - labels but no origin",
+			resource:       &fakeResourceWithLabels{labels: map[string]string{"foo": "bar"}},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name:           "unscoped - origin label mismatch",
+			resource:       &fakeResourceWithLabels{labels: map[string]string{types.OriginLabel: types.OriginDefaults}},
+			expected:       false,
+			expectedReason: fmt.Sprintf(ownershipIssueMismatchOriginLabel, types.OriginDefaults),
+		},
+		{
+			name:     "unscoped - origin label match but no id",
+			resource: &fakeResourceWithLabels{labels: map[string]string{types.OriginLabel: types.OriginKubernetes}},
+			expected: true,
+		},
+		{
+			name:     "unscoped - origin label match but mismatch id",
+			resource: &fakeResourceWithLabels{labels: map[string]string{types.OriginLabel: types.OriginKubernetes, OperatorIDLabel: conflictingID}},
+			expected: true,
+		},
+		{
+			name:     "unscoped - origin label match and matching id",
+			resource: &fakeResourceWithLabels{labels: map[string]string{types.OriginLabel: types.OriginKubernetes, OperatorIDLabel: testID}},
+			expected: true,
+		},
+		{
+			name: "scoped - no labels",
+			resource: &fakeResourceWithLabels{
+				labels: map[string]string{},
+				scope:  testScope,
+			},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name: "scoped - labels but no origin",
+			resource: &fakeResourceWithLabels{
+				labels: map[string]string{"foo": "bar"},
+				scope:  testScope,
+			},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name: "scoped - origin label mismatch",
+			resource: &fakeResourceWithLabels{
+				labels: map[string]string{types.OriginLabel: types.OriginDefaults},
+				scope:  testScope,
+			},
+			expected:       false,
+			expectedReason: fmt.Sprintf(ownershipIssueMismatchOriginLabel, types.OriginDefaults),
+		},
+		{
+			name: "scoped - origin label match but no id",
+			resource: &fakeResourceWithLabels{
+				labels: map[string]string{types.OriginLabel: types.OriginKubernetes},
+				scope:  testScope,
+			},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOperatorID,
+		},
+		{
+			name: "scoped - origin label match but mismatch id",
+			resource: &fakeResourceWithLabels{
+				labels: map[string]string{types.OriginLabel: types.OriginKubernetes, OperatorIDLabel: conflictingID},
+				scope:  testScope,
+			},
+			expected:       false,
+			expectedReason: fmt.Sprintf(ownershipIssueMismatchOperatorID, conflictingID, testID),
+		},
+		{
+			name: "scoped - origin label match and matching id",
+			resource: &fakeResourceWithLabels{
+				labels: map[string]string{types.OriginLabel: types.OriginKubernetes, OperatorIDLabel: testID},
+				scope:  testScope,
+			},
+			expected: true,
+		},
+	}
+
+	adapter := ScopedResourceWithLabelsAdapter[*fakeResourceWithLabels]{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owned, reason := adapter.CheckOwnership(tt.resource, OperatorMetadata{ID: testID})
+			require.Equal(t, tt.expected, owned)
+			require.Equal(t, tt.expectedReason, reason)
+		})
+	}
+
+}
+
+func TestScopedResourceWithLabelsAdapter_SetLabels(t *testing.T) {
+	const testScope = "/team/a"
+	initialLabels := map[string]string{
+		"foo": "bar",
+	}
+	kubeLabels := map[string]string{
+		"kube": "label",
+	}
+
+	operatorMetadata := OperatorMetadata{
+		Namespace: "namespace",
+		ID:        "id",
+		TokenName: "token",
+		Scope:     "scope",
+		Owner:     "owner",
+	}
+	resourceMetadata := customResourceMetadata{
+		namespace: "cr-namespace",
+		name:      "name",
+		gvk:       "gvk",
+	}
+
+	tests := []struct {
+		name           string
+		resource       *fakeResourceWithLabels
+		expectedLabels map[string]string
+	}{
+		{
+			name: "unscoped",
+			resource: &fakeResourceWithLabels{
+				labels: initialLabels,
+			},
+			expectedLabels: map[string]string{
+				"kube":            "label",
+				types.OriginLabel: types.OriginKubernetes,
+			},
+		},
+		{
+			name: "scoped",
+			resource: &fakeResourceWithLabels{
+				labels: initialLabels,
+				scope:  testScope,
+			},
+			expectedLabels: map[string]string{
+				"kube":                       "label",
+				types.OriginLabel:            types.OriginKubernetes,
+				OperatorIDLabel:              operatorMetadata.ID,
+				operatorNamespaceLabel:       operatorMetadata.Namespace,
+				operatorOwnerLabel:           operatorMetadata.Owner,
+				operatorTokenNameLabel:       operatorMetadata.TokenName,
+				customResourceNameLabel:      resourceMetadata.name,
+				customResourceNamespaceLabel: resourceMetadata.namespace,
+				customResourceGVKLabel:       resourceMetadata.gvk,
+			},
+		},
+	}
+
+	adapter := ScopedResourceWithLabelsAdapter[*fakeResourceWithLabels]{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter.SetResourceLabels(tt.resource, kubeLabels, operatorMetadata, resourceMetadata)
+			require.Equal(t, tt.expectedLabels, tt.resource.labels)
+		})
+	}
+}

--- a/integrations/operator/controllers/reconcilers/legacy_resource_with_labels_test.go
+++ b/integrations/operator/controllers/reconcilers/legacy_resource_with_labels_test.go
@@ -1,0 +1,284 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package reconcilers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+type fakeResourceWithLabels struct {
+	types.ResourceWithLabels
+	labels map[string]string
+	scope  string
+}
+
+func (r *fakeResourceWithLabels) GetLabel(key string) (string, bool) {
+	value, ok := r.labels[key]
+	return value, ok
+}
+
+func (r *fakeResourceWithLabels) SetStaticLabels(labels map[string]string) {
+	r.labels = labels
+}
+
+func (r *fakeResourceWithLabels) GetScope() string {
+	return r.scope
+}
+
+func TestResourceWithLabelsAdapter_CheckOwnership(t *testing.T) {
+	tests := []struct {
+		name           string
+		resource       *fakeResourceWithLabels
+		expected       bool
+		expectedReason string
+	}{
+		{
+			name:           "no labels",
+			resource:       &fakeResourceWithLabels{labels: map[string]string{}},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name:           "labels but no origin",
+			resource:       &fakeResourceWithLabels{labels: map[string]string{"foo": "bar"}},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name:           "origin label mismatch",
+			resource:       &fakeResourceWithLabels{labels: map[string]string{types.OriginLabel: types.OriginDefaults}},
+			expected:       false,
+			expectedReason: fmt.Sprintf(ownershipIssueMismatchOriginLabel, types.OriginDefaults),
+		},
+		{
+			name:     "origin label match",
+			resource: &fakeResourceWithLabels{labels: map[string]string{types.OriginLabel: types.OriginKubernetes}},
+			expected: true,
+		},
+	}
+
+	adapter := ResourceWithLabelsAdapter[*fakeResourceWithLabels]{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owned, reason := adapter.CheckOwnership(tt.resource, OperatorMetadata{})
+			require.Equal(t, tt.expected, owned)
+			require.Equal(t, tt.expectedReason, reason)
+		})
+	}
+}
+
+func TestResourceWithLabelsAdapter_SetResourceLabels(t *testing.T) {
+	adapter := ResourceWithLabelsAdapter[*fakeResourceWithLabels]{}
+	resource := &fakeResourceWithLabels{labels: map[string]string{}}
+	adapter.SetResourceLabels(resource, map[string]string{
+		"foo": "bar",
+	}, OperatorMetadata{
+		Namespace: "unused",
+		ID:        "unused",
+		TokenName: "unused",
+		Scope:     "unused",
+		Owner:     "unused",
+	}, customResourceMetadata{
+		name:      "unused",
+		namespace: "unused",
+		gvk:       "unused",
+	})
+	require.Equal(t, map[string]string{types.OriginLabel: types.OriginKubernetes, "foo": "bar"}, resource.labels)
+}
+
+func TestScopedResourceWithLabelsAdapter_CheckOwnership(t *testing.T) {
+	const (
+		testID        = "test-id"
+		conflictingID = "conflicting-id"
+		testScope     = "/team/a"
+	)
+	tests := []struct {
+		name           string
+		resource       *fakeResourceWithLabels
+		expected       bool
+		expectedReason string
+	}{
+		{
+			name:           "unscoped - no labels",
+			resource:       &fakeResourceWithLabels{labels: map[string]string{}},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name:           "uncscope - labels but no origin",
+			resource:       &fakeResourceWithLabels{labels: map[string]string{"foo": "bar"}},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name:           "unscoped - origin label mismatch",
+			resource:       &fakeResourceWithLabels{labels: map[string]string{types.OriginLabel: types.OriginDefaults}},
+			expected:       false,
+			expectedReason: fmt.Sprintf(ownershipIssueMismatchOriginLabel, types.OriginDefaults),
+		},
+		{
+			name:     "unscoped - origin label match but no id",
+			resource: &fakeResourceWithLabels{labels: map[string]string{types.OriginLabel: types.OriginKubernetes}},
+			expected: true,
+		},
+		{
+			name:     "unscoped - origin label match but mismatch id",
+			resource: &fakeResourceWithLabels{labels: map[string]string{types.OriginLabel: types.OriginKubernetes, OperatorIDLabel: conflictingID}},
+			expected: true,
+		},
+		{
+			name:     "unscoped - origin label match and matching id",
+			resource: &fakeResourceWithLabels{labels: map[string]string{types.OriginLabel: types.OriginKubernetes, OperatorIDLabel: testID}},
+			expected: true,
+		},
+		{
+			name: "scoped - no labels",
+			resource: &fakeResourceWithLabels{
+				labels: map[string]string{},
+				scope:  testScope,
+			},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name: "scoped - labels but no origin",
+			resource: &fakeResourceWithLabels{
+				labels: map[string]string{"foo": "bar"},
+				scope:  testScope,
+			},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name: "scoped - origin label mismatch",
+			resource: &fakeResourceWithLabels{
+				labels: map[string]string{types.OriginLabel: types.OriginDefaults},
+				scope:  testScope,
+			},
+			expected:       false,
+			expectedReason: fmt.Sprintf(ownershipIssueMismatchOriginLabel, types.OriginDefaults),
+		},
+		{
+			name: "scoped - origin label match but no id",
+			resource: &fakeResourceWithLabels{
+				labels: map[string]string{types.OriginLabel: types.OriginKubernetes},
+				scope:  testScope,
+			},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOperatorID,
+		},
+		{
+			name: "scoped - origin label match but mismatch id",
+			resource: &fakeResourceWithLabels{
+				labels: map[string]string{types.OriginLabel: types.OriginKubernetes, OperatorIDLabel: conflictingID},
+				scope:  testScope,
+			},
+			expected:       false,
+			expectedReason: fmt.Sprintf(ownershipIssueMismatchOperatorID, conflictingID, testID),
+		},
+		{
+			name: "scoped - origin label match and matching id",
+			resource: &fakeResourceWithLabels{
+				labels: map[string]string{types.OriginLabel: types.OriginKubernetes, OperatorIDLabel: testID},
+				scope:  testScope,
+			},
+			expected: true,
+		},
+	}
+
+	adapter := ScopedResourceWithLabelsAdapter[*fakeResourceWithLabels]{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owned, reason := adapter.CheckOwnership(tt.resource, OperatorMetadata{ID: testID})
+			require.Equal(t, tt.expected, owned)
+			require.Equal(t, tt.expectedReason, reason)
+		})
+	}
+
+}
+
+func TestScopedResourceWithLabelsAdapter_SetLabels(t *testing.T) {
+	const testScope = "/team/a"
+	initialLabels := map[string]string{
+		"foo": "bar",
+	}
+	kubeLabels := map[string]string{
+		"kube": "label",
+	}
+
+	operatorMetadata := OperatorMetadata{
+		Namespace: "namespace",
+		ID:        "id",
+		TokenName: "token",
+		Scope:     "scope",
+		Owner:     "owner",
+	}
+	resourceMetadata := customResourceMetadata{
+		namespace: "cr-namespace",
+		name:      "name",
+		gvk:       "gvk",
+	}
+
+	tests := []struct {
+		name           string
+		resource       *fakeResourceWithLabels
+		expectedLabels map[string]string
+	}{
+		{
+			name: "unscoped",
+			resource: &fakeResourceWithLabels{
+				labels: initialLabels,
+			},
+			expectedLabels: map[string]string{
+				"kube":            "label",
+				types.OriginLabel: types.OriginKubernetes,
+			},
+		},
+		{
+			name: "scoped",
+			resource: &fakeResourceWithLabels{
+				labels: initialLabels,
+				scope:  testScope,
+			},
+			expectedLabels: map[string]string{
+				"kube":                       "label",
+				types.OriginLabel:            types.OriginKubernetes,
+				OperatorIDLabel:              operatorMetadata.ID,
+				operatorNamespaceLabel:       operatorMetadata.Namespace,
+				operatorOwnerLabel:           operatorMetadata.Owner,
+				operatorTokenNameLabel:       operatorMetadata.TokenName,
+				customResourceNameLabel:      resourceMetadata.name,
+				customResourceNamespaceLabel: resourceMetadata.namespace,
+				customResourceGVKLabel:       resourceMetadata.gvk,
+			},
+		},
+	}
+
+	adapter := ScopedResourceWithLabelsAdapter[*fakeResourceWithLabels]{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter.SetResourceLabels(tt.resource, kubeLabels, operatorMetadata, resourceMetadata)
+			require.Equal(t, tt.expectedLabels, tt.resource.labels)
+		})
+	}
+}

--- a/integrations/operator/controllers/reconcilers/legacy_resource_without_labels.go
+++ b/integrations/operator/controllers/reconcilers/legacy_resource_without_labels.go
@@ -19,6 +19,8 @@
 package reconcilers
 
 import (
+	"fmt"
+
 	"github.com/gravitational/trace"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -52,9 +54,17 @@ func (a ResourceWithoutLabelsAdapter[T]) GetResourceRevision(res T) string {
 	return res.GetRevision()
 }
 
-// GetResourceOrigin implements the Adapter interface.
-func (a ResourceWithoutLabelsAdapter[T]) GetResourceOrigin(res T) string {
-	return res.Origin()
+// CheckOwnership implements the Adapter interface.
+func (a ResourceWithoutLabelsAdapter[T]) CheckOwnership(res T, _ OperatorMetadata) (bool, string) {
+	origin := res.Origin()
+	switch origin {
+	case types.OriginKubernetes:
+		return true, ""
+	case "":
+		return false, ownershipIssueMissingOriginLabel
+	default:
+		return false, fmt.Sprintf(ownershipIssueMismatchOriginLabel, origin)
+	}
 }
 
 // SetResourceRevision implements the Adapter interface.
@@ -64,11 +74,10 @@ func (a ResourceWithoutLabelsAdapter[T]) SetResourceRevision(res T, revision str
 
 // SetResourceLabels implements the Adapter interface. As the resource does not
 // support labels, it only sets the origin label.
-func (a ResourceWithoutLabelsAdapter[T]) SetResourceLabels(res T, labels map[string]string) {
+func (a ResourceWithoutLabelsAdapter[T]) SetResourceLabels(res T, labels map[string]string, _ OperatorMetadata, _ customResourceMetadata) {
 	// We don't set all labels as the Resource doesn't support them
 	// Only the origin
-	origin := labels[types.OriginLabel]
-	res.SetOrigin(origin)
+	res.SetOrigin(types.OriginKubernetes)
 }
 
 // NewTeleportResourceWithoutLabelsReconciler instantiates a resourceReconciler for a

--- a/integrations/operator/controllers/reconcilers/legacy_resource_without_labels_test.go
+++ b/integrations/operator/controllers/reconcilers/legacy_resource_without_labels_test.go
@@ -1,0 +1,101 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package reconcilers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+type fakeResourceWithoutLabels struct {
+	resourceWithoutLabels
+	labels map[string]string
+}
+
+func (r *fakeResourceWithoutLabels) Origin() string {
+	return r.labels[types.OriginLabel]
+}
+
+func (r *fakeResourceWithoutLabels) SetOrigin(origin string) {
+	r.labels[types.OriginLabel] = origin
+}
+
+func TestResourceWithoutLabelsAdapter_CheckOwnership(t *testing.T) {
+	tests := []struct {
+		name           string
+		resource       *fakeResourceWithoutLabels
+		expected       bool
+		expectedReason string
+	}{
+		{
+			name:           "no labels",
+			resource:       &fakeResourceWithoutLabels{labels: map[string]string{}},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name:           "labels but no origin",
+			resource:       &fakeResourceWithoutLabels{labels: map[string]string{"foo": "bar"}},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name:           "origin label mismatch",
+			resource:       &fakeResourceWithoutLabels{labels: map[string]string{types.OriginLabel: types.OriginDefaults}},
+			expected:       false,
+			expectedReason: fmt.Sprintf(ownershipIssueMismatchOriginLabel, types.OriginDefaults),
+		},
+		{
+			name:     "origin label match",
+			resource: &fakeResourceWithoutLabels{labels: map[string]string{types.OriginLabel: types.OriginKubernetes}},
+			expected: true,
+		},
+	}
+
+	adapter := ResourceWithoutLabelsAdapter[*fakeResourceWithoutLabels]{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owned, reason := adapter.CheckOwnership(tt.resource, OperatorMetadata{})
+			require.Equal(t, tt.expected, owned)
+			require.Equal(t, tt.expectedReason, reason)
+		})
+	}
+
+}
+
+func TestResourceWithoutLabelsAdapter_SetResourceLabels(t *testing.T) {
+	adapter := ResourceWithoutLabelsAdapter[*fakeResourceWithoutLabels]{}
+	resource := &fakeResourceWithoutLabels{labels: map[string]string{}}
+	adapter.SetResourceLabels(resource, map[string]string{
+		"foo": "bar",
+	}, OperatorMetadata{
+		Namespace: "unused",
+		ID:        "unused",
+		TokenName: "unused",
+		Scope:     "unused",
+		Owner:     "unused",
+	}, customResourceMetadata{
+		name:      "unused",
+		namespace: "unused",
+		gvk:       "unused",
+	})
+	require.Equal(t, map[string]string{types.OriginLabel: types.OriginKubernetes}, resource.labels)
+}

--- a/integrations/operator/controllers/reconcilers/legacy_resource_without_labels_test.go
+++ b/integrations/operator/controllers/reconcilers/legacy_resource_without_labels_test.go
@@ -1,0 +1,85 @@
+package reconcilers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+type fakeResourceWithoutLabels struct {
+	resourceWithoutLabels
+	labels map[string]string
+}
+
+func (r *fakeResourceWithoutLabels) Origin() string {
+	return r.labels[types.OriginLabel]
+}
+
+func (r *fakeResourceWithoutLabels) SetOrigin(origin string) {
+	r.labels[types.OriginLabel] = origin
+}
+
+func TestResourceWithoutLabelsAdapter_CheckOwnership(t *testing.T) {
+	tests := []struct {
+		name           string
+		resource       *fakeResourceWithoutLabels
+		expected       bool
+		expectedReason string
+	}{
+		{
+			name:           "no labels",
+			resource:       &fakeResourceWithoutLabels{labels: map[string]string{}},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name:           "labels but no origin",
+			resource:       &fakeResourceWithoutLabels{labels: map[string]string{"foo": "bar"}},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name:           "origin label mismatch",
+			resource:       &fakeResourceWithoutLabels{labels: map[string]string{types.OriginLabel: types.OriginDefaults}},
+			expected:       false,
+			expectedReason: fmt.Sprintf(ownershipIssueMismatchOriginLabel, types.OriginDefaults),
+		},
+		{
+			name:     "origin label match",
+			resource: &fakeResourceWithoutLabels{labels: map[string]string{types.OriginLabel: types.OriginKubernetes}},
+			expected: true,
+		},
+	}
+
+	adapter := ResourceWithoutLabelsAdapter[*fakeResourceWithoutLabels]{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owned, reason := adapter.CheckOwnership(tt.resource, OperatorMetadata{})
+			require.Equal(t, tt.expected, owned)
+			require.Equal(t, tt.expectedReason, reason)
+		})
+	}
+
+}
+
+func TestResourceWithoutLabelsAdapter_SetResourceLabels(t *testing.T) {
+	adapter := ResourceWithoutLabelsAdapter[*fakeResourceWithoutLabels]{}
+	resource := &fakeResourceWithoutLabels{labels: map[string]string{}}
+	adapter.SetResourceLabels(resource, map[string]string{
+		"foo": "bar",
+	}, OperatorMetadata{
+		Namespace: "unused",
+		ID:        "unused",
+		TokenName: "unused",
+		Scope:     "unused",
+		Owner:     "unused",
+	}, customResourceMetadata{
+		name:      "unused",
+		namespace: "unused",
+		gvk:       "unused",
+	})
+	require.Equal(t, map[string]string{types.OriginLabel: types.OriginKubernetes}, resource.labels)
+}

--- a/integrations/operator/controllers/reconcilers/resource153.go
+++ b/integrations/operator/controllers/reconcilers/resource153.go
@@ -19,6 +19,8 @@
 package reconcilers
 
 import (
+	"fmt"
+
 	"github.com/gravitational/trace"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -40,19 +42,22 @@ func (a Resource153Adapter[T]) GetResourceRevision(res T) string {
 	return res.GetMetadata().GetRevision()
 }
 
-// GetResourceOrigin implements the Adapter interface.
-func (a Resource153Adapter[T]) GetResourceOrigin(res T) string {
+// CheckOwnership implements the Adapter interface.
+func (a Resource153Adapter[T]) CheckOwnership(res T, _ OperatorMetadata) (bool, string) {
 	labels := res.GetMetadata().GetLabels()
 	// catches nil and empty maps
 	if len(labels) == 0 {
-		return ""
+		return false, ownershipIssueMissingOriginLabel
 	}
 
 	if origin, ok := labels[types.OriginLabel]; ok {
-		return origin
+		if origin == types.OriginKubernetes {
+			return true, ""
+		}
+		return false, fmt.Sprintf(ownershipIssueMismatchOriginLabel, origin)
 	}
 	// Origin label is not set
-	return ""
+	return false, ownershipIssueMissingOriginLabel
 }
 
 // SetResourceRevision implements the Adapter interface.
@@ -61,7 +66,8 @@ func (a Resource153Adapter[T]) SetResourceRevision(res T, revision string) {
 }
 
 // SetResourceLabels implements the Adapter interface.
-func (a Resource153Adapter[T]) SetResourceLabels(res T, labels map[string]string) {
+func (a Resource153Adapter[T]) SetResourceLabels(res T, labels map[string]string, _ OperatorMetadata, _ customResourceMetadata) {
+	labels[types.OriginLabel] = types.OriginKubernetes
 	res.GetMetadata().SetLabels(labels)
 }
 
@@ -98,12 +104,58 @@ func NewTeleportResource153Reconciler[T types.Resource153, K KubernetesCR[T]](
 	return reconciler, nil
 }
 
+// ScopedResource153 extends [types.Resource153] for Teleport
+// resources that are scoped.
+type ScopedResource153 interface {
+	types.Resource153
+	GetScope() string
+}
+
+type ScopedResource153Adapter[T ScopedResource153] struct {
+	Resource153Adapter[T]
+}
+
+func (a ScopedResource153Adapter[T]) GetResourceScope(res T) string {
+	return res.GetScope()
+}
+
+func (a ScopedResource153Adapter[T]) CheckOwnership(res T, metadata OperatorMetadata) (bool, string) {
+	// Do the base tests.
+	if ok, reason := a.Resource153Adapter.CheckOwnership(res, metadata); !ok {
+		return ok, reason
+	}
+
+	// For scoped resources, also check the operator ID.
+	if res.GetScope() == "" {
+		return true, ""
+	}
+	if id, ok := res.GetMetadata().GetLabels()[OperatorIDLabel]; ok {
+		if id != metadata.ID {
+			return false, fmt.Sprintf(ownershipIssueMismatchOperatorID, id, metadata.ID)
+		}
+		return true, ""
+	}
+
+	return false, ownershipIssueMissingOperatorID
+}
+
+func (a ScopedResource153Adapter[T]) SetResourceLabels(res T, labels map[string]string, metadata OperatorMetadata, customResourceMetadata customResourceMetadata) {
+	// No need to copy the label map here, the caller already does it.
+	if res.GetScope() == "" {
+		a.Resource153Adapter.SetResourceLabels(res, labels, metadata, customResourceMetadata)
+		return
+	}
+	updateScopedLabels(labels, metadata, customResourceMetadata)
+	res.GetMetadata().SetLabels(labels)
+}
+
 // NewTeleportScopedResource153Reconciler instantiates a resourceReconciler for a
 // ScopedResource153 resource.
 func NewTeleportScopedResource153Reconciler[T ScopedResource153, K KubernetesCR[T]](
 	client kclient.Client,
 	resourceClient resourceClient[T],
 	config Config,
+	operatorMetadata OperatorMetadata,
 ) (controllers.Reconciler, error) {
 	checkFeatures := controllers.AlwaysEnabled
 	if config.CheckFeatures != nil {
@@ -121,13 +173,14 @@ func NewTeleportScopedResource153Reconciler[T ScopedResource153, K KubernetesCR[
 	}
 
 	reconciler := &resourceReconciler[T, K]{
-		kubeClient:     client,
-		resourceClient: resourceClient,
-		gvk:            gvk,
-		adapter:        ScopedResource153Adapter[T]{},
-		scoped:         true,
-		teleportKind:   teleportKind,
-		checkFeatures:  checkFeatures,
+		kubeClient:       client,
+		resourceClient:   resourceClient,
+		gvk:              gvk,
+		adapter:          ScopedResource153Adapter[T]{},
+		scoped:           true,
+		teleportKind:     teleportKind,
+		checkFeatures:    checkFeatures,
+		operatorMetadata: operatorMetadata,
 	}
 	return reconciler, nil
 }

--- a/integrations/operator/controllers/reconcilers/resource153_test.go
+++ b/integrations/operator/controllers/reconcilers/resource153_test.go
@@ -20,6 +20,7 @@ package reconcilers
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -125,6 +126,13 @@ func TestScopedResource153Reconciler(t *testing.T) {
 		kubeClient,
 		resourceClient,
 		Config{Scoped: true},
+		OperatorMetadata{
+			Namespace: "ns",
+			ID:        "id",
+			TokenName: "token",
+			Scope:     scopeA,
+			Owner:     "test@example.com",
+		},
 	)
 	require.NoError(t, err)
 
@@ -141,6 +149,7 @@ func TestScopedResource153Reconciler(t *testing.T) {
 	roleA := resourceClient.store[ResourceKey{Name: name, Scope: scopeA}]
 	require.NotNil(t, roleA)
 	require.Equal(t, types.OriginKubernetes, roleA.GetMetadata().GetLabels()[types.OriginLabel])
+	require.Equal(t, name, roleA.GetMetadata().GetLabels()[customResourceNameLabel])
 	require.NotNil(t, resourceClient.store[ResourceKey{Name: name, Scope: scopeB}])
 
 	err = kubeClient.Delete(t.Context(), cr)
@@ -151,4 +160,257 @@ func TestScopedResource153Reconciler(t *testing.T) {
 
 	require.Nil(t, resourceClient.store[ResourceKey{Name: name, Scope: scopeA}])
 	require.NotNil(t, resourceClient.store[ResourceKey{Name: name, Scope: scopeB}])
+}
+
+type fakeResource153 struct {
+	ScopedResource153
+	metadata *headerv1.Metadata
+	scope    string
+}
+
+func (r *fakeResource153) GetMetadata() *headerv1.Metadata {
+	return r.metadata
+}
+
+func (r *fakeResource153) GetScope() string {
+	return r.scope
+}
+
+func TestResource153Adapter_CheckOwnership(t *testing.T) {
+	const (
+		testID        = "test-id"
+		conflictingID = "conflicting-id"
+	)
+	tests := []struct {
+		name           string
+		resource       *fakeResource153
+		expected       bool
+		expectedReason string
+	}{
+		{
+			name:           "no labels",
+			resource:       &fakeResource153{metadata: headerv1.Metadata_builder{Labels: map[string]string{}}.Build()},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name:           "labels but no origin",
+			resource:       &fakeResource153{metadata: headerv1.Metadata_builder{Labels: map[string]string{"foo": "bar"}}.Build()},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name:     "origin label match",
+			resource: &fakeResource153{metadata: headerv1.Metadata_builder{Labels: map[string]string{types.OriginLabel: types.OriginKubernetes}}.Build()},
+			expected: true,
+		},
+	}
+
+	adapter := Resource153Adapter[*fakeResource153]{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owned, reason := adapter.CheckOwnership(tt.resource, OperatorMetadata{})
+			require.Equal(t, tt.expected, owned)
+			require.Equal(t, tt.expectedReason, reason)
+		})
+	}
+}
+
+func TestScopedResource153Adapter_CheckOwnership(t *testing.T) {
+	const (
+		testID        = "test-id"
+		conflictingID = "conflicting-id"
+		testScope     = "/team/a"
+	)
+	tests := []struct {
+		name           string
+		resource       *fakeResource153
+		expected       bool
+		expectedReason string
+	}{
+		{
+			name:           "unscoped - no labels",
+			resource:       &fakeResource153{metadata: headerv1.Metadata_builder{Labels: map[string]string{}}.Build()},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name:           "uncscope - labels but no origin",
+			resource:       &fakeResource153{metadata: headerv1.Metadata_builder{Labels: map[string]string{"foo": "bar"}}.Build()},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name:           "unscoped - origin label mismatch",
+			resource:       &fakeResource153{metadata: headerv1.Metadata_builder{Labels: map[string]string{types.OriginLabel: types.OriginDefaults}}.Build()},
+			expected:       false,
+			expectedReason: fmt.Sprintf(ownershipIssueMismatchOriginLabel, types.OriginDefaults),
+		},
+		{
+			name:     "unscoped - origin label match but no id",
+			resource: &fakeResource153{metadata: headerv1.Metadata_builder{Labels: map[string]string{types.OriginLabel: types.OriginKubernetes}}.Build()},
+			expected: true,
+		},
+		{
+			name:     "unscoped - origin label match but mismatch id",
+			resource: &fakeResource153{metadata: headerv1.Metadata_builder{Labels: map[string]string{types.OriginLabel: types.OriginKubernetes, OperatorIDLabel: conflictingID}}.Build()},
+			expected: true,
+		},
+		{
+			name:     "unscoped - origin label match and matching id",
+			resource: &fakeResource153{metadata: headerv1.Metadata_builder{Labels: map[string]string{types.OriginLabel: types.OriginKubernetes, OperatorIDLabel: testID}}.Build()},
+			expected: true,
+		},
+		{
+			name: "scoped - no labels",
+			resource: &fakeResource153{
+				metadata: headerv1.Metadata_builder{Labels: map[string]string{}}.Build(),
+				scope:    testScope,
+			},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name: "scoped - labels but no origin",
+			resource: &fakeResource153{
+				metadata: headerv1.Metadata_builder{Labels: map[string]string{"foo": "bar"}}.Build(),
+				scope:    testScope,
+			},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name: "scoped - origin label mismatch",
+			resource: &fakeResource153{
+				metadata: headerv1.Metadata_builder{Labels: map[string]string{types.OriginLabel: types.OriginDefaults}}.Build(),
+				scope:    testScope,
+			},
+			expected:       false,
+			expectedReason: fmt.Sprintf(ownershipIssueMismatchOriginLabel, types.OriginDefaults),
+		},
+		{
+			name: "scoped - origin label match but no id",
+			resource: &fakeResource153{
+				metadata: headerv1.Metadata_builder{Labels: map[string]string{types.OriginLabel: types.OriginKubernetes}}.Build(),
+				scope:    testScope,
+			},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOperatorID,
+		},
+		{
+			name: "scoped - origin label match but mismatch id",
+			resource: &fakeResource153{
+				metadata: headerv1.Metadata_builder{Labels: map[string]string{types.OriginLabel: types.OriginKubernetes, OperatorIDLabel: conflictingID}}.Build(),
+				scope:    testScope,
+			},
+			expected:       false,
+			expectedReason: fmt.Sprintf(ownershipIssueMismatchOperatorID, conflictingID, testID),
+		},
+		{
+			name: "scoped - origin label match and matching id",
+			resource: &fakeResource153{
+				metadata: headerv1.Metadata_builder{Labels: map[string]string{types.OriginLabel: types.OriginKubernetes, OperatorIDLabel: testID}}.Build(),
+				scope:    testScope,
+			},
+			expected: true,
+		},
+	}
+
+	adapter := ScopedResource153Adapter[*fakeResource153]{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owned, reason := adapter.CheckOwnership(tt.resource, OperatorMetadata{ID: testID})
+			require.Equal(t, tt.expected, owned)
+			require.Equal(t, tt.expectedReason, reason)
+		})
+	}
+}
+
+func TestResource153Adapter_SetLabels(t *testing.T) {
+	adapter := Resource153Adapter[*fakeResource153]{}
+	resource := &fakeResource153{metadata: headerv1.Metadata_builder{Labels: map[string]string{}}.Build()}
+	adapter.SetResourceLabels(resource, map[string]string{
+		"foo": "bar",
+	}, OperatorMetadata{
+		Namespace: "unused",
+		ID:        "unused",
+		TokenName: "unused",
+		Scope:     "unused",
+		Owner:     "unused",
+	}, customResourceMetadata{
+		name:      "unused",
+		namespace: "unused",
+		gvk:       "unused",
+	})
+	require.Equal(t, map[string]string{
+		"foo":             "bar",
+		types.OriginLabel: types.OriginKubernetes,
+	}, resource.metadata.GetLabels())
+}
+
+func TestScopedResource153Adapter_SetLabels(t *testing.T) {
+	const testScope = "/team/a"
+	initialLabels := map[string]string{
+		"foo": "bar",
+	}
+	kubeLabels := map[string]string{
+		"kube": "label",
+	}
+
+	operatorMetadata := OperatorMetadata{
+		Namespace: "namespace",
+		ID:        "id",
+		TokenName: "token",
+		Scope:     "scope",
+		Owner:     "owner",
+	}
+	resourceMetadata := customResourceMetadata{
+		namespace: "cr-namespace",
+		name:      "name",
+		gvk:       "gvk",
+	}
+
+	tests := []struct {
+		name           string
+		resource       *fakeResource153
+		expectedLabels map[string]string
+	}{
+		{
+			name: "unscoped",
+			resource: &fakeResource153{
+				metadata: headerv1.Metadata_builder{Labels: initialLabels}.Build(),
+			},
+			expectedLabels: map[string]string{
+				"kube":            "label",
+				types.OriginLabel: types.OriginKubernetes,
+			},
+		},
+		{
+			name: "scoped",
+			resource: &fakeResource153{
+				metadata: headerv1.Metadata_builder{Labels: initialLabels}.Build(),
+				scope:    testScope,
+			},
+			expectedLabels: map[string]string{
+				"kube":                       "label",
+				types.OriginLabel:            types.OriginKubernetes,
+				OperatorIDLabel:              operatorMetadata.ID,
+				operatorNamespaceLabel:       operatorMetadata.Namespace,
+				operatorOwnerLabel:           operatorMetadata.Owner,
+				operatorTokenNameLabel:       operatorMetadata.TokenName,
+				customResourceNameLabel:      resourceMetadata.name,
+				customResourceNamespaceLabel: resourceMetadata.namespace,
+				customResourceGVKLabel:       resourceMetadata.gvk,
+			},
+		},
+	}
+
+	adapter := ScopedResource153Adapter[*fakeResource153]{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter.SetResourceLabels(tt.resource, kubeLabels, operatorMetadata, resourceMetadata)
+			require.Equal(t, tt.expectedLabels, tt.resource.metadata.GetLabels())
+		})
+	}
 }

--- a/integrations/operator/controllers/reconcilers/resource153_test.go
+++ b/integrations/operator/controllers/reconcilers/resource153_test.go
@@ -20,6 +20,7 @@ package reconcilers
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -125,6 +126,13 @@ func TestScopedResource153Reconciler(t *testing.T) {
 		kubeClient,
 		resourceClient,
 		Config{Scoped: true},
+		OperatorMetadata{
+			Namespace: "ns",
+			ID:        "id",
+			TokenName: "token",
+			Scope:     scopeA,
+			Owner:     "test@example.com",
+		},
 	)
 	require.NoError(t, err)
 
@@ -141,6 +149,7 @@ func TestScopedResource153Reconciler(t *testing.T) {
 	roleA := resourceClient.store[ResourceKey{Name: name, Scope: scopeA}]
 	require.NotNil(t, roleA)
 	require.Equal(t, types.OriginKubernetes, roleA.GetMetadata().GetLabels()[types.OriginLabel])
+	require.Equal(t, name, roleA.GetMetadata().GetLabels()[customResourceNameLabel])
 	require.NotNil(t, resourceClient.store[ResourceKey{Name: name, Scope: scopeB}])
 
 	err = kubeClient.Delete(t.Context(), cr)
@@ -151,4 +160,253 @@ func TestScopedResource153Reconciler(t *testing.T) {
 
 	require.Nil(t, resourceClient.store[ResourceKey{Name: name, Scope: scopeA}])
 	require.NotNil(t, resourceClient.store[ResourceKey{Name: name, Scope: scopeB}])
+}
+
+type fakeResource153 struct {
+	ScopedResource153
+	metadata *headerv1.Metadata
+	scope    string
+}
+
+func (r *fakeResource153) GetMetadata() *headerv1.Metadata {
+	return r.metadata
+}
+
+func (r *fakeResource153) GetScope() string {
+	return r.scope
+}
+
+func TestResource153Adapter_CheckOwnership(t *testing.T) {
+	tests := []struct {
+		name           string
+		resource       *fakeResource153
+		expected       bool
+		expectedReason string
+	}{
+		{
+			name:           "no labels",
+			resource:       &fakeResource153{metadata: headerv1.Metadata_builder{Labels: map[string]string{}}.Build()},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name:           "labels but no origin",
+			resource:       &fakeResource153{metadata: headerv1.Metadata_builder{Labels: map[string]string{"foo": "bar"}}.Build()},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name:     "origin label match",
+			resource: &fakeResource153{metadata: headerv1.Metadata_builder{Labels: map[string]string{types.OriginLabel: types.OriginKubernetes}}.Build()},
+			expected: true,
+		},
+	}
+
+	adapter := Resource153Adapter[*fakeResource153]{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owned, reason := adapter.CheckOwnership(tt.resource, OperatorMetadata{})
+			require.Equal(t, tt.expected, owned)
+			require.Equal(t, tt.expectedReason, reason)
+		})
+	}
+}
+
+func TestScopedResource153Adapter_CheckOwnership(t *testing.T) {
+	const (
+		testID        = "test-id"
+		conflictingID = "conflicting-id"
+		testScope     = "/team/a"
+	)
+	tests := []struct {
+		name           string
+		resource       *fakeResource153
+		expected       bool
+		expectedReason string
+	}{
+		{
+			name:           "unscoped - no labels",
+			resource:       &fakeResource153{metadata: headerv1.Metadata_builder{Labels: map[string]string{}}.Build()},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name:           "uncscope - labels but no origin",
+			resource:       &fakeResource153{metadata: headerv1.Metadata_builder{Labels: map[string]string{"foo": "bar"}}.Build()},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name:           "unscoped - origin label mismatch",
+			resource:       &fakeResource153{metadata: headerv1.Metadata_builder{Labels: map[string]string{types.OriginLabel: types.OriginDefaults}}.Build()},
+			expected:       false,
+			expectedReason: fmt.Sprintf(ownershipIssueMismatchOriginLabel, types.OriginDefaults),
+		},
+		{
+			name:     "unscoped - origin label match but no id",
+			resource: &fakeResource153{metadata: headerv1.Metadata_builder{Labels: map[string]string{types.OriginLabel: types.OriginKubernetes}}.Build()},
+			expected: true,
+		},
+		{
+			name:     "unscoped - origin label match but mismatch id",
+			resource: &fakeResource153{metadata: headerv1.Metadata_builder{Labels: map[string]string{types.OriginLabel: types.OriginKubernetes, OperatorIDLabel: conflictingID}}.Build()},
+			expected: true,
+		},
+		{
+			name:     "unscoped - origin label match and matching id",
+			resource: &fakeResource153{metadata: headerv1.Metadata_builder{Labels: map[string]string{types.OriginLabel: types.OriginKubernetes, OperatorIDLabel: testID}}.Build()},
+			expected: true,
+		},
+		{
+			name: "scoped - no labels",
+			resource: &fakeResource153{
+				metadata: headerv1.Metadata_builder{Labels: map[string]string{}}.Build(),
+				scope:    testScope,
+			},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name: "scoped - labels but no origin",
+			resource: &fakeResource153{
+				metadata: headerv1.Metadata_builder{Labels: map[string]string{"foo": "bar"}}.Build(),
+				scope:    testScope,
+			},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOriginLabel,
+		},
+		{
+			name: "scoped - origin label mismatch",
+			resource: &fakeResource153{
+				metadata: headerv1.Metadata_builder{Labels: map[string]string{types.OriginLabel: types.OriginDefaults}}.Build(),
+				scope:    testScope,
+			},
+			expected:       false,
+			expectedReason: fmt.Sprintf(ownershipIssueMismatchOriginLabel, types.OriginDefaults),
+		},
+		{
+			name: "scoped - origin label match but no id",
+			resource: &fakeResource153{
+				metadata: headerv1.Metadata_builder{Labels: map[string]string{types.OriginLabel: types.OriginKubernetes}}.Build(),
+				scope:    testScope,
+			},
+			expected:       false,
+			expectedReason: ownershipIssueMissingOperatorID,
+		},
+		{
+			name: "scoped - origin label match but mismatch id",
+			resource: &fakeResource153{
+				metadata: headerv1.Metadata_builder{Labels: map[string]string{types.OriginLabel: types.OriginKubernetes, OperatorIDLabel: conflictingID}}.Build(),
+				scope:    testScope,
+			},
+			expected:       false,
+			expectedReason: fmt.Sprintf(ownershipIssueMismatchOperatorID, conflictingID, testID),
+		},
+		{
+			name: "scoped - origin label match and matching id",
+			resource: &fakeResource153{
+				metadata: headerv1.Metadata_builder{Labels: map[string]string{types.OriginLabel: types.OriginKubernetes, OperatorIDLabel: testID}}.Build(),
+				scope:    testScope,
+			},
+			expected: true,
+		},
+	}
+
+	adapter := ScopedResource153Adapter[*fakeResource153]{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owned, reason := adapter.CheckOwnership(tt.resource, OperatorMetadata{ID: testID})
+			require.Equal(t, tt.expected, owned)
+			require.Equal(t, tt.expectedReason, reason)
+		})
+	}
+}
+
+func TestResource153Adapter_SetLabels(t *testing.T) {
+	adapter := Resource153Adapter[*fakeResource153]{}
+	resource := &fakeResource153{metadata: headerv1.Metadata_builder{Labels: map[string]string{}}.Build()}
+	adapter.SetResourceLabels(resource, map[string]string{
+		"foo": "bar",
+	}, OperatorMetadata{
+		Namespace: "unused",
+		ID:        "unused",
+		TokenName: "unused",
+		Scope:     "unused",
+		Owner:     "unused",
+	}, customResourceMetadata{
+		name:      "unused",
+		namespace: "unused",
+		gvk:       "unused",
+	})
+	require.Equal(t, map[string]string{
+		"foo":             "bar",
+		types.OriginLabel: types.OriginKubernetes,
+	}, resource.metadata.GetLabels())
+}
+
+func TestScopedResource153Adapter_SetLabels(t *testing.T) {
+	const testScope = "/team/a"
+	initialLabels := map[string]string{
+		"foo": "bar",
+	}
+	kubeLabels := map[string]string{
+		"kube": "label",
+	}
+
+	operatorMetadata := OperatorMetadata{
+		Namespace: "namespace",
+		ID:        "id",
+		TokenName: "token",
+		Scope:     "scope",
+		Owner:     "owner",
+	}
+	resourceMetadata := customResourceMetadata{
+		namespace: "cr-namespace",
+		name:      "name",
+		gvk:       "gvk",
+	}
+
+	tests := []struct {
+		name           string
+		resource       *fakeResource153
+		expectedLabels map[string]string
+	}{
+		{
+			name: "unscoped",
+			resource: &fakeResource153{
+				metadata: headerv1.Metadata_builder{Labels: initialLabels}.Build(),
+			},
+			expectedLabels: map[string]string{
+				"kube":            "label",
+				types.OriginLabel: types.OriginKubernetes,
+			},
+		},
+		{
+			name: "scoped",
+			resource: &fakeResource153{
+				metadata: headerv1.Metadata_builder{Labels: initialLabels}.Build(),
+				scope:    testScope,
+			},
+			expectedLabels: map[string]string{
+				"kube":                       "label",
+				types.OriginLabel:            types.OriginKubernetes,
+				OperatorIDLabel:              operatorMetadata.ID,
+				operatorNamespaceLabel:       operatorMetadata.Namespace,
+				operatorOwnerLabel:           operatorMetadata.Owner,
+				operatorTokenNameLabel:       operatorMetadata.TokenName,
+				customResourceNameLabel:      resourceMetadata.name,
+				customResourceNamespaceLabel: resourceMetadata.namespace,
+				customResourceGVKLabel:       resourceMetadata.gvk,
+			},
+		},
+	}
+
+	adapter := ScopedResource153Adapter[*fakeResource153]{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter.SetResourceLabels(tt.resource, kubeLabels, operatorMetadata, resourceMetadata)
+			require.Equal(t, tt.expectedLabels, tt.resource.metadata.GetLabels())
+		})
+	}
 }

--- a/integrations/operator/controllers/reconcilers/utils.go
+++ b/integrations/operator/controllers/reconcilers/utils.go
@@ -35,6 +35,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/gravitational/teleport/api/types/common"
 )
 
 const (
@@ -45,9 +47,13 @@ const (
 	ConditionReasonNoError                = "NoError"
 	ConditionReasonTeleportError          = "TeleportError"
 	ConditionReasonMutationError          = "MutationError"
+	ConditionReasonMatchingScope          = "MatchingScope"
+	ConditionReasonNonMatchingScope       = "NonMatchingScope"
 	ConditionTypeTeleportResourceOwned    = "TeleportResourceOwned"
 	ConditionTypeSuccessfullyReconciled   = "SuccessfullyReconciled"
 	ConditionTypeValidStructure           = "ValidStructure"
+	ConditionTypeValidScope               = "ValidScope"
+	ConditionTypeUnscoped                 = "Unscoped"
 )
 
 // gvkFromScheme looks up the GVK from the runtime scheme.
@@ -162,7 +168,7 @@ type updateStatusConfig struct {
 	condition metav1.Condition
 }
 
-// updateStatus updates the Resource status but swallows the error if the update fails.
+// updateStatus updates the Resource status.
 func updateStatus(config updateStatusConfig) error {
 	// If the condition is empty, we don't want to update the status.
 	if config.condition == (metav1.Condition{}) {
@@ -204,4 +210,17 @@ func checkAnnotationFlag(object kclient.Object, flagName string, defaultValue bo
 		return defaultValue
 	}
 	return value
+}
+
+// setOriginLabelsForScoped sets the origin labels for a scoped resource.
+// Works in place.
+func updateScopedLabels(labels map[string]string, metadata OperatorMetadata, resourceMetadata customResourceMetadata) {
+	labels[common.OriginLabel] = common.OriginKubernetes
+	labels[OperatorIDLabel] = metadata.ID
+	labels[operatorOwnerLabel] = metadata.Owner
+	labels[operatorNamespaceLabel] = metadata.Namespace
+	labels[operatorTokenNameLabel] = metadata.TokenName
+	labels[customResourceNamespaceLabel] = resourceMetadata.namespace
+	labels[customResourceNameLabel] = resourceMetadata.name
+	labels[customResourceGVKLabel] = resourceMetadata.gvk
 }

--- a/integrations/operator/controllers/resources/accesslist_controller.go
+++ b/integrations/operator/controllers/resources/accesslist_controller.go
@@ -23,6 +23,7 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gravitational/teleport/api/client"
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
@@ -36,7 +37,11 @@ type accessListClient struct {
 
 // Get gets the Teleport access_list of a given name
 func (r accessListClient) Get(ctx context.Context, key reconcilers.ResourceKey) (*accesslist.AccessList, error) {
-	accessList, err := r.teleportClient.AccessListClient().GetAccessList(ctx, key.Name)
+	accessList, err := r.teleportClient.AccessListClient().GetAccessListV2(ctx,
+		accesslistv1.GetAccessListRequest_builder{
+			Name:  key.Name,
+			Scope: key.Scope,
+		}.Build())
 	return accessList, trace.Wrap(err)
 }
 
@@ -54,7 +59,11 @@ func (r accessListClient) Update(ctx context.Context, accessList *accesslist.Acc
 
 // Delete deletes a Teleport access_list
 func (r accessListClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
-	return trace.Wrap(r.teleportClient.AccessListClient().DeleteAccessList(ctx, key.Name))
+	return trace.Wrap(r.teleportClient.AccessListClient().DeleteAccessListV2(ctx,
+		accesslistv1.DeleteAccessListRequest_builder{
+			Name:  key.Name,
+			Scope: key.Scope,
+		}.Build()))
 }
 
 // Mutate propagates fields from the existing AccessList resource
@@ -69,17 +78,18 @@ func (r accessListClient) Mutate(_ context.Context, new, existing *accesslist.Ac
 }
 
 // NewAccessListReconciler instantiates a new Kubernetes controller reconciling access_list resources
-func NewAccessListReconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
+func NewAccessListReconciler(client kclient.Client, tClient *client.Client, metadata reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	accessListClient := &accessListClient{
 		teleportClient: tClient,
 	}
 
-	resourceReconciler, err := reconcilers.NewTeleportResourceWithLabelsReconciler[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
+	resourceReconciler, err := reconcilers.NewTeleportScopedResourceWithLabelsReconciler[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
 		client,
 		accessListClient,
 		reconcilers.Config{
 			CheckFeatures: controllers.RequireEnterprise,
 		},
+		metadata,
 	)
 
 	return resourceReconciler, trace.Wrap(err, "building teleport resource reconciler")

--- a/integrations/operator/controllers/resources/accesslist_controller.go
+++ b/integrations/operator/controllers/resources/accesslist_controller.go
@@ -23,6 +23,7 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gravitational/teleport/api/client"
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
@@ -36,7 +37,11 @@ type accessListClient struct {
 
 // Get gets the Teleport access_list of a given name
 func (r accessListClient) Get(ctx context.Context, key reconcilers.ResourceKey) (*accesslist.AccessList, error) {
-	accessList, err := r.teleportClient.AccessListClient().GetAccessList(ctx, key.Name)
+	accessList, err := r.teleportClient.AccessListClient().GetAccessListV2(ctx,
+		accesslistv1.GetAccessListRequest_builder{
+			Name:  key.Name,
+			Scope: key.Scope,
+		}.Build())
 	return accessList, trace.Wrap(err)
 }
 
@@ -54,7 +59,11 @@ func (r accessListClient) Update(ctx context.Context, accessList *accesslist.Acc
 
 // Delete deletes a Teleport access_list
 func (r accessListClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
-	return trace.Wrap(r.teleportClient.AccessListClient().DeleteAccessList(ctx, key.Name))
+	return trace.Wrap(r.teleportClient.AccessListClient().DeleteAccessListV2(ctx,
+		accesslistv1.DeleteAccessListRequest_builder{
+			Name:  key.Name,
+			Scope: key.Scope,
+		}.Build()))
 }
 
 // Mutate propagates fields from the existing AccessList resource
@@ -69,17 +78,18 @@ func (r accessListClient) Mutate(_ context.Context, new, existing *accesslist.Ac
 }
 
 // NewAccessListReconciler instantiates a new Kubernetes controller reconciling access_list resources
-func NewAccessListReconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewAccessListReconciler(client kclient.Client, tClient *client.Client, metadata reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	accessListClient := &accessListClient{
 		teleportClient: tClient,
 	}
 
-	resourceReconciler, err := reconcilers.NewTeleportResourceWithLabelsReconciler[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
+	resourceReconciler, err := reconcilers.NewTeleportScopedResourceWithLabelsReconciler[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
 		client,
 		accessListClient,
 		reconcilers.Config{
 			CheckFeatures: controllers.RequireEnterprise,
 		},
+		metadata,
 	)
 
 	return resourceReconciler, trace.Wrap(err, "building teleport resource reconciler")

--- a/integrations/operator/controllers/resources/accesslist_controller.go
+++ b/integrations/operator/controllers/resources/accesslist_controller.go
@@ -69,7 +69,7 @@ func (r accessListClient) Mutate(_ context.Context, new, existing *accesslist.Ac
 }
 
 // NewAccessListReconciler instantiates a new Kubernetes controller reconciling access_list resources
-func NewAccessListReconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewAccessListReconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	accessListClient := &accessListClient{
 		teleportClient: tClient,
 	}

--- a/integrations/operator/controllers/resources/accessmonitoringrulev1_controller.go
+++ b/integrations/operator/controllers/resources/accessmonitoringrulev1_controller.go
@@ -67,7 +67,7 @@ func (l accessMonitoringRuleClient) Delete(ctx context.Context, key reconcilers.
 
 // NewAccessMonitoringRuleV1Reconciler instantiates a new Kubernetes controller reconciling accessMonitoringRule
 // resources
-func NewAccessMonitoringRuleV1Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewAccessMonitoringRuleV1Reconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	accessMonitoringRuleClient := &accessMonitoringRuleClient{
 		teleportClient: tClient,
 	}

--- a/integrations/operator/controllers/resources/appv3_controller.go
+++ b/integrations/operator/controllers/resources/appv3_controller.go
@@ -61,7 +61,7 @@ func (r appClient) Delete(ctx context.Context, key reconcilers.ResourceKey) erro
 }
 
 // NewAppV3Reconciler instantiates a new Kubernetes controller reconciling app v6 resources
-func NewAppV3Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewAppV3Reconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	appClient := &appClient{
 		teleportClient: tClient,
 	}

--- a/integrations/operator/controllers/resources/appv3_controller_test.go
+++ b/integrations/operator/controllers/resources/appv3_controller_test.go
@@ -126,20 +126,20 @@ func (g *appV3TestingPrimitives) CompareTeleportAndKubernetesResource(tResource 
 
 func TestTeleportAppV3Creation(t *testing.T) {
 	test := &appV3TestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewAppV3Reconciler, test)
+	testlib.ResourceCreationSynchronousTest[types.Application, *resourcesv1.TeleportAppV3](t, resources.NewAppV3Reconciler, test)
 }
 
 func TestTeleportAppV3Deletion(t *testing.T) {
 	test := &appV3TestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(t, resources.NewAppV3Reconciler, test)
+	testlib.ResourceDeletionSynchronousTest[types.Application, *resourcesv1.TeleportAppV3](t, resources.NewAppV3Reconciler, test)
 }
 
 func TestTeleportAppV3DeletionDrift(t *testing.T) {
 	test := &appV3TestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewAppV3Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.Application, *resourcesv1.TeleportAppV3](t, resources.NewAppV3Reconciler, test)
 }
 
 func TestTeleportAppV3Update(t *testing.T) {
 	test := &appV3TestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewAppV3Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous[types.Application, *resourcesv1.TeleportAppV3](t, resources.NewAppV3Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/autoupdateconfig_controller.go
+++ b/integrations/operator/controllers/resources/autoupdateconfig_controller.go
@@ -67,7 +67,7 @@ func (l autoUpdateConfigClient) Delete(ctx context.Context, key reconcilers.Reso
 
 // NewAutoUpdateConfigV1Reconciler instantiates a new Kubernetes controller reconciling autoUpdateConfig
 // resources
-func NewAutoUpdateConfigV1Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewAutoUpdateConfigV1Reconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	autoUpdateConfigClient := &autoUpdateConfigClient{
 		teleportClient: tClient,
 	}

--- a/integrations/operator/controllers/resources/autoupdateconfig_controller_test.go
+++ b/integrations/operator/controllers/resources/autoupdateconfig_controller_test.go
@@ -169,7 +169,7 @@ func (g *autoUpdateConfigTestingPrimitives) CompareTeleportAndKubernetesResource
 
 func TestAutoUpdateConfigCreation(t *testing.T) {
 	test := &autoUpdateConfigTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(
+	testlib.ResourceCreationSynchronousTest[*autoupdatev1pb.AutoUpdateConfig, *resourcesv1.TeleportAutoupdateConfigV1](
 		t,
 		resources.NewAutoUpdateConfigV1Reconciler,
 		test,
@@ -179,7 +179,7 @@ func TestAutoUpdateConfigCreation(t *testing.T) {
 
 func TestAutoUpdateConfigDeletion(t *testing.T) {
 	test := &autoUpdateConfigTestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(
+	testlib.ResourceDeletionSynchronousTest[*autoupdatev1pb.AutoUpdateConfig, *resourcesv1.TeleportAutoupdateConfigV1](
 		t,
 		resources.NewAutoUpdateConfigV1Reconciler,
 		test,
@@ -189,7 +189,7 @@ func TestAutoUpdateConfigDeletion(t *testing.T) {
 
 func TestAutoUpdateConfigDeletionDrift(t *testing.T) {
 	test := &autoUpdateConfigTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(
+	testlib.ResourceDeletionDriftSynchronousTest[*autoupdatev1pb.AutoUpdateConfig, *resourcesv1.TeleportAutoupdateConfigV1](
 		t,
 		resources.NewAutoUpdateConfigV1Reconciler,
 		test,
@@ -199,7 +199,7 @@ func TestAutoUpdateConfigDeletionDrift(t *testing.T) {
 
 func TestAutoUpdateConfigUpdate(t *testing.T) {
 	test := &autoUpdateConfigTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(
+	testlib.ResourceUpdateTestSynchronous[*autoupdatev1pb.AutoUpdateConfig, *resourcesv1.TeleportAutoupdateConfigV1](
 		t,
 		resources.NewAutoUpdateConfigV1Reconciler,
 		test,

--- a/integrations/operator/controllers/resources/autoupdateversion_controller.go
+++ b/integrations/operator/controllers/resources/autoupdateversion_controller.go
@@ -67,7 +67,7 @@ func (l autoUpdateVersionClient) Delete(ctx context.Context, key reconcilers.Res
 
 // NewAutoUpdateVersionV1Reconciler instantiates a new Kubernetes controller reconciling autoUpdateVersion
 // resources
-func NewAutoUpdateVersionV1Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewAutoUpdateVersionV1Reconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	autoUpdateVersionClient := &autoUpdateVersionClient{
 		teleportClient: tClient,
 	}

--- a/integrations/operator/controllers/resources/autoupdateversion_controller_test.go
+++ b/integrations/operator/controllers/resources/autoupdateversion_controller_test.go
@@ -149,7 +149,7 @@ func (g *autoUpdateVersionTestingPrimitives) CompareTeleportAndKubernetesResourc
 
 func TestAutoUpdateVersionCreation(t *testing.T) {
 	test := &autoUpdateVersionTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(
+	testlib.ResourceCreationSynchronousTest[*autoupdatev1pb.AutoUpdateVersion, *resourcesv1.TeleportAutoupdateVersionV1](
 		t,
 		resources.NewAutoUpdateVersionV1Reconciler,
 		test,
@@ -159,7 +159,7 @@ func TestAutoUpdateVersionCreation(t *testing.T) {
 
 func TestAutoUpdateVersionDeletion(t *testing.T) {
 	test := &autoUpdateVersionTestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(
+	testlib.ResourceDeletionSynchronousTest[*autoupdatev1pb.AutoUpdateVersion, *resourcesv1.TeleportAutoupdateVersionV1](
 		t,
 		resources.NewAutoUpdateVersionV1Reconciler,
 		test,
@@ -169,7 +169,7 @@ func TestAutoUpdateVersionDeletion(t *testing.T) {
 
 func TestAutoUpdateVersionDeletionDrift(t *testing.T) {
 	test := &autoUpdateVersionTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(
+	testlib.ResourceDeletionDriftSynchronousTest[*autoupdatev1pb.AutoUpdateVersion, *resourcesv1.TeleportAutoupdateVersionV1](
 		t,
 		resources.NewAutoUpdateVersionV1Reconciler,
 		test,
@@ -179,7 +179,7 @@ func TestAutoUpdateVersionDeletionDrift(t *testing.T) {
 
 func TestAutoUpdateVersionUpdate(t *testing.T) {
 	test := &autoUpdateVersionTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(
+	testlib.ResourceUpdateTestSynchronous[*autoupdatev1pb.AutoUpdateVersion, *resourcesv1.TeleportAutoupdateVersionV1](
 		t,
 		resources.NewAutoUpdateVersionV1Reconciler,
 		test,

--- a/integrations/operator/controllers/resources/botv1_controller.go
+++ b/integrations/operator/controllers/resources/botv1_controller.go
@@ -73,7 +73,7 @@ func (l botClient) Delete(ctx context.Context, key reconcilers.ResourceKey) erro
 
 // NewBotV1Reconciler instantiates a new Kubernetes controller reconciling bot
 // resources
-func NewBotV1Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewBotV1Reconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	botClient := &botClient{
 		teleportClient: tClient,
 	}

--- a/integrations/operator/controllers/resources/botv1_controller.go
+++ b/integrations/operator/controllers/resources/botv1_controller.go
@@ -40,7 +40,10 @@ type botClient struct {
 func (l botClient) Get(ctx context.Context, key reconcilers.ResourceKey) (*machineidv1.Bot, error) {
 	resp, err := l.teleportClient.
 		BotServiceClient().
-		GetBot(ctx, machineidv1.GetBotRequest_builder{BotName: key.Name}.Build())
+		GetBot(ctx, machineidv1.GetBotRequest_builder{
+			BotName: key.Name,
+			Scope:   key.Scope,
+		}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -67,18 +70,21 @@ func (l botClient) Update(ctx context.Context, resource *machineidv1.Bot) error 
 func (l botClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
 	_, err := l.teleportClient.
 		BotServiceClient().
-		DeleteBot(ctx, machineidv1.DeleteBotRequest_builder{BotName: key.Name}.Build())
+		DeleteBot(ctx, machineidv1.DeleteBotRequest_builder{
+			BotName: key.Name,
+			Scope:   key.Scope,
+		}.Build())
 	return trace.Wrap(err)
 }
 
 // NewBotV1Reconciler instantiates a new Kubernetes controller reconciling bot
 // resources
-func NewBotV1Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewBotV1Reconciler(client kclient.Client, tClient *client.Client, metadata reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	botClient := &botClient{
 		teleportClient: tClient,
 	}
 
-	resourceReconciler, err := reconcilers.NewTeleportResource153Reconciler[
+	resourceReconciler, err := reconcilers.NewTeleportScopedResource153Reconciler[
 		*machineidv1.Bot, *resourcesv1.TeleportBotV1,
 	](
 		client,
@@ -86,6 +92,7 @@ func NewBotV1Reconciler(client kclient.Client, tClient *client.Client) (controll
 		reconcilers.Config{
 			Scoped: true,
 		},
+		metadata,
 	)
 
 	return resourceReconciler, trace.Wrap(err, "building teleport resource reconciler")

--- a/integrations/operator/controllers/resources/botv1_controller_test.go
+++ b/integrations/operator/controllers/resources/botv1_controller_test.go
@@ -57,6 +57,8 @@ var botSpec = machineidv1.BotSpec_builder{
 	MaxSessionTtl: durationpb.New(defaults.DefaultBotMaxSessionTTL),
 }.Build()
 
+var scopedBotSpec = &machineidv1.BotSpec{}
+
 type botTestingPrimitives struct {
 	setup *testSetup
 	reconcilers.Resource153Adapter[*machineidv1.Bot]
@@ -71,16 +73,27 @@ func (g *botTestingPrimitives) SetupTeleportFixtures(ctx context.Context) error 
 }
 
 func (g *botTestingPrimitives) CreateTeleportResource(ctx context.Context, name string) error {
+	var spec *machineidv1.BotSpec
+	if scope := g.setup.OperatorMetadata().Scope; scope != "" {
+		spec = scopedBotSpec
+	} else {
+		spec = botSpec
+	}
+	labels := map[string]string{
+		types.OriginLabel: types.OriginKubernetes,
+	}
+	if g.setup.OperatorMetadata().Scope != "" {
+		labels[reconcilers.OperatorIDLabel] = g.setup.OperatorMetadata().ID
+	}
 	bot := machineidv1.Bot_builder{
 		Kind:    types.KindBot,
 		Version: types.V1,
 		Metadata: headerv1.Metadata_builder{
-			Name: name,
-			Labels: map[string]string{
-				types.OriginLabel: types.OriginKubernetes,
-			},
+			Name:   name,
+			Labels: labels,
 		}.Build(),
-		Spec: botSpec,
+		Spec:  spec,
+		Scope: g.setup.OperatorMetadata().Scope,
 	}.Build()
 	_, err := g.setup.TeleportClient.
 		BotServiceClient().
@@ -91,7 +104,10 @@ func (g *botTestingPrimitives) CreateTeleportResource(ctx context.Context, name 
 func (g *botTestingPrimitives) GetTeleportResource(ctx context.Context, name string) (*machineidv1.Bot, error) {
 	resp, err := g.setup.TeleportClient.
 		BotServiceClient().
-		GetBot(ctx, machineidv1.GetBotRequest_builder{BotName: name}.Build())
+		GetBot(ctx, machineidv1.GetBotRequest_builder{
+			BotName: name,
+			Scope:   g.setup.OperatorMetadata().Scope,
+		}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -101,7 +117,10 @@ func (g *botTestingPrimitives) GetTeleportResource(ctx context.Context, name str
 func (g *botTestingPrimitives) DeleteTeleportResource(ctx context.Context, name string) error {
 	_, err := g.setup.TeleportClient.
 		BotServiceClient().
-		DeleteBot(ctx, machineidv1.DeleteBotRequest_builder{BotName: name}.Build())
+		DeleteBot(ctx, machineidv1.DeleteBotRequest_builder{
+			BotName: name,
+			Scope:   g.setup.OperatorMetadata().Scope,
+		}.Build())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -109,12 +128,19 @@ func (g *botTestingPrimitives) DeleteTeleportResource(ctx context.Context, name 
 }
 
 func (g *botTestingPrimitives) CreateKubernetesResource(ctx context.Context, name string) error {
+	var spec *machineidv1.BotSpec
+	if scope := g.setup.OperatorMetadata().Scope; scope != "" {
+		spec = scopedBotSpec
+	} else {
+		spec = botSpec
+	}
 	bot := &resourcesv1.TeleportBotV1{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: g.setup.Namespace.Name,
 		},
-		Spec: (*resourcesv1.TeleportBotV1Spec)(botSpec),
+		Spec:  (*resourcesv1.TeleportBotV1Spec)(spec),
+		Scope: g.setup.OperatorMetadata().Scope,
 	}
 	return trace.Wrap(g.setup.K8sClient.Create(ctx, bot))
 }
@@ -140,6 +166,7 @@ func (g *botTestingPrimitives) GetKubernetesResource(ctx context.Context, name s
 }
 
 func (g *botTestingPrimitives) ModifyKubernetesResource(ctx context.Context, name string) error {
+	// Note: scoped bots hold no data, there's nothing to modify.
 	bot, err := g.GetKubernetesResource(ctx, name)
 	if err != nil {
 		return trace.Wrap(err)
@@ -165,20 +192,51 @@ func (g *botTestingPrimitives) CompareTeleportAndKubernetesResource(
 
 func TestBotCreation(t *testing.T) {
 	test := &botTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewBotV1Reconciler, test)
+	testlib.ResourceCreationSynchronousTest[
+		*machineidv1.Bot, *resourcesv1.TeleportBotV1,
+	](t, resources.NewBotV1Reconciler, test)
 }
 
 func TestBotDeletion(t *testing.T) {
 	test := &botTestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(t, resources.NewBotV1Reconciler, test)
+	testlib.ResourceDeletionSynchronousTest[
+		*machineidv1.Bot, *resourcesv1.TeleportBotV1,
+	](t, resources.NewBotV1Reconciler, test)
 }
 
 func TestBotDeletionDrift(t *testing.T) {
 	test := &botTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewBotV1Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest[
+		*machineidv1.Bot, *resourcesv1.TeleportBotV1,
+	](t, resources.NewBotV1Reconciler, test)
 }
 
 func TestBotUpdate(t *testing.T) {
 	test := &botTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewBotV1Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous[
+		*machineidv1.Bot, *resourcesv1.TeleportBotV1,
+	](t, resources.NewBotV1Reconciler, test)
 }
+
+func TestScopedBotCreation(t *testing.T) {
+	test := &botTestingPrimitives{}
+	testlib.ResourceCreationSynchronousTest[
+		*machineidv1.Bot, *resourcesv1.TeleportBotV1,
+	](t, resources.NewBotV1Reconciler, test, testlib.WithScope(testScope))
+}
+
+func TestScopedBotDeletion(t *testing.T) {
+	test := &botTestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest[
+		*machineidv1.Bot, *resourcesv1.TeleportBotV1,
+	](t, resources.NewBotV1Reconciler, test, testlib.WithScope(testScope))
+}
+
+func TestScopedBotDeletionDrift(t *testing.T) {
+	test := &botTestingPrimitives{}
+	testlib.ResourceDeletionDriftSynchronousTest[
+		*machineidv1.Bot, *resourcesv1.TeleportBotV1,
+	](t, resources.NewBotV1Reconciler, test, testlib.WithScope(testScope))
+}
+
+// Note: scoped bots hold no data, there's nothing to update, hence no update tests.

--- a/integrations/operator/controllers/resources/botv1_controller_test.go
+++ b/integrations/operator/controllers/resources/botv1_controller_test.go
@@ -165,20 +165,28 @@ func (g *botTestingPrimitives) CompareTeleportAndKubernetesResource(
 
 func TestBotCreation(t *testing.T) {
 	test := &botTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewBotV1Reconciler, test)
+	testlib.ResourceCreationSynchronousTest[
+		*machineidv1.Bot, *resourcesv1.TeleportBotV1,
+	](t, resources.NewBotV1Reconciler, test)
 }
 
 func TestBotDeletion(t *testing.T) {
 	test := &botTestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(t, resources.NewBotV1Reconciler, test)
+	testlib.ResourceDeletionSynchronousTest[
+		*machineidv1.Bot, *resourcesv1.TeleportBotV1,
+	](t, resources.NewBotV1Reconciler, test)
 }
 
 func TestBotDeletionDrift(t *testing.T) {
 	test := &botTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewBotV1Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest[
+		*machineidv1.Bot, *resourcesv1.TeleportBotV1,
+	](t, resources.NewBotV1Reconciler, test)
 }
 
 func TestBotUpdate(t *testing.T) {
 	test := &botTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewBotV1Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous[
+		*machineidv1.Bot, *resourcesv1.TeleportBotV1,
+	](t, resources.NewBotV1Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/databasev3_controller.go
+++ b/integrations/operator/controllers/resources/databasev3_controller.go
@@ -61,7 +61,7 @@ func (r databaseClient) Delete(ctx context.Context, key reconcilers.ResourceKey)
 }
 
 // NewDatabaseV3Reconciler instantiates a new Kubernetes controller reconciling database v6 resources
-func NewDatabaseV3Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewDatabaseV3Reconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	databaseClient := &databaseClient{
 		teleportClient: tClient,
 	}

--- a/integrations/operator/controllers/resources/databasev3_controller_test.go
+++ b/integrations/operator/controllers/resources/databasev3_controller_test.go
@@ -119,20 +119,20 @@ func (g *databaseV3TestingPrimitives) CompareTeleportAndKubernetesResource(tReso
 
 func TestTeleportDatabaseV3Creation(t *testing.T) {
 	test := &databaseV3TestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewDatabaseV3Reconciler, test)
+	testlib.ResourceCreationSynchronousTest[types.Database, *resourcesv1.TeleportDatabaseV3](t, resources.NewDatabaseV3Reconciler, test)
 }
 
 func TestTeleportDatabaseV3Deletion(t *testing.T) {
 	test := &databaseV3TestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(t, resources.NewDatabaseV3Reconciler, test)
+	testlib.ResourceDeletionSynchronousTest[types.Database, *resourcesv1.TeleportDatabaseV3](t, resources.NewDatabaseV3Reconciler, test)
 }
 
 func TestTeleportDatabaseV3DeletionDrift(t *testing.T) {
 	test := &databaseV3TestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewDatabaseV3Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.Database, *resourcesv1.TeleportDatabaseV3](t, resources.NewDatabaseV3Reconciler, test)
 }
 
 func TestTeleportDatabaseV3Update(t *testing.T) {
 	test := &databaseV3TestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewDatabaseV3Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous[types.Database, *resourcesv1.TeleportDatabaseV3](t, resources.NewDatabaseV3Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/github_connector_controller.go
+++ b/integrations/operator/controllers/resources/github_connector_controller.go
@@ -74,7 +74,7 @@ func (r githubConnectorClient) Mutate(ctx context.Context, new, _ types.GithubCo
 }
 
 // NewGithubConnectorReconciler instantiates a new Kubernetes controller reconciling github_connector resources
-func NewGithubConnectorReconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewGithubConnectorReconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	githubClient := &githubConnectorClient{
 		teleportClient: tClient,
 		kubeClient:     client,

--- a/integrations/operator/controllers/resources/github_connector_controller_test.go
+++ b/integrations/operator/controllers/resources/github_connector_controller_test.go
@@ -130,22 +130,30 @@ func (g *githubTestingPrimitives) CompareTeleportAndKubernetesResource(tResource
 
 func TestGithubConnectorCreation(t *testing.T) {
 	test := &githubTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewGithubConnectorReconciler, test)
+	testlib.ResourceCreationSynchronousTest[
+		types.GithubConnector, *resourcesv3.TeleportGithubConnector,
+	](t, resources.NewGithubConnectorReconciler, test)
 }
 
 func TestGithubConnectorDeletion(t *testing.T) {
 	test := &githubTestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(t, resources.NewGithubConnectorReconciler, test)
+	testlib.ResourceDeletionSynchronousTest[
+		types.GithubConnector, *resourcesv3.TeleportGithubConnector,
+	](t, resources.NewGithubConnectorReconciler, test)
 }
 
 func TestGithubConnectorDeletionDrift(t *testing.T) {
 	test := &githubTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewGithubConnectorReconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest[
+		types.GithubConnector, *resourcesv3.TeleportGithubConnector,
+	](t, resources.NewGithubConnectorReconciler, test)
 }
 
 func TestGithubConnectorUpdate(t *testing.T) {
 	test := &githubTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewGithubConnectorReconciler, test)
+	testlib.ResourceUpdateTestSynchronous[
+		types.GithubConnector, *resourcesv3.TeleportGithubConnector,
+	](t, resources.NewGithubConnectorReconciler, test)
 }
 
 func TestGithubConnectorSecretLookup(t *testing.T) {
@@ -192,7 +200,7 @@ func TestGithubConnectorSecretLookup(t *testing.T) {
 
 	require.NoError(t, kubeClient.Create(ctx, github))
 
-	reconciler, err := resources.NewGithubConnectorReconciler(kubeClient, setup.TeleportClient)
+	reconciler, err := resources.NewGithubConnectorReconciler(kubeClient, setup.TeleportClient, setup.OperatorMetadata())
 	require.NoError(t, err)
 	// Test execution: Kick off the reconciliation.
 	req := reconcile.Request{

--- a/integrations/operator/controllers/resources/inference_model_controller.go
+++ b/integrations/operator/controllers/resources/inference_model_controller.go
@@ -80,7 +80,7 @@ func (c inferenceModelClient) Delete(ctx context.Context, key reconcilers.Resour
 // NewInferenceModelReconciler creates a new Kubernetes controller reconciling
 // inference_model resources.
 func NewInferenceModelReconciler(
-	client kclient.Client, tClient *client.Client,
+	client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata,
 ) (controllers.Reconciler, error) {
 	inferenceModelClient := &inferenceModelClient{
 		teleportClient: tClient,

--- a/integrations/operator/controllers/resources/inference_policy_controller.go
+++ b/integrations/operator/controllers/resources/inference_policy_controller.go
@@ -80,7 +80,7 @@ func (c inferencePolicyClient) Delete(ctx context.Context, key reconcilers.Resou
 // NewInferencePolicyReconciler creates a new Kubernetes controller reconciling
 // inference_policy resources.
 func NewInferencePolicyReconciler(
-	client kclient.Client, tClient *client.Client,
+	client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata,
 ) (controllers.Reconciler, error) {
 	inferencePolicyClient := &inferencePolicyClient{
 		teleportClient: tClient,

--- a/integrations/operator/controllers/resources/inference_secret_controller.go
+++ b/integrations/operator/controllers/resources/inference_secret_controller.go
@@ -89,7 +89,7 @@ func (c inferenceSecretClient) Mutate(ctx context.Context, new, _ *summarizerv1.
 // NewInferenceSecretReconciler creates a new Kubernetes controller reconciling
 // inference_secret resources.
 func NewInferenceSecretReconciler(
-	client kclient.Client, tClient *client.Client,
+	client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata,
 ) (controllers.Reconciler, error) {
 	secretClient := &inferenceSecretClient{
 		teleportClient: tClient,

--- a/integrations/operator/controllers/resources/lock_controller.go
+++ b/integrations/operator/controllers/resources/lock_controller.go
@@ -67,7 +67,7 @@ func (r lockClient) Mutate(_ context.Context, new, existing types.Lock, _ kclien
 }
 
 // NewLockV2Reconciler instantiates a new Kubernetes controller reconciling lock resources
-func NewLockV2Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewLockV2Reconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	lockClient := &lockClient{
 		teleportClient: tClient,
 	}

--- a/integrations/operator/controllers/resources/lock_controller_test.go
+++ b/integrations/operator/controllers/resources/lock_controller_test.go
@@ -130,22 +130,30 @@ func (g *lockTestingPrimitives) CompareTeleportAndKubernetesResource(tResource t
 
 func TestLockCreation(t *testing.T) {
 	test := &lockTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewLockV2Reconciler, test)
+	testlib.ResourceCreationSynchronousTest[
+		types.Lock, *resourcesv1.TeleportLockV2,
+	](t, resources.NewLockV2Reconciler, test)
 }
 
 func TestLockDeletion(t *testing.T) {
 	test := &lockTestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(t, resources.NewLockV2Reconciler, test)
+	testlib.ResourceDeletionSynchronousTest[
+		types.Lock, *resourcesv1.TeleportLockV2,
+	](t, resources.NewLockV2Reconciler, test)
 }
 
 func TestLockDeletionDrift(t *testing.T) {
 	test := &lockTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewLockV2Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest[
+		types.Lock, *resourcesv1.TeleportLockV2,
+	](t, resources.NewLockV2Reconciler, test)
 }
 
 func TestLockUpdate(t *testing.T) {
 	test := &lockTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewLockV2Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous[
+		types.Lock, *resourcesv1.TeleportLockV2,
+	](t, resources.NewLockV2Reconciler, test)
 }
 
 // TestLockMutateExisting tests CreatedAt and CreatedBy fields are persisted
@@ -187,7 +195,7 @@ func TestLockMutateExisting(t *testing.T) {
 	}
 	require.NoError(t, setup.K8sClient.Create(ctx, k8sLock))
 
-	reconciler, err := resources.NewLockV2Reconciler(setup.K8sClient, setup.TeleportClient)
+	reconciler, err := resources.NewLockV2Reconciler(setup.K8sClient, setup.TeleportClient, setup.OperatorMetadata())
 	require.NoError(t, err)
 
 	req := reconcile.Request{

--- a/integrations/operator/controllers/resources/login_rule_controller.go
+++ b/integrations/operator/controllers/resources/login_rule_controller.go
@@ -66,7 +66,7 @@ func (l loginRuleClient) Delete(ctx context.Context, key reconcilers.ResourceKey
 }
 
 // NewLoginRuleReconciler instantiates a new Kubernetes controller reconciling login_rule resources
-func NewLoginRuleReconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewLoginRuleReconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	loginRuleClient := &loginRuleClient{
 		teleportClient: tClient,
 	}

--- a/integrations/operator/controllers/resources/oidc_connector_controller.go
+++ b/integrations/operator/controllers/resources/oidc_connector_controller.go
@@ -86,7 +86,7 @@ func (r oidcConnectorClient) Mutate(ctx context.Context, new, _ types.OIDCConnec
 }
 
 // NewOIDCConnectorReconciler instantiates a new Kubernetes controller reconciling oidc_connector resources
-func NewOIDCConnectorReconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewOIDCConnectorReconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	oidcClient := &oidcConnectorClient{
 		teleportClient: tClient,
 		kubeClient:     client,

--- a/integrations/operator/controllers/resources/oidc_connector_controller_test.go
+++ b/integrations/operator/controllers/resources/oidc_connector_controller_test.go
@@ -131,22 +131,30 @@ func (g *oidcTestingPrimitives) CompareTeleportAndKubernetesResource(tResource t
 
 func TestOIDCConnectorCreation(t *testing.T) {
 	test := &oidcTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewOIDCConnectorReconciler, test)
+	testlib.ResourceCreationSynchronousTest[
+		types.OIDCConnector, *resourcesv3.TeleportOIDCConnector,
+	](t, resources.NewOIDCConnectorReconciler, test)
 }
 
 func TestOIDCConnectorDeletion(t *testing.T) {
 	test := &oidcTestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(t, resources.NewOIDCConnectorReconciler, test)
+	testlib.ResourceDeletionSynchronousTest[
+		types.OIDCConnector, *resourcesv3.TeleportOIDCConnector,
+	](t, resources.NewOIDCConnectorReconciler, test)
 }
 
 func TestOIDCConnectorDeletionDrift(t *testing.T) {
 	test := &oidcTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewOIDCConnectorReconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest[
+		types.OIDCConnector, *resourcesv3.TeleportOIDCConnector,
+	](t, resources.NewOIDCConnectorReconciler, test)
 }
 
 func TestOIDCConnectorUpdate(t *testing.T) {
 	test := &oidcTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewOIDCConnectorReconciler, test)
+	testlib.ResourceUpdateTestSynchronous[
+		types.OIDCConnector, *resourcesv3.TeleportOIDCConnector,
+	](t, resources.NewOIDCConnectorReconciler, test)
 }
 
 func TestOIDCConnectorSecretLookup(t *testing.T) {
@@ -194,7 +202,7 @@ func TestOIDCConnectorSecretLookup(t *testing.T) {
 	oidc.Spec.GoogleAdminEmail = "this-is-required-for-gcp-sa@example.com"
 	require.NoError(t, kubeClient.Create(ctx, oidc))
 
-	reconciler, err := resources.NewOIDCConnectorReconciler(kubeClient, setup.TeleportClient)
+	reconciler, err := resources.NewOIDCConnectorReconciler(kubeClient, setup.TeleportClient, setup.OperatorMetadata())
 	require.NoError(t, err)
 	// Test execution: Kick off the reconciliation.
 	req := reconcile.Request{

--- a/integrations/operator/controllers/resources/okta_import_rule_controller.go
+++ b/integrations/operator/controllers/resources/okta_import_rule_controller.go
@@ -60,7 +60,7 @@ func (r oktaImportRuleClient) Delete(ctx context.Context, key reconcilers.Resour
 }
 
 // NewOktaImportRuleReconciler instantiates a new Kubernetes controller reconciling okta_import_rule resources
-func NewOktaImportRuleReconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewOktaImportRuleReconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	oktaImportRuleClient := &oktaImportRuleClient{
 		teleportClient: tClient,
 	}

--- a/integrations/operator/controllers/resources/okta_import_rule_controller_test.go
+++ b/integrations/operator/controllers/resources/okta_import_rule_controller_test.go
@@ -163,23 +163,23 @@ func (g *oktaImportRuleTestingPrimitives) CompareTeleportAndKubernetesResource(t
 func TestOktaImportRuleCreation(t *testing.T) {
 	t.Skip("Skipping test since okta reconsider is not available in OSS")
 	test := &oktaImportRuleTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewOktaImportRuleReconciler, test)
+	testlib.ResourceCreationSynchronousTest[types.OktaImportRule, *resourcesv1.TeleportOktaImportRule](t, resources.NewOktaImportRuleReconciler, test)
 }
 
 func TestOktaImportRuleDeletion(t *testing.T) {
 	t.Skip("Skipping test since okta reconsider is not available in OSS")
 	test := &oktaImportRuleTestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(t, resources.NewOktaImportRuleReconciler, test)
+	testlib.ResourceDeletionSynchronousTest[types.OktaImportRule, *resourcesv1.TeleportOktaImportRule](t, resources.NewOktaImportRuleReconciler, test)
 }
 
 func TestOktaImportRuleDeletionDrift(t *testing.T) {
 	t.Skip("Skipping test since okta reconsider is not available in OSS")
 	test := &oktaImportRuleTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewOktaImportRuleReconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.OktaImportRule, *resourcesv1.TeleportOktaImportRule](t, resources.NewOktaImportRuleReconciler, test)
 }
 
 func TestOktaImportRuleUpdate(t *testing.T) {
 	t.Skip("Skipping test since okta reconsider is not available in OSS")
 	test := &oktaImportRuleTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewOktaImportRuleReconciler, test)
+	testlib.ResourceUpdateTestSynchronous[types.OktaImportRule, *resourcesv1.TeleportOktaImportRule](t, resources.NewOktaImportRuleReconciler, test)
 }

--- a/integrations/operator/controllers/resources/openssheiceserverv2_controller.go
+++ b/integrations/operator/controllers/resources/openssheiceserverv2_controller.go
@@ -73,7 +73,7 @@ func (r openSSHEICEServerClient) Delete(ctx context.Context, key reconcilers.Res
 
 // NewOpenSSHEICEServerV2Reconciler instantiates a new Kubernetes controller
 // reconciling OpenSSHEICE server resources.
-func NewOpenSSHEICEServerV2Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewOpenSSHEICEServerV2Reconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	serverClient := &openSSHEICEServerClient{
 		teleportClient: tClient,
 	}

--- a/integrations/operator/controllers/resources/openssheiceserverv2_controller_test.go
+++ b/integrations/operator/controllers/resources/openssheiceserverv2_controller_test.go
@@ -126,20 +126,20 @@ func (g *opensshEICEServerV2TestingPrimitives) CompareTeleportAndKubernetesResou
 
 func TestTeleportOpensshEICEServerV2Creation(t *testing.T) {
 	test := &opensshEICEServerV2TestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewOpenSSHEICEServerV2Reconciler, test)
+	testlib.ResourceCreationSynchronousTest[types.Server, *resourcesv1.TeleportOpenSSHEICEServerV2](t, resources.NewOpenSSHEICEServerV2Reconciler, test)
 }
 
 func TestTeleportOpensshEICEServerV2Deletion(t *testing.T) {
 	test := &opensshEICEServerV2TestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(t, resources.NewOpenSSHEICEServerV2Reconciler, test)
+	testlib.ResourceDeletionSynchronousTest[types.Server, *resourcesv1.TeleportOpenSSHEICEServerV2](t, resources.NewOpenSSHEICEServerV2Reconciler, test)
 }
 
 func TestTeleportOpensshEICEServerV2DeletionDrift(t *testing.T) {
 	test := &opensshEICEServerV2TestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewOpenSSHEICEServerV2Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.Server, *resourcesv1.TeleportOpenSSHEICEServerV2](t, resources.NewOpenSSHEICEServerV2Reconciler, test)
 }
 
 func TestTeleportOpensshEICEServerV2Update(t *testing.T) {
 	test := &opensshEICEServerV2TestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewOpenSSHEICEServerV2Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous[types.Server, *resourcesv1.TeleportOpenSSHEICEServerV2](t, resources.NewOpenSSHEICEServerV2Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/opensshserverv2_controller.go
+++ b/integrations/operator/controllers/resources/opensshserverv2_controller.go
@@ -73,7 +73,7 @@ func (r openSSHServerClient) Delete(ctx context.Context, key reconcilers.Resourc
 
 // NewOpenSSHServerV2Reconciler instantiates a new Kubernetes controller
 // reconciling OpenSSH server resources.
-func NewOpenSSHServerV2Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewOpenSSHServerV2Reconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	serverClient := &openSSHServerClient{
 		teleportClient: tClient,
 	}

--- a/integrations/operator/controllers/resources/opensshserverv2_controller_test.go
+++ b/integrations/operator/controllers/resources/opensshserverv2_controller_test.go
@@ -118,20 +118,20 @@ func (g *opensshServerV2TestingPrimitives) CompareTeleportAndKubernetesResource(
 
 func TestTeleportOpensshServerV2Creation(t *testing.T) {
 	test := &opensshServerV2TestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewOpenSSHServerV2Reconciler, test)
+	testlib.ResourceCreationSynchronousTest[types.Server, *resourcesv1.TeleportOpenSSHServerV2](t, resources.NewOpenSSHServerV2Reconciler, test)
 }
 
 func TestTeleportOpensshServerV2Deletion(t *testing.T) {
 	test := &opensshServerV2TestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(t, resources.NewOpenSSHServerV2Reconciler, test)
+	testlib.ResourceDeletionSynchronousTest[types.Server, *resourcesv1.TeleportOpenSSHServerV2](t, resources.NewOpenSSHServerV2Reconciler, test)
 }
 
 func TestTeleportOpensshServerV2DeletionDrift(t *testing.T) {
 	test := &opensshServerV2TestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewOpenSSHServerV2Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.Server, *resourcesv1.TeleportOpenSSHServerV2](t, resources.NewOpenSSHServerV2Reconciler, test)
 }
 
 func TestTeleportOpensshServerV2Update(t *testing.T) {
 	test := &opensshServerV2TestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewOpenSSHServerV2Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous[types.Server, *resourcesv1.TeleportOpenSSHServerV2](t, resources.NewOpenSSHServerV2Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/provision_token_controller.go
+++ b/integrations/operator/controllers/resources/provision_token_controller.go
@@ -58,7 +58,7 @@ func (r provisionTokenClient) Delete(ctx context.Context, key reconcilers.Resour
 }
 
 // NewProvisionTokenReconciler instantiates a new Kubernetes controller reconciling provision token resources
-func NewProvisionTokenReconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewProvisionTokenReconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	tokenClient := &provisionTokenClient{
 		teleportClient: tClient,
 	}

--- a/integrations/operator/controllers/resources/provision_token_controller_test.go
+++ b/integrations/operator/controllers/resources/provision_token_controller_test.go
@@ -151,22 +151,22 @@ func (g *tokenTestingPrimitives) CompareTeleportAndKubernetesResource(tResource 
 
 func TestProvisionTokenCreation(t *testing.T) {
 	test := &tokenTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewProvisionTokenReconciler, test)
+	testlib.ResourceCreationSynchronousTest[types.ProvisionToken, *resourcesv2.TeleportProvisionToken](t, resources.NewProvisionTokenReconciler, test)
 }
 
 func TestProvisionTokenDeletion(t *testing.T) {
 	test := &tokenTestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(t, resources.NewProvisionTokenReconciler, test)
+	testlib.ResourceDeletionSynchronousTest[types.ProvisionToken, *resourcesv2.TeleportProvisionToken](t, resources.NewProvisionTokenReconciler, test)
 }
 
 func TestProvisionTokenDeletionDrift(t *testing.T) {
 	test := &tokenTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewProvisionTokenReconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.ProvisionToken, *resourcesv2.TeleportProvisionToken](t, resources.NewProvisionTokenReconciler, test)
 }
 
 func TestProvisionTokenUpdate(t *testing.T) {
 	test := &tokenTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewProvisionTokenReconciler, test)
+	testlib.ResourceUpdateTestSynchronous[types.ProvisionToken, *resourcesv2.TeleportProvisionToken](t, resources.NewProvisionTokenReconciler, test)
 }
 
 // This test checks the operator can create Token resources in Teleport for a
@@ -216,7 +216,7 @@ github:
 	err = setup.K8sClient.Create(ctx, obj)
 	require.NoError(t, err)
 
-	reconciler, err := resources.NewProvisionTokenReconciler(setup.K8sClient, setup.TeleportClient)
+	reconciler, err := resources.NewProvisionTokenReconciler(setup.K8sClient, setup.TeleportClient, setup.OperatorMetadata())
 	require.NoError(t, err)
 
 	// Test execution: Kick off the reconciliation.

--- a/integrations/operator/controllers/resources/retrieval_model_controller.go
+++ b/integrations/operator/controllers/resources/retrieval_model_controller.go
@@ -83,7 +83,7 @@ func (r retrievalModelClient) Mutate(_ context.Context, _, _ *summarizerv1.Retri
 }
 
 // NewRetrievalModelV1Reconciler instantiates a new Kubernetes controller reconciling RetrievalModel resources.
-func NewRetrievalModelV1Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewRetrievalModelV1Reconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	rmClient := &retrievalModelClient{
 		teleportClient: tClient,
 	}

--- a/integrations/operator/controllers/resources/role_controller_test.go
+++ b/integrations/operator/controllers/resources/role_controller_test.go
@@ -125,7 +125,7 @@ allow:
 		},
 	}
 
-	reconciler, err := resources.NewRoleReconciler(setup.K8sClient, setup.TeleportClient)
+	reconciler, err := resources.NewRoleReconciler(setup.K8sClient, setup.TeleportClient, setup.OperatorMetadata())
 	require.NoError(t, err)
 
 	for _, tc := range tests {
@@ -301,20 +301,20 @@ func (g *roleTestingPrimitives) CompareTeleportAndKubernetesResource(tResource t
 
 func TestTeleportRoleCreation(t *testing.T) {
 	test := &roleTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewRoleReconciler, test)
+	testlib.ResourceCreationSynchronousTest[types.Role, *resourcesv5.TeleportRole](t, resources.NewRoleReconciler, test)
 }
 
 func TestTeleportRoleDeletion(t *testing.T) {
 	test := &roleTestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(t, resources.NewRoleReconciler, test)
+	testlib.ResourceDeletionSynchronousTest[types.Role, *resourcesv5.TeleportRole](t, resources.NewRoleReconciler, test)
 }
 
 func TestTeleportRoleDeletionDrift(t *testing.T) {
 	test := &roleTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewRoleReconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.Role, *resourcesv5.TeleportRole](t, resources.NewRoleReconciler, test)
 }
 
 func TestTeleportRoleUpdate(t *testing.T) {
 	test := &roleTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewRoleReconciler, test)
+	testlib.ResourceUpdateTestSynchronous[types.Role, *resourcesv5.TeleportRole](t, resources.NewRoleReconciler, test)
 }

--- a/integrations/operator/controllers/resources/rolev6_controller_test.go
+++ b/integrations/operator/controllers/resources/rolev6_controller_test.go
@@ -135,20 +135,20 @@ func (g *roleV6TestingPrimitives) CompareTeleportAndKubernetesResource(tResource
 
 func TestTeleportRoleV6Creation(t *testing.T) {
 	test := &roleV6TestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewRoleV6Reconciler, test)
+	testlib.ResourceCreationSynchronousTest[types.Role, *resourcesv1.TeleportRoleV6](t, resources.NewRoleV6Reconciler, test)
 }
 
 func TestTeleportRoleV6Deletion(t *testing.T) {
 	test := &roleV6TestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(t, resources.NewRoleV6Reconciler, test)
+	testlib.ResourceDeletionSynchronousTest[types.Role, *resourcesv1.TeleportRoleV6](t, resources.NewRoleV6Reconciler, test)
 }
 
 func TestTeleportRoleV6DeletionDrift(t *testing.T) {
 	test := &roleV6TestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewRoleV6Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.Role, *resourcesv1.TeleportRoleV6](t, resources.NewRoleV6Reconciler, test)
 }
 
 func TestTeleportRoleV6Update(t *testing.T) {
 	test := &roleV6TestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewRoleV6Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous[types.Role, *resourcesv1.TeleportRoleV6](t, resources.NewRoleV6Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/rolev7_controller_test.go
+++ b/integrations/operator/controllers/resources/rolev7_controller_test.go
@@ -132,20 +132,20 @@ func (g *roleV7TestingPrimitives) CompareTeleportAndKubernetesResource(tResource
 
 func TestTeleportRoleV7Creation(t *testing.T) {
 	test := &roleV7TestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewRoleV7Reconciler, test)
+	testlib.ResourceCreationSynchronousTest[types.Role, *resourcesv1.TeleportRoleV7](t, resources.NewRoleV7Reconciler, test)
 }
 
 func TestTeleportRoleV7Deletion(t *testing.T) {
 	test := &roleV7TestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(t, resources.NewRoleV7Reconciler, test)
+	testlib.ResourceDeletionSynchronousTest[types.Role, *resourcesv1.TeleportRoleV7](t, resources.NewRoleV7Reconciler, test)
 }
 
 func TestTeleportRoleV7DeletionDrift(t *testing.T) {
 	test := &roleV7TestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewRoleV7Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.Role, *resourcesv1.TeleportRoleV7](t, resources.NewRoleV7Reconciler, test)
 }
 
 func TestTeleportRoleV7Update(t *testing.T) {
 	test := &roleV7TestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewRoleV7Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous[types.Role, *resourcesv1.TeleportRoleV7](t, resources.NewRoleV7Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/rolev8_controller_test.go
+++ b/integrations/operator/controllers/resources/rolev8_controller_test.go
@@ -134,20 +134,20 @@ func (g *roleV8TestingPrimitives) CompareTeleportAndKubernetesResource(tResource
 
 func TestTeleportRoleV8Creation(t *testing.T) {
 	test := &roleV8TestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewRoleV8Reconciler, test)
+	testlib.ResourceCreationSynchronousTest[types.Role, *resourcesv1.TeleportRoleV8](t, resources.NewRoleV8Reconciler, test)
 }
 
 func TestTeleportRoleV8Deletion(t *testing.T) {
 	test := &roleV8TestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(t, resources.NewRoleV8Reconciler, test)
+	testlib.ResourceDeletionSynchronousTest[types.Role, *resourcesv1.TeleportRoleV8](t, resources.NewRoleV8Reconciler, test)
 }
 
 func TestTeleportRoleV8DeletionDrift(t *testing.T) {
 	test := &roleV8TestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewRoleV8Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.Role, *resourcesv1.TeleportRoleV8](t, resources.NewRoleV8Reconciler, test)
 }
 
 func TestTeleportRoleV8Update(t *testing.T) {
 	test := &roleV8TestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewRoleV8Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous[types.Role, *resourcesv1.TeleportRoleV8](t, resources.NewRoleV8Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/rolevX_controller.go
+++ b/integrations/operator/controllers/resources/rolevX_controller.go
@@ -64,7 +64,7 @@ func (r roleClient) Delete(ctx context.Context, key reconcilers.ResourceKey) err
 }
 
 // NewRoleReconciler instantiates a new Kubernetes controller reconciling legacy role v5 resources
-func NewRoleReconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewRoleReconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	roleClient := &roleClient{
 		teleportClient: tClient,
 	}
@@ -79,7 +79,7 @@ func NewRoleReconciler(client kclient.Client, tClient *client.Client) (controlle
 }
 
 // NewRoleV6Reconciler instantiates a new Kubernetes controller reconciling role v6 resources
-func NewRoleV6Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewRoleV6Reconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	roleClient := &roleClient{
 		teleportClient: tClient,
 	}
@@ -94,7 +94,7 @@ func NewRoleV6Reconciler(client kclient.Client, tClient *client.Client) (control
 }
 
 // NewRoleV7Reconciler instantiates a new Kubernetes controller reconciling role v7 resources
-func NewRoleV7Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewRoleV7Reconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	roleClient := &roleClient{
 		teleportClient: tClient,
 	}
@@ -109,7 +109,7 @@ func NewRoleV7Reconciler(client kclient.Client, tClient *client.Client) (control
 }
 
 // NewRoleV8Reconciler instantiates a new Kubernetes controller reconciling role v8 resources
-func NewRoleV8Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewRoleV8Reconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	roleClient := &roleClient{
 		teleportClient: tClient,
 	}

--- a/integrations/operator/controllers/resources/saml_connector_controller.go
+++ b/integrations/operator/controllers/resources/saml_connector_controller.go
@@ -63,7 +63,7 @@ func (r samlConnectorClient) Delete(ctx context.Context, key reconcilers.Resourc
 }
 
 // NewSAMLConnectorReconciler instantiates a new Kubernetes controller reconciling saml_connector resources
-func NewSAMLConnectorReconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewSAMLConnectorReconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	samlClient := &samlConnectorClient{
 		teleportClient: tClient,
 	}

--- a/integrations/operator/controllers/resources/saml_connector_controller_test.go
+++ b/integrations/operator/controllers/resources/saml_connector_controller_test.go
@@ -184,20 +184,20 @@ func (g *samlTestingPrimitives) DebugDrifts(t *testing.T, name string) {
 
 func TestSAMLConnectorCreation(t *testing.T) {
 	test := &samlTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewSAMLConnectorReconciler, test)
+	testlib.ResourceCreationSynchronousTest[types.SAMLConnector, *resourcesv2.TeleportSAMLConnector](t, resources.NewSAMLConnectorReconciler, test)
 }
 
 func TestSAMLConnectorDeletion(t *testing.T) {
 	test := &samlTestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(t, resources.NewSAMLConnectorReconciler, test)
+	testlib.ResourceDeletionSynchronousTest[types.SAMLConnector, *resourcesv2.TeleportSAMLConnector](t, resources.NewSAMLConnectorReconciler, test)
 }
 
 func TestSAMLConnectorDeletionDrift(t *testing.T) {
 	test := &samlTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewSAMLConnectorReconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.SAMLConnector, *resourcesv2.TeleportSAMLConnector](t, resources.NewSAMLConnectorReconciler, test)
 }
 
 func TestSAMLConnectorUpdate(t *testing.T) {
 	test := &samlTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewSAMLConnectorReconciler, test)
+	testlib.ResourceUpdateTestSynchronous[types.SAMLConnector, *resourcesv2.TeleportSAMLConnector](t, resources.NewSAMLConnectorReconciler, test)
 }

--- a/integrations/operator/controllers/resources/saml_idp_service_providerv1_controller.go
+++ b/integrations/operator/controllers/resources/saml_idp_service_providerv1_controller.go
@@ -60,7 +60,7 @@ func (r samlIdPServiceProviderClient) Delete(ctx context.Context, key reconciler
 
 // NewSAMLIdPServiceProviderV1Reconciler instantiates a new Kubernetes controller
 // reconciling saml_idp_service_provider resources.
-func NewSAMLIdPServiceProviderV1Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewSAMLIdPServiceProviderV1Reconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	spClient := &samlIdPServiceProviderClient{
 		teleportClient: tClient,
 	}

--- a/integrations/operator/controllers/resources/saml_idp_service_providerv1_controller_test.go
+++ b/integrations/operator/controllers/resources/saml_idp_service_providerv1_controller_test.go
@@ -161,22 +161,22 @@ func (g *samlIdPServiceProviderTestingPrimitives) CompareTeleportAndKubernetesRe
 
 func TestSAMLIdPServiceProviderCreation(t *testing.T) {
 	test := &samlIdPServiceProviderTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewSAMLIdPServiceProviderV1Reconciler, test)
+	testlib.ResourceCreationSynchronousTest[types.SAMLIdPServiceProvider, *resourcesv1.TeleportSAMLIdPServiceProviderV1](t, resources.NewSAMLIdPServiceProviderV1Reconciler, test)
 }
 
 func TestSAMLIdPServiceProviderDeletion(t *testing.T) {
 	test := &samlIdPServiceProviderTestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(t, resources.NewSAMLIdPServiceProviderV1Reconciler, test)
+	testlib.ResourceDeletionSynchronousTest[types.SAMLIdPServiceProvider, *resourcesv1.TeleportSAMLIdPServiceProviderV1](t, resources.NewSAMLIdPServiceProviderV1Reconciler, test)
 }
 
 func TestSAMLIdPServiceProviderDeletionDrift(t *testing.T) {
 	test := &samlIdPServiceProviderTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewSAMLIdPServiceProviderV1Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.SAMLIdPServiceProvider, *resourcesv1.TeleportSAMLIdPServiceProviderV1](t, resources.NewSAMLIdPServiceProviderV1Reconciler, test)
 }
 
 func TestSAMLIdPServiceProviderUpdate(t *testing.T) {
 	test := &samlIdPServiceProviderTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewSAMLIdPServiceProviderV1Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous[types.SAMLIdPServiceProvider, *resourcesv1.TeleportSAMLIdPServiceProviderV1](t, resources.NewSAMLIdPServiceProviderV1Reconciler, test)
 }
 
 // This test ensures the controller behavior for Teleport API validation
@@ -186,7 +186,7 @@ func TestSAMLIdPServiceProviderUpdate(t *testing.T) {
 func TestSAMLIdPServiceProviderCreateValidationError(t *testing.T) {
 	ctx := t.Context()
 	setup := testlib.SetupFakeKubeTestEnv(t)
-	reconciler, err := resources.NewSAMLIdPServiceProviderV1Reconciler(setup.K8sClient, setup.TeleportClient)
+	reconciler, err := resources.NewSAMLIdPServiceProviderV1Reconciler(setup.K8sClient, setup.TeleportClient, setup.OperatorMetadata())
 	require.NoError(t, err)
 
 	name := validRandomResourceName("saml-sp-")

--- a/integrations/operator/controllers/resources/scopedrole_controller.go
+++ b/integrations/operator/controllers/resources/scopedrole_controller.go
@@ -66,7 +66,7 @@ func (s *scopedRoleClient) Update(ctx context.Context, role *accessv1.ScopedRole
 	return trace.Wrap(err)
 }
 
-func NewScopedRoleV1Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewScopedRoleV1Reconciler(client kclient.Client, tClient *client.Client, metadata reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	return reconcilers.NewTeleportScopedResource153Reconciler[*accessv1.ScopedRole, *resourcesv1.TeleportScopedRoleV1](
 		client,
 		&scopedRoleClient{
@@ -75,5 +75,6 @@ func NewScopedRoleV1Reconciler(client kclient.Client, tClient *client.Client) (c
 		reconcilers.Config{
 			Scoped: true,
 		},
+		metadata,
 	)
 }

--- a/integrations/operator/controllers/resources/scopedrole_controller_test.go
+++ b/integrations/operator/controllers/resources/scopedrole_controller_test.go
@@ -40,7 +40,7 @@ import (
 )
 
 var scopedRoleSpec = accessv1.ScopedRoleSpec_builder{
-	AssignableScopes: []string{"/staging"},
+	AssignableScopes: []string{testScope},
 	Rules: []*accessv1.ScopedRule{
 		accessv1.ScopedRule_builder{
 			Resources: []string{"scoped_role"},
@@ -69,10 +69,11 @@ func (g *scopedRoleTestingPrimitives) CreateTeleportResource(ctx context.Context
 		Metadata: headerv1.Metadata_builder{
 			Name: name,
 			Labels: map[string]string{
-				types.OriginLabel: types.OriginKubernetes,
+				types.OriginLabel:           types.OriginKubernetes,
+				reconcilers.OperatorIDLabel: g.setup.OperatorMetadata().ID,
 			},
 		}.Build(),
-		Scope: "/staging",
+		Scope: testScope,
 		Spec:  scopedRoleSpec,
 	}.Build()
 	_, err := g.setup.TeleportClient.ScopedAccessServiceClient().CreateScopedRole(ctx, accessv1.CreateScopedRoleRequest_builder{
@@ -83,7 +84,8 @@ func (g *scopedRoleTestingPrimitives) CreateTeleportResource(ctx context.Context
 
 func (g *scopedRoleTestingPrimitives) GetTeleportResource(ctx context.Context, name string) (*accessv1.ScopedRole, error) {
 	resp, err := g.setup.TeleportClient.ScopedAccessServiceClient().GetScopedRole(ctx, accessv1.GetScopedRoleRequest_builder{
-		Name: name,
+		Name:  name,
+		Scope: g.setup.OperatorMetadata().Scope,
 	}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -93,7 +95,8 @@ func (g *scopedRoleTestingPrimitives) GetTeleportResource(ctx context.Context, n
 
 func (g *scopedRoleTestingPrimitives) DeleteTeleportResource(ctx context.Context, name string) error {
 	_, err := g.setup.TeleportClient.ScopedAccessServiceClient().DeleteScopedRole(ctx, accessv1.DeleteScopedRoleRequest_builder{
-		Name: name,
+		Name:  name,
+		Scope: g.setup.OperatorMetadata().Scope,
 	}.Build())
 	return trace.Wrap(err)
 }
@@ -104,7 +107,7 @@ func (g *scopedRoleTestingPrimitives) CreateKubernetesResource(ctx context.Conte
 			Name:      name,
 			Namespace: g.setup.Namespace.Name,
 		},
-		Scope: "/staging",
+		Scope: testScope,
 		Spec:  (*resourcesv1.TeleportScopedRoleV1Spec)(scopedRoleSpec),
 	}
 	return trace.Wrap(g.setup.K8sClient.Create(ctx, role))
@@ -135,7 +138,7 @@ func (g *scopedRoleTestingPrimitives) ModifyKubernetesResource(ctx context.Conte
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	role.Spec.AssignableScopes = []string{"/staging/aa", "/staging/bb"}
+	role.Spec.AssignableScopes = []string{testScope, testNestedScope}
 	role.Spec.Ssh = accessv1.ScopedRoleSSH_builder{
 		Labels: []*labelv1.Label{
 			labelv1.Label_builder{
@@ -159,22 +162,37 @@ func (g *scopedRoleTestingPrimitives) CompareTeleportAndKubernetesResource(
 }
 
 func TestScopedRoleCreation(t *testing.T) {
-	t.Skip("scope namespaced resources are temporarily non-functional until we can update the operator to be compatible with namespacing")
 	t.Parallel()
 	test := &scopedRoleTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewScopedRoleV1Reconciler, test, testlib.WithScopesFeatures(scopes.Features{Enabled: true}))
+	testlib.ResourceCreationSynchronousTest[*accessv1.ScopedRole, *resourcesv1.TeleportScopedRoleV1](
+		t,
+		resources.NewScopedRoleV1Reconciler,
+		test,
+		testlib.WithScopesFeatures(scopes.Features{Enabled: true}),
+		testlib.WithScope(testScope),
+	)
 }
 
 func TestScopedRoleDeletionDrift(t *testing.T) {
-	t.Skip("scope namespaced resources are temporarily non-functional until we can update the operator to be compatible with namespacing")
 	t.Parallel()
 	test := &scopedRoleTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewScopedRoleV1Reconciler, test, testlib.WithScopesFeatures(scopes.Features{Enabled: true}))
+	testlib.ResourceDeletionDriftSynchronousTest[*accessv1.ScopedRole, *resourcesv1.TeleportScopedRoleV1](
+		t,
+		resources.NewScopedRoleV1Reconciler,
+		test,
+		testlib.WithScopesFeatures(scopes.Features{Enabled: true}),
+		testlib.WithScope(testScope),
+	)
 }
 
 func TestScopedRoleUpdate(t *testing.T) {
-	t.Skip("scope namespaced resources are temporarily non-functional until we can update the operator to be compatible with namespacing")
 	t.Parallel()
 	test := &scopedRoleTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewScopedRoleV1Reconciler, test, testlib.WithScopesFeatures(scopes.Features{Enabled: true}))
+	testlib.ResourceUpdateTestSynchronous[*accessv1.ScopedRole, *resourcesv1.TeleportScopedRoleV1](
+		t,
+		resources.NewScopedRoleV1Reconciler,
+		test,
+		testlib.WithScopesFeatures(scopes.Features{Enabled: true}),
+		testlib.WithScope(testScope),
+	)
 }

--- a/integrations/operator/controllers/resources/scopedroleassignment_controller.go
+++ b/integrations/operator/controllers/resources/scopedroleassignment_controller.go
@@ -69,7 +69,7 @@ func (s *scopedRoleAssignmentClient) Update(ctx context.Context, assignment *acc
 	return trace.Wrap(err)
 }
 
-func NewScopedRoleAssignmentV1Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewScopedRoleAssignmentV1Reconciler(client kclient.Client, tClient *client.Client, metadata reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	return reconcilers.NewTeleportScopedResource153Reconciler[*accessv1.ScopedRoleAssignment, *resourcesv1.TeleportScopedRoleAssignmentV1](
 		client,
 		&scopedRoleAssignmentClient{
@@ -78,5 +78,6 @@ func NewScopedRoleAssignmentV1Reconciler(client kclient.Client, tClient *client.
 		reconcilers.Config{
 			Scoped: true,
 		},
+		metadata,
 	)
 }

--- a/integrations/operator/controllers/resources/scopedroleassignment_controller_test.go
+++ b/integrations/operator/controllers/resources/scopedroleassignment_controller_test.go
@@ -43,8 +43,8 @@ var scopedRoleAssignmentSpec = accessv1.ScopedRoleAssignmentSpec_builder{
 	User: "test-user",
 	Assignments: []*accessv1.Assignment{
 		accessv1.Assignment_builder{
-			Role:  "test-role",
-			Scope: "/staging",
+			Role:  scopes.QualifiedName{Scope: testScope, Name: "test-role"}.String(),
+			Scope: testNestedScope,
 		}.Build(),
 	},
 }.Build()
@@ -70,10 +70,11 @@ func (g *scopedRoleAssignmentTestingPrimitives) CreateTeleportResource(ctx conte
 		Metadata: headerv1.Metadata_builder{
 			Name: name,
 			Labels: map[string]string{
-				types.OriginLabel: types.OriginKubernetes,
+				types.OriginLabel:           types.OriginKubernetes,
+				reconcilers.OperatorIDLabel: g.setup.OperatorMetadata().ID,
 			},
 		}.Build(),
-		Scope: "/staging",
+		Scope: testScope,
 		Spec:  scopedRoleAssignmentSpec,
 	}.Build()
 	_, err := g.setup.TeleportClient.ScopedAccessServiceClient().CreateScopedRoleAssignment(ctx, accessv1.CreateScopedRoleAssignmentRequest_builder{
@@ -85,6 +86,7 @@ func (g *scopedRoleAssignmentTestingPrimitives) CreateTeleportResource(ctx conte
 func (g *scopedRoleAssignmentTestingPrimitives) GetTeleportResource(ctx context.Context, name string) (*accessv1.ScopedRoleAssignment, error) {
 	resp, err := g.setup.TeleportClient.ScopedAccessServiceClient().GetScopedRoleAssignment(ctx, accessv1.GetScopedRoleAssignmentRequest_builder{
 		Name:    name,
+		Scope:   g.setup.OperatorMetadata().Scope,
 		SubKind: access.SubKindDynamic,
 	}.Build())
 	if err != nil {
@@ -96,6 +98,7 @@ func (g *scopedRoleAssignmentTestingPrimitives) GetTeleportResource(ctx context.
 func (g *scopedRoleAssignmentTestingPrimitives) DeleteTeleportResource(ctx context.Context, name string) error {
 	_, err := g.setup.TeleportClient.ScopedAccessServiceClient().DeleteScopedRoleAssignment(ctx, accessv1.DeleteScopedRoleAssignmentRequest_builder{
 		Name:    name,
+		Scope:   g.setup.OperatorMetadata().Scope,
 		SubKind: access.SubKindDynamic,
 	}.Build())
 	return trace.Wrap(err)
@@ -107,7 +110,7 @@ func (g *scopedRoleAssignmentTestingPrimitives) CreateKubernetesResource(ctx con
 			Name:      name,
 			Namespace: g.setup.Namespace.Name,
 		},
-		Scope: "/staging",
+		Scope: testScope,
 		Spec:  (*resourcesv1.TeleportScopedRoleAssignmentV1Spec)(scopedRoleAssignmentSpec),
 	}
 	return trace.Wrap(g.setup.K8sClient.Create(ctx, assignment))
@@ -140,8 +143,8 @@ func (g *scopedRoleAssignmentTestingPrimitives) ModifyKubernetesResource(ctx con
 	}
 	assignment.Spec.Assignments = []*accessv1.Assignment{
 		accessv1.Assignment_builder{
-			Role:  "test-role",
-			Scope: "/staging/aa",
+			Role:  scopes.QualifiedName{Scope: testScope, Name: "test-role"}.String(),
+			Scope: testScope, // change from testNestedScope to testScope
 		}.Build(),
 	}
 	return trace.Wrap(g.setup.K8sClient.Update(ctx, assignment))
@@ -158,22 +161,39 @@ func (g *scopedRoleAssignmentTestingPrimitives) CompareTeleportAndKubernetesReso
 }
 
 func TestScopedRoleAssignmentCreation(t *testing.T) {
-	t.Skip("scope namespaced resources are temporarily non-functional until we can update the operator to be compatible with namespacing")
 	t.Parallel()
 	test := &scopedRoleAssignmentTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewScopedRoleAssignmentV1Reconciler, test, testlib.WithResourceName(uuid.New().String()), testlib.WithScopesFeatures(scopes.Features{Enabled: true}))
+	testlib.ResourceCreationSynchronousTest[*accessv1.ScopedRoleAssignment, *resourcesv1.TeleportScopedRoleAssignmentV1](
+		t,
+		resources.NewScopedRoleAssignmentV1Reconciler,
+		test,
+		testlib.WithResourceName(uuid.New().String()),
+		testlib.WithScopesFeatures(scopes.Features{Enabled: true}),
+		testlib.WithScope(testScope),
+	)
 }
 
 func TestScopedRoleAssignmentDeletionDrift(t *testing.T) {
-	t.Skip("scope namespaced resources are temporarily non-functional until we can update the operator to be compatible with namespacing")
 	t.Parallel()
 	test := &scopedRoleAssignmentTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewScopedRoleAssignmentV1Reconciler, test, testlib.WithResourceName(uuid.New().String()), testlib.WithScopesFeatures(scopes.Features{Enabled: true}))
+	testlib.ResourceDeletionDriftSynchronousTest[*accessv1.ScopedRoleAssignment, *resourcesv1.TeleportScopedRoleAssignmentV1](t,
+		resources.NewScopedRoleAssignmentV1Reconciler,
+		test,
+		testlib.WithResourceName(uuid.New().String()),
+		testlib.WithScopesFeatures(scopes.Features{Enabled: true}),
+		testlib.WithScope(testScope),
+	)
 }
 
 func TestScopedRoleAssignmentUpdate(t *testing.T) {
-	t.Skip("scope namespaced resources are temporarily non-functional until we can update the operator to be compatible with namespacing")
 	t.Parallel()
 	test := &scopedRoleAssignmentTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewScopedRoleAssignmentV1Reconciler, test, testlib.WithResourceName(uuid.New().String()), testlib.WithScopesFeatures(scopes.Features{Enabled: true}))
+	testlib.ResourceUpdateTestSynchronous[*accessv1.ScopedRoleAssignment, *resourcesv1.TeleportScopedRoleAssignmentV1](
+		t,
+		resources.NewScopedRoleAssignmentV1Reconciler,
+		test,
+		testlib.WithResourceName(uuid.New().String()),
+		testlib.WithScopesFeatures(scopes.Features{Enabled: true}),
+		testlib.WithScope(testScope),
+	)
 }

--- a/integrations/operator/controllers/resources/scopedtoken_controller.go
+++ b/integrations/operator/controllers/resources/scopedtoken_controller.go
@@ -57,7 +57,7 @@ func (s *scopedTokenClient) Update(ctx context.Context, token *tokenv1.ScopedTok
 	return trace.Wrap(err)
 }
 
-func NewScopedTokenV1Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewScopedTokenV1Reconciler(client kclient.Client, tClient *client.Client, metadata reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	return reconcilers.NewTeleportScopedResource153Reconciler[*tokenv1.ScopedToken, *resourcesv1.TeleportScopedTokenV1](
 		client,
 		&scopedTokenClient{
@@ -66,5 +66,6 @@ func NewScopedTokenV1Reconciler(client kclient.Client, tClient *client.Client) (
 		reconcilers.Config{
 			Scoped: true,
 		},
+		metadata,
 	)
 }

--- a/integrations/operator/controllers/resources/scopedtoken_controller_test.go
+++ b/integrations/operator/controllers/resources/scopedtoken_controller_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 var scopedTokenSpec = tokenv1.ScopedTokenSpec_builder{
-	AssignedScope: "/staging/foo",
+	AssignedScope: testNestedScope,
 	Roles:         []string{types.RoleNode.String()},
 	JoinMethod:    string(types.JoinMethodToken),
 	UsageMode:     "unlimited",
@@ -69,10 +69,11 @@ func (g *scopedTokenTestingPrimitives) CreateTeleportResource(ctx context.Contex
 		Metadata: headerv1.Metadata_builder{
 			Name: name,
 			Labels: map[string]string{
-				types.OriginLabel: types.OriginKubernetes,
+				types.OriginLabel:           types.OriginKubernetes,
+				reconcilers.OperatorIDLabel: g.setup.OperatorMetadata().ID,
 			},
 		}.Build(),
-		Scope: "/staging",
+		Scope: testScope,
 		Spec:  scopedTokenSpec,
 	}.Build()
 	_, err := g.setup.TeleportClient.CreateScopedToken(ctx, token)
@@ -82,7 +83,7 @@ func (g *scopedTokenTestingPrimitives) CreateTeleportResource(ctx context.Contex
 func (g *scopedTokenTestingPrimitives) GetTeleportResource(ctx context.Context, name string) (*tokenv1.ScopedToken, error) {
 	return g.setup.TeleportClient.GetScopedToken(ctx, tokenv1.GetScopedTokenRequest_builder{
 		Name:       name,
-		Scope:      "/staging",
+		Scope:      testScope,
 		WithSecret: true,
 	}.Build())
 }
@@ -90,7 +91,7 @@ func (g *scopedTokenTestingPrimitives) GetTeleportResource(ctx context.Context, 
 func (g *scopedTokenTestingPrimitives) DeleteTeleportResource(ctx context.Context, name string) error {
 	return trace.Wrap(g.setup.TeleportClient.DeleteScopedToken(ctx, tokenv1.DeleteScopedTokenRequest_builder{
 		Name:  name,
-		Scope: "/staging",
+		Scope: testScope,
 	}.Build()))
 }
 
@@ -100,7 +101,7 @@ func (g *scopedTokenTestingPrimitives) CreateKubernetesResource(ctx context.Cont
 			Name:      name,
 			Namespace: g.setup.Namespace.Name,
 		},
-		Scope: "/staging",
+		Scope: testScope,
 		Spec:  (*resourcesv1.TeleportScopedTokenV1Spec)(scopedTokenSpec),
 	}
 	return trace.Wrap(g.setup.K8sClient.Create(ctx, token))
@@ -151,15 +152,15 @@ func (g *scopedTokenTestingPrimitives) CompareTeleportAndKubernetesResource(
 
 func TestScopedTokenCreation(t *testing.T) {
 	test := &scopedTokenTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewScopedTokenV1Reconciler, test)
+	testlib.ResourceCreationSynchronousTest[*tokenv1.ScopedToken, *resourcesv1.TeleportScopedTokenV1](t, resources.NewScopedTokenV1Reconciler, test, testlib.WithScope(testScope))
 }
 
 func TestScopedTokenDeletionDrift(t *testing.T) {
 	test := &scopedTokenTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewScopedTokenV1Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest[*tokenv1.ScopedToken, *resourcesv1.TeleportScopedTokenV1](t, resources.NewScopedTokenV1Reconciler, test, testlib.WithScope(testScope))
 }
 
 func TestScopedTokenUpdate(t *testing.T) {
 	test := &scopedTokenTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewScopedTokenV1Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous[*tokenv1.ScopedToken, *resourcesv1.TeleportScopedTokenV1](t, resources.NewScopedTokenV1Reconciler, test, testlib.WithScope(testScope))
 }

--- a/integrations/operator/controllers/resources/setup.go
+++ b/integrations/operator/controllers/resources/setup.go
@@ -32,10 +32,11 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
 )
 
 // ReconcilerFactory is a function that creates a reconciler from Kubernetes and Teleport clients.
-type ReconcilerFactory func(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error)
+type ReconcilerFactory func(client kclient.Client, tClient *client.Client, metadata reconcilers.OperatorMetadata) (controllers.Reconciler, error)
 
 // Add new reconcilers here.
 var supportedReconcilers = []ReconcilerFactory{
@@ -112,6 +113,8 @@ type Config struct {
 	// Features are the features advertised by the Teleport cluster.
 	// This is used to know which reconcilers should be started.
 	Features *proto.Features
+	// OperatorMetadata contains metadata about the operator.
+	OperatorMetadata reconcilers.OperatorMetadata
 }
 
 // gvkCache is a minimal opportunistic cache around the [discovery.DiscoveryInterface]
@@ -159,7 +162,7 @@ func filterEnabledReconcilers(c Config, reconcilers []ReconcilerFactory, discove
 	var enabledReconcilers []controllers.Reconciler
 	// Check which reconcilers can and should be enabled.
 	for i, factory := range reconcilers {
-		reconciler, err := factory(c.KubeClient, c.TeleportClient)
+		reconciler, err := factory(c.KubeClient, c.TeleportClient, c.OperatorMetadata)
 		if err != nil {
 			return nil, trace.Wrap(err, "creating reconciler[%d]", i)
 		}

--- a/integrations/operator/controllers/resources/setup_test.go
+++ b/integrations/operator/controllers/resources/setup_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
@@ -64,7 +65,7 @@ func (f *fakeReconciler) CheckFeatures(features *proto.Features) bool {
 }
 
 // Factory is a ReconcilerFactory for the given fakeReconciler.
-func (f *fakeReconciler) Factory(_ kclient.Client, _ *client.Client) (controllers.Reconciler, error) {
+func (f *fakeReconciler) Factory(_ kclient.Client, _ *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	return f, nil
 }
 

--- a/integrations/operator/controllers/resources/setup_test.go
+++ b/integrations/operator/controllers/resources/setup_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
@@ -86,7 +87,7 @@ func (f *fakeReconciler) CheckFeatures(features *proto.Features) bool {
 }
 
 // Factory is a ReconcilerFactory for the given fakeReconciler.
-func (f *fakeReconciler) Factory(_ kclient.Client, _ *client.Client) (controllers.Reconciler, error) {
+func (f *fakeReconciler) Factory(_ kclient.Client, _ *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	return f, nil
 }
 

--- a/integrations/operator/controllers/resources/suite_test.go
+++ b/integrations/operator/controllers/resources/suite_test.go
@@ -31,6 +31,11 @@ import (
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
 )
 
+const (
+	testScope       = "/staging"
+	testNestedScope = testScope + "/nested"
+)
+
 // Temporary type alias to slightly decrease the size of this commit, it can be
 // removed in a follow-up.
 type testSetup = testlib.TestSetup

--- a/integrations/operator/controllers/resources/testlib/accesslist_controller_tests.go
+++ b/integrations/operator/controllers/resources/testlib/accesslist_controller_tests.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gravitational/teleport/api/client"
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
@@ -38,6 +39,7 @@ import (
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
+	"github.com/gravitational/teleport/lib/scopes"
 )
 
 func newAccessListSpec(nextAudit time.Time) accesslist.Spec {
@@ -67,6 +69,30 @@ func newAccessListSpec(nextAudit time.Time) accesslist.Spec {
 	}
 }
 
+func newScopedAccessListSpec(nextAudit time.Time) accesslist.Spec {
+	return accesslist.Spec{
+		Title:       "crane operation",
+		Description: "Access list that Gru uses to allow the minions to operate the crane.",
+		Owners:      []accesslist.Owner{{Name: "Gru", Description: "The super villain.", MembershipKind: accesslist.MembershipKindUser}},
+		Audit: accesslist.Audit{
+			Recurrence: accesslist.Recurrence{
+				Frequency:  accesslist.SixMonths,
+				DayOfMonth: accesslist.FirstDayOfMonth,
+			},
+			NextAuditDate: nextAudit,
+		},
+		Grants: accesslist.Grants{
+			Traits: trait.Traits{},
+			ScopedRoles: []accesslist.ScopedRoleGrant{
+				{
+					Role:  scopes.QualifiedName{Name: "my-role", Scope: testScope}.String(),
+					Scope: testNestedScope,
+				},
+			},
+		},
+	}
+}
+
 type accessListTestingPrimitives struct {
 	setup *TestSetup
 	reconcilers.ResourceWithLabelsAdapter[*accesslist.AccessList]
@@ -84,10 +110,23 @@ func (g *accessListTestingPrimitives) CreateTeleportResource(ctx context.Context
 	metadata := header.Metadata{
 		Name: name,
 	}
-	accessList, err := accesslist.NewAccessList(metadata, newAccessListSpec(time.Time{}))
-	if err != nil {
-		return trace.Wrap(err)
+	var accessList *accesslist.AccessList
+	var err error
+	if scope := g.setup.OperatorMetadata().Scope; scope != "" {
+		accessList, err = accesslist.NewAccessListWithScope(metadata, newScopedAccessListSpec(time.Time{}), scope)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		accessList.Metadata.Labels = map[string]string{
+			reconcilers.OperatorIDLabel: g.setup.OperatorMetadata().ID,
+		}
+	} else {
+		accessList, err = accesslist.NewAccessList(metadata, newAccessListSpec(time.Time{}))
+		if err != nil {
+			return trace.Wrap(err)
+		}
 	}
+
 	if err := accessList.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -97,21 +136,37 @@ func (g *accessListTestingPrimitives) CreateTeleportResource(ctx context.Context
 }
 
 func (g *accessListTestingPrimitives) GetTeleportResource(ctx context.Context, name string) (*accesslist.AccessList, error) {
-	al, err := g.setup.TeleportClient.AccessListClient().GetAccessList(ctx, name)
+	al, err := g.setup.TeleportClient.AccessListClient().GetAccessListV2(ctx,
+		accesslistv1.GetAccessListRequest_builder{
+			Name:  name,
+			Scope: g.setup.OperatorMetadata().Scope,
+		}.Build())
 	return al, trace.Wrap(err)
 }
 
 func (g *accessListTestingPrimitives) DeleteTeleportResource(ctx context.Context, name string) error {
-	return trace.Wrap(g.setup.TeleportClient.AccessListClient().DeleteAccessList(ctx, name))
+	return trace.Wrap(g.setup.TeleportClient.AccessListClient().DeleteAccessListV2(ctx,
+		accesslistv1.DeleteAccessListRequest_builder{
+			Name:  name,
+			Scope: g.setup.OperatorMetadata().Scope,
+		}.Build()))
 }
 
 func (g *accessListTestingPrimitives) CreateKubernetesResource(ctx context.Context, name string) error {
+	var spec accesslist.Spec
+	if g.setup.OperatorMetadata().Scope != "" {
+		spec = newScopedAccessListSpec(time.Time{})
+	} else {
+		spec = newAccessListSpec(time.Time{})
+	}
+
 	accessList := &resourcesv1.TeleportAccessList{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: g.setup.Namespace.Name,
 		},
-		Spec: resourcesv1.TeleportAccessListSpec(newAccessListSpec(time.Time{})),
+		Spec:  resourcesv1.TeleportAccessListSpec(spec),
+		Scope: g.setup.OperatorMetadata().Scope,
 	}
 	return trace.Wrap(g.setup.K8sClient.Create(ctx, accessList))
 }
@@ -141,7 +196,21 @@ func (g *accessListTestingPrimitives) ModifyKubernetesResource(ctx context.Conte
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	accessList.Spec.Grants.Roles = []string{"crane-operator", "forklift-operator"}
+	if accessList.Scope != "" {
+		accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{
+			{
+				Role:  scopes.QualifiedName{Name: "my-role", Scope: testScope}.String(),
+				Scope: testNestedScope,
+			},
+			{
+				Role:  scopes.QualifiedName{Name: "my-other-role", Scope: testScope}.String(),
+				Scope: testScope,
+			},
+		}
+	} else {
+		accessList.Spec.Grants.Roles = []string{"crane-operator", "forklift-operator"}
+
+	}
 	return trace.Wrap(g.setup.K8sClient.Update(ctx, accessList))
 }
 
@@ -165,7 +234,7 @@ func (g *accessListTestingPrimitives) CompareTeleportAndKubernetesResource(tReso
 
 func AccessListCreationTest(t *testing.T, clt *client.Client) {
 	test := &accessListTestingPrimitives{}
-	ResourceCreationSynchronousTest(
+	ResourceCreationSynchronousTest[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
 		t,
 		resources.NewAccessListReconciler,
 		test,
@@ -175,7 +244,7 @@ func AccessListCreationTest(t *testing.T, clt *client.Client) {
 
 func AccessListDeletionTest(t *testing.T, clt *client.Client) {
 	test := &accessListTestingPrimitives{}
-	ResourceDeletionSynchronousTest(
+	ResourceDeletionSynchronousTest[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
 		t,
 		resources.NewAccessListReconciler,
 		test,
@@ -185,7 +254,7 @@ func AccessListDeletionTest(t *testing.T, clt *client.Client) {
 
 func AccessListDeletionDriftTest(t *testing.T, clt *client.Client) {
 	test := &accessListTestingPrimitives{}
-	ResourceDeletionDriftSynchronousTest(
+	ResourceDeletionDriftSynchronousTest[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
 		t,
 		resources.NewAccessListReconciler,
 		test,
@@ -195,11 +264,55 @@ func AccessListDeletionDriftTest(t *testing.T, clt *client.Client) {
 
 func AccessListUpdateTest(t *testing.T, clt *client.Client) {
 	test := &accessListTestingPrimitives{}
-	ResourceUpdateTestSynchronous(
+	ResourceUpdateTestSynchronous[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
 		t,
 		resources.NewAccessListReconciler,
 		test,
 		WithTeleportClient(clt),
+	)
+}
+
+func AccessListScopedCreationTest(t *testing.T, clt *client.Client) {
+	test := &accessListTestingPrimitives{}
+	ResourceCreationSynchronousTest[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
+		t,
+		resources.NewAccessListReconciler,
+		test,
+		WithTeleportClient(clt),
+		WithScope(testScope),
+	)
+}
+
+func AccessListScopedDeletionTest(t *testing.T, clt *client.Client) {
+	test := &accessListTestingPrimitives{}
+	ResourceDeletionSynchronousTest[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
+		t,
+		resources.NewAccessListReconciler,
+		test,
+		WithTeleportClient(clt),
+		WithScope(testScope),
+	)
+}
+
+func AccessListScopedDeletionDriftTest(t *testing.T, clt *client.Client) {
+	test := &accessListTestingPrimitives{}
+	ResourceDeletionDriftSynchronousTest[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
+		t,
+		resources.NewAccessListReconciler,
+		test,
+		WithTeleportClient(clt),
+		WithScope(testScope),
+	)
+}
+
+func AccessListScopedUpdateTest(t *testing.T, clt *client.Client) {
+	test := &accessListTestingPrimitives{}
+	ResourceUpdateTestSynchronous[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
+		t,
+		resources.NewAccessListReconciler,
+		test,
+		WithTeleportClient(clt),
+		WithScope(testScope),
 	)
 }
 
@@ -220,6 +333,7 @@ func AccessListMutateExistingTest(t *testing.T, clt *client.Client) {
 	accessList, err := accesslist.NewAccessList(metadata, spec)
 	require.NoError(t, err)
 	accessList.SetOrigin(types.OriginKubernetes)
+	accessList.Metadata.Labels[reconcilers.OperatorIDLabel] = setup.OperatorMetadata().ID
 	_, err = clt.AccessListClient().UpsertAccessList(ctx, accessList)
 	require.NoError(t, err)
 

--- a/integrations/operator/controllers/resources/testlib/accesslist_controller_tests.go
+++ b/integrations/operator/controllers/resources/testlib/accesslist_controller_tests.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gravitational/teleport/api/client"
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
@@ -38,6 +39,7 @@ import (
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
+	"github.com/gravitational/teleport/lib/scopes"
 )
 
 func newAccessListSpec(nextAudit time.Time) accesslist.Spec {
@@ -67,6 +69,30 @@ func newAccessListSpec(nextAudit time.Time) accesslist.Spec {
 	}
 }
 
+func newScopedAccessListSpec(nextAudit time.Time) accesslist.Spec {
+	return accesslist.Spec{
+		Title:       "crane operation",
+		Description: "Access list that Gru uses to allow the minions to operate the crane.",
+		Owners:      []accesslist.Owner{{Name: "Gru", Description: "The super villain.", MembershipKind: accesslist.MembershipKindUser}},
+		Audit: accesslist.Audit{
+			Recurrence: accesslist.Recurrence{
+				Frequency:  accesslist.SixMonths,
+				DayOfMonth: accesslist.FirstDayOfMonth,
+			},
+			NextAuditDate: nextAudit,
+		},
+		Grants: accesslist.Grants{
+			Traits: trait.Traits{},
+			ScopedRoles: []accesslist.ScopedRoleGrant{
+				{
+					Role:  scopes.QualifiedName{Name: "my-role", Scope: testScope}.String(),
+					Scope: testNestedScope,
+				},
+			},
+		},
+	}
+}
+
 type accessListTestingPrimitives struct {
 	setup *TestSetup
 	reconcilers.ResourceWithLabelsAdapter[*accesslist.AccessList]
@@ -84,10 +110,23 @@ func (g *accessListTestingPrimitives) CreateTeleportResource(ctx context.Context
 	metadata := header.Metadata{
 		Name: name,
 	}
-	accessList, err := accesslist.NewAccessList(metadata, newAccessListSpec(time.Time{}))
-	if err != nil {
-		return trace.Wrap(err)
+	var accessList *accesslist.AccessList
+	var err error
+	if scope := g.setup.OperatorMetadata().Scope; scope != "" {
+		accessList, err = accesslist.NewAccessListWithScope(metadata, newScopedAccessListSpec(time.Time{}), scope)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		accessList.Metadata.Labels = map[string]string{
+			reconcilers.OperatorIDLabel: g.setup.OperatorMetadata().ID,
+		}
+	} else {
+		accessList, err = accesslist.NewAccessList(metadata, newAccessListSpec(time.Time{}))
+		if err != nil {
+			return trace.Wrap(err)
+		}
 	}
+
 	if err := accessList.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -97,21 +136,37 @@ func (g *accessListTestingPrimitives) CreateTeleportResource(ctx context.Context
 }
 
 func (g *accessListTestingPrimitives) GetTeleportResource(ctx context.Context, name string) (*accesslist.AccessList, error) {
-	al, err := g.setup.TeleportClient.AccessListClient().GetAccessList(ctx, name)
+	al, err := g.setup.TeleportClient.AccessListClient().GetAccessListV2(ctx,
+		accesslistv1.GetAccessListRequest_builder{
+			Name:  name,
+			Scope: g.setup.OperatorMetadata().Scope,
+		}.Build())
 	return al, trace.Wrap(err)
 }
 
 func (g *accessListTestingPrimitives) DeleteTeleportResource(ctx context.Context, name string) error {
-	return trace.Wrap(g.setup.TeleportClient.AccessListClient().DeleteAccessList(ctx, name))
+	return trace.Wrap(g.setup.TeleportClient.AccessListClient().DeleteAccessListV2(ctx,
+		accesslistv1.DeleteAccessListRequest_builder{
+			Name:  name,
+			Scope: g.setup.OperatorMetadata().Scope,
+		}.Build()))
 }
 
 func (g *accessListTestingPrimitives) CreateKubernetesResource(ctx context.Context, name string) error {
+	var spec accesslist.Spec
+	if g.setup.OperatorMetadata().Scope != "" {
+		spec = newScopedAccessListSpec(time.Time{})
+	} else {
+		spec = newAccessListSpec(time.Time{})
+	}
+
 	accessList := &resourcesv1.TeleportAccessList{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: g.setup.Namespace.Name,
 		},
-		Spec: resourcesv1.TeleportAccessListSpec(newAccessListSpec(time.Time{})),
+		Spec:  resourcesv1.TeleportAccessListSpec(spec),
+		Scope: g.setup.OperatorMetadata().Scope,
 	}
 	return trace.Wrap(g.setup.K8sClient.Create(ctx, accessList))
 }
@@ -141,7 +196,21 @@ func (g *accessListTestingPrimitives) ModifyKubernetesResource(ctx context.Conte
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	accessList.Spec.Grants.Roles = []string{"crane-operator", "forklift-operator"}
+	if accessList.Scope != "" {
+		accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{
+			{
+				Role:  scopes.QualifiedName{Name: "my-role", Scope: testScope}.String(),
+				Scope: testNestedScope,
+			},
+			{
+				Role:  scopes.QualifiedName{Name: "my-other-role", Scope: testScope}.String(),
+				Scope: testScope,
+			},
+		}
+	} else {
+		accessList.Spec.Grants.Roles = []string{"crane-operator", "forklift-operator"}
+
+	}
 	return trace.Wrap(g.setup.K8sClient.Update(ctx, accessList))
 }
 
@@ -165,7 +234,7 @@ func (g *accessListTestingPrimitives) CompareTeleportAndKubernetesResource(tReso
 
 func AccessListCreationTest(t *testing.T, clt *client.Client) {
 	test := &accessListTestingPrimitives{}
-	ResourceCreationSynchronousTest(
+	ResourceCreationSynchronousTest[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
 		t,
 		resources.NewAccessListReconciler,
 		test,
@@ -175,7 +244,7 @@ func AccessListCreationTest(t *testing.T, clt *client.Client) {
 
 func AccessListDeletionTest(t *testing.T, clt *client.Client) {
 	test := &accessListTestingPrimitives{}
-	ResourceDeletionSynchronousTest(
+	ResourceDeletionSynchronousTest[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
 		t,
 		resources.NewAccessListReconciler,
 		test,
@@ -185,7 +254,7 @@ func AccessListDeletionTest(t *testing.T, clt *client.Client) {
 
 func AccessListDeletionDriftTest(t *testing.T, clt *client.Client) {
 	test := &accessListTestingPrimitives{}
-	ResourceDeletionDriftSynchronousTest(
+	ResourceDeletionDriftSynchronousTest[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
 		t,
 		resources.NewAccessListReconciler,
 		test,
@@ -195,11 +264,55 @@ func AccessListDeletionDriftTest(t *testing.T, clt *client.Client) {
 
 func AccessListUpdateTest(t *testing.T, clt *client.Client) {
 	test := &accessListTestingPrimitives{}
-	ResourceUpdateTestSynchronous(
+	ResourceUpdateTestSynchronous[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
 		t,
 		resources.NewAccessListReconciler,
 		test,
 		WithTeleportClient(clt),
+	)
+}
+
+func AccessListScopedCreationTest(t *testing.T, clt *client.Client) {
+	test := &accessListTestingPrimitives{}
+	ResourceCreationSynchronousTest[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
+		t,
+		resources.NewAccessListReconciler,
+		test,
+		WithTeleportClient(clt),
+		WithScope(testScope),
+	)
+}
+
+func AccessListScopedDeletionTest(t *testing.T, clt *client.Client) {
+	test := &accessListTestingPrimitives{}
+	ResourceDeletionSynchronousTest[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
+		t,
+		resources.NewAccessListReconciler,
+		test,
+		WithTeleportClient(clt),
+		WithScope(testScope),
+	)
+}
+
+func AccessListScopedDeletionDriftTest(t *testing.T, clt *client.Client) {
+	test := &accessListTestingPrimitives{}
+	ResourceDeletionDriftSynchronousTest[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
+		t,
+		resources.NewAccessListReconciler,
+		test,
+		WithTeleportClient(clt),
+		WithScope(testScope),
+	)
+}
+
+func AccessListScopedUpdateTest(t *testing.T, clt *client.Client) {
+	test := &accessListTestingPrimitives{}
+	ResourceUpdateTestSynchronous[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
+		t,
+		resources.NewAccessListReconciler,
+		test,
+		WithTeleportClient(clt),
+		WithScope(testScope),
 	)
 }
 
@@ -220,6 +333,7 @@ func AccessListMutateExistingTest(t *testing.T, clt *client.Client) {
 	accessList, err := accesslist.NewAccessList(metadata, spec)
 	require.NoError(t, err)
 	accessList.SetOrigin(types.OriginKubernetes)
+	accessList.Metadata.Labels[reconcilers.OperatorIDLabel] = setup.OperatorMetadata().ID
 	_, err = clt.AccessListClient().UpsertAccessList(ctx, accessList)
 	require.NoError(t, err)
 
@@ -245,7 +359,7 @@ func AccessListMutateExistingTest(t *testing.T, clt *client.Client) {
 	}
 	require.NoError(t, setup.K8sClient.Get(ctx, key, kubeAccessList))
 
-	reconciler, err := resources.NewAccessListReconciler(setup.K8sClient, clt)
+	reconciler, err := resources.NewAccessListReconciler(setup.K8sClient, clt, setup.OperatorMetadata())
 	require.NoError(t, err)
 
 	// Test execution: Kick off the reconciliation.

--- a/integrations/operator/controllers/resources/testlib/accesslist_controller_tests.go
+++ b/integrations/operator/controllers/resources/testlib/accesslist_controller_tests.go
@@ -245,7 +245,7 @@ func AccessListMutateExistingTest(t *testing.T, clt *client.Client) {
 	}
 	require.NoError(t, setup.K8sClient.Get(ctx, key, kubeAccessList))
 
-	reconciler, err := resources.NewAccessListReconciler(setup.K8sClient, clt)
+	reconciler, err := resources.NewAccessListReconciler(setup.K8sClient, clt, setup.OperatorMetadata())
 	require.NoError(t, err)
 
 	// Test execution: Kick off the reconciliation.

--- a/integrations/operator/controllers/resources/testlib/env.go
+++ b/integrations/operator/controllers/resources/testlib/env.go
@@ -63,6 +63,11 @@ import (
 // unprotected scheme.Scheme that triggers the race detector
 var scheme = controllers.Scheme
 
+const (
+	testScope       = "/test"
+	testNestedScope = testScope + "/nested"
+)
+
 func createNamespaceForTest(t *testing.T, kc kclient.Client) *core.Namespace {
 	ns := &core.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: ValidRandomResourceName("ns-")},
@@ -334,6 +339,7 @@ func WithScopesFeatures(features scopes.Features) TestOption {
 func WithScope(scope string) TestOption {
 	return func(setup *TestSetup) {
 		setup.scope = scope
+		setup.ScopesFeatures = scopes.Features{Enabled: true}
 	}
 }
 
@@ -379,7 +385,6 @@ func SetupFakeKubeTestEnv(t *testing.T, opts ...TestOption) *TestSetup {
 		Context:      t.Context(),
 		K8sClient:    k8sClient,
 		Namespace:    ns,
-		scope:        "/",
 		ResourceName: ValidRandomResourceName("resource-"),
 	}
 

--- a/integrations/operator/controllers/resources/testlib/env.go
+++ b/integrations/operator/controllers/resources/testlib/env.go
@@ -49,6 +49,7 @@ import (
 	"github.com/gravitational/teleport/integration/helpers"
 	apiresources "github.com/gravitational/teleport/integrations/operator/apis/resources"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
@@ -199,6 +200,17 @@ type TestSetup struct {
 	Context                  context.Context
 	InsecureMode             bool
 	ScopesFeatures           scopes.Features
+	scope                    string
+}
+
+func (s *TestSetup) OperatorMetadata() reconcilers.OperatorMetadata {
+	return reconcilers.OperatorMetadata{
+		Namespace: s.Namespace.Name,
+		ID:        "test-operator",
+		TokenName: "test-token",
+		Scope:     s.scope,
+		Owner:     "test@example.com",
+	}
 }
 
 // StartKubernetesOperator creates and start a new operator
@@ -242,11 +254,12 @@ func (s *TestSetup) StartKubernetesOperator(t *testing.T) {
 	}
 
 	err = resources.SetupAllControllers(resources.Config{
-		Log:            setupLog,
-		TeleportClient: s.TeleportClient,
-		KubeClient:     k8sManager.GetClient(),
-		Scoped:         false,
-		Features:       pong.ServerFeatures,
+		Log:              setupLog,
+		TeleportClient:   s.TeleportClient,
+		KubeClient:       k8sManager.GetClient(),
+		Scoped:           false,
+		Features:         pong.ServerFeatures,
+		OperatorMetadata: s.OperatorMetadata(),
 	}, k8sManager, discoveryClient)
 	require.NoError(t, err)
 
@@ -317,6 +330,13 @@ func WithScopesFeatures(features scopes.Features) TestOption {
 	}
 }
 
+// WithScope sets the operator for the tests.
+func WithScope(scope string) TestOption {
+	return func(setup *TestSetup) {
+		setup.scope = scope
+	}
+}
+
 func StepByStep(setup *TestSetup) {
 	setup.stepByStepReconciliation = true
 }
@@ -359,6 +379,7 @@ func SetupFakeKubeTestEnv(t *testing.T, opts ...TestOption) *TestSetup {
 		Context:      t.Context(),
 		K8sClient:    k8sClient,
 		Namespace:    ns,
+		scope:        "/",
 		ResourceName: ValidRandomResourceName("resource-"),
 	}
 

--- a/integrations/operator/controllers/resources/testlib/env.go
+++ b/integrations/operator/controllers/resources/testlib/env.go
@@ -49,6 +49,7 @@ import (
 	"github.com/gravitational/teleport/integration/helpers"
 	apiresources "github.com/gravitational/teleport/integrations/operator/apis/resources"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
@@ -61,6 +62,11 @@ import (
 // scheme is our own test-specific scheme to avoid using the global
 // unprotected scheme.Scheme that triggers the race detector
 var scheme = controllers.Scheme
+
+const (
+	testScope       = "/test"
+	testNestedScope = testScope + "/nested"
+)
 
 func createNamespaceForTest(t *testing.T, kc kclient.Client) *core.Namespace {
 	ns := &core.Namespace{
@@ -199,6 +205,17 @@ type TestSetup struct {
 	Context                  context.Context
 	InsecureMode             bool
 	ScopesFeatures           scopes.Features
+	scope                    string
+}
+
+func (s *TestSetup) OperatorMetadata() reconcilers.OperatorMetadata {
+	return reconcilers.OperatorMetadata{
+		Namespace: s.Namespace.Name,
+		ID:        "test-operator",
+		TokenName: "test-token",
+		Scope:     s.scope,
+		Owner:     "test@example.com",
+	}
 }
 
 // StartKubernetesOperator creates and start a new operator
@@ -242,11 +259,12 @@ func (s *TestSetup) StartKubernetesOperator(t *testing.T) {
 	}
 
 	err = resources.SetupAllControllers(resources.Config{
-		Log:            setupLog,
-		TeleportClient: s.TeleportClient,
-		KubeClient:     k8sManager.GetClient(),
-		Scoped:         false,
-		Features:       pong.ServerFeatures,
+		Log:              setupLog,
+		TeleportClient:   s.TeleportClient,
+		KubeClient:       k8sManager.GetClient(),
+		Scoped:           false,
+		Features:         pong.ServerFeatures,
+		OperatorMetadata: s.OperatorMetadata(),
 	}, k8sManager, discoveryClient)
 	require.NoError(t, err)
 
@@ -314,6 +332,14 @@ func WithInsecureMode() TestOption {
 func WithScopesFeatures(features scopes.Features) TestOption {
 	return func(setup *TestSetup) {
 		setup.ScopesFeatures = features
+	}
+}
+
+// WithScope sets the operator for the tests.
+func WithScope(scope string) TestOption {
+	return func(setup *TestSetup) {
+		setup.scope = scope
+		setup.ScopesFeatures = scopes.Features{Enabled: true}
 	}
 }
 

--- a/integrations/operator/controllers/resources/testlib/retrieval_model_controller_tests.go
+++ b/integrations/operator/controllers/resources/testlib/retrieval_model_controller_tests.go
@@ -171,7 +171,9 @@ func (p *retrievalModelTestingPrimitives) CompareTeleportAndKubernetesResource(
 
 func RetrievalModelCreationTest(t *testing.T, clt *client.Client) {
 	test := &retrievalModelTestingPrimitives{}
-	ResourceCreationSynchronousTest(
+	ResourceCreationSynchronousTest[
+		*summarizerv1.RetrievalModel, *resourcesv1.TeleportRetrievalModelV1,
+	](
 		t, resources.NewRetrievalModelV1Reconciler, test,
 		WithTeleportClient(clt),
 		WithResourceName(types.MetaNameRetrievalModel),
@@ -180,7 +182,9 @@ func RetrievalModelCreationTest(t *testing.T, clt *client.Client) {
 
 func RetrievalModelDeletionTest(t *testing.T, clt *client.Client) {
 	test := &retrievalModelTestingPrimitives{}
-	ResourceDeletionSynchronousTest(
+	ResourceDeletionSynchronousTest[
+		*summarizerv1.RetrievalModel, *resourcesv1.TeleportRetrievalModelV1,
+	](
 		t, resources.NewRetrievalModelV1Reconciler, test,
 		WithTeleportClient(clt),
 		WithResourceName(types.MetaNameRetrievalModel),
@@ -189,7 +193,9 @@ func RetrievalModelDeletionTest(t *testing.T, clt *client.Client) {
 
 func RetrievalModelDeletionDriftTest(t *testing.T, clt *client.Client) {
 	test := &retrievalModelTestingPrimitives{}
-	ResourceDeletionDriftSynchronousTest(
+	ResourceDeletionDriftSynchronousTest[
+		*summarizerv1.RetrievalModel, *resourcesv1.TeleportRetrievalModelV1,
+	](
 		t, resources.NewRetrievalModelV1Reconciler, test,
 		WithTeleportClient(clt),
 		WithResourceName(types.MetaNameRetrievalModel),
@@ -198,7 +204,9 @@ func RetrievalModelDeletionDriftTest(t *testing.T, clt *client.Client) {
 
 func RetrievalModelUpdateTest(t *testing.T, clt *client.Client) {
 	test := &retrievalModelTestingPrimitives{}
-	ResourceUpdateTestSynchronous(
+	ResourceUpdateTestSynchronous[
+		*summarizerv1.RetrievalModel, *resourcesv1.TeleportRetrievalModelV1,
+	](
 		t, resources.NewRetrievalModelV1Reconciler, test,
 		WithTeleportClient(clt),
 		WithResourceName(types.MetaNameRetrievalModel),
@@ -209,7 +217,7 @@ func RetrievalModelWrongNameTest(t *testing.T, clt *client.Client) {
 	ctx := t.Context()
 	setup := SetupFakeKubeTestEnv(t, WithTeleportClient(clt))
 
-	reconciler, err := resources.NewRetrievalModelV1Reconciler(setup.K8sClient, setup.TeleportClient)
+	reconciler, err := resources.NewRetrievalModelV1Reconciler(setup.K8sClient, setup.TeleportClient, setup.OperatorMetadata())
 	require.NoError(t, err)
 
 	const wrongName = "not-retrieval-model"

--- a/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
+++ b/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
@@ -31,7 +31,6 @@ import (
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
 	resources "github.com/gravitational/teleport/integrations/operator/controllers/resources"
 )
@@ -66,7 +65,7 @@ func ResourceUpdateTestSynchronous[T reconcilers.Resource, K reconcilers.Kuberne
 	test.Init(setup)
 	resourceName := setup.ResourceName
 
-	reconciler, err := newReconciler(setup.K8sClient, setup.TeleportClient)
+	reconciler, err := newReconciler(setup.K8sClient, setup.TeleportClient, setup.OperatorMetadata())
 	require.NoError(t, err)
 
 	err = test.SetupTeleportFixtures(ctx)
@@ -192,7 +191,7 @@ func ResourceCreationSynchronousTest[T reconcilers.Resource, K reconcilers.Kuber
 	test.Init(setup)
 	resourceName := setup.ResourceName
 
-	reconciler, err := newReconciler(setup.K8sClient, setup.TeleportClient)
+	reconciler, err := newReconciler(setup.K8sClient, setup.TeleportClient, setup.OperatorMetadata())
 	require.NoError(t, err)
 
 	err = test.SetupTeleportFixtures(ctx)
@@ -249,7 +248,8 @@ func ResourceCreationSynchronousTest[T reconcilers.Resource, K reconcilers.Kuber
 	kubeResource, err := test.GetKubernetesResource(ctx, resourceName)
 	require.NoError(t, err)
 	require.Equal(t, kubeResource.GetName(), test.GetResourceName(tResource))
-	require.Equal(t, types.OriginKubernetes, test.GetResourceOrigin(tResource))
+	owned, _ := test.CheckOwnership(tResource, setup.OperatorMetadata())
+	require.True(t, owned)
 
 	// Test cleanup: Delete the resource to avoid leftover state if we were running on a real instance.
 	require.NoError(t, test.DeleteKubernetesResource(ctx, resourceName))
@@ -269,7 +269,7 @@ func ResourceDeletionSynchronousTest[T reconcilers.Resource, K reconcilers.Kuber
 	test.Init(setup)
 	resourceName := setup.ResourceName
 
-	reconciler, err := newReconciler(setup.K8sClient, setup.TeleportClient)
+	reconciler, err := newReconciler(setup.K8sClient, setup.TeleportClient, setup.OperatorMetadata())
 	require.NoError(t, err)
 
 	err = test.SetupTeleportFixtures(ctx)
@@ -366,7 +366,7 @@ func ResourceDeletionDriftSynchronousTest[T reconcilers.Resource, K reconcilers.
 	test.Init(setup)
 	resourceName := setup.ResourceName
 
-	reconciler, err := newReconciler(setup.K8sClient, setup.TeleportClient)
+	reconciler, err := newReconciler(setup.K8sClient, setup.TeleportClient, setup.OperatorMetadata())
 	require.NoError(t, err)
 
 	err = test.SetupTeleportFixtures(ctx)

--- a/integrations/operator/controllers/resources/trusted_cluster_controller.go
+++ b/integrations/operator/controllers/resources/trusted_cluster_controller.go
@@ -76,7 +76,7 @@ func (r trustedClusterClient) Mutate(ctx context.Context, new, existing types.Tr
 }
 
 // NewTrustedClusterV2Reconciler instantiates a new Kubernetes controller reconciling trusted_cluster v2 resources
-func NewTrustedClusterV2Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewTrustedClusterV2Reconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	trustedClusterClient := &trustedClusterClient{
 		teleportClient: tClient,
 		kubeClient:     client,

--- a/integrations/operator/controllers/resources/trusted_clusterv2_controller_test.go
+++ b/integrations/operator/controllers/resources/trusted_clusterv2_controller_test.go
@@ -184,7 +184,7 @@ func TestTrustedClusterV2Creation(t *testing.T) {
 	test := &trustedClusterV2TestingPrimitives{}
 	const remoteClusterName = "remote.example.com"
 	test.setupTest(t, remoteClusterName)
-	testlib.ResourceCreationSynchronousTest(
+	testlib.ResourceCreationSynchronousTest[types.TrustedCluster, *resourcesv1.TeleportTrustedClusterV2](
 		t,
 		resources.NewTrustedClusterV2Reconciler,
 		test,
@@ -197,7 +197,7 @@ func TestTrustedClusterV2Deletion(t *testing.T) {
 	test := &trustedClusterV2TestingPrimitives{}
 	const remoteClusterName = "remote.example.com"
 	test.setupTest(t, remoteClusterName)
-	testlib.ResourceDeletionSynchronousTest(
+	testlib.ResourceDeletionSynchronousTest[types.TrustedCluster, *resourcesv1.TeleportTrustedClusterV2](
 		t,
 		resources.NewTrustedClusterV2Reconciler,
 		test,
@@ -210,7 +210,7 @@ func TestTrustedClusterV2DeletionDrift(t *testing.T) {
 	test := &trustedClusterV2TestingPrimitives{}
 	const remoteClusterName = "remote.example.com"
 	test.setupTest(t, remoteClusterName)
-	testlib.ResourceDeletionDriftSynchronousTest(
+	testlib.ResourceDeletionDriftSynchronousTest[types.TrustedCluster, *resourcesv1.TeleportTrustedClusterV2](
 		t,
 		resources.NewTrustedClusterV2Reconciler,
 		test,
@@ -225,7 +225,7 @@ func TestTrustedClusterV2Update(t *testing.T) {
 	t.Skip("This test is currently flaky because of the cert authorities internal.")
 	const remoteClusterName = "remote.example.com"
 	test.setupTest(t, remoteClusterName)
-	testlib.ResourceUpdateTestSynchronous(
+	testlib.ResourceUpdateTestSynchronous[types.TrustedCluster, *resourcesv1.TeleportTrustedClusterV2](
 		t,
 		resources.NewTrustedClusterV2Reconciler,
 		test,
@@ -268,7 +268,7 @@ func TestTrustedClusterV2SecretLookup(t *testing.T) {
 	test.trustedClusterSpec.Token = "secret://" + secretName + "/" + secretKey
 	require.NoError(t, test.CreateKubernetesResource(ctx, remoteClusterName))
 
-	reconciler, err := resources.NewTrustedClusterV2Reconciler(kubeClient, setup.TeleportClient)
+	reconciler, err := resources.NewTrustedClusterV2Reconciler(kubeClient, setup.TeleportClient, setup.OperatorMetadata())
 	require.NoError(t, err)
 
 	// Test execution: Kick off the reconciliation.

--- a/integrations/operator/controllers/resources/user_controller.go
+++ b/integrations/operator/controllers/resources/user_controller.go
@@ -68,7 +68,7 @@ func (r userClient) Mutate(_ context.Context, newUser, existingUser types.User, 
 }
 
 // NewUserReconciler instantiates a new Kubernetes controller reconciling user resources
-func NewUserReconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewUserReconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	userClient := &userClient{
 		teleportClient: tClient,
 	}

--- a/integrations/operator/controllers/resources/user_controller_test.go
+++ b/integrations/operator/controllers/resources/user_controller_test.go
@@ -145,22 +145,22 @@ func (g *userTestingPrimitives) CompareTeleportAndKubernetesResource(tResource t
 
 func TestTeleportUserCreation(t *testing.T) {
 	test := &userTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewUserReconciler, test)
+	testlib.ResourceCreationSynchronousTest[types.User, *v2.TeleportUser](t, resources.NewUserReconciler, test)
 }
 
 func TestTeleportUserDeletion(t *testing.T) {
 	test := &userTestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(t, resources.NewUserReconciler, test)
+	testlib.ResourceDeletionSynchronousTest[types.User, *v2.TeleportUser](t, resources.NewUserReconciler, test)
 }
 
 func TestTeleportUserDeletionDrift(t *testing.T) {
 	test := &userTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewUserReconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.User, *v2.TeleportUser](t, resources.NewUserReconciler, test)
 }
 
 func TestTeleportUserUpdate(t *testing.T) {
 	test := &userTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewUserReconciler, test)
+	testlib.ResourceUpdateTestSynchronous[types.User, *v2.TeleportUser](t, resources.NewUserReconciler, test)
 }
 
 func TestUserCreationFromYAML(t *testing.T) {
@@ -233,7 +233,7 @@ traits:
 			err = setup.K8sClient.Create(ctx, obj)
 			require.NoError(t, err)
 
-			reconciler, err := resources.NewUserReconciler(setup.K8sClient, setup.TeleportClient)
+			reconciler, err := resources.NewUserReconciler(setup.K8sClient, setup.TeleportClient, setup.OperatorMetadata())
 			require.NoError(t, err)
 			// Test execution: Kick off the reconciliation.
 			req := reconcile.Request{
@@ -359,7 +359,7 @@ func TestUserUpdate(t *testing.T) {
 	}
 	k8sCreateUser(ctx, t, setup.K8sClient, &k8sUser)
 
-	reconciler, err := resources.NewUserReconciler(setup.K8sClient, setup.TeleportClient)
+	reconciler, err := resources.NewUserReconciler(setup.K8sClient, setup.TeleportClient, setup.OperatorMetadata())
 	require.NoError(t, err)
 	// Test execution: Kick off the reconciliation.
 	req := reconcile.Request{

--- a/integrations/operator/controllers/resources/workload_identityv1_controller.go
+++ b/integrations/operator/controllers/resources/workload_identityv1_controller.go
@@ -94,7 +94,7 @@ func (l workloadIdentityClient) Delete(ctx context.Context, key reconcilers.Reso
 
 // NewWorkloadIdentityV1Reconciler instantiates a new Kubernetes controller
 // reconciling WorkloadIdentity resources
-func NewWorkloadIdentityV1Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+func NewWorkloadIdentityV1Reconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	workloadIdentityClient := &workloadIdentityClient{
 		teleportClient: tClient,
 	}

--- a/integrations/operator/controllers/resources/workload_identityv1_controller_test.go
+++ b/integrations/operator/controllers/resources/workload_identityv1_controller_test.go
@@ -186,20 +186,20 @@ func (g *workloadIdentityTestingPrimitives) CompareTeleportAndKubernetesResource
 
 func TestWorkloadIdentityCreation(t *testing.T) {
 	test := &workloadIdentityTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewWorkloadIdentityV1Reconciler, test)
+	testlib.ResourceCreationSynchronousTest[*workloadidentityv1.WorkloadIdentity, *resourcesv1.TeleportWorkloadIdentityV1](t, resources.NewWorkloadIdentityV1Reconciler, test)
 }
 
 func TestWorkloadIdentityDeletion(t *testing.T) {
 	test := &workloadIdentityTestingPrimitives{}
-	testlib.ResourceDeletionSynchronousTest(t, resources.NewWorkloadIdentityV1Reconciler, test)
+	testlib.ResourceDeletionSynchronousTest[*workloadidentityv1.WorkloadIdentity, *resourcesv1.TeleportWorkloadIdentityV1](t, resources.NewWorkloadIdentityV1Reconciler, test)
 }
 
 func TestWorkloadIdentityDeletionDrift(t *testing.T) {
 	test := &workloadIdentityTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewWorkloadIdentityV1Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest[*workloadidentityv1.WorkloadIdentity, *resourcesv1.TeleportWorkloadIdentityV1](t, resources.NewWorkloadIdentityV1Reconciler, test)
 }
 
 func TestWorkloadIdentityUpdate(t *testing.T) {
 	test := &workloadIdentityTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewWorkloadIdentityV1Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous[*workloadidentityv1.WorkloadIdentity, *resourcesv1.TeleportWorkloadIdentityV1](t, resources.NewWorkloadIdentityV1Reconciler, test)
 }

--- a/integrations/operator/crdgen/handlerequest.go
+++ b/integrations/operator/crdgen/handlerequest.go
@@ -202,6 +202,7 @@ func generateSchema(file *File, groupName string, format crdFormatFunc, resp *go
 			opts: []resourceSchemaOption{
 				withVersionOverride(types.V1),
 				legacyWithoutVersionInKindOverride(),
+				withScope(),
 			},
 		},
 		{

--- a/integrations/operator/main.go
+++ b/integrations/operator/main.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"k8s.io/client-go/discovery"
+	kubernetes "k8s.io/client-go/kubernetes"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -40,7 +40,10 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/integrations/lib/embeddedtbot"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
+	"github.com/gravitational/teleport/integrations/operator/state"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -87,7 +90,50 @@ func main() {
 		os.Exit(1)
 	}
 
-	botConfig.Scoped = config.scoped
+	kubeClientConfig := ctrl.GetConfigOrDie()
+	directKubeClient, err := kubernetes.NewForConfig(kubeClientConfig)
+	if err != nil {
+		setupLog.Error(err, "unable to create kubernetes client")
+		os.Exit(1)
+	}
+
+	// To prevent conflicts and ownership issues in scoped mode,
+	// the operator annotates created resources with its metadata.
+	// For backward compatibility, this only happens when running in scoped mode.
+	var operatorID, tokenName string
+	if config.scope != "" {
+		setupLog.Info("running in scoped mode, gathering operator metadata")
+
+		bk, err := state.New(ctx, directKubeClient)
+		if err != nil {
+			setupLog.Error(err, "unable to create kube state")
+			os.Exit(1)
+		}
+		id, err := bk.OperatorID(ctx)
+		if err != nil {
+			setupLog.Error(err, "unable to get operator id")
+			os.Exit(1)
+		}
+		operatorID = id.String()
+
+		rawToken, err := botConfig.Onboarding.Token()
+		if err != nil {
+			setupLog.Error(err, "unable to get token")
+			os.Exit(1)
+		}
+		tokenName, _, _ = joining.DecodeScopedToken(rawToken)
+		setupLog.Info("operator metadata", "operator-id", operatorID, "scope", config.scope, "token-name", tokenName)
+	}
+
+	operatorMetadata := reconcilers.OperatorMetadata{
+		Namespace: config.namespace,
+		ID:        operatorID,
+		TokenName: tokenName,
+		Scope:     config.scope,
+		Owner:     config.ownerEmail,
+	}
+
+	botConfig.Scoped = config.scope != ""
 	bot, err := embeddedtbot.New(botConfig, slogLogger.With(teleport.ComponentLabel, "embedded-tbot"))
 	if err != nil {
 		setupLog.Error(err, "unable to build tbot")
@@ -103,12 +149,6 @@ func main() {
 	client, err := bot.StartAndWaitForClient(ctx, 15*time.Second)
 	if err != nil {
 		setupLog.Error(err, "error waiting the teleport client")
-	}
-
-	kubeClientConfig := ctrl.GetConfigOrDie()
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(kubeClientConfig)
-	if err != nil {
-		setupLog.Error(err, "unable to create kubernetes client")
 	}
 
 	mgr, err := ctrl.NewManager(kubeClientConfig, ctrl.Options{
@@ -142,12 +182,13 @@ func main() {
 
 	if err = resources.SetupAllControllers(
 		resources.Config{
-			Log:            setupLog,
-			TeleportClient: client,
-			KubeClient:     mgr.GetClient(),
-			Scoped:         config.scoped,
-			Features:       pong.ServerFeatures,
-		}, mgr, discoveryClient); err != nil {
+			Log:              setupLog,
+			TeleportClient:   client,
+			KubeClient:       mgr.GetClient(),
+			Scoped:           config.scope != "",
+			Features:         pong.ServerFeatures,
+			OperatorMetadata: operatorMetadata,
+		}, mgr, directKubeClient.Discovery()); err != nil {
 		setupLog.Error(err, "failed to setup controllers")
 		os.Exit(1)
 	}

--- a/integrations/operator/state/doc.go
+++ b/integrations/operator/state/doc.go
@@ -1,0 +1,6 @@
+// Package state is a minimal package for the Teleport operator to store data in Kubernetes.
+// It supports running multiple operator replicas.
+// Content stored should be kept to a strict minimum.
+// Currently, the only content stored is the operator ID.
+// See RFD 324 for more details.
+package state

--- a/integrations/operator/state/doc.go
+++ b/integrations/operator/state/doc.go
@@ -1,0 +1,22 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package state is a minimal package for the Teleport operator to store data in Kubernetes.
+// It supports running multiple operator replicas.
+// Content stored should be kept to a strict minimum.
+// Currently, the only content stored is the operator ID.
+// See RFD 324 for more details.
+package state

--- a/integrations/operator/state/state.go
+++ b/integrations/operator/state/state.go
@@ -1,0 +1,88 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/gravitational/teleport/lib/backend"
+	kubebackend "github.com/gravitational/teleport/lib/backend/kubernetes"
+)
+
+const (
+	maxTries      = 3
+	operatorIDKey = "operator-id"
+)
+
+// State is used by the operator to store and retrieve information in Kubernetes.
+// The State is shared across operator replicas.
+type State struct {
+	bk *kubebackend.Backend
+}
+
+// New creates a new State for the operator.
+func New(ctx context.Context, client kubernetes.Interface) (*State, error) {
+	bk, err := kubebackend.NewSharedWithClient(ctx, client)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &State{bk: bk}, nil
+}
+
+// OperatorID returns the unique ID of the operator.
+// The ID is either retrieved from the kube state or created if it doesn't exist yet.
+// If the function returns no error, the state contains the ID.
+func (s *State) OperatorID(ctx context.Context) (uuid.UUID, error) {
+	key := backend.KeyFromString(operatorIDKey)
+	for tries := 0; ; tries++ {
+		item, err := s.bk.Get(ctx, key)
+		if err == nil {
+			// ID exists and we can read it.
+			return uuid.ParseBytes(item.Value)
+		}
+		if !trace.IsNotFound(err) {
+			// Unexpected error, return it.
+			return uuid.UUID{}, trace.Wrap(err, "getting operator ID from kube state")
+		}
+
+		// ID does not exist yet, try to create it.
+		newID := uuid.New()
+		_, err = s.bk.Create(ctx, backend.Item{
+			Key:   key,
+			Value: []byte(newID.String()),
+		})
+		if err == nil {
+			// Successfully created the ID, return it.
+			return newID, nil
+		}
+
+		if !trace.IsAlreadyExists(err) {
+			// Unexpected error.
+			return uuid.UUID{}, trace.Wrap(err, "creating operator ID in kube state")
+		}
+		// Something created the ID in the meantime, we must try again.
+
+		if tries >= maxTries {
+			// Avoid infinite retry loop.
+			return uuid.UUID{}, trace.Wrap(err, "failed to create operator ID in kube state a after too many attempts")
+		}
+	}
+}

--- a/integrations/operator/state/state.go
+++ b/integrations/operator/state/state.go
@@ -1,0 +1,74 @@
+package state
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/gravitational/teleport/lib/backend"
+	kubebackend "github.com/gravitational/teleport/lib/backend/kubernetes"
+)
+
+const (
+	maxTries      = 3
+	operatorIDKey = "operator-id"
+)
+
+// State is used by the operator to store and retrieve information in Kubernetes.
+// The State is shared across operator replicas.
+type State struct {
+	bk *kubebackend.Backend
+}
+
+// New creates a new State for the operator.
+func New(ctx context.Context, client kubernetes.Interface) (*State, error) {
+	bk, err := kubebackend.NewSharedWithClient(ctx, client)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &State{bk: bk}, nil
+}
+
+// OperatorID returns the unique ID of the operator.
+// The ID is either retrieved from the kube state or created if it doesn't exist yet.
+// If the function returns no error, the state contains the ID.
+func (s *State) OperatorID(ctx context.Context) (uuid.UUID, error) {
+	var tries int
+	key := backend.KeyFromString(operatorIDKey)
+	for {
+		tries++
+		item, err := s.bk.Get(ctx, key)
+		if err == nil {
+			// ID exists and we can read it.
+			return uuid.ParseBytes(item.Value)
+		}
+		if !trace.IsNotFound(err) {
+			// Unexpected error, return it.
+			return uuid.UUID{}, trace.Wrap(err, "getting operator ID from kube state")
+		}
+
+		// ID does not exist yet, try to create it.
+		newID := uuid.New()
+		_, err = s.bk.Create(ctx, backend.Item{
+			Key:   key,
+			Value: []byte(newID.String()),
+		})
+		if err == nil {
+			// Successfully created the ID, return it.
+			return newID, nil
+		}
+
+		if !trace.IsAlreadyExists(err) {
+			// Unexpected error.
+			return uuid.UUID{}, trace.Wrap(err, "creating operator ID in kube state")
+		}
+		// Something created the ID in the meantime, we must try again.
+
+		if tries >= maxTries {
+			// Avoid infinite retry loop.
+			return uuid.UUID{}, trace.Wrap(err, "failed to create operator ID in kube state a after too many attempts")
+		}
+	}
+}

--- a/integrations/operator/state/state_test.go
+++ b/integrations/operator/state/state_test.go
@@ -1,0 +1,197 @@
+package state
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	ctest "k8s.io/client-go/testing"
+)
+
+// this is a reactor that injects a resource version as the kube backend requires it.
+func createSecretAddResourceVersion(t *testing.T, tracker ctest.ObjectTracker) ctest.ReactionFunc {
+	return func(action ctest.Action) (handled bool, ret runtime.Object, err error) {
+		obj := action.(ctest.CreateAction).GetObject()
+		secret, ok := obj.(*corev1.Secret)
+		assert.True(t, ok)
+		secret.ResourceVersion = "123"
+		require.NoError(t, tracker.Add(secret))
+		return true, secret, nil
+	}
+}
+
+func TestOperatorID(t *testing.T) {
+	const (
+		testNamespace   = "test-namespace"
+		testRelease     = "test-release"
+		stateSecretName = testRelease + "-shared-state"
+	)
+	t.Setenv("KUBE_NAMESPACE", testNamespace)
+	t.Setenv("RELEASE_NAME", testRelease)
+	t.Run("no existing state", func(t *testing.T) {
+		// Test setup
+		kubeClient := fake.NewClientset()
+		kubeClient.PrependReactor("create", "secrets", createSecretAddResourceVersion(t, kubeClient.Tracker()))
+
+		state, err := New(t.Context(), kubeClient)
+		require.NoError(t, err)
+
+		// Test execution
+		id, err := state.OperatorID(t.Context())
+		require.NoError(t, err)
+		require.NotEmpty(t, id)
+
+		// Test validation
+		require.NotEqual(t, id, uuid.NullUUID{})
+		secret, err := kubeClient.CoreV1().Secrets(testNamespace).Get(t.Context(), stateSecretName, v1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, id.String(), string(secret.Data[operatorIDKey]))
+	})
+	t.Run("existing state", func(t *testing.T) {
+		// Test setup
+		existingID := uuid.New()
+		existingSecret := &corev1.Secret{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:            stateSecretName,
+				Namespace:       testNamespace,
+				ResourceVersion: "123",
+			},
+			Data: map[string][]byte{
+				operatorIDKey: []byte(existingID.String()),
+			},
+		}
+		kubeClient := fake.NewClientset(existingSecret)
+
+		state, err := New(t.Context(), kubeClient)
+		require.NoError(t, err)
+
+		// Test execution
+		id, err := state.OperatorID(t.Context())
+		require.NoError(t, err)
+		require.NotEmpty(t, id)
+
+		// Test validation
+		require.Equal(t, id, existingID)
+	})
+	t.Run("existing state with no ID", func(t *testing.T) {
+		existingSecret := &corev1.Secret{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:            stateSecretName,
+				Namespace:       testNamespace,
+				ResourceVersion: "123",
+			},
+			Data: map[string][]byte{
+				"other-id": []byte("random-data"),
+			},
+		}
+		kubeClient := fake.NewClientset(existingSecret)
+
+		state, err := New(t.Context(), kubeClient)
+		require.NoError(t, err)
+
+		// Test execution
+		id, err := state.OperatorID(t.Context())
+		require.NoError(t, err)
+		require.NotEmpty(t, id)
+
+		// Test validation
+		require.NotEqual(t, id, uuid.NullUUID{})
+		secret, err := kubeClient.CoreV1().Secrets(testNamespace).Get(t.Context(), stateSecretName, v1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, id.String(), string(secret.Data[operatorIDKey]))
+	})
+	t.Run("no existing state, then conflict", func(t *testing.T) {
+		// Test setup
+		existingID := uuid.New()
+		existingSecret := &corev1.Secret{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:            stateSecretName,
+				Namespace:       testNamespace,
+				ResourceVersion: "123",
+			},
+			Data: map[string][]byte{
+				operatorIDKey: []byte(existingID.String()),
+			},
+		}
+		kubeClient := fake.NewClientset(existingSecret)
+		var called int
+		kubeClient.PrependReactor("get", "secrets", func(action ctest.Action) (handled bool, ret runtime.Object, err error) {
+			// reactor that fakes a "not found" on the second call (first call is the existence check on state creation)
+			called++
+			if called == 2 {
+				return false, nil, nil
+			}
+			return true, nil, apierrors.NewNotFound(schema.GroupResource{
+				Group:    "",
+				Resource: "",
+			}, "")
+		})
+
+		state, err := New(t.Context(), kubeClient)
+		require.NoError(t, err)
+
+		// Test execution
+		id, err := state.OperatorID(t.Context())
+		require.NoError(t, err)
+
+		// Test validation
+		require.Equal(t, 2, called)
+		require.Equal(t, id, existingID)
+	})
+	t.Run("existing state, always conflicts", func(t *testing.T) {
+		// TODO implement conflict on update
+		existingSecret := &corev1.Secret{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:            stateSecretName,
+				Namespace:       testNamespace,
+				ResourceVersion: "123",
+			},
+			Data: map[string][]byte{},
+		}
+		kubeClient := fake.NewClientset(existingSecret)
+		var called int
+		kubeClient.PrependReactor("update", "secrets", func(action ctest.Action) (handled bool, ret runtime.Object, err error) {
+			called++
+			// reactor that always returns a conflict
+			return true, nil, apierrors.NewConflict(schema.GroupResource{
+				Group:    "",
+				Resource: "",
+			}, "", errors.New("conflict"))
+		})
+
+		state, err := New(t.Context(), kubeClient)
+		require.NoError(t, err)
+
+		// Test execution
+		id, err := state.OperatorID(t.Context())
+		require.Error(t, err)
+
+		// Test validation
+		require.NotZero(t, called)
+		require.Equal(t, id, uuid.NullUUID{}.UUID)
+	})
+}

--- a/integrations/operator/state/state_test.go
+++ b/integrations/operator/state/state_test.go
@@ -1,0 +1,213 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	ctest "k8s.io/client-go/testing"
+)
+
+// this is a reactor that injects a resource version as the kube backend requires it.
+func createSecretAddResourceVersion(t *testing.T, tracker ctest.ObjectTracker) ctest.ReactionFunc {
+	return func(action ctest.Action) (handled bool, ret runtime.Object, err error) {
+		obj := action.(ctest.CreateAction).GetObject()
+		secret, ok := obj.(*corev1.Secret)
+		assert.True(t, ok)
+		secret.ResourceVersion = "123"
+		require.NoError(t, tracker.Add(secret))
+		return true, secret, nil
+	}
+}
+
+func TestOperatorID(t *testing.T) {
+	const (
+		testNamespace   = "test-namespace"
+		testRelease     = "test-release"
+		stateSecretName = testRelease + "-shared-state"
+	)
+	t.Setenv("KUBE_NAMESPACE", testNamespace)
+	t.Setenv("RELEASE_NAME", testRelease)
+	t.Run("no existing state", func(t *testing.T) {
+		// Test setup
+		kubeClient := fake.NewClientset()
+		kubeClient.PrependReactor("create", "secrets", createSecretAddResourceVersion(t, kubeClient.Tracker()))
+
+		state, err := New(t.Context(), kubeClient)
+		require.NoError(t, err)
+
+		// Test execution
+		id, err := state.OperatorID(t.Context())
+		require.NoError(t, err)
+		require.NotEmpty(t, id)
+
+		// Test validation
+		require.NotEqual(t, uuid.NullUUID{}, id)
+		secret, err := kubeClient.CoreV1().Secrets(testNamespace).Get(t.Context(), stateSecretName, v1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, id.String(), string(secret.Data[operatorIDKey]))
+	})
+	t.Run("existing state", func(t *testing.T) {
+		// Test setup
+		existingID := uuid.New()
+		existingSecret := &corev1.Secret{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:            stateSecretName,
+				Namespace:       testNamespace,
+				ResourceVersion: "123",
+			},
+			Data: map[string][]byte{
+				operatorIDKey: []byte(existingID.String()),
+			},
+		}
+		kubeClient := fake.NewClientset(existingSecret)
+
+		state, err := New(t.Context(), kubeClient)
+		require.NoError(t, err)
+
+		// Test execution
+		id, err := state.OperatorID(t.Context())
+		require.NoError(t, err)
+		require.NotEmpty(t, id)
+
+		// Test validation
+		require.Equal(t, id, existingID)
+	})
+	t.Run("existing state with no ID", func(t *testing.T) {
+		existingSecret := &corev1.Secret{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:            stateSecretName,
+				Namespace:       testNamespace,
+				ResourceVersion: "123",
+			},
+			Data: map[string][]byte{
+				"other-id": []byte("random-data"),
+			},
+		}
+		kubeClient := fake.NewClientset(existingSecret)
+
+		state, err := New(t.Context(), kubeClient)
+		require.NoError(t, err)
+
+		// Test execution
+		id, err := state.OperatorID(t.Context())
+		require.NoError(t, err)
+		require.NotEmpty(t, id)
+
+		// Test validation
+		require.NotEqual(t, uuid.NullUUID{}, id)
+		secret, err := kubeClient.CoreV1().Secrets(testNamespace).Get(t.Context(), stateSecretName, v1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, id.String(), string(secret.Data[operatorIDKey]))
+	})
+	t.Run("no existing state, then conflict", func(t *testing.T) {
+		// Test setup
+		existingID := uuid.New()
+		existingSecret := &corev1.Secret{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:            stateSecretName,
+				Namespace:       testNamespace,
+				ResourceVersion: "123",
+			},
+			Data: map[string][]byte{
+				operatorIDKey: []byte(existingID.String()),
+			},
+		}
+		kubeClient := fake.NewClientset(existingSecret)
+		var called int
+		kubeClient.PrependReactor("get", "secrets", func(action ctest.Action) (handled bool, ret runtime.Object, err error) {
+			// reactor that fakes a "not found" on the second call (first call is the existence check on state creation)
+			called++
+			if called == 2 {
+				return false, nil, nil
+			}
+			return true, nil, apierrors.NewNotFound(schema.GroupResource{
+				Group:    "",
+				Resource: "",
+			}, "")
+		})
+
+		state, err := New(t.Context(), kubeClient)
+		require.NoError(t, err)
+
+		// Test execution
+		id, err := state.OperatorID(t.Context())
+		require.NoError(t, err)
+
+		// Test validation
+		require.Equal(t, 2, called)
+		require.Equal(t, id, existingID)
+	})
+	t.Run("existing state, always conflicts", func(t *testing.T) {
+		// TODO implement conflict on update
+		existingSecret := &corev1.Secret{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:            stateSecretName,
+				Namespace:       testNamespace,
+				ResourceVersion: "123",
+			},
+			Data: map[string][]byte{},
+		}
+		kubeClient := fake.NewClientset(existingSecret)
+		var called int
+		kubeClient.PrependReactor("update", "secrets", func(action ctest.Action) (handled bool, ret runtime.Object, err error) {
+			called++
+			// reactor that always returns a conflict
+			return true, nil, apierrors.NewConflict(schema.GroupResource{
+				Group:    "",
+				Resource: "",
+			}, "", errors.New("conflict"))
+		})
+
+		state, err := New(t.Context(), kubeClient)
+		require.NoError(t, err)
+
+		// Test execution
+		id, err := state.OperatorID(t.Context())
+		require.Error(t, err)
+
+		// Test validation
+		require.NotZero(t, called)
+		require.Equal(t, id, uuid.NullUUID{}.UUID)
+	})
+}


### PR DESCRIPTION
This commit implements the following changes described in RFD 328:

- add a kubernetes state in which the operator can store its ID
- move ownership checks and label setting to the adapter interface
- add the scoped resource with label adapter
- add operator metadata and propagate it to scoped reconcilers
- make scoped adapters check the operator id label when the resource is scoped
- make scoped adapters set provenance labels when the resource is scoped
- fix the controller tests that were no longer able to infer the generics type since `api/types` was not directly imported anymore
- introduce `ownerEmail` and make it required when running in scoped mode
- make the operator reject reconciling a resource whose scope does not match its own
- enable and fix scoped resource tests:
  - use the same test scope everythere
  - set the test scope in the operator metadata
  - generate and use the operator ID

## Note for reviewers

This change is time-sensitive and was intentionally sent as a large PR as opposed to several smaller ones.
I sync-ed with @rosstimothy before sending it. This will not be immediately backported to v18.

## Manual Test Plan
### Test Environment

- dev build `19.0.0-hugoscop.4` in a cloud staging tenant

### Test Cases
- [x] unscoped operator runs and reconciles resources
- [x] scoped operator runs and reconciles resources in its scope
- [x] scoped operator runs but refuses to reconciles resource outside of its scope
