### PR TITLE
tctl: output resource SQN instead of resource name

### DIFF
--- a/tool/tctl/common/resources/accesslist.go
+++ b/tool/tctl/common/resources/accesslist.go
@@ -142,16 +142,15 @@ func createAccessList(ctx context.Context, client *authclient.Client, raw servic
 	exists := (err == nil)
 
 	if exists && !opts.Force {
-		return trace.AlreadyExists("Access list %q already exists", accessList.GetName())
+		return trace.AlreadyExists("Access list %q already exists", accesslists.ScopeQualifiedName(accessList).String())
 	}
 
 	if _, err := client.AccessListClient().UpsertAccessList(ctx, accessList); err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("Access list %q has been %s\n", accessList.GetName(), upsertVerb(exists, opts.Force))
+	fmt.Printf("Access list %q has been %s\n", accesslists.ScopeQualifiedName(accessList).String(), upsertVerb(exists, opts.Force))
 
 	return nil
-
 }
 
 // deleteAccessList implements `tctl rm accesslist /scope::my-list` command.

--- a/tool/tctl/common/resources/kube_cluster.go
+++ b/tool/tctl/common/resources/kube_cluster.go
@@ -244,7 +244,7 @@ func createScopedKubeCluster(ctx context.Context, client *authclient.Client, raw
 			if err := client.UpdateKubernetesCluster(ctx, cluster); err != nil {
 				return trace.Wrap(err)
 			}
-			fmt.Printf("Kubernetes cluster %q has been updated\n", cluster.GetName())
+			fmt.Printf("Kubernetes cluster %q has been updated\n", sqn.String())
 			return nil
 		}
 		return trace.Wrap(err)

--- a/tool/tctl/common/resources/scoped_role.go
+++ b/tool/tctl/common/resources/scoped_role.go
@@ -91,7 +91,7 @@ func createScopedRole(ctx context.Context, client *authclient.Client, raw servic
 		fmt.Printf(
 			"%v %q has been upserted\n",
 			scopedaccess.KindScopedRole,
-			rsp.GetRole().GetMetadata().GetName(),
+			scopes.QualifiedName{Name: rsp.GetRole().GetMetadata().GetName(), Scope: rsp.GetRole().GetScope()}.String(),
 		)
 		return nil
 	}
@@ -105,7 +105,7 @@ func createScopedRole(ctx context.Context, client *authclient.Client, raw servic
 	fmt.Printf(
 		"%v %q has been created\n",
 		scopedaccess.KindScopedRole,
-		r.GetMetadata().GetName(),
+		scopes.QualifiedName{Name: r.GetMetadata().GetName(), Scope: r.GetScope()}.String(),
 	)
 
 	return nil
@@ -126,7 +126,7 @@ func updateScopedRole(ctx context.Context, client *authclient.Client, raw servic
 	fmt.Printf(
 		"%v %q has been updated\n",
 		scopedaccess.KindScopedRole,
-		r.GetMetadata().GetName(),
+		scopes.QualifiedName{Name: r.GetMetadata().GetName(), Scope: r.GetScope()}.String(),
 	)
 
 	return nil
@@ -172,7 +172,7 @@ func deleteScopedRole(ctx context.Context, client *authclient.Client, subKind st
 	fmt.Printf(
 		"%v %q has been deleted\n",
 		scopedaccess.KindScopedRole,
-		sqn.Name,
+		sqn.String(),
 	)
 	return nil
 }

--- a/tool/tctl/common/resources/scoped_role_assignment.go
+++ b/tool/tctl/common/resources/scoped_role_assignment.go
@@ -106,7 +106,7 @@ func createScopedRoleAssignment(ctx context.Context, client *authclient.Client, 
 		fmt.Printf(
 			"%v %q has been upserted\n",
 			scopedaccess.KindScopedRoleAssignment,
-			rsp.GetAssignment().GetMetadata().GetName(),
+			scopes.QualifiedName{Name: rsp.GetAssignment().GetMetadata().GetName(), Scope: rsp.GetAssignment().GetScope()}.String(),
 		)
 		return nil
 	}
@@ -142,7 +142,7 @@ func updateScopedRoleAssignment(ctx context.Context, client *authclient.Client, 
 	fmt.Printf(
 		"%v %q has been updated\n",
 		scopedaccess.KindScopedRoleAssignment,
-		r.GetMetadata().GetName(),
+		scopes.QualifiedName{Name: r.GetMetadata().GetName(), Scope: r.GetScope()}.String(),
 	)
 
 	return nil
@@ -182,10 +182,10 @@ func getScopedRoleAssignment(ctx context.Context, client *authclient.Client, sub
 func deleteScopedRoleAssignment(ctx context.Context, client *authclient.Client, subKind string, sqn scopes.QualifiedName) error {
 	if subKind == "" {
 		return trace.BadParameter(
-			"%s requires a sub-kind to delete a resource, try:\n  tctl rm %s/%s %s::%s",
+			"%s requires a sub-kind to delete a resource, try:\n  tctl rm %s/%s %s",
 			scopedaccess.KindScopedRoleAssignment,
 			scopedaccess.KindScopedRoleAssignment, scopedaccess.SubKindDynamic,
-			sqn.Scope, sqn.Name,
+			sqn.String(),
 		)
 	}
 	if subKind == scopedaccess.SubKindMaterialized {
@@ -202,7 +202,7 @@ func deleteScopedRoleAssignment(ctx context.Context, client *authclient.Client, 
 	fmt.Printf(
 		"%v %q has been deleted\n",
 		scopedaccess.KindScopedRoleAssignment,
-		sqn.Name,
+		sqn.String(),
 	)
 	return nil
 }

--- a/tool/tctl/common/resources/scoped_token.go
+++ b/tool/tctl/common/resources/scoped_token.go
@@ -109,7 +109,7 @@ func updateScopedToken(ctx context.Context, client *authclient.Client, raw servi
 		return trace.Wrap(err)
 	}
 
-	fmt.Printf("%v %q has been updated\n", types.KindScopedToken, token.GetMetadata().GetName())
+	fmt.Printf("%v %q has been updated\n", types.KindScopedToken, scopes.QualifiedName{Name: token.GetMetadata().GetName(), Scope: token.GetScope()}.String())
 	return nil
 }
 
@@ -193,7 +193,7 @@ func deleteScopedToken(ctx context.Context, client *authclient.Client, subKind s
 	fmt.Printf(
 		"%v %q has been deleted\n",
 		types.KindScopedToken,
-		sqn.Name,
+		sqn.String(),
 	)
 	return nil
 }

--- a/tool/tctl/common/resources/workload_identity.go
+++ b/tool/tctl/common/resources/workload_identity.go
@@ -201,7 +201,7 @@ func createWorkloadIdentity(
 		}
 	}
 
-	fmt.Printf("Workload Identity %q has been created\n", in.GetMetadata().GetName())
+	fmt.Printf("Workload Identity %q has been created\n", scopes.QualifiedName{Name: in.GetMetadata().GetName(), Scope: in.GetScope()}.String())
 
 	return nil
 }


### PR DESCRIPTION
Updates tctl get/create/rm to consistently use the SQN instead of the resource name alone.
