### PR TITLE
Fix e2e push runs on release branches always building against OSS master

### DIFF
--- a/.github/workflows/e2e-tests-base.yaml
+++ b/.github/workflows/e2e-tests-base.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: ${{ inputs.oss-repository || github.repository }}
-          ref: ${{ inputs.oss-repository && (github.event.pull_request.base.ref || github.event.merge_group.base_ref) || '' }}
+          ref: ${{ inputs.oss-repository && (github.event.pull_request.base.ref || github.event.merge_group.base_ref || github.ref_name) || '' }}
           fetch-depth: 1
 
       - name: Checkout Enterprise
@@ -201,7 +201,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: ${{ inputs.oss-repository || github.repository }}
-          ref: ${{ inputs.oss-repository && (github.event.pull_request.base.ref || github.event.merge_group.base_ref) || '' }}
+          ref: ${{ inputs.oss-repository && (github.event.pull_request.base.ref || github.event.merge_group.base_ref || github.ref_name) || '' }}
           fetch-depth: 1
           persist-credentials: false
 


### PR DESCRIPTION
## Purpose

This PR adds `github.ref_name` as a fallback for the OSS checkout ref in the e2e workflow so that push runs on
enterprise branches check out their correct corresponding OSS branch.

[Push events don't supply the `pull_request.base.ref` or `merge_group.base_ref`](https://docs.github.com/en/webhooks/webhook-events-and-payloads#push) which means the ref would always resolve to the empty string (which would just be the default branch aka `master`). This meant that a push to `branch/v18` in enterprise would build against OSS master.

This hadn't caused us any issues until now since enterprise e2e tests currently only exist on `master`, so the OSS ref always resolving to `master` worked fine, but this issue would likely have surfaced once we cut `branch/v19`.