### PR TITLE
Show User Display Name in the Access Request Review Box

### DIFF
--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestReview/RequestReview.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestReview/RequestReview.tsx
@@ -26,6 +26,7 @@ import { HoverTooltip } from 'design/Tooltip';
 import { FieldSelect } from 'shared/components/FieldSelect';
 import { FieldTextArea } from 'shared/components/FieldTextArea';
 import { Option } from 'shared/components/Select';
+import { UserDisplayName } from 'shared/components/UserDisplayName';
 import Validation, { Validator } from 'shared/components/Validation';
 import { requiredField } from 'shared/components/Validation/rules';
 import { Attempt } from 'shared/hooks/useAsync';
@@ -33,6 +34,7 @@ import {
   AccessRequest,
   RequestKind,
   RequestState,
+  UserDisplay,
 } from 'shared/services/accessRequests';
 
 import { AccessDurationReview } from '../../../AccessDuration';
@@ -50,6 +52,7 @@ export interface RequestReviewProps {
   fetchSuggestedAccessListsAttempt: Attempt<SuggestedAccessList[]>;
   shortTermDuration: string;
   user: string;
+  userDisplay?: UserDisplay;
   submitReviewAttempt: Attempt<AccessRequest>;
   request: AccessRequest;
 }
@@ -58,6 +61,7 @@ export default function RequestReview({
   submitReviewAttempt,
   submitReview,
   user,
+  userDisplay,
   fetchSuggestedAccessListsAttempt,
   shortTermDuration,
   request,
@@ -125,7 +129,15 @@ export default function RequestReview({
           style={{ position: 'relative' }}
         >
           <Box bg="levels.sunken" py={1} px={3}>
-            <H3 mr={3}>{user} - add a review</H3>
+            <H3 mr={3}>
+              <UserDisplayName
+                username={user}
+                primaryText={userDisplay?.primary}
+                primaryTextProps={{ fontWeight: 'bold' }}
+                layout="inline"
+              />
+              {' - add a review'}
+            </H3>
           </Box>
           <Box p={3} bg="levels.elevated">
             {submitReviewAttempt.status === 'error' && (

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.test.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.test.tsx
@@ -47,6 +47,10 @@ const sampleFlags: RequestFlags = {
 
 const props: RequestViewProps = {
   user: 'loggedInUsername',
+  userDisplay: {
+    primary: 'Logged In User',
+    secondary: 'logged-in-user@example.com',
+  },
   fetchRequestAttempt: makeSuccessAttempt(requestRolePending),
   submitReviewAttempt: makeEmptyAttempt(),
   getFlags: () => sampleFlags,
@@ -61,11 +65,15 @@ const props: RequestViewProps = {
   deleteRequest: () => null,
 };
 
-const reviewBoxText = `${props.user} - add a review`;
-
 test('renders review box if user can review', async () => {
   render(<RequestView {...props} />);
-  expect(screen.getByText(reviewBoxText)).toBeInTheDocument();
+  const reviewHeader = screen.getByText(/add a review/i);
+
+  expect(within(reviewHeader).getByText('Logged In User')).toBeVisible();
+  expect(within(reviewHeader).getByText('loggedInUsername')).toBeVisible();
+  expect(
+    within(reviewHeader).queryByText('logged-in-user@example.com')
+  ).not.toBeInTheDocument();
 });
 
 test('does not render review box if user cannot review', async () => {
@@ -78,7 +86,7 @@ test('does not render review box if user cannot review', async () => {
       })}
     />
   );
-  expect(screen.queryByText(reviewBoxText)).not.toBeInTheDocument();
+  expect(screen.queryByText(/add a review/i)).not.toBeInTheDocument();
 });
 
 test('renders requester and reviewer display names with usernames', () => {

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
@@ -78,6 +78,7 @@ import { SuggestedAccessList } from './types';
 
 export interface RequestViewProps {
   user: string;
+  userDisplay?: UserDisplay;
   getFlags(accessRequest: AccessRequest): RequestFlags;
   fetchRequestAttempt: Attempt<AccessRequest>;
   fetchSuggestedAccessListsAttempt: Attempt<SuggestedAccessList[]>;
@@ -94,6 +95,7 @@ export interface RequestViewProps {
 
 export function RequestView({
   user,
+  userDisplay,
   fetchRequestAttempt,
   getFlags,
   confirmDelete,
@@ -312,6 +314,7 @@ export function RequestView({
                 <RequestReview
                   submitReview={submitReview}
                   user={user}
+                  userDisplay={userDisplay}
                   submitReviewAttempt={submitReviewAttempt}
                   fetchSuggestedAccessListsAttempt={
                     fetchSuggestedAccessListsAttempt


### PR DESCRIPTION
This PR addresses [#66993](https://github.com/gravitational/teleport/issues/66993) by rendering the reviewing user's display name in the "add a review" box on the Access Request detail page. This was the last Access Request surface still showing a bare username after [#68822](https://github.com/gravitational/teleport/pull/68822).

Paired with https://github.com/gravitational/teleport.e/pull/9299, which supplies the [display prop](https://github.com/gravitational/teleport.e/pull/9299/changes#diff-ebad7d9f13bed773eb7ae59853a49a7e1fd1dbfed8b2fc95b602a4fe152578fb). 

## Screenshot

 <img width="911" height="677" alt="Screenshot 2026-07-30 at 8 28 33 PM" src="https://github.com/user-attachments/assets/0c309006-eeea-4d63-bc0a-2eeb4d22da48" />


## Manual Test Plan

### Test Environment

- A local cluster with both this branch and https://github.com/gravitational/teleport.e/pull/9299 checked out, since the review box header only receives a display value once `useRequestView` supplies it
- A pending Access Request submitted by some other user
- A reviewer account holding `review_requests` with its display traits populated (e.g. `displayName` or `email`)
- A second reviewer account with no display traits populated, to cover the fallback

### Test Cases

- [x] Verify the review box header shows the reviewer's display name
   1. Log in as the reviewer whose display traits are populated
   2. Open the pending Access Request from https://localhost:3000/web/requests
   3. Scroll to the review box at the bottom and verify its header reads `<display name> (<username>) - add a review`, with the display name in bold and the parenthesized username muted
   4. Verify the reviewer's email is not shown in the header

- [x] Verify the review box header falls back to the username alone
   1. Log in as the reviewer with no display traits populated
   2. Open the same pending Access Request and scroll to the review box
   3. Verify the header reads `<username> - add a review`, with no empty parentheses and no duplicated username


changelog: The web UI now shows the reviewing user's display name in the Access Request review box
