### PR TITLE
chore: added keyboard accessiblity support for menu item component

### DIFF
--- a/web/packages/design/src/Menu/Menu.tsx
+++ b/web/packages/design/src/Menu/Menu.tsx
@@ -32,6 +32,7 @@ export default function Menu(
     onEntering?: (el: HTMLElement) => void;
     menuListCss?: CSSProp;
     menuListProps?: ComponentPropsWithoutRef<typeof MenuList>;
+    autoFocus?: boolean;
   }> &
     Pick<
       PopoverProps,
@@ -43,6 +44,7 @@ export default function Menu(
       | 'anchorOrigin'
       | 'transformOrigin'
       | 'updatePositionOnChildResize'
+      | 'trapFocus'
     >
 ) {
   const {
@@ -51,6 +53,7 @@ export default function Menu(
     menuListCss,
     menuListProps,
     onEntering,
+    autoFocus,
     anchorOrigin = { vertical: 'bottom', horizontal: 'right' },
     transformOrigin = { vertical: 'top', horizontal: 'right' },
     ...other
@@ -81,11 +84,15 @@ export default function Menu(
         menuList.style.width = `calc(100% + ${size})`;
       }
 
+      if (autoFocus) {
+        menuList.focus();
+      }
+
       if (onEntering) {
         onEntering(element);
       }
     },
-    [onEntering]
+    [autoFocus, onEntering]
   );
 
   return (
@@ -98,7 +105,12 @@ export default function Menu(
       getContentAnchorEl={defaultGetContentAnchorEl}
       {...other}
     >
-      <MenuList {...menuListProps} css={menuListCss} ref={menuListRef}>
+      <MenuList
+        tabIndex={-1}
+        {...menuListProps}
+        css={menuListCss}
+        ref={menuListRef}
+      >
         {children}
       </MenuList>
     </Popover>
@@ -111,6 +123,7 @@ export const MenuList = styled.div.attrs({ role: 'menu' })`
   box-shadow: ${props => props.theme.boxShadow[0]};
   box-sizing: border-box;
   max-height: calc(100% - 96px);
+  outline: none;
   overflow: hidden;
   overflow-y: auto;
   position: relative;

--- a/web/packages/design/src/Modal/Modal.test.tsx
+++ b/web/packages/design/src/Modal/Modal.test.tsx
@@ -20,7 +20,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 
-import { fireEvent, render } from 'design/utils/testing';
+import { fireEvent, mockOffsetParent, render } from 'design/utils/testing';
 
 import Modal, { ModalProps } from './Modal';
 
@@ -177,42 +177,7 @@ test('closing dialog when attachCustomKeyEventHandler is set only hides it with 
 });
 
 describe('trapFocus', () => {
-  let originalOffsetParent: PropertyDescriptor | undefined;
-
-  beforeAll(() => {
-    // JSDOM doesn't implement layout, so offsetParent is always null. Mock it to return the
-    // parent element (non-null) for elements that aren't hidden via display:none on themselves or
-    // an ancestor.
-    originalOffsetParent = Object.getOwnPropertyDescriptor(
-      HTMLElement.prototype,
-      'offsetParent'
-    );
-    Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
-      get(this: HTMLElement) {
-        // Walk up the ancestor chain — in real browsers, offsetParent is null when any
-        // ancestor has display:none.
-        let el: HTMLElement | null = this;
-        while (el) {
-          if (el.style.display === 'none') {
-            return null;
-          }
-          el = el.parentElement; // eslint-disable-line testing-library/no-node-access
-        }
-        return this.parentElement; // eslint-disable-line testing-library/no-node-access
-      },
-      configurable: true,
-    });
-  });
-
-  afterAll(() => {
-    if (originalOffsetParent) {
-      Object.defineProperty(
-        HTMLElement.prototype,
-        'offsetParent',
-        originalOffsetParent
-      );
-    }
-  });
+  mockOffsetParent();
 
   // In the following describe group, the focused element is removed during a re-render, leaving
   // lastModalFocus as a stale detached reference. Explicit keys ensure React unmounts the Removable

--- a/web/packages/design/src/Modal/Modal.tsx
+++ b/web/packages/design/src/Modal/Modal.tsx
@@ -111,6 +111,7 @@ export default class Modal extends React.Component<ModalProps> {
   modalEl: HTMLDivElement | null = null;
   mounted = false;
   lastTabKeyDirection: 'forward' | 'backward' | null = null;
+  wasOpen = false;
 
   componentDidMount() {
     this.mounted = true;
@@ -123,7 +124,6 @@ export default class Modal extends React.Component<ModalProps> {
     if (prevProps.open && !this.props.open) {
       this.handleClose();
     } else if (!prevProps.open && this.props.open) {
-      this.lastFocus = document.activeElement as HTMLElement;
       this.handleOpen();
     } else if (
       this.props.open &&
@@ -377,6 +377,15 @@ export default class Modal extends React.Component<ModalProps> {
       className,
       keepInDOMAfterClose,
     } = this.props;
+
+    // Capture the element to restore focus to before the children render. Waiting until
+    // componentDidUpdate would be too late: layout effects of the children run first, so anything
+    // that moves focus inside the modal on mount would be captured instead of the element that was
+    // focused before the modal opened.
+    if (open && !this.wasOpen) {
+      this.lastFocus = document.activeElement as HTMLElement;
+    }
+    this.wasOpen = open;
 
     if (!open && !keepInDOMAfterClose) {
       return null;

--- a/web/packages/design/src/Modal/Modal.tsx
+++ b/web/packages/design/src/Modal/Modal.tsx
@@ -105,6 +105,12 @@ export type ModalProps = {
   trapFocus?: boolean;
 };
 
+/**
+ * Modal instances with an active focus trap, in the order the traps were enabled. Only the
+ * topmost trap responds to focus and Tab events.
+ */
+const focusTrapStack: Modal[] = [];
+
 export default class Modal extends React.Component<ModalProps> {
   lastFocus: HTMLElement | undefined;
   lastModalFocus: HTMLElement | undefined;
@@ -233,17 +239,24 @@ export default class Modal extends React.Component<ModalProps> {
     if (activeEl && this.modalEl?.contains(activeEl)) {
       this.lastModalFocus = activeEl;
     }
+    if (!focusTrapStack.includes(this)) {
+      focusTrapStack.push(this);
+    }
     document.addEventListener('focusin', this.handleFocusTrapFocusIn);
   };
 
   disableFocusTrap = () => {
+    const index = focusTrapStack.indexOf(this);
+    if (index !== -1) {
+      focusTrapStack.splice(index, 1);
+    }
     document.removeEventListener('focusin', this.handleFocusTrapFocusIn);
     this.lastModalFocus = undefined;
     this.lastTabKeyDirection = null;
   };
 
   handleFocusTrapFocusIn = (event: FocusEvent) => {
-    if (!this.modalEl) {
+    if (!this.modalEl || focusTrapStack.at(-1) !== this) {
       return;
     }
 
@@ -304,7 +317,12 @@ export default class Modal extends React.Component<ModalProps> {
   };
 
   handleFocusTrapTab = (event: KeyboardEvent) => {
-    if (!this.props.trapFocus || !this.modalEl || event.defaultPrevented) {
+    if (
+      !this.props.trapFocus ||
+      !this.modalEl ||
+      event.defaultPrevented ||
+      focusTrapStack.at(-1) !== this
+    ) {
       return;
     }
 

--- a/web/packages/design/src/utils/testing.tsx
+++ b/web/packages/design/src/utils/testing.tsx
@@ -184,6 +184,48 @@ export function enableMswServer() {
   afterAll(() => server.close());
 }
 
+/**
+ * Mocks HTMLElement.prototype.offsetParent for the current test suite. Call
+ * this at the top level of a test file (or inside a describe block) that
+ * exercises code filtering out hidden elements by offsetParent, e.g. the focus
+ * trap in Modal.
+ */
+export function mockOffsetParent() {
+  let originalOffsetParent: PropertyDescriptor | undefined;
+
+  beforeAll(() => {
+    originalOffsetParent = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'offsetParent'
+    );
+    Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+      get(this: HTMLElement) {
+        // Walk up the ancestor chain — in real browsers, offsetParent is null when any
+        // ancestor has display: none.
+        let el: HTMLElement | null = this;
+        while (el) {
+          if (el.style.display === 'none') {
+            return null;
+          }
+          el = el.parentElement;
+        }
+        return this.parentElement;
+      },
+      configurable: true,
+    });
+  });
+
+  afterAll(() => {
+    if (originalOffsetParent) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'offsetParent',
+        originalOffsetParent
+      );
+    }
+  });
+}
+
 export {
   act,
   screen,

--- a/web/packages/shared/components/MenuAction/MenuAction.test.tsx
+++ b/web/packages/shared/components/MenuAction/MenuAction.test.tsx
@@ -16,9 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { screen } from '@testing-library/react';
-
-import { fireEvent, render } from 'design/utils/testing';
+import {
+  fireEvent,
+  mockOffsetParent,
+  render,
+  screen,
+  userEvent,
+} from 'design/utils/testing';
 
 import { MenuIcon, MenuItem } from '.';
 
@@ -61,4 +65,47 @@ const menuListCss = {
 test('menuActionProps is respected', () => {
   render(<MenuIcon buttonIconProps={menuListCss} />);
   expect(screen.getByTestId('button')).toHaveStyle(menuListCss.style);
+});
+
+describe('keyboard navigation', () => {
+  mockOffsetParent();
+
+  const openMenu = async (user: ReturnType<typeof userEvent.setup>) => {
+    render(
+      <MenuIcon buttonIconProps={{ 'aria-label': 'Options' }}>
+        <MenuItem as="button">Edit</MenuItem>
+        <MenuItem as="button">Delete</MenuItem>
+      </MenuIcon>
+    );
+    await user.click(screen.getByRole('button', { name: 'Options' }));
+  };
+
+  test('tab moves focus through menu items and wraps around', async () => {
+    const user = userEvent.setup();
+    await openMenu(user);
+    expect(screen.getByRole('menu')).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole('menuitem', { name: 'Edit' })).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole('menuitem', { name: 'Delete' })).toHaveFocus();
+
+    // Focus wraps around at the end of the menu.
+    await user.tab();
+    expect(screen.getByRole('menuitem', { name: 'Edit' })).toHaveFocus();
+
+    await user.tab({ shift: true });
+    expect(screen.getByRole('menuitem', { name: 'Delete' })).toHaveFocus();
+  });
+
+  test('escape closes the menu and restores focus to the trigger', async () => {
+    const user = userEvent.setup();
+    await openMenu(user);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Options' })).toHaveFocus();
+  });
 });

--- a/web/packages/shared/components/MenuAction/MenuActionButton.tsx
+++ b/web/packages/shared/components/MenuAction/MenuActionButton.tsx
@@ -116,6 +116,8 @@ class InnerMenuActionIcon extends React.Component<
           anchorEl={this.anchorEl}
           open={open}
           onClose={this.onClose}
+          autoFocus
+          trapFocus
           transformOrigin={{
             vertical: 'top',
             horizontal: 'right',

--- a/web/packages/shared/components/MenuAction/MenuActionIcon.tsx
+++ b/web/packages/shared/components/MenuAction/MenuActionIcon.tsx
@@ -75,6 +75,8 @@ export default class MenuActionIcon extends React.Component<
           anchorEl={this.anchorEl}
           open={open}
           onClose={this.onClose}
+          autoFocus
+          trapFocus
           anchorOrigin={{
             vertical: 'bottom',
             horizontal: 'center',


### PR DESCRIPTION
## Changes
This PR makes the row action menus keyboard accessible. Previously, opening the menu left focus on the trigger button, so pressing Tab moved focus through the page behind the opened menu instead of into the menu items.

## Screenshot

https://github.com/user-attachments/assets/82ea22c2-6e9d-425f-ae88-c0ebc668513b




<!-- Provide a descriptive entry for the changelog of the next release. -->


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- Locally switch to this branch on a teleport cluster

### Test Cases
- [x] Use keyboard to navigate to an action item that opens the menu item and validate that tabbing let's you select options for the menu item.
- [x] From within an open menu clicking on escape returns focus to the menu item
