### PR TITLE
discovery: Parallelize region/account fetch in EC2 discovery

### DIFF
--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -30,6 +30,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
 
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -422,6 +423,10 @@ const (
 // ssm:DescribeInstanceInformation only accepts between 5 and 50.
 const awsEC2APIChunkSize = 50
 
+// ec2DiscoveryConcurrencyLimit limits the number of concurrent AWS API calls
+// made while discovering EC2 instances across accounts and regions.
+const ec2DiscoveryConcurrencyLimit = 10
+
 func newEC2InstanceFetcher(cfg ec2FetcherConfig) *ec2InstanceFetcher {
 	tagFilters := []ec2types.Filter{{
 		Name:   aws.String(AWSInstanceStateName),
@@ -584,6 +589,8 @@ type matcherRegionsParams struct {
 }
 
 func (f *ec2InstanceFetcher) matcherRegions(ctx context.Context, params matcherRegionsParams) ([]string, error) {
+	// GetInstances currently calls matcherRegions only for wildcard matchers.
+	// Keep this guard so the helper remains safe for other callers.
 	if !f.Matcher.IsRegionWildcard() {
 		return f.Matcher.Regions, nil
 	}
@@ -644,6 +651,19 @@ func (f *ec2InstanceFetcher) fetchAccountIDsUnderOrganization(ctx context.Contex
 type assumeRoleWithExternalID struct {
 	RoleARN    string
 	ExternalID string
+}
+
+type ec2AccountScan struct {
+	assumeRole            assumeRoleWithExternalID
+	awsOpts               []awsconfig.OptionsFn
+	resolveCallerIdentity awsCallerIdentityResolver
+	regions               []string
+	err                   error
+}
+
+type ec2RegionScanResult struct {
+	instances []*EC2Instances
+	err       error
 }
 
 // allAssumeRoles returns a list of all the AWS Assume Roles that must be assumed.
@@ -708,42 +728,93 @@ func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([
 		return nil, trace.Wrap(err)
 	}
 
-	for _, assumeRole := range accountRolesToAssume {
+	accountScans := make([]ec2AccountScan, len(accountRolesToAssume))
+	resolveRegionsGroup := new(errgroup.Group)
+	resolveRegionsGroup.SetLimit(ec2DiscoveryConcurrencyLimit)
+
+	for i, assumeRole := range accountRolesToAssume {
 		awsOpts := []awsconfig.OptionsFn{
 			awsconfig.WithCredentialsMaybeIntegration(awsconfig.IntegrationMetadata{Name: f.Matcher.Integration}),
 			awsconfig.WithAssumeRole(assumeRole.RoleARN, assumeRole.ExternalID),
 		}
 		resolveCallerIdentity := f.newCallerIdentityResolver(ctx, assumeRole.RoleARN, awsOpts...)
 
-		regions, err := f.matcherRegions(ctx, matcherRegionsParams{
+		accountScans[i] = ec2AccountScan{
+			assumeRole:            assumeRole,
 			awsOpts:               awsOpts,
-			assumeRoleARN:         assumeRole.RoleARN,
 			resolveCallerIdentity: resolveCallerIdentity,
-		})
-		if err != nil {
-			permissionErrors = append(permissionErrors,
-				f.permissionErrorOrWarn(ctx, err, "", assumeRole.RoleARN),
-			)
+		}
+
+		if !f.Matcher.IsRegionWildcard() {
+			accountScans[i].regions = f.Matcher.Regions
 			continue
 		}
 
-		for _, region := range regions {
-			regionInstances, err := f.getInstancesInRegion(ctx, getInstancesInRegionParams{
-				rotation:              rotation,
-				region:                region,
-				assumeRole:            assumeRole,
+		resolveRegionsGroup.Go(func() error {
+			regions, err := f.matcherRegions(ctx, matcherRegionsParams{
 				awsOpts:               awsOpts,
-				ssmRunParams:          ssmRunParams,
+				assumeRoleARN:         assumeRole.RoleARN,
 				resolveCallerIdentity: resolveCallerIdentity,
 			})
 			if err != nil {
-				permissionErrors = append(permissionErrors,
-					f.permissionErrorOrWarn(ctx, err, region, assumeRole.RoleARN),
-				)
-				continue
+				accountScans[i].err = f.permissionErrorOrWarn(ctx, err, "", assumeRole.RoleARN)
+				return nil
+			}
+			accountScans[i].regions = regions
+			return nil
+		})
+	}
+
+	if err := resolveRegionsGroup.Wait(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var regionScans []getInstancesInRegionParams
+	for _, accountScan := range accountScans {
+		if accountScan.err != nil {
+			permissionErrors = append(permissionErrors, accountScan.err)
+			continue
+		}
+
+		for _, region := range accountScan.regions {
+			regionScans = append(regionScans, getInstancesInRegionParams{
+				rotation:              rotation,
+				region:                region,
+				assumeRole:            accountScan.assumeRole,
+				awsOpts:               accountScan.awsOpts,
+				ssmRunParams:          ssmRunParams,
+				resolveCallerIdentity: accountScan.resolveCallerIdentity,
+			})
+		}
+	}
+
+	regionScanResults := make([]ec2RegionScanResult, len(regionScans))
+	scanRegionsGroup := new(errgroup.Group)
+	scanRegionsGroup.SetLimit(ec2DiscoveryConcurrencyLimit)
+
+	for i, scan := range regionScans {
+		scanRegionsGroup.Go(func() error {
+			instances, err := f.getInstancesInRegion(ctx, scan)
+			if err != nil {
+				err = f.permissionErrorOrWarn(ctx, err, scan.region, scan.assumeRole.RoleARN)
 			}
 
-			allInstances = append(allInstances, regionInstances...)
+			regionScanResults[i] = ec2RegionScanResult{
+				instances: instances,
+				err:       err,
+			}
+			return nil
+		})
+	}
+
+	if err := scanRegionsGroup.Wait(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	for _, result := range regionScanResults {
+		allInstances = append(allInstances, result.instances...)
+		if result.err != nil {
+			permissionErrors = append(permissionErrors, result.err)
 		}
 	}
 

--- a/lib/srv/server/ec2_watcher_test.go
+++ b/lib/srv/server/ec2_watcher_test.go
@@ -73,6 +73,27 @@ func (m *mockEC2Client) DescribeInstances(ctx context.Context, input *ec2.Descri
 	return &output, nil
 }
 
+type blockingEC2Client struct {
+	started chan<- struct{}
+	release <-chan struct{}
+	output  *ec2.DescribeInstancesOutput
+}
+
+func (c *blockingEC2Client) DescribeInstances(ctx context.Context, _ *ec2.DescribeInstancesInput, _ ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	select {
+	case c.started <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	select {
+	case <-c.release:
+		return c.output, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
 type mockAWSAccountClient struct {
 	output        *account.ListRegionsOutput
 	responseError error
@@ -84,6 +105,27 @@ func (m *mockAWSAccountClient) ListRegions(ctx context.Context, input *account.L
 	}
 
 	return m.output, nil
+}
+
+type blockingAWSAccountClient struct {
+	started chan<- struct{}
+	release <-chan struct{}
+	output  *account.ListRegionsOutput
+}
+
+func (c *blockingAWSAccountClient) ListRegions(ctx context.Context, _ *account.ListRegionsInput, _ ...func(*account.Options)) (*account.ListRegionsOutput, error) {
+	select {
+	case c.started <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	select {
+	case <-c.release:
+		return c.output, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 type mockAWSSTSClient struct {
@@ -319,6 +361,216 @@ func TestNewEC2InstanceFetcherTags(t *testing.T) {
 			require.Equal(t, tc.expectedFilters, fetcher.Filters)
 		})
 	}
+}
+
+func TestEC2WatcherGetInstancesConcurrency(t *testing.T) {
+	t.Parallel()
+
+	const (
+		organizationID = "o-abcdefghij"
+		rootOUID       = "r-123"
+	)
+	totalScans := ec2DiscoveryConcurrencyLimit + 1
+
+	regions := make([]string, 0, totalScans)
+	accountIDs := make([]string, 0, totalScans)
+	for i := range totalScans {
+		regions = append(regions, fmt.Sprintf("region-%d", i))
+		accountIDs = append(accountIDs, fmt.Sprintf("%012d", i))
+	}
+
+	tests := []struct {
+		name                   string
+		matcher                types.AWSMatcher
+		organizationsGetter    AWSOrganizationsGetter
+		expectedInstanceGroups int
+	}{
+		{
+			name: "regions",
+			matcher: types.AWSMatcher{
+				Params:  &types.InstallerParams{},
+				Regions: regions,
+				SSM:     &types.AWSSSM{},
+			},
+			expectedInstanceGroups: len(regions),
+		},
+		{
+			name: "accounts",
+			matcher: types.AWSMatcher{
+				Params:  &types.InstallerParams{},
+				Regions: []string{"us-west-2"},
+				SSM:     &types.AWSSSM{},
+				AssumeRole: &types.AssumeRole{
+					RoleName: "DiscoveryRole",
+				},
+				Organization: &types.AWSOrganizationMatcher{
+					OrganizationID: organizationID,
+					OrganizationalUnits: &types.AWSOrganizationUnitsMatcher{
+						Include: []string{types.Wildcard},
+					},
+				},
+			},
+			organizationsGetter: func(context.Context, ...awsconfig.OptionsFn) (liborganizations.OrganizationsClient, error) {
+				return &mockOrganizationsClient{
+					organizationID: organizationID,
+					rootOUID:       rootOUID,
+					ouItems: map[string]ouItem{
+						rootOUID: {
+							innerAccounts: accountIDs,
+						},
+					},
+				}, nil
+			},
+			expectedInstanceGroups: len(accountIDs),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				started := make(chan struct{}, totalScans)
+				release := make(chan struct{})
+				fetcher := newEC2InstanceFetcher(ec2FetcherConfig{
+					Matcher: tt.matcher,
+					EC2ClientGetter: func(context.Context, string, ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+						return &blockingEC2Client{
+							started: started,
+							release: release,
+							output: &ec2.DescribeInstancesOutput{
+								Reservations: []ec2types.Reservation{{
+									OwnerId: aws.String("123456789012"),
+									Instances: []ec2types.Instance{{
+										InstanceId: aws.String("i-1234567890"),
+									}},
+								}},
+							},
+						}, nil
+					},
+					AWSOrganizationsGetter: tt.organizationsGetter,
+				})
+
+				type fetchResult struct {
+					instances []*EC2Instances
+					err       error
+				}
+				resultC := make(chan fetchResult, 1)
+				go func() {
+					instances, err := fetcher.GetInstances(t.Context(), false)
+					resultC <- fetchResult{instances: instances, err: err}
+				}()
+
+				synctest.Wait()
+				require.Equal(t, ec2DiscoveryConcurrencyLimit, len(started))
+
+				close(release)
+				synctest.Wait()
+
+				result := <-resultC
+				require.NoError(t, result.err)
+				require.Len(t, result.instances, tt.expectedInstanceGroups)
+				require.Equal(t, totalScans, len(started))
+			})
+		})
+	}
+}
+
+func TestEC2WatcherResolveRegionsConcurrency(t *testing.T) {
+	t.Parallel()
+
+	const (
+		organizationID = "o-abcdefghij"
+		rootOUID       = "r-123"
+	)
+	totalAccounts := ec2DiscoveryConcurrencyLimit + 1
+	accountIDs := make([]string, 0, totalAccounts)
+	for i := range totalAccounts {
+		accountIDs = append(accountIDs, fmt.Sprintf("%012d", i))
+	}
+
+	synctest.Test(t, func(t *testing.T) {
+		started := make(chan struct{}, totalAccounts)
+		release := make(chan struct{})
+		fetcher := newEC2InstanceFetcher(ec2FetcherConfig{
+			Matcher: types.AWSMatcher{
+				Params:  &types.InstallerParams{},
+				Regions: []string{types.Wildcard},
+				Tags:    map[string]utils.Strings{"teleport": {"yes"}},
+				SSM:     &types.AWSSSM{},
+				AssumeRole: &types.AssumeRole{
+					RoleName: "DiscoveryRole",
+				},
+				Organization: &types.AWSOrganizationMatcher{
+					OrganizationID: organizationID,
+					OrganizationalUnits: &types.AWSOrganizationUnitsMatcher{
+						Include: []string{types.Wildcard},
+					},
+				},
+			},
+			EC2ClientGetter: func(context.Context, string, ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+				return &mockEC2Client{
+					output: &ec2.DescribeInstancesOutput{
+						Reservations: []ec2types.Reservation{{
+							OwnerId: aws.String("123456789012"),
+							Instances: []ec2types.Instance{{
+								InstanceId: aws.String("i-1234567890"),
+								State: &ec2types.InstanceState{
+									Name: ec2types.InstanceStateNameRunning,
+								},
+								Tags: []ec2types.Tag{{
+									Key:   aws.String("teleport"),
+									Value: aws.String("yes"),
+								}},
+							}},
+						}},
+					},
+				}, nil
+			},
+			RegionsListerGetter: func(context.Context, ...awsconfig.OptionsFn) (account.ListRegionsAPIClient, error) {
+				return &blockingAWSAccountClient{
+					started: started,
+					release: release,
+					output: &account.ListRegionsOutput{
+						Regions: []accounttypes.Region{{
+							RegionName: aws.String("us-west-2"),
+						}},
+					},
+				}, nil
+			},
+			AWSOrganizationsGetter: func(context.Context, ...awsconfig.OptionsFn) (liborganizations.OrganizationsClient, error) {
+				return &mockOrganizationsClient{
+					organizationID: organizationID,
+					rootOUID:       rootOUID,
+					ouItems: map[string]ouItem{
+						rootOUID: {
+							innerAccounts: accountIDs,
+						},
+					},
+				}, nil
+			},
+		})
+
+		type fetchResult struct {
+			instances []*EC2Instances
+			err       error
+		}
+		resultC := make(chan fetchResult, 1)
+		go func() {
+			instances, err := fetcher.GetInstances(t.Context(), false)
+			resultC <- fetchResult{instances: instances, err: err}
+		}()
+
+		synctest.Wait()
+		require.Equal(t, ec2DiscoveryConcurrencyLimit, len(started))
+
+		close(release)
+		synctest.Wait()
+
+		result := <-resultC
+		require.NoError(t, result.err)
+		require.Len(t, result.instances, totalAccounts)
+		require.Equal(t, totalAccounts, len(started))
+	})
 }
 
 func TestEC2Watcher(t *testing.T) {

--- a/lib/srv/server/ec2_watcher_test.go
+++ b/lib/srv/server/ec2_watcher_test.go
@@ -461,7 +461,7 @@ func TestEC2WatcherGetInstancesConcurrency(t *testing.T) {
 				}()
 
 				synctest.Wait()
-				require.Equal(t, ec2DiscoveryConcurrencyLimit, len(started))
+				require.Len(t, started, ec2DiscoveryConcurrencyLimit)
 
 				close(release)
 				synctest.Wait()
@@ -469,7 +469,7 @@ func TestEC2WatcherGetInstancesConcurrency(t *testing.T) {
 				result := <-resultC
 				require.NoError(t, result.err)
 				require.Len(t, result.instances, tt.expectedInstanceGroups)
-				require.Equal(t, totalScans, len(started))
+				require.Len(t, started, totalScans)
 			})
 		})
 	}
@@ -561,7 +561,7 @@ func TestEC2WatcherResolveRegionsConcurrency(t *testing.T) {
 		}()
 
 		synctest.Wait()
-		require.Equal(t, ec2DiscoveryConcurrencyLimit, len(started))
+		require.Len(t, started, ec2DiscoveryConcurrencyLimit)
 
 		close(release)
 		synctest.Wait()
@@ -569,7 +569,7 @@ func TestEC2WatcherResolveRegionsConcurrency(t *testing.T) {
 		result := <-resultC
 		require.NoError(t, result.err)
 		require.Len(t, result.instances, totalAccounts)
-		require.Equal(t, totalAccounts, len(started))
+		require.Len(t, started, totalAccounts)
 	})
 }
 


### PR DESCRIPTION
Fixes #69089

Part of #68560.

Changelog: EC2 auto-discovery now fetches instances across AWS accounts and regions concurrently with bounded concurrency.

## Summary

EC2 auto-discovery previously scanned AWS accounts and regions sequentially. In organization-wide configurations, discovery time therefore increased proportionally with the number of accounts and regions.

This change:

- Resolves wildcard regions across accounts concurrently.
- Flattens account and region combinations into one work queue.
- Fetches EC2 instances with a global concurrency limit of 10.
- Collects results per worker and merges them after completion, avoiding shared-slice races.
- Preserves partial results and existing IAM permission-error behavior when an account or region fails.

The global limit prevents large organization matchers from producing unbounded AWS API traffic.

## Automated Tests

```code
go test ./lib/srv/server -count=1
go test -race ./lib/srv/server \
  -run '^TestEC2Watcher(GetInstancesConcurrency|ResolveRegionsConcurrency)$' \
  -count=1
```

Coverage includes concurrent region and organization-account fetches, wildcard region resolution, enforcement of the limit of 10, complete result collection, and race detection.

## Manual Test Plan

Tested against mpmonboarding.cloud.gravitational.io using the PR build on two embedded Discovery Service replicas and a real AWS OIDC integration.

The DiscoveryConfig used regions: ["*"] against an account with 24 enabled regions and two tagged EC2 instances in eu-west-1 and eu-west-2.

- [x] Both replicas discovered and retained both expected instances with the correct AWS account, region, instance ID, and tags.
- [x] Repeated 24-region discovery iterations completed in approximately 1.9–2.2 seconds, with a median of approximately 2.03 seconds.
- [x] No AWS discovery warnings, permission errors, throttling, cancellations, or panics appeared in either replica’s logs.
- [x] Final DiscoveryConfig status reported two found and two enrolled instances from both replicas.
- [x] No temporary cloud or cluster resources were created.

Organization-scale manual testing was not practical. Account fan-out is covered deterministically by the automated tests using 11 account targets, including verification that only 10 requests run concurrently and all results are eventually returned.