### PR TITLE
[12] events: assign session event indexes at serialization

### DIFF
--- a/lib/events/session_writer.go
+++ b/lib/events/session_writer.go
@@ -27,12 +27,14 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/session"
 )
@@ -170,6 +172,10 @@ type SessionWriter struct {
 	// doneCh is closed when all internal processes have exited
 	doneCh chan struct{}
 
+	// nextEventIndex is only accessed by processEvents. Assigning indexes in
+	// that single consumer makes index order match storage order.
+	nextEventIndex int64
+
 	backoffUntil   time.Time
 	lostEvents     atomic.Int64
 	acceptedEvents atomic.Int64
@@ -270,15 +276,12 @@ func (a *SessionWriter) maybeSetBackoff(backoffUntil time.Time) bool {
 
 // RecordEvent emits audit event
 func (a *SessionWriter) RecordEvent(ctx context.Context, pe apievents.PreparedSessionEvent) error {
-	event := pe.GetAuditEvent()
-	if err := checkBasicEventFields(event); err != nil {
+	event, err := cloneAuditEvent(pe.GetAuditEvent())
+	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	// the index starts at 0, so we'll only know if the index is invalid
-	// if we've seen at least one event already
-	if event.GetIndex() == 0 && a.acceptedEvents.Load() > 0 {
-		return trace.BadParameter("missing mandatory event index field")
+	if err := checkBasicEventFields(event); err != nil {
+		return trace.Wrap(err)
 	}
 
 	a.acceptedEvents.Add(1)
@@ -295,9 +298,11 @@ func (a *SessionWriter) RecordEvent(ctx context.Context, pe apievents.PreparedSe
 		return nil
 	}
 
+	preparedEvent := preparedSessionEvent{event: event}
+
 	// This fast path will be used all the time during normal operation.
 	select {
-	case a.eventsCh <- pe:
+	case a.eventsCh <- preparedEvent:
 		return nil
 	case <-ctx.Done():
 		return trace.ConnectionProblem(ctx.Err(), "context canceled or timed out")
@@ -334,7 +339,7 @@ func (a *SessionWriter) RecordEvent(ctx context.Context, pe apievents.PreparedSe
 	defer timerPool.Put(t)
 
 	select {
-	case a.eventsCh <- pe:
+	case a.eventsCh <- preparedEvent:
 		stopped := t.Stop()
 		if !stopped {
 			// Here and below, consume triggered (but not yet received) timer event
@@ -365,6 +370,18 @@ func (a *SessionWriter) RecordEvent(ctx context.Context, pe apievents.PreparedSe
 		}
 		return trace.ConnectionProblem(a.closeCtx.Err(), "writer is closed")
 	}
+}
+
+func cloneAuditEvent(event apievents.AuditEvent) (apievents.AuditEvent, error) {
+	message, ok := event.(proto.Message)
+	if !ok {
+		return nil, trace.BadParameter("session event %T is not a protobuf message", event)
+	}
+	clonedEvent, ok := apiutils.CloneProtoMsg(message).(apievents.AuditEvent)
+	if !ok {
+		return nil, trace.BadParameter("cloned session event %T does not implement AuditEvent", message)
+	}
+	return clonedEvent, nil
 }
 
 var timerPool sync.Pool
@@ -432,6 +449,8 @@ func (a *SessionWriter) processEvents() {
 		case status := <-a.stream.Status():
 			a.updateStatus(status)
 		case event := <-a.eventsCh:
+			event.GetAuditEvent().SetIndex(a.nextEventIndex)
+			a.nextEventIndex++
 			a.buffer = append(a.buffer, event)
 			err := a.stream.RecordEvent(a.cfg.Context, event)
 			if err != nil {

--- a/lib/events/session_writer_test.go
+++ b/lib/events/session_writer_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -327,6 +328,71 @@ func TestSessionWriter(t *testing.T) {
 			}
 		}, 300*time.Millisecond, 100*time.Millisecond)
 	})
+}
+
+// TestSessionWriterOrdersClonedEventsAtSerialization verifies that prepared
+// events may arrive in any index order without being mutated or stored out of
+// order.
+func TestSessionWriterOrdersClonedEventsAtSerialization(t *testing.T) {
+	test := newSessionWriterTest(t, nil)
+	defer test.cancel()
+
+	// Prepared indexes, recorded in an order that is deliberately not ascending.
+	indexes := []int64{0, 5, 3, 4, 2, 1, 9, 6, 8, 7}
+	var inputEvents []*apievents.SessionPrint
+	for _, idx := range indexes {
+		e := &apievents.SessionPrint{
+			Metadata: apievents.Metadata{Type: events.SessionPrintEvent, Index: idx},
+			Data:     []byte{byte(idx)},
+		}
+		inputEvents = append(inputEvents, e)
+		require.NoError(t, test.writer.RecordEvent(test.ctx, eventstest.PrepareEvent(e)))
+		e.Data[0] = 255
+	}
+	require.NoError(t, test.writer.Complete(test.ctx))
+
+	out := test.collectEvents(t)
+	require.Len(t, out, len(indexes))
+	for i, event := range out {
+		require.Equal(t, int64(i), event.GetIndex())
+		require.Equal(t, []byte{byte(indexes[i])}, event.(*apievents.SessionPrint).Data)
+		require.Equal(t, indexes[i], inputEvents[i].GetIndex(), "RecordEvent mutated its input")
+	}
+}
+
+func TestSessionWriterAssignsIndexesForConcurrentEvents(t *testing.T) {
+	test := newSessionWriterTest(t, nil)
+	defer test.cancel()
+
+	const eventCount = 128
+	errCh := make(chan error, eventCount)
+	var wg sync.WaitGroup
+	for i := range eventCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			event := &apievents.SessionPrint{
+				Metadata: apievents.Metadata{
+					Type:  events.SessionPrintEvent,
+					Index: int64(i),
+				},
+				Data: []byte{byte(i)},
+			}
+			errCh <- test.writer.RecordEvent(test.ctx, eventstest.PrepareEvent(event))
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+	require.NoError(t, test.writer.Complete(test.ctx))
+
+	out := test.collectEvents(t)
+	require.Len(t, out, eventCount)
+	for i, event := range out {
+		require.Equal(t, int64(i), event.GetIndex())
+	}
 }
 
 type sessionWriterTest struct {


### PR DESCRIPTION
SessionWriter.RecordEvent accepts events from many goroutines at once, but the index arrived already stamped on the event by whoever prepared it. Which sender then won the send on eventsCh is what decided the order processEvents wrote them in, so a recording could be stored in an order its own indexes disagreed with. Anything that then orders or resumes a recording by index reads it wrongly - StreamSessionEvents resumes from a startIndex, and an index that does not track storage order makes that skip or repeat events.

Assign the index in processEvents instead. It is the sole consumer of eventsCh, so stamping there makes index order match storage order by construction rather than by every caller getting it right. Callers no longer supply an index at all, so the check that rejected a zero index after the first event goes with it.

Because the writer now writes to a field on the event, RecordEvent deep clones it first. The caller prepared that event and may still hold or reuse it, so mutating it in place would reach back into code that has no reason to expect it.


