### PR TITLE
Fix yum 404 when running in rocky or alma linux

### DIFF
--- a/lib/web/scripts/install/install.sh
+++ b/lib/web/scripts/install/install.sh
@@ -334,10 +334,14 @@ install_teleport() {
     install_via_apt_get
     ;;
   # if ID is amazon Linux 2/RHEL/etc, run yum
-  centos | rhel | rocky | almalinux | amzn)
+  centos | rhel | amzn)
     install_via_yum "$ID"
     ;;
-  sles)
+  # if rocky or alma, run yum with literal rhel
+  rocky | almalinux)
+    install_via_yum "rhel"
+    ;;
+sles)
     install_via_zypper
     ;;
   *)


### PR DESCRIPTION
Use `rhel` for rocky linux and alma linux. Neither the `rocky` nor `almalinux` ID have a dedicated yum repo path, and should use `rhel` literally.


## Manual Test Plan
### Test Environment

### Test Cases
- [x] Run script on rocky/alma linux.