### PR TITLE
Make helm unit tests set chart version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1497,7 +1497,7 @@ fix-license:
 # Used prior to a release by bumping VERSION in this Makefile and then
 # running "make update-version".
 .PHONY: update-version
-update-version: version test-helm
+update-version: version
 
 # This rule triggers re-generation of version files if Makefile changes.
 .PHONY: version

--- a/Makefile
+++ b/Makefile
@@ -1497,7 +1497,7 @@ fix-license:
 # Used prior to a release by bumping VERSION in this Makefile and then
 # running "make update-version".
 .PHONY: update-version
-update-version: version test-helm-update-snapshots
+update-version: version test-helm
 
 # This rule triggers re-generation of version files if Makefile changes.
 .PHONY: version

--- a/examples/chart/access/datadog/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/datadog/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,6 +26,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-datadog
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-datadog-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-datadog-99.0.0
       name: RELEASE-NAME-teleport-plugin-datadog

--- a/examples/chart/access/datadog/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/datadog/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,6 +26,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-datadog
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-datadog-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-datadog-18.0.0
       name: RELEASE-NAME-teleport-plugin-datadog

--- a/examples/chart/access/datadog/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/datadog/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-datadog
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-datadog-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-datadog-18.0.0
       name: RELEASE-NAME-teleport-plugin-datadog
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-datadog
-            app.kubernetes.io/version: 19.0.0-prealpha.2
-            helm.sh/chart: teleport-plugin-datadog-19.0.0-prealpha.2
+            app.kubernetes.io/version: 18.0.0
+            helm.sh/chart: teleport-plugin-datadog-18.0.0
         spec:
           containers:
             - command:

--- a/examples/chart/access/datadog/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/datadog/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-datadog
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-datadog-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-datadog-99.0.0
       name: RELEASE-NAME-teleport-plugin-datadog
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-datadog
-            app.kubernetes.io/version: 18.0.0
-            helm.sh/chart: teleport-plugin-datadog-18.0.0
+            app.kubernetes.io/version: 99.0.0
+            helm.sh/chart: teleport-plugin-datadog-99.0.0
         spec:
           containers:
             - command:

--- a/examples/chart/access/datadog/tests/configmap_test.yaml
+++ b/examples/chart/access/datadog/tests/configmap_test.yaml
@@ -3,8 +3,8 @@ templates:
   - configmap.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/datadog/tests/configmap_test.yaml
+++ b/examples/chart/access/datadog/tests/configmap_test.yaml
@@ -1,6 +1,10 @@
 suite: Test configmap
 templates:
   - configmap.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/datadog/tests/deployment_test.yaml
+++ b/examples/chart/access/datadog/tests/deployment_test.yaml
@@ -1,6 +1,10 @@
 suite: Test deployment
 templates:
   - deployment.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/datadog/tests/deployment_test.yaml
+++ b/examples/chart/access/datadog/tests/deployment_test.yaml
@@ -3,8 +3,8 @@ templates:
   - deployment.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/datadog/tests/secret_test.yaml
+++ b/examples/chart/access/datadog/tests/secret_test.yaml
@@ -3,8 +3,8 @@ templates:
   - secret.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should contain the api and application key
     set:

--- a/examples/chart/access/datadog/tests/secret_test.yaml
+++ b/examples/chart/access/datadog/tests/secret_test.yaml
@@ -1,6 +1,10 @@
 suite: Test secret
 templates:
   - secret.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should contain the api and application key
     set:

--- a/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-discord-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-discord-99.0.0
       name: RELEASE-NAME-teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-discord-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-discord-18.0.0
       name: RELEASE-NAME-teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-discord-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-discord-99.0.0
       name: RELEASE-NAME-teleport-plugin-discord
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-discord
-            app.kubernetes.io/version: 18.0.0
-            helm.sh/chart: teleport-plugin-discord-18.0.0
+            app.kubernetes.io/version: 99.0.0
+            helm.sh/chart: teleport-plugin-discord-99.0.0
         spec:
           containers:
             - command:

--- a/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-discord-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-discord-18.0.0
       name: RELEASE-NAME-teleport-plugin-discord
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-discord
-            app.kubernetes.io/version: 19.0.0-prealpha.2
-            helm.sh/chart: teleport-plugin-discord-19.0.0-prealpha.2
+            app.kubernetes.io/version: 18.0.0
+            helm.sh/chart: teleport-plugin-discord-18.0.0
         spec:
           containers:
             - command:

--- a/examples/chart/access/discord/tests/configmap_test.yaml
+++ b/examples/chart/access/discord/tests/configmap_test.yaml
@@ -1,6 +1,10 @@
 suite: Test deployment
 templates:
   - configmap.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/discord/tests/configmap_test.yaml
+++ b/examples/chart/access/discord/tests/configmap_test.yaml
@@ -3,8 +3,8 @@ templates:
   - configmap.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/discord/tests/deployment_test.yaml
+++ b/examples/chart/access/discord/tests/deployment_test.yaml
@@ -1,6 +1,10 @@
 suite: Test deployment
 templates:
   - deployment.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/discord/tests/deployment_test.yaml
+++ b/examples/chart/access/discord/tests/deployment_test.yaml
@@ -3,8 +3,8 @@ templates:
   - deployment.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/discord/tests/secret_test.yaml
+++ b/examples/chart/access/discord/tests/secret_test.yaml
@@ -3,8 +3,8 @@ templates:
   - secret.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should contain the api key
     set:

--- a/examples/chart/access/discord/tests/secret_test.yaml
+++ b/examples/chart/access/discord/tests/secret_test.yaml
@@ -1,6 +1,10 @@
 suite: Test secret
 templates:
   - secret.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should contain the api key
     set:

--- a/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
@@ -25,8 +25,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-email-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-email-99.0.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on):
   1: |
@@ -58,8 +58,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-email-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-email-99.0.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, no starttls):
   1: |
@@ -91,8 +91,8 @@ should match the snapshot (smtp on, no starttls):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-email-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-email-99.0.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, password file):
   1: |
@@ -124,8 +124,8 @@ should match the snapshot (smtp on, password file):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-email-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-email-99.0.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, roleToRecipients set):
   1: |
@@ -160,8 +160,8 @@ should match the snapshot (smtp on, roleToRecipients set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-email-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-email-99.0.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, starttls disabled):
   1: |
@@ -193,6 +193,6 @@ should match the snapshot (smtp on, starttls disabled):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-email-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-email-99.0.0
       name: RELEASE-NAME-teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
@@ -25,8 +25,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-email-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-email-18.0.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on):
   1: |
@@ -58,8 +58,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-email-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-email-18.0.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, no starttls):
   1: |
@@ -91,8 +91,8 @@ should match the snapshot (smtp on, no starttls):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-email-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-email-18.0.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, password file):
   1: |
@@ -124,8 +124,8 @@ should match the snapshot (smtp on, password file):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-email-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-email-18.0.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, roleToRecipients set):
   1: |
@@ -160,8 +160,8 @@ should match the snapshot (smtp on, roleToRecipients set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-email-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-email-18.0.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, starttls disabled):
   1: |
@@ -193,6 +193,6 @@ should match the snapshot (smtp on, starttls disabled):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-email-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-email-18.0.0
       name: RELEASE-NAME-teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should be possible to override volume name (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-email-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-email-99.0.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should be possible to override volume name (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.0.0
-            helm.sh/chart: teleport-plugin-email-18.0.0
+            app.kubernetes.io/version: 99.0.0
+            helm.sh/chart: teleport-plugin-email-99.0.0
         spec:
           containers:
             - command:
@@ -34,7 +34,7 @@ should be possible to override volume name (smtp on):
               env:
                 - name: TELEPORT_PLUGIN_FAIL_FAST
                   value: "true"
-              image: public.ecr.aws/gravitational/teleport-plugin-email:18.0.0
+              image: public.ecr.aws/gravitational/teleport-plugin-email:99.0.0
               imagePullPolicy: IfNotPresent
               name: teleport-plugin-email
               ports:
@@ -75,8 +75,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-email-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-email-99.0.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.0.0
-            helm.sh/chart: teleport-plugin-email-18.0.0
+            app.kubernetes.io/version: 99.0.0
+            helm.sh/chart: teleport-plugin-email-99.0.0
         spec:
           containers:
             - command:
@@ -136,8 +136,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-email-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-email-99.0.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -151,8 +151,8 @@ should match the snapshot (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.0.0
-            helm.sh/chart: teleport-plugin-email-18.0.0
+            app.kubernetes.io/version: 99.0.0
+            helm.sh/chart: teleport-plugin-email-99.0.0
         spec:
           containers:
             - command:
@@ -163,7 +163,7 @@ should match the snapshot (mailgun on):
               env:
                 - name: TELEPORT_PLUGIN_FAIL_FAST
                   value: "true"
-              image: public.ecr.aws/gravitational/teleport-plugin-email:18.0.0
+              image: public.ecr.aws/gravitational/teleport-plugin-email:99.0.0
               imagePullPolicy: IfNotPresent
               name: teleport-plugin-email
               ports:
@@ -204,8 +204,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-email-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-email-99.0.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -219,8 +219,8 @@ should match the snapshot (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.0.0
-            helm.sh/chart: teleport-plugin-email-18.0.0
+            app.kubernetes.io/version: 99.0.0
+            helm.sh/chart: teleport-plugin-email-99.0.0
         spec:
           containers:
             - command:
@@ -231,7 +231,7 @@ should match the snapshot (smtp on):
               env:
                 - name: TELEPORT_PLUGIN_FAIL_FAST
                   value: "true"
-              image: public.ecr.aws/gravitational/teleport-plugin-email:18.0.0
+              image: public.ecr.aws/gravitational/teleport-plugin-email:99.0.0
               imagePullPolicy: IfNotPresent
               name: teleport-plugin-email
               ports:
@@ -272,8 +272,8 @@ should mount external secret (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-email-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-email-99.0.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -287,8 +287,8 @@ should mount external secret (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.0.0
-            helm.sh/chart: teleport-plugin-email-18.0.0
+            app.kubernetes.io/version: 99.0.0
+            helm.sh/chart: teleport-plugin-email-99.0.0
         spec:
           containers:
             - command:
@@ -299,7 +299,7 @@ should mount external secret (mailgun on):
               env:
                 - name: TELEPORT_PLUGIN_FAIL_FAST
                   value: "true"
-              image: public.ecr.aws/gravitational/teleport-plugin-email:18.0.0
+              image: public.ecr.aws/gravitational/teleport-plugin-email:99.0.0
               imagePullPolicy: IfNotPresent
               name: teleport-plugin-email
               ports:
@@ -340,8 +340,8 @@ should mount external secret (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-email-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-email-99.0.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -355,8 +355,8 @@ should mount external secret (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.0.0
-            helm.sh/chart: teleport-plugin-email-18.0.0
+            app.kubernetes.io/version: 99.0.0
+            helm.sh/chart: teleport-plugin-email-99.0.0
         spec:
           containers:
             - command:
@@ -367,7 +367,7 @@ should mount external secret (smtp on):
               env:
                 - name: TELEPORT_PLUGIN_FAIL_FAST
                   value: "true"
-              image: public.ecr.aws/gravitational/teleport-plugin-email:18.0.0
+              image: public.ecr.aws/gravitational/teleport-plugin-email:99.0.0
               imagePullPolicy: IfNotPresent
               name: teleport-plugin-email
               ports:

--- a/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should be possible to override volume name (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-email-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-email-18.0.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should be possible to override volume name (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 19.0.0-prealpha.2
-            helm.sh/chart: teleport-plugin-email-19.0.0-prealpha.2
+            app.kubernetes.io/version: 18.0.0
+            helm.sh/chart: teleport-plugin-email-18.0.0
         spec:
           containers:
             - command:
@@ -34,7 +34,7 @@ should be possible to override volume name (smtp on):
               env:
                 - name: TELEPORT_PLUGIN_FAIL_FAST
                   value: "true"
-              image: public.ecr.aws/gravitational/teleport-plugin-email:19.0.0-prealpha.2
+              image: public.ecr.aws/gravitational/teleport-plugin-email:18.0.0
               imagePullPolicy: IfNotPresent
               name: teleport-plugin-email
               ports:
@@ -75,8 +75,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-email-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-email-18.0.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 19.0.0-prealpha.2
-            helm.sh/chart: teleport-plugin-email-19.0.0-prealpha.2
+            app.kubernetes.io/version: 18.0.0
+            helm.sh/chart: teleport-plugin-email-18.0.0
         spec:
           containers:
             - command:
@@ -136,8 +136,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-email-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-email-18.0.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -151,8 +151,8 @@ should match the snapshot (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 19.0.0-prealpha.2
-            helm.sh/chart: teleport-plugin-email-19.0.0-prealpha.2
+            app.kubernetes.io/version: 18.0.0
+            helm.sh/chart: teleport-plugin-email-18.0.0
         spec:
           containers:
             - command:
@@ -163,7 +163,7 @@ should match the snapshot (mailgun on):
               env:
                 - name: TELEPORT_PLUGIN_FAIL_FAST
                   value: "true"
-              image: public.ecr.aws/gravitational/teleport-plugin-email:19.0.0-prealpha.2
+              image: public.ecr.aws/gravitational/teleport-plugin-email:18.0.0
               imagePullPolicy: IfNotPresent
               name: teleport-plugin-email
               ports:
@@ -204,8 +204,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-email-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-email-18.0.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -219,8 +219,8 @@ should match the snapshot (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 19.0.0-prealpha.2
-            helm.sh/chart: teleport-plugin-email-19.0.0-prealpha.2
+            app.kubernetes.io/version: 18.0.0
+            helm.sh/chart: teleport-plugin-email-18.0.0
         spec:
           containers:
             - command:
@@ -231,7 +231,7 @@ should match the snapshot (smtp on):
               env:
                 - name: TELEPORT_PLUGIN_FAIL_FAST
                   value: "true"
-              image: public.ecr.aws/gravitational/teleport-plugin-email:19.0.0-prealpha.2
+              image: public.ecr.aws/gravitational/teleport-plugin-email:18.0.0
               imagePullPolicy: IfNotPresent
               name: teleport-plugin-email
               ports:
@@ -272,8 +272,8 @@ should mount external secret (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-email-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-email-18.0.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -287,8 +287,8 @@ should mount external secret (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 19.0.0-prealpha.2
-            helm.sh/chart: teleport-plugin-email-19.0.0-prealpha.2
+            app.kubernetes.io/version: 18.0.0
+            helm.sh/chart: teleport-plugin-email-18.0.0
         spec:
           containers:
             - command:
@@ -299,7 +299,7 @@ should mount external secret (mailgun on):
               env:
                 - name: TELEPORT_PLUGIN_FAIL_FAST
                   value: "true"
-              image: public.ecr.aws/gravitational/teleport-plugin-email:19.0.0-prealpha.2
+              image: public.ecr.aws/gravitational/teleport-plugin-email:18.0.0
               imagePullPolicy: IfNotPresent
               name: teleport-plugin-email
               ports:
@@ -340,8 +340,8 @@ should mount external secret (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-email-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-email-18.0.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -355,8 +355,8 @@ should mount external secret (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 19.0.0-prealpha.2
-            helm.sh/chart: teleport-plugin-email-19.0.0-prealpha.2
+            app.kubernetes.io/version: 18.0.0
+            helm.sh/chart: teleport-plugin-email-18.0.0
         spec:
           containers:
             - command:
@@ -367,7 +367,7 @@ should mount external secret (smtp on):
               env:
                 - name: TELEPORT_PLUGIN_FAIL_FAST
                   value: "true"
-              image: public.ecr.aws/gravitational/teleport-plugin-email:19.0.0-prealpha.2
+              image: public.ecr.aws/gravitational/teleport-plugin-email:18.0.0
               imagePullPolicy: IfNotPresent
               name: teleport-plugin-email
               ports:

--- a/examples/chart/access/email/tests/configmap_test.yaml
+++ b/examples/chart/access/email/tests/configmap_test.yaml
@@ -3,8 +3,8 @@ templates:
   - configmap.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot (smtp on)
     set:

--- a/examples/chart/access/email/tests/configmap_test.yaml
+++ b/examples/chart/access/email/tests/configmap_test.yaml
@@ -1,6 +1,10 @@
 suite: Test configmap
 templates:
   - configmap.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot (smtp on)
     set:

--- a/examples/chart/access/email/tests/deployment_test.yaml
+++ b/examples/chart/access/email/tests/deployment_test.yaml
@@ -1,6 +1,10 @@
 suite: Test deployment
 templates:
   - deployment.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/email/tests/deployment_test.yaml
+++ b/examples/chart/access/email/tests/deployment_test.yaml
@@ -3,8 +3,8 @@ templates:
   - deployment.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/email/tests/secret_test.yaml
+++ b/examples/chart/access/email/tests/secret_test.yaml
@@ -3,8 +3,8 @@ templates:
   - secret.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot (smtp on)
     set:

--- a/examples/chart/access/email/tests/secret_test.yaml
+++ b/examples/chart/access/email/tests/secret_test.yaml
@@ -1,6 +1,10 @@
 suite: Test secret
 templates:
   - secret.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot (smtp on)
     set:

--- a/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
@@ -30,6 +30,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-jira-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-jira-99.0.0
       name: RELEASE-NAME-teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
@@ -30,6 +30,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-jira-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-jira-18.0.0
       name: RELEASE-NAME-teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-jira-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-jira-18.0.0
       name: RELEASE-NAME-teleport-plugin-jira
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-jira
-            app.kubernetes.io/version: 19.0.0-prealpha.2
-            helm.sh/chart: teleport-plugin-jira-19.0.0-prealpha.2
+            app.kubernetes.io/version: 18.0.0
+            helm.sh/chart: teleport-plugin-jira-18.0.0
         spec:
           containers:
             - command:

--- a/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-jira-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-jira-99.0.0
       name: RELEASE-NAME-teleport-plugin-jira
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-jira
-            app.kubernetes.io/version: 18.0.0
-            helm.sh/chart: teleport-plugin-jira-18.0.0
+            app.kubernetes.io/version: 99.0.0
+            helm.sh/chart: teleport-plugin-jira-99.0.0
         spec:
           containers:
             - command:

--- a/examples/chart/access/jira/tests/configmap_test.yaml
+++ b/examples/chart/access/jira/tests/configmap_test.yaml
@@ -3,8 +3,8 @@ templates:
   - configmap.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot (smtp on)
     set:

--- a/examples/chart/access/jira/tests/configmap_test.yaml
+++ b/examples/chart/access/jira/tests/configmap_test.yaml
@@ -1,6 +1,10 @@
 suite: Test configmap
 templates:
   - configmap.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot (smtp on)
     set:

--- a/examples/chart/access/jira/tests/deployment_test.yaml
+++ b/examples/chart/access/jira/tests/deployment_test.yaml
@@ -1,6 +1,10 @@
 suite: Test deployment
 templates:
   - deployment.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/jira/tests/deployment_test.yaml
+++ b/examples/chart/access/jira/tests/deployment_test.yaml
@@ -3,8 +3,8 @@ templates:
   - deployment.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/jira/tests/secret_test.yaml
+++ b/examples/chart/access/jira/tests/secret_test.yaml
@@ -3,8 +3,8 @@ templates:
   - secret.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match snapshot
     set:

--- a/examples/chart/access/jira/tests/secret_test.yaml
+++ b/examples/chart/access/jira/tests/secret_test.yaml
@@ -1,6 +1,10 @@
 suite: Test secret
 templates:
   - secret.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match snapshot
     set:

--- a/examples/chart/access/jira/tests/service_test.yaml
+++ b/examples/chart/access/jira/tests/service_test.yaml
@@ -3,8 +3,8 @@ templates:
   -  service.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should be possible to add custom annotations
     set:

--- a/examples/chart/access/jira/tests/service_test.yaml
+++ b/examples/chart/access/jira/tests/service_test.yaml
@@ -1,6 +1,10 @@
 suite: Test service
 templates:
   -  service.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should be possible to add custom annotations
     set:

--- a/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
@@ -22,6 +22,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-mattermost-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-mattermost-18.0.0
       name: RELEASE-NAME-teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
@@ -22,6 +22,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-mattermost-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-mattermost-99.0.0
       name: RELEASE-NAME-teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-mattermost-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-mattermost-18.0.0
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 19.0.0-prealpha.2
-            helm.sh/chart: teleport-plugin-mattermost-19.0.0-prealpha.2
+            app.kubernetes.io/version: 18.0.0
+            helm.sh/chart: teleport-plugin-mattermost-18.0.0
         spec:
           containers:
             - command:
@@ -75,8 +75,8 @@ should mount external secret:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-mattermost-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-mattermost-18.0.0
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should mount external secret:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 19.0.0-prealpha.2
-            helm.sh/chart: teleport-plugin-mattermost-19.0.0-prealpha.2
+            app.kubernetes.io/version: 18.0.0
+            helm.sh/chart: teleport-plugin-mattermost-18.0.0
         spec:
           containers:
             - command:
@@ -102,7 +102,7 @@ should mount external secret:
               env:
                 - name: TELEPORT_PLUGIN_FAIL_FAST
                   value: "true"
-              image: public.ecr.aws/gravitational/teleport-plugin-mattermost:19.0.0-prealpha.2
+              image: public.ecr.aws/gravitational/teleport-plugin-mattermost:18.0.0
               imagePullPolicy: IfNotPresent
               name: teleport-plugin-mattermost
               ports:
@@ -143,8 +143,8 @@ should override volume name:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-mattermost-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-mattermost-18.0.0
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -158,8 +158,8 @@ should override volume name:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 19.0.0-prealpha.2
-            helm.sh/chart: teleport-plugin-mattermost-19.0.0-prealpha.2
+            app.kubernetes.io/version: 18.0.0
+            helm.sh/chart: teleport-plugin-mattermost-18.0.0
         spec:
           containers:
             - command:
@@ -170,7 +170,7 @@ should override volume name:
               env:
                 - name: TELEPORT_PLUGIN_FAIL_FAST
                   value: "true"
-              image: public.ecr.aws/gravitational/teleport-plugin-mattermost:19.0.0-prealpha.2
+              image: public.ecr.aws/gravitational/teleport-plugin-mattermost:18.0.0
               imagePullPolicy: IfNotPresent
               name: teleport-plugin-mattermost
               ports:

--- a/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-mattermost-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-mattermost-99.0.0
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 18.0.0
-            helm.sh/chart: teleport-plugin-mattermost-18.0.0
+            app.kubernetes.io/version: 99.0.0
+            helm.sh/chart: teleport-plugin-mattermost-99.0.0
         spec:
           containers:
             - command:
@@ -75,8 +75,8 @@ should mount external secret:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-mattermost-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-mattermost-99.0.0
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should mount external secret:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 18.0.0
-            helm.sh/chart: teleport-plugin-mattermost-18.0.0
+            app.kubernetes.io/version: 99.0.0
+            helm.sh/chart: teleport-plugin-mattermost-99.0.0
         spec:
           containers:
             - command:
@@ -102,7 +102,7 @@ should mount external secret:
               env:
                 - name: TELEPORT_PLUGIN_FAIL_FAST
                   value: "true"
-              image: public.ecr.aws/gravitational/teleport-plugin-mattermost:18.0.0
+              image: public.ecr.aws/gravitational/teleport-plugin-mattermost:99.0.0
               imagePullPolicy: IfNotPresent
               name: teleport-plugin-mattermost
               ports:
@@ -143,8 +143,8 @@ should override volume name:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-mattermost-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-mattermost-99.0.0
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -158,8 +158,8 @@ should override volume name:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 18.0.0
-            helm.sh/chart: teleport-plugin-mattermost-18.0.0
+            app.kubernetes.io/version: 99.0.0
+            helm.sh/chart: teleport-plugin-mattermost-99.0.0
         spec:
           containers:
             - command:
@@ -170,7 +170,7 @@ should override volume name:
               env:
                 - name: TELEPORT_PLUGIN_FAIL_FAST
                   value: "true"
-              image: public.ecr.aws/gravitational/teleport-plugin-mattermost:18.0.0
+              image: public.ecr.aws/gravitational/teleport-plugin-mattermost:99.0.0
               imagePullPolicy: IfNotPresent
               name: teleport-plugin-mattermost
               ports:

--- a/examples/chart/access/mattermost/tests/configmap_test.yaml
+++ b/examples/chart/access/mattermost/tests/configmap_test.yaml
@@ -1,6 +1,10 @@
 suite: Test deployment
 templates:
   - configmap.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/mattermost/tests/configmap_test.yaml
+++ b/examples/chart/access/mattermost/tests/configmap_test.yaml
@@ -3,8 +3,8 @@ templates:
   - configmap.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/mattermost/tests/deployment_test.yaml
+++ b/examples/chart/access/mattermost/tests/deployment_test.yaml
@@ -1,6 +1,10 @@
 suite: Test deployment
 templates:
   - deployment.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/mattermost/tests/deployment_test.yaml
+++ b/examples/chart/access/mattermost/tests/deployment_test.yaml
@@ -3,8 +3,8 @@ templates:
   - deployment.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/mattermost/tests/secret_test.yaml
+++ b/examples/chart/access/mattermost/tests/secret_test.yaml
@@ -1,6 +1,10 @@
 suite: Test secret
 templates:
   - secret.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should contain the token
     set:

--- a/examples/chart/access/mattermost/tests/secret_test.yaml
+++ b/examples/chart/access/mattermost/tests/secret_test.yaml
@@ -3,8 +3,8 @@ templates:
   - secret.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should contain the token
     set:

--- a/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
@@ -29,6 +29,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-msteams-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-msteams-99.0.0
       name: RELEASE-NAME-teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
@@ -29,6 +29,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-msteams-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-msteams-18.0.0
       name: RELEASE-NAME-teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-msteams-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-msteams-99.0.0
       name: RELEASE-NAME-teleport-plugin-msteams
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-msteams
-            app.kubernetes.io/version: 18.0.0
-            helm.sh/chart: teleport-plugin-msteams-18.0.0
+            app.kubernetes.io/version: 99.0.0
+            helm.sh/chart: teleport-plugin-msteams-99.0.0
         spec:
           containers:
             - command:

--- a/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-msteams-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-msteams-18.0.0
       name: RELEASE-NAME-teleport-plugin-msteams
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-msteams
-            app.kubernetes.io/version: 19.0.0-prealpha.2
-            helm.sh/chart: teleport-plugin-msteams-19.0.0-prealpha.2
+            app.kubernetes.io/version: 18.0.0
+            helm.sh/chart: teleport-plugin-msteams-18.0.0
         spec:
           containers:
             - command:

--- a/examples/chart/access/msteams/tests/configmap_test.yaml
+++ b/examples/chart/access/msteams/tests/configmap_test.yaml
@@ -1,6 +1,10 @@
 suite: Test deployment
 templates:
   - configmap.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/msteams/tests/configmap_test.yaml
+++ b/examples/chart/access/msteams/tests/configmap_test.yaml
@@ -3,8 +3,8 @@ templates:
   - configmap.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/msteams/tests/deployment_test.yaml
+++ b/examples/chart/access/msteams/tests/deployment_test.yaml
@@ -1,6 +1,10 @@
 suite: Test deployment
 templates:
   - deployment.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/msteams/tests/deployment_test.yaml
+++ b/examples/chart/access/msteams/tests/deployment_test.yaml
@@ -3,8 +3,8 @@ templates:
   - deployment.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/msteams/tests/secret_test.yaml
+++ b/examples/chart/access/msteams/tests/secret_test.yaml
@@ -3,8 +3,8 @@ templates:
   - secret.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should contain the api key
     set:

--- a/examples/chart/access/msteams/tests/secret_test.yaml
+++ b/examples/chart/access/msteams/tests/secret_test.yaml
@@ -1,6 +1,10 @@
 suite: Test secret
 templates:
   - secret.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should contain the api key
     set:

--- a/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
@@ -21,6 +21,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-pagerduty-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-pagerduty-99.0.0
       name: RELEASE-NAME-teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
@@ -21,6 +21,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-pagerduty-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-pagerduty-18.0.0
       name: RELEASE-NAME-teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-pagerduty-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-pagerduty-99.0.0
       name: RELEASE-NAME-teleport-plugin-pagerduty
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-pagerduty
-            app.kubernetes.io/version: 18.0.0
-            helm.sh/chart: teleport-plugin-pagerduty-18.0.0
+            app.kubernetes.io/version: 99.0.0
+            helm.sh/chart: teleport-plugin-pagerduty-99.0.0
         spec:
           containers:
             - command:

--- a/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-pagerduty-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-pagerduty-18.0.0
       name: RELEASE-NAME-teleport-plugin-pagerduty
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-pagerduty
-            app.kubernetes.io/version: 19.0.0-prealpha.2
-            helm.sh/chart: teleport-plugin-pagerduty-19.0.0-prealpha.2
+            app.kubernetes.io/version: 18.0.0
+            helm.sh/chart: teleport-plugin-pagerduty-18.0.0
         spec:
           containers:
             - command:

--- a/examples/chart/access/pagerduty/tests/configmap_test.yaml
+++ b/examples/chart/access/pagerduty/tests/configmap_test.yaml
@@ -1,6 +1,10 @@
 suite: Test deployment
 templates:
   - configmap.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot (smtp on)
     set:

--- a/examples/chart/access/pagerduty/tests/configmap_test.yaml
+++ b/examples/chart/access/pagerduty/tests/configmap_test.yaml
@@ -3,8 +3,8 @@ templates:
   - configmap.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot (smtp on)
     set:

--- a/examples/chart/access/pagerduty/tests/deployment_test.yaml
+++ b/examples/chart/access/pagerduty/tests/deployment_test.yaml
@@ -1,6 +1,10 @@
 suite: Test deployment
 templates:
   - deployment.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/pagerduty/tests/deployment_test.yaml
+++ b/examples/chart/access/pagerduty/tests/deployment_test.yaml
@@ -3,8 +3,8 @@ templates:
   - deployment.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/pagerduty/tests/secret_test.yaml
+++ b/examples/chart/access/pagerduty/tests/secret_test.yaml
@@ -3,8 +3,8 @@ templates:
   - secret.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should contain the api key
     set:

--- a/examples/chart/access/pagerduty/tests/secret_test.yaml
+++ b/examples/chart/access/pagerduty/tests/secret_test.yaml
@@ -1,6 +1,10 @@
 suite: Test secret
 templates:
   - secret.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should contain the api key
     set:

--- a/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
@@ -27,8 +27,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-slack-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-slack-99.0.0
       name: RELEASE-NAME-teleport-plugin-slack
 should match the snapshot (review.enabled is true):
   1: |
@@ -62,6 +62,6 @@ should match the snapshot (review.enabled is true):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-slack-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-slack-99.0.0
       name: RELEASE-NAME-teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
@@ -27,8 +27,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-slack-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-slack-18.0.0
       name: RELEASE-NAME-teleport-plugin-slack
 should match the snapshot (review.enabled is true):
   1: |
@@ -62,6 +62,6 @@ should match the snapshot (review.enabled is true):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-slack-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-slack-18.0.0
       name: RELEASE-NAME-teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should contain app token secret volume if review.enabled is true:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-slack-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-slack-99.0.0
       name: RELEASE-NAME-teleport-plugin-slack
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should contain app token secret volume if review.enabled is true:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-slack
-            app.kubernetes.io/version: 18.0.0
-            helm.sh/chart: teleport-plugin-slack-18.0.0
+            app.kubernetes.io/version: 99.0.0
+            helm.sh/chart: teleport-plugin-slack-99.0.0
         spec:
           containers:
             - command:
@@ -34,7 +34,7 @@ should contain app token secret volume if review.enabled is true:
               env:
                 - name: TELEPORT_PLUGIN_FAIL_FAST
                   value: "true"
-              image: public.ecr.aws/gravitational/teleport-plugin-slack:18.0.0
+              image: public.ecr.aws/gravitational/teleport-plugin-slack:99.0.0
               imagePullPolicy: IfNotPresent
               name: teleport-plugin-slack
               resources: {}
@@ -78,8 +78,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-slack-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-slack-99.0.0
       name: RELEASE-NAME-teleport-plugin-slack
     spec:
       replicas: 1
@@ -93,8 +93,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-slack
-            app.kubernetes.io/version: 18.0.0
-            helm.sh/chart: teleport-plugin-slack-18.0.0
+            app.kubernetes.io/version: 99.0.0
+            helm.sh/chart: teleport-plugin-slack-99.0.0
         spec:
           containers:
             - command:

--- a/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should contain app token secret volume if review.enabled is true:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-slack-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-slack-18.0.0
       name: RELEASE-NAME-teleport-plugin-slack
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should contain app token secret volume if review.enabled is true:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-slack
-            app.kubernetes.io/version: 19.0.0-prealpha.2
-            helm.sh/chart: teleport-plugin-slack-19.0.0-prealpha.2
+            app.kubernetes.io/version: 18.0.0
+            helm.sh/chart: teleport-plugin-slack-18.0.0
         spec:
           containers:
             - command:
@@ -34,7 +34,7 @@ should contain app token secret volume if review.enabled is true:
               env:
                 - name: TELEPORT_PLUGIN_FAIL_FAST
                   value: "true"
-              image: public.ecr.aws/gravitational/teleport-plugin-slack:19.0.0-prealpha.2
+              image: public.ecr.aws/gravitational/teleport-plugin-slack:18.0.0
               imagePullPolicy: IfNotPresent
               name: teleport-plugin-slack
               resources: {}
@@ -78,8 +78,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-slack-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-slack-18.0.0
       name: RELEASE-NAME-teleport-plugin-slack
     spec:
       replicas: 1
@@ -93,8 +93,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-slack
-            app.kubernetes.io/version: 19.0.0-prealpha.2
-            helm.sh/chart: teleport-plugin-slack-19.0.0-prealpha.2
+            app.kubernetes.io/version: 18.0.0
+            helm.sh/chart: teleport-plugin-slack-18.0.0
         spec:
           containers:
             - command:

--- a/examples/chart/access/slack/tests/configmap_test.yaml
+++ b/examples/chart/access/slack/tests/configmap_test.yaml
@@ -3,8 +3,8 @@ templates:
   - configmap.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/slack/tests/configmap_test.yaml
+++ b/examples/chart/access/slack/tests/configmap_test.yaml
@@ -1,6 +1,10 @@
 suite: Test configmap
 templates:
   - configmap.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/slack/tests/deployment_test.yaml
+++ b/examples/chart/access/slack/tests/deployment_test.yaml
@@ -1,6 +1,10 @@
 suite: Test deployment
 templates:
   - deployment.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/slack/tests/deployment_test.yaml
+++ b/examples/chart/access/slack/tests/deployment_test.yaml
@@ -3,8 +3,8 @@ templates:
   - deployment.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/access/slack/tests/secret_test.yaml
+++ b/examples/chart/access/slack/tests/secret_test.yaml
@@ -3,8 +3,8 @@ templates:
   - secret.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should create bot oauth token with api key
     set:

--- a/examples/chart/access/slack/tests/secret_test.yaml
+++ b/examples/chart/access/slack/tests/secret_test.yaml
@@ -1,6 +1,10 @@
 suite: Test secret
 templates:
   - secret.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should create bot oauth token with api key
     set:

--- a/examples/chart/event-handler/tests/__snapshot__/certificate_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/certificate_test.yaml.snap
@@ -7,8 +7,8 @@ should request certificates when certManager enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-event-handler-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-event-handler-18.0.0
       name: RELEASE-NAME-teleport-plugin-event-handler-server
       namespace: NAMESPACE
     spec:
@@ -35,8 +35,8 @@ should request certificates when certManager enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-event-handler-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-event-handler-18.0.0
       name: RELEASE-NAME-teleport-plugin-event-handler-client
       namespace: NAMESPACE
     spec:

--- a/examples/chart/event-handler/tests/__snapshot__/certificate_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/certificate_test.yaml.snap
@@ -7,8 +7,8 @@ should request certificates when certManager enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-event-handler-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-event-handler-99.0.0
       name: RELEASE-NAME-teleport-plugin-event-handler-server
       namespace: NAMESPACE
     spec:
@@ -35,8 +35,8 @@ should request certificates when certManager enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-event-handler-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-event-handler-99.0.0
       name: RELEASE-NAME-teleport-plugin-event-handler-client
       namespace: NAMESPACE
     spec:

--- a/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
@@ -33,6 +33,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-event-handler-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-event-handler-99.0.0
       name: RELEASE-NAME-teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
@@ -33,6 +33,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-event-handler-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-event-handler-18.0.0
       name: RELEASE-NAME-teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-event-handler-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-event-handler-18.0.0
       name: RELEASE-NAME-teleport-plugin-event-handler
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-event-handler
-            app.kubernetes.io/version: 19.0.0-prealpha.2
-            helm.sh/chart: teleport-plugin-event-handler-19.0.0-prealpha.2
+            app.kubernetes.io/version: 18.0.0
+            helm.sh/chart: teleport-plugin-event-handler-18.0.0
         spec:
           containers:
             - args:
@@ -87,7 +87,7 @@ should mount tls.existingCASecretName and set environment when set in values:
             value: "true"
           - name: SSL_CERT_FILE
             value: /etc/teleport-tls-ca/helm-lint-existing-tls-secret-key-name
-        image: public.ecr.aws/gravitational/teleport-plugin-event-handler:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-plugin-event-handler:18.0.0
         imagePullPolicy: IfNotPresent
         name: teleport-plugin-event-handler
         ports:

--- a/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-event-handler-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-event-handler-99.0.0
       name: RELEASE-NAME-teleport-plugin-event-handler
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-event-handler
-            app.kubernetes.io/version: 18.0.0
-            helm.sh/chart: teleport-plugin-event-handler-18.0.0
+            app.kubernetes.io/version: 99.0.0
+            helm.sh/chart: teleport-plugin-event-handler-99.0.0
         spec:
           containers:
             - args:
@@ -87,7 +87,7 @@ should mount tls.existingCASecretName and set environment when set in values:
             value: "true"
           - name: SSL_CERT_FILE
             value: /etc/teleport-tls-ca/helm-lint-existing-tls-secret-key-name
-        image: public.ecr.aws/gravitational/teleport-plugin-event-handler:18.0.0
+        image: public.ecr.aws/gravitational/teleport-plugin-event-handler:99.0.0
         imagePullPolicy: IfNotPresent
         name: teleport-plugin-event-handler
         ports:

--- a/examples/chart/event-handler/tests/__snapshot__/operator_crs_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/operator_crs_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot (tokenSpecOverride set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-event-handler-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-event-handler-99.0.0
       name: RELEASE-NAME-teleport-plugin-event-handler
       namespace: NAMESPACE
     spec:
@@ -28,8 +28,8 @@ should match the snapshot (tokenSpecOverride set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-event-handler-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-event-handler-99.0.0
       name: RELEASE-NAME-teleport-plugin-event-handler
       namespace: NAMESPACE
     spec:
@@ -43,8 +43,8 @@ should match the snapshot (tokenSpecOverride set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-plugin-event-handler-18.0.0
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-plugin-event-handler-99.0.0
       name: RELEASE-NAME-tbot
       namespace: NAMESPACE
     spec:

--- a/examples/chart/event-handler/tests/__snapshot__/operator_crs_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/operator_crs_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot (tokenSpecOverride set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-event-handler-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-event-handler-18.0.0
       name: RELEASE-NAME-teleport-plugin-event-handler
       namespace: NAMESPACE
     spec:
@@ -28,8 +28,8 @@ should match the snapshot (tokenSpecOverride set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-event-handler-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-event-handler-18.0.0
       name: RELEASE-NAME-teleport-plugin-event-handler
       namespace: NAMESPACE
     spec:
@@ -43,8 +43,8 @@ should match the snapshot (tokenSpecOverride set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-plugin-event-handler-19.0.0-prealpha.2
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-plugin-event-handler-18.0.0
       name: RELEASE-NAME-tbot
       namespace: NAMESPACE
     spec:

--- a/examples/chart/event-handler/tests/certificate_test.yaml
+++ b/examples/chart/event-handler/tests/certificate_test.yaml
@@ -1,6 +1,10 @@
 suite: Test cert-manager certificate
 templates:
   - certificate.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should request certificates when certManager enabled
     values:

--- a/examples/chart/event-handler/tests/certificate_test.yaml
+++ b/examples/chart/event-handler/tests/certificate_test.yaml
@@ -3,8 +3,8 @@ templates:
   - certificate.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should request certificates when certManager enabled
     values:

--- a/examples/chart/event-handler/tests/configmap_test.yaml
+++ b/examples/chart/event-handler/tests/configmap_test.yaml
@@ -3,8 +3,8 @@ templates:
   - configmap.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/event-handler/tests/configmap_test.yaml
+++ b/examples/chart/event-handler/tests/configmap_test.yaml
@@ -1,6 +1,10 @@
 suite: Test configmap
 templates:
   - configmap.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/event-handler/tests/deployment_test.yaml
+++ b/examples/chart/event-handler/tests/deployment_test.yaml
@@ -1,6 +1,10 @@
 suite: Test deployment
 templates:
   - deployment.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/event-handler/tests/deployment_test.yaml
+++ b/examples/chart/event-handler/tests/deployment_test.yaml
@@ -3,8 +3,8 @@ templates:
   - deployment.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot
     set:

--- a/examples/chart/event-handler/tests/issuer_test.yaml
+++ b/examples/chart/event-handler/tests/issuer_test.yaml
@@ -1,6 +1,10 @@
 suite: Test cert-manager issuer
 templates:
   - issuer.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should create CA Issuer if certManager.enabled is true
     values:

--- a/examples/chart/event-handler/tests/issuer_test.yaml
+++ b/examples/chart/event-handler/tests/issuer_test.yaml
@@ -3,8 +3,8 @@ templates:
   - issuer.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should create CA Issuer if certManager.enabled is true
     values:

--- a/examples/chart/event-handler/tests/operator_crs_test.yaml
+++ b/examples/chart/event-handler/tests/operator_crs_test.yaml
@@ -3,8 +3,8 @@ templates:
   - operator_crs.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot (tokenSpecOverride set)
     values:

--- a/examples/chart/event-handler/tests/operator_crs_test.yaml
+++ b/examples/chart/event-handler/tests/operator_crs_test.yaml
@@ -1,6 +1,10 @@
 suite: Test operator custom resources
 templates:
   - operator_crs.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot (tokenSpecOverride set)
     values:

--- a/examples/chart/lib/teleport-proxy-lib-test/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/lib/teleport-proxy-lib-test/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -55,7 +55,7 @@ should set nodeSelector when set in values:
     containers:
       - args:
           - --diag-addr=0.0.0.0:3000
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -180,7 +180,7 @@ should set resources when set in values:
         env:
           - name: GOMEMLIMIT
             value: "3865470567"
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -291,7 +291,7 @@ should set securityContext for initContainers when set in values:
     containers:
       - args:
           - --diag-addr=0.0.0.0:3000
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -418,7 +418,7 @@ should set securityContext when set in values:
     containers:
       - args:
           - --diag-addr=0.0.0.0:3000
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/examples/chart/lib/teleport-proxy-lib-test/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/lib/teleport-proxy-lib-test/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -55,7 +55,7 @@ should set nodeSelector when set in values:
     containers:
       - args:
           - --diag-addr=0.0.0.0:3000
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -180,7 +180,7 @@ should set resources when set in values:
         env:
           - name: GOMEMLIMIT
             value: "3865470567"
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -291,7 +291,7 @@ should set securityContext for initContainers when set in values:
     containers:
       - args:
           - --diag-addr=0.0.0.0:3000
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -418,7 +418,7 @@ should set securityContext when set in values:
     containers:
       - args:
           - --diag-addr=0.0.0.0:3000
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/examples/chart/lib/teleport-proxy-lib-test/tests/ingress_test.yaml
+++ b/examples/chart/lib/teleport-proxy-lib-test/tests/ingress_test.yaml
@@ -1,6 +1,10 @@
 suite: Proxy Ingress
 templates:
   - ingress.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: does not create an Ingress by default
     set:

--- a/examples/chart/lib/teleport-proxy-lib-test/tests/ingress_test.yaml
+++ b/examples/chart/lib/teleport-proxy-lib-test/tests/ingress_test.yaml
@@ -3,8 +3,8 @@ templates:
   - ingress.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: does not create an Ingress by default
     set:

--- a/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_certificate_test.yaml
+++ b/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_certificate_test.yaml
@@ -3,8 +3,8 @@ templates:
   - certificate.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should request a certificate for cluster name when cert-manager is enabled (cert-manager.yaml)
     values:

--- a/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_certificate_test.yaml
+++ b/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_certificate_test.yaml
@@ -1,6 +1,10 @@
 suite: Proxy Certificate
 templates:
   - certificate.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should request a certificate for cluster name when cert-manager is enabled (cert-manager.yaml)
     values:

--- a/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_config_test.yaml
+++ b/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_config_test.yaml
@@ -1,6 +1,10 @@
 suite: ConfigMap
 templates:
   - config.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: matches snapshot for log-basic.yaml
     values:

--- a/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_config_test.yaml
+++ b/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_config_test.yaml
@@ -3,8 +3,8 @@ templates:
   - config.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: matches snapshot for log-basic.yaml
     values:

--- a/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_deployment_test.yaml
+++ b/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_deployment_test.yaml
@@ -3,8 +3,8 @@ templates:
   - deployment.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: sets Deployment annotations when specified
     template: deployment.yaml

--- a/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_deployment_test.yaml
+++ b/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_deployment_test.yaml
@@ -1,6 +1,10 @@
 suite: Proxy Deployment
 templates:
   - deployment.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: sets Deployment annotations when specified
     template: deployment.yaml

--- a/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_pdb_test.yaml
+++ b/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_pdb_test.yaml
@@ -3,8 +3,8 @@ templates:
   - pdb.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: shoud not create a PDB when disabled in values
     set:

--- a/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_pdb_test.yaml
+++ b/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_pdb_test.yaml
@@ -1,6 +1,10 @@
 suite: Proxy PodDisruptionBudget
 templates:
   - pdb.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: shoud not create a PDB when disabled in values
     set:

--- a/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_predeploy_test.yaml
+++ b/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_predeploy_test.yaml
@@ -3,6 +3,10 @@ templates:
   - predeploy_job.yaml
   - predeploy_config.yaml
   - predeploy_serviceaccount.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: Deploys the proxy-test config
     template: predeploy_config.yaml

--- a/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_predeploy_test.yaml
+++ b/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_predeploy_test.yaml
@@ -5,8 +5,8 @@ templates:
   - predeploy_serviceaccount.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: Deploys the proxy-test config
     template: predeploy_config.yaml

--- a/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_service_test.yaml
+++ b/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_service_test.yaml
@@ -1,6 +1,10 @@
 suite: Proxy Service
 templates:
   - service.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: uses a LoadBalancer by default
     set:

--- a/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_service_test.yaml
+++ b/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_service_test.yaml
@@ -3,8 +3,8 @@ templates:
   - service.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: uses a LoadBalancer by default
     set:

--- a/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_serviceaccount_test.yaml
+++ b/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_serviceaccount_test.yaml
@@ -1,6 +1,10 @@
 suite: Proxy ServiceAccount
 templates:
   - serviceaccount.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: sets ServiceAccount annotations when specified
     values:

--- a/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_serviceaccount_test.yaml
+++ b/examples/chart/lib/teleport-proxy-lib-test/tests/proxy_serviceaccount_test.yaml
@@ -3,8 +3,8 @@ templates:
   - serviceaccount.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: sets ServiceAccount annotations when specified
     values:

--- a/examples/chart/lib/teleport-util-lib-test/tests/gomemlimit_test.yaml
+++ b/examples/chart/lib/teleport-util-lib-test/tests/gomemlimit_test.yaml
@@ -3,8 +3,8 @@ templates:
   - templates/gomemlimit.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: sets GOMEMLIMIT by default with SI units
     set:

--- a/examples/chart/lib/teleport-util-lib-test/tests/gomemlimit_test.yaml
+++ b/examples/chart/lib/teleport-util-lib-test/tests/gomemlimit_test.yaml
@@ -1,6 +1,10 @@
 suite: GOMEMLIMIT
 templates:
   - templates/gomemlimit.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: sets GOMEMLIMIT by default with SI units
     set:

--- a/examples/chart/lib/teleport-util-lib-test/tests/resource_quantity_test.yaml
+++ b/examples/chart/lib/teleport-util-lib-test/tests/resource_quantity_test.yaml
@@ -1,6 +1,10 @@
 suite: Resource Quantity
 templates:
   - templates/resource_quantity.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: parses numeric input without a suffix
     set:

--- a/examples/chart/lib/teleport-util-lib-test/tests/resource_quantity_test.yaml
+++ b/examples/chart/lib/teleport-util-lib-test/tests/resource_quantity_test.yaml
@@ -3,8 +3,8 @@ templates:
   - templates/resource_quantity.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: parses numeric input without a suffix
     set:

--- a/examples/chart/lib/teleport-util-lib-test/tests/version_test.yaml
+++ b/examples/chart/lib/teleport-util-lib-test/tests/version_test.yaml
@@ -3,8 +3,8 @@ templates:
   - templates/version.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: falls back to the chart version when no override is set
     asserts:

--- a/examples/chart/lib/teleport-util-lib-test/tests/version_test.yaml
+++ b/examples/chart/lib/teleport-util-lib-test/tests/version_test.yaml
@@ -1,6 +1,10 @@
 suite: version
 templates:
   - templates/version.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: falls back to the chart version when no override is set
     asserts:

--- a/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/daemonset_test.yaml.snap
@@ -21,7 +21,7 @@ should match the snapshot (full):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot-spiffe-daemon-set
-            helm.sh/chart: tbot-spiffe-daemon-set-19.0.0-prealpha.2
+            helm.sh/chart: tbot-spiffe-daemon-set-18.0.0
         spec:
           containers:
             - args:
@@ -38,7 +38,7 @@ should match the snapshot (full):
                       fieldPath: spec.nodeName
                 - name: KUBERNETES_TOKEN_PATH
                   value: /var/run/secrets/tokens/join-sa-token
-              image: public.ecr.aws/gravitational/tbot-distroless:19.0.0-prealpha.2
+              image: public.ecr.aws/gravitational/tbot-distroless:18.0.0
               imagePullPolicy: IfNotPresent
               name: tbot
               securityContext:
@@ -94,7 +94,7 @@ should match the snapshot (simple):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot-spiffe-daemon-set
-            helm.sh/chart: tbot-spiffe-daemon-set-19.0.0-prealpha.2
+            helm.sh/chart: tbot-spiffe-daemon-set-18.0.0
         spec:
           containers:
             - args:
@@ -110,7 +110,7 @@ should match the snapshot (simple):
                       fieldPath: spec.nodeName
                 - name: KUBERNETES_TOKEN_PATH
                   value: /var/run/secrets/tokens/join-sa-token
-              image: public.ecr.aws/gravitational/tbot-distroless:19.0.0-prealpha.2
+              image: public.ecr.aws/gravitational/tbot-distroless:18.0.0
               imagePullPolicy: IfNotPresent
               name: tbot
               securityContext:

--- a/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/daemonset_test.yaml.snap
@@ -21,7 +21,7 @@ should match the snapshot (full):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot-spiffe-daemon-set
-            helm.sh/chart: tbot-spiffe-daemon-set-18.0.0
+            helm.sh/chart: tbot-spiffe-daemon-set-99.0.0
         spec:
           containers:
             - args:
@@ -38,7 +38,7 @@ should match the snapshot (full):
                       fieldPath: spec.nodeName
                 - name: KUBERNETES_TOKEN_PATH
                   value: /var/run/secrets/tokens/join-sa-token
-              image: public.ecr.aws/gravitational/tbot-distroless:18.0.0
+              image: public.ecr.aws/gravitational/tbot-distroless:99.0.0
               imagePullPolicy: IfNotPresent
               name: tbot
               securityContext:
@@ -94,7 +94,7 @@ should match the snapshot (simple):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot-spiffe-daemon-set
-            helm.sh/chart: tbot-spiffe-daemon-set-18.0.0
+            helm.sh/chart: tbot-spiffe-daemon-set-99.0.0
         spec:
           containers:
             - args:
@@ -110,7 +110,7 @@ should match the snapshot (simple):
                       fieldPath: spec.nodeName
                 - name: KUBERNETES_TOKEN_PATH
                   value: /var/run/secrets/tokens/join-sa-token
-              image: public.ecr.aws/gravitational/tbot-distroless:18.0.0
+              image: public.ecr.aws/gravitational/tbot-distroless:99.0.0
               imagePullPolicy: IfNotPresent
               name: tbot
               securityContext:

--- a/examples/chart/tbot-spiffe-daemon-set/tests/clusterrole_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/clusterrole_test.yaml
@@ -3,8 +3,8 @@ templates:
   - clusterrole.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot (simple)
     template: clusterrole.yaml

--- a/examples/chart/tbot-spiffe-daemon-set/tests/clusterrole_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/clusterrole_test.yaml
@@ -1,6 +1,10 @@
 suite: Test ClusterRole
 templates:
   - clusterrole.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot (simple)
     template: clusterrole.yaml

--- a/examples/chart/tbot-spiffe-daemon-set/tests/clusterrolebinding_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/clusterrolebinding_test.yaml
@@ -3,8 +3,8 @@ templates:
   - clusterrolebinding.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot (simple)
     template: clusterrolebinding.yaml

--- a/examples/chart/tbot-spiffe-daemon-set/tests/clusterrolebinding_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/clusterrolebinding_test.yaml
@@ -1,6 +1,10 @@
 suite: Test ClusterRoleBinding
 templates:
   - clusterrolebinding.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot (simple)
     template: clusterrolebinding.yaml

--- a/examples/chart/tbot-spiffe-daemon-set/tests/config_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/config_test.yaml
@@ -1,6 +1,10 @@
 suite: Test Config
 templates:
   - config.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot (simple)
     template: config.yaml

--- a/examples/chart/tbot-spiffe-daemon-set/tests/config_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/config_test.yaml
@@ -3,8 +3,8 @@ templates:
   - config.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot (simple)
     template: config.yaml

--- a/examples/chart/tbot-spiffe-daemon-set/tests/daemonset_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/daemonset_test.yaml
@@ -3,8 +3,8 @@ templates:
   - daemonset.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot (simple)
     template: daemonset.yaml

--- a/examples/chart/tbot-spiffe-daemon-set/tests/daemonset_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/daemonset_test.yaml
@@ -1,6 +1,10 @@
 suite: Test Daemonset
 templates:
   - daemonset.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot (simple)
     template: daemonset.yaml

--- a/examples/chart/tbot-spiffe-daemon-set/tests/role_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/role_test.yaml
@@ -3,8 +3,8 @@ templates:
   - role.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot (simple)
     template: role.yaml

--- a/examples/chart/tbot-spiffe-daemon-set/tests/role_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/role_test.yaml
@@ -1,6 +1,10 @@
 suite: Test Role
 templates:
   - role.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot (simple)
     template: role.yaml

--- a/examples/chart/tbot-spiffe-daemon-set/tests/rolebinding_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/rolebinding_test.yaml
@@ -1,6 +1,10 @@
 suite: Test RoleBinding
 templates:
   - rolebinding.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot (simple)
     template: rolebinding.yaml

--- a/examples/chart/tbot-spiffe-daemon-set/tests/rolebinding_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/rolebinding_test.yaml
@@ -3,8 +3,8 @@ templates:
   - rolebinding.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot (simple)
     template: rolebinding.yaml

--- a/examples/chart/tbot-spiffe-daemon-set/tests/serviceaccount_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/serviceaccount_test.yaml
@@ -3,8 +3,8 @@ templates:
   - serviceaccount.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot (simple)
     template: serviceaccount.yaml

--- a/examples/chart/tbot-spiffe-daemon-set/tests/serviceaccount_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/serviceaccount_test.yaml
@@ -1,6 +1,10 @@
 suite: Test ServiceAccount
 templates:
   - serviceaccount.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot (simple)
     template: serviceaccount.yaml

--- a/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
@@ -29,7 +29,7 @@ should match the snapshot (full):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-18.0.0
+            helm.sh/chart: tbot-99.0.0
             test-key: test-label-pod
         spec:
           affinity:
@@ -68,7 +68,7 @@ should match the snapshot (full):
                   value: "1"
                 - name: TEST_ENV
                   value: test-value
-              image: public.ecr.aws/gravitational/tbot-distroless:18.0.0
+              image: public.ecr.aws/gravitational/tbot-distroless:99.0.0
               imagePullPolicy: Always
               livenessProbe:
                 failureThreshold: 6
@@ -167,7 +167,7 @@ should match the snapshot (simple):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-18.0.0
+            helm.sh/chart: tbot-99.0.0
         spec:
           containers:
             - args:
@@ -189,7 +189,7 @@ should match the snapshot (simple):
                       fieldPath: spec.nodeName
                 - name: KUBERNETES_TOKEN_PATH
                   value: /var/run/secrets/tokens/join-sa-token
-              image: public.ecr.aws/gravitational/tbot-distroless:18.0.0
+              image: public.ecr.aws/gravitational/tbot-distroless:99.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 6

--- a/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
@@ -29,7 +29,7 @@ should match the snapshot (full):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-19.0.0-prealpha.2
+            helm.sh/chart: tbot-18.0.0
             test-key: test-label-pod
         spec:
           affinity:
@@ -68,7 +68,7 @@ should match the snapshot (full):
                   value: "1"
                 - name: TEST_ENV
                   value: test-value
-              image: public.ecr.aws/gravitational/tbot-distroless:19.0.0-prealpha.2
+              image: public.ecr.aws/gravitational/tbot-distroless:18.0.0
               imagePullPolicy: Always
               livenessProbe:
                 failureThreshold: 6
@@ -167,7 +167,7 @@ should match the snapshot (simple):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-19.0.0-prealpha.2
+            helm.sh/chart: tbot-18.0.0
         spec:
           containers:
             - args:
@@ -189,7 +189,7 @@ should match the snapshot (simple):
                       fieldPath: spec.nodeName
                 - name: KUBERNETES_TOKEN_PATH
                   value: /var/run/secrets/tokens/join-sa-token
-              image: public.ecr.aws/gravitational/tbot-distroless:19.0.0-prealpha.2
+              image: public.ecr.aws/gravitational/tbot-distroless:18.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 6

--- a/examples/chart/tbot/tests/config_test.yaml
+++ b/examples/chart/tbot/tests/config_test.yaml
@@ -1,6 +1,10 @@
 suite: Test ConfigMap
 templates:
   - config.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot (simple)
     values:

--- a/examples/chart/tbot/tests/config_test.yaml
+++ b/examples/chart/tbot/tests/config_test.yaml
@@ -3,8 +3,8 @@ templates:
   - config.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot (simple)
     values:

--- a/examples/chart/tbot/tests/deployment_test.yaml
+++ b/examples/chart/tbot/tests/deployment_test.yaml
@@ -4,8 +4,8 @@ templates:
   - config.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot (simple)
     template: deployment.yaml

--- a/examples/chart/tbot/tests/deployment_test.yaml
+++ b/examples/chart/tbot/tests/deployment_test.yaml
@@ -2,6 +2,10 @@ suite: Test Deployment
 templates:
   - deployment.yaml
   - config.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot (simple)
     template: deployment.yaml

--- a/examples/chart/tbot/tests/role_test.yaml
+++ b/examples/chart/tbot/tests/role_test.yaml
@@ -1,6 +1,10 @@
 suite: Test Role
 templates:
   - role.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot (simple)
     values:

--- a/examples/chart/tbot/tests/role_test.yaml
+++ b/examples/chart/tbot/tests/role_test.yaml
@@ -3,8 +3,8 @@ templates:
   - role.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot (simple)
     values:

--- a/examples/chart/tbot/tests/rolebinding_test.yaml
+++ b/examples/chart/tbot/tests/rolebinding_test.yaml
@@ -3,8 +3,8 @@ templates:
   - rolebinding.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot (simple)
     values:

--- a/examples/chart/tbot/tests/rolebinding_test.yaml
+++ b/examples/chart/tbot/tests/rolebinding_test.yaml
@@ -1,6 +1,10 @@
 suite: Test RoleBinding
 templates:
   - rolebinding.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot (simple)
     values:

--- a/examples/chart/tbot/tests/serviceaccount_test.yaml
+++ b/examples/chart/tbot/tests/serviceaccount_test.yaml
@@ -3,8 +3,8 @@ templates:
   - serviceaccount.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should match the snapshot (simple)
     values:

--- a/examples/chart/tbot/tests/serviceaccount_test.yaml
+++ b/examples/chart/tbot/tests/serviceaccount_test.yaml
@@ -1,6 +1,10 @@
 suite: Test ServiceAccount
 templates:
   - serviceaccount.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should match the snapshot (simple)
     values:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/crds_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/crds_test.yaml
@@ -3,6 +3,10 @@ templates:
   # Renamed from crds.yaml: helm-unittest v1.x excludes a template named exactly
   # crds.yaml from rendering. See templates/crd-resources.yaml for details.
   - crd-resources.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: creates no CRDs when installCRDs is "never"
     set:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/crds_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/crds_test.yaml
@@ -5,8 +5,8 @@ templates:
   - crd-resources.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: creates no CRDs when installCRDs is "never"
     set:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/deployment_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/deployment_test.yaml
@@ -3,8 +3,8 @@ templates:
   - deployment.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: creates no deployment when operator is not enabled
     values:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/deployment_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/deployment_test.yaml
@@ -1,6 +1,10 @@
 suite: Operator Deployment
 templates:
   - deployment.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: creates no deployment when operator is not enabled
     values:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/role_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/role_test.yaml
@@ -1,6 +1,10 @@
 suite: Operator Role
 templates:
   - role.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: creates no role when operator is not enabled
     values:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/role_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/role_test.yaml
@@ -3,8 +3,8 @@ templates:
   - role.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: creates no role when operator is not enabled
     values:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/rolebinding_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/rolebinding_test.yaml
@@ -1,6 +1,10 @@
 suite: Operator RoleBinding
 templates:
   - rolebinding.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: creates no RoleBinding when operator is not enabled
     values:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/rolebinding_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/rolebinding_test.yaml
@@ -3,8 +3,8 @@ templates:
   - rolebinding.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: creates no RoleBinding when operator is not enabled
     values:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/serviceaccount_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/serviceaccount_test.yaml
@@ -1,6 +1,10 @@
 suite: Operator ServiceAccount
 templates:
   - serviceaccount.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: creates no ServiceAccount when operator is not enabled
     values:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/serviceaccount_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/serviceaccount_test.yaml
@@ -3,8 +3,8 @@ templates:
   - serviceaccount.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: creates no ServiceAccount when operator is not enabled
     values:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
@@ -8,9 +8,9 @@ adds operator permissions to ClusterRole:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-cluster-18.0.0
-        teleport.dev/majorVersion: "18"
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-cluster-99.0.0
+        teleport.dev/majorVersion: "99"
       name: RELEASE-NAME
     rules:
       - apiGroups:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
@@ -8,9 +8,9 @@ adds operator permissions to ClusterRole:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-cluster-19.0.0-prealpha.2
-        teleport.dev/majorVersion: "19"
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-cluster-18.0.0
+        teleport.dev/majorVersion: "18"
       name: RELEASE-NAME
     rules:
       - apiGroups:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -2040,9 +2040,9 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-cluster-19.0.0-prealpha.2
-        teleport.dev/majorVersion: "19"
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-cluster-18.0.0
+        teleport.dev/majorVersion: "18"
       name: RELEASE-NAME-auth
       namespace: NAMESPACE
 uses athena as primary backend when configured:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -2040,9 +2040,9 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-cluster-18.0.0
-        teleport.dev/majorVersion: "18"
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-cluster-99.0.0
+        teleport.dev/majorVersion: "99"
       name: RELEASE-NAME-auth
       namespace: NAMESPACE
 uses athena as primary backend when configured:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -7,7 +7,7 @@
       - args:
           - --diag-addr=0.0.0.0:3000
           - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -158,7 +158,7 @@ should set nodeSelector when set in values:
       - args:
           - --diag-addr=0.0.0.0:3000
           - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -276,7 +276,7 @@ should set resources when set in values:
         env:
           - name: GOMEMLIMIT
             value: "3865470567"
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -380,7 +380,7 @@ should set securityContext when set in values:
       - args:
           - --diag-addr=0.0.0.0:3000
           - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -7,7 +7,7 @@
       - args:
           - --diag-addr=0.0.0.0:3000
           - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -158,7 +158,7 @@ should set nodeSelector when set in values:
       - args:
           - --diag-addr=0.0.0.0:3000
           - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -276,7 +276,7 @@ should set resources when set in values:
         env:
           - name: GOMEMLIMIT
             value: "3865470567"
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -380,7 +380,7 @@ should set securityContext when set in values:
       - args:
           - --diag-addr=0.0.0.0:3000
           - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
@@ -567,8 +567,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-cluster-19.0.0-prealpha.2
-        teleport.dev/majorVersion: "19"
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-cluster-18.0.0
+        teleport.dev/majorVersion: "18"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
@@ -567,8 +567,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-cluster-18.0.0
-        teleport.dev/majorVersion: "18"
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-cluster-99.0.0
+        teleport.dev/majorVersion: "99"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -11,9 +11,9 @@ sets clusterDomain on Deployment Pods:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 19.0.0-prealpha.2
-        helm.sh/chart: teleport-cluster-19.0.0-prealpha.2
-        teleport.dev/majorVersion: "19"
+        app.kubernetes.io/version: 18.0.0
+        helm.sh/chart: teleport-cluster-18.0.0
+        teleport.dev/majorVersion: "18"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE
     spec:
@@ -26,7 +26,7 @@ sets clusterDomain on Deployment Pods:
       template:
         metadata:
           annotations:
-            checksum/config: d0c4c0f0778f4dc9f47c4fe2230358a10982bafc9843c0c02e0deca118ae0f20
+            checksum/config: 9784d7fd5be239f4883f92e87c92cca6b2099ff35cbd3dcba371b7ac5dfc97cd
             kubernetes.io/pod: test-annotation
             kubernetes.io/pod-different: 4
           labels:
@@ -34,9 +34,9 @@ sets clusterDomain on Deployment Pods:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-cluster
-            app.kubernetes.io/version: 19.0.0-prealpha.2
-            helm.sh/chart: teleport-cluster-19.0.0-prealpha.2
-            teleport.dev/majorVersion: "19"
+            app.kubernetes.io/version: 18.0.0
+            helm.sh/chart: teleport-cluster-18.0.0
+            teleport.dev/majorVersion: "18"
         spec:
           affinity:
             podAntiAffinity: null
@@ -44,7 +44,7 @@ sets clusterDomain on Deployment Pods:
           containers:
             - args:
                 - --diag-addr=0.0.0.0:3000
-              image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+              image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
               imagePullPolicy: IfNotPresent
               lifecycle:
                 preStop:
@@ -105,8 +105,8 @@ sets clusterDomain on Deployment Pods:
                 - teleport
                 - wait
                 - no-resolve
-                - RELEASE-NAME-auth-v18.NAMESPACE.svc.test.com
-              image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+                - RELEASE-NAME-auth-v17.NAMESPACE.svc.test.com
+              image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
               name: wait-auth-update
           serviceAccountName: RELEASE-NAME-proxy
           terminationGracePeriodSeconds: 60
@@ -154,8 +154,8 @@ should provision initContainer correctly when set in values:
         - teleport
         - wait
         - no-resolve
-        - RELEASE-NAME-auth-v18.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
+      image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
       name: wait-auth-update
       resources:
         limits:
@@ -219,7 +219,7 @@ should set nodeSelector when set in values:
     containers:
       - args:
           - --diag-addr=0.0.0.0:3000
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -280,8 +280,8 @@ should set nodeSelector when set in values:
           - teleport
           - wait
           - no-resolve
-          - RELEASE-NAME-auth-v18.NAMESPACE.svc.cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+          - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         name: wait-auth-update
     nodeSelector:
       environment: security
@@ -352,7 +352,7 @@ should set resources for wait-auth-update initContainer when set in values:
         env:
           - name: GOMEMLIMIT
             value: "3865470567"
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -420,8 +420,8 @@ should set resources for wait-auth-update initContainer when set in values:
           - teleport
           - wait
           - no-resolve
-          - RELEASE-NAME-auth-v18.NAMESPACE.svc.cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+          - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         name: wait-auth-update
         resources:
           limits:
@@ -481,7 +481,7 @@ should set resources when set in values:
         env:
           - name: GOMEMLIMIT
             value: "3865470567"
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -549,8 +549,8 @@ should set resources when set in values:
           - teleport
           - wait
           - no-resolve
-          - RELEASE-NAME-auth-v18.NAMESPACE.svc.cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+          - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         name: wait-auth-update
         resources:
           limits:
@@ -607,7 +607,7 @@ should set securityContext for initContainers when set in values:
     containers:
       - args:
           - --diag-addr=0.0.0.0:3000
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -675,8 +675,8 @@ should set securityContext for initContainers when set in values:
           - teleport
           - wait
           - no-resolve
-          - RELEASE-NAME-auth-v18.NAMESPACE.svc.cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+          - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         name: wait-auth-update
         securityContext:
           allowPrivilegeEscalation: false
@@ -733,7 +733,7 @@ should set securityContext when set in values:
     containers:
       - args:
           - --diag-addr=0.0.0.0:3000
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -801,8 +801,8 @@ should set securityContext when set in values:
           - teleport
           - wait
           - no-resolve
-          - RELEASE-NAME-auth-v18.NAMESPACE.svc.cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+          - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         name: wait-auth-update
         securityContext:
           allowPrivilegeEscalation: false

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -11,9 +11,9 @@ sets clusterDomain on Deployment Pods:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 18.0.0
-        helm.sh/chart: teleport-cluster-18.0.0
-        teleport.dev/majorVersion: "18"
+        app.kubernetes.io/version: 99.0.0
+        helm.sh/chart: teleport-cluster-99.0.0
+        teleport.dev/majorVersion: "99"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE
     spec:
@@ -26,7 +26,7 @@ sets clusterDomain on Deployment Pods:
       template:
         metadata:
           annotations:
-            checksum/config: 9784d7fd5be239f4883f92e87c92cca6b2099ff35cbd3dcba371b7ac5dfc97cd
+            checksum/config: dc607d76220ece282168d6b7e96663daf317a34b087b261f59419dc89e989f28
             kubernetes.io/pod: test-annotation
             kubernetes.io/pod-different: 4
           labels:
@@ -34,9 +34,9 @@ sets clusterDomain on Deployment Pods:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-cluster
-            app.kubernetes.io/version: 18.0.0
-            helm.sh/chart: teleport-cluster-18.0.0
-            teleport.dev/majorVersion: "18"
+            app.kubernetes.io/version: 99.0.0
+            helm.sh/chart: teleport-cluster-99.0.0
+            teleport.dev/majorVersion: "99"
         spec:
           affinity:
             podAntiAffinity: null
@@ -44,7 +44,7 @@ sets clusterDomain on Deployment Pods:
           containers:
             - args:
                 - --diag-addr=0.0.0.0:3000
-              image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+              image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
               imagePullPolicy: IfNotPresent
               lifecycle:
                 preStop:
@@ -105,8 +105,8 @@ sets clusterDomain on Deployment Pods:
                 - teleport
                 - wait
                 - no-resolve
-                - RELEASE-NAME-auth-v17.NAMESPACE.svc.test.com
-              image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+                - RELEASE-NAME-auth-v98.NAMESPACE.svc.test.com
+              image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
               name: wait-auth-update
           serviceAccountName: RELEASE-NAME-proxy
           terminationGracePeriodSeconds: 60
@@ -154,8 +154,8 @@ should provision initContainer correctly when set in values:
         - teleport
         - wait
         - no-resolve
-        - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        - RELEASE-NAME-auth-v98.NAMESPACE.svc.cluster.local
+      image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
       name: wait-auth-update
       resources:
         limits:
@@ -219,7 +219,7 @@ should set nodeSelector when set in values:
     containers:
       - args:
           - --diag-addr=0.0.0.0:3000
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -280,8 +280,8 @@ should set nodeSelector when set in values:
           - teleport
           - wait
           - no-resolve
-          - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+          - RELEASE-NAME-auth-v98.NAMESPACE.svc.cluster.local
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         name: wait-auth-update
     nodeSelector:
       environment: security
@@ -352,7 +352,7 @@ should set resources for wait-auth-update initContainer when set in values:
         env:
           - name: GOMEMLIMIT
             value: "3865470567"
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -420,8 +420,8 @@ should set resources for wait-auth-update initContainer when set in values:
           - teleport
           - wait
           - no-resolve
-          - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+          - RELEASE-NAME-auth-v98.NAMESPACE.svc.cluster.local
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         name: wait-auth-update
         resources:
           limits:
@@ -481,7 +481,7 @@ should set resources when set in values:
         env:
           - name: GOMEMLIMIT
             value: "3865470567"
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -549,8 +549,8 @@ should set resources when set in values:
           - teleport
           - wait
           - no-resolve
-          - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+          - RELEASE-NAME-auth-v98.NAMESPACE.svc.cluster.local
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         name: wait-auth-update
         resources:
           limits:
@@ -607,7 +607,7 @@ should set securityContext for initContainers when set in values:
     containers:
       - args:
           - --diag-addr=0.0.0.0:3000
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -675,8 +675,8 @@ should set securityContext for initContainers when set in values:
           - teleport
           - wait
           - no-resolve
-          - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+          - RELEASE-NAME-auth-v98.NAMESPACE.svc.cluster.local
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         name: wait-auth-update
         securityContext:
           allowPrivilegeEscalation: false
@@ -733,7 +733,7 @@ should set securityContext when set in values:
     containers:
       - args:
           - --diag-addr=0.0.0.0:3000
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -801,8 +801,8 @@ should set securityContext when set in values:
           - teleport
           - wait
           - no-resolve
-          - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+          - RELEASE-NAME-auth-v98.NAMESPACE.svc.cluster.local
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         name: wait-auth-update
         securityContext:
           allowPrivilegeEscalation: false

--- a/examples/chart/teleport-cluster/tests/auth_clusterrole_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_clusterrole_test.yaml
@@ -1,6 +1,10 @@
 suite: Auth ClusterRole
 templates:
   - auth/clusterrole.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: creates a ClusterRole
     asserts:

--- a/examples/chart/teleport-cluster/tests/auth_clusterrole_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_clusterrole_test.yaml
@@ -3,8 +3,8 @@ templates:
   - auth/clusterrole.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: creates a ClusterRole
     asserts:

--- a/examples/chart/teleport-cluster/tests/auth_clusterrolebinding_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_clusterrolebinding_test.yaml
@@ -3,8 +3,8 @@ templates:
   - auth/clusterrolebinding.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: creates a ClusterRoleBinding
     asserts:

--- a/examples/chart/teleport-cluster/tests/auth_clusterrolebinding_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_clusterrolebinding_test.yaml
@@ -1,6 +1,10 @@
 suite: Auth ClusterRoleBinding
 templates:
   - auth/clusterrolebinding.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: creates a ClusterRoleBinding
     asserts:

--- a/examples/chart/teleport-cluster/tests/auth_config_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_config_test.yaml
@@ -1,6 +1,10 @@
 suite: ConfigMap
 templates:
   - auth/config.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: matches snapshot for acme-off.yaml
     values:

--- a/examples/chart/teleport-cluster/tests/auth_config_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_config_test.yaml
@@ -3,8 +3,8 @@ templates:
   - auth/config.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: matches snapshot for acme-off.yaml
     values:

--- a/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
@@ -2,6 +2,10 @@ suite: Auth Deployment
 templates:
   - auth/deployment.yaml
   - auth/config.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: sets Deployment annotations when specified
     template: auth/deployment.yaml

--- a/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
@@ -4,8 +4,8 @@ templates:
   - auth/config.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: sets Deployment annotations when specified
     template: auth/deployment.yaml

--- a/examples/chart/teleport-cluster/tests/auth_pdb_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_pdb_test.yaml
@@ -3,8 +3,8 @@ templates:
   - auth/pdb.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: not should create a PDB when disabled in values
     set:

--- a/examples/chart/teleport-cluster/tests/auth_pdb_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_pdb_test.yaml
@@ -1,6 +1,10 @@
 suite: Auth PodDisruptionBudget
 templates:
   - auth/pdb.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: not should create a PDB when disabled in values
     set:

--- a/examples/chart/teleport-cluster/tests/auth_pvc_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_pvc_test.yaml
@@ -1,6 +1,10 @@
 suite: Auth PersistentVolumeClaim
 templates:
   - auth/pvc.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: creates a PersistentVolumeClaim when chartMode=standalone with default size
     set:

--- a/examples/chart/teleport-cluster/tests/auth_pvc_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_pvc_test.yaml
@@ -3,8 +3,8 @@ templates:
   - auth/pvc.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: creates a PersistentVolumeClaim when chartMode=standalone with default size
     set:

--- a/examples/chart/teleport-cluster/tests/auth_serviceaccount_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_serviceaccount_test.yaml
@@ -1,6 +1,10 @@
 suite: Auth ServiceAccount
 templates:
   - auth/serviceaccount.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: sets ServiceAccount annotations when specified
     values:

--- a/examples/chart/teleport-cluster/tests/auth_serviceaccount_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_serviceaccount_test.yaml
@@ -3,8 +3,8 @@ templates:
   - auth/serviceaccount.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: sets ServiceAccount annotations when specified
     values:

--- a/examples/chart/teleport-cluster/tests/ingress_test.yaml
+++ b/examples/chart/teleport-cluster/tests/ingress_test.yaml
@@ -1,6 +1,10 @@
 suite: Proxy Ingress
 templates:
   - proxy.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   # TODO(adamcarheden): identical to the teleport-proxy-lib test; kept so this PR's diff stays minimal, remove next PR
   - it: does not create an Ingress by default

--- a/examples/chart/teleport-cluster/tests/ingress_test.yaml
+++ b/examples/chart/teleport-cluster/tests/ingress_test.yaml
@@ -3,8 +3,8 @@ templates:
   - proxy.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   # TODO(adamcarheden): identical to the teleport-proxy-lib test; kept so this PR's diff stays minimal, remove next PR
   - it: does not create an Ingress by default

--- a/examples/chart/teleport-cluster/tests/podmonitor_test.yaml
+++ b/examples/chart/teleport-cluster/tests/podmonitor_test.yaml
@@ -3,8 +3,8 @@ templates:
   - podmonitor.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: does not create a PodMonitor by default
     set:

--- a/examples/chart/teleport-cluster/tests/podmonitor_test.yaml
+++ b/examples/chart/teleport-cluster/tests/podmonitor_test.yaml
@@ -1,6 +1,10 @@
 suite: PodMonitor
 templates:
   - podmonitor.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: does not create a PodMonitor by default
     set:

--- a/examples/chart/teleport-cluster/tests/predeploy_test.yaml
+++ b/examples/chart/teleport-cluster/tests/predeploy_test.yaml
@@ -6,8 +6,8 @@ templates:
   - proxy.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: Deploys the auth-test config
     template: auth/predeploy_config.yaml

--- a/examples/chart/teleport-cluster/tests/predeploy_test.yaml
+++ b/examples/chart/teleport-cluster/tests/predeploy_test.yaml
@@ -4,6 +4,10 @@ templates:
   - auth/predeploy_config.yaml
   - auth/predeploy_serviceaccount.yaml
   - proxy.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: Deploys the auth-test config
     template: auth/predeploy_config.yaml

--- a/examples/chart/teleport-cluster/tests/proxy_certificate_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_certificate_test.yaml
@@ -1,6 +1,10 @@
 suite: Proxy Certificate
 templates:
   - proxy.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should request a certificate for cluster name when cert-manager is enabled (cert-manager.yaml)
     values:

--- a/examples/chart/teleport-cluster/tests/proxy_certificate_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_certificate_test.yaml
@@ -3,8 +3,8 @@ templates:
   - proxy.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should request a certificate for cluster name when cert-manager is enabled (cert-manager.yaml)
     values:

--- a/examples/chart/teleport-cluster/tests/proxy_config_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_config_test.yaml
@@ -1,6 +1,10 @@
 suite: ConfigMap
 templates:
   - proxy.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   # TODO(adamcarheden): identical to the teleport-proxy-lib test; kept so this PR's diff stays minimal, remove next PR
   - it: matches snapshot for log-basic.yaml

--- a/examples/chart/teleport-cluster/tests/proxy_config_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_config_test.yaml
@@ -3,8 +3,8 @@ templates:
   - proxy.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   # TODO(adamcarheden): identical to the teleport-proxy-lib test; kept so this PR's diff stays minimal, remove next PR
   - it: matches snapshot for log-basic.yaml

--- a/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
@@ -3,8 +3,8 @@ templates:
   - proxy.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   # TODO(adamcarheden): identical to the teleport-proxy-lib test; kept so this PR's diff stays minimal, remove next PR
   - it: sets Deployment annotations when specified

--- a/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
@@ -1,6 +1,10 @@
 suite: Proxy Deployment
 templates:
   - proxy.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   # TODO(adamcarheden): identical to the teleport-proxy-lib test; kept so this PR's diff stays minimal, remove next PR
   - it: sets Deployment annotations when specified

--- a/examples/chart/teleport-cluster/tests/proxy_pdb_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_pdb_test.yaml
@@ -1,6 +1,10 @@
 suite: Proxy PodDisruptionBudget
 templates:
   - proxy.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should not create a PDB when disabled in values
     set:

--- a/examples/chart/teleport-cluster/tests/proxy_pdb_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_pdb_test.yaml
@@ -3,8 +3,8 @@ templates:
   - proxy.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should not create a PDB when disabled in values
     set:

--- a/examples/chart/teleport-cluster/tests/proxy_service_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_service_test.yaml
@@ -1,6 +1,10 @@
 suite: Proxy Service
 templates:
   - proxy.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   # TODO(adamcarheden): identical to the teleport-proxy-lib test; kept so this PR's diff stays minimal, remove next PR
   - it: uses a LoadBalancer by default

--- a/examples/chart/teleport-cluster/tests/proxy_service_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_service_test.yaml
@@ -3,8 +3,8 @@ templates:
   - proxy.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   # TODO(adamcarheden): identical to the teleport-proxy-lib test; kept so this PR's diff stays minimal, remove next PR
   - it: uses a LoadBalancer by default

--- a/examples/chart/teleport-cluster/tests/proxy_serviceaccount_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_serviceaccount_test.yaml
@@ -1,6 +1,10 @@
 suite: Proxy ServiceAccount
 templates:
   - proxy.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: sets ServiceAccount annotations when specified
     values:

--- a/examples/chart/teleport-cluster/tests/proxy_serviceaccount_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_serviceaccount_test.yaml
@@ -3,8 +3,8 @@ templates:
   - proxy.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: sets ServiceAccount annotations when specified
     values:

--- a/examples/chart/teleport-cluster/tests/psp_test.yaml
+++ b/examples/chart/teleport-cluster/tests/psp_test.yaml
@@ -3,8 +3,8 @@ templates:
   - psp.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: creates a PodSecurityPolicy when enabled in values and supported
     capabilities:

--- a/examples/chart/teleport-cluster/tests/psp_test.yaml
+++ b/examples/chart/teleport-cluster/tests/psp_test.yaml
@@ -1,6 +1,10 @@
 suite: PodSecurityPolicy
 templates:
   - psp.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: creates a PodSecurityPolicy when enabled in values and supported
     capabilities:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -25,7 +25,7 @@ should create ServiceAccount for post-delete hook by default:
                 fieldPath: metadata.namespace
           - name: RELEASE_NAME
             value: RELEASE-NAME
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         name: post-delete-job
         securityContext:
@@ -109,7 +109,7 @@ should not create ServiceAccount for post-delete hook if serviceAccount.create i
                       fieldPath: metadata.namespace
                 - name: RELEASE_NAME
                   value: RELEASE-NAME
-              image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+              image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
               imagePullPolicy: IfNotPresent
               name: post-delete-job
               securityContext:
@@ -140,7 +140,7 @@ should not create ServiceAccount, Role or RoleBinding for post-delete hook if se
                 fieldPath: metadata.namespace
           - name: RELEASE_NAME
             value: RELEASE-NAME
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         name: post-delete-job
         securityContext:
@@ -171,7 +171,7 @@ should set nodeSelector in post-delete hook:
                 fieldPath: metadata.namespace
           - name: RELEASE_NAME
             value: RELEASE-NAME
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         name: post-delete-job
         securityContext:
@@ -204,7 +204,7 @@ should set resources in the Job's pod spec if resources is set in values:
                 fieldPath: metadata.namespace
           - name: RELEASE_NAME
             value: RELEASE-NAME
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         name: post-delete-job
         resources:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -25,7 +25,7 @@ should create ServiceAccount for post-delete hook by default:
                 fieldPath: metadata.namespace
           - name: RELEASE_NAME
             value: RELEASE-NAME
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         name: post-delete-job
         securityContext:
@@ -109,7 +109,7 @@ should not create ServiceAccount for post-delete hook if serviceAccount.create i
                       fieldPath: metadata.namespace
                 - name: RELEASE_NAME
                   value: RELEASE-NAME
-              image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+              image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
               imagePullPolicy: IfNotPresent
               name: post-delete-job
               securityContext:
@@ -140,7 +140,7 @@ should not create ServiceAccount, Role or RoleBinding for post-delete hook if se
                 fieldPath: metadata.namespace
           - name: RELEASE_NAME
             value: RELEASE-NAME
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         name: post-delete-job
         securityContext:
@@ -171,7 +171,7 @@ should set nodeSelector in post-delete hook:
                 fieldPath: metadata.namespace
           - name: RELEASE_NAME
             value: RELEASE-NAME
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         name: post-delete-job
         securityContext:
@@ -204,7 +204,7 @@ should set resources in the Job's pod spec if resources is set in values:
                 fieldPath: metadata.namespace
           - name: RELEASE_NAME
             value: RELEASE-NAME
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         name: post-delete-job
         resources:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -19,7 +19,7 @@ sets Pod annotations when specified:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -106,7 +106,7 @@ sets Pod labels when specified:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -217,7 +217,7 @@ sets StatefulSet labels when specified:
                   value: RELEASE-NAME
                 - name: TELEPORT_KUBE_CLUSTER_DOMAIN
                   value: cluster.local
-              image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+              image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 6
@@ -336,7 +336,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -423,7 +423,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -530,7 +530,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
                   value: RELEASE-NAME
                 - name: TELEPORT_KUBE_CLUSTER_DOMAIN
                   value: cluster.local
-              image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+              image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 6
@@ -627,7 +627,7 @@ should add volumeMount for data volume when using StatefulSet:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -714,7 +714,7 @@ should expose diag port:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -801,7 +801,7 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -902,7 +902,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1001,7 +1001,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1088,7 +1088,7 @@ should have one replica when replicaCount is not set:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1175,7 +1175,7 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1264,7 +1264,7 @@ should mount extraVolumes and extraVolumeMounts:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1356,7 +1356,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1451,7 +1451,7 @@ should mount jamfCredentialsSecret.name when role is jamf:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1548,7 +1548,7 @@ should mount tls.existingCASecretName and set environment when set in values:
             value: cluster.local
           - name: SSL_CERT_FILE
             value: /etc/teleport-tls-ca/helm-lint-existing-tls-secret-key-name
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1647,7 +1647,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
             value: /etc/teleport-tls-ca/helm-lint-existing-tls-secret-key-name
           - name: HTTPS_PROXY
             value: http://username:password@my.proxy.host:3128
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1742,7 +1742,7 @@ should not add emptyDir for data when using StatefulSet:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1831,7 +1831,7 @@ should provision initContainer correctly when set in values:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1976,7 +1976,7 @@ should set affinity when set in values:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -2063,7 +2063,7 @@ should set default serviceAccountName when not set in values:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -2163,7 +2163,7 @@ should set environment when extraEnv set in values:
             value: cluster.local
           - name: HTTPS_PROXY
             value: http://username:password@my.proxy.host:3128
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -2337,7 +2337,7 @@ should set imagePullPolicy when set in values:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 6
@@ -2424,7 +2424,7 @@ should set nodeSelector if set in values:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -2525,7 +2525,7 @@ should set preferred affinity when more than one replica is used:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -2612,7 +2612,7 @@ should set probeTimeoutSeconds when set in values:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -2709,7 +2709,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -2798,7 +2798,7 @@ should set resources when set in values:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -2892,7 +2892,7 @@ should set serviceAccountName when set in values:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -2979,7 +2979,7 @@ should set storage.requests when set in values and action is an Upgrade:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -3066,7 +3066,7 @@ should set storage.storageClassName when set in values and action is an Upgrade:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -3153,7 +3153,7 @@ should set tolerations when set in values:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -19,7 +19,7 @@ sets Pod annotations when specified:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -106,7 +106,7 @@ sets Pod labels when specified:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -217,7 +217,7 @@ sets StatefulSet labels when specified:
                   value: RELEASE-NAME
                 - name: TELEPORT_KUBE_CLUSTER_DOMAIN
                   value: cluster.local
-              image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+              image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 6
@@ -336,7 +336,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -423,7 +423,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -530,7 +530,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
                   value: RELEASE-NAME
                 - name: TELEPORT_KUBE_CLUSTER_DOMAIN
                   value: cluster.local
-              image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+              image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 6
@@ -627,7 +627,7 @@ should add volumeMount for data volume when using StatefulSet:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -714,7 +714,7 @@ should expose diag port:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -801,7 +801,7 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -902,7 +902,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1001,7 +1001,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1088,7 +1088,7 @@ should have one replica when replicaCount is not set:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1175,7 +1175,7 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1264,7 +1264,7 @@ should mount extraVolumes and extraVolumeMounts:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1356,7 +1356,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1451,7 +1451,7 @@ should mount jamfCredentialsSecret.name when role is jamf:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1548,7 +1548,7 @@ should mount tls.existingCASecretName and set environment when set in values:
             value: cluster.local
           - name: SSL_CERT_FILE
             value: /etc/teleport-tls-ca/helm-lint-existing-tls-secret-key-name
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1647,7 +1647,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
             value: /etc/teleport-tls-ca/helm-lint-existing-tls-secret-key-name
           - name: HTTPS_PROXY
             value: http://username:password@my.proxy.host:3128
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1742,7 +1742,7 @@ should not add emptyDir for data when using StatefulSet:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1831,7 +1831,7 @@ should provision initContainer correctly when set in values:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -1976,7 +1976,7 @@ should set affinity when set in values:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -2063,7 +2063,7 @@ should set default serviceAccountName when not set in values:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -2163,7 +2163,7 @@ should set environment when extraEnv set in values:
             value: cluster.local
           - name: HTTPS_PROXY
             value: http://username:password@my.proxy.host:3128
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -2337,7 +2337,7 @@ should set imagePullPolicy when set in values:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 6
@@ -2424,7 +2424,7 @@ should set nodeSelector if set in values:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -2525,7 +2525,7 @@ should set preferred affinity when more than one replica is used:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -2612,7 +2612,7 @@ should set probeTimeoutSeconds when set in values:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -2709,7 +2709,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -2798,7 +2798,7 @@ should set resources when set in values:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -2892,7 +2892,7 @@ should set serviceAccountName when set in values:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -2979,7 +2979,7 @@ should set storage.requests when set in values and action is an Upgrade:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -3066,7 +3066,7 @@ should set storage.storageClassName when set in values and action is an Upgrade:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -3153,7 +3153,7 @@ should set tolerations when set in values:
             value: RELEASE-NAME
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-        image: public.ecr.aws/gravitational/teleport-distroless:18.0.0
+        image: public.ecr.aws/gravitational/teleport-distroless:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -27,7 +27,7 @@ sets the affinity:
           - --base-image=public.ecr.aws/gravitational/teleport-distroless
           - --version-server=https://my-custom-version-server/v1
           - --version-channel=custom/preview
-        image: public.ecr.aws/gravitational/teleport-kube-agent-updater:18.0.0
+        image: public.ecr.aws/gravitational/teleport-kube-agent-updater:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -75,7 +75,7 @@ sets the tolerations:
           - --base-image=public.ecr.aws/gravitational/teleport-distroless
           - --version-server=https://my-custom-version-server/v1
           - --version-channel=custom/preview
-        image: public.ecr.aws/gravitational/teleport-kube-agent-updater:18.0.0
+        image: public.ecr.aws/gravitational/teleport-kube-agent-updater:99.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -27,7 +27,7 @@ sets the affinity:
           - --base-image=public.ecr.aws/gravitational/teleport-distroless
           - --version-server=https://my-custom-version-server/v1
           - --version-channel=custom/preview
-        image: public.ecr.aws/gravitational/teleport-kube-agent-updater:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-kube-agent-updater:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -75,7 +75,7 @@ sets the tolerations:
           - --base-image=public.ecr.aws/gravitational/teleport-distroless
           - --version-server=https://my-custom-version-server/v1
           - --version-channel=custom/preview
-        image: public.ecr.aws/gravitational/teleport-kube-agent-updater:19.0.0-prealpha.2
+        image: public.ecr.aws/gravitational/teleport-kube-agent-updater:18.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/admin_clusterrolebinding_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/admin_clusterrolebinding_test.yaml
@@ -1,6 +1,10 @@
 suite: AdminClusterRoleBinding
 templates:
   - admin_clusterrolebinding.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: don't generate a admin cluster role binding when adminClusterRoleBinding.create is false
     asserts:

--- a/examples/chart/teleport-kube-agent/tests/admin_clusterrolebinding_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/admin_clusterrolebinding_test.yaml
@@ -3,8 +3,8 @@ templates:
   - admin_clusterrolebinding.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: don't generate a admin cluster role binding when adminClusterRoleBinding.create is false
     asserts:

--- a/examples/chart/teleport-kube-agent/tests/clusterrole_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/clusterrole_test.yaml
@@ -1,6 +1,10 @@
 suite: ClusterRole
 templates:
   - clusterrole.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: creates a ClusterRole
     asserts:

--- a/examples/chart/teleport-kube-agent/tests/clusterrole_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/clusterrole_test.yaml
@@ -3,8 +3,8 @@ templates:
   - clusterrole.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: creates a ClusterRole
     asserts:

--- a/examples/chart/teleport-kube-agent/tests/clusterrolebinding_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/clusterrolebinding_test.yaml
@@ -3,8 +3,8 @@ templates:
   - clusterrolebinding.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: creates a ClusterRoleBinding
     asserts:

--- a/examples/chart/teleport-kube-agent/tests/clusterrolebinding_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/clusterrolebinding_test.yaml
@@ -1,6 +1,10 @@
 suite: ClusterRoleBinding
 templates:
   - clusterrolebinding.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: creates a ClusterRoleBinding
     asserts:

--- a/examples/chart/teleport-kube-agent/tests/config_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/config_test.yaml
@@ -1,6 +1,10 @@
 suite: ConfigMap
 templates:
   - config.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: matches snapshot for affinity.yaml
     values:

--- a/examples/chart/teleport-kube-agent/tests/config_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/config_test.yaml
@@ -3,8 +3,8 @@ templates:
   - config.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: matches snapshot for affinity.yaml
     values:

--- a/examples/chart/teleport-kube-agent/tests/job_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/job_test.yaml
@@ -6,8 +6,8 @@ release:
   upgrade: true
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should not run deletion hook if skipHooks is set
     template: delete_hook.yaml

--- a/examples/chart/teleport-kube-agent/tests/job_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/job_test.yaml
@@ -4,6 +4,10 @@ templates:
 
 release:
   upgrade: true
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should not run deletion hook if skipHooks is set
     template: delete_hook.yaml

--- a/examples/chart/teleport-kube-agent/tests/pdb_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/pdb_test.yaml
@@ -3,8 +3,8 @@ templates:
   - pdb.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: should create a PDB when enabled in values (pdb.yaml)
     values:

--- a/examples/chart/teleport-kube-agent/tests/pdb_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/pdb_test.yaml
@@ -1,6 +1,10 @@
 suite: PodDisruptionBudget
 templates:
   - pdb.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: should create a PDB when enabled in values (pdb.yaml)
     values:

--- a/examples/chart/teleport-kube-agent/tests/podmonitor_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/podmonitor_test.yaml
@@ -3,8 +3,8 @@ templates:
   - podmonitor.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: does not create a PodMonitor by default
     set:

--- a/examples/chart/teleport-kube-agent/tests/podmonitor_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/podmonitor_test.yaml
@@ -1,6 +1,10 @@
 suite: PodMonitor
 templates:
   - podmonitor.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: does not create a PodMonitor by default
     set:

--- a/examples/chart/teleport-kube-agent/tests/psp_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/psp_test.yaml
@@ -3,8 +3,8 @@ templates:
   - psp.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: creates a PodSecurityPolicy when enabled in values and supported
     capabilities:

--- a/examples/chart/teleport-kube-agent/tests/psp_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/psp_test.yaml
@@ -1,6 +1,10 @@
 suite: PodSecurityPolicy
 templates:
   - psp.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: creates a PodSecurityPolicy when enabled in values and supported
     capabilities:

--- a/examples/chart/teleport-kube-agent/tests/role_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/role_test.yaml
@@ -3,8 +3,8 @@ templates:
   - role.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: Create a Role when upgrading
     release:

--- a/examples/chart/teleport-kube-agent/tests/role_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/role_test.yaml
@@ -1,6 +1,10 @@
 suite: Role
 templates:
   - role.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: Create a Role when upgrading
     release:

--- a/examples/chart/teleport-kube-agent/tests/rolebinding_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/rolebinding_test.yaml
@@ -3,8 +3,8 @@ templates:
   - rolebinding.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: Create a RoleBinding when upgrading
     release:

--- a/examples/chart/teleport-kube-agent/tests/rolebinding_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/rolebinding_test.yaml
@@ -1,6 +1,10 @@
 suite: RoleBinding
 templates:
   - rolebinding.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: Create a RoleBinding when upgrading
     release:

--- a/examples/chart/teleport-kube-agent/tests/secret_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/secret_test.yaml
@@ -1,6 +1,10 @@
 suite: Secret
 templates:
   - secret.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: generate a secret when neither authToken nor joinParams.tokenName are provided
     asserts:

--- a/examples/chart/teleport-kube-agent/tests/secret_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/secret_test.yaml
@@ -3,8 +3,8 @@ templates:
   - secret.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: generate a secret when neither authToken nor joinParams.tokenName are provided
     asserts:

--- a/examples/chart/teleport-kube-agent/tests/serviceaccount_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/serviceaccount_test.yaml
@@ -1,6 +1,10 @@
 suite: ServiceAccount
 templates:
   - serviceaccount.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: sets ServiceAccount labels when specified
     values:

--- a/examples/chart/teleport-kube-agent/tests/serviceaccount_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/serviceaccount_test.yaml
@@ -3,8 +3,8 @@ templates:
   - serviceaccount.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: sets ServiceAccount labels when specified
     values:

--- a/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
@@ -4,8 +4,8 @@ templates:
   - config.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: creates a StatefulSet
     template: statefulset.yaml

--- a/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
@@ -2,6 +2,10 @@ suite: StatefulSet
 templates:
   - statefulset.yaml
   - config.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: creates a StatefulSet
     template: statefulset.yaml

--- a/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
@@ -1,6 +1,10 @@
 suite: Updater Deployment
 templates:
   - updater.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   #
   # Basic tests

--- a/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
@@ -3,8 +3,8 @@ templates:
   - updater.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   #
   # Basic tests

--- a/examples/chart/teleport-kube-agent/tests/updater_role_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/updater_role_test.yaml
@@ -1,6 +1,10 @@
 suite: Updater Role
 templates:
   - updater.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   #
   # Basic tests

--- a/examples/chart/teleport-kube-agent/tests/updater_role_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/updater_role_test.yaml
@@ -3,8 +3,8 @@ templates:
   - updater.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   #
   # Basic tests

--- a/examples/chart/teleport-kube-agent/tests/updater_rolebinding_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/updater_rolebinding_test.yaml
@@ -1,6 +1,10 @@
 suite: Updater RoleBinding
 templates:
   - updater.yaml
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   #
   # Basic tests

--- a/examples/chart/teleport-kube-agent/tests/updater_rolebinding_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/updater_rolebinding_test.yaml
@@ -3,8 +3,8 @@ templates:
   - updater.yaml
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   #
   # Basic tests

--- a/examples/chart/teleport-relay/tests/configmap_test.yaml
+++ b/examples/chart/teleport-relay/tests/configmap_test.yaml
@@ -4,8 +4,8 @@ templates:
 
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: creates a config map
     values:

--- a/examples/chart/teleport-relay/tests/configmap_test.yaml
+++ b/examples/chart/teleport-relay/tests/configmap_test.yaml
@@ -2,6 +2,10 @@ suite: Test ConfigMap
 templates:
   - configmap.yaml
 
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: creates a config map
     values:

--- a/examples/chart/teleport-relay/tests/deployment_test.yaml
+++ b/examples/chart/teleport-relay/tests/deployment_test.yaml
@@ -5,8 +5,8 @@ templates:
 
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: creates a deployment
     template: deployment.yaml

--- a/examples/chart/teleport-relay/tests/deployment_test.yaml
+++ b/examples/chart/teleport-relay/tests/deployment_test.yaml
@@ -3,6 +3,10 @@ templates:
   - configmap.yaml
   - deployment.yaml
 
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: creates a deployment
     template: deployment.yaml

--- a/examples/chart/teleport-relay/tests/pdb_test.yaml
+++ b/examples/chart/teleport-relay/tests/pdb_test.yaml
@@ -2,6 +2,10 @@ suite: Test PodDisruptionBudget
 templates:
   - pdb.yaml
 
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: does not create a PDB by default
     asserts:

--- a/examples/chart/teleport-relay/tests/pdb_test.yaml
+++ b/examples/chart/teleport-relay/tests/pdb_test.yaml
@@ -4,8 +4,8 @@ templates:
 
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: does not create a PDB by default
     asserts:

--- a/examples/chart/teleport-relay/tests/secret_test.yaml
+++ b/examples/chart/teleport-relay/tests/secret_test.yaml
@@ -4,8 +4,8 @@ templates:
 
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: creates a secret by default
     set:

--- a/examples/chart/teleport-relay/tests/secret_test.yaml
+++ b/examples/chart/teleport-relay/tests/secret_test.yaml
@@ -2,6 +2,10 @@ suite: Test Secret
 templates:
   - secret.yaml
 
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: creates a secret by default
     set:

--- a/examples/chart/teleport-relay/tests/service_test.yaml
+++ b/examples/chart/teleport-relay/tests/service_test.yaml
@@ -4,8 +4,8 @@ templates:
 
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: creates a service
     asserts:

--- a/examples/chart/teleport-relay/tests/service_test.yaml
+++ b/examples/chart/teleport-relay/tests/service_test.yaml
@@ -2,6 +2,10 @@ suite: Test Service
 templates:
   - service.yaml
 
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: creates a service
     asserts:

--- a/examples/chart/teleport-relay/tests/serviceaccount_test.yaml
+++ b/examples/chart/teleport-relay/tests/serviceaccount_test.yaml
@@ -2,6 +2,10 @@ suite: Test ServiceAccount
 templates:
   - serviceaccount.yaml
 
+# Override chart version so snapshots are stable across releases.
+chart:
+  version: "18.0.0"
+  appVersion: "18.0.0"
 tests:
   - it: creates a service account by default
     asserts:

--- a/examples/chart/teleport-relay/tests/serviceaccount_test.yaml
+++ b/examples/chart/teleport-relay/tests/serviceaccount_test.yaml
@@ -4,8 +4,8 @@ templates:
 
 # Override chart version so snapshots are stable across releases.
 chart:
-  version: "18.0.0"
-  appVersion: "18.0.0"
+  version: "99.0.0"
+  appVersion: "99.0.0"
 tests:
   - it: creates a service account by default
     asserts:


### PR DESCRIPTION
Make helm unit tests use hard-coded version to avoid updating snapshots with each release.

Two benefits:
* Snapshot unit tests weren't effective when updating a release since we had to update rather than test against them. After this change they are validated.
* Backporting no longer requires a different version of the helm unittest plugin when different release branches use different versions, since we no longer need to run the `test-helm` or `test-helm-update-snapshots` make targets. Unit tests should pass in backport commits with only the version in `Chart.yaml` files updated, so they need not be run in the backporter's local environment.

## Manual Test Plan

### Test Environment

N/A - unit test change only.

### Test Cases

- [x] Make sure all changes are expected based on the version change. The command below should show only the diff commands because it greps out everything we expect to changes.

   ```
   git diff origin/master -- examples/chart \
    | grep -v \
    -e '^diff ' \
    -e '^index ' \
    -e '^+++ ' \
    -e '^--- ' \
    -e '^@@ ' \
    -e '^ ' \
    -e '^+# Override chart version so snapshots are stable across releases.' \
    -e '^+chart:' \
    -e '^+  version: "99.0.0"' \
    -e '^+  appVersion: "99.0.0"' \
    -e '^- .*19.0.0-prealpha.2' \
    -e '^+ .*99.0.0' \
    -e '^[+-] \s*checksum/config:' \
    -e '^-  .*majorVersion: "98"' \
    -e '^+  .*majorVersion: "18"' \
    -e '^+  .*v17' \
    -e '^-  .*v18' \
   ```