### PR TITLE
SKILL: add Azure management groups to discovery skill

### DIFF
--- a/skills/teleport-discovery/SKILL.md
+++ b/skills/teleport-discovery/SKILL.md
@@ -28,6 +28,7 @@ allowed-tools:
   - Bash(aws iam list-open-id-connect-providers:*)
   - Bash(aws iam get-open-id-connect-provider:*)
   - Bash(az account show:*)
+  - Bash(az account list:*)
   - Bash(az group show:*)
 ---
 
@@ -48,7 +49,7 @@ results.
 ## Determine the cloud
 
 Set `CLOUD` before anything else. Infer `aws` when the request names EC2, EKS, or an AWS
-account. Infer `azure` when it names VMs, a subscription, or a resource group. If
+account. Infer `azure` when it names VMs, a subscription, a resource group, or a management group. If
 the request implies neither, stop and ask the user which cloud. Do not run `aws` or `az` commands
 and do not write Terraform until `CLOUD` is set.
 

--- a/skills/teleport-discovery/evals/evals.json
+++ b/skills/teleport-discovery/evals/evals.json
@@ -319,6 +319,49 @@
         "The teleport provider version constraint in the applied configuration floors at the 18.7.6 module minimum or the cluster major and caps below the next major.",
         "The agent verified the resources itself following references/monitor.md and reported the verification in final-response.md."
       ]
+    },
+    {
+      "id": 18,
+      "eval_name": "azure-write-vm-management-group",
+      "cloud": "azure",
+      "tier": "write",
+      "fixture": "cloud-azure-management-group",
+      "copy_fixture": null,
+      "prompt": "Set up Azure VM auto-discovery across all subscriptions in our tenant on Teleport Cloud tenant azure-tenant.teleport.sh. Use management group scoped discovery with the tenant root group (tenant-wide). Put the managed identity in our existing resource group my-rg. Discover VMs tagged env=prod. The plan is approved. Write the Terraform into a new directory, don't apply it.",
+      "assertions": [
+        "Wrote Terraform into a new directory under outputs/ with versions.tf and main.tf.",
+        "terraform validate passes for the directory.",
+        "main.tf module source is exactly terraform.releases.teleport.dev/teleport/discovery/azure.",
+        "The agent treated this as management-group scope: the module block sets azure_management_group_id to data.azurerm_client_config.current.tenant_id, using a data azurerm_client_config block rather than hardcoding the tenant ID.",
+        "Because the stub az group show succeeds for my-rg, main.tf references the existing group via a data azurerm_resource_group block, not a resource block.",
+        "teleport_proxy_public_addr is exactly azure-tenant.teleport.sh:443 and teleport_discovery_group_name is exactly cloud-discovery-group.",
+        "One azure matcher: types [\"vm\"], subscriptions [\"*\"], tags {env: [\"prod\"]}. The subscriptions value is the wildcard, not an explicit UUID.",
+        "The teleport provider version constraint is >= 18.7.6, < 19.0.0. An open-ended >= 18.7.6, a major-only pin, or a 18.8.0 floor fails.",
+        "main.tf defines outputs named exactly integration_name, discovery_config_name, and provision_token_name.",
+        "The agent ran no terraform: outputs/ contains no agent-created .terraform directory, .tfstate, or lock file."
+      ]
+    },
+    {
+      "id": 19,
+      "eval_name": "azure-write-vm-management-group-custom-id",
+      "cloud": "azure",
+      "tier": "write",
+      "fixture": "cloud-azure-management-group",
+      "copy_fixture": null,
+      "prompt": "Set up Azure VM auto-discovery scoped to management group my-mg-example on Teleport Cloud tenant azure-tenant.teleport.sh. Use the existing resource group my-rg for the managed identity. The plan is approved. Write the Terraform into a new directory, don't apply it.",
+      "assertions": [
+        "Wrote Terraform into a new directory under outputs/ with versions.tf and main.tf.",
+        "terraform validate passes for the directory.",
+        "main.tf module source is exactly terraform.releases.teleport.dev/teleport/discovery/azure.",
+        "The module block sets azure_management_group_id to exactly \"my-mg-example\", not to data.azurerm_client_config.current.tenant_id.",
+        "No data azurerm_client_config block is present because the management group ID is provided directly, not derived from the tenant.",
+        "Because the stub az group show succeeds for my-rg, main.tf references the existing group via a data azurerm_resource_group block.",
+        "teleport_proxy_public_addr is exactly azure-tenant.teleport.sh:443 and teleport_discovery_group_name is exactly cloud-discovery-group.",
+        "One azure matcher: types [\"vm\"], subscriptions [\"*\"]. The subscriptions value is the wildcard.",
+        "The teleport provider version constraint is >= 18.7.6, < 19.0.0. An open-ended >= 18.7.6, a major-only pin, or a 18.8.0 floor fails.",
+        "main.tf defines outputs named exactly integration_name, discovery_config_name, and provision_token_name.",
+        "The agent ran no terraform: outputs/ contains no agent-created .terraform directory, .tfstate, or lock file."
+      ]
     }
   ]
 }

--- a/skills/teleport-discovery/evals/fixtures/_mocklib.py
+++ b/skills/teleport-discovery/evals/fixtures/_mocklib.py
@@ -287,6 +287,12 @@ def _az(scn: dict, args: list[str]) -> None:
 
     if cmd == "account" and sub == "show":
         if (
+            _flag_value(args, "--query") == "tenantId"
+            and _flag_value(args, "--output") == "tsv"
+        ):
+            _out(az.get("tenant_id", "00000000-0000-0000-0000-tenant000001"))
+            return
+        if (
             _flag_value(args, "--query") == "id"
             and _flag_value(args, "--output") == "tsv"
         ):
@@ -295,6 +301,7 @@ def _az(scn: dict, args: list[str]) -> None:
             _out(
                 {
                     "id": az["subscription_id"],
+                    "tenantId": az.get("tenant_id", "00000000-0000-0000-0000-tenant000001"),
                     "name": "eval-subscription",
                     "state": "Enabled",
                 }

--- a/skills/teleport-discovery/evals/fixtures/scenarios/cloud-azure-management-group.json
+++ b/skills/teleport-discovery/evals/fixtures/scenarios/cloud-azure-management-group.json
@@ -1,0 +1,18 @@
+{
+  "tsh": {
+    "profile_url": "https://azure-tenant.teleport.sh:443",
+    "cluster": "azure-tenant.teleport.sh",
+    "username": "eval"
+  },
+  "tctl": {
+    "cluster": "azure-tenant.teleport.sh",
+    "version": "18.8.0",
+    "integrations": [],
+    "inventory_discovery": [{ "id": "discovery-svc-1" }]
+  },
+  "az": {
+    "subscription_id": "00000000-0000-0000-0000-000000000001",
+    "tenant_id": "00000000-0000-0000-0000-tenant000001",
+    "resource_groups": { "my-rg": "eastus" }
+  }
+}

--- a/skills/teleport-discovery/references/azure-setup.md
+++ b/skills/teleport-discovery/references/azure-setup.md
@@ -7,15 +7,47 @@ Resolve the common fields from the skill's Setup section, then these Azure field
 
 | Field | Tool derivation | Default |
 |-------|-----------------|---------|
-| `subscriptions` | `az account show --query id --output tsv` for the current subscription | Ask |
+| `scope` | see **Scope** below | `subscription` |
+| `management_group_id` | Only when scope is management-group: see **Scope** below (ask before deriving) | Ask |
+| `subscriptions` | Subscription scope: `az account show --query id --output tsv` for the current subscription. Management-group scope: `["*"]` | Ask |
 | `resource_group` | none | Ask |
 | `location` | see **Resource group and location** below | Ask, per **Resource group and location** |
 | `regions` | none | Ask, with `["*"]` as the default |
 | `resource_groups` | none | Ask, with `["*"]` as the default |
 | `tags` | none | Ask, with `{"*": ["*"]}` as the default |
 
-Validate that every subscription ID is a UUID of the form
+When scope is subscription, validate that every subscription ID is a UUID of the form
 `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`. If any fails, ask the user to correct it.
+
+## Scope
+
+`azure_management_group_id` is only available in module version > `18.11.0`.
+
+Users can discover VMs in specific subscriptions or across subscriptions in a
+management group.
+
+Resolve `scope` before `subscriptions`.
+Set it to `management-group` when the request names a management group, tenant-wide
+discovery, discovery across all subscriptions, or otherwise refers to the whole Azure
+tenant or account (e.g. "enroll my azure tenant", "my whole azure account").
+
+When the request does not specify scope, run
+`az account list --query "length(@)" --output tsv`. If it returns more than 1, ask the user
+to choose between management-group and subscription scope, with subscription
+as the default option. Otherwise, use `subscription` scope.
+
+For management-group scope:
+
+1. Ask which management group to use. Default to the tenant ID (Tenant root group,
+   all subscriptions). The alternative is a specific management group ID.
+2. For tenant-wide: derive `management_group_id` from
+   `az account show --query tenantId --output tsv`. Note that using a tenant ID
+   targets the [Tenant root group](https://learn.microsoft.com/en-us/azure/governance/management-groups/overview#root-management-group-for-each-directory)
+   and requires [elevated access](https://learn.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin).
+3. For a specific management group: ask for the management group ID.
+4. Default `subscriptions` to `["*"]` (all subscriptions in the group). If the user asks to
+   filter to specific subscriptions, ask for their IDs and validate each as a UUID of the
+   form `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
 
 ## Resource group and location
 
@@ -63,6 +95,13 @@ provider "teleport" {
 }
 ```
 
+When scope is management-group and `management_group_id` is the tenant ID (tenant root group),
+add a data source to read it dynamically:
+
+```hcl
+data "azurerm_client_config" "current" {}
+```
+
 Write the discovery module. When `create_resource_group` is true, create the resource group
 and reference it from the module:
 
@@ -82,10 +121,17 @@ module "azure_discovery" {
   azure_resource_group_name       = azurerm_resource_group.teleport_discovery.name
   azure_managed_identity_location = azurerm_resource_group.teleport_discovery.location
 
+  # Fill azure_management_group_id only when scope is management-group:
+  # azure_management_group_id = data.azurerm_client_config.current.tenant_id
+  # or for a specific management group:
+  # azure_management_group_id = "<management_group_id>"
+
   azure_matchers = [
     {
       types         = ["vm"]
       subscriptions = [<each subscription ID quoted, comma-separated>]
+      # For management-group scope, default to: subscriptions = ["*"]
+      # or list specific subscription IDs to filter to just those subscriptions
       # add regions, resource_groups, or tags per the schema below to narrow
     }
   ]
@@ -122,7 +168,7 @@ data "azurerm_resource_group" "teleport_discovery" {
 | Field | Type | Default | Notes |
 |-------|------|---------|-------|
 | `types` | list(string) | required | Only `["vm"]`. |
-| `subscriptions` | list(string) | required | Azure subscription IDs to search. |
+| `subscriptions` | list(string) | required | Azure subscription IDs, or `["*"]` to match all subscriptions (default when `azure_management_group_id` is set). |
 | `regions` | list(string) | `["*"]` | `["*"]` matches all regions. |
 | `resource_groups` | list(string) | `["*"]` | `["*"]` matches all resource groups. |
 | `tags` | map(list(string)) | `{"*": ["*"]}` | Tag filter. |

--- a/skills/teleport-discovery/references/azure-setup.md
+++ b/skills/teleport-discovery/references/azure-setup.md
@@ -38,9 +38,9 @@ as the default option. Otherwise, use `subscription` scope.
 
 For management-group scope:
 
-1. Ask which management group to use. Default to the tenant ID (Tenant root group,
-   all subscriptions). The alternative is a specific management group ID.
-2. For tenant-wide: derive `management_group_id` from
+1. Ask which management group to use: a specific management group ID, or the tenant ID for
+   the Tenant root group (all subscriptions).
+2. For the Tenant root group: derive `management_group_id` from
    `az account show --query tenantId --output tsv`. Note that using a tenant ID
    targets the [Tenant root group](https://learn.microsoft.com/en-us/azure/governance/management-groups/overview#root-management-group-for-each-directory)
    and requires [elevated access](https://learn.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin).


### PR DESCRIPTION
Issue: https://github.com/gravitational/teleport/issues/60822

Adds managment group scope to the `teleport-discovery` agent skill

Changelog: Add Azure management group scope for teleport-discovery agent skill


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

- cloud

### Test Cases
- [x] Configure Teleport discovery with managment group scope in an existing project 
- [x] Configure Teleport discovery with tenant root scope in an existing project (entire tenant)

