### PR TITLE
[v17] Fix formatting issues due to linter upgrade

### DIFF
--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-docdb.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-docdb.mdx
@@ -29,6 +29,7 @@ tags:
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - AWS account with a DocumentDB cluster.
+
   <Admonition type="warning" title="IAM authentication and TLS">
   Teleport uses IAM authentication to connect users to DocumentDB, which is
   only supported for DocumentDB 5.0 or higher.
@@ -36,10 +37,13 @@ tags:
   In addition, the DocumentDB cluster must have Transport Layer Security (TLS)
   enabled. TLS is enabled by default when using the default parameter group.
   </Admonition>
+
 - Command-line client `mongosh` or `mongo` installed and added to your
   system's `PATH` environment variable.
+
 - A host, e.g., an EC2 instance, where you will run the Teleport Database
   Service.
+
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/6. Create a Teleport user

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds.mdx
@@ -44,6 +44,7 @@ which supports IAM authentication.
 
 - AWS account with RDS and Aurora databases and permissions to create and attach
   IAM policies.
+
   <Admonition type="warning" title="IAM authentication">
   Your RDS and Aurora databases must have password and IAM authentication
   enabled.
@@ -52,9 +53,11 @@ which supports IAM authentication.
   the Database Service will attempt to enable IAM authentication by modifying
   them using respective APIs.
   </Admonition>
+
 - A Linux host or Amazon Elastic Kubernetes Service cluster where you will run
   the Teleport Database Service, which proxies connections to your RDS
   databases. 
+
 - (!docs/pages/includes/tctl.mdx!)
 
 If you plan to run the Teleport Database Service on Kubernetes, you will need

--- a/docs/pages/migrate-plans.mdx
+++ b/docs/pages/migrate-plans.mdx
@@ -239,15 +239,12 @@ To migrate Teleport Agents:
    `stable/v(=teleport.major_version=)` or if you are using automatic
    upgrades the `stable/rolling` channel has all released versions.
 
-
 1. If you are using Teleport Community Edition, [uninstall Teleport](zero-trust-access/management/admin/uninstall-teleport.mdx)
    and install the enterprise edition of the `teleport` binary. You can confirm if the binary
    is correct by running `teleport version`. The output will contain the words
    `Teleport Enterprise`. The enterprise edition of the `teleport`
    binary should be used when connecting to Teleport Enterprise (Cloud) or
    Teleport Enterprise (Self-Hosted).
-
-
 
 1. Update the `proxy_server` or `auth_servers` field in each Agent configuration
    file to point to the address of your new Teleport Enterprise cluster. By

--- a/docs/pages/zero-trust-access/management/admin/trustedclusters.mdx
+++ b/docs/pages/zero-trust-access/management/admin/trustedclusters.mdx
@@ -576,7 +576,6 @@ running the following command:
    tsh status
    ```
 
-
 1. Confirm that the server running the Teleport Agent is joined to the leaf cluster by
 running a command similar to the following:
 


### PR DESCRIPTION
Backports #68882

We are upgrading our `remark` linter for the docs. To accommodate the upgrade, adjust formatting to fix issues caught by the linter.

- **MCP Access and stdio guides:** Replace an outer Tabs component, which contains an inner Tabs and thus introduces unnecessary complexity, with H3s. These guides introduced H4 headings without a preceding H3, which violate the linter.

- **Remove extra newlines** from lists in `trustedclusters.mdx`, `migrate-plans.mdx`, and `controls.mdx`.

- **Add required blank lines** to `aws-docdb.mdx` and the MWI getting started guide.
