### PR TITLE
Fix kube requests using the proxy special-verb path prefix

### DIFF
--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -246,7 +246,7 @@ spec:
         # - deletecollection
         # - exec - allows users to execute commands in a pod
         # - portforward - allows users to forward ports from a pod
-        # - proxy - allows users to send HTTP requests through a pod/service/node
+        # - proxy - allows users to send HTTP requests to a resource
         verbs: ['*']
 
     # Database account names this role can connect as.

--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -246,6 +246,7 @@ spec:
         # - deletecollection
         # - exec - allows users to execute commands in a pod
         # - portforward - allows users to forward ports from a pod
+        # - proxy - allows users to send HTTP requests through a pod/service/node
         verbs: ['*']
 
     # Database account names this role can connect as.

--- a/lib/kube/proxy/resource_rbac_test.go
+++ b/lib/kube/proxy/resource_rbac_test.go
@@ -4460,22 +4460,6 @@ func TestProxySubresourceRBAC(t *testing.T) {
 		Verbs: []string{"get"}, APIGroup: types.Wildcard,
 	}}, nil)
 
-	sendGet := func(t *testing.T, user types.User, urlPath string, opts ...GenTestKubeClientTLSCertOptions) (int, string) {
-		t.Helper()
-		_, cfg := testCtx.GenTestKubeClientTLSCert(t, user.GetName(), kubeCluster, opts...)
-		transport, err := rest.TransportFor(cfg)
-		require.NoError(t, err)
-		client := &http.Client{Transport: transport}
-		req, err := http.NewRequestWithContext(testCtx.Context, http.MethodGet, cfg.Host+urlPath, nil)
-		require.NoError(t, err)
-		resp, err := client.Do(req)
-		require.NoError(t, err)
-		t.Cleanup(func() { resp.Body.Close() })
-		body, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-		return resp.StatusCode, string(body)
-	}
-
 	tests := []struct {
 		name         string
 		user         types.User
@@ -4532,7 +4516,7 @@ func TestProxySubresourceRBAC(t *testing.T) {
 				opts = makeScopedOpts(t, testCtx, tt.user.GetName(), scope)
 			}
 			t.Run(fmt.Sprintf("%s scoped=%t", tt.name, scoped), func(t *testing.T) {
-				code, body := sendGet(t, tt.user, tt.urlPath, opts...)
+				code, body := sendKubeGet(t, testCtx, tt.user, tt.urlPath, opts...)
 				require.Equal(t, tt.wantCode, code, "body: %s", body)
 				require.Contains(t, body, tt.bodyContains)
 			})
@@ -4561,4 +4545,110 @@ func toScopedKubeResource(resource types.KubernetesResource) *accessv1.KubeResou
 
 func scopedUsername(username string) string {
 	return "scoped-" + username
+}
+
+// TestProxySpecialVerbPathRBAC verifies that the Kubernetes "special verb" URL form,
+// where a proxy segment precedes the resource path
+// (/apis/{group}/{version}/proxy/namespaces/{ns}/{kind}/{name}),
+// is parsed as the resource it targets and enforced with the KubeVerbProxy verb,
+// instead of being rejected as a resource kind the cluster doesn't serve.
+func TestProxySpecialVerbPathRBAC(t *testing.T) {
+	const (
+		basePath     = "/apis/resources.teleport.dev/v6"
+		resourceKind = "teleportroles"
+		resourceName = "telerole-1"
+	)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
+
+	newUser := func(name string, resources []types.KubernetesResource) types.User {
+		u, _ := testCtx.CreateUserAndRole(testCtx.Context, t, name, RoleSpec{
+			Name:          name,
+			KubeUsers:     roleKubeUsers,
+			KubeGroups:    roleKubeGroups,
+			SetupRoleFunc: func(r types.Role) { r.SetKubeResources(types.Allow, resources) },
+		})
+		return u
+	}
+
+	proxyUser := newUser("crd-proxy", []types.KubernetesResource{{
+		Kind: types.Wildcard, APIGroup: "*.teleport.dev", Namespace: types.Wildcard, Name: types.Wildcard,
+		Verbs: []string{types.KubeVerbGet, types.KubeVerbList, types.KubeVerbProxy},
+	}})
+	// Same resources, no proxy verb.
+	getUser := newUser("crd-get", []types.KubernetesResource{{
+		Kind: resourceKind, APIGroup: types.Wildcard, Namespace: types.Wildcard, Name: types.Wildcard,
+		Verbs: []string{types.KubeVerbGet, types.KubeVerbList},
+	}})
+	// Negative control: the proxy verb, but on a different kind.
+	otherKindUser := newUser("crd-other-kind", []types.KubernetesResource{{
+		Kind: "pods", APIGroup: types.Wildcard, Namespace: types.Wildcard, Name: types.Wildcard,
+		Verbs: []string{types.KubeVerbProxy},
+	}})
+
+	const proxyPath = basePath + "/proxy/namespaces/default/" + resourceKind + "/" + resourceName
+
+	tests := []struct {
+		name         string
+		user         types.User
+		urlPath      string
+		wantCode     int
+		bodyContains string
+	}{
+		{
+			// Before the fix this failed with a 404 no role could allow,
+			// because the verb segment was folded into the resource kind.
+			name:         "allowed_with_proxy_verb",
+			user:         proxyUser,
+			urlPath:      proxyPath,
+			wantCode:     http.StatusOK,
+			bodyContains: resourceName,
+		},
+		{
+			name:         "denied_without_proxy_verb",
+			user:         getUser,
+			urlPath:      proxyPath,
+			wantCode:     http.StatusForbidden,
+			bodyContains: `User \"crd-get\" cannot proxy resource \"` + resourceKind,
+		},
+		{
+			name:         "denied_proxy_verb_on_other_kind",
+			user:         otherKindUser,
+			urlPath:      proxyPath,
+			wantCode:     http.StatusForbidden,
+			bodyContains: "cannot proxy resource",
+		},
+		{
+			// The plain resource path is unaffected. It still uses the method-derived verb.
+			name:         "plain_get_still_allowed",
+			user:         getUser,
+			urlPath:      basePath + "/namespaces/default/" + resourceKind + "/" + resourceName,
+			wantCode:     http.StatusOK,
+			bodyContains: resourceName,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, body := sendKubeGet(t, testCtx, tt.user, tt.urlPath)
+			require.Equal(t, tt.wantCode, code, "body: %s", body)
+			require.Contains(t, body, tt.bodyContains)
+		})
+	}
+}
+
+// sendKubeGet issues a raw GET against the kube proxy as the given user and returns the status code and body.
+// Raw HTTP rather than a typed client, so arbitrary URL paths can be exercised.
+func sendKubeGet(t *testing.T, testCtx *TestContext, user types.User, urlPath string, opts ...GenTestKubeClientTLSCertOptions) (int, string) {
+	t.Helper()
+	_, cfg := testCtx.GenTestKubeClientTLSCert(t, user.GetName(), kubeCluster, opts...)
+	transport, err := rest.TransportFor(cfg)
+	require.NoError(t, err)
+	client := &http.Client{Transport: transport}
+	req, err := http.NewRequestWithContext(testCtx.Context, http.MethodGet, cfg.Host+urlPath, nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { resp.Body.Close() })
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, string(body)
 }

--- a/lib/kube/proxy/resource_rbac_test.go
+++ b/lib/kube/proxy/resource_rbac_test.go
@@ -4643,11 +4643,12 @@ func sendKubeGet(t *testing.T, testCtx *TestContext, user types.User, urlPath st
 	transport, err := rest.TransportFor(cfg)
 	require.NoError(t, err)
 	client := &http.Client{Transport: transport}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequestWithContext(testCtx.Context, http.MethodGet, cfg.Host+urlPath, nil)
 	require.NoError(t, err)
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	t.Cleanup(func() { resp.Body.Close() })
+	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	return resp.StatusCode, string(body)

--- a/lib/kube/proxy/testing/kube_server/kube_mock.go
+++ b/lib/kube/proxy/testing/kube_server/kube_mock.go
@@ -305,6 +305,7 @@ func (s *KubeMockServer) setup() {
 		router.Handle("GET /apis/"+k.group+"/"+k.version+"/"+k.plural, s.withWriter(s.listCRDs(crd)))
 		router.Handle("GET /apis/"+k.group+"/"+k.version+"/namespaces/{namespace}/"+k.plural+"/{name}", s.withWriter(s.getCRD(crd)))
 		router.Handle("DELETE /apis/"+k.group+"/"+k.version+"/namespaces/{namespace}/"+k.plural+"/{name}", s.withWriter(s.deleteCRD(crd)))
+		router.Handle("GET /apis/"+k.group+"/"+k.version+"/proxy/namespaces/{namespace}/"+k.plural+"/{name}", s.withWriter(s.getCRD(crd)))
 	}
 
 	router.Handle("GET /version", s.withWriter(s.versionEndpoint))

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -106,6 +106,8 @@ type apiResource struct {
 
 // parseResourcePath does best-effort parsing of a Kubernetes API request path.
 // All fields of the returned apiResource may be empty.
+//
+// TODO(jakealti): reuse k8s.io/apiserver request.RequestInfoFactory here instead of re-implementing it.
 func parseResourcePath(p string) apiResource {
 	// Kubernetes API reference: https://kubernetes.io/docs/reference/kubernetes-api/
 	// Let's try to parse this. Here be dragons!

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -219,6 +219,16 @@ func parseResourcePath(p string) apiResource {
 			}
 		}
 	}
+
+	// The core API accepts [scheme:]name[:port] in the name segment of its pods/services/nodes proxy endpoints,
+	// so the special verb form has to be normalized the same way the subresource form above is.
+	// Otherwise a rule naming the resource stops matching once a scheme or port is supplied.
+	if r.isProxyVerb && r.apiGroup == "" {
+		switch getResourceFromAPIResource(r.resourceKind) {
+		case "pods", "services", "nodes":
+			r.resourceName = stripProxyNamePortScheme(r.resourceName)
+		}
+	}
 	return r
 }
 

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -165,13 +165,15 @@ func parseResourcePath(p string) apiResource {
 	// Special verb endpoints carry the verb in a segment ahead of the resource path.
 	// The API server consumes that segment and parses the rest as a normal resource path, so we do the same.
 	// See specialVerbs in https://github.com/kubernetes/apiserver/blob/master/pkg/endpoints/request/requestinfo.go
-	switch {
-	case len(parts) > 0 && parts[0] == "watch":
-		r.isWatch = true
-		parts = parts[1:]
-	case len(parts) > 1 && parts[0] == "proxy":
-		r.isProxyVerb = true
-		parts = parts[1:]
+	if len(parts) > 1 {
+		switch parts[0] {
+		case "watch":
+			r.isWatch = true
+			parts = parts[1:]
+		case "proxy":
+			r.isProxyVerb = true
+			parts = parts[1:]
+		}
 	}
 
 	switch len(parts) {

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"path"
+	"slices"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -100,6 +101,7 @@ type apiResource struct {
 	resourceName    string
 	skipEvent       bool
 	isWatch         bool
+	isProxyVerb     bool
 }
 
 // parseResourcePath does best-effort parsing of a Kubernetes API request path.
@@ -158,10 +160,15 @@ func parseResourcePath(p string) apiResource {
 		return r
 	}
 
-	// Watch API endpoints have an extra /watch/ prefix. For now, silently
-	// strip it from our result.
-	if len(parts) > 0 && parts[0] == "watch" {
+	// Special verb endpoints carry the verb in a segment ahead of the resource path.
+	// The API server consumes that segment and parses the rest as a normal resource path, so we do the same.
+	// See specialVerbs in https://github.com/kubernetes/apiserver/blob/master/pkg/endpoints/request/requestinfo.go
+	switch {
+	case len(parts) > 0 && parts[0] == "watch":
 		r.isWatch = true
+		parts = parts[1:]
+	case len(parts) > 1 && parts[0] == "proxy":
+		r.isProxyVerb = true
 		parts = parts[1:]
 	}
 
@@ -292,7 +299,7 @@ func getResourceFromRequest(req *http.Request, kubeDetails *kubeDetails) (metaRe
 	}
 	out.resourceDefinition = &resource
 
-	if apiResource.resourceName == "" && out.verb != types.KubeVerbCreate {
+	if apiResource.resourceName == "" && !slices.Contains([]string{types.KubeVerbCreate, types.KubeVerbProxy}, out.verb) {
 		// if the resource is supported but the resource name is not present and not a create request,
 		// return nil because it's a list request.
 		out.isList = true
@@ -410,6 +417,10 @@ func isKubeWatchRequest(req *http.Request, r apiResource) bool {
 }
 
 func (r apiResource) getVerb(req *http.Request) string {
+	if r.isProxyVerb {
+		return types.KubeVerbProxy
+	}
+
 	verb := ""
 	isWatch := isKubeWatchRequest(req, r)
 	switch r.resourceKind {

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -220,11 +220,18 @@ func parseResourcePath(p string) apiResource {
 		}
 	}
 
+	// The proxy special verb takes no subresource.
+	// Kubernetes apiserver stops parsing at the name and hands every segment after it to the proxied backend.
+	// Drop them so the kind we record and report is the one the API server resolved.
+	if r.isProxyVerb {
+		r.resourceKind = getResourceFromAPIResource(r.resourceKind)
+	}
+
 	// The core API accepts [scheme:]name[:port] in the name segment of its pods/services/nodes proxy endpoints,
 	// so the special verb form has to be normalized the same way the subresource form above is.
 	// Otherwise a rule naming the resource stops matching once a scheme or port is supplied.
 	if r.isProxyVerb && r.apiGroup == "" {
-		switch getResourceFromAPIResource(r.resourceKind) {
+		switch r.resourceKind {
 		case "pods", "services", "nodes":
 			r.resourceName = stripProxyNamePortScheme(r.resourceName)
 		}

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -288,6 +288,15 @@ func (r rbacSupportedResources) getTeleportResourceKindFromAPIResource(api apiRe
 // getResourceFromRequest returns a KubernetesResource if the user tried to access
 // a specific endpoint that Teleport support resource filtering. Otherwise, returns nil.
 func getResourceFromRequest(req *http.Request, kubeDetails *kubeDetails) (metaResource, error) {
+	// A "." or ".." segment splits our view of the path from the API server's.
+	// We parse the cleaned path but forward the raw one, so a name we authorize
+	// is not necessarily the one the cluster resolves. Reject instead of guessing.
+	for segment := range strings.SplitSeq(req.URL.Path, "/") {
+		if segment == "." || segment == ".." {
+			return metaResource{}, trace.BadParameter("kubernetes request path must not contain %q segments", segment)
+		}
+	}
+
 	apiResource := parseResourcePath(req.URL.Path)
 
 	out := metaResource{

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -108,7 +108,7 @@ type apiResource struct {
 // All fields of the returned apiResource may be empty.
 //
 // TODO(jakealti): reuse k8s.io/apiserver request.RequestInfoFactory here instead of re-implementing it.
-func parseResourcePath(p string) apiResource {
+func parseResourcePath(p string) (apiResource, error) {
 	// Kubernetes API reference: https://kubernetes.io/docs/reference/kubernetes-api/
 	// Let's try to parse this. Here be dragons!
 	//
@@ -134,6 +134,15 @@ func parseResourcePath(p string) apiResource {
 	// for live updates on resources (specific resources or all of one kind)
 	var r apiResource
 
+	// Cleaning below resolves "." and ".." segments, which changes which resource the path names.
+	// The raw path is what gets forwarded, so parsing one and forwarding the other
+	// would authorize a name the cluster never resolves.
+	for segment := range strings.SplitSeq(p, "/") {
+		if segment == "." || segment == ".." {
+			return r, trace.BadParameter("kubernetes request path must not contain %q segments", segment)
+		}
+	}
+
 	// Clean up the path and make it absolute.
 	p = path.Clean(p)
 	if !path.IsAbs(p) {
@@ -156,10 +165,10 @@ func parseResourcePath(p string) apiResource {
 		// This is part of API discovery. Don't emit to audit log to reduce
 		// noise.
 		r.skipEvent = true
-		return r
+		return r, nil
 	default:
 		// Doesn't look like a k8s API path, return empty result.
-		return r
+		return r, nil
 	}
 
 	// Special verb endpoints carry the verb in a segment ahead of the resource path.
@@ -182,7 +191,7 @@ func parseResourcePath(p string) apiResource {
 		// This is part of API discovery. Don't emit to audit log to reduce
 		// noise.
 		r.skipEvent = true
-		return r
+		return r, nil
 	case 1:
 		// e.g. /api/v1/pods - list pods in all namespaces
 		r.resourceKind = parts[0]
@@ -240,7 +249,7 @@ func parseResourcePath(p string) apiResource {
 			r.resourceName = stripProxyNamePortScheme(r.resourceName)
 		}
 	}
-	return r
+	return r, nil
 }
 
 // stripProxyNamePortScheme extracts the bare resource name from the [scheme:]name[:port] segment that
@@ -288,16 +297,10 @@ func (r rbacSupportedResources) getTeleportResourceKindFromAPIResource(api apiRe
 // getResourceFromRequest returns a KubernetesResource if the user tried to access
 // a specific endpoint that Teleport support resource filtering. Otherwise, returns nil.
 func getResourceFromRequest(req *http.Request, kubeDetails *kubeDetails) (metaResource, error) {
-	// A "." or ".." segment splits our view of the path from the API server's.
-	// We parse the cleaned path but forward the raw one, so a name we authorize
-	// is not necessarily the one the cluster resolves. Reject instead of guessing.
-	for segment := range strings.SplitSeq(req.URL.Path, "/") {
-		if segment == "." || segment == ".." {
-			return metaResource{}, trace.BadParameter("kubernetes request path must not contain %q segments", segment)
-		}
+	apiResource, err := parseResourcePath(req.URL.Path)
+	if err != nil {
+		return metaResource{}, trace.Wrap(err)
 	}
-
-	apiResource := parseResourcePath(req.URL.Path)
 
 	out := metaResource{
 		requestedResource: apiResource,

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -319,8 +319,8 @@ func getResourceFromRequest(req *http.Request, kubeDetails *kubeDetails) (metaRe
 	out.resourceDefinition = &resource
 
 	if apiResource.resourceName == "" && !slices.Contains([]string{types.KubeVerbCreate, types.KubeVerbProxy}, out.verb) {
-		// if the resource is supported but the resource name is not present and not a create request,
-		// return nil because it's a list request.
+		// A missing name means the request targets the whole collection: a list.
+		// Create and proxy are the exceptions. Create has the name in the body, proxy has none.
 		out.isList = true
 		return out, nil
 	}

--- a/lib/kube/proxy/url_test.go
+++ b/lib/kube/proxy/url_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -436,6 +437,39 @@ func TestGetResourceFromRequest_SpecialVerbProxyPath(t *testing.T) {
 			require.False(t, got.isList)
 			require.Equal(t, types.KubeVerbProxy, got.verb)
 			require.Equal(t, "deployments", got.requestedResource.resourceKind)
+		})
+	}
+}
+
+// TestGetResourceFromRequest_RejectsDotSegments verifies that a dot segment is rejected rather than authorized.
+func TestGetResourceFromRequest_RejectsDotSegments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		urlPath string
+		reject  bool
+	}{
+		// Under the proxy verb, the API server hands every segment after the name to the backend,
+		// so it resolves "denied" while the cleaned path names "allowed".
+		{reject: true, urlPath: "/apis/apps/v1/proxy/namespaces/default/deployments/denied/../allowed"},
+		{reject: true, urlPath: "/apis/apps/v1/proxy/namespaces/default/deployments/denied/%2e%2e/allowed"},
+		{reject: true, urlPath: "/api/v1/namespaces/default/pods/denied/../allowed"},
+		{reject: true, urlPath: "/api/v1/namespaces/default/pods/./foo"},
+		// Trailing and doubled slashes are also normalized by path.Clean,
+		// but they name the same resource either way, so they stay allowed.
+		{urlPath: "/api/v1/pods/"},
+		{urlPath: "/api/v1//pods"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.urlPath, func(t *testing.T) {
+			u, err := url.Parse(tt.urlPath)
+			require.NoError(t, err)
+			_, err = getResourceFromRequest(&http.Request{Method: http.MethodGet, URL: u}, nil)
+			if tt.reject {
+				require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/lib/kube/proxy/url_test.go
+++ b/lib/kube/proxy/url_test.go
@@ -79,8 +79,9 @@ func TestExtractResourceNameFromPostRequest_Replayable(t *testing.T) {
 
 func TestParseResourcePath(t *testing.T) {
 	tests := []struct {
-		path string
-		want apiResource
+		path    string
+		want    apiResource
+		wantErr bool
 	}{
 		{path: "", want: apiResource{}},
 		{path: "/", want: apiResource{}},
@@ -138,11 +139,26 @@ func TestParseResourcePath(t *testing.T) {
 		// A bare verb segment carries no resource path.
 		// The API server rejects it, so keep it as a kind the cluster doesn't serve rather than a resource-less request.
 		{path: "/apis/resources.teleport.dev/v6/proxy", want: apiResource{apiGroup: "resources.teleport.dev", apiGroupVersion: "v6", resourceKind: "proxy"}},
+		// Cleaning resolves dot segments, but the raw path is what gets forwarded.
+		// Under the proxy verb the API server resolves "denied" while the cleaned path names "allowed",
+		// so reject rather than authorize a name it never resolves.
+		{wantErr: true, path: "/apis/apps/v1/proxy/namespaces/default/deployments/denied/./allowed"},
+		{wantErr: true, path: "/apis/apps/v1/proxy/namespaces/default/deployments/denied/../allowed"},
+		{wantErr: true, path: "/api/v1/namespaces/default/pods/denied/../allowed"},
+		{wantErr: true, path: "/api/v1/namespaces/default/pods/./foo"},
+		// Trailing and doubled slashes are normalized too,
+		// but they name the same resource either way, so they stay allowed.
+		{path: "/api/v1/pods/", want: apiResource{apiGroup: "", apiGroupVersion: "v1", resourceKind: "pods"}},
+		{path: "/api/v1//pods", want: apiResource{apiGroup: "", apiGroupVersion: "v1", resourceKind: "pods"}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
 			got, err := parseResourcePath(tt.path)
+			if tt.wantErr {
+				require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
+				return
+			}
 			require.NoError(t, err)
 			diff := cmp.Diff(got, tt.want, cmp.AllowUnexported(apiResource{}))
 			require.Empty(t, diff, "parsing path %q", tt.path)
@@ -438,39 +454,6 @@ func TestGetResourceFromRequest_SpecialVerbProxyPath(t *testing.T) {
 			require.False(t, got.isList)
 			require.Equal(t, types.KubeVerbProxy, got.verb)
 			require.Equal(t, "deployments", got.requestedResource.resourceKind)
-		})
-	}
-}
-
-// TestGetResourceFromRequest_RejectsDotSegments verifies that a dot segment is rejected rather than authorized.
-func TestGetResourceFromRequest_RejectsDotSegments(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		urlPath string
-		reject  bool
-	}{
-		// Under the proxy verb, the API server hands every segment after the name to the backend,
-		// so it resolves "denied" while the cleaned path names "allowed".
-		{reject: true, urlPath: "/apis/apps/v1/proxy/namespaces/default/deployments/denied/../allowed"},
-		{reject: true, urlPath: "/apis/apps/v1/proxy/namespaces/default/deployments/denied/%2e%2e/allowed"},
-		{reject: true, urlPath: "/api/v1/namespaces/default/pods/denied/../allowed"},
-		{reject: true, urlPath: "/api/v1/namespaces/default/pods/./foo"},
-		// Trailing and doubled slashes are also normalized by path.Clean,
-		// but they name the same resource either way, so they stay allowed.
-		{urlPath: "/api/v1/pods/"},
-		{urlPath: "/api/v1//pods"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.urlPath, func(t *testing.T) {
-			u, err := url.Parse(tt.urlPath)
-			require.NoError(t, err)
-			_, err = getResourceFromRequest(&http.Request{Method: http.MethodGet, URL: u}, nil)
-			if tt.reject {
-				require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
-			} else {
-				require.NoError(t, err)
-			}
 		})
 	}
 }

--- a/lib/kube/proxy/url_test.go
+++ b/lib/kube/proxy/url_test.go
@@ -126,6 +126,14 @@ func TestParseResourcePath(t *testing.T) {
 		{path: "/apis/resources.teleport.dev/v6/proxy/teleportroles/telerole-1", want: apiResource{apiGroup: "resources.teleport.dev", apiGroupVersion: "v6", resourceKind: "teleportroles", resourceName: "telerole-1", isProxyVerb: true}},
 		{path: "/apis/resources.teleport.dev/v6/proxy/namespaces/default/teleportroles/telerole-1/extra/path", want: apiResource{apiGroup: "resources.teleport.dev", apiGroupVersion: "v6", namespace: "default", resourceKind: "teleportroles/extra/path", resourceName: "telerole-1", isProxyVerb: true}},
 		{path: "/api/v1/proxy/namespaces/default/pods/foo", want: apiResource{apiGroup: "", apiGroupVersion: "v1", namespace: "default", resourceKind: "pods", resourceName: "foo", isProxyVerb: true}},
+		// The core API's proxyable kinds accept [scheme:]name[:port] here too,
+		// so the name is reduced the same way as in the subresource form above.
+		{path: "/api/v1/proxy/namespaces/default/services/https:admin:443/healthz", want: apiResource{apiGroup: "", apiGroupVersion: "v1", namespace: "default", resourceKind: "services/healthz", resourceName: "admin", isProxyVerb: true}},
+		{path: "/api/v1/proxy/nodes/https:node-1:10250/healthz", want: apiResource{apiGroup: "", apiGroupVersion: "v1", resourceKind: "nodes/healthz", resourceName: "node-1", isProxyVerb: true}},
+		// Only those kinds: an aggregated API server gets the name segment verbatim,
+		// so reducing it would match a name the API server never sees.
+		{path: "/api/v1/proxy/namespaces/default/configmaps/https:admin:443", want: apiResource{apiGroup: "", apiGroupVersion: "v1", namespace: "default", resourceKind: "configmaps", resourceName: "https:admin:443", isProxyVerb: true}},
+		{path: "/apis/resources.teleport.dev/v6/proxy/namespaces/default/teleportroles/https:admin:443", want: apiResource{apiGroup: "resources.teleport.dev", apiGroupVersion: "v6", namespace: "default", resourceKind: "teleportroles", resourceName: "https:admin:443", isProxyVerb: true}},
 		// A bare verb segment carries no resource path.
 		// The API server rejects it, so keep it as a kind the cluster doesn't serve rather than a resource-less request.
 		{path: "/apis/resources.teleport.dev/v6/proxy", want: apiResource{apiGroup: "resources.teleport.dev", apiGroupVersion: "v6", resourceKind: "proxy"}},

--- a/lib/kube/proxy/url_test.go
+++ b/lib/kube/proxy/url_test.go
@@ -398,9 +398,12 @@ func Test_getResourceFromRequest(t *testing.T) {
 	}
 }
 
-// The special verb form takes its verb from the path rather than the HTTP method,
-// and is always enforced as a single resource.
-// Treating a name-less request as a list would skip the kubernetes_resources matcher.
+// TestGetResourceFromRequest_SpecialVerbProxyPath covers the two properties of the
+// proxy special-verb form that RBAC relies on:
+//
+//   - The verb comes from the path, not the HTTP method, so every method maps to KubeVerbProxy.
+//   - A name-less path is still a single resource, not a list. Lists bypass KubernetesResourceMatcher
+//     and are enforced by filtering the response instead, but a proxied response carries no list to filter.
 func TestGetResourceFromRequest_SpecialVerbProxyPath(t *testing.T) {
 	t.Parallel()
 	details := &kubeDetails{kubeCodecs: &globalKubeCodecs, rbacSupportedTypes: getRBACSupportedTypes(t)}

--- a/lib/kube/proxy/url_test.go
+++ b/lib/kube/proxy/url_test.go
@@ -142,7 +142,8 @@ func TestParseResourcePath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
-			got := parseResourcePath(tt.path)
+			got, err := parseResourcePath(tt.path)
+			require.NoError(t, err)
 			diff := cmp.Diff(got, tt.want, cmp.AllowUnexported(apiResource{}))
 			require.Empty(t, diff, "parsing path %q", tt.path)
 		})

--- a/lib/kube/proxy/url_test.go
+++ b/lib/kube/proxy/url_test.go
@@ -119,6 +119,16 @@ func TestParseResourcePath(t *testing.T) {
 		{path: "/api/v1/namespaces/default/services/https:svc:/proxy/path", want: apiResource{apiGroup: "", apiGroupVersion: "v1", namespace: "default", resourceKind: "services/proxy/path", resourceName: "svc"}},
 		{path: "/api/v1/namespaces/default/pods/https:foo:8080/proxy/healthz", want: apiResource{apiGroup: "", apiGroupVersion: "v1", namespace: "default", resourceKind: "pods/proxy/healthz", resourceName: "foo"}},
 		{path: "/api/v1/nodes/https:node-1:10250/proxy/pods", want: apiResource{apiGroup: "", apiGroupVersion: "v1", resourceKind: "nodes/proxy/pods", resourceName: "node-1"}},
+		// The "special verb" form puts the verb ahead of the resource path.
+		// The verb segment is consumed and the remainder parses like any other resource path.
+		{path: "/apis/resources.teleport.dev/v6/proxy/namespaces/default/teleportroles/telerole-1", want: apiResource{apiGroup: "resources.teleport.dev", apiGroupVersion: "v6", namespace: "default", resourceKind: "teleportroles", resourceName: "telerole-1", isProxyVerb: true}},
+		{path: "/apis/resources.teleport.dev/v6/proxy/namespaces/default/teleportroles", want: apiResource{apiGroup: "resources.teleport.dev", apiGroupVersion: "v6", namespace: "default", resourceKind: "teleportroles", isProxyVerb: true}},
+		{path: "/apis/resources.teleport.dev/v6/proxy/teleportroles/telerole-1", want: apiResource{apiGroup: "resources.teleport.dev", apiGroupVersion: "v6", resourceKind: "teleportroles", resourceName: "telerole-1", isProxyVerb: true}},
+		{path: "/apis/resources.teleport.dev/v6/proxy/namespaces/default/teleportroles/telerole-1/extra/path", want: apiResource{apiGroup: "resources.teleport.dev", apiGroupVersion: "v6", namespace: "default", resourceKind: "teleportroles/extra/path", resourceName: "telerole-1", isProxyVerb: true}},
+		{path: "/api/v1/proxy/namespaces/default/pods/foo", want: apiResource{apiGroup: "", apiGroupVersion: "v1", namespace: "default", resourceKind: "pods", resourceName: "foo", isProxyVerb: true}},
+		// A bare verb segment carries no resource path.
+		// The API server rejects it, so keep it as a kind the cluster doesn't serve rather than a resource-less request.
+		{path: "/apis/resources.teleport.dev/v6/proxy", want: apiResource{apiGroup: "resources.teleport.dev", apiGroupVersion: "v6", resourceKind: "proxy"}},
 	}
 
 	for _, tt := range tests {
@@ -271,6 +281,13 @@ func Test_getResourceFromRequest(t *testing.T) {
 		{path: "/apis/apps/v1/namespaces/default/deployments", body: bodyFunc("Deployment", "apps/v1"), want: &types.KubernetesResource{Kind: "deployments", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: "apps"}},
 		{path: "/apis/apps/v1beta2/namespaces/default/deployments", body: bodyFunc("Deployment", "apps/v1beta2"), want: &types.KubernetesResource{Kind: "deployments", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: "apps"}},
 		{path: "/apis/apps/v1/namespaces/default/deployments", body: bodyFuncWithoutGVK(), want: &types.KubernetesResource{Kind: "deployments", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: "apps"}},
+		// The "special verb" form resolves to the kind the path targets and takes its
+		// verb from the path, not from the HTTP method.
+		{path: "/apis/apps/v1/proxy/namespaces/default/deployments/foo", want: &types.KubernetesResource{Kind: "deployments", Namespace: "default", Name: "foo", Verbs: []string{"proxy"}, APIGroup: "apps"}},
+		{path: "/apis/apps/v1/proxy/namespaces/default/deployments/foo/extra/path", want: &types.KubernetesResource{Kind: "deployments", Namespace: "default", Name: "foo", Verbs: []string{"proxy"}, APIGroup: "apps"}},
+		// A bare verb segment names no kind the cluster serves, so no RBAC resource
+		// is built and the forwarder denies the request.
+		{path: "/apis/apps/v1/proxy", want: nil},
 
 		// Statefulsets
 		{path: "/apis/apps/v1/statefulsets", want: &types.KubernetesResource{Kind: "statefulsets", Verbs: []string{"list"}, APIGroup: "apps"}},
@@ -369,6 +386,41 @@ func Test_getResourceFromRequest(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got.rbacResource(), "parsing path %q", tt.path)
+		})
+	}
+}
+
+// The special verb form takes its verb from the path rather than the HTTP method,
+// and is always enforced as a single resource.
+// Treating a name-less request as a list would skip the kubernetes_resources matcher.
+func TestGetResourceFromRequest_SpecialVerbProxyPath(t *testing.T) {
+	t.Parallel()
+	details := &kubeDetails{kubeCodecs: &globalKubeCodecs, rbacSupportedTypes: getRBACSupportedTypes(t)}
+
+	const (
+		named    = "/apis/apps/v1/proxy/namespaces/default/deployments/foo"
+		nameless = "/apis/apps/v1/proxy/namespaces/default/deployments"
+	)
+	tests := []struct {
+		method string
+		path   string
+	}{
+		{method: http.MethodGet, path: named},
+		{method: http.MethodPost, path: named},
+		{method: http.MethodPut, path: named},
+		{method: http.MethodPatch, path: named},
+		{method: http.MethodDelete, path: named},
+		{method: http.MethodGet, path: nameless},
+		{method: http.MethodDelete, path: nameless},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method+" "+tt.path, func(t *testing.T) {
+			got, err := getResourceFromRequest(&http.Request{Method: tt.method, URL: &url.URL{Path: tt.path}}, details)
+			require.NoError(t, err)
+			require.False(t, got.unsupportedResource)
+			require.False(t, got.isList)
+			require.Equal(t, types.KubeVerbProxy, got.verb)
 		})
 	}
 }

--- a/lib/kube/proxy/url_test.go
+++ b/lib/kube/proxy/url_test.go
@@ -124,12 +124,12 @@ func TestParseResourcePath(t *testing.T) {
 		{path: "/apis/resources.teleport.dev/v6/proxy/namespaces/default/teleportroles/telerole-1", want: apiResource{apiGroup: "resources.teleport.dev", apiGroupVersion: "v6", namespace: "default", resourceKind: "teleportroles", resourceName: "telerole-1", isProxyVerb: true}},
 		{path: "/apis/resources.teleport.dev/v6/proxy/namespaces/default/teleportroles", want: apiResource{apiGroup: "resources.teleport.dev", apiGroupVersion: "v6", namespace: "default", resourceKind: "teleportroles", isProxyVerb: true}},
 		{path: "/apis/resources.teleport.dev/v6/proxy/teleportroles/telerole-1", want: apiResource{apiGroup: "resources.teleport.dev", apiGroupVersion: "v6", resourceKind: "teleportroles", resourceName: "telerole-1", isProxyVerb: true}},
-		{path: "/apis/resources.teleport.dev/v6/proxy/namespaces/default/teleportroles/telerole-1/extra/path", want: apiResource{apiGroup: "resources.teleport.dev", apiGroupVersion: "v6", namespace: "default", resourceKind: "teleportroles/extra/path", resourceName: "telerole-1", isProxyVerb: true}},
+		{path: "/apis/resources.teleport.dev/v6/proxy/namespaces/default/teleportroles/telerole-1/extra/path", want: apiResource{apiGroup: "resources.teleport.dev", apiGroupVersion: "v6", namespace: "default", resourceKind: "teleportroles", resourceName: "telerole-1", isProxyVerb: true}},
 		{path: "/api/v1/proxy/namespaces/default/pods/foo", want: apiResource{apiGroup: "", apiGroupVersion: "v1", namespace: "default", resourceKind: "pods", resourceName: "foo", isProxyVerb: true}},
 		// The core API's proxyable kinds accept [scheme:]name[:port] here too,
 		// so the name is reduced the same way as in the subresource form above.
-		{path: "/api/v1/proxy/namespaces/default/services/https:admin:443/healthz", want: apiResource{apiGroup: "", apiGroupVersion: "v1", namespace: "default", resourceKind: "services/healthz", resourceName: "admin", isProxyVerb: true}},
-		{path: "/api/v1/proxy/nodes/https:node-1:10250/healthz", want: apiResource{apiGroup: "", apiGroupVersion: "v1", resourceKind: "nodes/healthz", resourceName: "node-1", isProxyVerb: true}},
+		{path: "/api/v1/proxy/namespaces/default/services/https:admin:443/healthz", want: apiResource{apiGroup: "", apiGroupVersion: "v1", namespace: "default", resourceKind: "services", resourceName: "admin", isProxyVerb: true}},
+		{path: "/api/v1/proxy/nodes/https:node-1:10250/healthz", want: apiResource{apiGroup: "", apiGroupVersion: "v1", resourceKind: "nodes", resourceName: "node-1", isProxyVerb: true}},
 		// Only those kinds: an aggregated API server gets the name segment verbatim,
 		// so reducing it would match a name the API server never sees.
 		{path: "/api/v1/proxy/namespaces/default/configmaps/https:admin:443", want: apiResource{apiGroup: "", apiGroupVersion: "v1", namespace: "default", resourceKind: "configmaps", resourceName: "https:admin:443", isProxyVerb: true}},
@@ -409,8 +409,9 @@ func TestGetResourceFromRequest_SpecialVerbProxyPath(t *testing.T) {
 	details := &kubeDetails{kubeCodecs: &globalKubeCodecs, rbacSupportedTypes: getRBACSupportedTypes(t)}
 
 	const (
-		named    = "/apis/apps/v1/proxy/namespaces/default/deployments/foo"
 		nameless = "/apis/apps/v1/proxy/namespaces/default/deployments"
+		named    = "/apis/apps/v1/proxy/namespaces/default/deployments/foo"
+		trailing = "/apis/apps/v1/proxy/namespaces/default/deployments/foo/extra/path"
 	)
 	tests := []struct {
 		method string
@@ -423,6 +424,8 @@ func TestGetResourceFromRequest_SpecialVerbProxyPath(t *testing.T) {
 		{method: http.MethodDelete, path: named},
 		{method: http.MethodGet, path: nameless},
 		{method: http.MethodDelete, path: nameless},
+		{method: http.MethodGet, path: trailing},
+		{method: http.MethodPost, path: trailing},
 	}
 
 	for _, tt := range tests {
@@ -432,6 +435,7 @@ func TestGetResourceFromRequest_SpecialVerbProxyPath(t *testing.T) {
 			require.False(t, got.unsupportedResource)
 			require.False(t, got.isList)
 			require.Equal(t, types.KubeVerbProxy, got.verb)
+			require.Equal(t, "deployments", got.requestedResource.resourceKind)
 		})
 	}
 }


### PR DESCRIPTION
Closes #69081

Kubernetes lets the verb come first in the URL: `/apis/{group}/{version}/proxy/namespaces/{ns}/{kind}/{name}`.
Kubernetes apiserver reads `proxy` as the verb and parses the rest as a normal resource path. Our `parseResourcePath` func didn't.

The fix is taking the verb from the path like the API server does, mapping it to `KubeVerbProxy`, and parsing the rest as a normal resource path.

Review turned up four more parser problems, each fixed in its own commit:

- `.` and `..` segments get a 400. We parsed the cleaned path but forwarded the raw one.
- `[scheme:]name[:port]` is reduced to the bare name for core `pods`, `services` and `nodes`, so deny rules still match.
- Segments after the name are dropped, matching upstream. Fixes the kind in audit events and error messages.
- `watch` and `proxy` share one length check. A bare `/api/v1/watch` is denied instead of forwarded unenforced.

## Why it broke now

With #67801, the forwarder stopped forwarding unknown kinds and started returning `NotFound`. It was backported to v18 as #68100.
The parsing code was already broken, but it had no effect because the forwarder passed unknown kinds through before #67801.

<!-- Provide a descriptive entry for the changelog of the next release. -->

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Kind (Kubernetes v1.35.0), `teleport-cluster` chart, enterprise binaries built from this branch. An aggregated APIService backed by a small in-cluster HTTPS server gives the proxy path a real backend. Two users whose roles differ only by the `proxy` verb. Before and after compared on the same cluster by swapping in a binary built with `master`'s `url.go`.

### Test Cases
- [x] With the `proxy` verb on a custom API group, `GET /apis/{group}/{version}/proxy/namespaces/{ns}/{kind}/{name}` reaches the API server (404 before this change)
- [x] Same request without the `proxy` verb is denied with 403
- [x] A websocket upgrade over the proxy path completes end to end (`101`; `404` before this change)
- [x] The audit event records the kind and name the path targets
- [x] `pods/{name}/proxy`, `services/{name}/proxy` and `nodes/{name}/proxy` still require the `proxy` verb
- [x] `/api/v1/watch/namespaces/{ns}/pods` still enforces the `watch` verb
- [x] Ordinary `kubectl get`/`list`/`logs` and `SelfSubjectAccessReview` behave as before
- [x] `[scheme:]name[:port]` on a core proxy path is reduced, so a deny rule naming the resource still matches
- [x] A path with a `.` or `..` segment gets a 400, while `//` is unaffected
- [x] A proxy request with trailing segments records the base kind in the audit event and error message
- [x] A bare `/api/v1/watch` is denied
