### PR TITLE
iOS: Production Serial Number

### DIFF
--- a/mobile/Verify/Verify/Device Trust/Serial Number/SerialNumberClient.swift
+++ b/mobile/Verify/Verify/Device Trust/Serial Number/SerialNumberClient.swift
@@ -20,12 +20,12 @@ import Sharing
 
 @DependencyClient
 struct SerialNumberClient {
-	var getDeviceSerialNumber: @Sendable () -> String = { "" }
+	var getDeviceSerialNumber: @Sendable () throws(SerialNumberError) -> String = { "" }
 }
 
 extension SerialNumberClient {
 	static let liveValue = SerialNumberClient(
-		getDeviceSerialNumber: {
+		getDeviceSerialNumber: { () throws(SerialNumberError) -> String in
 			#if DEBUG
 				@Shared(.debugStorage(.debugSerialNumber))
 				var debugSerialNumber: String? = nil
@@ -37,8 +37,17 @@ extension SerialNumberClient {
 				}
 				return debugSerialNumber
 			#else
-				fatalError("Production path has not yet been implemented. Requires messing around in Jamf.")
+				guard let serialNumber = ManagedAppConfiguration.serialNumber else {
+					throw .missingSerialNumber
+				}
+				return serialNumber
 			#endif
 		},
 	)
+}
+
+// MARK: - Supporting Types
+
+enum SerialNumberError: Error {
+	case missingSerialNumber
 }

--- a/mobile/Verify/Verify/Persistence/UserDefaults/ManagedAppConfiguration.swift
+++ b/mobile/Verify/Verify/Persistence/UserDefaults/ManagedAppConfiguration.swift
@@ -1,0 +1,38 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/
+
+import Foundation
+
+/// These are values managed by MDM (e.g. Jamf, Intune, etc.)
+///
+/// These values are non-nil if and only if both of the following are true:
+///
+/// 1. The device is managed by MDM
+/// 2. The MDM configuration supplies the value with the indicated key
+enum ManagedAppConfiguration {
+	static var serialNumber: String? {
+		value(for: "serialNumber")
+	}
+}
+
+// MARK: - User Defaults
+
+extension ManagedAppConfiguration {
+	private static let managedConfigurationDictionaryKey = "com.apple.configuration.managed"
+	private static func value<T>(for key: String) -> T? {
+		UserDefaults.standard.dictionary(forKey: managedConfigurationDictionaryKey)?[key] as? T
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/gravitational/teleport.e/issues/9258

This PR implements the production-side of Serial Number retrieval. The code is simple but testing it requires a whole setup with an MDM device and access to Jamf. Furthermore, the screenshot below is from a build that I did not commit since we don't necessarily want to show the serial number on the root view of the app. I mostly uploaded it to Jamf to demonstrate the feature working with relative ease.

The end result: there's a lot of "just trust me" in this PR 😅. We will have more ways of validating that this actually works as more and more of device trust gets built.

<img width="500" alt="IMG_0001" src="https://github.com/user-attachments/assets/3312c233-a537-4644-baa5-62852e84c523" />