### PR TITLE
Terraform: improve identifier type safety

### DIFF
--- a/integrations/terraform/provider/internal/resources/access_list.go
+++ b/integrations/terraform/provider/internal/resources/access_list.go
@@ -28,6 +28,7 @@ import (
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	convertv1 "github.com/gravitational/teleport/api/types/accesslist/convert/v1"
+	"github.com/gravitational/teleport/lib/scopes"
 
 	"github.com/gravitational/teleport/integrations/terraform/provider/internal/teleport"
 	"github.com/gravitational/teleport/integrations/terraform/provider/internal/tfdriver"
@@ -48,8 +49,10 @@ func NewAccessListDataSourceType() tfdriver.DataSourceType[accesslist.AccessList
 			},
 		},
 		Identifier: tfdriver.PossiblyUnscopedScopeQualifiedNameIdentifierFromPath(
-			path.Root("header").AtName("metadata").AtName("name"),
-			path.Root("scope"),
+			tfdriver.ScopeQualifiedPath{
+				Name:  path.Root("header").AtName("metadata").AtName("name"),
+				Scope: path.Root("scope"),
+			},
 		),
 	}
 }
@@ -87,10 +90,15 @@ func NewAccessListResourceType() tfdriver.ResourceType[accesslist.AccessList, tf
 		},
 		Normalizer: tfdriver.CheckAndSetDefaults[accesslist.AccessList](),
 		Identifier: tfdriver.PossiblyUnscopedScopeQualifiedNameIdentifierPolicy(
-			path.Root("header").AtName("metadata").AtName("name"),
-			path.Root("scope"),
-			func(av *accesslist.AccessList) (string, string) {
-				return av.GetMetadata().Name, av.GetScope()
+			tfdriver.ScopeQualifiedPath{
+				Name:  path.Root("header").AtName("metadata").AtName("name"),
+				Scope: path.Root("scope"),
+			},
+			func(av *accesslist.AccessList) scopes.QualifiedName {
+				return scopes.QualifiedName{
+					Name:  av.GetMetadata().Name,
+					Scope: av.GetScope(),
+				}
 			},
 		),
 		ResourceRevision: func(st *accesslist.AccessList) string {

--- a/integrations/terraform/provider/internal/resources/access_list_member.go
+++ b/integrations/terraform/provider/internal/resources/access_list_member.go
@@ -47,9 +47,10 @@ func NewAccessListMemberDataSourceType() tfdriver.DataSourceType[accesslist.Acce
 				return schemav1.CopyMemberToTerraform(ctx, convertv1.ToMemberProto(alm), o)
 			},
 		},
-		Identifier: tfdriver.ScopeQualifiedCompositeIdentifierFromPath(
-			path.Root("spec").AtName("access_list"),
-			path.Root("header").AtName("metadata").AtName("name"),
+		Identifier: tfdriver.ScopeQualifiedCompositeIdentifierFromPath(tfdriver.CompositeIdentifierPath{
+			Prefix: path.Root("spec").AtName("access_list"),
+			Name:   path.Root("header").AtName("metadata").AtName("name"),
+		},
 		),
 	}
 }
@@ -87,10 +88,15 @@ func NewAccessListMemberResourceType() tfdriver.ResourceType[accesslist.AccessLi
 		},
 		Normalizer: tfdriver.CheckAndSetDefaults[accesslist.AccessListMember](),
 		Identifier: tfdriver.ScopeQualifiedCompositeIdentifierPolicy(
-			path.Root("spec").AtName("access_list"),
-			path.Root("header").AtName("metadata").AtName("name"),
-			func(av *accesslist.AccessListMember) (string, string) {
-				return av.Spec.AccessList, av.GetMetadata().Name
+			tfdriver.CompositeIdentifierPath{
+				Prefix: path.Root("spec").AtName("access_list"),
+				Name:   path.Root("header").AtName("metadata").AtName("name"),
+			},
+			func(av *accesslist.AccessListMember) tfdriver.CompositeIdentifier {
+				return tfdriver.CompositeIdentifier{
+					Prefix: av.Spec.AccessList,
+					Name:   av.GetMetadata().Name,
+				}
 			}),
 		ResourceRevision: func(st *accesslist.AccessListMember) string {
 			return st.GetMetadata().Revision

--- a/integrations/terraform/provider/internal/resources/kubernetes.go
+++ b/integrations/terraform/provider/internal/resources/kubernetes.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 
 	apitypes "github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/scopes"
 
 	"github.com/gravitational/teleport/integrations/terraform/provider/internal/teleport"
 	"github.com/gravitational/teleport/integrations/terraform/provider/internal/tfdriver"
@@ -39,8 +40,10 @@ func NewKubernetesClusterDataSourceType() tfdriver.DataSourceType[apitypes.Kuber
 			ToStateFunc: tfschema.CopyKubernetesClusterV3ToTerraform,
 		},
 		Identifier: tfdriver.PossiblyUnscopedScopeQualifiedNameIdentifierFromPath(
-			path.Root("metadata").AtName("name"),
-			path.Root("scope"),
+			tfdriver.ScopeQualifiedPath{
+				Name:  path.Root("metadata").AtName("name"),
+				Scope: path.Root("scope"),
+			},
 		),
 	}
 }
@@ -59,10 +62,15 @@ func NewKubernetesClusterResourceType() tfdriver.ResourceType[apitypes.Kubernete
 		},
 		Normalizer: tfdriver.CheckAndSetDefaults[apitypes.KubernetesClusterV3](),
 		Identifier: tfdriver.PossiblyUnscopedScopeQualifiedNameIdentifierPolicy(
-			path.Root("metadata").AtName("name"),
-			path.Root("scope"),
-			func(av *apitypes.KubernetesClusterV3) (string, string) {
-				return av.GetMetadata().Name, av.GetScope()
+			tfdriver.ScopeQualifiedPath{
+				Name:  path.Root("metadata").AtName("name"),
+				Scope: path.Root("scope"),
+			},
+			func(av *apitypes.KubernetesClusterV3) scopes.QualifiedName {
+				return scopes.QualifiedName{
+					Name:  av.GetMetadata().Name,
+					Scope: av.GetScope(),
+				}
 			}),
 		ResourceRevision: func(st *apitypes.KubernetesClusterV3) string {
 			return st.GetMetadata().Revision

--- a/integrations/terraform/provider/internal/resources/scoped_role.go
+++ b/integrations/terraform/provider/internal/resources/scoped_role.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 
 	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 
 	"github.com/gravitational/teleport/integrations/terraform/provider/internal/teleport"
@@ -34,8 +35,12 @@ func NewScopedRoleDataSourceType() tfdriver.DataSourceType[accessv1.ScopedRole, 
 		NewDataSourceClient: func(p tfsdk.Provider) tfdriver.DataSourceClient[accessv1.ScopedRole, tfdriver.ScopeQualifiedNameIdentifier] {
 			return teleport.NewScopedRoleClient(clientFromProvider(p))
 		},
-		Identifier: tfdriver.ScopeQualifiedNameIdentifierFromPath(path.Root("metadata").AtName("name"), path.Root("scope")),
-		Kind:       scopedaccess.KindScopedRole,
+		Identifier: tfdriver.ScopeQualifiedNameIdentifierFromPath(
+			tfdriver.ScopeQualifiedPath{
+				Name:  path.Root("metadata").AtName("name"),
+				Scope: path.Root("scope"),
+			}),
+		Kind: scopedaccess.KindScopedRole,
 		Codec: tfdriver.DataSourceCodecFuncs[accessv1.ScopedRole]{
 			SchemaFunc:  schemav1.GenSchemaScopedRole,
 			ToStateFunc: schemav1.CopyScopedRoleToTerraform,
@@ -57,10 +62,15 @@ func NewScopedRoleResourceType() tfdriver.ResourceType[accessv1.ScopedRole, tfdr
 		},
 		Normalizer: tfdriver.ForceKind[accessv1.ScopedRole](scopedaccess.KindScopedRole),
 		Identifier: tfdriver.ScopeQualifiedNameIdentifierPolicy(
-			path.Root("metadata").AtName("name"),
-			path.Root("scope"),
-			func(st *accessv1.ScopedRole) (string, string) {
-				return st.GetMetadata().GetName(), st.GetScope()
+			tfdriver.ScopeQualifiedPath{
+				Name:  path.Root("metadata").AtName("name"),
+				Scope: path.Root("scope"),
+			},
+			func(st *accessv1.ScopedRole) scopes.QualifiedName {
+				return scopes.QualifiedName{
+					Name:  st.GetMetadata().GetName(),
+					Scope: st.GetScope(),
+				}
 			}),
 		ResourceRevision: func(st *accessv1.ScopedRole) string {
 			return st.GetMetadata().GetRevision()

--- a/integrations/terraform/provider/internal/resources/scoped_role_assignment.go
+++ b/integrations/terraform/provider/internal/resources/scoped_role_assignment.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 
 	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 
 	"github.com/gravitational/teleport/integrations/terraform/provider/internal/teleport"
@@ -34,8 +35,12 @@ func NewScopedRoleAssignmentDataSourceType() tfdriver.DataSourceType[accessv1.Sc
 		NewDataSourceClient: func(p tfsdk.Provider) tfdriver.DataSourceClient[accessv1.ScopedRoleAssignment, tfdriver.ScopeQualifiedNameIdentifier] {
 			return teleport.NewScopedRoleAssignmentClient(clientFromProvider(p))
 		},
-		Identifier: tfdriver.ScopeQualifiedNameIdentifierFromPath(path.Root("metadata").AtName("name"), path.Root("scope")),
-		Kind:       scopedaccess.KindScopedRoleAssignment,
+		Identifier: tfdriver.ScopeQualifiedNameIdentifierFromPath(
+			tfdriver.ScopeQualifiedPath{
+				Name:  path.Root("metadata").AtName("name"),
+				Scope: path.Root("scope"),
+			}),
+		Kind: scopedaccess.KindScopedRoleAssignment,
 		Codec: tfdriver.DataSourceCodecFuncs[accessv1.ScopedRoleAssignment]{
 			SchemaFunc:  schemav1.GenSchemaScopedRoleAssignment,
 			ToStateFunc: schemav1.CopyScopedRoleAssignmentToTerraform,
@@ -57,10 +62,16 @@ func NewScopedRoleAssignmentResourceType() tfdriver.ResourceType[accessv1.Scoped
 		},
 		Normalizer: tfdriver.ForceKind[accessv1.ScopedRoleAssignment](scopedaccess.KindScopedRoleAssignment),
 		Identifier: tfdriver.ScopeQualifiedNameIdentifierPolicy(
-			path.Root("metadata").AtName("name"),
-			path.Root("scope"),
-			func(st *accessv1.ScopedRoleAssignment) (string, string) {
-				return st.GetMetadata().GetName(), st.GetScope()
+			tfdriver.ScopeQualifiedPath{
+				Name:  path.Root("metadata").AtName("name"),
+				Scope: path.Root("scope"),
+			},
+			func(st *accessv1.ScopedRoleAssignment) scopes.QualifiedName {
+				return scopes.QualifiedName{
+					Name:  st.GetMetadata().GetName(),
+					Scope: st.GetScope(),
+				}
+
 			}),
 		ResourceRevision: func(st *accessv1.ScopedRoleAssignment) string {
 			return st.GetMetadata().GetRevision()

--- a/integrations/terraform/provider/internal/resources/scoped_token.go
+++ b/integrations/terraform/provider/internal/resources/scoped_token.go
@@ -22,6 +22,7 @@ import (
 
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	apitypes "github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/scopes"
 
 	"github.com/gravitational/teleport/integrations/terraform/provider/internal/teleport"
 	"github.com/gravitational/teleport/integrations/terraform/provider/internal/tfdriver"
@@ -35,9 +36,10 @@ func NewScopedTokenDataSourceType() tfdriver.DataSourceType[joiningv1.ScopedToke
 			return teleport.NewScopedTokenClient(clientFromProvider(p))
 		},
 		Identifier: tfdriver.ScopeQualifiedNameIdentifierFromPath(
-			path.Root("metadata").AtName("name"),
-			path.Root("scope"),
-		),
+			tfdriver.ScopeQualifiedPath{
+				Name:  path.Root("metadata").AtName("name"),
+				Scope: path.Root("scope"),
+			}),
 		Kind: apitypes.KindScopedToken,
 		Codec: tfdriver.DataSourceCodecFuncs[joiningv1.ScopedToken]{
 			SchemaFunc:  schemav1.GenSchemaScopedToken,
@@ -60,10 +62,15 @@ func NewScopedTokenResourceType() tfdriver.ResourceType[joiningv1.ScopedToken, t
 		},
 		Normalizer: tfdriver.ForceKind[joiningv1.ScopedToken](apitypes.KindScopedToken),
 		Identifier: tfdriver.ScopeQualifiedNameIdentifierPolicy(
-			path.Root("metadata").AtName("name"),
-			path.Root("scope"),
-			func(st *joiningv1.ScopedToken) (string, string) {
-				return st.GetMetadata().GetName(), st.GetScope()
+			tfdriver.ScopeQualifiedPath{
+				Name:  path.Root("metadata").AtName("name"),
+				Scope: path.Root("scope"),
+			},
+			func(st *joiningv1.ScopedToken) scopes.QualifiedName {
+				return scopes.QualifiedName{
+					Name:  st.GetMetadata().GetName(),
+					Scope: st.GetScope(),
+				}
 			},
 		),
 		ResourceRevision: func(st *joiningv1.ScopedToken) string {

--- a/integrations/terraform/provider/internal/tfdriver/identifier.go
+++ b/integrations/terraform/provider/internal/tfdriver/identifier.go
@@ -165,17 +165,24 @@ func NewPossiblyUnscopedScopeQualifiedNameIdentifier(s string) (ScopeQualifiedNa
 	return ScopeQualifiedNameIdentifier{Name: s}, nil
 }
 
+// ScopeQualifiedPath contains the paths to Terraform
+// name and scope paths.
+type ScopeQualifiedPath struct {
+	Name  path.Path
+	Scope path.Path
+}
+
 // ScopeQualifiedNameIdentifierFromPath returns a scope qualified name extractor.
-func ScopeQualifiedNameIdentifierFromPath(namePath, scopePath path.Path) TerraformIdentifierExtractor[ScopeQualifiedNameIdentifier] {
+func ScopeQualifiedNameIdentifierFromPath(p ScopeQualifiedPath) TerraformIdentifierExtractor[ScopeQualifiedNameIdentifier] {
 	return func(ctx context.Context, reader TerraformAttributeReader) (ScopeQualifiedNameIdentifier, diag.Diagnostics) {
 		var identifier types.String
-		diags := reader.GetAttribute(ctx, namePath, &identifier)
+		diags := reader.GetAttribute(ctx, p.Name, &identifier)
 		if diags.HasError() {
 			return ScopeQualifiedNameIdentifier{}, diags
 		}
 
 		var scope types.String
-		diags.Append(reader.GetAttribute(ctx, scopePath, &scope)...)
+		diags.Append(reader.GetAttribute(ctx, p.Scope, &scope)...)
 		if diags.HasError() {
 			return ScopeQualifiedNameIdentifier{}, diags
 		}
@@ -192,16 +199,16 @@ func ScopeQualifiedNameIdentifierFromPath(namePath, scopePath path.Path) Terrafo
 
 // PossiblyUnscopedScopeQualifiedNameIdentifierFromPath returns an extractor for
 // identifiers that may be either scope-qualified or unscoped.
-func PossiblyUnscopedScopeQualifiedNameIdentifierFromPath(namePath, scopePath path.Path) TerraformIdentifierExtractor[ScopeQualifiedNameIdentifier] {
+func PossiblyUnscopedScopeQualifiedNameIdentifierFromPath(p ScopeQualifiedPath) TerraformIdentifierExtractor[ScopeQualifiedNameIdentifier] {
 	return func(ctx context.Context, reader TerraformAttributeReader) (ScopeQualifiedNameIdentifier, diag.Diagnostics) {
 		var identifier types.String
-		diags := reader.GetAttribute(ctx, namePath, &identifier)
+		diags := reader.GetAttribute(ctx, p.Name, &identifier)
 		if diags.HasError() {
 			return ScopeQualifiedNameIdentifier{}, diags
 		}
 
 		var scope types.String
-		diags.Append(reader.GetAttribute(ctx, scopePath, &scope)...)
+		diags.Append(reader.GetAttribute(ctx, p.Scope, &scope)...)
 		if diags.HasError() {
 			return ScopeQualifiedNameIdentifier{}, diags
 		}
@@ -221,12 +228,12 @@ func PossiblyUnscopedScopeQualifiedNameIdentifierFromPath(namePath, scopePath pa
 }
 
 // ScopeQualifiedNameIdentifierPolicy returns a policy for scope qualified names.
-func ScopeQualifiedNameIdentifierPolicy[T any](namePath, scopePath path.Path, resourceNameAndScope func(*T) (name, scope string)) IdentifierPolicy[T, ScopeQualifiedNameIdentifier] {
+func ScopeQualifiedNameIdentifierPolicy[T any](p ScopeQualifiedPath, resourceNameAndScope func(*T) scopes.QualifiedName) IdentifierPolicy[T, ScopeQualifiedNameIdentifier] {
 	return IdentifierPolicy[T, ScopeQualifiedNameIdentifier]{
-		FromState: ScopeQualifiedNameIdentifierFromPath(namePath, scopePath),
+		FromState: ScopeQualifiedNameIdentifierFromPath(p),
 		FromResource: func(resource *T) ScopeQualifiedNameIdentifier {
-			name, scope := resourceNameAndScope(resource)
-			return ScopeQualifiedNameIdentifier{Name: name, Scope: scope}
+			sqn := resourceNameAndScope(resource)
+			return ScopeQualifiedNameIdentifier{Name: sqn.Name, Scope: sqn.Scope}
 		},
 		FromImportID: NewScopedQualifiedNameIdentifier,
 	}
@@ -234,12 +241,12 @@ func ScopeQualifiedNameIdentifierPolicy[T any](namePath, scopePath path.Path, re
 
 // PossiblyUnscopedScopeQualifiedNameIdentifierPolicy returns a policy for
 // identifiers that may be either scope-qualified or unscoped.
-func PossiblyUnscopedScopeQualifiedNameIdentifierPolicy[T any](namePath, scopePath path.Path, resourceNameAndScope func(*T) (name, scope string)) IdentifierPolicy[T, ScopeQualifiedNameIdentifier] {
+func PossiblyUnscopedScopeQualifiedNameIdentifierPolicy[T any](p ScopeQualifiedPath, resourceNameAndScope func(*T) scopes.QualifiedName) IdentifierPolicy[T, ScopeQualifiedNameIdentifier] {
 	return IdentifierPolicy[T, ScopeQualifiedNameIdentifier]{
-		FromState: PossiblyUnscopedScopeQualifiedNameIdentifierFromPath(namePath, scopePath),
+		FromState: PossiblyUnscopedScopeQualifiedNameIdentifierFromPath(p),
 		FromResource: func(resource *T) ScopeQualifiedNameIdentifier {
-			name, scope := resourceNameAndScope(resource)
-			return ScopeQualifiedNameIdentifier{Name: name, Scope: scope}
+			sqn := resourceNameAndScope(resource)
+			return ScopeQualifiedNameIdentifier{Name: sqn.Name, Scope: sqn.Scope}
 		},
 		FromImportID: NewPossiblyUnscopedScopeQualifiedNameIdentifier,
 	}
@@ -265,17 +272,24 @@ func NewCompositeIdentifier(s string) (CompositeIdentifier, error) {
 	return CompositeIdentifier{Prefix: prefix, Name: name}, nil
 }
 
+// CompositeIdentifierPath contains the Terraform paths
+// to the name and prefix of a Teleport resource.
+type CompositeIdentifierPath struct {
+	Prefix path.Path
+	Name   path.Path
+}
+
 // CompositeIdentifierFromPath returns an extractor for a composite identifier.
-func CompositeIdentifierFromPath(prefixPath, namePath path.Path) TerraformIdentifierExtractor[CompositeIdentifier] {
+func CompositeIdentifierFromPath(p CompositeIdentifierPath) TerraformIdentifierExtractor[CompositeIdentifier] {
 	return func(ctx context.Context, reader TerraformAttributeReader) (CompositeIdentifier, diag.Diagnostics) {
 		var prefix types.String
-		diags := reader.GetAttribute(ctx, prefixPath, &prefix)
+		diags := reader.GetAttribute(ctx, p.Prefix, &prefix)
 		if diags.HasError() {
 			return CompositeIdentifier{}, diags
 		}
 
 		var id types.String
-		diags.Append(reader.GetAttribute(ctx, namePath, &id)...)
+		diags.Append(reader.GetAttribute(ctx, p.Name, &id)...)
 		if diags.HasError() {
 			return CompositeIdentifier{}, diags
 		}
@@ -285,13 +299,10 @@ func CompositeIdentifierFromPath(prefixPath, namePath path.Path) TerraformIdenti
 }
 
 // CompositeIdentifierPolicy returns an identifier policy for composite identifiers.
-func CompositeIdentifierPolicy[T any](prefixPath, namePath path.Path, resourcePrefixAndName func(*T) (prefix, name string)) IdentifierPolicy[T, CompositeIdentifier] {
+func CompositeIdentifierPolicy[T any](p CompositeIdentifierPath, resourcePrefixAndName func(*T) CompositeIdentifier) IdentifierPolicy[T, CompositeIdentifier] {
 	return IdentifierPolicy[T, CompositeIdentifier]{
-		FromState: CompositeIdentifierFromPath(prefixPath, namePath),
-		FromResource: func(resource *T) CompositeIdentifier {
-			prefix, name := resourcePrefixAndName(resource)
-			return CompositeIdentifier{Prefix: prefix, Name: name}
-		},
+		FromState:    CompositeIdentifierFromPath(p),
+		FromResource: resourcePrefixAndName,
 		FromImportID: NewCompositeIdentifier,
 	}
 }
@@ -358,16 +369,16 @@ func newScopeQualifiedCompositeIdentifier(prefix, name string) (ScopeQualifiedCo
 
 // ScopeQualifiedCompositeIdentifierFromPath returns an extractor for a
 // scope-qualified composite identifier.
-func ScopeQualifiedCompositeIdentifierFromPath(prefixPath, namePath path.Path) TerraformIdentifierExtractor[ScopeQualifiedCompositeIdentifier] {
+func ScopeQualifiedCompositeIdentifierFromPath(p CompositeIdentifierPath) TerraformIdentifierExtractor[ScopeQualifiedCompositeIdentifier] {
 	return func(ctx context.Context, reader TerraformAttributeReader) (ScopeQualifiedCompositeIdentifier, diag.Diagnostics) {
 		var prefix types.String
-		diags := reader.GetAttribute(ctx, prefixPath, &prefix)
+		diags := reader.GetAttribute(ctx, p.Prefix, &prefix)
 		if diags.HasError() {
 			return ScopeQualifiedCompositeIdentifier{}, diags
 		}
 
 		var name types.String
-		diags.Append(reader.GetAttribute(ctx, namePath, &name)...)
+		diags.Append(reader.GetAttribute(ctx, p.Name, &name)...)
 		if diags.HasError() {
 			return ScopeQualifiedCompositeIdentifier{}, diags
 		}
@@ -407,13 +418,13 @@ func scopeQualifiedNameIdentifierFromPossiblyQualifiedString(s string) (ScopeQua
 
 // ScopeQualifiedCompositeIdentifierPolicy returns a policy for scope-qualified
 // composite identifiers.
-func ScopeQualifiedCompositeIdentifierPolicy[T any](prefixPath, namePath path.Path, resourcePrefixAndName func(*T) (prefix, name string)) IdentifierPolicy[T, ScopeQualifiedCompositeIdentifier] {
+func ScopeQualifiedCompositeIdentifierPolicy[T any](p CompositeIdentifierPath, resourcePrefixAndName func(*T) CompositeIdentifier) IdentifierPolicy[T, ScopeQualifiedCompositeIdentifier] {
 	return IdentifierPolicy[T, ScopeQualifiedCompositeIdentifier]{
-		FromState: ScopeQualifiedCompositeIdentifierFromPath(prefixPath, namePath),
+		FromState: ScopeQualifiedCompositeIdentifierFromPath(p),
 		FromResource: func(resource *T) ScopeQualifiedCompositeIdentifier {
-			prefix, name := resourcePrefixAndName(resource)
-			prefixID, _ := scopeQualifiedNameIdentifierFromPossiblyQualifiedString(prefix)
-			nameID, _ := scopeQualifiedNameIdentifierFromPossiblyQualifiedString(name)
+			id := resourcePrefixAndName(resource)
+			prefixID, _ := scopeQualifiedNameIdentifierFromPossiblyQualifiedString(id.Prefix)
+			nameID, _ := scopeQualifiedNameIdentifierFromPossiblyQualifiedString(id.Name)
 			return ScopeQualifiedCompositeIdentifier{Prefix: prefixID, Name: nameID}
 		},
 		FromImportID: NewScopeQualifiedCompositeIdentifier,

--- a/integrations/terraform/provider/internal/tfdriver/identifier_test.go
+++ b/integrations/terraform/provider/internal/tfdriver/identifier_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/lib/scopes"
+
 	"github.com/gravitational/teleport/integrations/terraform/provider/internal/tfdriver"
 )
 
@@ -184,7 +186,12 @@ func TestScopeQualifiedNameIdentifierFromPath(t *testing.T) {
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			identifier, d := tfdriver.ScopeQualifiedNameIdentifierFromPath(path.Root("name"), path.Root("scope"))(t.Context(), test.attributer)
+			identifier, d := tfdriver.ScopeQualifiedNameIdentifierFromPath(
+				tfdriver.ScopeQualifiedPath{
+					Name:  path.Root("name"),
+					Scope: path.Root("scope"),
+				})(t.Context(), test.attributer)
+
 			assert.Equal(t, test.expectError, d.HasError())
 			assert.Equal(t, test.expectedIdentifier, identifier)
 		})
@@ -278,7 +285,11 @@ func TestPossiblyUnscopedScopeQualifiedNameIdentifierFromPath(t *testing.T) {
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			identifier, d := tfdriver.PossiblyUnscopedScopeQualifiedNameIdentifierFromPath(path.Root("name"), path.Root("scope"))(t.Context(), test.attributer)
+			identifier, d := tfdriver.PossiblyUnscopedScopeQualifiedNameIdentifierFromPath(
+				tfdriver.ScopeQualifiedPath{
+					Name:  path.Root("name"),
+					Scope: path.Root("scope"),
+				})(t.Context(), test.attributer)
 			assert.Equal(t, test.expectError, d.HasError())
 			assert.Equal(t, test.expectedIdentifier, identifier)
 		})
@@ -362,10 +373,12 @@ func TestPossiblyUnscopedScopeQualifiedNameIdentifierPolicy(t *testing.T) {
 	}
 
 	policy := tfdriver.PossiblyUnscopedScopeQualifiedNameIdentifierPolicy(
-		path.Root("name"),
-		path.Root("scope"),
-		func(resource *testResource) (string, string) {
-			return resource.Name, resource.Scope
+		tfdriver.ScopeQualifiedPath{
+			Name:  path.Root("name"),
+			Scope: path.Root("scope"),
+		},
+		func(resource *testResource) scopes.QualifiedName {
+			return scopes.QualifiedName{Name: resource.Name, Scope: resource.Scope}
 		},
 	)
 
@@ -465,7 +478,11 @@ func TestCompositeIdentifierFromPath(t *testing.T) {
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			identifier, d := tfdriver.CompositeIdentifierFromPath(path.Root("prefix"), path.Root("name"))(t.Context(), test.attributer)
+			identifier, d := tfdriver.CompositeIdentifierFromPath(
+				tfdriver.CompositeIdentifierPath{
+					Prefix: path.Root("prefix"),
+					Name:   path.Root("name"),
+				})(t.Context(), test.attributer)
 			assert.Equal(t, test.expectError, d.HasError())
 			assert.Equal(t, test.expectedIdentifier, identifier)
 		})
@@ -552,10 +569,12 @@ func TestCompositeIdentifierPolicy(t *testing.T) {
 		name   string
 	}
 	policy := tfdriver.CompositeIdentifierPolicy(
-		path.Root("prefix"),
-		path.Root("name"),
-		func(r *resource) (prefix, name string) {
-			return r.prefix, r.name
+		tfdriver.CompositeIdentifierPath{Prefix: path.Root("prefix"), Name: path.Root("name")},
+		func(r *resource) tfdriver.CompositeIdentifier {
+			return tfdriver.CompositeIdentifier{
+				Prefix: r.prefix,
+				Name:   r.name,
+			}
 		},
 	)
 
@@ -591,10 +610,12 @@ func TestScopeQualifiedCompositeIdentifierPolicy(t *testing.T) {
 		name   string
 	}
 	policy := tfdriver.ScopeQualifiedCompositeIdentifierPolicy(
-		path.Root("prefix"),
-		path.Root("name"),
-		func(r *resource) (prefix, name string) {
-			return r.prefix, r.name
+		tfdriver.CompositeIdentifierPath{
+			Prefix: path.Root("prefix"),
+			Name:   path.Root("name"),
+		},
+		func(r *resource) tfdriver.CompositeIdentifier {
+			return tfdriver.CompositeIdentifier{Prefix: r.prefix, Name: r.name}
 		},
 	)
 
@@ -649,10 +670,12 @@ func TestScopeQualifiedNameIdentifierPolicy(t *testing.T) {
 		scope string
 	}
 	policy := tfdriver.ScopeQualifiedNameIdentifierPolicy(
-		path.Root("name"),
-		path.Root("scope"),
-		func(r *resource) (name, scope string) {
-			return r.name, r.scope
+		tfdriver.ScopeQualifiedPath{
+			Name:  path.Root("name"),
+			Scope: path.Root("scope"),
+		},
+		func(r *resource) scopes.QualifiedName {
+			return scopes.QualifiedName{Name: r.name, Scope: r.scope}
 		},
 	)
 


### PR DESCRIPTION
The IdentifierFromPath and IdentifierPolicy functions no longer rely on positional arguments to improve type safety. Path inputs are now combined into a single struct with named fields to better catch mistakes. Return types from IdentifierPolicy functions are now a single struct with named fields instead of returning multiple strings.
