### PR TITLE
Adding unpinned reads and watcher exceptions for locks and cluster-level resources

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1358,6 +1358,18 @@ func unscopedWatchKindException(kind string) (ura services.UnpinnedReadAuthoriza
 		return services.UnpinnedReadCertAuthority, true
 	case types.KindSPIFFEFederation:
 		return services.UnpinnedReadSPIFFEFederation, true
+	case types.KindLock:
+		return services.UnpinnedReadLock, true
+	case types.KindClusterName:
+		return services.UnpinnedReadClusterName, true
+	case types.KindClusterNetworkingConfig:
+		return services.UnpinnedReadClusterNetworkingConfig, true
+	case types.KindClusterAuthPreference:
+		return services.UnpinnedReadAuthPreference, true
+	case types.KindClusterAuditConfig:
+		return services.UnpinnedReadClusterAuditConfig, true
+	case types.KindSessionRecordingConfig:
+		return services.UnpinnedReadSessionRecordingConfig, true
 	default:
 		return services.UnpinnedReadAuthorization{}, false
 	}
@@ -5944,9 +5956,14 @@ func (a *ServerWithRoles) DeleteAllInstallers(ctx context.Context) error {
 }
 
 // GetClusterAuditConfig gets cluster audit configuration.
-func (a *ServerWithRoles) GetClusterAuditConfig(ctx context.Context) (types.ClusterAuditConfig, error) {
-	if err := a.authorizeAction(types.KindClusterAuditConfig, types.VerbRead); err != nil {
-		if err2 := a.authorizeAction(types.KindClusterConfig, types.VerbRead); err2 != nil {
+func (a *ScopedServerWithRoles) GetClusterAuditConfig(ctx context.Context) (types.ClusterAuditConfig, error) {
+	ruleCtx := a.scopedContext.RuleContext()
+	if err := a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadClusterAuditConfig, &ruleCtx); err != nil {
+		unscopedCtx, isUnscoped := a.scopedContext.UnscopedContext()
+		if !isUnscoped {
+			return nil, trace.Wrap(err)
+		}
+		if err2 := unscopedCtx.CheckAccessToKind(types.KindClusterConfig, types.VerbRead); err2 != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -7310,24 +7327,27 @@ func (a *ServerWithRoles) SearchSessionEvents(ctx context.Context, req events.Se
 }
 
 // GetLock gets a lock by name.
-func (a *ServerWithRoles) GetLock(ctx context.Context, name string) (types.Lock, error) {
-	if err := a.authorizeAction(types.KindLock, types.VerbRead); err != nil {
+func (a *ScopedServerWithRoles) GetLock(ctx context.Context, name string) (types.Lock, error) {
+	ruleCtx := a.scopedContext.RuleContext()
+	if err := a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadLock, &ruleCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.GetLock(ctx, name)
 }
 
 // GetLocks gets all/in-force locks that match at least one of the targets when specified.
-func (a *ServerWithRoles) GetLocks(ctx context.Context, inForceOnly bool, targets ...types.LockTarget) ([]types.Lock, error) {
-	if err := a.authorizeAction(types.KindLock, types.VerbList, types.VerbRead); err != nil {
+func (a *ScopedServerWithRoles) GetLocks(ctx context.Context, inForceOnly bool, targets ...types.LockTarget) ([]types.Lock, error) {
+	ruleCtx := a.scopedContext.RuleContext()
+	if err := a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadAndListLock, &ruleCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.Cache.GetLocks(ctx, inForceOnly, targets...)
 }
 
 // ListLocks returns a page of locks
-func (a *ServerWithRoles) ListLocks(ctx context.Context, limit int, startKey string, filter *types.LockFilter) ([]types.Lock, string, error) {
-	if err := a.authorizeAction(types.KindLock, types.VerbList, types.VerbRead); err != nil {
+func (a *ScopedServerWithRoles) ListLocks(ctx context.Context, limit int, startKey string, filter *types.LockFilter) ([]types.Lock, string, error) {
+	ruleCtx := a.scopedContext.RuleContext()
+	if err := a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadAndListLock, &ruleCtx); err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -2493,6 +2493,32 @@ func TestClusterNetworkingConfigScopedRead(t *testing.T) {
 	require.Empty(t, cmp.Diff(netConfig, nc))
 }
 
+func TestClusterAuditConfigScopedRead(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir: t.TempDir(),
+		ScopesFeatures: scopes.Features{
+			Enabled:         true,
+			AgentPinEnabled: true,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+
+	auditConfig := types.DefaultClusterAuditConfig()
+	_, err = as.AuthServer.UpsertClusterAuditConfig(ctx, auditConfig)
+	require.NoError(t, err)
+
+	const hostID = "testhost"
+	const scope = "/aa/bb"
+	srv := newScopePinnedTestServerForHost(t, as, hostID, scope, types.RoleNode)
+	ac, err := srv.GetClusterAuditConfig(ctx)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(auditConfig, ac))
+}
+
 func TestSessionRecordingConfigRBAC(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -4812,7 +4838,7 @@ func TestKindClusterConfig(t *testing.T) {
 			srv.AuditLog,
 			*authContext,
 		)
-		_, err1 := s.GetClusterAuditConfig(ctx)
+		_, err1 := s.ScopedServerWithRoles().GetClusterAuditConfig(ctx)
 		_, err2 := s.ScopedServerWithRoles().GetClusterNetworkingConfig(ctx)
 		_, err3 := s.ScopedServerWithRoles().GetSessionRecordingConfig(ctx)
 		return []error{err1, err2, err3}

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -3918,11 +3918,11 @@ func (g *GRPCServer) DeleteAllNodes(ctx context.Context, req *types.ResourcesInN
 
 // GetClusterAuditConfig gets cluster audit configuration.
 func (g *GRPCServer) GetClusterAuditConfig(ctx context.Context, _ *emptypb.Empty) (*types.ClusterAuditConfigV2, error) {
-	auth, err := g.authenticate(ctx)
+	auth, err := g.scopedAuthenticate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	auditConfig, err := auth.ServerWithRoles.GetClusterAuditConfig(ctx)
+	auditConfig, err := auth.ScopedServerWithRoles.GetClusterAuditConfig(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -4163,7 +4163,7 @@ func (g *GRPCServer) GetSessionEvents(ctx context.Context, req *authpb.GetSessio
 
 // GetLock retrieves a lock by name.
 func (g *GRPCServer) GetLock(ctx context.Context, req *authpb.GetLockRequest) (*types.LockV2, error) {
-	auth, err := g.authenticate(ctx)
+	auth, err := g.scopedAuthenticate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -4180,7 +4180,7 @@ func (g *GRPCServer) GetLock(ctx context.Context, req *authpb.GetLockRequest) (*
 
 // GetLocks gets all/in-force locks that match at least one of the targets when specified.
 func (g *GRPCServer) GetLocks(ctx context.Context, req *authpb.GetLocksRequest) (*authpb.GetLocksResponse, error) {
-	auth, err := g.authenticate(ctx)
+	auth, err := g.scopedAuthenticate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -4209,7 +4209,7 @@ func (g *GRPCServer) GetLocks(ctx context.Context, req *authpb.GetLocksRequest) 
 
 // ListLocks returns a page of locks matching a filter
 func (g *GRPCServer) ListLocks(ctx context.Context, req *authpb.ListLocksRequest) (*authpb.ListLocksResponse, error) {
-	auth, err := g.authenticate(ctx)
+	auth, err := g.scopedAuthenticate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -3713,10 +3713,21 @@ func TestLocksCRUD(t *testing.T) {
 		return filter
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	srv := newTestTLSServer(t)
 
 	clt, err := srv.NewClient(authtest.TestAdmin())
+	require.NoError(t, err)
+
+	clusterName, err := srv.Auth().GetClusterName(ctx)
+	require.NoError(t, err)
+
+	const (
+		scope        = "/aa"
+		scopedHostID = "scoped-host"
+	)
+
+	scopedClient, err := srv.NewClient(authtest.TestScopePinnedHost(clusterName.GetClusterName(), scopedHostID, scope, types.RoleNode))
 	require.NoError(t, err)
 
 	now := srv.Clock().Now()
@@ -3756,145 +3767,154 @@ func TestLocksCRUD(t *testing.T) {
 
 	// Run LockGetters in nested subtests to allow parallelization.
 	t.Run("LockGetters", func(t *testing.T) {
-		t.Run("GetLocks", func(t *testing.T) {
-			t.Parallel()
-			locks, err := clt.GetLocks(ctx, false)
-			require.NoError(t, err)
-			require.Len(t, locks, 2)
-			require.Empty(t, cmp.Diff([]types.Lock{lock1, lock2}, locks,
-				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
-		})
-		t.Run("ListLocks", func(t *testing.T) {
-			t.Parallel()
-			locks, next, err := clt.ListLocks(ctx, 0, "", nil)
-			require.Empty(t, next)
-			require.NoError(t, err)
-			require.Len(t, locks, 2)
-			require.Empty(t, cmp.Diff([]types.Lock{lock1, lock2}, locks,
-				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+		for _, clt := range []*authclient.Client{clt, scopedClient} {
+			makeTestName := func(name string) string {
+				if clt == scopedClient {
+					return name + " - scoped"
+				}
+				return name
+			}
+			t.Run(makeTestName("GetLocks"), func(t *testing.T) {
+				t.Parallel()
+				locks, err := clt.GetLocks(ctx, false)
+				require.NoError(t, err)
+				require.Len(t, locks, 2)
+				require.Empty(t, cmp.Diff([]types.Lock{lock1, lock2}, locks,
+					cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+			})
+			t.Run(makeTestName("ListLocks"), func(t *testing.T) {
+				t.Parallel()
+				locks, next, err := clt.ListLocks(ctx, 0, "", nil)
+				require.Empty(t, next)
+				require.NoError(t, err)
+				require.Len(t, locks, 2)
+				require.Empty(t, cmp.Diff([]types.Lock{lock1, lock2}, locks,
+					cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-			page1, page2Start, err := clt.ListLocks(ctx, 1, "", nil)
-			require.NotEmpty(t, page2Start)
-			require.NoError(t, err)
-			require.Len(t, page1, 1)
-			require.Empty(t, cmp.Diff([]types.Lock{lock1}, page1,
-				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+				page1, page2Start, err := clt.ListLocks(ctx, 1, "", nil)
+				require.NotEmpty(t, page2Start)
+				require.NoError(t, err)
+				require.Len(t, page1, 1)
+				require.Empty(t, cmp.Diff([]types.Lock{lock1}, page1,
+					cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-			page2, next, err := clt.ListLocks(ctx, 0, page2Start, nil)
-			require.Empty(t, next)
-			require.NoError(t, err)
-			require.Len(t, page2, 1)
-			require.Empty(t, cmp.Diff([]types.Lock{lock2}, page2,
-				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+				page2, next, err := clt.ListLocks(ctx, 0, page2Start, nil)
+				require.Empty(t, next)
+				require.NoError(t, err)
+				require.Len(t, page2, 1)
+				require.Empty(t, cmp.Diff([]types.Lock{lock2}, page2,
+					cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-			require.Empty(t, cmp.Diff([]types.Lock{lock1, lock2}, append(page1, page2...),
-				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
-		})
-		t.Run("RangeLocks", func(t *testing.T) {
-			t.Parallel()
-			locks, err := iterstream.Collect(clt.RangeLocks(ctx, "", "", nil))
-			require.NoError(t, err)
-			require.Len(t, locks, 2)
-			require.Empty(t, cmp.Diff([]types.Lock{lock1, lock2}, locks,
-				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+				require.Empty(t, cmp.Diff([]types.Lock{lock1, lock2}, append(page1, page2...),
+					cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+			})
+			t.Run(makeTestName("RangeLocks"), func(t *testing.T) {
+				t.Parallel()
+				locks, err := iterstream.Collect(clt.RangeLocks(ctx, "", "", nil))
+				require.NoError(t, err)
+				require.Len(t, locks, 2)
+				require.Empty(t, cmp.Diff([]types.Lock{lock1, lock2}, locks,
+					cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-			_, page2Start, _ := clt.ListLocks(ctx, 1, "", nil)
+				_, page2Start, _ := clt.ListLocks(ctx, 1, "", nil)
 
-			page1, err := iterstream.Collect(clt.RangeLocks(ctx, "", page2Start, nil))
-			require.NoError(t, err)
-			require.Len(t, page1, 1)
-			require.Empty(t, cmp.Diff([]types.Lock{lock1}, page1,
-				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+				page1, err := iterstream.Collect(clt.RangeLocks(ctx, "", page2Start, nil))
+				require.NoError(t, err)
+				require.Len(t, page1, 1)
+				require.Empty(t, cmp.Diff([]types.Lock{lock1}, page1,
+					cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-			page2, err := iterstream.Collect(clt.RangeLocks(ctx, page2Start, "", nil))
-			require.NoError(t, err)
-			require.Len(t, page2, 1)
-			require.Empty(t, cmp.Diff([]types.Lock{lock2}, page2,
-				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
-		})
-		t.Run("GetLocks with targets", func(t *testing.T) {
-			t.Parallel()
-			// Match both locks with the targets.
-			locks, err := clt.GetLocks(ctx, false, lock1.Target(), lock2.Target())
-			require.NoError(t, err)
-			require.Len(t, locks, 2)
-			require.Empty(t, cmp.Diff([]types.Lock{lock1, lock2}, locks,
-				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+				page2, err := iterstream.Collect(clt.RangeLocks(ctx, page2Start, "", nil))
+				require.NoError(t, err)
+				require.Len(t, page2, 1)
+				require.Empty(t, cmp.Diff([]types.Lock{lock2}, page2,
+					cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+			})
+			t.Run(makeTestName("GetLocks with targets"), func(t *testing.T) {
+				t.Parallel()
+				// Match both locks with the targets.
+				locks, err := clt.GetLocks(ctx, false, lock1.Target(), lock2.Target())
+				require.NoError(t, err)
+				require.Len(t, locks, 2)
+				require.Empty(t, cmp.Diff([]types.Lock{lock1, lock2}, locks,
+					cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-			// Match only one of the locks.
-			roleTarget := types.LockTarget{Role: "role-A"}
-			locks, err = clt.GetLocks(ctx, false, lock1.Target(), roleTarget)
-			require.NoError(t, err)
-			require.Len(t, locks, 1)
-			require.Empty(t, cmp.Diff([]types.Lock{lock1}, locks,
-				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+				// Match only one of the locks.
+				roleTarget := types.LockTarget{Role: "role-A"}
+				locks, err = clt.GetLocks(ctx, false, lock1.Target(), roleTarget)
+				require.NoError(t, err)
+				require.Len(t, locks, 1)
+				require.Empty(t, cmp.Diff([]types.Lock{lock1}, locks,
+					cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-			// Match none of the locks.
-			locks, err = clt.GetLocks(ctx, false, roleTarget)
-			require.NoError(t, err)
-			require.Empty(t, locks)
-		})
+				// Match none of the locks.
+				locks, err = clt.GetLocks(ctx, false, roleTarget)
+				require.NoError(t, err)
+				require.Empty(t, locks)
+			})
 
-		t.Run("ListLocks with targets", func(t *testing.T) {
-			t.Parallel()
-			// Match both locks with the targets.
-			locks, next, err := clt.ListLocks(ctx, 0, "", newLockFilter(false, lock1.Target(), lock2.Target()))
-			require.NoError(t, err)
-			require.Empty(t, next)
-			require.Len(t, locks, 2)
-			require.Empty(t, cmp.Diff([]types.Lock{lock1, lock2}, locks,
-				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+			t.Run(makeTestName("ListLocks with targets"), func(t *testing.T) {
+				t.Parallel()
+				// Match both locks with the targets.
+				locks, next, err := clt.ListLocks(ctx, 0, "", newLockFilter(false, lock1.Target(), lock2.Target()))
+				require.NoError(t, err)
+				require.Empty(t, next)
+				require.Len(t, locks, 2)
+				require.Empty(t, cmp.Diff([]types.Lock{lock1, lock2}, locks,
+					cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-			// Match only one of the locks.
-			roleTarget := types.LockTarget{Role: "role-A"}
-			locks, next, err = clt.ListLocks(ctx, 0, "", newLockFilter(false, lock1.Target(), roleTarget))
-			require.NoError(t, err)
-			require.Empty(t, next)
-			require.Len(t, locks, 1)
-			require.Empty(t, cmp.Diff([]types.Lock{lock1}, locks,
-				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+				// Match only one of the locks.
+				roleTarget := types.LockTarget{Role: "role-A"}
+				locks, next, err = clt.ListLocks(ctx, 0, "", newLockFilter(false, lock1.Target(), roleTarget))
+				require.NoError(t, err)
+				require.Empty(t, next)
+				require.Len(t, locks, 1)
+				require.Empty(t, cmp.Diff([]types.Lock{lock1}, locks,
+					cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-			// Match none of the locks.
-			locks, next, err = clt.ListLocks(ctx, 0, "", newLockFilter(false, roleTarget))
-			require.NoError(t, err)
-			require.Empty(t, next)
-			require.Empty(t, locks)
-		})
-		t.Run("RangeLocks with targets", func(t *testing.T) {
-			t.Parallel()
-			// Match both locks with the targets.
-			locks, err := iterstream.Collect(clt.RangeLocks(ctx, "", "", newLockFilter(false, lock1.Target(), lock2.Target())))
-			require.NoError(t, err)
-			require.Len(t, locks, 2)
-			require.Empty(t, cmp.Diff([]types.Lock{lock1, lock2}, locks,
-				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+				// Match none of the locks.
+				locks, next, err = clt.ListLocks(ctx, 0, "", newLockFilter(false, roleTarget))
+				require.NoError(t, err)
+				require.Empty(t, next)
+				require.Empty(t, locks)
+			})
+			t.Run(makeTestName("RangeLocks with targets"), func(t *testing.T) {
+				t.Parallel()
+				// Match both locks with the targets.
+				locks, err := iterstream.Collect(clt.RangeLocks(ctx, "", "", newLockFilter(false, lock1.Target(), lock2.Target())))
+				require.NoError(t, err)
+				require.Len(t, locks, 2)
+				require.Empty(t, cmp.Diff([]types.Lock{lock1, lock2}, locks,
+					cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-			// Match only one of the locks.
-			roleTarget := types.LockTarget{Role: "role-A"}
-			locks, err = iterstream.Collect(clt.RangeLocks(ctx, "", "", newLockFilter(false, lock1.Target(), roleTarget)))
-			require.NoError(t, err)
-			require.Len(t, locks, 1)
-			require.Empty(t, cmp.Diff([]types.Lock{lock1}, locks,
-				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+				// Match only one of the locks.
+				roleTarget := types.LockTarget{Role: "role-A"}
+				locks, err = iterstream.Collect(clt.RangeLocks(ctx, "", "", newLockFilter(false, lock1.Target(), roleTarget)))
+				require.NoError(t, err)
+				require.Len(t, locks, 1)
+				require.Empty(t, cmp.Diff([]types.Lock{lock1}, locks,
+					cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-			// Match none of the locks.
-			locks, err = iterstream.Collect(clt.RangeLocks(ctx, "", "", newLockFilter(false, roleTarget)))
-			require.NoError(t, err)
-			require.Empty(t, locks)
-		})
-		t.Run("GetLock", func(t *testing.T) {
-			t.Parallel()
-			// Get one of the locks.
-			lock, err := clt.GetLock(ctx, lock1.GetName())
-			require.NoError(t, err)
-			require.Empty(t, cmp.Diff(lock1, lock,
-				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+				// Match none of the locks.
+				locks, err = iterstream.Collect(clt.RangeLocks(ctx, "", "", newLockFilter(false, roleTarget)))
+				require.NoError(t, err)
+				require.Empty(t, locks)
+			})
 
-			// Attempt to get a nonexistent lock.
-			_, err = clt.GetLock(ctx, "lock3")
-			require.Error(t, err)
-			require.True(t, trace.IsNotFound(err))
-		})
+			t.Run("GetLock", func(t *testing.T) {
+				t.Parallel()
+				// Get one of the locks.
+				lock, err := clt.GetLock(ctx, lock1.GetName())
+				require.NoError(t, err)
+				require.Empty(t, cmp.Diff(lock1, lock,
+					cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+
+				// Attempt to get a nonexistent lock.
+				_, err = clt.GetLock(ctx, "lock3")
+				require.Error(t, err)
+				require.True(t, trace.IsNotFound(err))
+			})
+		}
 	})
 
 	t.Run("UpsertLock", func(t *testing.T) {

--- a/lib/services/scoped_access_checker_context.go
+++ b/lib/services/scoped_access_checker_context.go
@@ -675,4 +675,25 @@ var (
 		kind:          types.KindRole,
 		verbs:         []scopedaccess.Verb{scopedaccess.Read},
 	}
+	// UnpinnedReadAndListLock is a special authorization to complete an unscoped access check
+	// to read a lock.
+	UnpinnedReadAndListLock = UnpinnedReadAuthorization{
+		resourceScope: scopes.Root,
+		kind:          types.KindLock,
+		verbs:         []scopedaccess.Verb{scopedaccess.List, scopedaccess.Read},
+	}
+	// UnpinnedReadLock is a special authorization to complete an unscoped access check
+	// to read a lock.
+	UnpinnedReadLock = UnpinnedReadAuthorization{
+		resourceScope: scopes.Root,
+		kind:          types.KindLock,
+		verbs:         []scopedaccess.Verb{scopedaccess.Read},
+	}
+	// UnpinnedReadClusterAuditConfig is a special authorization to complete an unscoped access check
+	// to read a cluster audit config.
+	UnpinnedReadClusterAuditConfig = UnpinnedReadAuthorization{
+		resourceScope: scopes.Root,
+		kind:          types.KindClusterAuditConfig,
+		verbs:         []scopedaccess.Verb{scopedaccess.Read},
+	}
 )


### PR DESCRIPTION
Allows for unpinned reads of `Lock` and `ClusterAuditConfig` resources. These, along with some other cluster-level resources I missed in earlier PRs, will also be added to the list of unscoped exception kinds when creating watchers with a scoped identity.
<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local teleport cluster with scopes enabled and a scoped kube agent connected
### Test Cases
- [x] When the scoped kube agent starts, there are no errors about creating lock watchers
- [x] When the scoped kube agent starts, there are no warnings that the cache could not be created for `cluster_name`, `cluster_networking_config`, `cluster_auth_preference`, `cluster_audit_config`, or `session_recording_config`
