### PR TITLE
discovery: Add S3 bucket listing pagination

### DIFF
--- a/lib/cloud/mocks/aws_s3.go
+++ b/lib/cloud/mocks/aws_s3.go
@@ -37,9 +37,13 @@ type S3Client struct {
 	BucketTags          map[string][]s3types.Tag
 	BucketLocations     map[string]s3types.BucketLocationConstraint
 	ListBucketsPageSize int
+	RequireMaxBuckets   bool
 }
 
 func (m *S3Client) ListBuckets(_ context.Context, input *s3.ListBucketsInput, _ ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
+	if m.RequireMaxBuckets && input.MaxBuckets == nil {
+		return nil, trace.BadParameter("unpaginated ListBuckets requests are rejected for accounts with a bucket quota greater than 10,000")
+	}
 	// When <=0, all buckets are returned in a single page.
 	if m.ListBucketsPageSize <= 0 {
 		return &s3.ListBucketsOutput{

--- a/lib/cloud/mocks/aws_s3.go
+++ b/lib/cloud/mocks/aws_s3.go
@@ -20,6 +20,7 @@ package mocks
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -29,18 +30,39 @@ import (
 
 // S3Client mocks AWS S3 API.
 type S3Client struct {
-	Buckets            []s3types.Bucket
-	BucketPolicy       map[string]string
-	BucketPolicyStatus map[string]s3types.PolicyStatus
-	BucketACL          map[string][]s3types.Grant
-	BucketTags         map[string][]s3types.Tag
-	BucketLocations    map[string]s3types.BucketLocationConstraint
+	Buckets             []s3types.Bucket
+	BucketPolicy        map[string]string
+	BucketPolicyStatus  map[string]s3types.PolicyStatus
+	BucketACL           map[string][]s3types.Grant
+	BucketTags          map[string][]s3types.Tag
+	BucketLocations     map[string]s3types.BucketLocationConstraint
+	ListBucketsPageSize int
 }
 
-func (m *S3Client) ListBuckets(_ context.Context, _ *s3.ListBucketsInput, _ ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
-	return &s3.ListBucketsOutput{
-		Buckets: m.Buckets,
-	}, nil
+func (m *S3Client) ListBuckets(_ context.Context, input *s3.ListBucketsInput, _ ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
+	// When <=0, all buckets are returned in a single page.
+	if m.ListBucketsPageSize <= 0 {
+		return &s3.ListBucketsOutput{
+			Buckets: m.Buckets,
+		}, nil
+	}
+
+	start := 0
+	if token := aws.ToString(input.ContinuationToken); token != "" {
+		var err error
+		start, err = strconv.Atoi(token)
+		if err != nil {
+			return nil, trace.BadParameter("invalid continuation token %q", token)
+		}
+	}
+	end := min(start+m.ListBucketsPageSize, len(m.Buckets))
+	out := &s3.ListBucketsOutput{
+		Buckets: m.Buckets[start:end],
+	}
+	if end < len(m.Buckets) {
+		out.ContinuationToken = aws.String(strconv.Itoa(end))
+	}
+	return out, nil
 }
 
 func (m *S3Client) GetBucketPolicy(_ context.Context, input *s3.GetBucketPolicyInput, _ ...func(*s3.Options)) (*s3.GetBucketPolicyOutput, error) {

--- a/lib/cloud/mocks/aws_s3.go
+++ b/lib/cloud/mocks/aws_s3.go
@@ -30,25 +30,34 @@ import (
 
 // S3Client mocks AWS S3 API.
 type S3Client struct {
-	Buckets             []s3types.Bucket
-	BucketPolicy        map[string]string
-	BucketPolicyStatus  map[string]s3types.PolicyStatus
-	BucketACL           map[string][]s3types.Grant
-	BucketTags          map[string][]s3types.Tag
-	BucketLocations     map[string]s3types.BucketLocationConstraint
-	ListBucketsPageSize int
-	RequireMaxBuckets   bool
+	Buckets            []s3types.Bucket
+	BucketPolicy       map[string]string
+	BucketPolicyStatus map[string]s3types.PolicyStatus
+	BucketACL          map[string][]s3types.Grant
+	BucketTags         map[string][]s3types.Tag
+	BucketLocations    map[string]s3types.BucketLocationConstraint
+	// RequireMaxBuckets rejects unpaginated ListBuckets requests, as AWS does
+	// for accounts with a bucket quota above maxListBuckets.
+	RequireMaxBuckets bool
 }
 
+// maxListBuckets is the largest page size ListBuckets accepts for max-buckets.
+const maxListBuckets = 10000
+
+// ListBuckets pages through Buckets using max-buckets as the page size. The
+// continuation token is the index of the first bucket of the next page.
 func (m *S3Client) ListBuckets(_ context.Context, input *s3.ListBucketsInput, _ ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
-	if m.RequireMaxBuckets && input.MaxBuckets == nil {
-		return nil, trace.BadParameter("unpaginated ListBuckets requests are rejected for accounts with a bucket quota greater than 10,000")
-	}
-	// When <=0, all buckets are returned in a single page.
-	if m.ListBucketsPageSize <= 0 {
+	if input.MaxBuckets == nil {
+		if m.RequireMaxBuckets {
+			return nil, trace.BadParameter("unpaginated ListBuckets requests are rejected for accounts with a bucket quota greater than %d", maxListBuckets)
+		}
 		return &s3.ListBucketsOutput{
 			Buckets: m.Buckets,
 		}, nil
+	}
+	pageSize := int(aws.ToInt32(input.MaxBuckets))
+	if pageSize < 1 || pageSize > maxListBuckets {
+		return nil, trace.BadParameter("max-buckets must be between 1 and %d, got %d", maxListBuckets, pageSize)
 	}
 
 	start := 0
@@ -59,7 +68,7 @@ func (m *S3Client) ListBuckets(_ context.Context, input *s3.ListBucketsInput, _ 
 			return nil, trace.BadParameter("invalid continuation token %q", token)
 		}
 	}
-	end := min(start+m.ListBucketsPageSize, len(m.Buckets))
+	end := min(start+pageSize, len(m.Buckets))
 	out := &s3.ListBucketsOutput{
 		Buckets: m.Buckets[start:end],
 	}

--- a/lib/srv/discovery/fetchers/aws-sync/s3.go
+++ b/lib/srv/discovery/fetchers/aws-sync/s3.go
@@ -302,7 +302,12 @@ func (a *Fetcher) listS3Buckets(ctx context.Context) ([]s3types.Bucket, func(*st
 		return nil, nil, trace.Wrap(err)
 	}
 	s3Client := a.awsClients.getS3Client(awsCfg)
-	pager := s3.NewListBucketsPaginator(s3Client, &s3.ListBucketsInput{})
+	// MaxBuckets must be set so the request is paginated
+	pager := s3.NewListBucketsPaginator(s3Client, &s3.ListBucketsInput{
+		MaxBuckets: aws.Int32(pageSize),
+	}, func(opts *s3.ListBucketsPaginatorOptions) {
+		opts.StopOnDuplicateToken = true
+	})
 	var buckets []s3types.Bucket
 	for pager.HasMorePages() {
 		page, err := pager.NextPage(ctx)

--- a/lib/srv/discovery/fetchers/aws-sync/s3.go
+++ b/lib/srv/discovery/fetchers/aws-sync/s3.go
@@ -302,11 +302,16 @@ func (a *Fetcher) listS3Buckets(ctx context.Context) ([]s3types.Bucket, func(*st
 		return nil, nil, trace.Wrap(err)
 	}
 	s3Client := a.awsClients.getS3Client(awsCfg)
-	rsp, err := s3Client.ListBuckets(ctx, &s3.ListBucketsInput{})
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
+	pager := s3.NewListBucketsPaginator(s3Client, &s3.ListBucketsInput{})
+	var buckets []s3types.Bucket
+	for pager.HasMorePages() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		buckets = append(buckets, page.Buckets...)
 	}
-	return rsp.Buckets,
+	return buckets,
 		func(bucket *string) (string, error) {
 			rsp, err := s3Client.GetBucketLocation(
 				ctx,

--- a/lib/srv/discovery/fetchers/aws-sync/s3.go
+++ b/lib/srv/discovery/fetchers/aws-sync/s3.go
@@ -19,6 +19,7 @@
 package aws_sync
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"sync"
@@ -32,7 +33,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
-	awsregion "github.com/gravitational/teleport/lib/utils/aws/region"
 )
 
 // s3Client defines a subset of the AWS S3 client API.
@@ -82,42 +82,47 @@ func (a *Fetcher) fetchS3Buckets(ctx context.Context) ([]*accessgraphv1alpha.AWS
 		}
 	}
 
-	buckets, getBucketRegion, err := a.listS3Buckets(ctx)
+	// listClient is not tied to any bucket's region. It lists the buckets and
+	// resolves the region of any bucket that ListBuckets did not report one for.
+	listClient, err := a.getClient(ctx, a.s3ListRegion())
 	if err != nil {
 		return existing.S3Buckets, trace.Wrap(err)
 	}
 
-	// Iterate over the buckets and fetch their inline and attached policies.
+	// build a map of existing buckets to avoid quadratic lookup complexity from
+	// a linear scan of the slice (existing.S3Buckets).
+	existingByName := make(map[string]*accessgraphv1alpha.AWSS3BucketV1, len(existing.S3Buckets))
+	for _, bucket := range existing.S3Buckets {
+		if bucket.GetAccountId() == a.AccountID {
+			existingByName[bucket.GetName()] = bucket
+		}
+	}
+
+	buckets, err := listS3Buckets(ctx, listClient)
+	if err != nil {
+		return existing.S3Buckets, trace.Wrap(err)
+	}
+
 	for _, bucket := range buckets {
 		eG.Go(func() error {
-			var failedReqs failedRequests
-			var errs []error
-			existingBucket := sliceFilterPickFirst(existing.S3Buckets, func(b *accessgraphv1alpha.AWSS3BucketV1) bool {
-				return b.GetName() == aws.ToString(bucket.Name) && b.GetAccountId() == a.AccountID
-			},
-			)
-			bucketRegion, err := getBucketRegion(bucket.Name)
+			bucketName := aws.ToString(bucket.Name)
+			existingBucket := existingByName[bucketName]
+
+			region, err := getBucketRegion(ctx, listClient, bucket)
 			if err != nil {
-				errs = append(errs,
-					trace.Wrap(err),
-				)
-				failedReqs.policyFailed = true
-				failedReqs.failedPolicyStatus = true
-				failedReqs.failedAcls = true
-				failedReqs.failedTags = true
-				newBucket := awsS3Bucket(aws.ToString(bucket.Name), nil, nil, nil, nil, a.AccountID)
-				collect(mergeS3Protos(existingBucket, newBucket, failedReqs), trace.NewAggregate(errs...))
+				// Without a region none of the detail requests can be made.
+				b := cmp.Or(existingBucket, awsS3Bucket(bucketName, nil, nil, nil, nil, a.AccountID))
+				collect(b, err)
 				return nil
 			}
 
-			details, failedReqs, errsL := a.getS3BucketDetails(ctx, bucket, bucketRegion)
-
-			newBucket := awsS3Bucket(aws.ToString(bucket.Name), details.policy, details.policyStatus, details.acls, details.tags, a.AccountID)
-			collect(mergeS3Protos(existingBucket, newBucket, failedReqs), trace.NewAggregate(append(errs, errsL...)...))
+			details, failedReqs, errsL := a.getS3BucketDetails(ctx, bucket, region)
+			newBucket := awsS3Bucket(bucketName, details.policy, details.policyStatus, details.acls, details.tags, a.AccountID)
+			collect(mergeS3Protos(existingBucket, newBucket, failedReqs), trace.NewAggregate(errsL...))
 			return nil
 		})
 	}
-	// always discard the error
+	// always discard the error as we never return an error in the errorgroup
 	_ = eG.Wait()
 
 	return s3s, trace.NewAggregate(errs...)
@@ -176,7 +181,6 @@ type failedRequests struct {
 	failedPolicyStatus bool
 	failedAcls         bool
 	failedTags         bool
-	headFailed         bool
 }
 
 func mergeS3Protos(existing, new *accessgraphv1alpha.AWSS3BucketV1, failedReqs failedRequests) *accessgraphv1alpha.AWSS3BucketV1 {
@@ -210,26 +214,42 @@ type s3Details struct {
 	tags         *s3.GetBucketTaggingOutput
 }
 
+// getBucketRegion returns the region the bucket is in. A paginated ListBuckets
+// reports it, but if the response omitted it, clt is used to look it up. clt
+// may be for any region.
+func getBucketRegion(ctx context.Context, clt s3Client, bucket s3types.Bucket) (string, error) {
+	if region := aws.ToString(bucket.BucketRegion); region != "" {
+		return region, nil
+	}
+	rsp, err := clt.GetBucketLocation(ctx, &s3.GetBucketLocationInput{Bucket: bucket.Name})
+	if err != nil {
+		return "", trace.Wrap(err, "failed to fetch bucket %q region", aws.ToString(bucket.Name))
+	}
+	// An absent location constraint means us-east-1, which has no enum value.
+	return string(cmp.Or(rsp.LocationConstraint, "us-east-1")), nil
+}
+
+// getS3BucketDetails fetches the policy, policy status, ACLs and tags of a
+// bucket. bucketRegion must be the region the bucket is in, as the requests
+// are only served by that region's endpoint.
 func (a *Fetcher) getS3BucketDetails(ctx context.Context, bucket s3types.Bucket, bucketRegion string) (s3Details, failedRequests, []error) {
 	var failedReqs failedRequests
 	var errs []error
 	var details s3Details
 
-	awsCfg, err := a.AWSConfigProvider.GetConfig(ctx, bucketRegion, a.getAWSOptions()...)
+	s3Client, err := a.getClient(ctx, bucketRegion)
 	if err != nil {
 		errs = append(errs,
 			trace.Wrap(err, "failed to create s3 client for bucket %q", aws.ToString(bucket.Name)),
 		)
 		return s3Details{},
 			failedRequests{
-				headFailed:         true,
 				policyFailed:       true,
 				failedPolicyStatus: true,
 				failedAcls:         true,
 				failedTags:         true,
 			}, errs
 	}
-	s3Client := a.awsClients.getS3Client(awsCfg)
 
 	details.policy, err = s3Client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{
 		Bucket: bucket.Name,
@@ -290,46 +310,47 @@ func isS3BucketNoTagSet(err error) bool {
 	return isAPIErrorCode(err, "NoSuchTagSet")
 }
 
-func (a *Fetcher) listS3Buckets(ctx context.Context) ([]s3types.Bucket, func(*string) (string, error), error) {
-	region := awsregion.GetKnownRegions()[0]
-	if len(a.Regions) > 0 {
-		region = a.Regions[0]
-	}
-
-	// use any region to list buckets
-	awsCfg, err := a.AWSConfigProvider.GetConfig(ctx, region, a.getAWSOptions()...)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	s3Client := a.awsClients.getS3Client(awsCfg)
-	// MaxBuckets must be set so the request is paginated
-	pager := s3.NewListBucketsPaginator(s3Client, &s3.ListBucketsInput{
+func listS3Buckets(ctx context.Context, clt s3Client) ([]s3types.Bucket, error) {
+	// MaxBuckets must be set so the request is paginated. It also causes
+	// AWS to return BucketRegion in the response (providing any valid input
+	// parameter will do this).
+	pager := s3.NewListBucketsPaginator(clt, &s3.ListBucketsInput{
 		MaxBuckets: aws.Int32(pageSize),
 	}, func(opts *s3.ListBucketsPaginatorOptions) {
 		opts.StopOnDuplicateToken = true
 	})
+
 	var buckets []s3types.Bucket
 	for pager.HasMorePages() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			return nil, nil, trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 		buckets = append(buckets, page.Buckets...)
 	}
-	return buckets,
-		func(bucket *string) (string, error) {
-			rsp, err := s3Client.GetBucketLocation(
-				ctx,
-				&s3.GetBucketLocationInput{
-					Bucket: bucket,
-				},
-			)
-			if err != nil {
-				return "", trace.Wrap(err, "failed to fetch bucket %q region", aws.ToString(bucket))
-			}
-			if rsp.LocationConstraint == "" {
-				return "us-east-1", nil
-			}
-			return string(rsp.LocationConstraint), nil
-		}, nil
+	return buckets, nil
+}
+
+// defaultListRegion is used when the fetcher has no configured regions.
+// Discovery config requires at least one, so this is only a backstop. It is a
+// fixed region rather than the first of awsregion.GetKnownRegions(), which is
+// af-south-1 and changes whenever that generated list does.
+const defaultListRegion = "us-west-2"
+
+// s3ListRegion is the region used for the AWS APIs that are not specific to a
+// bucket's region: listing buckets and getting a bucket's region.
+func (a *Fetcher) s3ListRegion() string {
+	if len(a.Regions) == 0 {
+		return defaultListRegion
+	}
+	return a.Regions[0]
+}
+
+// getClient returns an s3Client for the given region.
+func (a *Fetcher) getClient(ctx context.Context, region string) (s3Client, error) {
+	awsCfg, err := a.AWSConfigProvider.GetConfig(ctx, region, a.getAWSOptions()...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return a.awsClients.getS3Client(awsCfg), nil
 }

--- a/lib/srv/discovery/fetchers/aws-sync/s3_test.go
+++ b/lib/srv/discovery/fetchers/aws-sync/s3_test.go
@@ -241,10 +241,11 @@ func TestListS3Buckets(t *testing.T) {
 	errListBuckets := trace.AccessDenied("access denied listing buckets")
 
 	tests := []struct {
-		name       string
-		pageSize   int
-		failOnPage int
-		wantErr    error
+		name              string
+		pageSize          int
+		failOnPage        int
+		rejectUnpaginated bool
+		wantErr           error
 	}{
 		{
 			name:     "multi-page with a partial final page",
@@ -270,6 +271,11 @@ func TestListS3Buckets(t *testing.T) {
 			failOnPage: 3,
 			wantErr:    errListBuckets,
 		},
+		{
+			name:              "reject unpaginated requests",
+			pageSize:          500,
+			rejectUnpaginated: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -277,6 +283,7 @@ func TestListS3Buckets(t *testing.T) {
 			var client s3Client = &mocks.S3Client{
 				Buckets:             s3Buckets(wantNames...),
 				ListBucketsPageSize: tt.pageSize,
+				RequireMaxBuckets:   tt.rejectUnpaginated,
 			}
 			if tt.failOnPage > 0 {
 				client = &failingListBucketsS3Client{

--- a/lib/srv/discovery/fetchers/aws-sync/s3_test.go
+++ b/lib/srv/discovery/fetchers/aws-sync/s3_test.go
@@ -20,12 +20,14 @@ package aws_sync
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
@@ -208,6 +210,105 @@ func TestPollAWSS3(t *testing.T) {
 			),
 			)
 
+		})
+	}
+}
+
+// failingListBucketsS3Client wraps an s3Client and returns err on the
+// failOnPage'th ListBuckets call
+type failingListBucketsS3Client struct {
+	s3Client
+	failOnPage int
+	err        error
+	page       int
+}
+
+func (c *failingListBucketsS3Client) ListBuckets(ctx context.Context, input *s3.ListBucketsInput, optFns ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
+	c.page++
+	if c.page == c.failOnPage {
+		return nil, c.err
+	}
+	return c.s3Client.ListBuckets(ctx, input, optFns...)
+}
+
+func TestListS3Buckets(t *testing.T) {
+	const totalBuckets = 2500
+	wantNames := make([]string, 0, totalBuckets)
+	for i := range totalBuckets {
+		wantNames = append(wantNames, fmt.Sprintf("bucket-%d", i))
+	}
+
+	errListBuckets := trace.AccessDenied("access denied listing buckets")
+
+	tests := []struct {
+		name       string
+		pageSize   int
+		failOnPage int
+		wantErr    error
+	}{
+		{
+			name:     "multi-page with a partial final page",
+			pageSize: 1000,
+		},
+		{
+			name:     "multi-page dividing evenly",
+			pageSize: 500,
+		},
+		{
+			name:     "single page",
+			pageSize: totalBuckets,
+		},
+		{
+			name:       "error on the first page",
+			pageSize:   500,
+			failOnPage: 1,
+			wantErr:    errListBuckets,
+		},
+		{
+			name:       "error on random page",
+			pageSize:   500,
+			failOnPage: 3,
+			wantErr:    errListBuckets,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var client s3Client = &mocks.S3Client{
+				Buckets:             s3Buckets(wantNames...),
+				ListBucketsPageSize: tt.pageSize,
+			}
+			if tt.failOnPage > 0 {
+				client = &failingListBucketsS3Client{
+					s3Client:   client,
+					failOnPage: tt.failOnPage,
+					err:        tt.wantErr,
+				}
+			}
+
+			a := &Fetcher{
+				Config: Config{
+					AWSConfigProvider: &mocks.AWSConfigProvider{},
+					Regions:           []string{"eu-west-1"},
+					awsClients:        fakeAWSClients{s3Client: client},
+				},
+			}
+
+			buckets, getRegion, err := a.listS3Buckets(context.Background())
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				require.Nil(t, buckets)
+				require.Nil(t, getRegion)
+				return
+			}
+
+			require.NoError(t, err)
+			gotNames := make([]string, 0, len(buckets))
+			for _, b := range buckets {
+				gotNames = append(gotNames, aws.ToString(b.Name))
+			}
+			require.Equal(t, wantNames, gotNames)
 		})
 	}
 }

--- a/lib/srv/discovery/fetchers/aws-sync/s3_test.go
+++ b/lib/srv/discovery/fetchers/aws-sync/s3_test.go
@@ -20,8 +20,8 @@ package aws_sync
 
 import (
 	"context"
-	"fmt"
 	"sort"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -55,25 +55,33 @@ func TestPollAWSS3(t *testing.T) {
 	require.NoError(t, err)
 
 	const (
-		accountID       = "12345678"
-		bucketName      = "bucket1"
-		otherBucketName = "bucket2"
-		missingBucket   = "missing_perm_bucket"
+		accountID        = "12345678"
+		bucketName       = "bucket1"
+		otherBucketName  = "bucket2"
+		missingBucket    = "missing_perm_bucket"
+		regionlessBucket = "regionless_bucket"
 	)
 	var (
 		regions      = []string{"eu-west-1"}
 		fakedClients = fakeAWSClients{
+			// The absent entries in the various fields of mocks.S3Client mean
+			// the mocked calls to retrieve that data for the absent buckets will
+			// fail, triggering the fallback cases in the unit under test.
 			s3Client: &mocks.S3Client{
-				Buckets: s3Buckets(bucketName, otherBucketName, missingBucket),
-				BucketLocations: map[string]s3types.BucketLocationConstraint{
-					bucketName:      s3types.BucketLocationConstraintEuWest1,
-					otherBucketName: s3types.BucketLocationConstraintEuWest1,
-					missingBucket:   s3types.BucketLocationConstraintEuWest1,
-				},
+				// regionlessBucket reports no region and has no
+				// GetBucketLocation entry, so its region cannot be resolved and
+				// none of its details can be fetched. The rest report a region,
+				// so GetBucketLocation is never consulted for them.
+				Buckets: append(
+					s3Buckets("eu-west-1", bucketName, otherBucketName, missingBucket),
+					s3Buckets("", regionlessBucket)...,
+				),
+				// No BucketPolicy for missingBucket or regionlessBucket
 				BucketPolicy: map[string]string{
 					bucketName:      "policy",
 					otherBucketName: "otherPolicy",
 				},
+				// No BucketPolicyStatus for missingBucket or regionlessBucket
 				BucketPolicyStatus: map[string]s3types.PolicyStatus{
 					bucketName: {
 						IsPublic: aws.Bool(true),
@@ -82,6 +90,7 @@ func TestPollAWSS3(t *testing.T) {
 						IsPublic: aws.Bool(false),
 					},
 				},
+				// No BucketACL for missingBucket or regionlessBucket
 				BucketACL: map[string][]s3types.Grant{
 					bucketName: {
 						{
@@ -100,6 +109,7 @@ func TestPollAWSS3(t *testing.T) {
 						},
 					},
 				},
+				// No BucketTags for otherBucketName, missingBucket or regionlessBucket
 				BucketTags: map[string][]s3types.Tag{
 					bucketName: {
 						{
@@ -112,12 +122,61 @@ func TestPollAWSS3(t *testing.T) {
 		}
 	)
 
+	// fetchedACLs and fetchedTags are what the mocked client returns for the
+	// buckets it has entries for.
+	fetchedACLs := func() []*accessgraphv1alpha.AWSS3BucketACL {
+		return []*accessgraphv1alpha.AWSS3BucketACL{
+			accessgraphv1alpha.AWSS3BucketACL_builder{
+				Grantee: accessgraphv1alpha.AWSS3BucketACLGrantee_builder{
+					Id: "id",
+				}.Build(),
+				Permission: "READ",
+			}.Build(),
+		}
+	}
+	fetchedTags := func() []*accessgraphv1alpha.AWSTag {
+		return []*accessgraphv1alpha.AWSTag{
+			accessgraphv1alpha.AWSTag_builder{
+				Key:   "tag",
+				Value: strPtrToWrapper(aws.String("val")),
+			}.Build(),
+		}
+	}
+
+	// existing is what a previous sync recorded for a bucket. Every field a
+	// request fails to fetch must be carried over from here.
+	existing := func(name string) *accessgraphv1alpha.AWSS3BucketV1 {
+		return accessgraphv1alpha.AWSS3BucketV1_builder{
+			Name:           name,
+			AccountId:      accountID,
+			PolicyDocument: []byte("existingPolicy"),
+			IsPublic:       true,
+			Acls: []*accessgraphv1alpha.AWSS3BucketACL{
+				accessgraphv1alpha.AWSS3BucketACL_builder{
+					Grantee: accessgraphv1alpha.AWSS3BucketACLGrantee_builder{
+						Id: "existingID",
+					}.Build(),
+					Permission: "WRITE",
+				}.Build(),
+			},
+			Tags: []*accessgraphv1alpha.AWSTag{
+				accessgraphv1alpha.AWSTag_builder{
+					Key:   "existingTag",
+					Value: strPtrToWrapper(aws.String("existingVal")),
+				}.Build(),
+			},
+		}.Build()
+	}
+
 	tests := []struct {
 		name string
-		want *Resources
+		// lastResult is what the previous sync recorded.
+		lastResult *Resources
+		want       *Resources
 	}{
 		{
-			name: "poll s3",
+			name:       "poll s3",
+			lastResult: &Resources{},
 			want: &Resources{
 				S3Buckets: []*accessgraphv1alpha.AWSS3BucketV1{
 					accessgraphv1alpha.AWSS3BucketV1_builder{
@@ -125,39 +184,63 @@ func TestPollAWSS3(t *testing.T) {
 						AccountId:      accountID,
 						PolicyDocument: []byte("policy"),
 						IsPublic:       true,
-						Acls: []*accessgraphv1alpha.AWSS3BucketACL{
-							accessgraphv1alpha.AWSS3BucketACL_builder{
-								Grantee: accessgraphv1alpha.AWSS3BucketACLGrantee_builder{
-									Id: "id",
-								}.Build(),
-								Permission: "READ",
-							}.Build(),
-						},
-						Tags: []*accessgraphv1alpha.AWSTag{
-							accessgraphv1alpha.AWSTag_builder{
-								Key:   "tag",
-								Value: strPtrToWrapper(aws.String("val")),
-							}.Build(),
-						},
+						Acls:           fetchedACLs(),
+						Tags:           fetchedTags(),
 					}.Build(),
 					accessgraphv1alpha.AWSS3BucketV1_builder{
 						Name:           otherBucketName,
 						AccountId:      accountID,
 						PolicyDocument: []byte("otherPolicy"),
 						IsPublic:       false,
-						Acls: []*accessgraphv1alpha.AWSS3BucketACL{
-							accessgraphv1alpha.AWSS3BucketACL_builder{
-								Grantee: accessgraphv1alpha.AWSS3BucketACLGrantee_builder{
-									Id: "id",
-								}.Build(),
-								Permission: "READ",
-							}.Build(),
-						},
+						Acls:           fetchedACLs(),
 					}.Build(),
 					accessgraphv1alpha.AWSS3BucketV1_builder{
 						Name:      missingBucket,
 						AccountId: accountID,
 					}.Build(),
+					accessgraphv1alpha.AWSS3BucketV1_builder{
+						Name:      regionlessBucket,
+						AccountId: accountID,
+					}.Build(),
+				},
+			},
+		},
+		{
+			// A failed request must not look like the attribute was removed, so
+			// each one falls back to what the last sync recorded.
+			name: "reuse existing buckets on failure",
+			lastResult: &Resources{
+				S3Buckets: []*accessgraphv1alpha.AWSS3BucketV1{
+					existing(bucketName),
+					existing(otherBucketName),
+					existing(missingBucket),
+					existing(regionlessBucket),
+				},
+			},
+			want: &Resources{
+				S3Buckets: []*accessgraphv1alpha.AWSS3BucketV1{
+					// Every request succeeded, so nothing is carried over.
+					accessgraphv1alpha.AWSS3BucketV1_builder{
+						Name:           bucketName,
+						AccountId:      accountID,
+						PolicyDocument: []byte("policy"),
+						IsPublic:       true,
+						Acls:           fetchedACLs(),
+						Tags:           fetchedTags(),
+					}.Build(),
+					// Only the tag request failed.
+					accessgraphv1alpha.AWSS3BucketV1_builder{
+						Name:           otherBucketName,
+						AccountId:      accountID,
+						PolicyDocument: []byte("otherPolicy"),
+						IsPublic:       false,
+						Acls:           fetchedACLs(),
+						Tags:           existing(otherBucketName).GetTags(),
+					}.Build(),
+					// Every request failed, so every field is carried over.
+					existing(missingBucket),
+					// The region was never resolved, so no request was made.
+					existing(regionlessBucket),
 				},
 			},
 		},
@@ -188,10 +271,10 @@ func TestPollAWSS3(t *testing.T) {
 					Integration: awsOIDCIntegration.GetName(),
 					awsClients:  fakedClients,
 				},
-				lastResult: &Resources{},
+				lastResult: tt.lastResult,
 			}
 			result := &Resources{}
-			execFunc := a.pollAWSS3Buckets(context.Background(), result, collectErr)
+			execFunc := a.pollAWSS3Buckets(t.Context(), result, collectErr)
 			require.NoError(t, execFunc())
 			require.Error(t, trace.NewAggregate(errs...))
 
@@ -231,59 +314,67 @@ func (c *failingListBucketsS3Client) ListBuckets(ctx context.Context, input *s3.
 	return c.s3Client.ListBuckets(ctx, input, optFns...)
 }
 
+// The mock pages by the max-buckets the fetcher sends, so page boundaries are
+// expressed relative to pageSize rather than chosen by each test case.
 func TestListS3Buckets(t *testing.T) {
-	const totalBuckets = 2500
-	wantNames := make([]string, 0, totalBuckets)
-	for i := range totalBuckets {
-		wantNames = append(wantNames, fmt.Sprintf("bucket-%d", i))
-	}
-
 	errListBuckets := trace.AccessDenied("access denied listing buckets")
 
 	tests := []struct {
 		name              string
-		pageSize          int
+		totalBuckets      int
 		failOnPage        int
 		rejectUnpaginated bool
 		wantErr           error
 	}{
 		{
-			name:     "multi-page with a partial final page",
-			pageSize: 1000,
+			name:         "no buckets",
+			totalBuckets: 0,
 		},
 		{
-			name:     "multi-page dividing evenly",
-			pageSize: 500,
+			name:         "partial single page",
+			totalBuckets: int(pageSize) - 1,
 		},
 		{
-			name:     "single page",
-			pageSize: totalBuckets,
+			name:         "exactly one full page",
+			totalBuckets: int(pageSize),
 		},
 		{
-			name:       "error on the first page",
-			pageSize:   500,
-			failOnPage: 1,
-			wantErr:    errListBuckets,
+			name:         "multi-page with a partial final page",
+			totalBuckets: int(pageSize)*4 + 1,
 		},
 		{
-			name:       "error on random page",
-			pageSize:   500,
-			failOnPage: 3,
-			wantErr:    errListBuckets,
+			name:         "multi-page dividing evenly",
+			totalBuckets: int(pageSize) * 5,
+		},
+		{
+			name:         "error on the first page",
+			totalBuckets: int(pageSize) * 5,
+			failOnPage:   1,
+			wantErr:      errListBuckets,
+		},
+		{
+			name:         "error on a later page",
+			totalBuckets: int(pageSize) * 5,
+			failOnPage:   3,
+			wantErr:      errListBuckets,
 		},
 		{
 			name:              "reject unpaginated requests",
-			pageSize:          500,
+			totalBuckets:      int(pageSize) * 5,
 			rejectUnpaginated: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			wantNames := make([]string, 0, tt.totalBuckets)
+			for i := range tt.totalBuckets {
+				wantNames = append(wantNames, "bucket-"+strconv.Itoa(i))
+			}
+
 			var client s3Client = &mocks.S3Client{
-				Buckets:             s3Buckets(wantNames...),
-				ListBucketsPageSize: tt.pageSize,
-				RequireMaxBuckets:   tt.rejectUnpaginated,
+				Buckets:           s3Buckets("eu-west-1", wantNames...),
+				RequireMaxBuckets: tt.rejectUnpaginated,
 			}
 			if tt.failOnPage > 0 {
 				client = &failingListBucketsS3Client{
@@ -293,20 +384,13 @@ func TestListS3Buckets(t *testing.T) {
 				}
 			}
 
-			a := &Fetcher{
-				Config: Config{
-					AWSConfigProvider: &mocks.AWSConfigProvider{},
-					Regions:           []string{"eu-west-1"},
-					awsClients:        fakeAWSClients{s3Client: client},
-				},
-			}
-
-			buckets, getRegion, err := a.listS3Buckets(context.Background())
+			buckets, err := listS3Buckets(t.Context(), client)
 
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
+				// A failed page discards the whole listing, so a partial list
+				// is never mistaken for the account's full set of buckets.
 				require.Nil(t, buckets)
-				require.Nil(t, getRegion)
 				return
 			}
 
@@ -320,14 +404,72 @@ func TestListS3Buckets(t *testing.T) {
 	}
 }
 
-func s3Buckets(bucketNames ...string) []s3types.Bucket {
+func TestBucketRegion(t *testing.T) {
+	const bucketName = "bucket"
+
+	tests := []struct {
+		name string
+		// listedRegion is the BucketRegion reported by ListBuckets. Empty means
+		// the response omitted it.
+		listedRegion string
+		// locations are the GetBucketLocation responses, keyed by bucket name.
+		// A bucket absent from the map makes the lookup fail.
+		locations  map[string]s3types.BucketLocationConstraint
+		wantRegion string
+		wantErr    string
+	}{
+		{
+			name:         "BucketRegion is used when reported",
+			listedRegion: "ap-south-1",
+			// locations is empty, so any GetBucketLocation call fails the test.
+			wantRegion: "ap-south-1",
+		},
+		{
+			name:       "absent BucketRegion falls back to GetBucketLocation",
+			locations:  map[string]s3types.BucketLocationConstraint{bucketName: "eu-west-1"},
+			wantRegion: "eu-west-1",
+		},
+		{
+			name:       "an empty location constraint means us-east-1",
+			locations:  map[string]s3types.BucketLocationConstraint{bucketName: ""},
+			wantRegion: "us-east-1",
+		},
+		{
+			name:    "a failed lookup is an error",
+			wantErr: `failed to fetch bucket "bucket" region`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clt := &mocks.S3Client{BucketLocations: tt.locations}
+			bucket := s3Buckets(tt.listedRegion, bucketName)[0]
+
+			region, err := getBucketRegion(t.Context(), clt, bucket)
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantRegion, region)
+		})
+	}
+}
+
+// s3Buckets builds ListBuckets results. An empty region models a response that
+// omitted BucketRegion, which is what AWS returns for unpaginated requests.
+func s3Buckets(region string, bucketNames ...string) []s3types.Bucket {
 	var output []s3types.Bucket
 	for _, name := range bucketNames {
-		output = append(output, s3types.Bucket{
+		bucket := s3types.Bucket{
 			Name:         aws.String(name),
 			CreationDate: aws.Time(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
-		})
-
+		}
+		if region != "" {
+			bucket.BucketRegion = aws.String(region)
+		}
+		output = append(output, bucket)
 	}
 	return output
 }


### PR DESCRIPTION

Use a `ListBucketsPaginator` instead of calling `ListBuckets` when
retrieving the bucket list for AWS discovery, setting the `MaxBuckets`
setting to the fetcher's standard `pageSize` (500). Pagination must be
used on an account when the approved general purpose bucket quota is
above 10,000; an unpaginated `ListBuckets` call will be rejected
otherwise.

Using a valid input parameter (`MaxBuckets`) to the `ListBuckets` call
means AWS now returns the bucket region in the result. As such, we can
remove the API call to fetch the bucket region, needed to query the
bucket details (policies, tags, etc). We still query the bucket region
if no `BucketRegion` is returned just in case, but we should not expect
that to be empty.

Use a map when looking up existing buckets for the failure path, instead
of a slice. If there are a large number of buckets (now possible with
this change), the quadratic complexity of the slice-based lookup can
become untenable.

Supersedes: https://github.com/gravitational/teleport/pull/68766

## Manual Test Plan
### Test Environment
* Build enterprise Teleport with a modification that drops the page size
  to 2 for the ListBucketsPaginator to ensure multiple pages are
  fetched, as our AWS dev accounts have less than 500 buckets (page
  size).

  `lib/srv/discovery/fetchers/aws-sync/s3.go:318
  ```go
  pager := s3.NewListBucketsPaginator(s3Client, &s3.ListBucketsInput{
  		MaxBuckets: aws.Int32(2),
  	})
  ```
* Run that build with access-graph, with discovery enabled and an
  `access_graph.aws` section in the discovery config.
* Find the buckets and count of in the account being used:

      aws s3 ls | tee /dev/tty | wc -l
* Ensure the AWS account being used has more than 2 buckets


### Test Cases
- [x] Access Graph shows all the buckets in the account
