### PR TITLE
Deprecate `roles` field in `tbot`

### DIFF
--- a/lib/tbot/cli/start_application.go
+++ b/lib/tbot/cli/start_application.go
@@ -53,8 +53,6 @@ func NewApplicationCommand(parentCmd *kingpin.CmdClause, action MutatorAction, m
 	cmd.Flag("app", "The name of the app in Teleport").Required().StringVar(&c.AppName)
 	cmd.Flag("specific-tls-extensions", "If set, includes additional `tls.crt`, `tls.key`, and `tls.cas` for apps that require these file extensions").BoolVar(&c.SpecificTLSExtensions)
 
-	// Note: CLI will not support roles; all will be requested.
-
 	return c
 }
 

--- a/lib/tbot/cli/start_application_tunnel.go
+++ b/lib/tbot/cli/start_application_tunnel.go
@@ -51,8 +51,6 @@ func NewApplicationTunnelCommand(parentCmd *kingpin.CmdClause, action MutatorAct
 	cmd.Flag("listen", "The socket URI on which the tunnel should listen, such as `tcp://0.0.0.0:8080`.").Required().StringVar(&c.Listen)
 	cmd.Flag("app", "The name of the app in Teleport").Required().StringVar(&c.AppName)
 
-	// Note: CLI will not support roles; all will be requested.
-
 	return c
 }
 

--- a/lib/tbot/cli/start_database_tunnel.go
+++ b/lib/tbot/cli/start_database_tunnel.go
@@ -54,8 +54,6 @@ func NewDatabaseTunnelCommand(parentCmd *kingpin.CmdClause, action MutatorAction
 	cmd.Flag("username", "The database user name.").Required().StringVar(&c.Username)
 	cmd.Flag("database", "The name of the database available in the requested database service.").Required().StringVar(&c.Database)
 
-	// Note: excluding roles from the CLI; will default to all available.
-
 	return c
 }
 

--- a/lib/tbot/cli/start_identity.go
+++ b/lib/tbot/cli/start_identity.go
@@ -53,7 +53,7 @@ func NewIdentityCommand(parentCmd *kingpin.CmdClause, action MutatorAction, mode
 
 	cmd.Flag("cluster", "The name of a specific cluster for which to issue an identity if using a leaf cluster.").StringVar(&c.Cluster)
 	cmd.Flag("allow-reissue", "Allow the credentials output by this command to be reissued.").BoolVar(&c.AllowReissue)
-	// Note: roles and ssh_config mode are excluded for now.
+	// Note: ssh_config mode is excluded for now.
 
 	return c
 }

--- a/lib/tbot/cli/start_kubernetes.go
+++ b/lib/tbot/cli/start_kubernetes.go
@@ -53,8 +53,6 @@ func NewKubernetesCommand(parentCmd *kingpin.CmdClause, action MutatorAction, mo
 	cmd.Flag("kubernetes-cluster", "The name of the Kubernetes cluster in Teleport for which to fetch credentials.").Required().StringVar(&c.KubernetesCluster)
 	cmd.Flag("disable-exec-plugin", "If set, disables the exec plugin. This allows credentials to be used without the `tbot` binary.").BoolVar(&c.DisableExecPlugin)
 
-	// Note: excluding roles; the bot will fetch all available in CLI mode.
-
 	return c
 }
 

--- a/lib/tbot/cli/start_legacy.go
+++ b/lib/tbot/cli/start_legacy.go
@@ -60,8 +60,7 @@ func (a *LegacyDestinationDirArgs) ApplyConfig(cfg *config.BotConfig, l *slog.Lo
 		// potential gotchas that currently exist when dealing with this
 		// override behavior.
 
-		// CLI only supports a single filesystem Destination with SSH client config
-		// and all roles.
+		// CLI only supports a single filesystem Destination.
 		if len(cfg.Services) > 0 {
 			log.WarnContext(
 				context.TODO(),

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -230,7 +230,6 @@ func TestBotConfig_YAML(t *testing.T) {
 						Destination: &destination.Directory{
 							Path: "/bot/output",
 						},
-						Roles:   []string{"editor"},
 						Cluster: "example.teleport.sh",
 					},
 					&identity.OutputConfig{
@@ -261,7 +260,6 @@ func TestBotConfig_YAML(t *testing.T) {
 					},
 					&application.TunnelConfig{
 						Listen:  "tcp://127.0.0.1:123",
-						Roles:   []string{"access"},
 						AppName: "my-app",
 						CredentialLifetime: bot.CredentialLifetime{
 							TTL:             30 * time.Second,
@@ -464,6 +462,71 @@ credential_ttl: 10m
 		require.NoError(t, err)
 		require.Equal(t, 10*time.Minute, cfg.CredentialLifetime.TTL)
 	})
+}
+
+// TestBotConfig_DeprecatedRolesRejected checks that the removed `roles` field is
+// rejected for every service that used to accept it.
+//
+// This deliberately goes through YAML parsing rather than setting the Go field:
+// the field only exists to keep the `roles` key bound, and unknown keys are
+// discarded silently, so a test that skips parsing would not notice the binding
+// being dropped.
+func TestBotConfig_DeprecatedRolesRejected(t *testing.T) {
+	tests := []struct {
+		name    string
+		service string
+	}{
+		{"identity", `
+  - type: identity
+    destination: {type: memory}
+    roles: [access]`},
+		{"identity/key-agent", `
+  - type: identity/key-agent
+    destination: {type: directory, path: /bot/output}
+    roles: [access]`},
+		{"database", `
+  - type: database
+    destination: {type: memory}
+    service: svc
+    database: db
+    username: alice
+    roles: [access]`},
+		{"database-tunnel", `
+  - type: database-tunnel
+    listen: tcp://127.0.0.1:3306
+    service: svc
+    database: db
+    username: alice
+    roles: [access]`},
+		{"application", `
+  - type: application
+    destination: {type: memory}
+    app_name: my-app
+    roles: [access]`},
+		{"application-tunnel", `
+  - type: application-tunnel
+    listen: tcp://127.0.0.1:8080
+    app_name: my-app
+    roles: [access]`},
+		{"kubernetes", `
+  - type: kubernetes
+    destination: {type: memory}
+    kubernetes_cluster: my-cluster
+    roles: [access]`},
+		{"ssh_host", `
+  - type: ssh_host
+    destination: {type: memory}
+    principals: [host.example.com]
+    roles: [access]`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := ReadConfig(strings.NewReader("version: v2\nservices:"+tt.service+"\n"), false)
+			require.NoError(t, err)
+			require.ErrorContains(t, cfg.CheckAndSetDefaults(), "roles: the roles field is no longer supported")
+		})
+	}
 }
 
 // TestBotConfig_Base64 ensures that config can be read from bas64 encoded YAML

--- a/lib/tbot/config/testdata/TestBotConfig_YAML/standard_config.golden
+++ b/lib/tbot/config/testdata/TestBotConfig_YAML/standard_config.golden
@@ -14,8 +14,6 @@ outputs:
     destination:
       type: directory
       path: /bot/output
-    roles:
-      - editor
     cluster: example.teleport.sh
   - type: identity
     destination:
@@ -37,8 +35,6 @@ services:
     renewal_interval: 15s
   - type: application-tunnel
     listen: tcp://127.0.0.1:123
-    roles:
-      - access
     app_name: my-app
     credential_ttl: 30s
     renewal_interval: 15s

--- a/lib/tbot/identity/generator.go
+++ b/lib/tbot/identity/generator.go
@@ -241,8 +241,8 @@ func (g *Generator) Generate(ctx context.Context, opts ...GenerateOption) (*Iden
 
 	log := cmp.Or(o.logger, g.logger)
 
-	// Roles are always resolved implicitly - there is no way for a service to
-	// request a narrower set.
+	// If we have been provided an existing identity, we can copy the role set
+	// from that - otherwise, we'll fetch the role set.
 	var roles []string
 	if o.currentIdentity != nil {
 		// If the caller provided an impersonated identity, take its roles.

--- a/lib/tbot/identity/generator.go
+++ b/lib/tbot/identity/generator.go
@@ -107,7 +107,6 @@ type Generator struct {
 
 type generateOpts struct {
 	delegationSessionID  string
-	roles                []string
 	ttl, renewalInterval time.Duration
 	currentIdentity      *Identity
 	logger               *slog.Logger
@@ -120,23 +119,9 @@ type GenerateOption func(*generateOpts)
 
 // WithDelegation uses the given delegation session ID to generate certificates
 // associated with a *human* user and delegation session.
-//
-// Note: this option is mutually-exclusive with WithRoles.
 func WithDelegation(sessionID string) GenerateOption {
 	return func(opts *generateOpts) {
 		opts.delegationSessionID = sessionID
-	}
-}
-
-// WithRoles sets the roles the generated identity should include.
-//
-// Generally, if the user did not specify any roles, it's best to leave this
-// empty and rely on the default behavior (of fetching all the bot's available
-// roles). If WithCurrentIdentity is provided, we'll default to using the roles
-// in its TLS certificate to avoid re-fetching them.
-func WithRoles(roles []string) GenerateOption {
-	return func(opts *generateOpts) {
-		opts.roles = roles
 	}
 }
 
@@ -256,22 +241,19 @@ func (g *Generator) Generate(ctx context.Context, opts ...GenerateOption) (*Iden
 
 	log := cmp.Or(o.logger, g.logger)
 
-	if len(o.roles) != 0 && o.delegationSessionID != "" {
-		return nil, trace.BadParameter("delegation sessions and explicit roles are mutually-exclusive")
-	}
-
-	if len(o.roles) == 0 {
-		if o.currentIdentity != nil {
-			// If the caller provided an impersonated identity, take its roles.
-			o.roles = o.currentIdentity.TLSIdentity.Groups
-		} else {
-			// Otherwise, fetch the bot identity's default roles.
-			var err error
-			if o.roles, err = g.botDefaultRoles(ctx); err != nil {
-				return nil, trace.Wrap(err, "fetching default roles")
-			}
-			log.DebugContext(ctx, "No roles configured, using all roles available.", "roles", o.roles)
+	// Roles are always resolved implicitly - there is no way for a service to
+	// request a narrower set.
+	var roles []string
+	if o.currentIdentity != nil {
+		// If the caller provided an impersonated identity, take its roles.
+		roles = o.currentIdentity.TLSIdentity.Groups
+	} else {
+		// Otherwise, fetch the bot identity's default roles.
+		var err error
+		if roles, err = g.botDefaultRoles(ctx); err != nil {
+			return nil, trace.Wrap(err, "fetching default roles")
 		}
+		log.DebugContext(ctx, "Using all roles available to the bot.", "roles", roles)
 	}
 
 	if o.currentIdentity == nil {
@@ -281,7 +263,7 @@ func (g *Generator) Generate(ctx context.Context, opts ...GenerateOption) (*Iden
 	req := proto.UserCertsRequest{
 		Username:       o.currentIdentity.X509Cert.Subject.CommonName,
 		Expires:        time.Now().Add(o.ttl),
-		RoleRequests:   o.roles,
+		RoleRequests:   roles,
 		RouteToCluster: o.currentIdentity.ClusterName,
 
 		// Make sure to specify this is an impersonated cert request. If unset,

--- a/lib/tbot/internal/deprecated_roles.go
+++ b/lib/tbot/internal/deprecated_roles.go
@@ -1,0 +1,40 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package internal
+
+import "github.com/gravitational/trace"
+
+const deprecatedRolesURL = "https://goteleport.com/docs/reference/machine-workload-identity/v19-upgrade-guide/"
+
+// CheckDeprecatedRoles returns an error if the removed `roles` field is set.
+//
+// Services keep the field bound to `yaml:"roles"` rather than deleting it
+// because unknown YAML keys are silently discarded, which for a
+// privilege-narrowing field would quietly broaden the issued credentials.
+//
+// TODO(noah): DELETE IN 20.0.0
+func CheckDeprecatedRoles(roles []string) error {
+	if len(roles) == 0 {
+		return nil
+	}
+	return trace.BadParameter(
+		"roles: the roles field is no longer supported and must be removed from your configuration. See %s for further information.",
+		deprecatedRolesURL,
+	)
+}

--- a/lib/tbot/services/application/output_config.go
+++ b/lib/tbot/services/application/output_config.go
@@ -37,9 +37,8 @@ type OutputConfig struct {
 	Name string `yaml:"name,omitempty"`
 	// Destination is where the credentials should be written to.
 	Destination destination.Destination `yaml:"destination"`
-	// Roles is the list of roles to request for the generated credentials.
-	// If empty, it defaults to all the bot's roles.
-	Roles []string `yaml:"roles,omitempty"`
+	// DeprecatedRoles is the removed `roles` field; see internal.CheckDeprecatedRoles.
+	DeprecatedRoles []string `yaml:"roles,omitempty"`
 
 	AppName string `yaml:"app_name"`
 
@@ -63,6 +62,9 @@ func (o *OutputConfig) Init(ctx context.Context) error {
 }
 
 func (o *OutputConfig) CheckAndSetDefaults(scoped bool) error {
+	if err := internal.CheckDeprecatedRoles(o.DeprecatedRoles); err != nil {
+		return trace.Wrap(err)
+	}
 	if scoped {
 		return trace.BadParameter("service type %q is not supported in scoped mode", OutputServiceType)
 	}
@@ -74,9 +76,6 @@ func (o *OutputConfig) CheckAndSetDefaults(scoped bool) error {
 	}
 	if o.AppName == "" {
 		return trace.BadParameter("app_name must not be empty")
-	}
-	if o.DelegationSessionID != "" && len(o.Roles) > 0 {
-		return trace.BadParameter("delegation_session_id: is mutually-exclusive with roles")
 	}
 
 	return nil

--- a/lib/tbot/services/application/output_config_test.go
+++ b/lib/tbot/services/application/output_config_test.go
@@ -33,7 +33,6 @@ func TestApplicationOutput_YAML(t *testing.T) {
 			name: "full",
 			in: OutputConfig{
 				Destination:         dest,
-				Roles:               []string{"access"},
 				AppName:             "my-app",
 				DelegationSessionID: "8a50ba48-2fad-4c2c-a8ce-f48bc18db9ee",
 				CredentialLifetime: bot.CredentialLifetime{
@@ -60,7 +59,6 @@ func TestApplicationOutput_CheckAndSetDefaults(t *testing.T) {
 			in: func() *OutputConfig {
 				return &OutputConfig{
 					Destination: destination.NewMemory(),
-					Roles:       []string{"access"},
 					AppName:     "app",
 				}
 			},
@@ -85,16 +83,15 @@ func TestApplicationOutput_CheckAndSetDefaults(t *testing.T) {
 			wantErr: "app_name must not be empty",
 		},
 		{
-			name: "delegation session id conflicts with roles",
+			name: "roles is no longer supported",
 			in: func() *OutputConfig {
 				return &OutputConfig{
-					Destination:         destination.NewMemory(),
-					Roles:               []string{"access"},
-					AppName:             "app",
-					DelegationSessionID: "8a50ba48-2fad-4c2c-a8ce-f48bc18db9ee",
+					Destination:     destination.NewMemory(),
+					AppName:         "app",
+					DeprecatedRoles: []string{"access"},
 				}
 			},
-			wantErr: "delegation_session_id: is mutually-exclusive with roles",
+			wantErr: "roles: the roles field is no longer supported",
 		},
 		{
 			name:   "scoped",

--- a/lib/tbot/services/application/output_service.go
+++ b/lib/tbot/services/application/output_service.go
@@ -125,9 +125,7 @@ func (s *OutputService) generate(ctx context.Context) error {
 		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
 		identity.WithLogger(s.log),
 	}
-	if s.cfg.DelegationSessionID == "" {
-		identityOpts = append(identityOpts, identity.WithRoles(s.cfg.Roles))
-	} else {
+	if s.cfg.DelegationSessionID != "" {
 		identityOpts = append(identityOpts, identity.WithDelegation(s.cfg.DelegationSessionID))
 	}
 	id, err := s.identityGenerator.GenerateFacade(ctx, identityOpts...)

--- a/lib/tbot/services/application/testdata/TestApplicationOutput_YAML/full.golden
+++ b/lib/tbot/services/application/testdata/TestApplicationOutput_YAML/full.golden
@@ -1,8 +1,6 @@
 type: application
 destination:
   type: memory
-roles:
-  - access
 app_name: my-app
 specific_tls_naming: false
 delegation_session_id: 8a50ba48-2fad-4c2c-a8ce-f48bc18db9ee

--- a/lib/tbot/services/application/tunnel_config.go
+++ b/lib/tbot/services/application/tunnel_config.go
@@ -27,6 +27,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/gravitational/teleport/lib/tbot/bot"
+	"github.com/gravitational/teleport/lib/tbot/internal"
 	"github.com/gravitational/teleport/lib/tbot/internal/encoding"
 )
 
@@ -41,9 +42,8 @@ type TunnelConfig struct {
 	// - "tcp://127.0.0.1:3306"
 	// - "tcp://0.0.0.0:3306
 	Listen string `yaml:"listen"`
-	// Roles is the list of roles to request for the tunnel.
-	// If empty, it defaults to all the bot's roles.
-	Roles []string `yaml:"roles,omitempty"`
+	// DeprecatedRoles is the removed `roles` field; see internal.CheckDeprecatedRoles.
+	DeprecatedRoles []string `yaml:"roles,omitempty"`
 	// AppName should be the name of the application as registered in Teleport
 	// that you wish to tunnel to.
 	AppName string `yaml:"app_name"`
@@ -99,6 +99,9 @@ func (s *TunnelConfig) UnmarshalYAML(node *yaml.Node) error {
 }
 
 func (s *TunnelConfig) CheckAndSetDefaults(scoped bool) error {
+	if err := internal.CheckDeprecatedRoles(s.DeprecatedRoles); err != nil {
+		return trace.Wrap(err)
+	}
 	if scoped {
 		return trace.BadParameter("service type %q is not supported in scoped mode", TunnelServiceType)
 	}
@@ -113,9 +116,6 @@ func (s *TunnelConfig) CheckAndSetDefaults(scoped bool) error {
 	}
 	if s.clock == nil {
 		s.clock = clockwork.NewRealClock()
-	}
-	if s.DelegationSessionID != "" && len(s.Roles) > 0 {
-		return trace.BadParameter("delegation_session_id: is mutually-exclusive with roles")
 	}
 
 	return nil

--- a/lib/tbot/services/application/tunnel_config_test.go
+++ b/lib/tbot/services/application/tunnel_config_test.go
@@ -58,14 +58,12 @@ func TestApplicationTunnelService_CheckAndSetDefaults(t *testing.T) {
 			in: func() *TunnelConfig {
 				return &TunnelConfig{
 					Listen:  "tcp://0.0.0.0:3621",
-					Roles:   []string{"role1", "role2"},
 					AppName: "my-app",
 					clock:   clock,
 				}
 			},
 			want: &TunnelConfig{
 				Listen:  "tcp://0.0.0.0:3621",
-				Roles:   []string{"role1", "role2"},
 				AppName: "my-app",
 				clock:   clock,
 			},
@@ -75,7 +73,6 @@ func TestApplicationTunnelService_CheckAndSetDefaults(t *testing.T) {
 			name: "missing listen",
 			in: func() *TunnelConfig {
 				return &TunnelConfig{
-					Roles:   []string{"role1", "role2"},
 					AppName: "my-app",
 				}
 			},
@@ -86,7 +83,6 @@ func TestApplicationTunnelService_CheckAndSetDefaults(t *testing.T) {
 			in: func() *TunnelConfig {
 				return &TunnelConfig{
 					Listen:  "\x00",
-					Roles:   []string{"role1", "role2"},
 					AppName: "my-app",
 				}
 			},
@@ -97,22 +93,20 @@ func TestApplicationTunnelService_CheckAndSetDefaults(t *testing.T) {
 			in: func() *TunnelConfig {
 				return &TunnelConfig{
 					Listen: "tcp://0.0.0.0:3621",
-					Roles:  []string{"role1", "role2"},
 				}
 			},
 			wantErr: "app_name: should not be empty",
 		},
 		{
-			name: "delegation session id conflicts with roles",
+			name: "roles is no longer supported",
 			in: func() *TunnelConfig {
 				return &TunnelConfig{
-					Listen:              "tcp://0.0.0.0:3621",
-					Roles:               []string{"role1", "role2"},
-					AppName:             "my-app",
-					DelegationSessionID: "8a50ba48-2fad-4c2c-a8ce-f48bc18db9ee",
+					Listen:          "tcp://0.0.0.0:3621",
+					AppName:         "my-app",
+					DeprecatedRoles: []string{"role1", "role2"},
 				}
 			},
-			wantErr: "delegation_session_id: is mutually-exclusive with roles",
+			wantErr: "roles: the roles field is no longer supported",
 		},
 		{
 			name:   "scoped",

--- a/lib/tbot/services/application/tunnel_service.go
+++ b/lib/tbot/services/application/tunnel_service.go
@@ -284,9 +284,7 @@ func (s *TunnelService) issueCert(
 		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
 		identity.WithLogger(s.log),
 	}
-	if s.cfg.DelegationSessionID == "" {
-		identityOpts = append(identityOpts, identity.WithRoles(s.cfg.Roles))
-	} else {
+	if s.cfg.DelegationSessionID != "" {
 		identityOpts = append(identityOpts, identity.WithDelegation(s.cfg.DelegationSessionID))
 	}
 	impersonatedIdentity, err := s.identityGenerator.GenerateFacade(ctx, identityOpts...)

--- a/lib/tbot/services/database/output_config.go
+++ b/lib/tbot/services/database/output_config.go
@@ -76,9 +76,8 @@ type OutputConfig struct {
 	Name string `yaml:"name,omitempty"`
 	// Destination is where the credentials should be written to.
 	Destination destination.Destination `yaml:"destination"`
-	// Roles is the list of roles to request for the generated credentials.
-	// If empty, it defaults to all the bot's roles.
-	Roles []string `yaml:"roles,omitempty"`
+	// DeprecatedRoles is the removed `roles` field; see internal.CheckDeprecatedRoles.
+	DeprecatedRoles []string `yaml:"roles,omitempty"`
 
 	// Formats specifies if any special behavior should be invoked when
 	// producing artifacts. An empty value is supported by most database,
@@ -123,6 +122,9 @@ func (o *OutputConfig) Init(ctx context.Context) error {
 }
 
 func (o *OutputConfig) CheckAndSetDefaults(scoped bool) error {
+	if err := internal.CheckDeprecatedRoles(o.DeprecatedRoles); err != nil {
+		return trace.Wrap(err)
+	}
 	if scoped {
 		return trace.BadParameter("service type %q is not supported in scoped mode", OutputServiceType)
 	}
@@ -139,9 +141,6 @@ func (o *OutputConfig) CheckAndSetDefaults(scoped bool) error {
 
 	if !slices.Contains(databaseFormats, o.Format) {
 		return trace.BadParameter("unrecognized format (%s)", o.Format)
-	}
-	if o.DelegationSessionID != "" && len(o.Roles) > 0 {
-		return trace.BadParameter("delegation_session_id: is mutually-exclusive with roles")
 	}
 
 	return nil

--- a/lib/tbot/services/database/output_config_test.go
+++ b/lib/tbot/services/database/output_config_test.go
@@ -33,7 +33,6 @@ func TestDatabaseOutput_YAML(t *testing.T) {
 			name: "full",
 			in: OutputConfig{
 				Destination:         dest,
-				Roles:               []string{"access"},
 				Format:              TLSDatabaseFormat,
 				Service:             "my-database-service",
 				Database:            "my-database",
@@ -63,7 +62,6 @@ func TestDatabaseOutput_CheckAndSetDefaults(t *testing.T) {
 			in: func() *OutputConfig {
 				return &OutputConfig{
 					Destination: destination.NewMemory(),
-					Roles:       []string{"access"},
 					Database:    "db",
 					Service:     "service",
 					Username:    "username",
@@ -101,16 +99,15 @@ func TestDatabaseOutput_CheckAndSetDefaults(t *testing.T) {
 			wantErr: "unrecognized format (no-such-format)",
 		},
 		{
-			name: "delegation session id conflicts with roles",
+			name: "roles is no longer supported",
 			in: func() *OutputConfig {
 				return &OutputConfig{
-					Destination:         destination.NewMemory(),
-					Roles:               []string{"access"},
-					Service:             "service",
-					DelegationSessionID: "8a50ba48-2fad-4c2c-a8ce-f48bc18db9ee",
+					Destination:     destination.NewMemory(),
+					Service:         "service",
+					DeprecatedRoles: []string{"access"},
 				}
 			},
-			wantErr: "delegation_session_id: is mutually-exclusive with roles",
+			wantErr: "roles: the roles field is no longer supported",
 		},
 		{
 			name:   "scoped",

--- a/lib/tbot/services/database/output_service.go
+++ b/lib/tbot/services/database/output_service.go
@@ -123,9 +123,7 @@ func (s *OutputService) generate(ctx context.Context) error {
 		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
 		identity.WithLogger(s.log),
 	}
-	if s.cfg.DelegationSessionID == "" {
-		identityOpts = append(identityOpts, identity.WithRoles(s.cfg.Roles))
-	} else {
+	if s.cfg.DelegationSessionID != "" {
 		identityOpts = append(identityOpts, identity.WithDelegation(s.cfg.DelegationSessionID))
 	}
 	id, err := s.identityGenerator.GenerateFacade(ctx, identityOpts...)

--- a/lib/tbot/services/database/testdata/TestDatabaseOutput_YAML/full.golden
+++ b/lib/tbot/services/database/testdata/TestDatabaseOutput_YAML/full.golden
@@ -1,8 +1,6 @@
 type: database
 destination:
   type: memory
-roles:
-  - access
 format: tls
 service: my-database-service
 database: my-database

--- a/lib/tbot/services/database/testdata/TestDatabaseTunnelService_YAML/full.golden
+++ b/lib/tbot/services/database/testdata/TestDatabaseTunnelService_YAML/full.golden
@@ -1,8 +1,5 @@
 type: database-tunnel
 listen: tcp://0.0.0.0:3621
-roles:
-  - role1
-  - role2
 service: service
 database: database
 username: username

--- a/lib/tbot/services/database/tunnel_config.go
+++ b/lib/tbot/services/database/tunnel_config.go
@@ -26,6 +26,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/gravitational/teleport/lib/tbot/bot"
+	"github.com/gravitational/teleport/lib/tbot/internal"
 	"github.com/gravitational/teleport/lib/tbot/internal/encoding"
 )
 
@@ -39,9 +40,8 @@ type TunnelConfig struct {
 	// - "tcp://127.0.0.1:3306"
 	// - "tcp://0.0.0.0:3306
 	Listen string `yaml:"listen"`
-	// Roles is the list of roles to request for the tunnel.
-	// If empty, it defaults to all the bot's roles.
-	Roles []string `yaml:"roles,omitempty"`
+	// DeprecatedRoles is the removed `roles` field; see internal.CheckDeprecatedRoles.
+	DeprecatedRoles []string `yaml:"roles,omitempty"`
 	// Service is the service name of the Teleport database. Generally this is
 	// the name of the Teleport resource. This field is required for all types
 	// of database.
@@ -94,6 +94,9 @@ func (s *TunnelConfig) UnmarshalYAML(node *yaml.Node) error {
 }
 
 func (s *TunnelConfig) CheckAndSetDefaults(scoped bool) error {
+	if err := internal.CheckDeprecatedRoles(s.DeprecatedRoles); err != nil {
+		return trace.Wrap(err)
+	}
 	if scoped {
 		return trace.BadParameter("service type %q is not supported in scoped mode", TunnelServiceType)
 	}
@@ -109,9 +112,6 @@ func (s *TunnelConfig) CheckAndSetDefaults(scoped bool) error {
 	}
 	if _, err := url.Parse(s.Listen); err != nil {
 		return trace.Wrap(err, "parsing listen")
-	}
-	if s.DelegationSessionID != "" && len(s.Roles) > 0 {
-		return trace.BadParameter("delegation_session_id: is mutually-exclusive with roles")
 	}
 	return nil
 }

--- a/lib/tbot/services/database/tunnel_config_test.go
+++ b/lib/tbot/services/database/tunnel_config_test.go
@@ -33,7 +33,6 @@ func TestDatabaseTunnelService_YAML(t *testing.T) {
 			name: "full",
 			in: TunnelConfig{
 				Listen:              "tcp://0.0.0.0:3621",
-				Roles:               []string{"role1", "role2"},
 				Service:             "service",
 				Database:            "database",
 				Username:            "username",
@@ -57,7 +56,6 @@ func TestDatabaseTunnelService_CheckAndSetDefaults(t *testing.T) {
 			in: func() *TunnelConfig {
 				return &TunnelConfig{
 					Listen:   "tcp://0.0.0.0:3621",
-					Roles:    []string{"role1", "role2"},
 					Service:  "service",
 					Database: "database",
 					Username: "username",
@@ -69,7 +67,6 @@ func TestDatabaseTunnelService_CheckAndSetDefaults(t *testing.T) {
 			name: "missing listen",
 			in: func() *TunnelConfig {
 				return &TunnelConfig{
-					Roles:    []string{"role1", "role2"},
 					Service:  "service",
 					Database: "database",
 					Username: "username",
@@ -82,7 +79,6 @@ func TestDatabaseTunnelService_CheckAndSetDefaults(t *testing.T) {
 			in: func() *TunnelConfig {
 				return &TunnelConfig{
 					Listen:   "tcp://0.0.0.0:3621",
-					Roles:    []string{"role1", "role2"},
 					Database: "database",
 					Username: "username",
 				}
@@ -94,7 +90,6 @@ func TestDatabaseTunnelService_CheckAndSetDefaults(t *testing.T) {
 			in: func() *TunnelConfig {
 				return &TunnelConfig{
 					Listen:   "tcp://0.0.0.0:3621",
-					Roles:    []string{"role1", "role2"},
 					Service:  "service",
 					Username: "username",
 				}
@@ -106,7 +101,6 @@ func TestDatabaseTunnelService_CheckAndSetDefaults(t *testing.T) {
 			in: func() *TunnelConfig {
 				return &TunnelConfig{
 					Listen:   "tcp://0.0.0.0:3621",
-					Roles:    []string{"role1", "role2"},
 					Service:  "service",
 					Database: "database",
 				}
@@ -114,18 +108,17 @@ func TestDatabaseTunnelService_CheckAndSetDefaults(t *testing.T) {
 			wantErr: "username: should not be empty",
 		},
 		{
-			name: "delegation session id conflicts with roles",
+			name: "roles is no longer supported",
 			in: func() *TunnelConfig {
 				return &TunnelConfig{
-					Listen:              "tcp://0.0.0.0:3621",
-					Roles:               []string{"role1", "role2"},
-					Service:             "service",
-					Database:            "database",
-					Username:            "username",
-					DelegationSessionID: "8a50ba48-2fad-4c2c-a8ce-f48bc18db9ee",
+					Listen:          "tcp://0.0.0.0:3621",
+					Service:         "service",
+					Database:        "database",
+					Username:        "username",
+					DeprecatedRoles: []string{"role1", "role2"},
 				}
 			},
-			wantErr: "delegation_session_id: is mutually-exclusive with roles",
+			wantErr: "roles: the roles field is no longer supported",
 		},
 		{
 			name:   "scoped",

--- a/lib/tbot/services/database/tunnel_service.go
+++ b/lib/tbot/services/database/tunnel_service.go
@@ -299,9 +299,7 @@ func (s *TunnelService) getRouteToDatabaseWithImpersonation(ctx context.Context)
 		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
 		identity.WithLogger(s.log),
 	}
-	if s.cfg.DelegationSessionID == "" {
-		identityOpts = append(identityOpts, identity.WithRoles(s.cfg.Roles))
-	} else {
+	if s.cfg.DelegationSessionID != "" {
 		identityOpts = append(identityOpts, identity.WithDelegation(s.cfg.DelegationSessionID))
 	}
 	impersonatedIdentity, err := s.identityGenerator.GenerateFacade(ctx, identityOpts...)
@@ -336,9 +334,7 @@ func (s *TunnelService) issueCert(
 		identity.WithLogger(s.log),
 		identity.WithRouteToDatabase(route),
 	}
-	if s.cfg.DelegationSessionID == "" {
-		identityOpts = append(identityOpts, identity.WithRoles(s.cfg.Roles))
-	} else {
+	if s.cfg.DelegationSessionID != "" {
 		identityOpts = append(identityOpts, identity.WithDelegation(s.cfg.DelegationSessionID))
 	}
 	ident, err := s.identityGenerator.Generate(ctx, identityOpts...)

--- a/lib/tbot/services/identity/key_agent_config.go
+++ b/lib/tbot/services/identity/key_agent_config.go
@@ -45,15 +45,10 @@ type KeyAgentConfig struct {
 	// DelegationSessionID optionally identifies the delegation session the
 	// generated credentials will be associated with, enabling the bot to act
 	// on a (human) user's behalf.
-	//
-	// It is mutually exclusive with Roles.
 	DelegationSessionID string `yaml:"delegation_session_id,omitempty"`
 
-	// Roles is the list of roles to request for the generated credentials. If
-	// empty, it defaults to all the bot's roles.
-	//
-	// It is mutually exclusive with DelegationSessionID.
-	Roles []string `yaml:"roles,omitempty"`
+	// DeprecatedRoles is the removed `roles` field; see internal.CheckDeprecatedRoles.
+	DeprecatedRoles []string `yaml:"roles,omitempty"`
 
 	// Cluster allows certificates to be generated for a leaf cluster of the
 	// cluster that the bot is connected to. These certificates can be used
@@ -79,6 +74,10 @@ type KeyAgentConfig struct {
 
 // CheckAndSetDefaults satisfies the config.ServiceConfig interface.
 func (c *KeyAgentConfig) CheckAndSetDefaults(scoped bool) error {
+	if err := internal.CheckDeprecatedRoles(c.DeprecatedRoles); err != nil {
+		return trace.Wrap(err)
+	}
+
 	// TODO(boxofrad): Add support for scopes (and support for the WithPrivateKey
 	// identity generator option to GenerateScoped). Scope support was omitted
 	// from the initial version because we do not need it in Beams yet.
@@ -94,10 +93,6 @@ func (c *KeyAgentConfig) CheckAndSetDefaults(scoped bool) error {
 	}
 	if _, isDir := c.Destination.(*destination.Directory); !isDir {
 		return trace.BadParameter("destination: must be a filesystem directory")
-	}
-
-	if c.DelegationSessionID != "" && len(c.Roles) > 0 {
-		return trace.BadParameter("delegation_session_id: is mutually-exclusive with roles")
 	}
 
 	return nil

--- a/lib/tbot/services/identity/key_agent_config_test.go
+++ b/lib/tbot/services/identity/key_agent_config_test.go
@@ -36,7 +36,6 @@ func TestKeyAgentService_YAML(t *testing.T) {
 				Destination: &destination.Directory{
 					Path: "/opt/machine-id",
 				},
-				Roles:        []string{"access"},
 				Cluster:      "leaf.example.com",
 				AllowReissue: true,
 				CredentialLifetime: bot.CredentialLifetime{
@@ -75,7 +74,7 @@ func TestKeyAgentService_CheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "valid with roles",
+			name: "roles is no longer supported",
 			in: func() *KeyAgentConfig {
 				return &KeyAgentConfig{
 					Destination: &destination.Directory{
@@ -83,9 +82,10 @@ func TestKeyAgentService_CheckAndSetDefaults(t *testing.T) {
 						ACLs:     botfs.ACLOff,
 						Symlinks: botfs.SymlinksInsecure,
 					},
-					Roles: []string{"access"},
+					DeprecatedRoles: []string{"access"},
 				}
 			},
+			wantErr: "roles: the roles field is no longer supported",
 		},
 		{
 			name: "valid with delegation session id",
@@ -115,19 +115,6 @@ func TestKeyAgentService_CheckAndSetDefaults(t *testing.T) {
 				}
 			},
 			wantErr: "destination: must be a filesystem directory",
-		},
-		{
-			name: "delegation session id conflicts with roles",
-			in: func() *KeyAgentConfig {
-				return &KeyAgentConfig{
-					Destination: &destination.Directory{
-						Path: "/opt/machine-id",
-					},
-					Roles:               []string{"access"},
-					DelegationSessionID: "8a50ba48-2fad-4c2c-a8ce-f48bc18db9ee",
-				}
-			},
-			wantErr: "delegation_session_id: is mutually-exclusive with roles",
 		},
 		{
 			name:   "scoped",

--- a/lib/tbot/services/identity/key_agent_service.go
+++ b/lib/tbot/services/identity/key_agent_service.go
@@ -216,9 +216,7 @@ func (s *KeyAgentService) renewIdentity(ctx context.Context, privKey crypto.Sign
 		generateOpts = append(generateOpts, identity.WithPrivateKey(privKey))
 	}
 
-	if s.cfg.DelegationSessionID == "" {
-		generateOpts = append(generateOpts, identity.WithRoles(s.cfg.Roles))
-	} else {
+	if s.cfg.DelegationSessionID != "" {
 		generateOpts = append(generateOpts, identity.WithDelegation(s.cfg.DelegationSessionID))
 	}
 

--- a/lib/tbot/services/identity/output.go
+++ b/lib/tbot/services/identity/output.go
@@ -162,9 +162,7 @@ func (s *OutputService) generate(ctx context.Context) error {
 		identity.WithReissuableRoleImpersonation(s.cfg.AllowReissue),
 		identity.WithLogger(s.log),
 	}
-	if s.cfg.DelegationSessionID == "" {
-		identityOpts = append(identityOpts, identity.WithRoles(s.cfg.Roles))
-	} else {
+	if s.cfg.DelegationSessionID != "" {
 		identityOpts = append(identityOpts, identity.WithDelegation(s.cfg.DelegationSessionID))
 	}
 	id, err := s.identityGenerator.GenerateFacade(ctx, identityOpts...)

--- a/lib/tbot/services/identity/output_config.go
+++ b/lib/tbot/services/identity/output_config.go
@@ -66,9 +66,8 @@ type OutputConfig struct {
 	Name string `yaml:"name,omitempty"`
 	// Destination is where the credentials should be written to.
 	Destination destination.Destination `yaml:"destination"`
-	// Roles is the list of roles to request for the generated credentials.
-	// If empty, it defaults to all the bot's roles.
-	Roles []string `yaml:"roles,omitempty"`
+	// DeprecatedRoles is the removed `roles` field; see internal.CheckDeprecatedRoles.
+	DeprecatedRoles []string `yaml:"roles,omitempty"`
 
 	// Cluster allows certificates to be generated for a leaf cluster of the
 	// cluster that the bot is connected to. These certificates can be used
@@ -120,6 +119,9 @@ func (o *OutputConfig) GetDestination() destination.Destination {
 }
 
 func (o *OutputConfig) CheckAndSetDefaults(scoped bool) error {
+	if err := internal.CheckDeprecatedRoles(o.DeprecatedRoles); err != nil {
+		return trace.Wrap(err)
+	}
 	if o.Destination == nil {
 		return trace.BadParameter("no destination configured for output")
 	}
@@ -129,8 +131,6 @@ func (o *OutputConfig) CheckAndSetDefaults(scoped bool) error {
 
 	if scoped {
 		switch {
-		case len(o.Roles) != 0:
-			return trace.BadParameter("roles: not supported with scopes")
 		case o.AllowReissue:
 			return trace.BadParameter("allow_reissue: not supported with scopes")
 		case o.Cluster != "":
@@ -159,9 +159,6 @@ func (o *OutputConfig) CheckAndSetDefaults(scoped bool) error {
 	case SSHConfigModeOff, SSHConfigModeOn:
 	default:
 		return trace.BadParameter("ssh_config: unrecognized value %q", o.SSHConfigMode)
-	}
-	if o.DelegationSessionID != "" && len(o.Roles) > 0 {
-		return trace.BadParameter("delegation_session_id: is mutually-exclusive with roles")
 	}
 
 	return nil

--- a/lib/tbot/services/identity/output_config_test.go
+++ b/lib/tbot/services/identity/output_config_test.go
@@ -33,7 +33,6 @@ func TestIdentityOutput_YAML(t *testing.T) {
 			name: "full",
 			in: OutputConfig{
 				Destination:         dest,
-				Roles:               []string{"access"},
 				Cluster:             "leaf.example.com",
 				SSHConfigMode:       SSHConfigModeOff,
 				AllowReissue:        true,
@@ -61,7 +60,6 @@ func TestIdentityOutput_CheckAndSetDefaults(t *testing.T) {
 			in: func() *OutputConfig {
 				return &OutputConfig{
 					Destination:   destination.NewMemory(),
-					Roles:         []string{"access"},
 					SSHConfigMode: SSHConfigModeOn,
 				}
 			},
@@ -98,16 +96,15 @@ func TestIdentityOutput_CheckAndSetDefaults(t *testing.T) {
 			wantErr: "ssh_config: unrecognized value \"invalid\"",
 		},
 		{
-			name: "delegation session id conflicts with roles",
+			name: "roles is no longer supported",
 			in: func() *OutputConfig {
 				return &OutputConfig{
-					Destination:         destination.NewMemory(),
-					Roles:               []string{"access"},
-					SSHConfigMode:       SSHConfigModeOn,
-					DelegationSessionID: "8a50ba48-2fad-4c2c-a8ce-f48bc18db9ee",
+					Destination:     destination.NewMemory(),
+					SSHConfigMode:   SSHConfigModeOn,
+					DeprecatedRoles: []string{"access"},
 				}
 			},
-			wantErr: "delegation_session_id: is mutually-exclusive with roles",
+			wantErr: "roles: the roles field is no longer supported",
 		},
 		{
 			name:   "scoped valid",
@@ -127,11 +124,11 @@ func TestIdentityOutput_CheckAndSetDefaults(t *testing.T) {
 			scoped: true,
 			in: func() *OutputConfig {
 				return &OutputConfig{
-					Destination: destination.NewMemory(),
-					Roles:       []string{"access"},
+					Destination:     destination.NewMemory(),
+					DeprecatedRoles: []string{"access"},
 				}
 			},
-			wantErr: "roles: not supported with scopes",
+			wantErr: "roles: the roles field is no longer supported",
 		},
 		{
 			name:   "scoped with allow_reissue",

--- a/lib/tbot/services/identity/testdata/TestIdentityOutput_YAML/full.golden
+++ b/lib/tbot/services/identity/testdata/TestIdentityOutput_YAML/full.golden
@@ -1,8 +1,6 @@
 type: identity
 destination:
   type: memory
-roles:
-  - access
 cluster: leaf.example.com
 ssh_config: "off"
 allow_reissue: true

--- a/lib/tbot/services/identity/testdata/TestKeyAgentService_YAML/full.golden
+++ b/lib/tbot/services/identity/testdata/TestKeyAgentService_YAML/full.golden
@@ -1,8 +1,6 @@
 name: key-agent
 credential_ttl: 1m0s
 renewal_interval: 30s
-roles:
-  - access
 cluster: leaf.example.com
 allow_reissue: true
 destination:

--- a/lib/tbot/services/k8s/output_v1.go
+++ b/lib/tbot/services/k8s/output_v1.go
@@ -157,9 +157,7 @@ func (s *OutputV1Service) generate(ctx context.Context) error {
 		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
 		identity.WithLogger(s.log),
 	}
-	if s.cfg.DelegationSessionID == "" {
-		identityOpts = append(identityOpts, identity.WithRoles(s.cfg.Roles))
-	} else {
+	if s.cfg.DelegationSessionID != "" {
 		identityOpts = append(identityOpts, identity.WithDelegation(s.cfg.DelegationSessionID))
 	}
 	id, err := s.identityGenerator.GenerateFacade(ctx, identityOpts...)

--- a/lib/tbot/services/k8s/output_v1_config.go
+++ b/lib/tbot/services/k8s/output_v1_config.go
@@ -39,9 +39,8 @@ type OutputV1Config struct {
 	Name string `yaml:"name,omitempty"`
 	// Destination is where the credentials should be written to.
 	Destination destination.Destination `yaml:"destination"`
-	// Roles is the list of roles to request for the generated credentials.
-	// If empty, it defaults to all the bot's roles.
-	Roles []string `yaml:"roles,omitempty"`
+	// DeprecatedRoles is the removed `roles` field; see internal.CheckDeprecatedRoles.
+	DeprecatedRoles []string `yaml:"roles,omitempty"`
 
 	// KubernetesCluster is the name of the Kubernetes cluster in Teleport.
 	// This is named a little more verbosely to avoid conflicting with the
@@ -76,6 +75,9 @@ func (o *OutputV1Config) SetName(name string) {
 }
 
 func (o *OutputV1Config) CheckAndSetDefaults(scoped bool) error {
+	if err := internal.CheckDeprecatedRoles(o.DeprecatedRoles); err != nil {
+		return trace.Wrap(err)
+	}
 	if scoped {
 		return trace.BadParameter("service type %q is not supported in scoped mode", OutputV1ServiceType)
 	}
@@ -87,9 +89,6 @@ func (o *OutputV1Config) CheckAndSetDefaults(scoped bool) error {
 	}
 	if o.KubernetesCluster == "" {
 		return trace.BadParameter("kubernetes_cluster must not be empty")
-	}
-	if o.DelegationSessionID != "" && len(o.Roles) > 0 {
-		return trace.BadParameter("delegation_session_id: is mutually-exclusive with roles")
 	}
 	return nil
 }

--- a/lib/tbot/services/k8s/output_v1_config_test.go
+++ b/lib/tbot/services/k8s/output_v1_config_test.go
@@ -33,7 +33,6 @@ func TestKubernetesOutput_YAML(t *testing.T) {
 			name: "full",
 			in: OutputV1Config{
 				Destination:         dest,
-				Roles:               []string{"access"},
 				KubernetesCluster:   "k8s.example.com",
 				DelegationSessionID: "8a50ba48-2fad-4c2c-a8ce-f48bc18db9ee",
 				CredentialLifetime: bot.CredentialLifetime{
@@ -60,7 +59,6 @@ func TestKubernetesOutput_CheckAndSetDefaults(t *testing.T) {
 			in: func() *OutputV1Config {
 				return &OutputV1Config{
 					Destination:       destination.NewMemory(),
-					Roles:             []string{"access"},
 					KubernetesCluster: "my-cluster",
 				}
 			},
@@ -85,16 +83,15 @@ func TestKubernetesOutput_CheckAndSetDefaults(t *testing.T) {
 			wantErr: "kubernetes_cluster must not be empty",
 		},
 		{
-			name: "delegation session id conflicts with roles",
+			name: "roles is no longer supported",
 			in: func() *OutputV1Config {
 				return &OutputV1Config{
-					Destination:         destination.NewMemory(),
-					Roles:               []string{"access"},
-					KubernetesCluster:   "my-cluster",
-					DelegationSessionID: "8a50ba48-2fad-4c2c-a8ce-f48bc18db9ee",
+					Destination:       destination.NewMemory(),
+					KubernetesCluster: "my-cluster",
+					DeprecatedRoles:   []string{"access"},
 				}
 			},
-			wantErr: "delegation_session_id: is mutually-exclusive with roles",
+			wantErr: "roles: the roles field is no longer supported",
 		},
 		{
 			name:   "scoped",

--- a/lib/tbot/services/k8s/testdata/TestKubernetesOutput_YAML/full.golden
+++ b/lib/tbot/services/k8s/testdata/TestKubernetesOutput_YAML/full.golden
@@ -1,8 +1,6 @@
 type: kubernetes
 destination:
   type: memory
-roles:
-  - access
 kubernetes_cluster: k8s.example.com
 disable_exec_plugin: false
 delegation_session_id: 8a50ba48-2fad-4c2c-a8ce-f48bc18db9ee

--- a/lib/tbot/services/ssh/host_output.go
+++ b/lib/tbot/services/ssh/host_output.go
@@ -124,7 +124,6 @@ func (s *HostOutputService) generate(ctx context.Context) error {
 
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
 	id, err := s.identityGenerator.GenerateFacade(ctx,
-		identity.WithRoles(s.cfg.Roles),
 		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
 		identity.WithLogger(s.log),
 	)

--- a/lib/tbot/services/ssh/host_output_config.go
+++ b/lib/tbot/services/ssh/host_output_config.go
@@ -52,9 +52,8 @@ type HostOutputConfig struct {
 	Name string `yaml:"name,omitempty"`
 	// Destination is where the credentials should be written to.
 	Destination destination.Destination `yaml:"destination"`
-	// Roles is the list of roles to request for the generated credentials.
-	// If empty, it defaults to all the bot's roles.
-	Roles []string `yaml:"roles,omitempty"`
+	// DeprecatedRoles is the removed `roles` field; see internal.CheckDeprecatedRoles.
+	DeprecatedRoles []string `yaml:"roles,omitempty"`
 
 	// Principals is a list of principals to request for the host cert.
 	Principals []string `yaml:"principals"`
@@ -87,6 +86,9 @@ func (o *HostOutputConfig) GetDestination() destination.Destination {
 }
 
 func (o *HostOutputConfig) CheckAndSetDefaults(scoped bool) error {
+	if err := internal.CheckDeprecatedRoles(o.DeprecatedRoles); err != nil {
+		return trace.Wrap(err)
+	}
 	if scoped {
 		return trace.BadParameter("service type %q is not supported in scoped mode", HostOutputServiceType)
 	}

--- a/lib/tbot/services/ssh/host_output_config_test.go
+++ b/lib/tbot/services/ssh/host_output_config_test.go
@@ -34,7 +34,6 @@ func TestSSHHostOutput_YAML(t *testing.T) {
 			name: "full",
 			in: HostOutputConfig{
 				Destination: dest,
-				Roles:       []string{"access"},
 				Principals:  []string{"host.example.com"},
 				CAType:      types.UserCA,
 				CredentialLifetime: bot.CredentialLifetime{
@@ -61,11 +60,22 @@ func TestSSHHostOutput_CheckAndSetDefaults(t *testing.T) {
 			in: func() *HostOutputConfig {
 				return &HostOutputConfig{
 					Destination: destination.NewMemory(),
-					Roles:       []string{"access"},
 					Principals:  []string{"host.example.com"},
 					CAType:      types.OpenSSHCA,
 				}
 			},
+		},
+		{
+			name: "roles is no longer supported",
+			in: func() *HostOutputConfig {
+				return &HostOutputConfig{
+					Destination:     destination.NewMemory(),
+					Principals:      []string{"host.example.com"},
+					CAType:          types.OpenSSHCA,
+					DeprecatedRoles: []string{"access"},
+				}
+			},
+			wantErr: "roles: the roles field is no longer supported",
 		},
 		{
 			name: "default ca_type",

--- a/lib/tbot/services/ssh/testdata/TestSSHHostOutput_YAML/full.golden
+++ b/lib/tbot/services/ssh/testdata/TestSSHHostOutput_YAML/full.golden
@@ -1,8 +1,6 @@
 type: ssh_host
 destination:
   type: memory
-roles:
-  - access
 principals:
   - host.example.com
 ca_type: user

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -377,10 +377,6 @@ func TestBot(t *testing.T) {
 	identityOutput := &identitysvc.OutputConfig{
 		Destination: &destination.Memory{},
 	}
-	identityOutputWithRoles := &identitysvc.OutputConfig{
-		Destination: &destination.Memory{},
-		Roles:       []string{mainRole},
-	}
 	identityOutputWithReissue := &identitysvc.OutputConfig{
 		Destination:  &destination.Memory{},
 		AllowReissue: true,
@@ -422,7 +418,6 @@ func TestBot(t *testing.T) {
 	botConfig := defaultBotConfig(
 		t, process, botParams, config.ServiceConfigs{
 			identityOutput,
-			identityOutputWithRoles,
 			appOutput,
 			dbOutput,
 			dbDiscoveredNameOutput,
@@ -460,13 +455,6 @@ func TestBot(t *testing.T) {
 		tlsIdent := tlsIdentFromDest(ctx, t, identityOutput.GetDestination())
 		requireValidOutputTLSIdent(
 			t, tlsIdent, defaultRoles, botResource.GetStatus().GetUserName(), false,
-		)
-	})
-
-	t.Run("output: identity with role specified", func(t *testing.T) {
-		tlsIdent := tlsIdentFromDest(ctx, t, identityOutputWithRoles.GetDestination())
-		requireValidOutputTLSIdent(
-			t, tlsIdent, []string{mainRole}, botResource.GetStatus().GetUserName(), false,
 		)
 	})
 


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/68344

Changelog: Breaking! Removed support for `roles` configuration field in `tbot`. See https://goteleport.com/docs/reference/machine-workload-identity/v19-upgrade-guide/ for further information.

Rather than straight-up remove these fields, I've preserved them within the struct. This allows us to show an error specific to this deprecation should a user be providing these fields.

Removing the ability to configure this field sets out a path whereby we can drop the selective role assumption mechanic from RPCs like `GenerateUserCerts`. This mechanic potentially weakens security in the Classic RBAC model - where dropped roles could contain vital deny clauses. Ideally, this also sets out a path whereby we can remove role assumption from `tbot` entirely - which would greatly simplify logic within `tbot` and reduce the number of certificates issued by `tbot`.

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

- [x] Configure `identity` service with `roles` field, ensure error shows.
- [x] Regression: Configure `identity` service without `roles` field, ensure it works.
