### PR TITLE
Adding scoped `tctl` resource handlers for `kube_server`

### DIFF
--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -41,7 +41,6 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/scopes"
-	scopecache "github.com/gravitational/teleport/lib/scopes/cache"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
 	"github.com/gravitational/teleport/lib/utils"
@@ -1752,21 +1751,13 @@ func (s *PresenceService) listKubeServers(ctx context.Context, req proto.ListRes
 }
 
 func getFakePaginationKey(ki backend.KeyedItem) string {
-	// TODO(eriktate/scopes): this will need to be reassessed when we implement scoped namespacing
-	if kubeCluster, ok := ki.(types.KubeCluster); ok {
-		if scope := kubeCluster.GetScope(); scope != "" {
-			// It should not be possible for EncodeStringToCursor to fail given that we've already
-			// confirmed the scope is non-empty and "@" is not a valid character for kube cluster
-			// names. However, in the case that it does fail for some reason, we fall back to
-			// backend.GetPaginationKey() since it will still work perfectly fine in lieu of
-			// duplicates cluster names across scope boundaries.
-			if key, err := scopecache.EncodeStringCursor(scopecache.Cursor[string]{
-				Key:   kubeCluster.GetName(),
-				Scope: scope,
-			}); err == nil {
-				return key
-			}
-		}
+	switch item := ki.(type) {
+	case types.KubeCluster:
+		return services.GetCursorForKubeCluster(item)
+	case types.KubeServer:
+		return services.GetCursorForKubeServer(item)
+	case types.AppServer:
+		return services.GetCursorForAppServer(item)
 	}
 
 	return backend.GetPaginationKey(ki)

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -1565,6 +1565,121 @@ func TestFakePaginateWithScopes(t *testing.T) {
 	}
 }
 
+func TestFakePaginateScopedCursors(t *testing.T) {
+	t.Parallel()
+	clock := clockwork.NewFakeClock()
+	bend, err := memory.New(memory.Config{
+		Clock: clock,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = bend.Close() })
+
+	const scope = "/aa"
+	encodedScope := scopes.EncodeForResourceCursor(scope)
+
+	unscopedKubeCluster, err := types.NewKubernetesClusterV3(
+		types.Metadata{
+			Name: "cluster",
+		},
+		types.KubernetesClusterSpecV3{},
+	)
+	require.NoError(t, err)
+
+	scopedKubeCluster, err := types.NewKubernetesClusterV3(
+		types.Metadata{
+			Name: "cluster",
+		},
+		types.KubernetesClusterSpecV3{},
+		types.KubeClusterWithScope(scope),
+	)
+	require.NoError(t, err)
+
+	unscopedKubeServer, err := types.NewKubernetesServerV3FromCluster(unscopedKubeCluster, "host", "host-id")
+	require.NoError(t, err)
+
+	scopedKubeServer, err := types.NewKubernetesServerV3FromCluster(scopedKubeCluster, "host", "host-id")
+	require.NoError(t, err)
+
+	unscopedApp, err := types.NewAppV3(types.Metadata{Name: "a"},
+		types.AppSpecV3{URI: "http://localhost:8080"})
+	require.NoError(t, err)
+
+	unscopedAppServer, err := types.NewAppServerV3FromApp(unscopedApp, "host", "host-id")
+	require.NoError(t, err)
+
+	scopedApp, err := types.NewAppV3(types.Metadata{Name: "a"},
+		types.AppSpecV3{URI: "http://localhost:8080"}, scope)
+	require.NoError(t, err)
+	scopedAppServer, err := types.NewAppServerV3FromApp(scopedApp, "host", "host-id")
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name          string
+		params        FakePaginateParams
+		resources     []types.ResourceWithLabels
+		expectNextKey string
+		expectErr     bool
+	}{
+		{
+			name: "next key is scoped kube cluster",
+			params: FakePaginateParams{
+				ResourceType: types.KindKubernetesCluster,
+				Limit:        1,
+			},
+			resources:     []types.ResourceWithLabels{unscopedKubeCluster, scopedKubeCluster},
+			expectNextKey: "~scoped/" + encodedScope + "/cluster",
+		},
+		{
+			name: "next key is unscoped kube cluster",
+			params: FakePaginateParams{
+				ResourceType: types.KindKubernetesCluster,
+				Limit:        1,
+			},
+			resources:     []types.ResourceWithLabels{scopedKubeCluster, unscopedKubeCluster},
+			expectNextKey: "cluster",
+		},
+		{
+			name: "fake paginating kube servers should fail",
+			params: FakePaginateParams{
+				ResourceType: types.KindKubeServer,
+				Limit:        2,
+			},
+			resources: []types.ResourceWithLabels{unscopedKubeServer, scopedKubeServer},
+			expectErr: true,
+		},
+		{
+			name: "next key is scoped app server",
+			params: FakePaginateParams{
+				ResourceType: types.KindAppServer,
+				Limit:        1,
+			},
+			resources:     []types.ResourceWithLabels{unscopedAppServer, scopedAppServer},
+			expectNextKey: "~scoped/" + encodedScope + "/host-id/a",
+		},
+		{
+			name: "next key is unscoped app server",
+			params: FakePaginateParams{
+				ResourceType: types.KindAppServer,
+				Limit:        1,
+			},
+			resources:     []types.ResourceWithLabels{scopedAppServer, unscopedAppServer},
+			expectNextKey: "host-id/a",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := FakePaginate(tt.resources, tt.params)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.expectNextKey, res.NextKey)
+		})
+	}
+
+}
+
 func TestPresenceService_CancelSemaphoreLease(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/lib/services/matchers.go
+++ b/lib/services/matchers.go
@@ -201,6 +201,8 @@ func MatchResourceByFilters(resource types.ResourceWithLabels, filter MatchResou
 		scope = res.GetScope()
 	case types.KubeServer:
 		scope = res.GetScope()
+	case types.AppServer:
+		scope = res.GetScope()
 	}
 	// We assume when filtering for services like KubeService, AppServer, and DatabaseServer
 	// the user is wanting to filter the contained resource ie. KubeClusters, Application, and Database.

--- a/tool/tctl/common/resources/kube_server.go
+++ b/tool/tctl/common/resources/kube_server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/tool/common"
 )
@@ -55,7 +56,10 @@ func (c *kubeServerCollection) WriteText(w io.Writer, verbose bool) error {
 		}
 		labels := common.FormatLabels(kube.GetAllLabels(), verbose)
 		rows = append(rows, []string{
-			common.FormatResourceName(kube, verbose),
+			scopes.QualifiedName{
+				Scope: server.GetScope(),
+				Name:  common.FormatResourceName(kube, verbose),
+			}.String(),
 			labels,
 			server.GetTeleportVersion(),
 		})
@@ -94,7 +98,7 @@ func getKubeServer(ctx context.Context, client *authclient.Client, ref services.
 	altNameFn := func(r types.KubeServer) string {
 		return r.GetHostname()
 	}
-	servers = FilterByNameOrDiscoveredName(servers, ref.Name, altNameFn)
+	servers = FilterBySQNOrDiscoveredName(servers, scopes.QualifiedName{Name: ref.Name}, altNameFn)
 	if len(servers) == 0 {
 		return nil, trace.NotFound("Kubernetes server %q not found", ref.Name)
 	}
@@ -107,14 +111,17 @@ func deleteKubeServer(ctx context.Context, client *authclient.Client, ref servic
 		return trace.Wrap(err)
 	}
 	resDesc := "Kubernetes server"
-	servers = FilterByNameOrDiscoveredName(servers, ref.Name)
+	// this filters scoped servers out of the result set so that they aren't accidentally deleted
+	// along with their unscoped counterpart
+	servers = FilterBySQNOrDiscoveredName(servers, scopes.QualifiedName{Name: ref.Name})
 	name, err := GetOneResourceNameToDelete(servers, ref, resDesc)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	for _, s := range servers {
 		err := client.DeleteKubeServer(ctx, presencev1.DeleteKubeServerRequest_builder{
-			Scope:  s.GetScope(),
+			// we omit scope here as an extra measure to prevent unintended deletion of scoped
+			// kube servers
 			HostId: s.GetHostID(),
 			Name:   name,
 		}.Build())
@@ -123,5 +130,62 @@ func deleteKubeServer(ctx context.Context, client *authclient.Client, ref servic
 		}
 	}
 	fmt.Printf("%s %q has been deleted\n", resDesc, name)
+	return nil
+}
+
+func scopedKubeServerHandler() ScopedHandler {
+	return ScopedHandler{
+		getHandler:    getScopedKubeServer,
+		deleteHandler: deleteScopedKubeServer,
+		description:   "Represents a Kubernetes service instance that proxies access to Kubernetes clusters.",
+	}
+}
+
+func getScopedKubeServer(ctx context.Context, client *authclient.Client, subKind string, sqn *scopes.QualifiedName, _ GetOpts) (Collection, error) {
+	if subKind != "" {
+		return nil, rejectSubKind(types.KindKubeServer, subKind)
+	}
+
+	servers, err := client.GetKubernetesServers(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if sqn == nil {
+		return NewKubeServerCollection(servers), nil
+	}
+
+	servers = FilterBySQNOrDiscoveredName(servers, *sqn)
+	if len(servers) == 0 {
+		return nil, trace.NotFound("Kubernetes server %q not found", sqn.String())
+	}
+	return NewKubeServerCollection(servers), nil
+}
+
+func deleteScopedKubeServer(ctx context.Context, client *authclient.Client, subKind string, sqn scopes.QualifiedName) error {
+	if subKind != "" {
+		return rejectSubKind(types.KindKubeServer, subKind)
+	}
+
+	// Fetch first to verify scope before deleting.
+	servers, err := client.GetKubernetesServers(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	servers = FilterBySQNOrDiscoveredName(servers, sqn)
+	if len(servers) == 0 {
+		return trace.NotFound("Kubernetes server %q not found", sqn.String())
+	}
+
+	for _, server := range servers {
+		if err := client.DeleteKubeServer(ctx, presencev1.DeleteKubeServerRequest_builder{
+			Scope:  server.GetScope(),
+			HostId: server.GetHostID(),
+			Name:   server.GetName(),
+		}.Build()); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	fmt.Printf("%v %q has been deleted\n", types.KindKubeServer, sqn.String())
 	return nil
 }

--- a/tool/tctl/common/resources/scoped_handler.go
+++ b/tool/tctl/common/resources/scoped_handler.go
@@ -42,6 +42,7 @@ func ScopedHandlers() map[string]ScopedHandler {
 		scopedaccess.KindScopedRoleAssignment: scopedRoleAssignmentScopedHandler(),
 		types.KindAccessList:                  accessListScopedHandler(),
 		types.KindKubernetesCluster:           scopedKubeClusterHandler(),
+		types.KindKubeServer:                  scopedKubeServerHandler(),
 	}
 }
 


### PR DESCRIPTION
Adds missing scoped handlers for fetching and deleting scoped kube servers and:
- Resolves an issue where deleting an unscoped kube server by name would delete scoped clusters that share the name.
- Uses finalized cursor keys for kube clusters, kube servers, and app servers when using fake pagination

## Manual Test Plan
### Test Environment
Local cluster with scopes enabled
### Test Cases
- [x] Fetch unscoped `kube_server` by name
- [x] Fetch scoped `kube_server` by SQN
- [x] Delete unscoped `kube_server` by name (does not delete scoped server with the same cluster name)
- [x] Delete scoped `kube_server` by SQN
- [x] Listing kube clusters, servers, and app servers still works properly (fake pagination is only used by kube clusters, adding kube and app servers is a precaution)
