### PR TITLE
Adding docs for scoped kube cluster registration and kube resources

### DIFF
--- a/docs/pages/zero-trust-access/rbac-get-started/scopes.mdx
+++ b/docs/pages/zero-trust-access/rbac-get-started/scopes.mdx
@@ -9,12 +9,25 @@ tags:
 page_type: conceptual
 ---
 
-**Scopes** are a hierarchical organization system for Teleport resources and
-permissions. A scope is a path-like attribute (for example `/staging/west` or
-`/prod`) attached to resources and permission grants. Permissions assigned at
-a scope apply to resources within that scope and all of its descendant
-scopes, but cannot reach across to orthogonal scopes or up to ancestor
-scopes.
+**Scopes** let you divide a Teleport cluster into a hierarchy of isolated
+administrative boundaries. Use scopes when you want to delegate management of
+one part of a cluster without granting access to unrelated resources.
+
+## How it works
+
+A scope is a path-like attribute (for example `/staging/west` or `/prod`) that
+Teleport attaches to supported resources, permission grants, and issued
+credentials. Permissions assigned at a scope apply to resources within that
+scope and its descendants, but not to parent or sibling scopes. Scopes are an
+*attribute*, not an object, so a scope path does not need to be created before
+resources or permissions are assigned to it.
+
+Cluster administrators create scoped roles, assign those roles to users at a
+specific scope, and create scoped join tokens for Agents. When a user logs in
+with a scope, Teleport issues credentials pinned to that scope. Scoped RBAC
+checks then authorize access only to resources in that scope or one of its
+descendants. Agents that join with a scoped token register their supported
+resources at the token's assigned scope.
 
 For example, a cluster administrator can assign a scoped admin role to Alice
 at `/staging/west`. Alice can then manage scoped roles, scoped tokens, and
@@ -22,8 +35,12 @@ SSH Services in `/staging/west` and descendant scopes such as
 `/staging/west/team-a`, but she cannot affect `/staging/east`, `/prod`, or
 unscoped cluster resources.
 
-This page describes the concepts behind scopes, and provides instructions for
-basic usage and specific scenarios.
+Scopes complement labels, but they solve a different problem. Labels describe
+individual resources and are used by roles to choose matching resources.
+Scopes define the administrative boundary and the scope of issued
+credentials. Label selectors can further restrict which resources a scoped
+role can access, but they cannot grant access outside the role assignment's
+scope.
 
 ## Use cases
 
@@ -40,16 +57,6 @@ Scopes are designed to enable:
 - **Mixed permissiveness.** Different access controls (such as session
   recording, port forwarding, or idle timeouts) can apply to the same user
   in different scopes.
-
-Scopes are an *attribute*, not an object. A scope path does not need to be
-created before resources or permissions are assigned to it.
-
-Scopes complement labels, but they solve a different problem. Labels describe
-individual resources and are used by roles to choose matching resources.
-Scopes define the administrative boundary and the scope of issued
-credentials. Label selectors can further restrict which resources a scoped
-role can access, but they cannot grant access outside the role assignment's
-scope.
 
 <Admonition type="warning" title="Active development">
 
@@ -73,6 +80,10 @@ supported set listed below.
 - All Teleport instances (Auth Service, Proxy Service, and Agents) must be
   running the same Teleport version, and must have the
   `TELEPORT_UNSTABLE_SCOPES=yes` environment variable set.
+- The Auth Service must also have the
+  `TELEPORT_UNSTABLE_AGENT_SCOPE_PIN=yes` environment variable set before
+  you use scoped tokens to join Agent roles other than SSH Services (`node`)
+  and Bots. This includes scoped Kubernetes Services and Application Services.
 
 ## Currently supported features
 
@@ -89,7 +100,8 @@ be assumed unsupported in scoped mode.
 - Basic scoped SSH access, including joining SSH Services at a
   scope and assigning scoped SSH access to users.
 - Basic scoped Kubernetes access, including joining Kubernetes services
-  at a scope and assigning scoped Kubernetes access to users.
+  at a scope, registering dynamic clusters, and assigning scoped Kubernetes
+  access to users.
 - Basic scoped Application access, including joining Application Services
   at a scope and assigning scoped application access to users.
 - Scoped Access Lists that can be managed by scoped administrators and used to
@@ -148,10 +160,16 @@ spec:
   assignable_scopes:
     - /examples
   kube:
+    groups: [cluster-admin]
     labels:
       - name: '*'
         values: ['*']
-    groups: [cluster-admin]
+    resources:
+      - kind: '*'
+        namespace: '*'
+        api_group: '*'
+        name: '*'
+        verbs: ['*']
   ssh:
     logins: [ubuntu]
     labels:
@@ -172,14 +190,11 @@ spec:
   rules:
     - resources: [scoped_role, scoped_role_assignment, bot, bot_instance, access_list]
       verbs: [create, list, readnosecrets, update, delete]
-    - resources: [scoped_token]
+    - resources: [scoped_token, kube_cluster]
       verbs: [create, list, read, update, delete]
 version: v1
 EOF
 ```
-
-Note that the `kube` configuration block does not yet support configuring
-`kubernetes_resources`.
 
 Next, create a scoped role assignment to grant `example-admin` to the user
 who will become the scoped admin (replace `alice` with your user):
@@ -255,9 +270,8 @@ $ tsh ssh ubuntu@example-node
 
 ## Joining a scoped Kubernetes Service
 
-Only static Kubernetes clusters support joining with scopes. Dynamic
-cluster registration, including those discovered by the Teleport Discovery
-Service, does not yet support scopes.
+Kubernetes Clusters discovered by the Teleport Discovery Service are not
+supported by scopes at this time.
 
 Log the scoped admin into the desired scope:
 
@@ -313,10 +327,6 @@ context or use the `tsh kubectl` sub-command to interact with the selected
 cluster.
 
 ## Joining a scoped Application Service
-
-To allow Application Services to join with scoped tokens, set
-`TELEPORT_UNSTABLE_AGENT_SCOPE_PIN=yes` on the Auth Service instances in addition
-to `TELEPORT_UNSTABLE_SCOPES=yes` before creating the token.
 
 Only statically configured applications served by Application Services support
 joining with scopes. Dynamic application registration, including those discovered
@@ -1020,4 +1030,528 @@ with the following SPIFFE ID:
 
 ```text
 spiffe://example.teleport.sh/staging/_/payments/api
+```
+
+## Kubernetes resource RBAC
+
+When defining scoped roles, the `resources` list provided in
+`scoped_role.spec.kube` must be defined in order for the role to grant access
+to a Kubernetes cluster. When the intent is to fully rely on Kubernetes'
+builtin RBAC rules, a wildcard entry must be defined:
+```yaml
+kind: scoped_role
+metadata:
+  name: kube-access
+scope: /examples
+spec:
+  assignable_scopes:
+    - /examples
+  kube:
+    groups: [cluster-admin]
+    labels:
+      - name: '*'
+        values: ['*']
+    resources:
+      - kind: '*'
+        namespace: '*'
+        api_group: '*'
+        name: '*'
+        verbs: ['*']
+version: v1
+```
+
+This is notably opposite to the behavior of unscoped Teleport roles which
+provide wildcard access by default when `kubernetes_resources` are left
+undefined. Scoped roles aim to be explicit and deny by default which is
+incompatible with the unscoped behavior.
+
+## Dynamic Kubernetes cluster registration
+
+With dynamic Kubernetes cluster registration, you can manage the Kubernetes
+clusters connected to your Teleport cluster without needing to modify the
+configuration file of an individual Kubernetes Service instance.
+
+Dynamic Kubernetes cluster registration is useful when you have deployed
+multiple Kubernetes Service instances or need to regularly reconfigure access to
+Kubernetes clusters in your infrastructure.
+
+In this guide, you will set up dynamic Kubernetes cluster registration, then
+create, list, update, and delete Kubernetes clusters via `tctl`.
+
+## How it works
+
+The Teleport Kubernetes Service proxies traffic from Teleport users to a
+Kubernetes API server so you can take advantage of passwordless authentication,
+role-based access controls, audit logging, and other Teleport features in order
+to manage access to Kubernetes.
+
+In this step, you will install the Teleport Kubernetes Service on a Linux host
+and configure it to access any Kubernetes cluster you register with your
+Teleport cluster.
+
+## Prerequisites
+
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
+- A Linux host where you will install the Teleport Kubernetes Service.
+
+  <Admonition type="tip">
+
+  Our `teleport-kube-agent` Helm chart does not support dynamic Kubernetes
+  cluster registration.
+
+  </Admonition>
+
+- A Kubernetes cluster to join to your Teleport cluster. You must have
+  permissions to create namespaces, secrets, service accounts, cluster roles,
+  and cluster role bindings in the cluster.
+
+- (!docs/pages/includes/tctl.mdx!)
+
+## Step 1/3. Set up the Teleport Kubernetes Service
+
+This step shows you how to install the Teleport Kubernetes Service on a Linux
+server.
+
+### Get a join token
+
+Establish trust between your Teleport cluster and your new Kubernetes Service
+instance by creating a scoped join token:
+
+```code
+$ tctl scoped tokens add --type=kube --scope=/examples/kube --assign-scope=/examples/kube --ttl=1h --format=text
+/examples/kube::(=presets.tokens.first=)
+```
+
+Copy the token and keep it somewhere safe so you can use it when running the
+Teleport Kubernetes Service.
+
+### Install the Teleport Kubernetes Service
+
+Install the Teleport Kubernetes Service on your Linux host:
+
+(!docs/pages/includes/install-linux.mdx!)
+
+### Configure the Teleport Kubernetes Service
+
+On the host where you will run the Teleport Kubernetes Service, run the
+following command to create a base configuration for your Teleport instance,
+assigning <Var name="example.teleport.sh:443" /> to the host and port of your
+Teleport Proxy Service or Teleport Cloud tenant and <Var name="join-token" /> to
+the join token we created earlier:
+
+```code
+$ sudo teleport configure \
+--proxy=<Var name="example.teleport.sh:443" /> \
+--roles=kube \
+--token=<Var name="join-token" /> \
+-o file
+```
+
+Edit your configuration file at `/etc/teleport.yaml` to include the following:
+
+```yaml
+kubernetes_service:
+  enabled: true
+  resources:
+  - labels:
+      "*": "*"
+```
+
+This configuration enables your Kubernetes Service instance to connect to any
+Kubernetes clusters you register with your Teleport cluster within the same
+scope. This is because the `resources[0].labels` field includes the wildcard
+pattern (`"*": "*"`), which allows this Kubernetes Service instance to
+connect to Kubernetes cluster resources with any label key or value. The
+Kubernetes Service instance's certificate will encode the scope assigned by its
+join token and be used to ensure only same-scope Kubernetes clusters are
+visible and registered.
+
+
+<details>
+<summary>Selectively watching Kubernetes clusters</summary>
+
+You can configure a Kubernetes Service instance to watch for a subset of
+Kubernetes clusters by including specific label keys and values instead of
+wildcard characters:
+
+```yaml
+resources:
+- labels:
+    "env": "prod"
+    "region": "us-east-2"
+- labels:
+    "env": "test"
+    "region": "us-west-1"
+```
+
+For the Kubernetes Service to register a cluster, *any* of the items in
+`resources` must match the cluster's labels. For an item in `resources` to
+match, *all* of the `labels` entries within that item must match the cluster's
+labels.
+
+For example, a cluster with the labels `env:prod` and `region:us-west-1` would
+not match the configuration above, since it only matches the `env:prod` label in
+the first `resources` item and the `region:us-west-1` label in the second
+`resources` item.
+
+However, a cluster with `env:test` and `region:us-west-1` would match, since it
+matches both labels given in the second `resources` item.
+
+When you create dynamic Kubernetes cluster resources later in this guide, you
+can assign them labels to ensure that only specific Kubernetes Service instances
+will watch for them.
+
+</details>
+
+### Run the Teleport Kubernetes Service
+
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Kubernetes Service"!)
+
+## Step 2/3. Authorize your user
+
+To enable dynamic Kubernetes cluster registration in Teleport, you will need to
+authorize your user to access the Kubernetes clusters you want to register with
+Teleport. We will configure this access in this step, both in Teleport and on
+your Kubernetes cluster.
+
+### Allow access to your Kubernetes cluster
+
+Ensure that you are in the correct Kubernetes context for the cluster you would
+like to enable access to.
+
+Retrieve all available contexts:
+
+```code
+$ kubectl config get-contexts
+```
+
+Switch to your context, replacing `CONTEXT_NAME` with the name of your chosen
+context:
+
+```code
+$ kubectl config use-context CONTEXT_NAME
+Switched to context CONTEXT_NAME
+```
+
+The scoped role you will create in the next section allows your Teleport user
+access to Kubernetes as the `viewers` group. Configure the `viewers` group in
+your Kubernetes cluster to have the built-in `view` ClusterRole. When your
+Teleport user accesses the cluster, the Teleport Kubernetes Service
+impersonates the `viewers` group and proxies the requests.
+
+Create a file called `viewers-bind.yaml` with the following contents:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: viewers-crb
+subjects:
+- kind: Group
+  # Bind the group "viewers", corresponding to the group we assign in the
+  # scoped role below.
+  name: viewers
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  # "view" is a default ClusterRole that grants read-only access to resources.
+  # See: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
+  name: view
+  apiGroup: rbac.authorization.k8s.io
+```
+
+Apply the `ClusterRoleBinding` with `kubectl`:
+
+```code
+$ kubectl apply -f viewers-bind.yaml
+```
+
+### Authorize your user to manage Kubernetes clusters
+
+Teleport tracks scoped Kubernetes clusters in your infrastructure via dynamic
+`kube_cluster` resources. To manage access to Kubernetes clusters with
+Teleport, your user will need permissions to manage these resources.
+
+Create a scoped role definition called `kube-manager.yaml` with the following
+content:
+
+```yaml
+kind: scoped_role
+metadata:
+  name: kube-manager
+scope: /examples
+spec:
+  assignable_scopes:
+    - /examples/kube
+  kube:
+    groups: [viewers]
+    labels:
+      - name: '*'
+        values: ['*']
+    resources:
+      - kind: '*'
+        namespace: '*'
+        api_group: '*'
+        name: '*'
+        verbs: ['*']
+  rules:
+    - resources: [kube_cluster]
+      verbs:
+        - create
+        - list
+        - read
+        - update
+        - delete
+version: v1
+```
+
+Create the scoped role:
+
+```code
+$ tctl create -f kube-manager.yaml
+```
+
+Assign the role to your <Var name="user" />:
+
+```code
+$ tctl create <<EOF
+kind: scoped_role_assignment
+sub_kind: dynamic
+scope: /examples
+spec:
+  user: <Var name="user" />
+  assignments:
+    - role: /examples::kube-manager
+      scope: /examples/kube
+version: v1
+EOF
+```
+
+Log out of your current session, then log in to the `/examples/kube` scope so
+the scoped role assignment is active for the following `tctl` commands:
+
+```code
+$ tsh logout
+$ tsh login --user=<Var name="user" /> --scope=/examples/kube --proxy=<Var name="example.teleport.sh:443" />
+```
+
+## Step 3/3. Manage dynamic Kubernetes cluster resources
+
+Now that your Teleport user has permissions to manage scoped Kubernetes cluster
+resources, we will show you how to create, list, update, and delete them.
+
+### Create a kubeconfig
+
+In this section, you will create a Kubernetes `Config` resource, or kubeconfig,
+that your Teleport cluster will use to authenticate to your Kubernetes cluster.
+
+When you signed into Teleport earlier in this guide, `tsh` may have changed
+your Kubernetes context to one based on your Teleport cluster, so make sure you
+update your Kubernetes context to match the cluster you would like to connect
+to Teleport:
+
+```code
+$ kubectl config get-contexts
+# Assign CONTEXT_NAME to your chosen context
+$ kubectl config use-context CONTEXT_NAME
+```
+
+On your workstation, download Teleport's `get-kubeconfig.sh` script, which you
+will use to generate the kubeconfig:
+
+```code
+$ curl -OL \
+https://raw.githubusercontent.com/gravitational/teleport/v(=teleport.version=)/examples/k8s-auth/get-kubeconfig.sh
+```
+
+The script creates a service account for the Teleport Kubernetes Service that
+can get Kubernetes pods as well as impersonate users, groups, and other service
+accounts. The Teleport Kubernetes Service uses this service account to manage
+access to resources in your Kubernetes cluster. The script also ensures that
+there is a Kubernetes `Secret` in your cluster to store service account
+credentials.
+
+`get-kubeconfig.sh` creates a namespace called `teleport` for the resources it
+deploys, though you can choose a different name by assigning the
+`TELEPORT_NAMESPACE` environment variable in the shell where you run the script.
+
+After creating resources, `get-kubeconfig.sh` writes a new kubeconfig to a file
+called `kubeconfig` in the directory where you run the script.
+
+Run the `get-kubeconfig.sh` script:
+
+```code
+$ bash get-kubeconfig.sh
+```
+
+The script is successful if you see this message:
+
+```text
+Done!
+```
+
+Ignore the script's instructions to copy the generated kubeconfig file to the
+Teleport Proxy Service. In the next section, we will show you how to use the
+kubeconfig file when creating a dynamic `kube_cluster` resource.
+
+### Create a Kubernetes cluster resource
+
+Define a scoped `kube_cluster` resource with the following content in a file
+called `kube_cluster.yaml`:
+
+```yaml
+kind: kube_cluster
+version: v3
+scope: /examples/kube
+metadata:
+  name: mycluster
+spec:
+  kubeconfig: |
+```
+
+The `spec.kubeconfig` field in the snippet above begins a multi-line string.
+Below, you will include the contents of the kubeconfig file as its value.
+
+Since `spec.kubeconfig` must be a base64-encoded string, convert the kubeconfig
+file to base64, then indent it and add it to the `kube_cluster.yaml` resource
+definition using the following command:
+
+```code
+$ printf "    %s\n" "$(cat kubeconfig | base64 | tr -d '\n')" >> kube_cluster.yaml
+```
+
+This command also removes any newlines added to the middle of the base64-encoded
+string before writing it to the `kube_cluster` resource definition.
+
+<details>
+<summary>Add labels to your kube_cluster</summary>
+
+You can add labels to the `kube_cluster` resource, allowing you to manage access
+to specific clusters from your Teleport roles or Kubernetes Service instances.
+
+Dynamic, scoped Kubernetes clusters only support static labels, which are
+key/value pairs. This example defines the `env=prod` and `team=dev` labels:
+
+```yaml
+kind: kube_cluster
+version: v3
+scope: /examples/kube
+metadata:
+  name: mycluster
+  labels:
+    env: prod
+    team: dev
+spec:
+  kubeconfig: KUBECONFIG
+```
+</details>
+
+To create the `kube_cluster` resource, run the following command:
+
+```code
+$ tctl create kube_cluster.yaml
+kubernetes cluster "/examples/kube::mycluster" has been created
+```
+
+### Access your new Kubernetes cluster
+
+Instances of the Teleport Kubernetes Service watch for newly created or updated
+`kube_cluster` resources within their assigned scope. When you create the
+`kube_cluster` resource, any Kubernetes Service instances you have configured
+in that scope to track that cluster's labels will register that cluster and
+enable access to it via Teleport.
+
+As a result, you should now see the cluster you registered above when you run
+`tsh kube ls`:
+
+```code
+$ tsh kube ls
+ Kube Cluster Name Labels                      Scope          Selected
+ ----------------- --------------------------- -------------- --------
+ mycluster         teleport.dev/origin=dynamic /examples/kube *
+```
+
+The `teleport.dev/origin=dynamic` label indicates that the cluster was
+registered dynamically.
+
+You can also log in to the cluster you just registered:
+
+```code
+$ tsh kube login mycluster
+Logged into kubernetes cluster "mycluster". Try 'kubectl version' to test the
+connection.
+```
+
+### List Kubernetes cluster resources
+
+You can list `kube_cluster` resources with the following command:
+
+```code
+$ tctl get kube_clusters
+```
+
+### Update a Kubernetes cluster resource
+
+To update the `kube_cluster` resource you created earlier, execute the following
+command to open the resource as it exists on the Auth Service's backend in your
+text editor:
+
+```code
+$ tctl edit kube_clusters /examples/kube::mycluster
+```
+
+Edit the resource to add a label to your `kube_cluster`:
+
+```diff
+  kind: kube_cluster
+  scope: /examples/kube
+  metadata:
+    id: 9999999999999999999
+    labels:
+      teleport.dev/origin: dynamic
++     env: test
+    name: mycluster
+  spec:
+    aws: {}
+    azure: {}
+    kubeconfig: KUBECONFIG
+  version: v3
+```
+
+Save and close the file in your editor to apply your changes.
+
+You should now see the updated labels:
+
+```code
+$ tsh kube ls
+ Kube Cluster Name Labels                               Scope          Selected
+ ----------------- ------------------------------------ -------------- --------
+ mycluster         env=test teleport.dev/origin=dynamic /examples/kube *
+```
+
+<Admonition type="warning">
+
+If the updated `kube_cluster` resource's labels no longer match the ones a
+Teleport Kubernetes Service instance is configured to watch, the instance will
+unregister and stop proxying the Kubernetes cluster.
+
+</Admonition>
+
+### Delete Kubernetes cluster resources
+
+To delete the `kube_cluster` resource you created earlier, run the following
+command:
+
+```code
+$ tctl rm kube_clusters /examples/kube::mycluster
+kubernetes cluster "/examples/kube::mycluster" has been deleted
+```
+
+This will unregister the Kubernetes cluster from Teleport:
+
+```code
+$ tsh kube ls
+Kube Cluster Name Labels Scope Selected
+----------------- ------ ----- --------
 ```


### PR DESCRIPTION
Adds new sections to the scopes doc covering dynamic kube cluster registration and `scoped_role.spec.kube.resources`. Because the process is identical except for the added `scope` field, linked to our existing docs explaining dynamic kube clusters. I can pull in more detail from there if we think it's worthwhile, but I worry that this overview will get too unwieldy if include too many details that aren't specific to scopes.


No test plan since this is a docs-only change.
