### PR TITLE
[v18] Display Bot SQN in `tctl get scoped_role_assignment` (#69155)

### DIFF
--- a/tool/tctl/common/resources/collection_test.go
+++ b/tool/tctl/common/resources/collection_test.go
@@ -1,0 +1,47 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package resources
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+)
+
+func collectionFormatTest(t *testing.T, collection Collection, wantVerbose, wantNonVerbose string) {
+	t.Helper()
+
+	t.Run("verbose mode", func(t *testing.T) {
+		t.Helper()
+		w := &bytes.Buffer{}
+		err := collection.WriteText(w, true)
+		require.NoError(t, err)
+		diff := cmp.Diff(wantVerbose, w.String())
+		require.Empty(t, diff)
+	})
+
+	t.Run("non-verbose mode", func(t *testing.T) {
+		t.Helper()
+		w := &bytes.Buffer{}
+		err := collection.WriteText(w, false)
+		require.NoError(t, err)
+		diff := cmp.Diff(wantNonVerbose, w.String())
+		require.Empty(t, diff)
+	})
+}

--- a/tool/tctl/common/resources/scoped_role_assignment.go
+++ b/tool/tctl/common/resources/scoped_role_assignment.go
@@ -55,7 +55,7 @@ func (c *ScopedRoleAssignmentCollection) Resources() []types.Resource {
 }
 
 func (c *ScopedRoleAssignmentCollection) WriteText(w io.Writer, verbose bool) error {
-	headers := []string{"SubKind", "ID", "User", "Assigns"}
+	headers := []string{"SubKind", "ID", "Assignee", "Assigns"}
 	rows := make([][]string, len(c.roleAssignments))
 
 	for i, item := range c.roleAssignments {
@@ -66,7 +66,7 @@ func (c *ScopedRoleAssignmentCollection) WriteText(w io.Writer, verbose bool) er
 		rows[i] = []string{
 			item.GetSubKind(),
 			scopes.QualifiedName{Scope: item.GetScope(), Name: item.GetMetadata().GetName()}.String(),
-			item.GetSpec().GetUser(),
+			scopedRoleAssignmentAssignee(item),
 			strings.Join(assigns, ", "),
 		}
 	}
@@ -75,6 +75,20 @@ func (c *ScopedRoleAssignmentCollection) WriteText(w io.Writer, verbose bool) er
 
 	_, err := t.AsBuffer().WriteTo(w)
 	return trace.Wrap(err)
+}
+
+// scopedRoleAssignmentAssignee describes the identity that an assignment applies to,
+// kind-prefixed to disambiguate the two forms (e.g. "user: alice", "bot: /staging::mybot").
+// Assignments apply to either a user (by name) or a bot (by scope-qualified name), and the
+// two are mutually exclusive.
+func scopedRoleAssignmentAssignee(assignment *scopedaccessv1.ScopedRoleAssignment) string {
+	if bot := assignment.GetSpec().GetBot(); bot != "" {
+		return fmt.Sprintf("%s: %s", types.KindBot, bot)
+	}
+	if user := assignment.GetSpec().GetUser(); user != "" {
+		return fmt.Sprintf("%s: %s", types.KindUser, user)
+	}
+	return ""
 }
 
 func scopedRoleAssignmentScopedHandler() ScopedHandler {

--- a/tool/tctl/common/resources/scoped_role_assignment_test.go
+++ b/tool/tctl/common/resources/scoped_role_assignment_test.go
@@ -1,0 +1,80 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package resources
+
+import (
+	"testing"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/asciitable"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+)
+
+func TestScopedRoleAssignmentCollection_WriteText(t *testing.T) {
+	assignments := []*scopedaccessv1.ScopedRoleAssignment{
+		scopedaccessv1.ScopedRoleAssignment_builder{
+			Kind:     scopedaccess.KindScopedRoleAssignment,
+			SubKind:  scopedaccess.SubKindDynamic,
+			Version:  types.V1,
+			Metadata: headerv1.Metadata_builder{Name: "alice-assignment"}.Build(),
+			Scope:    "/staging",
+			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+				User: "alice",
+				Assignments: []*scopedaccessv1.Assignment{
+					scopedaccessv1.Assignment_builder{
+						Role:  "/staging::role1",
+						Scope: "/staging/west",
+					}.Build(),
+				},
+			}.Build(),
+		}.Build(),
+		scopedaccessv1.ScopedRoleAssignment_builder{
+			Kind:     scopedaccess.KindScopedRoleAssignment,
+			SubKind:  scopedaccess.SubKindDynamic,
+			Version:  types.V1,
+			Metadata: headerv1.Metadata_builder{Name: "mybot-assignment"}.Build(),
+			Scope:    "/staging",
+			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+				Bot: "/staging/west::mybot",
+				Assignments: []*scopedaccessv1.Assignment{
+					scopedaccessv1.Assignment_builder{
+						Role:  "/staging::role1",
+						Scope: "/staging/west",
+					}.Build(),
+					scopedaccessv1.Assignment_builder{
+						Role:  "/staging::role2",
+						Scope: "/staging/west",
+					}.Build(),
+				},
+			}.Build(),
+		}.Build(),
+	}
+
+	table := asciitable.MakeTable(
+		[]string{"SubKind", "ID", "Assignee", "Assigns"},
+		[]string{"dynamic", "/staging::alice-assignment", "user: alice", "/staging::role1 -> /staging/west"},
+		[]string{"dynamic", "/staging::mybot-assignment", "bot: /staging/west::mybot", "/staging::role1 -> /staging/west, /staging::role2 -> /staging/west"},
+	)
+
+	formatted := table.AsBuffer().String()
+
+	collectionFormatTest(t, NewScopedRoleAssignmentCollection(assignments), formatted, formatted)
+}


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/69155

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

- [x] tctl get scoped_Role_assignments --format text
- [x] tctl scoped assignments ls