### PR TITLE
Document deprecation of `roles` config field in `tbot`

### DIFF
--- a/docs/pages/machine-workload-identity/faq.mdx
+++ b/docs/pages/machine-workload-identity/faq.mdx
@@ -56,12 +56,6 @@ For simpler scenarios — where you only expect the bot to use a single service
 or role — you can add the login to the logins trait of the bot user. This
 approach allows you to leverage default roles like `access`.
 
-For situations where your bot is producing certificates for different roles in
-different services, it is important to consider whether using a login trait
-grants access to resources that you didn't intend. To prevent a login trait from
-granting access you didn't intend, we recommend that you create bespoke roles
-that explicitly specify the logins that should be included in the certificates.
-
 ## Can MWI be used with per-session MFA?
 
 We do not currently support MWI and per-session MFA. Enabling per-session

--- a/docs/pages/reference/machine-workload-identity/v19-upgrade-guide.mdx
+++ b/docs/pages/reference/machine-workload-identity/v19-upgrade-guide.mdx
@@ -36,4 +36,4 @@ that you migrate to an approach that leverages distinct Bots with distinct sets
 of roles. You may run multiple instances of `tbot` on the same machine as long
 as they are configured to use different storage directories.
 
-For further assistance, reach out to the Teleport support team.
+For further assistance, reach out to the [Teleport support team](https://support.goteleport.com/hc/en-us).

--- a/docs/pages/reference/machine-workload-identity/v19-upgrade-guide.mdx
+++ b/docs/pages/reference/machine-workload-identity/v19-upgrade-guide.mdx
@@ -27,8 +27,9 @@ services:
 ```
 
 Removing the `roles` field will result in the service or output utilizing all
-roles available to the Bot that `tbot` has authenticated as. In many cases, this
-is the desired behavior.
+roles available to the Bot that `tbot` has authenticated as. Be aware that this
+may represent an increase in privileges if a subset of the Bot's roles were
+previously specified.
 
 If you require differing roles for different services or outputs, we recommend
 that you migrate to an approach that leverages distinct Bots with distinct sets

--- a/docs/pages/reference/machine-workload-identity/v19-upgrade-guide.mdx
+++ b/docs/pages/reference/machine-workload-identity/v19-upgrade-guide.mdx
@@ -1,0 +1,38 @@
+---
+title: V19 Upgrade Guide
+description: An overview of breaking changes to Machine & Workload Identity in Teleport V19
+tags:
+ - conceptual
+ - mwi
+---
+
+This document explains any breaking changes to Machine & Workload Identity in
+Teleport V19 and provides guidance on how to navigate these changes.
+
+## Deprecation of `roles` configuration in `tbot`
+
+From V19.0.0, it is no longer possible to configure per-service role
+impersonation in `tbot`.
+
+You are impacted if your `tbot` configuration includes a service or output that
+contains a non-empty `roles` field. For example:
+
+```yaml
+services:
+- type: identity
+  roles: ["role1"]
+  destination:
+    type: directory
+    path: /opt/machine-id
+```
+
+Removing the `roles` field will result in the service or output utilizing all
+roles available to the Bot that `tbot` has authenticated as. In many cases, this
+is the desired behavior.
+
+If you require differing roles for different services or outputs, we recommend
+that you migrate to an approach that leverages distinct Bots with distinct sets
+of roles. You may run multiple instances of `tbot` on the same machine as long
+as they are configured to use different storage directories.
+
+For further assistance, reach out to the Teleport support team.


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/68344

Adds a v19 upgrade guide to the MWI reference.
