### PR TITLE
Do not follow URLs when getting/updating SAML connectors in terraform…

### DIFF
--- a/integrations/terraform/gen/main.go
+++ b/integrations/terraform/gen/main.go
@@ -142,6 +142,8 @@ type payload struct {
 	// not specify one in the resource config. The user-provided sub_kind (on
 	// the resource or in state) takes precedence; this is only a fallback.
 	DefaultSubKind string
+	// GetMethodAdditionalArgs contains arguments appended to non-envelope Get calls.
+	GetMethodAdditionalArgs []string
 }
 
 // statePoll configures polling for state changes when creating or updating resources.
@@ -392,7 +394,7 @@ var (
 		Name:                   "SAMLConnector",
 		TypeName:               "SAMLConnectorV2",
 		VarName:                "samlConnector",
-		GetMethod:              "GetSAMLConnector",
+		GetMethod:              "GetSAMLConnectorWithValidationOptions",
 		CreateMethod:           "CreateSAMLConnector",
 		UpdateMethod:           "UpsertSAMLConnector",
 		UpsertMethodArity:      2,
@@ -403,6 +405,9 @@ var (
 		HasStaticID:            true,
 		TerraformResourceType:  "teleport_saml_connector",
 		HasCheckAndSetDefaults: true,
+		GetMethodAdditionalArgs: []string{
+			"apitypes.SAMLConnectorValidationFollowURLs(false)",
+		},
 	}
 
 	samlIdPServiceProvider = payload{

--- a/integrations/terraform/gen/plural_data_source.go.tpl
+++ b/integrations/terraform/gen/plural_data_source.go.tpl
@@ -99,7 +99,7 @@ func (r dataSourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadDat
 	})
 {{- else}}
 
-	{{.VarName}}I, err := r.p.Client().{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}{{if .IDPrefix}}idPrefix.Value, {{end}}id.Value{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
+	{{.VarName}}I, err := r.p.Client().{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}{{if .IDPrefix}}idPrefix.Value, {{end}}id.Value{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}}{{range .GetMethodAdditionalArgs}}, {{.}}{{end}})
 {{- end}}
 	if err != nil {
 		resp.Diagnostics.Append(tfdiag.DiagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))

--- a/integrations/terraform/gen/plural_resource.go.tpl
+++ b/integrations/terraform/gen/plural_resource.go.tpl
@@ -170,7 +170,7 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 	})
 {{- else}}
 
-	_, err = r.p.Client().{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}{{if .IDPrefix}}idPrefix, {{end}}id{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
+	_, err = r.p.Client().{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}{{if .IDPrefix}}idPrefix, {{end}}id{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}}{{range .GetMethodAdditionalArgs}}, {{.}}{{end}})
 {{- end}}
 	if !trace.IsNotFound(err) {
 		if err == nil {
@@ -237,7 +237,7 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 		{{- end}}
 		}
 	{{- else}}
-		{{.VarName}}I, err = r.p.Client().{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}{{if .IDPrefix}}idPrefix, {{end}}id{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
+		{{.VarName}}I, err = r.p.Client().{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}{{if .IDPrefix}}idPrefix, {{end}}id{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}}{{range .GetMethodAdditionalArgs}}, {{.}}{{end}})
 	{{- end}}
 		if trace.IsNotFound(err) {
 		    select {
@@ -423,7 +423,7 @@ func (r resourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadResou
 	})
 {{- else}}
 
-	{{.VarName}}I, err := r.p.Client().{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}{{if .IDPrefix}}idPrefix.Value, {{end}}id.Value{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
+	{{.VarName}}I, err := r.p.Client().{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}{{if .IDPrefix}}idPrefix.Value, {{end}}id.Value{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}}{{range .GetMethodAdditionalArgs}}, {{.}}{{end}})
 {{- end}}
 	if trace.IsNotFound(err) {
 		resp.State.RemoveResource(ctx)
@@ -534,7 +534,7 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 	{{- end}}
 {{- else}}
 
-	{{.VarName}}Before, err := r.p.Client().{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}{{if .IDPrefix}}idPrefix, {{end}}name{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
+	{{.VarName}}Before, err := r.p.Client().{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}{{if .IDPrefix}}idPrefix, {{end}}name{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}}{{range .GetMethodAdditionalArgs}}, {{.}}{{end}})
 	if err != nil {
 		resp.Diagnostics.Append(tfdiag.DiagFromWrappedErr("Error reading {{.Name}}", err, "{{.Kind}}"))
 		return
@@ -595,7 +595,7 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 		{{- end}}
 		}
 	{{- else}}
-		{{.VarName}}I, err = r.p.Client().{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}{{if .IDPrefix}}idPrefix, {{end}}name{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
+		{{.VarName}}I, err = r.p.Client().{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}{{if .IDPrefix}}idPrefix, {{end}}name{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}}{{range .GetMethodAdditionalArgs}}, {{.}}{{end}})
 	{{- end}}
 		if err != nil {
 			resp.Diagnostics.Append(tfdiag.DiagFromWrappedErr("Error reading {{.Name}}", err, "{{.Kind}}"))
@@ -803,7 +803,7 @@ func (r resourceTeleport{{.Name}}) ImportState(ctx context.Context, req tfsdk.Im
 	}
 	{{.VarName}}, err := r.p.Client().{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}idPrefix, name{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
 	{{- else}}
-	{{.VarName}}, err := r.p.Client().{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}req.ID{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
+	{{.VarName}}, err := r.p.Client().{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}req.ID{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}}{{range .GetMethodAdditionalArgs}}, {{.}}{{end}})
 	{{- end}}
 {{- end}}
 	if err != nil {

--- a/integrations/terraform/provider/internal/legacy/data_source_teleport_saml_connector.go
+++ b/integrations/terraform/provider/internal/legacy/data_source_teleport_saml_connector.go
@@ -60,7 +60,7 @@ func (r dataSourceTeleportSAMLConnector) Read(ctx context.Context, req tfsdk.Rea
 		return
 	}
 
-	samlConnectorI, err := r.p.Client().GetSAMLConnector(ctx, id.Value, true)
+	samlConnectorI, err := r.p.Client().GetSAMLConnectorWithValidationOptions(ctx, id.Value, true, apitypes.SAMLConnectorValidationFollowURLs(false))
 	if err != nil {
 		resp.Diagnostics.Append(tfdiag.DiagFromWrappedErr("Error reading SAMLConnector", trace.Wrap(err), "saml"))
 		return

--- a/integrations/terraform/provider/internal/legacy/resource_teleport_saml_connector.go
+++ b/integrations/terraform/provider/internal/legacy/resource_teleport_saml_connector.go
@@ -85,7 +85,7 @@ func (r resourceTeleportSAMLConnector) Create(ctx context.Context, req tfsdk.Cre
 
 	id := samlConnectorResource.Metadata.Name
 
-	_, err = r.p.Client().GetSAMLConnector(ctx, id, true)
+	_, err = r.p.Client().GetSAMLConnectorWithValidationOptions(ctx, id, true, apitypes.SAMLConnectorValidationFollowURLs(false))
 	if !trace.IsNotFound(err) {
 		if err == nil {
 			existErr := fmt.Sprintf("SAMLConnector exists in Teleport. Either remove it (tctl rm saml/%v)"+
@@ -115,7 +115,7 @@ func (r resourceTeleportSAMLConnector) Create(ctx context.Context, req tfsdk.Cre
 	}
 	for {
 		tries = tries + 1
-		samlConnectorI, err = r.p.Client().GetSAMLConnector(ctx, id, true)
+		samlConnectorI, err = r.p.Client().GetSAMLConnectorWithValidationOptions(ctx, id, true, apitypes.SAMLConnectorValidationFollowURLs(false))
 		if trace.IsNotFound(err) {
 		    select {
 			case <-ctx.Done():
@@ -176,7 +176,7 @@ func (r resourceTeleportSAMLConnector) Read(ctx context.Context, req tfsdk.ReadR
 		return
 	}
 
-	samlConnectorI, err := r.p.Client().GetSAMLConnector(ctx, id.Value, true)
+	samlConnectorI, err := r.p.Client().GetSAMLConnectorWithValidationOptions(ctx, id.Value, true, apitypes.SAMLConnectorValidationFollowURLs(false))
 	if trace.IsNotFound(err) {
 		resp.State.RemoveResource(ctx)
 		return
@@ -230,7 +230,7 @@ func (r resourceTeleportSAMLConnector) Update(ctx context.Context, req tfsdk.Upd
 	}
 	name := samlConnectorResource.Metadata.Name
 
-	samlConnectorBefore, err := r.p.Client().GetSAMLConnector(ctx, name, true)
+	samlConnectorBefore, err := r.p.Client().GetSAMLConnectorWithValidationOptions(ctx, name, true, apitypes.SAMLConnectorValidationFollowURLs(false))
 	if err != nil {
 		resp.Diagnostics.Append(tfdiag.DiagFromWrappedErr("Error reading SAMLConnector", err, "saml"))
 		return
@@ -252,7 +252,7 @@ func (r resourceTeleportSAMLConnector) Update(ctx context.Context, req tfsdk.Upd
 	}
 	for {
 		tries = tries + 1
-		samlConnectorI, err = r.p.Client().GetSAMLConnector(ctx, name, true)
+		samlConnectorI, err = r.p.Client().GetSAMLConnectorWithValidationOptions(ctx, name, true, apitypes.SAMLConnectorValidationFollowURLs(false))
 		if err != nil {
 			resp.Diagnostics.Append(tfdiag.DiagFromWrappedErr("Error reading SAMLConnector", err, "saml"))
 			return
@@ -312,7 +312,7 @@ func (r resourceTeleportSAMLConnector) Delete(ctx context.Context, req tfsdk.Del
 
 // ImportState imports SAMLConnector state
 func (r resourceTeleportSAMLConnector) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
-	samlConnector, err := r.p.Client().GetSAMLConnector(ctx, req.ID, true)
+	samlConnector, err := r.p.Client().GetSAMLConnectorWithValidationOptions(ctx, req.ID, true, apitypes.SAMLConnectorValidationFollowURLs(false))
 	if err != nil {
 		resp.Diagnostics.Append(tfdiag.DiagFromWrappedErr("Error reading SAMLConnector", trace.Wrap(err), "saml"))
 		return

--- a/integrations/terraform/testlib/fixtures/saml_connector_0_create_with_entitydescriptorurl.tf
+++ b/integrations/terraform/testlib/fixtures/saml_connector_0_create_with_entitydescriptorurl.tf
@@ -1,8 +1,8 @@
-resource "teleport_role" "admin" {
+resource "teleport_role" "test" {
   version = "v7"
   metadata = {
-    name        = "admin"
-    description = "admin role"
+    name        = "saml-test-role"
+    description = "SAML connector test role"
     expires     = "2032-12-12T00:00:00Z"
   }
 
@@ -25,7 +25,7 @@ resource "teleport_saml_connector" "test" {
   spec = {
     attributes_to_roles = [{
       name  = "groups"
-      roles = ["admin"]
+      roles = ["saml-test-role"]
       value = "okta-admin"
     }]
 

--- a/integrations/terraform/testlib/fixtures/saml_connector_data_source.tf
+++ b/integrations/terraform/testlib/fixtures/saml_connector_data_source.tf
@@ -1,0 +1,18 @@
+data "teleport_saml_connector" "test" {
+  kind    = "saml"
+  version = "v2"
+  metadata = {
+    name = "test_data_source"
+  }
+
+  spec = {
+    attributes_to_roles = [{
+      name  = "groups"
+      roles = ["saml-data-source-role"]
+      value = "okta-admin"
+    }]
+
+    acs                   = "https://example.com/v1/webapi/saml/acs"
+    entity_descriptor_url = "%v"
+  }
+}

--- a/integrations/terraform/testlib/saml_connector_test.go
+++ b/integrations/terraform/testlib/saml_connector_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"sync/atomic"
 
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -157,17 +158,96 @@ func (s *TerraformSuiteEnterprise) TestImportSAMLConnector() {
 }
 
 func (s *TerraformSuiteEnterprise) TestSAMLConnectorWithEntityDescriptorURL() {
-	s.T().Skip("TODO(hugoShaka): fix test")
-	// Start test HTTP server that returns SAML descriptor.
-	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var unavailable atomic.Bool
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if unavailable.Load() {
+			http.NotFound(w, nil)
+			return
+		}
 		fmt.Fprintln(w, testDescriptor)
 	}))
 	s.T().Cleanup(httpServer.Close)
+
+	name := "teleport_saml_connector.test"
+	metadataURL := httpServer.URL + "/app/exk4d7tmnz9DEaEw85d7/sso/saml/metadata"
+	config := s.getFixture("saml_connector_0_create_with_entitydescriptorurl.tf", httpServer.URL)
+
 	resource.Test(s.T(), resource.TestCase{
 		ProtoV6ProviderFactories: s.terraformProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: s.getFixture("saml_connector_0_create_with_entitydescriptorurl.tf", httpServer.URL),
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "saml"),
+					resource.TestCheckResourceAttr(name, "metadata.name", "test"),
+					resource.TestCheckResourceAttr(name, "spec.acs", "https://example.com/v1/webapi/saml/acs"),
+					resource.TestCheckResourceAttr(name, "spec.entity_descriptor_url", metadataURL),
+				),
+			},
+			{
+				PreConfig: func() {
+					unavailable.Store(true)
+				},
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func (s *TerraformSuiteEnterprise) TestSAMLConnectorDataSourceWithUnavailableEntityDescriptorURL() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+	var unavailable atomic.Bool
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if unavailable.Load() {
+			http.NotFound(w, nil)
+			return
+		}
+		fmt.Fprintln(w, testDescriptor)
+	}))
+	s.T().Cleanup(httpServer.Close)
+
+	const (
+		connectorName = "test_data_source"
+		roleName      = "saml-data-source-role"
+	)
+	metadataURL := httpServer.URL + "/app/exk4d7tmnz9DEaEw85d7/sso/saml/metadata"
+	role, err := types.NewRole(roleName, types.RoleSpecV6{})
+	require.NoError(s.T(), err)
+	_, err = s.client.UpsertRole(ctx, role)
+	require.NoError(s.T(), err)
+	s.T().Cleanup(func() {
+		require.NoError(s.T(), s.client.DeleteRole(ctx, roleName))
+	})
+
+	connector, err := types.NewSAMLConnector(connectorName, types.SAMLConnectorSpecV2{
+		AssertionConsumerService: "https://example.com/v1/webapi/saml/acs",
+		EntityDescriptorURL:      metadataURL,
+		AttributesToRoles: []types.AttributeMapping{
+			{Name: "groups", Value: "okta-admin", Roles: []string{roleName}},
+		},
+	})
+	require.NoError(s.T(), err)
+	_, err = s.client.CreateSAMLConnector(ctx, connector)
+	require.NoError(s.T(), err)
+	s.T().Cleanup(func() {
+		require.NoError(s.T(), s.client.DeleteSAMLConnector(ctx, connectorName))
+	})
+
+	unavailable.Store(true)
+	name := "data.teleport_saml_connector.test"
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("saml_connector_data_source.tf", metadataURL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "saml"),
+					resource.TestCheckResourceAttr(name, "metadata.name", connectorName),
+					resource.TestCheckResourceAttr(name, "spec.acs", "https://example.com/v1/webapi/saml/acs"),
+					resource.TestCheckResourceAttr(name, "spec.entity_descriptor_url", metadataURL),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
Issue: https://github.com/gravitational/teleport/issues/54732

related PRs:
- https://github.com/gravitational/teleport/pull/69092 (tctl)
- https://github.com/gravitational/teleport.e/pull/9260 (UI)

This ticket fixes the `terraform` command only.

## What
All saml objects should be returned when running `tctl get saml`, UI and Terraform provider.

## Why
The problem occurs because currently every call to terraform provider SAML connector has a validation step that queries the `entity_descriptor_url` and if the query fails, it aborts the operations resulting the given SAML connector omitted from the output.

Apart from failure to get/list/export the SAML connector info from with unreachable `entity_descriptor_url` via terraform provider, it's impossible to fix the connector by updating the URL to a reachable one and perform `terraform apply`. This change fixes this use case as well. Creating a new connector still requires a valid URL. 

Given the SAML connector is already in cache, the get/update/delete operations do not really need to perform the query validation step.

## Manual Test Plan
- [x] Create a dummy SAML connector with a dummy IdP and then stop the IdP.

### Test Environment

1. Start a local teleport instance.
2. Create a sample IdP response `metadata.xml`:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<md:EntityDescriptor
    xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
    entityID="https://idp.example.test/metadata">
  <md:IDPSSODescriptor
      protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
    <md:NameIDFormat>
      urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
    </md:NameIDFormat>
    <md:SingleSignOnService
        Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
        Location="https://idp.example.test/sso"/>
  </md:IDPSSODescriptor>
</md:EntityDescriptor>
```
3. Start a server in the same directory where `metadata.xml` file is.
```bash
$ python3 -m http server
```
4. generate auth identity
```bash
tctl auth sign \
  --user=admin \
  --out=.terraform-identity \
  --format=file \
  --overwrite \
  --ttl=2h
```

5. in another terminal window - create a saml connector via terraform using the following script(s):
main.tf:
```hsl
terraform {
  required_providers {
    teleport = {
      // requires dev_override to point to the built terraform provider at
      // integrations/terraform/build/terraform-provider-teleport
      source = "terraform.releases.teleport.dev/gravitational/teleport"
    }
  }
}

variable "teleport_addr" {
  type = string
}

variable "identity_file_path" {
  type = string
}

variable "metadata_url" {
  type = string
}

provider "teleport" {
  addr               = var.teleport_addr
  identity_file_path = var.identity_file_path
}

resource "teleport_role" "saml_repro" {
  version = "v7"

  metadata = {
    name = "saml-metadata-repro"
  }

  spec = {
    options = {}
    allow   = {}
  }
}

resource "teleport_saml_connector" "repro" {
  version = "v2"

  metadata = {
    name = "broken-metadata-repro"
  }

  spec = {
    display = "Broken metadata reproduction"

    acs                     = "https://proxy.example.com/v1/webapi/saml/acs/broken-metadata-repro"
    audience                = "https://proxy.example.com/v1/webapi/saml/acs/broken-metadata-repro"
    service_provider_issuer = "https://proxy.example.com/v1/webapi/saml/acs/broken-metadata-repro"

    entity_descriptor_url = var.metadata_url

    attributes_to_roles = [{
      name  = "groups"
      value = "developers"
      roles = [teleport_role.saml_repro.metadata.name]
    }]
  }
}
```

and run:
```bash
$ terraform apply \
    -var 'teleport_addr=127.0.0.1:3025' \
    -var 'identity_file_path=<path-to-terraform-identity>' \
    -var 'metadata_url=http://127.0.0.1:8000/metadata.xml'
```
6. Stop the python3 http server (dummy IdP)
7. Try `terraform plan` or `terraform apply` and observe plan command fails to complete successfully.
8. Build fixed terraform provider binary and validate the same workflows are working as expected.

### Test Cases
- [x] Reproduce the issue with the steps above. Make sure the issue is not reproduced with fixed terraform provider binary.