### PR TITLE
Deflake TestIntegrations/DiscoveryRecovers

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3943,7 +3943,7 @@ func testDiscoveryRecovers(t *testing.T, suite *integrationTestSuite) {
 			Name:              name,
 			DisableWebService: true,
 		}
-		newConfig.SSHAddr = helpers.NewListenerOn(t, main.Hostname, service.ListenerNodeSSH, &newConfig.FileDescriptors)
+		newConfig.SSHAddr = helpers.NewListenerOn(t, main.Hostname, service.ListenerProxySSH, &newConfig.FileDescriptors)
 		newConfig.WebAddr = helpers.NewListenerOn(t, main.Hostname, service.ListenerProxyWeb, &newConfig.FileDescriptors)
 		newConfig.ReverseTunnelAddr = helpers.NewListenerOn(t, main.Hostname, service.ListenerProxyTunnel, &newConfig.FileDescriptors)
 		reverseTunnelAddr = newConfig.ReverseTunnelAddr
@@ -4074,7 +4074,7 @@ func testDiscovery(t *testing.T, suite *integrationTestSuite) {
 		Name:              "cluster-main-proxy",
 		DisableWebService: true,
 	}
-	proxyConfig.SSHAddr = helpers.NewListenerOn(t, main.Hostname, service.ListenerNodeSSH, &proxyConfig.FileDescriptors)
+	proxyConfig.SSHAddr = helpers.NewListenerOn(t, main.Hostname, service.ListenerProxySSH, &proxyConfig.FileDescriptors)
 	proxyConfig.WebAddr = helpers.NewListenerOn(t, main.Hostname, service.ListenerProxyWeb, &proxyConfig.FileDescriptors)
 	proxyConfig.ReverseTunnelAddr = helpers.NewListenerOn(t, main.Hostname, service.ListenerProxyTunnel, &proxyConfig.FileDescriptors)
 
@@ -4206,7 +4206,7 @@ func testReverseTunnelCollapse(t *testing.T, suite *integrationTestSuite) {
 		DisableWebInterface:    true,
 		DisableALPNSNIListener: true,
 	}
-	proxyConfig.SSHAddr = helpers.NewListener(t, service.ListenerNodeSSH, &proxyConfig.FileDescriptors)
+	proxyConfig.SSHAddr = helpers.NewListener(t, service.ListenerProxySSH, &proxyConfig.FileDescriptors)
 	proxyConfig.WebAddr = helpers.NewListener(t, service.ListenerProxyWeb, &proxyConfig.FileDescriptors)
 	proxyConfig.ReverseTunnelAddr = helpers.NewListener(t, service.ListenerProxyTunnel, &proxyConfig.FileDescriptors)
 
@@ -4355,7 +4355,7 @@ func testDiscoveryNode(t *testing.T, suite *integrationTestSuite) {
 		Name:              "cluster-main-proxy",
 		DisableWebService: true,
 	}
-	proxyConfig.SSHAddr = helpers.NewListenerOn(t, main.Hostname, service.ListenerNodeSSH, &proxyConfig.FileDescriptors)
+	proxyConfig.SSHAddr = helpers.NewListenerOn(t, main.Hostname, service.ListenerProxySSH, &proxyConfig.FileDescriptors)
 	proxyConfig.WebAddr = helpers.NewListenerOn(t, main.Hostname, service.ListenerProxyWeb, &proxyConfig.FileDescriptors)
 	proxyConfig.ReverseTunnelAddr = helpers.NewListenerOn(t, main.Hostname, service.ListenerProxyTunnel, &proxyConfig.FileDescriptors)
 

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -3000,7 +3000,7 @@ func testExecNoAuth(t *testing.T, suite *KubeSuite) {
 		DisableWebService:      true,
 		DisableALPNSNIListener: true,
 	}
-	proxyConfig.SSHAddr = helpers.NewListenerOn(t, teleport.Hostname, service.ListenerNodeSSH, &proxyConfig.FileDescriptors)
+	proxyConfig.SSHAddr = helpers.NewListenerOn(t, teleport.Hostname, service.ListenerProxySSH, &proxyConfig.FileDescriptors)
 	proxyConfig.WebAddr = helpers.NewListenerOn(t, teleport.Hostname, service.ListenerProxyWeb, &proxyConfig.FileDescriptors)
 	proxyConfig.KubeAddr = helpers.NewListenerOn(t, teleport.Hostname, service.ListenerProxyKube, &proxyConfig.FileDescriptors)
 	proxyConfig.ReverseTunnelAddr = helpers.NewListenerOn(t, teleport.Hostname, service.ListenerProxyTunnel, &proxyConfig.FileDescriptors)


### PR DESCRIPTION
Our integration tests pre-bind ports and inject them into the Teleport process as file descriptors so that the subprocess doesn't have to bind itself.

Several tests were defeating this mechanism by tagging the proxy's SSH port with the wrong type (node SSH instead of proxy SSH). As a result, the pre-bound FD was closed and a new ephemeral port is bound from scratch. This creates a small window where some other parallel test can claim the port that was intended for this test.

You can see this in the output of the failed runs:

    Closing imported but unused descriptor.   type=node       addr=localhost:39923
    Setting up Proxy listeners
    Service is creating new listener.         type=proxy:ssh  addr=localhost:39923
    Teleport process has exited with error    listen tcp 127.0.0.1:39923: bind: address already in use

TestIntegrations/Discovery recovers starts 8 proxies, so it hits the race most frequently, but the following tests are also impacted:

- TestIntegrations/Discovery
- TestIntegrations/DiscoveryNode
- TestIntegrations/ReverseTunnelCollapse
- TestKube/ExecWithNoAuth

Closes #61486