### PR TITLE
test: Address flakiness in BotDetails tests

### DIFF
--- a/web/packages/teleport/src/Bots/Details/BotDetails.test.tsx
+++ b/web/packages/teleport/src/Bots/Details/BotDetails.test.tsx
@@ -624,19 +624,21 @@ describe('BotDetails', () => {
       await user.click(screen.getByText('Delete Bot'));
 
       // The operation is delayed to account for backend cache lag
-      await waitFor(
-        () => {
-          expect(
-            screen.queryByText('Delete test-bot-name?')
-          ).not.toBeInTheDocument();
-        },
-        { timeout: 5000 }
+      await waitForElementToBeRemoved(
+        () => screen.queryByText('Delete test-bot-name?'),
+        { timeout: 5_000 }
       );
 
-      expect(screen.getByTestId('current-pathname')).toHaveTextContent(
-        '/web/bots'
+      await waitFor(
+        () =>
+          expect(screen.getByTestId('current-pathname')).toHaveTextContent(
+            '/web/bots'
+          ),
+        {
+          timeout: 1_000,
+        }
       );
-    });
+    }, 6_000);
 
     it('should disable the delete action if no permissions', async () => {
       withFetchSuccess();

--- a/web/packages/teleport/src/Bots/Details/BotDetails.test.tsx
+++ b/web/packages/teleport/src/Bots/Details/BotDetails.test.tsx
@@ -624,9 +624,13 @@ describe('BotDetails', () => {
       await user.click(screen.getByText('Delete Bot'));
 
       // The operation is delayed to account for backend cache lag
-      await waitForElementToBeRemoved(
-        () => screen.queryByText('Delete test-bot-name?'),
-        { timeout: 5_000 }
+      await waitFor(
+        () => {
+          expect(
+            screen.queryByText('Delete test-bot-name?')
+          ).not.toBeInTheDocument();
+        },
+        { timeout: 5000 }
       );
 
       await waitFor(


### PR DESCRIPTION
## Summary

This change addresses flakiness in the BotDetails delete bot tests. I was not able to reproduce locally, so this change decreases the chance of flakiness rather than providing a solid fix.

Fixes: #66470

## Changes

- Moved `waitFor` to `waitForElementToBeRemoved` - should catch if the element was never there to start with
- Wrapped `current-pathname` check in `waitFor` in case navigation doesn't happen immediately