### PR TITLE
[vnet] Use order-insensitive DNS config comparison on Windows

### DIFF
--- a/api/utils/slices.go
+++ b/api/utils/slices.go
@@ -86,18 +86,18 @@ func DeduplicateAny[T any](in []T, compare func(T, T) bool) []T {
 // ContainSameUniqueElements returns true if the input slices contain the same
 // unique elements. Ordering and duplicates are ignored.
 func ContainSameUniqueElements[S ~[]E, E comparable](s1, s2 S) bool {
-	s1Dedup := Deduplicate(s1)
-	s2Dedup := Deduplicate(s2)
-
-	if len(s1Dedup) != len(s2Dedup) {
-		return false
+	set1 := make(map[E]struct{}, len(s1))
+	for _, v := range s1 {
+		set1[v] = struct{}{}
 	}
-	for i := range s1Dedup {
-		if !slices.Contains(s2Dedup, s1Dedup[i]) {
+	set2 := make(map[E]struct{}, len(s2))
+	for _, v := range s2 {
+		if _, ok := set1[v]; !ok {
 			return false
 		}
+		set2[v] = struct{}{}
 	}
-	return true
+	return len(set1) == len(set2)
 }
 
 // All checks if all elements of slice satisfy given predicate. If the slice is empty, it returns true.

--- a/api/utils/slices_test.go
+++ b/api/utils/slices_test.go
@@ -18,6 +18,8 @@ package utils
 
 import (
 	"bytes"
+	"math/rand/v2"
+	"slices"
 	"strconv"
 	"testing"
 
@@ -99,6 +101,12 @@ func TestContainSameUniqueElements(t *testing.T) {
 			s2:    []string{"a", "b", "c"},
 			check: require.False,
 		},
+		{
+			name:  "different (s2 subset of s1)",
+			s1:    []string{"a", "b", "c"},
+			s2:    []string{"b", "a", "a"},
+			check: require.False,
+		},
 	}
 
 	for _, test := range tests {
@@ -106,6 +114,55 @@ func TestContainSameUniqueElements(t *testing.T) {
 			test.check(t, ContainSameUniqueElements(test.s1, test.s2))
 		})
 	}
+}
+
+// TestContainSameUniqueElements_SameUniqueSet builds two slices over the same
+// unique element set (every element at least once, plus random duplicates,
+// shuffled) and asserts the result is true in both orders.
+func TestContainSameUniqueElements_SameUniqueSet(t *testing.T) {
+	for range 1000 {
+		uniq := randDistinct()
+		s1 := randMultisetOver(uniq)
+		s2 := randMultisetOver(uniq)
+
+		require.True(t, ContainSameUniqueElements(s1, s2), "s1=%v s2=%v", s1, s2)
+		require.True(t, ContainSameUniqueElements(s2, s1), "s1=%v s2=%v", s1, s2)
+	}
+}
+
+// TestContainSameUniqueElements_MissingElement removes one element from one
+// side, so the unique sets differ by construction, and asserts the result is
+// false.
+func TestContainSameUniqueElements_MissingElement(t *testing.T) {
+	for range 1000 {
+		uniq := randDistinct()
+		removed := rand.IntN(len(uniq))
+		smaller := slices.Delete(slices.Clone(uniq), removed, removed+1)
+
+		s1 := randMultisetOver(uniq)
+		s2 := randMultisetOver(smaller)
+
+		require.False(t, ContainSameUniqueElements(s1, s2), "s1=%v s2=%v", s1, s2)
+		require.False(t, ContainSameUniqueElements(s2, s1), "s1=%v s2=%v", s1, s2)
+	}
+}
+
+// randDistinct returns 1-8 distinct ints.
+func randDistinct() []int {
+	return rand.Perm(32)[:1+rand.IntN(8)]
+}
+
+// randMultisetOver returns a slice whose set of unique elements is exactly
+// uniq: one copy of each element, plus random extra copies, shuffled.
+func randMultisetOver(uniq []int) []int {
+	out := slices.Clone(uniq)
+	if len(uniq) > 0 {
+		for range rand.IntN(6) {
+			out = append(out, uniq[rand.IntN(len(uniq))])
+		}
+	}
+	rand.Shuffle(len(out), func(i, j int) { out[i], out[j] = out[j], out[i] })
+	return out
 }
 
 func TestAll(t *testing.T) {

--- a/lib/vnet/osconfig_windows.go
+++ b/lib/vnet/osconfig_windows.go
@@ -27,6 +27,8 @@ import (
 	"github.com/gravitational/trace"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
+
+	"github.com/gravitational/teleport/api/utils"
 )
 
 var (
@@ -140,8 +142,8 @@ func platformConfigureOS(ctx context.Context, cfg *osConfig, state *platformOSCo
 	if err != nil {
 		return trace.Wrap(err, "checking existence of VNet NRPT registry key under group policy path")
 	}
-	if !slices.Equal(cfg.dnsZones, state.configuredDNSZones) ||
-		!slices.Equal(cfg.dnsAddrs, state.configuredDNSAddrs) ||
+	if !utils.ContainSameUniqueElements(cfg.dnsZones, state.configuredDNSZones) ||
+		!utils.ContainSameUniqueElements(cfg.dnsAddrs, state.configuredDNSAddrs) ||
 		doesGroupPolicyKeyExist != state.configuredGroupPolicyKey ||
 		(doesGroupPolicyKeyExist && !vnetGroupPolicyNRPTKeyExists && len(cfg.dnsZones) > 0) {
 		if err := configureDNS(ctx, cfg.dnsZones, cfg.dnsAddrs, doesGroupPolicyKeyExist); err != nil {


### PR DESCRIPTION
Changes the DNS zone/nameserver comparison in the Windows OS configuration loop from the order-sensitive `slices.Equal` to `ContainSameUniqueElements`. The lists are rebuilt every 10 seconds with no ordering guarantee, so this prevents a theoretical possibility of a reordered list triggering a full NRPT rewrite and machine group policy re-application on every tick. Also optimizes `ContainSameUniqueElements` itself from.

## Manual Test Plan

Should be covered by existing tests
