### PR TITLE
[v18] Frontend for logging in to a scope

### DIFF
--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -65,6 +65,7 @@ import { ListView } from './ListView/ListView';
 import { ResourceTab } from './ResourceTab';
 import { getResourceId } from './shared/StatusInfo';
 import { mapResourceToViewItem } from './shared/viewItemsFactory';
+import './unifiedStyles.css';
 import {
   IncludedResourceMode,
   PinningSupport,
@@ -912,8 +913,12 @@ const ListFooter = styled.div`
  */
 export function getResourceAvailabilityFilter(
   availableResourceMode: AvailableResourceMode,
-  canRequestAllResources: boolean
+  canRequestAllResources: boolean,
+  scopedSession: boolean = false
 ): ResourceAvailabilityFilter {
+  if (scopedSession) {
+    return { mode: 'accessible', canRequestAll: false };
+  }
   switch (availableResourceMode) {
     case AvailableResourceMode.NONE:
       if (!canRequestAllResources) {

--- a/web/packages/teleport/src/Login/Login.story.tsx
+++ b/web/packages/teleport/src/Login/Login.story.tsx
@@ -50,6 +50,7 @@ export const Otp = () => <Login {...sample} auth2faType="otp" />;
 export const Webauthn = () => <Login {...sample} auth2faType="webauthn" />;
 export const Optional = () => <Login {...sample} auth2faType="optional" />;
 export const On = () => <Login {...sample} auth2faType="on" />;
+export const Scoped = () => <Login {...sample} scope="/prod/west" />;
 export const CommunityAcknowledgement = () => {
   cfg.edition = 'community';
   return <Login {...sample} licenseAcknowledged={false} />;
@@ -108,4 +109,5 @@ const sample: State = {
   acknowledgeMotd: () => null,
   licenseAcknowledged: true,
   setLicenseAcknowledged: () => {},
+  scope: '',
 };

--- a/web/packages/teleport/src/Login/Login.test.tsx
+++ b/web/packages/teleport/src/Login/Login.test.tsx
@@ -17,6 +17,7 @@
  */
 
 import { userEvent, UserEvent } from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
 import selectEvent from 'react-select-event';
 
 import { fireEvent, render, screen, waitFor } from 'design/utils/testing';
@@ -39,100 +40,127 @@ beforeEach(() => {
   user = userEvent.setup();
 });
 
+function LoginTest({ initialURL }: { initialURL?: string }) {
+  const initialEntries = initialURL ? [initialURL] : undefined;
+  return (
+    <MemoryRouter initialEntries={initialEntries}>
+      <Login />
+    </MemoryRouter>
+  );
+}
+
 test('basic rendering', () => {
-  render(<Login />);
+  render(<LoginTest />);
 
   // test rendering of logo and title
   expect(screen.getByRole('img')).toBeInTheDocument();
   expect(screen.getByText(/sign in to teleport/i)).toBeInTheDocument();
 });
 
-test('login with redirect', async () => {
-  jest.spyOn(auth, 'login').mockResolvedValue({});
+describe.each([
+  {
+    name: 'unscoped',
+    url: '/web/login',
+    scope: '',
+    ssoURL:
+      'http://localhost/v1/webapi/github/login/web?connector_id=github&redirect_url=http%3A%2F%2Flocalhost%2Fweb',
+  },
+  {
+    name: 'scoped',
+    url: '/web/login?scope=%2Fdev',
+    scope: '/dev',
+    ssoURL:
+      'http://localhost/v1/webapi/github/login/web?connector_id=github&scope=%2Fdev&redirect_url=http%3A%2F%2Flocalhost%2Fweb',
+  },
+])('$name', ({ url, scope, ssoURL }) => {
+  test('login with redirect', async () => {
+    jest.spyOn(auth, 'login').mockResolvedValue({});
 
-  render(<Login />);
+    render(<LoginTest initialURL={url} />);
 
-  // fill form
-  const username = screen.getByPlaceholderText(/username/i);
-  const password = screen.getByPlaceholderText(/password/i);
-  fireEvent.change(username, { target: { value: 'username' } });
-  fireEvent.change(password, { target: { value: '123' } });
+    // fill form
+    const user = userEvent.setup();
+    await user.type(screen.getByPlaceholderText(/username/i), 'username');
+    await user.type(screen.getByPlaceholderText(/password/i), '123');
 
-  // test login and redirect
-  fireEvent.click(screen.getByText('Sign In'));
-  await waitFor(() => {
-    expect(auth.login).toHaveBeenCalledWith('username', '123', '');
+    // test login and redirect
+    await user.click(screen.getByText('Sign In'));
+    await waitFor(() => {
+      expect(auth.login).toHaveBeenCalledWith('username', '123', '', scope);
+    });
+    expect(history.push).toHaveBeenCalledWith('http://localhost/web', true);
   });
-  expect(history.push).toHaveBeenCalledWith('http://localhost/web', true);
-});
 
-test('login with MFA, changing method to OTP', async () => {
-  jest.spyOn(cfg, 'getAuth2faType').mockImplementation(() => 'optional');
-  jest.spyOn(auth, 'login').mockResolvedValue({});
+  test('login with MFA, changing method to OTP', async () => {
+    jest.spyOn(cfg, 'getAuth2faType').mockImplementation(() => 'optional');
+    jest.spyOn(auth, 'login').mockResolvedValue({});
 
-  render(<Login />);
+    render(<LoginTest initialURL={url} />);
 
-  // fill form
-  const username = screen.getByLabelText(/username/i);
-  const password = screen.getByLabelText(/password/i);
-  const mfaType = screen.getByLabelText(/multi-factor type/i);
-  await user.type(username, 'username');
-  await user.type(password, '123');
+    // fill form
+    const username = screen.getByLabelText(/username/i);
+    const password = screen.getByLabelText(/password/i);
+    const mfaType = screen.getByLabelText(/multi-factor type/i);
+    await user.type(username, 'username');
+    await user.type(password, '123');
 
-  expect(
-    screen.queryByLabelText(/authenticator code/i)
-  ).not.toBeInTheDocument();
-  await selectEvent.select(mfaType, 'Authenticator App');
-  const authCode = screen.getByLabelText(/authenticator code/i);
-  await user.type(authCode, '987654');
+    expect(
+      screen.queryByLabelText(/authenticator code/i)
+    ).not.toBeInTheDocument();
+    await selectEvent.select(mfaType, 'Authenticator App');
+    const authCode = screen.getByLabelText(/authenticator code/i);
+    await user.type(authCode, '987654');
 
-  // test login and redirect
-  fireEvent.click(screen.getByText('Sign In'));
-  await waitFor(() => {
-    expect(auth.login).toHaveBeenCalledWith('username', '123', '987654');
+    // test login and redirect
+    fireEvent.click(screen.getByText('Sign In'));
+    await waitFor(() => {
+      expect(auth.login).toHaveBeenCalledWith(
+        'username',
+        '123',
+        '987654',
+        scope
+      );
+    });
+    expect(history.push).toHaveBeenCalledWith('http://localhost/web', true);
   });
-  expect(history.push).toHaveBeenCalledWith('http://localhost/web', true);
-});
 
-test('login with SSO', () => {
-  jest.spyOn(cfg, 'getAuth2faType').mockImplementation(() => 'otp');
-  jest.spyOn(cfg, 'getPrimaryAuthType').mockImplementation(() => 'sso');
-  jest.spyOn(cfg, 'getAuthProviders').mockImplementation(() => [
-    {
-      displayName: 'With GitHub',
-      type: 'github',
-      name: 'github',
-      url: '/github/login/web?connector_id=:providerName&redirect_url=:redirect?',
-    },
-  ]);
+  test('login with SSO', () => {
+    jest.spyOn(cfg, 'getAuth2faType').mockImplementation(() => 'otp');
+    jest.spyOn(cfg, 'getPrimaryAuthType').mockImplementation(() => 'sso');
+    jest.spyOn(cfg, 'getAuthProviders').mockImplementation(() => [
+      {
+        displayName: 'With GitHub',
+        type: 'github',
+        name: 'github',
+        url: '/v1/webapi/github/login/web?connector_id=:providerName&scope=:scope?&redirect_url=:redirect',
+      },
+    ]);
 
-  render(<Login />);
+    render(<LoginTest initialURL={url} />);
 
-  // test login pathways
-  fireEvent.click(screen.getByText('With GitHub'));
-  expect(history.push).toHaveBeenCalledWith(
-    'http://localhost/github/login/web?connector_id=github&redirect_url=http%3A%2F%2Flocalhost%2Fweb',
-    true
-  );
-});
+    // test login pathways
+    fireEvent.click(screen.getByText('With GitHub'));
+    expect(history.push).toHaveBeenCalledWith(ssoURL, true);
+  });
 
-test('passwordless login', async () => {
-  jest.spyOn(cfg, 'getPrimaryAuthType').mockReturnValue('passwordless');
-  jest.spyOn(auth, 'loginWithWebauthn').mockResolvedValue({});
+  test('passwordless login', async () => {
+    jest.spyOn(cfg, 'getPrimaryAuthType').mockReturnValue('passwordless');
+    jest.spyOn(auth, 'loginWithWebauthn').mockResolvedValue({});
 
-  render(<Login />);
+    render(<LoginTest initialURL={url} />);
 
-  await user.click(
-    screen.getByRole('button', { name: 'Sign in with a Passkey' })
-  );
-  expect(auth.loginWithWebauthn).toHaveBeenCalledWith(undefined); // No credentials
-  expect(history.push).toHaveBeenCalledWith('http://localhost/web', true);
+    await user.click(
+      screen.getByRole('button', { name: 'Sign in with a Passkey' })
+    );
+    expect(auth.loginWithWebauthn).toHaveBeenCalledWith(undefined, scope); // No credentials
+    expect(history.push).toHaveBeenCalledWith('http://localhost/web', true);
+  });
 });
 
 describe('test MOTD', () => {
   test('show motd only if motd is set', async () => {
     // default login form
-    const { unmount } = render(<Login />);
+    const { unmount } = render(<LoginTest />);
     expect(screen.getByPlaceholderText(/username/i)).toBeInTheDocument();
     expect(
       screen.queryByText('Welcome to cluster, your activity will be recorded.')
@@ -146,7 +174,7 @@ describe('test MOTD', () => {
         () => 'Welcome to cluster, your activity will be recorded.'
       );
 
-    render(<Login />);
+    render(<LoginTest />);
 
     expect(
       screen.getByText('Welcome to cluster, your activity will be recorded.')
@@ -160,7 +188,7 @@ describe('test MOTD', () => {
       .mockImplementation(
         () => 'Welcome to cluster, your activity will be recorded.'
       );
-    render(<Login />);
+    render(<LoginTest />);
     expect(
       screen.getByText('Welcome to cluster, your activity will be recorded.')
     ).toBeInTheDocument();
@@ -181,7 +209,7 @@ describe('test MOTD', () => {
         'https://teleport.example.com/web/headless/5c5c1f73-ac5c-52ee-bc9e-0353094dcb4a'
       );
 
-    render(<Login />);
+    render(<LoginTest />);
 
     expect(
       screen.queryByText('Welcome to cluster, your activity will be recorded.')
@@ -191,7 +219,7 @@ describe('test MOTD', () => {
   test('access changed message renders when the URL param is set', () => {
     jest.spyOn(history, 'hasAccessChangedParam').mockImplementation(() => true);
 
-    render(<Login />);
+    render(<LoginTest />);
 
     expect(screen.getByText(/sign in to teleport/i)).toBeInTheDocument();
     expect(screen.getByText(/Your access has changed/i)).toBeInTheDocument();
@@ -205,7 +233,7 @@ test('redirect to root if session is valid and path is not "/enterprise/saml-idp
     .mockReturnValue(
       'http://localhost/web/login?redirect_url=http://localhost/web/cluster/localhost/resources'
     );
-  render(<Login />);
+  render(<LoginTest />);
 
   expect(history.replace).toHaveBeenCalledWith('/web');
 });
@@ -216,6 +244,6 @@ test('redirect if session is valid and path matches "/enterprise/saml-idp/sso"',
   jest
     .spyOn(history, 'getRedirectParam')
     .mockReturnValue(samlIdPPath.toString());
-  render(<Login />);
+  render(<LoginTest />);
   expect(history.push).toHaveBeenCalledWith(samlIdPPath, true);
 });

--- a/web/packages/teleport/src/Login/Login.tsx
+++ b/web/packages/teleport/src/Login/Login.tsx
@@ -52,6 +52,7 @@ export function LoginComponent({
   motd,
   showMotd,
   acknowledgeMotd,
+  scope,
 }: State) {
   // while we are checking if a session is valid, we don't return anything
   // to prevent flickering. The check only happens for a frame or two so
@@ -89,6 +90,7 @@ export function LoginComponent({
           clearAttempt={clearAttempt}
           isPasswordlessEnabled={isPasswordlessEnabled}
           primaryAuthType={primaryAuthType}
+          scope={scope}
         />
       )}
     </>

--- a/web/packages/teleport/src/Login/Login.tsx
+++ b/web/packages/teleport/src/Login/Login.tsx
@@ -52,6 +52,7 @@ export function LoginComponent({
   motd,
   showMotd,
   acknowledgeMotd,
+  scope,
 }: State) {
   // while we are checking if a session is valid, we don't return anything
   // to prevent flickering. The check only happens for a frame or two so
@@ -85,6 +86,7 @@ export function LoginComponent({
           clearAttempt={clearAttempt}
           isPasswordlessEnabled={isPasswordlessEnabled}
           primaryAuthType={primaryAuthType}
+          scope={scope}
         />
       )}
     </>

--- a/web/packages/teleport/src/Login/useLogin.test.tsx
+++ b/web/packages/teleport/src/Login/useLogin.test.tsx
@@ -17,6 +17,8 @@
  */
 
 import { renderHook } from '@testing-library/react';
+import { PropsWithChildren } from 'react';
+import { MemoryRouter } from 'react-router';
 
 import cfg from 'teleport/config';
 import history from 'teleport/services/history';
@@ -45,15 +47,19 @@ afterEach(() => {
   jest.resetAllMocks();
 });
 
+function Wrapper({ children }: PropsWithChildren) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
 it('redirect to root on path not matching "/enterprise/saml-idp/sso"', () => {
   jest.spyOn(history, 'getRedirectParam').mockReturnValue('http://localhost');
-  renderHook(() => useLogin());
+  renderHook(() => useLogin(), { wrapper: Wrapper });
   expect(history.replace).toHaveBeenCalledWith('/web');
 
   jest
     .spyOn(history, 'getRedirectParam')
     .mockReturnValue('http://localhost/web/cluster/name/resources');
-  renderHook(() => useLogin());
+  renderHook(() => useLogin(), { wrapper: Wrapper });
   expect(history.replace).toHaveBeenCalledWith('/web');
 });
 
@@ -63,7 +69,7 @@ it('redirect to SAML SSO path on matching "/enterprise/saml-idp/sso"', () => {
   jest
     .spyOn(history, 'getRedirectParam')
     .mockReturnValue(samlIdpPath.toString());
-  renderHook(() => useLogin());
+  renderHook(() => useLogin(), { wrapper: Wrapper });
   expect(history.push).toHaveBeenCalledWith(samlIdpPath, true);
 });
 
@@ -72,7 +78,7 @@ it('non-base domain redirects with base domain for a matching "/enterprise/saml-
   jest
     .spyOn(history, 'getRedirectParam')
     .mockReturnValue(samlIdpPath.toString());
-  renderHook(() => useLogin());
+  renderHook(() => useLogin(), { wrapper: Wrapper });
   const expectedPath = new URL('http://localhost' + cfg.routes.samlIdpSso);
   expect(history.push).toHaveBeenCalledWith(expectedPath, true);
 });
@@ -82,7 +88,7 @@ it('base domain with different path is redirected to root', async () => {
   jest
     .spyOn(history, 'getRedirectParam')
     .mockReturnValue(nonSamlIdpPath.toString());
-  renderHook(() => useLogin());
+  renderHook(() => useLogin(), { wrapper: Wrapper });
   expect(history.replace).toHaveBeenCalledWith('/web');
 });
 
@@ -94,7 +100,7 @@ it('invalid session does nothing', async () => {
     .spyOn(history, 'getRedirectParam')
     .mockReturnValue(samlIdpPathWithDifferentBase.toString());
   jest.spyOn(session, 'isValid').mockImplementation(() => false);
-  renderHook(() => useLogin());
+  renderHook(() => useLogin(), { wrapper: Wrapper });
   expect(history.replace).not.toHaveBeenCalled();
   expect(history.push).not.toHaveBeenCalled();
 });

--- a/web/packages/teleport/src/Login/useLogin.ts
+++ b/web/packages/teleport/src/Login/useLogin.ts
@@ -17,7 +17,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import { matchPath } from 'react-router';
+import { matchPath, useLocation } from 'react-router';
 
 import { TrustedDeviceRequirement } from 'gen-proto-ts/teleport/legacy/types/trusted_device_requirement_pb';
 import { useAttempt } from 'shared/hooks';
@@ -55,6 +55,11 @@ export default function useLogin() {
     setShowMotd(false);
   }
 
+  const location = useLocation();
+  const scope: string | null = new URLSearchParams(location.search).get(
+    'scope'
+  );
+
   // onSuccess can receive a device webtoken. If so, it will
   // enable a prompt to allow users to authorize the current
   function onSuccess({
@@ -64,6 +69,7 @@ export default function useLogin() {
     // deviceWebToken will only exist on a login response
     // from enterprise but just in case there is a version mismatch
     // between the webclient and proxy
+    storageService.setScopeSelected(scope != null);
     if (trustedDeviceRequirement === TrustedDeviceRequirement.REQUIRED) {
       session.setDeviceTrustRequired();
     }
@@ -76,7 +82,7 @@ export default function useLogin() {
   useEffect(() => {
     if (session.isValid()) {
       try {
-        const redirectUrlWithBase = new URL(getEntryRoute());
+        const redirectUrlWithBase = new URL(history.getEntryRoute());
         const matched = matchPath(redirectUrlWithBase.pathname, {
           path: cfg.routes.samlIdpSso,
           strict: true,
@@ -102,7 +108,7 @@ export default function useLogin() {
     attemptActions.start();
     storageService.clearLoginTime();
     auth
-      .login(email, password, token)
+      .login(email, password, token, scope || '')
       .then(onSuccess)
       .catch(err => {
         attemptActions.error(err);
@@ -113,7 +119,7 @@ export default function useLogin() {
     attemptActions.start();
     storageService.clearLoginTime();
     auth
-      .loginWithWebauthn(creds)
+      .loginWithWebauthn(creds, scope || '')
       .then(onSuccess)
       .catch(err => {
         attemptActions.error(err);
@@ -123,13 +129,15 @@ export default function useLogin() {
   function onLoginWithSso(provider: AuthProvider, loginHint?: string) {
     attemptActions.start();
     storageService.clearLoginTime();
-    const appStartRoute = getEntryRoute();
-    const ssoUri = cfg.getSsoUrl(
-      provider.url,
-      provider.name,
-      appStartRoute,
-      loginHint
-    );
+    const appStartRoute = history.getEntryRoute();
+    const ssoUri = cfg.getSsoUrl({
+      providerUrl: provider.url,
+      providerName: provider.name,
+      redirect: appStartRoute,
+      loginHint,
+      scope: scope || '',
+    });
+    storageService.setScopeSelected(scope !== null);
     history.push(ssoUri, true);
   }
 
@@ -157,6 +165,7 @@ export default function useLogin() {
     motd,
     showMotd,
     acknowledgeMotd,
+    scope,
   };
 }
 
@@ -181,25 +190,9 @@ function authorizeWithDeviceTrust(token: DeviceWebToken) {
 }
 
 function loginSuccess() {
-  const redirect = getEntryRoute();
+  const redirect = history.getEntryRoute();
   const withPageRefresh = true;
   history.push(redirect, withPageRefresh);
-}
-
-/**
- * getEntryRoute returns a base ensured redirect URL value that is safe
- * for redirect.
- * @returns base ensured URL string.
- */
-function getEntryRoute() {
-  let entryUrl = history.getRedirectParam();
-  if (entryUrl) {
-    entryUrl = history.ensureKnownRoute(entryUrl);
-  } else {
-    entryUrl = cfg.routes.root;
-  }
-
-  return history.ensureBaseUrl(entryUrl);
 }
 
 export type State = ReturnType<typeof useLogin> & {

--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -38,6 +38,7 @@ import {
 import { marginTransitionCss } from 'shared/components/SlidingSidePanel/InfoGuide/const';
 import { ToastNotifications } from 'shared/components/ToastNotification';
 import useAttempt from 'shared/hooks/useAttemptNext';
+import { useStore } from 'shared/libs/stores';
 
 import { BannerList } from 'teleport/components/BannerList';
 import type { BannerType } from 'teleport/components/BannerList/BannerList';
@@ -73,6 +74,7 @@ export interface MainProps {
 
 export function Main(props: MainProps) {
   const ctx = useTeleport();
+  const storeUser = useStore(ctx.storeUser);
   const history = useHistory();
 
   const { attempt, setAttempt, run } = useAttempt('processing');
@@ -90,10 +92,15 @@ export function Main(props: MainProps) {
 
   const featureFlags = ctx.getFeatureFlags();
 
+  const scope = storeUser?.getScope();
   const features = useMemo(
     () =>
-      props.features.filter(feature => canShowFeature(feature, featureFlags)),
-    [featureFlags, props.features]
+      props.features.filter(
+        feature =>
+          canShowFeature(feature, featureFlags) &&
+          supportsCurrentScope(feature, scope)
+      ),
+    [featureFlags, props.features, scope]
   );
 
   const { alerts, dismissAlert } = useAlerts(props.initialAlerts);
@@ -134,7 +141,8 @@ export function Main(props: MainProps) {
     if (
       cfg.scopesEnabled &&
       availableScopes.length > 0 &&
-      !isScopePickerRoute
+      !isScopePickerRoute &&
+      !storageService.getScopeSelected()
     ) {
       return <Redirect to={historyService.getScopePickerUrl()} />;
     }
@@ -167,13 +175,15 @@ export function Main(props: MainProps) {
     return 'danger';
   };
 
-  const banners: BannerType[] = alerts.map((alert): BannerType => ({
-    message: alert.spec.message,
-    severity: mapSeverity(alert.spec.severity),
-    linkDestination: alert.metadata.labels[LINK_DESTINATION_LABEL],
-    linkText: alert.metadata.labels[LINK_TEXT_LABEL],
-    id: alert.metadata.name,
-  }));
+  const banners: BannerType[] = alerts.map(
+    (alert): BannerType => ({
+      message: alert.spec.message,
+      severity: mapSeverity(alert.spec.severity),
+      linkDestination: alert.metadata.labels[LINK_DESTINATION_LABEL],
+      linkText: alert.metadata.labels[LINK_TEXT_LABEL],
+      id: alert.metadata.name,
+    })
+  );
 
   return (
     <FeaturesContextProvider value={features}>
@@ -260,6 +270,13 @@ function renderRoutes(
   }
 
   return routes;
+}
+
+function supportsCurrentScope(
+  feature: TeleportFeature,
+  scope: string
+): boolean {
+  return !scope || feature.supportsScopes;
 }
 
 function FeatureRoutes({ lockedFeatures }: { lockedFeatures: LockedFeatures }) {

--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -175,15 +175,13 @@ export function Main(props: MainProps) {
     return 'danger';
   };
 
-  const banners: BannerType[] = alerts.map(
-    (alert): BannerType => ({
-      message: alert.spec.message,
-      severity: mapSeverity(alert.spec.severity),
-      linkDestination: alert.metadata.labels[LINK_DESTINATION_LABEL],
-      linkText: alert.metadata.labels[LINK_TEXT_LABEL],
-      id: alert.metadata.name,
-    })
-  );
+  const banners: BannerType[] = alerts.map((alert): BannerType => ({
+    message: alert.spec.message,
+    severity: mapSeverity(alert.spec.severity),
+    linkDestination: alert.metadata.labels[LINK_DESTINATION_LABEL],
+    linkText: alert.metadata.labels[LINK_TEXT_LABEL],
+    id: alert.metadata.name,
+  }));
 
   return (
     <FeaturesContextProvider value={features}>

--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -38,6 +38,7 @@ import {
 import { marginTransitionCss } from 'shared/components/SlidingSidePanel/InfoGuide/const';
 import { ToastNotifications } from 'shared/components/ToastNotification';
 import useAttempt from 'shared/hooks/useAttemptNext';
+import { useStore } from 'shared/libs/stores';
 
 import { BannerList } from 'teleport/components/BannerList';
 import type { BannerType } from 'teleport/components/BannerList/BannerList';
@@ -72,6 +73,7 @@ export interface MainProps {
 
 export function Main(props: MainProps) {
   const ctx = useTeleport();
+  const storeUser = useStore(ctx.storeUser);
   const history = useHistory();
 
   const { attempt, setAttempt, run } = useAttempt('processing');
@@ -89,9 +91,15 @@ export function Main(props: MainProps) {
 
   const featureFlags = ctx.getFeatureFlags();
 
+  const scope = storeUser?.getScope();
   const features = useMemo(
-    () => props.features.filter(feature => feature.hasAccess(featureFlags)),
-    [featureFlags, props.features]
+    () =>
+      props.features.filter(
+        feature =>
+          feature.hasAccess(featureFlags) &&
+          supportsCurrentScope(feature, scope)
+      ),
+    [featureFlags, props.features, scope]
   );
 
   const { alerts, dismissAlert } = useAlerts(props.initialAlerts);
@@ -132,7 +140,8 @@ export function Main(props: MainProps) {
     if (
       cfg.scopesEnabled &&
       availableScopes.length > 0 &&
-      !isScopePickerRoute
+      !isScopePickerRoute &&
+      !storageService.getScopeSelected()
     ) {
       return <Redirect to={historyService.getScopePickerUrl()} />;
     }
@@ -260,6 +269,13 @@ function renderRoutes(
   }
 
   return routes;
+}
+
+function supportsCurrentScope(
+  feature: TeleportFeature,
+  scope: string
+): boolean {
+  return !scope || feature.supportsScopes;
 }
 
 function FeatureRoutes({ lockedFeatures }: { lockedFeatures: LockedFeatures }) {

--- a/web/packages/teleport/src/Scopes/LoginScopePicker.tsx
+++ b/web/packages/teleport/src/Scopes/LoginScopePicker.tsx
@@ -26,6 +26,9 @@ import * as Icon from 'design/Icon';
 import { H1, H2 } from 'design/Text';
 import { useStore } from 'shared/libs/stores';
 
+import history from 'teleport/services/history/history';
+import { storageService } from 'teleport/services/storageService';
+import session from 'teleport/services/websession/websession';
 import useTeleport from 'teleport/useTeleport';
 
 /**
@@ -39,6 +42,17 @@ export function LoginScopePicker() {
   const ctx = useTeleport();
   const storeUser = useStore(ctx.storeUser);
 
+  function signInWithScope(scope: string) {
+    session.switchScope(scope);
+  }
+
+  function signInWithoutScope() {
+    storageService.setScopeSelected(true);
+    const redirect = history.getEntryRoute();
+    const withPageRefresh = true;
+    history.push(redirect, withPageRefresh);
+  }
+
   return (
     <Box px="5" width="100%" overflow="scroll">
       <Card my="5" mx="auto" width="100%" maxWidth={600} p={4}>
@@ -47,9 +61,28 @@ export function LoginScopePicker() {
           Choose a scope for your session:
         </H2>
         <Stack gap={2} as={Ul}>
+          <Li>
+            <ScopeButton
+              block
+              size="extra-large"
+              onClick={() => signInWithoutScope()}
+            >
+              <Icon.Home />
+              <Flex justifyContent="start" flex={1}>
+                Teleport Home
+              </Flex>
+              <SignInAffordance gap={2}>
+                Sign in <Icon.ArrowForward />
+              </SignInAffordance>
+            </ScopeButton>
+          </Li>
           {storeUser.getAvailableScopes().map(scope => (
             <Li key={scope}>
-              <ScopeButton key={scope} block size="extra-large">
+              <ScopeButton
+                block
+                size="extra-large"
+                onClick={() => signInWithScope(scope)}
+              >
                 <Icon.Contract />
                 <Flex justifyContent="start" flex={1}>
                   {scope}

--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -21,8 +21,10 @@ import { matchPath, useHistory } from 'react-router';
 import { Link } from 'react-router-dom';
 import styled, { css, useTheme } from 'styled-components';
 
-import { Box, breakpointsPx, Flex, Image, TopNav } from 'design';
+import { Box, breakpointsPx, Flex, Image, Text, TopNav } from 'design';
+import * as Icon from 'design/Icon';
 import { HoverTooltip } from 'design/Tooltip';
+import { useStore } from 'shared/libs/stores';
 
 import { logoSrc } from 'teleport/components/LogoHero/LogoHero';
 import { UserMenuNav } from 'teleport/components/UserMenuNav';
@@ -45,6 +47,8 @@ export function TopBar({
   const history = useHistory();
   const features = useFeatures();
   const { currentWidth } = useLayout();
+  const storeUser = useStore(ctx.storeUser);
+  const scope = storeUser.getScope();
 
   // find active feature
   const feature = features.find(
@@ -63,10 +67,24 @@ export function TopBar({
 
   return (
     <TopBarContainer>
-      <TeleportLogo CustomLogo={CustomLogo} withLink={!scopePickerMode} />
+      <Flex alignItems="center">
+        <TeleportLogo CustomLogo={CustomLogo} withLink={!scopePickerMode} />
+        {scope && !feature?.logoOnlyTopbar && (
+          <HoverTooltip tipContent="Current scope">
+            <Flex alignItems="center" gap={1}>
+              <Icon.Contract aria-label="scope" />
+              <Text typography="body1">{scope}</Text>
+            </Flex>
+          </HoverTooltip>
+        )}
+      </Flex>
       {!feature?.logoOnlyTopbar && (
         <Flex height="100%" alignItems="center">
-          <Notifications iconSize={iconSize} />
+          {
+            // TODO(bl-nero): enable notifications once they're supported by
+            // scopes.
+            !scope && <Notifications iconSize={iconSize} />
+          }
           <UserMenuNav
             username={ctx.storeUser.state.username}
             hideFeatures={feature instanceof FeatureScopes}
@@ -141,12 +159,6 @@ const commonLogoWrapperStyles = css`
   align-items: center;
   height: 100%;
   margin-right: 0px;
-  @media screen and (min-width: ${p => p.theme.breakpoints.medium}) {
-    margin-right: 76px;
-  }
-  @media screen and (min-width: ${p => p.theme.breakpoints.large}) {
-    margin-right: 67px;
-  }
 `;
 
 const BoxLogoWrapper = styled(Box)`

--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -39,6 +39,7 @@ import {
   getResourceId,
   openStatusInfoPanel,
 } from 'shared/components/UnifiedResources/shared/StatusInfo';
+import { useStore } from 'shared/libs/stores';
 
 import { useTeleport } from 'teleport';
 import AgentButtonAdd from 'teleport/components/AgentButtonAdd';
@@ -166,6 +167,7 @@ export function ClusterResources({
   availabilityFilter?: ResourceAvailabilityFilter;
 }) {
   const teleCtx = useTeleport();
+  const storeUser = useStore(teleCtx.storeUser);
   const flags = teleCtx.getFeatureFlags();
 
   useNoMinWidth();
@@ -318,11 +320,15 @@ export function ClusterResources({
         availableKinds={getAvailableKindsWithAccess(flags)}
         pinning={pinning}
         ClusterDropdown={
-          <ClusterDropdown
-            clusterLoader={teleCtx.clusterService}
-            clusterId={clusterId}
-            onError={setLoadClusterError}
-          />
+          // TODO(bl-nero): Enable cluster dropdown for scoped sessions once
+          // it's supported on the backend.
+          storeUser.getScope() ? undefined : (
+            <ClusterDropdown
+              clusterLoader={teleCtx.clusterService}
+              clusterId={clusterId}
+              onError={setLoadClusterError}
+            />
+          )
         }
         NoResources={
           <Empty

--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -38,6 +38,7 @@ import {
   getResourceId,
   openStatusInfoPanel,
 } from 'shared/components/UnifiedResources/shared/StatusInfo';
+import { useStore } from 'shared/libs/stores';
 
 import { useTeleport } from 'teleport';
 import AgentButtonAdd from 'teleport/components/AgentButtonAdd';
@@ -157,6 +158,7 @@ export function ClusterResources({
   availabilityFilter?: ResourceAvailabilityFilter;
 }) {
   const teleCtx = useTeleport();
+  const storeUser = useStore(teleCtx.storeUser);
   const flags = teleCtx.getFeatureFlags();
 
   useNoMinWidth();
@@ -309,11 +311,15 @@ export function ClusterResources({
         availableKinds={getAvailableKindsWithAccess(flags)}
         pinning={pinning}
         ClusterDropdown={
-          <ClusterDropdown
-            clusterLoader={teleCtx.clusterService}
-            clusterId={clusterId}
-            onError={setLoadClusterError}
-          />
+          // TODO(bl-nero): Enable cluster dropdown for scoped sessions once
+          // it's supported on the backend.
+          storeUser.getScope() ? undefined : (
+            <ClusterDropdown
+              clusterLoader={teleCtx.clusterService}
+              clusterId={clusterId}
+              onError={setLoadClusterError}
+            />
+          )
         }
         NoResources={
           <Empty

--- a/web/packages/teleport/src/components/FormLogin/FormLogin.story.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormLogin.story.tsx
@@ -39,6 +39,7 @@ const props: Props = {
   auth2faType: 'off',
   primaryAuthType: 'local',
   isPasswordlessEnabled: false,
+  scope: '',
 };
 
 export default {
@@ -82,6 +83,8 @@ export const Cloud = () => (
     onRecover={() => null}
   />
 );
+
+export const Scoped = () => <FormLogin {...props} scope="/dev/east" />;
 
 export const ServerError = () => {
   const attempt = {

--- a/web/packages/teleport/src/components/FormLogin/FormLogin.test.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormLogin.test.tsx
@@ -249,4 +249,5 @@ const props: Props = {
   onLoginWithWebauthn: null,
   isPasswordlessEnabled: false,
   primaryAuthType: 'local',
+  scope: '',
 };

--- a/web/packages/teleport/src/components/FormLogin/FormLogin.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormLogin.tsx
@@ -31,6 +31,7 @@ import {
   Text,
 } from 'design';
 import * as Alerts from 'design/Alert';
+import * as Icon from 'design/Icon';
 import { StepComponentProps, StepSlider } from 'design/StepSlider';
 import { P } from 'design/Text/Text';
 import FieldInput from 'shared/components/FieldInput';
@@ -68,6 +69,7 @@ export default function LoginForm(props: Props) {
     primaryAuthType,
     title = 'Sign in to Teleport',
     ssoTitle = 'Sign in to Teleport with SSO',
+    scope,
   } = props;
 
   const [showIdentifierFirstLogin, setShowIdentifierFirstLogin] = useState(
@@ -115,6 +117,12 @@ export default function LoginForm(props: Props) {
       <Text typography="h1" mb={4} textAlign="center">
         {title}
       </Text>
+      {scope && (
+        <Flex gap={2} alignItems="center" justifyContent="center">
+          <Icon.Contract aria-label="scope" />
+          <Text typography="body1">{scope}</Text>
+        </Flex>
+      )}
       {errorMessage && <Alerts.Danger m={4}>{errorMessage}</Alerts.Danger>}
       {showAccessChangedMessage && (
         <Alerts.Warning m={4}>
@@ -511,6 +519,7 @@ export type Props = {
   onLogin(username: string, password: string, token: string): void;
   autoFocus?: boolean;
   setShowIdentifierFirstLogin?: (value: boolean) => void;
+  scope: string;
 };
 
 type AttemptState = ReturnType<typeof useAttempt>[0];

--- a/web/packages/teleport/src/config.test.ts
+++ b/web/packages/teleport/src/config.test.ts
@@ -82,26 +82,36 @@ test('getIntegrationsEnroll without extra params', () => {
 
 test('getSsoUrl', () => {
   const providerUrl =
-    '/v1/webapi/oidc/login/web?connector_id=:providerName&login_hint=:loginHint?&redirect_url=:redirect';
+    '/v1/webapi/oidc/login/web?connector_id=:providerName&login_hint=:loginHint?&redirect_url=:redirect&scope=:scope?';
   expect(
-    cfg.getSsoUrl(providerUrl, 'keycloak', 'example.com', undefined)
+    cfg.getSsoUrl({
+      providerUrl,
+      providerName: 'keycloak',
+      redirect: 'example.com',
+    })
   ).toEqual(
     'http://localhost/v1/webapi/oidc/login/web?connector_id=keycloak&redirect_url=example.com'
   );
   expect(
-    cfg.getSsoUrl(providerUrl, 'keycloak', 'example.com', 'user@example.com')
+    cfg.getSsoUrl({
+      providerUrl,
+      providerName: 'keycloak',
+      redirect: 'example.com',
+      loginHint: 'user@example.com',
+      scope: '/foo/bar',
+    })
   ).toEqual(
-    'http://localhost/v1/webapi/oidc/login/web?connector_id=keycloak&login_hint=user@example.com&redirect_url=example.com'
+    'http://localhost/v1/webapi/oidc/login/web?connector_id=keycloak&login_hint=user@example.com&redirect_url=example.com&scope=%2Ffoo%2Fbar'
   );
   expect(
-    cfg.getSsoUrl(
+    cfg.getSsoUrl({
       providerUrl,
-      'keycloak',
-      'example.com?a=b&c=d',
-      'user@example.com'
-    )
+      providerName: 'keycloak',
+      redirect: 'example.com?a=b&c=d',
+      loginHint: 'user@example.com',
+    })
   ).toEqual(
-    'http://localhost/v1/webapi/oidc/login/web?connector_id=keycloak&login_hint=user@example.com&redirect_url=example.com%3Fa=b&c=d'
+    'http://localhost/v1/webapi/oidc/login/web?connector_id=keycloak&login_hint=user%40example.com&redirect_url=example.com%3Fa%3Db&c=d'
   );
 });
 

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -779,18 +779,38 @@ const cfg = {
     return searchString ? `${path}?${searchString}` : path;
   },
 
-  getSsoUrl(providerUrl, providerName, redirect, loginHint) {
+  getSsoUrl({
+    providerUrl,
+    providerName,
+    redirect,
+    loginHint,
+    scope,
+  }: {
+    providerUrl: string;
+    providerName: string;
+    redirect: string;
+    loginHint?: string;
+    scope?: string;
+  }) {
     loginHint = loginHint === '' ? undefined : loginHint;
+    scope = scope === '' ? undefined : scope;
     let basePath =
       cfg.baseUrl +
-      generatePath(providerUrl, { redirect, providerName, loginHint });
+      generatePath(providerUrl, {
+        redirect,
+        providerName,
+        loginHint,
+        scope,
+      });
 
+    const url = new URL(basePath);
     if (!loginHint) {
-      const url = new URL(basePath);
       url.searchParams.delete('login_hint', '');
-      basePath = url.toString();
     }
-    return basePath;
+    if (!scope) {
+      url.searchParams.delete('scope', '');
+    }
+    return url.toString();
   },
 
   getAuditRoute(clusterId: string) {

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -141,6 +141,7 @@ export class FeatureUnifiedResources implements TeleportFeature {
   sideNavCategory = SideNavigationCategory.Resources;
   // TODO(rudream): Remove this once shortcuts to pinned/nodes/apps/dbs/desktops/kubes are implemented.
   standalone = true;
+  supportsScopes = true;
 
   route = {
     title: 'Resources',
@@ -919,6 +920,8 @@ export class FeatureAccount implements TeleportFeature {
       'change password',
     ],
   };
+
+  supportsScopes = true;
 }
 
 export class FeatureHelpAndSupport implements TeleportFeature {
@@ -949,6 +952,8 @@ export class FeatureHelpAndSupport implements TeleportFeature {
       'version',
     ],
   };
+
+  supportsScopes = true;
 }
 
 export class FeatureScopes implements TeleportFeature {
@@ -960,6 +965,7 @@ export class FeatureScopes implements TeleportFeature {
   };
 
   hideNavigation = true;
+  supportsScopes = true;
 
   hasAccess(): boolean {
     return cfg.scopesEnabled;

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -151,6 +151,7 @@ export class FeatureUnifiedResources implements TeleportFeature {
   sideNavCategory = SideNavigationCategory.Resources;
   // TODO(rudream): Remove this once shortcuts to pinned/nodes/apps/dbs/desktops/kubes are implemented.
   standalone = true;
+  supportsScopes = true;
 
   route = {
     title: 'Resources',
@@ -910,6 +911,8 @@ export class FeatureAccount implements TeleportFeature {
       'change password',
     ],
   };
+
+  supportsScopes = true;
 }
 
 export class FeatureHelpAndSupport implements TeleportFeature {
@@ -940,6 +943,8 @@ export class FeatureHelpAndSupport implements TeleportFeature {
       'version',
     ],
   };
+
+  supportsScopes = true;
 }
 
 export class FeatureScopes implements TeleportFeature {
@@ -951,6 +956,7 @@ export class FeatureScopes implements TeleportFeature {
   };
 
   hideNavigation = true;
+  supportsScopes = true;
 
   hasAccess(): boolean {
     return cfg.scopesEnabled;

--- a/web/packages/teleport/src/services/auth/auth.test.ts
+++ b/web/packages/teleport/src/services/auth/auth.test.ts
@@ -32,23 +32,25 @@ describe('services/auth', () => {
   test('login()', async () => {
     jest.spyOn(api, 'post').mockResolvedValue({});
 
-    await auth.login(email, password, '');
+    await auth.login(email, password, '' /*otp*/, '' /*scope*/);
     expect(api.post).toHaveBeenCalledWith(cfg.api.webSessionPath, {
       user: email,
       pass: password,
       second_factor_token: '',
+      scope: '',
     });
   });
 
-  test('login() OTP', async () => {
+  test('login() OTP and scope', async () => {
     jest.spyOn(api, 'post').mockResolvedValue({});
     const data = {
       user: email,
       pass: password,
       second_factor_token: 'xxx',
+      scope: '/prod/europe',
     };
 
-    await auth.login(email, password, 'xxx');
+    await auth.login(email, password, 'xxx', '/prod/europe');
     expect(api.post).toHaveBeenCalledWith(cfg.api.webSessionPath, data);
   });
 

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -115,17 +115,18 @@ const auth = {
       .then(parseMfaChallengeJson);
   },
 
-  login(userId: string, password: string, otpCode: string) {
+  login(userId: string, password: string, otpCode: string, scope: string) {
     const data = {
       user: userId,
       pass: password,
       second_factor_token: otpCode,
+      scope,
     };
 
     return api.post(cfg.api.webSessionPath, data);
   },
 
-  loginWithWebauthn(creds?: UserCredentials) {
+  loginWithWebauthn(creds?: UserCredentials, scope: string = '') {
     return auth
       .checkWebauthnSupport()
       .then(() => auth.mfaLoginBegin(creds))
@@ -138,6 +139,7 @@ const auth = {
         const request = {
           user: creds?.username,
           webauthnAssertionResponse: makeWebauthnAssertionResponse(res),
+          scope,
         };
 
         return api.post(cfg.api.mfaLoginFinish, request);

--- a/web/packages/teleport/src/services/history/history.test.ts
+++ b/web/packages/teleport/src/services/history/history.test.ts
@@ -121,7 +121,7 @@ describe('services/history', () => {
       history.goToLogin({ rememberLocation: true });
 
       const expected =
-        '/web/login?redirect_uri=http://localhost/current-location';
+        '/web/login?redirect_uri=http%3A%2F%2Flocalhost%2Fcurrent-location';
       expect(history._pageRefresh).toHaveBeenCalledWith(expected);
     });
 
@@ -132,7 +132,7 @@ describe('services/history', () => {
       history.original().location.pathname = '/bogus-location';
       history.goToLogin({ rememberLocation: true });
 
-      const expected = '/web/login?redirect_uri=http://localhost/web';
+      const expected = '/web/login?redirect_uri=http%3A%2F%2Flocalhost%2Fweb';
       expect(history._pageRefresh).toHaveBeenCalledWith(expected);
     });
 
@@ -143,7 +143,7 @@ describe('services/history', () => {
       history.original().location.pathname = '/current-location';
       history.goToLogin({ withAccessChangedMessage: true });
 
-      const expected = '/web/login?access_changed';
+      const expected = '/web/login?access_changed=';
       expect(history._pageRefresh).toHaveBeenCalledWith(expected);
     });
 
@@ -158,7 +158,7 @@ describe('services/history', () => {
       });
 
       const expected =
-        '/web/login?access_changed&redirect_uri=http://localhost/current-location';
+        '/web/login?access_changed=&redirect_uri=http%3A%2F%2Flocalhost%2Fcurrent-location';
       expect(history._pageRefresh).toHaveBeenCalledWith(expected);
     });
 
@@ -184,7 +184,7 @@ describe('services/history', () => {
       });
 
       const expected =
-        '/web/login?access_changed&redirect_uri=http://localhost/current-location?test=value';
+        '/web/login?access_changed=&redirect_uri=http%3A%2F%2Flocalhost%2Fcurrent-location%3Ftest%3Dvalue';
       expect(history._pageRefresh).toHaveBeenCalledWith(expected);
     });
   });
@@ -196,7 +196,7 @@ describe('services/history', () => {
         .mockReturnValue(['/web/login', '/current-location']);
       history.original().location.pathname = '/current-location';
       expect(history.getScopePickerUrl()).toBe(
-        '/web/scope_picker?redirect_uri=http://localhost/current-location'
+        '/web/scope_picker?redirect_uri=http%3A%2F%2Flocalhost%2Fcurrent-location'
       );
     });
   });
@@ -207,7 +207,7 @@ describe('services/history', () => {
       .mockReturnValue(['/web/login', '/another-location']);
     history.original().location.pathname = '/bogus-location';
     expect(history.getScopePickerUrl()).toBe(
-      '/web/scope_picker?redirect_uri=http://localhost/web'
+      '/web/scope_picker?redirect_uri=http%3A%2F%2Flocalhost%2Fweb'
     );
   });
 });

--- a/web/packages/teleport/src/services/history/history.ts
+++ b/web/packages/teleport/src/services/history/history.ts
@@ -23,6 +23,12 @@ import cfg from 'teleport/config';
 
 let _inst: History = null;
 
+export type LoginOptions = {
+  rememberLocation?: boolean;
+  withAccessChangedMessage?: boolean;
+  scope?: string;
+};
+
 const history = {
   original() {
     return _inst;
@@ -53,29 +59,33 @@ const history = {
   goToLogin({
     rememberLocation = false,
     withAccessChangedMessage = false,
-  } = {}) {
-    const params: string[] = [];
+    scope = '',
+  }: LoginOptions = {}) {
+    const params = new URLSearchParams();
 
     // withAccessChangedMessage determines whether the login page the user is redirected to should include a notice that
     // they were logged out due to their roles having changed.
     if (withAccessChangedMessage) {
-      params.push('access_changed');
+      params.set('access_changed', '');
     }
 
     if (rememberLocation) {
       const { search, pathname } = _inst.location;
       const knownRoute = this.ensureKnownRoute(pathname);
       const knownRedirect = this.ensureBaseUrl(knownRoute);
-      const query = search ? encodeURIComponent(search) : '';
-      params.push(`redirect_uri=${knownRedirect}${query}`);
+      params.set('redirect_uri', knownRedirect + search);
     }
 
-    const queryString = params.join('&');
+    if (scope) {
+      params.set('scope', scope);
+    }
+
+    const queryString = params.toString();
     const url = queryString
       ? `${cfg.routes.login}?${queryString}`
       : cfg.routes.login;
 
-    this._pageRefresh(url);
+    this._pageRefresh(url.toString());
   },
 
   /**
@@ -83,15 +93,14 @@ const history = {
    * the scope has been picked.
    */
   getScopePickerUrl() {
-    const params: string[] = [];
+    const params = new URLSearchParams();
 
     const { search, pathname } = this.getLocation();
     const knownRoute = this.ensureKnownRoute(pathname);
     const knownRedirect = this.ensureBaseUrl(knownRoute);
-    const query = search ? encodeURIComponent(search) : '';
-    params.push(`redirect_uri=${knownRedirect}${query}`);
+    params.set(`redirect_uri`, knownRedirect + search);
 
-    const queryString = params.join('&');
+    const queryString = params.toString();
     const url = queryString
       ? `${cfg.routes.scopePicker}?${queryString}`
       : cfg.routes.scopePicker;
@@ -153,6 +162,22 @@ const history = {
 
   _pageRefresh(route: string) {
     window.location.href = this.ensureBaseUrl(route);
+  },
+
+  /**
+   * getEntryRoute returns a base ensured redirect URL value that is safe
+   * for redirect.
+   * @returns base ensured URL string.
+   */
+  getEntryRoute() {
+    let entryUrl = this.getRedirectParam();
+    if (entryUrl) {
+      entryUrl = this.ensureKnownRoute(entryUrl);
+    } else {
+      entryUrl = cfg.routes.root;
+    }
+
+    return this.ensureBaseUrl(entryUrl);
   },
 };
 

--- a/web/packages/teleport/src/services/history/index.ts
+++ b/web/packages/teleport/src/services/history/index.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import service, { getUrlParameter } from './history';
+import service, { getUrlParameter, LoginOptions } from './history';
 
 export default service;
-export { getUrlParameter };
+export { getUrlParameter, type LoginOptions };

--- a/web/packages/teleport/src/services/storageService/storageService.ts
+++ b/web/packages/teleport/src/services/storageService/storageService.ts
@@ -379,4 +379,18 @@ export const storageService = {
   getUseLoginScopePicker(): boolean {
     return this.getParsedJSONValue(KeysEnum.USE_LOGIN_SCOPE_PICKER, false);
   },
+
+  // Returns true if the user has already picked a scope for this session or
+  // explicitly made the session unscoped. This allows us to tell the
+  // difference between a session that is "implicitly unscoped" (where the user
+  // has not yet interacted with the scope picker) and an "explicitly unscoped"
+  // one (where the user already made their choice). In both cases, the scope
+  // is an empty string, hence this additional flag.
+  getScopeSelected(): boolean {
+    return this.getParsedJSONValue(KeysEnum.SCOPE_SELECTED, false);
+  },
+
+  setScopeSelected(s: boolean) {
+    window.localStorage.setItem(KeysEnum.SCOPE_SELECTED, JSON.stringify(s));
+  },
 };

--- a/web/packages/teleport/src/services/storageService/types.ts
+++ b/web/packages/teleport/src/services/storageService/types.ts
@@ -70,6 +70,7 @@ export const KeysEnum = {
   DESKTOP_HIDPI: 'grv_teleport_desktop_hidpi',
   // TODO(bl-nero): Remove this once the login scope picker is operational.
   USE_LOGIN_SCOPE_PICKER: 'grv_teleport_use_login_scope_picker',
+  SCOPE_SELECTED: 'grv_teleport_scope_selected',
 };
 
 // SurveyRequest is the request for sending data to the back end

--- a/web/packages/teleport/src/services/user/makeUserContext.ts
+++ b/web/packages/teleport/src/services/user/makeUserContext.ts
@@ -34,6 +34,7 @@ export default function makeUserContext(json: any): UserContext {
   const passwordState =
     json.passwordState || PasswordState.PASSWORD_STATE_UNSPECIFIED;
   const availableScopes = json.availableScopes || [];
+  const scope = json.scope || '';
 
   return {
     username,
@@ -46,6 +47,7 @@ export default function makeUserContext(json: any): UserContext {
     allowedSearchAsRoles,
     passwordState,
     availableScopes,
+    scope,
   };
 }
 

--- a/web/packages/teleport/src/services/user/types.ts
+++ b/web/packages/teleport/src/services/user/types.ts
@@ -54,6 +54,8 @@ export interface UserContext {
    * scoped role assignments.
    */
   availableScopes: string[];
+  /** Scope is the scope of current session. Empty if unscoped. */
+  scope: string;
 }
 
 /**

--- a/web/packages/teleport/src/services/user/user.test.ts
+++ b/web/packages/teleport/src/services/user/user.test.ts
@@ -421,6 +421,7 @@ test('undefined values in context response gives proper default values', async (
     allowedSearchAsRoles: [],
     passwordState: PasswordState.PASSWORD_STATE_UNSPECIFIED,
     availableScopes: [],
+    scope: '',
   } as UserContext);
 });
 

--- a/web/packages/teleport/src/services/websession/websession.ts
+++ b/web/packages/teleport/src/services/websession/websession.ts
@@ -39,29 +39,37 @@ const session = {
   _isDeviceTrustRequired: false,
   _isDeviceTrusted: false,
 
-  logout(rememberLocation = false) {
+  async logout(rememberLocation = false) {
     let samlSloUrl = '';
+    try {
+      const response = await this._plainLogout();
+      samlSloUrl = response?.samlSloUrl;
+    } finally {
+      if (samlSloUrl) {
+        window.open(samlSloUrl, '_self');
+      } else {
+        history.goToLogin({ rememberLocation });
+      }
+    }
+  },
 
-    api
-      .delete(cfg.api.webSessionPath)
-      .then(response => {
-        samlSloUrl = response?.samlSloUrl;
-      })
-      .catch(err => {
-        // This request can fail if the session is already expired, which isn't an issue, but we should still catch the error.
-        logger.error(
-          'Failed to delete session. This can happen if the session has already expired.',
-          err
-        );
-      })
-      .finally(() => {
-        this.clear();
-        if (samlSloUrl) {
-          window.open(samlSloUrl, '_self');
-        } else {
-          history.goToLogin({ rememberLocation });
-        }
-      });
+  async _plainLogout(): Promise<{ samlSloUrl: string } | undefined> {
+    try {
+      return await api.deleteWithOptions(cfg.api.webSessionPath, {});
+    } catch (err) {
+      // This request can fail if the session is already expired, which isn't an issue, but we should still catch the error.
+      logger.error(
+        'Failed to delete session. This can happen if the session has already expired.',
+        err
+      );
+    } finally {
+      this.clear();
+    }
+  },
+
+  async switchScope(scope: string) {
+    await this._plainLogout();
+    history.goToLogin({ scope });
   },
 
   logoutWithoutSlo({

--- a/web/packages/teleport/src/stores/storeUserContext.ts
+++ b/web/packages/teleport/src/stores/storeUserContext.ts
@@ -326,4 +326,8 @@ export default class StoreUserContext extends Store<UserContext> {
   getAvailableScopes() {
     return this.state.availableScopes;
   }
+
+  getScope() {
+    return this.state?.scope ?? '';
+  }
 }

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -164,6 +164,11 @@ export interface TeleportFeature {
   showInDashboard?: boolean;
   /** isHyperLink is whether this subsection is merely a hyperlink/shortcut to another subsection. */
   isHyperLink?: boolean;
+  /**
+   * supportsScopes indicates whether this feature should be enabled in scoped
+   * sessions.
+   */
+  supportsScopes?: boolean;
 }
 
 export type StickyCluster = {

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -174,6 +174,11 @@ export interface TeleportFeature {
   showInDashboard?: boolean;
   /** isHyperLink is whether this subsection is merely a hyperlink/shortcut to another subsection. */
   isHyperLink?: boolean;
+  /**
+   * supportsScopes indicates whether this feature should be enabled in scoped
+   * sessions.
+   */
+  supportsScopes?: boolean;
 }
 
 export type StickyCluster = {

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -156,7 +156,8 @@ export function UnifiedResources(props: {
       supported: 'yes',
       availabilityFilter: getResourceAvailabilityFilter(
         userPreferences.unifiedResourcePreferences.availableResourceMode,
-        rootCluster.showResources === ShowResources.REQUESTABLE
+        rootCluster.showResources === ShowResources.REQUESTABLE,
+        false /* scopedSession */
       ),
     };
   }, [


### PR DESCRIPTION
Backport #68885 to branch/v18

Depends on https://github.com/gravitational/teleport/pull/69197
Followed up by https://github.com/gravitational/teleport.e/pull/9298

## Manual Test Plan
### Test Environment
Any cluster with two users (Alice, Bob). Alice doesn't have scoped role assignments, Bob has multiple scoped role assignments. To turn on the feature:
- Turn on Scopes globally using `TELEPORT_UNSTABLE_SCOPES=yes` in the environment.
- Using Chrome dev tools, add `grv_teleport_use_login_scope_picker=true` to the application's local storage.

This test plan is common for the UI and the backend change. The follow-up enterprise PR is tested separately.

### Test Cases
- [x] Alice can sign in to Teleport just as she was before.
- [x] With the scope picker turned on, Bob is able to log in to a scope:
   - [x] Using a passkey
   - [x] Using OTP
   - [x] Using GitHub
- [x] With the scope picker turned on, Bob is able to log in to an unscoped session:
   - [x] Using a passkey
   - [x] Using OTP
   - [x] Using GitHub
- [x] With the scope picker turned off, Bob can sign in just as he was before.
  - [x] Turn off on the server side, using the environment variable
  - [x] Turn off on the client side, using Chrome dev tools
- [x] Neither Alice nor Bob can log in to an unassigned scope (e.g. by visiting `/web/login?scope=/not-assigned`).
- [x] Both Alice and Bob can have their *unscoped* sessions renewed (wait until a successful renew API call shows up in the network inspector).