### PR TITLE
[v18] Add `tctl discovery status` troubleshooting includes for AWS and Azure

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/databases/aws.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/databases/aws.mdx
@@ -313,6 +313,8 @@ for information about database user provisioning and configuration.
 
 ## Troubleshooting
 
+(!docs/pages/includes/discovery/tctl-discovery-status.mdx provider="AWS" cloud="aws" resource="AWS RDS"!)
+
 (!docs/pages/includes/discovery/discovery-service-troubleshooting.mdx resourceKind="database" tctlResource="db" cloud="AWS"!)
 
 (!docs/pages/includes/discovery/database-service-troubleshooting.mdx!)

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/eks-discovery/eks-discovery-terraform.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/eks-discovery/eks-discovery-terraform.mdx
@@ -350,6 +350,8 @@ in the newly-configured regions.
 
 ## Troubleshooting
 
+(!docs/pages/includes/discovery/tctl-discovery-status.mdx provider="AWS" cloud="aws" resource="AWS EKS"!)
+
 (!docs/pages/includes/discovery/discovery-service-troubleshooting.mdx resourceKind="Kubernetes cluster" tctlResource="kube_cluster" cloud="AWS"!)
 
 (!docs/pages/includes/discovery/kubernetes-service-troubleshooting.mdx!)

--- a/docs/pages/includes/auto-discovery/azure-vm-troubleshooting.mdx
+++ b/docs/pages/includes/auto-discovery/azure-vm-troubleshooting.mdx
@@ -1,4 +1,6 @@
 {/* this comment is here to make the include below render */}
+(!docs/pages/includes/discovery/tctl-discovery-status.mdx provider="Azure" cloud="azure" resource="Azure VM"!)
+
 (!docs/pages/includes/auto-discovery/tctl-discovery-nodes-azure.mdx!)
 
 ### Teleport reports no error but VM does not join

--- a/docs/pages/includes/auto-discovery/ec2-troubleshooting.mdx
+++ b/docs/pages/includes/auto-discovery/ec2-troubleshooting.mdx
@@ -1,4 +1,6 @@
 {/* this comment is here to make the include below render */}
+(!docs/pages/includes/discovery/tctl-discovery-status.mdx provider="AWS" cloud="aws" resource="AWS EC2"!)
+
 (!docs/pages/includes/auto-discovery/tctl-discovery-nodes-aws.mdx!)
 
 If Installs are showing failed or instances are failing to appear check the

--- a/docs/pages/includes/discovery/tctl-discovery-status.mdx
+++ b/docs/pages/includes/discovery/tctl-discovery-status.mdx
@@ -1,0 +1,38 @@
+{{ provider="AWS" cloud="aws" resource="AWS EC2" }}
+
+### Inspect {{ provider }} discovery status
+
+Run `tctl discovery status` to check the state of dynamic Discovery Service
+configurations, when each Discovery Service instance last reported, and the latest
+{{ provider }} enrollment totals:
+
+```code
+$ tctl discovery status --cloud={{ cloud }}
+```
+
+The following example shows a healthy configuration that discovered and enrolled two resources:
+
+```text
+Discovery config example-discovery:
+  Discovery group: production
+  Status: healthy
+  Last run: 1 minute ago
+
+  Service (00000000-0000-0000-0000-000000000000):
+    Poll interval: 5 minutes
+    Last update: 1 minute ago
+    example-integration:
+      {{ resource }}:
+        Previous sync: 1 minute ago (took 12s)
+        Result: 2 found, 2 enrolled, 0 failed
+```
+
+A persistent `error` or `not reporting yet` status, a message that no Discovery
+Service instances are running, or a nonzero `failed` count indicates a discovery
+or enrollment problem.
+
+The command reports dynamic `discovery_config` resources. It does not include
+static discovery matchers configured in `teleport.yaml`.
+
+See [`tctl discovery status`](../../reference/cli/tctl.mdx#tctl-discovery-status)
+for the full flag reference.


### PR DESCRIPTION
Summary
Adds tctl discovery status to troubleshooting guidance for applicable AWS and Azure auto-discovery guides.

Uses a shared partial to cover EC2 and Azure VM guides, with direct additions for AWS database and EKS Terraform discovery. Clarifies that the command reports dynamic discovery_config resources and excludes static teleport.yaml matchers.