### PR TITLE
Add gogoproto-friendly grpc proto codec

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -153,6 +153,7 @@ import (
 	"github.com/gravitational/teleport/lib/decision/decisionv1"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
+	_ "github.com/gravitational/teleport/lib/gogofriendlyprotocodec"
 	"github.com/gravitational/teleport/lib/httplib"
 	iterstream "github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/join"

--- a/lib/gogofriendlyprotocodec/init_test.go
+++ b/lib/gogofriendlyprotocodec/init_test.go
@@ -1,0 +1,31 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package gogofriendlyprotocodec_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/encoding"
+
+	"github.com/gravitational/teleport/lib/gogofriendlyprotocodec"
+)
+
+func TestInitOrder(t *testing.T) {
+	require.Nil(t, encoding.GetCodec("proto"))
+	require.IsType(t, gogofriendlyprotocodec.ExportedCodecV2{}, encoding.GetCodecV2("proto"))
+}

--- a/lib/gogofriendlyprotocodec/proto.go
+++ b/lib/gogofriendlyprotocodec/proto.go
@@ -1,0 +1,84 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package gogofriendlyprotocodec overrides the default protobuf codec defined
+// in grpc-go with one that supports gogoproto messages more efficiently.
+// Importing this package will register the codec.
+package gogofriendlyprotocodec
+
+import (
+	gogoproto "github.com/gogo/protobuf/proto"
+	"google.golang.org/grpc/encoding"
+	_ "google.golang.org/grpc/encoding/proto"
+	"google.golang.org/grpc/mem"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+var grpcProtoCodecV2 encoding.CodecV2
+
+func init() {
+	// we need to wrap the default proto codec at init time, and by importing
+	// the standard codec package we guarantee that its init (and thus its codec
+	// registration) runs before ours
+
+	grpcProtoCodecV2 = encoding.GetCodecV2("proto")
+	if grpcProtoCodecV2 == nil {
+		panic("grpc-go proto codec missing")
+	}
+
+	encoding.RegisterCodecV2(codecV2{})
+}
+
+type codecV2 struct{}
+
+func (codecV2) Name() string {
+	return "proto"
+}
+
+type gogoMarshaler = interface {
+	gogoproto.Message
+	gogoproto.Marshaler
+}
+
+func (codecV2) Marshal(v any) (data mem.BufferSlice, err error) {
+	if gogomsg, ok := v.(gogoMarshaler); ok {
+		buf, err := gogomsg.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		return mem.BufferSlice{mem.SliceBuffer(buf)}, nil
+	}
+
+	return grpcProtoCodecV2.Marshal(v)
+}
+
+type gogoUnmarshaler = interface {
+	gogoproto.Message
+	gogoproto.Unmarshaler
+}
+
+var _ gogoUnmarshaler = (*types.RoleV6)(nil)
+
+func (codecV2) Unmarshal(data mem.BufferSlice, v any) (err error) {
+	if gogomsg, ok := v.(gogoUnmarshaler); ok {
+		buf := data.MaterializeToBuffer(mem.DefaultBufferPool())
+		defer buf.Free()
+		return gogomsg.Unmarshal(buf.ReadOnlyData())
+	}
+
+	return grpcProtoCodecV2.Unmarshal(data, v)
+}

--- a/lib/gogofriendlyprotocodec/proto_test.go
+++ b/lib/gogofriendlyprotocodec/proto_test.go
@@ -1,0 +1,42 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package gogofriendlyprotocodec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+type ExportedCodecV2 = codecV2 // exported for init_test.go
+
+var _ gogoMarshaler = (*types.RoleV6)(nil)
+var _ gogoUnmarshaler = (*types.RoleV6)(nil)
+
+func TestImplements(t *testing.T) {
+	// gogoproto messages should match our type assertions (same check as the
+	// static assertion above, for completion)
+	require.Implements(t, (*gogoMarshaler)(nil), (*types.RoleV6)(nil))
+	require.Implements(t, (*gogoUnmarshaler)(nil), (*types.RoleV6)(nil))
+
+	// any new protobuf codegen should not match the assertions
+	require.NotImplements(t, (*gogoMarshaler)(nil), (*presencev1.RelayServer)(nil))
+	require.NotImplements(t, (*gogoUnmarshaler)(nil), (*presencev1.RelayServer)(nil))
+}


### PR DESCRIPTION
The default grpc-go `proto` codec implementation uses the [`protoadapt`](https://pkg.go.dev/google.golang.org/protobuf/protoadapt) package to use modern Protobuf functions for messages defined by the Protobuf "v1" API and codegen, which gogoproto also implements. The v1 protobuf API, unfortunately, does not have a way to calculate the size of the message, so when the codec implementation asks for the size to figure out if the message should use a buffer from the buffer pool, the protoadapt wrapper actually causes the message to be fully marshaled into a new byte slice just to calculate the size, even though gogoproto-generated messages have in fact an efficient way to extract the size of the message.

This PR adds a custom codec that wraps the default grpc-go codec, using the gogoproto-generated Marshal and Unmarshal methods for gogoproto messages, and falling back to the default codec otherwise.