### PR TITLE
`tctl devices add`: Derive `--os` flag from `devicepb.OSType`

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -1469,7 +1469,7 @@ Flags:
 |`--format`|`text` (one of: `text`, `json`, `yaml`)|Output format.|
 |`--[no-]current-device`|`false`|Registers the current device. Overrides --os and --asset-tag.|
 |`--[no-]enroll`|`false`|If set, creates a device enrollment token|
-|`--os`|*no default* (one of: `linux`, `macos`, `windows`)|Operating system|
+|`--os`|*no default* (one of: `ios`, `ipados`, `linux`, `macos`, `windows`)|Operating system|
 
 ## tctl devices enroll
 

--- a/tool/tctl/common/devices.go
+++ b/tool/tctl/common/devices.go
@@ -27,7 +27,6 @@ import (
 	"log/slog"
 	"os"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -63,24 +62,20 @@ type DevicesCommand struct {
 	Stdout io.Writer
 }
 
-type osType = string
-
-// osTypes (accepted --os values) and osTypeToEnum are derived from
-// devicepb.OSType, minus UNSPECIFIED.
-var osTypes, osTypeToEnum = func() (osTypes []osType, osTypeToEnum map[osType]devicepb.OSType) {
-	osTypeToEnum = make(map[osType]devicepb.OSType, len(devicepb.OSType_value)-1)
-	for name, v := range devicepb.OSType_value {
-		ost := devicepb.OSType(v)
-		if ost == devicepb.OSType_OS_TYPE_UNSPECIFIED {
+// osTypeFlagValues returns the accepted --os values: every [devicepb.OSType]
+// except UNSPECIFIED, spelled the way api spells it.
+func osTypeFlagValues() []string {
+	values := make([]string, 0, len(devicepb.OSType_name)-1)
+	for num := range devicepb.OSType_name {
+		osType := devicepb.OSType(num)
+		if osType == devicepb.OSType_OS_TYPE_UNSPECIFIED {
 			continue
 		}
-		s := strings.ToLower(strings.TrimPrefix(name, "OS_TYPE_"))
-		osTypeToEnum[s] = ost
-		osTypes = append(osTypes, s)
+		values = append(values, types.ResourceOSTypeToString(osType))
 	}
-	sort.Strings(osTypes)
-	return osTypes, osTypeToEnum
-}()
+	sort.Strings(values)
+	return values
+}
 
 func (c *DevicesCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, cfg *servicecfg.Config) {
 	devicesCmd := app.Command("devices", "Register and manage trusted devices").Hidden()
@@ -89,7 +84,7 @@ func (c *DevicesCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalC
 
 	addCmd := devicesCmd.Command("add", "Register managed devices.")
 	addCmd.Flag("os", "Operating system").
-		EnumVar(&c.add.os, osTypes...)
+		EnumVar(&c.add.os, osTypeFlagValues()...)
 	addCmd.Flag("asset-tag", "Inventory identifier for the device (e.g., Mac serial number)").
 		StringVar(&c.add.assetTag)
 	addCmd.Flag("current-device", "Registers the current device. Overrides --os and --asset-tag.").
@@ -197,10 +192,13 @@ func (c *deviceAddCommand) Run(ctx context.Context, authClient *authclient.Clien
 	}
 
 	if c.os != "" {
-		var ok bool
-		c.osType, ok = osTypeToEnum[c.os]
-		if !ok {
-			return trace.BadParameter("invalid --os: %v", c.os)
+		var err error
+		// kingpin makes sure that c.os is set to one of the values returned from
+		// [osTypeFlagValues], so we don't have to worry about "unspecified" here.
+		if c.osType, err = types.ResourceOSTypeFromString(c.os); err != nil {
+			// No need to re-wrap err into something specific to the --os flag, as at
+			// this point we know that c.os points to a valid OSType.
+			return trace.Wrap(err)
 		}
 	}
 

--- a/tool/tctl/common/devices.go
+++ b/tool/tctl/common/devices.go
@@ -27,6 +27,7 @@ import (
 	"log/slog"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -64,19 +65,22 @@ type DevicesCommand struct {
 
 type osType = string
 
-const (
-	linuxType   osType = "linux"
-	macosType   osType = "macos"
-	windowsType osType = "windows"
-)
-
-var osTypes = []string{linuxType, macosType, windowsType}
-
-var osTypeToEnum = map[osType]devicepb.OSType{
-	linuxType:   devicepb.OSType_OS_TYPE_LINUX,
-	macosType:   devicepb.OSType_OS_TYPE_MACOS,
-	windowsType: devicepb.OSType_OS_TYPE_WINDOWS,
-}
+// osTypes (accepted --os values) and osTypeToEnum are derived from
+// devicepb.OSType, minus UNSPECIFIED.
+var osTypes, osTypeToEnum = func() (osTypes []osType, osTypeToEnum map[osType]devicepb.OSType) {
+	osTypeToEnum = make(map[osType]devicepb.OSType, len(devicepb.OSType_value)-1)
+	for name, v := range devicepb.OSType_value {
+		ost := devicepb.OSType(v)
+		if ost == devicepb.OSType_OS_TYPE_UNSPECIFIED {
+			continue
+		}
+		s := strings.ToLower(strings.TrimPrefix(name, "OS_TYPE_"))
+		osTypeToEnum[s] = ost
+		osTypes = append(osTypes, s)
+	}
+	sort.Strings(osTypes)
+	return osTypes, osTypeToEnum
+}()
 
 func (c *DevicesCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, cfg *servicecfg.Config) {
 	devicesCmd := app.Command("devices", "Register and manage trusted devices").Hidden()

--- a/tool/tctl/common/devices_test.go
+++ b/tool/tctl/common/devices_test.go
@@ -22,12 +22,16 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/utils"
+	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 )
 
 func TestDeviceSourceToString(t *testing.T) {
@@ -147,4 +151,42 @@ func TestWriteCreatedLock(t *testing.T) {
 		err := writeCreatedLock("bogus", lock, &bytes.Buffer{})
 		require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
 	})
+}
+
+// TestOSTypeFlagValues covers the --os values offered by `tctl devices add`.
+// They come from devicepb.OSType, so an OSType that ResourceOSTypeToString
+// doesn't know about would reach the CLI as its bare proto name.
+func TestOSTypeFlagValues(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, []string{"ios", "ipados", "linux", "macos", "windows"},
+		osTypeFlagValues(), "osTypeFlagValues mismatch")
+}
+
+// TestDeviceAddOSFlag covers the --os values `tctl devices add` accepts.
+// The flag is the only thing keeping UNSPECIFIED out, as
+// [types.ResourceOSTypeFromString] resolves "unspecified" without an error.
+func TestDeviceAddOSFlag(t *testing.T) {
+	t.Parallel()
+
+	parse := func(t *testing.T, os string) error {
+		t.Helper()
+		c := DevicesCommand{}
+		app := utils.InitCLIParser("tctl", GlobalHelpString)
+		c.Initialize(app, &tctlcfg.GlobalCLIFlags{}, servicecfg.MakeDefaultConfig())
+		_, err := app.Parse([]string{"devices", "add", "--os", os, "--asset-tag", "C00AA0AAAA0A"})
+		return err
+	}
+
+	for _, os := range osTypeFlagValues() {
+		t.Run(os, func(t *testing.T) {
+			assert.NoError(t, parse(t, os), "--os %v rejected", os)
+		})
+	}
+
+	for _, os := range []string{"unspecified", "OS_TYPE_MACOS", "bogus"} {
+		t.Run("rejects "+os, func(t *testing.T) {
+			assert.ErrorContains(t, parse(t, os), "enum value must be one of ios,", "--os %v accepted", os)
+		})
+	}
 }


### PR DESCRIPTION
When working on a proof of concept for Gustavo, I realized that `tctl devices add` doesn't support Apple devices yet. We don't generally expect people to use Device Trust for iOS without using one of our MDM integrations, but technically it's still possible[^1]. To that end, those users would need to use either the API or tctl to manage their inventory. This PR makes sure that it'll be possible to manage Apple devices through tctl.

iOS and iPadOS were added to `OSType` back in #65834, but I forgot to take care of the `--os` values accepted by `tctl devices add`. This PR can be safely backported to v18 so that when https://github.com/gravitational/teleport/pull/67553, iOS and iPadOS will be supported by tctl without any extra changes.

[^1]: The only requirement RFD 32e places on users is that the device exists in the inventory and an app configuration is pushed to the device through an MDM. It's possible to use Device Trust for iOS with an MDM for which we don't have an inventory integration.

## Manual Test Plan
### Test Environment

A locally built cluster and tctl

### Test Cases
- [x] `tctl devices add --os ios` works
- [x] `tctl devices add --os macos` still works
