### PR TITLE
Do not follow URLs when getting/updating SAML connectors in tctl

### DIFF
--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -23,9 +23,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2854,6 +2858,126 @@ version: v1
 
 	require.Empty(t, cmp.Diff(expected, resources[0], cmpOpts...))
 	require.Empty(t, cmp.Diff(databaseobject.ResourceToProto(&expected), databaseobject.ResourceToProto(&resources[0]), cmpOpts...))
+}
+
+func TestSAMLCommandsWithUnavailableMetadata(t *testing.T) {
+	const (
+		connectorName = "unavailable-metadata"
+		metadata      = `<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://idp.example.com/metadata">
+  <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.example.com/sso"/>
+  </md:IDPSSODescriptor>
+</md:EntityDescriptor>`
+	)
+
+	process, err := testenv.NewTeleportProcess(t.TempDir(), testenv.WithConfig(func(cfg *servicecfg.Config) {
+		cfg.Modules = &modulestest.Modules{
+			TestBuildType: modules.BuildEnterprise,
+			TestFeatures: modules.Features{
+				Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+					entitlements.SAML: {Enabled: true},
+				},
+			},
+		}
+	}))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, process.Close())
+		require.NoError(t, process.Wait())
+	})
+
+	clt, err := testenv.NewDefaultAuthClient(process)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clt.Close()) })
+
+	var unavailable atomic.Bool
+	var metadataRequests atomic.Int64
+	metadataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		metadataRequests.Add(1)
+		if unavailable.Load() {
+			http.Error(w, "metadata unavailable", http.StatusNotFound)
+			return
+		}
+		_, _ = io.WriteString(w, metadata)
+	}))
+	t.Cleanup(metadataServer.Close)
+
+	connector, err := types.NewSAMLConnector(connectorName, types.SAMLConnectorSpecV2{
+		Display:                  "Unavailable metadata",
+		AssertionConsumerService: "https://proxy.example.com/v1/webapi/saml/acs/" + connectorName,
+		Audience:                 "https://proxy.example.com/v1/webapi/saml/acs/" + connectorName,
+		ServiceProviderIssuer:    "https://proxy.example.com/v1/webapi/saml/acs/" + connectorName,
+		EntityDescriptorURL:      metadataServer.URL,
+		AttributesToRoles: []types.AttributeMapping{
+			{Name: "groups", Value: "developers", Roles: []string{"access"}},
+		},
+	})
+	require.NoError(t, err)
+	_, err = clt.CreateSAMLConnector(t.Context(), connector)
+	require.NoError(t, err)
+
+	unavailable.Store(true)
+
+	t.Run("list", func(t *testing.T) {
+		requestCount := metadataRequests.Load()
+		out, err := runResourceCommand(t, clt, []string{"get", types.KindSAMLConnector, "--format=json"})
+		require.NoError(t, err)
+		require.Contains(t, out.String(), connectorName)
+		require.Equal(t, requestCount, metadataRequests.Load(), "tctl command followed the unavailable metadata URL")
+	})
+
+	t.Run("get", func(t *testing.T) {
+		requestCount := metadataRequests.Load()
+		out, err := runResourceCommand(t, clt, []string{"get", types.KindSAMLConnector + "/" + connectorName, "--format=json"})
+		require.NoError(t, err)
+		require.Contains(t, out.String(), connectorName)
+		require.Equal(t, requestCount, metadataRequests.Load(), "tctl command followed the unavailable metadata URL")
+	})
+
+	t.Run("export", func(t *testing.T) {
+		requestCount := metadataRequests.Load()
+		var exportErr error
+		var closeErr error
+		stdoutReader, stdoutWriter, err := os.Pipe()
+		require.NoError(t, err)
+		previousStdout := os.Stdout
+		os.Stdout = stdoutWriter
+		func() {
+			defer func() { os.Stdout = previousStdout }()
+			exportErr = (&SAMLCommand{connectorName: connectorName}).export(t.Context(), clt)
+			closeErr = stdoutWriter.Close()
+		}()
+		require.NoError(t, exportErr)
+		require.NoError(t, closeErr)
+		exportedCert, err := io.ReadAll(stdoutReader)
+		require.NoError(t, err)
+		require.NoError(t, stdoutReader.Close())
+		require.Contains(t, string(exportedCert), "BEGIN CERTIFICATE")
+		require.Equal(t, requestCount, metadataRequests.Load(), "tctl command followed the unavailable metadata URL")
+	})
+
+	t.Run("force replace", func(t *testing.T) {
+		requestCount := metadataRequests.Load()
+		replacement, err := types.NewSAMLConnector(connectorName, types.SAMLConnectorSpecV2{
+			Display:                  "Replacement",
+			AssertionConsumerService: "https://proxy.example.com/v1/webapi/saml/acs/" + connectorName,
+			Audience:                 "https://proxy.example.com/v1/webapi/saml/acs/" + connectorName,
+			ServiceProviderIssuer:    "https://proxy.example.com/v1/webapi/saml/acs/" + connectorName,
+			EntityDescriptor:         metadata,
+			AttributesToRoles: []types.AttributeMapping{
+				{Name: "groups", Value: "developers", Roles: []string{"access"}},
+			},
+		})
+		require.NoError(t, err)
+		replacementYAML, err := services.MarshalSAMLConnector(replacement)
+		require.NoError(t, err)
+		replacementPath := filepath.Join(t.TempDir(), "replacement.yaml")
+		require.NoError(t, os.WriteFile(replacementPath, replacementYAML, 0o600))
+		_, err = runResourceCommand(t, clt, []string{"create", "-f", replacementPath})
+		require.NoError(t, err)
+		require.Equal(t, requestCount, metadataRequests.Load(), "tctl command followed the unavailable metadata URL")
+	})
 }
 
 // TestCreateEnterpriseResources asserts that tctl create

--- a/tool/tctl/common/resources/saml_connector.go
+++ b/tool/tctl/common/resources/saml_connector.go
@@ -70,11 +70,11 @@ func getSAMLConnector(ctx context.Context, client *authclient.Client, ref servic
 		// TODO(okraport): DELETE IN v21.0.0, remove GetSAMLConnectors
 		connectors, err := clientutils.CollectWithFallback(ctx,
 			func(ctx context.Context, limit int, start string) ([]types.SAMLConnector, string, error) {
-				return client.ListSAMLConnectorsWithOptions(ctx, limit, start, opts.WithSecrets)
+				return client.ListSAMLConnectorsWithOptions(ctx, limit, start, opts.WithSecrets, types.SAMLConnectorValidationFollowURLs(false))
 			},
 			func(ctx context.Context) ([]types.SAMLConnector, error) {
 				//nolint:staticcheck // support older backends during migration
-				return client.GetSAMLConnectors(ctx, opts.WithSecrets)
+				return client.GetSAMLConnectorsWithValidationOptions(ctx, opts.WithSecrets, types.SAMLConnectorValidationFollowURLs(false))
 			},
 		)
 
@@ -83,7 +83,8 @@ func getSAMLConnector(ctx context.Context, client *authclient.Client, ref servic
 		}
 		return &samlConnectorCollection{connectors: connectors}, nil
 	}
-	connector, err := client.GetSAMLConnector(ctx, ref.Name, opts.WithSecrets)
+	connector, err := client.GetSAMLConnectorWithValidationOptions(ctx, ref.Name,
+		opts.WithSecrets, types.SAMLConnectorValidationFollowURLs(false))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -101,7 +102,8 @@ func createSAMLConnector(ctx context.Context, client *authclient.Client, raw ser
 	}
 
 	connectorName := conn.GetName()
-	foundConn, err := client.GetSAMLConnector(ctx, connectorName, true)
+	foundConn, err := client.GetSAMLConnectorWithValidationOptions(ctx, connectorName, true,
+		types.SAMLConnectorValidationFollowURLs(false))
 	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/saml_command.go
+++ b/tool/tctl/common/saml_command.go
@@ -25,6 +25,7 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
@@ -67,7 +68,8 @@ func (cmd *SAMLCommand) TryRun(ctx context.Context, selectedCommand string, clie
 
 // export executes 'tctl saml export <connector_name>'
 func (cmd *SAMLCommand) export(ctx context.Context, c *authclient.Client) error {
-	sc, err := c.GetSAMLConnector(ctx, cmd.connectorName, false)
+	sc, err := c.GetSAMLConnectorWithValidationOptions(ctx, cmd.connectorName, false,
+		types.SAMLConnectorValidationFollowURLs(false))
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Issue: https://github.com/gravitational/teleport/issues/54732

related PRs:
- https://github.com/gravitational/teleport.e/pull/9260 (UI)
- https://github.com/gravitational/teleport/pull/69094 (terraform)

This ticket fixes the `tctl` command only. Terraform and UI PRs to follow.

## What
All saml objects should be returned when running `tctl get saml`, UI and Terraform provider.

## Why
The problem occurs because currently every call to tctl SAML connector subcommands has a validation step that queries the `entity_descriptor_url` and if the query fails, it aborts the operations resulting the given SAML connector omitted from the output.

Apart from failure to get/list/export the SAML connector with unreachable `entity_descriptor_url`, it's impossible to fix the connector by updating the URL to a reachable one and perform `tctl create -f ./saml-connector.yaml`. This change fixes this use case as well. Creating a new connector still requires a valid URL. 

Given the SAML connector is already in cache, the get/update/delete operations do not really need to perform the query validation step.

## Manual Test Plan
- [x] Create a dummy SAML connector with a dummy IdP and then stop the IdP.

### Test Environment

1. Start a local teleport instance.
2. Create a sample IdP response `metadata.xml`:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<md:EntityDescriptor
    xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
    entityID="https://idp.example.test/metadata">
  <md:IDPSSODescriptor
      protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
    <md:NameIDFormat>
      urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
    </md:NameIDFormat>
    <md:SingleSignOnService
        Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
        Location="https://idp.example.test/sso"/>
  </md:IDPSSODescriptor>
</md:EntityDescriptor>
```
3. Start a server in the same directory where `metadata.xml` file is.
```bash
$ python3 -m http server
```
4. in another terminal window - create a SAML Connector with `tctl create -f ./saml-connector.yaml`
The `saml-connector.yaml` file is as follows:
```yaml
kind: saml
version: v2
metadata:
  name: broken-metadata-repro
spec:
  display: Broken metadata reproduction

  acs: https://teleport.example.com/v1/webapi/saml/acs/broken-metadata-repro
  audience: https://teleport.example.com/v1/webapi/saml/acs/broken-metadata-repro
  service_provider_issuer: https://teleport.example.com/v1/webapi/saml/acs/broken-metadata-repro

  entity_descriptor_url: http://127.0.0.1:8000/metadata.xml

  attributes_to_roles:
    - name: groups
      value: developers
      roles:
        - access
```
5. Stop the python3 http server (dummy IdP)
6. Try `tctl get saml` or `tctl saml export broken-metadata-repro` and observe the above SAML connector is not displayed. 
7. Build fixed `tctl` binary and validate the same workflows are working as expected.

### Test Cases
- [x] Reproduce the issue with the steps above. Make sure the issue is not reproduced with fixed `tctl` binary.