### PR TITLE
Ensure IAC and tctl cannot create scoped apps

### DIFF
--- a/integrations/operator/Makefile
+++ b/integrations/operator/Makefile
@@ -264,7 +264,7 @@ endif
 	kubectl create namespace test --dry-run=client -o yaml | kubectl apply -f -
 
 	$(if $(ENTERPRISE), kubectl -n test create secret generic license --from-file=/var/lib/teleport/license.pem --dry-run=client -o yaml | kubectl replace --force -f -)
-	
+
 	# deploy a teleport cluster with the operator
 	# To add feature flags, append --set "extraEnv[N].name=..." lines below.
 	KUBECONFIG=$(KUBECONFIG) helm upgrade \
@@ -280,5 +280,6 @@ endif
 		$(if $(LOCAL_BUILD),--set "image=$(TELEPORT_IMAGE)") \
 		$(if $(ENTERPRISE),--set "enterprise=true") \
 		$(if $(and $(ENTERPRISE),$(LOCAL_BUILD)),--set "enterpriseImage=$(TELEPORT_IMAGE)")
+
 
 	rm $$KUBECONFIG

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -7636,6 +7636,9 @@ func (a *Server) IterateResources(ctx context.Context, req proto.ListResourcesRe
 
 // CreateApp creates a new application resource.
 func (a *Server) CreateApp(ctx context.Context, app types.Application) error {
+	if err := services.EnsureNotScopedApp(app); err != nil {
+		return trace.Wrap(err)
+	}
 	if err := services.ValidateApp(app, a); err != nil {
 		return trace.Wrap(err)
 	}
@@ -7665,6 +7668,12 @@ func (a *Server) CreateApp(ctx context.Context, app types.Application) error {
 
 // UpdateApp updates an existing application resource.
 func (a *Server) UpdateApp(ctx context.Context, app types.Application) error {
+	// TODO (williamo/scopes): While a blanket deny is fine for update for now,
+	// when scoped dynamic app registration is supported, we must check whether
+	// the updated scope differs or not, and reject if different.
+	if err := services.EnsureNotScopedApp(app); err != nil {
+		return trace.Wrap(err)
+	}
 	if err := services.ValidateApp(app, a); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -7376,6 +7376,10 @@ func (a *ServerWithRoles) CreateApp(ctx context.Context, app types.Application) 
 	if err := a.authorizeAction(types.KindApp, types.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
+	// Reject scoped apps before the rest of validation
+	if err := services.EnsureNotScopedApp(app); err != nil {
+		return trace.Wrap(err)
+	}
 	// Validate before the label-matching access check so callers with
 	// the correct role see input errors rather than access-denied from
 	// a label mismatch on a malformed app.
@@ -7400,6 +7404,13 @@ func (a *ServerWithRoles) CreateApp(ctx context.Context, app types.Application) 
 // UpdateApp updates existing application resource.
 func (a *ServerWithRoles) UpdateApp(ctx context.Context, app types.Application) error {
 	if err := a.authorizeAction(types.KindApp, types.VerbUpdate); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// TODO (williamo/scopes): While a blanket deny is fine for update for now,
+	// when scoped dynamic app registration is supported, we must check whether
+	// the updated scope differs or not, and reject if different.
+	if err := services.EnsureNotScopedApp(app); err != nil {
 		return trace.Wrap(err)
 	}
 	// Validate before the GetApp existence check so a malformed name

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -4410,6 +4410,21 @@ func TestApps(t *testing.T) {
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
 	))
 
+	// Clients can't create/update scoped apps right now.
+	// TODO (williamo/scopes) - delete this check when dynamic scoped app registration is supported.
+	scopedApp := adminApp.Copy()
+	scopedApp.SetName("scoped")
+	scopedApp.Scope = "/prod"
+	err = adminClt.CreateApp(ctx, scopedApp)
+	require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+	require.ErrorContains(t, err, "dynamic registration of scoped applications is not supported")
+
+	scopedAdminApp := adminApp.Copy()
+	scopedAdminApp.Scope = "/prod"
+	err = adminClt.UpdateApp(ctx, scopedAdminApp)
+	require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+	require.ErrorContains(t, err, "dynamic registration of scoped applications is not supported")
+
 	// Clients can't create/update apps for the beams service.
 	adminApp.GetMetadata().Labels["teleport.internal/beams/app-type"] = "llm"
 	err = adminClt.UpdateApp(ctx, adminApp)

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -100,6 +100,18 @@ type ApplicationsInternal interface {
 	) ([]backend.ConditionalAction, error)
 }
 
+// TODO(williamo/scopes): remove once dynamic scoped app registration is
+// supported.
+func EnsureNotScopedApp(app types.Application) error {
+	if app == nil {
+		return trace.BadParameter("nil application")
+	}
+	if scope := app.GetScope(); scope != "" {
+		return trace.BadParameter("application %q cannot be created with scope %q: dynamic registration of scoped applications is not supported, remove the scope attribute", app.GetName(), scope)
+	}
+	return nil
+}
+
 // ValidateApp checks an Application's name, public_addr, and
 // required_apps.
 func ValidateApp(app types.Application, proxyGetter ProxyGetter) error {


### PR DESCRIPTION
Since we do not yet support scoped dynamic app registration, users should fail at creating app resources with scopes.

K8s Behavior: Since the crd for apps were never updated, users cannot create resources with the scope field for apps. The k8s api will reject app creation with scopes
Terraform Behavior:  The proto files were updated so users can create the scoped apps - stop at the api layer. This will account for tctl creations also.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: 


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster, k3d cluster, local terraform

### Test Cases
- [x] Users aren't able to create or update apps with scopes via tctl
- [x] via k8s
- [x] via terraform
