### PR TITLE
docs: Add proxy bypass advice to AWS console guide

### DIFF
--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
@@ -756,6 +756,28 @@ regarding `sts.amazonaws.com:443`. The Teleport Application Service must be able
 connect to `https://sts.amazonaws.com` and `https://signin.aws.amazon.com/federation`
 to create an authorized AWS console session.
 
+If the Teleport Application Service runs behind an HTTP CONNECT proxy, the
+`HTTPS_PROXY` and `HTTP_PROXY` variables in its environment also apply to these
+AWS calls. Add both endpoints to `NO_PROXY`, keeping any entries that are
+already there. If the service reads its AWS credentials from an EC2 instance
+profile, add the instance metadata address as well, because a proxied request
+for those credentials fails before the call to STS is made:
+
+```text
+NO_PROXY=169.254.169.254,*.amazonaws.com,signin.aws.amazon.com
+```
+
+The example covers standard AWS regions. AWS GovCloud (US) regions and AWS
+China regions use different sign-in endpoints, and AWS China regions also use a
+different STS endpoint, so bypass those domains instead. If the proxy is the
+only route out of the network, allow `CONNECT` to these hosts on the proxy
+rather than bypassing it.
+
+Set these variables in `/etc/default/teleport` on EC2, or in the `extraEnv`
+value of the `teleport-kube-agent` chart on EKS. For more on how Teleport uses
+them, see
+[HTTP CONNECT proxies](../../../reference/deployment/networking.mdx#http-connect-proxies).
+
 ### The Application Service is not authorized to assume a role
 
 If the Teleport Application Service fails to assume the `ExampleReadOnlyAccess`


### PR DESCRIPTION
The AWS console guide's troubleshooting section for `Internal Server Error` already says the Application Service must reach STS and the federation endpoint, but not what happens when its egress goes through an HTTP CONNECT proxy. Both calls honour the proxy environment variables, so name the hosts that belong in `NO_PROXY`. `signin.aws.amazon.com` is listed separately because `*.amazonaws.com` does not match it, and `169.254.169.254` because an Application Service that reads its credentials from an EC2 instance profile fails at the metadata service before it reaches STS. The text also covers the GovCloud and China sign-in domains, points EKS readers at the chart's `extraEnv` value, and says to allow `CONNECT` where the proxy is the only route out.

The issue asks for `teleport.cluster.local` in the bypass list, and I left it out because it has no effect on this path. gRPC hands the target to Teleport's custom dialer instead of consulting the proxy, that dialer discards the name and dials the Proxy Service's resolved address, and the auth HTTP client sets no proxy function at all. 

Issue: https://github.com/gravitational/teleport/issues/49727


## Manual Test Plan

### Test Environment

Single-process Teleport v19.0.0-prealpha.2 on macOS, with the Auth Service, Proxy Service and Application Service in one binary. A local HTTP CONNECT proxy logs every request it is asked to make and can refuse a list of hosts, and the agent runs with `HTTPS_PROXY` and `HTTP_PROXY` pointed at it. In every case `NO_PROXY` carries the cluster's own listen addresses, so only the outbound AWS calls are under test. The cluster registers an AWS console app with the URI `https://console.aws.amazon.com/ec2/v2/home`, a Teleport role grants a read-only IAM role in a development account, and the agent takes its AWS credentials from an SSO profile in its environment.

### Test Cases

- [x] With the proxy in the agent's environment, the credential chain probes the instance metadata service through the proxy, and the proxy log records a `PUT` and a `GET` for `169.254.169.254`.
- [x] Internal cluster traffic reaches the proxy under the listener address, `0.0.0.0:3025`, and never under `teleport.cluster.local`, which is why that name is absent from the bypass list.
- [ ] With `169.254.169.254` in `NO_PROXY`, the proxy log records no metadata request.
- [ ] With the proxy refusing `sts.amazonaws.com` and `signin.aws.amazon.com`, and neither host in `NO_PROXY`, launching the app from the Web UI fails with `Internal Server Error`, and the proxy log records the refused request.
- [ ] With both hosts added to `NO_PROXY`, launching the app returns an AWS console session, and the proxy log records no AWS request.
- [ ] With the proxy allowing AWS, and neither host in `NO_PROXY`, launching the app returns a console session, covering the case where `CONNECT` is allowed on the proxy instead of bypassing it.
- [ ] Following the EKS instruction, the same variables set through the `teleport-kube-agent` chart's `extraEnv` value reach the agent.
