### PR TITLE
Update pnpm to 11.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
       "web/.storybook/public"
     ]
   },
-  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
+  "packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72",
   "engines": {
     "node": "^24"
   }


### PR DESCRIPTION
Hopefully, this fixes the bug that causes `pnpm up -r <package>` to update unrelated packages.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Tag build https://github.com/gravitational/teleport.e/actions/runs/30340363568.
### Test Cases
- [x] Build passed. 
