### PR TITLE
allow configuring web session client dial options

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -57,6 +57,7 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 	"golang.org/x/crypto/ssh"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -201,6 +202,10 @@ type Handler struct {
 	autoUpdateResolver *autoupdatelookup.Resolver
 
 	accessGraphHandler http.Handler
+
+	// webSessionRootClientDialOptions contains additional gRPC dial options for
+	// root clients created for web sessions. Used for testing.
+	webSessionRootClientDialOptions []grpc.DialOption
 }
 
 // HandlerOption is a functional argument - an option that can be passed
@@ -211,6 +216,15 @@ type HandlerOption func(h *Handler) error
 func SetClock(clock clockwork.Clock) HandlerOption {
 	return func(h *Handler) error {
 		h.clock = clock
+		return nil
+	}
+}
+
+// WithWebSessionRootClientDialOption adds a [grpc.DialOption] to root clients
+// created for web sessions. It is intended for tests.
+func WithWebSessionRootClientDialOption(opt grpc.DialOption) HandlerOption {
+	return func(h *Handler) error {
+		h.webSessionRootClientDialOptions = append(h.webSessionRootClientDialOptions, opt)
 		return nil
 	}
 }
@@ -620,6 +634,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 		proxySigner:               cfg.PROXYSigner,
 		logger:                    h.logger,
 		buildType:                 cfg.Modules.BuildType(),
+		rootClientDialOptions:     h.webSessionRootClientDialOptions,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -645,6 +645,8 @@ type sessionCacheOptions struct {
 	sessionWatcherEventProcessedChannel chan struct{}
 	logger                              *slog.Logger
 	buildType                           string
+	// See [sessionCache.rootClientDialOptions]. Used for testing.
+	rootClientDialOptions []grpc.DialOption
 }
 
 // newSessionCache creates a [sessionCache] from the provided [config] and
@@ -687,6 +689,7 @@ func newSessionCache(ctx context.Context, config sessionCacheOptions) (*sessionC
 		}),
 		sessionWatcherEventProcessedChannel: config.sessionWatcherEventProcessedChannel,
 		buildType:                           config.buildType,
+		rootClientDialOptions:               config.rootClientDialOptions,
 	}
 
 	// periodically close expired and unused sessions
@@ -751,6 +754,9 @@ type sessionCache struct {
 	// May be nil.
 	// Used for testing.
 	sessionWatcherEventProcessedChannel chan struct{}
+	// rootClientDialOptions contains additional gRPC dial options for root clients.
+	// Used for testing.
+	rootClientDialOptions []grpc.DialOption
 }
 
 // Close closes all allocated resources and stops goroutines
@@ -1214,6 +1220,7 @@ func (s *sessionCache) newSessionContextFromSession(ctx context.Context, session
 		Credentials:          []apiclient.Credentials{apiclient.LoadTLS(tlsConfig)},
 		CircuitBreakerConfig: breaker.NoopBreakerConfig(),
 		PROXYHeaderGetter:    client.CreatePROXYHeaderGetter(ctx, s.proxySigner),
+		DialOpts:             s.rootClientDialOptions,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
Adds a web handler option for forwarding gRPC dial options to root clients created for web sessions.

For the time being, this is only used for test code and this is specifically being added to support the tests in this PR: https://github.com/gravitational/teleport.e/pull/9227

This allows Enterprise web tests to configure a per-handler receive-message limit instead of using the process-wide
`TELEPORT_UNSTABLE_GRPC_RECV_SIZE` environment variable. I previously used the env var in my test but that required me to not use `t.Parallel()`. With this change, I can safely use `t.Parallel()` in my test. (original suggestion here: https://github.com/gravitational/teleport.e/pull/9227#discussion_r3682391908)

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local macos build

### Test Cases
- [x] `go test ./e/lib/web -run ^TestAccessListsAdjustPageSize$ -count=1 -v`
