### PR TITLE
Fix Terraform scoped_token support for bot tokens.

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
@@ -50,13 +50,13 @@ Optional:
 
 Required:
 
-- `assigned_scope` (String) The scope to which this token is assigned.  Must be equivalent or descendent to the scope of the token itself.
 - `join_method` (String) The joining method required in order to use this token. Note that not all join methods support joining with scoped tokens.
 - `roles` (List of String) The list of roles associated with the token. They will be converted to metadata in the SSH and X509 certificates issued to the user of the token.
 - `usage_mode` (String) The usage mode of the token. Can be "single_use" or "unlimited". Single use tokens can only be used to provision a single resource. Unlimited tokens can be be used to provision any number of resources until it expires.
 
 Optional:
 
+- `assigned_scope` (String) The scope to which this token is assigned.  Must be equivalent or descendent to the scope of the token itself.
 - `aws` (Attributes) The AWS-specific configuration used with the "ec2" and "iam" join methods. (see [below for nested schema](#nested-schema-for-specaws))
 - `azure` (Attributes) The Azure-specific configuration used with the "azure" join method. (see [below for nested schema](#nested-schema-for-specazure))
 - `azure_devops` (Attributes) The Azure Devops-specific configuration used with the "azure_devops" join method. (see [below for nested schema](#nested-schema-for-specazure_devops))

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
@@ -94,13 +94,13 @@ Optional:
 
 Required:
 
-- `assigned_scope` (String) The scope to which this token is assigned.  Must be equivalent or descendent to the scope of the token itself.
 - `join_method` (String) The joining method required in order to use this token. Note that not all join methods support joining with scoped tokens.
 - `roles` (List of String) The list of roles associated with the token. They will be converted to metadata in the SSH and X509 certificates issued to the user of the token.
 - `usage_mode` (String) The usage mode of the token. Can be "single_use" or "unlimited". Single use tokens can only be used to provision a single resource. Unlimited tokens can be be used to provision any number of resources until it expires.
 
 Optional:
 
+- `assigned_scope` (String) The scope to which this token is assigned.  Must be equivalent or descendent to the scope of the token itself.
 - `aws` (Attributes) The AWS-specific configuration used with the "ec2" and "iam" join methods. (see [below for nested schema](#nested-schema-for-specaws))
 - `azure` (Attributes) The Azure-specific configuration used with the "azure" join method. (see [below for nested schema](#nested-schema-for-specazure))
 - `azure_devops` (Attributes) The Azure Devops-specific configuration used with the "azure_devops" join method. (see [below for nested schema](#nested-schema-for-specazure_devops))

--- a/integrations/terraform/protoc-gen-terraform-scopedtoken.yaml
+++ b/integrations/terraform/protoc-gen-terraform-scopedtoken.yaml
@@ -50,7 +50,6 @@ required_fields:
   - "ScopedToken.version"
   - "ScopedToken.scope"
   - "ScopedToken.spec"
-  - "ScopedToken.spec.assigned_scope"
   - "ScopedToken.spec.join_method"
   - "ScopedToken.spec.roles"
   - "ScopedToken.spec.usage_mode"

--- a/integrations/terraform/testlib/fixtures/scoped_token_bot_0_create.tf
+++ b/integrations/terraform/testlib/fixtures/scoped_token_bot_0_create.tf
@@ -1,0 +1,22 @@
+resource "teleport_scoped_token" "test" {
+  version = "v1"
+  metadata = {
+    name = "test-bot-scoped-token"
+  }
+  scope = "/staging/aa"
+  spec = {
+    bot         = "/staging/aa::server-enroller"
+    join_method = "kubernetes"
+    kubernetes = {
+      allow = [
+        { service_account_name = "pod-sa", service_account_namespace = "default" }
+      ]
+      oidc = {
+        issuer = "https://container.googleapis.com/v1/projects/my-project/locations/us-central1-a/clusters/my-cluster-name"
+      }
+      type = "oidc"
+    }
+    roles      = ["Bot"]
+    usage_mode = "bot"
+  }
+}

--- a/integrations/terraform/testlib/scoped_token_test.go
+++ b/integrations/terraform/testlib/scoped_token_test.go
@@ -84,6 +84,46 @@ func (s *TerraformSuiteOSS) TestScopedToken() {
 	})
 }
 
+func (s *TerraformSuiteOSS) TestScopedTokenBot() {
+	t := s.T()
+	ctx := t.Context()
+
+	checkDestroyed := func(state *terraform.State) error {
+		_, err := s.client.GetScopedToken(ctx, joiningv1.GetScopedTokenRequest_builder{
+			Name:  "test-bot-scoped-token",
+			Scope: "/staging/aa",
+		}.Build())
+		if !trace.IsNotFound(err) {
+			return trace.Errorf("expected not found, actual: %v", err)
+		}
+		return nil
+	}
+
+	name := "teleport_scoped_token.test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		CheckDestroy:             checkDestroyed,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("scoped_token_bot_0_create.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", types.KindScopedToken),
+					resource.TestCheckResourceAttr(name, "scope", "/staging/aa"),
+					resource.TestCheckResourceAttr(name, "spec.join_method", "kubernetes"),
+					resource.TestCheckResourceAttr(name, "spec.roles.0", "Bot"),
+					resource.TestCheckResourceAttr(name, "spec.usage_mode", "bot"),
+				),
+			},
+			{
+				Config:   s.getFixture("scoped_token_bot_0_create.tf"),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func (s *TerraformSuiteOSS) TestImportScopedToken() {
 	t := s.T()
 	ctx := t.Context()

--- a/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
+++ b/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
@@ -105,7 +105,7 @@ func GenSchemaScopedToken(ctx context.Context) (github_com_hashicorp_terraform_p
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				"assigned_scope": {
 					Description: "The scope to which this token is assigned.  Must be equivalent or descendent to the scope of the token itself.",
-					Required:    true,
+					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"aws": {


### PR DESCRIPTION
Terraform was previously requiring the `spec.assigned_scope` field. This field is only required when creating an agent token. Bot tokens must have an empty `spec.assigned_scope` field.

Changelog: Fixed a Terraform `scoped_token` bug where `spec.assigned_scope` was required for bot tokens. 


## Manual Test Plan
### Test Environment

- scoped staging tenant

### Test Cases
- [x] Can create scoped token for bots
