### PR TITLE
ui: update mwi guide link for generic linux

### DIFF
--- a/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
+++ b/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
@@ -182,7 +182,7 @@ export const integrations: BotIntegration[] = [
     title: 'Generic Linux',
     description:
       'Use Machine & Workload Identity (MWI) to eliminate long-lived credentials on Linux servers.',
-    link: ' https://goteleport.com/docs/machine-workload-identity/deployment/linux/',
+    link: 'https://goteleport.com/docs/machine-workload-identity/deployment/linux/',
     icon: 'server',
     kind: IntegrationEnrollKind.MachineID,
     type: 'bot',

--- a/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
+++ b/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
@@ -182,7 +182,7 @@ export const integrations: BotIntegration[] = [
     title: 'Generic Linux',
     description:
       'Use Machine & Workload Identity (MWI) to eliminate long-lived credentials on Linux servers.',
-    link: 'https://goteleport.com/docs/enroll-resources/machine-id/getting-started/',
+    link: 'https://goteleport.com/docs/machine-workload-identity/access-guides/ssh/',
     icon: 'server',
     kind: IntegrationEnrollKind.MachineID,
     type: 'bot',

--- a/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
+++ b/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
@@ -182,7 +182,7 @@ export const integrations: BotIntegration[] = [
     title: 'Generic Linux',
     description:
       'Use Machine & Workload Identity (MWI) to eliminate long-lived credentials on Linux servers.',
-    link: 'https://goteleport.com/docs/machine-workload-identity/access-guides/ssh/',
+    link: ' https://goteleport.com/docs/machine-workload-identity/deployment/linux/',
     icon: 'server',
     kind: IntegrationEnrollKind.MachineID,
     type: 'bot',


### PR DESCRIPTION
Update link to Machine & Workload Identity with Server Access. The previous link was a github actions walkthrough, not generic linux.

## Manual Test Plan
### Test Environment
  Dev
### Test Cases
- [x] Confirm new integration link shows and works for linux machine-id 
