### PR TITLE
[v18] Update app block to use number 10, from backport - to match master

### DIFF
--- a/api/gen/proto/go/teleport/scopes/access/v1/role_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role_protohybrid.pb.go
@@ -228,7 +228,7 @@ type ScopedRoleSpec struct {
 	// The kubernetes specific configuration for a scoped role.
 	Kube *ScopedRoleKube `protobuf:"bytes,8,opt,name=kube,proto3" json:"kube,omitempty"`
 	// The App Access specific configuration for a scoped role.
-	App           *ScopedRoleApp `protobuf:"bytes,9,opt,name=app,proto3" json:"app,omitempty"`
+	App           *ScopedRoleApp `protobuf:"bytes,10,opt,name=app,proto3" json:"app,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2136,7 +2136,8 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x05rules\x18\x06 \x03(\v2%.teleport.scopes.access.v1.ScopedRuleR\x05rules\x12:\n" +
 	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03ssh\x12=\n" +
 	"\x04kube\x18\b \x01(\v2).teleport.scopes.access.v1.ScopedRoleKubeR\x04kube\x12:\n" +
-	"\x03app\x18\t \x01(\v2(.teleport.scopes.access.v1.ScopedRoleAppR\x03appJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"\xac\x02\n" +
+	"\x03app\x18\n" +
+	" \x01(\v2(.teleport.scopes.access.v1.ScopedRoleAppR\x03appJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"\xac\x02\n" +
 	"\x12ScopedRoleDefaults\x12.\n" +
 	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\x12X\n" +
 	"\x11session_recording\x18\x02 \x01(\v2+.teleport.scopes.access.v1.SessionRecordingR\x10sessionRecording\x12;\n" +

--- a/api/gen/proto/go/teleport/scopes/access/v1/role_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role_protoopaque.pb.go
@@ -214,7 +214,7 @@ type ScopedRoleSpec struct {
 	xxx_hidden_Rules            *[]*ScopedRule         `protobuf:"bytes,6,rep,name=rules,proto3"`
 	xxx_hidden_Ssh              *ScopedRoleSSH         `protobuf:"bytes,7,opt,name=ssh,proto3"`
 	xxx_hidden_Kube             *ScopedRoleKube        `protobuf:"bytes,8,opt,name=kube,proto3"`
-	xxx_hidden_App              *ScopedRoleApp         `protobuf:"bytes,9,opt,name=app,proto3"`
+	xxx_hidden_App              *ScopedRoleApp         `protobuf:"bytes,10,opt,name=app,proto3"`
 	unknownFields               protoimpl.UnknownFields
 	sizeCache                   protoimpl.SizeCache
 }
@@ -2133,7 +2133,8 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x05rules\x18\x06 \x03(\v2%.teleport.scopes.access.v1.ScopedRuleR\x05rules\x12:\n" +
 	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03ssh\x12=\n" +
 	"\x04kube\x18\b \x01(\v2).teleport.scopes.access.v1.ScopedRoleKubeR\x04kube\x12:\n" +
-	"\x03app\x18\t \x01(\v2(.teleport.scopes.access.v1.ScopedRoleAppR\x03appJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"\xac\x02\n" +
+	"\x03app\x18\n" +
+	" \x01(\v2(.teleport.scopes.access.v1.ScopedRoleAppR\x03appJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"\xac\x02\n" +
 	"\x12ScopedRoleDefaults\x12.\n" +
 	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\x12X\n" +
 	"\x11session_recording\x18\x02 \x01(\v2+.teleport.scopes.access.v1.SessionRecordingR\x10sessionRecording\x12;\n" +

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -79,7 +79,7 @@ message ScopedRoleSpec {
   ScopedRoleKube kube = 8;
 
   // The App Access specific configuration for a scoped role.
-  ScopedRoleApp app = 9;
+  ScopedRoleApp app = 10;
 }
 
 // ScopedRoleDefaults provides fallback values for controls shared across multiple protocols.


### PR DESCRIPTION
Previous Backport merge has the app block listed as 9 instead of 10. Editing to match master.



<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster, docker apps, local agents

### Test Cases
- [x] Ensure scoped user can still list apps, log in, proxy
