### PR TITLE
[v18] Apply outcome statement standard to TF references

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_access_list Terraform data-source
 sidebar_label: access_list
-description: This page describes the supported values of the teleport_access_list data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_access_list data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_access_list` data source of the
+This page lists the supported values of the `teleport_access_list` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list_member.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list_member.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_access_list_member Terraform data-source
 sidebar_label: access_list_member
-description: This page describes the supported values of the teleport_access_list_member data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_access_list_member data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_access_list_member` data source of the
+This page lists the supported values of the `teleport_access_list_member` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_monitoring_rule.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_access_monitoring_rule Terraform data-source
 sidebar_label: access_monitoring_rule
-description: This page describes the supported values of the teleport_access_monitoring_rule data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_access_monitoring_rule data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_access_monitoring_rule` data source of the
+This page lists the supported values of the `teleport_access_monitoring_rule` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/app.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/app.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_app Terraform data-source
 sidebar_label: app
-description: This page describes the supported values of the teleport_app data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_app data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_app` data source of the
+This page lists the supported values of the `teleport_app` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/auth_preference.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/auth_preference.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_auth_preference Terraform data-source
 sidebar_label: auth_preference
-description: This page describes the supported values of the teleport_auth_preference data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_auth_preference data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_auth_preference` data source of the
+This page lists the supported values of the `teleport_auth_preference` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_config.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_autoupdate_config Terraform data-source
 sidebar_label: autoupdate_config
-description: This page describes the supported values of the teleport_autoupdate_config data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_autoupdate_config data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_autoupdate_config` data source of the
+This page lists the supported values of the `teleport_autoupdate_config` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_version.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_version.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_autoupdate_version Terraform data-source
 sidebar_label: autoupdate_version
-description: This page describes the supported values of the teleport_autoupdate_version data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_autoupdate_version data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_autoupdate_version` data source of the
+This page lists the supported values of the `teleport_autoupdate_version` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/client_ip_restriction.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/client_ip_restriction.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_client_ip_restriction Terraform data-source
 sidebar_label: client_ip_restriction
-description: This page describes the supported values of the teleport_client_ip_restriction data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_client_ip_restriction data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_client_ip_restriction` data source of the
+This page lists the supported values of the `teleport_client_ip_restriction` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/cluster_maintenance_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/cluster_maintenance_config.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_cluster_maintenance_config Terraform data-source
 sidebar_label: cluster_maintenance_config
-description: This page describes the supported values of the teleport_cluster_maintenance_config data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_cluster_maintenance_config data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_cluster_maintenance_config` data source of the
+This page lists the supported values of the `teleport_cluster_maintenance_config` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/cluster_networking_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/cluster_networking_config.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_cluster_networking_config Terraform data-source
 sidebar_label: cluster_networking_config
-description: This page describes the supported values of the teleport_cluster_networking_config data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_cluster_networking_config data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_cluster_networking_config` data source of the
+This page lists the supported values of the `teleport_cluster_networking_config` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/data-sources.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/data-sources.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Terraform data-sources index"
 description: "Index of all the data-sources supported by the Teleport Terraform Provider"
+page_type: landing
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/database.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/database.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_database Terraform data-source
 sidebar_label: database
-description: This page describes the supported values of the teleport_database data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_database data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_database` data source of the
+This page lists the supported values of the `teleport_database` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/db_object_import_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/db_object_import_rule.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_db_object_import_rule Terraform data-source
 sidebar_label: db_object_import_rule
-description: This page describes the supported values of the teleport_db_object_import_rule data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_db_object_import_rule data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_db_object_import_rule` data source of the
+This page lists the supported values of the `teleport_db_object_import_rule` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/discovery_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/discovery_config.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_discovery_config Terraform data-source
 sidebar_label: discovery_config
-description: This page describes the supported values of the teleport_discovery_config data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_discovery_config data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_discovery_config` data source of the
+This page lists the supported values of the `teleport_discovery_config` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/dynamic_windows_desktop.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/dynamic_windows_desktop.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_dynamic_windows_desktop Terraform data-source
 sidebar_label: dynamic_windows_desktop
-description: This page describes the supported values of the teleport_dynamic_windows_desktop data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_dynamic_windows_desktop data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_dynamic_windows_desktop` data source of the
+This page lists the supported values of the `teleport_dynamic_windows_desktop` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/github_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/github_connector.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_github_connector Terraform data-source
 sidebar_label: github_connector
-description: This page describes the supported values of the teleport_github_connector data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_github_connector data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_github_connector` data source of the
+This page lists the supported values of the `teleport_github_connector` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/health_check_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/health_check_config.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_health_check_config Terraform data-source
 sidebar_label: health_check_config
-description: This page describes the supported values of the teleport_health_check_config data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_health_check_config data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_health_check_config` data source of the
+This page lists the supported values of the `teleport_health_check_config` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/installer.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/installer.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_installer Terraform data-source
 sidebar_label: installer
-description: This page describes the supported values of the teleport_installer data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_installer data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_installer` data source of the
+This page lists the supported values of the `teleport_installer` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/integration.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/integration.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_integration Terraform data-source
 sidebar_label: integration
-description: This page describes the supported values of the teleport_integration data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_integration data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_integration` data source of the
+This page lists the supported values of the `teleport_integration` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/lock.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/lock.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_lock Terraform data-source
 sidebar_label: lock
-description: This page describes the supported values of the teleport_lock data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_lock data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_lock` data source of the
+This page lists the supported values of the `teleport_lock` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/login_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/login_rule.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_login_rule Terraform data-source
 sidebar_label: login_rule
-description: This page describes the supported values of the teleport_login_rule data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_login_rule data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_login_rule` data source of the
+This page lists the supported values of the `teleport_login_rule` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/oidc_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/oidc_connector.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_oidc_connector Terraform data-source
 sidebar_label: oidc_connector
-description: This page describes the supported values of the teleport_oidc_connector data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_oidc_connector data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_oidc_connector` data source of the
+This page lists the supported values of the `teleport_oidc_connector` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/okta_import_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/okta_import_rule.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_okta_import_rule Terraform data-source
 sidebar_label: okta_import_rule
-description: This page describes the supported values of the teleport_okta_import_rule data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_okta_import_rule data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_okta_import_rule` data source of the
+This page lists the supported values of the `teleport_okta_import_rule` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/provision_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/provision_token.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_provision_token Terraform data-source
 sidebar_label: provision_token
-description: This page describes the supported values of the teleport_provision_token data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_provision_token data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_provision_token` data source of the
+This page lists the supported values of the `teleport_provision_token` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/role.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_role Terraform data-source
 sidebar_label: role
-description: This page describes the supported values of the teleport_role data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_role data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_role` data source of the
+This page lists the supported values of the `teleport_role` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/saml_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/saml_connector.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_saml_connector Terraform data-source
 sidebar_label: saml_connector
-description: This page describes the supported values of the teleport_saml_connector data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_saml_connector data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_saml_connector` data source of the
+This page lists the supported values of the `teleport_saml_connector` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/saml_idp_service_provider.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/saml_idp_service_provider.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_saml_idp_service_provider Terraform data-source
 sidebar_label: saml_idp_service_provider
-description: This page describes the supported values of the teleport_saml_idp_service_provider data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_saml_idp_service_provider data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_saml_idp_service_provider` data source of the
+This page lists the supported values of the `teleport_saml_idp_service_provider` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_scoped_role Terraform data-source
 sidebar_label: scoped_role
-description: This page describes the supported values of the teleport_scoped_role data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_scoped_role data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_scoped_role` data source of the
+This page lists the supported values of the `teleport_scoped_role` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role_assignment.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role_assignment.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_scoped_role_assignment Terraform data-source
 sidebar_label: scoped_role_assignment
-description: This page describes the supported values of the teleport_scoped_role_assignment data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_scoped_role_assignment data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_scoped_role_assignment` data source of the
+This page lists the supported values of the `teleport_scoped_role_assignment` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_scoped_token Terraform data-source
 sidebar_label: scoped_token
-description: This page describes the supported values of the teleport_scoped_token data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_scoped_token data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_scoped_token` data source of the
+This page lists the supported values of the `teleport_scoped_token` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/session_recording_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/session_recording_config.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_session_recording_config Terraform data-source
 sidebar_label: session_recording_config
-description: This page describes the supported values of the teleport_session_recording_config data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_session_recording_config data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_session_recording_config` data source of the
+This page lists the supported values of the `teleport_session_recording_config` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/static_host_user.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/static_host_user.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_static_host_user Terraform data-source
 sidebar_label: static_host_user
-description: This page describes the supported values of the teleport_static_host_user data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_static_host_user data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_static_host_user` data source of the
+This page lists the supported values of the `teleport_static_host_user` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/trusted_cluster.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/trusted_cluster.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_trusted_cluster Terraform data-source
 sidebar_label: trusted_cluster
-description: This page describes the supported values of the teleport_trusted_cluster data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_trusted_cluster data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_trusted_cluster` data source of the
+This page lists the supported values of the `teleport_trusted_cluster` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/trusted_device.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/trusted_device.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_trusted_device Terraform data-source
 sidebar_label: trusted_device
-description: This page describes the supported values of the teleport_trusted_device data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_trusted_device data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_trusted_device` data source of the
+This page lists the supported values of the `teleport_trusted_device` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/ui_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/ui_config.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_ui_config Terraform data-source
 sidebar_label: ui_config
-description: This page describes the supported values of the teleport_ui_config data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_ui_config data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_ui_config` data source of the
+This page lists the supported values of the `teleport_ui_config` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/user.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/user.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_user Terraform data-source
 sidebar_label: user
-description: This page describes the supported values of the teleport_user data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_user data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_user` data source of the
+This page lists the supported values of the `teleport_user` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/vnet_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/vnet_config.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_vnet_config Terraform data-source
 sidebar_label: vnet_config
-description: This page describes the supported values of the teleport_vnet_config data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_vnet_config data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_vnet_config` data source of the
+This page lists the supported values of the `teleport_vnet_config` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/workload_cluster.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/workload_cluster.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_workload_cluster Terraform data-source
 sidebar_label: workload_cluster
-description: This page describes the supported values of the teleport_workload_cluster data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_workload_cluster data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_workload_cluster` data source of the
+This page lists the supported values of the `teleport_workload_cluster` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/workload_identity.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/workload_identity.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_workload_identity Terraform data-source
 sidebar_label: workload_identity
-description: This page describes the supported values of the teleport_workload_identity data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_workload_identity data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the `teleport_workload_identity` data source of the
+This page lists the supported values of the `teleport_workload_identity` data source of the
 Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_access_list Terraform resource
 sidebar_label: access_list
-description: This page describes the supported values of the teleport_access_list resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_access_list resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_access_list resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_access_list resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list_member.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list_member.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_access_list_member Terraform resource
 sidebar_label: access_list_member
-description: This page describes the supported values of the teleport_access_list_member resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_access_list_member resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_access_list_member resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_access_list_member resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_monitoring_rule.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_access_monitoring_rule Terraform resource
 sidebar_label: access_monitoring_rule
-description: This page describes the supported values of the teleport_access_monitoring_rule resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_access_monitoring_rule resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_access_monitoring_rule resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_access_monitoring_rule resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/app.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/app.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_app Terraform resource
 sidebar_label: app
-description: This page describes the supported values of the teleport_app resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_app resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_app resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_app resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/auth_preference.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/auth_preference.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_auth_preference Terraform resource
 sidebar_label: auth_preference
-description: This page describes the supported values of the teleport_auth_preference resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_auth_preference resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_auth_preference resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_auth_preference resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_config.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_autoupdate_config Terraform resource
 sidebar_label: autoupdate_config
-description: This page describes the supported values of the teleport_autoupdate_config resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_autoupdate_config resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_autoupdate_config resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_autoupdate_config resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_version.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_version.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_autoupdate_version Terraform resource
 sidebar_label: autoupdate_version
-description: This page describes the supported values of the teleport_autoupdate_version resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_autoupdate_version resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_autoupdate_version resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_autoupdate_version resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/bot.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/bot.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_bot Terraform resource
 sidebar_label: bot
-description: This page describes the supported values of the teleport_bot resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_bot resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_bot resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_bot resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/client_ip_restriction.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/client_ip_restriction.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_client_ip_restriction Terraform resource
 sidebar_label: client_ip_restriction
-description: This page describes the supported values of the teleport_client_ip_restriction resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_client_ip_restriction resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_client_ip_restriction resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_client_ip_restriction resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/cluster_maintenance_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/cluster_maintenance_config.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_cluster_maintenance_config Terraform resource
 sidebar_label: cluster_maintenance_config
-description: This page describes the supported values of the teleport_cluster_maintenance_config resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_cluster_maintenance_config resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_cluster_maintenance_config resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_cluster_maintenance_config resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/cluster_networking_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/cluster_networking_config.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_cluster_networking_config Terraform resource
 sidebar_label: cluster_networking_config
-description: This page describes the supported values of the teleport_cluster_networking_config resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_cluster_networking_config resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_cluster_networking_config resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_cluster_networking_config resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/database.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/database.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_database Terraform resource
 sidebar_label: database
-description: This page describes the supported values of the teleport_database resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_database resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_database resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_database resource of the Teleport Terraform provider.
 Follow [the database dynamic registration guide](../../../../enroll-resources/database-access/guides/dynamic-registration.mdx)
 to complete deploying a database_service and access the database resource
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/db_object_import_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/db_object_import_rule.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_db_object_import_rule Terraform resource
 sidebar_label: db_object_import_rule
-description: This page describes the supported values of the teleport_db_object_import_rule resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_db_object_import_rule resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_db_object_import_rule resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_db_object_import_rule resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/discovery_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/discovery_config.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_discovery_config Terraform resource
 sidebar_label: discovery_config
-description: This page describes the supported values of the teleport_discovery_config resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_discovery_config resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_discovery_config resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_discovery_config resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/dynamic_windows_desktop.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/dynamic_windows_desktop.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_dynamic_windows_desktop Terraform resource
 sidebar_label: dynamic_windows_desktop
-description: This page describes the supported values of the teleport_dynamic_windows_desktop resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_dynamic_windows_desktop resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_dynamic_windows_desktop resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_dynamic_windows_desktop resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/github_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/github_connector.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_github_connector Terraform resource
 sidebar_label: github_connector
-description: This page describes the supported values of the teleport_github_connector resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_github_connector resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_github_connector resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_github_connector resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/health_check_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/health_check_config.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_health_check_config Terraform resource
 sidebar_label: health_check_config
-description: This page describes the supported values of the teleport_health_check_config resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_health_check_config resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_health_check_config resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_health_check_config resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/inference_model.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/inference_model.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_inference_model Terraform resource
 sidebar_label: inference_model
-description: This page describes the supported values of the teleport_inference_model resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_inference_model resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_inference_model resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_inference_model resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/inference_policy.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/inference_policy.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_inference_policy Terraform resource
 sidebar_label: inference_policy
-description: This page describes the supported values of the teleport_inference_policy resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_inference_policy resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_inference_policy resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_inference_policy resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/inference_secret.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/inference_secret.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_inference_secret Terraform resource
 sidebar_label: inference_secret
-description: This page describes the supported values of the teleport_inference_secret resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_inference_secret resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_inference_secret resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_inference_secret resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/installer.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/installer.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_installer Terraform resource
 sidebar_label: installer
-description: This page describes the supported values of the teleport_installer resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_installer resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_installer resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_installer resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/integration.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/integration.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_integration Terraform resource
 sidebar_label: integration
-description: This page describes the supported values of the teleport_integration resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_integration resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_integration resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_integration resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/lock.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/lock.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_lock Terraform resource
 sidebar_label: lock
-description: This page describes the supported values of the teleport_lock resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_lock resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_lock resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_lock resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/login_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/login_rule.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_login_rule Terraform resource
 sidebar_label: login_rule
-description: This page describes the supported values of the teleport_login_rule resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_login_rule resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_login_rule resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_login_rule resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/oidc_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/oidc_connector.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_oidc_connector Terraform resource
 sidebar_label: oidc_connector
-description: This page describes the supported values of the teleport_oidc_connector resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_oidc_connector resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_oidc_connector resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_oidc_connector resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/okta_import_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/okta_import_rule.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_okta_import_rule Terraform resource
 sidebar_label: okta_import_rule
-description: This page describes the supported values of the teleport_okta_import_rule resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_okta_import_rule resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_okta_import_rule resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_okta_import_rule resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/provision_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/provision_token.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_provision_token Terraform resource
 sidebar_label: provision_token
-description: This page describes the supported values of the teleport_provision_token resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_provision_token resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_provision_token resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_provision_token resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/resources.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/resources.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Terraform resources index"
 description: "Index of all the datasources supported by the Teleport Terraform Provider"
+page_type: landing
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/retrieval_model.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/retrieval_model.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_retrieval_model Terraform resource
 sidebar_label: retrieval_model
-description: This page describes the supported values of the teleport_retrieval_model resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_retrieval_model resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_retrieval_model resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_retrieval_model resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/role.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_role Terraform resource
 sidebar_label: role
-description: This page describes the supported values of the teleport_role resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_role resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_role resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_role resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/saml_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/saml_connector.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_saml_connector Terraform resource
 sidebar_label: saml_connector
-description: This page describes the supported values of the teleport_saml_connector resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_saml_connector resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_saml_connector resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_saml_connector resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/saml_idp_service_provider.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/saml_idp_service_provider.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_saml_idp_service_provider Terraform resource
 sidebar_label: saml_idp_service_provider
-description: This page describes the supported values of the teleport_saml_idp_service_provider resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_saml_idp_service_provider resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_saml_idp_service_provider resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_saml_idp_service_provider resource of the Teleport Terraform provider.
 The Teleport API allows providing an XML `entity_descriptor`, an `entity_id`, an
 `acs_url`. However, the `entity_descriptor` contains both the `entity_id` and
 `acs_url` values. The API disallows mutations if `entity_id` doesn't match the

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_scoped_role Terraform resource
 sidebar_label: scoped_role
-description: This page describes the supported values of the teleport_scoped_role resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_scoped_role resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_scoped_role resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_scoped_role resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role_assignment.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role_assignment.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_scoped_role_assignment Terraform resource
 sidebar_label: scoped_role_assignment
-description: This page describes the supported values of the teleport_scoped_role_assignment resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_scoped_role_assignment resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_scoped_role_assignment resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_scoped_role_assignment resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_scoped_token Terraform resource
 sidebar_label: scoped_token
-description: This page describes the supported values of the teleport_scoped_token resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_scoped_token resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_scoped_token resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_scoped_token resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/server.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/server.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_server Terraform resource
 sidebar_label: server
-description: This page describes the supported values of the teleport_server resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_server resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_server resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_server resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/session_recording_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/session_recording_config.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_session_recording_config Terraform resource
 sidebar_label: session_recording_config
-description: This page describes the supported values of the teleport_session_recording_config resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_session_recording_config resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_session_recording_config resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_session_recording_config resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/static_host_user.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/static_host_user.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_static_host_user Terraform resource
 sidebar_label: static_host_user
-description: This page describes the supported values of the teleport_static_host_user resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_static_host_user resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_static_host_user resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_static_host_user resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/trusted_cluster.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/trusted_cluster.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_trusted_cluster Terraform resource
 sidebar_label: trusted_cluster
-description: This page describes the supported values of the teleport_trusted_cluster resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_trusted_cluster resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_trusted_cluster resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_trusted_cluster resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/trusted_device.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/trusted_device.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_trusted_device Terraform resource
 sidebar_label: trusted_device
-description: This page describes the supported values of the teleport_trusted_device resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_trusted_device resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_trusted_device resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_trusted_device resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/ui_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/ui_config.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_ui_config Terraform resource
 sidebar_label: ui_config
-description: This page describes the supported values of the teleport_ui_config resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_ui_config resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_ui_config resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_ui_config resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/user.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/user.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_user Terraform resource
 sidebar_label: user
-description: This page describes the supported values of the teleport_user resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_user resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_user resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_user resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/vnet_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/vnet_config.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_vnet_config Terraform resource
 sidebar_label: vnet_config
-description: This page describes the supported values of the teleport_vnet_config resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_vnet_config resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_vnet_config resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_vnet_config resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/workload_cluster.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/workload_cluster.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_workload_cluster Terraform resource
 sidebar_label: workload_cluster
-description: This page describes the supported values of the teleport_workload_cluster resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_workload_cluster resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_workload_cluster resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_workload_cluster resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/workload_identity.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/workload_identity.mdx
@@ -1,13 +1,14 @@
 ---
 title: Reference for the teleport_workload_identity Terraform resource
 sidebar_label: workload_identity
-description: This page describes the supported values of the teleport_workload_identity resource of the Teleport Terraform provider.
+description: This page lists the supported values of the teleport_workload_identity resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
-This page describes the supported values of the teleport_workload_identity resource of the Teleport Terraform provider.
+This page lists the supported values of the teleport_workload_identity resource of the Teleport Terraform provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/terraform-provider.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/terraform-provider.mdx
@@ -6,6 +6,7 @@ tags:
  - infrastructure-as-code
  - reference
  - platform-wide
+page_type: landing
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/integrations/terraform/templates/data-sources-index.mdx.tmpl
+++ b/integrations/terraform/templates/data-sources-index.mdx.tmpl
@@ -1,6 +1,7 @@
 ---
 title: "Terraform data-sources index"
 description: "Index of all the data-sources supported by the Teleport Terraform Provider"
+page_type: landing
 ---
 
 {{ "{/*Auto-generated file. Do not edit.*/}" }}

--- a/integrations/terraform/templates/data-sources.md.tmpl
+++ b/integrations/terraform/templates/data-sources.md.tmpl
@@ -1,13 +1,14 @@
 ---
 title: Reference for the {{.Name}} Terraform data-source
 sidebar_label: {{ slice .Name (len "teleport_") }}
-description: This page describes the supported values of the {{.Name}} data-source of the Teleport Terraform provider.
+description: This page lists the supported values of the {{.Name}} data-source of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {{ "{/*Auto-generated file. Do not edit.*/}" }}
 {{ "{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}" }}
 
-This page describes the supported values of the `{{.Name}}` data source of the
+This page lists the supported values of the `{{.Name}}` data source of the
 Teleport Terraform provider.
 
 {{ .Description | trimspace }}

--- a/integrations/terraform/templates/index.md.tmpl
+++ b/integrations/terraform/templates/index.md.tmpl
@@ -6,6 +6,7 @@ tags:
  - infrastructure-as-code
  - reference
  - platform-wide
+page_type: landing
 ---
 
 {{ "{/*Auto-generated file. Do not edit.*/}" }}

--- a/integrations/terraform/templates/resources-index.mdx.tmpl
+++ b/integrations/terraform/templates/resources-index.mdx.tmpl
@@ -1,6 +1,7 @@
 ---
 title: "Terraform resources index"
 description: "Index of all the datasources supported by the Teleport Terraform Provider"
+page_type: landing
 ---
 
 {{ "{/*Auto-generated file. Do not edit.*/}" }}

--- a/integrations/terraform/templates/resources.md.tmpl
+++ b/integrations/terraform/templates/resources.md.tmpl
@@ -1,13 +1,14 @@
 ---
 title: Reference for the {{.Name}} Terraform resource
 sidebar_label: {{ slice .Name (len "teleport_") }}
-description: This page describes the supported values of the {{.Name}} resource of the Teleport Terraform provider.
+description: This page lists the supported values of the {{.Name}} resource of the Teleport Terraform provider.
+page_type: reference
 ---
 
 {{ "{/*Auto-generated file. Do not edit.*/}" }}
 {{ "{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}" }}
 
-This page describes the supported values of the {{.Name}} resource of the Teleport Terraform provider.
+This page lists the supported values of the {{.Name}} resource of the Teleport Terraform provider.
 {{ includefileifexists (printf "./examples/resources/%s/introduction.md" .Name)}}
 
 {{ .Description | trimspace }}


### PR DESCRIPTION
Backports #68949

The docs are moving towards expecting a standard set of outcome statements. This allows us to ensure that each page includes a succinct summary of its purpose for human and agent readers, depending on the type of page, without requiring the reader to traverse more of the document than necessary.

This change edits the templates for the Terraform reference pages to:
- Add the `page_type` frontmatter field, which is used to enforce standards for different types of pages.
- Change "describes" to "lists", which is more accurate for reference pages and accommodates the expected outcome statement structure.