### PR TITLE
[v18] SAML: Add unstable env var to disable descriptor redirect check

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -1065,3 +1065,10 @@ const (
 	// OktaReviewerRoleContext  is the context used to name Okta Reviewer role created by Okta Access List sync
 	OktaReviewerRoleContext = "reviewer-okta-acl-role"
 )
+
+const (
+	// EnvVarUnstableDisableSAMLRedirectDowngradeCheck allows disabling saml_connector
+	// entity_descriptor_url check preventing following redirects via HTTP originating from
+	// HTTPS route.
+	EnvVarUnstableDisableSAMLRedirectDowngradeCheck = "TELEPORT_UNSTABLE_DISABLE_SAML_REDIRECT_DOWNGRADE_CHECK"
+)

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -41,6 +42,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -256,8 +258,12 @@ func getEntityDescriptor(ctx context.Context, params getEntityDescriptorParams) 
 	}()
 
 	if url != "" && !params.Options.NoFollowURLs {
-		httpClient := &http.Client{
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		var checkRedirect func(req *http.Request, via []*http.Request) error
+		// TODO(kopiczko): Remove this env var after Jul 2027 (one year since introduced) if no issue is reported.
+		if disableCheckRedirect, _ := apiutils.ParseBool(os.Getenv(teleport.EnvVarUnstableDisableSAMLRedirectDowngradeCheck)); disableCheckRedirect {
+			log.DebugContext(ctx, "Redirect HTTPS downgrade check disabled with the unstable environment variable")
+		} else {
+			checkRedirect = func(req *http.Request, via []*http.Request) error {
 				if len(via) != 0 && strings.EqualFold(via[len(via)-1].URL.Scheme, "https") && !strings.EqualFold(req.URL.Scheme, "https") {
 					return errors.New("connection downgrade not allowed for URL: " + req.URL.String())
 				}
@@ -265,8 +271,12 @@ func getEntityDescriptor(ctx context.Context, params getEntityDescriptorParams) 
 					return errors.New("stopped after 10 redirects")
 				}
 				return nil
-			},
-			Transport: params.Options.Transport,
+			}
+		}
+
+		httpClient := &http.Client{
+			CheckRedirect: checkRedirect,
+			Transport:     params.Options.Transport,
 		}
 
 		ctx, cancel := context.WithTimeout(ctx, defaults.DefaultIOTimeout)


### PR DESCRIPTION
Backport #68886 to branch/v18

## Manual Test Plan

### Test Environment

Prepare http server with a handler:

```go
const (
	HTTPServerEndpointRedirectDowngrade = "/redirect-downgrade"
)

func _httpServerHandlerRedirectDowngrade(w http.ResponseWriter, r *http.Request) {
	http.Redirect(w, r, "http://plan.http.test", http.StatusMovedPermanently)
}
```

### Test Cases

- [x] Verify creating a SAML connector with `entity_descriptor_url` works.
- [x] Verify creating a SAML connector with `entity_descriptor_url` and `export TELEPORT_UNSTABLE_DISABLE_SAML_REDIRECT_DOWNGRADE_CHECK=1` works.
- [x] Verify setting `https://127.0.0.1:9000/redirect-downgrade` for `entity_descriptor_url` fails with "connection downgrade not allowed for URL: http://plan.http.test"
- [x] Verify setting `https://127.0.0.1:9000/redirect-downgrade` for `entity_descriptor_url` and `export TELEPORT_UNSTABLE_DISABLE_SAML_REDIRECT_DOWNGRADE_CHECK=1` fails with "dial tcp: lookup plan.http.test: no such host"
