### PR TITLE
chore: updates the beams delete copy in cli to mentione ai summaries

### DIFF
--- a/tool/tsh/common/beams_rm.go
+++ b/tool/tsh/common/beams_rm.go
@@ -83,7 +83,8 @@ func (c *beamsRMCommand) run(cf *CLIConf) error {
 
 	if _, err := fmt.Fprintf(
 		cf.Stdout(),
-		"Beam %q successfully deleted.\n",
+		"Beam %q successfully deleted.\n"+
+			"An AI-generated summary for the beam will be available in 15-30 minutes in Beams > History in the Web UI.\n",
 		beam.GetStatus().GetAlias(),
 	); err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
## Changes
`tsh beams rm` success output now includes a second line pointing to the upcoming AI-generated summary in Beams > History in the Web UI.

## Screenshot
<img width="765" height="44" alt="image" src="https://github.com/user-attachments/assets/745d2819-a76a-4267-bada-aa02711f9601" />


<!-- Provide a descriptive entry for the changelog of the next release. -->


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- Cluster with beams enabled
-  `tsh` built locally from this branch (`make build/tsh`)
### Test Cases
- [x] `tsh beams add` followed by `tsh beams rm <beam-name>` → prints: `Beam "<beam-name>" successfully deleted.` followed by `An AI-generated summary for the beam will be available in 15-30 minutes in Beams > History in the Web UI.`

