### PR TITLE
[v18] Fix e2e push runs on release branches always building against OSS master

### DIFF
--- a/.github/workflows/e2e-tests-base.yaml
+++ b/.github/workflows/e2e-tests-base.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: ${{ inputs.oss-repository || github.repository }}
-          ref: ${{ inputs.oss-repository && (github.event.pull_request.base.ref || github.event.merge_group.base_ref) || '' }}
+          ref: ${{ inputs.oss-repository && (github.event.pull_request.base.ref || github.event.merge_group.base_ref || github.ref_name) || '' }}
           fetch-depth: 1
 
       - name: Checkout Enterprise
@@ -174,7 +174,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: ${{ inputs.oss-repository || github.repository }}
-          ref: ${{ inputs.oss-repository && (github.event.pull_request.base.ref || github.event.merge_group.base_ref) || '' }}
+          ref: ${{ inputs.oss-repository && (github.event.pull_request.base.ref || github.event.merge_group.base_ref || github.ref_name) || '' }}
           fetch-depth: 1
           persist-credentials: false
 


### PR DESCRIPTION
Backport #69208 to branch/v18