### PR TITLE
Fix missing prerequisite for Teleport user in CA Override doc.

### DIFF
--- a/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
@@ -57,10 +57,37 @@ The `cert_authority_override` resource targets a CA with the following fields:
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise (v18.9.0 or higher)"!)
 
+- A Teleport user with a role that has access to the `cert_authority_override`
+  resource. The preset `editor` role does not have this access. To grant it, add
+  the following rule to your role:
+
+  ```yaml
+  kind: role
+  version: v8
+  metadata:
+    name: <Var name="role-name" />
+  spec:
+    allow:
+      rules:
+        - resources:
+            - cert_authority_override
+          verbs:
+            - read
+            - list
+            - create
+            - update
+            - delete
+  ```
+
+  Assign the `<Var name="role-name" />` role to the user who will manage CA
+  overrides.
+
 - Only the following CAs are currently supported: `db_client` and `windows`.
+
 - All Auth Service instances and related services, such as Windows Desktop
   Service and Database Service instances, must be upgraded to the same CA
   override-aware Teleport version.
+
 - For safety, back up your cluster state before starting and retain downstream
   trust to the self-signed CA certificates until the upgrade is fully verified.
 

--- a/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
@@ -83,9 +83,11 @@ The `cert_authority_override` resource targets a CA with the following fields:
   CA overrides.
 
 - Only the following CAs are currently supported: `db_client` and `windows`.
+
 - All Auth Service instances and related services, such as Windows Desktop
   Service and Database Service instances, must be upgraded to the same CA
   override-aware Teleport version.
+
 - For safety, back up your cluster state before starting and retain downstream
   trust to the self-signed CA certificates until the upgrade is fully verified.
 

--- a/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
@@ -65,29 +65,27 @@ The `cert_authority_override` resource targets a CA with the following fields:
   kind: role
   version: v8
   metadata:
-    name: <Var name="role-name" />
+    name: <Var name="ca-override-admin" />
   spec:
     allow:
       rules:
         - resources:
             - cert_authority_override
           verbs:
-            - read
-            - list
             - create
-            - update
             - delete
+            - list
+            - read
+            - update
   ```
 
-  Assign the `<Var name="role-name" />` role to the user who will manage CA
-  overrides.
+  Assign the `<Var name="ca-override-admin" />` role to the user who will manage
+  CA overrides.
 
 - Only the following CAs are currently supported: `db_client` and `windows`.
-
 - All Auth Service instances and related services, such as Windows Desktop
   Service and Database Service instances, must be upgraded to the same CA
   override-aware Teleport version.
-
 - For safety, back up your cluster state before starting and retain downstream
   trust to the self-signed CA certificates until the upgrade is fully verified.
 


### PR DESCRIPTION
Went through the [official guide for CA Overrides ](https://goteleport.com/docs/zero-trust-access/management/security/ca-overrides/) and noticed that it doesn't tell you that your Teleport user needs certain permissions to actually follow the guide. Found this out after running the first command and had to debug to figure out why.

This change adds guidance under **Prerequisites**, following the doc pattern in the [Cloud Client IP Restrictions](https://goteleport.com/docs/zero-trust-access/management/security/ca-overrides/) page.

I tested it by following the guide and, good news, CA Overrides works too 😄 