### PR TITLE
Support scope filtering/watching for scoped bot instances

### DIFF
--- a/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_protohybrid.pb.go
@@ -754,9 +754,7 @@ type ListBotInstancesV2Request_Filters struct {
 	// should specify mode ALL.
 	//
 	// Mutually exclusive with bot_name, which already constrains the result to a
-	// single bot in a single scope; setting both is an error. Nested here, unlike
-	// other scope-aware list RPCs, because it is meaningless in isolation from
-	// bot_name and bot_scope.
+	// single bot in a single scope; setting both is an error.
 	ScopeFilter   *v1.Filter `protobuf:"bytes,5,opt,name=scope_filter,json=scopeFilter,proto3" json:"scope_filter,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -877,9 +875,7 @@ type ListBotInstancesV2Request_Filters_builder struct {
 	// should specify mode ALL.
 	//
 	// Mutually exclusive with bot_name, which already constrains the result to a
-	// single bot in a single scope; setting both is an error. Nested here, unlike
-	// other scope-aware list RPCs, because it is meaningless in isolation from
-	// bot_name and bot_scope.
+	// single bot in a single scope; setting both is an error.
 	ScopeFilter *v1.Filter
 }
 

--- a/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_protohybrid.pb.go
@@ -23,6 +23,7 @@
 package machineidv1
 
 import (
+	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	types "github.com/gravitational/teleport/api/types"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -745,8 +746,18 @@ type ListBotInstancesV2Request_Filters struct {
 	// (a scoped bot is identified by the pair (scope, name)); setting bot_scope
 	// without bot_name is an error. An empty bot_scope with a non-empty bot_name
 	// selects the unscoped bot with that name. This is not a standalone scope
-	// filter for listing all of a scope's instances.
-	BotScope      string `protobuf:"bytes,4,opt,name=bot_scope,json=botScope,proto3" json:"bot_scope,omitempty"`
+	// filter for listing all of a scope's instances - use scope_filter for that.
+	BotScope string `protobuf:"bytes,4,opt,name=bot_scope,json=botScope,proto3" json:"bot_scope,omitempty"`
+	// scope_filter selects BotInstances by the scope of their owning bot.
+	// Defaults to one of EXACT or UNSCOPED depending on whether the caller is a
+	// scoped or unscoped identity. Exhaustive user-facing views (e.g. `tctl get`)
+	// should specify mode ALL.
+	//
+	// Mutually exclusive with bot_name, which already constrains the result to a
+	// single bot in a single scope; setting both is an error. Nested here, unlike
+	// other scope-aware list RPCs, because it is meaningless in isolation from
+	// bot_name and bot_scope.
+	ScopeFilter   *v1.Filter `protobuf:"bytes,5,opt,name=scope_filter,json=scopeFilter,proto3" json:"scope_filter,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -804,6 +815,13 @@ func (x *ListBotInstancesV2Request_Filters) GetBotScope() string {
 	return ""
 }
 
+func (x *ListBotInstancesV2Request_Filters) GetScopeFilter() *v1.Filter {
+	if x != nil {
+		return x.ScopeFilter
+	}
+	return nil
+}
+
 func (x *ListBotInstancesV2Request_Filters) SetBotName(v string) {
 	x.BotName = v
 }
@@ -818,6 +836,21 @@ func (x *ListBotInstancesV2Request_Filters) SetQuery(v string) {
 
 func (x *ListBotInstancesV2Request_Filters) SetBotScope(v string) {
 	x.BotScope = v
+}
+
+func (x *ListBotInstancesV2Request_Filters) SetScopeFilter(v *v1.Filter) {
+	x.ScopeFilter = v
+}
+
+func (x *ListBotInstancesV2Request_Filters) HasScopeFilter() bool {
+	if x == nil {
+		return false
+	}
+	return x.ScopeFilter != nil
+}
+
+func (x *ListBotInstancesV2Request_Filters) ClearScopeFilter() {
+	x.ScopeFilter = nil
 }
 
 type ListBotInstancesV2Request_Filters_builder struct {
@@ -836,8 +869,18 @@ type ListBotInstancesV2Request_Filters_builder struct {
 	// (a scoped bot is identified by the pair (scope, name)); setting bot_scope
 	// without bot_name is an error. An empty bot_scope with a non-empty bot_name
 	// selects the unscoped bot with that name. This is not a standalone scope
-	// filter for listing all of a scope's instances.
+	// filter for listing all of a scope's instances - use scope_filter for that.
 	BotScope string
+	// scope_filter selects BotInstances by the scope of their owning bot.
+	// Defaults to one of EXACT or UNSCOPED depending on whether the caller is a
+	// scoped or unscoped identity. Exhaustive user-facing views (e.g. `tctl get`)
+	// should specify mode ALL.
+	//
+	// Mutually exclusive with bot_name, which already constrains the result to a
+	// single bot in a single scope; setting both is an error. Nested here, unlike
+	// other scope-aware list RPCs, because it is meaningless in isolation from
+	// bot_name and bot_scope.
+	ScopeFilter *v1.Filter
 }
 
 func (b0 ListBotInstancesV2Request_Filters_builder) Build() *ListBotInstancesV2Request_Filters {
@@ -848,6 +891,7 @@ func (b0 ListBotInstancesV2Request_Filters_builder) Build() *ListBotInstancesV2R
 	x.SearchTerm = b.SearchTerm
 	x.Query = b.Query
 	x.BotScope = b.BotScope
+	x.ScopeFilter = b.ScopeFilter
 	return m0
 }
 
@@ -855,7 +899,7 @@ var File_teleport_machineid_v1_bot_instance_service_proto protoreflect.FileDescr
 
 const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
-	"0teleport/machineid/v1/bot_instance_service.proto\x12\x15teleport.machineid.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\"p\n" +
+	"0teleport/machineid/v1/bot_instance_service.proto\x12\x15teleport.machineid.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\x1a\x1fteleport/scopes/v1/scopes.proto\"p\n" +
 	"\x15GetBotInstanceRequest\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vinstance_id\x18\x02 \x01(\tR\n" +
@@ -867,7 +911,7 @@ const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
 	"page_token\x18\x03 \x01(\tR\tpageToken\x12,\n" +
 	"\x12filter_search_term\x18\x04 \x01(\tR\x10filterSearchTerm\x12!\n" +
-	"\x04sort\x18\x05 \x01(\v2\r.types.SortByR\x04sort\"\xdf\x02\n" +
+	"\x04sort\x18\x05 \x01(\v2\r.types.SortByR\x04sort\"\x9f\x03\n" +
 	"\x19ListBotInstancesV2Request\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
@@ -875,13 +919,14 @@ const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
 	"sort_field\x18\x03 \x01(\tR\tsortField\x12\x1b\n" +
 	"\tsort_desc\x18\x04 \x01(\bR\bsortDesc\x12P\n" +
-	"\x06filter\x18\x05 \x01(\v28.teleport.machineid.v1.ListBotInstancesV2Request.FiltersR\x06filter\x1ax\n" +
+	"\x06filter\x18\x05 \x01(\v28.teleport.machineid.v1.ListBotInstancesV2Request.FiltersR\x06filter\x1a\xb7\x01\n" +
 	"\aFilters\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vsearch_term\x18\x02 \x01(\tR\n" +
 	"searchTerm\x12\x14\n" +
 	"\x05query\x18\x03 \x01(\tR\x05query\x12\x1b\n" +
-	"\tbot_scope\x18\x04 \x01(\tR\bbotScope\"\x8b\x01\n" +
+	"\tbot_scope\x18\x04 \x01(\tR\bbotScope\x12=\n" +
+	"\fscope_filter\x18\x05 \x01(\v2\x1a.teleport.scopes.v1.FilterR\vscopeFilter\"\x8b\x01\n" +
 	"\x18ListBotInstancesResponse\x12G\n" +
 	"\rbot_instances\x18\x01 \x03(\v2\".teleport.machineid.v1.BotInstanceR\fbotInstances\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"s\n" +
@@ -915,7 +960,8 @@ var file_teleport_machineid_v1_bot_instance_service_proto_goTypes = []any{
 	(*BotInstance)(nil),                       // 9: teleport.machineid.v1.BotInstance
 	(*BotInstanceStatusHeartbeat)(nil),        // 10: teleport.machineid.v1.BotInstanceStatusHeartbeat
 	(*BotInstanceServiceHealth)(nil),          // 11: teleport.machineid.v1.BotInstanceServiceHealth
-	(*emptypb.Empty)(nil),                     // 12: google.protobuf.Empty
+	(*v1.Filter)(nil),                         // 12: teleport.scopes.v1.Filter
+	(*emptypb.Empty)(nil),                     // 13: google.protobuf.Empty
 }
 var file_teleport_machineid_v1_bot_instance_service_proto_depIdxs = []int32{
 	8,  // 0: teleport.machineid.v1.ListBotInstancesRequest.sort:type_name -> types.SortBy
@@ -923,21 +969,22 @@ var file_teleport_machineid_v1_bot_instance_service_proto_depIdxs = []int32{
 	9,  // 2: teleport.machineid.v1.ListBotInstancesResponse.bot_instances:type_name -> teleport.machineid.v1.BotInstance
 	10, // 3: teleport.machineid.v1.SubmitHeartbeatRequest.heartbeat:type_name -> teleport.machineid.v1.BotInstanceStatusHeartbeat
 	11, // 4: teleport.machineid.v1.SubmitHeartbeatRequest.service_health:type_name -> teleport.machineid.v1.BotInstanceServiceHealth
-	0,  // 5: teleport.machineid.v1.BotInstanceService.GetBotInstance:input_type -> teleport.machineid.v1.GetBotInstanceRequest
-	1,  // 6: teleport.machineid.v1.BotInstanceService.ListBotInstances:input_type -> teleport.machineid.v1.ListBotInstancesRequest
-	2,  // 7: teleport.machineid.v1.BotInstanceService.ListBotInstancesV2:input_type -> teleport.machineid.v1.ListBotInstancesV2Request
-	4,  // 8: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:input_type -> teleport.machineid.v1.DeleteBotInstanceRequest
-	5,  // 9: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:input_type -> teleport.machineid.v1.SubmitHeartbeatRequest
-	9,  // 10: teleport.machineid.v1.BotInstanceService.GetBotInstance:output_type -> teleport.machineid.v1.BotInstance
-	3,  // 11: teleport.machineid.v1.BotInstanceService.ListBotInstances:output_type -> teleport.machineid.v1.ListBotInstancesResponse
-	3,  // 12: teleport.machineid.v1.BotInstanceService.ListBotInstancesV2:output_type -> teleport.machineid.v1.ListBotInstancesResponse
-	12, // 13: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:output_type -> google.protobuf.Empty
-	6,  // 14: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:output_type -> teleport.machineid.v1.SubmitHeartbeatResponse
-	10, // [10:15] is the sub-list for method output_type
-	5,  // [5:10] is the sub-list for method input_type
-	5,  // [5:5] is the sub-list for extension type_name
-	5,  // [5:5] is the sub-list for extension extendee
-	0,  // [0:5] is the sub-list for field type_name
+	12, // 5: teleport.machineid.v1.ListBotInstancesV2Request.Filters.scope_filter:type_name -> teleport.scopes.v1.Filter
+	0,  // 6: teleport.machineid.v1.BotInstanceService.GetBotInstance:input_type -> teleport.machineid.v1.GetBotInstanceRequest
+	1,  // 7: teleport.machineid.v1.BotInstanceService.ListBotInstances:input_type -> teleport.machineid.v1.ListBotInstancesRequest
+	2,  // 8: teleport.machineid.v1.BotInstanceService.ListBotInstancesV2:input_type -> teleport.machineid.v1.ListBotInstancesV2Request
+	4,  // 9: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:input_type -> teleport.machineid.v1.DeleteBotInstanceRequest
+	5,  // 10: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:input_type -> teleport.machineid.v1.SubmitHeartbeatRequest
+	9,  // 11: teleport.machineid.v1.BotInstanceService.GetBotInstance:output_type -> teleport.machineid.v1.BotInstance
+	3,  // 12: teleport.machineid.v1.BotInstanceService.ListBotInstances:output_type -> teleport.machineid.v1.ListBotInstancesResponse
+	3,  // 13: teleport.machineid.v1.BotInstanceService.ListBotInstancesV2:output_type -> teleport.machineid.v1.ListBotInstancesResponse
+	13, // 14: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:output_type -> google.protobuf.Empty
+	6,  // 15: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:output_type -> teleport.machineid.v1.SubmitHeartbeatResponse
+	11, // [11:16] is the sub-list for method output_type
+	6,  // [6:11] is the sub-list for method input_type
+	6,  // [6:6] is the sub-list for extension type_name
+	6,  // [6:6] is the sub-list for extension extendee
+	0,  // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_teleport_machineid_v1_bot_instance_service_proto_init() }

--- a/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_protoopaque.pb.go
@@ -829,9 +829,7 @@ type ListBotInstancesV2Request_Filters_builder struct {
 	// should specify mode ALL.
 	//
 	// Mutually exclusive with bot_name, which already constrains the result to a
-	// single bot in a single scope; setting both is an error. Nested here, unlike
-	// other scope-aware list RPCs, because it is meaningless in isolation from
-	// bot_name and bot_scope.
+	// single bot in a single scope; setting both is an error.
 	ScopeFilter *v1.Filter
 }
 

--- a/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_protoopaque.pb.go
@@ -23,6 +23,7 @@
 package machineidv1
 
 import (
+	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	types "github.com/gravitational/teleport/api/types"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -703,13 +704,14 @@ func (b0 SubmitHeartbeatResponse_builder) Build() *SubmitHeartbeatResponse {
 
 // Filters contains fields to be used to filter the results.
 type ListBotInstancesV2Request_Filters struct {
-	state                 protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_BotName    string                 `protobuf:"bytes,1,opt,name=bot_name,json=botName,proto3"`
-	xxx_hidden_SearchTerm string                 `protobuf:"bytes,2,opt,name=search_term,json=searchTerm,proto3"`
-	xxx_hidden_Query      string                 `protobuf:"bytes,3,opt,name=query,proto3"`
-	xxx_hidden_BotScope   string                 `protobuf:"bytes,4,opt,name=bot_scope,json=botScope,proto3"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	state                  protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_BotName     string                 `protobuf:"bytes,1,opt,name=bot_name,json=botName,proto3"`
+	xxx_hidden_SearchTerm  string                 `protobuf:"bytes,2,opt,name=search_term,json=searchTerm,proto3"`
+	xxx_hidden_Query       string                 `protobuf:"bytes,3,opt,name=query,proto3"`
+	xxx_hidden_BotScope    string                 `protobuf:"bytes,4,opt,name=bot_scope,json=botScope,proto3"`
+	xxx_hidden_ScopeFilter *v1.Filter             `protobuf:"bytes,5,opt,name=scope_filter,json=scopeFilter,proto3"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *ListBotInstancesV2Request_Filters) Reset() {
@@ -765,6 +767,13 @@ func (x *ListBotInstancesV2Request_Filters) GetBotScope() string {
 	return ""
 }
 
+func (x *ListBotInstancesV2Request_Filters) GetScopeFilter() *v1.Filter {
+	if x != nil {
+		return x.xxx_hidden_ScopeFilter
+	}
+	return nil
+}
+
 func (x *ListBotInstancesV2Request_Filters) SetBotName(v string) {
 	x.xxx_hidden_BotName = v
 }
@@ -779,6 +788,21 @@ func (x *ListBotInstancesV2Request_Filters) SetQuery(v string) {
 
 func (x *ListBotInstancesV2Request_Filters) SetBotScope(v string) {
 	x.xxx_hidden_BotScope = v
+}
+
+func (x *ListBotInstancesV2Request_Filters) SetScopeFilter(v *v1.Filter) {
+	x.xxx_hidden_ScopeFilter = v
+}
+
+func (x *ListBotInstancesV2Request_Filters) HasScopeFilter() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_ScopeFilter != nil
+}
+
+func (x *ListBotInstancesV2Request_Filters) ClearScopeFilter() {
+	x.xxx_hidden_ScopeFilter = nil
 }
 
 type ListBotInstancesV2Request_Filters_builder struct {
@@ -797,8 +821,18 @@ type ListBotInstancesV2Request_Filters_builder struct {
 	// (a scoped bot is identified by the pair (scope, name)); setting bot_scope
 	// without bot_name is an error. An empty bot_scope with a non-empty bot_name
 	// selects the unscoped bot with that name. This is not a standalone scope
-	// filter for listing all of a scope's instances.
+	// filter for listing all of a scope's instances - use scope_filter for that.
 	BotScope string
+	// scope_filter selects BotInstances by the scope of their owning bot.
+	// Defaults to one of EXACT or UNSCOPED depending on whether the caller is a
+	// scoped or unscoped identity. Exhaustive user-facing views (e.g. `tctl get`)
+	// should specify mode ALL.
+	//
+	// Mutually exclusive with bot_name, which already constrains the result to a
+	// single bot in a single scope; setting both is an error. Nested here, unlike
+	// other scope-aware list RPCs, because it is meaningless in isolation from
+	// bot_name and bot_scope.
+	ScopeFilter *v1.Filter
 }
 
 func (b0 ListBotInstancesV2Request_Filters_builder) Build() *ListBotInstancesV2Request_Filters {
@@ -809,6 +843,7 @@ func (b0 ListBotInstancesV2Request_Filters_builder) Build() *ListBotInstancesV2R
 	x.xxx_hidden_SearchTerm = b.SearchTerm
 	x.xxx_hidden_Query = b.Query
 	x.xxx_hidden_BotScope = b.BotScope
+	x.xxx_hidden_ScopeFilter = b.ScopeFilter
 	return m0
 }
 
@@ -816,7 +851,7 @@ var File_teleport_machineid_v1_bot_instance_service_proto protoreflect.FileDescr
 
 const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
-	"0teleport/machineid/v1/bot_instance_service.proto\x12\x15teleport.machineid.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\"p\n" +
+	"0teleport/machineid/v1/bot_instance_service.proto\x12\x15teleport.machineid.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\x1a\x1fteleport/scopes/v1/scopes.proto\"p\n" +
 	"\x15GetBotInstanceRequest\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vinstance_id\x18\x02 \x01(\tR\n" +
@@ -828,7 +863,7 @@ const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
 	"page_token\x18\x03 \x01(\tR\tpageToken\x12,\n" +
 	"\x12filter_search_term\x18\x04 \x01(\tR\x10filterSearchTerm\x12!\n" +
-	"\x04sort\x18\x05 \x01(\v2\r.types.SortByR\x04sort\"\xdf\x02\n" +
+	"\x04sort\x18\x05 \x01(\v2\r.types.SortByR\x04sort\"\x9f\x03\n" +
 	"\x19ListBotInstancesV2Request\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
@@ -836,13 +871,14 @@ const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
 	"sort_field\x18\x03 \x01(\tR\tsortField\x12\x1b\n" +
 	"\tsort_desc\x18\x04 \x01(\bR\bsortDesc\x12P\n" +
-	"\x06filter\x18\x05 \x01(\v28.teleport.machineid.v1.ListBotInstancesV2Request.FiltersR\x06filter\x1ax\n" +
+	"\x06filter\x18\x05 \x01(\v28.teleport.machineid.v1.ListBotInstancesV2Request.FiltersR\x06filter\x1a\xb7\x01\n" +
 	"\aFilters\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vsearch_term\x18\x02 \x01(\tR\n" +
 	"searchTerm\x12\x14\n" +
 	"\x05query\x18\x03 \x01(\tR\x05query\x12\x1b\n" +
-	"\tbot_scope\x18\x04 \x01(\tR\bbotScope\"\x8b\x01\n" +
+	"\tbot_scope\x18\x04 \x01(\tR\bbotScope\x12=\n" +
+	"\fscope_filter\x18\x05 \x01(\v2\x1a.teleport.scopes.v1.FilterR\vscopeFilter\"\x8b\x01\n" +
 	"\x18ListBotInstancesResponse\x12G\n" +
 	"\rbot_instances\x18\x01 \x03(\v2\".teleport.machineid.v1.BotInstanceR\fbotInstances\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"s\n" +
@@ -876,7 +912,8 @@ var file_teleport_machineid_v1_bot_instance_service_proto_goTypes = []any{
 	(*BotInstance)(nil),                       // 9: teleport.machineid.v1.BotInstance
 	(*BotInstanceStatusHeartbeat)(nil),        // 10: teleport.machineid.v1.BotInstanceStatusHeartbeat
 	(*BotInstanceServiceHealth)(nil),          // 11: teleport.machineid.v1.BotInstanceServiceHealth
-	(*emptypb.Empty)(nil),                     // 12: google.protobuf.Empty
+	(*v1.Filter)(nil),                         // 12: teleport.scopes.v1.Filter
+	(*emptypb.Empty)(nil),                     // 13: google.protobuf.Empty
 }
 var file_teleport_machineid_v1_bot_instance_service_proto_depIdxs = []int32{
 	8,  // 0: teleport.machineid.v1.ListBotInstancesRequest.sort:type_name -> types.SortBy
@@ -884,21 +921,22 @@ var file_teleport_machineid_v1_bot_instance_service_proto_depIdxs = []int32{
 	9,  // 2: teleport.machineid.v1.ListBotInstancesResponse.bot_instances:type_name -> teleport.machineid.v1.BotInstance
 	10, // 3: teleport.machineid.v1.SubmitHeartbeatRequest.heartbeat:type_name -> teleport.machineid.v1.BotInstanceStatusHeartbeat
 	11, // 4: teleport.machineid.v1.SubmitHeartbeatRequest.service_health:type_name -> teleport.machineid.v1.BotInstanceServiceHealth
-	0,  // 5: teleport.machineid.v1.BotInstanceService.GetBotInstance:input_type -> teleport.machineid.v1.GetBotInstanceRequest
-	1,  // 6: teleport.machineid.v1.BotInstanceService.ListBotInstances:input_type -> teleport.machineid.v1.ListBotInstancesRequest
-	2,  // 7: teleport.machineid.v1.BotInstanceService.ListBotInstancesV2:input_type -> teleport.machineid.v1.ListBotInstancesV2Request
-	4,  // 8: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:input_type -> teleport.machineid.v1.DeleteBotInstanceRequest
-	5,  // 9: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:input_type -> teleport.machineid.v1.SubmitHeartbeatRequest
-	9,  // 10: teleport.machineid.v1.BotInstanceService.GetBotInstance:output_type -> teleport.machineid.v1.BotInstance
-	3,  // 11: teleport.machineid.v1.BotInstanceService.ListBotInstances:output_type -> teleport.machineid.v1.ListBotInstancesResponse
-	3,  // 12: teleport.machineid.v1.BotInstanceService.ListBotInstancesV2:output_type -> teleport.machineid.v1.ListBotInstancesResponse
-	12, // 13: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:output_type -> google.protobuf.Empty
-	6,  // 14: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:output_type -> teleport.machineid.v1.SubmitHeartbeatResponse
-	10, // [10:15] is the sub-list for method output_type
-	5,  // [5:10] is the sub-list for method input_type
-	5,  // [5:5] is the sub-list for extension type_name
-	5,  // [5:5] is the sub-list for extension extendee
-	0,  // [0:5] is the sub-list for field type_name
+	12, // 5: teleport.machineid.v1.ListBotInstancesV2Request.Filters.scope_filter:type_name -> teleport.scopes.v1.Filter
+	0,  // 6: teleport.machineid.v1.BotInstanceService.GetBotInstance:input_type -> teleport.machineid.v1.GetBotInstanceRequest
+	1,  // 7: teleport.machineid.v1.BotInstanceService.ListBotInstances:input_type -> teleport.machineid.v1.ListBotInstancesRequest
+	2,  // 8: teleport.machineid.v1.BotInstanceService.ListBotInstancesV2:input_type -> teleport.machineid.v1.ListBotInstancesV2Request
+	4,  // 9: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:input_type -> teleport.machineid.v1.DeleteBotInstanceRequest
+	5,  // 10: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:input_type -> teleport.machineid.v1.SubmitHeartbeatRequest
+	9,  // 11: teleport.machineid.v1.BotInstanceService.GetBotInstance:output_type -> teleport.machineid.v1.BotInstance
+	3,  // 12: teleport.machineid.v1.BotInstanceService.ListBotInstances:output_type -> teleport.machineid.v1.ListBotInstancesResponse
+	3,  // 13: teleport.machineid.v1.BotInstanceService.ListBotInstancesV2:output_type -> teleport.machineid.v1.ListBotInstancesResponse
+	13, // 14: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:output_type -> google.protobuf.Empty
+	6,  // 15: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:output_type -> teleport.machineid.v1.SubmitHeartbeatResponse
+	11, // [11:16] is the sub-list for method output_type
+	6,  // [6:11] is the sub-list for method input_type
+	6,  // [6:6] is the sub-list for extension type_name
+	6,  // [6:6] is the sub-list for extension extendee
+	0,  // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_teleport_machineid_v1_bot_instance_service_proto_init() }

--- a/api/proto/teleport/machineid/v1/bot_instance_service.proto
+++ b/api/proto/teleport/machineid/v1/bot_instance_service.proto
@@ -19,6 +19,7 @@ package teleport.machineid.v1;
 import "google/protobuf/empty.proto";
 import "teleport/legacy/types/types.proto";
 import "teleport/machineid/v1/bot_instance.proto";
+import "teleport/scopes/v1/scopes.proto";
 
 option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1;machineidv1";
 
@@ -89,8 +90,18 @@ message ListBotInstancesV2Request {
     // (a scoped bot is identified by the pair (scope, name)); setting bot_scope
     // without bot_name is an error. An empty bot_scope with a non-empty bot_name
     // selects the unscoped bot with that name. This is not a standalone scope
-    // filter for listing all of a scope's instances.
+    // filter for listing all of a scope's instances - use scope_filter for that.
     string bot_scope = 4;
+    // scope_filter selects BotInstances by the scope of their owning bot.
+    // Defaults to one of EXACT or UNSCOPED depending on whether the caller is a
+    // scoped or unscoped identity. Exhaustive user-facing views (e.g. `tctl get`)
+    // should specify mode ALL.
+    //
+    // Mutually exclusive with bot_name, which already constrains the result to a
+    // single bot in a single scope; setting both is an error. Nested here, unlike
+    // other scope-aware list RPCs, because it is meaningless in isolation from
+    // bot_name and bot_scope.
+    teleport.scopes.v1.Filter scope_filter = 5;
   }
 }
 

--- a/api/proto/teleport/machineid/v1/bot_instance_service.proto
+++ b/api/proto/teleport/machineid/v1/bot_instance_service.proto
@@ -98,9 +98,7 @@ message ListBotInstancesV2Request {
     // should specify mode ALL.
     //
     // Mutually exclusive with bot_name, which already constrains the result to a
-    // single bot in a single scope; setting both is an error. Nested here, unlike
-    // other scope-aware list RPCs, because it is meaningless in isolation from
-    // bot_name and bot_scope.
+    // single bot in a single scope; setting both is an error.
     teleport.scopes.v1.Filter scope_filter = 5;
   }
 }

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1279,6 +1279,7 @@ func supportedScopedWatchKind(kind string) bool {
 	case types.KindAccessList,
 		types.KindAccessListMember,
 		types.KindAccessListReview,
+		types.KindBotInstance,
 		scopedaccess.KindScopedRole,
 		scopedaccess.KindScopedRoleAssignment,
 		types.KindKubernetesCluster:

--- a/lib/auth/auth_with_roles_watch_authz_test.go
+++ b/lib/auth/auth_with_roles_watch_authz_test.go
@@ -197,6 +197,38 @@ func TestScopedWatchKindAuthz(t *testing.T) {
 			assertErr: requireAccessDenied,
 		},
 		{
+			// bot_instance is namespaced and carries its scope on delete events, so it is
+			// whitelisted for scope-targeting watch filters.
+			name:      "bot_instance default resolves to EXACT at pin",
+			kind:      types.KindBotInstance,
+			filter:    nil,
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_EXACT,
+			wantScope: pinScope,
+		},
+		{
+			name:      "bot_instance DESCENDANTS at pin",
+			kind:      types.KindBotInstance,
+			filter:    filter(scopesv1.Mode_MODE_DESCENDANTS, pinScope),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_DESCENDANTS,
+			wantScope: pinScope,
+		},
+		{
+			name:      "bot_instance ALL rewritten to DESCENDANTS at pin",
+			kind:      types.KindBotInstance,
+			filter:    filter(scopesv1.Mode_MODE_ALL, ""),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_DESCENDANTS,
+			wantScope: pinScope,
+		},
+		{
+			name:      "bot_instance EXACT at orthogonal scope denied by pin enforcement",
+			kind:      types.KindBotInstance,
+			filter:    filter(scopesv1.Mode_MODE_EXACT, "/bar"),
+			assertErr: requireAccessDenied,
+		},
+		{
 			// scoped-kind-whitelist: this test case and associated behaviore can be removed once all scoped
 			// kinds are namespaced.
 			name:      "non-namespaced kind EXACT denied by whitelist",
@@ -395,6 +427,20 @@ func TestUnscopedWatchKindAuthz(t *testing.T) {
 		{
 			name:      "scoped_role EXACT allowed for unscoped caller",
 			kind:      scopedaccess.KindScopedRole,
+			filter:    filter(scopesv1.Mode_MODE_EXACT, "/foo"),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_EXACT,
+		},
+		{
+			name:      "bot_instance defaults to UNSCOPED for unscoped caller",
+			kind:      types.KindBotInstance,
+			filter:    nil,
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_UNSCOPED,
+		},
+		{
+			name:      "bot_instance EXACT allowed for unscoped caller",
+			kind:      types.KindBotInstance,
 			filter:    filter(scopesv1.Mode_MODE_EXACT, "/foo"),
 			assertErr: require.NoError,
 			wantMode:  scopesv1.Mode_MODE_EXACT,

--- a/lib/auth/machineid/machineidv1/bot_instance_service.go
+++ b/lib/auth/machineid/machineidv1/bot_instance_service.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/scopes"
@@ -218,14 +219,23 @@ func (b *BotInstanceService) ListBotInstances(ctx context.Context, req *pb.ListB
 		sortField = req.GetSort().Field
 		sortDesc = req.GetSort().IsDesc
 	}
+	// V1 cannot express a scope filter, so pin it to mode ALL rather than letting it
+	// inherit the identity-based default and silently hide scoped instances. Left
+	// unset alongside a bot filter, which V2 rejects the combination of.
+	var scopeFilter *scopesv1.Filter
+	if req.GetFilterBotName() == "" {
+		scopeFilter = scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build()
+	}
+
 	return b.ListBotInstancesV2(ctx, pb.ListBotInstancesV2Request_builder{
 		PageSize:  req.GetPageSize(),
 		PageToken: req.GetPageToken(),
 		SortField: sortField,
 		SortDesc:  sortDesc,
 		Filter: pb.ListBotInstancesV2Request_Filters_builder{
-			BotName:    req.GetFilterBotName(),
-			SearchTerm: req.GetFilterSearchTerm(),
+			BotName:     req.GetFilterBotName(),
+			SearchTerm:  req.GetFilterSearchTerm(),
+			ScopeFilter: scopeFilter,
 		}.Build(),
 	}.Build())
 }
@@ -247,9 +257,8 @@ func (b *BotInstanceService) ListBotInstancesV2(ctx context.Context, req *pb.Lis
 	}
 
 	if filterBotScope := req.GetFilter().GetBotScope(); filterBotScope != "" {
-		// bot_scope is only designed to scope-qualify bot_name. If we want to
-		// introduce actual scope-filtering down the line, we'll introduce a
-		// new field with more control (i.e. exact, descendent)
+		// bot_scope only scope-qualifies bot_name. Standalone scope filtering is
+		// scope_filter, handled below.
 		if req.GetFilter().GetBotName() == "" {
 			return nil, trace.BadParameter(
 				"bot_scope filter requires bot_name",
@@ -257,6 +266,28 @@ func (b *BotInstanceService) ListBotInstancesV2(ctx context.Context, req *pb.Lis
 		}
 
 		if err := scopes.StrongValidate(filterBotScope); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	// A bot filter already identifies a single bot in a single scope, so reject a
+	// scope filter alongside it rather than silently dropping one. Checked before
+	// defaulting, which would otherwise populate a filter for callers who set none.
+	byBot := req.GetFilter().GetBotName() != ""
+	explicitScopeFilter := req.GetFilter().GetScopeFilter().GetMode() != scopesv1.Mode_MODE_UNSPECIFIED
+	if byBot && explicitScopeFilter {
+		return nil, trace.BadParameter(
+			"scope_filter cannot be combined with a bot_name filter",
+		)
+	}
+
+	// Only the unfiltered listing gets a filter; defaulting on the by-bot path would
+	// hand the layers below the combination they reject.
+	var scopeFilter *scopesv1.Filter
+	if !byBot {
+		// list method scope filters must use identity-based defaults per RFD 0229i
+		scopeFilter = authCtx.CheckerContext.ResolveScopeFilter(req.GetFilter().GetScopeFilter())
+		if err := scopes.ValidateFilter(scopeFilter); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -270,6 +301,7 @@ func (b *BotInstanceService) ListBotInstancesV2(ctx context.Context, req *pb.Lis
 			SortDesc:         req.GetSortDesc(),
 			FilterBotName:    req.GetFilter().GetBotName(),
 			FilterBotScope:   req.GetFilter().GetBotScope(),
+			ScopeFilter:      scopeFilter,
 			FilterSearchTerm: req.GetFilter().GetSearchTerm(),
 			FilterQuery:      req.GetFilter().GetQuery(),
 			FilterFn: func(botInstance *pb.BotInstance) bool {

--- a/lib/auth/machineid/machineidv1/bot_instance_service.go
+++ b/lib/auth/machineid/machineidv1/bot_instance_service.go
@@ -270,8 +270,7 @@ func (b *BotInstanceService) ListBotInstancesV2(ctx context.Context, req *pb.Lis
 		}
 	}
 
-	// A bot filter already identifies a single bot in a single scope, so reject a
-	// scope filter alongside it rather than silently dropping one. Checked before
+	// Rejected rather than silently dropping one of the two; checked before
 	// defaulting, which would otherwise populate a filter for callers who set none.
 	byBot := req.GetFilter().GetBotName() != ""
 	explicitScopeFilter := req.GetFilter().GetScopeFilter().GetMode() != scopesv1.Mode_MODE_UNSPECIFIED

--- a/lib/auth/machineid/machineidv1/bot_instance_service.go
+++ b/lib/auth/machineid/machineidv1/bot_instance_service.go
@@ -256,39 +256,34 @@ func (b *BotInstanceService) ListBotInstancesV2(ctx context.Context, req *pb.Lis
 		return nil, trace.Wrap(err)
 	}
 
-	if filterBotScope := req.GetFilter().GetBotScope(); filterBotScope != "" {
-		// bot_scope only scope-qualifies bot_name. Standalone scope filtering is
-		// scope_filter, handled below.
-		if req.GetFilter().GetBotName() == "" {
+	f := req.GetFilter()
+	if err := scopes.ValidateFilter(f.GetScopeFilter()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var scopeFilter *scopesv1.Filter
+	if f.GetBotName() != "" {
+		// By-bot listing: bot_scope qualifies bot_name, which already pins the
+		// scope, so a scope_filter is meaningless and rejected.
+		if f.GetScopeFilter().GetMode() != scopesv1.Mode_MODE_UNSPECIFIED {
+			return nil, trace.BadParameter(
+				"scope_filter cannot be combined with a bot_name filter",
+			)
+		}
+		if f.GetBotScope() != "" {
+			if err := scopes.StrongValidate(f.GetBotScope()); err != nil {
+				return nil, trace.Wrap(err)
+			}
+		}
+	} else {
+		// Cross-bot listing: scope_filter selects the scopes, with identity-based
+		// defaults per RFD 0229i; bot_scope only exists to qualify bot_name.
+		if f.GetBotScope() != "" {
 			return nil, trace.BadParameter(
 				"bot_scope filter requires bot_name",
 			)
 		}
-
-		if err := scopes.StrongValidate(filterBotScope); err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-
-	// Rejected rather than silently dropping one of the two; checked before
-	// defaulting, which would otherwise populate a filter for callers who set none.
-	byBot := req.GetFilter().GetBotName() != ""
-	explicitScopeFilter := req.GetFilter().GetScopeFilter().GetMode() != scopesv1.Mode_MODE_UNSPECIFIED
-	if byBot && explicitScopeFilter {
-		return nil, trace.BadParameter(
-			"scope_filter cannot be combined with a bot_name filter",
-		)
-	}
-
-	// Only the unfiltered listing gets a filter; defaulting on the by-bot path would
-	// hand the layers below the combination they reject.
-	var scopeFilter *scopesv1.Filter
-	if !byBot {
-		// list method scope filters must use identity-based defaults per RFD 0229i
-		scopeFilter = authCtx.CheckerContext.ResolveScopeFilter(req.GetFilter().GetScopeFilter())
-		if err := scopes.ValidateFilter(scopeFilter); err != nil {
-			return nil, trace.Wrap(err)
-		}
+		scopeFilter = authCtx.CheckerContext.ResolveScopeFilter(f.GetScopeFilter())
 	}
 
 	botInstances, nextToken, err := b.cache.ListBotInstances(
@@ -298,11 +293,11 @@ func (b *BotInstanceService) ListBotInstancesV2(ctx context.Context, req *pb.Lis
 		&services.ListBotInstancesRequestOptions{
 			SortField:        req.GetSortField(),
 			SortDesc:         req.GetSortDesc(),
-			FilterBotName:    req.GetFilter().GetBotName(),
-			FilterBotScope:   req.GetFilter().GetBotScope(),
+			FilterBotName:    f.GetBotName(),
+			FilterBotScope:   f.GetBotScope(),
 			ScopeFilter:      scopeFilter,
-			FilterSearchTerm: req.GetFilter().GetSearchTerm(),
-			FilterQuery:      req.GetFilter().GetQuery(),
+			FilterSearchTerm: f.GetSearchTerm(),
+			FilterQuery:      f.GetQuery(),
 			FilterFn: func(botInstance *pb.BotInstance) bool {
 				ruleCtx := authCtx.RuleContext()
 				ruleCtx.Resource153 = botInstance

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -3638,6 +3638,24 @@ func TestBotInstanceService_ListBotInstancesV2(t *testing.T) {
 		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
 	})
 
+	t.Run("scope filter with a scope but no mode is rejected", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
+		require.NoError(t, err)
+
+		// Rejected as malformed rather than resolved to the identity default,
+		// which would silently discard the scope.
+		for _, botName := range []string{"", grantedInstances[0].GetSpec().GetBotName()} {
+			_, err = client.BotInstanceServiceClient().ListBotInstancesV2(t.Context(), machineidv1pb.ListBotInstancesV2Request_builder{
+				PageSize: 100,
+				Filter: machineidv1pb.ListBotInstancesV2Request_Filters_builder{
+					BotName:     botName,
+					ScopeFilter: scopesv1.Filter_builder{Scope: "/scopes/granted"}.Build(),
+				}.Build(),
+			}.Build())
+			require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
+		}
+	})
+
 	t.Run("bot scope with bot name returns that bot's instances", func(t *testing.T) {
 		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
 		require.NoError(t, err)

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -46,6 +46,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -3513,7 +3514,7 @@ func TestBotInstanceService_ListBotInstancesV2(t *testing.T) {
 		grantedIDs[bi.GetSpec().GetInstanceId()] = struct{}{}
 	}
 
-	listAll := func(t *testing.T, client machineidv1pb.BotInstanceServiceClient) []*machineidv1pb.BotInstance {
+	listAll := func(t *testing.T, client machineidv1pb.BotInstanceServiceClient, scopeFilter *scopesv1.Filter) []*machineidv1pb.BotInstance {
 		t.Helper()
 		out, err := stream.Collect(clientutils.Resources(
 			t.Context(),
@@ -3523,6 +3524,9 @@ func TestBotInstanceService_ListBotInstancesV2(t *testing.T) {
 				res, err := client.ListBotInstancesV2(ctx, machineidv1pb.ListBotInstancesV2Request_builder{
 					PageToken: nextToken,
 					PageSize:  int32(limit),
+					Filter: machineidv1pb.ListBotInstancesV2Request_Filters_builder{
+						ScopeFilter: scopeFilter,
+					}.Build(),
 				}.Build())
 				return res.GetBotInstances(), res.GetNextPageToken(), err
 			}),
@@ -3531,22 +3535,80 @@ func TestBotInstanceService_ListBotInstancesV2(t *testing.T) {
 		return out
 	}
 
-	t.Run("unscoped user sees all instances", func(t *testing.T) {
+	allScopes := scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build()
+
+	t.Run("unscoped user with mode ALL sees all instances", func(t *testing.T) {
 		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
 		require.NoError(t, err)
 
-		got := listAll(t, client.BotInstanceServiceClient())
+		got := listAll(t, client.BotInstanceServiceClient(), allScopes)
 		require.Len(t, got, len(allInstances))
 		for _, bi := range got {
 			require.Contains(t, allIDs, bi.GetSpec().GetInstanceId())
 		}
 	})
 
-	t.Run("scoped user sees only instances in granted scope", func(t *testing.T) {
+	t.Run("unscoped user without a scope filter sees only unscoped instances", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
+		require.NoError(t, err)
+
+		// Defaults to MODE_UNSCOPED, so scoped instances are excluded despite the
+		// caller having RBAC for them. Exhaustive views must ask for mode ALL.
+		got := listAll(t, client.BotInstanceServiceClient(), nil)
+		require.Len(t, got, len(unscopedInstances))
+		for _, bi := range got {
+			require.Empty(t, bi.GetScope())
+		}
+	})
+
+	t.Run("unscoped user can filter to an exact scope", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
+		require.NoError(t, err)
+
+		got := listAll(t, client.BotInstanceServiceClient(), scopesv1.Filter_builder{
+			Scope: "/scopes/granted",
+			Mode:  scopesv1.Mode_MODE_EXACT,
+		}.Build())
+		require.Len(t, got, len(grantedInstances))
+		for _, bi := range got {
+			require.Contains(t, grantedIDs, bi.GetSpec().GetInstanceId())
+		}
+	})
+
+	t.Run("unscoped user can filter to a scope and its descendants", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
+		require.NoError(t, err)
+
+		// Every scoped instance lives under /scopes, so this selects them all.
+		got := listAll(t, client.BotInstanceServiceClient(), scopesv1.Filter_builder{
+			Scope: "/scopes",
+			Mode:  scopesv1.Mode_MODE_DESCENDANTS,
+		}.Build())
+		require.Len(t, got, len(grantedInstances)+len(ungrantedInstances))
+		for _, bi := range got {
+			require.NotEmpty(t, bi.GetScope())
+		}
+	})
+
+	t.Run("scoped user without a scope filter sees only instances in granted scope", func(t *testing.T) {
 		client, err := srv.NewClient(authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"))
 		require.NoError(t, err)
 
-		got := listAll(t, client.BotInstanceServiceClient())
+		// An omitted filter defaults to MODE_EXACT at the caller's pin.
+		got := listAll(t, client.BotInstanceServiceClient(), nil)
+		require.Len(t, got, len(grantedInstances))
+		for _, bi := range got {
+			require.Contains(t, grantedIDs, bi.GetSpec().GetInstanceId())
+		}
+	})
+
+	t.Run("scoped user with mode ALL is still limited by RBAC", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"))
+		require.NoError(t, err)
+
+		// Unlike watches, a list does not rewrite mode ALL for scoped callers; the
+		// per-resource RBAC check is what confines them.
+		got := listAll(t, client.BotInstanceServiceClient(), allScopes)
 		require.Len(t, got, len(grantedInstances))
 		for _, bi := range got {
 			require.Contains(t, grantedIDs, bi.GetSpec().GetInstanceId())
@@ -3557,11 +3619,26 @@ func TestBotInstanceService_ListBotInstancesV2(t *testing.T) {
 		client, err := srv.NewClient(authtest.TestScopedUser(scopedUser.GetName(), "/scopes/other"))
 		require.NoError(t, err)
 
-		got := listAll(t, client.BotInstanceServiceClient())
+		got := listAll(t, client.BotInstanceServiceClient(), allScopes)
 		require.Empty(t, got)
 	})
 
-	t.Run("scope filter with bot name returns that bot's instances", func(t *testing.T) {
+	t.Run("scope filter cannot be combined with a bot name filter", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
+		require.NoError(t, err)
+
+		_, err = client.BotInstanceServiceClient().ListBotInstancesV2(t.Context(), machineidv1pb.ListBotInstancesV2Request_builder{
+			PageSize: 100,
+			Filter: machineidv1pb.ListBotInstancesV2Request_Filters_builder{
+				BotName:     grantedInstances[0].GetSpec().GetBotName(),
+				BotScope:    "/scopes/granted",
+				ScopeFilter: allScopes,
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
+	})
+
+	t.Run("bot scope with bot name returns that bot's instances", func(t *testing.T) {
 		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
 		require.NoError(t, err)
 

--- a/lib/cache/bot_instance.go
+++ b/lib/cache/bot_instance.go
@@ -114,9 +114,8 @@ func (c *Cache) ListBotInstances(ctx context.Context, pageSize int, lastToken st
 	ctx, span := c.Tracer.Start(ctx, "cache/ListBotInstances")
 	defer span.End()
 
-	// A bot is identified by the pair (scope, name), so the scope filter only
-	// ever qualifies the name filter. Listing a whole scope will be a separate
-	// filter with explicit exact/descendant control.
+	// See the field docs on ListBotInstancesRequestOptions for the rules
+	// enforced here.
 	if options.GetFilterBotScope() != "" && options.GetFilterBotName() == "" {
 		return nil, "", trace.BadParameter("bot scope filter requires a bot name filter")
 	}
@@ -124,8 +123,6 @@ func (c *Cache) ListBotInstances(ctx context.Context, pageSize int, lastToken st
 	if err := scopes.ValidateFilter(scopeFilter); err != nil {
 		return nil, "", trace.Wrap(err)
 	}
-	// The bot check in the filter closure below already constrains the scope, so
-	// the two are mutually exclusive rather than one silently winning.
 	if scopeFilter.GetMode() != scopesv1.Mode_MODE_UNSPECIFIED && options.GetFilterBotName() != "" {
 		return nil, "", trace.BadParameter("scope filter cannot be combined with a bot name filter")
 	}

--- a/lib/cache/bot_instance.go
+++ b/lib/cache/bot_instance.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/gravitational/teleport/api/defaults"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1/expression"
@@ -50,6 +51,13 @@ func newBotInstanceCollection(upstream services.BotInstance, w types.WatchKind) 
 	if upstream == nil {
 		return nil, trace.BadParameter("missing parameter upstream (BotInstance)")
 	}
+	// The seed must select the same set as the event stream, which is filtered
+	// per-event by services.WatchKindMatchesScope; an unfiltered seed would leave
+	// permanently stale out-of-scope entries in the store.
+	scopeFilter := w.ScopeFilter.ToProto()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	return &collection[*machineidv1.BotInstance, botInstanceIndex]{
 		store: newStore(
@@ -68,7 +76,9 @@ func newBotInstanceCollection(upstream services.BotInstance, w types.WatchKind) 
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*machineidv1.BotInstance, error) {
 			out, err := stream.Collect(clientutils.Resources(ctx,
 				func(ctx context.Context, limit int, start string) ([]*machineidv1.BotInstance, string, error) {
-					return upstream.ListBotInstances(ctx, limit, start, nil)
+					return upstream.ListBotInstances(ctx, limit, start, &services.ListBotInstancesRequestOptions{
+						ScopeFilter: scopeFilter,
+					})
 				},
 			))
 			return out, trace.Wrap(err)
@@ -109,6 +119,15 @@ func (c *Cache) ListBotInstances(ctx context.Context, pageSize int, lastToken st
 	// filter with explicit exact/descendant control.
 	if options.GetFilterBotScope() != "" && options.GetFilterBotName() == "" {
 		return nil, "", trace.BadParameter("bot scope filter requires a bot name filter")
+	}
+	scopeFilter := options.GetScopeFilter()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	// The bot check in the filter closure below already constrains the scope, so
+	// the two are mutually exclusive rather than one silently winning.
+	if scopeFilter.GetMode() != scopesv1.Mode_MODE_UNSPECIFIED && options.GetFilterBotName() != "" {
+		return nil, "", trace.BadParameter("scope filter cannot be combined with a bot name filter")
 	}
 
 	index := botInstanceNameIndex
@@ -161,6 +180,9 @@ func (c *Cache) ListBotInstances(ctx context.Context, pageSize int, lastToken st
 			// the backend's range routing in
 			// local.BotInstanceService.ListBotInstances.
 			if options.GetFilterBotName() != "" && b.GetScope() != options.GetFilterBotScope() {
+				return false
+			}
+			if !scopes.MatchScope(scopeFilter, b.GetScope()) {
 				return false
 			}
 			if !services.MatchBotInstance(b, options.GetFilterBotName(), options.GetFilterSearchTerm(), exp) {

--- a/lib/cache/bot_instance.go
+++ b/lib/cache/bot_instance.go
@@ -58,6 +58,11 @@ func newBotInstanceCollection(upstream services.BotInstance, w types.WatchKind) 
 	if err := scopes.ValidateFilter(scopeFilter); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	// An omitted filter means match-all here but identity-based defaults at the
+	// authz layer, so require the config to say which is meant.
+	if scopeFilter.GetMode() == scopesv1.Mode_MODE_UNSPECIFIED {
+		return nil, trace.BadParameter("bot instance cache requires an explicit scope filter mode")
+	}
 
 	return &collection[*machineidv1.BotInstance, botInstanceIndex]{
 		store: newStore(
@@ -99,8 +104,17 @@ func (c *Cache) GetBotInstance(ctx context.Context, req *machineidv1.GetBotInsta
 		cache:      c,
 		collection: c.collections.botInstances,
 		index:      botInstanceNameIndex,
-		upstreamGet: func(ctx context.Context, _ string) (*machineidv1.BotInstance, error) {
-			return c.Config.BotInstanceService.GetBotInstance(ctx, req)
+		upstreamGet: func(ctx context.Context, key string) (*machineidv1.BotInstance, error) {
+			bi, err := c.Config.BotInstanceService.GetBotInstance(ctx, req)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			// Mirror the healthy path: an instance outside the collection's
+			// scope filter is never in the store.
+			if !scopes.MatchScope(c.collections.botInstances.watch.ScopeFilter.ToProto(), bi.GetScope()) {
+				return nil, trace.NotFound("%q %q does not exist", types.KindBotInstance, key)
+			}
+			return bi, nil
 		},
 	}
 
@@ -168,7 +182,19 @@ func (c *Cache) ListBotInstances(ctx context.Context, pageSize int, lastToken st
 		isDesc:          isDesc,
 		defaultPageSize: defaults.DefaultChunkSize,
 		upstreamList: func(ctx context.Context, limit int, start string) ([]*machineidv1.BotInstance, string, error) {
-			return c.Config.BotInstanceService.ListBotInstances(ctx, limit, start, options)
+			// The backend enforces the request options but not the collection's
+			// scope filter; graft it onto the options' iteration filter so cache
+			// health doesn't change the visible set and pages still fill.
+			collectionFilter := c.collections.botInstances.watch.ScopeFilter.ToProto()
+			var opts services.ListBotInstancesRequestOptions
+			if options != nil {
+				opts = *options
+			}
+			inner := opts.FilterFn
+			opts.FilterFn = func(b *machineidv1.BotInstance) bool {
+				return scopes.MatchScope(collectionFilter, b.GetScope()) && (inner == nil || inner(b))
+			}
+			return c.Config.BotInstanceService.ListBotInstances(ctx, limit, start, &opts)
 		},
 		filter: func(b *machineidv1.BotInstance) bool {
 			// A bot is identified by (scope, name), so a by-bot filter also

--- a/lib/cache/bot_instance_test.go
+++ b/lib/cache/bot_instance_test.go
@@ -22,9 +22,9 @@ import (
 	"slices"
 	"testing"
 	"testing/synctest"
-	"time"
 
 	"github.com/google/uuid"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -132,11 +132,6 @@ func TestBotInstanceCollectionSeedHonorsWatchScopeFilter(t *testing.T) {
 		wantScopes  []string
 	}{
 		{
-			name:        "nil filter seeds every scope",
-			scopeFilter: nil,
-			wantScopes:  []string{"", "/bar", "/foo", "/foo/sub"},
-		},
-		{
 			name:        "mode ALL seeds every scope",
 			scopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build(),
 			wantScopes:  []string{"", "/bar", "/foo", "/foo/sub"},
@@ -185,6 +180,13 @@ func TestBotInstanceCollectionSeedHonorsWatchScopeFilter(t *testing.T) {
 			ScopeFilter: types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_EXACT}.Build()),
 		})
 		require.ErrorContains(t, err, "requires a non-empty scope")
+	})
+
+	t.Run("unspecified watch filter is rejected at construction", func(t *testing.T) {
+		_, err := newBotInstanceCollection(p.botInstanceService, types.WatchKind{
+			Kind: types.KindBotInstance,
+		})
+		require.ErrorContains(t, err, "explicit scope filter mode")
 	})
 }
 
@@ -583,59 +585,97 @@ func TestBotInstanceCacheList(t *testing.T) {
 }
 
 // TestBotInstanceCacheFallback tests that requests fallback to the upstream when the cache is unhealthy.
+// TestBotInstanceCacheFallback compares reads served by the unhealthy-cache
+// fallback against the healthy cache: both apply the collection's scope filter
+// to lists and gets, while sort support legitimately differs (the upstream
+// backend only supports bot_name-ascending iteration).
 func TestBotInstanceCacheFallback(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	for _, tt := range []struct {
+		name    string
+		neverOK bool
+	}{
+		{name: "HealthyCache", neverOK: false},
+		{name: "Fallback", neverOK: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx := t.Context()
 
-	p := newTestPack(t, func(cfg Config) Config {
-		cfg.neverOK = true // Force the cache into an unhealthy state
-		return ForAuth(cfg)
-	})
-	t.Cleanup(p.Close)
+				p := newTestPack(t, func(cfg Config) Config {
+					cfg = ForAuth(cfg)
+					cfg.neverOK = tt.neverOK
+					for i, w := range cfg.Watches {
+						if w.Kind == types.KindBotInstance {
+							cfg.Watches[i].ScopeFilter = types.ScopeFilterFromProto(
+								scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_DESCENDANTS, Scope: "/foo"}.Build(),
+							)
+						}
+					}
+					return cfg
+				})
+				t.Cleanup(p.Close)
 
-	_, err := p.botInstanceService.CreateBotInstance(ctx, machineidv1.BotInstance_builder{
-		Kind:     types.KindBotInstance,
-		Version:  types.V1,
-		Metadata: &headerv1.Metadata{},
-		Spec: machineidv1.BotInstanceSpec_builder{
-			BotName:    "bot-1",
-			InstanceId: "instance-1",
-		}.Build(),
-		Status: &machineidv1.BotInstanceStatus{},
-	}.Build())
-	require.NoError(t, err)
+				for i, scope := range []string{"", "/foo", "/foo/sub", "/bar"} {
+					_, err := p.botInstanceService.CreateBotInstance(ctx, machineidv1.BotInstance_builder{
+						Kind:     types.KindBotInstance,
+						Version:  types.V1,
+						Scope:    scope,
+						Metadata: &headerv1.Metadata{},
+						Spec: machineidv1.BotInstanceSpec_builder{
+							BotName:    fmt.Sprintf("bot-%d", i),
+							InstanceId: fmt.Sprintf("instance-%d", i),
+						}.Build(),
+						Status: &machineidv1.BotInstanceStatus{},
+					}.Build())
+					require.NoError(t, err)
+				}
 
-	// Let the cache catch up
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", nil)
-		require.NoError(t, err)
-		require.Len(t, results, 1)
-	}, 10*time.Second, 100*time.Millisecond)
+				synctest.Wait()
 
-	// sort ascending by bot_name
-	results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		SortField: "bot_name",
-		SortDesc:  false,
-	})
-	require.NoError(t, err) // asc by bot_name is the only sort supported by the upstream
-	require.Len(t, results, 1)
+				// Lists apply the collection's scope filter regardless of health.
+				results, _, err := p.cache.ListBotInstances(ctx, 0, "", nil)
+				require.NoError(t, err)
+				gotScopes := make([]string, 0, len(results))
+				for _, bi := range results {
+					gotScopes = append(gotScopes, bi.GetScope())
+				}
+				slices.Sort(gotScopes)
+				require.Equal(t, []string{"/foo", "/foo/sub"}, gotScopes)
 
-	// sort descending by bot_name
-	_, _, err = p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		SortField: "bot_name",
-		SortDesc:  true,
-	})
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "unsupported sort, only ascending order is supported")
+				// So do gets: in-filter is retrievable, out-of-filter reads as absent.
+				gotFoo, err := p.cache.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{
+					BotName: "bot-1", InstanceId: "instance-1", BotScope: "/foo",
+				}.Build())
+				require.NoError(t, err)
+				require.Equal(t, "/foo", gotFoo.GetScope())
 
-	// sort ascending by active_at_latest
-	_, _, err = p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		SortField: "active_at_latest",
-		SortDesc:  false,
-	})
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "unsupported sort, only bot_name field is supported, but got \"active_at_latest\"")
+				_, err = p.cache.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{
+					BotName: "bot-3", InstanceId: "instance-3", BotScope: "/bar",
+				}.Build())
+				require.True(t, trace.IsNotFound(err), "expected NotFound for out-of-filter instance, got %v", err)
+
+				// The healthy cache serves every sort from its indexes; the fallback
+				// surfaces the backend's ordering limits.
+				listErr := func(sortField string, desc bool) error {
+					_, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
+						SortField: sortField,
+						SortDesc:  desc,
+					})
+					return err
+				}
+				require.NoError(t, listErr("bot_name", false))
+				if tt.neverOK {
+					require.ErrorContains(t, listErr("bot_name", true), "unsupported sort, only ascending order is supported")
+					require.ErrorContains(t, listErr("active_at_latest", false), `unsupported sort, only bot_name field is supported, but got "active_at_latest"`)
+				} else {
+					require.NoError(t, listErr("bot_name", true))
+					require.NoError(t, listErr("active_at_latest", false))
+				}
+			})
+		})
+	}
 }
 
 func TestKeyForVersionIndex(t *testing.T) {

--- a/lib/cache/bot_instance_test.go
+++ b/lib/cache/bot_instance_test.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -30,6 +31,7 @@ import (
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/itertools/stream"
@@ -97,6 +99,93 @@ func TestBotInstanceCache(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestBotInstanceCollectionSeedHonorsWatchScopeFilter verifies that the cache's
+// initial fetch selects the same set as its scope-filtered event stream, which an
+// unfiltered seed would not, leaving permanently stale out-of-scope entries.
+func TestBotInstanceCollectionSeedHonorsWatchScopeFilter(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	for i, scope := range []string{"", "/foo", "/foo/sub", "/bar"} {
+		_, err := p.botInstanceService.CreateBotInstance(ctx, machineidv1.BotInstance_builder{
+			Kind:     types.KindBotInstance,
+			Version:  types.V1,
+			Scope:    scope,
+			Metadata: &headerv1.Metadata{},
+			Spec: machineidv1.BotInstanceSpec_builder{
+				BotName:    fmt.Sprintf("bot-%d", i),
+				InstanceId: uuid.New().String(),
+			}.Build(),
+			Status: &machineidv1.BotInstanceStatus{},
+		}.Build())
+		require.NoError(t, err)
+	}
+
+	tests := []struct {
+		name        string
+		scopeFilter *scopesv1.Filter
+		wantScopes  []string
+	}{
+		{
+			name:        "nil filter seeds every scope",
+			scopeFilter: nil,
+			wantScopes:  []string{"", "/bar", "/foo", "/foo/sub"},
+		},
+		{
+			name:        "mode ALL seeds every scope",
+			scopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build(),
+			wantScopes:  []string{"", "/bar", "/foo", "/foo/sub"},
+		},
+		{
+			name:        "mode UNSCOPED seeds only unscoped",
+			scopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build(),
+			wantScopes:  []string{""},
+		},
+		{
+			name:        "mode EXACT seeds one scope",
+			scopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_EXACT, Scope: "/foo"}.Build(),
+			wantScopes:  []string{"/foo"},
+		},
+		{
+			name:        "mode DESCENDANTS seeds the scope and below",
+			scopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_DESCENDANTS, Scope: "/foo"}.Build(),
+			wantScopes:  []string{"/foo", "/foo/sub"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			collection, err := newBotInstanceCollection(p.botInstanceService, types.WatchKind{
+				Kind:        types.KindBotInstance,
+				ScopeFilter: types.ScopeFilterFromProto(tc.scopeFilter),
+			})
+			require.NoError(t, err)
+
+			seeded, err := collection.fetcher(ctx, false)
+			require.NoError(t, err)
+
+			gotScopes := make([]string, 0, len(seeded))
+			for _, bi := range seeded {
+				gotScopes = append(gotScopes, bi.GetScope())
+			}
+			slices.Sort(gotScopes)
+			require.Equal(t, tc.wantScopes, gotScopes)
+		})
+	}
+
+	t.Run("malformed watch filter is rejected at construction", func(t *testing.T) {
+		_, err := newBotInstanceCollection(p.botInstanceService, types.WatchKind{
+			Kind: types.KindBotInstance,
+			// EXACT requires a scope.
+			ScopeFilter: types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_EXACT}.Build()),
+		})
+		require.ErrorContains(t, err, "requires a non-empty scope")
+	})
 }
 
 // TestBotInstanceCacheBackendTokenParity verifies that the cache lister and
@@ -233,6 +322,14 @@ func TestBotInstanceCacheList(t *testing.T) {
 		return (id[len(id)-1]-'0')%2 == 0
 	}
 
+	// Instance IDs name their scope, so expectations read as selected scopes.
+	scopeFilterInstances := []botInstanceSpec{
+		{botName: "u", id: "u"},
+		{scope: "/foo", botName: "f", id: "foo"},
+		{scope: "/foo/sub", botName: "fs", id: "foo-sub"},
+		{scope: "/bar", botName: "b", id: "bar"},
+	}
+
 	filterFnInstances := []botInstanceSpec{
 		{botName: "bot", id: "i-0"},
 		{botName: "bot", id: "i-1"},
@@ -281,15 +378,79 @@ func TestBotInstanceCacheList(t *testing.T) {
 			want: []string{"web-p1", "web-p2"},
 		},
 		{
-			// A scope filter only qualifies a bot name, so it is rejected on its
-			// own rather than listing every instance in the scope.
-			name: "scope filter without a bot name filter is rejected",
+			// A bot scope only qualifies a bot name, so it is rejected on its own
+			// rather than listing every instance in the scope. Standalone scope
+			// selection is ScopeFilter, covered below.
+			name: "bot scope without a bot name filter is rejected",
 			instances: []botInstanceSpec{
 				{botName: "web", id: "web-u"},
 				{scope: "/prod", botName: "web", id: "web-p1"},
 			},
 			opts:    &services.ListBotInstancesRequestOptions{FilterBotScope: "/prod"},
 			wantErr: "bot scope filter requires a bot name filter",
+		},
+		{
+			name:      "scope filter mode ALL spans all scopes",
+			instances: scopeFilterInstances,
+			opts: &services.ListBotInstancesRequestOptions{
+				ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build(),
+			},
+			want: []string{"u", "bar", "foo", "foo-sub"},
+		},
+		{
+			// Unscoped is orthogonal to every scoped value, not the root.
+			name:      "scope filter mode UNSCOPED matches only unscoped instances",
+			instances: scopeFilterInstances,
+			opts: &services.ListBotInstancesRequestOptions{
+				ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build(),
+			},
+			want: []string{"u"},
+		},
+		{
+			name:      "scope filter mode EXACT matches one scope",
+			instances: scopeFilterInstances,
+			opts: &services.ListBotInstancesRequestOptions{
+				ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_EXACT, Scope: "/foo"}.Build(),
+			},
+			want: []string{"foo"},
+		},
+		{
+			name:      "scope filter mode DESCENDANTS includes the scope and below",
+			instances: scopeFilterInstances,
+			opts: &services.ListBotInstancesRequestOptions{
+				ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_DESCENDANTS, Scope: "/foo"}.Build(),
+			},
+			want: []string{"foo", "foo-sub"},
+		},
+		{
+			name:      "scope filter with a bot filter is rejected",
+			instances: scopeFilterInstances,
+			opts: &services.ListBotInstancesRequestOptions{
+				FilterBotName:  "f",
+				FilterBotScope: "/foo",
+				ScopeFilter:    scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build(),
+			},
+			wantErr: "scope filter cannot be combined with a bot name filter",
+		},
+		{
+			// Rejected even though it would be harmless as a predicate.
+			name:      "scope filter mode ALL with a bot filter is rejected",
+			instances: scopeFilterInstances,
+			opts: &services.ListBotInstancesRequestOptions{
+				FilterBotName:  "f",
+				FilterBotScope: "/foo",
+				ScopeFilter:    scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build(),
+			},
+			wantErr: "scope filter cannot be combined with a bot name filter",
+		},
+		{
+			name:      "malformed scope filter is rejected",
+			instances: scopeFilterInstances,
+			// EXACT requires a scope.
+			opts: &services.ListBotInstancesRequestOptions{
+				ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_EXACT}.Build(),
+			},
+			wantErr: "requires a non-empty scope",
 		},
 		{
 			name: "search term matches across scopes",

--- a/lib/cache/bot_instance_test.go
+++ b/lib/cache/bot_instance_test.go
@@ -161,7 +161,7 @@ func TestBotInstanceCollectionSeedHonorsWatchScopeFilter(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			seeded, err := collection.fetcher(ctx, false)
+			seeded, err := collection.fetcher(t.Context(), false)
 			require.NoError(t, err)
 
 			gotScopes := make([]string, 0, len(seeded))
@@ -584,7 +584,6 @@ func TestBotInstanceCacheList(t *testing.T) {
 	}
 }
 
-// TestBotInstanceCacheFallback tests that requests fallback to the upstream when the cache is unhealthy.
 // TestBotInstanceCacheFallback compares reads served by the unhealthy-cache
 // fallback against the healthy cache: both apply the collection's scope filter
 // to lists and gets, while sort support legitimately differs (the upstream

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -225,7 +225,7 @@ func ForAuth(cfg Config) Config {
 		{Kind: types.KindWorkloadIdentity},
 		{Kind: types.KindHealthCheckConfig},
 		{Kind: types.KindRelayServer},
-		{Kind: types.KindBotInstance},
+		{Kind: types.KindBotInstance, ScopeFilter: allScopes},
 		{Kind: types.KindRecordingEncryption},
 		{Kind: types.KindAppAuthConfig},
 		{Kind: types.KindInferenceModel},

--- a/lib/cache/inventory/inventory_cache.go
+++ b/lib/cache/inventory/inventory_cache.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	inventoryv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/inventory/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/cache"
@@ -590,7 +591,9 @@ func (ic *InventoryCache) setupWatcher(ctx context.Context) (types.Watcher, erro
 		Name: "inventory_cache",
 		Kinds: []types.WatchKind{
 			{Kind: types.KindInstance},
-			{Kind: types.KindBotInstance},
+			{Kind: types.KindBotInstance, ScopeFilter: types.ScopeFilterFromProto(
+				scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build(),
+			)},
 		},
 	})
 	if err != nil {
@@ -667,7 +670,10 @@ func (ic *InventoryCache) populateBotInstances(ctx context.Context, limiter *rat
 			ctx,
 			defaults.DefaultChunkSize,
 			pageToken,
-			nil,
+			&services.ListBotInstancesRequestOptions{
+				// All scopes, matching this cache's watch filter.
+				ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build(),
+			},
 		)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/services/bot_instance.go
+++ b/lib/services/bot_instance.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/trace"
 
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1/expression"
 	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/utils/typical"
@@ -182,9 +183,15 @@ type ListBotInstancesRequestOptions struct {
 	// pair (scope, name), so this only ever qualifies FilterBotName and must be
 	// set alongside it; setting it without FilterBotName is an error. Leave
 	// empty if the bot is unscoped. This is deliberately not a scope filter for
-	// listing every BotInstance in a scope - that will be a separate field with
-	// explicit exact/descendant control.
+	// listing every BotInstance in a scope - use ScopeFilter for that.
 	FilterBotScope string
+	// ScopeFilter selects BotInstances by the scope of their owning bot. A nil or
+	// MODE_UNSPECIFIED filter matches every scope; identity-derived defaulting is
+	// the caller's job (see ScopedAccessCheckerContext.ResolveScopeFilter).
+	//
+	// Mutually exclusive with FilterBotName, which already constrains the result
+	// to a single bot in a single scope.
+	ScopeFilter *scopesv1.Filter
 	// A search term used to filter the results. If non-empty, it's used to
 	// match against supported fields.
 	FilterSearchTerm string
@@ -220,6 +227,13 @@ func (o *ListBotInstancesRequestOptions) GetFilterBotScope() string {
 		return ""
 	}
 	return o.FilterBotScope
+}
+
+func (o *ListBotInstancesRequestOptions) GetScopeFilter() *scopesv1.Filter {
+	if o == nil {
+		return nil
+	}
+	return o.ScopeFilter
 }
 
 func (o *ListBotInstancesRequestOptions) GetFilterSearchTerm() string {

--- a/lib/services/local/bot_instance.go
+++ b/lib/services/local/bot_instance.go
@@ -24,6 +24,7 @@ import (
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1/expression"
@@ -127,7 +128,8 @@ func (b *BotInstanceService) GetBotInstance(ctx context.Context, req *machineidv
 // If an non-empty bot name is provided, only instances for that bot will be fetched. The bot scope must be
 // provided alongside the name for a scoped bot's instances, and only ever qualifies the name - providing a
 // scope without a name is an error rather than a request for every instance in that scope. With no bot filter,
-// instances for all bots are listed, unscoped bots' instances first.
+// instances for all bots are listed, unscoped bots' instances first, narrowed by the options' scope filter if
+// one is set.
 // If an non-empty search term is provided, only instances with a value containing the term in supported fields are fetched.
 // Supported search fields include; bot name, instance id, hostname (latest), tbot version (latest), join method (latest).
 // Sorting by bot name in ascending order is supported - an error is returned for any other sort type.
@@ -143,6 +145,15 @@ func (b *BotInstanceService) ListBotInstances(ctx context.Context, pageSize int,
 	// filter with explicit exact/descendant control.
 	if options.GetFilterBotScope() != "" && options.GetFilterBotName() == "" {
 		return nil, "", trace.BadParameter("bot scope filter requires a bot name filter")
+	}
+	scopeFilter := options.GetScopeFilter()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	// The range routing below already constrains the scope for a bot filter, so the
+	// two are mutually exclusive rather than one silently winning.
+	if scopeFilter.GetMode() != scopesv1.Mode_MODE_UNSPECIFIED && options.GetFilterBotName() != "" {
+		return nil, "", trace.BadParameter("scope filter cannot be combined with a bot name filter")
 	}
 
 	// Satisfied by both the scope-aware wrapper (unified listing across the
@@ -179,12 +190,15 @@ func (b *BotInstanceService) ListBotInstances(ctx context.Context, pageSize int,
 	}
 
 	filterFn := options.GetFilterFn()
-	if options.GetFilterSearchTerm() == "" && exp == nil && filterFn == nil {
+	if options.GetFilterSearchTerm() == "" && exp == nil && filterFn == nil && scopes.IsMatchAll(scopeFilter) {
 		r, nextToken, err := service.ListResources(ctx, pageSize, lastKey)
 		return r, nextToken, trace.Wrap(err)
 	}
 
 	r, nextToken, err := service.ListResourcesWithFilter(ctx, pageSize, lastKey, func(item *machineidv1.BotInstance) bool {
+		if !scopes.MatchScope(scopeFilter, item.GetScope()) {
+			return false
+		}
 		if !services.MatchBotInstance(item, "", options.GetFilterSearchTerm(), exp) {
 			return false
 		}

--- a/lib/services/local/bot_instance.go
+++ b/lib/services/local/bot_instance.go
@@ -140,9 +140,8 @@ func (b *BotInstanceService) ListBotInstances(ctx context.Context, pageSize int,
 	if options.GetSortDesc() {
 		return nil, "", trace.CompareFailed("unsupported sort, only ascending order is supported")
 	}
-	// A bot is identified by the pair (scope, name), so the scope filter only
-	// ever qualifies the name filter. Listing a whole scope will be a separate
-	// filter with explicit exact/descendant control.
+	// See the field docs on ListBotInstancesRequestOptions for the rules
+	// enforced here.
 	if options.GetFilterBotScope() != "" && options.GetFilterBotName() == "" {
 		return nil, "", trace.BadParameter("bot scope filter requires a bot name filter")
 	}
@@ -150,8 +149,6 @@ func (b *BotInstanceService) ListBotInstances(ctx context.Context, pageSize int,
 	if err := scopes.ValidateFilter(scopeFilter); err != nil {
 		return nil, "", trace.Wrap(err)
 	}
-	// The range routing below already constrains the scope for a bot filter, so the
-	// two are mutually exclusive rather than one silently winning.
 	if scopeFilter.GetMode() != scopesv1.Mode_MODE_UNSPECIFIED && options.GetFilterBotName() != "" {
 		return nil, "", trace.BadParameter("scope filter cannot be combined with a bot name filter")
 	}

--- a/lib/services/local/bot_instance_test.go
+++ b/lib/services/local/bot_instance_test.go
@@ -718,5 +718,3 @@ func TestBotInstanceScopedCoexistence(t *testing.T) {
 	remaining := listInstances(t, ctx, service, nil)
 	require.Empty(t, remaining)
 }
-
-

--- a/lib/services/local/bot_instance_test.go
+++ b/lib/services/local/bot_instance_test.go
@@ -20,6 +20,8 @@ package local
 
 import (
 	"context"
+	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -31,6 +33,7 @@ import (
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
@@ -518,6 +521,110 @@ func TestBotInstanceScopedCoexistence(t *testing.T) {
 	require.NoError(t, service.DeleteAllBotInstances(ctx))
 	remaining := listInstances(t, ctx, service, nil)
 	require.Empty(t, remaining)
+}
+
+// TestBotInstanceListWithScopeFilter verifies that the scope filter selects
+// instances by their owning bot's scope across both key ranges, and is rejected
+// alongside a bot filter.
+func TestBotInstanceListWithScopeFilter(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service, err := NewBotInstanceService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
+
+	unscoped := newBotInstance("u")
+	foo := newBotInstance("f", withBotInstanceScope("/foo"))
+	fooSub := newBotInstance("fs", withBotInstanceScope("/foo/sub"))
+	bar := newBotInstance("b", withBotInstanceScope("/bar"))
+	for _, bi := range []*machineidv1.BotInstance{unscoped, foo, fooSub, bar} {
+		_, err := service.CreateBotInstance(ctx, bi)
+		require.NoError(t, err)
+	}
+
+	scopesOf := func(instances []*machineidv1.BotInstance) []string {
+		out := make([]string, 0, len(instances))
+		for _, bi := range instances {
+			out = append(out, bi.GetScope())
+		}
+		slices.Sort(out)
+		return out
+	}
+
+	tests := []struct {
+		name       string
+		options    *services.ListBotInstancesRequestOptions
+		wantScopes []string
+	}{
+		{
+			name:       "nil filter matches every scope",
+			options:    nil,
+			wantScopes: []string{"", "/bar", "/foo", "/foo/sub"},
+		},
+		{
+			name:       "mode ALL matches every scope",
+			options:    &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build()},
+			wantScopes: []string{"", "/bar", "/foo", "/foo/sub"},
+		},
+		{
+			// Unscoped is orthogonal to every scoped value, not the root.
+			name:       "mode UNSCOPED matches only unscoped instances",
+			options:    &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build()},
+			wantScopes: []string{""},
+		},
+		{
+			name:       "mode EXACT matches one scope",
+			options:    &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_EXACT, Scope: "/foo"}.Build()},
+			wantScopes: []string{"/foo"},
+		},
+		{
+			name:       "mode DESCENDANTS includes the scope and below",
+			options:    &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_DESCENDANTS, Scope: "/foo"}.Build()},
+			wantScopes: []string{"/foo", "/foo/sub"},
+		},
+		{
+			name:       "mode ANCESTORS includes the scope and above",
+			options:    &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ANCESTORS, Scope: "/foo/sub"}.Build()},
+			wantScopes: []string{"/foo", "/foo/sub"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := listInstances(t, ctx, service, tc.options)
+			require.Equal(t, tc.wantScopes, scopesOf(got))
+		})
+	}
+
+	t.Run("malformed filter is rejected", func(t *testing.T) {
+		_, _, err := service.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
+			// EXACT requires a scope.
+			ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_EXACT}.Build(),
+		})
+		require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
+	})
+
+	// Even mode ALL is rejected, so the rule is one a caller can state without
+	// knowing the modes.
+	for _, mode := range []scopesv1.Mode{scopesv1.Mode_MODE_UNSCOPED, scopesv1.Mode_MODE_ALL} {
+		t.Run(fmt.Sprintf("scope filter mode %v with a bot filter is rejected", mode), func(t *testing.T) {
+			_, _, err := service.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
+				FilterBotName:  "f",
+				FilterBotScope: "/foo",
+				ScopeFilter:    scopesv1.Filter_builder{Mode: mode}.Build(),
+			})
+			require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
+			require.ErrorContains(t, err, "scope filter cannot be combined with a bot name filter")
+		})
+	}
 }
 
 // TestBotInstanceListWithSearchFilter verifies list and filtering with search

--- a/lib/services/local/bot_instance_test.go
+++ b/lib/services/local/bot_instance_test.go
@@ -20,8 +20,6 @@ package local
 
 import (
 	"context"
-	"fmt"
-	"slices"
 	"testing"
 	"time"
 
@@ -151,23 +149,6 @@ func withBotInstanceHeartbeatHostname(value string) func(*machineidv1.BotInstanc
 
 		bi.GetStatus().GetInitialHeartbeat().SetHostname(value)
 	}
-}
-
-// createInstances creates new bot instances for the named bot with random UUIDs
-func createInstances(t *testing.T, ctx context.Context, service *BotInstanceService, botName string, count int, fns ...func(*machineidv1.BotInstance)) map[string]struct{} {
-	t.Helper()
-
-	ids := map[string]struct{}{}
-
-	for range count {
-		bi := newBotInstance(botName, fns...)
-		_, err := service.CreateBotInstance(ctx, bi)
-		require.NoError(t, err)
-
-		ids[bi.GetSpec().GetInstanceId()] = struct{}{}
-	}
-
-	return ids
 }
 
 // listInstances fetches all instances from the BotInstanceService matching the botName filter
@@ -351,83 +332,298 @@ func TestBotInstanceCRUD(t *testing.T) {
 	require.Error(t, service.DeleteBotInstance(ctx, machineidv1.DeleteBotInstanceRequest_builder{BotScope: "", BotName: bi.GetSpec().GetBotName(), InstanceId: bi.GetSpec().GetInstanceId()}.Build()))
 }
 
-// TestBotInstanceList verifies list and filtering by bot functionality for bot
-// instances.
+// listInstanceSpec declaratively describes a bot instance for
+// TestBotInstanceList cases.
+type listInstanceSpec struct {
+	scope, botName, id            string
+	hostname, version, joinMethod string
+}
+
+func (s listInstanceSpec) build() *machineidv1.BotInstance {
+	fns := []func(*machineidv1.BotInstance){withBotInstanceId(s.id)}
+	if s.scope != "" {
+		fns = append(fns, withBotInstanceScope(s.scope))
+	}
+	if s.hostname != "" {
+		fns = append(fns, withBotInstanceHeartbeatHostname(s.hostname))
+	}
+	if s.version != "" {
+		fns = append(fns, withBotInstanceHeartbeatVersion(s.version))
+	}
+	if s.joinMethod != "" {
+		fns = append(fns, withBotInstanceHeartbeatJoinMethod(s.joinMethod))
+	}
+	return newBotInstance(s.botName, fns...)
+}
+
+// TestBotInstanceList exercises ListBotInstances across filtering and sorting.
 func TestBotInstanceList(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
-	clock := clockwork.NewFakeClock()
-
-	mem, err := memory.New(memory.Config{
-		Context: ctx,
-		Clock:   clock,
-	})
-	require.NoError(t, err)
-
-	service, err := NewBotInstanceService(backend.NewSanitizer(mem), clock)
-	require.NoError(t, err)
-
-	aIds := createInstances(t, ctx, service, "a", 3)
-	bIds := createInstances(t, ctx, service, "b", 4)
-	// "a" is also the name of a scoped bot in /foo; its instances live in the
-	// scoped key range.
-	scopedAIds := createInstances(t, ctx, service, "a", 2, withBotInstanceScope("/foo"))
-
-	// listing "a" should only return known instances of the unscoped bot "a"
-	aInstances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
-		FilterBotName: "a",
-	})
-	require.Len(t, aInstances, 3)
-	for _, ins := range aInstances {
-		require.Contains(t, aIds, ins.GetSpec().GetInstanceId())
+	botInstanceIDs := func(instances []*machineidv1.BotInstance) []string {
+		out := make([]string, 0, len(instances))
+		for _, b := range instances {
+			out = append(out, b.GetSpec().GetInstanceId())
+		}
+		return out
 	}
 
-	// listing "b" should only return known "b" instances
-	bInstances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
-		FilterBotName: "b",
-	})
-	require.Len(t, bInstances, 4)
-	for _, ins := range bInstances {
-		require.Contains(t, bIds, ins.GetSpec().GetInstanceId())
+	// Two unscoped bots and a same-named scoped bot, to prove bot filters are
+	// scope-strict.
+	botFilterInstances := []listInstanceSpec{
+		{botName: "db", id: "db-a"},
+		{botName: "web", id: "web-a"},
+		{botName: "web", id: "web-b"},
+		{scope: "/prod", botName: "web", id: "web-c"},
 	}
 
-	// listing "a" in scope /foo should only return the scoped bot's instances
-	scopedAInstances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
-		FilterBotName:  "a",
-		FilterBotScope: "/foo",
-	})
-	require.Len(t, scopedAInstances, 2)
-	for _, ins := range scopedAInstances {
-		require.Contains(t, scopedAIds, ins.GetSpec().GetInstanceId())
+	// Instance IDs name their scope, so expectations read as selected scopes.
+	scopeFilterInstances := []listInstanceSpec{
+		{botName: "u", id: "u"},
+		{scope: "/foo", botName: "f", id: "foo"},
+		{scope: "/foo/sub", botName: "fs", id: "foo-sub"},
+		{scope: "/bar", botName: "b", id: "bar"},
 	}
 
-	// a scope filter only qualifies a bot name, so listing scope /foo without a
-	// bot name is rejected rather than listing the whole scope
-	_, _, err = service.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		FilterBotScope: "/foo",
-	})
-	require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
-
-	allIds := map[string]struct{}{}
-	for i := range aIds {
-		allIds[i] = struct{}{}
+	filterFnInstances := []listInstanceSpec{
+		{botName: "bot", id: "i-0"},
+		{botName: "bot", id: "i-1"},
+		{scope: "/s", botName: "bot", id: "i-2"},
+		{scope: "/s", botName: "bot", id: "i-3"},
 	}
-	for i := range bIds {
-		allIds[i] = struct{}{}
-	}
-	for i := range scopedAIds {
-		allIds[i] = struct{}{}
+	evenFilter := func(b *machineidv1.BotInstance) bool {
+		id := b.GetSpec().GetInstanceId()
+		return (id[len(id)-1]-'0')%2 == 0
 	}
 
-	// Listing with no bot filter should return all instances, unscoped and
-	// scoped.
-	allInstances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
-		FilterBotName: "",
-	})
-	require.Len(t, allInstances, 9)
-	for _, ins := range allInstances {
-		require.Contains(t, allIds, ins.GetSpec().GetInstanceId())
+	tests := []struct {
+		name      string
+		instances []listInstanceSpec
+		opts      *services.ListBotInstancesRequestOptions
+		want      []string
+		wantErr   string
+	}{
+		{
+			name:      "no filter spans both ranges, unscoped instances first",
+			instances: botFilterInstances,
+			want:      []string{"db-a", "web-a", "web-b", "web-c"},
+		},
+		{
+			name:      "bot name filter matches only the unscoped bot of that name",
+			instances: botFilterInstances,
+			opts:      &services.ListBotInstancesRequestOptions{FilterBotName: "web"},
+			want:      []string{"web-a", "web-b"},
+		},
+		{
+			name:      "bot name and scope filter matches the scoped bot",
+			instances: botFilterInstances,
+			opts:      &services.ListBotInstancesRequestOptions{FilterBotName: "web", FilterBotScope: "/prod"},
+			want:      []string{"web-c"},
+		},
+		{
+			// A bot scope only qualifies a bot name; standalone scope
+			// selection is ScopeFilter.
+			name:      "bot scope without a bot name filter is rejected",
+			instances: botFilterInstances,
+			opts:      &services.ListBotInstancesRequestOptions{FilterBotScope: "/prod"},
+			wantErr:   "bot scope filter requires a bot name filter",
+		},
+		{
+			name:      "scope filter mode ALL matches every scope",
+			instances: scopeFilterInstances,
+			opts:      &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build()},
+			want:      []string{"u", "bar", "foo", "foo-sub"},
+		},
+		{
+			// Unscoped is orthogonal to every scoped value, not the root.
+			name:      "scope filter mode UNSCOPED matches only unscoped instances",
+			instances: scopeFilterInstances,
+			opts:      &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build()},
+			want:      []string{"u"},
+		},
+		{
+			name:      "scope filter mode EXACT matches one scope",
+			instances: scopeFilterInstances,
+			opts:      &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_EXACT, Scope: "/foo"}.Build()},
+			want:      []string{"foo"},
+		},
+		{
+			name:      "scope filter mode DESCENDANTS includes the scope and below",
+			instances: scopeFilterInstances,
+			opts:      &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_DESCENDANTS, Scope: "/foo"}.Build()},
+			want:      []string{"foo", "foo-sub"},
+		},
+		{
+			name:      "scope filter mode ANCESTORS includes the scope and above",
+			instances: scopeFilterInstances,
+			opts:      &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ANCESTORS, Scope: "/foo/sub"}.Build()},
+			want:      []string{"foo", "foo-sub"},
+		},
+		{
+			name:      "malformed scope filter is rejected",
+			instances: scopeFilterInstances,
+			// EXACT requires a scope.
+			opts:    &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_EXACT}.Build()},
+			wantErr: "requires a non-empty scope",
+		},
+		{
+			name:      "scope filter with a bot filter is rejected",
+			instances: scopeFilterInstances,
+			opts: &services.ListBotInstancesRequestOptions{
+				FilterBotName:  "f",
+				FilterBotScope: "/foo",
+				ScopeFilter:    scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build(),
+			},
+			wantErr: "scope filter cannot be combined with a bot name filter",
+		},
+		{
+			// Rejected even though it would be harmless as a predicate, so the
+			// rule is one a caller can state without knowing the modes.
+			name:      "scope filter mode ALL with a bot filter is rejected",
+			instances: scopeFilterInstances,
+			opts: &services.ListBotInstancesRequestOptions{
+				FilterBotName:  "f",
+				FilterBotScope: "/foo",
+				ScopeFilter:    scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build(),
+			},
+			wantErr: "scope filter cannot be combined with a bot name filter",
+		},
+		{
+			name: "search matches bot name",
+			instances: []listInstanceSpec{
+				{botName: "this-is-nicks-test-bot", id: "match"},
+				{botName: "bot-not-matched", id: "decoy"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterSearchTerm: "nick"},
+			want: []string{"match"},
+		},
+		{
+			name: "search matches instance id",
+			instances: []listInstanceSpec{
+				{botName: "test-bot", id: "cb2c3523-01f6-4258-966b-ace9f38f9862"},
+				{botName: "bot-not-matched", id: "decoy"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterSearchTerm: "CB2C352"},
+			want: []string{"cb2c3523-01f6-4258-966b-ace9f38f9862"},
+		},
+		{
+			name: "search matches join method",
+			instances: []listInstanceSpec{
+				{botName: "test-bot", id: "match", joinMethod: "kubernetes"},
+				{botName: "bot-not-matched", id: "decoy"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterSearchTerm: "uber"},
+			want: []string{"match"},
+		},
+		{
+			name: "search matches version",
+			instances: []listInstanceSpec{
+				{botName: "test-bot", id: "match", version: "1.0.0-dev-a2g3hd"},
+				{botName: "bot-not-matched", id: "decoy"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterSearchTerm: "1.0.0"},
+			want: []string{"match"},
+		},
+		{
+			name: "search matches version with v prefix",
+			instances: []listInstanceSpec{
+				{botName: "test-bot", id: "match", version: "1.0.0-dev-a2g3hd"},
+				{botName: "bot-not-matched", id: "decoy"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterSearchTerm: "v1.0.0"},
+			want: []string{"match"},
+		},
+		{
+			name: "search matches hostname",
+			instances: []listInstanceSpec{
+				{botName: "test-bot", id: "match", hostname: "svr-eu-tel-123-a"},
+				{botName: "bot-not-matched", id: "decoy"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterSearchTerm: "tel-123"},
+			want: []string{"match"},
+		},
+		{
+			name: "search matches across scopes",
+			instances: []listInstanceSpec{
+				{botName: "runner", id: "r1", hostname: "host-match"},
+				{scope: "/foo", botName: "runner", id: "r2", hostname: "host-match"},
+				{botName: "runner", id: "r3", hostname: "host-other"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterSearchTerm: "host-match"},
+			want: []string{"r1", "r2"},
+		},
+		{
+			name: "predicate query matches",
+			instances: []listInstanceSpec{
+				{botName: "test-bot", id: "match", hostname: "svr-eu-tel-123-a"},
+				{botName: "bot-not-matched", id: "decoy"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterQuery: `status.latest_heartbeat.hostname == "svr-eu-tel-123-a"`},
+			want: []string{"match"},
+		},
+		{
+			name:    "unsupported sort field is rejected",
+			opts:    &services.ListBotInstancesRequestOptions{SortField: "test_field"},
+			wantErr: `unsupported sort, only bot_name field is supported, but got "test_field"`,
+		},
+		{
+			name:    "descending sort is rejected",
+			opts:    &services.ListBotInstancesRequestOptions{SortField: "bot_name", SortDesc: true},
+			wantErr: "unsupported sort, only ascending order is supported",
+		},
+		{
+			name:      "filter fn spans both ranges",
+			instances: filterFnInstances,
+			opts:      &services.ListBotInstancesRequestOptions{FilterFn: evenFilter},
+			want:      []string{"i-0", "i-2"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			clock := clockwork.NewFakeClock()
+
+			mem, err := memory.New(memory.Config{
+				Context: ctx,
+				Clock:   clock,
+			})
+			require.NoError(t, err)
+
+			service, err := NewBotInstanceService(backend.NewSanitizer(mem), clock)
+			require.NoError(t, err)
+
+			for _, s := range tc.instances {
+				_, err := service.CreateBotInstance(ctx, s.build())
+				require.NoError(t, err)
+			}
+
+			got, _, err := service.ListBotInstances(ctx, 0, "", tc.opts)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, botInstanceIDs(got))
+
+			// Page-size-1 pagination must agree with the single-page listing;
+			// cursors that don't line up across the unscoped/scoped ranges
+			// would skip entries.
+			var paged []*machineidv1.BotInstance
+			var token string
+			for {
+				page, next, err := service.ListBotInstances(ctx, 1, token, tc.opts)
+				require.NoError(t, err)
+				paged = append(paged, page...)
+				if next == "" {
+					break
+				}
+				token = next
+			}
+			require.Equal(t, tc.want, botInstanceIDs(paged))
+		})
 	}
 }
 
@@ -523,287 +719,4 @@ func TestBotInstanceScopedCoexistence(t *testing.T) {
 	require.Empty(t, remaining)
 }
 
-// TestBotInstanceListWithScopeFilter verifies that the scope filter selects
-// instances by their owning bot's scope across both key ranges, and is rejected
-// alongside a bot filter.
-func TestBotInstanceListWithScopeFilter(t *testing.T) {
-	t.Parallel()
 
-	ctx := t.Context()
-	clock := clockwork.NewFakeClock()
-
-	mem, err := memory.New(memory.Config{
-		Context: ctx,
-		Clock:   clock,
-	})
-	require.NoError(t, err)
-
-	service, err := NewBotInstanceService(backend.NewSanitizer(mem), clock)
-	require.NoError(t, err)
-
-	unscoped := newBotInstance("u")
-	foo := newBotInstance("f", withBotInstanceScope("/foo"))
-	fooSub := newBotInstance("fs", withBotInstanceScope("/foo/sub"))
-	bar := newBotInstance("b", withBotInstanceScope("/bar"))
-	for _, bi := range []*machineidv1.BotInstance{unscoped, foo, fooSub, bar} {
-		_, err := service.CreateBotInstance(ctx, bi)
-		require.NoError(t, err)
-	}
-
-	scopesOf := func(instances []*machineidv1.BotInstance) []string {
-		out := make([]string, 0, len(instances))
-		for _, bi := range instances {
-			out = append(out, bi.GetScope())
-		}
-		slices.Sort(out)
-		return out
-	}
-
-	tests := []struct {
-		name       string
-		options    *services.ListBotInstancesRequestOptions
-		wantScopes []string
-	}{
-		{
-			name:       "nil filter matches every scope",
-			options:    nil,
-			wantScopes: []string{"", "/bar", "/foo", "/foo/sub"},
-		},
-		{
-			name:       "mode ALL matches every scope",
-			options:    &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build()},
-			wantScopes: []string{"", "/bar", "/foo", "/foo/sub"},
-		},
-		{
-			// Unscoped is orthogonal to every scoped value, not the root.
-			name:       "mode UNSCOPED matches only unscoped instances",
-			options:    &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build()},
-			wantScopes: []string{""},
-		},
-		{
-			name:       "mode EXACT matches one scope",
-			options:    &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_EXACT, Scope: "/foo"}.Build()},
-			wantScopes: []string{"/foo"},
-		},
-		{
-			name:       "mode DESCENDANTS includes the scope and below",
-			options:    &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_DESCENDANTS, Scope: "/foo"}.Build()},
-			wantScopes: []string{"/foo", "/foo/sub"},
-		},
-		{
-			name:       "mode ANCESTORS includes the scope and above",
-			options:    &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ANCESTORS, Scope: "/foo/sub"}.Build()},
-			wantScopes: []string{"/foo", "/foo/sub"},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := listInstances(t, ctx, service, tc.options)
-			require.Equal(t, tc.wantScopes, scopesOf(got))
-		})
-	}
-
-	t.Run("malformed filter is rejected", func(t *testing.T) {
-		_, _, err := service.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-			// EXACT requires a scope.
-			ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_EXACT}.Build(),
-		})
-		require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
-	})
-
-	// Even mode ALL is rejected, so the rule is one a caller can state without
-	// knowing the modes.
-	for _, mode := range []scopesv1.Mode{scopesv1.Mode_MODE_UNSCOPED, scopesv1.Mode_MODE_ALL} {
-		t.Run(fmt.Sprintf("scope filter mode %v with a bot filter is rejected", mode), func(t *testing.T) {
-			_, _, err := service.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-				FilterBotName:  "f",
-				FilterBotScope: "/foo",
-				ScopeFilter:    scopesv1.Filter_builder{Mode: mode}.Build(),
-			})
-			require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
-			require.ErrorContains(t, err, "scope filter cannot be combined with a bot name filter")
-		})
-	}
-}
-
-// TestBotInstanceListWithSearchFilter verifies list and filtering with search
-// term functionality for bot instances.
-func TestBotInstanceListWithSearchFilter(t *testing.T) {
-	t.Parallel()
-
-	clock := clockwork.NewFakeClock()
-
-	tcs := []struct {
-		name       string
-		searchTerm string
-		instance   *machineidv1.BotInstance
-	}{
-		{
-			name:       "match on bot name",
-			searchTerm: "nick",
-			instance:   newBotInstance("this-is-nicks-test-bot"),
-		},
-		{
-			name:       "match on instance id",
-			searchTerm: "CB2C352",
-			instance:   newBotInstance("test-bot", withBotInstanceId("cb2c3523-01f6-4258-966b-ace9f38f9862")),
-		},
-		{
-			name:       "match on join method",
-			searchTerm: "uber",
-			instance:   newBotInstance("test-bot", withBotInstanceHeartbeatJoinMethod("kubernetes")),
-		},
-		{
-			name:       "match on version",
-			searchTerm: "1.0.0",
-			instance:   newBotInstance("test-bot", withBotInstanceHeartbeatVersion("1.0.0-dev-a2g3hd")),
-		},
-		{
-			name:       "match on version (with v)",
-			searchTerm: "v1.0.0",
-			instance:   newBotInstance("test-bot", withBotInstanceHeartbeatVersion("1.0.0-dev-a2g3hd")),
-		},
-		{
-			name:       "match on hostname",
-			searchTerm: "tel-123",
-			instance:   newBotInstance("test-bot", withBotInstanceHeartbeatHostname("svr-eu-tel-123-a")),
-		},
-	}
-
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := t.Context()
-
-			mem, err := memory.New(memory.Config{
-				Context: ctx,
-				Clock:   clock,
-			})
-			require.NoError(t, err)
-
-			service, err := NewBotInstanceService(backend.NewSanitizer(mem), clock)
-			require.NoError(t, err)
-
-			_, err = service.CreateBotInstance(ctx, tc.instance)
-			require.NoError(t, err)
-			_, err = service.CreateBotInstance(ctx, newBotInstance("bot-not-matched"))
-			require.NoError(t, err)
-
-			instances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
-				FilterSearchTerm: tc.searchTerm,
-			})
-
-			require.Len(t, instances, 1)
-			require.Equal(t, tc.instance.GetSpec().GetInstanceId(), instances[0].GetSpec().GetInstanceId())
-		})
-	}
-}
-
-// TestBotInstanceListWithQuery verifies list and filtering with query
-// functionality for bot instances.
-func TestBotInstanceListWithQuery(t *testing.T) {
-	t.Parallel()
-
-	clock := clockwork.NewFakeClock()
-	ctx := t.Context()
-	mem, err := memory.New(memory.Config{
-		Context: ctx,
-		Clock:   clock,
-	})
-	require.NoError(t, err)
-	service, err := NewBotInstanceService(backend.NewSanitizer(mem), clock)
-	require.NoError(t, err)
-
-	instance := newBotInstance("test-bot", withBotInstanceHeartbeatHostname("svr-eu-tel-123-a"))
-	_, err = service.CreateBotInstance(ctx, instance)
-	require.NoError(t, err)
-	_, err = service.CreateBotInstance(ctx, newBotInstance("bot-not-matched"))
-	require.NoError(t, err)
-
-	instances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
-		FilterQuery: `status.latest_heartbeat.hostname == "svr-eu-tel-123-a"`,
-	})
-
-	require.Len(t, instances, 1)
-	require.Equal(t, instance.GetSpec().GetInstanceId(), instances[0].GetSpec().GetInstanceId())
-}
-
-// TestBotInstanceListWithSort verifies sorting returns a not-implemented error.
-func TestBotInstanceListWithSort(t *testing.T) {
-	t.Parallel()
-
-	clock := clockwork.NewFakeClock()
-
-	ctx := t.Context()
-
-	mem, err := memory.New(memory.Config{
-		Context: ctx,
-		Clock:   clock,
-	})
-	require.NoError(t, err)
-
-	service, err := NewBotInstanceService(backend.NewSanitizer(mem), clock)
-	require.NoError(t, err)
-
-	_, _, err = service.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		SortField: "test_field",
-		SortDesc:  false,
-	})
-	require.Error(t, err)
-	require.ErrorContains(t, err, "unsupported sort, only bot_name field is supported, but got \"test_field\"")
-
-	_, _, err = service.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		SortField: "bot_name",
-		SortDesc:  true,
-	})
-	require.Error(t, err)
-	require.ErrorContains(t, err, "unsupported sort, only ascending order is supported")
-
-	_, _, err = service.ListBotInstances(ctx, 0, "", nil)
-	require.NoError(t, err)
-}
-
-func TestBotInstanceListWithFilterFn(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-	clock := clockwork.NewFakeClock()
-
-	mem, err := memory.New(memory.Config{
-		Context: ctx,
-		Clock:   clock,
-	})
-	require.NoError(t, err)
-
-	service, err := NewBotInstanceService(backend.NewSanitizer(mem), clock)
-	require.NoError(t, err)
-
-	// Create 10 instances for "test-bot".
-	var created []*machineidv1.BotInstance
-	for range 10 {
-		bi := newBotInstance("test-bot")
-		_, err := service.CreateBotInstance(ctx, bi)
-		require.NoError(t, err)
-		created = append(created, bi)
-	}
-
-	// Use a FilterFn that only accepts even-indexed instances.
-	accepted := map[string]struct{}{}
-	for i, bi := range created {
-		if i%2 == 0 {
-			accepted[bi.GetSpec().GetInstanceId()] = struct{}{}
-		}
-	}
-
-	instances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
-		FilterFn: func(bi *machineidv1.BotInstance) bool {
-			_, ok := accepted[bi.GetSpec().GetInstanceId()]
-			return ok
-		},
-	})
-
-	require.Len(t, instances, len(accepted))
-	for _, bi := range instances {
-		require.Contains(t, accepted, bi.GetSpec().GetInstanceId())
-	}
-}

--- a/lib/web/machineid.go
+++ b/lib/web/machineid.go
@@ -471,9 +471,8 @@ func (h *Handler) listBotInstancesV2(_ http.ResponseWriter, r *http.Request, _ h
 
 	botName := r.URL.Query().Get("bot_name")
 
-	// Exhaustive view, so ask for every scope rather than inheriting the
-	// identity-based default. A bot filter already pins the scope, and the server
-	// rejects the two together.
+	// Exhaustive view: mode ALL, not the identity default (never alongside a
+	// bot filter, which the server rejects).
 	var scopeFilter *scopesv1.Filter
 	if botName == "" {
 		scopeFilter = scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build()

--- a/lib/web/machineid.go
+++ b/lib/web/machineid.go
@@ -471,8 +471,7 @@ func (h *Handler) listBotInstancesV2(_ http.ResponseWriter, r *http.Request, _ h
 
 	botName := r.URL.Query().Get("bot_name")
 
-	// Exhaustive view: mode ALL, not the identity default (never alongside a
-	// bot filter, which the server rejects).
+	// Exhaustive view, per the scope_filter field docs.
 	var scopeFilter *scopesv1.Filter
 	if botName == "" {
 		scopeFilter = scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build()

--- a/lib/web/machineid.go
+++ b/lib/web/machineid.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -468,13 +469,24 @@ func (h *Handler) listBotInstancesV2(_ http.ResponseWriter, r *http.Request, _ h
 		return nil, trace.Wrap(err)
 	}
 
+	botName := r.URL.Query().Get("bot_name")
+
+	// Exhaustive view, so ask for every scope rather than inheriting the
+	// identity-based default. A bot filter already pins the scope, and the server
+	// rejects the two together.
+	var scopeFilter *scopesv1.Filter
+	if botName == "" {
+		scopeFilter = scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build()
+	}
+
 	request := machineidv1.ListBotInstancesV2Request_builder{
 		PageToken: r.URL.Query().Get("page_token"),
 		SortField: r.URL.Query().Get("sort_field"),
 		Filter: machineidv1.ListBotInstancesV2Request_Filters_builder{
-			BotName:    r.URL.Query().Get("bot_name"),
-			SearchTerm: r.URL.Query().Get("search"),
-			Query:      r.URL.Query().Get("query"),
+			BotName:     botName,
+			SearchTerm:  r.URL.Query().Get("search"),
+			Query:       r.URL.Query().Get("query"),
+			ScopeFilter: scopeFilter,
 		}.Build(),
 	}.Build()
 

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -758,9 +758,8 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client botsCommandCl
 		botScope, botName = qn.Scope, qn.Name
 	}
 
-	// Exhaustive view, so ask for every scope rather than inheriting the
-	// identity-based default. A bot filter already pins the scope, and the server
-	// rejects the two together.
+	// Exhaustive view: mode ALL, not the identity default (never alongside a
+	// bot filter, which the server rejects).
 	var scopeFilter *scopesv1.Filter
 	if botName == "" {
 		scopeFilter = scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build()

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -758,8 +758,7 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client botsCommandCl
 		botScope, botName = qn.Scope, qn.Name
 	}
 
-	// Exhaustive view: mode ALL, not the identity default (never alongside a
-	// bot filter, which the server rejects).
+	// Exhaustive view, per the scope_filter field docs.
 	var scopeFilter *scopesv1.Filter
 	if botName == "" {
 		scopeFilter = scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build()

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
@@ -757,6 +758,14 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client botsCommandCl
 		botScope, botName = qn.Scope, qn.Name
 	}
 
+	// Exhaustive view, so ask for every scope rather than inheriting the
+	// identity-based default. A bot filter already pins the scope, and the server
+	// rejects the two together.
+	var scopeFilter *scopesv1.Filter
+	if botName == "" {
+		scopeFilter = scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build()
+	}
+
 	pageFunc := func(ctx context.Context, pageSize int, pageToken string) ([]*machineidv1pb.BotInstance, string, error) {
 		resp, err := client.BotInstanceServiceClient().ListBotInstancesV2(ctx, machineidv1pb.ListBotInstancesV2Request_builder{
 			PageSize:  int32(pageSize),
@@ -764,10 +773,11 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client botsCommandCl
 			SortField: c.sortIndex,
 			SortDesc:  c.sortOrder == "descending",
 			Filter: machineidv1pb.ListBotInstancesV2Request_Filters_builder{
-				BotName:    botName,
-				BotScope:   botScope,
-				SearchTerm: c.search,
-				Query:      c.query,
+				BotName:     botName,
+				BotScope:    botScope,
+				SearchTerm:  c.search,
+				Query:       c.query,
+				ScopeFilter: scopeFilter,
 			}.Build(),
 		}.Build())
 		return resp.GetBotInstances(), resp.GetNextPageToken(), trace.Wrap(err)


### PR DESCRIPTION
Depends on https://github.com/gravitational/teleport/pull/68391

Adds support for the ScopeFilter parameter to the ListBotInstances RPC and to the events watcher for scoped users.

Will backport with Scoped Bot Instances to v18

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

- [x] Regression:
  - [x] Validate Web UI still shows all unscoped Bot Instances to an unscoped user 
  - [x] Validate `tctl` still shows all unscoped Bot Instances to an unscoped user  
- [x] Validate `tctl` shows all unscoped and scoped Bot Instances to an unscoped user
- [x] Validate Web UI shows all unscoped and scoped Bot Instances to an unscoped user. 
- [x] Validate `tctl` shows scoped Bot Instances to scoped admin in their scope.
