### PR TITLE
Increase ACL lock release timeout

### DIFF
--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -74,6 +74,15 @@ const (
 	// consistency of the one-to-many relationship between them.
 	accessListLockTTL = 5 * time.Second
 
+	// accessListLockReleaseTimeout bounds the time spent releasing the lock at the
+	// end of a locked access list operation. It is raised above the default 1 second
+	// because the access list flow performs nested locking, and under heavy database
+	// load (CI/stress test) the default timeout may be exceeded during lock release.
+	// It must stay below accessListLockTTL/2 (2.5s): the lock refresher is stopped
+	// before release, so remaining lock ownership can be as short as TTL/2, and a
+	// release that outlives ownership could delete a lock acquired by another writer.
+	accessListLockReleaseTimeout = 2*time.Second + 300*time.Millisecond
+
 	// createAccessListLimitLockName is the lock used to prevent simultaneous
 	// creation or update of AccessLists in order to enforce the license limit
 	// on the number AccessLists in a cluster.
@@ -321,42 +330,45 @@ func NewAccessListServiceV2(cfg AccessListServiceConfig) (*AccessListService, er
 	}
 
 	service, err := generic.NewScopeAwareService(&generic.ScopeAwareServiceConfig[*accesslist.AccessList]{
-		Backend:                     cfg.Backend,
-		PageLimit:                   accessListMaxPageSize,
-		ResourceKind:                types.KindAccessList,
-		UnscopedBackendPrefix:       backend.NewKey(accessListPrefix),
-		ScopedBackendPrefix:         backend.NewKey(scopedPrefix, accessListPrefix),
-		MarshalFunc:                 services.MarshalAccessList,
-		UnmarshalFunc:               services.UnmarshalAccessList,
-		RunWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
+		Backend:                      cfg.Backend,
+		PageLimit:                    accessListMaxPageSize,
+		ResourceKind:                 types.KindAccessList,
+		UnscopedBackendPrefix:        backend.NewKey(accessListPrefix),
+		ScopedBackendPrefix:          backend.NewKey(scopedPrefix, accessListPrefix),
+		MarshalFunc:                  services.MarshalAccessList,
+		UnmarshalFunc:                services.UnmarshalAccessList,
+		RunWhileLockedRetryInterval:  cfg.RunWhileLockedRetryInterval,
+		RunWhileLockedReleaseTimeout: accessListLockReleaseTimeout,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	memberService, err := generic.NewScopeAwareService(&generic.ScopeAwareServiceConfig[*accesslist.AccessListMember]{
-		Backend:                     cfg.Backend,
-		PageLimit:                   accessListMemberMaxPageSize,
-		ResourceKind:                types.KindAccessListMember,
-		UnscopedBackendPrefix:       backend.NewKey(accessListMemberPrefix),
-		ScopedBackendPrefix:         backend.NewKey(scopedPrefix, accessListMemberPrefix),
-		MarshalFunc:                 services.MarshalAccessListMember,
-		UnmarshalFunc:               services.UnmarshalAccessListMember,
-		RunWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
+		Backend:                      cfg.Backend,
+		PageLimit:                    accessListMemberMaxPageSize,
+		ResourceKind:                 types.KindAccessListMember,
+		UnscopedBackendPrefix:        backend.NewKey(accessListMemberPrefix),
+		ScopedBackendPrefix:          backend.NewKey(scopedPrefix, accessListMemberPrefix),
+		MarshalFunc:                  services.MarshalAccessListMember,
+		UnmarshalFunc:                services.UnmarshalAccessListMember,
+		RunWhileLockedRetryInterval:  cfg.RunWhileLockedRetryInterval,
+		RunWhileLockedReleaseTimeout: accessListLockReleaseTimeout,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	reviewService, err := generic.NewScopeAwareService(&generic.ScopeAwareServiceConfig[*accesslist.Review]{
-		Backend:                     cfg.Backend,
-		PageLimit:                   accessListReviewMaxPageSize,
-		ResourceKind:                types.KindAccessListReview,
-		UnscopedBackendPrefix:       backend.NewKey(accessListReviewPrefix),
-		ScopedBackendPrefix:         backend.NewKey(scopedPrefix, accessListReviewPrefix),
-		MarshalFunc:                 services.MarshalAccessListReview,
-		UnmarshalFunc:               services.UnmarshalAccessListReview,
-		RunWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
+		Backend:                      cfg.Backend,
+		PageLimit:                    accessListReviewMaxPageSize,
+		ResourceKind:                 types.KindAccessListReview,
+		UnscopedBackendPrefix:        backend.NewKey(accessListReviewPrefix),
+		ScopedBackendPrefix:          backend.NewKey(scopedPrefix, accessListReviewPrefix),
+		MarshalFunc:                  services.MarshalAccessListReview,
+		UnmarshalFunc:                services.UnmarshalAccessListReview,
+		RunWhileLockedRetryInterval:  cfg.RunWhileLockedRetryInterval,
+		RunWhileLockedReleaseTimeout: accessListLockReleaseTimeout,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/local/generic/scopeaware.go
+++ b/lib/services/local/generic/scopeaware.go
@@ -58,8 +58,9 @@ type ScopeAwareService[T ScopedResource] struct {
 	// Resources will be keyed at <scoped_prefix>/<backend_prefix>/<encoded_scope>/<name>
 	ScopedService *Service[T]
 
-	backend                     backend.Backend
-	runWhileLockedRetryInterval time.Duration
+	backend                      backend.Backend
+	runWhileLockedRetryInterval  time.Duration
+	runWhileLockedReleaseTimeout time.Duration
 }
 
 // ScopeAwareServiceConfig holds configuration options for ScopeAwareService.
@@ -88,6 +89,10 @@ type ScopeAwareServiceConfig[T ScopedResource] struct {
 	// If set to 0, the default interval of 250ms will be used.
 	// WARNING: If set to a negative value, the RunWhileLocked function will retry immediately.
 	RunWhileLockedRetryInterval time.Duration
+	// RunWhileLockedReleaseTimeout is the timeout for releasing the backend lock
+	// at the end of the RunWhileLocked function. If set to 0, the default timeout
+	// of 1s will be used.
+	RunWhileLockedReleaseTimeout time.Duration
 }
 
 // NewScopeAwareService returns a new scope-aware service.
@@ -132,10 +137,11 @@ func NewScopeAwareService[T ScopedResource](cfg *ScopeAwareServiceConfig[T]) (*S
 	}
 
 	return &ScopeAwareService[T]{
-		UnscopedService:             unscopedService,
-		ScopedService:               scopedService,
-		backend:                     cfg.Backend,
-		runWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
+		UnscopedService:              unscopedService,
+		ScopedService:                scopedService,
+		backend:                      cfg.Backend,
+		runWhileLockedRetryInterval:  cfg.RunWhileLockedRetryInterval,
+		runWhileLockedReleaseTimeout: cfg.RunWhileLockedReleaseTimeout,
 	}, nil
 }
 
@@ -397,6 +403,7 @@ func (s *ScopeAwareService[T]) RunWhileLocked(ctx context.Context, lockNameCompo
 				TTL:                ttl,
 				RetryInterval:      s.runWhileLockedRetryInterval,
 			},
+			ReleaseCtxTimeout: s.runWhileLockedReleaseTimeout,
 		}, func(ctx context.Context) error {
 			return fn(ctx, s.backend)
 		}))


### PR DESCRIPTION
### What


- Add ability to set runWhileLockedReleaseTimeout in  local service 
- Increase runWhileLockedReleaseTimeout from 1s to 2.3s  (below TTL) for the access list flow. 


### Why

Low lock release timeout value is know issue and manly affects CI - stress test flow  see: https://github.com/gravitational/teleport/pull/31729


This also address the https://github.com/gravitational/teleport.e/issues/9179 flaky test. 


### Can we return `nil` on context cancelation flow instead or error ?

 https://github.com/gravitational/teleport.e/issues/9179#issuecomment-5093225087
 
This is a more intrusive solution because it requires special handling for access list locking and undrestending from where lock is called. I think the locking flow should remain simple and predictable. Even if the main operation completes successfully, we should still return an error if releasing the lock fails.

Otherwise, if a lock is introduced in the middle of the flow in the future this special-case behavior could hide real issues and lead to bugs.



### Manual Test: 

- [x]  `go test -c -o flaky.test; stress -p 100 -count 1000 -failfast ./flaky.test -test.run="TestAdminActionMFA"`

          ```
          14m5s: 903 runs so far, 0 failures, 100 active
          14m10s: 910 runs so far, 0 failures, 100 active
          14m15s: 920 runs so far, 0 failures, 100 active
          14m20s: 999 runs so far, 0 failures, 100 active
          14m25s: 1003 runs so far, 0 failures, 100 active
          ```

