### PR TITLE
Discovery Config: add support for Azure AKS matchers

### DIFF
--- a/lib/cloud/azure/clients.go
+++ b/lib/cloud/azure/clients.go
@@ -365,7 +365,10 @@ func (c *clients) initSubscriptionsClient(ctx context.Context) (*SubscriptionCli
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	client := NewSubscriptionClient(armClient)
+	client, err := NewSubscriptionClient(armClient)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	c.subscriptionsClient = client
 	return client, nil
 }

--- a/lib/cloud/azure/subscriptions.go
+++ b/lib/cloud/azure/subscriptions.go
@@ -20,10 +20,15 @@ package azure
 
 import (
 	"context"
+	"slices"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // ARMSubscriptions provides an interface for armsubscription.SubscriptionsClient.
@@ -36,16 +41,35 @@ var _ ARMSubscriptions = (*armsubscription.SubscriptionsClient)(nil)
 
 // SubscriptionClient wraps the Azure SubscriptionsAPI to fetch subscription IDs.
 type SubscriptionClient struct {
-	api ARMSubscriptions
+	api   ARMSubscriptions
+	cache *utils.FnCache
 }
 
 // NewSubscriptionClient returns a SubscriptionsClient.
-func NewSubscriptionClient(api ARMSubscriptions) *SubscriptionClient {
-	return &SubscriptionClient{api: api}
+func NewSubscriptionClient(api ARMSubscriptions) (*SubscriptionClient, error) {
+	azureSubscriptionCache, err := utils.NewFnCache(utils.FnCacheConfig{
+		// Making an API call to list subscriptions at most once per
+		// minute is fine and limits the delay before changes to Azure
+		// permissions or subscriptions are seen by discovery services.
+		TTL: time.Minute,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &SubscriptionClient{
+		api:   api,
+		cache: azureSubscriptionCache,
+	}, nil
 }
 
 // ListSubscriptionIDs lists all subscription IDs using the Azure Subscription API.
 func (c *SubscriptionClient) ListSubscriptionIDs(ctx context.Context) ([]string, error) {
+	ids, err := utils.FnCacheGet(ctx, c.cache, struct{}{}, c.listSubscriptionIDsWithoutCache)
+	return slices.Clone(ids), trace.Wrap(err)
+}
+
+func (c *SubscriptionClient) listSubscriptionIDsWithoutCache(ctx context.Context) ([]string, error) {
 	pagerOpts := &armsubscription.SubscriptionsClientListOptions{}
 	pager := c.api.NewListPager(pagerOpts)
 	subIDs := []string{}
@@ -75,4 +99,20 @@ func isValidSubscription(subscription *armsubscription.Subscription) bool {
 	//
 	// https://learn.microsoft.com/en-us/azure/cost-management-billing/manage/subscription-states
 	return *subscription.State != armsubscription.SubscriptionStateDeleted
+}
+
+// ExpandSubscriptionIDs expands the provided subscription IDs.
+// If the list contains a wildcard, it will fetch all accessible subscription IDs from Azure.
+func ExpandSubscriptionIDs(ctx context.Context, azureClients Clients, subs []string) ([]string, error) {
+	if !slices.Contains(subs, types.Wildcard) {
+		return subs, nil
+	}
+
+	subscriptionsClient, err := azureClients.GetSubscriptionClient(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	subscriptionIds, err := subscriptionsClient.ListSubscriptionIDs(ctx)
+	return subscriptionIds, trace.Wrap(err)
 }

--- a/lib/cloud/azure/subscriptions_test.go
+++ b/lib/cloud/azure/subscriptions_test.go
@@ -20,11 +20,17 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 func TestListSubscriptionIDs(t *testing.T) {
@@ -59,7 +65,8 @@ func TestListSubscriptionIDs(t *testing.T) {
 	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := NewSubscriptionClient(tt.mockAPI)
+			client, err := NewSubscriptionClient(tt.mockAPI)
+			require.NoError(t, err)
 
 			// verify we get all subscriptions
 			subIDs, err := client.ListSubscriptionIDs(ctx)
@@ -67,4 +74,143 @@ func TestListSubscriptionIDs(t *testing.T) {
 			require.ElementsMatch(t, tt.wantIDs, subIDs)
 		})
 	}
+}
+
+func TestListSubscriptionIDsCache(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cached values are cloned and expire", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			api := &ARMSubscriptionsMock{
+				Subscriptions: []*armsubscription.Subscription{
+					{
+						SubscriptionID: new("sub1"),
+						State:          new(armsubscription.SubscriptionStateEnabled),
+					},
+				},
+			}
+			client, err := NewSubscriptionClient(api)
+			require.NoError(t, err)
+
+			ids, err := client.ListSubscriptionIDs(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, []string{"sub1"}, ids)
+
+			api.Subscriptions = []*armsubscription.Subscription{
+				{
+					SubscriptionID: new("sub2"),
+					State:          new(armsubscription.SubscriptionStateEnabled),
+				},
+			}
+			ids[0] = "modified"
+
+			ids, err = client.ListSubscriptionIDs(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, []string{"sub1"}, ids)
+
+			time.Sleep(time.Minute + time.Nanosecond)
+
+			ids, err = client.ListSubscriptionIDs(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, []string{"sub2"}, ids)
+		})
+	})
+
+	t.Run("errors expire", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			api := &ARMSubscriptionsMock{
+				NoAuth: true,
+				Subscriptions: []*armsubscription.Subscription{
+					{
+						SubscriptionID: new("sub1"),
+						State:          new(armsubscription.SubscriptionStateEnabled),
+					},
+				},
+			}
+			client, err := NewSubscriptionClient(api)
+			require.NoError(t, err)
+
+			_, err = client.ListSubscriptionIDs(t.Context())
+			require.True(t, trace.IsAccessDenied(err), "got %v", err)
+
+			api.NoAuth = false
+			_, err = client.ListSubscriptionIDs(t.Context())
+			require.True(t, trace.IsAccessDenied(err), "got %v", err)
+
+			time.Sleep(time.Minute + time.Nanosecond)
+
+			ids, err := client.ListSubscriptionIDs(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, []string{"sub1"}, ids)
+		})
+	})
+}
+
+func TestExpandSubscriptionIDs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("subscriptions without wildcard are unchanged", func(t *testing.T) {
+		clients := &subscriptionClientsMock{
+			err: errors.New("GetSubscriptionClient should not be called"),
+		}
+		subscriptions := []string{"sub1", "sub2"}
+
+		ids, err := ExpandSubscriptionIDs(t.Context(), clients, subscriptions)
+		require.NoError(t, err)
+		require.Equal(t, subscriptions, ids)
+		require.Zero(t, clients.getSubscriptionClientCalls)
+	})
+
+	t.Run("wildcard is replaced with accessible subscriptions", func(t *testing.T) {
+		client, err := NewSubscriptionClient(&ARMSubscriptionsMock{
+			Subscriptions: []*armsubscription.Subscription{
+				{
+					SubscriptionID: new("sub1"),
+					State:          new(armsubscription.SubscriptionStateEnabled),
+				},
+				{
+					SubscriptionID: new("sub2"),
+					State:          new(armsubscription.SubscriptionStateWarned),
+				},
+			},
+		})
+		require.NoError(t, err)
+		clients := &subscriptionClientsMock{subscriptionClient: client}
+
+		ids, err := ExpandSubscriptionIDs(t.Context(), clients, []string{"explicit-sub", types.Wildcard})
+		require.NoError(t, err)
+		require.Equal(t, []string{"sub1", "sub2"}, ids)
+		require.Equal(t, 1, clients.getSubscriptionClientCalls)
+	})
+
+	t.Run("getting subscription client fails", func(t *testing.T) {
+		getClientErr := errors.New("failed to get subscription client")
+		clients := &subscriptionClientsMock{err: getClientErr}
+
+		ids, err := ExpandSubscriptionIDs(t.Context(), clients, []string{types.Wildcard})
+		require.Nil(t, ids)
+		require.ErrorIs(t, err, getClientErr)
+	})
+
+	t.Run("listing subscriptions fails", func(t *testing.T) {
+		client, err := NewSubscriptionClient(&ARMSubscriptionsMock{NoAuth: true})
+		require.NoError(t, err)
+		clients := &subscriptionClientsMock{subscriptionClient: client}
+
+		ids, err := ExpandSubscriptionIDs(t.Context(), clients, []string{types.Wildcard})
+		require.Nil(t, ids)
+		require.True(t, trace.IsAccessDenied(err), "got %v", err)
+	})
+}
+
+type subscriptionClientsMock struct {
+	Clients
+	subscriptionClient         *SubscriptionClient
+	err                        error
+	getSubscriptionClientCalls int
+}
+
+func (m *subscriptionClientsMock) GetSubscriptionClient(context.Context) (*SubscriptionClient, error) {
+	m.getSubscriptionClientCalls++
+	return m.subscriptionClient, m.err
 }

--- a/lib/srv/db/cloud/resource_checker_credentials.go
+++ b/lib/srv/db/cloud/resource_checker_credentials.go
@@ -128,11 +128,7 @@ func (c *credentialsChecker) getAWSIdentity(ctx context.Context, meta *types.AWS
 
 func (c *credentialsChecker) checkAzure(ctx context.Context, database types.Database) {
 	allSubIDs, err := utils.FnCacheGet(ctx, c.cache, types.CloudAzure, func(ctx context.Context) ([]string, error) {
-		client, err := c.azureClients.GetSubscriptionClient(ctx)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return client.ListSubscriptionIDs(ctx)
+		return azure.ExpandSubscriptionIDs(ctx, c.azureClients, []string{types.Wildcard})
 	})
 	if err != nil {
 		c.warn(ctx, "Failed to get Azure subscription IDs when checking a database created by the discovery service",

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -1008,19 +1008,31 @@ func (s *Server) databaseFetchersFromMatchers(matchers Matchers, discoveryConfig
 func (s *Server) kubeFetchersFromMatchers(matchers Matchers, discoveryConfigName string) ([]common.Fetcher, error) {
 	var result []common.Fetcher
 
-	// AWS.
-	awsKubeMatchers, _ := splitMatchers(matchers.AWS, func(matcherType string) bool {
-		return matcherType == types.AWSMatcherEKS
-	})
-	if len(awsKubeMatchers) > 0 {
-		eksFetchers, err := fetchers.MakeEKSFetchersFromAWSMatchers(s.Log, s.AWSFetchersClients, s.GetAWSRegionsLister, awsKubeMatchers, discoveryConfigName)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		result = append(result, eksFetchers...)
+	awsEKSFetchers, err := fetchers.MakeEKSFetchersFromAWSMatchers(
+		s.Log,
+		s.AWSFetchersClients,
+		s.GetAWSRegionsLister,
+		matchers.AWS,
+		discoveryConfigName,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
+	result = append(result, awsEKSFetchers...)
 
-	// There can't be kube fetchers for other matcher types.
+	azureAKSFetchers, err := fetchers.MakeAKSFetchersFromAzureMatchers(
+		s.ctx,
+		s.Log,
+		s.getAzureClients,
+		matchers.Azure,
+		discoveryConfigName,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	result = append(result, azureAKSFetchers...)
+
+	// TODO(marco): add GKE fetchers.
 
 	return result, nil
 }
@@ -1066,52 +1078,19 @@ func (s *Server) getAzureClients(ctx context.Context, integration string) (azure
 	return out, nil
 }
 
-// initAzureWatchers starts Azure resource watchers based on types provided.
+// initAzureWatchers converts Azure AKS matchers into fetchers to later be used by the server.
 func (s *Server) initAzureWatchers(ctx context.Context, matchers []types.AzureMatcher) error {
-	// Filter out VM matchers
-	_, otherMatchers := splitMatchers(matchers, func(matcherType string) bool {
-		return matcherType == types.AzureMatcherVM
-	})
-
-	// Database fetchers were added in databaseFetchersFromMatchers.
-	_, otherMatchers = splitMatchers(otherMatchers, db.IsAzureMatcherType)
-
-	// Add kube fetchers.
-	for _, matcher := range otherMatchers {
-		subscriptions, err := s.getAzureSubscriptions(ctx, matcher.Integration, matcher.Subscriptions)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		for _, subscription := range subscriptions {
-			for _, t := range matcher.Types {
-				switch t {
-				case types.AzureMatcherKubernetes:
-					azureClients, err := s.getAzureClients(ctx, matcher.Integration)
-					if err != nil {
-						return trace.Wrap(err)
-					}
-					kubeClient, err := azureClients.GetKubernetesClient(ctx, subscription)
-					if err != nil {
-						return trace.Wrap(err)
-					}
-
-					fetcher, err := fetchers.NewAKSFetcher(fetchers.AKSFetcherConfig{
-						Client:              kubeClient,
-						Regions:             matcher.Regions,
-						FilterLabels:        matcher.ResourceTags,
-						ResourceGroups:      matcher.ResourceGroups,
-						Logger:              s.Log,
-						DiscoveryConfigName: noDiscoveryConfig,
-						Integration:         matcher.Integration,
-					})
-					if err != nil {
-						return trace.Wrap(err)
-					}
-					s.kubeFetchers = append(s.kubeFetchers, fetcher)
-				}
-			}
-		}
+	kubeFetchers, err := fetchers.MakeAKSFetchersFromAzureMatchers(
+		ctx,
+		s.Log,
+		s.getAzureClients,
+		matchers,
+		noDiscoveryConfig,
+	)
+	if err != nil {
+		return trace.Wrap(err)
 	}
+	s.kubeFetchers = append(s.kubeFetchers, kubeFetchers...)
 	return nil
 }
 
@@ -2486,27 +2465,6 @@ func (s *Server) Wait() error {
 		return trace.Wrap(err)
 	}
 	return nil
-}
-
-func (s *Server) getAzureSubscriptions(ctx context.Context, integration string, subs []string) ([]string, error) {
-	subscriptionIds := subs
-	if slices.Contains(subs, types.Wildcard) {
-		// TODO(gavin): instead of listing subscriptions during init, do it
-		// on every fetch to prevent stale discovery configuration when
-		// subscriptions are added or removed
-		azureClients, err := s.getAzureClients(ctx, integration)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		subsClient, err := azureClients.GetSubscriptionClient(ctx)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		subscriptionIds, err = subsClient.ListSubscriptionIDs(ctx)
-		return subscriptionIds, trace.Wrap(err)
-	}
-
-	return subscriptionIds, nil
 }
 
 func (s *Server) initTeleportNodeWatcher() (err error) {

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -487,11 +487,6 @@ type Server struct {
 
 	// azureClientCache caches instances of integration-specific Azure clients.
 	azureClientCache *utils.FnCache
-
-	// azureSubscriptionCache caches integration-to-subscription-list mapping.
-	// This cache avoids repeated API calls when multiple discovery matchers for
-	// the same integration use a wildcard subscription.
-	azureSubscriptionCache *utils.FnCache
 }
 
 // New initializes a discovery Server
@@ -893,53 +888,14 @@ func (s *Server) handleAzureSubscriptionListError(integration string, err error)
 	}
 }
 
-func (s *Server) getAzureSubscriptionListNoCache(ctx context.Context, integration string) ([]string, error) {
+func (s *Server) getAzureSubscriptionList(ctx context.Context, integration string) ([]string, error) {
 	azureClients, err := s.getAzureClients(ctx, integration)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	subsClient, err := azureClients.GetSubscriptionClient(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	subscriptions, err := subsClient.ListSubscriptionIDs(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return subscriptions, nil
-}
-
-func (s *Server) getAzureSubscriptionList(ctx context.Context, integration string) ([]string, error) {
-	err := func() error {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-		if s.azureSubscriptionCache == nil {
-			azureSubscriptionCache, err := utils.NewFnCache(utils.FnCacheConfig{
-				// Making an API call to list subscriptions at most once per
-				// minute is fine and limits the delay before changes to Azure
-				// permissions or subscriptions are seen by discovery services.
-				TTL:   time.Minute,
-				Clock: s.clock,
-			})
-			if err != nil {
-				return trace.Wrap(err)
-			}
-			s.azureSubscriptionCache = azureSubscriptionCache
-		}
-		return nil
-	}()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	out, err := utils.FnCacheGet(ctx, s.azureSubscriptionCache, integration, func(ctx context.Context) ([]string, error) {
-		return s.getAzureSubscriptionListNoCache(ctx, integration)
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return out, nil
+	subIDs, err := azure.ExpandSubscriptionIDs(ctx, azureClients, []string{types.Wildcard})
+	return subIDs, trace.Wrap(err)
 }
 
 // gcpServerFetchersFromMatchers converts Matchers into a set of GCP Servers Fetchers.

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -2133,20 +2133,21 @@ func TestServerKubeFetchersFromDynamicAKSMatchers(t *testing.T) {
 
 	for _, tt := range []struct {
 		name                  string
-		subscriptions         []string
+		subscriptionMatcher   []string
+		existingSubscriptions []string
 		subscriptionListAPI   *azure.ARMSubscriptionsMock
-		expectedSubscriptions []string
 	}{
 		{
-			name:          "explicit subscriptions",
-			subscriptions: []string{"sub-1", "sub-2"},
+			name:                  "explicit subscriptions",
+			subscriptionMatcher:   []string{"sub-1", "sub-2"},
+			existingSubscriptions: []string{"sub-1", "sub-2"},
 			// Explicit subscriptions must not require permission to list all subscriptions.
-			subscriptionListAPI:   &azure.ARMSubscriptionsMock{NoAuth: true},
-			expectedSubscriptions: []string{"sub-1", "sub-2"},
+			subscriptionListAPI: &azure.ARMSubscriptionsMock{NoAuth: true},
 		},
 		{
-			name:          "wildcard subscription",
-			subscriptions: []string{types.Wildcard},
+			name:                  "wildcard subscription",
+			subscriptionMatcher:   []string{types.Wildcard},
+			existingSubscriptions: []string{"sub-1", "sub-2"},
 			subscriptionListAPI: &azure.ARMSubscriptionsMock{
 				Subscriptions: []*armsubscription.Subscription{
 					{
@@ -2163,19 +2164,19 @@ func TestServerKubeFetchersFromDynamicAKSMatchers(t *testing.T) {
 					},
 				},
 			},
-			expectedSubscriptions: []string{"sub-1", "sub-2"},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			aksClients := make(map[string]azure.AKSClient, len(tt.expectedSubscriptions))
-			for _, subscription := range tt.expectedSubscriptions {
+			aksClients := make(map[string]azure.AKSClient, len(tt.existingSubscriptions))
+			for _, subscription := range tt.existingSubscriptions {
 				aksClients[subscription] = newPopulatedAKSMock()
 			}
+			azureSubscritpionClient, err := azure.NewSubscriptionClient(tt.subscriptionListAPI)
+			require.NoError(t, err)
+
 			azureClients := &azuretest.Clients{
-				AzureAKSClientPerSub: aksClients,
-				AzureSubscriptionClient: azure.NewSubscriptionClient(
-					tt.subscriptionListAPI,
-				),
+				AzureAKSClientPerSub:    aksClients,
+				AzureSubscriptionClient: azureSubscritpionClient,
 			}
 
 			s := &Server{
@@ -2201,7 +2202,7 @@ func TestServerKubeFetchersFromDynamicAKSMatchers(t *testing.T) {
 						// Mixed matchers are supported by DiscoveryConfig and
 						// must still produce an AKS fetcher.
 						Types:          []string{types.AzureMatcherVM, types.AzureMatcherKubernetes},
-						Subscriptions:  tt.subscriptions,
+						Subscriptions:  tt.subscriptionMatcher,
 						ResourceGroups: []string{types.Wildcard},
 						Regions:        []string{types.Wildcard},
 						ResourceTags:   types.Labels{types.Wildcard: {types.Wildcard}},
@@ -2210,7 +2211,8 @@ func TestServerKubeFetchersFromDynamicAKSMatchers(t *testing.T) {
 				},
 			}, discoveryConfigName)
 			require.NoError(t, err)
-			require.Len(t, kubeFetchers, len(tt.expectedSubscriptions))
+
+			require.Len(t, kubeFetchers, 1, "expected exactly one AKS fetcher to be created")
 
 			for _, fetcher := range kubeFetchers {
 				require.Equal(t, discoveryConfigName, fetcher.GetDiscoveryConfigName())
@@ -2219,6 +2221,14 @@ func TestServerKubeFetchersFromDynamicAKSMatchers(t *testing.T) {
 				resources, err := fetcher.Get(t.Context())
 				require.NoError(t, err)
 				require.NotEmpty(t, resources)
+
+				var expectedResourceCount int
+				for _, client := range aksClients {
+					clusters, err := client.ListAll(t.Context())
+					require.NoError(t, err)
+					expectedResourceCount += len(clusters)
+				}
+				require.Len(t, resources, expectedResourceCount)
 			}
 		})
 	}

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -1706,15 +1707,35 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 	t.Parallel()
 
 	const (
-		mainDiscoveryGroup  = "main"
-		otherDiscoveryGroup = "other"
+		mainDiscoveryGroup   = "main"
+		otherDiscoveryGroup  = "other"
+		dynamicAKSConfigName = "dynamic-aks"
 	)
+	dynamicAKSConfig, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{Name: dynamicAKSConfigName},
+		discoveryconfig.Spec{
+			DiscoveryGroup: mainDiscoveryGroup,
+			Azure: []types.AzureMatcher{
+				{
+					Types:          []string{types.AzureMatcherKubernetes},
+					ResourceTags:   map[string]utils.Strings{"env": {"prod"}},
+					Regions:        []string{types.Wildcard},
+					ResourceGroups: []string{types.Wildcard},
+					Subscriptions:  []string{"sub1"},
+					Integration:    "dummy-azure-integration",
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
 	tcs := []struct {
 		name                          string
 		existingKubeClusters          []types.KubeCluster
 		awsMatchers                   []types.AWSMatcher
 		azureMatchers                 []types.AzureMatcher
 		gcpMatchers                   []types.GCPMatcher
+		discoveryConfig               *discoveryconfig.DiscoveryConfig
 		expectedClustersToExistInAuth []types.KubeCluster
 		clustersNotUpdated            []string
 		expectedAssumedRoles          []string
@@ -1896,6 +1917,23 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 			wantEvents:         2,
 		},
 		{
+			name:            "AKS clusters configured by DiscoveryConfig",
+			discoveryConfig: dynamicAKSConfig,
+			expectedClustersToExistInAuth: []types.KubeCluster{
+				mustConvertAKSToKubeCluster(t, aksMockClusters["group1"][0], rewriteDiscoveryLabelsParams{
+					discoveryGroup:      mainDiscoveryGroup,
+					integration:         "dummy-azure-integration",
+					discoveryConfigName: dynamicAKSConfigName,
+				}),
+				mustConvertAKSToKubeCluster(t, aksMockClusters["group1"][1], rewriteDiscoveryLabelsParams{
+					discoveryGroup:      mainDiscoveryGroup,
+					integration:         "dummy-azure-integration",
+					discoveryConfigName: dynamicAKSConfigName,
+				}),
+			},
+			wantEvents: 2,
+		},
+		{
 			name:                 "no clusters in auth server, import 2 prod clusters from GKE",
 			existingKubeClusters: []types.KubeCluster{},
 			gcpMatchers: []types.GCPMatcher{
@@ -2039,18 +2077,33 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 			require.NoError(t, discServer.Start())
 			t.Cleanup(discServer.Stop)
 
-			select {
-			case <-waitForReconcile:
-				kubeClusters, err := tlsServer.Auth().GetKubernetesClusters(ctx)
-				require.NoError(t, err)
-
-				c1 := types.KubeClusters(tc.expectedClustersToExistInAuth).ToMap()
-				c2 := types.KubeClusters(kubeClusters).ToMap()
-				for k := range c1 {
-					require.True(t, c1[k].IsEqual(c2[k]), "expected no differences")
+			waitForKubeReconcile := func() {
+				t.Helper()
+				select {
+				case <-waitForReconcile:
+				case <-time.After(10 * time.Second):
+					require.FailNow(t, "Didn't receive reconcile event after 10s")
 				}
-			case <-time.After(10 * time.Second):
-				require.FailNow(t, "Didn't receive reconcile event after 10s")
+			}
+
+			if tc.discoveryConfig != nil {
+				// Wait for the initial empty reconciliation before creating the DiscoveryConfig.
+				// This verifies that the config change wakes the Kubernetes watcher instead of waiting for its poll interval.
+				waitForKubeReconcile()
+
+				_, err = tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, tc.discoveryConfig)
+				require.NoError(t, err)
+			}
+
+			waitForKubeReconcile()
+
+			kubeClusters, err := tlsServer.Auth().GetKubernetesClusters(ctx)
+			require.NoError(t, err)
+
+			c1 := types.KubeClusters(tc.expectedClustersToExistInAuth).ToMap()
+			c2 := types.KubeClusters(kubeClusters).ToMap()
+			for k := range c1 {
+				require.True(t, c1[k].IsEqual(c2[k]), "expected no differences")
 			}
 
 			require.ElementsMatch(t, tc.expectedAssumedRoles, mockedClients.STSClient.GetAssumedRoleARNs(), "roles incorrectly assumed")
@@ -2066,6 +2119,107 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 			}
 
 			require.Equal(t, tc.wantEvents, reporter.ResourceCreateEventCount())
+		})
+	}
+}
+
+func TestServerKubeFetchersFromDynamicAKSMatchers(t *testing.T) {
+	t.Parallel()
+
+	const (
+		discoveryConfigName = "dynamic-aks"
+		integrationName     = "azure-integration"
+	)
+
+	for _, tt := range []struct {
+		name                  string
+		subscriptions         []string
+		subscriptionListAPI   *azure.ARMSubscriptionsMock
+		expectedSubscriptions []string
+	}{
+		{
+			name:          "explicit subscriptions",
+			subscriptions: []string{"sub-1", "sub-2"},
+			// Explicit subscriptions must not require permission to list all subscriptions.
+			subscriptionListAPI:   &azure.ARMSubscriptionsMock{NoAuth: true},
+			expectedSubscriptions: []string{"sub-1", "sub-2"},
+		},
+		{
+			name:          "wildcard subscription",
+			subscriptions: []string{types.Wildcard},
+			subscriptionListAPI: &azure.ARMSubscriptionsMock{
+				Subscriptions: []*armsubscription.Subscription{
+					{
+						SubscriptionID: new("sub-1"),
+						State:          new(armsubscription.SubscriptionStateEnabled),
+					},
+					{
+						SubscriptionID: new("sub-2"),
+						State:          new(armsubscription.SubscriptionStateWarned),
+					},
+					{
+						SubscriptionID: new("sub-deleted"),
+						State:          new(armsubscription.SubscriptionStateDeleted),
+					},
+				},
+			},
+			expectedSubscriptions: []string{"sub-1", "sub-2"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			aksClients := make(map[string]azure.AKSClient, len(tt.expectedSubscriptions))
+			for _, subscription := range tt.expectedSubscriptions {
+				aksClients[subscription] = newPopulatedAKSMock()
+			}
+			azureClients := &azuretest.Clients{
+				AzureAKSClientPerSub: aksClients,
+				AzureSubscriptionClient: azure.NewSubscriptionClient(
+					tt.subscriptionListAPI,
+				),
+			}
+
+			s := &Server{
+				ctx: t.Context(),
+				Config: &Config{
+					Log: logtest.NewLogger(),
+					initAzureClients: func(...azure.ClientsOption) (azure.Clients, error) {
+						return azureClients, nil
+					},
+				},
+			}
+
+			kubeFetchers, err := s.kubeFetchersFromMatchers(Matchers{
+				Azure: []types.AzureMatcher{
+					{
+						Types:          []string{types.AzureMatcherVM},
+						Subscriptions:  []string{"ignored"},
+						ResourceGroups: []string{types.Wildcard},
+						Regions:        []string{types.Wildcard},
+						ResourceTags:   types.Labels{types.Wildcard: {types.Wildcard}},
+					},
+					{
+						// Mixed matchers are supported by DiscoveryConfig and
+						// must still produce an AKS fetcher.
+						Types:          []string{types.AzureMatcherVM, types.AzureMatcherKubernetes},
+						Subscriptions:  tt.subscriptions,
+						ResourceGroups: []string{types.Wildcard},
+						Regions:        []string{types.Wildcard},
+						ResourceTags:   types.Labels{types.Wildcard: {types.Wildcard}},
+						Integration:    integrationName,
+					},
+				},
+			}, discoveryConfigName)
+			require.NoError(t, err)
+			require.Len(t, kubeFetchers, len(tt.expectedSubscriptions))
+
+			for _, fetcher := range kubeFetchers {
+				require.Equal(t, discoveryConfigName, fetcher.GetDiscoveryConfigName())
+				require.Equal(t, integrationName, fetcher.IntegrationName())
+
+				resources, err := fetcher.Get(t.Context())
+				require.NoError(t, err)
+				require.NotEmpty(t, resources)
+			}
 		})
 	}
 }

--- a/lib/srv/discovery/fetchers/aks.go
+++ b/lib/srv/discovery/fetchers/aks.go
@@ -23,8 +23,10 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"sync"
 
 	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
@@ -52,51 +54,23 @@ func MakeAKSFetchersFromAzureMatchers(
 			return nil, trace.Wrap(err)
 		}
 
-		// TODO(gavin): instead of listing subscriptions during init, do it
-		// on every fetch to prevent stale discovery configuration when
-		// subscriptions are added or removed
-		subscriptions, err := getAzureSubscriptions(ctx, azureClients, matcher.Subscriptions)
+		fetcher, err := newAKSFetcher(aksFetcherConfig{
+			Logger:              logger,
+			AzureClients:        azureClients,
+			Subscriptions:       matcher.Subscriptions,
+			Regions:             matcher.Regions,
+			ResourceGroups:      matcher.ResourceGroups,
+			FilterLabels:        matcher.ResourceTags,
+			Integration:         matcher.Integration,
+			DiscoveryConfigName: discoveryConfigName,
+		})
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-
-		for _, subscription := range subscriptions {
-			kubeClient, err := azureClients.GetKubernetesClient(ctx, subscription)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			fetcher, err := newAKSFetcher(aksFetcherConfig{
-				Logger:              logger,
-				Client:              kubeClient,
-				Regions:             matcher.Regions,
-				ResourceGroups:      matcher.ResourceGroups,
-				FilterLabels:        matcher.ResourceTags,
-				Integration:         matcher.Integration,
-				DiscoveryConfigName: discoveryConfigName,
-			})
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			kubeFetchers = append(kubeFetchers, fetcher)
-		}
+		kubeFetchers = append(kubeFetchers, fetcher)
 	}
 
 	return kubeFetchers, nil
-}
-
-func getAzureSubscriptions(ctx context.Context, azureClients azure.Clients, subs []string) ([]string, error) {
-	subscriptionIds := subs
-	if slices.Contains(subs, types.Wildcard) {
-		subscriptionsClient, err := azureClients.GetSubscriptionClient(ctx)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		subscriptionIds, err := subscriptionsClient.ListSubscriptionIDs(ctx)
-		return subscriptionIds, trace.Wrap(err)
-	}
-
-	return subscriptionIds, nil
 }
 
 type aksFetcher struct {
@@ -105,8 +79,10 @@ type aksFetcher struct {
 
 // aksFetcherConfig configures the AKS fetcher.
 type aksFetcherConfig struct {
-	// Client is the Azure AKS client.
-	Client azure.AKSClient
+	// AzureClients is the Azure clients used to fetch Azure Subscriptions (when using wildcard) and AKS clusters.
+	AzureClients azure.Clients
+	// Subscriptions are the Azure subscriptions to fetch AKS clusters from.
+	Subscriptions []string
 	// Regions are the regions where the clusters should be located.
 	Regions []string
 	// ResourceGroups are the Azure resource groups the clusters must belong to.
@@ -123,8 +99,8 @@ type aksFetcherConfig struct {
 
 // checkAndSetDefaults validates and sets the defaults values.
 func (c *aksFetcherConfig) checkAndSetDefaults() error {
-	if c.Client == nil {
-		return trace.BadParameter("missing Client field")
+	if c.AzureClients == nil {
+		return trace.BadParameter("missing AzureClients field")
 	}
 	if len(c.Regions) == 0 {
 		return trace.BadParameter("missing Regions field")
@@ -132,6 +108,14 @@ func (c *aksFetcherConfig) checkAndSetDefaults() error {
 
 	if len(c.FilterLabels) == 0 {
 		return trace.BadParameter("missing FilterLabels field")
+	}
+
+	if len(c.ResourceGroups) == 0 {
+		return trace.BadParameter("missing ResourceGroups field")
+	}
+
+	if len(c.Subscriptions) == 0 {
+		return trace.BadParameter("missing Subscriptions field")
 	}
 
 	if c.Logger == nil {
@@ -188,26 +172,86 @@ func (a *aksFetcher) rewriteKubeClusters(clusters types.KubeClusters) {
 	}
 }
 
+// getAKSClusters fetches all AKS clusters from the configured subscriptions and resource groups.
+// If there's an error fetching clusters from a subscription, it will continue to the next subscription and log the errors at the end.
 func (a *aksFetcher) getAKSClusters(ctx context.Context) ([]*azure.AKSCluster, error) {
+	subscriptions, err := azure.ExpandSubscriptionIDs(ctx, a.AzureClients, a.Subscriptions)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// If there are no subscriptions to fetch, return an empty list of clusters.
+	// This will remove any previously discovered clusters but might be a valid state if the user has removed access to all subscriptions to the client (integration or ambient credentials).
+	if len(subscriptions) == 0 {
+		return nil, nil
+	}
+
 	var (
 		clusters []*azure.AKSCluster
-		err      error
+		errs     []error
+		mu       sync.Mutex
 	)
-	if len(a.ResourceGroups) == 1 && a.ResourceGroups[0] == types.Wildcard {
-		clusters, err = a.Client.ListAll(ctx)
-	} else {
-		var errs []error
-		for _, resourceGroup := range a.ResourceGroups {
-			lClusters, lerr := a.Client.ListWithinGroup(ctx, resourceGroup)
-			if lerr != nil {
-				errs = append(errs, trace.Wrap(lerr))
-				continue
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	// Work in parallel up to a limit of 5 subscriptions.
+	group.SetLimit(concurrencyLimit)
+
+	for _, subscription := range subscriptions {
+		group.Go(func() error {
+			subscriptionClusters, err := a.getAKSClusterInSubscription(groupCtx, subscription)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				errs = append(errs, trace.Wrap(err, "subscription %q", subscription))
+			} else {
+				clusters = append(clusters, subscriptionClusters...)
 			}
-			clusters = append(clusters, lClusters...)
-		}
-		err = trace.NewAggregate(errs...)
+
+			return nil
+		})
 	}
-	return clusters, trace.Wrap(err)
+
+	_ = group.Wait()
+
+	switch {
+	// All subscriptions failed, return an aggregated error.
+	case len(subscriptions) == len(errs):
+		return nil, trace.NewAggregate(errs...)
+	// Some subscriptions failed, log the errors and return the clusters from the successful subscriptions.
+	case len(errs) > 0:
+		a.Logger.WarnContext(ctx, "Failed to fetch AKS clusters in some subscriptions", "error", trace.NewAggregate(errs...))
+	}
+
+	return clusters, nil
+}
+
+func (a *aksFetcher) getAKSClusterInSubscription(ctx context.Context, subscriptionID string) ([]*azure.AKSCluster, error) {
+	kubeClient, err := a.AzureClients.GetKubernetesClient(ctx, subscriptionID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if a.matchAllResourceGroups() {
+		clusters, err := kubeClient.ListAll(ctx)
+		return clusters, trace.Wrap(err)
+	}
+
+	var clusters []*azure.AKSCluster
+	for _, resourceGroup := range a.ResourceGroups {
+		clustersInResourceGroup, err := kubeClient.ListWithinGroup(ctx, resourceGroup)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		clusters = append(clusters, clustersInResourceGroup...)
+	}
+
+	return clusters, nil
+}
+
+func (a *aksFetcher) matchAllResourceGroups() bool {
+	return len(a.ResourceGroups) == 1 && a.ResourceGroups[0] == types.Wildcard
 }
 
 func (a *aksFetcher) isRegionSupported(region string) bool {

--- a/lib/srv/discovery/fetchers/aks.go
+++ b/lib/srv/discovery/fetchers/aks.go
@@ -33,12 +33,78 @@ import (
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
 
-type aksFetcher struct {
-	AKSFetcherConfig
+// MakeAKSFetchersFromAzureMatchers creates Azure AKS fetchers from the provided matchers.
+func MakeAKSFetchersFromAzureMatchers(
+	ctx context.Context,
+	logger *slog.Logger,
+	getAzureClients func(context.Context, string) (azure.Clients, error),
+	matchers []types.AzureMatcher,
+	discoveryConfigName string,
+) ([]common.Fetcher, error) {
+	var kubeFetchers []common.Fetcher
+	for _, matcher := range services.SimplifyAzureMatchers(matchers) {
+		if !slices.Contains(matcher.Types, types.AzureMatcherKubernetes) {
+			continue
+		}
+
+		azureClients, err := getAzureClients(ctx, matcher.Integration)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		// TODO(gavin): instead of listing subscriptions during init, do it
+		// on every fetch to prevent stale discovery configuration when
+		// subscriptions are added or removed
+		subscriptions, err := getAzureSubscriptions(ctx, azureClients, matcher.Subscriptions)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		for _, subscription := range subscriptions {
+			kubeClient, err := azureClients.GetKubernetesClient(ctx, subscription)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			fetcher, err := newAKSFetcher(aksFetcherConfig{
+				Logger:              logger,
+				Client:              kubeClient,
+				Regions:             matcher.Regions,
+				ResourceGroups:      matcher.ResourceGroups,
+				FilterLabels:        matcher.ResourceTags,
+				Integration:         matcher.Integration,
+				DiscoveryConfigName: discoveryConfigName,
+			})
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			kubeFetchers = append(kubeFetchers, fetcher)
+		}
+	}
+
+	return kubeFetchers, nil
 }
 
-// AKSFetcherConfig configures the AKS fetcher.
-type AKSFetcherConfig struct {
+func getAzureSubscriptions(ctx context.Context, azureClients azure.Clients, subs []string) ([]string, error) {
+	subscriptionIds := subs
+	if slices.Contains(subs, types.Wildcard) {
+		subscriptionsClient, err := azureClients.GetSubscriptionClient(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		subscriptionIds, err := subscriptionsClient.ListSubscriptionIDs(ctx)
+		return subscriptionIds, trace.Wrap(err)
+	}
+
+	return subscriptionIds, nil
+}
+
+type aksFetcher struct {
+	aksFetcherConfig
+}
+
+// aksFetcherConfig configures the AKS fetcher.
+type aksFetcherConfig struct {
 	// Client is the Azure AKS client.
 	Client azure.AKSClient
 	// Regions are the regions where the clusters should be located.
@@ -55,8 +121,8 @@ type AKSFetcherConfig struct {
 	Integration string
 }
 
-// CheckAndSetDefaults validates and sets the defaults values.
-func (c *AKSFetcherConfig) CheckAndSetDefaults() error {
+// checkAndSetDefaults validates and sets the defaults values.
+func (c *aksFetcherConfig) checkAndSetDefaults() error {
 	if c.Client == nil {
 		return trace.BadParameter("missing Client field")
 	}
@@ -74,9 +140,9 @@ func (c *AKSFetcherConfig) CheckAndSetDefaults() error {
 	return nil
 }
 
-// NewAKSFetcher creates a new AKS fetcher configuration.
-func NewAKSFetcher(cfg AKSFetcherConfig) (common.Fetcher, error) {
-	if err := cfg.CheckAndSetDefaults(); err != nil {
+// newAKSFetcher creates a new AKS fetcher configuration.
+func newAKSFetcher(cfg aksFetcherConfig) (common.Fetcher, error) {
+	if err := cfg.checkAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/srv/discovery/fetchers/aks_test.go
+++ b/lib/srv/discovery/fetchers/aks_test.go
@@ -112,14 +112,14 @@ func TestAKSFetcher(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := AKSFetcherConfig{
+			cfg := aksFetcherConfig{
 				Client:         newPopulatedAKSMock(),
 				FilterLabels:   tt.args.filterLabels,
 				Regions:        tt.args.regions,
 				ResourceGroups: tt.args.resourceGroups,
 				Logger:         logtest.NewLogger(),
 			}
-			fetcher, err := NewAKSFetcher(cfg)
+			fetcher, err := newAKSFetcher(cfg)
 			require.NoError(t, err)
 			resources, err := fetcher.Get(context.Background())
 			require.NoError(t, err)

--- a/lib/srv/discovery/fetchers/aks_test.go
+++ b/lib/srv/discovery/fetchers/aks_test.go
@@ -113,11 +113,12 @@ func TestAKSFetcher(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := aksFetcherConfig{
-				Client:         newPopulatedAKSMock(),
+				AzureClients:   &mockAzureClients{kubernetesClient: newPopulatedAKSMock()},
 				FilterLabels:   tt.args.filterLabels,
 				Regions:        tt.args.regions,
 				ResourceGroups: tt.args.resourceGroups,
 				Logger:         logtest.NewLogger(),
+				Subscriptions:  []string{"sub1"},
 			}
 			fetcher, err := newAKSFetcher(cfg)
 			require.NoError(t, err)
@@ -150,6 +151,16 @@ func newPopulatedAKSMock() *mockAKSAPI {
 	return &mockAKSAPI{
 		group: aksMockClusters,
 	}
+}
+
+type mockAzureClients struct {
+	azure.Clients
+
+	kubernetesClient azure.AKSClient
+}
+
+func (m *mockAzureClients) GetKubernetesClient(ctx context.Context, subscription string) (azure.AKSClient, error) {
+	return m.kubernetesClient, nil
 }
 
 var aksMockClusters = map[string][]*azure.AKSCluster{

--- a/lib/srv/discovery/fetchers/db/azure.go
+++ b/lib/srv/discovery/fetchers/db/azure.go
@@ -184,22 +184,6 @@ func (f *azureFetcher[DBType, ListClient]) rewriteDatabases(databases types.Data
 	}
 }
 
-// getSubscriptions returns the subscriptions that this fetcher is configured to query.
-// This will make an API call to list subscription IDs when the fetcher is configured to match "*" subscription,
-// in order to discover and query new subscriptions.
-// Otherwise, a list containing the fetcher's non-wildcard subscription is returned.
-func (f *azureFetcher[DBType, ListClient]) getSubscriptions(ctx context.Context) ([]string, error) {
-	if f.cfg.Subscription != types.Wildcard {
-		return []string{f.cfg.Subscription}, nil
-	}
-	client, err := f.cfg.AzureClients.GetSubscriptionClient(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	subIDs, err := client.ListSubscriptionIDs(ctx)
-	return subIDs, trace.Wrap(err)
-}
-
 // getDBServersInSubscription fetches Azure DB servers within a given subscription.
 func (f *azureFetcher[DBType, ListClient]) getDBServersInSubscription(ctx context.Context, subID string) ([]DBType, error) {
 	client, err := f.GetListClient(ctx, &f.cfg, subID)
@@ -217,7 +201,7 @@ func (f *azureFetcher[DBType, ListClient]) getDBServersInSubscription(ctx contex
 // getAllDBServers fetches Azure DB servers from all subscriptions that this fetcher is configured to query.
 func (f *azureFetcher[DBType, ListClient]) getAllDBServers(ctx context.Context) ([]DBType, error) {
 	var result []DBType
-	subIDs, err := f.getSubscriptions(ctx)
+	subIDs, err := azure.ExpandSubscriptionIDs(ctx, f.cfg.AzureClients, []string{f.cfg.Subscription})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/discovery/fetchers/db/azure_dbserver_test.go
+++ b/lib/srv/discovery/fetchers/db/azure_dbserver_test.go
@@ -72,6 +72,11 @@ func TestAzureDBServerFetchers(t *testing.T) {
 	azPostgresServerDisabledState, _ := makeAzurePostgresServer(t, "server-8", subscription1, group1, eastus, nil, withAzurePostgresState(string(armpostgresql.ServerStateDisabled)))
 	azPostgresServerUnknownState, azPostgresDBUnknownState := makeAzurePostgresServer(t, "server-9", subscription1, group1, eastus, nil, withAzurePostgresState("unknown"))
 
+	azureSubscriptionClient, err := azure.NewSubscriptionClient(&azure.ARMSubscriptionsMock{
+		Subscriptions: []*armsubscription.Subscription{azureSub1, azureSub2},
+	})
+	require.NoError(t, err)
+
 	tests := []struct {
 		name          string
 		inputClients  azure.Clients
@@ -144,9 +149,7 @@ func TestAzureDBServerFetchers(t *testing.T) {
 						DBServers: []*armpostgresql.Server{azPostgresServer4},
 					}),
 				},
-				AzureSubscriptionClient: azure.NewSubscriptionClient(&azure.ARMSubscriptionsMock{
-					Subscriptions: []*armsubscription.Subscription{azureSub1, azureSub2},
-				}),
+				AzureSubscriptionClient: azureSubscriptionClient,
 				AzureMySQLFlex: azure.NewMySQLFlexServersClientByAPI(&azure.ARMMySQLFlexServerMock{
 					NoAuth: true,
 				}),

--- a/lib/srv/discovery/fetchers/db/azure_mysql_flex_test.go
+++ b/lib/srv/discovery/fetchers/db/azure_mysql_flex_test.go
@@ -45,10 +45,13 @@ func TestAzureMySQLFlexFetchers(t *testing.T) {
 		Regions:      []string{"eastus"},
 	}}
 
+	azureSubscritpionClient, err := azure.NewSubscriptionClient(&azure.ARMSubscriptionsMock{
+		Subscriptions: []*armsubscription.Subscription{azureSub},
+	})
+	require.NoError(t, err)
+
 	clients := &azuretest.Clients{
-		AzureSubscriptionClient: azure.NewSubscriptionClient(&azure.ARMSubscriptionsMock{
-			Subscriptions: []*armsubscription.Subscription{azureSub},
-		}),
+		AzureSubscriptionClient: azureSubscritpionClient,
 		AzureMySQL: azure.NewMySQLServersClient(&azure.ARMMySQLMock{
 			NoAuth: true,
 		}),

--- a/lib/srv/discovery/fetchers/db/azure_postgres_flex_test.go
+++ b/lib/srv/discovery/fetchers/db/azure_postgres_flex_test.go
@@ -45,10 +45,13 @@ func TestAzurePostgresFlexFetchers(t *testing.T) {
 		Regions:      []string{"eastus"},
 	}}
 
+	azureSubscritpionClient, err := azure.NewSubscriptionClient(&azure.ARMSubscriptionsMock{
+		Subscriptions: []*armsubscription.Subscription{azureSub},
+	})
+	require.NoError(t, err)
+
 	clients := &azuretest.Clients{
-		AzureSubscriptionClient: azure.NewSubscriptionClient(&azure.ARMSubscriptionsMock{
-			Subscriptions: []*armsubscription.Subscription{azureSub},
-		}),
+		AzureSubscriptionClient: azureSubscritpionClient,
 		AzurePostgres: azure.NewPostgresServerClient(&azure.ARMPostgresMock{
 			NoAuth: true,
 		}),

--- a/lib/srv/discovery/fetchers/db/azure_redis_test.go
+++ b/lib/srv/discovery/fetchers/db/azure_redis_test.go
@@ -53,10 +53,13 @@ func TestAzureRedisFetchers(t *testing.T) {
 		Regions:      []string{"eastus"},
 	}}
 
+	azureSubscritpionClient, err := azure.NewSubscriptionClient(&azure.ARMSubscriptionsMock{
+		Subscriptions: []*armsubscription.Subscription{azureSub},
+	})
+	require.NoError(t, err)
+
 	clients := &azuretest.Clients{
-		AzureSubscriptionClient: azure.NewSubscriptionClient(&azure.ARMSubscriptionsMock{
-			Subscriptions: []*armsubscription.Subscription{azureSub},
-		}),
+		AzureSubscriptionClient: azureSubscritpionClient,
 		AzureRedis: azure.NewRedisClientByAPI(&azure.ARMRedisMock{
 			Servers: []*armredis.ResourceInfo{azRedisServer},
 		}),

--- a/lib/srv/discovery/fetchers/eks.go
+++ b/lib/srv/discovery/fetchers/eks.go
@@ -168,11 +168,6 @@ func NewEKSFetcher(cfg EKSFetcherConfig) (common.Fetcher, error) {
 	return &eksFetcher{EKSFetcherConfig: cfg}, nil
 }
 
-// GetIntegration returns the integration name that is used for getting credentials of the fetcher.
-func (f *eksFetcher) GetIntegration() string {
-	return f.Matcher.Integration
-}
-
 type DiscoveredEKSCluster struct {
 	types.KubeCluster
 	awsCluster *ekstypes.Cluster

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -52,7 +52,7 @@ import (
 // EKS watchers can do that and they behave differently from non-integration ones - we install agent on the
 // discovered clusters, instead of just proxying them.
 func (s *Server) startKubeIntegrationWatchers() error {
-	if len(s.getKubeIntegrationFetchers()) == 0 && s.DiscoveryGroup == "" {
+	if len(s.getKubeFetchersUsingRemoteAgentDeployment()) == 0 && s.DiscoveryGroup == "" {
 		return nil
 	}
 
@@ -97,9 +97,9 @@ func (s *Server) startKubeIntegrationWatchers() error {
 
 	watcher, err := common.NewWatcher(s.ctx, common.WatcherConfig{
 		FetchersFn: func() []common.Fetcher {
-			kubeIntegrationFetchers := s.getKubeIntegrationFetchers()
-			s.submitFetchersEvent(kubeIntegrationFetchers)
-			return kubeIntegrationFetchers
+			fetchersUsingRemoteAgentDeployment := s.getKubeFetchersUsingRemoteAgentDeployment()
+			s.submitFetchersEvent(fetchersUsingRemoteAgentDeployment)
+			return fetchersUsingRemoteAgentDeployment
 		},
 		Logger:         s.Log.With("kind", types.KindKubernetesCluster),
 		DiscoveryGroup: s.DiscoveryGroup,
@@ -234,7 +234,7 @@ func (s *Server) kubernetesIntegrationWatcherIterationStarted() {
 	discoveryConfigs := s.awsEKSResourcesStatus.iterationDiscoveryConfigs()
 	s.updateDiscoveryConfigStatus(discoveryConfigs...)
 
-	allFetchers := s.getKubeIntegrationFetchers()
+	allFetchers := s.getKubeFetchersUsingRemoteAgentDeployment()
 
 	awsResultGroups := libslices.FilterMapUnique(
 		allFetchers,
@@ -347,35 +347,20 @@ func (s *Server) enrollEKSClusters(region, integration, discoveryConfigName stri
 	}
 }
 
-type IntegrationFetcher interface {
-	// GetIntegration returns the integration name that is used for getting credentials of the fetcher.
-	GetIntegration() string
-}
-
-func (s *Server) getKubeFetchers(integration bool) []common.Fetcher {
+func (s *Server) getKubeFetchers(remoteAgentDeployment bool) []common.Fetcher {
 	var kubeFetchers []common.Fetcher
 
-	filterIntegrationFetchers := func(fetcher common.Fetcher) bool {
-		f, ok := fetcher.(IntegrationFetcher)
-		if !ok {
-			return false
-		}
-
-		return f.GetIntegration() != ""
+	fetchersUsingRemoteAgentDeployment := func(fetcher common.Fetcher) bool {
+		return fetcher.FetcherType() == types.AWSMatcherEKS && fetcher.IntegrationName() != ""
 	}
 
-	filterNonIntegrationFetchers := func(fetcher common.Fetcher) bool {
-		f, ok := fetcher.(IntegrationFetcher)
-		if !ok {
-			return true
-		}
-
-		return f.GetIntegration() == ""
+	fetchersUsingKubernetesServiceAsProxy := func(fetcher common.Fetcher) bool {
+		return !fetchersUsingRemoteAgentDeployment(fetcher)
 	}
 
-	filter := filterIntegrationFetchers
-	if !integration {
-		filter = filterNonIntegrationFetchers
+	filter := fetchersUsingRemoteAgentDeployment
+	if !remoteAgentDeployment {
+		filter = fetchersUsingKubernetesServiceAsProxy
 	}
 
 	s.muDynamicKubeFetchers.RLock()
@@ -397,11 +382,11 @@ func (s *Server) getKubeFetchers(integration bool) []common.Fetcher {
 	return kubeFetchers
 }
 
-func (s *Server) getKubeIntegrationFetchers() []common.Fetcher {
+func (s *Server) getKubeFetchersUsingRemoteAgentDeployment() []common.Fetcher {
 	return s.getKubeFetchers(true)
 }
 
-func (s *Server) getKubeNonIntegrationFetchers() []common.Fetcher {
+func (s *Server) getKubeFetchersUsingKubernetesServiceAsProxy() []common.Fetcher {
 	return s.getKubeFetchers(false)
 }
 

--- a/lib/srv/discovery/kube_integration_watcher_test.go
+++ b/lib/srv/discovery/kube_integration_watcher_test.go
@@ -47,6 +47,8 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/automaticupgrades/version"
+	"github.com/gravitational/teleport/lib/cloud/azure"
+	"github.com/gravitational/teleport/lib/cloud/azure/azuretest"
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
@@ -82,24 +84,43 @@ func TestServer_getKubeFetchers(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	aks1, err := fetchers.NewAKSFetcher(fetchers.AKSFetcherConfig{
-		Client:       &mockAKSAPI{},
-		FilterLabels: types.Labels{"l1": []string{"v1"}},
-		Regions:      []string{"region1"},
-	})
+	var azureClientsGetter = func(ctx context.Context, integrationName string) (azure.Clients, error) {
+		return &azuretest.Clients{
+			AzureAKSClient: &mockAKSAPI{},
+		}, nil
+	}
+
+	const noDiscoveryConfig = ""
+
+	azureFetchers, err := fetchers.MakeAKSFetchersFromAzureMatchers(t.Context(), logtest.NewLogger(), azureClientsGetter, []types.AzureMatcher{{
+		ResourceTags:  types.Labels{"l1": []string{"v1"}},
+		Regions:       []string{"region1"},
+		Subscriptions: []string{"subID"},
+		Types:         []string{types.AzureMatcherKubernetes},
+	}}, noDiscoveryConfig)
 	require.NoError(t, err)
-	aks2, err := fetchers.NewAKSFetcher(fetchers.AKSFetcherConfig{
-		Client:       &mockAKSAPI{},
-		FilterLabels: types.Labels{"l1": []string{"v1"}},
-		Regions:      []string{"region1"},
-	})
+	require.Len(t, azureFetchers, 1)
+	aks1 := azureFetchers[0]
+
+	azureFetchers, err = fetchers.MakeAKSFetchersFromAzureMatchers(t.Context(), logtest.NewLogger(), azureClientsGetter, []types.AzureMatcher{{
+		ResourceTags:  types.Labels{"l1": []string{"v1"}},
+		Regions:       []string{"region1"},
+		Subscriptions: []string{"subID"},
+		Types:         []string{types.AzureMatcherKubernetes},
+	}}, noDiscoveryConfig)
 	require.NoError(t, err)
-	aks3, err := fetchers.NewAKSFetcher(fetchers.AKSFetcherConfig{
-		Client:       &mockAKSAPI{},
-		FilterLabels: types.Labels{"l1": []string{"v1"}},
-		Regions:      []string{"region1"},
-	})
+	require.Len(t, azureFetchers, 1)
+	aks2 := azureFetchers[0]
+
+	azureFetchers, err = fetchers.MakeAKSFetchersFromAzureMatchers(t.Context(), logtest.NewLogger(), azureClientsGetter, []types.AzureMatcher{{
+		ResourceTags:  types.Labels{"l1": []string{"v1"}},
+		Regions:       []string{"region1"},
+		Subscriptions: []string{"subID"},
+		Types:         []string{types.AzureMatcherKubernetes},
+	}}, noDiscoveryConfig)
 	require.NoError(t, err)
+	require.Len(t, azureFetchers, 1)
+	aks3 := azureFetchers[0]
 
 	testCases := []struct {
 		kubeFetchers                   []common.Fetcher

--- a/lib/srv/discovery/kube_integration_watcher_test.go
+++ b/lib/srv/discovery/kube_integration_watcher_test.go
@@ -122,40 +122,56 @@ func TestServer_getKubeFetchers(t *testing.T) {
 	require.Len(t, azureFetchers, 1)
 	aks3 := azureFetchers[0]
 
+	azureFetchers, err = fetchers.MakeAKSFetchersFromAzureMatchers(t.Context(), logtest.NewLogger(), azureClientsGetter, []types.AzureMatcher{{
+		ResourceTags:  types.Labels{"l1": []string{"v1"}},
+		Regions:       []string{"region1"},
+		Subscriptions: []string{"subID"},
+		Types:         []string{types.AzureMatcherKubernetes},
+	}}, "group1")
+	require.NoError(t, err)
+	require.Len(t, azureFetchers, 1)
+	aks4 := azureFetchers[0]
+
 	testCases := []struct {
-		kubeFetchers                   []common.Fetcher
-		kubeDynamicFetchers            map[string][]common.Fetcher
-		expectedIntegrationFetchers    []common.Fetcher
-		expectedNonIntegrationFetchers []common.Fetcher
+		kubeFetchers                             []common.Fetcher
+		kubeDynamicFetchers                      map[string][]common.Fetcher
+		expectedFetchersRemoteAgentDeployment    []common.Fetcher
+		expectedFetchersKubernetesServiceAsProxy []common.Fetcher
 	}{
 		{
-			kubeFetchers:                   []common.Fetcher{eks1},
-			expectedNonIntegrationFetchers: []common.Fetcher{eks1},
+			kubeFetchers:                             []common.Fetcher{eks1},
+			expectedFetchersKubernetesServiceAsProxy: []common.Fetcher{eks1},
 		},
 		{
-			kubeFetchers:                   []common.Fetcher{eks1, eks2, eks3, aks1, aks2, aks3},
-			expectedIntegrationFetchers:    []common.Fetcher{eks2, eks3},
-			expectedNonIntegrationFetchers: []common.Fetcher{eks1, aks1, aks2, aks3},
+			kubeFetchers:                             []common.Fetcher{eks1, eks2, eks3, aks1, aks2, aks3},
+			expectedFetchersRemoteAgentDeployment:    []common.Fetcher{eks2, eks3},
+			expectedFetchersKubernetesServiceAsProxy: []common.Fetcher{eks1, aks1, aks2, aks3},
 		},
 		{
-			kubeFetchers:                   []common.Fetcher{eks1},
-			kubeDynamicFetchers:            map[string][]common.Fetcher{"group1": {eks2}},
-			expectedIntegrationFetchers:    []common.Fetcher{eks2},
-			expectedNonIntegrationFetchers: []common.Fetcher{eks1},
+			kubeFetchers:                             []common.Fetcher{eks1},
+			kubeDynamicFetchers:                      map[string][]common.Fetcher{"group1": {eks2}},
+			expectedFetchersRemoteAgentDeployment:    []common.Fetcher{eks2},
+			expectedFetchersKubernetesServiceAsProxy: []common.Fetcher{eks1},
 		},
 		{
-			kubeFetchers:                   []common.Fetcher{aks1, aks2},
-			kubeDynamicFetchers:            map[string][]common.Fetcher{"group1": {eks1}},
-			expectedIntegrationFetchers:    []common.Fetcher{},
-			expectedNonIntegrationFetchers: []common.Fetcher{eks1, aks1, aks2},
+			kubeFetchers:                             []common.Fetcher{aks1, aks2},
+			kubeDynamicFetchers:                      map[string][]common.Fetcher{"group1": {eks1}},
+			expectedFetchersRemoteAgentDeployment:    []common.Fetcher{},
+			expectedFetchersKubernetesServiceAsProxy: []common.Fetcher{eks1, aks1, aks2},
+		},
+		{
+			kubeFetchers:                             []common.Fetcher{},
+			kubeDynamicFetchers:                      map[string][]common.Fetcher{"group1": {aks4}},
+			expectedFetchersRemoteAgentDeployment:    []common.Fetcher{},
+			expectedFetchersKubernetesServiceAsProxy: []common.Fetcher{aks4},
 		},
 	}
 
 	for _, tc := range testCases {
 		s := Server{kubeFetchers: tc.kubeFetchers, dynamicKubeFetchers: tc.kubeDynamicFetchers}
 
-		require.ElementsMatch(t, tc.expectedIntegrationFetchers, s.getKubeFetchers(true))
-		require.ElementsMatch(t, tc.expectedNonIntegrationFetchers, s.getKubeFetchers(false))
+		require.ElementsMatch(t, tc.expectedFetchersRemoteAgentDeployment, s.getKubeFetchersUsingRemoteAgentDeployment())
+		require.ElementsMatch(t, tc.expectedFetchersKubernetesServiceAsProxy, s.getKubeFetchersUsingKubernetesServiceAsProxy())
 	}
 }
 

--- a/lib/srv/discovery/kube_watcher.go
+++ b/lib/srv/discovery/kube_watcher.go
@@ -36,7 +36,7 @@ import (
 const kubeEventPrefix = "kube/"
 
 func (s *Server) startKubeWatchers() error {
-	if len(s.getKubeNonIntegrationFetchers()) == 0 && s.DiscoveryGroup == "" {
+	if len(s.getKubeFetchersUsingKubernetesServiceAsProxy()) == 0 && s.DiscoveryGroup == "" {
 		return nil
 	}
 
@@ -83,14 +83,15 @@ func (s *Server) startKubeWatchers() error {
 
 	watcher, err := common.NewWatcher(s.ctx, common.WatcherConfig{
 		FetchersFn: func() []common.Fetcher {
-			kubeNonIntegrationFetchers := s.getKubeNonIntegrationFetchers()
-			s.submitFetchersEvent(kubeNonIntegrationFetchers)
-			return kubeNonIntegrationFetchers
+			kubeFetchersUsingKubernetesServiceAsProxy := s.getKubeFetchersUsingKubernetesServiceAsProxy()
+			s.submitFetchersEvent(kubeFetchersUsingKubernetesServiceAsProxy)
+			return kubeFetchersUsingKubernetesServiceAsProxy
 		},
 		Logger:         s.Log.With("kind", types.KindKubernetesCluster),
 		DiscoveryGroup: s.DiscoveryGroup,
 		Interval:       s.PollInterval,
 		Origin:         types.OriginCloud,
+		TriggerFetchC:  s.newDiscoveryConfigChangedSub(),
 		Clock:          s.clock,
 	})
 	if err != nil {


### PR DESCRIPTION
When configuring Discovery, users can either use the `teleport.yaml` configuration or a Discovery Config resource to create matchers.

A matcher indicates what should be enrolled into teleport:
- cloud
- resource type
- filters like tags/labels, region/locations and cloud specific props

When we added Discovery Config as an alternative, we didn't immediatly added support for all resource types.

This PR adds support for configuring the Azure AKS matcher from the Discovery Config.






<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Added support for configuring Azure AKS auto discovery using a Discovery Config.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local env

### Test Cases
- [x] When a discovery config is created/updated with an AKS matcher, the Discovery Service starts enrolling that resource


### Demo
After updating the Discovery Config resource, we can see that the Discovery Service started looking for AKS clusters
```
2026-07-29T16:26:20.769+01:00 INFO  emitting audit event event_type:discovery_config.update fields:map[addr.remote:127.0.0.1:52744 ... code:DC002I ei:0 event:discovery_config.update expires:0001-01-01T00:00:00Z name:local-discovery time:2026-07-29T15:26:20.769Z trace.component:audit uid:2aa7c1b0-458b-45f5-9032-7451b1c150b7 ... user_kind:3 user_roles:[Admin]] events/emitter.go:477
...
2026-07-29T16:26:21.095+01:00 DEBU [DISCOVERY] Fetch triggered by discovery config change pid:99942.1 discovery/discovery.go:1813
...
2026-07-29T16:26:21.747+01:00 DEBU [DISCOVERY] AKS cluster labels does not match the selector pid:99942.1 reason:no value match: got 'Marco' want: '[MarcoNoNo]' fetchers/aks.go:173
2026-07-29T16:26:21.747+01:00 DEBU [DISCOVERY] Reconciling current resources with new resources pid:99942.1 kind:kube_cluster current_resource_count:0 new_resource_count:0 services/reconciler.go:302
```

After changing again the DiscoveryConfig, now matching one existing AKS cluster:

`tctl get kube_cluster | yq`
```yaml
kind: kube_cluster
metadata:
  description: Azure AKS cluster "marco-cluster01" in spaincentral
  labels:
    Discover: Marco
    region: spaincentral
    resource-group: marco-discover
    subscription-id: <subscription-id>
    teleport.dev/cloud: Azure
    teleport.dev/discovery-type: aks
    teleport.dev/origin: cloud
    teleport.internal/discovered-name: marco-cluster01
    teleport.internal/discovery-config-name: local-discovery
    teleport.internal/discovery-group-name: azure-prod
  name: marco-cluster01-aks-spaincentral-marco-discover-<subscription-id>
spec:
  aws: {}
  azure:
    resource_group: marco-discover
    resource_name: marco-cluster01
    subscription_id: <subscription-id>
    tenant_id: <tenant-id>
  gcp: {}
version: v3
```