### PR TITLE
[v18] Ensure IAC and tctl cannot create scoped apps 

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -7620,6 +7620,9 @@ func (a *Server) IterateResources(ctx context.Context, req proto.ListResourcesRe
 
 // CreateApp creates a new application resource.
 func (a *Server) CreateApp(ctx context.Context, app types.Application) error {
+	if err := services.EnsureNotScopedApp(app); err != nil {
+		return trace.Wrap(err)
+	}
 	if err := a.Services.CreateApp(ctx, app); err != nil {
 		return trace.Wrap(err)
 	}
@@ -7646,6 +7649,12 @@ func (a *Server) CreateApp(ctx context.Context, app types.Application) error {
 
 // UpdateApp updates an existing application resource.
 func (a *Server) UpdateApp(ctx context.Context, app types.Application) error {
+	// TODO (williamo/scopes): While a blanket deny is fine for update for now,
+	// when scoped dynamic app registration is supported, we must check whether
+	// the updated scope differs or not, and reject if different.
+	if err := services.EnsureNotScopedApp(app); err != nil {
+		return trace.Wrap(err)
+	}
 	if err := a.Services.UpdateApp(ctx, app); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -7506,6 +7506,10 @@ func (a *ServerWithRoles) CreateApp(ctx context.Context, app types.Application) 
 	if err := a.authorizeAction(types.KindApp, types.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
+	// Reject scoped apps before the rest of validation
+	if err := services.EnsureNotScopedApp(app); err != nil {
+		return trace.Wrap(err)
+	}
 	// Don't allow users create apps they wouldn't have access to (e.g.
 	// non-matching labels).
 	if err := a.checkAccessToApp(app); err != nil {
@@ -7524,6 +7528,13 @@ func (a *ServerWithRoles) CreateApp(ctx context.Context, app types.Application) 
 // UpdateApp updates existing application resource.
 func (a *ServerWithRoles) UpdateApp(ctx context.Context, app types.Application) error {
 	if err := a.authorizeAction(types.KindApp, types.VerbUpdate); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// TODO (williamo/scopes): While a blanket deny is fine for update for now,
+	// when scoped dynamic app registration is supported, we must check whether
+	// the updated scope differs or not, and reject if different.
+	if err := services.EnsureNotScopedApp(app); err != nil {
 		return trace.Wrap(err)
 	}
 	// Don't allow users update apps they don't have access to (e.g.

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -7510,6 +7510,9 @@ func (a *ServerWithRoles) CreateApp(ctx context.Context, app types.Application) 
 	if err := services.EnsureNotScopedApp(app); err != nil {
 		return trace.Wrap(err)
 	}
+	if err := services.ValidateApp(app, a.authServer); err != nil {
+		return trace.Wrap(err)
+	}
 	// Don't allow users create apps they wouldn't have access to (e.g.
 	// non-matching labels).
 	if err := a.checkAccessToApp(app); err != nil {
@@ -7535,6 +7538,9 @@ func (a *ServerWithRoles) UpdateApp(ctx context.Context, app types.Application) 
 	// when scoped dynamic app registration is supported, we must check whether
 	// the updated scope differs or not, and reject if different.
 	if err := services.EnsureNotScopedApp(app); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := services.ValidateApp(app, a.authServer); err != nil {
 		return trace.Wrap(err)
 	}
 	// Don't allow users update apps they don't have access to (e.g.

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -4307,6 +4307,21 @@ func TestApps(t *testing.T) {
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
 	))
 
+	// Clients can't create/update scoped apps right now.
+	// TODO (williamo/scopes) - delete this check when dynamic scoped app registration is supported.
+	scopedApp := adminApp.Copy()
+	scopedApp.SetName("scoped")
+	scopedApp.Scope = "/prod"
+	err = adminClt.CreateApp(ctx, scopedApp)
+	require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+	require.ErrorContains(t, err, "dynamic registration of scoped applications is not supported")
+
+	scopedAdminApp := adminApp.Copy()
+	scopedAdminApp.Scope = "/prod"
+	err = adminClt.UpdateApp(ctx, scopedAdminApp)
+	require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+	require.ErrorContains(t, err, "dynamic registration of scoped applications is not supported")
+
 	// Clients can't create/update apps for the beams service.
 	adminApp.GetMetadata().Labels["teleport.internal/beams/app-type"] = "llm"
 	err = adminClt.UpdateApp(ctx, adminApp)

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -4296,15 +4296,6 @@ func (g *GRPCServer) CreateApp(ctx context.Context, app *types.AppV3) (*emptypb.
 	if app.Origin() == "" {
 		app.SetOrigin(types.OriginDynamic)
 	}
-	// Reject scoped apps before app validation.
-	// TODO(williamo/scopes): master branch validates in ServerWithRoles/Server rather
-	// than here, delete this once the changes in master are backported.
-	if err := services.EnsureNotScopedApp(app); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if err := services.ValidateApp(app, auth); err != nil {
-		return nil, trace.Wrap(err)
-	}
 	if err := auth.CreateApp(ctx, app); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -4320,15 +4311,7 @@ func (g *GRPCServer) UpdateApp(ctx context.Context, app *types.AppV3) (*emptypb.
 	if app.Origin() == "" {
 		app.SetOrigin(types.OriginDynamic)
 	}
-	// Reject scoped apps before app validation.
-	// TODO(williamo/scopes): master branch validates in ServerWithRoles/Server rather
-	// than here, delete this once the changes in master are backported.
-	if err := services.EnsureNotScopedApp(app); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if err := services.ValidateApp(app, auth); err != nil {
-		return nil, trace.Wrap(err)
-	}
+
 	if err := auth.UpdateApp(ctx, app); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -4296,6 +4296,12 @@ func (g *GRPCServer) CreateApp(ctx context.Context, app *types.AppV3) (*emptypb.
 	if app.Origin() == "" {
 		app.SetOrigin(types.OriginDynamic)
 	}
+	// Reject scoped apps before app validation.
+	// TODO(williamo/scopes): master branch validates in ServerWithRoles/Server rather
+	// than here, delete this once the changes in master are backported.
+	if err := services.EnsureNotScopedApp(app); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	if err := services.ValidateApp(app, auth); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -4313,6 +4319,12 @@ func (g *GRPCServer) UpdateApp(ctx context.Context, app *types.AppV3) (*emptypb.
 	}
 	if app.Origin() == "" {
 		app.SetOrigin(types.OriginDynamic)
+	}
+	// Reject scoped apps before app validation.
+	// TODO(williamo/scopes): master branch validates in ServerWithRoles/Server rather
+	// than here, delete this once the changes in master are backported.
+	if err := services.EnsureNotScopedApp(app); err != nil {
+		return nil, trace.Wrap(err)
 	}
 	if err := services.ValidateApp(app, auth); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -99,7 +99,20 @@ type ApplicationsInternal interface {
 	) ([]backend.ConditionalAction, error)
 }
 
-// ValidateApp validates the Application resource.
+// TODO(williamo/scopes): remove once dynamic scoped app registration is
+// supported.
+func EnsureNotScopedApp(app types.Application) error {
+	if app == nil {
+		return trace.BadParameter("nil application")
+	}
+	if scope := app.GetScope(); scope != "" {
+		return trace.BadParameter("application %q cannot be created with scope %q: dynamic registration of scoped applications is not supported, remove the scope attribute", app.GetName(), scope)
+	}
+	return nil
+}
+
+// ValidateApp checks an Application's name, public_addr, and
+// required_apps.
 func ValidateApp(app types.Application, proxyGetter ProxyGetter) error {
 	if app == nil {
 		return trace.BadParameter("nil application")


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/69076



<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster, agents, docker apps

### Test Cases
- [x] Ensure users cannot create scoped apps via terraform, tctl, k8s
