### PR TITLE
Add configurable automatic review resolution reasons

### DIFF
--- a/api/gen/proto/go/teleport/accessmonitoringrules/v1/access_monitoring_rules_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/accessmonitoringrules/v1/access_monitoring_rules_protohybrid.pb.go
@@ -474,6 +474,7 @@ type AutomaticReview struct {
 	// decision specifies the proposed state of the access review. This can be
 	// either 'APPROVED' or 'DENIED'.
 	Decision      string `protobuf:"bytes,2,opt,name=decision,proto3" json:"decision,omitempty"`
+	Reason        string `protobuf:"bytes,3,opt,name=reason,proto3" json:"reason,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -517,12 +518,23 @@ func (x *AutomaticReview) GetDecision() string {
 	return ""
 }
 
+func (x *AutomaticReview) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
 func (x *AutomaticReview) SetIntegration(v string) {
 	x.Integration = v
 }
 
 func (x *AutomaticReview) SetDecision(v string) {
 	x.Decision = v
+}
+
+func (x *AutomaticReview) SetReason(v string) {
+	x.Reason = v
 }
 
 type AutomaticReview_builder struct {
@@ -534,6 +546,7 @@ type AutomaticReview_builder struct {
 	// decision specifies the proposed state of the access review. This can be
 	// either 'APPROVED' or 'DENIED'.
 	Decision string
+	Reason   string
 }
 
 func (b0 AutomaticReview_builder) Build() *AutomaticReview {
@@ -542,6 +555,7 @@ func (b0 AutomaticReview_builder) Build() *AutomaticReview {
 	_, _ = b, x
 	x.Integration = b.Integration
 	x.Decision = b.Decision
+	x.Reason = b.Reason
 	return m0
 }
 
@@ -1515,10 +1529,11 @@ const file_teleport_accessmonitoringrules_v1_access_monitoring_rules_proto_rawDe
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1e\n" +
 	"\n" +
 	"recipients\x18\x02 \x03(\tR\n" +
-	"recipients\"O\n" +
+	"recipients\"g\n" +
 	"\x0fAutomaticReview\x12 \n" +
 	"\vintegration\x18\x01 \x01(\tR\vintegration\x12\x1a\n" +
-	"\bdecision\x18\x02 \x01(\tR\bdecision\"O\n" +
+	"\bdecision\x18\x02 \x01(\tR\bdecision\x12\x16\n" +
+	"\x06reason\x18\x03 \x01(\tR\x06reason\"O\n" +
 	"\bSchedule\x12C\n" +
 	"\x04time\x18\x01 \x01(\v2/.teleport.accessmonitoringrules.v1.TimeScheduleR\x04time\"\xc4\x01\n" +
 	"\fTimeSchedule\x12M\n" +

--- a/api/gen/proto/go/teleport/accessmonitoringrules/v1/access_monitoring_rules_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/accessmonitoringrules/v1/access_monitoring_rules_protohybrid.pb.go
@@ -473,7 +473,9 @@ type AutomaticReview struct {
 	Integration string `protobuf:"bytes,1,opt,name=integration,proto3" json:"integration,omitempty"`
 	// decision specifies the proposed state of the access review. This can be
 	// either 'APPROVED' or 'DENIED'.
-	Decision      string `protobuf:"bytes,2,opt,name=decision,proto3" json:"decision,omitempty"`
+	Decision string `protobuf:"bytes,2,opt,name=decision,proto3" json:"decision,omitempty"`
+	// reason specifies a reason for the review decision. This field is optional and if
+	// it is not supplied, a generic reason will be applied to reviews.
 	Reason        string `protobuf:"bytes,3,opt,name=reason,proto3" json:"reason,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -546,7 +548,9 @@ type AutomaticReview_builder struct {
 	// decision specifies the proposed state of the access review. This can be
 	// either 'APPROVED' or 'DENIED'.
 	Decision string
-	Reason   string
+	// reason specifies a reason for the review decision. This field is optional and if
+	// it is not supplied, a generic reason will be applied to reviews.
+	Reason string
 }
 
 func (b0 AutomaticReview_builder) Build() *AutomaticReview {

--- a/api/gen/proto/go/teleport/accessmonitoringrules/v1/access_monitoring_rules_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/accessmonitoringrules/v1/access_monitoring_rules_protoopaque.pb.go
@@ -442,6 +442,7 @@ type AutomaticReview struct {
 	state                  protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_Integration string                 `protobuf:"bytes,1,opt,name=integration,proto3"`
 	xxx_hidden_Decision    string                 `protobuf:"bytes,2,opt,name=decision,proto3"`
+	xxx_hidden_Reason      string                 `protobuf:"bytes,3,opt,name=reason,proto3"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
@@ -485,12 +486,23 @@ func (x *AutomaticReview) GetDecision() string {
 	return ""
 }
 
+func (x *AutomaticReview) GetReason() string {
+	if x != nil {
+		return x.xxx_hidden_Reason
+	}
+	return ""
+}
+
 func (x *AutomaticReview) SetIntegration(v string) {
 	x.xxx_hidden_Integration = v
 }
 
 func (x *AutomaticReview) SetDecision(v string) {
 	x.xxx_hidden_Decision = v
+}
+
+func (x *AutomaticReview) SetReason(v string) {
+	x.xxx_hidden_Reason = v
 }
 
 type AutomaticReview_builder struct {
@@ -502,6 +514,7 @@ type AutomaticReview_builder struct {
 	// decision specifies the proposed state of the access review. This can be
 	// either 'APPROVED' or 'DENIED'.
 	Decision string
+	Reason   string
 }
 
 func (b0 AutomaticReview_builder) Build() *AutomaticReview {
@@ -510,6 +523,7 @@ func (b0 AutomaticReview_builder) Build() *AutomaticReview {
 	_, _ = b, x
 	x.xxx_hidden_Integration = b.Integration
 	x.xxx_hidden_Decision = b.Decision
+	x.xxx_hidden_Reason = b.Reason
 	return m0
 }
 
@@ -1457,10 +1471,11 @@ const file_teleport_accessmonitoringrules_v1_access_monitoring_rules_proto_rawDe
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1e\n" +
 	"\n" +
 	"recipients\x18\x02 \x03(\tR\n" +
-	"recipients\"O\n" +
+	"recipients\"g\n" +
 	"\x0fAutomaticReview\x12 \n" +
 	"\vintegration\x18\x01 \x01(\tR\vintegration\x12\x1a\n" +
-	"\bdecision\x18\x02 \x01(\tR\bdecision\"O\n" +
+	"\bdecision\x18\x02 \x01(\tR\bdecision\x12\x16\n" +
+	"\x06reason\x18\x03 \x01(\tR\x06reason\"O\n" +
 	"\bSchedule\x12C\n" +
 	"\x04time\x18\x01 \x01(\v2/.teleport.accessmonitoringrules.v1.TimeScheduleR\x04time\"\xc4\x01\n" +
 	"\fTimeSchedule\x12M\n" +

--- a/api/gen/proto/go/teleport/accessmonitoringrules/v1/access_monitoring_rules_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/accessmonitoringrules/v1/access_monitoring_rules_protoopaque.pb.go
@@ -514,7 +514,9 @@ type AutomaticReview_builder struct {
 	// decision specifies the proposed state of the access review. This can be
 	// either 'APPROVED' or 'DENIED'.
 	Decision string
-	Reason   string
+	// reason specifies a reason for the review decision. This field is optional and if
+	// it is not supplied, a generic reason will be applied to reviews.
+	Reason string
 }
 
 func (b0 AutomaticReview_builder) Build() *AutomaticReview {

--- a/api/proto/teleport/accessmonitoringrules/v1/access_monitoring_rules.proto
+++ b/api/proto/teleport/accessmonitoringrules/v1/access_monitoring_rules.proto
@@ -89,6 +89,9 @@ message AutomaticReview {
   // decision specifies the proposed state of the access review. This can be
   // either 'APPROVED' or 'DENIED'.
   string decision = 2;
+  // reason specifies a reason for the review decision. This field is optional and if
+  // it is not supplied, a generic reason will be applied to reviews.
+  string reason = 3;
 }
 
 // Schedule specifies a schedule that can be used to configure rule conditions.

--- a/docs/pages/reference/access-controls/access-monitoring-rules.mdx
+++ b/docs/pages/reference/access-controls/access-monitoring-rules.mdx
@@ -62,6 +62,11 @@ spec:
     # Possible values: "APPROVED" or "DENIED"
     decision: APPROVED
 
+    # Optional: reason is text explaining the reasoning for this review.
+    # If the review resolves the request, it becomes the request's resolution reason.
+    # If omitted, Teleport generates a default automatic-review reason.
+    reason: "Access is denied outside the scheduled maintenance window."
+
   # Optional: notification configures notification routing rules.
   notification:
     # name specifies the external integration to which the notifications should
@@ -178,6 +183,14 @@ state of the request and respect the required review thresholds.
 If multiple automatic review rules match an Access Request, `DENIED` rules take
 precedence.
 
+### Review reason
+
+The `automatic_review.reason` field is an optional text field which allows specifying
+the resolution reason that will be stored on the request if this automatic review
+resolves the request.
+
+If no value is specified, a generic default reason will be used.
+
 ### Example automatic review rule
 
 If the following rule is configured, then any time an Access Request for the
@@ -199,6 +212,7 @@ spec:
   automatic_review:
     integration: builtin
     decision: APPROVED
+    reason: "User is on the SRE team."
 ```
 
 ### Example automatic review rule for resources

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accessmonitoringrulesv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accessmonitoringrulesv1.mdx
@@ -44,6 +44,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |---|---|---|
 |decision|string|decision specifies the proposed state of the access review. This can be either 'APPROVED' or 'DENIED'.|
 |integration|string|integration is the name of the integration that is responsible for monitoring the rule. Set this value to `builtin` to monitor the rule with Teleport.|
+|reason|string|reason specifies a reason for the review decision. This field is optional and if it is not supplied, a generic reason will be applied to reviews.|
 
 ### spec.notification
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_monitoring_rule.mdx
@@ -53,6 +53,7 @@ Optional:
 
 - `decision` (String) decision specifies the proposed state of the access review. This can be either 'APPROVED' or 'DENIED'.
 - `integration` (String) integration is the name of the integration that is responsible for monitoring the rule. Set this value to `builtin` to monitor the rule with Teleport.
+- `reason` (String) reason specifies a reason for the review decision. This field is optional and if it is not supplied, a generic reason will be applied to reviews.
 
 
 ### Nested Schema for `spec.notification`

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_monitoring_rule.mdx
@@ -101,6 +101,7 @@ Optional:
 
 - `decision` (String) decision specifies the proposed state of the access review. This can be either 'APPROVED' or 'DENIED'.
 - `integration` (String) integration is the name of the integration that is responsible for monitoring the rule. Set this value to `builtin` to monitor the rule with Teleport.
+- `reason` (String) reason specifies a reason for the review decision. This field is optional and if it is not supplied, a generic reason will be applied to reviews.
 
 
 ### Nested Schema for `spec.notification`

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accessmonitoringrulesv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accessmonitoringrulesv1.yaml
@@ -55,6 +55,11 @@ spec:
                       responsible for monitoring the rule. Set this value to `builtin`
                       to monitor the rule with Teleport.
                     type: string
+                  reason:
+                    description: reason specifies a reason for the review decision.
+                      This field is optional and if it is not supplied, a generic
+                      reason will be applied to reviews.
+                    type: string
                 type: object
               condition:
                 description: condition is a predicate expression that operates on

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_accessmonitoringrulesv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_accessmonitoringrulesv1.yaml
@@ -55,6 +55,11 @@ spec:
                       responsible for monitoring the rule. Set this value to `builtin`
                       to monitor the rule with Teleport.
                     type: string
+                  reason:
+                    description: reason specifies a reason for the review decision.
+                      This field is optional and if it is not supplied, a generic
+                      reason will be applied to reviews.
+                    type: string
                 type: object
               condition:
                 description: condition is a predicate expression that operates on

--- a/integrations/terraform/tfschema/accessmonitoringrules/v1/access_monitoring_rules_terraform.go
+++ b/integrations/terraform/tfschema/accessmonitoringrules/v1/access_monitoring_rules_terraform.go
@@ -113,6 +113,11 @@ func GenSchemaAccessMonitoringRule(ctx context.Context) (github_com_hashicorp_te
 							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 							Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
+						"reason": {
+							Description: "reason specifies a reason for the review decision. This field is optional and if it is not supplied, a generic reason will be applied to reviews.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
 					}),
 					Description: "automatic_review defines automatic review configurations for Access Requests. Both notification and automatic_review may be set within the same access_monitoring_rule. If both fields are set, the rule will trigger both notifications and automatic reviews for the same set of access events. Separate plugins may be used if both notifications and automatic_reviews is set.",
 					Optional:    true,
@@ -579,6 +584,23 @@ func CopyAccessMonitoringRuleFromTerraform(_ context.Context, tf github_com_hash
 													t = string(v.Value)
 												}
 												obj.Decision = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["reason"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"AccessMonitoringRule.spec.automatic_review.reason"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"AccessMonitoringRule.spec.automatic_review.reason", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.Reason = t
 											}
 										}
 									}
@@ -1418,6 +1440,28 @@ func CopyAccessMonitoringRuleToTerraformPreserveUnknown(ctx context.Context, obj
 												v.Unknown = false
 											}
 											tf.Attrs["decision"] = v
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["reason"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"AccessMonitoringRule.spec.automatic_review.reason"})
+										} else {
+											v, ok := tf.Attrs["reason"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"AccessMonitoringRule.spec.automatic_review.reason", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"AccessMonitoringRule.spec.automatic_review.reason", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.Reason) == ""
+											}
+											v.Value = string(obj.Reason)
+											v.Unknown = false
+											tf.Attrs["reason"] = v
 										}
 									}
 								}

--- a/integrations/terraform/tfschema/accessmonitoringrules/v1/access_monitoring_rules_terraform.go
+++ b/integrations/terraform/tfschema/accessmonitoringrules/v1/access_monitoring_rules_terraform.go
@@ -114,9 +114,11 @@ func GenSchemaAccessMonitoringRule(ctx context.Context) (github_com_hashicorp_te
 							Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 						"reason": {
-							Description: "reason specifies a reason for the review decision. This field is optional and if it is not supplied, a generic reason will be applied to reviews.",
-							Optional:    true,
-							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+							Computed:      true,
+							Description:   "reason specifies a reason for the review decision. This field is optional and if it is not supplied, a generic reason will be applied to reviews.",
+							Optional:      true,
+							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+							Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 					}),
 					Description: "automatic_review defines automatic review configurations for Access Requests. Both notification and automatic_review may be set within the same access_monitoring_rule. If both fields are set, the rule will trigger both notifications and automatic reviews for the same set of access events. Separate plugins may be used if both notifications and automatic_reviews is set.",
@@ -1449,6 +1451,9 @@ func CopyAccessMonitoringRuleToTerraformPreserveUnknown(ctx context.Context, obj
 										} else {
 											v, ok := tf.Attrs["reason"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 											if !ok {
+												if tf.Attrs["reason"] != nil {
+													diags.Append(attrWriteUnexpectedExistingTypeDiag{"AccessMonitoringRule.spec.automatic_review.reason", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
 												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 												if err != nil {
 													diags.Append(attrWriteGeneralError{"AccessMonitoringRule.spec.automatic_review.reason", err})
@@ -1457,10 +1462,13 @@ func CopyAccessMonitoringRuleToTerraformPreserveUnknown(ctx context.Context, obj
 												if !ok {
 													diags.Append(attrWriteConversionFailureDiag{"AccessMonitoringRule.spec.automatic_review.reason", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 												}
-												v.Null = string(obj.Reason) == ""
 											}
+
+											v.Null = false
 											v.Value = string(obj.Reason)
-											v.Unknown = false
+											if !preserveUnknown {
+												v.Unknown = false
+											}
 											tf.Attrs["reason"] = v
 										}
 									}

--- a/lib/accessmonitoring/review/review.go
+++ b/lib/accessmonitoring/review/review.go
@@ -209,6 +209,7 @@ func (handler *Handler) onPendingRequest(ctx context.Context, req types.AccessRe
 		req.GetUser(),
 		reviewRule.GetMetadata().GetName(),
 		reviewRule.GetSpec().GetAutomaticReview().GetDecision(),
+		reviewRule.GetSpec().GetAutomaticReview().GetReason(),
 		time.Now(),
 	)
 	if err != nil {
@@ -253,7 +254,7 @@ func (handler *Handler) getMatchingRule(
 	return reviewRule
 }
 
-func newAccessReview(userName, ruleName, state string, created time.Time) (types.AccessReview, error) {
+func newAccessReview(userName, ruleName, state, reason string, created time.Time) (types.AccessReview, error) {
 	var proposedState types.RequestState
 	switch state {
 	case types.RequestState_APPROVED.String():
@@ -264,13 +265,18 @@ func newAccessReview(userName, ruleName, state string, created time.Time) (types
 		return types.AccessReview{}, trace.BadParameter("proposed state is unsupported: %s", state)
 	}
 
+	reviewReason := reason
+	if reviewReason == "" {
+		reviewReason = fmt.Sprintf("Access request has been automatically %[4]s by %[1]q. "+
+			"User %[2]q is %[4]s by access_monitoring_rule %[3]q.",
+			teleport.SystemAccessApproverUserName, userName, ruleName, strings.ToLower(state))
+	}
+
 	return types.AccessReview{
 		Author:        teleport.SystemAccessApproverUserName,
 		ProposedState: proposedState,
-		Reason: fmt.Sprintf("Access request has been automatically %[4]s by %[1]q. "+
-			"User %[2]q is %[4]s by access_monitoring_rule %[3]q.",
-			teleport.SystemAccessApproverUserName, userName, ruleName, strings.ToLower(state)),
-		Created: created,
+		Reason:        reviewReason,
+		Created:       created,
 	}, nil
 }
 

--- a/lib/accessmonitoring/review/review.go
+++ b/lib/accessmonitoring/review/review.go
@@ -265,9 +265,8 @@ func newAccessReview(userName, ruleName, state, reason string, created time.Time
 		return types.AccessReview{}, trace.BadParameter("proposed state is unsupported: %s", state)
 	}
 
-	reviewReason := reason
-	if reviewReason == "" {
-		reviewReason = fmt.Sprintf("Access request has been automatically %[4]s by %[1]q. "+
+	if reason == "" {
+		reason = fmt.Sprintf("Access request has been automatically %[4]s by %[1]q. "+
 			"User %[2]q is %[4]s by access_monitoring_rule %[3]q.",
 			teleport.SystemAccessApproverUserName, userName, ruleName, strings.ToLower(state))
 	}
@@ -275,7 +274,7 @@ func newAccessReview(userName, ruleName, state, reason string, created time.Time
 	return types.AccessReview{
 		Author:        teleport.SystemAccessApproverUserName,
 		ProposedState: proposedState,
-		Reason:        reviewReason,
+		Reason:        reason,
 		Created:       created,
 	}, nil
 }

--- a/lib/accessmonitoring/review/review_test.go
+++ b/lib/accessmonitoring/review/review_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/gravitational/teleport"
 	pb "github.com/gravitational/teleport/api/client/proto"
 	accessmonitoringrulesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
@@ -63,7 +64,7 @@ func TestInitializeCache(t *testing.T) {
 	}.Build()
 
 	mockResp := []*accessmonitoringrulesv1.AccessMonitoringRule{
-		newApprovedRule("test-rule", "condition"),
+		newApprovedRule("test-rule", "condition", ""),
 	}
 
 	mockClient.On("ListAccessMonitoringRulesWithFilter", mock.Anything, mockReq).
@@ -93,7 +94,7 @@ func TestHandleAccessMonitoringRule(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test add rule.
-	rule := newApprovedRule("test-rule", `condition`)
+	rule := newApprovedRule("test-rule", `condition`, "")
 	require.NoError(t, handler.HandleAccessMonitoringRule(ctx, types.Event{
 		Type:     types.OpPut,
 		Resource: types.Resource153ToResourceWithLabels(rule),
@@ -102,7 +103,7 @@ func TestHandleAccessMonitoringRule(t *testing.T) {
 	require.True(t, proto.Equal(rule, cache.Get()[0]))
 
 	// Test update rule.
-	rule = newApprovedRule("test-rule", `condition-updated`)
+	rule = newApprovedRule("test-rule", `condition-updated`, "")
 	require.NoError(t, handler.HandleAccessMonitoringRule(ctx, types.Event{
 		Type:     types.OpPut,
 		Resource: types.Resource153ToResourceWithLabels(rule),
@@ -118,7 +119,7 @@ func TestHandleAccessMonitoringRule(t *testing.T) {
 	require.Empty(t, cache.Get())
 
 	// Test rule does not apply with invalid automatic approval name.
-	rule = newApprovedRule("test-rule", `condition`)
+	rule = newApprovedRule("test-rule", `condition`, "")
 	rule.GetSpec().GetAutomaticReview().SetIntegration("invalid")
 	require.NoError(t, handler.HandleAccessMonitoringRule(ctx, types.Event{
 		Type:     types.OpPut,
@@ -127,7 +128,7 @@ func TestHandleAccessMonitoringRule(t *testing.T) {
 	require.Empty(t, cache.Get())
 
 	// Test rule does not apply with invalid state.
-	rule = newApprovedRule("test-rule", `condition`)
+	rule = newApprovedRule("test-rule", `condition`, "")
 	rule.GetSpec().SetDesiredState("invalid")
 	require.NoError(t, handler.HandleAccessMonitoringRule(ctx, types.Event{
 		Type:     types.OpPut,
@@ -136,7 +137,7 @@ func TestHandleAccessMonitoringRule(t *testing.T) {
 	require.Empty(t, cache.Get())
 
 	// Test rule does not apply with invalid subject.
-	rule = newApprovedRule("test-rule", `condition`)
+	rule = newApprovedRule("test-rule", `condition`, "")
 	rule.GetSpec().SetSubjects([]string{"invalid"})
 	require.NoError(t, handler.HandleAccessMonitoringRule(ctx, types.Event{
 		Type:     types.OpPut,
@@ -153,8 +154,8 @@ func TestConflictingRules(t *testing.T) {
 
 	testReqID := uuid.New().String()
 	requesterUserName := "requester"
-	approvedRule := newApprovedRule("approved-rule", "true")
-	deniedRule := newDeniedRule("denied-rule", "true")
+	approvedRule := newApprovedRule("approved-rule", "true", "I APPROVE")
+	deniedRule := newDeniedRule("denied-rule", "true", "I DENY")
 
 	// Configure both an approved and denied rule.
 	cache := accessmonitoring.NewCache()
@@ -177,6 +178,7 @@ func TestConflictingRules(t *testing.T) {
 		requesterUserName,
 		deniedRule.GetMetadata().GetName(),
 		deniedRule.GetSpec().GetAutomaticReview().GetDecision(),
+		deniedRule.GetSpec().GetAutomaticReview().GetReason(),
 		time.Time{},
 	)
 	require.NoError(t, err)
@@ -219,7 +221,8 @@ func TestScheduleRequest(t *testing.T) {
 
 	testRule := newApprovedRule(
 		testRuleName,
-		`true`)
+		`true`,
+		"")
 
 	testRule.GetSpec().SetSchedules(map[string]*accessmonitoringrulesv1.Schedule{
 		"test-schedule": accessmonitoringrulesv1.Schedule_builder{
@@ -254,6 +257,7 @@ func TestScheduleRequest(t *testing.T) {
 					requesterUserName,
 					testRuleName,
 					types.RequestState_APPROVED.String(),
+					"",
 					time.Time{},
 				)
 				require.NoError(t, err)
@@ -328,7 +332,8 @@ func TestResourceRequest(t *testing.T) {
 
 	testRule := newApprovedRule(
 		testRuleName,
-		`access_request.spec.resource_labels_intersection["env"].contains("test")`)
+		`access_request.spec.resource_labels_intersection["env"].contains("test")`,
+		"")
 
 	cache := accessmonitoring.NewCache()
 	cache.Put([]*accessmonitoringrulesv1.AccessMonitoringRule{testRule})
@@ -398,6 +403,7 @@ func TestResourceRequest(t *testing.T) {
 					requesterUserName,
 					testRuleName,
 					types.RequestState_APPROVED.String(),
+					"",
 					time.Time{},
 				)
 				require.NoError(t, err)
@@ -468,15 +474,10 @@ func TestHandleAccessRequest(t *testing.T) {
 
 	testReqID := uuid.New().String()
 
-	// Setup test rule
-	cache := accessmonitoring.NewCache()
-
-	rule := newApprovedRule(testRuleName,
-		fmt.Sprintf(`
-			contains_all(set("%s"), access_request.spec.roles) &&
-			contains_any(user.traits["%s"], set("%s"))`,
-			approvedRole, approvedUserTraitKey, approvedUserTraitVal))
-	cache.Put([]*accessmonitoringrulesv1.AccessMonitoringRule{rule})
+	ruleCondition := fmt.Sprintf(`
+		contains_all(set("%s"), access_request.spec.roles) &&
+		contains_any(user.traits["%s"], set("%s"))`,
+		approvedRole, approvedUserTraitKey, approvedUserTraitVal)
 
 	// Setup approved user login state
 	approvedUserLoginState, err := userloginstate.New(
@@ -500,14 +501,15 @@ func TestHandleAccessRequest(t *testing.T) {
 		description   string
 		requester     string
 		requestedRole string
-		setupMock     func(m *mockClient)
+		reviewReason  string
+		setupMock     func(m *mockClient, reviewReason string)
 		assertErr     require.ErrorAssertionFunc
 	}{
 		{
 			description:   "test non-existent user",
 			requester:     "non-existent-user",
 			requestedRole: "non-existent-role",
-			setupMock: func(m *mockClient) {
+			setupMock: func(m *mockClient, _ string) {
 				m.On("GetUserLoginState", mock.Anything, "non-existent-user").
 					Return(nil, trace.NotFound("user not found"))
 				m.On("GetUser", mock.Anything, "non-existent-user", false).
@@ -521,7 +523,7 @@ func TestHandleAccessRequest(t *testing.T) {
 			description:   "test approved user for unapproved role",
 			requester:     approvedUserName,
 			requestedRole: "unapproved-role",
-			setupMock: func(m *mockClient) {
+			setupMock: func(m *mockClient, _ string) {
 				m.On("GetUserLoginState", mock.Anything, approvedUserName).
 					Return(approvedUserLoginState, nil)
 
@@ -534,7 +536,7 @@ func TestHandleAccessRequest(t *testing.T) {
 			description:   "test unapproved user for approved role",
 			requester:     unapprovedUserName,
 			requestedRole: approvedRole,
-			setupMock: func(m *mockClient) {
+			setupMock: func(m *mockClient, _ string) {
 				m.On("GetUserLoginState", mock.Anything, unapprovedUserName).
 					Return(unapprovedUserLoginState, nil)
 
@@ -547,7 +549,7 @@ func TestHandleAccessRequest(t *testing.T) {
 			description:   "test approved user for approved role",
 			requester:     approvedUserName,
 			requestedRole: approvedRole,
-			setupMock: func(m *mockClient) {
+			setupMock: func(m *mockClient, reviewReason string) {
 				m.On("GetUserLoginState", mock.Anything, approvedUserName).
 					Return(approvedUserLoginState, nil)
 
@@ -555,6 +557,7 @@ func TestHandleAccessRequest(t *testing.T) {
 					approvedUserName,
 					testRuleName,
 					types.RequestState_APPROVED.String(),
+					reviewReason,
 					time.Time{},
 				)
 				require.NoError(t, err)
@@ -566,13 +569,42 @@ func TestHandleAccessRequest(t *testing.T) {
 			},
 			assertErr: require.NoError,
 		},
+		{
+			description:   "test approved user with custom approval reason",
+			requester:     approvedUserName,
+			requestedRole: approvedRole,
+			reviewReason:  "okay sure, I guess",
+			setupMock: func(m *mockClient, reviewReason string) {
+				m.On("GetUserLoginState", mock.Anything, approvedUserName).
+					Return(approvedUserLoginState, nil)
+
+				// Construct the review struct literally so we can validate the appropriate reason
+				// is threaded through to SubmitAccessReview.
+				expectedReview := types.AccessReview{
+					Author:        teleport.SystemAccessApproverUserName,
+					ProposedState: types.RequestState_APPROVED,
+					Reason:        reviewReason,
+					Created:       time.Time{},
+				}
+
+				m.On("SubmitAccessReview", mock.Anything, types.AccessReviewSubmission{
+					RequestID: testReqID,
+					Review:    expectedReview,
+				}).Return(mock.Anything, nil)
+			},
+			assertErr: require.NoError,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
+			cache := accessmonitoring.NewCache()
+			rule := newApprovedRule(testRuleName, ruleCondition, test.reviewReason)
+			cache.Put([]*accessmonitoringrulesv1.AccessMonitoringRule{rule})
+
 			client := &mockClient{}
 			if test.setupMock != nil {
-				test.setupMock(client)
+				test.setupMock(client, test.reviewReason)
 			}
 
 			handler, err := NewHandler(Config{
@@ -595,15 +627,48 @@ func TestHandleAccessRequest(t *testing.T) {
 	}
 }
 
-func newApprovedRule(name, condition string) *accessmonitoringrulesv1.AccessMonitoringRule {
-	return newReviewRule(name, condition, types.RequestState_APPROVED.String())
+func TestNewAccessReviewReason(t *testing.T) {
+	tests := []struct {
+		description          string
+		configuredReason     string
+		expectedReviewReason string
+	}{
+		{
+			description:          "review with default reason",
+			configuredReason:     "",
+			expectedReviewReason: `Access request has been automatically approved by "@teleport-access-approval-bot". User "user" is approved by access_monitoring_rule "rule-name".`,
+		},
+		{
+			description:          "review with configured reason",
+			configuredReason:     "i approve this request",
+			expectedReviewReason: "i approve this request",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			review, err := newAccessReview(
+				"user",
+				"rule-name",
+				types.RequestState_APPROVED.String(),
+				test.configuredReason,
+				time.Time{},
+			)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedReviewReason, review.Reason)
+		})
+	}
 }
 
-func newDeniedRule(name, condition string) *accessmonitoringrulesv1.AccessMonitoringRule {
-	return newReviewRule(name, condition, types.RequestState_DENIED.String())
+func newApprovedRule(name, condition, reason string) *accessmonitoringrulesv1.AccessMonitoringRule {
+	return newReviewRule(name, condition, types.RequestState_APPROVED.String(), reason)
 }
 
-func newReviewRule(name, condition, decision string) *accessmonitoringrulesv1.AccessMonitoringRule {
+func newDeniedRule(name, condition, reason string) *accessmonitoringrulesv1.AccessMonitoringRule {
+	return newReviewRule(name, condition, types.RequestState_DENIED.String(), reason)
+}
+
+func newReviewRule(name, condition, decision, reason string) *accessmonitoringrulesv1.AccessMonitoringRule {
 	return accessmonitoringrulesv1.AccessMonitoringRule_builder{
 		Kind: types.KindAccessMonitoringRule,
 		Metadata: headerv1.Metadata_builder{
@@ -616,6 +681,7 @@ func newReviewRule(name, condition, decision string) *accessmonitoringrulesv1.Ac
 			AutomaticReview: accessmonitoringrulesv1.AutomaticReview_builder{
 				Integration: handlerName,
 				Decision:    decision,
+				Reason:      reason,
 			}.Build(),
 		}.Build(),
 	}.Build()

--- a/lib/accessmonitoring/review/review_test.go
+++ b/lib/accessmonitoring/review/review_test.go
@@ -502,14 +502,14 @@ func TestHandleAccessRequest(t *testing.T) {
 		requester     string
 		requestedRole string
 		reviewReason  string
-		setupMock     func(m *mockClient, reviewReason string)
+		setupMock     func(m *mockClient)
 		assertErr     require.ErrorAssertionFunc
 	}{
 		{
 			description:   "test non-existent user",
 			requester:     "non-existent-user",
 			requestedRole: "non-existent-role",
-			setupMock: func(m *mockClient, _ string) {
+			setupMock: func(m *mockClient) {
 				m.On("GetUserLoginState", mock.Anything, "non-existent-user").
 					Return(nil, trace.NotFound("user not found"))
 				m.On("GetUser", mock.Anything, "non-existent-user", false).
@@ -523,7 +523,7 @@ func TestHandleAccessRequest(t *testing.T) {
 			description:   "test approved user for unapproved role",
 			requester:     approvedUserName,
 			requestedRole: "unapproved-role",
-			setupMock: func(m *mockClient, _ string) {
+			setupMock: func(m *mockClient) {
 				m.On("GetUserLoginState", mock.Anything, approvedUserName).
 					Return(approvedUserLoginState, nil)
 
@@ -536,7 +536,7 @@ func TestHandleAccessRequest(t *testing.T) {
 			description:   "test unapproved user for approved role",
 			requester:     unapprovedUserName,
 			requestedRole: approvedRole,
-			setupMock: func(m *mockClient, _ string) {
+			setupMock: func(m *mockClient) {
 				m.On("GetUserLoginState", mock.Anything, unapprovedUserName).
 					Return(unapprovedUserLoginState, nil)
 
@@ -549,7 +549,7 @@ func TestHandleAccessRequest(t *testing.T) {
 			description:   "test approved user for approved role",
 			requester:     approvedUserName,
 			requestedRole: approvedRole,
-			setupMock: func(m *mockClient, reviewReason string) {
+			setupMock: func(m *mockClient) {
 				m.On("GetUserLoginState", mock.Anything, approvedUserName).
 					Return(approvedUserLoginState, nil)
 
@@ -557,7 +557,7 @@ func TestHandleAccessRequest(t *testing.T) {
 					approvedUserName,
 					testRuleName,
 					types.RequestState_APPROVED.String(),
-					reviewReason,
+					"",
 					time.Time{},
 				)
 				require.NoError(t, err)
@@ -574,7 +574,7 @@ func TestHandleAccessRequest(t *testing.T) {
 			requester:     approvedUserName,
 			requestedRole: approvedRole,
 			reviewReason:  "okay sure, I guess",
-			setupMock: func(m *mockClient, reviewReason string) {
+			setupMock: func(m *mockClient) {
 				m.On("GetUserLoginState", mock.Anything, approvedUserName).
 					Return(approvedUserLoginState, nil)
 
@@ -583,7 +583,7 @@ func TestHandleAccessRequest(t *testing.T) {
 				expectedReview := types.AccessReview{
 					Author:        teleport.SystemAccessApproverUserName,
 					ProposedState: types.RequestState_APPROVED,
-					Reason:        reviewReason,
+					Reason:        "okay sure, I guess",
 					Created:       time.Time{},
 				}
 
@@ -604,7 +604,7 @@ func TestHandleAccessRequest(t *testing.T) {
 
 			client := &mockClient{}
 			if test.setupMock != nil {
-				test.setupMock(client, test.reviewReason)
+				test.setupMock(client)
 			}
 
 			handler, err := NewHandler(Config{

--- a/lib/services/access_monitoring_rules.go
+++ b/lib/services/access_monitoring_rules.go
@@ -115,6 +115,13 @@ func ValidateAccessMonitoringRule(accessMonitoringRule *accessmonitoringrulesv1.
 		default:
 			return trace.BadParameter("accessMonitoringRule automatic_review decision %q is not supported", automaticReview.GetDecision())
 		}
+
+		// The automatic review reason becomes the access request's resolve reason
+		// when the review resolves the request, so it must satisfy the access
+		// request reason limit
+		if len(automaticReview.GetReason()) > maxAccessRequestReasonSize {
+			return trace.BadParameter("accessMonitoringRule automatic_review reason is too long, max %v bytes", maxAccessRequestReasonSize)
+		}
 	}
 
 	if slices.Contains(accessMonitoringRule.GetSpec().GetSubjects(), types.KindAccessRequest) {

--- a/lib/services/access_monitoring_rules_test.go
+++ b/lib/services/access_monitoring_rules_test.go
@@ -19,6 +19,7 @@
 package services
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -98,6 +99,22 @@ func TestValidateAccessMonitoringRule(t *testing.T) {
 			},
 			assertErr: func(t require.TestingT, err error, i ...any) {
 				require.ErrorContains(t, err, `accessMonitoringRule automatic_review decision "invalid-decision" is not supported`)
+			},
+		},
+		{
+			description: "automatic_review reason at maximum length",
+			modifyAMR: func(amr *accessmonitoringrulesv1.AccessMonitoringRule) {
+				amr.GetSpec().GetAutomaticReview().SetReason(strings.Repeat("a", maxAccessRequestReasonSize))
+			},
+			assertErr: require.NoError,
+		},
+		{
+			description: "automatic_review reason too long",
+			modifyAMR: func(amr *accessmonitoringrulesv1.AccessMonitoringRule) {
+				amr.GetSpec().GetAutomaticReview().SetReason(strings.Repeat("a", maxAccessRequestReasonSize+1))
+			},
+			assertErr: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "automatic_review reason is too long")
 			},
 		},
 		{


### PR DESCRIPTION
Adds a configurable resolution reason to access monitoring rules and propagates it to automatic approval or denial decisions. Updates the API, validation, Terraform and operator schemas, documentation, and test coverage.

Changelog: Access Monitoring Rules can now include a configurable resolution reason for automatic review decisions.

Fixes #65149

## Manual Test Plan
### Test Environment

Teleport running locally on macOS

### Test Cases
- [x] Verify a configured automatic-review reason is propagated to the resolved access request.
- [x] Verify automatic-review uses default reason to resolved access request when no reason is specified.
- [x] Verify validation rejects invalid automatic-review reasons.

Note: I verified all of the above using the Web UI. I did not try using terraform or the K8s operator yet. Is that expected? If so, I'm happy to do that.